### PR TITLE
fix(librarian): unify markdown rendering + redesign source cards

### DIFF
--- a/src/app/[tenant]/reading-room/ReadingRoomClient.tsx
+++ b/src/app/[tenant]/reading-room/ReadingRoomClient.tsx
@@ -9,7 +9,7 @@ import remarkGfm from 'remark-gfm';
 import { tenantBookUrl } from '@/lib/slugify';
 // remarkBreaks removed — we use ensureParagraphBreaks() instead for proper spacing
 import SiteHeader from '@/components/layout/SiteHeader';
-import { ensureParagraphBreaks, linkifySourceUrls } from '@/lib/markdown-prep';
+import LibrarianMessageBody from '@/app/librarian/_components/MessageBody';
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -206,7 +206,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
     if (status === 'authenticated') setSidebarTab('mine');
   }, [status]);
   const [visibility, setVisibility] = useState<'public' | 'private'>('public');
-  const [showThinking, setShowThinking] = useState(false);
+  const [showThinking, setShowThinking] = useState(true);
   const [visibleThreads, setVisibleThreads] = useState(5);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -614,57 +614,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
 
                           {/* Response text */}
                           {assistant.content && (
-                            <div className="bg-[#f5f0e8] text-[#1a1612] rounded-2xl rounded-bl-sm px-4 py-3">
-                              <div className="max-w-none font-body text-[15px] leading-relaxed text-[#1a1612]">
-                                <ReactMarkdown
-                                  remarkPlugins={[remarkGfm]}
-                                  components={{
-                                    p: ({ children }) => (
-                                      <p className="mb-4 mt-0">{children}</p>
-                                    ),
-                                    h2: ({ children }) => (
-                                      <h2 className="text-xl font-serif mt-6 mb-3 text-[#1a1612]" style={{ fontWeight: 400 }}>{children}</h2>
-                                    ),
-                                    h3: ({ children }) => (
-                                      <h3 className="text-lg font-serif mt-5 mb-2 text-[#1a1612]" style={{ fontWeight: 400 }}>{children}</h3>
-                                    ),
-                                    a: ({ href, children }) => (
-                                      <a href={href} target="_blank" rel="noopener noreferrer" className="text-[#9e4a3a] underline underline-offset-2 decoration-[#9e4a3a]/30 hover:decoration-[#9e4a3a]">{children}</a>
-                                    ),
-                                    blockquote: ({ children }) => (
-                                      <blockquote className="border-l-2 border-[#c9a86c] pl-4 my-4 italic text-[#444]">{children}</blockquote>
-                                    ),
-                                    ul: ({ children }) => (
-                                      <ul className="my-3 ml-4 list-disc">{children}</ul>
-                                    ),
-                                    ol: ({ children }) => (
-                                      <ol className="my-3 ml-4 list-decimal">{children}</ol>
-                                    ),
-                                    li: ({ children }) => (
-                                      <li className="my-1">{children}</li>
-                                    ),
-                                    hr: () => <hr className="my-4 border-[#e8e4dc]" />,
-                                    img: ({ src, alt }) => (
-                                      <a href={src as string} target="_blank" rel="noopener noreferrer">
-                                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                                        <img
-                                          src={src as string}
-                                          alt={(alt as string) || ''}
-                                          className="rounded-lg shadow-md max-h-[300px] w-auto cursor-pointer hover:shadow-lg transition-shadow my-4"
-                                          loading="lazy"
-                                          onError={(e) => {
-                                            const img = e.currentTarget;
-                                            const wrapper = img.closest('a');
-                                            if (wrapper) wrapper.style.display = 'none';
-                                            else img.style.display = 'none';
-                                          }}
-                                        />
-                                      </a>
-                                    ),
-                                  }}
-                                >{ensureParagraphBreaks(linkifySourceUrls(assistant.content))}</ReactMarkdown>
-                              </div>
-                            </div>
+                            <LibrarianMessageBody content={assistant.content} variant="chat-bubble" />
                           )}
 
                           {/* Research direction choices */}

--- a/src/app/[tenant]/reading-room/thread/[id]/page.tsx
+++ b/src/app/[tenant]/reading-room/thread/[id]/page.tsx
@@ -3,9 +3,7 @@
 import { useState, useEffect, use } from 'react';
 import Link from 'next/link';
 import SiteHeader from '@/components/layout/SiteHeader';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { ensureParagraphBreaks, linkifySourceUrls } from '@/lib/markdown-prep';
+import LibrarianMessageBody from '@/app/librarian/_components/MessageBody';
 
 interface ThreadMessage {
   id: string;
@@ -127,22 +125,7 @@ export default function ThreadPage({ params }: { params: Promise<{ id: string }>
                   {msg.authorName}
                 </p>
                 {msg.authorType === 'ai' ? (
-                  <div className="prose prose-sm max-w-none font-body text-[15px] leading-relaxed text-[#1a1612] prose-p:mb-4 prose-p:mt-0 prose-h3:text-base prose-h3:font-semibold prose-h3:mt-5 prose-h3:mb-2 prose-h2:text-lg prose-h2:mt-6 prose-h2:mb-3 prose-headings:text-[#1a1612] prose-ul:my-3 prose-ol:my-3 prose-li:my-1 prose-a:text-[#9e4a3a] prose-a:underline prose-a:underline-offset-2 prose-a:decoration-[#9e4a3a]/30 hover:prose-a:decoration-[#9e4a3a] prose-blockquote:border-l-[#c9a86c] prose-blockquote:text-[#444] prose-blockquote:my-4 prose-blockquote:italic prose-strong:text-[#1a1612] prose-hr:my-4 prose-img:rounded-lg prose-img:shadow-md prose-img:my-4 prose-img:max-h-[400px] prose-img:w-auto">
-                    <ReactMarkdown
-                      remarkPlugins={[remarkGfm]}
-                      components={{
-                        a: ({ href, children }) => (
-                          <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>
-                        ),
-                        img: ({ src, alt }) => (
-                          <a href={src as string} target="_blank" rel="noopener noreferrer">
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={src as string} alt={(alt as string) || ''} className="rounded-lg shadow-md max-h-[400px] w-auto" loading="lazy" />
-                          </a>
-                        ),
-                      }}
-                    >{ensureParagraphBreaks(linkifySourceUrls(msg.content))}</ReactMarkdown>
-                  </div>
+                  <LibrarianMessageBody content={msg.content} variant="thread" />
                 ) : (
                   <p className="text-[15px] font-body leading-relaxed text-[#1a1612] whitespace-pre-wrap">
                     {msg.content}

--- a/src/app/experiments/search-v2/page.tsx
+++ b/src/app/experiments/search-v2/page.tsx
@@ -16,7 +16,7 @@ import { bookUrl } from '@/lib/slugify';
 import HighlightedText from '@/components/search/HighlightedText';
 import { ENTITY_TYPE_STYLES, type EntityType } from '@/lib/style-constants';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { ensureParagraphBreaks, linkifySourceUrls } from '@/lib/markdown-prep';
+import LibrarianMessageBody from '@/app/librarian/_components/MessageBody';
 
 const TOOL_LABELS: Record<string, string> = {
   search_collection: 'Searching the collection',
@@ -379,36 +379,10 @@ export default function SearchV2Page() {
               {/* Response bubble */}
               {librarianContent && (
                 <div className="bg-white text-[#1a1612] rounded-2xl rounded-bl-sm px-4 py-3 border border-[#e8e4dc]">
-                  <div className="prose prose-sm max-w-none font-body text-[15px] leading-relaxed prose-p:mb-4 prose-p:mt-0 prose-h3:text-base prose-h3:font-semibold prose-h3:mt-5 prose-h3:mb-2 prose-h2:text-lg prose-h2:mt-6 prose-h2:mb-3 prose-headings:text-[#1a1612] prose-ul:my-3 prose-ol:my-3 prose-li:my-1 prose-a:text-[#9e4a3a] prose-a:underline prose-a:underline-offset-2 prose-a:decoration-[#9e4a3a]/30 hover:prose-a:decoration-[#9e4a3a] prose-blockquote:border-l-[#c9a86c] prose-blockquote:text-[#444] prose-blockquote:my-4 prose-blockquote:italic prose-strong:text-[#1a1612] prose-hr:my-4 prose-img:rounded-lg prose-img:shadow-md prose-img:my-4 prose-img:max-h-[300px] prose-img:w-auto">
-                    <ReactMarkdown
-                      remarkPlugins={[remarkGfm]}
-                      components={{
-                        a: ({ href, children }) => (
-                          <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>
-                        ),
-                        img: ({ src, alt }) => (
-                          <a href={src as string} target="_blank" rel="noopener noreferrer">
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img
-                              src={src as string}
-                              alt={(alt as string) || ''}
-                              className="rounded-lg shadow-md max-h-[300px] w-auto cursor-pointer hover:shadow-lg transition-shadow"
-                              loading="lazy"
-                              onError={(e) => {
-                                const img = e.currentTarget;
-                                const wrapper = img.closest('a');
-                                if (wrapper) wrapper.style.display = 'none';
-                                else img.style.display = 'none';
-                              }}
-                            />
-                          </a>
-                        ),
-                      }}
-                    >{ensureParagraphBreaks(linkifySourceUrls(librarianContent))}</ReactMarkdown>
-                    {librarianStreaming && (
-                      <span className="inline-block w-1.5 h-4 bg-[#c9a86c] animate-pulse ml-0.5 align-text-bottom" />
-                    )}
-                  </div>
+                  <LibrarianMessageBody content={librarianContent} variant="thread" />
+                  {librarianStreaming && (
+                    <span className="inline-block w-1.5 h-4 bg-[#c9a86c] animate-pulse ml-0.5 align-text-bottom" />
+                  )}
                 </div>
               )}
 

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -9,7 +9,7 @@ import remarkGfm from 'remark-gfm';
 import { tenantBookUrl } from '@/lib/slugify';
 // remarkBreaks removed — we use ensureParagraphBreaks() instead for proper spacing
 import SiteHeader from '@/components/layout/SiteHeader';
-import { ensureParagraphBreaks, linkifySourceUrls } from '@/lib/markdown-prep';
+import LibrarianMessageBody from './_components/MessageBody';
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -206,7 +206,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
     if (status === 'authenticated') setSidebarTab('mine');
   }, [status]);
   const [visibility, setVisibility] = useState<'public' | 'private'>('public');
-  const [showThinking, setShowThinking] = useState(false);
+  const [showThinking, setShowThinking] = useState(true);
   const [visibleThreads, setVisibleThreads] = useState(5);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -616,57 +616,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
 
                           {/* Response text */}
                           {assistant.content && (
-                            <div className="bg-[#f5f0e8] text-[#1a1612] rounded-2xl rounded-bl-sm px-4 py-3">
-                              <div className="max-w-none font-body text-[15px] leading-relaxed text-[#1a1612]">
-                                <ReactMarkdown
-                                  remarkPlugins={[remarkGfm]}
-                                  components={{
-                                    p: ({ children }) => (
-                                      <p className="mb-4 mt-0">{children}</p>
-                                    ),
-                                    h2: ({ children }) => (
-                                      <h2 className="text-xl font-serif mt-6 mb-3 text-[#1a1612]" style={{ fontWeight: 400 }}>{children}</h2>
-                                    ),
-                                    h3: ({ children }) => (
-                                      <h3 className="text-lg font-serif mt-5 mb-2 text-[#1a1612]" style={{ fontWeight: 400 }}>{children}</h3>
-                                    ),
-                                    a: ({ href, children }) => (
-                                      <a href={href} target="_blank" rel="noopener noreferrer" className="text-[#9e4a3a] underline underline-offset-2 decoration-[#9e4a3a]/30 hover:decoration-[#9e4a3a]">{children}</a>
-                                    ),
-                                    blockquote: ({ children }) => (
-                                      <blockquote className="border-l-2 border-[#c9a86c] pl-4 my-4 italic text-[#444]">{children}</blockquote>
-                                    ),
-                                    ul: ({ children }) => (
-                                      <ul className="my-3 ml-4 list-disc">{children}</ul>
-                                    ),
-                                    ol: ({ children }) => (
-                                      <ol className="my-3 ml-4 list-decimal">{children}</ol>
-                                    ),
-                                    li: ({ children }) => (
-                                      <li className="my-1">{children}</li>
-                                    ),
-                                    hr: () => <hr className="my-4 border-[#e8e4dc]" />,
-                                    img: ({ src, alt }) => (
-                                      <a href={src as string} target="_blank" rel="noopener noreferrer">
-                                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                                        <img
-                                          src={src as string}
-                                          alt={(alt as string) || ''}
-                                          className="rounded-lg shadow-md max-h-[300px] w-auto cursor-pointer hover:shadow-lg transition-shadow my-4"
-                                          loading="lazy"
-                                          onError={(e) => {
-                                            const img = e.currentTarget;
-                                            const wrapper = img.closest('a');
-                                            if (wrapper) wrapper.style.display = 'none';
-                                            else img.style.display = 'none';
-                                          }}
-                                        />
-                                      </a>
-                                    ),
-                                  }}
-                                >{ensureParagraphBreaks(linkifySourceUrls(assistant.content))}</ReactMarkdown>
-                              </div>
-                            </div>
+                            <LibrarianMessageBody content={assistant.content} variant="chat-bubble" />
                           )}
 
                           {/* Research direction choices */}

--- a/src/app/librarian/_components/MessageBody.tsx
+++ b/src/app/librarian/_components/MessageBody.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { ensureParagraphBreaks, linkifySourceUrls } from '@/lib/markdown-prep';
+
+// ── Shared Librarian message body ─────────────────────────────────────
+// Single source of truth for assistant-message typography across:
+//   /librarian (live chat)            — variant="chat-bubble"
+//   /librarian/thread/[id] (persisted) — variant="thread"
+//   /[tenant]/reading-room and equivalents
+//
+// Why this exists: the live-chat and thread-page renderers were using two
+// different markdown styling systems (inline component overrides vs
+// Tailwind Typography prose-*: modifiers). The prose-*: modifiers were not
+// winning the cascade against the prose plugin's defaults, so paragraphs
+// collapsed (margin: 0) and h2/h3 rendered at body size. This component
+// owns the typography in one place. See PR conventions in CLAUDE.md.
+// ──────────────────────────────────────────────────────────────────────
+
+export type MessageBodyVariant = 'chat-bubble' | 'thread';
+
+interface LibrarianMessageBodyProps {
+  content: string;
+  variant?: MessageBodyVariant;
+}
+
+export default function LibrarianMessageBody({ content, variant = 'thread' }: LibrarianMessageBodyProps) {
+  const wrapperClass =
+    variant === 'chat-bubble'
+      ? 'bg-[#f5f0e8] text-[#1a1612] rounded-2xl rounded-bl-sm px-4 py-3'
+      : '';
+
+  return (
+    <div className={wrapperClass}>
+      <div className="max-w-none font-body text-[15px] text-[#1a1612]" style={{ lineHeight: 1.7 }}>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            p: ({ children }) => (
+              <p className="my-4 first:mt-0 last:mb-0">{children}</p>
+            ),
+            h2: ({ children }) => (
+              <h2 className="font-serif text-[22px] mt-8 mb-3 text-[#1a1612] leading-tight" style={{ fontWeight: 400 }}>{children}</h2>
+            ),
+            h3: ({ children }) => (
+              <h3 className="font-serif text-[18px] mt-6 mb-2 text-[#1a1612] leading-snug" style={{ fontWeight: 500 }}>{children}</h3>
+            ),
+            h4: ({ children }) => (
+              <h4 className="font-serif text-[16px] mt-5 mb-2 text-[#1a1612] leading-snug" style={{ fontWeight: 500 }}>{children}</h4>
+            ),
+            a: ({ href, children }) => (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#9e4a3a] font-medium underline underline-offset-2 decoration-[#9e4a3a]/80 hover:decoration-[#9e4a3a]"
+              >{children}</a>
+            ),
+            blockquote: ({ children }) => (
+              <blockquote className="border-l-2 border-[#c9a86c] pl-4 my-5 italic text-[#444]">{children}</blockquote>
+            ),
+            ul: ({ children }) => (
+              <ul className="my-4 ml-5 list-disc space-y-1">{children}</ul>
+            ),
+            ol: ({ children }) => (
+              <ol className="my-4 ml-5 list-decimal space-y-1">{children}</ol>
+            ),
+            li: ({ children }) => (
+              <li className="leading-[1.7]">{children}</li>
+            ),
+            hr: () => <hr className="my-6 border-[#e8e4dc]" />,
+            strong: ({ children }) => (
+              <strong className="font-semibold text-[#1a1612]">{children}</strong>
+            ),
+            table: ({ children }) => (
+              <div className="my-5 overflow-x-auto">
+                <table className="border-collapse text-[14px] w-full">{children}</table>
+              </div>
+            ),
+            thead: ({ children }) => <thead>{children}</thead>,
+            tbody: ({ children }) => <tbody>{children}</tbody>,
+            tr: ({ children }) => <tr>{children}</tr>,
+            th: ({ children }) => (
+              <th className="border-b-2 border-[#1a1612] px-3 py-2 text-left font-serif align-bottom text-[#1a1612]" style={{ fontWeight: 500 }}>{children}</th>
+            ),
+            td: ({ children }) => (
+              <td className="border-b border-[#e8e4dc] px-3 py-2 align-top">{children}</td>
+            ),
+            img: ({ src, alt }) => (
+              <a href={src as string} target="_blank" rel="noopener noreferrer">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={src as string}
+                  alt={(alt as string) || ''}
+                  className="rounded-lg shadow-md max-h-[400px] w-auto cursor-pointer hover:shadow-lg transition-shadow my-5"
+                  loading="lazy"
+                  onError={(e) => {
+                    const img = e.currentTarget as HTMLImageElement;
+                    const wrapper = img.closest('a') as HTMLAnchorElement | null;
+                    if (wrapper) wrapper.style.display = 'none';
+                    else img.style.display = 'none';
+                  }}
+                />
+              </a>
+            ),
+          }}
+        >{ensureParagraphBreaks(linkifySourceUrls(content))}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/src/app/librarian/thread/[id]/page.tsx
+++ b/src/app/librarian/thread/[id]/page.tsx
@@ -5,9 +5,7 @@ import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import SiteHeader from '@/components/layout/SiteHeader';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { ensureParagraphBreaks, linkifySourceUrls } from '@/lib/markdown-prep';
+import LibrarianMessageBody from '@/app/librarian/_components/MessageBody';
 
 interface ThreadMessage {
   id: string;
@@ -300,21 +298,26 @@ function SourceCards({ threadId }: { threadId: string }) {
 
   const bookList = [...books.entries()];
 
+  // Roman-numeral markers up to XX cover any realistic citation count; fall
+  // back to Arabic numerals past that. Decorative — they don't correspond
+  // to inline footnote markers in the prose (yet).
+  const ROMAN = ['I','II','III','IV','V','VI','VII','VIII','IX','X','XI','XII','XIII','XIV','XV','XVI','XVII','XVIII','XIX','XX'];
+
   return (
-    <div className="mt-6">
+    <div className="mt-8">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 text-[12px] text-[#6b6560] font-sans tracking-wide uppercase hover:text-[#444] transition-colors"
+        className="flex items-center gap-2 text-[10px] text-[#8a8480] font-serif tracking-[0.25em] uppercase hover:text-[#9e4a3a] transition-colors"
       >
-        <svg className={`w-3.5 h-3.5 transition-transform ${expanded ? 'rotate-90' : ''}`} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+        <svg className={`w-3 h-3 transition-transform ${expanded ? 'rotate-90' : ''}`} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
         </svg>
-        Sources ({bookList.length} books, {findings.length} passages)
+        <span>Cited works · {bookList.length} {bookList.length === 1 ? 'book' : 'books'}, {findings.length} {findings.length === 1 ? 'passage' : 'passages'}</span>
       </button>
 
       {expanded && (
-        <div className="mt-3 grid gap-3">
-          {bookList.map(([bookId, book]) => {
+        <div className="mt-6">
+          {bookList.map(([bookId, book], idx) => {
             const bookSlug = book.slug || bookId;
             const sortedPages = [...book.pages].sort((a, b) => a - b);
             // Single-cited-page: card click jumps straight to that page. Multi-page:
@@ -323,65 +326,72 @@ function SourceCards({ threadId }: { threadId: string }) {
             const cardHref = sortedPages.length === 1
               ? `https://sourcelibrary.org/book/${bookSlug}/page-number/${sortedPages[0]}`
               : `https://sourcelibrary.org/book/${bookSlug}`;
-            const thumbUrl = `https://sourcelibrary.org/api/image?url=https://images.sourcelibrary.org/covers/${bookId}.jpg&w=120&q=75`;
+            const marker = ROMAN[idx] || `${idx + 1}`;
+            const firstQuote = book.quotes[0];
+
             return (
-              <div
+              <article
                 key={bookId}
-                className="flex gap-3 p-3 bg-white rounded-lg border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors group"
+                className="relative pl-14 py-8 border-t border-[#d8cdb6] last:border-b last:border-[#d8cdb6]"
               >
-                <a href={cardHref} target="_blank" rel="noopener noreferrer" className="flex-shrink-0">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={thumbUrl}
-                    alt=""
-                    className="w-14 h-20 object-cover rounded bg-[#f0ece4]"
-                    loading="lazy"
-                    onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                  />
+                <span
+                  className="absolute left-0 top-8 font-serif text-[10px] tracking-[0.3em] uppercase text-[#9e4a3a]"
+                  aria-hidden="true"
+                >
+                  {marker}
+                </span>
+
+                <a href={cardHref} target="_blank" rel="noopener noreferrer" className="block group">
+                  <h3
+                    className="font-serif text-[#1a1612] group-hover:text-[#9e4a3a] transition-colors"
+                    style={{ fontSize: '22px', fontWeight: 400, lineHeight: 1.2, letterSpacing: '-0.005em' }}
+                  >
+                    {book.title}
+                  </h3>
                 </a>
-                <div className="min-w-0 flex-1">
-                  <a href={cardHref} target="_blank" rel="noopener noreferrer" className="block">
-                    <p className="text-[13px] font-serif text-[#1a1612] leading-snug group-hover:text-[#9e4a3a] transition-colors" style={{ fontWeight: 400 }}>
-                      {book.title}
-                    </p>
-                    <p className="text-[11px] text-[#8a8480] font-sans mt-0.5">
-                      {book.author}
-                    </p>
-                  </a>
-                  <p className="text-[11px] font-sans mt-1">
-                    {sortedPages.length === 1 ? (
-                      <a
-                        href={`https://sourcelibrary.org/book/${bookSlug}/page-number/${sortedPages[0]}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-[#9e4a3a] hover:underline"
-                      >
-                        Page {sortedPages[0]}
-                      </a>
-                    ) : (
-                      <>
-                        <span className="text-[#8a8480]">Pages </span>
-                        {sortedPages.map((p, i) => (
-                          <span key={p}>
-                            <a
-                              href={`https://sourcelibrary.org/book/${bookSlug}/page-number/${p}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-[#9e4a3a] hover:underline"
-                            >
-                              {p}
-                            </a>
-                            {i < sortedPages.length - 1 ? <span className="text-[#8a8480]">, </span> : null}
-                          </span>
-                        ))}
-                      </>
-                    )}
+
+                <p className="mt-1.5 text-[13px] italic font-serif text-[#6b6560]">
+                  {book.author}
+                </p>
+
+                <p className="mt-3.5 text-[10px] tracking-[0.16em] uppercase font-serif text-[#8a8480]">
+                  {sortedPages.length === 1 ? (
+                    <a
+                      href={`https://sourcelibrary.org/book/${bookSlug}/page-number/${sortedPages[0]}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[#9e4a3a] hover:text-[#7e3a2d] border-b border-[#9e4a3a]/30 hover:border-[#9e4a3a] pb-px transition-colors"
+                    >
+                      read at page {sortedPages[0]} &rarr;
+                    </a>
+                  ) : (
+                    <>
+                      <span>read at pages </span>
+                      {sortedPages.map((p, i) => (
+                        <span key={p}>
+                          <a
+                            href={`https://sourcelibrary.org/book/${bookSlug}/page-number/${p}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-[#9e4a3a] hover:text-[#7e3a2d] border-b border-[#9e4a3a]/30 hover:border-[#9e4a3a] pb-px transition-colors"
+                          >
+                            {p}
+                          </a>
+                          {i < sortedPages.length - 1 ? <span>, </span> : null}
+                        </span>
+                      ))}
+                    </>
+                  )}
+                </p>
+
+                {firstQuote && (
+                  <p className="mt-4 text-[13px] leading-[1.55] italic font-serif text-[#444039] max-w-[520px]">
+                    &ldquo;{firstQuote}&hellip;&rdquo;
                   </p>
-                </div>
-              </div>
+                )}
+              </article>
             );
           })}
-
         </div>
       )}
     </div>
@@ -844,33 +854,7 @@ export default function ThreadPage({ params }: { params: Promise<{ id: string }>
                   {msg.authorName}
                 </p>
                 {msg.authorType === 'ai' ? (
-                  <div className="prose prose-sm max-w-none font-body text-[15px] leading-relaxed text-[#1a1612] prose-p:mb-4 prose-p:mt-0 prose-h3:text-base prose-h3:font-semibold prose-h3:mt-5 prose-h3:mb-2 prose-h2:text-lg prose-h2:mt-6 prose-h2:mb-3 prose-headings:text-[#1a1612] prose-ul:my-3 prose-ol:my-3 prose-li:my-1 prose-a:text-[#9e4a3a] prose-a:underline prose-a:underline-offset-2 prose-a:decoration-[#9e4a3a]/30 hover:prose-a:decoration-[#9e4a3a] prose-blockquote:border-l-[#c9a86c] prose-blockquote:text-[#444] prose-blockquote:my-4 prose-blockquote:italic prose-strong:text-[#1a1612] prose-hr:my-4 prose-img:rounded-lg prose-img:shadow-md prose-img:my-4 prose-img:max-h-[400px] prose-img:w-auto">
-                    <ReactMarkdown
-                      remarkPlugins={[remarkGfm]}
-                      components={{
-                        a: ({ href, children }) => (
-                          <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>
-                        ),
-                        img: ({ src, alt }) => (
-                          <a href={src as string} target="_blank" rel="noopener noreferrer">
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img
-                              src={src as string}
-                              alt={(alt as string) || ''}
-                              className="rounded-lg shadow-md max-h-[400px] w-auto"
-                              loading="lazy"
-                              onError={(e) => {
-                                const img = e.currentTarget;
-                                const wrapper = img.closest('a');
-                                if (wrapper) wrapper.style.display = 'none';
-                                else img.style.display = 'none';
-                              }}
-                            />
-                          </a>
-                        ),
-                      }}
-                    >{ensureParagraphBreaks(linkifySourceUrls(msg.content))}</ReactMarkdown>
-                  </div>
+                  <LibrarianMessageBody content={msg.content} variant="thread" />
                 ) : (
                   <p className="text-[15px] font-body leading-relaxed text-[#1a1612] whitespace-pre-wrap">
                     {msg.content}


### PR DESCRIPTION
## Summary

Two related concerns, both originating from the same root cause we surfaced today on the planets/zodiac thread.

### 1. Typography unification (the bug)

The persisted thread view (`librarian/thread/[id]/page.tsx`, reading-room equivalents, search-v2) was styling AI markdown via Tailwind Typography \`prose-*:\` modifiers piled into one className string (\`prose prose-sm prose-p:mb-4 prose-h3:text-base prose-h3:font-semibold prose-h3:mt-5...\`). Computed styles on production showed those modifiers were losing the cascade fight against the prose plugin's own defaults — every \`<p>\` rendered with \`margin: 0\` and \`<h3>\` rendered at body-text size. Paragraphs ran together; headings vanished.

The live-chat surface (\`LibrarianClient.tsx\`) used inline ReactMarkdown component overrides instead and rendered correctly, so the two paths visibly diverged.

**Fix:** new \`src/app/librarian/_components/MessageBody.tsx\` owns assistant-message typography for all five surfaces. Explicit element overrides for \`p\`, \`h2\`–\`h4\`, \`a\`, \`blockquote\`, \`ul\`/\`ol\`/\`li\`, \`hr\`, \`strong\`, \`table\` family, and \`img\` (with \`onError\` from PR #2099). Takes a \`variant\` prop (\`chat-bubble\` adds the cream shell; \`thread\` is bare). ~250 lines of duplicated inline overrides deleted across five files.

The \"Show reasoning\" block in each caller still uses inline ReactMarkdown — different visual intent (muted/italic/smaller).

### 2. Source cards redesigned (librarian thread view)

Old: white rounded-card grid with broken cover thumbnails and \"Page 1\" fragments.

New: museum-wall-label treatment — continuous \`border-t\` rhythm, Roman-numeral markers (I, II, III) in rust on the left, 22px serif title, italic attribution, \"READ AT PAGE N →\" small-caps link, plus the first quote (the data was already collected upstream, just never rendered). Header changed from \"Sources (3 books)\" to \"Cited works · 3 books, 5 passages\" in small caps + tracked.

### 3. Defaults

- \`showThinking\` now defaults to \`true\` so the reasoning block is visible without a click. Toggle remains for users who want to hide it.

## Net diff

6 files, +197 / -244. Code shrank because inline overrides + broken-thumb code are gone.

## Out of scope

- Podcast format buttons (Deep Dive / Brief / Critique / Guided Reading) — separate concern, separate PR.
- A general redesign of the in-bubble live chat — only the typography mismatch was fixed there. Aesthetic changes deferred.

## Test plan

- [ ] Preview deploy: open \`/librarian/thread/6a06f0a2fbba267e7d2d3f4c\` and confirm paragraph spacing is restored and \`### headings\` render visibly
- [ ] Same URL, scroll to source cards — confirm Roman-numeral markers, italic title quote, no broken cover thumbnails, \"READ AT PAGE N →\" link works
- [ ] Open a fresh \`/librarian\` chat — confirm the \"Show reasoning\" block is expanded by default; links in the response render with the stronger underline (\`/80\` opacity) and \`font-medium\` weight
- [ ] Open a tenant subdomain (e.g. \`bph.sourcelibrary.org/reading-room\`) and verify the same rendering applies
- [ ] Confirm tables still render correctly (regression on PR #2091's table fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)