### PR TITLE
feat(wikipedia-playbook): claim + status tracking for volunteer execution

### DIFF
--- a/src/app/api/contribute/wikipedia/event/route.ts
+++ b/src/app/api/contribute/wikipedia/event/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase';
+import { isValidRating } from '@/lib/review-queue';
+
+export const maxDuration = 5;
+
+/**
+ * POST /api/contribute/wikipedia/event
+ *
+ * Body: { item_id, event, volunteer_id, detail? }
+ *
+ * Records one Wikipedia-playbook state-transition event. The event log is
+ * shared with the rating queues (volunteer_ratings table, queue='wikipedia').
+ *
+ * Valid events: claimed | released | posted | responded | merged | declined | abandoned
+ */
+export async function POST(request: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  const itemId = String(body.item_id ?? '').trim();
+  const event = String(body.event ?? '').trim();
+  const volunteerId = String(body.volunteer_id ?? '').trim();
+  const detail = body.detail ?? null;
+
+  if (!itemId || itemId.length > 200) {
+    return NextResponse.json({ error: 'invalid item_id' }, { status: 400 });
+  }
+  if (!isValidRating('wikipedia', event)) {
+    return NextResponse.json({ error: 'invalid event' }, { status: 400 });
+  }
+  if (!/^[0-9a-f-]{36}$/i.test(volunteerId)) {
+    return NextResponse.json({ error: 'invalid volunteer_id' }, { status: 400 });
+  }
+
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'supabase admin not configured' }, { status: 500 });
+  }
+
+  const ua = request.headers.get('user-agent')?.slice(0, 240) ?? null;
+
+  const { error } = await supabaseAdmin.from('volunteer_ratings').insert({
+    queue: 'wikipedia',
+    item_id: itemId,
+    rating: event,
+    detail,
+    volunteer_id: volunteerId,
+    user_agent: ua,
+  });
+
+  if (error) {
+    console.error('[wikipedia/event] insert failed:', error);
+    return NextResponse.json({ error: 'insert failed' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/contribute/wikipedia/state/route.ts
+++ b/src/app/api/contribute/wikipedia/state/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase';
+import { WIKIPEDIA_EVENT_ORDER } from '@/lib/review-queue';
+
+export const maxDuration = 5;
+
+/**
+ * GET /api/contribute/wikipedia/state?volunteer_id=<uuid>
+ *
+ * Returns the current state of every Wikipedia playbook item, computed
+ * from the volunteer_ratings event log (queue='wikipedia'):
+ *   - `mine[item_id]`: the latest status this volunteer set
+ *   - `global[item_id]`: aggregate { claimed_by, posted, merged, ... }
+ *     so we can show "currently claimed by anon42, 12min ago"
+ *   - `totals`: aggregate counters (across all volunteers)
+ */
+export async function GET(request: NextRequest) {
+  const volunteerId = request.nextUrl.searchParams.get('volunteer_id');
+  if (!volunteerId || !/^[0-9a-f-]{36}$/i.test(volunteerId)) {
+    return NextResponse.json({ error: 'invalid volunteer_id' }, { status: 400 });
+  }
+
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'supabase admin not configured' }, { status: 500 });
+  }
+
+  // Pull every event for the wikipedia queue. Volume is small (one event per
+  // claim/post/etc.); a single SELECT is fine for the foreseeable future.
+  const { data, error } = await supabaseAdmin
+    .from('volunteer_ratings')
+    .select('item_id,rating,volunteer_id,created_at,detail')
+    .eq('queue', 'wikipedia')
+    .order('created_at', { ascending: true })
+    .limit(20000);
+
+  if (error) {
+    console.error('[wikipedia/state] select failed:', error);
+    return NextResponse.json({ error: 'select failed' }, { status: 500 });
+  }
+
+  type Event = { item_id: string; rating: string; volunteer_id: string; created_at: string; detail: unknown };
+  const events = (data ?? []) as Event[];
+
+  // Aggregate state per item
+  const global: Record<string, {
+    latest_event?: string;
+    claimed_by?: string;
+    claimed_at?: string;
+    posted_count: number;
+    merged_count: number;
+    declined_count: number;
+  }> = {};
+  const mine: Record<string, { latest_event: string; created_at: string; detail?: unknown }> = {};
+  const totals = { claimed: 0, posted: 0, responded: 0, merged: 0, declined: 0, abandoned: 0 };
+
+  for (const ev of events) {
+    const g = (global[ev.item_id] ||= {
+      posted_count: 0,
+      merged_count: 0,
+      declined_count: 0,
+    });
+
+    // Track latest event ordering per item per volunteer to handle release.
+    if (ev.rating === 'claimed') {
+      g.claimed_by = ev.volunteer_id;
+      g.claimed_at = ev.created_at;
+    } else if (ev.rating === 'released') {
+      if (g.claimed_by === ev.volunteer_id) {
+        g.claimed_by = undefined;
+        g.claimed_at = undefined;
+      }
+    } else if (ev.rating === 'posted') {
+      g.posted_count++;
+      // A post implicitly resolves the claim — keep claimed_by so we know who.
+    } else if (ev.rating === 'merged') {
+      g.merged_count++;
+    } else if (ev.rating === 'declined') {
+      g.declined_count++;
+    }
+
+    const prevRank = WIKIPEDIA_EVENT_ORDER[g.latest_event ?? ''] ?? -1;
+    const nextRank = WIKIPEDIA_EVENT_ORDER[ev.rating] ?? -1;
+    if (nextRank >= prevRank) g.latest_event = ev.rating;
+
+    // Per-volunteer view
+    if (ev.volunteer_id === volunteerId) {
+      const prev = mine[ev.item_id];
+      const prevMyRank = prev ? (WIKIPEDIA_EVENT_ORDER[prev.latest_event] ?? -1) : -1;
+      if (nextRank >= prevMyRank) {
+        mine[ev.item_id] = { latest_event: ev.rating, created_at: ev.created_at, detail: ev.detail };
+      }
+    }
+
+    if (ev.rating in totals) (totals as Record<string, number>)[ev.rating]++;
+  }
+
+  return NextResponse.json({ mine, global, totals });
+}

--- a/src/app/contribute/wikipedia/WikipediaPlaybook.tsx
+++ b/src/app/contribute/wikipedia/WikipediaPlaybook.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getOrCreateVolunteerId } from '@/lib/volunteer-id';
 
 // ── Types ──
 
@@ -14,18 +15,53 @@ export type TalkPagePost = {
   pct: number;
   tier: 1 | 2 | 3;
   wikiText: string;
+  /** Stable identifier for this item — book slug. Used as item_id in the event log. */
+  slug: string;
 };
 
-// ── Components ──
+type ItemStatus = {
+  latest_event?: string;
+  claimed_by?: string;
+  claimed_at?: string;
+  posted_count: number;
+  merged_count: number;
+  declined_count: number;
+};
+
+type MyEvent = { latest_event: string; created_at: string };
+
+type StateResponse = {
+  mine: Record<string, MyEvent>;
+  global: Record<string, ItemStatus>;
+  totals: Record<string, number>;
+};
+
+type Event = 'claimed' | 'released' | 'posted' | 'responded' | 'merged' | 'declined' | 'abandoned';
+
+// ── Helpers ──
+
+function timeAgo(iso?: string): string {
+  if (!iso) return '';
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+  return `${Math.floor(s / 86400)}d ago`;
+}
+
+function shortVolunteer(id?: string): string {
+  if (!id) return '';
+  return 'anon-' + id.slice(0, 6);
+}
+
+// ── Subcomponents ──
 
 function CopyButton({ text, label }: { text: string; label?: string }) {
   const [copied, setCopied] = useState(false);
-
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
     } catch {
       const ta = document.createElement('textarea');
       ta.value = text;
@@ -33,18 +69,15 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
       ta.select();
       document.execCommand('copy');
       document.body.removeChild(ta);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
     }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
-
   return (
     <button
       onClick={handleCopy}
       className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
-        copied
-          ? 'bg-green-100 text-green-800 border border-green-300'
-          : 'bg-accent-rust text-white hover:opacity-90'
+        copied ? 'bg-green-100 text-green-800 border border-green-300' : 'bg-accent-rust text-white hover:opacity-90'
       }`}
     >
       {copied ? 'Copied!' : label || 'Copy text'}
@@ -52,12 +85,116 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
   );
 }
 
+function Badge({
+  color,
+  label,
+}: {
+  color: 'green' | 'red' | 'blue' | 'purple' | 'amber' | 'gray' | 'stone';
+  label: string;
+}) {
+  const colors: Record<string, string> = {
+    green: 'bg-green-50 text-green-800 border-green-200',
+    red: 'bg-red-50 text-red-800 border-red-200',
+    blue: 'bg-blue-50 text-blue-800 border-blue-200',
+    purple: 'bg-purple-50 text-purple-800 border-purple-200',
+    amber: 'bg-amber-50 text-amber-800 border-amber-200',
+    gray: 'bg-gray-100 text-gray-700 border-gray-200',
+    stone: 'bg-stone-100 text-stone-600 border-stone-200',
+  };
+  return <span className={`text-xs px-2 py-1 rounded-md border font-medium ${colors[color]}`}>{label}</span>;
+}
+
+function StatusBadge({
+  myEvent,
+  global,
+  volunteerId,
+}: {
+  myEvent?: string;
+  global?: ItemStatus;
+  volunteerId: string;
+}) {
+  if (myEvent === 'merged') return <Badge color="green" label="✓ Merged" />;
+  if (myEvent === 'declined') return <Badge color="red" label="Declined" />;
+  if (myEvent === 'abandoned') return <Badge color="gray" label="Abandoned" />;
+  if (myEvent === 'responded') return <Badge color="purple" label="Editor responded" />;
+  if (myEvent === 'posted') return <Badge color="green" label="✓ Posted by you" />;
+  if (myEvent === 'claimed') return <Badge color="blue" label="Claimed by you" />;
+  if (global?.claimed_by && global.claimed_by !== volunteerId) {
+    return (
+      <Badge
+        color="amber"
+        label={`Claimed by ${shortVolunteer(global.claimed_by)} ${timeAgo(global.claimed_at)}`}
+      />
+    );
+  }
+  if (global?.merged_count) return <Badge color="green" label={`✓ Merged (${global.merged_count})`} />;
+  if (global?.posted_count) return <Badge color="green" label={`Posted (${global.posted_count})`} />;
+  return <Badge color="stone" label="Unclaimed" />;
+}
+
+function ActionButtons({
+  myEvent,
+  onEvent,
+  busy,
+}: {
+  myEvent?: string;
+  onEvent: (e: Event) => void;
+  busy: boolean;
+}) {
+  const terminal = new Set(['merged', 'declined', 'abandoned']);
+  if (terminal.has(myEvent ?? '')) return null;
+  const buttons: { event: Event; label: string; primary?: boolean }[] = [];
+  if (!myEvent) {
+    buttons.push({ event: 'claimed', label: "I'll post this", primary: true });
+  } else if (myEvent === 'claimed') {
+    buttons.push({ event: 'posted', label: "I've posted it", primary: true });
+    buttons.push({ event: 'released', label: 'Release claim' });
+  } else if (myEvent === 'posted') {
+    buttons.push({ event: 'merged', label: '✓ Merged', primary: true });
+    buttons.push({ event: 'responded', label: 'Editor responded' });
+    buttons.push({ event: 'declined', label: 'Declined' });
+    buttons.push({ event: 'abandoned', label: 'Abandon' });
+  } else if (myEvent === 'responded') {
+    buttons.push({ event: 'merged', label: '✓ Merged', primary: true });
+    buttons.push({ event: 'declined', label: 'Declined' });
+    buttons.push({ event: 'abandoned', label: 'Abandon' });
+  }
+  return (
+    <div className="flex flex-wrap gap-2">
+      {buttons.map(b => (
+        <button
+          key={b.event}
+          onClick={() => onEvent(b.event)}
+          disabled={busy}
+          className={
+            b.primary
+              ? 'px-3 py-1.5 rounded-md text-sm bg-accent-rust text-white hover:opacity-90 disabled:opacity-50'
+              : 'px-3 py-1.5 rounded-md text-sm border border-border-light hover:bg-stone-50 disabled:opacity-50 text-secondary'
+          }
+        >
+          {b.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 function TalkPageCard({
   post,
   index,
+  volunteerId,
+  status,
+  myEvent,
+  onEvent,
+  busy,
 }: {
   post: TalkPagePost;
   index: number;
+  volunteerId: string;
+  status?: ItemStatus;
+  myEvent?: string;
+  onEvent: (e: Event) => void;
+  busy: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -76,26 +213,13 @@ function TalkPageCard({
             <span className="text-muted text-sm">
               {post.author}, {post.year}
             </span>
+            <StatusBadge myEvent={myEvent} global={status} volunteerId={volunteerId} />
           </div>
           <div className="text-sm text-muted mt-0.5">
-            {post.pages.toLocaleString('en-US')} pages, {post.pct}% translated
+            {post.pages.toLocaleString()} pages · {post.pct}% translated
           </div>
         </div>
-        <span
-          className={`flex-shrink-0 text-muted transition-transform ${
-            expanded ? 'rotate-180' : ''
-          }`}
-        >
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-            <path
-              d="M5 7.5L10 12.5L15 7.5"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </span>
+        <span className="text-muted text-xl">{expanded ? '−' : '+'}</span>
       </div>
 
       {expanded && (
@@ -133,15 +257,18 @@ function TalkPageCard({
             <div className="text-xs text-muted mb-2 font-medium uppercase tracking-wide">
               Preview of wiki text to paste:
             </div>
-            <pre className="text-sm text-secondary whitespace-pre-wrap font-mono leading-relaxed">
-              {post.wikiText}
-            </pre>
+            <pre className="text-sm text-secondary whitespace-pre-wrap font-mono leading-relaxed">{post.wikiText}</pre>
           </div>
 
           <div className="text-sm text-muted bg-cream rounded-lg p-3">
-            <strong>How:</strong> Click &ldquo;Copy wiki text&rdquo;, then
-            &ldquo;Open Talk page&rdquo;. On Wikipedia, click &ldquo;New
-            section&rdquo; (or &ldquo;Add topic&rdquo;), paste, and save.
+            <strong>How:</strong> Click &ldquo;Copy wiki text&rdquo;, then &ldquo;Open Talk page&rdquo;. On
+            Wikipedia, click &ldquo;New section&rdquo; (or &ldquo;Add topic&rdquo;), paste, and save. Then come
+            back here and mark it posted so others know it&rsquo;s done.
+          </div>
+
+          <div className="pt-2 border-t border-border-light">
+            <div className="text-xs text-muted uppercase tracking-wide mb-2 font-medium">Track your progress</div>
+            <ActionButtons myEvent={myEvent} onEvent={onEvent} busy={busy} />
           </div>
         </div>
       )}
@@ -149,31 +276,175 @@ function TalkPageCard({
   );
 }
 
+function MySidebar({ posts, mine }: { posts: TalkPagePost[]; mine: Record<string, MyEvent> }) {
+  const active = posts.filter(p => {
+    const m = mine[p.slug];
+    return m && !['merged', 'declined', 'abandoned'].includes(m.latest_event);
+  });
+  const done = posts.filter(p => {
+    const m = mine[p.slug];
+    return m && ['merged', 'declined', 'abandoned'].includes(m.latest_event);
+  });
+  if (active.length === 0 && done.length === 0) {
+    return (
+      <aside className="bg-cream rounded-xl p-5 border border-border-light text-sm text-muted">
+        <h3 className="text-primary font-semibold mb-2">Your contributions</h3>
+        Pick an item below and claim it to start. Your progress saves automatically (per-browser).
+      </aside>
+    );
+  }
+  return (
+    <aside className="bg-cream rounded-xl p-5 border border-border-light">
+      <h3 className="text-primary font-semibold mb-3">Your contributions</h3>
+      {active.length > 0 && (
+        <div className="mb-4">
+          <div className="text-xs text-muted uppercase tracking-wide mb-2 font-medium">Active</div>
+          <ul className="space-y-2 text-sm">
+            {active.map(p => (
+              <li key={p.slug} className="flex items-baseline justify-between gap-2">
+                <span className="text-secondary truncate">
+                  {p.title.slice(0, 36)}
+                  {p.title.length > 36 ? '…' : ''}
+                </span>
+                <span className="text-xs text-muted shrink-0">{mine[p.slug].latest_event}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {done.length > 0 && (
+        <div>
+          <div className="text-xs text-muted uppercase tracking-wide mb-2 font-medium">Done</div>
+          <ul className="space-y-2 text-sm">
+            {done.map(p => (
+              <li key={p.slug} className="flex items-baseline justify-between gap-2">
+                <span className="text-secondary truncate">
+                  {p.title.slice(0, 36)}
+                  {p.title.length > 36 ? '…' : ''}
+                </span>
+                <span className="text-xs text-muted shrink-0">{mine[p.slug].latest_event}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function GlobalTotals({ totals }: { totals: Record<string, number> }) {
+  const items: { key: string; label: string }[] = [
+    { key: 'claimed', label: 'claimed' },
+    { key: 'posted', label: 'posted' },
+    { key: 'responded', label: 'responses' },
+    { key: 'merged', label: 'merged' },
+  ];
+  const hasAny = items.some(i => (totals[i.key] ?? 0) > 0);
+  if (!hasAny) return null;
+  return (
+    <div className="flex flex-wrap gap-4 text-sm text-muted">
+      {items.map(i => (
+        <span key={i.key}>
+          <b className="text-primary">{totals[i.key] ?? 0}</b> {i.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function Step({ n, text }: { n: number; text: string }) {
+  return (
+    <div className="bg-white rounded-lg p-4 text-center">
+      <div className="text-2xl mb-2 text-primary font-display">{n}</div>
+      <div className="text-sm text-secondary">{text}</div>
+    </div>
+  );
+}
+
 // ── Main ──
 
 export function WikipediaPlaybook({ posts }: { posts: TalkPagePost[] }) {
-  const tier1 = posts.filter((p) => p.tier === 1);
-  const tier2 = posts.filter((p) => p.tier === 2);
-  const tier3 = posts.filter((p) => p.tier === 3);
+  const [volunteerId, setVolunteerId] = useState('');
+  const [state, setState] = useState<StateResponse | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const fetchState = useCallback(async (id: string) => {
+    try {
+      const r = await fetch(`/api/contribute/wikipedia/state?volunteer_id=${id}`);
+      const data = (await r.json()) as StateResponse;
+      setState(data);
+    } catch (e) {
+      // Soft-fail: page still works without tracking; just no badges.
+      console.warn('[wikipedia state] fetch failed', e);
+    }
+  }, []);
+
+  useEffect(() => {
+    const id = getOrCreateVolunteerId();
+    setVolunteerId(id);
+    fetchState(id);
+  }, [fetchState]);
+
+  const sendEvent = useCallback(
+    async (slug: string, event: Event) => {
+      if (!volunteerId || busy) return;
+      setBusy(true);
+      try {
+        await fetch('/api/contribute/wikipedia/event', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ item_id: slug, event, volunteer_id: volunteerId }),
+        });
+        await fetchState(volunteerId);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [volunteerId, busy, fetchState],
+  );
+
+  const tier1 = useMemo(() => posts.filter(p => p.tier === 1), [posts]);
+  const tier2 = useMemo(() => posts.filter(p => p.tier === 2), [posts]);
+  const tier3 = useMemo(() => posts.filter(p => p.tier === 3), [posts]);
+
+  const mine = state?.mine ?? {};
+  const global = state?.global ?? {};
+  const totals = state?.totals ?? {};
+
+  function renderCard(post: TalkPagePost, idx: number) {
+    return (
+      <TalkPageCard
+        key={post.slug}
+        post={post}
+        index={idx}
+        volunteerId={volunteerId}
+        status={global[post.slug]}
+        myEvent={mine[post.slug]?.latest_event}
+        onEvent={e => sendEvent(post.slug, e)}
+        busy={busy}
+      />
+    );
+  }
 
   return (
     <div className="space-y-10">
-      {/* Intro */}
       <div className="prose-content max-w-none">
         <p className="text-xl text-secondary leading-relaxed">
-          Source Library has thousands of translated historical texts:
-          Copernicus, Galileo, Euclid, the Corpus Hermeticum, and more. Wikipedia
-          readers should be able to find them. This page makes it easy to help.
+          Source Library has thousands of translated historical texts: Copernicus, Galileo, Euclid, the Corpus
+          Hermeticum, and more. Wikipedia readers should be able to find them. Claim an item, post it on the
+          Talk page, and track your contribution — so volunteers don&rsquo;t duplicate work and we can see the
+          impact.
         </p>
       </div>
 
-      {/* Prerequisites */}
+      <MySidebar posts={posts} mine={mine} />
+      <GlobalTotals totals={totals} />
+
       <section className="bg-white rounded-xl p-6 border border-border-light">
         <h2 className="text-xl text-primary mb-4">Before you start</h2>
         <ol className="text-secondary space-y-3 list-decimal list-inside">
           <li>
-            <strong>Create a Wikimedia account</strong> (if you don&rsquo;t have
-            one) &mdash;{' '}
+            <strong>Create a Wikimedia account</strong> (if you don&rsquo;t have one) &mdash;{' '}
             <a
               href="https://en.wikipedia.org/wiki/Special:CreateAccount"
               target="_blank"
@@ -185,140 +456,91 @@ export function WikipediaPlaybook({ posts }: { posts: TalkPagePost[] }) {
             . One account works for Wikipedia, Wikidata, and Commons.
           </li>
           <li>
-            <strong>Disclose your affiliation</strong> on your user Talk page:
-            write &ldquo;I am affiliated with Source Library&rdquo; or add{' '}
+            <strong>Disclose your affiliation</strong> on your user Talk page: write &ldquo;I am affiliated with
+            Source Library&rdquo; or add{' '}
             <code className="text-sm bg-stone-100 px-1.5 py-0.5 rounded">
               {'{{Wikipedia:Conflict of interest/Statement|Source Library}}'}
             </code>
           </li>
           <li>
-            <strong>Post no more than 5 per day</strong> to avoid looking like
-            spam. Quality over quantity.
+            <strong>Post no more than 5 per day</strong> to avoid looking like spam. Quality over quantity.
+          </li>
+          <li>
+            <strong>Claim an item below before you post</strong> so others can see it&rsquo;s in progress and
+            don&rsquo;t duplicate. Mark it Posted once you&rsquo;ve made the Talk-page contribution, and Merged
+            when an editor accepts it.
           </li>
         </ol>
       </section>
 
-      {/* How it works */}
       <section className="bg-cream rounded-xl p-6 border border-border-light">
         <h2 className="text-xl text-primary mb-3">How this works</h2>
         <p className="text-secondary mb-4">
-          Because Source Library is affiliated with these contributions, Wikipedia
-          policy asks us to <em>suggest</em> edits on article Talk pages rather than
-          editing articles directly. Each card below contains pre-written text. The
-          process for each one is:
+          Because Source Library is affiliated with these contributions, Wikipedia policy asks us to{' '}
+          <em>suggest</em> edits on article Talk pages rather than editing articles directly. Each card below
+          contains pre-written text. The process for each one is:
         </p>
-        <div className="grid sm:grid-cols-3 gap-4">
-          <div className="bg-white rounded-lg p-4 text-center">
-            <div className="text-2xl mb-2 text-primary font-display">1</div>
-            <div className="text-sm text-secondary">
-              Click <strong>&ldquo;Copy wiki text&rdquo;</strong>
-            </div>
-          </div>
-          <div className="bg-white rounded-lg p-4 text-center">
-            <div className="text-2xl mb-2 text-primary font-display">2</div>
-            <div className="text-sm text-secondary">
-              Click <strong>&ldquo;Open Talk page&rdquo;</strong>
-            </div>
-          </div>
-          <div className="bg-white rounded-lg p-4 text-center">
-            <div className="text-2xl mb-2 text-primary font-display">3</div>
-            <div className="text-sm text-secondary">
-              Click <strong>&ldquo;New section&rdquo;</strong>, paste, save
-            </div>
-          </div>
+        <div className="grid sm:grid-cols-4 gap-4">
+          <Step n={1} text='Click "I&apos;ll post this" to claim it' />
+          <Step n={2} text="Copy wiki text + open Talk page" />
+          <Step n={3} text="Paste as a new section on Wikipedia" />
+          <Step n={4} text="Mark Posted (then Merged when accepted)" />
         </div>
       </section>
 
-      {/* Tier 1 */}
       <section>
         <div className="mb-4">
-          <h2 className="text-2xl text-primary font-display">
-            Tier 1 &mdash; Highest-Traffic Articles
-          </h2>
-          <p className="text-muted text-sm mt-1">
-            Start here. These Wikipedia articles get the most readers.
-          </p>
+          <h2 className="text-2xl text-primary font-display">Tier 1 &mdash; Highest-Traffic Articles</h2>
+          <p className="text-muted text-sm mt-1">Start here. These Wikipedia articles get the most readers.</p>
         </div>
-        <div className="space-y-3">
-          {tier1.map((post, i) => (
-            <TalkPageCard key={post.bookUrl} post={post} index={i} />
-          ))}
-        </div>
+        <div className="space-y-3">{tier1.map((p, i) => renderCard(p, i))}</div>
       </section>
 
-      {/* Tier 2 */}
       <section>
         <div className="mb-4">
-          <h2 className="text-2xl text-primary font-display">
-            Tier 2 &mdash; Strong Candidates
-          </h2>
-          <p className="text-muted text-sm mt-1">
-            Post these after Tier 1, once you see some responses.
-          </p>
+          <h2 className="text-2xl text-primary font-display">Tier 2 &mdash; Strong Candidates</h2>
+          <p className="text-muted text-sm mt-1">Post these after Tier 1, once you see some responses.</p>
         </div>
-        <div className="space-y-3">
-          {tier2.map((post, i) => (
-            <TalkPageCard
-              key={post.bookUrl}
-              post={post}
-              index={tier1.length + i}
-            />
-          ))}
-        </div>
+        <div className="space-y-3">{tier2.map((p, i) => renderCard(p, tier1.length + i))}</div>
       </section>
 
-      {/* Tier 3 */}
       <section>
         <div className="mb-4">
-          <h2 className="text-2xl text-primary font-display">
-            Tier 3 &mdash; Major Author Articles
-          </h2>
+          <h2 className="text-2xl text-primary font-display">Tier 3 &mdash; Major Author Articles</h2>
           <p className="text-muted text-sm mt-1">
-            These link to the author&rsquo;s Wikipedia article rather than a
-            specific work article.
+            These link to the author&rsquo;s Wikipedia article rather than a specific work article.
           </p>
         </div>
-        <div className="space-y-3">
-          {tier3.map((post, i) => (
-            <TalkPageCard
-              key={post.bookUrl}
-              post={post}
-              index={tier1.length + tier2.length + i}
-            />
-          ))}
-        </div>
+        <div className="space-y-3">{tier3.map((p, i) => renderCard(p, tier1.length + tier2.length + i))}</div>
       </section>
 
-      {/* Tips */}
       <section className="bg-white rounded-xl p-6 border border-border-light">
         <h2 className="text-xl text-primary mb-4">Tips</h2>
         <ul className="text-secondary space-y-2 list-disc list-inside">
           <li>
-            <strong>Be patient.</strong> Some Talk page suggestions take days or
-            weeks to get a response. That&rsquo;s normal.
+            <strong>Be patient.</strong> Some Talk page suggestions take days or weeks to get a response.
+            That&rsquo;s normal.
           </li>
           <li>
-            <strong>Respond to feedback.</strong> If an editor asks a question,
-            engage respectfully.
+            <strong>Respond to feedback.</strong> If an editor asks a question, engage respectfully.
           </li>
           <li>
-            <strong>Never edit articles directly</strong> when you have a conflict
-            of interest. Always use Talk pages.
+            <strong>Never edit articles directly</strong> when you have a conflict of interest. Always use Talk
+            pages.
           </li>
           <li>
-            <strong>Don&rsquo;t game it.</strong> Source Library is genuinely
-            useful. Let the quality speak.
+            <strong>Don&rsquo;t game it.</strong> Source Library is genuinely useful. Let the quality speak.
+          </li>
+          <li>
+            <strong>Mark Merged honestly.</strong> Only when an editor actually updates the article — not when
+            you post on Talk. The merged counter helps us prove impact to funders.
           </li>
         </ul>
       </section>
 
-      {/* Footer */}
       <div className="text-sm text-muted text-center pb-8">
         Questions? Contact{' '}
-        <a
-          href="mailto:derek@sourcelibrary.org"
-          className="text-accent-rust hover:underline"
-        >
+        <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:underline">
           derek@sourcelibrary.org
         </a>
       </div>

--- a/src/app/contribute/wikipedia/page.tsx
+++ b/src/app/contribute/wikipedia/page.tsx
@@ -248,6 +248,7 @@ export default async function WikipediaContributePage() {
     } : null;
 
     return {
+      slug: config.slug,
       title: config.wikiTitle.replace(/\s*\(\d{4}.*?\)\s*$/, ''),
       author: (book.author as string) || 'Unknown',
       talkPageUrl: config.talkPageUrl,

--- a/src/lib/review-queue.ts
+++ b/src/lib/review-queue.ts
@@ -32,6 +32,18 @@ export const QUEUE_RATINGS: Record<string, RatingOption[]> = {
     { key: 'n', rating: 'blank',            label: '∅ blank',            color: '#6b7280', hint: 'Effectively blank page' },
     { key: 'u', rating: 'unclear',          label: '? unclear',          color: '#9ca3af', hint: "Can't tell" },
   ],
+  // Wikipedia contribution events. Not a rating queue — used as an event log
+  // for the /contribute/wikipedia playbook (claim → post → response → merged).
+  // No keyboard shortcuts; events come from explicit button clicks.
+  wikipedia: [
+    { key: '',  rating: 'claimed',    label: 'Claimed',    color: '#3b82f6', hint: "I'll post this one" },
+    { key: '',  rating: 'released',   label: 'Released',   color: '#6b7280', hint: 'Giving up my claim — someone else take it' },
+    { key: '',  rating: 'posted',     label: 'Posted',     color: '#10b981', hint: 'Posted on Wikipedia Talk page' },
+    { key: '',  rating: 'responded',  label: 'Responded',  color: '#a855f7', hint: 'A Wikipedia editor responded to my post' },
+    { key: '',  rating: 'merged',     label: 'Merged',     color: '#16a34a', hint: 'The article was actually updated' },
+    { key: '',  rating: 'declined',   label: 'Declined',   color: '#ef4444', hint: 'A Wikipedia editor declined the suggestion' },
+    { key: '',  rating: 'abandoned',  label: 'Abandoned',  color: '#9ca3af', hint: 'No response after a while; giving up' },
+  ],
 };
 
 export function isValidRating(queue: string, rating: string): boolean {
@@ -42,5 +54,17 @@ export function getRatingOptions(queue: string): RatingOption[] {
   return QUEUE_RATINGS[queue] ?? [];
 }
 
-export const QUEUE_KEYS = ['hallucination', 'gallery-quality', 'scan-quality'] as const;
+export const QUEUE_KEYS = ['hallucination', 'gallery-quality', 'scan-quality', 'wikipedia'] as const;
 export type QueueKey = (typeof QUEUE_KEYS)[number];
+
+// Wikipedia event ordering: defines what's a "later" status. Used to roll up
+// per-item state from the event log.
+export const WIKIPEDIA_EVENT_ORDER: Record<string, number> = {
+  claimed: 1,
+  released: 0,    // a release wipes the claim
+  posted: 2,
+  responded: 3,
+  declined: 4,    // terminal-but-negative
+  merged: 5,      // terminal-and-positive
+  abandoned: 4,   // terminal-but-incomplete
+};


### PR DESCRIPTION
Take the existing `/contribute/wikipedia` page to the next level so it can actually coordinate volunteers — not just hand them one-shot copy-paste text.

## Problem
The current page hands a volunteer everything they need to post **one** Talk-page contribution. But there's no shared state between volunteers and no follow-up loop:
- Two people could claim the same item and post the same message
- Nobody knew which items had been merged into Wikipedia and which were still waiting
- A volunteer who came back later had no record of what they'd already done

## Solution
Add a state-transition layer on top of the existing playbook:

```
claimed → posted → responded → (merged | declined | abandoned)
        or → released
```

Backed by the existing `volunteer_ratings` table (`queue='wikipedia'`), treated as an event log rather than a rating queue.

## What's new

**Per-item UI:**
- Status badge: `Unclaimed` / `Claimed by anon-abc 12m ago` / `Posted by you` / `✓ Merged` etc.
- Contextual action buttons: "I'll post this" → "I've posted it" → "✓ Merged", with branching for declined/abandoned/responded

**Page-level UI:**
- "Your contributions" sidebar (Active / Done sections)
- Global totals at the top: `N claimed · N posted · N responses · N merged`

**Two new API routes:**
- `GET /api/contribute/wikipedia/state?volunteer_id=X` — aggregates the event log into per-item and per-volunteer views in one round-trip
- `POST /api/contribute/wikipedia/event` — appends a single state-transition event

**Shared config:**
- Adds `wikipedia` queue to `lib/review-queue.ts` with 7 event kinds; existing queues unchanged
- `WIKIPEDIA_EVENT_ORDER` exported for state aggregation
- `TalkPagePost` gains a stable `slug` field used as `item_id`

## Soft-fails
If the state fetch errors out, the page still renders in its original copy-and-paste form — just without badges or action buttons. No regression for users hitting it before Supabase responds.

## Out of scope (follow-up)
- Auto-generated worklist beyond the manually-curated 17 (issue #2121 has this)
- Wikimedia Commons upload track / Wikidata edition records (separate queues)
- Real auth — currently anonymous via per-browser uuid in localStorage; sign-in is a future layer
- Onboarding modal for first-time volunteers

## Test plan
- [x] `npx tsc --noEmit` clean for affected files
- [x] proxy NON_TENANT_PATHS test still passes
- [ ] On Vercel preview: claim → post → merged flow works end-to-end against production Supabase
- [ ] Second browser sees "Claimed by anon-xxx" badge after first claims
- [ ] State fetch failure leaves the page functional