### PR TITLE
feat(embeddings): embedding_model + mongo_updated_at watermark for Supabase stores

### DIFF
--- a/scripts/backfill-clip-embeddings.mjs
+++ b/scripts/backfill-clip-embeddings.mjs
@@ -275,9 +275,13 @@ async function flushToPostgres(client, rows) {
   const params = [];
   let paramIdx = 1;
 
+  // Model identifier as reported by clip-server.mjs:25 (MODEL_ID) / :87 (/health endpoint).
+  // Kept inline so this script is self-contained even when the CLIP server is unreachable.
+  const CLIP_MODEL = 'Xenova/clip-vit-base-patch32';
+
   for (const row of rows) {
     const embeddingStr = `[${row._embedding.join(',')}]`;
-    values.push(`($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}::vector, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7}, $${paramIdx + 8})`);
+    values.push(`($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}::vector, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7}, $${paramIdx + 8}, $${paramIdx + 9})`);
     params.push(
       row.id,
       row.source_type,
@@ -288,12 +292,13 @@ async function flushToPostgres(client, rows) {
       row.author,
       row.resource_type,
       row.thumbnail_url,
+      CLIP_MODEL,
     );
-    paramIdx += 9;
+    paramIdx += 10;
   }
 
   const sql = `
-    INSERT INTO clip_embeddings (id, source_type, book_id, image_url, embedding, title, author, resource_type, thumbnail_url)
+    INSERT INTO clip_embeddings (id, source_type, book_id, image_url, embedding, title, author, resource_type, thumbnail_url, embedding_model)
     VALUES ${values.join(', ')}
     ON CONFLICT (id) DO UPDATE SET
       embedding = EXCLUDED.embedding,
@@ -301,6 +306,7 @@ async function flushToPostgres(client, rows) {
       title = EXCLUDED.title,
       author = EXCLUDED.author,
       thumbnail_url = EXCLUDED.thumbnail_url,
+      embedding_model = EXCLUDED.embedding_model,
       created_at = NOW()
   `;
 

--- a/scripts/migration/add-embedding-model-columns.sql
+++ b/scripts/migration/add-embedding-model-columns.sql
@@ -1,0 +1,86 @@
+-- Add embedding_model column to all five embedding tables.
+--
+-- Why: when Gemini retires `gemini-embedding-2-preview` (it's still labeled
+-- "preview" — see lesson_gemini_preview_suffix_retired.md for what happens
+-- when these suffixes get dropped from active models), we need to know
+-- which rows are on which model so a migration is mechanical instead of
+-- "re-embed everything and pray nothing reads the old vectors mid-flight."
+--
+-- Coverage:
+--   page_translations         — 768d Gemini
+--   book_embeddings           — 768d Gemini
+--   artwork_embeddings        — 3072d halfvec Gemini
+--   gallery_text_embeddings   — 768d Gemini  (legacy `model` column kept; see below)
+--   clip_embeddings           — 512d CLIP (Xenova/clip-vit-base-patch32 per clip-server.mjs:25)
+--
+-- gallery_text_embeddings already has a `model TEXT DEFAULT 'text-embedding-004'`
+-- column from its pre-Gemini migration. We KEEP that column intact and add
+-- `embedding_model` alongside for cross-table uniformity. Don't drop the legacy
+-- column — older rows may genuinely be on text-embedding-004 and the value is
+-- ground truth for them.
+--
+-- Defaults are best-known current-model strings, applied retroactively. Future
+-- writes set the column explicitly per worker code (see PR for worker edits).
+--
+-- Apply (idempotent):
+--   psql "$SUPABASE_DB_URL" -f scripts/migration/add-embedding-model-columns.sql
+
+BEGIN;
+
+-- ── page_translations ────────────────────────────────────────────────
+ALTER TABLE page_translations
+  ADD COLUMN IF NOT EXISTS embedding_model TEXT NOT NULL DEFAULT 'gemini-embedding-2-preview';
+
+CREATE INDEX IF NOT EXISTS page_translations_embedding_model_idx
+  ON page_translations (embedding_model);
+
+-- ── book_embeddings ──────────────────────────────────────────────────
+ALTER TABLE book_embeddings
+  ADD COLUMN IF NOT EXISTS embedding_model TEXT NOT NULL DEFAULT 'gemini-embedding-2-preview';
+
+CREATE INDEX IF NOT EXISTS book_embeddings_embedding_model_idx
+  ON book_embeddings (embedding_model);
+
+-- ── artwork_embeddings ───────────────────────────────────────────────
+ALTER TABLE artwork_embeddings
+  ADD COLUMN IF NOT EXISTS embedding_model TEXT NOT NULL DEFAULT 'gemini-embedding-2-preview';
+
+CREATE INDEX IF NOT EXISTS artwork_embeddings_embedding_model_idx
+  ON artwork_embeddings (embedding_model);
+
+-- ── gallery_text_embeddings ──────────────────────────────────────────
+-- Legacy `model` column kept for historical truth. New `embedding_model`
+-- added for uniform cross-table queries (e.g. "show me all rows still on
+-- gemini-embedding-2-preview after we ship v3").
+ALTER TABLE gallery_text_embeddings
+  ADD COLUMN IF NOT EXISTS embedding_model TEXT NOT NULL DEFAULT 'gemini-embedding-2-preview';
+
+CREATE INDEX IF NOT EXISTS gallery_text_embeddings_embedding_model_idx
+  ON gallery_text_embeddings (embedding_model);
+
+-- For rows where the legacy `model` column has a non-Gemini value, propagate
+-- it so embedding_model is accurate ground truth instead of the default.
+UPDATE gallery_text_embeddings
+   SET embedding_model = model
+ WHERE model IS NOT NULL
+   AND model <> ''
+   AND model <> embedding_model;
+
+-- ── clip_embeddings ──────────────────────────────────────────────────
+-- Default reflects current CLIP server (scripts/workers/clip-server.mjs:25):
+--   const MODEL_ID = 'Xenova/clip-vit-base-patch32'
+-- Verified via the server's /health endpoint at clip-server.mjs:87.
+ALTER TABLE clip_embeddings
+  ADD COLUMN IF NOT EXISTS embedding_model TEXT NOT NULL DEFAULT 'Xenova/clip-vit-base-patch32';
+
+CREATE INDEX IF NOT EXISTS clip_embeddings_embedding_model_idx
+  ON clip_embeddings (embedding_model);
+
+COMMIT;
+
+-- Sanity counts (run separately, not in the transaction):
+--   SELECT embedding_model, count(*) FROM page_translations         GROUP BY 1;
+--   SELECT embedding_model, count(*) FROM book_embeddings           GROUP BY 1;
+--   SELECT embedding_model, count(*) FROM artwork_embeddings        GROUP BY 1;
+--   SELECT embedding_model, count(*) FROM gallery_text_embeddings   GROUP BY 1;
+--   SELECT embedding_model, count(*) FROM clip_embeddings           GROUP BY 1;

--- a/scripts/migration/add-page-translations-watermark.sql
+++ b/scripts/migration/add-page-translations-watermark.sql
@@ -1,0 +1,48 @@
+-- Add mongo_updated_at watermark to page_translations.
+--
+-- Why: page_translations.translation is a denormalized snapshot of Mongo's
+-- pages.translation.data, kept in sync only when embed-gemini.mjs runs on
+-- a given page. When pages.updated_at advances (re-OCR, re-translation),
+-- the Supabase row goes stale — the embedding mismatches the now-different
+-- text. Today there is no invalidation signal; the only fix is a periodic
+-- "re-embed everything" or hope nobody re-translates.
+--
+-- The watermark stores the Mongo source page's freshness timestamp at
+-- write time. A re-stale scan (see embed-gemini.mjs --restale, added in
+-- the same PR) finds rows where Mongo has moved past the watermark and
+-- re-embeds them.
+--
+-- Scope: page_translations only. The other four embedding tables don't
+-- need this:
+--   book_embeddings   — derived from book_indexes which is rebuilt holistically
+--                       by enrich-worker; per-row freshness isn't actionable.
+--   artwork_embeddings — derived from artwork metadata which is essentially
+--                        immutable post-import.
+--   gallery_text_embeddings / clip_embeddings — derived from images which
+--                                                don't change.
+--
+-- Apply:
+--   psql "$SUPABASE_DB_URL" -f scripts/migration/add-page-translations-watermark.sql
+--
+-- Then backfill via:
+--   set -a; source .env.production.local; set +a
+--   node scripts/migration/backfill-page-translations-watermark.mjs --dry-run
+--   node scripts/migration/backfill-page-translations-watermark.mjs --apply
+
+BEGIN;
+
+ALTER TABLE page_translations
+  ADD COLUMN IF NOT EXISTS mongo_updated_at TIMESTAMPTZ;
+
+-- Index supports the staleness scan: WHERE mongo_updated_at IS NULL
+-- (rows never backfilled) OR comparing against Mongo timestamps fetched
+-- in batches. NULL-tolerant index so unbackfilled rows can be found.
+CREATE INDEX IF NOT EXISTS page_translations_mongo_updated_at_idx
+  ON page_translations (mongo_updated_at NULLS FIRST);
+
+COMMIT;
+
+-- Post-backfill verification:
+--   SELECT count(*) FILTER (WHERE mongo_updated_at IS NULL) AS unbackfilled,
+--          count(*)                                         AS total
+--   FROM page_translations;

--- a/scripts/migration/backfill-artwork-embeddings.mjs
+++ b/scripts/migration/backfill-artwork-embeddings.mjs
@@ -147,15 +147,17 @@ async function main() {
         await pgClient.query(`
           INSERT INTO artwork_embeddings (book_id, title, display_title, author, summary_text,
             subjects, figures, symbols, iconclass, technique, material, style, period, culture,
-            genre, ulan_artist, collections, embedding, resource_type, thumbnail_url, updated_at)
-          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,now())
+            genre, ulan_artist, collections, embedding, resource_type, thumbnail_url, updated_at,
+            embedding_model)
+          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,now(),$21)
           ON CONFLICT (book_id) DO UPDATE SET
             summary_text=EXCLUDED.summary_text, embedding=EXCLUDED.embedding,
             subjects=EXCLUDED.subjects, figures=EXCLUDED.figures, symbols=EXCLUDED.symbols,
             iconclass=EXCLUDED.iconclass, technique=EXCLUDED.technique, material=EXCLUDED.material,
             style=EXCLUDED.style, period=EXCLUDED.period, culture=EXCLUDED.culture,
             genre=EXCLUDED.genre, ulan_artist=EXCLUDED.ulan_artist, collections=EXCLUDED.collections,
-            display_title=EXCLUDED.display_title, thumbnail_url=EXCLUDED.thumbnail_url, updated_at=now()
+            display_title=EXCLUDED.display_title, thumbnail_url=EXCLUDED.thumbnail_url,
+            embedding_model=EXCLUDED.embedding_model, updated_at=now()
         `, [
           art.id, art.title, art.display_title || art.title, art.author, texts[idx],
           e.figures_depicted || [], e.figures_depicted || [], e.symbols || [],
@@ -165,6 +167,7 @@ async function main() {
           art.wikidata_artist?.ulan_id ? parseInt(art.wikidata_artist.ulan_id) : (e.ulan_artist || null),
           art.collections || [], JSON.stringify(embeddings[idx]),
           art.resource_type || null, art.thumbnail_blob || art.thumbnail || null,
+          'gemini-embedding-2-preview',
         ]);
       }
       embedded += batch.length;

--- a/scripts/migration/backfill-page-translations-watermark.mjs
+++ b/scripts/migration/backfill-page-translations-watermark.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Backfill mongo_updated_at on page_translations from the source Mongo page.
+ *
+ * Scale: ~3.9M rows. Batched by book_id (200-1000 pages per batch typically).
+ * Resumable: tracks progress in scripts/migration/.backfill-watermark.state
+ * Dry-run by default — pass --apply to write.
+ *
+ * Freshness chain (matches embed-gemini.mjs:435):
+ *   pages.translation.updated_at  →  pages.ocr.updated_at  →  pages.updated_at
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/migration/backfill-page-translations-watermark.mjs --dry-run
+ *   node scripts/migration/backfill-page-translations-watermark.mjs --apply
+ *   node scripts/migration/backfill-page-translations-watermark.mjs --apply --resume
+ *   node scripts/migration/backfill-page-translations-watermark.mjs --apply --book <book_id>
+ *
+ * Env required: MONGODB_URI, SUPABASE_DB_URL (direct PG; the REST API can't
+ * handle the per-row UPDATE rate efficiently).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MongoClient } from 'mongodb';
+import pg from 'pg';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STATE_FILE = path.join(__dirname, '.backfill-watermark.state');
+
+// ── Args ──────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const RESUME = args.includes('--resume');
+const BOOK_ID = args.find((_, i, a) => a[i - 1] === '--book');
+const LIMIT_BOOKS = parseInt(args.find((_, i, a) => a[i - 1] === '--limit-books') || '0') || 0;
+
+if (!APPLY) {
+  console.log('DRY RUN — no writes. Pass --apply to commit.');
+}
+
+// ── Env ───────────────────────────────────────────────────────────────
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL;
+if (!MONGODB_URI || !SUPABASE_DB_URL) {
+  console.error('Missing env: MONGODB_URI and SUPABASE_DB_URL required.');
+  process.exit(1);
+}
+
+// ── Clients ──────────────────────────────────────────────────────────
+
+const mongo = new MongoClient(MONGODB_URI, { maxPoolSize: 3 });
+await mongo.connect();
+const db = mongo.db('bookstore');
+
+const pgClient = new pg.Client({
+  connectionString: SUPABASE_DB_URL,
+  ssl: { rejectUnauthorized: false },
+});
+await pgClient.connect();
+await pgClient.query('SET statement_timeout = 60000');
+
+// ── Resume state ─────────────────────────────────────────────────────
+
+function loadState() {
+  if (!RESUME) return { processedBookIds: [] };
+  if (!fs.existsSync(STATE_FILE)) return { processedBookIds: [] };
+  return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+}
+
+function saveState(state) {
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+const state = loadState();
+const doneSet = new Set(state.processedBookIds);
+if (doneSet.size > 0) console.log(`Resuming — ${doneSet.size} books already processed`);
+
+// ── Plan ─────────────────────────────────────────────────────────────
+
+let bookIds;
+if (BOOK_ID) {
+  bookIds = [BOOK_ID];
+} else {
+  console.log('Listing distinct book_ids with NULL mongo_updated_at...');
+  const res = await pgClient.query(`
+    SELECT DISTINCT book_id
+      FROM page_translations
+     WHERE mongo_updated_at IS NULL
+     ORDER BY book_id
+  `);
+  bookIds = res.rows.map(r => r.book_id).filter(id => !doneSet.has(id));
+  console.log(`${bookIds.length.toLocaleString()} book_ids remaining to backfill`);
+  if (LIMIT_BOOKS > 0) {
+    bookIds = bookIds.slice(0, LIMIT_BOOKS);
+    console.log(`(limited to first ${LIMIT_BOOKS} for this run)`);
+  }
+}
+
+// ── Backfill loop ────────────────────────────────────────────────────
+
+let totalRows = 0;
+let totalUpdated = 0;
+let totalSkipped = 0;
+const start = Date.now();
+
+for (let bookIdx = 0; bookIdx < bookIds.length; bookIdx++) {
+  const bookId = bookIds[bookIdx];
+
+  // Fetch Mongo pages for this book — only the freshness fields we need
+  const pages = await db.collection('pages')
+    .find({ book_id: bookId }, {
+      projection: {
+        _id: 1,
+        page_number: 1,
+        'translation.updated_at': 1,
+        'ocr.updated_at': 1,
+        updated_at: 1,
+      },
+    })
+    .toArray();
+  if (pages.length === 0) {
+    doneSet.add(bookId);
+    continue;
+  }
+
+  // Build (page_id → freshness) map. page_id in Supabase is the Mongo
+  // ObjectId hex string (per embed-gemini.mjs:426 → item.page.id).
+  const freshness = new Map();
+  for (const p of pages) {
+    const ts = p.translation?.updated_at || p.ocr?.updated_at || p.updated_at;
+    if (ts) freshness.set(String(p._id), ts);
+  }
+  if (freshness.size === 0) {
+    doneSet.add(bookId);
+    continue;
+  }
+
+  // Fetch the corresponding Supabase rows (page_id only)
+  const { rows: ptRows } = await pgClient.query(
+    `SELECT page_id FROM page_translations WHERE book_id = $1 AND mongo_updated_at IS NULL`,
+    [bookId],
+  );
+  totalRows += ptRows.length;
+
+  let updated = 0;
+  let skipped = 0;
+  if (APPLY) {
+    // Group updates by timestamp to batch them (UPDATE ... WHERE page_id = ANY($2))
+    const byTs = new Map();
+    for (const r of ptRows) {
+      const ts = freshness.get(r.page_id);
+      if (!ts) { skipped++; continue; }
+      const key = new Date(ts).toISOString();
+      if (!byTs.has(key)) byTs.set(key, []);
+      byTs.get(key).push(r.page_id);
+    }
+    for (const [tsIso, pageIds] of byTs) {
+      const res = await pgClient.query(
+        `UPDATE page_translations SET mongo_updated_at = $1 WHERE page_id = ANY($2::text[])`,
+        [tsIso, pageIds],
+      );
+      updated += res.rowCount;
+    }
+  } else {
+    for (const r of ptRows) {
+      if (freshness.has(r.page_id)) updated++;
+      else skipped++;
+    }
+  }
+
+  totalUpdated += updated;
+  totalSkipped += skipped;
+  doneSet.add(bookId);
+
+  if ((bookIdx + 1) % 25 === 0 || bookIdx === bookIds.length - 1) {
+    const elapsed = (Date.now() - start) / 1000;
+    const rate = Math.round(totalUpdated / Math.max(elapsed, 1));
+    console.log(`  [${bookIdx + 1}/${bookIds.length}] ${bookId} → ${updated} updated, ${skipped} no-mongo-ts. Total ${totalUpdated.toLocaleString()} (${rate}/s)`);
+    if (APPLY) saveState({ processedBookIds: [...doneSet] });
+  }
+}
+
+if (APPLY) saveState({ processedBookIds: [...doneSet] });
+
+console.log(`\nDone. ${totalRows.toLocaleString()} rows inspected, ${totalUpdated.toLocaleString()} updated, ${totalSkipped.toLocaleString()} skipped (no Mongo timestamp).`);
+
+await pgClient.end();
+await mongo.close();

--- a/scripts/workers/embed-gemini.mjs
+++ b/scripts/workers/embed-gemini.mjs
@@ -15,11 +15,17 @@
  *   --full        Process all pages with OCR or translation
  *   --incremental Process pages newer than latest in Supabase (default)
  *   --missing-only Process only books that have pages with embedding IS NULL (~3-4h vs 85h for --full)
+ *   --restale     Re-embed rows whose Mongo source is newer than the
+ *                 Supabase mongo_updated_at watermark (catches re-OCR /
+ *                 re-translation in Mongo without re-embed). Requires the
+ *                 watermark column + backfill (see add-page-translations-
+ *                 watermark.sql and backfill-page-translations-watermark.mjs).
  *   --book ID     Process a single book
  *   --limit N     Stop after N pages
  *   --dry-run     Count pages without embedding
  *
- * Env: MONGODB_URI, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_DB_URL, GEMINI_API_KEY
+ * Env: MONGODB_URI, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_DB_URL,
+ *      GEMINI_API_KEY_TIER3 (preferred, no training opt-in) or GEMINI_API_KEY
  *
  * Run on Hetzner:
  *   set -a; source .env.production.local; set +a
@@ -35,16 +41,23 @@ const MONGODB_URI = process.env.MONGODB_URI;
 const SUPABASE_URL = (process.env.SUPABASE_URL || '').trim();
 const SUPABASE_KEY = (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
 const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL;
-const GEMINI_KEY = process.env.GEMINI_API_KEY;
+// Prefer paid Tier 3 (no training opt-in) for content-bearing translations;
+// fall back to default key for local/dev. Cron explicitly exports TIER3 too
+// (crontab.production), so this is belt-and-suspenders for ad-hoc runs.
+const GEMINI_KEY = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
 
 if (!MONGODB_URI || !SUPABASE_KEY || !GEMINI_KEY) {
-  console.error('Missing env: MONGODB_URI, SUPABASE_SERVICE_ROLE_KEY, or GEMINI_API_KEY');
+  console.error('Missing env: MONGODB_URI, SUPABASE_SERVICE_ROLE_KEY, or GEMINI_API_KEY[_TIER3]');
   process.exit(1);
 }
 
 const args = process.argv.slice(2);
 const FULL_MODE = args.includes('--full');
 const MISSING_ONLY = args.includes('--missing-only');
+// --restale: re-embed rows where the source Mongo page is newer than the
+// stored mongo_updated_at watermark. Catches OCR/translation updates that
+// would otherwise leave Supabase silently stale.
+const RESTALE = args.includes('--restale');
 const DRY_RUN = args.includes('--dry-run');
 const BOOK_ID = args.find((_, i, a) => a[i - 1] === '--book');
 const LIMIT = parseInt(args.find((_, i, a) => a[i - 1] === '--limit') || '0') || 0;
@@ -151,7 +164,7 @@ async function getLastSyncTime() {
 
 const start = Date.now();
 console.log(`Embedding model: ${MODEL} (${DIMS} dims)`);
-console.log(`Mode: ${FULL_MODE ? 'full' : MISSING_ONLY ? 'missing-only' : BOOK_ID ? 'book ' + BOOK_ID : 'incremental'}${WORKER_COUNT > 1 ? ` (worker ${WORKER_ID}/${WORKER_COUNT})` : ''}`);
+console.log(`Mode: ${FULL_MODE ? 'full' : RESTALE ? 'restale' : MISSING_ONLY ? 'missing-only' : BOOK_ID ? 'book ' + BOOK_ID : 'incremental'}${WORKER_COUNT > 1 ? ` (worker ${WORKER_ID}/${WORKER_COUNT})` : ''}`);
 
 const mongoClient = new MongoClient(MONGODB_URI, { maxPoolSize: 3 });
 await mongoClient.connect();
@@ -200,6 +213,68 @@ if (BOOK_ID) {
   globalThis.MISSING_PAGE_IDS = new Set(myRows.map(r => r.page_id));
   pageQuery.book_id = { $in: myBookIds };
   console.log(`Processing ${myRows.length.toLocaleString()} missing pages across ${myBookIds.length.toLocaleString()} books`);
+} else if (RESTALE) {
+  // Find rows whose Mongo source has moved past the Supabase mongo_updated_at
+  // watermark — re-OCR or re-translation in Mongo without a re-embed. The
+  // scan is per-book to keep the working set small.
+  const pg = await getPgClient();
+  if (!pg) {
+    console.error('SUPABASE_DB_URL required for --restale (per-book scans need many round-trips)');
+    process.exit(1);
+  }
+
+  console.log('Scanning for stale rows (Mongo updated_at > Supabase mongo_updated_at)...');
+  const { rows: bookRows } = await pg.query(`SELECT DISTINCT book_id FROM page_translations ORDER BY book_id`);
+  let allBookIds = bookRows.map(r => r.book_id);
+  if (WORKER_COUNT > 1) {
+    allBookIds = allBookIds.filter((_, i) => i % WORKER_COUNT === WORKER_ID);
+    console.log(`Worker ${WORKER_ID}/${WORKER_COUNT}: scanning ${allBookIds.length.toLocaleString()} books`);
+  }
+
+  const stalePageIds = new Set();
+  const staleBookIds = new Set();
+  let scannedBooks = 0;
+  for (const bookId of allBookIds) {
+    const { rows: ptRows } = await pg.query(
+      `SELECT page_id, mongo_updated_at FROM page_translations WHERE book_id = $1`,
+      [bookId],
+    );
+    if (ptRows.length === 0) continue;
+
+    const watermarks = new Map(ptRows.map(r => [r.page_id, r.mongo_updated_at]));
+
+    const mongoPages = await db.collection('pages')
+      .find({ book_id: bookId })
+      .project({ _id: 1, 'translation.updated_at': 1, 'ocr.updated_at': 1, updated_at: 1 })
+      .toArray();
+
+    for (const p of mongoPages) {
+      const pageId = String(p._id);
+      if (!watermarks.has(pageId)) continue; // not in Supabase yet (--missing-only's job)
+      const mongoTs = p.translation?.updated_at || p.ocr?.updated_at || p.updated_at;
+      if (!mongoTs) continue;
+      const watermark = watermarks.get(pageId);
+      if (!watermark || new Date(mongoTs).getTime() > new Date(watermark).getTime()) {
+        stalePageIds.add(pageId);
+        staleBookIds.add(bookId);
+      }
+    }
+
+    scannedBooks++;
+    if (scannedBooks % 100 === 0) {
+      console.log(`  scanned ${scannedBooks}/${allBookIds.length} books — ${stalePageIds.size} stale pages found`);
+    }
+  }
+
+  if (stalePageIds.size === 0) {
+    console.log('No stale rows found. All caught up.');
+    await mongoClient.close();
+    process.exit(0);
+  }
+
+  console.log(`Found ${stalePageIds.size.toLocaleString()} stale pages across ${staleBookIds.size.toLocaleString()} books`);
+  globalThis.MISSING_PAGE_IDS = stalePageIds; // reuse the same per-page gate as --missing-only
+  pageQuery.book_id = { $in: [...staleBookIds] };
 } else if (!FULL_MODE) {
   const lastSync = await getLastSyncTime();
   if (lastSync) {
@@ -260,6 +335,7 @@ const cursor = db.collection('pages')
     'translation.data': 1,
     'translation.updated_at': 1,
     'ocr.updated_at': 1,
+    updated_at: 1, // fallback for the mongo_updated_at watermark when sub-doc timestamps are missing
     translation_summary: 1,
     translation_keywords: 1,
   })
@@ -276,10 +352,11 @@ let supabaseBackoff = 0;
 for await (const page of cursor) {
   if (LIMIT && processed >= LIMIT) break;
 
-  // In --missing-only mode, only embed pages that actually lack an embedding
-  // (the MongoDB query is scoped to candidate books, but most of their pages
-  // already have valid embeddings — skip those)
-  if (MISSING_ONLY && !globalThis.MISSING_PAGE_IDS.has(page.id)) {
+  // In --missing-only / --restale modes, only embed pages identified by the
+  // pre-scan (missing embedding, or Mongo newer than Supabase watermark).
+  // The MongoDB query is scoped to candidate books but most of their pages
+  // are fine — skip the ones not in the set.
+  if ((MISSING_ONLY || RESTALE) && !globalThis.MISSING_PAGE_IDS.has(page.id)) {
     skipped++;
     processed++;
     continue;
@@ -384,8 +461,8 @@ async function upsertToSupabase(rows) {
     // (pg doesn't support multi-row upsert with vector columns easily)
     for (const row of rows) {
       await client.query(
-        `INSERT INTO page_translations (page_id, book_id, page_number, translation, embedding, book_title, book_author, book_language, book_year, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        `INSERT INTO page_translations (page_id, book_id, page_number, translation, embedding, book_title, book_author, book_language, book_year, updated_at, embedding_model, mongo_updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
          ON CONFLICT (page_id) DO UPDATE SET
            book_id = EXCLUDED.book_id,
            page_number = EXCLUDED.page_number,
@@ -395,12 +472,15 @@ async function upsertToSupabase(rows) {
            book_author = EXCLUDED.book_author,
            book_language = EXCLUDED.book_language,
            book_year = EXCLUDED.book_year,
-           updated_at = EXCLUDED.updated_at`,
+           updated_at = EXCLUDED.updated_at,
+           embedding_model = EXCLUDED.embedding_model,
+           mongo_updated_at = EXCLUDED.mongo_updated_at`,
         [
           row.page_id, row.book_id, row.page_number,
           row.translation, row.embedding,
           row.book_title, row.book_author, row.book_language, row.book_year,
           row.updated_at,
+          row.embedding_model, row.mongo_updated_at,
         ]
       );
     }
@@ -422,18 +502,26 @@ async function processBatch(items) {
     const texts = items.map(i => i.text);
     const embeddings = await embedBatch(texts);
 
-    const rows = items.map((item, i) => ({
-      page_id: item.page.id,
-      book_id: item.page.book_id,
-      page_number: item.page.page_number,
-      translation: (item.hasTranslation ? item.text : '').slice(0, 50000),
-      embedding: JSON.stringify(embeddings[i]),
-      book_title: item.book.title,
-      book_author: item.book.author,
-      book_language: item.book.language,
-      book_year: item.book.year,
-      updated_at: item.page.translation?.updated_at || item.page.ocr?.updated_at || new Date(),
-    }));
+    const rows = items.map((item, i) => {
+      const mongoTs = item.page.translation?.updated_at || item.page.ocr?.updated_at || item.page.updated_at;
+      return {
+        page_id: item.page.id,
+        book_id: item.page.book_id,
+        page_number: item.page.page_number,
+        translation: (item.hasTranslation ? item.text : '').slice(0, 50000),
+        embedding: JSON.stringify(embeddings[i]),
+        book_title: item.book.title,
+        book_author: item.book.author,
+        book_language: item.book.language,
+        book_year: item.book.year,
+        updated_at: mongoTs || new Date(),
+        embedding_model: MODEL,
+        // Watermark of the Mongo source's freshness at embed time. The
+        // --restale mode compares this against current Mongo updated_at to
+        // detect drift (re-OCR / re-translation in Mongo without re-embed).
+        mongo_updated_at: mongoTs || null,
+      };
+    });
 
     // Upsert in small sub-batches to avoid overwhelming Supabase
     let batchErrors = 0;

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -232,7 +232,10 @@ function composeBookEmbeddingText(book, indexData) {
 async function upsertBookEmbedding(book, indexData) {
   if (!supabaseClient) return;
 
-  const geminiKey = API_KEYS[0];
+  // Prefer paid Tier 3 for content-bearing embeddings (no training opt-in);
+  // fall back to first available key. Cron explicitly exports TIER3 too —
+  // this is belt-and-suspenders for ad-hoc / single-book runs.
+  const geminiKey = process.env.GEMINI_API_KEY_TIER3 || API_KEYS[0];
   if (!geminiKey) return;
 
   const text = composeBookEmbeddingText(book, indexData);
@@ -273,6 +276,7 @@ async function upsertBookEmbedding(book, indexData) {
       language: book.language || null,
       summary_text: text,
       embedding: JSON.stringify(embedding),
+      embedding_model: EMBED_MODEL,
       metadata: {
         has_index: true,
         categories: book.categories || [],


### PR DESCRIPTION
## Summary

Two durability fixes for the five Supabase embedding stores. **One concern**: per-row provenance and freshness tracking. No retrieval or schema-shape changes elsewhere.

- **embedding_model column** on all 5 tables — records which model wrote each row so a future migration (when \`gemini-embedding-2-preview\` retires its preview suffix, etc.) is mechanical. Indexed.
- **mongo_updated_at watermark** on \`page_translations\` only — the table holds a denormalized snapshot of \`pages.translation.data\`; today there's no invalidation signal when Mongo updates the source page. The watermark stores the Mongo freshness timestamp at embed time. Indexed (NULLS FIRST for the backfill scan).
- **\`embed-gemini.mjs --restale\` mode** — scans for rows where the Mongo source has moved past the watermark, re-embeds them. Reuses the existing per-page gate from \`--missing-only\` (just populates the candidate set differently).
- **TIER3 key preference** for \`embed-gemini.mjs\` and \`enrich-worker.mjs\` Phase 6.5 — prefer \`GEMINI_API_KEY_TIER3\` (paid, no training opt-in) with fallback to default. Cron already exports TIER3 for both workers (\`crontab.production\`), so this is belt-and-suspenders for ad-hoc / single-book runs. Costs are trivial (~$5/month).

## Out of scope

- **\`gallery_text_embeddings\` has no active writer.** The cron's \`gallery-text\` phase has been failing silently since its backfill script was deleted in \`8ddb4612\` (\"Live canon stats\" commit). The column gets added to the table for consistency, but adding it to a writer-that-doesn't-exist is impossible. Worth a follow-up issue.
- **Tenant filtering** — PR C handles \`tenant_id\` denormalization + RPC updates.
- **Retrieval changes** — PR A handles hybrid search + rerank.

## Apply order (on review)

\`\`\`bash
psql \"\$SUPABASE_DB_URL\" -f scripts/migration/add-embedding-model-columns.sql
psql \"\$SUPABASE_DB_URL\" -f scripts/migration/add-page-translations-watermark.sql

set -a; source .env.production.local; set +a
node scripts/migration/backfill-page-translations-watermark.mjs --dry-run
node scripts/migration/backfill-page-translations-watermark.mjs --apply

# then deploy worker changes (cron auto-picks up; ad-hoc runs need the env var)
\`\`\`

## Verification

- \`npx tsc --noEmit\` — passes (pre-existing d3 errors in carbon-ledger blog unrelated)
- \`node -c\` on all modified .mjs — passes
- Migrations are idempotent (\`ADD COLUMN IF NOT EXISTS\`, \`CREATE INDEX IF NOT EXISTS\`)
- Backfill script has \`--dry-run\` default and resumable state file
- \`--restale\` mode tested mentally; not run end-to-end (requires the watermark backfill to complete first to find any drift). Will validate post-apply.

## Test plan

- [ ] Apply migrations to a staging DB or live (idempotent so safe to re-run)
- [ ] Run watermark backfill dry-run, confirm reasonable counts
- [ ] Run watermark backfill \`--apply\` (3.9M rows, batched per book)
- [ ] Run \`embed-gemini.mjs --book <id> --restale\` on a known-stale book, confirm re-embed + watermark update
- [ ] Confirm cron-scheduled \`embed-gemini.mjs --incremental\` and \`enrich-worker\` still write rows correctly (new columns populated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)