### PR TITLE
feat(bph): click-to-sort headers, default Author A–Z, labeled view toggle

### DIFF
--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -253,6 +253,12 @@ export async function GET(req: NextRequest) {
       case 'author':
         query = query.order('author', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
         break;
+      case 'author_desc':
+        query = query.order('author', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
+        break;
+      case 'title_desc':
+        query = query.order('title', { ascending: false });
+        break;
       case 'shelfmark':
         query = query.order('shelf_mark', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
         break;

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -119,13 +119,35 @@ function isAdvFilterApplied(key: string, value: string | boolean, lockDigitized:
 
 const PER_PAGE = 50;
 
-const SORT_OPTIONS = [
-  { value: 'title', label: 'Title A-Z' },
-  { value: 'author', label: 'Author A-Z' },
-  { value: 'year_asc', label: 'Year (oldest first)' },
-  { value: 'year_desc', label: 'Year (newest first)' },
-  { value: 'shelfmark', label: 'Shelfmark' },
-];
+/** Per-column sort cycling — first click sorts ascending, second click sorts
+    descending. Shelfmark only supports ascending (codes don't read meaningfully
+    in reverse). Used by the clickable column headers in the list view. */
+type SortColumn = 'author' | 'title' | 'year' | 'shelfmark';
+
+function nextSort(column: SortColumn, current: string): string {
+  if (column === 'shelfmark') return 'shelfmark';
+  if (column === 'year') return current === 'year_asc' ? 'year_desc' : 'year_asc';
+  const asc = column;
+  const desc = `${column}_desc`;
+  return current === asc ? desc : asc;
+}
+
+function arrowFor(column: SortColumn, current: string): 'asc' | 'desc' | null {
+  if (column === 'shelfmark') return current === 'shelfmark' ? 'asc' : null;
+  if (column === 'year') {
+    if (current === 'year_asc') return 'asc';
+    if (current === 'year_desc') return 'desc';
+    return null;
+  }
+  if (current === column) return 'asc';
+  if (current === `${column}_desc`) return 'desc';
+  return null;
+}
+
+function SortArrow({ direction }: { direction: 'asc' | 'desc' | null }) {
+  if (direction === null) return <span aria-hidden className="ml-1 text-muted/40">↕</span>;
+  return <span aria-hidden className="ml-1 text-accent-rust">{direction === 'asc' ? '↑' : '↓'}</span>;
+}
 
 const KEYWORD_OPTIONS = [
   { value: '', label: 'All subjects' },
@@ -210,7 +232,7 @@ export default function BphCatalogBrowser({
   const searchParams = useSearchParams();
 
   const initialQ = searchParams.get('cq') || '';
-  const initialSort = searchParams.get('csort') || 'title';
+  const initialSort = searchParams.get('csort') || 'author';
   const initialKeyword = searchParams.get('ckeyword') || '';
   const initialOffset = parseInt(searchParams.get('coffset') || '0') || 0;
   const initialAdv: AdvancedFilters = {
@@ -322,7 +344,7 @@ export default function BphCatalogBrowser({
       else params.delete(key);
     };
     setOrDel('cq', q);
-    setOrDel('csort', s !== 'title' ? s : '');
+    setOrDel('csort', s !== 'author' ? s : '');
     setOrDel('ckeyword', kw);
     setOrDel('coffset', off ? String(off) : '');
     setOrDel('cauthor', a.author);
@@ -455,16 +477,16 @@ export default function BphCatalogBrowser({
   };
 
   // When the parent supplies a results-header slot (the unified shell does
-  // this to host the list/grid view icons), the sort dropdown moves into
-  // that row so it sits next to the icons — matching the partner mockup
-  // (search row stays light filters; sort lives with the count + icons).
-  const sortLivesInHeader = resultsHeaderSlot !== undefined;
+  // this to host the list/grid view icons), the count + icons render in a
+  // second row below the filters; otherwise the count renders inline in the
+  // search row.
+  const hasHeaderSlot = resultsHeaderSlot !== undefined;
 
   return (
     <div>
       {/* Search / filter row — search input, subjects dropdown, optional
           parent-supplied toggle (e.g. Show all / Show digitised & translated),
-          Advanced. Sort moves to the results-header row when sortLivesInHeader. */}
+          Advanced. Sort is driven by clicking column headers in the table. */}
       <div className="flex flex-wrap items-center gap-3 mb-3">
         <div className="relative flex-1 min-w-[14rem] max-w-xl">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
@@ -497,18 +519,6 @@ export default function BphCatalogBrowser({
 
         {searchRowSlot}
 
-        {!sortLivesInHeader && (
-          <select
-            value={sort}
-            onChange={(e) => handleSortChange(e.target.value)}
-            className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
-          >
-            {SORT_OPTIONS.map(o => (
-              <option key={o.value} value={o.value}>{o.label}</option>
-            ))}
-          </select>
-        )}
-
         <button
           onClick={() => setShowAdvanced(s => !s)}
           className="inline-flex items-center gap-1.5 text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary hover:bg-warm transition-colors"
@@ -522,37 +532,25 @@ export default function BphCatalogBrowser({
           )}
         </button>
 
-        {!hideInlineCount && !sortLivesInHeader && (
+        {!hideInlineCount && !hasHeaderSlot && (
           <span className="text-sm text-muted ml-auto">
             {total.toLocaleString('en-US')} works
           </span>
         )}
       </div>
 
-      {/* Results-header row — counter on the left, sort + parent-supplied
-          view icons on the right. Only rendered when the parent passes a
-          slot (the unified shell does so for the BPH iframe). The count
-          renders here regardless of hideInlineCount — that prop only gates
-          the inline count in the search row above. */}
-      {sortLivesInHeader && (
+      {/* Results-header row — counter on the left, parent-supplied view
+          icons on the right. Only rendered when the parent passes a slot
+          (the unified shell does so for the BPH iframe). The count renders
+          here regardless of hideInlineCount — that prop only gates the
+          inline count in the search row above. */}
+      {hasHeaderSlot && (
         <div className="flex flex-wrap items-center gap-3 mb-4">
           <span className="text-sm text-muted">
             <span className="font-medium text-primary">{total.toLocaleString('en-US')}</span>
             {catalogTotal && catalogTotal > 0 ? ` of ${catalogTotal.toLocaleString('en-US')} works` : ' works'}
           </span>
           <div className="flex items-center gap-3 ml-auto">
-            <label className="inline-flex items-center gap-2 text-sm text-muted">
-              <span>Sort by</span>
-              <select
-                value={sort}
-                onChange={(e) => handleSortChange(e.target.value)}
-                className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
-              >
-                {SORT_OPTIONS.map(o => (
-                  <option key={o.value} value={o.value}>{o.label}</option>
-                ))}
-              </select>
-            </label>
             {resultsHeaderSlot}
           </div>
         </div>
@@ -643,11 +641,43 @@ export default function BphCatalogBrowser({
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-border-light bg-warm">
-                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden sm:table-cell">Author</th>
-                <th className="text-left px-3 py-2.5 font-medium text-secondary">Title</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden sm:table-cell">
+                  <button
+                    type="button"
+                    onClick={() => handleSortChange(nextSort('author', sort))}
+                    className="inline-flex items-center hover:text-primary transition-colors"
+                  >
+                    Author<SortArrow direction={arrowFor('author', sort)} />
+                  </button>
+                </th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary">
+                  <button
+                    type="button"
+                    onClick={() => handleSortChange(nextSort('title', sort))}
+                    className="inline-flex items-center hover:text-primary transition-colors"
+                  >
+                    Title<SortArrow direction={arrowFor('title', sort)} />
+                  </button>
+                </th>
                 <th className="text-left px-3 py-2.5 font-medium text-secondary hidden md:table-cell">Place</th>
-                <th className="text-left px-3 py-2.5 font-medium text-secondary w-16">Year</th>
-                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden md:table-cell">Shelfmark</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary w-16">
+                  <button
+                    type="button"
+                    onClick={() => handleSortChange(nextSort('year', sort))}
+                    className="inline-flex items-center hover:text-primary transition-colors"
+                  >
+                    Year<SortArrow direction={arrowFor('year', sort)} />
+                  </button>
+                </th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden md:table-cell">
+                  <button
+                    type="button"
+                    onClick={() => handleSortChange(nextSort('shelfmark', sort))}
+                    className="inline-flex items-center hover:text-primary transition-colors"
+                  >
+                    Shelfmark<SortArrow direction={arrowFor('shelfmark', sort)} />
+                  </button>
+                </th>
                 <th className="text-left px-3 py-2.5 font-medium text-secondary hidden lg:table-cell">Subject</th>
               </tr>
             </thead>

--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -145,27 +145,32 @@ function ViewIcons({
   listHref: string;
   gridHref: string;
 }) {
+  // Labeled segmented control rather than icon-only buttons. Icon-only
+  // toggles read as decoration to readers who aren't already looking for
+  // a view switcher, so we pair each icon with its label.
   const base =
-    'inline-flex items-center justify-center w-9 h-9 transition-colors border border-border-light';
+    'inline-flex items-center gap-1.5 px-3 h-9 text-sm transition-colors border border-border-light';
   const active = 'bg-primary text-white border-primary';
   const inactive = 'bg-white text-muted hover:text-primary hover:bg-warm';
   return (
-    <div className="inline-flex">
+    <div className="inline-flex" role="group" aria-label="Display mode">
       <Link
         href={listHref}
-        title="List view"
         aria-label="List view"
+        aria-current={display === 'list' ? 'page' : undefined}
         className={`${base} rounded-l-md ${display === 'list' ? active : inactive}`}
       >
         <List className="w-4 h-4" />
+        <span>List</span>
       </Link>
       <Link
         href={gridHref}
-        title="Grid view"
-        aria-label="Grid view"
+        aria-label="Covers view"
+        aria-current={display === 'grid' ? 'page' : undefined}
         className={`${base} rounded-r-md -ml-px ${display === 'grid' ? active : inactive}`}
       >
         <LayoutGrid className="w-4 h-4" />
+        <span>Covers</span>
       </Link>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Click-to-sort column headers** with up/down arrow indicators (Author · Title · Year · Shelfmark). Click once for ascending, again for descending. Replaces the sort dropdown entirely — same pattern `TenantCatalogueTable` already uses for Bhutan/EAP. Shelfmark stays ascending-only because reversing organizational codes isn't useful.
- **Default sort changes from Title A–Z to Author A–Z** to match the leading column. Existing `?csort=…` URLs continue to work; only the implicit default flips.
- **Server adds `title_desc` and `author_desc`** to the sort switch in `/api/catalog/bph` so the new descending variants are valid. `year_asc` / `year_desc` / `shelfmark` are unchanged.
- **View toggle becomes a labeled segmented control** (List / Covers) instead of two unlabeled icons. Icon-only toggles read as decoration; the label makes the switcher discoverable. Adds `aria-current` so screen readers announce which view is active.

Builds on https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/pull/2125 (column reorder). Targets the same surface — https://bph.sourcelibrary.org/.

## Out of scope
- Active-filter chips above results (e.g. "Mysticism ×", "Digitised only ×"). Separate concern, follow-up PR.
- The `TenantCatalogueTable` for Bhutan/EAP — already uses clickable headers and isn't touched here.
- Grid-view title/author hierarchy — covers, then title-then-author below. The grid uses different visual logic than the list and is fine as-is.

## Test plan
- [ ] Preview deploy: open bph.sourcelibrary.org library page. Default sort should be Author A–Z with an `↑` arrow next to the Author header.
- [ ] Click Author header → arrow flips to `↓`, rows re-sort Z–A. Click again → back to A–Z.
- [ ] Click Title → arrow lights on Title, Author arrow clears. Click again → Z–A. Same for Year (oldest first / newest first) and Shelfmark (ascending only).
- [ ] Click the **Covers** button in the view toggle — should switch to grid view. Label and icon both visible. Click **List** to return.
- [ ] Old URL `?csort=title` still loads with Title selected as the active sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)