### PR TITLE
seo: drop unrecognized interactionStatistic from author schema

### DIFF
--- a/src/components/seo/AuthorSchema.tsx
+++ b/src/components/seo/AuthorSchema.tsx
@@ -82,11 +82,6 @@ export default function AuthorSchema({
     name: `${authorName} — Source Library`,
     ...(description && { description }),
     mainEntity: { '@id': `${pageUrl}#person` },
-    ...(workCount > 0 && { interactionStatistic: {
-      '@type': 'InteractionCounter',
-      interactionType: 'https://schema.org/ViewAction',
-      userInteractionCount: workCount,
-    } }),
   };
 
   const breadcrumbList = {


### PR DESCRIPTION
Clears the GSC warning 'Unrecognized field interactionStatistic' on /author/* pages. The field was on a ProfilePage where Google's parser rejects it, and was semantically misused anyway (workCount populated as a view count).