### PR TITLE
fix(bph): preserve search params across list/covers and show-all/digitised toggles

### DIFF
--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -14,7 +14,7 @@
  * for SL-backed books.
  */
 
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { LayoutGrid, List } from 'lucide-react';
 import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
 import { useEmbedHref } from '@/lib/EmbedContext';
@@ -37,9 +37,24 @@ interface Props {
   tenantSlug?: string;
 }
 
-/** Build a `?view=…&display=…` URL preserving the other dimension's value. */
-function makeHref(basePath: string, view: 'catalog' | 'books', display: CatalogueDisplay) {
-  return `${basePath}?view=${view}&display=${display}`;
+/** Build a `?view=…&display=…` URL while carrying every other param from the
+    *current* `window.location.search` through. `BphCatalogBrowser` owns its
+    own state — search (`cq`), sort (`csort`), keyword, advanced filters,
+    offset — and persists it via `window.history.replaceState` to `c*`-prefixed
+    params. That replaceState path bypasses Next's router, so `useSearchParams`
+    in this parent stays at the *initial* URL the user landed on. Reading
+    `window.location.search` at click time is the only way to capture the live
+    in-flight search.
+
+    SSR-safe: returns a no-param URL when `window` is unavailable, so a click
+    handler that runs in the browser always wins over the render-time href. */
+function makeHref(basePath: string, view: 'catalog' | 'books', display: CatalogueDisplay): string {
+  const live = typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search)
+    : new URLSearchParams();
+  live.set('view', view);
+  live.set('display', display);
+  return `${basePath}?${live.toString()}`;
 }
 
 export default function BphUnifiedCatalogue({
@@ -51,6 +66,7 @@ export default function BphUnifiedCatalogue({
   tenantSlug,
 }: Props) {
   const embedHref = useEmbedHref();
+  const router = useRouter();
 
   // "Show all" forces list display: grid only renders books with thumbnails
   // (the digitised subset), so preserving grid here would make the toggle a
@@ -61,16 +77,46 @@ export default function BphUnifiedCatalogue({
   // digitised subset, so clicking grid from any state must land on
   // view=books. Forcing books here keeps the chrome's count consistent with
   // the visible covers.
+  //
+  // Hrefs are built fresh at render and at click time. Render-time hrefs
+  // power middle-click and `view-source` correctly when the user lands on
+  // a URL with `?cq=…` etc. baked in. Click-time hrefs (computed in
+  // `navigateToggle`) cover the case where BphCatalogBrowser has updated
+  // `window.location.search` via replaceState since the last render — that
+  // mutation is invisible to Next's `useSearchParams`, so we read it
+  // directly from `window.location.search` at click.
   const allHref = embedHref(makeHref(basePath, 'catalog', 'list'));
   const digitizedHref = embedHref(makeHref(basePath, 'books', display));
   const listHref = embedHref(makeHref(basePath, mode === 'digitized' ? 'books' : 'catalog', 'list'));
   const gridHref = embedHref(makeHref(basePath, 'books', 'grid'));
 
+  const navigateToggle = (e: React.MouseEvent<HTMLAnchorElement>, view: 'catalog' | 'books', newDisplay: CatalogueDisplay) => {
+    // Only intercept primary-button, unmodified clicks. Let middle-click,
+    // cmd/ctrl-click, shift-click etc. follow the href so "open in new tab"
+    // and similar still work — they use the render-time href, which is
+    // already correct for the initial URL state.
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    e.preventDefault();
+    router.push(embedHref(makeHref(basePath, view, newDisplay)));
+  };
+
   const toggleNode = (
-    <SegmentedToggle mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
+    <SegmentedToggle
+      mode={mode}
+      display={display}
+      allHref={allHref}
+      digitizedHref={digitizedHref}
+      onNavigate={navigateToggle}
+    />
   );
   const viewIconsNode = (
-    <ViewIcons display={display} listHref={listHref} gridHref={gridHref} />
+    <ViewIcons
+      display={display}
+      mode={mode}
+      listHref={listHref}
+      gridHref={gridHref}
+      onNavigate={navigateToggle}
+    />
   );
 
   // Grid view shows only the digitised subset (covers only exist for
@@ -110,12 +156,16 @@ export default function BphUnifiedCatalogue({
 
 function SegmentedToggle({
   mode,
+  display,
   allHref,
   digitizedHref,
+  onNavigate,
 }: {
   mode: CatalogueMode;
+  display: CatalogueDisplay;
   allHref: string;
   digitizedHref: string;
+  onNavigate: (e: React.MouseEvent<HTMLAnchorElement>, view: 'catalog' | 'books', newDisplay: CatalogueDisplay) => void;
 }) {
   const base =
     'px-4 py-2 text-sm font-medium transition-colors';
@@ -123,27 +173,36 @@ function SegmentedToggle({
   const inactive = 'bg-white text-secondary hover:bg-warm';
   return (
     <div className="inline-flex border border-border-light rounded-md overflow-hidden">
-      <Link href={allHref} className={`${base} ${mode === 'all' ? active : inactive}`}>
+      <a
+        href={allHref}
+        onClick={(e) => onNavigate(e, 'catalog', 'list')}
+        className={`${base} ${mode === 'all' ? active : inactive}`}
+      >
         Show all
-      </Link>
-      <Link
+      </a>
+      <a
         href={digitizedHref}
+        onClick={(e) => onNavigate(e, 'books', display)}
         className={`${base} -ml-px ${mode === 'digitized' ? active : inactive}`}
       >
         Show digitised &amp; translated
-      </Link>
+      </a>
     </div>
   );
 }
 
 function ViewIcons({
   display,
+  mode,
   listHref,
   gridHref,
+  onNavigate,
 }: {
   display: CatalogueDisplay;
+  mode: CatalogueMode;
   listHref: string;
   gridHref: string;
+  onNavigate: (e: React.MouseEvent<HTMLAnchorElement>, view: 'catalog' | 'books', newDisplay: CatalogueDisplay) => void;
 }) {
   // Labeled segmented control rather than icon-only buttons. Icon-only
   // toggles read as decoration to readers who aren't already looking for
@@ -152,26 +211,31 @@ function ViewIcons({
     'inline-flex items-center gap-1.5 px-3 h-9 text-sm transition-colors border border-border-light';
   const active = 'bg-primary text-white border-primary';
   const inactive = 'bg-white text-muted hover:text-primary hover:bg-warm';
+  // Match what `listHref` / `gridHref` resolve to in the parent so click-time
+  // navigation lands on the same view+display combination.
+  const listView = mode === 'digitized' ? 'books' : 'catalog';
   return (
     <div className="inline-flex" role="group" aria-label="Display mode">
-      <Link
+      <a
         href={listHref}
+        onClick={(e) => onNavigate(e, listView, 'list')}
         aria-label="List view"
         aria-current={display === 'list' ? 'page' : undefined}
         className={`${base} rounded-l-md ${display === 'list' ? active : inactive}`}
       >
         <List className="w-4 h-4" />
         <span>List</span>
-      </Link>
-      <Link
+      </a>
+      <a
         href={gridHref}
+        onClick={(e) => onNavigate(e, 'books', 'grid')}
         aria-label="Covers view"
         aria-current={display === 'grid' ? 'page' : undefined}
         className={`${base} rounded-r-md -ml-px ${display === 'grid' ? active : inactive}`}
       >
         <LayoutGrid className="w-4 h-4" />
         <span>Covers</span>
-      </Link>
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Bugs #2 and #3 from the 2026-05-28 catalog browser pass (see `.claude/handoffs/2026-05-28-bph-catalog-browser-bugs.md`):

> If, after a search, I toggle the results from list to covers, the results are gone. The same goes for show all and digitised.

Both top-of-page toggles in `BphUnifiedCatalogue` (the **Show all / Show digitised & translated** segmented control and the **List / Covers** view picker) navigated to `?view=…&display=…` URLs built from a fixed template. Every other query param — search (`cq`), sort (`csort`), keyword (`ckeyword`), offset (`coffset`), and the advanced-filter cluster (`cauthor`, `ctitle`, `cplace`, `cprinter`, `cpublisher`, `cshelf`, `clang`, `cyfrom`, `cyto`, `cdig`, `cft`) — was dropped on toggle.

## Why the obvious fix didn't work
The intuitive fix is to read `useSearchParams()` in the parent and merge. But `BphCatalogBrowser` persists its search/sort/filter state via `window.history.replaceState`, **not** Next's router. That's deliberate (preserves the user-visible path on the BPH subdomain, see the comment block in `BphCatalogBrowser.tsx`'s `updateUrl`) but it means `useSearchParams()` in the parent stays frozen at the *initial* URL the user landed on. A `useMemo` over `useSearchParams()` reads stale values.

## What this PR does
- `makeHref` now reads `window.location.search` to build the toggle URL, so the live in-flight state is captured.
- Toggle links use `<a>` with an `onClick` that calls `router.push(makeHref(...))` for primary-button, unmodified clicks. Render-time hrefs still cover middle-click, cmd/ctrl-click, shift-click, and view-source — those paths use the initial-URL href (correct for that flow).
- SSR-safe: `makeHref` guards `typeof window !== 'undefined'`.

## Out of scope
- Bug #1 (sorting click-headers reported as not working) — this PR will probably unmask whether that's a real defect or was a downstream symptom of the toggle wiping `csort`. Will follow up after observation.
- The handoff at `.claude/handoffs/2026-05-28-bph-catalog-editor-browser-pass.md` (catalog editor revisions blocker + email leak) — different surface, separate PR.

## Test plan
- [ ] Preview deploy: bph.sourcelibrary.org/catalog (or wherever the unified catalogue renders).
- [ ] Type "Seleniana" — confirm count drops to ~3 and rows match. Click **Covers** — search persists, covers grid filters to those 3 (or shows the digitised subset of them).
- [ ] Click back to **List** — search still active.
- [ ] Click **Show all** ↔ **Show digitised & translated** with a search active — search persists.
- [ ] Click a sortable column header (Title) with a search active — sort applies, search still active.
- [ ] Middle-click a toggle from a URL with `?cq=foo` in the address bar (rare but valid path) — opens a new tab on the same `view+display+cq` combo (uses render-time href).

🤖 Generated with [Claude Code](https://claude.com/claude-code)