### PR TITLE
fix(bph): title_desc nulls + fetch race + covers digitised caption

### DIFF
--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -257,7 +257,10 @@ export async function GET(req: NextRequest) {
         query = query.order('author', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
         break;
       case 'title_desc':
-        query = query.order('title', { ascending: false });
+        // nullsFirst:false matches every other sort — Supabase otherwise puts
+        // null titles ahead of real ones for descending sorts, which renders
+        // five "None" rows at the top of an unfiltered desc listing.
+        query = query.order('title', { ascending: false, nullsFirst: false });
         break;
       case 'shelfmark':
         query = query.order('shelf_mark', { ascending: true, nullsFirst: false }).order('title', { ascending: true });

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -321,16 +321,27 @@ export default function BphCatalogBrowser({
       const params = buildParams(q, s, kw, off, a);
       const res = await fetch(`/api/catalog/bph?${params}`, { signal: controller.signal });
       const data = await res.json();
+      // Drop the result if a newer fetch superseded us. `AbortController.abort()`
+      // only rejects the fetch promise itself; if our `await fetch()` already
+      // resolved before the next call fired abort, `res.json()` keeps streaming
+      // the body and we'd `setWorks` with a stale page after the latest result
+      // already landed. Source of the "3 of 29,876 — but 5 rows shown" first-
+      // paint race when the user types fast enough to fire several debounced
+      // searches in a row.
+      if (abortRef.current !== controller) return;
       setWorks(data.works || []);
       setTotal(data.total || 0);
       onTotalChange?.(data.total || 0, isFiltered);
     } catch (err) {
       if ((err as Error).name === 'AbortError') return; // superseded by a newer query
+      if (abortRef.current !== controller) return;
       setWorks([]);
       setTotal(0);
       onTotalChange?.(0, isFiltered);
     } finally {
-      if (!controller.signal.aborted) setLoading(false);
+      if (abortRef.current === controller && !controller.signal.aborted) {
+        setLoading(false);
+      }
     }
   }, [buildParams, onTotalChange, lockDigitized]);
 
@@ -553,6 +564,11 @@ export default function BphCatalogBrowser({
           <span className="text-sm text-muted">
             <span className="font-medium text-primary">{total.toLocaleString('en-US')}</span>
             {catalogTotal && catalogTotal > 0 ? ` of ${catalogTotal.toLocaleString('en-US')} works` : ' works'}
+            {display === 'grid' && (
+              <span className="ml-2 text-xs">
+                · Covers view shows only digitised works
+              </span>
+            )}
           </span>
           <div className="flex items-center gap-3 ml-auto">
             {resultsHeaderSlot}


### PR DESCRIPTION
## Summary
Three findings from the 2026-05-28 post-#2131 catalog browser test:

### 1. `title_desc` returned 5 NULL-titled rows first when no query was set
Supabase's default for descending orders is `nullsFirst: true`. Every other `_desc` case already passed `nullsFirst: false`; title_desc didn't, since it was added in #2127 without that arg. With a search query the bug was masked because the title-prefix relevance bump pushed real matches up before the order mattered — but on the unfiltered list, the first paint of a "Z–A" sort showed five `None` rows. One-line fix.

### 2. First-paint race in `fetchWorks`
User-visible as the report's "3 of 29,876 works — but 5 rows shown" with two rows leaking from a prior search. `AbortController.abort()` only rejects the fetch promise itself; if `await fetch()` already resolved before the next call fired abort, `res.json()` keeps streaming the body and `setWorks` runs with a stale page *after* the latest result already landed. Fix: after the body parses, re-check `abortRef.current === controller` and drop the result if a newer fetch superseded us. Guard the catch + finally branches the same way so a stale rejection doesn't reset state either.

### 3. Covers view silently auto-enables the digitised filter
The grid mode is locked to `digitized: 'sl'` because covers don't exist for non-digitised works (deliberate, see comment in `BphUnifiedCatalogue.tsx`'s `effectiveLockDigitized`). But the user sees their count drop from 3 to 2 on clicking Covers with no explanation. Adds a small inline caption beside the count when `display === 'grid'`: *"Covers view shows only digitised works."* Doesn't change behavior — just stops it from being silent.

## Out of scope
- The user's step-5 sub-finding that the title-prefix relevance bump masks desc sort when *all* matches share the same title prefix (three rows starting with "Seleniana"). That's an interaction between two correct behaviors — leaving it alone for now; can revisit if it bites anyone in practice.
- Decoupling covers from digitised entirely (showing placeholder covers for non-digitised) — bigger change, separate decision.

## Test plan
- [ ] Preview: hit `/api/catalog/bph?sort=title_desc&limit=5` with no `q` — should return 5 real titles, not 5 `null`s.
- [ ] Type a query fast enough to fire 3+ debounced searches in succession; final state should match the final query (no stale rows from intermediate searches).
- [ ] Click Covers from a list view with a search active — caption *"Covers view shows only digitised works"* appears beside the count.
- [ ] Re-run the full 5-step plan from the post-#2131 test on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)