### PR TITLE
copy(bph): relabel "Canonical" → "Standard name" in catalog editor + book record

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/GenericCatalogEntry.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/GenericCatalogEntry.tsx
@@ -268,7 +268,7 @@ export default async function GenericCatalogEntry({
 
                 <dl className="space-y-1.5 text-sm mb-4">
                   {canonicalAuthor && canonicalAuthor !== row.author && (
-                    <Field label="Canonical author" value={canonicalAuthor} />
+                    <Field label="Standard name" value={canonicalAuthor} />
                   )}
                   {slBook.published && slBook.published !== String(row.year || '') && (
                     <Field label="Published" value={slBook.published} />

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -456,7 +456,7 @@ export default async function CatalogEntryPage({ params }: Props) {
 
                 <dl className="space-y-1.5 text-sm mb-4">
                   {canonicalAuthor && canonicalAuthor !== work.author && (
-                    <Field label="Canonical author" value={canonicalAuthor} />
+                    <Field label="Standard name" value={canonicalAuthor} />
                   )}
                   {slBook.published && slBook.published !== String(work.year || '') && (
                     <Field label="Published" value={slBook.published} />
@@ -585,11 +585,11 @@ export default async function CatalogEntryPage({ params }: Props) {
           <Field label="Editor / translator" value={work.editor} />
           <Field label="Editor (as on title page)" value={work.variant_editor} />
           {/* Author authority (#1921 P3) — only render when an identifier is
-              actually linked. The label uses "Canonical (VIAF)" to mirror the
-              terminology in the editor's picker, so cataloguers see the same
-              wording on read and write. */}
+              actually linked. The label uses "Standard name (VIAF)" to mirror
+              the terminology in the editor's picker, so cataloguers see the
+              same wording on read and write. */}
           {(work.author_canonical_name || work.author_entity_id || work.author_wikidata_qid) && (
-            <FieldRaw label="Canonical (VIAF)">
+            <FieldRaw label="Standard name (VIAF)">
               <span className="flex flex-wrap items-baseline gap-x-2 text-primary">
                 {work.author_canonical_name && <span>{work.author_canonical_name}</span>}
                 {work.author_entity_id && (

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -247,7 +247,7 @@ export default function BibliographicInfo({
                   )}
                   {hasCanonical && (
                     <div className="flex gap-2">
-                      <span className="text-stone-500 w-24 flex-shrink-0">Canonical:</span>
+                      <span className="text-stone-500 w-24 flex-shrink-0">Standard name:</span>
                       <span className="text-stone-200 flex flex-wrap items-baseline gap-x-2">
                         {canonicalName || `VIAF ${viafId}`}
                         {viafId && (

--- a/src/components/book/BphCatalogueRecord.tsx
+++ b/src/components/book/BphCatalogueRecord.tsx
@@ -156,7 +156,7 @@ export default async function BphCatalogueRecord({ ubn }: { ubn: string }) {
             <Field label="Editor / translator" value={work.editor} />
             <Field label="Editor (as on title page)" value={work.variant_editor} />
             {(work.author_canonical_name || work.author_viaf_id || work.author_wikidata_qid) && (
-              <FieldRaw label="Canonical (VIAF)">
+              <FieldRaw label="Standard name (VIAF)">
                 <span className="flex flex-wrap items-baseline gap-x-2">
                   {work.author_canonical_name && (
                     <span>{work.author_canonical_name}</span>

--- a/src/components/catalog/AuthorAuthorityPicker.tsx
+++ b/src/components/catalog/AuthorAuthorityPicker.tsx
@@ -16,9 +16,11 @@ import type { AuthorAuthorityMatch, AuthorAuthorityResult } from '@/lib/author-a
  *      and stores it on `author_entity_id` (Atlas) or `bph_works.author_entity_id`
  *      (Supabase).
  *
- * If a canonical id is already set, the picker shows "Canonical: <name>"
+ * If an identity is already set, the picker shows "Standard name: <name>"
  * with a "Change" button instead of the search box — the common case is a
- * stable identity that never needs lookup.
+ * stable identity that never needs lookup. (The internal storage columns
+ * are still named `author_canonical_name` / `author_entity_id` etc; the
+ * relabel was a 2026-05-28 UX pass to use plainer terminology.)
  *
  * Issue #1921 (P3).
  */
@@ -155,7 +157,7 @@ export default function AuthorAuthorityPicker({
   if (!open && hasCanonical) {
     return (
       <div className="text-xs text-stone-600 dark:text-stone-400 flex items-center gap-2 flex-wrap">
-        <span className="font-medium">Canonical:</span>
+        <span className="font-medium">Standard name:</span>
         <span>{current?.canonical_name || '(linked)'}</span>
         {current?.viaf_id && (
           <a
@@ -191,7 +193,7 @@ export default function AuthorAuthorityPicker({
             type="button"
             onClick={onClear}
             className="text-stone-500 hover:text-accent-rust underline"
-            title="Clear canonical link"
+            title="Clear standard name link"
           >
             Clear
           </button>
@@ -204,7 +206,7 @@ export default function AuthorAuthorityPicker({
     <div className="mt-1 p-2 border border-stone-200 dark:border-stone-700 rounded-md bg-stone-50/50 dark:bg-stone-900/40">
       <div className="flex items-center justify-between mb-1.5">
         <label className="text-[11px] uppercase tracking-wide text-stone-500">
-          Look up canonical author (VIAF)
+          Look up standard name (VIAF)
         </label>
         {hasCanonical && (
           <button

--- a/src/components/catalog/BphWorkEditForm.tsx
+++ b/src/components/catalog/BphWorkEditForm.tsx
@@ -54,7 +54,7 @@ const SECTIONS: Array<{
   {
     title: 'Authorship',
     fields: [
-      { name: 'author', label: 'Author (canonical)' },
+      { name: 'author', label: 'Author (standard name)' },
       { name: 'variant_author', label: 'Author (as on title page)' },
       { name: 'pseudonym', label: 'Pseudonym' },
       { name: 'editor', label: 'Editor / translator' },
@@ -336,7 +336,7 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
             {section.title === 'Authorship' && (
               <div className="pb-2 border-b border-stone-100">
                 <label className="flex items-baseline gap-2 mb-1">
-                  <span className="text-xs text-muted">Canonical author (VIAF)</span>
+                  <span className="text-xs text-muted">Standard name (VIAF)</span>
                   {(changedFields.includes('author_entity_id') ||
                     changedFields.includes('author_canonical_name') ||
                     changedFields.includes('author_wikidata_qid') ||


### PR DESCRIPTION
## Summary
Per Paul — the authority-linking surface used "Canonical" / "Canonical (VIAF)" which read as library-science jargon. Relabelling to **"Standard name"** / **"Standard name (VIAF)"** across every visible surface. Internal schema (column names like `author_canonical_name`, helper variables like `canonicalAuthor`, booleans like `hasCanonical`) is untouched — those aren't user-visible.

## Visible label swaps

| Location | Before | After |
|---|---|---|
| `BphWorkEditForm.tsx` field | Author (canonical) | Author (standard name) |
| `BphWorkEditForm.tsx` picker header | Canonical author (VIAF) | Standard name (VIAF) |
| `AuthorAuthorityPicker.tsx` compact view | Canonical: | Standard name: |
| `AuthorAuthorityPicker.tsx` lookup header | Look up canonical author (VIAF) | Look up standard name (VIAF) |
| `AuthorAuthorityPicker.tsx` clear tooltip | Clear canonical link | Clear standard name link |
| Catalog read-only page (embed/[tenant]/catalog/[ubn]/page.tsx) | Canonical author | Standard name |
| Catalog read-only page authority block | Canonical (VIAF) | Standard name (VIAF) |
| GenericCatalogEntry (non-BPH tenants) | Canonical author | Standard name |
| BphCatalogueRecord (book page) | Canonical (VIAF) | Standard name (VIAF) |
| BibliographicInfo (book page header) | Canonical: | Standard name: |

## Test plan
- [ ] Preview: BPH catalog editor → edit a work → Authorship section reads "Standard name (VIAF)" with the picker beneath.
- [ ] Save a VIAF selection on a fresh work — read-only view renders "Standard name (VIAF): …".
- [ ] Same author on the public book page (Embassy of Free Mind or BPH digitised) shows "Standard name:" in the bibliographic header.
- [ ] Non-BPH tenant catalog (Bhutan/EAP) also shows "Standard name" if a canonical record exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)