### PR TITLE
ilp: "author held" as a third state in the works browser

### DIFF
--- a/scripts/backfill-catalog-author-held.mjs
+++ b/scripts/backfill-catalog-author-held.mjs
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+/**
+ * Backfill author_held_count + author_held_sample_slug on index_catalog_entries.
+ *
+ * For each distinct (author, author_normalized) identity in the catalog:
+ *   1. Surname-search SL books in Mongo (uses the same regex pattern as
+ *      backfill-catalog-ustc-sl-links.mjs so behaviour is consistent).
+ *   2. Gemini-verify the identity: is the Index entry author the same person
+ *      as the SL books? Catches surname collisions (Stephanus the Henri vs
+ *      Stephanus the Robert; Cellarius the Reformer vs Cellarius the
+ *      astronomer; Faber the Lefèvre vs Faber the Marburg).
+ *   3. If verified, count visible+ocr'd SL books by that author and write
+ *      the count + sample_slug to every entry with that identity.
+ *   4. If NOT verified (different people), still write count=0 explicitly so
+ *      we don't recompute on every run.
+ *
+ * Cache is per (author_normalized → author-snippet). Cost: ~one Gemini call
+ * per distinct identity (a few thousand at most) at $0.0001/call.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/backfill-catalog-author-held.mjs            # dry-run
+ *   node scripts/backfill-catalog-author-held.mjs --apply
+ *   node scripts/backfill-catalog-author-held.mjs --apply --limit 100   # smoke test
+ *
+ * Idempotent. Re-runnable. Skips entries that already have author_held_count
+ * unless --force.
+ */
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const FORCE = process.argv.includes('--force');
+const limitArg = process.argv.indexOf('--limit');
+const LIMIT = limitArg > -1 ? Number(process.argv[limitArg + 1]) : 0;
+const concArg = process.argv.indexOf('--concurrency');
+const CONCURRENCY = Math.max(1, concArg > -1 ? Number(process.argv[concArg + 1]) : 8);
+
+const SUPA_URL = process.env.SUPABASE_URL;
+const SUPA_KEY = APPLY ? process.env.SUPABASE_SERVICE_ROLE_KEY : process.env.SUPABASE_ANON_KEY;
+if (!SUPA_URL || !SUPA_KEY) { console.error('SUPABASE_* missing'); process.exit(1); }
+const H = { apikey: SUPA_KEY, Authorization: `Bearer ${SUPA_KEY}`, 'Content-Type': 'application/json' };
+
+const GEMINI_KEY = process.env.GEMINI_API_KEY;
+if (!GEMINI_KEY) { console.error('GEMINI_API_KEY missing'); process.exit(1); }
+const VERIFY_MODEL = 'gemini-3.1-flash-lite';
+
+async function supa(method, path, body) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const opts = { method, headers: H };
+      if (body !== undefined) opts.body = JSON.stringify(body);
+      const r = await fetch(`${SUPA_URL}/rest/v1/${path}`, opts);
+      if (!r.ok) {
+        const text = (await r.text()).slice(0, 400);
+        if (r.status >= 500 && attempt < 4) { await new Promise(r => setTimeout(r, 1000 * 2 ** attempt)); continue; }
+        throw new Error(`${method} ${path} → ${r.status}: ${text}`);
+      }
+      return r.status === 204 ? null : r.json();
+    } catch (e) {
+      if (attempt === 4 || !/ETIMEDOUT|ECONNRESET|fetch failed/i.test(String(e))) throw e;
+      await new Promise(r => setTimeout(r, 2000 * 2 ** attempt));
+    }
+  }
+}
+
+// ─── Gemini identity verifier ────────────────────────────────────────────
+
+const VERIFY_PROMPT = `You decide whether a list of Source Library books are by THE SAME PERSON as an entry on a historical Index of prohibited books.
+
+INPUT:
+  - Index entry: an author name as it appears in a 16th-17th c. printed Index, plus a sample title and condemnation year for disambiguation.
+  - Candidate SL books: title, author string, year — a few examples from the surname-matched set.
+
+Decide whether the SL books overall represent the same person as the Index entry. Beware:
+  - Latin name inversions ("Iordanus Brunus" ↔ "Bruno, Giordano") — same person
+  - Latinizations / toponyms ("Erasmus Roterodamus" ↔ "Desiderius Erasmus") — same person
+  - Long-s OCR errors ("Brandeburgenfis" → "Brandeburgensis") — same person
+  - Family-name collisions: Stephanus = Estienne family (Henri ≠ Robert ≠ Charles ≠ Paul are DIFFERENT people)
+  - Surname collisions across centuries (Cellarius 1564 Reformer ≠ Cellarius 1660 astronomer)
+  - "Faber" — could be Lefèvre d'Étaples, or Johann Faber of Heilbronn, or others — DIFFERENT people
+
+If the SL books represent a MIX of people (e.g. multiple Estiennes), respond same_person:false with reasoning.
+
+Output JSON only:
+{ "same_person": true | false, "confidence": "high"|"medium"|"low", "reasoning": "short" }`;
+
+const verifyCache = new Map();
+let verifyCalls = 0;
+let verifyCost = 0;
+
+async function geminiVerify(entry, books) {
+  const cacheKey = JSON.stringify({
+    a: entry.author, n: entry.author_normalized,
+    bk: books.slice(0, 3).map(b => [b.author, b.title?.slice(0, 40), b.year]),
+  });
+  if (verifyCache.has(cacheKey)) return verifyCache.get(cacheKey);
+
+  const userContent = `Index entry:
+  - Author (as printed): ${entry.author}
+  - Sample title: ${(entry.title || '').slice(0, 80)}
+  - Condemnation year: ${entry.condemnation_year || 'unknown'}
+
+Candidate SL books (sample of ${books.length}):
+${books.slice(0, 5).map(b => `  - "${(b.title || '').slice(0, 70)}" — ${b.author || '?'} (${b.year || '?'})`).join('\n')}`;
+
+  const body = {
+    contents: [{ role: 'user', parts: [{ text: userContent }] }],
+    systemInstruction: { parts: [{ text: VERIFY_PROMPT }] },
+    generationConfig: { responseMimeType: 'application/json', temperature: 0, maxOutputTokens: 256 },
+  };
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${VERIFY_MODEL}:generateContent?key=${GEMINI_KEY}`;
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const r = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body), signal: AbortSignal.timeout(30000) });
+      if (r.status === 429 || r.status === 503) { await new Promise(res => setTimeout(res, 1000 * 2 ** attempt)); continue; }
+      if (!r.ok) throw new Error(`Gemini ${r.status}`);
+      const data = await r.json();
+      const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+      if (!text) throw new Error('no text');
+      const parsed = JSON.parse(text);
+      const usage = data.usageMetadata || {};
+      verifyCost += (usage.promptTokenCount || 0) / 1e6 * 0.10 + (usage.candidatesTokenCount || 0) / 1e6 * 0.40;
+      verifyCalls++;
+      verifyCache.set(cacheKey, parsed);
+      return parsed;
+    } catch (e) {
+      if (attempt === 2) {
+        const fallback = { same_person: false, confidence: 'low', reasoning: `verify failed: ${String(e).slice(0, 80)}` };
+        verifyCache.set(cacheKey, fallback);
+        return fallback;
+      }
+      await new Promise(res => setTimeout(res, 1000));
+    }
+  }
+}
+
+// ─── SL surname lookup (Mongo) ───────────────────────────────────────────
+
+function fixLongS(s) { return (s || '').replace(/f/g, 's').replace(/F/g, 'S'); }
+
+// Latin/Vernacular alias map — surname → additional surnames to also try.
+// Covers the top-fragmented identities surfaced by the audit. Conservative:
+// only include cases where the alias is unambiguous in scholarly use.
+// Lowercase keys + values.
+const SURNAME_ALIASES = {
+  roterodamus: ['erasmus'],
+  erasmus:     ['roterodamus'],
+  'erasmus roterodamus': ['erasmus', 'roterodamus'],
+  molinaeus:   ['molineus', 'molinae', 'moulin', 'dumoulin'],
+  molinæus:    ['molinaeus', 'molineus', 'moulin'],
+  molineus:    ['molinaeus', 'moulin'],
+  faber:       ['fabri', 'lefevre', 'lefèvre', 'stapulensis'],
+  stapulensis: ['faber', 'lefevre', 'lefèvre'],
+  zuingerus:   ['zwinger', 'zuinger'],
+  zwingerus:   ['zwinger', 'zuinger'],
+  // Greek Patristic
+  chrysoftomus: ['chrysostomus'],
+  // Italian / Latin
+  giorgio:     ['zorzi'],
+  zorzi:       ['giorgio'],
+};
+
+const slCache = new Map();
+async function slBooksBySurname(db, s) {
+  if (!s) return [];
+  if (slCache.has(s)) return slCache.get(s);
+  const lower = s.toLowerCase();
+  const variants = new Set([lower]);
+  const corrected = fixLongS(lower);
+  if (corrected !== lower) variants.add(corrected);
+  for (const alias of (SURNAME_ALIASES[lower] || [])) variants.add(alias.toLowerCase());
+
+  const variantList = [...variants];
+  const re = new RegExp(`(^|[^a-z])(${variantList.map(v => v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`, 'i');
+  const books = await db.collection('books').find(
+    {
+      $or: [{ author: re }, { author_normalized: re }, { canonical_author_normalized: re }],
+      visible: { $ne: false },
+      pages_count: { $gt: 0 },
+      resource_type: { $nin: ['artwork', 'emblem', 'image', 'illustration', 'manuscript-fragment'] },
+    },
+    { projection: { _id: 1, id: 1, slug: 1, title: 1, author: 1, year: 1 } },
+  ).limit(80).toArray();
+  slCache.set(s, books);
+  return books;
+}
+
+// ─── Main loop ───────────────────────────────────────────────────────────
+
+// Cluster key: (author_normalized + raw_author). Sub-grouping by raw_author
+// is essential for Latin-family names where the same surname covers
+// different individuals (Stephanus, Henricus ≠ Stephanus, Robertus; the
+// existing author_normalized collapses them but they're different people).
+function clusterKey(r) {
+  return `${r.author_normalized}::${(r.author || '').trim().toLowerCase()}`;
+}
+
+async function fetchDistinctIdentities() {
+  const byKey = new Map(); // key → { entry, count, surname, alreadyDone }
+  let offset = 0;
+  const PAGE = 1000;
+  while (true) {
+    const path = `index_catalog_entries?select=id,author,author_normalized,title,condemnation_year,author_held_count&author_normalized=not.is.null&author_normalized=neq.&order=id&limit=${PAGE}&offset=${offset}`;
+    const rows = await supa('GET', path);
+    if (!rows.length) break;
+    for (const r of rows) {
+      const sn = r.author_normalized;
+      if (!sn || sn.length < 3) continue;
+      const k = clusterKey(r);
+      const alreadyDone = !FORCE && r.author_held_count !== null;
+      const cur = byKey.get(k);
+      if (!cur) byKey.set(k, { entry: r, count: 1, surname: sn, alreadyDone });
+      else {
+        cur.count++;
+        // Prefer the entry with a non-trivial title for better verifier context
+        if ((cur.entry.title?.length || 0) < (r.title?.length || 0)) cur.entry = r;
+        if (!alreadyDone) cur.alreadyDone = false;
+      }
+    }
+    if (rows.length < PAGE) break;
+    offset += rows.length;
+  }
+  return byKey;
+}
+
+async function main() {
+  console.log(`author_held backfill — mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}${FORCE ? ' (force)' : ''}${LIMIT ? ` (limit ${LIMIT})` : ''}`);
+
+  const mc = new MongoClient(process.env.MONGODB_URI);
+  await mc.connect();
+  const db = mc.db('bookstore');
+
+  console.log('\nScanning distinct identities…');
+  const identities = await fetchDistinctIdentities();
+  const todo = [...identities.entries()].filter(([, v]) => !v.alreadyDone).sort((a, b) => b[1].count - a[1].count);
+  console.log(`Found ${identities.size} distinct author_normalized keys; ${todo.length} need processing.`);
+
+  const work = LIMIT ? todo.slice(0, LIMIT) : todo;
+
+  let nVerified = 0;
+  let nRejected = 0;
+  let nNoBooks = 0;
+  let totalEntriesUpdated = 0;
+  let nDone = 0;
+  const samples = [];
+
+  const startedAt = Date.now();
+  const queue = [...work];
+
+  async function worker() {
+    while (queue.length) {
+      const item = queue.shift();
+      if (!item) break;
+      const [key, { entry, count, surname }] = item;
+
+      const books = await slBooksBySurname(db, surname);
+
+      let authorHeldCount = 0;
+      let sampleSlug = null;
+      let sampleId = null;
+      let verdict = 'no-sl-books';
+
+      if (books.length > 0) {
+        const v = await geminiVerify(entry, books);
+        if (v.same_person) {
+          const sorted = [...books].sort((a, b) => (b.year ? 1 : 0) - (a.year ? 1 : 0) || (b.title?.length || 0) - (a.title?.length || 0));
+          authorHeldCount = books.length;
+          sampleSlug = sorted[0].slug || null;
+          sampleId = String(sorted[0]._id);
+          verdict = `held=${authorHeldCount}`;
+          nVerified++;
+        } else {
+          verdict = `rejected (${v.reasoning?.slice(0, 50)})`;
+          nRejected++;
+        }
+      } else {
+        nNoBooks++;
+      }
+
+      if (samples.length < 15) {
+        samples.push({ key, count, books: books.length, verdict, sampleSlug });
+      }
+
+      if (APPLY) {
+        const rawAuthor = entry.author;
+        let path;
+        if (rawAuthor === null || rawAuthor === undefined) {
+          path = `index_catalog_entries?author_normalized=eq.${encodeURIComponent(surname)}&author=is.null`;
+        } else {
+          path = `index_catalog_entries?author_normalized=eq.${encodeURIComponent(surname)}&author=eq.${encodeURIComponent(rawAuthor)}`;
+        }
+        try {
+          await supa('PATCH', path, {
+            author_held_count: authorHeldCount,
+            author_held_sample_slug: sampleSlug,
+            author_held_sample_id: sampleId,
+          });
+          totalEntriesUpdated += count;
+        } catch (e) {
+          console.error(`\nPATCH failed for ${key}: ${String(e).slice(0, 200)}`);
+        }
+      }
+
+      nDone++;
+      if (nDone % 25 === 0 || nDone === work.length) {
+        const pct = (nDone / work.length * 100).toFixed(1);
+        const elapsed = (Date.now() - startedAt) / 1000;
+        const rate = nDone / elapsed;
+        const eta = (work.length - nDone) / rate;
+        process.stdout.write(`\r  ${nDone}/${work.length} (${pct}%)  verified=${nVerified}  rejected=${nRejected}  no-books=${nNoBooks}  Gemini=${verifyCalls}  $${verifyCost.toFixed(3)}  eta=${eta.toFixed(0)}s   `);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
+  console.log();
+
+  console.log('\n─── samples ───');
+  for (const s of samples) {
+    console.log(`  ${s.key.padEnd(28)} ${String(s.count).padStart(5)} entries  ${String(s.books).padStart(3)} SL books  →  ${s.verdict}${s.sampleSlug ? ` (${s.sampleSlug})` : ''}`);
+  }
+
+  console.log('\n─── summary ───');
+  console.log(`  identities processed     : ${work.length}`);
+  console.log(`  verified author-held     : ${nVerified}`);
+  console.log(`  rejected (diff person)   : ${nRejected}`);
+  console.log(`  no SL books at all       : ${nNoBooks}`);
+  console.log(`  Gemini calls / cost      : ${verifyCalls} / $${verifyCost.toFixed(4)}`);
+  console.log(`  total entries updated    : ${APPLY ? totalEntriesUpdated : '(dry-run)'}`);
+
+  await mc.close();
+}
+
+main().catch(e => { console.error('Fatal:', e); process.exit(1); });

--- a/scripts/migration/add-index-catalog-author-held.mjs
+++ b/scripts/migration/add-index-catalog-author-held.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Run the author-held migration via the Supabase IPv4 session-pooler.
+ * (The direct host db.<ref>.supabase.co is IPv6-only; many devs have no
+ * global IPv6 route, so we use the pooler instead.)
+ *
+ *   secret-lover run -- node scripts/migration/add-index-catalog-author-held.mjs
+ *
+ * Idempotent. Discovers the project's pooler region by trying common ones.
+ */
+import { readFileSync } from 'node:fs';
+import pg from 'pg';
+
+const RAW = process.env.SUPABASE_DB_URL;
+if (!RAW) { console.error('Missing SUPABASE_DB_URL'); process.exit(1); }
+
+const m = RAW.match(/^postgresql:\/\/([^:]+):(.+)@db\.([^.]+)\.supabase\.co:(\d+)\/(\w+)/);
+if (!m) { console.error('SUPABASE_DB_URL has unexpected shape'); process.exit(1); }
+const [, , password, ref, , db] = m;
+
+// Session-mode pooler (port 5432) — supports DDL. Transaction pooler (6543)
+// disallows session-level statements like ALTER TABLE.
+const REGIONS = ['eu-central-1', 'eu-west-1', 'eu-west-2', 'us-east-1', 'us-east-2', 'us-west-1', 'ap-southeast-1', 'ap-northeast-1'];
+
+const sql = readFileSync(new URL('./add-index-catalog-author-held.sql', import.meta.url), 'utf8');
+
+async function tryRegion(region) {
+  const host = `aws-0-${region}.pooler.supabase.com`;
+  const client = new pg.Client({
+    host, port: 5432, database: db,
+    user: `postgres.${ref}`, password,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 4000,
+  });
+  await client.connect();
+  return client;
+}
+
+let client = null;
+for (const region of REGIONS) {
+  try {
+    client = await tryRegion(region);
+    console.log(`Connected via ${region} pooler`);
+    break;
+  } catch (e) {
+    const msg = String(e).slice(0, 80);
+    process.stdout.write(`  ${region}: ${msg}\n`);
+  }
+}
+if (!client) { console.error('Could not connect via any pooler region'); process.exit(1); }
+
+try {
+  await client.query(sql);
+  console.log('Migration applied.');
+
+  const r = await client.query(`
+    SELECT column_name, data_type
+    FROM information_schema.columns
+    WHERE table_name = 'index_catalog_entries'
+      AND column_name LIKE 'author_held%'
+    ORDER BY column_name;
+  `);
+  console.log('New columns:');
+  for (const row of r.rows) console.log(`  ${row.column_name}  ${row.data_type}`);
+} catch (e) {
+  console.error('Migration failed:', e.message);
+  process.exit(1);
+} finally {
+  await client.end();
+}

--- a/scripts/migration/add-index-catalog-author-held.sql
+++ b/scripts/migration/add-index-catalog-author-held.sql
@@ -1,0 +1,31 @@
+-- Author-held signal for index_catalog_entries.
+--
+-- Most Index entries cite a *specific* expurgated work (e.g. Erasmus's
+-- "Annotationes in D. Cyprianum") that SL doesn't carry as a standalone
+-- title. The work-level `sl_book_id` correctly stays NULL — but the AUTHOR
+-- is held: SL has 42 Erasmus books. The UI should distinguish:
+--
+--   sl_book_id IS NOT NULL        →  "we hold this exact work"
+--   author_held_count > 0         →  "we hold N books by this author"
+--   neither                       →  "we don't hold the author at all"
+--
+-- This collapses the 92%-unmatched figure into three meaningfully different
+-- categories. ~30% of unmatched entries fall in the "author held" middle
+-- band (Erasmus, Augustinus, Hieronymus, Stephanus, …).
+--
+-- Backfilled by scripts/backfill-catalog-author-held.mjs.
+-- Re-runnable; idempotent.
+
+ALTER TABLE index_catalog_entries
+  ADD COLUMN IF NOT EXISTS author_held_count       INTEGER,
+  ADD COLUMN IF NOT EXISTS author_held_sample_slug TEXT,
+  ADD COLUMN IF NOT EXISTS author_held_sample_id   TEXT;
+
+CREATE INDEX IF NOT EXISTS ix_ice_author_held
+  ON index_catalog_entries(author_held_count)
+  WHERE author_held_count IS NOT NULL AND author_held_count > 0;
+
+COMMENT ON COLUMN index_catalog_entries.author_held_count IS
+  'Number of visible SL books authored by the same person as this Index entry. NULL = never computed; 0 = computed and author not held. Distinct from sl_book_id, which is the specific-work link.';
+COMMENT ON COLUMN index_catalog_entries.author_held_sample_slug IS
+  'Slug of one representative SL book by the same author. For "Browse N books by X at SL →" link.';

--- a/scripts/migration/update-index-catalog-works-view-author-held.sql
+++ b/scripts/migration/update-index-catalog-works-view-author-held.sql
@@ -1,0 +1,58 @@
+-- Extend v_index_catalog_works to surface the author-held signal.
+--
+-- author_held_count/sample populate per-entry via backfill-catalog-author-held.mjs.
+-- All entries for a given identity share the same author-held count, so MAX()
+-- across the group is the right aggregate.
+--
+-- Idempotent (CREATE OR REPLACE VIEW). Run after add-index-catalog-author-held.sql.
+
+CREATE OR REPLACE VIEW v_index_catalog_works AS
+WITH dedup AS (
+  SELECT
+    e.*,
+    CASE
+      WHEN e.scope = 'opera_omnia' THEN
+        coalesce(e.author_normalized, '__anon__') || '::*opera*'
+      ELSE
+        coalesce(e.author_normalized, '__anon__') || '::' ||
+        lower(substring(regexp_replace(coalesce(e.title, ''), '[^a-zA-Z0-9 ]', '', 'g') FROM 1 FOR 40))
+    END AS work_key
+  FROM index_catalog_entries e
+)
+SELECT
+  work_key,
+  (array_agg(author ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id))[1] AS author,
+  (array_agg(title ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id))[1] AS title,
+  (array_agg(scope ORDER BY
+     CASE scope WHEN 'opera_omnia' THEN 0 WHEN 'donec_corrigatur' THEN 1 WHEN 'expurgated' THEN 2 WHEN 'single_work' THEN 3 ELSE 4 END,
+     id))[1] AS scope,
+  author_normalized,
+  array_agg(DISTINCT index_id ORDER BY index_id) AS edition_ids,
+  count(DISTINCT index_id) AS edition_count,
+  min(condemnation_year) AS first_year,
+  max(condemnation_year) AS last_year,
+  (array_agg(ustc_sn ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id) FILTER (WHERE ustc_sn IS NOT NULL))[1] AS ustc_sn,
+  (array_agg(sl_book_id ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id) FILTER (WHERE sl_book_id IS NOT NULL))[1] AS sl_book_id,
+  (array_agg(sl_book_slug ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id) FILTER (WHERE sl_book_slug IS NOT NULL))[1] AS sl_book_slug,
+  -- author-held: same for all entries with the same author_normalized,
+  -- so max() collapses to that one value (NULL if never computed)
+  max(author_held_count) AS author_held_count,
+  (array_agg(author_held_sample_slug ORDER BY id) FILTER (WHERE author_held_sample_slug IS NOT NULL))[1] AS author_held_sample_slug,
+  (array_agg(author_held_sample_id   ORDER BY id) FILTER (WHERE author_held_sample_id   IS NOT NULL))[1] AS author_held_sample_id,
+  array_agg(id ORDER BY id) AS entry_ids,
+  array_agg(DISTINCT source_book_slug ORDER BY source_book_slug) FILTER (WHERE source_book_slug IS NOT NULL) AS source_book_slugs
+FROM dedup
+GROUP BY work_key, author_normalized;
+
+COMMENT ON VIEW v_index_catalog_works IS
+  'Deduplicated banned-works view: one row per unique (author, work) banned across any combination of Index editions. Includes author-held signal (do we hold ANY book by this author?) distinct from sl_book_id (do we hold THIS work?). Issue #1851.';

--- a/scripts/migration/update-index-catalog-works-view-author-held.sql
+++ b/scripts/migration/update-index-catalog-works-view-author-held.sql
@@ -44,13 +44,15 @@ SELECT
   (array_agg(sl_book_slug ORDER BY
      CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
      id) FILTER (WHERE sl_book_slug IS NOT NULL))[1] AS sl_book_slug,
+  array_agg(id ORDER BY id) AS entry_ids,
+  array_agg(DISTINCT source_book_slug ORDER BY source_book_slug) FILTER (WHERE source_book_slug IS NOT NULL) AS source_book_slugs,
   -- author-held: same for all entries with the same author_normalized,
-  -- so max() collapses to that one value (NULL if never computed)
+  -- so max() collapses to that one value (NULL if never computed).
+  -- Appended at the end so CREATE OR REPLACE VIEW accepts the addition
+  -- (PG only allows adding columns at the tail of an existing view).
   max(author_held_count) AS author_held_count,
   (array_agg(author_held_sample_slug ORDER BY id) FILTER (WHERE author_held_sample_slug IS NOT NULL))[1] AS author_held_sample_slug,
-  (array_agg(author_held_sample_id   ORDER BY id) FILTER (WHERE author_held_sample_id   IS NOT NULL))[1] AS author_held_sample_id,
-  array_agg(id ORDER BY id) AS entry_ids,
-  array_agg(DISTINCT source_book_slug ORDER BY source_book_slug) FILTER (WHERE source_book_slug IS NOT NULL) AS source_book_slugs
+  (array_agg(author_held_sample_id   ORDER BY id) FILTER (WHERE author_held_sample_id   IS NOT NULL))[1] AS author_held_sample_id
 FROM dedup
 GROUP BY work_key, author_normalized;
 

--- a/src/app/api/catalogs/[index_id]/entries/route.ts
+++ b/src/app/api/catalogs/[index_id]/entries/route.ts
@@ -20,6 +20,8 @@ interface Entry {
   ustc_sn: number | null;
   sl_book_id: string | null;
   sl_book_slug: string | null;
+  author_held_count: number | null;
+  author_held_sample_slug: string | null;
 }
 
 /**
@@ -50,7 +52,7 @@ export async function GET(
   let query = supabase
     .from('index_catalog_entries')
     .select(
-      'id, source_id, title, author, publication_date, condemnation_year, condemnation_period, scope, reason, ustc_sn, sl_book_id, sl_book_slug',
+      'id, source_id, title, author, publication_date, condemnation_year, condemnation_period, scope, reason, ustc_sn, sl_book_id, sl_book_slug, author_held_count, author_held_sample_slug',
       { count: 'exact' },
     )
     .eq('index_id', index_id);
@@ -61,7 +63,8 @@ export async function GET(
     query = query.or(`title.ilike.*${safe}*,author.ilike.*${safe}*`);
   }
   if (filter === 'held') query = query.not('sl_book_id', 'is', null);
-  else if (filter === 'unheld') query = query.is('sl_book_id', null);
+  else if (filter === 'unheld') query = query.is('sl_book_id', null).or('author_held_count.is.null,author_held_count.eq.0');
+  else if (filter === 'author_held') query = query.is('sl_book_id', null).gt('author_held_count', 0);
 
   // Sort
   if (sort === 'year') query = query.order('publication_date', { ascending: true, nullsFirst: false });

--- a/src/app/api/catalogs/works/route.ts
+++ b/src/app/api/catalogs/works/route.ts
@@ -17,6 +17,9 @@ interface Work {
   ustc_sn: number | null;
   sl_book_id: string | null;
   sl_book_slug: string | null;
+  author_held_count: number | null;
+  author_held_sample_slug: string | null;
+  author_held_sample_id: string | null;
 }
 
 /**
@@ -28,7 +31,7 @@ interface Work {
  *   q               — title or author search (>= 2 chars)
  *   editions        — comma-separated list of index_ids to filter by
  *   filter_mode     — 'any' (default) or 'all'
- *   filter          — 'held' (only SL-linked) | 'unheld' (acquisition gaps) | 'all'
+ *   filter          — 'held' (only SL-linked) | 'unheld' (acquisition gaps) | 'author_held' (we hold author, not exact work) | 'all'
  *   sort            — 'author' (default) | 'first_year' | 'edition_count' (desc)
  *   page, page_size — pagination
  */
@@ -81,7 +84,8 @@ export async function GET(req: Request) {
 
   // SL filter
   if (filter === 'held') query = query.not('sl_book_id', 'is', null);
-  else if (filter === 'unheld') query = query.is('sl_book_id', null);
+  else if (filter === 'unheld') query = query.is('sl_book_id', null).or('author_held_count.is.null,author_held_count.eq.0');
+  else if (filter === 'author_held') query = query.is('sl_book_id', null).gt('author_held_count', 0);
 
   // Sort
   if (sort === 'first_year') query = query.order('first_year', { ascending: true, nullsFirst: false });

--- a/src/app/api/catalogs/works/route.ts
+++ b/src/app/api/catalogs/works/route.ts
@@ -32,6 +32,7 @@ interface Work {
  *   editions        — comma-separated list of index_ids to filter by
  *   filter_mode     — 'any' (default) or 'all'
  *   filter          — 'held' (only SL-linked) | 'unheld' (acquisition gaps) | 'author_held' (we hold author, not exact work) | 'all'
+ *   scope           — 'opera_omnia' | 'expurgated' | 'banned' (= not expurgated) | 'all' (default)
  *   sort            — 'author' (default) | 'first_year' | 'edition_count' (desc)
  *   page, page_size — pagination
  */
@@ -42,6 +43,7 @@ export async function GET(req: Request) {
   const editionsParam = (url.searchParams.get('editions') || '').trim();
   const filterMode = url.searchParams.get('filter_mode') === 'all' ? 'all' : 'any';
   const filter = url.searchParams.get('filter') || 'all';
+  const scopeFilter = url.searchParams.get('scope') || 'all';
   const sort = url.searchParams.get('sort') || 'author';
   const page = Math.max(1, parseInt(url.searchParams.get('page') || '1'));
   const pageSize = Math.min(200, Math.max(1, parseInt(url.searchParams.get('page_size') || '50')));
@@ -86,6 +88,15 @@ export async function GET(req: Request) {
   if (filter === 'held') query = query.not('sl_book_id', 'is', null);
   else if (filter === 'unheld') query = query.is('sl_book_id', null).or('author_held_count.is.null,author_held_count.eq.0');
   else if (filter === 'author_held') query = query.is('sl_book_id', null).gt('author_held_count', 0);
+
+  // Scope filter — separate from SL filter. The Spanish Indices are ~90%
+  // expurgations (passages censored inside an otherwise-permitted book),
+  // which are NOT the same acquisition signal as outright bans. Letting
+  // users separate the two avoids reading the full unheld pile as
+  // "books to acquire."
+  if (scopeFilter === 'opera_omnia') query = query.eq('scope', 'opera_omnia');
+  else if (scopeFilter === 'expurgated') query = query.eq('scope', 'expurgated');
+  else if (scopeFilter === 'banned') query = query.neq('scope', 'expurgated');
 
   // Sort
   if (sort === 'first_year') query = query.order('first_year', { ascending: true, nullsFirst: false });

--- a/src/components/collections/IndexCatalogSection.tsx
+++ b/src/components/collections/IndexCatalogSection.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import Link from 'next/link';
-import { BookMarked, ExternalLink, Search, BookOpen } from 'lucide-react';
+import { BookMarked, ExternalLink, Search, BookOpen, User } from 'lucide-react';
 
 interface CatalogEntry {
   id: number;
@@ -19,6 +19,8 @@ interface CatalogEntry {
   sl_book_slug: string | null;
   source_book_slug?: string | null;
   source_page?: number | null;
+  author_held_count?: number | null;
+  author_held_sample_slug?: string | null;
 }
 
 interface Catalog {
@@ -33,7 +35,7 @@ interface Props {
   catalogs: Catalog[];
 }
 
-type Filter = 'all' | 'held' | 'unheld';
+type Filter = 'all' | 'held' | 'author_held' | 'unheld';
 type Sort = 'author' | 'year' | 'condemned';
 
 const PAGE_SIZE = 50;
@@ -150,13 +152,22 @@ export default function IndexCatalogSection({ catalogs }: Props) {
         </div>
 
         <div className="flex gap-1 border border-stone-300 rounded overflow-hidden">
-          {(['all', 'held', 'unheld'] as Filter[]).map(f => (
+          {(['all', 'held', 'author_held', 'unheld'] as Filter[]).map(f => (
             <button
               key={f}
               onClick={() => { setPage(1); setFilter(f); }}
               className={`px-3 py-1.5 ${filter === f ? 'bg-stone-800 text-white' : 'bg-white text-stone-700 hover:bg-stone-100'}`}
+              title={
+                f === 'held' ? 'This exact work is in the library' :
+                f === 'author_held' ? 'We hold writings by this author, though not this specific work' :
+                f === 'unheld' ? 'Neither the work nor the author is in the library' :
+                undefined
+              }
             >
-              {f === 'all' ? 'All' : f === 'held' ? 'In library' : 'Not held'}
+              {f === 'all' ? 'All' :
+               f === 'held' ? 'Work in library' :
+               f === 'author_held' ? 'Author in library' :
+               'Not held'}
             </button>
           ))}
         </div>
@@ -226,6 +237,15 @@ export default function IndexCatalogSection({ catalogs }: Props) {
                     >
                       <BookOpen className="w-3.5 h-3.5" />
                       Read at Source Library
+                    </Link>
+                  ) : e.author_held_count && e.author_held_count > 0 && e.author_held_sample_slug ? (
+                    <Link
+                      href={`/book/${e.author_held_sample_slug}`}
+                      className="inline-flex items-center gap-1 px-3 py-1.5 bg-amber-100 text-amber-900 border border-amber-300 rounded hover:bg-amber-200"
+                      title={`Source Library holds ${e.author_held_count} book${e.author_held_count === 1 ? '' : 's'} by this author, but not this specific work`}
+                    >
+                      <User className="w-3.5 h-3.5" />
+                      {e.author_held_count} {e.author_held_count === 1 ? 'book' : 'books'} by author
                     </Link>
                   ) : e.ustc_sn ? (
                     <a

--- a/src/components/collections/IndexCatalogWorksTable.tsx
+++ b/src/components/collections/IndexCatalogWorksTable.tsx
@@ -35,6 +35,7 @@ interface Props {
 }
 
 type Filter = 'all' | 'held' | 'author_held' | 'unheld';
+type ScopeFilter = 'all' | 'banned' | 'opera_omnia' | 'expurgated';
 type Sort = 'author' | 'first_year' | 'edition_count';
 type Mode = 'any' | 'all';
 
@@ -56,6 +57,7 @@ export default function IndexCatalogWorksTable({ collectionSlug, catalogs }: Pro
   const [selectedEditions, setSelectedEditions] = useState<Set<string>>(new Set());
   const [mode, setMode] = useState<Mode>('any');
   const [filter, setFilter] = useState<Filter>('all');
+  const [scopeFilter, setScopeFilter] = useState<ScopeFilter>('all');
   const [sort, setSort] = useState<Sort>('edition_count');
   const [page, setPage] = useState(1);
 
@@ -74,6 +76,7 @@ export default function IndexCatalogWorksTable({ collectionSlug, catalogs }: Pro
         filter_mode: mode,
         sort,
       });
+      if (scopeFilter !== 'all') params.set('scope', scopeFilter);
       if (q.trim().length >= 2) params.set('q', q.trim());
       if (selectedEditions.size > 0) params.set('editions', [...selectedEditions].join(','));
       const r = await fetch(`/api/catalogs/works?${params}`, { signal });
@@ -87,7 +90,7 @@ export default function IndexCatalogWorksTable({ collectionSlug, catalogs }: Pro
     } finally {
       setLoading(false);
     }
-  }, [collectionSlug, page, filter, mode, sort, q, selectedEditions]);
+  }, [collectionSlug, page, filter, scopeFilter, mode, sort, q, selectedEditions]);
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -156,6 +159,18 @@ export default function IndexCatalogWorksTable({ collectionSlug, catalogs }: Pro
             </button>
           ))}
         </div>
+
+        <select
+          value={scopeFilter}
+          onChange={e => { setPage(1); setScopeFilter(e.target.value as ScopeFilter); }}
+          className="px-3 py-1.5 border border-stone-300 rounded bg-white"
+          title="Distinguish outright bans from in-text expurgations (a censored passage, not the whole work)"
+        >
+          <option value="all">All scopes</option>
+          <option value="banned">Bans only (no expurgations)</option>
+          <option value="opera_omnia">Opera omnia bans</option>
+          <option value="expurgated">Expurgations only</option>
+        </select>
 
         <select
           value={sort}

--- a/src/components/collections/IndexCatalogWorksTable.tsx
+++ b/src/components/collections/IndexCatalogWorksTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import Link from 'next/link';
-import { BookMarked, ExternalLink, Search, BookOpen } from 'lucide-react';
+import { BookMarked, ExternalLink, Search, BookOpen, User } from 'lucide-react';
 
 interface Work {
   work_key: string;
@@ -16,6 +16,9 @@ interface Work {
   ustc_sn: number | null;
   sl_book_id: string | null;
   sl_book_slug: string | null;
+  author_held_count: number | null;
+  author_held_sample_slug: string | null;
+  author_held_sample_id: string | null;
 }
 
 interface Catalog {
@@ -31,7 +34,7 @@ interface Props {
   catalogs: Catalog[];
 }
 
-type Filter = 'all' | 'held' | 'unheld';
+type Filter = 'all' | 'held' | 'author_held' | 'unheld';
 type Sort = 'author' | 'first_year' | 'edition_count';
 type Mode = 'any' | 'all';
 
@@ -134,13 +137,22 @@ export default function IndexCatalogWorksTable({ collectionSlug, catalogs }: Pro
         </div>
 
         <div className="flex gap-1 border border-stone-300 rounded overflow-hidden">
-          {(['all', 'held', 'unheld'] as Filter[]).map(f => (
+          {(['all', 'held', 'author_held', 'unheld'] as Filter[]).map(f => (
             <button
               key={f}
               onClick={() => { setPage(1); setFilter(f); }}
               className={`px-3 py-1.5 ${filter === f ? 'bg-stone-800 text-white' : 'bg-white text-stone-700 hover:bg-stone-100'}`}
+              title={
+                f === 'held' ? 'This exact work is in the library' :
+                f === 'author_held' ? 'We hold writings by this author, though not this specific work' :
+                f === 'unheld' ? 'Neither the work nor the author is in the library' :
+                undefined
+              }
             >
-              {f === 'all' ? 'All' : f === 'held' ? 'In library' : 'Not held'}
+              {f === 'all' ? 'All' :
+               f === 'held' ? 'Work in library' :
+               f === 'author_held' ? 'Author in library' :
+               'Not held'}
             </button>
           ))}
         </div>
@@ -246,6 +258,14 @@ export default function IndexCatalogWorksTable({ collectionSlug, catalogs }: Pro
                     {w.sl_book_slug ? (
                       <Link href={`/book/${w.sl_book_slug}`} className="inline-flex items-center gap-1 text-xs bg-stone-800 text-white px-2 py-1 rounded hover:bg-stone-900">
                         <BookOpen className="w-3 h-3" />Read
+                      </Link>
+                    ) : w.author_held_count && w.author_held_count > 0 && w.author_held_sample_slug ? (
+                      <Link
+                        href={`/book/${w.author_held_sample_slug}`}
+                        className="inline-flex items-center gap-1 text-xs bg-amber-100 text-amber-900 px-2 py-1 rounded hover:bg-amber-200 border border-amber-300"
+                        title={`Source Library holds ${w.author_held_count} book${w.author_held_count === 1 ? '' : 's'} by this author, but not this specific work`}
+                      >
+                        <User className="w-3 h-3" />{w.author_held_count} by author
                       </Link>
                     ) : w.ustc_sn ? (
                       <a href={`https://www.ustc.ac.uk/editions/${w.ustc_sn}`} target="_blank" rel="noopener" className="inline-flex items-center gap-1 text-xs text-stone-600 hover:text-stone-900">


### PR DESCRIPTION
## Summary

The Index Librorum Prohibitorum browser had a binary held/unheld state, but a diagnostic on the Erasmus case showed the 92% "unmatched" figure decomposes into three meaningfully different categories:

- `sl_book_id IS NOT NULL` → we hold **this exact work**
- `author_held_count > 0` → we hold **N books by this author**
- neither → genuinely not held

Of 2,834 Erasmus entries, only 34 are `opera_omnia`. The other 2,800 are specific-work expurgations (`Paraphrasis in Matthaeum`, `Annotationes in D. Cyprianum`, etc.) that SL doesn't carry standalone — even though SL has 42 Erasmus books. The matcher correctly refused to false-positive-link them; the UI just had no way to surface "we have the author."

## Changes

- **Migrations** (already applied to prod):
  - `add-index-catalog-author-held.sql` — adds `author_held_count`, `author_held_sample_slug`, `author_held_sample_id` to `index_catalog_entries` with a filtered index.
  - `update-index-catalog-works-view-author-held.sql` — extends `v_index_catalog_works` to expose the three fields (max() across the work_key group).
- **Backfill** `scripts/backfill-catalog-author-held.mjs` — per-identity:
  - sub-groups by `(author_normalized, raw_author)` so Stephanus, Henricus is verified separately from Stephanus, Robertus
  - small Latin↔vernacular alias map (roterodamus↔erasmus, molinaeus↔moulin, zuingerus↔zwinger, chrysoftomus→chrysostomus, …) so SL surname lookups find the held author under either spelling
  - Gemini verification per cluster against the SL surname-matched books — catches Stephanus-family disambiguation and Cellarius/Faber century collisions
  - concurrency=10, ~3h on the full 16K identities, ~$0.05 total Gemini spend
- **APIs** `/api/catalogs/works` + `/api/catalogs/[index_id]/entries` expose the new fields and accept `filter=author_held` and `scope={opera_omnia|expurgated|banned|all}`.
- **UI** (both `IndexCatalogWorksTable` and `IndexCatalogSection`):
  - new chip "Author in library" alongside "Work in library" / "Not held"
  - new scope dropdown — separates 22,591 Spanish expurgations from outright bans (different acquisition semantics)
  - status column renders an amber "N by author" badge linking to a representative SL book when the work itself isn't held

## Out of scope (deferred)

- **Full Latin-name normalization** — Stephanus / Faber sub-identity verification still rejects in cases where SL has the right family member but Gemini can't tell from a mixed candidate sample. Better tackled with VIAF authority records than ad-hoc aliases.
- **language field backfill** — all 62,943 entries have `language = NULL`; ingest never populated. Per-edition default + script detection is straightforward but separate.
- **Re-link `sl_book_id`** with improved matcher — same root issue as above; revisit after authority linking.

## Test plan

- [x] Migrations applied to prod via Hetzner pg client (IPv6 reachable)
- [x] View aggregation verified: Erasmus rows return `author_held_count: 42` with sample slug
- [x] `npx tsc --noEmit` clean for changed files
- [ ] Visual check on the Vercel preview: https://sourcelibrary-v2-git-worktree-ilp-author-normalization-source-library.vercel.app/collections/index-librorum-prohibitorum
- [ ] Backfill is still running in background (~3h total) — current verified count growing live