### PR TITLE
fix: sweep abort-race + nullsFirst patterns from BPH catalog browser pass

### DIFF
--- a/src/app/api/books/browse/route.ts
+++ b/src/app/api/books/browse/route.ts
@@ -63,10 +63,13 @@ export async function GET(request: NextRequest) {
     // Sort
     switch (sort) {
       case 'title-asc':
-        query = query.order('sort_title', { ascending: true });
+        query = query.order('sort_title', { ascending: true, nullsFirst: false });
         break;
       case 'title-desc':
-        query = query.order('sort_title', { ascending: false });
+        // nullsFirst:false matches the asc case — Supabase otherwise puts
+        // NULL sort_title ahead of real ones for descending sorts. Same
+        // class of bug as the BPH title_desc fix in #2132.
+        query = query.order('sort_title', { ascending: false, nullsFirst: false });
         break;
       case 'date_asc':
         query = query.order('year', { ascending: true, nullsFirst: false });

--- a/src/components/book/BookLibrary.tsx
+++ b/src/components/book/BookLibrary.tsx
@@ -174,6 +174,11 @@ export default function BookLibrary({ initialBooks, totalBooks, languages, colle
       if (!res.ok) throw new Error('Failed to fetch');
       const data = await res.json();
 
+      // Drop the result if a newer fetch superseded us — abort() doesn't
+      // stop res.json() once await fetch already resolved. Same race as
+      // fixed in BphCatalogBrowser (#2132).
+      if (abortRef.current !== controller) return;
+
       if (append) {
         setApiBooks(prev => [...(prev ?? initialBooks), ...data.books]);
       } else {
@@ -184,7 +189,7 @@ export default function BookLibrary({ initialBooks, totalBooks, languages, colle
       if (error instanceof Error && error.name === 'AbortError') return;
       console.error('Failed to fetch books:', error);
     } finally {
-      if (!controller.signal.aborted) {
+      if (abortRef.current === controller && !controller.signal.aborted) {
         setLoading(false);
         setLoadingMore(false);
       }

--- a/src/components/catalog/CatalogBrowser.tsx
+++ b/src/components/catalog/CatalogBrowser.tsx
@@ -81,13 +81,19 @@ export default function CatalogBrowser({ initialBooks, initialTotal, languages }
       });
       if (!res.ok) throw new Error('fetch failed');
       const data = await res.json();
+      // Drop the result if a newer fetch superseded us — abort() doesn't
+      // stop res.json() once await fetch already resolved. Same race as
+      // fixed in BphCatalogBrowser (#2132).
+      if (abortRef.current !== controller) return;
       setBooks(data.books || []);
       setTotal(data.total || 0);
     } catch (err) {
       if ((err as Error).name === 'AbortError') return;
       // Keep current state on error
     } finally {
-      if (!controller.signal.aborted) setLoading(false);
+      if (abortRef.current === controller && !controller.signal.aborted) {
+        setLoading(false);
+      }
     }
   }, []);
 

--- a/src/components/libraries/CatalogBrowser.tsx
+++ b/src/components/libraries/CatalogBrowser.tsx
@@ -224,16 +224,23 @@ export default function CatalogBrowser({
       const params = buildParams(q, s, kw, off, a);
       const res = await fetch(`/api/catalog/${encodeURIComponent(tenant)}?${params}`, { signal: controller.signal });
       const data = await res.json();
+      // Drop the result if a newer fetch superseded us — abort() doesn't
+      // stop res.json() once await fetch already resolved. Same race as
+      // fixed in BphCatalogBrowser (#2132).
+      if (abortRef.current !== controller) return;
       setWorks(data.works || []);
       setTotal(data.total || 0);
       onTotalChange?.(data.total || 0, isFiltered);
     } catch (err) {
       if ((err as Error).name === 'AbortError') return;
+      if (abortRef.current !== controller) return;
       setWorks([]);
       setTotal(0);
       onTotalChange?.(0, isFiltered);
     } finally {
-      if (!controller.signal.aborted) setLoading(false);
+      if (abortRef.current === controller && !controller.signal.aborted) {
+        setLoading(false);
+      }
     }
   }, [tenant, buildParams, onTotalChange, lockDigitized]);
 


### PR DESCRIPTION
## Summary
Two engineering patterns surfaced by #2132 (BPH catalog browser fix) turned out to exist in other components and endpoints. Sweeping them here.

### Abort-race in `fetch + setState`
`AbortController.abort()` rejects the fetch promise itself, but if `await fetch()` has already resolved (headers received) before the next call fires abort, `res.json()` keeps streaming and a subsequent `setState` lands *after* the latest result already committed. Fix: re-check `abortRef.current === controller` after the body parses, before touching state.

Applied to:
- `src/components/libraries/CatalogBrowser.tsx` — Bhutan / Kloss / non-BPH unified catalogues
- `src/components/catalog/CatalogBrowser.tsx` — `/catalog` browse
- `src/components/book/BookLibrary.tsx` — `/library` (high traffic)

**Not applied** to streaming-chat components (`LibrarianClient`, `ReadingRoomClient`, `experiments/search-v2`) — those use `reader.read()` which is abort-aware end-to-end, so the race doesn't apply.

### Supabase desc orders missing `nullsFirst: false`
`.order(col, { ascending: false })` defaults to `nullsFirst: true` → NULL rows surface ahead of real ones on descending sorts. Five `None` titles at the top was the BPH symptom in #2132.

Applied to `src/app/api/books/browse/route.ts` — both `sort_title-asc` and `sort_title-desc` (asc was also missing the arg).

**Not applied** to other candidate columns (`book_count`, `total_mentions`, `edition_count`, analytics `timestamp`) — unlikely to be null in practice, leaving alone until reported.

## Out of scope
- The `replaceState` + sibling-toggle pattern lives in several components (`gallery/image/[id]/page.tsx`, `CollectionAllBooks.tsx`, etc.) but is only a bug when there's a sibling toggle that builds URLs from a fixed template. Needs per-file investigation — separate PR if any of them surface a user report.

## Test plan
- [ ] `/library` (apex): type a search fast enough to fire several debounced fetches; final rendered list should match the final query.
- [ ] `/catalog` (apex): same fast-typing test.
- [ ] `bhutan.sourcelibrary.org/catalogue` (or any non-BPH unified catalogue): same.
- [ ] `/api/books/browse?sort=title-desc&limit=5` — should return 5 real titles, not `null`s.
- [ ] `/api/books/browse?sort=title-asc&limit=5` — should be unchanged (asc behavior was already correct in practice; this PR just makes it explicit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)