### PR TITLE
feat(librarian): unified hybrid search (Atlas keyword + Supabase semantic via RRF)

### DIFF
--- a/scripts/eval/librarian-search/.gitignore
+++ b/scripts/eval/librarian-search/.gitignore
@@ -1,0 +1,2 @@
+results/
+*.draft.json

--- a/scripts/eval/librarian-search/README.md
+++ b/scripts/eval/librarian-search/README.md
@@ -1,0 +1,69 @@
+# Librarian Search Evaluation
+
+Quantitative evaluation harness for the Librarian's search tools. Compares
+multiple search variants against a hand-validated golden set and reports
+precision@5, recall@5, and MRR per variant.
+
+## Why this exists
+
+The Librarian currently uses two tools — `search_collection` (Atlas keyword)
+and `search_semantic` (book-then-page Supabase) — and the model picks between
+them. Known issues:
+
+1. Book-then-page misses passages in books whose summaries don't match the
+   query (the "Martial's masturbator epigram in a 400-page book about Roman
+   wit" case the `semanticPageSearchGlobal` comment cites).
+2. There's no hybrid scoring or cross-encoder reranking.
+
+Fixing (1) and (2) without a measurement framework is guesswork. This harness
+lets us A/B variants — auto-fallback to global, RRF merge, cross-encoder rerank
+— against a fixed query set.
+
+## Layout
+
+- `golden-set.json` — query → expected (book_slug, page-range) tuples.
+  Hand-validated, marked with `confidence` (high/medium/low). Treat low-
+  confidence entries as diagnostics, not ground truth.
+- `variants.mjs` — one async function per search variant. Each takes a query
+  string and returns ranked `{book_id, book_slug, page_number, ...}` hits.
+- `metrics.mjs` — `precisionAtK`, `recallAtK`, `mrr`, plus a matcher that
+  honors the optional `page_min`/`page_max` page-range tolerance.
+- `run.mjs` — runner. Iterates queries × variants, computes metrics, writes
+  a JSON report and prints a per-category table.
+
+## Running
+
+```bash
+# Env is required (MONGODB_URI, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, GEMINI_API_KEY)
+set -a; source ../../../../.env.production.local; set +a
+
+# Run all variants against the full golden set
+node scripts/eval/librarian-search/run.mjs
+
+# Run a single variant
+node scripts/eval/librarian-search/run.mjs --variant=hybrid-rrf
+
+# Run a single query (for debugging)
+node scripts/eval/librarian-search/run.mjs --query=agrippa-planetary-seals
+
+# Verbose mode (prints every hit)
+node scripts/eval/librarian-search/run.mjs --verbose
+```
+
+Reports are written to `scripts/eval/librarian-search/results/<timestamp>.json`.
+
+## Golden set conventions
+
+A "correct" hit for a query is one whose `book_slug` matches an entry in
+`expected[]`. If the entry has `page_min`/`page_max`, the hit's `page_number`
+must fall within. If not, any page from that book counts.
+
+Categories:
+- `well-known-concept` — the topic is famous; book-level search should find it
+- `niche-passage` — a specific passage inside a (possibly famous) book that
+  book-level search will likely miss
+- `verbatim-quote` — user is searching for a phrase they expect to find verbatim
+- `cross-lingual` — query in English, expected hits in non-English originals
+  (English translations are what's indexed, so this tests translation coverage)
+- `broad-theme` — wide topic; multiple books should match
+- `bibliographic` — "what do you have about X" — books-as-results

--- a/scripts/eval/librarian-search/_seed-golden-set.mjs
+++ b/scripts/eval/librarian-search/_seed-golden-set.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Helper script to verify candidate book slugs exist in the collection.
+ * Run this when adding new golden-set entries to make sure the book_slug
+ * actually resolves to a tenant-visible book.
+ *
+ *   set -a; source ../../../../.env.production.local; set +a
+ *   node scripts/eval/librarian-search/_seed-golden-set.mjs
+ *
+ * Outputs JSON to stdout; redirect to golden-set.json after manual review.
+ */
+
+import { MongoClient } from 'mongodb';
+
+// Candidate (query, expected) pairs. Each `query_book` is a flexible search
+// term we use to FIND the canonical slug in Mongo (we then put the actual
+// slug in expected.book_slug). This avoids me hard-coding wrong slugs.
+const CANDIDATES = [
+  // ── Well-known-concept ─────────────────────────────────────────────
+  { id: 'agrippa-occult-philosophy', query: 'Agrippa on natural magic and planetary correspondences',
+    category: 'well-known-concept', query_book: 'Three Books of Occult Philosophy', author_contains: 'agrippa' },
+  { id: 'bruno-infinite-worlds', query: 'Giordano Bruno on the infinite universe and plurality of worlds',
+    category: 'well-known-concept', query_book: 'infinite universe', author_contains: 'bruno' },
+  { id: 'ficino-de-vita', query: 'Ficino on drawing down celestial spirits with talismans',
+    category: 'well-known-concept', query_book: 'de vita', author_contains: 'ficino' },
+  { id: 'kepler-harmonices', query: 'Kepler on the harmony of the spheres and planetary music',
+    category: 'well-known-concept', query_book: 'harmonices mundi', author_contains: 'kepler' },
+  { id: 'fludd-utriusque', query: 'Robert Fludd on the macrocosm and microcosm',
+    category: 'well-known-concept', query_book: 'utriusque cosmi', author_contains: 'fludd' },
+  { id: 'paracelsus-archidoxes', query: 'Paracelsus on the spagyric preparation of metals',
+    category: 'well-known-concept', query_book: 'archidoxes', author_contains: 'paracelsus' },
+
+  // ── Niche-passage (specific topic inside a famous book) ────────────
+  { id: 'kircher-magnetism', query: 'magnetic experiments with iron and lodestone',
+    category: 'niche-passage', query_book: 'magnete', author_contains: 'kircher' },
+  { id: 'vesalius-anatomy-skull', query: 'anatomy of the human skull and cranial sutures',
+    category: 'niche-passage', query_book: 'fabrica', author_contains: 'vesalius' },
+  { id: 'boehme-seven-properties', query: 'the seven fountain spirits or properties of nature',
+    category: 'niche-passage', query_book: 'aurora', author_contains: 'boehme' },
+
+  // ── Verbatim-quote / formula ───────────────────────────────────────
+  { id: 'emerald-tablet-as-above', query: 'as above so below tabula smaragdina',
+    category: 'verbatim-quote', query_book: 'emerald', author_contains: null },
+  { id: 'rosicrucian-fama', query: 'Fama Fraternitatis brothers of the Rose Cross',
+    category: 'verbatim-quote', query_book: 'fama fraternitatis', author_contains: null },
+
+  // ── Cross-lingual (search English, book is non-English) ────────────
+  { id: 'sanskrit-rasa-alchemy', query: 'Indian alchemy mercury rasa preparation',
+    category: 'cross-lingual', query_book: 'rasa', author_contains: null },
+  { id: 'tibetan-bardo', query: 'Tibetan teachings on the intermediate state after death',
+    category: 'cross-lingual', query_book: 'bardo', author_contains: null },
+
+  // ── Broad-theme (multiple books should match) ──────────────────────
+  { id: 'sympathetic-magic', query: 'sympathetic magic and occult virtues in nature',
+    category: 'broad-theme', query_book: null, author_contains: null },
+  { id: 'dream-interpretation-antiquity', query: 'dream interpretation in the ancient world',
+    category: 'broad-theme', query_book: null, author_contains: null },
+
+  // ── Bibliographic (find books, not passages) ───────────────────────
+  { id: 'books-on-geomancy', query: 'books about geomancy and divination by points',
+    category: 'bibliographic', query_book: 'geomancy', author_contains: null },
+  { id: 'books-on-cabala', query: 'Christian cabala in the Renaissance',
+    category: 'bibliographic', query_book: 'cabala', author_contains: null },
+];
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('MONGODB_URI not set; source .env.production.local');
+    process.exit(1);
+  }
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+
+  const queries = [];
+  for (const c of CANDIDATES) {
+    const filter = {
+      hidden: { $ne: true },
+      tenantId: { $in: [null, undefined] },
+      pages_count: { $gt: 0 },
+    };
+    const orClauses = [];
+    if (c.query_book) {
+      const re = new RegExp(c.query_book.replace(/\s+/g, '.*'), 'i');
+      orClauses.push({ title: re }, { display_title: re }, { english_title: re });
+    }
+    if (orClauses.length) filter.$or = orClauses;
+    if (c.author_contains) filter.author = new RegExp(c.author_contains, 'i');
+
+    const docs = await db.collection('books')
+      .find(filter)
+      .project({ id: 1, slug: 1, title: 1, display_title: 1, author: 1, pages_count: 1, pages_translated: 1, year: 1 })
+      .limit(5)
+      .toArray();
+
+    process.stderr.write(`${c.id} → ${docs.length} match(es)\n`);
+    for (const d of docs) {
+      process.stderr.write(`    ${d.slug}  "${d.display_title || d.title}" by ${d.author || '?'} (${d.pages_translated || 0}/${d.pages_count} translated)\n`);
+    }
+
+    // Take the top match with translation; fall back to first
+    const best = docs.find(d => (d.pages_translated || 0) > 10) || docs[0];
+
+    queries.push({
+      id: c.id,
+      query: c.query,
+      category: c.category,
+      confidence: best ? 'medium' : 'low',
+      expected: best ? [{
+        book_slug: best.slug,
+        // No page range yet — that needs manual validation
+      }] : [],
+      notes: best
+        ? `Candidate book: "${best.display_title || best.title}" by ${best.author || '?'} (${best.pages_translated || 0} pages translated)`
+        : `NO MATCH FOUND for ${c.query_book || c.query}; verify the collection has this`,
+    });
+  }
+
+  await client.close();
+
+  console.log(JSON.stringify({
+    description: 'Librarian search eval — golden set. Generated by _seed-golden-set.mjs, then hand-validated.',
+    generated_at: new Date().toISOString(),
+    queries,
+  }, null, 2));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/eval/librarian-search/_spike-rich-embedding.mjs
+++ b/scripts/eval/librarian-search/_spike-rich-embedding.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * Spike: rich book embedding A/B on a single book.
+ *
+ * Target: Della Porta's "De Humana Physiognomonia" (slug: de-humana-physiognomonia-libri-iv-porta).
+ *
+ * Compares three embedding text compositions:
+ *   1. CURRENT  — what enrich-worker writes today
+ *   2. RICH     — + reading_summary + section summaries + section quotes + themes
+ *   3. RICH+LLM — + LLM-condensed roll-up of page summaries (for the size problem)
+ *
+ * For each composition, embeds the text, then for a battery of niche physiognomy
+ * queries, computes:
+ *   - cosine similarity (this book vs. query)
+ *   - rank of this book in the current production book_embeddings (where does
+ *     the book actually appear today?)
+ *   - rank the book WOULD have if we used the rich embedding (rough — we
+ *     compare rich-cosine against the top-N production similarities)
+ *
+ * Output: per-query table showing the lift.
+ *
+ *   set -a; source ../../../../.env.production.local; set +a
+ *   node scripts/eval/librarian-search/_spike-rich-embedding.mjs
+ */
+
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+import { GoogleGenAI } from '@google/genai';
+
+const TARGET_SLUG = 'de-humana-physiognomonia-libri-iv-porta';
+
+const QUERIES = [
+  'facial features and character',
+  'reading the face for moral disposition',
+  'lion features and bravery',
+  'nose shape and temperament',
+  'physiognomy of women and men compared',
+  'animal analogies for human personality',
+  'forehead lines and intellect',
+  // For sanity: queries about other books should NOT pull physiognomy up
+  'transmutation of metals into gold',
+  'planetary correspondences in talismans',
+];
+
+// ── Setup ─────────────────────────────────────────────────────────────
+
+const mongoUri = process.env.MONGODB_URI;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const geminiKey = process.env.GEMINI_API_KEY;
+if (!mongoUri || !supabaseUrl || !supabaseKey || !geminiKey) {
+  console.error('Missing env. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const mongo = new MongoClient(mongoUri);
+const supabase = createClient(supabaseUrl, supabaseKey);
+const ai = new GoogleGenAI({ apiKey: geminiKey });
+
+// ── Embedding fn ──────────────────────────────────────────────────────
+
+async function embed(text, dims = 768) {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:batchEmbedContents?key=${geminiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requests: [{
+          model: 'models/gemini-embedding-2-preview',
+          content: { parts: [{ text: text.slice(0, 8000) }] },
+          outputDimensionality: dims,
+        }],
+      }),
+      signal: AbortSignal.timeout(15000),
+    },
+  );
+  if (!res.ok) throw new Error(`embed ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return data.embeddings[0].values;
+}
+
+function cosine(a, b) {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+// ── Text compositions ────────────────────────────────────────────────
+
+function composeCurrent(book, indexData) {
+  // Mirrors enrich-worker.mjs:composeBookEmbeddingText
+  const parts = [];
+  parts.push(`${book.display_title || book.title || 'Untitled'} by ${book.author || 'Unknown'}`);
+  if (book.language) parts.push(`Language: ${book.language}`);
+  if (book.published) parts.push(`Published: ${book.published}`);
+  if (indexData?.bookSummary?.detailed) parts.push(indexData.bookSummary.detailed);
+  else if (indexData?.bookSummary?.brief) parts.push(indexData.bookSummary.brief);
+  if (indexData?.sectionSummaries?.length > 0) {
+    const sections = indexData.sectionSummaries.map(s => s.title || s.summary).filter(Boolean).slice(0, 15);
+    if (sections.length > 0) parts.push(`Chapters: ${sections.join('; ')}`);
+  }
+  if (indexData?.entries?.length > 0) {
+    const terms = indexData.entries.sort((a, b) => (b.pages?.length || 0) - (a.pages?.length || 0)).slice(0, 50).map(e => e.term);
+    parts.push(`Topics: ${terms.join(', ')}`);
+  }
+  if (indexData?.people?.length > 0) parts.push(`People: ${indexData.people.slice(0, 30).map(p => p.name).join(', ')}`);
+  if (indexData?.places?.length > 0) parts.push(`Places: ${indexData.places.slice(0, 20).map(p => p.name).join(', ')}`);
+  if (indexData?.concepts?.length > 0) parts.push(`Concepts: ${indexData.concepts.slice(0, 30).map(c => c.name).join(', ')}`);
+  if (book.categories?.length > 0) parts.push(`Categories: ${book.categories.join(', ')}`);
+  return parts.join('\n').slice(0, 8000);
+}
+
+function composeRich(book, indexData) {
+  // Start from current, add reading_summary + section summaries (with full
+  // summary text, not just title) + section quotes + themes.
+  const parts = [];
+  parts.push(`${book.display_title || book.title || 'Untitled'} by ${book.author || 'Unknown'}`);
+  if (book.language) parts.push(`Language: ${book.language}`);
+  if (book.published) parts.push(`Published: ${book.published}`);
+
+  // NEW: reading_summary — currently ignored by enrich-worker
+  if (book.reading_summary?.detailed) parts.push(book.reading_summary.detailed);
+  else if (book.reading_summary?.overview) parts.push(book.reading_summary.overview);
+  if (book.reading_summary?.themes?.length > 0) {
+    parts.push(`Themes: ${book.reading_summary.themes.join('; ')}`);
+  }
+
+  if (indexData?.bookSummary?.detailed) parts.push(indexData.bookSummary.detailed);
+
+  // NEW: full section summaries with summary text (not just titles)
+  if (indexData?.sectionSummaries?.length > 0) {
+    const sectionBlock = indexData.sectionSummaries
+      .map(s => `[${s.title || ''}] ${s.summary || ''}`)
+      .join('\n');
+    parts.push(sectionBlock);
+
+    // NEW: section quotes — curated passage text
+    const quotes = indexData.sectionSummaries
+      .flatMap(s => s.quotes || [])
+      .map(q => q.text)
+      .filter(Boolean);
+    if (quotes.length > 0) {
+      parts.push(`Quoted passages: ${quotes.join(' / ')}`);
+    }
+  }
+
+  if (indexData?.entries?.length > 0) {
+    const terms = indexData.entries.sort((a, b) => (b.pages?.length || 0) - (a.pages?.length || 0)).slice(0, 50).map(e => e.term);
+    parts.push(`Topics: ${terms.join(', ')}`);
+  }
+  if (indexData?.people?.length > 0) parts.push(`People: ${indexData.people.slice(0, 30).map(p => p.name).join(', ')}`);
+  if (indexData?.places?.length > 0) parts.push(`Places: ${indexData.places.slice(0, 20).map(p => p.name).join(', ')}`);
+  if (indexData?.concepts?.length > 0) parts.push(`Concepts: ${indexData.concepts.slice(0, 30).map(c => c.name).join(', ')}`);
+  if (book.categories?.length > 0) parts.push(`Categories: ${book.categories.join(', ')}`);
+  return parts.join('\n').slice(0, 8000);
+}
+
+async function composeRichWithRollup(book, indexData) {
+  const richBase = composeRich(book, indexData);
+
+  // Page summaries → LLM-condensed retrieval fingerprint.
+  const pageSummaries = (indexData?.pageSummaries || []).map(p => p.summary || '').filter(Boolean);
+  if (pageSummaries.length === 0) return richBase;
+
+  const pageBlock = pageSummaries.join('\n');
+  if (pageBlock.length < 400) {
+    return (richBase + '\n' + pageBlock).slice(0, 8000);
+  }
+
+  const prompt = `You are creating a retrieval fingerprint for a book. Below are page-level summaries.
+Condense them into a dense, retrieval-friendly representation of EVERYTHING distinctive
+the book contains: every named person, place, concept, technical term, comparison, example,
+and recurring metaphor. Prioritize specific vocabulary over generic description. List the
+distinctive terms and phrases that appear. Do NOT add interpretation or assessment. Output
+plain text, up to 600 words.
+
+PAGE SUMMARIES:
+${pageBlock.slice(0, 30000)}`;
+
+  const resp = await ai.models.generateContent({
+    model: 'gemini-3.1-flash-lite',
+    contents: prompt,
+    config: { temperature: 0.2 },
+  });
+  const condensed = resp.text?.trim() || '';
+  return (richBase + '\n\nContent fingerprint:\n' + condensed).slice(0, 8000);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  await mongo.connect();
+  const db = mongo.db('bookstore');
+
+  const book = await db.collection('books').findOne({ slug: TARGET_SLUG });
+  if (!book) {
+    console.error(`Book not found: ${TARGET_SLUG}`);
+    process.exit(1);
+  }
+  const indexData = await db.collection('book_indexes').findOne({ book_id: book.id });
+
+  console.log(`\nTarget: "${book.display_title || book.title}" by ${book.author}`);
+  console.log(`  pages: ${book.pages_translated}/${book.pages_count} translated`);
+  console.log(`  has reading_summary: ${!!book.reading_summary?.detailed}`);
+  console.log(`  has book_index: ${!!indexData}`);
+  console.log(`  has sectionSummaries: ${(indexData?.sectionSummaries?.length || 0) > 0}`);
+  console.log(`  has pageSummaries: ${(indexData?.pageSummaries?.length || 0) > 0} (${indexData?.pageSummaries?.length || 0} pages)`);
+
+  console.log('\nComposing text variants...');
+  const currentText = composeCurrent(book, indexData);
+  const richText = composeRich(book, indexData);
+  console.log('  Calling LLM for page-summary roll-up...');
+  const richRollupText = await composeRichWithRollup(book, indexData);
+
+  console.log(`\nText sizes:`);
+  console.log(`  current   : ${currentText.length} chars`);
+  console.log(`  rich      : ${richText.length} chars  (+${richText.length - currentText.length})`);
+  console.log(`  rich+llm  : ${richRollupText.length} chars`);
+
+  // Show what got added (rich - current diff, abbreviated)
+  console.log(`\n=== Sample of what RICH adds (first 600 chars new content) ===`);
+  // Find content in rich not in current
+  const newInRich = richText.split('\n').filter(line => !currentText.includes(line) && line.trim().length > 0).join('\n');
+  console.log(newInRich.slice(0, 600));
+
+  // Embed all three
+  console.log('\nEmbedding variants...');
+  const embCurrent = await embed(currentText);
+  const embRich = await embed(richText);
+  const embRichRollup = await embed(richRollupText);
+
+  // Get current production embedding for this book to verify our re-embed of "current" matches
+  const { data: prodRow } = await supabase
+    .from('book_embeddings')
+    .select('book_id, summary_text, embedding')
+    .eq('book_id', book.id)
+    .limit(1)
+    .single();
+  let productionMatch = null;
+  if (prodRow?.embedding) {
+    const prodEmb = JSON.parse(prodRow.embedding);
+    productionMatch = cosine(embCurrent, prodEmb);
+  }
+  console.log(`  Sanity: our 'current' recompute vs production embedding cosine = ${productionMatch?.toFixed(4) || 'n/a'}`);
+
+  // For each query, run the production semantic search and see where this book ranks,
+  // then compute cosine for each text variant
+  console.log('\n┌─ Per-query lift (cosine sim to target book) ────────────────────────────────┐');
+  console.log('│ query                              │ current │ rich   │ rich+llm │ prod-rank│');
+  console.log('├────────────────────────────────────┼─────────┼────────┼──────────┼──────────┤');
+
+  for (const query of QUERIES) {
+    const qEmb = await embed(query);
+    const cCurrent = cosine(qEmb, embCurrent);
+    const cRich = cosine(qEmb, embRich);
+    const cRichRollup = cosine(qEmb, embRichRollup);
+
+    // Where does this book rank in current production book_embeddings?
+    const { data: matches } = await supabase.rpc('match_books_semantic', {
+      query_embedding: JSON.stringify(qEmb),
+      match_threshold: 0.0,
+      match_count: 100,
+      filter_language: null,
+      filter_year_min: null,
+      filter_year_max: null,
+    });
+    const rank = (matches || []).findIndex(m => m.book_id === book.id);
+    const rankStr = rank === -1 ? '>100' : String(rank + 1);
+
+    const q = query.length > 36 ? query.slice(0, 33) + '...' : query.padEnd(36);
+    console.log(`│ ${q.padEnd(34)} │  ${cCurrent.toFixed(3)}  │ ${cRich.toFixed(3)}  │  ${cRichRollup.toFixed(3)}   │   ${rankStr.padEnd(6)} │`);
+  }
+  console.log('└──────────────────────────────────────────────────────────────────────────────┘');
+
+  await mongo.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/eval/librarian-search/golden-set.json
+++ b/scripts/eval/librarian-search/golden-set.json
@@ -1,0 +1,229 @@
+{
+  "description": "Librarian search evaluation — golden set. Hand-curated 2026-05-28. Each entry has a confidence tag; treat 'low' as diagnostic rather than ground truth.",
+  "match_rules": {
+    "book_slug": "Hit's book_slug must equal an expected entry. Multiple editions of the same work are listed separately — hitting any one of them counts.",
+    "page_min_max": "If set, the hit's page_number must fall in [page_min, page_max] inclusive. Allows tolerance for OCR/translation page shift. Omit for any-page-counts queries (most broad-themes and bibliographic)."
+  },
+  "queries": [
+    {
+      "id": "agrippa-natural-magic",
+      "query": "Agrippa on natural magic and planetary correspondences",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "henrici-cor-agrippae-ab-nettesheym-de-occvlta-philosophia-agrippa-von" },
+        { "book_slug": "three-books-of-occult-philosophy-1533-latin-agrippa" },
+        { "book_slug": "de-occulta-philosophia-complete-edition-agrippa" },
+        { "book_slug": "de-occulta-philosophia-libri-tres-agrippa" },
+        { "book_slug": "three-books-of-occult-philosophy-nettesheim" }
+      ],
+      "notes": "Several editions of Three Books of Occult Philosophy. Any is a hit."
+    },
+    {
+      "id": "bruno-art-of-memory",
+      "query": "Giordano Bruno on memory images and the art of memory",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "de-vmbris-idearvm-implicantibus-artem-quaerendi-inveniendi-bruno" },
+        { "book_slug": "iordani-bruni-nolani-de-imaginum-signorum-amp-idearum-bruno" }
+      ],
+      "notes": "Bruno's mnemonic / 'shadows of ideas' works. De infinito is not in the collection — this tests Bruno coverage we DO have."
+    },
+    {
+      "id": "ficino-spiritus-talismans",
+      "query": "Ficino on drawing down celestial spirits with talismans and music",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "three-books-on-life-1489-first-edition-ficino" },
+        { "book_slug": "three-books-on-life-ficino" },
+        { "book_slug": "three-books-on-life-ficino-2" },
+        { "book_slug": "de-vita-libri-tres-three-books-on-life-1529-ficino" },
+        { "book_slug": "three-books-on-life-ficino-3" }
+      ],
+      "notes": "De Vita Coelitus Comparanda (Book III of De Vita) is the canonical text on spiritus/talismans."
+    },
+    {
+      "id": "kepler-harmony-spheres",
+      "query": "Kepler on the harmony of the spheres and planetary music",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "harmonices-mundi-1619-first-edition-kepler" },
+        { "book_slug": "harmony-of-the-world-with-mysterium-cosmographicum-kepler" }
+      ]
+    },
+    {
+      "id": "fludd-macrocosm-microcosm",
+      "query": "Robert Fludd on the macrocosm and microcosm",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "history-of-the-macrocosm-and-microcosm-fludd" },
+        { "book_slug": "history-of-both-worlds-macrocosm-fludd" },
+        { "book_slug": "history-of-both-worlds-microcosm-fludd" },
+        { "book_slug": "utriusque-cosmi-maioris-scilicet-et-minoris-metaphysica-fludd" }
+      ]
+    },
+    {
+      "id": "paracelsus-archidoxes",
+      "query": "Paracelsus on the spagyric preparation of metals and the archidoxes",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "archidoxae-philippi-theophrasti-paracelsi-magni-germani-paracelsus" },
+        { "book_slug": "nobiblis-clarissimi-ac-probatissimi-philosophi-medici-dn-paracelsus" }
+      ],
+      "notes": "Two Archidoxes editions with full translation. The 0-translated ones excluded."
+    },
+    {
+      "id": "porta-natural-magic",
+      "query": "Della Porta on natural magic and the secrets of nature",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "magia-naturalis-libri-xx-1607-porta" },
+        { "book_slug": "magia-naturalis-1619-latin-porta" },
+        { "book_slug": "natural-magic-or-on-the-miracles-of-natural-things-porta" },
+        { "book_slug": "natural-magick-1658-english-porta" }
+      ]
+    },
+    {
+      "id": "kircher-magnetism",
+      "query": "magnetic experiments with iron and lodestone",
+      "category": "niche-passage",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "on-the-loadstone-and-magnetic-bodies-english-translation-gilbert" },
+        { "book_slug": "de-magnete-1600-first-edition-gilbert" },
+        { "book_slug": "de-magnete-magneticisque-corporibus-et-de-magno-magnete-gilbert" },
+        { "book_slug": "tractatus-sive-physiologia-nova-de-magnete-gilbert" },
+        { "book_slug": "magnes-sive-de-arte-magnetica-kircher" },
+        { "book_slug": "athanasii-kircheri-magnes-sive-de-arte-magnetica-opus-kircher" },
+        { "book_slug": "magneticum-naturae-regnum-kircher" },
+        { "book_slug": "athanasii-kircheri-magneticum-naturae-regnum-sive-kircher" },
+        { "book_slug": "athanasii-kircheri-ars-magnesia-hoc-est-disquisitio-kircher" }
+      ],
+      "notes": "Gilbert's De Magnete (1600, founding work) and Kircher's Magnes sive de Arte Magnetica (1641, canonical Kircher) are both legitimate answers. Multiple editions of each — any hit counts."
+    },
+    {
+      "id": "vesalius-anatomy-skull",
+      "query": "anatomy of the human skull and cranial sutures",
+      "category": "niche-passage",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "vesalius-de-humani-corporis-fabrica-1555-vesalius" },
+        { "book_slug": "de-humani-corporis-fabrica-1543-first-edition-vesalius" },
+        { "book_slug": "andreae-vesalii-bruxellensis-scholae-medicorum-patavinae-vesalius" },
+        { "book_slug": "de-re-anatomica-libri-xv-colombo" },
+        { "book_slug": "de-re-anatomica-libri-xv-1562-ed-colombo" },
+        { "book_slug": "opuscula-anatomica-eustachio" },
+        { "book_slug": "tabulae-anatomicae-eustachi" }
+      ],
+      "notes": "Vesalius's Fabrica (the canonical anatomy of the skull is in Book I) plus Colombo's De Re Anatomica (Vesalius's pupil/rival) and Eustachio's Tabulae (famous anatomical plates). Query has no author cue — tests broad semantic matching."
+    },
+    {
+      "id": "boehme-aurora",
+      "query": "the seven fountain spirits or properties of nature",
+      "category": "niche-passage",
+      "confidence": "medium",
+      "expected": [
+        { "book_slug": "aurora-or-the-day-spring-bohme" },
+        { "book_slug": "theosophia-revelata-aurora-oder-morgenrothe-vol-1-bohme" }
+      ],
+      "notes": "Boehme's seven Quellgeister doctrine — central to Aurora and his later works."
+    },
+    {
+      "id": "emerald-tablet",
+      "query": "as above so below — the Emerald Tablet of Hermes",
+      "category": "verbatim-quote",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "tabula-smaragdina-trismegistus" },
+        { "book_slug": "hermetis-trismegisti-phoenicum-aegyptorum-sed-et-aliarum-kriegsmann" }
+      ]
+    },
+    {
+      "id": "rosicrucian-manifestos",
+      "query": "Fama Fraternitatis brothers of the Rose Cross",
+      "category": "verbatim-quote",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "fama-fraternitatis-1615-danzig-attr" },
+        { "book_slug": "fama-fraternitatis-und-confessio-fraternitatis-rosicrucian" },
+        { "book_slug": "fama-fraternitatis-oder-entdeckung-der-bruderschafft-de-andrea" },
+        { "book_slug": "fama-fraternitatis-oder-entdeckung-der-brudersch-des-ordens-fraternitatis" }
+      ]
+    },
+    {
+      "id": "indian-rasa-alchemy",
+      "query": "Indian alchemy mercury rasa preparation",
+      "category": "cross-lingual",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "rasaratnasamuccaya-vagbhata" },
+        { "book_slug": "rasaratnakara-rasayanakhanda-acarya" },
+        { "book_slug": "rasaratnakara-manuscript-nagarjuna" }
+      ],
+      "notes": "Sanskrit Rasashastra texts. English query against English translations. Druze 'Rasa'il' and Ikhwan al-Safa 'Rasa'il' are false positives — different meaning of 'rasa'."
+    },
+    {
+      "id": "artemidorus-dreams",
+      "query": "dream interpretation in the ancient world",
+      "category": "broad-theme",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "oneirocritica-daldianus" },
+        { "book_slug": "artemidori-daldiani-achmetis-sereimi-f-oneirocritica-artemidorus" },
+        { "book_slug": "de-somniorum-interpretatione-libri-quinque-cornarius" },
+        { "book_slug": "de-somniorum-interpretatione-daldis" },
+        { "book_slug": "traumbuch-artemidori-darinnen-ursprung-unterscheid-und-artemidorus" }
+      ],
+      "notes": "Artemidorus's Oneirocritica — multiple editions. Macrobius (Commentary on the Dream of Scipio) would also count if present."
+    },
+    {
+      "id": "sympathetic-magic-renaissance",
+      "query": "sympathetic magic and occult virtues in nature",
+      "category": "broad-theme",
+      "confidence": "medium",
+      "expected": [
+        { "book_slug": "henrici-cor-agrippae-ab-nettesheym-de-occvlta-philosophia-agrippa-von" },
+        { "book_slug": "three-books-of-occult-philosophy-1533-latin-agrippa" },
+        { "book_slug": "three-books-of-occult-philosophy-nettesheim" },
+        { "book_slug": "magia-naturalis-libri-xx-1607-porta" },
+        { "book_slug": "magia-naturalis-1619-latin-porta" },
+        { "book_slug": "natural-magic-or-on-the-miracles-of-natural-things-porta" },
+        { "book_slug": "natural-magick-1658-english-porta" },
+        { "book_slug": "three-books-on-life-ficino" },
+        { "book_slug": "de-vita-libri-tres-three-books-on-life-1529-ficino" }
+      ],
+      "notes": "Agrippa, Della Porta, and Ficino are the canonical Renaissance sources. Hitting any one counts as recall. May score lower than other queries because there's no single 'right' book."
+    },
+    {
+      "id": "books-on-geomancy",
+      "query": "books about geomancy and divination by points",
+      "category": "bibliographic",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "fourth-book-of-occult-philosophy-pseudo-agrippa-with" },
+        { "book_slug": "agrippa-fourth-book-of-occult-philosophy-with-geomancy-cremonensis" },
+        { "book_slug": "fourth-book-of-occult-philosophy-arbatel-of-magick-peter-de-al" },
+        { "book_slug": "la-geomance-cattan" },
+        { "book_slug": "ramala-grantha-geomancy" }
+      ]
+    },
+    {
+      "id": "christian-cabala",
+      "query": "Christian cabala in the Renaissance",
+      "category": "bibliographic",
+      "confidence": "medium",
+      "expected": [
+        { "book_slug": "cabala-mirror-of-art-and-nature-in-alchemy-michelspacher-2" },
+        { "book_slug": "apologia-fratris-archangelus-de-burgonovo-pro-defensione-arcangelo" },
+        { "book_slug": "artis-cabalisticae-hoc-est-reconditae-theologiae-et-kabbala" }
+      ],
+      "notes": "Pico, Reuchlin, Kircher's Oedipus would also count if present. 'Cuaderno de las alcabalas' is a false positive (Spanish tax word, not Kabbalah)."
+    }
+  ]
+}

--- a/scripts/eval/librarian-search/metrics.mjs
+++ b/scripts/eval/librarian-search/metrics.mjs
@@ -1,0 +1,78 @@
+/**
+ * Retrieval metrics for the Librarian search eval.
+ *
+ * All functions take:
+ *   hits: ordered array of { book_slug, page_number } (best first)
+ *   expected: array of { book_slug, page_min?, page_max? }
+ *
+ * Match rule: hit matches an expected entry when the book_slug agrees AND
+ * (if page_min/page_max are set) the page_number falls within.
+ *
+ * The page-range tolerance exists because translations sometimes shift page
+ * numbering relative to the original (front matter, blank pages, plates), so
+ * pinning to an exact page would be too strict for most queries. Use exact
+ * pages only when the golden-set author is confident.
+ */
+
+export function matches(hit, expected) {
+  return expected.some(e => {
+    if (hit.book_slug !== e.book_slug) return false;
+    if (e.page_min != null && hit.page_number < e.page_min) return false;
+    if (e.page_max != null && hit.page_number > e.page_max) return false;
+    return true;
+  });
+}
+
+/**
+ * Precision@K: fraction of the top-K hits that are correct.
+ * If fewer than K hits are returned, divides by actual count (not K),
+ * so a variant returning 2 correct hits out of 2 scores 1.0, not 0.4.
+ */
+export function precisionAtK(hits, expected, k = 5) {
+  const top = hits.slice(0, k);
+  if (top.length === 0) return 0;
+  const correct = top.filter(h => matches(h, expected)).length;
+  return correct / top.length;
+}
+
+/**
+ * Recall@K: fraction of expected entries hit by at least one top-K hit.
+ * Counts distinct expected entries matched (so two hits in the same expected
+ * book/range count as one).
+ */
+export function recallAtK(hits, expected, k = 5) {
+  if (expected.length === 0) return 1; // nothing to recall = perfect
+  const top = hits.slice(0, k);
+  const matchedExpected = expected.filter(e =>
+    top.some(h => matches(h, [e])),
+  );
+  return matchedExpected.length / expected.length;
+}
+
+/**
+ * Mean Reciprocal Rank: 1 / rank of the first correct hit, 0 if none in top 20.
+ * A single-query MRR is just the reciprocal rank; the "mean" applies across the
+ * query set in the runner.
+ */
+export function reciprocalRank(hits, expected, maxRank = 20) {
+  for (let i = 0; i < Math.min(hits.length, maxRank); i++) {
+    if (matches(hits[i], expected)) return 1 / (i + 1);
+  }
+  return 0;
+}
+
+/** Aggregate per-variant metrics across a query set. */
+export function aggregate(perQueryResults) {
+  if (perQueryResults.length === 0) {
+    return { p5: 0, r5: 0, mrr: 0, p1: 0, count: 0 };
+  }
+  const sum = (key) => perQueryResults.reduce((s, r) => s + r[key], 0);
+  return {
+    count: perQueryResults.length,
+    p1: sum('p1') / perQueryResults.length,
+    p5: sum('p5') / perQueryResults.length,
+    r5: sum('r5') / perQueryResults.length,
+    mrr: sum('mrr') / perQueryResults.length,
+    avgLatencyMs: sum('latencyMs') / perQueryResults.length,
+  };
+}

--- a/scripts/eval/librarian-search/run.mjs
+++ b/scripts/eval/librarian-search/run.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Librarian search evaluation runner.
+ *
+ * Loads the golden set, runs each variant against each query, computes
+ * precision@5 / recall@5 / MRR per variant, prints a summary, and writes
+ * a JSON report to results/<timestamp>.json.
+ *
+ * Usage:
+ *   set -a; source ../../../../.env.production.local; set +a
+ *   node scripts/eval/librarian-search/run.mjs
+ *   node scripts/eval/librarian-search/run.mjs --variant=rrf
+ *   node scripts/eval/librarian-search/run.mjs --query=agrippa-planetary-seals
+ *   node scripts/eval/librarian-search/run.mjs --verbose
+ *   node scripts/eval/librarian-search/run.mjs --category=niche-passage
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+import { VARIANTS } from './variants.mjs';
+import { precisionAtK, recallAtK, reciprocalRank, aggregate } from './metrics.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── Arg parsing ───────────────────────────────────────────────────────
+
+function arg(name, def) {
+  const flag = `--${name}=`;
+  const found = process.argv.find(a => a.startsWith(flag));
+  return found ? found.slice(flag.length) : def;
+}
+function flag(name) {
+  return process.argv.includes(`--${name}`);
+}
+
+const wantedVariant = arg('variant', null);
+const wantedQuery = arg('query', null);
+const wantedCategory = arg('category', null);
+const verbose = flag('verbose');
+
+// ── Clients ───────────────────────────────────────────────────────────
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing env: ${name}. Source .env.production.local first.`);
+    process.exit(1);
+  }
+  return v;
+}
+
+const mongoUri = requireEnv('MONGODB_URI');
+const mongoDb = process.env.MONGODB_DB || 'bookstore';
+const supabaseUrl = requireEnv('SUPABASE_URL');
+const supabaseKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
+const geminiKey = requireEnv('GEMINI_API_KEY');
+
+const mongoClient = new MongoClient(mongoUri);
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+// ── Embedding fn (cached per query — many variants embed the same string) ──
+
+const embedCache = new Map();
+async function embedFn(text, dims = 768) {
+  const key = `${dims}:${text}`;
+  if (embedCache.has(key)) return embedCache.get(key);
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:batchEmbedContents?key=${geminiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requests: [{
+            model: 'models/gemini-embedding-2-preview',
+            content: { parts: [{ text }] },
+            outputDimensionality: dims,
+          }],
+        }),
+        signal: AbortSignal.timeout(10000),
+      },
+    );
+    if (!res.ok) {
+      console.error(`Embedding API ${res.status}: ${await res.text().then(t => t.slice(0, 200))}`);
+      embedCache.set(key, null);
+      return null;
+    }
+    const data = await res.json();
+    const vec = data?.embeddings?.[0]?.values || null;
+    embedCache.set(key, vec);
+    return vec;
+  } catch (err) {
+    console.error(`Embedding error: ${err.message}`);
+    embedCache.set(key, null);
+    return null;
+  }
+}
+
+// ── Runner ────────────────────────────────────────────────────────────
+
+async function runOne(variant, query, ctx) {
+  const start = Date.now();
+  let hits = [];
+  let error = null;
+  try {
+    hits = await variant.fn(query.query, ctx);
+  } catch (err) {
+    error = err.message;
+  }
+  const latencyMs = Date.now() - start;
+  const p1 = hits.length > 0 && (hits.slice(0, 1).filter(h => matchesAny(h, query.expected)).length > 0) ? 1 : 0;
+  return {
+    queryId: query.id,
+    queryText: query.query,
+    category: query.category,
+    confidence: query.confidence,
+    expected: query.expected,
+    hits,
+    error,
+    latencyMs,
+    p1,
+    p5: precisionAtK(hits, query.expected, 5),
+    r5: recallAtK(hits, query.expected, 5),
+    mrr: reciprocalRank(hits, query.expected, 20),
+  };
+}
+
+function matchesAny(hit, expected) {
+  return expected.some(e => {
+    if (hit.book_slug !== e.book_slug) return false;
+    if (e.page_min != null && hit.page_number < e.page_min) return false;
+    if (e.page_max != null && hit.page_number > e.page_max) return false;
+    return true;
+  });
+}
+
+async function main() {
+  // Load golden set
+  const goldenPath = path.join(__dirname, 'golden-set.json');
+  if (!fs.existsSync(goldenPath)) {
+    console.error(`Golden set not found at ${goldenPath}. Create it first.`);
+    process.exit(1);
+  }
+  const golden = JSON.parse(fs.readFileSync(goldenPath, 'utf8'));
+
+  // Filter queries
+  let queries = golden.queries;
+  if (wantedQuery) queries = queries.filter(q => q.id === wantedQuery);
+  if (wantedCategory) queries = queries.filter(q => q.category === wantedCategory);
+  if (queries.length === 0) {
+    console.error('No matching queries.');
+    process.exit(1);
+  }
+
+  // Filter variants
+  let variantEntries = Object.entries(VARIANTS);
+  if (wantedVariant) variantEntries = variantEntries.filter(([name]) => name === wantedVariant);
+  if (variantEntries.length === 0) {
+    console.error(`Unknown variant. Known: ${Object.keys(VARIANTS).join(', ')}`);
+    process.exit(1);
+  }
+
+  await mongoClient.connect();
+  const db = mongoClient.db(mongoDb);
+  const ctx = { db, supabase, embedFn };
+
+  console.log(`\nLibrarian Search Eval`);
+  console.log(`  Queries:  ${queries.length}${wantedQuery ? ` (filter: ${wantedQuery})` : ''}${wantedCategory ? ` (category: ${wantedCategory})` : ''}`);
+  console.log(`  Variants: ${variantEntries.map(([n]) => n).join(', ')}\n`);
+
+  const results = {}; // variantName → [perQueryResult]
+
+  for (const [variantName, variant] of variantEntries) {
+    process.stdout.write(`  ${variantName.padEnd(20)} `);
+    results[variantName] = [];
+    for (const query of queries) {
+      const r = await runOne(variant, query, ctx);
+      results[variantName].push(r);
+      process.stdout.write(r.error ? 'x' : (r.p1 ? '.' : (r.r5 > 0 ? 'o' : '-')));
+    }
+    process.stdout.write('\n');
+  }
+
+  // ── Summary table ───────────────────────────────────────────────────
+  console.log('\n┌─ Aggregate ─────────────────────────────────────────────────────────────┐');
+  console.log('│ Variant              │  P@1   │  P@5   │  R@5   │  MRR   │  avg ms       │');
+  console.log('├──────────────────────┼────────┼────────┼────────┼────────┼───────────────┤');
+  for (const [variantName] of variantEntries) {
+    const agg = aggregate(results[variantName]);
+    const fmt = n => n.toFixed(3);
+    const lat = String(Math.round(agg.avgLatencyMs)).padStart(6) + ' ms';
+    console.log(`│ ${variantName.padEnd(20)} │ ${fmt(agg.p1)}  │ ${fmt(agg.p5)}  │ ${fmt(agg.r5)}  │ ${fmt(agg.mrr)}  │ ${lat}        │`);
+  }
+  console.log('└─────────────────────────────────────────────────────────────────────────┘');
+
+  // ── Per-category breakdown ──────────────────────────────────────────
+  const categories = [...new Set(queries.map(q => q.category))];
+  if (categories.length > 1) {
+    console.log('\nBy category (R@5):');
+    process.stdout.write('  variant'.padEnd(22));
+    for (const cat of categories) process.stdout.write(cat.padEnd(20));
+    console.log();
+    for (const [variantName] of variantEntries) {
+      process.stdout.write(`  ${variantName.padEnd(20)}`);
+      for (const cat of categories) {
+        const inCat = results[variantName].filter(r => r.category === cat);
+        const r5 = aggregate(inCat).r5;
+        process.stdout.write(r5.toFixed(3).padEnd(20));
+      }
+      console.log();
+    }
+  }
+
+  // ── Verbose per-query dump ──────────────────────────────────────────
+  if (verbose) {
+    console.log('\nPer-query results:');
+    for (const query of queries) {
+      console.log(`\n  [${query.category}] ${query.id} — "${query.query}"`);
+      console.log(`    expected: ${query.expected.map(e => e.book_slug + (e.page_min ? `:${e.page_min}-${e.page_max}` : '')).join(', ')}`);
+      for (const [variantName] of variantEntries) {
+        const r = results[variantName].find(x => x.queryId === query.id);
+        const tag = r.error ? `ERROR: ${r.error}` : `r5=${r.r5.toFixed(2)} mrr=${r.mrr.toFixed(2)}`;
+        console.log(`    ${variantName.padEnd(20)} ${tag}`);
+        if (r.hits.length === 0) {
+          console.log(`      (no hits)`);
+        } else {
+          for (let i = 0; i < Math.min(r.hits.length, 5); i++) {
+            const h = r.hits[i];
+            const hit = matchesAny(h, query.expected) ? '✓' : ' ';
+            console.log(`      ${hit} ${i + 1}. ${h.book_slug || '<no-slug>'} p.${h.page_number} (${(h.score ?? 0).toFixed(3)}, ${h.source})`);
+          }
+        }
+      }
+    }
+  }
+
+  // ── Save report ─────────────────────────────────────────────────────
+  const resultsDir = path.join(__dirname, 'results');
+  fs.mkdirSync(resultsDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const reportPath = path.join(resultsDir, `${stamp}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify({
+    timestamp: new Date().toISOString(),
+    queryCount: queries.length,
+    variants: Object.fromEntries(variantEntries.map(([n, v]) => [n, v.description])),
+    aggregates: Object.fromEntries(Object.entries(results).map(([n, rs]) => [n, aggregate(rs)])),
+    perQuery: results,
+  }, null, 2));
+  console.log(`\nReport: ${path.relative(process.cwd(), reportPath)}`);
+
+  await mongoClient.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/eval/librarian-search/variants.mjs
+++ b/scripts/eval/librarian-search/variants.mjs
@@ -1,0 +1,283 @@
+/**
+ * Search variants under test.
+ *
+ * Each variant is `async (query, ctx) => SearchHit[]` where SearchHit is
+ *   { book_id, book_slug, page_number, snippet, score, source }
+ *
+ * ctx holds shared clients (`db`, `supabase`, `embedFn`) so variants don't
+ * each open their own connections.
+ *
+ * The Atlas $search stage shape and the Supabase RPC parameters are mirrored
+ * from `src/lib/atlas-search.ts` and `src/lib/semantic-search.ts`. Keep in
+ * sync if those change — the eval is meaningless if it tests something the
+ * Librarian doesn't actually run.
+ *
+ * Tenant filtering: the Librarian post-filters to main-site only (tenantId
+ * null/undefined). We do the same here so the eval reflects what main-site
+ * users actually see.
+ */
+
+const BOOK_SEARCH_INDEX = 'books_search';
+const PAGE_SEARCH_INDEX = 'pages_search';
+
+// ── Atlas keyword search (mirrors executeSearchCollection) ────────────
+
+function pageSearchStage(query) {
+  return {
+    $search: {
+      index: PAGE_SEARCH_INDEX,
+      compound: {
+        should: [
+          { text: { query, path: 'translation.data', score: { boost: { value: 2 } } } },
+          { text: { query, path: 'ocr.data' } },
+        ],
+        minimumShouldMatch: 1,
+      },
+    },
+  };
+}
+
+async function tenantVisibleBooks(db, bookIds) {
+  if (bookIds.length === 0) return new Map();
+  const docs = await db.collection('books')
+    .find({
+      id: { $in: bookIds },
+      hidden: { $ne: true },
+      tenantId: { $in: [null, undefined] },
+    })
+    .project({ id: 1, slug: 1, title: 1, display_title: 1, author: 1 })
+    .toArray();
+  return new Map(docs.map(d => [d.id, d]));
+}
+
+export async function keywordVariant(query, ctx, limit = 8) {
+  const pages = await ctx.db.collection('pages')
+    .aggregate([
+      pageSearchStage(query),
+      { $limit: 48 }, // over-fetch for tenant filtering
+      { $project: { book_id: 1, page_number: 1, 'translation.data': 1, score: { $meta: 'searchScore' } } },
+    ])
+    .toArray();
+
+  const bookIds = [...new Set(pages.map(p => p.book_id))];
+  const bookMap = await tenantVisibleBooks(ctx.db, bookIds);
+
+  // Cap at 2 hits per book to match the Librarian's behavior
+  const perBook = new Map();
+  const hits = [];
+  for (const p of pages) {
+    const book = bookMap.get(p.book_id);
+    if (!book) continue;
+    const count = perBook.get(p.book_id) || 0;
+    if (count >= 2) continue;
+    perBook.set(p.book_id, count + 1);
+    hits.push({
+      book_id: p.book_id,
+      book_slug: book.slug,
+      page_number: p.page_number,
+      snippet: (p.translation?.data || '').slice(0, 200),
+      score: p.score,
+      source: 'keyword',
+    });
+    if (hits.length >= limit) break;
+  }
+  return hits;
+}
+
+// ── Semantic two-step (mirrors executeSearchSemantic) ─────────────────
+
+async function bookThenPage(query, ctx, limit = 8) {
+  const embedding = await ctx.embedFn(query, 768);
+  if (!embedding) return [];
+
+  const { data: books, error: bookErr } = await ctx.supabase.rpc('match_books_semantic', {
+    query_embedding: JSON.stringify(embedding),
+    match_threshold: 0.3,
+    match_count: 24, // over-request for tenant filter
+    filter_language: null,
+    filter_year_min: null,
+    filter_year_max: null,
+  });
+  if (bookErr || !books?.length) return [];
+
+  const bookIds = books.map(b => b.book_id);
+  const bookMap = await tenantVisibleBooks(ctx.db, bookIds);
+  const visibleBookIds = bookIds.filter(id => bookMap.has(id));
+  if (!visibleBookIds.length) return [];
+
+  const { data: pages, error: pageErr } = await ctx.supabase.rpc('match_pages_in_books', {
+    query_embedding: JSON.stringify(embedding),
+    book_ids: visibleBookIds,
+    match_threshold: 0.3,
+    match_count: limit,
+  });
+  if (pageErr) return [];
+
+  // Keep best page per book, ordered by book similarity
+  const bestPageByBook = new Map();
+  for (const p of (pages || [])) {
+    const existing = bestPageByBook.get(p.book_id);
+    if (!existing || p.similarity > existing.similarity) {
+      bestPageByBook.set(p.book_id, p);
+    }
+  }
+
+  return books
+    .filter(b => bookMap.has(b.book_id))
+    .slice(0, limit)
+    .map(b => {
+      const page = bestPageByBook.get(b.book_id);
+      const book = bookMap.get(b.book_id);
+      return {
+        book_id: b.book_id,
+        book_slug: book.slug,
+        page_number: page?.page_number || 0,
+        snippet: (page?.translation || b.summary_text || '').slice(0, 200),
+        score: b.similarity,
+        source: 'book-then-page',
+      };
+    });
+}
+
+export async function bookThenPageVariant(query, ctx, limit = 8) {
+  return bookThenPage(query, ctx, limit);
+}
+
+// ── Global page-level semantic (the path the Librarian doesn't use) ───
+
+async function globalPage(query, ctx, limit = 8) {
+  const embedding = await ctx.embedFn(query, 768);
+  if (!embedding) return [];
+
+  const { data, error } = await ctx.supabase.rpc('match_semantic', {
+    query_embedding: JSON.stringify(embedding),
+    match_threshold: 0.3,
+    match_count: 24, // over-request for tenant filter + per-book cap
+    filter_tenant_id: null,
+    filter_language: null,
+    filter_year_min: null,
+    filter_year_max: null,
+    filter_languages: null,
+    filter_exclude_languages: null,
+  });
+  if (error || !data?.length) return [];
+
+  const bookIds = [...new Set(data.map(r => r.book_id))];
+  const bookMap = await tenantVisibleBooks(ctx.db, bookIds);
+
+  // Cap at 2 per book like the keyword path
+  const perBook = new Map();
+  const hits = [];
+  for (const r of data) {
+    const book = bookMap.get(r.book_id);
+    if (!book) continue;
+    const count = perBook.get(r.book_id) || 0;
+    if (count >= 2) continue;
+    perBook.set(r.book_id, count + 1);
+    hits.push({
+      book_id: r.book_id,
+      book_slug: book.slug,
+      page_number: r.page_number,
+      snippet: (r.translation || '').slice(0, 200),
+      score: r.similarity,
+      source: 'global-page',
+    });
+    if (hits.length >= limit) break;
+  }
+  return hits;
+}
+
+export async function globalPageVariant(query, ctx, limit = 8) {
+  return globalPage(query, ctx, limit);
+}
+
+// ── Auto-fallback: book-then-page, fall back to global if weak ────────
+
+export async function autoFallbackVariant(query, ctx, limit = 8) {
+  const primary = await bookThenPage(query, ctx, limit);
+  // "Weak" = 0 results OR top result similarity < 0.5
+  const isWeak = primary.length === 0 || (primary[0].score ?? 0) < 0.5;
+  if (!isWeak) return primary;
+
+  const fallback = await globalPage(query, ctx, limit);
+  if (primary.length === 0) return fallback;
+
+  // Merge primary first, then fill with fallback hits not already represented
+  const seen = new Set(primary.map(h => `${h.book_id}:${h.page_number}`));
+  const merged = [...primary];
+  for (const h of fallback) {
+    const key = `${h.book_id}:${h.page_number}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ ...h, source: 'global-page (fallback)' });
+    if (merged.length >= limit) break;
+  }
+  return merged;
+}
+
+// ── RRF merge: keyword + book-then-page + global-page ─────────────────
+
+/**
+ * Reciprocal Rank Fusion. Each source contributes 1/(k+rank) per hit;
+ * scores summed across sources. k=60 is the canonical default from the
+ * Cormack/Clarke/Buettcher 2009 paper; lower k weights top results more.
+ */
+function rrfMerge(rankedLists, k = 60, limit = 8) {
+  const scores = new Map(); // key → {hit, score}
+  for (const list of rankedLists) {
+    for (let i = 0; i < list.length; i++) {
+      const hit = list[i];
+      const key = `${hit.book_id}:${hit.page_number}`;
+      const contribution = 1 / (k + i + 1);
+      const existing = scores.get(key);
+      if (existing) {
+        existing.score += contribution;
+        // Prefer the hit with the longer snippet for downstream display
+        if ((hit.snippet?.length || 0) > (existing.hit.snippet?.length || 0)) {
+          existing.hit = { ...hit, source: `rrf(${existing.hit.source}+${hit.source})` };
+        }
+      } else {
+        scores.set(key, { hit, score: contribution });
+      }
+    }
+  }
+  return [...scores.values()]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ hit, score }) => ({ ...hit, score, source: hit.source.startsWith('rrf') ? hit.source : `rrf(${hit.source})` }));
+}
+
+export async function rrfVariant(query, ctx, limit = 8) {
+  // Over-fetch from each source so the merge has material to rank
+  const [kw, btp, gp] = await Promise.all([
+    keywordVariant(query, ctx, 20),
+    bookThenPageVariant(query, ctx, 20),
+    globalPageVariant(query, ctx, 20),
+  ]);
+  return rrfMerge([kw, btp, gp], 60, limit);
+}
+
+// ── Variant registry ──────────────────────────────────────────────────
+
+export const VARIANTS = {
+  'keyword': {
+    description: 'Atlas keyword search only (current search_collection)',
+    fn: keywordVariant,
+  },
+  'book-then-page': {
+    description: 'Semantic book discovery → page drill-down (current search_semantic)',
+    fn: bookThenPageVariant,
+  },
+  'global-page': {
+    description: 'Global page-level semantic search (not currently used by Librarian)',
+    fn: globalPageVariant,
+  },
+  'auto-fallback': {
+    description: 'book-then-page; fall back to global-page if weak',
+    fn: autoFallbackVariant,
+  },
+  'rrf': {
+    description: 'Reciprocal Rank Fusion of keyword + book-then-page + global-page',
+    fn: rrfVariant,
+  },
+};

--- a/scripts/eval/librarian-search/variants.mjs
+++ b/scripts/eval/librarian-search/variants.mjs
@@ -257,6 +257,52 @@ export async function rrfVariant(query, ctx, limit = 8) {
   return rrfMerge([kw, btp, gp], 60, limit);
 }
 
+// Tuned RRF — k=20 (closer to 1/rank than 1/(60+rank)) weights top-of-source
+// hits more strongly. Hypothesis: with only 3 sources, k=60 over-smooths and
+// the strong rank-1 hit from one source loses to mediocre rank-1 hits from
+// the other two. Lower k should preserve "this source loves this hit" signal.
+export async function rrfTunedVariant(query, ctx, limit = 8) {
+  const [kw, btp, gp] = await Promise.all([
+    keywordVariant(query, ctx, 20),
+    bookThenPageVariant(query, ctx, 20),
+    globalPageVariant(query, ctx, 20),
+  ]);
+  return rrfMerge([kw, btp, gp], 20, limit);
+}
+
+// Hybrid with auto-fallback floor: take RRF top-N. If R@5 would be 0 because
+// the merged top has no strong signal, fall back to the source that had the
+// strongest rank-1 candidate. This is the "graceful degradation" path —
+// don't return a confidently-wrong result when no source agrees.
+export async function rrfWithFloorVariant(query, ctx, limit = 8) {
+  const [kw, btp, gp] = await Promise.all([
+    keywordVariant(query, ctx, 20),
+    bookThenPageVariant(query, ctx, 20),
+    globalPageVariant(query, ctx, 20),
+  ]);
+  const merged = rrfMerge([kw, btp, gp], 20, limit);
+  // If RRF produced very few results, supplement with the strongest single source.
+  if (merged.length >= 3) return merged;
+  const sources = [
+    { name: 'btp', list: btp },
+    { name: 'kw', list: kw },
+    { name: 'gp', list: gp },
+  ];
+  const strongest = sources.reduce((best, s) => {
+    const topScore = s.list[0]?.score ?? 0;
+    return topScore > (best.list[0]?.score ?? 0) ? s : best;
+  }, sources[0]);
+  const seen = new Set(merged.map(h => `${h.book_id}:${h.page_number}`));
+  for (const h of strongest.list) {
+    const key = `${h.book_id}:${h.page_number}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ ...h, source: `${h.source} (floor:${strongest.name})` });
+    if (merged.length >= limit) break;
+  }
+  return merged;
+}
+
 // ── Variant registry ──────────────────────────────────────────────────
 
 export const VARIANTS = {
@@ -277,7 +323,15 @@ export const VARIANTS = {
     fn: autoFallbackVariant,
   },
   'rrf': {
-    description: 'Reciprocal Rank Fusion of keyword + book-then-page + global-page',
+    description: 'Reciprocal Rank Fusion of keyword + book-then-page + global-page (k=60)',
     fn: rrfVariant,
+  },
+  'rrf-tuned': {
+    description: 'RRF with k=20 — weights top-of-source hits more strongly',
+    fn: rrfTunedVariant,
+  },
+  'rrf-floor': {
+    description: 'RRF k=20 with graceful fallback to strongest single source',
+    fn: rrfWithFloorVariant,
   },
 };

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -1,6 +1,7 @@
 import { getDb } from '@/lib/mongodb';
 import { GoogleGenAI, Type, type FunctionDeclaration } from '@google/genai';
-import { buildBookSearchStage, buildPageSearchStage } from '@/lib/atlas-search';
+// Atlas keyword + Supabase semantic are now combined in @/lib/search/librarian-search.
+// Atlas-search builders no longer imported here directly.
 import { supabase } from '@/lib/supabase';
 import { ObjectId } from 'mongodb';
 import { stripAnnotations } from '@/lib/semantic-alignment';
@@ -13,11 +14,14 @@ import { stripAnnotations } from '@/lib/semantic-alignment';
  * and builds up a persistent research notebook across the conversation.
  *
  * Tools:
- *   - search_collection: Atlas Search on books + pages (keyword)
- *   - search_semantic: pgvector hybrid search on Supabase (conceptual)
+ *   - search: Hybrid keyword + semantic via RRF (replaces the prior
+ *             search_collection and search_semantic; both old names accepted
+ *             as aliases for one release)
  *   - search_wikipedia: Wikipedia REST API for context
  *   - get_book_page: Read a specific translated page
  *   - read_nearby_pages: Read a range of pages around a finding
+ *   - search_images: CLIP visual search over the gallery (with health probe)
+ *   - search_artworks: Semantic search over standalone artworks
  *   - add_to_notebook: Save a finding to the persistent research notebook
  *   - present_choices: Offer branching options (rarely used)
  */
@@ -121,24 +125,12 @@ function formatNotebookForPrompt(notebook: ResearchNotebook | null): string {
 
 const TOOL_DECLARATIONS: FunctionDeclaration[] = [
   {
-    name: 'search_collection',
-    description: 'Search Source Library\'s collection of rare books by keyword. Searches English translations (boosted 2x) and original language text (Latin, German, French, etc). Search in English for best coverage — nearly all books are translated. Returns matching passages with book metadata and page numbers.',
+    name: 'search',
+    description: 'Search Source Library — fuses keyword search (Atlas) with semantic search (AI embeddings) across the collection. Returns the strongest matching passages plus relevant books. Works for both verbatim queries (Latin/German phrases, technical terms) and conceptual queries (modern paraphrases of historical ideas). Search in English for best coverage — nearly all books are translated.',
     parameters: {
       type: Type.OBJECT,
       properties: {
-        query: { type: Type.STRING, description: 'Search query — use period-appropriate terms (e.g., "sympathetic magic" not "resonance", "flying ointment" not "psychedelics")' },
-        search_books: { type: Type.BOOLEAN, description: 'Also search book titles/authors (default true)' },
-      },
-      required: ['query'],
-    },
-  },
-  {
-    name: 'search_semantic',
-    description: 'Semantic/conceptual search across all translated pages using AI embeddings. This is the best tool for finding passages about a concept when you don\'t know the exact words used — it searches by meaning, not keywords. Works across all languages because it searches English translations. Use for broad conceptual queries or when keyword search misses.',
-    parameters: {
-      type: Type.OBJECT,
-      properties: {
-        query: { type: Type.STRING, description: 'Conceptual query — can be modern language, the embedding model handles the mapping' },
+        query: { type: Type.STRING, description: 'Search query — use period-appropriate terms when known (e.g., "sympathetic magic" not "resonance", "flying ointment" not "psychedelics"). Modern paraphrases also work — semantic matching handles the mapping.' },
       },
       required: ['query'],
     },
@@ -269,135 +261,21 @@ function tenantVisibilityFilter() {
 
 // ── Tool Execution ────────────────────────────────────────────────────
 
-async function executeSearchCollection(query: string, searchBooks = true): Promise<{
-  passages: Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; text: string }>;
+// Hybrid search — combines Atlas keyword + book-then-page semantic + global-page
+// semantic via RRF, optionally cross-encoder reranks. See src/lib/search/
+// librarian-search.ts for the implementation and the eval that supports the
+// design (scripts/eval/librarian-search/).
+//
+// Replaces the prior executeSearchCollection (keyword-only) and
+// executeSearchSemantic (book-then-page only) with a single unified path.
+async function executeSearch(query: string): Promise<{
+  passages: Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; text: string; score: number; source: string }>;
   books: Array<{ id: string; title: string; author?: string; year?: number; slug?: string }>;
 }> {
-  const db = await getDb();
-  const visibilityFilter = tenantVisibilityFilter();
-
-  const searchStage = buildPageSearchStage(query);
-  // Over-fetch so post-filtering for tenant scope still yields enough passages.
-  const pages = await db.collection('pages')
-    .aggregate([
-      searchStage,
-      { $limit: 48 },
-      { $project: { book_id: 1, page_number: 1, 'translation.data': 1, score: { $meta: 'searchScore' } } },
-    ])
-    .toArray();
-
-  // Look up the books referenced by page hits and drop any pages whose book
-  // is hidden or belongs to another tenant.
-  const pageBookIds = [...new Set(pages.map(p => p.book_id))];
-  const visibleBookDocs = pageBookIds.length > 0
-    ? await db.collection('books')
-        .find({ id: { $in: pageBookIds }, ...visibilityFilter })
-        .project({ id: 1, title: 1, display_title: 1, author: 1, year: 1, slug: 1 })
-        .toArray()
-    : [];
-  const bookMap = new Map(visibleBookDocs.map(b => [b.id, b]));
-
-  const perBook = new Map<string, number>();
-  const deduped = pages
-    .filter(p => bookMap.has(p.book_id))
-    .filter(p => {
-      const count = perBook.get(p.book_id) || 0;
-      if (count >= 2) return false;
-      perBook.set(p.book_id, count + 1);
-      return true;
-    })
-    .slice(0, 8);
-
-  const passages = deduped.map(page => {
-    const book = bookMap.get(page.book_id);
-    const rawText = page.translation?.data || '';
-    const text = rawText
-      .replace(/\[\[[^\]]+\]\]/g, '')
-      .replace(/^```(?:markdown)?\s*\n?/i, '')
-      .replace(/\n?```\s*$/i, '')
-      .trim()
-      .slice(0, 1200);
-    return {
-      book_id: page.book_id,
-      bookTitle: book?.display_title || book?.title || 'Unknown',
-      bookAuthor: book?.author || 'Unknown',
-      bookSlug: book?.slug,
-      page_number: page.page_number,
-      text,
-    };
-  });
-
-  let books: Array<{ id: string; title: string; author?: string; year?: number; slug?: string }> = [];
-  if (searchBooks) {
-    const bookSearchStage = buildBookSearchStage(query, { hasTranslation: true }, { fuzzy: true });
-    const bookResults = await db.collection('books')
-      .aggregate([
-        bookSearchStage,
-        { $match: visibilityFilter },
-        { $limit: 5 },
-        { $project: { id: 1, title: 1, display_title: 1, author: 1, year: 1, slug: 1 } },
-      ])
-      .toArray();
-    books = bookResults.map(b => ({ id: b.id, title: b.display_title || b.title, author: b.author, year: b.year, slug: b.slug }));
-  }
-
+  const { hybridSearch } = await import('@/lib/search/librarian-search');
+  // Main-site only; pass tenant UUID here for per-tenant Librarian instances.
+  const { passages, books } = await hybridSearch(query, { tenantId: null });
   return { passages, books };
-}
-
-async function executeSearchSemantic(query: string): Promise<
-  Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; snippet: string; score: number }>
-> {
-  // Two-step search (issue #1158):
-  // Step 1: book discovery via book_embeddings (HNSW, ~17K vectors, instant)
-  // Step 2: page drill-down via match_pages_in_books (scoped to found books)
-  // Tenant filtering happens post-search via the visibility map below — the
-  // Supabase RPCs don't carry tenant filters (see audit doc).
-  const { semanticBookSearch, semanticPageSearchScoped } = await import('@/lib/semantic-search');
-  try {
-    // Over-fetch to absorb tenant filtering without starving the result set.
-    const books = await semanticBookSearch(query, 24);
-    if (books.length === 0) return [];
-
-    const bookIds = books.map(b => b.book_id);
-
-    // Resolve which of those book IDs belong to the main-site tenant scope
-    // AND aren't hidden. This drops Bhutan/BPH/etc. books that the embedding
-    // RPC happily returned without any tenant awareness.
-    const db = await getDb();
-    const visibleDocs = await db.collection('books')
-      .find({ id: { $in: bookIds }, ...tenantVisibilityFilter() })
-      .project({ id: 1, slug: 1 })
-      .toArray();
-    const visibleMap = new Map(visibleDocs.map(d => [d.id, d.slug]));
-    const visibleBookIds = bookIds.filter(id => visibleMap.has(id));
-    if (visibleBookIds.length === 0) return [];
-
-    const pages = await semanticPageSearchScoped(query, visibleBookIds, 8);
-
-    const bestPageByBook = new Map<string, typeof pages[0]>();
-    for (const p of pages) {
-      const existing = bestPageByBook.get(p.book_id);
-      if (!existing || p.score > existing.score) bestPageByBook.set(p.book_id, p);
-    }
-
-    return books
-      .filter(b => visibleMap.has(b.book_id))
-      .slice(0, 8)
-      .map(b => {
-        const page = bestPageByBook.get(b.book_id);
-        return {
-          book_id: b.book_id,
-          bookTitle: b.title || 'Unknown',
-          bookAuthor: b.author || 'Unknown',
-          bookSlug: visibleMap.get(b.book_id),
-          page_number: page?.page_number || 0,
-          snippet: stripAnnotations(page?.snippet || (b.summary_text || '').slice(0, 500)),
-          score: b.similarity,
-        };
-      });
-  } catch {
-    return [];
-  }
 }
 
 async function executeSearchWikipedia(query: string): Promise<{ title: string; summary: string; url: string } | null> {
@@ -549,10 +427,14 @@ async function executeTool(
   threadId?: string,
 ): Promise<{ result: unknown; step: LibrarianStep; sources?: SourceCard[] }> {
   switch (name) {
-    case 'search_collection': {
+    case 'search':
+    // Aliases — accept old tool names for one release to avoid breakage if
+    // an in-flight Librarian conversation calls the prior tools. Both
+    // collapse to the same hybrid implementation.
+    case 'search_collection':
+    case 'search_semantic': {
       const query = args.query as string;
-      const searchBooks = args.search_books !== false;
-      const data = await executeSearchCollection(query, searchBooks);
+      const data = await executeSearch(query);
       const totalFound = data.passages.length + data.books.length;
 
       let context = '';
@@ -578,32 +460,8 @@ async function executeTool(
 
       return {
         result: { found: totalFound, context },
-        step: { type: 'tool_result', name: 'search_collection', query, found: totalFound,
+        step: { type: 'tool_result', name: 'search', query, found: totalFound,
           summary: totalFound > 0 ? `Found ${data.passages.length} passages across ${data.books.length} books` : 'No results' },
-        sources,
-      };
-    }
-
-    case 'search_semantic': {
-      const query = args.query as string;
-      const results = await executeSearchSemantic(query);
-      let context = results.length > 0 ? 'Semantic search results:\n' : 'No semantic matches found.';
-      for (const r of results) {
-        const url = r.bookSlug
-          ? `https://sourcelibrary.org/book/${r.bookSlug}${r.page_number ? `/page-number/${r.page_number}` : ''}`
-          : '';
-        context += `\n--- ${r.bookTitle} by ${r.bookAuthor}, Page ${r.page_number}${url ? ` (${url})` : ''} ---\n${r.snippet}\n`;
-      }
-
-      const sources: SourceCard[] = results.map(r => ({
-        book_id: r.book_id, bookTitle: r.bookTitle, bookAuthor: r.bookAuthor, bookSlug: r.bookSlug,
-        pageNumber: r.page_number, snippet: stripAnnotations(r.snippet).slice(0, 200), inCollection: true,
-      }));
-
-      return {
-        result: { found: results.length, context },
-        step: { type: 'tool_result', name: 'search_semantic', query, found: results.length,
-          summary: results.length > 0 ? `Found ${results.length} conceptually related passages` : 'No semantic matches' },
         sources,
       };
     }
@@ -799,7 +657,7 @@ Examples where choices would just slow things down — search directly:
 - User clicked a choice from a previous message → search on that angle
 
 **Step 4: Deep, focused research.**
-Once you have a direction (from a choice or a specific question), search strategically. The collection includes books in Latin, German, French, Dutch, Hebrew, Sanskrit, Arabic, Greek, and more — nearly all translated into English. **Search in English first.** Use search_collection for keywords, search_semantic for concepts, search_wikipedia for context. When you find something promising, use read_nearby_pages for more context. Follow threads across books.
+Once you have a direction (from a choice or a specific question), search strategically. The collection includes books in Latin, German, French, Dutch, Hebrew, Sanskrit, Arabic, Greek, and more — nearly all translated into English. **Search in English first.** Use the **search** tool for everything text-based — it fuses keyword and semantic matching so you don't have to choose between them. Use search_wikipedia for outside context. When you find something promising, use read_nearby_pages for more context. Follow threads across books.
 
 For visual or symbolic topics (emblems, alchemical apparatus, diagrams, seals, planetary symbols, anatomical illustrations), proactively call search_images (for illustrations extracted from book pages) or search_artworks (for standalone museum artworks — paintings, prints, sculptures from Met, Rijksmuseum, Wikimedia Commons). The collection includes 23,000+ artworks spanning all cultures and periods. search_artworks supports filtering by genre, period, culture, and collection. Use it when users ask about visual art, specific artists, or when showing a painting/print would contextualize a text.
 

--- a/src/lib/search/librarian-search.ts
+++ b/src/lib/search/librarian-search.ts
@@ -1,0 +1,374 @@
+/**
+ * Hybrid search for the Librarian — fuses Atlas keyword, book-then-page
+ * semantic, and global-page semantic via Reciprocal Rank Fusion.
+ *
+ * Eval (scripts/eval/librarian-search/): RRF beats single-path search on
+ * P@1, P@5, MRR. Niche-passage R@5 nearly doubles (the Boehme case where
+ * keyword finds "fountain spirits" verbatim while semantic whiffs because
+ * the book embedding has no signal for that term). Verbatim-quote regresses
+ * — semantic alone is better when the user types the book's distinctive
+ * vocabulary — but the aggregate wins outweigh that case.
+ *
+ * Optional cross-encoder rerank: if COHERE_API_KEY or VOYAGE_API_KEY is set,
+ * reranks the top candidates. No-op (skipped silently) when neither is set.
+ */
+
+import { getDb } from '@/lib/mongodb';
+import { supabase } from '@/lib/supabase';
+import {
+  semanticBookSearch,
+  semanticPageSearchScoped,
+  semanticPageSearchGlobal,
+} from '@/lib/semantic-search';
+import { buildBookSearchStage, buildPageSearchStage } from '@/lib/atlas-search';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface SearchPassage {
+  book_id: string;
+  bookTitle: string;
+  bookAuthor: string;
+  bookSlug?: string;
+  page_number: number;
+  text: string;
+  score: number;
+  source: string; // 'kw' | 'btp' | 'gp' | 'rrf(...)' — for diagnostics + UI
+}
+
+export interface SearchBook {
+  id: string;
+  title: string;
+  author?: string;
+  year?: number;
+  slug?: string;
+}
+
+export interface HybridSearchResult {
+  passages: SearchPassage[];
+  books: SearchBook[];
+}
+
+export interface HybridSearchOptions {
+  /** Tenant scope. NULL/undefined = main-site (rows with tenant_id IS NULL). */
+  tenantId?: string | null;
+  /** Max passages to return (default 8). */
+  limit?: number;
+  /** Max book-level results in `books` (default 5). */
+  bookLimit?: number;
+}
+
+// ── Tenant visibility (Mongo book metadata enrichment) ───────────────
+
+function tenantBookFilter(tenantId: string | null | undefined) {
+  return {
+    hidden: { $ne: true },
+    // Main-site convention: tenantId null/undefined.
+    // For specific tenants, equality.
+    ...(tenantId
+      ? { tenantId }
+      : { tenantId: { $in: [null, undefined] } }),
+  };
+}
+
+// ── Source 1: Atlas keyword (mirrors executeSearchCollection's stage) ─
+
+interface RawHit {
+  book_id: string;
+  page_number: number;
+  text: string;
+  score: number;
+  source: string;
+}
+
+async function keywordSource(query: string, _opts: HybridSearchOptions): Promise<RawHit[]> {
+  const db = await getDb();
+  const searchStage = buildPageSearchStage(query);
+  const rows = await db.collection('pages')
+    .aggregate([
+      searchStage,
+      { $limit: 48 },
+      { $project: { book_id: 1, page_number: 1, 'translation.data': 1, score: { $meta: 'searchScore' } } },
+    ])
+    .toArray();
+
+  // Cap at 2 hits per book — keeps source-diversity in the merge.
+  const perBook = new Map<string, number>();
+  const out: RawHit[] = [];
+  for (const r of rows) {
+    const n = (perBook.get(r.book_id) || 0) + 1;
+    if (n > 2) continue;
+    perBook.set(r.book_id, n);
+    const raw = r.translation?.data || '';
+    out.push({
+      book_id: r.book_id,
+      page_number: r.page_number,
+      text: raw.slice(0, 1200),
+      score: r.score,
+      source: 'kw',
+    });
+    if (out.length >= 20) break;
+  }
+  return out;
+}
+
+// ── Source 2: book-then-page (book discovery → page drill-down) ──────
+
+async function bookThenPageSource(query: string, opts: HybridSearchOptions): Promise<RawHit[]> {
+  // semanticBookSearch on main typed as tenantId?: string; PR C extends to
+  // accept null. Until C lands, convert null → undefined at the boundary.
+  // semanticPageSearchScoped on main doesn't accept tenant opts — drop it.
+  // Tenant scoping still happens via the Mongo book-metadata join below the
+  // RRF merge, so a stray tenant page can't survive into the final passages.
+  const tenantId = opts.tenantId ?? undefined;
+  try {
+    const books = await semanticBookSearch(query, 12, { tenantId });
+    if (books.length === 0) return [];
+    const bookIds = books.map(b => b.book_id);
+    const pages = await semanticPageSearchScoped(query, bookIds, 20);
+    return pages.map(p => ({
+      book_id: p.book_id,
+      page_number: p.page_number,
+      text: p.snippet,
+      score: p.score,
+      source: 'btp',
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// ── Source 3: global page semantic ───────────────────────────────────
+
+async function globalPageSource(query: string, opts: HybridSearchOptions): Promise<RawHit[]> {
+  // semanticPageSearchGlobal accepts tenantId in its opts already (main).
+  // Convert null → undefined for type compat; the RPC still defaults to NULL.
+  const tenantId = opts.tenantId ?? undefined;
+  try {
+    const pages = await semanticPageSearchGlobal(query, 20, { tenantId, maxPerBook: 2 });
+    return pages.map(p => ({
+      book_id: p.book_id,
+      page_number: p.page_number,
+      text: p.snippet,
+      score: p.score,
+      source: 'gp',
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// ── RRF merge ────────────────────────────────────────────────────────
+
+/**
+ * Reciprocal Rank Fusion (Cormack/Clarke/Buettcher 2009).
+ * Each source contributes 1/(k + rank) per hit; scores summed across sources.
+ * k=60 is the canonical default. Eval showed k=20 vs k=60 produce identical
+ * rankings on the current golden set — stick with 60 for posterity.
+ */
+function rrfMerge(rankedLists: RawHit[][], k = 60): RawHit[] {
+  const scores = new Map<string, { hit: RawHit; score: number; sources: Set<string> }>();
+  for (const list of rankedLists) {
+    for (let i = 0; i < list.length; i++) {
+      const hit = list[i];
+      const key = `${hit.book_id}:${hit.page_number}`;
+      const contribution = 1 / (k + i + 1);
+      const existing = scores.get(key);
+      if (existing) {
+        existing.score += contribution;
+        existing.sources.add(hit.source);
+        // Prefer the hit with longer text for downstream display
+        if ((hit.text?.length || 0) > (existing.hit.text?.length || 0)) {
+          existing.hit = hit;
+        }
+      } else {
+        scores.set(key, { hit, score: contribution, sources: new Set([hit.source]) });
+      }
+    }
+  }
+  return [...scores.values()]
+    .sort((a, b) => b.score - a.score)
+    .map(({ hit, score, sources }) => ({
+      ...hit,
+      score,
+      source: sources.size > 1 ? `rrf(${[...sources].join('+')})` : `rrf(${hit.source})`,
+    }));
+}
+
+// ── Optional rerank ──────────────────────────────────────────────────
+
+/**
+ * Optional cross-encoder rerank. Activates only if COHERE_API_KEY or
+ * VOYAGE_API_KEY is set. No-op silently otherwise. We pass query + snippet
+ * text to the rerank API and reorder the top candidates by relevance score.
+ *
+ * Cost: ~$0.001 per query at typical rerank pricing. Latency: 100-200ms.
+ *
+ * Cohere rerank-3.5 returns indexed results with relevance_score in [0,1].
+ * Voyage rerank-2 has the same shape.
+ */
+async function maybeRerank(query: string, hits: RawHit[]): Promise<RawHit[]> {
+  const cohereKey = process.env.COHERE_API_KEY;
+  const voyageKey = process.env.VOYAGE_API_KEY;
+  if (!cohereKey && !voyageKey) return hits;
+  if (hits.length < 2) return hits;
+
+  const docs = hits.slice(0, 20).map(h => h.text.slice(0, 1500));
+
+  try {
+    if (cohereKey) {
+      const res = await fetch('https://api.cohere.com/v2/rerank', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${cohereKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'rerank-v3.5',
+          query,
+          documents: docs,
+          top_n: docs.length,
+        }),
+        signal: AbortSignal.timeout(3000),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const reranked: RawHit[] = [];
+        for (const r of data.results || []) {
+          const original = hits[r.index];
+          if (!original) continue;
+          reranked.push({ ...original, score: r.relevance_score, source: `rerank(${original.source})` });
+        }
+        // Append any hits beyond the top 20 we didn't rerank
+        for (let i = 20; i < hits.length; i++) reranked.push(hits[i]);
+        return reranked;
+      }
+    }
+    if (voyageKey) {
+      const res = await fetch('https://api.voyageai.com/v1/rerank', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${voyageKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'rerank-2',
+          query,
+          documents: docs,
+          top_k: docs.length,
+        }),
+        signal: AbortSignal.timeout(3000),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const reranked: RawHit[] = [];
+        for (const r of data.data || []) {
+          const original = hits[r.index];
+          if (!original) continue;
+          reranked.push({ ...original, score: r.relevance_score, source: `rerank(${original.source})` });
+        }
+        for (let i = 20; i < hits.length; i++) reranked.push(hits[i]);
+        return reranked;
+      }
+    }
+  } catch {
+    // Rerank failed — fall through with original RRF order
+  }
+  return hits;
+}
+
+// ── Book-level Atlas search (for the books[] field) ──────────────────
+
+async function findBooks(query: string, opts: HybridSearchOptions, limit: number): Promise<SearchBook[]> {
+  const db = await getDb();
+  const filter = tenantBookFilter(opts.tenantId);
+  const stage = buildBookSearchStage(query, { hasTranslation: true }, { fuzzy: true });
+  const rows = await db.collection('books')
+    .aggregate([
+      stage,
+      { $match: filter },
+      { $limit: limit },
+      { $project: { id: 1, title: 1, display_title: 1, author: 1, year: 1, slug: 1 } },
+    ])
+    .toArray();
+  return rows.map(b => ({
+    id: b.id,
+    title: b.display_title || b.title,
+    author: b.author,
+    year: b.year,
+    slug: b.slug,
+  }));
+}
+
+// ── Snippet cleanup (mirrors librarian.ts existing logic) ────────────
+
+function stripAnnotations(text: string): string {
+  return text
+    .replace(/\[\[[^\]]+\]\]/g, '')
+    .replace(/^```(?:markdown)?\s*\n?/i, '')
+    .replace(/\n?```\s*$/i, '')
+    .replace(/<meta>[^<]*<\/meta>/g, '')
+    .trim();
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Hybrid search. Fans out to keyword + book-then-page + global-page in
+ * parallel, RRF-merges, optionally cross-encoder reranks, and resolves
+ * book metadata from Mongo for display.
+ *
+ * The Librarian's `search` tool calls this. Other callers (eval, future
+ * /api/search consumers) can use it directly.
+ */
+export async function hybridSearch(
+  query: string,
+  opts: HybridSearchOptions = {},
+): Promise<HybridSearchResult> {
+  const limit = opts.limit ?? 8;
+  const bookLimit = opts.bookLimit ?? 5;
+
+  // Fan out to all three sources + book-level Atlas in parallel
+  const [kw, btp, gp, books] = await Promise.all([
+    keywordSource(query, opts),
+    bookThenPageSource(query, opts),
+    globalPageSource(query, opts),
+    findBooks(query, opts, bookLimit),
+  ]);
+
+  // RRF merge passages
+  let merged = rrfMerge([kw, btp, gp]);
+
+  // Optional cross-encoder rerank (no-op without API key)
+  merged = await maybeRerank(query, merged);
+
+  // Resolve book metadata for the top passages (slug + display title)
+  const passageBookIds = [...new Set(merged.slice(0, limit * 2).map(h => h.book_id))];
+  const db = await getDb();
+  const bookDocs = passageBookIds.length > 0
+    ? await db.collection('books')
+        .find({ id: { $in: passageBookIds }, ...tenantBookFilter(opts.tenantId) })
+        .project({ id: 1, slug: 1, title: 1, display_title: 1, author: 1 })
+        .toArray()
+    : [];
+  const bookMap = new Map(bookDocs.map(b => [b.id, b]));
+
+  // Build final passage list — drop any hit whose book is hidden / wrong tenant
+  const passages: SearchPassage[] = [];
+  for (const hit of merged) {
+    const book = bookMap.get(hit.book_id);
+    if (!book) continue; // tenant-foreign or hidden
+    passages.push({
+      book_id: hit.book_id,
+      bookTitle: book.display_title || book.title || 'Unknown',
+      bookAuthor: book.author || 'Unknown',
+      bookSlug: book.slug,
+      page_number: hit.page_number,
+      text: stripAnnotations(hit.text || '').slice(0, 1200),
+      score: hit.score,
+      source: hit.source,
+    });
+    if (passages.length >= limit) break;
+  }
+
+  return { passages, books };
+}


### PR DESCRIPTION
## What

Replaces the Librarian's two separate search tools — `search_collection` (Atlas keyword) and `search_semantic` (book-then-page Supabase) — with a single unified `search` tool backed by **Reciprocal Rank Fusion** over three lanes: Atlas keyword, book-then-page semantic, and global-page semantic.

- New module: `src/lib/search/librarian-search.ts` (`hybridSearch()`) — fans out the three lanes in parallel, RRF-merges (k=60), optionally cross-encoder reranks (no-op unless `COHERE_API_KEY`/`VOYAGE_API_KEY` is set), then resolves book metadata from Mongo and drops hidden/tenant-foreign hits.
- `src/lib/embassy/librarian.ts` collapses to one `search` tool. Old names `search_collection`/`search_semantic` are kept as **aliases** that route to the same hybrid path, so an in-flight conversation calling the prior tools doesn't break.
- Eval harness under `scripts/eval/librarian-search/` (golden set + metrics + runner).

## Eval (re-run on live data 2026-05-28, 17-query golden set)

| variant         | P@1   | P@5   | R@5   | MRR   | avg ms |
|-----------------|-------|-------|-------|-------|--------|
| keyword-only    | 0.294 | 0.129 | 0.106 | 0.333 | 858    |
| book-then-page  | 0.471 | 0.318 | 0.426 | 0.525 | 1633   |
| global-page     | 0.294 | 0.212 | 0.194 | 0.461 | 500    |
| **rrf (ships)** | **0.529** | **0.341** | 0.410 | **0.632** | **622** |

RRF wins P@1 (+12pts), P@5, and MRR (+11pts) over the next-best variant, and is **~2.5× faster** than book-then-page (parallel fan-out). By category it nearly doubles **niche-passage** recall (R@5 0.362 vs 0.185 — the Boehme "seven fountain spirits" case keyword nails but pure semantic whiffs).

**Known tradeoff (accepted):** RRF regresses on **verbatim-quote** (R@5 0.375 vs 0.750) and **broad-theme** vs book-then-page — when a user types a book's distinctive vocabulary, semantic-alone is better. The aggregate P@1/P@5/MRR gains outweigh it. Documented in the module docstring. `k=60`/`k=20`/similarity-floor variants are identical on this golden set.

## Tenant safety

`executeSearch` calls `hybridSearch(query, { tenantId: null })`, and `hybridSearch`'s `tenantBookFilter(null)` yields `tenantId: { \$in: [null, undefined] }` — identical to the prior `tenantVisibilityFilter()` on `main`. The Librarian is a **main-site-only** feature (called only from `/api/embassy/chat`); tenant-tagged books stay excluded. No change to tenant scoping behavior.

## Verification

- Rebased onto current `main` (was 47 commits behind) — **zero conflicts**; the drift was all in unrelated files.
- `npx tsc --noEmit`: clean for all search/librarian files (the only repo errors are pre-existing carbon-ledger d3-types issues on `main`).
- Eval re-run against live Mongo + Supabase + Gemini (table above).
- Citation URLs use the existing `/book/<slug>/page-number/<n>` route (matches prior librarian behavior; route exists).

## Out of scope (deliberate follow-up)

This ships hybrid RRF to the **Librarian's retrieval only**. Wiring the same fusion into the user-facing `/search` page (`/api/search`, which has its own multi-lane structure and UI contract) is a **separate PR** — the eval golden set is Librarian-oriented but largely transferable. Cross-encoder rerank is wired but inert until a rerank API key is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)