### PR TITLE
fix(bph): gate title-prefix relevance bump on sort=title only

### DIFF
--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -333,6 +333,13 @@ export async function GET(req: NextRequest) {
   // somewhere else in the record. The underlying ordering (default: title A-Z)
   // is preserved within each group.
   //
+  // Gated on `sort === 'title'`: when the user has explicitly clicked a
+  // different sort header (Author, Year, Shelfmark, or any *_desc variant),
+  // respect their order without re-ordering by prefix relevance. Without
+  // this gate, `cq=X&sort=title_desc` ended up identical to `cq=X&sort=title`
+  // because the bump held prefix matches at the top regardless of direction
+  // (cowork test pass, 2026-05-28 — step A7).
+  //
   // Implementation: we re-sort the current page in JS using a stable sort that
   // keeps title-prefix matches first and falls back to the order Postgres
   // already returned. This avoids any Supabase schema changes (no view, no RPC).
@@ -342,7 +349,7 @@ export async function GET(req: NextRequest) {
   // page 1 — that would require a server-side computed-column sort or an RPC.
   // For BPH (a few thousand rows) the first page is what users see, so this
   // fix satisfies the partner complaint without infra changes.
-  if (q.length >= 2 && works.length > 1) {
+  if (q.length >= 2 && works.length > 1 && sort === 'title') {
     const needle = q.toLocaleLowerCase();
     // Decorate-sort-undecorate to keep the comparator stable.
     const decorated = works.map((row, idx) => {


### PR DESCRIPTION
## Summary
Cowork's 2026-05-28 regression pass (step A7) reported that with `cq=Seleniana`, clicking the Title header twice flipped the arrow to ↓ and the URL to `csort=title_desc` but the row order did not visibly change.

## Root cause
The JS-side title-prefix relevance bump in `/api/catalog/bph` (issue #1690) re-sorts the fetched page to put title-prefix matches first, with the Postgres-returned order preserved within each group. The bump fired regardless of which sort the user had clicked, so for `cq=Seleniana&sort=title_desc` the visible output collapsed to the same order as `&sort=title`: both Seleniana rows in the prefix-match group, Sereniss in the non-match group, identical order in either direction. This was the "Acknowledged-but-not-fixed" item from #2132.

## Fix
Gate the bump on `sort === 'title'`. When the user explicitly chooses Author, Year, Shelfmark, or any `_desc` variant, the Postgres-returned order is what the user sees.

## Other items from the test pass
- **A2 — count 3 / rows 5 on first paint after typing** — couldn't reproduce from API alone (the API returns exactly 3 rows + total=3 for q=Seleniana). My #2132 staleness guard is on origin/main and should cover the typical race. Possibly a browser cache from an older bundle on cowork's first test; want to ask cowork to hard-reload and retest before chasing further.
- **A3 — URL exposed as `/embed/bph?...` after toggle click** — real consequence of #2131 using `router.push`. Fixable by switching to `window.history.replaceState` + an internal state update, but riskier change; tracking separately.
- **A8 — Z→A wrinkle puts `[Andreae] Chymische Hochzeit` at top instead of real Z titles** — `bph_works.title` sort uses the raw `title` field; rows with leading punctuation (`[`, `(`) sort before letters in PG's default collation. Separate concern, not a regression.

## Test plan
- [ ] Preview: `/api/catalog/bph?q=Seleniana&sort=title&limit=10` — Seleniana rows still first (bump applies).
- [ ] Preview: `/api/catalog/bph?q=Seleniana&sort=title_desc&limit=10` — order is now Sereniss, Seleniana, Seleniana (bump skipped, desc respected).
- [ ] Preview: bph.sourcelibrary.org/catalog, search "Seleniana", click Title twice — second click visibly reorders rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)