### PR TITLE
fix(bph): create missing /embed/[tenant]/search route + null-ubn link guard

### DIFF
--- a/src/app/embed/[tenant]/search/page.tsx
+++ b/src/app/embed/[tenant]/search/page.tsx
@@ -1,0 +1,15 @@
+import SearchPage from '@/app/search/page';
+
+// Iframe-target wrapper. Tenant subdomains like bph.sourcelibrary.org get
+// their /search?q=… requests rewritten by src/proxy.ts to
+// /embed/[tenant]/search?q=… — this route is the landing pad. Without it the
+// rewrite produces a hard 404 (observed in not_found_reports: ?q=boehme,
+// ?q=rosicrucian, ?q=Hartmann all firing this URL).
+//
+// The root SearchPage already reads tenant context from request headers
+// (set by proxy.ts) and renders embed-mode UI accordingly, so a thin
+// re-export gives partner subdomains a working search results page.
+
+export default function EmbedSearchPage() {
+  return <SearchPage forceEmbedded={true} />;
+}

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -487,7 +487,14 @@ export default function BphCatalogBrowser({
   // /libraries/{slug}. The bph subdomain proxy doesn't rewrite /embed/...
   // paths, so the URL bar will read /embed/bph/catalog/{ubn} there — uglier
   // than the legacy /catalog/{ubn} but functional in every context.
-  const detailUrl = (ubn: string) => {
+  //
+  // Returns null if ubn is missing. Callers must render plain text instead
+  // of a link in that case — without this guard, `encodeURIComponent(null)`
+  // produces the string "null" and the link points at /catalog/null, which
+  // 404s as a soft 404 ("Catalogue entry not found"). Observed in
+  // not_found_reports 2026-05-26 to 2026-05-28.
+  const detailUrl = (ubn: string | null | undefined): string | null => {
+    if (!ubn) return null;
     return `${basePath.replace(/\/$/, '')}/catalog/${encodeURIComponent(ubn)}`;
   };
 
@@ -745,12 +752,16 @@ export default function BphCatalogBrowser({
                       </td>
                       <td className="px-3 py-2 align-top">
                         <div className="font-medium text-primary leading-snug">
-                          <a
-                            href={detailUrl(w.ubn)}
-                            className="hover:text-accent-rust transition-colors"
-                          >
-                            {displayTitle}
-                          </a>
+                          {detailUrl(w.ubn) ? (
+                            <a
+                              href={detailUrl(w.ubn)!}
+                              className="hover:text-accent-rust transition-colors"
+                            >
+                              {displayTitle}
+                            </a>
+                          ) : (
+                            <span>{displayTitle}</span>
+                          )}
                         </div>
                         {digitized && (
                           <a
@@ -845,10 +856,11 @@ export default function BphCatalogBrowser({
                   : external
                     ? bookUrl({ id: external.id, slug: external.slug })
                     : detailUrl(w.ubn);
+                const Wrapper: React.ElementType = href ? 'a' : 'div';
                 return (
-                  <a
+                  <Wrapper
                     key={w.ubn}
-                    href={href}
+                    {...(href ? { href } : {})}
                     className="group flex flex-col text-left"
                   >
                     <div className="relative aspect-[2/3] bg-warm rounded-md overflow-hidden border border-border-light group-hover:border-accent-rust/40 transition-colors">
@@ -880,7 +892,7 @@ export default function BphCatalogBrowser({
                         {w.year ? ` · ${w.year}` : ''}
                       </div>
                     )}
-                  </a>
+                  </Wrapper>
                 );
               })}
             </div>


### PR DESCRIPTION
## Summary

Two real 404s surfaced from `not_found_reports` over the past 48h:

| URL | Type | Hits/48h | Root cause |
|---|---|---|---|
| `/embed/bph/search?q=<term>` | hard 404 | ~7 (boehme, rosicrucian, Hartmann) | Route doesn't exist |
| `/embed/bph/catalog/null` | soft 404 | 5 (5 distinct IPs) | `encodeURIComponent(null)` → "null" in URL |

## #1 — Create missing `/embed/[tenant]/search` route

`proxy.ts` rewrites `bph.sourcelibrary.org/search?q=…` to `/embed/[tenant]/search?q=…`, but no route handler exists there — hard 404. Created a thin wrapper that re-exports the root `SearchPage` with `forceEmbedded=true`. The page already reads tenant context from proxy-stamped headers (`x-tenant-id`, `x-tenant-slug`) and renders embed-mode UI.

Follows the same pattern as `src/app/embed/[tenant]/book/[slug]/page.tsx` (re-exports root book page).

## #2 — Null-ubn link guard in BphCatalogBrowser

`detailUrl(w.ubn)` was called with possibly-null `w.ubn` (catalog rows with incomplete metadata). `encodeURIComponent(null)` returns the string `"null"`, producing a link to `/catalog/null` that 200s but renders "Catalogue entry not found" — a soft 404 that Google treats as a 404.

Two-pronged fix:
- `detailUrl()` returns `null` when `ubn` is falsy
- Both call sites (table row + grid card) render plain text / non-link wrapper instead of a broken link

## Test plan

- [ ] After deploy: `curl -I https://bph.sourcelibrary.org/search?q=boehme` returns 200
- [ ] After deploy: visit any BPH catalog grid → rows without UBN render as plain text, not broken links
- [ ] No regression on rows with valid UBN — both list and grid links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)