### PR TITLE
fix(bph): stable React key for null-ubn catalog rows

### DIFF
--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -737,14 +737,22 @@ export default function BphCatalogBrowser({
                     </tr>
                   ))
                 )}
-                {works.map((w) => {
+                {works.map((w, idx) => {
                   const digitized = resolveDigitized(w);
                   const external = resolveExternal(w, !!digitized);
                   const displayTitle = w.title || w.parallel_title || w.uniform_title || '(untitled)';
                   const displayAuthor = w.author || w.variant_author || w.pseudonym;
                   return (
                     <tr
-                      key={w.ubn}
+                      // 2,012 of 29,876 catalog rows have ubn:null (legacy
+                      // pre-Memorix entries). With reactCompiler:true, multiple
+                      // siblings sharing key={null} collide in the per-key
+                      // memoization cache and previous-search rows persist in
+                      // the DOM after works[] shrinks — e.g. searching
+                      // "Helicone" returned 2 rows but rendered 4. Offset the
+                      // fallback key with the row index so each null-ubn row
+                      // is unique within the current results page.
+                      key={w.ubn ?? `null-ubn-${idx}`}
                       className="border-b border-border-light last:border-0 hover:bg-cream/50 transition-colors"
                     >
                       <td className="px-3 py-2 align-top text-secondary hidden sm:table-cell">
@@ -846,7 +854,7 @@ export default function BphCatalogBrowser({
             </div>
           ) : works.length > 0 ? (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
-              {works.map((w) => {
+              {works.map((w, idx) => {
                 const digitized = resolveDigitized(w);
                 const external = resolveExternal(w, !!digitized);
                 const displayTitle = w.title || w.parallel_title || w.uniform_title || '(untitled)';
@@ -859,7 +867,10 @@ export default function BphCatalogBrowser({
                 const Wrapper: React.ElementType = href ? 'a' : 'div';
                 return (
                   <Wrapper
-                    key={w.ubn}
+                    // Same null-ubn fallback as the list view above — see
+                    // comment at the table render for the reactCompiler /
+                    // duplicate-key collision rationale.
+                    key={w.ubn ?? `null-ubn-${idx}`}
                     {...(href ? { href } : {})}
                     className="group flex flex-col text-left"
                   >


### PR DESCRIPTION
## Summary

- BPH catalog search "Helicone" returned `2 of 29,876 works` but rendered 4 rows — 2 Helicone matches plus 2 unrelated Chymische Hochzeit rows leaked from the initial 50-row fetch.
- Root cause: 2,012 of 29,876 `bph_works` rows have `ubn: null` (legacy pre-Memorix entries). The catalog used `<tr key={w.ubn}>`, so every null-ubn row got `key={null}`. With `reactCompiler: true`, the compiler's per-key memoization collides on duplicate null keys, and shrinking the works array leaves stale null-keyed siblings in the DOM. The counter (`total` scalar) updates correctly because it doesn't go through per-key memoization.
- Fix: fall back to `null-ubn-${idx}` so every row in the current page has a unique key. Applied to both list view and grid view. `setWorks` always replaces the array, so idx-based keys are safe here.

## Test plan
- [x] Reproduced with Playwright before fix: `Visible rows: 4, Counter: 2 of 29,876 works`
- [ ] After preview deploy, re-run the repro against the preview URL and confirm `Visible rows: 2`
- [ ] Manual: search "Helicone" on the preview tenant, confirm only the 2 Turbo entries render
- [ ] Manual: search "Seleniana" (per [the earlier handoff](.claude/handoffs/2026-05-28-bph-catalog-browser-bugs.md)) and confirm no Hochzeit leak
- [ ] Manual: spot-check a third search term and toggle list ↔ covers, no stale rows

## Out of scope
- Backfilling UBNs for the 2,012 null-ubn rows. They're real catalog entries (mostly "fot"-prefixed photographic copies); the right key is structural, not data cleanup.
- The deeper question of whether `reactCompiler: true` produces other duplicate-key collisions elsewhere in the codebase. This PR fixes the BPH catalog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)