### PR TITLE
Mobile tap opens native image; in-app pinch tracks fingers + reaches native resolution

### DIFF
--- a/src/components/reader/FullscreenImageViewer.tsx
+++ b/src/components/reader/FullscreenImageViewer.tsx
@@ -18,6 +18,13 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
   const [isLoaded, setIsLoaded] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
+  // Dynamic ceiling: lets pinch reach native pixel resolution + a bit of
+  // headroom for inspecting scan texture. Computed on image load.
+  const [maxScale, setMaxScale] = useState(5);
+  // Tracks whether any fingers are currently down — used to kill the
+  // 200ms ease-out transition during pinch so the image tracks fingers
+  // in real time instead of playing catch-up animations every frame.
+  const [hasActiveTouches, setHasActiveTouches] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
@@ -34,6 +41,8 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
   const mousePosStart = useRef({ x: 0, y: 0 });
   const touchDragStart = useRef({ x: 0, y: 0 });
   const touchPosStart = useRef({ x: 0, y: 0 });
+  const maxScaleRef = useRef(5);
+  const touchCountRef = useRef(0);
 
   useEffect(() => { scaleRef.current = scale; }, [scale]);
   useEffect(() => { positionRef.current = position; }, [position]);
@@ -54,8 +63,12 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
       setPosition({ x: 0, y: 0 });
       setIsLoaded(false);
       setHasError(false);
+      setMaxScale(5);
+      setHasActiveTouches(false);
       scaleRef.current = 1;
       positionRef.current = { x: 0, y: 0 };
+      maxScaleRef.current = 5;
+      touchCountRef.current = 0;
       document.body.style.overflow = 'hidden';
     } else {
       document.body.style.overflow = '';
@@ -87,6 +100,8 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
     };
 
     const onTouchStart = (e: TouchEvent) => {
+      touchCountRef.current = e.touches.length;
+      setHasActiveTouches(true);
       if (e.touches.length === 2) {
         lastTouchDistance.current = getTouchDist(e.touches);
       } else if (e.touches.length === 1 && scaleRef.current > 1) {
@@ -102,7 +117,7 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
         e.preventDefault();
         const newDist = getTouchDist(e.touches);
         if (lastTouchDistance.current > 0) {
-          const newScale = Math.min(Math.max(scaleRef.current * (newDist / lastTouchDistance.current), 1), 5);
+          const newScale = Math.min(Math.max(scaleRef.current * (newDist / lastTouchDistance.current), 1), maxScaleRef.current);
           const rect = container.getBoundingClientRect();
           const cx = (e.touches[0].clientX + e.touches[1].clientX) / 2 - rect.left - rect.width / 2;
           const cy = (e.touches[0].clientY + e.touches[1].clientY) / 2 - rect.top - rect.height / 2;
@@ -129,6 +144,8 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
     };
 
     const onTouchEnd = (e: TouchEvent) => {
+      touchCountRef.current = e.touches.length;
+      if (touchCountRef.current === 0) setHasActiveTouches(false);
       lastTouchDistance.current = 0;
       isDraggingRef.current = false;
       setIsDragging(false);
@@ -230,7 +247,7 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
   // ── Button controls ───────────────────────────────────────────────────────
 
   const zoomIn = () => {
-    const s = Math.min(scaleRef.current * 1.5, 5);
+    const s = Math.min(scaleRef.current * 1.5, maxScaleRef.current);
     scaleRef.current = s;
     setScale(s);
   };
@@ -281,7 +298,7 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
           </span>
           <button
             onClick={zoomIn}
-            disabled={scale >= 5}
+            disabled={scale >= maxScale}
             className="p-2 rounded-full bg-white/10 hover:bg-white/20 disabled:opacity-30 transition-all"
           >
             <ZoomIn className="w-5 h-5 text-white" />
@@ -351,10 +368,19 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
             className={`max-w-full max-h-full object-contain transition-opacity duration-300 ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
             style={{
               transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
-              transition: isDragging ? 'none' : 'transform 0.2s ease-out',
+              transition: (isDragging || hasActiveTouches) ? 'none' : 'transform 0.2s ease-out',
               cursor: isDragging ? 'grabbing' : scale > 1 ? 'grab' : 'default',
             }}
-            onLoad={() => setIsLoaded(true)}
+            onLoad={() => {
+              setIsLoaded(true);
+              const img = imageRef.current;
+              if (img && img.naturalWidth && img.offsetWidth) {
+                // Allow zoom to native pixel resolution + 50% inspection headroom
+                const newMax = Math.max(5, (img.naturalWidth / img.offsetWidth) * 1.5);
+                maxScaleRef.current = newMax;
+                setMaxScale(newMax);
+              }
+            }}
             onError={() => setHasError(true)}
             draggable={false}
           />

--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -18,9 +18,11 @@ interface ImageWithMagnifierProps {
   imgClassName?: string; // Override default img sizing classes (replaces h-full object-contain)
 }
 
-// Magnifier component for zooming into the source image
-// Desktop: hover to show magnifier lens, click HD button for fullscreen
-// Mobile/Touch: native browser pinch-zoom + tap to open fullscreen viewer
+// Magnifier component for zooming into the source image.
+// Desktop: hover to show magnifier lens, click to open in-app fullscreen viewer.
+// Mobile/Touch: tap opens the raw high-res image in a new tab so the browser's
+// native pinch-zoom can take over (the in-app viewer caps at 5x, which isn't
+// enough for high-DPI scans — see PR #1873 for the prior escape-hatch button).
 export default function ImageWithMagnifier({
   src,
   thumbnail,
@@ -229,11 +231,17 @@ export default function ImageWithMagnifier({
     }
   };
 
-  // Tap/click to open fullscreen
+  // Tap/click to open fullscreen.
+  // On touch devices, skip the in-app viewer (capped at 5x) and open the
+  // highest-resolution image in a new tab so the browser's native pinch-zoom
+  // can take over. Desktop keeps the in-app viewer where the magnifier lives.
   const handleClick = () => {
-    if (isLoaded) {
-      setShowFullscreen(true);
+    if (!isLoaded) return;
+    if (isTouchDevice) {
+      window.open(highResSrc || src, '_blank', 'noopener,noreferrer');
+      return;
     }
+    setShowFullscreen(true);
   };
 
   return (


### PR DESCRIPTION
## Summary

Continuation of #1873. Two complementary fixes for the mobile zoom experience — the user feedback was that fingers couldn't zoom effectively and the pinch felt discrete.

**1. Mobile tap → native image in new tab** (`ImageWithMagnifier.tsx`)
On touch devices, tap opens `highResSrc || src` in a new tab so the browser's native pinch-zoom has no practical ceiling. Desktop click behavior unchanged.

**2. In-app fullscreen viewer pinch is now smooth + reaches native resolution** (`FullscreenImageViewer.tsx`)
Root-cause of the "discreteness" was the `transition: transform 0.2s ease-out` style running during pinch — every touchmove triggered a 200ms catch-up animation toward the new finger position. Fix: transition is `none` while any finger is on the screen, restored on touchend. Also raised the hardcoded 5× cap to a dynamic ceiling (`naturalWidth / offsetWidth * 1.5`) so high-DPI scans can zoom to their actual pixel resolution.

## Why both

The new-tab default solves the experience the user explicitly asked for ("just open image so you can zoom in normally"). The in-app viewer fix is belt-and-suspenders: desktop touchscreen users still pass through it, the "Open original" escape-hatch button from #1873 stays useful, and anyone who reverts the tap-default behavior gets a viewer that's no longer broken.

## Scope

- Changed: `src/components/ui/ImageWithMagnifier.tsx`, `src/components/reader/FullscreenImageViewer.tsx`
- **Out of scope:** removing the "Open original" header button (still useful as an escape hatch); imperative DOM transforms during pinch (overkill given the transition fix lands the win).

## Test plan

- [ ] Mobile (real device): tap a gallery image → opens raw image in new tab → native pinch-zoom works past 5×
- [ ] Mobile: tap a book page image → same behavior
- [ ] Desktop touchscreen (or DevTools touch emulation): click an image → in-app viewer opens → pinch tracks fingers smoothly (not staircased) → can zoom past 5× on high-DPI scans
- [ ] Desktop mouse: click an image → in-app viewer opens → magnifier lens behavior unaffected, double-click zoom + reset still work
- [ ] Verify across `/gallery/image/[id]`, book reader, `ArtworkHero`, `ExhibitionLayout`