### PR TITLE
bph: hide AI summaries by default on the BPH reading room

### DIFF
--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -13,7 +13,15 @@ export const metadata: Metadata = {
 // flash of unstyled content. The CSS rules in globals.css consume the
 // data attributes set here. Kept inline + minified so it ships in the
 // initial HTML payload without needing a separate script request.
-const VIEW_MODE_INIT_SCRIPT = `(function(){var c=document.cookie;if(/(?:^|; )sl_hide_ai=1/.test(c))document.documentElement.dataset.slHideAi='1';if(/(?:^|; )sl_hide_guide=1/.test(c))document.documentElement.dataset.slHideGuide='1';})();`;
+//
+// AI summaries / introductions default to HIDDEN on the BPH reading room
+// (host bph.* or path /embed/bph/*) — BPH scholars distrust AI-written prose
+// over primary sources, so the partner surface leads without it. A visitor
+// can still opt in via the gear menu, which persists sl_hide_ai=0 (show).
+// The cookie is tri-state: '1'=hide, '0'=show, absent=default (BPH hides,
+// other tenants show). The reading-guide toggle is unchanged (default show,
+// hide only on explicit sl_hide_guide=1). Must mirror EmbedUserMenu.tsx.
+const VIEW_MODE_INIT_SCRIPT = `(function(){var d=document,c=d.cookie,h=location.hostname,p=location.pathname;var bph=/^bph\\./.test(h)||/^\\/embed\\/bph(\\/|$)/.test(p);var m=c.match(/(?:^|; )sl_hide_ai=([01])/);if(m?m[1]==='1':bph)d.documentElement.dataset.slHideAi='1';if(/(?:^|; )sl_hide_guide=1/.test(c))d.documentElement.dataset.slHideGuide='1';})();`;
 
 /**
  * Layout for embed routes. Adds data-embed attribute to hide

--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -58,19 +58,37 @@ const COOKIE_HIDE_AI = 'sl_hide_ai';
 const COOKIE_HIDE_GUIDE = 'sl_hide_guide';
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
 
+// BPH leads without AI prose by default; other tenants/the main site show it.
+// Must mirror the detection in embed/layout.tsx's VIEW_MODE_INIT_SCRIPT.
+function isBphSurface(): boolean {
+  if (typeof window === 'undefined') return false;
+  return /^bph\./.test(window.location.hostname)
+    || /^\/embed\/bph(\/|$)/.test(window.location.pathname);
+}
+
 function readCookie(name: string): boolean {
   if (typeof document === 'undefined') return false;
   const row = document.cookie.split('; ').find(r => r.startsWith(name + '='));
   return row?.split('=')[1] === '1';
 }
 
+// Effective "hide AI summaries" state. The cookie is tri-state: '1' hide,
+// '0' show, absent = default (BPH hides, everyone else shows).
+function readHideAi(): boolean {
+  if (typeof document === 'undefined') return false;
+  const row = document.cookie.split('; ').find(r => r.startsWith(COOKIE_HIDE_AI + '='));
+  const val = row?.split('=')[1];
+  if (val === '1') return true;
+  if (val === '0') return false;
+  return isBphSurface();
+}
+
+// Persist an explicit choice. We always write '0'/'1' (never delete) so an
+// opt-in-to-show on BPH survives reload instead of falling back to the
+// default-hidden state.
 function writeCookie(name: string, on: boolean) {
   if (typeof document === 'undefined') return;
-  if (on) {
-    document.cookie = `${name}=1; path=/; max-age=${COOKIE_MAX_AGE}; samesite=lax`;
-  } else {
-    document.cookie = `${name}=; path=/; max-age=0; samesite=lax`;
-  }
+  document.cookie = `${name}=${on ? '1' : '0'}; path=/; max-age=${COOKIE_MAX_AGE}; samesite=lax`;
 }
 
 export default function EmbedUserMenu() {
@@ -86,7 +104,7 @@ export default function EmbedUserMenu() {
   // rendered the book page using whatever the cookie said at request time;
   // this just keeps the checkbox UI in sync.
   useEffect(() => {
-    setHideAi(readCookie(COOKIE_HIDE_AI));
+    setHideAi(readHideAi());
     setHideGuide(readCookie(COOKIE_HIDE_GUIDE));
   }, []);
 


### PR DESCRIPTION
## Why
BPH scholars distrust AI-written prose presented over primary sources — the default-shown summaries/introductions were eroding trust in the partner reading room. This makes the BPH reading room **lead without AI prose by default**, while keeping it one click away for anyone who wants it.

## What changed
- **`src/app/embed/layout.tsx`** — the view-mode init script now defaults `sl_hide_ai` to **hidden on the BPH surface** (host `bph.*` or path `/embed/bph/*`). The `sl_hide_ai` cookie is now tri-state: `'1'` = hide, `'0'` = show, **absent = default** (BPH hides; every other tenant and the main site are unchanged and still show).
- **`src/components/embed/EmbedUserMenu.tsx`** — the gear-menu "Hide AI introductions & summaries" toggle starts **checked** on BPH, and now persists an explicit `'0'` on opt-in so "show" survives reload instead of reverting to default-hidden. Reading-guide toggle behaviour is unchanged.

## Coverage
All three BPH summary surfaces render through `AISection` (`data-view-section="ai-summary"`), so the existing CSS hide (`html[data-sl-hide-ai="1"]`) catches every one:
1. Catalog entry page (`/embed/[tenant]/catalog/[ubn]/page.tsx`) — `reading_summary.overview`
2. Generic catalog entry variant
3. Embed book reading page (re-exports the main `BookDetailPage`)

## Scope / out of scope
- **In scope:** BPH only, by request. Default-hidden + opt-in-to-show, fully reversible per visitor.
- **Out of scope (deliberately):** the main public site (`sourcelibrary.org/book/...`), where general readers still benefit from summaries and there is currently no toggle UI; and other tenants (bhutan, etc.). A site-wide "hide for everyone" was considered and left for a separate decision.

## How to test
On the preview's BPH surface, open a digitized catalog entry / book page: the AI summary should be **absent by default**. Open the gear menu (top-right) → uncheck "Hide AI introductions & summaries" → summary appears and persists across reloads. Other tenants and the main site are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)