### PR TITLE
fix(hooks): make branch-safety guard actually block, not just warn

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Branch-safety guard (PreToolUse, matcher: Bash) — see CLAUDE.md "Multi-Session Awareness".
+#
+# Derek runs ~10 Claude Code sessions sharing the main working directory. A
+# `git checkout <branch>` in that directory silently breaks every other session.
+# The rule is absolute: the MAIN DIRECTORY STAYS ON `main`; feature work happens
+# in worktrees (EnterWorktree / `git worktree add`).
+#
+# This hook BLOCKS (exit 2) any `git checkout`/`git switch` that would move the
+# main directory off `main`. Allowed: switching TO `main`, file restores
+# (`git checkout -- <file>` / `git restore`), and anything in a worktree.
+#
+# Worktrees are unaffected: `git worktree add` is not a checkout/switch, and
+# branch switches inside a worktree have cwd != the main directory.
+
+MAIN_DIR="/Users/dereklomas/sourcelibrary"
+
+INPUT=$(cat)
+
+# Parse cwd + command from the PreToolUse payload. On any parse failure, fail
+# open (exit 0) — a guard must never wedge the whole session.
+eval "$(printf '%s' "$INPUT" | python3 -c '
+import json, sys, shlex
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+cmd = d.get("tool_input", {}).get("command", "") or ""
+cwd = d.get("cwd", "") or ""
+print("CMD=" + shlex.quote(cmd))
+print("CWD=" + shlex.quote(cwd))
+' 2>/dev/null)"
+
+[ -z "${CMD:-}" ] && exit 0
+
+# Only police commands that act on the main directory: either the session cwd is
+# the main dir, or the command explicitly targets it via `git -C <main dir>`.
+TARGETS_MAIN=0
+[ "${CWD:-}" = "$MAIN_DIR" ] && TARGETS_MAIN=1
+printf '%s' "$CMD" | grep -Eq "git[[:space:]]+-C[[:space:]]+$MAIN_DIR" && TARGETS_MAIN=1
+[ "$TARGETS_MAIN" -eq 0 ] && exit 0
+
+# Decide whether this is a branch-changing checkout/switch. Done in python so we
+# can inspect the actual token sequence rather than guess with a regex.
+DECISION=$(printf '%s' "$CMD" | python3 -c '
+import sys, shlex
+cmd = sys.stdin.read()
+try:
+    toks = shlex.split(cmd)
+except Exception:
+    print("ALLOW"); sys.exit(0)
+
+# Find a "git checkout" / "git switch" verb (tolerate "git -C <dir> checkout"
+# and other git-level options before the subcommand).
+verb = idx = None
+for i, t in enumerate(toks[:-1]):
+    if t == "git":
+        j = i + 1
+        while j < len(toks):
+            tj = toks[j]
+            if tj in ("checkout", "switch"):
+                verb, idx = tj, j; break
+            if tj in ("-C", "-c", "--git-dir", "--work-tree", "--namespace"):
+                j += 2              # option that consumes the next token
+                continue
+            if tj.startswith("-"):
+                j += 1              # standalone git-level flag
+                continue
+            break                   # some other subcommand (status, log, ...)
+    if verb:
+        break
+
+if not verb:
+    print("ALLOW"); sys.exit(0)
+
+args = toks[idx + 1:]
+
+# File restore forms are fine: `git checkout -- <file>`, `git checkout . `,
+# `git checkout <ref> -- <file>`.
+if "--" in args:
+    print("ALLOW"); sys.exit(0)
+if args == ["."]:
+    print("ALLOW"); sys.exit(0)
+
+# Creating/switching-and-creating a branch in the main dir is also forbidden.
+if any(a in ("-b", "-B", "-c", "-C") for a in args):
+    print("BLOCK"); sys.exit(0)
+
+# First non-flag arg is the target branch/ref.
+target = next((a for a in args if not a.startswith("-")), None)
+if target is None:
+    print("ALLOW"); sys.exit(0)   # e.g. bare `git switch` with no branch
+if target == "main":
+    print("ALLOW"); sys.exit(0)   # returning to main is always safe
+
+print("BLOCK")
+' 2>/dev/null)
+
+if [ "$DECISION" = "BLOCK" ]; then
+  echo "BLOCKED: refusing 'git checkout/switch' to a non-main branch in the main directory ($MAIN_DIR)." >&2
+  echo "The main checkout must stay on 'main' so Derek's other ~10 sessions don't break (see CLAUDE.md > Multi-Session Awareness)." >&2
+  echo "Use EnterWorktree (or 'git worktree add') for feature-branch work. To restore a file, use 'git restore <file>' or 'git checkout -- <file>'." >&2
+  exit 2
+fi
+
+# Not a blocking case. Keep the original advisory: if the main dir is somehow
+# already off 'main' (e.g. a non-Claude terminal switched it), warn.
+BRANCH=$(git -C "$MAIN_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$BRANCH" != "main" ] && [ -n "$BRANCH" ] && [ "${CWD:-}" = "$MAIN_DIR" ]; then
+  echo "WARNING: Main directory is on branch '$BRANCH', not 'main'. Another session may have switched it. Use a worktree for feature-branch work." >&2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,12 @@
       "Bash(vercel list)",
       "Bash(vercel list *)",
       "Bash(vercel inspect *)",
+      "Bash(vercel logs *)",
+      "Bash(vercel domains ls)",
+      "Bash(vercel domains ls *)",
+      "Bash(vercel domains inspect *)",
+      "Bash(dig *)",
+      "Bash(lpstat *)",
       "Bash(open *)",
       "mcp__claude_ai_Gmail__search_threads",
       "mcp__claude_ai_Gmail__get_thread",
@@ -21,12 +27,14 @@
       "mcp__chrome-devtools__navigate_page",
       "mcp__chrome-devtools__take_screenshot",
       "mcp__chrome-devtools__resize_page",
+      "mcp__chrome-devtools__wait_for",
       "mcp__claude_ai_Google_Drive__read_file_content",
       "mcp__claude_ai_Google_Drive__search_files",
       "mcp__claude-conversation-search__search_conversations",
       "mcp__claude_ai_Source_Library__search_library",
       "mcp__claude_ai_Source_Library__get_book",
-      "mcp__claude_ai_Source_Library__get_book_text"
+      "mcp__claude_ai_Source_Library__get_book_text",
+      "mcp__claude_ai_Source_Library__get_quote"
     ]
   },
   "hooks": {
@@ -36,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "BRANCH=$(git -C /Users/dereklomas/sourcelibrary rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$BRANCH\" != \"main\" ] && [ -n \"$BRANCH\" ] && [ \"$PWD\" = \"/Users/dereklomas/sourcelibrary\" ]; then echo \"WARNING: Main directory is on branch '$BRANCH', not 'main'. Another session may have switched it. Use a worktree for feature branch work.\" >&2; fi; exit 0"
+            "command": "bash /Users/dereklomas/sourcelibrary/.claude/hooks/branch-guard.sh"
           }
         ]
       }


### PR DESCRIPTION
## Why

The main working directory ended up sitting on a merged feature branch (`fix-author-schema-interaction-stat`) today, with the reflog showing a string of direct `git checkout`s in the main dir (`fix-icon-svg-*`, `fix-favicon-*`, …). That's the multi-session breakage `CLAUDE.md` > **Multi-Session Awareness** explicitly warns about — Derek runs ~10 sessions sharing this directory.

Root cause: the `PreToolUse` Bash hook in `.claude/settings.json` was **warn-only**. It echoed a warning to stderr and `exit 0`, and only checked the branch *after the fact* on the next Bash call. It never inspected the command, so it could never actually stop a `git checkout <branch>`.

(Separately, a stale `fix-efm-stripe-link` worktree was squatting on `main`, which physically prevented the main dir from returning to `main`. That worktree was clean/unused and has been removed — not part of this PR.)

## What

- Replace the inline warn-only command with **`.claude/hooks/branch-guard.sh`**, which parses the pending Bash command and **blocks (`exit 2`)** any `git checkout`/`git switch` that would move the main directory off `main`.
- **Allowed (exit 0):** switching *to* `main`, file restores (`git checkout -- <file>`, `git restore`), worktree operations (`git worktree add`), and any switch whose cwd is inside a worktree. Tolerates `git -C <maindir> …` forms. Fails open on any parse error so it can never wedge a session. Retains the original post-hoc warning as a secondary signal.

## Verification

Tested against 13 block/allow payloads (the JSON shape Claude Code feeds a `PreToolUse` hook):
- BLOCK: `git checkout <feature>`, `git switch <feature>`, `git checkout -b <new>`, `git -C <maindir> checkout <feature>` from elsewhere
- ALLOW: `git checkout main`, `git checkout -- <file>`, checkout inside a worktree, `git worktree add … -b`, `git -C <maindir> status`, unrelated commands

## Out of scope

`settings.json` also gains a few permission-allowlist entries (`vercel logs/domains`, `dig`, `lpstat`, `chrome wait_for`, Source Library `get_quote`) — included only because they share the file. No logic depends on them. `settings.local.json` (per-machine permission churn) is deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)