### PR TITLE
bph: run AI-summary hide on the real subdomain (move init script to root layout)

### DIFF
--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -8,20 +8,11 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-// Synchronous cookie reader. Runs during HTML parsing before any of the
-// gated sections render, so toggling the menu options never produces a
-// flash of unstyled content. The CSS rules in globals.css consume the
-// data attributes set here. Kept inline + minified so it ships in the
-// initial HTML payload without needing a separate script request.
-//
-// AI summaries / introductions default to HIDDEN on the BPH reading room
-// (host bph.* or path /embed/bph/*) — BPH scholars distrust AI-written prose
-// over primary sources, so the partner surface leads without it. A visitor
-// can still opt in via the gear menu, which persists sl_hide_ai=0 (show).
-// The cookie is tri-state: '1'=hide, '0'=show, absent=default (BPH hides,
-// other tenants show). The reading-guide toggle is unchanged (default show,
-// hide only on explicit sl_hide_guide=1). Must mirror EmbedUserMenu.tsx.
-const VIEW_MODE_INIT_SCRIPT = `(function(){var d=document,c=d.cookie,h=location.hostname,p=location.pathname;var bph=/^bph\\./.test(h)||/^\\/embed\\/bph(\\/|$)/.test(p);var m=c.match(/(?:^|; )sl_hide_ai=([01])/);if(m?m[1]==='1':bph)d.documentElement.dataset.slHideAi='1';if(/(?:^|; )sl_hide_guide=1/.test(c))d.documentElement.dataset.slHideGuide='1';})();`;
+// The view-mode init script (default-hide AI summaries on BPH) lives in the
+// ROOT layout (src/app/layout.tsx) so it also runs on the real BPH subdomain,
+// which serves global routes (e.g. /book/[id]) without the /embed rewrite and
+// therefore never mounts this layout. No need to duplicate it here — the root
+// layout wraps embed routes too.
 
 /**
  * Layout for embed routes. Adds data-embed attribute to hide
@@ -33,7 +24,6 @@ const VIEW_MODE_INIT_SCRIPT = `(function(){var d=document,c=d.cookie,h=location.
 export default function EmbedLayout({ children }: { children: React.ReactNode }) {
   return (
     <TenantLayoutWrapper>
-      <script dangerouslySetInnerHTML={{ __html: VIEW_MODE_INIT_SCRIPT }} />
       <div data-embed="" className="embed-mode">
         {children}
         <EmbedUserMenu />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,25 @@ import EmbedHistoryPatch from "@/components/embed/EmbedHistoryPatch";
 
 
 
+// Synchronous, host-aware view-mode init. Runs during HTML parsing before
+// any content paints, so gated sections never flash. Kept inline + minified
+// so it ships in the initial HTML and needs no separate request.
+//
+// AI summaries / introductions default to HIDDEN on the BPH reading room
+// (host bph.* or path /embed/bph/*) — BPH scholars distrust AI-written prose
+// over primary sources, so the partner surface leads without it. A visitor
+// can still opt in via the gear menu (sl_hide_ai=0). The cookie is tri-state:
+// '1'=hide, '0'=show, absent=default (BPH hides; main site + other tenants
+// show). Reading-guide toggle is unchanged (default show, hide only on
+// explicit sl_hide_guide=1). The CSS rules in globals.css consume the data
+// attributes set here. Must live in the ROOT layout (not embed/layout): the
+// real BPH subdomain serves the global /book/[id] route directly (proxy adds
+// x-tenant-* headers, no /embed rewrite), so the embed layout never wraps it.
+// Detection is client-side by hostname to stay ISR-safe — the HTML is
+// host-agnostic and cached; this script self-determines at runtime.
+// Must mirror the detection in EmbedUserMenu.tsx.
+const VIEW_MODE_INIT_SCRIPT = `(function(){var d=document,c=d.cookie,h=location.hostname,p=location.pathname;var bph=/^bph\\./.test(h)||/^\\/embed\\/bph(\\/|$)/.test(p);var m=c.match(/(?:^|; )sl_hide_ai=([01])/);if(m?m[1]==='1':bph)d.documentElement.dataset.slHideAi='1';if(/(?:^|; )sl_hide_guide=1/.test(c))d.documentElement.dataset.slHideGuide='1';})();`;
+
 export const metadata: Metadata = {
   title: "Source Library — Ancient Texts Translated to English",
   description: "Digitizing and translating ancient texts for scholars, seekers and AI systems.",
@@ -87,6 +106,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <script dangerouslySetInnerHTML={{ __html: VIEW_MODE_INIT_SCRIPT }} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link

--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -59,7 +59,8 @@ const COOKIE_HIDE_GUIDE = 'sl_hide_guide';
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
 
 // BPH leads without AI prose by default; other tenants/the main site show it.
-// Must mirror the detection in embed/layout.tsx's VIEW_MODE_INIT_SCRIPT.
+// Must mirror the detection in the root layout's VIEW_MODE_INIT_SCRIPT
+// (src/app/layout.tsx).
 function isBphSurface(): boolean {
   if (typeof window === 'undefined') return false;
   return /^bph\./.test(window.location.hostname)


### PR DESCRIPTION
## Why (follow-up to #2145)
#2145 made AI summaries hidden-by-default on BPH, but put the init script in `embed/layout.tsx` — which only runs on the **legacy `/embed/*` path**. After the tenant-as-filter migration, the real subdomain `bph.sourcelibrary.org` serves the **global `/book/[id]` route** directly (proxy adds `x-tenant-*` headers, no `/embed` rewrite — see `proxy.ts`), so the embed layout never wraps it.

**Verified live before this fix:** on `bph.sourcelibrary.org/book/...`, `data-sl-hide-ai` was unset and the AI summary was `display:block` (visible) — #2145 had no effect on the actual subdomain. (My earlier preview verification passed only because it used the `/embed/bph/` path, a different route.)

## What changed
- **`src/app/layout.tsx`** — moved `VIEW_MODE_INIT_SCRIPT` into the root layout's `<head>`, so it runs on every route including the subdomain's `/book/[id]`. Detection stays client-side by hostname (`bph.*`), which is ISR-safe: the cached HTML is host-agnostic and the script self-determines at runtime. The script is **inert off-BPH**, so the main site and other tenants are unaffected.
- **`src/app/embed/layout.tsx`** — removed the now-redundant copy (root wraps embed routes too).
- **`src/components/embed/EmbedUserMenu.tsx`** — repointed the mirror comment.

The `data-view-section="ai-summary"` wrapper and the global `globals.css` hide rule were already present on the subdomain page — only the trigger was missing.

## Verification
Logic test (actual deployed script string) passes all cases, incl. `bph.sourcelibrary.org` subdomain → HIDDEN, `sl_hide_ai=0` → shown, main site → shown, other tenants → shown. Will re-verify on the live subdomain post-deploy with a headless browser (computed `display`).

## Known gap (out of scope, flagged)
The gear-menu toggle (`EmbedUserMenu`) is also only mounted by `embed/layout.tsx`, so it does **not** appear on the real subdomain — summaries are hidden there with no in-page opt-in yet. The pre-migration scholar toggle never reached the subdomain. Restoring it (client-gated, in the root layout) is a separate change; flagging for a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)