### PR TITLE
Librarian search evaluation harness

### DIFF
--- a/scripts/eval/librarian-search/.gitignore
+++ b/scripts/eval/librarian-search/.gitignore
@@ -1,0 +1,2 @@
+results/
+*.draft.json

--- a/scripts/eval/librarian-search/README.md
+++ b/scripts/eval/librarian-search/README.md
@@ -1,0 +1,69 @@
+# Librarian Search Evaluation
+
+Quantitative evaluation harness for the Librarian's search tools. Compares
+multiple search variants against a hand-validated golden set and reports
+precision@5, recall@5, and MRR per variant.
+
+## Why this exists
+
+The Librarian currently uses two tools — `search_collection` (Atlas keyword)
+and `search_semantic` (book-then-page Supabase) — and the model picks between
+them. Known issues:
+
+1. Book-then-page misses passages in books whose summaries don't match the
+   query (the "Martial's masturbator epigram in a 400-page book about Roman
+   wit" case the `semanticPageSearchGlobal` comment cites).
+2. There's no hybrid scoring or cross-encoder reranking.
+
+Fixing (1) and (2) without a measurement framework is guesswork. This harness
+lets us A/B variants — auto-fallback to global, RRF merge, cross-encoder rerank
+— against a fixed query set.
+
+## Layout
+
+- `golden-set.json` — query → expected (book_slug, page-range) tuples.
+  Hand-validated, marked with `confidence` (high/medium/low). Treat low-
+  confidence entries as diagnostics, not ground truth.
+- `variants.mjs` — one async function per search variant. Each takes a query
+  string and returns ranked `{book_id, book_slug, page_number, ...}` hits.
+- `metrics.mjs` — `precisionAtK`, `recallAtK`, `mrr`, plus a matcher that
+  honors the optional `page_min`/`page_max` page-range tolerance.
+- `run.mjs` — runner. Iterates queries × variants, computes metrics, writes
+  a JSON report and prints a per-category table.
+
+## Running
+
+```bash
+# Env is required (MONGODB_URI, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, GEMINI_API_KEY)
+set -a; source ../../../../.env.production.local; set +a
+
+# Run all variants against the full golden set
+node scripts/eval/librarian-search/run.mjs
+
+# Run a single variant
+node scripts/eval/librarian-search/run.mjs --variant=hybrid-rrf
+
+# Run a single query (for debugging)
+node scripts/eval/librarian-search/run.mjs --query=agrippa-planetary-seals
+
+# Verbose mode (prints every hit)
+node scripts/eval/librarian-search/run.mjs --verbose
+```
+
+Reports are written to `scripts/eval/librarian-search/results/<timestamp>.json`.
+
+## Golden set conventions
+
+A "correct" hit for a query is one whose `book_slug` matches an entry in
+`expected[]`. If the entry has `page_min`/`page_max`, the hit's `page_number`
+must fall within. If not, any page from that book counts.
+
+Categories:
+- `well-known-concept` — the topic is famous; book-level search should find it
+- `niche-passage` — a specific passage inside a (possibly famous) book that
+  book-level search will likely miss
+- `verbatim-quote` — user is searching for a phrase they expect to find verbatim
+- `cross-lingual` — query in English, expected hits in non-English originals
+  (English translations are what's indexed, so this tests translation coverage)
+- `broad-theme` — wide topic; multiple books should match
+- `bibliographic` — "what do you have about X" — books-as-results

--- a/scripts/eval/librarian-search/_seed-golden-set.mjs
+++ b/scripts/eval/librarian-search/_seed-golden-set.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Helper script to verify candidate book slugs exist in the collection.
+ * Run this when adding new golden-set entries to make sure the book_slug
+ * actually resolves to a tenant-visible book.
+ *
+ *   set -a; source ../../../../.env.production.local; set +a
+ *   node scripts/eval/librarian-search/_seed-golden-set.mjs
+ *
+ * Outputs JSON to stdout; redirect to golden-set.json after manual review.
+ */
+
+import { MongoClient } from 'mongodb';
+
+// Candidate (query, expected) pairs. Each `query_book` is a flexible search
+// term we use to FIND the canonical slug in Mongo (we then put the actual
+// slug in expected.book_slug). This avoids me hard-coding wrong slugs.
+const CANDIDATES = [
+  // ── Well-known-concept ─────────────────────────────────────────────
+  { id: 'agrippa-occult-philosophy', query: 'Agrippa on natural magic and planetary correspondences',
+    category: 'well-known-concept', query_book: 'Three Books of Occult Philosophy', author_contains: 'agrippa' },
+  { id: 'bruno-infinite-worlds', query: 'Giordano Bruno on the infinite universe and plurality of worlds',
+    category: 'well-known-concept', query_book: 'infinite universe', author_contains: 'bruno' },
+  { id: 'ficino-de-vita', query: 'Ficino on drawing down celestial spirits with talismans',
+    category: 'well-known-concept', query_book: 'de vita', author_contains: 'ficino' },
+  { id: 'kepler-harmonices', query: 'Kepler on the harmony of the spheres and planetary music',
+    category: 'well-known-concept', query_book: 'harmonices mundi', author_contains: 'kepler' },
+  { id: 'fludd-utriusque', query: 'Robert Fludd on the macrocosm and microcosm',
+    category: 'well-known-concept', query_book: 'utriusque cosmi', author_contains: 'fludd' },
+  { id: 'paracelsus-archidoxes', query: 'Paracelsus on the spagyric preparation of metals',
+    category: 'well-known-concept', query_book: 'archidoxes', author_contains: 'paracelsus' },
+
+  // ── Niche-passage (specific topic inside a famous book) ────────────
+  { id: 'kircher-magnetism', query: 'magnetic experiments with iron and lodestone',
+    category: 'niche-passage', query_book: 'magnete', author_contains: 'kircher' },
+  { id: 'vesalius-anatomy-skull', query: 'anatomy of the human skull and cranial sutures',
+    category: 'niche-passage', query_book: 'fabrica', author_contains: 'vesalius' },
+  { id: 'boehme-seven-properties', query: 'the seven fountain spirits or properties of nature',
+    category: 'niche-passage', query_book: 'aurora', author_contains: 'boehme' },
+
+  // ── Verbatim-quote / formula ───────────────────────────────────────
+  { id: 'emerald-tablet-as-above', query: 'as above so below tabula smaragdina',
+    category: 'verbatim-quote', query_book: 'emerald', author_contains: null },
+  { id: 'rosicrucian-fama', query: 'Fama Fraternitatis brothers of the Rose Cross',
+    category: 'verbatim-quote', query_book: 'fama fraternitatis', author_contains: null },
+
+  // ── Cross-lingual (search English, book is non-English) ────────────
+  { id: 'sanskrit-rasa-alchemy', query: 'Indian alchemy mercury rasa preparation',
+    category: 'cross-lingual', query_book: 'rasa', author_contains: null },
+  { id: 'tibetan-bardo', query: 'Tibetan teachings on the intermediate state after death',
+    category: 'cross-lingual', query_book: 'bardo', author_contains: null },
+
+  // ── Broad-theme (multiple books should match) ──────────────────────
+  { id: 'sympathetic-magic', query: 'sympathetic magic and occult virtues in nature',
+    category: 'broad-theme', query_book: null, author_contains: null },
+  { id: 'dream-interpretation-antiquity', query: 'dream interpretation in the ancient world',
+    category: 'broad-theme', query_book: null, author_contains: null },
+
+  // ── Bibliographic (find books, not passages) ───────────────────────
+  { id: 'books-on-geomancy', query: 'books about geomancy and divination by points',
+    category: 'bibliographic', query_book: 'geomancy', author_contains: null },
+  { id: 'books-on-cabala', query: 'Christian cabala in the Renaissance',
+    category: 'bibliographic', query_book: 'cabala', author_contains: null },
+];
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('MONGODB_URI not set; source .env.production.local');
+    process.exit(1);
+  }
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+
+  const queries = [];
+  for (const c of CANDIDATES) {
+    const filter = {
+      hidden: { $ne: true },
+      tenantId: { $in: [null, undefined] },
+      pages_count: { $gt: 0 },
+    };
+    const orClauses = [];
+    if (c.query_book) {
+      const re = new RegExp(c.query_book.replace(/\s+/g, '.*'), 'i');
+      orClauses.push({ title: re }, { display_title: re }, { english_title: re });
+    }
+    if (orClauses.length) filter.$or = orClauses;
+    if (c.author_contains) filter.author = new RegExp(c.author_contains, 'i');
+
+    const docs = await db.collection('books')
+      .find(filter)
+      .project({ id: 1, slug: 1, title: 1, display_title: 1, author: 1, pages_count: 1, pages_translated: 1, year: 1 })
+      .limit(5)
+      .toArray();
+
+    process.stderr.write(`${c.id} → ${docs.length} match(es)\n`);
+    for (const d of docs) {
+      process.stderr.write(`    ${d.slug}  "${d.display_title || d.title}" by ${d.author || '?'} (${d.pages_translated || 0}/${d.pages_count} translated)\n`);
+    }
+
+    // Take the top match with translation; fall back to first
+    const best = docs.find(d => (d.pages_translated || 0) > 10) || docs[0];
+
+    queries.push({
+      id: c.id,
+      query: c.query,
+      category: c.category,
+      confidence: best ? 'medium' : 'low',
+      expected: best ? [{
+        book_slug: best.slug,
+        // No page range yet — that needs manual validation
+      }] : [],
+      notes: best
+        ? `Candidate book: "${best.display_title || best.title}" by ${best.author || '?'} (${best.pages_translated || 0} pages translated)`
+        : `NO MATCH FOUND for ${c.query_book || c.query}; verify the collection has this`,
+    });
+  }
+
+  await client.close();
+
+  console.log(JSON.stringify({
+    description: 'Librarian search eval — golden set. Generated by _seed-golden-set.mjs, then hand-validated.',
+    generated_at: new Date().toISOString(),
+    queries,
+  }, null, 2));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/eval/librarian-search/_spike-rich-embedding.mjs
+++ b/scripts/eval/librarian-search/_spike-rich-embedding.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * Spike: rich book embedding A/B on a single book.
+ *
+ * Target: Della Porta's "De Humana Physiognomonia" (slug: de-humana-physiognomonia-libri-iv-porta).
+ *
+ * Compares three embedding text compositions:
+ *   1. CURRENT  — what enrich-worker writes today
+ *   2. RICH     — + reading_summary + section summaries + section quotes + themes
+ *   3. RICH+LLM — + LLM-condensed roll-up of page summaries (for the size problem)
+ *
+ * For each composition, embeds the text, then for a battery of niche physiognomy
+ * queries, computes:
+ *   - cosine similarity (this book vs. query)
+ *   - rank of this book in the current production book_embeddings (where does
+ *     the book actually appear today?)
+ *   - rank the book WOULD have if we used the rich embedding (rough — we
+ *     compare rich-cosine against the top-N production similarities)
+ *
+ * Output: per-query table showing the lift.
+ *
+ *   set -a; source ../../../../.env.production.local; set +a
+ *   node scripts/eval/librarian-search/_spike-rich-embedding.mjs
+ */
+
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+import { GoogleGenAI } from '@google/genai';
+
+const TARGET_SLUG = 'de-humana-physiognomonia-libri-iv-porta';
+
+const QUERIES = [
+  'facial features and character',
+  'reading the face for moral disposition',
+  'lion features and bravery',
+  'nose shape and temperament',
+  'physiognomy of women and men compared',
+  'animal analogies for human personality',
+  'forehead lines and intellect',
+  // For sanity: queries about other books should NOT pull physiognomy up
+  'transmutation of metals into gold',
+  'planetary correspondences in talismans',
+];
+
+// ── Setup ─────────────────────────────────────────────────────────────
+
+const mongoUri = process.env.MONGODB_URI;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const geminiKey = process.env.GEMINI_API_KEY;
+if (!mongoUri || !supabaseUrl || !supabaseKey || !geminiKey) {
+  console.error('Missing env. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const mongo = new MongoClient(mongoUri);
+const supabase = createClient(supabaseUrl, supabaseKey);
+const ai = new GoogleGenAI({ apiKey: geminiKey });
+
+// ── Embedding fn ──────────────────────────────────────────────────────
+
+async function embed(text, dims = 768) {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:batchEmbedContents?key=${geminiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requests: [{
+          model: 'models/gemini-embedding-2-preview',
+          content: { parts: [{ text: text.slice(0, 8000) }] },
+          outputDimensionality: dims,
+        }],
+      }),
+      signal: AbortSignal.timeout(15000),
+    },
+  );
+  if (!res.ok) throw new Error(`embed ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return data.embeddings[0].values;
+}
+
+function cosine(a, b) {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+// ── Text compositions ────────────────────────────────────────────────
+
+function composeCurrent(book, indexData) {
+  // Mirrors enrich-worker.mjs:composeBookEmbeddingText
+  const parts = [];
+  parts.push(`${book.display_title || book.title || 'Untitled'} by ${book.author || 'Unknown'}`);
+  if (book.language) parts.push(`Language: ${book.language}`);
+  if (book.published) parts.push(`Published: ${book.published}`);
+  if (indexData?.bookSummary?.detailed) parts.push(indexData.bookSummary.detailed);
+  else if (indexData?.bookSummary?.brief) parts.push(indexData.bookSummary.brief);
+  if (indexData?.sectionSummaries?.length > 0) {
+    const sections = indexData.sectionSummaries.map(s => s.title || s.summary).filter(Boolean).slice(0, 15);
+    if (sections.length > 0) parts.push(`Chapters: ${sections.join('; ')}`);
+  }
+  if (indexData?.entries?.length > 0) {
+    const terms = indexData.entries.sort((a, b) => (b.pages?.length || 0) - (a.pages?.length || 0)).slice(0, 50).map(e => e.term);
+    parts.push(`Topics: ${terms.join(', ')}`);
+  }
+  if (indexData?.people?.length > 0) parts.push(`People: ${indexData.people.slice(0, 30).map(p => p.name).join(', ')}`);
+  if (indexData?.places?.length > 0) parts.push(`Places: ${indexData.places.slice(0, 20).map(p => p.name).join(', ')}`);
+  if (indexData?.concepts?.length > 0) parts.push(`Concepts: ${indexData.concepts.slice(0, 30).map(c => c.name).join(', ')}`);
+  if (book.categories?.length > 0) parts.push(`Categories: ${book.categories.join(', ')}`);
+  return parts.join('\n').slice(0, 8000);
+}
+
+function composeRich(book, indexData) {
+  // Start from current, add reading_summary + section summaries (with full
+  // summary text, not just title) + section quotes + themes.
+  const parts = [];
+  parts.push(`${book.display_title || book.title || 'Untitled'} by ${book.author || 'Unknown'}`);
+  if (book.language) parts.push(`Language: ${book.language}`);
+  if (book.published) parts.push(`Published: ${book.published}`);
+
+  // NEW: reading_summary — currently ignored by enrich-worker
+  if (book.reading_summary?.detailed) parts.push(book.reading_summary.detailed);
+  else if (book.reading_summary?.overview) parts.push(book.reading_summary.overview);
+  if (book.reading_summary?.themes?.length > 0) {
+    parts.push(`Themes: ${book.reading_summary.themes.join('; ')}`);
+  }
+
+  if (indexData?.bookSummary?.detailed) parts.push(indexData.bookSummary.detailed);
+
+  // NEW: full section summaries with summary text (not just titles)
+  if (indexData?.sectionSummaries?.length > 0) {
+    const sectionBlock = indexData.sectionSummaries
+      .map(s => `[${s.title || ''}] ${s.summary || ''}`)
+      .join('\n');
+    parts.push(sectionBlock);
+
+    // NEW: section quotes — curated passage text
+    const quotes = indexData.sectionSummaries
+      .flatMap(s => s.quotes || [])
+      .map(q => q.text)
+      .filter(Boolean);
+    if (quotes.length > 0) {
+      parts.push(`Quoted passages: ${quotes.join(' / ')}`);
+    }
+  }
+
+  if (indexData?.entries?.length > 0) {
+    const terms = indexData.entries.sort((a, b) => (b.pages?.length || 0) - (a.pages?.length || 0)).slice(0, 50).map(e => e.term);
+    parts.push(`Topics: ${terms.join(', ')}`);
+  }
+  if (indexData?.people?.length > 0) parts.push(`People: ${indexData.people.slice(0, 30).map(p => p.name).join(', ')}`);
+  if (indexData?.places?.length > 0) parts.push(`Places: ${indexData.places.slice(0, 20).map(p => p.name).join(', ')}`);
+  if (indexData?.concepts?.length > 0) parts.push(`Concepts: ${indexData.concepts.slice(0, 30).map(c => c.name).join(', ')}`);
+  if (book.categories?.length > 0) parts.push(`Categories: ${book.categories.join(', ')}`);
+  return parts.join('\n').slice(0, 8000);
+}
+
+async function composeRichWithRollup(book, indexData) {
+  const richBase = composeRich(book, indexData);
+
+  // Page summaries → LLM-condensed retrieval fingerprint.
+  const pageSummaries = (indexData?.pageSummaries || []).map(p => p.summary || '').filter(Boolean);
+  if (pageSummaries.length === 0) return richBase;
+
+  const pageBlock = pageSummaries.join('\n');
+  if (pageBlock.length < 400) {
+    return (richBase + '\n' + pageBlock).slice(0, 8000);
+  }
+
+  const prompt = `You are creating a retrieval fingerprint for a book. Below are page-level summaries.
+Condense them into a dense, retrieval-friendly representation of EVERYTHING distinctive
+the book contains: every named person, place, concept, technical term, comparison, example,
+and recurring metaphor. Prioritize specific vocabulary over generic description. List the
+distinctive terms and phrases that appear. Do NOT add interpretation or assessment. Output
+plain text, up to 600 words.
+
+PAGE SUMMARIES:
+${pageBlock.slice(0, 30000)}`;
+
+  const resp = await ai.models.generateContent({
+    model: 'gemini-3.1-flash-lite',
+    contents: prompt,
+    config: { temperature: 0.2 },
+  });
+  const condensed = resp.text?.trim() || '';
+  return (richBase + '\n\nContent fingerprint:\n' + condensed).slice(0, 8000);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  await mongo.connect();
+  const db = mongo.db('bookstore');
+
+  const book = await db.collection('books').findOne({ slug: TARGET_SLUG });
+  if (!book) {
+    console.error(`Book not found: ${TARGET_SLUG}`);
+    process.exit(1);
+  }
+  const indexData = await db.collection('book_indexes').findOne({ book_id: book.id });
+
+  console.log(`\nTarget: "${book.display_title || book.title}" by ${book.author}`);
+  console.log(`  pages: ${book.pages_translated}/${book.pages_count} translated`);
+  console.log(`  has reading_summary: ${!!book.reading_summary?.detailed}`);
+  console.log(`  has book_index: ${!!indexData}`);
+  console.log(`  has sectionSummaries: ${(indexData?.sectionSummaries?.length || 0) > 0}`);
+  console.log(`  has pageSummaries: ${(indexData?.pageSummaries?.length || 0) > 0} (${indexData?.pageSummaries?.length || 0} pages)`);
+
+  console.log('\nComposing text variants...');
+  const currentText = composeCurrent(book, indexData);
+  const richText = composeRich(book, indexData);
+  console.log('  Calling LLM for page-summary roll-up...');
+  const richRollupText = await composeRichWithRollup(book, indexData);
+
+  console.log(`\nText sizes:`);
+  console.log(`  current   : ${currentText.length} chars`);
+  console.log(`  rich      : ${richText.length} chars  (+${richText.length - currentText.length})`);
+  console.log(`  rich+llm  : ${richRollupText.length} chars`);
+
+  // Show what got added (rich - current diff, abbreviated)
+  console.log(`\n=== Sample of what RICH adds (first 600 chars new content) ===`);
+  // Find content in rich not in current
+  const newInRich = richText.split('\n').filter(line => !currentText.includes(line) && line.trim().length > 0).join('\n');
+  console.log(newInRich.slice(0, 600));
+
+  // Embed all three
+  console.log('\nEmbedding variants...');
+  const embCurrent = await embed(currentText);
+  const embRich = await embed(richText);
+  const embRichRollup = await embed(richRollupText);
+
+  // Get current production embedding for this book to verify our re-embed of "current" matches
+  const { data: prodRow } = await supabase
+    .from('book_embeddings')
+    .select('book_id, summary_text, embedding')
+    .eq('book_id', book.id)
+    .limit(1)
+    .single();
+  let productionMatch = null;
+  if (prodRow?.embedding) {
+    const prodEmb = JSON.parse(prodRow.embedding);
+    productionMatch = cosine(embCurrent, prodEmb);
+  }
+  console.log(`  Sanity: our 'current' recompute vs production embedding cosine = ${productionMatch?.toFixed(4) || 'n/a'}`);
+
+  // For each query, run the production semantic search and see where this book ranks,
+  // then compute cosine for each text variant
+  console.log('\n┌─ Per-query lift (cosine sim to target book) ────────────────────────────────┐');
+  console.log('│ query                              │ current │ rich   │ rich+llm │ prod-rank│');
+  console.log('├────────────────────────────────────┼─────────┼────────┼──────────┼──────────┤');
+
+  for (const query of QUERIES) {
+    const qEmb = await embed(query);
+    const cCurrent = cosine(qEmb, embCurrent);
+    const cRich = cosine(qEmb, embRich);
+    const cRichRollup = cosine(qEmb, embRichRollup);
+
+    // Where does this book rank in current production book_embeddings?
+    const { data: matches } = await supabase.rpc('match_books_semantic', {
+      query_embedding: JSON.stringify(qEmb),
+      match_threshold: 0.0,
+      match_count: 100,
+      filter_language: null,
+      filter_year_min: null,
+      filter_year_max: null,
+    });
+    const rank = (matches || []).findIndex(m => m.book_id === book.id);
+    const rankStr = rank === -1 ? '>100' : String(rank + 1);
+
+    const q = query.length > 36 ? query.slice(0, 33) + '...' : query.padEnd(36);
+    console.log(`│ ${q.padEnd(34)} │  ${cCurrent.toFixed(3)}  │ ${cRich.toFixed(3)}  │  ${cRichRollup.toFixed(3)}   │   ${rankStr.padEnd(6)} │`);
+  }
+  console.log('└──────────────────────────────────────────────────────────────────────────────┘');
+
+  await mongo.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/eval/librarian-search/golden-set.json
+++ b/scripts/eval/librarian-search/golden-set.json
@@ -1,0 +1,229 @@
+{
+  "description": "Librarian search evaluation — golden set. Hand-curated 2026-05-28. Each entry has a confidence tag; treat 'low' as diagnostic rather than ground truth.",
+  "match_rules": {
+    "book_slug": "Hit's book_slug must equal an expected entry. Multiple editions of the same work are listed separately — hitting any one of them counts.",
+    "page_min_max": "If set, the hit's page_number must fall in [page_min, page_max] inclusive. Allows tolerance for OCR/translation page shift. Omit for any-page-counts queries (most broad-themes and bibliographic)."
+  },
+  "queries": [
+    {
+      "id": "agrippa-natural-magic",
+      "query": "Agrippa on natural magic and planetary correspondences",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "henrici-cor-agrippae-ab-nettesheym-de-occvlta-philosophia-agrippa-von" },
+        { "book_slug": "three-books-of-occult-philosophy-1533-latin-agrippa" },
+        { "book_slug": "de-occulta-philosophia-complete-edition-agrippa" },
+        { "book_slug": "de-occulta-philosophia-libri-tres-agrippa" },
+        { "book_slug": "three-books-of-occult-philosophy-nettesheim" }
+      ],
+      "notes": "Several editions of Three Books of Occult Philosophy. Any is a hit."
+    },
+    {
+      "id": "bruno-art-of-memory",
+      "query": "Giordano Bruno on memory images and the art of memory",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "de-vmbris-idearvm-implicantibus-artem-quaerendi-inveniendi-bruno" },
+        { "book_slug": "iordani-bruni-nolani-de-imaginum-signorum-amp-idearum-bruno" }
+      ],
+      "notes": "Bruno's mnemonic / 'shadows of ideas' works. De infinito is not in the collection — this tests Bruno coverage we DO have."
+    },
+    {
+      "id": "ficino-spiritus-talismans",
+      "query": "Ficino on drawing down celestial spirits with talismans and music",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "three-books-on-life-1489-first-edition-ficino" },
+        { "book_slug": "three-books-on-life-ficino" },
+        { "book_slug": "three-books-on-life-ficino-2" },
+        { "book_slug": "de-vita-libri-tres-three-books-on-life-1529-ficino" },
+        { "book_slug": "three-books-on-life-ficino-3" }
+      ],
+      "notes": "De Vita Coelitus Comparanda (Book III of De Vita) is the canonical text on spiritus/talismans."
+    },
+    {
+      "id": "kepler-harmony-spheres",
+      "query": "Kepler on the harmony of the spheres and planetary music",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "harmonices-mundi-1619-first-edition-kepler" },
+        { "book_slug": "harmony-of-the-world-with-mysterium-cosmographicum-kepler" }
+      ]
+    },
+    {
+      "id": "fludd-macrocosm-microcosm",
+      "query": "Robert Fludd on the macrocosm and microcosm",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "history-of-the-macrocosm-and-microcosm-fludd" },
+        { "book_slug": "history-of-both-worlds-macrocosm-fludd" },
+        { "book_slug": "history-of-both-worlds-microcosm-fludd" },
+        { "book_slug": "utriusque-cosmi-maioris-scilicet-et-minoris-metaphysica-fludd" }
+      ]
+    },
+    {
+      "id": "paracelsus-archidoxes",
+      "query": "Paracelsus on the spagyric preparation of metals and the archidoxes",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "archidoxae-philippi-theophrasti-paracelsi-magni-germani-paracelsus" },
+        { "book_slug": "nobiblis-clarissimi-ac-probatissimi-philosophi-medici-dn-paracelsus" }
+      ],
+      "notes": "Two Archidoxes editions with full translation. The 0-translated ones excluded."
+    },
+    {
+      "id": "porta-natural-magic",
+      "query": "Della Porta on natural magic and the secrets of nature",
+      "category": "well-known-concept",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "magia-naturalis-libri-xx-1607-porta" },
+        { "book_slug": "magia-naturalis-1619-latin-porta" },
+        { "book_slug": "natural-magic-or-on-the-miracles-of-natural-things-porta" },
+        { "book_slug": "natural-magick-1658-english-porta" }
+      ]
+    },
+    {
+      "id": "kircher-magnetism",
+      "query": "magnetic experiments with iron and lodestone",
+      "category": "niche-passage",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "on-the-loadstone-and-magnetic-bodies-english-translation-gilbert" },
+        { "book_slug": "de-magnete-1600-first-edition-gilbert" },
+        { "book_slug": "de-magnete-magneticisque-corporibus-et-de-magno-magnete-gilbert" },
+        { "book_slug": "tractatus-sive-physiologia-nova-de-magnete-gilbert" },
+        { "book_slug": "magnes-sive-de-arte-magnetica-kircher" },
+        { "book_slug": "athanasii-kircheri-magnes-sive-de-arte-magnetica-opus-kircher" },
+        { "book_slug": "magneticum-naturae-regnum-kircher" },
+        { "book_slug": "athanasii-kircheri-magneticum-naturae-regnum-sive-kircher" },
+        { "book_slug": "athanasii-kircheri-ars-magnesia-hoc-est-disquisitio-kircher" }
+      ],
+      "notes": "Gilbert's De Magnete (1600, founding work) and Kircher's Magnes sive de Arte Magnetica (1641, canonical Kircher) are both legitimate answers. Multiple editions of each — any hit counts."
+    },
+    {
+      "id": "vesalius-anatomy-skull",
+      "query": "anatomy of the human skull and cranial sutures",
+      "category": "niche-passage",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "vesalius-de-humani-corporis-fabrica-1555-vesalius" },
+        { "book_slug": "de-humani-corporis-fabrica-1543-first-edition-vesalius" },
+        { "book_slug": "andreae-vesalii-bruxellensis-scholae-medicorum-patavinae-vesalius" },
+        { "book_slug": "de-re-anatomica-libri-xv-colombo" },
+        { "book_slug": "de-re-anatomica-libri-xv-1562-ed-colombo" },
+        { "book_slug": "opuscula-anatomica-eustachio" },
+        { "book_slug": "tabulae-anatomicae-eustachi" }
+      ],
+      "notes": "Vesalius's Fabrica (the canonical anatomy of the skull is in Book I) plus Colombo's De Re Anatomica (Vesalius's pupil/rival) and Eustachio's Tabulae (famous anatomical plates). Query has no author cue — tests broad semantic matching."
+    },
+    {
+      "id": "boehme-aurora",
+      "query": "the seven fountain spirits or properties of nature",
+      "category": "niche-passage",
+      "confidence": "medium",
+      "expected": [
+        { "book_slug": "aurora-or-the-day-spring-bohme" },
+        { "book_slug": "theosophia-revelata-aurora-oder-morgenrothe-vol-1-bohme" }
+      ],
+      "notes": "Boehme's seven Quellgeister doctrine — central to Aurora and his later works."
+    },
+    {
+      "id": "emerald-tablet",
+      "query": "as above so below — the Emerald Tablet of Hermes",
+      "category": "verbatim-quote",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "tabula-smaragdina-trismegistus" },
+        { "book_slug": "hermetis-trismegisti-phoenicum-aegyptorum-sed-et-aliarum-kriegsmann" }
+      ]
+    },
+    {
+      "id": "rosicrucian-manifestos",
+      "query": "Fama Fraternitatis brothers of the Rose Cross",
+      "category": "verbatim-quote",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "fama-fraternitatis-1615-danzig-attr" },
+        { "book_slug": "fama-fraternitatis-und-confessio-fraternitatis-rosicrucian" },
+        { "book_slug": "fama-fraternitatis-oder-entdeckung-der-bruderschafft-de-andrea" },
+        { "book_slug": "fama-fraternitatis-oder-entdeckung-der-brudersch-des-ordens-fraternitatis" }
+      ]
+    },
+    {
+      "id": "indian-rasa-alchemy",
+      "query": "Indian alchemy mercury rasa preparation",
+      "category": "cross-lingual",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "rasaratnasamuccaya-vagbhata" },
+        { "book_slug": "rasaratnakara-rasayanakhanda-acarya" },
+        { "book_slug": "rasaratnakara-manuscript-nagarjuna" }
+      ],
+      "notes": "Sanskrit Rasashastra texts. English query against English translations. Druze 'Rasa'il' and Ikhwan al-Safa 'Rasa'il' are false positives — different meaning of 'rasa'."
+    },
+    {
+      "id": "artemidorus-dreams",
+      "query": "dream interpretation in the ancient world",
+      "category": "broad-theme",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "oneirocritica-daldianus" },
+        { "book_slug": "artemidori-daldiani-achmetis-sereimi-f-oneirocritica-artemidorus" },
+        { "book_slug": "de-somniorum-interpretatione-libri-quinque-cornarius" },
+        { "book_slug": "de-somniorum-interpretatione-daldis" },
+        { "book_slug": "traumbuch-artemidori-darinnen-ursprung-unterscheid-und-artemidorus" }
+      ],
+      "notes": "Artemidorus's Oneirocritica — multiple editions. Macrobius (Commentary on the Dream of Scipio) would also count if present."
+    },
+    {
+      "id": "sympathetic-magic-renaissance",
+      "query": "sympathetic magic and occult virtues in nature",
+      "category": "broad-theme",
+      "confidence": "medium",
+      "expected": [
+        { "book_slug": "henrici-cor-agrippae-ab-nettesheym-de-occvlta-philosophia-agrippa-von" },
+        { "book_slug": "three-books-of-occult-philosophy-1533-latin-agrippa" },
+        { "book_slug": "three-books-of-occult-philosophy-nettesheim" },
+        { "book_slug": "magia-naturalis-libri-xx-1607-porta" },
+        { "book_slug": "magia-naturalis-1619-latin-porta" },
+        { "book_slug": "natural-magic-or-on-the-miracles-of-natural-things-porta" },
+        { "book_slug": "natural-magick-1658-english-porta" },
+        { "book_slug": "three-books-on-life-ficino" },
+        { "book_slug": "de-vita-libri-tres-three-books-on-life-1529-ficino" }
+      ],
+      "notes": "Agrippa, Della Porta, and Ficino are the canonical Renaissance sources. Hitting any one counts as recall. May score lower than other queries because there's no single 'right' book."
+    },
+    {
+      "id": "books-on-geomancy",
+      "query": "books about geomancy and divination by points",
+      "category": "bibliographic",
+      "confidence": "high",
+      "expected": [
+        { "book_slug": "fourth-book-of-occult-philosophy-pseudo-agrippa-with" },
+        { "book_slug": "agrippa-fourth-book-of-occult-philosophy-with-geomancy-cremonensis" },
+        { "book_slug": "fourth-book-of-occult-philosophy-arbatel-of-magick-peter-de-al" },
+        { "book_slug": "la-geomance-cattan" },
+        { "book_slug": "ramala-grantha-geomancy" }
+      ]
+    },
+    {
+      "id": "christian-cabala",
+      "query": "Christian cabala in the Renaissance",
+      "category": "bibliographic",
+      "confidence": "medium",
+      "expected": [
+        { "book_slug": "cabala-mirror-of-art-and-nature-in-alchemy-michelspacher-2" },
+        { "book_slug": "apologia-fratris-archangelus-de-burgonovo-pro-defensione-arcangelo" },
+        { "book_slug": "artis-cabalisticae-hoc-est-reconditae-theologiae-et-kabbala" }
+      ],
+      "notes": "Pico, Reuchlin, Kircher's Oedipus would also count if present. 'Cuaderno de las alcabalas' is a false positive (Spanish tax word, not Kabbalah)."
+    }
+  ]
+}

--- a/scripts/eval/librarian-search/metrics.mjs
+++ b/scripts/eval/librarian-search/metrics.mjs
@@ -1,0 +1,78 @@
+/**
+ * Retrieval metrics for the Librarian search eval.
+ *
+ * All functions take:
+ *   hits: ordered array of { book_slug, page_number } (best first)
+ *   expected: array of { book_slug, page_min?, page_max? }
+ *
+ * Match rule: hit matches an expected entry when the book_slug agrees AND
+ * (if page_min/page_max are set) the page_number falls within.
+ *
+ * The page-range tolerance exists because translations sometimes shift page
+ * numbering relative to the original (front matter, blank pages, plates), so
+ * pinning to an exact page would be too strict for most queries. Use exact
+ * pages only when the golden-set author is confident.
+ */
+
+export function matches(hit, expected) {
+  return expected.some(e => {
+    if (hit.book_slug !== e.book_slug) return false;
+    if (e.page_min != null && hit.page_number < e.page_min) return false;
+    if (e.page_max != null && hit.page_number > e.page_max) return false;
+    return true;
+  });
+}
+
+/**
+ * Precision@K: fraction of the top-K hits that are correct.
+ * If fewer than K hits are returned, divides by actual count (not K),
+ * so a variant returning 2 correct hits out of 2 scores 1.0, not 0.4.
+ */
+export function precisionAtK(hits, expected, k = 5) {
+  const top = hits.slice(0, k);
+  if (top.length === 0) return 0;
+  const correct = top.filter(h => matches(h, expected)).length;
+  return correct / top.length;
+}
+
+/**
+ * Recall@K: fraction of expected entries hit by at least one top-K hit.
+ * Counts distinct expected entries matched (so two hits in the same expected
+ * book/range count as one).
+ */
+export function recallAtK(hits, expected, k = 5) {
+  if (expected.length === 0) return 1; // nothing to recall = perfect
+  const top = hits.slice(0, k);
+  const matchedExpected = expected.filter(e =>
+    top.some(h => matches(h, [e])),
+  );
+  return matchedExpected.length / expected.length;
+}
+
+/**
+ * Mean Reciprocal Rank: 1 / rank of the first correct hit, 0 if none in top 20.
+ * A single-query MRR is just the reciprocal rank; the "mean" applies across the
+ * query set in the runner.
+ */
+export function reciprocalRank(hits, expected, maxRank = 20) {
+  for (let i = 0; i < Math.min(hits.length, maxRank); i++) {
+    if (matches(hits[i], expected)) return 1 / (i + 1);
+  }
+  return 0;
+}
+
+/** Aggregate per-variant metrics across a query set. */
+export function aggregate(perQueryResults) {
+  if (perQueryResults.length === 0) {
+    return { p5: 0, r5: 0, mrr: 0, p1: 0, count: 0 };
+  }
+  const sum = (key) => perQueryResults.reduce((s, r) => s + r[key], 0);
+  return {
+    count: perQueryResults.length,
+    p1: sum('p1') / perQueryResults.length,
+    p5: sum('p5') / perQueryResults.length,
+    r5: sum('r5') / perQueryResults.length,
+    mrr: sum('mrr') / perQueryResults.length,
+    avgLatencyMs: sum('latencyMs') / perQueryResults.length,
+  };
+}

--- a/scripts/eval/librarian-search/run.mjs
+++ b/scripts/eval/librarian-search/run.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Librarian search evaluation runner.
+ *
+ * Loads the golden set, runs each variant against each query, computes
+ * precision@5 / recall@5 / MRR per variant, prints a summary, and writes
+ * a JSON report to results/<timestamp>.json.
+ *
+ * Usage:
+ *   set -a; source ../../../../.env.production.local; set +a
+ *   node scripts/eval/librarian-search/run.mjs
+ *   node scripts/eval/librarian-search/run.mjs --variant=rrf
+ *   node scripts/eval/librarian-search/run.mjs --query=agrippa-planetary-seals
+ *   node scripts/eval/librarian-search/run.mjs --verbose
+ *   node scripts/eval/librarian-search/run.mjs --category=niche-passage
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+import { VARIANTS } from './variants.mjs';
+import { precisionAtK, recallAtK, reciprocalRank, aggregate } from './metrics.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── Arg parsing ───────────────────────────────────────────────────────
+
+function arg(name, def) {
+  const flag = `--${name}=`;
+  const found = process.argv.find(a => a.startsWith(flag));
+  return found ? found.slice(flag.length) : def;
+}
+function flag(name) {
+  return process.argv.includes(`--${name}`);
+}
+
+const wantedVariant = arg('variant', null);
+const wantedQuery = arg('query', null);
+const wantedCategory = arg('category', null);
+const verbose = flag('verbose');
+
+// ── Clients ───────────────────────────────────────────────────────────
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing env: ${name}. Source .env.production.local first.`);
+    process.exit(1);
+  }
+  return v;
+}
+
+const mongoUri = requireEnv('MONGODB_URI');
+const mongoDb = process.env.MONGODB_DB || 'bookstore';
+const supabaseUrl = requireEnv('SUPABASE_URL');
+const supabaseKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
+const geminiKey = requireEnv('GEMINI_API_KEY');
+
+const mongoClient = new MongoClient(mongoUri);
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+// ── Embedding fn (cached per query — many variants embed the same string) ──
+
+const embedCache = new Map();
+async function embedFn(text, dims = 768) {
+  const key = `${dims}:${text}`;
+  if (embedCache.has(key)) return embedCache.get(key);
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:batchEmbedContents?key=${geminiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requests: [{
+            model: 'models/gemini-embedding-2-preview',
+            content: { parts: [{ text }] },
+            outputDimensionality: dims,
+          }],
+        }),
+        signal: AbortSignal.timeout(10000),
+      },
+    );
+    if (!res.ok) {
+      console.error(`Embedding API ${res.status}: ${await res.text().then(t => t.slice(0, 200))}`);
+      embedCache.set(key, null);
+      return null;
+    }
+    const data = await res.json();
+    const vec = data?.embeddings?.[0]?.values || null;
+    embedCache.set(key, vec);
+    return vec;
+  } catch (err) {
+    console.error(`Embedding error: ${err.message}`);
+    embedCache.set(key, null);
+    return null;
+  }
+}
+
+// ── Runner ────────────────────────────────────────────────────────────
+
+async function runOne(variant, query, ctx) {
+  const start = Date.now();
+  let hits = [];
+  let error = null;
+  try {
+    hits = await variant.fn(query.query, ctx);
+  } catch (err) {
+    error = err.message;
+  }
+  const latencyMs = Date.now() - start;
+  const p1 = hits.length > 0 && (hits.slice(0, 1).filter(h => matchesAny(h, query.expected)).length > 0) ? 1 : 0;
+  return {
+    queryId: query.id,
+    queryText: query.query,
+    category: query.category,
+    confidence: query.confidence,
+    expected: query.expected,
+    hits,
+    error,
+    latencyMs,
+    p1,
+    p5: precisionAtK(hits, query.expected, 5),
+    r5: recallAtK(hits, query.expected, 5),
+    mrr: reciprocalRank(hits, query.expected, 20),
+  };
+}
+
+function matchesAny(hit, expected) {
+  return expected.some(e => {
+    if (hit.book_slug !== e.book_slug) return false;
+    if (e.page_min != null && hit.page_number < e.page_min) return false;
+    if (e.page_max != null && hit.page_number > e.page_max) return false;
+    return true;
+  });
+}
+
+async function main() {
+  // Load golden set
+  const goldenPath = path.join(__dirname, 'golden-set.json');
+  if (!fs.existsSync(goldenPath)) {
+    console.error(`Golden set not found at ${goldenPath}. Create it first.`);
+    process.exit(1);
+  }
+  const golden = JSON.parse(fs.readFileSync(goldenPath, 'utf8'));
+
+  // Filter queries
+  let queries = golden.queries;
+  if (wantedQuery) queries = queries.filter(q => q.id === wantedQuery);
+  if (wantedCategory) queries = queries.filter(q => q.category === wantedCategory);
+  if (queries.length === 0) {
+    console.error('No matching queries.');
+    process.exit(1);
+  }
+
+  // Filter variants
+  let variantEntries = Object.entries(VARIANTS);
+  if (wantedVariant) variantEntries = variantEntries.filter(([name]) => name === wantedVariant);
+  if (variantEntries.length === 0) {
+    console.error(`Unknown variant. Known: ${Object.keys(VARIANTS).join(', ')}`);
+    process.exit(1);
+  }
+
+  await mongoClient.connect();
+  const db = mongoClient.db(mongoDb);
+  const ctx = { db, supabase, embedFn };
+
+  console.log(`\nLibrarian Search Eval`);
+  console.log(`  Queries:  ${queries.length}${wantedQuery ? ` (filter: ${wantedQuery})` : ''}${wantedCategory ? ` (category: ${wantedCategory})` : ''}`);
+  console.log(`  Variants: ${variantEntries.map(([n]) => n).join(', ')}\n`);
+
+  const results = {}; // variantName → [perQueryResult]
+
+  for (const [variantName, variant] of variantEntries) {
+    process.stdout.write(`  ${variantName.padEnd(20)} `);
+    results[variantName] = [];
+    for (const query of queries) {
+      const r = await runOne(variant, query, ctx);
+      results[variantName].push(r);
+      process.stdout.write(r.error ? 'x' : (r.p1 ? '.' : (r.r5 > 0 ? 'o' : '-')));
+    }
+    process.stdout.write('\n');
+  }
+
+  // ── Summary table ───────────────────────────────────────────────────
+  console.log('\n┌─ Aggregate ─────────────────────────────────────────────────────────────┐');
+  console.log('│ Variant              │  P@1   │  P@5   │  R@5   │  MRR   │  avg ms       │');
+  console.log('├──────────────────────┼────────┼────────┼────────┼────────┼───────────────┤');
+  for (const [variantName] of variantEntries) {
+    const agg = aggregate(results[variantName]);
+    const fmt = n => n.toFixed(3);
+    const lat = String(Math.round(agg.avgLatencyMs)).padStart(6) + ' ms';
+    console.log(`│ ${variantName.padEnd(20)} │ ${fmt(agg.p1)}  │ ${fmt(agg.p5)}  │ ${fmt(agg.r5)}  │ ${fmt(agg.mrr)}  │ ${lat}        │`);
+  }
+  console.log('└─────────────────────────────────────────────────────────────────────────┘');
+
+  // ── Per-category breakdown ──────────────────────────────────────────
+  const categories = [...new Set(queries.map(q => q.category))];
+  if (categories.length > 1) {
+    console.log('\nBy category (R@5):');
+    process.stdout.write('  variant'.padEnd(22));
+    for (const cat of categories) process.stdout.write(cat.padEnd(20));
+    console.log();
+    for (const [variantName] of variantEntries) {
+      process.stdout.write(`  ${variantName.padEnd(20)}`);
+      for (const cat of categories) {
+        const inCat = results[variantName].filter(r => r.category === cat);
+        const r5 = aggregate(inCat).r5;
+        process.stdout.write(r5.toFixed(3).padEnd(20));
+      }
+      console.log();
+    }
+  }
+
+  // ── Verbose per-query dump ──────────────────────────────────────────
+  if (verbose) {
+    console.log('\nPer-query results:');
+    for (const query of queries) {
+      console.log(`\n  [${query.category}] ${query.id} — "${query.query}"`);
+      console.log(`    expected: ${query.expected.map(e => e.book_slug + (e.page_min ? `:${e.page_min}-${e.page_max}` : '')).join(', ')}`);
+      for (const [variantName] of variantEntries) {
+        const r = results[variantName].find(x => x.queryId === query.id);
+        const tag = r.error ? `ERROR: ${r.error}` : `r5=${r.r5.toFixed(2)} mrr=${r.mrr.toFixed(2)}`;
+        console.log(`    ${variantName.padEnd(20)} ${tag}`);
+        if (r.hits.length === 0) {
+          console.log(`      (no hits)`);
+        } else {
+          for (let i = 0; i < Math.min(r.hits.length, 5); i++) {
+            const h = r.hits[i];
+            const hit = matchesAny(h, query.expected) ? '✓' : ' ';
+            console.log(`      ${hit} ${i + 1}. ${h.book_slug || '<no-slug>'} p.${h.page_number} (${(h.score ?? 0).toFixed(3)}, ${h.source})`);
+          }
+        }
+      }
+    }
+  }
+
+  // ── Save report ─────────────────────────────────────────────────────
+  const resultsDir = path.join(__dirname, 'results');
+  fs.mkdirSync(resultsDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const reportPath = path.join(resultsDir, `${stamp}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify({
+    timestamp: new Date().toISOString(),
+    queryCount: queries.length,
+    variants: Object.fromEntries(variantEntries.map(([n, v]) => [n, v.description])),
+    aggregates: Object.fromEntries(Object.entries(results).map(([n, rs]) => [n, aggregate(rs)])),
+    perQuery: results,
+  }, null, 2));
+  console.log(`\nReport: ${path.relative(process.cwd(), reportPath)}`);
+
+  await mongoClient.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/eval/librarian-search/variants.mjs
+++ b/scripts/eval/librarian-search/variants.mjs
@@ -1,0 +1,283 @@
+/**
+ * Search variants under test.
+ *
+ * Each variant is `async (query, ctx) => SearchHit[]` where SearchHit is
+ *   { book_id, book_slug, page_number, snippet, score, source }
+ *
+ * ctx holds shared clients (`db`, `supabase`, `embedFn`) so variants don't
+ * each open their own connections.
+ *
+ * The Atlas $search stage shape and the Supabase RPC parameters are mirrored
+ * from `src/lib/atlas-search.ts` and `src/lib/semantic-search.ts`. Keep in
+ * sync if those change — the eval is meaningless if it tests something the
+ * Librarian doesn't actually run.
+ *
+ * Tenant filtering: the Librarian post-filters to main-site only (tenantId
+ * null/undefined). We do the same here so the eval reflects what main-site
+ * users actually see.
+ */
+
+const BOOK_SEARCH_INDEX = 'books_search';
+const PAGE_SEARCH_INDEX = 'pages_search';
+
+// ── Atlas keyword search (mirrors executeSearchCollection) ────────────
+
+function pageSearchStage(query) {
+  return {
+    $search: {
+      index: PAGE_SEARCH_INDEX,
+      compound: {
+        should: [
+          { text: { query, path: 'translation.data', score: { boost: { value: 2 } } } },
+          { text: { query, path: 'ocr.data' } },
+        ],
+        minimumShouldMatch: 1,
+      },
+    },
+  };
+}
+
+async function tenantVisibleBooks(db, bookIds) {
+  if (bookIds.length === 0) return new Map();
+  const docs = await db.collection('books')
+    .find({
+      id: { $in: bookIds },
+      hidden: { $ne: true },
+      tenantId: { $in: [null, undefined] },
+    })
+    .project({ id: 1, slug: 1, title: 1, display_title: 1, author: 1 })
+    .toArray();
+  return new Map(docs.map(d => [d.id, d]));
+}
+
+export async function keywordVariant(query, ctx, limit = 8) {
+  const pages = await ctx.db.collection('pages')
+    .aggregate([
+      pageSearchStage(query),
+      { $limit: 48 }, // over-fetch for tenant filtering
+      { $project: { book_id: 1, page_number: 1, 'translation.data': 1, score: { $meta: 'searchScore' } } },
+    ])
+    .toArray();
+
+  const bookIds = [...new Set(pages.map(p => p.book_id))];
+  const bookMap = await tenantVisibleBooks(ctx.db, bookIds);
+
+  // Cap at 2 hits per book to match the Librarian's behavior
+  const perBook = new Map();
+  const hits = [];
+  for (const p of pages) {
+    const book = bookMap.get(p.book_id);
+    if (!book) continue;
+    const count = perBook.get(p.book_id) || 0;
+    if (count >= 2) continue;
+    perBook.set(p.book_id, count + 1);
+    hits.push({
+      book_id: p.book_id,
+      book_slug: book.slug,
+      page_number: p.page_number,
+      snippet: (p.translation?.data || '').slice(0, 200),
+      score: p.score,
+      source: 'keyword',
+    });
+    if (hits.length >= limit) break;
+  }
+  return hits;
+}
+
+// ── Semantic two-step (mirrors executeSearchSemantic) ─────────────────
+
+async function bookThenPage(query, ctx, limit = 8) {
+  const embedding = await ctx.embedFn(query, 768);
+  if (!embedding) return [];
+
+  const { data: books, error: bookErr } = await ctx.supabase.rpc('match_books_semantic', {
+    query_embedding: JSON.stringify(embedding),
+    match_threshold: 0.3,
+    match_count: 24, // over-request for tenant filter
+    filter_language: null,
+    filter_year_min: null,
+    filter_year_max: null,
+  });
+  if (bookErr || !books?.length) return [];
+
+  const bookIds = books.map(b => b.book_id);
+  const bookMap = await tenantVisibleBooks(ctx.db, bookIds);
+  const visibleBookIds = bookIds.filter(id => bookMap.has(id));
+  if (!visibleBookIds.length) return [];
+
+  const { data: pages, error: pageErr } = await ctx.supabase.rpc('match_pages_in_books', {
+    query_embedding: JSON.stringify(embedding),
+    book_ids: visibleBookIds,
+    match_threshold: 0.3,
+    match_count: limit,
+  });
+  if (pageErr) return [];
+
+  // Keep best page per book, ordered by book similarity
+  const bestPageByBook = new Map();
+  for (const p of (pages || [])) {
+    const existing = bestPageByBook.get(p.book_id);
+    if (!existing || p.similarity > existing.similarity) {
+      bestPageByBook.set(p.book_id, p);
+    }
+  }
+
+  return books
+    .filter(b => bookMap.has(b.book_id))
+    .slice(0, limit)
+    .map(b => {
+      const page = bestPageByBook.get(b.book_id);
+      const book = bookMap.get(b.book_id);
+      return {
+        book_id: b.book_id,
+        book_slug: book.slug,
+        page_number: page?.page_number || 0,
+        snippet: (page?.translation || b.summary_text || '').slice(0, 200),
+        score: b.similarity,
+        source: 'book-then-page',
+      };
+    });
+}
+
+export async function bookThenPageVariant(query, ctx, limit = 8) {
+  return bookThenPage(query, ctx, limit);
+}
+
+// ── Global page-level semantic (the path the Librarian doesn't use) ───
+
+async function globalPage(query, ctx, limit = 8) {
+  const embedding = await ctx.embedFn(query, 768);
+  if (!embedding) return [];
+
+  const { data, error } = await ctx.supabase.rpc('match_semantic', {
+    query_embedding: JSON.stringify(embedding),
+    match_threshold: 0.3,
+    match_count: 24, // over-request for tenant filter + per-book cap
+    filter_tenant_id: null,
+    filter_language: null,
+    filter_year_min: null,
+    filter_year_max: null,
+    filter_languages: null,
+    filter_exclude_languages: null,
+  });
+  if (error || !data?.length) return [];
+
+  const bookIds = [...new Set(data.map(r => r.book_id))];
+  const bookMap = await tenantVisibleBooks(ctx.db, bookIds);
+
+  // Cap at 2 per book like the keyword path
+  const perBook = new Map();
+  const hits = [];
+  for (const r of data) {
+    const book = bookMap.get(r.book_id);
+    if (!book) continue;
+    const count = perBook.get(r.book_id) || 0;
+    if (count >= 2) continue;
+    perBook.set(r.book_id, count + 1);
+    hits.push({
+      book_id: r.book_id,
+      book_slug: book.slug,
+      page_number: r.page_number,
+      snippet: (r.translation || '').slice(0, 200),
+      score: r.similarity,
+      source: 'global-page',
+    });
+    if (hits.length >= limit) break;
+  }
+  return hits;
+}
+
+export async function globalPageVariant(query, ctx, limit = 8) {
+  return globalPage(query, ctx, limit);
+}
+
+// ── Auto-fallback: book-then-page, fall back to global if weak ────────
+
+export async function autoFallbackVariant(query, ctx, limit = 8) {
+  const primary = await bookThenPage(query, ctx, limit);
+  // "Weak" = 0 results OR top result similarity < 0.5
+  const isWeak = primary.length === 0 || (primary[0].score ?? 0) < 0.5;
+  if (!isWeak) return primary;
+
+  const fallback = await globalPage(query, ctx, limit);
+  if (primary.length === 0) return fallback;
+
+  // Merge primary first, then fill with fallback hits not already represented
+  const seen = new Set(primary.map(h => `${h.book_id}:${h.page_number}`));
+  const merged = [...primary];
+  for (const h of fallback) {
+    const key = `${h.book_id}:${h.page_number}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ ...h, source: 'global-page (fallback)' });
+    if (merged.length >= limit) break;
+  }
+  return merged;
+}
+
+// ── RRF merge: keyword + book-then-page + global-page ─────────────────
+
+/**
+ * Reciprocal Rank Fusion. Each source contributes 1/(k+rank) per hit;
+ * scores summed across sources. k=60 is the canonical default from the
+ * Cormack/Clarke/Buettcher 2009 paper; lower k weights top results more.
+ */
+function rrfMerge(rankedLists, k = 60, limit = 8) {
+  const scores = new Map(); // key → {hit, score}
+  for (const list of rankedLists) {
+    for (let i = 0; i < list.length; i++) {
+      const hit = list[i];
+      const key = `${hit.book_id}:${hit.page_number}`;
+      const contribution = 1 / (k + i + 1);
+      const existing = scores.get(key);
+      if (existing) {
+        existing.score += contribution;
+        // Prefer the hit with the longer snippet for downstream display
+        if ((hit.snippet?.length || 0) > (existing.hit.snippet?.length || 0)) {
+          existing.hit = { ...hit, source: `rrf(${existing.hit.source}+${hit.source})` };
+        }
+      } else {
+        scores.set(key, { hit, score: contribution });
+      }
+    }
+  }
+  return [...scores.values()]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ hit, score }) => ({ ...hit, score, source: hit.source.startsWith('rrf') ? hit.source : `rrf(${hit.source})` }));
+}
+
+export async function rrfVariant(query, ctx, limit = 8) {
+  // Over-fetch from each source so the merge has material to rank
+  const [kw, btp, gp] = await Promise.all([
+    keywordVariant(query, ctx, 20),
+    bookThenPageVariant(query, ctx, 20),
+    globalPageVariant(query, ctx, 20),
+  ]);
+  return rrfMerge([kw, btp, gp], 60, limit);
+}
+
+// ── Variant registry ──────────────────────────────────────────────────
+
+export const VARIANTS = {
+  'keyword': {
+    description: 'Atlas keyword search only (current search_collection)',
+    fn: keywordVariant,
+  },
+  'book-then-page': {
+    description: 'Semantic book discovery → page drill-down (current search_semantic)',
+    fn: bookThenPageVariant,
+  },
+  'global-page': {
+    description: 'Global page-level semantic search (not currently used by Librarian)',
+    fn: globalPageVariant,
+  },
+  'auto-fallback': {
+    description: 'book-then-page; fall back to global-page if weak',
+    fn: autoFallbackVariant,
+  },
+  'rrf': {
+    description: 'Reciprocal Rank Fusion of keyword + book-then-page + global-page',
+    fn: rrfVariant,
+  },
+};


### PR DESCRIPTION
## What

A quantitative evaluation harness for the Librarian's search tools, in `scripts/eval/librarian-search/`. Compares search variants against a hand-validated golden set and reports precision@5, recall@5, and MRR per variant.

## Why

The Librarian picks between `search_collection` (Atlas keyword) and `search_semantic` (book-then-page Supabase). Two known weaknesses — book-then-page misses passages in books whose summaries don't match the query, and there's no hybrid scoring or reranking. Tuning either without measurement is guesswork; this harness lets us A/B variants (auto-fallback to global, RRF merge, cross-encoder rerank) against a fixed query set.

## Scope

- **Additive only** — 8 new files under `scripts/eval/librarian-search/`, no changes to app or pipeline code. Zero runtime/build impact.
- `golden-set.json` (229 lines, hand-validated query→expected tuples), `variants.mjs`, `metrics.mjs`, `run.mjs`, README.
- Two helper scripts are underscore-prefixed scratch (`_seed-golden-set.mjs`, `_spike-rich-embedding.mjs`) — kept for reproducibility of the golden set; trivial to drop in review if preferred.

## Out of scope

No changes to the live search variants themselves — this only measures them. Acting on the results (hybrid/rerank) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)