### PR TITLE
fix(enrich): plain-encyclopedic About-This-Book summaries + review tooling

### DIFF
--- a/scripts/maintenance/resynthesize-summaries.mjs
+++ b/scripts/maintenance/resynthesize-summaries.mjs
@@ -1,0 +1,185 @@
+/**
+ * Re-synthesize "About This Book" summaries from already-stored index data.
+ *
+ * Why: the synthesis prompt was rewritten (plain encyclopedic, see
+ * scripts/workers/lib/summary-prompt.mjs). Re-running full Phase 6 to refresh
+ * the prose would re-extract every translated page — slow and costly — when
+ * only the final writing step changed. This script reuses the per-book
+ * extraction already stored in `book_indexes` (sectionSummaries, people,
+ * places, concepts, quotes) and runs ONLY the synthesis call: ~1 cheap Gemini
+ * call per book.
+ *
+ * NON-DESTRUCTIVE: writes to `book.summary_candidate`, never to the live
+ * `book.summary` / `book.reading_summary`. Promotion to live happens after
+ * human review via /platform/admin/summary-review.
+ *
+ * Usage:
+ *   node scripts/maintenance/resynthesize-summaries.mjs --ids=ID1,ID2
+ *   node scripts/maintenance/resynthesize-summaries.mjs --sample=150
+ *   node scripts/maintenance/resynthesize-summaries.mjs --all [--limit=N] [--skip-existing]
+ *   node scripts/maintenance/resynthesize-summaries.mjs --sample=20 --dry-run   (print, don't write)
+ */
+
+import { MongoClient } from 'mongodb';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { buildSummaryPrompt, SUMMARY_GEN_CONFIG, SUMMARY_PROMPT_VERSION } from '../workers/lib/summary-prompt.mjs';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const LITE_MODEL = 'gemini-3.1-flash-lite';
+const CONCURRENCY = 6;
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const ALL = args.includes('--all');
+const SKIP_EXISTING = args.includes('--skip-existing');
+const idsArg = args.find(a => a.startsWith('--ids='))?.split('=')[1];
+const sampleArg = args.find(a => a.startsWith('--sample='))?.split('=')[1];
+const limitArg = args.find(a => a.startsWith('--limit='))?.split('=')[1];
+
+const API_KEYS = [
+  process.env.GEMINI_API_KEY,
+  ...Array.from({ length: 9 }, (_, i) => process.env[`GEMINI_API_KEY_${i + 2}`]),
+  process.env.GEMINI_API_KEY_TIER3,
+].filter(Boolean);
+
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+if (API_KEYS.length === 0) { console.error('No Gemini API keys configured'); process.exit(1); }
+
+let keyIndex = 0;
+function nextClient() {
+  const c = new GoogleGenerativeAI(API_KEYS[keyIndex % API_KEYS.length]);
+  keyIndex++;
+  return c;
+}
+
+function parseSummaryJson(text) {
+  const m = text.match(/\{[\s\S]*\}/);
+  if (!m) throw new Error('no JSON in response');
+  try {
+    return JSON.parse(m[0]);
+  } catch {
+    const cleaned = m[0].replace(/,\s*([}\]])/g, '$1').replace(/[\x00-\x1f]/g, ' ');
+    return JSON.parse(cleaned);
+  }
+}
+
+const ensureString = (v) => {
+  if (typeof v === 'string') return v;
+  if (v == null) return '';
+  if (Array.isArray(v)) return v.join('\n\n');
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+};
+
+/** Assemble synthesis inputs from a stored book_indexes doc. */
+function inputsFromIndex(book, idx) {
+  const sections = Array.isArray(idx.sectionSummaries) ? idx.sectionSummaries : [];
+  const sectionSummariesText = sections
+    .map(s => `Pages ${s.startPage ?? '?'}-${s.endPage ?? '?'}: ${s.summary ?? ''}`)
+    .join('\n');
+  const quotes = sections.flatMap(s => Array.isArray(s.quotes) ? s.quotes : []);
+  const quotesText = quotes.slice(0, 15)
+    .map(q => `- "${q.text}" (p. ${q.page ?? '?'})${q.significance ? ` — ${q.significance}` : ''}`)
+    .join('\n');
+
+  const bookLanguage = book.language && book.language !== 'Unknown' ? book.language : '';
+  return {
+    bookTitle: book.title || book.display_title || '(untitled)',
+    englishTitle: book.display_title || '',
+    bookAuthor: book.author || 'Unknown',
+    languageContext: bookLanguage ? ` The original text is in ${bookLanguage}.` : '',
+    researchSection: '',
+    chapterSection: '',
+    themes: (idx.keywords && idx.keywords.length ? idx.keywords : idx.concepts) || [],
+    people: idx.people || [],
+    places: idx.places || [],
+    concepts: idx.concepts || [],
+    sectionSummariesText,
+    quotesText,
+    hasChapters: sections.length > 0,
+  };
+}
+
+async function resynth(book, idx) {
+  const inputs = inputsFromIndex(book, idx);
+  const prompt = buildSummaryPrompt(inputs);
+  const model = nextClient().getGenerativeModel({ model: LITE_MODEL, generationConfig: SUMMARY_GEN_CONFIG });
+  const result = await model.generateContent(prompt);
+  const parsed = parseSummaryJson(result.response.text());
+  return {
+    brief: ensureString(parsed.brief),
+    abstract: ensureString(parsed.abstract),
+    detailed: ensureString(parsed.detailed),
+  };
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+  const indexes = db.collection('book_indexes');
+
+  // Select target books
+  let targets;
+  if (idsArg) {
+    const ids = idsArg.split(',').map(s => s.trim()).filter(Boolean);
+    targets = await books.find({ id: { $in: ids } })
+      .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1 }).toArray();
+  } else {
+    const match = { 'summary.data': { $type: 'string', $ne: '' } };
+    if (SKIP_EXISTING) match.summary_candidate = { $exists: false };
+    if (sampleArg) {
+      targets = await books.aggregate([
+        { $match: match },
+        { $sample: { size: parseInt(sampleArg) } },
+        { $project: { id: 1, title: 1, display_title: 1, author: 1, language: 1 } },
+      ]).toArray();
+    } else if (ALL) {
+      const cur = books.find(match).project({ id: 1, title: 1, display_title: 1, author: 1, language: 1 });
+      if (limitArg) cur.limit(parseInt(limitArg));
+      targets = await cur.toArray();
+    } else {
+      console.error('Specify --ids=, --sample=N, or --all'); await client.close(); process.exit(1);
+    }
+  }
+
+  console.log(`[resynth] prompt=${SUMMARY_PROMPT_VERSION} dry-run=${DRY_RUN} targets=${targets.length}`);
+
+  let done = 0, skipped = 0, failed = 0;
+  const queue = [...targets];
+  const workers = Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
+    while (queue.length) {
+      const book = queue.shift();
+      try {
+        const idx = await indexes.findOne({ book_id: book.id });
+        if (!idx || !Array.isArray(idx.sectionSummaries) || idx.sectionSummaries.length === 0) {
+          skipped++; console.log(`  SKIP (no index) ${book.id} ${book.title?.slice(0, 40)}`); continue;
+        }
+        const cand = await resynth(book, idx);
+        if (!cand.brief) { skipped++; console.log(`  SKIP (empty) ${book.id}`); continue; }
+        if (DRY_RUN) {
+          console.log(`\n--- ${book.title?.slice(0, 50)} (${book.id}) ---\n${cand.brief}`);
+        } else {
+          await books.updateOne({ id: book.id }, { $set: { summary_candidate: {
+            ...cand,
+            generated_at: new Date(),
+            model: LITE_MODEL,
+            prompt_version: SUMMARY_PROMPT_VERSION,
+            status: 'pending',
+          } } });
+        }
+        done++;
+        if (done % 25 === 0) console.log(`  ...${done}/${targets.length}`);
+      } catch (err) {
+        failed++; console.error(`  ERROR ${book.id}: ${err.message}`);
+      }
+    }
+  });
+  await Promise.all(workers);
+
+  console.log(`[resynth] done=${done} skipped=${skipped} failed=${failed}`);
+  await client.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -38,6 +38,7 @@ import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { logUsage as logUsageToSupabase } from './lib/supabase-usage-logger.mjs';
 import { createBookRevisions } from './lib/book-revisions.mjs';
+import { buildSummaryPrompt, SUMMARY_GEN_CONFIG } from './lib/summary-prompt.mjs';
 import { createClient } from '@supabase/supabase-js';
 
 /** Trigger on-demand revalidation for a book page after enrichment completes. */
@@ -614,8 +615,11 @@ function extractPageSummaries(pages) {
 }
 
 // ── Book summary generation ──
-async function generateBookSummary(batchExtractions, bookTitle, bookAuthor, bookLanguage, researchContext, chapters) {
-  const model = getClient().getGenerativeModel({ model: LITE_MODEL });
+async function generateBookSummary(batchExtractions, bookTitle, bookAuthor, bookLanguage, researchContext, chapters, englishTitle) {
+  const model = getClient().getGenerativeModel({
+    model: LITE_MODEL,
+    generationConfig: SUMMARY_GEN_CONFIG,
+  });
 
   if (batchExtractions.length === 0) {
     return {
@@ -646,76 +650,11 @@ async function generateBookSummary(batchExtractions, bookTitle, bookAuthor, book
   const hasChapters = chapters && chapters.length > 0;
   const chapterSection = hasChapters ? `\n## Detected Chapter Structure\n${chapters.map(c => `- Page ${c.pageNumber}: ${c.title}`).join('\n')}\n` : '';
 
-  const prompt = `You're writing compelling copy to help readers discover "${bookTitle}" by ${bookAuthor}.${languageContext}
-
-${researchSection}
-${chapterSection}
-## Extracted from the text:
-
-**Themes:** ${allThemes.join(', ')}
-
-**Key People:** ${allPeople.join(', ') || 'None identified'}
-
-**Key Places:** ${allPlaces.join(', ') || 'None identified'}
-
-**Key Concepts:** ${allConcepts.join(', ')}
-
-## Section-by-section summaries:
-${batchSummariesText}
-
-## Notable quotes extracted:
-${quotesText}
-
-## Your Task
-Synthesize the above into compelling summaries that make readers WANT to explore this text.
-
-**Writing style:**
-- Write like a knowledgeable human, not an AI. Be direct and concrete.
-- NEVER use em-dashes (—). Use commas, colons, semicolons, or separate sentences instead.
-- NEVER use these AI-isms: "delves into", "rich tapestry", "fascinating exploration", "sheds light on", "offers a window into", "comprehensive", "intricate", "nuanced", "multifaceted", "groundbreaking", "seminal".
-- Prefer short, clear sentences over long compound ones.
-- Scholarly but accessible. Say what the text does, not how impressive it is.
-
-1. **BRIEF** (2-3 punchy sentences):
-   - Hook the reader - what's compelling about this text?
-   - What questions does it tackle? What will readers discover?
-
-2. **ABSTRACT** (1 paragraph, 4-6 sentences):
-   - What makes this text worth reading?
-   - What bold claims or intriguing ideas does it contain?
-   - What's the author's unique perspective?
-
-3. **DETAILED** (2-4 paragraphs):
-   - Paint a picture of the journey through this text
-   - Highlight the most striking ideas or arguments
-   - Convey the texture and flavor of the writing
-
-4. **SECTIONS**: ${hasChapters ? 'Use the detected chapter structure.' : 'Group into 5-8 thematic sections.'} For each:
-   - Title and page range
-   - What it covers (2-3 sentences)
-   - 2-4 notable quotes with page numbers and significance
-   - Key concepts
-
-Output as JSON:
-{
-  "brief": "...",
-  "abstract": "...",
-  "detailed": "...",
-  "sections": [
-    {
-      "title": "Section Title",
-      "startPage": 1,
-      "endPage": 10,
-      "summary": "What this section covers...",
-      "quotes": [
-        {"text": "Exact quote", "page": 3, "significance": "Why this matters"}
-      ],
-      "concepts": ["Key Term", "Important Concept"]
-    }
-  ]
-}
-
-IMPORTANT: Use the actual quotes provided above. Don't invent new ones.`;
+  const prompt = buildSummaryPrompt({
+    bookTitle, englishTitle, bookAuthor, languageContext, researchSection, chapterSection,
+    themes: allThemes, people: allPeople, places: allPlaces, concepts: allConcepts,
+    sectionSummariesText: batchSummariesText, quotesText, hasChapters,
+  });
 
   const result = await withTimeout(
     model.generateContent(prompt),
@@ -1036,10 +975,11 @@ async function enrichBook(db, book) {
   if (batchExtractions.length > 0 || researchContext) {
     try {
       const generated = await generateBookSummary(
-        batchExtractions, bookTitle, bookAuthor,
+        batchExtractions, book.title || bookTitle, bookAuthor,
         book.language || undefined,
         researchContext || undefined,
-        chapters.length > 0 ? chapters : undefined
+        chapters.length > 0 ? chapters : undefined,
+        book.display_title || undefined
       );
       bookSummary = { brief: generated.brief, abstract: generated.abstract, detailed: generated.detailed };
       sectionSummaries = generated.sections || [];

--- a/scripts/workers/lib/summary-prompt.mjs
+++ b/scripts/workers/lib/summary-prompt.mjs
@@ -1,0 +1,129 @@
+/**
+ * Shared "About This Book" summary prompt — single source of truth.
+ *
+ * Used by:
+ *   - scripts/workers/enrich-worker.mjs  (Phase 6, full pipeline from translated pages)
+ *   - scripts/maintenance/resynthesize-summaries.mjs  (cheap re-write from stored index data)
+ *
+ * Keeping the prompt here prevents the two callers from drifting. If you tune
+ * the voice, bump SUMMARY_PROMPT_VERSION so generated records are traceable to
+ * a prompt revision.
+ *
+ * Voice: plain encyclopedic — a library catalog note / museum wall label, not
+ * marketing copy. See PR (fix/about-book-prompt) for the before/after rationale.
+ */
+
+export const SUMMARY_PROMPT_VERSION = '2026-05-29-plain-encyclopedic';
+
+// Low temperature keeps the prose factual. At the default (~1.0) flash-lite
+// reaches for grand register ("seminal", "delineates the trajectory of...")
+// and slips into copywriter mode ("Readers will discover...").
+export const SUMMARY_GEN_CONFIG = { temperature: 0.2 };
+
+/**
+ * Build the synthesis prompt from already-assembled inputs.
+ * @param {object} o
+ * @param {string} o.bookTitle      Original-language title (do not pre-translate)
+ * @param {string} [o.englishTitle] English/display title, used only as a gloss
+ * @param {string} o.bookAuthor
+ * @param {string} o.languageContext  e.g. " The original text is in Dutch." or ''
+ * @param {string} o.researchSection  Wikipedia context block or ''
+ * @param {string} o.chapterSection   Detected chapter structure block or ''
+ * @param {string[]} o.themes
+ * @param {string[]} o.people
+ * @param {string[]} o.places
+ * @param {string[]} o.concepts
+ * @param {string} o.sectionSummariesText  Pre-joined "Pages a-b: ..." lines
+ * @param {string} o.quotesText            Pre-joined "- "quote" (p. N)" lines
+ * @param {boolean} o.hasChapters
+ * @returns {string}
+ */
+export function buildSummaryPrompt(o) {
+  const {
+    bookTitle, englishTitle = '', bookAuthor, languageContext = '', researchSection = '',
+    chapterSection = '', themes = [], people = [], places = [], concepts = [],
+    sectionSummariesText = '', quotesText = '', hasChapters = false,
+  } = o;
+
+  // Only treat the English title as a distinct gloss when it actually differs.
+  const hasGloss = englishTitle && englishTitle.trim() && englishTitle.trim() !== bookTitle.trim();
+  const titleRule = hasGloss
+    ? `- Refer to the work by its original title exactly as given: "${bookTitle}". Lead the BRIEF with that original title, then add the English gloss in parentheses once: ("${englishTitle}"). Do not translate the title yourself or use only the English form.`
+    : `- Refer to the work by its original title exactly as given: "${bookTitle}". Do not translate the title. You may add a short English gloss in parentheses once, after the first mention.`;
+
+  return `Write a clear, factual reference description of "${bookTitle}" by ${bookAuthor}.${languageContext} Think of a good library catalog note or a museum wall label: it tells the reader plainly what the text is, what it argues, how it is structured, and who would want to read it. It does not sell.
+
+${researchSection}
+${chapterSection}
+## Extracted from the text:
+
+**Themes:** ${themes.join(', ')}
+
+**Key People:** ${people.join(', ') || 'None identified'}
+
+**Key Places:** ${places.join(', ') || 'None identified'}
+
+**Key Concepts:** ${concepts.join(', ')}
+
+## Section-by-section summaries:
+${sectionSummariesText}
+
+## Notable quotes extracted:
+${quotesText}
+
+## Your Task
+Synthesize the material above into a plain, encyclopedic description. Ground every claim in the extracted content; do not embellish or invent significance.
+
+**Hard rules — these are the difference between a catalog note and ad copy:**
+${titleRule}
+- Do NOT address or refer to the reader. Ban "you", "your", "readers", "readers will discover", "imagine", "discover". The description talks about the text, never to a prospective reader.
+- Do NOT open with a question. No rhetorical hooks ("What if...?", "Why did...?", "How can...?"). Open by naming the work and stating plainly what it is.
+- Do NOT claim modern relevance the text does not contain. No "distractions of modern life", "still resonates today", "timeless". Describe the text in its own terms and period.
+- Never rate the text. Drop all praise vocabulary: no "seminal", "important", "fascinating", "remarkable", "essential", "profound", "rich", "masterful", "groundbreaking", "radical", "bold", "urgent".
+
+**Style:**
+- Also avoid these AI tells: "delves into", "rich tapestry", "sheds light on", "offers a window into", "pulls back the curtain", "comprehensive", "intricate", "nuanced", "multifaceted", and stiff verbs like "delineates", "elucidates", "utilizes" (write "uses"), "explores the trajectory of".
+- No em-dashes (—). Use commas, colons, semicolons, or separate sentences.
+- Short, concrete sentences. Plain words over Latinate ones. Name people, places, and specifics instead of gesturing at them.
+
+Example of the WRONG register (sells, addresses the reader, rates the text — do NOT write like this):
+  "Willem Teellinck strips away the distractions of modern life to focus on a singular, urgent question. Readers will discover a seminal manual for the soul that delineates the trajectory toward sanctification."
+Example of the RIGHT register (states what it is, factual, no reader — write like this):
+  "'t Nieuwe Jerusalem is a devotional treatise cast as a dialogue between the Lord and a woman named Maria. It describes how the soul moves from worldly attachment toward sanctification, joining strict Reformed doctrine to the practice of daily piety. Willem Teellinck wrote it as practical guidance for lay believers of the Dutch Second Reformation."
+
+1. **BRIEF** (2-3 sentences):
+   - Open by naming the work and what kind of text it is (treatise, dialogue, manual, essay, collection). Then state its central subject in plain terms. No hook, no reader.
+
+2. **ABSTRACT** (1 paragraph, 4-6 sentences):
+   - What the text covers, the author's position or method, and the kind of reader it serves. Factual, not promotional.
+
+3. **DETAILED** (2-4 paragraphs):
+   - How the text is organized and how the argument or material unfolds. Concrete content: the actual ideas, people, and claims in the text.
+
+4. **SECTIONS**: ${hasChapters ? 'Use the detected chapter structure.' : 'Group into 5-8 thematic sections.'} For each:
+   - Title and page range
+   - What it covers (2-3 sentences)
+   - 2-4 notable quotes with page numbers and significance
+   - Key concepts
+
+Output as JSON:
+{
+  "brief": "...",
+  "abstract": "...",
+  "detailed": "...",
+  "sections": [
+    {
+      "title": "Section Title",
+      "startPage": 1,
+      "endPage": 10,
+      "summary": "What this section covers...",
+      "quotes": [
+        {"text": "Exact quote", "page": 3, "significance": "Why this matters"}
+      ],
+      "concepts": ["Key Term", "Important Concept"]
+    }
+  ]
+}
+
+IMPORTANT: Use the actual quotes provided above. Don't invent new ones.`;
+}

--- a/src/app/api/admin/summary-review/route.ts
+++ b/src/app/api/admin/summary-review/route.ts
@@ -1,0 +1,180 @@
+/**
+ * Admin review queue for re-synthesized "About This Book" summaries.
+ *
+ * Candidates are generated NON-DESTRUCTIVELY into `book.summary_candidate` by
+ * scripts/maintenance/resynthesize-summaries.mjs. This route lets a reviewer
+ * (via /platform/admin/summary-review) approve, reject, or edit them.
+ *
+ * IMPORTANT — what actually shows as "About This Book":
+ * the book page (src/app/book/[id]/page.tsx) reads, in order,
+ *   book_indexes.bookSummary.brief  ->  book.reading_summary.overview  ->  book.summary.data
+ * so promotion writes to book_indexes.bookSummary AND the book doc, or the
+ * page would not change. The pre-promotion text is stashed in
+ * summary_candidate.replaced for rollback.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { getDb, getReadDb } from '@/lib/mongodb';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+interface ReviewItem {
+  id: string;
+  title?: string;
+  display_title?: string;
+  author?: string;
+  slug?: string;
+  oldBrief: string;
+  candidate: {
+    brief?: string;
+    abstract?: string;
+    detailed?: string;
+    status?: string;
+    edited?: boolean;
+    prompt_version?: string;
+    generated_at?: Date;
+  };
+}
+
+export const GET = withAdminAuth(async (request: NextRequest) => {
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get('status') || 'pending';
+  const limit = Math.min(Math.max(Number(searchParams.get('limit')) || 200, 1), 500);
+
+  const db = await getReadDb();
+
+  const match = { 'summary_candidate.status': status };
+  const books = await db.collection('books')
+    .find(match)
+    .project({
+      id: 1, title: 1, display_title: 1, author: 1, slug: 1,
+      'summary.data': 1, summary_candidate: 1, _id: 0,
+    })
+    .limit(limit)
+    .toArray();
+
+  // The live "About This Book" comes from book_indexes.bookSummary.brief first.
+  const ids = books.map((b) => b.id);
+  const idxDocs = await db.collection('book_indexes')
+    .find({ book_id: { $in: ids } })
+    .project({ book_id: 1, 'bookSummary.brief': 1, _id: 0 })
+    .toArray();
+  const idxBrief = new Map(idxDocs.map((d) => [d.book_id, d.bookSummary?.brief as string | undefined]));
+
+  const items: ReviewItem[] = books.map((b) => ({
+    id: b.id,
+    title: b.title,
+    display_title: b.display_title,
+    author: b.author,
+    slug: b.slug,
+    oldBrief: idxBrief.get(b.id) || (typeof b.summary === 'string' ? b.summary : b.summary?.data) || '',
+    candidate: b.summary_candidate || {},
+  }));
+
+  const counts = await db.collection('books').aggregate([
+    { $match: { 'summary_candidate.status': { $exists: true } } },
+    { $group: { _id: '$summary_candidate.status', n: { $sum: 1 } } },
+  ]).toArray();
+  const countMap: Record<string, number> = {};
+  for (const c of counts) countMap[c._id] = c.n;
+
+  return NextResponse.json({ items, counts: countMap });
+});
+
+export const POST = withAdminAuth(async (request: NextRequest, session) => {
+  const body = await request.json().catch(() => null);
+  if (!body?.id || !body?.action) {
+    return NextResponse.json({ error: 'id and action required' }, { status: 400 });
+  }
+  const { id, action } = body as {
+    id: string;
+    action: 'approve' | 'reject' | 'save';
+    brief?: string;
+    abstract?: string;
+    detailed?: string;
+  };
+
+  const db = await getDb();
+  const books = db.collection('books');
+  const book = await books.findOne({ id }, { projection: { id: 1, summary: 1, reading_summary: 1, summary_candidate: 1 } });
+  if (!book) return NextResponse.json({ error: 'book not found' }, { status: 404 });
+
+  const cand = (book.summary_candidate || {}) as Record<string, unknown>;
+  const reviewer = (session.user as { email?: string })?.email || 'unknown';
+
+  // Edits from the reviewer take precedence over the generated text.
+  const brief = (body.brief ?? cand.brief ?? '') as string;
+  const abstract = (body.abstract ?? cand.abstract ?? '') as string;
+  const detailed = (body.detailed ?? cand.detailed ?? '') as string;
+  const edited = body.brief != null || body.abstract != null || body.detailed != null;
+
+  if (action === 'reject') {
+    await books.updateOne({ id }, { $set: {
+      'summary_candidate.status': 'rejected',
+      'summary_candidate.reviewed_at': new Date(),
+      'summary_candidate.reviewed_by': reviewer,
+    } });
+    return NextResponse.json({ ok: true, status: 'rejected' });
+  }
+
+  if (action === 'save') {
+    // Persist edits, keep in the pending queue.
+    await books.updateOne({ id }, { $set: {
+      'summary_candidate.brief': brief,
+      'summary_candidate.abstract': abstract,
+      'summary_candidate.detailed': detailed,
+      'summary_candidate.edited': true,
+      'summary_candidate.status': 'pending',
+    } });
+    return NextResponse.json({ ok: true, status: 'pending', edited: true });
+  }
+
+  if (action === 'approve') {
+    if (!brief.trim()) return NextResponse.json({ error: 'empty brief' }, { status: 400 });
+
+    // Stash the current live text for rollback before overwriting.
+    const idxDoc = await db.collection('book_indexes').findOne({ book_id: id }, { projection: { bookSummary: 1 } });
+    const replaced = {
+      summary: book.summary ?? null,
+      reading_summary: book.reading_summary ?? null,
+      bookSummary: idxDoc?.bookSummary ?? null,
+    };
+
+    // 1) book_indexes.bookSummary — this is what "About This Book" reads first.
+    await db.collection('book_indexes').updateOne(
+      { book_id: id },
+      { $set: { 'bookSummary.brief': brief, 'bookSummary.abstract': abstract, 'bookSummary.detailed': detailed } },
+    );
+
+    // 2) book doc — the fallback surfaces (summary.data, reading_summary).
+    await books.updateOne({ id }, { $set: {
+      'summary.data': brief,
+      'summary.generated_at': new Date(),
+      'summary.model': cand.model ?? null,
+      'summary.prompt_version': cand.prompt_version ?? null,
+      'summary.source': 'ai-resynth-approved',
+      'reading_summary.overview': abstract,
+      'reading_summary.detailed': detailed,
+      'summary_candidate.brief': brief,
+      'summary_candidate.abstract': abstract,
+      'summary_candidate.detailed': detailed,
+      'summary_candidate.edited': edited,
+      'summary_candidate.status': 'approved',
+      'summary_candidate.reviewed_at': new Date(),
+      'summary_candidate.reviewed_by': reviewer,
+      'summary_candidate.replaced': replaced,
+    } });
+
+    // Best-effort page revalidation so the change shows without waiting for ISR.
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (process.env.REVALIDATE_SECRET) headers['x-revalidate-secret'] = process.env.REVALIDATE_SECRET;
+      await fetch(`https://sourcelibrary.org/api/admin/revalidate-book/${id}`, { method: 'POST', headers });
+    } catch { /* best-effort */ }
+
+    return NextResponse.json({ ok: true, status: 'approved' });
+  }
+
+  return NextResponse.json({ error: 'unknown action' }, { status: 400 });
+});

--- a/src/app/platform/(protected)/admin/summary-review/ReviewClient.tsx
+++ b/src/app/platform/(protected)/admin/summary-review/ReviewClient.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+/**
+ * Client UI for the summary review queue. Each card shows the live "About This
+ * Book" text vs the re-synthesized candidate, with editable fields and
+ * Approve / Reject / Save actions that POST to /api/admin/summary-review.
+ * Acted-on cards drop out of the list.
+ */
+import { useState } from 'react';
+
+export interface ReviewItem {
+  id: string;
+  title?: string;
+  display_title?: string;
+  author?: string;
+  slug?: string;
+  language?: string;
+  oldBrief: string;
+  brief: string;
+  abstract: string;
+  detailed: string;
+  prompt_version?: string;
+}
+
+const C = {
+  bg: '#0d1117', card: '#161b22', border: '#30363d', text: '#e6edf3',
+  dim: '#8b949e', blue: '#58a6ff', green: '#3fb950', red: '#f85149', amber: '#f0883e',
+};
+
+function Card({ item, onResolved }: { item: ReviewItem; onResolved: (id: string, how: string) => void }) {
+  const [brief, setBrief] = useState(item.brief);
+  const [abstract, setAbstract] = useState(item.abstract);
+  const [detailed, setDetailed] = useState(item.detailed);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [showDetail, setShowDetail] = useState(false);
+
+  const dirty = brief !== item.brief || abstract !== item.abstract || detailed !== item.detailed;
+
+  async function act(action: 'approve' | 'reject' | 'save') {
+    setBusy(action); setErr(null);
+    try {
+      const res = await fetch('/api/admin/summary-review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(
+          action === 'reject'
+            ? { id: item.id, action }
+            : { id: item.id, action, brief, abstract, detailed },
+        ),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      if (action === 'save') { setBusy(null); return; } // stays in queue
+      onResolved(item.id, action);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'failed'); setBusy(null);
+    }
+  }
+
+  const hasGloss = item.display_title && item.display_title !== item.title;
+
+  return (
+    <div style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: 8, padding: 16, marginBottom: 16 }}>
+      <div style={{ marginBottom: 10 }}>
+        <a href={`/book/${item.slug || item.id}`} target="_blank" rel="noreferrer"
+          style={{ color: C.blue, fontWeight: 600, fontSize: 15, textDecoration: 'none' }}>
+          {item.title || item.id}
+        </a>
+        {hasGloss && <span style={{ color: C.dim, fontSize: 13 }}> ({item.display_title})</span>}
+        <span style={{ color: C.dim, fontSize: 13 }}> · {item.author || 'Unknown'}{item.language ? ` · ${item.language}` : ''}</span>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+        {/* OLD (live) */}
+        <div>
+          <div style={{ color: C.amber, fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 6 }}>Current (live)</div>
+          <div style={{ color: '#c9d1d9', fontSize: 14, lineHeight: 1.55, whiteSpace: 'pre-wrap' }}>
+            {item.oldBrief || <span style={{ color: C.dim }}>(none)</span>}
+          </div>
+        </div>
+        {/* NEW (candidate, editable) */}
+        <div>
+          <div style={{ color: C.green, fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 6 }}>
+            Candidate {item.prompt_version ? `· ${item.prompt_version}` : ''}{dirty ? ' · edited' : ''}
+          </div>
+          <textarea value={brief} onChange={(e) => setBrief(e.target.value)} rows={5}
+            style={{ width: '100%', background: C.bg, color: C.text, border: `1px solid ${C.border}`, borderRadius: 4, padding: 8, fontSize: 14, lineHeight: 1.55, fontFamily: 'inherit', resize: 'vertical' }} />
+        </div>
+      </div>
+
+      <button onClick={() => setShowDetail((s) => !s)}
+        style={{ background: 'none', border: 'none', color: C.blue, cursor: 'pointer', fontSize: 12, padding: '8px 0 0' }}>
+        {showDetail ? '▾ hide' : '▸ show'} abstract & detailed (Reading Guide)
+      </button>
+      {showDetail && (
+        <div style={{ marginTop: 8, display: 'grid', gap: 10 }}>
+          <div>
+            <div style={{ color: C.dim, fontSize: 11, marginBottom: 4 }}>ABSTRACT</div>
+            <textarea value={abstract} onChange={(e) => setAbstract(e.target.value)} rows={4}
+              style={{ width: '100%', background: C.bg, color: C.text, border: `1px solid ${C.border}`, borderRadius: 4, padding: 8, fontSize: 13, lineHeight: 1.5, fontFamily: 'inherit', resize: 'vertical' }} />
+          </div>
+          <div>
+            <div style={{ color: C.dim, fontSize: 11, marginBottom: 4 }}>DETAILED</div>
+            <textarea value={detailed} onChange={(e) => setDetailed(e.target.value)} rows={7}
+              style={{ width: '100%', background: C.bg, color: C.text, border: `1px solid ${C.border}`, borderRadius: 4, padding: 8, fontSize: 13, lineHeight: 1.5, fontFamily: 'inherit', resize: 'vertical' }} />
+          </div>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 12 }}>
+        <button onClick={() => act('approve')} disabled={!!busy}
+          style={{ background: C.green, color: '#0d1117', border: 'none', borderRadius: 5, padding: '7px 16px', fontWeight: 600, cursor: 'pointer', opacity: busy ? 0.6 : 1 }}>
+          {busy === 'approve' ? 'Approving…' : (dirty ? 'Approve edited' : 'Approve')}
+        </button>
+        <button onClick={() => act('reject')} disabled={!!busy}
+          style={{ background: 'transparent', color: C.red, border: `1px solid ${C.red}`, borderRadius: 5, padding: '7px 16px', cursor: 'pointer', opacity: busy ? 0.6 : 1 }}>
+          {busy === 'reject' ? 'Rejecting…' : 'Reject'}
+        </button>
+        {dirty && (
+          <button onClick={() => act('save')} disabled={!!busy}
+            style={{ background: 'transparent', color: C.dim, border: `1px solid ${C.border}`, borderRadius: 5, padding: '7px 12px', cursor: 'pointer' }}>
+            {busy === 'save' ? 'Saving…' : 'Save edit (keep pending)'}
+          </button>
+        )}
+        {err && <span style={{ color: C.red, fontSize: 12 }}>{err}</span>}
+      </div>
+    </div>
+  );
+}
+
+export function ReviewClient({ initialItems, counts }: { initialItems: ReviewItem[]; counts: Record<string, number> }) {
+  const [items, setItems] = useState(initialItems);
+  const [resolved, setResolved] = useState<{ approved: number; rejected: number }>({ approved: 0, rejected: 0 });
+
+  function onResolved(id: string, how: string) {
+    setItems((prev) => prev.filter((it) => it.id !== id));
+    setResolved((r) => ({ ...r, [how]: (r as Record<string, number>)[how] + 1 || 1 }));
+  }
+
+  return (
+    <div style={{ maxWidth: 1200, margin: '0 auto', color: C.text }}>
+      <h1 style={{ fontSize: 24, margin: '0 0 6px' }}>About This Book — summary review</h1>
+      <div style={{ color: C.dim, fontSize: 14, marginBottom: 20 }}>
+        Live text (left) vs re-synthesized candidate (right, editable). Approve promotes to live and revalidates the page; reject discards.
+        {' '}Queue: <strong style={{ color: C.text }}>{counts.pending ?? 0}</strong> pending
+        {counts.approved ? ` · ${counts.approved} approved` : ''}
+        {counts.rejected ? ` · ${counts.rejected} rejected` : ''}.
+        {(resolved.approved || resolved.rejected) ? (
+          <span style={{ color: C.green }}> This session: {resolved.approved} approved, {resolved.rejected} rejected.</span>
+        ) : null}
+      </div>
+
+      {items.length === 0 ? (
+        <div style={{ color: C.dim, padding: 40, textAlign: 'center' }}>No pending candidates. Generate some with <code>scripts/maintenance/resynthesize-summaries.mjs --sample=N</code>.</div>
+      ) : (
+        items.map((it) => <Card key={it.id} item={it} onResolved={onResolved} />)
+      )}
+    </div>
+  );
+}

--- a/src/app/platform/(protected)/admin/summary-review/page.tsx
+++ b/src/app/platform/(protected)/admin/summary-review/page.tsx
@@ -1,0 +1,59 @@
+/**
+ * "About This Book" summary review queue.
+ *
+ * Re-synthesized summaries (plain-encyclopedic prompt rewrite) land in
+ * book.summary_candidate via scripts/maintenance/resynthesize-summaries.mjs,
+ * NON-DESTRUCTIVELY. This page shows the live text vs the candidate so a
+ * reviewer can approve (promote to live), reject, or edit-then-approve.
+ *
+ * Gated by the platform-protected layout (requireSuperAdmin). Mutations go
+ * through /api/admin/summary-review.
+ */
+import { getReadDb } from '@/lib/mongodb';
+import { ReviewClient, type ReviewItem } from './ReviewClient';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+export default async function SummaryReviewPage({ searchParams }: { searchParams: Promise<{ limit?: string }> }) {
+  const params = await searchParams;
+  const limit = Math.min(Math.max(Number(params.limit) || 100, 1), 500);
+
+  const db = await getReadDb();
+
+  const books = await db.collection('books')
+    .find({ 'summary_candidate.status': 'pending' })
+    .project({ id: 1, title: 1, display_title: 1, author: 1, slug: 1, language: 1, 'summary.data': 1, summary_candidate: 1, _id: 0 })
+    .limit(limit)
+    .toArray();
+
+  const ids = books.map((b) => b.id);
+  const idxDocs = await db.collection('book_indexes')
+    .find({ book_id: { $in: ids } })
+    .project({ book_id: 1, 'bookSummary.brief': 1, _id: 0 })
+    .toArray();
+  const idxBrief = new Map(idxDocs.map((d) => [d.book_id, d.bookSummary?.brief as string | undefined]));
+
+  const items: ReviewItem[] = books.map((b) => ({
+    id: b.id,
+    title: b.title,
+    display_title: b.display_title,
+    author: b.author,
+    slug: b.slug,
+    language: b.language,
+    oldBrief: idxBrief.get(b.id) || (typeof b.summary === 'string' ? b.summary : b.summary?.data) || '',
+    brief: b.summary_candidate?.brief || '',
+    abstract: b.summary_candidate?.abstract || '',
+    detailed: b.summary_candidate?.detailed || '',
+    prompt_version: b.summary_candidate?.prompt_version,
+  }));
+
+  const countsAgg = await db.collection('books').aggregate([
+    { $match: { 'summary_candidate.status': { $exists: true } } },
+    { $group: { _id: '$summary_candidate.status', n: { $sum: 1 } } },
+  ]).toArray();
+  const counts: Record<string, number> = {};
+  for (const c of countsAgg) counts[c._id] = c.n;
+
+  return <ReviewClient initialItems={items} counts={counts} />;
+}


### PR DESCRIPTION
## Why
The \"About This Book\" blurbs read like ad copy: *\"Willem Teellinck's 'The New Jerusalem' is a **seminal treatise** that **delineates the trajectory of the soul**...\"*. Root cause: the Phase 6 synthesis prompt was briefed as marketing copy (\"compelling copy to make readers WANT to explore\", \"Hook the reader\", \"Paint a picture\") while *also* banning the hype vocabulary that brief produces, and the synthesis call ran at Gemini's default temperature (~1.0) where flash-lite reaches for grand register and leaks banned words.

Voice chosen with Derek: **plain encyclopedic** — a library catalog note / museum wall label, optimized for scholarly credibility.

## What's in scope
- **`scripts/workers/lib/summary-prompt.mjs`** — extract the synthesis prompt to a single source of truth (prompt + temp + version tag). Reframed: factual reference description; hard rules against reader-address, rhetorical hooks, invented modern relevance, and praise vocabulary; a wrong-vs-right example pair. Temperature pinned to **0.2**.
- **Original-title-first** — leads with the original-language title and glosses English in parens (\"'t Nieuwe Jerusalem (The New Jerusalem)\") instead of the English `display_title`. Worker passes both.
- **`scripts/maintenance/resynthesize-summaries.mjs`** — regenerate prose from already-stored `book_indexes` (1 cheap call/book, no page re-extraction) into a **non-destructive `book.summary_candidate`** field. `--ids` / `--sample=N` / `--all` / `--dry-run`.
- **`/platform/admin/summary-review` + `/api/admin/summary-review`** — human review queue: live text vs candidate, **approve / reject / edit**. Approve promotes to live (`book_indexes.bookSummary` *and* the book doc, matching the page's read precedence) and stashes prior text in `summary_candidate.replaced` for rollback.

## Before / after (5-book sample)
| Book | Before | After |
|---|---|---|
| Teellinck (Dutch) | \"a **seminal treatise**... **delineates the trajectory of the soul**... **utilizes** a didactic dialogue\" | \"'t Nieuwe Jerusalem (The New Jerusalem) is a devotional treatise... a dialogue between the Lord and a believer, focusing on the transition from earthly life to the afterlife and the practice of daily godliness.\" |
| Southcott (English) | \"**What if** the woman who brought the 'Fall of Man'...? ...**Discover a text that dares to redefine**...\" | \"...a prophetic treatise by Joanna Southcott. It outlines a prophetic timeline for the end of the world and the role of the woman in human redemption.\" |
| Dubois-Fontanelle (French) | \"**Why did** ancient civilizations obsess over the Sacred Fire? This essay **reveals how fear, priestly manipulation**...\" | \"Essai sur le feu sacré et sur les Vestales (Essay on the Sacred Fire and on the Vestals) is a historical and philosophical treatise... examines the origins of fire worship and the institutional role of the Vestal Virgins.\" |

## Out of scope (deliberately)
- **No bulk live overwrite.** Rollout is staged: candidates are reviewed by a human (scholar lens) before promotion. Full-corpus run is a follow-up once the voice is approved.
- The 5 sample books were regenerated directly via the worker (live) during development; the rest go through the candidate/review path.

## Testing
- `npx tsc --noEmit`: clean for all touched files (pre-existing d3 errors in `carbon-ledger` blog components are unrelated).
- Re-synthesis script verified end-to-end on multiple books; produces consistent plain-encyclopedic output across Dutch/Latin/German/English/French.
- Review page gated by the existing `(protected)` superadmin layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)