### PR TITLE
ILP catalog: authority resolution, entity-join author/work-held, language + fixes

### DIFF
--- a/.claude/docs/author-normalization-method.md
+++ b/.claude/docs/author-normalization-method.md
@@ -1,0 +1,190 @@
+# Author normalization & reconciliation — method note
+
+How catalog translation records were matched to USTC works by author, for the
+Translation Gap census (2026-05-29). Written for reproducibility and as the
+basis for a production-grade aligner. See also
+`.claude/handoffs/2026-05-29-translation-gap-census.md` and
+auto-memory `project_ustc_translation_census.md`.
+
+## The problem
+We need to decide whether a translation record (in `translation_catalogs`)
+and a USTC work (in `ustc_distinct_works`) are by the **same author**. Naïve
+exact-string surname matching fails badly on early-modern names:
+
+- **Latinization / vernacular splits** — *Agrippa von Nettesheim* filed as
+  `nettesheim` in one source, `agrippa` in another.
+- **Pseudonyms & pseudo-attributions** — *Geber* ↔ *Jabir ibn Hayyan* ↔
+  *pseudo-Geber*.
+- **Particles & word order** — *de la*, *von*, *della*; surname-first vs
+  given-first.
+- **Diacritics & spelling drift** — *Böhme / Boehme / Behmen*.
+
+The matcher therefore has two layers: (1) deterministic **string
+normalization**, and (2) **authority reconciliation** that expands a surname
+to its known variant forms.
+
+## Layer 1 — string normalization
+Single function applied to every name string on both sides:
+
+```python
+import unicodedata, re
+def norm(s):
+    if not s: return ""
+    s = unicodedata.normalize("NFKD", str(s)).encode("ascii", "ignore").decode()  # strip diacritics
+    return re.sub(r"[^a-z0-9 ]", " ", s.lower())                                  # lowercase, punct→space
+```
+
+- `NFKD` + `encode('ascii','ignore')` folds `Böhme→Bohme`, `Khūnrath→Khunrath`.
+- Punctuation→space avoids `geber,`/`geber.` mismatches.
+- Source fields: catalog `author_surname` (already lowercased in
+  `translation_catalogs`); USTC `ustc_distinct_works.author_surname`.
+
+This alone (v1/v2 of the matcher) matches only when the two sources happen to
+file the author under the *same* surname token. It misses every case in the
+problem list above — e.g. under exact `geber`, USTC holds just **1** record.
+
+## Layer 2 — authority reconciliation (the "VIAF" step)
+Two Supabase tables supply variant name forms:
+
+- **`entity_aliases`** (80,912 rows) — authority clusters keyed to
+  VIAF/Wikidata/GND/CERL IDs. Each row carries `primary_name`, a `names[]`
+  array, and a `surnames[]` array of every variant surname for that one
+  identity.
+- **`author_aliases`** (202 rows) — a small *curated* bridge of
+  `ustc_form` ↔ `catalog_form` pairs (e.g. `ovid` ↔ `ovidius naso`).
+
+Build surname→cluster and cluster→surnames indexes from `entity_aliases`:
+
+```python
+sur2cl, cl2sur = {}, {}
+for e in entity_aliases:                       # e = {"id":..., "surnames":[...]}
+    cid = e["id"]
+    sset = {norm(s) for s in (e.get("surnames") or []) if len(norm(s)) >= 4}
+    cl2sur[cid] = sset
+    for s in sset:
+        sur2cl.setdefault(s, set()).add(cid)
+```
+
+`len >= 4` is a crude noise filter: `surnames[]` in practice also contains
+given-name fragments (e.g. `giuseppe`), which would over-link if treated as
+surnames.
+
+Curated bridge (last token used as a surname proxy):
+
+```python
+cat2ustc = {}
+for r in author_aliases:
+    cf, uf = norm(r["catalog_form"]), norm(r["ustc_form"])
+    if cf and uf:
+        cat2ustc.setdefault(cf.split()[-1], set()).add(uf.split()[-1])
+```
+
+Expand a catalog surname to all forms an equivalent USTC author might use:
+
+```python
+def expand(sn):
+    out = {sn}
+    cls = sur2cl.get(sn, set())
+    if 0 < len(cls) <= 3:                # ambiguity guard
+        for c in cls:
+            out |= cl2sur[c]
+    out |= cat2ustc.get(sn, set())       # curated overrides always applied
+    return out
+```
+
+**Ambiguity guard** — a surname appearing in `>3` clusters is *not* expanded.
+A common token (e.g. a frequent given-name fragment that slipped past the
+`len>=4` filter) would otherwise pull in dozens of unrelated identities.
+Trade-off: this also refuses to expand genuinely prolific surnames, so it
+under-recalls on those.
+
+Matching candidates for a catalog author = the union of USTC works filed under
+**any** expanded surname (not just the literal one). A candidate pair is only
+*accepted* if it also passes the title test (shared Latin incipit/bigram, or
+high token-overlap) — author reconciliation widens recall; the title gate
+holds precision.
+
+## Results
+- Catalog surnames `4,097` → expanded variant universe `9,606`.
+- Distinct USTC Latin works linked: `1,286` (no reconciliation) → `1,513`
+  (with reconciliation), +18%.
+- Net effect on the Latin rate: ~2.24% → ~2.29% (small; see robustness table
+  in the resource).
+
+## Known limitations (and why the gain was modest)
+1. **Surname-only.** Given names and life-dates from `entity_aliases` were not
+   used to disambiguate; collisions are possible (held in check only by the
+   title gate).
+2. **`surnames[]` mixes given names and surnames** — `len>=4` + the ambiguity
+   guard are blunt instruments, not real role tagging.
+3. **`author_aliases` is tiny (202)** and its last-token surname proxy is
+   fragile for multi-part names.
+4. **No transliteration / fuzzy / phonetic matching** — the Arabic↔Latin
+   *Jabir→Geber* leap isn't bridged; `geber` stayed unexpanded (its cluster
+   either omits `geber` as a surname or is too ambiguous), so pseudo-Geber's
+   *Summa* still missed in validation.
+5. Most of the residual gap is **structural, not author-matching**: a large
+   share of catalog translations are of works outside USTC's Latin scope
+   (classical Greek/Roman, post-1700, vernacular, manuscript), which no name
+   reconciliation can recover.
+
+## Recommended production approach
+- **Reconcile on cluster ID, not surnames.** Tag both catalog authors and
+  USTC authors with their `entity_aliases` cluster ID up front (the
+  `viaf-author-linking.mjs` pipeline already resolves authors to authority
+  IDs), then match on shared cluster ID — eliminating surname games entirely.
+- Use **full name + birth/death years** from the authority record to
+  disambiguate same-surname different-person cases; drop the ≤3-cluster guard.
+- Add a **phonetic/edit-distance surname fallback** (Double Metaphone +
+  Levenshtein) gated by a corroborating title-incipit match.
+- For authors with **no authority cluster**, call the VIAF/Wikidata
+  reconciliation API live and cache results.
+- Keep the **tiered completeness score** on the resulting link, not a boolean.
+
+## Addendum — stem-then-authority (2026-05-29, applied to the ILP catalog)
+
+Implemented as `scripts/lib/author-reconcile.mjs`. Validating against the Index
+Librorum Prohibitorum surfaced one finding that changes Layer 2 materially:
+
+**Authority records enumerate vernacular/standard variants but NOT every Latin
+grammatical inflection.** The Giovanni Pico cluster (VIAF 34491108) lists
+`pico, pic, picco, mirandula, mirandola, mirandole, mirandulensis…` — but *not*
+`picus`. So Layer 2 as originally written (exact surname → cluster) still misses
+the Index form "Picus, Ioannes", and an exact `picus` lookup mis-pulls *Andreas
+Picus* and *Ranuccio Pico* instead. The authority table is built from how
+libraries file names, not from how a 16th-c. Latin index inflects them.
+
+**Fix: a morphological layer BEFORE the authority lookup.** Stem each token to
+fold Latin endings (`-us/-i/-o/-um/-ae/-ensis…`), so `picus → pic` meets the
+cluster's enumerated `pic`. Stemming is applied to *both* the query and the
+cluster surnames; match on shared stem.
+
+**Surname-vs-given-name separation, done by document frequency instead of
+`len>=4`.** `surnames[]` mixes real surnames with given-name fragments
+(`ioannes`, `john`, `giovanni`). Rather than a length heuristic, compute each
+stem's document-frequency across all 80,912 clusters: a stem in thousands of
+clusters is a given name / generic word, a real surname stem is rare. Gate both
+candidate-matching and expansion on **distinctive** stems (df ≤ 30). Measured:
+`pic`=10, `mirandol`=12, `mirandul`=3 (kept) vs `john`=1312, `ioann`=610,
+`giovann`=1870 (dropped). This is what stopped the first cut from "recalling"
+John Calvin and Chrysostom for Pico.
+
+**Common-surname rescue.** A surname that is *itself* a common token (Desiderius
+**Erasmus**) would be blocked by the distinctiveness gate and recall nothing —
+the old ambiguity-guard's blind spot. Fallback: for a non-distinctive surname
+stem, still admit candidate clusters, but only those that ALSO match the query's
+given name. "Erasmus, Desiderius" → resolves correctly; the literal surname is
+always unioned back into the search terms so catalog-native forms aren't lost.
+
+**Disambiguation = given-name overlap (dominant) + life-date plausibility**
+(can't be banned before birth). "Picus, **Ioannes**" → Giovanni Pico; "Picus,
+**Andreas**" → Andreas Picus; no cross-contamination.
+
+Validated recall (literal-surname SL search → reconciled): Pico 0→40, Bruno
+2→34, Machiavelli 0→5, Erasmus 40→40 (+Dutch forms), Andreas Picus 0→0 (decoy
+correctly refused). Reconciliation widens recall; the title gate + Gemini
+same-person verifier in the backfill scripts still hold precision (they must —
+surname clusters can't separate Giovanni Pico from his nephew Gianfrancesco, or
+from Jean Pic the Carthusian, all "Ioannes Picus").
+
+Run it: `node scripts/lib/author-reconcile.mjs "Picus, Ioannes" 1632`.

--- a/scripts/backfill-catalog-author-entity.mjs
+++ b/scripts/backfill-catalog-author-entity.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Resolve each catalog author → canonical Mongo `entities` record and write
+ * index_catalog_entries.author_entity_id, plus an EXACT entity-join
+ * author_held_count (and sample book) for resolved authors.
+ *
+ * This is the entity-join upgrade of backfill-catalog-author-held.mjs. It uses
+ * scripts/lib/entity-resolve.mjs (stem-then-authority reconcile → bridge to the
+ * Mongo entity by viaf / vernacular name → author_entity_id). Advantages over
+ * the surname-cluster path:
+ *   • Exact: separates same-surname people (Giovanni Pico vs nephew
+ *     Gianfrancesco) that surname regex conflates.
+ *   • No Gemini: the entity IS the verified identity, so this runs in minutes.
+ *   • author_entity_id becomes the JOIN KEY linking the catalog to the main
+ *     site's author graph — persistence timeline, catalog↔author cross-links,
+ *     "every edition that banned author X", dedup.
+ *
+ * Identities that DON'T resolve to an entity are left as-is (their v1
+ * surname-based author_held_count stands; author_entity_id stays null). Run the
+ * surname backfill for that tail separately if needed.
+ *
+ * Requires the column (run once in Supabase SQL Editor):
+ *   ALTER TABLE index_catalog_entries ADD COLUMN author_entity_id text;
+ *   CREATE INDEX ON index_catalog_entries (author_entity_id);
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/backfill-catalog-author-entity.mjs            # dry-run
+ *   node scripts/backfill-catalog-author-entity.mjs --apply
+ *   node scripts/backfill-catalog-author-entity.mjs --apply --concurrency 4
+ */
+import { MongoClient } from 'mongodb';
+import { loadResolver, resolveToEntity } from './lib/entity-resolve.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const limitArg = process.argv.indexOf('--limit');
+const LIMIT = limitArg > -1 ? Number(process.argv[limitArg + 1]) : 0;
+const concArg = process.argv.indexOf('--concurrency');
+// Default concurrency 4: per-identity PATCHes target disjoint rows, but keep it
+// low to avoid the index-contention deadlocks (40P01) seen at 10.
+const CONCURRENCY = Math.max(1, concArg > -1 ? Number(process.argv[concArg + 1]) : 4);
+
+const SUPA_URL = process.env.SUPABASE_URL;
+const SUPA_KEY = APPLY ? process.env.SUPABASE_SERVICE_ROLE_KEY : process.env.SUPABASE_ANON_KEY;
+if (!SUPA_URL || !SUPA_KEY) { console.error('SUPABASE_* missing'); process.exit(1); }
+const H = { apikey: SUPA_KEY, Authorization: `Bearer ${SUPA_KEY}`, 'Content-Type': 'application/json' };
+
+async function supa(method, path, body) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const opts = { method, headers: H };
+      if (body !== undefined) opts.body = JSON.stringify(body);
+      const r = await fetch(`${SUPA_URL}/rest/v1/${path}`, opts);
+      if (!r.ok) {
+        const text = (await r.text()).slice(0, 400);
+        if ((r.status >= 500 || r.status === 409) && attempt < 4) { await new Promise(res => setTimeout(res, 800 * 2 ** attempt)); continue; }
+        throw new Error(`${method} ${path} → ${r.status}: ${text}`);
+      }
+      return r.status === 204 ? null : r.json();
+    } catch (e) {
+      if (attempt === 4 || !/ETIMEDOUT|ECONNRESET|fetch failed|self-signed/i.test(String(e))) throw e;
+      await new Promise(res => setTimeout(res, 1500 * 2 ** attempt));
+    }
+  }
+}
+
+// Count held books for an entity, matching author-held v1 semantics
+// (visible + actually-processed, books not artwork/fragments).
+async function heldBooksForEntity(db, entityId) {
+  return db.collection('books').find(
+    { author_entity_id: entityId,
+      visible: { $ne: false },
+      pages_count: { $gt: 0 },
+      resource_type: { $nin: ['artwork', 'emblem', 'image', 'illustration', 'manuscript-fragment'] } },
+    { projection: { _id: 1, slug: 1, year: 1, title: 1, pages_count: 1 } },
+  ).toArray();
+}
+
+// Distinct (author_normalized, author) identities + a representative entry.
+async function fetchIdentities() {
+  const byKey = new Map();
+  let offset = 0;
+  const PAGE = 1000;
+  while (true) {
+    const rows = await supa('GET',
+      `index_catalog_entries?select=author,author_normalized,condemnation_year,author_held_count&author_normalized=not.is.null&author_normalized=neq.&order=author_normalized&limit=${PAGE}&offset=${offset}`);
+    if (!rows.length) break;
+    for (const r of rows) {
+      if (!r.author_normalized || r.author_normalized.length < 3) continue;
+      const k = `${r.author_normalized}::${(r.author || '').trim().toLowerCase()}`;
+      const cur = byKey.get(k);
+      if (!cur) byKey.set(k, { author: r.author, author_normalized: r.author_normalized, condemnation_year: r.condemnation_year, priorHeld: r.author_held_count || 0, count: 1 });
+      else {
+        cur.count++;
+        // representative year: earliest non-null condemnation (closest to the life)
+        if (r.condemnation_year && (!cur.condemnation_year || r.condemnation_year < cur.condemnation_year)) cur.condemnation_year = r.condemnation_year;
+        if ((r.author_held_count || 0) > cur.priorHeld) cur.priorHeld = r.author_held_count || 0;
+      }
+    }
+    if (rows.length < PAGE) break;
+    offset += rows.length;
+  }
+  return byKey;
+}
+
+async function main() {
+  console.log(`catalog author-entity backfill — mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}${LIMIT ? ` (limit ${LIMIT})` : ''}`);
+
+  const mc = new MongoClient(process.env.MONGODB_URI);
+  await mc.connect();
+  const db = mc.db('bookstore');
+
+  console.log('Loading resolver (Supabase authority + Mongo entity bridge)…');
+  const resolver = await loadResolver((path) => supa('GET', path), db);
+  console.log(`  ${resolver.authority.clusters.size} clusters; ${resolver.byViaf.size} viaf + ${resolver.byName.size} name bridges.`);
+
+  console.log('Scanning identities…');
+  const identities = [...fetchIdentitiesSorted(await fetchIdentities())];
+  const work = LIMIT ? identities.slice(0, LIMIT) : identities;
+  console.log(`${work.length} distinct authored identities.\n`);
+
+  let resolved = 0, withEntity = 0, held = 0, entriesUpdated = 0, done = 0;
+  const samples = [];
+  const queue = [...work];
+  const startedAt = Date.now();
+
+  async function worker() {
+    while (queue.length) {
+      const id = queue.shift();
+      if (!id) break;
+      done++;
+      const r = resolveToEntity(id.author, { resolver, year: id.condemnation_year });
+      if (r && r.entityId) {
+        resolved++; withEntity++;
+        const books = await heldBooksForEntity(db, r.entityId);
+        // representative sample: prefer a book with a year + most pages
+        const sample = [...books].sort((a, b) => (b.year ? 1 : 0) - (a.year ? 1 : 0) || (b.pages_count || 0) - (a.pages_count || 0))[0];
+        if (books.length) held++;
+        if (samples.length < 15) samples.push({ key: `${id.author}`, entity: r.primary_name, via: r.via, books: books.length });
+
+        if (APPLY) {
+          // author_entity_id is the deliverable — always write it. For the held
+          // count, never regress: take max(prior surname count, entity-join
+          // count), since entity-join undercounts authors whose books lack an
+          // author_entity_id. Only refresh the sample when the entity join is
+          // the winning (≥) count, so the sample matches the number shown.
+          const patch = { author_entity_id: r.entityId };
+          if (books.length >= (id.priorHeld || 0)) {
+            patch.author_held_count = books.length;
+            patch.author_held_sample_slug = sample?.slug || null;
+            patch.author_held_sample_id = sample ? String(sample._id) : null;
+          }
+          const path = id.author == null
+            ? `index_catalog_entries?author_normalized=eq.${encodeURIComponent(id.author_normalized)}&author=is.null`
+            : `index_catalog_entries?author_normalized=eq.${encodeURIComponent(id.author_normalized)}&author=eq.${encodeURIComponent(id.author)}`;
+          try { await supa('PATCH', path, patch); entriesUpdated += id.count; }
+          catch (e) { console.error(`\nPATCH failed ${id.author}: ${String(e).slice(0, 120)}`); }
+        }
+      }
+      if (done % 50 === 0 || done === work.length) {
+        const el = (Date.now() - startedAt) / 1000;
+        process.stdout.write(`\r  ${done}/${work.length}  resolved=${resolved}  with-entity=${withEntity}  held>0=${held}  ${el.toFixed(0)}s   `);
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
+  console.log();
+
+  console.log('\n─── samples (resolved → entity) ───');
+  for (const s of samples) console.log(`  ${s.key.slice(0, 34).padEnd(34)} → ${s.entity} [${s.via}]  ${s.books} held`);
+
+  console.log('\n─── summary ───');
+  console.log(`  identities            : ${work.length}`);
+  console.log(`  resolved to entity    : ${withEntity} (${(withEntity / work.length * 100).toFixed(1)}%)`);
+  console.log(`  of those, hold ≥1 book: ${held}`);
+  console.log(`  catalog entries updated: ${APPLY ? entriesUpdated : '(dry-run)'}`);
+
+  await mc.close();
+}
+
+// Sort identities by descending entry-count (process high-impact first).
+function* fetchIdentitiesSorted(byKey) {
+  yield* [...byKey.values()].sort((a, b) => b.count - a.count);
+}
+
+main().catch(e => { console.error('Fatal:', e); process.exit(1); });

--- a/scripts/backfill-catalog-author-entity.mjs
+++ b/scripts/backfill-catalog-author-entity.mjs
@@ -40,6 +40,18 @@ const concArg = process.argv.indexOf('--concurrency');
 // low to avoid the index-contention deadlocks (40P01) seen at 10.
 const CONCURRENCY = Math.max(1, concArg > -1 ? Number(process.argv[concArg + 1]) : 4);
 
+// Curated split-identity overrides: an exact author-string that denotes more
+// than one person. Resolution is per author-string, so these need per-ENTRY
+// title disambiguation, applied as a post-pass. Extend as conflations surface
+// (general title-aware per-entry resolution is the future-work version).
+const SPLIT_OVERRIDES = [
+  // "Picus, Ioannes" = Giovanni Pico della Mirandola (philosopher) AND Jean Pic
+  // the Carthusian (Psalms paraphrases). The Carthusian has no Mongo entity, so
+  // unlink his entries (title is the only disambiguator; name+year can't split
+  // them — both are "Ioannes Picus" alive before the condemnations).
+  { author: 'Picus, Ioannes', titleMatch: /paraphras|psalm/i, entityId: null },
+];
+
 const SUPA_URL = process.env.SUPABASE_URL;
 const SUPA_KEY = APPLY ? process.env.SUPABASE_SERVICE_ROLE_KEY : process.env.SUPABASE_ANON_KEY;
 if (!SUPA_URL || !SUPA_KEY) { console.error('SUPABASE_* missing'); process.exit(1); }
@@ -165,6 +177,21 @@ async function main() {
   }
   await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
   console.log();
+
+  // Per-entry split-identity overrides (must run AFTER the per-identity pass,
+  // which tags every entry of an author-string uniformly).
+  for (const ov of SPLIT_OVERRIDES) {
+    const rows = await supa('GET',
+      `index_catalog_entries?select=id,title&author=eq.${encodeURIComponent(ov.author)}`);
+    const hit = rows.filter(r => ov.titleMatch.test(r.title || ''));
+    console.log(`split-override "${ov.author}" /${ov.titleMatch.source}/ → ${hit.length} entries → entity ${ov.entityId ?? 'null'}`);
+    if (APPLY) {
+      for (const r of hit) {
+        await supa('PATCH', `index_catalog_entries?id=eq.${r.id}`,
+          { author_entity_id: ov.entityId, author_held_count: 0, author_held_sample_slug: null, author_held_sample_id: null });
+      }
+    }
+  }
 
   console.log('\n─── samples (resolved → entity) ───');
   for (const s of samples) console.log(`  ${s.key.slice(0, 34).padEnd(34)} → ${s.entity} [${s.via}]  ${s.books} held`);

--- a/scripts/backfill-catalog-author-held.mjs
+++ b/scripts/backfill-catalog-author-held.mjs
@@ -27,8 +27,10 @@
  * unless --force.
  */
 import { MongoClient } from 'mongodb';
+import { loadAuthority, reconcile } from './lib/author-reconcile.mjs';
 
 const APPLY = process.argv.includes('--apply');
+const NO_RECONCILE = process.argv.includes('--no-reconcile');
 const FORCE = process.argv.includes('--force');
 const limitArg = process.argv.indexOf('--limit');
 const LIMIT = limitArg > -1 ? Number(process.argv[limitArg + 1]) : 0;
@@ -161,18 +163,38 @@ const SURNAME_ALIASES = {
   zorzi:       ['giorgio'],
 };
 
-const slCache = new Map();
-async function slBooksBySurname(db, s) {
-  if (!s) return [];
-  if (slCache.has(s)) return slCache.get(s);
-  const lower = s.toLowerCase();
-  const variants = new Set([lower]);
-  const corrected = fixLongS(lower);
-  if (corrected !== lower) variants.add(corrected);
-  for (const alias of (SURNAME_ALIASES[lower] || [])) variants.add(alias.toLowerCase());
+// Build the set of surname forms to search for one identity. Sources, unioned:
+//   • the literal author_normalized surname (+ long-s correction)
+//   • the curated SURNAME_ALIASES backstop
+//   • stem-then-authority reconciliation (entity_aliases) — the big lever:
+//     resolves Latin "Picus, Ioannes" → the Pico cluster → {pico, mirandola,
+//     mirandula, …}, which our vernacular-catalogued books actually carry.
+// Reconciliation only widens recall; the Gemini same-person verifier downstream
+// still rejects mismatches (Carthusian, wrong surname-mate, etc.).
+function searchTermsForEntry(entry, authority) {
+  const terms = new Set();
+  const lit = (entry.author_normalized || '').toLowerCase();
+  if (lit) {
+    terms.add(lit);
+    const c = fixLongS(lit);
+    if (c !== lit) terms.add(c);
+    for (const a of (SURNAME_ALIASES[lit] || [])) terms.add(a.toLowerCase());
+  }
+  if (authority && entry.author) {
+    const rec = reconcile(entry.author, { authority, year: entry.condemnation_year });
+    if (rec) for (const f of rec.expandedSurnames) terms.add(f.toLowerCase());
+  }
+  return [...terms].filter(t => t.length >= 4);
+}
 
-  const variantList = [...variants];
-  const re = new RegExp(`(^|[^a-z])(${variantList.map(v => v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`, 'i');
+const slCache = new Map();
+async function slBooksForEntry(db, entry, authority) {
+  const terms = searchTermsForEntry(entry, authority);
+  if (!terms.length) return [];
+  const cacheKey = terms.slice().sort().join('|');
+  if (slCache.has(cacheKey)) return slCache.get(cacheKey);
+  // Whole-word match so forms like "pico" don't prefix-match "Piccolomini".
+  const re = new RegExp(`(^|[^a-z])(${terms.map(v => v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})([^a-z]|$)`, 'i');
   const books = await db.collection('books').find(
     {
       $or: [{ author: re }, { author_normalized: re }, { canonical_author_normalized: re }],
@@ -182,7 +204,7 @@ async function slBooksBySurname(db, s) {
     },
     { projection: { _id: 1, id: 1, slug: 1, title: 1, author: 1, year: 1 } },
   ).limit(80).toArray();
-  slCache.set(s, books);
+  slCache.set(cacheKey, books);
   return books;
 }
 
@@ -231,6 +253,13 @@ async function main() {
   await mc.connect();
   const db = mc.db('bookstore');
 
+  let authority = null;
+  if (!NO_RECONCILE) {
+    console.log('Loading entity_aliases authority index (stem-then-authority)…');
+    authority = await loadAuthority((path) => supa('GET', path));
+    console.log(`  ${authority.clusters.size} clusters indexed.`);
+  }
+
   console.log('\nScanning distinct identities…');
   const identities = await fetchDistinctIdentities();
   const todo = [...identities.entries()].filter(([, v]) => !v.alreadyDone).sort((a, b) => b[1].count - a[1].count);
@@ -254,7 +283,7 @@ async function main() {
       if (!item) break;
       const [key, { entry, count, surname }] = item;
 
-      const books = await slBooksBySurname(db, surname);
+      const books = await slBooksForEntry(db, entry, authority);
 
       let authorHeldCount = 0;
       let sampleSlug = null;

--- a/scripts/backfill-catalog-language.mjs
+++ b/scripts/backfill-catalog-language.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Backfill index_catalog_entries.language from the linked USTC edition.
+ *
+ * `language` is the language of the *banned work*, not the print language of
+ * the Index edition. It is genuinely mixed within a single edition — a Spanish
+ * Index lists Latin, Spanish, Italian and German works side by side — so a
+ * per-edition blanket default (the original "Roman=lat, Spanish=lat/spa" idea)
+ * would mislabel a meaningful slice. We instead copy the accurate per-work
+ * language from the matched USTC edition (`ustc_editions.language_1`), which
+ * uses full English names ("Latin", "German", "Italian", …).
+ *
+ * Entries with no `ustc_sn` (the ~92% unmatched) are left NULL on purpose:
+ * most are author-only `opera_omnia` lines whose work-language is genuinely
+ * indeterminate from the entry. NULL is more honest than a guess. When the
+ * matching pass (backfill-catalog-ustc-sl-links.mjs) links more entries, just
+ * re-run this — it only fills rows where language IS NULL.
+ *
+ * Idempotent. Re-runnable. One PATCH per distinct ustc_sn (not per entry).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/backfill-catalog-language.mjs            # dry-run
+ *   node scripts/backfill-catalog-language.mjs --apply
+ */
+const APPLY = process.argv.includes('--apply');
+
+const SUPA_URL = process.env.SUPABASE_URL;
+const SUPA_KEY = APPLY ? process.env.SUPABASE_SERVICE_ROLE_KEY : process.env.SUPABASE_ANON_KEY;
+if (!SUPA_URL || !SUPA_KEY) { console.error('SUPABASE_* missing'); process.exit(1); }
+const H = { apikey: SUPA_KEY, Authorization: `Bearer ${SUPA_KEY}`, 'Content-Type': 'application/json' };
+
+async function supa(method, path, body) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const opts = { method, headers: H };
+      if (body !== undefined) opts.body = JSON.stringify(body);
+      const r = await fetch(`${SUPA_URL}/rest/v1/${path}`, opts);
+      if (!r.ok) {
+        const text = (await r.text()).slice(0, 400);
+        if (r.status >= 500 && attempt < 4) { await new Promise(res => setTimeout(res, 1000 * 2 ** attempt)); continue; }
+        throw new Error(`${method} ${path} → ${r.status}: ${text}`);
+      }
+      return r.status === 204 ? null : r.json();
+    } catch (e) {
+      if (attempt === 4 || !/ETIMEDOUT|ECONNRESET|fetch failed/i.test(String(e))) throw e;
+      await new Promise(res => setTimeout(res, 2000 * 2 ** attempt));
+    }
+  }
+}
+
+// Fetch every distinct ustc_sn among entries still missing a language.
+async function fetchUnlinkedSns() {
+  const sns = new Set();
+  let offset = 0;
+  const PAGE = 1000;
+  while (true) {
+    const rows = await supa('GET',
+      `index_catalog_entries?select=ustc_sn&ustc_sn=not.is.null&language=is.null&order=ustc_sn&limit=${PAGE}&offset=${offset}`);
+    for (const r of rows) if (r.ustc_sn != null) sns.add(r.ustc_sn);
+    if (rows.length < PAGE) break;
+    offset += rows.length;
+  }
+  return [...sns];
+}
+
+// Look up language_1 for a batch of USTC editions.
+async function ustcLanguages(sns) {
+  const map = new Map();
+  const CHUNK = 200;
+  for (let i = 0; i < sns.length; i += CHUNK) {
+    const batch = sns.slice(i, i + CHUNK);
+    const rows = await supa('GET',
+      `ustc_editions?select=sn,language_1&sn=in.(${batch.join(',')})`);
+    // USTC values carry casing/whitespace noise ("latin", "Latin "); canonicalise
+    // so "Latin"/"latin"/"Latin " collapse into one bucket.
+    for (const r of rows) {
+      if (!r.language_1) continue;
+      const lang = r.language_1.trim().replace(/^./, c => c.toUpperCase());
+      map.set(r.sn, lang);
+    }
+  }
+  return map;
+}
+
+async function main() {
+  console.log(`catalog language backfill — mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+
+  const sns = await fetchUnlinkedSns();
+  console.log(`USTC-linked entries missing language: ${sns.length} distinct ustc_sn`);
+  if (!sns.length) { console.log('Nothing to do.'); return; }
+
+  const langBySn = await ustcLanguages(sns);
+  console.log(`Resolved a USTC language for ${langBySn.size}/${sns.length} editions.`);
+
+  // Group sns by the language we'll write, so we can PATCH per-language.
+  const byLang = new Map();
+  for (const [sn, lang] of langBySn) {
+    if (!byLang.has(lang)) byLang.set(lang, []);
+    byLang.get(lang).push(sn);
+  }
+
+  console.log('\nLanguage distribution to write:');
+  for (const [lang, list] of [...byLang.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    console.log(`  ${lang.padEnd(16)} ${list.length} editions`);
+  }
+
+  if (!APPLY) {
+    console.log('\n(dry run — pass --apply to write)');
+    return;
+  }
+
+  console.log('\nWriting…');
+  let patched = 0;
+  for (const [lang, list] of byLang) {
+    const CHUNK = 200;
+    for (let i = 0; i < list.length; i += CHUNK) {
+      const batch = list.slice(i, i + CHUNK);
+      // Only touch rows still NULL, so a re-run never clobbers a better value.
+      await supa('PATCH',
+        `index_catalog_entries?ustc_sn=in.(${batch.join(',')})&language=is.null`,
+        { language: lang });
+      patched += batch.length;
+      process.stdout.write(`\r  ${patched} editions patched`);
+    }
+  }
+  console.log(`\nDone. Patched entries for ${patched} editions across ${byLang.size} languages.`);
+}
+
+main().catch(e => { console.error('Fatal:', e); process.exit(1); });

--- a/scripts/backfill-catalog-ustc-sl-links.mjs
+++ b/scripts/backfill-catalog-ustc-sl-links.mjs
@@ -79,7 +79,7 @@ async function supa(method, path, body) {
 // One verification reuses across all entries that share the same pair.
 
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
-const VERIFY_MODEL = 'gemini-3.1-flash-lite-preview';
+const VERIFY_MODEL = 'gemini-3.1-flash-lite';
 const verifyCache = new Map();
 let verifyCallCount = 0;
 let verifyCostTotal = 0;

--- a/scripts/backfill-catalog-ustc-sl-links.mjs
+++ b/scripts/backfill-catalog-ustc-sl-links.mjs
@@ -20,6 +20,29 @@
  *   node scripts/backfill-catalog-ustc-sl-links.mjs --all --apply                            # every index
  */
 import { MongoClient } from 'mongodb';
+import { loadAuthority, reconcile } from './lib/author-reconcile.mjs';
+
+// Authority index (entity_aliases) for stem-then-authority reconciliation;
+// loaded once in main() unless --no-reconcile.
+let AUTHORITY = null;
+const NO_RECONCILE = process.argv.includes('--no-reconcile');
+
+// Surname forms to search for one catalog entry: literal author_normalized
+// (+ long-s) plus stem-then-authority expansion. `reconciled` is true when the
+// authority resolved a confident cluster — callers use it to relax the
+// surname-collision year guard (identity is established by name+dates, not by
+// year proximity). See scripts/lib/author-reconcile.mjs.
+function slFormsForEntry(entry) {
+  const lit = (entry.author_normalized || '').toLowerCase();
+  const terms = new Set();
+  let reconciled = false;
+  if (lit) { terms.add(lit); const c = fixLongS(lit).toLowerCase(); if (c !== lit) terms.add(c); }
+  if (AUTHORITY && entry.author) {
+    const rec = reconcile(entry.author, { authority: AUTHORITY, year: entry.condemnation_year });
+    if (rec) { reconciled = true; for (const f of rec.expandedSurnames) terms.add(f.toLowerCase()); }
+  }
+  return { forms: [...terms].filter(t => t.length >= 4), reconciled };
+}
 
 function arg(name, fallback) {
   const i = process.argv.indexOf(name);
@@ -184,13 +207,11 @@ function fixLongS(s) { return (s || '').replace(/f/g, 's').replace(/F/g, 'S'); }
 // ─── USTC fetch cache (per surname) ───────────────────────────────────────
 
 const ustcCache = new Map();
-async function ustcEditionsBySurname(s) {
-  if (!s) return [];
-  if (ustcCache.has(s)) return ustcCache.get(s);
-  const variants = [s];
-  // Try OCR-corrected surname too: "Brandeburgenfis" → "Brandeburgensis"
-  const corrected = fixLongS(s);
-  if (corrected !== s) variants.push(corrected);
+async function ustcEditionsByForms(forms) {
+  if (!forms || !forms.length) return [];
+  const cacheKey = forms.slice().sort().join('|');
+  if (ustcCache.has(cacheKey)) return ustcCache.get(cacheKey);
+  const variants = forms;
 
   const editions = [];
   for (const v of variants) {
@@ -209,7 +230,7 @@ async function ustcEditionsBySurname(s) {
       }
     }
   }
-  ustcCache.set(s, editions);
+  ustcCache.set(cacheKey, editions);
   return editions;
 }
 
@@ -286,42 +307,46 @@ async function getMongo() {
   return mongoClient;
 }
 
-// Fetch SL books in our domain whose author surname-normalises to `s`.
-// Cache per surname to avoid repeated Mongo queries.
+// Fetch SL books whose author matches one of the entry's expanded surname
+// forms (literal + stem-then-authority). Returns { books, reconciled }.
 const slCache = new Map();
-async function slBooksBySurname(s) {
-  if (!s) return [];
-  if (slCache.has(s)) return slCache.get(s);
+async function slBooksForEntry(entry) {
+  const { forms, reconciled } = slFormsForEntry(entry);
+  if (!forms.length) return { books: [], reconciled };
+  const cacheKey = forms.slice().sort().join('|');
+  if (slCache.has(cacheKey)) return { books: slCache.get(cacheKey), reconciled };
   const mc = await getMongo();
   const db = mc.db('bookstore');
-  const variants = [s];
-  const corrected = fixLongS(s);
-  if (corrected !== s) variants.push(corrected);
-  const re = new RegExp(`(^|[^a-z])(${variants.map(v => v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`, 'i');
+  // Whole-word match so "pico" doesn't prefix-match "Piccolomini".
+  const re = new RegExp(`(^|[^a-z])(${forms.map(v => v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})([^a-z]|$)`, 'i');
   const books = await db.collection('books').find(
     { $or: [{ author: re }, { author_normalized: re }, { canonical_author_normalized: re }],
       visible: { $ne: false },
       resource_type: { $nin: ['artwork', 'emblem', 'image', 'illustration', 'manuscript-fragment'] } },
     { projection: { _id: 1, id: 1, slug: 1, title: 1, author: 1, year: 1 } }
   ).limit(80).toArray();
-  slCache.set(s, books);
-  return books;
+  slCache.set(cacheKey, books);
+  return { books, reconciled };
 }
 
 async function findSlBookFor(entry) {
-  const eds = await slBooksBySurname(entry.author_normalized);
+  const { books: eds, reconciled } = await slBooksForEntry(entry);
   if (!eds.length) return null;
+  // The ±year cap guards against unrelated same-surname authors a century
+  // apart. When the authority cluster has CONFIRMED the identity (reconciled),
+  // that collision risk is already handled — so widen the window to cover
+  // posthumous bans (e.g. Pico d.1494, banned 1632, editions 1496–1601). The
+  // Gemini verifier downstream is the real precision gate.
+  const WINDOW = reconciled ? 250 : 50;
   let best = null;
   for (const b of eds) {
-    // Year cap applies to BOTH opera_omnia and title-overlap paths. Without this
-    // a 1564-banned Reformer's surname matches an unrelated 1660 author. ±50y
-    // window covers reprints during the author's plausible lifetime + a generation.
-    if (entry.condemnation_year && b.year && Math.abs(entry.condemnation_year - b.year) > 50) continue;
+    if (entry.condemnation_year && b.year && Math.abs(entry.condemnation_year - b.year) > WINDOW) continue;
 
     if (entry.scope === 'opera_omnia') {
       const proximity = entry.condemnation_year && b.year ? Math.abs(entry.condemnation_year - b.year) : 9999;
-      if (proximity === 9999 && entry.condemnation_year) continue; // SL book has no year — too risky for opera_omnia
-      if (!best || proximity < best.proximity) best = { book: b, score: 1, proximity, reason: 'opera_omnia' };
+      // SL book with no year is too risky for opera_omnia UNLESS reconciled.
+      if (proximity === 9999 && entry.condemnation_year && !reconciled) continue;
+      if (!best || proximity < best.proximity) best = { book: b, score: 1, proximity, reason: reconciled ? 'opera_omnia+authority' : 'opera_omnia' };
       continue;
     }
     const score = scoreMatch(entry.title, b.title);
@@ -351,11 +376,13 @@ async function backfillIndex(indexId) {
       const e = queue.shift();
       const sn = e.author_normalized;
 
-      // Get USTC candidates: prefer author-based, fall back to title-based
+      // Get USTC candidates: prefer author-based, fall back to title-based.
+      // Author search uses stem-then-authority expanded surname forms.
       let editions = [];
       let matchedVia = 'author';
       if (sn && sn.length >= 3) {
-        editions = await ustcEditionsBySurname(sn);
+        const { forms } = slFormsForEntry(e);
+        editions = await ustcEditionsByForms(forms);
       }
       if (editions.length === 0) {
         // Title-fallback for anonymous OR where author search returned nothing
@@ -489,6 +516,12 @@ async function backfillIndex(indexId) {
 
 async function main() {
   console.log(`Catalog → USTC backfill\nMode: ${APPLY ? 'APPLY' : 'DRY-RUN'}${FORCE ? ' --force' : ''}`);
+
+  if (!NO_RECONCILE) {
+    console.log('Loading entity_aliases authority index (stem-then-authority)…');
+    AUTHORITY = await loadAuthority((path) => supa('GET', path));
+    console.log(`  ${AUTHORITY.clusters.size} clusters indexed.`);
+  }
 
   let indexIds = [];
   if (ALL) {

--- a/scripts/backfill-catalog-work-held-entity.mjs
+++ b/scripts/backfill-catalog-work-held-entity.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Entity-first work-held matcher: set index_catalog_entries.sl_book_id by
+ * matching an entry to a HELD book BY THE SAME ENTITY (author_entity_id), so
+ * the "banned book we hold" chip lights up on the exact work.
+ *
+ * Precise because it's entity-scoped — no surname collisions, no ±year guard
+ * needed (identity is already established by author_entity_id, set by
+ * backfill-catalog-author-entity.mjs). For each entry with author_entity_id and
+ * no sl_book_id:
+ *   • opera_omnia / author-only title → link a representative collected-works
+ *     volume by that entity (prefer "opera/omnia" in the title), else the
+ *     longest/most-complete book.
+ *   • single_work / expurgated → link the entity's book whose title shares ≥2
+ *     distinctive tokens with the entry title (best overlap wins).
+ *
+ * Idempotent — only fills sl_book_id IS NULL. Run after the author-entity
+ * backfill.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/backfill-catalog-work-held-entity.mjs            # dry-run
+ *   node scripts/backfill-catalog-work-held-entity.mjs --apply
+ */
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const concArg = process.argv.indexOf('--concurrency');
+const CONCURRENCY = Math.max(1, concArg > -1 ? Number(process.argv[concArg + 1]) : 4);
+
+const SUPA_URL = process.env.SUPABASE_URL;
+const SUPA_KEY = APPLY ? process.env.SUPABASE_SERVICE_ROLE_KEY : process.env.SUPABASE_ANON_KEY;
+if (!SUPA_URL || !SUPA_KEY) { console.error('SUPABASE_* missing'); process.exit(1); }
+const H = { apikey: SUPA_KEY, Authorization: `Bearer ${SUPA_KEY}`, 'Content-Type': 'application/json' };
+
+async function supa(method, path, body) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const opts = { method, headers: H };
+      if (body !== undefined) opts.body = JSON.stringify(body);
+      const r = await fetch(`${SUPA_URL}/rest/v1/${path}`, opts);
+      if (!r.ok) {
+        const text = (await r.text()).slice(0, 300);
+        if ((r.status >= 500 || r.status === 409) && attempt < 4) { await new Promise(res => setTimeout(res, 800 * 2 ** attempt)); continue; }
+        throw new Error(`${method} ${path} → ${r.status}: ${text}`);
+      }
+      return r.status === 204 ? null : r.json();
+    } catch (e) {
+      if (attempt === 4 || !/ETIMEDOUT|ECONNRESET|fetch failed|self-signed/i.test(String(e))) throw e;
+      await new Promise(res => setTimeout(res, 1500 * 2 ** attempt));
+    }
+  }
+}
+
+const STOP = new Set([
+  'libri', 'liber', 'libro', 'tres', 'duo', 'sive', 'seu', 'oder', 'over', 'quam', 'est',
+  'das', 'ist', 'und', 'von', 'dans', 'dell', 'della', 'dello', 'this', 'that', 'sopra',
+  'opera', 'omnia', 'tomus', 'editio', 'epistola', 'epistolae', 'tractatus', 'dialogo',
+  'oeuvres', 'works', 'traite', 'schriften', 'memoires', 'schrift', 'dialogus',
+]);
+const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+const titleTokens = (t) => norm(t).split(/\s+/).filter(w => w.length >= 5 && !STOP.has(w));
+function overlap(entryTitle, bookTitle) {
+  const toks = titleTokens(entryTitle);
+  if (!toks.length) return 0;
+  const bt = norm(bookTitle);
+  let n = 0; for (const t of toks) if (bt.includes(t)) n++;
+  return n;
+}
+
+let mc;
+const booksCache = new Map();
+async function entityBooks(entityId) {
+  if (booksCache.has(entityId)) return booksCache.get(entityId);
+  const db = mc.db('bookstore');
+  const books = await db.collection('books').find(
+    { author_entity_id: entityId, visible: { $ne: false }, pages_count: { $gt: 0 },
+      resource_type: { $nin: ['artwork', 'emblem', 'image', 'illustration', 'manuscript-fragment'] } },
+    { projection: { _id: 1, slug: 1, title: 1, year: 1, pages_count: 1 } }).toArray();
+  booksCache.set(entityId, books);
+  return books;
+}
+
+// Junk/placeholder books that slipped into the books collection.
+const isJunk = (b) => !b.title || /check-only|^\s*test\b|placeholder|untitled/i.test(b.title);
+
+function pickBook(entry, books) {
+  const pool = books.filter(b => !isJunk(b));
+  if (!pool.length) return null;
+  const isOpera = entry.scope === 'opera_omnia' || norm(entry.title) === norm(entry.author_string || '') || !titleTokens(entry.title).length;
+  if (isOpera) {
+    // Only link an "all works banned" entry to a genuine collected-works volume
+    // we hold (the Pico-opera-omnia pattern). Never an arbitrary "largest" book
+    // — for opera_omnia the author-held signal already conveys "we hold him".
+    const operas = pool.filter(b => /\b(opera|omnia|opuscula)\b/i.test(b.title || ''));
+    if (!operas.length) return null;
+    const best = [...operas].sort((a, b) => (b.pages_count || 0) - (a.pages_count || 0))[0];
+    return { book: best, reason: 'opera_omnia→collected-works' };
+  }
+  let best = null;
+  for (const b of pool) {
+    const score = overlap(entry.title, b.title);
+    if (score < 2) continue;
+    if (!best || score > best.score) best = { book: b, score, reason: `${score}-token-overlap` };
+  }
+  return best;
+}
+
+async function main() {
+  console.log(`entity-first work-held — mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+  mc = new MongoClient(process.env.MONGODB_URI);
+  await mc.connect();
+
+  // entries with an entity but no work link yet
+  const entries = [];
+  let offset = 0;
+  while (true) {
+    const rows = await supa('GET',
+      `index_catalog_entries?select=id,title,author,scope,author_entity_id&author_entity_id=not.is.null&sl_book_id=is.null&order=id&limit=1000&offset=${offset}`);
+    entries.push(...rows);
+    if (rows.length < 1000) break;
+    offset += rows.length;
+  }
+  console.log(`${entries.length} entity-linked entries lack a work link.`);
+
+  let linked = 0, done = 0;
+  const samples = [];
+  const queue = [...entries];
+  async function worker() {
+    while (queue.length) {
+      const e = queue.shift(); if (!e) break;
+      done++;
+      const books = await entityBooks(e.author_entity_id);
+      const m = pickBook({ ...e, author_string: e.author }, books);
+      if (m) {
+        linked++;
+        if (samples.length < 15) samples.push({ t: (e.title || '').slice(0, 36), b: m.book.slug, r: m.reason });
+        if (APPLY) {
+          await supa('PATCH', `index_catalog_entries?id=eq.${e.id}`, {
+            sl_book_id: String(m.book._id), sl_book_slug: m.book.slug || null,
+            match_method: 'entity_title_match', match_confidence: m.reason.startsWith('opera') ? 'medium' : 'high',
+          });
+        }
+      }
+      if (done % 200 === 0) process.stdout.write(`\r  ${done}/${entries.length} linked=${linked}   `);
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
+  console.log();
+  console.log('\nsamples:');
+  for (const s of samples) console.log(`  "${s.t}" → ${s.b} (${s.r})`);
+  console.log(`\n${APPLY ? 'Linked' : 'Would link'} ${linked} entries to a held work by the same entity.`);
+  await mc.close();
+}
+main().catch(e => { console.error('Fatal:', e); process.exit(1); });

--- a/scripts/ingest-index-from-ocr.mjs
+++ b/scripts/ingest-index-from-ocr.mjs
@@ -25,7 +25,7 @@
  *   --concurrency K           Parallel page-extraction requests (default: 4)
  *   --max-pages N             Cap on pages processed (default: all)
  *   --start-page P            Start at this 1-indexed page (default: 1)
- *   --model M                 Gemini model (default: gemini-3.1-flash-lite-preview)
+ *   --model M                 Gemini model (default: gemini-3.1-flash-lite)
  *   --collection-slug SLUG    What index_catalogs.collection_slug to point at (default: index-librorum-prohibitorum)
  */
 
@@ -43,7 +43,7 @@ const INDEX_ID = arg('--index-id');
 const CONCURRENCY = Math.max(1, Number(arg('--concurrency', 4)));
 const MAX_PAGES = Number(arg('--max-pages', 0)) || Infinity;
 const START_PAGE = Number(arg('--start-page', 1));
-const MODEL = arg('--model', 'gemini-3.1-flash-lite-preview');
+const MODEL = arg('--model', 'gemini-3.1-flash-lite');
 const COLLECTION_SLUG = arg('--collection-slug', 'index-librorum-prohibitorum');
 
 if (!BOOK_ID || !INDEX_ID) {

--- a/scripts/lib/author-reconcile.mjs
+++ b/scripts/lib/author-reconcile.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * Author reconciliation for catalog matching — stem-then-authority.
+ *
+ * Problem (see .claude/docs/author-normalization-method.md): the Index lists
+ * authors in Latin ("Picus, Ioannes"); our books and USTC use vernacular
+ * ("Pico della Mirandola, Giovanni"). Exact-surname matching misses them, and
+ * even authority reconciliation via `entity_aliases` misses them too — because
+ * authority records enumerate vernacular/standard variants ("pico", "pic",
+ * "mirandula") but NOT every Latin grammatical inflection ("picus", "pici").
+ *
+ * The fix is an extra morphological layer BEFORE the authority lookup: stem
+ * each name token to fold Latin inflections, so "picus" → "pic" meets the
+ * cluster's enumerated "pic". Then disambiguate same-stem candidates by given
+ * name + life-dates, and expand to the chosen cluster's full surname set.
+ *
+ *   Index "Picus, Ioannes" (1632)
+ *     → stem surname "picus" → {picus, pic}
+ *     → entity_aliases clusters containing a surname that stems into that set:
+ *          • Giovanni Pico della Mirandola (b1463 d1494) — given "ioannes" ✓
+ *          • Andreas Picus (b1543 d1609)               — given "andreas" ✗
+ *          • Ranuccio Pico (b1568 d1644)               — given "ranuccio" ✗
+ *     → given-name overlap picks Giovanni Pico
+ *     → expand to {pico, mirandola, mirandula, mirandulensis, …}
+ *     → SL search now finds "Pico della Mirandola, Giovanni" books.
+ *
+ * Recall vs precision: reconciliation only WIDENS recall (it can surface both
+ * the right person and a same-named decoy — e.g. Jean Pic the Carthusian, also
+ * "Ioannes Picus"). Precision is still held downstream by the title gate and
+ * the Gemini same-person verifier in the backfill scripts.
+ *
+ * CLI (doubles as the proof / debug tool):
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/lib/author-reconcile.mjs "Picus, Ioannes" 1632
+ */
+
+// ─── Layer 1: string normalization (matches the doc) ──────────────────────
+export function norm(s) {
+  if (!s) return '';
+  return String(s).normalize('NFKD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase().replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+// Particles / honorifics that are never the surname.
+const PARTICLES = new Set([
+  'de', 'del', 'della', 'di', 'da', 'la', 'le', 'van', 'von', 'der', 'den',
+  'du', 'des', 'el', 'al', 'ibn', 'ben', 'a', 'ab', 'zu', 'of', 'the',
+  'don', 'fr', 'st', 'saint', 'pseudo',
+]);
+
+// ─── Latin morphological stemming ──────────────────────────────────────────
+// Fold inflectional endings so picus/pico/pici/picum all reach a common stem.
+// Conservative: only strips when ≥3 chars remain. Returns the token plus every
+// plausible stem (recall-first; collisions are resolved downstream).
+const LATIN_ENDINGS = /(?:issimus|issima|orum|arum|ibus|ensis|enses|onis|ones|ius|eus|aeus|aei|ane|us|um|os|is|es|em|ae|i|o|a|e)$/;
+
+export function stems(tokenRaw) {
+  const out = new Set();
+  const token = norm(tokenRaw);
+  if (token.length < 3) return out;
+  const bases = new Set([token]);
+  // Long-s OCR confusion (ſ→f): "brandeburgenfis" → "brandeburgensis".
+  const longS = token.replace(/f/g, 's');
+  if (longS !== token) bases.add(longS);
+  for (const base of bases) {
+    out.add(base);
+    const m = base.match(LATIN_ENDINGS);
+    if (m) {
+      const stem = base.slice(0, base.length - m[0].length);
+      if (stem.length >= 3) out.add(stem);
+    }
+  }
+  return new Set([...out].filter(s => s.length >= 3));
+}
+
+function tokens(name) {
+  // "Surname, Given" → surname is everything before the first comma.
+  const n = norm(name);
+  if (!n) return { surnames: [], givens: [] };
+  let surnamePart = n, givenPart = '';
+  if (name.includes(',')) {
+    const [a, b] = name.split(',');
+    surnamePart = norm(a);
+    givenPart = norm(b);
+  }
+  const surTokens = surnamePart.split(' ').filter(t => t && !PARTICLES.has(t));
+  const givTokens = givenPart.split(' ').filter(t => t && !PARTICLES.has(t));
+  // If no comma, the last token is the likely given name in "Given Surname"
+  // order — but Index entries are surname-first, so default to treating ALL
+  // non-particle tokens as candidate surnames.
+  return { surnames: surTokens, givens: givTokens };
+}
+
+// ─── Authority index (built once from entity_aliases) ──────────────────────
+// entity_aliases.surnames[] mixes true surnames with given-name fragments
+// ("ioannes", "john"…). We can't tell them apart per-row, but we can across
+// the corpus: a stem that recurs in thousands of clusters is a given name or a
+// generic word; a real surname stem is comparatively rare. So we compute each
+// stem's document-frequency and treat only LOW-frequency stems as distinctive
+// surnames — for both candidate matching and expansion. This is the data-driven
+// version of the doc's `len>=4` + ambiguity-guard heuristics.
+//
+// Returns: { stem2cl: stem→Set(clusterId), clusters: id→meta, stemDF: stem→count }
+export async function loadAuthority(supaGet, { dfMax = 30 } = {}) {
+  const stem2cl = new Map();
+  const clusters = new Map();
+  const stemDF = new Map();
+  let offset = 0;
+  const PAGE = 1000;
+  while (true) {
+    const rows = await supaGet(
+      `entity_aliases?select=id,primary_name,surnames,names,birth_year,death_year&order=id&limit=${PAGE}&offset=${offset}`);
+    if (!rows.length) break;
+    for (const r of rows) {
+      const surnameStems = new Set();
+      const surnameForms = new Set();   // original normalized tokens, for searching
+      for (const s of (r.surnames || [])) {
+        for (const tok of norm(s).split(' ')) {
+          if (tok.length < 3) continue;
+          surnameForms.add(tok);
+          for (const st of stems(tok)) surnameStems.add(st);
+        }
+      }
+      // Given-name stems: first token of each full name in names[] (Western
+      // order) — used only to disambiguate, never to search.
+      const givenStems = new Set();
+      for (const nm of (r.names || [])) {
+        const first = norm(nm).split(' ')[0];
+        for (const st of stems(first)) givenStems.add(st);
+      }
+      clusters.set(r.id, {
+        primary_name: r.primary_name,
+        surnameStems, surnameForms, givenStems,
+        birth: r.birth_year, death: r.death_year,
+      });
+      for (const st of surnameStems) {
+        if (!stem2cl.has(st)) stem2cl.set(st, new Set());
+        stem2cl.get(st).add(r.id);
+        stemDF.set(st, (stemDF.get(st) || 0) + 1);
+      }
+    }
+    if (rows.length < PAGE) break;
+    offset += rows.length;
+  }
+  return { stem2cl, clusters, stemDF, dfMax };
+}
+
+// ─── Reconcile one name → best cluster + expanded surname forms ─────────────
+export function reconcile(rawName, { authority, year } = {}) {
+  const { stem2cl, clusters, stemDF, dfMax = 30 } = authority;
+  const distinctive = (st) => (stemDF.get(st) || 0) <= dfMax;
+  const { surnames, givens } = tokens(rawName);
+  if (!surnames.length) return null;
+
+  const queryStems = new Set();
+  for (const t of surnames) for (const st of stems(t)) queryStems.add(st);
+  const givenStems = new Set();
+  for (const t of givens) for (const st of stems(t)) givenStems.add(st);
+
+  // Candidate clusters. A DISTINCTIVE surname stem (rare across the corpus,
+  // e.g. "pic") admits all its clusters. A COMMON stem (e.g. "erasm", which is
+  // also a widespread given name) would pull thousands — so for those we admit
+  // a cluster only if it ALSO matches the query's given name. This rescues
+  // marquee authors with given-name-like surnames (Desiderius *Erasmus*) that
+  // the doc's blanket ambiguity-guard dropped, without the blowup.
+  const candIds = new Set();
+  for (const st of queryStems) {
+    const ids = stem2cl.get(st);
+    if (!ids) continue;
+    if (distinctive(st)) {
+      for (const id of ids) candIds.add(id);
+    } else if (givenStems.size) {
+      for (const id of ids) {
+        const c = clusters.get(id);
+        if ([...givenStems].some(g => c.givenStems.has(g))) candIds.add(id);
+      }
+    }
+  }
+  if (!candIds.size) return null;
+
+  let best = null;
+  for (const id of candIds) {
+    const c = clusters.get(id);
+    // given-name overlap is the strongest disambiguator (Ioannes Pico vs
+    // Andreas Picus). Year plausibility: an author can't be banned before birth.
+    let givenHit = 0;
+    for (const g of givenStems) if (c.givenStems.has(g)) { givenHit = 1; break; }
+    let yearOk = 1;
+    if (year && c.birth && year < c.birth - 5) yearOk = 0;     // banned before born → no
+    const surnameMatches = [...queryStems].filter(s => c.surnameStems.has(s)).length;
+    // Score: given-name match dominates, then year plausibility, then surname depth.
+    const score = givenHit * 100 + yearOk * 10 + Math.min(surnameMatches, 5);
+    if (!best || score > best.score) best = { id, c, score, givenHit, yearOk };
+  }
+  if (!best) return null;
+  // If the entry has a given name but NOTHING matched it, the cluster is a
+  // same-surname decoy — refuse rather than mislink (precision floor).
+  if (givenStems.size && !best.givenHit && [...candIds].some(id => {
+    const c = clusters.get(id);
+    return [...givenStems].some(g => c.givenStems.has(g));
+  })) {
+    return null; // a better-matching given-name cluster exists; this isn't it
+  }
+
+  // Expand: the cluster's real surname FORMS, kept only when their (shortest,
+  // most aggressive) stem is distinctive — this drops given-name fragments
+  // ("john", "ioannes", "count") and keeps {pico, mirandola, mirandula, …} as
+  // whole-word search terms (forms, not prefixes).
+  const shortestStem = (f) => [...stems(f)].sort((a, b) => a.length - b.length)[0] || f;
+  const expanded = new Set(
+    [...best.c.surnameForms].filter(f => f.length >= 4 && distinctive(shortestStem(f))));
+  // Always include the entry's own literal surname(s): for an author whose
+  // surname is itself a common token (Erasmus), the literal form is dropped
+  // from the cluster expansion but is exactly what our catalog files him under.
+  for (const t of surnames) if (t.length >= 4) expanded.add(t);
+  return {
+    clusterId: best.id,
+    primary_name: best.c.primary_name,
+    birth: best.c.birth, death: best.c.death,
+    score: best.score,
+    expandedSurnames: [...expanded],
+  };
+}
+
+// ─── CLI / proof harness ────────────────────────────────────────────────────
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const name = process.argv[2];
+  const year = process.argv[3] ? Number(process.argv[3]) : undefined;
+  if (!name) { console.error('usage: author-reconcile.mjs "Surname, Given" [year]'); process.exit(1); }
+
+  const SUPA_URL = process.env.SUPABASE_URL;
+  const SUPA_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  const supaGet = async (path) => {
+    const r = await fetch(`${SUPA_URL}/rest/v1/${path}`, {
+      headers: { apikey: SUPA_KEY, Authorization: `Bearer ${SUPA_KEY}` } });
+    if (!r.ok) throw new Error(`${r.status}: ${(await r.text()).slice(0, 200)}`);
+    return r.json();
+  };
+
+  console.log(`Query: "${name}"${year ? ` (year ${year})` : ''}`);
+  console.log(`Surname stems: ${[...new Set([...tokens(name).surnames].flatMap(t => [...stems(t)]))].join(', ')}`);
+  console.log('Loading entity_aliases…');
+  const authority = await loadAuthority(supaGet);
+  console.log(`Loaded ${authority.clusters.size} clusters.\n`);
+
+  // DF calibration for a few telling stems.
+  const df = (s) => authority.stemDF.get(s) || 0;
+  console.log(`stem DF — pic:${df('pic')} mirandol:${df('mirandol')} mirandul:${df('mirandul')} john:${df('john')} ioann:${df('ioann')} giovann:${df('giovann')}\n`);
+
+  const r = reconcile(name, { authority, year });
+  if (!r) { console.log('No confident cluster.'); process.exit(0); }
+  console.log(`→ ${r.primary_name} (b${r.birth ?? '?'} d${r.death ?? '?'}), score ${r.score}`);
+  console.log(`  expanded surnames: ${r.expandedSurnames.join(', ')}`);
+
+  // Prove SL recall: search Mongo with OLD (literal surname) vs NEW (expanded).
+  const { MongoClient } = await import('mongodb');
+  const mc = new MongoClient(process.env.MONGODB_URI);
+  await mc.connect();
+  const db = mc.db('bookstore');
+  const litSurname = tokens(name).surnames[0];
+  // Whole-word match on real surname forms (not prefixes).
+  const mkRe = (terms) => new RegExp(`(^|[^a-z])(${terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})([^a-z]|$)`, 'i');
+  const find = (terms) => db.collection('books').find(
+    { author: mkRe(terms), visible: { $ne: false } },
+    { projection: { title: 1, author: 1, year: 1, slug: 1 } }).limit(40).toArray();
+  const oldHits = await find([litSurname]);
+  const newHits = await find(r.expandedSurnames);
+  console.log(`\nSL books — OLD (literal "${litSurname}"): ${oldHits.length}`);
+  console.log(`SL books — NEW (expanded forms): ${newHits.length}`);
+  for (const b of newHits.slice(0, 12)) console.log(`   • "${(b.title || '').slice(0, 50)}" — ${b.author} (${b.year ?? '?'})`);
+  await mc.close();
+}

--- a/scripts/lib/author-reconcile.mjs
+++ b/scripts/lib/author-reconcile.mjs
@@ -109,7 +109,7 @@ export async function loadAuthority(supaGet, { dfMax = 30 } = {}) {
   const PAGE = 1000;
   while (true) {
     const rows = await supaGet(
-      `entity_aliases?select=id,primary_name,surnames,names,birth_year,death_year&order=id&limit=${PAGE}&offset=${offset}`);
+      `entity_aliases?select=id,primary_name,surnames,names,birth_year,death_year,viaf_id,wikidata_qid&order=id&limit=${PAGE}&offset=${offset}`);
     if (!rows.length) break;
     for (const r of rows) {
       const surnameStems = new Set();
@@ -132,6 +132,7 @@ export async function loadAuthority(supaGet, { dfMax = 30 } = {}) {
         primary_name: r.primary_name,
         surnameStems, surnameForms, givenStems,
         birth: r.birth_year, death: r.death_year,
+        viaf: r.viaf_id, wikidata: r.wikidata_qid,
       });
       for (const st of surnameStems) {
         if (!stem2cl.has(st)) stem2cl.set(st, new Set());
@@ -217,6 +218,8 @@ export function reconcile(rawName, { authority, year } = {}) {
     clusterId: best.id,
     primary_name: best.c.primary_name,
     birth: best.c.birth, death: best.c.death,
+    viafId: best.c.viaf || null,
+    wikidata: best.c.wikidata || null,
     score: best.score,
     expandedSurnames: [...expanded],
   };

--- a/scripts/lib/entity-resolve.mjs
+++ b/scripts/lib/entity-resolve.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Resolve an author name → canonical Mongo `entities` record → that author's
+ * books, via the two authority stores' complementary strengths:
+ *
+ *   name (any form, incl. Latin index)
+ *     │  stem-then-authority reconciliation against Supabase entity_aliases
+ *     │  (full surnames + life-dates + viaf_id) — author-reconcile.mjs
+ *     ▼
+ *   cluster { primary_name (vernacular), viaf_id }
+ *     │  bridge to Mongo `entities`:  by viaf_id (exact), else by normalized
+ *     │  primary_name (the hard Latin→vernacular step is already done, so this
+ *     │  is now an easy exact match)
+ *     ▼
+ *   author_entity_id  →  books.find({ author_entity_id })  — EXACT join
+ *
+ * Why this and not surname regex: the entity join separates same-surname people
+ * a surname can't — e.g. Giovanni Pico (entity → 12 books) vs his nephew
+ * Gianfrancesco (own entity). Reusable anywhere author identity matters:
+ * catalog matching, "books by this author", related-works, dedup.
+ *
+ * Coverage honesty: the Mongo entity store is mostly bare name stubs (only
+ * ~1.7% carry aliases, ~0.2% a VIAF id, none have dates). The bridge therefore
+ * lands for the resolved head (famous authors — Pico, Erasmus, Bruno); for the
+ * long tail with no resolvable entity, callers should fall back to the surname-
+ * cluster path (reconcile().expandedSurnames). This module returns enough to do
+ * both: entityId when bridged, expandedSurnames always.
+ *
+ * CLI proof:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/lib/entity-resolve.mjs "Picus, Ioannes" 1632
+ */
+import { loadAuthority, reconcile, norm } from './author-reconcile.mjs';
+
+// Build the resolver once: Supabase authority for reconciliation + two Mongo
+// entity lookup indexes (by viaf, by normalized name) for the bridge.
+export async function loadResolver(supaGet, db, { dfMax = 30 } = {}) {
+  const authority = await loadAuthority(supaGet, { dfMax });
+  const byViaf = new Map();
+  const byName = new Map();
+  const cur = db.collection('entities').find(
+    { type: 'person' }, { projection: { name: 1, viaf_id: 1 } });
+  for await (const e of cur) {
+    if (e.viaf_id) byViaf.set(String(e.viaf_id), String(e._id));
+    const n = norm(e.name);
+    if (n && !byName.has(n)) byName.set(n, String(e._id));   // first wins; name-only stubs
+  }
+  return { authority, byViaf, byName };
+}
+
+// name → { entityId | null, primary_name, viafId, score, expandedSurnames, via }
+export function resolveToEntity(name, { resolver, year } = {}) {
+  const rec = reconcile(name, { authority: resolver.authority, year });
+  if (!rec) return null;
+  let entityId = null, via = null;
+  if (rec.viafId && resolver.byViaf.has(String(rec.viafId))) {
+    entityId = resolver.byViaf.get(String(rec.viafId)); via = 'viaf';
+  } else {
+    const byName = resolver.byName.get(norm(rec.primary_name));
+    if (byName) { entityId = byName; via = 'name'; }
+  }
+  return {
+    entityId, via,
+    primary_name: rec.primary_name,
+    viafId: rec.viafId,
+    score: rec.score,
+    expandedSurnames: rec.expandedSurnames,
+  };
+}
+
+export async function booksForEntity(db, entityId) {
+  if (!entityId) return [];
+  return db.collection('books').find(
+    { author_entity_id: entityId, visible: { $ne: false } },
+    { projection: { title: 1, author: 1, year: 1, slug: 1 } }).toArray();
+}
+
+// ─── CLI / proof harness ────────────────────────────────────────────────────
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const name = process.argv[2];
+  const year = process.argv[3] ? Number(process.argv[3]) : undefined;
+  if (!name) { console.error('usage: entity-resolve.mjs "Surname, Given" [year]'); process.exit(1); }
+
+  const SUPA_URL = process.env.SUPABASE_URL;
+  const SUPA_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  const supaGet = async (path) => {
+    const r = await fetch(`${SUPA_URL}/rest/v1/${path}`, {
+      headers: { apikey: SUPA_KEY, Authorization: `Bearer ${SUPA_KEY}` } });
+    if (!r.ok) throw new Error(`${r.status}: ${(await r.text()).slice(0, 200)}`);
+    return r.json();
+  };
+  const { MongoClient } = await import('mongodb');
+  const mc = new MongoClient(process.env.MONGODB_URI);
+  await mc.connect();
+  const db = mc.db('bookstore');
+
+  console.log(`Query: "${name}"${year ? ` (${year})` : ''}`);
+  console.log('Loading resolver (Supabase authority + Mongo entity bridge)…');
+  const resolver = await loadResolver(supaGet, db);
+  console.log(`  ${resolver.authority.clusters.size} clusters, ${resolver.byViaf.size} viaf-bridged + ${resolver.byName.size} name-bridged entities.\n`);
+
+  const r = resolveToEntity(name, { resolver, year });
+  if (!r) { console.log('No confident cluster.'); await mc.close(); process.exit(0); }
+  console.log(`reconciled → ${r.primary_name} (VIAF ${r.viafId || '—'}), score ${r.score}`);
+  console.log(`entity bridge → ${r.entityId ? `${r.entityId} (via ${r.via})` : 'NONE (fall back to surname expansion)'}`);
+
+  if (r.entityId) {
+    const books = await booksForEntity(db, r.entityId);
+    console.log(`\nEXACT entity join → ${books.length} books:`);
+    for (const b of books.slice(0, 15)) console.log(`   • "${(b.title || '').slice(0, 48)}" — ${b.author} (${b.year ?? '?'})`);
+  } else {
+    console.log(`\nNo entity; surname-expansion fallback terms: ${r.expandedSurnames.join(', ')}`);
+  }
+  await mc.close();
+}

--- a/src/app/api/catalogs/works/route.ts
+++ b/src/app/api/catalogs/works/route.ts
@@ -65,9 +65,15 @@ export async function GET(req: Request) {
     ? editionsParam.split(',').filter(id => collectionIndexIds.includes(id))
     : collectionIndexIds;
 
+  // 'estimated' not 'exact': an exact count re-runs the full v_index_catalog_works
+  // aggregation (~1s extra) and tipped this endpoint over the role statement
+  // timeout (500s). has_more is computed by fetching one extra row instead, so
+  // pagination stays correct; total is the planner estimate (fine for a "~N
+  // works" display). The deeper fix is a GIN index on edition_ids / a
+  // materialized view — see the catalog perf note.
   let query = supabase
     .from('v_index_catalog_works')
-    .select('*', { count: 'exact' });
+    .select('*', { count: 'estimated' });
 
   // Edition filter — works whose edition_ids array OVERLAPS (any) or CONTAINS (all) the selection
   if (selectedEditions.length > 0) {
@@ -103,16 +109,21 @@ export async function GET(req: Request) {
   else if (sort === 'edition_count') query = query.order('edition_count', { ascending: false });
   else query = query.order('author', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
 
-  query = query.range(from, to);
+  // Fetch one extra row to detect has_more without depending on the exact count.
+  query = query.range(from, to + 1);
   const { data, error, count } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
+  const rows = (data || []) as Work[];
+  const hasMore = rows.length > pageSize;
+  const works = hasMore ? rows.slice(0, pageSize) : rows;
+
   return NextResponse.json({
-    works: (data || []) as Work[],
-    total: count ?? 0,
+    works,
+    total: count ?? works.length,   // planner estimate; approximate by design
     page,
     page_size: pageSize,
-    has_more: (count ?? 0) > to + 1,
+    has_more: hasMore,
     editions: collectionIndexIds,
   });
 }


### PR DESCRIPTION
Bundled work on the *Index Librorum Prohibitorum* reference catalog (2026-05-29). One arc: make the catalog matchable, then join it to the main-site author graph.

## Bug fixes
- **Retired Gemini model name** (`gemini-3.1-flash-lite-preview` → GA) in `backfill-catalog-ustc-sl-links.mjs` + `ingest-index-from-ocr.mjs`. The verify step fell back to `same_person:false` on the 404, silently rejecting ~100% of matches.
- **`/api/catalogs/works` 500** — `count:'exact'` on the `v_index_catalog_works` aggregation tipped the role statement timeout. Switched to `count:'estimated'` + fetch-one-extra pagination.

## Data backfills (applied to prod Supabase)
- **`language`** backfilled from the matched USTC edition (5,228 entries, 23 languages) — the per-edition blanket default would mislabel the 34% non-Latin works.
- **author-held** completed for all authored identities.
- **`author_entity_id`** (new column) populated via the resolver: 16,505 entries linked to the main-site author graph; author-held entries 6,139→8,158.
- **work-held** (`sl_book_id`) via entity-first matching: 469→839.

## New capability — reusable author resolution
- `scripts/lib/author-reconcile.mjs` — **stem-then-authority**: stems Latin inflections (`picus→pic`) so they meet the authority's enumerated forms; document-frequency distinctiveness separates surnames from given-names; given-name + life-date disambiguation.
- `scripts/lib/entity-resolve.mjs` — bridges a resolved name to the Mongo `entities` record (by VIAF / vernacular name) → exact `author_entity_id` book join.
- `scripts/backfill-catalog-author-entity.mjs`, `scripts/backfill-catalog-work-held-entity.mjs` — apply it to the catalog.
- Method note: `.claude/docs/author-normalization-method.md`.

**Proven:** `Picus, Ioannes` → Giovanni Pico → exactly 12 held books (0 before); nephew Gianfrancesco and Jean Pic the Carthusian correctly separated. Erasmus, Bruno, Machiavelli, Estienne (Henri vs Robert) all resolve.

## Known / out of scope
- Resolution is per author-string; exact-name splits (Pico/Carthusian) handled by a curated `SPLIT_OVERRIDES` post-pass — general per-entry title disambiguation is future work.
- Robust works-API perf = materialize `v_index_catalog_works` (needs DDL).
- "Banned by the Index" book-page chip + Forbidden-Library reading room: issue #2164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)