### PR TITLE
Librarian search eval: expand golden set + ai-expand multiquery variant

### DIFF
--- a/scripts/eval/librarian-search/_expand-golden-set.mjs
+++ b/scripts/eval/librarian-search/_expand-golden-set.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Expansion pass for the Librarian search eval golden set.
+ *
+ * Adds candidates to the THIN categories (cross-lingual, verbatim-quote,
+ * broad-theme, bibliographic, niche-passage) that the first eval flagged as
+ * noisy (only 1-3 queries each). Resolves flexible query_book/author terms to
+ * REAL slugs in Mongo so we never hard-code a wrong slug, then prints entries
+ * to merge into golden-set.json after review.
+ *
+ *   set -a; source ../../../../.env.production.local; set +a
+ *   node scripts/eval/librarian-search/_expand-golden-set.mjs
+ *
+ * Mirrors the resolver in _seed-golden-set.mjs. Review stderr, then merge the
+ * stdout JSON entries into golden-set.json.
+ */
+
+import { MongoClient } from 'mongodb';
+
+const CANDIDATES = [
+  // ── cross-lingual (English query → non-English originals/translations) ──
+  { id: 'zohar-sefirot', query: 'Kabbalah on the ten sefirot and divine emanation',
+    category: 'cross-lingual', query_book: 'zohar', author_contains: null },
+  { id: 'sefer-yetzirah-creation', query: 'Hebrew letters and the creation of the world',
+    category: 'cross-lingual', query_book: 'yetzirah', author_contains: null },
+  { id: 'ibn-arabi-unity', query: 'Sufi metaphysics of the unity of being and divine names',
+    category: 'cross-lingual', query_book: 'arabi|futuhat|fusus', author_contains: 'arabi' },
+  { id: 'suhrawardi-illumination', query: 'philosophy of illumination and the world of light',
+    category: 'cross-lingual', query_book: 'illumination|ishraq|hikmat', author_contains: 'suhrawardi' },
+
+  // ── verbatim-quote (famous line tied to a specific work) ──────────────
+  { id: 'rosicrucian-fama', query: 'Fama Fraternitatis and the discovery of the tomb of Christian Rosenkreutz',
+    category: 'verbatim-quote', query_book: 'fama|fraternitatis|rosenkreutz', author_contains: null },
+  { id: 'chymical-wedding', query: 'the chymical wedding of Christian Rosenkreutz',
+    category: 'verbatim-quote', query_book: 'chymical wedding|chymische hochzeit', author_contains: null },
+  { id: 'maier-atalanta-motto', query: 'Atalanta Fugiens emblem the wind carried him in his belly',
+    category: 'verbatim-quote', query_book: 'atalanta', author_contains: 'maier' },
+
+  // ── broad-theme ───────────────────────────────────────────────────────
+  { id: 'coniunctio-opposites', query: 'the marriage and union of opposites in alchemy',
+    category: 'broad-theme', query_book: 'rosarium', author_contains: null },
+  { id: 'rosicrucian-reformation', query: 'the universal reformation of the whole wide world',
+    category: 'broad-theme', query_book: 'confessio|reformation', author_contains: null },
+  { id: 'neoplatonic-ascent', query: 'the ascent of the soul to the One',
+    category: 'broad-theme', query_book: 'enneads|plotinus', author_contains: 'plotinus' },
+
+  // ── bibliographic (find a SET of books, not one passage) ──────────────
+  { id: 'alchemical-emblem-books', query: 'alchemical emblem books with engraved plates',
+    category: 'bibliographic', query_book: 'mutus liber|splendor solis|atalanta', author_contains: null },
+  { id: 'corpus-hermeticum-editions', query: 'editions of the Corpus Hermeticum',
+    category: 'bibliographic', query_book: 'hermeticum|pimander|pymander', author_contains: null },
+  { id: 'paracelsus-medicine', query: 'works of Paracelsus on medicine and chemistry',
+    category: 'bibliographic', query_book: null, author_contains: 'paracelsus' },
+
+  // ── niche-passage (specific topic inside a known book) ────────────────
+  { id: 'paracelsus-homunculus', query: 'the artificial generation of a homunculus',
+    category: 'niche-passage', query_book: 'natura rerum|de generatione', author_contains: 'paracelsus' },
+  { id: 'ripley-green-lion', query: 'the green lion devouring the sun in alchemy',
+    category: 'niche-passage', query_book: 'ripley|rosarium', author_contains: null },
+];
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) { console.error('MONGODB_URI not set; source .env.production.local'); process.exit(1); }
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+
+  const queries = [];
+  for (const c of CANDIDATES) {
+    const filter = { hidden: { $ne: true }, tenantId: { $in: [null, undefined] }, pages_count: { $gt: 0 } };
+    const orClauses = [];
+    if (c.query_book) {
+      const re = new RegExp(c.query_book.replace(/\s+/g, '.*'), 'i');
+      orClauses.push({ title: re }, { display_title: re }, { english_title: re });
+    }
+    if (orClauses.length) filter.$or = orClauses;
+    if (c.author_contains) filter.author = new RegExp(c.author_contains, 'i');
+
+    const docs = await db.collection('books')
+      .find(filter)
+      .project({ slug: 1, title: 1, display_title: 1, author: 1, pages_count: 1, pages_translated: 1, year: 1 })
+      .limit(6).toArray();
+
+    process.stderr.write(`\n${c.id} [${c.category}] → ${docs.length} match(es)\n`);
+    for (const d of docs) {
+      process.stderr.write(`    ${d.slug}  "${d.display_title || d.title}" by ${d.author || '?'} (${d.pages_translated || 0}/${d.pages_count} tr)\n`);
+    }
+
+    queries.push({
+      id: c.id, query: c.query, category: c.category,
+      confidence: docs.length ? 'medium' : 'low',
+      expected: docs.slice(0, 5).map(d => ({ book_slug: d.slug })),
+      notes: docs.length
+        ? `Resolved ${docs.length} candidate(s); review before trusting.`
+        : `NO MATCH for ${c.query_book || c.query}; verify collection coverage.`,
+    });
+  }
+
+  await client.close();
+  console.log(JSON.stringify({ new_entries: queries }, null, 2));
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/eval/librarian-search/golden-set.json
+++ b/scripts/eval/librarian-search/golden-set.json
@@ -11,11 +11,21 @@
       "category": "well-known-concept",
       "confidence": "high",
       "expected": [
-        { "book_slug": "henrici-cor-agrippae-ab-nettesheym-de-occvlta-philosophia-agrippa-von" },
-        { "book_slug": "three-books-of-occult-philosophy-1533-latin-agrippa" },
-        { "book_slug": "de-occulta-philosophia-complete-edition-agrippa" },
-        { "book_slug": "de-occulta-philosophia-libri-tres-agrippa" },
-        { "book_slug": "three-books-of-occult-philosophy-nettesheim" }
+        {
+          "book_slug": "henrici-cor-agrippae-ab-nettesheym-de-occvlta-philosophia-agrippa-von"
+        },
+        {
+          "book_slug": "three-books-of-occult-philosophy-1533-latin-agrippa"
+        },
+        {
+          "book_slug": "de-occulta-philosophia-complete-edition-agrippa"
+        },
+        {
+          "book_slug": "de-occulta-philosophia-libri-tres-agrippa"
+        },
+        {
+          "book_slug": "three-books-of-occult-philosophy-nettesheim"
+        }
       ],
       "notes": "Several editions of Three Books of Occult Philosophy. Any is a hit."
     },
@@ -25,8 +35,12 @@
       "category": "well-known-concept",
       "confidence": "high",
       "expected": [
-        { "book_slug": "de-vmbris-idearvm-implicantibus-artem-quaerendi-inveniendi-bruno" },
-        { "book_slug": "iordani-bruni-nolani-de-imaginum-signorum-amp-idearum-bruno" }
+        {
+          "book_slug": "de-vmbris-idearvm-implicantibus-artem-quaerendi-inveniendi-bruno"
+        },
+        {
+          "book_slug": "iordani-bruni-nolani-de-imaginum-signorum-amp-idearum-bruno"
+        }
       ],
       "notes": "Bruno's mnemonic / 'shadows of ideas' works. De infinito is not in the collection — this tests Bruno coverage we DO have."
     },
@@ -36,11 +50,21 @@
       "category": "well-known-concept",
       "confidence": "high",
       "expected": [
-        { "book_slug": "three-books-on-life-1489-first-edition-ficino" },
-        { "book_slug": "three-books-on-life-ficino" },
-        { "book_slug": "three-books-on-life-ficino-2" },
-        { "book_slug": "de-vita-libri-tres-three-books-on-life-1529-ficino" },
-        { "book_slug": "three-books-on-life-ficino-3" }
+        {
+          "book_slug": "three-books-on-life-1489-first-edition-ficino"
+        },
+        {
+          "book_slug": "three-books-on-life-ficino"
+        },
+        {
+          "book_slug": "three-books-on-life-ficino-2"
+        },
+        {
+          "book_slug": "de-vita-libri-tres-three-books-on-life-1529-ficino"
+        },
+        {
+          "book_slug": "three-books-on-life-ficino-3"
+        }
       ],
       "notes": "De Vita Coelitus Comparanda (Book III of De Vita) is the canonical text on spiritus/talismans."
     },
@@ -50,8 +74,12 @@
       "category": "well-known-concept",
       "confidence": "high",
       "expected": [
-        { "book_slug": "harmonices-mundi-1619-first-edition-kepler" },
-        { "book_slug": "harmony-of-the-world-with-mysterium-cosmographicum-kepler" }
+        {
+          "book_slug": "harmonices-mundi-1619-first-edition-kepler"
+        },
+        {
+          "book_slug": "harmony-of-the-world-with-mysterium-cosmographicum-kepler"
+        }
       ]
     },
     {
@@ -60,10 +88,18 @@
       "category": "well-known-concept",
       "confidence": "high",
       "expected": [
-        { "book_slug": "history-of-the-macrocosm-and-microcosm-fludd" },
-        { "book_slug": "history-of-both-worlds-macrocosm-fludd" },
-        { "book_slug": "history-of-both-worlds-microcosm-fludd" },
-        { "book_slug": "utriusque-cosmi-maioris-scilicet-et-minoris-metaphysica-fludd" }
+        {
+          "book_slug": "history-of-the-macrocosm-and-microcosm-fludd"
+        },
+        {
+          "book_slug": "history-of-both-worlds-macrocosm-fludd"
+        },
+        {
+          "book_slug": "history-of-both-worlds-microcosm-fludd"
+        },
+        {
+          "book_slug": "utriusque-cosmi-maioris-scilicet-et-minoris-metaphysica-fludd"
+        }
       ]
     },
     {
@@ -72,8 +108,12 @@
       "category": "well-known-concept",
       "confidence": "high",
       "expected": [
-        { "book_slug": "archidoxae-philippi-theophrasti-paracelsi-magni-germani-paracelsus" },
-        { "book_slug": "nobiblis-clarissimi-ac-probatissimi-philosophi-medici-dn-paracelsus" }
+        {
+          "book_slug": "archidoxae-philippi-theophrasti-paracelsi-magni-germani-paracelsus"
+        },
+        {
+          "book_slug": "nobiblis-clarissimi-ac-probatissimi-philosophi-medici-dn-paracelsus"
+        }
       ],
       "notes": "Two Archidoxes editions with full translation. The 0-translated ones excluded."
     },
@@ -83,10 +123,18 @@
       "category": "well-known-concept",
       "confidence": "high",
       "expected": [
-        { "book_slug": "magia-naturalis-libri-xx-1607-porta" },
-        { "book_slug": "magia-naturalis-1619-latin-porta" },
-        { "book_slug": "natural-magic-or-on-the-miracles-of-natural-things-porta" },
-        { "book_slug": "natural-magick-1658-english-porta" }
+        {
+          "book_slug": "magia-naturalis-libri-xx-1607-porta"
+        },
+        {
+          "book_slug": "magia-naturalis-1619-latin-porta"
+        },
+        {
+          "book_slug": "natural-magic-or-on-the-miracles-of-natural-things-porta"
+        },
+        {
+          "book_slug": "natural-magick-1658-english-porta"
+        }
       ]
     },
     {
@@ -95,15 +143,33 @@
       "category": "niche-passage",
       "confidence": "high",
       "expected": [
-        { "book_slug": "on-the-loadstone-and-magnetic-bodies-english-translation-gilbert" },
-        { "book_slug": "de-magnete-1600-first-edition-gilbert" },
-        { "book_slug": "de-magnete-magneticisque-corporibus-et-de-magno-magnete-gilbert" },
-        { "book_slug": "tractatus-sive-physiologia-nova-de-magnete-gilbert" },
-        { "book_slug": "magnes-sive-de-arte-magnetica-kircher" },
-        { "book_slug": "athanasii-kircheri-magnes-sive-de-arte-magnetica-opus-kircher" },
-        { "book_slug": "magneticum-naturae-regnum-kircher" },
-        { "book_slug": "athanasii-kircheri-magneticum-naturae-regnum-sive-kircher" },
-        { "book_slug": "athanasii-kircheri-ars-magnesia-hoc-est-disquisitio-kircher" }
+        {
+          "book_slug": "on-the-loadstone-and-magnetic-bodies-english-translation-gilbert"
+        },
+        {
+          "book_slug": "de-magnete-1600-first-edition-gilbert"
+        },
+        {
+          "book_slug": "de-magnete-magneticisque-corporibus-et-de-magno-magnete-gilbert"
+        },
+        {
+          "book_slug": "tractatus-sive-physiologia-nova-de-magnete-gilbert"
+        },
+        {
+          "book_slug": "magnes-sive-de-arte-magnetica-kircher"
+        },
+        {
+          "book_slug": "athanasii-kircheri-magnes-sive-de-arte-magnetica-opus-kircher"
+        },
+        {
+          "book_slug": "magneticum-naturae-regnum-kircher"
+        },
+        {
+          "book_slug": "athanasii-kircheri-magneticum-naturae-regnum-sive-kircher"
+        },
+        {
+          "book_slug": "athanasii-kircheri-ars-magnesia-hoc-est-disquisitio-kircher"
+        }
       ],
       "notes": "Gilbert's De Magnete (1600, founding work) and Kircher's Magnes sive de Arte Magnetica (1641, canonical Kircher) are both legitimate answers. Multiple editions of each — any hit counts."
     },
@@ -113,13 +179,27 @@
       "category": "niche-passage",
       "confidence": "high",
       "expected": [
-        { "book_slug": "vesalius-de-humani-corporis-fabrica-1555-vesalius" },
-        { "book_slug": "de-humani-corporis-fabrica-1543-first-edition-vesalius" },
-        { "book_slug": "andreae-vesalii-bruxellensis-scholae-medicorum-patavinae-vesalius" },
-        { "book_slug": "de-re-anatomica-libri-xv-colombo" },
-        { "book_slug": "de-re-anatomica-libri-xv-1562-ed-colombo" },
-        { "book_slug": "opuscula-anatomica-eustachio" },
-        { "book_slug": "tabulae-anatomicae-eustachi" }
+        {
+          "book_slug": "vesalius-de-humani-corporis-fabrica-1555-vesalius"
+        },
+        {
+          "book_slug": "de-humani-corporis-fabrica-1543-first-edition-vesalius"
+        },
+        {
+          "book_slug": "andreae-vesalii-bruxellensis-scholae-medicorum-patavinae-vesalius"
+        },
+        {
+          "book_slug": "de-re-anatomica-libri-xv-colombo"
+        },
+        {
+          "book_slug": "de-re-anatomica-libri-xv-1562-ed-colombo"
+        },
+        {
+          "book_slug": "opuscula-anatomica-eustachio"
+        },
+        {
+          "book_slug": "tabulae-anatomicae-eustachi"
+        }
       ],
       "notes": "Vesalius's Fabrica (the canonical anatomy of the skull is in Book I) plus Colombo's De Re Anatomica (Vesalius's pupil/rival) and Eustachio's Tabulae (famous anatomical plates). Query has no author cue — tests broad semantic matching."
     },
@@ -129,8 +209,12 @@
       "category": "niche-passage",
       "confidence": "medium",
       "expected": [
-        { "book_slug": "aurora-or-the-day-spring-bohme" },
-        { "book_slug": "theosophia-revelata-aurora-oder-morgenrothe-vol-1-bohme" }
+        {
+          "book_slug": "aurora-or-the-day-spring-bohme"
+        },
+        {
+          "book_slug": "theosophia-revelata-aurora-oder-morgenrothe-vol-1-bohme"
+        }
       ],
       "notes": "Boehme's seven Quellgeister doctrine — central to Aurora and his later works."
     },
@@ -140,8 +224,12 @@
       "category": "verbatim-quote",
       "confidence": "high",
       "expected": [
-        { "book_slug": "tabula-smaragdina-trismegistus" },
-        { "book_slug": "hermetis-trismegisti-phoenicum-aegyptorum-sed-et-aliarum-kriegsmann" }
+        {
+          "book_slug": "tabula-smaragdina-trismegistus"
+        },
+        {
+          "book_slug": "hermetis-trismegisti-phoenicum-aegyptorum-sed-et-aliarum-kriegsmann"
+        }
       ]
     },
     {
@@ -150,10 +238,18 @@
       "category": "verbatim-quote",
       "confidence": "high",
       "expected": [
-        { "book_slug": "fama-fraternitatis-1615-danzig-attr" },
-        { "book_slug": "fama-fraternitatis-und-confessio-fraternitatis-rosicrucian" },
-        { "book_slug": "fama-fraternitatis-oder-entdeckung-der-bruderschafft-de-andrea" },
-        { "book_slug": "fama-fraternitatis-oder-entdeckung-der-brudersch-des-ordens-fraternitatis" }
+        {
+          "book_slug": "fama-fraternitatis-1615-danzig-attr"
+        },
+        {
+          "book_slug": "fama-fraternitatis-und-confessio-fraternitatis-rosicrucian"
+        },
+        {
+          "book_slug": "fama-fraternitatis-oder-entdeckung-der-bruderschafft-de-andrea"
+        },
+        {
+          "book_slug": "fama-fraternitatis-oder-entdeckung-der-brudersch-des-ordens-fraternitatis"
+        }
       ]
     },
     {
@@ -162,9 +258,15 @@
       "category": "cross-lingual",
       "confidence": "high",
       "expected": [
-        { "book_slug": "rasaratnasamuccaya-vagbhata" },
-        { "book_slug": "rasaratnakara-rasayanakhanda-acarya" },
-        { "book_slug": "rasaratnakara-manuscript-nagarjuna" }
+        {
+          "book_slug": "rasaratnasamuccaya-vagbhata"
+        },
+        {
+          "book_slug": "rasaratnakara-rasayanakhanda-acarya"
+        },
+        {
+          "book_slug": "rasaratnakara-manuscript-nagarjuna"
+        }
       ],
       "notes": "Sanskrit Rasashastra texts. English query against English translations. Druze 'Rasa'il' and Ikhwan al-Safa 'Rasa'il' are false positives — different meaning of 'rasa'."
     },
@@ -174,11 +276,21 @@
       "category": "broad-theme",
       "confidence": "high",
       "expected": [
-        { "book_slug": "oneirocritica-daldianus" },
-        { "book_slug": "artemidori-daldiani-achmetis-sereimi-f-oneirocritica-artemidorus" },
-        { "book_slug": "de-somniorum-interpretatione-libri-quinque-cornarius" },
-        { "book_slug": "de-somniorum-interpretatione-daldis" },
-        { "book_slug": "traumbuch-artemidori-darinnen-ursprung-unterscheid-und-artemidorus" }
+        {
+          "book_slug": "oneirocritica-daldianus"
+        },
+        {
+          "book_slug": "artemidori-daldiani-achmetis-sereimi-f-oneirocritica-artemidorus"
+        },
+        {
+          "book_slug": "de-somniorum-interpretatione-libri-quinque-cornarius"
+        },
+        {
+          "book_slug": "de-somniorum-interpretatione-daldis"
+        },
+        {
+          "book_slug": "traumbuch-artemidori-darinnen-ursprung-unterscheid-und-artemidorus"
+        }
       ],
       "notes": "Artemidorus's Oneirocritica — multiple editions. Macrobius (Commentary on the Dream of Scipio) would also count if present."
     },
@@ -188,15 +300,33 @@
       "category": "broad-theme",
       "confidence": "medium",
       "expected": [
-        { "book_slug": "henrici-cor-agrippae-ab-nettesheym-de-occvlta-philosophia-agrippa-von" },
-        { "book_slug": "three-books-of-occult-philosophy-1533-latin-agrippa" },
-        { "book_slug": "three-books-of-occult-philosophy-nettesheim" },
-        { "book_slug": "magia-naturalis-libri-xx-1607-porta" },
-        { "book_slug": "magia-naturalis-1619-latin-porta" },
-        { "book_slug": "natural-magic-or-on-the-miracles-of-natural-things-porta" },
-        { "book_slug": "natural-magick-1658-english-porta" },
-        { "book_slug": "three-books-on-life-ficino" },
-        { "book_slug": "de-vita-libri-tres-three-books-on-life-1529-ficino" }
+        {
+          "book_slug": "henrici-cor-agrippae-ab-nettesheym-de-occvlta-philosophia-agrippa-von"
+        },
+        {
+          "book_slug": "three-books-of-occult-philosophy-1533-latin-agrippa"
+        },
+        {
+          "book_slug": "three-books-of-occult-philosophy-nettesheim"
+        },
+        {
+          "book_slug": "magia-naturalis-libri-xx-1607-porta"
+        },
+        {
+          "book_slug": "magia-naturalis-1619-latin-porta"
+        },
+        {
+          "book_slug": "natural-magic-or-on-the-miracles-of-natural-things-porta"
+        },
+        {
+          "book_slug": "natural-magick-1658-english-porta"
+        },
+        {
+          "book_slug": "three-books-on-life-ficino"
+        },
+        {
+          "book_slug": "de-vita-libri-tres-three-books-on-life-1529-ficino"
+        }
       ],
       "notes": "Agrippa, Della Porta, and Ficino are the canonical Renaissance sources. Hitting any one counts as recall. May score lower than other queries because there's no single 'right' book."
     },
@@ -206,11 +336,21 @@
       "category": "bibliographic",
       "confidence": "high",
       "expected": [
-        { "book_slug": "fourth-book-of-occult-philosophy-pseudo-agrippa-with" },
-        { "book_slug": "agrippa-fourth-book-of-occult-philosophy-with-geomancy-cremonensis" },
-        { "book_slug": "fourth-book-of-occult-philosophy-arbatel-of-magick-peter-de-al" },
-        { "book_slug": "la-geomance-cattan" },
-        { "book_slug": "ramala-grantha-geomancy" }
+        {
+          "book_slug": "fourth-book-of-occult-philosophy-pseudo-agrippa-with"
+        },
+        {
+          "book_slug": "agrippa-fourth-book-of-occult-philosophy-with-geomancy-cremonensis"
+        },
+        {
+          "book_slug": "fourth-book-of-occult-philosophy-arbatel-of-magick-peter-de-al"
+        },
+        {
+          "book_slug": "la-geomance-cattan"
+        },
+        {
+          "book_slug": "ramala-grantha-geomancy"
+        }
       ]
     },
     {
@@ -219,11 +359,314 @@
       "category": "bibliographic",
       "confidence": "medium",
       "expected": [
-        { "book_slug": "cabala-mirror-of-art-and-nature-in-alchemy-michelspacher-2" },
-        { "book_slug": "apologia-fratris-archangelus-de-burgonovo-pro-defensione-arcangelo" },
-        { "book_slug": "artis-cabalisticae-hoc-est-reconditae-theologiae-et-kabbala" }
+        {
+          "book_slug": "cabala-mirror-of-art-and-nature-in-alchemy-michelspacher-2"
+        },
+        {
+          "book_slug": "apologia-fratris-archangelus-de-burgonovo-pro-defensione-arcangelo"
+        },
+        {
+          "book_slug": "artis-cabalisticae-hoc-est-reconditae-theologiae-et-kabbala"
+        }
       ],
       "notes": "Pico, Reuchlin, Kircher's Oedipus would also count if present. 'Cuaderno de las alcabalas' is a false positive (Spanish tax word, not Kabbalah)."
+    },
+    {
+      "id": "zohar-sefirot",
+      "query": "Kabbalah on the ten sefirot and divine emanation",
+      "category": "cross-lingual",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "the-zohar-book-of-genesis-attributed"
+        },
+        {
+          "book_slug": "kabbala-denudata-tomus-ii-rosenroth"
+        },
+        {
+          "book_slug": "the-zohar-sefer-ha-zohar-attributed"
+        },
+        {
+          "book_slug": "the-zohar-sefer-ha-zohar-attributed-2"
+        },
+        {
+          "book_slug": "vat-ebr-226-leon"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "sefer-yetzirah-creation",
+      "query": "Hebrew letters and the creation of the world",
+      "category": "cross-lingual",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "the-origin-of-letters-and-numerals-according-to-the-sefer-mordell"
+        },
+        {
+          "book_slug": "sepher-yetzirah-book-of-formation-westcott-attr"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "ibn-arabi-unity",
+      "query": "Sufi metaphysics of the unity of being and divine names",
+      "category": "cross-lingual",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "awrad-ibn-arabi-daily-prayers-arabi"
+        },
+        {
+          "book_slug": "al-futuhat-al-makkiyya-the-meccan-revelations-ed"
+        },
+        {
+          "book_slug": "fusus-al-hikam-the-bezels-of-wisdom-trans"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "suhrawardi-illumination",
+      "query": "philosophy of illumination and the world of light",
+      "category": "cross-lingual",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "hikmat-al-ishraq-philosophy-of-illumination-suhrawardi"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "rosicrucian-fama",
+      "query": "Fama Fraternitatis and the discovery of the tomb of Christian Rosenkreutz",
+      "category": "verbatim-quote",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "fama-fraternitatis-1615-danzig-attr"
+        },
+        {
+          "book_slug": "fama-fraternitatis-und-confessio-fraternitatis-rosicrucian"
+        },
+        {
+          "book_slug": "chymische-hochzeit-christiani-rosencreutz-andreae"
+        },
+        {
+          "book_slug": "sphynx-rosacea-das-ist-der-entdeckung-der-bruderschafft-de-nigrinus"
+        },
+        {
+          "book_slug": "silentium-post-clamores-hoc-est-tractatus-apologeticus-quo-maier"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "chymical-wedding",
+      "query": "the chymical wedding of Christian Rosenkreutz",
+      "category": "verbatim-quote",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "chemical-wedding-1616-strassburg-andreae"
+        },
+        {
+          "book_slug": "chymische-hochzeit-christiani-rosencreutz-andreae"
+        },
+        {
+          "book_slug": "chymische-hochzeit-christiani-rosencreutz-anno-1459-arcana-andrea"
+        },
+        {
+          "book_slug": "chymische-hochzeit-christiani-rosencreutz-anno-1459-andrea"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "maier-atalanta-motto",
+      "query": "Atalanta Fugiens emblem the wind carried him in his belly",
+      "category": "verbatim-quote",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "atalanta-fugiens-hoc-est-emblemata-nova-de-secretis-naturae-maier"
+        },
+        {
+          "book_slug": "atalanta-fugiens-hoc-est-emblemata-nova-de-secretis-naturae-maier-3"
+        },
+        {
+          "book_slug": "atalanta-fleeing-new-chemical-emblems-of-the-secrets-of-maier"
+        },
+        {
+          "book_slug": "michael-maier-atalanta-fugiens-1618-merian-engravings-maier"
+        },
+        {
+          "book_slug": "atalanta-fugiens-c-1625-english-ms-translator"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "coniunctio-opposites",
+      "query": "the marriage and union of opposites in alchemy",
+      "category": "broad-theme",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "reg-lat-1278-anonymous"
+        },
+        {
+          "book_slug": "tractatus-aliquot-chemici-singvlares-summum-philosophorum-ferrarius"
+        },
+        {
+          "book_slug": "rosarium-philosophorum-secunda-pars-alchimiae-de-lapide-s-n-3"
+        },
+        {
+          "book_slug": "rosarium-novum-olympicum-et-benedictum-figulus"
+        },
+        {
+          "book_slug": "rosarium-secretissimum-philosophorum-arcanum-comprehendens-dastin"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "rosicrucian-reformation",
+      "query": "the universal reformation of the whole wide world",
+      "category": "broad-theme",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "fama-fraternitatis-1615-danzig-attr"
+        },
+        {
+          "book_slug": "fama-fraternitatis-und-confessio-fraternitatis-rosicrucian"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "neoplatonic-ascent",
+      "query": "the ascent of the soul to the One",
+      "category": "broad-theme",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "corpus-hermeticum-and-plotinus-enneads-cambridge-trinity-plotinus"
+        },
+        {
+          "book_slug": "urb-gr-62-plotinus"
+        },
+        {
+          "book_slug": "plotini-enneades-ficino-working-copy-plotinus"
+        },
+        {
+          "book_slug": "plotini-enneades-13th-c-copy-a-plotinus"
+        },
+        {
+          "book_slug": "plotini-enneades-13th-c-copy-b-plotinus"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "alchemical-emblem-books",
+      "query": "alchemical emblem books with engraved plates",
+      "category": "bibliographic",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "atalanta-fugiens-c-1625-english-ms-translator"
+        },
+        {
+          "book_slug": "splendor-solis-the-splendour-of-the-sun-trismosin"
+        },
+        {
+          "book_slug": "atalanta-fleeing-new-chemical-emblems-of-the-secrets-of-maier"
+        },
+        {
+          "book_slug": "mutus-liber-the-silent-book-saulat"
+        },
+        {
+          "book_slug": "splendor-solis-solomon-trismosin-trismosin"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "corpus-hermeticum-editions",
+      "query": "editions of the Corpus Hermeticum",
+      "category": "bibliographic",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "complete-hermetica-1505-paris-edition-hermes-trismegistus"
+        },
+        {
+          "book_slug": "corpus-hermeticum-pimander-1481-venice-edition-hermes-trismegistus"
+        },
+        {
+          "book_slug": "musaeum-hermeticum-1677-edition-jennis"
+        },
+        {
+          "book_slug": "the-hermetic-museum-various-sendivogius"
+        },
+        {
+          "book_slug": "poimandres-corpus-hermeticum-ficino"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "paracelsus-medicine",
+      "query": "works of Paracelsus on medicine and chemistry",
+      "category": "bibliographic",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "paramirum-works-paracelsus"
+        },
+        {
+          "book_slug": "paracelsus-complete-works-latin-paracelsus"
+        },
+        {
+          "book_slug": "philosophy-reformed-four-profound-tractates-paracelsus"
+        },
+        {
+          "book_slug": "de-lapide-philosophorum-philosophers-stone-paracelsus"
+        },
+        {
+          "book_slug": "de-secretis-creationis-secrets-of-creation-paracelsus"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
+    },
+    {
+      "id": "ripley-green-lion",
+      "query": "the green lion devouring the sun in alchemy",
+      "category": "niche-passage",
+      "confidence": "medium",
+      "expected": [
+        {
+          "book_slug": "ripley-reviv-d-1678-cooper"
+        },
+        {
+          "book_slug": "reg-lat-1278-anonymous"
+        },
+        {
+          "book_slug": "bodleian-library-ms-bodl-rolls-1-attributed"
+        },
+        {
+          "book_slug": "alchemical-treatises-cambridge-university-library-ms-kk-6-30-george-ripley"
+        },
+        {
+          "book_slug": "tractatus-aliquot-chemici-singvlares-summum-philosophorum-ferrarius"
+        }
+      ],
+      "notes": "Added 2026-05-29 expansion pass; slugs resolved against Mongo + false-positives pruned."
     }
   ]
 }

--- a/scripts/eval/librarian-search/run.mjs
+++ b/scripts/eval/librarian-search/run.mjs
@@ -99,6 +99,45 @@ async function embedFn(text, dims = 768) {
   }
 }
 
+// ── Query expansion fn (mirrors the terms half of /api/search/ai-expand) ──
+// Generates period-appropriate reformulations (Latin titles, original-language
+// names, synonyms) so the multiquery variant can RRF-fuse per-term searches.
+const expandCache = new Map();
+async function expandFn(query) {
+  if (expandCache.has(query)) return expandCache.get(query);
+  const prompt = `You expand search queries for Source Library — alchemy, Hermetica, Kabbalah, Rosicrucianism, Neoplatonism, Renaissance natural magic, and early modern science (antiquity through ~1850).
+Query: "${query}"
+Return ONLY a JSON array of 3-5 search terms a visitor wouldn't think of: period-appropriate synonyms, Latin or original-language titles, original-language author names, specific canonical works. No prose, no markdown — just the array.
+Example for "Agrippa on planetary magic": ["De Occulta Philosophia","Cornelius Agrippa von Nettesheim","planetary seals","talismanic correspondences","celestial magic"]`;
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent?key=${geminiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0.3, maxOutputTokens: 200 },
+        }),
+        signal: AbortSignal.timeout(15000),
+      },
+    );
+    if (!res.ok) { expandCache.set(query, []); return []; }
+    const data = await res.json();
+    const text = data?.candidates?.[0]?.content?.parts?.[0]?.text || '';
+    const m = text.match(/\[[\s\S]*?\]/);
+    let terms = [];
+    if (m) { try { const p = JSON.parse(m[0]); if (Array.isArray(p)) terms = p.filter(t => typeof t === 'string' && t.length >= 2); } catch { /* parse fail */ } }
+    terms = terms.slice(0, 5);
+    expandCache.set(query, terms);
+    return terms;
+  } catch (err) {
+    console.error(`Expand error: ${err.message}`);
+    expandCache.set(query, []);
+    return [];
+  }
+}
+
 // ── Runner ────────────────────────────────────────────────────────────
 
 async function runOne(variant, query, ctx) {
@@ -165,7 +204,7 @@ async function main() {
 
   await mongoClient.connect();
   const db = mongoClient.db(mongoDb);
-  const ctx = { db, supabase, embedFn };
+  const ctx = { db, supabase, embedFn, expandFn };
 
   console.log(`\nLibrarian Search Eval`);
   console.log(`  Queries:  ${queries.length}${wantedQuery ? ` (filter: ${wantedQuery})` : ''}${wantedCategory ? ` (category: ${wantedCategory})` : ''}`);

--- a/scripts/eval/librarian-search/variants.mjs
+++ b/scripts/eval/librarian-search/variants.mjs
@@ -303,6 +303,28 @@ export async function rrfWithFloorVariant(query, ctx, limit = 8) {
   return merged;
 }
 
+// ── ai-expand multiquery: LLM term expansion + per-term RRF fusion ────
+//
+// Measures the contribution of the search page's `ai-expand` layer, which the
+// other variants ignore. Generates 3-5 reformulations (Latin titles, original-
+// language names, synonyms) via ctx.expandFn, runs book-then-page for each, and
+// RRF-fuses them alongside the base keyword+btp+gp lists for the original query.
+// Hypothesis: lifts niche-passage (more formulations surface buried passages)
+// and cross-lingual (original-language terms hit non-English originals) without
+// the verbatim/broad-theme regression plain RRF shows.
+export async function aiExpandMultiqueryVariant(query, ctx, limit = 8) {
+  const terms = ctx.expandFn ? await ctx.expandFn(query) : [];
+  const base = await Promise.all([
+    keywordVariant(query, ctx, 20),
+    bookThenPageVariant(query, ctx, 20),
+    globalPageVariant(query, ctx, 20),
+  ]);
+  const expanded = await Promise.all(
+    terms.map(t => bookThenPage(t, ctx, 20).catch(() => [])),
+  );
+  return rrfMerge([...base, ...expanded], 60, limit);
+}
+
 // ── Variant registry ──────────────────────────────────────────────────
 
 export const VARIANTS = {
@@ -333,5 +355,9 @@ export const VARIANTS = {
   'rrf-floor': {
     description: 'RRF k=20 with graceful fallback to strongest single source',
     fn: rrfWithFloorVariant,
+  },
+  'ai-expand-multiquery': {
+    description: 'LLM query expansion (ai-expand terms) + per-term book-then-page, RRF-fused with base kw+btp+gp (k=60)',
+    fn: aiExpandMultiqueryVariant,
   },
 };


### PR DESCRIPTION
## What
Builds on the Librarian search-eval harness (already in main) with two additions, plus the findings from running it.

- **Golden set 17→31, rebalanced.** The first run had categories too thin to trust (cross-lingual had 1 query). Expanded to ~5 per category: cross-lingual 1→5, verbatim-quote 2→5, broad-theme 2→5, bibliographic 2→5, niche-passage 3→4. New slugs resolved against Mongo via `_expand-golden-set.mjs` (title/author regex), then false positives hand-pruned.
- **New `ai-expand-multiquery` variant.** Generates 3–5 query reformulations (Latin titles, original-language names, synonyms) via a new `ctx.expandFn` that mirrors the terms half of `/api/search/ai-expand`, runs book-then-page per reformulation, and RRF-fuses them with the base keyword+btp+gp lists. This measures the search page's expansion layer, which the other variants ignore.

## Findings (de-noised, 31 queries)
- **`rrf` (k=60) is the best balanced variant** — P@1 0.419, MRR 0.513. **k=60 ≥ k=20** (the live tuning gave up ranking quality for speed it didn't need).
- **`auto-fallback` and `rrf-floor` are dead weight** — byte-identical metrics to their base variants. Candidates for removal in whatever owns the live variants.
- **`ai-expand-multiquery` is inconclusive** — see caveat.

## ⚠ Known confound (read before trusting thematic-category numbers)
`_expand-golden-set.mjs` resolved `expected` lists by title-regex. For thematic queries this is too narrow and **biased toward keyword search**: semantic/RRF surfaces topically-correct books with non-matching titles that score 0 (e.g. `zohar-sefirot` returned Pardes Rimonim / Gikatilla — genuinely about sefirot — for 0.00). So the new thematic categories' absolute recall is deflated for exactly the variants under test. **Trust the specific-answer categories** (well-known, niche-passage, verbatim) for the variant ranking. Fix before next iteration: replace exact-slug recall with an LLM relevance judge for thematic categories.

## Scope
- `scripts/eval/` only — no app/pipeline/build impact. Eval reports (`results/*.json`) stay gitignored.

See `.claude/handoffs/2026-05-29-librarian-search-eval.md` for full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)