### PR TITLE
docs(eval): record Librarian search findings + fix variant example

### DIFF
--- a/scripts/eval/librarian-search/README.md
+++ b/scripts/eval/librarian-search/README.md
@@ -40,8 +40,9 @@ set -a; source ../../../../.env.production.local; set +a
 # Run all variants against the full golden set
 node scripts/eval/librarian-search/run.mjs
 
-# Run a single variant
-node scripts/eval/librarian-search/run.mjs --variant=hybrid-rrf
+# Run a single variant (registry in variants.mjs: keyword, book-then-page,
+# global-page, rrf, rrf-tuned, rrf-floor, auto-fallback, ai-expand-multiquery)
+node scripts/eval/librarian-search/run.mjs --variant=rrf
 
 # Run a single query (for debugging)
 node scripts/eval/librarian-search/run.mjs --query=agrippa-planetary-seals
@@ -67,3 +68,33 @@ Categories:
   (English translations are what's indexed, so this tests translation coverage)
 - `broad-theme` — wide topic; multiple books should match
 - `bibliographic` — "what do you have about X" — books-as-results
+
+## Findings to date (2026-05-29, 31-query set)
+
+- **`rrf` (k=60) is the best balanced variant** — P@1 0.419, MRR 0.513, beating
+  book-then-page (0.290 / 0.395). It nearly doubles niche-passage recall (the
+  buried-passage problem). **k=60 ≥ k=20** — the lower-k "tuned" variant gave up
+  ranking quality for speed it didn't need.
+- **`auto-fallback` and `rrf-floor` are dead weight** — byte-identical metrics to
+  their base variants. Don't ship them; candidates for removal.
+- **No single variant wins every category.** RRF lifts niche/cross-lingual but
+  regresses verbatim-quote and broad-theme vs book-then-page. The likely answer
+  is query-aware routing (the search page's `ai-expand` HINT already classifies
+  intent — see `src/app/api/search/ai-expand/route.ts`).
+- **`ai-expand-multiquery` is currently inconclusive — not a verdict.**
+
+### ⚠ Known confound — read before trusting thematic-category numbers
+
+The 2026-05-29 expansion (`_expand-golden-set.mjs`) resolved `expected[]` by
+**title-regex**. For thematic categories (`broad-theme`, `cross-lingual`,
+`bibliographic`) this is too narrow and **biased toward keyword search**:
+semantic/RRF correctly surface topically-relevant books with *non-matching
+titles* that then score 0 (e.g. `zohar-sefirot` returns Pardes Rimonim /
+Gikatilla — genuinely about sefirot — for 0.00). So absolute recall on those
+categories is deflated for exactly the variants under test.
+
+**Trust the specific-answer categories** (`well-known-concept`, `niche-passage`,
+`verbatim-quote`) for the variant ranking. Treat the thematic categories as
+directional only. **Fix before the next iteration:** replace exact-slug recall
+with an LLM relevance judge ("is this returned book on-topic?") for the thematic
+categories. Full context: `.claude/handoffs/2026-05-29-librarian-search-eval.md`.


### PR DESCRIPTION
Documentation-only follow-up to #2158.

- Adds a **Findings to date** section to `scripts/eval/librarian-search/README.md` so anyone re-running the harness sees the conclusions (rrf k=60 is the balanced winner, k=60 ≥ k=20, `auto-fallback`/`rrf-floor` are dead weight) and — critically — the **title-regex expected-set confound** that makes the thematic-category numbers and `ai-expand-multiquery` untrustworthy until an LLM relevance judge replaces exact-slug recall.
- Fixes the run example: `--variant=hybrid-rrf` was never a real variant name.

Docs only. Full context in `.claude/handoffs/2026-05-29-librarian-search-eval.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)