### PR TITLE
feat(enrich): author identity + significance in summaries; corpus rollout tooling

### DIFF
--- a/scripts/maintenance/promote-summaries.mjs
+++ b/scripts/maintenance/promote-summaries.mjs
@@ -1,0 +1,104 @@
+/**
+ * Promote staged summary candidates (book.summary_candidate) to LIVE.
+ *
+ * Writes the candidate's brief/abstract/detailed to the fields the book page
+ * actually reads, in precedence order:
+ *   book_indexes.bookSummary.{brief,abstract,detailed}  (shown first)
+ *   book.summary.data            (= brief)
+ *   book.reading_summary.{overview=abstract, detailed}
+ *
+ * REVERSIBLE: the prior live values are stashed into summary_candidate.replaced
+ * before overwrite. Run with --restore to roll every promoted book back.
+ *
+ * Cleans a junk leading ellipsis ("... Title is a treatise") that a handful of
+ * candidates inherited from titles literally beginning with "...".
+ *
+ * Safety: DRY-RUN by default (prints count + samples). Pass --execute to write.
+ *
+ * Usage:
+ *   node scripts/maintenance/promote-summaries.mjs                 # dry-run
+ *   node scripts/maintenance/promote-summaries.mjs --execute       # promote
+ *   node scripts/maintenance/promote-summaries.mjs --visible-only --execute
+ *   node scripts/maintenance/promote-summaries.mjs --restore --execute
+ */
+import { MongoClient } from 'mongodb';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const args = process.argv.slice(2);
+const EXECUTE = args.includes('--execute');
+const RESTORE = args.includes('--restore');
+const VISIBLE_ONLY = args.includes('--visible-only');
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+// Strip a junk leading ellipsis / leading dots (from titles that begin "...").
+const clean = (s) => (s || '').replace(/^\s*(?:\.\.\.|…)\s*/, '').trim();
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+  const indexes = db.collection('book_indexes');
+
+  if (RESTORE) {
+    const toRestore = await books.find({ 'summary_candidate.status': 'promoted', 'summary_candidate.replaced': { $exists: true } })
+      .project({ id: 1, 'summary_candidate.replaced': 1 }).toArray();
+    console.log(`[restore] ${toRestore.length} promoted books have a stashed previous summary`);
+    if (!EXECUTE) { console.log('  dry-run; pass --execute to restore'); await client.close(); return; }
+    let n = 0;
+    for (const b of toRestore) {
+      const r = b.summary_candidate.replaced || {};
+      await books.updateOne({ id: b.id }, {
+        $set: { summary: r.summary ?? null, reading_summary: r.reading_summary ?? null, 'summary_candidate.status': 'pending' },
+      });
+      if (r.bookSummary) await indexes.updateOne({ book_id: b.id }, { $set: { bookSummary: r.bookSummary } });
+      else await indexes.updateOne({ book_id: b.id }, { $unset: { bookSummary: '' } });
+      if (++n % 250 === 0) console.log(`  restored ${n}/${toRestore.length}`);
+    }
+    console.log(`[restore] done=${n}`);
+    await client.close();
+    return;
+  }
+
+  const match = { 'summary_candidate.status': 'pending', 'summary_candidate.brief': { $type: 'string', $ne: '' } };
+  if (VISIBLE_ONLY) match.visible = true;
+  const targets = await books.find(match)
+    .project({ id: 1, title: 1, summary: 1, reading_summary: 1, summary_candidate: 1 }).toArray();
+
+  const dotty = targets.filter(t => /^\s*(?:\.\.\.|…)/.test(t.summary_candidate.brief)).length;
+  console.log(`[promote] candidates to promote=${targets.length}${VISIBLE_ONLY ? ' (visible only)' : ''} · leading-ellipsis cleaned=${dotty}`);
+  console.log('  samples:');
+  for (const t of targets.slice(0, 5)) console.log(`   - ${clean(t.summary_candidate.brief).slice(0, 90)}`);
+
+  if (!EXECUTE) { console.log('\n  DRY-RUN. Pass --execute to promote (reversible via --restore).'); await client.close(); return; }
+
+  let n = 0, failed = 0;
+  for (const b of targets) {
+    try {
+      const c = b.summary_candidate;
+      const brief = clean(c.brief), abstract = clean(c.abstract), detailed = clean(c.detailed);
+      if (!brief) { continue; }
+      const idx = await indexes.findOne({ book_id: b.id }, { projection: { bookSummary: 1 } });
+      const replaced = { summary: b.summary ?? null, reading_summary: b.reading_summary ?? null, bookSummary: idx?.bookSummary ?? null };
+
+      await indexes.updateOne({ book_id: b.id }, { $set: { 'bookSummary.brief': brief, 'bookSummary.abstract': abstract, 'bookSummary.detailed': detailed } });
+      await books.updateOne({ id: b.id }, { $set: {
+        'summary.data': brief,
+        'summary.generated_at': new Date(),
+        'summary.model': c.model ?? null,
+        'summary.prompt_version': c.prompt_version ?? null,
+        'summary.source': 'ai-resynth-promoted',
+        'reading_summary.overview': abstract,
+        'reading_summary.detailed': detailed,
+        'summary_candidate.status': 'promoted',
+        'summary_candidate.promoted_at': new Date(),
+        'summary_candidate.replaced': replaced,
+      } });
+      if (++n % 250 === 0) console.log(`  promoted ${n}/${targets.length}`);
+    } catch (e) { failed++; console.error(`  ERR ${b.id}: ${e.message}`); }
+  }
+  console.log(`[promote] promoted=${n} failed=${failed} (reversible: --restore --execute)`);
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/remove-straggler-summaries.mjs
+++ b/scripts/maintenance/remove-straggler-summaries.mjs
@@ -1,0 +1,111 @@
+/**
+ * Remove (reversibly) the live "About This Book" summary from "straggler" books:
+ * visible books that have a summary but NO section-level index data, so the
+ * cheap plain-encyclopedic rewrite (resynthesize-summaries.mjs) cannot improve
+ * them. Per product decision: better no summary than a stale marketing-style
+ * one, especially for scholarly credibility.
+ *
+ * REVERSIBLE: the current summary / reading_summary / book_indexes.bookSummary
+ * are stashed into book.summary_removed before the live fields are cleared.
+ * Run with --restore to put them back.
+ *
+ * The page (src/app/book/[id]/page.tsx) shows "No summary" only when ALL of
+ *   book_indexes.bookSummary.brief, book.reading_summary.overview, book.summary.data
+ * are empty, so all three are cleared.
+ *
+ * Safety: DRY-RUN by default. Prints the count and a sample. Pass --execute to
+ * actually write. --visible-only is implied (stragglers are scoped to visible).
+ *
+ * Usage:
+ *   node scripts/maintenance/remove-straggler-summaries.mjs            # dry-run, show count + sample
+ *   node scripts/maintenance/remove-straggler-summaries.mjs --execute  # clear (reversible)
+ *   node scripts/maintenance/remove-straggler-summaries.mjs --restore --execute
+ */
+import { MongoClient } from 'mongodb';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const args = process.argv.slice(2);
+const EXECUTE = args.includes('--execute');
+const RESTORE = args.includes('--restore');
+const INCLUDE_HIDDEN = args.includes('--include-hidden');
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+  const indexes = db.collection('book_indexes');
+
+  if (RESTORE) {
+    const toRestore = await books.find({ 'summary_removed.removed_at': { $exists: true } })
+      .project({ id: 1, summary_removed: 1 }).toArray();
+    console.log(`[restore] ${toRestore.length} books have stashed summaries`);
+    if (!EXECUTE) { console.log('  (dry-run; pass --execute to restore)'); await client.close(); return; }
+    let n = 0;
+    for (const b of toRestore) {
+      const r = b.summary_removed || {};
+      await books.updateOne({ id: b.id }, {
+        $set: { summary: r.summary ?? null, reading_summary: r.reading_summary ?? null },
+        $unset: { summary_removed: '' },
+      });
+      if (r.bookSummary) await indexes.updateOne({ book_id: b.id }, { $set: { bookSummary: r.bookSummary } });
+      if (++n % 200 === 0) console.log(`  restored ${n}/${toRestore.length}`);
+    }
+    console.log(`[restore] done=${n}`);
+    await client.close();
+    return;
+  }
+
+  // Cheap-eligible = has a book_indexes doc WITH section data. Stragglers are
+  // the visible, summarized books that are NOT in that set.
+  console.log('[straggler] building set of cheap-eligible book_ids (have sectionSummaries)...');
+  const eligible = new Set(
+    (await indexes.find({ 'sectionSummaries.0': { $exists: true } }).project({ book_id: 1, _id: 0 }).toArray())
+      .map(d => d.book_id),
+  );
+  console.log(`  cheap-eligible: ${eligible.size}`);
+
+  const baseMatch = { 'summary.data': { $type: 'string', $ne: '' } };
+  if (!INCLUDE_HIDDEN) baseMatch.visible = true;
+  const summarized = await books.find(baseMatch)
+    .project({ id: 1, title: 1, display_title: 1, author: 1, summary_candidate: 1, _id: 0 }).toArray();
+
+  // Straggler = summarized + visible + NOT cheap-eligible + not already being rewritten.
+  const stragglers = summarized.filter(b =>
+    !eligible.has(b.id) &&
+    !['pending', 'approved'].includes(b.summary_candidate?.status),
+  );
+
+  console.log(`[straggler] summarized(${INCLUDE_HIDDEN ? 'all' : 'visible'})=${summarized.length} · stragglers to clear=${stragglers.length}`);
+  console.log('  sample:');
+  for (const b of stragglers.slice(0, 8)) console.log(`   - ${b.id} ${(b.title || '').slice(0, 55)} — ${b.author || ''}`);
+
+  if (!EXECUTE) { console.log('\n  DRY-RUN. Pass --execute to clear these (reversible via --restore).'); await client.close(); return; }
+
+  let n = 0;
+  for (const b of stragglers) {
+    const cur = await books.findOne({ id: b.id }, { projection: { summary: 1, reading_summary: 1 } });
+    const idx = await indexes.findOne({ book_id: b.id }, { projection: { bookSummary: 1 } });
+    await books.updateOne({ id: b.id }, { $set: {
+      summary_removed: {
+        summary: cur?.summary ?? null,
+        reading_summary: cur?.reading_summary ?? null,
+        bookSummary: idx?.bookSummary ?? null,
+        removed_at: new Date(),
+        reason: 'no-section-data-straggler',
+      },
+      'summary.data': '',
+      'reading_summary.overview': '',
+      'reading_summary.detailed': '',
+    } });
+    if (idx?.bookSummary) {
+      await indexes.updateOne({ book_id: b.id }, { $set: { 'bookSummary.brief': '', 'bookSummary.abstract': '', 'bookSummary.detailed': '' } });
+    }
+    if (++n % 200 === 0) console.log(`  cleared ${n}/${stragglers.length}`);
+  }
+  console.log(`[straggler] cleared=${n} (reversible: --restore --execute)`);
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/resynthesize-summaries.mjs
+++ b/scripts/maintenance/resynthesize-summaries.mjs
@@ -26,11 +26,12 @@ import { buildSummaryPrompt, SUMMARY_GEN_CONFIG, SUMMARY_PROMPT_VERSION } from '
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const LITE_MODEL = 'gemini-3.1-flash-lite';
-const CONCURRENCY = 6;
+const CONCURRENCY = 12;
 
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const ALL = args.includes('--all');
+const VISIBLE_ONLY = args.includes('--visible-only');
 const SKIP_EXISTING = args.includes('--skip-existing');
 const idsArg = args.find(a => a.startsWith('--ids='))?.split('=')[1];
 const sampleArg = args.find(a => a.startsWith('--sample='))?.split('=')[1];
@@ -128,6 +129,7 @@ async function main() {
       .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1 }).toArray();
   } else {
     const match = { 'summary.data': { $type: 'string', $ne: '' } };
+    if (VISIBLE_ONLY) match.visible = true;
     if (SKIP_EXISTING) match.summary_candidate = { $exists: false };
     if (sampleArg) {
       targets = await books.aggregate([

--- a/scripts/workers/lib/summary-prompt.mjs
+++ b/scripts/workers/lib/summary-prompt.mjs
@@ -72,30 +72,34 @@ ${sectionSummariesText}
 ${quotesText}
 
 ## Your Task
-Synthesize the material above into a plain, encyclopedic description. Ground every claim in the extracted content; do not embellish or invent significance.
+Synthesize the material above into a plain, encyclopedic description. Ground every claim in the extracted content or in well-established fact. State significance concretely and factually, never as vague praise.
+
+**Identify the author and say what makes the text notable (do this, concretely):**
+- On first naming the author, add a short factual identifier: who they were in a few words (role, period, place), e.g. "Irenaeus, a second-century bishop of Lyon and early Church Father" or "Robert Fludd, an English physician and Paracelsian philosopher". Only state facts you are confident are well established. If the author is obscure or you are unsure, give the name alone and invent nothing.
+- Say in one concrete sentence why the text is notable, when there is a real, factual answer: what it preserves, what it influenced, what it is a source for, what is unusual about it. Example: a polemic against a movement can be a principal source for that movement because it quotes it at length (as with Irenaeus and the Gnostics). This is factual significance, not a rating. If nothing concrete is known, omit it rather than padding with praise.
 
 **Hard rules — these are the difference between a catalog note and ad copy:**
 ${titleRule}
 - Do NOT address or refer to the reader. Ban "you", "your", "readers", "readers will discover", "imagine", "discover". The description talks about the text, never to a prospective reader.
 - Do NOT open with a question. No rhetorical hooks ("What if...?", "Why did...?", "How can...?"). Open by naming the work and stating plainly what it is.
 - Do NOT claim modern relevance the text does not contain. No "distractions of modern life", "still resonates today", "timeless". Describe the text in its own terms and period.
-- Never rate the text. Drop all praise vocabulary: no "seminal", "important", "fascinating", "remarkable", "essential", "profound", "rich", "masterful", "groundbreaking", "radical", "bold", "urgent".
+- Significance must be concrete and specific. Drop empty praise adjectives: no "seminal", "important", "fascinating", "remarkable", "essential", "profound", "rich", "masterful", "groundbreaking", "radical", "bold", "urgent". Say what the text did or preserves, not how impressive it is.
 
 **Style:**
 - Also avoid these AI tells: "delves into", "rich tapestry", "sheds light on", "offers a window into", "pulls back the curtain", "comprehensive", "intricate", "nuanced", "multifaceted", and stiff verbs like "delineates", "elucidates", "utilizes" (write "uses"), "explores the trajectory of".
 - No em-dashes (—). Use commas, colons, semicolons, or separate sentences.
 - Short, concrete sentences. Plain words over Latinate ones. Name people, places, and specifics instead of gesturing at them.
 
-Example of the WRONG register (sells, addresses the reader, rates the text — do NOT write like this):
+Example of the WRONG register (sells, addresses the reader, empty praise — do NOT write like this):
   "Willem Teellinck strips away the distractions of modern life to focus on a singular, urgent question. Readers will discover a seminal manual for the soul that delineates the trajectory toward sanctification."
-Example of the RIGHT register (states what it is, factual, no reader — write like this):
-  "'t Nieuwe Jerusalem is a devotional treatise cast as a dialogue between the Lord and a woman named Maria. It describes how the soul moves from worldly attachment toward sanctification, joining strict Reformed doctrine to the practice of daily piety. Willem Teellinck wrote it as practical guidance for lay believers of the Dutch Second Reformation."
+Example of the RIGHT register (identifies the author, states concrete significance, factual, no reader — write like this):
+  "Adversus haereses (Against Heresies) is a theological treatise by Irenaeus, a second-century bishop of Lyon and one of the early Church Fathers. Writing around 180 AD, he lays out the teachings of Valentinus and other Gnostic groups in order to refute them and defend what he held to be apostolic tradition. Because he quotes those teachings at length, the work is now a principal source for Gnostic thought that survives almost nowhere else."
 
-1. **BRIEF** (2-3 sentences):
-   - Open by naming the work and what kind of text it is (treatise, dialogue, manual, essay, collection). Then state its central subject in plain terms. No hook, no reader.
+1. **BRIEF** (2-4 sentences):
+   - Open by naming the work and what kind of text it is (treatise, dialogue, manual, essay, collection). Identify the author in a few words. State the central subject plainly, and where there is a concrete answer, add one sentence on why the text is notable (what it preserves, influenced, or is a source for). No hook, no reader, no empty praise.
 
 2. **ABSTRACT** (1 paragraph, 4-6 sentences):
-   - What the text covers, the author's position or method, and the kind of reader it serves. Factual, not promotional.
+   - What the text covers, who the author was, the author's position or method, and what the text is a source for or contributed. Factual, not promotional.
 
 3. **DETAILED** (2-4 paragraphs):
    - How the text is organized and how the argument or material unfolds. Concrete content: the actual ideas, people, and claims in the text.

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -64,8 +64,12 @@ export async function generateStaticParams() {
 
 interface PageProps {
   params: Promise<{ id: string }>;
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
   tenantContext?: TenantContext | null;
+  // Review preview: when true, render the staged summary_candidate instead of
+  // the live summary. Set only by the dynamic /book/[id]/preview route — NOT
+  // read from searchParams here, because this page is ISR/static (revalidate)
+  // and reading request-time query params would force a render error.
+  previewProposed?: boolean;
 }
 
 // Cached book lookup — deduplicates between generateMetadata and BookInfo
@@ -1212,13 +1216,8 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed
   );
 }
 
-export default async function BookDetailPage({ params, searchParams, tenantContext }: PageProps) {
+export default async function BookDetailPage({ params, tenantContext, previewProposed = false }: PageProps) {
   const { id } = await params;
-  const sp = searchParams ? await searchParams : {};
-  // Review preview: ?summary=proposed renders the staged summary_candidate in
-  // the live layout so a reviewer can see the proposed "About This Book" in
-  // context before it is promoted. No effect for normal visitors.
-  const previewProposed = sp.summary === 'proposed';
   const ctx = tenantContext ?? null;
   const embedPolicy = getEmbedUiPolicy(ctx);
   const isEmbedded = ctx?.isEmbedded ?? false;

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -64,6 +64,7 @@ export async function generateStaticParams() {
 
 interface PageProps {
   params: Promise<{ id: string }>;
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
   tenantContext?: TenantContext | null;
 }
 
@@ -536,7 +537,7 @@ function PagesGridSkeleton() {
 }
 
 // Book info component (streams in via Suspense)
-async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string; tenantId?: string; tenantSlug: string; embedPolicy: EmbedUiPolicy }) {
+async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed = false }: { id: string; tenantId?: string; tenantSlug: string; embedPolicy: EmbedUiPolicy; previewProposed?: boolean }) {
   let data;
   try {
     data = await getBook(id, tenantId, tenantSlug);
@@ -648,11 +649,17 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
           ? 'blocked'
           : 'open';
   const imageRestricted = imageAccess === 'blocked';
-  const bookSummaryObj = (book as unknown as { index?: { bookSummary?: { brief?: string; detailed?: string; abstract?: string } } }).index?.bookSummary;
+  const candidate = (book as unknown as { summary_candidate?: { brief?: string; abstract?: string; detailed?: string } }).summary_candidate;
+  const bookSummaryObj = previewProposed && candidate?.brief
+    ? { brief: candidate.brief, abstract: candidate.abstract, detailed: candidate.detailed }
+    : (book as unknown as { index?: { bookSummary?: { brief?: string; detailed?: string; abstract?: string } } }).index?.bookSummary;
   const indexBrief = bookSummaryObj?.brief;
-  const readingSummary = (book as unknown as { reading_summary?: { overview?: string } }).reading_summary?.overview;
+  const readingSummary = previewProposed && candidate?.abstract
+    ? candidate.abstract
+    : (book as unknown as { reading_summary?: { overview?: string } }).reading_summary?.overview;
   const summaryText = indexBrief || readingSummary || (typeof book.summary === 'string' ? book.summary : book.summary?.data);
   const hasSummary = !!summaryText;
+  const showProposedBanner = previewProposed && !!candidate?.brief;
   const isComplete = ocrCount >= totalPages && translatedCount >= totalPages && hasSummary;
   const summaryEntities = buildEntityList((book as unknown as { index?: { people?: Array<{ term: string }>; places?: Array<{ term: string }>; concepts?: Array<{ term: string }> } }).index);
 
@@ -1030,6 +1037,11 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                 belongs on a stripped-down bibliographic page. */}
             <AISection className="card p-6">
               <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>About This Book</h2>
+              {showProposedBanner && (
+                <div className="mb-4 text-xs font-medium rounded px-3 py-2" style={{ background: 'rgba(63,185,80,0.12)', color: '#3fb950', border: '1px solid rgba(63,185,80,0.35)' }}>
+                  Previewing the proposed summary (not yet live). Remove <code>?summary=proposed</code> from the URL to see the current version.
+                </div>
+              )}
 
               {hasSummary ? (
                 <>
@@ -1200,8 +1212,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
   );
 }
 
-export default async function BookDetailPage({ params, tenantContext }: PageProps) {
+export default async function BookDetailPage({ params, searchParams, tenantContext }: PageProps) {
   const { id } = await params;
+  const sp = searchParams ? await searchParams : {};
+  // Review preview: ?summary=proposed renders the staged summary_candidate in
+  // the live layout so a reviewer can see the proposed "About This Book" in
+  // context before it is promoted. No effect for normal visitors.
+  const previewProposed = sp.summary === 'proposed';
   const ctx = tenantContext ?? null;
   const embedPolicy = getEmbedUiPolicy(ctx);
   const isEmbedded = ctx?.isEmbedded ?? false;
@@ -1239,7 +1256,7 @@ export default async function BookDetailPage({ params, tenantContext }: PageProp
           </main>
         </>
       }>
-        <BookInfo id={id} tenantId={tenantId} tenantSlug={tenantSlug} embedPolicy={embedPolicy} />
+        <BookInfo id={id} tenantId={tenantId} tenantSlug={tenantSlug} embedPolicy={embedPolicy} previewProposed={previewProposed} />
       </Suspense>
       {!isEmbedded && <SignUpCTA />}
     </div>

--- a/src/app/book/[id]/preview/page.tsx
+++ b/src/app/book/[id]/preview/page.tsx
@@ -1,0 +1,23 @@
+/**
+ * Dynamic review-preview of a book's STAGED summary candidate.
+ *
+ * /book/<id-or-slug>/preview renders the same book page but with the proposed
+ * summary (book.summary_candidate) shown in place of the live one, plus a
+ * banner. Kept as a separate route because the main /book/[id] page is
+ * ISR/static (export const revalidate) and cannot read request-time params;
+ * this route is force-dynamic so it always reflects the current candidate.
+ *
+ * No promotion happens here — read-only preview for reviewers.
+ */
+import BookDetailPage, { generateMetadata as parentGenerateMetadata } from '../page';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  return parentGenerateMetadata({ params });
+}
+
+export default async function BookSummaryPreviewPage({ params }: { params: Promise<{ id: string }> }) {
+  return <BookDetailPage params={params} previewProposed />;
+}


### PR DESCRIPTION
Builds on #2153. Supersedes #2157 (which hit a squash-merge history conflict — same prompt change, rebuilt cleanly off main, plus rollout tooling).

## 1. Prompt: author identity + concrete significance (`summary-prompt.mjs`)
Per feedback, summaries now:
- **Identify the author** with a short factual gloss: *"Irenaeus, a second-century bishop of Lyon and early Church Father"*. Only well-established facts; obscure/uncertain authors get the name alone, no invented bio.
- **State one concrete significance line** where there's a real answer: what the text preserves, influenced, or is a source for — e.g. Irenaeus quotes the Gnostics at length, so his polemic is now a primary source for them. Factual significance, **not** a rating; empty praise adjectives stay banned.

## 2. `resynthesize-summaries.mjs`
- `--visible-only` to scope the corpus run to publicly shown books; higher concurrency for large batches.

## 3. `remove-straggler-summaries.mjs` (new)
Reversibly clears the live summary on visible books with **no section-level index data** (the cheap rewrite can't improve them — better no summary than stale marketing copy). Stashes `summary` / `reading_summary` / `book_indexes.bookSummary` into `book.summary_removed`; `--restore` puts them back. DRY-RUN by default.

## Rollout status (visible scope, ~12,310 summarized books)
- **2,709 stragglers** cleared (reversible) — largely Tibetan monastery books with no section data.
- **~9,600 cheap-eligible** being regenerated into `summary_candidate` (non-destructive); review/approve via `/platform/admin/summary-review`. Nothing else promoted to live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)