### PR TITLE
feat(search): click instrumentation + ranking/routing docs

### DIFF
--- a/.claude/docs/search-ranking-and-routing.md
+++ b/.claude/docs/search-ranking-and-routing.md
@@ -1,0 +1,96 @@
+# Search ranking, routing & the measurement loop
+
+How Source Library decides the *order* of search results, how the LLM step at
+search start feeds that decision, and how we measure whether it's any good.
+
+> Status (2026-05-29): the leak fix + click instrumentation are/should be on
+> `main`; ranking routing (`auto`, LLM intent) is in PR #2154; the BPH compare
+> tool is in PR #2161 (preview-only). "Live vs in-PR" is marked per section.
+
+---
+
+## Surfaces
+
+Three places run search, with different intelligence:
+
+1. **The search page** (`src/app/search/page.tsx`) → `/api/search` for results, plus `/api/search/ai-expand` for an LLM narration / expanded terms / intent. This is the high-traffic public surface.
+2. **The Librarian** (`src/lib/embassy/librarian.ts`) → `src/lib/search/librarian-search.ts` (`hybridSearch`), one unified `search` tool. RRF is **live** here (PR #2137). It's a research assistant, so conceptual queries dominate.
+3. **The BPH compare tool** (`/embed/[tenant]/search-compare`, PR #2161) → `/api/search/compare`. A librarian A/B harness, not a public surface.
+
+## The four lanes (`/api/search`)
+
+Every query fans out to four lanes in parallel, each tenant-scoped:
+- **keyword books** — Supabase trigram (`books_catalog`) → Mongo metadata.
+- **keyword pages** — Atlas Search `pages_search` (phrase/fuzzy on translation+OCR).
+- **semantic books** — `match_books_semantic` (Gemini 768-dim). ⚠️ global RPC (no `tenant_id` column); tenant scope is re-applied in the Mongo materialization — see "Tenant scoping" below.
+- **semantic pages** — `match_semantic` (passes `filter_tenant_id`, so tenant-safe at the RPC).
+
+Lane results are concatenated, then **ordered** by the chosen ranking strategy, then work-id-deduped and paginated.
+
+## Ranking strategies
+
+`?ranking=` on `/api/search` (default `auto`):
+
+- **`ladder`** — the legacy curatorial heuristic, and still the right answer for navigational lookups: books > pages → title/author word match → exact-phrase-in-title → **original language beats English translation** → **older edition wins** → quality. Encodes real curation; don't treat it as a naive baseline.
+- **`rrf`** — Reciprocal Rank Fusion (`src/lib/search/rrf.ts`, k=60) of the four lanes' ranked id-lists. Lets a cross-confirmed passage outrank a weakly-matched book. Wins conceptual/niche queries.
+- **`auto`** (default, PR #2154) — routes per query:
+  - If an LLM **intent** is supplied (`&intent=`), use it: `navigational → ladder`, `conceptual`/`verbatim → rrf`.
+  - Else fall back to **word count**: 1–2 words → ladder, 3+ → rrf.
+  - The response + log report the applied mode (`auto-rrf:conceptual`, `auto-ladder:words`, …).
+
+### Why routing, not wholesale RRF
+Two evals + the real query mix drove this:
+- **Eval (Librarian golden set):** RRF wins overall (P@1 0.53 vs 0.47, MRR 0.63) and ~doubles niche-passage recall, **but halves verbatim-quote recall (0.75→0.38)** and hurts broad-theme. No single ranker wins every category.
+- **Real `/api/search` traffic (28K queries):** **~69% one word, 84% ≤2 words (navigational), ~16% 3+ words (conceptual), ~0% quoted.** RRF helps the 16% tail and would risk the 84% majority where the ladder is already strong (verified live: `boehme`, `kircher`, `paracelsus`, `agrippa` all return the right canonical/original-language books).
+
+So `auto` keeps the majority on the proven ladder and applies RRF only where it wins.
+
+## LLM intent at search start (PR #2154)
+
+`/api/search/ai-expand` (gemini-3.1-flash-lite, streaming SSE) runs per search-page query. It emits:
+- `display` hint (`images_first | books_first | not_in_collection`) — **layout** only.
+- `strategy` (`navigational | conceptual | verbatim`) — **retrieval routing**. New. Streamed as a `strategy` SSE event, cached/replayed.
+- `narration`, `terms` (expanded search terms), `image_terms`.
+
+The `strategy` is the better routing signal than word count (e.g. 2-word "sympathetic magic" is conceptual). Consumed via `&intent=` on `/api/search`. **The live search page is intentionally NOT serialized behind the LLM** — `/api/search` fires immediately with word-count `auto` (zero added latency); the intent param is exercised by the compare tool first to validate routing quality before wiring a live re-rank.
+
+**Latent opportunity (not built):** the LLM `terms` (Latin titles, original-language names) could be embedded and fused into the RRF as extra ranked lists — a multi-query attack on cross-lingual + niche recall.
+
+## Tenant scoping (lockdown) — fixed in #2159
+
+Partner subdomains (BPH/EFM) must never show non-tenant content. The keyword lanes and the semantic *page* lane scope by tenant; the semantic *book* lane did **not** (its RPC is global and `book_embeddings` has no `tenant_id` column), so it leaked global books into BPH results — measured at up to 18/25 for "hermetic philosophy and the soul". Fixed by re-applying the tenant filter in the semantic materialization queries. Guard: `scripts/audit/search-tenant-purity.mjs` (asserts 0 cross-tenant survivors; re-run after touching the semantic lanes).
+
+## The BPH compare tool (PR #2161, preview-only)
+
+`/embed/bph/search-compare` — librarians compare **Current (ladder)** vs **New (RRF)** side by side on their corpus, thumb individual results, pick a winner, leave a note → `search_compare_votes` (anonymous). Features: scope toggle (BPH-only vs whole library), clickable results (BPH → `bph.sourcelibrary.org`, else `sourcelibrary.org`), and an LLM-intent banner ("Search read this as a *conceptual* query → production would show New (RRF)"). The vote stores `scope` + `strategy`, so we can ask "for queries the LLM called conceptual, did librarians prefer RRF?" — the validation for flipping `auto` on in production.
+
+## The measurement loop — click instrumentation (this PR)
+
+Until now we logged **what** people search (`search_query`, 29K/90d) and **what** they read (`page_read`, `book_read`) but **not the click that connects them** — so result quality wasn't measurable, hence the manual compare tool.
+
+`POST /api/search/click` (fired via `navigator.sendBeacon` from the search page) records `event: search_result_click` in `analytics_events`: `{query, ranking, slug, page_number, rank, view, total, ip, created_at}`. A single delegated capture-phase listener on the search page beacons any `/book/` result click; `clickCtx` attributes it to the query + ranking strategy that produced it.
+
+This enables, per ranking strategy (`auto-rrf` / `auto-ladder` / `ladder`):
+- **CTR** — clicks ÷ searches.
+- **Mean clicked-rank** — the core ranking-quality metric (lower = better ordering).
+- **Zero-click / abandonment rate** — searches with no follow-up click (the strongest "bad results" signal). Derive from `search_query` events with no matching `search_result_click` by ip+time.
+
+Once #2154 is live, this **automatically A/B-measures `auto-rrf` vs `auto-ladder` on real behavior** — no manual eval needed. Before #2154, it captures a `ladder`/baseline CTR + clicked-rank to compare against.
+
+## Where to look
+| Concern | File |
+|---|---|
+| Lanes + ranking + auto routing + intent | `src/app/api/search/route.ts` |
+| RRF util | `src/lib/search/rrf.ts` |
+| Ladder (legacy) | inline in `route.ts` (`ladderCompare`) + mirrored in `compare-search.ts` |
+| LLM intent | `src/app/api/search/ai-expand/route.ts` (`<strategy>`) |
+| Librarian hybrid (live) | `src/lib/search/librarian-search.ts` |
+| Compare tool | `src/lib/search/compare-search.ts`, `src/app/api/search/compare/*`, `src/app/embed/[tenant]/search-compare/*` |
+| Click telemetry | `src/app/api/search/click/route.ts` + delegated listener in `src/app/search/page.tsx` |
+| Tenant-purity guard | `scripts/audit/search-tenant-purity.mjs` |
+
+## Open follow-ups
+1. **Decide `auto`'s fate** from compare votes + click data (CTR / clicked-rank per strategy). Likely keep routing; tune the navigational/conceptual boundary.
+2. **Wire the live search page to pass `intent`** (re-rank when the LLM disagrees with word count) once routing is validated — handle latency (instant word-count results, async refine).
+3. **LLM terms → RRF multi-query** (the recall play).
+4. Extend click tracking to index/image result cards (currently book/page links).

--- a/src/app/api/search/click/route.ts
+++ b/src/app/api/search/click/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+
+export const preferredRegion = 'fra1';
+
+// POST /api/search/click — records which search result a user clicked.
+// Closes the search measurement loop: paired with `search_query` events it
+// yields click-through rate, mean clicked-rank, and zero-click (abandoned)
+// rate, broken down by ranking strategy (auto-rrf / auto-ladder / ladder…).
+// Anonymous + fire-and-forget (sent via navigator.sendBeacon), so it stays off
+// the navigation critical path. Mirrors the existing analytics_events shape.
+export async function POST(request: NextRequest) {
+  let b: any;
+  try {
+    b = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const query = String(b?.query || '').trim().slice(0, 300);
+  if (!query) return NextResponse.json({ ok: false }, { status: 400 });
+
+  try {
+    const db = await getDb();
+    await db.collection('analytics_events').insertOne({
+      event: 'search_result_click',
+      query,
+      ranking: typeof b?.ranking === 'string' ? b.ranking.slice(0, 40) : null, // e.g. auto-rrf:conceptual
+      slug: typeof b?.slug === 'string' ? b.slug.slice(0, 200) : undefined,
+      page_number: typeof b?.page_number === 'number' ? b.page_number : undefined,
+      rank: typeof b?.rank === 'number' ? b.rank : undefined,                   // 1-based position, if known
+      view: typeof b?.view === 'string' ? b.view.slice(0, 20) : undefined,      // all | books | index | images
+      total: typeof b?.total === 'number' ? b.total : undefined,
+      ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
+      created_at: new Date(),
+    });
+  } catch {
+    // Telemetry must never break the click — swallow and move on.
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -187,6 +187,43 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
   const displayHintLocked = useRef(false); // lock once results render to prevent layout shift
   const aiAbortRef = useRef<(() => void) | null>(null);
 
+  // Search-click telemetry context — read by the delegated click listener below.
+  // Updated on each search so a result click can be attributed to the query +
+  // ranking strategy that produced it (closes the search measurement loop).
+  const clickCtx = useRef<{ query: string; ranking: string | null; results: SearchResult[]; view: string; total: number }>({ query: '', ranking: null, results: [], view: 'all', total: 0 });
+
+  // Delegated capture-phase listener: any click on a /book/ link while a search
+  // is active beacons {query, ranking, slug, rank, …} to /api/search/click. One
+  // listener, no per-card wiring; non-result /book/ links won't match a current
+  // result and are recorded with rank undefined (or skipped if no active query).
+  useEffect(() => {
+    function onResultClick(e: MouseEvent) {
+      const anchor = (e.target as HTMLElement)?.closest?.('a[href*="/book/"]') as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const ctx = clickCtx.current;
+      if (!ctx.query) return; // only track within an active search (not browse)
+      const href = anchor.getAttribute('href') || '';
+      const pageMatch = href.match(/\/book\/([^/?#]+)\/page-number\/(\d+)/);
+      const bookMatch = href.match(/\/book\/([^/?#]+)/);
+      const slug = (pageMatch?.[1] || bookMatch?.[1] || '').toLowerCase();
+      if (!slug) return;
+      const idx = ctx.results.findIndex(r =>
+        (r.slug || '').toLowerCase() === slug || (r.book_id || '').toLowerCase() === slug);
+      const payload = {
+        query: ctx.query, ranking: ctx.ranking, slug,
+        page_number: pageMatch ? Number(pageMatch[2]) : undefined,
+        rank: idx >= 0 ? idx + 1 : undefined, view: ctx.view, total: ctx.total,
+      };
+      try {
+        const body = JSON.stringify(payload);
+        if (navigator.sendBeacon) navigator.sendBeacon('/api/search/click', new Blob([body], { type: 'application/json' }));
+        else fetch('/api/search/click', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body, keepalive: true });
+      } catch { /* never block the click */ }
+    }
+    document.addEventListener('click', onResultClick, true);
+    return () => document.removeEventListener('click', onResultClick, true);
+  }, []);
+
   // Load filter options + collections (independent so one failure doesn't block others)
   useEffect(() => {
     utils.languages().then((langData) => {
@@ -382,6 +419,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
           const bTotal = data.books?.total || 0;
           const index = (data.index?.results || []).slice(0, PREVIEW_INDEX);
           const iTotal = data.index?.total || 0;
+          clickCtx.current = { query: q, ranking: (data.books as any)?.ranking || null, results: books, view: 'all', total: bTotal };
 
           // Map unified gallery + visual + artwork results to GalleryItem shape
           // Merge all image sources, deduped by id
@@ -563,6 +601,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         });
         setBookResults(data.results || []);
         setBookTotal(data.total || 0);
+        clickCtx.current = { query: q, ranking: (data as any).ranking || null, results: data.results || [], view: 'books', total: data.total || 0 };
       } else if (mode === 'index') {
         const data = await searchApi.index(q, { type: indexType || undefined });
         setIndexResults(data.results || []);


### PR DESCRIPTION
Closes the search measurement loop and documents the ranking system.

## Why
We log **what** people search (`search_query`, 29K/90d) and **what** they read (`page_read`, `book_read`) but never the **click that connects them** — so search result quality has been unmeasurable (which is why RRF needed a manual compare tool). This adds the missing signal.

## What
- **`POST /api/search/click`** → `analytics_events {event:'search_result_click', query, ranking, slug, page_number, rank, view, total, ip, created_at}`. Anonymous, fire-and-forget via `navigator.sendBeacon` so it never blocks navigation. Mirrors the existing analytics_events shape.
- **`search/page.tsx`**: one **delegated** capture-phase listener beacons any `/book/` result click, attributed via `clickCtx` to the query + ranking strategy that produced it. No per-card wiring; non-result links don't match a current result and are recorded with `rank` undefined (or skipped when there's no active query).
- **`.claude/docs/search-ranking-and-routing.md`** — canonical doc: four lanes, ladder/RRF/`auto` routing, LLM intent (#2154), tenant leak fix (#2159), BPH compare tool (#2161), and this loop.

## What it unlocks
Per ranking strategy (`auto-rrf` / `auto-ladder` / `ladder`):
- **CTR**, **mean clicked-rank** (core ranking-quality metric), **zero-click/abandonment rate** (strongest "bad results" signal).
- Once #2154 (auto routing) lands, this **A/B-measures `auto-rrf` vs `auto-ladder` on real behavior** automatically. Before that, it captures a `ladder`/baseline.

## Safe to ship
Purely additive telemetry + a doc — no behavior change to search itself. `ranking` is recorded as whatever the response reports (`baseline`/null until #2154 lands). Should merge to `main` so it starts collecting real click data now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)