### PR TITLE
perf(supabase): fix ustc_editions title seq scan + materialize get_sl_progress

### DIFF
--- a/scripts/migration/add-ustc-title-trgm-index.mjs
+++ b/scripts/migration/add-ustc-title-trgm-index.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Supabase CPU relief (2026-05-29) — the dominant fix.
+ *
+ * The public USTC title search ran `... FROM ustc_editions WHERE title ILIKE $1
+ * AND year BETWEEN ...` as a full Parallel Seq Scan of the 1.6M-row table:
+ * 27,813 calls at a 7.2s mean, ~35% of the whole instance's DB time, 171B
+ * tuples read. Root cause: the existing trigram index idx_ustc_title_trgm was
+ * built on lower(title) — an EXPRESSION index — which a raw `title ILIKE`
+ * filter cannot use, so the planner fell back to seq scan. (The author_1 search
+ * is the same shape but fast, because idx_ustc_author1_trgm is on the raw column.)
+ *
+ * Fix: a gin_trgm_ops index on the RAW title column. Plan cost dropped
+ * 118,399 -> 224 (~530x); EXPLAIN flips Seq Scan -> Bitmap Index Scan.
+ *
+ * The old lower(title) index is now dead weight on this hot path and is a future
+ * drop candidate (verify nothing queries lower(title) first) — left in place here.
+ *
+ * Idempotent. Run on Hetzner where SUPABASE_DB_URL lives:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/migration/add-ustc-title-trgm-index.mjs
+ *
+ * gotcha: pg.Client({ statement_timeout: 0 }) is a silent no-op (0 is falsy and
+ * never sent), so the server default killed the CONCURRENTLY build mid-flight.
+ * We SET it explicitly below. A failed CONCURRENTLY build leaves an INVALID
+ * index; this script drops any such leftover before (re)building.
+ */
+import pg from 'pg';
+
+const url = process.env.SUPABASE_DB_URL;
+if (!url) { console.error('Missing SUPABASE_DB_URL'); process.exit(1); }
+const client = new pg.Client({ connectionString: url.replace(':6543/', ':5432/') });
+
+await client.connect();
+await client.query('SET statement_timeout = 0');
+await client.query('SET lock_timeout = 0');
+await client.query("SET maintenance_work_mem = '512MB'");
+
+const invalid = await client.query(`
+  SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE NOT i.indisvalid AND c.relname = 'idx_ustc_title_trgm_raw'`);
+if (invalid.rows.length) {
+  console.log('Dropping invalid leftover idx_ustc_title_trgm_raw...');
+  await client.query('DROP INDEX CONCURRENTLY IF EXISTS idx_ustc_title_trgm_raw');
+}
+
+console.log('Building idx_ustc_title_trgm_raw CONCURRENTLY (no-op if present)...');
+await client.query(`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ustc_title_trgm_raw
+  ON public.ustc_editions USING gin (title gin_trgm_ops)`);
+
+const v = await client.query(`
+  SELECT i.indisvalid, pg_size_pretty(pg_relation_size(i.indexrelid)) AS size
+  FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE c.relname = 'idx_ustc_title_trgm_raw'`);
+console.log(`idx_ustc_title_trgm_raw valid=${v.rows[0]?.indisvalid} size=${v.rows[0]?.size}`);
+
+const plan = await client.query(`EXPLAIN SELECT sn, title, author_1, year
+  FROM ustc_editions WHERE title ILIKE '%astronomia%' AND year >= 1500 AND year <= 1700 LIMIT 50`);
+console.log('Plan (expect Bitmap Index Scan on idx_ustc_title_trgm_raw):');
+console.log(plan.rows.map(r => '  ' + r['QUERY PLAN']).join('\n'));
+
+await client.end();
+console.log('Done.');

--- a/scripts/migration/materialize-sl-progress-and-tune-cron.mjs
+++ b/scripts/migration/materialize-sl-progress-and-tune-cron.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Supabase CPU relief (2026-05-29). Two operational changes:
+ *
+ * 1. Materialize get_sl_progress(). It was a STABLE SQL function recomputing a
+ *    full books_catalog aggregation (GROUP BY language, GROUP BY century, totals)
+ *    on EVERY call — ~143K calls in the pg_stat_statements window, 126ms each.
+ *    The public /census and /about/progress pages call it on each load. We move
+ *    the computation into a single-row matview (sl_progress_mv) refreshed hourly
+ *    by pg_cron, and rewrite the function to read that one row (sub-ms). The
+ *    JSON shape is preserved EXACTLY (copied from the live function body), so no
+ *    app change is needed. This script verifies matview == function output
+ *    before swapping the function — it aborts the swap if they differ.
+ *
+ * 2. Tune over-frequent matview refresh crons. dashboard_usage (built from the
+ *    4.7M-row gemini_usage table) and coverage_stats_mv were both refreshing
+ *    every 5 min; dashboard_usage alone took ~8s each = ~38 CPU-min/day. Usage
+ *    and coverage stats tolerate hourly. pipeline_velocity is left at 5 min
+ *    (negligible cost, benefits from freshness for pipeline monitoring).
+ *
+ * Context: the dominant CPU driver (a ustc_editions title seq scan, ~35% of DB
+ * time) was already fixed separately via idx_ustc_title_trgm_raw.
+ *
+ * Idempotent. Run on Hetzner where SUPABASE_DB_URL lives:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/migration/materialize-sl-progress-and-tune-cron.mjs
+ */
+import pg from 'pg';
+
+const url = process.env.SUPABASE_DB_URL;
+if (!url) { console.error('Missing SUPABASE_DB_URL'); process.exit(1); }
+// Direct port (not the :6543 pooler) so DDL / CONCURRENTLY behave.
+const client = new pg.Client({ connectionString: url.replace(':6543/', ':5432/') });
+
+// The live get_sl_progress() body, verbatim. Used both as the matview definition
+// and (post-swap) replaced by a thin read. Keep this in sync if the metric ever changes.
+const AGG_SQL = `
+  WITH by_lang AS (
+    SELECT language,
+      count(*) AS total,
+      count(*) FILTER (WHERE pages_translated > 0) AS translated,
+      count(*) FILTER (WHERE translation_pct >= 90) AS over_90,
+      count(*) FILTER (WHERE is_first_translation) AS first_trans
+    FROM books_catalog
+    WHERE pages_count > 0 AND language IS NOT NULL
+    GROUP BY language
+    ORDER BY count(*) DESC
+    LIMIT 20
+  ),
+  by_century AS (
+    SELECT
+      (floor(year::numeric / 100) * 100)::int AS century_start,
+      count(*) AS total,
+      count(*) FILTER (WHERE pages_translated > 0 AND language != 'English') AS translated_by_sl,
+      count(*) FILTER (WHERE translation_pct >= 90) AS over_90,
+      count(*) FILTER (WHERE is_first_translation) AS first_trans
+    FROM books_catalog
+    WHERE pages_count > 0 AND year IS NOT NULL
+    GROUP BY floor(year::numeric / 100) * 100
+    ORDER BY floor(year::numeric / 100) * 100
+  ),
+  totals AS (
+    SELECT
+      count(*) AS total_books,
+      count(*) FILTER (WHERE pages_translated > 0 AND language != 'English' AND language IS NOT NULL) AS translated_by_sl,
+      count(*) FILTER (WHERE pages_translated > 0 AND language = 'English') AS english_digitized,
+      count(*) FILTER (WHERE translation_pct >= 90 AND language != 'English' AND language IS NOT NULL) AS over_90_translated,
+      count(*) FILTER (WHERE is_first_translation AND language != 'English') AS first_translations
+    FROM books_catalog
+    WHERE pages_count > 0
+  )
+  SELECT json_build_object(
+    'totals', (SELECT row_to_json(t) FROM totals t),
+    'by_language', (SELECT json_agg(row_to_json(l)) FROM by_lang l),
+    'by_century', (SELECT json_agg(row_to_json(c)) FROM by_century c)
+  )`;
+
+await client.connect();
+await client.query('SET statement_timeout = 0');
+await client.query('SET lock_timeout = 0');
+
+// 0) Snapshot the CURRENT live function output (the source of truth to match).
+const before = (await client.query('SELECT get_sl_progress() AS d')).rows[0].d;
+console.log('Captured live get_sl_progress() output. totals:', JSON.stringify(before.totals));
+
+// 1) (Re)create the single-row matview from the same aggregation.
+await client.query('DROP MATERIALIZED VIEW IF EXISTS public.sl_progress_mv');
+await client.query(`CREATE MATERIALIZED VIEW public.sl_progress_mv AS
+  SELECT 1 AS id, (${AGG_SQL}) AS data`);
+await client.query('CREATE UNIQUE INDEX sl_progress_mv_id ON public.sl_progress_mv (id)');
+console.log('Created sl_progress_mv (single row + unique index for CONCURRENTLY refresh).');
+
+// 2) Verify the matview matches the live function output EXACTLY before swapping.
+const mv = (await client.query('SELECT data FROM public.sl_progress_mv WHERE id = 1')).rows[0].data;
+const eq = JSON.stringify(mv) === JSON.stringify(before);
+if (!eq) {
+  console.error('ABORT: matview output != live function output. Not swapping the function.');
+  console.error('matview totals:', JSON.stringify(mv.totals));
+  await client.query('DROP MATERIALIZED VIEW IF EXISTS public.sl_progress_mv');
+  await client.end();
+  process.exit(1);
+}
+console.log('Verified: sl_progress_mv matches live get_sl_progress() byte-for-byte.');
+
+// 3) Swap the function to a thin read of the matview (same return type/shape).
+await client.query(`
+  CREATE OR REPLACE FUNCTION public.get_sl_progress()
+  RETURNS json LANGUAGE sql STABLE AS $fn$
+    SELECT data FROM public.sl_progress_mv WHERE id = 1
+  $fn$`);
+const after = (await client.query('SELECT get_sl_progress() AS d')).rows[0].d;
+console.log('Swapped get_sl_progress() to read matview. post-swap matches:',
+  JSON.stringify(after) === JSON.stringify(before));
+
+// 4) Schedule the hourly refresh (idempotent: cron.schedule upserts by jobname).
+await client.query(`SELECT cron.schedule('refresh-sl-progress', '13 * * * *',
+  'REFRESH MATERIALIZED VIEW CONCURRENTLY public.sl_progress_mv')`);
+console.log("Scheduled cron 'refresh-sl-progress' at minute 13 hourly.");
+
+// 5) Slow the over-frequent refreshes from every-5-min to hourly (staggered minutes).
+const tune = async (match, schedule) => {
+  const r = await client.query(
+    `SELECT cron.alter_job(jobid, schedule => $1) , jobid, command
+     FROM cron.job WHERE command ILIKE $2`, [schedule, match]);
+  for (const row of r.rows) console.log(`  altered job ${row.jobid} -> '${schedule}'  (${row.command.replace(/\s+/g,' ').slice(0,50)})`);
+};
+await tune('%dashboard_usage%', '17 * * * *');
+await tune('%coverage_stats_mv%', '23 * * * *');
+
+console.log('\n=== resulting cron schedule ===');
+console.table((await client.query(
+  `SELECT jobid, schedule, active, left(regexp_replace(command,'\\s+',' ','g'),48) AS command
+   FROM cron.job ORDER BY jobid`)).rows);
+
+await client.end();
+console.log('Done.');


### PR DESCRIPTION
## Why
Supabase (`secondrenaissance`) fired a **>80% CPU** alert. Diagnosed against live `pg_stat_statements`. The vector/embedding search is healthy — not the cause. Three drivers; this PR addresses the two fixable ones.

These DB changes were **already applied to production** to clear the alert; the migration scripts here document and reproduce them (idempotent, safe to re-run).

## 1. `ustc_editions` title search — ~35% of all DB time *(the big one)*
The public USTC title search ran `WHERE title ILIKE $1 AND year BETWEEN …` as a **full Parallel Seq Scan** of the 1.6M-row table: 27,813 calls, **7.2s mean**, 171B tuples read.

Root cause: the trigram index `idx_ustc_title_trgm` was built on `lower(title)` (an expression index), which a raw `title ILIKE` filter can't use → seq scan. The `author_1` search is the identical shape but fast — its index is on the raw column.

**Fix:** `idx_ustc_title_trgm_raw` on raw `title` (`gin_trgm_ops`). EXPLAIN flips Seq Scan → Bitmap Index Scan, plan cost **118,399 → 224 (~530×)**. No app change.

## 2. `get_sl_progress()` recomputed on every page load — ~3% + latency
A `STABLE` function recomputing a full `books_catalog` aggregation on **every** call (~143K calls, 126ms each) behind the public `/census` and `/about/progress` pages.

**Fix:** materialized into single-row `sl_progress_mv`, refreshed hourly by pg_cron; the function now reads one row. **JSON output verified byte-for-byte identical before/after the swap** — no app change. Also moved `dashboard_usage` (~8s × 288/day, built from 4.7M-row `gemini_usage`) and `coverage_stats_mv` refreshes from every-5-min → hourly. `pipeline_velocity` left at 5-min (negligible cost, wants freshness).

## Out of scope (deliberately left undone)
- **Dropping the now-redundant `lower(title)` index** — left in place until we confirm no caller queries `lower(title)`.
- **`page_translations` INSERT (~24%)** — legitimate ingest write load (each insert maintains the 18GB HNSW index); only batching would trim it, separate concern.
- **Vector/HNSW indexes** — verified present and used; the halfvec fix is holding. Not a contributor.

## Verification
- `idx_ustc_title_trgm_raw`: valid, 355 MB; EXPLAIN confirms Bitmap Index Scan.
- `get_sl_progress()`: pre/post-swap JSON equal; `sl_progress_mv` populated + hourly cron scheduled.
- Watch the Supabase CPU graph over the next hour to confirm the drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)