### PR TITLE
feat(bph): catalogue search next to gear + restore catalogue AI summaries

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -490,7 +490,7 @@ export default async function CatalogEntryPage({ params }: Props) {
                 </dl>
 
                 {slBook.reading_summary?.overview && (
-                  <AISection>
+                  <AISection kind="ai-summary-catalog">
                     <p className="text-sm text-secondary leading-relaxed mb-4 italic">
                       {slBook.reading_summary.overview.length > 380
                         ? slBook.reading_summary.overview.slice(0, 380) + '…'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -651,6 +651,14 @@ body:has(.embed-mode) {
    Apply outside .embed-mode too — root-domain book pages should respect
    the same preferences. */
 html[data-sl-hide-ai="1"] [data-view-section="ai-summary"],
+html[data-sl-hide-ai="default"] [data-view-section="ai-summary"],
 html[data-sl-hide-guide="1"] [data-view-section="reading-guide"] {
+  display: none !important;
+}
+
+/* Catalogue summaries (BphCatalogEntry) are editorially reviewed, so they
+   show under the BPH default ("default") and hide only on an EXPLICIT opt-out
+   ("1") via the gear menu. See VIEW_MODE_INIT_SCRIPT in src/app/layout.tsx. */
+html[data-sl-hide-ai="1"] [data-view-section="ai-summary-catalog"] {
   display: none !important;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,15 +23,21 @@ import EmbedHistoryPatch from "@/components/embed/EmbedHistoryPatch";
 // over primary sources, so the partner surface leads without it. A visitor
 // can still opt in via the gear menu (sl_hide_ai=0). The cookie is tri-state:
 // '1'=hide, '0'=show, absent=default (BPH hides; main site + other tenants
-// show). Reading-guide toggle is unchanged (default show, hide only on
-// explicit sl_hide_guide=1). The CSS rules in globals.css consume the data
-// attributes set here. Must live in the ROOT layout (not embed/layout): the
-// real BPH subdomain serves the global /book/[id] route directly (proxy adds
+// show). We distinguish the two ways AI prose ends up hidden by writing
+// data-sl-hide-ai="1" for an EXPLICIT opt-out vs "default" for the BPH
+// implicit default. Most AI surfaces (book intros, reading guides) hide on
+// either. The catalogue summary is the exception: its works have been
+// editorially reviewed, so it shows under the BPH default and hides only on
+// an explicit opt-out — globals.css keys that off the "1" value alone.
+// Reading-guide toggle is unchanged (default show, hide only on explicit
+// sl_hide_guide=1). The CSS rules in globals.css consume the data attributes
+// set here. Must live in the ROOT layout (not embed/layout): the real BPH
+// subdomain serves the global /book/[id] route directly (proxy adds
 // x-tenant-* headers, no /embed rewrite), so the embed layout never wraps it.
 // Detection is client-side by hostname to stay ISR-safe — the HTML is
 // host-agnostic and cached; this script self-determines at runtime.
 // Must mirror the detection in EmbedUserMenu.tsx.
-const VIEW_MODE_INIT_SCRIPT = `(function(){var d=document,c=d.cookie,h=location.hostname,p=location.pathname;var bph=/^bph\\./.test(h)||/^\\/embed\\/bph(\\/|$)/.test(p);var m=c.match(/(?:^|; )sl_hide_ai=([01])/);if(m?m[1]==='1':bph)d.documentElement.dataset.slHideAi='1';if(/(?:^|; )sl_hide_guide=1/.test(c))d.documentElement.dataset.slHideGuide='1';})();`;
+const VIEW_MODE_INIT_SCRIPT = `(function(){var d=document,c=d.cookie,h=location.hostname,p=location.pathname;var bph=/^bph\\./.test(h)||/^\\/embed\\/bph(\\/|$)/.test(p);var m=c.match(/(?:^|; )sl_hide_ai=([01])/);var v=m?m[1]:(bph?'d':null);if(v==='1')d.documentElement.dataset.slHideAi='1';else if(v==='d')d.documentElement.dataset.slHideAi='default';if(/(?:^|; )sl_hide_guide=1/.test(c))d.documentElement.dataset.slHideGuide='1';})();`;
 
 export const metadata: Metadata = {
   title: "Source Library — Ancient Texts Translated to English",

--- a/src/components/embed/AISection.tsx
+++ b/src/components/embed/AISection.tsx
@@ -12,7 +12,12 @@ import type { ReactNode } from 'react';
  * failure mode: the toggle silently misses that surface.
  */
 interface AISectionProps {
-  kind?: 'ai-summary' | 'reading-guide';
+  // 'ai-summary' and 'reading-guide' hide under both the explicit and the
+  // BPH-default "Hide AI" states. 'ai-summary-catalog' is shown under the BPH
+  // default and hides only on an explicit opt-out (catalogue works are
+  // editorially reviewed) — see VIEW_MODE_INIT_SCRIPT in src/app/layout.tsx
+  // and the globals.css rules.
+  kind?: 'ai-summary' | 'reading-guide' | 'ai-summary-catalog';
   className?: string;
   children: ReactNode;
 }

--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -3,7 +3,7 @@
 import { signOut } from 'next-auth/react';
 import { useStableSession } from '@/hooks/useStableSession';
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { Settings } from 'lucide-react';
+import { Settings, Search, X } from 'lucide-react';
 
 // On tenant subdomains, /auth/* and /account are caught by the proxy.ts
 // rewrite (it sends every non-/embed/, non-/api/, non-/_next/ path to
@@ -84,6 +84,23 @@ function readHideAi(): boolean {
   return isBphSurface();
 }
 
+// Build the catalogue-search destination. On the tenant subdomain (proxy
+// rewrites every path to /embed/<tenant>) a relative /catalog?cq= resolves
+// on-host and the proxy maps it to ?view=catalog. When we're rendering the
+// raw /embed/<tenant> path (e.g. a sourcelibrary.org preview), a relative
+// /catalog would escape to the GLOBAL search — a tenant-lockdown leak — so we
+// target the explicit embed route instead. Either way the search stays within
+// the tenant's own catalogue.
+function catalogSearchUrl(query: string): string {
+  const q = encodeURIComponent(query.trim());
+  if (typeof window === 'undefined') return '/catalog';
+  const embedMatch = window.location.pathname.match(/^\/embed\/([^/]+)/);
+  if (embedMatch) {
+    return `/embed/${embedMatch[1]}?view=catalog${q ? `&cq=${q}` : ''}`;
+  }
+  return `/catalog${q ? `?cq=${q}` : ''}`;
+}
+
 // Persist an explicit choice. We always write '0'/'1' (never delete) so an
 // opt-in-to-show on BPH survives reload instead of falling back to the
 // default-hidden state.
@@ -98,8 +115,19 @@ export default function EmbedUserMenu() {
   const [imgError, setImgError] = useState(false);
   const [hideAi, setHideAi] = useState(false);
   const [hideGuide, setHideGuide] = useState(false);
+  // Catalogue search is a BPH affordance (the /catalog?cq= flow). Hydrated
+  // after mount to keep the server HTML host-agnostic (ISR-safe).
+  const [showSearch, setShowSearch] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const handleImgError = useCallback(() => setImgError(true), []);
+
+  const submitSearch = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    window.location.assign(catalogSearchUrl(searchQuery));
+  }, [searchQuery]);
 
   // Hydrate toggle state from cookies after mount. The server has already
   // rendered the book page using whatever the cookie said at request time;
@@ -107,7 +135,13 @@ export default function EmbedUserMenu() {
   useEffect(() => {
     setHideAi(readHideAi());
     setHideGuide(readCookie(COOKIE_HIDE_GUIDE));
+    setShowSearch(isBphSurface());
   }, []);
+
+  // Focus the field as it expands.
+  useEffect(() => {
+    if (searchOpen) searchInputRef.current?.focus();
+  }, [searchOpen]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -141,7 +175,7 @@ export default function EmbedUserMenu() {
     document.documentElement.dataset.slHideGuide = next ? '1' : '';
   };
 
-  const containerCls = 'fixed top-3 right-3 z-50 print:hidden';
+  const containerCls = 'fixed top-3 right-3 z-50 print:hidden flex items-center gap-2';
 
   const name = session?.user?.name || session?.user?.email || 'Account';
   const initials = session?.user?.name
@@ -153,6 +187,62 @@ export default function EmbedUserMenu() {
 
   return (
     <div ref={menuRef} className={containerCls}>
+      {showSearch && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submitSearch();
+          }}
+          className="flex items-center"
+        >
+          {searchOpen ? (
+            <div className="flex items-center bg-white/90 backdrop-blur-sm border border-border-light shadow-sm rounded-full pl-3 pr-1 py-0.5">
+              <input
+                ref={searchInputRef}
+                type="search"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    setSearchOpen(false);
+                    setSearchQuery('');
+                  }
+                }}
+                placeholder="Search the catalogue…"
+                aria-label="Search the catalogue"
+                className="w-44 bg-transparent text-sm text-primary placeholder:text-muted focus:outline-none"
+              />
+              <button
+                type="submit"
+                aria-label="Search"
+                className="w-7 h-7 rounded-full flex items-center justify-center text-secondary hover:text-primary"
+              >
+                <Search className="w-4 h-4" aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                aria-label="Close search"
+                onClick={() => {
+                  setSearchOpen(false);
+                  setSearchQuery('');
+                }}
+                className="w-7 h-7 rounded-full flex items-center justify-center text-muted hover:text-primary"
+              >
+                <X className="w-4 h-4" aria-hidden="true" />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              aria-label="Search the catalogue"
+              onClick={() => setSearchOpen(true)}
+              className="flex items-center justify-center w-9 h-9 rounded-full bg-white/90 backdrop-blur-sm border border-border-light shadow-sm hover:bg-white transition-colors text-secondary hover:text-primary"
+            >
+              <Search className="w-4 h-4" aria-hidden="true" />
+            </button>
+          )}
+        </form>
+      )}
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-2 px-2 py-1 rounded-full bg-white/90 backdrop-blur-sm border border-border-light shadow-sm hover:bg-white transition-colors"


### PR DESCRIPTION
## What

Two small BPH reading-room changes Derek asked for.

### 1. Catalogue search bar next to the gear icon
`EmbedUserMenu` (the floating top-right control) gains an **expanding search icon** to the left of the gear. Click it → a compact input slides out → Enter routes into the BPH catalogue search.

- **Tenant-safe by construction.** It targets the tenant catalogue only: `/catalog?cq=…` on the subdomain (proxy maps it to `?view=catalog`), or `/embed/<tenant>?view=catalog&cq=…` when rendered off-subdomain (preview). Never the global search — honours the Tenant Subdomain Lockdown.
- Shown on **BPH surfaces only** (`isBphSurface()`), hydrated client-side after mount to stay ISR-safe.
- Reuses the existing `cq=` param that `BphCatalogBrowser` already reads.

### 2. Catalogue AI summaries restored (default-show, still toggleable)
Catalogue entry summaries (`reading_summary.overview`) show again by default on BPH. They were hidden when PR #1955 wrapped all AI prose in `<AISection>` (BPH default-hides AI). The works have since been editorially reviewed.

- The init script now distinguishes an **explicit** "Hide AI" opt-out (`data-sl-hide-ai="1"`) from the **BPH implicit default** (`"default"`).
- A new `ai-summary-catalog` section hides **only on the explicit opt-out** — so the gear toggle still works, but the catalogue leads with the summary.
- Book intros and reading guides are **unchanged** — still default-hidden on BPH.

## Out of scope
- Catalogue *list/browser* rows don't render summaries, so this only touches the catalogue **entry** page.
- No change to the book-reading-page AI default (stays hidden on BPH per Paul's request).
- The known catalogue search/toggle param-loss bugs (`.claude/handoffs/2026-05-28-bph-catalog-browser-bugs.md`) are separate and not addressed here.

## Test notes
- `npx tsc --noEmit`: no errors in changed files (the 14 reported are pre-existing `@types/d3` gaps in unrelated carbon-ledger blog components, surfaced only by this fresh worktree's node_modules).
- Verify on the real subdomain `bph.sourcelibrary.org` (not the `/embed/bph` path) — the gear/search chrome and the init script run on the global routes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)