### PR TITLE
feat(research): Translation Gap census page (/research/translation-gap)

### DIFF
--- a/public/data/ustc-translation-census.csv
+++ b/public/data/ustc-translation-census.csv
@@ -1,0 +1,182 @@
+language,total_works,total_editions,works_with_translation,editions_with_translation,pct_works_translated,distinct_authors,authors_with_translation
+Latin,444120,502554,8644,14862,1.95,46734,402
+German,295566,336870,419,549,0.14,17050,80
+French,194874,232848,1615,2985,0.83,12164,175
+English,149462,162857,553,654,0.37,8130,130
+Italian,101335,110090,576,783,0.57,11822,96
+Dutch,82651,113658,462,649,0.56,6720,75
+Spanish,76472,83534,340,517,0.44,9569,64
+Greek,8509,9677,132,168,1.55,1988,56
+Swedish,7026,7860,7,11,0.1,914,6
+Portuguese,6598,6979,18,20,0.27,962,12
+Czech,5645,5888,45,48,0.8,1067,15
+Polish,4002,4268,35,39,0.87,1248,21
+Hebrew,3827,4107,2,2,0.05,1064,2
+Catalan,3704,3861,15,20,0.4,545,10
+Danish,1882,2058,8,10,0.43,432,5
+Hungarian,1639,1738,7,7,0.43,423,4
+Low German,1473,1516,8,8,0.54,311,4
+Finnish,370,410,0,0,0.0,63,0
+mixed,282,292,3,3,1.06,142,3
+Icelandic,261,278,0,0,0.0,72,0
+Aramaic,204,219,0,0,0.0,76,0
+Arabic,191,209,0,0,0.0,96,0
+Church Slavonic,190,212,0,0,0.0,26,0
+Welsh,185,192,1,1,0.54,60,1
+Greek/Latin,103,103,5,5,4.85,55,4
+Romansh,81,82,0,0,0.0,32,0
+Armenian,80,82,2,2,2.5,22,2
+Multilingual,73,82,1,1,1.37,38,1
+Sicilian,72,72,1,1,1.39,41,1
+Latin/German,70,70,0,0,0.0,52,0
+Croatian,63,63,0,0,0.0,33,0
+Breton,61,69,0,0,0.0,12,0
+Nahuatl,50,53,0,0,0.0,25,0
+Estonian,49,60,0,0,0.0,6,0
+Basque,47,51,0,0,0.0,21,0
+Law French,40,43,1,1,2.5,7,1
+Lithuanian,38,43,0,0,0.0,20,0
+Latvian,33,46,0,0,0.0,7,0
+German/Latin,32,32,2,2,6.25,23,2
+Yiddish,31,31,0,0,0.0,14,0
+Provençal,26,28,0,0,0.0,12,0
+French/German,26,26,0,0,0.0,11,0
+Romanian,25,39,0,0,0.0,2,0
+Hebrew/Latin,23,23,0,0,0.0,14,0
+French/Latin,21,28,2,2,9.52,9,2
+Russian,20,20,0,0,0.0,6,0
+Irish,18,20,0,0,0.0,8,0
+Occitan,18,18,0,0,0.0,10,0
+Latin/French,18,19,2,2,11.11,9,2
+Slovenian,17,17,0,0,0.0,4,0
+Gascon,16,16,0,0,0.0,5,0
+Latin/Spanish,15,15,0,0,0.0,2,0
+Greek and Latin,15,15,0,0,0.0,9,0
+Sami,12,13,0,0,0.0,4,0
+Japanese,12,12,0,0,0.0,7,0
+Ruthenian,11,11,0,0,0.0,5,0
+Spanish/Latin,10,10,0,0,0.0,2,0
+Gaelic,9,9,0,0,0.0,2,0
+Algonquian,9,9,0,0,0.0,4,0
+Mixed,8,8,0,0,0.0,4,0
+Albanian,8,8,0,0,0.0,2,0
+Poitevin,7,7,0,0,0.0,4,0
+Aymara,7,8,0,0,0.0,3,0
+Illyrian,7,7,0,0,0.0,6,0
+Ethiopic,6,6,0,0,0.0,4,0
+Latin/Italian,6,6,2,2,33.33,2,2
+Béarnais,6,6,0,0,0.0,3,0
+Purépecha,6,6,0,0,0.0,2,0
+Syriac,6,6,0,0,0.0,0,0
+German/Italian,5,5,0,0,0.0,3,0
+Mexican,5,5,0,0,0.0,4,0
+Tagalog,5,5,0,0,0.0,4,0
+Amharic,5,5,0,0,0.0,2,0
+Italian/Latin,5,5,1,1,20.0,4,1
+Malay,5,5,0,0,0.0,1,0
+Guarani,4,4,0,0,0.0,2,0
+German/French,4,4,0,0,0.0,2,0
+Bosnian,4,4,0,0,0.0,4,0
+Quechuan,4,4,0,0,0.0,3,0
+Latin/Dutch,3,3,0,0,0.0,2,0
+Quichua,3,3,0,0,0.0,3,0
+Scots,3,3,0,0,0.0,2,0
+Slovak,3,3,0,0,0.0,2,0
+Provencal,3,3,0,0,0.0,1,0
+other,3,3,0,0,0.0,3,0
+French/Italian,3,3,0,0,0.0,2,0
+Arabic/Latin,3,3,0,0,0.0,2,0
+Dutch/French,3,3,0,0,0.0,2,0
+Dutch/Latin,3,3,0,0,0.0,3,0
+Latin/Greek,3,3,0,0,0.0,2,0
+Pangasinan,2,2,0,0,0.0,2,0
+Swedish/Latin,2,2,0,0,0.0,1,0
+Judaeo-Spanish,2,2,0,0,0.0,2,0
+Spanish/Italian,2,2,0,0,0.0,2,0
+Serbo-Croatian,2,2,0,0,0.0,0,0
+Konkani,2,2,0,0,0.0,2,0
+Spanish/French,2,2,0,0,0.0,2,0
+French and German,2,2,0,0,0.0,0,0
+Allentiac,2,2,0,0,0.0,1,0
+Latin/Polish,2,2,0,0,0.0,2,0
+Latin/Catalan,2,2,1,1,50.0,1,1
+Scottish Gaelic,2,2,0,0,0.0,2,0
+Quechua,2,2,0,0,0.0,2,0
+French and Dutch,2,2,0,0,0.0,0,0
+Farsi,2,2,0,0,0.0,2,0
+Georgian,2,2,0,0,0.0,2,0
+Sorbian,2,2,0,0,0.0,1,0
+French/Spanish,2,2,0,0,0.0,2,0
+Frisian,2,2,0,0,0.0,1,0
+Coptic,2,2,0,0,0.0,0,0
+French/Dutch,2,2,0,0,0.0,1,0
+,1,1,0,0,0.0,0,0
+Anglo-Saxon,1,1,0,0,0.0,1,0
+Armenian and Italian,1,1,0,0,0.0,1,0
+Bantu,1,1,0,0,0.0,1,0
+Bergamasque,1,1,0,0,0.0,0,0
+Bikol,1,1,0,0,0.0,1,0
+Bisaya,1,1,0,0,0.0,1,0
+Bisayan,1,1,0,0,0.0,1,0
+Bramana Marasta,1,1,0,0,0.0,1,0
+Carib,1,1,0,0,0.0,1,0
+Catalan and Latin,1,1,0,0,0.0,0,0
+Catalan/Spanish,1,1,0,0,0.0,0,0
+Chiapaneca,1,1,0,0,0.0,1,0
+Chilean,1,1,0,0,0.0,1,0
+Chinese,1,1,0,0,0.0,0,0
+Corsican,1,1,0,0,0.0,1,0
+Cumanagoto,1,1,0,0,0.0,1,0
+Czech/German,1,1,0,0,0.0,0,0
+Danish/Latin,1,1,0,0,0.0,1,0
+Dutch Low Saxon,1,1,0,0,0.0,0,0
+English and French,1,1,0,0,0.0,0,0
+English and Latin,1,1,0,0,0.0,1,0
+French and Latin,1,1,0,0,0.0,0,0
+"French, Italian, Spanish, German",1,1,0,0,0.0,1,0
+French/German/Latin,1,1,0,0,0.0,1,0
+Geʽez,1,1,0,0,0.0,1,0
+German and French,1,1,0,0,0.0,0,0
+German and Latin,1,1,0,0,0.0,0,0
+German/Polish,1,1,0,0,0.0,0,0
+German/Slovenian,1,1,0,0,0.0,1,0
+German/Spanish,1,1,0,0,0.0,0,0
+Greek/Italian,1,1,0,0,0.0,1,0
+Hebrew/German,1,1,0,0,0.0,1,0
+Huasteca,1,1,0,0,0.0,1,0
+Italian & Latin,1,1,0,0,0.0,1,0
+Italian/French,1,1,0,0,0.0,1,0
+Kapampangan,1,1,0,0,0.0,1,0
+Kiriri,1,1,0,0,0.0,1,0
+Latin and Dutch,1,1,0,0,0.0,1,0
+Latin and French,1,3,0,0,0.0,1,0
+Latin/Arabic,1,1,0,0,0.0,1,0
+Latin/Danish,1,1,0,0,0.0,1,0
+Latin/Dutch/French,1,1,0,0,0.0,0,0
+Latin/English,1,1,1,1,100.0,1,1
+Latin/French/German,1,1,0,0,0.0,1,0
+Latin/German/Italian,1,1,0,0,0.0,1,0
+Latin/Hungarian,1,1,0,0,0.0,1,0
+Malay/Latin,1,1,0,0,0.0,1,0
+Mame,1,1,0,0,0.0,1,0
+Manx,1,1,0,0,0.0,0,0
+Matlatzinca,1,1,0,0,0.0,1,0
+Mayan,1,1,0,0,0.0,1,0
+Mazahua,1,1,0,0,0.0,1,0
+Middle German,1,1,0,0,0.0,0,0
+Mixtec,1,1,0,0,0.0,1,0
+Nahuatl (Mexicano),1,1,0,0,0.0,1,0
+Native American (Algonquian),1,1,0,0,0.0,0,0
+Old English,1,1,0,0,0.0,1,0
+Old Gothic,1,1,0,0,0.0,1,0
+Old Prussian,1,1,0,0,0.0,1,0
+Old Prussian/German,1,1,0,0,0.0,1,0
+Other,1,1,0,0,0.0,1,0
+Panayana,1,1,0,0,0.0,1,0
+Philippino,1,1,0,0,0.0,1,0
+Polish/German,1,1,0,0,0.0,1,0
+"Spanish, Latin",1,1,0,0,0.0,1,0
+Spanish/Basque,1,1,0,0,0.0,0,0
+Swedish/Greek,1,1,0,0,0.0,1,0
+Turkish,1,1,0,0,0.0,0,0
+,1,1,0,0,0.0,0,0

--- a/src/app/research/translation-gap/page.tsx
+++ b/src/app/research/translation-gap/page.tsx
@@ -17,6 +17,7 @@ export const metadata: Metadata = {
 };
 
 // Snapshot from translation_census_by_language (Supabase), May 2026.
+// Static dated snapshot — refresh from the census view when sources are added.
 // Denominator: USTC (~1.4M distinct works); numerator: 30-source federated catalogue.
 const LANGS = [
   { lang: 'Latin', works: 444120, tr: 8644, pct: 1.95 },

--- a/src/app/research/translation-gap/page.tsx
+++ b/src/app/research/translation-gap/page.tsx
@@ -1,0 +1,218 @@
+import { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+
+export const revalidate = false;
+
+export const metadata: Metadata = {
+  title: 'The Translation Gap — Source Library Research',
+  description:
+    'Of ~1.4 million early-modern works in the Universal Short Title Catalogue, how many have a known modern translation? A federated, authority-reconciled census. About one in a hundred.',
+  alternates: { canonical: '/research/translation-gap' },
+  openGraph: {
+    title: 'The Translation Gap',
+    description:
+      'Of ~1.4 million early-modern works, roughly 1% have a known modern translation. A federated census against the Universal Short Title Catalogue.',
+  },
+};
+
+// Snapshot from translation_census_by_language (Supabase), May 2026.
+// Denominator: USTC (~1.4M distinct works); numerator: 30-source federated catalogue.
+const LANGS = [
+  { lang: 'Latin', works: 444120, tr: 8644, pct: 1.95 },
+  { lang: 'German', works: 295566, tr: 419, pct: 0.14 },
+  { lang: 'French', works: 194874, tr: 1615, pct: 0.83 },
+  { lang: 'English', works: 149462, tr: 553, pct: 0.37 },
+  { lang: 'Italian', works: 101335, tr: 576, pct: 0.57 },
+  { lang: 'Dutch', works: 82651, tr: 462, pct: 0.56 },
+  { lang: 'Spanish', works: 76472, tr: 340, pct: 0.44 },
+  { lang: 'Greek (anc.)', works: 8509, tr: 132, pct: 1.55 },
+  { lang: 'Czech', works: 5645, tr: 45, pct: 0.8 },
+  { lang: 'Polish', works: 4002, tr: 35, pct: 0.87 },
+];
+const MAXPCT = 1.95;
+const ROBUSTNESS = [
+  { method: 'Exact title overlap (naïve)', works: '667', rate: '~2.10%' },
+  { method: '+ Latin incipit / bigram', works: '1,286', rate: '~2.24%' },
+  { method: '+ VIAF author reconciliation', works: '1,513', rate: '~2.29%' },
+  { method: 'Absolute ceiling (every plausible link)', works: '≤16,967', rate: '≤3.8%' },
+];
+const fmt = (n: number) => n.toLocaleString('en-US');
+
+function Stat({ n, unit, label }: { n: string; unit?: string; label: string }) {
+  return (
+    <div className="px-5 py-6 border-stone-200 [&:not(:last-child)]:border-r max-sm:[&:nth-child(odd)]:border-r max-sm:[&:nth-child(-n+2)]:border-b">
+      <div className="font-serif text-3xl md:text-4xl text-stone-900 tracking-tight">
+        {n}
+        {unit && <span className="text-amber-800 text-2xl">{unit}</span>}
+      </div>
+      <div className="font-body text-sm text-stone-500 mt-1.5 leading-snug">{label}</div>
+    </div>
+  );
+}
+
+function Section({ kicker, title, children }: { kicker: string; title: string; children: ReactNode }) {
+  return (
+    <section className="py-12 border-b border-stone-200">
+      <div className="font-body text-xs tracking-[0.16em] uppercase text-amber-700 font-semibold mb-3">{kicker}</div>
+      <h2 className="font-serif text-2xl md:text-3xl text-stone-900 mb-4 tracking-tight">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+export default function TranslationGapPage() {
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="The Translation Gap"
+          subtitle="The Universal Short Title Catalogue records roughly 1.4 million distinct works printed in Europe before 1700. How many can a modern reader actually read in translation? We built a federated, authority-reconciled census to find out — the short answer is about one in a hundred."
+        />
+      }
+    >
+      <div className="max-w-3xl mx-auto font-body text-stone-700 text-lg leading-relaxed">
+        {/* stat band */}
+        <div className="grid grid-cols-2 md:grid-cols-4 border border-stone-200 rounded-sm bg-stone-50 my-8">
+          <Stat n="1.39" unit="M" label="distinct early-modern works in the USTC corpus" />
+          <Stat n="~0.9" unit="%" label="have a known modern translation, across all languages" />
+          <Stat n="~2" unit="%" label="of the Latin corpus — the largest — is translated" />
+          <Stat n="30+" label="catalogues & publishers federated to count translations" />
+        </div>
+
+        <Section kicker="The map of the gap" title="What share of each language has been translated?">
+          <p className="mb-6 text-stone-600">
+            Each bar is the share of distinct works in that original language for which our census records a modern
+            translation (predominantly into English). Bars are scaled to the highest rate; absolute work counts are shown
+            beside each language.
+          </p>
+          <div className="space-y-2.5">
+            {LANGS.map((d) => (
+              <div key={d.lang} className="grid grid-cols-[7rem_1fr_5.5rem] items-center gap-3">
+                <div className="text-right font-body text-sm text-stone-800">
+                  {d.lang}
+                  <span className="block text-[11px] text-stone-400">{fmt(d.works)} works</span>
+                </div>
+                <div className="h-5 bg-stone-200 rounded-sm overflow-hidden">
+                  <div
+                    className="h-full rounded-sm bg-gradient-to-r from-amber-800 to-amber-900"
+                    style={{ width: `${Math.max((d.pct / MAXPCT) * 100, 1.5)}%` }}
+                  />
+                </div>
+                <div className="font-body text-sm font-semibold text-amber-800">
+                  {d.pct.toFixed(2)}% <span className="text-stone-400 font-normal">· {fmt(d.tr)}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-6 bg-stone-50 border-l-2 border-amber-600 rounded-r-sm px-5 py-4 text-base text-stone-700">
+            <div className="font-body text-xs tracking-wider uppercase text-amber-700 font-semibold mb-1">Read this carefully</div>
+            These are <strong>floors, not ceilings</strong> — they count translations we could find and verify. The Latin
+            figure (~2%) has been stress-tested across four matching methods and is robust; the smaller-language figures
+            have had less validation and should be read as lower bounds.
+          </div>
+        </Section>
+
+        <Section kicker="How it was built" title="Method">
+          <p className="mb-4">
+            <strong>The denominator — USTC.</strong> The Universal Short Title Catalogue is the standard census of
+            early-modern European print; its expansion to 1700 brings the total to <strong>~1.4 million distinct
+            works</strong> (USTC&rsquo;s own figure). The dataset used here comprises 1,391,970 distinct works across
+            1,593,766 edition records, in 181 languages. Latin alone accounts for 444,120 works (32%).
+          </p>
+          <p className="mb-4">
+            <strong>The numerator — a federated catalogue.</strong> Rather than trust any single source (each mislabels
+            facsimiles, misses scholarly editions, or has coverage holes), we pooled <strong>26,855 translation records
+            from 30+ sources</strong>: UNESCO Index Translationum, Library of Congress MARC, OpenLibrary, HathiTrust, the
+            Loeb Classical Library, Harvard&rsquo;s I Tatti and DOML, Brill, OUP, CUP, Yale, Chicago, Penguin, and curated
+            specialist series.
+          </p>
+          <p>
+            <strong>The hard part — reconciliation.</strong> A translation titled <em>&ldquo;Atalanta Fugiens: an edition
+            of the fugues, emblems and epigrams&rdquo;</em> shares almost no words with the Latin original{' '}
+            <em>&ldquo;Atalanta fugiens, hoc est, Emblemata nova&hellip;&rdquo;</em>. We match on Latin incipits and
+            reconcile author names through 80,912 VIAF / Wikidata / GND / CERL authority clusters (so &ldquo;Geber&rdquo;,
+            &ldquo;Jabir&rdquo;, and &ldquo;pseudo-Geber&rdquo; resolve to one identity), and grade every match on a tiered
+            completeness scale rather than a brittle yes/no.
+          </p>
+        </Section>
+
+        <Section kicker="Is the number real?" title="Why we believe ~2%">
+          <p className="mb-5 text-stone-600">
+            A low number could be an artifact of weak matching. So we stress-tested Latin with four matchers of increasing
+            sophistication. If recall were the problem, the figure would keep climbing. It doesn&rsquo;t:
+          </p>
+          <table className="w-full text-base border-collapse">
+            <thead>
+              <tr className="text-left font-body text-xs uppercase tracking-wider text-stone-500">
+                <th className="py-2.5 border-b border-stone-200 font-semibold">Matching method</th>
+                <th className="py-2.5 border-b border-stone-200 font-semibold text-right">Latin works linked</th>
+                <th className="py-2.5 border-b border-stone-200 font-semibold text-right">Implied rate</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ROBUSTNESS.map((r) => (
+                <tr key={r.method}>
+                  <td className="py-2.5 border-b border-stone-200">{r.method}</td>
+                  <td className="py-2.5 border-b border-stone-200 text-right tabular-nums">{r.works}</td>
+                  <td className="py-2.5 border-b border-stone-200 text-right tabular-nums font-semibold text-amber-800">{r.rate}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="mt-5 text-stone-600">
+            Each improvement adds less than the last. The figure converges in the <strong>2–2.3%</strong> range and cannot
+            exceed ~3.8% even if every author-matched record linked perfectly. The gap is structural, not a search failure:
+            most untranslated works are minor — disputations, sermons, dissertations — never rendered into a living
+            language.
+          </p>
+        </Section>
+
+        <Section kicker="What this is not" title="Caveats">
+          <ul className="list-disc pl-5 space-y-2.5">
+            <li><strong>Lower bounds.</strong> Every figure counts only translations we could locate and verify; true rates are somewhat higher, especially for non-Latin languages.</li>
+            <li><strong>&ldquo;Translation&rdquo; is graded, not binary.</strong> A few captions in English is not a complete scholarly edition; the headline counts lean toward substantial translations.</li>
+            <li><strong>USTC scope.</strong> The denominator is printed European books, c.1450–1700 — manuscripts, post-1700 editions, and non-European printing are out of frame.</li>
+            <li><strong>Residual name variants.</strong> Some pseudonymous and classical authors still resist reconciliation, nudging the true count up — but within the ~3.8% ceiling.</li>
+          </ul>
+          <div className="mt-6 bg-stone-50 border-l-2 border-amber-600 rounded-r-sm px-5 py-4 text-base text-stone-700">
+            <div className="font-body text-xs tracking-wider uppercase text-amber-700 font-semibold mb-1">The honest headline</div>
+            The ~2% is approximately real. The vast majority of the early-modern Latin corpus is{' '}
+            <strong>genuinely untranslated</strong> — not a measurement failure, but the size of the opportunity.
+          </div>
+        </Section>
+
+        <Section kicker="Help close it" title="Collaborate">
+          <p className="mb-6">
+            We&rsquo;re sharing the full per-language census and inviting catalogues, publishers, and scholars to add
+            sources and correct records. If you maintain translation data — or spot a work we&rsquo;ve miscounted — we want
+            to hear from you.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <a
+              href="/data/ustc-translation-census.csv"
+              download
+              className="font-body text-sm font-semibold bg-amber-800 hover:bg-amber-900 text-stone-50 px-6 py-3 rounded-sm transition-colors"
+            >
+              Download the data (CSV, 181 languages)
+            </a>
+            <a
+              href="mailto:derek@sourcelibrary.org?subject=The%20Translation%20Gap%20%E2%80%94%20collaboration"
+              className="font-body text-sm font-semibold border border-amber-800 text-amber-800 hover:bg-amber-50 px-6 py-3 rounded-sm transition-colors"
+            >
+              Get in touch
+            </a>
+          </div>
+        </Section>
+
+        <p className="py-8 font-body text-sm text-stone-500 leading-relaxed">
+          A data study by Source Library, May 2026. Denominator: the Universal Short Title Catalogue (University of St
+          Andrews); the ~1.39M distinct-work count is consistent with USTC&rsquo;s stated ~1.4 million distinct items for
+          its expansion to 1700. Translation census federated from 30+ catalogues and publishers; author reconciliation via
+          VIAF, Wikidata, GND, and CERL. Figures are conservative lower bounds and will be updated as sources are added.
+          Contact: <a className="text-amber-800 underline" href="mailto:derek@sourcelibrary.org">derek@sourcelibrary.org</a>.
+        </p>
+      </div>
+    </ContentPageLayout>
+  );
+}


### PR DESCRIPTION
## What
Adds a static research page at **/research/translation-gap** presenting the USTC translation-gap census: per-language translation rates (denominator: USTC ~1.4M distinct works), the 30-source federated-catalogue method, a four-matcher robustness analysis (naïve → incipit → VIAF-reconciled → ceiling), honest caveats, and a downloadable 181-language census CSV (`public/data/ustc-translation-census.csv`).

It mirrors the standalone resource already live at https://translation-gap-site.vercel.app — this is the in-app version at the canonical URL.

## Scope
- **In:** one new server page + one CSV asset. Static (data baked in as a dated snapshot from `translation_census_by_language`), wrapped in `ContentPageLayout`/`ContentHeader`, Tailwind, no new deps, no client JS.
- **Out (deliberately):** no live Supabase fetch (snapshot is intentional for a citable resource); no `translation_catalogs`→USTC alignment writes; no changes to the existing `/census` or `/research` index.

## Validation
- `check-imports` pre-commit hook passes.
- Type-checked via Vercel preview build (worktree has no local `node_modules`). Please confirm the preview renders before merge.

## Notes for review
- Figures are USTC-aligned: leads with ~1.4M distinct works (USTC's own stated figure), edition count framed as "edition records in the dataset." Reconcile against USTC's official numbers if anything looks off before external sharing.
- Contact email on the page: derek@sourcelibrary.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)