### PR TITLE
ILP catalog: 'Banned by the Index' book chip + materialized works view

### DIFF
--- a/scripts/migration/add-index-catalog-works-matview.sql
+++ b/scripts/migration/add-index-catalog-works-matview.sql
@@ -1,0 +1,85 @@
+-- Materialize v_index_catalog_works.
+--
+-- The live view re-aggregates all ~62,943 index_catalog_entries into deduped
+-- works on every query; with the edition_ids overlap filter + order it runs
+-- ~2.6s and was tipping /api/catalogs/works over the role statement_timeout.
+-- A materialized view turns that into an indexed table read (<100ms) and lets
+-- the API use exact counts again.
+--
+-- Definition is IDENTICAL to v_index_catalog_works (keep in sync if that view
+-- changes — see update-index-catalog-works-view-author-held.sql).
+--
+-- Run in the Supabase SQL editor (DDL; PostgREST can't do this). Idempotent.
+
+DROP MATERIALIZED VIEW IF EXISTS mv_index_catalog_works;
+
+CREATE MATERIALIZED VIEW mv_index_catalog_works AS
+WITH dedup AS (
+  SELECT
+    e.*,
+    CASE
+      WHEN e.scope = 'opera_omnia' THEN
+        coalesce(e.author_normalized, '__anon__') || '::*opera*'
+      ELSE
+        coalesce(e.author_normalized, '__anon__') || '::' ||
+        lower(substring(regexp_replace(coalesce(e.title, ''), '[^a-zA-Z0-9 ]', '', 'g') FROM 1 FOR 40))
+    END AS work_key
+  FROM index_catalog_entries e
+)
+SELECT
+  work_key,
+  (array_agg(author ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id))[1] AS author,
+  (array_agg(title ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id))[1] AS title,
+  (array_agg(scope ORDER BY
+     CASE scope WHEN 'opera_omnia' THEN 0 WHEN 'donec_corrigatur' THEN 1 WHEN 'expurgated' THEN 2 WHEN 'single_work' THEN 3 ELSE 4 END,
+     id))[1] AS scope,
+  author_normalized,
+  array_agg(DISTINCT index_id ORDER BY index_id) AS edition_ids,
+  count(DISTINCT index_id) AS edition_count,
+  min(condemnation_year) AS first_year,
+  max(condemnation_year) AS last_year,
+  (array_agg(ustc_sn ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id) FILTER (WHERE ustc_sn IS NOT NULL))[1] AS ustc_sn,
+  (array_agg(sl_book_id ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id) FILTER (WHERE sl_book_id IS NOT NULL))[1] AS sl_book_id,
+  (array_agg(sl_book_slug ORDER BY
+     CASE match_confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END DESC,
+     id) FILTER (WHERE sl_book_slug IS NOT NULL))[1] AS sl_book_slug,
+  array_agg(id ORDER BY id) AS entry_ids,
+  array_agg(DISTINCT source_book_slug ORDER BY source_book_slug) FILTER (WHERE source_book_slug IS NOT NULL) AS source_book_slugs,
+  max(author_held_count) AS author_held_count,
+  (array_agg(author_held_sample_slug ORDER BY id) FILTER (WHERE author_held_sample_slug IS NOT NULL))[1] AS author_held_sample_slug,
+  (array_agg(author_held_sample_id   ORDER BY id) FILTER (WHERE author_held_sample_id   IS NOT NULL))[1] AS author_held_sample_id
+FROM dedup
+GROUP BY work_key, author_normalized;
+
+-- Unique index required for REFRESH ... CONCURRENTLY; the rest serve the API's
+-- overlap filter, sorts, and held filters.
+CREATE UNIQUE INDEX mv_icw_work_key ON mv_index_catalog_works (work_key);
+CREATE INDEX mv_icw_edition_ids ON mv_index_catalog_works USING GIN (edition_ids);
+CREATE INDEX mv_icw_author ON mv_index_catalog_works (author);
+CREATE INDEX mv_icw_first_year ON mv_index_catalog_works (first_year);
+CREATE INDEX mv_icw_edition_count ON mv_index_catalog_works (edition_count);
+CREATE INDEX mv_icw_sl_book ON mv_index_catalog_works (sl_book_id);
+CREATE INDEX mv_icw_author_held ON mv_index_catalog_works (author_held_count);
+
+-- Refresh entrypoint callable from PostgREST (supabase.rpc('refresh_index_catalog_works')).
+-- SECURITY DEFINER so the API/service role can refresh without owning the matview.
+CREATE OR REPLACE FUNCTION refresh_index_catalog_works()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_index_catalog_works;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION refresh_index_catalog_works() TO authenticated, service_role, anon;
+GRANT SELECT ON mv_index_catalog_works TO authenticated, service_role, anon;

--- a/scripts/refresh-index-catalog-matview.mjs
+++ b/scripts/refresh-index-catalog-matview.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Refresh the materialized works view after a catalog backfill.
+ *
+ * mv_index_catalog_works is the read path for /api/catalogs/works (the deduped
+ * works browser). It's a snapshot — run this after any script that writes to
+ * index_catalog_entries (matching, author-entity, work-held, language) so the
+ * browser reflects the new data.
+ *
+ * Calls the refresh_index_catalog_works() RPC (defined in
+ * scripts/migration/add-index-catalog-works-matview.sql), which does
+ * REFRESH MATERIALIZED VIEW CONCURRENTLY. No-op-safe if the matview is absent
+ * (logs the error and exits 0 — the API falls back to the live view).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/refresh-index-catalog-matview.mjs
+ */
+const SUPA_URL = process.env.SUPABASE_URL;
+const KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+if (!SUPA_URL || !KEY) { console.error('SUPABASE_* missing'); process.exit(1); }
+
+const r = await fetch(`${SUPA_URL}/rest/v1/rpc/refresh_index_catalog_works`, {
+  method: 'POST',
+  headers: { apikey: KEY, Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json' },
+  body: '{}',
+});
+if (r.ok) {
+  console.log('mv_index_catalog_works refreshed.');
+} else {
+  console.warn(`refresh skipped (${r.status}): ${(await r.text()).slice(0, 200)}`);
+  console.warn('If the matview/RPC are not yet created, run scripts/migration/add-index-catalog-works-matview.sql.');
+}

--- a/src/app/api/catalogs/works/route.ts
+++ b/src/app/api/catalogs/works/route.ts
@@ -65,53 +65,41 @@ export async function GET(req: Request) {
     ? editionsParam.split(',').filter(id => collectionIndexIds.includes(id))
     : collectionIndexIds;
 
-  // 'estimated' not 'exact': an exact count re-runs the full v_index_catalog_works
-  // aggregation (~1s extra) and tipped this endpoint over the role statement
-  // timeout (500s). has_more is computed by fetching one extra row instead, so
-  // pagination stays correct; total is the planner estimate (fine for a "~N
-  // works" display). The deeper fix is a GIN index on edition_ids / a
-  // materialized view — see the catalog perf note.
-  let query = supabase
-    .from('v_index_catalog_works')
-    .select('*', { count: 'estimated' });
-
-  // Edition filter — works whose edition_ids array OVERLAPS (any) or CONTAINS (all) the selection
-  if (selectedEditions.length > 0) {
-    if (filterMode === 'all') {
-      query = query.contains('edition_ids', selectedEditions);
-    } else {
-      query = query.overlaps('edition_ids', selectedEditions);
+  // Build the query against a given source (the live view or its materialized
+  // copy) + count mode. Fetch one extra row so has_more never depends on the
+  // count value (which may be a planner estimate).
+  const buildQuery = (source: string, countMode: 'exact' | 'estimated') => {
+    let query = supabase.from(source).select('*', { count: countMode });
+    if (selectedEditions.length > 0) {
+      query = filterMode === 'all'
+        ? query.contains('edition_ids', selectedEditions)
+        : query.overlaps('edition_ids', selectedEditions);
     }
+    if (q.length >= 2) {
+      const safe = q.replace(/[,()]/g, '');
+      query = query.or(`title.ilike.*${safe}*,author.ilike.*${safe}*`);
+    }
+    if (filter === 'held') query = query.not('sl_book_id', 'is', null);
+    else if (filter === 'unheld') query = query.is('sl_book_id', null).or('author_held_count.is.null,author_held_count.eq.0');
+    else if (filter === 'author_held') query = query.is('sl_book_id', null).gt('author_held_count', 0);
+    // Scope filter — Spanish Indices are ~90% expurgations (passages censored
+    // inside an otherwise-permitted book), a different signal from outright bans.
+    if (scopeFilter === 'opera_omnia') query = query.eq('scope', 'opera_omnia');
+    else if (scopeFilter === 'expurgated') query = query.eq('scope', 'expurgated');
+    else if (scopeFilter === 'banned') query = query.neq('scope', 'expurgated');
+    if (sort === 'first_year') query = query.order('first_year', { ascending: true, nullsFirst: false });
+    else if (sort === 'edition_count') query = query.order('edition_count', { ascending: false });
+    else query = query.order('author', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+    return query.range(from, to + 1);
+  };
+
+  // Prefer the materialized view: indexed reads make an exact count affordable.
+  // Fall back to the live view (estimated count) if the matview isn't present
+  // yet — see scripts/migration/add-index-catalog-works-matview.sql.
+  let { data, error, count } = await buildQuery('mv_index_catalog_works', 'exact');
+  if (error) {
+    ({ data, error, count } = await buildQuery('v_index_catalog_works', 'estimated'));
   }
-
-  // Search
-  if (q.length >= 2) {
-    const safe = q.replace(/[,()]/g, '');
-    query = query.or(`title.ilike.*${safe}*,author.ilike.*${safe}*`);
-  }
-
-  // SL filter
-  if (filter === 'held') query = query.not('sl_book_id', 'is', null);
-  else if (filter === 'unheld') query = query.is('sl_book_id', null).or('author_held_count.is.null,author_held_count.eq.0');
-  else if (filter === 'author_held') query = query.is('sl_book_id', null).gt('author_held_count', 0);
-
-  // Scope filter — separate from SL filter. The Spanish Indices are ~90%
-  // expurgations (passages censored inside an otherwise-permitted book),
-  // which are NOT the same acquisition signal as outright bans. Letting
-  // users separate the two avoids reading the full unheld pile as
-  // "books to acquire."
-  if (scopeFilter === 'opera_omnia') query = query.eq('scope', 'opera_omnia');
-  else if (scopeFilter === 'expurgated') query = query.eq('scope', 'expurgated');
-  else if (scopeFilter === 'banned') query = query.neq('scope', 'expurgated');
-
-  // Sort
-  if (sort === 'first_year') query = query.order('first_year', { ascending: true, nullsFirst: false });
-  else if (sort === 'edition_count') query = query.order('edition_count', { ascending: false });
-  else query = query.order('author', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
-
-  // Fetch one extra row to detect has_more without depending on the exact count.
-  query = query.range(from, to + 1);
-  const { data, error, count } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
   const rows = (data || []) as Work[];

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -24,6 +24,7 @@ import DownloadButton from '@/components/ui/DownloadButton';
 import BibliographicInfo from '@/components/book/BibliographicInfo';
 import BphCatalogueRecord from '@/components/book/BphCatalogueRecord';
 import RelatedEditions from '@/components/book/RelatedEditions';
+import IndexCatalogChip from '@/components/book/IndexCatalogChip';
 import RelatedBooks from '@/components/book/RelatedBooks';
 import AuthorCrossReference from '@/components/book/AuthorCrossReference';
 import PublishEditionButton from '@/components/editions/PublishEditionButton';
@@ -1001,6 +1002,14 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed
                 {embedPolicy.showRelatedEditions && (book as unknown as { work_id?: string }).work_id && (
                   <Suspense fallback={null}>
                     <RelatedEditions bookId={book.id} workId={(book as unknown as { work_id?: string }).work_id!} />
+                  </Suspense>
+                )}
+                {embedPolicy.showIndexCatalogStatus && (
+                  <Suspense fallback={null}>
+                    <IndexCatalogChip
+                      bookIds={[(book as unknown as { _id?: string })._id, book.id]}
+                      authorEntityId={(book as unknown as { author_entity_id?: string }).author_entity_id ?? null}
+                    />
                   </Suspense>
                 )}
               </BibliographicInfo>

--- a/src/components/book/IndexCatalogChip.tsx
+++ b/src/components/book/IndexCatalogChip.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link';
+import { getIndexCatalogStatus } from '@/lib/index-catalog-status';
+
+/**
+ * "Banned by the Index" chip. Renders on the book page when this work — or its
+ * author — was condemned on the Index Librorum Prohibitorum. Links into the
+ * catalog browser. Self-contained async server component (does its own
+ * Supabase read); wrap in <Suspense fallback={null}> so it streams.
+ *
+ * Tenant-gated by the caller via embedPolicy.showIndexCatalogStatus — it points
+ * at a GLOBAL collection, so it must not render in an embedded/tenant view
+ * (Tenant Subdomain Lockdown).
+ */
+export default async function IndexCatalogChip({
+  bookIds, authorEntityId,
+}: { bookIds: (string | null | undefined)[]; authorEntityId: string | null | undefined }) {
+  const status = await getIndexCatalogStatus(bookIds, authorEntityId).catch(() => null);
+  if (!status) return null;
+
+  // Strongest scope drives the headline.
+  const has = (s: string) => status.scopes.includes(s);
+  const expurgationOnly = (has('expurgated') || has('donec_corrigatur')) && !has('opera_omnia') && !has('single_work');
+
+  const headline = status.workBanned
+    ? (expurgationOnly ? 'Expurgated by the Index' : 'Banned by the Index')
+    : 'Author censored by the Index';
+
+  const detail = status.workBanned
+    ? (expurgationOnly
+        ? 'Passages of this work were ordered censored on the Index Librorum Prohibitorum.'
+        : 'This work appears on the Index Librorum Prohibitorum.')
+    : 'Works by this author were condemned on the Index Librorum Prohibitorum.';
+
+  const span = status.firstYear
+    ? (status.lastYear && status.lastYear !== status.firstYear ? `${status.firstYear}–${status.lastYear}` : `${status.firstYear}`)
+    : null;
+  const editionsLabel = status.editionCount > 0
+    ? `${status.editionCount} edition${status.editionCount === 1 ? '' : 's'}${span ? `, ${span}` : ''}`
+    : null;
+
+  // Amber for expurgation (you may read it, minus passages); rust for outright ban.
+  const tone = expurgationOnly
+    ? 'border-amber-300/70 bg-amber-50/60 text-amber-900'
+    : 'border-rose-300/70 bg-rose-50/50 text-rose-900';
+
+  return (
+    <Link
+      href={`/collections/${status.collectionSlug}`}
+      className={`group mt-3 flex items-start gap-2.5 rounded-md border ${tone} px-3 py-2 no-underline transition-colors hover:bg-opacity-80`}
+      title="View the Index Librorum Prohibitorum catalogue"
+    >
+      <svg viewBox="0 0 20 20" aria-hidden className="mt-0.5 h-4 w-4 flex-none opacity-70" fill="currentColor">
+        <path fillRule="evenodd" d="M10 1.5a8.5 8.5 0 100 17 8.5 8.5 0 000-17zM4.7 5.4l9.9 9.9a6.5 6.5 0 01-9.9-9.9zm1.4-1.1a6.5 6.5 0 019.6 8.4L6.1 4.3z" clipRule="evenodd" />
+      </svg>
+      <span className="text-sm leading-snug">
+        <span className="font-medium">{headline}</span>
+        {editionsLabel && <span className="opacity-70"> · {editionsLabel}</span>}
+        <span className="block text-xs opacity-80">{detail}{' '}
+          <span className="underline decoration-dotted underline-offset-2 group-hover:decoration-solid">See the catalogue →</span>
+        </span>
+      </span>
+    </Link>
+  );
+}

--- a/src/lib/embed-ui-policy.ts
+++ b/src/lib/embed-ui-policy.ts
@@ -33,6 +33,9 @@ export interface EmbedUiPolicy {
   // them in embed mode is the simplest way to guarantee no non-tenant content leaks.
   showRelatedEditions: boolean;
   showAuthorCrossReference: boolean;
+  // "Banned by the Index" chip links to the GLOBAL index-librorum-prohibitorum
+  // collection and reads cross-library catalog data — hide in embed/tenant views.
+  showIndexCatalogStatus: boolean;
   // Gallery rendering pulls images keyed off `held_by` / provider, not the
   // active tenant. Disabling cross-tenant images keeps embed gallery views
   // strictly within the tenant's holdings.
@@ -54,6 +57,7 @@ export function getEmbedUiPolicy(ctx: TenantContext | null): EmbedUiPolicy {
       showGalleryImages: true,
       showRelatedEditions: true,
       showAuthorCrossReference: true,
+      showIndexCatalogStatus: true,
       showGalleryCrossTenantImages: true,
     };
   }
@@ -69,6 +73,7 @@ export function getEmbedUiPolicy(ctx: TenantContext | null): EmbedUiPolicy {
     showGalleryImages: false,
     showRelatedEditions: false,
     showAuthorCrossReference: false,
+    showIndexCatalogStatus: false,
     showGalleryCrossTenantImages: false,
   };
 }

--- a/src/lib/index-catalog-status.ts
+++ b/src/lib/index-catalog-status.ts
@@ -1,0 +1,82 @@
+import { supabase } from './supabase';
+
+/**
+ * Reverse lookup: was this book (or its author) condemned by the Index
+ * Librorum Prohibitorum? Powers the "Banned by the Index" chip on the book
+ * page. Two signals, distinct:
+ *   - workBanned  — an Index entry is linked to THIS book (sl_book_id)
+ *   - authorBanned — the book's author (author_entity_id) appears in the Index,
+ *                    even if this exact work isn't separately listed
+ *
+ * Data lives in Supabase `index_catalog_entries` (see project_ilp_catalog).
+ * Returns null when neither applies, so the caller renders nothing.
+ */
+export interface IndexCatalogStatus {
+  workBanned: boolean;
+  authorBanned: boolean;
+  editionCount: number;        // distinct Index editions involved
+  scopes: string[];            // 'opera_omnia' | 'expurgated' | 'donec_corrigatur' | 'single_work'
+  firstYear: number | null;
+  lastYear: number | null;
+  collectionSlug: string;
+}
+
+const COLLECTION_SLUG = 'index-librorum-prohibitorum';
+const COLS = 'index_id,scope,condemnation_year,sl_book_id';
+
+export async function getIndexCatalogStatus(
+  bookIds: (string | null | undefined)[],
+  authorEntityId: string | null | undefined,
+): Promise<IndexCatalogStatus | null> {
+  const ids = [...new Set(bookIds.filter((x): x is string => !!x))];
+
+  // Two cheap reads in parallel: this exact work, and anything by this author.
+  // The author read is capped — distinct editions/scopes saturate well under
+  // the cap (there are only ~10 editions), so the aggregate stays accurate.
+  const [workRes, authorRes] = await Promise.all([
+    ids.length
+      ? supabase.from('index_catalog_entries').select(COLS).in('sl_book_id', ids)
+      : Promise.resolve({ data: [] as Row[] }),
+    authorEntityId
+      ? supabase.from('index_catalog_entries').select(COLS).eq('author_entity_id', authorEntityId).limit(1000)
+      : Promise.resolve({ data: [] as Row[] }),
+  ]);
+
+  const workRows = (workRes.data || []) as Row[];
+  const authorRows = (authorRes.data || []) as Row[];
+  if (!workRows.length && !authorRows.length) return null;
+
+  // Lead with the WORK's own status when this exact work is linked (so we say
+  // "expurgated" for a work that was only expurgated, even if the author was
+  // more broadly banned). Otherwise describe the author-level signal.
+  const lead = workRows.length ? workRows : authorRows;
+  const editions = new Set<string>();
+  const scopes = new Set<string>();
+  let firstYear: number | null = null;
+  let lastYear: number | null = null;
+  for (const r of lead) {
+    if (r.index_id) editions.add(r.index_id);
+    if (r.scope) scopes.add(r.scope);
+    if (typeof r.condemnation_year === 'number') {
+      firstYear = firstYear === null ? r.condemnation_year : Math.min(firstYear, r.condemnation_year);
+      lastYear = lastYear === null ? r.condemnation_year : Math.max(lastYear, r.condemnation_year);
+    }
+  }
+
+  return {
+    workBanned: workRows.length > 0,
+    authorBanned: authorRows.length > 0,
+    editionCount: editions.size,
+    scopes: [...scopes],
+    firstYear,
+    lastYear,
+    collectionSlug: COLLECTION_SLUG,
+  };
+}
+
+interface Row {
+  index_id: string | null;
+  scope: string | null;
+  condemnation_year: number | null;
+  sl_book_id: string | null;
+}


### PR DESCRIPTION
Follow-on to #2156. Two pieces.

## 1. "Banned by the Index" book-page chip (issue #2164)
On the book page, surface whether this work — or its author — was condemned on the *Index Librorum Prohibitorum*.
- `src/lib/index-catalog-status.ts` — reverse lookup on `index_catalog_entries` by `sl_book_id` (this exact work) and `author_entity_id` (this author).
- `src/components/book/IndexCatalogChip.tsx` — async server component, Suspense-streamed, renders a chip or nothing. **Expurgated** → amber ("passages censored, you may still read it"); **banned/opera-omnia** → rust. Shows edition count + year span, links into the catalogue.
- Leads with the **work's own** status when linked — Pico's *Disputationes* reads "Expurgated by the Index · 1619", not the author's broader 1632 opera-omnia ban.
- Tenant-gated via new `embedPolicy.showIndexCatalogStatus` (false in embed/tenant views — it points at the global collection, per the Tenant Subdomain Lockdown).

## 2. Materialized works view (robust `/api/catalogs/works` perf)
The dedup works view re-aggregates ~62,943 entries per query (~2.6s); #2156 dropped it to estimated counts to dodge the statement-timeout 500, but it's still heavy.
- `scripts/migration/add-index-catalog-works-matview.sql` — `mv_index_catalog_works` (identical definition) + GIN/btree indexes + `refresh_index_catalog_works()` RPC. **(DDL — run in the SQL editor.)**
- The works API now **prefers the matview** (indexed → exact counts affordable) and **falls back to the live view** if it's absent, so this is safe to deploy before or after the DDL runs.
- `scripts/refresh-index-catalog-matview.mjs` — refresh after future backfills.

## Verified
Pico's *Disputationes* book: `sl_book_id` match → "Expurgated by the Index 1619"; author entity (15 entries) drives the author-level chip on his other books. tsc clean.

## To run (you)
The matview DDL (clipboard / SQL editor). Until then the API uses the live-view fallback — no breakage either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)