### PR TITLE
fix(bph): make the gear control a clean circle matching the search icon

### DIFF
--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -245,7 +245,7 @@ export default function EmbedUserMenu() {
       )}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-2 py-1 rounded-full bg-white/90 backdrop-blur-sm border border-border-light shadow-sm hover:bg-white transition-colors"
+        className="flex items-center justify-center w-9 h-9 rounded-full bg-white/90 backdrop-blur-sm border border-border-light shadow-sm hover:bg-white transition-colors"
         aria-label={session ? 'Account & view options' : 'View options'}
       >
         {session ? (


### PR DESCRIPTION
Cosmetic follow-up to #2170. The floating gear was a `px-2 py-1` pill (reads as a slight oval); the collapsed search icon next to it is a clean `w-9 h-9` circle. This matches the gear to the same fixed circle so the two controls look consistent.

One-line className change in `EmbedUserMenu`; covers both the anonymous (Settings icon) and signed-in (avatar/initials) states since the inner content stays `w-7 h-7` centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)