### PR TITLE
ILP catalogue: wire the searchable browser into the collection page + scanned-folio links + VIAF fix

### DIFF
--- a/src/app/api/catalogs/[index_id]/entries/route.ts
+++ b/src/app/api/catalogs/[index_id]/entries/route.ts
@@ -52,7 +52,7 @@ export async function GET(
   let query = supabase
     .from('index_catalog_entries')
     .select(
-      'id, source_id, title, author, publication_date, condemnation_year, condemnation_period, scope, reason, ustc_sn, sl_book_id, sl_book_slug, author_held_count, author_held_sample_slug',
+      'id, source_id, title, author, publication_date, condemnation_year, condemnation_period, scope, reason, ustc_sn, sl_book_id, sl_book_slug, author_held_count, author_held_sample_slug, source_book_slug, source_page',
       { count: 'exact' },
     )
     .eq('index_id', index_id);

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -10,6 +10,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { notFound } from 'next/navigation';
 import CollectionSchema from '@/components/seo/CollectionSchema';
 import CollectionAllBooks from '@/components/collections/CollectionAllBooks';
+import IndexCatalogBrowser from '@/components/collections/IndexCatalogBrowser';
 import ExhibitionLayout from '@/components/collections/ExhibitionLayout';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { bookUrl, tenantBookUrl } from '@/lib/slugify';
@@ -1210,6 +1211,12 @@ export default async function CollectionDetailPage({ params, provider }: Props &
             )}
           </div>
         )}
+
+        {/* Index Librorum Prohibitorum catalogue browser — self-gates (renders
+            only for collections that have index_catalogs editions). */}
+        <React.Suspense fallback={null}>
+          <IndexCatalogBrowser collectionSlug={id} />
+        </React.Suspense>
 
         {/* All Books — client component handles compact → expanded transition */}
         <CollectionAllBooks

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -234,7 +234,12 @@ export default function BibliographicInfo({
               const canonicalName = book.author_canonical_name;
               const viafId = book.author_viaf_id;
               const wikidataQid = book.author_wikidata_qid;
-              const hasCanonical = !!(book.author_entity_id || viafId || wikidataQid || canonicalName);
+              // Require an actual displayable authority value. A book linked by
+              // author_entity_id ALONE (no denormalized viaf/canonical) was
+              // rendering "Standard name: VIAF undefined" here — the rich
+              // authority for those books comes from <AuthorAuthority>, fed by
+              // the entity record, so this denormalized row should stay silent.
+              const hasCanonical = !!(canonicalName || viafId || wikidataQid);
               return (
                 <>
                   {showAuthorRow && (
@@ -249,7 +254,7 @@ export default function BibliographicInfo({
                     <div className="flex gap-2">
                       <span className="text-stone-500 w-24 flex-shrink-0">Standard name:</span>
                       <span className="text-stone-200 flex flex-wrap items-baseline gap-x-2">
-                        {canonicalName || `VIAF ${viafId}`}
+                        {canonicalName || (viafId ? `VIAF ${viafId}` : null)}
                         {viafId && (
                           <a
                             href={`https://viaf.org/viaf/${viafId}`}

--- a/src/components/collections/IndexCatalogBrowser.tsx
+++ b/src/components/collections/IndexCatalogBrowser.tsx
@@ -1,0 +1,111 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { BookMarked } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+import { getReadDb } from '@/lib/mongodb';
+import IndexCatalogSection from './IndexCatalogSection';
+
+/**
+ * The Index catalogue browser, mounted on a collection page that has catalog
+ * editions (index_catalogs.collection_slug === the collection). Two halves:
+ *   1. "The printed editions" — the actual scanned Index volumes we hold, each
+ *      linking to the book so a reader meets the primary source itself.
+ *   2. <IndexCatalogSection> — the searchable, per-edition, held-filtered
+ *      browser of all entries, each linking to the exact scanned folio.
+ *
+ * Self-gating: returns null for collections with no catalog editions, so it's
+ * safe to render unconditionally on every collection page.
+ */
+export default async function IndexCatalogBrowser({ collectionSlug }: { collectionSlug: string }) {
+  const { data: editionsRaw } = await supabase
+    .from('index_catalogs')
+    .select('id, name, short_name, start_year, entry_count, source_url')
+    .eq('collection_slug', collectionSlug)
+    .order('start_year', { ascending: true });
+  const editions = editionsRaw || [];
+  if (!editions.length) return null;
+
+  const slugFor = (e: { source_url: string | null }) =>
+    (e.source_url || '').split('/book/')[1]?.replace(/\/$/, '') || null;
+
+  // Per-edition held count + scanned-volume thumbnails, in parallel.
+  const [heldCounts, books] = await Promise.all([
+    Promise.all(editions.map(async (e) => {
+      const { count } = await supabase
+        .from('index_catalog_entries')
+        .select('id', { count: 'exact', head: true })
+        .eq('index_id', e.id)
+        .not('sl_book_id', 'is', null);
+      return count ?? 0;
+    })),
+    (async () => {
+      const slugs = editions.map(slugFor).filter((s): s is string => !!s);
+      const db = await getReadDb();
+      const rows = await db.collection('books')
+        .find({ slug: { $in: slugs } }, { projection: { _id: 0, slug: 1, thumbnail: 1, image_thumb: 1, title: 1 } })
+        .toArray();
+      return new Map(rows.map((b) => [b.slug as string, b]));
+    })(),
+  ]);
+
+  const totalEntries = editions.reduce((s, e) => s + (e.entry_count || 0), 0);
+  const totalHeld = heldCounts.reduce((s, n) => s + n, 0);
+
+  const catalogs = editions.map((e, i) => ({
+    indexId: e.id,
+    indexName: e.short_name || e.name,
+    startYear: e.start_year,
+    totalEntries: e.entry_count || 0,
+    heldCount: heldCounts[i],
+  }));
+
+  return (
+    <section className="mt-16 border-t border-stone-200 pt-12">
+      <div className="flex items-center gap-2 text-stone-900">
+        <BookMarked className="w-5 h-5" />
+        <h2 className="font-display text-2xl">The Index itself</h2>
+      </div>
+      <p className="mt-2 max-w-2xl text-stone-600 text-sm leading-relaxed">
+        We scanned {editions.length} printed editions of the <em>Index Librorum Prohibitorum</em> and read them
+        cover to cover — <strong>{totalEntries.toLocaleString()}</strong> condemnations in all, of which{' '}
+        <strong>{totalHeld.toLocaleString()}</strong> link to a banned book you can read here. Open any edition to
+        see the bans as they were printed; search below to trace a work or author across the editions.
+      </p>
+
+      {/* The printed editions — the primary sources themselves */}
+      <div className="mt-8 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4">
+        {editions.map((e) => {
+          const slug = slugFor(e);
+          const b = slug ? books.get(slug) : null;
+          const thumb = (b?.thumbnail || b?.image_thumb) as string | undefined;
+          if (!slug) return null;
+          return (
+            <Link
+              key={e.id}
+              href={`/book/${slug}`}
+              className="group flex flex-col rounded-md border border-stone-200 bg-stone-50 overflow-hidden hover:border-stone-400 transition-colors"
+              title={`Open the ${e.start_year} edition`}
+            >
+              <div className="relative aspect-[3/4] bg-stone-200">
+                {thumb && (
+                  <Image src={thumb} alt={`${e.start_year} Index, scanned`} fill sizes="160px"
+                    className="object-cover group-hover:opacity-90" />
+                )}
+              </div>
+              <div className="px-2 py-2">
+                <div className="font-display text-stone-900 text-sm leading-tight">{e.start_year}</div>
+                <div className="text-[11px] text-stone-500 leading-tight">{e.short_name || e.name}</div>
+                <div className="text-[11px] text-stone-400 mt-0.5">{(e.entry_count || 0).toLocaleString()} entries</div>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* Searchable browser over all entries */}
+      <div className="mt-12">
+        <IndexCatalogSection catalogs={catalogs} />
+      </div>
+    </section>
+  );
+}

--- a/src/components/collections/IndexCatalogSection.tsx
+++ b/src/components/collections/IndexCatalogSection.tsx
@@ -258,6 +258,16 @@ export default function IndexCatalogSection({ catalogs }: Props) {
                       USTC {e.ustc_sn}
                     </a>
                   ) : null}
+                  {e.source_book_slug && e.source_page != null && (
+                    <Link
+                      href={`/book/${e.source_book_slug}/page/${e.source_page}`}
+                      className="inline-flex items-center gap-1 px-3 py-1.5 border border-stone-300 text-stone-500 rounded hover:bg-stone-100"
+                      title="See this entry on the original scanned page of the printed Index"
+                    >
+                      <BookMarked className="w-3.5 h-3.5" />
+                      In the Index, p.{e.source_page}
+                    </Link>
+                  )}
                 </div>
               </li>
             ))}


### PR DESCRIPTION
Makes the Index Librorum Prohibitorum dataset (62,943 entries, 10 editions) actually browsable, and fixes the "VIAF undefined" book-page bug.

## The catalogue browser (was built in #1847, never mounted)
`IndexCatalogSection` existed but no page imported it — the dataset had no public UI beyond the book chip. New `IndexCatalogBrowser` mounts it on the collection page:
- **"The Index itself"** — the actual scanned printed editions we hold (title-page thumbnails, year, entry count), each linking to the book. The reader meets the primary source directly.
- The existing **searchable / per-edition / held-filtered** browser below it.
- **Every entry links to the exact scanned folio** it was OCR'd from — `/book/<source_book_slug>/page/<source_page>`, "In the Index, p.N". (Added `source_book_slug` + `source_page` to the entries API.)
- **Self-gating** (renders only for collections with `index_catalogs` editions) + Suspense-streamed, so all other collection pages are unaffected.

## VIAF-undefined fix
`BibliographicInfo` treated `author_entity_id` alone as "has canonical authority" and rendered `VIAF ${viafId}` → literal "VIAF undefined" on entity-linked books (e.g. Pico). Now requires a real displayable value; the rich authority already renders via `<AuthorAuthority>` (fed by the entity).

## Verified
tsc clean; thumbnail host already whitelisted for next/image. Will confirm on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)