### PR TITLE
curate(theosophy): Tier 1 import batch + Campbell library source snapshot

### DIFF
--- a/.claude/docs/theosophical-import/README.md
+++ b/.claude/docs/theosophical-import/README.md
@@ -1,0 +1,45 @@
+# Theosophical import — source material & batch log
+
+## Provenance
+On 2026-05-29, Reinout Spaink (`respaink@12move.nl`, via Jozef Ritman) emailed Derek
+a pointer to the **Campbell Theosophical Research Library** index, "Links to
+Theosophical Texts Online" — the catalog of the Theosophical Society in Australia.
+The original site (`austheos.org.au/clibrary/`) is **dead on the live web**; it
+survives only via the Wayback Machine. Reinout urged grabbing it before the archived
+copy also goes. The three saved HTML pages here are that snapshot:
+
+- `theos-index.html` — top-level contents (author pages, A–Z, sections)
+- `theos-early.html` — **Early Classics** (primary wisdom texts: Hermetica, Gnostic,
+  Kabbalah, Vedas/Upanishads, Tao Te Ching, Dhammapada, etc.)
+- `theos-online-libs.html` — **Online Theosophical Libraries** (a directory of ~60
+  theosophy websites — mostly HTML transcriptions, not scans)
+
+Wayback origin: `https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-0.html`
+
+## What's importable
+The directory itself is a *map*, not a feed — most "Online Libraries" links are typed
+transcriptions that don't fit our scanned-original + OCR model. The importable layer is
+the **Internet Archive** corpus it points at (thousands of public-domain texts:
+theosophy ~4.9k, kabbalah ~4k, hermeticism ~1.7k, Blavatsky ~1.9k).
+
+## Tier 1 batch (this PR)
+`scripts/maintenance/import-theosophy-tier1.mjs` — Early Classics overlapping our core
+mission (Hermetica / Gnostic / Kabbalah primaries). Deduped against the live collection;
+we already held the Ficino 1481 *Pimander*, Mead's *Thrice-Greatest Hermes* (3 vols),
+*Fragments of a Faith Forgotten*, and a *Pistis Sophia* edition. Net-new imports (5):
+
+| IA id | Title | Year | Lang | Pages |
+|---|---|---|---|---|
+| `b30329619` | The Divine Pymander (Everard) | 1650 | English | 236 |
+| `hymnshermes00hermgoog` | The Hymns of Hermes (Mead) | 1907 | English | 93 |
+| `bub_gb_oDUgg6Xh8LgC` | Kabbala Denudata (Knorr von Rosenroth) | 1677 | Latin | 776 |
+| `b24884443` | The Kabbalah Unveiled (Mathers) | 1887 | English | 408 |
+| `cu31924075115380` | The Kabbalah (Ginsburg) | 1865 | English | 166 |
+
+Imported `visible: false`; auth via the `CRON_SECRET` bearer bypass (the `/api/import/*`
+routes now require `editor`+ — the curator skill doc is stale on this).
+
+## Tier 2 (not yet imported)
+The public-domain Blavatsky / Theosophical Society canon — *Secret Doctrine*,
+*Isis Unveiled*, *Key to Theosophy*, Besant, Olcott's *Old Diary Leaves*, Judge,
+Leadbeater. Candidate IA ids gathered but held for a separate batch.

--- a/.claude/docs/theosophical-import/theos-early.html
+++ b/.claude/docs/theosophical-import/theos-early.html
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><script type="text/javascript" src="https://web-static.archive.org/_static/js/bundle-playback.js?v=oZ57VlYl" charset="utf-8"></script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script>window.RufflePlayer=window.RufflePlayer||{};window.RufflePlayer.config={"autoplay":"on","unmuteOverlay":"hidden","showSwfDownload":true};</script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/ruffle/ruffle.js"></script>
+<script type="text/javascript">
+    __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://www.austheos.org.au/clibrary/bindex-early-classics.html","20180314030546","https://web.archive.org/","web","https://web-static.archive.org/_static/",
+	      "1520996746");
+</script>
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/banner-styles.css?v=1utQkbB3" />
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=3PDvdIFv" />
+<!-- End Wayback Rewrite JS Include -->
+
+<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+<meta http-equiv="cache-control" content="no-cache"/>
+<title>Links to Theosophical Texts Online: Early Classics</title>
+<link href="/web/20180314030546cs_/http://www.austheos.org.au/clibrary/bindex.css" rel="stylesheet" type="text/css"/>
+</head>
+<body>
+<h1 class="maintitle">.: Links to Theosophical Texts Online :.</h1>
+<!-- Begin navigation -->
+<!--  start outer -->
+<div class="navigationcontainer">
+<!-- start inner -->
+<div class="navigation" style="text-align:center">
+<p class="navcontents"><b><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-0.html"><span class="itembox">Contents and Information</span></a></b></p><br/>
+<p class="navnames"><b><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-besant.html"><span class="itembox">Besant</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-blavatsky.html"><span class="itembox">Blavatsky</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-depurucker.html"><span class="itembox">de Purucker</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-judge.html"><span class="itembox">Judge</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-leadbeater.html"><span class="itembox">Leadbeater</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-olcott.html"><span class="itembox">Olcott</span></a></b></p>
+<br/><p class="navalphabet"><b><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-a.html"><span class="itembox">A</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-b.html"><span class="itembox">B</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-c.html"><span class="itembox">C</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-d.html"><span class="itembox">D</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-e.html"><span class="itembox">E</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-f.html"><span class="itembox">F</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-g.html"><span class="itembox">G</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-h.html"><span class="itembox">H</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-i.html"><span class="itembox">I</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-j.html"><span class="itembox">J</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-k.html"><span class="itembox">K</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-l.html"><span class="itembox">L</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-m.html"><span class="itembox">M</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-n.html"><span class="itembox">N</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-o.html"><span class="itembox">O</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-p.html"><span class="itembox">P</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-q.html"><span class="itembox">Q</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-r.html"><span class="itembox">R</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-s.html"><span class="itembox">S</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-t.html"><span class="itembox">T</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-u.html"><span class="itembox">U</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-v.html"><span class="itembox">V</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-w.html"><span class="itembox">W</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-x.html"><span class="itembox">X</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-y.html"><span class="itembox">Y</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-z.html"><span class="itembox">Z</span></a></b></p>
+<br/><p class="navgroups"><b><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-early-classics.html"><span class="itemboxrev whitecustom">Early Classics</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-online-periodicals.html"><span class="itembox">Online Periodicals</span></a></b><b><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-online-libraries.html"><span class="itembox">Online Libraries</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-glossaries.html"><span class="itembox">Glossaries</span></a></b></p>
+</div>
+<!--  end inner -->
+</div>
+<!--  end outer -->
+<br style="clear:both"/>
+<hr/>
+<!-- End navigation  -->
+
+<!-- Start links to Theosophical Texts -->
+<h2>Analects</h2>
+<!-- <p><a href="http://uweb.superlink.net/~fsu/analect1.html">The Analects of Confucius</a>, c. 500 B.C., Su Tsu's Chinese Philosophy Page</p> -->
+<p><a href="https://web.archive.org/web/20180314030546/http://classics.mit.edu/Confucius/analects.html">The Analects of Confucius</a>, c. 500 B.C., The Internet Classics Archive</p>
+<h2>Apocrypha - see <em>Bible, etc.</em></h2>
+<h2>Asoka - see <em>Edicts</em></h2>
+<h2>Bhagavad Gita</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.theosociety.org/pasadena/gita/bg-eg-hp.htm">Bhagavad-Gita and Essays on the Gita</a><span style="font-style: italic">, William Quan Judge</span> Recension, 1890/1969, The Theosophical University Press Online Edition</p>
+<!--<p><a href="http://www.teosofia.com/gita/gita.html">The Bhagavad-Gita [For the Disciple - A Guide] and Essays on the Gita</a><span style="font-style: italic">, William Quan Judge</span> Recension, 1890/1969, The Theosophical University Press Online Edition, <em>Plus</em> Introduction by Gandhi, and Summary of each chapter of the Gita, Rudy's Page on Theosophy.</p>-->
+<p><a href="https://web.archive.org/web/20180314030546/http://www.phx-ult-lodge.org/bhagavad.htm">Bhagavad-Gita with Glossary</a>. From the Sanskrit by, and with Antecedent Words by, William Q. Judge, and with Glossary and notes by Dallas TenBroeck, United Lodge of Theosophists, Phoenix, Arizona</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.theosophical.ca/adyar_pamphlets/AdyarPamphlet_No59.pdf">The Bhagavad Gita</a>, by C. Jinarajadasa, 1904/1915, Adyar Pamphlets No. 59, Canadian Theosophical Association
+[pdf file]</p>
+
+<!--Link out of service September 2009
+<p><a href="http://www.theosophical.ca/DiscoursesBhagavadGitaCJ.htm">Discourses on the Bhagavad Gita</a>, by C. Jinarajadasa, 1946/1953, Canadian Theosophical Association</p>
+-->
+
+<p><a href="https://web.archive.org/web/20180314030546/http://hpb.narod.ru/DiscoursesBhagavadGitaCJ.htm">Discourses on the Bhagavad Gita</a>, by C. Jinarajadasa, 1946/1953, The Theosophy Library</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.phx-ult-lodge.org/anotes.htm">Notes On The Bhagavad-Gita</a>, by William Q. Judge (First Seven Chapters) and a Student Taught by Him, ULT - Phoenix AZ</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.theosophical.ca/adyar_pamphlets/AdyarPamphlet_No17.pdf">On The Bhagavad-Gita</a>, by T. Subba Rao and Nobin K. Bannerji, 1912, Adyar Pamphlets No. 17, Canadian Theosophical Association
+[pdf file]</p>
+
+<!--Link out of service September 2009
+<p><a href="http://www.theosophical.ca/PhiloBhagavad.htm">Philosophy of the Bhagavad-Gita - Four Lectures</a>, by T. Subba Row, 1886/1912, Canadian Theosophical Association</p>
+-->
+
+<p><a href="https://web.archive.org/web/20180314030546/http://hpb.narod.ru/PhiloBhagavad.htm">Philosophy of the Bhagavad-Gita - Four Lectures</a>, by T. Subba Row, 1886/1912, The Theosophy Library</p>
+<h2>Bible, Apocrypha and Gnostic Writings</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/chr/apo/index.htm">The Apocrypha</a>, Internet Sacred Text Archive</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://onlinebooks.library.upenn.edu/webbin/gutbook/lookup?num=30">The Bible (King James Version), Gutenberg text</a> (66-book canon)</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.hti.umich.edu/r/rsv/">The Bible: Revised Standard Version</a>, searchable HTML at Uni. Michigan</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.gnosis.org/library/cac.htm">Christian Apocrypha and Early Christian Literature</a>, The Gnostic Society Library</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.earlychristianwritings.com/">Early Christian Writings</a></p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.gnosis.org/library.html">Gnostic Society Library</a></p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.gnosis.org/library/gs.htm">Gnostic Scriptures and Fragments</a>, The Gnostic Society Library</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.gnosis.org/library/grs-mead/mead_index.htm">The G.R.S. Mead Collection</a>, The Gnostic Society Library</p>
+<!--<p><a href="http://www.gnosticjudas.com/texts/EN_The_Gospel_of_Mary.pdf">The Gospel of Mary Magdelene</a>, Gnostic Judas [pdf file] </p>-->
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/chr/thomas.htm">The Gospel of Thomas</a>, translated by Thomas O. Lambdin and others, Commentary by Craig Schenk, Internet Sacred Text Archive</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.gnosis.org/naghamm/gosthom.html">The Gospel of Thomas</a>, translated by Stephen Patterson and Marvin Meyer, The Gnostic Society Library</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/bib/kjv/index.htm">King James Version of the Bible</a>, Internet Sacred Text Archive</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.nationalgeographic.com/lostgospel/document_nf.html">The Lost Gospel of Judas</a>, National Geographic</p>
+<!--<p><a href="http://www.gnosticjudas.com/gnostic-gospels-ancient-texts/nag-hammadi-library">The Nag Hammadi Library</a>, Gnostic Judas</p>-->
+<p><a href="https://web.archive.org/web/20180314030546/http://www.gnosis.org/naghamm/nhl.html">The Nag Hammadi Library</a>, The Gnostic Society library</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/chr/ps/index.htm">Pistis Sophia</a>, translated by G.R.S. Mead, 1921, Internet Sacred Text Archive</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://ebible.org/">The World English Bible</a> [also other editions], eBible.org </p>
+<h2>Cabala,  Cabbala - see <em>Kabbalah</em></h2>
+<h2>Corpus Hermeticum (Attributed to Hermes Trismegistus)</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/chr/herm/index.htm">The Corpus Hermeticum</a>, 13 Books, with Introduction by John Michael Greer, Translated by G.R.S. Mead, 1906, Internet Sacred Text Archive</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.levity.com/alchemy/corpherm.html">Corpus Hermeticum</a> (The Divine Pymander in 17 Books), Translated by John Everard, 1650, The Alchemy Website</p>
+<h2>Crest Jewel of Discrimination (or Wisdom) - see <em>Viveka Chudamani</em></h2>
+<h2>Dhammapada</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.theosociety.org/pasadena/dhamma/dham-hp.htm">Dhammapada, Wisdom of the Buddha</a>, Translated by Harischandra Kaviratna, Theosophical University Press Online Edition</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.accesstoinsight.org/tipitaka/kn/dhp/index.html">Dhammapada, The Path of Dhamma</a>. Translations by Buddharakkhita and Thanissaro Bhikkhu (Geoffrey DeGraff). Access to Insight Website</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.accesstoinsight.org/tipitaka/kn/dhp/dhp.intro.budd.html">Dhammapada, The Buddha's Path of Wisdom</a> . Translated from the Pali by Acharya Buddharakkhita with Introduction by Bhikkhu Bodhi. Access to Insight Website</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.pathofdhamma.com/">Dhammapada, The Path of the Dhamma</a>. 26 chapters. What do you think, my friend? (Writings on Buddhism). Site created by Chng Tiak Jung and Tan Chade Meng</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.phx-ult-lodge.org/Dhammapada.htm">Dhammapada</a>. With Explanatory Notes and a Short Essay on Buddha's Thought, (trans. by B. P. Wadia?), 1955, ULT - Phoenix AZ</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://theosophytrust.org/tlodocs/articlesOther.php?d=TwinVers.htm&amp;p=19">Dhammapada 1, The Twin Verses</a>, Sri Raghavan Iyer Memorial Library, Theosophy Trust</p>
+<h2>Edicts of Asoka</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.katinkahesselink.net/tibet/asoka1.html">A Translation of the Edicts of Asoka</a> (anonymous), Katinka Hesselink</p>
+<h2>Enneads of Plotinus</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://classics.mit.edu/Plotinus/enneads.1.first.html">The Six Enneads by Plotinus</a>, The Internet Classics Archive</p>
+<h2>Gnostic Writings - see <em>Bible, Apocrypha and Gnostic Writings</em></h2>
+<h2>The Golden Rule</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://theosophytrust.org/tlodocs/articlesOther.php?d=GoldnRul.htm&amp;p=6">The Golden Rule</a> - in ten religions/philosophies, Sri Raghavan Iyer Memorial Library, Theosophy Trust</p>
+<h2>Golden Verses of Pythagoras</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/cla/gvp/index.htm">The Golden Verses of Pythagoras, And Other Pythagorean Fragments</a>, ed. by Florence M. Firth, Introduction by Annie Besant, 1904, Internet Sacred Text Archive</p>
+<h2>Guru Granth Sahib (also known as the Adi Granth)</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sikhs.org/granth.htm">Guru Granth Sahib</a> The Sikhism Home Page</p>
+<h2>Hermes Trismegistus - see <em>Corpus Hermeticum</em></h2>
+<h2>Jain Texts</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/jai/index.htm">Jain Texts</a>, Internet Sacred Text Archive</p>
+<h2>Kabbalah</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.jewishencyclopedia.com/view.jsp?artid=1&amp;letter=C">Cabala</a>, by Kaufmann Kohler and Louis Ginzberg, including chapter: <a href="https://web.archive.org/web/20180314030546/http://www.jewishencyclopedia.com/view.jsp?artid=1&amp;letter=C#13">God in the Theosophy of the Talmud</a>, Jewish Encyclopedia</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.theosociety.org/pasadena/gfk-qab/qab-hp.htm">Theosophy in the Qabbalah</a>, by Grace F Knoche, 2006, Theosophical University Online Edition</p>
+<!-- link not working 28 June 2012 <p><a href="http://www2.kabbalah.com/k/index.php/p=zohar/zohar">The Zohar</a>, Kabbalah Centre International, Inc</p>-->
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/jud/zdm/index.htm">Zohar: Bereshith to Lekh Lekha</a>, by Nurho de Manhar, Internet Sacred Text Archive</p>
+<h2>Koran - see Qur'an</h2>
+<h2>Lao Tzu - see <em>Tao Teh Ching</em></h2>
+<h2>Letters From a Sufi Teacher: Shaikh Sharfuddin Maneri</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.theosophical.ca/books/LettersFromASufiTeacher_SSManeri.pdf">Letters From a Sufi Teacher</a>, by Shaikh Sharfuddin Maneri or Makhdum-ul-Mulk, 1867, Canadian Theosophical Association<br/>
+[pdf file]</p>
+<h2>Patanjali - see <em>Yoga Sutras</em></h2>
+<h2>Pistis Sophia <em>-</em>see <em>Bible, Apocrypha and Gnostic Writings</em></h2>
+<h2>Plotinus - see <em>Enneads</em></h2>
+<h2>Puranas</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/hin/index.htm#puranas">Puranas</a>, Internet Sacred Text Archive</p>
+<h2>Pythagoras - see <em>Golden Verses</em></h2>
+<h2>Qabalah, Qabbalah - see <em>Kabbalah</em></h2>
+<h2>Qur'an</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://austheos.org.au/articles/articles-essays/theosophy-islam/">Theosophy and Islam</a>, by Zehra Bharucha, 2004, Theosophy in Australia, Theosophical Society in Australia</p>
+<h2>Tao Te(h) Ching (also Dao De Jing), attrib. Lao Tzu</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.theosophical.ca/adyar_pamphlets/AdyarPamphlet_No180.pdf">The Book of Tao</a>, 1933, Adyar Pamphlets No. 180, Canadian Theosophical Association
+[pdf file]</p>
+<!--<p><a href="http://www.vl-site.org/taoism/ttc-list.html">English Translations of the Tao Te Ching/Dao De Jing</a>, (Links), The WWW Virtual Library: Taoism Virtual Library</p>-->
+<p><a href="https://web.archive.org/web/20180314030546/http://www.hermetica.info/LaoziA.htm">Lao Zi zhi Dao De Jing</a>, two Literal Translations, One Simple, One Complex, by Bradford Hatcher, Hermetica.Info</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.phx-ult-lodge.org/Upanishads.htm">Selections from The Upanishads and The Tao Te King</a>. Cunningham Press, 1951, ULT - Phoenix AZ</p>
+<!-- <p><a href="http://uweb.superlink.net/~fsu/tao2.html">Tao Te Ching</a>, Peter A. Merel's Interpolation, Su Tzu's Chinese Philosophy Page</p> -->
+<h2>Upanishads</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.phx-ult-lodge.org/Upanishads.htm">Selections from The Upanishads and The Tao Te King</a>. Cunningham Press, 1951, ULT - Phonix AZ</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/hin/sbe01/index.htm">The Upanishads, Part 1</a>, <a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/hin/sbe15/index.htm">Part 2</a>, translated by Max Muller, 1879 - 1884, Internet Sacred Text Archive</p>
+<h2>Vedas</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/hin/index.htm#vedas">The Vedas</a>, Internet Sacred Text Archive</p>
+<h2>Viveka Chudamani of S(h)ankaracharya (or Sankara) - or: The Crest Jewel of Discrimination (or Wisdom)</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.theosociety.org/pasadena/crest/crest-hp.htm">The Crest-Jewel of Wisdom and other Writings of Sankaracharya</a>. Translations and Commentaries by Charles Johnston (1894-96/1946), Theosophical University Press Online Edition</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://theosophytrust.org/tlodocs/articlesOther.php?d=FourQual.htm&amp;p=5">The Four Qualifications, from The Crest-Jewel of Wisdom, 1-41</a>, Sri Raghavan Iyer Memorial Library, Theosophy Trust</p>
+<h2>Yoga Sutras or Aphorisms of Patanjali</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.theosociety.org/pasadena/patanjal/patan-hp.htm">The Yoga Aphorisms of Patanjali</a>, William Q. Judge interpretation, 1889. Theosophical University Press Online Edition</p>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.phx-ult-lodge.org/yoga.htm">The Yoga Aphorisms of Patanjali</a>, An Interpretation by William Q. Judge,1889, ULT - Phoenix AZ</p>
+<h2>Zend Avesta</h2>
+<p><a href="https://web.archive.org/web/20180314030546/http://www.sacred-texts.com/zor/index.htm">The Zend Avesta and other Zoroastrian texts</a>, Internet Sacred Text Archive</p>
+<h2>Zohar - see Kabbalah</h2>
+<!-- End links to Theosophical Texts -->
+
+<!-- Begin bottom and additional navigation -->
+<p>&nbsp;</p>
+<hr/>
+<br style="clear:both"/>
+<!--  start outer -->
+<div class="navigationcontainer">
+<!-- start inner -->
+<div class="navigation bottom" style="text-align:center">
+<p class="navnames"><b><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-besant.html"><span class="itembox">Besant</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-blavatsky.html"><span class="itembox">Blavatsky</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-depurucker.html"><span class="itembox">de Purucker</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-judge.html"><span class="itembox">Judge</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-leadbeater.html"><span class="itembox">Leadbeater</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-olcott.html"><span class="itembox">Olcott</span></a></b></p>
+<br/><p class="navalphabet"><b><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-a.html"><span class="itembox">A</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-b.html"><span class="itembox">B</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-c.html"><span class="itembox">C</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-d.html"><span class="itembox">D</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-e.html"><span class="itembox">E</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-f.html"><span class="itembox">F</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-g.html"><span class="itembox">G</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-h.html"><span class="itembox">H</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-i.html"><span class="itembox">I</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-j.html"><span class="itembox">J</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-k.html"><span class="itembox">K</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-l.html"><span class="itembox">L</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-m.html"><span class="itembox">M</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-n.html"><span class="itembox">N</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-o.html"><span class="itembox">O</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-p.html"><span class="itembox">P</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-q.html"><span class="itembox">Q</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-r.html"><span class="itembox">R</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-s.html"><span class="itembox">S</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-t.html"><span class="itembox">T</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-u.html"><span class="itembox">U</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-v.html"><span class="itembox">V</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-w.html"><span class="itembox">W</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-x.html"><span class="itembox">X</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-y.html"><span class="itembox">Y</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-z.html"><span class="itembox">Z</span></a></b></p>
+<br/><p class="navgroups"><b><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-early-classics.html"><span class="itemboxrev whitecustom">Early Classics</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-online-periodicals.html"><span class="itembox">Online Periodicals</span></a></b><b><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-online-libraries.html"><span class="itembox">Online Libraries</span></a><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/clibrary/bindex-glossaries.html"><span class="itembox">Glossaries</span></a></b></p>
+</div>
+<!--  end inner -->
+</div>
+<!--  end outer -->
+
+<!-- Begin additional navigation -->
+<p class="sitenav"><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/resources-2/campbell-theosophical-research-library/">The Campbell Theosophical Research Library</a></p>
+<p class="sitenav"><a class="nav" href="https://web.archive.org/web/20180314030546/http://www.austheos.org.au/">The Theosophical Society in Australia</a> Home</p>
+<p class="pageinfo">Updated 7 February 2018&nbsp;&nbsp;&nbsp;Compliant <a class="nav" href="https://web.archive.org/web/20180314030546/http://validator.w3.org/check?uri=referer">XHTML 1.0T</a> and <a class="nav" href="https://web.archive.org/web/20180314030546/http://jigsaw.w3.org/css-validator/check/referer"> CSS 3</a></p>
+<!-- End bottom and additional navigation -->
+</body>
+</html><!--
+     FILE ARCHIVED ON 03:05:46 Mar 14, 2018 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 16:24:54 May 29, 2026.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 0.494
+  exclusion.robots: 0.045
+  exclusion.robots.policy: 0.034
+  esindex: 0.009
+  cdx.remote: 5.639
+  LoadShardBlock: 89.047 (3)
+  PetaboxLoader3.datanode: 80.569 (4)
+  PetaboxLoader3.resolve: 120.897 (2)
+  load_resource: 200.469
+-->

--- a/.claude/docs/theosophical-import/theos-index.html
+++ b/.claude/docs/theosophical-import/theos-index.html
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-au" lang="en-au">
+<head><script type="text/javascript" src="https://web-static.archive.org/_static/js/bundle-playback.js?v=oZ57VlYl" charset="utf-8"></script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script>window.RufflePlayer=window.RufflePlayer||{};window.RufflePlayer.config={"autoplay":"on","unmuteOverlay":"hidden","showSwfDownload":true};</script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/ruffle/ruffle.js"></script>
+<script type="text/javascript">
+    __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://www.austheos.org.au/clibrary/bindex-0.html","20180314022808","https://web.archive.org/","web","https://web-static.archive.org/_static/",
+	      "1520994488");
+</script>
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/banner-styles.css?v=1utQkbB3" />
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=3PDvdIFv" />
+<!-- End Wayback Rewrite JS Include -->
+
+<meta name="generator" content="HTML Tidy for Linux/x86 (vers 1 September 2005), see www.w3.org"/>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+<meta http-equiv="cache-control" content="no-cache"/>
+<link rel="shortcut icon" href="/web/20180314022808im_/http://www.austheos.org.au/clibrary/ltto-fav.ico"/>
+<link rel="icon" href="/web/20180314022808im_/http://www.austheos.org.au/clibrary/ltto-fav.ico"/>
+<title>Links to Theosophical Texts Online Contents</title>
+<!--  <link href="bindex-contents.css" rel="stylesheet" type="text/css" /> */ -->
+<link href="/web/20180314022808cs_/http://www.austheos.org.au/clibrary/bindex.css" rel="stylesheet" type="text/css"/>
+</head>
+<body>
+
+<p class="sitenav bold"><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/">The Theosophical Society in Australia</a><br/><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/resources-2/campbell-theosophical-research-library/">The Campbell Theosophical Research Library</a></p>
+
+<h1 class="maintitle">.: Links to Theosophical Texts Online :.</h1>
+
+<!--  start outer -->
+<div class="navigationcontainer">
+<!-- start inner -->
+<div class="navigation" style="text-align:center">
+<p class="navcontents"><b><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-0.html"><span class="itemboxrev whitecustom">Contents and Information</span></a></b></p><br/>
+<p class="navnames"><b><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-besant.html"><span class="itembox">Besant</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-blavatsky.html"><span class="itembox">Blavatsky</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-depurucker.html"><span class="itembox">de&nbsp;Purucker</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-judge.html"><span class="itembox">Judge</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-leadbeater.html"><span class="itembox">Leadbeater</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-olcott.html"><span class="itembox">Olcott</span></a></b></p>
+<br/><p class="navalphabet"><b><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-a.html"><span class="itembox">A</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-b.html"><span class="itembox">B</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-c.html"><span class="itembox">C</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-d.html"><span class="itembox">D</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-e.html"><span class="itembox">E</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-f.html"><span class="itembox">F</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-g.html"><span class="itembox">G</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-h.html"><span class="itembox">H</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-i.html"><span class="itembox">I</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-j.html"><span class="itembox">J</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-k.html"><span class="itembox">K</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-l.html"><span class="itembox">L</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-m.html"><span class="itembox">M</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-n.html"><span class="itembox">N</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-o.html"><span class="itembox">O</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-p.html"><span class="itembox">P</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-q.html"><span class="itembox">Q</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-r.html"><span class="itembox">R</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-s.html"><span class="itembox">S</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-t.html"><span class="itembox">T</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-u.html"><span class="itembox">U</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-v.html"><span class="itembox">V</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-w.html"><span class="itembox">W</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-x.html"><span class="itembox">X</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-y.html"><span class="itembox">Y</span></a><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-z.html"><span class="itembox">Z</span></a></b></p>
+</div>
+<!--  end inner -->
+</div>
+<!--  end outer -->
+
+<!--  start outer -->
+<div class="navigationcontainer">
+<!-- start inner -->
+<div class="navigation" style="text-align:left">
+<p style="margin-top: 0.2em; margin-bottom: 0.5em; display: inline-block;" class="contentsgroups itembox"><b><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-early-classics.html">Early Classics</a></b></p>
+<p style="margin-bottom: 0.0em; margin-top: 0.0em" class="contentsgroups">Bhagavad Gita, Bible, Cabala, Dhammapada, Gnostics, Qur'an, Tao Te Ching, Upanishads, Viveka Chudamani, Yoga Sutras, and others</p>
+<p style="margin-top: 1.0em; margin-bottom: 0.3em; display: inline-block" class="contentsgroups itembox"><b><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-online-periodicals.html">Online Periodicals and Series</a></b></p>
+<br style="clear:both"/>
+<p style="margin-top: 1.0em; margin-bottom: 0.3em; display: inline-block" class="contentsgroups itembox"><b><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-online-libraries.html">Online Theosophical Libraries: Books, Pamphlets, Articles</a></b></p>
+<br style="clear:both"/>
+<p style="margin-top: 1.0em; margin-bottom: 0.3em; display: inline-block" class="contentsgroups itembox"><b><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-glossaries.html"> Glossaries,  Sanskrit Pronunciation,  Search Facilities,  Theosopedia </a></b></p>
+<br style="clear:both"/>
+<p style="margin-top: 1.0em; margin-bottom: 0.3em; display: inline-block" class="contentsgroups itembox"><b><a class="nav" href="https://web.archive.org/web/20180314022808/http://www.austheos.org.au/clibrary/bindex-appendix.html">Appendix: Reader and Browser Programs</a></b></p>
+</div>
+<!--  end inner -->
+</div>
+<!--  end outer -->
+
+
+
+
+<!-- <hr /> -->
+
+<!--  start outer -->
+<div class="navigationcontainer">
+<!-- start inner -->
+<div class="navigation" style="text-align:left">
+
+<table class="siteinformation">
+<tbody>
+<tr>
+<td width="50%" valign="top"><b>Disclaimer</b><br/>The Theosophical Society in Australia is not responsible for opinions expressed on the web sites to which links are provided in the "Links to Theosophical Texts Online" web pages.</td>
+<td width="2%"></td>
+<td valign="top"><b>Criteria for Inclusion</b><br/>"Theosophical" is used in a broad and eclectic sense.<br/>"Texts": includes books, booklets, pamphlets, collections of articles, as well as significant individual articles.</td>
+</tr>
+<tr>
+<td valign="top"><b>Number of Links</b><br/>
+Number of different "theosophical texts":&nbsp;&nbsp;1582<br/>
+Total number of links, including to different versions of "texts", and to other categories:&nbsp;&nbsp;1849</td>
+<td></td>
+<td valign="top"><b>Last Updated </b><br/>
+  7 February 2018&nbsp;&nbsp;&nbsp;<a class="nav" href="https://web.archive.org/web/20180314022808/http://validator.w3.org/check?uri=referer">XHTM 1.0 Transitional</a> and <a class="nav" href="https://web.archive.org/web/20180314022808/http://jigsaw.w3.org/css-validator/check/referer"> CSS 3</a> Compliant.<br/>
+	Please notify additional links and/or changes to <a class="nav" href="https://web.archive.org/web/20180314022808/mailto:pres@austheos.org.au">&#112;&#114;&#101;&#115;&#064;&#097;&#117;&#115;&#116;&#104;&#101;&#111;&#115;&#046;&#111;&#114;&#103;&#046;&#097;&#117;</a></td>
+</tr>
+</tbody>
+</table>
+
+</div>
+<!--  end inner -->
+</div>
+<!--  end outer -->
+</body>
+</html><!--
+     FILE ARCHIVED ON 02:28:08 Mar 14, 2018 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 16:24:34 May 29, 2026.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 0.39
+  exclusion.robots: 0.064
+  exclusion.robots.policy: 0.056
+  esindex: 0.007
+  cdx.remote: 6.833
+  LoadShardBlock: 234.21 (3)
+  PetaboxLoader3.resolve: 526.712 (4)
+  PetaboxLoader3.datanode: 108.108 (4)
+  load_resource: 501.14
+-->

--- a/.claude/docs/theosophical-import/theos-online-libs.html
+++ b/.claude/docs/theosophical-import/theos-online-libs.html
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><script type="text/javascript" src="https://web-static.archive.org/_static/js/bundle-playback.js?v=oZ57VlYl" charset="utf-8"></script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script>window.RufflePlayer=window.RufflePlayer||{};window.RufflePlayer.config={"autoplay":"on","unmuteOverlay":"hidden","showSwfDownload":true};</script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/ruffle/ruffle.js"></script>
+<script type="text/javascript">
+    __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://www.austheos.org.au/clibrary/bindex-online-libraries.html","20180314030552","https://web.archive.org/","web","https://web-static.archive.org/_static/",
+	      "1520996752");
+</script>
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/banner-styles.css?v=1utQkbB3" />
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=3PDvdIFv" />
+<!-- End Wayback Rewrite JS Include -->
+
+<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+<meta http-equiv="cache-control" content="no-cache"/>
+<title>Links to Theosophical Texts Online: Online Theosophical Libraries</title>
+<link href="/web/20180314030552cs_/http://www.austheos.org.au/clibrary/bindex.css" rel="stylesheet" type="text/css"/>
+</head>
+<body>
+<h1 class="maintitle">.: Links to Theosophical Texts Online :.</h1>
+<!-- Begin navigation -->
+<!--  start outer -->
+<div class="navigationcontainer">
+<!-- start inner -->
+<div class="navigation" style="text-align:center">
+<p class="navcontents"><b><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-0.html"><span class="itembox">Contents and Information</span></a></b></p><br/>
+<p class="navnames"><b><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-besant.html"><span class="itembox">Besant</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-blavatsky.html"><span class="itembox">Blavatsky</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-depurucker.html"><span class="itembox">de Purucker</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-judge.html"><span class="itembox">Judge</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-leadbeater.html"><span class="itembox">Leadbeater</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-olcott.html"><span class="itembox">Olcott</span></a></b></p>
+<br/><p class="navalphabet"><b><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-a.html"><span class="itembox">A</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-b.html"><span class="itembox">B</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-c.html"><span class="itembox">C</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-d.html"><span class="itembox">D</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-e.html"><span class="itembox">E</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-f.html"><span class="itembox">F</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-g.html"><span class="itembox">G</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-h.html"><span class="itembox">H</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-i.html"><span class="itembox">I</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-j.html"><span class="itembox">J</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-k.html"><span class="itembox">K</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-l.html"><span class="itembox">L</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-m.html"><span class="itembox">M</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-n.html"><span class="itembox">N</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-o.html"><span class="itembox">O</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-p.html"><span class="itembox">P</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-q.html"><span class="itembox">Q</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-r.html"><span class="itembox">R</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-s.html"><span class="itembox">S</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-t.html"><span class="itembox">T</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-u.html"><span class="itembox">U</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-v.html"><span class="itembox">V</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-w.html"><span class="itembox">W</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-x.html"><span class="itembox">X</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-y.html"><span class="itembox">Y</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-z.html"><span class="itembox">Z</span></a></b></p>
+<br/><p class="navgroups"><b><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-early-classics.html"><span class="itembox">Early Classics</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-online-periodicals.html"><span class="itembox">Online Periodicals</span></a></b><b><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-online-libraries.html"><span class="itemboxrev whitecustom">Online Libraries</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-glossaries.html"><span class="itembox">Glossaries</span></a></b></p>
+</div>
+<!--  end inner -->
+</div>
+<!--  end outer -->
+<br style="clear:both"/>
+<hr/>
+<!-- End navigation  -->
+
+<!-- Start links to Theosophical Texts -->
+<h2>Alpheus - conducted by Govert Schuller</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.alpheus.org/html/contentindices/esoteric_history_index.html">Alpheus - Esoteric History</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.alpheus.org/html/contentindices/krishnamurti_index.html">Alpheus - Krishnamurti</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.alpheus.org/html/contentindices/theosophy_index.html">Alpheus - Theosophy</a></p>
+<h2>Anand Gholap</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.anandgholap.net/index.html">AnandGholap.Net</a>, focused on the writings of Charles Leadbeater and Annie Besant</p>
+<h2>Blavatsky Archives and Blavatsky Study Center - conducted by Daniel Caldwell</h2>
+<p><a href="https://web.archive.org/web/20180314030552/https://www.theosophytrust.org/HPB-article">Articles by H.P. Blavatsky (Published by Theosophy Trust)</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/intromaterial6.htm">Blavatsky Archives: Hundreds of Rare Source Documents</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/intromaterial6.htm">Blavatsky Archives</a>: <a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/compitems2.htm">Material A-Z</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskybooks.net/">BlavatskyBooks.Net</a>: H. P. Blavatsky's Books &amp; the Mahatma Letters</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/articleshpbtheosophy.htm">Blavatsky Reading Room: Articles, Books and Other Material on Theosophy, H.P. Blavatsky, &amp; the Mahatmas</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/hpbcontro.htm">Blavatsky Study Center: Controversies Surrounding Madame Blavatsky's Work &amp; the Teachings of Theosophy</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/">Blavatsky Study Center: Gateway to Material on the Life, Writings and Teachings of H.P. Blavatsky</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/othermaterial.htm">Blavatsky Study Center: Other Material about H.P. Blavatsky &amp; the Mahatmas published on the World Wide Web</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/intheblavatskytradition.htm">The Blavatsky Tradition: Major Online Books, Pamphlets &amp; Other material on H.P. Blavatsky, the Mahatmas &amp; Theosophy</a>, compiled by Daniel H. Caldwell</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/hpblinks.htm#Blavatsky">Blavatsky Websites</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/mastersencounterswith.htm">A Casebook of Encounters with the Theosophical Mahatmas</a>, Compiled and Edited by Daniel H Caldwell</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/leadbeaterbib.htm">Charles Webster Leadbeater: His Life, Writings &amp; Theosophical Teachings</a>, compiled by Daniel H. Caldwell.<!-- Also available on: <a href="http://leadbeater.info/">Leadbeater.INFO</a>--> </p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/hpblinks.htm#Classics">Classics of Modern Theosophy</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/hpbcontro.htm">Controversies Surrounding Madame Blavatsky's Work, &amp; the Teachings of Theosophy</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/exploringtheunknown.htm">Exploring the Unknown: Links to Articles in Wikipedia selected and collated by Daniel H. Caldwell</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/othermaterial.htm">Historical Material about H.P. Blavatsky &amp; the Mahatmas</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/onlinematerial.htm">H.P. Blavatsky, the Mahatmas and Theosophy: Online and Imprint Material</a></p>
+<!--<p><a href="http://collectedwritings.net/">H.B. Blavatsky Collected Writings Online, CollectedWritings.Net - with Keyword Search</a></p>-->
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/intromaterial.htm">Introductory Material &amp; Special Studies on Theosophy, H.P. Blavatsky and the Mahatmas</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/mastersportraitsintroductory.htm">Mahatmas and Their Letters</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/introductiononlinebooks.htm">Major Online Books and Pamphlets about H.P. Blavatsky and Theosophy - by Author</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/hpblinks.htm#Libraries">Online Libraries of Books/Articles/Documents/etc.</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/hpbwritingsalphalist.htm">Online Writings of H.P. Blavatsky and the Mahatmas - Alphabetical by Title</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/hpbwritings.htm">Online Writings of H.P. Blavatsky and the Mahatmas - in Chronological Order</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/intromaterial3.htm">Overviews of, &amp; Collations from, the Classics of Theosophy</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/postingsdanielcontents.htm">Postings by Daniel H. Caldwell /Blavatsky Archives on the Theos-Talk Mailing List</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/hpblinks.htm#Special">Special Libraries</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyarchives.com/intromaterial5.htm">Theosophical Claims &amp; Controversies After HPB's Death</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/hpblinks.htm#History">Theosophical History</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/hpblinks.htm#Magazines">Theosophical Magazines</a></p>
+<!-- <p><a href="http://theosophicalsearch.net/">TheosophySearch.INFO, Theosophical Search &amp; Find: Quick Access to Hundreds of Online Resource:</a></p> -->
+<!-- <p><a href="http://theosophy.info/">Theosophy.info: A Reading Room of Articles, Books &amp; Other Material on Theosophy, H.P. Blavatsky &amp; the Mahatmas</a></p> -->
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/hpblinks.htm">TheosophyLinks.Net: Websites and Internet Resources on H.P. Blavatsky, the Mahatmas and Theosophy</a></p>
+<!--<p><a href="http://theosophyonthe.net/">TheosophyOnThe.Net</a>, Easy Net Access to the Classics of Modern Theosophy</p>-->
+<!--<h2>H.B. Blavatsky Collected Writings Online</h2>-->
+<!--<p><a href="http://collectedwritings.net/">H.B. Blavatsky Collected Writings Online</a>, CollectedWritings.Net - with Keyword Search</p>-->
+<h2>Blavatsky Foundation</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskyfoundation.org/">Blavatsky Foundation and The Writings of Walter A. Carrithers Jr</a></p>
+<h2>Blavatsky.gr - Athens ULT</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatsky.gr/index.php?id=7&amp;L=1">Articles</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatsky.gr/index.php?id=92&amp;L=1">Books and Works Online</a></p>
+<h2>Blavatsky Net - conducted by Reed Carson</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatsky.net/index.php/articles-by-h-p-blavatsky">Articles by H.P. Blavatsky</a> (238)</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatsky.net/index.php/articles-by-w-q-judge">Articles by William Q. Judge</a> (277)</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatsky.net/">Blavatsky Net - Theosophy</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatsky.net/index.php/links-support-theosophy-blavatsky-reading-seeker">Books by Blavatsky</a></p>
+<!--<p><a href="http://www.blavatsky.net/theosophy/theosophy-links.htm">Other Theosophical Texts Online</a></p>-->
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatsky.net/index.php/w-q-judge">William Q. Judge Texts Online</a></p>
+<h2>Blavatsky Study Center - see Blavatsky Archives</h2>
+<h2>Blavatsky Trust - founded by Geoffrey A. Farthing</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskytrust.org.uk/">Blavatsky Trust</a></p>
+<p>Geoffrey A Farthing: Articles and Books: <a href="https://web.archive.org/web/20180314030552/http://www.blavatskytrust.org.uk/html/articles/ancient%20wisdom.htm">1</a>, <a href="https://web.archive.org/web/20180314030552/http://www.blavatskytrust.org.uk/html/trilogy_intro.htm">2</a>, <a href="https://web.archive.org/web/20180314030552/http://www.blavatskytrust.org.uk/html/articles/aspects%20divine%20law%20p1.htm">3</a>, <a href="https://web.archive.org/web/20180314030552/http://www.blavatskytrust.org.uk/html/articles/the%20right%20angle%20p1.htm">4</a>, <a href="https://web.archive.org/web/20180314030552/http://www.blavatskytrust.org.uk/html/wr_whattheosophyis.htm">5</a>, <a href="https://web.archive.org/web/20180314030552/http://www.blavatskytrust.org.uk/html/a_blavatsky_lecture_2001.html">6</a>, <a href="https://web.archive.org/web/20180314030552/http://www.blavatskytrust.org.uk/html/wr_whattheosophyis.htm">Other Articles And Books</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.blavatskytrust.org.uk/html/archive.htm">Theosophical Archive: Books, Articles, Blavatsky Lectures and Newsletters</a></p>
+<h2>Campbell Theosophical Research Library</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/resources-2/campbell-theosophical-research-library/">Campbell Theosophical Research Library</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/FromLib.htm">From the Campbell Library Collection</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-0.html">Links to Theosophical Texts Online</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/indices/pindex.htm">Union Index of Theosophical Periodicals</a></p>
+<h2>Canadian Theosophical Association</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophical.ca/resources_online_adyar.shtml">Resources - Online Items - Adyar Pamphlets </a>(212 titles) [pdf files]</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophical.ca/resources_online_books.shtml">Resources - Online Items - Books</a> (82 titles) [pdf files] </p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophical.ca/resources_online_otherdocuments.shtml">Resources - Online Items - Other Documents</a> (36 titles) [pdf files] </p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophical.ca/resources_online_siftings.shtml">Resources - Online Items -Theosophical Siftings</a> , Volumes 1-7, 1888-1895 (245 titles)
+[pdf files]</p>
+<h2>CWL World - conducted by Pedro Oliveira</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.cwlworld.info/index.html">Includes Articles by and about CW Leadbeater</a></p>
+<h2>David Green's Critical History Page on Theosophy</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://members.tripod.com/davidgreen_2/">David Green's Critical History Page on Theosophy: Blavatsky, Judge and Tingley, Crosbie, Conger, Leadbeater, Bailey</a></p>
+<!--<h2>Digital Library of India</h2>
+<p><a href="http://www.dli.ernet.in">Religion Titles</a> (<em>search for subject</em>: religion; or <em>select subject</em>: religion)</p>-->
+<h2>Eastern Tradition Research Institute - conducted by David and Nancy Reigle</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://easterntradition.org/">Eastern Tradition Research Institute</a></p>
+<h2>eBooks@Adelaide</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://ebooks.adelaide.edu.au/">eBooks@Adelaide (University of Adelaide Library eBooks)</a></p>
+<!-- no longer carrying online documents ?
+<h2>Edmonton Theosophical Society - see Theosophy Canada</h2>
+-->
+<h2>Exploring Theosophy - conducted by David Pratt</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/">Exploring Theosophy, The Synthesis of Science, Religion and Philosophy,</a> including: - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#Th">What is theosophy?</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#St">Studies in theosophy</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#Hi">Theosophical history</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#De">Death and rebirth</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#Pa">Earth mysteries and the paranormal</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#Re">Religion</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#Ci">Ancient civilizations</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#Ls">Life science</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#Ea">Earth science</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#As">Astronomy and cosmology</a> - <a href="https://web.archive.org/web/20180314030552/http://davidpratt.info/#Sc">General science and philosophy</a></p>
+<h2>Goethean Science Site</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.goetheanscience.org/">Goethean Science</a></p>
+<!--<h2>The Global Library</h2>
+<p><a href="http://www.global.org/Work/Authors.asp.html">Global Library - by Author</a>, also available <a href="http://www.global.org/Work/titles.asp.html">by Title</a></p>
+<p><a href="http://www.global.org/kw/Theosophy/index.html">"Theosophy" at the Global Library</a></p>
+-->
+<h2>Glossaries: - see <a href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-glossaries.html">Glossaries and Search Facilities</a></h2>
+<!--<h2>Gnostic Judas</h2>
+<p><a href="http://www.gnosticjudas.com/">Gnostic Resources, including by G.R.S. Mead</a></p>
+-->
+<h2>Google Book Search</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://books.google.com/">Google Book Search</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://books.google.com/books?q=Blavatsky&amp;as_brr=1">Google Books on Blavatsky</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://books.google.com/books?as_brr=1&amp;q=Theosophical+Society&amp;btnG=Search+Books">Google Search on Theosophical Society</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://books.google.com/books?q=Theosophy&amp;btnG=Search+Books&amp;as_brr=1">Google Books on Theosophy</a></p>
+<!--<h2>Google Videos Search</h2>
+<p><a href="http://video.google.com/videosearch?q=theosophical+society&amp;hl=en#q=blavatsky&amp;hl=en&amp;sitesearch=">Google Videos on Blavatsky</a></p>
+<p><a href="http://video.google.com/videosearch?q=theosophical+society&amp;hl=en#">Google Videos on Theosophical Society</a></p>
+<p><a href="http://video.google.com/videosearch?q=theosophical+society&amp;hl=en#q=theosophy&amp;hl=en&amp;view=2&amp;emb=0">Google Videos on Theosophy</a></p>
+-->
+<h2>HERMES Library: See Theosophy Trust</h2>
+<h2>Internet Archive - Universal Access to Human Knowledge</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.archive.org/search.php?query=theosophy">Theosophy Titles Online</a></p>
+<h2>Katinka Hesselink.Net</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.katinkahesselink.net/sitemap.htm">Site Map of Katinka Hesselink's Webpages</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.katinkahesselink.net/other/c/contents.htm">Contents by Author</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.katinkahesselink.net/other/c/c_hpb.html">H.P. Blavatsky Contents - Articles and Quotes</a></p>
+<!-- <p><a href="http://www.katinkahesselink.net/other/">Modern Theosophy</a></p> -->
+<p><a href="https://web.archive.org/web/20180314030552/http://www.katinkahesselink.net/estg.htm">Esoteric Studies Guide</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.katinkahesselink.net/his/index_au.htm">Eclectic Theosophical History: Content by Author</a> - <a href="https://web.archive.org/web/20180314030552/http://www.katinkahesselink.net/his/index_sb.htm">Content by Subject</a></p>
+<h2>Kurt Leland's Spiritual Orienteering</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/">Home</a></p>
+<p>Including <strong>Annie Besant Shrine</strong>, with detailed Chronology and over 1400 listings and hundreds of links to her books, pamphlets etc. online:</p>
+<p>- <a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/annie-besant-shrine/orientation-annie">Orientation</a></p>
+<p>- <a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/annie-besant-shrine/orientation-annie/39-why-a-shrine">Introductory Essay to A Bibliography of Annie Besant (1847-1933)</a></p>
+<p>- <a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/annie-besant-shrine/orientation-annie/41-chronology">Chronology - Principal Events of Annie Besant's Life</a></p>
+<p>- <a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/annie-besant-shrine/orientation-annie/42-sources">Sources - books, articles, internet resources</a></p>
+<p>- <a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/annie-besant-shrine/early-works">Early Works - I-III</a></p>
+<p>- <a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/annie-besant-shrine/books">Books - IV-IXa</a></p>
+<p>- <a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/annie-besant-shrine/pamphlets">Pamphlets - X-XV</a></p>
+<p>- <a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/annie-besant-shrine/periodicals">Periodicals (and Articles) - XVI-XXII</a></p>
+<p>- <a href="https://web.archive.org/web/20180314030552/http://www.kurtleland.com/annie-besant-shrine/miscellaneous">Miscellaneous (Biographical Publications, Posthumous Publications, Bibliographies) - XXIII-XXV</a></p>
+<!--<h2>Library of Theosophical Books</h2>-->
+<!--<p><a href="http://ftp1.dns-systems.net/~hpb/books/">Library of Theosophical Books - Dedicated to H.P.B.</a></p>-->
+<!--<h2>Modern Theosophy - See "Katinka Hesselink.Net" above</h2>-->
+<h2>Nick's Theosophical Webpage - conducted by Nick Mojzesz</h2>
+<!--<p><a href="http://users.ez2.net/nick29/theosophy/">Lessons, Books, and Links</a></p>-->
+<!--<p><a href="http://users.ez2.net/nick29/theosophy/lessons.htm">Lessons in Theosophy (A Besant/Leadbeater Perspective)</a></p>-->
+<p><a href="https://web.archive.org/web/20180314030552/http://web.archive.org/web/20080209011638/http:/users.ez2.net/nick29/theosophy/stanzas.htm#absolute">The Stanzas of Dzyan - A Study Guide</a> (archived at Internet Archive WaybackMachine)</p>
+<h2>Online Books Page</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://onlinebooks.library.upenn.edu/titles.html">The Online Books Page: Search by Title</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://onlinebooks.library.upenn.edu/authors.html">The Online Books Page: Search by Author</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://onlinebooks.library.upenn.edu/webbin/book/browse?type=lcsubc&amp;key=Theosophy">The Online Books Page - Theosophy Titles</a></p>
+<h2>Pablo Sender's Theosophical Website: Living Theosophy</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://pablosender.com/all-articles/">Online articles and blog posts by Pablo Sender</a></p>
+<p>also</p>
+<!--<p><a href="http://pasender.tripod.com/id11.html">Articles by Other Authors</a></p>-->
+<p><a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/senderstcoursesd.htm">Study Course on The Secret Doctrine</a>, by Pablo Sender and Juliana Cesano,  [also: <a href="https://web.archive.org/web/20180314030552/http://blavatskyarchives.com/SecretDoctrineStudyCourse.pdf">PDF file</a>], Blavatsky Archives</p> 
+<h2>Patanjali.ch</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.patanjali.ch/index.html">Home page</a>: Patanjali, Meditations, Library</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.patanjali.ch/library/pys_library.html">Library</a>: Books, Documents, Krishnamurti, etc.</p>
+<h2>Philaletheians</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.philaletheians.co.uk/index.htm">Philaletheians - Home Page</a> including Study Notes </p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.philaletheians.co.uk/Eclectic%20Theosophy.htm">Philaletheians - Eclectic Theosophy</a></p>
+<h2>Stephen M Phillips</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.smphillips.mysite.com/">Physics related to Theosophy</a> - Sacred Geometries and Their Scientific Meanings</p>
+<h2>Project Gutenberg</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.gutenberg.org/catalog/">Online Books: Search by Author or Title</a></p>
+<h2>Religion Online</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.religion-online.org/">Religion Online</a> - Full texts by recognized religious scholars</p>
+<h2>Rudolf Steiner Archive</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.rsarchive.org/Books/">Rudolf Steiner Archive</a></p>
+<!--<h2>Rudy's Page on Theosophy (teosofia.com) - conducted by Rodolfo Don</h2>
+<p><a href="http://www.teosofia.com/">Rudy's Page on Theosophy:</a> <a href="http://www.teosofia.com/">Selected Theosophical Writings</a></p>
+<p><a href="http://www.teosofia.com/AT.html">"The Aquarian Theosophist" Magazine, from Volume I (November 2000)</a></p>
+<p>"<a href="http://www.teosofia.com/TTM.html">The Theosophical Movement" Magazine, from Volume 71 (November 2000)</a></p>
+-->
+<h2>Sacred Texts</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.sacred-texts.com/index.htm">Internet Sacred Text Archive: Home Page</a> (Links to many topics)</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.sacred-texts.com/the/index.htm">Internet Sacred Text Archive: Theosophy</a>. (Other topics available)</p>
+<!--<h2>Schuelers Theosophy Web Page</h2>
+<p><a href="http://www.schuelers.com/Theosophy/index.htm">Articles on Theosophy by Gerald Schueler</a></p>
+-->
+<h2>Teosofiskakompaniet - see "United Lodge of Theosophists (ULT), Malmo, Sweden"</h2>
+<h2>Teozofija - see Theosophy in Slovenia</h2>
+<!--<h2>Theosophical Classics</h2>-->
+<!--<p><a href="http://ftp1.dns-systems.net/~hpb/books/">Theosophical Classics: Theosophical Books in djvu format, CD, books by E. Krishnamacharya</a></p>-->
+<h2>Theosophical History</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theohistory.org/">Theosophical History</a>, including:</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theohistory.org/fulltextthhist.html">Volume I - 1985-86, edited by Leslie Price: Free</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theohistory.org/pdf-s.html">Second Series - From Volume III, 1990, edited by James Santucci </a>(some require password/fee)</p>
+<h2>Theosophical Society, Adyar, Chennai, India</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/book-store">Adyar Newsletter, 2008 (4 issues)</a></p>
+<p style="margin-bottom:0.5em"><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/content/magazines#The_Theosophist">The Theosophist</a></p>
+<!-- Start: table to order the information for The Theosophist -->
+<table width="" border="0" style="margin-left:2.0em" class="subtable">
+  <tr>
+  	<td style="width:4.1em">Volume</td>
+  	<td style="width:4.1em">Issues</td>
+  	<td>Dates</td>
+  </tr>
+  <!-- VIP set correct URL here for clickable table row with mouseover highlight and hand-cursor -->
+  <!-- VIP for xhtml validation "onclick" "onmouseover" and "onmouseout" are case sensitive and must be lower case -->
+  <tr style="cursor:pointer" onclick="document.location.href='https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/book-store#The_Theosophist';" onmouseover="this.style.background='#f6f6f6'" onmouseout="this.style.background='#ffffff'">
+  	<td><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/content/volume-136-oct-2014-sep-2015">136</a></td>
+  	<td><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/content/volume-136-oct-2014-sep-2015">1-12</a></td>
+  	<td><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/content/volume-136-oct-2014-sep-2015">October 2014 - September 2015 </a></td>
+  	</tr>
+  <!-- Not as above: these below are individual links -->
+  <tr>
+  	<td><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/theosophist/volume-137-oct-2015-sep-2016">137</a></td>
+  	<td><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/theosophist/volume-137-oct-2015-sep-2016">1-12</a></td>
+  	<td><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/theosophist/volume-137-oct-2015-sep-2016">October 2015 - September 2016</a></td>
+  	</tr>
+  <tr>
+    <td><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/theosophist/volume-138-oct-2016-sep-2017">138</a></td>
+    <td><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/theosophist/volume-138-oct-2016-sep-2017">1-12</a></td>
+    <td><a href="https://web.archive.org/web/20180314030552/http://www.ts-adyar.org/theosophist/volume-138-oct-2016-sep-2017">October 2016 - September 2017</a></td>
+  </tr>
+</table>
+<!-- End: table to order the information for The Theosophist -->
+<h2>Theosophical Society in America</h2>
+<p><a href="https://web.archive.org/web/20180314030552/https://www.theosophical.org/research-tools/media-library"> Media Library </a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophical.org/online-resources/articles">Online Articles</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophical.org/online-resources/books">Online Books</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophical.org/online-resources/leaflets">Online Leaflets</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophical.org/publications/quest-magazine">"Quest" Magazine</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophical.org/online-resources/self-study-courses">Self Study Courses</a></p>
+<h2>Theosophical Society in Australia</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/resources-2/campbell-theosophical-research-library/">Campbell Theosophical Research Library</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/FromLib.htm">From the Campbell Library Collection</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-0.html">Links to Theosophical Texts Online</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://austheos.org.au/articles/articles-essays/"> Articles and Essays </a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://austheos.org.au/articles/theosophy-science-group-newsletter/">Science Newsletter Articles</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/indices/pindex.htm">Union Index of Theosophical Periodicals</a></p>
+<!--<h2>Theosophical Society in England</h2>
+<p><a href="http://www.theosophical-society.org.uk/ASP/insight.asp">Selected Articles from "Insight", from November/December 2001 and Blavatsky Lectures 1999 to 2003</a></p>
+-->
+<h2>Theosophical Society in Greece</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophicalsociety.gr/index.php/2">Theosophical Society in Greece - Articles</a></p>
+<h2>Theosophical Society in the Philippines</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy.ph/onlinebooks.html">Old Diary Leaves, by Henry Steel Olcott</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy.ph/onlinebooks.html">Theosophical Society in the Philippines: Online Books and Articles</a></p>
+<h2>Theosophical Society (Pasadena, CA)</h2>
+<p>See "Theosophical University Press Online" and "Theosophy Northwest"</p>
+<h2>Theosophical Society (Pasadena) Australasian Section</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophydownunder.org/ifensterl.php?./library/">Theosophy Downunder Library</a></p>
+<h2>Theosophical University Press Online</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosociety.org/pasadena/ts/tup-onl.htm">Theosophical University Press Online</a>, including:</p>
+<p>Books (by <a href="https://web.archive.org/web/20180314030552/http://www.theosociety.org/pasadena/ts/tup-onl.htm#author">Author</a> and by <a href="https://web.archive.org/web/20180314030552/http://www.theosociety.org/pasadena/ts/tup-onl.htm#title">Title</a>)</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosociety.org/pasadena/etgloss/etg-hp.htm">Encyclopedic Theosophical Glossary</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosociety.org/pasadena/ts/tup-onl.htm#introductory">Introductory Theosophical Manuals: G. de Purucker Series</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosociety.org/pasadena/sunrise/sunr-hp.htm">"Sunrise: Theosophic Perspectives" Magazine, Volumes 20-56, 1970-2007</a> by <a href="https://web.archive.org/web/20180314030552/http://www.theosociety.org/pasadena/sunrise/sun-back.htm">Author and by Issue/Date</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosociety.org/pasadena/sunrise/sunr-hp.htm#special">"Sunrise: Theosophic Perspectives" Special Issues, 1975-2006</a></p>
+<!-- no longer carrying documents online ?
+<h2>Theosophy Canada (Edmonton Theosophical Society)</h2>
+<p><a href="http://www.theosophycanada.com/ct.htm">Defence of Madame Blavatsky by Beatrice Hastings</a></p>
+<p><a href="http://www.theosophycanada.com/ct.htm">Selected Articles from "The Canadian Theosophist"</a></p>
+<p><a href="http://www.theosophycanada.com/fohat_exc.htm">Selected Articles from "Fohat"</a></p>
+-->
+<h2>Theosophy Company - see "United Lodge of Theosophists"</h2>
+<h2>Theosophy.com and Theosophy.net - conducted by Eldon Tucker</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy.com/index.html">Theosophy.com</a> and <a href="https://web.archive.org/web/20180314030552/http://www.theosophy.net/">Theosophy.net</a> (Theosophical Network)</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.hctheosophist.com/archives/news.html">"High Country Newsletter"</a> from April/December 1986 to June/August 1990</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.hctheosophist.com/archives/mags.html">"High Country Theosophist"</a> from January 1991 to March/April 2004</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theos-world.com/archives/index.html">"Theosophy World" Magazine</a>, online issues from May 1996</p>
+<!--<h2>Theosophy.info - compiled by Blavatsky Study Center</h2>
+<p><a href="http://theosophy.info/">Theosophy.info: A Reading Room of Articles, Books &amp; Other Material on Theosophy, H.P. Blavatsky &amp; the Mahatmas</a>, Blavatsky Study Center</p>
+-->
+<h2>Theosophy in Slovenia</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.teozofija.info/Clanki.htm">Articles Online</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.teozofija.info/Knjige.htm">Books Online</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.teozofija.info/Theosophia/Theosophia_index.htm">Theosophia</a>, magazine edited by Boris de Zirkoff, 1944-1981</p>
+<h2>Theosophy Library Online - ULT, Phoenix, Arizona</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophy.org/index.htm">Theosophy Library Online</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophy.org/index-pda.htm">Complete Online List</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophy.org/blavatsky.htm">H.P. Blavatsky</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophy.org/judge.htm">William Q. Judge</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophy.org/crosbie.htm">Robert Crosbie</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophytrust.org/rni_articles.php">Raghavan N. Iyer</a> - at Theosophy Trust</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophy.org/other.htm">Other Writers</a></p>
+<!--<h2>Theosophy Links</h2>
+<p><a href="http://theosophylinks.net/">TheosophyLinks.Net: Websites and Internet Resources on H P Blavatsky, the Mahatmas and Theosophy</a>, see also Blavatsky Archives</p>
+-->
+<h2>Theosophy Northwest - the Northwest Branch of The Theosophical Society (Pasadena, CA)</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/home/thnw-hp.htm">Theosophy Northwest:</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/ctg/ctg-hp.htm">Collation of Theosophical Glossaries</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/theos/alc-jal.htm">Colonel Arthur L. Conger and James A. Long: Theosophical Topics in Depth</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/theos/gdp-selc.htm">Gottfried de Purucker: Theosophical Topics in Depth</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/theos/gfk-selc.htm">Grace F. Knoche: Theosophical Topics in Depth</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/theos/hpb-selc.htm">H.P. Blavatsky - Theosophical Topics in Depth</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/theos/kt-selec.htm">Katherine Tingley and Point Loma: Theosophical Topics in Depth</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosociety.org/pasadena/sunrise/sunr-hp.htm">Sunrise: Theosophic Perspectives</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/ktmanual/kt-hp.htm">Theosophical Manuals: Katherine Tingley Series</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/theos/sd-selec.htm">"The Secret Doctrine", Commentaries, Historical Material and Reference Works</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/books/books-hp.htm">Theosophical and Related Publications - by Author</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/home/art-ol.htm">Theosophy and Related Subjects: Almost 1000 Articles, organized by Topic</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/theos/th-selec.htm">Theosophy and The Theosophical Society: Theosophical Topics in Depth</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophy-nw.org/theosnw/theos/wqj-selc.htm">William Q. Judge and Henry S. Olcott: Theosophical Topics in Depth</a></p>
+<h2>Theosophy Trust - Sri Raghavan Iyer Memorial Library - HERMES Library</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophytrust.org/main.php">Theosophy Trust</a> - Sri Raghavan Iyer Memorial Library - HERMES Library</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophytrust.org/search.php">Search Facility</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/https://theosophytrust.mobi/listing-teacher_article">The Teacher Articles</a>, by Elton Hall</p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophytrust.org/rni_articles.php">The Writings of Raghavan Iyer</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/https://www.theosophytrust.org/theosophy-online-books.htm">Theosophy Trust Books Online</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophytrust.org/HPB_index.php">The Writings of H.P. Blavatsky</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/https://www.theosophytrust.org/RCrosbie-article">The Writings of Robert Crosbie</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophytrust.org/william_index.php">The Writings of William Q. Judge</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://theosophytrust.org/other_index.php">The Writings of Other Authors</a></p>
+<h2>U.L.T. Athens, Greece - see Blavatsky.gr</h2>
+<h2>United Lodge of Theosophists (ULT), Malmo, Sweden</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.teosofiskakompaniet.net/">The Theosophical Library Online</a>, including 1008 texts in English by Helena Blavatsky, William Q. Judge, Robert Crosbie, and B.P. Wadia</p>
+<h2>United Lodge of Theosophists (ULT), New York, USA</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.ult.org/freelit.html">Free Literature Online: Pamphlets</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.ult.org/index2.html">Free Videos Online</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.ult.org/hpbjudge.html">Selected Articles by H.P. Blavatsky and W.Q. Judge</a></p>
+<h2>United Lodge of Theosophists (ULT), Phoenix, Arizona, USA</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.phx-ult-lodge.org/#top">Books and some Articles</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.phx-ult-lodge.org/articles_of_william_q.htm">Judge Articles (222)</a></p>
+<!--<h2>United Lodge of Theosophists (ULT): "TheosophySandiego", San Diego, CA, USA</h2>
+<p><a href="http://www.theosophysandiego.org/online/online.htm">Books Online</a></p>
+-->
+<h2>Universal Access to Human Knowledge</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.archive.org/search.php?query=theosophy">Internet Archive : Theosophical Titles Online (174)</a></p>
+<h2>Wikipedia, the free encyclopedia</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://en.wikipedia.org/wiki/Main_Page">Wikipedia - Main Page</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://en.wikipedia.org/wiki/Theosophy">Article on Theosophy</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://en.wikipedia.org/wiki/Wikipedia:Quick_index">Contents: Quick Index - by first two letters</a></p>
+<p><a href="https://web.archive.org/web/20180314030552/http://en.wikipedia.org/wiki/Special:Search?search=">Wikipedia - Search</a></p>
+<h2>www.TheosophyOnline.com</h2>
+<p><a href="https://web.archive.org/web/20180314030552/http://www.theosophyonline.com/materias.php?session=29">&quot;The Aquarian Theosophist&quot; Magazine, from Volume I (November 2000)</a></p>
+<!-- End links to Theosophical Texts -->
+
+<!-- Begin bottom and additional navigation -->
+<p>&nbsp;</p>
+<hr/>
+<br style="clear:both"/>
+<!--  start outer -->
+<div class="navigationcontainer">
+<!-- start inner -->
+<div class="navigation bottom" style="text-align:center">
+<p class="navnames"><b><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-besant.html"><span class="itembox">Besant</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-blavatsky.html"><span class="itembox">Blavatsky</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-depurucker.html"><span class="itembox">de Purucker</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-judge.html"><span class="itembox">Judge</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-leadbeater.html"><span class="itembox">Leadbeater</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-olcott.html"><span class="itembox">Olcott</span></a></b></p>
+<br/><p class="navalphabet"><b><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-a.html"><span class="itembox">A</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-b.html"><span class="itembox">B</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-c.html"><span class="itembox">C</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-d.html"><span class="itembox">D</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-e.html"><span class="itembox">E</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-f.html"><span class="itembox">F</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-g.html"><span class="itembox">G</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-h.html"><span class="itembox">H</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-i.html"><span class="itembox">I</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-j.html"><span class="itembox">J</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-k.html"><span class="itembox">K</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-l.html"><span class="itembox">L</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-m.html"><span class="itembox">M</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-n.html"><span class="itembox">N</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-o.html"><span class="itembox">O</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-p.html"><span class="itembox">P</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-q.html"><span class="itembox">Q</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-r.html"><span class="itembox">R</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-s.html"><span class="itembox">S</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-t.html"><span class="itembox">T</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-u.html"><span class="itembox">U</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-v.html"><span class="itembox">V</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-w.html"><span class="itembox">W</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-x.html"><span class="itembox">X</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-y.html"><span class="itembox">Y</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-z.html"><span class="itembox">Z</span></a></b></p>
+<br/><p class="navgroups"><b><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-early-classics.html"><span class="itembox">Early Classics</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-online-periodicals.html"><span class="itembox">Online Periodicals</span></a></b><b><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-online-libraries.html"><span class="itemboxrev whitecustom">Online Libraries</span></a><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/clibrary/bindex-glossaries.html"><span class="itembox">Glossaries</span></a></b></p>
+</div>
+<!--  end inner -->
+</div>
+<!--  end outer -->
+
+<!-- Begin additional navigation -->
+<p class="sitenav"><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/resources-2/campbell-theosophical-research-library/">The Campbell Theosophical Research Library</a></p>
+<p class="sitenav"><a class="nav" href="https://web.archive.org/web/20180314030552/http://www.austheos.org.au/">The Theosophical Society in Australia</a> Home</p>
+<p class="pageinfo">Updated 7 February 2018&nbsp;&nbsp;&nbsp;Compliant <a class="nav" href="https://web.archive.org/web/20180314030552/http://validator.w3.org/check?uri=referer">XHTML 1.0T</a> and <a class="nav" href="https://web.archive.org/web/20180314030552/http://jigsaw.w3.org/css-validator/check/referer"> CSS 3</a></p>
+<!-- End bottom and additional navigation -->
+</body>
+</html><!--
+     FILE ARCHIVED ON 03:05:52 Mar 14, 2018 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 16:24:52 May 29, 2026.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 1.125
+  exclusion.robots: 0.126
+  exclusion.robots.policy: 0.108
+  esindex: 0.014
+  cdx.remote: 9.016
+  LoadShardBlock: 222.205 (3)
+  PetaboxLoader3.datanode: 73.771 (4)
+  PetaboxLoader3.resolve: 568.521 (2)
+  load_resource: 481.199
+-->

--- a/scripts/maintenance/import-theosophy-tier1.mjs
+++ b/scripts/maintenance/import-theosophy-tier1.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Import batch — "Theosophy & the Wisdom Traditions", Tier 1
+ *
+ * Seeded by Reinout Spaink's Campbell Theosophical Research Library directory
+ * (raw pages saved at .claude/docs/theosophical-import/). Reinout flagged the
+ * AUSTHEOS "Links to Theosophical Texts Online" index — now dead on the live web,
+ * surviving only via the Wayback Machine — as a high-value map of the wisdom
+ * traditions. The importable layer it points at is the Internet Archive corpus.
+ *
+ * Tier 1 = Early Classics overlapping Source Library's core mission
+ * (Hermetica / Gnostic / Kabbalah primaries), scanned public-domain originals.
+ *
+ * Deduped 2026-05-29 against the live collection. Already held (skipped):
+ *   - Ficino 1481 Pimander (bib_fict_4102599)
+ *   - Mead, Thrice-Greatest Hermes vols I-III (thricegreatesthe0{1,2,3}hermuoft)
+ *   - Mead, Fragments of a Faith Forgotten (fragmentsoffaith00meaduoft)
+ *
+ * Imports are additive and start hidden; reversible via /api/books/restore/[id].
+ */
+
+const BASE = process.env.SL_BASE || 'https://sourcelibrary.org';
+const CRON_SECRET = process.env.CRON_SECRET;
+if (!CRON_SECRET) {
+  console.error('Missing CRON_SECRET — source .env.production.local first.');
+  process.exit(1);
+}
+const AUTH = { Authorization: `Bearer ${CRON_SECRET}` };
+
+const BOOKS = [
+  // ---- Hermetica ----
+  {
+    ia_identifier: 'b30329619',
+    title: 'The Divine Pymander of Hermes Mercurius Trismegistus, in XVII Books',
+    author: 'Hermes Trismegistus (trans. John Everard)',
+    year: 1650,
+    original_language: 'English',
+    note: 'Major 17th-c English translation of the Corpus Hermeticum — primary edition.',
+  },
+  {
+    ia_identifier: 'hymnshermes00hermgoog',
+    title: 'The Hymns of Hermes',
+    author: 'G. R. S. Mead',
+    year: 1907,
+    original_language: 'English',
+    note: 'Mead\'s edition of the Hermetic hymns; companion to Thrice-Greatest Hermes.',
+  },
+  // ---- Gnostic (public-domain Mead-era editions) ----
+  {
+    ia_identifier: 'pistissophiagnos00mead',
+    title: 'Pistis Sophia: A Gnostic Gospel',
+    author: 'G. R. S. Mead',
+    year: 1896,
+    original_language: 'English',
+    note: 'Foundational Gnostic primary text — Mead\'s first English translation (1896).',
+  },
+  // ---- Kabbalah ----
+  {
+    ia_identifier: 'bub_gb_oDUgg6Xh8LgC',
+    title: 'Kabbala Denudata seu Doctrina Hebraeorum Transcendentalis et Metaphysica',
+    author: 'Christian Knorr von Rosenroth',
+    year: 1677,
+    original_language: 'Latin',
+    work_id: 'knorr-kabbala-denudata',
+    note: 'THE early-modern Christian Kabbalah primary; source for later Zohar translations.',
+  },
+  {
+    ia_identifier: 'b24884443',
+    title: 'The Kabbalah Unveiled, Containing the Following Books of the Zohar',
+    author: 'S. L. MacGregor Mathers',
+    year: 1887,
+    original_language: 'English',
+    work_id: 'knorr-kabbala-denudata',
+    note: 'English translation of Zohar excerpts drawn from Knorr\'s Kabbala Denudata.',
+  },
+  {
+    ia_identifier: 'cu31924075115380',
+    title: 'The Kabbalah: Its Doctrines, Development, and Literature',
+    author: 'Christian D. Ginsburg',
+    year: 1865,
+    original_language: 'English',
+    note: 'FLAG: 19th-c scholarly study (secondary), kept for its survey value; lower fit.',
+  },
+];
+
+async function importWithRetry(book) {
+  const { note, ...payload } = book;
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    let res, text;
+    try {
+      res = await fetch(`${BASE}/api/import/ia`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...AUTH },
+        body: JSON.stringify(payload),
+      });
+      text = await res.text();
+    } catch (e) {
+      if (attempt === 4) return { ok: false, status: 0, text: String(e) };
+      await new Promise((r) => setTimeout(r, 10000));
+      continue;
+    }
+    if (res.ok || res.status === 409) return { ok: res.ok, status: res.status, text };
+    const transient = res.status >= 500 && /Timeout|timed out|fetch failed/i.test(text);
+    if (!transient || attempt === 4) return { ok: false, status: res.status, text };
+    await new Promise((r) => setTimeout(r, 10000));
+  }
+}
+
+const results = [];
+for (const book of BOOKS) {
+  const r = await importWithRetry(book);
+  const tag = r.status === 409 ? 'EXISTS' : r.ok ? 'OK' : `FAIL(${r.status})`;
+  console.log(`[${tag}] ${book.ia_identifier} — ${book.title}`);
+  if (!r.ok && r.status !== 409) console.log(`        ${r.text.slice(0, 200)}`);
+  results.push({ id: book.ia_identifier, tag });
+}
+
+const ok = results.filter((r) => r.tag === 'OK').length;
+const exists = results.filter((r) => r.tag === 'EXISTS').length;
+const fail = results.filter((r) => r.tag.startsWith('FAIL')).length;
+console.log(`\nSummary: ${ok} imported, ${exists} already existed, ${fail} failed (of ${BOOKS.length}).`);


### PR DESCRIPTION
## Why
Reinout Spaink (theosophy researcher, attending the June 4 launch) emailed Derek a pointer to the **Campbell Theosophical Research Library** index — the catalog of the Theosophical Society in Australia. The original site (`austheos.org.au/clibrary/`) is **dead on the live web** and survives only via the Wayback Machine; Reinout urged grabbing it before the archived copy also goes.

## What's in scope
- **Source snapshot** (`.claude/docs/theosophical-import/`): the three Wayback pages (index, Early Classics, Online Theosophical Libraries) + a README documenting provenance and what's actually importable.
- **Tier 1 import script** (`scripts/maintenance/import-theosophy-tier1.mjs`): Early Classics overlapping our core mission — Hermetica / Gnostic / Kabbalah primaries.

## Imports (already run against production, `visible: false`)
Deduped against the live collection — we already held the Ficino 1481 *Pimander*, Mead's *Thrice-Greatest Hermes* (3 vols), *Fragments of a Faith Forgotten*, and a *Pistis Sophia* edition. 5 net-new landed and were verified in Mongo:

| IA id | Title | Year | Lang | Pages |
|---|---|---|---|---|
| `b30329619` | The Divine Pymander (Everard) | 1650 | English | 236 |
| `hymnshermes00hermgoog` | The Hymns of Hermes (Mead) | 1907 | English | 93 |
| `bub_gb_oDUgg6Xh8LgC` | **Kabbala Denudata** (Knorr von Rosenroth) | 1677 | **Latin** | 776 |
| `b24884443` | The Kabbalah Unveiled (Mathers) | 1887 | English | 408 |
| `cu31924075115380` | The Kabbalah (Ginsburg) | 1865 | English | 166 |

Standout: the 1677 *Kabbala Denudata*, a genuine early-modern Christian Kabbalah primary.

## Notes for reviewers
- The `/api/import/*` routes now require `editor`+ role (the curator skill doc is stale on this). The script authenticates via the existing `CRON_SECRET` bearer bypass in `withAuth`.
- Imports are additive and start hidden; reversible via `/api/books/restore/[id]`. They have page images, so the pipeline cron will auto-enroll them for OCR/translation.
- The `?ia_identifier=` audit filter on `/api/books` returns `[]` for these even though they exist — fetch-by-id confirms them. Possible pre-existing filter-field mismatch, flagged but not addressed here.

## Out of scope (deliberately)
- **Tier 2** (Blavatsky / TS canon: *Secret Doctrine*, *Isis Unveiled*, Besant, Olcott, Judge, Leadbeater) — candidate IDs gathered, held for a separate batch.
- Promoting these to `visible: true` and any collection assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)