### PR TITLE
ILP catalogue polish: folio 404 fix, BPH-style table, drop visual art, author links

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -181,8 +181,7 @@ function linkBookTitles(
   // from the collection's book authors; a token mapping to more than one author
   // is ambiguous and skipped. Best-effort prose linking (names appear in many
   // forms — "Galileo", "Bruno", "Descartes" — so we match any unique token).
-  const tokenHref = new Map<string, string>();
-  const tokenCount = new Map<string, number>();
+  const tokenHrefs = new Map<string, Set<string>>();
   const authorSource = [...allBooks.map(b => b.author), ...authorStrings];
   for (const author of authorSource) {
     const a = (author || '').trim();
@@ -194,12 +193,13 @@ function linkBookTitles(
       const tok = raw.trim().toLowerCase();
       if (tok.length < 5 || seenInThisAuthor.has(tok)) continue;
       seenInThisAuthor.add(tok);
-      tokenCount.set(tok, (tokenCount.get(tok) || 0) + 1);
-      if (!tokenHref.has(tok)) tokenHref.set(tok, href);
+      if (!tokenHrefs.has(tok)) tokenHrefs.set(tok, new Set());
+      tokenHrefs.get(tok)!.add(href);
     }
   }
-  for (const [tok, href] of tokenHref) {
-    if ((tokenCount.get(tok) || 0) > 1) continue; // ambiguous across authors
+  for (const [tok, hrefs] of tokenHrefs) {
+    if (hrefs.size !== 1) continue; // maps to >1 distinct author page → ambiguous
+    const href = [...hrefs][0];
     const escaped = tok.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const regex = new RegExp(`\\b${escaped}\\b`, 'gi');
     let match;

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -20,6 +20,8 @@ import { bookTitle, sanitizeThumbnail, withTimeout } from '@/lib/collections-uti
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import { browseBooks } from '@/lib/books-catalog';
+import { supabase } from '@/lib/supabase';
+import { authorUrl } from '@/lib/slugify';
 
 // ISR: rebuild at most once per day
 export const revalidate = 86400;
@@ -125,7 +127,7 @@ function linkBookTitles(
   explicitMentions?: { text: string; book_id: string }[],
   tenantSlug?: string | null,
 ): React.ReactNode {
-  const matches: { start: number; end: number; title: string; id: string }[] = [];
+  const matches: { start: number; end: number; title: string; id: string; href?: string }[] = [];
   const usedRanges: [number, number][] = [];
 
   // 1. Explicit mentions first (highest priority — exact text from description)
@@ -174,6 +176,41 @@ function linkBookTitles(
     }
   }
 
+  // 3. Author names → author pages. Collect distinctive name tokens (≥5 chars)
+  // from the collection's book authors; a token mapping to more than one author
+  // is ambiguous and skipped. Best-effort prose linking (names appear in many
+  // forms — "Galileo", "Bruno", "Descartes" — so we match any unique token).
+  const tokenHref = new Map<string, string>();
+  const tokenCount = new Map<string, number>();
+  for (const book of allBooks) {
+    const a = (book.author || '').trim();
+    if (!a) continue;
+    const href = authorUrl(a);
+    if (!href) continue;
+    const seenInThisAuthor = new Set<string>();
+    for (const raw of a.replace(/\([^)]*\)/g, '').split(/[\s,;|]+/)) {
+      const tok = raw.trim().toLowerCase();
+      if (tok.length < 5 || seenInThisAuthor.has(tok)) continue;
+      seenInThisAuthor.add(tok);
+      tokenCount.set(tok, (tokenCount.get(tok) || 0) + 1);
+      if (!tokenHref.has(tok)) tokenHref.set(tok, href);
+    }
+  }
+  for (const [tok, href] of tokenHref) {
+    if ((tokenCount.get(tok) || 0) > 1) continue; // ambiguous across authors
+    const escaped = tok.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`\\b${escaped}\\b`, 'gi');
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const start = match.index;
+      const end = start + match[0].length;
+      if (!usedRanges.some(([s, e]) => start < e && end > s)) {
+        matches.push({ start, end, title: match[0], id: `author-${tok}`, href });
+        usedRanges.push([start, end]);
+      }
+    }
+  }
+
   if (matches.length === 0) return text;
   matches.sort((a, b) => a.start - b.start);
 
@@ -182,7 +219,7 @@ function linkBookTitles(
   for (const m of matches) {
     if (m.start > lastIdx) parts.push(text.slice(lastIdx, m.start));
     parts.push(
-      <Link key={m.id + '-' + m.start} href={tenantBookUrl({ id: m.id }, tenantSlug)} className="text-accent-rust hover:underline italic">
+      <Link key={m.id + '-' + m.start} href={m.href ?? tenantBookUrl({ id: m.id }, tenantSlug)} className="text-accent-rust hover:underline italic">
         {m.title}
       </Link>
     );
@@ -590,6 +627,13 @@ export default async function CollectionDetailPage({ params, provider }: Props &
   if (!data) notFound();
 
   const { collection, books, highlights: curatedHighlightsData, galleryImages, total, mentionedBooks, parentCollection, galleryCollectionSlug, galleryTotalCount, exhibition, exhibitionBooks, childCollections, artworks } = data;
+
+  // Collections that carry an Index catalogue (index_catalogs editions) render
+  // the catalogue browser as their centrepiece — hide the Visual Art section
+  // there so it doesn't compete with the bans listing.
+  const { count: catalogEditionCount } = await supabase
+    .from('index_catalogs').select('id', { count: 'exact', head: true }).eq('collection_slug', id);
+  const isCatalogCollection = (catalogEditionCount ?? 0) > 0;
   const languages = (collection.languages || []).filter((l: { count: number }) => l.count > 2);
   const isArtCollection = collection.collection_type === 'visual_art';
   const itemLabel = isArtCollection ? 'works' : 'books';
@@ -954,7 +998,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
       {/* Gallery section moved above exhibition/featured book */}
 
       {/* Visual Art — artworks tagged to this collection (hidden when exhibition present) */}
-      {artworks.length > 0 && !exhibition?.layout && (
+      {artworks.length > 0 && !exhibition?.layout && !isCatalogCollection && (
         <div className="bg-warm border-b border-border-light">
           <div className="max-w-7xl mx-auto px-6 py-8">
             <div className="flex items-center justify-between mb-2">

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -126,6 +126,7 @@ function linkBookTitles(
   allBooks: BookItem[],
   explicitMentions?: { text: string; book_id: string }[],
   tenantSlug?: string | null,
+  authorStrings: string[] = [],
 ): React.ReactNode {
   const matches: { start: number; end: number; title: string; id: string; href?: string }[] = [];
   const usedRanges: [number, number][] = [];
@@ -182,8 +183,9 @@ function linkBookTitles(
   // forms — "Galileo", "Bruno", "Descartes" — so we match any unique token).
   const tokenHref = new Map<string, string>();
   const tokenCount = new Map<string, number>();
-  for (const book of allBooks) {
-    const a = (book.author || '').trim();
+  const authorSource = [...allBooks.map(b => b.author), ...authorStrings];
+  for (const author of authorSource) {
+    const a = (author || '').trim();
     if (!a) continue;
     const href = authorUrl(a);
     if (!href) continue;
@@ -634,6 +636,17 @@ export default async function CollectionDetailPage({ params, provider }: Props &
   const { count: catalogEditionCount } = await supabase
     .from('index_catalogs').select('id', { count: 'exact', head: true }).eq('collection_slug', id);
   const isCatalogCollection = (catalogEditionCount ?? 0) > 0;
+
+  // For catalogue collections, the description names many authors (Bruno,
+  // Galileo, …) — link them to their author pages. `books` is only a compact
+  // subset, so pull the full distinct author list for the description linker.
+  let descriptionAuthors: string[] = [];
+  if (isCatalogCollection) {
+    try {
+      const db = await getReadDb();
+      descriptionAuthors = (await db.collection('books').distinct('author', { collections: id })) as string[];
+    } catch { /* non-fatal — description just won't gain author links */ }
+  }
   const languages = (collection.languages || []).filter((l: { count: number }) => l.count > 2);
   const isArtCollection = collection.collection_type === 'visual_art';
   const itemLabel = isArtCollection ? 'works' : 'books';
@@ -1084,7 +1097,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
             <div className="max-w-4xl">
               {(collection.expanded_description || collection.description)!.split('\n\n').map((para: string, i: number) => (
                 <p key={i} className="text-secondary text-lg leading-relaxed mb-4 last:mb-0 font-body">
-                  {linkBookTitles(para, allBooksForLinking, explicitMentions, tenantSlug)}
+                  {linkBookTitles(para, allBooksForLinking, explicitMentions, tenantSlug, descriptionAuthors)}
                 </p>
               ))}
             </div>

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -184,7 +184,9 @@ function linkBookTitles(
   const tokenHrefs = new Map<string, Set<string>>();
   const authorSource = [...allBooks.map(b => b.author), ...authorStrings];
   for (const author of authorSource) {
-    const a = (author || '').trim();
+    // Normalise so date/qualifier variants of ONE person collapse to one page:
+    // "Bruno, Giordano, 1548-1600" / "Bruno, Giordano (Nolan)" → "Bruno, Giordano".
+    const a = (author || '').replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').trim().replace(/[,;]\s*$/, '');
     if (!a) continue;
     const href = authorUrl(a);
     if (!href) continue;

--- a/src/components/collections/IndexCatalogSection.tsx
+++ b/src/components/collections/IndexCatalogSection.tsx
@@ -194,84 +194,77 @@ export default function IndexCatalogSection({ catalogs }: Props) {
         </div>
       ) : (
         <>
-          <ul className="divide-y divide-stone-200 border-t border-b border-stone-200">
-            {loading && entries.length === 0 ? (
-              <li className="py-8 text-center text-stone-500 text-sm">Loading…</li>
-            ) : entries.length === 0 ? (
-              <li className="py-8 text-center text-stone-500 text-sm">No matching entries.</li>
-            ) : entries.map(e => (
-              <li key={e.id} className="py-4 flex flex-col sm:flex-row sm:items-baseline gap-2 sm:gap-4">
-                <div className="flex-grow min-w-0">
-                  <div className="font-display text-base text-stone-900 leading-snug">
-                    {e.sl_book_slug ? (
-                      <Link href={`/book/${e.sl_book_slug}`} className="hover:underline">{e.title}</Link>
-                    ) : (
-                      <span>{e.title}</span>
-                    )}
-                  </div>
-                  <div className="text-sm text-stone-600 mt-0.5">
-                    {e.author && <span>{e.author}</span>}
-                    {e.publication_date && <span className="text-stone-400"> · {e.publication_date}</span>}
-                    {e.scope === 'opera_omnia' && (
-                      <span className="ml-2 inline-block text-[10px] uppercase tracking-wider bg-red-100 text-red-900 px-1.5 py-0.5 rounded">
-                        Opera omnia
-                      </span>
-                    )}
-                    {e.scope === 'donec_corrigatur' && (
-                      <span className="ml-2 inline-block text-[10px] uppercase tracking-wider bg-amber-100 text-amber-900 px-1.5 py-0.5 rounded">
-                        Donec corrigatur
-                      </span>
-                    )}
-                    {e.scope === 'expurgated' && (
-                      <span className="ml-2 inline-block text-[10px] uppercase tracking-wider bg-amber-100 text-amber-900 px-1.5 py-0.5 rounded">
-                        Expurgated
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div className="flex flex-wrap gap-2 text-xs">
-                  {e.sl_book_slug ? (
-                    <Link
-                      href={`/book/${e.sl_book_slug}`}
-                      className="inline-flex items-center gap-1 px-3 py-1.5 bg-stone-800 text-white rounded hover:bg-stone-900"
-                    >
-                      <BookOpen className="w-3.5 h-3.5" />
-                      Read at Source Library
-                    </Link>
-                  ) : e.author_held_count && e.author_held_count > 0 && e.author_held_sample_slug ? (
-                    <Link
-                      href={`/book/${e.author_held_sample_slug}`}
-                      className="inline-flex items-center gap-1 px-3 py-1.5 bg-amber-100 text-amber-900 border border-amber-300 rounded hover:bg-amber-200"
-                      title={`Source Library holds ${e.author_held_count} book${e.author_held_count === 1 ? '' : 's'} by this author, but not this specific work`}
-                    >
-                      <User className="w-3.5 h-3.5" />
-                      {e.author_held_count} {e.author_held_count === 1 ? 'book' : 'books'} by author
-                    </Link>
-                  ) : e.ustc_sn ? (
-                    <a
-                      href={`https://www.ustc.ac.uk/editions/${e.ustc_sn}`}
-                      target="_blank"
-                      rel="noopener"
-                      className="inline-flex items-center gap-1 px-3 py-1.5 border border-stone-400 text-stone-700 rounded hover:bg-stone-100"
-                    >
-                      <ExternalLink className="w-3.5 h-3.5" />
-                      USTC {e.ustc_sn}
-                    </a>
-                  ) : null}
-                  {e.source_book_slug && e.source_page != null && (
-                    <Link
-                      href={`/book/${e.source_book_slug}/page/${e.source_page}`}
-                      className="inline-flex items-center gap-1 px-3 py-1.5 border border-stone-300 text-stone-500 rounded hover:bg-stone-100"
-                      title="See this entry on the original scanned page of the printed Index"
-                    >
-                      <BookMarked className="w-3.5 h-3.5" />
-                      In the Index, p.{e.source_page}
-                    </Link>
-                  )}
-                </div>
-              </li>
-            ))}
-          </ul>
+          <div className="overflow-x-auto rounded-lg border border-stone-200 bg-white">
+            <table className="w-full text-sm">
+              <thead className="bg-stone-50 text-left">
+                <tr className="text-stone-700">
+                  <th className="px-3 py-2 font-medium">Author</th>
+                  <th className="px-3 py-2 font-medium">Work</th>
+                  <th className="px-3 py-2 font-medium whitespace-nowrap">Condemned</th>
+                  <th className="px-3 py-2 font-medium">Scope</th>
+                  <th className="px-3 py-2 font-medium">In the library</th>
+                  <th className="px-3 py-2 font-medium">Source</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-stone-100">
+                {loading && entries.length === 0 ? (
+                  <tr><td colSpan={6} className="py-8 text-center text-stone-500">Loading…</td></tr>
+                ) : entries.length === 0 ? (
+                  <tr><td colSpan={6} className="py-8 text-center text-stone-500">No matching entries.</td></tr>
+                ) : entries.map(e => {
+                  const scopeBadge =
+                    e.scope === 'opera_omnia' ? { label: 'Opera omnia', cls: 'bg-red-100 text-red-900' } :
+                    e.scope === 'donec_corrigatur' ? { label: 'Donec corrigatur', cls: 'bg-amber-100 text-amber-900' } :
+                    e.scope === 'expurgated' ? { label: 'Expurgated', cls: 'bg-amber-100 text-amber-900' } :
+                    e.scope === 'single_work' ? { label: 'Banned', cls: 'bg-stone-100 text-stone-700' } : null;
+                  return (
+                    <tr key={e.id} className="align-top hover:bg-stone-50/60">
+                      <td className="px-3 py-2.5 text-stone-700 whitespace-nowrap">{e.author || <span className="text-stone-400">—</span>}</td>
+                      <td className="px-3 py-2.5 font-display text-stone-900 min-w-[14rem]">
+                        {e.sl_book_slug
+                          ? <Link href={`/book/${e.sl_book_slug}`} className="hover:underline">{e.title}</Link>
+                          : <span>{e.title}</span>}
+                      </td>
+                      <td className="px-3 py-2.5 text-stone-500 whitespace-nowrap">{e.condemnation_year ?? e.publication_date ?? '—'}</td>
+                      <td className="px-3 py-2.5">
+                        {scopeBadge && (
+                          <span className={`inline-block text-[10px] uppercase tracking-wider ${scopeBadge.cls} px-1.5 py-0.5 rounded`}>
+                            {scopeBadge.label}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2.5 whitespace-nowrap">
+                        {e.sl_book_slug ? (
+                          <Link href={`/book/${e.sl_book_slug}`} className="inline-flex items-center gap-1 text-stone-800 hover:underline">
+                            <BookOpen className="w-3.5 h-3.5" /> Read
+                          </Link>
+                        ) : e.author_held_count && e.author_held_count > 0 && e.author_held_sample_slug ? (
+                          <Link href={`/book/${e.author_held_sample_slug}`} className="inline-flex items-center gap-1 text-amber-800 hover:underline"
+                            title={`We hold ${e.author_held_count} book${e.author_held_count === 1 ? '' : 's'} by this author, not this specific work`}>
+                            <User className="w-3.5 h-3.5" /> {e.author_held_count} by author
+                          </Link>
+                        ) : e.ustc_sn ? (
+                          <a href={`https://www.ustc.ac.uk/editions/${e.ustc_sn}`} target="_blank" rel="noopener"
+                            className="inline-flex items-center gap-1 text-stone-500 hover:underline">
+                            <ExternalLink className="w-3.5 h-3.5" /> USTC
+                          </a>
+                        ) : <span className="text-stone-300">—</span>}
+                      </td>
+                      <td className="px-3 py-2.5 whitespace-nowrap">
+                        {e.source_book_slug && e.source_page != null ? (
+                          <Link href={`/book/${e.source_book_slug}/page-number/${e.source_page}`}
+                            className="inline-flex items-center gap-1 text-stone-500 hover:underline"
+                            title="See this entry on the original scanned page of the printed Index">
+                            <BookMarked className="w-3.5 h-3.5" /> p.{e.source_page}
+                          </Link>
+                        ) : <span className="text-stone-300">—</span>}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
 
           {totalPages > 1 && (
             <nav className="flex items-center justify-between mt-6 text-sm">


### PR DESCRIPTION
Live-review fixes for the Index collection page.

1. **Folio links 404'd** — `/book/<slug>/page/<n>` resolves `[pageId]` as the page *document id*, not the page number, so numeric pages `notFound()`. Switched to the `/page-number/<n>` route (redirects to canonical). Verified it resolves to the real scan.
2. **BPH-style table** — the entry list is now a bordered, columnar, sortable-feeling table (Author · Work · Condemned · Scope · In the library · Source) matching `TenantCatalogueTable`, instead of the stacked `<ul>`.
3. **Drop Visual Art** on catalogue collections (gated by a cheap `index_catalogs` head-count) so it doesn't compete with the bans listing.
4. **Description author links** — the linkifier now links author names (Bruno, Galileo, Servetus…) to their author pages, sourced from the collection's own book authors (distinctive tokens ≥5 chars; ambiguous tokens skipped). Best-effort prose linking.

tsc clean; will verify on preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)