### PR TITLE
docs(pipeline): watchdog runs on Hetzner cron, not Mac launchd

### DIFF
--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -18,7 +18,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 | Chapter extraction | **Hetzner** (`enrich-worker.mjs`) | Direct Gemini calls, runs after summary+index |
 | Lightweight crons | **Vercel** | social-post, health-check, daily-report, warm |
 | e-rara / Harvard / Gallica archiving | **Local Mac** via launchd | Source hosts block Hetzner IPs (`archive-{erara,harvard,gallica}.mjs`, every 30 min, plists `org.sourcelibrary.archive-*`) |
-| Archiving watchdog | **Local Mac** via launchd (`org.sourcelibrary.archiving-watchdog`, every 6h) | Self-heals books stuck in `archiving`: parks IA-lending/dead-URL books → `needs_attention`, escalates stale-unreachable, optional `--rearchive`. `scripts/maintenance/archiving-watchdog.mjs`, logs `/tmp/archiving-watchdog.log`, audit in `watchdog_runs`. Permanent home should be Hetzner cron. |
+| Archiving watchdog | **Hetzner** crontab (`45 */6 * * *`, every 6h) | Self-heals books stuck in `archiving`: parks IA-lending/dead-URL books → `needs_attention`, escalates stale-unreachable. `scripts/maintenance/archiving-watchdog.mjs --apply` (conservative; add `--rearchive` manually to push recoverable books to R2). Logs `/var/log/sourcelibrary/archiving-watchdog.log`, audit in `watchdog_runs`. |
 
 **Lambda translation is deprecated for the main pipeline.** The SQS FIFO translation queue is only used for preview translation and manual job submission. The Hetzner `translate-worker.mjs` handles all production translation.
 


### PR DESCRIPTION
Follow-up to #2182. The archiving watchdog was deployed to the **Hetzner crontab** (`45 */6 * * *`, conservative `--apply` mode), and the temporary Mac launchd job was removed. This corrects the `pipeline-ops.md` row to show the real runner and log path (`/var/log/sourcelibrary/archiving-watchdog.log`).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)