### PR TITLE
fix(author): CSP-safe Wikidata portraits + life-date backfill

### DIFF
--- a/scripts/maintenance/backfill-wikidata-portraits-dates.mjs
+++ b/scripts/maintenance/backfill-wikidata-portraits-dates.mjs
@@ -1,0 +1,114 @@
+/**
+ * Backfill Wikidata enrichment on author/artist `entities`:
+ *   - portrait_url : re-resolve P18 to a CSP-safe upload.wikimedia.org URL
+ *                    (the old code cached commons.wikimedia.org/w/thumb.php
+ *                    URLs, which the site CSP img-src blocks in browsers)
+ *   - wikidata_birth_date / wikidata_death_date : P569 / P570
+ *
+ * Targets any entity with a wikidata_id that is missing a date OR whose
+ * portrait_url points at the blocked commons.wikimedia.org domain. The page
+ * render path (src/lib/wikidata-enrichment.ts) self-heals these lazily too —
+ * this script just does it eagerly so cached/CDN pages get fixed dates.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; \
+ *   node scripts/maintenance/backfill-wikidata-portraits-dates.mjs [--limit N] [--dry]
+ */
+import { MongoClient } from 'mongodb';
+
+const DRY = process.argv.includes('--dry');
+const limitArg = process.argv.indexOf('--limit');
+const LIMIT = limitArg !== -1 ? parseInt(process.argv[limitArg + 1], 10) : Infinity;
+
+const UA = 'sourcelibrary-entity-enrichment/1.0 (https://sourcelibrary.org)';
+
+function normaliseTime(time) {
+  if (!time) return null;
+  const m = time.match(/^\+?(-?\d{1,4}-\d{2}-\d{2})/);
+  return m ? m[1] : null;
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' } });
+  if (!res.ok) throw new Error(`${res.status} ${url}`);
+  return res.json();
+}
+
+async function resolvePortrait(filename) {
+  const url =
+    `https://commons.wikimedia.org/w/api.php?action=query&format=json` +
+    `&titles=${encodeURIComponent(`File:${filename}`)}` +
+    `&prop=imageinfo&iiprop=url&iiurlwidth=300`;
+  const data = await fetchJson(url);
+  const page = Object.values(data?.query?.pages || {})[0];
+  const info = page?.imageinfo?.[0];
+  const resolved = info?.thumburl || info?.url || null;
+  return resolved && resolved.includes('upload.wikimedia.org') ? resolved : null;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const uri = process.env.MONGODB_URI || process.env.MONGODB_ATLAS_URI;
+const client = new MongoClient(uri);
+await client.connect();
+const entities = client.db('bookstore').collection('entities');
+
+const query = {
+  type: 'person',
+  wikidata_id: { $exists: true, $ne: null },
+  $or: [
+    { wikidata_birth_date: { $exists: false } },
+    { wikidata_birth_date: null },
+    { portrait_url: /commons\.wikimedia\.org/ },
+  ],
+};
+
+const total = await entities.countDocuments(query);
+console.log(`${total} entities need enrichment${DRY ? ' (dry run)' : ''}; processing up to ${LIMIT === Infinity ? 'all' : LIMIT}`);
+
+const cursor = entities.find(query, {
+  projection: { wikidata_id: 1, portrait_url: 1, wikidata_birth_date: 1, wikidata_death_date: 1 },
+});
+
+let processed = 0, portraitsFixed = 0, datesFixed = 0, errors = 0;
+for await (const ent of cursor) {
+  if (processed >= LIMIT) break;
+  processed++;
+  try {
+    const data = await fetchJson(
+      `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${ent.wikidata_id}&props=claims&format=json`,
+    );
+    const claims = data?.entities?.[ent.wikidata_id]?.claims;
+    if (!claims) continue;
+
+    const set = {};
+
+    const portraitBad = !ent.portrait_url || ent.portrait_url.includes('commons.wikimedia.org');
+    if (portraitBad) {
+      const filename = claims?.P18?.[0]?.mainsnak?.datavalue?.value;
+      if (filename) {
+        const url = await resolvePortrait(filename);
+        if (url && url !== ent.portrait_url) { set.portrait_url = url; portraitsFixed++; }
+      }
+    }
+
+    const birth = normaliseTime(claims?.P569?.[0]?.mainsnak?.datavalue?.value?.time);
+    const death = normaliseTime(claims?.P570?.[0]?.mainsnak?.datavalue?.value?.time);
+    if (birth && birth !== ent.wikidata_birth_date) { set.wikidata_birth_date = birth; datesFixed++; }
+    if (death && death !== ent.wikidata_death_date) set.wikidata_death_date = death;
+
+    if (Object.keys(set).length > 0 && !DRY) {
+      await entities.updateOne({ _id: ent._id }, { $set: set });
+    }
+    if (processed % 100 === 0) {
+      console.log(`  ${processed}/${Math.min(total, LIMIT)} — portraits:${portraitsFixed} dates:${datesFixed} errors:${errors}`);
+    }
+    await sleep(120); // be polite to Wikidata/Commons
+  } catch (err) {
+    errors++;
+    if (errors <= 10) console.warn(`  ! ${ent.wikidata_id}: ${err.message}`);
+  }
+}
+
+console.log(`Done. processed:${processed} portraitsFixed:${portraitsFixed} datesFixed:${datesFixed} errors:${errors}`);
+await client.close();

--- a/src/app/artist/[name]/page.tsx
+++ b/src/app/artist/[name]/page.tsx
@@ -8,6 +8,7 @@ import { bookUrl, authorSlug, authorUrl } from '@/lib/slugify';
 import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
 import { ObjectId, type Db } from 'mongodb';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import { enrichEntityFromWikidata } from '@/lib/wikidata-enrichment';
 
 export const revalidate = 86400;
 export const dynamicParams = true;
@@ -60,34 +61,6 @@ interface ArtistEntity {
   wikidata_birth_date?: string;
   wikidata_death_date?: string;
   portrait_url?: string;
-}
-
-async function getPortraitUrl(db: Db, entity: ArtistEntity | null): Promise<string | null> {
-  if (!entity) return null;
-  if (entity.portrait_url) return entity.portrait_url;
-  if (!entity.wikidata_id) return null;
-
-  try {
-    const res = await fetch(
-      `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${entity.wikidata_id}&props=claims&format=json`,
-      { next: { revalidate: 86400 } }
-    );
-    if (!res.ok) return null;
-    const data = await res.json();
-    const filename = data.entities?.[entity.wikidata_id]?.claims?.P18?.[0]?.mainsnak?.datavalue?.value;
-    if (!filename) return null;
-
-    const thumbUrl = `https://commons.wikimedia.org/w/thumb.php?f=${encodeURIComponent(filename)}&w=300`;
-
-    db.collection('entities').updateOne(
-      { _id: entity._id },
-      { $set: { portrait_url: thumbUrl } }
-    ).catch(() => {});
-
-    return thumbUrl;
-  } catch {
-    return null;
-  }
 }
 
 interface ArtistPageProps {
@@ -218,11 +191,15 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
       : `${Math.min(...years)}–${Math.max(...years)}`
     : null;
 
-  const birthYear = entity?.wikidata_birth_date?.split('-')[0];
-  const deathYear = entity?.wikidata_death_date?.split('-')[0];
+  // Portrait + life dates from Wikidata (lazily resolved & cached on the
+  // entity). Portrait resolves to a CSP-safe upload.wikimedia.org URL.
+  const enrichment = await enrichEntityFromWikidata(db, entity);
+
+  const birthYear = (enrichment.birthDate || entity?.wikidata_birth_date)?.split('-')[0];
+  const deathYear = (enrichment.deathDate || entity?.wikidata_death_date)?.split('-')[0];
   const lifeDates = birthYear ? `${birthYear}–${deathYear || '?'}` : null;
 
-  const portraitUrl = await getPortraitUrl(db, entity);
+  const portraitUrl = enrichment.portraitUrl;
 
   const wikipediaUrl = entity?.wikipedia_url
     || (entity?.wikidata_id ? `https://www.wikidata.org/wiki/Special:GoToLinkedPage/enwiki/${entity.wikidata_id}` : null);

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -8,8 +8,9 @@ import { bookUrl, authorSlug, artistUrl } from '@/lib/slugify';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import AuthorBibliography from '@/components/browse/AuthorBibliography';
 import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
-import { ObjectId, type Db } from 'mongodb';
+import { ObjectId } from 'mongodb';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import { enrichEntityFromWikidata } from '@/lib/wikidata-enrichment';
 import AuthorSchema from '@/components/seo/AuthorSchema';
 
 // ISR: 24h background revalidation (survives deploys better than revalidate=false)
@@ -65,37 +66,6 @@ interface AuthorEntity {
   wikidata_birth_date?: string;
   wikidata_death_date?: string;
   portrait_url?: string;
-}
-
-/** Fetch portrait thumbnail URL from Wikidata P18 claim, cache on entity */
-async function getPortraitUrl(db: Db, entity: AuthorEntity | null): Promise<string | null> {
-  if (!entity) return null;
-  if (entity.portrait_url) return entity.portrait_url;
-  if (!entity.wikidata_id) return null;
-
-  try {
-    const res = await fetch(
-      `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${entity.wikidata_id}&props=claims&format=json`,
-      { next: { revalidate: 86400 } } // cache 24h
-    );
-    if (!res.ok) return null;
-    const data = await res.json();
-    const filename = data.entities?.[entity.wikidata_id]?.claims?.P18?.[0]?.mainsnak?.datavalue?.value;
-    if (!filename) return null;
-
-    // Use thumb.php API — more reliable than direct commons URL (avoids 429s)
-    const thumbUrl = `https://commons.wikimedia.org/w/thumb.php?f=${encodeURIComponent(filename)}&w=300`;
-
-    // Cache on entity (fire-and-forget)
-    db.collection('entities').updateOne(
-      { _id: entity._id },
-      { $set: { portrait_url: thumbUrl } }
-    ).catch(() => {});
-
-    return thumbUrl;
-  } catch {
-    return null;
-  }
 }
 
 // dynamicParams + generateStaticParams: generate on first request, not at build time
@@ -294,9 +264,14 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
       : `${Math.min(...years)}–${Math.max(...years)}`
     : null;
 
-  // Life dates from entity
-  const birthYear = entity?.wikidata_birth_date?.split('-')[0];
-  const deathYear = entity?.wikidata_death_date?.split('-')[0];
+  // Portrait + life dates from Wikidata (lazily resolved & cached on the
+  // entity). Portrait resolves to a CSP-safe upload.wikimedia.org URL; dates
+  // backfill entities that carry a wikidata_id but were never date-enriched.
+  const enrichment = await enrichEntityFromWikidata(db, entity);
+
+  // Life dates — prefer freshly resolved, fall back to whatever was cached.
+  const birthYear = (enrichment.birthDate || entity?.wikidata_birth_date)?.split('-')[0];
+  const deathYear = (enrichment.deathDate || entity?.wikidata_death_date)?.split('-')[0];
   const lifeDates = birthYear ? `${birthYear}–${deathYear || '?'}` : null;
 
   // Encyclopedia entry: use entity directly if we have one, otherwise regex fallback
@@ -308,8 +283,8 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     { projection: { name: 1 } }
   );
 
-  // Portrait image from Wikidata
-  const portraitUrl = await getPortraitUrl(db, entity);
+  // Portrait image from Wikidata (resolved above)
+  const portraitUrl = enrichment.portraitUrl;
 
   // Derive Wikipedia URL from entity
   const wikipediaUrl = entity?.wikipedia_url
@@ -345,8 +320,8 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         authorSlug={name}
         description={entity?.description}
         aliases={entity?.aliases}
-        birthDate={entity?.wikidata_birth_date}
-        deathDate={entity?.wikidata_death_date}
+        birthDate={enrichment.birthDate || entity?.wikidata_birth_date}
+        deathDate={enrichment.deathDate || entity?.wikidata_death_date}
         wikipediaUrl={wikipediaUrl}
         wikidataId={entity?.wikidata_id}
         viafId={entity?.viaf_id}

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import EntitySchema from '@/components/seo/EntitySchema';
+import { enrichEntityFromWikidata } from '@/lib/wikidata-enrichment';
 
 // ISR: 24h background revalidation
 export const revalidate = 86400;
@@ -88,6 +89,18 @@ export const getEntity = cache(async (name: string) => {
     );
     if (!entity) return null;
 
+    // Backfill life dates from Wikidata for people that carry a wikidata_id
+    // but were never date-enriched (same gap that left author pages blank).
+    // Gated to persons — places/concepts have no birth/death, so enriching
+    // them would re-fetch every render (the missing date never caches).
+    let birthDate = entity.wikidata_birth_date as string | undefined;
+    let deathDate = entity.wikidata_death_date as string | undefined;
+    if (entity.type === 'person' && (!birthDate || !deathDate)) {
+      const enrichment = await enrichEntityFromWikidata(db, entity as Parameters<typeof enrichEntityFromWikidata>[1]);
+      birthDate = birthDate || enrichment.birthDate || undefined;
+      deathDate = deathDate || enrichment.deathDate || undefined;
+    }
+
     // Fetch related entities (same books)
     const bookIds = entity.books?.map((b: { book_id: string }) => b.book_id) || [];
     const related = bookIds.length > 0
@@ -110,8 +123,8 @@ export const getEntity = cache(async (name: string) => {
       description: entity.description as string | undefined,
       wikipedia_url: entity.wikipedia_url as string | undefined,
       wikidata_id: entity.wikidata_id as string | undefined,
-      wikidata_birth_date: entity.wikidata_birth_date as string | undefined,
-      wikidata_death_date: entity.wikidata_death_date as string | undefined,
+      wikidata_birth_date: birthDate,
+      wikidata_death_date: deathDate,
       wikidata_coordinates: entity.wikidata_coordinates as { lat: number; lng: number } | undefined,
       books: (entity.books || []) as Array<{ book_id: string; book_title: string; book_author: string; pages: number[] }>,
       total_mentions: (entity.total_mentions || 0) as number,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -63,15 +63,15 @@ export function getBookThumbnailUrl(
     : (book.image_thumb || book.thumbnail_blob || book.thumbnail || null);
   if (!raw) return null;
 
-  // Wikimedia Commons: rewrite to thumb.php for CDN-cached resized images.
-  // Loading full-res Wikimedia files (3000-8000px) directly causes 429 rate-limits
-  // and wastes bandwidth. thumb.php serves fast, CDN-cached thumbnails.
+  // Wikimedia Commons images: serve the upload.wikimedia.org CDN URL as-is.
+  // We must NOT rewrite to commons.wikimedia.org/w/thumb.php — the site CSP
+  // `img-src` whitelists upload.wikimedia.org but not commons.wikimedia.org,
+  // so a thumb.php URL loads via curl yet is blocked by the browser. Manually
+  // constructing /thumb/.../<w>px- URLs is also unreliable (Wikimedia 400s
+  // widths it hasn't pre-rendered), so we keep the canonical CDN URL. Only ~43
+  // legacy books still reference these; new imports rehost to R2.
   if (raw.includes('upload.wikimedia.org/wikipedia/commons/')) {
-    const filename = raw.split('/').pop();
-    if (filename) {
-      const w = size === 'thumb' ? 400 : 800;
-      return `https://commons.wikimedia.org/w/thumb.php?f=${filename}&w=${w}`;
-    }
+    return raw;
   }
 
   if (!raw.includes('images.sourcelibrary.org/')) return raw;

--- a/src/lib/wikidata-enrichment.ts
+++ b/src/lib/wikidata-enrichment.ts
@@ -1,0 +1,144 @@
+/**
+ * Lazy Wikidata enrichment for author/artist `entities`.
+ *
+ * Given an entity that carries a `wikidata_id`, this resolves three display
+ * fields and caches them back on the entity so subsequent renders are free:
+ *   - `portrait_url`        — P18 image, resolved to a CSP-safe CDN URL
+ *   - `wikidata_birth_date` — P569
+ *   - `wikidata_death_date` — P570
+ *
+ * Two non-obvious constraints drove the implementation:
+ *
+ * 1. **CSP.** The site's `img-src` whitelists `upload.wikimedia.org` (the
+ *    Wikimedia CDN) but NOT `commons.wikimedia.org`. The old code cached
+ *    `commons.wikimedia.org/w/thumb.php?...` URLs, which load fine via curl
+ *    but are blocked by the browser — every portrait silently broke. We must
+ *    resolve P18 to an `upload.wikimedia.org` URL. The Commons `imageinfo`
+ *    API does this (and snaps to a renderable thumbnail bucket — hand-built
+ *    `/thumb/.../800px-` URLs 400 unless that exact width was pre-rendered).
+ *
+ * 2. **Lazy backfill.** ~6.7k entities have a `wikidata_id` but no dates, and
+ *    ~1k have a stale `commons.*` portrait. Rather than gate everything on a
+ *    batch job, we re-resolve on first render when a field is missing or the
+ *    cached portrait points at the blocked domain, then persist.
+ */
+
+import type { Db, ObjectId } from 'mongodb';
+
+export interface EnrichableEntity {
+  _id: ObjectId;
+  wikidata_id?: string;
+  portrait_url?: string;
+  wikidata_birth_date?: string;
+  wikidata_death_date?: string;
+}
+
+export interface WikidataEnrichment {
+  portraitUrl: string | null;
+  birthDate: string | null;
+  deathDate: string | null;
+}
+
+/** 24h revalidate — Wikidata/Commons facts for historical figures rarely move. */
+const REVALIDATE = 60 * 60 * 24;
+
+/** A cached portrait on the blocked Commons domain must be re-resolved. */
+function isCspSafePortrait(url: string | undefined): url is string {
+  return !!url && url.includes('upload.wikimedia.org');
+}
+
+/** "+1396-06-05T00:00:00Z" → "1396-06-05"; leaves BCE ("-0044-…") intact. */
+function normaliseWikidataTime(time: string | undefined): string | null {
+  if (!time) return null;
+  const m = time.match(/^\+?(-?\d{1,4}-\d{2}-\d{2})/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Resolve a Commons file name (P18 value, e.g. "Giannozzo manetti.jpg") to a
+ * CSP-safe `upload.wikimedia.org` thumbnail URL via the imageinfo API.
+ * Returns the full-size CDN URL when the source is smaller than the request.
+ */
+async function resolveCommonsPortrait(filename: string): Promise<string | null> {
+  const url =
+    `https://commons.wikimedia.org/w/api.php?action=query&format=json` +
+    `&titles=${encodeURIComponent(`File:${filename}`)}` +
+    `&prop=imageinfo&iiprop=url&iiurlwidth=300`;
+  try {
+    const res = await fetch(url, { next: { revalidate: REVALIDATE } });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const pages = data?.query?.pages;
+    const page = pages && Object.values(pages)[0] as { imageinfo?: Array<{ thumburl?: string; url?: string }> };
+    const info = page?.imageinfo?.[0];
+    const resolved = info?.thumburl || info?.url || null;
+    // Defensive: only return whitelisted CDN URLs.
+    return resolved && resolved.includes('upload.wikimedia.org') ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return portrait + life dates for an entity, resolving anything missing from
+ * Wikidata and caching it back on the entity (fire-and-forget). Safe to call
+ * on every render — it only hits the network when a field is absent or the
+ * cached portrait points at the CSP-blocked domain.
+ */
+export async function enrichEntityFromWikidata(
+  db: Db,
+  entity: EnrichableEntity | null,
+): Promise<WikidataEnrichment> {
+  if (!entity) return { portraitUrl: null, birthDate: null, deathDate: null };
+
+  const cachedPortrait = isCspSafePortrait(entity.portrait_url) ? entity.portrait_url : null;
+  const cachedBirth = entity.wikidata_birth_date ?? null;
+  const cachedDeath = entity.wikidata_death_date ?? null;
+
+  const needsPortrait = !cachedPortrait;
+  const needsBirth = !cachedBirth;
+  const needsDeath = !cachedDeath;
+
+  // Nothing to do, or nothing we *can* do.
+  if ((!needsPortrait && !needsBirth && !needsDeath) || !entity.wikidata_id) {
+    return { portraitUrl: cachedPortrait, birthDate: cachedBirth, deathDate: cachedDeath };
+  }
+
+  try {
+    const res = await fetch(
+      `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${entity.wikidata_id}&props=claims&format=json`,
+      { next: { revalidate: REVALIDATE } },
+    );
+    if (!res.ok) {
+      return { portraitUrl: cachedPortrait, birthDate: cachedBirth, deathDate: cachedDeath };
+    }
+    const data = await res.json();
+    const claims = data?.entities?.[entity.wikidata_id]?.claims;
+
+    let portraitUrl = cachedPortrait;
+    if (needsPortrait) {
+      const filename = claims?.P18?.[0]?.mainsnak?.datavalue?.value as string | undefined;
+      if (filename) portraitUrl = await resolveCommonsPortrait(filename);
+    }
+
+    const birthDate = needsBirth
+      ? normaliseWikidataTime(claims?.P569?.[0]?.mainsnak?.datavalue?.value?.time)
+      : cachedBirth;
+    const deathDate = needsDeath
+      ? normaliseWikidataTime(claims?.P570?.[0]?.mainsnak?.datavalue?.value?.time)
+      : cachedDeath;
+
+    // Persist whatever we newly resolved (don't overwrite with null).
+    const set: Record<string, string> = {};
+    if (portraitUrl && portraitUrl !== entity.portrait_url) set.portrait_url = portraitUrl;
+    if (birthDate && birthDate !== entity.wikidata_birth_date) set.wikidata_birth_date = birthDate;
+    if (deathDate && deathDate !== entity.wikidata_death_date) set.wikidata_death_date = deathDate;
+    if (Object.keys(set).length > 0) {
+      db.collection('entities').updateOne({ _id: entity._id }, { $set: set }).catch(() => {});
+    }
+
+    return { portraitUrl, birthDate, deathDate };
+  } catch {
+    return { portraitUrl: cachedPortrait, birthDate: cachedBirth, deathDate: cachedDeath };
+  }
+}

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -160,14 +160,17 @@ describe('getBookThumbnailUrl', () => {
     expect(getBookThumbnailUrl(book, 'display')).toBe('https://images.sourcelibrary.org/pages/abc123/0005.jpg');
   });
 
-  // Wikimedia: rewrite to thumb.php
-  it('rewrites Wikimedia URLs to thumb.php', () => {
+  // Wikimedia: keep the upload.wikimedia.org CDN URL as-is. We must NOT
+  // rewrite to commons.wikimedia.org/w/thumb.php — the site CSP img-src
+  // whitelists upload.wikimedia.org but not commons.wikimedia.org, so a
+  // thumb.php URL is blocked by the browser (loads only via curl).
+  it('keeps Wikimedia upload URLs on the whitelisted CDN domain', () => {
     const book = {
       thumbnail: 'https://upload.wikimedia.org/wikipedia/commons/a/ab/Image.jpg',
     };
     const result = getBookThumbnailUrl(book, 'thumb');
-    expect(result).toContain('thumb.php');
-    expect(result).toContain('w=400');
+    expect(result).toBe('https://upload.wikimedia.org/wikipedia/commons/a/ab/Image.jpg');
+    expect(result).not.toContain('commons.wikimedia.org');
   });
 
   // Artwork URLs without -thumb or -full suffix should pass through


### PR DESCRIPTION
## Problem

`/author/giannozzo-manetti` (and author/artist pages generally) rendered **no birth/death dates** and a **broken portrait image**. The same blank-dates symptom affected `/encyclopedia/[name]` people.

## Root causes

1. **Broken portrait (CSP).** `getPortraitUrl` cached portraits as `commons.wikimedia.org/w/thumb.php?...` URLs. The site CSP `img-src` whitelists `upload.wikimedia.org` but **not** `commons.wikimedia.org`, so the browser blocked every Wikidata portrait (~995 entities). It loaded fine via `curl` (which ignores CSP), masking the bug. `getBookThumbnailUrl` in `utils.ts` made it worse by rewriting *good* `upload.wikimedia.org` URLs into the blocked domain.
2. **Missing life dates.** Author and encyclopedia pages only read cached `entity.wikidata_birth_date` / `wikidata_death_date`. ~6,700 entities carry a `wikidata_id` but were never date-enriched, and nothing fetched dates live. Wikidata has Manetti as **1396–1459**.

## Fix

- **New `src/lib/wikidata-enrichment.ts`** — shared helper resolving P18 to a CSP-safe `upload.wikimedia.org` URL via the Commons `imageinfo` API (hand-built `/thumb/.../<w>px-` URLs 400 unless Wikimedia pre-rendered that width), plus P569/P570 dates. Caches all three on the entity and **self-heals** stale `commons.*` portraits.
- **`author/[name]` and `artist/[name]`** use the helper (removed the duplicated, buggy `getPortraitUrl` from both).
- **`encyclopedia/[name]`** self-heals life dates for `type:'person'` entities (gated so places/concepts don't re-fetch every render).
- **`utils.ts`** keeps `upload.wikimedia.org` URLs as-is instead of rewriting to the blocked `commons` domain (only ~43 legacy books hit this path).
- **`scripts/maintenance/backfill-wikidata-portraits-dates.mjs`** — eagerly fixes the ~7,487 existing entities (portraits + dates). Run against production; ~75% get fixed, 0 errors.
- **Test** updated to assert the new whitelisted-CDN behavior (the old test asserted the CSP-blocked `thumb.php` rewrite).

## Scope check

- Data scan: only `entities.portrait_url` carried the blocked domain — books, gallery_images, collections are clean.
- Did **not** widen CSP to allow `commons.wikimedia.org` — the fix uses the already-whitelisted CDN, keeping CSP tight.
- Did not rehost portraits to R2 (larger pipeline change); the CDN URL is stable and whitelisted.
- Known broader latent risk (separate work): any rendered external image host not in the CSP allowlist silently breaks in-browser while passing curl — a guard/lint would catch the whole class.

## Verification

- Live-API check for Q1234681: P569→`1396-06-05`, P570→`1459-10-27`, P18→`upload.wikimedia.org/...` returns `200 image/jpeg` and is CSP-whitelisted.
- Manetti entity patched directly; backfill running corpus-wide (0 errors).
- `vitest` utils suite passes (32/32); preview build for the first commit is Ready (TypeScript green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)