### PR TITLE
docs(pipeline): dedicated finalize cron for the completion tail

### DIFF
--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -17,6 +17,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 | Summary + Index | **Hetzner** (`enrich-worker.mjs`) | Direct Gemini calls, every 5 min, 30 books/run |
 | Chapter extraction | **Hetzner** (`enrich-worker.mjs`) | Direct Gemini calls, runs after summary+index |
 | Lightweight crons | **Vercel** | social-post, health-check, daily-report, warm |
+| Finalize tail (cover-select + complete) | **Hetzner** crontab (`*/15 * * * *`) | `pipeline-orchestrator.mjs --phase 9` runs Phase 8.9 (cover) + 9 (finalize), decoupled from the main loop so the tail doesn't starve behind OCR/translation. flock `/tmp/sl-finalize.lock`, log `/var/log/sourcelibrary/finalize.log`. See `lesson_finalize_tail_starvation`. |
 | e-rara / Harvard / Gallica archiving | **Local Mac** via launchd | Source hosts block Hetzner IPs (`archive-{erara,harvard,gallica}.mjs`, every 30 min, plists `org.sourcelibrary.archive-*`) |
 | Archiving watchdog | **Hetzner** crontab (`45 */6 * * *`, every 6h) | Self-heals books stuck in `archiving`: parks IA-lending/dead-URL books → `needs_attention`, escalates stale-unreachable. `scripts/maintenance/archiving-watchdog.mjs --apply` (conservative; add `--rearchive` manually to push recoverable books to R2). Logs `/var/log/sourcelibrary/archiving-watchdog.log`, audit in `watchdog_runs`. |
 


### PR DESCRIPTION
Documents the operational fix from this session. The completion tail — Phase 8.9 (cover selection, `.limit(50)`/cycle) + Phase 9 (finalize) — ran only inside the every-2-min `pipeline-orchestrator.mjs` and rarely got reached behind the busy OCR/translation phases. Result: **8,041 fully-processed books stuck at `images_complete`** (6,162 of them >7 days), never flipping to `complete`.

Fix (ops, already live on Hetzner): a dedicated cron `*/15 * * * *` running `pipeline-orchestrator.mjs --phase 9` (which runs both 8.9 and 9), decoupled from the main loop. Drained the backlog and keeps the tail clear (cleared ~4,700 to `complete` this session).

Docs only — adds the row to the runs-where table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)