### PR TITLE
fix(pipeline): stop mis-flagging single-object artworks as "Empty book"

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2539,12 +2539,19 @@ async function run() {
 
     // Artwork resource types — these skip the book pipeline entirely (no text to OCR/translate)
     const ARTWORK_TYPES = ['painting', 'print', 'drawing', 'fresco', 'papyrus_fragment', 'object'];
+    // Canonical artwork signal is content_type:'artwork'. resource_type is a finer-grained
+    // sub-category (sculpture, manuscript, scientific_instrument, …) that under-matches — so
+    // match on either. (See CLAUDE.md: don't gate artwork on resource_type alone.)
+    const ARTWORK_MATCH = { $or: [{ content_type: 'artwork' }, { resource_type: { $in: ARTWORK_TYPES } }] };
 
     // ── Phase 0: Skip artworks that somehow entered the pipeline ──
     if (shouldRun(1)) {
       const artworks = await db.collection('books').find({
-        'pipeline_auto.status': { $in: ['queued', 'archiving', 'archive_complete'] },
-        resource_type: { $in: ARTWORK_TYPES },
+        // Catch artwork at ANY pre-terminal stage, not just early ones. Some slip all the way
+        // to finalize where Phase 9 mis-flags them "Empty book: 0 pages" (single-object
+        // artworks legitimately have 0 pages).
+        'pipeline_auto.status': { $nin: ['complete', 'needs_attention', 'failed', 'parked'] },
+        ...ARTWORK_MATCH,
       }).project({ id: 1, title: 1 }).toArray();
       if (artworks.length > 0) {
         console.log(`\n--- Phase 0: Skipping ${artworks.length} artworks ---`);
@@ -2566,7 +2573,7 @@ async function run() {
       const ENGLISH_VARIANTS_P1 = ['english', 'eng', 'en'];
       let queuedBooks = await db.collection('books')
         .aggregate([
-          { $match: { 'pipeline_auto.status': 'queued', resource_type: { $nin: ARTWORK_TYPES } } },
+          { $match: { 'pipeline_auto.status': 'queued', content_type: { $ne: 'artwork' }, resource_type: { $nin: ARTWORK_TYPES } } },
           { $addFields: {
             _priority: {
               $switch: {
@@ -4995,7 +5002,7 @@ Rules:
       let readyToFinalize = await db.collection('books')
         .find({ 'pipeline_auto.status': 'cover_selected' })
         .sort({ hidden: 1 })
-        .project({ id: 1, title: 1, pages_count: 1, language: 1 })
+        .project({ id: 1, title: 1, pages_count: 1, language: 1, content_type: 1, resource_type: 1 })
         .limit(FINALIZE_LIMIT)
         .toArray();
       if (BOOK_OVERRIDE) readyToFinalize = await applyBookOverride(db, readyToFinalize, { id: 1, title: 1, pages_count: 1, language: 1 });
@@ -5006,6 +5013,14 @@ Rules:
         const totalPages = book.pages_count || await db.collection('pages').countDocuments({ book_id: book.id });
 
         if (totalPages === 0) {
+          // Single-object artworks legitimately have 0 pages — finalize, don't flag as a
+          // failed import. (Phase 0 normally diverts these, but the dedicated `--phase 9`
+          // finalize cron doesn't run Phase 0, so guard here too.)
+          if (book.content_type === 'artwork') {
+            if (!DRY_RUN) await setPipelineStatus(db, book.id, 'complete', { skipped: 'artwork', completed_at: new Date() });
+            log.completed = (log.completed || 0) + 1;
+            continue;
+          }
           if (!DRY_RUN) {
             await setPipelineStatus(db, book.id, 'needs_attention', {
               error: 'Empty book: 0 pages. Likely a failed import.',


### PR DESCRIPTION
## Bug
Phase 0's artwork-skip in `pipeline-orchestrator.mjs` matched only `resource_type` against a 6-value list (`painting/print/drawing/fresco/papyrus_fragment/object`). But the **canonical artwork signal is `content_type:'artwork'`** — `resource_type` is a finer sub-category (`sculpture`, `manuscript`, `scientific_instrument`, …) that under-matches. CLAUDE.md even warns: *"Don't filter on `resource_type` here."*

So artworks with those resource_types slipped past Phase 0, flowed through the book pipeline, and Phase 9 finalize flagged them **"Empty book: 0 pages. Likely a failed import."** — single-object artworks (a marble horse head, the Buraq, papyri) legitimately have 0 pages. **221 found mis-parked in `needs_attention` on 2026-05-30** (the Marble head of a horse, The Fabulous Creature Buraq, etc.). Those 221 were corrected to `complete` by hand this session; this PR fixes the cause so it doesn't recur.

## Fix
1. **Phase 0** now matches `content_type:'artwork'` OR the legacy resource_type list (`ARTWORK_MATCH`), and sweeps artwork at **any pre-terminal status** (not just `queued/archiving/archive_complete`) — some had slipped all the way to finalize.
2. **Phase 1 enrollment** also excludes `content_type:'artwork'` (don't let artwork enter the text pipeline at all).
3. **Phase 9 finalize** guards the 0-pages case: `content_type:'artwork'` → `complete` (`skipped:artwork`), not `needs_attention`. Needed because the dedicated `--phase 9` finalize cron (added this session) doesn't run Phase 0.

## Scope
- Single file, behavior-only; `node --check` passes. No change to how real books finalize.
- Out of scope: the existing 221 (already corrected manually). This prevents the next wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)