### PR TITLE
fix(authors): cluster non-Latin authors in canonical relink (#2179)

### DIFF
--- a/scripts/maintenance/canonical-authors-proof.mjs
+++ b/scripts/maintenance/canonical-authors-proof.mjs
@@ -17,6 +17,13 @@ function canonicalKey(author) {
     .replace(/^j/,'i').replace(/^gi/,'i').replace(/v/g,'u')
     .replace(/(issimus|us|um|orum|arum|ibus|onis|ius|is|ae|i|o|a|e)$/,''))
     .filter(t => t.length>=3).sort();
+  // Non-Latin scripts (CJK / Cyrillic / Greek / Arabic) lose every token to the
+  // a–z filter above; fall back to the diacritic-folded raw name so they still
+  // cluster instead of collapsing to an empty key (e.g. 李時珍 / Li Shizhen).
+  if (!stems.length) {
+    return (author || '').normalize('NFKD').replace(/[̀-ͯ]/g,'')
+      .replace(/\([^)]*\)/g,'').replace(/[\d,.;]/g,'').replace(/\s+/g,'').toLowerCase();
+  }
   return stems.join(' ');
 }
 

--- a/scripts/maintenance/canonical-authors-relink.mjs
+++ b/scripts/maintenance/canonical-authors-relink.mjs
@@ -39,6 +39,14 @@ function canonicalKey(author) {
     .replace(/^j/, 'i').replace(/^gi/, 'i').replace(/v/g, 'u')
     .replace(/(issimus|us|um|orum|arum|ibus|onis|ius|is|ae|i|o|a|e)$/, ''))
     .filter(t => t.length >= 3).sort();
+  // Non-Latin scripts (CJK / Cyrillic / Greek / Arabic) lose every token to the
+  // a–z filter above and would yield an empty key — silently dropping the author
+  // from clustering (e.g. 李時珍 / Li Shizhen). Fall back to the diacritic-folded
+  // raw name (minus editorial parens/dates) so they still cluster + relink.
+  if (!stems.length) {
+    return (author || '').normalize('NFKD').replace(/[̀-ͯ]/g, '')
+      .replace(/\([^)]*\)/g, '').replace(/[\d,.;]/g, '').replace(/\s+/g, '').toLowerCase();
+  }
   return stems.join(' ');
 }
 


### PR DESCRIPTION
## What
Fixes a blind spot in the canonical-author clustering key used by
`canonical-authors-relink.mjs` and `canonical-authors-proof.mjs` (the #2179
rebuild tooling): `canonicalKey` strips everything outside `[a-z]` before
tokenizing, so **CJK / Cyrillic / Greek / Arabic** author names collapse to an
empty key and are silently dropped from clustering. The relink skipped them
entirely — e.g. 李時珍 (Li Shizhen, 27 books) stayed unlinked.

Both scripts now fall back, when no Latin stem survives, to the diacritic-folded
raw name (minus editorial parens/dates). Latin behavior is unchanged:
`"Giordano Bruno"` and `"Bruno, Giordano"` still collapse to one cluster
(`brun iordan`).

## In scope
- `canonicalKey` non-Latin fallback in `relink` + `proof` (kept identical).

## Out of scope (deliberately)
- The larger #2179 plan — building canonical entity records, canonical author
  slugs + variant-slug redirects (unblocks #2176), and dedupe-on-write in the
  mention pipeline — are separate, design-heavier PRs.
- `build-canonical-authors.mjs` (a third, union-find clustering variant) is left
  out to avoid adding a divergent algorithm alongside the merged `relink`/`proof`
  key.

## Data already applied this session (prod `bookstore`)
Verified #2179's claims, then using the **already-merged** relink tooling:
- Relinked **435** books to their canonical entity (2 ambiguous multi-VIAF
  clusters skipped for review).
- Normalized `author_entity_id` to string **corpus-wide** — cast 557 residual
  `objectId` values → **0 objectId remaining** on live books, closing the
  string/ObjectId join-safety split #2179 documented.
- Backup of pre-change `{id, author, author_entity_id}` for all live books saved
  locally (untracked) for recovery.

Note: live book→entity linkage measured **~64–68%**, not the 42% in the issue
(the 42% used a broader denominator incl. non-live books).

🤖 Generated with [Claude Code](https://claude.com/claude-code)