### PR TITLE
fix(press): ground the Wikipedia comparison in a measured word count

### DIFF
--- a/src/components/press/releases/SourceLibraryPublicBetaLaunch.tsx
+++ b/src/components/press/releases/SourceLibraryPublicBetaLaunch.tsx
@@ -194,14 +194,21 @@ export default function SourceLibraryPublicBetaLaunch() {
 
         {/* Wikipedia-scale callout */}
         <div className="bg-accent-gold/5 rounded-lg border border-accent-gold/20 p-6 md:p-8 mb-8">
-          <h3 className="font-serif text-lg text-primary mb-3">As big as a fifth of Wikipedia &mdash; in primary sources</h3>
-          <p className="text-secondary leading-relaxed font-body">
+          <h3 className="font-serif text-lg text-primary mb-3">About a third of Wikipedia &mdash; in primary sources</h3>
+          <p className="text-secondary leading-relaxed font-body mb-3">
             The English Wikipedia, the largest reference work ever created, holds about{' '}
             <strong className="text-stone-800">5 billion words</strong> across 7.2 million articles.
-            Source Library&rsquo;s roughly four million translated pages amount to{' '}
-            <strong className="text-stone-800">on the order of a billion words</strong> &mdash; close to
-            a fifth the size of the entire English Wikipedia &mdash; drawn not from modern summaries but
-            from the original record of human thought across five centuries and more than 170 languages.
+            Source Library&rsquo;s 4.07 million translated pages amount to roughly{' '}
+            <strong className="text-stone-800">1.7 billion words</strong> &mdash; about{' '}
+            <strong className="text-stone-800">a third the size of the entire English Wikipedia</strong>{' '}
+            &mdash; drawn not from modern summaries but from the original record of human thought across
+            five centuries and more than 170 languages. Counting the original-language texts shown
+            alongside each translation, the corpus is larger still.
+          </p>
+          <p className="text-xs text-muted font-body">
+            Word count estimated from a 7,500-page random sample of the translation corpus
+            (mean 415 words per page) across 4,071,861 translated pages; English Wikipedia figures
+            per Wikipedia&rsquo;s own statistics, May 2026.
           </p>
         </div>
 


### PR DESCRIPTION
Follow-up to #2191. The June launch release's Wikipedia comparison was an estimate ("on the order of a billion words ≈ a fifth of Wikipedia"). Measured the real figure instead.

**Measurement:** random sample of 7,500 translated pages across all 4,071,861 rows in \`page_translations\` → mean 415 words/page (median 379) → **≈ 1.7 billion words** of English translation, **≈ a third** of the English Wikipedia's ~5B words.

- Updates the callout copy + heading ("About a third of Wikipedia").
- Adds a methodology footnote (sample size, mean words/page, total pages, Wikipedia source).
- Notes the original-language texts make the corpus larger still.

Release is still **draft** — this just makes the claim defensible before it's published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)