### PR TITLE
fix(import): source-wins language/date precedence + provenance (#2185)

### DIFF
--- a/scripts/maintenance/audit-language-provenance.mjs
+++ b/scripts/maintenance/audit-language-provenance.mjs
@@ -1,0 +1,151 @@
+// scripts/maintenance/audit-language-provenance.mjs
+//
+// Issue #2184 / #2185: detect books whose catalogued `language` disagrees with
+// the language Gemini actually OCR'd off the scanned pages. The trigger case is
+// Pico's Oratio — catalogued Latin/1486 but the scan is a 20th-c. Russian
+// translation. This promotes the one-off audit from #2184 into a committed,
+// re-runnable guard.
+//
+// Method: for each IA-sourced book, compare catalogued `language` against the
+// per-page <lang> tag Gemini emits in `ocr.data`. To avoid the front-matter /
+// facsimile false positives noted in #2184 (the praefatio of a Greek critical
+// edition is Latin/English), we sample ACROSS THE WHOLE BOOK, not just the first
+// N pages — evenly spaced page_numbers rather than `.limit(15)` on insertion order.
+//
+// Usage:
+//   set -a; source .env.production.local; set +a; node scripts/maintenance/audit-language-provenance.mjs [--provider all] [--sample 20] [--json out.json]
+//
+// Read-only. Never writes.
+
+import { MongoClient } from 'mongodb';
+
+const args = process.argv.slice(2);
+const getArg = (flag, def) => {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : def;
+};
+const PROVIDER = getArg('--provider', 'internet_archive'); // 'all' to scan every provider
+const SAMPLE = parseInt(getArg('--sample', '20'), 10);     // pages to sample per book
+const JSON_OUT = getArg('--json', null);
+
+// ISO-639 (and common 3-letter) → display name. Mirror of the importer's normalizer.
+const ISO = {
+  la: 'latin', lat: 'latin', grc: 'greek', el: 'greek', gre: 'greek', ell: 'greek',
+  sa: 'sanskrit', san: 'sanskrit', zh: 'chinese', chi: 'chinese', zho: 'chinese',
+  ar: 'arabic', ara: 'arabic', de: 'german', ger: 'german', deu: 'german',
+  fr: 'french', fra: 'french', fre: 'french', it: 'italian', ita: 'italian',
+  ru: 'russian', rus: 'russian', en: 'english', eng: 'english',
+  hi: 'hindi', hin: 'hindi', te: 'telugu', tel: 'telugu', he: 'hebrew', heb: 'hebrew',
+  syr: 'syriac', nl: 'dutch', dut: 'dutch', nld: 'dutch', es: 'spanish', spa: 'spanish',
+  pt: 'portuguese', por: 'portuguese', mar: 'marathi', mr: 'marathi',
+  fa: 'persian', per: 'persian', fas: 'persian', ja: 'japanese', jpn: 'japanese',
+  ta: 'tamil', tam: 'tamil', pl: 'polish', pol: 'polish', cs: 'czech', ces: 'czech',
+  la_grc: 'latin', tr: 'turkish', tur: 'turkish',
+};
+const NULL = new Set([
+  'none', 'n/a', 'na', 'unknown', 'und', 'null', '', 'multiple', 'mul',
+  'mixed', 'various', 'zxx', 'undetermined',
+]);
+const norm = (s) => {
+  let x = (s || '').toLowerCase().trim().replace(/^(modern|ancient|old|classical|medieval|middle)\s+/, '');
+  return ISO[x] || x;
+};
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI not set. Run: set -a; source .env.production.local; set +a; node ...');
+  process.exit(1);
+}
+
+const c = new MongoClient(uri);
+await c.connect();
+const db = c.db(process.env.MONGODB_DB || 'bookstore');
+const books = db.collection('books');
+const pages = db.collection('pages');
+
+const bookFilter = {
+  language: { $exists: true, $ne: null },
+  ...(PROVIDER === 'all' ? {} : { 'image_source.provider': PROVIDER }),
+};
+
+const all = await books
+  .find(bookFilter, { projection: { language: 1, title: 1, slug: 1, pages_count: 1 } })
+  .toArray();
+
+console.error(`Scanning ${all.length} books (provider=${PROVIDER}, sample=${SAMPLE})...`);
+
+const out = [];
+let scanned = 0;
+let withTags = 0;
+
+for (const b of all) {
+  scanned++;
+  if (scanned % 500 === 0) console.error(`  ...${scanned}/${all.length}`);
+
+  const cat = norm(b.language);
+  if (!cat || NULL.has(cat)) continue;
+
+  // Sample evenly across the whole book. Pull pages that have a <lang> tag,
+  // sorted by page_number, then take an evenly-spaced subset.
+  const tagged = await pages
+    .find(
+      { book_id: b._id.toString(), 'ocr.data': /<lang>/i },
+      { projection: { 'ocr.data': 1, page_number: 1 } }
+    )
+    .sort({ page_number: 1 })
+    .toArray();
+
+  if (tagged.length < 3) continue;
+  withTags++;
+
+  const step = Math.max(1, Math.floor(tagged.length / SAMPLE));
+  const sampled = tagged.filter((_, i) => i % step === 0).slice(0, SAMPLE);
+
+  const tags = sampled
+    .map((p) => norm((p.ocr.data.match(/<lang>([^<]+)<\/lang>/i) || [])[1]))
+    .filter((t) => t && !NULL.has(t) && !/[,/]/.test(t));
+
+  if (tags.length < 3) continue;
+
+  const catFrac = tags.filter((t) => t === cat).length / tags.length;
+  const freq = {};
+  tags.forEach((t) => (freq[t] = (freq[t] || 0) + 1));
+  const dom = Object.entries(freq).sort((a, b) => b[1] - a[1])[0][0];
+
+  if (dom === cat) continue;
+
+  // Classify per #2184 buckets
+  let bucket;
+  if (catFrac === 0) bucket = 'absent';        // ~196 cohort — strongest mislabel signal
+  else if (catFrac < 0.2) bucket = 'front_matter';
+  else bucket = 'bilingual';
+
+  out.push({
+    id: b._id.toString(),
+    slug: b.slug || null,
+    cat,
+    dom,
+    catFrac: Number(catFrac.toFixed(2)),
+    sampled: tags.length,
+    title: (b.title || '').slice(0, 70),
+    bucket,
+  });
+}
+
+out.sort((a, b) => a.bucket.localeCompare(b.bucket) || a.catFrac - b.catFrac);
+
+const byBucket = out.reduce((m, r) => ((m[r.bucket] = (m[r.bucket] || 0) + 1), m), {});
+
+console.error(`\nScanned ${scanned} books; ${withTags} had >=3 <lang>-tagged pages.`);
+console.error(`${out.length} mismatches:`, byBucket);
+console.error('(absent = catalogued language never appears on sampled pages — strongest signal)\n');
+
+console.table(out.filter((r) => r.bucket === 'absent').slice(0, 50));
+
+if (JSON_OUT) {
+  const { writeFileSync } = await import('fs');
+  writeFileSync(JSON_OUT, JSON.stringify({ generatedFilter: bookFilter, counts: byBucket, mismatches: out }, null, 2));
+  console.error(`Wrote ${out.length} rows to ${JSON_OUT}`);
+}
+
+await c.close();

--- a/src/app/api/import/gallica/route.ts
+++ b/src/app/api/import/gallica/route.ts
@@ -7,6 +7,7 @@ import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
+import { resolveLanguage } from '@/lib/resolve-language';
 
 export const maxDuration = 300;
 
@@ -149,6 +150,11 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     const slug = await generateUniqueBookSlug(db, title, author, display_title);
 
+    // #2185: normalise the caller's language and stamp provenance. Gallica IIIF v2
+    // manifests don't expose a reliable structured language field, so the caller
+    // is the only signal here — but normalised and attributed rather than raw.
+    const lang = resolveLanguage({ callerLanguage: language });
+
     const bookDoc = {
       _id: bookId,
       id: bookIdStr,
@@ -156,7 +162,9 @@ export const POST = withCuratorAuth(async (request, session) => {
       title,
       display_title: display_title || null,
       author,
-      language: language || 'Unknown',
+      language: lang.language,
+      ...(lang.original_language ? { original_language: lang.original_language } : {}),
+      field_provenance: { language: lang.provenance },
       published: published || 'Unknown',
       categories: categories || [],
       ...(work_id ? { work_id } : {}),

--- a/src/app/api/import/google-books/route.ts
+++ b/src/app/api/import/google-books/route.ts
@@ -7,6 +7,7 @@ import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
+import { resolveLanguage, resolveDate, type LanguageSignal } from '@/lib/resolve-language';
 
 export const maxDuration = 300;
 
@@ -160,6 +161,19 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     const slug = await generateUniqueBookSlug(db, title, author, display_title);
 
+    // #2185: prefer IA's empirical language signals (the GBooks scan is mirrored
+    // via IA) over the caller's work-language hint. Same precedence as /import/ia.
+    const gbLangCollection = (Array.isArray(iaMetadata.collection) ? iaMetadata.collection : [iaMetadata.collection])
+      .map((c: unknown) => /^booksbylanguage_(.+)$/i.exec(String(c || ''))?.[1])
+      .find(Boolean) || null;
+    const sourceSignals: LanguageSignal[] = [
+      { value: Array.isArray(iaMetadata.ocr_detected_lang) ? iaMetadata.ocr_detected_lang[0] : iaMetadata.ocr_detected_lang, source: 'ia_ocr_detected' },
+      { value: Array.isArray(iaMetadata.language) ? iaMetadata.language[0] : iaMetadata.language, source: 'ia_metadata' },
+      { value: gbLangCollection, source: 'ia_collection' },
+    ];
+    const lang = resolveLanguage({ callerLanguage: language, sourceSignals });
+    const dateRes = resolveDate({ callerPublished: published, sourceDate: iaMetadata.date || null });
+
     const bookDoc = {
       _id: bookId,
       id: bookIdStr,
@@ -167,8 +181,13 @@ export const POST = withCuratorAuth(async (request, session) => {
       title,
       display_title: display_title || null,
       author,
-      language: language || 'Unknown',
-      published: published || 'Unknown',
+      language: lang.language,
+      ...(lang.original_language ? { original_language: lang.original_language } : {}),
+      ...(lang.is_translation ? { is_translation: true } : {}),
+      ...(lang.language_review ? { language_review: true } : {}),
+      published: dateRes.published || 'Unknown',
+      ...(dateRes.original_work_year ? { original_work_year: dateRes.original_work_year } : {}),
+      field_provenance: { language: lang.provenance },
       categories: categories || [],
       ...(work_id ? { work_id } : {}),
       ia_identifier,

--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -7,6 +7,7 @@ import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
+import { resolveLanguage, resolveDate, type LanguageSignal } from '@/lib/resolve-language';
 
 export const maxDuration = 300;
 
@@ -243,6 +244,29 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     const slug = await generateUniqueBookSlug(db, title, author, display_title);
 
+    // #2185: resolve the MANIFESTATION language from IA's empirical signals
+    // (what the scan actually is), not the caller's work-language hint. All
+    // three IA signals below were already fetched at import and previously
+    // ignored — see #2184. Order = most empirical first.
+    const iaLangCollection = (Array.isArray(iaCatalog.collections) ? iaCatalog.collections : [])
+      .map((c) => /^booksbylanguage_(.+)$/i.exec(String(c))?.[1])
+      .find(Boolean) || null;
+    const sourceSignals: LanguageSignal[] = [
+      { value: iaCatalog.ocr_detected_lang as string, source: 'ia_ocr_detected' },
+      { value: Array.isArray(iaMetadataRaw.language) ? iaMetadataRaw.language[0] : iaMetadataRaw.language, source: 'ia_metadata' },
+      { value: iaLangCollection, source: 'ia_collection' },
+    ];
+    const lang = resolveLanguage({
+      callerLanguage: language,
+      callerOriginalLanguage: original_language,
+      sourceSignals,
+    });
+    const dateRes = resolveDate({
+      callerPublished: published,
+      callerYear: year,
+      sourceDate: (iaCatalog.date_iso as string) || iaMetadataRaw.date || null,
+    });
+
     const bookDoc = {
       _id: bookId,
       id: bookIdStr,
@@ -250,8 +274,13 @@ export const POST = withCuratorAuth(async (request, session) => {
       title,
       display_title: display_title || null,
       author,
-      language: language || original_language || iaMetadataRaw.language?.[0] || iaMetadataRaw.language || 'Unknown',
-      published: published || (year ? String(year) : null) || iaMetadataRaw.date || 'Unknown',
+      language: lang.language,
+      ...(lang.original_language ? { original_language: lang.original_language } : {}),
+      ...(lang.is_translation ? { is_translation: true } : {}),
+      ...(lang.language_review ? { language_review: true } : {}),
+      published: dateRes.published || 'Unknown',
+      ...(dateRes.original_work_year ? { original_work_year: dateRes.original_work_year } : {}),
+      field_provenance: { language: lang.provenance },
       categories: categories || [],
       ...(requestCollections?.length ? { collections: requestCollections } : {}),
       ...(work_id ? { work_id } : {}),

--- a/src/app/api/import/kyoto/route.ts
+++ b/src/app/api/import/kyoto/route.ts
@@ -46,7 +46,10 @@ export const POST = withCuratorAuth(async (request, session) => {
       title,
       display_title,
       author,
-      language: language || 'Japanese',
+      // #2185: don't hardcode 'Japanese' — Kyoto RMDA also holds Chinese, Sanskrit
+      // and Western rare books. Let resolveLanguage normalise the caller hint and
+      // stamp provenance (Unknown when absent, rather than a wrong blanket default).
+      language: language || undefined,
       published,
       categories,
       work_id,

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
+import { resolveLanguage } from '@/lib/resolve-language';
 
 /**
  * Import a book from a local directory
@@ -88,6 +89,11 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     const slug = await generateUniqueBookSlug(db, title, author, display_title);
 
+    // #2185: normalise the caller's language (codes → display names) and stamp
+    // provenance. Local-directory imports have no source metadata, so the caller
+    // is the only signal — but it's no longer stored raw and unattributed.
+    const lang = resolveLanguage({ callerLanguage: language });
+
     const bookDoc = {
       _id: bookId,
       id: bookIdStr,
@@ -95,7 +101,9 @@ export const POST = withCuratorAuth(async (request, session) => {
       title,
       display_title: display_title || null,
       author,
-      language: language || 'Unknown',
+      language: lang.language,
+      ...(lang.original_language ? { original_language: lang.original_language } : {}),
+      field_provenance: { language: lang.provenance },
       published: published || 'Unknown',
       categories: categories || [],
       ia_identifier: ia_identifier || null,

--- a/src/lib/import-utils.ts
+++ b/src/lib/import-utils.ts
@@ -7,6 +7,7 @@ import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { computeProcessingPriority } from '@/lib/processing-priority';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
+import { resolveLanguage, resolveDate } from '@/lib/resolve-language';
 
 // IIIF v2 manifest shape (covers most digital library providers)
 export interface IIIFManifest {
@@ -358,6 +359,14 @@ export async function importBookFromIIIF(
 
   const slug = await generateUniqueBookSlug(db, config.title, config.author, config.display_title);
 
+  // #2185: normalise the caller's language and record provenance. IIIF manifests
+  // carry no reliable structured language field across providers, so the caller
+  // hint is the only signal here — but it's normalised (codes → display names)
+  // and stamped with provenance so a later source signal can slot in and flag
+  // conflicts. The manifest date is treated as the edition (manifestation) date.
+  const lang = resolveLanguage({ callerLanguage: config.language });
+  const dateRes = resolveDate({ callerPublished: config.published, sourceDate: manifestDate });
+
   const bookDoc = {
     _id: bookId,
     id: bookIdStr,
@@ -365,8 +374,13 @@ export async function importBookFromIIIF(
     title: config.title,
     display_title: config.display_title || manifestLabel || null,
     author: config.author,
-    language: config.language || 'Unknown',
-    published: config.published || manifestDate || 'Unknown',
+    language: lang.language,
+    ...(lang.original_language ? { original_language: lang.original_language } : {}),
+    ...(lang.is_translation ? { is_translation: true } : {}),
+    ...(lang.language_review ? { language_review: true } : {}),
+    published: dateRes.published || 'Unknown',
+    ...(dateRes.original_work_year ? { original_work_year: dateRes.original_work_year } : {}),
+    field_provenance: { language: lang.provenance },
     categories: config.categories || [],
     ...(config.identifier_field || {}),
     ...(config.work_id ? { work_id: config.work_id } : {}),
@@ -435,7 +449,7 @@ export async function importBookFromIIIF(
       thumbnail: pageImages[i]?.thumbnail || '',
       photo_original: pageImages[i]?.photo || '',
       ocr: {
-        language: config.language || 'Unknown',
+        language: lang.language,
         model: null,
         data: '',
       },

--- a/src/lib/language-utils.ts
+++ b/src/lib/language-utils.ts
@@ -13,6 +13,58 @@ const NAME_TO_CODE: Record<string, string> = Object.fromEntries(
 );
 
 /**
+ * ISO-639-2/3 (and other 3-letter) code → canonical English name.
+ * Internet Archive and IIIF manifests emit 3-letter codes (`rus`, `lat`, `grc`).
+ * This was the silent gap behind #2184 — IA's `metadata.language: "rus"` never
+ * matched the catalogued "Russian" because nothing normalised the code.
+ */
+const CODE3_TO_NAME: Record<string, string> = {
+  ara: 'Arabic', ces: 'Czech', cze: 'Czech', dan: 'Danish', deu: 'German', ger: 'German',
+  ell: 'Greek', gre: 'Greek', grc: 'Greek', eng: 'English', spa: 'Spanish',
+  fas: 'Persian', per: 'Persian', fra: 'French', fre: 'French', heb: 'Hebrew',
+  hun: 'Hungarian', ita: 'Italian', jpn: 'Japanese', lat: 'Latin', nld: 'Dutch', dut: 'Dutch',
+  nor: 'Norwegian', pol: 'Polish', por: 'Portuguese', rus: 'Russian', san: 'Sanskrit',
+  swe: 'Swedish', tur: 'Turkish', zho: 'Chinese', chi: 'Chinese',
+  hin: 'Hindi', tel: 'Telugu', tam: 'Tamil', mar: 'Marathi', syr: 'Syriac', urd: 'Urdu',
+};
+
+/**
+ * Normalise a raw language token (ISO-639-1/2/3 code OR free-text name) to a
+ * canonical display name, e.g. "rus" → "Russian", "la" → "Latin",
+ * "Modern Greek" → "Greek". Returns null for empty / placeholder tokens so
+ * callers can treat "no signal" distinctly from a real value.
+ */
+export function displayLanguage(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const cleaned = String(raw)
+    .toLowerCase()
+    .trim()
+    .replace(/^(modern|ancient|old|classical|medieval|middle|early)\s+/, '');
+  if (!cleaned) return null;
+  if (PLACEHOLDER_LANGS.has(cleaned)) return null;
+  if (CODE_TO_NAME[cleaned]) return CODE_TO_NAME[cleaned];
+  if (CODE3_TO_NAME[cleaned]) return CODE3_TO_NAME[cleaned];
+  // Already a display name: title-case it for storage consistency.
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+/** Tokens that mean "no usable language signal". */
+const PLACEHOLDER_LANGS = new Set([
+  'none', 'n/a', 'na', 'unknown', 'und', 'null', '', 'multiple', 'mul',
+  'mixed', 'various', 'zxx', 'undetermined',
+]);
+
+/**
+ * True when two language tokens refer to the same language after normalisation.
+ * Either argument may be a code or a display name.
+ */
+export function sameLanguage(a: string | null | undefined, b: string | null | undefined): boolean {
+  const na = displayLanguage(a);
+  const nb = displayLanguage(b);
+  return !!na && !!nb && na.toLowerCase() === nb.toLowerCase();
+}
+
+/**
  * Expand a language list to include both ISO codes and English names.
  * e.g. ["French", "la"] → ["French", "fr", "Latin", "la"]
  *

--- a/src/lib/resolve-language.ts
+++ b/src/lib/resolve-language.ts
@@ -1,0 +1,186 @@
+import { displayLanguage, sameLanguage } from '@/lib/language-utils';
+import type { FieldProvenanceEntry } from '@/lib/types/book';
+
+/**
+ * Language/date resolution for book imports — issue #2185.
+ *
+ * The bug (#2184): every import route set `language` from CALLER input first,
+ * with the source's own structured metadata used only as a last resort (or not
+ * at all). A caller passing "Latin" (the *work* language of Pico's Oratio)
+ * silently overrode IA's `metadata.language: "rus"` (the *manifestation*
+ * language — the scan is a 20th-c. Russian translation).
+ *
+ * The fix flips precedence: empirical SOURCE signals decide the manifestation
+ * `language`; the caller's value becomes the work hint (`original_language`).
+ * When the two disagree we don't silently pick — we flag `language_review` and
+ * record BOTH claims (the value + its source) in `field_provenance.language`,
+ * so a wrong value can no longer wear a trustworthy "internet_archive" badge.
+ *
+ * A `LanguageSignal` carries both the raw value and where it came from. Pass
+ * source signals in PRIORITY ORDER (most empirical first, e.g. OCR-detected
+ * before catalogued metadata before collection tags).
+ */
+export interface LanguageSignal {
+  /** Raw token — ISO code (`rus`, `la`) or display name (`Russian`). */
+  value: string | null | undefined;
+  /** Provenance label, e.g. 'ia_ocr_detected', 'ia_metadata', 'iiif_manifest'. */
+  source: string;
+}
+
+export interface ResolveLanguageInput {
+  /** Caller-supplied manifestation language (request body `language`). */
+  callerLanguage?: string | null;
+  /** Caller-supplied work-language hint (request body `original_language`). */
+  callerOriginalLanguage?: string | null;
+  /** Empirical signals from the source, most-trustworthy first. */
+  sourceSignals?: LanguageSignal[];
+  /** Label for the caller's signal in provenance (default 'caller'). */
+  callerSource?: string;
+}
+
+export interface ResolveLanguageResult {
+  /** Resolved manifestation language (display name), or 'Unknown'. */
+  language: string;
+  /** Work language, when known to differ from the manifestation. */
+  original_language: string | null;
+  /** True when the manifestation language differs from the work language. */
+  is_translation: boolean;
+  /** True when caller and source disagreed on the manifestation language. */
+  conflict: boolean;
+  /**
+   * True when the record must NOT auto-publish pending human review.
+   * Set on any caller-vs-source conflict.
+   */
+  language_review: boolean;
+  /** Ready to store at `field_provenance.language`. */
+  provenance: FieldProvenanceEntry;
+}
+
+/**
+ * Resolve the manifestation language for an imported book, recording provenance.
+ *
+ * Precedence:
+ *   1. First non-empty SOURCE signal (in the order given) wins the manifestation language.
+ *   2. If the source is silent, fall back to the caller's value.
+ *   3. If both are silent, 'Unknown'.
+ *
+ * Conflict (caller present, source present, they disagree):
+ *   - manifestation = source value (the artifact's real language)
+ *   - original_language = caller value (the work hint)
+ *   - is_translation = true, conflict = true, language_review = true
+ */
+export function resolveLanguage(input: ResolveLanguageInput): ResolveLanguageResult {
+  const callerSource = input.callerSource || 'caller';
+  const caller = displayLanguage(input.callerLanguage);
+  const callerOriginal = displayLanguage(input.callerOriginalLanguage);
+
+  // First usable source signal, preserving the caller's intended priority order.
+  const usableSignals = (input.sourceSignals || [])
+    .map((s) => ({ source: s.source, value: displayLanguage(s.value), raw: s.value }))
+    .filter((s) => s.value);
+  const sourcePick = usableSignals[0] || null;
+
+  // All distinct claims, for provenance.
+  const claims: Array<{ source: string; value: string }> = [];
+  if (caller) claims.push({ source: callerSource, value: caller });
+  for (const s of usableSignals) {
+    if (!claims.some((c) => c.source === s.source && sameLanguage(c.value, s.value!))) {
+      claims.push({ source: s.source, value: s.value! });
+    }
+  }
+
+  let language: string;
+  let original_language: string | null = callerOriginal;
+  let is_translation = false;
+  let conflict = false;
+  let chosenSource: string;
+
+  if (sourcePick && caller && !sameLanguage(sourcePick.value, caller)) {
+    // The defect's core case: source and caller disagree → trust the artifact,
+    // demote the caller to the work hint, and flag for review.
+    language = sourcePick.value!;
+    original_language = callerOriginal || caller;
+    is_translation = true;
+    conflict = true;
+    chosenSource = sourcePick.source;
+  } else if (sourcePick) {
+    // Source present and either agrees with or has no competing caller value.
+    language = sourcePick.value!;
+    chosenSource = sourcePick.source;
+  } else if (caller) {
+    // No source signal at all — caller is the only evidence we have.
+    language = caller;
+    chosenSource = callerSource;
+  } else {
+    language = 'Unknown';
+    chosenSource = 'none';
+  }
+
+  // Don't keep original_language === language (FRBR work == manifestation).
+  if (original_language && sameLanguage(original_language, language)) {
+    original_language = null;
+    is_translation = false;
+  }
+
+  const provenance: FieldProvenanceEntry = {
+    source: 'import',
+    value: language,
+    chosen_from: chosenSource,
+    claims,
+    ...(conflict ? { conflict: true } : {}),
+    date: new Date().toISOString(),
+  };
+
+  return { language, original_language, is_translation, conflict, language_review: conflict, provenance };
+}
+
+/**
+ * Resolve the manifestation/edition date for an import (#2185).
+ *
+ * Same shape of bug as language: callers pass the *work*-composition year
+ * (Pico: 1486) which overrode the source's edition/scan date. Prefer the
+ * source date for the manifestation; route a caller-only year to
+ * `original_work_year` rather than letting it masquerade as the edition date.
+ */
+export interface ResolveDateResult {
+  /** Manifestation `published` value, or null. */
+  published: string | null;
+  /** Work-composition year when the caller supplied one the source lacks. */
+  original_work_year: string | null;
+}
+
+export function resolveDate(opts: {
+  callerPublished?: string | null;
+  callerYear?: string | number | null;
+  sourceDate?: string | null;
+}): ResolveDateResult {
+  const sourceDate = clean(opts.sourceDate);
+  const callerDate = clean(opts.callerPublished) || clean(opts.callerYear != null ? String(opts.callerYear) : null);
+
+  if (sourceDate) {
+    // Source has a real edition/scan date — it wins the manifestation date.
+    // A differing caller year is the work-composition year.
+    const callerYear = extractYear(callerDate);
+    const sourceYear = extractYear(sourceDate);
+    return {
+      published: sourceDate,
+      original_work_year: callerYear && callerYear !== sourceYear ? callerYear : null,
+    };
+  }
+
+  // No source date. Do NOT promote a caller's work-composition year to the
+  // manifestation date — leave `published` null and stash the year as the work year.
+  return { published: null, original_work_year: extractYear(callerDate) };
+}
+
+function clean(s: string | null | undefined): string | null {
+  if (!s) return null;
+  const t = String(s).trim();
+  return !t || /^unknown$/i.test(t) ? null : t;
+}
+
+function extractYear(s: string | null): string | null {
+  if (!s) return null;
+  const m = s.match(/-?\d{3,4}/);
+  return m ? m[0] : null;
+}


### PR DESCRIPTION
## What

All six import routes set a book's manifestation `language` (and date) from **caller-supplied input first**, with the source's own structured metadata ignored or used only as a last resort. A wrong caller value silently overrode what the scan actually is — the engineering root cause behind #2184 (Pico's *Oratio* imported as Latin/1486 when the scan is a 20th-c. Russian translation; IA's `metadata.language: rus`, `booksbylanguage_russian`, and `ocr_detected_lang` were all fetched and none gated the result).

This flips the precedence and adds a provenance + reconciliation layer.

## Changes

- **`src/lib/resolve-language.ts` (new)** — shared `resolveLanguage()` / `resolveDate()`. Source-empirical signals decide the manifestation `language`; the caller's value becomes the work hint (`original_language`). On caller-vs-source conflict: set `is_translation`, `language_review`, and record **both claims (value + source)** in `field_provenance.language`. A wrong value can no longer wear a trustworthy `internet_archive` badge.
- **`src/lib/language-utils.ts`** — `displayLanguage()` normalises ISO-639-1/2/3 codes (`rus`→Russian, `lat`→Latin, `grc`→Greek). This was the silent gap: IA's `"rus"` never matched catalogued `"Russian"` because nothing normalised the code. Plus `sameLanguage()` for conflict checks.
- **All six routes wired:**
  - `import/ia` + `import/google-books` — full IA signal precedence (`ocr_detected_lang` → `metadata.language` → `booksbylanguage_*`), then caller as work hint.
  - `import-utils` (IIIF, used by iiif + kyoto routes), `import/gallica`, `import/route` (local dir) — normalise the caller hint + stamp provenance (no reliable structured source-language field across these providers).
  - `import/kyoto` — drops the hardcoded `|| 'Japanese'` default (Kyoto RMDA also holds Chinese, Sanskrit, Western rare books).
- **Dates** — prefer the source edition/scan date; route a caller-only work-composition year to `original_work_year` instead of letting it masquerade as the edition date (Pico passed 1486; IA had no date).
- **`scripts/maintenance/audit-language-provenance.mjs` (new)** — promotes #2184's one-off detection into a committed, re-runnable reconciliation backstop. Samples **across the whole book** (not the first N pages) to avoid the front-matter/facsimile false positives noted in #2184.

## Audit result (fresh run against prod, read-only)

299 mismatches across the 1,443 IA books that carry per-page `<lang>` tags:
- **180 absent** — catalogued language never appears on sampled pages (strongest mislabel signal; e.g. Sanskrit jyotisha texts catalogued Sanskrit but OCR'd as Hindi/Telugu/Marathi, Greek→English Loebs, Syriac→English).
- **86 bilingual** — catalogued lang on ≥20% of pages (often deliberate `greek-latin` / `arabic-english` editions).
- **33 front_matter** — catalogued lang on <20% (critical-edition praefatio).

JSON triage list available; not all 180 "absent" are clean mislabels (some are wrong-scan or sampling edge cases) — still needs human triage per #2184.

## Behaviour / safety

- Records still insert `status: 'draft'`, `hidden: true`, `visible: false` as before, so review-flagged conflicts never auto-publish.
- No data migration here — this fixes the import boundary going forward. The committed audit script is the backstop for the existing backlog.

## Out of scope (deliberately)

- **Remediating the ~180/299 backlog** — stays in #2184 (data remediation, one concern per PR).
- **#2179 canonical author layer** — unrelated, separate effort.

Closes #2185. Refs #2184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)