### PR TITLE
fix(collections): link full author names in catalogue descriptions (#2179)

### DIFF
--- a/scripts/workers/sync-worker.mjs
+++ b/scripts/workers/sync-worker.mjs
@@ -14,7 +14,7 @@
  *   node scripts/workers/sync-worker.mjs --gallery-only
  */
 
-import { MongoClient } from 'mongodb';
+import { MongoClient, ObjectId } from 'mongodb';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -334,7 +334,33 @@ async function syncAuthorSlugs(db) {
     author: { $exists: true, $ne: null, $nin: ['Unknown', 'Anonymous', 'Various'] },
   });
   const slugs = {};
-  for (const a of authors) slugs[authorSlugFn(a)] = a;
+  for (const a of authors) { const s = authorSlugFn(a); if (s) slugs[s] = a; }
+
+  // Canonical-name aliases: an author's books may all be stored under a
+  // name-order variant ("Bruno, Giordano") while links point at the entity's
+  // canonical form ("Giordano Bruno"). Register slug(canonical) → a stored
+  // variant so /author/<canonical-slug> resolves (the page loads by entity and
+  // displays the canonical name). Don't overwrite a base entry. Unblocks the
+  // collection-description author linker (#2176/#2179).
+  let aliases = 0;
+  const ents = await db.collection('books').aggregate([
+    { $match: { visible: true, author: { $type: 'string', $ne: '' }, author_entity_id: { $nin: [null, ''] } } },
+    { $group: { _id: '$author_entity_id', sample: { $first: '$author' } } },
+  ], { allowDiskUse: true }).toArray();
+  const sampleOf = new Map(ents.map(e => [String(e._id), e.sample]));
+  const objIds = [...sampleOf.keys()].filter(s => ObjectId.isValid(s)).map(s => new ObjectId(s));
+  for (let i = 0; i < objIds.length; i += 2000) {
+    const docs = await db.collection('entities').find(
+      { _id: { $in: objIds.slice(i, i + 2000) } },
+      { projection: { canonical_name: 1, name: 1 } }).toArray();
+    for (const e of docs) {
+      const canon = e.canonical_name || e.name;
+      if (!canon) continue;
+      const s = authorSlugFn(canon);
+      const rep = sampleOf.get(String(e._id));
+      if (s && rep && !slugs[s]) { slugs[s] = rep; aliases++; }
+    }
+  }
 
   if (!DRY_RUN) {
     await db.collection('system_config').updateOne(
@@ -344,7 +370,7 @@ async function syncAuthorSlugs(db) {
     );
   }
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);
-  console.log(`  ${Object.keys(slugs).length} author slugs synced | ${elapsed}s`);
+  console.log(`  ${Object.keys(slugs).length} author slugs synced (${aliases} canonical aliases) | ${elapsed}s`);
   return { author_slugs: Object.keys(slugs).length };
 }
 

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -127,7 +127,7 @@ function linkBookTitles(
   allBooks: BookItem[],
   explicitMentions?: { text: string; book_id: string }[],
   tenantSlug?: string | null,
-  authorLinks: { name: string; href: string; canonical?: string }[] = [],
+  authorLinks: { name: string; href: string; canonical?: string; count?: number }[] = [],
 ): React.ReactNode {
   const matches: { start: number; end: number; title: string; id: string; href?: string }[] = [];
   const usedRanges: [number, number][] = [];
@@ -215,28 +215,34 @@ function linkBookTitles(
     }
   }
 
-  // 3. Author names → author pages. Collect distinctive name tokens (≥5 chars)
-  // from the collection's book authors; a token mapping to more than one author
-  // is ambiguous and skipped. Best-effort prose linking (names appear in many
-  // forms — "Galileo", "Bruno", "Descartes" — so we match any unique token).
-  const tokenHrefs = new Map<string, Set<string>>();
-  // authorLinks carry each author string + its CANONICAL author-page href
-  // (resolved via the book's entity), so variants of one person ("Bruno,
-  // Giordano" / "Giordano Bruno") share one href and survive the dedup below.
-  for (const { name, href } of authorLinks) {
+  // 3. Single surname/name tokens (≥5 chars). Descriptions usually name an
+  // author by bare surname ("Bruno", "Spinoza", "Descartes"), so a token often
+  // maps to several people in one collection (Giordano Bruno vs Christoph Bruno
+  // vs Elwin Bruno Christoffel). Rather than drop every contested surname, link
+  // it to the DOMINANT author when one clearly owns it — measured by how many of
+  // the collection's books each candidate holds. Genuinely split surnames
+  // (e.g. two prominent Picos) stay unlinked.
+  const tokenWeights = new Map<string, Map<string, number>>(); // tok → href → book count
+  for (const { name, href, count } of authorLinks) {
     if (!name || !href) continue;
     const seenInThisAuthor = new Set<string>();
     for (const raw of name.replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').split(/[\s,;|]+/)) {
       const tok = raw.trim().toLowerCase();
       if (tok.length < 5 || seenInThisAuthor.has(tok)) continue;
       seenInThisAuthor.add(tok);
-      if (!tokenHrefs.has(tok)) tokenHrefs.set(tok, new Set());
-      tokenHrefs.get(tok)!.add(href);
+      if (!tokenWeights.has(tok)) tokenWeights.set(tok, new Map());
+      const w = tokenWeights.get(tok)!;
+      w.set(href, (w.get(href) || 0) + (count || 1));
     }
   }
-  for (const [tok, hrefs] of tokenHrefs) {
-    if (hrefs.size !== 1) continue; // maps to >1 distinct author page → ambiguous
-    const href = [...hrefs][0];
+  for (const [tok, weights] of tokenWeights) {
+    const ranked = [...weights.entries()].sort((a, b) => b[1] - a[1]);
+    const [topHref, topN] = ranked[0];
+    const secondN = ranked[1]?.[1] ?? 0;
+    // Unique owner → always link. Contested → link only on a clear plurality
+    // (≥3 books and ≥3× the runner-up) so we don't guess on a real tie.
+    if (ranked.length > 1 && !(topN >= 3 && topN >= 3 * secondN)) continue;
+    const href = topHref;
     const escaped = tok.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const regex = new RegExp(`\\b${escaped}\\b`, 'gi');
     let match;
@@ -686,7 +692,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
       const db = await getReadDb();
       const pairs = await db.collection('books').aggregate([
         { $match: { collections: id, author: { $type: 'string', $ne: '' } } },
-        { $group: { _id: '$author', ent: { $first: '$author_entity_id' } } },
+        { $group: { _id: '$author', ent: { $first: '$author_entity_id' }, n: { $sum: 1 } } },
       ]).toArray();
       const entIds = [...new Set(pairs.map(p => p.ent).filter(Boolean).map(String))];
       const entDocs = entIds.length
@@ -698,7 +704,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
       descriptionAuthorLinks = pairs.flatMap(p => {
         const canon = (p.ent ? entName.get(String(p.ent)) : null) as string | null;
         const href = authorUrl(canon || (p._id as string));
-        return href ? [{ name: p._id as string, canonical: canon || undefined, href }] : [];
+        return href ? [{ name: p._id as string, canonical: canon || undefined, href, count: (p.n as number) || 1 }] : [];
       });
     } catch { /* non-fatal — description just won't gain author links */ }
   }

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -127,7 +127,7 @@ function linkBookTitles(
   allBooks: BookItem[],
   explicitMentions?: { text: string; book_id: string }[],
   tenantSlug?: string | null,
-  authorLinks: { name: string; href: string }[] = [],
+  authorLinks: { name: string; href: string; canonical?: string }[] = [],
 ): React.ReactNode {
   const matches: { start: number; end: number; title: string; id: string; href?: string }[] = [];
   const usedRanges: [number, number][] = [];
@@ -173,6 +173,43 @@ function linkBookTitles(
       const end = start + match[0].length;
       if (!usedRanges.some(([s, e]) => start < e && end > s)) {
         matches.push({ start, end, title: match[0], id });
+        usedRanges.push([start, end]);
+      }
+    }
+  }
+
+  // 3a. Full-name phrases first. A bare surname is often shared by several
+  // people in one collection ("Bruno" → Giordano Bruno, Christoph Bruno,
+  // Elwin Bruno Christoffel), so the single-token pass below rules it ambiguous
+  // and drops it. The full/canonical name ("Giordano Bruno") is unambiguous,
+  // so match those multi-token phrases here and claim their ranges — this is
+  // what lets prominent authors link despite a contested surname (#2176/#2179).
+  const phraseHrefs = new Map<string, Set<string>>();
+  const phraseForm = (s: string) => s
+    .replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').replace(/[,;|].*$/, '').trim();
+  for (const { name, href, canonical } of authorLinks) {
+    if (!href) continue;
+    for (const form of [canonical, name]) {
+      if (!form) continue;
+      const p = phraseForm(form);
+      if (p.split(/\s+/).filter(Boolean).length < 2) continue; // need a full name
+      const key = p.toLowerCase();
+      if (!phraseHrefs.has(key)) phraseHrefs.set(key, new Set());
+      phraseHrefs.get(key)!.add(href);
+    }
+  }
+  // longest phrase first so "Giordano Bruno" wins before any shorter overlap
+  for (const [key, hrefs] of [...phraseHrefs].sort((a, b) => b[0].length - a[0].length)) {
+    if (hrefs.size !== 1) continue;
+    const href = [...hrefs][0];
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
+    const regex = new RegExp(`\\b${escaped}\\b`, 'gi');
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const start = match.index;
+      const end = start + match[0].length;
+      if (!usedRanges.some(([s, e]) => start < e && end > s)) {
+        matches.push({ start, end, title: match[0], id: `author-${key}`, href });
         usedRanges.push([start, end]);
       }
     }
@@ -643,7 +680,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
   // slug, so name-order variants of one person ("Bruno, Giordano" / "Giordano
   // Bruno") share a single href (this is what the canonical-author relink in
   // #2180 enables). Falls back to the raw string slug when unlinked.
-  let descriptionAuthorLinks: { name: string; href: string }[] = [];
+  let descriptionAuthorLinks: { name: string; href: string; canonical?: string }[] = [];
   if (isCatalogCollection) {
     try {
       const db = await getReadDb();
@@ -659,9 +696,9 @@ export default async function CollectionDetailPage({ params, provider }: Props &
         : [];
       const entName = new Map(entDocs.map(e => [String(e._id), e.canonical_name || e.name]));
       descriptionAuthorLinks = pairs.flatMap(p => {
-        const canon = p.ent ? entName.get(String(p.ent)) : null;
+        const canon = (p.ent ? entName.get(String(p.ent)) : null) as string | null;
         const href = authorUrl(canon || (p._id as string));
-        return href ? [{ name: p._id as string, href }] : [];
+        return href ? [{ name: p._id as string, canonical: canon || undefined, href }] : [];
       });
     } catch { /* non-fatal — description just won't gain author links */ }
   }


### PR DESCRIPTION
## Context
The collection-description author-linker (#2176) turns author surnames in the prose into links to their author pages. This PR hardens it and ensures canonical-slug author URLs resolve.

**What was actually broken vs. what this fixes:** the ILP author links (Bruno, Spinoza, Descartes, Servetus, Galileo, Pufendorf, Vanini) are **already live in production** and all resolve `200` — the earlier canonical-author relink (#2180, applied separately) made a person's name variants share one entity → one href, which the existing linker already handles. So this PR is **hardening**, not the load-bearing fix:

## Changes
1. **Disambiguate by prominence** (`linkBookTitles`). The old rule dropped *any* surname token that mapped to >1 author in the collection — wrong when one person clearly owns it (a famous author tagged alongside a one-book namesake). Now a contested token links to the **dominant** author when it holds **≥3 books and ≥3× the runner-up**; genuine ties (e.g. two prominent Picos) still skip. A **full-name phrase pass** runs first so "Giordano Bruno" can match where the bare surname is contested.
2. **`syncAuthorSlugs`** registers `slug(canonical_name) → a stored variant`, so `/author/<canonical-slug>` resolves even when every book is filed under a name-order variant ("Bruno, Giordano"). The author page already loads by entity and shows the canonical name.

## Verification
- Simulated the full linker against the real ILP description + authors: links Bruno→giordano-bruno, Descartes→rene-descartes, Spinoza→benedictus-de-spinoza, Galileo, Servetus, Pufendorf, Vanini.
- Production already renders those 7 links; all 7 `/author/*` pages return `200`.
- Slug-alias enrichment applied to prod immediately: **+1,313 canonical aliases** (7,038 → 8,351 author slugs).
- `tsc` clean for the changed file (pre-existing d3-types errors in unrelated blog interactives remain).

## Scope
Linker disambiguation + canonical-slug registration only. The larger #2179 work (a clean canonical `authors` collection, read-path migration, dedupe-on-write in the mention pipeline) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)