### PR TITLE
fix(pipeline): content_type authoritative for artwork; papyri are books

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2537,12 +2537,15 @@ async function run() {
       console.log(`  Enrolled: ${log.enrolled}`);
     }
 
-    // Artwork resource types — these skip the book pipeline entirely (no text to OCR/translate)
-    const ARTWORK_TYPES = ['painting', 'print', 'drawing', 'fresco', 'papyrus_fragment', 'object'];
-    // Canonical artwork signal is content_type:'artwork'. resource_type is a finer-grained
-    // sub-category (sculpture, manuscript, scientific_instrument, …) that under-matches — so
-    // match on either. (See CLAUDE.md: don't gate artwork on resource_type alone.)
-    const ARTWORK_MATCH = { $or: [{ content_type: 'artwork' }, { resource_type: { $in: ARTWORK_TYPES } }] };
+    // Artwork resource types — these skip the book pipeline entirely (no text to OCR/translate).
+    // NOTE: 'papyrus_fragment' is deliberately NOT here — papyri (and cuneiform) are textual
+    // sources and belong in the BOOK pipeline, like the Egyptian Book-of-the-Dead papyri.
+    const ARTWORK_TYPES = ['painting', 'print', 'drawing', 'fresco', 'object'];
+    // content_type is AUTHORITATIVE: 'book' is never artwork (overrides resource_type — needed
+    // for object-typed textual papyri like "Papyrus, funerary, Book of the Dead"), 'artwork'
+    // always is. resource_type is only a fallback when content_type is unset.
+    // (See CLAUDE.md: don't gate artwork on resource_type alone.)
+    const ARTWORK_MATCH = { content_type: { $ne: 'book' }, $or: [{ content_type: 'artwork' }, { resource_type: { $in: ARTWORK_TYPES } }] };
 
     // ── Phase 0: Skip artworks that somehow entered the pipeline ──
     if (shouldRun(1)) {
@@ -2573,7 +2576,7 @@ async function run() {
       const ENGLISH_VARIANTS_P1 = ['english', 'eng', 'en'];
       let queuedBooks = await db.collection('books')
         .aggregate([
-          { $match: { 'pipeline_auto.status': 'queued', content_type: { $ne: 'artwork' }, resource_type: { $nin: ARTWORK_TYPES } } },
+          { $match: { 'pipeline_auto.status': 'queued', content_type: { $ne: 'artwork' }, $or: [{ content_type: 'book' }, { resource_type: { $nin: ARTWORK_TYPES } }] } },
           { $addFields: {
             _priority: {
               $switch: {


### PR DESCRIPTION
Follow-up to #2193, prompted by the directive that **papyri and cuneiform are textual sources → books** (like the Egyptian Book-of-the-Dead papyri), while papyrus-*motif* objects (amulets, kohl tubes, mirror handles) stay artwork.

## Two gaps in #2193
1. `resource_type:'object'` is in `ARTWORK_TYPES`, but it's generic — it covers both papyrus-motif amulets **and** textual papyri (Met catalogs Book-of-the-Dead papyri as `object`). So a textual papyrus retagged `content_type:'book'` but still `resource_type:'object'` got swept **back** to artwork by Phase 0 every 2-min cycle.
2. `papyrus_fragment` was in `ARTWORK_TYPES`, classifying papyri as artwork.

## Fixes
- Drop `papyrus_fragment` from `ARTWORK_TYPES`.
- **`content_type` is now authoritative**: `ARTWORK_MATCH` requires `content_type != 'book'`, so an explicit book is never reclassified as artwork regardless of `resource_type`. `resource_type` remains a fallback only when `content_type` is unset (null).
- Phase 1 enrollment lets `content_type:'book'` through even with an artwork-ish `resource_type`.

## Data (same session)
- 68 papyri retagged `content_type:'book'` (26 with page images re-enrolled; 42 text-only catalog stubs — PGM magical papyri, Homer/Sappho literary papyri — cataloged).
- 20 papyrus-motif objects correctly stay artwork.
- 0 cuneiform was mis-tagged (the "tablet" hits were all *Emerald Tablet* paintings).

`node --check` passes. Behavior-only change to artwork classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)