### PR TITLE
feat(authors): additive canonical authors-collection builder (#2179, step 1)

### DIFF
--- a/scripts/maintenance/build-authors-collection.mjs
+++ b/scripts/maintenance/build-authors-collection.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Build the clean canonical `authors` collection (GitHub #2179, step 1).
+ *
+ * The `entities` collection conflates ~305K mentioned people (mention-extraction
+ * debris) with the few thousand actual BOOK authors, fragmenting one person
+ * across many records. This builds a separate, clean author layer scoped to
+ * book authors only — one document per person — WITHOUT touching `entities`,
+ * `books`, or any read path. It is purely additive and fully reversible
+ * (`db.authors.drop()`); migrating reads onto it and retiring `entities` are
+ * later, reviewed steps.
+ *
+ * Clustering = canonical name key (Latin↔vernacular / name-order / date variants
+ * collapse; non-Latin scripts keyed on the folded raw name) UNIONED with shared
+ * harvested authority ids (VIAF / Wikidata) so e.g. Erasmus/Desiderius/
+ * Roterodamus merge when they share a VIAF even if the name key differs.
+ *
+ * Each author doc (provenance kept so the build is auditable / reversible):
+ *   { _id: <slug>, canonical_name, slug, variants[], variant_slugs[],
+ *     book_count, viaf_id, wikidata_id, entity_ids[], source, built_at }
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/build-authors-collection.mjs            # dry-run (no writes)
+ *   node scripts/maintenance/build-authors-collection.mjs --apply    # writes `authors`
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+
+const PARTICLES = new Set(['de','del','della','di','da','la','le','van','von','der','den','du','des','el','al','ibn','ben','a','ab','zu','of','the','don','fr','st','saint','y','e','pseudo']);
+// People-only: drop placeholders, institutions, and ethnonym/anonymous buckets.
+const PLACEHOLDER = /^(anonymous|unknown|various|anon|n\/a|none|egyptian|sumerian|babylonian|assyrian|traditional|chinese|japanese|tibetan|greek|roman)\b|collection|monastery|temple|press|library|dynasty|school of|circle of|workshop|^mtena|\b(church|council|society|congregation|order of|company of|guild|academy|université|university|conserv|ministry|commission|office|bureau)\b/i;
+/** Compound authorship ("A & B", "A; B", "A and B" with two names) — real co-
+ *  authored works, but not one person, so they don't become a canonical author. */
+const COMPOUND = /\s(&|;|\band\b)\s.*[a-z]/i;
+
+const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
+
+/** Cluster key: folded Latin stems of the name tokens; non-Latin names fall back
+ *  to the diacritic-folded raw name so CJK/Cyrillic/Greek authors still cluster. */
+function canonicalKey(author) {
+  const s = norm(author).replace(/\([^)]*\)/g, '').replace(/,?\s*\d{3,4}\b.*$/, '').replace(/[^a-z\s,]/g, ' ');
+  const toks = s.split(/[\s,]+/).filter(t => t.length >= 3 && !PARTICLES.has(t));
+  const stems = toks.map(t => t
+    .replace(/^j/, 'i').replace(/^gi/, 'i').replace(/v/g, 'u')
+    .replace(/(issimus|us|um|orum|arum|ibus|onis|ius|is|ae|i|o|a|e)$/, ''))
+    .filter(t => t.length >= 3).sort();
+  if (!stems.length) {
+    return (author || '').normalize('NFKD').replace(/[̀-ͯ]/g, '')
+      .replace(/\([^)]*\)/g, '').replace(/[\d,.;]/g, '').replace(/\s+/g, '').toLowerCase();
+  }
+  return stems.join(' ');
+}
+
+/** URL slug — must match src/lib/slugify.ts authorSlug() exactly. */
+const authorSlug = (a) => (a || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-');
+
+const mc = new MongoClient(process.env.MONGODB_URI); await mc.connect();
+const db = mc.db('bookstore'); const books = db.collection('books'); const ents = db.collection('entities');
+
+console.log(`build authors collection — ${APPLY ? 'APPLY' : 'DRY-RUN'}\n`);
+
+// 1. distinct book-author strings over live books, with book counts + linked entities
+const rows = await books.aggregate([
+  { $match: { visible: { $ne: false }, pages_count: { $gt: 0 }, author: { $type: 'string', $ne: '' } } },
+  { $group: { _id: '$author', n: { $sum: 1 }, ents: { $addToSet: '$author_entity_id' } } },
+], { allowDiskUse: true }).toArray();
+const compound = rows.filter(r => !PLACEHOLDER.test(r._id.trim()) && COMPOUND.test(r._id));
+const authors = rows.filter(r => !PLACEHOLDER.test(r._id.trim()) && !COMPOUND.test(r._id));
+console.log(`distinct live author strings: ${rows.length}  (people: ${authors.length}, compound/co-author strings held back: ${compound.length}, placeholders/institutions: ${rows.length - authors.length - compound.length})`);
+
+// 2. harvest viaf / wikidata / canonical_name from the linked entity records
+const allIds = [...new Set(authors.flatMap(r => r.ents).filter(Boolean).map(String))];
+const objIds = allIds.filter(s => ObjectId.isValid(s)).map(s => new ObjectId(s));
+const em = new Map();
+for (let i = 0; i < objIds.length; i += 2000) {
+  const docs = await ents.find({ _id: { $in: objIds.slice(i, i + 2000) } },
+    { projection: { viaf_id: 1, wikidata_id: 1, canonical_name: 1, name: 1, book_count: 1 } }).toArray();
+  for (const e of docs) em.set(String(e._id), e);
+}
+for (const r of authors) {
+  r.viaf = null; r.wd = null; r.entName = null; r.entBooks = 0; r.entIds = [];
+  for (const id of r.ents) {
+    if (!id) continue;
+    const e = em.get(String(id)); if (!e) continue;
+    r.entIds.push(String(id));
+    if (e.viaf_id && !r.viaf) { r.viaf = e.viaf_id; r.entName = e.canonical_name || e.name; }
+    if (e.wikidata_id && !r.wd) r.wd = e.wikidata_id;
+    if ((e.book_count || 0) >= r.entBooks) { r.entBooks = e.book_count || 0; if (!r.entName) r.entName = e.canonical_name || e.name; }
+  }
+  r.key = canonicalKey(r._id);
+}
+
+// 3. union-find: merge on canonical key, then on shared VIAF, then shared Wikidata
+const parent = authors.map((_, i) => i);
+const find = (x) => { while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; } return x; };
+const union = (a, b) => { const ra = find(a), rb = find(b); if (ra !== rb) parent[ra] = rb; };
+const groupBy = (keyFn) => { const m = new Map(); authors.forEach((r, i) => { const k = keyFn(r); if (!k) return; (m.get(k) || m.set(k, []).get(k)).push(i); }); return m; };
+for (const fn of [r => r.key, r => r.viaf, r => r.wd]) {
+  for (const g of groupBy(fn).values()) for (let j = 1; j < g.length; j++) union(g[0], g[j]);
+}
+
+// 4. assemble one author doc per cluster
+const clusters = new Map();
+authors.forEach((r, i) => { const root = find(i); (clusters.get(root) || clusters.set(root, []).get(root)).push(r); });
+
+const docs = [];
+const slugCounts = new Map();
+for (const members of clusters.values()) {
+  members.sort((a, b) => b.n - a.n);
+  const viaf = members.find(m => m.viaf)?.viaf || null;
+  const wd = members.find(m => m.wd)?.wd || null;
+  // canonical name: prefer a harvested entity canonical_name (clean, natural order); else the most-common variant
+  const canonical_name = members.find(m => m.viaf && m.entName)?.entName || members.find(m => m.entName)?.entName || members[0]._id;
+  let slug = authorSlug(canonical_name);
+  if (!slug) continue;
+  const seen = slugCounts.get(slug) || 0; slugCounts.set(slug, seen + 1);
+  if (seen > 0) slug = `${slug}-${seen + 1}`;            // disambiguate slug collisions across different people
+  const variants = [...new Set(members.map(m => m._id))];
+  docs.push({
+    _id: slug,
+    canonical_name,
+    slug,
+    variants,
+    variant_slugs: [...new Set(variants.map(authorSlug).filter(Boolean))],
+    book_count: members.reduce((s, m) => s + m.n, 0),
+    viaf_id: viaf,
+    wikidata_id: wd,
+    entity_ids: [...new Set(members.flatMap(m => m.entIds))],
+    source: 'build-authors-collection',
+    built_at: new Date(),
+  });
+}
+docs.sort((a, b) => b.book_count - a.book_count);
+
+console.log(`\nclusters → ${docs.length} canonical authors`);
+console.log(`  with VIAF: ${docs.filter(d => d.viaf_id).length}  with Wikidata: ${docs.filter(d => d.wikidata_id).length}  multi-variant: ${docs.filter(d => d.variants.length > 1).length}`);
+console.log('\nTop 15 by book_count (name · books · variants · viaf):');
+for (const d of docs.slice(0, 15)) console.log(`  ${String(d.book_count).padStart(4)}b ${String(d.variants.length).padStart(2)}v ${d.viaf_id ? 'VIAF' : 'no-viaf'}  "${d.canonical_name}"  [${d.slug}]`);
+
+// fragmentation sanity — each famous person should be exactly ONE doc
+const oneDoc = (re) => docs.filter(d => d.variants.some(v => re.test(v))).length;
+console.log('\nFragmentation sanity (should be 1 each):');
+for (const [nm, re] of [['Spinoza', /spinoza/i], ['Bruno', /giordano bruno|bruno, giordano/i], ['Erasmus', /erasmus|roterodam/i], ['Paracelsus', /paracelsus/i], ['Aquinas', /aquinas|aquino/i], ['Descartes', /descartes/i]])
+  console.log(`  ${nm.padEnd(12)} → ${oneDoc(re)} doc(s)`);
+
+if (APPLY) {
+  await db.collection('authors').drop().catch(() => {});
+  // chunked insert
+  for (let i = 0; i < docs.length; i += 1000) await db.collection('authors').insertMany(docs.slice(i, i + 1000), { ordered: false });
+  await db.collection('authors').createIndex({ slug: 1 }, { unique: true });
+  await db.collection('authors').createIndex({ variant_slugs: 1 });
+  await db.collection('authors').createIndex({ viaf_id: 1 }, { sparse: true });
+  await db.collection('authors').createIndex({ book_count: -1 });
+  console.log(`\nWrote ${docs.length} docs to authors (+ indexes). Reversible: db.authors.drop()`);
+} else {
+  console.log(`\nDRY-RUN — no writes. Re-run with --apply to create the authors collection.`);
+}
+await mc.close();

--- a/scripts/maintenance/build-authors-collection.mjs
+++ b/scripts/maintenance/build-authors-collection.mjs
@@ -31,9 +31,13 @@ const APPLY = process.argv.includes('--apply');
 const PARTICLES = new Set(['de','del','della','di','da','la','le','van','von','der','den','du','des','el','al','ibn','ben','a','ab','zu','of','the','don','fr','st','saint','y','e','pseudo']);
 // People-only: drop placeholders, institutions, and ethnonym/anonymous buckets.
 const PLACEHOLDER = /^(anonymous|unknown|various|anon|n\/a|none|egyptian|sumerian|babylonian|assyrian|traditional|chinese|japanese|tibetan|greek|roman)\b|collection|monastery|temple|press|library|dynasty|school of|circle of|workshop|^mtena|\b(church|council|society|congregation|order of|company of|guild|academy|université|university|conserv|ministry|commission|office|bureau)\b/i;
-/** Compound authorship ("A & B", "A; B", "A and B" with two names) — real co-
- *  authored works, but not one person, so they don't become a canonical author. */
-const COMPOUND = /\s(&|;|\band\b)\s.*[a-z]/i;
+/** Compound authorship ("A & B", "A | B", "A / B", "A; B", "A, B, C, …") — real
+ *  co-authored / multi-attribution works. An entity-linked compound string is
+ *  routed to its primary author via that entity below; the rest are held back so
+ *  they don't mint a spurious "author". Editor/translator tails ("; ed. Waite")
+ *  are NOT compounds — but separating them by string alone is unreliable, so
+ *  entity-linked ones still resolve correctly and only no-entity ones drop. */
+const COMPOUND = /\s[|/&]\s|;\s|\bet\s+al\b|,[^,]+,[^,]+,/i;
 
 const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
 
@@ -67,9 +71,14 @@ const rows = await books.aggregate([
   { $match: { visible: { $ne: false }, pages_count: { $gt: 0 }, author: { $type: 'string', $ne: '' } } },
   { $group: { _id: '$author', n: { $sum: 1 }, ents: { $addToSet: '$author_entity_id' } } },
 ], { allowDiskUse: true }).toArray();
-const compound = rows.filter(r => !PLACEHOLDER.test(r._id.trim()) && COMPOUND.test(r._id));
-const authors = rows.filter(r => !PLACEHOLDER.test(r._id.trim()) && !COMPOUND.test(r._id));
-console.log(`distinct live author strings: ${rows.length}  (people: ${authors.length}, compound/co-author strings held back: ${compound.length}, placeholders/institutions: ${rows.length - authors.length - compound.length})`);
+const people = rows.filter(r => !PLACEHOLDER.test(r._id.trim()));
+// Keep an entity-linked compound string ("Sendivogius, Michael | Paracelsus")
+// — it carries the PRIMARY author's entity, so union-find routes its books to
+// that person. Drop no-entity compounds (can't attribute → would mint noise).
+const hasEnt = (r) => (r.ents || []).some(Boolean);
+const authors = people.filter(r => !COMPOUND.test(r._id) || hasEnt(r));
+const droppedCompound = people.length - authors.length;
+console.log(`distinct live author strings: ${rows.length}  (people: ${people.length}, clustered: ${authors.length}, no-entity compounds dropped: ${droppedCompound}, placeholders/institutions: ${rows.length - people.length})`);
 
 // 2. harvest viaf / wikidata / canonical_name from the linked entity records
 const allIds = [...new Set(authors.flatMap(r => r.ents).filter(Boolean).map(String))];
@@ -113,7 +122,10 @@ for (const members of clusters.values()) {
   const viaf = members.find(m => m.viaf)?.viaf || null;
   const wd = members.find(m => m.wd)?.wd || null;
   // canonical name: prefer a harvested entity canonical_name (clean, natural order); else the most-common variant
-  const canonical_name = members.find(m => m.viaf && m.entName)?.entName || members.find(m => m.entName)?.entName || members[0]._id;
+  const canonical_name = members.find(m => m.viaf && m.entName)?.entName
+    || members.find(m => m.entName)?.entName
+    || members.find(m => !COMPOUND.test(m._id))?._id   // prefer a clean sole-author string
+    || members[0]._id;
   let slug = authorSlug(canonical_name);
   if (!slug) continue;
   const seen = slugCounts.get(slug) || 0; slugCounts.set(slug, seen + 1);
@@ -135,16 +147,29 @@ for (const members of clusters.values()) {
 }
 docs.sort((a, b) => b.book_count - a.book_count);
 
+// NOTE: merging is DETERMINISTIC only — shared name-key ∪ shared VIAF ∪ shared
+// Wikidata. The famous people already collapse to one doc this way. The
+// no-authority obscure tail (~2K strings) stays as separate docs on purpose:
+// under-merging an obscure author is harmless (a duplicate page); MIS-merging
+// two same-surname people is not. Consolidating that tail correctly needs
+// authority resolution disambiguated by each author's actual books (title /
+// year / language) — tracked as the follow-up "grounded reconciliation" step,
+// NOT a blind name/LLM merge (both mis-resolve same-surname people).
+
 console.log(`\nclusters → ${docs.length} canonical authors`);
 console.log(`  with VIAF: ${docs.filter(d => d.viaf_id).length}  with Wikidata: ${docs.filter(d => d.wikidata_id).length}  multi-variant: ${docs.filter(d => d.variants.length > 1).length}`);
 console.log('\nTop 15 by book_count (name · books · variants · viaf):');
 for (const d of docs.slice(0, 15)) console.log(`  ${String(d.book_count).padStart(4)}b ${String(d.variants.length).padStart(2)}v ${d.viaf_id ? 'VIAF' : 'no-viaf'}  "${d.canonical_name}"  [${d.slug}]`);
 
-// fragmentation sanity — each famous person should be exactly ONE doc
-const oneDoc = (re) => docs.filter(d => d.variants.some(v => re.test(v))).length;
-console.log('\nFragmentation sanity (should be 1 each):');
-for (const [nm, re] of [['Spinoza', /spinoza/i], ['Bruno', /giordano bruno|bruno, giordano/i], ['Erasmus', /erasmus|roterodam/i], ['Paracelsus', /paracelsus/i], ['Aquinas', /aquinas|aquino/i], ['Descartes', /descartes/i]])
-  console.log(`  ${nm.padEnd(12)} → ${oneDoc(re)} doc(s)`);
+// fragmentation sanity — count docs whose CANONICAL NAME is this person (not
+// every doc that merely lists the surname among its variants — those are mostly
+// co-author strings that correctly belong to the other author).
+const canonDocs = (re) => docs.filter(d => re.test(d.canonical_name));
+console.log('\nFragmentation sanity (canonical-name match, should be 1 each):');
+for (const [nm, re] of [['Spinoza', /spinoza/i], ['Bruno', /giordano bruno|bruno, giordano/i], ['Erasmus', /^(desiderius )?erasmus|roterodam/i], ['Paracelsus', /paracelsus|hohenheim/i], ['Aquinas', /aquinas|aquino/i], ['Descartes', /descartes/i]]) {
+  const ds = canonDocs(re);
+  console.log(`  ${nm.padEnd(12)} → ${ds.length} doc(s)${ds.length > 1 ? ': ' + ds.map(d => `"${d.canonical_name}"(${d.book_count}b)`).join(', ') : ''}`);
+}
 
 if (APPLY) {
   await db.collection('authors').drop().catch(() => {});

--- a/scripts/maintenance/reconcile-authors-grounded.mjs
+++ b/scripts/maintenance/reconcile-authors-grounded.mjs
@@ -99,6 +99,7 @@ const queue = clean.slice(0, Number.isFinite(LIMIT) ? LIMIT : clean.length);
 console.log(`unanchored authors: ${targets.length} | malformed skipped: ${targets.length - clean.length} | attempting: ${queue.length}\n`);
 
 let anchored = 0, nulled = 0, gated = 0, errored = 0;
+let inTok = 0, outTok = 0; // flash-lite token usage, for exact cost
 const decisions = [];
 for (const t of queue) {
   try {
@@ -119,6 +120,7 @@ ${cands.map((c, i) => `${i + 1}. ${c.qid} — ${c.label}${c.description ? ` — 
 
 Return STRICT JSON: {"qid":"Q...."|null,"reason":"<≤12 words>"}`;
     const res = await model.generateContent({ contents: [{ role: 'user', parts: [{ text: prompt }] }], generationConfig: { responseMimeType: 'application/json', temperature: 0 } });
+    const um = res.response.usageMetadata; inTok += um?.promptTokenCount || 0; outTok += um?.candidatesTokenCount || 0;
     const pick = JSON.parse(res.response.text());
     const chosen = pick.qid && cands.find(c => c.qid === pick.qid);
     if (!chosen) { nulled++; decisions.push(`  ∅ no-match     "${t.canonical_name}" — ${pick.reason || ''}`); continue; }
@@ -142,6 +144,10 @@ Return STRICT JSON: {"qid":"Q...."|null,"reason":"<≤12 words>"}`;
 
 console.log(decisions.join('\n'));
 console.log(`\nanchored ${anchored} | null ${nulled} | date-gated ${gated} | errors ${errored}  (of ${queue.length})`);
+// gemini-3.1-flash-lite list price (USD per 1M tokens) — update if the rate card changes
+const PRICE_IN = 0.10, PRICE_OUT = 0.40;
+const cost = (inTok / 1e6) * PRICE_IN + (outTok / 1e6) * PRICE_OUT;
+console.log(`flash-lite tokens: ${inTok.toLocaleString()} in / ${outTok.toLocaleString()} out → ~$${cost.toFixed(3)} (at $${PRICE_IN}/$${PRICE_OUT} per 1M)`);
 
 // merge author docs that now share an authority id (only meaningful with --apply)
 if (APPLY && anchored) {

--- a/scripts/maintenance/reconcile-authors-grounded.mjs
+++ b/scripts/maintenance/reconcile-authors-grounded.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Grounded author reconciliation (GitHub #2218 — step 2 of the #2179 rebuild).
+ *
+ * Anchors the unanchored authors in the `authors` collection to a Wikidata QID
+ * (+ VIAF) using each author's OWN BOOKS as the disambiguator. The hard problem
+ * is same-surname people: a name alone resolves "Hans Christian Andersen" to
+ * "Jürgen Andersen". The fix is to judge against real authority records using
+ * real evidence — the books — rather than guess from the name.
+ *
+ * Per unanchored author:
+ *   1. Pull a few representative books (title / year / language).
+ *   2. Search Wikidata for REAL candidate people for the name.
+ *   3. flash-lite picks the matching candidate QID — or null — constrained to
+ *      the real candidates, using the books + each candidate's dates/description.
+ *   4. Life-date gate: reject if a book predates birth−5 or postdates death+50
+ *      (catches a confident-but-wrong pick).
+ *   5. Write wikidata_id (+ VIAF via P214) onto the author doc.
+ * Finally, merge author docs that now share a wikidata_id / viaf_id.
+ *
+ * Precision rule: UNDER-MERGE before MIS-MERGE. null beats a wrong anchor.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/reconcile-authors-grounded.mjs --limit 20        # dry-run sample
+ *   node scripts/maintenance/reconcile-authors-grounded.mjs --apply           # full, writes authors
+ */
+import { MongoClient } from 'mongodb';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+const APPLY = process.argv.includes('--apply');
+const LIMIT = (() => { const i = process.argv.indexOf('--limit'); return i > -1 ? Number(process.argv[i + 1]) : Infinity; })();
+const MODEL = 'gemini-3.1-flash-lite';
+const UA = 'SourceLibrary-author-reconcile/1.0 (https://sourcelibrary.org; admin@sourcelibrary.org)';
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+const yearOf = (s) => { const m = String(s || '').match(/\b(\d{3,4})\b/); return m ? Number(m[1]) : null; };
+
+// title-contaminated / bracketed strings can't be looked up by name; skip the
+// search and leave them for a name-cleaning pass.
+const MALFORMED = /[|\/\[\]]|\b(magia|arcana|oedipus|mundus|musurgia|aurora|monas|medicina|ars |arbor|kabbalah|portae|silentium|symbola|steganographia|hermetica|works|de occulta|de mysteriis)\b/i;
+
+// Search Wikidata under a few name forms — many records are filed surname-first
+// ("Manuzio, Aldo") or with honorifics ("Albertus, Magnus, Heiliger"), which the
+// raw search misses. Try natural order + an honorific-stripped form, dedup by QID.
+function nameVariants(name) {
+  const out = new Set();
+  const strip = (s) => s.replace(/\b(heiliger|heilige|saint|sankt|der heilige|pseudo|approximately|active|fl\.?|ca\.?|circa)\b/gi, '').replace(/\([^)]*\)/g, '').replace(/\s{2,}/g, ' ').trim();
+  out.add(strip(name));
+  if (name.includes(',')) {
+    const parts = name.split(',').map(s => s.trim()).filter(Boolean);
+    if (parts.length >= 2) out.add(strip(`${parts[1]} ${parts[0]}`)); // "Aldo Manuzio"
+  }
+  return [...out].filter(s => s.length > 1).slice(0, 3);
+}
+async function wbSearch(name) {
+  const byQid = new Map();
+  for (const v of nameVariants(name)) {
+    const u = `https://www.wikidata.org/w/api.php?action=wbsearchentities&search=${encodeURIComponent(v)}&language=en&uselang=en&type=item&format=json&limit=7`;
+    const r = await fetch(u, { headers: { 'User-Agent': UA } });
+    if (!r.ok) throw new Error(`wbsearch ${r.status}`);
+    for (const s of ((await r.json()).search || [])) if (!byQid.has(s.id)) byQid.set(s.id, { qid: s.id, label: s.label, description: s.description || '' });
+    if (byQid.size >= 8) break;
+    await sleep(80);
+  }
+  return [...byQid.values()];
+}
+
+async function wbFacts(qid) {
+  const u = `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${qid}&props=claims|descriptions&languages=en&format=json`;
+  const r = await fetch(u, { headers: { 'User-Agent': UA } });
+  if (!r.ok) throw new Error(`wbget ${r.status}`);
+  const e = (await r.json()).entities?.[qid];
+  const claims = e?.claims || {};
+  const instanceOf = (claims.P31 || []).map(c => c.mainsnak?.datavalue?.value?.id);
+  const time = (p) => { const t = claims[p]?.[0]?.mainsnak?.datavalue?.value?.time; return t ? Number(String(t).replace(/^[+-]/, '').slice(0, 4)) : null; };
+  return {
+    isHuman: instanceOf.includes('Q5'),
+    viaf: claims.P214?.[0]?.mainsnak?.datavalue?.value || null,
+    birth: time('P569'),
+    death: time('P570'),
+    description: e?.descriptions?.en?.value || '',
+  };
+}
+
+const mc = new MongoClient(process.env.MONGODB_URI); await mc.connect();
+const db = mc.db('bookstore'); const authors = db.collection('authors'); const books = db.collection('books');
+const GEMINI_KEY = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
+if (!GEMINI_KEY) { console.error('GEMINI_API_KEY not set'); process.exit(1); }
+const model = new GoogleGenerativeAI(GEMINI_KEY).getGenerativeModel({ model: MODEL });
+
+console.log(`grounded author reconciliation — ${APPLY ? 'APPLY' : 'DRY-RUN'}${Number.isFinite(LIMIT) ? ` (limit ${LIMIT})` : ''}\n`);
+
+const targets = await authors.find(
+  { viaf_id: null, wikidata_id: null },
+  { projection: { canonical_name: 1, variants: 1, book_count: 1 } },
+).sort({ book_count: -1 }).toArray();
+const clean = targets.filter(t => !MALFORMED.test(t.canonical_name));
+const queue = clean.slice(0, Number.isFinite(LIMIT) ? LIMIT : clean.length);
+console.log(`unanchored authors: ${targets.length} | malformed skipped: ${targets.length - clean.length} | attempting: ${queue.length}\n`);
+
+let anchored = 0, nulled = 0, gated = 0, errored = 0;
+const decisions = [];
+for (const t of queue) {
+  try {
+    const bks = await books.find({ author: { $in: t.variants }, visible: { $ne: false } },
+      { projection: { _id: 0, title: 1, display_title: 1, year: 1, published: 1, language: 1 } }).limit(3).toArray();
+    const evidence = bks.map(b => `"${(b.display_title || b.title || '').slice(0, 80)}"${b.year || b.published ? ` (${b.year || b.published})` : ''}${b.language ? ` [${b.language}]` : ''}`).join('; ') || '(no book metadata)';
+    const cands = await wbSearch(t.canonical_name);
+    await sleep(120);
+    if (!cands.length) { nulled++; decisions.push(`  ∅ no-wikidata  "${t.canonical_name}"`); continue; }
+
+    const prompt = `Identify which Wikidata person (if any) wrote the book(s) attributed to this author. Choose ONLY from the candidates; if none is clearly the same person, return null. Use the book title/year/language as evidence — an author's dates must be consistent with their books. Do NOT pick a same-surname different person.
+
+AUTHOR (as recorded): ${JSON.stringify(t.canonical_name)}${t.variants.length > 1 ? `\nALSO RECORDED AS: ${t.variants.filter(v => v !== t.canonical_name).slice(0, 5).map(v => JSON.stringify(v)).join(', ')}` : ''}
+THEIR BOOK(S): ${evidence}
+
+CANDIDATES:
+${cands.map((c, i) => `${i + 1}. ${c.qid} — ${c.label}${c.description ? ` — ${c.description}` : ''}`).join('\n')}
+
+Return STRICT JSON: {"qid":"Q...."|null,"reason":"<≤12 words>"}`;
+    const res = await model.generateContent({ contents: [{ role: 'user', parts: [{ text: prompt }] }], generationConfig: { responseMimeType: 'application/json', temperature: 0 } });
+    const pick = JSON.parse(res.response.text());
+    const chosen = pick.qid && cands.find(c => c.qid === pick.qid);
+    if (!chosen) { nulled++; decisions.push(`  ∅ no-match     "${t.canonical_name}" — ${pick.reason || ''}`); continue; }
+
+    // life-date gate against the real entity. ONLY the lower bound is valid here:
+    // a book cannot predate its author's birth. The upper bound is meaningless —
+    // this library re-hosts posthumous reprints / incunabula (Sacrobosco d.1256
+    // printed 1480), so a late publication year is normal, not a mismatch.
+    const facts = await wbFacts(chosen.qid); await sleep(120);
+    const by = Math.min(...bks.map(b => yearOf(b.year ?? b.published)).filter(Boolean), Infinity);
+    if (facts.birth && Number.isFinite(by) && by < facts.birth - 5) {
+      gated++; decisions.push(`  ⚠ date-gate    "${t.canonical_name}" → ${chosen.label} (b${facts.birth}) vs book ${by} (predates birth)`); continue;
+    }
+    if (!facts.isHuman) { nulled++; decisions.push(`  ∅ not-human    "${t.canonical_name}" → ${chosen.label}`); continue; }
+
+    anchored++;
+    decisions.push(`  ✓ ${chosen.qid}${facts.viaf ? ' viaf' : '     '}  "${t.canonical_name}" → ${chosen.label} (${facts.birth ?? '?'}–${facts.death ?? '?'})`);
+    if (APPLY) await authors.updateOne({ _id: t._id }, { $set: { wikidata_id: chosen.qid, viaf_id: facts.viaf, anchored_by: 'grounded-reconciliation', wikidata_birth_year: facts.birth ?? null, wikidata_death_year: facts.death ?? null } });
+  } catch (e) { errored++; decisions.push(`  ! error        "${t.canonical_name}" — ${e.message}`); await sleep(400); }
+}
+
+console.log(decisions.join('\n'));
+console.log(`\nanchored ${anchored} | null ${nulled} | date-gated ${gated} | errors ${errored}  (of ${queue.length})`);
+
+// merge author docs that now share an authority id (only meaningful with --apply)
+if (APPLY && anchored) {
+  for (const field of ['wikidata_id', 'viaf_id']) {
+    const groups = await authors.aggregate([
+      { $match: { [field]: { $ne: null } } },
+      { $group: { _id: `$${field}`, ids: { $push: '$_id' }, n: { $sum: 1 } } },
+      { $match: { n: { $gt: 1 } } },
+    ]).toArray();
+    for (const g of groups) {
+      const docs = await authors.find({ _id: { $in: g.ids } }).sort({ book_count: -1 }).toArray();
+      const [keep, ...fold] = docs;
+      const merged = {
+        variants: [...new Set([...keep.variants, ...fold.flatMap(d => d.variants)])],
+        variant_slugs: [...new Set([...keep.variant_slugs, ...fold.flatMap(d => d.variant_slugs)])],
+        entity_ids: [...new Set([...keep.entity_ids, ...fold.flatMap(d => d.entity_ids)])],
+        book_count: docs.reduce((s, d) => s + d.book_count, 0),
+        merged_from: fold.map(d => d.canonical_name),
+      };
+      await authors.updateOne({ _id: keep._id }, { $set: merged });
+      await authors.deleteMany({ _id: { $in: fold.map(d => d._id) } });
+      console.log(`  merged on ${field}=${g._id}: ${fold.map(d => `"${d.canonical_name}"`).join(', ')} → "${keep.canonical_name}"`);
+    }
+  }
+  console.log(`\nauthors now: ${await authors.countDocuments()}`);
+}
+await mc.close();


### PR DESCRIPTION
## What — APPLIED to prod
First step of the #2179 author-layer rebuild: a clean `authors` collection scoped to **book authors only** — one document per person — separate from the ~305K-record `entities` collection (mostly mention-extraction debris). Built and **applied to prod**: 5,019 docs.

Purely additive and reversible. New `authors` collection only; no read path, no `books`/`entities` mutation. `db.authors.drop()` undoes it. Nothing reads it yet.

## Merging is DETERMINISTIC only
Shared name-key (Latin↔vernacular / name-order / date variants; non-Latin scripts keyed on the folded raw name) ∪ shared VIAF ∪ shared Wikidata. Famous people collapse to one doc this way (Paracelsus 12 variants→1, Bruno/Spinoza/Descartes→1, Li Shizhen clusters via the non-Latin fix). Holds back placeholders, institutions, and no-entity compound co-author strings.

I built and audited an LLM stray-merge pass and **removed it.** Audit finding: *both* blind approaches mis-resolve same-surname people — flash-lite merged "Boissiere"→"Duret"; the local entity_aliases authority merged "Hans Christian Andersen"→"Jürgen Andersen". A foundation must never mis-merge, so the obscure no-authority tail (~2K strings) stays as separate docs on purpose (under-merge is harmless; mis-merge is not).

## Result (prod)
5,019 authors · 568 VIAF · 1,351 Wikidata · 13,118 books covered. Indexes on `slug` (unique), `variant_slugs`, `viaf_id`, `book_count`. Each doc carries `variants`, `variant_slugs`, `entity_ids`, `book_count` provenance.

## Next (separate issue #2218)
Grounded reconciliation: anchor the obscure tail to one authority ID using each author's **own books** (title/year/language) as the disambiguator, with the LLM constrained to pick among real authority candidates — then merge on the ID and backfill VIAF/Wikidata. After that: stamp `author_id` on books and migrate read paths; retire `entities` from authorship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)