### PR TITLE
fix(uptime): stop flapping 'DOWN' alerts on embed_bhutan (raise SLO to 2500ms)

### DIFF
--- a/scripts/uptime-monitor.mjs
+++ b/scripts/uptime-monitor.mjs
@@ -46,7 +46,11 @@ const ENDPOINTS = [
     name: 'embed_bhutan',
     url: 'https://sourcelibrary-v2.vercel.app/embed/bhutan',
     twoShot: true,
-    latencySloMs: 1000,
+    // Bhutan embed SSR sits ~900ms warm and trips a 1000ms SLO on cold-adjacent
+    // hits (the warm shot can land on a different cold lambda instance under
+    // load-balancing), producing flapping "DOWN" alerts that aren't outages.
+    // 2500ms gives headroom while still catching a genuine stall.
+    latencySloMs: 2500,
     checkBody: true,
   },
 ];
@@ -191,6 +195,7 @@ async function checkTwoShot(endpoint) {
       latency_ms: warm_ms,  // primary latency = warm shot
       warm_ms,
       cold_ms,
+      latency_slo_ms: endpoint.latencySloMs ?? null,
       error: reason,
       reason,
       checked_at,
@@ -365,9 +370,16 @@ async function main() {
 
     // Send recovery notification if endpoint was down and is now back and fast
     for (const r of results.filter(r => r.ok)) {
-      // For two-shot embed endpoints, require warm_ms < RECOVERY_WARM_THRESHOLD_MS for recovery
-      if (r.warm_ms !== undefined && r.warm_ms >= RECOVERY_WARM_THRESHOLD_MS) {
-        continue; // still marginal — don't declare recovery yet
+      // For two-shot embed endpoints, recovery requires warm_ms to be comfortably
+      // under the endpoint's own SLO (80% of it), falling back to the global
+      // headroom threshold. A flat 800ms would never let a 2500ms-SLO endpoint recover.
+      if (r.warm_ms !== undefined) {
+        const recoveryCeiling = r.latency_slo_ms
+          ? Math.max(RECOVERY_WARM_THRESHOLD_MS, r.latency_slo_ms * 0.8)
+          : RECOVERY_WARM_THRESHOLD_MS;
+        if (r.warm_ms >= recoveryCeiling) {
+          continue; // still marginal — don't declare recovery yet
+        }
       }
 
       const lastFail = await checksCol.findOne(


### PR DESCRIPTION
## What

The `sourcelibrary-uptime` monitor fired a **Source Library DOWN** alert for `embed_bhutan` at 11:40 today with reason `slow: 1005ms > 1000ms`. The site was **not down** — every endpoint returns HTTP 200. This was a false alarm from a too-tight latency SLO.

## Why it flaps

The Bhutan embed home (`/embed/bhutan`) is a dynamic SSR page (`await searchParams`) that runs the full tenant loaders — two `browseTenantBooks` calls + language counts + a gallery aggregation + a contributing-libraries `$group` (Mongo + Supabase) — on every request. It sits ~900ms warm. There's a 5-min in-memory cache, but it's per-Vercel-function-instance, and Bhutan is low-traffic, so lambdas cycle out before the cache warms.

The monitor's two-shot probe measures the *warm* shot for the SLO, but under load-balancing the warm shot can land on a **different cold instance**, pushing it just over 1000ms. Result: intermittent `slow: 1005ms` alerts that aren't outages.

## Changes

- Bump `embed_bhutan` `latencySloMs` **1000 → 2500ms** — headroom over the ~900ms baseline, still catches a genuine stall.
- Make the **recovery threshold per-endpoint**: `max(global 800ms, 80% of the endpoint's SLO)`. The flat 800ms global would have left a 2500ms-SLO endpoint permanently unable to be declared 'recovered' (its warm baseline never dips under 800ms).
- Carry `latency_slo_ms` through the two-shot result so the recovery check can read it.

## Out of scope

- **Not repointing the probe at `bhutan.sourcelibrary.org`.** The monitor runs on Hetzner, whose IP gets a 403 from Cloudflare on the apex domain — that's why it deliberately probes `*.vercel.app`, which hits the identical SSR code path anyway.
- **Not optimizing the SSR itself.** ~900ms for a full Mongo+Supabase tenant render is acceptable for a low-traffic reading room; cross-instance caching (ISR) would be a larger change with tenant-lockdown implications. Left for a separate PR if it becomes a real UX problem.

Verified with `node scripts/uptime-monitor.mjs --probe-only`: all five endpoints OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)