### PR TITLE
fix(import): Met Egyptian importer tags papyri/ostraca/stelae as books

### DIFF
--- a/scripts/import/import-met-egyptian.mjs
+++ b/scripts/import/import-met-egyptian.mjs
@@ -33,6 +33,18 @@ const INSCRIBED_CLASSIFICATIONS = [
   'coffin', 'sarcophagus', 'scarab', 'amulet', 'temple',
 ];
 
+// Textual artifacts (papyri, ostraca, inscribed stelae, cuneiform tablets) carry readable
+// text and belong in the BOOK pipeline — like the Egyptian Book-of-the-Dead papyri.
+// Everything else this importer touches (statue, relief, coffin, scarab, amulet, …) is a
+// single-object ARTWORK. content_type is AUTHORITATIVE downstream — a 'book' is never
+// reclassified as artwork (see pipeline-orchestrator ARTWORK_MATCH).
+const TEXTUAL_TYPES = ['papyrus', 'ostracon', 'stela', 'cuneiform', 'tablet'];
+function classifyContentType(obj) {
+  const s = `${obj.objectName || ''} ${obj.classification || ''}`.toLowerCase();
+  const t = TEXTUAL_TYPES.find(x => s.includes(x));
+  return t ? { content_type: 'book', resource_type: t } : { content_type: 'artwork', resource_type: 'object' };
+}
+
 // ── Helpers ──
 function slugify(text) {
   return text.toLowerCase().replace(/[^\w\s-]/g, '').replace(/[\s_]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, 80);
@@ -217,9 +229,10 @@ async function main() {
 
     const language = mapLanguage(obj);
     const year = obj.objectBeginDate || null;
+    const { content_type: contentType, resource_type: resourceType } = classifyContentType(obj);
 
     if (DRY_RUN) {
-      console.log(`  [DRY] ${title} | ${obj.objectName || obj.classification} | ${language} | ${year || '?'} | ${images.length} images`);
+      console.log(`  [DRY] ${title} | ${obj.objectName || obj.classification} | ${contentType} | ${language} | ${year || '?'} | ${images.length} images`);
       imported++;
       if (checked % 50 === 0) logProgress();
       continue;
@@ -243,6 +256,8 @@ async function main() {
         published: year ? String(year) : 'Unknown',
         categories: [],
         collections: ['middle-east-africa', 'ancient-egyptian'],
+        content_type: contentType,
+        resource_type: resourceType,
         thumbnail: obj.primaryImageSmall || obj.primaryImage,
         pages_count: images.length,
         pages_ocr: 0,
@@ -268,13 +283,17 @@ async function main() {
         status: 'draft',
         hidden: false,
         visible: true,
-        pipeline_auto: {
-          status: 'archiving',
-          source: 'import',
-          queued_at: new Date(),
-          last_updated: new Date(),
-          retry_count: 0,
-        },
+        // Textual artifacts enter the book pipeline (OCR the inscription); single-object
+        // artworks terminalize immediately (no text to OCR/translate).
+        pipeline_auto: contentType === 'artwork'
+          ? { status: 'complete', skipped: 'artwork', source: 'import', last_updated: new Date() }
+          : {
+              status: 'archiving',
+              source: 'import',
+              queued_at: new Date(),
+              last_updated: new Date(),
+              retry_count: 0,
+            },
         source_fingerprint: `met:${objectID}`,
         normalized_title: normalizedT,
         normalized_author: normalizeAuthor(author),


### PR DESCRIPTION
Closes the "going forward" half of the papyri-as-books work. `import-met-egyptian.mjs` imports inscribed Egyptian objects (papyrus, ostracon, stela, relief, statue, coffin, scarab, …) but set **no `content_type`**, so a downstream classifier later tagged the textual papyri as `content_type:'artwork'` — which pulled Book-of-the-Dead papyri out of the book pipeline (the root of the artwork/book confusion this session).

## Fix
Classify at import time:
- **Textual** (papyrus / ostracon / stela / cuneiform / tablet) → `content_type:'book'` + enrolled for OCR.
- **Everything else** (statue, relief, coffin, scarab, amulet, …) → `content_type:'artwork'` + terminal (`complete`, `skipped:'artwork'`).

`content_type` is authoritative downstream (PR #2201), so book-tagged papyri can't be re-swept to artwork.

## Scope
- The 42 PGM/literary papyrus stubs are **not** from any importer (no provider — manually/script-created), so nothing to fix there.
- Other artwork importers (Commons/Rijksmuseum) rarely touch papyri/cuneiform; if they ever do, the same `TEXTUAL_TYPES` helper pattern applies. Left out of scope to keep this focused.

`node --check` passes. Manual on-demand import script; behavior change only for textual-vs-sculptural tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)