### PR TITLE
refactor(entities): static render + offline Wikidata enrichment

### DIFF
--- a/scripts/maintenance/backfill-wikidata-portraits-dates.mjs
+++ b/scripts/maintenance/backfill-wikidata-portraits-dates.mjs
@@ -81,7 +81,9 @@ for await (const ent of cursor) {
     const claims = data?.entities?.[ent.wikidata_id]?.claims;
     if (!claims) continue;
 
-    const set = {};
+    // Always stamp the checked marker (negative cache) — mirrors
+    // src/lib/wikidata-enrichment.ts so the cron treats these as done.
+    const set = { wikidata_enriched_at: new Date() };
 
     const portraitBad = !ent.portrait_url || ent.portrait_url.includes('commons.wikimedia.org');
     if (portraitBad) {
@@ -97,7 +99,7 @@ for await (const ent of cursor) {
     if (birth && birth !== ent.wikidata_birth_date) { set.wikidata_birth_date = birth; datesFixed++; }
     if (death && death !== ent.wikidata_death_date) set.wikidata_death_date = death;
 
-    if (Object.keys(set).length > 0 && !DRY) {
+    if (!DRY) {
       await entities.updateOne({ _id: ent._id }, { $set: set });
     }
     if (processed % 100 === 0) {

--- a/src/app/api/cron/enrich-entities/route.ts
+++ b/src/app/api/cron/enrich-entities/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { enrichEntity, type EnrichableEntity } from '@/lib/wikidata-enrichment';
+
+export const maxDuration = 300;
+export const preferredRegion = 'fra1';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/cron/enrich-entities
+ *
+ * Offline Wikidata enrichment for person `entities` — keeps `portrait_url`,
+ * `wikidata_birth_date`, and `wikidata_death_date` populated so author /
+ * artist / encyclopedia pages stay a pure static read (they never call
+ * Wikidata at render time).
+ *
+ * Each run processes a bounded batch (fits in maxDuration), preferring:
+ *   1. never-enriched entities (no `wikidata_enriched_at`)
+ *   2. then the stalest (refreshes the ~thousands with no P18/P569/P570 yet,
+ *      in case Wikidata has since gained the data)
+ *
+ * Steady state is cheap — new entities arrive a few per day (and are also
+ * enriched inline when an author is linked). The staleness sweep is what
+ * slowly re-checks the long tail. Scheduled daily via vercel.json crons.
+ */
+
+const BATCH = 150;
+const STALE_DAYS = 90;
+const POLITE_DELAY_MS = 150;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function GET() {
+  const db = await getDb();
+  const staleCutoff = new Date(Date.now() - STALE_DAYS * 24 * 60 * 60 * 1000);
+
+  const batch = (await db
+    .collection('entities')
+    .find(
+      {
+        type: 'person',
+        wikidata_id: { $exists: true, $ne: null },
+        $or: [
+          { wikidata_enriched_at: { $exists: false } },
+          { wikidata_enriched_at: { $lt: staleCutoff } },
+        ],
+      },
+      {
+        projection: {
+          wikidata_id: 1,
+          portrait_url: 1,
+          wikidata_birth_date: 1,
+          wikidata_death_date: 1,
+          wikidata_enriched_at: 1,
+        },
+      },
+    )
+    // Missing field sorts first in ascending order → never-enriched go first.
+    .sort({ wikidata_enriched_at: 1 })
+    .limit(BATCH)
+    .toArray()) as unknown as EnrichableEntity[];
+
+  let checked = 0;
+  let portraitsFixed = 0;
+  let datesFixed = 0;
+  let failed = 0;
+
+  for (const entity of batch) {
+    const result = await enrichEntity(db, entity);
+    if (result.checked) {
+      checked++;
+      if (result.updated.includes('portrait_url')) portraitsFixed++;
+      if (result.updated.includes('wikidata_birth_date')) datesFixed++;
+    } else {
+      failed++;
+    }
+    await sleep(POLITE_DELAY_MS);
+  }
+
+  return NextResponse.json({
+    scanned: batch.length,
+    checked,
+    portraitsFixed,
+    datesFixed,
+    failed,
+    note: batch.length < BATCH ? 'queue drained' : 'more remaining; next run continues',
+  });
+}

--- a/src/app/artist/[name]/page.tsx
+++ b/src/app/artist/[name]/page.tsx
@@ -8,7 +8,6 @@ import { bookUrl, authorSlug, authorUrl } from '@/lib/slugify';
 import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
 import { ObjectId, type Db } from 'mongodb';
 import { getBookThumbnailUrl } from '@/lib/utils';
-import { enrichEntityFromWikidata } from '@/lib/wikidata-enrichment';
 
 export const revalidate = 86400;
 export const dynamicParams = true;
@@ -191,15 +190,13 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
       : `${Math.min(...years)}–${Math.max(...years)}`
     : null;
 
-  // Portrait + life dates from Wikidata (lazily resolved & cached on the
-  // entity). Portrait resolves to a CSP-safe upload.wikimedia.org URL.
-  const enrichment = await enrichEntityFromWikidata(db, entity);
-
-  const birthYear = (enrichment.birthDate || entity?.wikidata_birth_date)?.split('-')[0];
-  const deathYear = (enrichment.deathDate || entity?.wikidata_death_date)?.split('-')[0];
+  // Life dates + portrait are a static read of the entity. Enrichment from
+  // Wikidata happens OFFLINE (cron + link hook) — never on render.
+  const birthYear = entity?.wikidata_birth_date?.split('-')[0];
+  const deathYear = entity?.wikidata_death_date?.split('-')[0];
   const lifeDates = birthYear ? `${birthYear}–${deathYear || '?'}` : null;
 
-  const portraitUrl = enrichment.portraitUrl;
+  const portraitUrl = entity?.portrait_url ?? null;
 
   const wikipediaUrl = entity?.wikipedia_url
     || (entity?.wikidata_id ? `https://www.wikidata.org/wiki/Special:GoToLinkedPage/enwiki/${entity.wikidata_id}` : null);

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -10,7 +10,6 @@ import AuthorBibliography from '@/components/browse/AuthorBibliography';
 import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
 import { ObjectId } from 'mongodb';
 import { getBookThumbnailUrl } from '@/lib/utils';
-import { enrichEntityFromWikidata } from '@/lib/wikidata-enrichment';
 import AuthorSchema from '@/components/seo/AuthorSchema';
 
 // ISR: 24h background revalidation (survives deploys better than revalidate=false)
@@ -264,14 +263,11 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
       : `${Math.min(...years)}–${Math.max(...years)}`
     : null;
 
-  // Portrait + life dates from Wikidata (lazily resolved & cached on the
-  // entity). Portrait resolves to a CSP-safe upload.wikimedia.org URL; dates
-  // backfill entities that carry a wikidata_id but were never date-enriched.
-  const enrichment = await enrichEntityFromWikidata(db, entity);
-
-  // Life dates — prefer freshly resolved, fall back to whatever was cached.
-  const birthYear = (enrichment.birthDate || entity?.wikidata_birth_date)?.split('-')[0];
-  const deathYear = (enrichment.deathDate || entity?.wikidata_death_date)?.split('-')[0];
+  // Life dates + portrait are a static read of the entity. Enrichment from
+  // Wikidata happens OFFLINE (cron + link hook, see wikidata-enrichment.ts) —
+  // never on render, since these are immutable facts.
+  const birthYear = entity?.wikidata_birth_date?.split('-')[0];
+  const deathYear = entity?.wikidata_death_date?.split('-')[0];
   const lifeDates = birthYear ? `${birthYear}–${deathYear || '?'}` : null;
 
   // Encyclopedia entry: use entity directly if we have one, otherwise regex fallback
@@ -283,8 +279,8 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     { projection: { name: 1 } }
   );
 
-  // Portrait image from Wikidata (resolved above)
-  const portraitUrl = enrichment.portraitUrl;
+  // Portrait image — static read (enriched offline; CSP-safe CDN URL).
+  const portraitUrl = entity?.portrait_url ?? null;
 
   // Derive Wikipedia URL from entity
   const wikipediaUrl = entity?.wikipedia_url
@@ -320,8 +316,8 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         authorSlug={name}
         description={entity?.description}
         aliases={entity?.aliases}
-        birthDate={enrichment.birthDate || entity?.wikidata_birth_date}
-        deathDate={enrichment.deathDate || entity?.wikidata_death_date}
+        birthDate={entity?.wikidata_birth_date}
+        deathDate={entity?.wikidata_death_date}
         wikipediaUrl={wikipediaUrl}
         wikidataId={entity?.wikidata_id}
         viafId={entity?.viaf_id}

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -3,7 +3,6 @@ import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import EntitySchema from '@/components/seo/EntitySchema';
-import { enrichEntityFromWikidata } from '@/lib/wikidata-enrichment';
 
 // ISR: 24h background revalidation
 export const revalidate = 86400;
@@ -89,17 +88,10 @@ export const getEntity = cache(async (name: string) => {
     );
     if (!entity) return null;
 
-    // Backfill life dates from Wikidata for people that carry a wikidata_id
-    // but were never date-enriched (same gap that left author pages blank).
-    // Gated to persons — places/concepts have no birth/death, so enriching
-    // them would re-fetch every render (the missing date never caches).
-    let birthDate = entity.wikidata_birth_date as string | undefined;
-    let deathDate = entity.wikidata_death_date as string | undefined;
-    if (entity.type === 'person' && (!birthDate || !deathDate)) {
-      const enrichment = await enrichEntityFromWikidata(db, entity as Parameters<typeof enrichEntityFromWikidata>[1]);
-      birthDate = birthDate || enrichment.birthDate || undefined;
-      deathDate = deathDate || enrichment.deathDate || undefined;
-    }
+    // Life dates are a static read. Wikidata enrichment happens OFFLINE
+    // (cron + link hook, see src/lib/wikidata-enrichment.ts) — never on render.
+    const birthDate = entity.wikidata_birth_date as string | undefined;
+    const deathDate = entity.wikidata_death_date as string | undefined;
 
     // Fetch related entities (same books)
     const bookIds = entity.books?.map((b: { book_id: string }) => b.book_id) || [];

--- a/src/lib/author-authority.ts
+++ b/src/lib/author-authority.ts
@@ -29,6 +29,7 @@
  */
 
 import { getDb } from '@/lib/mongodb';
+import { enrichEntity } from '@/lib/wikidata-enrichment';
 
 export interface AuthorAuthorityMatch {
   /** VIAF cluster id (numeric string), e.g. "22156484". */
@@ -198,6 +199,18 @@ export async function linkAuthorToEntity(
     if (!existingDoc?.wikidata_death_date && match.death_year) updateFields.wikidata_death_date = String(match.death_year);
     if (!existingDoc?.aliases?.length && match.alternate_names?.length) updateFields.aliases = match.alternate_names;
     await col.updateOne({ _id: existing._id }, { $set: updateFields });
+    // Enrich portrait + precise life dates from Wikidata now, so the entity's
+    // pages are a static read (see wikidata-enrichment.ts). Best-effort.
+    const wikidataId = (existingDoc?.wikidata_id as string) || match.wikidata_qid || undefined;
+    if (wikidataId) {
+      await enrichEntity(db, {
+        _id: existing._id,
+        wikidata_id: wikidataId,
+        portrait_url: existingDoc?.portrait_url as string | undefined,
+        wikidata_birth_date: (existingDoc?.wikidata_birth_date as string | undefined) ?? (updateFields.wikidata_birth_date as string | undefined),
+        wikidata_death_date: (existingDoc?.wikidata_death_date as string | undefined) ?? (updateFields.wikidata_death_date as string | undefined),
+      }).catch(() => {});
+    }
     return { entity_id: String(existing._id) };
   }
 
@@ -220,6 +233,15 @@ export async function linkAuthorToEntity(
   };
   Object.keys(doc).forEach((k) => doc[k] === undefined && delete doc[k]);
   const inserted = await col.insertOne(doc);
+  // Enrich portrait + precise life dates from Wikidata now (best-effort).
+  if (match.wikidata_qid) {
+    await enrichEntity(db, {
+      _id: inserted.insertedId,
+      wikidata_id: match.wikidata_qid,
+      wikidata_birth_date: doc.wikidata_birth_date as string | undefined,
+      wikidata_death_date: doc.wikidata_death_date as string | undefined,
+    }).catch(() => {});
+  }
   return { entity_id: String(inserted.insertedId) };
 }
 

--- a/src/lib/wikidata-enrichment.ts
+++ b/src/lib/wikidata-enrichment.ts
@@ -1,26 +1,34 @@
 /**
- * Lazy Wikidata enrichment for author/artist `entities`.
+ * Offline Wikidata enrichment for author/artist/person `entities`.
  *
  * Given an entity that carries a `wikidata_id`, this resolves three display
- * fields and caches them back on the entity so subsequent renders are free:
+ * fields and writes them onto the entity so the render path is a pure static
+ * read (it never calls Wikidata itself):
  *   - `portrait_url`        — P18 image, resolved to a CSP-safe CDN URL
  *   - `wikidata_birth_date` — P569
  *   - `wikidata_death_date` — P570
+ *   - `wikidata_enriched_at`— marker so we don't re-check on every run
  *
- * Two non-obvious constraints drove the implementation:
+ * This runs OFFLINE only — from the `/api/cron/enrich-entities` cron, the
+ * `backfill-wikidata-portraits-dates.mjs` script, and once when an author is
+ * linked (`linkAuthorToEntity`). It must NOT be called from a page render:
+ * birth/death/portrait are effectively immutable facts, so they belong in the
+ * DB, not pulled per view. See PR #2187 (the bug that started this) and the
+ * follow-up that made render static.
+ *
+ * Two non-obvious constraints:
  *
  * 1. **CSP.** The site's `img-src` whitelists `upload.wikimedia.org` (the
- *    Wikimedia CDN) but NOT `commons.wikimedia.org`. The old code cached
- *    `commons.wikimedia.org/w/thumb.php?...` URLs, which load fine via curl
- *    but are blocked by the browser — every portrait silently broke. We must
- *    resolve P18 to an `upload.wikimedia.org` URL. The Commons `imageinfo`
- *    API does this (and snaps to a renderable thumbnail bucket — hand-built
- *    `/thumb/.../800px-` URLs 400 unless that exact width was pre-rendered).
+ *    Wikimedia CDN) but NOT `commons.wikimedia.org`. A `commons.wikimedia.org`
+ *    portrait URL loads fine via curl but is blocked by the browser. We resolve
+ *    P18 to an `upload.wikimedia.org` URL via the Commons `imageinfo` API
+ *    (hand-built `/thumb/.../800px-` URLs 400 unless that width was
+ *    pre-rendered, so let the API hand us a renderable thumburl).
  *
- * 2. **Lazy backfill.** ~6.7k entities have a `wikidata_id` but no dates, and
- *    ~1k have a stale `commons.*` portrait. Rather than gate everything on a
- *    batch job, we re-resolve on first render when a field is missing or the
- *    cached portrait points at the blocked domain, then persist.
+ * 2. **Negative caching.** Many people legitimately have no P18/P569/P570 in
+ *    Wikidata. We still stamp `wikidata_enriched_at` so the cron treats them as
+ *    "checked, nothing there" and stops re-fetching — a staleness window
+ *    (cron-side) re-checks them later in case Wikidata gains the data.
  */
 
 import type { Db, ObjectId } from 'mongodb';
@@ -33,16 +41,14 @@ export interface EnrichableEntity {
   wikidata_death_date?: string;
 }
 
-export interface WikidataEnrichment {
-  portraitUrl: string | null;
-  birthDate: string | null;
-  deathDate: string | null;
+export interface EnrichResult {
+  /** Fields newly written this run (excludes the always-written marker). */
+  updated: Array<'portrait_url' | 'wikidata_birth_date' | 'wikidata_death_date'>;
+  /** False when the entity had no wikidata_id or the Wikidata fetch failed. */
+  checked: boolean;
 }
 
-/** 24h revalidate — Wikidata/Commons facts for historical figures rarely move. */
-const REVALIDATE = 60 * 60 * 24;
-
-/** A cached portrait on the blocked Commons domain must be re-resolved. */
+/** A portrait on the CSP-blocked Commons domain is treated as not-yet-resolved. */
 function isCspSafePortrait(url: string | undefined): url is string {
   return !!url && url.includes('upload.wikimedia.org');
 }
@@ -65,7 +71,7 @@ async function resolveCommonsPortrait(filename: string): Promise<string | null> 
     `&titles=${encodeURIComponent(`File:${filename}`)}` +
     `&prop=imageinfo&iiprop=url&iiurlwidth=300`;
   try {
-    const res = await fetch(url, { next: { revalidate: REVALIDATE } });
+    const res = await fetch(url, { cache: 'no-store' });
     if (!res.ok) return null;
     const data = await res.json();
     const pages = data?.query?.pages;
@@ -80,65 +86,56 @@ async function resolveCommonsPortrait(filename: string): Promise<string | null> 
 }
 
 /**
- * Return portrait + life dates for an entity, resolving anything missing from
- * Wikidata and caching it back on the entity (fire-and-forget). Safe to call
- * on every render — it only hits the network when a field is absent or the
- * cached portrait points at the CSP-blocked domain.
+ * Fetch P18/P569/P570 from Wikidata and write any missing fields onto the
+ * entity, then stamp `wikidata_enriched_at`. Only fills gaps — never
+ * overwrites an existing value. Returns what changed.
+ *
+ * OFFLINE ONLY (cron / script / link hook). Do not call from a render path.
  */
-export async function enrichEntityFromWikidata(
+export async function enrichEntity(
   db: Db,
-  entity: EnrichableEntity | null,
-): Promise<WikidataEnrichment> {
-  if (!entity) return { portraitUrl: null, birthDate: null, deathDate: null };
+  entity: EnrichableEntity,
+): Promise<EnrichResult> {
+  const set: Record<string, string | Date> = {};
 
-  const cachedPortrait = isCspSafePortrait(entity.portrait_url) ? entity.portrait_url : null;
-  const cachedBirth = entity.wikidata_birth_date ?? null;
-  const cachedDeath = entity.wikidata_death_date ?? null;
+  if (entity.wikidata_id) {
+    try {
+      const res = await fetch(
+        `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${entity.wikidata_id}&props=claims&format=json`,
+        { cache: 'no-store' },
+      );
+      if (res.ok) {
+        const data = await res.json();
+        const claims = data?.entities?.[entity.wikidata_id]?.claims;
 
-  const needsPortrait = !cachedPortrait;
-  const needsBirth = !cachedBirth;
-  const needsDeath = !cachedDeath;
+        if (!isCspSafePortrait(entity.portrait_url)) {
+          const filename = claims?.P18?.[0]?.mainsnak?.datavalue?.value as string | undefined;
+          if (filename) {
+            const portraitUrl = await resolveCommonsPortrait(filename);
+            if (portraitUrl) set.portrait_url = portraitUrl;
+          }
+        }
+        if (!entity.wikidata_birth_date) {
+          const b = normaliseWikidataTime(claims?.P569?.[0]?.mainsnak?.datavalue?.value?.time);
+          if (b) set.wikidata_birth_date = b;
+        }
+        if (!entity.wikidata_death_date) {
+          const d = normaliseWikidataTime(claims?.P570?.[0]?.mainsnak?.datavalue?.value?.time);
+          if (d) set.wikidata_death_date = d;
+        }
 
-  // Nothing to do, or nothing we *can* do.
-  if ((!needsPortrait && !needsBirth && !needsDeath) || !entity.wikidata_id) {
-    return { portraitUrl: cachedPortrait, birthDate: cachedBirth, deathDate: cachedDeath };
+        // Mark as checked (negative cache) regardless of what we found.
+        set.wikidata_enriched_at = new Date();
+        await db.collection('entities').updateOne({ _id: entity._id }, { $set: set });
+        return {
+          updated: Object.keys(set).filter((k) => k !== 'wikidata_enriched_at') as EnrichResult['updated'],
+          checked: true,
+        };
+      }
+    } catch {
+      // fall through to checked:false (no marker — let the cron retry it)
+    }
   }
 
-  try {
-    const res = await fetch(
-      `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${entity.wikidata_id}&props=claims&format=json`,
-      { next: { revalidate: REVALIDATE } },
-    );
-    if (!res.ok) {
-      return { portraitUrl: cachedPortrait, birthDate: cachedBirth, deathDate: cachedDeath };
-    }
-    const data = await res.json();
-    const claims = data?.entities?.[entity.wikidata_id]?.claims;
-
-    let portraitUrl = cachedPortrait;
-    if (needsPortrait) {
-      const filename = claims?.P18?.[0]?.mainsnak?.datavalue?.value as string | undefined;
-      if (filename) portraitUrl = await resolveCommonsPortrait(filename);
-    }
-
-    const birthDate = needsBirth
-      ? normaliseWikidataTime(claims?.P569?.[0]?.mainsnak?.datavalue?.value?.time)
-      : cachedBirth;
-    const deathDate = needsDeath
-      ? normaliseWikidataTime(claims?.P570?.[0]?.mainsnak?.datavalue?.value?.time)
-      : cachedDeath;
-
-    // Persist whatever we newly resolved (don't overwrite with null).
-    const set: Record<string, string> = {};
-    if (portraitUrl && portraitUrl !== entity.portrait_url) set.portrait_url = portraitUrl;
-    if (birthDate && birthDate !== entity.wikidata_birth_date) set.wikidata_birth_date = birthDate;
-    if (deathDate && deathDate !== entity.wikidata_death_date) set.wikidata_death_date = deathDate;
-    if (Object.keys(set).length > 0) {
-      db.collection('entities').updateOne({ _id: entity._id }, { $set: set }).catch(() => {});
-    }
-
-    return { portraitUrl, birthDate, deathDate };
-  } catch {
-    return { portraitUrl: cachedPortrait, birthDate: cachedBirth, deathDate: cachedDeath };
-  }
+  return { updated: [], checked: false };
 }

--- a/tests/unit/static-entity-render.test.ts
+++ b/tests/unit/static-entity-render.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * Render paths for author / artist / encyclopedia entity pages must be a pure
+ * static read of the cached `entities` fields. Wikidata enrichment is OFFLINE
+ * only (cron + link hook, see src/lib/wikidata-enrichment.ts) — birth/death/
+ * portrait are immutable facts and must not be pulled per page view.
+ *
+ * This guards the decision behind the PR #2187 follow-up: no enrichment import
+ * may creep back into a render path.
+ */
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+
+const RENDER_FILES = [
+  'src/app/author/[name]/page.tsx',
+  'src/app/artist/[name]/page.tsx',
+  'src/app/encyclopedia/[name]/layout.tsx',
+  'src/app/encyclopedia/[name]/page.tsx',
+];
+
+describe('entity render paths are static (no Wikidata at render time)', () => {
+  it.each(RENDER_FILES)('%s does not import wikidata-enrichment', (rel) => {
+    const src = readFileSync(path.join(PROJECT_ROOT, rel), 'utf8');
+    expect(
+      src,
+      `${rel} must not import wikidata-enrichment — entity life dates/portrait ` +
+        `are a static DB read; enrich offline via the cron or link hook instead.`,
+    ).not.toMatch(/from\s+['"]@\/lib\/wikidata-enrichment['"]/);
+  });
+
+  it('the enrichment helper is reached only from offline callers', () => {
+    const helper = '@/lib/wikidata-enrichment';
+    const offline = [
+      'src/app/api/cron/enrich-entities/route.ts',
+      'src/lib/author-authority.ts',
+    ];
+    for (const rel of offline) {
+      const src = readFileSync(path.join(PROJECT_ROOT, rel), 'utf8');
+      expect(src, `${rel} should import ${helper}`).toMatch(
+        /from\s+['"]@\/lib\/wikidata-enrichment['"]/,
+      );
+    }
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
     {
       "path": "/api/cron/sync-catalog-sl-book-ids",
       "schedule": "30 */6 * * *"
+    },
+    {
+      "path": "/api/cron/enrich-entities",
+      "schedule": "15 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Why

Follow-up to #2187. That PR self-healed entity portraits/dates **on render**. The flaw: it had no negative cache, so any person Wikidata lacks a P18/P569/P570 for was re-fetched on every render (bounded only by Next's 24h fetch cache). Birth/death/portrait are immutable facts — they should be stored once and read statically, never pulled per view.

## What changed

**Render is now a pure static read** (no Wikidata at render time):
- `author/[name]`, `artist/[name]`, `encyclopedia/[name]` read `entity.portrait_url` / `wikidata_birth_date` / `wikidata_death_date` directly.
- New `tests/unit/static-entity-render.test.ts` fails if an enrichment import creeps back into a render path.

**Enrichment moved fully offline:**
- `src/lib/wikidata-enrichment.ts` — render-time `enrichEntityFromWikidata()` replaced by offline `enrichEntity(db, entity)` that writes portrait + dates and **always stamps `wikidata_enriched_at`** (negative cache → "checked, nothing there" is recorded, not re-fetched).
- `GET /api/cron/enrich-entities` — daily Vercel cron, bounded batch (150) of never-enriched/stalest person entities; a 90-day staleness sweep slowly re-checks the long tail (the ~2,300 with no Wikidata date yet) in case Wikidata gains the data.
- `linkAuthorToEntity` enriches a newly-linked author inline (best-effort), so new entities are populated immediately rather than waiting for the cron.
- Backfill script stamps the marker too, for consistent manual re-runs.

## Post-deploy step (manual, by me)

A one-time stamp of `wikidata_enriched_at` on the ~7,485 already-enriched entities, so the cron's "never enriched" queue starts empty and only handles new + stale. (Without it the cron would needlessly re-fetch the whole corpus.)

## Verification

- `vitest`: static-render guard + CSP guard + utils all pass (71 assertions).
- tsc: clean for all changed files (the only local tsc errors are a pre-existing `@types/d3` install gap in `blog/carbon-ledger/*`, unrelated; CI has the dep).
- Behavior unchanged for users — pages still show the same dates/portraits, just from a static read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)