### PR TITLE
fix(press): full-corpus scale (originals + translation + summaries)

### DIFF
--- a/src/components/press/releases/SourceLibraryPublicBetaLaunch.tsx
+++ b/src/components/press/releases/SourceLibraryPublicBetaLaunch.tsx
@@ -194,21 +194,23 @@ export default function SourceLibraryPublicBetaLaunch() {
 
         {/* Wikipedia-scale callout */}
         <div className="bg-accent-gold/5 rounded-lg border border-accent-gold/20 p-6 md:p-8 mb-8">
-          <h3 className="font-serif text-lg text-primary mb-3">About a third of Wikipedia &mdash; in primary sources</h3>
+          <h3 className="font-serif text-lg text-primary mb-3">On the scale of all of Wikipedia &mdash; in primary sources</h3>
           <p className="text-secondary leading-relaxed font-body mb-3">
             The English Wikipedia, the largest reference work ever created, holds about{' '}
             <strong className="text-stone-800">5 billion words</strong> across 7.2 million articles.
-            Source Library&rsquo;s 4.07 million translated pages amount to roughly{' '}
-            <strong className="text-stone-800">1.7 billion words</strong> &mdash; about{' '}
-            <strong className="text-stone-800">a third the size of the entire English Wikipedia</strong>{' '}
-            &mdash; drawn not from modern summaries but from the original record of human thought across
-            five centuries and more than 170 languages. Counting the original-language texts shown
-            alongside each translation, the corpus is larger still.
+            Source Library&rsquo;s English translations alone come to roughly{' '}
+            <strong className="text-stone-800">1.7 billion words</strong> &mdash; about a third that size.
+            Counting the original-language transcriptions shown beside every translation, plus the
+            AI-generated summaries and indexes, the full corpus runs to roughly{' '}
+            <strong className="text-stone-800">3.5 billion words &mdash; around 5 billion tokens</strong>,
+            approaching the size of the entire English Wikipedia. But where Wikipedia is modern summary,
+            this is the original record of human thought across five centuries and more than 170 languages.
           </p>
           <p className="text-xs text-muted font-body">
-            Word count estimated from a 7,500-page random sample of the translation corpus
-            (mean 415 words per page) across 4,071,861 translated pages; English Wikipedia figures
-            per Wikipedia&rsquo;s own statistics, May 2026.
+            Word counts estimated from random samples of the 6.5-million-page corpus (4 million+ pages
+            translated), using median and trimmed-mean page lengths to exclude OCR artifacts; original
+            transcriptions in non-spaced scripts (e.g. Chinese, Tibetan) are undercounted, so the true
+            total is higher. English Wikipedia figures per Wikipedia&rsquo;s own statistics, May 2026.
           </p>
         </div>
 


### PR DESCRIPTION
Follow-up to #2196. Per Derek: count the **whole** corpus, not just translations.

**Measured (robust):**
- English translation: ~1.7B words (~2.2B tokens)
- Original-language transcriptions (OCR): ~1.5–2B words
- Summaries/indexes: ~0.2B
- **Full corpus ≈ 3.5B words / ~5B tokens** — approaching all of English Wikipedia (~5B words)

The raw arithmetic mean was inflated ~5× by AI recitation-loop hallucinations (one page = 65,518 words; p99 = 52,422). Used median/trimmed-mean estimators to exclude those artifacts. CJK/Tibetan transcriptions are whitespace-undercounted, so the true total is higher.

Updates the callout heading + copy and the methodology footnote. Release still **draft**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)