### PR TITLE
feat(librarian): surface image failures instead of swallowing them

### DIFF
--- a/src/app/librarian/_components/MessageBody.tsx
+++ b/src/app/librarian/_components/MessageBody.tsx
@@ -1,8 +1,42 @@
 'use client';
 
+import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ensureParagraphBreaks, linkifySourceUrls } from '@/lib/markdown-prep';
+
+// Image that degrades to a labelled placeholder instead of vanishing when the
+// source 404s — so the reader knows a figure was meant to appear here (and can
+// still follow the link), rather than silently losing it.
+function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
+  const [broken, setBroken] = useState(false);
+  if (!src) return null;
+  if (broken) {
+    return (
+      <a
+        href={src}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="my-5 flex items-center gap-2 rounded-lg border border-dashed border-[#d8cfbe] bg-[#faf7f1] px-3 py-2 text-[13px] text-[#8a8276] no-underline"
+      >
+        <span aria-hidden>🖼️</span>
+        <span>{alt ? `Image unavailable: ${alt}` : 'Image unavailable'}</span>
+      </a>
+    );
+  }
+  return (
+    <a href={src} target="_blank" rel="noopener noreferrer">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={src}
+        alt={alt || ''}
+        className="rounded-lg shadow-md max-h-[400px] w-auto cursor-pointer hover:shadow-lg transition-shadow my-5"
+        loading="lazy"
+        onError={() => setBroken(true)}
+      />
+    </a>
+  );
+}
 
 // ── Shared Librarian message body ─────────────────────────────────────
 // Single source of truth for assistant-message typography across:
@@ -88,21 +122,7 @@ export default function LibrarianMessageBody({ content, variant = 'thread' }: Li
               <td className="border-b border-[#e8e4dc] px-3 py-2 align-top">{children}</td>
             ),
             img: ({ src, alt }) => (
-              <a href={src as string} target="_blank" rel="noopener noreferrer">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={src as string}
-                  alt={(alt as string) || ''}
-                  className="rounded-lg shadow-md max-h-[400px] w-auto cursor-pointer hover:shadow-lg transition-shadow my-5"
-                  loading="lazy"
-                  onError={(e) => {
-                    const img = e.currentTarget as HTMLImageElement;
-                    const wrapper = img.closest('a') as HTMLAnchorElement | null;
-                    if (wrapper) wrapper.style.display = 'none';
-                    else img.style.display = 'none';
-                  }}
-                />
-              </a>
+              <MarkdownImage src={src as string} alt={alt as string} />
             ),
           }}
         >{ensureParagraphBreaks(linkifySourceUrls(content))}</ReactMarkdown>

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -345,15 +345,19 @@ async function executeReadNearbyPages(bookId: string, centerPage: number, range 
   };
 }
 
-async function executeSearchImages(query: string, bookId?: string): Promise<
-  Array<{ id: string; imageUrl: string; description: string; bookTitle: string; bookAuthor: string; bookSlug?: string; pageNumber: number; type?: string }>
-> {
+async function executeSearchImages(query: string, bookId?: string): Promise<{
+  images: Array<{ id: string; imageUrl: string; description: string; bookTitle: string; bookAuthor: string; bookSlug?: string; pageNumber: number; type?: string }>;
+  clipUnavailable: boolean;
+}> {
   // Use CLIP visual search via the gallery API for text-to-image matching
   const db = await getDb();
   const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
 
-  // Try CLIP text-to-image search first
+  // Try CLIP text-to-image search first. Distinguish "CLIP searched and found
+  // nothing" (reachable, fall back to keyword search) from "CLIP is down"
+  // (unreachable — we must NOT let the model imply no illustrations exist).
   let clipIds = new Map<string, number>();
+  let clipUnavailable = false;
   try {
     const resp = await fetch(`${CLIP_URL}/embed-text`, {
       method: 'POST',
@@ -376,9 +380,18 @@ async function executeSearchImages(query: string, bookId?: string): Promise<
             }
           }
         }
+      } else {
+        clipUnavailable = true; // responded without an embedding
       }
+    } else {
+      clipUnavailable = true; // non-2xx from the CLIP service
     }
-  } catch { /* CLIP unavailable — fall back to text search */ }
+  } catch {
+    clipUnavailable = true; // network error / timeout — CLIP is down
+  }
+  if (clipUnavailable) {
+    console.warn(`[Librarian] CLIP visual search unavailable (${CLIP_URL}); falling back to keyword image search`);
+  }
 
   // Fetch gallery_images by CLIP IDs or text search fallback
   let images;
@@ -407,16 +420,19 @@ async function executeSearchImages(query: string, bookId?: string): Promise<
       .toArray();
   }
 
-  return images.slice(0, 6).map(img => ({
-    id: img._id.toString(),
-    imageUrl: img.image_url,
-    description: (img.museum_description || img.description || '').slice(0, 300),
-    bookTitle: img.book_title || 'Unknown',
-    bookAuthor: img.book_author || 'Unknown',
-    bookSlug: img.book_slug,
-    pageNumber: img.page_number,
-    type: img.type,
-  }));
+  return {
+    images: images.slice(0, 6).map(img => ({
+      id: img._id.toString(),
+      imageUrl: img.image_url,
+      description: (img.museum_description || img.description || '').slice(0, 300),
+      bookTitle: img.book_title || 'Unknown',
+      bookAuthor: img.book_author || 'Unknown',
+      bookSlug: img.book_slug,
+      pageNumber: img.page_number,
+      type: img.type,
+    })),
+    clipUnavailable,
+  };
 }
 
 // ── Tool Router ───────────────────────────────────────────────────────
@@ -505,7 +521,7 @@ async function executeTool(
     case 'search_images': {
       const query = args.query as string;
       const bookId = args.book_id as string | undefined;
-      const images = await executeSearchImages(query, bookId);
+      const { images, clipUnavailable } = await executeSearchImages(query, bookId);
 
       let context = '';
       if (images.length > 0) {
@@ -517,14 +533,18 @@ async function executeTool(
           context += `  Gallery: ${url}\n`;
           context += `  Image: ${img.imageUrl}\n`;
         }
+      } else if (clipUnavailable) {
+        // CLIP is down and the keyword fallback found nothing. Do NOT let the
+        // model conclude the library has no illustrations on this topic.
+        context = 'Visual search is temporarily unavailable, so illustrations could not be searched for this query. Do not claim the library has no images on this topic — say image search is briefly unavailable and offer to look again later.';
       } else {
         context = 'No matching images found in the gallery.';
       }
 
       return {
-        result: { found: images.length, context, images: images.map(i => ({ id: i.id, url: i.imageUrl, description: i.description.slice(0, 100), bookTitle: i.bookTitle })) },
+        result: { found: images.length, clipUnavailable, context, images: images.map(i => ({ id: i.id, url: i.imageUrl, description: i.description.slice(0, 100), bookTitle: i.bookTitle })) },
         step: { type: 'tool_result', name: 'search_images', query, found: images.length,
-          summary: images.length > 0 ? `Found ${images.length} illustrations` : 'No images found' },
+          summary: images.length > 0 ? `Found ${images.length} illustrations` : (clipUnavailable ? 'Visual search unavailable' : 'No images found') },
       };
     }
 


### PR DESCRIPTION
## Why

Part of the librarian-quality pass. Two places where the visual side failed *silently*, which is worse than failing loudly for a research tool:

1. **CLIP outage looked like "no illustrations exist."** `executeSearchImages` caught CLIP errors and quietly fell back to keyword search. When both came up empty, the model would tell the reader the library has nothing illustrating a topic — when really the visual index was just down. (Note: the prod CLIP endpoint is a hardcoded bare IP across several files — de-hardcoding that is a separate, cross-cutting PR; this one makes the librarian *honest* about the outage.)
2. **Broken images vanished.** `MessageBody` hid a failed `<img>` with `display:none`, so an intended figure disappeared without a trace.

## What changed

**`src/lib/embassy/librarian.ts`**
- `executeSearchImages` now distinguishes **CLIP unreachable** (network error / non-2xx / missing embedding) from **CLIP searched and found nothing**, logs a `console.warn` for ops, and returns a `clipUnavailable` flag.
- The `search_images` tool result: when CLIP is down *and* the keyword fallback is also empty, the context tells the model to say visual search is briefly unavailable rather than assert the library has no images. Step summary reflects the degraded state.

**`src/app/librarian/_components/MessageBody.tsx`**
- New `MarkdownImage` component: on load error it degrades to a small dashed *"Image unavailable: &lt;alt&gt;"* placeholder that still links to the source, instead of silently disappearing.

## Testing

- `tsc --noEmit` clean.
- Normal image query: shape change (array → `{images, clipUnavailable}`) intact, images still embed.
- Dead CLIP host: warning logs, keyword fallback returns results, answer never falsely claims "no images."

## Scope

One concern: honest surfacing of image failures. Out of scope: centralizing the hardcoded CLIP IP (separate PR — it spans `identify`, `gallery`, `search/visual`, `search/unified`), and the notebook-in-chat UI (next in the pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)