### PR TITLE
feat(librarian): surface the research notebook live in the chat

### DIFF
--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -42,6 +42,17 @@ interface AssistantMessage {
   notebookTopic?: string;
 }
 
+interface NotebookFinding {
+  key: string;
+  quote: string;
+  note: string;
+  bookId: string;
+  bookTitle: string;
+  bookAuthor: string;
+  bookSlug?: string;
+  pageNumber: number;
+}
+
 interface UserMessage {
   role: 'user';
   content: string;
@@ -164,6 +175,74 @@ function SearchSteps({ steps }: { steps: SearchStep[] }) {
   );
 }
 
+// ── Research Notebook Panel ───────────────────────────────────────────
+// Surfaces the findings the Librarian saved this session, so the notebook is
+// something you can read and cite — not just a count badge that's opaque
+// until export.
+
+function NotebookPanel({
+  findings,
+  topic,
+  threadId,
+  onClose,
+}: {
+  findings: NotebookFinding[];
+  topic?: string;
+  threadId: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <div className="border-t border-[#e8e4dc] bg-[#faf8f4]">
+      <div className="flex items-center justify-between px-4 py-2.5">
+        <div className="flex items-center gap-2 text-[13px] font-sans text-[#6b8f5e]">
+          <span aria-hidden>&#x1F4D3;</span>
+          <span className="font-medium">Research notebook</span>
+          <span className="text-[#8a8480]">
+            {findings.length} finding{findings.length === 1 ? '' : 's'}{topic ? ` · ${topic}` : ''}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          {threadId && (
+            <a
+              href={`/api/embassy/threads/${threadId}/notebook`}
+              download
+              className="text-[11px] text-[#6b8f5e] hover:text-[#4a6b40] font-sans"
+            >
+              Export
+            </a>
+          )}
+          <button onClick={onClose} className="text-[11px] text-[#8a8480] hover:text-[#6b6560] font-sans">
+            Close
+          </button>
+        </div>
+      </div>
+      <div className="max-h-[40vh] overflow-y-auto px-4 pb-3 space-y-3">
+        {findings.map((f) => {
+          const url = `/book/${f.bookSlug || f.bookId}/page-number/${f.pageNumber}`;
+          return (
+            <div key={f.key} className="rounded-lg border border-[#e8e4dc] bg-white px-3 py-2.5">
+              <blockquote className="border-l-2 border-[#c9a86c] pl-3 text-[13px] font-body italic text-[#444] leading-relaxed">
+                {f.quote}
+              </blockquote>
+              {f.note && (
+                <p className="mt-2 text-[12px] font-body text-[#6b6560] leading-relaxed">{f.note}</p>
+              )}
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-1.5 inline-block text-[11px] font-sans text-[#9e4a3a] hover:underline"
+              >
+                {f.bookTitle} &mdash; {f.bookAuthor}, p.{f.pageNumber}
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 // ── Main Component ────────────────────────────────────────────────────
 
 const ALL_SUGGESTIONS = [
@@ -206,6 +285,10 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
     if (status === 'authenticated') setSidebarTab('mine');
   }, [status]);
   const [visibility, setVisibility] = useState<'public' | 'private'>('public');
+  // Research notebook accumulated live across the thread (from notebook_update).
+  const [notebookFindings, setNotebookFindings] = useState<NotebookFinding[]>([]);
+  const [notebookTopic, setNotebookTopic] = useState<string | undefined>();
+  const [notebookOpen, setNotebookOpen] = useState(false);
   const [showThinking, setShowThinking] = useState(true);
   const [visibleThreads, setVisibleThreads] = useState(5);
   const chatContainerRef = useRef<HTMLDivElement>(null);
@@ -396,6 +479,14 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                     notebookCount: event.notebook?.findingCount,
                     notebookTopic: event.notebook?.topic || m.notebookTopic,
                   }));
+                  if (event.notebook?.topic) setNotebookTopic(event.notebook.topic);
+                  if (event.notebook?.finding) {
+                    const f = event.notebook.finding;
+                    const key = `${f.bookId}:${f.pageNumber}:${(f.quote || '').slice(0, 48)}`;
+                    setNotebookFindings(prev =>
+                      prev.some(p => p.key === key) ? prev : [...prev, { ...f, key }],
+                    );
+                  }
                   break;
 
                 case 'error':
@@ -467,6 +558,9 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
   const startNewThread = () => {
     setMessages([]);
     setThreadId(null);
+    setNotebookFindings([]);
+    setNotebookTopic(undefined);
+    setNotebookOpen(false);
     inputRef.current?.focus();
   };
 
@@ -679,6 +773,16 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                   <div />
                 </div>
 
+                {/* Research notebook (collapsible) */}
+                {notebookOpen && notebookFindings.length > 0 && (
+                  <NotebookPanel
+                    findings={notebookFindings}
+                    topic={notebookTopic}
+                    threadId={threadId}
+                    onClose={() => setNotebookOpen(false)}
+                  />
+                )}
+
                 {/* Input area */}
                 <div className="border-t border-[#e8e4dc] p-4">
                   <form onSubmit={handleSubmit} className="flex gap-3 items-end">
@@ -718,14 +822,15 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                           New conversation
                         </button>
                       )}
-                      {threadId && messages.some(m => m.role === 'assistant' && (m as AssistantMessage).notebookCount) && (
-                        <a
-                          href={`/api/embassy/threads/${threadId}/notebook`}
-                          download
-                          className="text-[11px] text-[#6b8f5e] hover:text-[#4a6b40] transition-colors font-sans"
+                      {notebookFindings.length > 0 && (
+                        <button
+                          onClick={() => setNotebookOpen(o => !o)}
+                          aria-expanded={notebookOpen}
+                          className="text-[11px] text-[#6b8f5e] hover:text-[#4a6b40] transition-colors font-sans flex items-center gap-1"
                         >
-                          Export research
-                        </a>
+                          <span aria-hidden>&#x1F4D3;</span>
+                          <span>{notebookOpen ? 'Hide' : 'Research'} notebook ({notebookFindings.length})</span>
+                        </button>
                       )}
                     </div>
                     <div className="flex items-center gap-3">

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -75,7 +75,21 @@ export interface LibrarianStep {
   options?: string[];
   descriptions?: (string | undefined)[];
   sources?: SourceCard[];
-  notebook?: { findingCount: number; topic?: string };
+  notebook?: {
+    findingCount: number;
+    topic?: string;
+    // The finding just saved — lets the client render the notebook live
+    // instead of only exposing a count badge.
+    finding?: {
+      quote: string;
+      note: string;
+      bookId: string;
+      bookTitle: string;
+      bookAuthor: string;
+      bookSlug?: string;
+      pageNumber: number;
+    };
+  };
 }
 
 interface ConversationMessage {
@@ -593,7 +607,19 @@ async function executeTool(
       return {
         result: { saved: true, findingCount: count },
         step: { type: 'notebook_update', name: 'add_to_notebook', summary: `Saved finding #${count}`,
-          notebook: { findingCount: count, topic: args.topic as string | undefined } },
+          notebook: {
+            findingCount: count,
+            topic: args.topic as string | undefined,
+            finding: {
+              quote: finding.quote,
+              note: finding.note,
+              bookId: finding.source.bookId,
+              bookTitle: finding.source.bookTitle,
+              bookAuthor: finding.source.bookAuthor,
+              bookSlug: finding.source.bookSlug,
+              pageNumber: finding.source.pageNumber,
+            },
+          } },
       };
     }
 


### PR DESCRIPTION
## Why

The Librarian's differentiator is that it's a *research agent* — it accumulates findings into a notebook. But in the live chat that notebook was a black box: just a "N findings saved" badge and a JSON export link. You couldn't read what was saved without downloading it. This closes the gap I flagged in the librarian audit (#3: "notebook not surfaced in live chat").

## What changed

**`src/lib/embassy/librarian.ts`**
- The `notebook_update` step now carries the **finding just saved** (quote, note, book, page), not only a count. (The chat route already forwards `step.notebook` wholesale, so no route change.)

**`src/app/librarian/LibrarianClient.tsx`**
- Accumulate findings live into thread-level state from `notebook_update` (de-duped by `book:page:quote`).
- New collapsible **Research Notebook panel** above the input: each finding shows its quote, the Librarian's analytical note, and a link to the exact page; export lives inside the panel. Toggled from the footer ("📓 Research notebook (N)"), resets on a new conversation.
- Links are **relative** (`/book/<slug>/page-number/<n>`) so they stay on-host under tenant subdomains (proxy rewrite), per the tenant-lockdown invariant.

## Testing

- `tsc --noEmit` clean.
- Backend stream test (throwaway thread, self-cleaning): a research query produced **2** `notebook_update` events, each carrying a complete finding (quote + book + page) and the topic — 2/2 PASS.
- The panel itself is gated behind an authenticated chat session; the data path is verified above and the Vercel preview confirms the build/render.

## Scope

One concern: making the notebook *visible* in chat. **View-only** — removing/curating findings needs a `DELETE` on the notebook route + ownership checks, which I kept as a clean follow-up. Also out of scope: the persisted thread page (separate route) and the a11y/copy polish (next PR in the pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)