### PR TITLE
feat(librarian): accessibility + label polish for search steps

### DIFF
--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -88,10 +88,15 @@ function timeAgo(dateStr: string): string {
 }
 
 const TOOL_LABELS: Record<string, string> = {
+  search: 'Searching the collection',
   search_collection: 'Searching the collection',
   search_semantic: 'Semantic search',
   search_wikipedia: 'Checking Wikipedia',
+  search_images: 'Searching illustrations',
+  search_artworks: 'Searching artworks',
   get_book_page: 'Reading a page',
+  read_nearby_pages: 'Reading nearby pages',
+  add_to_notebook: 'Saving to notebook',
   present_choices: 'Thinking...',
 };
 
@@ -138,17 +143,27 @@ function SourceCardRow({ sources, tenant }: { sources: SourceCard[]; tenant?: st
 
 function SearchSteps({ steps }: { steps: SearchStep[] }) {
   if (steps.length === 0) return null;
+  const busy = steps.some(s => s.status === 'searching');
   return (
-    <div className="space-y-1 mb-2">
-      {steps.map((step, i) => (
+    <div role="status" aria-live="polite" aria-busy={busy} className="space-y-1 mb-2">
+      {steps.map((step, i) => {
+        const statusLabel =
+          step.status === 'searching' ? 'in progress'
+            : step.found && step.found > 0 ? 'found results'
+            : 'no results';
+        return (
         <div key={i} className="flex items-center gap-2 text-[12px] font-sans text-[#8a8480]">
-          <span className={`inline-block w-3.5 text-center ${step.status === 'done' ? (step.found && step.found > 0 ? 'text-[#6b8f5e]' : 'text-[#b0a89c]') : 'text-[#c9a86c]'}`}>
+          <span
+            role="img"
+            aria-label={statusLabel}
+            className={`inline-block w-3.5 text-center ${step.status === 'done' ? (step.found && step.found > 0 ? 'text-[#6b8f5e]' : 'text-[#b0a89c]') : 'text-[#c9a86c]'}`}
+          >
             {step.status === 'searching' ? (
-              <span className="inline-block animate-pulse">...</span>
+              <span aria-hidden className="inline-block animate-pulse">...</span>
             ) : step.found && step.found > 0 ? (
-              <span>&#x2713;</span>
+              <span aria-hidden>&#x2713;</span>
             ) : (
-              <span>&#x2717;</span>
+              <span aria-hidden>&#x2717;</span>
             )}
           </span>
           <span>
@@ -159,7 +174,8 @@ function SearchSteps({ steps }: { steps: SearchStep[] }) {
             )}
           </span>
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
@@ -599,6 +615,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                             <div className="mb-2">
                               <button
                                 onClick={() => setShowThinking(!showThinking)}
+                                aria-expanded={showThinking}
                                 className="text-[11px] text-[#b0a89c] hover:text-[#8a8480] font-sans transition-colors"
                               >
                                 {showThinking ? 'Hide reasoning' : 'Show reasoning'}


### PR DESCRIPTION
## Why

Final item in the librarian-quality pass — accessibility gaps + a small label bug in the live search-step list.

## What changed (`src/app/librarian/LibrarianClient.tsx`)

- **Live region for search steps.** The step list is now `role="status" aria-live="polite"` with `aria-busy` while a tool is running, so screen-reader users hear "Searching the collection… found results" as it happens instead of nothing.
- **Status not by colour alone.** Each step's ✓/✗/… was colour + glyph only; the status (in progress / found results / no results) now has an `aria-label`, with the decorative glyph `aria-hidden`.
- **`aria-expanded`** on the Show/Hide reasoning toggle.
- **Completed `TOOL_LABELS`.** It was missing `search`, `search_images`, `search_artworks`, `read_nearby_pages`, and `add_to_notebook`, so those rendered as raw tool names (e.g. "search_images") in the step list. All now have friendly labels.

## Testing

`tsc --noEmit` clean. UI-only, attribute + label changes; Vercel preview confirms render.

## Scope

One concern: accessibility/labels of the search-step list. Not included: copy-to-clipboard citations (a separate UX feature) and the pre-existing React #418 hydration warning on the empty state (caused by random suggestion chips seeded in a `useState` initializer — present on production too; a clean separate fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)