### PR TITLE
refactor(clip): centralize the CLIP endpoint into one config module

### DIFF
--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -5,9 +5,7 @@ import { getTenantContextFromRequest, resolveTenantId } from '@/lib/tenant-conte
 import { supabase } from '@/lib/supabase';
 import { generateQueryEmbedding, cosineSimilarity } from '@/lib/embeddings';
 import { deduplicateByDHash } from '@/lib/dhash';
-
-// CLIP server on Hetzner for visual text→image search
-const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
+import { CLIP_URL } from '@/lib/clip';
 
 export const maxDuration = 30;
 

--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -4,15 +4,13 @@ import { getDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import { semanticArtworkSearch, type SemanticArtworkResult } from '@/lib/semantic-search';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+import { CLIP_URL } from '@/lib/clip';
 
 export const maxDuration = 30;
 export const dynamic = 'force-dynamic';
 
 // Max image size: 4MB (Vercel serverless body limit is 4.5MB)
 const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
-
-// CLIP server on Hetzner, proxied through the text embedding server (port 3456)
-const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
 
 const IDENTIFY_PROMPT = `You are an art historian identifying a physical artwork or book page from a photograph taken in a museum or library.
 

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -8,9 +8,7 @@ import { searchBookIds } from '@/lib/books-catalog';
 import { semanticBookSearch, semanticArtworkSearch } from '@/lib/semantic-search';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
-
-// CLIP server on Hetzner for visual text→image search
-const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
+import { CLIP_URL } from '@/lib/clip';
 
 const ENTITIES_SEARCH_INDEX = 'entities_search';
 const GALLERY_SEARCH_INDEX = 'gallery_search';

--- a/src/app/api/search/visual/route.ts
+++ b/src/app/api/search/visual/route.ts
@@ -2,11 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabase';
 import { getReadDb } from '@/lib/mongodb';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
+import { CLIP_URL } from '@/lib/clip';
 
 export const maxDuration = 15;
-
-// CLIP server on Hetzner, proxied through the text embedding server
-const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
 
 /**
  * GET /api/search/visual?q=ouroboros&limit=20

--- a/src/lib/clip.ts
+++ b/src/lib/clip.ts
@@ -1,0 +1,22 @@
+// Single source of truth for the CLIP visual-embedding service endpoint.
+//
+// The image-search routes (/api/identify, /api/gallery, /api/search/visual,
+// /api/search/unified) and the Librarian all call a self-hosted CLIP box to
+// turn text/images into embeddings for visual search. The base URL used to be
+// a bare-IP literal duplicated in five files — change the host and you had to
+// find every copy. It now lives here: override with the CLIP_URL env var, or
+// fall back to the default host.
+
+const DEFAULT_CLIP_URL = 'http://46.224.122.120:3456/clip';
+
+/** Resolved CLIP service base URL. Append `/embed-text` or `/embed-image`. */
+export const CLIP_URL = process.env.CLIP_URL || DEFAULT_CLIP_URL;
+
+/** True when CLIP_URL is explicitly configured (not relying on the fallback host). */
+export const isClipConfigured = (): boolean => !!process.env.CLIP_URL;
+
+// Surface the liability once per cold start: if we're in production and no
+// CLIP_URL is set, visual search depends on the hardcoded fallback host.
+if (process.env.NODE_ENV === 'production' && !process.env.CLIP_URL) {
+  console.warn(`[clip] CLIP_URL not set — visual search is using the fallback host ${DEFAULT_CLIP_URL}. Set CLIP_URL to make this configurable.`);
+}

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -5,6 +5,7 @@ import { GoogleGenAI, Type, type FunctionDeclaration } from '@google/genai';
 import { supabase } from '@/lib/supabase';
 import { ObjectId } from 'mongodb';
 import { stripAnnotations } from '@/lib/semantic-alignment';
+import { CLIP_URL } from '@/lib/clip';
 
 /**
  * The Librarian — Research agent for Source Library.
@@ -365,7 +366,6 @@ async function executeSearchImages(query: string, bookId?: string): Promise<{
 }> {
   // Use CLIP visual search via the gallery API for text-to-image matching
   const db = await getDb();
-  const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
 
   // Try CLIP text-to-image search first. Distinguish "CLIP searched and found
   // nothing" (reachable, fall back to keyword search) from "CLIP is down"


### PR DESCRIPTION
## Why

The CLIP visual-embedding service URL was a bare-IP literal (`http://46.224.122.120:3456/clip`) **duplicated in five files** — `/api/identify`, `/api/gallery`, `/api/search/visual`, `/api/search/unified`, and the Librarian. Changing the host meant hunting down every copy. Worse: `CLIP_URL` is set in *neither* the pulled prod env nor Vercel, so all visual search silently depends on that one hardcoded fallback — the "ticking time bomb" flagged in the librarian audit.

## What changed

- **New `src/lib/clip.ts`** — single source of truth. Exports `CLIP_URL` (env override or the default host) and `isClipConfigured()`, and `console.warn`s once on cold start in production when `CLIP_URL` is unset, so the fallback dependency shows up in logs instead of being invisible.
- **All five consumers** now `import { CLIP_URL } from '@/lib/clip'` and dropped their local declarations. The IP literal exists in exactly one place.

## Testing

- No behavior change — identical env-or-default resolution; usages (`${CLIP_URL}/embed-text`, `/embed-image`) are untouched.
- `tsc --noEmit` clean; check-imports hook passes.
- `grep '46.224.122.120' src/` now returns only the single default in `clip.ts` (plus two unrelated system-map doc strings about the Hetzner cron box).

## Follow-up (not this PR)

Set `CLIP_URL` in Vercel to a stable DNS name once one exists, so the service can move without a deploy. That's an ops/env change, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)