### PR TITLE
feat(pipeline): classify ex-libris/bookplates, keep them out of OCR & gallery

### DIFF
--- a/scripts/thumbnails/backfill-collection-images.mjs
+++ b/scripts/thumbnails/backfill-collection-images.mjs
@@ -125,6 +125,8 @@ async function run() {
       { $match: {
         book_id: { $in: bookIds },
         gallery_quality: { $gte: 0.7 },
+        // Never feature ownership bookplates / ex-libris (provenance, not content)
+        type: { $nin: ['exlibris', 'bookplate', 'decorative', 'symbol', 'musical_score'] },
         $or: [
           { extracted_url: { $exists: true, $ne: null, $ne: '' } },
           { image_url: { $exists: true, $ne: null, $ne: '' } },

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -108,6 +108,8 @@ const SKIP_MARKUP_RULES = [
   { type: 'stamp', significance: '*' },
   { type: 'ornament', significance: '*' },        // printer's ornaments, tailpieces
   { type: 'blank', significance: '*' },
+  { type: 'exlibris', significance: '*' },        // ownership bookplates — provenance, not content
+  { type: 'bookplate', significance: '*' },
   { type: 'decorative', significance: 'low' },    // drop caps, framing rules
   { type: "printer's mark", significance: 'low' },
   { type: 'photograph', significance: 'low' },    // binding/fore-edge photos
@@ -191,7 +193,7 @@ If the page contains no significant illustrations, return \`extracted_images: []
 For each significant illustration return:
 {
   "description": "Brief factual description",
-  "type": "emblem|woodcut|engraving|portrait|frontispiece|musical_score|diagram|symbol|map",
+  "type": "emblem|woodcut|engraving|portrait|frontispiece|musical_score|diagram|symbol|map|exlibris",
   "bbox": { "x": 0.15, "y": 0.25, "width": 0.70, "height": 0.45 },
   "confidence": 0.95,
   "gallery_quality": 0.85,

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -177,6 +177,8 @@ const SKIP_MARKUP_RULES = [
   { type: 'stamp', significance: '*' },
   { type: 'ornament', significance: '*' },
   { type: 'blank', significance: '*' },
+  { type: 'exlibris', significance: '*' },        // ownership bookplates — provenance, not content
+  { type: 'bookplate', significance: '*' },
   { type: 'decorative', significance: 'low' },
   { type: "printer's mark", significance: 'low' },
   { type: 'photograph', significance: 'low' },
@@ -454,7 +456,7 @@ async function probeDbHealth(db) {
 
 // Page types to skip for translation (mirrors defaults.ts)
 const SKIP_TRANSLATION_PAGE_TYPES = [
-  'blank',
+  'blank', 'exlibris', 'bookplate',
 ];
 
 // Languages that get inline transliteration before translation.
@@ -1922,7 +1924,7 @@ If the page contains no significant illustrations, return \`[]\` — an empty ar
 For each significant illustration return:
 {
   "description": "Brief factual description",
-  "type": "emblem|woodcut|engraving|portrait|frontispiece|musical_score|diagram|symbol|map",
+  "type": "emblem|woodcut|engraving|portrait|frontispiece|musical_score|diagram|symbol|map|exlibris",
   "bbox": { "x": 0.15, "y": 0.25, "width": 0.70, "height": 0.45 },
   "confidence": 0.95,
   "gallery_quality": 0.85,

--- a/scripts/workers/sync-worker.mjs
+++ b/scripts/workers/sync-worker.mjs
@@ -234,6 +234,8 @@ async function syncGalleryImages(db) {
         'detected_images.bbox': { $exists: true },
         'detected_images.detection_source': { $in: ['vision_model', 'manual', 'ocr_tag'] },
         'detected_images.gallery_quality': { $gte: 0.5 },
+        // Ownership bookplates / ex-libris are provenance, not content — never materialize them
+        'detected_images.type': { $nin: ['exlibris', 'bookplate'] },
       },
     },
     {

--- a/src/lib/image-extraction-filter.ts
+++ b/src/lib/image-extraction-filter.ts
@@ -16,6 +16,8 @@ export const SKIP_MARKUP_RULES: readonly SkipRule[] = [
   { type: 'stamp', significance: '*' },
   { type: 'ornament', significance: '*' },
   { type: 'blank', significance: '*' },
+  { type: 'exlibris', significance: '*' },   // ownership bookplates — provenance, not content
+  { type: 'bookplate', significance: '*' },
   { type: 'decorative', significance: 'low' },
   { type: "printer's mark", significance: 'low' },
   { type: 'photograph', significance: 'low' },

--- a/src/lib/image-extraction.ts
+++ b/src/lib/image-extraction.ts
@@ -28,12 +28,13 @@ IMAGE TYPES (use these exactly):
 SKIP these — do NOT include them:
 - Page ornaments, borders, decorative initials, printer's devices
 - Marbled papers, blank frames, ruled lines
+- Ownership bookplates / ex-libris pasted into pastedowns or endpapers — if you must record one, use type "exlibris" with gallery_quality ≤ 0.3 (provenance, not the book's content)
 - Any element that is purely decorative with no intellectual content
 
 For each significant illustration return:
 {
   "description": "Brief factual description",
-  "type": "emblem|woodcut|engraving|portrait|frontispiece|musical_score|diagram|symbol|map",
+  "type": "emblem|woodcut|engraving|portrait|frontispiece|musical_score|diagram|symbol|map|exlibris",
   "bbox": { "x": 0.15, "y": 0.25, "width": 0.70, "height": 0.45 },
   "confidence": 0.95,
   "gallery_quality": 0.85,

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -224,7 +224,7 @@ export interface ImageMetadata {
 export interface DetectedImage {
   id?: string;                  // Unique ID for this detection
   description: string;          // What the image depicts (brief)
-  type?: 'woodcut' | 'diagram' | 'chart' | 'illustration' | 'symbol' | 'table' | 'map' | 'decorative' | 'emblem' | 'engraving' | 'portrait' | 'frontispiece' | 'musical_score' | 'unknown';
+  type?: 'woodcut' | 'diagram' | 'chart' | 'illustration' | 'symbol' | 'table' | 'map' | 'decorative' | 'emblem' | 'engraving' | 'portrait' | 'frontispiece' | 'musical_score' | 'exlibris' | 'bookplate' | 'unknown';
   // Bounding box (0-1 normalized coordinates, for future extraction)
   bbox?: {
     x: number;      // Left edge (0-1)

--- a/src/lib/types/prompts/defaults.ts
+++ b/src/lib/types/prompts/defaults.ts
@@ -2,17 +2,18 @@ import { ProcessingPrompts } from "./core";
 import type { DetectedImage } from "../page";
 
 // Bump this when DEFAULT_PROMPTS change. Stored on every page record for audit trail.
-export const PROMPT_VERSION = 'v6.2026-03';
+export const PROMPT_VERSION = 'v6.1.2026-05';
 
 const VALID_PAGE_TYPES = new Set([
   'title-page', 'frontispiece', 'dedication', 'preface', 'toc', 'index',
   'errata', 'colophon', 'appendix', 'blank', 'illustration', 'diagram', 'map', 'text',
-  'digitizer-insert',
+  'digitizer-insert', 'exlibris', 'bookplate',
 ]);
 
 // Page types that should be skipped during translation — no meaningful text content
+// (ex-libris/bookplates are ownership marks, not book content)
 export const SKIP_TRANSLATION_PAGE_TYPES = [
-  'blank',
+  'blank', 'exlibris', 'bookplate',
 ];
 
 // Page types hidden from the reader navigation (still accessible via direct URL)
@@ -50,7 +51,8 @@ export function extractScriptType(ocrText: string): 'printed' | 'handwritten' | 
 
 const VALID_IMAGE_TYPES = new Set([
   'woodcut', 'diagram', 'chart', 'illustration', 'symbol', 'table', 'map',
-  'decorative', 'emblem', 'engraving', 'portrait', 'frontispiece', 'musical_score', 'unknown',
+  'decorative', 'emblem', 'engraving', 'portrait', 'frontispiece', 'musical_score',
+  'exlibris', 'bookplate', 'unknown',
 ]);
 
 /** Parse <detected-images> JSON from OCR text into typed DetectedImage[]. Returns empty array if none found. */
@@ -158,8 +160,9 @@ export const DEFAULT_PROMPTS: ProcessingPrompts = {
 
 **Metadata tags (hidden from readers):**
 - <language>X</language> — the detected language of this page (REQUIRED — always identify the language, e.g. Latin, German, French, English)
-- <page-type>X</page-type> — classify this page (REQUIRED). One of: title-page, frontispiece, dedication, preface, toc, index, errata, colophon, appendix, blank, illustration, diagram, map, text, digitizer-insert
+- <page-type>X</page-type> — classify this page (REQUIRED). One of: title-page, frontispiece, dedication, preface, toc, index, errata, colophon, appendix, blank, illustration, diagram, map, text, digitizer-insert, exlibris
   - Use "digitizer-insert" for pages added by the digitizer (NOT part of the original book): Internet Archive credit pages, Google Books inserts, "Digitized by Google" pages, library barcode/scan sheets, digital watermark pages
+  - Use "exlibris" for an ownership bookplate pasted into the book (usually on a pastedown or endpaper): an armorial or emblematic plate naming or marking the owner, often with a motto. It is provenance, not the book's content — do NOT treat its motto as body text.
 - <columns>N</columns> — number of text columns on this page (omit for single-column pages, include for 2+ columns)
 - <page-num>N</page-num> — visible page/folio numbers (NOT in body text)
 - <header>X</header> — running headers/chapter titles at top of page (NEVER duplicate as heading in body)
@@ -191,7 +194,7 @@ export const DEFAULT_PROMPTS: ProcessingPrompts = {
 **IMAGE DETECTION:** If the page contains ANY illustrations, diagrams, emblems, woodcuts, engravings, or decorative elements, add at the END:
 
 <detected-images>
-[{"description": "Brief description", "type": "emblem|woodcut|engraving|diagram|portrait|frontispiece|decorative|map", "bbox": {"x": 0.1, "y": 0.2, "width": 0.7, "height": 0.5}, "gallery_quality": 0.85, "museum_rationale": "Why museum-worthy or not"}]
+[{"description": "Brief description", "type": "emblem|woodcut|engraving|diagram|portrait|frontispiece|decorative|map|exlibris", "bbox": {"x": 0.1, "y": 0.2, "width": 0.7, "height": 0.5}, "gallery_quality": 0.85, "museum_rationale": "Why museum-worthy or not"}]
 </detected-images>
 
 **Bounding box (0.0-1.0):** x=left edge, y=top edge. Measure PRECISELY to tightly enclose each illustration.
@@ -201,6 +204,7 @@ export const DEFAULT_PROMPTS: ProcessingPrompts = {
 - 0.7-0.9: High — well-executed illustrations, interesting diagrams
 - 0.4-0.7: Moderate — standard frontispieces, simple diagrams
 - 0.0-0.4: Low — page ornaments, generic borders, printer's marks
+- Ownership bookplates / ex-libris: ALWAYS type "exlibris" with gallery_quality ≤ 0.3 — these are provenance marks, not the book's own illustrations, and must not surface in the gallery.
 
 If text-only page, omit the <detected-images> block.`,
 


### PR DESCRIPTION
## Why
An ownership **ex-libris bookplate** (pasted into an endpaper) was being treated as book content — OCR'd, translated, extracted as an illustration, and even featured on the Theosophy collection (a Welling pelican plate). The homepage and `libraries/[slug]` pages already filter `exlibris`/`bookplate` image types, but **nothing ever emitted those types** — so it was dead defensive code and plates leaked through as `emblem`/`frontispiece`.

## What
Wires the classifier end-to-end. You can't pre-skip OCR (OCR is what *identifies* a plate), so the design is: tag it `exlibris` during OCR, then every downstream stage skips it.

- **OCR prompt** — `src/lib/types/prompts/defaults.ts` (canonical) + the 3 inline copies (`image-extraction.ts`, `image-extract-worker.mjs`, `pipeline-orchestrator.mjs`): new `exlibris` page-type and image-type, with instructions to tag ownership plates and score them `≤ 0.3`. `PROMPT_VERSION` bumped.
- **No translation** — `SKIP_TRANSLATION_PAGE_TYPES += exlibris, bookplate` (defaults + orchestrator).
- **No extraction** — `SKIP_MARKUP_RULES += exlibris, bookplate` (filter + both worker copies): a page whose only detected images are plates is skipped.
- **No gallery** — `sync-worker` materialization never turns `exlibris`/`bookplate` detections into `gallery_images`.
- **No featuring** — `backfill-collection-images` excludes them (plus `decorative`/`symbol`/`musical_score`).
- Types: `page.ts` image-type union + `VALID_PAGE_TYPES`/`VALID_IMAGE_TYPES`.

## Scope / out of scope
- Affects **new OCR only**. Existing mis-typed plates (tagged `emblem`/`frontispiece` across the corpus) need a one-off **backfill** — a vision re-classification pass over front-matter `emblem`/`frontispiece` images. Tracked separately; not in this PR.
- The one instance that prompted this (Welling Theosophy collection) was already hand-fixed and swapped for a real cosmological diagram.

`npx tsc --noEmit` clean for all touched files (pre-existing d3 errors in the carbon-ledger blog are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)