### PR TITLE
fix(librarian): stop hydration mismatch from random suggestions (React #418)

### DIFF
--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -289,7 +289,11 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
   const params = useParams<{ tenant: string }>();
   const tenant = params?.tenant;
   const [messages, setMessages] = useState<Message[]>([]);
-  const [suggestions] = useState(() => pickSuggestions(4));
+  // Seed deterministically so SSR and the first client render agree (a random
+  // initial set caused a hydration mismatch — React #418). Shuffle for variety
+  // only after mount, where a state update is safe.
+  const [suggestions, setSuggestions] = useState<string[]>(() => ALL_SUGGESTIONS.slice(0, 4));
+  useEffect(() => { setSuggestions(pickSuggestions(4)); }, []);
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const [threadId, setThreadId] = useState<string | null>(null);


### PR DESCRIPTION
## Why

`/librarian` threw **React #418** (hydration text mismatch) on every load — found while smoke-testing the notebook PR, and confirmed present on production too. Cause: the suggested-prompt chips are seeded with `useState(() => pickSuggestions(4))`, and `pickSuggestions` uses `Math.random()`. The server renders one random set; the client's first render produces a different one → the hydrated text doesn't match the server HTML.

## Fix

`src/app/librarian/LibrarianClient.tsx` — seed the initial state **deterministically** (`ALL_SUGGESTIONS.slice(0, 4)`) so SSR and the first client render agree, then shuffle for variety in a post-mount `useEffect` (a state update after hydration is safe). Visitors still get a varied set; React no longer sees a mismatch.

## Testing

- `tsc --noEmit` clean.
- Will confirm on the preview that `/librarian` no longer logs React #418 (it does today, and on production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)