### PR TITLE
fix(search): stop quoting <meta> editorial prose as source text

### DIFF
--- a/scripts/maintenance/backfill-clean-snippets.mjs
+++ b/scripts/maintenance/backfill-clean-snippets.mjs
@@ -67,58 +67,71 @@ async function main() {
   }
 
   const cursor = db.collection('pages')
-    .find(mongoFilter, { projection: { _id: 1, book_id: 1, page_number: 1, 'translation.data': 1, 'ocr.data': 1 } })
-    .sort({ page_number: 1 });
+    .find(mongoFilter, { projection: { _id: 1, book_id: 1, page_number: 1, 'translation.data': 1, 'ocr.data': 1 } });
 
-  let scanned = 0, changed = 0, written = 0, droppedTokens = 0;
+  let scanned = 0, changed = 0, written = 0, droppedTokens = 0, errors = 0;
   const samples = [];
 
-  for await (const page of cursor) {
-    if (LIMIT && scanned >= LIMIT) break;
-    scanned++;
+  // Run a batch of Mongo pages: bulk-select existing Supabase snippets in one
+  // call (.in), then UPDATE only the changed rows with a concurrency pool.
+  // We UPDATE (never upsert) so the embedding column is never touched.
+  const SELECT_BATCH = 500;
+  const UPDATE_CONCURRENCY = 25;
 
-    const raw = page.translation?.data || page.ocr?.data || '';
-    if (!raw) continue;
-    const cleaned = cleanText(raw);
-
-    const pageId = page._id.toString();
-    const { data: existing } = await supabase
+  async function flush(batch) {
+    const ids = batch.map(b => b.pageId);
+    const { data: rows, error } = await supabase
       .from('page_translations')
-      .select('translation')
-      .eq('page_id', pageId)
-      .maybeSingle();
-    if (!existing) continue; // not embedded yet — worker will write it clean
+      .select('page_id, translation')
+      .in('page_id', ids);
+    if (error) { console.error(`select batch: ${error.message}`); errors += batch.length; return; }
+    const existing = new Map((rows || []).map(r => [r.page_id, r.translation || '']));
 
-    const old = existing.translation || '';
-    if (old === cleaned) continue;
-    changed++;
+    const todo = [];
+    for (const b of batch) {
+      if (!existing.has(b.pageId)) continue; // not embedded yet — worker writes clean
+      const old = existing.get(b.pageId);
+      if (old === b.cleaned) continue;
+      changed++;
 
-    // crude signal: words present in old snippet but gone after re-clean
-    const oldWords = new Set(old.toLowerCase().match(/[a-z]{4,}/g) || []);
-    const newWords = new Set(cleaned.toLowerCase().match(/[a-z]{4,}/g) || []);
-    const removed = [...oldWords].filter(w => !newWords.has(w));
-    droppedTokens += removed.length;
-
-    if (samples.length < 8) {
-      samples.push({
-        page: page.page_number,
-        removedSample: removed.slice(0, 12).join(', '),
-        oldLen: old.length,
-        newLen: cleaned.length,
-      });
+      const oldWords = new Set(old.toLowerCase().match(/[a-z]{4,}/g) || []);
+      const newWords = new Set(b.cleaned.toLowerCase().match(/[a-z]{4,}/g) || []);
+      const removed = [...oldWords].filter(w => !newWords.has(w));
+      droppedTokens += removed.length;
+      if (samples.length < 8) {
+        samples.push({ page: b.page_number, removedSample: removed.slice(0, 12).join(', '), oldLen: old.length, newLen: b.cleaned.length });
+      }
+      if (WRITE) todo.push(b);
     }
 
-    if (WRITE) {
-      const { error } = await supabase
-        .from('page_translations')
-        .update({ translation: cleaned })
-        .eq('page_id', pageId);
-      if (error) { console.error(`  page ${page.page_number}: ${error.message}`); continue; }
-      written++;
+    for (let i = 0; i < todo.length; i += UPDATE_CONCURRENCY) {
+      const slice = todo.slice(i, i + UPDATE_CONCURRENCY);
+      await Promise.all(slice.map(async b => {
+        const { error: uerr } = await supabase
+          .from('page_translations')
+          .update({ translation: b.cleaned })
+          .eq('page_id', b.pageId);
+        if (uerr) { errors++; } else { written++; }
+      }));
     }
   }
 
-  console.log(`\nScanned ${scanned} pages | snippet changed: ${changed} | written: ${written}${WRITE ? '' : ' (DRY RUN)'}`);
+  let batch = [];
+  for await (const page of cursor) {
+    if (LIMIT && scanned >= LIMIT) break;
+    scanned++;
+    const raw = page.translation?.data || page.ocr?.data || '';
+    if (!raw) continue;
+    batch.push({ pageId: page._id.toString(), page_number: page.page_number, cleaned: cleanText(raw) });
+    if (batch.length >= SELECT_BATCH) {
+      await flush(batch);
+      batch = [];
+      if (scanned % 50000 === 0) console.log(`  …scanned ${scanned} | changed ${changed} | written ${written} | errors ${errors}`);
+    }
+  }
+  if (batch.length) await flush(batch);
+
+  console.log(`\nScanned ${scanned} pages | snippet changed: ${changed} | written: ${written} | errors: ${errors}${WRITE ? '' : ' (DRY RUN)'}`);
   console.log(`Words removed from snippets (editorial prose): ${droppedTokens}\n`);
   for (const s of samples) {
     console.log(`  p${s.page} ${s.oldLen}→${s.newLen} chars | removed: ${s.removedSample}`);

--- a/scripts/maintenance/backfill-clean-snippets.mjs
+++ b/scripts/maintenance/backfill-clean-snippets.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Re-derive the page_translations.translation SNIPPET column from Mongo,
+ * dropping editorial-wrapper content (<meta>/<summary>/<keywords>/<vocab>).
+ *
+ * WHY: embed-gemini.mjs cleanText() used to keep the inner prose of those
+ * wrappers, so AI page-descriptions ("the previous page focused on mercury…")
+ * were stored as quotable snippets and mislocated content onto the wrong page
+ * (Nirmal's "mercury on page 89" misquote, 2026-05-30). The code fix prevents
+ * NEW pollution; this backfill cleans the already-stored rows.
+ *
+ * It does NOT touch the embedding vector — zero Gemini calls, zero cost. That
+ * is deliberate: cleaning the snippet fixes the *quoted text* immediately, so
+ * we can measure whether the (still meta-polluted) vectors actually need a
+ * paid re-embed before spending on one.
+ *
+ * Modes:
+ *   --book ID     One book (Mongo book.id)
+ *   --full        All pages that have a Supabase row
+ *   --limit N     Stop after N pages
+ *   --write       Actually UPDATE (default is dry-run: show before/after)
+ *
+ * Env: MONGODB_URI, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ *   set -a; source .env.production.local; set +a
+ */
+
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const SUPABASE_URL = (process.env.SUPABASE_URL || '').trim();
+const SUPABASE_KEY = (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
+
+if (!MONGODB_URI || !SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing env: MONGODB_URI, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const FULL = args.includes('--full');
+const WRITE = args.includes('--write');
+const BOOK_ID = args.find((_, i, a) => a[i - 1] === '--book');
+const LIMIT = parseInt(args.find((_, i, a) => a[i - 1] === '--limit') || '0') || 0;
+
+// Identical to scripts/workers/embed-gemini.mjs cleanText (keep in sync).
+function cleanText(text) {
+  if (!text || typeof text !== 'string') return '';
+  return text
+    .replace(/<(meta|summary|keywords|vocab)>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 8000);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+
+async function main() {
+  const mongo = new MongoClient(MONGODB_URI);
+  await mongo.connect();
+  const db = mongo.db('bookstore');
+
+  const mongoFilter = BOOK_ID ? { book_id: BOOK_ID } : {};
+  if (!BOOK_ID && !FULL) {
+    console.error('Pass --book ID or --full');
+    process.exit(1);
+  }
+
+  const cursor = db.collection('pages')
+    .find(mongoFilter, { projection: { _id: 1, book_id: 1, page_number: 1, 'translation.data': 1, 'ocr.data': 1 } })
+    .sort({ page_number: 1 });
+
+  let scanned = 0, changed = 0, written = 0, droppedTokens = 0;
+  const samples = [];
+
+  for await (const page of cursor) {
+    if (LIMIT && scanned >= LIMIT) break;
+    scanned++;
+
+    const raw = page.translation?.data || page.ocr?.data || '';
+    if (!raw) continue;
+    const cleaned = cleanText(raw);
+
+    const pageId = page._id.toString();
+    const { data: existing } = await supabase
+      .from('page_translations')
+      .select('translation')
+      .eq('page_id', pageId)
+      .maybeSingle();
+    if (!existing) continue; // not embedded yet — worker will write it clean
+
+    const old = existing.translation || '';
+    if (old === cleaned) continue;
+    changed++;
+
+    // crude signal: words present in old snippet but gone after re-clean
+    const oldWords = new Set(old.toLowerCase().match(/[a-z]{4,}/g) || []);
+    const newWords = new Set(cleaned.toLowerCase().match(/[a-z]{4,}/g) || []);
+    const removed = [...oldWords].filter(w => !newWords.has(w));
+    droppedTokens += removed.length;
+
+    if (samples.length < 8) {
+      samples.push({
+        page: page.page_number,
+        removedSample: removed.slice(0, 12).join(', '),
+        oldLen: old.length,
+        newLen: cleaned.length,
+      });
+    }
+
+    if (WRITE) {
+      const { error } = await supabase
+        .from('page_translations')
+        .update({ translation: cleaned })
+        .eq('page_id', pageId);
+      if (error) { console.error(`  page ${page.page_number}: ${error.message}`); continue; }
+      written++;
+    }
+  }
+
+  console.log(`\nScanned ${scanned} pages | snippet changed: ${changed} | written: ${written}${WRITE ? '' : ' (DRY RUN)'}`);
+  console.log(`Words removed from snippets (editorial prose): ${droppedTokens}\n`);
+  for (const s of samples) {
+    console.log(`  p${s.page} ${s.oldLen}→${s.newLen} chars | removed: ${s.removedSample}`);
+  }
+
+  await mongo.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/workers/embed-gemini.mjs
+++ b/scripts/workers/embed-gemini.mjs
@@ -130,7 +130,13 @@ async function embedBatch(texts) {
 function cleanText(text) {
   if (!text || typeof text !== 'string') return '';
   return text
-    .replace(/<[^>]+>/g, ' ')    // strip HTML/XML tags
+    // Drop EDITORIAL page-level wrappers content-and-all. These are Gemini's
+    // "what this page is about" descriptions — they routinely name content from
+    // ADJACENT pages (e.g. a page-89 <meta> mentioning the "mercury" wheel that
+    // is actually on page 88). Embedding/quoting them mislocates the source and
+    // produces citations to words that aren't on the page. (Nirmal, 2026-05-30.)
+    .replace(/<(meta|summary|keywords|vocab)>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')    // strip remaining tags, keep inner body text
     .replace(/\s+/g, ' ')        // collapse whitespace
     .trim()
     .slice(0, 8000);             // Gemini embedding-2 supports 8192 tokens

--- a/src/lib/search/librarian-search.ts
+++ b/src/lib/search/librarian-search.ts
@@ -306,7 +306,13 @@ function stripAnnotations(text: string): string {
     .replace(/\[\[[^\]]+\]\]/g, '')
     .replace(/^```(?:markdown)?\s*\n?/i, '')
     .replace(/\n?```\s*$/i, '')
-    .replace(/<meta>[^<]*<\/meta>/g, '')
+    // Drop editorial page-level wrappers content-and-all (multiline, any of
+    // meta/summary/keywords/vocab). These describe the page — often naming
+    // content from neighbouring pages — and must never be quoted as source
+    // text. Old regex (<meta>[^<]*</meta>) missed multiline + the other tags
+    // and was the root of the "mercury on page 89" misquote (Nirmal, 2026-05-30).
+    .replace(/<(meta|summary|keywords|vocab)>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/\s{2,}/g, ' ')
     .trim();
 }
 

--- a/src/lib/semantic-alignment.ts
+++ b/src/lib/semantic-alignment.ts
@@ -76,10 +76,12 @@ function cosineSimilarity(a: number[], b: number[]): number {
  */
 export function stripAnnotations(text: string): string {
   return text
-    // Remove full XML tag pairs and their content for meta/structural tags
-    .replace(/<(?:meta|language|page-type|page-num|header|sig|folio|warning)>[^]*?<\/(?:meta|language|page-type|page-num|header|sig|folio|warning)>/g, '')
+    // Remove full XML tag pairs and their content for meta/structural tags.
+    // summary/keywords/vocab are editorial page-level descriptions — never
+    // verbatim source, must not be embedded or quoted (Nirmal misquote, 2026-05-30).
+    .replace(/<(?:meta|summary|keywords|vocab|language|page-type|page-num|header|sig|folio|warning)>[^]*?<\/(?:meta|summary|keywords|vocab|language|page-type|page-num|header|sig|folio|warning)>/g, '')
     // Remove self-closing and opening-only structural tags
-    .replace(/<\/?(?:meta|language|page-type|page-num|header|sig|folio|warning)>/g, '')
+    .replace(/<\/?(?:meta|summary|keywords|vocab|language|page-type|page-num|header|sig|folio|warning)>/g, '')
     // Keep content-bearing tags (note, margin, gloss, term, etc.) but strip the tags themselves
     .replace(/<\/?[a-z-]+>/g, '')
     // Clean up whitespace


### PR DESCRIPTION
## Problem

Nirmal reported a librarian citation to page 89 of Munisvara's *Siddhanta Sarvabhauma* quoting:

> "While the previous page focused on perpetual motion wheels using mercury, this page shifts toward water-driven mechanisms and the construction of the Armillary Sphere (Gola-yantra)…"

…but "mercury" appears nowhere on page 89. Page 89's body is about a water-driven armillary sphere; the mercury wheel is on **page 88**.

## Root cause

That sentence is not a quote — it's the AI-written `<meta>` annotation describing page 89. `cleanText()` in `embed-gemini.mjs` stripped XML tags but **kept the inner prose**, so the meta description was (a) baked into page 89's embedding vector (which is why a "mercury" query ranked it) and (b) stored as the quotable `page_translations.translation` snippet. The librarian quoted it verbatim, attributed to page 89.

This is **corpus-wide** — `<meta>`/`<summary>`/`<keywords>`/`<vocab>` wrap every translated page.

## Fix

Drop editorial-wrapper **content** (not just tags) in all three strippers:
- `scripts/workers/embed-gemini.mjs` `cleanText` — embedding + stored snippet
- `src/lib/search/librarian-search.ts` `stripAnnotations` — keyword path (live now; reads tagged Mongo text)
- `src/lib/semantic-alignment.ts` `stripAnnotations` — embassy librarian

Inline glosses (`note`/`term`/`margin`) are kept — they sit on real body text.

## Backfill (decoupled, free)

`scripts/maintenance/backfill-clean-snippets.mjs` re-derives the stored snippet column from Mongo with **zero Gemini calls** (existing rows already had tags stripped at write time, so a read-time re-strip can't recover them — the Mongo re-derive is required). It does **not** touch embeddings, so we can fix the quoted text now and measure whether the still-polluted vectors warrant a paid re-embed.

Proven on the Munisvara book (302/302 snippets polluted); page 89 now quotes its real body. **That book is already corrected in prod** as the proof case.

## Out of scope (follow-ups)
- Full-corpus snippet backfill (~4M rows, free) — pending go-ahead.
- Optional re-embed (~\$170 batch / \$340 standard for translation column) — only if retrieval eval shows meta-pollution still mislocates content after the snippet fix.

Reported by Nirmal Patel, 2026-05-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)