### PR TITLE
fix(search): strip editorial wrappers on keyword search + likes surfaces

### DIFF
--- a/.claude/handoffs/2026-05-30-meta-annotation-quote-leak.md
+++ b/.claude/handoffs/2026-05-30-meta-annotation-quote-leak.md
@@ -1,0 +1,73 @@
+# Meta-annotation quote leak — "mercury on page 89"
+
+**Date:** 2026-05-30
+**Reported by:** Nirmal Patel
+**PRs:** #2232 (embed/snippet + librarian), #2233 (keyword surfaces + likes + shared helper + CLAUDE.md invariant)
+**Status:** code fix shipped; corpus snippet backfill in progress; paid re-embed deferred pending eval.
+
+## The report
+
+The librarian cited page 89 of Munisvara's *Siddhanta Sarvabhauma, Part Two*
+(`book/siddhanta-sarvabhauma-part-2-munisvara`, Mongo id `69907c485f855ec553e73532`)
+with the "quote":
+
+> "While the previous page focused on perpetual motion wheels using mercury, this page shifts toward water-driven mechanisms and the construction of the Armillary Sphere (Gola-yantra)…"
+
+…but "mercury" appears nowhere on page 89. The mercury wheel is on **page 88**;
+page 89's body is a water-driven armillary sphere.
+
+## Root cause
+
+That sentence is not a quote — it's the AI-written `<meta>` annotation describing
+page 89. Page text in `pages.{ocr,translation}.data` is wrapped in editorial
+blocks (`<meta>`, `<summary>`, `<keywords>`, `<vocab>`) that describe the page and
+often name adjacent-page content. Every text-cleaning path used the classic
+`replace(/<[^>]+>/g, '')` — strips the **tag** but keeps the **prose**. So the
+description was embedded into the page vector (why "mercury" ranked page 89) and
+served as a quotable snippet.
+
+## Why it was bigger than one page / one surface
+
+Search has multiple independent read surfaces, each with its own text cleaner;
+fixes don't propagate (see memory `project_search_three_surfaces`). Confirmed live
+via MCP after #2232:
+- `search_translations` (`/api/search`) and `search_within_book`
+  (`/api/books/[id]/search`) still returned meta prose as `snippet_type:"translation"`
+  across many books — Siddhanta Shiromani p759, Surya Siddhanta p369/370, etc.
+- `/api/likes/{popular,mine}` excerpts: meta sits at the field head, so the
+  excerpt *was* the meta description.
+
+## Fix
+
+- **`src/lib/strip-editorial-wrappers.ts`** — single shared helper. Strips
+  `<meta>/<summary>/<keywords>/<vocab>` content (paired + orphan), keeps inline
+  glosses (`note`/`term`/`margin`).
+- Wired into: `embed-gemini.mjs cleanText`, `librarian-search.ts`,
+  `semantic-alignment.ts` (#2232); `/api/search`, `/api/books/[id]/search`,
+  likes {popular,mine} main+tenant (#2233). `/api/learn` already stripped correctly.
+- Unit test: `tests/unit/strip-editorial-wrappers.test.ts`.
+- CLAUDE.md: new "Quote & snippet integrity — CRITICAL" invariant.
+
+## Backfill (decoupled, free)
+
+`scripts/maintenance/backfill-clean-snippets.mjs` re-derives the stored
+`page_translations.translation` snippet column from Mongo — **zero Gemini calls**,
+UPDATE-only (never touches the embedding). Existing rows had tags stripped at
+write time, so a read-time re-strip can't recover them; the Mongo re-derive is
+required for the **semantic** surface. (Keyword surfaces read Mongo live, so the
+code fix alone repairs them — no backfill needed there.)
+
+First `--full` attempt died silently: one find() cursor held open over 4M pages
+across slow Supabase writes timed out ("cursor not found"). Hardened to drive
+per-book (46K books, sorted, short cursors), restartable via `--after <bookId>`.
+Run: `set -a; source .env.production.local; set +a; node scripts/maintenance/backfill-clean-snippets.mjs --full --write`.
+
+## Open / follow-ups
+
+- **Paid re-embed?** ~$170 batch / $340 standard for the translation corpus
+  (`gemini-embedding-001`, $0.15/1M std, $0.075/1M batch). Only changes *ranking*
+  (a page that matched only via meta words can still rank, but no longer shows
+  meta as the quote). **Decide on a retrieval eval, not reflexively.**
+- **Atlas index still contains meta** — exclude editorial blocks from the
+  `pages` search index so meta-only matches stop ranking at all. Separate change.
+- The Munisvara book is already backfilled in prod as the proof case.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,16 @@ Image extraction emits two separate quality signals in the **same Gemini call**.
 
 A famous Kircher diagram has `gallery_quality: 0.9` whether the scan is pristine or microfilmed; the same diagram on microfilm has `scan_quality.scan_class: bitonal_microfilm` regardless of how gallery-worthy it is. See `/blog/what-makes-a-good-scan` for the user-facing version.
 
+## Quote & snippet integrity — CRITICAL
+Lessons from PRs #2232/#2233 (the "mercury on page 89" misquote — Nirmal, 2026-05-30).
+
+OCR/translation text in `pages.{ocr,translation}.data` is wrapped in AI-written **editorial annotation blocks**: `<meta>`, `<summary>`, `<keywords>`, `<vocab>`. These *describe* the page and routinely name content from **adjacent** pages ("the previous page focused on perpetual motion wheels using mercury…"). They are **never verbatim source** — quoting or embedding them fabricates citations to words that aren't on the page, which strikes at the core "read and quote the original" promise.
+
+- **Never serve `<meta>`/`<summary>`/`<keywords>`/`<vocab>` content as quotable text.** Strip the *content*, not just the tag. The classic bug is `replace(/<[^>]+>/g, '')` — it deletes the tag but keeps the editorial prose. Use `stripEditorialWrappers()` from `src/lib/strip-editorial-wrappers.ts` **before** any generic tag strip.
+- **Every search/snippet surface reads its own copy of the page text — fixes do NOT propagate.** Known text-cleaning paths: `/api/search`, `/api/books/[id]/search`, `src/lib/search/librarian-search.ts`, `src/lib/semantic-alignment.ts`, `scripts/workers/embed-gemini.mjs` (`cleanText`), `/api/likes/{popular,mine}` (+ tenant), `/api/learn`. Route them all through `stripEditorialWrappers`. When you add a new surface that snippets page text, wire it through too. (See [[project_search_three_surfaces]].)
+- **Inline glosses (`<note>`/`<term>`/`<margin>`/`<gloss>`/`<unclear>`) are NOT editorial wrappers** — they sit on real body text. Keep their content; they aid recall and reading.
+- **The leak is frozen into stored artifacts.** `page_translations.translation` (the semantic-search snippet column) and the embedding vectors were written by the old `cleanText`, so the editorial prose is baked in with the tags already gone — a read-time re-strip can't recover it. Re-derive the snippet column from Mongo with `scripts/maintenance/backfill-clean-snippets.mjs` (UPDATE-only, zero Gemini cost — does NOT touch embeddings). Re-embedding (paid) is separate and only changes *ranking*; decide it on an eval, not reflexively.
+
 ## System Map
 - **Interactive diagram:** https://sourcelibrary.org/platform/admin/system-map — click any node for details, key files, collections, gotchas (requires platform login)
 - **Markdown reference:** `.claude/docs/system-map.md` — full text version with file layout, collection inventory, dead code list

--- a/scripts/maintenance/backfill-clean-snippets.mjs
+++ b/scripts/maintenance/backfill-clean-snippets.mjs
@@ -60,14 +60,10 @@ async function main() {
   await mongo.connect();
   const db = mongo.db('bookstore');
 
-  const mongoFilter = BOOK_ID ? { book_id: BOOK_ID } : {};
   if (!BOOK_ID && !FULL) {
     console.error('Pass --book ID or --full');
     process.exit(1);
   }
-
-  const cursor = db.collection('pages')
-    .find(mongoFilter, { projection: { _id: 1, book_id: 1, page_number: 1, 'translation.data': 1, 'ocr.data': 1 } });
 
   let scanned = 0, changed = 0, written = 0, droppedTokens = 0, errors = 0;
   const samples = [];
@@ -116,20 +112,47 @@ async function main() {
     }
   }
 
-  let batch = [];
-  for await (const page of cursor) {
-    if (LIMIT && scanned >= LIMIT) break;
-    scanned++;
-    const raw = page.translation?.data || page.ocr?.data || '';
-    if (!raw) continue;
-    batch.push({ pageId: page._id.toString(), page_number: page.page_number, cleaned: cleanText(raw) });
-    if (batch.length >= SELECT_BATCH) {
-      await flush(batch);
-      batch = [];
-      if (scanned % 50000 === 0) console.log(`  …scanned ${scanned} | changed ${changed} | written ${written} | errors ${errors}`);
+  // Process ONE book at a time with a short-lived Mongo cursor. A single 4M-doc
+  // cursor held open across slow Supabase writes times out ("cursor not found")
+  // and the process dies mid-run with no summary — which is exactly what
+  // happened on the first attempt. Per-book cursors are hundreds of docs, so
+  // they finish fast; the loop is also restartable via --after.
+  async function processBook(bookId) {
+    const cursor = db.collection('pages')
+      .find({ book_id: bookId }, { projection: { _id: 1, page_number: 1, 'translation.data': 1, 'ocr.data': 1 } });
+    let batch = [];
+    for await (const page of cursor) {
+      if (LIMIT && scanned >= LIMIT) break;
+      scanned++;
+      const raw = page.translation?.data || page.ocr?.data || '';
+      if (!raw) continue;
+      batch.push({ pageId: page._id.toString(), page_number: page.page_number, cleaned: cleanText(raw) });
+      if (batch.length >= SELECT_BATCH) { await flush(batch); batch = []; }
+    }
+    if (batch.length) await flush(batch);
+  }
+
+  if (BOOK_ID) {
+    await processBook(BOOK_ID);
+  } else {
+    // --full: drive over book ids (small collection) rather than a giant pages cursor.
+    const AFTER = args.find((_, i, a) => a[i - 1] === '--after') || '';
+    const bookIds = (await db.collection('books')
+      .find({ id: { $exists: true } }, { projection: { id: 1 } })
+      .map(b => b.id).toArray())
+      .filter(Boolean)
+      .sort();
+    const start = AFTER ? bookIds.findIndex(id => id > AFTER) : 0;
+    const work = start < 0 ? [] : bookIds.slice(start);
+    console.log(`Books to process: ${work.length}${AFTER ? ` (resuming after ${AFTER})` : ''}`);
+    let bi = 0;
+    for (const bookId of work) {
+      if (LIMIT && scanned >= LIMIT) break;
+      await processBook(bookId);
+      bi++;
+      if (bi % 200 === 0) console.log(`  …${bi}/${work.length} books | scanned ${scanned} | written ${written} | errors ${errors} | last ${bookId}`);
     }
   }
-  if (batch.length) await flush(batch);
 
   console.log(`\nScanned ${scanned} pages | snippet changed: ${changed} | written: ${written} | errors: ${errors}${WRITE ? '' : ' (DRY RUN)'}`);
   console.log(`Words removed from snippets (editorial prose): ${droppedTokens}\n`);

--- a/src/app/api/[tenant]/likes/mine/route.ts
+++ b/src/app/api/[tenant]/likes/mine/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { auth } from '@/lib/auth';
 import { getReadDb } from '@/lib/mongodb';
 import { LikeTargetType } from '@/lib/types';
@@ -127,7 +128,7 @@ export async function GET(
           if (!page) return null;
           const book = booksMap.get(page.book_id);
           const rawText = page.translation?.data || page.ocr?.data || '';
-          const text = rawText.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+          const text = stripEditorialWrappers(rawText).replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
           return {
             id: page.id,
             pageNumber: page.page_number,

--- a/src/app/api/[tenant]/likes/popular/route.ts
+++ b/src/app/api/[tenant]/likes/popular/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { getReadDb } from '@/lib/mongodb';
 import { LikeTargetType } from '@/lib/types';
 import { buildCropUrl } from '@/lib/social-image-selector';
@@ -224,7 +225,7 @@ export async function GET(
           if (!page) return null;
           const book = booksMap.get(page.book_id);
           const rawText = page.translation?.data || page.ocr?.data || '';
-          const text = rawText.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+          const text = stripEditorialWrappers(rawText).replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
           return {
             id: page.id,
             pageNumber: page.page_number,

--- a/src/app/api/books/[id]/search/route.ts
+++ b/src/app/api/books/[id]/search/route.ts
@@ -3,6 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { buildPageSearchStage, NON_CONTENT_PAGE_TYPES } from '@/lib/atlas-search';
 import { semanticPageSearchScoped } from '@/lib/semantic-search';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 
 interface SearchMatch {
   field: 'ocr' | 'translation';
@@ -22,8 +23,8 @@ function escapeRegex(str: string): string {
 
 /** Strip XML/HTML tags and clean up formatting artifacts */
 function cleanText(text: string): string {
-  return text
-    .replace(/<[^>]+>/g, '')                    // strip all XML/HTML tags
+  return stripEditorialWrappers(text)           // drop <meta>/<summary>/<keywords>/<vocab> prose first
+    .replace(/<[^>]+>/g, '')                    // strip remaining tags, keep inner body text
     .replace(/\*\*([^*]+)\*\*/g, '$1')          // strip markdown bold
     .replace(/\*([^*]+)\*/g, '$1')              // strip markdown italic
     .replace(/original:\s*[^;]+;?\s*/gi, '')    // strip "original: Latin;" annotations

--- a/src/app/api/likes/mine/route.ts
+++ b/src/app/api/likes/mine/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { auth } from '@/lib/auth';
 import { getReadDb } from '@/lib/mongodb';
 import { LikeTargetType } from '@/lib/types';
@@ -139,7 +140,7 @@ export async function GET(request: NextRequest) {
           if (!page) return null;
           const book = booksMap.get(page.book_id);
           const rawText = page.translation?.data || page.ocr?.data || '';
-          const text = rawText.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+          const text = stripEditorialWrappers(rawText).replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
           return {
             id: page.id,
             pageNumber: page.page_number,

--- a/src/app/api/likes/popular/route.ts
+++ b/src/app/api/likes/popular/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { getReadDb } from '@/lib/mongodb';
 import { LikeTargetType } from '@/lib/types';
 import { buildCropUrl } from '@/lib/social-image-selector';
@@ -236,7 +237,7 @@ export async function GET(request: NextRequest) {
           const book = booksMap.get(page.book_id);
           const rawText = page.translation?.data || page.ocr?.data || '';
           // Strip XML tags (e.g. <meta>, <page-type>, <columns>) for clean excerpts
-          const text = rawText.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+          const text = stripEditorialWrappers(rawText).replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
           return {
             id: page.id,
             pageNumber: page.page_number,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -10,6 +10,7 @@ import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { withApiAuth } from '@/lib/api-auth';
 import { expandLanguages } from '@/lib/language-utils';
 import { logSearchQuery } from '@/lib/search-log';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 
 export const preferredRegion = 'fra1';
 
@@ -17,8 +18,8 @@ const MAX_PAGE_RESULTS = 25;
 
 /** Strip XML/HTML tags and clean up OCR artifacts for display */
 function cleanText(text: string): string {
-  return text
-    .replace(/<[^>]+>/g, '')        // strip all XML/HTML tags
+  return stripEditorialWrappers(text) // drop <meta>/<summary>/<keywords>/<vocab> prose first
+    .replace(/<[^>]+>/g, '')        // strip remaining tags, keep inner body text
     .replace(/\*\*([^*]+)\*\*/g, '$1') // strip markdown bold
     .replace(/\s+/g, ' ')           // collapse whitespace
     .trim();

--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -1,0 +1,35 @@
+/**
+ * Strip EDITORIAL page-level wrapper blocks — content and all — from
+ * OCR/translation text before it is embedded, indexed for snippets, or
+ * quoted back to a reader.
+ *
+ * The translation format wraps each page in AI-written <meta> / <summary> /
+ * <keywords> / <vocab> blocks that *describe* the page. They routinely name
+ * content from ADJACENT pages ("the previous page focused on perpetual motion
+ * wheels using mercury…"), so they are never verbatim source text. If the tag
+ * is stripped but the inner prose kept (the old `replace(/<[^>]+>/g, '')`
+ * mistake), that description gets embedded and served as a quotable snippet —
+ * producing citations to words that aren't on the page (Nirmal's "mercury on
+ * page 89" misquote, 2026-05-30; see PR #2232).
+ *
+ * Call this BEFORE the generic tag strip. Inline glosses (note/term/margin/
+ * gloss/unclear) are intentionally left for the caller to handle — they sit on
+ * real body text and are safe to keep.
+ *
+ * IMPORTANT: every search/snippet surface reads its own copy of the page text
+ * (web /api/search, /api/books/[id]/search, the librarian, embeddings, the
+ * eval). Fixes do NOT propagate between them — route every text-cleaning path
+ * through this helper so the leak can't reopen on one surface.
+ */
+
+const EDITORIAL_WRAPPERS = 'meta|summary|keywords|vocab';
+
+export function stripEditorialWrappers(text: string): string {
+  if (!text) return text;
+  return text
+    // Paired blocks, content and all (multiline). Backreference keeps it from
+    // swallowing text between two different wrapper types.
+    .replace(new RegExp(`<(${EDITORIAL_WRAPPERS})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
+    // Any orphan opening/closing wrapper tag left by malformed AI output.
+    .replace(new RegExp(`<\\/?(?:${EDITORIAL_WRAPPERS})>`, 'gi'), ' ');
+}

--- a/tests/unit/strip-editorial-wrappers.test.ts
+++ b/tests/unit/strip-editorial-wrappers.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+
+describe('stripEditorialWrappers', () => {
+  it('drops a <meta> block content-and-all', () => {
+    // The real page-89 misquote: the <meta> note names "mercury", which is on
+    // page 88, not 89. Stripping it must remove "mercury" entirely.
+    const page89 = `<meta>While the previous page focused on perpetual motion wheels using mercury, this page shifts toward water-driven mechanisms.</meta>\n\n...should be held in that <term>yantra</term>. When the interior space is filled with water...`;
+    const out = stripEditorialWrappers(page89);
+    expect(out).not.toMatch(/mercury/i);
+    expect(out).not.toMatch(/perpetual/i);
+    expect(out).toContain('filled with water');
+    expect(out).toContain('<term>yantra</term>'); // inline glosses survive
+  });
+
+  it('drops summary, keywords, and vocab blocks', () => {
+    const t = `body text <summary>AI description of the page</summary> more body <keywords>a, b, c</keywords> end <vocab>term1, term2</vocab>`;
+    const out = stripEditorialWrappers(t).replace(/\s+/g, ' ').trim();
+    expect(out).toBe('body text more body end');
+  });
+
+  it('handles multiline wrapper content', () => {
+    const t = `<meta>line one\nline two\nline three</meta>real body`;
+    expect(stripEditorialWrappers(t)).not.toMatch(/line (one|two|three)/);
+    expect(stripEditorialWrappers(t)).toContain('real body');
+  });
+
+  it('does not swallow body text between two different wrapper types', () => {
+    const t = `<meta>desc</meta>KEEP THIS BODY<keywords>k</keywords>`;
+    expect(stripEditorialWrappers(t)).toContain('KEEP THIS BODY');
+  });
+
+  it('removes orphan wrapper tags from malformed AI output', () => {
+    const t = `body <meta>unclosed description that runs to end of page`;
+    expect(stripEditorialWrappers(t)).not.toContain('<meta>');
+  });
+
+  it('is a no-op on text with no wrappers', () => {
+    const t = 'plain translated body with a <term>gloss</term>';
+    expect(stripEditorialWrappers(t)).toBe(t);
+  });
+});


### PR DESCRIPTION
## Why this exists (follow-up to #2232)

Live MCP testing after #2232 merged showed Nirmal's misquote **still reproduces** — and on more books than the one reported. The keyword search surfaces read raw Mongo `translation.data` and clean it with their own `cleanText()`, which stripped tags but kept the AI editorial prose. #2232 only fixed the embedding/snippet-column path and the librarian; these surfaces were untouched.

Examples returned live as `snippet_type:"translation"` (i.e. claimed quotable):
- Siddhanta Shiromani p759 — "While the previous page focused on mercury-driven wheels, this section transitions into hydraulic mechanisms…"
- Surya Siddhanta p369 — "It highlights the mechanical ingenuity required to create perpetual motion…"
- Munisvara p89 — the original report.

## Fix

- **`src/lib/strip-editorial-wrappers.ts`** — one shared helper. Per the three-surfaces lesson, every search/snippet path reads its own copy of the text and fixes don't propagate, so they now all route through this.
- Wired into `cleanText` in **`/api/search`** and **`/api/books/[id]/search`** (the two MCP keyword tools), and the excerpt builder in **likes {popular,mine}** main + tenant (meta sits at the field head, so the excerpt *was* the meta description).
- Unit test: page-89 case, multiline, cross-wrapper boundary, orphan tags, no-op.

`/api/learn` already stripped editorial content correctly — left as-is.

## Scope / out of scope
- This fixes the **quoted text** on every read surface. A page that matched *only* via meta words can still rank in Atlas keyword results (the index still contains meta) but will no longer show meta prose as the quote — it drops out (non-Atlas path) or shows body text. Excluding `<meta>` from the Atlas index is a separate follow-up.
- The Supabase snippet-column backfill (semantic surface) is tracked separately; the keyword surfaces fixed here don't use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)