### PR TITLE
fix(search): snippets from full field, not Atlas highlight fragments

### DIFF
--- a/src/app/api/[tenant]/books/[id]/search/route.ts
+++ b/src/app/api/[tenant]/books/[id]/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { resolveTenantId } from '@/lib/tenant-context';
 
 interface SearchMatch {
@@ -20,7 +21,11 @@ function escapeRegex(str: string): string {
 
 function generateSnippet(text: string, query: string, contextChars: number = 80): SearchMatch[] {
   const matches: SearchMatch[] = [];
-  const lowerText = text.toLowerCase();
+  // Strip editorial wrappers (<meta>/<summary>/<keywords>/<vocab>) AND remaining
+  // XML tags before searching/slicing — this route previously sliced raw text,
+  // so snippets carried both AI page-descriptions and markup.
+  const cleaned = stripEditorialWrappers(text).replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+  const lowerText = cleaned.toLowerCase();
   const lowerQuery = query.toLowerCase();
   const words = lowerQuery.split(/\s+/).filter(w => w.length > 0);
 
@@ -51,13 +56,13 @@ function generateSnippet(text: string, query: string, contextChars: number = 80)
 
   for (const pos of snippetPositions) {
     const start = Math.max(0, pos - contextChars);
-    const end = Math.min(text.length, pos + contextChars + query.length);
+    const end = Math.min(cleaned.length, pos + contextChars + query.length);
 
-    let snippet = text.slice(start, end);
+    let snippet = cleaned.slice(start, end);
 
     // Add ellipsis
     if (start > 0) snippet = '...' + snippet;
-    if (end < text.length) snippet = snippet + '...';
+    if (end < cleaned.length) snippet = snippet + '...';
 
     matches.push({
       field: 'ocr', // Will be set by caller

--- a/src/app/api/books/[id]/search/route.ts
+++ b/src/app/api/books/[id]/search/route.ts
@@ -142,26 +142,26 @@ export async function GET(
           const matches: SearchMatch[] = [];
 
           if (usedAtlas && Array.isArray(page.highlights) && page.highlights.length > 0) {
+            // Generate the snippet from the FULL field text, not from the Atlas
+            // highlight fragments. The fragments are a window around the hit, so
+            // when the hit lands inside a <meta>/<summary>/<keywords>/<vocab>
+            // block the fragment carries the editorial prose WITHOUT its wrapper
+            // tags — stripEditorialWrappers (which needs the tags) then can't
+            // remove it, and the AI page-description gets served as a quote (the
+            // "mercury on page 89" leak; PRs #2232/#2233 only fixed the full-field
+            // path). generateSnippet runs cleanText over the complete field, where
+            // both tags are present, so the block is stripped. If the only hit was
+            // inside an editorial block it's now gone, generateSnippet finds
+            // nothing, and the page correctly drops out of results.
+            const ocr = page.ocr as { data?: string } | undefined;
+            const translation = page.translation as { data?: string } | undefined;
             for (const hl of page.highlights as Array<{ path: string; texts: Array<{ value: string; type: string }> }>) {
               const field: 'ocr' | 'translation' = hl.path === 'translation.data' ? 'translation' : 'ocr';
-              const raw = cleanText(hl.texts.map(t => t.value).join(''));
-              // Cap highlight length — Atlas Search can return entire page content
-              const MAX_SNIPPET = 300;
-              let snippet = raw;
-              if (raw.length > MAX_SNIPPET) {
-                // Find the highlight hit (marked by type: 'hit') and center around it
-                const hitText = hl.texts.find(t => t.type === 'hit')?.value?.toLowerCase() || matchQuery.toLowerCase();
-                const hitPos = raw.toLowerCase().indexOf(hitText);
-                if (hitPos >= 0) {
-                  const half = Math.floor(MAX_SNIPPET / 2);
-                  const start = Math.max(0, hitPos - half);
-                  const end = Math.min(raw.length, hitPos + hitText.length + half);
-                  snippet = (start > 0 ? '...' : '') + raw.slice(start, end) + (end < raw.length ? '...' : '');
-                } else {
-                  snippet = raw.slice(0, MAX_SNIPPET) + '...';
-                }
-              }
-              matches.push({ field, snippet, position: 0 });
+              const fullData = (field === 'translation' ? translation?.data : ocr?.data) || '';
+              if (!fullData) continue;
+              const hitText = hl.texts.find(t => t.type === 'hit')?.value || matchQuery;
+              const snips = generateSnippet(fullData, hitText);
+              matches.push(...snips.map(m => ({ ...m, field })));
             }
           } else {
             const ocr = page.ocr as { data?: string } | undefined;

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -468,8 +468,18 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
           // Prefer translation highlights over OCR
           const translationHL = highlights.find(h => h.path === 'translation.data');
           const hl = translationHL || highlights[0];
-          snippet = cleanText(hl.texts.map(t => t.value).join(''));
           snippetType = hl.path === 'translation.data' ? 'translation' : 'ocr';
+          // Center on the Atlas hit but extract from the FULL field, not the
+          // highlight fragments. Fragments are a window around the hit, so a hit
+          // inside a <meta>/<summary>/<keywords>/<vocab> block arrives WITHOUT
+          // its wrapper tags and stripEditorialWrappers can't remove it — that
+          // leaked the AI page-description as a quote ("mercury on page 89").
+          // extractSnippet runs cleanText over the complete field (tags intact),
+          // so the block is stripped; if the hit was editorial-only it falls back
+          // to real body text rather than the description.
+          const fullData = (snippetType === 'translation' ? page.translation?.data : page.ocr?.data) as string || '';
+          const hitText = hl.texts.find(t => t.type === 'hit')?.value || matchQuery;
+          snippet = extractSnippet(fullData || hl.texts.map(t => t.value).join(''), hitText);
         } else {
           // Fallback to full text extraction
           const translationText = page.translation?.data as string || '';


### PR DESCRIPTION
## Why (third follow-up — #2232, #2233, this)

Live MCP testing **after #2233 deployed** showed the misquote still reproduced on `search_within_book` / `search_translations`. Page 137 (a `<keywords>` block) correctly went empty — proving the new code ran — but page 89's `<meta>` prose survived.

**Cause:** the Atlas keyword path built snippets from `searchHighlights` **fragments** (`hl.texts.join('')`) — a window around the hit. When the hit lands inside a `<meta>/<summary>/<keywords>/<vocab>` block, the fragment carries the editorial prose **without** its wrapper tags, so `stripEditorialWrappers` (which matches on tags) can't remove it. #2232/#2233 only fixed the full-field path.

## Fix
- `/api/search` and `/api/books/[id]/search`: in the Atlas branch, center on the Atlas hit but extract the snippet from the **complete field** (tags intact → wrapper stripped). Editorial-only hit ⇒ page drops or falls back to real body text, never the description.
- `/api/[tenant]/books/[id]/search`: its `generateSnippet` sliced **raw** text with no cleaning at all (leaked editorial prose *and* XML markup) — now routed through `stripEditorialWrappers` + tag strip, matching the main route.

## Verification
Will re-run the live MCP query on page 89 + the Shiromani/Surya cases once this deploys and confirm in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)