### PR TITLE
feat(book): surface earlier published translations on book pages

### DIFF
--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -399,6 +399,25 @@ export default function BibliographicInfo({
                       <p>
                         {firstTranslationDescription(book.translation_verification.disposition)}
                       </p>
+                      {(book.translation_verification.translations_found?.length ?? 0) > 0 && (
+                        <div className="space-y-1 pt-1">
+                          <span className="text-stone-400">Earlier translations</span>
+                          {book.translation_verification.translations_found!.map((t, i: number) => (
+                            <div key={i} className="pl-2">
+                              <span className="text-stone-300 italic">{t.english_title}</span>
+                              {t.translator && <span className="text-stone-400">, trans. {t.translator}</span>}
+                              {t.pub_year && <span className="text-stone-400"> ({t.pub_year})</span>}
+                              {t.publisher && <span className="text-stone-500">, {t.publisher}</span>}
+                              {t.completeness && t.completeness !== 'complete' && t.completeness !== 'unknown' && (
+                                <span className="text-stone-500"> &mdash; {t.completeness === 'partial' ? 'partial translation' : 'translated excerpts'}</span>
+                              )}
+                              {showExternalLinks && t.url && (
+                                <>{' '}<a href={t.url} target="_blank" rel="noopener noreferrer" className="text-accent-gold hover:text-accent-gold/80 underline">view</a></>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
                       {book.translation_verification.tools_called && (
                         <details className="cursor-pointer">
                           <summary className="text-accent-gold hover:text-accent-gold/80 underline">
@@ -414,19 +433,6 @@ export default function BibliographicInfo({
                             </p>
                             {book.translation_verification.reasoning && (
                               <p className="text-stone-400">{book.translation_verification.reasoning}</p>
-                            )}
-                            {(book.translation_verification.translations_found?.length ?? 0) > 0 && (
-                              <div>
-                                <span className="text-stone-500">Partial/related translations found:</span>
-                                {book.translation_verification.translations_found!.map((t, i: number) => (
-                                  <p key={i} className="text-stone-400 pl-2">
-                                    {t.english_title}{t.translator ? `, trans. ${t.translator}` : ''}{t.pub_year ? ` (${t.pub_year})` : ''}
-                                    {showExternalLinks && t.url && (
-                                        <>{' '}<a href={t.url} target="_blank" rel="noopener noreferrer" className="text-accent-gold hover:text-accent-gold/80 underline">source</a></>
-                                    )}
-                                  </p>
-                                ))}
-                              </div>
                             )}
                             <p className="text-stone-600 text-[10px]">
                               Verified {book.translation_verification.verified_at ? new Date(book.translation_verification.verified_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : ''} via {book.translation_verification.model || 'AI'}


### PR DESCRIPTION
## Why

When a reader lands on a work we've translated, and a published scholarly translation of part of it already exists, the honest and useful thing is to point them to it. This is the *ad fontes* / scholarly-accountability principle the library already follows for source scans and IIIF manifests — extended to prior translations.

Concretely: Robert Fludd's *Utriusque Cosmi Historia* is flagged as our first **complete** English translation, but partial translations exist (Peter Hauge's critical edition of the *Temple of Music*; translated excerpts in Godwin 1979 and Huffman 1992). Crediting them makes the 'first complete translation' claim *more* precise, not less.

## What

The book `translation_verification.translations_found[]` field already holds this data (translator, year, publisher, completeness, url), but it only rendered **inside a collapsed 'Verification evidence' disclosure that requires `tools_called` to be present** — so for most books it never showed at all.

This PR renders a visible **'Earlier translations'** subsection in `BibliographicInfo` whenever `translations_found` is populated, independent of `tools_called`. Each entry shows title, translator, year, publisher, a completeness label (*partial translation* / *translated excerpts*), and an external **view** link.

- **Tenant-safe:** the external link is gated by `showExternalLinks`, so it stays hidden on tenant subdomains (no off-subdomain leak).
- Removes the now-duplicate listing from the verification-evidence details (single source of truth).

## Data

The two UCH volumes have been populated with the verified prior translations (Hauge → Vol. 1 only; Godwin + Huffman → both). Data fill is independent of this UI change; the field already exists in the schema.

## Out of scope

- A reusable enrichment pass to populate `translations_found` across the rest of the corpus (the catalog-discovery pipeline misses section translations published under a different title, e.g. *Temple of Music* vs *Utriusque Cosmi Historia*). That's a separate, larger effort — worth a follow-up issue.

## Test

`npx tsc --noEmit` clean for the changed file (pre-existing `@types/d3` errors in unrelated carbon-ledger blog interactives remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)