### PR TITLE
analysis: Latin (USTC) census QC — error bars on the ~2%

### DIFF
--- a/docs/translation-gap-census-paper/latin-qc-audit.md
+++ b/docs/translation-gap-census-paper/latin-qc-audit.md
@@ -1,0 +1,67 @@
+# Manual QC audit — Latin (USTC) census, error bars (2026-05-31)
+
+Mirror of the Siku Quanshu QC, applied to the Latin half. The Latin ~2% rests on
+**author-surname matching** (USTC author ↔ translation-catalogue author, + 120+
+Latin→English aliases): 499,607 Latin editions / 362,263 distinct works / 49,306
+authors → 2.18% of authors with ≥1 translation, ~0.99% of works (estimated),
+12.83% of editions by a translated author. The flag `ustc_editions.has_english_
+translation` is **author-derived** (one translated work flags all that author's
+editions). Goal: put error bars on this via two hand-audits.
+
+## Audit A — precision of the flag at the *work* level (n=25 flagged-true)
+
+Sampled 25 editions flagged translated; hand-checked whether *this specific work*
+has an English translation.
+
+- **~17–18 genuine** (≈70%): Tacitus *Agricola*, Kempis *Imitatio Christi*,
+  Terence (comedies/Flores ×3), Cicero *Rhetorica*, Ausonius (Loeb), Ovid
+  *Metamorphoses* speeches, Tertullian *De Pallio*, Cassian *Conferences*, Hermes
+  *Pimander* (Copenhaver), Euclid *Elements* defs, Erasmus *De conscribendis
+  epistolis* / *Colloquies* / *Paraphrase on John* (CWE).
+- **~7 false positives** (≈30%): minor works of translated authors not themselves
+  translated — Grotius's wedding poem (*Carmen in domumductionem*), Erasmus's
+  grammar *De octo partium orationis*, Durand's legal *Speculum* (3rd/4th parts),
+  Vossius's *Latina grammatica*, Dorat's funeral oration — plus **same-surname
+  collisions**: an *almanac* by "Regnerus Agricola" (flagged via a translated
+  Agricola), "Andrew Hunter" *Pyramis Germano-Britannica*.
+
+→ **Author-flag work-level precision ≈ 70%.** It overcounts because translated
+authors have many untranslated minor works, and because surname matching collides
+across distinct people.
+
+## Audit B — base-rate sanity (n=50 random Latin works)
+
+A random edition-drawn, dedup-to-works sample: 41/50 unflagged are
+**confirmed-pattern untranslated** (almanacs, funeral/commemorative orations,
+university dissertations, papal bulls, polyglot dictionaries, local histories) —
+the genuine obscure bulk. The 9 flagged are all famous authors (Cicero, Erasmus,
+Poliziano, Boethius, Alciati); hand-checked ~4–5 are real work-level translations.
+
+## Key methodological finding: the sampling *unit* dominates the rate
+
+**Edition-weighted sampling over-represents translated works**, because famous
+(translated) authors have far more editions than obscure ones. A clean work-level
+rate needs **work-uniform sampling** from the 362,263 distinct works, not
+edition-drawn sampling. The census's ~0.99% work figure is an *estimate* derived
+from author counts, not a directly-sampled work rate.
+
+## Error-bar conclusion (Latin)
+
+The Latin work-level rate is **~1–2%**, order-of-magnitude robust (the obscure
+bulk is genuinely untranslated), but the precise figure is **unit-sensitive** and
+the author-flag has **~70% work-level precision** with **unmeasured recall**
+(name-match failures for genuinely-translated lesser authors cut the other way).
+A defensible published figure needs the same gold-standard as Chinese:
+**work-uniform sampling + per-work verification**.
+
+This is the same lesson both corpora teach — heuristic matching (author names for
+Latin, titles for Chinese) has limited precision/recall, so the honest rate
+requires per-work human verification. That convergence *strengthens* the paper's
+method argument and the headline (~2% Latin, ~1–2% Chinese).
+
+## Next (paper checklist)
+- Build a **work-uniform** Latin sampler (dedup works first, sample from works)
+  and run a per-work verification (web/OpenLibrary + LLM adjudication) for a
+  directly-measured rate + Wilson CI.
+- Quantify flag **recall**: sample flagged-*false* works by mid-tier authors and
+  check for missed translations (the name-match-failure direction).

--- a/scripts/analysis/latin-qc-base-sample.json
+++ b/scripts/analysis/latin-qc-base-sample.json
@@ -1,0 +1,402 @@
+[
+ {
+  "id": 112979,
+  "author_1": null,
+  "title": "Mirabilis liber qui prophetias revelationes ",
+  "year": 1523,
+  "classification_1": "Almanacs, Calendars and Prognostications",
+  "has_english_translation": false
+ },
+ {
+  "id": 1624200,
+  "author_1": "Giorgio Baglivi, Alessandro Pascoli",
+  "title": "De circulatione sanguinis in testudine, ejusdemque cordis anatome",
+  "year": 1700,
+  "classification_1": "Medical Texts",
+  "has_english_translation": false
+ },
+ {
+  "id": 234319,
+  "author_1": "Cicero, Marcus Tullius",
+  "title": "Consularis in topica Ciceronis, commentariorum libri sex quibus vix aliud in philosophia aut acutum aut utile magis extat.",
+  "year": 1531,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 1624017,
+  "author_1": "Arcturi, Claudius",
+  "title": "Axiomaticum prognosticon anni 1523 per Claudium Arcturum.",
+  "year": 1523,
+  "classification_1": "Almanacs, Calendars and Prognostications",
+  "has_english_translation": false
+ },
+ {
+  "id": 756961,
+  "author_1": null,
+  "title": "Animantium terbestrium, volatilium, et aquatilitm effigies ad vivum depictae, una cum eorundem Latinis et Germanicis nomenclaturis. Gethier fisch und gefluegels allerhandt gar artlich abconterfeyt und fürgemalet.",
+  "year": 1562,
+  "classification_1": "Agriculture",
+  "has_english_translation": false
+ },
+ {
+  "id": 586803,
+  "author_1": "Sorin, Tanneguy",
+  "title": "De jurisdictione commentarii, via, arte, et ratione docendi, discendique confecti ",
+  "year": 1567,
+  "classification_1": "Jurisprudence",
+  "has_english_translation": false
+ },
+ {
+  "id": 778003,
+  "author_1": "Malafossa, Giacobino",
+  "title": "Orationis dominicalis expositio. Per excellentiss. Iacobinum Barges minoritanum primum Patavii, deinde in Monteregali, postemo Taurini metaphisicam publicè profitentem",
+  "year": 1571,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 417969,
+  "author_1": null,
+  "title": "Annales regum Francorum,pipini,caroli magni et lodouici: ab anno 741. Usque ad annum 829.aut. Quidem incerto,sed docto,benedictinae religionis monacho. Item, Caroli cognomento magni, imperatoris occidentalis primi vita et gesta",
+  "year": 1562,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 636217,
+  "author_1": "Angelomus (Luxoviensis)",
+  "title": "Angelomi monachi lvxoviensis ordinis divi Benedicti, autoris vetusti, et in abstrusis scripturarum locis eruendis explicandisque ingenii acerrimi viuacissimique, enarrationes in cantica canticorum miro artificio elaboratae, ac iam primum typis axcusae.",
+  "year": 1531,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 255313,
+  "author_1": "Tyard, Pontus de",
+  "title": "De coelestibus asterismis poematium ",
+  "year": 1573,
+  "classification_1": "Poetry",
+  "has_english_translation": false
+ },
+ {
+  "id": 437044,
+  "author_1": "Calepino, Ambrogio",
+  "title": "Dictionarium decem linguarum ",
+  "year": 1586,
+  "classification_1": "Dictionaries",
+  "has_english_translation": false
+ },
+ {
+  "id": 616051,
+  "author_1": "Maiorano, Ludovico",
+  "title": "Clypeus militantis ecclesiae seu De vero Dei cultu libri tres Ludovico Maiorano Grauinate canonico regulari lateranensi authore. Eiusdem De opt. reip. statu oratio quam misit ad patres in Concilio Tridentino",
+  "year": 1575,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 509029,
+  "author_1": null,
+  "title": "Annales regum Francorum, pipini, Caroli magni et lodouici: ab anno 741. Usque ad annum 829.aut.quidem incerto.sed docto,benedictinae religionis monacho. Item, Caroli cognomento magni,imperatoris occidentalis primi vita et gesta.autore eginharto Germano,ipsius Caroli alumno. Caroli cognomento magni imperatoris occidentalis primi vita et gesta vita et gesta Caroli magni",
+  "year": 1561,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 467303,
+  "author_1": "Malfanti, Genesio",
+  "title": "Civilis philosophiae compendium",
+  "year": 1586,
+  "classification_1": "Philosophy and Morality",
+  "has_english_translation": false
+ },
+ {
+  "id": 1134711,
+  "author_1": "Thülden, Christian Adolph",
+  "title": "Historiae Nostri Temporis Pars 2: Ab Anno Christi M.DC.LV. usque ad M.DC.LVII. Qua In Germania res gestae describuntur",
+  "year": 1657,
+  "classification_1": "History and Chronicles",
+  "has_english_translation": false
+ },
+ {
+  "id": 751719,
+  "author_1": "Maldonado, Juan",
+  "title": "Commentarii in quattuor evangelistas nunc primum in lucem editi, et in duos tomos divisi. Quorum prior eos, qui in Matthaeum, & Marcum; posterior eos, qui in Lucam, & Ioannem, complectitur",
+  "year": 1597,
+  "classification_1": "Religious",
+  "has_english_translation": true
+ },
+ {
+  "id": 948782,
+  "author_1": "Primke, Christian",
+  "title": "Asylum Ligniciense heu! Corruit. Hoc est: Serenissimus Dn. Ludovicus, Dux Silesiae Ligniciensis, Bregens. & Goldbergensis, A. C. MDCLXIII. D. XXIV. Novemb. Eheu! Luctuosissimam Suis Omnibus mortem Obiit. Quem Desideratissimum Principem, Asylo iure comparatum, In Ephebeo Ligniciensi, XIV. Martii, tertio, a coeptis Illustribus Exsequiis, Die, A. C. MDCLXIV, Coram Splendidissima frequentissimaque Panegyri ..., M. Christianus Primkius P. L. C. Eiusd. Ludi Rector.",
+  "year": 1664,
+  "classification_1": "Funeral Orations",
+  "has_english_translation": false
+ },
+ {
+  "id": 783996,
+  "author_1": "Poliziano, Angelo",
+  "title": "Silua: cui titulus rusticus: in poetae hesiodi: Vergiliique Georgicon enarratione pronunciata.",
+  "year": 1521,
+  "classification_1": null,
+  "has_english_translation": true
+ },
+ {
+  "id": 529069,
+  "author_1": "Malaspina, Giovanni Battista",
+  "title": "Illustri iurisperito eloquentissimo domino Baylardino Nogarollae, comiti Veronensi, dignissimo, et domino suo colendissimo",
+  "year": 1590,
+  "classification_1": null,
+  "has_english_translation": false
+ },
+ {
+  "id": 289468,
+  "author_1": "Poliziano, Angelo",
+  "title": "Sylva, cui titulus est rusticus, cum docta elegantissimáque Nicolai beral di interpretatione.",
+  "year": 1518,
+  "classification_1": null,
+  "has_english_translation": true
+ },
+ {
+  "id": 515779,
+  "author_1": "Robin du Faux, Paschal",
+  "title": "Lamentatio in obitum illustrissimi et omni laude cumulatissimi Timoleontis Cossaei, comitis Brissacci ",
+  "year": 1569,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 968709,
+  "author_1": "Meinhart, Georg Friedrich",
+  "title": "De Nasiraeis Dissertatio Philologica Tertia, Quam Benivolo Superiorum in illustri Academia Ienensi indultu, Praeses M. Georgius Fridericus Meinhardus, Arnstadiensis, & Respondens Daniel Valentinus Weihe, Francohusa-Thuringus, Publicae hierologophilōn disquisitioni submittunt Ad d. Iunii Anno M.DC.LXXVI.",
+  "year": 1676,
+  "classification_1": "University Publications",
+  "has_english_translation": false
+ },
+ {
+  "id": 137155,
+  "author_1": "Passerat, Jean",
+  "title": "In Adriani Turnebi obitum ",
+  "year": 1565,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 271024,
+  "author_1": "Scultetus, Abraham",
+  "title": "Psalmus Vigesimus Waldsassii explicatus in superiori Electorali Palatinatu 14.,24. 10. Anno 1619. Cum ... Friderico, Regi Bohemiae, Comiti Palatino Rheni Et Electori ... antegressa Electio denunciata, [et] ab ipsius Maiestate esset acceptata , Ab Abrahamo",
+  "year": 1620,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 655667,
+  "author_1": "Henri IV",
+  "title": "In paricidas regum et Jesuitas paricidarum impulsores et in paedotribas plagiarios ",
+  "year": 1595,
+  "classification_1": "Religious",
+  "has_english_translation": true
+ },
+ {
+  "id": 155366,
+  "author_1": "Cicero, Marcus Tullius",
+  "title": "Les epistres familieres ",
+  "year": 1585,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 698975,
+  "author_1": "Malfanti, Genesio",
+  "title": "Civilis philosophiæ compendium. In quo quidquid in libris Ethicorum, Politicorum, & Oeconomic. disservit Aristoteles, dilucide perstringitur, & ad eorum librorum intelligentiam facilis via paratur",
+  "year": 1587,
+  "classification_1": "Philosophy and Morality",
+  "has_english_translation": false
+ },
+ {
+  "id": 12758,
+  "author_1": "Grosse, Matthias",
+  "title": "Angelodrakontomachia sive Michaelis cum lucifero bellum scriptum ad amplissimum virum Christophorum Wernerum ciuem Halberstadensem, gratitudinis ergò à Matthia grosio Halberstaensi.",
+  "year": 1578,
+  "classification_1": null,
+  "has_english_translation": false
+ },
+ {
+  "id": 1400704,
+  "author_1": null,
+  "title": "Joseph aegypti Prorex Primae Infulae Adm[odum] R[everen]di D[omi] ni Emerici Luctor, Abbatis B[eat]ae Mariae Virginis Annunciatae de Gágy, Custodis",
+  "year": 1651,
+  "classification_1": "University Publications",
+  "has_english_translation": false
+ },
+ {
+  "id": 106574,
+  "author_1": null,
+  "title": "Bulla sanctissimi domini nostri domini Clementis Papae 8. confirmationis privilegiorum religionis S. Ioannis Hierosolymitani",
+  "year": 1592,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 579281,
+  "author_1": "Malloni, Giovanni Tommaso",
+  "title": "De principiis. Causisque rerum naturalium conclusiones",
+  "year": 1599,
+  "classification_1": null,
+  "has_english_translation": false
+ },
+ {
+  "id": 625358,
+  "author_1": "Calepino, Ambrogio",
+  "title": "Dictionarium undecim linguarum ",
+  "year": 1598,
+  "classification_1": "Dictionaries",
+  "has_english_translation": false
+ },
+ {
+  "id": 45830,
+  "author_1": null,
+  "title": "Priuilegia Ordinis s. Io. Hierosolimitani",
+  "year": 1564,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 1623984,
+  "author_1": null,
+  "title": "Officia propria sanctorum camaldvlensium quae in breviario monastico desiderantur, ad usum congregationis eremitarum camaldulensium Montis Coronae.",
+  "year": 1650,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 272324,
+  "author_1": "Vredeman de Vries, Hans",
+  "title": "Architectura ou bastiment, prins de Vitruve et des anchiens escrivains, traictant sur les cincq ordres des columnes",
+  "year": 1577,
+  "classification_1": "Art and Architecture",
+  "has_english_translation": false
+ },
+ {
+  "id": 550604,
+  "author_1": null,
+  "title": "Laurus Prima [et] suprema Philosophiae Illa Tubingae Anno 1618. Die 26. 09.a ... M. Zacharia Schaeffero Oratoriae [et] Historiar. P. P. Haec Altorpii. Anno 1621. pridie Kalend. Iuni[i]. Rectore ... Christiano Matthia, SS. Theolog. Doctore Celeberrimo [et]",
+  "year": 1621,
+  "classification_1": "News Books",
+  "has_english_translation": false
+ },
+ {
+  "id": 85323,
+  "author_1": "Alciati, Andrea",
+  "title": "In tres posteriores codicis Justiniani annotationes. In quibus obiter qua plurima aliorum authorum loca explanantur. Eiusdem opusculum, quo Graece dictiones fere ubique in digestis restituuntur.",
+  "year": 1515,
+  "classification_1": "Jurisprudence",
+  "has_english_translation": true
+ },
+ {
+  "id": 910443,
+  "author_1": "Calixt, Friedrich Ulrich",
+  "title": "Exercitatio Theologica De Creatione, Quam Praeside Friderico Ulrico Calixto, S. Th. D. Eiusdemque In Acad. Iulia Publ. Et Ordin. Professore. In Iuleo Maiori die Martii Tuebitur Henricus Ernestus Otto Osterodensis",
+  "year": 1664,
+  "classification_1": "University Publications",
+  "has_english_translation": false
+ },
+ {
+  "id": 561083,
+  "author_1": "Malaspina, Leonardo",
+  "title": "Oratio, in funere Francisci cardinalis Gonzagae, Mantuae habita, Non. Feb. MDLXVI. Huic adiectae sunt epistolae consolatoriae ad eundem duae, altera de obitu Herculis card. patrui, altera sororis Hippolytae",
+  "year": 1566,
+  "classification_1": "Funeral Orations",
+  "has_english_translation": false
+ },
+ {
+  "id": 107635,
+  "author_1": "Baïf, Jean-Antoine de",
+  "title": "De profectione et adventu Henrici regis Polonorum ",
+  "year": 1574,
+  "classification_1": "Poetry",
+  "has_english_translation": false
+ },
+ {
+  "id": 50893,
+  "author_1": "Cigauld, Vincent",
+  "title": "Opus laudabile et aureum, facta principum, prelatorum et baronum, judicum et subditorum, nec non jurisditionum eorundem determinans, junctis infinitis questionibus super ytalico bello",
+  "year": 1516,
+  "classification_1": "Jurisprudence",
+  "has_english_translation": false
+ },
+ {
+  "id": 444344,
+  "author_1": "Boethius, Anicius Manlius Severinus",
+  "title": "Anitii manlii seuerini boetii viri clarissimi elegantissimus divisionum liber.",
+  "year": 1508,
+  "classification_1": null,
+  "has_english_translation": true
+ },
+ {
+  "id": 597789,
+  "author_1": null,
+  "title": "Epistolae Friderici Ante Hac Electoris Nunc Exulis : Iam Olim Ad Varios Scriptae Missae Que Sed Hoc Demum Anno 1621. erutae Atque Ab Eodem Friderico, Tanquam A Redivivo Ovidio Usurpatae ",
+  "year": 1621,
+  "classification_1": "Literature",
+  "has_english_translation": false
+ },
+ {
+  "id": 1134729,
+  "author_1": "Weise, Christian",
+  "title": "Lanienam Stocholmiensem D. VIII. Nov. MDXX. A Christierno II. Dan. R. Susceptam, In Illustri Augusteo Moderatore M. Christiano Weisio, P.P. Ad d. 15. Decembr. MDCLXXVI. aliquot Oratiunculis ventilabunt Johannes Augustus Fischer, Longo-Salissanus. Christian Fridericus Vockel, Weissenfelsensis. Christianus Vockel, Sangerhusanus",
+  "year": 1676,
+  "classification_1": "University Publications",
+  "has_english_translation": false
+ },
+ {
+  "id": 328513,
+  "author_1": "Barth, Michael",
+  "title": "Annaeberga. Libri tres, quibus continetur urbis Annaebergae in Misnia descriptio, ortus, & positus: conscripti versibus à Michaele barth, ciue grato et amante patriae. Quibus accesserunt, Joannis saliani de eadem urbe & sylva hercynia libellus. H.eobani Hessi elegia. Joachimi camerarii pab.elegia hodoiporike metallaria",
+  "year": 1557,
+  "classification_1": null,
+  "has_english_translation": false
+ },
+ {
+  "id": 95282,
+  "author_1": "Erasmus, Desiderius",
+  "title": "De octo partium orationis constructione libellus ",
+  "year": 1541,
+  "classification_1": "Educational Books",
+  "has_english_translation": true
+ },
+ {
+  "id": 7780,
+  "author_1": "Malafossa, Giacobino",
+  "title": "Super primum Senten. doctoris subtilis theologorum principis Ioannis Scoti exactissima enarratio absolutissimaque expositio. In qua centum, & triginta Contradictiones Scoti, quæ in hoc primo hactenus latitarunt, acie ingenii luculenter dissoluuntur. Duo demum horum onmium extant indices: quorum alter Contradictionum summas continet: alter, & quidem refertissimus; omnia, quæ in hoc libro scitu digna iudicantur, accuratissime demonstrat. Opus modo recens et natum, et excussum",
+  "year": 1560,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ },
+ {
+  "id": 638157,
+  "author_1": null,
+  "title": "Discursus Politico-Iuridicus De Armorum Inter Caesarem Romanum Ferdinandum II. Daniae Regem Christianum IV. [et] Status circuli inferioris Saxoniae, Iustitia, [et] quid de ea statuendum sit : Post tentatam Brunswigae Anno 1625. sed irritam factam pacifica",
+  "year": 1628,
+  "classification_1": "Government and Political Thought",
+  "has_english_translation": false
+ },
+ {
+  "id": 207438,
+  "author_1": "Sagittarius, Thomas",
+  "title": "Oratio Historico-Poetica Fridericum Regem Bohemorum. Ducem Silesiorum [etc] Breslam accedentem, ibidem commorantem, ab eadem discedentem excipiens, describens prosequens",
+  "year": 1620,
+  "classification_1": "Commemorative Events",
+  "has_english_translation": false
+ },
+ {
+  "id": 230826,
+  "author_1": null,
+  "title": "Bulla sanctissimi domini nostri domini Gregorii papae XIIII confirmationis privilegiorum religionis sancti Ioannis Hierosolymitani",
+  "year": 1591,
+  "classification_1": "Religious",
+  "has_english_translation": false
+ }
+]

--- a/scripts/analysis/latin-qc-flagged-sample.json
+++ b/scripts/analysis/latin-qc-flagged-sample.json
@@ -1,0 +1,202 @@
+[
+ {
+  "id": 650807,
+  "author_1": "Grotius, Hugo",
+  "title": "Carmen in domumductionem nobilissimæ lectissimæque Mariæ van der Duyn viro prelustri Reginaldo Brederodio noviter nuptæ",
+  "year": 1603,
+  "classification_1": "Wedding Pamphlets",
+  "has_english_translation": true
+ },
+ {
+  "id": 165917,
+  "author_1": "Dorat, Jean",
+  "title": "Remigii Bellaquei Poetae Tumulus ",
+  "year": 1577,
+  "classification_1": "Funeral Orations",
+  "has_english_translation": true
+ },
+ {
+  "id": 121841,
+  "author_1": "Ausonius, Decimus Magnus",
+  "title": "Omnia, quae adhuc in veteribus bibliothecis inveniri potuerunt opbra (sic!). Adhaec. Symmachi, et Pontii Paulini litterae ad Ausonium scriptae, tum Ciceronis, Supliciae, aliorumque quorumdam veterum carmina nonnulla",
+  "year": 1589,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 337516,
+  "author_1": "Erasmus, Desiderius",
+  "title": "Opus de conscribendis epistolis, ex postrema autoris recognitione emendatius aeditu. Cum annotationibus marginalibus, quae partim artificiu, partim autorum locos explicant. Et indice locupletiore.",
+  "year": 1532,
+  "classification_1": "Educational Books",
+  "has_english_translation": true
+ },
+ {
+  "id": 426813,
+  "author_1": "Agricola, Regnerus",
+  "title": "Arumer almanach, op't iaer M. DC. XLV",
+  "year": 1645,
+  "classification_1": "Almanacs, Calendars and Prognostications",
+  "has_english_translation": true
+ },
+ {
+  "id": 569798,
+  "author_1": "Ovidius Naso, Publius",
+  "title": "Orationes Aiacis et Ulyxis, contendentium de armis Achillis, ex XIII. Metamorphoseos",
+  "year": 1575,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 556187,
+  "author_1": "Tacitus, Cornelius",
+  "title": "Agricola",
+  "year": 1642,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 283057,
+  "author_1": "Cicero, Marcus Tullius",
+  "title": "Rhetorica cum commento. Rhetoricum libri quatuor",
+  "year": 1531,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 801783,
+  "author_1": "Kempis, Thomas à",
+  "title": "De imitatione Christi libri quator",
+  "year": 1622,
+  "classification_1": "Religious",
+  "has_english_translation": true
+ },
+ {
+  "id": 126674,
+  "author_1": "Erasmus, Desiderius",
+  "title": "Apologia posterior, quae nihil habet neque nasi neque dentis neque stomachi neque ungium, respondet duabus invectivis eduardi lei apologia, qua respondet duabus invectivis eduardi lei D. Erasmi ro. Apologiae duae. In priore palam re fellit quorudam seditiosos clamores apud populu, et magnates in posteriore, quae nihil habet, neque nasi, neque dentis, neque stomachi, neque unguium, rñdet duabus invectiuis eduardi lei",
+  "year": 1520,
+  "classification_1": "Political Tracts",
+  "has_english_translation": true
+ },
+ {
+  "id": 11931,
+  "author_1": "Tertullianus, Quintus Septimus Florentius",
+  "title": "Liber de Pallio ",
+  "year": 1600,
+  "classification_1": "Religious",
+  "has_english_translation": true
+ },
+ {
+  "id": 438403,
+  "author_1": "Cassianus, Johannes",
+  "title": "De lib. Arbitrio collatio.",
+  "year": 1528,
+  "classification_1": "Religious",
+  "has_english_translation": true
+ },
+ {
+  "id": 95282,
+  "author_1": "Erasmus, Desiderius",
+  "title": "De octo partium orationis constructione libellus ",
+  "year": 1541,
+  "classification_1": "Educational Books",
+  "has_english_translation": true
+ },
+ {
+  "id": 543688,
+  "author_1": "Hermes Trismegistus",
+  "title": "Pimandras utraque lingua restitutus. Ad Maximilianum Caesarem eius nominis quartum",
+  "year": 1574,
+  "classification_1": "Linguistics and Philology",
+  "has_english_translation": true
+ },
+ {
+  "id": 383847,
+  "author_1": "Erasmus, Desiderius",
+  "title": "Opus de conscribendis epistolis, quod quidam & mendosum, & mutilum aediderant, recognitum ab autore & locupletatum. Parabolarum sive similium liber, ab autore recognitus",
+  "year": 1522,
+  "classification_1": "Educational Books",
+  "has_english_translation": true
+ },
+ {
+  "id": 128738,
+  "author_1": "Terentius Afer, Publius",
+  "title": "Flores",
+  "year": 1596,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 456810,
+  "author_1": "Terentius Afer, Publius",
+  "title": "Omni interpretationis genere in adolescentulorum gratiam facilior effecta ",
+  "year": 1547,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 607348,
+  "author_1": "Durand, Guillaume",
+  "title": "Tertia et quarta pars speculi cum additionibus cum suo repertorio facilius et utilius qua antea singulares materias demonstrante",
+  "year": 1531,
+  "classification_1": "Jurisprudence",
+  "has_english_translation": true
+ },
+ {
+  "id": 457527,
+  "author_1": "Terentius Afer, Publius",
+  "title": "Comoediae sex]",
+  "year": 1606,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 795171,
+  "author_1": "Erasmus, Desiderius",
+  "title": "Paraphrasis in evangelium secundum Joannem, ad illustrissimum principem ferdinandum nunc primum excusa.",
+  "year": 1523,
+  "classification_1": "Religious",
+  "has_english_translation": true
+ },
+ {
+  "id": 321105,
+  "author_1": "Hunter, Andrew",
+  "title": "Pyramis Germano-Britannica, spiritu sancto architecto, Salomone rege amanuensi hneusto nuptijs superstructa. Quam Frederico & Elizabetha pricipibus Palatinis consecrat",
+  "year": 1613,
+  "classification_1": "Art and Architecture",
+  "has_english_translation": true
+ },
+ {
+  "id": 403663,
+  "author_1": "Erasmus, Desiderius",
+  "title": "Familiarium colloquiorum opus, ut postremum a frobenio est editum, ipsius auctoris manu recognitum: doctissimis etiam scholiis nunc recens illustratum. Brevis eiusdem auctoris vita. Adiecto rerum et verborum memorabilium indice locupletissimo.",
+  "year": 1599,
+  "classification_1": "Educational Books",
+  "has_english_translation": true
+ },
+ {
+  "id": 71453,
+  "author_1": "Vossius, Gerardus Johannes",
+  "title": "Latina grammatica contracta. In usum scholarum",
+  "year": 1649,
+  "classification_1": "Linguistics and Philology",
+  "has_english_translation": true
+ },
+ {
+  "id": 448653,
+  "author_1": "Euclides",
+  "title": "Definitiones elementi quincti et sexti",
+  "year": 1575,
+  "classification_1": "Classical Authors",
+  "has_english_translation": true
+ },
+ {
+  "id": 530730,
+  "author_1": "Thomas Aquinas, St",
+  "title": "In Heremiam commentaria",
+  "year": 1531,
+  "classification_1": "Religious",
+  "has_english_translation": true
+ }
+]

--- a/scripts/analysis/latin-translation-qc.mjs
+++ b/scripts/analysis/latin-translation-qc.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Latin (USTC) translation census — QC sampler for error bars
+ *
+ * The Latin ~2% figure rests on author-surname matching (USTC author ↔
+ * translation-catalogue author + Latin→English aliases). This script pulls two
+ * samples for a manual error-bar audit (mirror of the Siku Quanshu QC):
+ *   A) flagged-true sample — editions where ustc_editions.has_english_translation
+ *      is true; hand-check whether THIS work is actually translated (flag
+ *      precision at the work level).
+ *   B) base-rate sample — random Latin editions, deduped to works; hand-check
+ *      the base rate.
+ *
+ * Finding (see docs/translation-gap-census-paper/latin-qc-audit.md): the
+ * author-flag is ~70% precise at the work level (translated authors have many
+ * untranslated minor works; surname collisions); and edition-weighted sampling
+ * over-represents translated works — a clean work-level rate needs work-uniform
+ * sampling + per-work verification.
+ *
+ * Read-only against the public Supabase (secondrenaissance). Writes sample JSON
+ * for the manual audit. Usage: node scripts/analysis/latin-translation-qc.mjs
+ */
+import { writeFileSync } from 'fs';
+
+const URL = 'https://ykhxaecbbxaaqlujuzde.supabase.co';
+const KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlraHhhZWNiYnhhYXFsdWp1emRlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjUwNjExMDEsImV4cCI6MjA4MDYzNzEwMX0.O2chfnHGQWLOaVSFQ-F6UJMlya9EzPbsUh848SEOPj4';
+const H = { apikey: KEY, Authorization: `Bearer ${KEY}` };
+const SEL = 'id,author_1,title,year,classification_1,has_english_translation';
+const SEED = 42;
+
+function mulberry32(a) {
+  return () => { a |= 0; a = (a + 0x6D2B79F5) | 0; let t = Math.imul(a ^ (a >>> 15), 1 | a); t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t; return ((t ^ (t >>> 14)) >>> 0) / 4294967296; };
+}
+async function page(extra, off, lim) {
+  const u = `${URL}/rest/v1/ustc_editions?language_1=eq.Latin&select=${SEL}&order=sn.asc&offset=${off}&limit=${lim}${extra}`;
+  const r = await fetch(u, { headers: H });
+  return r.ok ? await r.json() : [];
+}
+const rng = mulberry32(SEED);
+function dedupWorks(arr) {
+  const m = new Map();
+  for (const e of arr) { const k = (e.author_1 || '') + '|' + (e.title || '').slice(0, 40); if (!m.has(k)) m.set(k, e); }
+  return [...m.values()];
+}
+function sample(arr, n) { return dedupWorks(arr).sort(() => rng() - 0.5).slice(0, n); }
+
+async function main() {
+  // base-rate: random spread across the sn range, edition-drawn → deduped to works
+  const rand = [];
+  for (const off of [0, 80000, 160000, 240000, 320000, 400000]) rand.push(...await page('', off, 60));
+  // flagged-true: precision check
+  const flagged = [];
+  for (const off of [0, 20000, 40000]) flagged.push(...await page('&has_english_translation=eq.true', off, 40));
+
+  const base = sample(rand, 50), flag = sample(flagged, 25);
+  writeFileSync('scripts/analysis/latin-qc-base-sample.json', JSON.stringify(base, null, 1));
+  writeFileSync('scripts/analysis/latin-qc-flagged-sample.json', JSON.stringify(flag, null, 1));
+  console.log(`base: ${base.length} works (census-flagged translated: ${base.filter(e => e.has_english_translation).length}); flagged-true: ${flag.length}`);
+  console.log('Caveat: edition-weighted sampling over-represents prolific (translated) authors — see latin-qc-audit.md.');
+}
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## What & why

Step 2 of the translation-gap paper pipeline: **error bars on the Latin ~2%**, the other half's soft spot. Mirrors the Siku Quanshu QC (#2237). The Latin figure rests on **author-surname matching**; this PR audits its precision and characterizes the measurement's sensitivity.

## Findings (full write-up: `docs/translation-gap-census-paper/latin-qc-audit.md`)

- **Author-flag work-level precision ≈ 70%** (n=25 flagged-true). It overcounts because translated authors carry many *untranslated* minor works (Grotius's wedding poem, Erasmus's grammar *De octo partium*, Durand's legal *Speculum*, Vossius's grammar) and because surname matching **collides across distinct people** (an *almanac* by "Regnerus Agricola" flagged via a translated Agricola).
- **Base rate (n=50 random):** 41/50 unflagged works are confirmed-pattern untranslated (almanacs, funeral orations, university dissertations, papal bulls, polyglot dictionaries) — the genuine obscure bulk.
- **Key methodological finding:** the rate is **unit-sensitive** — edition-weighted sampling over-represents prolific (translated) authors, so the census's ~0.99% work figure is an *estimate*, not a directly-sampled rate. A clean work-level rate needs **work-uniform sampling + per-work verification**.

## Why this strengthens the paper

Both corpora teach the *same* lesson from opposite directions — heuristic matching (author names for Latin, titles for Chinese) has limited precision/recall, so the honest rate needs per-work human verification. The order of magnitude is robust: **~2% Latin, ~1–2% Chinese**. This becomes the paper's recall/precision audit and the argument for human-in-the-loop measurement.

## Files
- `scripts/analysis/latin-translation-qc.mjs` — reproducible sampler (read-only vs public Supabase)
- `scripts/analysis/latin-qc-{base,flagged}-sample.json` — the audited samples
- `docs/translation-gap-census-paper/latin-qc-audit.md` — findings + error-bar conclusion

## Out of scope (next)
Work-uniform Latin sampler + per-work LLM-adjudicated verification for a directly-measured rate + Wilson CI; flag-recall audit (flagged-false mid-tier authors). Tracked on #2234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
