### PR TITLE
fix(routing): resolve renamed book slugs via slug_aliases

### DIFF
--- a/scripts/maintenance/populate-book-slugs.mjs
+++ b/scripts/maintenance/populate-book-slugs.mjs
@@ -143,6 +143,25 @@ async function main() {
         console.error('Failed to create index:', e.message);
       }
     }
+
+    // Old slugs after a rename live in books.slug_aliases. findBookByIdOrSlug
+    // adds a { slug_aliases } branch to its $or so stale URLs resolve and 301
+    // to the canonical slug — that branch MUST be index-backed, or every book
+    // lookup degrades to a collection scan (Mongo can't index an $or with any
+    // unindexed branch). Sparse + multikey; non-unique to tolerate legacy data.
+    try {
+      await db.collection('books').createIndex(
+        { slug_aliases: 1 },
+        { name: 'books_slug_aliases_idx', sparse: true, background: true }
+      );
+      console.log('Created index on books.slug_aliases');
+    } catch (e) {
+      if (e.message.includes('already exists')) {
+        console.log('Index books_slug_aliases_idx already exists');
+      } else {
+        console.error('Failed to create slug_aliases index:', e.message);
+      }
+    }
   }
 
   await client.close();

--- a/scripts/maintenance/populate-book-slugs.mjs
+++ b/scripts/maintenance/populate-book-slugs.mjs
@@ -145,10 +145,10 @@ async function main() {
     }
 
     // Old slugs after a rename live in books.slug_aliases. findBookByIdOrSlug
-    // adds a { slug_aliases } branch to its $or so stale URLs resolve and 301
-    // to the canonical slug — that branch MUST be index-backed, or every book
-    // lookup degrades to a collection scan (Mongo can't index an $or with any
-    // unindexed branch). Sparse + multikey; non-unique to tolerate legacy data.
+    // consults this field ONLY on a miss (a would-be 404), to resolve a stale
+    // URL and 301 to the canonical slug — it is kept out of the hot-path $or.
+    // The index keeps that miss-path lookup (and 404s generally) from scanning
+    // the collection. Sparse + multikey; non-unique to tolerate legacy data.
     try {
       await db.collection('books').createIndex(
         { slug_aliases: 1 },

--- a/src/lib/book-lookup.ts
+++ b/src/lib/book-lookup.ts
@@ -18,7 +18,8 @@ export interface BookLookupResult {
  * 1. slug (new SEO-friendly URLs)
  * 2. id (existing URLs, internal references)
  * 3. _id as ObjectId (legacy URLs)
- * 4. slug_aliases (old slugs after a rename — resolve, then 301 to canonical)
+ * 4. slug_aliases — ONLY on a miss (old slugs after a rename), so the common
+ *    hot path stays a single indexed lookup. See note below.
  *
  * The `matchedBySlug` flag tells the caller whether to 301 redirect
  * (if false and book has a slug, redirect to the slug URL). An alias match
@@ -40,9 +41,6 @@ export async function findBookByIdOrSlug(
   const orConditions: Document[] = [
     { slug: idOrSlug },
     { id: idOrSlug },
-    // Old slugs after a rename. Indexed by books_slug_aliases_idx — keep this
-    // branch index-backed so the $or never degrades to a collection scan.
-    { slug_aliases: idOrSlug },
   ];
   if (ObjectId.isValid(idOrSlug)) {
     try {
@@ -56,8 +54,21 @@ export async function findBookByIdOrSlug(
   if (tenantId) query.tenantId = tenantId;
 
   const book = await db.collection('books').findOne(query, opts);
-  if (!book) return null;
+  if (book) {
+    const matchedBySlug = book.slug === idOrSlug;
+    return { book, matchedBySlug };
+  }
 
-  const matchedBySlug = book.slug === idOrSlug;
-  return { book, matchedBySlug };
+  // Miss path only: the slug/id/_id lookup found nothing, so this might be an
+  // OLD slug from a rename. Resolve via slug_aliases (indexed by
+  // books_slug_aliases_idx) and let the caller 301 to the canonical slug.
+  // Kept OUT of the $or above so it never touches the common hot path — it
+  // runs solely on a would-be 404, where one extra indexed findOne is free.
+  const aliasQuery: Document = { slug_aliases: idOrSlug };
+  if (tenantId) aliasQuery.tenantId = tenantId;
+  const aliased = await db.collection('books').findOne(aliasQuery, opts);
+  if (!aliased) return null;
+
+  // Matched by alias, not the canonical slug → caller redirects to aliased.slug.
+  return { book: aliased, matchedBySlug: false };
 }

--- a/src/lib/book-lookup.ts
+++ b/src/lib/book-lookup.ts
@@ -18,9 +18,12 @@ export interface BookLookupResult {
  * 1. slug (new SEO-friendly URLs)
  * 2. id (existing URLs, internal references)
  * 3. _id as ObjectId (legacy URLs)
+ * 4. slug_aliases (old slugs after a rename — resolve, then 301 to canonical)
  *
  * The `matchedBySlug` flag tells the caller whether to 301 redirect
- * (if false and book has a slug, redirect to the slug URL).
+ * (if false and book has a slug, redirect to the slug URL). An alias match
+ * returns matchedBySlug:false (book.slug !== the alias), so the caller
+ * redirects the stale URL to the current canonical slug.
  *
  * If tenantId is provided, filters by that tenant for multi-tenant isolation.
  */
@@ -37,6 +40,9 @@ export async function findBookByIdOrSlug(
   const orConditions: Document[] = [
     { slug: idOrSlug },
     { id: idOrSlug },
+    // Old slugs after a rename. Indexed by books_slug_aliases_idx — keep this
+    // branch index-backed so the $or never degrades to a collection scan.
+    { slug_aliases: idOrSlug },
   ];
   if (ObjectId.isValid(idOrSlug)) {
     try {


### PR DESCRIPTION
## Why

Renaming a book's `slug` 404'd the old URL. `findBookByIdOrSlug` only matched `slug` / `id` / `_id`, so a stale slug resolved to nothing. Surfaced while correcting two mis-catalogued Ficino editions; the Lyon record's slug was renamed `…aldine-1497-ficino` → `…lyon-1607-ficino`.

## What

When a book is renamed, the old slug is stored in `books.slug_aliases`. `findBookByIdOrSlug` resolves it and the existing route logic 301-redirects to the canonical slug (an alias match returns `matchedBySlug: false`).

## Hot path stays untouched (revised from first pass)

The first version added a `{ slug_aliases }` branch to the main lookup `$or` — which would evaluate it on **every** book-page load, the hottest query on the site, to support a *rare* event (renames). Reworked: the `slug/id/_id` lookup is unchanged on the **hit path**; `slug_aliases` is consulted **only when that returns null** (a would-be 404), where one extra indexed `findOne` is free. Normal book loads pay zero added cost.

## Index

A sparse `books_slug_aliases_idx` backs the miss-path query (and keeps 404s generally from scanning the collection). Already created in production; added to `populate-book-slugs.mjs` for reproducibility.

## Scope

Routing + index only. No change to slug *assignment*. `tsc` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)