### PR TITLE
fix(routes): force-dynamic on ISR pages reading request headers (Next 16 500s)

### DIFF
--- a/src/app/book/[id]/overview/page.tsx
+++ b/src/app/book/[id]/overview/page.tsx
@@ -4,9 +4,7 @@ import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { getTenantContext } from '@/lib/tenant-context';
 import type { Metadata } from 'next';
 import BookOverview from '@/components/reader/BookOverview';
-
-// ISR: 24h background revalidation + on-demand via pipeline
-export const revalidate = 86400;
+export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
 export async function generateStaticParams() {
   return [];

--- a/src/app/browse/artists/[letter]/page.tsx
+++ b/src/app/browse/artists/[letter]/page.tsx
@@ -9,7 +9,7 @@ import { notFound } from 'next/navigation';
 
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
-export const revalidate = 86400;
+export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 export const dynamicParams = true;
 

--- a/src/app/browse/authors/[letter]/page.tsx
+++ b/src/app/browse/authors/[letter]/page.tsx
@@ -9,14 +9,12 @@ import { notFound } from 'next/navigation';
 
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
-// ISR: 24h background revalidation
-export const revalidate = 86400;
+// This route reads request headers (await headers() for tenant detection),
+// so it must render dynamically. Declaring `revalidate` (ISR / static) here
+// while calling headers() throws DYNAMIC_SERVER_USAGE in Next 16 and 500s the
+// whole /browse/authors/[letter] route. Force dynamic instead.
+export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
-export const dynamicParams = true;
-
-export function generateStaticParams() {
-  return []; // Generate on first request, not at build time
-}
 
 interface PageProps {
   params: Promise<{ letter: string }>;

--- a/src/app/browse/titles/[letter]/page.tsx
+++ b/src/app/browse/titles/[letter]/page.tsx
@@ -8,9 +8,7 @@ import { notFound } from 'next/navigation';
 import BrowseViewToggle from '@/components/browse/BrowseViewToggle';
 
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
-
-// ISR: rebuild daily. Allow 60s for first-hit generation.
-export const revalidate = 86400;
+export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 export const dynamicParams = true;
 


### PR DESCRIPTION
## Problem
`https://sourcelibrary.org/browse/authors/J` — and every letter A–Z — returned HTTP 500 (reported by Julika). Vercel runtime logs showed `digest: 'DYNAMIC_SERVER_USAGE'`. The same error was 500ing other routes too.

## Root cause
Next.js 16 throws `DYNAMIC_SERVER_USAGE` when a statically-generated route (`export const revalidate = N`) also calls a per-request API like `headers()`. Several pages declared `revalidate` for ISR but also read `headers()` to detect the tenant subdomain — an incompatible combination under Next 16 that 500s the whole route. The data layer was never at fault: the Supabase author query returns J's 675 rows in ~270ms with no error.

## Fix
On each route **confirmed returning 500 in production** (verified by curl), replace `export const revalidate = N` with `export const dynamic = 'force-dynamic'`:
- `src/app/browse/authors/[letter]/page.tsx`
- `src/app/browse/titles/[letter]/page.tsx`
- `src/app/browse/artists/[letter]/page.tsx`
- `src/app/book/[id]/overview/page.tsx`

These pages are inherently per-request (output depends on the tenant host), so dynamic rendering is correct and the fast catalog queries make the lost ISR cache immaterial.

## Out of scope (deliberately untouched)
These share the `revalidate` directive but returned **200** in prod, so they were left alone to keep the PR tight: `/gallery`, `/collections`, `/collections/[id]` (already `force-dynamic`), `/browse/years/[period]`.

## Verification
- Reproduced the Supabase query directly — healthy, fast, no error (confirms render-time framework error, not data).
- `npx tsc --noEmit` clean except pre-existing `d3` / `d3-sankey` type noise in unrelated `carbon-ledger` blog components (present on main, which deploys fine).
- Will confirm prod letter pages return 200 after merge/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)