### PR TITLE
maintenance: catalog data-quality fixes (#2234 items 7-9)

### DIFF
--- a/scripts/maintenance/backfill-translation-catalog-source-language.mjs
+++ b/scripts/maintenance/backfill-translation-catalog-source-language.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Backfill `source_language` (+ provenance) on translation_catalogs (Mongo).
+ * Issue #2234 Phase 0. The catalog was built as a Latin-translation verifier,
+ * so source language is mostly Latin by construction; non-Latin originals are
+ * recovered by script detection on `original_title`.
+ *
+ * Provenance tiers (recorded in source_language_provenance):
+ *   script_detected   — non-Latin script in original_title (high confidence)
+ *   source_scope_classical — Loeb/Harvard classical series (Latin OR Greek; default la, lower conf)
+ *   source_scope      — Latin by catalog construction (default la)
+ *
+ * NB: only the Mongo copy is updated (24,040 rows). The Supabase copy (26,789,
+ * diverged) needs a separate sync/DDL — flagged, not done here.
+ *
+ * Usage: node scripts/maintenance/backfill-translation-catalog-source-language.mjs [--apply]
+ */
+import { MongoClient } from 'mongodb';
+const APPLY = process.argv.includes('--apply');
+const CLASSICAL_MIXED = new Set(['loeb','extended_harvard_lcl']); // include Greek
+function detectScript(s){
+  if(!s) return null;
+  if(/[一-鿿]/.test(s)) return /[぀-ヿ]/.test(s)?'ja':'zh';
+  if(/[Ѐ-ӿ]/.test(s)) return 'ru';
+  if(/[Ͱ-Ͽἀ-῿]/.test(s)) return 'grc';
+  if(/[֐-׿]/.test(s)) return 'he';
+  if(/[؀-ۿ]/.test(s)) return 'ar';
+  if(/[ऀ-ॿ]/.test(s)) return 'sa';
+  return null;
+}
+const c=new MongoClient(process.env.MONGODB_URI); await c.connect();
+const tc=c.db('bookstore').collection('translation_catalogs');
+const dist={}; let ops=[],applied=0,total=0;
+for await (const r of tc.find({},{projection:{source:1,original_title:1,source_language:1}})){
+  total++;
+  const sd=detectScript(r.original_title);
+  let lang,prov;
+  if(sd){ lang=sd; prov='script_detected'; }
+  else if(CLASSICAL_MIXED.has(r.source)){ lang='la'; prov='source_scope_classical'; }
+  else { lang='la'; prov='source_scope'; }
+  dist[prov]=(dist[prov]||0)+1;
+  if(APPLY){ ops.push({updateOne:{filter:{_id:r._id},update:{$set:{source_language:lang,source_language_provenance:prov}}}});
+    if(ops.length>=1000){applied+=(await tc.bulkWrite(ops)).modifiedCount;ops=[];} }
+}
+if(APPLY&&ops.length)applied+=(await tc.bulkWrite(ops)).modifiedCount;
+console.log(`${APPLY?'APPLIED':'DRY-RUN'} over ${total} rows`);
+console.log('by provenance:',JSON.stringify(dist,null,2));
+if(APPLY){
+  console.log(`modified ${applied}`);
+  const byLang=await tc.aggregate([{$group:{_id:'$source_language',n:{$sum:1}}},{$sort:{n:-1}}]).toArray();
+  console.log('source_language distribution:',byLang.map(x=>`${x._id}:${x.n}`).join(', '));
+}
+await c.close();

--- a/scripts/maintenance/detect-language-untagged-ocr.mjs
+++ b/scripts/maintenance/detect-language-untagged-ocr.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Detect language for books with OCR text but Unknown/null language (#2234 #9).
+ * Title-script detection is unreliable here (scholarly editions: "The
+ * Oxyrhynchus Papyri" is Greek; "Atharva-Veda" is Sanskrit), so we ask Gemini
+ * for the work's ORIGINAL/primary language, gate on high confidence, preserve
+ * the original in language_raw, and flag low-confidence for review (no guessing).
+ * Usage: node scripts/maintenance/detect-language-untagged-ocr.mjs [--apply]
+ */
+import { MongoClient } from 'mongodb';
+const APPLY=process.argv.includes('--apply');
+const KEY=process.env.GEMINI_API_KEY, M='gemini-3.1-flash-lite';
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+async function detect(title){
+  const prompt=`What is the ORIGINAL/primary language of the historical work titled "${title}"? For a scholarly edition (e.g. a papyri or Veda edition), give the language of the SOURCE TEXT, not the title. Respond JSON only: {"language":"<full English name e.g. Latin, Greek, Sanskrit, Italian, French, German, English>"|null,"confidence":"high"|"medium"|"low"}. Use null + low if genuinely unsure.`;
+  const u=`https://generativelanguage.googleapis.com/v1beta/models/${M}:generateContent?key=${KEY}`;
+  for(let a=0;a<3;a++){ let r; try{ r=await fetch(u,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({contents:[{parts:[{text:prompt}]}],generationConfig:{temperature:0,responseMimeType:'application/json'}})});}catch{await sleep(1200);continue;}
+    if(r.status===429||r.status>=500){await sleep(2000);continue;} if(!r.ok)return null;
+    const d=await r.json(); const t=d?.candidates?.[0]?.content?.parts?.[0]?.text; if(!t)return null; try{return JSON.parse(t);}catch{return null;} }
+  return null;
+}
+const c=new MongoClient(process.env.MONGODB_URI); await c.connect();
+const B=c.db('bookstore').collection('books');
+const cand=await B.find({language:{$in:['Unknown',null]},pages_ocr:{$gt:0}},{projection:{title:1}}).toArray();
+let set=0,flagged=0,err=0; const results=[];
+for(const b of cand){ const v=await detect(b.title); 
+  if(!v){err++;continue;}
+  if(v.language && v.confidence==='high'){ set++; results.push(`${v.language}  ← ${(b.title||'').slice(0,45)}`);
+    if(APPLY) await B.updateOne({_id:b._id},{$set:{language:v.language,languages:[v.language],language_raw:'Unknown',language_detected:'gemini_title'}}); }
+  else { flagged++; if(APPLY) await B.updateOne({_id:b._id},{$set:{language_review:true}}); }
+  await sleep(200);
+}
+console.log(`${APPLY?'APPLIED':'DRY-RUN'}: ${cand.length} books | high-conf set=${set}, low-conf flagged=${flagged}, errors=${err}`);
+console.log('\nhigh-confidence detections:'); results.forEach(r=>console.log('  '+r));
+await c.close();

--- a/scripts/maintenance/flag-malformed-catalog-authors.mjs
+++ b/scripts/maintenance/flag-malformed-catalog-authors.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * Flag malformed translation_catalogs rows for manual review (issue #2234 #8).
+ * The "noise" (translators stuffed in the author field, scrambled name order,
+ * non-Latin/non-relevant rows) is too heterogeneous to auto-rewrite safely —
+ * auto-extraction would mis-assign translators. So we FLAG, not fix.
+ *
+ * Flags rows where author/canonical_author embeds a translator marker
+ * ("(trans", "(translator)", "(translation"). Sets needs_review + review_reason.
+ * Usage: node scripts/maintenance/flag-malformed-catalog-authors.mjs [--apply]
+ */
+import { MongoClient } from 'mongodb';
+const APPLY = process.argv.includes('--apply');
+const c=new MongoClient(process.env.MONGODB_URI); await c.connect();
+const tc=c.db('bookstore').collection('translation_catalogs');
+const filter={$or:[{author:/\(trans/i},{canonical_author:/\(trans/i},{author:/\(translat/i},{canonical_author:/\(translat/i}]};
+const n=await tc.countDocuments(filter);
+console.log(`${APPLY?'APPLIED':'DRY-RUN'}: ${n} malformed-author rows to flag needs_review`);
+if(APPLY){ const r=await tc.updateMany(filter,{$set:{needs_review:true,review_reason:'malformed_author_translator_embedded'}}); console.log(`modified ${r.modifiedCount}`); }
+await c.close();


### PR DESCRIPTION
Three data-quality fixes from the translation-gap thread (issue #2234), each a committed re-runnable script; all applied to production this session.

**#7 — `source_language` on `translation_catalogs`** (Mongo, 24,040 rows). Derived with honest provenance tiers: `script_detected` (0 — all originals are romanized), `source_scope_classical` (385 Loeb/LCL rows, Latin *or* Greek), `source_scope` (23,655 Latin-by-construction). All resolve to `la`; the Latin/Greek author-split is the documented refinement. The Supabase copy (diverged: 26,789 vs Mongo 24,040) needs a separate sync/DDL — flagged, not done.

**#8 — flag malformed author rows.** 26 rows with a translator stuffed in the author field ("B. O. (trans) Foster", etc.) are too heterogeneous to auto-rewrite without introducing errors, so they're flagged `needs_review` rather than mangled.

**#9 — language detection for 82 untagged-but-OCR'd books.** Title-script detection is unreliable for scholarly editions ("The Oxyrhynchus Papyri" → Greek; "Atharva-Veda" → Sanskrit), so Gemini identifies the *original* language, high-confidence-gated, original preserved in `language_raw` (reversible). A few edge cases (artwork-ish, edition-vs-original) are debatable but strictly better than `Unknown`.

All additive/reversible; no destructive writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)