### PR TITLE
seo(robots): disallow /encyclopedia/ to free crawl budget for the catalogue

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -18,6 +18,12 @@ export default function robots(): MetadataRoute.Robots {
           // letting Google crawl this burns budget on tens of thousands of
           // redirects (showed up as "Blocked 403" / "Page with redirect" in GSC).
           '/book/*/page-number/',
+          // Auto-generated thin concept stubs. Google classifies these as
+          // soft-404 (1,241 in the 2026-05-31 GSC Coverage report — the single
+          // largest not-indexed bucket) and crawling them burns budget that
+          // should go to the ~15K /book/ landing pages. Block to prioritize
+          // the catalogue. See SEO crawl-budget PR (2026-05-31).
+          '/encyclopedia/',
           '/api/',
           '/admin/',
           '/analytics',


### PR DESCRIPTION
## Why

Derek flagged that Google Search Console showed the catalogue not getting indexed ("0 discovered pages"). Investigation cleared the suspected cause (Cloudflare bot protection) and found the real one.

**Cloudflare is fine.** Verified crawlers (Googlebot et al.) skip all WAF challenges via the top-priority skip rule; `robots.txt` and `sitemap*` are always reachable; sampled book pages return clean 200s to a real Googlebot UA with no noindex headers. The "0 discovered" figure was a GSC artifact — reading the sitemap-*index* row instead of the 6 child sitemaps (which carry all 16,119 URLs).

**The real drag is crawl budget.** The latest GSC Coverage report shows the biggest not-indexed bucket is **Soft 404 (1,241)**, overwhelmingly `/encyclopedia/<term>` pages — auto-generated thin concept stubs Google refuses to index. Crawling thousands of them starves the ~15,352 `/book/` landing pages, which are technically clean (200, self-canonical, no noindex, in-sitemap) but indexing slowly on a young site.

## What

Add `/encyclopedia/` to the `disallow` list in `src/app/robots.ts` (the Next.js route that generates robots.txt). This stops the crawl waste so budget flows to the catalogue.

## Scope

**In scope:** one entry + explanatory comment in robots.ts. Nothing else.

**Out of scope (deliberate):**
- `/search?q=` and `/author/` pages also draw crawl budget but are already `noindex` — lower priority, separate change if wanted.
- The 245 GSC "Server error (5xx)" entries: probed 1,536 book URLs (every 10th across the corpus) as Googlebot — **100% returned 200, zero 5xx**. Those were transient crawl-time blips; "Validate Fix" in GSC will clear them. No code fix needed.
- A few noindex pages (`/languages/`, `/gallery/image/`) are still listed in the sitemap — minor consistency nit, not addressed here.

## Verification

- Pre-commit import check + `npx tsc` (robots route) clean.
- Diff is the single `/encyclopedia/` disallow entry in the `userAgent: '*'` rule.
- No code path treats `/encyclopedia/` as an indexable ranking surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)