### PR TITLE
fix(enrich): book-grounded summaries (drop Wikipedia blob from synthesis)

### DIFF
--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -646,7 +646,14 @@ async function generateBookSummary(batchExtractions, bookTitle, bookAuthor, book
     .join('\n');
 
   const languageContext = bookLanguage ? ` The original text is in ${bookLanguage}.` : '';
-  const researchSection = researchContext ? `\n## Wikipedia Context\n${researchContext}\n` : '';
+  // Summaries are synthesized from the book's own content (section summaries,
+  // themes, quotes, chapter structure) — NOT from a Wikipedia blob. Injecting
+  // Wikipedia here caused mis-attributions framed as fact (e.g. a De Mysteriis
+  // edition summarized as a "correspondence between Porphyry and Abammon", a
+  // detail absent from the page text). This matches resynthesize-summaries.mjs,
+  // which already passes researchSection:'' for the corpus rollout. researchContext
+  // is still used as a placeholder for books with zero extractable content (below).
+  const researchSection = '';
   const hasChapters = chapters && chapters.length > 0;
   const chapterSection = hasChapters ? `\n## Detected Chapter Structure\n${chapters.map(c => `- Page ${c.pageNumber}: ${c.title}`).join('\n')}\n` : '';
 


### PR DESCRIPTION
## Why

The enrich worker injected a fetched **Wikipedia blob** into the summary-synthesis prompt. For a *De Mysteriis* edition this produced a confident mis-attribution — summarizing it as a "correspondence between Porphyry and Abammon" — a framing **absent from the page text** ("Abammon" appears 0× in the book's OCR; the OCR's only "Anebo" is a faithful reference in Ficino's own Argumentum). The corpus-rollout path (`resynthesize-summaries.mjs`) already avoids this by passing `researchSection: ''`; the worker did not, so the two diverged.

## What

`enrich-worker.mjs`: `researchSection = ''` — summaries synthesize from the book's own sections / themes / quotes / chapter structure, matching `resynthesize-summaries.mjs`. Wikipedia (`researchContext`) is retained only as a placeholder for books with zero extractable content. Author identity / significance still come through (prompt-driven from model knowledge, as in the #2163 rollout — verified resynth produces them with no Wikipedia).

## Scope

- Does **not** change the synthesis prompt wording or version (`summary-prompt.mjs` untouched) — only *what context is fed in*.
- Does **not** retroactively re-run the corpus; applies to future enrichments. (The two Ficino editions that surfaced this were redone via resynth + promote.)
- The related catalog-precedence fix (browse/search reading a stale summary field) is split into its own PR because it has a corpus-wide blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)