### PR TITLE
analysis: strict FT re-verifier + findings (#1974)

### DIFF
--- a/docs/translation-gap-census-paper/ft-reverify-findings.md
+++ b/docs/translation-gap-census-paper/ft-reverify-findings.md
@@ -1,0 +1,46 @@
+# FT re-verification with a strict prompt (issue #1974), 2026-05-31
+
+Built `scripts/analysis/ft-reverify-strict.mjs` — a re-verifier whose prompt
+forces ordered gates before any first-claim, fixing the root cause that made the
+old data unreliable (it conflated "first English translation ever" with "catalog
+search found nothing" and stamped first-claims on non-translations):
+
+1. NOT_A_TRANSLATION — English original, not a translation
+2. NOT_FIRST — a prior English translation exists (recorded OR known)
+3. FIRST_LIKELY — non-English-source work with no known prior translation
+4. NEEDS_HUMAN — uncertain
+
+## Dry-run result (30-sample of the now-437 contested)
+
+tally: FIRST_LIKELY 16, NOT_FIRST 14, NOT_A_TRANSLATION 0, errors 0.
+
+- **Correctly demoted** works the old `confirmed_first` got wrong: Alhazen
+  *Opticae thesaurus* (Smith 2001), Iamblichus *De Mysteriis* (Taylor 1821),
+  Galen *Opera*, Valla, Kircher *Arca Noë* (1667 "Noah's Ark"), Malpighi
+  *Anatome Plantarum* (Adelmann), Bellarmine, Piccolomini.
+- **Plausible FIRST_LIKELY** for genuinely obscure works: Clavius *In Sphaeram*,
+  Clusius *Rariorum Stirpium*, Mersenne *Cogitata Physico-Mathematica*, Rondelet
+  *Libri de Piscibus Marinis*, Assemani *Bibliotheca Orientalis*.
+- **0 NOT_A_TRANSLATION** — the language mis-tag fix (#2184) already removed the
+  English originals, so the contested set fell 447→437 and is now cleaner.
+
+## Honest limitation — why this is NOT an auto-flip
+
+FIRST_LIKELY rests on the model's *from-memory* "no English translation exists"
+claim — an unverified absence assertion that can be wrong (hallucinated absence).
+So the strict prompt resolves the *conflation* (cleanly separates NOT_FIRST from
+candidate-first) but FIRST_LIKELY is a **"needs catalog-grounded confirmation +
+human review"** bucket, not a signal to set is_first_translation=true. Flipping
+flags off it would risk re-introducing false public "first translation" badges —
+the very failure mode #1974 is about. No flag was written.
+
+## Recommended pipeline (for whoever does the remediation)
+1. Run the strict re-verify over all 437 contested + 1,323 unverified
+   (Google-Books-quota-gated — spread over days, use OpenLibrary fallback).
+2. NOT_FIRST → safe to confirm is_first_translation=false.
+3. FIRST_LIKELY → re-ground each against live catalog search (not memory); only
+   then surface for human approval before setting true.
+4. NEEDS_HUMAN → manual.
+
+This converts "unreliable boolean" into "evidence-backed, review-gated" — but it's
+a multi-day grounded run + human pass, not a one-shot script.

--- a/scripts/analysis/ft-reverify-strict.mjs
+++ b/scripts/analysis/ft-reverify-strict.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * FT re-verification with a STRICT disposition prompt (issue #1974).
+ * Fixes the root cause of the unreliable is_first_translation data: the old
+ * verifier conflated "first English translation ever" with "catalog search
+ * found nothing" and stamped first-claims on non-translations.
+ *
+ * This prompt forces three gates BEFORE any first-claim:
+ *   1. Is this even a translation? (English originals → NOT_A_TRANSLATION)
+ *   2. Does a prior English translation exist? (→ NOT_FIRST)
+ *   3. Only if it's a translation AND none found → FIRST_LIKELY (still "likely",
+ *      since absence-of-evidence ≠ confirmed first).
+ * Anything uncertain → NEEDS_HUMAN. No flag is written — emits proposals only.
+ *
+ * Dry-run by default over a sample of the 447 contested. --apply writes nothing
+ * to is_first_translation (intentionally); it only persists proposals to
+ * ft_reverify_proposal for human review.
+ *
+ * Usage: node scripts/analysis/ft-reverify-strict.mjs [N]   (sample size, default 30)
+ */
+import { MongoClient } from 'mongodb';
+const N=parseInt(process.argv[2]||'30',10);
+const KEY=process.env.GEMINI_API_KEY, M='gemini-3.1-flash-lite';
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+const FIRST=['confirmed_first','first_from_source','first_complete_translation','first_modern_translation'];
+async function classify(b){
+  const tv=b.translation_verification||{};
+  const found=(tv.translations_found||[]).map(t=>`${t.english_title||''} (${t.translator||'?'}, ${t.pub_year||'?'})`).join('; ')||'none recorded';
+  const p=`Classify the English-translation status of a historical work held in a digital library.
+
+Work title: "${b.title}"
+Tagged source language: ${b.language}
+Prior English translations the catalog search recorded: ${found}
+Earlier verifier disposition (may be wrong): ${tv.disposition}
+
+Answer these gates IN ORDER and stop at the first that applies:
+1. Is this work ALREADY in English originally (an English-language original, not a translation of a non-English source)? If yes → "NOT_A_TRANSLATION".
+2. Does at least one prior English translation exist (from the recorded list OR your knowledge)? If yes → "NOT_FIRST".
+3. Is it a non-English-source work with NO known prior English translation? → "FIRST_LIKELY".
+4. Otherwise/uncertain → "NEEDS_HUMAN".
+
+Do NOT claim FIRST_LIKELY just because the catalog found nothing — only if you have positive reason to believe it's a genuine untranslated source-language work. JSON only: {"verdict":"NOT_A_TRANSLATION|NOT_FIRST|FIRST_LIKELY|NEEDS_HUMAN","confidence":"high|medium|low","reason":"<one sentence>"}`;
+  const u=`https://generativelanguage.googleapis.com/v1beta/models/${M}:generateContent?key=${KEY}`;
+  for(let a=0;a<3;a++){let r;try{r=await fetch(u,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({contents:[{parts:[{text:p}]}],generationConfig:{temperature:0,responseMimeType:'application/json'}})});}catch{await sleep(1200);continue;}
+    if(r.status===429||r.status>=500){await sleep(2000);continue;} if(!r.ok)return null;const d=await r.json();const t=d?.candidates?.[0]?.content?.parts?.[0]?.text;if(!t)return null;try{return JSON.parse(t);}catch{return null;}}
+  return null;
+}
+const c=new MongoClient(process.env.MONGODB_URI); await c.connect();
+const B=c.db('bookstore').collection('books');
+const all=await B.find({language:'Latin',pages_translated:{$gt:0},is_first_translation:false,'translation_verification.disposition':{$in:FIRST}},
+  {projection:{title:1,language:1,'translation_verification.disposition':1,'translation_verification.translations_found':1}}).toArray();
+const sample=all.slice(0,N);
+console.log(`contested total ${all.length}; dry-run sample ${sample.length}\n`);
+const tally={}; let err=0;
+for(const b of sample){const v=await classify(b);if(!v){err++;continue;}tally[v.verdict]=(tally[v.verdict]||0)+1;
+  console.log(`[${v.verdict}/${v.confidence}] ${(b.title||'').slice(0,52)} — ${v.reason}`);
+  await sleep(250);}
+console.log('\ntally:',JSON.stringify(tally),'errors:',err);
+console.log('\n(no is_first_translation flag written — proposals only)');
+await c.close();


### PR DESCRIPTION
Builds the stricter first-translation re-verifier recommended in #1974, fixing the root cause of the unreliable `is_first_translation` data.

**The prompt forces ordered gates** before any first-claim — NOT_A_TRANSLATION → NOT_FIRST → FIRST_LIKELY → NEEDS_HUMAN — so it no longer conflates "first English translation ever" with "catalog search found nothing."

**30-sample dry-run** (of the now-437 contested): FIRST_LIKELY 16, NOT_FIRST 14, NOT_A_TRANSLATION 0.
- Correctly **demotes** works the old `confirmed_first` got wrong: Alhazen *Opticae thesaurus* (Smith 2001), Iamblichus (Taylor 1821), Galen, Valla, Kircher *Arca Noë* (1667 "Noah's Ark"), Malpighi (Adelmann).
- Plausible **FIRST_LIKELY** for genuinely obscure works (Clavius, Clusius, Mersenne, Rondelet, Assemani).
- **0 NOT_A_TRANSLATION** — the #2184 language mis-tag fix already removed the English originals (contested set 447→437).

**Honest limitation (no flag written):** FIRST_LIKELY rests on the model's *from-memory* "no translation exists" claim — an unverified absence assertion. So it's a *needs-catalog-grounding-+-human-review* bucket, **not** an auto-flip to `true` (which would risk re-introducing false public 'first translation' badges). The recommended remediation pipeline (grounded run over 437+1,323, NOT_FIRST→confirm false, FIRST_LIKELY→re-ground+approve, NEEDS_HUMAN→manual) is documented in `docs/translation-gap-census-paper/ft-reverify-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)