### PR TITLE
fix(browse): stop /browse/years 500s (ISR + headers() in Next 16)

### DIFF
--- a/src/app/browse/years/[period]/page.tsx
+++ b/src/app/browse/years/[period]/page.tsx
@@ -20,8 +20,11 @@ const PERIODS: Record<string, { label: string; min: number; max: number }> = {
 
 const PERIOD_SLUGS = Object.keys(PERIODS);
 
-// ISR: 24h background revalidation
-export const revalidate = 86400;
+// Must be dynamic: this page reads request headers (x-tenant-id) for tenant
+// scoping. Pairing `revalidate` (ISR) with `await headers()` throws
+// DYNAMIC_SERVER_USAGE and 500s the whole route in Next 16 (see PR #2260,
+// which fixed authors/titles/artists but missed this route).
+export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 export const dynamicParams = true;
 


### PR DESCRIPTION
## What
Every `/browse/years/*` page returns a **live 500**. Confirmed across all period values:
```
500  /browse/years/1500s
500  /browse/years/1600s
500  /browse/years/1700s
500  /browse/years/medieval
500  /browse/years/ancient
```
while sibling browse routes (`authors`, `titles`, `artists`) all return 200.

## Why
`src/app/browse/years/[period]/page.tsx` paired `export const revalidate = 86400` (ISR) with `await headers()` (line 52, reads `x-tenant-id` for tenant scoping). In Next 16 that combination throws `DYNAMIC_SERVER_USAGE` and 500s the whole route.

This is the **same bug PR #2260 fixed** on browse/authors|titles|artists — those routes dropped `revalidate` and became dynamic-by-default. The `years` route was missed.

## Fix
Swap ISR for `export const dynamic = 'force-dynamic'` (one-line behavioral change; route already reads request headers, so it can't be statically cached anyway).

## Evidence
`application_errors` (prod) shows a steady stream of `server_render` errors on `/browse/years` — 357 in the last 7d on this route alone, still firing today (07:30 on 1500s/1700s). Decaying on the already-fixed routes, persistent here.

## Out of scope
- Broken-image reports (~117/day, mostly `images.sourcelibrary.org` CDN 404s + the ficinosociety `/api/image` proxy) — separate issue, not a code 500.
- Client-side error noise (wallet-extension injection, React #418 hydration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)