### PR TITLE
docs(ft): catalog identification is the only valid basis for NOT_FIRST (#1974)

### DIFF
--- a/docs/translation-gap-census-paper/ft-reverify-findings.md
+++ b/docs/translation-gap-census-paper/ft-reverify-findings.md
@@ -24,23 +24,75 @@ tally: FIRST_LIKELY 16, NOT_FIRST 14, NOT_A_TRANSLATION 0, errors 0.
 - **0 NOT_A_TRANSLATION** — the language mis-tag fix (#2184) already removed the
   English originals, so the contested set fell 447→437 and is now cleaner.
 
-## Honest limitation — why this is NOT an auto-flip
+## NOT_FIRST spot-check (2026-05-31) — memory-based demotions are ~12–29% wrong
 
-FIRST_LIKELY rests on the model's *from-memory* "no English translation exists"
-claim — an unverified absence assertion that can be wrong (hallucinated absence).
-So the strict prompt resolves the *conflation* (cleanly separates NOT_FIRST from
-candidate-first) but FIRST_LIKELY is a **"needs catalog-grounded confirmation +
-human review"** bucket, not a signal to set is_first_translation=true. Flipping
-flags off it would risk re-introducing false public "first translation" badges —
-the very failure mode #1974 is about. No flag was written.
+Ran the verifier over a 70-book sample (24 NOT_FIRST) and fact-checked the
+verdicts. The error rate is entirely concentrated in one half:
+
+| Subset | n | Confirmed wrong | + unsupported |
+|---|---|---|---|
+| Catalog-recorded (`translations_found` named a prior tr.) | 8 | **0** | 0 |
+| Memory-based (`recorded: none`, asserted from model knowledge) | 16 | **3 (19%)** | 7 (44%) |
+| **All NOT_FIRST** | **24** | **3 (12.5%)** | **7 (29%)** |
+
+Three confirmed hallucinations — all memory-based, all genuine first-translation
+candidates that NOT_FIRST would wrongly bury:
+
+- **Kircher, *Arca Noë*** → claimed a "1667 English edition 'Noah's Ark'." No such
+  translation exists (1675 Latin; no full English translation ever published).
+- **Nicephorus Gregoras, *Byzantina Historia*** → claimed translated by "Van
+  Dieten." Van Dieten's translation is **German**; no complete English exists.
+- **Malpighi, *Anatome Plantarum*** → claimed "Adelmann, 1960s." Adelmann wrote
+  *about* it and called the plant material "beyond the competence of the present
+  writer." No English translation.
+
+(Note: the "correctly demoted" examples in the dry-run section above include
+*Arca Noë* and *Malpighi/Adelmann* — i.e. the earlier write-up trusted two of
+these hallucinated groundings. They are demotion **errors**, not successes.)
+Plus 4 on hand-wave reasoning with no named translation: Galen *Opera* vol 18 pt
+2, *Poemata Omnia* (model guesses the author), Bellarmine *De Sacramento
+Eucharistiae*, *Sophiae cum Moria Certamen*. The 8 catalog-recorded verdicts were
+100% correct.
+
+## Honest limitation — why this is NOT an auto-flip (in EITHER direction)
+
+The failure mode is symmetric, and it is the same root cause both ways: **a model's
+training memory cannot settle a bibliographic fact.**
+
+- **FIRST_LIKELY** rests on a from-memory *absence* claim ("no English translation
+  exists") — an unverified absence assertion (hallucinated absence).
+- **NOT_FIRST**, when not backed by a recorded catalog hit, rests on a from-memory
+  *presence* claim ("a prior translation exists") — an unverified presence
+  assertion (hallucinated presence), as the spot-check above demonstrates.
+
+So the strict prompt resolves the *conflation* (cleanly separates the buckets) but
+neither a memory-based NOT_FIRST nor any FIRST_LIKELY may write a flag. Doing so
+would re-introduce false public "first translation" badges (or wrongly bury real
+firsts) — the very failure mode #1974 is about. No flag was written.
+
+**Methodological rule:** catalog identification is the only valid basis for a
+NOT_FIRST determination. A prior translation is a positive bibliographic fact —
+it lives in catalogs, not in model memory. Memory may only *surface candidates to
+look up*; a catalog hit is the only thing that can *settle* NOT_FIRST. (And a
+catalog miss still can't settle FIRST — absence of evidence — so FIRST always
+needs human sign-off.)
 
 ## Recommended pipeline (for whoever does the remediation)
 1. Run the strict re-verify over all 437 contested + 1,323 unverified
    (Google-Books-quota-gated — spread over days, use OpenLibrary fallback).
-2. NOT_FIRST → safe to confirm is_first_translation=false.
+2. **NOT_FIRST with a recorded `translations_found` entry** → safe to confirm
+   is_first_translation=false. **NOT_FIRST with `recorded: none` (memory-only)**
+   → NOT safe; re-ground against live catalog search and route to human review,
+   same as FIRST_LIKELY (~12–29% of memory-based NOT_FIRST verdicts are wrong).
 3. FIRST_LIKELY → re-ground each against live catalog search (not memory); only
    then surface for human approval before setting true.
 4. NEEDS_HUMAN → manual.
+
+Implementation note: the strict prompt currently invites memory-based NOT_FIRST
+("from the recorded list OR your knowledge"). The grounded remediation run should
+either drop the "OR your knowledge" license for NOT_FIRST, or tag each NOT_FIRST
+with whether a recorded hit backs it so the gate in step 2 can be applied
+automatically.
 
 This converts "unreliable boolean" into "evidence-backed, review-gated" — but it's
 a multi-day grounded run + human pass, not a one-shot script.


### PR DESCRIPTION
## Why

Spot-check of the strict FT re-verifier (`ft-reverify-strict.mjs`, PR #2269) over a 70-book sample found its **NOT_FIRST** verdicts have a **~12–29% error rate — and it is entirely in the memory-based subset.**

| Subset | n | Confirmed wrong | + unsupported |
|---|---|---|---|
| Catalog-recorded (`translations_found` named a prior tr.) | 8 | **0** | 0 |
| Memory-based (`recorded: none`) | 16 | **3 (19%)** | 7 (44%) |
| All NOT_FIRST | 24 | **3 (12.5%)** | 7 (29%) |

Three confirmed hallucinations, all genuine first-translation candidates NOT_FIRST would wrongly bury:
- **Kircher, *Arca Noë*** → fabricated "1667 English 'Noah's Ark'" (no English translation exists)
- **Nicephorus Gregoras** → "Van Dieten" translation is **German**, not English
- **Malpighi, *Anatome Plantarum*** → "Adelmann" wrote *about* it, no translation

## What this changes

Docs only — corrects `ft-reverify-findings.md`:

1. The earlier "correctly demoted" example list trusted two of these hallucinated groundings (Arca Noë, Malpighi/Adelmann). Flagged as demotion **errors**, not successes.
2. Adds the spot-check table + the symmetric-failure framing: a model's memory can't settle a bibliographic fact in *either* direction (FIRST_LIKELY = hallucinated absence; memory NOT_FIRST = hallucinated presence).
3. Fixes the remediation pipeline: NOT_FIRST is auto-safe **only when backed by a recorded `translations_found` entry**; memory-only NOT_FIRST must re-ground + human-review like FIRST_LIKELY.

**Methodological rule:** catalog identification is the only valid basis for NOT_FIRST. Memory may surface candidates to look up; only a catalog hit can settle a prior-translation (presence) claim.

## Out of scope

No flags written, no script logic changed — the doc notes the script's prompt still licenses memory-based NOT_FIRST and should be tightened by whoever runs the grounded remediation.

Refs #1974

🤖 Generated with [Claude Code](https://claude.com/claude-code)