### PR TITLE
fix(catalog): browse/search read maintained summary fields, not the legacy embed

### DIFF
--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -33,13 +33,20 @@ const BATCH_SIZE = 200;
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, { auth: { persistSession: false } });
 
 function extractSummaryText(book) {
-  // Priority: index.bookSummary.brief > reading_summary.overview > summary.data
-  const indexBrief = book.index?.bookSummary?.brief;
-  if (indexBrief) return indexBrief;
+  // Prefer the fields the current enrich/promote pipeline actually maintains:
+  // book.summary.data (the brief) and book.reading_summary.overview. The embedded
+  // book.index.bookSummary is LEGACY — the worker writes the dedicated book_indexes
+  // collection (merged onto book.index only at book-page render time), so reading
+  // the embed first served stale text: the #2153/#2163 plain-encyclopedic rewrite
+  // updated summary.data/reading_summary but NOT the embed, so browse/search kept
+  // showing the old ad-copy voice for ~5k books. Keep the embed as a last resort
+  // for old books that predate book.summary.data.
+  if (typeof book.summary === 'string' && book.summary) return book.summary;
+  if (book.summary?.data) return book.summary.data;
   const readingOverview = book.reading_summary?.overview;
   if (readingOverview) return readingOverview;
-  if (typeof book.summary === 'string') return book.summary;
-  if (book.summary?.data) return book.summary.data;
+  const indexBrief = book.index?.bookSummary?.brief;
+  if (indexBrief) return indexBrief;
   return null;
 }
 


### PR DESCRIPTION
## Why

Browse and search have been showing the **old ad-copy summary voice** for ~5k books, even though the #2153/#2163 rewrite replaced it. Root cause: the catalog sync's `extractSummaryText` read the embedded `book.index.bookSummary.brief` first — a field the current pipeline **no longer writes**. The enrich/promote pipeline writes the `book_indexes` *collection* + `book.summary.data` + `reading_summary`. The book *page* merges `book_indexes` over `book.index` at render time; the catalog sync does neither, so it kept serving the stale embed.

Example (before → after):
- *De Re Anatomica*: "Realdo Colombo rejects centuries of unchecked dogma to…" → "De Re Anatomica Libri XV (On Anatomy) is an anatomical treatise…"
- *Theatrum Orbis Terrarum*: "Abraham Ortelius transformed how we see the world…" → "Theatrum Orbis Terrarum (Theatre of the World) is a cartographic…"

## What

Reorder `extractSummaryText` precedence to: `book.summary.data` → `reading_summary.overview` → (legacy) `index.bookSummary.brief`.

## Blast radius (measured against production)

Of **7,684** visible books carrying the legacy embed, **5,173 (67%)** get a different — and correct — browse/search snippet. **0 regressions**: the embed stays the last-resort fallback, so no book whose only summary lives in the embed loses it. The change takes effect on the next catalog sync after merge.

## Scope

`extractSummaryText` only. No schema change, no re-enrichment. A deeper cleanup (collapsing the legacy embedded `book.index.bookSummary` and the `book_indexes` collection into one source of truth) is left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)