### PR TITLE
fix(authors): read thesaurus read-path flag at runtime (#2250)

### DIFF
--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -11,7 +11,7 @@ import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
 import { ObjectId } from 'mongodb';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import AuthorSchema from '@/components/seo/AuthorSchema';
-import { AUTHOR_THESAURUS_READPATH, resolveCanonicalAuthor } from '@/lib/author-thesaurus';
+import { authorThesaurusReadpathEnabled, resolveCanonicalAuthor } from '@/lib/author-thesaurus';
 
 // ISR: 24h background revalidation (survives deploys better than revalidate=false)
 export const revalidate = 86400;
@@ -289,7 +289,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
   // to the canonical slug. Falls back to the legacy entity/string path on a miss
   // so no author page regresses while the thesaurus tail is still being linked.
   let data: Awaited<ReturnType<typeof loadAuthorData>> = null;
-  if (AUTHOR_THESAURUS_READPATH) {
+  if (authorThesaurusReadpathEnabled()) {
     const canonical = await loadCanonicalAuthorData(db, name);
     if (canonical) {
       if (canonical.canonicalSlug && canonical.canonicalSlug !== name) {

--- a/src/lib/author-thesaurus.ts
+++ b/src/lib/author-thesaurus.ts
@@ -24,9 +24,19 @@ import { ObjectId } from 'mongodb';
  * the canonical John Calvin page because "John Calvin" is one of his variants.
  */
 
-export const AUTHOR_THESAURUS_READPATH =
-  process.env.AUTHOR_THESAURUS_READPATH === '1' ||
-  process.env.AUTHOR_THESAURUS_READPATH === 'true';
+/**
+ * Whether the canonical read-path is enabled. Read at RUNTIME (per call), not as
+ * a module-level const — a const is evaluated at build/compile time and gets
+ * baked into the importing page's bundle, so a cached page module keeps the old
+ * value and flipping the env var has no effect without a clean rebuild. A
+ * function read at request time picks up the env var on the next request.
+ */
+export function authorThesaurusReadpathEnabled(): boolean {
+  return (
+    process.env.AUTHOR_THESAURUS_READPATH === '1' ||
+    process.env.AUTHOR_THESAURUS_READPATH === 'true'
+  );
+}
 
 /** NFD-strip + lowercase, matching how variants/variant_slugs were built. */
 function norm(s: string): string {


### PR DESCRIPTION
The `AUTHOR_THESAURUS_READPATH` flag was a module-level const evaluated at build time and baked into the importing page's bundle. When the page module is restored from build cache across a deploy, it keeps the stale value — so setting the env var to 1 had **no effect** (verified on production: cold-rendered author pages returned 200, not the canonical redirect). Replaced with a runtime function read. A feature flag must be runtime-readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)