### PR TITLE
perf(collections): serve thumb/medium variants on collection pages, not 4MB full scans

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -18,6 +18,7 @@ import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
 import { bookTitle, sanitizeThumbnail, withTimeout } from '@/lib/collections-utils';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import { galleryThumbLoader } from '@/lib/book-cover-loader';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import { browseBooks } from '@/lib/books-catalog';
 import { supabase } from '@/lib/supabase';
@@ -807,7 +808,8 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                 'grid-cols-3 sm:grid-cols-6'
             }`}>
             {heroImages.map((img: { pageId?: string; page_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string }) => {
-              const src = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
+              const rawSrc = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
+              const src = rawSrc ? galleryThumbLoader({ src: rawSrc, width: 400 }) : rawSrc;
               const key = `${img.pageId || img.page_id}-${img.detectionIndex ?? img.detection_index}`;
               if (!src) return null;
               return (
@@ -834,7 +836,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
         ) : fallbackHeroUrl && (
           <div className="absolute inset-0 opacity-40">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={fallbackHeroUrl} alt="" className="absolute inset-0 w-full h-full object-cover" />
+            <img src={galleryThumbLoader({ src: fallbackHeroUrl, width: 800 })} alt="" className="absolute inset-0 w-full h-full object-cover" />
           </div>
         )}
 
@@ -907,6 +909,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                     {heroUrl ? (
                       <Image
                         src={heroUrl}
+                        loader={galleryThumbLoader}
                         alt={`Illustration from ${child.name}`}
                         fill
                         sizes="(max-width: 640px) 50vw, 25vw"
@@ -967,11 +970,11 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                     {thumb && (
                       <Image
                         src={thumb}
+                        loader={galleryThumbLoader}
                         alt={img.description || img.bookTitle || img.book_title || 'Illustration'}
                         fill
                         className="object-cover group-hover:scale-105 transition-transform duration-300"
                         sizes="(min-width: 1024px) 200px, (min-width: 640px) 160px, 120px"
-                        unoptimized
                       />
                     )}
                     <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2 pt-6 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/app/collections/all/page.tsx
+++ b/src/app/collections/all/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { collectionCountLabel } from '@/lib/collections-utils';
+import { galleryThumbLoader } from '@/lib/book-cover-loader';
 import type { Metadata } from 'next';
 
 export const revalidate = 86400;
@@ -122,11 +123,11 @@ function CollectionCard({ col }: { col: SubCollection }) {
       {col.image ? (
         <Image
           src={col.image}
+          loader={galleryThumbLoader}
           alt={col.name}
           fill
           sizes="(max-width: 640px) 50vw, (max-width: 1024px) 25vw, 16vw"
           className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
-          unoptimized
         />
       ) : (
         <div className="absolute inset-0 bg-warm" />
@@ -179,11 +180,11 @@ export default async function AllCollectionsPage() {
               {wing.image ? (
                 <Image
                   src={wing.image}
+                  loader={galleryThumbLoader}
                   alt={wing.name}
                   fill
                   sizes="100vw"
                   className="object-cover transition-transform duration-500 group-hover:scale-105"
-                  unoptimized
                 />
               ) : (
                 <div className="absolute inset-0 bg-gradient-to-r from-[#2a1f17] to-[#3d2e22]" />

--- a/src/app/collections/contemplative-traditions/page.tsx
+++ b/src/app/collections/contemplative-traditions/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { ArrowLeft, BookOpen } from 'lucide-react';
 import { getReadDb } from '@/lib/mongodb';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
+import { galleryThumbLoader } from '@/lib/book-cover-loader';
 
 export const revalidate = false;
 
@@ -187,6 +188,7 @@ function TraditionCard({ tradition }: { tradition: TraditionCollection }) {
                     {thumb ? (
                       <Image
                         src={thumb}
+                        loader={galleryThumbLoader}
                         alt={book.title}
                         fill
                         className="object-cover group-hover:scale-105 transition-transform duration-300"

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { headers } from 'next/headers';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { sortCollections, sanitizeThumbnail, collectionCountLabel } from '@/lib/collections-utils';
+import { galleryThumbLoader } from '@/lib/book-cover-loader';
 import EraTimeline, { type DecadeBucket } from '@/components/collections/EraTimeline';
 import ShowMorePathways from '@/components/collections/ShowMorePathways';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
@@ -190,6 +191,7 @@ function CollectionCard({ col, tenantSlug, priority = false }: { col: Collection
       {heroUrl ? (
         <Image
           src={heroUrl}
+          loader={galleryThumbLoader}
           alt={`Illustration from ${col.name}`}
           fill
           sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw"
@@ -227,6 +229,7 @@ function CuratedCard({ col, tenantSlug, priority = false }: { col: CollectionDoc
       {heroUrl ? (
         <Image
           src={heroUrl}
+          loader={galleryThumbLoader}
           alt={`Illustration from ${col.name}`}
           fill
           sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"

--- a/src/app/collections/sacred-texts/page.tsx
+++ b/src/app/collections/sacred-texts/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from 'lucide-react';
 import { getReadDb } from '@/lib/mongodb';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
+import { galleryThumbLoader } from '@/lib/book-cover-loader';
 
 export const revalidate = false;
 
@@ -128,11 +129,11 @@ function TraditionCard({ tradition }: { tradition: TraditionCollection }) {
       {heroImage ? (
         <Image
           src={heroImage}
+          loader={galleryThumbLoader}
           alt={`Illustration from ${tradition.name}`}
           fill
           sizes="(max-width: 640px) 50vw, 25vw"
           className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
-          unoptimized
         />
       ) : (
         <div className="absolute inset-0 bg-warm" />

--- a/src/lib/book-cover-loader.ts
+++ b/src/lib/book-cover-loader.ts
@@ -60,3 +60,35 @@ export function bookCoverResponsiveLoader({
 
   return src;
 }
+
+/**
+ * Loader for collection hero / gallery thumbnails.
+ *
+ * These render gallery illustrations (`gallery_images.extracted_url` /
+ * `image_url`), which point at the **full-resolution** `-full.jpg` R2 source
+ * — 3–4 MB scans (e.g. 3409×5254). The slots that show them are small:
+ * 4:3 cards (~400px) and full-width hero banners (~1200px). The original is
+ * never needed here.
+ *
+ * Unlike `bookCoverResponsiveLoader` (which falls through to the source for
+ * large widths), this loader **caps at the medium variant** (`.jpg`,
+ * ~1200px, ~150 KB) and never returns `-full`. Tiny widths get `-thumb.jpg`
+ * (~150px, ~2 KB). A 4 MB scan becomes ~150 KB — roughly 26× smaller.
+ *
+ * Falls through to the original `src` for any URL we don't recognise.
+ */
+export function galleryThumbLoader({
+  src,
+  width,
+}: {
+  src: string;
+  width: number;
+  quality?: number;
+}): string {
+  if (!src.includes(SOURCELIBRARY_HOST)) return src;
+  const variant = width <= 200 ? '-thumb.jpg' : '.jpg';
+  if (src.endsWith('-full.jpg')) return src.replace(/-full\.jpg$/, variant);
+  if (src.endsWith('-thumb.jpg')) return src.replace(/-thumb\.jpg$/, variant);
+  if (src.endsWith('.jpg')) return src.replace(/\.jpg$/, variant);
+  return src;
+}


### PR DESCRIPTION
## Problem

`/collections/sacred-texts` (and the other collection pages) load slowly because their gallery illustrations and book thumbnails are served from the raw `-full.jpg` R2 source — **~4 MB scans** (e.g. 3409×5254). On sacred-texts that's 12 such images. Some used `unoptimized` (browser downloads the full 4 MB); the rest still make the Next optimizer pull 4 MB from R2 per image. The slots that display them are small: 4:3 hero cards (~400px), 64px book thumbnails, full-width hero banners. The original resolution is never shown.

## Fix

New `galleryThumbLoader` in `book-cover-loader.ts` — like `bookCoverResponsiveLoader` but **caps at the medium variant** (`.jpg`, ~1200px, ~150 KB) and never returns `-full`; tiny widths (≤200) get `-thumb.jpg` (~150px, ~2 KB). Wired into every collection gallery/hero image:

- `collections/page.tsx` — index hero cards + curated cards
- `collections/all/page.tsx` — wing + sub-collection cards
- `collections/sacred-texts/page.tsx` — tradition cards
- `collections/contemplative-traditions/page.tsx` — book thumbnails
- `collections/[id]/page.tsx` — hero collage (raw `<img>`), child-collection cards, illustration grid

Dropped `unoptimized` everywhere it appeared on these. **~26× smaller** per gallery thumbnail (4 MB → ~150 KB). R2 variants confirmed present: `-full.jpg` 4 MB / `.jpg` 152 KB / `-thumb.jpg` 2 KB.

## Scope / out of scope

- Covers all `/collections/*` surfaces.
- **Out of scope:** `gallery/*`, `search`, `topics`, `libraries`, `languages`, `curated`, `favorites` pages carry the same `unoptimized` + full-res pattern (~20 more files). Left for a focused follow-up rather than bundling — different surfaces, different review concerns.
- `npx tsc --noEmit` clean on all touched files (pre-existing d3 errors in unrelated blog/carbon-ledger files are not from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)