### PR TITLE
docs(authors): document the canonical author thesaurus + fix builder-script error

### DIFF
--- a/.claude/docs/author-identity-system.md
+++ b/.claude/docs/author-identity-system.md
@@ -29,25 +29,41 @@ and `author_id` are written (transitional); new consumers should read `author_id
 
 ### The `authors` thesaurus doc (`authors` collection)
 
-Built by `scripts/maintenance/build-canonical-authors.mjs` (#2202). One doc per
-canonical person:
+Built by `scripts/maintenance/build-authors-collection.mjs` (#2202) — the
+deterministic clusterer (shared name-key ∪ VIAF ∪ Wikidata). `source` on every
+live doc is `build-authors-collection`. (`build-canonical-authors.mjs` is the
+older read-only sizer — it does NOT write the collection; don't run it to
+rebuild.) Authority on the no-authority tail was then backfilled by the grounded
+reconciler `scripts/maintenance/reconcile-authors-grounded.mjs` (#2218), which
+adds the `anchored_by` / `wikidata_birth_year` / `merged_from` fields below. One
+doc per canonical person:
 
 ```
-_id            "athanasius-kircher"        // == canonical slug
-canonical_name "Athanasius Kircher"
-slug           "athanasius-kircher"
-variants       ["Athanasius Kircher", "Kircher, Athanasius"]   // every author STRING form
-variant_slugs  ["athanasius-kircher", "kircher-athanasius"]    // every URL form that resolves here
-entity_ids     ["6957ef96…"]               // legacy entities merged into this person
-viaf_id        "31998409"                  // external anchors (may be null)
-wikidata_id    "Q76738"
-book_count     71                          // STALE — build-time snapshot, do not trust at render
-source         "build-canonical-authors"
-built_at       <ISO>
+_id                 "athanasius-kircher"   // == canonical slug
+canonical_name      "Athanasius Kircher"
+slug                "athanasius-kircher"
+variants            ["Athanasius Kircher", "Kircher, Athanasius"]   // every author STRING form
+variant_slugs       ["athanasius-kircher", "kircher-athanasius"]    // every URL form that resolves here
+entity_ids          ["6957ef96…"]          // legacy entities merged into this person
+viaf_id             "31998409"             // external anchors (may be null)
+wikidata_id         "Q76738"
+book_count          71                     // STALE — build-time snapshot, do not trust at render
+source              "build-authors-collection"
+built_at            <ISO>
+// added by the grounded reconciler (#2218) when it anchors a previously-bare doc:
+anchored_by         "grounded-reconciliation"   // provenance — present only on grounded anchors
+wikidata_birth_year 1602                    // life-dates from Wikidata (used as the date gate)
+wikidata_death_year 1680
+merged_from         ["Kircher Oedipus"]     // canonical_names of strays folded in on a shared id
 ```
 
 **`book_count` is stale** — it's a build snapshot. The true count is the live
 read-path query (Kircher: doc says 71, actual live is 191). Never render it.
+
+**Coverage (post-#2218):** 4,815 author docs, ~70% Wikidata-anchored, ~52% VIAF
+(up from 27% / 11% at build). The grounded reconciler under-merges rather than
+mis-merges — a same-name person it can't confidently resolve is left bare, not
+wrongly anchored.
 
 ---
 
@@ -242,7 +258,9 @@ Ji off Li Xiaojiang); 28 wrong wikidata anchors cleared (id + dates + portrait,
 |---|---|
 | `src/lib/author-thesaurus.ts` | `resolveCanonicalAuthor()` — the read-path resolver. |
 | `src/app/author/[name]/page.tsx` | Author page; flag-gated canonical branch + 301. |
-| `scripts/maintenance/build-canonical-authors.mjs` | Builds the `authors` thesaurus (#2202). |
+| `scripts/maintenance/build-authors-collection.mjs` | Builds the `authors` thesaurus — deterministic name-key ∪ VIAF ∪ Wikidata (#2202). The actual writer; `source: build-authors-collection`. |
+| `scripts/maintenance/reconcile-authors-grounded.mjs` | Grounded reconciler — anchors the bare tail to a Wikidata QID/VIAF using each author's books as evidence; merges on shared id (#2218). |
+| `scripts/maintenance/build-canonical-authors.mjs` | Older READ-ONLY cluster sizer — does not write `authors`. Superseded by build-authors-collection. |
 | `scripts/maintenance/quarantine-non-person-authors.mjs` | Flags non-persons `is_person:false` (#2230). |
 | `scripts/maintenance/backfill-author-canonical-links.mjs` | Links the tail; writes `author_id` + provenance (#2250). |
 | `scripts/maintenance/dedup-canonical-authors.mjs` | Self-dedup + title-fold + quarantine + `book_count` recompute (#2250 §5). |

--- a/.claude/docs/system-map.md
+++ b/.claude/docs/system-map.md
@@ -132,8 +132,8 @@ Routes: `/artwork/[slug]`, `/artist/[name]`, `/api/artwork/`. Collections suppor
 | `pages_warehouse` | Archived pages (~6.4M) | Same schema |
 | `deleted_books` | Soft-deleted books | Same as books, recoverable |
 | `collections` | Book groupings | `slug`, `name`, `hidden`, `collection_type` |
-| `entities` | Encyclopedia entries | People, places, concepts |
-| `authors` | Normalized author entities | Aliases, Wikipedia, enrichment |
+| `entities` | Legacy per-string author/encyclopedia layer (people, places, concepts). **Being retired for authorship** — superseded by `authors`. | linked via `books.author_entity_id` |
+| `authors` | **Canonical person thesaurus** — one doc per person, `_id`=slug. Books FK via `books.author_id`. | variants, variant_slugs, viaf_id, wikidata_id, entity_ids · see `.claude/docs/author-identity-system.md` |
 
 ### Processing
 | Collection | Purpose |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,14 @@ encodes that:
    after PR #2025 and are candidates for deletion. New contributing libraries
    go in `LIBRARY_PARTNERS`, not in the `tenants` collection.
 
+## Author identity — the `authors` thesaurus (read this before touching author code)
+"Who wrote this, and is *this* Andreas the same as *that* Andreas?" is answered by the canonical **`authors`** collection — one doc per person, `_id` = canonical slug, with `variants[]` / `variant_slugs[]` / `viaf_id` / `wikidata_id`. It **supersedes** the legacy `entities` layer. Umbrella issue #2179.
+
+- **Read `books.author_id` → `authors._id`, not `author_entity_id`.** `author_id` is the canonical FK (~74% of live books linked); `author_entity_id` → `entities` is transitional and being retired. Both are written during migration.
+- **Don't render `authors.book_count`** — it's a stale build snapshot. The true count is the read-path union query.
+- **Build/enrich scripts:** `scripts/maintenance/build-authors-collection.mjs` writes the collection (deterministic name-key ∪ VIAF ∪ Wikidata, #2202); `reconcile-authors-grounded.mjs` anchors the tail to Wikidata/VIAF using each author's books as evidence (#2218). The similarly-named `build-canonical-authors.mjs` is a read-only sizer that does NOT write — don't run it to rebuild.
+- **Read-path** (`/author/[slug]` → `src/lib/author-thesaurus.ts`) is flag-gated by `AUTHOR_THESAURUS_READPATH` and redirects every variant slug to the canonical one. Full design, provenance, and migration status: **`.claude/docs/author-identity-system.md`**.
+
 ## Authentication across subdomains
 
 The NextAuth session cookie is set on `.sourcelibrary.org` (with the leading dot) in production, so signing in on `sourcelibrary.org` carries through to every tenant subdomain (`bph.sourcelibrary.org` today, `kloss/jung/...` later) and vice versa. Gated on `VERCEL_ENV === 'production'` — Vercel previews and localhost stay host-scoped.


### PR DESCRIPTION
The `authors` thesaurus (#2179 / #2250) is now load-bearing infrastructure — ~74% of live books carry `author_id`, the `/author/[slug]` read-path is live behind a flag — but it was **absent from the two docs every session loads** (CLAUDE.md, system-map.md), and the system doc named the wrong build script.

## Changes (docs only)
1. **CLAUDE.md** — new "Author identity" section: read `author_id` not `author_entity_id`; `authors` supersedes `entities`; don't render the stale `book_count`; which script actually writes the collection; pointer to `.claude/docs/author-identity-system.md`.
2. **author-identity-system.md** — fixes a factual error: the collection is built by **`build-authors-collection.mjs`** (verified via the live `source` field), not `build-canonical-authors.mjs` (which is the read-only sizer and writes nothing). Adds the **#2218 grounded reconciler** + its fields (`anchored_by` / `wikidata_birth_year` / `merged_from`) to the schema and file map, plus current coverage (4,815 docs, ~70% Wikidata / ~52% VIAF).
3. **system-map.md** — replaces the stale `authors` row with its real role (canonical person thesaurus + `author_id` FK); marks `entities` as retiring for authorship.

## Out of scope (flagged separately to the #2250 owner)
The thesaurus read-path flag (`AUTHOR_THESAURUS_READPATH="1"`) is set and #2280's runtime-read code is deployed, but cold variant slugs still return 200 instead of 307→canonical — likely the ISR author-page cache was never purged (handoff step-3 `POST /api/admin/revalidate-authors`) or the prod alias serves a pre-#2280 build. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)