### PR TITLE
feat(curator): "Translate Next" disposition dashboard

### DIFF
--- a/src/app/api/admin/translate-queue/route.ts
+++ b/src/app/api/admin/translate-queue/route.ts
@@ -1,0 +1,311 @@
+/**
+ * Curator "Translate Next" queue — disposition dashboard over all
+ * `confirmed_first` first-translation candidates.
+ *
+ * Background: the translation-verification pipeline (PRs #2178/#2190/#2195/
+ * #2205/#2226/#2241) labelled ~6,950 books `translation_verification.disposition
+ * = 'confirmed_first'` + `is_first_translation: true` — "no prior English
+ * translation found, so translating this would be a first." ~93% of those are
+ * already fully translated by us; the actionable tail (~450) is untranslated or
+ * partial. This surface lets a curator review the whole set, filter it, and act:
+ *
+ *   - queue              → flag for translation; a scheduled run picks up
+ *                          `translation_queue.status: 'queued'` in priority order
+ *   - defer              → explicitly not now (keeps it out of the untriaged pile)
+ *   - already_translated → a prior English translation DOES exist; this is not a
+ *                          first-translation candidate. Flips is_first_translation
+ *                          → false and disposition → 'translation_found', stashing
+ *                          the prior values in translation_queue.prior for undo.
+ *   - clear              → remove the curator decision (restores prior flags if the
+ *                          book had been marked already_translated).
+ *
+ * Default ranking is the existing deterministic `processing_priority` composite
+ * (src/lib/processing-priority.ts: subject + language + scan + scholarly +
+ * illustrations + efficiency) — read_count is ~0 across the untranslated tail, so
+ * it can't carry the ranking on its own.
+ *
+ * Page: /platform/admin/translate-queue. Read + mutations gated at editor
+ * (curator) role via withEditorAuth.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { withEditorAuth } from '@/lib/auth-helpers';
+import { getDb, getReadDb } from '@/lib/mongodb';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const BASE_MATCH = {
+  'translation_verification.disposition': 'confirmed_first',
+  is_first_translation: true,
+};
+
+// Readable-translation threshold, matching the homepage-stats invariant in
+// CLAUDE.md: translated if pages_translated >= 90% of (pages_ocr - pages_blank).
+const READABLE_RATIO = 0.9;
+
+// $expr fragment computing the readable denominator: max(0, pages_ocr - pages_blank)
+const DENOM = { $max: [0, { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] }] };
+const PT = { $ifNull: ['$pages_translated', 0] };
+
+const STATUS_EXPR: Record<string, Record<string, unknown>> = {
+  untranslated: { $lte: [PT, 0] },
+  partial: {
+    $and: [
+      { $gt: [PT, 0] },
+      { $lt: [PT, { $multiply: [READABLE_RATIO, DENOM] }] },
+    ],
+  },
+  translated: {
+    $and: [
+      { $gt: [PT, 0] },
+      { $gte: [PT, { $multiply: [READABLE_RATIO, DENOM] }] },
+    ],
+  },
+};
+
+function translationStatus(b: {
+  pages_translated?: number;
+  pages_ocr?: number;
+  pages_blank?: number;
+}): 'translated' | 'partial' | 'untranslated' {
+  const pt = b.pages_translated || 0;
+  if (pt <= 0) return 'untranslated';
+  const denom = Math.max(0, (b.pages_ocr || 0) - (b.pages_blank || 0));
+  if (denom > 0 && pt >= READABLE_RATIO * denom) return 'translated';
+  return 'partial';
+}
+
+export const GET = withEditorAuth(async (request: NextRequest) => {
+  const { searchParams } = new URL(request.url);
+  const lang = searchParams.get('lang') || '';
+  const collection = searchParams.get('collection') || '';
+  const status = searchParams.get('status') || 'all'; // translated|partial|untranslated|all
+  const queue = searchParams.get('queue') || 'all'; // queued|deferred|already_translated|untriaged|all
+  const minReads = Math.max(0, Number(searchParams.get('minReads')) || 0);
+  const q = (searchParams.get('q') || '').trim();
+  const sort = searchParams.get('sort') || 'priority';
+  const page = Math.max(0, Number(searchParams.get('page')) || 0);
+  const limit = Math.min(Math.max(Number(searchParams.get('limit')) || 50, 1), 200);
+
+  const db = await getReadDb();
+  const books = db.collection('books');
+
+  // ── Build the match for the current filters ────────────────────────────
+  const match: Record<string, unknown> = { ...BASE_MATCH };
+  if (lang) match.language = lang;
+  if (collection) match.collections = collection;
+  if (minReads > 0) match.read_count = { $gte: minReads };
+  if (queue === 'untriaged') match.translation_queue = { $exists: false };
+  else if (queue !== 'all') match['translation_queue.status'] = queue;
+  if (q) {
+    const rx = { $regex: q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), $options: 'i' };
+    match.$or = [{ title: rx }, { display_title: rx }, { author: rx }];
+  }
+  const exprs: Record<string, unknown>[] = [];
+  if (status !== 'all' && STATUS_EXPR[status]) exprs.push(STATUS_EXPR[status]);
+  if (exprs.length) match.$expr = exprs.length === 1 ? exprs[0] : { $and: exprs };
+
+  // ── Sort ────────────────────────────────────────────────────────────────
+  // priority: composite processing_priority desc (the default ranking signal).
+  // queue_priority: curator-flagged order (priority asc), for the scheduled run's view.
+  const sortSpec: Record<string, 1 | -1> =
+    sort === 'reads' ? { read_count: -1, processing_priority: -1 }
+    : sort === 'pages_asc' ? { pages_count: 1, processing_priority: -1 }
+    : sort === 'pages_desc' ? { pages_count: -1, processing_priority: -1 }
+    : sort === 'recent' ? { 'translation_queue.set_at': -1 }
+    : sort === 'queue_priority' ? { 'translation_queue.priority': 1, processing_priority: -1 }
+    : { processing_priority: -1, read_count: -1 }; // priority (default)
+
+  const projection = {
+    _id: 0,
+    id: 1,
+    slug: 1,
+    title: 1,
+    display_title: 1,
+    author: 1,
+    language: 1,
+    collections: 1,
+    read_count: 1,
+    pages_count: 1,
+    pages_translated: 1,
+    pages_ocr: 1,
+    pages_blank: 1,
+    processing_priority: 1,
+    'translation_verification.disposition': 1,
+    'translation_verification.confidence': 1,
+    'translation_verification.validated_translations': 1,
+    'translation_verification.verification_audit': 1,
+    translation_queue: 1,
+  };
+
+  const [rows, totalArr] = await Promise.all([
+    books.aggregate([
+      { $match: match },
+      { $sort: sortSpec },
+      { $skip: page * limit },
+      { $limit: limit },
+      { $project: projection },
+    ]).toArray(),
+    books.aggregate([{ $match: match }, { $count: 'n' }]).toArray(),
+  ]);
+  const total = totalArr[0]?.n || 0;
+
+  const items = rows.map((b) => {
+    const tv = b.translation_verification || {};
+    const validated = (tv.validated_translations || []) as Array<Record<string, unknown>>;
+    const audit = tv.verification_audit || null;
+    return {
+      id: b.id,
+      slug: b.slug,
+      title: b.display_title || b.title,
+      author: b.author,
+      language: b.language,
+      collections: b.collections || [],
+      read_count: b.read_count || 0,
+      pages_count: b.pages_count || 0,
+      pages_translated: b.pages_translated || 0,
+      status: translationStatus(b),
+      priority_score: typeof b.processing_priority === 'number' ? b.processing_priority : null,
+      confidence: tv.confidence || null,
+      validated_count: validated.length,
+      validated_first: validated[0] || null,
+      audit: audit ? { verdict: audit.verdict, confidence: audit.confidence } : null,
+      queue: b.translation_queue || null,
+    };
+  });
+
+  // ── Global facets (over the base set, independent of active filters) ─────
+  const [langFacet, statusFacet, queueFacet, collFacet] = await Promise.all([
+    books.aggregate([
+      { $match: BASE_MATCH },
+      { $group: { _id: '$language', n: { $sum: 1 } } },
+      { $sort: { n: -1 } },
+      { $limit: 25 },
+    ]).toArray(),
+    books.aggregate([
+      { $match: BASE_MATCH },
+      {
+        $group: {
+          _id: null,
+          untranslated: { $sum: { $cond: [STATUS_EXPR.untranslated, 1, 0] } },
+          partial: { $sum: { $cond: [STATUS_EXPR.partial, 1, 0] } },
+          translated: { $sum: { $cond: [STATUS_EXPR.translated, 1, 0] } },
+        },
+      },
+    ]).toArray(),
+    books.aggregate([
+      { $match: BASE_MATCH },
+      { $group: { _id: { $ifNull: ['$translation_queue.status', 'untriaged'] }, n: { $sum: 1 } } },
+    ]).toArray(),
+    books.aggregate([
+      { $match: BASE_MATCH },
+      { $unwind: '$collections' },
+      { $group: { _id: '$collections', n: { $sum: 1 } } },
+      { $sort: { n: -1 } },
+      { $limit: 30 },
+    ]).toArray(),
+  ]);
+
+  const queueCounts: Record<string, number> = {};
+  for (const r of queueFacet) queueCounts[r._id as string] = r.n;
+
+  return NextResponse.json({
+    total,
+    page,
+    limit,
+    items,
+    facets: {
+      languages: langFacet.map((l) => ({ language: l._id || 'Unknown', count: l.n })),
+      collections: collFacet.map((c) => ({ collection: c._id, count: c.n })),
+      status: statusFacet[0] || { untranslated: 0, partial: 0, translated: 0 },
+      queue: queueCounts,
+    },
+  });
+});
+
+type Action = 'queue' | 'defer' | 'already_translated' | 'clear';
+
+export const POST = withEditorAuth(async (request: NextRequest, session) => {
+  const body = await request.json().catch(() => null);
+  const id = body?.id as string | undefined;
+  const action = body?.action as Action | undefined;
+  if (!id || !action) {
+    return NextResponse.json({ error: 'id and action required' }, { status: 400 });
+  }
+
+  const db = await getDb();
+  const books = db.collection('books');
+  const book = await books.findOne(
+    { id },
+    { projection: { id: 1, is_first_translation: 1, 'translation_verification.disposition': 1, translation_queue: 1 } },
+  );
+  if (!book) return NextResponse.json({ error: 'book not found' }, { status: 404 });
+
+  const by = (session.user as { email?: string })?.email || 'unknown';
+  const now = new Date();
+  const note = typeof body.note === 'string' ? body.note.trim() : '';
+
+  if (action === 'queue') {
+    const priority = [1, 2, 3].includes(Number(body.priority)) ? Number(body.priority) : 2;
+    await books.updateOne({ id }, {
+      $set: {
+        translation_queue: { status: 'queued', priority, note, set_by: by, set_at: now },
+      },
+    });
+    return NextResponse.json({ ok: true, status: 'queued', priority });
+  }
+
+  if (action === 'defer') {
+    await books.updateOne({ id }, {
+      $set: { translation_queue: { status: 'deferred', note, set_by: by, set_at: now } },
+    });
+    return NextResponse.json({ ok: true, status: 'deferred' });
+  }
+
+  if (action === 'already_translated') {
+    // Consequential: a prior English translation exists, so this is NOT a
+    // first-translation candidate. Flip the bibliographic flags, stashing the
+    // prior values for undo via `clear`.
+    const external = body.external_translation && typeof body.external_translation === 'object'
+      ? body.external_translation
+      : null;
+    await books.updateOne({ id }, {
+      $set: {
+        translation_queue: {
+          status: 'already_translated',
+          note,
+          external_translation: external,
+          set_by: by,
+          set_at: now,
+          prior: {
+            is_first_translation: book.is_first_translation ?? null,
+            disposition: book.translation_verification?.disposition ?? null,
+          },
+        },
+        is_first_translation: false,
+        'translation_verification.disposition': 'translation_found',
+        'translation_verification.disposition_reasoning':
+          `Curator (${by}) marked already-translated${note ? `: ${note}` : ''}`,
+        'translation_verification.disposition_at': now,
+      },
+    });
+    return NextResponse.json({ ok: true, status: 'already_translated' });
+  }
+
+  if (action === 'clear') {
+    const prior = book.translation_queue?.prior;
+    const update: Record<string, unknown> = { $unset: { translation_queue: '' } };
+    // Restore flags if we had flipped them when marking already_translated.
+    if (prior) {
+      update.$set = {
+        is_first_translation: prior.is_first_translation ?? true,
+        'translation_verification.disposition': prior.disposition ?? 'confirmed_first',
+        'translation_verification.disposition_at': now,
+      };
+    }
+    await books.updateOne({ id }, update);
+    return NextResponse.json({ ok: true, status: 'cleared', restored: !!prior });
+  }
+
+  return NextResponse.json({ error: `unknown action: ${action}` }, { status: 400 });
+});

--- a/src/app/platform/(protected)/admin/translate-queue/TranslateQueueClient.tsx
+++ b/src/app/platform/(protected)/admin/translate-queue/TranslateQueueClient.tsx
@@ -1,0 +1,463 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface QueueState {
+  status: 'queued' | 'deferred' | 'already_translated';
+  priority?: number;
+  note?: string;
+  set_by?: string;
+  set_at?: string;
+}
+
+interface Item {
+  id: string;
+  slug?: string;
+  title: string;
+  author?: string;
+  language?: string;
+  collections: string[];
+  read_count: number;
+  pages_count: number;
+  pages_translated: number;
+  status: 'translated' | 'partial' | 'untranslated';
+  priority_score: number | null;
+  confidence: string | null;
+  validated_count: number;
+  validated_first: { english_title?: string; translator?: string; pub_year?: string } | null;
+  audit: { verdict?: string; confidence?: string } | null;
+  queue: QueueState | null;
+}
+
+interface Facets {
+  languages: { language: string; count: number }[];
+  collections: { collection: string; count: number }[];
+  status: { untranslated: number; partial: number; translated: number };
+  queue: Record<string, number>;
+}
+
+interface ApiResponse {
+  total: number;
+  page: number;
+  limit: number;
+  items: Item[];
+  facets: Facets;
+}
+
+const C = {
+  bg: '#0d1117',
+  panel: '#161b22',
+  border: '#30363d',
+  text: '#e6edf3',
+  dim: '#8b949e',
+  accent: '#58a6ff',
+  green: '#3fb950',
+  amber: '#d29922',
+  red: '#f85149',
+  purple: '#bc8cff',
+};
+
+const STATUS_COLOR: Record<Item['status'], string> = {
+  translated: C.green,
+  partial: C.amber,
+  untranslated: C.red,
+};
+
+const QUEUE_COLOR: Record<string, string> = {
+  queued: C.accent,
+  deferred: C.dim,
+  already_translated: C.purple,
+};
+
+const LIMIT = 50;
+
+function chip(label: string, color: string, title?: string) {
+  return (
+    <span
+      title={title}
+      style={{
+        fontSize: 11,
+        fontWeight: 600,
+        color,
+        border: `1px solid ${color}`,
+        borderRadius: 4,
+        padding: '1px 6px',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function TranslateQueueClient() {
+  const [lang, setLang] = useState('');
+  const [collection, setCollection] = useState('');
+  const [status, setStatus] = useState('all');
+  const [queue, setQueue] = useState('all');
+  const [minReads, setMinReads] = useState(0);
+  const [q, setQ] = useState('');
+  const [sort, setSort] = useState('priority');
+  const [page, setPage] = useState(0);
+
+  const [data, setData] = useState<ApiResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [acting, setActing] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchData = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+    const params = new URLSearchParams({
+      status,
+      queue,
+      sort,
+      page: String(page),
+      limit: String(LIMIT),
+    });
+    if (lang) params.set('lang', lang);
+    if (collection) params.set('collection', collection);
+    if (minReads > 0) params.set('minReads', String(minReads));
+    if (q.trim()) params.set('q', q.trim());
+    try {
+      const res = await fetch(`/api/admin/translate-queue?${params}`, { signal: controller.signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = (await res.json()) as ApiResponse;
+      if (abortRef.current === controller) setData(json);
+    } catch (e) {
+      if ((e as Error).name !== 'AbortError') setError((e as Error).message);
+    } finally {
+      if (abortRef.current === controller) setLoading(false);
+    }
+  }, [lang, collection, status, queue, minReads, q, sort, page]);
+
+  // Debounce the text query; everything else fires immediately.
+  useEffect(() => {
+    const t = setTimeout(fetchData, q ? 350 : 0);
+    return () => clearTimeout(t);
+  }, [fetchData, q]);
+
+  // Reset to page 0 whenever a filter (not the page itself) changes.
+  useEffect(() => {
+    setPage(0);
+  }, [lang, collection, status, queue, minReads, q, sort]);
+
+  const act = useCallback(
+    async (id: string, action: string, extra: Record<string, unknown> = {}) => {
+      setActing(id);
+      try {
+        const res = await fetch('/api/admin/translate-queue', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id, action, ...extra }),
+        });
+        if (!res.ok) {
+          const j = await res.json().catch(() => ({}));
+          throw new Error(j.error || `HTTP ${res.status}`);
+        }
+        await fetchData();
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setActing(null);
+      }
+    },
+    [fetchData],
+  );
+
+  const facets = data?.facets;
+  const totalPages = data ? Math.ceil(data.total / LIMIT) : 0;
+
+  const qf = facets?.queue ?? {};
+
+  const selStyle: React.CSSProperties = {
+    background: C.bg,
+    color: C.text,
+    border: `1px solid ${C.border}`,
+    borderRadius: 6,
+    padding: '5px 8px',
+    fontSize: 13,
+  };
+
+  return (
+    <div style={{ maxWidth: 1280, margin: '0 auto' }}>
+      <div style={{ marginBottom: 4 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 600, margin: 0 }}>Translate Next</h1>
+        <p style={{ color: C.dim, fontSize: 13, margin: '4px 0 0' }}>
+          First-translation candidates (<code>confirmed_first</code>). Queue a book for translation, defer
+          it, or mark it already-translated. Ranked by composite priority score.
+        </p>
+      </div>
+
+      {/* Summary stat cards */}
+      {facets && (
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', margin: '16px 0' }}>
+          <Stat label="Untranslated" value={facets.status.untranslated} color={C.red} onClick={() => { setStatus('untranslated'); setQueue('all'); }} />
+          <Stat label="Partial" value={facets.status.partial} color={C.amber} onClick={() => { setStatus('partial'); setQueue('all'); }} />
+          <Stat label="Translated" value={facets.status.translated} color={C.green} onClick={() => { setStatus('translated'); setQueue('all'); }} />
+          <div style={{ width: 1, background: C.border, margin: '0 4px' }} />
+          <Stat label="Queued" value={qf.queued || 0} color={C.accent} onClick={() => { setQueue('queued'); setStatus('all'); }} />
+          <Stat label="Deferred" value={qf.deferred || 0} color={C.dim} onClick={() => { setQueue('deferred'); setStatus('all'); }} />
+          <Stat label="Already translated" value={qf.already_translated || 0} color={C.purple} onClick={() => { setQueue('already_translated'); setStatus('all'); }} />
+          <Stat label="Untriaged" value={qf.untriaged || 0} color={C.text} onClick={() => { setQueue('untriaged'); setStatus('all'); }} />
+        </div>
+      )}
+
+      {/* Filter bar */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 10,
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          background: C.panel,
+          border: `1px solid ${C.border}`,
+          borderRadius: 8,
+          padding: 12,
+          marginBottom: 14,
+        }}
+      >
+        <input
+          placeholder="Search title or author…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          style={{ ...selStyle, minWidth: 220, flex: 1 }}
+        />
+        <select value={lang} onChange={(e) => setLang(e.target.value)} style={selStyle}>
+          <option value="">All languages</option>
+          {facets?.languages.map((l) => (
+            <option key={l.language} value={l.language}>
+              {l.language} ({l.count})
+            </option>
+          ))}
+        </select>
+        <select value={collection} onChange={(e) => setCollection(e.target.value)} style={selStyle}>
+          <option value="">All collections</option>
+          {facets?.collections.map((c) => (
+            <option key={c.collection} value={c.collection}>
+              {c.collection} ({c.count})
+            </option>
+          ))}
+        </select>
+        <select value={status} onChange={(e) => setStatus(e.target.value)} style={selStyle}>
+          <option value="all">Any status</option>
+          <option value="untranslated">Untranslated</option>
+          <option value="partial">Partial</option>
+          <option value="translated">Translated</option>
+        </select>
+        <select value={queue} onChange={(e) => setQueue(e.target.value)} style={selStyle}>
+          <option value="all">Any triage</option>
+          <option value="untriaged">Untriaged</option>
+          <option value="queued">Queued</option>
+          <option value="deferred">Deferred</option>
+          <option value="already_translated">Already translated</option>
+        </select>
+        <select value={String(minReads)} onChange={(e) => setMinReads(Number(e.target.value))} style={selStyle}>
+          <option value="0">Any reads</option>
+          <option value="1">1+ reads</option>
+          <option value="5">5+ reads</option>
+          <option value="20">20+ reads</option>
+        </select>
+        <select value={sort} onChange={(e) => setSort(e.target.value)} style={selStyle}>
+          <option value="priority">Sort: Priority score</option>
+          <option value="reads">Sort: Read count</option>
+          <option value="pages_asc">Sort: Fewest pages</option>
+          <option value="pages_desc">Sort: Most pages</option>
+          <option value="queue_priority">Sort: Queue priority</option>
+          <option value="recent">Sort: Recently triaged</option>
+        </select>
+      </div>
+
+      {error && (
+        <div style={{ color: C.red, fontSize: 13, marginBottom: 10 }}>Error: {error}</div>
+      )}
+
+      <div style={{ color: C.dim, fontSize: 12, marginBottom: 8 }}>
+        {loading ? 'Loading…' : `${data?.total ?? 0} books · page ${page + 1} of ${totalPages || 1}`}
+      </div>
+
+      {/* Table */}
+      <div style={{ border: `1px solid ${C.border}`, borderRadius: 8, overflow: 'hidden' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr style={{ background: C.panel, color: C.dim, textAlign: 'left' }}>
+              <th style={th}>Book</th>
+              <th style={th}>Lang</th>
+              <th style={{ ...th, textAlign: 'right' }}>Pages</th>
+              <th style={{ ...th, textAlign: 'right' }}>Reads</th>
+              <th style={{ ...th, textAlign: 'right' }}>Score</th>
+              <th style={th}>Status</th>
+              <th style={th}>Triage</th>
+              <th style={{ ...th, width: 280 }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data?.items.map((b) => (
+              <Row key={b.id} b={b} acting={acting === b.id} onAct={act} />
+            ))}
+            {!loading && data?.items.length === 0 && (
+              <tr>
+                <td colSpan={8} style={{ padding: 24, textAlign: 'center', color: C.dim }}>
+                  No books match these filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 16 }}>
+          <button onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0} style={pageBtn(page === 0)}>
+            ← Prev
+          </button>
+          <span style={{ color: C.dim, fontSize: 13, alignSelf: 'center' }}>
+            {page + 1} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={page >= totalPages - 1}
+            style={pageBtn(page >= totalPages - 1)}
+          >
+            Next →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, color, onClick }: { label: string; value: number; color: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        background: C.panel,
+        border: `1px solid ${C.border}`,
+        borderRadius: 8,
+        padding: '8px 14px',
+        cursor: 'pointer',
+        textAlign: 'left',
+        minWidth: 96,
+      }}
+    >
+      <div style={{ fontSize: 20, fontWeight: 700, color }}>{value.toLocaleString()}</div>
+      <div style={{ fontSize: 11, color: C.dim }}>{label}</div>
+    </button>
+  );
+}
+
+function Row({ b, acting, onAct }: { b: Item; acting: boolean; onAct: (id: string, action: string, extra?: Record<string, unknown>) => void }) {
+  const [priority, setPriority] = useState(2);
+  const bookUrl = `https://sourcelibrary.org/book/${b.slug || b.id}`;
+  return (
+    <tr style={{ borderTop: `1px solid ${C.border}`, opacity: acting ? 0.5 : 1 }}>
+      <td style={td}>
+        <a href={bookUrl} target="_blank" rel="noreferrer" style={{ color: C.accent, textDecoration: 'none', fontWeight: 500 }}>
+          {b.title}
+        </a>
+        <div style={{ color: C.dim, fontSize: 12 }}>
+          {b.author || '—'}
+          {b.collections.length > 0 && <span> · {b.collections.slice(0, 3).join(', ')}</span>}
+        </div>
+        {(b.validated_count > 0 || b.audit) && (
+          <div style={{ display: 'flex', gap: 6, marginTop: 4, flexWrap: 'wrap' }}>
+            {b.validated_count > 0 &&
+              chip(
+                `catalog: ${b.validated_first?.translator || b.validated_first?.english_title || b.validated_count}`,
+                C.purple,
+                'A prior translation was found in a catalog — consider "Already translated"',
+              )}
+            {b.audit?.verdict && chip(`audit: ${b.audit.verdict}`, C.dim, `confidence: ${b.audit.confidence || '—'}`)}
+          </div>
+        )}
+      </td>
+      <td style={td}>{b.language || '—'}</td>
+      <td style={{ ...td, textAlign: 'right' }}>
+        {b.pages_count}
+        {b.status === 'partial' && (
+          <div style={{ fontSize: 11, color: C.amber }}>{b.pages_translated} done</div>
+        )}
+      </td>
+      <td style={{ ...td, textAlign: 'right' }}>{b.read_count}</td>
+      <td style={{ ...td, textAlign: 'right', fontWeight: 600 }}>{b.priority_score ?? '—'}</td>
+      <td style={td}>{chip(b.status, STATUS_COLOR[b.status])}</td>
+      <td style={td}>
+        {b.queue
+          ? chip(
+              b.queue.status === 'queued' ? `queued P${b.queue.priority}` : b.queue.status.replace('_', ' '),
+              QUEUE_COLOR[b.queue.status] || C.text,
+              b.queue.note ? `${b.queue.note} — ${b.queue.set_by || ''}` : b.queue.set_by,
+            )
+          : chip('untriaged', C.dim)}
+      </td>
+      <td style={td}>
+        <div style={{ display: 'flex', gap: 4, alignItems: 'center', flexWrap: 'wrap' }}>
+          <select
+            value={priority}
+            onChange={(e) => setPriority(Number(e.target.value))}
+            disabled={acting}
+            style={{ background: C.bg, color: C.text, border: `1px solid ${C.border}`, borderRadius: 4, fontSize: 12, padding: '2px 4px' }}
+            title="Queue priority"
+          >
+            <option value={1}>P1</option>
+            <option value={2}>P2</option>
+            <option value={3}>P3</option>
+          </select>
+          <ActBtn label="Queue" color={C.accent} disabled={acting} onClick={() => onAct(b.id, 'queue', { priority })} />
+          <ActBtn label="Defer" color={C.dim} disabled={acting} onClick={() => onAct(b.id, 'defer')} />
+          <ActBtn
+            label="Translated"
+            color={C.purple}
+            disabled={acting}
+            onClick={() => {
+              if (confirm(`Mark "${b.title}" as already translated? This flips is_first_translation → false.`)) {
+                onAct(b.id, 'already_translated');
+              }
+            }}
+          />
+          {b.queue && <ActBtn label="Clear" color={C.text} disabled={acting} onClick={() => onAct(b.id, 'clear')} />}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function ActBtn({ label, color, onClick, disabled }: { label: string; color: string; onClick: () => void; disabled: boolean }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        background: 'transparent',
+        color,
+        border: `1px solid ${color}`,
+        borderRadius: 4,
+        padding: '3px 8px',
+        fontSize: 12,
+        cursor: disabled ? 'default' : 'pointer',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+const th: React.CSSProperties = { padding: '8px 12px', fontWeight: 600, fontSize: 12 };
+const td: React.CSSProperties = { padding: '10px 12px', verticalAlign: 'top' };
+function pageBtn(disabled: boolean): React.CSSProperties {
+  return {
+    background: C.panel,
+    color: disabled ? C.dim : C.text,
+    border: `1px solid ${C.border}`,
+    borderRadius: 6,
+    padding: '6px 14px',
+    fontSize: 13,
+    cursor: disabled ? 'default' : 'pointer',
+  };
+}

--- a/src/app/platform/(protected)/admin/translate-queue/page.tsx
+++ b/src/app/platform/(protected)/admin/translate-queue/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * Curator "Translate Next" dashboard.
+ *
+ * Disposition queue over every `confirmed_first` first-translation candidate.
+ * A curator filters by language / collection / translation status / read count
+ * and acts on each book: queue it for translation (a scheduled run consumes
+ * `translation_queue.status: 'queued'` in priority order), defer it, or mark it
+ * already-translated (a prior English translation exists — flips it out of the
+ * first-translation set).
+ *
+ * Gated by the platform-protected layout (requireSuperAdmin). All data + writes
+ * go through /api/admin/translate-queue (editor role).
+ */
+import { TranslateQueueClient } from './TranslateQueueClient';
+
+export const dynamic = 'force-dynamic';
+
+export default function TranslateQueuePage() {
+  return <TranslateQueueClient />;
+}

--- a/src/app/platform/PlatformNav.tsx
+++ b/src/app/platform/PlatformNav.tsx
@@ -7,6 +7,7 @@ import { useSession, signOut } from 'next-auth/react';
 
 const navLinks = [
   { href: '/platform/dashboard', label: 'Dashboard' },
+  { href: '/platform/admin/translate-queue', label: 'Translate Next' },
   { href: '/platform/tenants/new', label: 'New Library' },
 ];
 


### PR DESCRIPTION
## What

A platform-admin **disposition dashboard** over every `confirmed_first` first-translation candidate (~6,950 books). A curator filters the set and acts on each book.

**Page:** `/platform/admin/translate-queue` (superadmin via the protected layout; mutation API gated at editor/curator).

## Why a full dashboard, not a tight work queue

I probed production before designing. The premise ("7,908 books to triage for translation") doesn't match the data:

- **6,499** confirmed_first books are **already fully translated** by us (≥90% readable)
- **131** partial
- **322** untranslated

So the literal "translate next" opportunity is only ~450 books. The durable curatorial value is reviewing dispositions across the *whole* set — catching books where a prior English translation actually exists (mark already-translated), deferring, and queuing the genuine opportunities. That's the scope chosen in the design conversation.

Also: `read_count` is ~0 across the untranslated tail (median 0, max 9) — it can't carry the ranking, so the default sort is the existing deterministic **`processing_priority`** composite (subject + language + scan + scholarly + illustrations + efficiency, from `src/lib/processing-priority.ts`), which is already populated on 90% of these books.

## Changes

- **`GET/POST /api/admin/translate-queue`** (`withEditorAuth`)
  - filter by language / collection / translation status / read count / text search
  - sort by priority score (default), reads, page count, queue priority, recency
  - actions:
    - `queue` (P1–P3) — flags `translation_queue.status:'queued'` for a scheduled run to consume in priority order
    - `defer`
    - `already_translated` — flips `is_first_translation → false` and disposition → `translation_found`, **stashing prior values in `translation_queue.prior` for undo**
    - `clear` — removes the decision, restoring prior flags if it had been marked already-translated
  - global facets (status / queue / language / collection counts)
- **`/platform/admin/translate-queue`** page + client (dark platform theme): summary stat cards (click to filter), filter bar, sortable table with catalog/audit evidence chips, per-row actions, pagination
- **PlatformNav:** "Translate Next" link

## Verification

- `npx tsc --noEmit` clean on all new files (the 14 repo errors are pre-existing d3 type gaps in `carbon-ledger` blog interactives, unrelated)
- Aggregation logic verified against prod: status facet returns 322 / 131 / 6499; filtered+sorted queries return correct composite-ranked rows
- Pre-commit import scan passes

## Out of scope (deliberate)

Wiring the **scheduled run** that consumes `translation_queue.status:'queued'`. The field + P1–P3 priority contract are in place and queryable; the consumer (daily-sourcelibrary / a cron sorted by `translation_queue.priority`) is a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)