### PR TITLE
feat(curator): translation-failure triage + scoped batch-retry

### DIFF
--- a/src/app/api/admin/translation-failures/route.ts
+++ b/src/app/api/admin/translation-failures/route.ts
@@ -1,0 +1,203 @@
+/**
+ * Translation-failure triage — confirmed_first first-translation candidates that
+ * are stuck in the pipeline rather than waiting to be queued.
+ *
+ * Motivation: of ~322 untranslated `confirmed_first` books, ~226 are
+ * `pipeline_auto.status` failed / needs_attention (they ran and broke), not
+ * un-queued work. Re-queuing a book that already failed just fails again — so
+ * triage groups them by ROOT CAUSE and only re-enrolls the buckets that are
+ * genuinely retryable. These are shippable first translations once unblocked,
+ * which is why the scope is confirmed_first + untranslated specifically.
+ *
+ * Root-cause buckets observed in prod:
+ *   - import_failed_empty   → never got pages; needs re-acquisition, NOT a retry
+ *   - ocr_finalize_blocked  → OCR produced 0 pages; retry is worth a shot
+ *   - ocr_failed_precondition → gemini-preview deprecation casualties; root cause
+ *                              already fixed (commit f346e288), so retry should work
+ *   - image_download_failed → provider hiccup (retry) unless IA access-restricted (park)
+ *   - ia_access_restricted  → lending/printdisabled; unarchivable, do not retry
+ *
+ * Retry re-enrolls in place (status → 'queued', retry_count → 0) — the same
+ * mechanism as /api/admin/enroll-pipeline, but scoped to this set so a stray id
+ * can't be enrolled through here. Page: /platform/admin/translation-failures.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { withEditorAuth } from '@/lib/auth-helpers';
+import { getDb, getReadDb } from '@/lib/mongodb';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const SCOPE = {
+  'translation_verification.disposition': 'confirmed_first',
+  is_first_translation: true,
+  $expr: { $lte: [{ $ifNull: ['$pages_translated', 0] }, 0] },
+  'pipeline_auto.status': { $in: ['failed', 'needs_attention'] },
+};
+
+type BucketKey =
+  | 'import_failed_empty'
+  | 'ocr_finalize_blocked'
+  | 'ocr_failed_precondition'
+  | 'image_download_failed'
+  | 'ia_access_restricted'
+  | 'other';
+
+interface BucketMeta {
+  label: string;
+  detail: string;
+  action: 'retry' | 'reacquire' | 'park' | 'review';
+}
+
+// retry = re-enrolling should help; reacquire = needs a fresh source; park = unfixable
+// here; review = unknown, look before acting.
+const BUCKETS: Record<BucketKey, BucketMeta> = {
+  ocr_failed_precondition: {
+    label: 'OCR precondition failed',
+    detail: 'gemini-preview deprecation casualties — root cause fixed, retry should now succeed.',
+    action: 'retry',
+  },
+  ocr_finalize_blocked: {
+    label: 'OCR finalize blocked',
+    detail: 'OCR produced 0 usable pages. Re-enrolling re-runs OCR; worth a shot.',
+    action: 'retry',
+  },
+  image_download_failed: {
+    label: 'Image download failed',
+    detail: 'Page images failed to download — often a transient provider hiccup.',
+    action: 'retry',
+  },
+  import_failed_empty: {
+    label: 'Import failed (empty)',
+    detail: 'The import never produced pages. Needs re-acquisition from another source — a retry will not help.',
+    action: 'reacquire',
+  },
+  ia_access_restricted: {
+    label: 'IA access-restricted',
+    detail: 'Lending / print-disabled at the Internet Archive — unarchivable. Park or find another source.',
+    action: 'park',
+  },
+  other: {
+    label: 'Other / unclassified',
+    detail: 'No matched signature — inspect the error before acting.',
+    action: 'review',
+  },
+};
+
+function classify(pa: { error?: string; attention_reason?: string }): BucketKey {
+  const reason = pa.attention_reason || '';
+  const err = pa.error || '';
+  if (reason === 'import_failed_empty') return 'import_failed_empty';
+  if (reason === 'ocr_finalize_blocked' || /Finalize blocked/i.test(err)) return 'ocr_finalize_blocked';
+  if (/access-restricted|lending|printdisabled/i.test(err)) return 'ia_access_restricted';
+  if (reason === 'image_download_failed' || /image downloads? failed/i.test(err)) return 'image_download_failed';
+  if (/FAILED_PRECONDITION|Precondition check/i.test(err)) return 'ocr_failed_precondition';
+  return 'other';
+}
+
+export const GET = withEditorAuth(async () => {
+  const db = await getReadDb();
+  const rows = await db.collection('books')
+    .find(SCOPE)
+    .project({
+      _id: 0,
+      id: 1,
+      slug: 1,
+      title: 1,
+      display_title: 1,
+      author: 1,
+      language: 1,
+      pages_count: 1,
+      pages_ocr: 1,
+      'pipeline_auto.status': 1,
+      'pipeline_auto.error': 1,
+      'pipeline_auto.attention_reason': 1,
+      'pipeline_auto.retry_count': 1,
+      'pipeline_auto.last_updated': 1,
+    })
+    .toArray();
+
+  const grouped: Record<BucketKey, Array<Record<string, unknown>>> = {
+    ocr_failed_precondition: [], ocr_finalize_blocked: [], image_download_failed: [],
+    import_failed_empty: [], ia_access_restricted: [], other: [],
+  };
+
+  for (const b of rows) {
+    const pa = b.pipeline_auto || {};
+    const key = classify(pa);
+    grouped[key].push({
+      id: b.id,
+      slug: b.slug,
+      title: b.display_title || b.title,
+      author: b.author,
+      language: b.language,
+      pages_count: b.pages_count || 0,
+      pages_ocr: b.pages_ocr || 0,
+      status: pa.status,
+      retry_count: pa.retry_count || 0,
+      error: (pa.error || pa.attention_reason || '').toString().slice(0, 200),
+      last_updated: pa.last_updated || null,
+    });
+  }
+
+  const buckets = (Object.keys(BUCKETS) as BucketKey[])
+    .map((key) => ({
+      key,
+      ...BUCKETS[key],
+      count: grouped[key].length,
+      retryable: BUCKETS[key].action === 'retry',
+      books: grouped[key].sort((a, b) => (b.pages_count as number) - (a.pages_count as number)),
+    }))
+    .filter((b) => b.count > 0);
+
+  return NextResponse.json({ total: rows.length, buckets });
+});
+
+export const POST = withEditorAuth(async (request: NextRequest, session) => {
+  const body = await request.json().catch(() => null);
+  const bookIds = Array.isArray(body?.bookIds) ? body.bookIds.filter((x: unknown) => typeof x === 'string') : [];
+  if (bookIds.length === 0) {
+    return NextResponse.json({ error: 'bookIds (string[]) required' }, { status: 400 });
+  }
+  if (bookIds.length > 500) {
+    return NextResponse.json({ error: 'too many books in one retry (max 500)' }, { status: 400 });
+  }
+
+  const db = await getDb();
+  const now = new Date();
+  const by = (session.user as { email?: string })?.email || 'unknown';
+
+  // Scope guard: only re-enroll ids that are actually in the failed/needs_attention
+  // confirmed_first untranslated set — a stray id can't be queued through here.
+  const inScope = await db.collection('books')
+    .find({ ...SCOPE, id: { $in: bookIds } })
+    .project({ id: 1, _id: 0 })
+    .toArray();
+  const scopedIds = inScope.map((b) => b.id);
+  if (scopedIds.length === 0) {
+    return NextResponse.json({ error: 'no provided ids are in the retryable scope' }, { status: 400 });
+  }
+
+  const result = await db.collection('books').updateMany(
+    { id: { $in: scopedIds } },
+    {
+      $set: {
+        'pipeline_auto.status': 'queued',
+        'pipeline_auto.source': 'admin-triage',
+        'pipeline_auto.retry_count': 0,
+        'pipeline_auto.queued_at': now,
+        'pipeline_auto.last_updated': now,
+        'pipeline_auto.requeued_by': by,
+        updated_at: now,
+      },
+    },
+  );
+
+  return NextResponse.json({
+    ok: true,
+    requested: bookIds.length,
+    requeued: result.modifiedCount,
+    skipped: bookIds.length - scopedIds.length,
+    message: `Re-enrolled ${result.modifiedCount} book(s). The pipeline cron picks them up within ~10 minutes.`,
+  });
+});

--- a/src/app/platform/(protected)/admin/translation-failures/TranslationFailuresClient.tsx
+++ b/src/app/platform/(protected)/admin/translation-failures/TranslationFailuresClient.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+interface Book {
+  id: string;
+  slug?: string;
+  title: string;
+  author?: string;
+  language?: string;
+  pages_count: number;
+  pages_ocr: number;
+  status: string;
+  retry_count: number;
+  error: string;
+  last_updated: string | null;
+}
+
+interface Bucket {
+  key: string;
+  label: string;
+  detail: string;
+  action: 'retry' | 'reacquire' | 'park' | 'review';
+  count: number;
+  retryable: boolean;
+  books: Book[];
+}
+
+interface ApiResponse {
+  total: number;
+  buckets: Bucket[];
+}
+
+const C = {
+  bg: '#0d1117', panel: '#161b22', border: '#30363d', text: '#e6edf3',
+  dim: '#8b949e', accent: '#58a6ff', green: '#3fb950', amber: '#d29922',
+  red: '#f85149', purple: '#bc8cff',
+};
+
+const ACTION_COLOR: Record<Bucket['action'], string> = {
+  retry: C.green, reacquire: C.amber, park: C.dim, review: C.purple,
+};
+
+export function TranslationFailuresClient() {
+  const [data, setData] = useState<ApiResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [flash, setFlash] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/translation-failures');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData((await res.json()) as ApiResponse);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const retry = useCallback(
+    async (bucket: Bucket) => {
+      if (!confirm(`Re-enroll ${bucket.count} book(s) in "${bucket.label}"? The pipeline cron picks them up within ~10 min.`)) return;
+      setBusy(bucket.key);
+      setFlash(null);
+      try {
+        const res = await fetch('/api/admin/translation-failures', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ bookIds: bucket.books.map((b) => b.id) }),
+        });
+        const j = await res.json();
+        if (!res.ok) throw new Error(j.error || `HTTP ${res.status}`);
+        setFlash(j.message || `Re-enrolled ${j.requeued}.`);
+        await load();
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [load],
+  );
+
+  return (
+    <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+      <h1 style={{ fontSize: 22, fontWeight: 600, margin: 0 }}>Translation-Failure Triage</h1>
+      <p style={{ color: C.dim, fontSize: 13, margin: '4px 0 0' }}>
+        First-translation candidates (<code>confirmed_first</code>) that are untranslated because they
+        broke in the pipeline — grouped by root cause. Retry only re-enrolls buckets where re-running
+        actually helps; <span style={{ color: C.amber }}>re-acquire</span> /{' '}
+        <span style={{ color: C.dim }}>park</span> buckets need a different fix.
+      </p>
+
+      {flash && (
+        <div style={{ background: '#0f2a16', border: `1px solid ${C.green}`, color: C.green, borderRadius: 8, padding: '10px 14px', fontSize: 13, margin: '14px 0' }}>
+          {flash}
+        </div>
+      )}
+      {error && <div style={{ color: C.red, fontSize: 13, margin: '14px 0' }}>Error: {error}</div>}
+
+      <div style={{ color: C.dim, fontSize: 12, margin: '16px 0 8px' }}>
+        {loading ? 'Loading…' : `${data?.total ?? 0} stuck first-translation candidates across ${data?.buckets.length ?? 0} root causes`}
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {data?.buckets.map((bucket) => {
+          const color = ACTION_COLOR[bucket.action];
+          const isOpen = open === bucket.key;
+          return (
+            <div key={bucket.key} style={{ border: `1px solid ${C.border}`, borderRadius: 8, overflow: 'hidden' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '14px 16px', background: C.panel }}>
+                <div style={{ fontSize: 26, fontWeight: 700, color, minWidth: 48, textAlign: 'right' }}>{bucket.count}</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 15, fontWeight: 600 }}>
+                    {bucket.label}
+                    <span style={{ marginLeft: 10, fontSize: 11, fontWeight: 700, color, border: `1px solid ${color}`, borderRadius: 4, padding: '1px 6px', textTransform: 'uppercase' }}>
+                      {bucket.action}
+                    </span>
+                  </div>
+                  <div style={{ fontSize: 12.5, color: C.dim, marginTop: 3 }}>{bucket.detail}</div>
+                </div>
+                <button onClick={() => setOpen(isOpen ? null : bucket.key)} style={btn(C.dim, busy === bucket.key)}>
+                  {isOpen ? 'Hide' : 'Show'} books
+                </button>
+                {bucket.retryable && (
+                  <button onClick={() => retry(bucket)} disabled={busy === bucket.key} style={btn(C.green, busy === bucket.key)}>
+                    {busy === bucket.key ? 'Re-enrolling…' : `Retry ${bucket.count}`}
+                  </button>
+                )}
+              </div>
+              {isOpen && (
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12.5 }}>
+                  <thead>
+                    <tr style={{ color: C.dim, textAlign: 'left', background: C.bg }}>
+                      <th style={th}>Book</th>
+                      <th style={th}>Lang</th>
+                      <th style={{ ...th, textAlign: 'right' }}>Pages</th>
+                      <th style={{ ...th, textAlign: 'right' }}>Retries</th>
+                      <th style={th}>Error</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {bucket.books.map((b) => (
+                      <tr key={b.id} style={{ borderTop: `1px solid ${C.border}` }}>
+                        <td style={td}>
+                          <a href={`https://sourcelibrary.org/book/${b.slug || b.id}`} target="_blank" rel="noreferrer" style={{ color: C.accent, textDecoration: 'none' }}>
+                            {b.title}
+                          </a>
+                          <div style={{ color: C.dim, fontSize: 11 }}>{b.author || '—'}</div>
+                        </td>
+                        <td style={td}>{b.language || '—'}</td>
+                        <td style={{ ...td, textAlign: 'right' }}>{b.pages_ocr}/{b.pages_count}</td>
+                        <td style={{ ...td, textAlign: 'right' }}>{b.retry_count}</td>
+                        <td style={{ ...td, color: C.dim, fontFamily: 'monospace', fontSize: 11 }}>{b.error || '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          );
+        })}
+        {!loading && data?.buckets.length === 0 && (
+          <div style={{ color: C.dim, padding: 24, textAlign: 'center' }}>No stuck first-translation candidates — the queue is clear.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function btn(color: string, disabled: boolean): React.CSSProperties {
+  return {
+    background: 'transparent', color, border: `1px solid ${color}`, borderRadius: 6,
+    padding: '6px 12px', fontSize: 13, fontWeight: 500, whiteSpace: 'nowrap',
+    cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.6 : 1,
+  };
+}
+
+const th: React.CSSProperties = { padding: '8px 12px', fontWeight: 600, fontSize: 11 };
+const td: React.CSSProperties = { padding: '8px 12px', verticalAlign: 'top' };

--- a/src/app/platform/(protected)/admin/translation-failures/page.tsx
+++ b/src/app/platform/(protected)/admin/translation-failures/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Translation-failure triage dashboard.
+ *
+ * confirmed_first first-translation candidates that are untranslated because
+ * they failed / need attention in the pipeline — grouped by root cause, with
+ * batch-retry on the genuinely-retryable buckets. See the API route for the
+ * bucket taxonomy. Gated by the protected layout (requireSuperAdmin); data +
+ * retry go through /api/admin/translation-failures.
+ */
+import { TranslationFailuresClient } from './TranslationFailuresClient';
+
+export const dynamic = 'force-dynamic';
+
+export default function TranslationFailuresPage() {
+  return <TranslationFailuresClient />;
+}

--- a/src/app/platform/PlatformNav.tsx
+++ b/src/app/platform/PlatformNav.tsx
@@ -7,6 +7,7 @@ import { useSession, signOut } from 'next-auth/react';
 
 const navLinks = [
   { href: '/platform/dashboard', label: 'Dashboard' },
+  { href: '/platform/admin/translation-failures', label: 'Translation Failures' },
   { href: '/platform/tenants/new', label: 'New Library' },
 ];
 


### PR DESCRIPTION
## What

A platform-admin **triage view** for `confirmed_first` first-translation candidates that are untranslated **because they broke in the pipeline** — grouped by root cause, with batch-retry on the buckets where re-running actually helps.

**Page:** `/platform/admin/translation-failures`

## Why (replaces #2283)

I started on a "translate next" queue (#2283) but checking the data killed the premise: of 6,952 `confirmed_first` books, **93% are already translated**. Of the 322 untranslated, **226 are `pipeline_auto` failed / needs_attention** — they ran and broke, they aren't waiting to be queued. A queue button would mostly re-point at books that already failed. The thing that actually ships more first translations is unblocking the failures, so I closed #2283 and built this instead.

## Root-cause buckets (verified against prod — 226 books, 0 unclassified)

| Count | Bucket | Action |
|---|---|---|
| **27** | OCR `FAILED_PRECONDITION` | **retry** — `gemini-preview` deprecation casualties; root cause already fixed (`f346e288`), so retry should now succeed. The high-confidence win. |
| 67 | OCR finalize blocked (0 pages) | retry — worth a shot |
| 28 | Image download failed | retry — usually a transient provider hiccup |
| 103 | Import failed (empty) | **reacquire** — never got pages; a retry won't help, needs a fresh source |
| 1 | IA access-restricted | **park** — lending/print-disabled, unarchivable |

122 retryable, 104 need a different fix. The view is honest about which is which — only retryable buckets get a retry button; reacquire/park are labelled, not given a button that does nothing.

## Changes

- **`GET/POST /api/admin/translation-failures`** (`withEditorAuth`)
  - GET groups the scope (confirmed_first + untranslated + failed/needs_attention) by error signature into actionable buckets
  - POST re-enrolls (`status → queued`, `retry_count → 0`) — same mechanism as `enroll-pipeline`, but **scope-guarded**: a stray id outside the failed set can't be queued through here. Capped at 500/call.
- **`/platform/admin/translation-failures`** page + client (dark platform theme): per-bucket count, root-cause explanation, action chip, expandable book list with error strings + retry counts, batch-retry on retryable buckets, success flash.
- **PlatformNav:** "Translation Failures" link.

## Verification

- `npx tsc --noEmit` clean on all new files (14 repo errors are pre-existing d3 type gaps in unrelated carbon-ledger blog code)
- Bucket classification re-run against prod mirrors the route's exact `classify()` — 226 total, split 103/67/28/27/1, nothing falls through to "other"
- Pre-commit import scan passes

## After merge

The obvious first action is **Retry 27** on the OCR-precondition bucket — those are the deprecation casualties whose root cause is fixed, so they should flow straight through. The cron picks up re-enrolled books within ~10 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)