### PR TITLE
docs: monthly CLAUDE.md staleness audit (2026-06)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Derek runs ~10 Claude Code terminals simultaneously, all sharing the main workin
 ## Visibility & Stats Invariants
 Lessons from PR #2055 (see `.claude/handoffs/`). The homepage and most public surfaces filter on `visible: true`, but `hidden: true` exists as a parallel flag. When the two disagree, books leak into public counts.
 
-- **`visible` and `hidden` must be opposites.** Every writer that sets `hidden: true` must also set `visible: false` (and vice versa for un-hide). Don't write one without the other. Active writers: `scripts/maintenance/hide-{unarchived,efm-duplicates}.mjs`, `scripts/maintenance/set-launch-books.mjs`, `scripts/workers/pipeline-orchestrator.mjs`, `src/app/api/admin/duplicates/route.ts`, `src/app/api/books/[id]/visibility/route.ts`. Historical drift cleaned up by `scripts/maintenance/fix-conflicting-visibility.mjs` — re-run if `db.books.countDocuments({ visible: true, hidden: true })` ever climbs above zero again.
+- **`visible` and `hidden` must be opposites.** Every writer that sets `hidden: true` must also set `visible: false` (and vice versa for un-hide). Don't write one without the other. Active writers: `scripts/maintenance/hide-{unarchived-books,efm-duplicates}.mjs`, `scripts/maintenance/set-launch-books.mjs`, `scripts/workers/pipeline-orchestrator.mjs`, `src/app/api/admin/duplicates/route.ts`, `src/app/api/books/[id]/visibility/route.ts`. Historical drift cleaned up by `scripts/maintenance/fix-conflicting-visibility.mjs` — re-run if `db.books.countDocuments({ visible: true, hidden: true })` ever climbs above zero again.
 - **Homepage stats live in `system_config.homepage_stats`** (Mongo). Refreshed daily at 05:00 by `scripts/maintenance/prewarm-browse.mjs`, also writable on demand by `scripts/maintenance/update-homepage-stats.mjs`. Both scripts now share the same canonical filters — keep them in sync if you touch either. The canonical filters are:
   - `totalBooks` / `authorCount` / `languageCount`: `visible: true && pages_count > 0` (plus `pages_translated > 0` for authors/languages)
   - `translatedToEnglish`: ≥90% "readable" — `pages_translated >= 0.9 * (pages_ocr - pages_blank)`
@@ -126,7 +126,7 @@ Source: `src/lib/auth.ts` (cookies block). See `.claude/docs/auth-tenant-cookies
 
 ## Stack
 - Next.js 16, MongoDB Atlas, Gemini AI, Vercel deployment
-- Production database: `bookstore`, NOT `sourcelibrary_research`. As of 2026-05-26: ~46K total docs, ~29K `visible: true` (publicly shown), ~15K with `pages_count > 0` (actually processed), ~14K with any OCR. The `tier` field is legacy (only used by `src/app/page.tsx` homepage ranking, seeded by `scripts/tmp-write-highlighted-books.mjs`); current canonical "live" filter across all public APIs is `visible: true && pages_count > 0` (see `/api/books/library`).
+- Production database: `bookstore`, NOT `sourcelibrary_research`. As of 2026-05-26: ~46K total docs, ~29K `visible: true` (publicly shown), ~15K with `pages_count > 0` (actually processed), ~14K with any OCR. The `tier` field is legacy (only used by `src/app/page.tsx` homepage ranking via `highlighted_books` collection entries); current canonical "live" filter across all public APIs is `visible: true && pages_count > 0` (see `/api/books/library`).
 
 ## AI Models — IMPORTANT
 - Summary/Index generation: enrich-worker uses `gemini-3.1-flash-lite` for all phases — summary+index (Phase 6), chapters (Phase 7), quality scoring (Phase 7.5), collection assignment (Phase 7.6). NEVER use models older than v3.
@@ -155,7 +155,7 @@ OCR/translation text in `pages.{ocr,translation}.data` is wrapped in AI-written 
 ## System Map
 - **Interactive diagram:** https://sourcelibrary.org/platform/admin/system-map — click any node for details, key files, collections, gotchas (requires platform login)
 - **Markdown reference:** `.claude/docs/system-map.md` — full text version with file layout, collection inventory, dead code list
-- **Dead code cleanup:** GitHub issue #258 (closed) — most cleaned up, some camera components may remain. Note: rithmomachia is a live feature (`/[tenant]/rithmomachia`), not dead code.
+- **Dead code cleanup:** GitHub issue #258 (closed) — most cleaned up, some camera components may remain. Note: rithmomachia is a live feature (`/rithmomachia`, at `src/app/rithmomachia`), not dead code.
 
 ## Domain Context
 


### PR DESCRIPTION
## Summary

Monthly automated audit of CLAUDE.md for stale file paths, symbol names, route URLs, and script references. Three drift items found and fixed.

## Stale references fixed

| # | Stale reference | Fix applied | Evidence |
|---|-----------------|-------------|----------|
| 1 | `scripts/maintenance/hide-{unarchived,efm-duplicates}.mjs` | → `hide-{unarchived-books,efm-duplicates}.mjs` | `test -f scripts/maintenance/hide-unarchived.mjs` → missing; `test -f scripts/maintenance/hide-unarchived-books.mjs` → exists |
| 2 | `scripts/tmp-write-highlighted-books.mjs` (cited as seeding the `tier` field) | Removed deleted script; replaced with description of current mechanism (`highlighted_books` collection entries) | `find scripts/ -name "tmp-write-highlighted-books.mjs"` → no output; `git log -- scripts/tmp-write-highlighted-books.mjs` → no history |
| 3 | `/[tenant]/rithmomachia` (described as the live rithmomachia route) | → `/rithmomachia` (`src/app/rithmomachia`) | `find src/app -type d -name rithmomachia` → `src/app/rithmomachia` (no `[tenant]` ancestor); `find src/app/\[tenant\] -name rithmomachia` → empty |

## What was checked and found clean

All other references in CLAUDE.md verified against the codebase:
- All other script paths under `scripts/maintenance/`, `scripts/workers/`, `scripts/` — present
- All `src/lib/`, `src/app/`, `.claude/docs/`, `memory/` file paths — present
- Route directories: `/api/books/restore`, `/api/books/library`, `/api/search`, `/api/books/[id]/search`, `/api/likes/popular`, `/api/likes/mine`, `/api/learn`, `/embed`, `/blog`, `/libraries`, `/api/[tenant]/books/[id]/quote` — all exist under `src/app/`
- Symbols: `getTenantMembershipRole`, `withAuth`/`withEditorAuth`/`withAdminAuth`, `stripEditorialWrappers`, `getShortUrl`, `getRequestBaseUrl`, `LIBRARY_PARTNERS`, `BibliographicInfo.tsx`, `cleanText` — all present
- MongoDB collections: `deleted_books`, `system_config`, `gallery_images`, `memberships`, `tenants` — all referenced in `src/`
- GitHub issue #258 — confirmed `closed` / `completed`
- `/platform/admin/system-map` URL — confirmed at `src/app/platform/(protected)/admin/system-map/page.tsx`

## Out of scope

- Prose/tone/style — not changed
- `.claude/worktrees/` absence — expected (only exists when worktrees are active, not drift)

https://claude.ai/code/session_01XRaJnJFNW22NYoVNbFP4fj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRaJnJFNW22NYoVNbFP4fj)_