### PR TITLE
feat(images): canonical size-first page-image URL resolver (#1727) — core only

### DIFF
--- a/scripts/lib/page-image-url.mjs
+++ b/scripts/lib/page-image-url.mjs
@@ -1,0 +1,42 @@
+/**
+ * JS twin of src/lib/page-image-url.ts for pipeline/worker scripts (issue #1727).
+ *
+ * Scripts choose the OCR / image-extraction SOURCE — they want the original
+ * readable image, not a display resize. So this twin exports `getPageSource`
+ * (the split-aware source-identity normalizer) and the two small predicates it
+ * needs. Keep it in lockstep with `getPageSource` in the TS module.
+ *
+ * Why a separate copy: scripts run as plain .mjs and can't import the `@/`
+ * TS-path-aliased lib. The logic is small and stable; the unit tests assert the
+ * two implementations agree.
+ */
+
+/** A usable HTTP(S) image URL (not a "failed:HTTP 404" marker). */
+export function isUsableImageUrl(url) {
+  return !!url && (url.startsWith('http://') || url.startsWith('https://'));
+}
+
+/** Archiving was attempted and failed — the source URLs are known dead. */
+export function isArchiveFailed(photo) {
+  return typeof photo === 'string' && photo.startsWith('failed:');
+}
+
+/**
+ * The original-resolution source image for a page — the file to OCR, download,
+ * or resize from. Split-aware:
+ *   1. cropped_photo        — old-era split: materialized cropped half
+ *   2. split_from_spread photo — new-era split: `photo` rewritten to the sp… half
+ *   3. archiving failed → null
+ *   4. archived_photo → photo_original → photo
+ *
+ * (enhanced_photo intentionally omitted — dead field, 0% populated.)
+ */
+export function getPageSource(page) {
+  if (isUsableImageUrl(page.cropped_photo)) return page.cropped_photo;
+  if (page.split_from_spread && isUsableImageUrl(page.photo)) return page.photo;
+  if (isArchiveFailed(page.archived_photo)) return null;
+  if (isUsableImageUrl(page.archived_photo)) return page.archived_photo;
+  if (isUsableImageUrl(page.photo_original)) return page.photo_original;
+  if (isUsableImageUrl(page.photo)) return page.photo;
+  return null;
+}

--- a/src/lib/page-image-url.ts
+++ b/src/lib/page-image-url.ts
@@ -1,0 +1,209 @@
+/**
+ * Canonical page-image URL resolver — issue #1727.
+ *
+ * Two orthogonal axes, and only one is universal:
+ *  - SIZE (100% of pages): every page needs thumb / display / original / hires.
+ *    This is the spine — `getPageImageUrl(page, size)`.
+ *  - SOURCE IDENTITY (~10% need care): which file *is* this page. Obvious for
+ *    most pages; the only non-trivial case is split-from-spread scans, where
+ *    "the page" is half a physical scan. Handled once in `getPageSource()`.
+ *
+ * Invariants:
+ *  - `thumb` / `display` always return a browser-safe, size-bounded URL — a
+ *    pre-sized R2 variant, an IIIF-native resize, or the /api/image proxy.
+ *    Never the raw full-res original, never a .jp2/.tif.
+ *  - The raw original is reserved for `original` (OCR/download) and `hires`.
+ *  - Never routes through /_next/image (metered Vercel image optimization).
+ *
+ * Size tiers (cheapest → fallback):
+ *   pre-sized R2 variant (free egress)
+ *     → IIIF-native resize `/full/{w},/` (origin server resizes, free, blockable)
+ *       → /api/image sharp proxy (our compute, cached 1 week)
+ *         → raw original (only for `original`/`hires`)
+ *
+ * JP2/TIFF never reach here: providers' IIIF servers transcode to JPEG, and our
+ * archive pipeline runs opj_decompress → JPEG on R2. 100% of stored URLs are .jpg.
+ */
+import { isUsableImageUrl, isArchiveFailed } from '@/lib/utils';
+
+export type ImageSize = 'thumb' | 'display' | 'original' | 'hires';
+
+const DISPLAY_WIDTH = 1200;
+const THUMB_WIDTH = 150;
+const HIRES_WIDTH = 4000;
+
+/**
+ * Structural subset of a page document. Works with Mongo docs, Partial<Page>,
+ * and API projections — only the image-bearing fields matter here.
+ */
+export interface PageImageFields {
+  photo?: string | null;
+  photo_original?: string | null;
+  archived_photo?: string | null;
+  cropped_photo?: string | null;
+  display_photo?: string | null;
+  image_thumb?: string | null;
+  /** @deprecated superseded by image_thumb; still read as a fallback */
+  thumbnail_blob?: string | null;
+  thumbnail?: string | null;
+  split_from_spread?: boolean;
+  crop?: { xStart?: number; xEnd?: number } | null;
+}
+
+/** Formats a browser cannot render — must never be returned for display/thumb. */
+const UNSAFE_FORMAT = /\.(jp2|jpx|jpf|j2k|tiff?)(\?|$)/i;
+
+/**
+ * True if the URL is safe to hand straight to an <img>. Note: an IIIF URL that
+ * merely *contains* `.jp2` as its source identifier but ends in `default.jpg`
+ * is safe — we only reject URLs whose final extension is non-renderable.
+ */
+function isBrowserSafe(url: string): boolean {
+  return !UNSAFE_FORMAT.test(url);
+}
+
+/**
+ * IIIF-native resize: ask the origin server for a given width by rewriting the
+ * size segment of a IIIF Image API URL (`/full/{size}/{rot}/{quality}.jpg`).
+ * Returns null for non-IIIF URLs. Free, but the origin can rate-limit/block —
+ * callers fall back to the /api/image proxy.
+ */
+function iiifResize(url: string, width: number): string | null {
+  if (!/\/full\/(full|max|\d+,|,\d+|pct:[\d.]+)\/\d+\/(default|color|gray|bitonal)\.(jpe?g|png)$/i.test(url)) {
+    return null;
+  }
+  return url.replace(/\/full\/(full|max|\d+,|,\d+|pct:[\d.]+)\//, `/full/${width},/`);
+}
+
+/** Build an /api/image proxy URL (our sharp resizer, Cloudflare-cached). */
+function proxyUrl(
+  base: string,
+  width: number,
+  quality: number,
+  crop?: { xStart?: number; xEnd?: number } | null,
+): string {
+  let url = `/api/image?url=${encodeURIComponent(base)}&w=${width}&q=${quality}`;
+  if (crop && crop.xStart !== undefined && crop.xEnd !== undefined) {
+    url += `&cx=${crop.xStart}&cw=${crop.xEnd}`;
+  }
+  return url;
+}
+
+/**
+ * Derive a pre-sized R2 variant from a canonical `pages/{bookId}/{NNNN}` photo
+ * URL (handles the `sp` prefix for new-era split halves). Returns null if the
+ * photo isn't a canonical pages/ URL.
+ */
+function deriveVariant(photo: string | null | undefined, size: 'display' | 'thumb'): string | null {
+  if (!photo) return null;
+  const m = photo.match(
+    /^(https:\/\/images\.sourcelibrary\.org\/pages\/[^/]+\/(?:sp[a-z0-9]*-?)?\d{4,})(-full)?\.jpg$/,
+  );
+  if (!m) return null;
+  return size === 'thumb' ? `${m[1]}-thumb.jpg` : `${m[1]}.jpg`;
+}
+
+/**
+ * The original-resolution source image for a page — the file to OCR, download,
+ * or resize from. This is the SOURCE-identity axis: trivial for most pages, but
+ * split-aware for the ~10% split-from-spread scans.
+ *
+ * Precedence:
+ *   1. `cropped_photo` — old-era split: the materialized cropped half (unambiguous).
+ *   2. split-from-spread `photo` — new-era split: the splitter rewrote `photo`
+ *      to the `sp…` cropped half.
+ *   3. archiving failed → null (archiving already proved the source URLs dead).
+ *   4. `archived_photo` → `photo_original` → `photo` (normal pages).
+ *
+ * (`enhanced_photo` is intentionally omitted — 0% populated, a dead field.)
+ */
+export function getPageSource(page: PageImageFields): string | null {
+  if (isUsableImageUrl(page.cropped_photo)) return page.cropped_photo;
+  if (page.split_from_spread && isUsableImageUrl(page.photo)) return page.photo;
+  if (isArchiveFailed(page.archived_photo)) return null;
+  if (isUsableImageUrl(page.archived_photo)) return page.archived_photo;
+  if (isUsableImageUrl(page.photo_original)) return page.photo_original;
+  if (isUsableImageUrl(page.photo)) return page.photo;
+  return null;
+}
+
+/**
+ * Resolve a display- or thumb-sized URL. Prefers a pre-sized R2 variant, then an
+ * IIIF-native resize, then the /api/image proxy. Always browser-safe and bounded.
+ */
+function resolveSized(page: PageImageFields, size: 'display' | 'thumb'): string | null {
+  const width = size === 'thumb' ? THUMB_WIDTH : DISPLAY_WIDTH;
+  const quality = size === 'thumb' ? 60 : 80;
+  const hasCroppedHalf = isUsableImageUrl(page.cropped_photo);
+
+  // (A) Pre-sized R2 variant — only when it matches the *displayed* content.
+  // Skip for old-era split pages: their display_photo / image_thumb are resizes
+  // of the UNcropped image, so using them would show more than the cropped half.
+  if (!hasCroppedHalf) {
+    if (size === 'display' && isUsableImageUrl(page.display_photo)) return page.display_photo;
+    if (size === 'thumb') {
+      if (isUsableImageUrl(page.image_thumb)) return page.image_thumb;
+      if (isUsableImageUrl(page.thumbnail_blob)) return page.thumbnail_blob;
+    }
+    const derived = deriveVariant(page.photo, size);
+    if (derived) return derived;
+  }
+
+  // (B) No matching pre-sized variant → resize the logical source on the fly.
+  const base = getPageSource(page);
+  if (!base || !isBrowserSafe(base)) {
+    // Source unusable for display; last-resort browser-safe thumbnail field.
+    if (size === 'thumb' && isUsableImageUrl(page.thumbnail)) return page.thumbnail;
+    return null;
+  }
+
+  // Crop-coords-only page (no materialized half): proxy must crop the source.
+  const crop =
+    !hasCroppedHalf && page.crop?.xStart !== undefined && page.crop?.xEnd !== undefined
+      ? page.crop
+      : undefined;
+  if (!crop) {
+    const iiif = iiifResize(base, width);
+    if (iiif) return iiif;
+  }
+  return proxyUrl(base, width, quality, crop);
+}
+
+/** Resolve a large (zoom/magnifier) URL — IIIF-native at high width, else proxy. */
+function resolveHires(page: PageImageFields): string | null {
+  const base = getPageSource(page);
+  if (!base || !isBrowserSafe(base)) return null;
+  const crop =
+    !isUsableImageUrl(page.cropped_photo) &&
+    page.crop?.xStart !== undefined &&
+    page.crop?.xEnd !== undefined
+      ? page.crop
+      : undefined;
+  if (!crop) {
+    const iiif = iiifResize(base, HIRES_WIDTH);
+    if (iiif) return iiif;
+  }
+  return proxyUrl(base, HIRES_WIDTH, 85, crop);
+}
+
+/**
+ * Canonical entry point. Resolve the URL for a page at the requested size.
+ *
+ * - `thumb` (~150px) / `display` (~1200px): browser-safe, bounded, free-first.
+ * - `original`: the raw full-res source (OCR, download). May be large; not for
+ *   browser display unless you know it's safe.
+ * - `hires`: large bounded image for zoom/magnifier (~4000px via IIIF or proxy).
+ *
+ * Returns null when the page has no usable image (e.g. archiving failed).
+ */
+export function getPageImageUrl(page: PageImageFields, size: ImageSize = 'display'): string | null {
+  switch (size) {
+    case 'original':
+      return getPageSource(page);
+    case 'hires':
+      return resolveHires(page);
+    case 'thumb':
+    case 'display':
+      return resolveSized(page, size);
+  }
+}

--- a/tests/unit/page-image-url.test.ts
+++ b/tests/unit/page-image-url.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { getPageImageUrl, getPageSource, type PageImageFields } from '@/lib/page-image-url';
+import { getPageSource as getPageSourceJs } from '../../scripts/lib/page-image-url.mjs';
+
+const R2 = 'https://images.sourcelibrary.org';
+const BOOK = '674057212677591a7c897d60';
+
+// One representative page per real-world shape we measured in the corpus.
+const fixtures: Record<string, PageImageFields> = {
+  // ~89%: a normal archived page with pre-sized variants.
+  normal: {
+    photo: `${R2}/pages/${BOOK}/0005-full.jpg`,
+    archived_photo: `${R2}/archived/${BOOK}/5.jpg`,
+    display_photo: `${R2}/pages/${BOOK}/0005.jpg`,
+    image_thumb: `${R2}/pages/${BOOK}/0005-thumb.jpg`,
+  },
+  // Old-era split: cropped_photo is the half; display_photo is the WRONG uncropped resize.
+  oldSplit: {
+    split_from_spread: true,
+    cropped_photo: `${R2}/cropped/${BOOK}/abc123.jpg`,
+    photo: `${R2}/archived/${BOOK}/1.jpg`,
+    archived_photo: `${R2}/archived/${BOOK}/1.jpg`,
+    display_photo: `${R2}/pages/${BOOK}/0001.jpg`,
+  },
+  // New-era split: photo is already the `sp…` half; display_photo is correct.
+  newSplit: {
+    split_from_spread: true,
+    photo: `${R2}/pages/${BOOK}/sp0014-full.jpg`,
+    archived_photo: `${R2}/pages/${BOOK}/sp0014-full.jpg`,
+    display_photo: `${R2}/pages/${BOOK}/sp0014.jpg`,
+  },
+  // IIIF source, no R2 variant: origin server resizes via /full/{w},/.
+  iiif: {
+    photo: `https://digi.vatlib.it/iiifimage/MSS_Vat.arm.19/Vat.arm.19_0003.jp2/full/1000,/0/default.jpg`,
+  },
+  // Raw JP2 source (no variant): browser-unsafe — must not be served for display.
+  rawJp2: {
+    photo: `https://example.org/scans/${BOOK}/0007.jp2`,
+  },
+  // Archiving failed: source URLs are dead.
+  failed: {
+    archived_photo: 'failed:HTTP 404',
+    photo: `${R2}/archived/${BOOK}/9.jpg`,
+  },
+};
+
+describe('getPageImageUrl — universal size axis', () => {
+  it('normal page: display → pre-sized R2 display variant (free)', () => {
+    expect(getPageImageUrl(fixtures.normal, 'display')).toBe(`${R2}/pages/${BOOK}/0005.jpg`);
+  });
+  it('normal page: thumb → pre-sized R2 thumb variant', () => {
+    expect(getPageImageUrl(fixtures.normal, 'thumb')).toBe(`${R2}/pages/${BOOK}/0005-thumb.jpg`);
+  });
+  it('normal page: original → the archived source', () => {
+    expect(getPageImageUrl(fixtures.normal, 'original')).toBe(`${R2}/archived/${BOOK}/5.jpg`);
+  });
+  it('default size is display', () => {
+    expect(getPageImageUrl(fixtures.normal)).toBe(getPageImageUrl(fixtures.normal, 'display'));
+  });
+});
+
+describe('split-from-spread source identity', () => {
+  it('old-era: display proxies the cropped half, NOT the uncropped display_photo', () => {
+    const url = getPageImageUrl(fixtures.oldSplit, 'display')!;
+    expect(url).toContain('/api/image');
+    expect(url).toContain(encodeURIComponent(`${R2}/cropped/${BOOK}/abc123.jpg`));
+    expect(url).not.toContain('0001.jpg'); // the trap variant
+  });
+  it('old-era: original → the cropped half', () => {
+    expect(getPageImageUrl(fixtures.oldSplit, 'original')).toBe(`${R2}/cropped/${BOOK}/abc123.jpg`);
+  });
+  it('new-era: display → the correct sp… display variant', () => {
+    expect(getPageImageUrl(fixtures.newSplit, 'display')).toBe(`${R2}/pages/${BOOK}/sp0014.jpg`);
+  });
+  it('new-era: thumb → derived sp… thumb variant', () => {
+    expect(getPageImageUrl(fixtures.newSplit, 'thumb')).toBe(`${R2}/pages/${BOOK}/sp0014-thumb.jpg`);
+  });
+  it('new-era: original → the sp… half', () => {
+    expect(getPageImageUrl(fixtures.newSplit, 'original')).toBe(`${R2}/pages/${BOOK}/sp0014-full.jpg`);
+  });
+});
+
+describe('IIIF-native resize tier', () => {
+  it('display → rewrites the IIIF size segment to the requested width', () => {
+    expect(getPageImageUrl(fixtures.iiif, 'display')).toBe(
+      `https://digi.vatlib.it/iiifimage/MSS_Vat.arm.19/Vat.arm.19_0003.jp2/full/1200,/0/default.jpg`,
+    );
+  });
+  it('thumb → IIIF size segment at thumb width', () => {
+    expect(getPageImageUrl(fixtures.iiif, 'thumb')).toContain('/full/150,/');
+  });
+  it('a .jp2 mid-URL ending in default.jpg is browser-safe (not rejected)', () => {
+    expect(getPageImageUrl(fixtures.iiif, 'display')).not.toBeNull();
+  });
+});
+
+describe('format & failure guards', () => {
+  it('raw .jp2 source is not served for display (browser-unsafe)', () => {
+    expect(getPageImageUrl(fixtures.rawJp2, 'display')).toBeNull();
+    expect(getPageImageUrl(fixtures.rawJp2, 'thumb')).toBeNull();
+  });
+  it('raw .jp2 is still returned for original (OCR/download can transcode)', () => {
+    expect(getPageImageUrl(fixtures.rawJp2, 'original')).toBe(`https://example.org/scans/${BOOK}/0007.jp2`);
+  });
+  it('failed archive → null at every size', () => {
+    for (const size of ['thumb', 'display', 'original', 'hires'] as const) {
+      expect(getPageImageUrl(fixtures.failed, size)).toBeNull();
+    }
+  });
+});
+
+describe('cost-tier invariant', () => {
+  it('never routes through the metered Vercel image optimizer', () => {
+    for (const page of Object.values(fixtures)) {
+      for (const size of ['thumb', 'display', 'original', 'hires'] as const) {
+        const url = getPageImageUrl(page, size);
+        if (url) expect(url).not.toContain('/_next/image');
+      }
+    }
+  });
+});
+
+describe('TS and scripts JS twin agree on getPageSource', () => {
+  it('returns identical source for every fixture', () => {
+    for (const [name, page] of Object.entries(fixtures)) {
+      expect(getPageSourceJs(page), name).toBe(getPageSource(page));
+    }
+  });
+});


### PR DESCRIPTION
Read-side core for the image-URL resolver consolidation tracked in #1727. **No call sites migrated** — this is the contract to review before the fan-out.

## What this adds
- `src/lib/page-image-url.ts` — `getPageImageUrl(page, size)` with **size as the spine** (`thumb` ~150 / `display` ~1200 / `original` / `hires` ~4000) and `getPageSource(page)` as the **one split-aware source-identity normalizer**.
- `scripts/lib/page-image-url.mjs` — JS twin so pipeline workers share `getPageSource` (they pick the OCR source, not a display size). Tests assert the two agree.
- `tests/unit/page-image-url.test.ts` — 17 tests across both split eras, IIIF, format guard, failed-archive, and the no-`/_next/image` invariant.

## Design (per the #1727 thread)
Size tiers, cheapest → fallback: **pre-sized R2 variant (free)** → **IIIF-native** `/full/{w},/` → **/api/image** sharp proxy → **raw original** (only for `original`/`hires`). Two invariants baked in:
- `display`/`thumb` are always **browser-safe** (never `.jp2`/`.tif`) and **bounded** — never the raw full-res.
- The raw original is reserved for OCR/download.

Also fixes the **old-era split trap** (a split page's `display_photo` is the *uncropped* resize → prefer the cropped half) and drops the dead `enhanced_photo` field from precedence.

## In scope / out of scope
- ✅ In: the resolver + JS twin + tests. Pure addition; touches no existing files.
- ⛔ Out (deliberately separate, tracked in #1727): migrating the ~26 call sites; deprecating the `utils.ts`/`page.ts` duplicates to re-exports; the two confirmed bugs (`enrich-metadata-vision.mjs:184`, `bulk-reocr-opened-books.mjs:70`); the `/api/image` input-cap hardening; backfill (#1814) and splitter thumbs (#1730).

## Verification
- 17 new tests pass; full unit suite green (181). `tsc --noEmit` clean on the new files (the 14 repo-wide errors are pre-existing in `blog/carbon-ledger/interactives/*`).
- Variant siblings + IIIF/proxy outputs spot-checked against live R2 earlier in the #1727 investigation (HEAD 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)