### PR TITLE
fix(pipeline): use shared getPageSource for OCR-source selection (#1727)

### DIFF
--- a/scripts/batch/bulk-reocr-opened-books.mjs
+++ b/scripts/batch/bulk-reocr-opened-books.mjs
@@ -17,6 +17,7 @@
 
 import { MongoClient } from 'mongodb';
 import { nanoid } from 'nanoid';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 
 // --- Config ---
 const MONGODB_URI = process.env.MONGODB_URI;
@@ -65,12 +66,6 @@ async function fetchImageAsBase64(url, timeout = 30000) {
     clearTimeout(timeoutId);
     return null;
   }
-}
-
-function getPageImageUrl(page) {
-  if (page.crop && page.cropped_photo) return page.cropped_photo;
-  if (page.archived_photo) return page.archived_photo;
-  return page.photo_original || page.photo;
 }
 
 // --- Gemini Batch API ---

--- a/scripts/enrichment/enrich-metadata-vision.mjs
+++ b/scripts/enrichment/enrich-metadata-vision.mjs
@@ -20,6 +20,7 @@
 import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
 import { MongoClient, ObjectId } from 'mongodb';
 import fs from 'fs';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -177,17 +178,6 @@ First translation assessment rules:
 - Most pre-1800 Latin, German, and other non-English texts on alchemy, Hermeticism, Kabbalah, astrology, and natural philosophy were NEVER translated to English. Be aware of this baseline.
 - For well-known classical authors (Plato, Aristotle, Virgil, Ovid, Galen, etc.), their major works have translations, but minor/obscure works often do not.
 - If the book IS already in English or is a modern translation of another work, set status to "not_applicable"`;
-}
-
-// ── Image URL resolution ─────────────────────────────────────────────
-
-function getPageImageUrl(page) {
-  // Skip failed URLs (e.g. "failed:HTTP 403")
-  const candidates = [page.cropped_photo, page.archived_photo, page.photo, page.photo_original];
-  for (const url of candidates) {
-    if (url && url.startsWith('http')) return url;
-  }
-  return null;
 }
 
 // ── Core classification ──────────────────────────────────────────────


### PR DESCRIPTION
First migration onto the #1727 resolver — and it fixes an active data-corruption bug.

## The bug
`scripts/batch/bulk-reocr-opened-books.mjs` selected the OCR source with:
\`\`\`js
if (page.crop && page.cropped_photo) return page.cropped_photo;
if (page.archived_photo) return page.archived_photo;
\`\`\`
It only uses the cropped half when `page.crop` (coords) is set — but split-from-spread pages carry `cropped_photo` **without** crop coords (`crop` ~1.4% vs `split_from_spread` ~10.6%). Those pages fell through to `archived_photo` = the full uncropped spread, so the re-OCR ran on both pages merged → garbage text.

`scripts/enrichment/enrich-metadata-vision.mjs` had a milder divergence (no split handling, `photo` before `photo_original`) flagged in the #1727 audit.

## The fix
Both now `import { getPageSource as getPageImageUrl }` from `scripts/lib/page-image-url.mjs` (the shared twin shipped in #2287) — prefers the cropped half, handles new-era `sp…` splits, skips `failed:` markers. Aliased to the existing local name, so call sites are untouched and each diff is just delete-local-fn + add-import.

## Verification
- `node --check` clean on both; `check-imports` hook passes.
- Proved the bug case: `{split_from_spread, cropped_photo, no crop}` now resolves to `/cropped/…` (was `/archived/…` spread); normal pages unchanged.
- Twin agreement + resolver unit tests green (17).

## Scope
- ✅ In: the two audit-flagged source-selection sites.
- ⛔ Out: the ~11 other pipeline scripts whose local copies are *correct* (drift cleanup, follow-up); display/thumb call-site migration; `utils.ts`/`page.ts` resolver dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)