### PR TITLE
ci(e2e): stop daily 'still failing' comment churn (#1582)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -69,13 +69,14 @@ jobs:
               per_page: 1,
             });
             if (existing.length > 0) {
-              // Add a comment to the existing issue instead
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing[0].number,
-                body: `Still failing as of ${date}.\n**Run:** ${runUrl}`,
-              });
+              // An open tracking issue already exists. Do NOT append a daily
+              // "Still failing as of …" comment — that churn emailed every
+              // subscriber once a day with zero new signal (24 such comments
+              // on #1582 before this change). The daily run still executes and
+              // the playwright-report artifact is still attached to this run,
+              // so nothing is lost; we just stop the inbox spam. The run page
+              // is the source of truth while the issue stays open.
+              core.notice(`E2E still failing; tracking issue #${existing[0].number} already open. Suppressing daily comment. Run: ${runUrl}`);
               return;
             }
 


### PR DESCRIPTION
## What
The E2E test workflow appended a `Still failing as of <date>` comment to the open tracking issue **every morning** — 24 comments on #1582, each emailing every subscriber with zero new signal. A chunk of the daily `github-actions[bot]` inbox noise.

## Change
When an open `e2e-tests` issue already exists, the workflow now suppresses the daily comment and emits a `core.notice()` on the run instead. The scheduled run still executes and the `playwright-report` artifact is still attached — nothing is lost, only the churn. A fresh issue is still filed when none is open.

Implements the denoise plan from the [2026-05-27 triage on #1582](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/1582#issuecomment-4553798984).

## Out of scope
The E2E suite is still genuinely failing (systemic, since May 3). This PR only stops the notification spam, not the test failures — tracked in #1582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)