### PR TITLE
refactor(images): delegate source resolvers to getPageSource (#1727)

### DIFF
--- a/scripts/lib/page-image-url.mjs
+++ b/scripts/lib/page-image-url.mjs
@@ -27,14 +27,14 @@ export function isArchiveFailed(photo) {
  *   1. cropped_photo        — old-era split: materialized cropped half
  *   2. split_from_spread photo — new-era split: `photo` rewritten to the sp… half
  *   3. archiving failed → null
- *   4. archived_photo → photo_original → photo
- *
- * (enhanced_photo intentionally omitted — dead field, 0% populated.)
+ *   4. enhanced_photo — enhanced copy, preferred when present (after split handling)
+ *   5. archived_photo → photo_original → photo
  */
 export function getPageSource(page) {
   if (isUsableImageUrl(page.cropped_photo)) return page.cropped_photo;
   if (page.split_from_spread && isUsableImageUrl(page.photo)) return page.photo;
   if (isArchiveFailed(page.archived_photo)) return null;
+  if (isUsableImageUrl(page.enhanced_photo)) return page.enhanced_photo;
   if (isUsableImageUrl(page.archived_photo)) return page.archived_photo;
   if (isUsableImageUrl(page.photo_original)) return page.photo_original;
   if (isUsableImageUrl(page.photo)) return page.photo;

--- a/src/lib/page-image-url.ts
+++ b/src/lib/page-image-url.ts
@@ -40,6 +40,7 @@ export interface PageImageFields {
   photo?: string | null;
   photo_original?: string | null;
   archived_photo?: string | null;
+  enhanced_photo?: string | null;
   cropped_photo?: string | null;
   display_photo?: string | null;
   image_thumb?: string | null;
@@ -113,14 +114,16 @@ function deriveVariant(photo: string | null | undefined, size: 'display' | 'thum
  *   2. split-from-spread `photo` — new-era split: the splitter rewrote `photo`
  *      to the `sp…` cropped half.
  *   3. archiving failed → null (archiving already proved the source URLs dead).
- *   4. `archived_photo` → `photo_original` → `photo` (normal pages).
- *
- * (`enhanced_photo` is intentionally omitted — 0% populated, a dead field.)
+ *   4. `enhanced_photo` — contrast/brightness-enhanced copy, preferred when present
+ *      (currently ~0% populated, but a deliberate cover-selection preference; placed
+ *      *after* split handling so it can never reintroduce the full-spread).
+ *   5. `archived_photo` → `photo_original` → `photo` (normal pages).
  */
 export function getPageSource(page: PageImageFields): string | null {
   if (isUsableImageUrl(page.cropped_photo)) return page.cropped_photo;
   if (page.split_from_spread && isUsableImageUrl(page.photo)) return page.photo;
   if (isArchiveFailed(page.archived_photo)) return null;
+  if (isUsableImageUrl(page.enhanced_photo)) return page.enhanced_photo;
   if (isUsableImageUrl(page.archived_photo)) return page.archived_photo;
   if (isUsableImageUrl(page.photo_original)) return page.photo_original;
   if (isUsableImageUrl(page.photo)) return page.photo;

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -1,4 +1,5 @@
 import { PromptReference } from "./prompt";
+import { getPageSource } from "@/lib/page-image-url";
 
 export interface Page {
   id: string;
@@ -254,18 +255,13 @@ export interface DetectedImage {
 }
 
 /**
- * Get the best available image URL for a page.
- * Prefers enhanced > cropped > archived > photo_original > photo.
- * For split-from-spread pages, uses photo directly (skip legacy fallback).
+ * Get the best available source image URL for a page.
+ *
+ * Delegates to the canonical {@link getPageSource} (`@/lib/page-image-url`,
+ * issue #1727), which prefers the cropped half for split pages (old-era
+ * `cropped_photo` or new-era `sp…` `photo`) and drops the dead `enhanced_photo`
+ * field. Returns '' on a miss to preserve this helper's string contract.
  */
 export function pageImageUrl(page: Partial<Page>): string {
-  // Split pages: use photo directly (the cropped half), skip legacy fallback
-  // which would show the full spread via archived_photo/photo_original
-  if ((page as any).split_from_spread || (page as any).crop) return page.photo || '';
-  return (page as any).enhanced_photo
-    || (page as any).cropped_photo
-    || page.archived_photo
-    || page.photo_original
-    || page.photo
-    || '';
+  return getPageSource(page) ?? '';
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { getPageSource } from '@/lib/page-image-url';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -158,29 +159,16 @@ export function formatAuthor(author: string | undefined | null): { name: string;
 }
 
 /**
- * Resolve the best source image URL for a page.
+ * Resolve the best source image URL for a page (the file to OCR, download, or
+ * resize from).
  *
- * IMPORTANT: All image resolution in the app should go through this function
- * or one of its variants (getPageDisplayUrl, getPageThumbUrl) to ensure
- * consistent behavior. In particular, split-from-spread pages bypass the
- * legacy fallback chain entirely — see `.claude/docs/page-system.md`.
- *
- * Legacy chain (non-split pages): cropped_photo > archived_photo > photo_original > photo
- * Split pages: photo directly (no fallback)
+ * Delegates to the canonical {@link getPageSource} (`@/lib/page-image-url`,
+ * issue #1727). Kept as a named export for back-compat with existing callers;
+ * for the size axis use `getPageImageUrl(page, size)` from that module, or the
+ * `getPageDisplayUrl`/`getPageThumbUrl` variants below.
  */
 export function getPageImageUrl(page: Record<string, any>): string | null {
-  // Split-from-spread pages: photo is the single source of truth.
-  // NEVER fall through to photo_original/archived_photo — those point to the unsplit spread.
-  if (page.split_from_spread && isUsableImageUrl(page.photo)) return page.photo;
-
-  if (isUsableImageUrl(page.cropped_photo)) return page.cropped_photo;
-  if (isUsableImageUrl(page.archived_photo)) return page.archived_photo;
-  // If archiving was attempted and failed ("failed:HTTP 404" etc), the source URL is dead.
-  // Don't try photo/photo_original — archiving already proved those URLs don't work.
-  if (isArchiveFailed(page.archived_photo)) return null;
-  if (isUsableImageUrl(page.photo_original)) return page.photo_original;
-  if (isUsableImageUrl(page.photo)) return page.photo;
-  return null;
+  return getPageSource(page);
 }
 
 /**


### PR DESCRIPTION
Consolidates the duplicate **source** resolvers onto the canonical `getPageSource` (#2287). No call sites edited — this rewires two shared helpers, so every caller benefits at once.

## Changes
- `utils.ts` `getPageImageUrl(page)` → `getPageSource` (16+ callers — gallery source, OCR routes, thumbnail generation).
- `types/page.ts` `pageImageUrl(page)` → `getPageSource` (drops the divergent copy that led with the dead `enhanced_photo` and used `split||crop` detection).

## Why it matters
Both previously returned the **pre-crop spread** for old-era split pages (which carry a separate `cropped_photo` half) — `getPageSource` prefers the cropped half. So this fixes the split-source bug across all those callers, not just one surface. All 6 existing `getPageImageUrl` unit assertions pass unchanged.

## Course-correction caught by the suite
The #1727 audit called `enhanced_photo` a dead field (0% populated) and #2287 dropped it. But `cover-fields.test.ts` pins it as a **deliberate cover-selection preference** — so this PR **restores** `enhanced_photo` to `getPageSource` (TS + JS twin), placed *after* split handling so it can never reintroduce the full-spread. Good example of the test suite doing its job.

## Scope
- ✅ In: the two source resolvers + the `enhanced_photo` restoration.
- ⛔ Out: `getPageDisplayUrl`/`getPageThumbUrl` (display/thumb migration is a separate, more delicate PR); the local route-level `getPageImageUrl` redefinitions (batch-ocr-async etc.).

## Verification
- Full unit suite green (181); circular import (`utils ↔ page-image-url`) resolves fine under ESM.
- `tsc --noEmit` clean on changed files (14 pre-existing carbon-ledger errors only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)