### PR TITLE
debug(health): echo AUTHOR_THESAURUS_READPATH runtime value (#2250 flag-flip)

### DIFF
--- a/src/app/api/admin/health/route.ts
+++ b/src/app/api/admin/health/route.ts
@@ -269,6 +269,16 @@ export const GET = withAdminAuth(async () => {
     checked_at: new Date().toISOString(),
     duration_ms: Date.now() - started,
     checks,
+    // TEMP DIAGNOSTIC (#2250 flag-flip): echo what the runtime actually reads for
+    // the thesaurus read-path flag. Not a secret (a feature flag). Remove once the
+    // env-injection puzzle is resolved.
+    runtime_flags: {
+      AUTHOR_THESAURUS_READPATH_raw: process.env.AUTHOR_THESAURUS_READPATH ?? null,
+      AUTHOR_THESAURUS_READPATH_len: (process.env.AUTHOR_THESAURUS_READPATH ?? '').length,
+      thesaurus_readpath_enabled:
+        process.env.AUTHOR_THESAURUS_READPATH === '1' ||
+        process.env.AUTHOR_THESAURUS_READPATH === 'true',
+    },
   });
 });
 


### PR DESCRIPTION
Temporary one-field diagnostic on `/api/admin/health` to read what the live serverless runtime sees for `process.env.AUTHOR_THESAURUS_READPATH` — the flag reads false in prod despite a clean `1` baked into a fresh deploy (cache/resolver/propagation/quoting all ruled out). Not a secret (a feature flag), admin-gated. **Will be reverted once the env-injection puzzle is resolved.**