### PR TITLE
fix(pipeline): migrate remaining 7 OCR/vision source-pickers to shared getPageSource (#1727)

### DIFF
--- a/scripts/batch/bulk-reocr-local.mjs
+++ b/scripts/batch/bulk-reocr-local.mjs
@@ -22,6 +22,7 @@
 
 import { MongoClient } from 'mongodb';
 import { nanoid } from 'nanoid';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -183,11 +184,7 @@ async function createBatchJobInline(model, requests, displayName, retries = 3) {
 }
 
 // --- Image helpers ---
-function getPageImageUrl(page) {
-  if (page.crop && page.cropped_photo) return page.cropped_photo;
-  if (page.archived_photo && !page.archived_photo.startsWith('failed:')) return page.archived_photo;
-  return page.photo_original || page.photo || null;
-}
+// getPageImageUrl is imported from the shared resolver (#1727) — see top of file.
 
 async function fetchImageBase64(url) {
   try {
@@ -349,7 +346,7 @@ async function main() {
         projection: {
           _id: 0, id: 1, page_number: 1,
           photo: 1, photo_original: 1, archived_photo: 1,
-          cropped_photo: 1, crop: 1,
+          cropped_photo: 1, crop: 1, split_from_spread: 1,
         }
       }).sort({ page_number: 1 }).limit(MAX_PAGES).toArray();
 

--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -23,6 +23,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -108,11 +109,7 @@ function markKeyRateLimited(keyName) {
 }
 
 // --- Image helpers ---
-function getPageImageUrl(page) {
-  if (page.crop && page.cropped_photo) return page.cropped_photo;
-  if (page.archived_photo && !page.archived_photo.startsWith('failed:')) return page.archived_photo;
-  return page.photo_original || page.photo || null;
-}
+// getPageImageUrl is imported from the shared resolver (#1727) — see top of file.
 
 async function fetchImageBuffer(url) {
   const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
@@ -505,7 +502,7 @@ async function main() {
       projection: {
         id: 1, _id: 0, book_id: 1, page_number: 1,
         photo: 1, photo_original: 1, archived_photo: 1,
-        cropped_photo: 1, crop: 1,
+        cropped_photo: 1, crop: 1, split_from_spread: 1,
         'ocr.model': 1, 'ocr.prompt_version': 1,
       },
     }).sort({ book_id: 1, page_number: 1 }).skip(OFFSET).limit(MAX_PAGES).toArray();

--- a/scripts/batch/realtime-reocr-efm.mjs
+++ b/scripts/batch/realtime-reocr-efm.mjs
@@ -17,6 +17,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -60,11 +61,7 @@ function getNextKey() {
 }
 
 // --- Image helpers ---
-function getPageImageUrl(page) {
-  if (page.crop && page.cropped_photo) return page.cropped_photo;
-  if (page.archived_photo && !page.archived_photo.startsWith('failed:')) return page.archived_photo;
-  return page.photo_original || page.photo || null;
-}
+// getPageImageUrl is imported from the shared resolver (#1727) — see top of file.
 
 async function fetchImageBuffer(url) {
   const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
@@ -382,7 +379,7 @@ async function main() {
       projection: {
         id: 1, _id: 0, book_id: 1, page_number: 1,
         photo: 1, photo_original: 1, archived_photo: 1,
-        cropped_photo: 1, crop: 1,
+        cropped_photo: 1, crop: 1, split_from_spread: 1,
         'ocr.model': 1, 'ocr.prompt_version': 1,
       },
     }).sort({ page_number: 1 }).limit(MAX_PAGES).toArray();

--- a/scripts/enrichment/enrich-metadata-vision.mjs
+++ b/scripts/enrichment/enrich-metadata-vision.mjs
@@ -430,7 +430,9 @@ async function main() {
         .find({ book_id: book.id })
         .sort({ page_number: 1 })
         .limit(pagesPerBook)
-        .project({ page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1 })
+        // split_from_spread is required by getPageSource() to pick the new-era
+        // sp… cropped half; omitting it silently routes ~all splits to the spread.
+        .project({ page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, split_from_spread: 1 })
         .toArray();
 
       if (pages.length === 0) {

--- a/scripts/maintenance/batch-cover-selection.mjs
+++ b/scripts/maintenance/batch-cover-selection.mjs
@@ -18,6 +18,7 @@
 
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { buildCoverUpdate } from '../lib/cover-write.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -80,15 +81,7 @@ Confidence levels: "high" = clear frontispiece, "medium" = decent title page, "l
 
 // --- Helpers ---
 
-function getPageImageUrl(page) {
-  const isUsable = (u) => u && (u.startsWith('http://') || u.startsWith('https://'));
-  if (isUsable(page.cropped_photo)) return page.cropped_photo;
-  if (isUsable(page.archived_photo)) return page.archived_photo;
-  if (page.archived_photo?.startsWith('failed:')) return null;
-  if (isUsable(page.photo)) return page.photo;
-  if (isUsable(page.photo_original)) return page.photo_original;
-  return null;
-}
+// getPageImageUrl is imported from the shared resolver (#1727) — see top of file.
 
 async function fetchImageBase64(url, retries = 2) {
   for (let attempt = 0; attempt <= retries; attempt++) {

--- a/scripts/maintenance/smart-cover-selection.mjs
+++ b/scripts/maintenance/smart-cover-selection.mjs
@@ -19,6 +19,7 @@
 
 import { MongoClient } from 'mongodb';
 import { scorePageForCover } from '../lib/cover-scoring.mjs';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const SKIP_MANUAL = process.argv.includes('--skip-manual');
@@ -49,15 +50,7 @@ const client = new MongoClient(process.env.MONGODB_URI, {
 await client.connect();
 const db = client.db('bookstore');
 
-function getPageImageUrl(page) {
-  const isUsable = (u) => u && (u.startsWith('http://') || u.startsWith('https://'));
-  if (isUsable(page.cropped_photo)) return page.cropped_photo;
-  if (isUsable(page.archived_photo)) return page.archived_photo;
-  if (page.archived_photo?.startsWith('failed:')) return null;
-  if (isUsable(page.photo)) return page.photo;
-  if (isUsable(page.photo_original)) return page.photo_original;
-  return null;
-}
+// getPageImageUrl is imported from the shared resolver (#1727) — see top of file.
 
 // --- Main ---
 console.log(`\n=== Smart Cover Selection (OCR-based) ===`);
@@ -104,7 +97,7 @@ for (let i = 0; i < allBooks.length; i += BATCH_SIZE) {
       {
         projection: {
           book_id: 1, page_number: 1, page_type: 1,
-          photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1,
+          photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, split_from_spread: 1,
           'ocr.data': 1,
         }
       }

--- a/scripts/migration/backfill-ocr-near-complete.mjs
+++ b/scripts/migration/backfill-ocr-near-complete.mjs
@@ -16,6 +16,7 @@
 
 import { MongoClient } from 'mongodb';
 import { nanoid } from 'nanoid';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 
 // ── Config ──
 const MONGODB_URI = process.env.MONGODB_URI;
@@ -81,11 +82,7 @@ function getOcrModelForBook(book) {
 }
 
 // ── Image helpers ──
-function getPageImageUrl(page) {
-  if (page.crop && page.cropped_photo) return page.cropped_photo;
-  if (page.archived_photo && !page.archived_photo.startsWith('failed:')) return page.archived_photo;
-  return page.photo_original || page.photo || null;
-}
+// getPageImageUrl is imported from the shared resolver (#1727) — see top of file.
 
 async function fetchImageBase64(url) {
   try {
@@ -273,7 +270,7 @@ async function main() {
         ]}],
       })
       .sort({ page_number: 1 })
-      .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1 })
+      .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1 })
       .toArray();
 
     if (pages.length === 0) {

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -16,6 +16,7 @@
 
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI, SchemaType } from '@google/generative-ai';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { nanoid } from 'nanoid';
 import sharp from 'sharp';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
@@ -329,11 +330,7 @@ Re-read your scan_quality block before finalizing. If any of these rules is viol
 fix the scan_class to match the evidence in concerns/completeness, not the other way around.`;
 
 // ── Helpers ──
-function getPageImageUrl(page) {
-  if (page.crop && page.cropped_photo) return page.cropped_photo;
-  if (page.archived_photo && !page.archived_photo.startsWith('failed:')) return page.archived_photo;
-  return page.photo_original || page.photo || null;
-}
+// getPageImageUrl is imported from the shared resolver (#1727) — see top of file.
 
 async function fetchImage(url) {
   try {
@@ -746,7 +743,7 @@ async function processBook(db, book) {
         { page_type: { $in: IMAGE_CANDIDATE_PAGE_TYPES } },
         { 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
       ],
-    }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, 'ocr.data': 1 } })
+    }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1, 'ocr.data': 1 } })
     .toArray();
 
   // Pre-filter: drop pages where OCR has already classified all illustrations

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -23,6 +23,7 @@
 
 import { MongoClient, ObjectId } from 'mongodb';
 import { nanoid } from 'nanoid';
+import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { GoogleGenAI } from '@google/genai';
@@ -1155,11 +1156,7 @@ async function canSubmitMore() {
   return getLeastLoadedKey() >= 0;
 }
 
-function getPageImageUrl(page) {
-  if (page.crop && page.cropped_photo) return page.cropped_photo;
-  if (page.archived_photo && !page.archived_photo.startsWith('failed:')) return page.archived_photo;
-  return page.photo_original || page.photo || null;
-}
+// getPageImageUrl is imported from the shared resolver (#1727) — see top of file.
 
 /**
  * Fetch image and return as base64. If maxDim is set, resize to fit within that
@@ -1406,7 +1403,7 @@ async function submitOcrDirectly(db, book, { modelOverride, maxPages } = {}) {
     })
     .sort({ page_number: 1 })
     .limit(pageLimit)
-    .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1 })
+    .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1 })
     .toArray();
 
   if (pages.length === 0) {
@@ -1732,7 +1729,7 @@ async function submitCrossBookOcrBatches(db, books) {
       })
       .sort({ page_number: 1 })
       .limit(remaining)
-      .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1 })
+      .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1 })
       .toArray();
 
     if (pages.length === 0) continue;
@@ -1964,7 +1961,7 @@ async function submitImageExtractionBatch(db, book, candidatePages) {
   // Fetch page image URLs
   const pages = await db.collection('pages')
     .find({ id: { $in: candidatePages.map(p => p.id) } })
-    .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1 })
+    .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1 })
     .toArray();
 
   if (pages.length === 0) return { submitted: 0 };
@@ -2208,7 +2205,7 @@ async function submitCrossBookImageBatches(db, bookItems) {
 
     const pages = await db.collection('pages')
       .find({ id: { $in: candidatePages.map(p => p.id) } })
-      .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1 })
+      .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1 })
       .toArray();
 
     if (pages.length === 0) continue;
@@ -2969,7 +2966,7 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
             })
             .sort({ page_number: 1 })
             .limit(PREVIEW_PAGE_COUNT)
-            .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1 })
+            .project({ _id: 0, id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1 })
             .toArray();
 
           if (previewPages.length === 0) {


### PR DESCRIPTION
## What

Finishes the pipeline source-picker consolidation started in #2287 (resolver) / #2288 (first 2 pickers). Seven more scripts each carried their own copy of the OCR/vision source-image selection; all now use the shared `getPageSource` from `scripts/lib/page-image-url.mjs`.

Migrated: `pipeline-orchestrator`, `image-extract-worker`, `bulk-reocr-local`, `realtime-ocr`, `realtime-reocr-efm`, `smart-cover-selection`, `batch-cover-selection`, `backfill-ocr-near-complete`. Imported as `getPageSource as getPageImageUrl` so call sites are unchanged (matches #2288's pattern).

## Why it matters

The local pickers opened with `if (page.crop && page.cropped_photo) return cropped_photo` — but `crop` is on 0.5% and `cropped_photo` on 0.0% of current split pages, so that guard fires for ~0% of splits. Split-from-spread pages therefore fell through to `archived_photo` = the uncropped **spread**, and got OCR'd / vision-scored as one merged image (garbage text, wrong cover). `getPageSource` picks the new-era `sp…` cropped half instead.

## The load-bearing projection fix

`getPageSource` keys on `split_from_spread` to select the sp-half (99.8% of splits). **Several call sites' Mongo projections omitted that field** — so a bare function-swap would compile and run but silently route splits back to the spread. Notably `enrich-metadata-vision` was migrated in #2288 but its projection (`page-image-url.ts` line 433) never carried `split_from_spread`, leaving its split detection dead. This PR adds `split_from_spread: 1` to **every** projection feeding a migrated picker.

## Verification

- Resolver unit suite: **17/17 green**.
- All edited files `node --check` clean; imports resolve (commit-time hook passed).
- Behavioral spot-check against prod (real split pages, widened projection): **4/5 now resolve to the `sp…` half; OLD picker returned `archived/…/N.jpg` spreads** (DIFFERS→fixed). Stripping `split_from_spread` reproduces the regression — proving the projection edits are necessary, not cosmetic.
- No DB writes; read-path only.

## Out of scope (deliberately)

- `scripts/thumbnails/generate-thumbnails-fast.ts` — TypeScript, and it's thumbnail-source not OCR-source selection; would use the TS resolver. Separate concern, separate PR.
- `pipeline-orchestrator` `selectBestCoverPage`'s inline `cropped_photo || archived_photo || photo` — cover selection, not OCR source.
- The re-OCR corruption remediation (re-queue the already-corrupted split pages) — separate data workstream, tracked in #1727; **this PR stops new corruption, it doesn't repair past runs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)