### PR TITLE
debug(health): remove temp AUTHOR_THESAURUS_READPATH echo (#2250 resolved)

### DIFF
--- a/src/app/api/admin/health/route.ts
+++ b/src/app/api/admin/health/route.ts
@@ -269,16 +269,6 @@ export const GET = withAdminAuth(async () => {
     checked_at: new Date().toISOString(),
     duration_ms: Date.now() - started,
     checks,
-    // TEMP DIAGNOSTIC (#2250 flag-flip): echo what the runtime actually reads for
-    // the thesaurus read-path flag. Not a secret (a feature flag). Remove once the
-    // env-injection puzzle is resolved.
-    runtime_flags: {
-      AUTHOR_THESAURUS_READPATH_raw: process.env.AUTHOR_THESAURUS_READPATH ?? null,
-      AUTHOR_THESAURUS_READPATH_len: (process.env.AUTHOR_THESAURUS_READPATH ?? '').length,
-      thesaurus_readpath_enabled:
-        process.env.AUTHOR_THESAURUS_READPATH === '1' ||
-        process.env.AUTHOR_THESAURUS_READPATH === 'true',
-    },
   });
 });
 


### PR DESCRIPTION
Reverts the temporary diagnostic from #2293. The #2250 flag-flip is resolved — the runtime reads the flag as enabled and variant slugs now 308→canonical in prod. Removing the throwaway echo.