### PR TITLE
feat(provenance): stamp ocr.source_url + code_version on model writes (#2297)

### DIFF
--- a/scripts/maintenance/audit-ocr-source-drift.mjs
+++ b/scripts/maintenance/audit-ocr-source-drift.mjs
@@ -1,0 +1,77 @@
+/**
+ * Audit OCR-source drift (#2297 → unblocks #2298).
+ *
+ * Lists pages whose recorded OCR provenance (`ocr.source_url`, stamped by the
+ * worker per #2297) does NOT match what the canonical resolver `getPageSource`
+ * would pick today — i.e. the page was OCR'd from the wrong image (the
+ * spread-instead-of-half bug class fixed forward in #2288/#2294).
+ *
+ * This is the precise, enumerable corrupted set the re-OCR repair (#2298)
+ * re-queues — no aspect-ratio estimate needed once source_url is populated.
+ *
+ * Pages with no `ocr.source_url` are "pre-provenance" (OCR'd before #2297);
+ * they are reported separately and fall back to the AR-sweep heuristic in #2298.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; \
+ *     node scripts/maintenance/audit-ocr-source-drift.mjs [--limit N] [--json]
+ */
+import { MongoClient } from 'mongodb';
+import { getPageSource } from '../lib/page-image-url.mjs';
+
+const LIMIT = (() => {
+  const i = process.argv.indexOf('--limit');
+  return i !== -1 ? parseInt(process.argv[i + 1], 10) : 0;
+})();
+const AS_JSON = process.argv.includes('--json');
+
+const client = new MongoClient(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 20000 });
+await client.connect();
+const pages = client.db('bookstore').collection('pages');
+
+// Only pages that actually have OCR + the provenance field. New-writes-only:
+// pages OCR'd before #2297 won't have ocr.source_url and are excluded here
+// (counted separately as the pre-provenance backlog).
+const PROJ = {
+  _id: 0, id: 1, book_id: 1, page_number: 1,
+  'ocr.source_url': 1,
+  cropped_photo: 1, photo: 1, archived_photo: 1, photo_original: 1,
+  crop: 1, split_from_spread: 1,
+};
+
+const withProvenance = await pages.countDocuments({ 'ocr.source_url': { $exists: true, $ne: null } });
+const ocrTotal = await pages.countDocuments({ 'ocr.data': { $exists: true, $ne: '' } });
+
+const cursor = pages.find(
+  { 'ocr.source_url': { $exists: true, $ne: null } },
+  { projection: PROJ }
+);
+
+const drifted = [];
+let scanned = 0;
+for await (const p of cursor) {
+  scanned++;
+  const expected = getPageSource(p);
+  if (expected && p.ocr.source_url !== expected) {
+    drifted.push({ id: p.id, book_id: p.book_id, page_number: p.page_number, was: p.ocr.source_url, should_be: expected });
+    if (LIMIT && drifted.length >= LIMIT) break;
+  }
+}
+
+if (AS_JSON) {
+  console.log(JSON.stringify({ ocrTotal, withProvenance, scanned, drifted: drifted.length, items: drifted }, null, 2));
+} else {
+  console.log(`OCR pages total:            ${ocrTotal}`);
+  console.log(`  with source_url (#2297):  ${withProvenance}  (${ocrTotal ? (100 * withProvenance / ocrTotal).toFixed(1) : 0}%)`);
+  console.log(`  pre-provenance backlog:   ${ocrTotal - withProvenance}  (use #2298 AR-sweep for these)`);
+  console.log(`Scanned with provenance:    ${scanned}`);
+  console.log(`DRIFTED (source ≠ resolver): ${drifted.length}  ← re-queue set for #2298`);
+  for (const d of drifted.slice(0, 20)) {
+    console.log(`  - ${d.book_id}/${d.page_number} (${d.id})`);
+    console.log(`      was:       ${d.was}`);
+    console.log(`      should_be: ${d.should_be}`);
+  }
+  if (drifted.length > 20) console.log(`  … and ${drifted.length - 20} more (use --json for full list)`);
+}
+
+await client.close();

--- a/src/lib/types/sqs.ts
+++ b/src/lib/types/sqs.ts
@@ -87,6 +87,8 @@ export interface OcrWriteResult extends WriteResultBase {
     columns?: number;
     scriptType?: 'printed' | 'handwritten' | 'mixed';
     detectedImages?: unknown[];
+    sourceUrl?: string;          // Exact image URL sent to the model (provenance, #2297)
+    codeVersion?: string;        // Git SHA / release of the producing code (#2297)
   };
   geminiUsage?: GeminiUsagePayload;
 }

--- a/src/workers/ocr-processor-logic.ts
+++ b/src/workers/ocr-processor-logic.ts
@@ -33,6 +33,10 @@ import { sendWriteResult } from '@/lib/sqs-client';
 
 import { getPageImageUrl, isArchiveFailed } from '@/lib/utils';
 
+// Git SHA of the producing code, for OCR provenance (#2297). Same convention as
+// /api/status; 'dev' when unset (local/uncommitted).
+const CODE_VERSION = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 8) || 'dev';
+
 /**
  * Build a GeminiUsagePayload for the write queue.
  */
@@ -234,6 +238,8 @@ export async function processOcrPage(message: PageProcessingMessage): Promise<vo
         ...(columns && { columns }),
         ...(scriptType && { scriptType }),
         ...(detectedImages.length > 0 && { detectedImages }),
+        sourceUrl: imageUrl,        // provenance: the exact image OCR'd (#2297)
+        codeVersion: CODE_VERSION,
       },
       geminiUsage: buildUsagePayload({
         model: modelId, bookId, pageId, jobId, durationMs,
@@ -293,6 +299,8 @@ export async function processOcrPage(message: PageProcessingMessage): Promise<vo
               ...(retryPageType && { pageType: retryPageType }),
               ...(retryColumns && { columns: retryColumns }),
               ...(retryImages.length > 0 && { detectedImages: retryImages }),
+              sourceUrl: imageUrl,        // provenance: the exact image OCR'd (#2297)
+              codeVersion: CODE_VERSION,
             },
             geminiUsage: buildUsagePayload({
               model: nextModel, bookId, pageId, jobId, durationMs: retryDuration,

--- a/src/workers/translation-processor-logic.ts
+++ b/src/workers/translation-processor-logic.ts
@@ -14,6 +14,12 @@ import { getTranslationPrompt } from '@/lib/prompts';
 import { syncPageUpdate } from '@/lib/supabase-page-writer';
 import type { PromptReference } from '@/lib/types';
 
+// Git SHA of the producing code, for translation provenance (#2297). Translation's
+// *input* is the page's OCR text (not an image), so there is no image source_url to
+// stamp here — its source is traceable via the page's ocr.* provenance. We record
+// code_version so a translation can be tied to the code release that produced it.
+const CODE_VERSION = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 8) || 'dev';
+
 /**
  * Translation Processor - processes one page at a time
  *
@@ -244,6 +250,7 @@ export async function processTranslationPage(message: PageProcessingMessage) {
         prompt_hash: promptRef.content_hash,
         prompt_id: promptRef.id,
         prompt_name: promptRef.name,
+        code_version: CODE_VERSION,     // provenance (#2297)
       },
       ...translationMeta,
       updated_at: new Date()

--- a/src/workers/write-processor-logic.ts
+++ b/src/workers/write-processor-logic.ts
@@ -73,7 +73,7 @@ async function processOcrResult(db: Awaited<ReturnType<typeof getDb>>, message: 
     // Save revision before overwriting OCR (no-op on first write)
     try { await createRevision(pageId, 'ocr', jobId); } catch {}
     // Save OCR result to page
-    const { text, language, model, promptVersion, promptId, promptHash, promptName, pageType, columns, scriptType, detectedImages } = message.data;
+    const { text, language, model, promptVersion, promptId, promptHash, promptName, pageType, columns, scriptType, detectedImages, sourceUrl, codeVersion } = message.data;
     const ocrSetPayload = {
       ocr: {
         data: text,
@@ -85,6 +85,8 @@ async function processOcrResult(db: Awaited<ReturnType<typeof getDb>>, message: 
         ...(promptId && { prompt_id: promptId }),
         ...(promptHash && { prompt_hash: promptHash }),
         ...(promptName && { prompt_name: promptName }),
+        ...(sourceUrl && { source_url: sourceUrl }),     // provenance (#2297)
+        ...(codeVersion && { code_version: codeVersion }),
       },
       ...(pageType && { page_type: pageType }),
       ...(columns && { columns }),


### PR DESCRIPTION
Closes #2297. Part of the #1727 image-resolution epic; unblocks #2298 (re-OCR repair).

## What
Records **which image URL was actually sent to the model** for OCR (`ocr.source_url`) plus the **git SHA of the producing code** (`ocr.code_version`). This is the data-layer twin of the #2287 resolver: the resolver decides *which* image to use; provenance records *which we used*. It turns the #2288/#2294 'OCR'd the spread instead of the half' question from a forensic dig into a query.

## Changes (live SQS/Lambda path)
- `src/lib/types/sqs.ts` — `OcrWriteResult.data` += `sourceUrl`, `codeVersion`.
- `src/workers/ocr-processor-logic.ts` — stamp `sourceUrl` = the `imageUrl` actually fetched & sent (both the main send **and** the RECITATION-fallback retry send); `codeVersion` from `VERCEL_GIT_COMMIT_SHA` (same convention as `/api/status`, `'dev'` when unset).
- `src/workers/write-processor-logic.ts` — persist `ocr.source_url` + `ocr.code_version` onto the page.

## Translation: code_version only (deliberate)
Translation's input is the page's OCR **text**, not an image — there is no image `source_url` to stamp, so only `code_version` is recorded on `translation.*`. Its source is already traceable via the page's `ocr.*` provenance. Stamping an image URL on a translation would be cargo-culting.

## DoD enumeration query → unblocks #2298
`scripts/maintenance/audit-ocr-source-drift.mjs` lists pages where `ocr.source_url ≠ getPageSource(page)` (the exact re-queue set for the repair), and reports the pre-provenance backlog (pages OCR'd before this change, no `source_url`) separately so #2298 can AR-sweep those.

## Scope
- **New-writes-only, additive.** No backfill — existing pages keep `source_url: null` = 'pre-provenance', which is queryable.
- Out of scope (per the issue): `batch_jobs` job-level provenance; image-extraction / vision-metadata / cover-selection writers.
- `tsc` clean on all touched files (the 14 remaining errors are pre-existing `carbon-ledger`/d3 files, untouched).

## Note for reviewers
`ocr-processor-logic.ts` still imports the **old** `getPageImageUrl` from `@/lib/utils` (not the #2287 resolver). This PR stamps the URL it *actually sends* — honest provenance regardless of which resolver computed it. Migrating that worker's picker to `getPageSource` belongs to the resolver-adoption lane, not this issue (and would make the audit query report 0 drift once both are aligned, which is the goal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)