### PR TITLE
Shorten library attribution footer text

### DIFF
--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -573,7 +573,7 @@ export default function SharedLibraryView({
             ) : (
               <span className="text-secondary">{partner.name}</span>
             )}
-            . Original provenance is preserved for every page. Source Library provides OCR transcription, translation, and indexing as a scholarly service.
+            . Original provenance is preserved.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Trims the attribution line in the library detail footer (shown in the embed used on the Embassy of the Free Mind digital collection page).

Before:
> All book images and metadata are sourced from Bibliotheca Philosophica Hermetica. Original provenance is preserved for every page. Source Library provides OCR transcription, translation, and indexing as a scholarly service.

After:
> All book images and metadata are sourced from Bibliotheca Philosophica Hermetica. Original provenance is preserved.

Single-line copy change in `src/components/libraries/SharedLibraryView.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)