### PR TITLE
fix(images): prevent empty-buffer crash-loop in display backfill (#1814)

### DIFF
--- a/scripts/migration/backfill-display-images.mjs
+++ b/scripts/migration/backfill-display-images.mjs
@@ -141,6 +141,15 @@ const stats = {
   _supabaseUpdates: [],
 };
 
+// Safety net for an unattended multi-hour drain: a stray async rejection (e.g.
+// a future floating-promise like the #1814 empty-buffer crash) must not abort
+// the whole batch — log it loudly and keep going. Per-page work is already in
+// try/catch; this only catches escapes.
+process.on('unhandledRejection', (reason) => {
+  stats.failed++;
+  console.error('[backfill-display] unhandledRejection (continuing):', reason?.message || reason);
+});
+
 /**
  * Resolve the correct source for a full Mongo page doc, or a skip reason.
  * Old-era split (cropped_photo) is intentionally out of scope (see header).
@@ -175,6 +184,11 @@ async function processPage(page, db) {
 
     if (!fileAlready) {
       const fullResBuffer = await downloadFromR2(source);
+      // A 200-with-empty-body slips past downloadFromR2's !res.ok check; an
+      // empty buffer would make sharp throw. Fail this page cleanly instead.
+      if (!fullResBuffer || fullResBuffer.length === 0) {
+        throw new Error(`empty source download: ${source.slice(0, 100)}`);
+      }
       const { display, thumb } = await generateDisplayVariants(fullResBuffer);
       displayUrl = await uploadToR2(keys.display, display);
       thumbUrl = await uploadToR2(keys.thumb, thumb);

--- a/scripts/workers/lib/display-image.mjs
+++ b/scripts/workers/lib/display-image.mjs
@@ -127,6 +127,16 @@ async function applyProvenanceMarks(buffer) {
  * @returns {{ display: Buffer, thumb: Buffer }} - The generated variants
  */
 export async function generateDisplayVariants(fullResBuffer) {
+  // Guard BEFORE creating displayPromise: an empty/invalid buffer makes the
+  // sharp() constructor throw *synchronously*. If that sync throw happened at
+  // the thumbPromise line below, `displayPromise` would already be a pending
+  // (then rejected) promise with no handler yet attached — an unhandled
+  // rejection that crashes the whole process instead of a catchable error.
+  // Throwing here (before any promise exists) keeps it a clean async rejection
+  // every caller's try/catch can handle. (Root cause of the #1814 crash-loop.)
+  if (!fullResBuffer || fullResBuffer.length === 0) {
+    throw new Error('generateDisplayVariants: empty/invalid input buffer');
+  }
   const displayPromise = (async () => {
     const displayResized = await sharp(fullResBuffer)
       .resize(DISPLAY_WIDTH, null, { fit: 'inside', withoutEnlargement: true })


### PR DESCRIPTION
## Why (urgent follow-up to #2309)

After #2309 merged and deployed to Hetzner, the display backfill would **crash-loop**: some `archived_photo` files on R2 are **0 bytes** (bad-archive data). A 0-byte buffer makes sharp's constructor throw **synchronously** inside `generateDisplayVariants`; because that sync throw lands at the `thumbPromise` line while `displayPromise` is already pending, `displayPromise` floats with no handler → **unhandled rejection → whole process crashes** instead of failing the one page. The worker would die on the first empty-source page and never persist its cursor → no progress.

(The original crash predates this code — same bug would hit the old worker and the archive workers — but the new per-book drain reaches these pages, so it surfaced now.)

## Fix
- **`generateDisplayVariants` (shared):** guard empty/invalid buffer at the very top, before any promise is created → clean catchable rejection for **all** callers (archive workers included). Root cause.
- **`backfill-display-images`:** reject empty source downloads before sharp (clean per-page `FAIL` + log), and add an `unhandledRejection` safety net so a stray rejection logs + counts rather than aborting a multi-hour drain.

## Verified
- Unit: empty/null buffer → clean throw, no unhandled rejection, process alive.
- End-to-end on the real crashing book (Cicero Topica…, pages 8 & 10 = 0-byte `archived_photo`): both **FAIL cleanly**, worker **exits 0**, no crash.

## Note
The 0-byte `archived_photo` files are a separate data issue (failed archives) — those pages stay in the gap until re-archived; not this worker's job. Worth a follow-up to detect/re-archive empty R2 source files.

display-backfill scheduler entry is currently **paused via a held lock on Hetzner**; I'll release it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)