### PR TITLE
docs(images): document OCR provenance fields + point spread-splitting at the resolver (#1727)

### DIFF
--- a/.claude/docs/page-system.md
+++ b/.claude/docs/page-system.md
@@ -94,6 +94,8 @@ CDN cache: `Cache-Control: max-age=31536000` (1 year). You cannot invalidate by 
 | `ocr.output_tokens` | number | Gemini output tokens |
 | `ocr.batch_job_id` | string | Batch job that produced this OCR |
 | `ocr.updated_at` | Date | When OCR was last updated |
+| `ocr.source_url` | string | **Provenance (#2297/#2302):** the exact image URL sent to the model. Compare to `getPageSource(page)` (`@/lib/page-image-url`) to find pages OCR'd on the wrong image — e.g. a split page OCR'd on the full spread. Pages OCR'd before #2302 lack this. |
+| `ocr.code_version` | string | **Provenance:** git SHA / release tag of the producing code, so a buggy run is identifiable and reversible as a set. |
 
 ### OCR Metadata Tags
 
@@ -130,6 +132,7 @@ The OCR text contains inline XML tags that serve dual purposes:
 | `translation.target_language` | string | Always `'English'` |
 | `translation.prompt_version` | string | Translation prompt version |
 | `translation.source` | string | `'batch_api'`, `'hetzner'`, `'realtime'` |
+| `translation.code_version` | string | **Provenance (#2302):** git SHA / release of the producing code. Note: translation has **no** `source_url` — its input is the OCR *text*, not an image; image lineage is recoverable via the same page's `ocr.source_url`. |
 
 ### Page Classification
 

--- a/.claude/docs/spread-splitting.md
+++ b/.claude/docs/spread-splitting.md
@@ -155,21 +155,19 @@ This is the root cause of most display bugs. The page record has 6 image-related
 | `thumbnail` | Standard pipeline | 150px grid thumbnail |
 | `thumbnail_blob` | Vercel Blob era | Legacy CDN thumbnail |
 
-The frontend checks them in priority order:
+**Source resolution is centralized (as of #1727).** Every consumer resolves
+images through `getPageSource(page)` (`@/lib/page-image-url`; JS twin
+`scripts/lib/page-image-url.mjs`) — **do not hand-roll** the
+`cropped_photo || archived_photo || …` chain. The resolver is split-aware:
+old-era split → `cropped_photo` (the half); new-era split → the `sp…` `photo`;
+never the spread. `getPageDisplayUrl`/`getPageThumbUrl` in `src/lib/utils.ts` are
+thin wrappers over `getPageImageUrl(page, size)`. Full model:
+`.claude/docs/page-system.md` → "Images — resolved through ONE function".
 
-**`getPageThumbUrl()` in `src/lib/utils.ts`:**
-1. `crop` coordinates → proxy URL with crop params
-2. `thumbnail_blob` → direct URL
-3. Derive from `photo` path (regex for `/NNNN.jpg` pattern)
-4. `thumbnail` → direct URL
-5. `archived_photo || photo_original || photo` → proxy URL
-
-**`BookPagesSection.tsx` cover picker (line 494):**
-```
-cropped_photo || archived_photo || photo_original || photo
-```
-
-**The problem**: If ANY of the legacy fields exist and point to a spread image, the frontend shows the spread instead of the cropped single page. Setting `photo` is necessary but not sufficient — you must also `$unset` all fields that override it.
+**The hazard it guards against**: if legacy fields exist and point to a spread
+image, a naive precedence chain shows the spread instead of the cropped page.
+Setting `photo` is necessary but not sufficient — you must also `$unset` the
+fields that would override it.
 
 **Mitigation**: The split pipeline MUST `$unset: { photo_original, archived_photo, cropped_photo, thumbnail_blob }` on every page it touches. This is a hard requirement, not optional cleanup.
 


### PR DESCRIPTION
Closes the two documentation gaps left after the #1727 image-resolution epic. Docs-only.

- **`page-system.md`** — the page-field reference was missing the new provenance fields from #2302. Added `ocr.source_url` + `ocr.code_version` to the OCR table (with the "compare to `getPageSource` to find pages OCR'd on the wrong image" note) and `translation.code_version` (noting translation has *no* `source_url` — its input is OCR text, image lineage recoverable via the page's `ocr.source_url`).
- **`spread-splitting.md`** — still documented the old per-function source chains (`getPageThumbUrl` steps, cover-picker `cropped_photo || archived_photo || …`) that #1727 obsoleted. Replaced with a pointer to the canonical `getPageSource` resolver; kept the load-bearing `$unset` mitigation.

The worker-touched architecture docs (r2-storage.md, pipeline-architecture.md, pipeline-diagram.html) were already current — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)