### PR TITLE
fix(zenodo): organizational contributors no longer fail DOI mint

### DIFF
--- a/src/lib/types/edition.ts
+++ b/src/lib/types/edition.ts
@@ -8,7 +8,7 @@
 export interface Contributor {
   name: string;
   role: 'translator' | 'editor' | 'reviewer' | 'transcriber';
-  type: 'ai' | 'human';
+  type: 'ai' | 'human' | 'org'; // 'org' = institutional/partner; maps to a Zenodo organizational creator (no family_name)
   orcid?: string;              // e.g., "0000-0002-1825-0097"
   affiliation?: string;        // e.g., "University of Example"
   model?: string;              // For AI: "gemini-2.0-flash"

--- a/src/lib/zenodo.ts
+++ b/src/lib/zenodo.ts
@@ -305,17 +305,33 @@ function buildMetadata(book: Book, edition: TranslationEdition) {
     role: { id: 'other' },
   });
 
-  // Additional human contributors as personal, AI as organizational
+  // Additional contributors. Human → personal (Zenodo requires family_name, so
+  // split the name like the primary author above); AI and org → organizational
+  // (no family_name; only AI gets the "(AI)" disambiguation suffix). Without the
+  // family_name split, ANY personal contributor — and any single-token org name
+  // mis-typed as 'human' — fails Zenodo validation with "family_name cannot be blank".
   for (const c of edition.contributors) {
     if (c.name === 'Source Library') continue;
-    const displayName = c.type === 'ai' ? `${c.name} (AI)` : c.name;
-    creators.push({
-      person_or_org: {
-        name: displayName,
-        type: c.type === 'human' ? 'personal' as const : 'organizational' as const,
-      },
-      role: { id: 'other' },
-    });
+    if (c.type === 'human') {
+      const parts = c.name.split(' ');
+      const familyName = parts.pop() || c.name;
+      const givenName = parts.join(' ') || undefined;
+      creators.push({
+        person_or_org: {
+          name: c.name,
+          type: 'personal' as const,
+          family_name: familyName,
+          ...(givenName && { given_name: givenName }),
+        },
+        role: { id: 'other' },
+      });
+    } else {
+      const displayName = c.type === 'ai' ? `${c.name} (AI)` : c.name;
+      creators.push({
+        person_or_org: { name: displayName, type: 'organizational' as const },
+        role: { id: 'other' },
+      });
+    }
   }
 
   const description = buildDescription(book, edition) +


### PR DESCRIPTION
## Problem

Minting a DOI 500s with `Zenodo publish: metadata.creators.2.person_or_org.family_name: Family name cannot be blank` whenever an edition lists an **organizational contributor** (e.g. a partner institution).

`src/lib/zenodo.ts` mapped edition contributors with `type: 'human'` → Zenodo `personal` creators but **never populated `family_name`**. Zenodo requires it for personal creators, so:
- an org name typed as 'human' (single token, no family name) fails, and
- *any* human contributor would have failed too — the field was simply never set.

The primary author already handles this correctly (splits the name into given/family); contributors didn't.

## Fix

- Add `'org'` to `Contributor.type` (`src/lib/types/edition.ts`) for institutional/partner contributors.
- In the creators mapping: human → personal **with a family_name** (same name-split as the primary author); ai and org → organizational (no family_name; only ai gets the `(AI)` suffix).

## Provenance

Surfaced while re-minting the corrected Fludd *Utriusque Cosmi Historia Vol. 1* edition (issue #2256). "Embassy of the Free Mind" listed as a contributor failed validation; the mint succeeded once it was an organizational creator. That edition is now published (v1.1.0, DOI 10.5281/zenodo.20488476) — this PR removes the manual workaround for next time.

## Out of scope

Existing edition docs in Mongo that were created with org partners typed as `'human'` aren't migrated here — they'll mint correctly going forward, and the one affected edition (Fludd) was already fixed inline.

## Test

`npx tsc --noEmit` clean for both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)