### PR TITLE
feat(provenance): stamp ocr.source_url + code_version on the batch OCR path (#2297)

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -383,6 +383,13 @@ async function processOneJob(db, job) {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
 
+    // OCR provenance (#2297): map page_id → the exact image URL the orchestrator
+    // fetched + sent, recorded on the batch job at submit. Lets us stamp
+    // ocr.source_url so `ocr.source_url ≠ getPageSource(page)` becomes a query
+    // (the #2298 re-OCR set) instead of an aspect-ratio guess. Empty for jobs
+    // submitted before this shipped — those pages stay pre-provenance (null).
+    const sourceUrlByPage = new Map((job.page_sources || []).map(s => [s.page_id, s.source_url]));
+
     for (const { pageId, text, usage } of pageResults) {
       if (text.length > HALLUCINATION_LIMIT) { failCount++; continue; }
 
@@ -411,6 +418,11 @@ async function processOneJob(db, job) {
           'ocr.output_tokens': outputTokens,
           updated_at: now,
         };
+        // Provenance (#2297) — only stamp when present, so older jobs without
+        // page_sources don't write null and look like a drift mismatch.
+        const srcUrl = sourceUrlByPage.get(pageId);
+        if (srcUrl) setObj['ocr.source_url'] = srcUrl;
+        if (job.code_version) setObj['ocr.code_version'] = job.code_version;
         if (isMultiPage) setObj['ocr.pages_per_request'] = job.pages_per_request;
         if (pageType) setObj.page_type = pageType;
         if (columns) setObj.columns = columns;

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -153,6 +153,21 @@ function getOcrModelForBook(book) {
 }
 const OCR_MODEL = OCR_MODEL_FLASH; // Legacy fallback for recitation retry path
 const OCR_PROMPT_VERSION = 'v10'; // Read from DB at runtime; this label is for batch_jobs metadata only
+
+// Code provenance (#2297): the git SHA actually checked out on this worker box.
+// Hetzner auto-pulls main every ~5 min, so HEAD == the running code. Falls back
+// to the Vercel env SHA (if ever run there), then 'dev'. Computed once, cached.
+let _codeVersion = null;
+async function getCodeVersion() {
+  if (_codeVersion) return _codeVersion;
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', '--short', 'HEAD']);
+    _codeVersion = stdout.trim() || 'dev';
+  } catch {
+    _codeVersion = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 8) || 'dev';
+  }
+  return _codeVersion;
+}
 const OCR_INLINE_BATCH_SIZE = 20;  // Pages per inline batch (base64 in body, ~20MB limit)
 const OCR_FILE_BATCH_SIZE = 1000;  // Pages per file-based batch. With 1500px resize, 1000 pages = ~500MB JSONL (well under 2GB File API limit). Google recommends 1K-5K. Experiment 2026-04-13: identical OCR quality at 1500px vs full-res.
 const CROSS_BOOK_BATCH_SIZE = 250; // Smaller batches for cross-book OCR — 500-page cross-book batches have 24% success vs 51% single-book. Half size = less blast radius on Gemini cancellation.
@@ -1197,7 +1212,9 @@ async function downloadImagesParallel(pages, concurrency, { maxDim } = {}) {
         if (!url || (!url.startsWith('http://') && !url.startsWith('https://'))) return null;
         const image = await fetchImageBase64(url, { maxDim });
         if (!image) return null;
-        return { pageId: page.id, image };
+        // Carry the exact URL we fetched so the batch job can record OCR
+        // provenance (#2297) — `url` is the canonical getPageSource result.
+        return { pageId: page.id, image, sourceUrl: url };
       })
     );
     for (const r of settled) {
@@ -1626,6 +1643,11 @@ Output structure:
       type: 'ocr',
       book_id: book.id,
       page_ids: chunk.map(c => c.pageId),
+      // OCR provenance (#2297): the exact image URL fetched + sent for each page,
+      // so batch-collector can stamp ocr.source_url at write-back. getPageSource
+      // already chose this URL in downloadImagesParallel.
+      page_sources: chunk.map(c => ({ page_id: c.pageId, source_url: c.sourceUrl || null })),
+      code_version: await getCodeVersion(),
       page_count: chunk.length,
       status: 'pending',
       model: ocrModel,
@@ -1752,7 +1774,7 @@ async function submitCrossBookOcrBatches(db, books) {
 
     bookMap.set(book.id, book);
     for (const item of downloaded) {
-      allDownloaded.push({ pageId: item.pageId, image: item.image, prompt, bookId: book.id });
+      allDownloaded.push({ pageId: item.pageId, image: item.image, prompt, bookId: book.id, sourceUrl: item.sourceUrl });
     }
   }
 
@@ -1842,6 +1864,9 @@ async function submitCrossBookOcrBatches(db, books) {
     book_id: chunkBookIds[0],
     book_ids: chunkBookIds,
     page_ids: allDownloaded.map(d => d.pageId),
+    // OCR provenance (#2297) — exact image fetched per page, for batch-collector.
+    page_sources: allDownloaded.map(d => ({ page_id: d.pageId, source_url: d.sourceUrl || null })),
+    code_version: await getCodeVersion(),
     page_count: allDownloaded.length,
     status: 'pending',
     model: ocrModel,


### PR DESCRIPTION
Follow-up to #2297 / PR #2302. Part of the #1727 epic; unblocks #2298.

## Problem
#2302 added OCR provenance (`ocr.source_url` + `ocr.code_version`) to the **SQS/Lambda** path (`ocr-processor-logic` → `write-processor-logic`). But that's the minority writer. Production OCR is dominated by the **Hetzner batch path** (`pipeline-orchestrator` → `batch-collector`), which recorded no `source_url`.

Production write counts, last 7 days (`pages.ocr.updated_at` by `ocr.source`):

| ocr.source (writer) | writes / 7d | had source_url |
|---|---|---|
| `batch_api` (batch-collector) | **434,106** | 0 |
| `pipeline_preview` (realtime) | 25,928 | 0 |
| `ai` (SQS/Lambda — instrumented by #2302) | 4,851 | 0 |

So ~94% of new OCR writes had no provenance, and **#2298's drift query (`ocr.source_url ≠ getPageSource`) would stay ~empty even for the go-forward set**.

## Change (additive only)
- **`pipeline-orchestrator.mjs`** — `downloadImagesParallel` already selects the image URL via the canonical `getPageSource` resolver, then discarded it; now returns it as `sourceUrl`. Both OCR submit paths (per-book + cross-book pooling) record `page_sources: [{page_id, source_url}]` + `code_version` on the `batch_jobs` doc at submit. `code_version` = the box's checked-out git SHA (Hetzner auto-pulls `main`, so HEAD == running code) → Vercel env SHA → `'dev'`.
- **`batch-collector.mjs`** — builds a `page_id → source_url` map from `job.page_sources` and stamps `ocr.source_url` + `ocr.code_version` in the OCR write. **Only stamps when present**, so jobs submitted before this ships stay pre-provenance (null) instead of writing a false drift mismatch.

No change to image selection, batching, or any existing field. Same `ocr.source_url`/`ocr.code_version` field names + `code_version` convention as #2302, so the existing `scripts/maintenance/audit-ocr-source-drift.mjs` now covers batch-path pages with no query change.

## Verification
- `node --check` clean on both workers; `check-imports` hook passed.
- Field-name/convention parity with #2302 confirmed (`write-processor-logic.ts` writes the same keys).
- 1:1 `page_id → source_url` mapping verified: `downloadImagesParallel` yields one item per page; collector keys the map by `pageId` (covers both single-page and multipage parse paths).

## Out of scope (follow-ups)
- `pipeline_preview` realtime OCR writes (25,928/7d) — separate path.
- Backfilling the ~90k existing pre-provenance `batch_jobs` — go-forward only here.

## Deploy note
Scripts under `scripts/**` need no Vercel deploy — the Hetzner box auto-pulls `main` every ~5 min, so this goes live on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)