### PR TITLE
feat(blog): "How Big Is the Library?" — corpus size vs Wikipedia + measurement script

### DIFF
--- a/scripts/analytics/corpus-size.mjs
+++ b/scripts/analytics/corpus-size.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// Corpus size measurement — how much text does Source Library hold?
+//
+// Counts words across every text layer: original-language OCR, AI translation,
+// per-page enrichment (summaries/keywords), AI image descriptions, and
+// book-level enrichment. Reports against English Wikipedia (~5B words of
+// article prose) and all-Wikipedias-combined (~30B words).
+//
+// WHY trimmed means: a handful of `pages.translation.data` fields hold
+// 50k-65k "words" (whole-book/concatenated dumps stuffed into one page record
+// — a genuine ingest bug, see --outliers). Those wreck the arithmetic mean
+// (translation mean 2,326 vs median 463). We report the median and a 1%-
+// trimmed mean; the trimmed mean is the headline estimate. Run --outliers to
+// list the pathological pages.
+//
+// Source of truth is Mongo `pages` (NOT Supabase page_translations, which is a
+// partial ~74% mirror used for embeddings/snippets). Estimates are $sample
+// extrapolations — expect a few percent of sampling noise.
+//
+// Run:  set -a; source .env.production.local; set +a; \
+//       node scripts/analytics/corpus-size.mjs [--sample N] [--outliers]
+
+import { MongoClient } from 'mongodb';
+
+const arg = (flag, def) => { const i = process.argv.indexOf(flag); return i > -1 ? process.argv[i + 1] : def; };
+const SAMPLE = Number(arg('--sample', 8000));
+const OUTLIERS = process.argv.includes('--outliers');
+// Per-page winsorization cap. A real dense double-column folio translates to at
+// most ~2,500 English words; anything above WINSOR is a duplicated/concatenated
+// ingest artifact (see --outliers), so we cap each page's contribution here.
+// This is the honest basis for a TOTAL — it keeps legitimately long pages while
+// refusing to let a handful of 50k-word junk pages dominate the sum.
+const WINSOR = Number(arg('--winsor', 3000));
+
+const WIKI_EN = 5.0e9;   // English Wikipedia article prose, words (~2026)
+const WIKI_ALL = 30e9;   // all language Wikipedias combined, words
+
+// --- word counting + editorial-wrapper stripping (mirrors
+//     src/lib/strip-editorial-wrappers.ts; inlined for .mjs) ---
+const EDITORIAL = 'meta|summary|keywords|vocab';
+const stripEditorial = (t) => !t ? '' : t
+  .replace(new RegExp(`<(${EDITORIAL})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
+  .replace(new RegExp(`<\\/?(?:${EDITORIAL})>`, 'gi'), ' ');
+// Also drop structural OCR tags (header/sig/lang/page-type) and any remaining
+// inline tags, keeping inner text (note/term/margin/gloss are real body text).
+const cleanWords = (t) => {
+  if (!t || typeof t !== 'string') return 0;
+  const body = stripEditorial(t)
+    .replace(/<(header|sig|lang|page-type)>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ');
+  const m = body.trim().match(/\S+/g);
+  return m ? m.length : 0;
+};
+
+const stats = (arr) => {
+  const a = [...arr].sort((x, y) => x - y);
+  const n = a.length;
+  const pct = (p) => a[Math.min(n - 1, Math.floor(n * p))] ?? 0;
+  const mean = a.reduce((s, v) => s + v, 0) / Math.max(1, n);
+  // Winsorized mean: cap each value at WINSOR before averaging. Robust to the
+  // fat junk-page tail (p99 ~52k words) in a way a 1% trim is not — the tail
+  // here is far thicker than 1%.
+  const winsor = a.reduce((s, v) => s + Math.min(v, WINSOR), 0) / Math.max(1, n);
+  const capped = a.filter(v => v > WINSOR).length;
+  return { n, mean, winsor, capped, median: pct(0.5), p90: pct(0.9), p99: pct(0.99), max: a[n - 1] ?? 0 };
+};
+
+const B = (x) => (x / 1e9).toFixed(2) + ' B';
+const M = (x) => (x / 1e6).toFixed(0) + ' M';
+
+const uri = process.env.MONGODB_URI || process.env.MONGO_URI;
+if (!uri) { console.error('Set MONGODB_URI'); process.exit(1); }
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const pages = db.collection('pages');
+const books = db.collection('books');
+const gallery = db.collection('gallery_images');
+
+const totalPages = await pages.estimatedDocumentCount();
+console.log(`\nCORPUS SIZE — ${totalPages.toLocaleString()} page docs, sampling ${SAMPLE.toLocaleString()}\n`);
+
+// --- outlier mode: list the pathological pages and exit ---
+if (OUTLIERS) {
+  console.log('Pages whose translation.data exceeds 15,000 words (a page should be ~300-700):');
+  const samp = await pages.aggregate([
+    { $sample: { size: 40000 } },
+    { $project: { book_id: 1, page_number: 1, 'translation.data': 1 } },
+  ], { allowDiskUse: true }).toArray();
+  const bad = samp
+    .map(p => ({ book_id: p.book_id, page: p.page_number, words: cleanWords(p.translation?.data) }))
+    .filter(p => p.words > 15000)
+    .sort((a, b) => b.words - a.words);
+  if (!bad.length) { console.log('  none in this sample (they are rare — try a larger --sample).'); }
+  for (const p of bad) console.log(`  ${p.words.toLocaleString().padStart(8)} words  book=${p.book_id} page=${p.page}`);
+  console.log(`\n  ${bad.length} of ${samp.length} sampled (${(bad.length / samp.length * 100).toFixed(2)}%). ` +
+    `Extrapolated ~${Math.round(bad.length / samp.length * totalPages).toLocaleString()} pathological pages library-wide.`);
+  await client.close();
+  process.exit(0);
+}
+
+// --- main: sample pages, measure OCR + translation + per-page enrichment ---
+const samp = await pages.aggregate([
+  { $sample: { size: SAMPLE } },
+  { $project: { 'ocr.data': 1, 'translation.data': 1, translation_summary: 1, translation_keywords: 1 } },
+], { allowDiskUse: true }).toArray();
+
+const ocr = [], tr = [];
+let psWords = 0, kwWords = 0;
+for (const p of samp) {
+  if (p.ocr?.data) ocr.push(cleanWords(p.ocr.data));
+  if (p.translation?.data) tr.push(cleanWords(p.translation.data));
+  psWords += cleanWords(p.translation_summary);
+  kwWords += cleanWords(p.translation_keywords);
+}
+const ocrS = stats(ocr), trS = stats(tr);
+const ocrCov = ocr.length / samp.length, trCov = tr.length / samp.length;
+
+const project = (perPage, cov) => perPage * cov * totalPages;
+const ocrWords = project(ocrS.winsor, ocrCov);
+const trWords = project(trS.winsor, trCov);
+const psTotal = (psWords / samp.length) * totalPages;
+const kwTotal = (kwWords / samp.length) * totalPages;
+
+console.log(`PER-PAGE (clean words, editorial wrappers stripped; winsorized at ${WINSOR}):`);
+console.log(`  OCR  : ${(ocrCov * 100).toFixed(1)}% of pages | median ${ocrS.median} | winsor-mean ${ocrS.winsor.toFixed(0)} | raw-mean ${ocrS.mean.toFixed(0)} | p99 ${ocrS.p99} | max ${ocrS.max}`);
+console.log(`  TRANS: ${(trCov * 100).toFixed(1)}% of pages | median ${trS.median} | winsor-mean ${trS.winsor.toFixed(0)} | raw-mean ${trS.mean.toFixed(0)} | p99 ${trS.p99} | max ${trS.max}`);
+console.log(`  (capped ${ocrS.capped} OCR + ${trS.capped} TRANS pages above ${WINSOR}w as junk; raw-mean is the inflated ceiling)`);
+if (trS.max > 15000) console.log(`  ⚠  translation max ${trS.max.toLocaleString()} words on one page — outlier ingest bug. Run --outliers.`);
+
+// --- gallery image descriptions ---
+const giTotal = await gallery.estimatedDocumentCount();
+const gsamp = await gallery.aggregate([{ $sample: { size: 4000 } },
+  { $project: { description: 1, museum_description: 1, gallery_rationale: 1 } }]).toArray();
+let giWords = 0;
+for (const g of gsamp) giWords += cleanWords(g.description) + cleanWords(g.museum_description) + cleanWords(g.gallery_rationale);
+const giTotalWords = (giWords / gsamp.length) * giTotal;
+
+// --- book-level enrichment (full scan, robust) ---
+let bkWords = 0, nb = 0;
+try {
+  const cur = books.find({}, { projection: {
+    description: 1, 'index.bookSummary': 1, 'summary.data': 1,
+    'reading_summary.overview': 1, 'reading_summary.detailed': 1, 'reading_summary.themes': 1,
+    'ai_metadata.description': 1,
+  } });
+  for await (const b of cur) {
+    nb++;
+    const themes = Array.isArray(b.reading_summary?.themes) ? b.reading_summary.themes.join(' ') : b.reading_summary?.themes;
+    bkWords += cleanWords(b.description) + cleanWords(b.index?.bookSummary) + cleanWords(b.summary?.data)
+      + cleanWords(b.reading_summary?.overview) + cleanWords(b.reading_summary?.detailed)
+      + cleanWords(themes) + cleanWords(b.ai_metadata?.description);
+  }
+} catch (e) { console.error('book scan stopped early after', nb, ':', e.message); }
+
+const enrich = psTotal + kwTotal + giTotalWords + bkWords;
+const grand = ocrWords + trWords + enrich;
+
+console.log('\nTOTALS (winsorized-mean basis, words):');
+console.log(`  OCR (originals)     ${B(ocrWords)}`);
+console.log(`  Translations        ${B(trWords)}`);
+console.log(`  Enrichment          ${B(enrich)}  (page-sum ${M(psTotal)} + kw ${M(kwTotal)} + image ${M(giTotalWords)} (${giTotal.toLocaleString()} imgs) + book ${M(bkWords)} over ${nb.toLocaleString()} books)`);
+console.log(`  ─────────────────────────────`);
+console.log(`  TOTAL               ${B(grand)} words  |  ~${B(grand * 1.4)} tokens (~1.4x, mixed scripts)`);
+console.log('\nvs WIKIPEDIA:');
+console.log(`  English Wikipedia (~5B words): ${(grand / WIKI_EN * 100).toFixed(0)}%`);
+console.log(`  Originals only vs EN-Wiki:     ${(ocrWords / WIKI_EN * 100).toFixed(0)}%`);
+console.log(`  All Wikipedias (~30B words):   ${(grand / WIKI_ALL * 100).toFixed(0)}%`);
+console.log('\nFor reference, MEDIAN-basis totals (conservative floor):');
+console.log(`  OCR ${B(project(ocrS.median, ocrCov))} + TRANS ${B(project(trS.median, trCov))} = ${B(project(ocrS.median, ocrCov) + project(trS.median, trCov) + enrich)}`);
+console.log('\nNote: estimates are $sample extrapolations (±few %). Winsorized-mean is the');
+console.log(`headline (caps junk pages at ${WINSOR}w); median is the floor; raw-mean the inflated`);
+console.log('ceiling. Run --outliers to inspect the junk pages.\n');
+
+await client.close();
+process.exit(0);

--- a/src/app/blog/how-big-is-the-library/page.tsx
+++ b/src/app/blog/how-big-is-the-library/page.tsx
@@ -1,0 +1,324 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import BlogComments from '@/components/blog/BlogComments';
+import BlogPostSchema from '@/components/seo/BlogPostSchema';
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: 'How Big Is the Library? - Research Notes - Source Library',
+  description:
+    "We counted every word Source Library holds — original OCR, AI translation, and enrichment. The answer: roughly 5-7 billion words, about the size of English Wikipedia. Here is how we measured it, junk pages and all.",
+  openGraph: {
+    title: 'How Big Is the Library?',
+    description:
+      'Roughly 5-7 billion words across 6.5 million pages — about the size of English Wikipedia. With the methodology, and the recitation-loop bug that nearly tripled the count.',
+    images: [
+      {
+        url: 'https://images.sourcelibrary.org/gallery/a5d0c381-d4ea-42cd-8864-44457e7fda33/69500509f426a210d109c5bd-0.jpg',
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+  alternates: {
+    canonical: '/blog/how-big-is-the-library',
+  },
+};
+
+// --- Data (measured 2026-06-01; see scripts/analytics/corpus-size.mjs) ---
+// Winsorized-mean basis (caps junk pages at 3,000 words/page). Median basis is
+// the conservative floor; raw mean is inflated by recitation-loop junk pages.
+const WORDS = {
+  originals: 3.28, // B, OCR of source-language pages
+  translations: 3.76, // B, AI English translation
+  enrichment: 0.02, // B, summaries + image descriptions + book metadata
+};
+const TOTAL = WORDS.originals + WORDS.translations + WORDS.enrichment; // 7.06 B
+const FLOOR = 4.87; // B, median-basis floor
+const TOKENS = 9.9; // B, ~1.4x words (mixed scripts tokenize denser)
+
+// Comparison baselines (billions of words)
+const WIKI_EN = 4.7; // English Wikipedia article prose
+const WIKI_ALL = 30; // all 300+ language editions combined
+
+// Horizontal stacked bar — values in billions of words
+function Bar({
+  label,
+  segments,
+  total,
+  scaleMax,
+  note,
+}: {
+  label: string;
+  segments: { value: number; color: string; name: string }[];
+  total: number;
+  scaleMax: number;
+  note?: string;
+}) {
+  return (
+    <div className="mb-5">
+      <div className="flex items-baseline justify-between mb-1.5">
+        <span className="font-serif text-primary text-base md:text-lg">{label}</span>
+        <span className="font-mono text-sm text-secondary tabular-nums">
+          {total.toFixed(1)}B words
+        </span>
+      </div>
+      <div className="flex h-7 w-full overflow-hidden rounded-sm bg-stone-100 ring-1 ring-stone-200">
+        {segments.map((s) => (
+          <div
+            key={s.name}
+            className={s.color}
+            style={{ width: `${(s.value / scaleMax) * 100}%` }}
+            title={`${s.name}: ${s.value.toFixed(2)}B`}
+          />
+        ))}
+      </div>
+      {note && <p className="text-xs text-muted mt-1 italic">{note}</p>}
+    </div>
+  );
+}
+
+export default function HowBigIsTheLibraryPage() {
+  const scaleMax = WIKI_ALL; // longest bar sets the scale
+  return (
+    <>
+      <BlogPostSchema
+        slug="how-big-is-the-library"
+        title="How Big Is the Library?"
+        description="We counted every word Source Library holds — original OCR, AI translation, and enrichment. Roughly 5-7 billion words, about the size of English Wikipedia."
+        datePublished="2026-06-01"
+        image="https://images.sourcelibrary.org/gallery/a5d0c381-d4ea-42cd-8864-44457e7fda33/69500509f426a210d109c5bd-0.jpg"
+      />
+      <ContentPageLayout
+        header={
+          <ContentHeader
+            title="How Big Is the Library?"
+            subtitle="Roughly five to seven billion words — about the size of English Wikipedia"
+            image="https://images.sourcelibrary.org/gallery/a5d0c381-d4ea-42cd-8864-44457e7fda33/69500509f426a210d109c5bd-0.jpg"
+            imageAlt="Frontispiece of Athanasius Kircher's Ars Magna Lucis et Umbrae (1671)"
+          >
+            <p className="text-stone-400 text-sm mt-4">1 June 2026 &middot; 6 min read</p>
+          </ContentHeader>
+        }
+        bg="bg-cream"
+      >
+        <div className="mb-8">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 text-muted hover:text-secondary transition-colors text-sm"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            All notes
+          </Link>
+        </div>
+
+        <article className="prose-content max-w-none">
+          {/* Lede */}
+          <p className="text-xl text-secondary leading-relaxed mb-8 font-body">
+            A natural question for any library: how much is in here? We have 6.5&nbsp;million
+            pages across roughly 15,500 readable books in 158 languages. But pages and books are
+            containers. We wanted the contents &mdash; the actual <em>words</em>.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-10 font-body">
+            So we counted. Not just the original texts, but everything the pipeline adds: the
+            facing-page English translations, the per-page summaries, the descriptions our vision
+            models write for 142,000 illustrations. The answer is about{' '}
+            <strong className="text-primary">seven billion words</strong> &mdash; or, if you only
+            trust the most conservative count, about five. Either way, that puts Source Library at
+            roughly the scale of <strong className="text-primary">English Wikipedia</strong>.
+          </p>
+
+          {/* Headline numbers */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 my-10">
+            {[
+              { n: '~7B', l: 'words of text' },
+              { n: '~10B', l: 'tokens' },
+              { n: '6.5M', l: 'pages' },
+              { n: '158', l: 'languages' },
+            ].map((s) => (
+              <div key={s.l} className="bg-white rounded-lg border border-border-light p-4 text-center">
+                <div className="font-serif text-3xl text-accent-rust">{s.n}</div>
+                <div className="text-xs text-muted mt-1 uppercase tracking-wide">{s.l}</div>
+              </div>
+            ))}
+          </div>
+
+          <hr className="border-border-light my-12" />
+
+          {/* The comparison */}
+          <section className="mb-14">
+            <h2 className="font-serif text-2xl md:text-3xl text-primary mb-6">
+              Against the obvious yardstick
+            </h2>
+            <p className="text-secondary leading-relaxed mb-8 font-body">
+              Wikipedia is the reference everyone has a feel for. English Wikipedia is about{' '}
+              <strong className="text-primary">4.7&nbsp;billion words</strong> of article prose;
+              all 300-plus language editions together come to roughly{' '}
+              <strong className="text-primary">30&nbsp;billion</strong>. Here is where we land,
+              counting our original texts and their translations as two layers of the same bar:
+            </p>
+
+            <div className="bg-white rounded-lg border border-border-light p-6 my-8">
+              <Bar
+                label="Source Library"
+                total={TOTAL}
+                scaleMax={scaleMax}
+                segments={[
+                  { value: WORDS.originals, color: 'bg-accent-rust', name: 'Originals (OCR)' },
+                  { value: WORDS.translations, color: 'bg-amber-400', name: 'Translations' },
+                  { value: WORDS.enrichment, color: 'bg-stone-400', name: 'Enrichment' },
+                ]}
+                note="Original-language OCR + AI English translation + enrichment"
+              />
+              <Bar
+                label="English Wikipedia"
+                total={WIKI_EN}
+                scaleMax={scaleMax}
+                segments={[{ value: WIKI_EN, color: 'bg-sky-600', name: 'Article prose' }]}
+              />
+              <Bar
+                label="All Wikipedias"
+                total={WIKI_ALL}
+                scaleMax={scaleMax}
+                segments={[{ value: WIKI_ALL, color: 'bg-sky-800', name: '300+ languages' }]}
+              />
+              <div className="flex flex-wrap gap-x-5 gap-y-2 mt-5 pt-4 border-t border-border-light text-xs text-secondary">
+                <span className="inline-flex items-center gap-1.5"><span className="w-3 h-3 rounded-sm bg-accent-rust inline-block" />Originals (OCR)</span>
+                <span className="inline-flex items-center gap-1.5"><span className="w-3 h-3 rounded-sm bg-amber-400 inline-block" />Translations</span>
+                <span className="inline-flex items-center gap-1.5"><span className="w-3 h-3 rounded-sm bg-stone-400 inline-block" />Enrichment</span>
+                <span className="inline-flex items-center gap-1.5"><span className="w-3 h-3 rounded-sm bg-sky-600 inline-block" />Wikipedia</span>
+              </div>
+            </div>
+
+            <p className="text-secondary leading-relaxed mb-6 font-body">
+              Counting originals and translations together, we are a little <em>larger</em> than
+              English Wikipedia. Counting only the original source texts &mdash; the
+              centuries-old Latin, Greek, Chinese, Sanskrit, Arabic, and the rest &mdash; we are
+              about two-thirds of it. And against the whole multilingual Wikipedia, we are
+              something like a quarter. For a library of pre-modern primary sources, assembled in
+              a few years, that is a strange and slightly vertiginous fact.
+            </p>
+          </section>
+
+          <hr className="border-border-light my-12" />
+
+          {/* The layers */}
+          <section className="mb-14">
+            <h2 className="font-serif text-2xl md:text-3xl text-primary mb-6">
+              What&apos;s actually in the count
+            </h2>
+            <p className="text-secondary leading-relaxed mb-8 font-body">
+              The number is the sum of distinct layers. Roughly half is the original text, scanned
+              and OCR&apos;d page by page. Almost as much again is the AI translation that sits
+              beside it &mdash; a little larger per page, because Latin and Greek are compact and
+              English spells everything out. The enrichment layer (summaries, keywords, the
+              museum-style descriptions for every illustration) is real but small.
+            </p>
+
+            <div className="bg-white rounded-lg border border-border-light p-6 my-8 space-y-4">
+              {[
+                { name: 'Original text (OCR)', v: WORDS.originals, color: 'bg-accent-rust', sub: '~6.2M pages · 158 languages' },
+                { name: 'English translation', v: WORDS.translations, color: 'bg-amber-400', sub: '~5.5M pages translated' },
+                { name: 'Enrichment & captions', v: WORDS.enrichment, color: 'bg-stone-400', sub: 'summaries + 142K image descriptions' },
+              ].map((r) => (
+                <div key={r.name}>
+                  <div className="flex items-baseline justify-between mb-1">
+                    <span className="font-serif text-primary">{r.name}</span>
+                    <span className="font-mono text-sm text-secondary tabular-nums">{r.v.toFixed(2)}B</span>
+                  </div>
+                  <div className="h-5 w-full rounded-sm bg-stone-100 overflow-hidden ring-1 ring-stone-200">
+                    <div className={r.color} style={{ width: `${(r.v / WORDS.translations) * 100}%`, height: '100%' }} />
+                  </div>
+                  <p className="text-xs text-muted mt-1">{r.sub}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <hr className="border-border-light my-12" />
+
+          {/* The honest part: how hard it was to measure */}
+          <section className="mb-14">
+            <h2 className="font-serif text-2xl md:text-3xl text-primary mb-6">
+              Why we give a range, not a number
+            </h2>
+            <p className="text-secondary leading-relaxed mb-6 font-body">
+              The honest answer is a range &mdash; <strong className="text-primary">five to
+              seven billion words</strong> &mdash; and the gap between those two figures is itself
+              a story about machine translation.
+            </p>
+            <p className="text-secondary leading-relaxed mb-6 font-body">
+              When we first averaged the words per translated page, the number came out absurdly
+              high: nearly 1,900 words a page, which would have implied a translation corpus of
+              over ten billion words on its own. A typical page has about 460. Something was
+              dragging the average up by a factor of four.
+            </p>
+            <p className="text-secondary leading-relaxed mb-6 font-body">
+              The culprit was a familiar failure mode. About <strong className="text-primary">2.4%
+              of pages</strong> &mdash; on the order of 150,000 of them &mdash; carry translations
+              that <em>run away</em>. The model, an older preview build, hits a repetitive passage
+              and gets stuck, emitting the same phrase tens of thousands of times until it slams
+              into its output ceiling. One leaf of a Tibetan sutra translated into the sentence{' '}
+              <span className="italic">&ldquo;They see the Dharma.&rdquo;</span> repeated{' '}
+              <strong className="text-primary">6,522 times</strong> &mdash; 52,000 words from a
+              page whose original is 1,600. (We wrote about the most extreme case, a Javanese
+              Bible leaf, in{' '}
+              <Link href="/blog/does-ai-get-religion" className="text-accent-rust hover:text-accent-rust underline">
+                Does the AI Get Religion?
+              </Link>
+              )
+            </p>
+            <p className="text-secondary leading-relaxed mb-6 font-body">
+              A handful of 50,000-word junk pages can fabricate billions of words that no reader
+              would ever see. So we don&apos;t use the raw average. We cap each page&apos;s
+              contribution at a generous 3,000 words &mdash; more than any real folio &mdash;
+              which gives the seven-billion headline. The five-billion floor is the page{' '}
+              <em>median</em>, which ignores the long tail entirely. The truth sits between, and
+              both comfortably clear &ldquo;about the size of Wikipedia.&rdquo; Those runaway pages
+              are now on the list to be re-translated and purged from search.
+            </p>
+            <div className="bg-stone-50 border-l-2 border-accent-rust pl-5 py-3 my-8">
+              <p className="text-sm text-secondary font-body italic">
+                The whole measurement is reproducible:{' '}
+                <code className="text-xs bg-white px-1.5 py-0.5 rounded border border-border-light not-italic">
+                  scripts/analytics/corpus-size.mjs
+                </code>{' '}
+                samples pages from the database, strips the editorial annotation that wraps each
+                one, and reports the median, winsorized, and raw figures side by side &mdash; plus
+                a <code className="text-xs bg-white px-1.5 py-0.5 rounded border border-border-light not-italic">--outliers</code>{' '}
+                mode that lists the runaway pages.
+              </p>
+            </div>
+          </section>
+
+          <hr className="border-border-light my-12" />
+
+          {/* Close */}
+          <section className="mb-10">
+            <p className="text-secondary leading-relaxed mb-6 font-body">
+              Size is not the point of a library &mdash; a single readable page of Ficino that no
+              one could read before is worth more than a million words of boilerplate. But scale
+              does say something. A few years ago this was one untranslated book in a glass case in
+              Amsterdam. It is now, by word count, a Wikipedia&apos;s worth of primary sources that
+              had mostly never been carried into English &mdash; sitting in one place, readable and
+              quotable, page by facing page.
+            </p>
+            <p className="text-muted text-sm font-body">
+              Counts measured 1&nbsp;June 2026 from the production database. Wikipedia baselines:
+              English ~4.7B words of article prose; all editions ~30B. Word totals are{' '}
+              <code className="text-xs">$sample</code> extrapolations (±a few percent); token
+              estimates assume ~1.4 tokens per word for mixed scripts.
+            </p>
+          </section>
+        </article>
+
+        <BlogComments slug="how-big-is-the-library" />
+      </ContentPageLayout>
+    </>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -25,6 +25,18 @@ interface BlogPost {
 
 const posts: BlogPost[] = [
   {
+    slug: 'how-big-is-the-library',
+    title: 'How Big Is the Library?',
+    subtitle:
+      'We counted every word — original OCR, AI translation, and enrichment. Roughly five to seven billion words, about the size of English Wikipedia. With the methodology, and the recitation-loop bug that nearly tripled the count.',
+    date: '1 June 2026',
+    readTime: '6 min read',
+    tag: 'Research',
+    tagColor: 'bg-blue-50 text-blue-700',
+    image: 'https://images.sourcelibrary.org/gallery/a5d0c381-d4ea-42cd-8864-44457e7fda33/69500509f426a210d109c5bd-0.jpg',
+    imageAlt: "Frontispiece of Athanasius Kircher's Ars Magna Lucis et Umbrae (1671)",
+  },
+  {
     slug: 'how-long-to-translate',
     title: 'How Long Would It Take to Translate the Renaissance?',
     subtitle: 'We measured the rate of new Latin translations and counted what is left. At the current pace, the Latin Renaissance alone would take about ten thousand years to finish.',

--- a/src/components/press/releases/SourceLibraryPublicBetaLaunch.tsx
+++ b/src/components/press/releases/SourceLibraryPublicBetaLaunch.tsx
@@ -3,7 +3,7 @@
  * Embassy-framed arc: the institution and its creed (ad fontes) open and close the piece;
  * the untranslated-Renaissance idea and open access drive it. Straight prose, no stat boxes.
  * Fundraising lives only in private donor materials, never here.
- * Figures verified against the live Source Library database on 30 May 2026.
+ * Figures verified against the live Source Library database on 1 June 2026.
  * Header/dateline and back-link are supplied by the /press-releases/[slug] route.
  */
 
@@ -62,7 +62,7 @@ export default function SourceLibraryPublicBetaLaunch() {
         translated volumes since 1911; Harvard&rsquo;s I Tatti Renaissance Library about 100 since 2001.
         Source Library holds more than 15,000, and unlike those series it translates works that were never
         available in English at all. Counted together, the original texts and their translations come to
-        more than four billion words, roughly 90 percent of the entire English Wikipedia.
+        roughly five billion words &mdash; comparable in scale to the entire English Wikipedia.
       </p>
 
       <p className="text-secondary leading-relaxed mb-6 font-body">
@@ -133,7 +133,7 @@ export default function SourceLibraryPublicBetaLaunch() {
 
       <p className="text-xs text-muted leading-relaxed mt-6 font-body">
         Source for the translation estimate: D. Shuger, UCLA. Library figures verified against the Source
-        Library database, 30 May 2026.
+        Library database, 1 June 2026.
       </p>
     </article>
   );


### PR DESCRIPTION
## What

A new research-notes post — **How Big Is the Library?** — answering "how much text do we actually hold?" plus the reproducible script behind it.

**Headline:** ~7B words (winsorized) / ~4.9B (median floor), ~10B tokens — roughly the size of English Wikipedia article prose (~4.7B), counting originals + translations as two layers.

### In scope
- `src/app/blog/how-big-is-the-library/page.tsx` — the post, with self-contained CSS data-vis (no new deps): a stacked comparison bar (Source Library vs English Wikipedia vs all Wikipedias) and a layer breakdown. Honest methodology section on the median/winsorized range.
- `src/app/blog/page.tsx` — registers the post at the top of the index (dated 1 June 2026).
- `scripts/analytics/corpus-size.mjs` — reproducible sampler. Strips editorial wrappers, reports median / winsorized-mean / raw-mean per-page word counts across OCR + translation + enrichment, projects totals, compares to Wikipedia. `--outliers` lists the runaway pages.

### Why the script winsorizes
The naive translation mean is ~1,900 words/page (median is ~460). The inflation is **~2.4% of pages (~155K library-wide)** carrying recitation-loop garbage — 50–65K "words" each, e.g. a Tibetan sutra leaf rendered as *"They see the Dharma."* ×6,522. Source model is the retired `gemini-3.1-flash-lite-preview`. The script caps per-page contribution at 3,000w so a handful of junk pages can't fabricate billions of words.

### Out of scope (follow-ups)
- **Re-translating / purging the ~155K recitation-loop pages** — they also likely pollute search snippets and embeddings. Separate data-quality PR.
- **Stale hard-coded counts in older blog posts** (10000-books, worlds-largest-collection, first-translations, etc.) predate the library's growth to ~15.5K books / 6,008 first translations. Audited separately; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)