### PR TITLE
perf(images): exclude old-era split at query level in display backfill (#1814)

### DIFF
--- a/scripts/migration/backfill-display-images.mjs
+++ b/scripts/migration/backfill-display-images.mjs
@@ -95,10 +95,22 @@ const PAGE_PROJECTION = {
   cropped_photo: 1, display_photo: 1, image_thumb: 1, split_from_spread: 1,
 };
 
-/** Per-book Mongo pre-filter: pages missing display_photo. */
+/**
+ * Per-book Mongo pre-filter: pages missing display_photo AND not old-era split.
+ *
+ * Excluding old-era split (`cropped_photo` set) at the QUERY level — not just in
+ * `resolveSource()` — matters because BPH (~half the catalogue) is almost
+ * entirely old-era split spreads. Without this, a split-heavy book returns
+ * thousands of pages that all get skipped, burning the per-run page budget on
+ * scan-and-skip instead of producing variants (observed: one run skipped
+ * 9,830 / 10,009 pages). The read-side proxies+crops these regardless, so they
+ * are out of scope (see header). `resolveSource()` keeps its guard as defence
+ * in depth for any that slip through (e.g. cropped_photo added after this read).
+ */
 const gapFilter = (bookId) => ({
   book_id: bookId,
   $or: [{ display_photo: { $exists: false } }, { display_photo: null }, { display_photo: '' }],
+  cropped_photo: { $in: [null, ''] },  // exclude old-era split (field absent or empty)
 });
 
 function variantKeys(bookId, pageNumber) {


### PR DESCRIPTION
## Why

Follow-up to #2316 (seen-first). The visible-first drain walked into **BPH** (~half the catalogue, almost entirely old-era split spreads) and **burned its 10K-page budget scanning pages it only skips**: one observed run processed 10,009 pages but **9,830 were old-era-split skips**, yielding just 179 variants.

Old-era split is only ~2.3% of the gap *globally* but **heavily clustered**, so any run landing in the BPH region was near-pure scan-and-skip.

## Change

Add `cropped_photo: {$in:[null,'']}` to the per-book gap filter so old-era split pages never enter the candidate set. `resolveSource()` keeps its guard as defence-in-depth.

**Verified:** a known old-era-split book went from **1,511 candidate pages (≈1,510 skipped) → 1** (the lone genuine non-split gap page). Budget now goes to real backfills.

## On "prioritize what actually gets hit"

Measured the available Mongo signals before building an ordering:
- `view_count` / `like_count` / `popularity`: **0% populated**
- `read_count`: near-flat (book **8.5%**, page **0.5%**)
- `quality_score`: 64% — but that's editorial quality, not hits

So **no queryable hit signal exists** in Mongo. The real "what gets hit" data lives in the `/api/image` proxy/CDN logs. Given that, **visible-first (#2316) + this split-exclusion already targets the only reader-servable pages** (hidden = never shown; split spreads = never served). Finer hit-ordering would require instrumenting the proxy to record served (bookId, page) into a hot-set — a separate, bigger piece (frontend deploy + days of accumulation). Flagging rather than faking it with a flat field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)