### PR TITLE
fix(iiif): close editorial-wrapper leak + AI provenance, real canvas dims, broader image services & rights

### DIFF
--- a/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
+++ b/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
@@ -11,6 +11,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { aiGenerator } from '@/lib/iiif-provenance';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -62,8 +64,8 @@ export async function GET(
     // Fetch only the field we need
     const projection =
       type === 'ocr'
-        ? { 'ocr.data': 1, 'ocr.language': 1, page_number: 1 }
-        : { 'translation.data': 1, 'translation.language': 1, page_number: 1 };
+        ? { 'ocr.data': 1, 'ocr.language': 1, 'ocr.model': 1, page_number: 1 }
+        : { 'translation.data': 1, 'translation.language': 1, 'translation.model': 1, page_number: 1 };
 
     const page = await db.collection('pages').findOne(
       { book_id: id, page_number: pageNum },
@@ -76,6 +78,16 @@ export async function GET(
 
     const content = type === 'ocr' ? page.ocr : page.translation;
     if (!content?.data) {
+      return NextResponse.json({ error: `No ${type} data for this page` }, { status: 404 });
+    }
+
+    // Strip AI editorial wrapper blocks (<meta>/<summary>/<keywords>/<vocab>)
+    // before serving as a transcription/translation. These describe the page
+    // (often naming content from ADJACENT pages) and are never verbatim source —
+    // overlaying them in a viewer fabricates citations to words not on the page
+    // (the "mercury on page 89" misquote, PR #2232). Strip content, not just tags.
+    const value = stripEditorialWrappers(content.data).trim();
+    if (!value) {
       return NextResponse.json({ error: `No ${type} data for this page` }, { status: 404 });
     }
 
@@ -94,10 +106,13 @@ export async function GET(
           motivation: 'supplementing',
           body: {
             type: 'TextualBody',
-            value: content.data,
+            value,
             format: 'text/plain',
             language,
           },
+          // Machine origin made explicit so AI text is never mistaken for a
+          // human-verified transcript.
+          generator: aiGenerator(type, content.model),
           target: canvasId,
         },
       ],

--- a/src/app/api/iiif/[id]/manifest/route.ts
+++ b/src/app/api/iiif/[id]/manifest/route.ts
@@ -14,16 +14,43 @@ import { getReadDb } from '@/lib/mongodb';
 
 const BASE = 'https://sourcelibrary.org';
 
-// Map SPDX-ish license IDs to IIIF-required CC/RS URIs
+// Map SPDX-ish license IDs to IIIF-required CC/RS URIs. Keys are matched
+// case-insensitively (see resolveRights), so list the canonical form only.
 const LICENSE_URIS: Record<string, string> = {
   publicdomain: 'http://creativecommons.org/publicdomain/mark/1.0/',
-  'CC0-1.0': 'http://creativecommons.org/publicdomain/zero/1.0/',
-  'CC-BY-4.0': 'http://creativecommons.org/licenses/by/4.0/',
-  'CC-BY-SA-4.0': 'http://creativecommons.org/licenses/by-sa/4.0/',
-  'CC-BY-NC-4.0': 'http://creativecommons.org/licenses/by-nc/4.0/',
-  'CC-BY-NC-SA-4.0': 'http://creativecommons.org/licenses/by-nc-sa/4.0/',
+  pdm: 'http://creativecommons.org/publicdomain/mark/1.0/',
+  'public-domain': 'http://creativecommons.org/publicdomain/mark/1.0/',
+  'cc0-1.0': 'http://creativecommons.org/publicdomain/zero/1.0/',
+  cc0: 'http://creativecommons.org/publicdomain/zero/1.0/',
+  'cc-by-4.0': 'http://creativecommons.org/licenses/by/4.0/',
+  'cc-by-sa-4.0': 'http://creativecommons.org/licenses/by-sa/4.0/',
+  'cc-by-nd-4.0': 'http://creativecommons.org/licenses/by-nd/4.0/',
+  'cc-by-nc-4.0': 'http://creativecommons.org/licenses/by-nc/4.0/',
+  'cc-by-nc-sa-4.0': 'http://creativecommons.org/licenses/by-nc-sa/4.0/',
+  'cc-by-nc-nd-4.0': 'http://creativecommons.org/licenses/by-nc-nd/4.0/',
   'in-copyright': 'http://rightsstatements.org/vocab/InC/1.0/',
+  inc: 'http://rightsstatements.org/vocab/InC/1.0/',
+  'noc-us': 'http://rightsstatements.org/vocab/NoC-US/1.0/',
+  'noc-nc': 'http://rightsstatements.org/vocab/NoC-NC/1.0/',
+  cne: 'http://rightsstatements.org/vocab/CNE/1.0/',
+  und: 'http://rightsstatements.org/vocab/UND/1.0/',
 };
+
+/**
+ * Resolve a stored license/rights value to a single IIIF `rights` URI.
+ * Passes through values that are already CC / rightsstatements.org URIs, and
+ * otherwise maps SPDX-ish IDs case-insensitively. The IIIF spec REQUIRES rights
+ * to be exactly one CC or rightsstatements.org URI — anything else is dropped
+ * rather than emitted as an invalid value.
+ */
+function resolveRights(license?: string): string | undefined {
+  if (!license) return undefined;
+  const raw = license.trim();
+  if (/^https?:\/\/(creativecommons\.org|rightsstatements\.org)\//i.test(raw)) {
+    return raw;
+  }
+  return LICENSE_URIS[raw.toLowerCase()];
+}
 
 // BCP 47 codes for languages we encounter
 const LANG_CODES: Record<string, string> = {
@@ -46,42 +73,50 @@ function langCode(language?: string): string {
   return LANG_CODES[lower] || lower.slice(0, 2);
 }
 
+// Known IIIF image hosts whose API version/profile we can state precisely.
+// Anything else that is still IIIF-shaped falls through to a conservative
+// default (see extractImageService).
+const KNOWN_IIIF_HOSTS: Array<{ test: RegExp; type: string; profile: string }> = [
+  { test: /iiif\.archive\.org\/image\/iiif\/3\//, type: 'ImageService3', profile: 'level2' },
+  { test: /gallica\.bnf\.fr\/iiif\//, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level2.json' },
+  { test: /api\.digitale-sammlungen\.de\/iiif\/image\/v2\//, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level2.json' },
+  { test: /e-rara\.ch\/i3f\/v20\//, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level1.json' },
+  { test: /iiif\.wellcomecollection\.org\//, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level2.json' },
+  { test: /iiif\.bodleian\.ox\.ac\.uk\//, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level2.json' },
+  { test: /tile\.loc\.gov\//, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level2.json' },
+  { test: /digi\.vatlib\.it\//, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level1.json' },
+  { test: /ids\.lib\.harvard\.edu\//, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level2.json' },
+  { test: /images\.lib\.cam\.ac\.uk\//, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level2.json' },
+];
+
 /**
- * Try to extract a IIIF Image Service URL from a page image URL.
- * Returns { id, type, profile } or null.
+ * Try to extract a IIIF Image Service from a stored page image URL.
+ *
+ * Works for ANY upstream IIIF endpoint, not a fixed host list: a canonical
+ * Image API request is `{service}/{region}/{size}/{rotation}/{quality}.{format}`,
+ * so we strip those four trailing segments to recover the service base. Known
+ * hosts get their exact API version/profile; an unrecognized but IIIF-shaped
+ * URL gets the most widely supported default (viewers read info.json for the
+ * truth). Plain re-hosted JPEGs (our R2 derivatives) don't match and correctly
+ * return null — we don't run an Image API server over those.
  */
 function extractImageService(url: string): { id: string; type: string; profile: string } | null {
-  // Internet Archive IIIF v3
-  // e.g. https://iiif.archive.org/image/iiif/3/identifier%24pagenum/full/max/0/default.jpg
-  const iaMatch = url.match(/^(https:\/\/iiif\.archive\.org\/image\/iiif\/3\/[^/]+)\/full\//);
-  if (iaMatch) {
-    return { id: iaMatch[1], type: 'ImageService3', profile: 'level2' };
+  const m = url.match(
+    /^(https?:\/\/.+?)\/(full|square|\d+,\d+,\d+,\d+|pct:[\d.,]+)\/(max|full|\^?!?\d*,\d*|pct:[\d.]+)\/(!?-?\d+(?:\.\d+)?)\/(default|color|gray|bitonal)\.(jpg|jpeg|png|tif|tiff|gif|jp2|webp)$/i
+  );
+  if (!m) return null;
+  const base = m[1];
+  for (const host of KNOWN_IIIF_HOSTS) {
+    if (host.test.test(base)) {
+      return { id: base, type: host.type, profile: host.profile };
+    }
   }
-
-  // Gallica IIIF v2
-  // e.g. https://gallica.bnf.fr/iiif/ark:/12148/bpt6k.../f42/full/full/0/native.jpg
-  const gallicaMatch = url.match(/^(https:\/\/gallica\.bnf\.fr\/iiif\/ark:\/12148\/[^/]+\/f\d+)\/full\//);
-  if (gallicaMatch) {
-    return { id: gallicaMatch[1], type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level2.json' };
-  }
-
-  // MDZ / BSB IIIF
-  // e.g. https://api.digitale-sammlungen.de/iiif/image/v2/bsb.../full/...
-  const mdzMatch = url.match(/^(https:\/\/api\.digitale-sammlungen\.de\/iiif\/image\/v2\/[^/]+)\/full\//);
-  if (mdzMatch) {
-    return { id: mdzMatch[1], type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level2.json' };
-  }
-
-  // e-rara IIIF
-  const eraraMatch = url.match(/^(https:\/\/www\.e-rara\.ch\/i3f\/v20\/[^/]+)\/full\//);
-  if (eraraMatch) {
-    return { id: eraraMatch[1], type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level1.json' };
-  }
-
-  return null;
+  // IIIF-shaped URL from an unrecognized host: declare the broadly compatible
+  // v2/level1 and let the viewer confirm via info.json.
+  return { id: base, type: 'ImageService2', profile: 'http://iiif.io/api/image/2/level1.json' };
 }
 
-// Default canvas dimensions (reasonable for a book page)
+// Default canvas dimensions, used only when a page has no stored pixel size.
 const DEFAULT_WIDTH = 1500;
 const DEFAULT_HEIGHT = 2160;
 
@@ -122,6 +157,7 @@ export async function GET(
             photo: 1,
             photo_original: 1,
             archived_photo: 1,
+            image_width: 1, image_height: 1,
             thumbnail_blob: 1, image_thumb: 1,
             thumbnail: 1, image_display: 1,
             'ocr.language': 1,
@@ -229,7 +265,7 @@ export async function GET(
 
     // Rights
     const license = book.image_source?.license || book.license;
-    const rightsUri = license ? LICENSE_URIS[license] : undefined;
+    const rightsUri = resolveRights(license);
 
     // Attribution
     const attribution = book.image_source?.attribution;
@@ -241,12 +277,18 @@ export async function GET(
       const imageUrl = page.archived_photo || page.photo_original || page.photo;
       const service = imageUrl ? extractImageService(imageUrl) : null;
 
+      // Use the real digitized pixel size when archiving recorded it, so that
+      // xywh region citation / annotation targeting lands on the correct part
+      // of the image. Fall back to a nominal page size only when unknown.
+      const width = page.image_width || DEFAULT_WIDTH;
+      const height = page.image_height || DEFAULT_HEIGHT;
+
       const imageBody: Record<string, unknown> = {
         id: imageUrl,
         type: 'Image',
         format: 'image/jpeg',
-        width: DEFAULT_WIDTH,
-        height: DEFAULT_HEIGHT,
+        width,
+        height,
       };
       if (service) {
         imageBody.service = [service];
@@ -256,8 +298,8 @@ export async function GET(
         id: canvasId,
         type: 'Canvas',
         label: { none: [`p. ${pageNum}`] },
-        width: DEFAULT_WIDTH,
-        height: DEFAULT_HEIGHT,
+        width,
+        height,
         items: [
           {
             id: `${canvasId}/painting`,

--- a/src/app/api/iiif/[id]/search/route.ts
+++ b/src/app/api/iiif/[id]/search/route.ts
@@ -13,6 +13,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { aiGenerator } from '@/lib/iiif-provenance';
 
 const BASE = 'https://sourcelibrary.org';
 const MAX_RESULTS = 200;
@@ -132,7 +134,9 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
           page_number: 1,
           'ocr.data': 1,
           'ocr.language': 1,
+          'ocr.model': 1,
           'translation.data': 1,
+          'translation.model': 1,
         },
         sort: { page_number: 1 },
         limit: 100, // Cap pages scanned
@@ -150,8 +154,10 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
       const pageNum = page.page_number;
       const canvasId = `${BASE}/api/iiif/${bookId}/canvas/p${pageNum}`;
 
-      // Check OCR text
-      const ocrText = page.ocr?.data as string | undefined;
+      // Check OCR text. Strip AI editorial wrappers first so the search never
+      // matches or returns <meta>/<summary> prose that isn't on the page (PR #2232).
+      const ocrRaw = page.ocr?.data as string | undefined;
+      const ocrText = ocrRaw ? stripEditorialWrappers(ocrRaw).trim() : undefined;
       if (ocrText) {
         const ocrMatches = findMatches(ocrText, query);
         if (ocrMatches.length > 0) {
@@ -166,6 +172,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
               format: 'text/plain',
               language: page.ocr?.language || 'none',
             },
+            generator: aiGenerator('ocr', page.ocr?.model),
             target: canvasId,
           });
 
@@ -191,8 +198,9 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
         }
       }
 
-      // Check translation text
-      const transText = page.translation?.data as string | undefined;
+      // Check translation text (same wrapper strip as OCR).
+      const transRaw = page.translation?.data as string | undefined;
+      const transText = transRaw ? stripEditorialWrappers(transRaw).trim() : undefined;
       if (transText) {
         const transMatches = findMatches(transText, query);
         if (transMatches.length > 0) {
@@ -207,6 +215,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
               format: 'text/plain',
               language: 'en',
             },
+            generator: aiGenerator('translation', page.translation?.model),
             target: canvasId,
           });
 

--- a/src/lib/iiif-provenance.ts
+++ b/src/lib/iiif-provenance.ts
@@ -1,0 +1,35 @@
+/**
+ * Provenance for AI-generated IIIF annotation bodies.
+ *
+ * Our OCR transcriptions and English translations are machine-generated and,
+ * unless explicitly reviewed, NOT human-verified. When we expose them as IIIF
+ * `supplementing` annotations a viewer (Mirador, Universal Viewer, Clover)
+ * overlays them on the original page image — visually indistinguishable from a
+ * scholarly transcription. Attaching a `generator` agent makes the machine
+ * origin explicit and citable, so a reader never mistakes AI output for a
+ * faithful human transcript.
+ *
+ * `generator` is the W3C Web Annotation field for the software that produced
+ * the annotation body (https://www.w3.org/TR/annotation-model/#agents).
+ */
+
+type AnnotationKind = 'ocr' | 'translation';
+
+/**
+ * Build a `generator` Software agent for an AI-produced annotation body.
+ * Pass the concrete model name (e.g. `pages.ocr.model`) when known so the
+ * provenance is specific rather than generic.
+ */
+export function aiGenerator(kind: AnnotationKind, model?: string) {
+  const what =
+    kind === 'ocr'
+      ? 'AI OCR transcription — machine-generated, not human-verified'
+      : 'AI translation — machine-generated, not human-verified';
+  const label = model ? `${what} (${model})` : what;
+
+  return {
+    id: 'https://sourcelibrary.org/about/processing',
+    type: 'Software',
+    label: { en: [label] },
+  };
+}


### PR DESCRIPTION
## Why

Walking the IIIF conference, the sharpest fair critiques of our IIIF surfaces were on the on-demand annotation/search/manifest routes — code paths that earlier integrity and compliance fixes never reached. A scholar pulling our books into Mirador would have hit all of these.

## What changed

**Integrity (the bugs they'd catch first)**
- **Editorial-wrapper leak, now closed on IIIF.** The OCR/translation annotation route and the content-search route served `pages.{ocr,translation}.data` raw. They now run through `stripEditorialWrappers()` — the same fix the web surfaces got in #2232 (the *mercury on page 89* misquote). Previously a viewer overlaid AI `<meta>`/`<summary>` prose (which routinely describes *adjacent* pages) as if it were the transcription on that folio.
- **AI provenance.** Supplementing annotations now carry a W3C Web-Annotation `generator` agent (`src/lib/iiif-provenance.ts`) marking the body machine-generated and **not human-verified**, with the concrete model name when stored. AI text is no longer indistinguishable from a human transcript.

**Compliance nits**
- **Real canvas dimensions.** Canvases used a hardcoded 1500×2160 regardless of the image, so `xywh` region citation / annotation targeting was geometrically wrong. Now uses `page.image_width/height` (recorded at archiving) when present, nominal only as fallback.
- **Image Service coverage.** Deep zoom resolved for only 4 hard-coded hosts. Now any **upstream IIIF endpoint** resolves via canonical Image-API URL parsing (strip `{region}/{size}/{rotation}/{quality}.{format}`); known hosts keep their exact version/profile. Our own re-hosted flat JPEGs still correctly return no service.
- **Rights.** `resolveRights()` passes through CC / rightsstatements.org URIs and maps SPDX-ish IDs case-insensitively, with an expanded table; invalid values are dropped rather than emitted.

## Out of scope (deliberately)
- **Deep zoom for truly re-hosted pages** needs us to run a IIIF Image API server over our R2 derivatives — infra, separate PR.
- **Crediting the holding institution as a manifest `provider` Agent** (attribution fidelity) — we currently list only Source Library as provider; worth a focused follow-up.

## Test
- `npx tsc --noEmit` clean for all touched files (pre-existing d3/carbon-ledger errors unrelated).
- check-imports hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)