### PR TITLE
fix(iiif): credit the holding institution as the primary manifest provider

### DIFF
--- a/src/app/api/iiif/[id]/manifest/route.ts
+++ b/src/app/api/iiif/[id]/manifest/route.ts
@@ -11,6 +11,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
+import { getPartnerByProvider, type LibraryPartner } from '@/lib/library-partners';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -84,6 +85,85 @@ function extractImageService(url: string): { id: string; type: string; profile: 
 // Default canvas dimensions (reasonable for a book page)
 const DEFAULT_WIDTH = 1500;
 const DEFAULT_HEIGHT = 2160;
+
+// `image_source.provider` has accumulated alternate keys over time; map the
+// aliases back to the canonical key that LIBRARY_PARTNERS is registered under
+// so the holding institution still resolves.
+const PROVIDER_KEY_ALIASES: Record<string, string> = {
+  ia: 'internet_archive',
+  bsb: 'mdz',
+  e_rara: 'e-rara',
+  vatlib: 'vatican',
+  ndl: 'ndl_japan',
+};
+
+function resolvePartner(provider?: string): LibraryPartner | undefined {
+  if (!provider) return undefined;
+  return (
+    getPartnerByProvider(provider) ||
+    getPartnerByProvider(PROVIDER_KEY_ALIASES[provider] ?? provider)
+  );
+}
+
+/**
+ * IIIF `provider` agents, holding institution FIRST.
+ *
+ * The library that digitized the book is the primary provider — IIIF's whole
+ * model rests on consumers crediting the source institution structurally, not
+ * demoting it to a free-text metadata row. Source Library is listed second as
+ * the aggregator that re-hosts and adds AI OCR/translation. Falls back to the
+ * stored `provider_name` / `source_url` when the institution isn't a registered
+ * LIBRARY_PARTNER, so long-tail sources are still credited.
+ */
+function buildProviders(
+  imageSource: { provider?: string; provider_name?: string; source_url?: string } | undefined,
+): Array<Record<string, unknown>> {
+  const providers: Array<Record<string, unknown>> = [];
+
+  const partner = resolvePartner(imageSource?.provider);
+  const name = partner?.name || imageSource?.provider_name;
+  const homepageUrl = partner?.url || imageSource?.source_url;
+
+  if (name) {
+    const agent: Record<string, unknown> = {
+      id: homepageUrl || BASE,
+      type: 'Agent',
+      label: { en: [name] },
+    };
+    if (homepageUrl) {
+      agent.homepage = [
+        { id: homepageUrl, type: 'Text', label: { en: [name] }, format: 'text/html' },
+      ];
+    }
+    if (partner) {
+      agent.seeAlso = [
+        {
+          id: `${BASE}/libraries/${partner.slug}`,
+          type: 'Text',
+          label: { en: [`${name} on Source Library`] },
+          format: 'text/html',
+        },
+      ];
+    }
+    providers.push(agent);
+  }
+
+  providers.push({
+    id: BASE,
+    type: 'Agent',
+    label: { en: ['Source Library'] },
+    homepage: [
+      {
+        id: BASE,
+        type: 'Text',
+        label: { en: ['Source Library — re-hosted edition with AI OCR & translation'] },
+        format: 'text/html',
+      },
+    ],
+  });
+
+  return providers;
+}
 
 export async function GET(
   request: NextRequest,
@@ -231,8 +311,16 @@ export async function GET(
     const license = book.image_source?.license || book.license;
     const rightsUri = license ? LICENSE_URIS[license] : undefined;
 
-    // Attribution
-    const attribution = book.image_source?.attribution;
+    // Attribution — always credit the digitizing institution. Prefer an explicit
+    // attribution string when stored; otherwise build one from the institution
+    // name so the required statement is never empty.
+    const institutionName =
+      resolvePartner(book.image_source?.provider)?.name || book.image_source?.provider_name;
+    const attribution =
+      book.image_source?.attribution ||
+      (institutionName
+        ? `Digitized by ${institutionName}. Re-hosted with AI-generated OCR and translation by Source Library.`
+        : 'Re-hosted with AI-generated OCR and translation by Source Library.');
 
     // Build canvases
     const canvases = pagesLight.map((page) => {
@@ -343,21 +431,7 @@ export async function GET(
       behavior: ['paged'],
       viewingDirection: 'left-to-right',
 
-      provider: [
-        {
-          id: BASE,
-          type: 'Agent',
-          label: { en: ['Source Library'] },
-          homepage: [
-            {
-              id: BASE,
-              type: 'Text',
-              label: { en: ['Source Library — Digital Archive of Western Esoteric Texts'] },
-              format: 'text/html',
-            },
-          ],
-        },
-      ],
+      provider: buildProviders(book.image_source),
 
       homepage: [
         {
@@ -388,12 +462,10 @@ export async function GET(
       manifest.rights = rightsUri;
     }
 
-    if (attribution) {
-      manifest.requiredStatement = {
-        label: { en: ['Attribution'] },
-        value: { en: [attribution] },
-      };
-    }
+    manifest.requiredStatement = {
+      label: { en: ['Attribution'] },
+      value: { en: [attribution] },
+    };
 
     if (book.published) {
       // navDate needs ISO 8601 — approximate from year


### PR DESCRIPTION
## Why

Follow-up to #2323, split out as its own concern (attribution, not integrity). Our IIIF manifest listed **Source Library as the sole `provider` Agent**, and the holding institution — the library that actually digitized the book — appeared only as a free-text "Source" row in `metadata`, or not at all. To an IIIF audience that's the central attribution-fidelity miss: the ecosystem runs on consumers crediting the source institution *structurally and prominently*, not demoting it beneath the re-publisher. For a project that re-hosts, taking the lone provider slot is exactly the optic that reads as 'scraping the commons.'

## What changed (manifest route only)

- **`provider` is now an array, holding institution first.** Resolved from `LIBRARY_PARTNERS` via `image_source.provider` (with alias normalization for accumulated alternate keys like `ia`→`internet_archive`, `bsb`→`mdz`), falling back to the stored `provider_name`/`source_url` so long-tail sources not in the partner registry are still credited. Source Library is listed **second**, as the aggregator that re-hosts and adds AI OCR/translation. The institution agent links both to its own site and to its `/libraries/<slug>` page here.
- **`requiredStatement` is now always present.** Previously gated on an explicit `attribution` string (sparse), so most manifests carried no required credit. Now: `"Digitized by {institution}. Re-hosted with AI-generated OCR and translation by Source Library."`, preferring an explicit attribution when stored.

## Out of scope
- **Institution logos** — `LIBRARY_PARTNERS` has no logo field yet; adding one is a small separate change.
- **Image service / pixel hosting** — whether the manifest's image *service* should point at the provider vs. an Image API over our R2 derivatives is a hosting decision tracked separately (see #2323 discussion).

## Test
- `npx tsc --noEmit` clean for touched files (pre-existing d3/carbon-ledger errors unrelated).
- check-imports hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)