### PR TITLE
fix(text): strip OCR page-level metadata envelope, not just translation wrappers

### DIFF
--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -12,17 +12,28 @@
  * producing citations to words that aren't on the page (Nirmal's "mercury on
  * page 89" misquote, 2026-05-30; see PR #2232).
  *
+ * The OCR format adds its own PAGE-LEVEL metadata envelope — <language>,
+ * <scan-quality>, <script>, <page-type>, <columns>, <warning> — that likewise
+ * *describes* the page/scan rather than transcribing it (the same tags the
+ * enrich-worker skips, enrich-worker.mjs). Serving "<scan-quality>good</…>" as
+ * a transcription is the same class of fabrication, so these are stripped too.
+ *
  * Call this BEFORE the generic tag strip. Inline glosses (note/term/margin/
- * gloss/unclear) are intentionally left for the caller to handle — they sit on
- * real body text and are safe to keep.
+ * gloss/unclear) and real page marks that happen to sit outside the body flow
+ * (header/catchword/sig/page-num — actual printed text, not AI description) are
+ * intentionally left for the caller to handle and are safe to keep.
  *
  * IMPORTANT: every search/snippet surface reads its own copy of the page text
  * (web /api/search, /api/books/[id]/search, the librarian, embeddings, the
- * eval). Fixes do NOT propagate between them — route every text-cleaning path
- * through this helper so the leak can't reopen on one surface.
+ * eval, the IIIF annotation + content-search routes). Fixes do NOT propagate
+ * between them — route every text-cleaning path through this helper so the leak
+ * can't reopen on one surface.
  */
 
-const EDITORIAL_WRAPPERS = 'meta|summary|keywords|vocab';
+// Translation-side page-description blocks ∪ OCR-side page-level metadata
+// envelope. All *describe* the page; none are verbatim source text.
+const EDITORIAL_WRAPPERS =
+  'meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning';
 
 export function stripEditorialWrappers(text: string): string {
   if (!text) return text;

--- a/tests/unit/strip-editorial-wrappers.test.ts
+++ b/tests/unit/strip-editorial-wrappers.test.ts
@@ -39,4 +39,31 @@ describe('stripEditorialWrappers', () => {
     const t = 'plain translated body with a <term>gloss</term>';
     expect(stripEditorialWrappers(t)).toBe(t);
   });
+
+  it('strips the OCR page-level metadata envelope content-and-all', () => {
+    // The real value served by the live IIIF OCR annotation route before the fix.
+    const ocr = `<scan-quality>good</scan-quality>\n<language>English</language>\n<script>printed</script>\n<page-type>blank</page-type>\n\nActual body line of the page.`;
+    const out = stripEditorialWrappers(ocr);
+    expect(out).not.toMatch(/scan-quality|page-type/);
+    expect(out).not.toMatch(/\bprinted\b/); // <script>printed</script> label gone
+    expect(out).not.toMatch(/\bblank\b/);   // <page-type>blank</page-type> label gone
+    expect(out).toContain('Actual body line of the page.');
+  });
+
+  it('drops <columns> and <warning> metadata but keeps real page marks', () => {
+    const t = `<columns>2</columns><warning>low contrast</warning><header>RUNNING HEAD</header>real body<insert>OLIN BM 175</insert>`;
+    const out = stripEditorialWrappers(t);
+    expect(out).not.toMatch(/low contrast/);
+    expect(out).not.toContain('<columns>');
+    // header/insert are real printed marks, not AI description — they survive.
+    expect(out).toContain('<header>RUNNING HEAD</header>');
+    expect(out).toContain('real body');
+    expect(out).toContain('<insert>OLIN BM 175</insert>');
+  });
+
+  it('strips inline <language> switch markers without eating the body', () => {
+    const t = `Lorem ipsum <language>Latin</language> dolor sit amet`;
+    const out = stripEditorialWrappers(t).replace(/\s+/g, ' ').trim();
+    expect(out).toBe('Lorem ipsum dolor sit amet');
+  });
 });


### PR DESCRIPTION
## Why

Caught while **verifying #2323 live in production**. The IIIF OCR annotation route now strips the translation-side wrappers, but the served value still led with `<scan-quality>good</scan-quality>`, `<language>English</language>`, `<script>printed</script>`, `<page-type>blank</page-type>`.

`stripEditorialWrappers` only knew the *translation* blocks (`meta|summary|keywords|vocab`). OCR has its **own page-level metadata envelope** that describes the scan rather than transcribing it — the same tags `enrich-worker.mjs:1125` already skips. Serving them as transcription is the same fabrication class as the original meta leak (#2232), just different tags — the OCR half of the same bug.

## What changed
- Extend the shared stripper to also drop `language|scan-quality|script|page-type|columns|warning` (content and all). Every snippet surface routes through this one helper, so the fix lands on search, embeddings, the librarian, and the IIIF routes at once.
- **Deliberately NOT stripped:** `header|catchword|sig|page-num` — real printed page marks, kept verbatim. Inline glosses (`note/term/margin/gloss/unclear/insert`) survive too.
- `<language>` also appears as an inline switch marker; stripping removes only the language *label*, never the body between markers (test covers it).

## Test
- `tests/unit/strip-editorial-wrappers.test.ts`: 9 passing — real pre-fix IIIF value, columns/warning-stripped vs header/insert-survive, inline `<language>` not eating body.
- check-imports passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)