### PR TITLE
feat(maintenance): backfill reading_summary for translated-but-unsummarized books

### DIFF
--- a/scripts/maintenance/backfill-bph-summaries.mjs
+++ b/scripts/maintenance/backfill-bph-summaries.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Backfill reading_summary for BPH live books that are translated but never
+ * summarized (legacy books stuck at pipeline_auto.status:'complete', which the
+ * enrich cron skips — it only selects 'translate_complete'). See issue context:
+ * Fludd UCH Vol.1 had this; ~1,137 BPH books share it.
+ *
+ * Runs enrich-worker --book=ID --phase=6 per book (Phase 6 ONLY — does not touch
+ * existing chapters). Idempotent: re-queries the no-summary set each run, so
+ * completed books drop out and it's safe to re-run / resume after interruption.
+ *
+ *   --limit=N   max books this run (default 25)
+ *   --dry-run   list what would be processed
+ */
+import { MongoClient } from 'mongodb';
+import { execFileSync } from 'child_process';
+const LIMIT=parseInt((process.argv.find(a=>a.startsWith('--limit='))||'').split('=')[1]||'25',10);
+const DRY=process.argv.includes('--dry-run');
+const c=new MongoClient(process.env.MONGODB_URI,{serverSelectionTimeoutMS:20000}); await c.connect();
+const db=c.db('bookstore');
+const q={ visible:true, held_by:'bph', pages_count:{$gt:0},
+  $expr:{$gte:['$pages_translated',{$multiply:[0.9,'$pages_count']}]},
+  'reading_summary.overview':{$in:['',null]} };
+const books=await db.collection('books').find(q,{projection:{id:1,title:1,pages_count:1}})
+  .sort({pages_count:1}).limit(LIMIT).toArray();   // small-first = fast early wins
+const remaining=await db.collection('books').countDocuments(q);
+console.log(`BPH books still needing summary: ${remaining} | this run: ${books.length}`);
+await c.close();
+if(DRY){ for(const b of books) console.log(`  ${b.id} ${(b.title||'').slice(0,55)} ${b.pages_count}p`); process.exit(0); }
+let ok=0,fail=0;
+for(const b of books){
+  process.stdout.write(`  [${ok+fail+1}/${books.length}] ${(b.title||b.id).slice(0,45)} (${b.pages_count}p)... `);
+  try{ execFileSync('node',['scripts/workers/enrich-worker.mjs',`--book=${b.id}`,'--phase=6'],{stdio:'ignore',timeout:600000}); ok++; console.log('ok'); }
+  catch(e){ fail++; console.log('FAIL '+(e.message||'').slice(0,60)); }
+}
+console.log(`\nDone: ${ok} summarized, ${fail} failed. ${remaining-ok} BPH books still need summary.`);


### PR DESCRIPTION
## Problem

~1,134 BPH books (and ~3,950 corpus-wide) are fully translated but have an empty `reading_summary`. Root cause: they sit at `pipeline_auto.status: 'complete'`, but the enrich cron's Phase 6 only selects `'translate_complete'` — so it skips them **permanently**. Surfaced when Fludd's *Utriusque Cosmi Historia Vol. 1* turned out to have no summary despite being 100% translated.

## What

`scripts/maintenance/backfill-bph-summaries.mjs` — drives `enrich-worker --book=ID --phase=6` per book.

- **Phase 6 only** → writes `reading_summary`, leaves existing chapters untouched (verified on Dee's *Monad*: 24 chapters preserved, full summary added).
- Scoped to BPH: `held_by:'bph'`, `visible`, ≥90% translated, empty summary.
- **Small-first** ordering for fast early progress.
- **Idempotent / resumable**: re-queries the no-summary set each run, so completed books drop out — safe to re-run or resume after interruption.
- `--limit=N`, `--dry-run`.

Designed to run on the Hetzner enrich box (stable Atlas access; it already hosts the enrich worker). Reusable for the non-BPH tail afterward by dropping the `held_by` filter.

## Validation

Piloted on 3 BPH flagships (Monas Hieroglyphica, Divine Pymander, Veritatis Proscenium) + Fludd UCH: clean, page-grounded summaries on `gemini-3.1-flash-lite`; chapters preserved; small books <1 min each.

## Out of scope

The ~101 BPH books missing *chapters* (Phase 7) — separate small job. And the non-BPH ~3,300 — same tool, later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)