### PR TITLE
fix(analytics): real first-party traffic dashboard + GA4 ID via env

### DIFF
--- a/src/app/api/[tenant]/analytics/route.ts
+++ b/src/app/api/[tenant]/analytics/route.ts
@@ -1,38 +1,18 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-helpers';
-import { supabaseAdmin } from '@/lib/supabase';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { getTrafficData } from '@/lib/analytics-traffic';
+
+export const maxDuration = 30;
 
 // In-memory cache (10 minutes — traffic data changes slowly)
-let cache: { key: string; data: unknown; ts: number } | null = null;
+let cache: { data: unknown; ts: number } | null = null;
 const CACHE_TTL_MS = 10 * 60 * 1000;
 
-/** Fetch all pageviews from Supabase, paginating through 1000-row pages.
- *  Uses the service-role client because analytics_pageviews is RLS-locked
- *  to service_role only (visitor PII; see issue #1981 + the
- *  rls-lockdown-phase1-pii.sql migration). End-user access is gated at
- *  the app layer via withAuth above. */
-async function fetchAllPageviews(since: string) {
-  if (!supabaseAdmin) throw new Error('supabaseAdmin not configured — SUPABASE_SERVICE_ROLE_KEY missing');
-  const rows: any[] = [];
-  let offset = 0;
-  while (true) {
-    const { data } = await supabaseAdmin
-      .from('analytics_pageviews')
-      .select('path, referrer, country, ip, timestamp')
-      .gte('timestamp', since)
-      .not('path', 'is', null)
-      .order('timestamp', { ascending: false })
-      .range(offset, offset + 999);
-    if (!data || data.length === 0) break;
-    rows.push(...data);
-    offset += 1000;
-    if (data.length < 1000) break;
-  }
-  return rows;
-}
-
-export const GET = withAuth(async (request, session, context) => {
+// Pageviews are global (no per-tenant field on the doc), so the data is the
+// same regardless of tenant. We still require a valid tenant + auth to reach
+// it. Reads MongoDB directly — see src/lib/analytics-traffic.ts for why.
+export const GET = withAuth(async (_request, _session, context) => {
   try {
     const { tenant } = await context.params;
     const tenantId = await resolveTenantId(tenant);
@@ -40,70 +20,15 @@ export const GET = withAuth(async (request, session, context) => {
       return NextResponse.json({ error: 'Tenant not found' }, { status: 400 });
     }
 
-    const cacheKey = tenantId;
-    if (cache && cache.key === cacheKey && Date.now() - cache.ts < CACHE_TTL_MS) {
+    if (cache && Date.now() - cache.ts < CACHE_TTL_MS) {
       return NextResponse.json(cache.data);
     }
 
-    const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-    const rows = await fetchAllPageviews(since);
-
-    // Aggregate in JS (Supabase REST doesn't support GROUP BY)
-    const uniqueIps = new Set<string>();
-    const pageCountMap = new Map<string, number>();
-    const referrerCountMap = new Map<string, number>();
-    const countryCountMap = new Map<string, number>();
-    const hourlyMap = new Map<string, { ips: Set<string>; pageviews: number }>();
-
-    for (const row of rows) {
-      if (row.ip) uniqueIps.add(row.ip);
-
-      // Top pages
-      if (row.path) {
-        pageCountMap.set(row.path, (pageCountMap.get(row.path) || 0) + 1);
-      }
-
-      // Top referrers
-      if (row.referrer) {
-        referrerCountMap.set(row.referrer, (referrerCountMap.get(row.referrer) || 0) + 1);
-      }
-
-      // Top countries
-      if (row.country && row.country !== 'Unknown') {
-        countryCountMap.set(row.country, (countryCountMap.get(row.country) || 0) + 1);
-      }
-
-      // Visitors by hour
-      if (row.timestamp) {
-        const hour = row.timestamp.substring(0, 13) + ':00';
-        const hourEntry = hourlyMap.get(hour) || { ips: new Set(), pageviews: 0 };
-        if (row.ip) hourEntry.ips.add(row.ip);
-        hourEntry.pageviews++;
-        hourlyMap.set(hour, hourEntry);
-      }
-    }
-
-    const sortDesc = (map: Map<string, number>) =>
-      [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
-
-    const data = {
-      totalPageviews: rows.length,
-      totalVisitors: uniqueIps.size,
-      topPages: sortDesc(pageCountMap).map(([path, count]) => ({ path, count })),
-      topReferrers: sortDesc(referrerCountMap).map(([referrer, count]) => ({ referrer, count })),
-      topCountries: sortDesc(countryCountMap).map(([country, count]) => ({ country, count })),
-      visitorsByHour: [...hourlyMap.entries()]
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([hour, v]) => ({ hour, visitors: v.ips.size, pageviews: v.pageviews })),
-    };
-
-    cache = { key: cacheKey, data, ts: Date.now() };
+    const data = await getTrafficData(30);
+    cache = { data, ts: Date.now() };
     return NextResponse.json(data);
   } catch (error) {
     console.error('Analytics API error:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch analytics' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 });
   }
 });

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,101 +1,26 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-helpers';
-import { supabaseAdmin } from '@/lib/supabase';
+import { getTrafficData } from '@/lib/analytics-traffic';
+
+export const maxDuration = 30;
 
 // In-memory cache (10 minutes — traffic data changes slowly)
 let cache: { data: unknown; ts: number } | null = null;
 const CACHE_TTL_MS = 10 * 60 * 1000;
 
-/** Fetch all pageviews from Supabase, paginating through 1000-row pages.
- *  Uses the service-role client because analytics_pageviews is RLS-locked
- *  to service_role only (visitor PII; see issue #1981 + the
- *  rls-lockdown-phase1-pii.sql migration). End-user access is gated at
- *  the app layer via withAuth above. */
-async function fetchAllPageviews(since: string) {
-  if (!supabaseAdmin) throw new Error('supabaseAdmin not configured — SUPABASE_SERVICE_ROLE_KEY missing');
-  const rows: any[] = [];
-  let offset = 0;
-  while (true) {
-    const { data } = await supabaseAdmin
-      .from('analytics_pageviews')
-      .select('path, referrer, country, ip, timestamp')
-      .gte('timestamp', since)
-      .not('path', 'is', null)
-      .order('timestamp', { ascending: false })
-      .range(offset, offset + 999);
-    if (!data || data.length === 0) break;
-    rows.push(...data);
-    offset += 1000;
-    if (data.length < 1000) break;
-  }
-  return rows;
-}
-
-export const GET = withAuth(async (request, session) => {
+// Reads first-party pageviews directly from MongoDB (the source of truth).
+// See src/lib/analytics-traffic.ts for why we no longer go through Supabase.
+export const GET = withAuth(async () => {
   try {
     if (cache && Date.now() - cache.ts < CACHE_TTL_MS) {
       return NextResponse.json(cache.data);
     }
 
-    const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-    const rows = await fetchAllPageviews(since);
-
-    // Aggregate in JS (Supabase REST doesn't support GROUP BY)
-    const uniqueIps = new Set<string>();
-    const pageCountMap = new Map<string, number>();
-    const referrerCountMap = new Map<string, number>();
-    const countryCountMap = new Map<string, number>();
-    const hourlyMap = new Map<string, { ips: Set<string>; pageviews: number }>();
-
-    for (const row of rows) {
-      if (row.ip) uniqueIps.add(row.ip);
-
-      // Top pages
-      if (row.path) {
-        pageCountMap.set(row.path, (pageCountMap.get(row.path) || 0) + 1);
-      }
-
-      // Top referrers
-      if (row.referrer) {
-        referrerCountMap.set(row.referrer, (referrerCountMap.get(row.referrer) || 0) + 1);
-      }
-
-      // Top countries
-      if (row.country && row.country !== 'Unknown') {
-        countryCountMap.set(row.country, (countryCountMap.get(row.country) || 0) + 1);
-      }
-
-      // Visitors by hour
-      if (row.timestamp) {
-        const hour = row.timestamp.substring(0, 13) + ':00';
-        const hourEntry = hourlyMap.get(hour) || { ips: new Set(), pageviews: 0 };
-        if (row.ip) hourEntry.ips.add(row.ip);
-        hourEntry.pageviews++;
-        hourlyMap.set(hour, hourEntry);
-      }
-    }
-
-    const sortDesc = (map: Map<string, number>) =>
-      [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
-
-    const data = {
-      totalPageviews: rows.length,
-      totalVisitors: uniqueIps.size,
-      topPages: sortDesc(pageCountMap).map(([path, count]) => ({ path, count })),
-      topReferrers: sortDesc(referrerCountMap).map(([referrer, count]) => ({ referrer, count })),
-      topCountries: sortDesc(countryCountMap).map(([country, count]) => ({ country, count })),
-      visitorsByHour: [...hourlyMap.entries()]
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([hour, v]) => ({ hour, visitors: v.ips.size, pageviews: v.pageviews })),
-    };
-
+    const data = await getTrafficData(30);
     cache = { data, ts: Date.now() };
     return NextResponse.json(data);
   } catch (error) {
     console.error('Analytics API error:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch analytics' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 });
   }
 });

--- a/src/components/providers/AnalyticsScripts.tsx
+++ b/src/components/providers/AnalyticsScripts.tsx
@@ -4,7 +4,11 @@ import { useEffect, useState } from 'react';
 import Script from 'next/script';
 import { getConsent, type ConsentState } from '@/lib/consent';
 
-const GA_ID = 'G-C1QJNTSZT2';
+// GA4 measurement ID, sourced from env so we can point at a Source
+// Library-owned property without a code change. The literal fallback is the
+// legacy property that lives under the PlayPower Labs GA account — keep it
+// only until NEXT_PUBLIC_GA_ID is set in Vercel, then it's dead weight.
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID || 'G-C1QJNTSZT2';
 const AHREFS_KEY = 'rzuKlnvyAKd8TdooDnPSYg';
 const POSTHOG_KEY = 'phc_b6JJdGHB6YKKhjfPEKn3YLbsYmwAcWliAR3F8jbFch8';
 const POSTHOG_HOST = 'https://eu.i.posthog.com';

--- a/src/lib/analytics-traffic.ts
+++ b/src/lib/analytics-traffic.ts
@@ -1,0 +1,88 @@
+import { getReadDb } from '@/lib/mongodb';
+
+/**
+ * First-party traffic aggregation, read directly from MongoDB.
+ *
+ * This is the source of truth: `/api/track` writes every (bot-filtered,
+ * IP-anonymized) pageview into `analytics_pageviews` in Mongo. We previously
+ * read these through a Supabase mirror, but the Hetzner `supabase-sync.mjs`
+ * worker stalled on 2026-04-13 and the dashboard silently went stale. Reading
+ * Mongo directly removes that moving part — the numbers are always current and
+ * complete. Visitor PII (anonymized IP) never leaves the server: callers gate
+ * this behind `withAuth` / `requireInnerCircle`.
+ */
+
+export interface TrafficData {
+  topPages: Array<{ path: string; count: number }>;
+  topReferrers: Array<{ referrer: string; count: number }>;
+  topCountries: Array<{ country: string; count: number }>;
+  totalVisitors: number;
+  totalPageviews: number;
+  visitorsByHour: Array<{ hour: string; visitors: number; pageviews: number }>;
+}
+
+export async function getTrafficData(days = 30): Promise<TrafficData> {
+  const db = await getReadDb();
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+  const [result] = await db
+    .collection('analytics_pageviews')
+    .aggregate(
+      [
+        { $match: { timestamp: { $gte: since }, path: { $ne: null } } },
+        {
+          $facet: {
+            totals: [
+              { $group: { _id: null, pageviews: { $sum: 1 }, ips: { $addToSet: '$ip' } } },
+            ],
+            topPages: [
+              { $group: { _id: '$path', count: { $sum: 1 } } },
+              { $sort: { count: -1 } },
+              { $limit: 10 },
+            ],
+            topReferrers: [
+              { $match: { referrer: { $nin: [null, '', 'direct'] } } },
+              { $group: { _id: '$referrer', count: { $sum: 1 } } },
+              { $sort: { count: -1 } },
+              { $limit: 10 },
+            ],
+            topCountries: [
+              { $match: { country: { $nin: [null, '', 'Unknown'] } } },
+              { $group: { _id: '$country', count: { $sum: 1 } } },
+              { $sort: { count: -1 } },
+              { $limit: 10 },
+            ],
+            byHour: [
+              {
+                $group: {
+                  _id: { $dateToString: { format: '%Y-%m-%dT%H:00', date: '$timestamp' } },
+                  ips: { $addToSet: '$ip' },
+                  pageviews: { $sum: 1 },
+                },
+              },
+              { $sort: { _id: 1 } },
+            ],
+          },
+        },
+      ],
+      { allowDiskUse: true }
+    )
+    .toArray();
+
+  const totals = result?.totals?.[0] as { pageviews: number; ips: (string | null)[] } | undefined;
+
+  return {
+    totalPageviews: totals?.pageviews ?? 0,
+    totalVisitors: (totals?.ips ?? []).filter(Boolean).length,
+    topPages: (result?.topPages ?? []).map((p: { _id: string; count: number }) => ({ path: p._id, count: p.count })),
+    topReferrers: (result?.topReferrers ?? []).map((r: { _id: string; count: number }) => ({ referrer: r._id, count: r.count })),
+    topCountries: (result?.topCountries ?? []).map((c: { _id: string; count: number }) => ({ country: c._id, count: c.count })),
+    visitorsByHour: (result?.byHour ?? []).map(
+      (h: { _id: string; ips: (string | null)[]; pageviews: number }) => ({
+        hour: h._id,
+        visitors: h.ips.filter(Boolean).length,
+        pageviews: h.pageviews,
+      })
+    ),
+  };
+}


### PR DESCRIPTION
## Why
Derek flagged that Google Analytics "isn't set up right." Investigation surfaced two distinct, real problems on the analytics stack — neither of which was the GA *code* being wrong.

## What this PR does

### 1. Traffic dashboard now reads live data (the real bug)
The admin `/analytics` **Traffic** tab (visitors, pageviews, top pages, referrers, countries) read pageviews from **Supabase** `analytics_pageviews`, mirrored from Mongo by the Hetzner `supabase-sync.mjs` worker.

**That worker stalled on 2026-04-13** — all five synced analytics tables (`analytics_pageviews`, `analytics_events`, `cron_runs`, `pipeline_snapshots`, `loading_metrics`) stopped at the same instant. So the dashboard silently showed a 7-week-old, ~empty slice while Mongo held **75,384 healthy pageviews / 1,715 unique visitors** over the last 30 days.

Fix: both traffic routes (`/api/analytics`, `/api/[tenant]/analytics`) now call a new `getTrafficData()` helper that aggregates `analytics_pageviews` **directly in Mongo** — the source of truth that `/api/track` writes to. This removes the fragile sync dependency for this surface; data is real-time and complete. Same `withAuth` gate keeps anonymized-IP PII server-side. Verified against prod Mongo: 2.4s for 75K docs, sensible output (top referrers `embassyofthefreemind.com`, `ficinosociety.org`, `google.com`; countries US/NL/DE/GB/BR), cached 10 min.

### 2. GA4 measurement ID via env (move off PlayPower)
`G-C1QJNTSZT2` lives under the PlayPower Labs Google Analytics account. The ID is now sourced from `NEXT_PUBLIC_GA_ID` (falling back to the legacy literal), so migrating to a Source Library-owned GA4 property is a Vercel env change, not a deploy. **Action for Derek:** create the new property, set `NEXT_PUBLIC_GA_ID` in Vercel prod+preview.

## Out of scope (deliberately)
- **Broader `supabase-sync.mjs` breakage** — the Pipeline/cron-health tabs still depend on the stalled sync. Needs Hetzner access to diagnose why the cron died on 04-13 (and the 7-week gap won't backfill on its own). Tracked as a follow-up issue.
- **The consent gate.** GA/PostHog/Ahrefs only load after cookie Accept, which is why GA volume looks tiny. That's a GDPR policy decision (Consent Mode v2, etc.), left untouched here.

## Test
- `npx tsc --noEmit` — no new errors in changed files (pre-existing d3 type errors in carbon-ledger blog interactives are unrelated).
- Live aggregation verified against production Mongo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)