### PR TITLE
Refresh press-release launch stats to current verified figures

### DIFF
--- a/src/components/press/releases/SourceLibraryPublicBetaLaunch.tsx
+++ b/src/components/press/releases/SourceLibraryPublicBetaLaunch.tsx
@@ -2,7 +2,10 @@
  * Press release body — official EFM beta-launch release (4 June 2026).
  * This is the Embassy of the Free Mind's authoritative press text; keep it in sync
  * with the EFM-approved release rather than rewriting it editorially. Launch stats
- * (13,000+ books, 5,100+ translated, etc.) are the official figures — do not inflate.
+ * (15,000+ books, 15,000+ translated, ~7B words, etc.) verified against the live
+ * Source Library database on 1 June 2026. The "~7B words ≈ English Wikipedia" figure
+ * is the corpus re-measurement behind /blog/how-big-is-the-library (winsorised mean
+ * 7.07B; median floor ~4.9B) — NOT the old 1.7B Supabase-snippet undercount.
  * Header/dateline ("FOR IMMEDIATE RELEASE · …") and back-link are supplied by the
  * /press-releases/[slug] route. Press contact is EFM (Maria Marqués), not Source Library.
  */
@@ -47,11 +50,17 @@ export default function SourceLibraryPublicBetaLaunch() {
       <p className="text-secondary leading-relaxed mb-4 font-body">At launch, the full collection spans:</p>
 
       <ul className="list-disc pl-6 mb-6 space-y-1 text-secondary font-body">
-        <li>13,000+ books in 40+ languages</li>
-        <li>5,100+ books with English translation</li>
-        <li>1.1 million+ pages translated into English</li>
-        <li>2,900+ first-ever English translations</li>
-        <li>1.8 million digitised page images with 69,000+ extracted illustrations</li>
+        <li>15,000+ books in 55+ languages</li>
+        <li>15,000+ books with English translation</li>
+        <li>4.2 million+ pages translated into English</li>
+        <li>6,000+ first-ever English translations</li>
+        <li>
+          roughly 7 billion words of original text and translation &mdash; about the size of the entire{' '}
+          <a href="https://sourcelibrary.org/blog/how-big-is-the-library" className="text-accent-rust hover:underline">
+            English Wikipedia
+          </a>
+        </li>
+        <li>4.5 million+ digitised page images with 142,000+ extracted illustrations</li>
       </ul>
 
       <p className="text-secondary leading-relaxed mb-6 font-body">

--- a/src/lib/press-releases.ts
+++ b/src/lib/press-releases.ts
@@ -45,9 +45,9 @@ export const PRESS_RELEASES: PressReleaseMeta[] = [
     date: '2026-06-04',
     status: 'published',
     summary:
-      'The Embassy of the Free Mind announces the public beta of Source Library: an open-access library that opens with 13,000+ books in 40+ languages, 5,100+ already translated into English — 2,900+ for the first time ever — each read beside a scan of the original page.',
+      'The Embassy of the Free Mind announces the public beta of Source Library: an open-access library that opens with 15,000+ books in 55+ languages, 15,000+ translated into English — 6,000+ for the first time ever, roughly 7 billion words in all — each read beside a scan of the original page.',
     metaDescription:
-      'The Embassy of the Free Mind launches Source Library, an open-access library of translated historical primary sources. At beta it spans 13,000+ books in 40+ languages, 5,100+ translated into English and 2,900+ first-ever English translations, each read beside the original page.',
+      'The Embassy of the Free Mind launches Source Library, an open-access library of translated historical primary sources. At beta it spans 15,000+ books in 55+ languages, 15,000+ translated into English and 6,000+ first-ever English translations — roughly 7 billion words, about the size of the entire English Wikipedia — each read beside the original page.',
     ogImage: 'https://sourcelibrary.org/og-image.png',
   },
   {


### PR DESCRIPTION
Follow-up to #2336. The official EFM release shipped with a March-era snapshot that understated the library 2–4×. This refreshes the stat bullets (and the SEO summary/description) to figures verified against the live database on 1 June 2026.

### Updated figures
| Was (official release) | Now (verified 1 Jun 2026) |
|---|---|
| 13,000+ books / 40+ languages | **15,000+ books / 55+ languages** |
| 5,100+ books with English translation | **15,000+ books with English translation** |
| 1.1M+ pages translated | **4.2M+ pages translated** |
| 2,900+ first-ever translations | **6,000+ first-ever translations** |
| 1.8M page images / 69,000+ illustrations | **4.5M+ page images / 142,000+ illustrations** |
| — | **~7 billion words — about the size of English Wikipedia** (new) |

### Why these numbers
- **5,100 → 15,000 translated** was the most important fix: the old number was ~3× low and directly contradicted Source Library's own homepage (~15,000).
- **4.2M pages translated** confirmed two independent ways: Mongo `sum(pages_translated)` = 4,200,510; Supabase `page_translations` = 4,071,861.
- **55+ languages**: distinct individual source languages with >2 books (raw distinct field count is 158, but that's padded with `auto-detect`, bilingual combos like `Latin-German`, and casing variants — not defensible).
- **~7 billion words ≈ English Wikipedia**: matches the corpus re-measurement and public blog post `/blog/how-big-is-the-library` (winsorised mean 7.07B; median floor ~4.9B). The earlier "1.7B / a third of Wikipedia" was a Supabase-snippet undercount, superseded.

### Scope
- Only the stat bullets + registry SEO strings changed. Prose, quotes, event details, and the EFM press contact (Maria Marqués) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)