### PR TITLE
chore(cron): re-snapshot live crontab + fix drift-sync (#2332 Task 0)

### DIFF
--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -46,11 +46,6 @@
 # R2 coverage snapshot (every 6h — updates the doc /admin/r2-coverage reads)
 30 */6 * * * cd /root/sourcelibrary && flock -n /tmp/sl-r2-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/r2-coverage-snapshot.mjs" >> /var/log/sourcelibrary/r2-snapshot.log 2>&1
 
-# Gallery_images CDN coverage snapshot (every 12h, offset 3h from the page-side
-# snapshot so they don't compete for the undici connection pool). ~90s on
-# the full catalog. Surfaced on the same /admin/r2-coverage page.
-45 3,15 * * * cd /root/sourcelibrary && flock -n /tmp/sl-gallery-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/gallery-coverage-snapshot.mjs" >> /var/log/sourcelibrary/gallery-coverage.log 2>&1
-
 # Archive auto-unblock (daily — retry books blocked >14d ago with transient failure reasons)
 0 9 * * * cd /root/sourcelibrary && flock -n /tmp/sl-archive-unblock.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/archive-auto-unblock.mjs" >> /var/log/sourcelibrary/archive-auto-unblock.log 2>&1
 
@@ -83,3 +78,17 @@
 # Image-side embeddings — artwork_embeddings, gallery_text_embeddings, clip_embeddings (issue #2021)
 # These tables had no recurring writer; froze for 35+ days. Uses TIER3 paid key for data-rights.
 0 2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-image-embeddings.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=$GEMINI_API_KEY_TIER3; node scripts/workers/image-embeddings-cron.mjs" >> /var/log/sourcelibrary/image-embeddings.log 2>&1
+45 3,15 * * * cd /root/sourcelibrary && flock -n /tmp/sl-gallery-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/gallery-coverage-snapshot.mjs" >> /var/log/sourcelibrary/gallery-coverage.log 2>&1
+
+45 */6 * * * cd /root/sourcelibrary && flock -n /tmp/sl-archiving-watchdog.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/archiving-watchdog.mjs --apply --stale-hours=12 --escalate-days=7" >> /var/log/sourcelibrary/archiving-watchdog.log 2>&1
+
+*/15 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-finalize.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/pipeline-orchestrator.mjs --phase 9" >> /var/log/sourcelibrary/finalize.log 2>&1
+
+# FT verification continuous: audit hallucinated translator claims, then apply verdicts (idempotent, ~$0.014/book)
+40 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-audit.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/audit-translation-claims.mjs --apply --limit 300 && node scripts/maintenance/apply-audit-verdicts.mjs --apply" >> /var/log/sourcelibrary/ft-audit.log 2>&1
+# FT discovery continuous: sample confirmed_first books for missed translations, then apply (idempotent)
+40 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-discover.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/discover-translations-estimate.mjs --save --limit 300 && node scripts/maintenance/apply-discovery-results.mjs --apply" >> /var/log/sourcelibrary/ft-discover.log 2>&1
+0 8 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-ground.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analysis/ft-ground-remediation.mjs --set unverified --limit 250" >> /var/log/sourcelibrary/ft-ground.log 2>&1
+
+# Crontab drift detector — logs if live crontab diverges from committed snapshot (#2332)
+0 4 * * * /root/sourcelibrary/scripts/workers/sync-crontab.sh >> /var/log/sourcelibrary/crontab-sync.log 2>&1

--- a/scripts/workers/sync-crontab.sh
+++ b/scripts/workers/sync-crontab.sh
@@ -1,30 +1,39 @@
 #!/bin/bash
-# Auto-sync Hetzner crontab to git.
-# Runs daily via cron. Commits directly to main (acceptable for this file per #498).
-# Usage: add to Hetzner crontab:
+# Detect drift between the live Hetzner crontab and the committed snapshot.
+#
+# HISTORY: this script used to `git push origin main` directly (see #498). That
+# stopped working — direct pushes to main are blocked by branch protection and
+# the DCO bot requires a Signed-off-by trailer the auto-commit never added, so
+# the job silently failed and `crontab.production` drifted ~stale for weeks
+# (#2332 Task 0). It was also not even installed in the live crontab.
+#
+# The live crontab is the SOURCE OF TRUTH; `crontab.production` is a derived
+# snapshot kept fresh by hand via PR. This script no longer commits anything —
+# it only reports drift so an operator (or Claude) opens a PR to re-snapshot.
+#
+# Install on Hetzner (logs drift daily; never mutates git):
 #   0 4 * * * /root/sourcelibrary/scripts/workers/sync-crontab.sh >> /var/log/sourcelibrary/crontab-sync.log 2>&1
+#
+# To re-snapshot after a crontab change:
+#   crontab -l > scripts/workers/crontab.production   # on Hetzner, then PR it
+# or from a workstation with SSH:
+#   ssh root@<hetzner> crontab -l > scripts/workers/crontab.production && open a PR
 
-set -euo pipefail
-cd /root/sourcelibrary
+set -uo pipefail
+cd /root/sourcelibrary || { echo "[sync-crontab] repo missing"; exit 1; }
 
 CRONTAB_FILE="scripts/workers/crontab.production"
 
-# Dump current crontab
-crontab -l > "$CRONTAB_FILE.tmp"
-
-# Check if anything changed
-if diff -q "$CRONTAB_FILE" "$CRONTAB_FILE.tmp" > /dev/null 2>&1; then
-  rm "$CRONTAB_FILE.tmp"
-  echo "[sync-crontab] $(date -Iseconds) No changes"
+# Compare ignoring blank lines (crontab -l can vary trailing whitespace).
+if diff -q \
+    <(grep -vE '^[[:space:]]*$' "$CRONTAB_FILE" 2>/dev/null) \
+    <(crontab -l 2>/dev/null | grep -vE '^[[:space:]]*$') > /dev/null 2>&1; then
+  echo "[sync-crontab] $(date -Iseconds) No drift — crontab.production matches live"
   exit 0
 fi
 
-mv "$CRONTAB_FILE.tmp" "$CRONTAB_FILE"
-
-# Pull latest to avoid conflicts, then commit and push
-git pull --rebase --quiet origin main 2>/dev/null || true
-git add "$CRONTAB_FILE"
-git commit -m "chore: auto-sync Hetzner crontab [skip ci]" --no-gpg-sign
-git push origin main
-
-echo "[sync-crontab] $(date -Iseconds) Crontab updated and pushed"
+echo "[sync-crontab] $(date -Iseconds) DRIFT DETECTED — committed crontab.production is stale."
+echo "[sync-crontab] Re-snapshot with: crontab -l > $CRONTAB_FILE  (then open a PR)"
+echo "[sync-crontab] Diff (committed <  vs  live >):"
+diff "$CRONTAB_FILE" <(crontab -l 2>/dev/null) || true
+exit 0


### PR DESCRIPTION
Closes Task 0 of #2332.

## What & why
`scripts/workers/crontab.production` had drifted stale — missing **five live jobs**: `ft-audit`, `ft-discover`, `ft-ground`, `archiving-watchdog`, and `finalize --phase 9`.

**Root cause (corrected from the issue's hypothesis):** it is *not* the "stale git stash" gotcha. `sync-crontab.sh` was simply **not installed in the live Hetzner crontab**, so the daily auto-dump never ran. Separately, its old design pushed **directly to `main`** with `--no-gpg-sign` and no `Signed-off-by` — both rejected by branch protection + the DCO bot, so it could never have committed successfully regardless.

## Changes
- **Re-snapshot** `crontab.production` from the live Hetzner crontab (the live crontab is the source of truth; the committed file is derived). Verified identical to `crontab -l` modulo blank lines.
- **Rewrite `sync-crontab.sh` as a non-mutating drift detector**: it diffs live vs. committed and logs when they diverge, telling the operator to open a PR. No `git commit`/`push`.
- **Installed the drift detector on Hetzner** (`0 4 * * *`) so future drift is caught instead of silently accumulating.

## Out of scope (other #2332 tasks, separate PRs)
- Task 1 (archive dead scripts) — note: the issue lists `reconcile-ft-from-catalog.mjs` for archival, but the canonical doc treats it as the live disposition→flag bridge. That conflict needs resolving first.
- Task 2 (rename dated `*_2026_05_30` schema fields) — touches live cron idempotent-skip filters; riskiest, own PR.
- Tasks 3/4 (coverage metric + drift-logging job) — additive.
- Task 6 (doc rewrite) — appears already done; the doc body is current.

## Deploy note
Scripts under `scripts/**` need no Vercel deploy — Hetzner auto-pulls `main`. After merge, the next hourly auto-pull (`:17`) replaces the old `sync-crontab.sh` on Hetzner before its first `04:00` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)