### PR TITLE
feat(stats): FT verification_coverage metric (#2332 Task 3)

### DIFF
--- a/scripts/maintenance/prewarm-browse.mjs
+++ b/scripts/maintenance/prewarm-browse.mjs
@@ -68,7 +68,7 @@ if (process.env.MONGODB_URI) {
     // Artworks: single-object entries (content_type:'artwork') — see update-homepage-stats.mjs for rationale.
     const artworkFilter = { visible: true, content_type: 'artwork' };
 
-    const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount] = await Promise.all([
+    const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount, verificationReadable, verificationChecked] = await Promise.all([
       books.countDocuments(filter),
       books.countDocuments(readableFilter),
       books.countDocuments({ ...translatedFilter, is_first_translation: true }),
@@ -76,9 +76,18 @@ if (process.env.MONGODB_URI) {
       books.distinct('language', translatedFilter).then(l => l.filter(x => x && !x.includes(',') && !x.includes(' and ')).length),
       books.countDocuments(artworkFilter),
       db.collection('gallery_images').countDocuments({}),
+      // First-translation verification coverage (#2332 Task 3): of all readable+visible
+      // books (the FT-eligible pool = translatedFilter), how many have a catalog disposition?
+      books.countDocuments(translatedFilter),
+      books.countDocuments({ ...translatedFilter, 'translation_verification.disposition': { $exists: true } }),
     ]);
 
-    const stats = { totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount, updatedAt: new Date() };
+    const verification_coverage = {
+      checked: verificationChecked,
+      readable: verificationReadable,
+      pct: verificationReadable ? +(100 * verificationChecked / verificationReadable).toFixed(1) : 0,
+    };
+    const stats = { totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, updatedAt: new Date() };
     await db.collection('system_config').updateOne(
       { _id: 'homepage_stats' },
       { $set: stats },

--- a/scripts/maintenance/update-homepage-stats.mjs
+++ b/scripts/maintenance/update-homepage-stats.mjs
@@ -31,7 +31,7 @@ const readableFilter = {
 // resource_type is too narrow: it omits sculpture, religious art, allegory, etc.
 const artworkFilter = { visible: true, content_type: 'artwork' };
 
-const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount] = await Promise.all([
+const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount, verificationReadable, verificationChecked] = await Promise.all([
   books.countDocuments(filter),
   books.countDocuments(readableFilter),
   books.countDocuments({ ...translatedFilter, is_first_translation: true }),
@@ -39,9 +39,19 @@ const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, lang
   books.distinct('language', translatedFilter).then(l => l.filter(x => x && !x.includes(',') && !x.includes(' and ')).length),
   books.countDocuments(artworkFilter),
   db.collection('gallery_images').countDocuments({}),
+  // First-translation verification coverage (#2332 Task 3): of all readable+visible
+  // books (the FT-eligible pool = translatedFilter), how many have a catalog disposition?
+  books.countDocuments(translatedFilter),
+  books.countDocuments({ ...translatedFilter, 'translation_verification.disposition': { $exists: true } }),
 ]);
 
-const stats = { totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount, updatedAt: new Date() };
+const verification_coverage = {
+  checked: verificationChecked,
+  readable: verificationReadable,
+  pct: verificationReadable ? +(100 * verificationChecked / verificationReadable).toFixed(1) : 0,
+};
+
+const stats = { totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, updatedAt: new Date() };
 
 await db.collection('system_config').updateOne(
   { _id: 'homepage_stats' },


### PR DESCRIPTION
Closes Task 3 of #2332.

Adds `verification_coverage` to `system_config.homepage_stats` — the first-translation subsystem's observability metric: of all readable+visible books (the FT-eligible pool: `visible:true ∧ pages_count>0 ∧ pages_translated>0`), how many carry a catalog-evidence disposition (`translation_verification.disposition`).

```
verification_coverage: { checked: 10271, readable: 15318, pct: 67.1 }
```

- Written by **both** `homepage_stats` writers, kept in lockstep per CLAUDE.md's "Visibility & Stats Invariants": `prewarm-browse.mjs` (daily 05:00) and `update-homepage-stats.mjs` (on-demand).
- **Verified live** — ran `update-homepage-stats.mjs`; it wrote `{ checked: 10271, readable: 15318, pct: 67.1 }`, matching the canonical doc's 10,273 / 15,320 ≈ 67%.

## Scope notes
- The metric lands in `homepage_stats` (the issue's first option). It is **not** rendered on the public homepage — it's an internal QA signal; a future admin tile can read this field with no recompute. Rendering is a trivial follow-up if wanted.
- Pure-additive: no existing key changed, no flag flips. `scripts/**` needs no Vercel deploy (Hetzner auto-pulls); the daily prewarm will keep it fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)