### PR TITLE
refactor(ft): stable names for date-stamped verification fields (#2332 Task 2)

### DIFF
--- a/scripts/enrichment/catalog-lookup-confirmed-first.mjs
+++ b/scripts/enrichment/catalog-lookup-confirmed-first.mjs
@@ -98,7 +98,10 @@ await pgc.query('SET statement_timeout = 30000');
 
 const match = {
   'translation_verification.disposition': 'confirmed_first',
+  // Stable + legacy markers both honored (#2332 Task 2).
+  'translation_verification.audit_applied': { $ne: true },
   'translation_verification.audit_applied_2026_05_30': { $ne: true },
+  'translation_verification.catalog_lookup': { $exists: false },
   'translation_verification.catalog_lookup_2026_05_30': { $exists: false },
   visible: true,
   pages_count: { $gt: 0 },
@@ -157,7 +160,7 @@ for (const b of books) {
     await db.collection('books').updateOne(
       { _id: b._id },
       { $set: {
-        'translation_verification.catalog_lookup_2026_05_30': {
+        'translation_verification.catalog_lookup': {
           looked_up_at: new Date(),
           translation_found: true,
           hit: {

--- a/scripts/enrichment/discover-translations-estimate.mjs
+++ b/scripts/enrichment/discover-translations-estimate.mjs
@@ -125,7 +125,11 @@ async function main() {
 
   const match = {
     'translation_verification.disposition': 'confirmed_first',
+    // Stable + legacy markers both honored (#2332 Task 2): skip a book if it
+    // was audited or already estimated under EITHER the new or the dated name.
+    'translation_verification.audit_applied': { $ne: true },
     'translation_verification.audit_applied_2026_05_30': { $ne: true },
+    'translation_verification.discovery_estimate': { $exists: false },
     'translation_verification.discovery_estimate_2026_05_30': { $exists: false },  // idempotent skip
     visible: true,
     pages_count: { $gt: 0 },
@@ -164,7 +168,7 @@ async function main() {
         await db.collection('books').updateOne(
           { _id: book._id },
           { $set: {
-            'translation_verification.discovery_estimate_2026_05_30': {
+            'translation_verification.discovery_estimate': {
               audited_at: new Date(),
               model: MODEL,
               translation_exists: r.translation_exists,

--- a/scripts/maintenance/apply-audit-verdicts.mjs
+++ b/scripts/maintenance/apply-audit-verdicts.mjs
@@ -58,7 +58,12 @@ const env = loadEnv();
 const apply = process.argv.includes('--apply');
 const getArg = name => { const i = process.argv.indexOf(name); return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null; };
 const LIMIT = getArg('--limit') ? parseInt(getArg('--limit')) : null;
-const FLAG = 'audit_applied_2026_05_30';
+// Stable field name (#2332 Task 2). LEGACY is the pre-rename dated marker —
+// still honored in skip filters so already-processed books aren't re-audited
+// before the one-time backfill (scripts/maintenance/migrate-ft-dated-fields.mjs)
+// copies legacy→stable. A follow-up can drop the LEGACY branch once backfilled.
+const FLAG = 'audit_applied';
+const LEGACY_FLAG = 'audit_applied_2026_05_30';
 
 // Negative reasoning patterns: when the audit's reasoning text contains any of
 // these, the alternative_translation_found is suspect — usually a different
@@ -118,6 +123,7 @@ const eligible = await db.collection('books').find({
   'translation_verification.disposition': 'needs_review',
   'translation_verification.verification_audit.audited_at': { $exists: true },
   [`translation_verification.${FLAG}`]: { $ne: true },
+  [`translation_verification.${LEGACY_FLAG}`]: { $ne: true },
 }).project({
   id: 1,
   'translation_verification.disposition': 1,
@@ -229,6 +235,7 @@ for (const b of queue) {
 
   const update = {
     [`translation_verification.${FLAG}`]: true,
+    'translation_verification.audit_run_at': now,
     updated_at: now,
   };
   // Disposition mutation paths (skip if keeping at needs_review)

--- a/scripts/maintenance/apply-discovery-results.mjs
+++ b/scripts/maintenance/apply-discovery-results.mjs
@@ -44,7 +44,13 @@ function loadEnv() {
 
 const env = loadEnv();
 const apply = process.argv.includes('--apply');
-const FLAG = 'discovery_applied_2026_05_30';
+// Stable field names (#2332 Task 2). LEGACY_* are the pre-rename dated markers,
+// still honored on read so already-applied / already-estimated books survive the
+// transition until migrate-ft-dated-fields.mjs backfills legacy→stable.
+const FLAG = 'discovery_applied';
+const LEGACY_FLAG = 'discovery_applied_2026_05_30';
+const ESTIMATE = 'discovery_estimate';
+const LEGACY_ESTIMATE = 'discovery_estimate_2026_05_30';
 
 // Same as apply-audit-verdicts — reasoning text patterns that mean the
 // discovered "translation" is actually a study, edition, partial, or
@@ -109,13 +115,19 @@ const db = c.db(env.MONGODB_DB || 'bookstore');
 
 const eligible = await db.collection('books').find({
   'translation_verification.disposition': 'confirmed_first',
-  'translation_verification.discovery_estimate_2026_05_30': { $exists: true },
+  // has an estimate under EITHER name, and not-yet-applied under EITHER name
+  $or: [
+    { [`translation_verification.${ESTIMATE}`]: { $exists: true } },
+    { [`translation_verification.${LEGACY_ESTIMATE}`]: { $exists: true } },
+  ],
   [`translation_verification.${FLAG}`]: { $ne: true },
+  [`translation_verification.${LEGACY_FLAG}`]: { $ne: true },
 }).project({
   id: 1, language: 1, author: 1,
   'translation_verification.disposition': 1,
   'translation_verification.disposition_reasoning': 1,
-  'translation_verification.discovery_estimate_2026_05_30': 1,
+  [`translation_verification.${ESTIMATE}`]: 1,
+  [`translation_verification.${LEGACY_ESTIMATE}`]: 1,
 }).toArray();
 console.log(`Eligible books (with discovery results): ${eligible.length}`);
 
@@ -129,7 +141,7 @@ const samples = { tf: [], suspect: [], partial: [] };
 const now = new Date();
 
 for (const b of eligible) {
-  const d = b.translation_verification.discovery_estimate_2026_05_30;
+  const d = b.translation_verification[ESTIMATE] ?? b.translation_verification[LEGACY_ESTIMATE];
   if (!d.translation_exists) { counts.not_found_no_change++; continue; }
 
   // Reasoning-text gate — same as apply-audit-verdicts

--- a/scripts/maintenance/migrate-ft-dated-fields.mjs
+++ b/scripts/maintenance/migrate-ft-dated-fields.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Backfill: copy the legacy date-stamped first-translation markers to their
+ * stable names on translation_verification (#2332 Task 2).
+ *
+ *   audit_applied_2026_05_30     → audit_applied
+ *   discovery_estimate_2026_05_30 → discovery_estimate
+ *   discovery_applied_2026_05_30  → discovery_applied
+ *   catalog_lookup_2026_05_30     → catalog_lookup
+ *
+ * Additive + idempotent + reversible: each field is copied ONLY when the legacy
+ * value exists and the stable target is absent; the legacy field is left in
+ * place (nothing is deleted). Safe to re-run.
+ *
+ * The writers/skip-filters already dual-read (stable OR legacy), so this backfill
+ * is NOT required for correctness — it exists so a later cleanup PR can drop the
+ * legacy branch once every doc carries the stable name. (prior_translations_*
+ * is intentionally excluded — its writer, discover-prior-translations.mjs / #2244,
+ * is not yet merged to main.)
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/migrate-ft-dated-fields.mjs            # dry run (counts only)
+ *   node scripts/maintenance/migrate-ft-dated-fields.mjs --apply    # write
+ */
+import { MongoClient } from 'mongodb';
+
+const apply = process.argv.includes('--apply');
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+const TV = 'translation_verification';
+const FIELDS = [
+  'audit_applied',
+  'discovery_estimate',
+  'discovery_applied',
+  'catalog_lookup',
+];
+
+const client = await MongoClient.connect(uri);
+const books = client.db(process.env.MONGODB_DB || 'bookstore').collection('books');
+
+console.log(`=== Migrate FT dated fields → stable names (${apply ? 'APPLYING' : 'DRY RUN'}) ===\n`);
+
+let grandTotal = 0;
+for (const stable of FIELDS) {
+  const legacy = `${stable}_2026_05_30`;
+  const filter = {
+    [`${TV}.${legacy}`]: { $exists: true },
+    [`${TV}.${stable}`]: { $exists: false },
+  };
+  const pending = await books.countDocuments(filter);
+  grandTotal += pending;
+
+  if (!apply) {
+    console.log(`  ${legacy} → ${stable}: ${pending} doc(s) would be copied`);
+    continue;
+  }
+  if (pending === 0) { console.log(`  ${legacy} → ${stable}: 0 (nothing to do)`); continue; }
+
+  const res = await books.updateMany(filter, [
+    { $set: { [`${TV}.${stable}`]: `$${TV}.${legacy}` } },
+  ]);
+  console.log(`  ${legacy} → ${stable}: matched ${res.matchedCount}, modified ${res.modifiedCount}`);
+}
+
+console.log(`\n${apply ? 'Done.' : `Dry run — ${grandTotal} total copies pending. Re-run with --apply to write.`}`);
+await client.close();


### PR DESCRIPTION
Closes Task 2 of #2332.

The `translation_verification` subdoc accreted dated markers (`*_2026_05_30`) that gate **live-cron idempotent-skip logic**. This renames them to stable names without risking a re-processing storm.

| Legacy | Stable |
|---|---|
| `audit_applied_2026_05_30` | `audit_applied` (+ `audit_run_at`) |
| `discovery_estimate_2026_05_30` | `discovery_estimate` |
| `discovery_applied_2026_05_30` | `discovery_applied` |
| `catalog_lookup_2026_05_30` | `catalog_lookup` |

### Why dual-read (and why it's safe to merge before the backfill)
These scripts auto-deploy on Hetzner via auto-pull, and merge timing isn't controllable. A blind rename would make the next nightly run see every already-processed book as un-processed (the skip markers would "vanish") and re-audit/re-estimate up to the nightly `--limit`. So:
- **Writers** write the **stable** name.
- **Every idempotent-skip filter** and the **cross-script estimate read** accept **stable OR legacy**.
- Correctness therefore does **not** depend on the backfill — the deploy is safe whenever it lands.

`scripts/maintenance/migrate-ft-dated-fields.mjs` backfills legacy→stable (additive, idempotent, reversible, **dry-run by default**) so a later cleanup PR can drop the legacy branch once every doc carries the stable name.

### Verified live (dry-run, no writes)
- migration would copy **3,037** docs (audit 1678, discovery_estimate 1101, discovery_applied 258, catalog_lookup 0 — that manual tool never ran).
- `apply-audit-verdicts.mjs` (1 eligible) and `apply-discovery-results.mjs` (843 eligible) still select correctly and read the estimate object via the stable-or-legacy fallback — no errors.

### Out of scope
- `prior_translations_2026_05_31`: its writer `discover-prior-translations.mjs` (#2244) is **untracked / not yet on main** — migrate when #2244 lands.
- Running the prod backfill: deliberate post-merge step (`node scripts/maintenance/migrate-ft-dated-fields.mjs --apply`), then a follow-up can drop the legacy reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)