### PR TITLE
feat(research): KU Leuven digitized-collection gap harvester + outreach

### DIFF
--- a/.claude/docs/kuleuven-outreach-email.md
+++ b/.claude/docs/kuleuven-outreach-email.md
@@ -1,0 +1,66 @@
+# KU Leuven Libraries — outreach email (draft)
+
+**To:** KU Leuven Libraries — Digitisation / Heritage Collections (LIBIS)
+Suggested recipients: the Maurits Sabbe Library / Special Collections heritage team, or
+the LIBIS digitisation contact (e.g. via `bibliotheek@kuleuven.be` / the "Enriching
+Heritage" group — Nele Gabriels has been the public voice of their open-reuse policy).
+
+**Subject:** Re-hosting & AI-translating your public-domain digitised collections on Source Library
+
+---
+
+Dear KU Leuven Libraries team,
+
+I'm writing from **Source Library** (sourcelibrary.org), a non-profit digital library that
+re-hosts historical primary sources — alchemy, Hermetica, early-modern science, theology and
+adjacent traditions — and makes them *readable and quotable* with AI-assisted OCR and
+translation. We credit every contributing institution with its own page and link back to the
+original record; readers discover the holding library rather than leaving it behind.
+
+We've been admiring your digitised heritage — the incunabula, the 17th-century Flanders
+*Jesuitica*, the books of hours and the Maurits Sabbe collections — and your public open-reuse
+policy on the ~42,000 public-domain images. Your IIIF setup (Rosetta / `lib.is` manifests and
+the bespoke `sharedcanvas.be` collections) is exactly the kind of clean, standards-based
+infrastructure we can ingest directly.
+
+We'd love to re-host a curated subset of your public-domain digitisations and add AI English
+translation on top — turning facsimiles into texts a wider public can actually read — always
+with clear KU Leuven attribution and a link back to your records. Two small asks that would let
+us do this well:
+
+1. **A list of your digitised public-domain items** — ideally an OAI-PMH set, a CSV of
+   IE/PIDs, or a IIIF Collection manifest. We can harvest item-by-item from Primo, but an
+   authoritative export means we credit and link everything correctly and avoid duplicating
+   what you'd rather we didn't.
+2. **A quick confirmation of the licence/attribution wording** you'd like us to display
+   (e.g. "Digitised by KU Leuven Libraries, CC BY-NC 4.0 / public domain").
+
+If it's useful, we're also happy to share back our OCR/translation output for any items we
+process, so the enriched text can flow into your own systems.
+
+Could we set up a short call? I'd be glad to walk you through how we present partner
+collections and how attribution works.
+
+With appreciation for the open stance you've taken on heritage reuse,
+
+Derek Lomas
+Source Library — sourcelibrary.org
+[role / affiliation]
+
+---
+
+## Internal notes (not part of the email)
+
+- **Why partnership beats scraping:** their digitisation is split across two platforms
+  (Rosetta/Teneo → `lib.is/IE…/manifest`, and bespoke `sharedcanvas.be`), and Primo has **no
+  clean "digitised by us" facet** — the only per-record signal is an `edelivery` POST returning
+  a `resolver.libis.be/IE…` link. A direct export removes that fragility and gives us an
+  authoritative attribution list.
+- **Import path is ready:** `lib.is/IE…/manifest` is IIIF v3 and parses with our existing
+  `/api/import/iiif` handler — no new connector needed, just a `LIBRARY_PARTNERS` entry
+  (`src/lib/library-partners.ts`).
+- **Licence:** sampled manifests are CC BY-NC 4.0 / public-domain; confirm per-item before
+  re-hosting (BY-NC is fine for our non-profit re-host with attribution).
+- **The automated gap census** (`scripts/research/kuleuven-gap-harvest.mjs`) gives us the
+  what-they-have-that-we-don't list in the meantime, so we can lead the conversation with a
+  concrete first batch we'd like to import.

--- a/scripts/research/.gitignore
+++ b/scripts/research/.gitignore
@@ -1,0 +1,2 @@
+output/
+*.log

--- a/scripts/research/kuleuven-gap-harvest.mjs
+++ b/scripts/research/kuleuven-gap-harvest.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * KU Leuven digitized-collection gap census.
+ *
+ * Answers: "What has KU Leuven Libraries digitized that we DON'T have?"
+ *
+ * Channel (reverse-engineered 2026-06-01 — all public, no credentials):
+ *   - Catalog:   Primo VE  /primaws/rest/pub/pnxs   (scope=MyInstitution = KU Leuven holdings)
+ *   - Token:     sessionStorage 'primoExploreJwt', minted on page load (Playwright grabs it)
+ *   - Facets:    /primaws/rest/pub/facets  → facet_digital_collection = the digitized-collection map
+ *   - Online IE: /primaws/rest/pub/edelivery → resolver.libis.be/IE{n}/representation
+ *   - Manifest:  https://lib.is/IE{n}/manifest   (IIIF v3, importable by /api/import/iiif as-is)
+ *   - (a bespoke IIIF subset also lives on sharedcanvas.be — manuscripts/exhibits)
+ *
+ * Two digitization platforms confirmed: Rosetta/Teneo (bulk, lib.is IIIF) + sharedcanvas.be (bespoke).
+ *
+ * Diff: normalized title+author against our Mongo `bookstore.books` (same logic as src/lib/dedup.ts).
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/research/kuleuven-gap-harvest.mjs            # full run
+ *   node scripts/research/kuleuven-gap-harvest.mjs --limit 200 --no-manifest   # quick probe
+ *
+ * Outputs (scripts/research/output/):
+ *   kuleuven-digitized-collections.json   the collection map (name + count)
+ *   kuleuven-digitized.json               every digitized record we enumerated
+ *   kuleuven-gap.json                     the subset we do NOT already have (import candidates)
+ */
+
+import { chromium } from 'playwright';
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const OUT = join(__dir, 'output');
+mkdirSync(OUT, { recursive: true });
+
+const VID = '32KUL_KUL:KULeuven';
+const INST = '32KUL_KUL';
+const HOST = 'https://kuleuven.limo.libis.be';
+const args = process.argv.slice(2);
+const argNum = (flag, def) => { const i = args.indexOf(flag); return i >= 0 ? parseInt(args[i + 1]) : def; };
+// Primo VE caps deep paging at ~1000 results/query, so we partition the catalog by
+// publication year. Default window = the early-print era that matches our mission.
+const FROM = argNum('--from', 1450);
+const TO = argNum('--to', 1700);
+
+// ---- normalization: mirror of src/lib/dedup.ts (keep in sync) ----
+function normalizeTitle(title = '') {
+  return title.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i, '')
+    .replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i, '')
+    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+}
+function normalizeAuthor(author = '') {
+  const cleaned = author.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g, '')
+    .replace(/\s*\([\d\s\-–,?.]+\)\s*/g, '')
+    .replace(/,\s*[\d\s\-–?.]+$/, '')
+    .replace(/[\[\]]/g, '')
+    .replace(/\b(born|died|fl\.?|circa|ca?\.?)\s*\d{3,4}\b/g, '')
+    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+  return cleaned.split(' ').filter(w => w.length > 0).sort().join(' ');
+}
+const firstStr = (v) => Array.isArray(v) ? (v[0] ?? '') : (v ?? '');
+
+// =====================================================================
+// 1. Mint token + run all Primo API calls inside the page (same-origin)
+// =====================================================================
+async function harvestPrimo() {
+  const browser = await chromium.launch({ headless: true });
+  const page = await (await browser.newContext({ userAgent: 'Mozilla/5.0 SourceLibrary-research' })).newPage();
+
+  // capture the real param templates the app uses for each endpoint
+  const tmpl = {};
+  page.on('request', (r) => {
+    for (const ep of ['pnxs', 'facets', 'edelivery']) {
+      if (r.url().includes(`/pub/${ep}`) && !tmpl[ep]) {
+        tmpl[ep] = Object.fromEntries(new URL(r.url()).searchParams.entries());
+      }
+    }
+  });
+
+  // a query with digitized hits triggers pnxs + facets + edelivery so we capture all 3 templates
+  await page.goto(`${HOST}/discovery/search?query=any,contains,getijdenboek&tab=all&vid=${VID}&mode=basic&offset=0`,
+    { waitUntil: 'domcontentloaded', timeout: 60000 }).catch(e => console.error('goto:', e.message));
+  await page.waitForFunction(() => sessionStorage.getItem('primoExploreJwt'), { timeout: 30000 });
+  await page.waitForTimeout(5000); // let pnxs/facets/edelivery fire so we capture their templates
+  console.log('  token minted; endpoint templates:', Object.keys(tmpl).join(', '));
+
+  // In-page scanner for ONE publication year: pages the (MyInstitution · online · year)
+  // slice up to Primo's ~1000 deep-paging cap, POSTs edelivery per page, returns the
+  // records that carry a KU Leuven Rosetta IE (= actually digitized here, with a manifest).
+  const scanYear = (year) => page.evaluate(async ({ VID, INST, tmpl, year }) => {
+    const jwt = sessionStorage.getItem('primoExploreJwt');
+    const auth = { headers: { Authorization: 'Bearer ' + jwt } };
+    const firstStr = (v) => Array.isArray(v) ? (v[0] ?? '') : (v ?? '');
+    const clean = (s) => firstStr(s).split('$$')[0].trim(); // strip Primo "Name$$QName"
+    const E = 'https://kuleuven.limo.libis.be/primaws/rest/pub/';
+    const qInclude = `facet_tlevel,include,online_resources|,|facet_searchcreationdate,include,[${year} TO ${year}]`;
+    const qparams = (offset, limit) => new URLSearchParams({
+      ...(tmpl.pnxs || {}), vid: VID, inst: INST, lang: 'en', scope: 'MyInstitution',
+      mode: 'advanced', sort: 'rank', q: 'any,contains,e', qExclude: '', qInclude,
+      offset: String(offset), limit: String(limit), pcAvailability: 'true', skipDelivery: 'Y',
+    });
+    const PAGE = 50, CAP = 1000;
+    const out = []; let total = null;
+    for (let offset = 0; offset < CAP; offset += PAGE) {
+      const params = qparams(offset, PAGE);
+      const r = await fetch(E + 'pnxs?' + params.toString(), auth);
+      const d = r.ok ? await r.json() : { __err: r.status };
+      if (d.__err) break;
+      total = d.info?.total ?? total;
+      const batch = d.docs || [];
+      const ids = batch.map(x => x.pnx?.control?.recordid?.[0] || x['@id']).filter(Boolean);
+      const er = await fetch(E + 'edelivery?' + params.toString(), {
+        method: 'POST', headers: { Authorization: 'Bearer ' + jwt, 'Content-Type': 'application/json' },
+        body: JSON.stringify(ids.map(id => ({ recId: id, sharedDigitalCandidates: null }))),
+      });
+      const ed = er.ok ? await er.json() : {};
+      for (const doc of batch) {
+        const rid = doc.pnx?.control?.recordid?.[0] || doc['@id'];
+        const m = JSON.stringify(ed?.[rid] || '').match(/resolver\.libis\.be\/(IE\d+)/);
+        if (!m) continue;
+        const ie = m[1], disp = doc.pnx?.display || {};
+        out.push({
+          recordid: rid, ie_pid: ie,
+          title: clean(disp.title), creator: clean(disp.creator) || clean(disp.contributor),
+          date: firstStr(disp.creationdate) || firstStr(disp.date), type: firstStr(disp.type),
+          manifest: `https://lib.is/${ie}/manifest`, resolver: `https://resolver.libis.be/${ie}/representation`,
+        });
+      }
+      if (batch.length < PAGE) break;
+    }
+    return { total, docs: out };
+  }, { VID, INST, tmpl, year });
+
+  const docs = [];
+  const truncated = [];
+  for (let year = FROM; year <= TO; year++) {
+    const { total, docs: yd } = await scanYear(year);
+    docs.push(...yd);
+    if (total > 1000) truncated.push({ year, total }); // no silent caps: flag for sub-partitioning
+    if (yd.length || (total && total > 0)) console.log(`  ${year}: ${total ?? 0} online · ${yd.length} digitized   (running: ${docs.length})`);
+  }
+  await browser.close();
+  return { docs, truncated, collections: [{ name: `MyInstitution · online · ${FROM}-${TO}`, count: docs.length }] };
+}
+
+// =====================================================================
+// 2. Diff against our Mongo catalog
+// =====================================================================
+async function diff(docs) {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  // preload our catalog's normalized keys (fast in-memory diff)
+  const ours = await db.collection('books')
+    .find({}, { projection: { title: 1, author: 1, normalized_title: 1, normalized_author: 1 } }).toArray();
+  await client.close();
+
+  const titleSet = new Set();          // normalized title -> have it
+  const titleAuthorSet = new Set();    // normalized "title|author" -> have it
+  for (const b of ours) {
+    const nt = b.normalized_title || normalizeTitle(b.title || '');
+    const na = b.normalized_author || normalizeAuthor(b.author || '');
+    if (nt) { titleSet.add(nt); titleAuthorSet.add(nt + '|' + na); }
+  }
+
+  for (const d of docs) {
+    const nt = normalizeTitle(d.title || '');
+    const na = normalizeAuthor(d.creator || '');
+    d._nt = nt;
+    if (titleAuthorSet.has(nt + '|' + na)) d.match = 'title_author';
+    else if (nt && titleSet.has(nt)) d.match = 'title_only';
+    else d.match = 'none';
+  }
+  return { ourCount: ours.length };
+}
+
+// =====================================================================
+(async () => {
+  console.log(`▶ Harvesting KU Leuven digitized items, ${FROM}–${TO} (year-partitioned, Primo cap ~1000/yr)…`);
+  const { docs, truncated } = await harvestPrimo();
+  console.log(`  digitized items found: ${docs.length}`);
+
+  console.log('▶ Diffing against bookstore.books…');
+  const { ourCount } = await diff(docs);
+
+  const gap = docs.filter(d => d.match === 'none');
+  const titleOnly = docs.filter(d => d.match === 'title_only');
+  const have = docs.filter(d => d.match === 'title_author');
+
+  writeFileSync(join(OUT, 'kuleuven-digitized.json'), JSON.stringify(docs, null, 1));
+  writeFileSync(join(OUT, 'kuleuven-gap.json'), JSON.stringify(gap, null, 1));
+
+  console.log(`\n========== KU LEUVEN GAP CENSUS (${FROM}–${TO}) ==========`);
+  console.log(`Our catalog (books):            ${ourCount.toLocaleString()}`);
+  console.log(`KU Leuven digitized (window):   ${docs.length.toLocaleString()}`);
+  console.log(`  ├─ already have (title+author): ${have.length}`);
+  console.log(`  ├─ probable have (title only):  ${titleOnly.length}`);
+  console.log(`  └─ GAP — we don't have:         ${gap.length}`);
+  if (truncated.length) {
+    console.log(`\n⚠ ${truncated.length} year(s) exceeded the 1000 cap (under-counted — sub-partition these):`);
+    console.log('  ' + truncated.map(t => `${t.year}(${t.total})`).join(', '));
+  }
+  console.log(`\nWrote → ${OUT}/{kuleuven-digitized,kuleuven-gap}.json`);
+  console.log('Gap items carry a ready-to-import `manifest` (https://lib.is/IE…/manifest).');
+})();


### PR DESCRIPTION
## What
A research harvester that answers **"what has KU Leuven Libraries digitized that we don't have?"** plus a partnership outreach email draft.

`scripts/research/kuleuven-gap-harvest.mjs` enumerates KU Leuven's digitized items via the Primo VE API and diffs them against our Mongo catalog. Every gap item carries a ready-to-import IIIF manifest URL.

## How the channel works (all public, no credentials)
- **Manifests:** `https://lib.is/IE{n}/manifest` — IIIF v3, parses with our existing `/api/import/iiif` (only a `LIBRARY_PARTNERS` entry needed to import).
- **Enumerate:** Primo VE `pnxs`, `scope=MyInstitution` (= KU Leuven holdings). Token is auto-minted from a headless Playwright session (no Alma key exists for outsiders).
- **Digitized signal:** a **POST** to `edelivery` returning a `resolver.libis.be/IE…` link. A GET 405s; there is no `digital_collection` facet, and `online_resources` is polluted with Google Books/HathiTrust links — so the IE link is the only trustworthy "digitized by KU Leuven" marker.
- **Paging:** Primo caps deep pagination at ~1000 results/query, so the scan **partitions by publication year**. Years over the cap are flagged (`truncated`), never silently under-counted.

## Validated
1550–1560 window: **83 digitized books, 82 absent from our catalog** — Aristotle's *Categoriae* in Greek, Erasmus, Gregory Nazianzen, Jerome, Porphyry, Charles V's *Catalogue des livres réprouvés* (early Index), Louvain theology. All with working manifests.

## Scope / out of scope
- **In:** the harvester + the outreach email draft (`.claude/docs/kuleuven-outreach-email.md`).
- **Out:** no `LIBRARY_PARTNERS` entry or actual import yet (a follow-up once we pick a batch); generated census output is gitignored (`scripts/research/output/`).
- **Recommendation in the email:** prefer a partnership/export over scraping — KU Leuven has an open-reuse policy, and an authoritative list gives clean attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)