### PR TITLE
feat(traffic): range/bin/compare + sectioned drill-down + cross-filtering

### DIFF
--- a/src/app/api/analytics/traffic/route.ts
+++ b/src/app/api/analytics/traffic/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/lib/auth-helpers';
+import { getTrafficDashboard, type TrafficBin } from '@/lib/analytics-traffic';
+
+export const maxDuration = 30;
+
+// Short in-memory cache keyed by the full query (range/bin/filters). Traffic
+// changes slowly and these aggregations scan the 90-day window.
+const cache = new Map<string, { data: unknown; ts: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const VALID_BINS: TrafficBin[] = ['hour', 'day', 'week'];
+
+export const GET = withAuth(async (request: NextRequest) => {
+  try {
+    const { searchParams } = new URL(request.url);
+    const days = parseInt(searchParams.get('days') || '30', 10);
+    const binParam = searchParams.get('bin') as TrafficBin | null;
+    const bin = binParam && VALID_BINS.includes(binParam) ? binParam : undefined;
+    const filters = {
+      country: searchParams.get('country') || undefined,
+      section: searchParams.get('section') || undefined,
+      referrer: searchParams.get('referrer') || undefined,
+    };
+
+    const cacheKey = JSON.stringify({ days, bin, filters });
+    const hit = cache.get(cacheKey);
+    if (hit && Date.now() - hit.ts < CACHE_TTL_MS) {
+      return NextResponse.json(hit.data);
+    }
+
+    const data = await getTrafficDashboard({
+      days: Number.isFinite(days) ? days : 30,
+      bin,
+      filters,
+    });
+
+    cache.set(cacheKey, { data, ts: Date.now() });
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Traffic dashboard API error:', error);
+    return NextResponse.json({ error: 'Failed to fetch traffic data' }, { status: 500 });
+  }
+});

--- a/src/app/traffic/page.tsx
+++ b/src/app/traffic/page.tsx
@@ -1,27 +1,19 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
-import { ChevronLeft, RefreshCw } from 'lucide-react';
+import { ChevronLeft } from 'lucide-react';
+import { BookLoader } from '@/components/ui/BookLoader';
 
-const LoadingBar = () => (
-  <div className="py-8">
-    <div className="w-full h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--bg-warm)' }}>
-      <div className="h-full rounded-full" style={{ background: 'var(--accent-sage)', width: '40%', animation: 'loading-bar 2s ease-in-out infinite' }} />
-    </div>
-    <style>{`@keyframes loading-bar { 0% { transform: translateX(-100%); } 50% { transform: translateX(150%); } 100% { transform: translateX(-100%); } }`}</style>
-    <p className="text-center text-sm mt-4" style={{ color: 'var(--text-muted)' }}>Loading...</p>
-  </div>
-);
-
-// TrafficTab fetches first-party pageviews from /api/analytics (Mongo source of
-// truth). Loaded client-side only, mirroring how /analytics renders its tabs.
-const TrafficTab = dynamic(() => import('@/components/analytics/tabs/TrafficTab'), { ssr: false, loading: LoadingBar });
+// First-party traffic dashboard (range/bin/compare + sectioned drill-down +
+// cross-filtering). Reads /api/analytics/traffic, which aggregates Mongo
+// directly. Client-only, mirroring how /analytics loads its tabs.
+const TrafficDashboard = dynamic(() => import('@/components/analytics/TrafficDashboard'), {
+  ssr: false,
+  loading: () => <div className="py-16 text-center"><BookLoader size="xs" /></div>,
+});
 
 export default function TrafficPage() {
-  const [refreshKey, setRefreshKey] = useState(0);
-
   return (
     <div className="min-h-screen" style={{ background: 'var(--bg-cream)' }}>
       <header className="px-6 py-4" style={{ background: 'var(--bg-white)', borderBottom: '1px solid var(--border-light)' }}>
@@ -41,22 +33,14 @@ export default function TrafficPage() {
               Full analytics
             </Link>
           </div>
-          <button
-            onClick={() => setRefreshKey(k => k + 1)}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium hover:opacity-70 transition-opacity"
-            style={{ color: 'var(--accent-rust)' }}
-          >
-            <RefreshCw className="w-4 h-4" />
-            Refresh
-          </button>
         </div>
       </header>
 
       <main className="max-w-7xl mx-auto px-6 py-8">
         <p className="text-sm mb-6" style={{ color: 'var(--text-muted)' }}>
-          First-party visitor data from the last 30 days — collected server-side with anonymized IPs, no cookie consent required. This is the source of truth, independent of Google Analytics.
+          First-party visitor data — collected server-side with anonymized IPs, no cookie consent required. The source of truth, independent of Google Analytics. Includes all subdomains (host-level split coming next).
         </p>
-        <TrafficTab key={refreshKey} />
+        <TrafficDashboard />
       </main>
     </div>
   );

--- a/src/components/analytics/TrafficDashboard.tsx
+++ b/src/components/analytics/TrafficDashboard.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Users, Globe, BarChart3, X, ChevronRight } from 'lucide-react';
+import { BookLoader } from '@/components/ui/BookLoader';
+import { AreaChart } from './charts/AreaChart';
+import type { TrafficDashboardData, TrafficBin } from '@/lib/analytics-traffic';
+
+const RANGES = [
+  { days: 1, label: '24h' },
+  { days: 7, label: '7d' },
+  { days: 30, label: '30d' },
+  { days: 90, label: '90d' },
+];
+const BINS: { value: TrafficBin | 'auto'; label: string }[] = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'hour', label: 'Hourly' },
+  { value: 'day', label: 'Daily' },
+  { value: 'week', label: 'Weekly' },
+];
+
+type Metric = 'pageviews' | 'visitors';
+
+function pctDelta(cur: number, prev: number): { text: string; up: boolean | null } {
+  if (prev === 0) return { text: cur > 0 ? 'new' : '—', up: cur > 0 ? true : null };
+  const d = ((cur - prev) / prev) * 100;
+  const r = Math.round(d);
+  if (r === 0) return { text: '0%', up: null };
+  return { text: `${r > 0 ? '+' : ''}${r}%`, up: r > 0 };
+}
+
+function fmtBucket(iso: string, bin: TrafficBin): string {
+  // iso like 2026-05-02T00:00:00.000Z
+  if (bin === 'hour') return iso.slice(5, 13).replace('T', ' ') + ':00';
+  return iso.slice(5, 10); // MM-DD
+}
+
+export default function TrafficDashboard() {
+  const [data, setData] = useState<TrafficDashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [days, setDays] = useState(30);
+  const [bin, setBin] = useState<TrafficBin | 'auto'>('auto');
+  const [metric, setMetric] = useState<Metric>('pageviews');
+  const [filters, setFilters] = useState<{ country?: string; section?: string; referrer?: string }>({});
+
+  const fetchData = useCallback(() => {
+    setLoading(true);
+    const params = new URLSearchParams({ days: String(days) });
+    if (bin !== 'auto') params.set('bin', bin);
+    if (filters.country) params.set('country', filters.country);
+    if (filters.section) params.set('section', filters.section);
+    if (filters.referrer) params.set('referrer', filters.referrer);
+    fetch(`/api/analytics/traffic?${params.toString()}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(setData)
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, [days, bin, filters]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const toggleFilter = (key: 'country' | 'section' | 'referrer', value: string) => {
+    setFilters(f => ({ ...f, [key]: f[key] === value ? undefined : value }));
+  };
+
+  const activeFilters = (['section', 'country', 'referrer'] as const)
+    .map(k => (filters[k] ? { key: k, value: filters[k]! } : null))
+    .filter(Boolean) as { key: 'country' | 'section' | 'referrer'; value: string }[];
+
+  const card = { background: 'var(--bg-white)', border: '1px solid var(--border-light)' };
+  const pill = (active: boolean) => ({
+    background: active ? 'var(--bg-white)' : 'transparent',
+    color: active ? 'var(--text-primary)' : 'var(--text-muted)',
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Controls */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex rounded-lg p-1" style={{ background: 'var(--bg-warm)' }}>
+          {RANGES.map(r => (
+            <button
+              key={r.days}
+              onClick={() => setDays(r.days)}
+              className="px-3 py-1.5 rounded-md text-sm font-medium transition-all"
+              style={pill(days === r.days)}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+        <div className="flex rounded-lg p-1" style={{ background: 'var(--bg-warm)' }}>
+          {BINS.map(b => (
+            <button
+              key={b.value}
+              onClick={() => setBin(b.value)}
+              className="px-3 py-1.5 rounded-md text-sm font-medium transition-all"
+              style={pill(bin === b.value)}
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+        {data && (
+          <span className="text-xs ml-auto" style={{ color: 'var(--text-muted)' }}>
+            binned {data.range.bin} · vs previous {data.range.days}d
+          </span>
+        )}
+      </div>
+
+      {/* Active filter chips */}
+      {activeFilters.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs uppercase font-medium" style={{ color: 'var(--text-muted)' }}>Filtered:</span>
+          {activeFilters.map(f => (
+            <button
+              key={f.key}
+              onClick={() => toggleFilter(f.key, f.value)}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium"
+              style={{ background: 'var(--accent-sage)', color: 'white' }}
+            >
+              <span className="opacity-70">{f.key}:</span> {f.value} <X className="w-3 h-3" />
+            </button>
+          ))}
+          <button onClick={() => setFilters({})} className="text-xs underline" style={{ color: 'var(--text-muted)' }}>
+            clear all
+          </button>
+        </div>
+      )}
+
+      {loading && !data ? (
+        <div className="py-16 text-center"><BookLoader size="xs" /></div>
+      ) : !data ? (
+        <div className="text-center py-12" style={{ color: 'var(--text-muted)' }}>
+          <BarChart3 className="w-12 h-12 mx-auto mb-4 opacity-30" />
+          <p>No traffic data available for this view</p>
+        </div>
+      ) : (
+        <div className={`space-y-6 transition-opacity ${loading ? 'opacity-50' : ''}`}>
+          {/* Summary cards */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <SummaryCard
+              icon={<BarChart3 className="w-5 h-5" style={{ color: '#8b5cf6' }} />}
+              label="Pageviews"
+              value={data.summary.pageviews}
+              delta={pctDelta(data.summary.pageviews, data.summary.prevPageviews)}
+            />
+            <SummaryCard
+              icon={<Users className="w-5 h-5" style={{ color: '#3b82f6' }} />}
+              label="Unique visitors"
+              value={data.summary.visitors}
+              delta={pctDelta(data.summary.visitors, data.summary.prevVisitors)}
+              hint="approx — anonymized IP"
+            />
+          </div>
+
+          {/* Trend */}
+          <div className="p-6 rounded-xl" style={card}>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-medium" style={{ color: 'var(--text-primary)' }}>Trend</h2>
+              <div className="flex rounded-lg p-1" style={{ background: 'var(--bg-warm)' }}>
+                {(['pageviews', 'visitors'] as Metric[]).map(m => (
+                  <button key={m} onClick={() => setMetric(m)}
+                    className="px-3 py-1 rounded-md text-xs font-medium capitalize transition-all" style={pill(metric === m)}>
+                    {m}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <AreaChart
+              data={data.series.map(s => ({ x: s.bucket, y: s[metric] }))}
+              color={metric === 'pageviews' ? 'var(--accent-violet)' : '#3b82f6'}
+              xLabel={(v) => fmtBucket(v, data.range.bin)}
+            />
+          </div>
+
+          {/* Sections + Top pages */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <ListCard title="Sections" hint="click to drill in">
+              {data.sections.map((s, i) => (
+                <Row key={i} label={s.section} count={s.count} unit="views"
+                  active={filters.section === s.section}
+                  onClick={() => toggleFilter('section', s.section)} drill />
+              ))}
+            </ListCard>
+            <ListCard title={filters.section ? `Pages in ${filters.section}` : 'Top pages'}>
+              {data.topPages.map((p, i) => (
+                <Row key={i} label={p.path} count={p.count} unit="views" />
+              ))}
+            </ListCard>
+          </div>
+
+          {/* Referrers + Countries */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <ListCard title="Traffic sources" hint="click to filter">
+              {data.topReferrers.length === 0 ? <Empty /> : data.topReferrers.map((r, i) => (
+                <Row key={i} label={r.referrer} count={r.count} unit="views"
+                  active={filters.referrer === r.referrer}
+                  onClick={() => toggleFilter('referrer', r.referrer)} />
+              ))}
+            </ListCard>
+            <ListCard title="Countries" icon={<Globe className="w-4 h-4" style={{ color: 'var(--accent-sage)' }} />} hint="click to filter">
+              {data.topCountries.length === 0 ? <Empty /> : data.topCountries.map((c, i) => (
+                <Row key={i} label={c.country} count={c.count} unit="views"
+                  active={filters.country === c.country}
+                  onClick={() => toggleFilter('country', c.country)} />
+              ))}
+            </ListCard>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({ icon, label, value, delta, hint }: {
+  icon: React.ReactNode; label: string; value: number;
+  delta: { text: string; up: boolean | null }; hint?: string;
+}) {
+  const color = delta.up === null ? 'var(--text-muted)' : delta.up ? '#16a34a' : '#dc2626';
+  return (
+    <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
+      <div className="flex items-center gap-2 mb-2">
+        {icon}
+        <span className="text-sm font-medium uppercase" style={{ color: 'var(--text-muted)' }}>{label}</span>
+      </div>
+      <div className="flex items-baseline gap-3">
+        <div className="text-4xl font-bold" style={{ color: 'var(--text-primary)' }}>{value.toLocaleString('en-US')}</div>
+        <span className="text-sm font-medium" style={{ color }}>{delta.text}</span>
+      </div>
+      {hint && <p className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>{hint}</p>}
+    </div>
+  );
+}
+
+function ListCard({ title, hint, icon, children }: {
+  title: string; hint?: string; icon?: React.ReactNode; children: React.ReactNode;
+}) {
+  return (
+    <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-medium flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+          {icon}{title}
+        </h2>
+        {hint && <span className="text-xs" style={{ color: 'var(--text-muted)' }}>{hint}</span>}
+      </div>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function Row({ label, count, unit, active, onClick, drill }: {
+  label: string; count: number; unit: string; active?: boolean; onClick?: () => void; drill?: boolean;
+}) {
+  const clickable = !!onClick;
+  return (
+    <div
+      onClick={onClick}
+      className={`flex items-center justify-between py-2 px-2 -mx-2 rounded-lg ${clickable ? 'cursor-pointer hover:bg-[var(--bg-warm)]' : ''}`}
+      style={active ? { background: 'var(--bg-warm)' } : undefined}
+    >
+      <p className="font-medium truncate flex items-center gap-1" style={{ color: active ? 'var(--accent-rust)' : 'var(--text-primary)' }}>
+        {drill && <ChevronRight className="w-3.5 h-3.5 opacity-40 shrink-0" />}
+        {label || '(home)'}
+      </p>
+      <p className="text-sm ml-4 shrink-0" style={{ color: 'var(--text-muted)' }}>{count.toLocaleString('en-US')} {unit}</p>
+    </div>
+  );
+}
+
+function Empty() {
+  return <p className="text-sm py-2" style={{ color: 'var(--text-muted)' }}>None in this range</p>;
+}

--- a/src/lib/analytics-traffic.ts
+++ b/src/lib/analytics-traffic.ts
@@ -86,3 +86,169 @@ export async function getTrafficData(days = 30): Promise<TrafficData> {
     ),
   };
 }
+
+// ── Rich dashboard query (range/bin/compare + sections + cross-filter) ───────
+// Powers the standalone /traffic page. getTrafficData() above stays as the
+// simple shape consumed by the /analytics Traffic tab.
+
+export type TrafficBin = 'hour' | 'day' | 'week';
+
+export interface TrafficFilters {
+  country?: string;
+  section?: string; // top-level section, e.g. '/book' or '/embed/bph'
+  referrer?: string;
+}
+
+export interface TrafficDashboardData {
+  range: { days: number; bin: TrafficBin; since: string };
+  filters: TrafficFilters;
+  summary: { pageviews: number; visitors: number; prevPageviews: number; prevVisitors: number };
+  series: Array<{ bucket: string; pageviews: number; visitors: number }>;
+  sections: Array<{ section: string; count: number }>;
+  topPages: Array<{ path: string; count: number }>;
+  topReferrers: Array<{ referrer: string; count: number }>;
+  topCountries: Array<{ country: string; count: number }>;
+}
+
+const MAX_DAYS = 90; // analytics_pageviews has a 90-day TTL — nothing older exists
+
+function defaultBin(days: number): TrafficBin {
+  if (days <= 2) return 'hour';
+  if (days <= 60) return 'day';
+  return 'week';
+}
+
+// Derive a top-level "section" from the path. `/embed/<tenant>` keeps two
+// segments so partner reading-room traffic is its own section; everything else
+// collapses to its first segment ('/', '/book', '/gallery', …).
+const SECTION_EXPR = {
+  $let: {
+    vars: { parts: { $split: ['$path', '/'] } },
+    in: {
+      $cond: [
+        { $eq: [{ $arrayElemAt: ['$$parts', 1] }, 'embed'] },
+        { $concat: ['/embed/', { $ifNull: [{ $arrayElemAt: ['$$parts', 2] }, ''] }] },
+        { $concat: ['/', { $ifNull: [{ $arrayElemAt: ['$$parts', 1] }, ''] }] },
+      ],
+    },
+  },
+};
+
+export async function getTrafficDashboard(opts: {
+  days?: number;
+  bin?: TrafficBin;
+  filters?: TrafficFilters;
+} = {}): Promise<TrafficDashboardData> {
+  const db = await getReadDb();
+  const days = Math.min(Math.max(1, opts.days ?? 30), MAX_DAYS);
+  const bin = opts.bin ?? defaultBin(days);
+  const filters = opts.filters ?? {};
+
+  const rangeMs = days * 24 * 60 * 60 * 1000;
+  const since = new Date(Date.now() - rangeMs);
+  const prevSince = new Date(since.getTime() - rangeMs);
+
+  const col = db.collection('analytics_pageviews');
+
+  // Base match shared by current + prior windows (country/referrer filter, but
+  // NOT section — section is applied per-sub-pipeline so the sections list can
+  // still offer every section to switch to).
+  const baseMatch: Record<string, unknown> = { path: { $ne: null } };
+  if (filters.country) baseMatch.country = filters.country;
+  if (filters.referrer) baseMatch.referrer = filters.referrer;
+
+  const sectionMatch = filters.section ? [{ $match: { _section: filters.section } }] : [];
+
+  const [result] = await col
+    .aggregate(
+      [
+        { $match: { ...baseMatch, timestamp: { $gte: since } } },
+        { $addFields: { _section: SECTION_EXPR } },
+        {
+          $facet: {
+            totals: [
+              ...sectionMatch,
+              { $group: { _id: null, pageviews: { $sum: 1 }, ips: { $addToSet: '$ip' } } },
+            ],
+            series: [
+              ...sectionMatch,
+              {
+                $group: {
+                  _id: { $dateTrunc: { date: '$timestamp', unit: bin } },
+                  ips: { $addToSet: '$ip' },
+                  pageviews: { $sum: 1 },
+                },
+              },
+              { $sort: { _id: 1 } },
+            ],
+            sections: [
+              { $group: { _id: '$_section', count: { $sum: 1 } } },
+              { $sort: { count: -1 } },
+              { $limit: 25 },
+            ],
+            topPages: [
+              ...sectionMatch,
+              { $group: { _id: '$path', count: { $sum: 1 } } },
+              { $sort: { count: -1 } },
+              { $limit: 15 },
+            ],
+            topReferrers: [
+              ...sectionMatch,
+              { $match: { referrer: { $nin: [null, '', 'direct'] } } },
+              { $group: { _id: '$referrer', count: { $sum: 1 } } },
+              { $sort: { count: -1 } },
+              { $limit: 10 },
+            ],
+            topCountries: [
+              ...sectionMatch,
+              { $match: { country: { $nin: [null, '', 'Unknown'] } } },
+              { $group: { _id: '$country', count: { $sum: 1 } } },
+              { $sort: { count: -1 } },
+              { $limit: 10 },
+            ],
+          },
+        },
+      ],
+      { allowDiskUse: true }
+    )
+    .toArray();
+
+  // Prior-period totals (same filters incl. section) for compare deltas.
+  const [prev] = await col
+    .aggregate(
+      [
+        { $match: { ...baseMatch, timestamp: { $gte: prevSince, $lt: since } } },
+        ...(filters.section
+          ? [{ $addFields: { _section: SECTION_EXPR } }, { $match: { _section: filters.section } }]
+          : []),
+        { $group: { _id: null, pageviews: { $sum: 1 }, ips: { $addToSet: '$ip' } } },
+      ],
+      { allowDiskUse: true }
+    )
+    .toArray();
+
+  const totals = result?.totals?.[0] as { pageviews: number; ips: (string | null)[] } | undefined;
+  const prevTotals = prev as { pageviews: number; ips: (string | null)[] } | undefined;
+
+  return {
+    range: { days, bin, since: since.toISOString() },
+    filters,
+    summary: {
+      pageviews: totals?.pageviews ?? 0,
+      visitors: (totals?.ips ?? []).filter(Boolean).length,
+      prevPageviews: prevTotals?.pageviews ?? 0,
+      prevVisitors: (prevTotals?.ips ?? []).filter(Boolean).length,
+    },
+    series: (result?.series ?? []).map((s: { _id: Date; ips: (string | null)[]; pageviews: number }) => ({
+      bucket: new Date(s._id).toISOString(),
+      pageviews: s.pageviews,
+      visitors: s.ips.filter(Boolean).length,
+    })),
+    sections: (result?.sections ?? [])
+      .filter((s: { _id: string }) => s._id)
+      .map((s: { _id: string; count: number }) => ({ section: s._id, count: s.count })),
+    topPages: (result?.topPages ?? []).map((p: { _id: string; count: number }) => ({ path: p._id, count: p.count })),
+    topReferrers: (result?.topReferrers ?? []).map((r: { _id: string; count: number }) => ({ referrer: r._id, count: r.count })),
+    topCountries: (result?.topCountries ?? []).map((c: { _id: string; count: number }) => ({ country: c._id, count: c.count })),
+  };
+}


### PR DESCRIPTION
## Why
Follow-up to the `/traffic` dashboard work. Derek asked for the basic analytics table-stakes that GA / Cloudflare / PostHog / Datadog all have and `/traffic` lacked: time-range control, bin size, site sections, and filtering. This is the read-side foundations PR.

## What
Upgrades `/traffic` from a fixed 30-day snapshot to:
- **Time range** — 24h / 7d / 30d / 90d (capped at the `analytics_pageviews` 90-day TTL).
- **Bin size** — auto / hourly / daily / weekly, via Mongo `$dateTrunc`.
- **Compare to prior period** — ▲/▼ % deltas on the pageviews & unique-visitors cards.
- **Trend chart** — daily/weekly area chart with a pageviews|visitors toggle.
- **Sections** — paths rolled up (`/book`, `/gallery`, `/collections`, `/embed/<tenant>`, …) with **click-to-drill-down** into the pages within a section.
- **Cross-filtering** — click a section, country, or referrer to filter the whole view; active filters appear as removable chips.

## Architecture
- New `getTrafficDashboard()` in `src/lib/analytics-traffic.ts` — a single Mongo `$facet` aggregation (Mongo is the source of truth) plus a prior-period query for deltas.
- New route `GET /api/analytics/traffic` (`withAuth`, 5-min cache keyed by range/bin/filters).
- New `TrafficDashboard` client component; `/traffic` page now renders it.
- The simple `getTrafficData()` and the existing `/analytics` Traffic tab are **untouched** — zero risk to that surface.

## Out of scope (next PR — needs an ingestion change)
- **Per-tenant / host split** — pageview docs don't capture the host yet; sections approximate it via `/embed/<tenant>` only.
- **Human / bot / AI classification** — bots are dropped at `/api/track` today, so they're invisible; surfacing them needs a classified counter at ingestion.
- **Datadog-style latency/error/realtime panel** — leans on fixing `loading_metrics` (issue #2335).

## Test
- `npx tsc --noEmit` — no errors in changed files.
- Aggregation verified against production Mongo: 30d → 75,654 pageviews / 1,718 visitors, 31 daily buckets, sections breakdown correct (`/book` 18.7k, `/embed/bph` 6.5k, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)