### PR TITLE
feat(traffic): host/tenant split + human·bot·AI classification

### DIFF
--- a/src/app/api/analytics/traffic/route.ts
+++ b/src/app/api/analytics/traffic/route.ts
@@ -21,6 +21,7 @@ export const GET = withAuth(async (request: NextRequest) => {
       country: searchParams.get('country') || undefined,
       section: searchParams.get('section') || undefined,
       referrer: searchParams.get('referrer') || undefined,
+      host: searchParams.get('host') || undefined,
     };
 
     const cacheKey = JSON.stringify({ days, bin, filters });

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -1,15 +1,35 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { anonymizeIp } from '@/lib/anonymize-ip';
+import { classifyTraffic, type TrafficClass } from '@/lib/traffic-classification';
 
 const SITE_HOST = 'sourcelibrary.org';
 
-// Bot detection patterns
-const BOT_PATTERNS = /bot|crawler|spider|headlesschrome|googleother|vercel-screenshot|slurp|bingpreview|facebookexternalhit|twitterbot|linkedinbot|whatsapp|telegrambot|applebot|yandexbot|baiduspider|duckduckbot|semrush|ahrefs|mj12bot|dotbot|petalbot|bytespider/i;
+// Normalize the request host into a tenant-identifying key. Strips port and a
+// leading www.; falls back to the canonical site host.
+function resolveHost(request: NextRequest): string {
+  const raw = (request.headers.get('x-forwarded-host') || request.headers.get('host') || SITE_HOST)
+    .split(',')[0]
+    .trim()
+    .toLowerCase();
+  return raw.replace(/:\d+$/, '').replace(/^www\./, '') || SITE_HOST;
+}
 
-function isBot(userAgent: string | null | undefined): boolean {
-  if (!userAgent) return false;
-  return BOT_PATTERNS.test(userAgent);
+// Increment the compact per-day/host/class counter. This is the ONLY place
+// non-human traffic is recorded (bots/AI are not stored as full pageviews), and
+// because it's tiny + aggregated it carries no TTL — it's our long-term
+// human-vs-bot-vs-AI history, surviving the 90-day pageview TTL.
+async function recordClass(
+  db: Awaited<ReturnType<typeof getDb>>,
+  host: string,
+  cls: TrafficClass
+): Promise<void> {
+  const day = new Date().toISOString().slice(0, 10);
+  await db.collection('analytics_traffic_class').updateOne(
+    { _id: `${day}|${host}|${cls}` } as never,
+    { $inc: { count: 1 }, $setOnInsert: { day, host, class: cls } },
+    { upsert: true }
+  );
 }
 
 // Rate limiting: in-memory dedup cache (persists within a single serverless instance)
@@ -62,16 +82,6 @@ function exceedsIpCap(ip: string, ua: string): boolean {
   return s.count > IP_DAILY_CAP && s.uas.size <= 1;
 }
 
-// Cloudflare bot-management signals (we're behind CF). cf-verified-bot is
-// true for legit crawlers we don't want either; cf-threat-score is 0-100
-// (higher = worse). Drop anything CF already classifies as a bot.
-function isCloudflareBot(request: NextRequest): boolean {
-  if (request.headers.get('cf-verified-bot') === 'true') return true;
-  const threat = parseInt(request.headers.get('cf-threat-score') || '', 10);
-  if (Number.isFinite(threat) && threat >= 30) return true;
-  return false;
-}
-
 // DB write timeout — analytics is fire-and-forget, don't hold a serverless slot for 30s+
 const DB_TIMEOUT_MS = 3000;
 
@@ -84,22 +94,34 @@ export async function POST(request: NextRequest) {
     // Use server-side UA header as authoritative (client can be spoofed)
     const serverUA = request.headers.get('user-agent');
     const effectiveUA = serverUA || userAgent;
+    const host = resolveHost(request);
 
-    // Drop bot traffic entirely — no DB write
-    if (isBot(effectiveUA) || isCloudflareBot(request)) {
-      return NextResponse.json({ success: true });
-    }
+    // Cloudflare bot-management signals (we're behind CF).
+    const cfVerifiedBot = request.headers.get('cf-verified-bot') === 'true';
+    const cfThreat = parseInt(request.headers.get('cf-threat-score') || '', 10);
 
     const rawIp = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
     const ip = anonymizeIp(rawIp);
 
-    // Rate limit: same IP + path within 60s = skip
-    if (path && isDuplicate(ip, path)) {
+    // Spoofed-UA scrapers that pass the UA check are caught by the per-IP cap.
+    const rateCapped = exceedsIpCap(ip, effectiveUA || '');
+
+    const cls = classifyTraffic(effectiveUA, {
+      verifiedBot: cfVerifiedBot,
+      threatScore: Number.isFinite(cfThreat) ? cfThreat : undefined,
+      rateCapped,
+    });
+
+    // Non-human traffic: record the compact class counter only, no pageview.
+    if (cls !== 'human') {
+      const counted = (async () => { await recordClass(await getDb(), host, cls); })();
+      const timeout = new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), DB_TIMEOUT_MS));
+      await Promise.race([counted, timeout]);
       return NextResponse.json({ success: true });
     }
 
-    // Per-IP daily cap with UA-diversity check (drops spoofed-UA scrapers)
-    if (exceedsIpCap(ip, effectiveUA || '')) {
+    // Human: rate-limit same IP + path within 60s (don't double-count reloads).
+    if (path && isDuplicate(ip, path)) {
       return NextResponse.json({ success: true });
     }
 
@@ -124,14 +146,18 @@ export async function POST(request: NextRequest) {
     // don't hold a serverless function slot during DB degradation
     const dbWrite = (async () => {
       const db = await getDb();
-      await db.collection('analytics_pageviews').insertOne({
-        path,
-        referrer: referrerDomain,
-        country,
-        userAgent: (effectiveUA || userAgent)?.substring(0, 200),
-        timestamp: new Date(),
-        ip,
-      });
+      await Promise.all([
+        db.collection('analytics_pageviews').insertOne({
+          path,
+          referrer: referrerDomain,
+          country,
+          host,
+          userAgent: (effectiveUA || userAgent)?.substring(0, 200),
+          timestamp: new Date(),
+          ip,
+        }),
+        recordClass(db, host, 'human'),
+      ]);
     })();
 
     const timeout = new Promise<'timeout'>((resolve) =>

--- a/src/app/traffic/page.tsx
+++ b/src/app/traffic/page.tsx
@@ -30,7 +30,7 @@ export default function TrafficPage() {
               className="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors hover:opacity-80"
               style={{ background: 'var(--bg-warm)', color: 'var(--text-secondary)' }}
             >
-              Full analytics
+              Pipeline &amp; system
             </Link>
           </div>
         </div>
@@ -38,7 +38,7 @@ export default function TrafficPage() {
 
       <main className="max-w-7xl mx-auto px-6 py-8">
         <p className="text-sm mb-6" style={{ color: 'var(--text-muted)' }}>
-          First-party visitor data — collected server-side with anonymized IPs, no cookie consent required. The source of truth, independent of Google Analytics. Includes all subdomains (host-level split coming next).
+          First-party visitor data — collected server-side with anonymized IPs, no cookie consent required. The source of truth, independent of Google Analytics. Filter by subdomain under “Sites,” and see the human / bot / AI split (accruing from today).
         </p>
         <TrafficDashboard />
       </main>

--- a/src/components/analytics/TrafficDashboard.tsx
+++ b/src/components/analytics/TrafficDashboard.tsx
@@ -1,10 +1,22 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Users, Globe, BarChart3, X, ChevronRight } from 'lucide-react';
+import { Users, Globe, BarChart3, X, ChevronRight, Server, Bot } from 'lucide-react';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { AreaChart } from './charts/AreaChart';
 import type { TrafficDashboardData, TrafficBin } from '@/lib/analytics-traffic';
+import { TRAFFIC_CLASS_LABELS, type TrafficClass } from '@/lib/traffic-classification';
+
+type FilterKey = 'country' | 'section' | 'referrer' | 'host';
+
+// Display order + color for the human/bot/AI breakdown.
+const CLASS_ORDER: { key: TrafficClass; color: string }[] = [
+  { key: 'human', color: '#16a34a' },
+  { key: 'ai_agent', color: '#8b5cf6' },
+  { key: 'ai_trainer', color: '#a855f7' },
+  { key: 'search_crawler', color: '#3b82f6' },
+  { key: 'other_bot', color: '#94a3b8' },
+];
 
 const RANGES = [
   { days: 1, label: '24h' },
@@ -41,15 +53,15 @@ export default function TrafficDashboard() {
   const [days, setDays] = useState(30);
   const [bin, setBin] = useState<TrafficBin | 'auto'>('auto');
   const [metric, setMetric] = useState<Metric>('pageviews');
-  const [filters, setFilters] = useState<{ country?: string; section?: string; referrer?: string }>({});
+  const [filters, setFilters] = useState<Partial<Record<FilterKey, string>>>({});
 
   const fetchData = useCallback(() => {
     setLoading(true);
     const params = new URLSearchParams({ days: String(days) });
     if (bin !== 'auto') params.set('bin', bin);
-    if (filters.country) params.set('country', filters.country);
-    if (filters.section) params.set('section', filters.section);
-    if (filters.referrer) params.set('referrer', filters.referrer);
+    (['country', 'section', 'referrer', 'host'] as FilterKey[]).forEach(k => {
+      if (filters[k]) params.set(k, filters[k]!);
+    });
     fetch(`/api/analytics/traffic?${params.toString()}`)
       .then(r => (r.ok ? r.json() : null))
       .then(setData)
@@ -59,13 +71,13 @@ export default function TrafficDashboard() {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  const toggleFilter = (key: 'country' | 'section' | 'referrer', value: string) => {
+  const toggleFilter = (key: FilterKey, value: string) => {
     setFilters(f => ({ ...f, [key]: f[key] === value ? undefined : value }));
   };
 
-  const activeFilters = (['section', 'country', 'referrer'] as const)
+  const activeFilters = (['host', 'section', 'country', 'referrer'] as FilterKey[])
     .map(k => (filters[k] ? { key: k, value: filters[k]! } : null))
-    .filter(Boolean) as { key: 'country' | 'section' | 'referrer'; value: string }[];
+    .filter(Boolean) as { key: FilterKey; value: string }[];
 
   const card = { background: 'var(--bg-white)', border: '1px solid var(--border-light)' };
   const pill = (active: boolean) => ({
@@ -152,6 +164,18 @@ export default function TrafficDashboard() {
               delta={pctDelta(data.summary.visitors, data.summary.prevVisitors)}
               hint="approx — anonymized IP"
             />
+          </div>
+
+          {/* Sites + Human/bot/AI split */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <ListCard title="Sites" icon={<Server className="w-4 h-4" style={{ color: 'var(--accent-rust)' }} />} hint="click to filter by subdomain">
+              {data.sites.length === 0 ? <Empty /> : data.sites.map((s, i) => (
+                <Row key={i} label={s.host} count={s.count} unit="views"
+                  active={filters.host === s.host}
+                  onClick={s.host === '(pre-tracking)' ? undefined : () => toggleFilter('host', s.host)} />
+              ))}
+            </ListCard>
+            <ClassificationCard rows={data.classification} />
           </div>
 
           {/* Trend */}
@@ -270,4 +294,58 @@ function Row({ label, count, unit, active, onClick, drill }: {
 
 function Empty() {
   return <p className="text-sm py-2" style={{ color: 'var(--text-muted)' }}>None in this range</p>;
+}
+
+// Human vs bot vs AI. Counts come from the ingestion-time classifier, which
+// only starts accruing once this ships — so it's empty for prior history.
+function ClassificationCard({ rows }: { rows: { class: string; count: number }[] }) {
+  const byClass = new Map(rows.map(r => [r.class, r.count]));
+  const ordered = CLASS_ORDER.map(c => ({ ...c, count: byClass.get(c.key) ?? 0 }));
+  const total = ordered.reduce((sum, c) => sum + c.count, 0);
+  const aiCount = (byClass.get('ai_agent') ?? 0) + (byClass.get('ai_trainer') ?? 0);
+
+  return (
+    <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-medium flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+          <Bot className="w-4 h-4" style={{ color: 'var(--accent-violet)' }} />
+          Human · bot · AI
+        </h2>
+        {total > 0 && (
+          <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+            AI {Math.round((aiCount / total) * 100)}% of {total.toLocaleString('en-US')}
+          </span>
+        )}
+      </div>
+
+      {total === 0 ? (
+        <p className="text-sm py-2" style={{ color: 'var(--text-muted)' }}>
+          No classified traffic yet — this begins accruing now that ingestion records it.
+        </p>
+      ) : (
+        <>
+          {/* Proportion bar */}
+          <div className="flex w-full h-3 rounded-full overflow-hidden mb-4">
+            {ordered.filter(c => c.count > 0).map(c => (
+              <div key={c.key} style={{ width: `${(c.count / total) * 100}%`, background: c.color }}
+                title={`${TRAFFIC_CLASS_LABELS[c.key]}: ${c.count.toLocaleString('en-US')}`} />
+            ))}
+          </div>
+          <div className="space-y-1">
+            {ordered.map(c => (
+              <div key={c.key} className="flex items-center justify-between py-1">
+                <span className="flex items-center gap-2 text-sm" style={{ color: 'var(--text-primary)' }}>
+                  <span className="w-2.5 h-2.5 rounded-full" style={{ background: c.color }} />
+                  {TRAFFIC_CLASS_LABELS[c.key]}
+                </span>
+                <span className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                  {c.count.toLocaleString('en-US')} · {total > 0 ? Math.round((c.count / total) * 100) : 0}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
 }

--- a/src/lib/analytics-traffic.ts
+++ b/src/lib/analytics-traffic.ts
@@ -97,6 +97,7 @@ export interface TrafficFilters {
   country?: string;
   section?: string; // top-level section, e.g. '/book' or '/embed/bph'
   referrer?: string;
+  host?: string; // tenant subdomain, e.g. 'bph.sourcelibrary.org'
 }
 
 export interface TrafficDashboardData {
@@ -105,9 +106,13 @@ export interface TrafficDashboardData {
   summary: { pageviews: number; visitors: number; prevPageviews: number; prevVisitors: number };
   series: Array<{ bucket: string; pageviews: number; visitors: number }>;
   sections: Array<{ section: string; count: number }>;
+  sites: Array<{ host: string; count: number }>;
   topPages: Array<{ path: string; count: number }>;
   topReferrers: Array<{ referrer: string; count: number }>;
   topCountries: Array<{ country: string; count: number }>;
+  // Human vs bot vs AI, from the compact ingestion counter (not the pageview
+  // collection). Empty until traffic accrues after this feature ships.
+  classification: Array<{ class: string; count: number }>;
 }
 
 const MAX_DAYS = 90; // analytics_pageviews has a 90-day TTL — nothing older exists
@@ -156,6 +161,7 @@ export async function getTrafficDashboard(opts: {
   const baseMatch: Record<string, unknown> = { path: { $ne: null } };
   if (filters.country) baseMatch.country = filters.country;
   if (filters.referrer) baseMatch.referrer = filters.referrer;
+  if (filters.host) baseMatch.host = filters.host;
 
   const sectionMatch = filters.section ? [{ $match: { _section: filters.section } }] : [];
 
@@ -185,6 +191,12 @@ export async function getTrafficDashboard(opts: {
               { $group: { _id: '$_section', count: { $sum: 1 } } },
               { $sort: { count: -1 } },
               { $limit: 25 },
+            ],
+            sites: [
+              ...sectionMatch,
+              { $group: { _id: { $ifNull: ['$host', '(pre-tracking)'] }, count: { $sum: 1 } } },
+              { $sort: { count: -1 } },
+              { $limit: 10 },
             ],
             topPages: [
               ...sectionMatch,
@@ -227,6 +239,21 @@ export async function getTrafficDashboard(opts: {
     )
     .toArray();
 
+  // Human/bot/AI split from the compact per-day counter (separate collection,
+  // no TTL). Section/country/referrer filters don't apply here (the counter
+  // isn't per-pageview), but host does.
+  const sinceDay = since.toISOString().slice(0, 10);
+  const classMatch: Record<string, unknown> = { day: { $gte: sinceDay } };
+  if (filters.host) classMatch.host = filters.host;
+  const classRows = await db
+    .collection('analytics_traffic_class')
+    .aggregate([
+      { $match: classMatch },
+      { $group: { _id: '$class', count: { $sum: '$count' } } },
+      { $sort: { count: -1 } },
+    ])
+    .toArray();
+
   const totals = result?.totals?.[0] as { pageviews: number; ips: (string | null)[] } | undefined;
   const prevTotals = prev as { pageviews: number; ips: (string | null)[] } | undefined;
 
@@ -247,8 +274,10 @@ export async function getTrafficDashboard(opts: {
     sections: (result?.sections ?? [])
       .filter((s: { _id: string }) => s._id)
       .map((s: { _id: string; count: number }) => ({ section: s._id, count: s.count })),
+    sites: (result?.sites ?? []).map((s: { _id: string; count: number }) => ({ host: s._id, count: s.count })),
     topPages: (result?.topPages ?? []).map((p: { _id: string; count: number }) => ({ path: p._id, count: p.count })),
     topReferrers: (result?.topReferrers ?? []).map((r: { _id: string; count: number }) => ({ referrer: r._id, count: r.count })),
     topCountries: (result?.topCountries ?? []).map((c: { _id: string; count: number }) => ({ country: c._id, count: c.count })),
+    classification: (classRows as { _id: string; count: number }[]).map((c) => ({ class: c._id, count: c.count })),
   };
 }

--- a/src/lib/traffic-classification.ts
+++ b/src/lib/traffic-classification.ts
@@ -1,0 +1,58 @@
+/**
+ * Classify a request by user-agent (+ Cloudflare bot signals) into one of five
+ * traffic classes. Used at ingestion (`/api/track`) to answer "how much of the
+ * library is read by humans vs. crawlers vs. AI?" — a question GA can't, and
+ * one that matters when your content is exactly what AI wants to ingest.
+ *
+ * Order matters: AI agents/trainers often contain the substring "bot", so they
+ * must be matched before the generic search/other-bot patterns.
+ */
+
+export type TrafficClass =
+  | 'human'
+  | 'ai_trainer' // crawls to build/train AI models or AI search indexes
+  | 'ai_agent' // fetches live on behalf of a user (assistant browsing)
+  | 'search_crawler' // traditional search-engine indexers
+  | 'other_bot'; // SEO tools, scrapers, monitoring, CF-flagged, rate-capped
+
+export const TRAFFIC_CLASS_LABELS: Record<TrafficClass, string> = {
+  human: 'Humans',
+  ai_agent: 'AI agents (live)',
+  ai_trainer: 'AI crawlers',
+  search_crawler: 'Search engines',
+  other_bot: 'Other bots',
+};
+
+// AI assistants fetching a page live for a user (not bulk training crawls).
+const AI_AGENT = /chatgpt-user|oai-searchbot|perplexity-user|claude-user|claude-web|google-cloudvertexbot|duckassistbot|gemini-user/i;
+
+// Bulk crawlers feeding AI training sets or AI search indexes.
+const AI_TRAINER = /gptbot|ccbot|claudebot|anthropic-ai|google-extended|bytespider|amazonbot|applebot-extended|cohere-ai|diffbot|imagesiftbot|omgili|meta-externalagent|facebookbot|perplexitybot|youbot|webzio|timpibot|ai2bot|panscient/i;
+
+// Traditional search-engine indexers.
+const SEARCH_CRAWLER = /googlebot|googleother|bingbot|bingpreview|slurp|duckduckbot|baiduspider|yandexbot|applebot|seznambot|sogou|exabot/i;
+
+// Everything else automated: SEO tools, scrapers, monitors, generic libraries.
+const OTHER_BOT = /ahrefs|semrush|mj12bot|dotbot|petalbot|dataforseo|screaming frog|bot\b|crawler|spider|headlesschrome|python-requests|curl|wget|axios|go-http-client|java\/|okhttp|scrapy|httpclient/i;
+
+export function classifyTraffic(
+  userAgent: string | null | undefined,
+  cf?: { verifiedBot?: boolean; threatScore?: number; rateCapped?: boolean }
+): TrafficClass {
+  const ua = userAgent || '';
+
+  if (AI_AGENT.test(ua)) return 'ai_agent';
+  if (AI_TRAINER.test(ua)) return 'ai_trainer';
+  if (SEARCH_CRAWLER.test(ua)) return 'search_crawler';
+
+  // Spoofed-UA scrapers caught by the per-IP rate cap, or anything Cloudflare
+  // already classifies as a bot, falls here even if the UA looks human.
+  if (cf?.rateCapped) return 'other_bot';
+  if (OTHER_BOT.test(ua)) return 'other_bot';
+  if (cf?.verifiedBot) return 'other_bot';
+  if (typeof cf?.threatScore === 'number' && cf.threatScore >= 30) return 'other_bot';
+
+  // Empty UA is treated as human (matches prior ingestion behavior — too noisy
+  // to classify, and often legitimate privacy-tooling).
+  return 'human';
+}


### PR DESCRIPTION
## Why
Second analytics PR (the ingestion-side follow-up to the read-side foundations). Answers Derek's two questions: the dashboard *was* blending all tenants with no way to separate them, and it couldn't show human-vs-AI because bots were dropped at the door.

## What
- **Host / tenant split** — `/api/track` now records the request `host` (read server-side from `x-forwarded-host`/`host`, so it can't be spoofed) on each human pageview. New **Sites** card on `/traffic` filters the whole view by subdomain — EFM/BPH see their reading room; main-site numbers stop being inflated by partner traffic. (Only attributes traffic going forward; the existing 90-day history has no host and shows as `(pre-tracking)`.)
- **Human · bot · AI classification** — new `src/lib/traffic-classification.ts` buckets every request into `human` / `ai_agent` (live assistant fetches: ChatGPT-User, Claude-User…) / `ai_trainer` (GPTBot, ClaudeBot, CCBot, Google-Extended, PerplexityBot, Bytespider…) / `search_crawler` / `other_bot`. Bots are no longer silently dropped — they're tallied in a compact **per-day/host/class counter** (`analytics_traffic_class`). It carries **no TTL**, so it doubles as long-term history beyond the 90-day pageview TTL. New **Human · bot · AI** panel headlines "AI X% of N".
- **Label fix** — the `/traffic → "Full analytics"` link is renamed **"Pipeline & system"** (that page is system/pipeline observability, not visitor analytics).

## Design notes
- Bots add one tiny `$inc` upsert per hit (not a stored pageview row), so the human pageview collection stays clean and small. The counter is ~classes×hosts×days docs.
- Human pageview flow is unchanged except `host` is now stored; dedup/IP-cap untouched. Rate-capped spoofers count as `other_bot`.
- `getTrafficDashboard` gains a `host` filter + `sites` breakdown + `classification` array.

## Out of scope
- Datadog-style latency/error/realtime panel (needs `loading_metrics`, issue #2335).
- Backfilling host onto pre-existing pageviews (not recoverable — host wasn't captured).

## Test
- `npx tsc --noEmit` — clean on changed files.
- Classifier ordering unit-checked against 13 representative UAs (GPTBot→ai_trainer, ChatGPT-User→ai_agent, Googlebot→search, real browsers→human, Applebot vs Applebot-Extended): **13/13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)