### PR TITLE
feat(traffic): add "Clicks by source" card (distinct visitors per referrer)

### DIFF
--- a/src/components/analytics/TrafficDashboard.tsx
+++ b/src/components/analytics/TrafficDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Users, Globe, BarChart3, X, ChevronRight, Server, Bot } from 'lucide-react';
+import { Users, Globe, BarChart3, X, ChevronRight, Server, Bot, MousePointerClick } from 'lucide-react';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { AreaChart } from './charts/AreaChart';
 import type { TrafficDashboardData, TrafficBin } from '@/lib/analytics-traffic';
@@ -214,15 +214,30 @@ export default function TrafficDashboard() {
             </ListCard>
           </div>
 
-          {/* Referrers + Countries */}
+          {/* Clicks by source vs Traffic sources — distinct visitors vs pageviews */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <ListCard title="Traffic sources" hint="click to filter">
+            <ListCard
+              title="Clicks by source"
+              icon={<MousePointerClick className="w-4 h-4" style={{ color: 'var(--accent-violet)' }} />}
+              hint="distinct visitors · ~ Search Console clicks"
+            >
+              {data.clicksBySource.length === 0 ? <Empty /> : data.clicksBySource.map((r, i) => (
+                <Row key={i} label={r.referrer} count={r.count} unit="clicks"
+                  active={filters.referrer === r.referrer}
+                  onClick={() => toggleFilter('referrer', r.referrer)} />
+              ))}
+            </ListCard>
+            <ListCard title="Traffic sources" hint="pageviews · click to filter">
               {data.topReferrers.length === 0 ? <Empty /> : data.topReferrers.map((r, i) => (
                 <Row key={i} label={r.referrer} count={r.count} unit="views"
                   active={filters.referrer === r.referrer}
                   onClick={() => toggleFilter('referrer', r.referrer)} />
               ))}
             </ListCard>
+          </div>
+
+          {/* Countries */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <ListCard title="Countries" icon={<Globe className="w-4 h-4" style={{ color: 'var(--accent-sage)' }} />} hint="click to filter">
               {data.topCountries.length === 0 ? <Empty /> : data.topCountries.map((c, i) => (
                 <Row key={i} label={c.country} count={c.count} unit="views"

--- a/src/lib/analytics-traffic.ts
+++ b/src/lib/analytics-traffic.ts
@@ -109,6 +109,12 @@ export interface TrafficDashboardData {
   sites: Array<{ host: string; count: number }>;
   topPages: Array<{ path: string; count: number }>;
   topReferrers: Array<{ referrer: string; count: number }>;
+  // Clicks (= distinct visitors) per source, not pageviews. `referrer` is
+  // frozen at the visit's entry point and re-sent on every in-app navigation,
+  // so topReferrers above counts every page a visitor reads under their
+  // arrival source. Deduping by anonymized IP collapses that back to one
+  // "click" per visitor, which is the number comparable to Search Console.
+  clicksBySource: Array<{ referrer: string; count: number }>;
   topCountries: Array<{ country: string; count: number }>;
   // Human vs bot vs AI, from the compact ingestion counter (not the pageview
   // collection). Empty until traffic accrues after this feature ships.
@@ -211,6 +217,15 @@ export async function getTrafficDashboard(opts: {
               { $sort: { count: -1 } },
               { $limit: 10 },
             ],
+            clicksBySource: [
+              ...sectionMatch,
+              { $match: { referrer: { $nin: [null, '', 'direct'] } } },
+              // Dedupe to one click per distinct visitor (anonymized IP) per source.
+              { $group: { _id: '$referrer', ips: { $addToSet: '$ip' } } },
+              { $project: { count: { $size: '$ips' } } },
+              { $sort: { count: -1 } },
+              { $limit: 10 },
+            ],
             topCountries: [
               ...sectionMatch,
               { $match: { country: { $nin: [null, '', 'Unknown'] } } },
@@ -277,6 +292,7 @@ export async function getTrafficDashboard(opts: {
     sites: (result?.sites ?? []).map((s: { _id: string; count: number }) => ({ host: s._id, count: s.count })),
     topPages: (result?.topPages ?? []).map((p: { _id: string; count: number }) => ({ path: p._id, count: p.count })),
     topReferrers: (result?.topReferrers ?? []).map((r: { _id: string; count: number }) => ({ referrer: r._id, count: r.count })),
+    clicksBySource: (result?.clicksBySource ?? []).map((r: { _id: string; count: number }) => ({ referrer: r._id, count: r.count })),
     topCountries: (result?.topCountries ?? []).map((c: { _id: string; count: number }) => ({ country: c._id, count: c.count })),
     classification: (classRows as { _id: string; count: number }[]).map((c) => ({ class: c._id, count: c.count })),
   };


### PR DESCRIPTION
## What

Adds a **Clicks by source** card to the `/traffic` dashboard, beside the existing **Traffic sources** card.

- **Traffic sources** = pageviews per referrer (unchanged).
- **Clicks by source** = distinct visitors (deduped anonymized IP) per referrer.

## Why

`document.referrer` is frozen at a visit's entry point and re-sent on every in-app navigation (`PageTracker` fires on each `pathname` change). So one visitor who arrives from Google and reads a multi-page book inflates the `google.com` pageview count by every page they view. Concretely, the dashboard showed ~4,359 `google.com` "views" while Search Console reported ~45 clicks for the same window.

Deduping by visitor (anonymized IP) per referrer collapses that back to roughly one "click" per arrival, which is the number actually comparable to Search Console. Showing both side by side makes the clicks-vs-views distinction legible instead of misleading.

## Changes

- `src/lib/analytics-traffic.ts` — new `clicksBySource` facet in `getTrafficDashboard` (`$addToSet` IPs per referrer → `$size`), added to `TrafficDashboardData`.
- `src/components/analytics/TrafficDashboard.tsx` — new card; Countries moved to its own row.

## Scope / out of scope

- **In scope:** read-only dashboard addition. No tracking/ingestion changes, no DB writes, no new deps.
- **Out of scope (deliberately):** the underlying tracking issue — `PageTracker` should arguably only attach the external referrer to the *first* pageview of a visit and mark subsequent in-app navigations as internal. That's a behavior change to ingestion and belongs in its own PR. This card works correctly against existing data without it.
- "Clicks" here is a per-window distinct-visitor count (anonymized IP), so it shares the same approximation caveat as the existing "Unique visitors" summary.

## Notes

`tsc --noEmit` was not run locally (no `node_modules` in this checkout); relying on CI + the Vercel build. Change is dependency-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)