### PR TITLE
fix(reader): preserve query string on page-number redirect

### DIFF
--- a/src/app/book/[id]/page-number/[num]/route.ts
+++ b/src/app/book/[id]/page-number/[num]/route.ts
@@ -39,5 +39,8 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 
   const pageId = page.id || page._id?.toString();
   const destination = new URL(`/book/${bookSlug}/page/${pageId}`, request.url);
+  // Preserve the incoming query string (e.g. ?highlight=, ?v=) so search-result
+  // links that land here still highlight/pin on the resolved page reader.
+  destination.search = request.nextUrl.search;
   return NextResponse.redirect(destination, 308);
 }


### PR DESCRIPTION
## What

The `/book/[id]/page-number/[num]` route 308-redirects to the canonical `/book/[id]/page/[pageId]` reader URL, but it built the destination with `new URL(path, request.url)` and **dropped the query string**. So a link like `…/page-number/11?highlight=Mercury` redirected to `…/page/<id>` with no `?highlight=`, and the reader's `useSearchHighlight` had nothing to act on — the search term never highlighted or scrolled into view. Same loss for `?v=` citation-version pins.

Fix: copy `request.nextUrl.search` onto the redirect destination so all query params survive the 308.

## Why it surfaced

Chasing a 'book not found' report on a search→reader link. The direct `/page/[pageId]?highlight=` form (what in-book search currently emits) already works; this hardens the by-page-number path so it highlights too.

## Scope

One line in one route handler. No behavior change for requests without a query string. Out of scope: the separate observation that the in-book search API returns the Mongo `_id` as `pageId` while the reader looks pages up by their `id` field (same value for current data; left as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)