### PR TITLE
feat(harvest): IIIF manifest harvest layer — Biblissima + Europeana → ledger → triage (#2357)

### DIFF
--- a/scripts/research/biblissima-harvest.mjs
+++ b/scripts/research/biblissima-harvest.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+/**
+ * Biblissima IIIF manifest harvester  (issue #2357, stage 1)
+ *
+ * Biblissima (https://iiif.biblissima.fr/collections) aggregates pre-1800
+ * MANUSCRIPTS + RARE BOOKS from 40+ libraries — our exact domain — already
+ * normalized. Its search HTML embeds the ORIGINAL provider's manifest URL on
+ * each result card, so harvesting is a plain HTML scrape (no API key, no SPARQL):
+ *
+ *   <li class="result ... cart-item"
+ *       data-id="<sha1>"                      stable id
+ *       data-thumbnail="…"                     thumb
+ *       data-shelfmark="Paris. BnF … Latin …"  label / holding institution
+ *       data-manifest="https://gallica.bnf.fr/iiif/ark:/12148/…/manifest.json">
+ *
+ * The manifest URL points back at the source library (Gallica, IRHT, Sorbonne,
+ * BSB, Bodleian, …) — Biblissima is purely the DISCOVERY layer; page images are
+ * still fetched from the original provider at import time.
+ *
+ * Flow (this script = harvest only): query our subject terms → scrape every
+ * result card → coarse-dedup against our Mongo catalog → upsert into the
+ * `harvest_candidates` ledger as decision:'pending'. Triage + promote are
+ * separate stages (see issue #2357).
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/research/biblissima-harvest.mjs               # DRY RUN (writes JSON only)
+ *   node scripts/research/biblissima-harvest.mjs --limit 2     # only first 2 queries
+ *   node scripts/research/biblissima-harvest.mjs --commit      # upsert into Mongo harvest_candidates
+ *   node scripts/research/biblissima-harvest.mjs --q alchimie  # single ad-hoc query
+ *
+ * Output (dry run): scripts/research/output/biblissima-candidates.json
+ */
+
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const OUT = join(__dir, 'output');
+mkdirSync(OUT, { recursive: true });
+
+const BASE = 'https://iiif.biblissima.fr/collections/search';
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
+const DELAY_MS = 400; // be polite to Biblissima
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── args ──────────────────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+const COMMIT = argv.includes('--commit');
+const flag = (name) => { const i = argv.indexOf(name); return i >= 0 ? argv[i + 1] : null; };
+const LIMIT = flag('--limit') ? Number(flag('--limit')) : null;
+const AD_HOC = flag('--q');
+
+// Domain subject terms (FR is most productive on this French-led corpus; + EN + Latin).
+// Keep curated — each term is one paginated crawl.
+const QUERIES = AD_HOC ? [AD_HOC] : [
+  'alchimie', 'alchemy', 'alchemia',
+  'hermétisme', 'hermes trismegiste', 'hermetica', 'mercurius trismegistus',
+  'kabbale', 'cabale', 'kabbalah', 'cabala',
+  'rose-croix', 'rosicrucian', 'rosae crucis',
+  'astrologie', 'astrology', 'astrologia',
+  'magie', 'magia', 'philosophia occulta',
+  'paracelse', 'paracelsus',
+  'lullisme', 'ars notoria', 'géomancie', 'talisman',
+];
+
+// ── provider mapping from the manifest host ─────────────────────────────────
+function providerFromManifest(url) {
+  let host = '';
+  try { host = new URL(url).host; } catch { return { provider: 'unknown', source_library: 'Unknown' }; }
+  const map = [
+    [/gallica\.bnf\.fr/, 'gallica', 'Bibliothèque nationale de France'],
+    [/irht\.cnrs\.fr/, 'irht', 'IRHT (CNRS)'],
+    [/bis-sorbonne\.fr/, 'sorbonne', 'Bibliothèque interuniversitaire de la Sorbonne'],
+    [/digitale-sammlungen\.de/, 'bsb', 'Bayerische Staatsbibliothek'],
+    [/bodleian|digital\.bodleian/, 'bodleian', 'Bodleian Library'],
+    [/teca\.bmlonline|bmlonline/, 'laurenziana', 'Biblioteca Medicea Laurenziana'],
+    [/digi\.ub\.uni-heidelberg/, 'heidelberg', 'Heidelberg University Library'],
+    [/purl\.pt|bnportugal|bnd\.bn\.pt/, 'bnp', 'Biblioteca Nacional de Portugal'],
+  ];
+  for (const [re, provider, lib] of map) if (re.test(host)) return { provider, source_library: lib };
+  return { provider: host.replace(/^www\./, ''), source_library: host };
+}
+
+// ── parse one search-results HTML page ──────────────────────────────────────
+function parseResults(html) {
+  const out = [];
+  // each result card is an <li class="result ... cart-item" data-*="...">
+  const re = /<li[^>]*class="[^"]*\bresult\b[^"]*"[^>]*>/g;
+  let m;
+  while ((m = re.exec(html))) {
+    const tag = m[0];
+    const attr = (name) => {
+      const a = tag.match(new RegExp(`data-${name}="([^"]*)"`));
+      return a ? a[1].replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, "'") : null;
+    };
+    const manifest = attr('manifest');
+    if (!manifest) continue;
+    out.push({
+      biblissima_id: attr('id'),
+      manifest_url: manifest,
+      shelfmark: attr('shelfmark'),
+      thumbnail: attr('thumbnail'),
+    });
+  }
+  return out;
+}
+
+function totalResults(html) {
+  const m = html.match(/<h2>\s*([\d.,\s]+)\s*results?\s*<\/h2>/i) || html.match(/([\d.,\s]+)\s+results? found/i);
+  return m ? Number(m[1].replace(/[.,\s]/g, '')) : null;
+}
+
+const PAGE_SIZE = 20; // Biblissima paginates via &from=<offset> in steps of 20
+
+async function fetchPage(query, page) {
+  const from = (page - 1) * PAGE_SIZE;
+  const url = `${BASE}?q=${encodeURIComponent(query)}${from > 0 ? `&from=${from}` : ''}`;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': UA } });
+      if (res.ok) return await res.text();
+      if (res.status === 404 || res.status === 400) return null;
+    } catch (e) { /* retry */ }
+    await sleep(DELAY_MS * (attempt + 1));
+  }
+  return null;
+}
+
+async function harvestQuery(query) {
+  const seen = new Set();
+  const items = [];
+  let total = null;
+  for (let page = 1; page <= 200; page++) {
+    const html = await fetchPage(query, page);
+    if (!html) break;
+    if (page === 1) total = totalResults(html);
+    const rows = parseResults(html);
+    if (rows.length === 0) break;
+    let added = 0;
+    for (const r of rows) {
+      const key = r.manifest_url;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      items.push({ ...r, ...providerFromManifest(r.manifest_url) });
+      added++;
+    }
+    process.stdout.write(`\r  q="${query}"  page ${page}  (+${added}, total seen ${items.length}${total ? `/${total}` : ''})   `);
+    if (total && items.length >= total) break;
+    if (added === 0) break; // no new manifests on this page
+    await sleep(DELAY_MS);
+  }
+  process.stdout.write('\n');
+  return { query, total, items };
+}
+
+// ── coarse dedup against our catalog (manifest/ark match) ───────────────────
+function arkOf(url = '') {
+  const m = url.match(/ark:\/[^/]+\/[^/?#]+/);
+  return m ? m[0] : null;
+}
+
+async function main() {
+  console.log(`Biblissima harvest — ${COMMIT ? 'COMMIT (Mongo)' : 'DRY RUN (JSON only)'} — ${QUERIES.length} queries`);
+
+  // Build candidates across all queries (dedupe by manifest URL across queries,
+  // tracking which subject terms surfaced each one).
+  const byManifest = new Map();
+  const queryList = LIMIT ? QUERIES.slice(0, LIMIT) : QUERIES;
+  for (const q of queryList) {
+    const { items } = await harvestQuery(q);
+    for (const it of items) {
+      const existing = byManifest.get(it.manifest_url);
+      if (existing) { existing.subjects.add(q); continue; }
+      byManifest.set(it.manifest_url, { ...it, subjects: new Set([q]) });
+    }
+  }
+
+  const candidates = [...byManifest.values()].map((c) => ({
+    _id: c.biblissima_id || arkOf(c.manifest_url) || c.manifest_url,
+    provider: c.provider,
+    source_library: c.source_library,
+    manifest_url: c.manifest_url,
+    source_uri: c.manifest_url.replace(/\/manifest(\.json)?$/, ''),
+    label: c.shelfmark,           // shelfmark; true work-title comes from the manifest at promote time
+    thumbnail: c.thumbnail,
+    ark: arkOf(c.manifest_url),
+    subjects: [...c.subjects],
+    aggregator: 'biblissima',
+    dedup_status: 'unchecked',
+    matched_book_id: null,
+    decision: 'pending',
+    reason: null,
+    imported_book_id: null,
+  }));
+
+  console.log(`\nHarvested ${candidates.length} unique manifests across ${queryList.length} queries.`);
+  const byProv = {};
+  for (const c of candidates) byProv[c.provider] = (byProv[c.provider] || 0) + 1;
+  console.log('By provider:', Object.entries(byProv).sort((a, b) => b[1] - a[1]).map(([p, n]) => `${p}:${n}`).join('  '));
+
+  // Coarse dedup: do we already hold this ARK / manifest?
+  let client;
+  if (process.env.MONGODB_URI) {
+    client = new MongoClient(process.env.MONGODB_URI);
+    await client.connect();
+    const db = client.db('bookstore');
+    const arks = candidates.map((c) => c.ark).filter(Boolean);
+    const owned = await db.collection('books').find(
+      { $or: [
+        { 'image_source.source_url': { $regex: '(ark:|/iiif/)', $options: 'i' } },
+        { iiif_manifest: { $exists: true } },
+      ] },
+      { projection: { iiif_manifest: 1, 'image_source.source_url': 1 } },
+    ).toArray();
+    const ownedArks = new Set();
+    for (const b of owned) {
+      for (const u of [b.iiif_manifest, b.image_source?.source_url]) {
+        const a = arkOf(u || ''); if (a) ownedArks.add(a);
+      }
+    }
+    let dupes = 0;
+    for (const c of candidates) {
+      if (c.ark && ownedArks.has(c.ark)) { c.dedup_status = 'duplicate'; dupes++; }
+      else c.dedup_status = 'novel';
+    }
+    console.log(`Dedup vs catalog: ${dupes} already held (by ARK), ${candidates.length - dupes} novel.`);
+
+    if (COMMIT) {
+      const col = db.collection('harvest_candidates');
+      await col.createIndex({ manifest_url: 1 }, { unique: true }).catch(() => {});
+      await col.createIndex({ decision: 1, provider: 1 });
+      const now = new Date();
+      const ops = candidates.map((c) => ({
+        updateOne: {
+          filter: { _id: c._id },
+          update: {
+            $set: { ...c, harvested_at: now },
+            $setOnInsert: { first_seen: now },
+          },
+          upsert: true,
+        },
+      }));
+      const res = await col.bulkWrite(ops, { ordered: false });
+      console.log(`Upserted: ${res.upsertedCount} new, ${res.modifiedCount} updated in harvest_candidates.`);
+      // record harvest state per query
+      const state = db.collection('harvest_state');
+      await state.updateOne(
+        { _id: 'biblissima' },
+        { $set: { last_run_at: now, queries: queryList, candidate_count: candidates.length } },
+        { upsert: true },
+      );
+    }
+    await client.close();
+  } else {
+    console.log('(no MONGODB_URI — skipping dedup; source .env.production.local for the dedup pass)');
+  }
+
+  if (!COMMIT) {
+    const path = join(OUT, 'biblissima-candidates.json');
+    writeFileSync(path, JSON.stringify({ harvested_at: new Date().toISOString(), queries: queryList, count: candidates.length, candidates }, null, 2));
+    console.log(`\nDRY RUN — wrote ${candidates.length} candidates to ${path}`);
+    console.log('Re-run with --commit to upsert into Mongo harvest_candidates.');
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/research/biblissima-harvest.mjs
+++ b/scripts/research/biblissima-harvest.mjs
@@ -36,6 +36,7 @@ import { MongoClient } from 'mongodb';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeCandidate, upsertCandidates, recordRun, arkOf } from './lib/harvest-store.mjs';
 
 const __dir = dirname(fileURLToPath(import.meta.url));
 const OUT = join(__dir, 'output');
@@ -66,24 +67,6 @@ const QUERIES = AD_HOC ? [AD_HOC] : [
   'paracelse', 'paracelsus',
   'lullisme', 'ars notoria', 'géomancie', 'talisman',
 ];
-
-// ── provider mapping from the manifest host ─────────────────────────────────
-function providerFromManifest(url) {
-  let host = '';
-  try { host = new URL(url).host; } catch { return { provider: 'unknown', source_library: 'Unknown' }; }
-  const map = [
-    [/gallica\.bnf\.fr/, 'gallica', 'Bibliothèque nationale de France'],
-    [/irht\.cnrs\.fr/, 'irht', 'IRHT (CNRS)'],
-    [/bis-sorbonne\.fr/, 'sorbonne', 'Bibliothèque interuniversitaire de la Sorbonne'],
-    [/digitale-sammlungen\.de/, 'bsb', 'Bayerische Staatsbibliothek'],
-    [/bodleian|digital\.bodleian/, 'bodleian', 'Bodleian Library'],
-    [/teca\.bmlonline|bmlonline/, 'laurenziana', 'Biblioteca Medicea Laurenziana'],
-    [/digi\.ub\.uni-heidelberg/, 'heidelberg', 'Heidelberg University Library'],
-    [/purl\.pt|bnportugal|bnd\.bn\.pt/, 'bnp', 'Biblioteca Nacional de Portugal'],
-  ];
-  for (const [re, provider, lib] of map) if (re.test(host)) return { provider, source_library: lib };
-  return { provider: host.replace(/^www\./, ''), source_library: host };
-}
 
 // ── parse one search-results HTML page ──────────────────────────────────────
 function parseResults(html) {
@@ -145,7 +128,7 @@ async function harvestQuery(query) {
       const key = r.manifest_url;
       if (seen.has(key)) continue;
       seen.add(key);
-      items.push({ ...r, ...providerFromManifest(r.manifest_url) });
+      items.push(r);
       added++;
     }
     process.stdout.write(`\r  q="${query}"  page ${page}  (+${added}, total seen ${items.length}${total ? `/${total}` : ''})   `);
@@ -157,17 +140,12 @@ async function harvestQuery(query) {
   return { query, total, items };
 }
 
-// ── coarse dedup against our catalog (manifest/ark match) ───────────────────
-function arkOf(url = '') {
-  const m = url.match(/ark:\/[^/]+\/[^/?#]+/);
-  return m ? m[0] : null;
-}
-
 async function main() {
   console.log(`Biblissima harvest — ${COMMIT ? 'COMMIT (Mongo)' : 'DRY RUN (JSON only)'} — ${QUERIES.length} queries`);
 
   // Build candidates across all queries (dedupe by manifest URL across queries,
-  // tracking which subject terms surfaced each one).
+  // tracking which subject terms surfaced each one). Discovery only — dedup vs
+  // the catalog and title recovery happen in the triage stage.
   const byManifest = new Map();
   const queryList = LIMIT ? QUERIES.slice(0, LIMIT) : QUERIES;
   for (const q of queryList) {
@@ -179,22 +157,13 @@ async function main() {
     }
   }
 
-  const candidates = [...byManifest.values()].map((c) => ({
-    _id: c.biblissima_id || arkOf(c.manifest_url) || c.manifest_url,
-    provider: c.provider,
-    source_library: c.source_library,
+  const candidates = [...byManifest.values()].map((c) => makeCandidate({
+    id: c.biblissima_id || arkOf(c.manifest_url) || c.manifest_url,
     manifest_url: c.manifest_url,
-    source_uri: c.manifest_url.replace(/\/manifest(\.json)?$/, ''),
-    label: c.shelfmark,           // shelfmark; true work-title comes from the manifest at promote time
+    label: c.shelfmark, // shelfmark; real work-title is recovered in triage
     thumbnail: c.thumbnail,
-    ark: arkOf(c.manifest_url),
-    subjects: [...c.subjects],
     aggregator: 'biblissima',
-    dedup_status: 'unchecked',
-    matched_book_id: null,
-    decision: 'pending',
-    reason: null,
-    imported_book_id: null,
+    subjects: [...c.subjects],
   }));
 
   console.log(`\nHarvested ${candidates.length} unique manifests across ${queryList.length} queries.`);
@@ -202,64 +171,16 @@ async function main() {
   for (const c of candidates) byProv[c.provider] = (byProv[c.provider] || 0) + 1;
   console.log('By provider:', Object.entries(byProv).sort((a, b) => b[1] - a[1]).map(([p, n]) => `${p}:${n}`).join('  '));
 
-  // Coarse dedup: do we already hold this ARK / manifest?
-  let client;
-  if (process.env.MONGODB_URI) {
-    client = new MongoClient(process.env.MONGODB_URI);
+  if (COMMIT) {
+    const client = new MongoClient(process.env.MONGODB_URI);
     await client.connect();
     const db = client.db('bookstore');
-    const arks = candidates.map((c) => c.ark).filter(Boolean);
-    const owned = await db.collection('books').find(
-      { $or: [
-        { 'image_source.source_url': { $regex: '(ark:|/iiif/)', $options: 'i' } },
-        { iiif_manifest: { $exists: true } },
-      ] },
-      { projection: { iiif_manifest: 1, 'image_source.source_url': 1 } },
-    ).toArray();
-    const ownedArks = new Set();
-    for (const b of owned) {
-      for (const u of [b.iiif_manifest, b.image_source?.source_url]) {
-        const a = arkOf(u || ''); if (a) ownedArks.add(a);
-      }
-    }
-    let dupes = 0;
-    for (const c of candidates) {
-      if (c.ark && ownedArks.has(c.ark)) { c.dedup_status = 'duplicate'; dupes++; }
-      else c.dedup_status = 'novel';
-    }
-    console.log(`Dedup vs catalog: ${dupes} already held (by ARK), ${candidates.length - dupes} novel.`);
-
-    if (COMMIT) {
-      const col = db.collection('harvest_candidates');
-      await col.createIndex({ manifest_url: 1 }, { unique: true }).catch(() => {});
-      await col.createIndex({ decision: 1, provider: 1 });
-      const now = new Date();
-      const ops = candidates.map((c) => ({
-        updateOne: {
-          filter: { _id: c._id },
-          update: {
-            $set: { ...c, harvested_at: now },
-            $setOnInsert: { first_seen: now },
-          },
-          upsert: true,
-        },
-      }));
-      const res = await col.bulkWrite(ops, { ordered: false });
-      console.log(`Upserted: ${res.upsertedCount} new, ${res.modifiedCount} updated in harvest_candidates.`);
-      // record harvest state per query
-      const state = db.collection('harvest_state');
-      await state.updateOne(
-        { _id: 'biblissima' },
-        { $set: { last_run_at: now, queries: queryList, candidate_count: candidates.length } },
-        { upsert: true },
-      );
-    }
+    const now = new Date();
+    const res = await upsertCandidates(db, candidates, now);
+    await recordRun(db, 'biblissima', { queries: queryList, candidate_count: candidates.length }, now);
+    console.log(`Upserted: ${res.upserted} new, ${res.modified} updated in harvest_candidates. Run triage next.`);
     await client.close();
   } else {
-    console.log('(no MONGODB_URI — skipping dedup; source .env.production.local for the dedup pass)');
-  }
-
-  if (!COMMIT) {
     const path = join(OUT, 'biblissima-candidates.json');
     writeFileSync(path, JSON.stringify({ harvested_at: new Date().toISOString(), queries: queryList, count: candidates.length, candidates }, null, 2));
     console.log(`\nDRY RUN — wrote ${candidates.length} candidates to ${path}`);

--- a/scripts/research/europeana-harvest.mjs
+++ b/scripts/research/europeana-harvest.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Europeana manifest harvester  (issue #2357) — second aggregator into the
+ * same `harvest_candidates` ledger. Continuous + decoupled from import.
+ *
+ * Europeana is huge (50M+ items of all European heritage), so unlike Biblissima
+ * we DON'T crawl a corpus — we run subject-scoped queries via the Search API and
+ * keep only digitised TEXT items that expose a IIIF manifest.
+ *
+ * Requires an API key:  EUROPEANA_API_KEY  (free, https://pro.europeana.eu/page/get-api)
+ *
+ *   Search:   https://api.europeana.eu/record/v2/search.json?wskey=KEY&query=…&rows=100&cursor=*
+ *   Manifest: https://iiif.europeana.eu/presentation{recordId}/manifest   (recordId = item.id, leading /)
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/research/europeana-harvest.mjs              # DRY RUN
+ *   node scripts/research/europeana-harvest.mjs --commit
+ *   node scripts/research/europeana-harvest.mjs --q alchemy --commit
+ */
+
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeCandidate, upsertCandidates, recordRun } from './lib/harvest-store.mjs';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const OUT = join(__dir, 'output');
+mkdirSync(OUT, { recursive: true });
+
+const KEY = process.env.EUROPEANA_API_KEY;
+const SEARCH = 'https://api.europeana.eu/record/v2/search.json';
+const MANIFEST = (id) => `https://iiif.europeana.eu/presentation${id}/manifest`;
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
+const DELAY_MS = 350;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const argv = process.argv.slice(2);
+const COMMIT = argv.includes('--commit');
+const flag = (n) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : null; };
+const LIMIT = flag('--limit') ? Number(flag('--limit')) : null;
+const AD_HOC = flag('--q');
+const MAX_PER_QUERY = flag('--max') ? Number(flag('--max')) : 600;
+
+const QUERIES = AD_HOC ? [AD_HOC] : [
+  'alchemy', 'alchimie', 'alchemia',
+  'hermetica', 'hermeticism', 'hermes trismegistus',
+  'kabbalah', 'cabala', 'kabbale',
+  'rosicrucian', 'rose-croix',
+  'astrology', 'astrologia', 'paracelsus',
+  'occult philosophy', 'ars magica', 'talisman',
+];
+
+const first = (v) => (Array.isArray(v) ? v[0] : v) || null;
+
+async function fetchJson(url) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': UA } });
+      if (res.ok) return await res.json();
+      if (res.status === 429) { await sleep(2000 * (attempt + 1)); continue; }
+      return null;
+    } catch { await sleep(800 * (attempt + 1)); }
+  }
+  return null;
+}
+
+async function harvestQuery(query) {
+  const items = [];
+  let cursor = '*';
+  while (cursor && items.length < MAX_PER_QUERY) {
+    const url = `${SEARCH}?wskey=${KEY}&query=${encodeURIComponent(query)}`
+      + `&qf=TYPE:TEXT&media=true&rows=100&profile=rich&cursor=${encodeURIComponent(cursor)}`;
+    const json = await fetchJson(url);
+    if (!json || !json.items?.length) break;
+    for (const it of json.items) {
+      // keep only items that carry / can carry a IIIF manifest
+      const id = it.id; // e.g. "/2021803/oai_..."
+      if (!id) continue;
+      items.push(makeCandidate({
+        id: `europeana${id}`,
+        manifest_url: MANIFEST(id),
+        source_uri: first(it.edmIsShownAt) || `https://www.europeana.eu/item${id}`,
+        label: first(it.title) || first(it.dcTitleLangAware?.def),
+        thumbnail: first(it.edmPreview),
+        aggregator: 'europeana',
+        subjects: [query],
+        language: first(it.dcLanguage),
+        source_library: first(it.dataProvider) || first(it.edmDataProvider),
+      }));
+    }
+    cursor = json.nextCursor || null;
+    process.stdout.write(`\r  q="${query}"  ${items.length} items${cursor ? ' …' : ''}   `);
+    await sleep(DELAY_MS);
+  }
+  process.stdout.write('\n');
+  return items;
+}
+
+async function main() {
+  if (!KEY) {
+    console.error('EUROPEANA_API_KEY not set. Get a free key at https://pro.europeana.eu/page/get-api,');
+    console.error('add it to .env.production.local, then: set -a; source .env.production.local; set +a');
+    process.exit(1);
+  }
+  console.log(`Europeana harvest — ${COMMIT ? 'COMMIT' : 'DRY RUN'} — ${QUERIES.length} queries`);
+  const queryList = LIMIT ? QUERIES.slice(0, LIMIT) : QUERIES;
+
+  const byUrl = new Map();
+  for (const q of queryList) {
+    for (const c of await harvestQuery(q)) {
+      const ex = byUrl.get(c.manifest_url);
+      if (ex) { ex.subjects = [...new Set([...ex.subjects, ...c.subjects])]; continue; }
+      byUrl.set(c.manifest_url, c);
+    }
+  }
+  const candidates = [...byUrl.values()];
+  console.log(`\nHarvested ${candidates.length} unique Europeana manifests.`);
+
+  if (COMMIT) {
+    const client = new MongoClient(process.env.MONGODB_URI);
+    await client.connect();
+    const db = client.db('bookstore');
+    const now = new Date();
+    const res = await upsertCandidates(db, candidates, now);
+    await recordRun(db, 'europeana', { queries: queryList, candidate_count: candidates.length }, now);
+    console.log(`Upserted: ${res.upserted} new, ${res.modified} updated.`);
+    await client.close();
+  } else {
+    const path = join(OUT, 'europeana-candidates.json');
+    writeFileSync(path, JSON.stringify({ count: candidates.length, candidates }, null, 2));
+    console.log(`DRY RUN — wrote ${candidates.length} to ${path}. Re-run with --commit.`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/research/harvest-triage.mjs
+++ b/scripts/research/harvest-triage.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Harvest triage  (issue #2357, stage 2) — the consumer half, decoupled from import.
+ *
+ * Reads `harvest_candidates`, fetches each candidate's IIIF manifest to recover
+ * the real work TITLE / author / date / language / canvas count (the harvest
+ * stage only has shelfmarks), then:
+ *   - dedups against the Mongo catalog by ARK *and* normalized title+author
+ *     (mirror of src/lib/dedup.ts)
+ *   - scores domain relevance (weighted by the subject terms that surfaced it
+ *     + a keyword pass over the recovered title)
+ *   - suggests a decision: duplicates → skip; weak-subject → skip; else stays
+ *     `pending` for curator review. Never auto-sets `import`.
+ *
+ * Continuous + resumable: only touches rows with dedup_status:'unchecked' unless
+ * --reenrich. Import is a SEPARATE downstream step that draws from this ledger.
+ *
+ * NOTE: manifest fetches hit the original provider. Gallica/Harvard 429 datacenter
+ * IPs — run from a residential IP or keep CONCURRENCY low. Polite + retried.
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/research/harvest-triage.mjs --limit 50        # DRY RUN
+ *   node scripts/research/harvest-triage.mjs --commit          # write back to ledger
+ *   node scripts/research/harvest-triage.mjs --reenrich --commit
+ */
+
+import { MongoClient } from 'mongodb';
+import { arkOf } from './lib/harvest-store.mjs';
+
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
+const CONCURRENCY = 4;
+const argv = process.argv.slice(2);
+const COMMIT = argv.includes('--commit');
+const REENRICH = argv.includes('--reenrich');
+const flag = (n) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : null; };
+const LIMIT = flag('--limit') ? Number(flag('--limit')) : null;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── normalization: mirror of src/lib/dedup.ts (keep in sync) ────────────────
+function normalizeTitle(title = '') {
+  return title.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i, '')
+    .replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i, '')
+    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+}
+function normalizeAuthor(author = '') {
+  const cleaned = author.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g, '')
+    .replace(/\s*\([\d\s\-–,?.]+\)\s*/g, '')
+    .replace(/,\s*[\d\s\-–?.]+$/, '')
+    .replace(/[\[\]]/g, '')
+    .replace(/\b(born|died|fl\.?|circa|ca?\.?)\s*\d{3,4}\b/g, '')
+    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+  return cleaned.split(' ').filter((w) => w.length > 0).sort().join(' ');
+}
+
+// ── domain lexicon for keyword scoring over the recovered title ─────────────
+const DOMAIN_TERMS = [
+  'alchem', 'alchim', 'alchimi', 'chymic', 'spagyr', 'hermet', 'hermes', 'trismegist',
+  'kabbal', 'cabal', 'qabal', 'zohar', 'sefirot', 'rosicruc', 'rose-croix', 'rosae crucis',
+  'astrolog', 'astronom', 'magia', 'magie', 'magic', 'occult', 'paracels', 'lull', 'lulli',
+  'philosoph', 'mercur', 'sulphur', 'lapis', 'elixir', 'transmut', 'cabbal', 'theosoph',
+  'geomanc', 'géomanc', 'talisman', 'emblem', 'mystic', 'gnos',
+];
+
+// ── IIIF manifest parsing (v2 + v3) ─────────────────────────────────────────
+function localized(v) {
+  if (!v) return null;
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v)) return v.map(localized).filter(Boolean)[0] || null;
+  if (typeof v === 'object') {
+    // v3 language map { en: [...], none: [...] } or v2 { '@value': ... }
+    if (v['@value']) return v['@value'];
+    const vals = Object.values(v).flat();
+    return vals.find((x) => typeof x === 'string') || null;
+  }
+  return null;
+}
+function metaValue(manifest, ...labels) {
+  const md = manifest.metadata || [];
+  for (const entry of md) {
+    const label = (localized(entry.label) || '').toLowerCase();
+    if (labels.some((l) => label.includes(l))) return localized(entry.value);
+  }
+  return null;
+}
+function parseManifest(m) {
+  const label = localized(m.label);
+  const canvases = m.items?.length // v3
+    || m.sequences?.[0]?.canvases?.length // v2
+    || null;
+  return {
+    title: label,
+    author: metaValue(m, 'author', 'creator', 'auteur'),
+    date: metaValue(m, 'date', 'datation', 'origin date'),
+    language: metaValue(m, 'language', 'langue'),
+    canvas_count: canvases,
+  };
+}
+
+// ── per-host rate limiting (Gallica 429s aggressively even from residential IPs) ─
+const HOST_MIN_INTERVAL = { 'gallica.bnf.fr': 1500 }; // ms between requests to a host
+const DEFAULT_INTERVAL = 250;
+const hostNext = new Map(); // host -> earliest next-request timestamp (chained)
+
+async function hostGate(url) {
+  let host = '';
+  try { host = new URL(url).host; } catch { return; }
+  const interval = HOST_MIN_INTERVAL[host] ?? DEFAULT_INTERVAL;
+  const now = Date.now();
+  const earliest = Math.max(now, hostNext.get(host) || 0);
+  hostNext.set(host, earliest + interval);
+  if (earliest > now) await sleep(earliest - now);
+}
+
+async function fetchManifest(url) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    await hostGate(url);
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': UA, Accept: 'application/json,application/ld+json' }, redirect: 'follow' });
+      if (res.ok) return await res.json();
+      if (res.status === 429 || res.status === 503) { await sleep(2000 * (attempt + 1)); continue; }
+      return null;
+    } catch { await sleep(800 * (attempt + 1)); }
+  }
+  return null;
+}
+
+function subjectScore(candidate, recoveredTitle) {
+  // weight: how many distinct domain queries surfaced it + keyword hits in title
+  const qBoost = Math.min((candidate.subjects?.length || 0) * 0.25, 0.75);
+  const t = (recoveredTitle || candidate.label || '').toLowerCase();
+  const kw = DOMAIN_TERMS.some((term) => t.includes(term)) ? 0.4 : 0;
+  return Math.min(1, qBoost + kw + 0.15); // floor 0.15: it came from a domain query at all
+}
+
+async function main() {
+  console.log(`Harvest triage — ${COMMIT ? 'COMMIT' : 'DRY RUN'}${REENRICH ? ' (reenrich)' : ''}`);
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const candCol = db.collection('harvest_candidates');
+
+  // catalog dedup keys (ARK + normalized title|author)
+  const owned = await db.collection('books').find({},
+    { projection: { _id: 1, title: 1, author: 1, normalized_title: 1, normalized_author: 1, iiif_manifest: 1, 'image_source.source_url': 1 } }).toArray();
+  const ownedArk = new Map();   // ark -> book _id
+  const ownedTA = new Map();    // "nt|na" -> book _id
+  for (const b of owned) {
+    for (const u of [b.iiif_manifest, b.image_source?.source_url]) { const a = arkOf(u || ''); if (a) ownedArk.set(a, b._id); }
+    const nt = b.normalized_title || normalizeTitle(b.title || '');
+    const na = b.normalized_author || normalizeAuthor(b.author || '');
+    if (nt) ownedTA.set(`${nt}|${na}`, b._id);
+  }
+  console.log(`Catalog dedup keys: ${ownedArk.size} ARKs, ${ownedTA.size} title|author.`);
+
+  const filter = REENRICH ? {} : { dedup_status: 'unchecked' };
+  let cursor = candCol.find(filter);
+  if (LIMIT) cursor = cursor.limit(LIMIT);
+  const todo = await cursor.toArray();
+  console.log(`Triaging ${todo.length} candidates (concurrency ${CONCURRENCY})…`);
+
+  let done = 0, dupes = 0, weak = 0, enriched = 0, failed = 0;
+  for (let i = 0; i < todo.length; i += CONCURRENCY) {
+    const batch = todo.slice(i, i + CONCURRENCY);
+    await Promise.all(batch.map(async (c) => {
+      const m = await fetchManifest(c.manifest_url);
+      const parsed = m ? parseManifest(m) : null;
+      if (m) enriched++; else failed++;
+      const title = parsed?.title || c.label;
+      // dedup
+      let dedup_status = 'novel', matched = null;
+      if (c.ark && ownedArk.has(c.ark)) { dedup_status = 'duplicate'; matched = ownedArk.get(c.ark); }
+      else {
+        const key = `${normalizeTitle(title || '')}|${normalizeAuthor(parsed?.author || '')}`;
+        if (parsed?.title && ownedTA.has(key)) { dedup_status = 'duplicate'; matched = ownedTA.get(key); }
+      }
+      const score = subjectScore(c, title);
+      if (dedup_status === 'duplicate') dupes++;
+      let decision = c.decision, reason = c.reason;
+      // only auto-suggest on rows the curator hasn't decided
+      if (c.decision === 'pending') {
+        if (dedup_status === 'duplicate') { decision = 'skip'; reason = `duplicate of ${matched}`; }
+        else if (score < 0.4) { decision = 'skip'; reason = 'weak subject relevance'; weak++; }
+      }
+      const update = {
+        dedup_status, matched_book_id: matched, subject_score: score,
+        title: parsed?.title || null, author: parsed?.author || null,
+        date: parsed?.date || null, manifest_language: parsed?.language || null,
+        canvas_count: parsed?.canvas_count ?? null,
+        triaged_at: new Date(), decision, reason,
+      };
+      if (COMMIT) await candCol.updateOne({ _id: c._id }, { $set: update });
+      done++;
+    }));
+    process.stdout.write(`\r  ${done}/${todo.length}  (enriched ${enriched}, fetch-fail ${failed}, dup ${dupes}, weak ${weak})   `);
+    await sleep(300);
+  }
+  process.stdout.write('\n');
+
+  const summary = { triaged: done, enriched, fetch_failed: failed, duplicates: dupes, weak_subject: weak };
+  console.log(COMMIT ? 'Wrote triage results to ledger.' : 'DRY RUN — no writes.', JSON.stringify(summary));
+  if (COMMIT) {
+    const pending = await candCol.countDocuments({ decision: 'pending' });
+    const novel = await candCol.countDocuments({ dedup_status: 'novel' });
+    console.log(`Ledger now: ${pending} pending for curator, ${novel} novel.`);
+  }
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/research/harvest-triage.mjs
+++ b/scripts/research/harvest-triage.mjs
@@ -101,7 +101,7 @@ function parseManifest(m) {
 }
 
 // ── per-host rate limiting (Gallica 429s aggressively even from residential IPs) ─
-const HOST_MIN_INTERVAL = { 'gallica.bnf.fr': 1500 }; // ms between requests to a host
+const HOST_MIN_INTERVAL = { 'gallica.bnf.fr': 2000 }; // ms between requests to a host
 const DEFAULT_INTERVAL = 250;
 const hostNext = new Map(); // host -> earliest next-request timestamp (chained)
 
@@ -115,8 +115,11 @@ async function hostGate(url) {
   if (earliest > now) await sleep(earliest - now);
 }
 
+// Only 2 attempts: persistent Gallica 429s aren't worth a 5x retry storm
+// (it exhausts local ephemeral ports → EADDRNOTAVAIL). Failures stay un-enriched
+// and are re-tried on the next resume run.
 async function fetchManifest(url) {
-  for (let attempt = 0; attempt < 5; attempt++) {
+  for (let attempt = 0; attempt < 2; attempt++) {
     await hostGate(url);
     try {
       const res = await fetch(url, { headers: { 'User-Agent': UA, Accept: 'application/json,application/ld+json' }, redirect: 'follow' });
@@ -156,13 +159,24 @@ async function main() {
   }
   console.log(`Catalog dedup keys: ${ownedArk.size} ARKs, ${ownedTA.size} title|author.`);
 
-  const filter = REENRICH ? {} : { dedup_status: 'unchecked' };
+  // Resume by default: only rows not yet successfully triaged (no triaged_at).
+  // Fetch-failures never set triaged_at, so a plain re-run retries them.
+  // --reenrich forces all rows.
+  const filter = REENRICH ? {} : { triaged_at: { $exists: false } };
   let cursor = candCol.find(filter);
   if (LIMIT) cursor = cursor.limit(LIMIT);
   const todo = await cursor.toArray();
-  console.log(`Triaging ${todo.length} candidates (concurrency ${CONCURRENCY})…`);
+  console.log(`Triaging ${todo.length} candidates${REENRICH ? '' : ' (resume — un-triaged only)'} (concurrency ${CONCURRENCY})…`);
 
   let done = 0, dupes = 0, weak = 0, enriched = 0, failed = 0;
+  let pendingOps = [];
+  async function flush() {
+    if (!COMMIT || !pendingOps.length) { pendingOps = []; return; }
+    try { await candCol.bulkWrite(pendingOps, { ordered: false }); }
+    catch (e) { console.error(`\n  [warn] bulkWrite failed (${e.message}); ${pendingOps.length} updates dropped this batch, will retry on resume`); }
+    pendingOps = [];
+  }
+
   for (let i = 0; i < todo.length; i += CONCURRENCY) {
     const batch = todo.slice(i, i + CONCURRENCY);
     await Promise.all(batch.map(async (c) => {
@@ -170,34 +184,38 @@ async function main() {
       const parsed = m ? parseManifest(m) : null;
       if (m) enriched++; else failed++;
       const title = parsed?.title || c.label;
-      // dedup
+      // dedup: ARK first (works even without a fetched title), then title|author
       let dedup_status = 'novel', matched = null;
       if (c.ark && ownedArk.has(c.ark)) { dedup_status = 'duplicate'; matched = ownedArk.get(c.ark); }
-      else {
-        const key = `${normalizeTitle(title || '')}|${normalizeAuthor(parsed?.author || '')}`;
-        if (parsed?.title && ownedTA.has(key)) { dedup_status = 'duplicate'; matched = ownedTA.get(key); }
+      else if (parsed?.title) {
+        const key = `${normalizeTitle(title)}|${normalizeAuthor(parsed?.author || '')}`;
+        if (ownedTA.has(key)) { dedup_status = 'duplicate'; matched = ownedTA.get(key); }
       }
       const score = subjectScore(c, title);
       if (dedup_status === 'duplicate') dupes++;
       let decision = c.decision, reason = c.reason;
-      // only auto-suggest on rows the curator hasn't decided
-      if (c.decision === 'pending') {
+      if (c.decision === 'pending') { // only auto-suggest on undecided rows
         if (dedup_status === 'duplicate') { decision = 'skip'; reason = `duplicate of ${matched}`; }
         else if (score < 0.4) { decision = 'skip'; reason = 'weak subject relevance'; weak++; }
       }
+      // Mark done only if we got a usable result (fetched OR resolved as duplicate
+      // by ARK). A pure fetch-failure leaves triaged_at unset so resume retries it.
+      const resolved = m || dedup_status === 'duplicate';
       const update = {
         dedup_status, matched_book_id: matched, subject_score: score,
         title: parsed?.title || null, author: parsed?.author || null,
         date: parsed?.date || null, manifest_language: parsed?.language || null,
-        canvas_count: parsed?.canvas_count ?? null,
-        triaged_at: new Date(), decision, reason,
+        canvas_count: parsed?.canvas_count ?? null, decision, reason,
+        ...(resolved ? { triaged_at: new Date() } : {}),
       };
-      if (COMMIT) await candCol.updateOne({ _id: c._id }, { $set: update });
+      pendingOps.push({ updateOne: { filter: { _id: c._id }, update: { $set: update } } });
       done++;
     }));
+    if (pendingOps.length >= 100) await flush();
     process.stdout.write(`\r  ${done}/${todo.length}  (enriched ${enriched}, fetch-fail ${failed}, dup ${dupes}, weak ${weak})   `);
-    await sleep(300);
+    await sleep(200);
   }
+  await flush();
   process.stdout.write('\n');
 
   const summary = { triaged: done, enriched, fetch_failed: failed, duplicates: dupes, weak_subject: weak };

--- a/scripts/research/harvest-triage.mjs
+++ b/scripts/research/harvest-triage.mjs
@@ -35,6 +35,10 @@ const COMMIT = argv.includes('--commit');
 const REENRICH = argv.includes('--reenrich');
 const flag = (n) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : null; };
 const LIMIT = flag('--limit') ? Number(flag('--limit')) : null;
+// Skip providers that are rate-limiting us (e.g. --exclude gallica) — defers them
+// to a later gentle resume. Comma-separated.
+const EXCLUDE = (flag('--exclude') || '').split(',').map((s) => s.trim()).filter(Boolean);
+const ONLY = flag('--only'); // restrict to a single provider (e.g. --only gallica)
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -163,6 +167,8 @@ async function main() {
   // Fetch-failures never set triaged_at, so a plain re-run retries them.
   // --reenrich forces all rows.
   const filter = REENRICH ? {} : { triaged_at: { $exists: false } };
+  if (EXCLUDE.length) filter.provider = { $nin: EXCLUDE };
+  if (ONLY) filter.provider = ONLY;
   let cursor = candCol.find(filter);
   if (LIMIT) cursor = cursor.limit(LIMIT);
   const todo = await cursor.toArray();

--- a/scripts/research/ia-harvest.mjs
+++ b/scripts/research/ia-harvest.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Internet Archive printed-book harvester  (issue #2419) — the printed-book
+ * counterpart to the Wikidata manuscript channel (Wikidata P6108 has ~0 printed
+ * books; they live in IA).
+ *
+ * IA is ~40M texts, so we DON'T dump it — we scope to our domain via the Scrape
+ * API and template the IIIF manifest URL (every IA text has one):
+ *
+ *   Scrape:   https://archive.org/services/search/v1/scrape?q=<query>&fields=...&cursor=<c>
+ *   Manifest: https://iiif.archive.org/iiif/3/{identifier}/manifest.json   (verified 200)
+ *
+ * Writes into the iiif_manifests discovery index, kind:'printed'.
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/research/ia-harvest.mjs            # DRY RUN
+ *   node scripts/research/ia-harvest.mjs --commit
+ */
+
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeCandidate, upsertCandidates, recordRun } from './lib/harvest-store.mjs';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const OUT = join(__dir, 'output');
+mkdirSync(OUT, { recursive: true });
+
+const SCRAPE = 'https://archive.org/services/search/v1/scrape';
+const MANIFEST = (id) => `https://iiif.archive.org/iiif/3/${id}/manifest.json`;
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const argv = process.argv.slice(2);
+const COMMIT = argv.includes('--commit');
+const flag = (n) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : null; };
+const MAX = flag('--max') ? Number(flag('--max')) : Infinity;
+const COLLECTION = flag('--collection') || 'iiif_manifests';
+
+// Domain-scoped: printed texts in our traditions. IA metadata search.
+const QUERY = 'mediatype:texts AND ('
+  + 'alchemy OR alchemia OR alchimie OR alchimia OR spagyric OR chymistry OR '
+  + 'hermetica OR hermetic OR "hermes trismegistus" OR '
+  + 'kabbalah OR cabala OR cabbala OR "jewish mysticism" OR '
+  + 'rosicrucian OR rosenkreutz OR "rosy cross" OR '
+  + 'paracelsus OR "occult philosophy" OR theosophy OR "natural magic"'
+  + ')';
+
+async function scrapePage(cursor) {
+  const params = new URLSearchParams({ q: QUERY, fields: 'identifier,title,creator,year,language', count: '5000' });
+  if (cursor) params.set('cursor', cursor);
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      const res = await fetch(`${SCRAPE}?${params}`, { headers: { 'User-Agent': UA } });
+      if (res.ok) return await res.json();
+      if (res.status === 429 || res.status >= 500) { await sleep(3000 * (attempt + 1)); continue; }
+      console.error(`scrape ${res.status}: ${(await res.text()).slice(0, 120)}`);
+      return null;
+    } catch (e) { await sleep(1500 * (attempt + 1)); }
+  }
+  return null;
+}
+
+const first = (v) => (Array.isArray(v) ? v[0] : v) || null;
+
+async function main() {
+  console.log(`IA harvest — ${COMMIT ? 'COMMIT' : 'DRY RUN'} → ${COLLECTION}`);
+  const byId = new Map();
+  let cursor = null;
+  do {
+    const json = await scrapePage(cursor);
+    if (!json || !json.items?.length) break;
+    for (const it of json.items) {
+      if (!it.identifier || byId.has(it.identifier)) continue;
+      byId.set(it.identifier, makeCandidate({
+        id: `ia:${it.identifier}`,
+        manifest_url: MANIFEST(it.identifier),
+        source_uri: `https://archive.org/details/${it.identifier}`,
+        label: first(it.title),
+        aggregator: 'internet_archive',
+        kind: 'printed',
+        language: first(it.language),
+        source_library: 'Internet Archive',
+      }));
+    }
+    cursor = json.cursor || null;
+    process.stdout.write(`\r  scraped ${byId.size}${json.total ? `/${json.total}` : ''}${cursor ? ' …' : ''}   `);
+    if (byId.size >= MAX) break;
+    await sleep(400);
+  } while (cursor);
+  process.stdout.write('\n');
+
+  const candidates = [...byId.values()];
+  console.log(`Harvested ${candidates.length} IA printed-text manifests.`);
+
+  if (COMMIT) {
+    const client = new MongoClient(process.env.MONGODB_URI);
+    await client.connect();
+    const db = client.db('bookstore');
+    const now = new Date();
+    const res = await upsertCandidates(db, candidates, now, COLLECTION);
+    await recordRun(db, 'internet_archive', { candidate_count: candidates.length, collection: COLLECTION, query: QUERY }, now);
+    console.log(`Upserted into ${COLLECTION}: ${res.upserted} new, ${res.modified} updated.`);
+    await client.close();
+  } else {
+    const path = join(OUT, 'ia-candidates.json');
+    writeFileSync(path, JSON.stringify({ count: candidates.length, candidates: candidates.slice(0, 500) }, null, 2));
+    console.log(`DRY RUN — wrote sample (≤500) to ${path}. Re-run with --commit.`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/research/lib/harvest-store.mjs
+++ b/scripts/research/lib/harvest-store.mjs
@@ -1,0 +1,125 @@
+/**
+ * Shared store for the manifest-harvest layer (issue #2357).
+ *
+ * One ledger collection — `bookstore.harvest_candidates` — fed by multiple
+ * provider harvesters (Biblissima, Europeana, …) and consumed by triage +
+ * promote. Harvest is CONTINUOUS and decoupled from import: re-running a
+ * harvester must UPDATE existing rows (refresh last_seen, union the subject
+ * terms that surfaced them) WITHOUT clobbering curator decisions or triage
+ * results. So `decision` and `dedup_status` are written on INSERT only;
+ * later stages own them.
+ *
+ * Candidate shape (uniform across providers):
+ *   _id            stable id (provider's id, else ARK, else manifest_url)
+ *   provider       short slug derived from the manifest host (gallica, bsb, …)
+ *   aggregator     where we discovered it (biblissima | europeana | direct)
+ *   source_library human-readable holding institution
+ *   manifest_url   IIIF manifest at the ORIGINAL provider (image source at import)
+ *   source_uri     the object/record page
+ *   label          title or shelfmark (best available pre-manifest-fetch)
+ *   thumbnail      thumb URL
+ *   ark            ark:/… if present (dedup key)
+ *   subjects[]     union of query terms that surfaced this (accumulates)
+ *   language       if known
+ *   --- owned by triage ---
+ *   dedup_status   unchecked | novel | duplicate
+ *   matched_book_id
+ *   subject_score
+ *   --- owned by curator/promote ---
+ *   decision       pending | import | skip
+ *   reason
+ *   imported_book_id
+ */
+
+export function arkOf(url = '') {
+  const m = String(url).match(/ark:\/[^/]+\/[^/?#]+/);
+  return m ? m[0] : null;
+}
+
+const HOST_MAP = [
+  [/gallica\.bnf\.fr/, 'gallica', 'Bibliothèque nationale de France'],
+  [/irht\.cnrs\.fr/, 'irht', 'IRHT (CNRS)'],
+  [/bis-sorbonne\.fr/, 'sorbonne', 'Bibliothèque interuniversitaire de la Sorbonne'],
+  [/digitale-sammlungen\.de/, 'bsb', 'Bayerische Staatsbibliothek'],
+  [/bodleian/, 'bodleian', 'Bodleian Library'],
+  [/bmlonline/, 'laurenziana', 'Biblioteca Medicea Laurenziana'],
+  [/uni-heidelberg/, 'heidelberg', 'Heidelberg University Library'],
+  [/purl\.pt|bn\.pt/, 'bnp', 'Biblioteca Nacional de Portugal'],
+  [/vatlib\.it/, 'vatican', 'Biblioteca Apostolica Vaticana'],
+  [/e-codices/, 'e-codices', 'e-codices'],
+  [/universiteitleiden|leidenuniv/, 'leiden', 'Leiden University Library'],
+  [/stanford\.edu/, 'stanford', 'Stanford Libraries'],
+  [/lib\.cam\.ac\.uk/, 'cambridge', 'Cambridge University Library'],
+  [/lib\.harvard\.edu/, 'harvard', 'Harvard Library'],
+  [/europeana\.eu/, 'europeana', 'Europeana'],
+];
+
+export function providerFromManifest(url) {
+  let host = '';
+  try { host = new URL(url).host; } catch { return { provider: 'unknown', source_library: 'Unknown' }; }
+  for (const [re, provider, lib] of HOST_MAP) if (re.test(host)) return { provider, source_library: lib };
+  return { provider: host.replace(/^www\./, ''), source_library: host };
+}
+
+/** Build a uniform candidate doc. `subjects` is the term(s) that surfaced it. */
+export function makeCandidate({ id, manifest_url, label, thumbnail, source_uri, aggregator, subjects = [], language = null, source_library = null }) {
+  const { provider, source_library: lib } = providerFromManifest(manifest_url);
+  const ark = arkOf(manifest_url);
+  return {
+    _id: id || ark || manifest_url,
+    provider,
+    aggregator,
+    source_library: source_library || lib,
+    manifest_url,
+    source_uri: source_uri || manifest_url.replace(/\/manifest(\.json)?$/, ''),
+    label: label || null,
+    thumbnail: thumbnail || null,
+    ark,
+    language,
+    subjects: [...new Set(subjects)],
+  };
+}
+
+/**
+ * Idempotent upsert. Refreshes last_seen + unions subjects; never overwrites
+ * decision / dedup_status / triage fields on existing rows.
+ */
+export async function upsertCandidates(db, candidates, now = new Date()) {
+  if (!candidates.length) return { upserted: 0, modified: 0 };
+  const col = db.collection('harvest_candidates');
+  await col.createIndex({ manifest_url: 1 }, { unique: true }).catch(() => {});
+  await col.createIndex({ decision: 1, dedup_status: 1, provider: 1 }).catch(() => {});
+  const ops = candidates.map((c) => {
+    const { subjects, ...rest } = c;
+    return {
+      updateOne: {
+        filter: { _id: c._id },
+        update: {
+          $set: { ...rest, last_seen: now },
+          $addToSet: { subjects: { $each: subjects || [] } },
+          $setOnInsert: {
+            first_seen: now,
+            dedup_status: 'unchecked',
+            matched_book_id: null,
+            subject_score: null,
+            decision: 'pending',
+            reason: null,
+            imported_book_id: null,
+          },
+        },
+        upsert: true,
+      },
+    };
+  });
+  const res = await col.bulkWrite(ops, { ordered: false });
+  return { upserted: res.upsertedCount, modified: res.modifiedCount };
+}
+
+/** Record a per-aggregator run summary in harvest_state. */
+export async function recordRun(db, aggregator, info, now = new Date()) {
+  await db.collection('harvest_state').updateOne(
+    { _id: aggregator },
+    { $set: { ...info, last_run_at: now } },
+    { upsert: true },
+  );
+}

--- a/scripts/research/lib/harvest-store.mjs
+++ b/scripts/research/lib/harvest-store.mjs
@@ -52,6 +52,7 @@ const HOST_MAP = [
   [/lib\.cam\.ac\.uk/, 'cambridge', 'Cambridge University Library'],
   [/lib\.harvard\.edu/, 'harvard', 'Harvard Library'],
   [/europeana\.eu/, 'europeana', 'Europeana'],
+  [/archive\.org/, 'internet_archive', 'Internet Archive'],
 ];
 
 export function providerFromManifest(url) {
@@ -61,8 +62,9 @@ export function providerFromManifest(url) {
   return { provider: host.replace(/^www\./, ''), source_library: host };
 }
 
-/** Build a uniform candidate doc. `subjects` is the term(s) that surfaced it. */
-export function makeCandidate({ id, manifest_url, label, thumbnail, source_uri, aggregator, subjects = [], language = null, source_library = null }) {
+/** Build a uniform candidate doc. `subjects` is the term(s) that surfaced it.
+ *  `kind` is the material type (manuscript | printed | art | unknown). */
+export function makeCandidate({ id, manifest_url, label, thumbnail, source_uri, aggregator, subjects = [], language = null, source_library = null, kind = null }) {
   const { provider, source_library: lib } = providerFromManifest(manifest_url);
   const ark = arkOf(manifest_url);
   return {
@@ -76,6 +78,7 @@ export function makeCandidate({ id, manifest_url, label, thumbnail, source_uri, 
     thumbnail: thumbnail || null,
     ark,
     language,
+    ...(kind ? { kind } : {}),
     subjects: [...new Set(subjects)],
   };
 }
@@ -84,9 +87,9 @@ export function makeCandidate({ id, manifest_url, label, thumbnail, source_uri, 
  * Idempotent upsert. Refreshes last_seen + unions subjects; never overwrites
  * decision / dedup_status / triage fields on existing rows.
  */
-export async function upsertCandidates(db, candidates, now = new Date()) {
+export async function upsertCandidates(db, candidates, now = new Date(), collectionName = 'harvest_candidates') {
   if (!candidates.length) return { upserted: 0, modified: 0 };
-  const col = db.collection('harvest_candidates');
+  const col = db.collection(collectionName);
   await col.createIndex({ manifest_url: 1 }, { unique: true }).catch(() => {});
   await col.createIndex({ decision: 1, dedup_status: 1, provider: 1 }).catch(() => {});
   const ops = candidates.map((c) => {
@@ -122,4 +125,13 @@ export async function recordRun(db, aggregator, info, now = new Date()) {
     { $set: { ...info, last_run_at: now } },
     { upsert: true },
   );
+}
+
+/** True if this manifest_url already exists in the catalog (books.image_source.iiif_manifest).
+ *  Cheap exact-URL dedup the triage ARK-matcher can miss (e.g. Leiden, no ARK). */
+export async function loadOwnedManifests(db) {
+  const rows = await db.collection('books')
+    .find({ 'image_source.iiif_manifest': { $exists: true, $ne: null } }, { projection: { 'image_source.iiif_manifest': 1 } })
+    .toArray();
+  return new Set(rows.map((b) => b.image_source?.iiif_manifest).filter(Boolean));
 }

--- a/scripts/research/lib/harvest-store.mjs
+++ b/scripts/research/lib/harvest-store.mjs
@@ -92,15 +92,21 @@ export async function upsertCandidates(db, candidates, now = new Date(), collect
   const col = db.collection(collectionName);
   await col.createIndex({ manifest_url: 1 }, { unique: true }).catch(() => {});
   await col.createIndex({ decision: 1, dedup_status: 1, provider: 1 }).catch(() => {});
+  // Dedup identity is manifest_url (the unique index), NOT _id: the same manifest
+  // can arrive via different channels with different _ids (e.g. a Wikidata item
+  // and an IA identifier pointing at the same archive.org manifest). Filtering on
+  // _id would then try to INSERT a duplicate manifest_url → E11000. _id is set
+  // once on insert (first channel wins) and never changed thereafter.
   const ops = candidates.map((c) => {
-    const { subjects, ...rest } = c;
+    const { subjects, _id, manifest_url, ...rest } = c;
     return {
       updateOne: {
-        filter: { _id: c._id },
+        filter: { manifest_url },
         update: {
-          $set: { ...rest, last_seen: now },
+          $set: { ...rest, manifest_url, last_seen: now },
           $addToSet: { subjects: { $each: subjects || [] } },
           $setOnInsert: {
+            _id,
             first_seen: now,
             dedup_status: 'unchecked',
             matched_book_id: null,
@@ -114,8 +120,13 @@ export async function upsertCandidates(db, candidates, now = new Date(), collect
       },
     };
   });
-  const res = await col.bulkWrite(ops, { ordered: false });
-  return { upserted: res.upsertedCount, modified: res.modifiedCount };
+  // Chunk to isolate failures and keep payloads sane at 60k+ scale.
+  let upserted = 0, modified = 0;
+  for (let i = 0; i < ops.length; i += 2000) {
+    const res = await col.bulkWrite(ops.slice(i, i + 2000), { ordered: false });
+    upserted += res.upsertedCount; modified += res.modifiedCount;
+  }
+  return { upserted, modified };
 }
 
 /** Record a per-aggregator run summary in harvest_state. */

--- a/scripts/research/wikidata-harvest.mjs
+++ b/scripts/research/wikidata-harvest.mjs
@@ -36,10 +36,12 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const argv = process.argv.slice(2);
 const COMMIT = argv.includes('--commit');
 const DOMAIN = argv.includes('--domain');
+const MANUSCRIPTS = argv.includes('--manuscripts'); // P31 = manuscript (Q87167) — multipage books
 const WITH_LABELS = argv.includes('--with-labels') || DOMAIN;
 const flag = (n) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : null; };
 const PAGE = flag('--page') ? Number(flag('--page')) : 5000;
 const MAX = flag('--max') ? Number(flag('--max')) : Infinity;
+const COLLECTION = flag('--collection') || (MANUSCRIPTS ? 'iiif_manifests' : 'harvest_candidates');
 
 // Domain main-subjects (P921) — Wikidata QIDs for our traditions.
 const DOMAIN_QIDS = [
@@ -53,9 +55,11 @@ const DOMAIN_QIDS = [
 ];
 
 function buildQuery(offset) {
-  const subjectFilter = DOMAIN
-    ? `?item wdt:P921 ?subj . VALUES ?subj { ${DOMAIN_QIDS.map((q) => `wd:${q}`).join(' ')} }`
-    : '';
+  const subjectFilter = MANUSCRIPTS
+    ? '?item wdt:P31 wd:Q87167 .'
+    : DOMAIN
+      ? `?item wdt:P921 ?subj . VALUES ?subj { ${DOMAIN_QIDS.map((q) => `wd:${q}`).join(' ')} }`
+      : '';
   const labels = WITH_LABELS
     ? `OPTIONAL { ?item wdt:P170 ?creator. } SERVICE wikibase:label { bd:serviceParam wikibase:language "en,la,de,fr,it". }`
     : '';
@@ -93,12 +97,14 @@ function toCandidate(b) {
     label: b.itemLabel?.value || null,
     source_uri: b.item.value,
     aggregator: 'wikidata',
+    kind: MANUSCRIPTS ? 'manuscript' : null,
     subjects: DOMAIN ? ['wikidata-domain'] : [],
   });
 }
 
 async function main() {
-  console.log(`Wikidata harvest — ${COMMIT ? 'COMMIT' : 'DRY RUN'}${DOMAIN ? ' (domain-filtered)' : ' (full P6108)'} — page ${PAGE}`);
+  const scope = MANUSCRIPTS ? 'manuscripts (P31=Q87167)' : DOMAIN ? 'domain-filtered' : 'full P6108';
+  console.log(`Wikidata harvest — ${COMMIT ? 'COMMIT' : 'DRY RUN'} (${scope}) → ${COLLECTION} — page ${PAGE}`);
   const byUrl = new Map();
   for (let offset = 0; offset < MAX; offset += PAGE) {
     const rows = await runQuery(buildQuery(offset));
@@ -124,9 +130,9 @@ async function main() {
     await client.connect();
     const db = client.db('bookstore');
     const now = new Date();
-    const res = await upsertCandidates(db, candidates, now);
-    await recordRun(db, DOMAIN ? 'wikidata-domain' : 'wikidata', { candidate_count: candidates.length }, now);
-    console.log(`Upserted: ${res.upserted} new, ${res.modified} updated.`);
+    const res = await upsertCandidates(db, candidates, now, COLLECTION);
+    await recordRun(db, MANUSCRIPTS ? 'wikidata-manuscripts' : DOMAIN ? 'wikidata-domain' : 'wikidata', { candidate_count: candidates.length, collection: COLLECTION }, now);
+    console.log(`Upserted into ${COLLECTION}: ${res.upserted} new, ${res.modified} updated.`);
     await client.close();
   } else {
     const path = join(OUT, `wikidata-${DOMAIN ? 'domain' : 'all'}-candidates.json`);

--- a/scripts/research/wikidata-harvest.mjs
+++ b/scripts/research/wikidata-harvest.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Wikidata IIIF manifest harvester  (issue #2419) — the highest-yield bulk channel.
+ *
+ * Wikidata property P6108 ("IIIF manifest") carries ~306k manifest URLs across
+ * every major institution, each with structured creator/date/subject already
+ * attached — retrievable by SPARQL, no crawling, no per-manifest fetch.
+ *
+ *   Endpoint: https://query.wikidata.org/sparql
+ *   Bulk:     SELECT ?item ?manifest WHERE { ?item wdt:P6108 ?manifest } (paginate)
+ *   Domain:   add a P921 (main subject) filter to pull only on-topic manifests
+ *
+ * Writes into the same harvest_candidates ledger as the other channels.
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/research/wikidata-harvest.mjs --max 10000        # DRY RUN (bulk)
+ *   node scripts/research/wikidata-harvest.mjs --domain --commit   # domain-filtered, write
+ *   node scripts/research/wikidata-harvest.mjs --commit            # full ~306k pull, write
+ */
+
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeCandidate, upsertCandidates, recordRun } from './lib/harvest-store.mjs';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const OUT = join(__dir, 'output');
+mkdirSync(OUT, { recursive: true });
+
+const ENDPOINT = 'https://query.wikidata.org/sparql';
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const argv = process.argv.slice(2);
+const COMMIT = argv.includes('--commit');
+const DOMAIN = argv.includes('--domain');
+const WITH_LABELS = argv.includes('--with-labels') || DOMAIN;
+const flag = (n) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : null; };
+const PAGE = flag('--page') ? Number(flag('--page')) : 5000;
+const MAX = flag('--max') ? Number(flag('--max')) : Infinity;
+
+// Domain main-subjects (P921) — Wikidata QIDs for our traditions.
+const DOMAIN_QIDS = [
+  'Q1132271', // alchemy
+  'Q131227',  // Hermeticism
+  'Q170978',  // Kabbalah
+  'Q11653',   // astrology
+  'Q178794',  // Rosicrucianism
+  'Q189325',  // occultism / occult
+  'Q40953',   // magic (supernatural)
+];
+
+function buildQuery(offset) {
+  const subjectFilter = DOMAIN
+    ? `?item wdt:P921 ?subj . VALUES ?subj { ${DOMAIN_QIDS.map((q) => `wd:${q}`).join(' ')} }`
+    : '';
+  const labels = WITH_LABELS
+    ? `OPTIONAL { ?item wdt:P170 ?creator. } SERVICE wikibase:label { bd:serviceParam wikibase:language "en,la,de,fr,it". }`
+    : '';
+  const sel = WITH_LABELS ? '?item ?manifest ?itemLabel ?creatorLabel' : '?item ?manifest';
+  return `SELECT ${sel} WHERE {
+    ?item wdt:P6108 ?manifest .
+    ${subjectFilter}
+    ${labels}
+  } LIMIT ${PAGE} OFFSET ${offset}`;
+  // NB: no ORDER BY — sorting all ~306k rows times out WDQS (60s). Unordered
+  // OFFSET paging may overlap/skip slightly across pages; the unique-by-URL
+  // upsert makes overlaps harmless, and a re-run fills any gaps.
+}
+
+async function runQuery(q) {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      const res = await fetch(`${ENDPOINT}?query=${encodeURIComponent(q)}`, {
+        headers: { 'User-Agent': UA, Accept: 'application/sparql-results+json' },
+      });
+      if (res.ok) return (await res.json()).results.bindings;
+      if (res.status === 429 || res.status === 500) { await sleep(3000 * (attempt + 1)); continue; }
+      console.error(`SPARQL ${res.status}: ${(await res.text()).slice(0, 120)}`);
+      return null;
+    } catch (e) { await sleep(2000 * (attempt + 1)); }
+  }
+  return null;
+}
+
+function toCandidate(b) {
+  const qid = (b.item.value.match(/Q\d+$/) || [])[0];
+  return makeCandidate({
+    id: `wikidata:${qid}`,
+    manifest_url: b.manifest.value,
+    label: b.itemLabel?.value || null,
+    source_uri: b.item.value,
+    aggregator: 'wikidata',
+    subjects: DOMAIN ? ['wikidata-domain'] : [],
+  });
+}
+
+async function main() {
+  console.log(`Wikidata harvest — ${COMMIT ? 'COMMIT' : 'DRY RUN'}${DOMAIN ? ' (domain-filtered)' : ' (full P6108)'} — page ${PAGE}`);
+  const byUrl = new Map();
+  for (let offset = 0; offset < MAX; offset += PAGE) {
+    const rows = await runQuery(buildQuery(offset));
+    if (rows === null) { console.error('query failed; stopping'); break; }
+    if (rows.length === 0) break;
+    for (const b of rows) {
+      const c = toCandidate(b);
+      if (!byUrl.has(c.manifest_url)) byUrl.set(c.manifest_url, c);
+    }
+    process.stdout.write(`\r  offset ${offset}  (+${rows.length}, unique ${byUrl.size})   `);
+    if (rows.length < PAGE) break;
+    await sleep(500);
+  }
+  process.stdout.write('\n');
+  const candidates = [...byUrl.values()];
+  console.log(`Harvested ${candidates.length} unique manifests.`);
+  const byProv = {};
+  for (const c of candidates) byProv[c.provider] = (byProv[c.provider] || 0) + 1;
+  console.log('Top providers:', Object.entries(byProv).sort((a, b) => b[1] - a[1]).slice(0, 12).map(([p, n]) => `${p}:${n}`).join('  '));
+
+  if (COMMIT) {
+    const client = new MongoClient(process.env.MONGODB_URI);
+    await client.connect();
+    const db = client.db('bookstore');
+    const now = new Date();
+    const res = await upsertCandidates(db, candidates, now);
+    await recordRun(db, DOMAIN ? 'wikidata-domain' : 'wikidata', { candidate_count: candidates.length }, now);
+    console.log(`Upserted: ${res.upserted} new, ${res.modified} updated.`);
+    await client.close();
+  } else {
+    const path = join(OUT, `wikidata-${DOMAIN ? 'domain' : 'all'}-candidates.json`);
+    writeFileSync(path, JSON.stringify({ count: candidates.length, candidates: candidates.slice(0, 500) }, null, 2));
+    console.log(`DRY RUN — wrote sample (≤500) to ${path}. Re-run with --commit to write all.`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Implements the manifest-harvest layer from #2357 — **harvest is continuous and decoupled from import**. Manifests flow into a `harvest_candidates` ledger; importing is a separate downstream decision that draws from it.

## Pieces
- **`lib/harvest-store.mjs`** — shared ledger store. Idempotent upserts that union subject terms and **never clobber curator decisions / triage fields on re-harvest** (the correctness requirement for continuous harvest). Provider mapping from manifest host.
- **`biblissima-harvest.mjs`** — discovery via Biblissima's pre-1800 mss/rare-book portal. Scrapes `data-manifest` URLs (pointing back at the original provider) across our domain terms; pagination via `&from=`. No API key.
- **`europeana-harvest.mjs`** — second aggregator into the same ledger. Subject-scoped Search API + `iiif.europeana.eu` manifests. Reads `EUROPEANA_API_KEY` (ready to plug in).
- **`harvest-triage.mjs`** — the consumer. Fetches each candidate's IIIF manifest (v2+v3) to recover title/author/date/canvas count, dedups by ARK + normalized title|author vs the catalog, scores domain relevance, auto-skips duplicates. **Per-host rate limiting** (Gallica 429s hard from any IP): 18/20 enriched in sample after throttle vs 13/20 before.

## Validated
- Biblissima sweep: **2,908 unique manifests across 26 queries, 2,884 novel**, 31 source libraries (Gallica 1,327, OCLC ContentDM 650, IRHT 161, BSB 161, Vatican 122, …). Ledger populated.
- Triage sample: manifest parse + title-dedup confirmed working across Gallica/IRHT/Sorbonne; full pass running.

## Flow
`harvest (biblissima/europeana) → ledger (pending) → triage (dedup + score, auto-skip dups) → curator promote (import → hidden book → pipeline)`

## Out of scope (follow-ups on #2357)
- Promote step (candidate → hidden book → pipeline) and curator review surface.
- Hetzner cron entries for continuous harvest.
- Rijks Change Discovery (we already harvest Rijks better via targeted artist search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)