### PR TITLE
fix(categories): force-dynamic to stop /categories/[id] 500ing

### DIFF
--- a/src/app/categories/[id]/page.tsx
+++ b/src/app/categories/[id]/page.tsx
@@ -29,12 +29,12 @@ interface Book {
   summary?: { data: string } | string;
 }
 
-// ISR: rebuild at most every hour
-export const revalidate = false;
-export const dynamicParams = true;
-export async function generateStaticParams() {
-  return []; // All paths generated on demand via ISR
-}
+// This route reads request headers (await headers() for tenant detection),
+// so it must render dynamically. Declaring `revalidate` (ISR / static) here
+// while calling headers() throws DYNAMIC_SERVER_USAGE in Next 16 and 500s the
+// whole /categories/[id] route. Force dynamic instead (same fix as PR #2260).
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
 
 interface CategoryPageProps {
   params: Promise<{ id: string }>;


### PR DESCRIPTION
## Problem
Every \`/categories/*\` page returned **HTTP 500** in production — all 29 of them (alchemy, hermeticism, neoplatonism, astrology, rosicrucianism, kabbalah, …). They're in the sitemap, so this was both a user-facing outage and an SEO liability (Google crawling 500s).

## Root cause
\`src/app/categories/[id]/page.tsx\` declared \`export const revalidate = false\` (ISR/static) **and** called \`await headers()\` for tenant detection. In Next 16 that combination throws \`DYNAMIC_SERVER_USAGE\` and 500s the whole route.

This is the exact pattern fixed for browse-by-author/title/artist and book overview in **PR #2260** — this route was simply missed. It's now the only page left in the codebase with `revalidate = false` + `headers()`.

## Fix
Replace the ISR exports (\`revalidate\`, \`dynamicParams\`, empty \`generateStaticParams\`) with \`export const dynamic = 'force-dynamic'\` + \`maxDuration = 60\`, mirroring the #2260 fix and its explanatory comment.

## How it was found
A full-site cache-warming pass (warming all ~16K sitemap URLs) surfaced 29 consistent 500s, all on \`/categories/*\`.

## Scope
- **In scope:** the /categories/[id] 500 only — one file, six lines.
- **Out of scope:** ~31 \`/work/*\` sitemap URLs that 404 (genuine \`notFound()\` from data drift + a few malformed work_ids containing \`|\`/\`[\`). That's separate sitemap-hygiene work, not a route outage; tracked separately.

## Verification
- \`/categories/alchemy\` currently 500s on prod (reproduced via curl).
- check-imports hook passes; one-line config change, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)