### PR TITLE
fix(bph): right-size catalogue grid covers (optimiser + thumb backfill)

### DIFF
--- a/scripts/maintenance/backfill-bph-cover-thumbs.mjs
+++ b/scripts/maintenance/backfill-bph-cover-thumbs.mjs
@@ -1,0 +1,120 @@
+/**
+ * Backfill `-thumb.jpg` variants for digitised BPH covers that only have the
+ * 1200px display variant.
+ *
+ * Why: the BPH catalogue grid (and the EFM embed) render covers via the SL
+ * image optimiser. ~82% of covers live under /pages/ and already have a
+ * pipeline-generated `-thumb.jpg` (150px). The remaining ~18% — the /cropped/
+ * manuscript covers and /uploads/ — were never given a thumb, so the
+ * thumb-swap loader (bookCoverResponsiveLoader) would 404 exactly those.
+ * This script generates the missing 150px thumbs and uploads them to R2 so
+ * the loader is safe for every cover.
+ *
+ * Idempotent: skips any cover whose `-thumb.jpg` already returns 200.
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a; \
+ *   node scripts/maintenance/backfill-bph-cover-thumbs.mjs [--dry-run] [--all]
+ *
+ *   --dry-run  enumerate + report, write nothing
+ *   --all      also (re)check /pages/ covers, not just /cropped/ + /uploads/
+ */
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+
+const THUMB_WIDTH = 150;
+const THUMB_QUALITY = 60; // matches scripts/workers/lib/display-image.mjs
+const CONCURRENCY = 8;
+const API = 'https://sourcelibrary.org/api/catalog/bph';
+const PUBLIC_URL = (process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org').replace(/\/$/, '');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const ALL = process.argv.includes('--all');
+
+const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY } = process.env;
+const BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary-images';
+if (!DRY_RUN && (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY)) {
+  console.error('Missing R2_* env vars. Source .env.production.local first.');
+  process.exit(1);
+}
+const s3 = DRY_RUN ? null : new S3Client({
+  region: 'auto',
+  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+});
+
+/** Enumerate every digitised BPH cover URL via the catalogue API. */
+async function collectCovers() {
+  const seen = new Set();
+  let offset = 0;
+  const limit = 200;
+  for (;;) {
+    const res = await fetch(`${API}?digitized=sl&limit=${limit}&offset=${offset}`);
+    if (!res.ok) throw new Error(`API ${res.status} at offset ${offset}`);
+    const { works, total } = await res.json();
+    for (const w of works) {
+      if (typeof w.sl_cover === 'string' && w.sl_cover.startsWith(PUBLIC_URL) && w.sl_cover.endsWith('.jpg')) {
+        seen.add(w.sl_cover);
+      }
+    }
+    offset += limit;
+    if (offset >= total) break;
+  }
+  return [...seen];
+}
+
+async function thumbExists(thumbUrl) {
+  try {
+    const r = await fetch(thumbUrl, { method: 'GET', headers: { Range: 'bytes=0-0' } });
+    return r.status === 200 || r.status === 206;
+  } catch {
+    return false;
+  }
+}
+
+async function backfillOne(displayUrl) {
+  const thumbUrl = displayUrl.replace(/\.jpg$/, '-thumb.jpg');
+  if (await thumbExists(thumbUrl)) return 'exists';
+  if (DRY_RUN) return 'would-write';
+
+  const res = await fetch(displayUrl);
+  if (!res.ok) return `display-${res.status}`;
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.length === 0) return 'empty-display';
+
+  const thumb = await sharp(buf)
+    .resize(THUMB_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: THUMB_QUALITY })
+    .toBuffer();
+
+  const key = thumbUrl.slice(PUBLIC_URL.length + 1); // strip "https://host/"
+  await s3.send(new PutObjectCommand({
+    Bucket: BUCKET, Key: key, Body: thumb, ContentType: 'image/jpeg',
+    CacheControl: 'public, max-age=31536000, immutable',
+  }));
+  return 'written';
+}
+
+async function run() {
+  console.log(`[backfill] mode=${DRY_RUN ? 'DRY-RUN' : 'LIVE'} scope=${ALL ? 'all' : 'cropped+uploads'}`);
+  const all = await collectCovers();
+  const targets = ALL
+    ? all
+    : all.filter((u) => /\/(cropped|uploads)\//.test(u));
+  console.log(`[backfill] ${all.length} digitised covers, ${targets.length} in scope`);
+
+  const tally = {};
+  let done = 0;
+  for (let i = 0; i < targets.length; i += CONCURRENCY) {
+    const batch = targets.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(batch.map(backfillOne));
+    for (const r of results) tally[r] = (tally[r] || 0) + 1;
+    done += batch.length;
+    if (done % 80 === 0 || done === targets.length) {
+      console.log(`[backfill] ${done}/${targets.length} ${JSON.stringify(tally)}`);
+    }
+  }
+  console.log('[backfill] DONE', JSON.stringify(tally, null, 2));
+}
+
+run().catch((e) => { console.error(e); process.exit(1); });

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { useDebouncedCallback } from 'use-debounce';
 import { Search, X, ChevronLeft, ChevronRight, BookMarked, SlidersHorizontal } from 'lucide-react';
@@ -876,12 +877,23 @@ export default function BphCatalogBrowser({
                   >
                     <div className="relative aspect-[2/3] bg-warm rounded-md overflow-hidden border border-border-light group-hover:border-accent-rust/40 transition-colors">
                       {w.sl_cover ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
+                        // Next's image optimiser resizes the 1200px display
+                        // source down to the grid-tile width (~170px) and
+                        // serves AVIF/WebP, so the browser no longer downloads
+                        // a ~400KB cover per tile. We intentionally do NOT use
+                        // bookCoverResponsiveLoader here: ~18% of digitised BPH
+                        // covers (the /cropped/ manuscript covers + /uploads/)
+                        // have no `-thumb.jpg` sibling, so the thumb-swap would
+                        // 404 exactly the manuscript covers. The default loader
+                        // fetches the always-present display variant instead.
+                        <Image
                           src={w.sl_cover}
                           alt={displayTitle}
+                          fill
                           loading="lazy"
-                          className="absolute inset-0 w-full h-full object-cover"
+                          quality={70}
+                          sizes="(min-width: 1280px) 16vw, (min-width: 1024px) 20vw, (min-width: 768px) 25vw, (min-width: 640px) 33vw, 50vw"
+                          className="object-cover"
                         />
                       ) : (
                         <div className="absolute inset-0 flex items-center justify-center text-muted">

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
+import { bookCoverResponsiveLoader } from '@/lib/book-cover-loader';
 import { useDebouncedCallback } from 'use-debounce';
 import { Search, X, ChevronLeft, ChevronRight, BookMarked, SlidersHorizontal } from 'lucide-react';
 // Book URL helper moved inline to use basePath
@@ -877,21 +878,22 @@ export default function BphCatalogBrowser({
                   >
                     <div className="relative aspect-[2/3] bg-warm rounded-md overflow-hidden border border-border-light group-hover:border-accent-rust/40 transition-colors">
                       {w.sl_cover ? (
-                        // Next's image optimiser resizes the 1200px display
-                        // source down to the grid-tile width (~170px) and
-                        // serves AVIF/WebP, so the browser no longer downloads
-                        // a ~400KB cover per tile. We intentionally do NOT use
-                        // bookCoverResponsiveLoader here: ~18% of digitised BPH
-                        // covers (the /cropped/ manuscript covers + /uploads/)
-                        // have no `-thumb.jpg` sibling, so the thumb-swap would
-                        // 404 exactly the manuscript covers. The default loader
-                        // fetches the always-present display variant instead.
+                        // Next's image optimiser resizes the cover down to the
+                        // grid-tile width (~170px) and serves AVIF/WebP, so the
+                        // browser no longer downloads a ~400KB display JPEG per
+                        // tile. bookCoverResponsiveLoader additionally swaps the
+                        // R2 *source* to the 150px `-thumb.jpg` for small widths,
+                        // cutting optimiser-side egress ~40×. Safe for every
+                        // digitised BPH cover: the /cropped/ + /uploads/ thumbs
+                        // (~18%) that were missing are backfilled by
+                        // scripts/maintenance/backfill-bph-cover-thumbs.mjs.
                         <Image
                           src={w.sl_cover}
+                          loader={bookCoverResponsiveLoader}
                           alt={displayTitle}
                           fill
                           loading="lazy"
-                          quality={70}
+                          quality={75}
                           sizes="(min-width: 1280px) 16vw, (min-width: 1024px) 20vw, (min-width: 768px) 25vw, (min-width: 640px) 33vw, 50vw"
                           className="object-cover"
                         />


### PR DESCRIPTION
## Problem

The BPH catalogue **grid view** — what the Embassy of the Free Mind embeds at [`/digital-collection-search?view=books&display=grid`](https://www.embassyofthefreemind.com/digital-collection-search?view=books&display=grid) via `sourcelibrary.org/embed/v1.js` — rendered each cover with a plain `<img src={w.sl_cover}>`. `sl_cover` is the **1200px display variant** (~370–410 KB), so the browser downloaded a full-size JPEG per tile and CSS-scaled it into a ~170px cell: **~8–25 MB per grid page**.

## Fix

`<img>` → `next/image` with `bookCoverResponsiveLoader` + `sizes` matching the grid breakpoints. The optimiser serves a ~170px AVIF to the browser, and the loader points the R2 *source* at the 150px `-thumb.jpg`. **Result: ~3–4 KB AVIF per cover** (verified end-to-end on both `sourcelibrary.org` and `bph.sourcelibrary.org`) — ~99% smaller.

## Backfill (the missing 18%)

The thumb-swap loader needs every cover to have a `-thumb.jpg`. Census of all **2,343 digitised BPH covers**:

| Path | Count | Had thumb? |
|---|---|---|
| `/pages/` | 1,924 (82%) | ✅ yes |
| `/cropped/` (manuscript covers) | ~385 (16%) | ❌ no |
| `/uploads/` | ~36 (1.5%) | ❌ no |

`scripts/maintenance/backfill-bph-cover-thumbs.mjs` generated the **419** missing 150px/q60 thumbs (matching `generateDisplayVariants`) and uploaded them to R2. **Run live: 419 written, 0 failures.** Cloudflare cache purged for those URLs so the optimiser sees them.

## Gotcha caught pre-merge

`quality={70}` returns `INVALID_IMAGE_OPTIMIZE_REQUEST` (400) — Next 16 only allows `qualities: [75,80,85,90]` (next.config.ts). Set to `75`.

## Risk

Low. Optimiser reachable on apex + subdomain (`proxy.ts` excludes `/_next/image`); all cover hosts allowlisted in `remotePatterns` + CSP; every cover now has a thumb. Verified live.

## Scope

- **In:** BPH catalogue grid cover rendering + thumb backfill script.
- **Out:** list view (ignores `sl_cover`); making the crop/upload path emit thumbs going forward (future drift guard — noted as follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)