### PR TITLE
fix(reader): clean up Notes-off residue in translation pane

### DIFF
--- a/src/components/reader/NotesRenderer.tsx
+++ b/src/components/reader/NotesRenderer.tsx
@@ -292,6 +292,28 @@ function preprocessBracketTags(text: string, showNotes: boolean): string {
   return result;
 }
 
+// Handle <term> vocabulary chips when notes are hidden.
+// A trailing glossary entry is a <term> immediately followed by its defining <note>
+// (e.g. `<term>bite</term> <note>original: "morsus."</note>`). With notes off the
+// <note> renders as null, leaving the term chip dangling with no definition. Remove
+// the whole pair. Any remaining <term> is inline within running prose — unwrap it to
+// plain text so the sentence stays intact, just without the highlight chip.
+function preprocessTerms(text: string, showNotes: boolean): string {
+  if (showNotes) return text;
+  return text
+    .replace(/<term>[\s\S]*?<\/term>\s*<note>[\s\S]*?<\/note>/gi, '')
+    .replace(/<term>([\s\S]*?)<\/term>/gi, '$1');
+}
+
+// On description-only pages (illustrations, diagrams, etc.) the entire "translation"
+// is AI-generated description. The model wraps some of it in <note>/<image-desc> and
+// leaves the rest as plain prose, producing inconsistent half-highlighting. Since
+// there is no source text to distinguish from, unwrap those tags so the whole
+// description reads uniformly as plain text.
+function unwrapDescriptionNotes(text: string): string {
+  return text.replace(/<(note|image-desc)>([\s\S]*?)<\/\1>/gi, '$2');
+}
+
 // Convert markdown bold/italic to HTML tags.
 // Used inside HTML block elements (divs, headings) where the markdown parser won't process inline syntax.
 function inlineMarkdownToHtml(text: string): string {
@@ -756,11 +778,20 @@ function ColumnMarkdown({ text, showNotes, withNotes }: {
 export default function NotesRenderer({ text, className = '', showMetadata = true, showNotes = true, language, columns, pageType }: NotesRendererProps) {
   const { cleanText, metadata } = useMemo(() => extractMetadata(text), [text]);
 
-  // For non-text page types (frontispiece, illustration, etc.), all content is AI description
-  const isDescriptionOnly = pageType ? DESCRIPTION_ONLY_PAGE_TYPES.has(pageType) : false;
+  // For non-text page types (frontispiece, illustration, etc.), all content is AI description.
+  // Check the prop and the model's own <page-type> tag (captured into metadata).
+  const isDescriptionOnly = DESCRIPTION_ONLY_PAGE_TYPES.has(pageType ?? '') ||
+    DESCRIPTION_ONLY_PAGE_TYPES.has(metadata.pageType ?? '');
 
   const withBracketTags = useMemo(() => preprocessBracketTags(cleanText, showNotes), [cleanText, showNotes]);
-  const withGreek = useMemo(() => preprocessLatexGreek(withBracketTags), [withBracketTags]);
+  // Drop dangling vocabulary chips when notes are off (see preprocessTerms).
+  const withTerms = useMemo(() => preprocessTerms(withBracketTags, showNotes), [withBracketTags, showNotes]);
+  // On description-only pages, render the whole AI description uniformly (no half-highlighting).
+  const withDescription = useMemo(
+    () => (isDescriptionOnly && showNotes ? unwrapDescriptionNotes(withTerms) : withTerms),
+    [withTerms, isDescriptionOnly, showNotes]
+  );
+  const withGreek = useMemo(() => preprocessLatexGreek(withDescription), [withDescription]);
   const withLatex = useMemo(() => preprocessLatexSuperscripts(withGreek), [withGreek]);
   const withAnnotationMd = useMemo(() => preprocessAnnotationInlineMarkdown(withLatex), [withLatex]);
   const withCentering = useMemo(() => preprocessCentering(withAnnotationMd), [withAnnotationMd]);


### PR DESCRIPTION
## Why

Reported by Derek from two reader pages:

1. **The Book of Playing Cards (p.127):** with **Notes Off**, a stack of bare vocabulary chips (*Hydra, unfaithful woman, deceit, bite, wounds*) stayed pinned at the bottom of the translation, with no definitions and no context.
2. **The New Pearl of Great Price (p.59):** an all-illustration page where the AI description was half gold-highlighted, half plain — "everything seems to be notes but they aren't all yellow highlighted."

## Root cause

In `NotesRenderer.tsx`, the gold highlight marks `<note>` editorial annotations, gated behind the Notes toggle. Two gaps:

- `<term>` vocabulary chips were rendered **unconditionally** ("terms always shown"). A trailing glossary entry is a `<term>` immediately followed by its defining `<note>`. Notes-off nulled the `<note>` but kept the `<term>`, orphaning the chip.
- The translation model wraps *some* illustration-description prose in `<note>` and leaves the rest as plain body text. On a description-only page that produced inconsistent half-highlighting.

## Changes

- **Drop orphaned vocab.** When notes are off, remove `<term>…</term> <note>…</note>` glossary pairs whole; unwrap any remaining inline `<term>` to plain text so running sentences stay intact (just without the chip).
- **Uniform description pages.** On description-only page types, unwrap `<note>`/`<image-desc>` to plain text when notes are shown, so the whole description reads consistently instead of half-gold.
- **Better detection.** Description-only detection now also honors the model's own `<page-type>` tag, not only the `pageType` prop.

## Scope

- Out of scope: the upstream cause of #2 (model inconsistently tagging description as `<note>` vs body text) is a prompt-side issue, not fixed here. This PR only normalizes rendering.
- No behavior change when Notes are **on** for normal text pages — inline term chips and note highlights render exactly as before.
- `npx tsc --noEmit` clean for the component; no existing tests for `NotesRenderer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)