### PR TITLE
feat(librarian): allow anonymous use — no login required

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -4,6 +4,7 @@ import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { streamAgenticResponse, type LibrarianStep, type SourceCard } from '@/lib/embassy/librarian';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
@@ -38,9 +39,24 @@ const chatRequestSchema = z.object({
  *   error      — something went wrong
  */
 export async function POST(request: NextRequest) {
+  // The Librarian is open to everyone — no login required. Signed-in users get
+  // their threads tied to their account; anonymous visitors get ephemeral
+  // public threads. We rate-limit anonymous traffic per-IP because this is an
+  // expensive agentic endpoint (multiple tool calls, up to maxDuration each).
   const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Sign in required' }, { status: 401 });
+  const userId = session?.user?.id ?? null;
+
+  if (!userId) {
+    const rl = checkRateLimit(
+      { name: 'librarian-chat', limit: 20, windowSeconds: 3600 },
+      getClientIp(request),
+    );
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: 'You\'ve reached the hourly limit for anonymous use. Sign in (free) to keep going, or try again later.' },
+        { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } },
+      );
+    }
   }
 
   const body = await request.json();
@@ -55,21 +71,26 @@ export async function POST(request: NextRequest) {
   const { threadId, message, history = [], visibility = 'public', stream = false } = parsed.data;
   const db = await getDb();
 
-  // Get user display name
-  const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
-    { projection: { name: 1, membership: 1 } },
-  );
+  // Get user display name (anonymous visitors skip the lookup)
+  const user = userId
+    ? await db.collection('users').findOne(
+        { _id: userId as any },
+        { projection: { name: 1, membership: 1 } },
+      )
+    : null;
   const displayName = user?.membership?.profile?.displayName || user?.name || 'A visitor';
 
   const now = new Date();
   let activeThreadId: string;
 
   if (threadId) {
-    // Continue existing thread — verify ownership
+    // Continue existing thread — verify ownership. Signed-in users may only
+    // continue their own threads; anonymous visitors may only continue
+    // anonymous (creatorId: null) threads, so they can't append to a
+    // logged-in user's conversation.
     const thread = await db.collection('embassy_threads').findOne({
       _id: new ObjectId(threadId),
-      creatorId: session.user.id,
+      creatorId: userId,
     });
     if (!thread) {
       return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
@@ -79,19 +100,22 @@ export async function POST(request: NextRequest) {
     await db.collection('embassy_messages').insertOne({
       threadId: new ObjectId(threadId),
       authorType: 'human',
-      authorId: session.user.id,
+      authorId: userId,
       authorName: displayName,
       content: message,
       createdAt: now,
     });
   } else {
-    // Create new thread
+    // Create new thread. Anonymous threads are 'unlisted' (null creatorId,
+    // so they can't be claimed via the "mine" filter and aren't surfaced in
+    // the public Recent feed) — the conversation still continues in-session
+    // via threadId. Signed-in users keep their public/private choice.
     const result = await db.collection('embassy_threads').insertOne({
       type: 'chat',
       title: message.slice(0, 120),
-      creatorId: session.user.id,
+      creatorId: userId,
       creatorName: displayName,
-      visibility,
+      visibility: userId ? visibility : 'unlisted',
       aiEnabled: true,
       messageCount: 0,
       createdAt: now,
@@ -102,7 +126,7 @@ export async function POST(request: NextRequest) {
     await db.collection('embassy_messages').insertOne({
       threadId: result.insertedId,
       authorType: 'human',
-      authorId: session.user.id,
+      authorId: userId,
       authorName: displayName,
       content: message,
       createdAt: now,

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -812,8 +812,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                       value={input}
                       onChange={handleInputChange}
                       onKeyDown={handleKeyDown}
-                      placeholder={isSignedIn ? 'Ask the Librarian...' : 'Sign in to ask the Librarian...'}
-                      disabled={!isSignedIn && status !== 'loading'}
+                      placeholder="Ask the Librarian..."
                       rows={1}
                       className="flex-1 resize-none border border-[#e8e4dc] rounded-lg px-4 py-2.5 text-[15px] font-body text-[#1a1612] placeholder-[#8a8480] focus:outline-none focus:border-[#c9a86c] transition-colors bg-transparent disabled:opacity-50"
                     />
@@ -828,7 +827,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                     ) : (
                       <button
                         type="submit"
-                        disabled={!input.trim() || (!isSignedIn && status !== 'loading')}
+                        disabled={!input.trim()}
                         className="flex-shrink-0 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] disabled:opacity-30 transition-colors"
                       >
                         Send
@@ -873,7 +872,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                       <Link href="/auth/signin?callbackUrl=/librarian" className="text-[#9e4a3a] hover:underline">
                         Sign in
                       </Link>
-                      {' '}to talk with the Librarian. Free — no membership required.
+                      {' '}(free) to save your conversations and keep them private.
                     </p>
                   )}
                 </div>

--- a/tests/integration/embassy-api.test.ts
+++ b/tests/integration/embassy-api.test.ts
@@ -102,16 +102,29 @@ describe('Embassy API', () => {
       expect(messages[1].authorName).toBe('The Librarian');
     });
 
-    it('rejects unauthenticated requests', async () => {
+    it('allows unauthenticated requests as an anonymous, unlisted thread', async () => {
       const { auth } = await import('@/lib/auth');
       (auth as any).mockResolvedValueOnce(null);
 
       const req = makeRequest('/api/embassy/chat', {
         message: 'Hello',
+        visibility: 'public',
       });
 
       const res = await chatPost(req as any);
-      expect(res.status).toBe(401);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.threadId).toBeDefined();
+
+      // Anonymous threads carry a null creatorId and are 'unlisted' — they
+      // never surface in the public Recent feed or anyone's "mine" list, even
+      // when the request asked for 'public'.
+      const db = getTestDb();
+      const thread = await db.collection('embassy_threads').findOne({
+        _id: new ObjectId(data.threadId),
+      });
+      expect(thread!.creatorId).toBeNull();
+      expect(thread!.visibility).toBe('unlisted');
     });
 
     it('validates message length', async () => {


### PR DESCRIPTION
## What

Opens the **Librarian** chat to anonymous visitors. (Search was already open — `/api/search` allows same-origin anonymous traffic; the only login wall was the Librarian.)

## Changes

**Server — `src/app/api/embassy/chat/route.ts`**
- The session is now optional. Previously the route hard-returned `401 Sign in required`.
- Anonymous requests are **rate-limited per-IP (20 messages/hour)** via the existing `checkRateLimit` helper, because the Librarian is an expensive agentic endpoint (multiple tool calls, up to `maxDuration` each). Signed-in users are unaffected.
- Anonymous threads carry `creatorId: null` and `visibility: 'unlisted'`:
  - They **continue in-session** via `threadId` (the chat streams normally).
  - They **do not** appear in the public **Recent** feed (`visibility: 'public'` only) or anyone's **My Conversations** (`creatorId` match).
  - An anonymous visitor **cannot append** to a signed-in user's thread (ownership filter is `creatorId: userId`, and anon's userId is null).

**Client — `src/app/librarian/LibrarianClient.tsx`**
- The input box and **Send** button are no longer disabled when logged out.
- The sign-in note changed from "Sign in to talk with the Librarian" → "Sign in (free) to save your conversations and keep them private" — signing in is now an upsell, not a gate.

## Signed-in behavior (unchanged)
Signing in still ties threads to the account, unlocks the public/private toggle, and gives saved history under **My Conversations**.

## Out of scope
- Did not touch the Embassy **rooms** POST gate (`/api/embassy/rooms/[slug]/messages`) — that's a separate social-posting surface, not the Librarian search/chat the request was about.
- Rate limit is the existing in-memory per-instance limiter (same one search uses) — not a new external store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)