### PR TITLE
feat(iiif): serve a single-canvas manifest for artworks

### DIFF
--- a/src/app/api/iiif/[id]/manifest/route.ts
+++ b/src/app/api/iiif/[id]/manifest/route.ts
@@ -258,6 +258,27 @@ export async function GET(
       ])
       .toArray();
 
+    // Visual art (content_type:'artwork') has no `pages` documents — it's a single
+    // object/image. Synthesize one canvas from the book-level image fields so artworks
+    // get a valid IIIF manifest just like books. full_width/full_height match image_full
+    // (both written at import from the same buffer), so canvas dims line up with the body.
+    if (pagesLight.length === 0) {
+      const artImage = (book as any).image_full || (book as any).archived_full_url || (book as any).image_display || book.thumbnail;
+      if (artImage) {
+        pagesLight.push({
+          page_number: 1,
+          photo: artImage,
+          photo_original: (book as any).image_full || (book as any).archived_full_url || artImage,
+          image_width: (book as any).full_width || undefined,
+          image_height: (book as any).full_height || undefined,
+          thumbnail_blob: (book as any).image_thumb || (book as any).image_display || book.thumbnail,
+          thumbnail: (book as any).image_display || book.thumbnail,
+          hasOcr: false,
+          hasTranslation: false,
+        });
+      }
+    }
+
     const manifestId = `${BASE}/api/iiif/${id}/manifest`;
     const originalLang = langCode(book.language);
 


### PR DESCRIPTION
## Why
Artworks (`content_type: 'artwork'`) have no `pages` documents — they're a single object/image — so `/api/iiif/{id}/manifest` produced an empty, canvas-less manifest. They couldn't be opened in a IIIF viewer or cited the way books can. (Surfaced while importing the 49 hashika-e measles prints.)

## What
When a book has zero `pages`, synthesize one canvas from the book-level image fields (`image_full` + `full_width`/`full_height`, which are written from the same buffer at import so the declared canvas dims match the image body). Result: artworks get a valid single-canvas IIIF Presentation manifest, same endpoint as books.

## Scope
- One file: `src/app/api/iiif/[id]/manifest/route.ts`.
- Out of scope: exposing `enrichment.inscriptions` transcription/translation as canvas annotations (follow-up); back-catalog artworks already work since they share the same image fields.

## Test
`curl /api/iiif/<artwork-id>/manifest` now returns one canvas with the full-res image body + thumbnail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)