### PR TITLE
feat: 5 free actions/hour then sign-in for Librarian, voice, and search

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -48,12 +48,15 @@ export async function POST(request: NextRequest) {
 
   if (!userId) {
     const rl = checkRateLimit(
-      { name: 'librarian-chat', limit: 20, windowSeconds: 3600 },
+      { name: 'librarian-chat', limit: 5, windowSeconds: 3600 },
       getClientIp(request),
     );
     if (!rl.allowed) {
       return NextResponse.json(
-        { error: 'You\'ve reached the hourly limit for anonymous use. Sign in (free) to keep going, or try again later.' },
+        {
+          error: 'You\'ve used your 5 free questions this hour. Sign in (free) to keep talking with the Librarian.',
+          code: 'SIGNIN_REQUIRED',
+        },
         { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } },
       );
     }

--- a/src/app/api/embassy/voice/route.ts
+++ b/src/app/api/embassy/voice/route.ts
@@ -1,10 +1,29 @@
 import { NextResponse } from 'next/server';
+import { anonActionGate, SIGNIN_URL } from '@/lib/anon-gate';
+
+export const dynamic = 'force-dynamic';
 
 /**
  * GET /api/embassy/voice — Generate a signed URL for the ElevenLabs Conversational AI agent.
  * This keeps the agent private (not callable without a signed URL).
+ *
+ * Open to everyone, but anonymous visitors get 5 voice sessions/hour (each
+ * "Begin" fetches a fresh signed URL); past that we return 401 with a sign-in
+ * CTA. Signed-in users, SEO crawlers, and internal warmers are exempt.
  */
-export async function GET() {
+export async function GET(request: Request) {
+  const gate = await anonActionGate(request, { name: 'voice-anon', limit: 5 });
+  if (!gate.allowed) {
+    return NextResponse.json(
+      {
+        error: 'You\'ve used your 5 free voice sessions this hour. Sign in (free) to keep talking with the Librarian.',
+        code: 'SIGNIN_REQUIRED',
+        sign_in: SIGNIN_URL,
+      },
+      { status: 401, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : {} },
+    );
+  }
+
   const agentId = process.env.ELEVENLABS_AGENT_ID;
   const apiKey = process.env.ELEVENLABS_API_KEY;
 

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -7,6 +7,7 @@ import { searchBooksCatalog } from '@/lib/books-catalog';
 import { searchBookIds } from '@/lib/books-catalog';
 import { semanticBookSearch, semanticArtworkSearch } from '@/lib/semantic-search';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+import { anonSearchGate, SIGNIN_URL } from '@/lib/anon-gate';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { CLIP_URL } from '@/lib/clip';
 
@@ -66,6 +67,23 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const tenantContext = getTenantContextFromRequest(request.headers);
     const query = searchParams.get('q') || '';
+
+    // Anonymous visitors get 5 distinct searches/hour, then a sign-in prompt.
+    // Counts distinct query strings (not raw requests) so typeahead and filter
+    // refinement of one search don't burn the allowance. Signed-in users, SEO
+    // crawlers, and internal warmers are exempt (see anon-gate.ts).
+    const gate = await anonSearchGate(request, query);
+    if (!gate.allowed) {
+      return NextResponse.json(
+        {
+          error: 'You\'ve used your 5 free searches this hour. Sign in (free) to keep searching.',
+          code: 'SIGNIN_REQUIRED',
+          sign_in: SIGNIN_URL,
+        },
+        { status: 401, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : {} },
+      );
+    }
+
     const limit = Math.min(parseInt(searchParams.get('limit') || '8'), 12);
     const galleryLimit = Math.min(parseInt(searchParams.get('gallery_limit') || '6'), 12);
 

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -400,10 +400,12 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 429 || err.code === 'SIGNIN_REQUIRED') {
+          // Anonymous visitors get a few free questions; past that we ask them
+          // to sign in (free) to continue.
           updateLastAssistant(m => ({
             ...m,
-            content: 'Please [sign in](/auth/signin?callbackUrl=/librarian) to talk with the Librarian. It\'s free — just create an account or sign in with Google.',
+            content: 'You\'ve used your free questions for now. [Sign in](/auth/signin?callbackUrl=/librarian) (free) to keep talking with the Librarian — create an account or sign in with Google.',
           }));
         } else {
           updateLastAssistant(m => ({ ...m, content: err.error || 'Something went wrong. Please try again.' }));

--- a/src/app/librarian/voice/VoiceAgentClient.tsx
+++ b/src/app/librarian/voice/VoiceAgentClient.tsx
@@ -136,6 +136,7 @@ function VoiceAgentInner() {
   const [showVisuals, setShowVisuals] = useState(true);
   const [agentSpeaking, setAgentSpeaking] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [signInRequired, setSignInRequired] = useState(false);
   const [volume, setVolume] = useState(0);
   const [textInput, setTextInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -190,9 +191,18 @@ function VoiceAgentInner() {
   const [pttMode, setPttMode] = useState(true);
 
   const start = async () => {
-    setAppStatus('connecting'); setErrorMsg(null); setTranscript([]); setSources([]); setVisuals([]);
+    setAppStatus('connecting'); setErrorMsg(null); setSignInRequired(false); setTranscript([]); setSources([]); setVisuals([]);
     try {
-      const res = await fetch('/api/embassy/voice'); if (!res.ok) throw new Error(`Signed URL failed: ${res.status}`);
+      const res = await fetch('/api/embassy/voice');
+      if (res.status === 401) {
+        // Anonymous voice-session allowance used up — ask the visitor to sign in.
+        const body = await res.json().catch(() => ({}));
+        setSignInRequired(true);
+        setErrorMsg(body.error || 'You\'ve used your free voice sessions for now. Sign in (free) to keep going.');
+        setAppStatus('error');
+        return;
+      }
+      if (!res.ok) throw new Error(`Signed URL failed: ${res.status}`);
       const { signedUrl } = await res.json();
       conversation.startSession({
         signedUrl,
@@ -260,6 +270,12 @@ function VoiceAgentInner() {
               </button>
             )}
             {errorMsg && <p className="text-red-300 text-sm mt-5 font-sans max-w-[360px]">{errorMsg}</p>}
+            {signInRequired && (
+              <Link href="/auth/signin?callbackUrl=/librarian/voice"
+                className="mt-3 inline-block px-5 py-2.5 rounded-full bg-[#c9a86c]/90 hover:bg-[#c9a86c] text-[#0e0c0a] text-sm font-sans font-medium transition-colors">
+                Sign in &mdash; free
+              </Link>
+            )}
             <Link href="/librarian" className="mt-10 text-sm text-white/50 hover:text-white/80 font-display">Prefer to type? Switch to text chat &rarr;</Link>
           </div>
         </div>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -87,6 +87,9 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
   const [query, setQuery] = useState(searchParams.get('q') || '');
   const [viewMode, setViewMode] = useState<ViewMode>(initialMode);
   const [loading, setLoading] = useState(false);
+  // Anonymous visitors get 5 free searches/hour; past that the API 401s and we
+  // show a sign-in wall instead of results.
+  const [signInRequired, setSignInRequired] = useState(false);
 
   // Unified results
   const [bookResults, setBookResults] = useState<SearchResult[]>([]);
@@ -383,6 +386,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
       return;
     }
     setLoading(true);
+    setSignInRequired(false);
 
     try {
       if (mode === 'unified') {
@@ -507,8 +511,23 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             if (oldest) searchCache.current.delete(oldest[0]);
           }
         } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          // Anonymous free-search allowance exhausted — show the sign-in wall
+          // and stop (don't fire the parallel agents or report an error).
+          if (/free searches this hour/i.test(msg) || /SIGNIN_REQUIRED/.test(msg)) {
+            setSignInRequired(true);
+            setBookResults([]); setBookTotal(0);
+            setIndexResults([]); setIndexTotal(0);
+            setImageResults([]); setImageTotal(0);
+            setCollectionResults([]); setSemanticResults([]);
+            // Stop the parallel AI-expand stream so nothing leaks past the wall.
+            aiAbortRef.current?.();
+            setAiResults([]); setAiNarration(''); setAiStreaming(false);
+            setLoading(false);
+            return;
+          }
           reportError({
-            message: `Unified search failed: ${err instanceof Error ? err.message : String(err)}`,
+            message: `Unified search failed: ${msg}`,
             source: 'search_query',
           });
         }
@@ -769,7 +788,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
 
   // Fuzzy suggestions on zero results
   const totalResults = bookTotal + indexTotal + imageTotal;
-  const noResults = query.length >= 2 && !loading && !semanticLoading && !passageLoading && !catalogLoading && totalResults === 0 && semanticResults.length === 0 && passageResults.length === 0 && catalogResults.length === 0;
+  const noResults = !signInRequired && query.length >= 2 && !loading && !semanticLoading && !passageLoading && !catalogLoading && totalResults === 0 && semanticResults.length === 0 && passageResults.length === 0 && catalogResults.length === 0;
   useEffect(() => {
     if (!noResults || query.length < 3) { setSuggestion(null); return; }
     let cancelled = false;
@@ -1110,6 +1129,20 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
 
       {/* Results */}
       <main className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 py-8">
+        {/* Anonymous free-search wall — shown after 5 searches/hour */}
+        {signInRequired && (
+          <div className="text-center py-16 max-w-lg mx-auto">
+            <Search className="w-16 h-16 text-border-medium mx-auto mb-4" />
+            <h2 className="text-2xl font-serif font-medium text-primary mb-2">Sign in to keep searching</h2>
+            <p className="text-secondary mb-6">
+              You&rsquo;ve used your free searches for now. Sign in &mdash; it&rsquo;s free &mdash; to keep exploring over 10,000 primary sources.
+            </p>
+            <Link href="/auth/signin?callbackUrl=/search"
+              className="inline-block px-6 py-3 rounded-xl bg-accent-rust text-white font-medium hover:bg-accent-rust/90 transition-colors">
+              Sign in &mdash; free
+            </Link>
+          </div>
+        )}
         {/* Browse gallery — shown when no query + images tab */}
         {isBrowseMode && viewMode === 'images' && (
           <div>
@@ -1369,7 +1402,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         )}
 
         {/* ==================== UNIFIED VIEW — ADAPTIVE LAYOUT ==================== */}
-        {viewMode === 'unified' && !loading && query.length >= 2 && (totalResults > 0 || semanticResults.length > 0 || semanticLoading || passageResults.length > 0 || passageLoading || catalogResults.length > 0 || catalogLoading) && (() => {
+        {!signInRequired && viewMode === 'unified' && !loading && query.length >= 2 && (totalResults > 0 || semanticResults.length > 0 || semanticLoading || passageResults.length > 0 || passageLoading || catalogResults.length > 0 || catalogLoading) && (() => {
           const keywordIds = new Set(bookResults.map(b => b.id || (b as any).book_id));
           const uniqueSemantic = semanticResults.filter((sem: any) => !keywordIds.has(sem.book_id));
           const hasBoth = bookResults.length > 0 && uniqueSemantic.length > 0;
@@ -1665,7 +1698,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         )}
 
         {/* AI-expanded related results — shows for all searches with results */}
-        {!noResults && !loading && query.length >= 3 && !aiStreaming && aiResults.length > 0 && (
+        {!signInRequired && !noResults && !loading && query.length >= 3 && !aiStreaming && aiResults.length > 0 && (
           <section className="mt-12 pt-8 border-t border-border-light">
             <h2 className="text-sm font-medium text-muted uppercase tracking-wide mb-4">Related in the Library</h2>
             <div className="space-y-3">

--- a/src/lib/anon-gate.ts
+++ b/src/lib/anon-gate.ts
@@ -1,0 +1,124 @@
+/**
+ * Anonymous-access gates for the public AI surfaces (Librarian text chat, voice,
+ * and search). These let signed-out visitors use the features a few times, then
+ * return a 401 that the client turns into a "sign in (free) to continue" prompt —
+ * driving sign-ups while keeping the door open for a real first taste.
+ *
+ * These intentionally differ from `withApiAuth` (src/lib/api-auth.ts): that gate
+ * meters EXTERNAL API consumers and deliberately EXEMPTS same-origin browser
+ * traffic. The gates here are for the browser UI itself, so same-origin is NOT
+ * exempt — the whole point is to meter logged-out humans on the site.
+ *
+ * Always exempt: signed-in users, verified SEO crawlers, and internal cache
+ * warmers (which send `X-Warm-Ping`).
+ */
+import { auth } from '@/lib/auth';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+
+export const SIGNIN_URL = 'https://sourcelibrary.org/auth/signin';
+
+// Same list withApiAuth uses — UA substrings that get the SEO-crawler bypass so
+// indexing is never walled. Spoofable, but the worst case is a scraper getting
+// the same access as a logged-out human.
+const VERIFIED_BOT_UAS = [
+  'googlebot', 'google-extended', 'bingbot', 'msnbot',
+  'duckduckbot', 'applebot', 'mojeekbot',
+];
+
+function isVerifiedBot(request: Request): boolean {
+  const ua = (request.headers.get('user-agent') || '').toLowerCase();
+  return VERIFIED_BOT_UAS.some(sig => ua.includes(sig));
+}
+
+async function hasSession(): Promise<boolean> {
+  try {
+    const session = await auth();
+    return !!session?.user?.id;
+  } catch {
+    // auth() can throw in some runtime contexts — treat as anonymous.
+    return false;
+  }
+}
+
+/** True when this request should bypass anon gating entirely. */
+async function isExempt(request: Request): Promise<boolean> {
+  if (request.headers.get('x-warm-ping')) return true; // internal cache warmers
+  if (isVerifiedBot(request)) return true;             // SEO crawlers
+  if (await hasSession()) return true;                 // signed-in users
+  return false;
+}
+
+export interface GateResult {
+  allowed: boolean;
+  /** Seconds until the window resets, when blocked. */
+  retryAfter?: number;
+}
+
+/**
+ * Per-IP hourly action gate for anonymous users. Use for discrete, expensive
+ * actions where one request == one action (e.g. starting a voice session,
+ * sending a Librarian message).
+ */
+export async function anonActionGate(
+  request: Request,
+  opts: { name: string; limit: number; windowSeconds?: number },
+): Promise<GateResult> {
+  if (await isExempt(request)) return { allowed: true };
+  const rl = checkRateLimit(
+    { name: opts.name, limit: opts.limit, windowSeconds: opts.windowSeconds ?? 3600 },
+    getClientIp(request),
+  );
+  return rl.allowed ? { allowed: true } : { allowed: false, retryAfter: rl.retryAfter };
+}
+
+// ── Distinct-query quota (search) ──────────────────────────────────────────
+// Search is typeahead: the /search page fires /api/search/unified on debounced
+// input AND on every filter change, so one user "search" is several requests.
+// Counting raw requests would wall a visitor mid-first-search. Instead we count
+// DISTINCT normalized query strings per IP per window — refining filters or
+// re-running the same query is free; the Nth *new* query trips the gate.
+
+interface SearchBucket { queries: Set<string>; resetAt: number }
+const searchBuckets = new Map<string, SearchBucket>();
+
+function distinctQueryQuota(
+  ip: string,
+  query: string,
+  limit: number,
+  windowSeconds: number,
+): GateResult {
+  const now = Date.now();
+
+  // Prune stale buckets occasionally to bound memory.
+  if (searchBuckets.size > 5000 && Math.random() < 0.01) {
+    for (const [key, val] of searchBuckets) if (val.resetAt < now) searchBuckets.delete(key);
+  }
+
+  let bucket = searchBuckets.get(ip);
+  if (!bucket || bucket.resetAt < now) {
+    bucket = { queries: new Set(), resetAt: now + windowSeconds * 1000 };
+    searchBuckets.set(ip, bucket);
+  }
+
+  const norm = query.trim().toLowerCase().slice(0, 200);
+  if (!norm) return { allowed: true };           // empty query — never counts
+  if (bucket.queries.has(norm)) return { allowed: true }; // already counted this query
+  if (bucket.queries.size >= limit) {
+    return { allowed: false, retryAfter: Math.ceil((bucket.resetAt - now) / 1000) };
+  }
+  bucket.queries.add(norm);
+  return { allowed: true };
+}
+
+/**
+ * Anonymous search gate: N distinct queries per hour, then sign-in. Exempts
+ * signed-in users, SEO crawlers, and internal warmers.
+ */
+export async function anonSearchGate(
+  request: Request,
+  query: string,
+  limit = 5,
+): Promise<GateResult> {
+  if (await isExempt(request)) return { allowed: true };
+  return distinctQueryQuota(getClientIp(request), query, limit, 3600);
+}


### PR DESCRIPTION
## What

Extends the anonymous-access model (just shipped for the text Librarian in #2366) to **voice** and **search**, and tightens all three to **5 free actions/hour** for signed-out visitors, after which they get a **sign in (free)** prompt.

Per Derek's call: search lowered to match (5/hour) rather than staying at its old 60/hour allowance.

## New shared gate — `src/lib/anon-gate.ts`

Unlike `withApiAuth` (which meters *external* API consumers — MCP/SDK/scrapers — and **deliberately exempts same-origin browser traffic**), these gates are for the **browser UI itself**, so same-origin is *not* exempt. Always exempt: **signed-in users**, **verified SEO crawlers**, and **internal cache warmers** (`X-Warm-Ping`).

## Surfaces

| Surface | Before | After |
|---|---|---|
| Librarian text (`/api/embassy/chat`) | 20/hour anon | **5/hour**, client shows markdown sign-in prompt |
| Voice (`/api/embassy/voice`) | **wide open, no limit** | **5 sessions/hour** anon → 401, voice client shows sign-in button |
| Search (`/api/search/unified`) | 60/hour (different gate) | **5 distinct queries/hour** anon → 401, search page shows sign-in wall |

## Why search counts *distinct queries*, not requests

The `/search` page fires `/api/search/unified` on **debounced typeahead** *and* on **every filter change** — one user search is several requests. A literal 5-request cap would wall a visitor mid-first-search. So the gate counts **distinct normalized query strings** per IP/hour: refining filters or re-running the same query is free; the 6th *new* query trips the wall. The page also aborts the parallel AI-expand stream on the 401 so nothing leaks past the wall.

## Not changed
- Signed-in users: unaffected.
- `withApiAuth` routes (book reading APIs, MCP): untouched — lowering its shared anon limit would have throttled book reads + MCP, so search got its own gate instead.
- In-book search (`/api/books/[id]/search`) and the global header in-book panel: not gated (that's reading, not discovery).

## Verification
- `npx tsc --noEmit`: clean on touched files.
- Embassy integration tests: 10/10 pass (anon chat still allowed, now at the 5-limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)