### PR TITLE
fix(cover-picker): serve thumbnails, not full-res scans

### DIFF
--- a/scripts/maintenance/fix-fullres-page-thumbs.mjs
+++ b/scripts/maintenance/fix-fullres-page-thumbs.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Fix page docs whose thumbnail fields point at the FULL-RES image instead of
+ * the small pre-sized thumbnail.
+ *
+ * Symptom: the "Choose Cover Image" picker (and any grid that reads
+ * `image_thumb` / `thumbnail_blob` directly) downloads multi-MB `…-full.jpg`
+ * scans where it should load the ~2 KB `…-thumb.jpg`. Seen on legacy-split BPH
+ * books (e.g. books-of-alchemy-geber, 6970e3609b09d309d780a266) where an old
+ * split/thumbnail pass wrote the `pages/{book}/{NNNN}-full.jpg` URL into the
+ * thumb fields. The matching `{NNNN}-thumb.jpg` exists on R2 — it's just not
+ * referenced.
+ *
+ * This is a PURE SIZE SWAP of the identical image (`-full` → `-thumb`), built
+ * together by the variant generator, so it never changes WHICH image a page
+ * shows — only its byte size. We HEAD-verify the `-thumb.jpg` exists before
+ * writing; if it's missing we leave the field untouched.
+ *
+ * Out of scope (left for the resolver's /api/image proxy to size at render
+ * time): legacy `/cropped/{objectid}.jpg` URLs, which have no derivable
+ * pre-sized sibling and would need a fresh thumbnail generated.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --book <bookId>          # dry run, one book
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --book <bookId> --apply  # write, one book
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --all                    # dry run, whole library
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --all --apply            # write, whole library
+ */
+
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const ALL = process.argv.includes('--all');
+const bookIdx = process.argv.indexOf('--book');
+const BOOK_ID = bookIdx !== -1 ? process.argv[bookIdx + 1] : null;
+const CONCURRENCY = 24;
+
+// Heavy field value we want to replace: a canonical pages/ full-res image.
+// images.sourcelibrary.org/pages/{book}/{digits}-full.jpg
+const FULL_RE = /^(https:\/\/images\.sourcelibrary\.org\/pages\/[a-f0-9-]+\/\d{3,})-full\.jpg$/;
+const THUMB_FIELDS = ['image_thumb', 'thumbnail_blob'];
+
+const headCache = new Map();
+async function exists(url) {
+  if (headCache.has(url)) return headCache.get(url);
+  let ok = false;
+  try {
+    const r = await fetch(url, { method: 'HEAD' });
+    ok = r.status === 200;
+  } catch {
+    ok = false;
+  }
+  headCache.set(url, ok);
+  return ok;
+}
+
+async function main() {
+  if (!process.env.MONGODB_URI) {
+    console.error('MONGODB_URI not set. source .env.production.local first.');
+    process.exit(1);
+  }
+  if (!ALL && !BOOK_ID) {
+    console.error('Pass --book <bookId> or --all.');
+    process.exit(1);
+  }
+
+  const client = new MongoClient(process.env.MONGODB_URI, {
+    serverSelectionTimeoutMS: 30000,
+    socketTimeoutMS: 0,
+  });
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+  const pages = db.collection('pages');
+
+  // Match pages where EITHER thumb field is a -full.jpg pages URL.
+  const fullRegex = { $regex: '^https://images\\.sourcelibrary\\.org/pages/[a-f0-9-]+/\\d{3,}-full\\.jpg$' };
+  const query = {
+    $or: [{ image_thumb: fullRegex }, { thumbnail_blob: fullRegex }],
+  };
+  if (BOOK_ID) query.book_id = BOOK_ID;
+
+  console.log(`mode: ${APPLY ? 'APPLY (writes will happen)' : 'DRY RUN (no writes)'}  scope: ${BOOK_ID ? `book ${BOOK_ID}` : 'ALL books'}`);
+
+  const cursor = pages.find(query, {
+    projection: { _id: 1, book_id: 1, page_number: 1, image_thumb: 1, thumbnail_blob: 1 },
+  });
+
+  let scanned = 0, fixable = 0, written = 0, missingThumb = 0;
+  let queue = [];
+
+  const flush = async () => {
+    if (queue.length === 0) return;
+    const batch = queue.splice(0, queue.length);
+    await Promise.all(batch.map(async (page) => {
+      const set = {};
+      for (const field of THUMB_FIELDS) {
+        const val = page[field];
+        const m = val && FULL_RE.exec(val);
+        if (!m) continue;
+        const thumbUrl = `${m[1]}-thumb.jpg`;
+        if (await exists(thumbUrl)) {
+          set[field] = thumbUrl;
+        } else {
+          missingThumb++;
+        }
+      }
+      if (Object.keys(set).length === 0) return;
+      fixable++;
+      if (APPLY) {
+        await pages.updateOne({ _id: page._id }, { $set: { ...set, updated_at: new Date() } });
+        written++;
+      }
+      if (fixable <= 10 || fixable % 200 === 0) {
+        console.log(`  fix ${page.book_id} p${page.page_number}: ${Object.keys(set).join(',')} -> -thumb.jpg`);
+      }
+    }));
+  };
+
+  for await (const page of cursor) {
+    scanned++;
+    queue.push(page);
+    if (queue.length >= CONCURRENCY) await flush();
+    if (scanned % 1000 === 0) console.log(`  ...scanned ${scanned}, fixable ${fixable}`);
+  }
+  await flush();
+
+  console.log('---');
+  console.log(`scanned (matched -full thumb):   ${scanned}`);
+  console.log(`fixable (thumb sibling exists):  ${fixable}`);
+  console.log(`thumb sibling MISSING (skipped): ${missingThumb}`);
+  console.log(`written:                         ${written}${APPLY ? '' : ' (dry run — re-run with --apply)'}`);
+
+  await client.close();
+}
+
+main().catch(err => { console.error('FAILED:', err); process.exit(1); });

--- a/src/components/book/CoverImagePicker.tsx
+++ b/src/components/book/CoverImagePicker.tsx
@@ -7,6 +7,7 @@ import { BookOpen, X, Check, Loader2 } from 'lucide-react';
 import { books } from '@/lib/api-client';
 import type { Page } from '@/lib/types';
 import { buildCoverUpdate } from '@/lib/cover-fields';
+import { getPageImageUrl } from '@/lib/page-image-url';
 import { AuthCheck } from '../auth/AuthCheck';
 
 interface CoverImagePickerProps {
@@ -44,25 +45,6 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, handleClose]);
-
-  const getPageImageUrl = (page: Page) => {
-    const typedPage = page as Page & { archived_photo?: string; cropped_photo?: string };
-
-    // Split pages: use cropped_photo (the actual half-page image).
-    // `page.photo` points at the full uncropped spread for these, so
-    // returning it would render both halves of the spread instead of
-    // the individual page.
-    if (page.split_from_spread || page.crop) {
-      return typedPage.cropped_photo || page.photo;
-    }
-
-    // Prefer pre-generated R2 thumbnail (fast CDN)
-    if (page.thumbnail_blob) return page.thumbnail_blob;
-
-    const baseUrl = typedPage.archived_photo || page.photo_original || page.photo;
-    if (!baseUrl) return null;
-    return `/api/image?url=${encodeURIComponent(baseUrl)}&w=150&q=60`;
-  };
 
   const selectCover = async (page: Page) => {
     setSaving(page.id);
@@ -167,7 +149,10 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
             <div className="p-4 overflow-y-auto max-h-[calc(85vh-80px)]">
               <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-3">
                 {pages.map((page) => {
-                  const imageUrl = getPageImageUrl(page);
+                  // Canonical resolver: always a size-bounded thumbnail (pre-sized
+                  // R2 variant, IIIF resize, or /api/image proxy) — never the raw
+                  // full-res scan. Fixes the picker loading multi-MB images per cell.
+                  const imageUrl = getPageImageUrl(page, 'thumb');
                   const typedPage = page as Page & { archived_photo?: string };
                   const baseUrl = typedPage.archived_photo || page.photo_original || page.photo;
                   const isCurrentCover = currentThumbnail?.includes(encodeURIComponent(baseUrl));
@@ -188,6 +173,8 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
                           src={imageUrl}
                           alt={`Page ${page.page_number}`}
                           className="w-full h-full object-cover"
+                          loading="lazy"
+                          decoding="async"
                         />
                       )}
                       {isCurrentCover && (


### PR DESCRIPTION
## Problem

The **Choose Cover Image** picker (and any grid reading page thumb fields directly) was slow because it downloaded **full-resolution page scans** — 1.5–2.9 MB each, ~30 per grid, no lazy-loading — and shrank them in the browser.

Root cause: on legacy-split BPH books (e.g. [books-of-alchemy-geber](https://sourcelibrary.org/book/books-of-alchemy-geber), 332 pages, 330 split) the page docs' `image_thumb` / `thumbnail_blob` point at `pages/{book}/{NNNN}-full.jpg` instead of the ~2 KB `{NNNN}-thumb.jpg` sibling that already exists on R2 right beside it. The picker also had its own ad-hoc URL logic that returned `cropped_photo`/`photo` (raw full-res) for split pages, bypassing the thumbnail entirely.

## Fix

**1. Picker → canonical resolver.** `CoverImagePicker` now calls `getPageImageUrl(page, 'thumb')` from `src/lib/page-image-url.ts` instead of rolling its own. That resolver always returns a size-bounded URL (pre-sized R2 variant → IIIF resize → `/api/image` proxy) and is split-aware. Added `loading="lazy"` + `decoding="async"` to the grid `<img>`s.

**2. Data backfill.** `scripts/maintenance/fix-fullres-page-thumbs.mjs` repoints `image_thumb`/`thumbnail_blob` from `{NNNN}-full.jpg` to `{NNNN}-thumb.jpg` where the thumb sibling exists on R2 (HEAD-verified). This is a **pure size swap of the identical image** (both built together by the variant generator) — it never changes *which* image a page shows, only its byte size. Dry-run by default; `--book <id>` or `--all`, `--apply` to write.

Applied to Geber already (123 pages → all now point at the 2 KB thumb; 0 remaining heavy). Library-wide run in progress.

## Out of scope

Legacy `/cropped/{objectid}.jpg` thumb URLs have no derivable pre-sized sibling — generating fresh thumbnails for those is a separate pipeline job. Until then the resolver sizes them via the `/api/image` proxy (150px, Cloudflare-cached) at render time, so the picker is still fast for them.

## Test

- `npx tsc --noEmit` — no new errors (pre-existing d3/carbon-ledger blog errors only).
- Backfill dry-run + apply verified on Geber: 123 fixable, 123 thumb siblings present, 0 missing, 123 written, 0 remaining heavy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)