### PR TITLE
feat(iiif-discovery): Leiden University Libraries source adapter

### DIFF
--- a/scripts/iiif-discovery/README.md
+++ b/scripts/iiif-discovery/README.md
@@ -5,22 +5,51 @@ Bulk discovery and import of pre-1800 books from IIIF-enabled digital libraries.
 ## Architecture
 
 ```
-Discovery (OAI-PMH / SRU / IIIF Collections)
-  → import_candidates (MongoDB staging collection)
-    → import-batch.mjs (dedup + import via /api/import/iiif)
-      → books collection (main library)
-        → OCR/translation pipeline
+1. ENUMERATE   sources/<x>.mjs            → import_candidates (id + manifest_url + metadata)
+2. CACHE       harvest-manifests.mjs      → manifest_cache on each candidate (pages + rights)
+3. DEDUPE      analyze/dedupe-candidates  → mark dupes vs the library + cross-source
+4. IMPORT      import-from-cache.mjs       → books (+ pages) HIDDEN   [offline, no network]
+                                          → QA → flip visible
 ```
 
-**Two-phase approach:**
-1. **Discovery** — harvest metadata + manifest URLs from each source into `import_candidates`
-2. **Import** — batch import from candidates, with dedup checking, into the main collection
+**Why four stages (not two).** A staging collection (`import_candidates`) decouples
+discovery from import. The key piece is the **manifest-cache stage**: it fetches each
+candidate's IIIF manifest exactly once — isolating all the slow, rate-limited, or
+browser-driven network work into one resumable pass — and stores the per-page image
+URLs + rights on the candidate. Import is then a fast, offline, idempotent DB→DB
+operation. A throttled source (Leiden F5, Harvard 429) is hit once.
 
-This separation means:
-- Discovery can run independently per source
-- Candidates can be reviewed/filtered before import
-- Everything is resumable
-- Progress is tracked per source
+- Each stage runs independently and is fully resumable
+- Network work (the expensive part) happens once, in stage 2
+- Candidates are deduped/reviewed before any write to `books`
+- `import-from-cache` routes by shape: 1 canvas → `content_type:'artwork'`,
+  >1 → book + per-page docs. No bespoke importer per source.
+
+**Two ways to enumerate (stage 1):** rich adapters fetch the manifest during
+enumeration (fine for fast sources); `--enumerate-only` (e.g. `sources/leiden.mjs`)
+records just id + manifest_url and leaves the single fetch to stage 2 — best for
+slow/bot-walled sources, avoids fetching each manifest twice.
+
+**Legacy path:** `import-batch.mjs` is the older one-shot importer (manifest fetched
+server-side via `/api/import/iiif`, books only). Still fine for fast/open/book
+sources; it breaks on artworks and datacenter-429/F5 sources — those use the
+cache→import-from-cache path (or a direct importer like `import-leiden-{artworks,books}.mjs`).
+
+### The new pipeline, end to end
+
+```bash
+set -a; source .env.production.local; set +a
+# 1. enumerate (lightweight) — e.g. Indonesian maps from Leiden
+node scripts/iiif-discovery/sources/leiden.mjs --collection=ubl_maps \
+  --extra-facet="mods_originInfo_place_placeTerm_text_authority_marccountry_ms:Indonesia" --enumerate-only
+# 2. cache every manifest once (browser fetcher auto-selected for leiden)
+node scripts/iiif-discovery/harvest-manifests.mjs --source=leiden --collection=ubl_maps
+# 3. (optional) dedupe/analyze
+node scripts/iiif-discovery/analyze-candidates.mjs --source=leiden --mark-dupes
+# 4. import offline — routes artwork vs book automatically; lands HIDDEN
+node scripts/iiif-discovery/import-from-cache.mjs --source=leiden --collection=ubl_maps \
+  --sl-collection=indonesian-maps --book-type=map --facsimile --dry-run
+```
 
 ## Sources
 

--- a/scripts/iiif-discovery/harvest-manifests.mjs
+++ b/scripts/iiif-discovery/harvest-manifests.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Stage 2 of the pipeline: BULK-HARVEST every candidate's IIIF manifest ONCE.
+ *
+ *   enumerate (sources/*.mjs) → import_candidates
+ *   → THIS: harvest-manifests.mjs   (fetch + cache each manifest's pages + rights)
+ *   → import-from-cache.mjs         (offline DB→DB insert; no network)
+ *
+ * Why a distinct stage: it isolates ALL the slow / rate-limited / browser-driven
+ * network work into one resumable pass, so import is a fast, offline, idempotent
+ * DB operation. A throttled source (Leiden F5, Harvard 429) gets hit exactly once.
+ *
+ * It writes a `manifest_cache` subdoc onto each candidate:
+ *   { harvested_at, canvas_count, rights, license, label, pages: [{photo,thumbnail}] }
+ * and refreshes top-level page_count + metadata.rights.
+ *
+ * Source-aware fetch strategy (FETCHERS registry):
+ *   - 'browser' — Playwright navigation (sources behind JS/bot walls, e.g. leiden)
+ *   - 'plain'   — plain fetch (most open IIIF servers); also works residentially
+ *                 for datacenter-429 sources (run from a residential IP).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/iiif-discovery/harvest-manifests.mjs --source=leiden --collection=ubl_maps
+ *   node scripts/iiif-discovery/harvest-manifests.mjs --source=erara --limit=500
+ *   node scripts/iiif-discovery/harvest-manifests.mjs --source=leiden --fetcher=browser --refetch
+ *
+ * Options:
+ *   --source=<s>          only this source (default: all)
+ *   --collection=<slug>   only candidates with this category tag
+ *   --fetcher=plain|browser   override the per-source default
+ *   --limit=N             cap candidates this run
+ *   --refetch             re-harvest even if manifest_cache exists
+ *   --drop-restricted     mark non-open candidates 'skipped' (default: keep, flagged)
+ */
+
+import { chromium } from 'playwright';
+import { getScriptClient } from '../lib/mongo.mjs';
+import { manifestToPages, manifestRights, extractLabel, extractManifestMetadata } from './lib/iiif-metadata.mjs';
+
+const args = Object.fromEntries(
+  process.argv.slice(2).filter(a => a.startsWith('--')).map(a => { const [k, v] = a.slice(2).split('='); return [k, v ?? true]; })
+);
+const SOURCE = args.source || null;
+const COLLECTION = args.collection || null;
+const LIMIT = parseInt(args.limit) || 100000;
+const REFETCH = 'refetch' in args;
+const DROP_RESTRICTED = 'drop-restricted' in args;
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+const CHALLENGE_RE = /bobcmn|support id is|failureConfig/i;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// Per-source default fetch strategy. Override with --fetcher.
+const FETCHERS = { leiden: 'browser' };
+const fetcherFor = src => args.fetcher || FETCHERS[src] || 'plain';
+
+// ---- plain fetcher (open servers / residential) ----
+async function fetchPlain(url) {
+  for (let t = 0; t < 4; t++) {
+    try {
+      const r = await fetch(url, { headers: { 'User-Agent': UA, Accept: 'application/json,application/ld+json,*/*' } });
+      if (r.status === 429 || r.status >= 500) { await sleep(2000 * (t + 1)); continue; }
+      if (!r.ok) return { error: r.status };
+      const txt = await r.text();
+      try { return { manifest: JSON.parse(txt) }; } catch { return { error: 'not-json' }; }
+    } catch (e) { await sleep(2000 * (t + 1)); }
+  }
+  return { error: 'fetch-failed' };
+}
+
+// ---- browser fetcher (JS/bot-walled servers, e.g. Leiden F5) ----
+async function fetchBrowser(page, url) {
+  for (let t = 0; t < 6; t++) {
+    try { await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 }); }
+    catch { await sleep(3000 * (t + 1)); continue; }
+    await sleep(500);
+    const txt = await page.evaluate(() => document.body?.innerText || '');
+    if (txt.trim().startsWith('{') && !CHALLENGE_RE.test(txt)) { try { return { manifest: JSON.parse(txt) }; } catch { return { error: 'not-json' }; } }
+    if (/no manifest available/i.test(txt)) return { error: 'no-manifest' };
+    await sleep(4000 * (t + 1));
+  }
+  return { error: 'challenged' };
+}
+
+const { client, db } = await getScriptClient({ noTimeout: true });
+const col = db.collection('import_candidates');
+const filter = { status: 'discovered' };
+if (SOURCE) filter.source = SOURCE;
+if (COLLECTION) filter.categories = COLLECTION;
+if (!REFETCH) filter['manifest_cache.harvested_at'] = { $exists: false };
+
+const cands = await col.find(filter).limit(LIMIT).toArray();
+const fetcher = fetcherFor(SOURCE);
+console.log(`[harvest-manifests] ${cands.length} candidates (source=${SOURCE || 'all'}, collection=${COLLECTION || 'all'}) via ${fetcher} fetcher\n`);
+
+let browser = null, page = null;
+if (fetcher === 'browser') { browser = await chromium.launch({ headless: true }); page = await (await browser.newContext({ userAgent: UA })).newPage(); }
+
+let cached = 0, restricted = 0, errors = 0, idx = 0;
+for (const c of cands) {
+  idx++;
+  const res = fetcher === 'browser' ? await fetchBrowser(page, c.manifest_url) : await fetchPlain(c.manifest_url);
+  if (res.error) { errors++; if (errors <= 8) console.log(`  [err ${idx}/${cands.length}] ${c.source_id || c.manifest_url} → ${res.error}`); await sleep(fetcher === 'browser' ? 1200 : 200); continue; }
+
+  const m = res.manifest;
+  const pages = manifestToPages(m);
+  const rights = manifestRights(m);
+  const label = extractLabel(m.label) || c.title;
+
+  // Enrich candidate metadata from the manifest when the adapter left it blank
+  // (supports a lightweight enumerate-only adapter — manifest is the source of truth).
+  const meta = extractManifestMetadata(m);
+  const enrich = {};
+  const blank = v => !v || v === 'Unknown' || v === '(pending)';
+  if (blank(c.title) && meta.title) enrich.title = meta.title;
+  if (blank(c.author) && meta.author) enrich.author = meta.author;
+  if (blank(c.language) && meta.language) enrich.language = meta.language;
+  if (!c.date_text && meta.date_text) { enrich.date_text = meta.date_text; enrich.date_earliest = meta.date_earliest; enrich.date_latest = meta.date_latest; }
+
+  if (!rights.open && DROP_RESTRICTED) {
+    restricted++;
+    await col.updateOne({ _id: c._id }, { $set: { status: 'skipped', skip_reason: `rights:${rights.label}`, 'manifest_cache.rights': rights.label, 'manifest_cache.harvested_at': new Date() } });
+    await sleep(fetcher === 'browser' ? 700 : 100); continue;
+  }
+
+  await col.updateOne({ _id: c._id }, {
+    $set: {
+      ...enrich,
+      page_count: pages.length,
+      'metadata.rights': rights.label,
+      manifest_cache: { harvested_at: new Date(), canvas_count: pages.length, rights: rights.label, license: rights.text.slice(0, 300), label: String(label).slice(0, 500), pages },
+    },
+  });
+  cached++;
+  if (!rights.open) restricted++;
+  if (cached <= 3 || cached % 50 === 0) console.log(`  cached [${cached}] ${String(label).slice(0, 50)} — ${pages.length}pp, ${rights.label}`);
+  await sleep(fetcher === 'browser' ? 700 : 100);
+}
+
+console.log(`\n[harvest-manifests] done: ${cached} cached, ${restricted} restricted-rights, ${errors} errors`);
+if (browser) await browser.close();
+await client.close();

--- a/scripts/iiif-discovery/import-from-cache.mjs
+++ b/scripts/iiif-discovery/import-from-cache.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Stage 3 of the pipeline: OFFLINE import from cached manifests. No network.
+ *
+ *   enumerate → import_candidates → harvest-manifests (cache) → THIS
+ *
+ * Reads candidates whose manifest_cache is populated and inserts them into the
+ * `books` collection — source-agnostic, using the candidate fields + cached
+ * pages. Because everything is already in Mongo, this is fast, idempotent, and
+ * fully resumable (re-run skips imported + in-memory dedups).
+ *
+ * Routing by shape:
+ *   - 1 cached page  → content_type:'artwork' (single object; --artwork-type)
+ *   - >1 cached page → content_type:'book' + per-page docs (--book-type)
+ *
+ * Images are HOT-LINKED from the cached IIIF URLs (the Met/Rijks/Leiden pattern).
+ * Imports land HIDDEN by default (review → QA → flip visible). Sets
+ * pipeline_auto.status:'complete' for artworks and for --facsimile books, so the
+ * OCR cron leaves facsimile-only material alone.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/iiif-discovery/import-from-cache.mjs --source=leiden --collection=ubl_maps --sl-collection=indonesian-maps --book-type=map --facsimile --dry-run
+ *   node scripts/iiif-discovery/import-from-cache.mjs --source=leiden --collection=ubl_maps --sl-collection=indonesian-maps --book-type=map --facsimile
+ *   node scripts/iiif-discovery/import-from-cache.mjs --source=erara --limit=200            # generic books, will OCR
+ *
+ * Options:
+ *   --source=<s>            candidate source (default: all)
+ *   --collection=<slug>     candidate category filter (source-side slug)
+ *   --sl-collection=<slug>  Source Library collection to tag
+ *   --artwork-type=<t>      resource_type for 1-canvas items (default: print)
+ *   --book-type=<t>         resource_type for multi-canvas items (optional)
+ *   --facsimile             keep books out of OCR cron (pipeline_auto.complete)
+ *   --provider-name=<name>  override display provider name
+ *   --limit=N               max books this run
+ *   --publish               import live+visible (default: hidden)
+ *   --dry-run               no writes
+ */
+
+import { ObjectId } from 'mongodb';
+import { getScriptClient } from '../lib/mongo.mjs';
+
+const args = Object.fromEntries(
+  process.argv.slice(2).filter(a => a.startsWith('--')).map(a => { const [k, v] = a.slice(2).split('='); return [k, v ?? true]; })
+);
+const SOURCE = args.source || null;
+const COLLECTION = args.collection || null;
+const SL_COLLECTION = args['sl-collection'] || null;
+const ARTWORK_TYPE = args['artwork-type'] || 'print';
+const BOOK_TYPE = args['book-type'] || null;
+const FACSIMILE = 'facsimile' in args;
+const PROVIDER_NAME = args['provider-name'] || null;
+const LIMIT = parseInt(args.limit) || 100000;
+const PUBLISH = 'publish' in args;
+const DRY_RUN = 'dry-run' in args;
+
+const slugify = (t, max = 70) => (t || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, max).replace(/-$/, '');
+const normTitle = t => (t || '').toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+const normAuthor = a => (a || '').toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+const licenseFor = r => r === 'public-domain' ? 'publicdomain' : (r === 'cc-by' ? 'CC-BY-4.0' : (r || 'unknown'));
+const yearFrom = text => { const m = (text || '').match(/\b(1[0-9]{3}|20[0-2][0-9])\b/); return m ? parseInt(m[1]) : null; };
+
+const { client, db } = await getScriptClient({ noTimeout: true });
+async function uniqueSlug(base) { let slug = base || 'item', i = 2; while (await db.collection('books').findOne({ slug }, { projection: { _id: 1 } })) slug = `${base}-${i++}`; return slug; }
+
+const filter = { status: 'discovered', 'manifest_cache.harvested_at': { $exists: true } };
+if (SOURCE) filter.source = SOURCE;
+if (COLLECTION) filter.categories = COLLECTION;
+const cands = await db.collection('import_candidates').find(filter).limit(LIMIT).toArray();
+console.log(`[import-cache] ${cands.length} cached candidates (source=${SOURCE || 'all'}, collection=${COLLECTION || 'all'}) → ${SL_COLLECTION || '(no collection)'}, ${PUBLISH ? 'PUBLISH' : 'hidden'}${FACSIMILE ? ', facsimile' : ''}\n`);
+
+// In-memory dedup against existing books from this source
+const existingFp = new Map();
+const dedupQuery = SOURCE ? { 'image_source.provider': SOURCE } : {};
+for (const b of await db.collection('books').find(dedupQuery, { projection: { id: 1, source_fingerprint: 1, 'image_source.iiif_manifest': 1 } }).toArray()) {
+  if (b.source_fingerprint) existingFp.set(b.source_fingerprint, b.id);
+  if (b.image_source?.iiif_manifest) existingFp.set(b.image_source.iiif_manifest, b.id);
+}
+
+let artworks = 0, books = 0, pagesTotal = 0, skipped = 0, failed = 0, idx = 0;
+for (const c of cands) {
+  idx++;
+  const mc = c.manifest_cache;
+  const pages = mc?.pages || [];
+  if (!pages.length) { failed++; if (failed <= 5) console.log(`  [fail] ${c.source_id} — no cached pages`); continue; }
+
+  const fp = `${c.source}:${c.source_id || c.manifest_url}`;
+  if (existingFp.has(fp) || existingFp.has(c.manifest_url)) {
+    skipped++;
+    if (!DRY_RUN) await db.collection('import_candidates').updateOne({ _id: c._id }, { $set: { status: 'imported', book_id: existingFp.get(fp) || existingFp.get(c.manifest_url), imported_at: new Date() } });
+    continue;
+  }
+
+  const isArtwork = pages.length === 1;
+  const title = (c.title || mc.label || `${c.source} item`).slice(0, 500);
+  const author = c.author && c.author !== 'Unknown' ? c.author : 'Unknown';
+  const year = yearFrom(c.date_text);
+
+  if (DRY_RUN) {
+    if (idx <= 15) console.log(`  ${isArtwork ? 'ART ' : 'BOOK'} | ${title.slice(0, 48)} | ${author.slice(0, 18)} | ${pages.length}pp | ${mc.rights}`);
+    isArtwork ? artworks++ : books++; pagesTotal += pages.length; continue;
+  }
+
+  const now = new Date();
+  const slug = await uniqueSlug(slugify(title));
+  const bookId = new ObjectId();
+  const facsimile = isArtwork || FACSIMILE;
+  const doc = {
+    _id: bookId, id: bookId.toHexString(), slug, tenant_id: 'default',
+    title, display_title: title, author,
+    language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
+    published: c.date_text || 'Unknown', ...(year ? { year } : {}),
+    thumbnail: pages[0].thumbnail || pages[0].photo || '',
+    ...(isArtwork ? { image_display: pages[0].photo, image_source_url: pages[0].photo, commons_full_url: pages[0].photo } : {}),
+    pageCount: pages.length, pages_count: pages.length, pages_ocr: 0, pages_translated: 0, pages_archived: 0,
+    content_type: isArtwork ? 'artwork' : 'book',
+    resource_type: isArtwork ? ARTWORK_TYPE : (BOOK_TYPE || undefined),
+    status: PUBLISH ? 'live' : 'draft', hidden: !PUBLISH, visible: PUBLISH,
+    categories: isArtwork ? ['visual-art'] : [],
+    ...(SL_COLLECTION ? { collections: [SL_COLLECTION] } : {}),
+    ...(facsimile ? { pipeline_auto: { status: 'complete', note: isArtwork ? 'artwork facsimile (no OCR)' : 'facsimile-only (handwritten/untrusted OCR)', updated_at: now } } : {}),
+    image_source: {
+      provider: c.source, provider_name: PROVIDER_NAME || c.provider_name || c.origin_library || c.source,
+      source_url: c.source_url || c.manifest_url, iiif_manifest: c.manifest_url,
+      license: licenseFor(mc.rights),
+      ...(c.origin_library ? { contributing_library: c.origin_library } : {}),
+      access_date: now,
+    },
+    dublin_core: { dc_identifier: [fp], dc_source: c.source_url || c.manifest_url },
+    ...(c.metadata?.shelfmark ? { shelfmark: c.metadata.shelfmark } : {}),
+    ...(c.metadata?.subject_geographic ? { subject_geographic: c.metadata.subject_geographic } : {}),
+    source_fingerprint: fp, normalized_title: normTitle(title), normalized_author: normAuthor(author),
+    created_at: now, updated_at: now,
+  };
+  if (doc.resource_type === undefined) delete doc.resource_type;
+
+  try {
+    await db.collection('books').insertOne(doc);
+    if (!isArtwork) {
+      const CHUNK = 500;
+      for (let s = 0; s < pages.length; s += CHUNK) {
+        const pdocs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: doc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }; });
+        await db.collection('pages').insertMany(pdocs, { ordered: false });
+      }
+    }
+    await db.collection('import_candidates').updateOne({ _id: c._id }, { $set: { status: 'imported', book_id: doc.id, imported_at: now } });
+    existingFp.set(fp, doc.id);
+    isArtwork ? artworks++ : books++; pagesTotal += pages.length;
+    if ((artworks + books) <= 3 || (artworks + books) % 50 === 0) console.log(`  ${isArtwork ? 'ART' : 'BOOK'} [${artworks + books}] ${title.slice(0, 45)} (${pages.length}pp) → /book/${slug}`);
+  } catch (e) { failed++; console.log(`  [fail] ${c.source_id} → ${e.message.slice(0, 80)}`); }
+}
+
+console.log(`\n[import-cache] done: ${artworks} artworks + ${books} books (${pagesTotal} pages), ${skipped} already-present, ${failed} failed`);
+if (!DRY_RUN && !PUBLISH && (artworks + books) > 0) console.log(`[import-cache] imported HIDDEN — review, then --publish (or flip visible) + sync-books-catalog.`);
+await client.close();

--- a/scripts/iiif-discovery/import-leiden-artworks.mjs
+++ b/scripts/iiif-discovery/import-leiden-artworks.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Import Leiden IIIF candidates as ARTWORKS into the books collection.
+ *
+ * Why a dedicated importer (not the generic import-batch.mjs / /api/import/iiif):
+ *   - These are single-object ARTWORKS (1 canvas), not multi-page books. The
+ *     generic path assumes books (min-pages gate, creates a `pages` doc per
+ *     canvas, content_type:'book'). We want content_type:'artwork'.
+ *   - Leiden's MANIFEST host (digitalcollections.universiteitleiden.nl) is behind
+ *     F5 bot protection, so /api/import/iiif's server-side fetch is blocked. But
+ *     the IMAGE host (iiif.universiteitleiden.nl) is OPEN and already in the CSP
+ *     img-src allowlist — so we hot-link images (Met/Rijks pattern), no R2 needed.
+ *   - The IIIF image id is deterministic from the item id, so no browser is
+ *     required at import time: all metadata is already in `import_candidates`.
+ *
+ * Image URL shape (verified): the IIIF identifier is `hdl:1887.1/item:<ID>`,
+ * which becomes `hdl:1887.1%252Fitem:<ID>` in the path (the `/` is %2F, then the
+ * `%` is %25 → %252F):
+ *   https://iiif.universiteitleiden.nl/iiif/2/hdl:1887.1%252Fitem:<ID>/full/<size>/0/default.jpg
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/iiif-discovery/import-leiden-artworks.mjs --collection=balinese_narrative_drawings --dry-run
+ *   node scripts/iiif-discovery/import-leiden-artworks.mjs --collection=balinese_narrative_drawings --limit=5
+ *   node scripts/iiif-discovery/import-leiden-artworks.mjs --collection=balinese_narrative_drawings   # all, hidden
+ *   node scripts/iiif-discovery/import-leiden-artworks.mjs --collection=balinese_narrative_drawings --publish
+ *
+ * Options:
+ *   --collection=<slug>     Leiden Fedora slug filter on candidates (categories[])
+ *   --sl-collection=<slug>  Source Library collection slug to tag (default derived)
+ *   --resource-type=<t>     artwork resource_type (default: drawing)
+ *   --limit=N               max to import this run
+ *   --publish               import as live+visible (default: hidden for review)
+ *   --dry-run               show what would be imported, no writes
+ */
+
+import { ObjectId } from 'mongodb';
+import { getScriptClient } from '../lib/mongo.mjs';
+
+const args = Object.fromEntries(
+  process.argv.slice(2).filter(a => a.startsWith('--')).map(a => { const [k, v] = a.slice(2).split('='); return [k, v ?? true]; })
+);
+const LEIDEN_COLLECTION = args.collection || null;
+const RESOURCE_TYPE = args['resource-type'] || 'drawing';
+const LIMIT = parseInt(args.limit) || 100000;
+const PUBLISH = 'publish' in args;
+const DRY_RUN = 'dry-run' in args;
+const IMG_HOST = 'https://iiif.universiteitleiden.nl/iiif/2';
+
+// Map a Leiden Fedora collection slug → Source Library collection slug.
+const SL_COLLECTION_MAP = {
+  balinese_narrative_drawings: 'balinese-narrative-drawings',
+};
+const SL_COLLECTION = args['sl-collection'] || (LEIDEN_COLLECTION ? SL_COLLECTION_MAP[LEIDEN_COLLECTION] : null);
+
+const slugify = t => t.toLowerCase().replace(/[^\w\s-]/g, '').replace(/[\s_]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, 80);
+const normalizeTitle = t => (t || '').toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+const normalizeAuthor = a => (a || '').toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+async function generateSlug(db, title) {
+  const base = slugify(title) || 'leiden-drawing';
+  let slug = base, i = 1;
+  while (await db.collection('books').findOne({ slug }, { projection: { _id: 1 } })) slug = `${base}-${i++}`;
+  return slug;
+}
+const imgBase = id => `${IMG_HOST}/hdl:1887.1%252Fitem:${id}`;
+const licenseFor = r => r === 'public-domain' ? 'publicdomain' : (r === 'cc-by' ? 'CC-BY-4.0' : 'unknown');
+function yearFrom(text) { const m = (text || '').match(/\b(1[0-9]{3}|20[0-2][0-9])\b/); return m ? parseInt(m[1]) : null; }
+
+const { client, db } = await getScriptClient({ noTimeout: true });
+const filter = { source: 'leiden', status: 'discovered' };
+if (LEIDEN_COLLECTION) filter.categories = LEIDEN_COLLECTION;
+const cands = await db.collection('import_candidates').find(filter).limit(LIMIT).toArray();
+console.log(`[import] ${cands.length} candidates (collection=${LEIDEN_COLLECTION || 'all'}) → SL collection: ${SL_COLLECTION || '(none)'}, ${PUBLISH ? 'PUBLISH live+visible' : 'hidden draft'}`);
+
+// Preload existing Leiden books once (source_fingerprint + iiif_manifest) for fast in-memory dedup
+// — avoids a per-candidate collection scan on the 46K-doc books collection.
+const existingFp = new Map(); // fp/manifest → book id
+for (const b of await db.collection('books').find({ 'image_source.provider': 'leiden' }, { projection: { id: 1, source_fingerprint: 1, 'image_source.iiif_manifest': 1 } }).toArray()) {
+  if (b.source_fingerprint) existingFp.set(b.source_fingerprint, b.id);
+  if (b.image_source?.iiif_manifest) existingFp.set(b.image_source.iiif_manifest, b.id);
+}
+console.log(`[import] ${existingFp.size} existing Leiden keys loaded for dedup\n`);
+
+let imported = 0, skipped = 0, failed = 0;
+for (const c of cands) {
+  const id = (c.source_id || '').replace('item:', '');
+  if (!id) { failed++; console.log(`  [skip] ${c.manifest_url} — no item id`); continue; }
+
+  const fp = `leiden:item:${id}`;
+  const existingId = existingFp.get(fp) || existingFp.get(c.manifest_url);
+  if (existingId) {
+    skipped++;
+    if (!DRY_RUN) await db.collection('import_candidates').updateOne({ _id: c._id }, { $set: { status: 'imported', book_id: existingId, imported_at: new Date() } });
+    continue;
+  }
+
+  const title = c.title || `Leiden drawing ${id}`;
+  const author = c.author && c.author !== 'Unknown' ? c.author : 'Unknown artist';
+  const base = imgBase(id);
+  const fullUrl = `${base}/full/full/0/default.jpg`;
+  const displayUrl = `${base}/full/1200,/0/default.jpg`;
+  const thumbUrl = `${base}/full/!400,400/0/default.jpg`;
+  const year = yearFrom(c.date_text);
+
+  if (DRY_RUN) {
+    if (imported < 12) console.log(`  ${title.slice(0, 55)} | ${author.slice(0, 22)} | ${c.date_text || '?'} | ${RESOURCE_TYPE} | ${c.metadata?.shelfmark || ''}`);
+    imported++; continue;
+  }
+
+  const slug = await generateSlug(db, title);
+  const bookId = new ObjectId();
+  const now = new Date();
+  const normTitle = normalizeTitle(title), normAuthor = normalizeAuthor(author);
+  const doc = {
+    _id: bookId, id: bookId.toHexString(), slug, tenant_id: 'default',
+    title, display_title: title, author,
+    language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
+    published: c.date_text || 'Unknown', ...(year ? { year } : {}),
+    thumbnail: thumbUrl, image_display: displayUrl, image_source_url: fullUrl, commons_full_url: fullUrl,
+    pageCount: 1, pages_count: 1, pages_ocr: 0, pages_translated: 0,
+    content_type: 'artwork', resource_type: RESOURCE_TYPE,
+    status: PUBLISH ? 'live' : 'draft', hidden: !PUBLISH, visible: PUBLISH,
+    categories: ['visual-art'],
+    ...(SL_COLLECTION ? { collections: [SL_COLLECTION] } : {}),
+    image_source: {
+      provider: 'leiden', provider_name: 'Leiden University Libraries',
+      source_url: c.source_url || `http://hdl.handle.net/1887.1/item:${id}`,
+      iiif_manifest: c.manifest_url,
+      license: licenseFor(c.metadata?.rights),
+      attribution: 'Leiden University Libraries',
+      contributing_library: 'Leiden University Libraries',
+      access_date: now,
+    },
+    dublin_core: {
+      dc_identifier: [`leiden:item:${id}`],
+      dc_source: c.source_url || `http://hdl.handle.net/1887.1/item:${id}`,
+    },
+    ...(c.metadata?.shelfmark ? { shelfmark: c.metadata.shelfmark } : {}),
+    ...(c.metadata?.subject_geographic ? { subject_geographic: c.metadata.subject_geographic } : {}),
+    ...(c.metadata?.reference ? { provenance_reference: c.metadata.reference } : {}),
+    source_fingerprint: fp, normalized_title: normTitle, normalized_author: normAuthor,
+    created_at: now, updated_at: now,
+  };
+  try {
+    await db.collection('books').insertOne(doc);
+    await db.collection('import_candidates').updateOne({ _id: c._id }, { $set: { status: 'imported', book_id: doc.id, imported_at: now } });
+    existingFp.set(fp, doc.id);
+    imported++;
+    if (imported <= 3 || imported % 50 === 0) console.log(`  IMPORTED [${imported}] ${title.slice(0, 50)} → /book/${slug}`);
+  } catch (e) { failed++; console.log(`  [fail] item:${id} → ${e.message.slice(0, 80)}`); }
+}
+
+console.log(`\n[import] done: ${imported} ${DRY_RUN ? 'would-import' : 'imported'}, ${skipped} already-present, ${failed} failed`);
+if (!DRY_RUN && !PUBLISH && imported > 0) console.log(`[import] imported HIDDEN — review, then re-run with --publish (or flip visible) to show in gallery/collection.`);
+await client.close();

--- a/scripts/iiif-discovery/import-leiden-artworks.mjs
+++ b/scripts/iiif-discovery/import-leiden-artworks.mjs
@@ -120,6 +120,9 @@ for (const c of cands) {
     pageCount: 1, pages_count: 1, pages_ocr: 0, pages_translated: 0,
     content_type: 'artwork', resource_type: RESOURCE_TYPE,
     status: PUBLISH ? 'live' : 'draft', hidden: !PUBLISH, visible: PUBLISH,
+    // Keep out of the OCR/translation cron: 'leiden' isn't in the orchestrator's
+    // ART_PROVIDERS skip-list, so without this artworks get auto-enrolled.
+    pipeline_auto: { status: 'complete', note: 'artwork facsimile (no OCR)', updated_at: now },
     categories: ['visual-art'],
     ...(SL_COLLECTION ? { collections: [SL_COLLECTION] } : {}),
     image_source: {

--- a/scripts/iiif-discovery/import-leiden-books.mjs
+++ b/scripts/iiif-discovery/import-leiden-books.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Import Leiden IIIF candidates as multi-page BOOKS (manuscripts) into Mongo.
+ *
+ * Counterpart to import-leiden-artworks.mjs (1-canvas). Manuscripts are codices,
+ * so each becomes one `books` doc + N `pages` docs (Harvard-direct pattern).
+ *
+ * Why a browser is needed HERE (unlike the artwork importer): per-page image
+ * URLs are NOT deterministic from the item id — each canvas has its own IIIF id —
+ * so we must read the manifest. The manifest host is F5-protected, so we navigate
+ * with Playwright (challenge-aware backoff). The IMAGE host is open, so the
+ * page `photo` URLs render fine for readers.
+ *
+ * Facsimile-only on purpose: these are handwritten Javanese/Malay/Arabic/Sundanese
+ * manuscripts and our Javanese OCR is not yet trustworthy, so we set
+ * pipeline_auto.status:'complete' to keep them OUT of the OCR/translation cron
+ * (provider 'leiden' is NOT in the orchestrator's ART_PROVIDERS skip-list, so
+ * without this they'd be auto-enrolled). Matches the Javanese Kraton stance:
+ * facsimile now, trustworthy full-text later.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/iiif-discovery/import-leiden-books.mjs --collection=ubl_manuscripts --dry-run
+ *   node scripts/iiif-discovery/import-leiden-books.mjs --collection=ubl_manuscripts --limit=3
+ *   node scripts/iiif-discovery/import-leiden-books.mjs --collection=ubl_manuscripts            # all, hidden
+ *   node scripts/iiif-discovery/import-leiden-books.mjs --collection=ubl_manuscripts --publish
+ *
+ * Options:
+ *   --collection=<slug>     Leiden Fedora slug filter on candidates (default ubl_manuscripts)
+ *   --sl-collection=<slug>  Source Library collection slug (default indonesian-manuscripts)
+ *   --resource-type=<t>     default: manuscript
+ *   --limit=N               max books this run
+ *   --publish               import live+visible (default: hidden for review)
+ *   --dry-run               show what would be imported, no writes
+ */
+
+import { ObjectId } from 'mongodb';
+import { chromium } from 'playwright';
+import { getScriptClient } from '../lib/mongo.mjs';
+
+const args = Object.fromEntries(
+  process.argv.slice(2).filter(a => a.startsWith('--')).map(a => { const [k, v] = a.slice(2).split('='); return [k, v ?? true]; })
+);
+const LEIDEN_COLLECTION = args.collection || 'ubl_manuscripts';
+const SL_COLLECTION = args['sl-collection'] || 'indonesian-manuscripts';
+const RESOURCE_TYPE = args['resource-type'] || 'manuscript';
+const LIMIT = parseInt(args.limit) || 100000;
+const PUBLISH = 'publish' in args;
+const DRY_RUN = 'dry-run' in args;
+const HOST = 'https://digitalcollections.universiteitleiden.nl';
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+const CHALLENGE_RE = /bobcmn|support id is|failureConfig/i;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const slugify = (t, max = 70) => (t || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, max).replace(/-$/, '');
+const normalizeTitle = t => (t || '').toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+const normalizeAuthor = a => (a || '').toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+const licenseFor = r => r === 'public-domain' ? 'publicdomain' : (r === 'cc-by' ? 'CC-BY-4.0' : 'unknown');
+const yearFrom = text => { const m = (text || '').match(/\b(1[0-9]{3}|20[0-2][0-9])\b/); return m ? parseInt(m[1]) : null; };
+
+const { client, db } = await getScriptClient({ noTimeout: true });
+async function uniqueSlug(base) { let slug = base || 'leiden-manuscript', i = 2; while (await db.collection('books').findOne({ slug }, { projection: { _id: 1 } })) slug = `${base}-${i++}`; return slug; }
+
+/** Navigate to the manifest, backing off on F5 challenge; return parsed JSON or null. */
+async function fetchManifest(page, id) {
+  const url = `${HOST}/iiif_manifest/item:${id}/manifest`;
+  for (let t = 0; t < 6; t++) {
+    try { await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 }); }
+    catch { await sleep(3000 * (t + 1)); continue; }
+    await sleep(500);
+    const txt = await page.evaluate(() => document.body?.innerText || '');
+    if (txt.trim().startsWith('{') && !CHALLENGE_RE.test(txt)) { try { return JSON.parse(txt); } catch { return null; } }
+    await sleep(4000 * (t + 1));
+  }
+  return null;
+}
+
+/** IIIF v2 canvases → ordered [{ photo, thumbnail }]. */
+function pagesFromManifest(m) {
+  const canvases = m.sequences?.[0]?.canvases || [];
+  return canvases.map(c => {
+    const res = c.images?.[0]?.resource;
+    const svc = res?.service?.['@id'];
+    const photo = (svc ? `${svc}/full/full/0/default.jpg` : res?.['@id']) || null;
+    const thumbnail = svc ? `${svc}/full/!400,400/0/default.jpg` : photo;
+    return photo ? { photo, thumbnail } : null;
+  }).filter(Boolean);
+}
+
+const cands = await db.collection('import_candidates').find({ source: 'leiden', status: 'discovered', categories: LEIDEN_COLLECTION }).limit(LIMIT).toArray();
+console.log(`[import-books] ${cands.length} candidates (${LEIDEN_COLLECTION}) → ${SL_COLLECTION}, ${PUBLISH ? 'PUBLISH live+visible' : 'hidden draft'}\n`);
+
+// In-memory dedup against existing leiden books
+const existingFp = new Map();
+for (const b of await db.collection('books').find({ 'image_source.provider': 'leiden' }, { projection: { id: 1, source_fingerprint: 1, 'image_source.iiif_manifest': 1 } }).toArray()) {
+  if (b.source_fingerprint) existingFp.set(b.source_fingerprint, b.id);
+  if (b.image_source?.iiif_manifest) existingFp.set(b.image_source.iiif_manifest, b.id);
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await (await browser.newContext({ userAgent: UA })).newPage();
+
+let imported = 0, skipped = 0, failed = 0, totalPages = 0, idx = 0;
+for (const c of cands) {
+  idx++;
+  const id = (c.source_id || '').replace('item:', '');
+  const fp = `leiden:item:${id}`;
+  if (existingFp.has(fp) || existingFp.has(c.manifest_url)) { skipped++; if (!DRY_RUN) await db.collection('import_candidates').updateOne({ _id: c._id }, { $set: { status: 'imported', book_id: existingFp.get(fp) || existingFp.get(c.manifest_url), imported_at: new Date() } }); continue; }
+
+  const manifest = await fetchManifest(page, id);
+  if (!manifest) { failed++; console.log(`  [fail ${idx}/${cands.length}] item:${id} — manifest unavailable/challenged`); await sleep(1200); continue; }
+  const pages = pagesFromManifest(manifest);
+  if (!pages.length) { failed++; console.log(`  [fail ${idx}/${cands.length}] item:${id} — no page images`); continue; }
+
+  const title = c.title || `Leiden manuscript ${id}`;
+  const author = c.author && c.author !== 'Unknown' ? c.author : 'Unknown';
+  const year = yearFrom(c.date_text);
+
+  if (DRY_RUN) {
+    if (imported < 15) console.log(`  ${title.slice(0, 50)} | ${author.slice(0, 20)} | ${c.date_text || '?'} | ${pages.length}pp | ${c.metadata?.shelfmark || ''}`);
+    imported++; totalPages += pages.length; await sleep(700); continue;
+  }
+
+  const slug = await uniqueSlug(slugify(title));
+  const bookId = new ObjectId();
+  const now = new Date();
+  const bookDoc = {
+    _id: bookId, id: bookId.toHexString(), slug, tenant_id: 'default',
+    title, display_title: title, author,
+    language: c.language && c.language !== 'Unknown' ? c.language : 'Unknown',
+    published: c.date_text || 'Unknown', ...(year ? { year } : {}),
+    thumbnail: pages[0].thumbnail || '',
+    pages_count: pages.length, pages_ocr: 0, pages_translated: 0, pages_archived: 0,
+    content_type: 'book', resource_type: RESOURCE_TYPE,
+    status: PUBLISH ? 'live' : 'draft', hidden: !PUBLISH, visible: PUBLISH,
+    categories: [], collections: [SL_COLLECTION],
+    // facsimile-only: keep out of the OCR/translation cron (Javanese OCR untrusted)
+    pipeline_auto: { status: 'complete', note: 'facsimile-only (handwritten; trustworthy OCR pending)', updated_at: now },
+    image_source: {
+      provider: 'leiden', provider_name: 'Leiden University Libraries',
+      source_url: c.source_url || `http://hdl.handle.net/1887.1/item:${id}`,
+      iiif_manifest: c.manifest_url,
+      license: licenseFor(c.metadata?.rights),
+      attribution: 'Leiden University Libraries', contributing_library: 'Leiden University Libraries',
+      access_date: now,
+    },
+    dublin_core: { dc_identifier: [`leiden:item:${id}`], dc_source: c.source_url || `http://hdl.handle.net/1887.1/item:${id}` },
+    ...(c.metadata?.shelfmark ? { shelfmark: c.metadata.shelfmark } : {}),
+    ...(c.metadata?.subject_geographic ? { subject_geographic: c.metadata.subject_geographic } : {}),
+    source_fingerprint: fp, normalized_title: normalizeTitle(title), normalized_author: normalizeAuthor(author),
+    created_at: now, updated_at: now,
+  };
+  try {
+    await db.collection('books').insertOne(bookDoc);
+    const CHUNK = 500;
+    for (let s = 0; s < pages.length; s += CHUNK) {
+      const docs = pages.slice(s, s + CHUNK).map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: bookDoc.id, page_number: s + k + 1, photo: p.photo, photo_original: p.photo, thumbnail: p.thumbnail, created_at: now, updated_at: now }; });
+      await db.collection('pages').insertMany(docs, { ordered: false });
+    }
+    await db.collection('import_candidates').updateOne({ _id: c._id }, { $set: { status: 'imported', book_id: bookDoc.id, imported_at: now } });
+    existingFp.set(fp, bookDoc.id);
+    imported++; totalPages += pages.length;
+    if (imported <= 3 || imported % 25 === 0) console.log(`  IMPORTED [${imported}] ${title.slice(0, 45)} (${pages.length}pp) → /book/${slug}`);
+  } catch (e) { failed++; console.log(`  [fail] item:${id} → ${e.message.slice(0, 90)}`); }
+  await sleep(900);
+}
+
+console.log(`\n[import-books] done: ${imported} ${DRY_RUN ? 'would-import' : 'imported'} (${totalPages} pages), ${skipped} already-present, ${failed} failed`);
+if (!DRY_RUN && !PUBLISH && imported > 0) console.log(`[import-books] imported HIDDEN — review, then --publish (or flip visible) + sync-books-catalog.`);
+await browser.close();
+await client.close();

--- a/scripts/iiif-discovery/lib/iiif-metadata.mjs
+++ b/scripts/iiif-discovery/lib/iiif-metadata.mjs
@@ -189,6 +189,68 @@ export function extractManifestMetadata(manifest) {
 }
 
 /**
+ * Extract ordered per-page image URLs from a IIIF manifest (v2 + v3).
+ * Returns [{ photo, thumbnail }] — `photo` is a full-size image URL, `thumbnail`
+ * a ~400px derivative. Prefers the IIIF Image API service (so we can size on
+ * demand); falls back to the static resource id.
+ *
+ * @param {Object} manifest
+ * @param {Object} [opts]
+ * @param {number|string} [opts.thumbSize=!400,400] IIIF size param for thumbnails
+ */
+export function manifestToPages(manifest, { thumbSize = '!400,400' } = {}) {
+  const fromService = (svc, fallback) => {
+    const base = typeof svc === 'string' ? svc : (svc?.['@id'] || svc?.id);
+    if (!base) return fallback ? { photo: fallback, thumbnail: fallback } : null;
+    return { photo: `${base}/full/full/0/default.jpg`, thumbnail: `${base}/full/${thumbSize}/0/default.jpg` };
+  };
+
+  // v2: sequences[].canvases[].images[].resource(.service)
+  const v2 = manifest.sequences?.[0]?.canvases;
+  if (Array.isArray(v2)) {
+    return v2.map(c => {
+      const res = c.images?.[0]?.resource;
+      const svc = res?.service;
+      return fromService(Array.isArray(svc) ? svc[0] : svc, res?.['@id']);
+    }).filter(Boolean);
+  }
+
+  // v3: items[](canvas).items[](AnnotationPage).items[](Annotation).body(.service)
+  const v3 = manifest.items;
+  if (Array.isArray(v3)) {
+    return v3.map(canvas => {
+      const body = canvas.items?.[0]?.items?.[0]?.body;
+      const b = Array.isArray(body) ? body[0] : body;
+      const svc = b?.service;
+      return fromService(Array.isArray(svc) ? svc[0] : svc, b?.id);
+    }).filter(Boolean);
+  }
+
+  return [];
+}
+
+/**
+ * Classify rights from a IIIF manifest (v2 `attribution`/`license`,
+ * v3 `requiredStatement`/`rights`). Returns { open, label, text }.
+ */
+export function manifestRights(manifest) {
+  const parts = [];
+  if (manifest.license) parts.push(String(manifest.license));
+  if (manifest.rights) parts.push(String(manifest.rights));
+  if (typeof manifest.attribution === 'string') parts.push(manifest.attribution);
+  else if (manifest.attribution) parts.push(extractLabel(manifest.attribution) || '');
+  const rs = manifest.requiredStatement?.value;
+  if (rs) parts.push(extractLabel(rs) || '');
+  const text = parts.join(' ').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+  const t = text.toLowerCase();
+  if (/within the library premises|on campus|not available off|reading room/.test(t)) return { open: false, label: 'restricted', text };
+  if (/public\s*domain|publicdomain|\/mark\/|cc0|no known copyright/.test(t)) return { open: true, label: 'public-domain', text };
+  if (/creativecommons\.org\/licenses\/by|cc[\s-]?by/.test(t)) return { open: true, label: 'cc-by', text };
+  if (/full access/.test(t)) return { open: true, label: 'full-access', text };
+  return { open: false, label: 'unknown', text };
+}
+
+/**
  * Clean a title string — strip HTML, normalize whitespace, truncate.
  */
 function cleanTitle(title) {

--- a/scripts/iiif-discovery/sources/leiden.mjs
+++ b/scripts/iiif-discovery/sources/leiden.mjs
@@ -70,6 +70,10 @@ const MAX_RECORDS = parseInt(args['max-records']) || 100000;
 const DRY_RUN = 'dry-run' in args;
 const INCLUDE_RESTRICTED = 'include-restricted' in args;
 const HEADED = 'headed' in args;
+// Lightweight mode: record id + manifest_url only (no per-item manifest fetch).
+// Metadata + rights + pages are filled later by harvest-manifests.mjs. This is
+// the decoupled pipeline: enumerate → harvest-manifests → import-from-cache.
+const ENUMERATE_ONLY = 'enumerate-only' in args;
 
 if (!COLLECTION) {
   console.error('ERROR: --collection=<slug> is required (e.g. balinese_narrative_drawings)');
@@ -224,8 +228,23 @@ async function readManifest(page, id) {
   let inserted = 0, skippedDup = 0, skippedRights = 0, errors = 0, idx = 0;
   for (const id of ids) {
     idx++;
+    const manifest_url = `${HOST}/iiif_manifest/item:${id}/manifest`;
     // Idempotency: skip already-harvested URLs before the expensive manifest nav.
-    if (haveUrls.has(`${HOST}/iiif_manifest/item:${id}/manifest`)) { skippedDup++; continue; }
+    if (haveUrls.has(manifest_url)) { skippedDup++; continue; }
+
+    // Decoupled pipeline: record id+url only; harvest-manifests.mjs fills the rest.
+    if (ENUMERATE_ONLY) {
+      if (DRY_RUN) { if (idx <= 12) console.log(`  item:${id}`); inserted++; continue; }
+      const res = await insertCandidate(db, {
+        manifest_url, source: SOURCE, origin_library: 'Leiden University Libraries',
+        provider_name: 'Leiden University Libraries', title: '(pending)', author: 'Unknown',
+        categories: [COLLECTION], source_url: `http://hdl.handle.net/1887.1/item:${id}`, source_id: `item:${id}`,
+      });
+      if (res.inserted) { inserted++; haveUrls.add(manifest_url); if (inserted <= 3 || inserted % 100 === 0) console.log(`  enumerated [${inserted}] item:${id}`); }
+      else skippedDup++;
+      continue;
+    }
+
     const man = await readManifest(page, id);
     if (man.error) { errors++; if (errors <= 8) console.log(`  [err ${idx}/${ids.length}] item:${id} → ${man.error}`); await sleep(1500); continue; }
 

--- a/scripts/iiif-discovery/sources/leiden.mjs
+++ b/scripts/iiif-discovery/sources/leiden.mjs
@@ -21,11 +21,19 @@
  *
  * Indonesian / Southeast-Asian collection slugs (counts ≈ full collection):
  *   balinese_narrative_drawings  Balinese Narrative Drawings (van der Tuuk) — ART, ~434, all PD
- *   ubl_manuscripts              Manuscripts, Archives & Letters (Oriental mss)
- *   sinomalay                    (Sino-)Malay popular fiction (KITLV)
- *   kitlv_maps / KIT_maps / ubl_maps   Maps & atlases
+ *   ubl_manuscripts              GLOBAL manuscripts collection (mostly European VLQ codices).
+ *                                For Indonesian mss, narrow with --extra-facet country=Indonesia
+ *                                → 139 PD multi-page codices (Diponegoro, Pasai Sufi 1629, etc.).
+ *   kitlv_maps / KIT_maps / ubl_maps   Maps & atlases (mostly PD)
  *   kitlv_photos / kern / photoalbums  Photography (huge — curate before bulk)
  *   indonesianprinted / aceh_books     Printed books (mostly post-1900 → restricted)
+ *   sinomalay                    (Sino-)Malay popular fiction — NO public IIIF manifests
+ *                                ({"error":"No manifest available"}); not harvestable here.
+ *
+ * Narrowing a global collection: add a second Solr facet, e.g.
+ *   --extra-facet="mods_originInfo_place_placeTerm_text_authority_marccountry_ms:Indonesia"
+ *   --extra-facet="mods_subject_geographic_ms:Indonesia"
+ * (Useful facet fields: ...marccountry_ms, mods_subject_geographic_ms, language facets.)
  *
  * Usage:
  *   set -a; source .env.production.local; set +a
@@ -72,6 +80,17 @@ if (!COLLECTION) {
 function collectionFacet(slug) {
   const v = `info\\:fedora\\/collection\\:${slug}`;
   return `RELS_EXT_isMemberOfCollection_uri_ms:%22${encodeURIComponent(v).replace(/%5C/g, '%5C')}%22`;
+}
+
+// Optional second facet to narrow a global collection, e.g.
+//   --extra-facet="mods_originInfo_place_placeTerm_text_authority_marccountry_ms:Indonesia"
+//   --extra-facet="mods_language_..._ms:Javanese"
+// Pass as field:value (value is plain text; we URL-encode it).
+function extraFacetParam(spec) {
+  if (!spec) return null;
+  const i = spec.indexOf(':');
+  const field = spec.slice(0, i), value = spec.slice(i + 1);
+  return `${field}:%22${encodeURIComponent(value)}%22`;
 }
 
 const firstStr = v => Array.isArray(v) ? (v[0] ?? '') : (v ?? '');
@@ -121,7 +140,8 @@ const scrapeIds = page => page.$$eval('a[href*="/view/item/"]', as =>
  * never truncating the whole collection. Returns ordered list of item ids.
  */
 async function enumerateCollection(page) {
-  const base = `${HOST}/islandora/search?type=dismax&islandora_solr_search_navigation=0&f%5B0%5D=${collectionFacet(COLLECTION)}`;
+  const extra = extraFacetParam(args['extra-facet']);
+  const base = `${HOST}/islandora/search?type=dismax&islandora_solr_search_navigation=0&f%5B0%5D=${collectionFacet(COLLECTION)}${extra ? `&f%5B1%5D=${extra}` : ''}`;
   const ids = []; const seen = new Set();
   const pageUrl = p => base + `&page=${p}`;
   const readyIds = async pg => { const f = await scrapeIds(pg); return f.length ? f : null; };

--- a/scripts/iiif-discovery/sources/leiden.mjs
+++ b/scripts/iiif-discovery/sources/leiden.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Leiden University Libraries — Digital Collections discovery crawler.
+ *
+ * Leiden runs an **Islandora 7** (Drupal + Fedora + Solr) platform, fronted by
+ * **F5 Shape / TSPD bot protection**. Plain curl/fetch — even from a residential
+ * IP — gets a JS challenge page (HTTP 200, no data). So we drive a real browser
+ * (Playwright) which executes the challenge, then page the Solr search and read
+ * IIIF manifests through the warmed browser context. (Same tactic as the KU
+ * Leuven harvester in scripts/research/.)
+ *
+ * Channel (reverse-engineered 2026-06-03, all public, no credentials):
+ *   - Search:   /islandora/search?type=dismax&f[0]=<facet>&page=N   (20 hits/page, HTML)
+ *               Use /islandora/search — the bare /search route is challenged harder.
+ *   - Collection facet:  RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/collection:<slug>"
+ *   - Result links:      /view/item/<NNNN>   → item id = NNNN
+ *   - Manifest:          https://digitalcollections.universiteitleiden.nl/iiif_manifest/item:<NNNN>/manifest
+ *                        (IIIF Presentation v2; images on https://iiif.universiteitleiden.nl/iiif/2/)
+ *   - Rights:            manifest.attribution (HTML) — "public domain" / "CC-BY" = importable;
+ *                        "within the library premises" = restricted, skip.
+ *
+ * Indonesian / Southeast-Asian collection slugs (counts ≈ full collection):
+ *   balinese_narrative_drawings  Balinese Narrative Drawings (van der Tuuk) — ART, ~434, all PD
+ *   ubl_manuscripts              Manuscripts, Archives & Letters (Oriental mss)
+ *   sinomalay                    (Sino-)Malay popular fiction (KITLV)
+ *   kitlv_maps / KIT_maps / ubl_maps   Maps & atlases
+ *   kitlv_photos / kern / photoalbums  Photography (huge — curate before bulk)
+ *   indonesianprinted / aceh_books     Printed books (mostly post-1900 → restricted)
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/iiif-discovery/sources/leiden.mjs --collection=balinese_narrative_drawings
+ *   node scripts/iiif-discovery/sources/leiden.mjs --collection=ubl_manuscripts --max-records=200
+ *   node scripts/iiif-discovery/sources/leiden.mjs --collection=balinese_narrative_drawings --dry-run
+ *
+ * Options:
+ *   --collection=<slug>   Fedora collection slug (required)
+ *   --max-records=N       Stop after N items enumerated (default: 100000)
+ *   --include-restricted  Keep items whose rights aren't clearly open (default: skip)
+ *   --dry-run             Enumerate + read manifests, print, but don't write to DB
+ *   --headed              Run browser non-headless (debugging)
+ */
+
+import { chromium } from 'playwright';
+import { getScriptClient } from '../../lib/mongo.mjs';
+import { ensureIndexes, insertCandidate } from '../lib/candidate-store.mjs';
+import { parseDateRange } from '../lib/iiif-metadata.mjs';
+
+const SOURCE = 'leiden';
+const HOST = 'https://digitalcollections.universiteitleiden.nl';
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+const PAGE_SIZE = 20; // Islandora fixed page size
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const args = Object.fromEntries(
+  process.argv.slice(2).filter(a => a.startsWith('--')).map(a => {
+    const [k, v] = a.slice(2).split('='); return [k, v ?? true];
+  })
+);
+const COLLECTION = args.collection;
+const MAX_RECORDS = parseInt(args['max-records']) || 100000;
+const DRY_RUN = 'dry-run' in args;
+const INCLUDE_RESTRICTED = 'include-restricted' in args;
+const HEADED = 'headed' in args;
+
+if (!COLLECTION) {
+  console.error('ERROR: --collection=<slug> is required (e.g. balinese_narrative_drawings)');
+  process.exit(1);
+}
+
+// Fedora collection facet, with the backslash-escaping Islandora's Solr query parser expects.
+function collectionFacet(slug) {
+  const v = `info\\:fedora\\/collection\\:${slug}`;
+  return `RELS_EXT_isMemberOfCollection_uri_ms:%22${encodeURIComponent(v).replace(/%5C/g, '%5C')}%22`;
+}
+
+const firstStr = v => Array.isArray(v) ? (v[0] ?? '') : (v ?? '');
+function langClean(v) {
+  // Leiden stores some values as {"@value":"Dutch","@language":"eng"} JSON strings
+  if (typeof v === 'string' && v.startsWith('{')) { try { return JSON.parse(v)['@value'] || v; } catch { return v; } }
+  return v;
+}
+
+/** Classify rights from the manifest attribution/license text. */
+function classifyRights(text = '') {
+  const t = text.toLowerCase();
+  if (/within the library premises|on campus|not available off|toegang.*bibliotheek/.test(t)) return { open: false, label: 'restricted' };
+  if (/public\s*domain|publicdomain/.test(t)) return { open: true, label: 'public-domain' };
+  if (/creativecommons\.org\/licenses\/by|cc[\s-]?by/.test(t)) return { open: true, label: 'cc-by' };
+  if (/full access/.test(t)) return { open: true, label: 'full-access' };
+  return { open: false, label: 'unknown' };
+}
+
+// F5 Shape serves a JS challenge shell (HTTP 200) when it throttles. Detect it so we can back off.
+const CHALLENGE_RE = /bobcmn|support id is|failureConfig/i;
+async function bodyText(page) { return page.evaluate(() => document.body?.innerText || document.documentElement?.outerHTML?.slice(0, 400) || ''); }
+async function looksChallenged(page) { return page.evaluate(() => typeof window.bobcmn !== 'undefined'); }
+
+/**
+ * Navigate to a page that should yield real content. `ready(page)` returns truthy
+ * once the expected content is present. On a challenge/empty shell, back off
+ * exponentially and retry — F5 lifts the throttle after a pause.
+ */
+async function gotoReady(page, url, ready, tries = 6) {
+  for (let t = 0; t < tries; t++) {
+    try { await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 }); }
+    catch { await sleep(3000 * (t + 1)); continue; }
+    await sleep(600);
+    if (!(await looksChallenged(page))) { const r = await ready(page); if (r) return r; }
+    await sleep(4000 * (t + 1)); // exponential-ish backoff: 4s, 8s, 12s, 16s, 20s
+  }
+  return null;
+}
+
+const scrapeIds = page => page.$$eval('a[href*="/view/item/"]', as =>
+  [...new Set(as.map(a => { const m = a.getAttribute('href').match(/\/view\/item\/(\d+)/); return m ? m[1] : null; }).filter(Boolean))]);
+
+/**
+ * Page the Solr search for one collection. Resilient to F5 throttling: a page
+ * that stays challenged after backoff is recorded and RETRIED in a second pass,
+ * never truncating the whole collection. Returns ordered list of item ids.
+ */
+async function enumerateCollection(page) {
+  const base = `${HOST}/islandora/search?type=dismax&islandora_solr_search_navigation=0&f%5B0%5D=${collectionFacet(COLLECTION)}`;
+  const ids = []; const seen = new Set();
+  const pageUrl = p => base + `&page=${p}`;
+  const readyIds = async pg => { const f = await scrapeIds(pg); return f.length ? f : null; };
+  const addIds = found => { for (const id of found) if (!seen.has(id)) { seen.add(id); ids.push(id); } };
+
+  // Page 0 establishes the reported total → known page count.
+  const first = await gotoReady(page, pageUrl(0), readyIds, 8);
+  const reported = await page.evaluate(() => { const m = document.body.innerText.match(/of\s+([\d,]+)/i); return m ? m[1] : null; }).catch(() => null);
+  const total = Math.min(reported ? parseInt(String(reported).replace(/,/g, '')) : MAX_RECORDS, MAX_RECORDS);
+  console.log(`  [enum] collection reports ${reported} items → ${Math.ceil(total / PAGE_SIZE)} pages`);
+  if (first) addIds(first);
+
+  const failed = [];
+  const nPages = Math.ceil(total / PAGE_SIZE);
+  for (let p = 1; p < nPages && ids.length < MAX_RECORDS; p++) {
+    const found = await gotoReady(page, pageUrl(p), readyIds, 6);
+    if (!found) { failed.push(p); console.log(`  [enum] page ${p}: throttled, deferring`); }
+    else { const before = ids.length; addIds(found); if (p % 5 === 0) console.log(`  [enum] page ${p}: ${ids.length} ids (+${ids.length - before})`); }
+    await sleep(1000);
+  }
+  // Second pass over throttled pages, slower.
+  if (failed.length) {
+    console.log(`  [enum] retrying ${failed.length} throttled pages…`);
+    for (const p of failed) {
+      const found = await gotoReady(page, pageUrl(p), readyIds, 8);
+      if (found) addIds(found); else console.log(`  [enum] page ${p}: still throttled — skipped`);
+      await sleep(2000);
+    }
+  }
+  console.log(`  [enum] collected ${ids.length}/${total} ids`);
+  return { ids: ids.slice(0, MAX_RECORDS), reported };
+}
+
+/**
+ * Read a IIIF manifest by NAVIGATING to it (top-level loads pass F5; same-origin
+ * XHR fetch gets challenged after a short burst). The JSON arrives as the page body.
+ */
+async function readManifest(page, id) {
+  const url = `${HOST}/iiif_manifest/item:${id}/manifest`;
+  const txt = await gotoReady(page, url, async pg => {
+    const t = await bodyText(pg);
+    return (t.trim().startsWith('{') && !CHALLENGE_RE.test(t)) ? t : null;
+  }, 5);
+  if (!txt) return { error: 'challenged' };
+  let j; try { j = JSON.parse(txt); } catch { return { error: 'not-json' }; }
+  const meta = {};
+  (j.metadata || []).forEach(m => {
+    const k = typeof m.label === 'string' ? m.label : (m.label?.[0]?.['@value'] || JSON.stringify(m.label));
+    const v = typeof m.value === 'string' ? m.value : (m.value?.[0]?.['@value'] || (Array.isArray(m.value) ? m.value.map(x => x['@value'] || x).join('; ') : JSON.stringify(m.value)));
+    if (k && !(k in meta)) meta[k] = v;
+  });
+  return {
+    label: typeof j.label === 'string' ? j.label : (j.label?.[0]?.['@value'] || ''),
+    attribution: j.attribution || '', license: j.license || '',
+    canvases: j.sequences?.[0]?.canvases?.length ?? null, meta,
+  };
+}
+
+(async () => {
+  const browser = await chromium.launch({ headless: !HEADED });
+  const page = await (await browser.newContext({ userAgent: UA })).newPage();
+
+  console.log(`[leiden] enumerating collection: ${COLLECTION}`);
+  const { ids } = await enumerateCollection(page);
+  console.log(`[leiden] enumerated ${ids.length} item ids\n`);
+
+  let client = null, db = null;
+  if (!DRY_RUN) {
+    ({ client, db } = await getScriptClient({ noTimeout: true }));
+    try { await ensureIndexes(db); } catch (e) { console.log(`[leiden] index warning: ${e.message.slice(0, 80)}`); }
+  }
+
+  let inserted = 0, skippedDup = 0, skippedRights = 0, errors = 0, idx = 0;
+  for (const id of ids) {
+    idx++;
+    const man = await readManifest(page, id);
+    if (man.error) { errors++; if (errors <= 8) console.log(`  [err ${idx}/${ids.length}] item:${id} → ${man.error}`); await sleep(1500); continue; }
+
+    const rights = classifyRights(man.attribution || man.license);
+    if (!rights.open && !INCLUDE_RESTRICTED) {
+      skippedRights++;
+      if (skippedRights <= 3) console.log(`  [skip:rights=${rights.label}] item:${id} ${man.label.slice(0, 50)}`);
+      await sleep(900); continue;
+    }
+
+    const m = man.meta;
+    const dateText = m['Published'] || m['Date issued'] || m['Date'] || null;
+    const dr = dateText ? parseDateRange(dateText) : {};
+    const candidate = {
+      manifest_url: `${HOST}/iiif_manifest/item:${id}/manifest`,
+      source: SOURCE,
+      origin_library: 'Leiden University Libraries',
+      provider_name: 'Leiden University Libraries',
+      title: (man.label || m['Title'] || 'Unknown').slice(0, 500),
+      author: m['Author/creator'] || m['Author'] || m['Creator'] || 'Unknown',
+      language: langClean(m['Language']) || 'Unknown',
+      date_text: dateText,
+      date_earliest: dr.earliest || null,
+      date_latest: dr.latest || null,
+      page_count: man.canvases,
+      categories: [COLLECTION],
+      source_url: m['Persistent URL'] || `http://hdl.handle.net/1887.1/item:${id}`,
+      source_id: `item:${id}`,
+      metadata: {
+        collection: COLLECTION,
+        rights: rights.label,
+        shelfmark: m['Shelfmark'] || null,
+        country: langClean(m['Country']) || null,
+        subject_geographic: m['Subject (geographic)'] || null,
+        subject_topical: m['Subject (topical)'] || null,
+        extent: m['Extent'] || null,
+        reference: m['Reference'] || null,
+      },
+    };
+
+    if (DRY_RUN) {
+      if (idx <= 12) console.log(`  ${candidate.title.slice(0, 55)} | ${candidate.author.slice(0, 24)} | ${dateText || '?'} | ${man.canvases}c | ${rights.label}`);
+      inserted++; await sleep(900); continue;
+    }
+
+    try {
+      const res = await insertCandidate(db, candidate);
+      if (res.inserted) { inserted++; if (inserted <= 3 || inserted % 50 === 0) console.log(`  NEW [${inserted}/${ids.length}] ${candidate.title.slice(0, 55)} (${dateText || '?'}, ${rights.label})`); }
+      else skippedDup++;
+    } catch (e) { errors++; console.log(`  [db-err] item:${id} → ${e.message.slice(0, 80)}`); }
+    await sleep(900);
+  }
+
+  console.log(`\n[leiden] ${COLLECTION} done: ${inserted} ${DRY_RUN ? 'would-insert' : 'inserted'}, ${skippedDup} dup, ${skippedRights} skipped-rights, ${errors} errors`);
+  if (client) await client.close();
+  await browser.close();
+})();

--- a/scripts/iiif-discovery/sources/leiden.mjs
+++ b/scripts/iiif-discovery/sources/leiden.mjs
@@ -189,14 +189,23 @@ async function readManifest(page, id) {
   console.log(`[leiden] enumerated ${ids.length} item ids\n`);
 
   let client = null, db = null;
+  // The shared import_candidates collection already carries a NON-unique
+  // `manifest_url_lookup` index, which blocks ensureIndexes() from adding the
+  // unique one — so insertCandidate's 11000-dup guard never fires and re-runs
+  // would duplicate rows. Guard idempotency ourselves with a preloaded URL set.
+  const haveUrls = new Set();
   if (!DRY_RUN) {
     ({ client, db } = await getScriptClient({ noTimeout: true }));
     try { await ensureIndexes(db); } catch (e) { console.log(`[leiden] index warning: ${e.message.slice(0, 80)}`); }
+    (await db.collection('import_candidates').distinct('manifest_url', { source: SOURCE })).forEach(u => haveUrls.add(u));
+    console.log(`[leiden] ${haveUrls.size} existing leiden candidates already in ledger (will skip)\n`);
   }
 
   let inserted = 0, skippedDup = 0, skippedRights = 0, errors = 0, idx = 0;
   for (const id of ids) {
     idx++;
+    // Idempotency: skip already-harvested URLs before the expensive manifest nav.
+    if (haveUrls.has(`${HOST}/iiif_manifest/item:${id}/manifest`)) { skippedDup++; continue; }
     const man = await readManifest(page, id);
     if (man.error) { errors++; if (errors <= 8) console.log(`  [err ${idx}/${ids.length}] item:${id} → ${man.error}`); await sleep(1500); continue; }
 


### PR DESCRIPTION
## What

A complete **Leiden University Libraries** acquisition channel for the `scripts/iiif-discovery/` framework, focused on Indonesian/Southeast-Asian holdings — plus two importers that brought **544 public-domain items live** in two new collections.

## Scripts

- **`sources/leiden.mjs`** — discovery harvester. Leiden is Islandora 7 behind **F5 Shape bot protection**, so it drives Playwright (like the KU Leuven harvester): pages the `/islandora/search` collection facet, reads IIIF v2 manifests by navigation, filters to public-domain/CC-BY, writes to `import_candidates`. Challenge-aware backoff + two-pass enumerator. `--extra-facet` narrows a global collection (e.g. `country=Indonesia`).
- **`import-leiden-artworks.mjs`** — imports 1-canvas candidates as `content_type:'artwork'`. Image host is open + CSP-allowlisted → hot-linked (no R2); image URL deterministic from item id (no browser at import).
- **`import-leiden-books.mjs`** — imports multi-page candidates as books (book + per-page docs, Harvard-direct pattern); reads each manifest via Playwright (per-page image ids aren't deterministic).
- Both importers set `pipeline_auto.status:'complete'` (facsimile-only): `leiden` isn't in the orchestrator's `ART_PROVIDERS` skip-list, so without it the OCR cron auto-enrolls them — and handwritten Javanese/Jawi OCR isn't yet trustworthy.

## Shipped live (data writes to prod, no deploy needed)

- **Balinese Narrative Drawings** — 412 PD artworks (van der Tuuk, Or. 3390): `/collections/balinese-narrative-drawings`
- **Indonesian Manuscripts** — 132 PD codices / 8,824 pages (Diponegoro verse, Pasai Sufi 1629, Malay/Javanese/Sundanese/Bugis): `/collections/indonesian-manuscripts`

## Out of scope / notes

- **sinomalay** has no public IIIF manifests (printed books) — not harvestable. **Maps** (ubl_maps/KIT_maps/kitlv_maps, PD) and **photo archives** (100K+, curate first) remain available via the harvester.
- A latent framework issue surfaced: `import_candidates` has a non-unique `manifest_url` index that defeats `insertCandidate`'s dedup — every source adapter relying on it can duplicate rows on re-run. Worked around in the adapters (in-memory dedup); the proper fix (make `insertCandidate` an upsert) is left as a separate PR to stay single-concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)