### PR TITLE
fix(mcp-server): backport languages/exclude_languages filter params

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@source-library/mcp-server",
-  "version": "4.2.0",
+  "version": "4.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@source-library/mcp-server",
-      "version": "4.2.0",
+      "version": "4.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-library/mcp-server",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "mcpName": "io.github.Embassy-of-the-Free-Mind/source-library",
   "description": "Search, read, and cite ~22,000 rare pre-modern texts (alchemy, Hermetica, Kabbalah, theology, early science) with AI-generated English translations. CLI + MCP server, no API key needed.",
   "type": "module",

--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -152,6 +152,8 @@ export async function searchLibrary(args: {
 export async function searchPassages(args: {
   query: string;
   language?: string;
+  languages?: string[];
+  exclude_languages?: string[];
   year_from?: number;
   year_to?: number;
   book_id?: string;
@@ -163,6 +165,10 @@ export async function searchPassages(args: {
     limit: String(Math.min(args.limit || 20, 50)),
   });
   if (args.language) params.set("language", args.language);
+  if (Array.isArray(args.languages) && args.languages.length > 0)
+    params.set("languages", args.languages.join(","));
+  if (Array.isArray(args.exclude_languages) && args.exclude_languages.length > 0)
+    params.set("exclude_languages", args.exclude_languages.join(","));
   if (args.year_from) params.set("year_from", String(args.year_from));
   if (args.year_to) params.set("year_to", String(args.year_to));
   if (args.book_id) params.set("book_id", args.book_id);
@@ -199,6 +205,8 @@ export async function searchPassages(args: {
 export async function searchConcept(args: {
   query: string;
   language?: string;
+  languages?: string[];
+  exclude_languages?: string[];
   year_from?: number;
   year_to?: number;
   limit?: number;
@@ -209,6 +217,10 @@ export async function searchConcept(args: {
     limit: String(Math.min(args.limit || 15, 50)),
   });
   if (args.language) params.set("language", args.language);
+  if (Array.isArray(args.languages) && args.languages.length > 0)
+    params.set("languages", args.languages.join(","));
+  if (Array.isArray(args.exclude_languages) && args.exclude_languages.length > 0)
+    params.set("exclude_languages", args.exclude_languages.join(","));
   if (args.year_from) params.set("year_min", String(args.year_from));
   if (args.year_to) params.set("year_max", String(args.year_to));
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -126,7 +126,17 @@ const TOOLS: Tool[] = [
         },
         language: {
           type: "string",
-          description: "Filter by book's original language (e.g., 'Latin', 'German', 'Greek')",
+          description: "Filter by a single original language (e.g., 'Latin', 'German', 'Greek')",
+        },
+        languages: {
+          type: "array",
+          items: { type: "string" },
+          description: 'Filter to any of these languages, e.g. ["Sanskrit", "Arabic", "Chinese"]. Use instead of language when targeting multiple traditions.',
+        },
+        exclude_languages: {
+          type: "array",
+          items: { type: "string" },
+          description: 'Exclude these languages, e.g. ["Latin", "French", "German", "English"] to surface non-Western sources.',
         },
         year_from: {
           type: "number",
@@ -163,7 +173,17 @@ const TOOLS: Tool[] = [
         },
         language: {
           type: "string",
-          description: "Filter by original language (e.g., Latin, German, Greek, Arabic, Chinese, Sanskrit, Hebrew, Persian, Tibetan). Use this filter when you want passages from a specific tradition — unfiltered English queries skew toward Latin/German/English results, so set language=Chinese/Arabic/etc. explicitly to surface those texts.",
+          description: "Filter by a single original language (e.g., Latin, German, Greek, Arabic, Chinese, Sanskrit, Hebrew, Persian, Tibetan). Use this filter when you want passages from a specific tradition — unfiltered English queries skew toward Latin/German/English results, so set language=Chinese/Arabic/etc. explicitly to surface those texts.",
+        },
+        languages: {
+          type: "array",
+          items: { type: "string" },
+          description: 'Filter to any of these languages, e.g. ["Sanskrit", "Arabic", "Chinese"]. Use instead of language when targeting multiple traditions.',
+        },
+        exclude_languages: {
+          type: "array",
+          items: { type: "string" },
+          description: 'Exclude these languages, e.g. ["Latin", "French", "German", "English"] to surface non-Western sources.',
         },
         year_from: {
           type: "number",


### PR DESCRIPTION
## Bug

The published `@source-library/mcp-server` npm package only accepted a singular `language?: string` param on `search_translations` and `search_concept`. Clients requesting `languages: ["Sanskrit", "Tibetan"]` or `exclude_languages: ["Latin"]` had those filters **silently ignored** — they got the old broken behavior.

The web API (`src/app/api/mcp/route.ts`) gained plural `languages[]` / `exclude_languages[]` filters in commits `0c256f7c` (#1786) and `77c53360` (#1787, code↔name normalization via `expandLanguages()`), but the standalone package was never updated.

## Fix

- **`mcp-server/src/api.ts`** — added `languages?: string[]` and `exclude_languages?: string[]` to the `searchPassages` and `searchConcept` signatures, forwarded as comma-joined query params (`languages`, `exclude_languages`), exactly mirroring the web route.
- **`mcp-server/src/index.ts`** — declared both array params in the `search_translations` and `search_concept` JSON tool schemas, with descriptions copied from the web API tool defs. Kept the singular `language` for backward compat.
- Bumped package version `4.3.0` → `4.3.1`.

## Why no in-package normalization

The package talks to the **SL HTTP API** (`https://sourcelibrary.org/api`), not the DB directly. It just forwards the plural params as query strings; the API's server-side `expandLanguages()` (in `src/lib/language-utils.ts`) handles the code↔name matching. No need to vendor `expandLanguages` into the package.

## Scope / out of scope

- The CLI (`mcp-server/src/cli.ts`) still only exposes a singular `--language` flag. Left unchanged — adding a multi-value CLI flag is a separate concern; the optional new params don't break its typecheck.
- **Republish to npm still needed.** This PR bumps the version but does NOT publish — a maintainer must `npm publish` from `mcp-server/` for clients to receive the fix.

## Verify

`cd mcp-server && npx tsc --noEmit` → exit 0 (with deps installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)