### PR TITLE
Map: add a 'tradition origin' layer + un-freeze the data cache

### DIFF
--- a/scripts/enrichment/geocode-origin-by-tradition.mjs
+++ b/scripts/enrichment/geocode-origin-by-tradition.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Geocode books by *cultural origin* (language / textual tradition) for the
+ * /explore/map view.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The map plots `books.locations[]`, which is populated from two signals:
+ *   - publication place  (geocode-publication-places.mjs)
+ *   - author birth/death (backfill-author-locations.mjs, via Wikidata)
+ * Both are heavily Western-skewed: non-Western books almost never carry a
+ * `place_of_publication`, and their authors are rarely linked to a Wikidata
+ * entity with coordinates. The result is that whole traditions the library
+ * actually holds — 1,400+ Tibetan, ~600 Chinese, Japanese, Korean, Ge'ez,
+ * Sanskrit, cuneiform — were invisible on the map (see 2026-06-03 finding).
+ *
+ * This script adds a THIRD, clearly-labelled layer: `type: 'origin'`. For a
+ * curated allowlist of languages whose textual tradition is tightly bound to
+ * one region, it places the book at that tradition's historic heartland.
+ *
+ * SCOPE / HONESTY
+ * ---------------
+ * - Only "strongly-bound" traditions are included. Diffuse / heavily-diaspora
+ *   or printed-in-Europe languages (Latin, Greek, Hebrew, Arabic, the European
+ *   vernaculars) are deliberately EXCLUDED — a single dot would misrepresent
+ *   them. Honest absence beats a misleading pin.
+ * - The layer is `source: 'tradition'`, `confidence: 'inferred'` and renders as
+ *   a distinct, toggleable type in the UI. It never claims a precise imprint.
+ * - It is a FALLBACK: only added to books that have NO existing location, and
+ *   never duplicated. Fully reversible — remove with:
+ *     db.books.updateMany({}, { $pull: { locations: { source: 'tradition' } } })
+ *
+ * Usage:
+ *   node scripts/enrichment/geocode-origin-by-tradition.mjs [--dry-run]
+ */
+
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+/**
+ * Curated language/tradition → cultural-origin heartland.
+ * Keys are normalized (lowercase, alpha-only). Coordinates point at the
+ * historic center of the textual tradition, not a modern administrative seat.
+ */
+const ORIGIN_TRADITIONS = {
+  // East / Inner Asia
+  tibetan:   { city: 'Lhasa',        country: 'Tibet',        lat: 29.6520, lng: 91.1721 },
+  chinese:   { city: 'Beijing',      country: 'China',        lat: 39.9042, lng: 116.4074 },
+  japanese:  { city: 'Kyoto',        country: 'Japan',        lat: 35.0116, lng: 135.7681 },
+  korean:    { city: 'Seoul',        country: 'South Korea',  lat: 37.5665, lng: 126.9780 },
+  mongolian: { city: 'Ulaanbaatar',  country: 'Mongolia',     lat: 47.8864, lng: 106.9057 },
+  manchu:    { city: 'Shenyang',     country: 'China',        lat: 41.8057, lng: 123.4315 },
+
+  // South / Southeast Asia
+  sanskrit:  { city: 'Varanasi',     country: 'India',        lat: 25.3176, lng: 82.9739 },
+  hindi:     { city: 'Varanasi',     country: 'India',        lat: 25.3176, lng: 82.9739 },
+  bengali:   { city: 'Kolkata',      country: 'India',        lat: 22.5726, lng: 88.3639 },
+  tamil:     { city: 'Thanjavur',    country: 'India',        lat: 10.7870, lng: 79.1378 },
+  pali:      { city: 'Anuradhapura', country: 'Sri Lanka',    lat: 8.3114,  lng: 80.4037 },
+  javanese:  { city: 'Yogyakarta',   country: 'Indonesia',    lat: -7.7956, lng: 110.3695 },
+  balinese:  { city: 'Denpasar',     country: 'Indonesia',    lat: -8.6705, lng: 115.2126 },
+
+  // Ethiopia / Horn of Africa
+  geez:      { city: 'Aksum',        country: 'Ethiopia',     lat: 14.1211, lng: 38.7245 },
+  amharic:   { city: 'Gondar',       country: 'Ethiopia',     lat: 12.6030, lng: 37.4521 },
+  tigrinya:  { city: 'Aksum',        country: 'Ethiopia',     lat: 14.1211, lng: 38.7245 },
+
+  // Ancient Near East / Egypt
+  sumerian:  { city: 'Nippur',       country: 'Iraq',         lat: 32.1264, lng: 45.2317 },
+  akkadian:  { city: 'Babylon',      country: 'Iraq',         lat: 32.5355, lng: 44.4275 },
+  egyptian:  { city: 'Thebes',       country: 'Egypt',        lat: 25.6872, lng: 32.6396 },
+  coptic:    { city: 'Alexandria',   country: 'Egypt',        lat: 31.2001, lng: 29.9187 },
+
+  // Caucasus / Levant
+  syriac:    { city: 'Edessa',       country: 'Turkey',       lat: 37.1591, lng: 38.7969 },
+  armenian:  { city: 'Echmiadzin',   country: 'Armenia',      lat: 40.1620, lng: 44.2910 },
+
+  // Iran
+  persian:   { city: 'Isfahan',      country: 'Iran',         lat: 32.6539, lng: 51.6660 },
+};
+
+/** Tibetan-script material from Bhutan (Tshamdrak monastery, BL Bhutan corpus). */
+const BHUTAN_ORIGIN = { city: 'Thimphu', country: 'Bhutan', lat: 27.4712, lng: 89.6339 };
+
+/**
+ * Normalize a language label to an ORIGIN_TRADITIONS key.
+ * Handles common variants and punctuation (Ge'ez/Geez/Ethiopic, Farsi, etc.).
+ */
+function normalizeLanguage(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const k = raw.toLowerCase().replace(/[^a-z]/g, '');
+  const aliases = {
+    ethiopic: 'geez', geez: 'geez',
+    farsi: 'persian', persian: 'persian',
+    egyptianhieroglyphs: 'egyptian', ancientegyptian: 'egyptian', egyptian: 'egyptian',
+    classicalchinese: 'chinese', literarychinese: 'chinese', mandarin: 'chinese',
+    classicaltibetan: 'tibetan',
+  };
+  if (aliases[k]) return aliases[k];
+  return ORIGIN_TRADITIONS[k] ? k : null;
+}
+
+/** Pick the tradition key for a book from its language fields. */
+function resolveTradition(book) {
+  const candidates = [
+    book.language,
+    ...(Array.isArray(book.languages) ? book.languages : []),
+    book.language_multi,
+  ];
+  for (const c of candidates) {
+    const key = normalizeLanguage(c);
+    if (key) return key;
+  }
+  return null;
+}
+
+/** Does this book's metadata indicate a Bhutanese (vs Tibetan) origin? */
+function isBhutanese(book) {
+  const hay = [
+    book.author, book.place_published, book.place_of_publication,
+    ...(Array.isArray(book.collections) ? book.collections : []),
+  ].filter(Boolean).join(' ').toLowerCase();
+  return /bhutan|tshamdrak|thimphu|drukpa/.test(hay);
+}
+
+async function main() {
+  console.log(`Geocode Origin by Tradition — ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
+  console.log('─'.repeat(60));
+
+  const client = await MongoClient.connect(process.env.MONGODB_URI);
+  const db = client.db('bookstore');
+
+  // Candidates: visible books with NO location at all.
+  const cursor = db.collection('books').find(
+    { visible: true, 'locations.0': { $exists: false } },
+    { projection: {
+      id: 1, language: 1, languages: 1, language_multi: 1,
+      author: 1, place_published: 1, place_of_publication: 1, collections: 1,
+    } },
+  );
+
+  const counts = {};
+  let scanned = 0, matched = 0, updated = 0;
+
+  for await (const book of cursor) {
+    scanned++;
+    const key = resolveTradition(book);
+    if (!key) continue;
+    matched++;
+
+    let geo = ORIGIN_TRADITIONS[key];
+    if (key === 'tibetan' && isBhutanese(book)) geo = BHUTAN_ORIGIN;
+
+    const label = geo.country;
+    counts[label] = (counts[label] || 0) + 1;
+
+    if (DRY_RUN) continue;
+
+    const location = {
+      type: 'origin',
+      city: geo.city,
+      country: geo.country,
+      lat: geo.lat,
+      lng: geo.lng,
+      source: 'tradition',
+      confidence: 'inferred',
+    };
+    const res = await db.collection('books').updateOne(
+      { _id: book._id, 'locations.source': { $ne: 'tradition' } },
+      { $push: { locations: location } },
+    );
+    updated += res.modifiedCount;
+  }
+
+  console.log(`\nScanned ${scanned} location-less visible books`);
+  console.log(`Matched a strongly-bound tradition: ${matched}`);
+  console.log(`${DRY_RUN ? 'Would update' : 'Updated'}: ${DRY_RUN ? matched : updated} books\n`);
+
+  console.log('By origin country:');
+  for (const [c, n] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${c.padEnd(14)} ${n}`);
+  }
+
+  console.log('\n' + '─'.repeat(60));
+  console.log('Done.');
+  await client.close();
+}
+
+main().catch(err => { console.error('Fatal:', err); process.exit(1); });

--- a/scripts/maintenance/build-map-cache.mjs
+++ b/scripts/maintenance/build-map-cache.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Build the /explore/map data cache (system_config._id = 'map_data').
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The map page (src/app/explore/map/page.tsx) reads a pre-computed snapshot
+ * from system_config.map_data and only falls back to a live aggregate when the
+ * cache is empty. Nothing was writing that doc — the snapshot was frozen on
+ * 2026-04-04, so every book geocoded since (publication, author, and the new
+ * `origin` tradition layer) was invisible. This script recomputes the snapshot
+ * from `books.locations[]` and is meant to run on a cron (Hetzner) so the map
+ * stays current.
+ *
+ * It mirrors the grouping in page.tsx's live-compute fallback exactly, so the
+ * cached and uncached code paths produce identical shapes.
+ *
+ * Usage:
+ *   node scripts/maintenance/build-map-cache.mjs [--dry-run]
+ */
+
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const MAX_BOOKS_PER_GROUP = 200;
+
+async function main() {
+  console.log(`Build Map Cache — ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
+  console.log('─'.repeat(60));
+
+  const client = await MongoClient.connect(process.env.MONGODB_URI);
+  const db = client.db('bookstore');
+
+  const books = await db.collection('books').find(
+    { visible: true, 'locations.0': { $exists: true } },
+    { projection: { id: 1, title: 1, display_title: 1, author: 1, year: 1, slug: 1, locations: 1 } },
+  ).toArray();
+
+  const groups = new Map();
+  const byType = {};
+  let totalBooks = 0;
+
+  for (const book of books) {
+    const locs = book.locations;
+    if (!Array.isArray(locs)) continue;
+
+    for (const loc of locs) {
+      if (!loc.lat || !loc.lng || !loc.city) continue;
+      const key = `${loc.city}|${loc.type}|${loc.lat.toFixed(2)}|${loc.lng.toFixed(2)}`;
+
+      if (!groups.has(key)) {
+        groups.set(key, {
+          city: loc.city, country: loc.country ?? null,
+          lat: loc.lat, lng: loc.lng, type: loc.type, books: [],
+        });
+      }
+      const group = groups.get(key);
+      if (group.books.length < MAX_BOOKS_PER_GROUP) {
+        group.books.push({
+          id: book.id,
+          title: book.title || 'Untitled',
+          display_title: book.display_title || undefined,
+          author: book.author || 'Unknown',
+          year: book.year ?? null,
+          slug: book.slug || '',
+        });
+      }
+      byType[loc.type] = (byType[loc.type] || 0) + 1;
+      totalBooks++;
+    }
+  }
+
+  const data = {
+    locations: Array.from(groups.values()),
+    stats: { total_books: totalBooks, total_locations: groups.size, by_type: byType },
+  };
+
+  console.log(`Visible books with locations: ${books.length}`);
+  console.log(`Distinct location groups:     ${groups.size}`);
+  console.log('Plotted points by type:');
+  for (const [t, n] of Object.entries(byType).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${t.padEnd(14)} ${n}`);
+  }
+
+  if (!DRY_RUN) {
+    await db.collection('system_config').updateOne(
+      { _id: 'map_data' },
+      { $set: { data, generatedAt: new Date(), count: groups.size } },
+      { upsert: true },
+    );
+    console.log(`\nWrote system_config.map_data (${groups.size} groups).`);
+  }
+
+  console.log('\n' + '─'.repeat(60));
+  console.log('Done.');
+  await client.close();
+}
+
+main().catch(err => { console.error('Fatal:', err); process.exit(1); });

--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -11,7 +11,7 @@ export const maxDuration = 60;
 export const metadata: Metadata = {
   title: 'Map — Explore — Source Library',
   description:
-    'Interactive map of 7,000+ books plotted by publication city and author birthplace from Wikidata coordinates.',
+    'Interactive map of 10,000+ books plotted by publication city, author birthplace, and the heartland of each text’s tradition.',
   openGraph: {
     title: 'Map — Explore — Source Library',
     description:
@@ -117,7 +117,7 @@ export default async function MapPage() {
         header={
           <ContentHeader maxWidth="wide"
             title="Map"
-            subtitle={`${locationCount.toLocaleString('en-US')} locations across Europe and beyond — publication cities, birthplaces, and institutions`}
+            subtitle={`${locationCount.toLocaleString('en-US')} locations worldwide — publication cities, author birthplaces, and the heartlands of the traditions we hold`}
           >
             <div className="mt-5">
               <ExploreTabBar />

--- a/src/components/explore/BookMap.tsx
+++ b/src/components/explore/BookMap.tsx
@@ -9,7 +9,7 @@ export interface BookLocation {
   country: string | null;
   lat: number;
   lng: number;
-  type: 'publication' | 'author_birth' | 'author_death';
+  type: 'publication' | 'author_birth' | 'author_death' | 'origin';
   books: Array<{
     id: string;
     title: string;
@@ -33,6 +33,7 @@ const TYPE_CONFIG: Record<string, { color: string; label: string; lightBg: strin
   publication:  { color: '#9e4a3a', label: 'Published here',  lightBg: 'rgba(158,74,58,0.1)' },
   author_birth: { color: '#5a7d8b', label: 'Author born here', lightBg: 'rgba(90,125,139,0.1)' },
   author_death: { color: '#8b7d5a', label: 'Author died here', lightBg: 'rgba(139,125,90,0.1)' },
+  origin:       { color: '#6a8a5a', label: 'Tradition origin', lightBg: 'rgba(106,138,90,0.1)' },
 };
 
 function createLocationIcon(type: string, bookCount: number) {
@@ -59,7 +60,7 @@ export default function BookMap({ locations }: BookMapProps) {
 
   const [selected, setSelected] = useState<BookLocation | null>(null);
   const [filters, setFilters] = useState({
-    types: new Set(['publication', 'author_birth', 'author_death']),
+    types: new Set(['publication', 'author_birth', 'author_death', 'origin']),
     minBooks: 1,
     yearFrom: 800,
     yearTo: 2025,
@@ -147,7 +148,8 @@ export default function BookMap({ locations }: BookMapProps) {
     for (const pin of cityPins) {
       if (pin.totalBooks < minBooksForZoom) continue;
       const dominantType = pin.types.has('publication') ? 'publication'
-        : pin.types.has('author_birth') ? 'author_birth' : 'author_death';
+        : pin.types.has('author_birth') ? 'author_birth'
+        : pin.types.has('author_death') ? 'author_death' : 'origin';
 
       const marker = L.marker([pin.lat, pin.lng], {
         icon: createLocationIcon(dominantType, pin.totalBooks),
@@ -203,7 +205,7 @@ export default function BookMap({ locations }: BookMapProps) {
         </h1>
 
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-          {(['publication', 'author_birth', 'author_death'] as const).map((type) => {
+          {(['publication', 'author_birth', 'author_death', 'origin'] as const).map((type) => {
             const active = filters.types.has(type);
             const config = TYPE_CONFIG[type];
             return (


### PR DESCRIPTION
## Why
The `/explore/map` view felt empty for whole swaths of the library. Looking at the map, you'd never know we hold 1,400+ Tibetan texts, ~600 Chinese, plus Japanese, Korean, Ge'ez, Sanskrit, and cuneiform material — nothing east of Pakistan except a couple of author-birthplace dots.

Root cause: the map plots `books.locations[]`, populated only from **publication place** and **author Wikidata birthplace**. Both are Western-skewed — non-Western books almost never carry a `place_of_publication`, and their authors are rarely linked to a Wikidata entity with coordinates. Net result: **only 24% of visible books (7,135) appeared on the map at all.**

## What this does
**1. A third location layer — `type: 'origin'`.** For a curated allowlist of languages whose textual tradition is tightly bound to one region, it places the book at that tradition's historic heartland:

| Tradition | Heartland | Books |
|---|---|---|
| Tibetan (Bhutanese) | Thimphu | 1,357 |
| Chinese | Beijing | 624 |
| Sumerian / Akkadian | Nippur / Babylon | 384 |
| Sanskrit / Hindi / Bengali | Varanasi / Kolkata | 312 |
| Japanese | Kyoto | 170 |
| Egyptian / Coptic | Thebes / Alexandria | 144 |
| Tibetan (Tibet) | Lhasa | 116 |
| Korean | Seoul | 88 |
| Persian | Isfahan | 47 |
| Syriac | Edessa | 42 |
| Armenian | Echmiadzin | 40 |
| Javanese | Yogyakarta | 39 |
| Ge'ez / Amharic | Aksum / Gondar | 20 |
| Pali | Anuradhapura | 7 |

The Tibetan corpus splits Bhutan vs. Tibet by metadata hints (Tshamdrak monastery / "Bhutan, Asia" → Thimphu), which is more accurate than dumping all 1,473 on Lhasa.

**Design choices (the honest part):**
- **Strongly-bound traditions only.** Diffuse / heavily-diaspora / printed-in-Europe languages (Latin, Greek, Hebrew, Arabic, the European vernaculars) are **deliberately excluded** — a single dot would misrepresent them. Honest absence beats a misleading pin.
- `source: 'tradition'`, `confidence: 'inferred'`. It's a **fallback** — added only to books with *no* existing location, never overriding hard provenance.
- Renders as a **distinct colour** ("Tradition origin", olive) and is **toggleable off**, so it never masquerades as a real imprint.
- Fully reversible: `db.books.updateMany({}, { $pull: { locations: { source: 'tradition' } } })`

**2. Un-freezes the map cache.** `system_config.map_data` was written once on **2026-04-04** and nothing refreshed it. Because the page only recomputes live when the cache is *empty*, the map had been frozen on April data — every book geocoded since was invisible regardless of layer. `scripts/maintenance/build-map-cache.mjs` recomputes the snapshot (mirrors the page's live-fallback exactly) and is meant to run on a Hetzner cron.

## Result
Books on the map: **7,135 → 10,526** (+3,391 origin points). The cache has been rebuilt against production, so the effect is already live in the data; this PR ships the UI (new toggle + colour + copy) and the two scripts.

## Out of scope (deliberately)
- **`place_published` field gap.** 680 books (incl. 120 tagged "Bhutan, Asia") store their place in `place_published`, which the publication geocoder ignores (it reads `place_of_publication`). Mostly European editions — a separate, smaller fix for another PR.
- **The "Visual" (6,796) and "Unknown" (5,624) language buckets** can't be placed by language; left off the map.
- **Cron registration on Hetzner** for `build-map-cache.mjs` — operational step, handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)