### PR TITLE
fix(gallery): scope image viewer prev/next to collection

### DIFF
--- a/src/app/gallery/collections/[slug]/CollectionImageCard.tsx
+++ b/src/app/gallery/collections/[slug]/CollectionImageCard.tsx
@@ -18,16 +18,18 @@ export interface CollectionImageProps {
   likeCount?: number;
 }
 
-export default function CollectionImageCard({ item, priority = false }: { item: CollectionImageProps; priority?: boolean }) {
+export default function CollectionImageCard({ item, priority = false, collectionSlug }: { item: CollectionImageProps; priority?: boolean; collectionSlug?: string }) {
   const [imageError, setImageError] = useState(false);
   const displayUrl = item.thumbnailUrl || item.extractedUrl || item.imageUrl;
   // Only bypass Next.js optimization for pre-generated R2 thumbnails (already small).
   // Fallback URLs (extractedUrl, imageUrl) can be 2MB+ and need optimization.
   const isPreGenerated = !!item.thumbnailUrl;
+  // Forward the gallery-collection slug so the viewer scopes prev/next to this curated set.
+  const imageHref = `/gallery/image/${item.id}${collectionSlug ? `?gcollection=${encodeURIComponent(collectionSlug)}` : ''}`;
 
   return (
     <div className="relative group bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-all hover:-translate-y-0.5">
-      <Link href={`/gallery/image/${item.id}`}>
+      <Link href={imageHref}>
         <div className="relative aspect-square bg-stone-100">
           {!imageError ? (
             <Image

--- a/src/app/gallery/collections/[slug]/page.tsx
+++ b/src/app/gallery/collections/[slug]/page.tsx
@@ -122,7 +122,7 @@ export default async function CollectionDetailPage({ params }: PageProps) {
         ) : (
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
             {data.items.map((item, i) => (
-              <CollectionImageCard key={item.id} item={item} priority={i < 6} />
+              <CollectionImageCard key={item.id} item={item} priority={i < 6} collectionSlug={slug} />
             ))}
           </div>
         )}

--- a/src/app/gallery/image/[id]/page.tsx
+++ b/src/app/gallery/image/[id]/page.tsx
@@ -101,6 +101,23 @@ export default function ImageDetailPage({
   const [currentIndex, setCurrentIndex] = useState(-1);
   const [imageOpacity, setImageOpacity] = useState(1);
 
+  // Collection scope for prev/next navigation. When the viewer is opened from a
+  // collection (via ?collection=<book-collection-slug> from the /gallery listing,
+  // or ?gcollection=<gallery-collection-slug> from a curated gallery collection),
+  // the prev/next list is built from that collection's image set instead of every
+  // image in the book. This mirrors the artwork fix (PR #2363) so paging left/right
+  // stays inside the set the reader is browsing. When neither is present, navigation
+  // stays book-scoped (unchanged).
+  const [collectionScope, setCollectionScope] = useState<{ collection?: string; gcollection?: string } | null>(null);
+  const collectionQuery = collectionScope?.collection
+    ? `?collection=${encodeURIComponent(collectionScope.collection)}`
+    : collectionScope?.gcollection
+    ? `?gcollection=${encodeURIComponent(collectionScope.gcollection)}`
+    : '';
+  useEffect(() => {
+    collectionQueryRef.current = collectionQuery;
+  }, [collectionQuery]);
+
   // Ref to prevent stale closures in keyboard handler
   const navRef = useRef({ bookImageIds: [] as string[], currentIndex: -1 });
   const isNavigatingRef = useRef(false);
@@ -108,10 +125,23 @@ export default function ImageDetailPage({
     navRef.current = { bookImageIds, currentIndex };
   }, [bookImageIds, currentIndex]);
 
+  // Ref so the (empty-deps) navigateTo callback always reads the live collection query.
+  const collectionQueryRef = useRef('');
+
   // Resolve params
   useEffect(() => {
     params.then(p => setImageId(p.id));
   }, [params]);
+
+  // Read collection scope from the URL once on mount (kept stable across in-page
+  // navigation, which only mutates the path via replaceState — see navigateTo).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const sp = new URLSearchParams(window.location.search);
+    const collection = sp.get('collection') || undefined;
+    const gcollection = sp.get('gcollection') || undefined;
+    if (collection || gcollection) setCollectionScope({ collection, gcollection });
+  }, []);
 
   // Fetch image data (initial load only — navigation handles its own fetching)
   useEffect(() => {
@@ -164,30 +194,82 @@ export default function ImageDetailPage({
     if (data?.rotation != null) setRotation(data.rotation as 0 | 90 | 180 | 270);
   }, [data?.description, data?.galleryQuality, data?.museumDescription, data?.metadata, data?.bbox, data?.rotation]);
 
-  // Fetch all images for this book (for navigation)
+  // Fetch the prev/next navigation list. Default scope is "all images in this book"
+  // (sorted by page number). When opened from a collection, scope to that collection's
+  // image set instead, preserving its native ordering so paging stays inside the set
+  // the reader is browsing (mirrors the artwork fix, PR #2363).
   useEffect(() => {
-    if (!data?.book?.id) return;
+    // Collection-scoped navigation doesn't depend on the loaded book, so it can run
+    // as soon as the scope is known. Book-scoped navigation waits for the book id.
+    if (!collectionScope && !data?.book?.id) return;
 
-    gallery.list({
-      bookId: data.book.id,
-      limit: 500,
-      includeArchive: true,
-      maxPerBook: 500,
-      minQuality: 0,
-    }).then(res => {
-      const items = [...res.items].sort((a, b) => a.pageNumber - b.pageNumber);
+    let cancelled = false;
+
+    async function loadNav(): Promise<{
+      ids: string[];
+      thumbs: Map<string, { thumb: string; desc: string }>;
+    }> {
+      // Curated gallery collection (ordered image_ids list) — use its own ordering.
+      if (collectionScope?.gcollection) {
+        const coll = await gallery.collections.get(collectionScope.gcollection);
+        const items = (coll?.items || []) as Array<{
+          id: string;
+          thumbnailUrl?: string;
+          extractedUrl?: string;
+          imageUrl?: string;
+          description?: string;
+        }>;
+        const ids = items.map(item => item.id);
+        const thumbs = new Map<string, { thumb: string; desc: string }>();
+        items.forEach(item => {
+          thumbs.set(item.id, {
+            thumb: item.thumbnailUrl || item.extractedUrl || item.imageUrl || '',
+            desc: item.description || '',
+          });
+        });
+        return { ids, thumbs };
+      }
+
+      // Book-collection slug — same source the /gallery listing uses; keep the API's
+      // native ordering (quality, year, book, page) rather than re-sorting by page,
+      // since a collection can span multiple books.
+      const res = await gallery.list({
+        collection: collectionScope?.collection,
+        bookId: collectionScope ? undefined : data!.book.id,
+        limit: 500,
+        includeArchive: true,
+        maxPerBook: 500,
+        minQuality: 0,
+      });
+      // Book scope keeps its original page-number ordering for backward compatibility.
+      const items = collectionScope
+        ? res.items
+        : [...res.items].sort((a, b) => a.pageNumber - b.pageNumber);
       const ids = items.map(item => `${item.pageId}-${item.detectionIndex}`);
       const thumbs = new Map<string, { thumb: string; desc: string }>();
       items.forEach(item => {
         const id = `${item.pageId}-${item.detectionIndex}`;
         thumbs.set(id, { thumb: item.thumbnailUrl || item.extractedUrl || item.imageUrl, desc: item.description });
       });
+      return { ids, thumbs };
+    }
+
+    loadNav().then(({ ids, thumbs }) => {
+      if (cancelled) return;
+      // If the current image isn't in the scoped set (e.g. a stale link), fall back to
+      // book scope so navigation still works rather than showing a single-image set.
+      if (collectionScope && imageId && !ids.includes(imageId) && data?.book?.id) {
+        setCollectionScope(null);
+        return;
+      }
       setBookImageIds(ids);
       setBookThumbnails(thumbs);
       const idx = ids.indexOf(imageId!);
       setCurrentIndex(idx >= 0 ? idx : 0);
     });
-  }, [data?.book?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return () => { cancelled = true; };
+  }, [data?.book?.id, collectionScope]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update currentIndex when imageId changes (after navigation)
   useEffect(() => {
@@ -250,9 +332,10 @@ export default function ImageDetailPage({
     setImageOpacity(0);
     await new Promise(r => setTimeout(r, 280));
 
-    // Update URL and reset editing state while screen is black
+    // Update URL and reset editing state while screen is black. Preserve the collection
+    // scope query param so a reload / share keeps prev/next inside the collection.
     setCurrentIndex(index);
-    window.history.replaceState(null, '', `/gallery/image/${imgId}`);
+    window.history.replaceState(null, '', `/gallery/image/${imgId}${collectionQueryRef.current}`);
     setEditingTitle(false);
     setEditingQuality(false);
     setEditingDescription(false);
@@ -1139,12 +1222,25 @@ export default function ImageDetailPage({
                 </div>
               </div>
 
-              {/* More pictures from this book */}
+              {/* More pictures — from this collection when collection-scoped, else this book */}
               {bookImageIds.length > 1 && (
                 <div className="bg-stone-800 rounded-lg p-5">
                   <div className="flex items-center justify-between mb-3">
-                    <h3 className="text-base font-medium text-stone-300">More pictures from this book</h3>
-                    <Link href={data.galleryUrl} className="text-sm text-accent-gold hover:text-accent-gold">See all</Link>
+                    <h3 className="text-base font-medium text-stone-300">
+                      {collectionScope ? 'More pictures from this collection' : 'More pictures from this book'}
+                    </h3>
+                    <Link
+                      href={
+                        collectionScope?.gcollection
+                          ? `/gallery/collections/${collectionScope.gcollection}`
+                          : collectionScope?.collection
+                          ? `/gallery?collection=${encodeURIComponent(collectionScope.collection)}`
+                          : data.galleryUrl
+                      }
+                      className="text-sm text-accent-gold hover:text-accent-gold"
+                    >
+                      See all
+                    </Link>
                   </div>
                   <div className="grid grid-cols-3 gap-2">
                     {bookImageIds
@@ -1156,7 +1252,7 @@ export default function ImageDetailPage({
                         return (
                           <Link
                             key={id}
-                            href={`/gallery/image/${id}`}
+                            href={`/gallery/image/${id}${collectionQuery}`}
                             onClick={(e) => {
                               e.preventDefault();
                               const idx = bookImageIds.indexOf(id);

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -626,7 +626,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
             )}
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
               {allItems.map((item, idx) => (
-                <GalleryCard key={`${item.pageId}-${item.detectionIndex}-${idx}`} item={item} priority={idx < 12} tenantPrefix={tenantPrefix} />
+                <GalleryCard key={`${item.pageId}-${item.detectionIndex}-${idx}`} item={item} priority={idx < 12} tenantPrefix={tenantPrefix} collectionScope={collectionFilter || undefined} />
               ))}
             </div>
 
@@ -656,7 +656,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   );
 }
 
-function GalleryCard({ item, priority = false, tenantPrefix = '' }: { item: GalleryItem; priority?: boolean; tenantPrefix?: string }) {
+function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScope }: { item: GalleryItem; priority?: boolean; tenantPrefix?: string; collectionScope?: string }) {
   const [imageError, setImageError] = useState(false);
   const [useCropFallback, setUseCropFallback] = useState(false);
 
@@ -670,10 +670,12 @@ function GalleryCard({ item, priority = false, tenantPrefix = '' }: { item: Gall
 
   const isPreGenerated = !useCropFallback && !!blobUrl;
   const galleryImageId = `${item.pageId}-${item.detectionIndex}`;
+  // Forward the collection scope so the image viewer keeps prev/next inside the collection.
+  const imageHref = `${tenantPrefix}/gallery/image/${galleryImageId}${collectionScope ? `?collection=${encodeURIComponent(collectionScope)}` : ''}`;
 
   return (
     <div className="relative group rounded-lg overflow-hidden hover:shadow-md transition-all hover:-translate-y-0.5">
-      <Link href={`${tenantPrefix}/gallery/image/${galleryImageId}`} className="block relative aspect-square bg-stone-100">
+      <Link href={imageHref} className="block relative aspect-square bg-stone-100">
         {!imageError ? (
           <Image
             src={displayUrl}


### PR DESCRIPTION
## Why

Opening a gallery image from a collection (`/gallery?collection=<id>` listing, or a curated gallery-collection page) dropped you into the viewer at `/gallery/image/[id]`, but the viewer built its prev/next list from **every image in the book** — so paging left/right escaped the collection the reader was browsing.

This mirrors the already-merged **artwork** fix in PR #2363 (`fix(artwork): scope prev/next nav to collection, not just artist`), which scoped artwork prev/next to the work's collection. The artwork fix is server-side Mongo; the gallery viewer is a client component using the `gallery` API client, so the mechanism differs but the intent is identical.

## What (in scope)

- The viewer reads a collection scope from the URL on mount:
  - `?collection=<book-collection-slug>` → builds the prev/next list via `gallery.list({ collection })` — the **same source** the `/gallery?collection=` listing uses (no new endpoint). Keeps the API's native ordering since a collection can span multiple books.
  - `?gcollection=<gallery-collection-slug>` → builds it via `gallery.collections.get(slug)` — the curated `image_ids` set, in its stored order.
- The scope param is forwarded into the image href by the two entry points that reach the viewer from a collection:
  - `GalleryClient` (the `/gallery?collection=` listing) → appends `?collection=`.
  - `CollectionImageCard` (curated `/gallery/collections/[slug]` pages) → appends `?gcollection=`.
- The scope rides along in-page navigation (`replaceState`, via a ref to avoid a stale closure) and in the "More pictures" thumbnails / "See all" link, which retitle to "…from this collection" when scoped.
- Prev/next arrows, keyboard arrows, the "N / M" counter, and prefetch all operate on the scoped list.
- Stale links whose image isn't in the scoped set fall back to book scope rather than showing a one-image set.

## Backward compatibility

When no scope param is present, behavior is **unchanged**: the list is still built from `gallery.list({ bookId })` and sorted by page number; the URL gets no query string. The new nav effect's only added dependency is `collectionScope`, which stays `null` in that path.

## Tenant/embed safety

All forwarded hrefs stay relative (`/gallery/image/...?collection=...`), so BPH/tenant subdomains are unaffected — no absolute `sourcelibrary.org` URLs introduced.

## Out of scope

- The **collection page** "Illustrations" grid (`/collections/[id]`, lines ~946-992) links directly to the **book page** (`/book/.../page/...`), not the image viewer, so it never triggers the prev/next bug — left unchanged. Routing it through the viewer would be a separate UX change.
- No new API endpoint: both scopes reuse existing `gallery.list` / `gallery.collections.get`.

## Verification

- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
