### PR TITLE
feat(etcsl): --only-missing + updated_at bump in CDLI witness cover matcher

### DIFF
--- a/scripts/etcsl/fetch-cdli-witnesses.mjs
+++ b/scripts/etcsl/fetch-cdli-witnesses.mjs
@@ -11,6 +11,7 @@
  *   node scripts/etcsl/fetch-cdli-witnesses.mjs --dry-run
  *   node scripts/etcsl/fetch-cdli-witnesses.mjs --book-id=69afd3fcf6ab0e0de59ae807
  *   node scripts/etcsl/fetch-cdli-witnesses.mjs --limit=10
+ *   node scripts/etcsl/fetch-cdli-witnesses.mjs --only-missing   # only books with no thumbnail yet
  */
 
 import { MongoClient } from 'mongodb';
@@ -144,6 +145,7 @@ function artifactToWitness(artifact, hasPhoto, qNumber) {
 async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
+  const onlyMissing = args.includes('--only-missing');
   const bookIdArg = args.find(a => a.startsWith('--book-id='))?.split('=')[1];
   const limitArg = parseInt(args.find(a => a.startsWith('--limit='))?.split('=')[1] || '0', 10);
 
@@ -159,6 +161,9 @@ async function main() {
   // Find ETCSL books
   const query = { etcsl_id: { $exists: true, $ne: '' } };
   if (bookIdArg) query.id = bookIdArg;
+  // --only-missing: skip books that already have a cover, so a re-run just
+  // fills gaps (and doesn't re-hit CDLI for the whole corpus).
+  if (onlyMissing) query.$or = [{ thumbnail: { $exists: false } }, { thumbnail: null }, { thumbnail: '' }];
 
   const books = await db.collection('books')
     .find(query, { projection: { _id: 0, id: 1, etcsl_id: 1, title: 1, thumbnail: 1, thumbnail_source: 1 } })
@@ -212,10 +217,14 @@ async function main() {
     // Update book with witnesses
     const update = { $set: { cdli_witnesses: witnesses } };
 
-    // Set thumbnail to first witness with a photo (if book has no manual cover)
+    // Set thumbnail to first witness with a photo (if book has no manual cover).
+    // Bump updated_at so the Supabase books_catalog sync (5-min cron / manual
+    // sync-books-catalog.mjs) picks up the new cover — a plain $set of thumbnail
+    // does NOT touch updated_at, so the collection grid would otherwise lag.
     if (withPhotos.length > 0 && book.thumbnail_source !== 'manual') {
       update.$set.thumbnail = withPhotos[0].photo_url;
       update.$set.thumbnail_source = 'auto';
+      update.$set.updated_at = new Date();
       thumbnailsUpdated++;
     }
 


### PR DESCRIPTION
## Why

While investigating the Sumerian & Mesopotamian collection, the ask was: give the image-less ETCSL texts real cuneiform covers, **but only if connected to the text directly** (no generic tablets). `scripts/etcsl/fetch-cdli-witnesses.mjs` already does this correctly — it matches each composition to the tablets CDLI catalogs as its witnesses (`ETCSL <id>` search) and sets the cover to a photographed witness. This PR makes the gap-fill re-run safe and effective.

## Changes (scripts-only, no deploy needed — Hetzner auto-pulls)

- **`--only-missing`** — process only ETCSL books with no thumbnail yet, so a re-run fills gaps without re-hitting CDLI for the whole 373-book corpus.
- **Bump `updated_at` when a cover is set** — fixes a latent bug: a bare `$set` of `thumbnail` left `updated_at` untouched, so the Supabase `books_catalog` sync (5-min cron / `sync-books-catalog.mjs`) never picked up the new cover and the collection grid kept showing a blank card. See the `lesson_collection_grid_supabase_sync` pattern.

## Result of running it (`--only-missing`, live, all 105 blank books)

- 373 ETCSL books: **268 already have a genuine witness cover**, 105 blank.
- Of the 105 blank: 68 have witness tablets cataloged on CDLI but **none are photographed**, and 37 have no witnesses. I also checked CDLI **line-art** endpoints — also 404 for these witnesses (the tablets are in BM/Istanbul/Louvre/Hilprecht collections, cataloged but not digitized).
- **0 covers added** — by design. With no directly-connected image (photo or line-art) available, attaching anything would break the integrity rule. The `--only-missing` re-run will pick them up automatically as CDLI digitizes more over time.

## Integrity

Covers come only from tablets CDLI lists as witnesses to that exact composition, with an existing image. Compositions with no photographed/drawn witness stay blank rather than getting a generic tablet.

## Out of scope

- De-blanking the remaining 105 via a **typographic placeholder cover** (title-based, clearly not a tablet image) — a UI change, separate PR if wanted.
- Wiring a periodic `--only-missing` cron so new CDLI digitizations surface automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)