### PR TITLE
fix(collections): serve higher-res artwork thumbnails on collection grids

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -58,10 +58,22 @@ export function getBookThumbnailUrl(
   book: { thumbnail?: string | null; thumbnail_blob?: string | null; image_display?: string | null; image_thumb?: string | null },
   size: 'display' | 'thumb' = 'display'
 ): string | null {
-  // Prefer canonical image_* fields, fall back to legacy thumbnail/thumbnail_blob
+  // Prefer canonical image_* fields, fall back to legacy thumbnail/thumbnail_blob.
+  //
+  // Artwork exception: ~98% of artworks store a 150px `book-thumbnails/{id}-thumb.jpg`
+  // in `image_thumb` while their real high-res lives at `artwork/art-*.jpg`
+  // (which has a 600px `-thumb.jpg` variant). Card grids render ~300px CSS cells —
+  // ~600px on a 2x-DPR display — so the 150px thumb upscales ~4x and looks badly
+  // pixelated (reported on /collections/hermetic-image, 2026-06-03). When an
+  // artwork source URL is available, derive the thumb from it (→ 600px) instead
+  // of the 150px `book-thumbnails/` variant. (#1727 cost policy: still a tier-1
+  // R2 variant, never /_next/image.)
+  const artworkSource = (book.image_display?.includes('/artwork/') && book.image_display)
+    || (book.thumbnail?.includes('/artwork/') && book.thumbnail)
+    || null;
   const raw = size === 'display'
     ? (book.image_display || book.thumbnail || book.thumbnail_blob || null)
-    : (book.image_thumb || book.thumbnail_blob || book.thumbnail || null);
+    : (artworkSource || book.image_thumb || book.thumbnail_blob || book.thumbnail || null);
   if (!raw) return null;
 
   // Wikimedia Commons images: serve the upload.wikimedia.org CDN URL as-is.
@@ -78,10 +90,17 @@ export function getBookThumbnailUrl(
   if (!raw.includes('images.sourcelibrary.org/')) return raw;
 
   // Artwork URLs: use thumb variants for 'thumb' size, full for 'display'.
+  // Three R2 variants exist per artwork: `-thumb.jpg` (600px), `.jpg` (2000px),
+  // `-full.jpg` (original, 3-4MB). Card grids want the 600px thumb; detail/hero
+  // wants full. Normalize whichever suffix `raw` carries to the requested one.
   if (raw.includes('/artwork/')) {
     if (size === 'thumb') {
-      // Prefer -thumb.jpg for card grids
+      // Prefer -thumb.jpg (600px) for card grids — map both -full and the bare
+      // 2000px display variant down to it (the bare-.jpg case is the common one,
+      // since image_display / thumbnail hold the 2000px URL).
+      if (raw.endsWith('-thumb.jpg')) return raw;
       if (raw.endsWith('-full.jpg')) return raw.replace(/-full\.jpg$/, '-thumb.jpg');
+      if (raw.endsWith('.jpg')) return raw.replace(/\.jpg$/, '-thumb.jpg');
       return raw;
     }
     // Display size: prefer -full.jpg

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -173,16 +173,41 @@ describe('getBookThumbnailUrl', () => {
     expect(result).not.toContain('commons.wikimedia.org');
   });
 
-  // Artwork URLs without -thumb or -full suffix should pass through
-  it('passes through artwork URLs without size suffix', () => {
+  // A bare artwork .jpg is the 2000px display variant; thumb mode must map it
+  // down to the 600px -thumb.jpg (the bare 2000px would be ~1.5MB into a ~300px
+  // card cell). Display mode keeps the bare .jpg (there's nothing to upgrade).
+  it('maps a bare artwork .jpg to -thumb.jpg in thumb mode', () => {
     const book = {
       thumbnail: 'https://images.sourcelibrary.org/artwork/some-image.jpg',
       thumbnail_blob: 'https://images.sourcelibrary.org/artwork/some-image.jpg',
     };
-    // Display: no -thumb to rewrite, passes through
     expect(getBookThumbnailUrl(book, 'display')).toBe('https://images.sourcelibrary.org/artwork/some-image.jpg');
-    // Thumb: no -full to rewrite, passes through
-    expect(getBookThumbnailUrl(book, 'thumb')).toBe('https://images.sourcelibrary.org/artwork/some-image.jpg');
+    expect(getBookThumbnailUrl(book, 'thumb')).toBe('https://images.sourcelibrary.org/artwork/some-image-thumb.jpg');
+  });
+
+  // Regression for /collections/hermetic-image low-res grid (2026-06-03):
+  // ~98% of artworks store a 150px book-thumbnails/{id}-thumb.jpg in image_thumb
+  // while their real high-res lives at artwork/art-*.jpg (with a 600px -thumb).
+  // thumb mode must prefer the 600px artwork thumb over the 150px book-thumbnail.
+  it('prefers the 600px artwork thumb over a 150px book-thumbnails image_thumb', () => {
+    const book = {
+      image_display: 'https://images.sourcelibrary.org/artwork/art-khunrath.jpg',
+      image_thumb: 'https://images.sourcelibrary.org/book-thumbnails/abc123-thumb.jpg',
+      thumbnail: 'https://images.sourcelibrary.org/artwork/art-khunrath.jpg',
+    };
+    // Was returning the 150px book-thumbnails URL → 4x upscale in card cells.
+    expect(getBookThumbnailUrl(book, 'thumb')).toBe('https://images.sourcelibrary.org/artwork/art-khunrath-thumb.jpg');
+    expect(getBookThumbnailUrl(book, 'display')).toBe('https://images.sourcelibrary.org/artwork/art-khunrath.jpg');
+  });
+
+  // Non-artwork books keep using image_thumb (their pages/ thumbnails are the
+  // right source — the artwork exception must not touch them).
+  it('keeps image_thumb for non-artwork books', () => {
+    const book = {
+      image_display: 'https://images.sourcelibrary.org/pages/abc/0002.jpg',
+      image_thumb: 'https://images.sourcelibrary.org/pages/abc/0002-thumb.jpg',
+    };
+    expect(getBookThumbnailUrl(book, 'thumb')).toBe('https://images.sourcelibrary.org/pages/abc/0002-thumb.jpg');
   });
 
   // Default size is 'display'


### PR DESCRIPTION
## What the live page showed

Reported (2026-06-03): images on `/collections/hermetic-image` look *really low res* — "is it the difference in size/AR? Do we need a different AR r2 besides thumbnail?"

Verified live (headless render + network capture + DB/curl):
- `hermetic-image` is a **`visual_art`** collection (parent `hermetica`), 430 visible artworks. Its dynamic gallery query genuinely returns **0** `gallery_images` (artworks have no `gallery_images` rows), so the page falls to the artwork rendering path — not the illustration grid.
- The "All Works" **grid view** (`CollectionAllBooks.tsx`) rendered `<img>` cells measured at **298×224 CSS (596×448 device px at DPR 2)** whose `naturalWidth` was only **150px** (`book-thumbnails/{id}-thumb.jpg`) → a **~4× upscale → visible pixelation**. That is the "low res."

## Root cause (resolving the contradiction)

The prior hypothesis assumed the page served full-res bare `<img>` (which would look fine, not low-res). It doesn't. `getBookThumbnailUrl(book, 'thumb')` prefers `image_thumb` first, and **~98% of visible artworks (14,108 / 14,346)** store a **150px** `book-thumbnails/{id}-thumb.jpg` in `image_thumb` — while their real high-res lives at `artwork/art-*.jpg` (R2 variants: 600px `-thumb.jpg`, 2000px `.jpg`, original `-full.jpg`). The 150px `book-thumbnails/` path has **no larger variant** (`.jpg`/`-full.jpg` → 404), so it can't simply be served bigger.

So: low-res because the grid served the 150px book-thumbnail, not because it served full-res. The user's instinct ("different AR/variant besides thumbnail") was right.

## Fix

In `getBookThumbnailUrl` (`src/lib/utils.ts`): when a book carries an `artwork/` source URL (`image_display` or `thumbnail`), derive the **thumb** from it (→ 600px `-thumb.jpg`) instead of falling to the 150px `image_thumb`. Also map a bare 2000px artwork `.jpg` down to `-thumb.jpg` in thumb mode (it was returned as the ~1.5MB display variant). Non-artwork books are untouched.

- Stays on **tier-1 R2 variants** per the #1727 resolver cost policy — **never `/_next/image`**.
- Fixes every artwork thumbnail site-wide (collection grids, hero collages, search/cards), not just this page.
- Verified **25/25** sampled 600px artwork thumbs return 200.
- `npx tsc --noEmit` clean; unit suite green (added 3 cases, updated 1 that encoded the old buggy pass-through).

## Out of scope / not reused

- The closed **PR #2281** (`galleryThumbLoader`) is **not** reused — per Derek's closing note it 404'd on non-canonical paths and its revision routed through the metered Vercel optimizer (tier-3). This fix follows the #1727 cost policy instead.
- Non-artwork book cards could hit the same 150px-into-large-cell upscale, but they use the `pages/` cover thumbs and weren't part of the report — left for a separate pass.
- This is a `visual_art` collection; the `gallery_images` illustration grid path (#2092 field-priority) is unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)