### PR TITLE
fix(thumbs): cover split-half full-res thumbnails + --provider scope

### DIFF
--- a/scripts/maintenance/fix-fullres-page-thumbs.mjs
+++ b/scripts/maintenance/fix-fullres-page-thumbs.mjs
@@ -24,8 +24,14 @@
  *   set -a; source .env.production.local; set +a
  *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --book <bookId>          # dry run, one book
  *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --book <bookId> --apply  # write, one book
- *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --all                    # dry run, whole library
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --provider bph           # dry run, one provider (indexed)
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --provider bph --apply   # write, one provider
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --all                    # dry run, whole library (COLLSCAN)
  *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --all --apply            # write, whole library
+ *
+ * Prefer --provider bph over --all: the affected population is the BPH
+ * 2-page-spread books, and the indexed book_id $in query avoids the slow,
+ * connection-fragile full pages COLLSCAN that --all forces.
  */
 
 import { MongoClient } from 'mongodb';
@@ -34,11 +40,16 @@ const APPLY = process.argv.includes('--apply');
 const ALL = process.argv.includes('--all');
 const bookIdx = process.argv.indexOf('--book');
 const BOOK_ID = bookIdx !== -1 ? process.argv[bookIdx + 1] : null;
+const provIdx = process.argv.indexOf('--provider');
+const PROVIDER = provIdx !== -1 ? process.argv[provIdx + 1] : null;
 const CONCURRENCY = 24;
 
-// Heavy field value we want to replace: a canonical pages/ full-res image.
-// images.sourcelibrary.org/pages/{book}/{digits}-full.jpg
-const FULL_RE = /^(https:\/\/images\.sourcelibrary\.org\/pages\/[a-f0-9-]+\/\d{3,})-full\.jpg$/;
+// Heavy field value we want to replace: a pages/ full-res image. Covers both
+// canonical {NNNN}-full.jpg and new-era split halves split-{objectid}-full.jpg
+// (and any other pages/ basename) — the -thumb.jpg sibling is the same image at
+// thumb size and is HEAD-verified before any write.
+// images.sourcelibrary.org/pages/{book}/{basename}-full.jpg
+const FULL_RE = /^(https:\/\/images\.sourcelibrary\.org\/pages\/[a-f0-9-]+\/.+)-full\.jpg$/;
 const THUMB_FIELDS = ['image_thumb', 'thumbnail_blob'];
 
 const headCache = new Map();
@@ -60,8 +71,8 @@ async function main() {
     console.error('MONGODB_URI not set. source .env.production.local first.');
     process.exit(1);
   }
-  if (!ALL && !BOOK_ID) {
-    console.error('Pass --book <bookId> or --all.');
+  if (!ALL && !BOOK_ID && !PROVIDER) {
+    console.error('Pass --book <bookId>, --provider <name>, or --all.');
     process.exit(1);
   }
 
@@ -74,13 +85,25 @@ async function main() {
   const pages = db.collection('pages');
 
   // Match pages where EITHER thumb field is a -full.jpg pages URL.
-  const fullRegex = { $regex: '^https://images\\.sourcelibrary\\.org/pages/[a-f0-9-]+/\\d{3,}-full\\.jpg$' };
+  const fullRegex = { $regex: '^https://images\\.sourcelibrary\\.org/pages/[a-f0-9-]+/.+-full\\.jpg$' };
   const query = {
     $or: [{ image_thumb: fullRegex }, { thumbnail_blob: fullRegex }],
   };
-  if (BOOK_ID) query.book_id = BOOK_ID;
+  let scopeLabel = 'ALL books';
+  if (BOOK_ID) {
+    query.book_id = BOOK_ID;
+    scopeLabel = `book ${BOOK_ID}`;
+  } else if (PROVIDER) {
+    // Resolve book ids first, then query pages by indexed book_id $in —
+    // avoids a full pages COLLSCAN (which the regex-only --all path forces).
+    const ids = await db.collection('books')
+      .find({ 'image_source.provider': PROVIDER }, { projection: { _id: 0, id: 1 } })
+      .map(b => b.id).toArray();
+    query.book_id = { $in: ids };
+    scopeLabel = `provider ${PROVIDER} (${ids.length} books)`;
+  }
 
-  console.log(`mode: ${APPLY ? 'APPLY (writes will happen)' : 'DRY RUN (no writes)'}  scope: ${BOOK_ID ? `book ${BOOK_ID}` : 'ALL books'}`);
+  console.log(`mode: ${APPLY ? 'APPLY (writes will happen)' : 'DRY RUN (no writes)'}  scope: ${scopeLabel}`);
 
   const cursor = pages.find(query, {
     projection: { _id: 1, book_id: 1, page_number: 1, image_thumb: 1, thumbnail_blob: 1 },


### PR DESCRIPTION
Follow-up to #2373. Two improvements to `scripts/maintenance/fix-fullres-page-thumbs.mjs`, both shaken out while backfilling the live BPH corpus:

1. **Broaden the match pattern.** The merged version only matched canonical `pages/{book}/{NNNN}-full.jpg` thumb URLs. New-era split halves are stored as `pages/{book}/split-{objectid}-full.jpg`, which the `\d{3,}` pattern skipped — leaving ~10.8K BPH page docs still pointing `image_thumb`/`thumbnail_blob` at the 1.7–2.2 MB full-res split half instead of the ~3 KB `-thumb.jpg` sibling. Broadened `FULL_RE` (and the Mongo query) to any `pages/` basename ending in `-full.jpg`. The HEAD-verify guard is unchanged, so it stays a pure, sibling-confirmed size swap.

2. **Add `--provider <name>` scope.** Resolves book ids first, then queries pages by indexed `book_id: {$in}` — avoids the full pages COLLSCAN that `--all` forces (which kept dying on flaky connections). Prefer `--provider bph` for the affected population.

## Verified on BPH (live)
- Canonical `{NNNN}-full.jpg`: 43,818 matched, ~all fixed (first run).
- Split-half `split-{id}-full.jpg`: 10,837 matched, 10,835 fixable, 2 with no sibling (left for thumbnail generation).

## Out of scope
Pages whose only thumb source is a legacy `/cropped/{objectid}.jpg` (no derivable pre-sized sibling) — the `/api/image` proxy sizes those at render time; generating fresh thumbnails for them is a separate pipeline pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)