### PR TITLE
feat(ui): typographic cover for books with no scanned image

### DIFF
--- a/src/components/BookCoverPlaceholder.tsx
+++ b/src/components/BookCoverPlaceholder.tsx
@@ -1,0 +1,62 @@
+/**
+ * Typographic cover for books with no scanned image.
+ *
+ * Some texts in the library have no digitized facsimile — e.g. ETCSL Sumerian
+ * compositions reconstructed from witness tablets that were never photographed.
+ * Rather than a blank card with a generic icon (which reads as "broken"), we
+ * render an intentional, title-page-style cover. It never implies an image we
+ * don't have; it's clearly a typographic stand-in.
+ *
+ * Deterministic per title (no Math.random) so the same book always looks the
+ * same and a grid gets gentle, stable variety instead of one flat wall.
+ */
+
+const PALETTES = [
+  { bg: 'from-[#f3ece0] to-[#e7dcc8]', ink: 'text-[#5b4a36]', rule: 'border-[#bda981]' },
+  { bg: 'from-[#efe9e2] to-[#ddd0c2]', ink: 'text-[#574838]', rule: 'border-[#b8a487]' },
+  { bg: 'from-[#f0ebe1] to-[#e2d6c4]', ink: 'text-[#574a3a]', rule: 'border-[#b9a888]' },
+  { bg: 'from-[#efe7da] to-[#e0d3bf]', ink: 'text-[#5a4a37]', rule: 'border-[#bca680]' },
+];
+
+function pick(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) | 0;
+  return Math.abs(h) % PALETTES.length;
+}
+
+interface BookCoverPlaceholderProps {
+  title: string;
+  author?: string | null;
+  /** Optional small line under the title (e.g. year, tradition). */
+  meta?: string | null;
+  className?: string;
+}
+
+export default function BookCoverPlaceholder({ title, author, meta, className = '' }: BookCoverPlaceholderProps) {
+  const p = PALETTES[pick(title || 'untitled')];
+
+  return (
+    <div
+      className={`absolute inset-0 flex items-center justify-center bg-gradient-to-br ${p.bg} ${className}`}
+      aria-hidden="true"
+    >
+      {/* inset frame, like a printed title page */}
+      <div className={`absolute inset-[7%] border ${p.rule} opacity-50 rounded-[2px]`} />
+
+      <div className={`relative flex flex-col items-center justify-center text-center px-[12%] ${p.ink}`}>
+        <span className={`block w-7 border-t ${p.rule} mb-3 opacity-70`} />
+        <h4
+          className="font-serif font-semibold leading-snug line-clamp-5 text-[clamp(0.8rem,2.6vw,1.15rem)]"
+          style={{ fontFamily: 'var(--font-serif)' }}
+        >
+          {title}
+        </h4>
+        {author && author.toLowerCase() !== 'unknown' && (
+          <p className="mt-2 text-[clamp(0.6rem,1.7vw,0.78rem)] italic opacity-80 line-clamp-1">{author}</p>
+        )}
+        {meta && <p className="mt-1 text-[clamp(0.55rem,1.5vw,0.7rem)] uppercase tracking-wide opacity-60 line-clamp-1">{meta}</p>}
+        <span className={`block w-7 border-t ${p.rule} mt-3 opacity-70`} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -3,12 +3,13 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { BookOpen, Calendar, FileText } from 'lucide-react';
+import { Calendar, FileText } from 'lucide-react';
 import { cn, getBookThumbnailUrl } from '@/lib/utils';
 import { bookCoverResponsiveLoader } from '@/lib/book-cover-loader';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import { isPublishedFirstTranslation } from '@/lib/book';
 import AuthorName from '@/components/AuthorName';
+import BookCoverPlaceholder from '@/components/BookCoverPlaceholder';
 import { getEffectiveByline } from '@/lib/byline';
 import { useEmbedHref } from '@/lib/EmbedContext';
 
@@ -100,9 +101,10 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
               blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMyIgaGVpZ2h0PSI0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIzIiBoZWlnaHQ9IjQiIGZpbGw9IiNlN2UyZGUiLz48L3N2Zz4="
             />
           ) : (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <BookOpen className="w-16 h-16 text-muted" />
-            </div>
+            <BookCoverPlaceholder
+              title={book.display_title || book.title}
+              author={isArtwork ? undefined : book.author}
+            />
           )}
 
           {/* Status badges */}

--- a/src/components/book/BookCard.tsx
+++ b/src/components/book/BookCard.tsx
@@ -3,7 +3,6 @@
 import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { Book as BookIcon } from 'lucide-react';
 import type { Book } from '@/lib/types';
 import { recordLoadingMetric } from '@/lib/analytics';
 import { bookUrl } from '@/lib/slugify';
@@ -11,6 +10,7 @@ import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import { isPublishedFirstTranslation } from '@/lib/book';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import AuthorName from '@/components/AuthorName';
+import BookCoverPlaceholder from '@/components/BookCoverPlaceholder';
 import { getEffectiveByline } from '@/lib/byline';
 
 interface BookCardProps {
@@ -152,9 +152,10 @@ export default function BookCard({ book, priority = false }: BookCardProps) {
               blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMyIgaGVpZ2h0PSI0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIzIiBoZWlnaHQ9IjQiIGZpbGw9IiNlN2UyZGUiLz48L3N2Zz4="
             />
           ) : (
-            <div className="w-full h-full flex items-center justify-center">
-              <BookIcon className="w-16 h-16 text-stone-300" />
-            </div>
+            <BookCoverPlaceholder
+              title={book.display_title || book.title}
+              author={book.author}
+            />
           )}
 
           {isPublishedFirstTranslation(book) && (


### PR DESCRIPTION
## Why

Follow-on from the Sumerian & Mesopotamian investigation. ~105 ETCSL compositions have no digitized facsimile — their witness tablets were never photographed (verified against CDLI photo + line-art; both absent). They rendered as blank cards with a generic book icon, which reads as "broken." Integrity rules out attaching a generic tablet image, so the honest fix is a clearly-typographic cover.

## What

- **`src/components/BookCoverPlaceholder.tsx`** — an intentional, title-page-style cover: the title in serif inside a printed-frame motif on a parchment gradient, optional author beneath. Deterministic per title (no `Math.random` — stable across renders, gentle variety across a grid). Never implies an image we don't have.
- Wired into **`CollectionBookCard`** (collection grid + `CatalogBrowser`) and **`BookCard`**, replacing their lucide-icon fallbacks. Removed now-unused icon imports.

Applies **library-wide**: any image-less book gets a real cover, not just ETCSL.

## Scope / integrity

- Pure presentational fallback — only renders when there's no thumbnail / the image errors. Books with covers are unaffected.
- No data changes; no claim of a source image. Complements PR #2379 (which adds *real* witness covers wherever CDLI has a photo).

## Out of scope

- Other minor card surfaces with their own icon fallbacks (gallery/artwork/library views) — left as-is; this targets the book-grid cards that render collections.

## Testing

`npx tsc --noEmit` clean. Verified visually on the Vercel preview (see comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)