### PR TITLE
feat(import): direct importers for non-IIIF Nordic/Baltic digital libraries (Fragmenta + Tartu)

### DIFF
--- a/scripts/import/fragmenta-direct.mjs
+++ b/scripts/import/fragmenta-direct.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Generalized direct importer for the National Library of Finland's
+ * Fragmenta membranea collection (https://fragmenta.kansalliskirjasto.fi).
+ *
+ * Fragmenta is a DSpace instance with NO IIIF. Its ".tif.jpg" derivatives are
+ * useless ~2KB thumbnails, so for each item handle we:
+ *   1. scrape the item page for the full-res ~30MB TIF master bitstreams + DC metadata,
+ *   2. convert each TIF → web JPEG (+thumb) with sharp,
+ *   3. rehost on R2 (images.sourcelibrary.org/manuscripts/fragmenta/<signum>/…),
+ *   4. insert a hidden book + pages straight into Mongo (pipeline cron auto-enrolls).
+ *
+ * All Fragmenta material is CC Public Domain Mark 1.0. Dedup is by handle.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/fragmenta-direct.mjs --dry-run 1378 1387
+ *   node scripts/import/fragmenta-direct.mjs --commit  1378 1387
+ *
+ * Handle = the numeric DSpace id in /handle/10024/<N>.
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+
+const COMMIT = process.argv.includes('--commit');
+const HANDLES = process.argv.slice(2).filter(a => /^\d+$/.test(a));
+if (!HANDLES.length) { console.error('Pass one or more numeric handles, e.g. 1378 1387'); process.exit(1); }
+
+const FRAG = 'https://fragmenta.kansalliskirjasto.fi';
+
+// Known text → author attributions (Fragmenta rarely records dc:creator).
+const AUTHORS = [
+  [/Reductorium morale/i, 'Petrus Berchorius (Pierre Bersuire)'],
+  [/Summa conservationis et curationis/i, 'Guglielmo da Saliceto (William of Saliceto)'],
+  [/De civitate Dei/i, 'Aurelius Augustinus'],
+  [/Antidotarium/i, 'Unknown (Salernitan school?)'],
+];
+
+const r2 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: process.env.R2_ACCESS_KEY_ID, secretAccessKey: process.env.R2_SECRET_ACCESS_KEY },
+});
+const BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary-images';
+const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+
+function slugify(text, maxLen = 70) {
+  return text.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-')
+    .replace(/^-|-$/g, '').substring(0, maxLen).replace(/-$/, '');
+}
+async function uniqueSlug(db, base) {
+  let slug = base, i = 2;
+  while (await db.collection('books').findOne({ slug }, { projection: { _id: 1 } })) slug = `${base}-${i++}`;
+  return slug;
+}
+function unescapeHtml(s) {
+  return s.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'");
+}
+
+async function scrape(handle) {
+  const url = `${FRAG}/handle/10024/${handle}`;
+  const html = await (await fetch(url, { headers: { 'User-Agent': 'SourceLibrary/1.0 (scholarly archive)' } })).text();
+  const meta = (name) => [...html.matchAll(new RegExp(`<meta name="${name}"[^>]*content="([^"]*)"`, 'g'))].map(m => unescapeHtml(m[1]));
+  const title = (meta('DC.title')[0] || `Fragmenta 10024/${handle}`).trim();
+  const desc = meta('DC.description');
+  const ident = meta('DC.identifier');
+  const dates = meta('DC.date');
+  const signum = ident.find(i => /^F\.m\./.test(i)) || `10024-${handle}`;
+  const urn = ident.find(i => /^URN:/.test(i)) || null;
+  const saec = desc.find(d => /Saec\./i.test(d)) || '';
+  const text = desc[0] || title.replace(/^F\.m[^(]*\(([^)]*)\).*/, '$1');
+  const origin = [...desc].reverse().find(d => d && d.length < 30 && /^[A-ZÅÄÖ]/.test(d) && !/^Saec/i.test(d)) || '';
+  const tifLeaves = [...new Set([...html.matchAll(new RegExp(`/bitstream/handle/10024/${handle}/([^"?]+)\\.tif\\?sequence=(\\d+)`, 'g'))].map(m => `${m[1]}|${m[2]}`))]
+    .map(s => { const [file, seq] = s.split('|'); return { file, seq }; })
+    .sort((a, b) => a.file.localeCompare(b.file));
+  const author = (AUTHORS.find(([re]) => re.test(text) || re.test(title)) || [, 'Unknown'])[1];
+  const yearStart = dates[0] && /^\d{3,4}$/.test(dates[0]) ? parseInt(dates[0]) : null;
+  const yearEnd = dates[1] && /^\d{3,4}$/.test(dates[1]) ? parseInt(dates[1]) : null;
+  return { handle, url, title, text, signum, urn, saec, origin, author,
+    dateLabel: saec || (dates.length ? dates.join('/') : '?'),
+    year: yearStart && yearEnd ? Math.round((yearStart + yearEnd) / 2) : (yearStart || null),
+    dateRange: dates.join('/'), tifLeaves };
+}
+
+async function rehost(handle, signum, leaf) {
+  const tifUrl = `${FRAG}/bitstream/handle/10024/${handle}/${leaf.file}.tif?sequence=${leaf.seq}&isAllowed=y`;
+  const res = await fetch(tifUrl, { headers: { 'User-Agent': 'SourceLibrary/1.0 (scholarly archive)' } });
+  if (!res.ok) throw new Error(`fetch ${leaf.file} → ${res.status}`);
+  const tif = Buffer.from(await res.arrayBuffer());
+  const full = await sharp(tif).rotate().resize({ width: 2200, height: 2200, fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 82 }).toBuffer();
+  const thumb = await sharp(tif).rotate().resize({ width: 400, height: 400, fit: 'inside' }).jpeg({ quality: 75 }).toBuffer();
+  const prefix = `manuscripts/fragmenta/${slugify(signum)}`;
+  const baseKey = `${prefix}/${leaf.file}`;
+  if (COMMIT) {
+    await r2.send(new PutObjectCommand({ Bucket: BUCKET, Key: `${baseKey}.jpg`, Body: full, ContentType: 'image/jpeg', CacheControl: 'public, max-age=31536000, immutable' }));
+    await r2.send(new PutObjectCommand({ Bucket: BUCKET, Key: `${baseKey}.thumb.jpg`, Body: thumb, ContentType: 'image/jpeg', CacheControl: 'public, max-age=31536000, immutable' }));
+  }
+  return { photo: `${R2_PUBLIC_URL}/${baseKey}.jpg`, thumbnail: `${R2_PUBLIC_URL}/${baseKey}.thumb.jpg`, photo_original: tifUrl };
+}
+
+async function importItem(db, m) {
+  const fp = `fragmenta:10024/${m.handle}`;
+  if (COMMIT && db) {
+    const existing = await db.collection('books').findOne({ $or: [{ source_fingerprint: fp }, { 'image_source.source_url': m.url }] }, { projection: { _id: 1, slug: 1 } });
+    if (existing) { console.log(`  already imported: ${existing.slug} — skip`); return null; }
+  }
+  console.log(`  rehosting ${m.tifLeaves.length} leaves (TIF→JPEG→R2)…`);
+  const pages = [];
+  for (const leaf of m.tifLeaves) {
+    const p = await rehost(m.handle, m.signum, leaf);
+    pages.push(p);
+    if (pages.length % 8 === 0) console.log(`    …${pages.length}/${m.tifLeaves.length}`);
+  }
+  if (!pages.length) { console.log('  no images — skip'); return null; }
+  if (!COMMIT) { console.log(`  DRY-RUN: would insert "${m.title}" — ${pages.length} pages (author: ${m.author})`); return null; }
+
+  const bookId = new ObjectId();
+  const bookIdStr = bookId.toHexString();
+  const slug = await uniqueSlug(db, slugify(`${m.text}-fragmenta-${m.signum}`));
+  const now = new Date();
+  const bookDoc = {
+    _id: bookId, id: bookIdStr, slug, tenant_id: 'default',
+    title: m.title, display_title: m.text, author: m.author,
+    language: 'Latin', original_language: 'Latin',
+    published: m.dateLabel, year: m.year,
+    categories: [], collections: [],
+    thumbnail: pages[0].thumbnail || '',
+    pages_count: pages.length, pages_ocr: 0, pages_translated: 0, pages_archived: 0,
+    content_type: 'book', resource_type: 'manuscript',
+    dublin_core: {
+      dc_identifier: [m.urn ? `URN:${m.urn}` : null, `Fragmenta:${m.signum}`, `handle:10024/${m.handle}`].filter(Boolean),
+      dc_source: m.url, dc_spatial: m.origin || undefined, dc_date: m.dateRange || undefined,
+    },
+    image_source: {
+      provider: 'fragmenta_membranea',
+      provider_name: 'Fragmenta membranea — National Library of Finland',
+      source_url: m.url, iiif_manifest: null,
+      license: 'Creative Commons Public Domain Mark 1.0',
+      contributing_library: 'National Library of Finland (Kansalliskirjasto) — Fragmenta membranea collection',
+      attribution: 'National Library of Finland, Fragmenta membranea collection (CC PDM 1.0).',
+      access_date: now,
+    },
+    notes: `Medieval (${m.saec || m.dateRange}) Latin manuscript fragment from the Fragmenta membranea collection (signum ${m.signum}; origin ${m.origin || 'unknown'}). Parchment leaf reused as a binding cover for Swedish-realm tax records, hence its survival. Imported direct from the Fragmenta DSpace TIF masters (no IIIF), rehosted on R2.`,
+    status: 'draft', hidden: true, visible: false,
+    source_fingerprint: fp,
+    normalized_title: slugify(m.text).replace(/-/g, ' '),
+    normalized_author: slugify(m.author).replace(/-/g, ' '),
+    created_at: now, updated_at: now,
+  };
+  await db.collection('books').insertOne(bookDoc);
+  const docs = pages.map((p, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: bookIdStr, page_number: k + 1, photo: p.photo, thumbnail: p.thumbnail, photo_original: p.photo_original, created_at: now, updated_at: now }; });
+  await db.collection('pages').insertMany(docs, { ordered: false });
+  console.log(`  ✓ inserted ${slug} (${bookIdStr}) — ${pages.length} pages, hidden`);
+  console.log(`    https://sourcelibrary.org/book/${slug}`);
+  return slug;
+}
+
+async function main() {
+  let client, db;
+  if (COMMIT) { client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 }); await client.connect(); db = client.db('bookstore'); }
+  for (const h of HANDLES) {
+    console.log(`\n=== handle 10024/${h} ===`);
+    const m = await scrape(h);
+    console.log(`  ${m.title}\n  text=${m.text} | author=${m.author} | ${m.dateLabel} | ${m.origin} | leaves=${m.tifLeaves.length}`);
+    await importItem(db, m);
+  }
+  if (client) await client.close();
+  console.log('\nDone.');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/import/fragmenta-direct.mjs
+++ b/scripts/import/fragmenta-direct.mjs
@@ -128,7 +128,7 @@ async function importItem(db, m) {
     categories: [], collections: [],
     thumbnail: pages[0].thumbnail || '',
     pages_count: pages.length, pages_ocr: 0, pages_translated: 0, pages_archived: 0,
-    content_type: 'book', resource_type: 'manuscript',
+    content_type: 'book', // do NOT set resource_type: ANY resource_type makes isArtworkRecord()/CollectionBookCard treat the record as artwork (→ /artwork/ route). These are textual manuscripts = books.
     dublin_core: {
       dc_identifier: [m.urn ? `URN:${m.urn}` : null, `Fragmenta:${m.signum}`, `handle:10024/${m.handle}`].filter(Boolean),
       dc_source: m.url, dc_spatial: m.origin || undefined, dc_date: m.dateRange || undefined,

--- a/scripts/import/tartu-dspace-pdf-direct.mjs
+++ b/scripts/import/tartu-dspace-pdf-direct.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Direct importer for digitized rare books/manuscripts from the University of
+ * Tartu Library DSpace (https://dspace.ut.ee). Tartu serves its digitized rare
+ * material as large single-PDF bitstreams (IIIF is enabled only on a subset of
+ * image items, NOT on these books), so the server /api/import/pdf route would
+ * time out on Vercel (300s) for 100–400MB files. This does it locally:
+ *   download PDF → pdftoppm (JPEG, scaled) → upload pages to R2 → insert hidden
+ *   book + pages into Mongo (pipeline cron auto-enrolls for OCR/translation).
+ *
+ * Most Tartu digitized material is CC0. Dedup is by DSpace item URL.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/tartu-dspace-pdf-direct.mjs --dry-run
+ *   node scripts/import/tartu-dspace-pdf-direct.mjs --commit
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, createWriteStream } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+const COMMIT = process.argv.includes('--commit');
+
+const ITEMS = [
+  {
+    pdf_url: 'https://dspace.ut.ee/server/api/core/bitstreams/8d041997-43a7-4d59-817d-63ba80b3cdf5/content',
+    item_url: 'https://dspace.ut.ee/items/4a243232-8f87-48c6-b95d-e5a56d61db1c',
+    title: 'Clavis magiae: die geheime Naturweisheit vom Stein der Weisen',
+    display_title: 'Key of Magic: The Secret Natural Wisdom of the Philosopher’s Stone',
+    author: 'Unknown', language: 'German', published: '1794', year: 1794,
+    identifier: 'Mscr 362', resource_type: 'manuscript',
+    slug_base: 'clavis-magiae-secret-wisdom-philosophers-stone',
+  },
+  {
+    pdf_url: 'https://dspace.ut.ee/server/api/core/bitstreams/94ffc90b-5878-4855-b465-a1f0852c2a7e/content',
+    item_url: 'https://dspace.ut.ee/items/2db9da61-eec8-4eeb-948c-5ee686af6b83',
+    title: 'Der grossen Wundartzney das erst Buch (Große Wundarznei)',
+    display_title: 'The Great Surgery',
+    author: 'Paracelsus (Theophrastus von Hohenheim)', language: 'German', published: '1536', year: 1536,
+    identifier: 'R V o 25', resource_type: 'book',
+    slug_base: 'die-grosse-wundarznei-paracelsus-1536',
+  },
+];
+
+const r2 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: process.env.R2_ACCESS_KEY_ID, secretAccessKey: process.env.R2_SECRET_ACCESS_KEY },
+});
+const BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary-images';
+const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+
+function slugify(t, n = 70) {
+  return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, n).replace(/-$/, '');
+}
+async function uniqueSlug(db, base) { let s = base, i = 2; while (await db.collection('books').findOne({ slug: s }, { projection: { _id: 1 } })) s = `${base}-${i++}`; return s; }
+
+async function downloadTo(url, path) {
+  const res = await fetch(url, { headers: { 'User-Agent': 'SourceLibrary/1.0 (scholarly archive)' } });
+  if (!res.ok) throw new Error(`download ${res.status}`);
+  await pipeline(Readable.fromWeb(res.body), createWriteStream(path));
+}
+
+async function importItem(db, it) {
+  const fp = `tartu-dspace:${it.item_url}`;
+  if (COMMIT) {
+    const ex = await db.collection('books').findOne({ $or: [{ source_fingerprint: fp }, { 'image_source.source_url': it.item_url }] }, { projection: { slug: 1 } });
+    if (ex) { console.log(`  already imported: ${ex.slug} — skip`); return; }
+  }
+  const work = mkdtempSync(join(tmpdir(), 'tartu-'));
+  const pdfPath = join(work, 'src.pdf');
+  try {
+    console.log(`  downloading ${it.pdf_url} …`);
+    await downloadTo(it.pdf_url, pdfPath);
+    const np = parseInt(execFileSync('pdfinfo', [pdfPath]).toString().match(/Pages:\s+(\d+)/)?.[1] || '0', 10);
+    console.log(`  ${np} pages; rasterizing (pdftoppm jpeg, longest side 2000px)…`);
+    execFileSync('pdftoppm', ['-jpeg', '-jpegopt', 'quality=82', '-scale-to', '2000', pdfPath, join(work, 'p')], { stdio: 'ignore' });
+    const files = readdirSync(work).filter(f => f.endsWith('.jpg')).sort();
+    if (!files.length) throw new Error('pdftoppm produced no pages');
+    console.log(`  rasterized ${files.length} pages; uploading to R2…`);
+    const prefix = `manuscripts/tartu/${it.slug_base}`;
+    const pages = [];
+    for (let i = 0; i < files.length; i++) {
+      const key = `${prefix}/p${String(i + 1).padStart(4, '0')}.jpg`;
+      if (COMMIT) await r2.send(new PutObjectCommand({ Bucket: BUCKET, Key: key, Body: readFileSync(join(work, files[i])), ContentType: 'image/jpeg', CacheControl: 'public, max-age=31536000, immutable' }));
+      pages.push(`${R2_PUBLIC_URL}/${key}`);
+      if ((i + 1) % 50 === 0) console.log(`    …${i + 1}/${files.length}`);
+    }
+    if (!COMMIT) { console.log(`  DRY-RUN: "${it.title}" — ${pages.length} pages (no upload/insert)`); return; }
+
+    const bookId = new ObjectId(); const idStr = bookId.toHexString();
+    const slug = await uniqueSlug(db, it.slug_base); const now = new Date();
+    await db.collection('books').insertOne({
+      _id: bookId, id: idStr, slug, tenant_id: 'default',
+      title: it.title, display_title: it.display_title, author: it.author,
+      language: it.language, original_language: it.language, published: it.published, year: it.year,
+      categories: [], collections: [], thumbnail: pages[0] || '',
+      pages_count: pages.length, pages_ocr: 0, pages_translated: 0, pages_archived: 0,
+      content_type: 'book', resource_type: it.resource_type,
+      dublin_core: { dc_identifier: [`Tartu:${it.identifier}`, it.item_url], dc_source: it.item_url },
+      image_source: {
+        provider: 'tartu_dspace', provider_name: 'University of Tartu Library (DSpace)',
+        source_url: it.item_url, iiif_manifest: null,
+        license: 'CC0 1.0 Universal', contributing_library: 'University of Tartu Library (Tartu Ülikooli raamatukogu)',
+        attribution: 'University of Tartu Library (CC0 1.0).', access_date: now,
+      },
+      notes: `Digitized rare ${it.resource_type} from the University of Tartu Library DSpace (shelfmark ${it.identifier}). Imported from the source PDF bitstream (rasterized locally; Tartu does not expose IIIF for these books), rehosted on R2.`,
+      status: 'draft', hidden: true, visible: false, source_fingerprint: fp,
+      normalized_title: slugify(it.display_title).replace(/-/g, ' '), normalized_author: slugify(it.author).replace(/-/g, ' '),
+      created_at: now, updated_at: now,
+    });
+    const CHUNK = 500;
+    for (let s = 0; s < pages.length; s += CHUNK) {
+      const docs = pages.slice(s, s + CHUNK).map((photo, k) => { const pid = new ObjectId(); return { _id: pid, id: pid.toHexString(), tenant_id: 'default', book_id: idStr, page_number: s + k + 1, photo, thumbnail: photo, photo_original: photo, created_at: now, updated_at: now }; });
+      await db.collection('pages').insertMany(docs, { ordered: false });
+    }
+    console.log(`  ✓ inserted ${slug} (${idStr}) — ${pages.length} pages, hidden`);
+    console.log(`    https://sourcelibrary.org/book/${slug}`);
+  } finally { rmSync(work, { recursive: true, force: true }); }
+}
+
+async function main() {
+  let client, db;
+  if (COMMIT) { client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 }); await client.connect(); db = client.db('bookstore'); }
+  for (const it of ITEMS) { console.log(`\n=== ${it.display_title} (${it.published}) ===`); await importItem(db, it); }
+  if (client) await client.close();
+  console.log('\nDone.');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/import/tartu-dspace-pdf-direct.mjs
+++ b/scripts/import/tartu-dspace-pdf-direct.mjs
@@ -25,8 +25,12 @@ import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
 const COMMIT = process.argv.includes('--commit');
+// Optional: --items <path.json> supplies the import list (array of item objects with the
+// same shape as the built-in ITEMS below). Lets the same importer drive curated sweeps.
+const itemsArgIdx = process.argv.indexOf('--items');
+const ITEMS_FILE = itemsArgIdx > -1 ? process.argv[itemsArgIdx + 1] : null;
 
-const ITEMS = [
+const BUILTIN_ITEMS = [
   {
     pdf_url: 'https://dspace.ut.ee/server/api/core/bitstreams/8d041997-43a7-4d59-817d-63ba80b3cdf5/content',
     item_url: 'https://dspace.ut.ee/items/4a243232-8f87-48c6-b95d-e5a56d61db1c',
@@ -126,6 +130,7 @@ async function importItem(db, it) {
 }
 
 async function main() {
+  const ITEMS = ITEMS_FILE ? JSON.parse(readFileSync(ITEMS_FILE, 'utf8')) : BUILTIN_ITEMS;
   let client, db;
   if (COMMIT) { client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 }); await client.connect(); db = client.db('bookstore'); }
   for (const it of ITEMS) { console.log(`\n=== ${it.display_title} (${it.published}) ===`); await importItem(db, it); }

--- a/scripts/import/tartu-dspace-pdf-direct.mjs
+++ b/scripts/import/tartu-dspace-pdf-direct.mjs
@@ -106,7 +106,7 @@ async function importItem(db, it) {
       language: it.language, original_language: it.language, published: it.published, year: it.year,
       categories: [], collections: [], thumbnail: pages[0] || '',
       pages_count: pages.length, pages_ocr: 0, pages_translated: 0, pages_archived: 0,
-      content_type: 'book', resource_type: it.resource_type,
+      content_type: 'book', // do NOT set resource_type: ANY resource_type makes isArtworkRecord()/CollectionBookCard treat the record as artwork (→ /artwork/ route). These are textual books.
       dublin_core: { dc_identifier: [`Tartu:${it.identifier}`, it.item_url], dc_source: it.item_url },
       image_source: {
         provider: 'tartu_dspace', provider_name: 'University of Tartu Library (DSpace)',


### PR DESCRIPTION
## What

Two reusable direct importers for digitized collections that **lack usable IIIF**, so the server-side import routes can't fetch them:

1. `scripts/import/fragmenta-direct.mjs` — National Library of Finland's [Fragmenta membranea](https://fragmenta.kansalliskirjasto.fi) (DSpace, no IIIF; ~2KB thumbnail derivatives). Scrapes the full-res ~30MB TIF masters + Dublin Core, converts with sharp, rehosts on R2, inserts hidden book+pages. CC PDM 1.0.
2. `scripts/import/tartu-dspace-pdf-direct.mjs` — [University of Tartu Library](https://dspace.ut.ee) DSpace (DSpace 7.6.6; IIIF enabled only on a subset of image items, NOT the books). Digitized rare books/mss are large single-PDF bitstreams (100–400MB) that time out the Vercel `/api/import/pdf` route, so this rasterizes locally with pdftoppm → R2 → hidden book+pages. Mostly CC0.

Both insert hidden; the pipeline cron auto-enrolls for OCR/translation. Dedup by source URL / fingerprint.

## Imported with these (all net-new, dedup-verified, hidden/awaiting QA)

**Fragmenta (medieval Latin manuscript fragments):**
- Antidotarium cum glossa (saec. xi–xii pharmacology)
- Summa conservationis et curationis — William of Saliceto, surgery (48pp)
- Reductorium morale — Pierre Bersuire (32pp)

**Tartu (CC0 rare books/mss):**
- Clavis magiae: die geheime Naturweisheit vom Stein der Weisen (1794) — alchemical manuscript, 83pp
- Paracelsus, Die grosse Wundarznei (1536) — Great Surgery, 143pp

## Scope

- In scope: the two importers + the on-mission gaps above. Both are `scripts/**` (Hetzner auto-pull, no Vercel deploy).
- Out of scope: bulk harvest of either collection (mostly liturgical / institutional-repository noise — low curation fit); a generalized DSpace importer (the two share a pattern but target different bitstream shapes — TIF vs PDF — so kept separate for clarity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)