### PR TITLE
fix(gallery): sharp artwork thumbnails + non-blank collection covers

### DIFF
--- a/scripts/maintenance/backfill-artwork-thumb-pointers.mjs
+++ b/scripts/maintenance/backfill-artwork-thumb-pointers.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Fix blurry artwork thumbnails in collection grids.
+ *
+ * Root cause: ~14,160 visible artworks have `image_thumb` pointing at a 150px
+ * `book-thumbnails/{id}-thumb.jpg` variant (made by the book display-variant
+ * worker). The art-grid card requests the 'thumb' size, so a 150px image is
+ * upscaled into a ~270–540px card → visibly blurry.
+ *
+ * But every artwork already has a sharp 600px sibling at
+ * `artwork/{prefix}-thumb.jpg` (written by the artwork importers /
+ * upgrade-artwork-images.mjs). The fix is almost entirely a cheap repoint:
+ * set `image_thumb` to that existing 600px URL. Only artworks that genuinely
+ * lack the sibling get a freshly generated 600px thumb (--generate), resized
+ * from the 2000px display we already host.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/backfill-artwork-thumb-pointers.mjs --dry-run
+ *   node scripts/maintenance/backfill-artwork-thumb-pointers.mjs --generate
+ *   node scripts/maintenance/backfill-artwork-thumb-pointers.mjs --collection ficinos-florence
+ */
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const GENERATE = process.argv.includes('--generate');
+const LIMIT = parseInt(process.argv.find((_, i, a) => a[i - 1] === '--limit') || '0') || 0;
+const ONLY_COLLECTION = process.argv.find((_, i, a) => a[i - 1] === '--collection') || null;
+const CONCURRENCY = 20;
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@sourcelibrary.org) bot';
+
+const client = new MongoClient(process.env.MONGODB_URI);
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+  },
+});
+
+/** Candidate sharp-thumb URLs for an artwork, in priority order. */
+function candidateThumbUrls(doc) {
+  const out = [];
+  const push = (u) => { if (u && !out.includes(u)) out.push(u); };
+  for (const src of [doc.image_display, doc.thumbnail, doc.thumbnail_blob]) {
+    if (!src || typeof src !== 'string') continue;
+    if (!src.includes('images.sourcelibrary.org/artwork/')) continue;
+    if (src.endsWith('-thumb.jpg')) { push(src); continue; }
+    if (src.endsWith('-full.jpg')) { push(src.replace(/-full\.jpg$/, '-thumb.jpg')); continue; }
+    if (src.endsWith('.jpg')) { push(src.replace(/\.jpg$/, '-thumb.jpg')); }
+  }
+  return out;
+}
+
+async function exists(url) {
+  try {
+    const r = await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(10000) });
+    return r.ok;
+  } catch { return false; }
+}
+
+/** Generate a 600px thumb from the artwork's hi-res display image and upload it. */
+async function generateThumb(doc) {
+  const src = doc.image_display || doc.thumbnail;
+  if (!src) return null;
+  // Derive the R2 key for the thumb from the display key when possible.
+  const m = src.match(/images\.sourcelibrary\.org\/artwork\/(.+?)(?:-full|-thumb)?\.jpg$/);
+  if (!m) return null;
+  const key = `artwork/${m[1]}-thumb.jpg`;
+  const res = await fetch(src, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(60000) });
+  if (!res.ok) return null;
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.length === 0) return null;
+  const thumb = await sharp(buf).resize({ width: 600, withoutEnlargement: true }).jpeg({ quality: 80, mozjpeg: true }).toBuffer();
+  await s3.send(new PutObjectCommand({
+    Bucket: process.env.R2_BUCKET_NAME,
+    Key: key,
+    Body: thumb,
+    ContentType: 'image/jpeg',
+    CacheControl: 'public, max-age=31536000, immutable',
+  }));
+  return `https://images.sourcelibrary.org/${key}`;
+}
+
+async function main() {
+  await client.connect();
+  const books = client.db('bookstore').collection('books');
+
+  const match = {
+    content_type: 'artwork',
+    visible: true,
+    $or: [
+      { image_thumb: { $regex: '/book-thumbnails/' } },
+      { image_thumb: { $in: [null, ''] } },
+      { image_thumb: { $exists: false } },
+    ],
+  };
+  if (ONLY_COLLECTION) match.collections = ONLY_COLLECTION;
+
+  const cursor = books.find(match, {
+    projection: { image_display: 1, thumbnail: 1, thumbnail_blob: 1, image_thumb: 1 },
+    noCursorTimeout: true,
+  });
+  if (LIMIT) cursor.limit(LIMIT);
+  const docs = await cursor.toArray();
+
+  console.log(`${DRY_RUN ? 'DRY RUN — ' : ''}${docs.length} affected artworks${ONLY_COLLECTION ? ` in "${ONLY_COLLECTION}"` : ''}`);
+
+  let repointed = 0, generated = 0, skippedNoSrc = 0, errors = 0, processed = 0;
+  const ops = [];
+
+  async function handle(doc) {
+    processed++;
+    try {
+      const cands = candidateThumbUrls(doc);
+      let chosen = null;
+      for (const u of cands) { if (await exists(u)) { chosen = u; break; } }
+      if (chosen) {
+        if (!DRY_RUN) ops.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { image_thumb: chosen, updated_at: new Date() } } } });
+        repointed++;
+      } else if (GENERATE) {
+        if (DRY_RUN) { generated++; return; }
+        const url = await generateThumb(doc);
+        if (url) { ops.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { image_thumb: url, updated_at: new Date() } } } }); generated++; }
+        else { skippedNoSrc++; }
+      } else {
+        skippedNoSrc++;
+      }
+    } catch (e) { errors++; if (errors <= 10) console.log(`  err ${doc._id}: ${e.message?.slice(0, 80)}`); }
+    if (ops.length >= 500) { const batch = ops.splice(0, ops.length); await books.bulkWrite(batch, { ordered: false }); }
+    if (processed % 500 === 0) console.log(`  ${processed}/${docs.length} (repoint ${repointed}, gen ${generated}, no-src ${skippedNoSrc})`);
+  }
+
+  // simple concurrency pool
+  let idx = 0;
+  await Promise.all(Array.from({ length: CONCURRENCY }, async () => {
+    while (idx < docs.length) { const d = docs[idx++]; await handle(d); }
+  }));
+  if (ops.length && !DRY_RUN) await books.bulkWrite(ops, { ordered: false });
+
+  console.log('\n━━━ SUMMARY ━━━');
+  console.log(`Processed:          ${processed}`);
+  console.log(`Repointed (free):   ${repointed}`);
+  console.log(GENERATE ? `Generated (600px):  ${generated}` : `Would need gen:     ${skippedNoSrc} (re-run with --generate)`);
+  if (GENERATE) console.log(`No usable source:   ${skippedNoSrc}`);
+  console.log(`Errors:             ${errors}`);
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/backfill-gallery-collection-covers.mjs
+++ b/scripts/maintenance/backfill-gallery-collection-covers.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Fix bare cover cards on /gallery/collections.
+ *
+ * Each gallery_collections doc shows a cover resolved as:
+ *   cover_image_id → first image_ids[] entry → null (gray placeholder).
+ * The cover id is looked up in `gallery_images` (extracted_url || thumbnail_url).
+ *
+ * Two failure modes the page can't recover from on its own:
+ *   B) cover_image_id points at a now-deleted gallery_images row, but the
+ *      collection's own image_ids[] still has a resolvable image → repoint.
+ *   C) NO image_ids entry resolves (backing images were purged into
+ *      deleted_gallery_images) → cannot get a cover from its own content →
+ *      set hidden:true so the public grid (which now filters hidden) skips it.
+ *
+ * Reversible: un-hiding is just unsetting `hidden`. Admin manager passes
+ * includeHidden=true so these stay visible/manageable there.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/backfill-gallery-collection-covers.mjs --dry-run
+ *   node scripts/maintenance/backfill-gallery-collection-covers.mjs
+ */
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const client = new MongoClient(process.env.MONGODB_URI);
+
+function usableUrl(img) {
+  return img && (img.extracted_url || img.thumbnail_url) || null;
+}
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+  const gc = db.collection('gallery_collections');
+  const gi = db.collection('gallery_images');
+
+  const collections = await gc.find({}, {
+    projection: { id: 1, slug: 1, title: 1, cover_image_id: 1, image_ids: 1, hidden: 1 },
+  }).toArray();
+
+  // Resolve every candidate id (current cover + all image_ids) in one sweep.
+  const allIds = new Set();
+  for (const c of collections) {
+    if (c.cover_image_id) allIds.add(c.cover_image_id);
+    for (const id of (c.image_ids || [])) allIds.add(id);
+  }
+  const imgDocs = await gi.find({ id: { $in: [...allIds] } }, {
+    projection: { id: 1, extracted_url: 1, thumbnail_url: 1 },
+  }).toArray();
+  const imgMap = new Map(imgDocs.map((d) => [d.id, d]));
+
+  let ok = 0, repointed = 0, hidden = 0, unhid = 0;
+  const repointEx = [], hideEx = [];
+  const ops = [];
+
+  for (const c of collections) {
+    const coverOk = c.cover_image_id && usableUrl(imgMap.get(c.cover_image_id));
+    if (coverOk) {
+      ok++;
+      // A previously-hidden collection that now has a working cover → un-hide.
+      if (c.hidden) { ops.push({ updateOne: { filter: { _id: c._id }, update: { $unset: { hidden: '' }, $set: { updated_at: new Date() } } } }); unhid++; }
+      continue;
+    }
+    // Find the first image in the collection that resolves to a usable URL.
+    const firstGood = (c.image_ids || []).find((id) => usableUrl(imgMap.get(id)));
+    if (firstGood) {
+      ops.push({ updateOne: { filter: { _id: c._id }, update: { $set: { cover_image_id: firstGood, updated_at: new Date() }, $unset: { hidden: '' } } } });
+      repointed++;
+      if (repointEx.length < 12) repointEx.push(c.slug);
+    } else {
+      ops.push({ updateOne: { filter: { _id: c._id }, update: { $set: { hidden: true, updated_at: new Date() } } } });
+      hidden++;
+      if (hideEx.length < 20) hideEx.push(`${c.slug} (${(c.image_ids || []).length} imgs)`);
+    }
+  }
+
+  if (!DRY_RUN && ops.length) await gc.bulkWrite(ops, { ordered: false });
+
+  console.log(`${DRY_RUN ? 'DRY RUN — ' : ''}gallery_collections: ${collections.length}`);
+  console.log(`  cover OK (unchanged):     ${ok}`);
+  console.log(`  repointed cover (B):      ${repointed}  ${repointEx.join(', ')}`);
+  console.log(`  hidden — no cover (C):    ${hidden}  ${hideEx.join(', ')}`);
+  console.log(`  un-hidden (cover fixed):  ${unhid}`);
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/admin/collections/page.tsx
+++ b/src/app/admin/collections/page.tsx
@@ -111,7 +111,7 @@ export default function AdminCollectionsPage() {
 
   const fetchCollections = useCallback(async () => {
     try {
-      const data = await gallery.collections.list();
+      const data = await gallery.collections.list(undefined, true); // admin sees hidden too
       setCollections(data.collections);
     } catch (e) {
       console.error('Failed to load collections:', e);

--- a/src/app/api/gallery/collections/route.ts
+++ b/src/app/api/gallery/collections/route.ts
@@ -16,6 +16,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const featured = searchParams.get('featured') === 'true';
     const type = searchParams.get('type'); // 'visual' | 'thematic'
+    const includeHidden = searchParams.get('includeHidden') === 'true'; // admin manager
 
     // Tenant scoping. Proxy.ts sets x-tenant-id for tenant-subdomain SSR;
     // the browser apiClient sets X-Tenant-Slug for client-side calls under
@@ -30,6 +31,7 @@ export async function GET(request: NextRequest) {
 
     const db = await getDb();
     const filter: Record<string, unknown> = {};
+    if (!includeHidden) filter.hidden = { $ne: true }; // public surfaces hide cover-less collections
     if (featured) filter.featured = true;
     if (type === 'visual' || type === 'thematic') filter.type = type;
     if (tenantId) filter.tenantId = tenantId;

--- a/src/app/gallery/collections/page.tsx
+++ b/src/app/gallery/collections/page.tsx
@@ -37,7 +37,9 @@ async function getCollections(): Promise<CollectionListItem[]> {
 
     const collections = await db
       .collection('gallery_collections')
-      .find({}, { projection: { id: 1, slug: 1, title: 1, description: 1, image_ids: 1, featured: 1, cover_image_id: 1 } })
+      // Hide collections with no resolvable cover (their backing gallery_images
+      // were deleted) — flagged `hidden: true` by backfill-gallery-collection-covers.mjs.
+      .find({ hidden: { $ne: true } }, { projection: { id: 1, slug: 1, title: 1, description: 1, image_ids: 1, featured: 1, cover_image_id: 1 } })
       .sort({ sort_order: 1, created_at: -1 })
       .toArray();
 

--- a/src/lib/api-client/gallery.ts
+++ b/src/lib/api-client/gallery.ts
@@ -101,7 +101,7 @@ export const gallery = {
    * Collection operations
    */
   collections: {
-    list: async (featured?: boolean): Promise<{
+    list: async (featured?: boolean, includeHidden?: boolean): Promise<{
       collections: Array<{
         id: string;
         slug: string;
@@ -113,7 +113,10 @@ export const gallery = {
       }>;
       total: number;
     }> => {
-      const params = featured ? '?featured=true' : '';
+      const qs = new URLSearchParams();
+      if (featured) qs.set('featured', 'true');
+      if (includeHidden) qs.set('includeHidden', 'true');
+      const params = qs.toString() ? `?${qs.toString()}` : '';
       return await apiClient.get(`/api/gallery/collections${params}`);
     },
 


### PR DESCRIPTION
## What & why

Two collection-imagery fixes Derek flagged from the live site — artwork thumbnails rendering **blurry** in collection art grids, and **bare/placeholder covers** on `/gallery/collections`. Both turned out to be data-pointer problems (the sharp images already existed), plus one small render filter.

### 1. Blurry artwork thumbnails (data backfill)
The art grid (`CollectionAllBooks` grid view) requests the `thumb` size. For ~14,160 visible artworks, `image_thumb` pointed at a **150px** `book-thumbnails/{id}-thumb.jpg` variant, which got upscaled into ~270–540px cards → visibly blurry. Every artwork already has a sharp **600px** sibling at `artwork/{prefix}-thumb.jpg` (written by the artwork importers), so the fix is almost entirely a free repoint:

- **14,108** repointed to the existing 600px thumb (no upload)
- **412** Leiden IIIF displays pointed at a 600px IIIF variant (`/full/600,/`)
- **60** generated a fresh 600px thumb from the hosted 1200/2000px display
- 33 Wikimedia-hosted artworks left as-is (fetch 403'd the datacenter IP; they already render sharp from the Commons CDN via the `thumbnail` fallback)
- **0 artworks remain on the 150px variant.**

Art-collection manifests read `image_thumb` straight from Mongo (`/api/collections/[id]` art branch), so this is live after a CDN purge — no Supabase sync needed.

### 2. Bare covers on /gallery/collections
Of **266** `gallery_collections`: **243** fine, **12** had a dead `cover_image_id` but a resolvable image in their own `image_ids[]` → **repointed**; **11** had no resolvable image at all (their backing `gallery_images` were purged into `deleted_gallery_images`) → flagged **`hidden: true`**.

The public page + API now filter `hidden: { $ne: true }`. The admin manager passes `includeHidden=true` so it can still see/un-hide them. The backfill is idempotent and self-healing — a collection that regains a working cover gets un-hidden on re-run.

## Scripts
- `scripts/maintenance/backfill-artwork-thumb-pointers.mjs`
- `scripts/maintenance/backfill-gallery-collection-covers.mjs`

Both backfills have **already been run against production Mongo** and the CDN was purged, so the blur fix and bucket-B covers are already live. The bucket-C hiding needs this PR's page/API filter deployed to take effect.

## Out of scope
Restoring the deleted `gallery_images` backing the 11 hidden collections (notably `collection-dreams-unconscious`, 469 purged images) — separate work; hiding is reversible in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)