### PR TITLE
Map: read place_published in geocoder + daily ISR so cache refreshes surface

### DIFF
--- a/scripts/enrichment/geocode-publication-places.mjs
+++ b/scripts/enrichment/geocode-publication-places.mjs
@@ -2,7 +2,7 @@
 /**
  * Geocode place_of_publication strings to lat/lng coordinates.
  *
- * 1. Collect all distinct place_of_publication values
+ * 1. Collect all distinct place strings from place_of_publication AND place_published
  * 2. Query Wikidata for coordinates (batch via SPARQL)
  * 3. Build city→coords lookup and cache in system_config
  * 4. Write locations[] array to books
@@ -142,11 +142,18 @@ async function main() {
     console.log(`Loaded ${Object.keys(cache).length} cached cities`);
   }
 
-  // Step 2: Get all distinct place_of_publication values
-  const places = await db.collection('books').distinct('place_of_publication', {
-    visible: true,
-    place_of_publication: { $exists: true, $ne: null, $ne: '' },
-  });
+  // Step 2: Get all distinct place strings. Books record their imprint city in
+  // EITHER `place_of_publication` OR the legacy `place_published` field; geocode
+  // the union of both so neither set of books is silently left off the map.
+  const [placesA, placesB] = await Promise.all([
+    db.collection('books').distinct('place_of_publication', {
+      visible: true, place_of_publication: { $exists: true, $ne: null, $ne: '' },
+    }),
+    db.collection('books').distinct('place_published', {
+      visible: true, place_published: { $exists: true, $ne: null, $ne: '' },
+    }),
+  ]);
+  const places = [...new Set([...placesA, ...placesB])];
 
   // Filter out non-place values
   const skipPatterns = [/^n\.p\.?$/i, /^s\.l\.?$/i, /^\?$/, /^unknown$/i, /^—$/];
@@ -251,16 +258,19 @@ async function main() {
 
     if (DRY_RUN) continue;
 
+    // A book matches this place via either imprint field.
+    const placeMatch = { $or: [{ place_of_publication: place }, { place_published: place }] };
+
     if (FIX_OVERRIDES) {
       // When fixing overrides: replace existing publication location
       const result = await db.collection('books').updateMany(
-        { visible: true, place_of_publication: place, 'locations.type': 'publication' },
+        { visible: true, ...placeMatch, 'locations.type': 'publication' },
         { $set: { 'locations.$[elem]': location } },
         { arrayFilters: [{ 'elem.type': 'publication' }] }
       );
       // Also add to books that don't have one yet
       const result2 = await db.collection('books').updateMany(
-        { visible: true, place_of_publication: place, 'locations.type': { $ne: 'publication' } },
+        { visible: true, ...placeMatch, 'locations.type': { $ne: 'publication' } },
         { $push: { locations: location } }
       );
       updated += result.modifiedCount + result2.modifiedCount;
@@ -269,7 +279,7 @@ async function main() {
       const result = await db.collection('books').updateMany(
         {
           visible: true,
-          place_of_publication: place,
+          ...placeMatch,
           'locations.type': { $ne: 'publication' }, // don't add if already has one
         },
         {

--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -5,7 +5,11 @@ import ExploreTabBar from '@/components/explore/ExploreTabBar';
 import BookMapLoader from '@/components/explore/BookMapLoader';
 import type { BookLocation } from '@/components/explore/BookMap';
 
-export const revalidate = false;
+// Daily ISR so the page re-reads the system_config.map_data cache that the
+// Hetzner cron rebuilds at 05:45 — `revalidate = false` froze the rendered
+// page at deploy time, hiding every cache refresh. The layout chain uses no
+// headers()/cookies(), so ISR is safe here (cf. explore/page.tsx).
+export const revalidate = 86400;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {


### PR DESCRIPTION
Follow-up to #2377 (the map origin layer). Two related fixes that close the remaining `/explore/map` coverage and freshness gaps.

## 1. Geocoder reads the legacy `place_published` field
`geocode-publication-places.mjs` only collected/matched on `place_of_publication`, but **790 visible books** record their imprint city in the parallel `place_published` field instead (71 London, 57 Amsterdam, 46 Paris, … and 120 tagged "Bhutan, Asia") — so they never got a publication dot. Now it geocodes the **union** of both fields and matches books on either when writing `locations[]`. Idempotent (only adds to books lacking a publication location).

A catch-up run placed **1,350 books** — the 790 `place_published`-only set plus ~560 newly-imported books with a place that hadn't been geocoded since the last run. Map total **10,526 → 11,684** (publication points 4,145 → 5,495).

## 2. Map page uses daily ISR (completes the #2377 un-freeze)
#2377 added a cron (`build-map-cache.mjs`, 05:45) to keep `system_config.map_data` fresh — but the page had `export const revalidate = false`, which **bakes the cache into the rendered output at deploy time**. So the cron refreshed the data and nothing ever surfaced it (this is exactly why the +1,350 dots above didn't appear on prod after I rebuilt the cache). Switched to `revalidate = 86400`, matching `explore/page.tsx`.

**Safe here:** the layout chain (`ContentPageLayout`, `ExploreTabBar`) uses no `headers()`/`cookies()`, so there's no `DYNAMIC_SERVER_USAGE`/ISR-500 risk (cf. the ISR+headers incident in PR #2260).

## Verification
- Geocoder catch-up run: 1,350 books updated, cache rebuilt to 1,495 groups / 11,684 books (verified against prod Mongo).
- The data is already in the prod cache; this PR's ISR change is what lets the rendered page pick it up (needs a prod deploy to take first effect, then self-refreshes daily).

## Out of scope
- A long tail of archaic Dutch imprint strings (`t'Amsterdam`, `À La Haye :`, `Te Leyden,`) don't resolve via Wikidata — better imprint-string normalization is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)