### PR TITLE
fix(ux): responsive feedback-widget submit + realistic reading-room wait copy

### DIFF
--- a/src/app/librarian/thread/[id]/page.tsx
+++ b/src/app/librarian/thread/[id]/page.tsx
@@ -507,7 +507,7 @@ function AskWhileListening({ threadId }: { threadId: string }) {
       <audio ref={audioRef} className="hidden" />
       {loading && (
         <p className="mt-2 text-[12px] text-[#8a8480] font-sans animate-pulse">
-          Elena and Marcus are thinking... <span className="opacity-60">(~15 seconds)</span>
+          Elena and Marcus are thinking... <span className="opacity-60">(this can take up to a minute)</span>
         </p>
       )}
       {exchanges.map((ex, i) => (

--- a/src/components/feedback/FeedbackWidget.tsx
+++ b/src/components/feedback/FeedbackWidget.tsx
@@ -120,14 +120,14 @@ export default function FeedbackWidget({ className, style, initialMessage, label
               />
             )}
 
-            <div className="flex items-center justify-between gap-3 mt-4">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mt-4 w-full">
               <p className="text-xs text-stone-400 truncate min-w-0 flex-1">
                 Sent from {typeof window !== 'undefined' ? window.location.pathname : '/'}
               </p>
               <button
                 onClick={submit}
                 disabled={!message.trim() || status === 'sending' || needsEmailForVolunteer}
-                className="flex-shrink-0 px-4 py-2 bg-stone-800 hover:bg-stone-700 text-white text-sm font-medium rounded-lg disabled:opacity-50 transition-colors"
+                className="w-full sm:w-auto flex-shrink-0 px-4 py-2 bg-stone-800 hover:bg-stone-700 text-white text-sm font-medium rounded-lg disabled:opacity-50 transition-colors"
               >
                 {status === 'sending' ? 'Sending...' : status === 'error' ? 'Try again' : 'Send'}
               </button>


### PR DESCRIPTION
Two small UX fixes from user feedback. Both are CSS/copy-only — no logic changes.

## Feedback items addressed

1. **Feedback widget submit button cut off on narrow / embedded (BPH) viewports.** The form footer row (`src/components/feedback/FeedbackWidget.tsx`) kept "Sent from <path>" and the Send button on one row, pushing the button off-screen on narrow widths and requiring horizontal scroll. Now the row stacks vertically on small screens (`flex-col sm:flex-row`) with the button full-width on mobile (`w-full sm:w-auto`); the "Sent from…" text keeps `min-w-0`/`truncate` so it can't force overflow.

2. **Reading-room "Elena and Marcus are thinking" wait estimate understated the wait.** Status said "(~15 seconds)" but it actually takes about a minute. Updated copy to "(this can take up to a minute)" (`src/app/librarian/thread/[id]/page.tsx`). The sibling generate-status string already reads "30–60 seconds" and was left as-is.

## Out of scope
- Did NOT change the reading-room loading/generation logic — copy string only.
- No changes to how/when the thinking indicator is shown, only its text.

## Verification
- `npx tsc --noEmit` clean (exit 0).
- Diff is class-string + copy-string changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)