### PR TITLE
tools: blurry-image audit + page-thumb generator

### DIFF
--- a/scripts/maintenance/blurry-image-audit.js
+++ b/scripts/maintenance/blurry-image-audit.js
@@ -1,0 +1,36 @@
+/*
+ * Blurry-image audit — paste into the browser DevTools console on ANY page.
+ *
+ * Flags every <img> (and CSS background-image) the browser is UPSCALING:
+ * intrinsic pixels (naturalWidth) well below the displayed size × the device
+ * pixel ratio. Those are the ones that look soft / blurry on screen.
+ *
+ * Usage: open the page, open DevTools (Cmd+Opt+J), paste, Enter.
+ * Lower `RATIO` to be stricter (0.5 = only badly upscaled), raise toward 1.0
+ * to catch anything not pixel-perfect on this display.
+ */
+(() => {
+  const DPR = window.devicePixelRatio || 1;
+  const RATIO = 0.66; // intrinsic must be >= RATIO * (cssWidth * DPR) to pass
+  const rows = [];
+  for (const img of document.querySelectorAll('img')) {
+    const cssW = img.clientWidth;
+    if (!cssW || !img.naturalWidth) continue;        // hidden / not loaded
+    const needed = cssW * DPR;
+    const ratio = img.naturalWidth / needed;
+    if (ratio < RATIO) {
+      rows.push({
+        upscale: `${(needed / img.naturalWidth).toFixed(1)}x`,
+        shownPx: Math.round(cssW),
+        intrinsicPx: img.naturalWidth,
+        src: (img.currentSrc || img.src || '').slice(0, 120),
+        alt: (img.alt || '').slice(0, 40),
+      });
+    }
+  }
+  rows.sort((a, b) => parseFloat(b.upscale) - parseFloat(a.upscale));
+  console.log(`%cBlurry/upscaled images: ${rows.length}  (DPR=${DPR}, threshold ${RATIO})`,
+    'font-weight:bold');
+  console.table(rows);
+  return rows;
+})();

--- a/scripts/maintenance/blurry-image-sweep.mjs
+++ b/scripts/maintenance/blurry-image-sweep.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Site-wide blurry-image sweep.
+ *
+ * Visits a set of public surfaces with a headless retina viewport (DPR 2),
+ * scrolls to trigger lazy-loading, then in each page flags every <img> the
+ * browser is UPSCALING — intrinsic pixels (naturalWidth) below the displayed
+ * size × DPR. Those render soft/blurry. Aggregates a ranked report by URL and
+ * by image, so you can see which surfaces and which sources are worst.
+ *
+ * This is the automated, multi-page version of scripts/maintenance/blurry-image-audit.js
+ * (the paste-into-console one-pager).
+ *
+ * Usage (resolves playwright from the main checkout's node_modules):
+ *   node scripts/tools/blurry-image-sweep.mjs
+ *   node scripts/tools/blurry-image-sweep.mjs https://sourcelibrary.org/gallery https://sourcelibrary.org/book/<slug>
+ *   RATIO=0.5 node scripts/tools/blurry-image-sweep.mjs       # stricter (only badly upscaled)
+ *   OUT=/tmp/blur.json node scripts/tools/blurry-image-sweep.mjs
+ */
+
+import { chromium } from 'playwright';
+import { writeFileSync } from 'node:fs';
+
+const RATIO = parseFloat(process.env.RATIO || '0.66'); // intrinsic must be >= RATIO * shownPx*DPR
+const DPR = parseFloat(process.env.DPR || '2');        // emulate Retina (worst case)
+const OUT = process.env.OUT || '/tmp/blurry-image-sweep.json';
+
+const DEFAULT_URLS = [
+  'https://sourcelibrary.org/',
+  'https://sourcelibrary.org/gallery',
+  'https://sourcelibrary.org/browse/title',
+  'https://sourcelibrary.org/browse/author',
+  'https://sourcelibrary.org/collections',
+  'https://sourcelibrary.org/book/books-of-alchemy-geber',
+  'https://sourcelibrary.org/book/splendor-solis-the-splendour-of-the-sun-trismosin',
+];
+
+const urls = process.argv.slice(2).filter(a => a.startsWith('http'));
+const targets = urls.length ? urls : DEFAULT_URLS;
+
+// Runs in the page. Flags upscaled <img>s. (Playwright passes a single arg.)
+function auditInPage({ ratio, dpr }) {
+  const rows = [];
+  for (const img of document.querySelectorAll('img')) {
+    const cssW = img.clientWidth;
+    if (!cssW || !img.naturalWidth) continue;
+    const needed = cssW * dpr;
+    const r = img.naturalWidth / needed;
+    if (r < ratio) {
+      rows.push({
+        upscale: +(needed / img.naturalWidth).toFixed(2),
+        shownPx: Math.round(cssW),
+        intrinsicPx: img.naturalWidth,
+        src: (img.currentSrc || img.src || '').slice(0, 160),
+        alt: (img.alt || '').slice(0, 50),
+      });
+    }
+  }
+  return rows;
+}
+
+async function autoScroll(page) {
+  await page.evaluate(async () => {
+    await new Promise((resolve) => {
+      let y = 0;
+      const step = () => {
+        window.scrollBy(0, 800);
+        y += 800;
+        if (y >= document.body.scrollHeight - window.innerHeight) return resolve();
+        setTimeout(step, 250);
+      };
+      step();
+    });
+  });
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: DPR });
+const report = [];
+
+for (const url of targets) {
+  const page = await ctx.newPage();
+  let rows = [];
+  try {
+    await page.goto(url, { waitUntil: 'networkidle', timeout: 45000 });
+    await autoScroll(page);
+    await page.waitForTimeout(1500); // let lazy images settle
+    rows = await page.evaluate(auditInPage, { ratio: RATIO, dpr: DPR });
+  } catch (e) {
+    console.log(`  ✗ ${url} — ${e.message.split('\n')[0]}`);
+  }
+  rows.sort((a, b) => b.upscale - a.upscale);
+  report.push({ url, blurry: rows.length, worst: rows.slice(0, 15) });
+  console.log(`${rows.length.toString().padStart(4)} blurry  ${url}`);
+  await page.close();
+}
+
+await browser.close();
+
+writeFileSync(OUT, JSON.stringify({ ratio: RATIO, dpr: DPR, generated: new Date().toISOString(), report }, null, 2));
+console.log(`\n— worst offenders —`);
+const all = report.flatMap(r => r.worst.map(w => ({ ...w, url: r.url })));
+all.sort((a, b) => b.upscale - a.upscale);
+for (const w of all.slice(0, 20)) {
+  console.log(`  ${String(w.upscale).padStart(5)}x  ${w.intrinsicPx}px→${w.shownPx}px  ${w.src}`);
+}
+console.log(`\nfull report: ${OUT}`);

--- a/scripts/maintenance/fix-fullres-page-thumbs.mjs
+++ b/scripts/maintenance/fix-fullres-page-thumbs.mjs
@@ -24,8 +24,14 @@
  *   set -a; source .env.production.local; set +a
  *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --book <bookId>          # dry run, one book
  *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --book <bookId> --apply  # write, one book
- *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --all                    # dry run, whole library
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --provider bph           # dry run, one provider (indexed)
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --provider bph --apply   # write, one provider
+ *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --all                    # dry run, whole library (COLLSCAN)
  *   node scripts/maintenance/fix-fullres-page-thumbs.mjs --all --apply            # write, whole library
+ *
+ * Prefer --provider bph over --all: the affected population is the BPH
+ * 2-page-spread books, and the indexed book_id $in query avoids the slow,
+ * connection-fragile full pages COLLSCAN that --all forces.
  */
 
 import { MongoClient } from 'mongodb';
@@ -34,11 +40,16 @@ const APPLY = process.argv.includes('--apply');
 const ALL = process.argv.includes('--all');
 const bookIdx = process.argv.indexOf('--book');
 const BOOK_ID = bookIdx !== -1 ? process.argv[bookIdx + 1] : null;
+const provIdx = process.argv.indexOf('--provider');
+const PROVIDER = provIdx !== -1 ? process.argv[provIdx + 1] : null;
 const CONCURRENCY = 24;
 
-// Heavy field value we want to replace: a canonical pages/ full-res image.
-// images.sourcelibrary.org/pages/{book}/{digits}-full.jpg
-const FULL_RE = /^(https:\/\/images\.sourcelibrary\.org\/pages\/[a-f0-9-]+\/\d{3,})-full\.jpg$/;
+// Heavy field value we want to replace: a pages/ full-res image. Covers both
+// canonical {NNNN}-full.jpg and new-era split halves split-{objectid}-full.jpg
+// (and any other pages/ basename) — the -thumb.jpg sibling is the same image at
+// thumb size and is HEAD-verified before any write.
+// images.sourcelibrary.org/pages/{book}/{basename}-full.jpg
+const FULL_RE = /^(https:\/\/images\.sourcelibrary\.org\/pages\/[a-f0-9-]+\/.+)-full\.jpg$/;
 const THUMB_FIELDS = ['image_thumb', 'thumbnail_blob'];
 
 const headCache = new Map();
@@ -60,8 +71,8 @@ async function main() {
     console.error('MONGODB_URI not set. source .env.production.local first.');
     process.exit(1);
   }
-  if (!ALL && !BOOK_ID) {
-    console.error('Pass --book <bookId> or --all.');
+  if (!ALL && !BOOK_ID && !PROVIDER) {
+    console.error('Pass --book <bookId>, --provider <name>, or --all.');
     process.exit(1);
   }
 
@@ -74,13 +85,25 @@ async function main() {
   const pages = db.collection('pages');
 
   // Match pages where EITHER thumb field is a -full.jpg pages URL.
-  const fullRegex = { $regex: '^https://images\\.sourcelibrary\\.org/pages/[a-f0-9-]+/\\d{3,}-full\\.jpg$' };
+  const fullRegex = { $regex: '^https://images\\.sourcelibrary\\.org/pages/[a-f0-9-]+/.+-full\\.jpg$' };
   const query = {
     $or: [{ image_thumb: fullRegex }, { thumbnail_blob: fullRegex }],
   };
-  if (BOOK_ID) query.book_id = BOOK_ID;
+  let scopeLabel = 'ALL books';
+  if (BOOK_ID) {
+    query.book_id = BOOK_ID;
+    scopeLabel = `book ${BOOK_ID}`;
+  } else if (PROVIDER) {
+    // Resolve book ids first, then query pages by indexed book_id $in —
+    // avoids a full pages COLLSCAN (which the regex-only --all path forces).
+    const ids = await db.collection('books')
+      .find({ 'image_source.provider': PROVIDER }, { projection: { _id: 0, id: 1 } })
+      .map(b => b.id).toArray();
+    query.book_id = { $in: ids };
+    scopeLabel = `provider ${PROVIDER} (${ids.length} books)`;
+  }
 
-  console.log(`mode: ${APPLY ? 'APPLY (writes will happen)' : 'DRY RUN (no writes)'}  scope: ${BOOK_ID ? `book ${BOOK_ID}` : 'ALL books'}`);
+  console.log(`mode: ${APPLY ? 'APPLY (writes will happen)' : 'DRY RUN (no writes)'}  scope: ${scopeLabel}`);
 
   const cursor = pages.find(query, {
     projection: { _id: 1, book_id: 1, page_number: 1, image_thumb: 1, thumbnail_blob: 1 },

--- a/scripts/maintenance/generate-missing-page-thumbs.mjs
+++ b/scripts/maintenance/generate-missing-page-thumbs.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Generate real pre-sized thumbnails for pages whose thumb fields still point
+ * at a full-resolution image with NO derivable pre-sized sibling.
+ *
+ * Companion to fix-fullres-page-thumbs.mjs. That script does a cheap URL swap
+ * (`…-full.jpg` → existing `…-thumb.jpg`). This one handles the leftover pages
+ * where no `-thumb.jpg` exists to point at — chiefly legacy split halves stored
+ * as `/cropped/{book}/{objectid}.jpg` (full-res, no variant) plus a handful of
+ * `pages/{book}/{NNNN}-full.jpg` whose thumb sibling was never generated.
+ *
+ * For each target page it fetches the page's true displayed source (the cropped
+ * half for split pages), resizes to a 150px-wide JPEG, uploads it to R2 at a
+ * collision-free key derived from the page id, and repoints image_thumb +
+ * thumbnail_blob at it. photo / cropped_photo (the full-res source) are left
+ * untouched — only the thumb fields change.
+ *
+ * Requires R2 credentials + sharp (present on the Hetzner workers box).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/generate-missing-page-thumbs.mjs --provider bph            # dry run
+ *   node scripts/maintenance/generate-missing-page-thumbs.mjs --provider bph --apply    # write
+ *   node scripts/maintenance/generate-missing-page-thumbs.mjs --book <bookId> --apply
+ */
+
+import { MongoClient } from 'mongodb';
+import sharp from 'sharp';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+
+const APPLY = process.argv.includes('--apply');
+const bookIdx = process.argv.indexOf('--book');
+const BOOK_ID = bookIdx !== -1 ? process.argv[bookIdx + 1] : null;
+const provIdx = process.argv.indexOf('--provider');
+const PROVIDER = provIdx !== -1 ? process.argv[provIdx + 1] : null;
+const limIdx = process.argv.indexOf('--limit');
+const LIMIT = limIdx !== -1 ? parseInt(process.argv[limIdx + 1], 10) : 0;
+const CONCURRENCY = 8;
+const THUMB_WIDTH = 150;
+const THUMB_QUALITY = 60;
+
+const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY } = process.env;
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary';
+const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+
+const r2 = (R2_ACCOUNT_ID && R2_ACCESS_KEY_ID && R2_SECRET_ACCESS_KEY)
+  ? new S3Client({
+      region: 'auto',
+      endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+    })
+  : null;
+
+async function uploadThumb(key, body) {
+  const k = key.replace(/^\//, '');
+  await r2.send(new PutObjectCommand({
+    Bucket: R2_BUCKET, Key: k, Body: body, ContentType: 'image/jpeg',
+    CacheControl: 'public, max-age=604800, s-maxage=604800',
+  }));
+  return `${R2_PUBLIC_URL}/${k}`;
+}
+
+// The page's true displayed full-res source (split-aware), mirroring
+// getPageSource() in src/lib/page-image-url.ts.
+function pageSource(p) {
+  if (p.cropped_photo) return p.cropped_photo;
+  if (p.split_from_spread && p.photo) return p.photo;
+  return p.archived_photo || p.photo_original || p.photo || null;
+}
+
+async function fetchBuf(url) {
+  const resp = await fetch(url, { signal: AbortSignal.timeout(45000) });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
+async function main() {
+  if (!process.env.MONGODB_URI) { console.error('MONGODB_URI not set.'); process.exit(1); }
+  if (!APPLY && !r2) console.warn('(R2 creds absent — dry run only)');
+  if (APPLY && !r2) { console.error('R2 creds required for --apply.'); process.exit(1); }
+  if (!BOOK_ID && !PROVIDER) { console.error('Pass --book <id> or --provider <name>.'); process.exit(1); }
+
+  const client = new MongoClient(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 30000, socketTimeoutMS: 0 });
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+  const pages = db.collection('pages');
+
+  // Heavy thumb field with no derivable pre-sized sibling: legacy /cropped/
+  // URLs, or any remaining -full.jpg (the cheap-swap script already handled the
+  // ones whose -thumb.jpg sibling existed, so a -full.jpg still here has none).
+  const heavy = { $regex: '(/cropped/|-full\\.jpg$)' };
+  const query = { $or: [{ image_thumb: heavy }, { thumbnail_blob: heavy }] };
+  let scope = 'ALL';
+  if (BOOK_ID) { query.book_id = BOOK_ID; scope = `book ${BOOK_ID}`; }
+  else if (PROVIDER) {
+    const ids = await db.collection('books').find({ 'image_source.provider': PROVIDER }, { projection: { _id: 0, id: 1 } }).map(b => b.id).toArray();
+    query.book_id = { $in: ids };
+    scope = `provider ${PROVIDER} (${ids.length} books)`;
+  }
+
+  console.log(`mode: ${APPLY ? 'APPLY' : 'DRY RUN'}  scope: ${scope}`);
+
+  const cursor = pages.find(query, { projection: { _id: 1, id: 1, book_id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, split_from_spread: 1 } });
+  if (LIMIT) cursor.limit(LIMIT);
+
+  let scanned = 0, generated = 0, skipped = 0, failed = 0;
+  let queue = [];
+
+  const flush = async () => {
+    if (!queue.length) return;
+    const batch = queue.splice(0, queue.length);
+    await Promise.all(batch.map(async (p) => {
+      const src = pageSource(p);
+      if (!src) { skipped++; return; }
+      try {
+        if (!APPLY) { generated++; if (generated <= 8) console.log(`  would gen ${p.book_id} p${p.page_number} from ${src.split('/').slice(-2).join('/')}`); return; }
+        const buf = await fetchBuf(src);
+        const thumb = await sharp(buf).resize(THUMB_WIDTH).jpeg({ quality: THUMB_QUALITY }).toBuffer();
+        const key = `pages/${p.book_id}/gen-${p.id}-thumb.jpg`;
+        const url = await uploadThumb(key, thumb);
+        await pages.updateOne({ _id: p._id }, { $set: { image_thumb: url, thumbnail_blob: url, updated_at: new Date() } });
+        generated++;
+        if (generated % 500 === 0) console.log(`  ...generated ${generated}`);
+      } catch (e) {
+        failed++;
+        if (failed <= 10) console.log(`  FAIL ${p.book_id} p${p.page_number}: ${e.message}`);
+      }
+    }));
+  };
+
+  for await (const p of cursor) {
+    scanned++;
+    queue.push(p);
+    if (queue.length >= CONCURRENCY) await flush();
+    if (scanned % 1000 === 0) console.log(`  ...scanned ${scanned}, generated ${generated}, failed ${failed}`);
+  }
+  await flush();
+
+  console.log('---');
+  console.log(`scanned:   ${scanned}`);
+  console.log(`generated: ${generated}${APPLY ? '' : ' (dry run)'}`);
+  console.log(`skipped (no source): ${skipped}`);
+  console.log(`failed:    ${failed}`);
+  await client.close();
+}
+
+main().catch(err => { console.error('FAILED:', err); process.exit(1); });


### PR DESCRIPTION
Diagnostics + tooling from the thumbnail investigation (follow-on to #2373 / #2381).

- **`scripts/maintenance/blurry-image-audit.js`** — paste-into-DevTools-console one-pager. Flags every `<img>` the browser is upscaling (intrinsic `naturalWidth` < displayed × device-pixel-ratio) → the ones that look soft. Works on any page, including logged-in surfaces.
- **`scripts/maintenance/blurry-image-sweep.mjs`** — Playwright crawl of public surfaces at retina DPR running the same check; reports worst offenders by URL and image. The site-wide version of the console tool.
- **`scripts/maintenance/generate-missing-page-thumbs.mjs`** — generates real 150px thumbs for pages whose thumb field has no derivable pre-sized sibling (legacy `/cropped/`). **Available but intentionally not bulk-run**: 353K BPH pages at ~300KB each, already proxied small by the resolver — low marginal value.

## First sweep result (DPR 2)
Homepage 42 blurry, /collections 40, /gallery 11; /browse and book pages clean. Worst offenders are page/gallery `-thumb.jpg` images served via `/_next/image` whose `sizes` attribute is too small — the browser loads a ~45–135px candidate into a 118–324px retina slot (≈5× upscale). That's a `sizes`-prop fix on those grids, separate from the source-resolution work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)