### PR TITLE
fix(pipeline): add gemini-3.1-flash-lite retry tier for RECITATION-blocked OCR

### DIFF
--- a/scripts/maintenance/unblock-recitation-books-to-lite.mjs
+++ b/scripts/maintenance/unblock-recitation-books-to-lite.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * unblock-recitation-books-to-lite.mjs
+ *
+ * One-off backfill: re-enroll books permanently benched by Gemini's RECITATION
+ * filter (pipeline_auto.recitation_blocked === true) straight into the
+ * gemini-3.1-flash-lite OCR retry tier.
+ *
+ * Context: ~14 famous published texts (Spinoza Ethics, Humboldt Kosmos,
+ * Roman de la Rose, Histoire de la magie, …) were permanently blocked because
+ * gemini-3-flash-preview AND the gemini-2.5-flash fallback both refused to OCR
+ * them with finishReason=RECITATION. gemini-3.1-flash-lite has been verified to
+ * bypass RECITATION on these texts (probe: finishReason=STOP, clean body-page
+ * transcription). The pipeline now has a 3-tier escalation
+ * (gemini-2.5-flash -> gemini-3.1-flash-lite -> permanent block); this script
+ * fast-tracks the already-blocked books to the lite tier (skipping 2.5-flash,
+ * which is the proven-to-fail model for them).
+ *
+ * For each blocked book it:
+ *   $unset pipeline_auto.recitation_blocked
+ *   $unset pipeline_auto.recitation_blocked_at
+ *   $unset pipeline_auto.recitation_retry
+ *   $set   pipeline_auto.recitation_retry_lite = true
+ *   $set   pipeline_auto.status = 'archive_complete'
+ *   touches pipeline_auto.last_updated / updated_at
+ *
+ * Default is DRY-RUN (prints what it WOULD change). Pass --apply to mutate.
+ *
+ * NOTE: run this only AFTER the orchestrator/batch-collector change is live on
+ * Hetzner — otherwise the recitation_retry_lite tier won't be picked up.
+ *
+ * Usage:
+ *   node scripts/maintenance/unblock-recitation-books-to-lite.mjs           # dry-run
+ *   node scripts/maintenance/unblock-recitation-books-to-lite.mjs --apply   # mutate
+ */
+
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const MONGODB_URI = process.env.MONGODB_URI;
+
+if (!MONGODB_URI) {
+  console.error('Missing MONGODB_URI in environment.');
+  process.exit(1);
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+
+  const blocked = await books
+    .find(
+      { 'pipeline_auto.recitation_blocked': true },
+      { projection: { id: 1, title: 1, pages_count: 1, 'pipeline_auto.status': 1 } }
+    )
+    .toArray();
+
+  console.log(`${APPLY ? 'APPLY' : 'DRY-RUN'} — found ${blocked.length} recitation_blocked book(s)\n`);
+
+  if (blocked.length === 0) {
+    console.log('Nothing to do.');
+    await client.close();
+    return;
+  }
+
+  let changed = 0;
+  for (const book of blocked) {
+    const label = (book.title || '(untitled)').substring(0, 70);
+    const pages = book.pages_count ?? '?';
+    const curStatus = book.pipeline_auto?.status ?? '?';
+    console.log(`  ${book.id} | ${pages} pages | status=${curStatus} | ${label}`);
+
+    if (!APPLY) continue;
+
+    const now = new Date();
+    const res = await books.updateOne(
+      { id: book.id },
+      {
+        $set: {
+          'pipeline_auto.status': 'archive_complete',
+          'pipeline_auto.recitation_retry_lite': true,
+          'pipeline_auto.last_updated': now,
+          last_updated: now,
+          updated_at: now,
+        },
+        $unset: {
+          'pipeline_auto.recitation_blocked': '',
+          'pipeline_auto.recitation_blocked_at': '',
+          'pipeline_auto.recitation_retry': '',
+        },
+      }
+    );
+    if (res.modifiedCount === 1) changed++;
+    else console.log(`    ! updateOne modifiedCount=${res.modifiedCount} for ${book.id}`);
+  }
+
+  console.log('');
+  if (APPLY) {
+    console.log(`Done. Re-enrolled ${changed}/${blocked.length} book(s) into the gemini-3.1-flash-lite retry tier.`);
+  } else {
+    console.log(`DRY-RUN complete. Would re-enroll ${blocked.length} book(s). Re-run with --apply to mutate.`);
+  }
+
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -1222,22 +1222,24 @@ async function run() {
 
   // RECITATION recovery: mark affected books for retry with a different model.
   // The batch API with gemini-3-flash-preview triggers RECITATION on some historical
-  // texts. Orchestrator retries these with gemini-2.5-flash (modelOverride).
-  // If a book that already had recitation_retry=true fails RECITATION again,
-  // it means even the fallback model can't handle this content — mark as
-  // pipeline_auto.recitation_blocked=true so both Pass 1 and Pass 2 permanently skip it.
+  // texts. Three-tier escalation before a permanent block:
+  //   1. First failure  -> recitation_retry      -> orchestrator retries with gemini-2.5-flash.
+  //   2. Second failure -> recitation_retry_lite -> orchestrator retries with gemini-3.1-flash-lite
+  //                        (proven to bypass RECITATION on famous texts where 2.5-flash also fails).
+  //   3. Third failure  -> recitation_blocked    -> permanently skip (all 3 models failed).
   if (recitationBooks.size > 0) {
     console.log(`\nRECITATION recovery: flagging ${recitationBooks.size} books for retry`);
     for (const bookId of recitationBooks) {
       try {
         const book = await db.collection('books').findOne(
           { id: bookId },
-          { projection: { 'pipeline_auto.recitation_retry': 1 } }
+          { projection: { 'pipeline_auto.recitation_retry': 1, 'pipeline_auto.recitation_retry_lite': 1 } }
         );
-        const alreadyRetried = book?.pipeline_auto?.recitation_retry === true;
+        const retriedFallback = book?.pipeline_auto?.recitation_retry === true;
+        const retriedLite = book?.pipeline_auto?.recitation_retry_lite === true;
 
-        if (alreadyRetried) {
-          // Second RECITATION failure: fallback model also blocked. Permanently skip.
+        if (retriedLite) {
+          // Third RECITATION failure: flash-lite also blocked. Permanently skip.
           await db.collection('books').updateOne(
             { id: bookId },
             {
@@ -1248,10 +1250,25 @@ async function run() {
                 'pipeline_auto.recitation_blocked_at': new Date(),
                 updated_at: new Date(),
               },
+              $unset: { 'pipeline_auto.recitation_retry_lite': '' },
+            }
+          );
+          console.log(`  RECITATION permanently blocked ${bookId} -> needs_attention (all 3 models failed)`);
+        } else if (retriedFallback) {
+          // Second RECITATION failure: gemini-2.5-flash also blocked. Escalate to gemini-3.1-flash-lite.
+          await db.collection('books').updateOne(
+            { id: bookId, 'pipeline_auto.status': { $in: ['ocr_submitted', 'ocr_complete'] } },
+            {
+              $set: {
+                'pipeline_auto.status': 'archive_complete',
+                'pipeline_auto.last_updated': new Date(),
+                'pipeline_auto.recitation_retry_lite': true,
+                updated_at: new Date(),
+              },
               $unset: { 'pipeline_auto.recitation_retry': '' },
             }
           );
-          console.log(`  RECITATION permanently blocked ${bookId} -> needs_attention (both models failed)`);
+          console.log(`  RECITATION escalate to flash-lite ${bookId} -> archive_complete (recitation_retry_lite)`);
         } else {
           // First RECITATION failure: reset to archive_complete for retry with fallback model.
           await db.collection('books').updateOne(
@@ -1270,6 +1287,8 @@ async function run() {
       } catch (e) { console.error(`  RECITATION reset error ${bookId}: ${e.message}`); }
     }
   }
+  // NOTE: Translation-side RECITATION is a separate per-page mechanism in translate-worker.mjs
+  // and is NOT handled here. A parallel flash-lite translation-retry tier is a possible follow-up.
 
   // ── Recovery sweep: re-check recently-failed jobs against Gemini ──
   // Race condition: collector marks a job as "failed" (stale PENDING), but Gemini

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3802,6 +3802,7 @@ Rules:
             $or: [
               { pages_ocr: { $gt: 0 } }, // Already has some OCR (preview pass done)
               { 'pipeline_auto.recitation_retry': true }, // All pages were RECITATION-blocked — retry with fallback model regardless of pages_ocr
+              { 'pipeline_auto.recitation_retry_lite': true }, // 2.5-flash also RECITATION-blocked — retry with gemini-3.1-flash-lite regardless of pages_ocr
             ],
           }},
           { $addFields: {
@@ -3818,7 +3819,7 @@ Rules:
             },
           }},
           { $sort: { _priority: 1, hidden: 1 } },
-          { $project: { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, work_id: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.recitation_retry': 1, 'pipeline_auto.split_checked': 1 } },
+          { $project: { id: 1, title: 1, author: 1, year: 1, pages_count: 1, needs_splitting: 1, work_id: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.recitation_retry': 1, 'pipeline_auto.recitation_retry_lite': 1, 'pipeline_auto.split_checked': 1 } },
           { $limit: ocrLimit },
         ])
         .toArray() : [];
@@ -3845,10 +3846,18 @@ Rules:
           }
 
           // Direct OCR submission — downloads images on Hetzner, submits to Gemini Batch API
-          // Use fallback model for RECITATION retries (gemini-3-flash-preview triggers it)
+          // Use a fallback model for RECITATION retries (gemini-3-flash-preview triggers it).
+          // 3-tier escalation: recitation_retry -> gemini-2.5-flash; recitation_retry_lite ->
+          // gemini-3.1-flash-lite (proven to bypass RECITATION where 2.5-flash also fails).
+          const isLiteRetry = book.pipeline_auto?.recitation_retry_lite === true;
           const isRecitationRetry = book.pipeline_auto?.recitation_retry === true;
-          const ocrOpts = isRecitationRetry ? { modelOverride: 'gemini-2.5-flash' } : {};
-          if (isRecitationRetry) console.log(`  RECITATION retry with gemini-2.5-flash: ${label}`);
+          const ocrOpts = isLiteRetry
+            ? { modelOverride: OCR_MODEL_LITE }
+            : isRecitationRetry
+              ? { modelOverride: 'gemini-2.5-flash' }
+              : {};
+          if (isLiteRetry) console.log(`  RECITATION retry with ${OCR_MODEL_LITE}: ${label}`);
+          else if (isRecitationRetry) console.log(`  RECITATION retry with gemini-2.5-flash: ${label}`);
           else console.log(`  Submitting OCR: ${label}...`);
           const result = await submitOcrDirectly(db, book, ocrOpts);
 
@@ -3862,8 +3871,14 @@ Rules:
           } else {
             const statusExtra = { ocr_job_name: result.jobName, retry_count: 0 };
             await setPipelineStatus(db, book.id, 'ocr_submitted', statusExtra);
-            // Clear recitation_retry flag after successful resubmission
-            if (isRecitationRetry) {
+            // Clear whichever recitation retry flag was set after successful resubmission.
+            // (If this attempt also hits RECITATION, batch-collector re-flags the next tier.)
+            if (isLiteRetry) {
+              await db.collection('books').updateOne(
+                { id: book.id },
+                { $unset: { 'pipeline_auto.recitation_retry_lite': '' } }
+              );
+            } else if (isRecitationRetry) {
               await db.collection('books').updateOne(
                 { id: book.id },
                 { $unset: { 'pipeline_auto.recitation_retry': '' } }


### PR DESCRIPTION
## Problem

14 books are permanently benched with `pipeline_auto.recitation_blocked: true` because Gemini's RECITATION filter refuses to OCR famous published texts — Spinoza *Ethics*, Humboldt *Kosmos*, *Roman de la Rose*, *Histoire de la magie*, etc. The pipeline tries the primary OCR model (`gemini-3-flash-preview`), retries with `gemini-2.5-flash`, then permanently blocks. Both models return `finishReason=RECITATION` on these texts.

**Proven fix:** `gemini-3.1-flash-lite` does NOT trigger RECITATION on these texts (verified by probing real body pages — `finishReason=STOP`, clean transcription). The full-OCR path never tried lite.

## Change

Replaces the 2-tier (2.5-flash retry → permanent block) recovery with a **3-tier escalation**:
1. First RECITATION failure → `recitation_retry` → retry with `gemini-2.5-flash` (unchanged)
2. Second failure → `recitation_retry_lite` → retry with `gemini-3.1-flash-lite` (NEW)
3. Third failure → `recitation_blocked` → permanent block (only after lite also fails)

Additive and backward-compatible: books with no retry flag behave exactly as before (`ocrOpts = {}`).

## Files changed

- `scripts/workers/batch-collector.mjs` — 3-tier RECITATION recovery state machine in the recitation-recovery loop.
- `scripts/workers/pipeline-orchestrator.mjs` — Pass 2: pick up `recitation_retry_lite` books regardless of `pages_ocr`, route them to `gemini-3.1-flash-lite`, clear the correct flag on successful resubmit.
- `scripts/maintenance/unblock-recitation-books-to-lite.mjs` — one-off backfill to re-enroll the 14 existing `recitation_blocked` books straight into the lite tier (skips 2.5-flash, the proven-to-fail model). **Dry-run by default; `--apply` to mutate.**

## Deploy / run order

`scripts/**` auto-deploys to Hetzner (no Vercel deploy). **Run the backfill AFTER this is live on Hetzner** — otherwise the `recitation_retry_lite` tier isn't picked up. The backfill is dry-run by default; review the printed list, then run with `--apply`.

## Out of scope

Translation-side RECITATION is a separate per-page mechanism in `translate-worker.mjs` and is deliberately untouched. A parallel flash-lite translation-retry tier is noted in code as a possible follow-up.

## Verify

- `node --check` passes on all three files.
- Unit suite: 288 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)