### PR TITLE
fix(gallery): recover 10 hidden collections + image_url cover fallback

### DIFF
--- a/scripts/maintenance/backfill-gallery-collection-covers.mjs
+++ b/scripts/maintenance/backfill-gallery-collection-covers.mjs
@@ -27,7 +27,8 @@ const DRY_RUN = process.argv.includes('--dry-run');
 const client = new MongoClient(process.env.MONGODB_URI);
 
 function usableUrl(img) {
-  return img && (img.extracted_url || img.thumbnail_url) || null;
+  // Matches the page resolver: extracted_url → thumbnail_url → image_url.
+  return img && (img.extracted_url || img.thumbnail_url || img.image_url) || null;
 }
 
 async function main() {
@@ -47,7 +48,7 @@ async function main() {
     for (const id of (c.image_ids || [])) allIds.add(id);
   }
   const imgDocs = await gi.find({ id: { $in: [...allIds] } }, {
-    projection: { id: 1, extracted_url: 1, thumbnail_url: 1 },
+    projection: { id: 1, extracted_url: 1, thumbnail_url: 1, image_url: 1 },
   }).toArray();
   const imgMap = new Map(imgDocs.map((d) => [d.id, d]));
 

--- a/scripts/maintenance/recover-hidden-gallery-collections.mjs
+++ b/scripts/maintenance/recover-hidden-gallery-collections.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Re-cover the gallery collections that backfill-gallery-collection-covers.mjs
+ * hid (no resolvable cover). Investigation showed the images aren't gone — the
+ * CDN files survive and the source books are still visible; the rows were moved
+ * to `deleted_gallery_images` by a false-positive "orphan_page_id" dedup pass,
+ * or the collection's books simply have live `gallery_images` we never pointed at.
+ *
+ * Per collection, in order:
+ *   1. UNDELETE — re-insert any `deleted_gallery_images` rows referenced by the
+ *      collection's image_ids that have NO dedup survivor (kept_id empty) and
+ *      aren't already present. Re-derive image_url + denormalized book_* from
+ *      the source book so they also surface in the main /gallery grid.
+ *   2. PULL — if the collection still has no resolvable cover, populate
+ *      image_ids from its book collection's live gallery_images (best
+ *      gallery_quality first).
+ *   3. Set cover_image_id to the first resolvable image and unhide.
+ *   4. If nothing resolves from existing assets, leave hidden and report it
+ *      (needs new art sourced online).
+ *
+ * Cover resolves on `extracted_url || thumbnail_url || image_url` — matching the
+ * page resolver (image_url fallback added in the same change set).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/recover-hidden-gallery-collections.mjs --dry-run
+ *   node scripts/maintenance/recover-hidden-gallery-collections.mjs
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const MAX_PULL = 30;
+const client = new MongoClient(process.env.MONGODB_URI);
+
+const SLUGS = [
+  'collection-mandaeanism', 'collection-sikhism', 'collection-rumi',
+  'collection-mesoamerican', 'collection-kashmir-shaivism',
+  'collection-templar-chivalric-orders', 'collection-royal-court-poetry',
+  'collection-roman-canon-law', 'collection-dreams-unconscious',
+  'collection-socialist-revolutionary-thought', 'collection-kama',
+];
+
+const urlOf = (img) => img && (img.extracted_url || img.thumbnail_url || img.image_url) || null;
+const TOMBSTONE = ['deleted_at', 'reason', 'kept_id', 'restored_at', 'restored_from', '_id'];
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+  const gc = db.collection('gallery_collections');
+  const gi = db.collection('gallery_images');
+  const dgi = db.collection('deleted_gallery_images');
+  const booksCol = db.collection('books');
+
+  const docs = await gc.find({ slug: { $in: SLUGS } }).toArray();
+
+  for (const d of docs) {
+    const bcs = d.book_collection_slug || d.slug.replace(/^collection-/, '');
+    let undeleted = 0, pulled = 0;
+    let imageIds = [...(d.image_ids || [])];
+
+    // ---- 1. UNDELETE referenced deleted rows (no survivor, not already present)
+    if (imageIds.length) {
+      const present = new Set((await gi.find({ id: { $in: imageIds } }, { projection: { id: 1 } }).toArray()).map((x) => x.id));
+      const delRows = await dgi.find({
+        id: { $in: imageIds.filter((id) => !present.has(id)) },
+        $or: [{ kept_id: { $in: [null, ''] } }, { kept_id: { $exists: false } }],
+      }).toArray();
+      // Re-derive book_* + image_url from the source book.
+      const bookIds = [...new Set(delRows.map((r) => r.book_id).filter(Boolean))];
+      const bookDocs = bookIds.length ? await booksCol.find({ $or: [{ _id: { $in: bookIds.map(safeOid).filter(Boolean) } }, { id: { $in: bookIds } }] }).project({ _id: 1, id: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, visible: 1, image_source: 1 }).toArray() : [];
+      const bookMap = new Map();
+      for (const b of bookDocs) { bookMap.set(String(b._id), b); if (b.id) bookMap.set(b.id, b); }
+      const inserts = delRows.map((r) => {
+        const b = bookMap.get(r.book_id);
+        const row = { ...r };
+        for (const k of TOMBSTONE) delete row[k];
+        if (!row.image_url && row.extracted_url) row.image_url = row.extracted_url;
+        if (b) {
+          row.book_title = b.display_title || b.title;
+          row.book_author = b.author;
+          row.book_year = b.year;
+          row.book_language = b.language;
+          row.book_visible = b.visible !== false;
+          row.book_provider = b.image_source?.provider;
+        }
+        row.restored_at = DRY_RUN ? null : new Date();
+        return row;
+      });
+      if (!DRY_RUN && inserts.length) await gi.insertMany(inserts, { ordered: false });
+      undeleted = inserts.length;
+    }
+
+    // ---- 2. recompute resolvable cover among current image_ids
+    let resolvable = [];
+    if (imageIds.length) {
+      const imgs = await gi.find({ id: { $in: imageIds } }, { projection: { id: 1, extracted_url: 1, thumbnail_url: 1, image_url: 1 } }).toArray();
+      const byId = new Map(imgs.map((x) => [x.id, x]));
+      resolvable = imageIds.filter((id) => urlOf(byId.get(id)));
+    }
+
+    // ---- 3. PULL from the book collection's live gallery_images if still bare
+    if (!resolvable.length) {
+      const books = await booksCol.find({ collections: bcs }).project({ _id: 1, id: 1 }).toArray();
+      const bookKeys = [...new Set(books.flatMap((b) => [String(b._id), b.id]).filter(Boolean))];
+      if (bookKeys.length) {
+        const imgs = await gi.find({
+          book_id: { $in: bookKeys },
+          $or: [{ extracted_url: { $nin: [null, ''] } }, { thumbnail_url: { $nin: [null, ''] } }, { image_url: { $nin: [null, ''] } }],
+        }, { projection: { id: 1 } }).sort({ gallery_quality: -1 }).limit(MAX_PULL).toArray();
+        if (imgs.length) { imageIds = imgs.map((x) => x.id); resolvable = [...imageIds]; pulled = imgs.length; }
+      }
+    }
+
+    // ---- 4. apply
+    if (resolvable.length) {
+      const cover = resolvable[0];
+      if (!DRY_RUN) await gc.updateOne({ _id: d._id }, { $set: { cover_image_id: cover, image_ids: imageIds, updated_at: new Date() }, $unset: { hidden: '' } });
+      console.log(`✓ ${d.slug}: undeleted=${undeleted} pulled=${pulled} → ${resolvable.length} images, cover=${cover} — UNHIDDEN`);
+    } else {
+      console.log(`✗ ${d.slug}: no recoverable images from existing assets — STILL HIDDEN (needs online sourcing)`);
+    }
+  }
+  await client.close();
+}
+
+function safeOid(s) { try { return new ObjectId(s); } catch { return null; } }
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -542,7 +542,10 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
             </div>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
               {artworks.slice(0, 12).map(art => {
-                const thumb = art.image_thumb || art.image_display || getBookThumbnailUrl(art);
+                // Route through the resolver (size 'thumb') so artwork URL
+                // normalization applies — reading image_thumb raw re-introduces
+                // the 150px-upscaled blur if an import ever writes a small thumb.
+                const thumb = getBookThumbnailUrl(art, 'thumb') || art.image_display;
                 return (
                   <Link
                     key={art.id}

--- a/src/app/gallery/collections/page.tsx
+++ b/src/app/gallery/collections/page.tsx
@@ -83,15 +83,17 @@ async function resolveCoverImages(db: any, imageIds: string[]) {
     .collection('gallery_images')
     .find(
       { id: { $in: imageIds } },
-      { projection: { id: 1, extracted_url: 1, thumbnail_url: 1, description: 1 } }
+      { projection: { id: 1, extracted_url: 1, thumbnail_url: 1, image_url: 1, description: 1 } }
     )
     .toArray();
 
   const result = new Map<string, { url: string; description: string }>();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   for (const doc of docs as any[]) {
+    // Fall back to image_url (full archived page) — some gallery_images have
+    // only image_url populated, which would otherwise render a blank cover.
     result.set(doc.id, {
-      url: doc.extracted_url || doc.thumbnail_url || '',
+      url: doc.extracted_url || doc.thumbnail_url || doc.image_url || '',
       description: doc.description || '',
     });
   }


### PR DESCRIPTION
## What & why

Follow-up to #2384. A site-wide image sweep found the 11 "empty" gallery collections we hid weren't actually empty — their backing `gallery_images` rows had been moved to `deleted_gallery_images` by a **false-positive `orphan_page_id` dedup pass**, but the CDN files all survive (HTTP 200) and the source books are still visible.

### Recovered 10 of 11 hidden collections
`scripts/maintenance/recover-hidden-gallery-collections.mjs` (already run against prod): un-deletes the referenced rows (only those with no dedup survivor, re-deriving `image_url` + denormalized `book_*` from the source book) and/or pulls live `gallery_images` from each collection's book collection, then sets a resolvable cover and un-hides.

- **dreams-unconscious** — 469 images restored
- **mandaeanism, rumi, sikhism, kama, kashmir-shaivism, roman-canon-law** — their curated Met/Cleveland picks un-deleted
- **mesoamerican (30), templar** — pulled from live book images
- **socialist-revolutionary-thought** — was hidden in error, resolves as-is
- **royal-court-poetry** — the only one still hidden; no images in `gallery_images`, `deleted_gallery_images`, or its books → needs art sourced online (IIIF). Tracking separately.

All 10 recovered covers verified HTTP 200.

### Two render fixes the sweep surfaced
- **`gallery/collections/page.tsx`** cover resolver now falls back to `image_url` (the full archived page) — fixes ~4 collections whose `gallery_images` have only `image_url` populated and rendered a **blank cover**. The backfill script gets the same fallback so its hide decisions match the page.
- **`author/[name]/page.tsx`** artwork grid now routes through `getBookThumbnailUrl(art, 'thumb')` instead of reading `image_thumb` raw — closes a latent re-occurrence of the 150px-upscale blur (#2384) if any future import writes a small thumb.

## Out of scope (reported, not done)
- `royal-court-poetry` online art sourcing (IIIF).
- ~1,764 sub-1,200px artworks (mostly Commons-maxed Blake) + 514 unknown-dim IIIF works needing a dimension backfill — separate low-res-upgrade effort.
- Author-portrait coverage gap (~70% of entity-linked authors) — enrichment backfill, renders gracefully today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)