### PR TITLE
fix(gallery): hide low-quality images instead of deleting them

### DIFF
--- a/src/app/api/gallery/image/[id]/route.ts
+++ b/src/app/api/gallery/image/[id]/route.ts
@@ -557,46 +557,51 @@ export async function PATCH(
     }
 
     // Sync changes to materialized gallery_images collection
-    let gallerySyncStatus: 'ok' | 'removed_low_quality' | 'no_change' | { error: string } = 'no_change';
+    let gallerySyncStatus: 'ok' | 'hidden_low_quality' | 'no_change' | { error: string } = 'no_change';
     try {
       const galleryImageId = `${pageId}-${detectionIndex}`;
 
-      // If quality dropped below materialization threshold, remove from gallery
-      if (typeof body.galleryQuality === 'number' && body.galleryQuality < 0.5) {
-        await db.collection('gallery_images').deleteOne({ id: galleryImageId, ...tenantGalleryFilter });
-        gallerySyncStatus = 'removed_low_quality';
-      } else {
-        const galleryUpdate: Record<string, unknown> = {};
-        if (typeof body.galleryQuality === 'number') {
-          galleryUpdate.gallery_quality = Math.max(0, Math.min(1, body.galleryQuality));
-        }
-        if (typeof body.featured === 'boolean') galleryUpdate.featured = body.featured;
-        if (typeof body.museumDescription === 'string') galleryUpdate.museum_description = body.museumDescription;
-        if (typeof body.description === 'string') galleryUpdate.description = body.description;
-        if (body.metadata && typeof body.metadata === 'object') galleryUpdate.metadata = body.metadata;
-        if (typeof body.rotation === 'number') galleryUpdate.rotation = body.rotation;
-        if (body.bbox) galleryUpdate.bbox = updateFields[`detected_images.${detectionIndex}.bbox`];
+      // Always upsert — never delete. When a curator lowers quality below the
+      // 0.5 materialization threshold the row is HIDDEN from the public gallery
+      // by the gallery_quality >= minQuality read-filter gate (see
+      // api/gallery/route.ts), not destroyed. It stays recoverable: raising
+      // quality back ≥ 0.5 makes it reappear, and admin/curation views
+      // (minQuality=0) can still see it. (Source of truth
+      // pages.detected_images[].gallery_quality was already updated above.)
+      const galleryUpdate: Record<string, unknown> = {};
+      if (typeof body.galleryQuality === 'number') {
+        galleryUpdate.gallery_quality = Math.max(0, Math.min(1, body.galleryQuality));
+      }
+      if (typeof body.featured === 'boolean') galleryUpdate.featured = body.featured;
+      if (typeof body.museumDescription === 'string') galleryUpdate.museum_description = body.museumDescription;
+      if (typeof body.description === 'string') galleryUpdate.description = body.description;
+      if (body.metadata && typeof body.metadata === 'object') galleryUpdate.metadata = body.metadata;
+      if (typeof body.rotation === 'number') galleryUpdate.rotation = body.rotation;
+      if (body.bbox) galleryUpdate.bbox = updateFields[`detected_images.${detectionIndex}.bbox`];
 
-        if (Object.keys(galleryUpdate).length > 0) {
-          galleryUpdate.updated_at = new Date();
-          // Upsert: if a prior edit dropped quality < 0.5 the row was deleted
-          // (line above). Without upsert, raising quality back ≥ 0.5 would leave
-          // the gallery list view permanently out of sync with pages.detected_images.
-          // On insert, also write the foreign-key fields needed for queries.
-          const result = await db.collection('gallery_images').updateOne(
-            { id: galleryImageId, ...tenantGalleryFilter },
-            {
-              $set: galleryUpdate,
-              $setOnInsert: {
-                id: galleryImageId,
-                page_id: pageId,
-                detection_index: detectionIndex,
-              },
+      const lowQuality = typeof body.galleryQuality === 'number' && body.galleryQuality < 0.5;
+
+      if (Object.keys(galleryUpdate).length > 0) {
+        galleryUpdate.updated_at = new Date();
+        // Upsert (never delete): keeps the gallery list view in sync with
+        // pages.detected_images and preserves the row when quality drops < 0.5.
+        // On insert, also write the foreign-key fields needed for queries.
+        const result = await db.collection('gallery_images').updateOne(
+          { id: galleryImageId, ...tenantGalleryFilter },
+          {
+            $set: galleryUpdate,
+            $setOnInsert: {
+              id: galleryImageId,
+              page_id: pageId,
+              detection_index: detectionIndex,
             },
-            { upsert: true },
-          );
-          gallerySyncStatus = result.upsertedCount > 0 || result.modifiedCount > 0 ? 'ok' : 'no_change';
-        }
+          },
+          { upsert: true },
+        );
+        const changed = result.upsertedCount > 0 || result.modifiedCount > 0;
+        gallerySyncStatus = lowQuality ? 'hidden_low_quality' : changed ? 'ok' : 'no_change';
+      } else if (lowQuality) {
+        gallerySyncStatus = 'hidden_low_quality';
       }
     } catch (syncErr) {
       console.error('Gallery images sync failed:', syncErr);

--- a/src/lib/api-client/types/gallery.ts
+++ b/src/lib/api-client/types/gallery.ts
@@ -109,7 +109,7 @@ export interface GalleryImageUpdateResponse {
   extractedUrl?: string;
   thumbnailUrl?: string;
   /** Diagnostic info for the materialized gallery_images sync. */
-  gallerySync?: 'ok' | 'removed_low_quality' | 'no_change' | { error: string };
+  gallerySync?: 'ok' | 'hidden_low_quality' | 'no_change' | { error: string };
 }
 
 export interface GalleryImageDetail {


### PR DESCRIPTION
## Problem

When a curator lowered a gallery image's quality below the **0.5** materialization threshold in the gallery image editor, the save handler called `deleteOne()` on the materialized `gallery_images` row — **destroying** the curation record. The owner's concern: lowering quality should *hide* an image from the public gallery, not delete it. The deletion was effectively unrecoverable from the editor.

## Fix

In `src/app/api/gallery/image/[id]/route.ts`, the delete-on-low-quality branch is replaced with an **unconditional upsert**:

- A row whose quality drops below 0.5 is now **kept**, with its clamped `gallery_quality` (and other edited fields) written as before.
- It is automatically **hidden from the public gallery** by the existing `gallery_quality >= minQuality` read-filter gate in `src/app/api/gallery/route.ts` (minQuality defaults to 0.5 across the base filter, the Atlas `$search` range filter, the book-context fallback, and the CLIP-only fetch). **No read-path change was needed.**
- It stays fully **recoverable**: raising quality back ≥ 0.5 makes it reappear, and admin/curation views (which pass `minQuality=0`) can still see it.

The **source of truth** `pages.detected_images[detectionIndex].gallery_quality` is updated earlier in the handler and is **unaffected** — no data loss there either.

The diagnostic status `gallerySync` value `'removed_low_quality'` is renamed to `'hidden_low_quality'` in both the route producer and the `GalleryImageUpdateResponse` type. `grep -rn` confirmed **no frontend or other consumer** branches on the old string — only the route and the type referenced it.

The second gallery-sync site in the same file (the bbox/rotation path inside the image-generation block) already upserted and never deleted; it is unchanged.

## Scope

- **In scope:** delete → keep (hide) behavior on low-quality save; status string rename.
- **Out of scope:** no read-path changes (the existing minQuality gate already hides sub-threshold rows); no data backfill (already-deleted rows are not recovered here — they re-materialize from `pages.detected_images` on the next sync/edit).

## Verification

- `npx tsc --noEmit` clean (exit 0). The union-type change is consistent across producer + type.
- Only behavioral change is delete → keep; all other fields and the source-of-truth `detected_images` update are untouched.

## Files changed
- `src/app/api/gallery/image/[id]/route.ts`
- `src/lib/api-client/types/gallery.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)