### PR TITLE
fix(work): decode non-ASCII work_id so CJK/accented work pages resolve

### DIFF
--- a/src/app/work/[id]/compare/page.tsx
+++ b/src/app/work/[id]/compare/page.tsx
@@ -89,7 +89,9 @@ async function getEditionsForCompare(workId: string): Promise<EditionForCompare[
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const { id } = await params;
+  const { id: rawId } = await params;
+  // Decode non-ASCII work_id (CJK / accented) before use — see /work/[id]/page.tsx.
+  const id = decodeURIComponent(rawId);
   const title = workTitle(id);
   return {
     title: `Compare Translations — ${title} | Source Library`,
@@ -100,7 +102,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function CompareWorkPage({ params }: PageProps) {
-  const { id } = await params;
+  const { id: rawId } = await params;
+  const id = decodeURIComponent(rawId);
   const editions = await getEditionsForCompare(id);
   if (editions.length < 2) notFound();
 

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -42,7 +42,11 @@ function workTitle(workId: string): string {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const { id } = await params;
+  const { id: rawId } = await params;
+  // work_id values include non-ASCII (CJK, accented Latin); the route param
+  // arrives percent-encoded, so decode before matching against Mongo — otherwise
+  // the query silently finds 0 editions and 404s. Same pattern as /author/[name].
+  const id = decodeURIComponent(rawId);
   let editions: Awaited<ReturnType<typeof getWorkEditions>>;
   try {
     editions = await getWorkEditions(id);
@@ -62,7 +66,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function WorkPage({ params }: PageProps) {
-  const { id } = await params;
+  const { id: rawId } = await params;
+  const id = decodeURIComponent(rawId);
   const editions = await getWorkEditions(id);
   if (editions.length === 0) notFound();
 


### PR DESCRIPTION
## Problem
~28 \`/work/*\` pages 404'd despite being in the sitemap (which only emits works with ≥2 visible editions). Every affected work_id contained **non-ASCII** characters — CJK titles and accented Latin. Examples: \`/work/茅元儀-武備志\` (**42 visible editions**), \`/work/dürer-four-books-human-proportion\`, \`/work/lévi-dogme-rituel-haute-magie\`, several Böhme works.

## Root cause
\`/work/[id]/page.tsx\` and \`/work/[id]/compare/page.tsx\` query Mongo with the raw route param (\`{ work_id: id }\`). The param arrives **percent-encoded**, so for non-ASCII work_ids the encoded string never matched the stored value → \`getWorkEditions()\` returned 0 → \`notFound()\`. ASCII work_ids (e.g. \`ficino-theologia-platonica\`) were unaffected.

Verified against prod data: \`茅元儀-武備志\` has 42 visible editions in Mongo, yet the page rendered fresh (\`x-vercel-cache: MISS\`) and 404'd — confirming a param-matching bug, not data drift or stale cache.

## Fix
\`decodeURIComponent(rawId)\` before querying, in both the work page and the compare page (metadata + render paths). This matches the existing convention in \`/author/[name]/page.tsx\`, which already decodes for the same reason.

## How it was found
A full-site cache-warming pass flagged 31 \`/work/*\` 404s; investigation split them into ~28 non-ASCII decode failures (this PR) and a few malformed work_ids (below).

## Scope
- **In scope:** non-ASCII work_id decoding for /work/[id] and /work/[id]/compare.
- **Out of scope:** ~3 genuinely malformed work_ids in the data containing \`|\` / \`[\` (e.g. \`…artephius|flamel\`, \`philosophia-s-scripturae-interpres-[meyer\`). Those are bad slugs from work-id generation and need a data cleanup, not a decode — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)