### PR TITLE
chore(images): Met sourcing + targeted low-res upgrade scripts

### DIFF
--- a/scripts/import/met-royal-court-poetry-gallery.mjs
+++ b/scripts/import/met-royal-court-poetry-gallery.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * Give the `collection-royal-court-poetry` gallery collection real imagery.
+ *
+ * The collection's 165 books are ETCSL Sumerian text-corpus transcriptions
+ * (royal hymns, laments, Gudea cylinders) — plain text, no scans, so nothing
+ * to extract. This sources ~12 thematically-matched objects from the Met's
+ * Ancient West Asian Art department (open access, CC0): Gudea statuary,
+ * royal steles, banquet/court cylinder seals, cuneiform royal inscriptions.
+ *
+ * Images are rehosted to R2 (full + 600px thumb), inserted as `gallery_images`
+ * rows (id `met-{objectID}` — same convention as the other museum-sourced
+ * collections like mandaeanism), then the collection gets cover + image_ids
+ * and is un-hidden.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/met-royal-court-poetry-gallery.mjs --dry-run
+ *   node scripts/import/met-royal-court-poetry-gallery.mjs
+ */
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const MAX_ITEMS = 12;
+const MET_API = 'https://collectionapi.metmuseum.org/public/collection/v1';
+const DEPT_ANCIENT_WEST_ASIAN = 3;
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@sourcelibrary.org)';
+const DELAY_MS = 300;
+const COLLECTION_SLUG = 'collection-royal-court-poetry';
+const R2_DIR = `gallery/${COLLECTION_SLUG}`;
+
+// Thematic queries, in priority order — Sumerian royal/court material first.
+const QUERIES = [
+  'Gudea',
+  'Ur III',
+  'Sumerian',
+  'foundation figure',
+  'cylinder seal banquet',
+  'stele',
+  'cuneiform royal',
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const client = new MongoClient(process.env.MONGODB_URI);
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: process.env.R2_ACCESS_KEY_ID, secretAccessKey: process.env.R2_SECRET_ACCESS_KEY },
+});
+
+async function met(path) {
+  const res = await fetch(`${MET_API}${path}`, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(20000) });
+  if (!res.ok) throw new Error(`Met ${path} → ${res.status}`);
+  return res.json();
+}
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+  const gi = db.collection('gallery_images');
+  const gc = db.collection('gallery_collections');
+
+  // ---- gather candidate object IDs (priority-ordered, deduped)
+  const seen = new Set();
+  const ordered = [];
+  for (const q of QUERIES) {
+    try {
+      const r = await met(`/search?q=${encodeURIComponent(q)}&departmentId=${DEPT_ANCIENT_WEST_ASIAN}&hasImages=true`);
+      for (const id of (r.objectIDs || []).slice(0, 25)) {
+        if (!seen.has(id)) { seen.add(id); ordered.push({ id, q }); }
+      }
+    } catch (e) { console.log(`search "${q}" failed: ${e.message}`); }
+    await sleep(DELAY_MS);
+  }
+  console.log(`${ordered.length} candidate objects across ${QUERIES.length} queries`);
+
+  // ---- fetch objects, keep CC0 + imaged, prefer highlights, cap MAX_ITEMS
+  const picks = [];
+  for (const { id, q } of ordered) {
+    if (picks.length >= MAX_ITEMS) break;
+    try {
+      const o = await met(`/objects/${id}`);
+      if (!o.isPublicDomain || !o.primaryImage) continue;
+      if (o.department && !/west asian|near east/i.test(o.department)) continue;
+      picks.push({
+        objectID: o.objectID,
+        title: o.title || 'Untitled',
+        date: o.objectDate || '',
+        medium: o.medium || '',
+        url: o.primaryImage,
+        highlight: !!o.isHighlight,
+        query: q,
+        credit: o.creditLine || '',
+        objectURL: o.objectURL || '',
+      });
+    } catch { /* skip */ }
+    await sleep(DELAY_MS);
+  }
+  // Highlights first, then priority order (stable sort keeps query priority).
+  picks.sort((a, b) => Number(b.highlight) - Number(a.highlight));
+
+  console.log(`\nCurated ${picks.length} objects:`);
+  picks.forEach((p) => console.log(`  ${p.highlight ? '★' : ' '} met-${p.objectID}  ${p.title.slice(0, 60)} (${p.date}) [${p.query}]`));
+  if (DRY_RUN) { await client.close(); return; }
+
+  // ---- rehost + insert gallery_images
+  const imageIds = [];
+  for (const p of picks) {
+    const gid = `met-${p.objectID}`;
+    const existing = await gi.findOne({ id: gid }, { projection: { _id: 1 } });
+    if (existing) { imageIds.push(gid); console.log(`= ${gid} already in gallery_images`); continue; }
+    try {
+      const res = await fetch(p.url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(120000) });
+      if (!res.ok) { console.log(`✗ ${gid} image fetch ${res.status}`); continue; }
+      const buf = Buffer.from(await res.arrayBuffer());
+      if (!buf.length) { console.log(`✗ ${gid} empty buffer`); continue; }
+      const full = await sharp(buf).jpeg({ quality: 88, mozjpeg: true }).toBuffer();
+      const thumb = await sharp(buf).resize({ width: 600, withoutEnlargement: true }).jpeg({ quality: 80, mozjpeg: true }).toBuffer();
+      const fullKey = `${R2_DIR}/${gid}.jpg`;
+      const thumbKey = `${R2_DIR}/${gid}-thumb.jpg`;
+      for (const [key, body] of [[fullKey, full], [thumbKey, thumb]]) {
+        await s3.send(new PutObjectCommand({
+          Bucket: process.env.R2_BUCKET_NAME, Key: key, Body: body,
+          ContentType: 'image/jpeg', CacheControl: 'public, max-age=31536000, immutable',
+        }));
+      }
+      const meta = await sharp(buf).metadata();
+      await gi.insertOne({
+        id: gid,
+        page_id: gid,
+        extracted_url: `https://images.sourcelibrary.org/${fullKey}`,
+        thumbnail_url: `https://images.sourcelibrary.org/${thumbKey}`,
+        image_url: `https://images.sourcelibrary.org/${fullKey}`,
+        description: [p.title, p.date, p.medium].filter(Boolean).join('. ') + '. The Metropolitan Museum of Art (CC0).',
+        type: 'artifact',
+        gallery_quality: p.highlight ? 0.9 : 0.85,
+        book_title: 'The Metropolitan Museum of Art',
+        source: 'met',
+        source_object_url: p.objectURL,
+        width: meta.width, height: meta.height,
+        created_at: new Date(),
+      });
+      imageIds.push(gid);
+      console.log(`✓ ${gid} rehosted (${meta.width}x${meta.height}) — ${p.title.slice(0, 50)}`);
+    } catch (e) { console.log(`✗ ${gid}: ${e.message?.slice(0, 80)}`); }
+    await sleep(DELAY_MS);
+  }
+
+  if (!imageIds.length) { console.log('No images imported — leaving collection hidden.'); await client.close(); return; }
+
+  await gc.updateOne(
+    { slug: COLLECTION_SLUG },
+    { $set: { image_ids: imageIds, cover_image_id: imageIds[0], updated_at: new Date() }, $unset: { hidden: '' } }
+  );
+  console.log(`\n✓ ${COLLECTION_SLUG}: ${imageIds.length} images, cover=${imageIds[0]} — UNHIDDEN`);
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/upgrade-lowres-met-artworks.mjs
+++ b/scripts/maintenance/upgrade-lowres-met-artworks.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Targeted resolution upgrade for low-res Met artworks.
+ *
+ * Scoping (2026-06-03) found ~99 visible Met artworks stored under 1200px
+ * (including 10 of the 11 truly-tiny <600px ones) whose Met objects serve
+ * full-res primaryImage (typically 3–4000px) via the open-access API. The
+ * broader Commons low-res population is mostly already at Commons' max res —
+ * this script deliberately targets only the Met, where the win is real.
+ *
+ * For each: image_source.identifier → Met objectID → primaryImage → rehost the
+ * artwork triplet at the SAME R2 keys derived from image_display
+ * (`artwork/{base}.jpg` display ≤3840px, `-thumb.jpg` 600px, `-full.jpg`
+ * original), then update commons_width/height + image_upgraded. Only applies
+ * when the new image is meaningfully larger (>1.3× max dimension).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/upgrade-lowres-met-artworks.mjs --dry-run
+ *   node scripts/maintenance/upgrade-lowres-met-artworks.mjs [--max-dim 1200]
+ */
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const MAX_DIM = parseInt(process.argv.find((_, i, a) => a[i - 1] === '--max-dim') || '') || 1200;
+const MET_API = 'https://collectionapi.metmuseum.org/public/collection/v1';
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@sourcelibrary.org)';
+const DELAY_MS = 300;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const client = new MongoClient(process.env.MONGODB_URI);
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: process.env.R2_ACCESS_KEY_ID, secretAccessKey: process.env.R2_SECRET_ACCESS_KEY },
+});
+
+async function main() {
+  await client.connect();
+  const books = client.db('bookstore').collection('books');
+
+  const docs = await books.find({
+    content_type: 'artwork', visible: true,
+    'image_source.provider': 'met',
+    commons_width: { $lt: MAX_DIM }, commons_height: { $lt: MAX_DIM },
+  }, { projection: { title: 1, slug: 1, image_display: 1, commons_width: 1, commons_height: 1, 'image_source.identifier': 1 } }).toArray();
+
+  console.log(`${DRY_RUN ? 'DRY RUN — ' : ''}${docs.length} Met artworks under ${MAX_DIM}px`);
+  let upgraded = 0, noBigger = 0, errors = 0;
+
+  for (const d of docs) {
+    const ident = String(d.image_source?.identifier || '').replace(/^met-/, '');
+    const oldMax = Math.max(d.commons_width || 0, d.commons_height || 0);
+    // Two storage shapes: artwork triplet (artwork/{base}.jpg) or page-style
+    // (pages/{bookId}/{num}.jpg — artworks imported as 1-page books).
+    const artBase = d.image_display?.match(/images\.sourcelibrary\.org\/artwork\/(.+?)(?:-full|-thumb)?\.jpg$/)?.[1];
+    const pageM = d.image_display?.match(/images\.sourcelibrary\.org\/pages\/([^/]+)\/(\d+)(?:-thumb|-full)?\.jpg$/);
+    const label = `${d.title?.slice(0, 45)} (${oldMax}px, met ${ident})`;
+    if (!/^\d+$/.test(ident) || (!artBase && !pageM)) { errors++; console.log(`✗ ${label} — bad identifier or display URL`); continue; }
+    try {
+      const res = await fetch(`${MET_API}/objects/${ident}`, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(20000) });
+      if (!res.ok) { errors++; console.log(`✗ ${label} — Met API ${res.status}`); await sleep(DELAY_MS); continue; }
+      const o = await res.json();
+      if (!o.primaryImage) { noBigger++; await sleep(DELAY_MS); continue; }
+      const imgRes = await fetch(o.primaryImage, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(120000) });
+      if (!imgRes.ok) { errors++; console.log(`✗ ${label} — image ${imgRes.status}`); await sleep(DELAY_MS); continue; }
+      const buf = Buffer.from(await imgRes.arrayBuffer());
+      if (!buf.length) { errors++; await sleep(DELAY_MS); continue; }
+      const meta = await sharp(buf).metadata();
+      const newMax = Math.max(meta.width || 0, meta.height || 0);
+      if (newMax < oldMax * 1.3) { noBigger++; console.log(`= ${label} — Met serves ${newMax}px, not meaningfully larger`); await sleep(DELAY_MS); continue; }
+      if (DRY_RUN) { upgraded++; console.log(`↑ ${label} → ${meta.width}x${meta.height} [dry]`); await sleep(DELAY_MS); continue; }
+
+      const display = await sharp(buf).resize({ width: 3840, withoutEnlargement: true }).jpeg({ quality: 85, mozjpeg: true }).toBuffer();
+      const thumb = await sharp(buf).resize({ width: 600, withoutEnlargement: true }).jpeg({ quality: 80, mozjpeg: true }).toBuffer();
+      const full = await sharp(buf).jpeg({ quality: 92, mozjpeg: true }).toBuffer();
+      const keys = artBase
+        ? [[`artwork/${artBase}.jpg`, display], [`artwork/${artBase}-thumb.jpg`, thumb], [`artwork/${artBase}-full.jpg`, full]]
+        : [[`pages/${pageM[1]}/${pageM[2]}.jpg`, display], [`pages/${pageM[1]}/${pageM[2]}-thumb.jpg`, thumb], [`archived/${pageM[1]}/${parseInt(pageM[2], 10)}.jpg`, full]];
+      for (const [key, body] of keys) {
+        await s3.send(new PutObjectCommand({
+          Bucket: process.env.R2_BUCKET_NAME, Key: key, Body: body,
+          ContentType: 'image/jpeg', CacheControl: 'public, max-age=31536000, immutable',
+        }));
+      }
+      await books.updateOne({ _id: d._id }, {
+        $set: {
+          commons_width: meta.width, commons_height: meta.height,
+          image_upgraded: true, image_upgraded_at: new Date(),
+          image_upgrade_source: 'met_api', updated_at: new Date(),
+        },
+        $unset: { low_res: '' },
+      });
+      upgraded++;
+      console.log(`↑ ${label} → ${meta.width}x${meta.height}`);
+    } catch (e) { errors++; console.log(`✗ ${label} — ${e.message?.slice(0, 60)}`); }
+    await sleep(DELAY_MS);
+  }
+
+  console.log(`\n━━━ SUMMARY ━━━\nUpgraded: ${upgraded}\nNo bigger available: ${noBigger}\nErrors: ${errors}`);
+  console.log('Note: R2 keys are overwritten in place with immutable cache headers — purge Cloudflare after a live run so the new resolution serves.');
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Scripts-only PR from the image sweep (no frontend changes, no deploy needed — both already run against prod):

1. **`scripts/import/met-royal-court-poetry-gallery.mjs`** — `collection-royal-court-poetry` is 163 ETCSL Sumerian text-corpus books with zero native images (nothing to extract). Sourced 12 CC0 objects from the Met's Ancient West Asian Art dept (Gudea statue cover ★, head of a ruler ★, proto-cuneiform tablet ★, cult vessel ★, royal/cultic cylinder seals), rehosted to R2, inserted as `gallery_images` (`met-{objectID}` convention, same as mandaeanism etc.), collection un-hidden. **All 11 of the 11 originally-hidden gallery collections are now recovered.**

2. **`scripts/maintenance/upgrade-lowres-met-artworks.mjs`** — targeted upgrade for the ~99 visible Met artworks stored <1200px (incl. 10/11 of the truly-tiny <600px set). Pulls full-res `primaryImage` (3–4000px) from the Met open-access API and rehosts in place (both `artwork/` triplet and page-style storage shapes). Dry-run: 88 upgradeable, 11 already at max. Met-only by design — the Commons low-res tail (2,996) is already confirmed at Commons' max res, and Rijks (19) needs multi-hop linked-art resolution (skipped, low yield).

🤖 Generated with [Claude Code](https://claude.com/claude-code)