### PR TITLE
Geocoder: normalize archaic/messy imprint strings

### DIFF
--- a/scripts/enrichment/geocode-publication-places.mjs
+++ b/scripts/enrichment/geocode-publication-places.mjs
@@ -40,6 +40,74 @@ const MANUAL_OVERRIDES = {
   'Girard':       null, // Small US town, not a historical publishing center — skip
 };
 
+/**
+ * Old-spelling / variant → modern label that Wikidata's English label index
+ * knows. Only for forms that fail to resolve as written (verified empirically).
+ */
+const ARCHAIC_NORMALIZE = {
+  leyden: 'Leiden', leiden: 'Leiden',
+  haerlem: 'Haarlem',
+  neuremberg: 'Nuremberg', nuremberg: 'Nuremberg', nurnberg: 'Nuremberg', nürnberg: 'Nuremberg',
+  wittemberg: 'Wittenberg',
+  francfort: 'Frankfurt', franckfurt: 'Frankfurt', franckfort: 'Frankfurt',
+  coln: 'Cologne', colln: 'Cologne', cölln: 'Cologne', cöln: 'Cologne', keulen: 'Cologne',
+  edimbourg: 'Edinburgh', edimburgh: 'Edinburgh',
+  liegnitz: 'Legnica', brieg: 'Brzeg', breslau: 'Wrocław', wroclaw: 'Wrocław',
+  wittemberga: 'Wittenberg', argentorati: 'Strasbourg', argentina: 'Strasbourg',
+  lugduni: 'Lyon', lutetiae: 'Paris', basileae: 'Basel', venetiis: 'Venice',
+  köln: 'Cologne', munchen: 'Munich', münchen: 'Munich',
+  strassbourg: 'Strasbourg', strassburg: 'Strasbourg',
+  stpetersburg: 'Saint Petersburg', sintpetersburg: 'Saint Petersburg', leningrad: 'Saint Petersburg',
+  pressburg: 'Bratislava', dantzig: 'Gdańsk', gdansk: 'Gdańsk',
+  parijs: 'Paris', londen: 'London', weenen: 'Vienna', wien: 'Vienna',
+  freyberg: 'Freiberg', buedingen: 'Büdingen', antwerpen: 'Antwerp',
+};
+
+/** Placeless / non-geographic imprint markers — return null (no dot). */
+const PLACELESS = [
+  /^n\.?\s*p\.?$/i, /^s\.?\s*l\.?$/i, /^z\.?\s*p\.?$/i, /^s\.?\s*n\.?$/i,
+  /^sans lieu$/i, /^unknown$/i, /^onbekend$/i, /^that year$/i, /^by\b/i, /^\?+$/,
+];
+
+/**
+ * Normalize a raw imprint string to a single geocodable city, or null to skip.
+ * Handles bracketed editorial places, false imprints (real city in brackets,
+ * fictitious city quoted), Dutch/Latin prepositions, multi-city lists, and
+ * archaic spellings. See scope notes — recovers ~250 books the naive cleaner
+ * left unmapped.
+ */
+function cleanPlaceName(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  let s = raw.trim();
+
+  // 1. Prefer a bracketed editorial place: "Fake" [Real], [=Real], X [Real].
+  const br = s.match(/\[\s*=?\s*([^\][?]+?)\s*\??\s*\]/);
+  if (br && br[1].trim().length > 1) s = br[1].trim();
+  else s = s.replace(/[[\]]/g, ' ');
+
+  // 2. Dutch contraction t'/'t (before quote-stripping eats the apostrophe).
+  s = s.replace(/^\s*'?t'\s*/i, ' ').replace(/^\s*'t\s+/i, ' ');
+
+  // 3. Strip quotes, question marks, colons, semicolons.
+  s = s.replace(/["'`?:;]/g, ' ');
+
+  // 4. Strip leading place-prepositions (Dutch te/tot, Latin ad/apud, à/a/in/zu).
+  s = s.replace(/^\s*(te|tot|in|ad|apud|à|a|zu|zur|au)\s+/i, ' ');
+
+  // 5. "Oldname = Modernname" → modern; then multi-city lists → first city.
+  s = s.split('=').pop().split('|')[0]
+       .split(/\s+en\s+/i)[0].split(/\s+and\s+/i)[0].split(/\s+et\s+/i)[0]
+       .split('/')[0].split('&')[0].split(',')[0]
+       .split(/\s{2,}/)[0]           // double-space-separated multi-imprint
+       .trim();
+
+  if (!s || s.length < 2) return null;
+  if (PLACELESS.some((p) => p.test(s))) return null;
+
+  const key = s.toLowerCase().replace(/[^a-zà-ÿ]/g, '');
+  return ARCHAIC_NORMALIZE[key] || s;
+}
+
 /** Query Wikidata SPARQL for city coordinates — prefer large cities */
 async function geocodeViaWikidata(cityName) {
   // Prefer cities/towns (P31 = Q515 city, Q3957 town, Q1549591 big city) with largest population
@@ -190,18 +258,10 @@ async function main() {
     const place = uncached[i];
     if (i > 0 && i % 10 === 0) console.log(`  ${i}/${uncached.length}...`);
 
-    // Clean up place name: strip brackets, take first city from multi-city
-    let primaryPlace = place
-      .replace(/^\[+/, '').replace(/\]+$/, '')  // strip [brackets]
-      .replace(/^\"+/, '').replace(/\"+$/, '')  // strip "quotes"
-      .replace(/^`+/, '').replace(/'+$/, '')    // strip backticks
-      .split('|')[0]                            // first city from multi-city
-      .split(/\s+en\s+/i)[0]                   // Dutch "en" = "and"
-      .split(/\s+and\s+/i)[0]                  // English "and"
-      .split(',')[0]                            // before comma (strip state/country qualifier)
-      .trim();
-    // Skip if empty or looks like a pseudonym place
-    if (!primaryPlace || primaryPlace.length < 2) { cache[place] = null; continue; }
+    // Normalize the raw imprint string to a single geocodable city (handles
+    // brackets, false imprints, Dutch/Latin prepositions, archaic spellings).
+    const primaryPlace = cleanPlaceName(place);
+    if (!primaryPlace) { cache[place] = null; continue; }
 
     // Check manual overrides first, then SPARQL, then search API
     let result = null;


### PR DESCRIPTION
Final follow-up in the `/explore/map` coverage series (#2377, #2388).

## Scope of the problem
474 visible books had an imprint string but no publication dot. 140 are genuinely placeless (`n.p.`, `s.l.`, `z.p.`) — correctly excluded. The other ~334 failed because the naive cleaner couldn't handle real catalog messiness.

## What this does
Replaces the inline cleanup with a `cleanPlaceName()` helper handling the actual patterns found in the data:

| Pattern | Example → result |
|---|---|
| False imprints (bracketed = true place) | `"Newenstatt" [=Halle]` → Halle; `"Amsterdam" [= Hannover]` → Hannover |
| Bracket/punctuation noise | `[Amsterdam] :` → Amsterdam; `[Leiden ?]` → Leiden |
| Dutch/Latin prepositions | `Te Leyden,` → Leiden; `t'Amsterdam` → Amsterdam |
| Old = modern | `[Dantzig = Gdansk]` → Gdańsk |
| Multi-imprint lists | `Frankfurt  Leipzig` → Frankfurt |
| Archaic spellings / exonyms | Neuremberg, Wittemberg, Köln, Parijs, Pressburg, Brieg → modern names |
| Placeless markers | `z.p.`, `that year`, `by <printer>` → skipped |

Unit-tested against the 25 worst real strings before running. Catch-up runs resolved **157** previously-failed place strings → **~210 new publication dots** (~177 newly-located books). Map total **11,684 → 11,861**. Cache rebuilt.

Remaining failures are genuinely fictitious (`Salomopolis`) or non-places (`Germany or Austria`, `漁坪`) — honest absence.

Script-only change: Hetzner auto-pulls, no Vercel deploy needed. (Two of the catch-up runs hit transient Atlas `PoolClearedOnNetworkError` mid-write — the write loop is idempotent, so re-running completed cleanly; noting in case the flakiness recurs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)