### PR TITLE
chore(images): IIIF dimension backfill + Rijks low-res upgrade scripts

### DIFF
--- a/scripts/maintenance/backfill-iiif-artwork-dimensions.mjs
+++ b/scripts/maintenance/backfill-iiif-artwork-dimensions.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Backfill commons_width/commons_height for artworks whose image lives on an
+ * external IIIF server (Leiden, UMedia, Allard Pierson, …) and whose docs
+ * never stored dimensions. ~514 visible artworks as of 2026-06-03.
+ *
+ * Reads the IIIF info.json next to the image (strip /{region}/{size}/{rot}/
+ * default.jpg → /info.json) and stores the full canvas width/height. These
+ * works are full IIIF sources, so they're "unknown", not low-res — this fixes
+ * the data so resolution audits stop counting them as unknowns.
+ *
+ * NOTE: Leiden's IIIF rate-limits some IPs — run this from the Hetzner box if
+ * local fetches return empty.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/backfill-iiif-artwork-dimensions.mjs [--dry-run]
+ */
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@sourcelibrary.org)';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function infoJsonUrl(imageUrl) {
+  // IIIF Image API: {base}/{region}/{size}/{rotation}/default.{fmt}
+  const m = String(imageUrl || '').match(/^(.*)\/[^/]+\/[^/]+\/[^/]+\/default\.(?:jpg|jpeg|png|webp)$/);
+  return m ? `${m[1]}/info.json` : null;
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+
+async function main() {
+  await client.connect();
+  const books = client.db('bookstore').collection('books');
+  const docs = await books.find({
+    content_type: 'artwork', visible: true,
+    $or: [{ commons_width: { $exists: false } }, { commons_width: null }],
+  }, { projection: { image_display: 1, thumbnail: 1, 'image_source.provider': 1 } }).toArray();
+
+  console.log(`${DRY_RUN ? 'DRY RUN — ' : ''}${docs.length} visible artworks without stored dimensions`);
+  let set = 0, noIiif = 0, errors = 0, n = 0;
+  const ops = [];
+
+  for (const d of docs) {
+    n++;
+    const info = infoJsonUrl(d.image_display) || infoJsonUrl(d.thumbnail);
+    if (!info) { noIiif++; continue; }
+    try {
+      const res = await fetch(info, { headers: { 'User-Agent': UA, 'Accept': 'application/json' }, signal: AbortSignal.timeout(15000) });
+      if (!res.ok) { errors++; continue; }
+      const j = await res.json();
+      if (j.width && j.height) {
+        ops.push({ updateOne: { filter: { _id: d._id }, update: { $set: { commons_width: j.width, commons_height: j.height, updated_at: new Date() } } } });
+        set++;
+      } else { errors++; }
+    } catch { errors++; }
+    if (n % 100 === 0) console.log(`  ${n}/${docs.length} set:${set} noIiif:${noIiif} err:${errors}`);
+    await sleep(150);
+  }
+
+  if (!DRY_RUN && ops.length) await books.bulkWrite(ops, { ordered: false });
+  console.log(`\nDONE. dims set:${set} | not IIIF-shaped:${noIiif} | errors:${errors}`);
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/upgrade-lowres-rijks-artworks.mjs
+++ b/scripts/maintenance/upgrade-lowres-rijks-artworks.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Targeted resolution upgrade for low-res Rijksmuseum artworks (~19 visible
+ * under 1200px). Keyless, via the Rijks linked-art chain (same as the
+ * importer): search?objectNumber → HumanMadeObject → shows → VisualItem →
+ * digitally_shown_by → DigitalObject → access_point IIIF → full-res download.
+ * Rehosts the artwork triplet in place and updates commons_width/height.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/upgrade-lowres-rijks-artworks.mjs [--dry-run]
+ */
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@sourcelibrary.org)';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const client = new MongoClient(process.env.MONGODB_URI);
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: process.env.R2_ACCESS_KEY_ID, secretAccessKey: process.env.R2_SECRET_ACCESS_KEY },
+});
+
+async function fetchJson(u) {
+  const r = await fetch(u, { headers: { 'User-Agent': UA, Accept: 'application/json' }, signal: AbortSignal.timeout(20000) });
+  if (!r.ok) return null;
+  return r.json();
+}
+
+async function resolveFullRes(objectNumber) {
+  const search = await fetchJson(`https://data.rijksmuseum.nl/search/collection?objectNumber=${encodeURIComponent(objectNumber)}`);
+  const objUrl = search?.orderedItems?.[0]?.id;
+  if (!objUrl) return null;
+  await sleep(100);
+  const obj = await fetchJson(objUrl);
+  const shows = Array.isArray(obj?.shows) ? obj.shows : [obj?.shows].filter(Boolean);
+  const viUrl = shows[0]?.id;
+  if (!viUrl) return null;
+  await sleep(100);
+  const vi = await fetchJson(viUrl);
+  const digi = Array.isArray(vi?.digitally_shown_by) ? vi.digitally_shown_by : [vi?.digitally_shown_by].filter(Boolean);
+  const digUrl = digi[0]?.id;
+  if (!digUrl) return null;
+  await sleep(100);
+  const dig = await fetchJson(digUrl);
+  const ap = Array.isArray(dig?.access_point) ? dig.access_point : [dig?.access_point].filter(Boolean);
+  return ap[0]?.id || null; // .../full/max/0/default.jpg
+}
+
+async function main() {
+  await client.connect();
+  const books = client.db('bookstore').collection('books');
+  const docs = await books.find({
+    content_type: 'artwork', visible: true,
+    'image_source.provider': 'rijksmuseum',
+    commons_width: { $lt: 1200 }, commons_height: { $lt: 1200 },
+  }, { projection: { title: 1, image_display: 1, commons_width: 1, commons_height: 1, 'image_source.identifier': 1 } }).toArray();
+
+  console.log(`${DRY_RUN ? 'DRY RUN — ' : ''}${docs.length} Rijks artworks under 1200px`);
+  let upgraded = 0, noBigger = 0, errors = 0;
+
+  for (const d of docs) {
+    const objectNumber = String(d.image_source?.identifier || '').replace(/^rijks-/, '');
+    const oldMax = Math.max(d.commons_width || 0, d.commons_height || 0);
+    const base = d.image_display?.match(/images\.sourcelibrary\.org\/artwork\/(.+?)(?:-full|-thumb)?\.jpg$/)?.[1];
+    const label = `${d.title?.slice(0, 45)} (${oldMax}px, ${objectNumber})`;
+    if (!objectNumber || !base) { errors++; console.log(`✗ ${label} — bad identifier/display`); continue; }
+    try {
+      const iiifUrl = await resolveFullRes(objectNumber);
+      if (!iiifUrl) { errors++; console.log(`✗ ${label} — no IIIF access point`); await sleep(200); continue; }
+      const imgRes = await fetch(iiifUrl, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(120000) });
+      if (!imgRes.ok) { errors++; console.log(`✗ ${label} — image ${imgRes.status}`); await sleep(200); continue; }
+      const buf = Buffer.from(await imgRes.arrayBuffer());
+      const meta = await sharp(buf).metadata();
+      const newMax = Math.max(meta.width || 0, meta.height || 0);
+      if (newMax < oldMax * 1.3) { noBigger++; console.log(`= ${label} — serves ${newMax}px`); await sleep(200); continue; }
+      if (DRY_RUN) { upgraded++; console.log(`↑ ${label} → ${meta.width}x${meta.height} [dry]`); await sleep(200); continue; }
+      const display = await sharp(buf).resize({ width: 3840, withoutEnlargement: true }).jpeg({ quality: 85, mozjpeg: true }).toBuffer();
+      const thumb = await sharp(buf).resize({ width: 600, withoutEnlargement: true }).jpeg({ quality: 80, mozjpeg: true }).toBuffer();
+      const full = await sharp(buf).jpeg({ quality: 92, mozjpeg: true }).toBuffer();
+      for (const [key, body] of [[`artwork/${base}.jpg`, display], [`artwork/${base}-thumb.jpg`, thumb], [`artwork/${base}-full.jpg`, full]]) {
+        await s3.send(new PutObjectCommand({ Bucket: process.env.R2_BUCKET_NAME, Key: key, Body: body, ContentType: 'image/jpeg', CacheControl: 'public, max-age=31536000, immutable' }));
+      }
+      await books.updateOne({ _id: d._id }, {
+        $set: { commons_width: meta.width, commons_height: meta.height, image_upgraded: true, image_upgraded_at: new Date(), image_upgrade_source: 'rijks_linked_art', updated_at: new Date() },
+        $unset: { low_res: '' },
+      });
+      upgraded++;
+      console.log(`↑ ${label} → ${meta.width}x${meta.height}`);
+    } catch (e) { errors++; console.log(`✗ ${label} — ${e.message?.slice(0, 60)}`); }
+    await sleep(200);
+  }
+  console.log(`\nDONE. upgraded:${upgraded} noBigger:${noBigger} errors:${errors} — purge Cloudflare after a live run.`);
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Final two scripts from the image sweep (scripts-only, no deploy):

1. **`backfill-iiif-artwork-dimensions.mjs`** — fills `commons_width/height` for ~514 artworks hosted on external IIIF (info.json). **Blocked for now on the 412 Leiden items**: Leiden's F5 IP-banned the Mac + Hetzner + cloud ASNs after today's harvest traffic. check-host.net confirms 6/6 global locations still serve HTTP 200 → **users unaffected**, the hot-linked images render fine. Re-run when the ban lifts. (Diagnosis lesson recorded: multi-location-check before declaring a third-party host down.)
2. **`upgrade-lowres-rijks-artworks.mjs`** — keyless Rijks upgrade via the linked-art chain. Definitive run result: all 19 sub-1200px Rijks prints are already at the max resolution the Rijksmuseum serves (877–1186px). Nothing to upgrade; script kept as the documented answer.

Also appended a Leiden-ban addendum to `.claude/handoffs/2026-06-03-leiden-iiif-indonesia-harvest.md` (the hot-linking fragility + rehost-to-R2 recommendation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)