### PR TITLE
fix(thumbnails): null-bbox guard + skip COLLSCAN count in apply mode

### DIFF
--- a/scripts/workers/generate-thumbnails.mjs
+++ b/scripts/workers/generate-thumbnails.mjs
@@ -209,10 +209,14 @@ async function main() {
     matchFilter.book_id = BOOK_ID;
   }
 
-  const totalNeeding = await pagesCol.countDocuments(matchFilter);
-  console.log(`\nPages needing thumbnail generation: ${totalNeeding}`);
-
+  // countDocuments(matchFilter) is a full COLLSCAN over the pages collection
+  // (the $elemMatch on detected_images isn't indexed) and at backlog scale
+  // (tens of thousands matching) it can take many minutes — pointless to pay
+  // in apply mode where it's only an informational log. The limited find below
+  // stops early once it hits LIMIT matches, so skip the count unless dry-run.
   if (DRY_RUN) {
+    const totalNeeding = await pagesCol.countDocuments(matchFilter);
+    console.log(`\nPages needing thumbnail generation: ${totalNeeding}`);
     // Count individual detections
     const detectionCount = await pagesCol.aggregate([
       { $match: matchFilter },
@@ -252,7 +256,7 @@ async function main() {
 
     for (let idx = 0; idx < (page.detected_images || []).length; idx++) {
       const det = page.detected_images[idx];
-      if (!det.bbox) continue;
+      if (!det || !det.bbox) continue;
       if (det.extracted_url) continue; // already has thumbnail
       if (!['vision_model', 'manual', 'ocr_tag'].includes(det.detection_source)) continue;
       if (MIN_QUALITY > 0 && (det.gallery_quality || 0) < MIN_QUALITY) continue;


### PR DESCRIPTION
Two fixes for `scripts/workers/generate-thumbnails.mjs`, found running it against the 46.8K missing-gallery-thumbnail backlog (related to #2401):

1. **Null `detected_images` entry crashed the worker** — `TypeError: Cannot read properties of null (reading 'bbox')`. Some BPH pages have null array entries. Guard with `!det || !det.bbox`.

2. **`countDocuments(matchFilter)` blocked the worker for minutes before any work.** It's an unindexed full COLLSCAN of the pages collection ($elemMatch on `detected_images`), yet only feeds an informational log. Now run dry-run only; apply mode goes straight to the limited `find`, which stops early at `LIMIT` matches.

With these, bounded `--limit=4000` batches process at ~9.5 detections/s instead of hanging on a single load-all-46K pass. The backlog is being cleared now via a looped driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)