### PR TITLE
fix(likes): hearts don't persist — 404 for tenantless targets + image id parsing

### DIFF
--- a/src/app/api/[tenant]/likes/route.ts
+++ b/src/app/api/[tenant]/likes/route.ts
@@ -45,14 +45,19 @@ export async function POST(
     }
 
     const db = await getDb();
-    const filter = { target_type, target_id, visitor_id, tenantId };
+    // Toggle key matches the unique index (target_type, target_id,
+    // visitor_id) — tenantId is scoping metadata, not part of a like's
+    // identity. Including it in the delete filter would miss a like the same
+    // visitor filed from a global URL (tenantId: null) and then hit a
+    // duplicate-key error on insert.
+    const filter = { target_type, target_id, visitor_id };
 
     // Atomic toggle: try delete first. If no deletion occurred, insert new like.
     const deleted = await db.collection('likes').deleteOne(filter);
     const liked = deleted.deletedCount === 0;
 
     if (liked) {
-      await db.collection('likes').insertOne({ ...filter, created_at: new Date() });
+      await db.collection('likes').insertOne({ ...filter, tenantId, created_at: new Date() });
     }
 
     const count = await db.collection('likes').countDocuments({

--- a/src/app/api/likes/route.ts
+++ b/src/app/api/likes/route.ts
@@ -12,50 +12,51 @@ import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { LikeTargetType } from '@/lib/types';
 
 /**
- * Resolve the tenantId that a like for this target should be filed under.
+ * Resolve the like target: does it exist, and which tenantId (if any) should
+ * the like be filed under?
  *
  * Toggle requests come in from many surfaces: tenant subdomains, /[tenant]/...
  * paths, and (most often) global URLs like /book/{slug}, /favorites, and
  * /gallery/image/{id}. The proxy can only attach a tenant header for the first
- * two. For the rest, we fall back to looking up the target's own tenantId —
- * books, pages, and gallery images all carry one. This keeps likes correctly
- * scoped without relying on the request path.
+ * two. For the rest, we look up the target's own tenantId. Most books and
+ * pages have NO tenantId (only tenant-promoted content gets backfilled), so a
+ * missing tenantId is normal — the like is stored with `tenantId: null` and
+ * still counts on global surfaces. Only a target that doesn't exist at all is
+ * rejected.
  */
-async function resolveTargetTenantId(
+async function resolveTarget(
   db: Awaited<ReturnType<typeof getDb>>,
   targetType: LikeTargetType,
   targetId: string
-): Promise<string | null> {
+): Promise<{ found: boolean; tenantId: string | null }> {
   try {
     if (targetType === 'book') {
       const book = await db.collection('books').findOne(
         { $or: [{ id: targetId }, { slug: targetId }] },
         { projection: { tenantId: 1 } }
       );
-      return (book?.tenantId as string) || null;
+      return { found: !!book, tenantId: (book?.tenantId as string) || null };
     }
-    if (targetType === 'page') {
-      const page = await db.collection('pages').findOne(
-        { id: targetId },
-        { projection: { tenantId: 1 } }
-      );
-      return (page?.tenantId as string) || null;
-    }
-    if (targetType === 'image') {
-      // Image targetIds are `{pageId}:{detectionIndex}` — the tenant lives on
-      // the parent page.
-      const pageId = targetId.split(':')[0] || targetId.split('-').slice(0, -1).join('-');
-      if (!pageId) return null;
+    if (targetType === 'page' || targetType === 'image') {
+      // Image targetIds are `{pageId}-{detectionIndex}` (current UI) or
+      // legacy `{pageId}:{detectionIndex}` — the tenant lives on the parent
+      // page either way.
+      const pageId = targetType === 'page'
+        ? targetId
+        : targetId.includes(':')
+          ? targetId.split(':')[0]
+          : targetId.replace(/-\d+$/, '');
+      if (!pageId) return { found: false, tenantId: null };
       const page = await db.collection('pages').findOne(
         { id: pageId },
         { projection: { tenantId: 1 } }
       );
-      return (page?.tenantId as string) || null;
+      return { found: !!page, tenantId: (page?.tenantId as string) || null };
     }
   } catch {
-    // Lookup failures fall through to null — the caller decides what to do.
+    // Lookup failures fall through — the caller decides what to do.
   }
-  return null;
+  return { found: false, tenantId: null };
 }
 
 /**
@@ -98,32 +99,42 @@ export async function POST(request: NextRequest) {
     const db = await getDb();
 
     // Prefer the tenant header attached by the proxy; fall back to the
-    // target's own tenantId for likes initiated from non-tenant URLs.
-    let tenantId = getTenantContextFromRequest(request).id;
+    // target's own tenantId for likes initiated from non-tenant URLs. A
+    // target without a tenantId is the common case (most books/pages aren't
+    // tenant-promoted) — the like is stored with tenantId: null. Only reject
+    // when the target doesn't exist at all.
+    const requestTenantId = getTenantContextFromRequest(request).id;
+    let tenantId: string | null = requestTenantId;
     if (!tenantId) {
-      tenantId = await resolveTargetTenantId(db, target_type as LikeTargetType, target_id);
-    }
-    if (!tenantId) {
-      return NextResponse.json(
-        { error: 'Target not found' },
-        { status: 404 }
-      );
+      const target = await resolveTarget(db, target_type as LikeTargetType, target_id);
+      if (!target.found) {
+        return NextResponse.json(
+          { error: 'Target not found' },
+          { status: 404 }
+        );
+      }
+      tenantId = target.tenantId;
     }
 
-    const filter = { target_type, target_id, visitor_id, tenantId };
+    // Toggle key matches the unique index (target_type, target_id,
+    // visitor_id) — tenantId is scoping metadata, not part of the identity of
+    // a like, so un-liking works regardless of which surface filed the like.
+    const filter = { target_type, target_id, visitor_id };
 
     // Atomic toggle: try to delete first — if nothing was deleted, insert
     const deleted = await db.collection('likes').deleteOne(filter);
     const liked = deleted.deletedCount === 0;
 
     if (liked) {
-      await db.collection('likes').insertOne({ ...filter, created_at: new Date() });
+      await db.collection('likes').insertOne({ ...filter, tenantId, created_at: new Date() });
     }
 
+    // Count semantics mirror GET: scope to the tenant only when the request
+    // itself carries a tenant header; global surfaces count across tenants.
     const count = await db.collection('likes').countDocuments({
       target_type,
       target_id,
-      tenantId,
+      ...(requestTenantId ? { tenantId: requestTenantId } : {}),
     });
 
     // Cascade: liking a page also likes the parent book
@@ -131,7 +142,7 @@ export async function POST(request: NextRequest) {
     if (target_type === 'page' && liked) {
       try {
         const page = await db.collection('pages').findOne(
-          { id: target_id, tenantId },
+          { id: target_id },
           { projection: { book_id: 1 } }
         );
         if (page?.book_id) {
@@ -151,7 +162,7 @@ export async function POST(request: NextRequest) {
           const bookCount = await db.collection('likes').countDocuments({
             target_type: 'book',
             target_id: page.book_id,
-            tenantId,
+            ...(requestTenantId ? { tenantId: requestTenantId } : {}),
           });
           cascade = { book_id: page.book_id, book_liked: true, book_count: bookCount };
         }


### PR DESCRIPTION
## Why
Hearts on gallery images (and most books) don't stay: the button fills optimistically, the POST 404s, and the UI reverts. Broken since #1691 (May 11).

## Root causes
1. **Image id parsing bug**: image targetIds are `{pageId}-{detectionIndex}`, but `resolveTargetTenantId` did `targetId.split(':')[0] || <hyphen fallback>` — `split(':')` on a hyphen-format id returns the whole string (truthy), so the fallback never ran and the page lookup always missed → 404 for **every** image like from a global URL.
2. **Tenantless content rejected**: only ~5.5K of ~48K books are tenant-promoted; pages of newer imports carry no `tenantId` either. `POST /api/likes` treated "no tenantId" as "target not found" → 404 for book/page/image likes on ~89% of the catalog.

Verified against prod before fixing: `POST /api/likes` with a real gallery image id and a real (tenantless) book id both returned `404 Target not found`.

## Fix
- Resolve target **existence** and **tenantId** separately (`resolveTarget`). Only a genuinely missing target 404s; tenantless targets store the like with `tenantId: null`. Global GET (no tenant header) already counts across tenants, so these likes surface correctly.
- Parse both image id formats (`pageId-idx` current UI, `pageId:idx` legacy).
- Align the toggle delete-filter with the unique index `(target_type, target_id, visitor_id)` in **both** `/api/likes` and `/api/[tenant]/likes` — tenantId stays as scoping metadata on insert. Previously a like filed under one tenantId couldn't be un-liked from a surface that resolved a different one, and re-liking would hit the unique index (500).
- Count semantics now mirror GET: tenant-scoped only when the request carries a tenant header.

## Out of scope
- `/gallery/image/[id]` doesn't pass `initialCount`/`initialLiked` to LikeButton (it self-fetches via GET, which works) — cosmetic, separate change if wanted.
- Tenant-scoped GET won't show likes filed under `tenantId: null` on subdomains — deliberate, consistent with reading-room scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)