### PR TITLE
fix(thumbnails): require source image in generator match filter (unstall backlog loop)

### DIFF
--- a/scripts/workers/generate-thumbnails.mjs
+++ b/scripts/workers/generate-thumbnails.mjs
@@ -202,6 +202,18 @@ async function main() {
     },
   };
 
+  // Require a source image to crop from. Pages with no archived/cropped/photo
+  // can't be thumbnailed — the work-item loop skips them — but without this
+  // they still match the filter and re-appear in every `--limit` batch, so a
+  // front cluster of source-less pages stalls the batch loop before it reaches
+  // processable pages further back (and the loop never terminates).
+  matchFilter.$or = [
+    { archived_photo: { $ne: null } },
+    { cropped_photo: { $ne: null } },
+    { photo_original: { $ne: null } },
+    { photo: { $ne: null } },
+  ];
+
   if (ARCHIVED_ONLY) {
     matchFilter.archived_photo = { $exists: true, $ne: '' };
   }


### PR DESCRIPTION
Follow-up to #2404. When clearing the gallery-thumbnail backlog in `--limit` batches, the loop stalled: each batch kept re-fetching the same front cluster of pages that **match the filter** (a detection needs a thumbnail) but have **no `archived`/`cropped`/`photo` source** to crop from. The work-item loop skips them, so they never get `extracted_url` and re-match every batch — blocking the loop from reaching processable pages and from terminating. (~17K of ~64K generated before this surfaced.)

Fix: add a source-exists `$or` to `matchFilter`, so source-less pages don't match. Batches now advance and the loop terminates when the processable backlog is clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)