### PR TITLE
feat(views): durable first-party view counters for gallery images

### DIFF
--- a/src/app/api/gallery/image/[id]/route.ts
+++ b/src/app/api/gallery/image/[id]/route.ts
@@ -300,6 +300,13 @@ export async function GET(
     // wrong side of a spread. extracted_url is the authoritative crop.
     const croppedUrl = detection.extracted_url || detection.hires_url || cropUrl || imageUrl;
 
+    // Durable first-party view counter (written by POST /api/views; keyed the
+    // same hyphen-form id as likes)
+    const viewsDoc = await db.collection('views').findOne(
+      { target_type: 'image', target_id: `${pageId}-${detectionIndex}` },
+      { projection: { count: 1 } }
+    );
+
     // Build the response
     const response = {
       // Identity
@@ -328,6 +335,9 @@ export async function GET(
       galleryQuality: detection.gallery_quality ?? null,
       galleryRationale: detection.gallery_rationale ?? null,
       featured: detection.featured ?? false,
+
+      // Engagement
+      viewCount: viewsDoc?.count ?? 0,
 
       // Rich metadata
       metadata: detection.metadata ?? null,

--- a/src/app/api/views/route.ts
+++ b/src/app/api/views/route.ts
@@ -1,0 +1,166 @@
+/**
+ * Views API — durable first-party view counters.
+ *
+ * POST /api/views - Record a view (fire-and-forget beacon from the client)
+ * GET  /api/views - Get view counts for a batch of targets
+ *
+ * Why this exists: the only per-item view signals were GA `view_item` events
+ * (consent-gated, captures almost nothing) and `analytics_pageviews`
+ * (path-level, 90-day TTL, misses in-lightbox navigation). This collection
+ * keeps a tiny permanent counter per target so "most viewed" is a real,
+ * queryable thing — same target keying as the likes system.
+ *
+ * Storage: `views` collection, one doc per target:
+ *   { target_type, target_id, count, created_at, updated_at }
+ * Index (created 2026-06-03): unique on (target_type, target_id).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { anonymizeIp } from '@/lib/anonymize-ip';
+import { classifyTraffic } from '@/lib/traffic-classification';
+
+const VALID_TYPES = ['image', 'page', 'book'] as const;
+const TARGET_ID_RE = /^[\w:.-]{1,128}$/;
+
+// Same in-memory dedup pattern as /api/track: don't double-count the same
+// visitor hammering the same target within the window (reloads, re-renders).
+// Per-serverless-instance, which is good enough for a counter.
+const recentHits = new Map<string, number>();
+const DEDUP_WINDOW_MS = 60_000;
+let lastCleanup = Date.now();
+
+function isDuplicate(ip: string, target: string): boolean {
+  const now = Date.now();
+  if (now - lastCleanup > DEDUP_WINDOW_MS) {
+    lastCleanup = now;
+    for (const [key, ts] of recentHits) {
+      if (now - ts > DEDUP_WINDOW_MS) recentHits.delete(key);
+    }
+  }
+  const key = `${ip}:${target}`;
+  const lastHit = recentHits.get(key);
+  if (lastHit && now - lastHit < DEDUP_WINDOW_MS) return true;
+  recentHits.set(key, now);
+  return false;
+}
+
+/**
+ * Image targetIds come in `{pageId}-{detectionIndex}` (current UI) and legacy
+ * `{pageId}:{detectionIndex}` forms — normalize to the hyphen form so both
+ * spellings increment the same counter. Matches the gallery URL shape.
+ */
+function normalizeTargetId(targetType: string, targetId: string): string {
+  if (targetType === 'image') return targetId.replace(':', '-');
+  return targetId;
+}
+
+// Views are non-critical — never hold a serverless slot on a slow DB.
+const DB_TIMEOUT_MS = 3000;
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { target_type } = body;
+    const target_id = typeof body.target_id === 'string'
+      ? normalizeTargetId(target_type, body.target_id)
+      : null;
+
+    if (!VALID_TYPES.includes(target_type) || !target_id || !TARGET_ID_RE.test(target_id)) {
+      return NextResponse.json({ success: true });
+    }
+
+    // Bot filter — same Cloudflare signals as /api/track. Scrapers must not
+    // inflate counters.
+    const ua = request.headers.get('user-agent') || '';
+    const cfVerifiedBot = request.headers.get('cf-verified-bot') === 'true';
+    const cfThreat = parseInt(request.headers.get('cf-threat-score') || '', 10);
+    const cls = classifyTraffic(ua, {
+      verifiedBot: cfVerifiedBot,
+      threatScore: Number.isFinite(cfThreat) ? cfThreat : undefined,
+    });
+    if (cls !== 'human') {
+      return NextResponse.json({ success: true });
+    }
+
+    const rawIp = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const ip = anonymizeIp(rawIp);
+    if (isDuplicate(ip, `${target_type}:${target_id}`)) {
+      return NextResponse.json({ success: true });
+    }
+
+    const dbWrite = (async () => {
+      const db = await getDb();
+      await db.collection('views').updateOne(
+        { target_type, target_id },
+        {
+          $inc: { count: 1 },
+          $set: { updated_at: new Date() },
+          $setOnInsert: { created_at: new Date() },
+        },
+        { upsert: true }
+      );
+    })();
+    const timeout = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), DB_TIMEOUT_MS)
+    );
+    await Promise.race([dbWrite, timeout]);
+
+    return NextResponse.json({ success: true });
+  } catch {
+    // Analytics must never error to the client
+    return NextResponse.json({ success: true });
+  }
+}
+
+/**
+ * GET /api/views?targets=[{"type":"image","id":"abc-0"}]
+ *
+ * Batch view counts, same request/response shape as GET /api/likes:
+ * { results: { "image:abc-0": { count: 12 } } }
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const targetsJson = searchParams.get('targets');
+    if (!targetsJson) {
+      return NextResponse.json({ error: 'targets parameter is required' }, { status: 400 });
+    }
+
+    let targets: Array<{ type: string; id: string }>;
+    try {
+      targets = JSON.parse(targetsJson);
+    } catch {
+      return NextResponse.json({ error: 'Invalid targets JSON' }, { status: 400 });
+    }
+    if (!Array.isArray(targets) || targets.length === 0) {
+      return NextResponse.json({ results: {} });
+    }
+    targets = targets.slice(0, 100)
+      .filter(t => VALID_TYPES.includes(t.type as typeof VALID_TYPES[number]) && typeof t.id === 'string')
+      .map(t => ({ type: t.type, id: normalizeTargetId(t.type, t.id) }));
+
+    const db = await getDb();
+    const docs = await db.collection('views').find({
+      $or: targets.map(t => ({ target_type: t.type, target_id: t.id })),
+    }, { projection: { target_type: 1, target_id: 1, count: 1 } }).toArray();
+
+    const results: Record<string, { count: number }> = {};
+    for (const t of targets) {
+      results[`${t.type}:${t.id}`] = { count: 0 };
+    }
+    for (const d of docs) {
+      const key = `${d.target_type}:${d.target_id}`;
+      if (results[key]) results[key].count = d.count || 0;
+    }
+
+    return NextResponse.json({ results }, {
+      headers: { 'Cache-Control': 'public, max-age=60, stale-while-revalidate=300' },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to get views' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/gallery/image/[id]/page.tsx
+++ b/src/app/gallery/image/[id]/page.tsx
@@ -26,12 +26,13 @@ import {
   ChevronLeft,
   ChevronRight,
   Download,
-  Loader2
+  Loader2,
+  Eye
 } from 'lucide-react';
 import ImageWithMagnifier from '@/components/ui/ImageWithMagnifier';
 import LikeButton from '@/components/ui/LikeButton';
 import { BookLoader } from '@/components/ui/BookLoader';
-import { gallery } from '@/lib/api-client';
+import { gallery, views } from '@/lib/api-client';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import type { GalleryImageDetail, GalleryItem, ImageMetadata } from '@/lib/api-client';
 import SimilarImages from '@/components/gallery/SimilarImages';
@@ -161,6 +162,7 @@ export default function ImageDetailPage({
         preload.onerror = () => requestAnimationFrame(() => setImageOpacity(1));
         preload.src = json.imageUrl;
         sendGAEvent({ action: 'view_item', category: 'gallery', label: imageId!, content_type: 'image' });
+        views.record('image', imageId!);
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Failed to load');
       } finally {
@@ -361,6 +363,7 @@ export default function ImageDetailPage({
       setImageId(imgId);
       setData(json);
       sendGAEvent({ action: 'view_item', category: 'gallery', label: imgId, content_type: 'image' });
+      views.record('image', imgId);
       requestAnimationFrame(() => setImageOpacity(1));
     } catch {
       // On error, fade back in with old content
@@ -733,6 +736,15 @@ export default function ImageDetailPage({
             )}
 
             <div className="flex items-center gap-1 flex-shrink-0 overflow-x-auto">
+              {(data?.viewCount ?? 0) > 0 && (
+                <span
+                  className="hidden sm:inline-flex items-center gap-1 px-1.5 text-sm text-stone-500 tabular-nums flex-shrink-0"
+                  title={`${data!.viewCount!.toLocaleString()} views`}
+                >
+                  <Eye className="w-4 h-4" />
+                  {data!.viewCount!.toLocaleString()}
+                </span>
+              )}
               {imageId && (
                 <div className="p-1.5 rounded-lg hover:bg-white/10 transition-colors flex-shrink-0">
                   <LikeButton

--- a/src/lib/api-client/index.ts
+++ b/src/lib/api-client/index.ts
@@ -49,6 +49,7 @@ export * from './prompts';
 export * from './qa';
 export * from './queues';
 export * from './research'; // Client-safe API wrappers only
+export * from './views';
 export * from './search';
 export * from './social';
 export * from './email';

--- a/src/lib/api-client/types/gallery.ts
+++ b/src/lib/api-client/types/gallery.ts
@@ -131,6 +131,7 @@ export interface GalleryImageDetail {
   galleryQuality?: number | null;
   galleryRationale?: string | null;
   featured?: boolean;
+  viewCount?: number;
   metadata?: ImageMetadata | null;
   museumDescription?: string | null;
   bbox?: BBox;

--- a/src/lib/api-client/views.ts
+++ b/src/lib/api-client/views.ts
@@ -1,0 +1,26 @@
+import { apiClient } from './client';
+import type { LikeTargetType } from '@/lib/types';
+
+/**
+ * Views API client — durable first-party view counters (see /api/views).
+ *
+ * `record` is fire-and-forget via sendBeacon so it never blocks navigation
+ * and survives the page unloading mid-request (same pattern as
+ * reading-history). Server handles bot filtering and dedup.
+ */
+export const views = {
+  record: (targetType: LikeTargetType, targetId: string) => {
+    if (typeof navigator === 'undefined' || !navigator.sendBeacon) return;
+    const payload = JSON.stringify({ target_type: targetType, target_id: targetId });
+    navigator.sendBeacon('/api/views', new Blob([payload], { type: 'application/json' }));
+  },
+
+  /**
+   * Batch view counts: { results: { "image:abc-0": { count: 12 } } }
+   */
+  getCounts: async (
+    targets: Array<{ type: LikeTargetType; id: string }>
+  ): Promise<{ results: Record<string, { count: number }> }> => {
+    return await apiClient.get(`/api/views?targets=${encodeURIComponent(JSON.stringify(targets))}`);
+  },
+};


### PR DESCRIPTION
## Why
"Do we record views clearly?" — no. Per-image view signals were: GA `view_item` events (consent-gated → captures almost nothing) and `analytics_pageviews` (path-level, 90-day TTL, and in-lightbox navigation between images never logs because the viewer uses `replaceState`). There was no durable, queryable per-image view count.

## What
- **`POST /api/views`** — fire-and-forget beacon. Bot-filtered (`classifyTraffic` + Cloudflare verified-bot/threat headers), 60s per-IP+target dedup, then `$inc` upsert into a new `views` Mongo collection keyed `(target_type, target_id)` — the same target keying as the likes system (`image` ids normalized to the `{pageId}-{idx}` hyphen form). Always returns 200; 3s DB timeout race so analytics never holds a serverless slot.
- **`GET /api/views?targets=[...]`** — batch counts, same request/response shape as `GET /api/likes`.
- **Client**: `views.record(type, id)` via `navigator.sendBeacon` (same pattern as reading-history), fired from the gallery image viewer on initial load **and** on lightbox navigation — each image actually viewed gets counted, fixing the undercount the path-level tracker can't see.
- **Display**: gallery image detail API now returns `viewCount`; the viewer header shows a subtle eye + count next to the heart (only when > 0, sm+ screens).

## Ops
Unique index `views_target_idx` on `(target_type, target_id)` already created on Atlas `bookstore.views` (2026-06-03).

## Out of scope
- Book/page view counters (the API accepts those types, but nothing fires beacons for them yet — books already have `reading_history` for logged-in users).
- Sorting the gallery by views / "most viewed" surfaces — trivial to add later on top of the `views` collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)