### PR TITLE
fix(quote-api): strip editorial annotation blocks from quotable text

### DIFF
--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -3,6 +3,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { markForExport } from '@/lib/provenance';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { resolveTenantId } from '@/lib/tenant-context';
 
@@ -200,7 +201,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
     // Build response
     const response: QuoteResponse = {
       quote: {
-        translation: markForExport(page.translation.data, book.id),
+        // Editorial annotation blocks (<meta>/<summary>/… and the OCR page
+        // envelope) describe the page — they are never verbatim source text
+        // and must not be served as quotable content (PR #2232).
+        translation: markForExport(stripEditorialWrappers(page.translation.data).trim(), book.id),
         page: pageNumber,
         book_id: book.id,
         book_title: book.title,
@@ -220,7 +224,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     // Include original text if requested
     if (includeOriginal && page.ocr?.data) {
-      response.quote.original = page.ocr.data;
+      response.quote.original = stripEditorialWrappers(page.ocr.data).trim();
     }
 
     // Include context (adjacent pages) if requested
@@ -241,8 +245,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
       const prevText = (prevPage as unknown as Page | null)?.translation?.data;
       const nextText = (nextPage as unknown as Page | null)?.translation?.data;
       response.context = {
-        previous_page: prevText ? markForExport(prevText, book.id) : undefined,
-        next_page: nextText ? markForExport(nextText, book.id) : undefined,
+        previous_page: prevText ? markForExport(stripEditorialWrappers(prevText).trim(), book.id) : undefined,
+        next_page: nextText ? markForExport(stripEditorialWrappers(nextText).trim(), book.id) : undefined,
       };
     }
 

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -3,6 +3,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { markForExport } from '@/lib/provenance';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { withApiAuth } from '@/lib/api-auth';
 
@@ -194,7 +195,10 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
     // Build response
     const response: QuoteResponse = {
       quote: {
-        translation: markForExport(page.translation.data, book.id),
+        // Editorial annotation blocks (<meta>/<summary>/… and the OCR page
+        // envelope) describe the page — they are never verbatim source text
+        // and must not be served as quotable content (PR #2232).
+        translation: markForExport(stripEditorialWrappers(page.translation.data).trim(), book.id),
         page: pageNumber,
         book_id: book.id,
         book_title: book.title,
@@ -214,7 +218,7 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
 
     // Include original text if requested
     if (includeOriginal && page.ocr?.data) {
-      response.quote.original = page.ocr.data;
+      response.quote.original = stripEditorialWrappers(page.ocr.data).trim();
     }
 
     // Include context (adjacent pages) if requested
@@ -233,8 +237,8 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
       const prevText = (prevPage as unknown as Page | null)?.translation?.data;
       const nextText = (nextPage as unknown as Page | null)?.translation?.data;
       response.context = {
-        previous_page: prevText ? markForExport(prevText, book.id) : undefined,
-        next_page: nextText ? markForExport(nextText, book.id) : undefined,
+        previous_page: prevText ? markForExport(stripEditorialWrappers(prevText).trim(), book.id) : undefined,
+        next_page: nextText ? markForExport(stripEditorialWrappers(nextText).trim(), book.id) : undefined,
       };
     }
 


### PR DESCRIPTION
## What

The documented citation endpoint `GET /api/books/[id]/quote?page=N` (and the tenant variant `/api/[tenant]/books/[id]/quote`) served raw `pages.translation.data` as the quotable "translation" — including the AI-written editorial annotation blocks (`<meta>`/`<summary>`/`<keywords>`/`<vocab>`). Confirmed live during tonight's pre-launch audit: a page-1 quote returned `<meta>The spine of the volume bears the fragmentary text …</meta>` as the quoted text.

This is the exact leak class CLAUDE.md flags as CRITICAL ("mercury on page 89", PRs #2232/#2233) — editorial blocks describe the page (often naming adjacent-page content) and are never verbatim source. This surface was missed in the #2232 sweep.

## Fix

Route all three text paths in both routes through `stripEditorialWrappers()` (strips both wrapper families, content and all) + `.trim()` before `markForExport`:
- `quote.translation`
- `quote.original` (OCR-side page-level envelope tags)
- `context.previous_page` / `context.next_page`

Inline glosses (`<note>`/`<term>`/…) and real page marks are intentionally untouched, per the strip lib's contract.

## Out of scope

- Stored-artifact cleanup (snippet column / embeddings) — already handled by #2232's backfill; this is a read-path-only surface.
- The soft-404 on garbage book slugs and the BPH /terms robots.txt absolute link (other audit findings) — separate trivial fixes.

## Testing

- `npx tsc --noEmit` clean
- `tests/unit/strip-editorial-wrappers.test.ts` 9/9 pass
- Verified the leak live on prod before the fix; after merge+deploy, `/api/books/<id>/quote?page=1` on an affected book should return body text only

🤖 Generated with [Claude Code](https://claude.com/claude-code)