### PR TITLE
feat(collections): inline markdown links in exhibition copy

### DIFF
--- a/src/components/collections/ExhibitionLayout.tsx
+++ b/src/components/collections/ExhibitionLayout.tsx
@@ -134,6 +134,54 @@ function linkBookNames(text: string, books: BookRef[]): React.ReactNode {
   return <>{parts}</>;
 }
 
+/**
+ * Renders curated text with inline markdown-style links: `[label](href)`.
+ * Internal hrefs (starting with `/`) become Next links and stay relative,
+ * so they resolve on tenant subdomains too (see CLAUDE.md, Tenant Subdomain
+ * Lockdown). External hrefs open in a new tab. Plain-text segments still get
+ * automatic book-title linking via linkBookNames.
+ *
+ * Lets exhibition copy cite sources directly: quote → `/book/<id>?page=N`,
+ * illustration → `/gallery/image/<id>`.
+ */
+function renderRichText(text: string, books: BookRef[]): React.ReactNode {
+  const re = /\[([^\]]+)\]\(([^)\s]+)\)/g;
+  const parts: React.ReactNode[] = [];
+  let lastIdx = 0;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const [full, label, href] = match;
+    if (match.index > lastIdx) {
+      parts.push(
+        <React.Fragment key={`t-${lastIdx}`}>
+          {linkBookNames(text.slice(lastIdx, match.index), books)}
+        </React.Fragment>
+      );
+    }
+    parts.push(
+      href.startsWith('/') ? (
+        <Link key={`l-${match.index}`} href={href} className="text-accent-rust hover:underline">
+          {label}
+        </Link>
+      ) : (
+        <a key={`l-${match.index}`} href={href} target="_blank" rel="noopener noreferrer" className="text-accent-rust hover:underline">
+          {label}
+        </a>
+      )
+    );
+    lastIdx = match.index + full.length;
+  }
+  if (parts.length === 0) return linkBookNames(text, books);
+  if (lastIdx < text.length) {
+    parts.push(
+      <React.Fragment key={`t-${lastIdx}`}>
+        {linkBookNames(text.slice(lastIdx), books)}
+      </React.Fragment>
+    );
+  }
+  return <>{parts}</>;
+}
+
 // ─── Component: Hook ────────────────────────────────────────────
 
 function HookBlock({ text, attribution }: { text: string; attribution?: string }) {
@@ -193,7 +241,7 @@ function SectionsBlock({ sections, books }: {
                 <span className="text-sm text-muted whitespace-nowrap">{section.period}</span>
               )}
             </div>
-            <p className="text-secondary leading-relaxed max-w-3xl">{section.description}</p>
+            <p className="text-secondary leading-relaxed max-w-3xl">{renderRichText(section.description || '', books)}</p>
           </div>
 
           <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
@@ -576,7 +624,7 @@ function ThematicGalleryBlock({ clusters, books }: {
               {cluster.theme}
             </h3>
             {cluster.description && (
-              <p className="text-sm text-muted mb-4">{linkBookNames(cluster.description, books)}</p>
+              <p className="text-sm text-muted mb-4">{renderRichText(cluster.description, books)}</p>
             )}
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
               {/* Hero image — spans 2 cols on desktop */}
@@ -741,7 +789,7 @@ export default function ExhibitionLayout({ layout, books, images, collectionSlug
               <div key={i} className="max-w-3xl">
                 {(block.paragraphs || []).map((p: string, pi: number) => (
                   <p key={pi} className="text-secondary text-lg leading-relaxed mb-4 last:mb-0 font-body">
-                    {linkBookNames(p, books)}
+                    {renderRichText(p, books)}
                   </p>
                 ))}
               </div>


### PR DESCRIPTION
## What
Adds `renderRichText()` to `ExhibitionLayout`: curated exhibition text now supports inline markdown-style links `[label](href)` in:
- `description` block paragraphs
- `sections[].description`
- `thematic_gallery` cluster descriptions

Internal hrefs (`/book/...`, `/gallery/image/...`) render as relative Next `<Link>`s — tenant-subdomain safe per the lockdown invariant (no absolute sourcelibrary.org hrefs). External hrefs render as `<a target=_blank rel=noopener>`. Plain-text segments still pass through the existing `linkBookNames` auto-linker.

## Why
Curated collection copy quotes primary sources (e.g. Aldus's 1495 dedication on the Aldine Press page). A quote in running prose had no way to cite its source page; illustrations mentioned in prose couldn't link to their gallery page. With this, content drafts can write `[quoted words](/book/<id>?page=8)` and `[the woodcut map of Hell](/gallery/image/<id>)`.

## Out of scope
- Reading-path `instruction` and timeline `label` strings stay plain text (each step/highlight already links its book).
- The non-exhibition overview description path (`linkBookTitles` in the page) is unchanged — `expanded_description` also feeds JSON-LD/meta where raw markdown would leak.

First consumer: the Aldine Press collection exhibition (content in `curation_drafts`, updated separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)