### PR TITLE
feat(reader): historical-translation notice with link to held original (#2395)

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -23,6 +23,7 @@ import CoverImagePicker from '@/components/book/CoverImagePicker';
 import DownloadButton from '@/components/ui/DownloadButton';
 import BibliographicInfo from '@/components/book/BibliographicInfo';
 import BphCatalogueRecord from '@/components/book/BphCatalogueRecord';
+import OriginalEditionNotice from '@/components/book/OriginalEditionNotice';
 import RelatedEditions from '@/components/book/RelatedEditions';
 import IndexCatalogChip from '@/components/book/IndexCatalogChip';
 import RelatedBooks from '@/components/book/RelatedBooks';
@@ -902,6 +903,22 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed
               <div className="mt-3">
                 <BookDedication bookId={book.id} dedication={(book as any).dedication || null} />
               </div>
+
+              {/* Historical-translation notice — never let an old English
+                  translation silently present as the source (#2395). Cross-link
+                  to the held original is tenant-gated like RelatedEditions. */}
+              {['modern-translation', 'period-translation'].includes((book as any).text_role) && (
+                <Suspense fallback={null}>
+                  <OriginalEditionNotice
+                    textRole={(book as any).text_role}
+                    originalEditionId={(book as any).original_edition_id ?? null}
+                    originalInScan={(book as any).original_in_scan ?? false}
+                    originalLanguage={(book as any).original_language ?? null}
+                    year={Number((book as any).year || book.published) || null}
+                    showCrossLink={embedPolicy.showRelatedEditions}
+                  />
+                </Suspense>
+              )}
 
               {/* Read This Book — first chapter > endpaper-skip fallback */}
               {embedPolicy.showBookReadCta && (() => {

--- a/src/components/book/OriginalEditionNotice.tsx
+++ b/src/components/book/OriginalEditionNotice.tsx
@@ -1,0 +1,83 @@
+import { getReadDb } from '@/lib/mongodb';
+import Link from 'next/link';
+import { ScrollText } from 'lucide-react';
+
+/**
+ * Reader-orienting notice for books that are themselves historical English
+ * translations (text_role: modern-translation | period-translation), so an
+ * old translation never silently presents as the source. See issue #2395.
+ *
+ * Three states, driven by the linkage fields written by
+ * scripts/maintenance/link-translation-originals.mjs:
+ *   - original_edition_id  → "we hold the original — read it" cross-link
+ *   - original_in_scan     → Loeb-style facing-page note (original co-present)
+ *   - neither              → plain "historical translation" label
+ *
+ * `showCrossLink` must be the embedPolicy.showRelatedEditions flag: on tenant
+ * subdomains the linked original may not belong to the tenant, and cross-book
+ * references are gated exactly like RelatedEditions (tenant lockdown).
+ */
+
+interface OriginalEditionNoticeProps {
+  textRole: string;
+  originalEditionId?: string | null;
+  originalInScan?: boolean;
+  originalLanguage?: string | null;
+  year?: number | null;
+  showCrossLink: boolean;
+}
+
+export default async function OriginalEditionNotice({
+  textRole,
+  originalEditionId,
+  originalInScan,
+  originalLanguage,
+  year,
+  showCrossLink,
+}: OriginalEditionNoticeProps) {
+  if (textRole !== 'modern-translation' && textRole !== 'period-translation') return null;
+
+  const yearStr = year && year > 0 ? ` (${year})` : '';
+  const langStr = originalLanguage || 'another language';
+
+  interface OriginalEdition { slug?: string; id?: string; title?: string; language?: string; year?: number; pages_translated?: number }
+  let original: OriginalEdition | null = null;
+  if (originalEditionId && showCrossLink) {
+    const db = await getReadDb();
+    original = (await db.collection('books').findOne(
+      { id: originalEditionId, visible: true },
+      { projection: { _id: 0, slug: 1, id: 1, title: 1, language: 1, year: 1, pages_translated: 1 }, maxTimeMS: 3000 },
+    ).catch(() => null)) as OriginalEdition | null;
+  }
+
+  return (
+    <div className="mt-3 flex items-start gap-2.5 p-3 bg-stone-800/50 rounded-lg border border-stone-700/50 text-sm">
+      <ScrollText className="w-4 h-4 mt-0.5 text-accent-gold flex-shrink-0" />
+      <div className="text-stone-300">
+        {original ? (
+          <>
+            This volume is a historical English translation{yearStr}. The library holds the
+            original {original.language || langStr} edition —{' '}
+            <Link
+              href={`/book/${encodeURIComponent(original.slug || original.id || '')}`}
+              className="text-accent-gold hover:text-accent-gold/80 underline underline-offset-2"
+            >
+              {original.title}
+              {original.year ? ` (${original.year})` : ''}
+            </Link>
+            {(original.pages_translated ?? 0) > 0 ? ', with our English translation.' : '.'}
+          </>
+        ) : originalInScan ? (
+          <>
+            This edition includes the original {langStr} text alongside the English translation.
+          </>
+        ) : (
+          <>
+            This volume is a historical English translation{yearStr} of a work originally
+            written in {langStr}.
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

The reader-facing half of #2395's gate: a book that is itself an old English translation now says so and points the reader at the original, instead of silently presenting as the source.

For `text_role: modern-translation | period-translation`, the book header (between dedication and the Read CTA) renders one of:

1. **We hold the original** (`original_edition_id`, 138 books): "This volume is a historical English translation (1875). The library holds the original Greek edition — *Platonis Opera Quae Extant* (1578), with our English translation." → links to the original's book page.
2. **Original in the same scan** (`original_in_scan`, Loeb/SBE, 53 books): "This edition includes the original Greek text alongside the English translation."
3. **Original not held** (74 books): "This volume is a historical English translation (1896) of a work originally written in French."

## Tenant lockdown

The cross-link is gated by `embedPolicy.showRelatedEditions` — same gate as `RelatedEditions` — because the linked original may not belong to the tenant. The plain label still renders in embed mode (it's self-referential, no leak).

## Out of scope

- Search/browse ranking demotion of old translations — `text_role` is not yet in the Supabase `books_catalog` index; separate increment.
- Verified-visible check: the notice only links originals that are `visible: true`.

Test books on preview: `/book/tibetan-book-of-the-dead-bardo-thodol-evans-wentz` (linked), `/book/appian-s-roman-history-vol-iii-civil-wars-books-i-ii-white` (in-scan), `/book/arcana-coelestia-heavenly-arcana-swedenborg` (missing).

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)