### PR TITLE
feat(iiif): capture manifests on import (#2416 part 3)

### DIFF
--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -6,6 +6,7 @@ import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
+import { storeImportedManifest } from '@/lib/iiif-manifest-store';
 import type { ImageSourceProvider } from '@/lib/types/image-source';
 
 export const maxDuration = 300;
@@ -558,6 +559,14 @@ export const POST = withCuratorAuth(async (request, session) => {
     }
 
     await db.collection('pages').insertMany(pageDocs);
+
+    // Persist the IIIF manifest we already fetched (provenance, #2416; non-blocking)
+    storeImportedManifest(db, {
+      manifest,
+      manifest_url,
+      book_id: bookIdStr,
+      source: (provider as string) || 'iiif',
+    }).catch((e) => console.warn(`[IIIF Import] manifest store failed for ${bookIdStr}: ${e?.message}`));
 
     // Queue preview OCR for early metadata enrichment (non-blocking)
     queuePreviewOcr(bookIdStr, title).catch(() => {});

--- a/src/lib/iiif-manifest-store.ts
+++ b/src/lib/iiif-manifest-store.ts
@@ -1,0 +1,118 @@
+/**
+ * Persist an IIIF manifest the importer already fetched into the
+ * `iiif_manifests` collection (provenance + pre-extracted page URLs).
+ *
+ * The bulk backfill counterpart lives in
+ * scripts/iiif-discovery/lib/manifest-store.mjs (issue #2416). This module is
+ * the import-path side: it stores the manifest we ALREADY have in hand, so it
+ * never makes a second network request. Self-contained extraction (mirrors the
+ * .mjs lib) avoids a circular import with import-utils.
+ *
+ * Callers should treat this as best-effort/non-blocking — a storage failure
+ * must never fail an import.
+ */
+import type { Db } from 'mongodb';
+
+interface MinimalCanvas {
+  images?: Array<{ resource?: { '@id'?: string; id?: string; service?: unknown } }>;
+  items?: Array<{ items?: Array<{ body?: { id?: string; service?: unknown } }> }>;
+}
+interface MinimalManifest {
+  '@context'?: string | string[];
+  '@id'?: string;
+  label?: unknown;
+  sequences?: Array<{ canvases?: MinimalCanvas[] }>;
+  items?: MinimalCanvas[];
+}
+
+function detectVersion(manifest: MinimalManifest): 2 | 3 {
+  const ctx = manifest?.['@context'];
+  const ctxStr = Array.isArray(ctx) ? ctx.join(' ') : (ctx || '');
+  if (ctxStr.includes('/presentation/3')) return 3;
+  if (ctxStr.includes('/presentation/2')) return 2;
+  if (Array.isArray(manifest?.items)) return 3;
+  if (Array.isArray(manifest?.sequences)) return 2;
+  return manifest?.['@id'] ? 2 : 3;
+}
+
+function getCanvases(manifest: MinimalManifest): MinimalCanvas[] {
+  if (manifest?.sequences?.[0]?.canvases?.length) return manifest.sequences[0].canvases!;
+  if (manifest?.items?.length) return manifest.items;
+  return [];
+}
+
+function serviceId(service: unknown): string | undefined {
+  const s = Array.isArray(service) ? service[0] : service;
+  if (!s || typeof s !== 'object') return undefined;
+  const o = s as Record<string, unknown>;
+  return (o.id as string) || (o['@id'] as string) || undefined;
+}
+
+function extractCanvasImage(canvas: MinimalCanvas): { photo: string; thumbnail: string } {
+  const imageResource = canvas?.images?.[0]?.resource;
+  if (imageResource) {
+    const sid = serviceId(imageResource.service);
+    if (sid) return { photo: `${sid}/full/full/0/default.jpg`, thumbnail: `${sid}/full/200,/0/default.jpg` };
+    const direct = imageResource['@id'] || imageResource.id || '';
+    return { photo: direct, thumbnail: direct };
+  }
+  const body = canvas?.items?.[0]?.items?.[0]?.body;
+  if (body) {
+    const sid = serviceId(body.service);
+    if (sid) return { photo: `${sid}/full/full/0/default.jpg`, thumbnail: `${sid}/full/200,/0/default.jpg` };
+    const direct = body.id || '';
+    return { photo: direct, thumbnail: direct };
+  }
+  return { photo: '', thumbnail: '' };
+}
+
+function extractLabel(label: unknown): string | null {
+  if (!label) return null;
+  if (typeof label === 'string') return label.trim();
+  if (Array.isArray(label)) {
+    const en = label.find((l) => l?.['@language'] === 'en');
+    return ((en?.['@value'] || label[0]?.['@value'] || label[0] || '') as string).toString().trim() || null;
+  }
+  if (typeof label === 'object') {
+    const obj = label as Record<string, unknown>;
+    const vals = (obj.en || obj.none || Object.values(obj)[0]) as unknown;
+    if (Array.isArray(vals)) return (vals[0] || '').toString().trim() || null;
+  }
+  return null;
+}
+
+/**
+ * Upsert an already-fetched IIIF manifest into `iiif_manifests`.
+ * Keyed unique on manifest_url. Best-effort: callers should `.catch()`.
+ */
+export async function storeImportedManifest(
+  db: Db,
+  opts: { manifest: unknown; manifest_url: string; book_id?: string | null; source?: string | null; storeRaw?: boolean }
+): Promise<{ ok: boolean; page_count?: number; error?: string }> {
+  const { manifest, manifest_url, book_id = null, source = null, storeRaw = true } = opts;
+  if (!manifest_url) return { ok: false, error: 'no manifest_url' };
+
+  const m = manifest as MinimalManifest;
+  const canvases = getCanvases(m);
+  const image_urls = canvases.map(extractCanvasImage).filter((u) => u.photo);
+
+  const setDoc: Record<string, unknown> = {
+    manifest_url,
+    book_id,
+    source,
+    iiif_version: detectVersion(m),
+    label: extractLabel(m?.label),
+    page_count: canvases.length,
+    image_urls,
+    fetched_at: new Date(),
+    error: null,
+  };
+  if (storeRaw) setDoc.raw = manifest;
+
+  await db.collection('iiif_manifests').updateOne(
+    { manifest_url },
+    { $set: setDoc },
+    { upsert: true }
+  );
+  return { ok: true, page_count: canvases.length };
+}

--- a/src/lib/import-utils.ts
+++ b/src/lib/import-utils.ts
@@ -8,6 +8,7 @@ import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { computeProcessingPriority } from '@/lib/processing-priority';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
 import { resolveLanguage, resolveDate } from '@/lib/resolve-language';
+import { storeImportedManifest } from '@/lib/iiif-manifest-store';
 
 // IIIF v2 manifest shape (covers most digital library providers)
 export interface IIIFManifest {
@@ -473,6 +474,14 @@ export async function importBookFromIIIF(
     pages_affected: pageDocs.length,
     metadata: { provider: config.provider, identifier: config.identifier },
   });
+
+  // Persist the IIIF manifest we already fetched (provenance, #2416; non-blocking)
+  storeImportedManifest(db, {
+    manifest,
+    manifest_url: config.manifest_url,
+    book_id: bookIdStr,
+    source: config.provider,
+  }).catch((e) => console.warn(`[Import] manifest store failed for ${bookIdStr}: ${e?.message}`));
 
   // Queue preview OCR for early metadata enrichment (non-blocking)
   queuePreviewOcr(bookIdStr, config.title).catch(() => {});


### PR DESCRIPTION
Part 3 of #2416 (parts 1+2 merged in #2418).

## What
Every new IIIF import now persists the manifest it **already fetched** into the `iiif_manifests` collection. Adds `src/lib/iiif-manifest-store.ts` (`storeImportedManifest`) and wires it into both import paths:
- `importBookFromIIIF()` in `src/lib/import-utils.ts`
- `/api/import/iiif/route.ts`

## Design
- **No extra network call** — stores the manifest object the importer already has in hand (unlike the backfill, which fetches).
- **Non-blocking / best-effort** — fire-and-forget with `.catch`; a manifest-store failure never fails or slows an import (same pattern as the existing audit-log / preview-OCR / archive-kickoff calls).
- **Self-contained extraction** with a type-only import of `IIIFManifest` — avoids a circular runtime dependency with `import-utils`.
- Same collection + shape as the backfill (#2418), keyed unique on `manifest_url`.

## Verified
- `npx tsc --noEmit` clean.
- Import-resolve pre-commit hook passes.

## Out of scope
- The bulk backfill of existing books (done in #2418; running now on Hetzner).
- Candidate pre-fetch (Part 4, deliberately deferred — would be ~1M requests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)