### PR TITLE
fix(deploy): never skip CDN purge when vercel CLI exits nonzero post-deploy

### DIFF
--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -53,8 +53,19 @@ echo "▸ Typechecking (npx tsc --noEmit)…"
 npx tsc --noEmit
 
 # 4. Deploy to production.
+#    Do NOT let a nonzero exit from the CLI abort the script before the purge:
+#    `vercel --prod` can deploy SUCCESSFULLY and then exit nonzero on a
+#    post-deploy status-poll timeout (ETIMEDOUT against api.vercel.com — bit us
+#    2026-06-04). Skipping the purge is far worse than purging after a failed
+#    deploy (a purge is always safe; stale HTML pointing at purged CSS is not).
 echo "▸ Deploying to production (vercel --prod)…"
-vercel --prod
+DEPLOY_EXIT=0
+vercel --prod || DEPLOY_EXIT=$?
+if [ "$DEPLOY_EXIT" -ne 0 ]; then
+  echo "  ⚠ vercel exited $DEPLOY_EXIT — verifying whether the deployment actually shipped…" >&2
+  PROD_OK=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "https://sourcelibrary.org/" || echo 000)
+  echo "  prod / responds: HTTP $PROD_OK — continuing to purge + warm regardless." >&2
+fi
 
 # 5. Purge the CDN so cached HTML can't outlive the assets it references.
 echo "▸ Purging Cloudflare cache (purge_everything)…"
@@ -80,4 +91,8 @@ WARM_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
   --max-time 300 || true)
 echo "  deploy-warm → HTTP $WARM_CODE"
 
+if [ "$DEPLOY_EXIT" -ne 0 ]; then
+  echo "⚠ Purge + warm completed, but the vercel CLI exited $DEPLOY_EXIT — verify the deployment shipped (vercel ls sourcelibrary-v2 | head -2)." >&2
+  exit "$DEPLOY_EXIT"
+fi
 echo "✓ Production deploy complete (deployed → purged → warmed)."


### PR DESCRIPTION
## Why

On today's deploy, `vercel --prod` **deployed successfully** and then exited nonzero on a post-deploy status-poll timeout (`read ETIMEDOUT` against `api.vercel.com`). With `set -e`, `deploy-prod.sh` aborted before the Cloudflare purge + warm — recreating exactly the stale-HTML/dead-CSS window the wrapper exists to prevent (I ran the purge manually this time; prod is healthy).

## What

- The `vercel --prod` step no longer aborts the script on nonzero exit: the purge + warm **always run** (a purge is always safe; stale HTML pointing at purged CSS is not).
- A nonzero CLI exit is logged with a prod-responds probe, surfaced again at the end, and the script still exits nonzero — real deploy failures aren't masked.

Scripts-only, no Vercel deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)