### PR TITLE
feat(search): text_role-aware ranking — originals beat old translations (#2395)

### DIFF
--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -86,6 +86,7 @@ function transformBook(book) {
     place_published: book.place_published || null,
     doi: book.doi || null,
     work_id: book.work_id || null,
+    text_role: book.text_role || null,
     resource_type: book.resource_type || null,
     source_url: book.image_source?.source_url || null,
     provider_name: book.image_source?.provider_name || null,
@@ -168,7 +169,7 @@ const projection = {
   // Book detail fields
   summary: 1, 'index.bookSummary.brief': 1, 'reading_summary.overview': 1,
   publisher: 1, place_published: 1, doi: 1, work_id: 1,
-  resource_type: 1, cover_image: 1, dedication: 1, subtitle: 1,
+  resource_type: 1, cover_image: 1, dedication: 1, subtitle: 1, text_role: 1,
   source_work_dates: 1,
   'translation_verification.disposition': 1, 'translation_verification.reasoning': 1,
   'ai_metadata.description': 1, description: 1, subject_keywords: 1,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
+import { textRoleRank } from '@/lib/text-role';
 import { Book } from '@/lib/types';
 import type { SearchResult, SearchResponse } from '@/lib/api-client/types/search';
 import { buildPageSearchStage, NON_CONTENT_PAGE_TYPES } from '@/lib/atlas-search';
@@ -197,6 +198,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       };
       // Transient field for work-level dedup (stripped before response)
       if ((typedBook as any).work_id) (result as any)._work_id = (typedBook as any).work_id;
+      if ((typedBook as any).text_role) (result as any)._text_role = (typedBook as any).text_role;
       return result;
     }
 
@@ -230,7 +232,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         try {
           const matchingIds = await searchBookIds(query, { limit: limit * 2 });
           const bookFilters = buildBookFilters();
-          const bookProjection = { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, is_first_translation: 1, quality_score: 1, summary: 1, reading_summary: 1, work_id: 1 };
+          const bookProjection = { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, is_first_translation: 1, quality_score: 1, summary: 1, reading_summary: 1, work_id: 1, text_role: 1 };
 
           let books: any[] = [];
           if (matchingIds.length > 0) {
@@ -445,7 +447,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         const pageBooks = await db.collection('books')
           .find(
             { id: { $in: pageBookIds }, ...(tenantId ? { tenantId } : {}) },
-            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, hidden: 1, quality_score: 1, work_id: 1 } }
+            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, hidden: 1, quality_score: 1, work_id: 1, text_role: 1 } }
           )
           .toArray();
         for (const b of pageBooks) {
@@ -513,6 +515,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
           thumbnail_blob: (book as any).thumbnail_blob,
         };
         if ((book as any).work_id) (pageResult as any)._work_id = (book as any).work_id;
+        if ((book as any).text_role) (pageResult as any)._text_role = (book as any).text_role;
         results.push(pageResult);
       }
     }
@@ -545,7 +548,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
               ...(languages.length > 0 ? { language: { $in: languages } } : {}),
               ...(excludeLanguages.length > 0 && languages.length === 0 ? { language: { $nin: excludeLanguages } } : {}),
             },
-            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1, summary: 1, reading_summary: 1 } }
+            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1, summary: 1, reading_summary: 1, text_role: 1 } }
           )
           .maxTimeMS(3000)
           .toArray();
@@ -584,6 +587,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
             quality_score: (book as any).quality_score,
           };
           if ((book as any).work_id) (semResult as any)._work_id = (book as any).work_id;
+          if ((book as any).text_role) (semResult as any)._text_role = (book as any).text_role;
           results.push(semResult);
         }
       }
@@ -617,7 +621,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
               ...(languages.length > 0 ? { language: { $in: languages } } : {}),
               ...(excludeLanguages.length > 0 && languages.length === 0 ? { language: { $nin: excludeLanguages } } : {}),
             },
-            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1 } }
+            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1, text_role: 1 } }
           )
           .maxTimeMS(3000)
           .toArray();
@@ -656,6 +660,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
           thumbnail_blob: book.thumbnail_blob,
         };
         if (book.work_id) (spResult as any)._work_id = book.work_id;
+        if ((book as any).text_role) (spResult as any)._text_role = (book as any).text_role;
         results.push(spResult);
       }
     }
@@ -705,11 +710,13 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         const bTitleExact = bTitle.includes(queryLower);
         if (aTitleExact !== bTitleExact) return aTitleExact ? -1 : 1;
 
-        // 3. Original language beats modern English translations
-        // A Latin "De Occulta Philosophia" should rank above an English reprint
-        const aOriginal = a.language !== ENGLISH ? 1 : 0;
-        const bOriginal = b.language !== ENGLISH ? 1 : 0;
-        if (aOriginal !== bOriginal) return bOriginal - aOriginal;
+        // 3. Closeness to the source (#2395): original-language texts beat
+        // period translations beat modern translations. text_role is the
+        // classified signal; language is the fallback proxy for pages and
+        // unclassified imports (see src/lib/text-role.ts).
+        const aRank = textRoleRank((a as any)._text_role, a.language);
+        const bRank = textRoleRank((b as any)._text_role, b.language);
+        if (aRank !== bRank) return aRank - bRank;
 
         // 4. Older editions rank higher (earlier = closer to source)
         const aYear = parseInt(a.published?.match(/\d{3,4}/)?.[0] || '9999');
@@ -753,7 +760,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
 
     // Apply offset and strip transient fields
     const paginatedResults = dedupedResults.slice(offset, offset + limit)
-      .map(r => { const { _work_id, ...clean } = r as any; return clean as SearchResult; });
+      .map(r => { const { _work_id, _text_role, ...clean } = r as any; return clean as SearchResult; });
 
     // For exact year searches, find nearby books (within 5 years)
     let nearby: SearchResult[] = [];

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { textRoleRank } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import type { BookSearchFilters } from '@/lib/atlas-search';
@@ -442,10 +443,11 @@ async function searchBooks(
     const bTitleMatch = bTitle.includes(queryLower);
     if (aTitleMatch !== bTitleMatch) return aTitleMatch ? -1 : 1;
 
-    // 2. Original language beats English translations
-    const aOriginal = a.language !== 'English' ? 1 : 0;
-    const bOriginal = b.language !== 'English' ? 1 : 0;
-    if (aOriginal !== bOriginal) return bOriginal - aOriginal;
+    // 2. Closeness to the source (#2395): originals beat period translations
+    // beat modern translations; language is the fallback for unclassified rows.
+    const aRank = textRoleRank(a.text_role, a.language);
+    const bRank = textRoleRank(b.text_role, b.language);
+    if (aRank !== bRank) return aRank - bRank;
 
     // 3. Older editions rank higher (earlier = closer to source)
     const aYear = parsePublishedYear(a.published);

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -33,6 +33,8 @@ export interface CatalogBook {
   categories: string[];
   collections: string[];
   resource_type: string | null;
+  /** original | period-translation | modern-translation — see src/lib/text-role.ts (#2395) */
+  text_role: string | null;
 }
 
 /** Extended book detail from Supabase — includes fields for the /book/[id] page shell. */
@@ -59,7 +61,7 @@ export interface CatalogBookDetail extends CatalogBook {
   updated_at: string | null;
 }
 
-const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, resource_type';
+const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, resource_type, text_role';
 
 export type SortOption = 'popular' | 'title' | 'author' | 'year_asc' | 'year_desc' | 'recent' | 'last_translated' | 'quality';
 

--- a/src/lib/text-role.ts
+++ b/src/lib/text-role.ts
@@ -1,0 +1,23 @@
+/**
+ * Ranking tier for the original-vs-translation distinction (issue #2395).
+ *
+ * `text_role` is written by scripts/maintenance/classify-text-role.mjs:
+ *   original | period-translation | modern-translation
+ *
+ * Lower rank = closer to the source = ranks higher in search:
+ *   0  original-language source (incl. genuine English-native works)
+ *   1  period translation (pre-~1700 historical artifact) / unknown
+ *   2  modern translation (~18th c.+ standing in for an original)
+ *
+ * When text_role is missing (pages, imports newer than the last classifier
+ * run), fall back to the old language proxy: a non-English scan is an
+ * original-language source; an unclassified English book sits between
+ * originals and modern translations — matching the previous behavior where
+ * "original language beats English translations".
+ */
+export function textRoleRank(textRole?: string | null, language?: string | null): number {
+  if (textRole === 'original') return 0;
+  if (textRole === 'period-translation') return 1;
+  if (textRole === 'modern-translation') return 2;
+  return language && language !== 'English' ? 0 : 1;
+}


### PR DESCRIPTION
## What

The search-ranking half of #2395's gate. Both book-ranking surfaces used the crude proxy *"non-English ranks above English"* — which demoted genuine English-native originals (Bacon, Cudworth) and couldn't tell a 1650 period translation from a 1916 modern one. They now rank by the classified `text_role`:

**original (0) < period-translation (1) < modern-translation (2)**, with the old language proxy as fallback for pages and unclassified imports (`src/lib/text-role.ts`).

- **`/api/search`**: ladder step 3 (and thus the RRF tiebreaker) — `text_role` projected from Mongo in all four book lanes, threaded as transient `_text_role` beside `_work_id`, stripped before response.
- **`/api/search/unified`**: step 2 — books come from Supabase `books_catalog`, so:
- **Supabase**: `text_role` column added (migration applied via Hetzner `SUPABASE_DB_URL`), **30,319 rows backfilled** (30,054 original / 248 modern / 17 period), `BOOK_SELECT` + `CatalogBook` + sync-worker projection & mapping updated so it stays fresh.

## Behavioral change

A reader searching "Plato dialogues" now gets the Greek editions ranked above Jowett's 1875 translation; "Hermetic Museum" surfaces the *Musaeum hermeticum* Latin above Waite. English-native originals stop being unfairly demoted below non-English books. Demotion is a ranking tier, not a filter — translations still appear.

## Ordering note

The Supabase migration + backfill are **already applied** (additive column) — required before this code deploys since `BOOK_SELECT` references it.

## Out of scope

- Periodic re-classification of new imports (they fall back to the language proxy until classify-text-role.mjs re-runs).
- The MCP search tools surface (separate codepath per the three-surfaces lesson; can follow).

`npx tsc --noEmit` clean; sync worker `node -c` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)