### PR TITLE
fix(artwork): vision-verify Commons upgrade candidates + audit/revert tooling

### DIFF
--- a/scripts/maintenance/audit-upgraded-artwork-images.mjs
+++ b/scripts/maintenance/audit-upgraded-artwork-images.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Audit artworks whose images were replaced by upgrade-artwork-images.mjs.
+ *
+ * Background: the upgrade script's findHigherResOnCommons() did a free-text
+ * Commons search for "<author> <title>" and took the highest-resolution image
+ * hit with NO verification it depicted the same artwork. Result: e.g.
+ * art-angelic-concert (El Greco) served a 2013 concert photo of the Hevia Trio
+ * for weeks (found 2026-06-04).
+ *
+ * This script vision-checks every `image_upgraded: true` artwork: it sends the
+ * served thumbnail + the artwork's title/author/description to Gemini and asks
+ * whether the image plausibly depicts that artwork. Mismatches are written to
+ * a report and flagged in Mongo (`image_mismatch_suspected: true`).
+ *
+ * It does NOT modify images. Run revert-bad-artwork-upgrades.mjs on the report
+ * to restore originals.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/audit-upgraded-artwork-images.mjs [--limit N] [--slug SLUG]
+ *
+ * Output: scripts/output/artwork-upgrade-audit.json
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'fs';
+
+const LIMIT = parseInt(process.argv.find((_, i, a) => a[i - 1] === '--limit') || '0') || 999999;
+const ONLY_SLUG = process.argv.find((_, i, a) => a[i - 1] === '--slug') || null;
+
+const MODEL = 'gemini-3.1-flash-lite';
+const API_KEY = process.env.GEMINI_API_KEY;
+if (!API_KEY) { console.error('GEMINI_API_KEY missing'); process.exit(1); }
+
+const client = new MongoClient(process.env.MONGODB_URI);
+
+async function visionCheck(thumbUrl, title, author, description) {
+  const imgRes = await fetch(thumbUrl, { signal: AbortSignal.timeout(30000) });
+  if (!imgRes.ok) return { error: `thumb fetch ${imgRes.status}` };
+  const b64 = Buffer.from(await imgRes.arrayBuffer()).toString('base64');
+
+  const prompt = `You are auditing a digital art library for image/metadata mismatches.
+
+The catalog record says this image is:
+Title: ${title}
+Artist: ${author || 'Unknown'}
+${description ? `Catalog description: ${description.substring(0, 600)}` : ''}
+
+Look at the attached image. Does it plausibly depict THIS artwork (or a detail/crop/engraving of it)?
+A mismatch means the image is clearly a DIFFERENT subject — e.g. a modern photograph when the record describes an old master painting, a different artwork entirely, a book page about an unrelated topic.
+Style variations, crops, details, different photographic reproductions of the same work, or black-and-white versions are MATCHES.
+
+Respond with JSON only: {"match": true|false, "confidence": "high"|"medium"|"low", "image_shows": "<one short sentence describing what the image actually depicts>"}`;
+
+  const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${API_KEY}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ parts: [
+        { inline_data: { mime_type: 'image/jpeg', data: b64 } },
+        { text: prompt },
+      ] }],
+      generationConfig: { responseMimeType: 'application/json', temperature: 0 },
+    }),
+    signal: AbortSignal.timeout(60000),
+  });
+  if (!res.ok) return { error: `gemini ${res.status}` };
+  const data = await res.json();
+  const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+  if (!text) return { error: `no candidate (${data.candidates?.[0]?.finishReason || 'empty'})` };
+  try { return JSON.parse(text); } catch { return { error: 'unparseable: ' + text.substring(0, 100) }; }
+}
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+
+  const query = { image_upgraded: true };
+  if (ONLY_SLUG) query.slug = ONLY_SLUG;
+
+  const docs = await books.find(query, {
+    projection: { slug: 1, title: 1, author: 1, description: 1, summary: 1, thumbnail: 1, commons_title: 1, image_upgrade_source: 1, 'image_source.identifier': 1, 'image_source.provider': 1 },
+  }).limit(LIMIT).toArray();
+
+  console.log(`Auditing ${docs.length} upgraded artworks…`);
+  const results = [];
+  let mismatches = 0, errors = 0, done = 0;
+
+  for (const d of docs) {
+    done++;
+    const thumb = d.thumbnail;
+    if (!thumb) { results.push({ slug: d.slug, error: 'no thumbnail' }); errors++; continue; }
+    let verdict;
+    try {
+      verdict = await visionCheck(thumb, d.title, d.author, d.description || d.summary);
+    } catch (err) {
+      verdict = { error: err.message?.substring(0, 80) };
+    }
+    const row = {
+      slug: d.slug, title: d.title, author: d.author,
+      upgrade_source: d.image_upgrade_source,
+      upgraded_to: d.commons_title,
+      original_file: d.image_source?.identifier,
+      original_provider: d.image_source?.provider,
+      ...verdict,
+    };
+    results.push(row);
+    if (verdict.error) {
+      errors++;
+      console.log(`[${done}/${docs.length}] ERR  ${d.slug}: ${verdict.error}`);
+    } else if (!verdict.match) {
+      mismatches++;
+      console.log(`[${done}/${docs.length}] MISMATCH ${d.slug} (${d.author} — ${d.title?.substring(0, 40)}) → image shows: ${verdict.image_shows}`);
+      await books.updateOne({ _id: d._id }, { $set: { image_mismatch_suspected: true } });
+    } else if (done % 25 === 0) {
+      console.log(`[${done}/${docs.length}] ok (${mismatches} mismatches so far)`);
+    }
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  mkdirSync('scripts/output', { recursive: true });
+  const out = 'scripts/output/artwork-upgrade-audit.json';
+  writeFileSync(out, JSON.stringify({ audited_at: new Date().toISOString(), total: docs.length, mismatches, errors, results }, null, 2));
+  console.log(`\n━━━ Done: ${docs.length} audited, ${mismatches} mismatches, ${errors} errors → ${out}`);
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/revert-bad-artwork-upgrades.mjs
+++ b/scripts/maintenance/revert-bad-artwork-upgrades.mjs
@@ -68,13 +68,25 @@ async function main() {
 
   for (const m of mismatches) {
     const label = `${m.slug} (${m.author} — ${m.title?.substring(0, 40)})`;
-    if (m.original_provider !== 'wikimedia_commons' || !m.original_file) {
-      console.log(`SKIP ${label}: original is ${m.original_provider || 'unknown'} / ${m.original_file || 'no file'} — handle manually`);
+    // Original file reference: image_source.identifier when the importer set it,
+    // else parse the (percent-encoded) Commons File: page URL in source_url.
+    let originalFile = m.original_file;
+    if (!originalFile) {
+      const doc = await books.findOne({ slug: m.slug }, { projection: { 'image_source.source_url': 1 } });
+      const srcUrl = doc?.image_source?.source_url || '';
+      const match = srcUrl.match(/commons\.wikimedia\.org\/wiki\/(.+)$/);
+      if (match) {
+        const decoded = decodeURIComponent(match[1]);
+        if (/^File:/i.test(decoded)) originalFile = decoded;
+      }
+    }
+    if (m.original_provider !== 'wikimedia_commons' || !originalFile) {
+      console.log(`SKIP ${label}: original is ${m.original_provider || 'unknown'} / ${originalFile || 'no file'} — handle manually`);
       skipped++;
       continue;
     }
     try {
-      const info = await commonsFileUrl(m.original_file);
+      const info = await commonsFileUrl(originalFile);
       if (DRY_RUN) {
         console.log(`WOULD REVERT ${label} → ${info.url} (${info.width}x${info.height})`);
         reverted++;
@@ -103,7 +115,7 @@ async function main() {
 
       await books.updateOne({ slug: m.slug }, {
         $set: {
-          commons_title: m.original_file.startsWith('File:') ? m.original_file : `File:${m.original_file}`,
+          commons_title: originalFile.startsWith('File:') ? originalFile : `File:${originalFile}`,
           commons_full_url: info.url,
           commons_width: meta.width,
           commons_height: meta.height,

--- a/scripts/maintenance/revert-bad-artwork-upgrades.mjs
+++ b/scripts/maintenance/revert-bad-artwork-upgrades.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Revert artwork images that upgrade-artwork-images.mjs replaced with the
+ * WRONG image (free-text Commons search, no identity check — see
+ * audit-upgraded-artwork-images.mjs for the audit that finds them).
+ *
+ * For every mismatch in the audit report, re-downloads the ORIGINAL Commons
+ * file recorded at import time (image_source.identifier), regenerates the
+ * three R2 sizes, fixes the Mongo record, and purges the Cloudflare cache
+ * for the rewritten image URLs.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/revert-bad-artwork-upgrades.mjs [--dry-run] [--report PATH]
+ */
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+import { readFileSync } from 'fs';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const REPORT = process.argv.find((_, i, a) => a[i - 1] === '--report') || 'scripts/output/artwork-upgrade-audit.json';
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@sourcelibrary.org) bot';
+
+const client = new MongoClient(process.env.MONGODB_URI);
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: process.env.R2_ACCESS_KEY_ID, secretAccessKey: process.env.R2_SECRET_ACCESS_KEY },
+});
+
+async function commonsFileUrl(filename) {
+  const title = filename.startsWith('File:') ? filename : `File:${filename}`;
+  const url = `https://commons.wikimedia.org/w/api.php?action=query&titles=${encodeURIComponent(title)}&prop=imageinfo&iiprop=url|size&format=json`;
+  const res = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(15000) });
+  if (!res.ok) throw new Error(`commons api ${res.status}`);
+  const data = await res.json();
+  const page = Object.values(data.query?.pages || {})[0];
+  const info = page?.imageinfo?.[0];
+  if (!info) throw new Error('file not found on Commons');
+  return info;
+}
+
+async function purgeCloudflare(urls) {
+  for (let i = 0; i < urls.length; i += 30) {
+    const chunk = urls.slice(i, i + 30);
+    const res = await fetch(`https://api.cloudflare.com/client/v4/zones/${process.env.CLOUDFLARE_ZONE_ID}/purge_cache`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ files: chunk }),
+    });
+    const data = await res.json();
+    if (!data.success) console.error('CF purge failed:', JSON.stringify(data.errors));
+    await new Promise(r => setTimeout(r, 500));
+  }
+}
+
+async function main() {
+  const report = JSON.parse(readFileSync(REPORT, 'utf8'));
+  const mismatches = report.results.filter(r => r.match === false);
+  console.log(`${DRY_RUN ? '=== DRY RUN ===\n' : ''}Report has ${mismatches.length} mismatches to revert.`);
+
+  await client.connect();
+  const books = client.db('bookstore').collection('books');
+
+  let reverted = 0, skipped = 0, errors = 0;
+  const purgeUrls = [];
+
+  for (const m of mismatches) {
+    const label = `${m.slug} (${m.author} — ${m.title?.substring(0, 40)})`;
+    if (m.original_provider !== 'wikimedia_commons' || !m.original_file) {
+      console.log(`SKIP ${label}: original is ${m.original_provider || 'unknown'} / ${m.original_file || 'no file'} — handle manually`);
+      skipped++;
+      continue;
+    }
+    try {
+      const info = await commonsFileUrl(m.original_file);
+      if (DRY_RUN) {
+        console.log(`WOULD REVERT ${label} → ${info.url} (${info.width}x${info.height})`);
+        reverted++;
+        continue;
+      }
+      const imgRes = await fetch(info.url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(120000) });
+      if (!imgRes.ok) throw new Error(`download ${imgRes.status}`);
+      const buf = Buffer.from(await imgRes.arrayBuffer());
+      const meta = await sharp(buf).metadata();
+
+      const prefix = m.slug.startsWith('art-') || m.slug.startsWith('rijks-') || m.slug.startsWith('met-') ? m.slug : `art-${m.slug}`;
+      const display = await sharp(buf).resize({ width: 3840, withoutEnlargement: true }).jpeg({ quality: 85, mozjpeg: true }).toBuffer();
+      const thumb = await sharp(buf).resize({ width: 600, withoutEnlargement: true }).jpeg({ quality: 80, mozjpeg: true }).toBuffer();
+      const full = await sharp(buf).jpeg({ quality: 92, mozjpeg: true }).toBuffer();
+      for (const [key, body] of [
+        [`artwork/${prefix}.jpg`, display],
+        [`artwork/${prefix}-thumb.jpg`, thumb],
+        [`artwork/${prefix}-full.jpg`, full],
+      ]) {
+        await s3.send(new PutObjectCommand({
+          Bucket: process.env.R2_BUCKET_NAME, Key: key, Body: body,
+          ContentType: 'image/jpeg', CacheControl: 'public, max-age=31536000, immutable',
+        }));
+        purgeUrls.push(`https://images.sourcelibrary.org/${key}`);
+      }
+
+      await books.updateOne({ slug: m.slug }, {
+        $set: {
+          commons_title: m.original_file.startsWith('File:') ? m.original_file : `File:${m.original_file}`,
+          commons_full_url: info.url,
+          commons_width: meta.width,
+          commons_height: meta.height,
+          thumbnail: `https://images.sourcelibrary.org/artwork/${prefix}-thumb.jpg`,
+          thumbnail_blob: `https://images.sourcelibrary.org/artwork/${prefix}.jpg`,
+          archived_full_url: `https://images.sourcelibrary.org/artwork/${prefix}-full.jpg`,
+          image_upgrade_reverted: true,
+          image_upgrade_reverted_at: new Date(),
+          updated_at: new Date(),
+        },
+        $unset: { image_upgraded: '', image_upgraded_at: '', image_upgrade_source: '', image_mismatch_suspected: '', low_res: '' },
+      });
+      console.log(`REVERTED ${label} → ${meta.width}x${meta.height}`);
+      reverted++;
+      await new Promise(r => setTimeout(r, 1500));
+    } catch (err) {
+      console.log(`ERROR ${label}: ${err.message?.substring(0, 80)}`);
+      errors++;
+    }
+  }
+
+  if (!DRY_RUN && purgeUrls.length) {
+    console.log(`Purging ${purgeUrls.length} URLs from Cloudflare…`);
+    await purgeCloudflare(purgeUrls);
+  }
+
+  console.log(`\n━━━ Reverted: ${reverted}, skipped (non-Commons): ${skipped}, errors: ${errors}`);
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/upgrade-artwork-images.mjs
+++ b/scripts/upgrade-artwork-images.mjs
@@ -39,6 +39,10 @@ const s3 = new S3Client({
 async function findHigherResOnCommons(title, author, currentMaxDim) {
   // Search Commons for alternate uploads of the same artwork
   // Prioritize Google Art Project versions (often 10000+ px)
+  // NOTE: this is a FREE-TEXT search — results are candidates, not matches.
+  // Every candidate MUST pass verifyCandidateDepicts() before being used
+  // (2026-06-04: an unverified run served a 2013 concert photo as El Greco's
+  // "Angelic Concert" — see scripts/maintenance/audit-upgraded-artwork-images.mjs).
   const searchTerms = `${author} ${title}`.replace(/[^\w\s]/g, '').substring(0, 100);
   const url = `https://commons.wikimedia.org/w/api.php?action=query&list=search&srsearch=${encodeURIComponent(searchTerms)}&srnamespace=6&srlimit=15&format=json`;
 
@@ -60,7 +64,7 @@ async function findHigherResOnCommons(title, author, currentMaxDim) {
   let best = null;
   for (const r of imageResults) {
     try {
-      const infoUrl = `https://commons.wikimedia.org/w/api.php?action=query&titles=${encodeURIComponent(r.title)}&prop=imageinfo&iiprop=url|size&format=json`;
+      const infoUrl = `https://commons.wikimedia.org/w/api.php?action=query&titles=${encodeURIComponent(r.title)}&prop=imageinfo&iiprop=url|size&iiurlwidth=600&format=json`;
       const infoRes = await fetch(infoUrl, {
         headers: { 'User-Agent': UA },
         signal: AbortSignal.timeout(10000),
@@ -80,6 +84,7 @@ async function findHigherResOnCommons(title, author, currentMaxDim) {
         best = {
           title: r.title,
           url: info.url,
+          thumbUrl: info.thumburl || info.url,
           width: info.width,
           height: info.height,
           maxDim,
@@ -91,6 +96,58 @@ async function findHigherResOnCommons(title, author, currentMaxDim) {
   }
 
   return best;
+}
+
+// ─── Candidate verification (REQUIRED before any upgrade) ────────────────────
+// Free-text Commons search returns plausible-sounding but wrong files (a
+// "concert" query matches concert photos). Vision-check that the candidate
+// actually depicts the recorded artwork. Fails CLOSED: any error → reject.
+
+async function verifyCandidateDepicts(candidateThumbUrl, title, author, description) {
+  if (!process.env.GEMINI_API_KEY) {
+    console.error('GEMINI_API_KEY missing — cannot verify candidates, rejecting all upgrades');
+    return false;
+  }
+  try {
+    const imgRes = await fetch(candidateThumbUrl, {
+      headers: { 'User-Agent': UA },
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!imgRes.ok) return false;
+    const b64 = Buffer.from(await imgRes.arrayBuffer()).toString('base64');
+
+    const prompt = `You are verifying a candidate replacement image for a digital art library.
+
+The catalog record is:
+Title: ${title}
+Artist: ${author || 'Unknown'}
+${description ? `Catalog description: ${description.substring(0, 600)}` : ''}
+
+Does the attached image plausibly depict THIS artwork (or a detail/crop/engraving/photographic reproduction of it)?
+Different reproductions, crops, details, or black-and-white versions of the same work are MATCHES.
+A clearly different subject (a different artwork, a modern photograph, an unrelated book page) is NOT a match.
+
+Respond with JSON only: {"match": true|false}`;
+
+    const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent?key=${process.env.GEMINI_API_KEY}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [
+          { inline_data: { mime_type: 'image/jpeg', data: b64 } },
+          { text: prompt },
+        ] }],
+        generationConfig: { responseMimeType: 'application/json', temperature: 0 },
+      }),
+      signal: AbortSignal.timeout(60000),
+    });
+    if (!res.ok) return false;
+    const data = await res.json();
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+    return JSON.parse(text)?.match === true;
+  } catch {
+    return false;
+  }
 }
 
 // ─── Strategy 3: Museum IIIF ─────────────────────────────────────────────────
@@ -172,6 +229,7 @@ async function main() {
       _id: 1, slug: 1, title: 1, author: 1,
       commons_title: 1, commons_full_url: 1,
       commons_width: 1, commons_height: 1,
+      description: 1, summary: 1,
     },
     noCursorTimeout: true,
   }).limit(LIMIT);
@@ -190,6 +248,21 @@ async function main() {
       );
 
       if (better && better.maxDim >= MIN_UPGRADE_PX) {
+        // REQUIRED gate: the search result must actually depict this artwork.
+        const verified = await verifyCandidateDepicts(
+          better.thumbUrl, doc.title, doc.author, doc.description || doc.summary
+        );
+        if (!verified) {
+          console.log(`${label} → REJECTED candidate (failed vision check: ${better.title.substring(5, 60)})`);
+          if (!DRY_RUN) {
+            await books.updateOne({ _id: doc._id }, {
+              $set: { low_res: true, upgrade_available: null }
+            });
+          }
+          noUpgrade++;
+          await new Promise(r => setTimeout(r, 1500));
+          continue;
+        }
         const src = better.isGAP ? 'Google Art Project' : 'Commons alternate';
         console.log(`${label} → UPGRADE via ${src} (${better.maxDim}px — ${better.title.substring(5, 60)})`);
 


### PR DESCRIPTION
## Why

`scripts/upgrade-artwork-images.mjs` upgraded low-res artwork images by **free-text searching Commons** for `<author> <title>` and taking the highest-resolution image hit — with no check that the file depicts the same artwork. A search for *El Greco Angelic Concert* matched `File:FIL 2013 - Hevia Trio - 7851.JPG` (a 2013 concert photo of a folk band), which then served as El Greco's painting on https://sourcelibrary.org/artwork/art-angelic-concert since 2026-05-10.

**Blast radius:** 520 artworks have `image_upgraded: true` (391 "Commons alternate", 42 GAP, 88 met_api). A vision audit in progress is finding **~40% mismatches** in the Commons-alternate cohort.

## What's in scope

- **`scripts/upgrade-artwork-images.mjs`** — every search candidate must now pass a Gemini flash-lite vision check (does the image depict the recorded title/artist/description?) before download/upload. Fails closed: missing API key, fetch error, or parse error → candidate rejected.
- **`scripts/maintenance/audit-upgraded-artwork-images.mjs`** (new) — vision-audits all `image_upgraded: true` artworks; flags `image_mismatch_suspected: true`; writes `scripts/output/artwork-upgrade-audit.json`.
- **`scripts/maintenance/revert-bad-artwork-upgrades.mjs`** (new) — for each audit mismatch, re-downloads the original Commons file recorded at import (`image_source.identifier`), regenerates the three R2 sizes, fixes the Mongo record (`commons_*`, thumbnails, unsets `image_upgraded`), and purges Cloudflare for the rewritten URLs. `--dry-run` supported. Non-Commons originals are skipped and listed for manual handling.

## Out of scope

- The actual data revert run (will be executed once the audit completes; art-angelic-concert itself was already hot-fixed and verified live).
- Any rerun of the upgrade sweep with the new gate.

Scripts-only change — no Vercel deploy needed (Hetzner auto-pulls main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)