### PR TITLE
fix(collections): restore book_count cache sync in sync-worker

### DIFF
--- a/scripts/workers/sync-worker.mjs
+++ b/scripts/workers/sync-worker.mjs
@@ -183,6 +183,72 @@ async function syncPageCounts(db) {
   return { books_checked: books.length, mismatches: mismatchCount, updated };
 }
 
+// ── Sync Collection Counts ──
+//
+// Restores the collections.book_count / artwork_count cache sync that lived in
+// the archived Vercel cron (src/app/api/cron/_archived/sync-page-counts). When
+// the cron routes were archived (45fb98fb) this block was never ported into
+// sync-worker, so the cached counts drifted on 271/359 collections (found
+// 2026-06-04 via the eastern-erotic-literature "0 books" header — the
+// collection page header at src/app/collections/[id]/page.tsx reads this
+// cached field while the book grid does a live query, so they disagreed).
+
+async function syncCollectionCounts(db) {
+  console.log('\n--- Sync Collection Counts ---');
+  const start = Date.now();
+
+  // One pass over books per counter, instead of 2 countDocuments per collection.
+  // book_count uses the canonical "readable book" filter from the archived cron;
+  // artwork_count counts resource_type-bearing entries regardless of visibility.
+  const [bookCounts, artworkCounts] = await Promise.all([
+    db.collection('books').aggregate([
+      { $match: { status: { $ne: 'deleted' }, visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 }, resource_type: { $exists: false } } },
+      { $unwind: '$collections' },
+      { $group: { _id: '$collections', n: { $sum: 1 } } },
+    ]).toArray(),
+    db.collection('books').aggregate([
+      { $match: { resource_type: { $exists: true } } },
+      { $unwind: '$collections' },
+      { $group: { _id: '$collections', n: { $sum: 1 } } },
+    ]).toArray(),
+  ]);
+  const bookMap = new Map(bookCounts.map(r => [r._id, r.n]));
+  const artMap = new Map(artworkCounts.map(r => [r._id, r.n]));
+
+  const collections = await db.collection('collections')
+    .find({}, { projection: { _id: 1, slug: 1, book_count: 1, artwork_count: 1 } })
+    .toArray();
+
+  const ops = [];
+  let mismatchCount = 0;
+  for (const col of collections) {
+    const liveBookCount = bookMap.get(col.slug) || 0;
+    const liveArtworkCount = artMap.get(col.slug) || 0;
+    if ((col.book_count || 0) !== liveBookCount || (col.artwork_count || 0) !== liveArtworkCount) {
+      mismatchCount++;
+      if (!DRY_RUN) {
+        ops.push({
+          updateOne: {
+            filter: { _id: col._id },
+            update: { $set: { book_count: liveBookCount, artwork_count: liveArtworkCount, updated_at: new Date() } },
+          },
+        });
+      }
+    }
+  }
+
+  let updated = 0;
+  if (ops.length > 0) {
+    const result = await db.collection('collections').bulkWrite(ops);
+    updated = result.modifiedCount;
+  }
+
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+  console.log(`  Collections checked: ${collections.length} | Mismatches: ${mismatchCount} | Updated: ${updated} | ${elapsed}s`);
+
+  return { collections_checked: collections.length, mismatches: mismatchCount, updated };
+}
+
 // ── Sync Gallery Images ──
 
 async function syncGalleryImages(db) {
@@ -752,6 +818,14 @@ async function run() {
     } catch (err) {
       console.error(`[sync-worker] Page counts phase FAILED: ${err.message}`);
       phaseErrors.push({ phase: 'counts', error: err.message });
+    }
+
+    try {
+      await syncCollectionCounts(db);
+      phasesCompleted.push('collection_counts');
+    } catch (err) {
+      console.error(`[sync-worker] Collection counts phase FAILED: ${err.message}`);
+      phaseErrors.push({ phase: 'collection_counts', error: err.message });
     }
   }
 

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -344,8 +344,9 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     .map((m: { book_id: string }) => m.book_id)
     .filter(Boolean);
 
-  // Use cached book_count — sync-page-counts cron updates this every 6h
-  // to reflect only translated books (pages_translated > 0).
+  // Use cached book_count — syncCollectionCounts in scripts/workers/sync-worker.mjs
+  // (Hetzner, every 2h) updates this to reflect only translated books
+  // (pages_translated > 0). The old Vercel sync-page-counts cron is archived.
   const total = collection.book_count || 0;
 
   // Track gallery collection slug for linking (captured in the gallery query below)


### PR DESCRIPTION
## Why

The `/collections/eastern-erotic-literature` page showed **"0 books"** in the header while the grid listed 25. The header reads the cached `collections.book_count`; the grid does a live query — and nothing has been writing the cache.

The writer lived in the Vercel `sync-page-counts` cron, archived in 45fb98fb ("replaced by Hetzner workers"), but the collection-counts block was never actually ported to `scripts/workers/sync-worker.mjs`. Result: **271 of 359 collections** had drifted counts (measured 2026-06-04), and the `collection-health` cron has been raising false `no_content` issues off the stale field.

## What

- New `syncCollectionCounts()` phase in `sync-worker.mjs` (Hetzner, every 2h). Same canonical filter as the archived cron (`visible:true`, `pages_count>0`, `pages_translated>0`, `resource_type` absent → book_count; `resource_type` present → artwork_count), but computed with two `$unwind`/`$group` aggregations instead of 2× `countDocuments` per collection (718 round-trips → 2).
- Fixed the stale comment at `src/app/collections/[id]/page.tsx:347` that still credited the archived cron.

## Verified

- `node --check` passes; aggregation output cross-checked against `countDocuments` for 4 sample slugs (all match).
- One-off recompute already run against prod (271 collections corrected) — this PR makes it stay correct.

## Out of scope

- The header (cached, translated-only) and the grid (live, includes untranslated) still use *different filters* by design — they can legitimately disagree for collections with untranslated books. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)