### PR TITLE
fix(search): apply text_role demotion to the RRF fused score (#2395)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -733,9 +733,22 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         // Reciprocal Rank Fusion: primary sort by fused lane score (desc),
         // ladder as the deterministic tiebreaker. Unlike the ladder, this lets
         // a strongly-cross-confirmed page outrank a weakly-matched book.
+        //
+        // text_role demotion (#2395): the ladder tier only breaks RRF ties, so
+        // a popular old translation (Evans-Wentz, Jowett) still outranked the
+        // original via lane cross-confirmation. Scale the fused score down for
+        // CLASSIFIED translations only — unclassified results are untouched,
+        // so this is surgical (265 books + their pages), not a filter.
+        const rrfAdjusted = (r: SearchResult) => {
+          const s = rrf.get(r.id) ?? 0;
+          const tr = (r as any)._text_role;
+          if (tr === 'modern-translation') return s / 1.5;
+          if (tr === 'period-translation') return s / 1.2;
+          return s;
+        };
         results.sort((a, b) => {
-          const sa = rrf.get(a.id) ?? 0;
-          const sb = rrf.get(b.id) ?? 0;
+          const sa = rrfAdjusted(a);
+          const sb = rrfAdjusted(b);
           if (sb !== sa) return sb - sa;
           return ladderCompare(a, b);
         });


### PR DESCRIPTION
## Why

Live verification of #2426 showed Evans-Wentz's English *Tibetan Book of the Dead* still ranking above the Tibetan original for the query "tibetan book of the dead": the text_role tier lives in the ladder, but the ladder only breaks **ties** under RRF — and RRF is the default for queries ≥3 words / non-navigational intent. A popular translation cross-confirmed by several lanes beats the original on fused score before the ladder ever runs.

## What

Scale the RRF fused score for **classified translations only**: `modern-translation` ÷1.5, `period-translation` ÷1.2, unclassified results untouched. Surgical — affects exactly the 265 classified books (and their page results, which inherit `_text_role`), and it's a penalty, not a filter.

`npx tsc --noEmit` clean. Will verify the live query post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)