### PR TITLE
fix(gallery): hold crop materialization for sensitive books until #2431 ships

### DIFF
--- a/scripts/maintenance/flag-sensitive-books.mjs
+++ b/scripts/maintenance/flag-sensitive-books.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Derive `books.sensitive: true` from erotic-collection membership — step 1 of
+ * the sensitive-content gate (issue #2431).
+ *
+ * Policy (Derek, 2026-06-04): erotic content stays fully readable inside its
+ * collections, but must not surface on global discovery surfaces (gallery
+ * feed, homepage pickers, search, similar-images, browse covers). The
+ * book-level flag is the signal those read paths will exclude on once the
+ * gate ships; until then it also drives the materialization hold in
+ * scripts/workers/generate-thumbnails.mjs (crops for sensitive books are not
+ * generated, preserving the status-quo hold-out).
+ *
+ * Additive only: never unsets `sensitive` (a book may be flagged manually for
+ * reasons other than collection membership). Books flagged but no longer in
+ * an erotic collection are reported for human review.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/flag-sensitive-books.mjs            # dry run
+ *   node scripts/maintenance/flag-sensitive-books.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+
+// Collection slugs whose members are sensitive. Keep in sync with issue #2431.
+const SENSITIVE_COLLECTIONS = [
+  'erotic-art',
+  'eastern-erotic-literature',
+  'european-vernacular-erotica',
+  'kama',
+  'erotic-literature', // orphan legacy tag, still present on some books
+];
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+  const books = db.collection('books');
+
+  const memberFilter = { collections: { $in: SENSITIVE_COLLECTIONS } };
+  const toFlag = await books.countDocuments({ ...memberFilter, sensitive: { $ne: true } });
+  const already = await books.countDocuments({ ...memberFilter, sensitive: true });
+  console.log(`members of sensitive collections: ${toFlag + already} (${already} already flagged, ${toFlag} to flag)`);
+
+  if (APPLY && toFlag > 0) {
+    const r = await books.updateMany({ ...memberFilter, sensitive: { $ne: true } }, { $set: { sensitive: true } });
+    console.log(`flagged: ${r.modifiedCount}`);
+  } else if (!APPLY) {
+    console.log('(dry run — pass --apply to write)');
+  }
+
+  // Flagged but no longer a member — report only, never auto-unset.
+  const stale = await books.find(
+    { sensitive: true, collections: { $nin: SENSITIVE_COLLECTIONS } },
+    { projection: { id: 1, title: 1, collections: 1 } },
+  ).limit(20).toArray();
+  if (stale.length > 0) {
+    console.log(`\nflagged but not in a sensitive collection (review by hand, not auto-unset):`);
+    stale.forEach(b => console.log(`  ${b.id} ${(b.title || '').slice(0, 60)}`));
+  }
+
+  await client.close();
+}
+
+main().catch((e) => { console.error('FAILED:', e); process.exit(1); });

--- a/scripts/workers/generate-thumbnails.mjs
+++ b/scripts/workers/generate-thumbnails.mjs
@@ -54,6 +54,7 @@ async function storagePut(key, body, contentType = 'application/octet-stream') {
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const ARCHIVED_ONLY = args.includes('--archived-only');
+const INCLUDE_SENSITIVE = args.includes('--include-sensitive');
 
 function getArg(name, defaultVal) {
   const arg = args.find(a => a.startsWith(`--${name}=`));
@@ -219,6 +220,19 @@ async function main() {
   }
   if (BOOK_ID) {
     matchFilter.book_id = BOOK_ID;
+  } else if (!INCLUDE_SENSITIVE) {
+    // Sensitive-content hold (issue #2431): the global gallery/feed/search
+    // currently have NO sensitive gate — erotic books' images stay out of
+    // those surfaces only because their crops were never materialized.
+    // Until the read-path gate ships, do not materialize crops for books
+    // flagged `sensitive: true` (set from erotic-collection membership by
+    // scripts/maintenance/flag-sensitive-books.mjs). Explicit --book-id or
+    // --include-sensitive overrides for deliberate, scoped runs.
+    const sensitiveIds = await db.collection('books').distinct('id', { sensitive: true });
+    if (sensitiveIds.length > 0) {
+      matchFilter.book_id = { $nin: sensitiveIds };
+      console.log(`Skipping ${sensitiveIds.length} sensitive books (#2431; --include-sensitive to override)`);
+    }
   }
 
   // countDocuments(matchFilter) is a full COLLSCAN over the pages collection


### PR DESCRIPTION
## Why

#2430 added a nightly cron running `generate-thumbnails.mjs` to clear the 30K-row crop backlog from the Gemini Batch extraction path. But #2431 (sensitive-content gate, not yet implemented) documents that erotic books' images are absent from the global gallery feed **only because their crops were never materialized** — the backfill itself is the leak vector. The first backlog run cropped 92 erotic-collection rows (incl. 9 explicit shunga at q≥0.95) before being stopped; those crops were unlinked again in production.

## What

- `generate-thumbnails.mjs`: skip books flagged `sensitive: true` unless `--book-id` or `--include-sensitive` is passed. Logs the skip count.
- New `scripts/maintenance/flag-sensitive-books.mjs`: additive-only derivation of `books.sensitive` from erotic-collection membership (`erotic-art`, `eastern-erotic-literature`, `european-vernacular-erotica`, `kama`, `erotic-literature`) — the exact script #2431 step 1 names. Reports flagged-but-no-longer-member books for human review; never auto-unsets.
- Production data already updated (2026-06-04): 582 books flagged, 92 fresh crops unlinked (`crop_held_pending_2431: true` marks them for easy re-link once the gate ships).

## In scope / out of scope

- In scope: the materialization hold + the flag-derivation script.
- Out of scope: the read-path gate itself (`sensitive: { $ne: true }` on gallery/homepage/search/similar) — that's #2431, awaiting Derek's review.

Hetzner auto-pulls main, so this is live on the box ~5 min after merge; the paused backlog run resumes after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)