### PR TITLE
fix(routing): content_type:'book' always wins over resource_type (never route a book to /artwork/)

### DIFF
--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -87,7 +87,9 @@ function transformBook(book) {
     doi: book.doi || null,
     work_id: book.work_id || null,
     text_role: book.text_role || null,
-    resource_type: book.resource_type || null,
+    // content_type:'book' wins — never expose a resource_type for a book, or the catalog
+    // grid (CollectionBookCard) routes it to /artwork/ instead of /book/.
+    resource_type: book.content_type === 'book' ? null : (book.resource_type || null),
     source_url: book.image_source?.source_url || null,
     provider_name: book.image_source?.provider_name || null,
     image_attribution: book.image_source?.attribution || null,

--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -18,7 +18,8 @@ async function getArtwork(slug: string) {
   // Try exact slug match, then with art- prefix
   const slugsToTry = [slug, `art-${slug}`];
   const artwork = await db.collection('books').findOne(
-    { slug: { $in: slugsToTry }, resource_type: { $exists: true } },
+    // content_type:'book' wins: never render a textual book as artwork even via a direct /artwork/<slug> URL.
+    { slug: { $in: slugsToTry }, resource_type: { $exists: true }, content_type: { $ne: 'book' } },
   );
   if (!artwork) return null;
 
@@ -58,6 +59,7 @@ async function getArtwork(slug: string) {
           {
             ...navScope,
             resource_type: { $exists: true },
+            content_type: { $ne: 'book' },
             $or: [
               { published: { $lt: artwork.published || '' } },
               { published: artwork.published || '', title: { $lt: artwork.title } },
@@ -72,6 +74,7 @@ async function getArtwork(slug: string) {
           {
             ...navScope,
             resource_type: { $exists: true },
+            content_type: { $ne: 'book' },
             $or: [
               { published: { $gt: artwork.published || '' } },
               { published: artwork.published || '', title: { $gt: artwork.title } },

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -51,6 +51,10 @@ function isArtworkRecord(b: Pick<Book, 'content_type' | 'resource_type'>): boole
   // have only one. Treat either as artwork to avoid leaks during slow
   // backfills, mirroring the /artist/[slug] page (which keys off
   // resource_type).
+  // An explicit content_type:'book' always wins: a textual book that happens to
+  // carry a resource_type (e.g. a digitized papyrus text tagged 'papyrus_fragment')
+  // must never be treated as artwork, or it routes to /artwork/ instead of /book/.
+  if (b.content_type === 'book') return false;
   return b.content_type === 'artwork' || !!b.resource_type;
 }
 


### PR DESCRIPTION
## Problem
A textual book that carries a `resource_type` was classified as **artwork** everywhere and routed to `/artwork/<slug>` instead of `/book/<slug>`. Root: `isArtworkRecord()` returned true on `!!resource_type`, `sync-books-catalog` copied `resource_type` into `books_catalog` (so `CollectionBookCard` linked to /artwork/), and `/artwork/[slug]` matched it.

Surfaced when ~200 real books showed as artwork — the **Greek Magical Papyri (PGM)**, Homer, Menander, the Leiden papyri (all tagged `papyrus_fragment` but `content_type:'book'`), plus importer mistakes (Fragmenta/Tartu) and split picture-albums.

## Fix
A record with `content_type:'book'` is **never** treated as artwork:
- `isArtworkRecord()` (author page): returns `false` when `content_type==='book'`
- `sync-books-catalog.mjs`: nulls `resource_type` in the catalog for `content_type:'book'` (so grids link to /book/)
- `/artwork/[slug]`: excludes `content_type:'book'` from the main lookup + prev/next nav

Legit artworks (`content_type:'artwork'`, or `resource_type` without `content_type:'book'`) are unaffected — no legit artwork has `content_type:'book'`.

## Scope
- In scope: the routing guard only. The affected production data was already corrected out-of-band (`resource_type` stashed → `former_resource_type`, re-synced) and the Fragmenta/Tartu importers were fixed (#2383). This PR prevents **recurrence** from any future import.
- Out of scope: re-modeling deliberately-imported single artworks; the 24h collection-page CDN cache (separate latent issue).
- Frontend change → needs a prod deploy to take effect (`scripts/**` change auto-pulls on Hetzner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)