### PR TITLE
fix(import): Wellcome multi-copy (sc:Collection) works + collections param in IIIF/Wellcome routes

### DIFF
--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -193,6 +193,7 @@ function parseLicense(licenseUrl: string | null, attribution: string | null, pro
  *   language?: string,
  *   published?: string,
  *   categories?: string[],
+ *   collections?: string[],  // Source Library collection slugs to tag the book with
  *   provider?: string,       // e.g., "Vatican", "IRHT", "Bodleian"
  *   start_page?: number,     // 1-indexed start page (for extracting portion of manifest)
  *   end_page?: number        // 1-indexed end page (inclusive)
@@ -210,6 +211,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       language,
       published,
       categories,
+      collections: requestCollections,
       work_id,
       provider,
       start_page,
@@ -495,6 +497,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       language: language || 'Unknown',
       published: published || 'Unknown',
       categories: categories || [],
+      ...(requestCollections?.length ? { collections: requestCollections } : {}),
       ...(work_id ? { work_id } : {}),
       ...(contributing_library ? { contributing_library } : providerName !== 'IIIF Source' ? { contributing_library: providerName } : {}),
       thumbnail: pageImages[0]?.thumbnail || '',

--- a/src/app/api/import/wellcome/route.ts
+++ b/src/app/api/import/wellcome/route.ts
@@ -28,10 +28,13 @@ interface WellcomeWork {
 }
 
 interface IIIFManifest {
+  '@type'?: string;
   label?: string | { '@value'?: string }[];
   description?: string | { '@value'?: string }[];
   license?: string;
   attribution?: string;
+  // Multi-copy works return a sc:Collection wrapping one manifest per copy
+  manifests?: Array<{ '@id'?: string; label?: string }>;
   sequences?: Array<{
     canvases?: Array<{
       '@id'?: string;
@@ -57,7 +60,8 @@ interface IIIFManifest {
  *   author?: string,        // Override author
  *   language?: string,
  *   published?: string,
- *   categories?: string[]
+ *   categories?: string[],
+ *   collections?: string[]  // Source Library collection slugs to tag the book with
  * }
  */
 export const POST = withCuratorAuth(async (request, session) => {
@@ -70,6 +74,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       language: languageOverride,
       published: publishedOverride,
       categories,
+      collections: requestCollections,
     } = body;
 
     if (!work_id) {
@@ -105,24 +110,43 @@ export const POST = withCuratorAuth(async (request, session) => {
       );
     }
 
-    const manifestUrl = iiifLocation.url;
+    let manifestUrl = iiifLocation.url;
 
     // Fetch IIIF manifest
-    const manifestRes = await fetch(manifestUrl, {
-      headers: {
-        'User-Agent': 'SourceLibrary/1.0 (https://sourcelibrary.org; scholarly digital library)',
-        'Accept': 'application/json, application/ld+json',
+    const fetchManifest = async (url: string): Promise<IIIFManifest | NextResponse> => {
+      const res = await fetch(url, {
+        headers: {
+          'User-Agent': 'SourceLibrary/1.0 (https://sourcelibrary.org; scholarly digital library)',
+          'Accept': 'application/json, application/ld+json',
+        }
+      });
+      if (!res.ok) {
+        return NextResponse.json(
+          { error: `Failed to fetch IIIF manifest: ${res.status}` },
+          { status: 400 }
+        );
       }
-    });
+      return res.json();
+    };
 
-    if (!manifestRes.ok) {
-      return NextResponse.json(
-        { error: `Failed to fetch IIIF manifest: ${manifestRes.status}` },
-        { status: 400 }
-      );
+    let manifest = await fetchManifest(manifestUrl);
+    if (manifest instanceof NextResponse) return manifest;
+
+    // Works with multiple physical copies return a sc:Collection whose
+    // manifests[] holds one manifest per copy (e.g. b10005766 → b10005766_0001
+    // "Copy 1"). Follow the first copy's manifest. See issue #2437.
+    if (manifest['@type'] === 'sc:Collection' && manifest.manifests?.length) {
+      const copyUrl = manifest.manifests[0]['@id'];
+      if (!copyUrl) {
+        return NextResponse.json(
+          { error: 'IIIF collection has no resolvable copy manifest' },
+          { status: 400 }
+        );
+      }
+      manifestUrl = copyUrl;
+      manifest = await fetchManifest(manifestUrl);
+      if (manifest instanceof NextResponse) return manifest;
     }
-
-    const manifest: IIIFManifest = await manifestRes.json();
 
     // Get page count from IIIF canvases
     const canvases = manifest.sequences?.[0]?.canvases || [];
@@ -225,6 +249,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       language,
       published,
       categories: categories || work.subjects?.map(s => s.label) || [],
+      ...(requestCollections?.length ? { collections: requestCollections } : {}),
       ...(work_id ? { work_id } : {}),
       wellcome_id: work_id,
       wellcome_b_number: bNumber,


### PR DESCRIPTION
Fixes #2437.

## In scope
1. **`/api/import/wellcome` — collection-wrapped manifests.** Works with multiple physical copies (e.g. `f7h5wv75`, the Nuovo Receptario 1498) expose a `sc:Collection` at their `iiif-presentation` location, with `manifests[]` holding one manifest per copy. The route only parsed a bare `sc:Manifest` and failed with "No pages found in IIIF manifest". It now follows the first copy's manifest (`b10005766` → `b10005766_0001`).
2. **`collections` body param in `/api/import/iiif` and `/api/import/wellcome`.** Both routes silently dropped it; they now write it to the book doc exactly like the IA route (`...(requestCollections?.length ? { collections: requestCollections } : {})`).

## Out of scope (deliberately)
- Auditing the other ~20 provider routes (bodleian, mdz, e-rara, …) for the same `collections` gap — same pattern applies, but better as a follow-up sweep than bundled here.
- Multi-copy selection UX (always takes Copy 1; a `copy` param could come later if ever needed).

## Verification
- `npx tsc --noEmit` clean.
- The failing case was reproduced live against prod (Wellcome `f7h5wv75` → 'No pages found'); the workaround used the same Copy-1 manifest URL this code now resolves, and imported 186 pages successfully (book `6a22c194a71b5f5ffb2e4f82`), confirming the downstream parse path handles the copy manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)