### PR TITLE
fix(split): AR gate uses median of sampled pages; stop writing flags in --dry-run

### DIFF
--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -309,23 +309,47 @@ if (!iiifUrls || iiifUrls.length === 0) {
 
 console.log(`  ${iiifUrls.length} original images found`);
 
-// --- AR gate: check first image aspect ratio ---
-// If the first image is portrait (AR < 1.1), this book isn't actually spreads.
+// --- AR gate: sample several pages and use the median aspect ratio ---
+// The first page is often a portrait cover/title on a book whose body is
+// spreads (e.g. Hollandus VCQ 37: page 1 AR 0.45, body AR ~1.35), so gating
+// on iiifUrls[0] alone produced false "portrait" verdicts. Sample up to 5
+// pages spread through the book and decide on the median.
 try {
-  const gateBuf = await fetchImage(iiifUrls[0]);
-  const gateMeta = await sharp(gateBuf).metadata();
-  const ar = gateMeta.width / gateMeta.height;
-  if (ar < MIN_SPREAD_AR) {
-    console.log(`  AR gate: ${ar.toFixed(2)} < ${MIN_SPREAD_AR} — portrait pages, not spreads. Skipping.`);
-    await db.collection('books').updateOne({ id: book.id }, {
-      $set: { needs_splitting: false, split_completed: true, split_note: `AR gate: ${ar.toFixed(2)} — portrait` },
-    });
-    await client.close();
-    process.exit(0);
+  const sampleCount = Math.min(5, iiifUrls.length);
+  const sampleIdxs = [...new Set(
+    Array.from({ length: sampleCount }, (_, i) =>
+      Math.floor(((i + 1) / (sampleCount + 1)) * iiifUrls.length))
+  )];
+  const ars = [];
+  for (const idx of sampleIdxs) {
+    try {
+      const gateBuf = await fetchImage(iiifUrls[idx]);
+      const gateMeta = await sharp(gateBuf).metadata();
+      ars.push(gateMeta.width / gateMeta.height);
+    } catch { /* skip unfetchable sample */ }
   }
-  console.log(`  AR: ${ar.toFixed(2)} — confirmed spreads`);
+  if (ars.length > 0) {
+    ars.sort((a, b) => a - b);
+    const ar = ars[Math.floor(ars.length / 2)];
+    const arList = ars.map(a => a.toFixed(2)).join(', ');
+    if (ar < MIN_SPREAD_AR) {
+      console.log(`  AR gate: median ${ar.toFixed(2)} < ${MIN_SPREAD_AR} over ${ars.length} samples [${arList}] — portrait pages, not spreads. Skipping.`);
+      if (!DRY_RUN) {
+        await db.collection('books').updateOne({ id: book.id }, {
+          $set: { needs_splitting: false, split_completed: true, split_note: `AR gate: median ${ar.toFixed(2)} — portrait` },
+        });
+      } else {
+        console.log('  (dry run — not writing needs_splitting/split_completed)');
+      }
+      await client.close();
+      process.exit(0);
+    }
+    console.log(`  AR: median ${ar.toFixed(2)} over ${ars.length} samples [${arList}] — confirmed spreads`);
+  } else {
+    console.log('  AR gate: no sample images fetchable — proceeding anyway');
+  }
 } catch (e) {
-  console.log(`  AR gate: failed to fetch first image (${e.message?.slice(0, 40)}) — proceeding anyway`);
+  console.log(`  AR gate: failed (${e.message?.slice(0, 40)}) — proceeding anyway`);
 }
 
 // --- Step 2: Load existing pages (for their OCR) ---


### PR DESCRIPTION
## What

Two bugs in `scripts/split-book.mjs`'s aspect-ratio gate:

1. **Gate sampled only the first image.** Page 1 is often a portrait cover/title on a book whose body is two-page spreads (live example: Hollandus *Elixir philosophorum* — cover AR 0.45, body spreads AR ~1.35). The gate declared the whole book portrait, wrote `needs_splitting: false, split_completed: true`, and permanently excluded it from Phase 3.1 splitting. Now samples up to 5 pages evenly through the book and gates on the **median** AR.

2. **`--dry-run` still wrote the flags.** The gate's updateOne wasn't wrapped in the DRY_RUN check, so a dry-run probe clobbered `needs_splitting` on the live book (verified: it did exactly that today). Now respects `--dry-run`.

## Out of scope

- The translate-worker race that lets `needs_splitting && !split_completed` books get translated as spreads before Phase 3.1 runs (separate issue to follow)
- Phase 1.25 detection (works fine — both affected books were correctly flagged there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)