### PR TITLE
fix(pipeline): spread-integrity guards — stop unsplit spread books from being translated or preview-OCR'd (#2449)

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -1437,7 +1437,9 @@ async function submitOcrDirectly(db, book, { modelOverride, maxPages } = {}) {
     // Exception: if this is the entire book (small book), submit anyway
     const totalBookPages = book.pages_count || 0;
     const ocrDone = book.pages_ocr || 0;
-    if (ocrDone > 0 && pages.length < MIN_BATCH_PAGES) {
+    if (ocrDone > 0 && pages.length < MIN_BATCH_PAGES && !book.needs_splitting) {
+      // Spread books are exempt (#2449): their sub-25-page re-OCR remainders carry
+      // the split markers Phase 3.1 depends on — starving them wedges the split.
       console.log(`    Skipping small retry batch: ${pages.length} pages remaining (min ${MIN_BATCH_PAGES})`);
       return { submitted: 0, jobName: null, skippedSmallBatch: true };
     }
@@ -2960,6 +2962,10 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
           'pipeline_auto.preview_ocr_done': { $ne: true },
           'pipeline_auto.recitation_retry': { $ne: true },
           'pipeline_auto.recitation_blocked': { $ne: true },
+          // Spread guard (#2449): preview OCR uses the standard prompt, which writes
+          // marker-less text that poisons the post-OCR split. Spread books get their
+          // first OCR from Phase 2's spread-aware path instead.
+          $or: [{ needs_splitting: { $ne: true } }, { split_completed: true }],
         })
         .sort({ 'pipeline_auto.likely_first_translation': -1, hidden: 1 })
         .project({ id: 1, title: 1, language: 1, needs_splitting: 1 })
@@ -4325,7 +4331,12 @@ Rules:
 
         // Fresh books first (never translated), then re-queue partially-translated books
         let freshBooks = effectiveLimit > 0 ? await db.collection('books').aggregate([
-          { $match: { 'pipeline_auto.status': { $in: ['ocr_complete'] } } },
+          // Spread guard (#2449): unsplit spread books must wait for Phase 3.1 —
+          // translating them produces two-page texts the split then discards.
+          { $match: {
+            'pipeline_auto.status': { $in: ['ocr_complete'] },
+            $or: [{ needs_splitting: { $ne: true } }, { split_completed: true }],
+          } },
           { $addFields: { _speedTier: { $switch: {
             branches: [
               { case: { $in: ['$language', ['Latin', 'German', 'French', 'Italian', 'Dutch', 'Spanish', 'Portuguese', 'English', 'Czech', 'Polish', 'Swedish', 'Danish']] }, then: 0 },
@@ -4351,6 +4362,8 @@ Rules:
             { $match: {
               'pipeline_auto.status': { $in: ['translate_partial', 'translate_complete', 'chapters_complete', 'complete'] },
               pages_ocr: { $gt: 0 },
+              // Spread guard (#2449)
+              $or: [{ needs_splitting: { $ne: true } }, { split_completed: true }],
             }},
             { $addFields: { _denominator: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] } } },
             { $match: { _denominator: { $gt: 0 }, $expr: { $lt: [{ $divide: [{ $ifNull: ['$pages_translated', 0] }, '$_denominator'] }, 0.9] } } },

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -1051,7 +1051,12 @@ async function selfDispatch(db, limit) {
   // Find fresh books (ocr_complete) — sorted by language speed tier
   // so each batch is homogeneous (all fast or all slow books together).
   const fresh = await db.collection('books').aggregate([
-    { $match: { 'pipeline_auto.status': { $in: ['ocr_complete'] } } },
+    // Spread guard (#2449): never translate a book that still needs splitting —
+    // Phase 3.1 must crop the spreads first, or readers get two-page translations.
+    { $match: {
+      'pipeline_auto.status': { $in: ['ocr_complete'] },
+      $or: [{ needs_splitting: { $ne: true } }, { split_completed: true }],
+    } },
     { $addFields: { _speedTier: { $switch: {
       branches: [
         { case: { $in: ['$language', ['Latin', 'German', 'French', 'Italian', 'Dutch', 'Spanish', 'Portuguese', 'English', 'Czech', 'Polish', 'Swedish', 'Danish']] }, then: 0 },
@@ -1072,7 +1077,11 @@ async function selfDispatch(db, limit) {
   let candidates = fresh;
   if (fresh.length === 0) {
     candidates = await db.collection('books').aggregate([
-      { $match: { 'pipeline_auto.status': 'translate_partial' } },
+      { $match: {
+        'pipeline_auto.status': 'translate_partial',
+        // Spread guard (#2449)
+        $or: [{ needs_splitting: { $ne: true } }, { split_completed: true }],
+      } },
       { $addFields: { _denominator: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] } } },
       { $match: { _denominator: { $gt: 0 }, $expr: { $gte: [{ $divide: ['$pages_translated', '$_denominator'] }, 0] } } },
       { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'image_source.provider': 1 } },

--- a/src/app/api/[tenant]/books/[id]/batch-ocr-async/route.ts
+++ b/src/app/api/[tenant]/books/[id]/batch-ocr-async/route.ts
@@ -221,7 +221,30 @@ export const POST = withAuth(async (request, session, context) => {
 
     // Get the main OCR prompt with language substituted
     const ocrPromptResult = await getOcrPrompt();
-    const prompt = ocrPromptResult.text;
+
+    // Spread guard (#2449): flagged spread books must be OCR'd with the spread
+    // prefix so <split-position>/<page-break/> markers survive for Phase 3.1's
+    // split. The bare prompt silently produces marker-less text that wedges the
+    // book as an unsplit spread. Mirrors pipeline-orchestrator submitOcrDirectly.
+    const needsSpreadPrompt = book.needs_splitting === true && book.split_completed !== true;
+    const spreadPrefix = `**TWO-PAGE SPREAD HANDLING:**
+This image is a two-page spread (open book scan). Process BOTH pages separately.
+
+CRITICAL: Each page may have its own multi-column layout. Handle columns WITHIN each page:
+- If a page has 2+ columns, use <column-break/> between columns ON THAT PAGE
+- Each page MUST include its own <vocab> tag with key terms from THAT page only.
+- Use ISO 639-1 language codes (de, fr, la, en, nl, he, grc — NOT "German", "Latin", etc.)
+
+If this is NOT a two-page spread (single page), set split_position to null and process normally.
+
+Output structure:
+1. <split-position>N</split-position> (0-1000, or null if single page) at the very top
+2. All metadata and content for LEFT page
+3. <page-break/> on its own line
+4. All metadata and content for RIGHT page
+
+`;
+    const prompt = needsSpreadPrompt ? spreadPrefix + ocrPromptResult.text : ocrPromptResult.text;
     const promptRef = ocrPromptResult.reference;
     const promptProvenance = {
       prompt_id: promptRef.id,

--- a/src/app/api/books/[id]/batch-ocr-async/route.ts
+++ b/src/app/api/books/[id]/batch-ocr-async/route.ts
@@ -215,7 +215,30 @@ export const POST = withAuth(async (request, session, context) => {
 
     // Get the main OCR prompt with language substituted
     const ocrPromptResult = await getOcrPrompt();
-    const prompt = ocrPromptResult.text;
+
+    // Spread guard (#2449): flagged spread books must be OCR'd with the spread
+    // prefix so <split-position>/<page-break/> markers survive for Phase 3.1's
+    // split. The bare prompt silently produces marker-less text that wedges the
+    // book as an unsplit spread. Mirrors pipeline-orchestrator submitOcrDirectly.
+    const needsSpreadPrompt = book.needs_splitting === true && book.split_completed !== true;
+    const spreadPrefix = `**TWO-PAGE SPREAD HANDLING:**
+This image is a two-page spread (open book scan). Process BOTH pages separately.
+
+CRITICAL: Each page may have its own multi-column layout. Handle columns WITHIN each page:
+- If a page has 2+ columns, use <column-break/> between columns ON THAT PAGE
+- Each page MUST include its own <vocab> tag with key terms from THAT page only.
+- Use ISO 639-1 language codes (de, fr, la, en, nl, he, grc — NOT "German", "Latin", etc.)
+
+If this is NOT a two-page spread (single page), set split_position to null and process normally.
+
+Output structure:
+1. <split-position>N</split-position> (0-1000, or null if single page) at the very top
+2. All metadata and content for LEFT page
+3. <page-break/> on its own line
+4. All metadata and content for RIGHT page
+
+`;
+    const prompt = needsSpreadPrompt ? spreadPrefix + ocrPromptResult.text : ocrPromptResult.text;
     const promptRef = ocrPromptResult.reference;
     const promptProvenance = {
       prompt_id: promptRef.id,


### PR DESCRIPTION
## What

Implements the tactical guards from #2449. One invariant, enforced at every gap found during the 2026-06-05/06 incident: **a `needs_splitting` book must not advance past or around Phase 3.1's split.**

1. **Translation race (the main bug):** orchestrator Phase 4 (`freshBooks` + `partialBooks`) and `translate-worker.mjs` `selfDispatch` (fresh + partial) now exclude `needs_splitting && !split_completed` books. This is the race that let 305 books reach `complete` with two-page spread translations.
2. **Phase 1.5 preview OCR** skips unsplit spread books — its standard prompt wrote marker-less OCR on the first 25 pages, which Pass 2 then treated as done, so the split silently kept those pages as unsplit "singles."
3. **`MIN_BATCH_PAGES` gate** exempts spread books — their sub-25-page re-OCR remainders carry the load-bearing markers; the gate wedged Wiederlegunge (24 pages remaining) at `archive_complete` permanently.
4. **`batch-ocr-async` routes** (global + tenant twin) prepend the same spread prefix `submitOcrDirectly` uses, so manual/scripted OCR submissions can't recreate the marker-less state. Prefix text is copied verbatim from the orchestrator so `split-book.mjs` marker parsing matches.

## Testing

- `npx tsc --noEmit` clean; `node --check` on both workers clean
- Guard shape verified against live data: the three remediated books (Historia Lettica, Wiederlegunge, Hollandus) were translated-raced exactly through paths 1–3 this week

## Out of scope

- The structural fix (split at detection time, before any OCR) — #2454
- Collector idempotency for stale batch jobs after manual resets — #2449 item 2
- The 305-book remediation sweep — runs after #2454 per plan
- Ops guards (key parity, pause-age alerts) — #2455

## Deploy notes

`scripts/**` changes go live via Hetzner auto-pull (hourly). The two route files need the next Vercel prod deploy to take effect — until then manual batch-ocr-async submissions for spread books remain unsafe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)