### PR TITLE
feat(works-catalog): universal works catalog schema + Chinese/Islamicate/Tibetan ingests (#2453)

### DIFF
--- a/scripts/works-catalog/README.md
+++ b/scripts/works-catalog/README.md
@@ -1,0 +1,39 @@
+# Universal works catalog (pre-1900) — issue #2453
+
+Work-level union catalog across traditions, in Supabase. Sits ABOVE
+edition/item-level registries (`ustc_editions`, `import_candidates` from
+#2447 — L3 in that issue's dedup vocabulary). Answers, per work: where do
+scans exist, does an open transcription exist, is there an English
+translation (evidenced claim), and do we hold it.
+
+## Tables
+
+- `works` — one row per work; prefixed authority ids (`kr:KR1a0002`,
+  `oiti:0179MalikIbnAnas.Muwatta`, `bdrc:…`, `wd:Q844278`); evidenced
+  `translation_status` (status + evidence + method — never a bare boolean).
+- `work_sources` — scans/transcriptions/translations per work, with coverage
+  (juan/volume range) for multi-volume items.
+- `work_holdings` — our Mongo books mapped to works, with coverage.
+
+## Run order (Hetzner — `SUPABASE_DB_URL` lives there)
+
+```
+node scripts/works-catalog/apply-schema.mjs        # idempotent DDL
+node scripts/works-catalog/ingest-kanripo.mjs      # ~10.1K Chinese works (Kanseki Repository)
+node scripts/works-catalog/ingest-siku-wikidata.mjs # 3,418 Siku QIDs joined onto kr: works
+node scripts/works-catalog/ingest-openiti.mjs      # ~8.9K Islamicate works (Arabic/Persian)
+node scripts/works-catalog/ingest-bdrc.mjs         # Tibetan works (BUDA linked data)
+```
+
+All idempotent (upserts). Env: `set -a; source .env.production.local; set +a`.
+
+## Gotchas
+
+- **CJK variant glyphs** (説/說, 録/錄, …): always match via
+  `normalizeCjk()` from `lib.mjs` — raw match had a 28% false-miss rate.
+- **raw.githubusercontent truncates multi-MB files with HTTP 200** — use the
+  jsDelivr mirror + parse-inside-retry (see `ingest-openiti.mjs`).
+- **trgm indexes are on the RAW columns** — query `title_normalized` /
+  `title_english` directly, no `lower()` wrapper (ustc_editions lesson).
+- Don't collapse different works; editions/copies are `work_sources` rows,
+  never separate `works` rows for the same work.

--- a/scripts/works-catalog/apply-schema.mjs
+++ b/scripts/works-catalog/apply-schema.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// Apply the works-catalog schema (#2453). Idempotent (IF NOT EXISTS throughout).
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { pgClient } from './lib.mjs';
+
+const sql = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'schema.sql'), 'utf8');
+const client = pgClient();
+await client.connect();
+await client.query(sql);
+const r = await client.query(`
+  select relname, n_live_tup from pg_stat_user_tables
+  where relname in ('works','work_sources','work_holdings') order by relname`);
+for (const row of r.rows) console.log(`${row.relname}: ${row.n_live_tup} rows`);
+await client.end();
+console.log('Schema applied.');

--- a/scripts/works-catalog/ingest-bdrc.mjs
+++ b/scripts/works-catalog/ingest-bdrc.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Ingest BDRC/BUDA (Tibetan & Himalayan Buddhist canon) into the works
+ * catalog (#2453).
+ *
+ * BDRC has no public SPARQL or bulk dump (endpoint answers "disabled for that
+ * server"); the only complete route (verified 2026-06-06) is:
+ *   1. sitemap enumeration -> ~48,500 bdr:MW* Instance IDs (the rich
+ *      bibliographic records; WA* abstract Works are not enumerable directly)
+ *   2. per-resource JSON-LD from purl.bdrc.io (CC0) — ~10s/record server-side
+ *      latency, so the harvest is disk-cached, resumable, and parallel.
+ *   3. load pass groups Instances by their bdo:instanceOf WA Work — one works
+ *      row per WA (work-level), one work_sources row per MW (edition-level).
+ *
+ * Usage (Hetzner):
+ *   node scripts/works-catalog/ingest-bdrc.mjs --harvest   # hours; resumable; run under nohup/tmux
+ *   node scripts/works-catalog/ingest-bdrc.mjs --load      # parse cache -> Supabase
+ *
+ * Politeness: BDRC is a small nonprofit server. Concurrency capped at 12,
+ * back-off on 5xx, and the cache means we never re-fetch.
+ */
+import { mkdirSync, existsSync, readFileSync, writeFileSync, readdirSync } from 'fs';
+import { gunzipSync } from 'zlib';
+import { pgClient, sleep, upsertWorks, upsertSources } from './lib.mjs';
+
+const CACHE = process.env.BDRC_CACHE_DIR || '/root/works-catalog-cache/bdrc';
+const CONCURRENCY = 12;
+const UA = { 'User-Agent': 'SourceLibrary-WorksCatalog/1.0 (derek@sourcelibrary.org)' };
+
+async function enumerateIds() {
+  const ids = new Set();
+  for (const n of ['00001', '00002', '00003', '00004']) {
+    const res = await fetch(`https://library.bdrc.io/scripts/sitemap/sitemap-${n}.xml.gz`, { headers: UA });
+    const xml = gunzipSync(Buffer.from(await res.arrayBuffer())).toString('utf8');
+    for (const m of xml.matchAll(/show\/bdr:(MW[0-9A-Za-z_-]+)/g)) ids.add(m[1]);
+  }
+  return [...ids];
+}
+
+async function harvest() {
+  mkdirSync(CACHE, { recursive: true });
+  const ids = await enumerateIds();
+  const todo = ids.filter(id => !existsSync(`${CACHE}/${id}.jsonld`));
+  console.log(`BDRC: ${ids.length} MW ids, ${todo.length} to fetch (cache: ${CACHE})`);
+  let done = 0, errors = 0;
+  async function worker(queue) {
+    for (;;) {
+      const id = queue.pop();
+      if (!id) return;
+      try {
+        const res = await fetch(`https://purl.bdrc.io/resource/${id}.jsonld`, { headers: UA });
+        if (res.status >= 500) { errors++; await sleep(15000); queue.push(id); continue; }
+        if (!res.ok) { errors++; writeFileSync(`${CACHE}/${id}.error`, String(res.status)); continue; }
+        const body = await res.text();
+        JSON.parse(body); // truncation guard
+        writeFileSync(`${CACHE}/${id}.jsonld`, body);
+      } catch { errors++; await sleep(5000); }
+      if (++done % 200 === 0) console.log(`${done}/${todo.length} fetched (${errors} errors)`);
+    }
+  }
+  const queue = [...todo];
+  await Promise.all(Array.from({ length: CONCURRENCY }, () => worker(queue)));
+  console.log(`Harvest complete: ${done} fetched, ${errors} errors`);
+}
+
+// --- JSON-LD helpers -------------------------------------------------------
+const label = v => {
+  // prefLabel/altLabel values: object or array of {@value,@language}
+  const arr = Array.isArray(v) ? v : v ? [v] : [];
+  const by = lang => arr.find(x => x['@language'] === lang)?.['@value'];
+  return {
+    ewts: by('bo-x-ewts') || null,
+    bo: by('bo') || null,
+    en: by('en') || by('en-x-mixed') || null,
+    zh: by('zh-Hans') || by('zh-Hant') || null,
+    any: arr[0]?.['@value'] || (typeof v === 'string' ? v : null),
+  };
+};
+const refs = v => (Array.isArray(v) ? v : v ? [v] : []).map(x => (typeof x === 'string' ? x : x['@id'])).filter(Boolean);
+
+function parseRecord(id) {
+  let doc;
+  try { doc = JSON.parse(readFileSync(`${CACHE}/${id}.jsonld`, 'utf8')); } catch { return null; }
+  const graph = doc['@graph'] || [doc];
+  const node = graph.find(n => (n['@id'] || '').endsWith(`bdr:${id}`) || (n['@id'] || '').endsWith(`/${id}`));
+  if (!node) return null;
+  const pref = label(node['skos:prefLabel'] ?? node.prefLabel);
+  const alts = label(node['skos:altLabel'] ?? node.altLabel);
+  // creator: reified AgentAsCreator nodes -> agent P-id
+  const creatorNodes = refs(node['creator'] ?? node['bdo:creator'])
+    .map(cid => graph.find(n => n['@id'] === cid)).filter(Boolean);
+  const agents = creatorNodes.flatMap(c => refs(c['agent'] ?? c['bdo:agent']));
+  const wa = refs(node['instanceOf'] ?? node['bdo:instanceOf'])[0] || null;
+  const event = refs(node['instanceEvent'] ?? node['bdo:instanceEvent'])
+    .map(eid => graph.find(n => n['@id'] === eid)).filter(Boolean)[0];
+  const when = event?.['eventWhen']?.['@value'] || event?.['eventWhen'] || null;
+  return {
+    mw: id,
+    wa: wa?.replace(/^bdr:/, '') || null,
+    title: pref.bo || pref.ewts || pref.any,
+    title_bo: pref.bo || alts.bo || null,
+    ewts: pref.ewts || alts.ewts || null,
+    en: pref.en || alts.en || null,
+    agents: agents.map(a => a.replace(/^bdr:/, '')),
+    when: typeof when === 'string' ? when : null,
+    script: refs(node['script'] ?? node['bdo:script'])[0]?.replace(/^bdr:Script/, '') || null,
+  };
+}
+
+async function load() {
+  const files = readdirSync(CACHE).filter(f => f.endsWith('.jsonld'));
+  console.log(`Parsing ${files.length} cached records`);
+  const byWa = new Map(); // WA id (or MW fallback) -> { rec, instances: [] }
+  let parsed = 0;
+  for (const f of files) {
+    const rec = parseRecord(f.replace(/\.jsonld$/, ''));
+    if (!rec || !rec.title) continue;
+    parsed++;
+    const key = rec.wa || rec.mw;
+    if (!byWa.has(key)) byWa.set(key, { rec, instances: [] });
+    byWa.get(key).instances.push(rec);
+  }
+  console.log(`${parsed} parsed -> ${byWa.size} works (WA-clustered)`);
+
+  const works = [];
+  const sources = [];
+  for (const [key, { rec, instances }] of byWa) {
+    // representative record: prefer one with an English title
+    const best = instances.find(i => i.en) || rec;
+    const year = parseInt((best.when || '').slice(0, 4), 10);
+    works.push({
+      id: `bdrc:${key}`,
+      tradition: 'tibetan',
+      original_language: 'bod',
+      title: best.title_bo || best.title,
+      title_normalized: (best.title_bo || best.title).trim(),
+      title_romanized: best.ewts,
+      title_english: best.en,
+      author: null, // P-ids resolved in a later pass; stored in authority_ids
+      century: Number.isFinite(year) ? Math.floor(year / 100) + 1 : null,
+      authority_ids: {
+        bdrc_work: rec.wa,
+        bdrc_instances: instances.map(i => i.mw).slice(0, 50),
+        bdrc_agents: [...new Set(instances.flatMap(i => i.agents))].slice(0, 10),
+      },
+      corpus_tags: ['bdrc'],
+      source_catalog: 'bdrc',
+      extra: { script: best.script, published: best.when },
+    });
+    for (const i of instances) {
+      sources.push({
+        work_id: `bdrc:${key}`,
+        source: 'bdrc',
+        source_id: i.mw,
+        kind: 'scan', // BUDA viewer record; IIIF manifests hang off the linked image instances
+        url: `https://library.bdrc.io/show/bdr:${i.mw}`,
+        iiif: true,
+        extra: { ewts: i.ewts },
+      });
+    }
+  }
+  const client = pgClient();
+  await client.connect();
+  const nW = await upsertWorks(client, works);
+  const nS = await upsertSources(client, sources);
+  const count = (await client.query(`select count(*) n from works where source_catalog = 'bdrc'`)).rows[0].n;
+  await client.end();
+  console.log(`Upserted ${nW} works, ${nS} sources. works(source_catalog=bdrc) = ${count}`);
+}
+
+const mode = process.argv[2];
+if (mode === '--harvest') await harvest();
+else if (mode === '--load') await load();
+else { console.error('Usage: ingest-bdrc.mjs --harvest | --load'); process.exit(1); }

--- a/scripts/works-catalog/ingest-kanripo.mjs
+++ b/scripts/works-catalog/ingest-kanripo.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Ingest the Kanripo / Kanseki Repository catalog into the works catalog (#2453).
+ *
+ * Source: github.com/kanripo/KR-Catalog — org-mode files, one heading per work:
+ *   *** KR1a0002 子夏易傳-周-卜商        (title-dynasty-author)
+ *   :PROPERTIES: ... :KR_ID: / :SOURCE: 四庫全書 文淵閣版 / :EXTENT: 11 卷
+ *
+ * ~10,142 works, all with open transcriptions (each KR id is a git repo at
+ * github.com/kanripo/{KR_ID}). 3,477 are explicitly SKQS-sourced.
+ *
+ * Idempotent. Usage (Hetzner, where SUPABASE_DB_URL lives):
+ *   set -a; source .env.production.local; set +a; node scripts/works-catalog/ingest-kanripo.mjs
+ */
+import { pgClient, normalizeCjk, fetchRetry, upsertWorks, upsertSources } from './lib.mjs';
+
+const SECTION_TAG = { KR1: 'jing-classics', KR2: 'shi-histories', KR3: 'zi-masters', KR4: 'ji-belles-lettres', KR5: 'daozang', KR6: 'buddhist-canon' };
+
+const idx = await (await fetchRetry('https://api.github.com/repos/kanripo/KR-Catalog/contents/KR', { headers: { 'User-Agent': 'SourceLibrary-WorksCatalog/1.0 (derek@sourcelibrary.org)' } })).json();
+if (!Array.isArray(idx)) { console.error('GitHub API error:', idx.message); process.exit(1); }
+
+const works = [];
+const sources = [];
+for (const f of idx.filter(f => f.name.endsWith('.txt'))) {
+  const txt = await (await fetchRetry(`https://raw.githubusercontent.com/kanripo/KR-Catalog/master/KR/${f.name}`)).text();
+  // section header: ** KR1a ZB1a 易類
+  const section = (txt.match(/^\*\* (KR\S+)\s+\S+\s+(\S+)/m) || [])[2] || null;
+  // split on work headings; each block = heading line + properties drawer
+  const blocks = txt.split(/^\*\*\* /m).slice(1);
+  for (const block of blocks) {
+    const headline = block.split('\n')[0].trim();
+    const m = headline.match(/^(KR\S+)\s+(.+)$/);
+    if (!m) continue;
+    const krId = m[1];
+    // title-dynasty-author; title itself never contains '-' in this catalog
+    const [title, dynasty, author] = m[2].split('-').map(s => s?.trim() || null);
+    if (!title) continue;
+    const prop = name => (block.match(new RegExp(`^\\s*:${name}:\\s*(.+)$`, 'm')) || [])[1]?.trim() || null;
+    const skqsSource = prop('SOURCE');
+    const isSkqs = /四庫全書/.test(skqsSource || '');
+    const top = krId.slice(0, 3);
+    const tags = [SECTION_TAG[top]].filter(Boolean);
+    if (isSkqs) tags.push('siku-quanshu');
+    works.push({
+      id: `kr:${krId}`,
+      tradition: 'chinese',
+      original_language: 'lzh',
+      title,
+      title_normalized: normalizeCjk(title),
+      author: author || null,
+      authority_ids: { kanripo_id: krId },
+      corpus_tags: tags,
+      source_catalog: 'kanripo',
+      extra: {
+        dynasty: dynasty || null,
+        kr_section: section,
+        kr_custom_id: prop('CUSTOM_ID'),
+        kr_source: skqsSource,
+        extent: prop('EXTENT'),
+      },
+    });
+    sources.push({
+      work_id: `kr:${krId}`,
+      source: 'kanripo',
+      source_id: krId,
+      kind: 'transcription',
+      url: `https://github.com/kanripo/${krId}`,
+      iiif: false,
+    });
+  }
+  process.stderr.write(`${f.name}: ${works.length} works so far\n`);
+}
+
+console.log(`Parsed ${works.length} works (${works.filter(w => w.corpus_tags.includes('siku-quanshu')).length} SKQS-sourced)`);
+
+const client = pgClient();
+await client.connect();
+const nW = await upsertWorks(client, works);
+const nS = await upsertSources(client, sources);
+const count = (await client.query(`select count(*) n from works where source_catalog = 'kanripo'`)).rows[0].n;
+await client.end();
+console.log(`Upserted ${nW} works, ${nS} sources. works(source_catalog=kanripo) = ${count}`);

--- a/scripts/works-catalog/ingest-openiti.mjs
+++ b/scripts/works-catalog/ingest-openiti.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Ingest the OpenITI corpus (work-level Arabic/Persian Islamicate texts) into
+ * the works catalog (#2453).
+ *
+ * Source: OpenITI/kitab-metadata-automation `all_book_meta.json` (~8.9K works,
+ * URIs like 0179MalikIbnAnas.Muwatta — AH death-date + author + work) and
+ * `all_author_meta.json` for author display names. Every work has open
+ * mARkdown transcriptions (versions[]).
+ *
+ * Gotcha: raw.githubusercontent truncates these multi-MB files mid-stream
+ * with HTTP 200 — parse-inside-retry, and prefer the jsDelivr mirror.
+ *
+ * Idempotent.
+ *   set -a; source .env.production.local; set +a; node scripts/works-catalog/ingest-openiti.mjs
+ */
+import { pgClient, sleep, upsertWorks, upsertSources } from './lib.mjs';
+
+async function fetchJson(path, tries = 5) {
+  const urls = [
+    `https://cdn.jsdelivr.net/gh/OpenITI/kitab-metadata-automation@master/output/${path}`,
+    `https://raw.githubusercontent.com/OpenITI/kitab-metadata-automation/master/output/${path}`,
+  ];
+  for (let i = 0; i < tries; i++) {
+    try {
+      const res = await fetch(urls[i % urls.length]);
+      return JSON.parse(await res.text()); // truncation shows up here, not as an HTTP error
+    } catch (e) {
+      if (i === tries - 1) throw e;
+      process.stderr.write(`fetch ${path} attempt ${i + 1} failed (${e.message.slice(0, 60)}), retrying\n`);
+      await sleep(3000);
+    }
+  }
+}
+
+const books = await fetchJson('OpenITI_Github_clone_all_book_meta.json');
+const authors = await fetchJson('OpenITI_Github_clone_all_author_meta.json');
+console.log(`OpenITI: ${Object.keys(books).length} works, ${Object.keys(authors).length} authors`);
+
+function authorInfo(authorUri) {
+  const a = authors[authorUri];
+  if (!a) return { name: null, qid: null };
+  // prefer the Latin shuhra ("famous name"), fall back to Latin/Arabic name lists
+  const name = a.shuhra || a.author_lat?.[0] || a.author_ar?.[0] || null;
+  const qid = (a.external_id?.match(/wikidata@(Q\d+)/) || [])[1] || null;
+  return { name, qid };
+}
+
+const works = [];
+const sources = [];
+for (const [uri, b] of Object.entries(books)) {
+  const m = uri.match(/^(\d{4})([A-Za-z]+)\.(\S+)$/);
+  if (!m) continue;
+  const [, ahStr, authorKey] = m;
+  const authorUri = ahStr + authorKey;
+  const ah = parseInt(ahStr, 10);
+  const ceYear = Math.round(ah * 0.970225 + 621.54); // AH -> CE
+  const titleAr = (b.title_ar || []).find(t => t?.trim()) || null;
+  const titleLat = (b.title_lat || []).find(t => t?.trim()) || null;
+  if (!titleAr && !titleLat) continue;
+  // language: majority vote over version URI suffixes (-ara1, -per1, ...)
+  const langs = (b.versions || []).map(v => (v.match(/-([a-z]{3})\d*$/) || [])[1]).filter(Boolean);
+  const lang = langs.sort((a, c) => langs.filter(x => x === c).length - langs.filter(x => x === a).length)[0] || 'ara';
+  const { name: authorName, qid: authorQid } = authorInfo(authorUri);
+  works.push({
+    id: `oiti:${uri}`,
+    tradition: 'islamicate',
+    original_language: lang,
+    title: titleAr || titleLat,
+    title_normalized: (titleAr || titleLat).replace(/\s+/g, ' ').trim(),
+    title_romanized: titleLat,
+    author: authorName || authorKey.replace(/([a-z])([A-Z])/g, '$1 $2'),
+    century: Math.floor(ceYear / 100) + 1, // author death century, CE — composition proxy
+    authority_ids: { openiti_uri: uri, openiti_author: authorUri, ...(authorQid ? { author_wikidata_qid: authorQid } : {}) },
+    corpus_tags: ['openiti'],
+    source_catalog: 'openiti',
+    extra: {
+      author_death_ah: ah,
+      author_death_ce: ceYear,
+      genre_tags: (b.genre_tags || []).slice(0, 12),
+      n_versions: (b.versions || []).length,
+      relations: (b.relations || []).length,
+    },
+  });
+  sources.push({
+    work_id: `oiti:${uri}`,
+    source: 'openiti',
+    source_id: uri,
+    kind: 'transcription',
+    url: `https://github.com/OpenITI/${ahStr}AH`, // 25-years repo bucket; exact path in extra
+    iiif: false,
+    extra: { versions: (b.versions || []).slice(0, 5) },
+  });
+}
+
+console.log(`Parsed ${works.length} works (langs: ${[...new Set(works.map(w => w.original_language))].join(', ')})`);
+const client = pgClient();
+await client.connect();
+const nW = await upsertWorks(client, works);
+const nS = await upsertSources(client, sources);
+const count = (await client.query(`select count(*) n from works where source_catalog = 'openiti'`)).rows[0].n;
+await client.end();
+console.log(`Upserted ${nW} works, ${nS} sources. works(source_catalog=openiti) = ${count}`);

--- a/scripts/works-catalog/ingest-siku-wikidata.mjs
+++ b/scripts/works-catalog/ingest-siku-wikidata.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Join the Siku Quanshu Wikidata denominator (3,418 QIDs, from the translation
+ * census #2234) onto the works catalog (#2453).
+ *
+ * For each QID: fetch zh labels, match to an existing kr: work by normalized
+ * title (variant glyphs handled in lib). On match → set wikidata_qid +
+ * 'siku-quanshu' tag + English title/aliases. No match → create a wd: work row
+ * so the denominator is fully represented.
+ *
+ * Also writes translation_status for the census labeled-stratum verdicts
+ * (method 'census-auto' — a recall floor, see memory; hand-verified upgrades
+ * come later).
+ *
+ * Run AFTER ingest-kanripo.mjs. Idempotent.
+ *   set -a; source .env.production.local; set +a; node scripts/works-catalog/ingest-siku-wikidata.mjs
+ */
+import { readFileSync } from 'fs';
+import { pgClient, normalizeCjk, fetchRetry, sleep, upsertWorks } from './lib.mjs';
+
+const denom = JSON.parse(readFileSync('scripts/analysis/siku-denominator.json', 'utf8'));
+const census = JSON.parse(readFileSync('scripts/analysis/siku-census-results.json', 'utf8'));
+const translatedQids = new Map(census.labeled_hits.map(h => [h.qid, h.evidence]));
+
+const client = pgClient();
+await client.connect();
+
+// kr: works lookup by normalized title
+const kr = await client.query(`select id, title_normalized from works where id like 'kr:%'`);
+const krByNorm = new Map(kr.rows.map(r => [r.title_normalized, r.id]));
+console.log(`Loaded ${krByNorm.size} kanripo works for matching`);
+
+// zh labels for all QIDs, batched 50/call
+const zhByQid = {};
+for (let i = 0; i < denom.length; i += 50) {
+  const ids = denom.slice(i, i + 50).map(w => w.qid).join('|');
+  const j = await (await fetchRetry(
+    `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${ids}&props=labels|aliases&languages=zh|zh-hant|zh-hans|lzh&format=json`,
+    { headers: { 'User-Agent': 'SourceLibrary-WorksCatalog/1.0 (derek@sourcelibrary.org)' } })).json();
+  for (const [qid, ent] of Object.entries(j.entities || {})) {
+    const set = new Set();
+    for (const lang of ['zh-hant', 'lzh', 'zh', 'zh-hans'])
+      for (const v of [ent.labels?.[lang]?.value, ...(ent.aliases?.[lang] || []).map(a => a.value)]) if (v) set.add(v);
+    zhByQid[qid] = [...set];
+  }
+  await sleep(400);
+  if (i % 500 === 0) process.stderr.write(`labels ${i}/${denom.length}\n`);
+}
+
+let matched = 0;
+const newWorks = [];
+for (const w of denom) {
+  const zh = zhByQid[w.qid] || [];
+  const en = w.enLabel && /[a-z]/i.test(w.enLabel) ? w.enLabel : (/[a-z]/i.test(w.label) ? w.label : null);
+  // strip "(Siku Quanshu)" style edition suffixes from English display titles
+  const enClean = en?.replace(/\s*\((Siku Quanshu|四庫全書)[^)]*\)\s*$/i, '') || null;
+  let krId = null;
+  for (const t of zh) { krId = krByNorm.get(normalizeCjk(t)); if (krId) break; }
+  const status = translatedQids.has(w.qid)
+    ? { s: 'partial', ev: translatedQids.get(w.qid), m: 'census-auto' }
+    : null;
+  if (krId) {
+    matched++;
+    await client.query(
+      `update works set
+         wikidata_qid = coalesce(wikidata_qid, $2),
+         title_english = coalesce(title_english, $3),
+         corpus_tags = (select array(select distinct unnest(corpus_tags || '{siku-quanshu}'))),
+         authority_ids = authority_ids || jsonb_build_object('siku_qid', $2),
+         translation_status = case when $4::text is not null and translation_status = 'unknown' then $4 else translation_status end,
+         translation_evidence = coalesce(translation_evidence, $5),
+         translation_method = coalesce(translation_method, $6),
+         updated_at = now()
+       where id = $1`,
+      [krId, w.qid, enClean, status?.s ?? null, status?.ev ?? null, status ? status.m : null]);
+  } else {
+    const title = zh[0] || w.label;
+    newWorks.push({
+      id: `wd:${w.qid}`,
+      tradition: 'chinese',
+      original_language: 'lzh',
+      title,
+      title_normalized: normalizeCjk(title),
+      title_english: enClean,
+      wikidata_qid: w.qid,
+      authority_ids: { siku_qid: w.qid },
+      corpus_tags: ['siku-quanshu'],
+      source_catalog: 'wikidata-siku',
+      extra: { wikidata_description: w.desc || null, aliases: (w.alts || []).slice(0, 10) },
+    });
+  }
+}
+
+const inserted = await upsertWorks(client, newWorks);
+// census verdicts for wd: rows
+for (const [qid, ev] of translatedQids) {
+  await client.query(
+    `update works set translation_status = 'partial', translation_evidence = $2, translation_method = 'census-auto', updated_at = now()
+     where id = $1 and translation_status = 'unknown'`, [`wd:${qid}`, ev]);
+}
+
+const stats = (await client.query(`
+  select count(*) filter (where 'siku-quanshu' = any(corpus_tags)) total,
+         count(*) filter (where wikidata_qid is not null and 'siku-quanshu' = any(corpus_tags)) with_qid
+  from works where tradition = 'chinese'`)).rows[0];
+await client.end();
+console.log(`QID-matched to kanripo: ${matched}/${denom.length}; new wd: works: ${inserted}`);
+console.log(`siku-quanshu tagged works: ${stats.total} (${stats.with_qid} with QID)`);

--- a/scripts/works-catalog/lib.mjs
+++ b/scripts/works-catalog/lib.mjs
@@ -1,0 +1,109 @@
+// Shared helpers for the universal works catalog ingests (#2453).
+import pg from 'pg';
+
+export function pgClient() {
+  const url = process.env.SUPABASE_DB_URL;
+  if (!url) {
+    console.error('SUPABASE_DB_URL required (Hetzner-only — run there or tunnel)');
+    process.exit(1);
+  }
+  return new pg.Client({ connectionString: url, statement_timeout: 0 });
+}
+
+// CJK variant-glyph normalization. Wikidata zh labels, Kanripo titles, and
+// IA-CADAL titles disagree on variant forms (説/說, 録/錄, …) — raw string
+// match had a 28% false-miss rate in the 2026-06-06 gap analysis. Extend as
+// new variants surface; keep TARGET forms = the traditional forms Kanripo uses.
+const CJK_VARIANTS = {
+  '説': '說', '録': '錄', '黙': '默', '寳': '寶', '寶': '寶', '様': '樣',
+  '歴': '歷', '厯': '歷', '戸': '戶', '畧': '略', '䟽': '疏', '㴑': '溯',
+  '経': '經', '禅': '禪', '蔵': '藏', '徳': '德', '紀': '記', '叙': '敘',
+  '温': '溫', '况': '況', '寛': '寬', '隷': '隸', '効': '效', '勅': '敕',
+  '顔': '顏', '恵': '惠', '虚': '虛', '満': '滿', '単': '單', '専': '專',
+};
+
+export function normalizeCjk(s) {
+  return [...(s || '')]
+    .map(c => CJK_VARIANTS[c] || c)
+    .join('')
+    .replace(/[()（）\s]/g, '');
+}
+
+export async function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+export async function fetchRetry(url, opts = {}, tries = 4) {
+  for (let i = 0; i < tries; i++) {
+    try {
+      const res = await fetch(url, opts);
+      if (res.status >= 500 && i < tries - 1) { await sleep(3000 * (i + 1)); continue; }
+      return res;
+    } catch (e) {
+      if (i === tries - 1) throw e;
+      await sleep(3000 * (i + 1));
+    }
+  }
+}
+
+// Batched upsert into works. Rows: array of objects with works columns.
+// ON CONFLICT updates the mutable fields but never downgrades translation
+// status fields that another ingest set (COALESCE keeps existing non-null).
+export async function upsertWorks(client, rows, { batch = 500 } = {}) {
+  let n = 0;
+  for (let i = 0; i < rows.length; i += batch) {
+    const chunk = rows.slice(i, i + batch);
+    const cols = ['id','tradition','original_language','title','title_normalized','title_romanized',
+      'title_english','author','century','wikidata_qid','authority_ids','corpus_tags','source_catalog','extra'];
+    const values = [];
+    const params = [];
+    chunk.forEach((r, j) => {
+      const base = j * cols.length;
+      values.push(`(${cols.map((_, k) => `$${base + k + 1}`).join(',')})`);
+      params.push(r.id, r.tradition, r.original_language ?? null, r.title, r.title_normalized ?? null,
+        r.title_romanized ?? null, r.title_english ?? null, r.author ?? null, r.century ?? null,
+        r.wikidata_qid ?? null, JSON.stringify(r.authority_ids ?? {}), r.corpus_tags ?? [],
+        r.source_catalog, JSON.stringify(r.extra ?? {}));
+    });
+    const res = await client.query(
+      `insert into works (${cols.join(',')}) values ${values.join(',')}
+       on conflict (id) do update set
+         title_romanized = coalesce(excluded.title_romanized, works.title_romanized),
+         title_english   = coalesce(excluded.title_english, works.title_english),
+         author          = coalesce(excluded.author, works.author),
+         century         = coalesce(excluded.century, works.century),
+         wikidata_qid    = coalesce(excluded.wikidata_qid, works.wikidata_qid),
+         authority_ids   = works.authority_ids || excluded.authority_ids,
+         corpus_tags     = (select array(select distinct unnest(works.corpus_tags || excluded.corpus_tags))),
+         extra           = works.extra || excluded.extra,
+         updated_at      = now()`,
+      params,
+    );
+    n += res.rowCount;
+  }
+  return n;
+}
+
+export async function upsertSources(client, rows, { batch = 500 } = {}) {
+  let n = 0;
+  for (let i = 0; i < rows.length; i += batch) {
+    const chunk = rows.slice(i, i + batch);
+    const cols = ['work_id','source','source_id','kind','url','iiif','coverage','extra'];
+    const values = [];
+    const params = [];
+    chunk.forEach((r, j) => {
+      const base = j * cols.length;
+      values.push(`(${cols.map((_, k) => `$${base + k + 1}`).join(',')})`);
+      params.push(r.work_id, r.source, r.source_id, r.kind, r.url ?? null,
+        r.iiif ?? false, r.coverage ?? null, JSON.stringify(r.extra ?? {}));
+    });
+    const res = await client.query(
+      `insert into work_sources (${cols.join(',')}) values ${values.join(',')}
+       on conflict (work_id, source, source_id) do update set
+         url = coalesce(excluded.url, work_sources.url),
+         coverage = coalesce(excluded.coverage, work_sources.coverage),
+         extra = work_sources.extra || excluded.extra`,
+      params,
+    );
+    n += res.rowCount;
+  }
+  return n;
+}

--- a/scripts/works-catalog/lib.mjs
+++ b/scripts/works-catalog/lib.mjs
@@ -48,6 +48,10 @@ export async function fetchRetry(url, opts = {}, tries = 4) {
 // ON CONFLICT updates the mutable fields but never downgrades translation
 // status fields that another ingest set (COALESCE keeps existing non-null).
 export async function upsertWorks(client, rows, { batch = 500 } = {}) {
+  // dedupe by id within the call — ON CONFLICT can't update the same row twice
+  // in one statement (KR-Catalog has a handful of duplicate headings)
+  const seen = new Set();
+  rows = rows.filter(r => !seen.has(r.id) && seen.add(r.id));
   let n = 0;
   for (let i = 0; i < rows.length; i += batch) {
     const chunk = rows.slice(i, i + batch);
@@ -83,6 +87,11 @@ export async function upsertWorks(client, rows, { batch = 500 } = {}) {
 }
 
 export async function upsertSources(client, rows, { batch = 500 } = {}) {
+  const seen = new Set();
+  rows = rows.filter(r => {
+    const k = `${r.work_id}|${r.source}|${r.source_id}`;
+    return !seen.has(k) && seen.add(k);
+  });
   let n = 0;
   for (let i = 0; i < rows.length; i += batch) {
     const chunk = rows.slice(i, i + batch);

--- a/scripts/works-catalog/schema.sql
+++ b/scripts/works-catalog/schema.sql
@@ -1,0 +1,75 @@
+-- Universal works catalog (pre-1900) — issue #2453
+-- Work-level union catalog across traditions. Sits ABOVE edition/item-level
+-- registries (ustc_editions, import_candidates from #2447): L3 in the #2447
+-- dedup vocabulary. Never collapse different works; editions/copies hang off
+-- a work via work_sources, our books via work_holdings.
+--
+-- Apply with: node scripts/works-catalog/apply-schema.mjs  (needs SUPABASE_DB_URL)
+
+create extension if not exists pg_trgm;
+
+create table if not exists works (
+  id text primary key,                    -- prefixed authority id: 'kr:KR1a0002', 'oiti:0179MalikIbnAnas.Muwatta', 'bdrc:WA0RK0529', 'wd:Q844278'
+  tradition text not null,                -- 'chinese' | 'tibetan' | 'arabic' | 'latin' | 'sanskrit' | 'greek' | 'hebrew' | ...
+  original_language text,                 -- ISO 639-3 where known: 'lzh', 'bod', 'ara', 'fas', ...
+  title text not null,                    -- canonical title in original script
+  title_normalized text,                  -- variant-normalized matching form (CJK variant glyphs, etc.)
+  title_romanized text,                   -- pinyin / Wylie / transliteration
+  title_english text,
+  author text,                            -- display form; thesaurus linking is a later pass
+  author_id text,                         -- -> Mongo authors._id (canonical author thesaurus), when resolved
+  century int,                            -- rough composition century (e.g. 13 = 1200s); null if unknown
+  wikidata_qid text,
+  authority_ids jsonb not null default '{}',  -- {"kanripo_id":..., "openiti_uri":..., "bdrc_id":..., "siku_qid":...}
+  corpus_tags text[] not null default '{}',   -- {'siku-quanshu','daozang','cbeta','kangyur','tengyur',...}
+  -- Translation status is an evidenced CLAIM, never a bare boolean
+  -- (see CLAUDE.md "is_first_translation is a claim, not deliverable").
+  translation_status text not null default 'unknown'
+    check (translation_status in ('unknown','none','partial','full')),
+  translation_evidence text,              -- citation / URL for the status
+  translation_method text                 -- 'census-auto' | 'hand-verified' | 'claimed'
+    check (translation_method is null or translation_method in ('census-auto','hand-verified','claimed')),
+  source_catalog text not null,           -- ingest provenance: 'kanripo' | 'wikidata-siku' | 'openiti' | 'bdrc' | ...
+  extra jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists works_tradition_idx on works (tradition);
+create index if not exists works_qid_idx on works (wikidata_qid) where wikidata_qid is not null;
+create index if not exists works_translation_idx on works (tradition, translation_status);
+-- trgm on the RAW columns we actually query (lesson: index expression must
+-- match the query expression — lower() drift caused the ustc_editions seq scans)
+create index if not exists works_title_norm_trgm on works using gin (title_normalized gin_trgm_ops);
+create index if not exists works_title_english_trgm on works using gin (title_english gin_trgm_ops);
+
+create table if not exists work_sources (
+  id bigserial primary key,
+  work_id text not null references works(id) on delete cascade,
+  source text not null,                   -- 'kanripo' | 'ia-cadal' | 'harvard-yenching' | 'bdrc' | 'openiti' | 'waseda' | ...
+  source_id text not null,                -- KR id / IA identifier / FHCL id / BDRC W-id / OpenITI version URI
+  kind text not null check (kind in ('scan','transcription','translation')),
+  url text,
+  iiif boolean not null default false,
+  coverage text,                          -- juan/volume range for multi-volume items ('卷4-5', 'vol. 2', null = whole work)
+  extra jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  unique (work_id, source, source_id)
+);
+
+create index if not exists work_sources_source_idx on work_sources (source);
+create index if not exists work_sources_work_idx on work_sources (work_id);
+
+create table if not exists work_holdings (
+  id bigserial primary key,
+  work_id text not null references works(id) on delete cascade,
+  book_id text not null,                  -- Mongo books._id (string form)
+  coverage text,                          -- juan/volume range we hold; null = whole work
+  pages int,
+  translated_pct numeric,
+  matched_by text,                        -- 'title-auto' | 'hand-verified'
+  created_at timestamptz not null default now(),
+  unique (work_id, book_id)
+);
+
+create index if not exists work_holdings_book_idx on work_holdings (book_id);


### PR DESCRIPTION
## What

First implementation slice of #2453 — the work-level union catalog (L3 of #2447's dedup vocabulary). New `scripts/works-catalog/`:

- **`schema.sql` + `apply-schema.mjs`** — Supabase tables `works` / `work_sources` / `work_holdings`. Prefixed authority ids (`kr:`, `oiti:`, `bdrc:`, `wd:`), evidenced `translation_status` (status + evidence + method, never a bare boolean — the `is_first_translation` lesson), trgm indexes on **raw** columns (the `ustc_editions` lower()-drift lesson).
- **`ingest-kanripo.mjs`** — 10,141 Chinese works from the Kanseki Repository catalog (3,462 SKQS-sourced), each with an open-transcription `work_sources` row.
- **`ingest-siku-wikidata.mjs`** — joins the 3,418-QID Siku census denominator onto `kr:` works by variant-normalized title (2,748 matched = 80%; 670 new `wd:` rows); census verdicts land as `census-auto` translation claims.
- **`ingest-openiti.mjs`** — 8,791 Islamicate works (OpenITI), author shuhra + author Wikidata QIDs, AH→CE centuries.
- **`ingest-bdrc.mjs`** — Tibetan: two-phase (resumable disk-cached harvest of ~48.5K sitemap-enumerated MW records → WA-clustered load). BDRC has no SPARQL/dump; per-resource JSON-LD (CC0) is the only complete route.

## Already run (idempotent, re-runnable)

Schema applied + three ingests executed from Hetzner: **19,602 works** live (`chinese` 10,811, `islamicate` 8,791), 18,932 `work_sources` transcription rows, 4 census-auto translation claims. BDRC harvest is running on Hetzner (`/root/works-catalog-cache/bdrc/`, ~3h); `--load` adds the `tibetan` tradition after it completes.

## Out of scope (follow-ups per #2453)

- `work_holdings` join to our Mongo books
- IA-CADAL / Harvard-Yenching scan sources for Chinese works (#2447 workstreams)
- Latin/USTC work-clustering (#2318), Greek/Hebrew/Sanskrit ingests
- BDRC author resolution (P-ids stored in `authority_ids` for now)

## Notes for review

- `SUPABASE_DB_URL` is Hetzner-only; all run instructions assume that (README).
- raw.githubusercontent truncates multi-MB files with HTTP 200 — OpenITI ingest uses jsDelivr + parse-inside-retry.
- One catalog landmine documented in README: never collapse different works; editions/copies are `work_sources` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)