### PR TITLE
fix(iiif-discovery): ia-language adapter killed at 300s by withMongo default timeout

### DIFF
--- a/scripts/iiif-discovery/sources/ia-language.mjs
+++ b/scripts/iiif-discovery/sources/ia-language.mjs
@@ -137,6 +137,8 @@ async function filterNew(db, candidates) {
   return candidates.filter(c => !seen.has(c.manifest_url));
 }
 
+// noTimeout: withMongo's 300s zombie-killer force-exits long runs — a full
+// language sweep (chinese: 717K items, ~72 batches) takes 15+ minutes.
 await withMongo(async (db) => {
   await ensureIndexes(db);
 
@@ -243,4 +245,4 @@ await withMongo(async (db) => {
   if (cursor && totalDiscovered >= MAX_RECORDS) {
     console.log(`Stopped at --max-records. Resume with: --cursor=${cursor}`);
   }
-});
+}, { noTimeout: true });


### PR DESCRIPTION
Follow-up to #2457. `withMongo()` defaults to a 300s safety timeout that force-exits the process. A full IA language sweep runs much longer (chinese: 717K items ≈ 15+ min) — the production chinese harvest was killed at batch 32/72 (319,980 staged) with `[mongo] Script timeout after 300s — forcing exit`. Latin (200K, ~260s) only finished by luck.

One-line fix: pass `{ noTimeout: true }`, same as other long-running workers. The run is already resumable via `--cursor`, so the killed sweep continues from batch 32 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)