### PR TITLE
feat(works-catalog): IA-CADAL scan sources + Mongo holdings join (#2453)

### DIFF
--- a/scripts/works-catalog/README.md
+++ b/scripts/works-catalog/README.md
@@ -22,7 +22,9 @@ node scripts/works-catalog/apply-schema.mjs        # idempotent DDL
 node scripts/works-catalog/ingest-kanripo.mjs      # ~10.1K Chinese works (Kanseki Repository)
 node scripts/works-catalog/ingest-siku-wikidata.mjs # 3,418 Siku QIDs joined onto kr: works
 node scripts/works-catalog/ingest-openiti.mjs      # ~8.9K Islamicate works (Arabic/Persian)
-node scripts/works-catalog/ingest-bdrc.mjs         # Tibetan works (BUDA linked data)
+node scripts/works-catalog/ingest-bdrc.mjs         # Tibetan works (BUDA linked data; --harvest then --load)
+node scripts/works-catalog/ingest-ia-cadal.mjs     # IA-CADAL scan volumes -> chinese work_sources
+node scripts/works-catalog/build-holdings.mjs      # Mongo books -> work_holdings (title-auto)
 ```
 
 All idempotent (upserts). Env: `set -a; source .env.production.local; set +a`.

--- a/scripts/works-catalog/build-holdings.mjs
+++ b/scripts/works-catalog/build-holdings.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Map our Mongo books onto catalog works -> work_holdings (#2453).
+ *
+ * v1 matching is deliberately conservative (matched_by 'title-auto'):
+ *  - Chinese works: extract CJK runs from the book title, variant-normalize,
+ *    exact-match against works.title_normalized (tradition 'chinese').
+ *    Longest CJK run wins; runs < 2 chars ignored.
+ *  - Other traditions: exact match of the full normalized book title against
+ *    title_normalized or title_romanized (case-insensitive) — rare, but free.
+ * No fuzzy matching in v1: a wrong holding is worse than a missing one.
+ * Re-runnable; clears and rebuilds only rows with matched_by 'title-auto'.
+ *
+ *   set -a; source .env.production.local; set +a; node scripts/works-catalog/build-holdings.mjs
+ */
+import { MongoClient } from 'mongodb';
+import { pgClient, normalizeCjk } from './lib.mjs';
+
+const client = pgClient();
+await client.connect();
+
+// works lookup
+const works = await client.query(`select id, tradition, title_normalized, title_romanized from works`);
+const cjkByNorm = new Map();
+const romByNorm = new Map();
+for (const w of works.rows) {
+  if (w.tradition === 'chinese' && w.title_normalized && !cjkByNorm.has(w.title_normalized)) {
+    cjkByNorm.set(w.title_normalized, w.id);
+  }
+  if (w.title_romanized) {
+    const k = w.title_romanized.toLowerCase().replace(/[^a-z]/g, '');
+    if (k.length >= 8 && !romByNorm.has(k)) romByNorm.set(k, w.id);
+  }
+}
+console.log(`works: ${works.rows.length} (${cjkByNorm.size} CJK keys, ${romByNorm.size} romanized keys)`);
+
+const mongo = new MongoClient(process.env.MONGODB_URI);
+await mongo.connect();
+const books = mongo.db('bookstore').collection('books');
+const cur = books.find(
+  { pages_count: { $gt: 0 } },
+  { projection: { title: 1, language: 1, pages_count: 1, pages_translated: 1, pages_ocr: 1, visible: 1 } },
+);
+
+const holdings = [];
+let scanned = 0;
+for await (const b of cur) {
+  scanned++;
+  const title = String(b.title || '');
+  let workId = null;
+  // CJK runs, longest first; require >= 2 chars
+  const runs = (title.match(/[㐀-鿿]{2,}/g) || []).sort((a, c) => c.length - a.length);
+  for (const run of runs) {
+    workId = cjkByNorm.get(normalizeCjk(run));
+    if (workId) break;
+  }
+  if (!workId && !runs.length) {
+    const k = title.toLowerCase().replace(/[^a-z]/g, '');
+    if (k.length >= 8) workId = romByNorm.get(k) || null;
+  }
+  if (!workId) continue;
+  const readable = (b.pages_ocr || b.pages_count || 0);
+  holdings.push({
+    work_id: workId,
+    book_id: String(b._id),
+    pages: b.pages_count || null,
+    translated_pct: readable > 0 ? Math.min(100, Math.round(100 * (b.pages_translated || 0) / readable)) : null,
+  });
+}
+await mongo.close();
+console.log(`scanned ${scanned} books -> ${holdings.length} title-auto matches`);
+
+// rebuild title-auto rows (keep any future hand-verified rows)
+await client.query(`delete from work_holdings where matched_by = 'title-auto'`);
+for (let i = 0; i < holdings.length; i += 500) {
+  const chunk = holdings.slice(i, i + 500);
+  const values = [];
+  const params = [];
+  chunk.forEach((h, j) => {
+    const base = j * 4;
+    values.push(`($${base + 1},$${base + 2},$${base + 3},$${base + 4},'title-auto')`);
+    params.push(h.work_id, h.book_id, h.pages, h.translated_pct);
+  });
+  await client.query(
+    `insert into work_holdings (work_id, book_id, pages, translated_pct, matched_by)
+     values ${values.join(',')}
+     on conflict (work_id, book_id) do update set
+       pages = excluded.pages, translated_pct = excluded.translated_pct`,
+    params,
+  );
+}
+const stats = (await client.query(`
+  select w.tradition, count(distinct h.work_id) works_held, count(*) books
+  from work_holdings h join works w on w.id = h.work_id group by 1`)).rows;
+await client.end();
+console.log('holdings by tradition:', JSON.stringify(stats));

--- a/scripts/works-catalog/ingest-ia-cadal.mjs
+++ b/scripts/works-catalog/ingest-ia-cadal.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Attach IA-CADAL facsimile scans to Chinese works (#2453, feeds #2447).
+ *
+ * IA's `collection:universallibrary` holds 78K+ CADAL scans (identifiers
+ * `NNNNNNNN.cn`, sponsor "China-America Digital Academic Library"). Items are
+ * VOLUME-level: titles like 毛詩注疏·卷四~卷五 — base title before '·',
+ * juan coverage after. We group by variant-normalized base title, match to
+ * existing chinese works, and write one work_sources row per volume with
+ * coverage preserved (never collapse volumes into each other — the work/
+ * edition/item invariant).
+ *
+ * Manifest URL is a pure function of the identifier (iiif.archive.org), so
+ * no per-item fetches are needed.
+ *
+ * Idempotent. ~78K items via IA's cursor scrape API (fast, ~8 calls).
+ *   node scripts/works-catalog/ingest-ia-cadal.mjs
+ */
+import { pgClient, normalizeCjk, fetchRetry, sleep, upsertSources } from './lib.mjs';
+
+// 1. full sweep of the collection via the scrape API (cursor-based)
+const items = [];
+let cursor = null;
+for (;;) {
+  const url = `https://archive.org/services/search/v1/scrape?q=${encodeURIComponent('collection:universallibrary')}&fields=identifier,title,language&count=10000${cursor ? `&cursor=${cursor}` : ''}`;
+  const j = await (await fetchRetry(url, { headers: { 'User-Agent': 'SourceLibrary-WorksCatalog/1.0 (derek@sourcelibrary.org)' } })).json();
+  items.push(...(j.items || []));
+  process.stderr.write(`scraped ${items.length}/${j.total}\n`);
+  if (!j.cursor) break;
+  cursor = j.cursor;
+  await sleep(1000);
+}
+// CADAL items are the .cn identifiers; the collection also has Indic/English material
+const cn = items.filter(i => /\.cn$/.test(i.identifier) && i.title);
+console.log(`IA universallibrary: ${items.length} items, ${cn.length} CADAL .cn items`);
+
+// 2. group by base title (before '·'), keep coverage suffix per volume
+const groups = new Map(); // normalized base -> [{identifier, title, coverage}]
+for (const it of cn) {
+  const title = String(it.title);
+  const dot = title.indexOf('·');
+  const base = (dot > 0 ? title.slice(0, dot) : title).trim();
+  const coverage = dot > 0 ? title.slice(dot + 1).trim() : null;
+  const norm = normalizeCjk(base);
+  if (!norm) continue;
+  if (!groups.has(norm)) groups.set(norm, []);
+  groups.get(norm).push({ identifier: it.identifier, title, coverage });
+}
+console.log(`${groups.size} distinct base titles`);
+
+// 3. match to chinese works by normalized title
+const client = pgClient();
+await client.connect();
+const works = await client.query(`select id, title_normalized from works where tradition = 'chinese'`);
+const byNorm = new Map();
+for (const w of works.rows) {
+  if (!byNorm.has(w.title_normalized)) byNorm.set(w.title_normalized, w.id);
+}
+
+const sources = [];
+let matchedWorks = 0, matchedVols = 0;
+for (const [norm, vols] of groups) {
+  const workId = byNorm.get(norm);
+  if (!workId) continue;
+  matchedWorks++;
+  matchedVols += vols.length;
+  for (const v of vols) {
+    sources.push({
+      work_id: workId,
+      source: 'ia-cadal',
+      source_id: v.identifier,
+      kind: 'scan',
+      url: `https://iiif.archive.org/iiif/${v.identifier}/manifest.json`,
+      iiif: true,
+      coverage: v.coverage,
+      extra: { ia_title: v.title },
+    });
+  }
+}
+console.log(`Matched ${matchedWorks} works / ${matchedVols} volumes (${groups.size - matchedWorks} base titles unmatched — editions of works outside the catalog)`);
+
+const n = await upsertSources(client, sources);
+const stats = (await client.query(`
+  select count(distinct work_id) works, count(*) vols from work_sources where source = 'ia-cadal'`)).rows[0];
+await client.end();
+console.log(`Upserted ${n} sources. ia-cadal now: ${stats.works} works, ${stats.vols} volume rows`);


### PR DESCRIPTION
## What

Second slice of #2453 — fills the availability and holdings layers:

- **`ingest-ia-cadal.mjs`** — sweeps IA `collection:universallibrary` (119,431 items, 78,380 CADAL `.cn`), groups volume items by base title (juan coverage preserved per volume), matches to chinese works by variant-normalized title, derives IIIF manifest URLs from identifiers (zero per-item fetches).
- **`build-holdings.mjs`** — conservative title-auto matching of Mongo books onto works: CJK-run extraction + variant normalization for Chinese, exact romanized-title match otherwise. No fuzzy matching — a wrong holding is worse than a missing one. Rebuilds only `matched_by='title-auto'` rows.

## Already run (idempotent)

- **ia-cadal: 2,091 works now have 33,821 scan volumes attached** (43% of CADAL volumes; the 38,920 unmatched base titles are editions of works outside the current catalog — gazetteers, Qing collectanea, etc.).
- **holdings: 917 books → 764 works held** (tibetan 691, chinese 68, islamicate 5). Tibetan spot-checked against Mongo: our BL/EAP Bhutan books match BDRC's EAP work records exactly (same Wylie titles) — verified real, not fuzzy-match artifacts.

## Out of scope

Harvard-Yenching/Waseda sources, Latin/USTC clustering (#2318), Persian PDL ingest, translation censuses over tibetan/islamicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)