### PR TITLE
fix(collector): OCR generation guard + canonical reset-book-ocr script (#2449)

### DIFF
--- a/scripts/maintenance/reset-book-ocr.mjs
+++ b/scripts/maintenance/reset-book-ocr.mjs
@@ -1,0 +1,141 @@
+/**
+ * Canonical OCR reset for a book (#2449).
+ *
+ * Manual "clear the OCR and let the pipeline redo it" resets used to be ad-hoc
+ * Mongo updates, which left two traps armed:
+ *   1. Outstanding batch_jobs from before the reset could be collected later
+ *      and silently resurrect the cleared text (the spread-book incident).
+ *   2. Nothing recorded that a reset happened, so the collector had no way to
+ *      tell fresh results from stale ones.
+ *
+ * This script does the reset safely, in order:
+ *   1. Saves a page_revisions snapshot of every cleared field (recoverable).
+ *   2. Cancels the book's outstanding (pending/processing) OCR batch_jobs.
+ *   3. Bumps pipeline_auto.ocr_generation — submitters stamp this on new jobs,
+ *      and batch-collector refuses to save results from an older generation.
+ *   4. Clears ocr (and optionally translation) on the selected pages.
+ *   5. Resets book counters and queues it at archive_complete.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; \
+ *   node scripts/maintenance/reset-book-ocr.mjs <book-id-or-slug> [options]
+ *
+ * Options:
+ *   --dry-run              Report what would change, write nothing.
+ *   --also-translation     Clear translation.data alongside ocr.data.
+ *   --pages 5-39           Only clear a page_number range (inclusive).
+ *   --reason "..."         Recorded on the revision notes (default: manual reset).
+ */
+
+import { MongoClient } from 'mongodb';
+import { randomBytes } from 'crypto';
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const ALSO_TRANSLATION = args.includes('--also-translation');
+const target = args.find(a => !a.startsWith('--'));
+const reasonIdx = args.indexOf('--reason');
+const REASON = reasonIdx !== -1 ? args[reasonIdx + 1] : 'manual reset via reset-book-ocr.mjs';
+const pagesIdx = args.indexOf('--pages');
+let pageRange = null;
+if (pagesIdx !== -1) {
+  const m = (args[pagesIdx + 1] || '').match(/^(\d+)-(\d+)$/);
+  if (!m) { console.error('--pages expects a range like 5-39'); process.exit(1); }
+  pageRange = { $gte: parseInt(m[1]), $lte: parseInt(m[2]) };
+}
+
+if (!target) {
+  console.log('Usage: node scripts/maintenance/reset-book-ocr.mjs <book-id-or-slug> [--dry-run] [--also-translation] [--pages N-M] [--reason "..."]');
+  process.exit(1);
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+const book = await db.collection('books').findOne(
+  { $or: [{ id: target }, { slug: target }] },
+  { projection: { id: 1, slug: 1, title: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, 'pipeline_auto.ocr_generation': 1, 'pipeline_auto.status': 1, needs_splitting: 1, split_completed: 1 } }
+);
+if (!book) { console.error(`Book not found: ${target}`); process.exit(1); }
+
+const currentGen = book.pipeline_auto?.ocr_generation || 0;
+console.log(`\n=== Reset OCR: ${(book.title || '').slice(0, 60)} ===`);
+console.log(`id: ${book.id} | status: ${book.pipeline_auto?.status} | ocr ${book.pages_ocr}/${book.pages_count} | generation ${currentGen} -> ${currentGen + 1}`);
+if (book.needs_splitting && !book.split_completed) {
+  console.log('NOTE: book is an unsplit spread — after reset it re-OCRs via the spread-aware path.');
+}
+if (DRY_RUN) console.log('DRY RUN — nothing will be written.');
+
+// 1. Outstanding OCR jobs
+const activeJobFilter = {
+  $or: [{ book_id: book.id }, { book_ids: book.id }],
+  type: 'ocr',
+  status: { $in: ['pending', 'processing', 'JOB_STATE_PENDING', 'JOB_STATE_RUNNING'] },
+};
+const activeJobs = await db.collection('batch_jobs').countDocuments(activeJobFilter);
+console.log(`Outstanding OCR batch_jobs to cancel: ${activeJobs}`);
+
+// 2. Pages to clear
+const pageFilter = { book_id: book.id, 'ocr.data': { $exists: true, $nin: [null, ''] } };
+if (pageRange) pageFilter.page_number = pageRange;
+const pages = await db.collection('pages').find(
+  pageFilter, { projection: { id: 1, book_id: 1, ocr: 1, translation: 1 } }
+).toArray();
+console.log(`Pages to clear: ${pages.length}${pageRange ? ` (page_number ${pageRange.$gte}-${pageRange.$lte})` : ''}${ALSO_TRANSLATION ? ' (ocr + translation)' : ' (ocr only)'}`);
+
+if (DRY_RUN) { await client.close(); process.exit(0); }
+
+// 3. Revisions first — never destroy without a snapshot
+let revisions = 0;
+for (const p of pages) {
+  const fields = ALSO_TRANSLATION ? ['ocr', 'translation'] : ['ocr'];
+  for (const field of fields) {
+    if (!p[field]?.data) continue;
+    await db.collection('page_revisions').insertOne({
+      id: randomBytes(6).toString('hex'),
+      page_id: p.id, book_id: p.book_id, field,
+      data: p[field].data, source: p[field].source || 'ai', model: p[field].model,
+      language: p[field].language, prompt_version: p[field].prompt_version,
+      original_date: p[field].updated_at, created_at: new Date(),
+      note: `reset-book-ocr: ${REASON}`,
+    });
+    revisions++;
+  }
+}
+console.log(`Revisions saved: ${revisions}`);
+
+// 4. Cancel outstanding jobs BEFORE clearing pages (closes the resurrect window)
+const cancelRes = await db.collection('batch_jobs').updateMany(activeJobFilter, {
+  $set: { status: 'cancelled', error: `cancelled by reset-book-ocr: ${REASON}`, updated_at: new Date() },
+});
+console.log(`Jobs cancelled: ${cancelRes.modifiedCount}`);
+
+// 5. Bump generation BEFORE clearing — any not-yet-cancelled job (e.g. created
+// by a concurrent submitter mid-reset) is now stale by generation.
+await db.collection('books').updateOne({ id: book.id }, {
+  $inc: { 'pipeline_auto.ocr_generation': 1 },
+  $set: { 'pipeline_auto.last_updated': new Date() },
+});
+
+// 6. Clear page fields
+const unset = ALSO_TRANSLATION ? { ocr: '', translation: '' } : { ocr: '' };
+const clearFilter = { book_id: book.id };
+if (pageRange) clearFilter.page_number = pageRange;
+const clearRes = await db.collection('pages').updateMany(clearFilter, { $unset: unset });
+console.log(`Pages cleared: ${clearRes.modifiedCount}`);
+
+// 7. Recount + requeue
+const remainingOcr = await db.collection('pages').countDocuments({ book_id: book.id, 'ocr.data': { $exists: true, $nin: [null, ''] } });
+const remainingTr = await db.collection('pages').countDocuments({ book_id: book.id, 'translation.data': { $exists: true, $nin: [null, ''] } });
+await db.collection('books').updateOne({ id: book.id }, {
+  $set: {
+    pages_ocr: remainingOcr,
+    pages_translated: remainingTr,
+    'pipeline_auto.status': 'archive_complete',
+    'pipeline_auto.last_updated': new Date(),
+  },
+});
+console.log(`Book requeued at archive_complete | pages_ocr: ${remainingOcr} | pages_translated: ${remainingTr} | generation: ${currentGen + 1}`);
+
+await client.close();

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -270,6 +270,46 @@ async function processOneJob(db, job) {
     console.log(`  Collecting: ${job.book_id} | ${job.type} | ${state}`);
     if (DRY_RUN) return { status: 'would_collect', bookId: job.book_id };
 
+    // ── Generation guard (#2449) ──
+    // If a book's OCR was deliberately reset after this job was submitted
+    // (scripts/maintenance/reset-book-ocr.mjs bumps pipeline_auto.ocr_generation),
+    // these results are stale: saving them would resurrect cleared marker-less
+    // text and silently undo the reset. Jobs submitted before this shipped have
+    // no ocr_generation field and are exempt.
+    let staleDropPages = null; // Set of pageIds to skip (cross-book partial staleness)
+    if (job.type === 'ocr' && job.ocr_generation !== undefined) {
+      const genBookIds = job.book_ids?.length ? job.book_ids : [job.book_id];
+      const genDocs = await db.collection('books').find(
+        { id: { $in: genBookIds } },
+        { projection: { id: 1, 'pipeline_auto.ocr_generation': 1 } }
+      ).toArray();
+      const jobGens = job.book_generations || { [job.book_id]: job.ocr_generation };
+      const staleBooks = new Set();
+      for (const b of genDocs) {
+        const current = b.pipeline_auto?.ocr_generation || 0;
+        const submitted = jobGens[b.id] ?? job.ocr_generation ?? 0;
+        if (current !== submitted) staleBooks.add(b.id);
+      }
+      if (staleBooks.size >= genBookIds.length) {
+        // Every book in the job was reset — nothing to save.
+        await db.collection('batch_jobs').updateOne(
+          { _id: job._id },
+          { $set: { status: 'superseded', error: `OCR generation advanced after submit (job gen ${job.ocr_generation})`, updated_at: new Date() } }
+        );
+        console.log(`  SUPERSEDED (generation guard): ${jobName} (book: ${job.book_id})`);
+        return { status: 'superseded', bookId: job.book_id };
+      }
+      if (staleBooks.size > 0 && job.page_ids?.length) {
+        // Cross-book job, some books reset: drop only their pages.
+        const stalePages = await db.collection('pages').find(
+          { id: { $in: job.page_ids }, book_id: { $in: [...staleBooks] } },
+          { projection: { id: 1 } }
+        ).toArray();
+        staleDropPages = new Set(stalePages.map(pg => pg.id));
+        console.log(`  Generation guard: dropping ${staleDropPages.size} pages from ${staleBooks.size} reset book(s) in cross-book job ${jobName}`);
+      }
+    }
+
     const responses = await extractResults(sdkJob, workingKey);
     let successCount = 0;
     let failCount = 0;
@@ -391,6 +431,7 @@ async function processOneJob(db, job) {
     const sourceUrlByPage = new Map((job.page_sources || []).map(s => [s.page_id, s.source_url]));
 
     for (const { pageId, text, usage } of pageResults) {
+      if (staleDropPages?.has(pageId)) { continue; } // generation guard (#2449)
       if (text.length > HALLUCINATION_LIMIT) { failCount++; continue; }
 
       const inputTokens = usage?.promptTokenCount || 0;

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -1399,6 +1399,13 @@ async function submitOcrDirectly(db, book, { modelOverride, maxPages } = {}) {
     return { submitted: 0, jobName: null, alreadyDone: false, skippedDuplicate: true };
   }
 
+  // Generation guard (#2449): stamp the book's current OCR generation on every
+  // job so batch-collector can refuse to save results from before a deliberate
+  // reset (reset-book-ocr.mjs bumps pipeline_auto.ocr_generation).
+  const ocrGeneration = (await db.collection('books').findOne(
+    { id: book.id }, { projection: { 'pipeline_auto.ocr_generation': 1 } }
+  ))?.pipeline_auto?.ocr_generation || 0;
+
   // Find pages needing OCR — only pages with R2 images (archived_photo or cropped_photo).
   // Pages without R2 URLs are not ready for OCR (archiving incomplete).
   const pages = await db.collection('pages')
@@ -1661,6 +1668,7 @@ Output structure:
       prompt_hash: ocrPromptRef.content_hash,
       submission_method: useFileBased ? 'file' : 'inline',
       key_index: batchJob.keyIndex,
+      ocr_generation: ocrGeneration, // #2449 generation guard
       force: false,
       created_at: new Date(),
       updated_at: new Date(),
@@ -1688,6 +1696,7 @@ Output structure:
       book_id: book.id,
       child_job_ids: childJobIds,
       total_pages: totalSubmitted,
+      ocr_generation: ocrGeneration, // #2449 generation guard
       status: 'pending',
       model: ocrModel,
       prompt_version: ocrPromptRef.version || OCR_PROMPT_VERSION,
@@ -1731,6 +1740,14 @@ async function submitCrossBookOcrBatches(db, books) {
     eligible.push(book);
   }
   if (eligible.length === 0) return { submitted: 0, batchCount: 0, bookIds: [] };
+
+  // Generation guard (#2449): per-book OCR generations, stamped on the job so
+  // the collector can drop pages of any book that was reset after submit.
+  const genDocs = await db.collection('books').find(
+    { id: { $in: eligible.map(b => b.id) } },
+    { projection: { id: 1, 'pipeline_auto.ocr_generation': 1 } }
+  ).toArray();
+  const bookGenerations = Object.fromEntries(genDocs.map(d => [d.id, d.pipeline_auto?.ocr_generation || 0]));
 
   // Gather pages from all eligible books
   const allDownloaded = []; // { pageId, image, prompt, bookId }
@@ -1882,6 +1899,8 @@ async function submitCrossBookOcrBatches(db, books) {
     submission_method: 'file',
     key_index: batchJob.keyIndex,
     cross_book: true,
+    ocr_generation: bookGenerations[chunkBookIds[0]] ?? 0, // #2449 generation guard
+    book_generations: Object.fromEntries(chunkBookIds.map(id => [id, bookGenerations[id] ?? 0])),
     created_at: new Date(),
     updated_at: new Date(),
   });

--- a/src/app/api/[tenant]/books/[id]/batch-ocr-async/route.ts
+++ b/src/app/api/[tenant]/books/[id]/batch-ocr-async/route.ts
@@ -227,6 +227,9 @@ export const POST = withAuth(async (request, session, context) => {
     // split. The bare prompt silently produces marker-less text that wedges the
     // book as an unsplit spread. Mirrors pipeline-orchestrator submitOcrDirectly.
     const needsSpreadPrompt = book.needs_splitting === true && book.split_completed !== true;
+    // Generation guard (#2449): stamp the book's current OCR generation on every
+    // job so batch-collector refuses results submitted before a deliberate reset.
+    const ocrGeneration = book.pipeline_auto?.ocr_generation || 0;
     const spreadPrefix = `**TWO-PAGE SPREAD HANDLING:**
 This image is a two-page spread (open book scan). Process BOTH pages separately.
 
@@ -402,6 +405,7 @@ Output structure:
         language,
         force,
         ...promptProvenance,
+        ocr_generation: ocrGeneration, // #2449 generation guard
         page_ids: allPageIds,
         page_count: allPageIds.length,
         pages_per_request: effectivePPR,
@@ -499,6 +503,7 @@ Output structure:
         language,
         force,
         ...promptProvenance,
+        ocr_generation: ocrGeneration, // #2449 generation guard
         page_ids: child.batchPageIds,
         page_count: child.batchPageIds.length,
         pages_per_request: effectivePPR,
@@ -520,6 +525,7 @@ Output structure:
       language,
       force,
       ...promptProvenance,
+      ocr_generation: ocrGeneration, // #2449 generation guard
       page_ids: allPageIds,
       page_count: allPageIds.length,
       total_pages: allPageIds.length,

--- a/src/app/api/books/[id]/batch-ocr-async/route.ts
+++ b/src/app/api/books/[id]/batch-ocr-async/route.ts
@@ -221,6 +221,9 @@ export const POST = withAuth(async (request, session, context) => {
     // split. The bare prompt silently produces marker-less text that wedges the
     // book as an unsplit spread. Mirrors pipeline-orchestrator submitOcrDirectly.
     const needsSpreadPrompt = book.needs_splitting === true && book.split_completed !== true;
+    // Generation guard (#2449): stamp the book's current OCR generation on every
+    // job so batch-collector refuses results submitted before a deliberate reset.
+    const ocrGeneration = book.pipeline_auto?.ocr_generation || 0;
     const spreadPrefix = `**TWO-PAGE SPREAD HANDLING:**
 This image is a two-page spread (open book scan). Process BOTH pages separately.
 
@@ -395,6 +398,7 @@ Output structure:
         language,
         force,
         ...promptProvenance,
+        ocr_generation: ocrGeneration, // #2449 generation guard
         page_ids: allPageIds,
         page_count: allPageIds.length,
         pages_per_request: effectivePPR,
@@ -491,6 +495,7 @@ Output structure:
         language,
         force,
         ...promptProvenance,
+        ocr_generation: ocrGeneration, // #2449 generation guard
         page_ids: child.batchPageIds,
         page_count: child.batchPageIds.length,
         pages_per_request: effectivePPR,
@@ -511,6 +516,7 @@ Output structure:
       language,
       force,
       ...promptProvenance,
+      ocr_generation: ocrGeneration, // #2449 generation guard
       page_ids: allPageIds,
       page_count: allPageIds.length,
       total_pages: allPageIds.length,


### PR DESCRIPTION
## What

Closes the last tactical item in #2449: after a manual OCR reset, stale pending batch jobs could be collected later and silently resurrect the cleared text (this re-poisoned the spread books **twice** during the 2026-06-05/06 incident).

### Mechanism

- Books carry `pipeline_auto.ocr_generation` (absent = 0).
- Every OCR submitter stamps it on the batch_jobs doc: orchestrator `submitOcrDirectly` (child + parent) and `submitCrossBookOcrBatches` (per-book `book_generations` map), plus both `batch-ocr-async` routes (global + tenant).
- `batch-collector` compares at collect time: all books stale → job marked `superseded`, nothing saved; some books stale (cross-book) → only their pages dropped.
- Jobs without the field (pre-deploy) are exempt — fully backwards-compatible, no backfill needed.

### Canonical reset script

`scripts/maintenance/reset-book-ocr.mjs <id-or-slug> [--dry-run] [--also-translation] [--pages N-M] [--reason]` does the safe sequence: page_revisions snapshot → cancel outstanding jobs → bump generation → clear → recount + requeue at `archive_complete`. Future manual resets should use this instead of ad-hoc Mongo updates.

## Testing

- `npx tsc --noEmit` clean, `node --check` on all three workers/scripts clean
- Guard logic is read-only on the happy path (one extra projection-only find per OCR job collected)

## Out of scope

- #2454 (split-at-detection redesign) and #2455 (ops guards) — next PRs
- Generation guards for translation jobs (no incident has needed one; same pattern applies if it does)

## Deploy notes

Worker changes ride the Hetzner pull; the two route files take effect on the next Vercel prod deploy (stamp-only, harmless to lag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)