### PR TITLE
feat(ops): pipeline ops guards — broken-key exclusion, 404-drift alert, pause-age + key-parity checks (#2455)

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -1442,6 +1442,44 @@ async function run() {
   if (zombiesReaped > 0) console.log(`Zombies reaped: ${zombiesReaped}`);
   if (notFoundCount > 0) console.log(`Gemini 404 (gone): ${notFoundCount}`);
   if (ghostsCleaned > 0) console.log(`Ghosts cleaned: ${ghostsCleaned}`);
+
+  // ── 404-on-all-keys alert (#2455) ──
+  // A burst of jobs that 404 on EVERY key almost always means key drift between
+  // the submitting host (Vercel) and this collector — the jobs exist, we just
+  // can't see them (348 jobs were falsely failed this way on 2026-06-05). Email
+  // instead of failing silently. 12h cooldown so a drift doesn't spam.
+  const NOT_FOUND_ALERT_THRESHOLD = 10;
+  if (notFoundCount >= NOT_FOUND_ALERT_THRESHOLD && process.env.RESEND_API_KEY && !DRY_RUN) {
+    try {
+      const COOLDOWN_MS = 12 * 60 * 60 * 1000;
+      const state = await db.collection('system_config').findOne({ _id: 'collector_404_alert_state' });
+      const elapsed = state?.last_sent_at ? Date.now() - new Date(state.last_sent_at).getTime() : Infinity;
+      if (elapsed >= COOLDOWN_MS) {
+        const { Resend } = await import('resend');
+        const resend = new Resend(process.env.RESEND_API_KEY);
+        await resend.emails.send({
+          from: 'Source Library <noreply@sourcelibrary.org>',
+          to: process.env.ALERT_EMAIL || 'derek@sourcelibrary.org',
+          subject: `[COLLECTOR] ${notFoundCount} batch jobs 404 on all Gemini keys — likely key drift`,
+          html: [
+            '<h2>Batch jobs invisible to every collector key</h2>',
+            `<p><strong>${notFoundCount}</strong> jobs this run returned 404 from <code>batches.get</code> on all ${ALL_KEYS.length} keys and were marked failed.</p>`,
+            '<p>This pattern almost always means the submitting host (Vercel) holds a Gemini key this box does not — the jobs exist and their results are recoverable. See memory/pipeline-ops.md (2026-06-05 key-drift lesson): mirror the missing key into the Hetzner env, reset the jobs to pending, and re-run the collector.</p>',
+          ].join('\n'),
+        });
+        await db.collection('system_config').updateOne(
+          { _id: 'collector_404_alert_state' },
+          { $set: { last_sent_at: new Date(), last_count: notFoundCount } },
+          { upsert: true },
+        );
+        console.log(`[collector] 404-drift alert emailed (${notFoundCount} jobs)`);
+      } else {
+        console.log(`[collector] 404-drift alert suppressed (cooldown, ${notFoundCount} jobs)`);
+      }
+    } catch (e) {
+      console.error(`[collector] 404-drift alert failed: ${e.message}`);
+    }
+  }
   console.log(`Total time: ${totalElapsed}s`);
 
   // Write cron_runs record for observability

--- a/scripts/workers/pipeline-health-alert.mjs
+++ b/scripts/workers/pipeline-health-alert.mjs
@@ -220,6 +220,67 @@ async function run() {
     });
   }
 
+  // 8. Pause-age check (#2455): paused_phases sat for 6 days behind a "healthy"
+  // status while 1,759 books piled up at archive_complete. Warn after 48h.
+  try {
+    const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
+    const paused = control?.paused_phases || [];
+    if (paused.length > 0) {
+      const setAt = control.paused_phases_set_at ? new Date(control.paused_phases_set_at) : null;
+      const ageHours = setAt ? (now - setAt) / 3600000 : Infinity;
+      if (ageHours >= 48) {
+        const backlog = await db.collection('books').countDocuments({
+          'pipeline_auto.status': { $in: ['archive_complete', 'ocr_complete'] },
+        });
+        alerts.push({
+          level: 'critical',
+          check: 'paused_phases_stale',
+          message: `paused_phases=[${paused.join(', ')}] set ${setAt ? ageHours.toFixed(0) + 'h ago' : 'at unknown time'} (reason: ${control.paused_phases_reason || 'none recorded'}). ${backlog} books queued behind the pause. Clear system_config.processing_control.paused_phases if no longer needed.`,
+        });
+      } else {
+        console.log(`[health] paused_phases=[${paused.join(', ')}] active for ${ageHours.toFixed(0)}h (alerts at 48h)`);
+      }
+    }
+  } catch (e) {
+    console.error(`[health] pause-age check failed: ${e.message}`);
+  }
+
+  // 9. Gemini key parity (#2455): batch jobs are visible only to their creating
+  // key. If Vercel holds a key this box lacks, the collector falsely fails every
+  // job that key submits (the 2026-06-05 key-drift incident). Compare SHA-256
+  // fingerprints with the production deployment.
+  try {
+    const { createHash } = await import('crypto');
+    const localFps = new Map();
+    for (const [name, value] of Object.entries(process.env)) {
+      if (!name.startsWith('GEMINI_API_KEY') || !value) continue;
+      localFps.set(createHash('sha256').update(value).digest('hex').slice(0, 12), name);
+    }
+    const res = await fetch('https://sourcelibrary.org/api/admin/key-fingerprints', {
+      headers: { Authorization: `Bearer ${process.env.CRON_SECRET}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (res.ok) {
+      const { fingerprints: remote } = await res.json();
+      const missingHere = Object.entries(remote || {}).filter(([, fp]) => !localFps.has(fp));
+      if (missingHere.length > 0) {
+        alerts.push({
+          level: 'critical',
+          check: 'gemini_key_drift',
+          message: `Vercel holds ${missingHere.length} Gemini key(s) absent from this box (${missingHere.map(([n]) => n).join(', ')}). Batch jobs submitted with them will 404 for the collector and be falsely failed. Mirror them into /root/sourcelibrary/.env.production.local (see memory/pipeline-ops.md 2026-06-05 lesson).`,
+        });
+      } else {
+        console.log(`[health] Gemini key parity OK (${localFps.size} local keys cover all ${Object.keys(remote || {}).length} Vercel keys)`);
+      }
+    } else if (res.status === 404) {
+      console.log('[health] key-fingerprints endpoint not deployed yet — skipping parity check');
+    } else {
+      console.error(`[health] key parity check HTTP ${res.status}`);
+    }
+  } catch (e) {
+    console.error(`[health] key parity check failed: ${e.message}`);
+  }
+
   // 7. Quick stats
   const ocrSubmitted = await db.collection('books').countDocuments({
     'pipeline_auto.status': 'ocr_submitted',

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -1088,6 +1088,21 @@ let _geminiKeyLoadsAt = 0; // timestamp of last refresh
 
 const MAX_ACTIVE_PER_KEY = 30; // Hard cap per GCP project — Gemini stalls above this
 
+// Batch-broken keys (#2455): a key that returns FAILED_PRECONDITION from
+// batches.create can't run Batch API at all (free tier / unbilled project).
+// Such a key always LOOKS least-loaded — its batches die instantly — so the
+// load-aware selector funnels every submission into it (602 books failed this
+// way on 2026-06-05). Mark it broken for the rest of the run and route around.
+const _batchBrokenKeys = new Set();
+const _batchBrokenKeyEvents = [];
+function markKeyBatchBroken(ki, context) {
+  if (_batchBrokenKeys.has(ki)) return;
+  _batchBrokenKeys.add(ki);
+  const msg = `Gemini key ${ki} marked batch-broken (FAILED_PRECONDITION on batches.create, ${context}) — excluded for the rest of this run. Likely free-tier/unbilled; remove it from GEMINI_API_KEY_2..10 if persistent.`;
+  _batchBrokenKeyEvents.push(msg);
+  console.error(`    ALERT: ${msg}`);
+}
+
 /**
  * Query real Gemini-side active job counts per key.
  * Returns { total, perKey: number[] }. Also updates the cached _geminiKeyLoads.
@@ -1135,6 +1150,7 @@ function getLeastLoadedKey() {
   let bestKey = -1;
   let bestCount = Infinity;
   for (let i = 0; i < _geminiKeyLoads.length; i++) {
+    if (_batchBrokenKeys.has(i)) continue; // batch-broken key (#2455) — never select
     if (_geminiKeyLoads[i] < MAX_ACTIVE_PER_KEY && _geminiKeyLoads[i] < bestCount) {
       bestCount = _geminiKeyLoads[i];
       bestKey = i;
@@ -1260,6 +1276,11 @@ async function createBatchJobInline(model, requests, displayName) {
         _geminiKeyLoads[ki] = MAX_ACTIVE_PER_KEY; // Mark as full
         continue;
       }
+      if (msg.includes('FAILED_PRECONDITION') || msg.includes('Precondition check failed')) {
+        // Key can't run Batch API at all (#2455) — exclude it and try the next key
+        markKeyBatchBroken(ki, 'inline batch');
+        continue;
+      }
       throw err;
     }
   }
@@ -1348,11 +1369,22 @@ async function createBatchJobFromFile(model, fileName, displayName, preferredKey
     if (state === 'FAILED') throw new Error(`File API processing FAILED for ${fileName}`);
     await new Promise(r => setTimeout(r, 2000)); // up to ~60s
   }
-  const batchJob = await client.batches.create({
-    model,
-    src: { fileName },
-    config: { displayName },
-  });
+  let batchJob;
+  try {
+    batchJob = await client.batches.create({
+      model,
+      src: { fileName },
+      config: { displayName },
+    });
+  } catch (err) {
+    const msg = err.message || '';
+    // File reached ACTIVE but batch creation still 400s — the KEY can't run
+    // Batch API (#2455). Mark it so the selector routes future uploads elsewhere.
+    if (msg.includes('FAILED_PRECONDITION') || msg.includes('Precondition check failed')) {
+      markKeyBatchBroken(preferredKeyIndex, 'file-based batch');
+    }
+    throw err;
+  }
   return { name: batchJob.name, state: batchJob.state || 'JOB_STATE_PENDING', keyIndex: preferredKeyIndex };
 }
 
@@ -5342,8 +5374,8 @@ Rules:
             stale_failed: log.stale_failed,
             zombie_jobs_cancelled: log.zombie_jobs_cancelled,
           },
-          errors: log.errors.slice(0, 50).map(msg => ({ message: msg, timestamp: new Date() })),
-          error_count: log.errors.length,
+          errors: [..._batchBrokenKeyEvents, ...log.errors].slice(0, 50).map(msg => ({ message: msg, timestamp: new Date() })),
+          error_count: _batchBrokenKeyEvents.length + log.errors.length,
           health_grade: healthGrade,
           summary: `[${healthGrade}] E:${log.enrolled} A:${log.archived} D:${log.dedup_books}/${log.dedup_pages_hidden}p P:${log.preview_queued} O:${log.ocr_submitted}/${log.ocr_advanced} M:${log.metadata_enriched} Tr:${log.transliterated}/${log.transliterate_pages}p T:${log.translate_submitted}/${log.translate_advanced} R:${log.enriched} C:${log.chapters_extracted} I:${log.images_submitted}/${log.images_advanced} F:${log.finalized}`,
         }),

--- a/src/app/api/admin/key-fingerprints/route.ts
+++ b/src/app/api/admin/key-fingerprints/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createHash } from 'crypto';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/key-fingerprints — SHA-256 fingerprints of this deployment's
+ * Gemini API keys (#2455).
+ *
+ * Lets the Hetzner health worker detect key drift between Vercel and the
+ * pipeline box: Gemini Batch jobs are visible only to their creating key, so a
+ * key present here but absent on Hetzner means the collector silently fails
+ * every job that key submits (348 jobs were falsely failed this way on
+ * 2026-06-05 — see memory/pipeline-ops.md).
+ *
+ * Returns 12-hex-char SHA-256 prefixes — enough to diff key sets, useless for
+ * recovering key material. CRON_SECRET bearer auth, same as other admin crons.
+ */
+export async function GET(request: NextRequest) {
+  const auth = request.headers.get('authorization');
+  if (!process.env.CRON_SECRET || auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const fingerprints: Record<string, string> = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (!name.startsWith('GEMINI_API_KEY') || !value) continue;
+    fingerprints[name] = createHash('sha256').update(value).digest('hex').slice(0, 12);
+  }
+
+  return NextResponse.json({ host: 'vercel', fingerprints });
+}


### PR DESCRIPTION
## What

Implements all four guards from #2455 so the 2026-06-05/06 failure classes get caught by machines:

1. **Batch-broken key exclusion (orchestrator).** A key that returns FAILED_PRECONDITION from `batches.create` (free-tier/unbilled project) is marked broken for the rest of the run and skipped by `getLeastLoadedKey()` — closing the selection-bias trap where the broken key always looked idle *because* its batches died instantly (602 books failed through it in one evening). Inline path now tries the next key instead of aborting the whole submission; file path marks the key before rethrow. Events appear in the run's cron_runs errors.
2. **404-on-all-keys alert (collector).** ≥10 jobs in one run that 404 on every key → email via Resend (12h cooldown). That pattern means key drift, not lost jobs — 348 jobs were falsely failed silently before.
3. **Pause-age alert (daily health worker).** `paused_phases` non-empty for >48h → critical alert including the count of books queued behind the pause (it previously sat 6 days while the orchestrator reported healthy).
4. **Key-parity check (daily health worker + new endpoint).** `GET /api/admin/key-fingerprints` (CRON_SECRET auth) returns SHA-256 12-char prefixes of the deployment's `GEMINI_API_KEY*` values; the Hetzner health worker diffs them against its own env and goes critical when Vercel holds a key the box lacks. Degrades gracefully (logs + skips) until the endpoint is deployed.

## Testing

- `npx tsc --noEmit` clean; `node --check` clean on all three workers
- Parity check verified conceptually against the real incident: Vercel's `GEMINI_API_KEY`/_2/_TIER3 were absent from Hetzner — this check would have alerted on day one

## Out of scope

- #2454 split-at-detection redesign (next PR)
- Startup batch-capability probe per key (the run-scoped exclusion covers the practical case at zero quota cost)

## Deploy notes

Workers ride Hetzner auto-pull. The key-fingerprints route needs a Vercel prod deploy before check 4 reports parity (until then it logs 'endpoint not deployed yet' and skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)