### PR TITLE
feat(pipeline): split spreads at detection time, before any OCR (#2454)

### DIFF
--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -32,10 +32,11 @@ const MIN_SPREAD_AR = 1.1;   // Aspect ratio gate: below this is portrait (singl
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const WITH_OCR = args.includes('--with-ocr');
+const GUTTER_ONLY = args.includes('--gutter-only'); // #2454: split images BEFORE OCR — cheap gutter detection, pages created without OCR
 const targetSlug = args.find(a => !a.startsWith('--'));
 
 if (!targetSlug) {
-  console.log('Usage: node scripts/split-book.mjs <slug-or-id> [--dry-run] [--with-ocr]');
+  console.log('Usage: node scripts/split-book.mjs <slug-or-id> [--dry-run] [--with-ocr] [--gutter-only]');
   process.exit(1);
 }
 
@@ -196,6 +197,34 @@ async function runSpreadOCR(imageBuf) {
     { inlineData: { mimeType: 'image/jpeg', data: imageBuf.toString('base64') } }
   ]);
   return r.response.text();
+}
+
+// --- Gutter-only detection (#2454: split BEFORE OCR) ---
+// One cheap vision call per page: where is the gutter? No transcription, so
+// output is ~10 tokens instead of ~2K. The split pages then flow through the
+// normal single-page OCR pipeline (batch, 50% off) instead of realtime.
+const GUTTER_PROMPT = `This image is a scan from a book. Decide whether it shows a TWO-PAGE SPREAD (an open book with a left and a right page) or a SINGLE page.
+
+Respond with EXACTLY one tag and nothing else:
+- Two-page spread: <split-position>N</split-position> where N (0-1000) is the horizontal position of the gutter (the fold between the pages). The gutter is usually near the center (400-600).
+- Single page: <split-position>null</split-position>`;
+
+async function initGeminiGutter() {
+  const { GoogleGenerativeAI } = await import('@google/generative-ai');
+  const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+  geminiModel = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
+}
+
+async function runGutterDetect(imageBuf) {
+  const r = await geminiModel.generateContent([
+    GUTTER_PROMPT,
+    { inlineData: { mimeType: 'image/jpeg', data: imageBuf.toString('base64') } }
+  ]);
+  const text = r.response.text();
+  const m = text.match(/<split-position>([^<]*)<\/split-position>/);
+  if (!m) return null; // unparseable — caller decides fallback
+  const n = parseInt(m[1]);
+  return (!isNaN(n) && n > 0 && n < 1000) ? n : 'single';
 }
 
 // --- Parse spread OCR ---
@@ -373,7 +402,41 @@ console.log(`  ${withPageBreak.length} have <page-break/>, ${withSplitPos.length
 
 // --- Step 3: Run OCR if needed ---
 let ocrVersion = 'existing';
-if (WITH_OCR || withPageBreak.length === 0) {
+if (GUTTER_ONLY) {
+  // #2454: no transcription — one cheap gutter call per landscape page.
+  // Portrait pages (AR < MIN_SPREAD_AR) skip the call entirely.
+  console.log('\n--- Step 3: Gutter-only detection (no OCR) ---');
+  await initGeminiGutter();
+  for (let i = 0; i < iiifUrls.length; i += CONCURRENCY) {
+    const batch = iiifUrls.slice(i, i + CONCURRENCY);
+    await Promise.all(batch.map(async (url, j) => {
+      const idx = i + j;
+      if (!url || idx >= existingPages.length) return;
+      const page = existingPages[idx];
+      try {
+        const buf = await fetchImage(url);
+        const meta = await sharp(buf).metadata();
+        page._imageBuf = buf;
+        page._w = meta.width;
+        page._h = meta.height;
+        const ar = meta.width / meta.height;
+        if (ar < MIN_SPREAD_AR) {
+          page._gutter = 'single'; // portrait — no Gemini call needed
+          return;
+        }
+        const pos = await runGutterDetect(buf);
+        // Wide page where detection failed or said single: a landscape page in a
+        // flagged spread book is overwhelmingly a spread — default to center.
+        page._gutter = pos === 'single' && ar < 1.3 ? 'single' : (typeof pos === 'number' ? pos : 500);
+      } catch (e) {
+        console.log(`  FAIL p.${page.page_number}: ${e.message?.slice(0, 50)}`);
+        page._error = true;
+      }
+    }));
+    process.stderr.write(`  Gutter: ${Math.min(i + CONCURRENCY, iiifUrls.length)}/${iiifUrls.length}\r`);
+  }
+  console.log();
+} else if (WITH_OCR || withPageBreak.length === 0) {
   if (!WITH_OCR && withPageBreak.length === 0) {
     console.log('\n  No spread OCR found. Running Gemini OCR (use --with-ocr to force)...');
   }
@@ -416,6 +479,19 @@ for (let idx = 0; idx < existingPages.length; idx++) {
   const page = existingPages[idx];
   if (page._error) {
     newPages.push({ side: 'error', ocr: null, sourceIdx: idx, splitPosition: null });
+    continue;
+  }
+
+  if (GUTTER_ONLY) {
+    if (page._gutter === 'single') {
+      // Singles keep any existing OCR — it was made from this exact image.
+      newPages.push({ side: 'single', ocr: page.ocr?.data || null, sourceIdx: idx, splitPosition: null });
+    } else {
+      // Spread: two OCR-less pages; the normal pipeline OCRs them as singles.
+      const pos = typeof page._gutter === 'number' ? page._gutter : 500;
+      newPages.push({ side: 'left', ocr: null, sourceIdx: idx, splitPosition: pos });
+      newPages.push({ side: 'right', ocr: null, sourceIdx: idx, splitPosition: pos });
+    }
     continue;
   }
 
@@ -555,7 +631,7 @@ for (let i = 0; i < newPages.length; i++) {
     split_side: p.side === 'error' ? 'single' : p.side,
     split_position: p.splitPosition,
     field_provenance: {
-      ocr: { source: 'gemini', method: 'spread-split-ocr', confidence: 1.0, date: new Date() },
+      ...(p.ocr ? { ocr: { source: 'gemini', method: 'spread-split-ocr', confidence: 1.0, date: new Date() } } : {}),
       photo: { source: 'r2', method: 'spread-split-crop', confidence: 1.0, date: new Date() },
     },
     created_at: new Date(),
@@ -630,6 +706,16 @@ await db.collection('books').updateOne({ id: book.id }, {
     updated_at: new Date(),
   }
 });
+
+if (GUTTER_ONLY) {
+  // #2454: pages were created without OCR — requeue the book so the normal
+  // single-page batch OCR pipeline picks it up (needs_splitting is now false,
+  // so no spread prompt and no Phase 1.5 skip).
+  await db.collection('books').updateOne({ id: book.id }, {
+    $set: { 'pipeline_auto.status': 'archive_complete', 'pipeline_auto.last_updated': new Date() },
+  });
+  console.log('  Requeued at archive_complete for single-page OCR');
+}
 
 console.log(`  pages: ${existingPages.length} spread → ${newDocs.length} split`);
 console.log(`  OCR: ${pagesWithOCR}/${newDocs.length}`);

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2948,6 +2948,74 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
       console.log(`  Split checked: ${splitChecked}, flagged for splitting: ${splitFlagged}`);
     }
 
+    // ── Phase 1.3: Split spreads at detection time (#2454) ──
+    // Books flagged needs_splitting by Phase 1.25 get their images split into
+    // left/right pages BEFORE any OCR, via split-book.mjs --gutter-only (one
+    // cheap "where is the gutter" Gemini call per page, no transcription).
+    // Everything downstream — preview OCR, batch OCR, translation, extraction —
+    // then only ever sees single pages, eliminating the entire marker-dance /
+    // race-window class of bugs (#2449). Phase 3.1 remains for books already
+    // past OCR with spread markers (legacy in-flight path).
+    if (shouldRun(1.3)) {
+      console.log('\n--- Phase 1.3: Pre-OCR spread split (gutter-only) ---');
+
+      const PRE_SPLIT_LIMIT = 8; // each book downloads + crops + uploads all its images
+
+      let readyForPreSplit = await db.collection('books')
+        .find({
+          'pipeline_auto.status': 'archive_complete',
+          'pipeline_auto.split_checked': true,
+          needs_splitting: true,
+          split_completed: { $ne: true },
+          // Books that already have substantial OCR are mid-flight on the legacy
+          // marker path (Phase 2 spread OCR → Phase 3.1) — let that finish rather
+          // than discarding their spread OCR. Fresh books have at most preview OCR.
+          $or: [{ pages_ocr: { $in: [0, null] } }, { pages_ocr: { $exists: false } }],
+        })
+        .sort({ pages_count: 1 }) // smallest first — fast wins
+        .project({ id: 1, title: 1, pages_count: 1, 'pipeline_auto.pre_split_retry_count': 1 })
+        .limit(PRE_SPLIT_LIMIT)
+        .toArray();
+      if (BOOK_OVERRIDE) readyForPreSplit = await applyBookOverride(db, readyForPreSplit, { id: 1, title: 1, pages_count: 1, pipeline_auto: 1 });
+
+      if (readyForPreSplit.length > 0) {
+        console.log(`  Books ready for pre-OCR split: ${readyForPreSplit.length}`);
+      }
+
+      for (const book of readyForPreSplit) {
+        const label = (book.title || '').substring(0, 50);
+        if (DRY_RUN) { console.log(`  Would pre-split: ${label} (${book.pages_count} pages)`); continue; }
+        try {
+          console.log(`  Pre-splitting: ${label} (${book.pages_count} pages)...`);
+          const scriptPath = new URL('../split-book.mjs', import.meta.url).pathname;
+          const { stderr } = await execFileAsync('node', [scriptPath, book.id, '--gutter-only'], {
+            timeout: 600000, // 10 min per book (downloads + crops + uploads)
+            env: process.env,
+            maxBuffer: 10 * 1024 * 1024,
+          });
+          if (stderr) console.log(`    stderr: ${stderr.slice(0, 200)}`);
+          // split-book.mjs sets split_completed, needs_splitting:false, and
+          // requeues at archive_complete — the book now flows as single pages.
+          console.log(`    Done: ${label}`);
+        } catch (err) {
+          const msg = err.stderr || err.message || String(err);
+          console.log(`    FAIL: ${label} — ${msg.slice(0, 150)}`);
+          const retryCount = (book.pipeline_auto?.pre_split_retry_count || 0) + 1;
+          if (retryCount >= 3) {
+            await setPipelineStatus(db, book.id, 'needs_attention', {
+              error: `Pre-OCR split failed ${retryCount} times: ${msg.slice(0, 200)}`,
+              pre_split_retry_count: retryCount,
+            });
+          } else {
+            await db.collection('books').updateOne(
+              { id: book.id },
+              { $set: { 'pipeline_auto.pre_split_retry_count': retryCount, 'pipeline_auto.last_updated': new Date() } }
+            );
+          }
+        }
+      }
+    }
+
     // ── Phase 1.5: Preview OCR — first 25 pages via inline Gemini ──
     // OCRs the title page, TOC, and opening pages directly via Gemini realtime API.
     // Purpose: get text for AI metadata classification (Phase 1.6) before full OCR.


### PR DESCRIPTION
## What

Implements #2454: spread books get their images split into left/right pages **before** any OCR, so every downstream phase (preview OCR, batch OCR, translation, image extraction) only ever sees single pages. This removes the structural cause behind the whole #2449 class of bugs — the marker dance, the translate race, preview-OCR poisoning, and starved re-OCR remainders all existed because pages lived in spread form until a single narrowly-scheduled late phase.

### `split-book.mjs --gutter-only`

- Per landscape page: one Gemini vision call that returns only `<split-position>N|null</split-position>` (~10 output tokens vs ~2K for spread OCR)
- Portrait pages (AR < 1.1) skip the call entirely; detected singles keep their existing OCR (it was made from that exact image)
- Spread pages are created OCR-less, then the book is requeued at `archive_complete` — the normal single-page **batch** OCR picks them up (50% cheaper than the realtime spread OCR `--with-ocr` uses)
- Fallback: a wide page (AR ≥ 1.3) where detection fails or claims 'single' defaults to a center split — in a flagged spread book that's overwhelmingly correct

### Orchestrator Phase 1.3

Runs right after Phase 1.25 detection: `archive_complete + split_checked + needs_splitting + !split_completed + pages_ocr ∈ {0, null}`, smallest-first, 8 books/cycle, 3 retries then `needs_attention` — same operational shape as Phase 3.1.

### Migration / coexistence

- Books already mid-flight on the legacy marker path (`pages_ocr > 0`) are deliberately excluded — Phase 2 spread OCR + Phase 3.1 finish them and remain unchanged
- Phase 3.1 retires once the in-flight set drains (follow-up, not this PR)
- The #2449 sweep (295 confirmed translated-as-spreads + 36 falsely gate-cleared) can now be remediated by un-flagging them into this path — separate run, numbers in #2449

## Testing

- `--gutter-only --dry-run` against a live 10-spread book (Het leggend Waterrad): 10 spreads → 20 pages, per-page gutter positions 485–502
- `node --check` clean on both files; no TS surface touched

## Out of scope

- Phase 3.1 retirement (after in-flight drains)
- The 331-book remediation run (uses this path; proposed separately with cost numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)