### PR TITLE
fix(iiif-discovery): dedupe clusters on edition edges only

### DIFF
--- a/scripts/iiif-discovery/dedupe-candidates.mjs
+++ b/scripts/iiif-discovery/dedupe-candidates.mjs
@@ -373,7 +373,6 @@ for (const [blockKey, records] of blocks) {
 
       if (score >= 0.85) {
         totalMatches++;
-        union(parent, rank, a._id.toString(), b._id.toString());
 
         // Determine match type
         const sameSource = a.source === b.source;
@@ -381,6 +380,20 @@ for (const [blockKey, records] of blocks) {
         const matchType = sameSource && sameDate ? 'same_edition_copies'
           : !sameSource && sameDate ? 'cross_source_same_edition'
           : 'related_edition';
+
+        // EDITION edges only feed clusters. related_edition pairs (dates
+        // differ) are the same WORK in a different edition — clustering them
+        // chains 1556 and 1601 printings into one cluster and --apply would
+        // mark distinct editions skipped (43% of all matches on the 2026-06
+        // full-pool dry run were related_edition). Work-level grouping is
+        // issue #2318, not this script. Near-dates (±2y) still count as the
+        // same edition: catalogs disagree by a year or two on the same
+        // printing far more often than a true reprint lands within 2 years.
+        const nearDate = sameDate
+          || (a.date_earliest && b.date_earliest && Math.abs(a.date_earliest - b.date_earliest) <= 2);
+        if (nearDate) {
+          union(parent, rank, a._id.toString(), b._id.toString());
+        }
 
         matchTypeCounts[matchType] = (matchTypeCounts[matchType] || 0) + 1;
         if (matchPairs.length < MATCH_SAMPLE_CAP) {


### PR DESCRIPTION
Follow-up to #2466, gates `--apply` (see #2447).

The full 2.19M dry run revealed **43% of match pairs were `related_edition`** (same title/author, dates >±2y apart). These were being unioned into clusters, so `--apply` would have marked distinct *editions* — a 1556 and a 1601 printing of the same work — as duplicates and skipped the later one. Wrong for the census (editions are the unit), wrong for import (we deliberately hold multiple editions), and #2318's work-identity layer is the right home for that relationship.

Change: only same-date / near-date (±2y) pairs feed union-find. `related_edition` pairs are still counted and sampled — they're the seed data for #2318.

Verified on a 30K live sample. Known accepted limitation: year-titled annual serials can still chain through ±2y transitivity; they mostly live in the author-less >500 blocks that are skipped (and logged) anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)