### PR TITLE
feat(split): pixel-primary gutter detection + Gemini fallback + uncertainty guard (#2454)

### DIFF
--- a/scripts/lib/gutter-detect.mjs
+++ b/scripts/lib/gutter-detect.mjs
@@ -47,58 +47,67 @@ export async function detectGutterPixel(spreadBuf) {
     const bandEnd = Math.round(H * 0.75);
     const DARK = 120;
     const inkPerCol = new Float32Array(W);
+    const lumPerCol = new Float32Array(W); // mean luminance — for binding-shadow valley
     for (let x = 0; x < W; x++) {
-      let d = 0;
+      let d = 0, lum = 0;
       for (let y = bandStart; y < bandEnd; y++) {
         const i = (y * W + x) * 3;
         const m = Math.min(raw[i], raw[i + 1], raw[i + 2]);
         if (m < DARK) d++;
+        lum += (raw[i] + raw[i + 1] + raw[i + 2]) / 3;
       }
       inkPerCol[x] = d / (bandEnd - bandStart);
+      lumPerCol[x] = lum / (bandEnd - bandStart);
     }
 
-    // ±5px smoothing so inter-character white slivers don't fragment the gap.
-    const half = 5;
-    const smoothed = new Float32Array(W);
-    for (let x = 0; x < W; x++) {
-      const lo = Math.max(0, x - half);
-      const hi = Math.min(W - 1, x + half);
-      let s = 0;
-      for (let i = lo; i <= hi; i++) s += inkPerCol[i];
-      smoothed[x] = s / (hi - lo + 1);
-    }
-
-    const cs = Math.round(W * 0.30);
-    const ce = Math.round(W * 0.70);
-    const NO_INK = 0.02;
-    let bestStart = -1, bestLen = 0;
-    let curStart = -1, curLen = 0;
-    for (let x = cs; x < ce; x++) {
-      if (smoothed[x] < NO_INK) {
-        if (curStart < 0) curStart = x;
-        curLen = x - curStart + 1;
-        if (curLen > bestLen) { bestLen = curLen; bestStart = curStart; }
-      } else {
-        curStart = -1; curLen = 0;
+    // LIGHT smoothing (±2px) — bridges inter-character white slivers without
+    // smearing a NARROW gutter above the detection floor. ±5px used to erase
+    // 1-2px bright gutters entirely (the bug that sent clean pages to Gemini's
+    // useless center-guess).
+    const smooth = (src) => {
+      const out = new Float32Array(W);
+      const half2 = 2;
+      for (let x = 0; x < W; x++) {
+        const lo = Math.max(0, x - half2), hi = Math.min(W - 1, x + half2);
+        let s = 0; for (let i = lo; i <= hi; i++) s += src[i];
+        out[x] = s / (hi - lo + 1);
       }
-    }
-
-    // No usable ink-free run → LOW confidence. The old code center-cut here;
-    // we hand off to the caller (Gemini fallback) instead.
-    if (bestStart < 0 || bestLen < 10) {
-      return { column: null, confidence: 'low', reason: 'no-ink-free-run', ar };
-    }
-
-    const WIDE = Math.round(W * 0.15);
-    const chosen = bestLen < WIDE
-      ? bestStart + bestLen                  // narrow gap → cut at gap end
-      : bestStart + Math.floor(bestLen / 2); // wide gap → cut at gap center
-    return {
-      column: Math.round(chosen / ratio),
-      confidence: 'high',
-      reason: bestLen < WIDE ? `ink-free-run-${bestLen}px-end` : `ink-free-run-${bestLen}px-center`,
-      ar,
+      return out;
     };
+    const ink = smooth(inkPerCol);
+    const lum = smooth(lumPerCol);
+
+    // Search the CENTRAL third only (35%–65%). These books are 2-columns-per-page,
+    // so the intra-page column gaps sit near 25% and 75% — outside this window —
+    // leaving the binding gutter as the dominant central valley.
+    const cs = Math.round(W * 0.35);
+    const ce = Math.round(W * 0.65);
+    const flank = Math.round(W * 0.08);
+
+    // ── Signal A: bright gutter — the relative ink MINIMUM in the window,
+    // confirmed as a valley flanked by text (higher ink) on both sides.
+    let inkX = cs, inkMin = Infinity;
+    for (let x = cs; x < ce; x++) if (ink[x] < inkMin) { inkMin = ink[x]; inkX = x; }
+    let lInk = 0, rInk = 0;
+    for (let x = Math.max(0, inkX - flank); x < inkX; x++) lInk = Math.max(lInk, ink[x]);
+    for (let x = inkX + 1; x <= Math.min(W - 1, inkX + flank); x++) rInk = Math.max(rInk, ink[x]);
+    if (inkMin < 0.10 && lInk - inkMin >= 0.10 && rInk - inkMin >= 0.10) {
+      return { column: Math.round(inkX / ratio), confidence: 'high', reason: `ink-valley-${Math.round(inkMin * 100)}pct`, ar };
+    }
+
+    // ── Signal B: dark gutter (binding shadow) — the luminance MINIMUM,
+    // confirmed as a valley flanked by brighter page margins on both sides.
+    let lumX = cs, lumMin = Infinity;
+    for (let x = cs; x < ce; x++) if (lum[x] < lumMin) { lumMin = lum[x]; lumX = x; }
+    let lLum = 0, rLum = 0;
+    for (let x = Math.max(0, lumX - flank); x < lumX; x++) lLum = Math.max(lLum, lum[x]);
+    for (let x = lumX + 1; x <= Math.min(W - 1, lumX + flank); x++) rLum = Math.max(rLum, lum[x]);
+    if (lLum - lumMin >= 25 && rLum - lumMin >= 25) {
+      return { column: Math.round(lumX / ratio), confidence: 'high', reason: `dark-valley-${Math.round(lumMin)}lum`, ar };
+    }
+
+    // Neither a bright nor dark central valley → LOW; caller escalates / parks.
+    return { column: null, confidence: 'low', reason: 'no-central-valley', ar };
   } catch (e) {
     return { column: null, confidence: 'low', reason: `pixel-error:${(e.message || '').slice(0, 40)}`, ar };
   }

--- a/scripts/lib/gutter-detect.mjs
+++ b/scripts/lib/gutter-detect.mjs
@@ -1,0 +1,113 @@
+/**
+ * Gutter detection for two-page spreads (#2454 decision tree).
+ *
+ * Primary: pixel ink-density detector — free, no model call. Ported from the
+ * battle-tested `detectGutterColumn()` in scripts/workers/batch-split-bph.mjs
+ * (which survived four false starts — see memory lesson-splitter-gutter-detection),
+ * but here it returns a CONFIDENCE signal instead of silently falling back to a
+ * center cut. Center-cutting is the documented way text gets clipped: BPH gutters
+ * are offset from center by up to 19%.
+ *
+ * The caller uses confidence to decide whether to trust the pixel result or fall
+ * back to a Gemini vision call (the manuscript / tight-binding tail), and to
+ * refuse to cut at all when neither detector is confident.
+ *
+ * Operating principle (hard-won): measure ink CONTENT presence per column, not
+ * brightness. Ink = min(R,G,B) < 120 so colored rubrication registers (grayscale
+ * weights red at ~21% and missed vermillion titles).
+ */
+
+import sharp from 'sharp';
+
+/**
+ * @returns {Promise<{ column: number|null, confidence: 'high'|'low', reason: string, ar: number }>}
+ *   column     — gutter x in ORIGINAL image pixels, or null when not found
+ *   confidence — 'high' only when a clear ink-free run was located in the search band
+ *   reason     — short human label for logs / provenance
+ *   ar         — width/height aspect ratio of the source image
+ */
+export async function detectGutterPixel(spreadBuf) {
+  const meta = await sharp(spreadBuf).metadata();
+  const imgWidth = meta.width || 1;
+  const imgHeight = meta.height || 1;
+  const ar = imgWidth / imgHeight;
+
+  try {
+    const W = 800;
+    const ratio = W / imgWidth;
+    const H = Math.round(imgHeight * ratio);
+    const raw = await sharp(spreadBuf)
+      .resize(W, H, { fit: 'fill' })
+      .removeAlpha()
+      .toColourspace('srgb')
+      .raw()
+      .toBuffer();
+
+    const bandStart = Math.round(H * 0.25);
+    const bandEnd = Math.round(H * 0.75);
+    const DARK = 120;
+    const inkPerCol = new Float32Array(W);
+    for (let x = 0; x < W; x++) {
+      let d = 0;
+      for (let y = bandStart; y < bandEnd; y++) {
+        const i = (y * W + x) * 3;
+        const m = Math.min(raw[i], raw[i + 1], raw[i + 2]);
+        if (m < DARK) d++;
+      }
+      inkPerCol[x] = d / (bandEnd - bandStart);
+    }
+
+    // ±5px smoothing so inter-character white slivers don't fragment the gap.
+    const half = 5;
+    const smoothed = new Float32Array(W);
+    for (let x = 0; x < W; x++) {
+      const lo = Math.max(0, x - half);
+      const hi = Math.min(W - 1, x + half);
+      let s = 0;
+      for (let i = lo; i <= hi; i++) s += inkPerCol[i];
+      smoothed[x] = s / (hi - lo + 1);
+    }
+
+    const cs = Math.round(W * 0.30);
+    const ce = Math.round(W * 0.70);
+    const NO_INK = 0.02;
+    let bestStart = -1, bestLen = 0;
+    let curStart = -1, curLen = 0;
+    for (let x = cs; x < ce; x++) {
+      if (smoothed[x] < NO_INK) {
+        if (curStart < 0) curStart = x;
+        curLen = x - curStart + 1;
+        if (curLen > bestLen) { bestLen = curLen; bestStart = curStart; }
+      } else {
+        curStart = -1; curLen = 0;
+      }
+    }
+
+    // No usable ink-free run → LOW confidence. The old code center-cut here;
+    // we hand off to the caller (Gemini fallback) instead.
+    if (bestStart < 0 || bestLen < 10) {
+      return { column: null, confidence: 'low', reason: 'no-ink-free-run', ar };
+    }
+
+    const WIDE = Math.round(W * 0.15);
+    const chosen = bestLen < WIDE
+      ? bestStart + bestLen                  // narrow gap → cut at gap end
+      : bestStart + Math.floor(bestLen / 2); // wide gap → cut at gap center
+    return {
+      column: Math.round(chosen / ratio),
+      confidence: 'high',
+      reason: bestLen < WIDE ? `ink-free-run-${bestLen}px-end` : `ink-free-run-${bestLen}px-center`,
+      ar,
+    };
+  } catch (e) {
+    return { column: null, confidence: 'low', reason: `pixel-error:${(e.message || '').slice(0, 40)}`, ar };
+  }
+}
+
+/**
+ * Convert a 0-1000 split-position (Gemini's scale) to an absolute pixel column.
+ */
+export function splitPositionToColumn(splitPosition, imgWidth) {
+  if (typeof splitPosition !== 'number') return null;
+  return Math.round((splitPosition / 1000) * imgWidth);
+}

--- a/scripts/maintenance/split-audit-visual.mjs
+++ b/scripts/maintenance/split-audit-visual.mjs
@@ -1,0 +1,175 @@
+/**
+ * Visual split-quality audit (reproduces the 2026-03/04 method).
+ *
+ * For a set of books, samples pages through each, runs the #2454 decision-tree
+ * gutter detector (pixel-primary → Gemini fallback) WITHOUT writing anything,
+ * and renders a self-contained HTML gallery: each sampled spread shown with the
+ * proposed cut line overlaid at the detected position, colored by which detector
+ * fired. The eye check is the only reliable confirmation (memory: numeric
+ * distributions hide failure modes that look identical in aggregate).
+ *
+ * Cut-line color = method:  green pixel · blue gemini · red uncertain/center
+ * Book border    = verdict: green ok · amber would-park
+ *
+ * Usage (read-only, no DB writes):
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/split-audit-visual.mjs --ids id1,id2,... --out /tmp/split-audit.html
+ *   node scripts/maintenance/split-audit-visual.mjs --ids-file /tmp/ids.json --samples 6
+ */
+
+import { MongoClient } from 'mongodb';
+import sharp from 'sharp';
+import { writeFileSync } from 'fs';
+import { detectGutterPixel } from '../lib/gutter-detect.mjs';
+
+const arg = (flag, def) => {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 ? process.argv[i + 1] : def;
+};
+const OUT = arg('--out', '/tmp/split-audit.html');
+const SAMPLES = parseInt(arg('--samples', '6'), 10);
+let IDS = (arg('--ids', '') || '').split(',').filter(Boolean);
+if (!IDS.length && arg('--ids-file')) {
+  IDS = JSON.parse((await import('fs')).readFileSync(arg('--ids-file'), 'utf8'));
+}
+if (!IDS.length) { console.error('Provide --ids or --ids-file'); process.exit(1); }
+
+const MIN_SPREAD_AR = 1.1;
+
+// Gemini gutter fallback — same prompt/model as split-book.mjs --gutter-only.
+let geminiModel = null;
+const GUTTER_PROMPT = `This image is a scan from a book. Decide whether it shows a TWO-PAGE SPREAD (an open book with a left and a right page) or a SINGLE page.
+
+Respond with EXACTLY one tag and nothing else:
+- Two-page spread: <split-position>N</split-position> where N (0-1000) is the horizontal position of the gutter (the fold between the pages). The gutter is usually near the center (400-600).
+- Single page: <split-position>null</split-position>`;
+async function initGemini() {
+  const { GoogleGenerativeAI } = await import('@google/generative-ai');
+  geminiModel = new GoogleGenerativeAI(process.env.GEMINI_API_KEY).getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
+}
+async function runGutterDetect(buf) {
+  const r = await geminiModel.generateContent([GUTTER_PROMPT, { inlineData: { mimeType: 'image/jpeg', data: buf.toString('base64') } }]);
+  const m = r.response.text().match(/<split-position>([^<]*)<\/split-position>/);
+  if (!m) return null;
+  const n = parseInt(m[1]);
+  return (!isNaN(n) && n > 0 && n < 1000) ? n : 'single';
+}
+
+// Resolve one decision-tree result for a page image (no writes).
+async function decide(buf) {
+  const meta = await sharp(buf).metadata();
+  const ar = meta.width / meta.height;
+  if (ar < MIN_SPREAD_AR) return { colPx: null, pct: null, method: 'portrait', color: '#7a7ae8', uncertain: false, ar, meta };
+  const pix = await detectGutterPixel(buf);
+  if (pix.confidence === 'high' && pix.column != null) {
+    return { colPx: pix.column, pct: (pix.column / meta.width) * 100, method: `pixel (${pix.reason})`, color: '#7ae87a', uncertain: false, ar, meta };
+  }
+  if (!geminiModel) await initGemini();
+  let gem = null;
+  try { gem = await runGutterDetect(buf); } catch { gem = null; }
+  if (typeof gem === 'number') return { colPx: Math.round((gem / 1000) * meta.width), pct: gem / 10, method: 'gemini', color: '#7a9ae8', uncertain: false, ar, meta };
+  if (ar >= 1.3) return { colPx: Math.round(meta.width / 2), pct: 50, method: 'center (uncertain)', color: '#e87a7a', uncertain: true, ar, meta };
+  return { colPx: null, pct: null, method: 'kept-whole (uncertain)', color: '#e8b07a', uncertain: true, ar, meta };
+}
+
+const HEX = { '#7ae87a': [122, 232, 122], '#7a9ae8': [122, 154, 232], '#e87a7a': [232, 122, 122], '#e8b07a': [232, 176, 122], '#7a7ae8': [122, 122, 232] };
+
+// Gutter-zoom: crop a vertical band around the cut, burn the cut line into the
+// image, return a base64 PNG data-URI. This is the diagnostic view — the
+// line-vs-text relationship is unmistakable, and a data-URI always renders in a
+// headless screenshot (remote loads can flake).
+async function gutterZoom(buf, colPx, color, meta) {
+  const H = 340;
+  const bandHalf = Math.round(meta.width * 0.16);
+  const left = colPx != null ? Math.max(0, colPx - bandHalf) : 0;
+  const w = colPx != null ? Math.min(meta.width - left, bandHalf * 2) : meta.width;
+  const region = await sharp(buf).extract({ left, top: 0, width: w, height: meta.height }).resize({ height: H }).toBuffer();
+  const rMeta = await sharp(region).metadata();
+  if (colPx == null) return `data:image/png;base64,${(await sharp(region).png().toBuffer()).toString('base64')}`;
+  const scale = H / meta.height;
+  const lineX = Math.round((colPx - left) * scale);
+  const [r, g, b] = HEX[color] || [255, 0, 0];
+  const svg = Buffer.from(`<svg width="${rMeta.width}" height="${H}"><line x1="${lineX}" y1="0" x2="${lineX}" y2="${H}" stroke="rgb(${r},${g},${b})" stroke-width="3"/></svg>`);
+  const out = await sharp(region).composite([{ input: svg, top: 0, left: 0 }]).png().toBuffer();
+  return `data:image/png;base64,${out.toString('base64')}`;
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+const esc = (s) => String(s || '').replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+let bookHtml = '';
+let parkCount = 0;
+
+for (const id of IDS) {
+  const book = await db.collection('books').findOne({ id }, { projection: { id: 1, title: 1, slug: 1, pages_count: 1, image_source: 1 } });
+  if (!book) { console.error(`skip ${id}: not found`); continue; }
+  const pages = await db.collection('pages').find({ book_id: id }, { projection: { page_number: 1, archived_photo: 1, photo: 1 } }).sort({ page_number: 1 }).toArray();
+  const total = pages.length;
+  if (!total) continue;
+
+  // sample SAMPLES pages evenly through the book
+  const idxs = [...new Set(Array.from({ length: Math.min(SAMPLES, total) }, (_, i) => Math.floor(((i + 1) / (Math.min(SAMPLES, total) + 1)) * total)))];
+  let samplesHtml = '';
+  let uncertain = 0, landscape = 0;
+  for (const idx of idxs) {
+    const p = pages[idx];
+    const url = p.archived_photo || p.photo;
+    if (!url) continue;
+    let d, zoom;
+    try {
+      const buf = Buffer.from(await (await fetch(url, { signal: AbortSignal.timeout(20000) })).arrayBuffer());
+      d = await decide(buf);
+      zoom = await gutterZoom(buf, d.colPx, d.color, d.meta);
+    } catch (e) { samplesHtml += `<div class="sample"><div class="err">p${p.page_number} fetch fail</div></div>`; continue; }
+    if (d.method !== 'portrait') landscape++;
+    if (d.uncertain) uncertain++;
+    samplesHtml += `<div class="sample"><div class="imgwrap"><img src="${zoom}" alt="p${p.page_number}"></div><div class="label" style="color:${d.color}">p${p.page_number} · AR ${d.ar.toFixed(2)}<br>${esc(d.method)}</div></div>`;
+  }
+  const uncertainFrac = landscape ? uncertain / landscape : 0;
+  const wouldPark = uncertainFrac > 0.15;
+  if (wouldPark) parkCount++;
+  const url = `https://sourcelibrary.org/book/${book.slug || book.id}`;
+  bookHtml += `<div class="book" style="border-color:${wouldPark ? '#e8b07a' : '#7ae87a'}">
+    <h2><a href="${url}" target="_blank">${esc(book.title)}</a> ${wouldPark ? '<span class="park">WOULD PARK</span>' : ''}</h2>
+    <div class="meta">${esc(book.image_source?.provider || '?')} · ${total} pages · ${uncertain}/${landscape} sampled-landscape uncertain</div>
+    <div class="samples">${samplesHtml}</div>
+  </div>`;
+  console.error(`done ${id}: ${uncertain}/${landscape} uncertain${wouldPark ? ' (PARK)' : ''}`);
+}
+
+const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Split Audit — Difficult Subset</title><style>
+body{font-family:system-ui;background:#1a1a1a;color:#ddd;padding:20px;max-width:1500px;margin:0 auto}
+h1{color:#e8c87a}
+.legend{display:flex;gap:18px;margin:14px 0;font-size:13px;flex-wrap:wrap}
+.legend span{display:flex;align-items:center;gap:6px}
+.dot{width:12px;height:12px;border-radius:50%;display:inline-block}
+.book{border:2px solid #333;margin:18px 0;padding:14px;border-radius:8px;background:#222}
+.book h2{font-size:15px;color:#e8c87a;margin:0 0 4px}
+.book h2 a{color:#e8c87a;text-decoration:none}
+.park{color:#e8b07a;font-size:11px;border:1px solid #e8b07a;padding:1px 6px;border-radius:4px;margin-left:8px}
+.meta{font-size:12px;color:#888;margin-bottom:10px}
+.samples{display:flex;gap:10px;overflow-x:auto;padding-bottom:8px}
+.sample{flex-shrink:0;text-align:center}
+.imgwrap{position:relative;display:inline-block}
+.imgwrap img{height:340px;border:1px solid #444;border-radius:4px;display:block;image-rendering:auto}
+.cut{position:absolute;top:0;bottom:0;width:2px;opacity:0.85}
+.label{font-size:11px;margin-top:4px;line-height:1.3}
+.err{color:#e87a7a;font-size:12px;height:360px;display:flex;align-items:center;padding:0 20px}
+</style></head><body>
+<h1>Split Audit — Difficult Subset (${IDS.length} books, ${parkCount} would park)</h1>
+<p style="font-size:13px;color:#aaa">Each tile is a <b>zoom on the gutter region</b> with the proposed cut line burned in. Check: does the line sit in the binding, or slice through text? Color = which detector chose the cut.</p>
+<div class="legend">
+<span><span class="dot" style="background:#7ae87a"></span>pixel (free)</span>
+<span><span class="dot" style="background:#7a9ae8"></span>gemini fallback</span>
+<span><span class="dot" style="background:#e87a7a"></span>center — uncertain</span>
+<span><span class="dot" style="background:#e8b07a"></span>kept whole — uncertain</span>
+<span><span class="dot" style="background:#7a7ae8"></span>portrait (no cut)</span>
+</div>
+${bookHtml}
+</body></html>`;
+
+writeFileSync(OUT, html);
+console.error(`\nWrote ${OUT} (${IDS.length} books, ${parkCount} would park)`);
+await client.close();

--- a/scripts/maintenance/split-audit-visual.mjs
+++ b/scripts/maintenance/split-audit-visual.mjs
@@ -28,6 +28,7 @@ const arg = (flag, def) => {
 };
 const OUT = arg('--out', '/tmp/split-audit.html');
 const SAMPLES = parseInt(arg('--samples', '6'), 10);
+const GEMINI_MODEL = arg('--gemini-model', 'gemini-3-flash-preview');
 let IDS = (arg('--ids', '') || '').split(',').filter(Boolean);
 if (!IDS.length && arg('--ids-file')) {
   IDS = JSON.parse((await import('fs')).readFileSync(arg('--ids-file'), 'utf8'));
@@ -38,14 +39,14 @@ const MIN_SPREAD_AR = 1.1;
 
 // Gemini gutter fallback — same prompt/model as split-book.mjs --gutter-only.
 let geminiModel = null;
-const GUTTER_PROMPT = `This image is a scan from a book. Decide whether it shows a TWO-PAGE SPREAD (an open book with a left and a right page) or a SINGLE page.
+const GUTTER_PROMPT = `This is a photo of an open book showing a left page and a right page. Find the GUTTER — the vertical line where the two pages meet at the binding (often a shadow, or the innermost margins of the two pages). It may NOT be at the center; look carefully.
 
 Respond with EXACTLY one tag and nothing else:
-- Two-page spread: <split-position>N</split-position> where N (0-1000) is the horizontal position of the gutter (the fold between the pages). The gutter is usually near the center (400-600).
-- Single page: <split-position>null</split-position>`;
+- Two-page spread: <split-position>N</split-position> where N (0-1000) is the gutter's horizontal position. 0 = far left edge, 1000 = far right edge.
+- Single page (not a spread): <split-position>null</split-position>`;
 async function initGemini() {
   const { GoogleGenerativeAI } = await import('@google/generative-ai');
-  geminiModel = new GoogleGenerativeAI(process.env.GEMINI_API_KEY).getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
+  geminiModel = new GoogleGenerativeAI(process.env.GEMINI_API_KEY).getGenerativeModel({ model: GEMINI_MODEL });
 }
 async function runGutterDetect(buf) {
   const r = await geminiModel.generateContent([GUTTER_PROMPT, { inlineData: { mimeType: 'image/jpeg', data: buf.toString('base64') } }]);
@@ -55,42 +56,48 @@ async function runGutterDetect(buf) {
   return (!isNaN(n) && n > 0 && n < 1000) ? n : 'single';
 }
 
-// Resolve one decision-tree result for a page image (no writes).
+// Resolve one decision-tree result (no writes): pixel valley + Gemini cross-check.
+const AGREE_TOL = 80; // 0-1000 → 8%
 async function decide(buf) {
   const meta = await sharp(buf).metadata();
   const ar = meta.width / meta.height;
   if (ar < MIN_SPREAD_AR) return { colPx: null, pct: null, method: 'portrait', color: '#7a7ae8', uncertain: false, ar, meta };
   const pix = await detectGutterPixel(buf);
-  if (pix.confidence === 'high' && pix.column != null) {
-    return { colPx: pix.column, pct: (pix.column / meta.width) * 100, method: `pixel (${pix.reason})`, color: '#7ae87a', uncertain: false, ar, meta };
-  }
+  const pixPos = (pix.confidence === 'high' && pix.column != null) ? Math.round((pix.column / meta.width) * 1000) : null;
   if (!geminiModel) await initGemini();
-  let gem = null;
-  try { gem = await runGutterDetect(buf); } catch { gem = null; }
-  if (typeof gem === 'number') return { colPx: Math.round((gem / 1000) * meta.width), pct: gem / 10, method: 'gemini', color: '#7a9ae8', uncertain: false, ar, meta };
+  let gemPos = null;
+  try { gemPos = await runGutterDetect(buf); if (typeof gemPos !== 'number') gemPos = null; } catch { gemPos = null; }
+  const toCol = (pos1000) => Math.round((pos1000 / 1000) * meta.width);
+  if (pixPos != null && gemPos != null) {
+    if (Math.abs(pixPos - gemPos) <= AGREE_TOL) {
+      const pos = Math.round((pixPos + gemPos) / 2);
+      return { colPx: toCol(pos), pct: pos / 10, method: `agree px${pixPos}/gem${gemPos}`, color: '#7ae87a', uncertain: false, pos, confirmed: true, ar, meta };
+    }
+    // disagree → uncertain
+    return { colPx: toCol(pixPos), pct: pixPos / 10, method: `DISAGREE px${pixPos}/gem${gemPos}`, color: '#e87a7a', uncertain: true, ar, meta };
+  }
+  if (pixPos != null) return { colPx: toCol(pixPos), pct: pixPos / 10, method: `pixel ${pix.reason}`, color: '#9ae87a', uncertain: false, pos: pixPos, confirmed: true, ar, meta };
+  if (gemPos != null) return { colPx: toCol(gemPos), pct: gemPos / 10, method: `gemini ${gemPos} (unconfirmed)`, color: '#7a9ae8', uncertain: true, ar, meta };
   if (ar >= 1.3) return { colPx: Math.round(meta.width / 2), pct: 50, method: 'center (uncertain)', color: '#e87a7a', uncertain: true, ar, meta };
   return { colPx: null, pct: null, method: 'kept-whole (uncertain)', color: '#e8b07a', uncertain: true, ar, meta };
 }
 
 const HEX = { '#7ae87a': [122, 232, 122], '#7a9ae8': [122, 154, 232], '#e87a7a': [232, 122, 122], '#e8b07a': [232, 176, 122], '#7a7ae8': [122, 122, 232] };
 
-// Gutter-zoom: crop a vertical band around the cut, burn the cut line into the
-// image, return a base64 PNG data-URI. This is the diagnostic view — the
-// line-vs-text relationship is unmistakable, and a data-URI always renders in a
-// headless screenshot (remote loads can flake).
-async function gutterZoom(buf, colPx, color, meta) {
-  const H = 340;
-  const bandHalf = Math.round(meta.width * 0.16);
-  const left = colPx != null ? Math.max(0, colPx - bandHalf) : 0;
-  const w = colPx != null ? Math.min(meta.width - left, bandHalf * 2) : meta.width;
-  const region = await sharp(buf).extract({ left, top: 0, width: w, height: meta.height }).resize({ height: H }).toBuffer();
-  const rMeta = await sharp(region).metadata();
-  if (colPx == null) return `data:image/png;base64,${(await sharp(region).png().toBuffer()).toString('base64')}`;
-  const scale = H / meta.height;
-  const lineX = Math.round((colPx - left) * scale);
+// Honest render: the FULL spread with the cut line at its TRUE horizontal
+// position (not a band re-centered on the cut). This is the only view that
+// shows whether the line lands in the binding or slices a column. Burned into
+// the image (data-URI) so a headless screenshot always renders it.
+async function fullSpreadWithLine(buf, colPx, color, meta) {
+  const W = 520;
+  const scale = W / meta.width;
+  const H = Math.round(meta.height * scale);
+  const base = await sharp(buf).resize(W, H, { fit: 'fill' }).toBuffer();
+  if (colPx == null) return `data:image/png;base64,${(await sharp(base).png().toBuffer()).toString('base64')}`;
+  const lineX = Math.round(colPx * scale);
   const [r, g, b] = HEX[color] || [255, 0, 0];
-  const svg = Buffer.from(`<svg width="${rMeta.width}" height="${H}"><line x1="${lineX}" y1="0" x2="${lineX}" y2="${H}" stroke="rgb(${r},${g},${b})" stroke-width="3"/></svg>`);
-  const out = await sharp(region).composite([{ input: svg, top: 0, left: 0 }]).png().toBuffer();
+  const svg = Buffer.from(`<svg width="${W}" height="${H}"><line x1="${lineX}" y1="0" x2="${lineX}" y2="${H}" stroke="rgb(${r},${g},${b})" stroke-width="2"/></svg>`);
+  const out = await sharp(base).composite([{ input: svg, top: 0, left: 0 }]).png().toBuffer();
   return `data:image/png;base64,${out.toString('base64')}`;
 }
 
@@ -109,37 +116,55 @@ for (const id of IDS) {
   const total = pages.length;
   if (!total) continue;
 
-  // sample SAMPLES pages evenly through the book
+  // Pass 1: decide each sampled page (no rendering yet — need the book median first).
   const idxs = [...new Set(Array.from({ length: Math.min(SAMPLES, total) }, (_, i) => Math.floor(((i + 1) / (Math.min(SAMPLES, total) + 1)) * total)))];
-  let samplesHtml = '';
-  let uncertain = 0, landscape = 0;
+  const samples = [];
+  const confidentPositions = [];
+  let landscape = 0;
   for (const idx of idxs) {
     const p = pages[idx];
     const url = p.archived_photo || p.photo;
     if (!url) continue;
-    let d, zoom;
     try {
       const buf = Buffer.from(await (await fetch(url, { signal: AbortSignal.timeout(20000) })).arrayBuffer());
-      d = await decide(buf);
-      zoom = await gutterZoom(buf, d.colPx, d.color, d.meta);
-    } catch (e) { samplesHtml += `<div class="sample"><div class="err">p${p.page_number} fetch fail</div></div>`; continue; }
-    if (d.method !== 'portrait') landscape++;
-    if (d.uncertain) uncertain++;
-    samplesHtml += `<div class="sample"><div class="imgwrap"><img src="${zoom}" alt="p${p.page_number}"></div><div class="label" style="color:${d.color}">p${p.page_number} · AR ${d.ar.toFixed(2)}<br>${esc(d.method)}</div></div>`;
+      const d = await decide(buf);
+      if (d.method !== 'portrait') landscape++;
+      if (d.confirmed && typeof d.pos === 'number') confidentPositions.push(d.pos);
+      samples.push({ p, buf, d });
+    } catch { samples.push({ p, err: true }); }
   }
-  const uncertainFrac = landscape ? uncertain / landscape : 0;
-  const wouldPark = uncertainFrac > 0.15;
+
+  // Book consensus (approach A): robust median + MAD; snap outliers/uncertain to it.
+  const sorted = [...confidentPositions].sort((a, b) => a - b);
+  const median = sorted.length ? sorted[Math.floor(sorted.length / 2)] : 500;
+  const mad = sorted.length ? [...sorted.map(v => Math.abs(v - median))].sort((a, b) => a - b)[Math.floor(sorted.length / 2)] : 0;
+  const enoughSignal = confidentPositions.length >= Math.max(2, Math.ceil(landscape * 0.4));
+  const scattered = confidentPositions.length >= 3 && mad > 60;
+  const wouldPark = !enoughSignal || scattered;
   if (wouldPark) parkCount++;
+
+  // Pass 2: render, snapping outlier/uncertain landscape pages to the median.
+  let samplesHtml = '', snapped = 0;
+  for (const s of samples) {
+    if (s.err) { samplesHtml += `<div class="sample"><div class="err">p${s.p.page_number} fetch fail</div></div>`; continue; }
+    let { d } = s; let colPx = d.colPx, color = d.color, method = d.method;
+    const isLandscape = d.method !== 'portrait';
+    if (!wouldPark && isLandscape && (d.uncertain || (typeof d.pos === 'number' && Math.abs(d.pos - median) > 80))) {
+      colPx = Math.round((median / 1000) * d.meta.width); color = '#c79ae8'; method = `book-median(${median})`; snapped++;
+    }
+    const zoom = await fullSpreadWithLine(s.buf, colPx, color, d.meta);
+    samplesHtml += `<div class="sample"><div class="imgwrap"><img src="${zoom}" alt="p${s.p.page_number}"></div><div class="label" style="color:${color}">p${s.p.page_number} · AR ${d.ar.toFixed(2)}<br>${esc(method)}</div></div>`;
+  }
   const url = `https://sourcelibrary.org/book/${book.slug || book.id}`;
   bookHtml += `<div class="book" style="border-color:${wouldPark ? '#e8b07a' : '#7ae87a'}">
     <h2><a href="${url}" target="_blank">${esc(book.title)}</a> ${wouldPark ? '<span class="park">WOULD PARK</span>' : ''}</h2>
-    <div class="meta">${esc(book.image_source?.provider || '?')} · ${total} pages · ${uncertain}/${landscape} sampled-landscape uncertain</div>
+    <div class="meta">${esc(book.image_source?.provider || '?')} · ${total} pages · median ${median}/1000 · MAD ${mad} · ${confidentPositions.length}/${landscape} confident${snapped ? ` · ${snapped} snapped` : ''}${scattered ? ' · SCATTERED' : ''}${!enoughSignal ? ' · LOW-SIGNAL' : ''}</div>
     <div class="samples">${samplesHtml}</div>
   </div>`;
-  console.error(`done ${id}: ${uncertain}/${landscape} uncertain${wouldPark ? ' (PARK)' : ''}`);
+  console.error(`done ${id}: median ${median} MAD ${mad} ${confidentPositions.length}/${landscape} conf${wouldPark ? ' (PARK)' : ''}`);
 }
 
-const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Split Audit — Difficult Subset</title><style>
+const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Split Audit — ${GEMINI_MODEL}</title><style>
 body{font-family:system-ui;background:#1a1a1a;color:#ddd;padding:20px;max-width:1500px;margin:0 auto}
 h1{color:#e8c87a}
 .legend{display:flex;gap:18px;margin:14px 0;font-size:13px;flex-wrap:wrap}
@@ -158,12 +183,13 @@ h1{color:#e8c87a}
 .label{font-size:11px;margin-top:4px;line-height:1.3}
 .err{color:#e87a7a;font-size:12px;height:360px;display:flex;align-items:center;padding:0 20px}
 </style></head><body>
-<h1>Split Audit — Difficult Subset (${IDS.length} books, ${parkCount} would park)</h1>
+<h1>Split Audit — gutter model: ${GEMINI_MODEL} (${IDS.length} books, ${parkCount} would park)</h1>
 <p style="font-size:13px;color:#aaa">Each tile is a <b>zoom on the gutter region</b> with the proposed cut line burned in. Check: does the line sit in the binding, or slice through text? Color = which detector chose the cut.</p>
 <div class="legend">
-<span><span class="dot" style="background:#7ae87a"></span>pixel (free)</span>
-<span><span class="dot" style="background:#7a9ae8"></span>gemini fallback</span>
-<span><span class="dot" style="background:#e87a7a"></span>center — uncertain</span>
+<span><span class="dot" style="background:#7ae87a"></span>pixel + gemini agree</span>
+<span><span class="dot" style="background:#9ae87a"></span>pixel only</span>
+<span><span class="dot" style="background:#7a9ae8"></span>gemini only</span>
+<span><span class="dot" style="background:#e87a7a"></span>disagree / center — uncertain</span>
 <span><span class="dot" style="background:#e8b07a"></span>kept whole — uncertain</span>
 <span><span class="dot" style="background:#7a7ae8"></span>portrait (no cut)</span>
 </div>

--- a/scripts/maintenance/split-audit-visual.mjs
+++ b/scripts/maintenance/split-audit-visual.mjs
@@ -77,7 +77,7 @@ async function decide(buf) {
     return { colPx: toCol(pixPos), pct: pixPos / 10, method: `DISAGREE px${pixPos}/gem${gemPos}`, color: '#e87a7a', uncertain: true, ar, meta };
   }
   if (pixPos != null) return { colPx: toCol(pixPos), pct: pixPos / 10, method: `pixel ${pix.reason}`, color: '#9ae87a', uncertain: false, pos: pixPos, confirmed: true, ar, meta };
-  if (gemPos != null) return { colPx: toCol(gemPos), pct: gemPos / 10, method: `gemini ${gemPos} (unconfirmed)`, color: '#7a9ae8', uncertain: true, ar, meta };
+  if (gemPos != null) return { colPx: toCol(gemPos), pct: gemPos / 10, method: `gemini ${gemPos}`, color: '#7a9ae8', uncertain: false, pos: gemPos, confirmed: true, ar, meta };
   if (ar >= 1.3) return { colPx: Math.round(meta.width / 2), pct: 50, method: 'center (uncertain)', color: '#e87a7a', uncertain: true, ar, meta };
   return { colPx: null, pct: null, method: 'kept-whole (uncertain)', color: '#e8b07a', uncertain: true, ar, meta };
 }
@@ -112,9 +112,20 @@ let parkCount = 0;
 for (const id of IDS) {
   const book = await db.collection('books').findOne({ id }, { projection: { id: 1, title: 1, slug: 1, pages_count: 1, image_source: 1 } });
   if (!book) { console.error(`skip ${id}: not found`); continue; }
-  const pages = await db.collection('pages').find({ book_id: id }, { projection: { page_number: 1, archived_photo: 1, photo: 1 } }).sort({ page_number: 1 }).toArray();
+  const pages = await db.collection('pages').find({ book_id: id }, { projection: { page_number: 1, archived_photo: 1, photo: 1, page_type: 1, 'ocr.data': 1 } }).sort({ page_number: 1 }).toArray();
   const total = pages.length;
   if (!total) continue;
+
+  // OCR content class (free): plate/map book vs text spread book.
+  const IMG_PAGE_TYPES = new Set(['map', 'illustration', 'diagram', 'frontispiece', 'plate']);
+  let imgPages = 0, contentPages = 0;
+  for (const pg of pages) {
+    if (pg.page_type === 'blank') continue;
+    const body = (pg.ocr?.data || '').replace(/<[^>]+>/g, '').trim().length;
+    if (IMG_PAGE_TYPES.has(pg.page_type) || (/<image-desc>/i.test(pg.ocr?.data || '') && body < 400)) imgPages++; else contentPages++;
+  }
+  const imgFrac = (imgPages + contentPages) ? imgPages / (imgPages + contentPages) : 0;
+  const contentClass = imgFrac >= 0.6 ? 'PLATE/MAP — keep whole' : imgFrac >= 0.25 ? 'MIXED — review' : 'text';
 
   // Pass 1: decide each sampled page (no rendering yet — need the book median first).
   const idxs = [...new Set(Array.from({ length: Math.min(SAMPLES, total) }, (_, i) => Math.floor(((i + 1) / (Math.min(SAMPLES, total) + 1)) * total)))];
@@ -138,9 +149,9 @@ for (const id of IDS) {
   const sorted = [...confidentPositions].sort((a, b) => a - b);
   const median = sorted.length ? sorted[Math.floor(sorted.length / 2)] : 500;
   const mad = sorted.length ? [...sorted.map(v => Math.abs(v - median))].sort((a, b) => a - b)[Math.floor(sorted.length / 2)] : 0;
-  const enoughSignal = confidentPositions.length >= Math.max(2, Math.ceil(landscape * 0.4));
+  const enoughSignal = confidentPositions.length >= Math.max(2, Math.ceil(landscape * 0.25));
   const scattered = confidentPositions.length >= 3 && mad > 60;
-  const wouldPark = !enoughSignal || scattered;
+  const wouldPark = imgFrac >= 0.25 || !enoughSignal || scattered;
   if (wouldPark) parkCount++;
 
   // Pass 2: render, snapping outlier/uncertain landscape pages to the median.
@@ -158,7 +169,7 @@ for (const id of IDS) {
   const url = `https://sourcelibrary.org/book/${book.slug || book.id}`;
   bookHtml += `<div class="book" style="border-color:${wouldPark ? '#e8b07a' : '#7ae87a'}">
     <h2><a href="${url}" target="_blank">${esc(book.title)}</a> ${wouldPark ? '<span class="park">WOULD PARK</span>' : ''}</h2>
-    <div class="meta">${esc(book.image_source?.provider || '?')} · ${total} pages · median ${median}/1000 · MAD ${mad} · ${confidentPositions.length}/${landscape} confident${snapped ? ` · ${snapped} snapped` : ''}${scattered ? ' · SCATTERED' : ''}${!enoughSignal ? ' · LOW-SIGNAL' : ''}</div>
+    <div class="meta">${esc(book.image_source?.provider || '?')} · ${total}p · ${esc(contentClass)} (imgFrac ${imgFrac.toFixed(2)}) · median ${median} MAD ${mad} · ${confidentPositions.length}/${landscape} conf${snapped ? ` · ${snapped} snapped` : ''}${scattered ? ' · SCATTERED' : ''}</div>
     <div class="samples">${samplesHtml}</div>
   </div>`;
   console.error(`done ${id}: median ${median} MAD ${mad} ${confidentPositions.length}/${landscape} conf${wouldPark ? ' (PARK)' : ''}`);

--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -22,7 +22,7 @@ import sharp from 'sharp';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 
 // --- Config ---
-const OVERLAP = 0.01;        // 1% overlap on each crop
+const OVERLAP = 0.03;        // 3% overlap on each crop (#1491 lesson #6: 1% clipped tight gutters)
 const CONCURRENCY = 3;       // Gemini / fetch concurrency
 const MAX_RETRIES = 3;       // Image fetch retries
 const FETCH_TIMEOUT = 15000; // 15s per image
@@ -69,6 +69,7 @@ function spPath(bookId, pageNum, suffix) {
 
 async function cropAndUpload(buf, left, width, height, bookId, pageNum) {
   const full = await sharp(buf).extract({ left, top: 0, width, height }).jpeg({ quality: 90, progressive: true }).toBuffer();
+  const fullDim = { width, height };
   const display = await sharp(full).resize(1200, null, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 85, progressive: true }).toBuffer();
   const thumb = await sharp(full).resize(150, null, { fit: 'inside' }).jpeg({ quality: 60 }).toBuffer();
   const [fullUrl, dispUrl, thumbUrl] = await Promise.all([
@@ -76,10 +77,11 @@ async function cropAndUpload(buf, left, width, height, bookId, pageNum) {
     upload(spPath(bookId, pageNum, '.jpg'), display),
     upload(spPath(bookId, pageNum, '-thumb.jpg'), thumb),
   ]);
-  return { fullUrl, dispUrl, thumbUrl };
+  return { fullUrl, dispUrl, thumbUrl, width: fullDim.width, height: fullDim.height };
 }
 
 async function uploadFullImage(buf, bookId, pageNum) {
+  const fm = await sharp(buf).metadata();
   const display = await sharp(buf).resize(1200, null, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 85, progressive: true }).toBuffer();
   const thumb = await sharp(buf).resize(150, null, { fit: 'inside' }).jpeg({ quality: 60 }).toBuffer();
   const [fullUrl, dispUrl, thumbUrl] = await Promise.all([
@@ -87,7 +89,7 @@ async function uploadFullImage(buf, bookId, pageNum) {
     upload(spPath(bookId, pageNum, '.jpg'), display),
     upload(spPath(bookId, pageNum, '-thumb.jpg'), thumb),
   ]);
-  return { fullUrl, dispUrl, thumbUrl };
+  return { fullUrl, dispUrl, thumbUrl, width: fm.width, height: fm.height };
 }
 
 // --- Page type extraction ---
@@ -662,6 +664,8 @@ for (let batch = 0; batch < sourceIndices.length; batch += CONCURRENCY) {
         entry._photo = urls.dispUrl;
         entry._thumb = urls.thumbUrl;
         entry._full = urls.fullUrl;
+        entry._imgW = urls.width;
+        entry._imgH = urls.height;
       } else if (entry.side === 'left') {
         const splitFrac = (entry.splitPosition || 500) / 1000;
         const leftEnd = Math.round(Math.min(1, splitFrac + OVERLAP) * w);
@@ -669,6 +673,8 @@ for (let batch = 0; batch < sourceIndices.length; batch += CONCURRENCY) {
         entry._photo = urls.dispUrl;
         entry._thumb = urls.thumbUrl;
         entry._full = urls.fullUrl;
+        entry._imgW = urls.width;
+        entry._imgH = urls.height;
       } else if (entry.side === 'right') {
         const splitFrac = (entry.splitPosition || 500) / 1000;
         const rightStart = Math.round(Math.max(0, splitFrac - OVERLAP) * w);
@@ -676,6 +682,8 @@ for (let batch = 0; batch < sourceIndices.length; batch += CONCURRENCY) {
         entry._photo = urls.dispUrl;
         entry._thumb = urls.thumbUrl;
         entry._full = urls.fullUrl;
+        entry._imgW = urls.width;
+        entry._imgH = urls.height;
       }
     }
 
@@ -714,6 +722,7 @@ for (let i = 0; i < newPages.length; i++) {
     archived_photo: p._full || p._photo,   // full-res crop — what archive audits key on (#829)
     display_photo: p._photo,
     thumbnail_blob: p._thumb,
+    ...(p._imgW ? { image_width: p._imgW, image_height: p._imgH } : {}), // #1491: dims on each page record
     ...(iiifUrls[p.sourceIdx] ? { spread_source: iiifUrls[p.sourceIdx] } : {}), // lineage to the pre-split spread
     ocr: p.ocr ? {
       data: p.ocr,

--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -71,23 +71,23 @@ async function cropAndUpload(buf, left, width, height, bookId, pageNum) {
   const full = await sharp(buf).extract({ left, top: 0, width, height }).jpeg({ quality: 90, progressive: true }).toBuffer();
   const display = await sharp(full).resize(1200, null, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 85, progressive: true }).toBuffer();
   const thumb = await sharp(full).resize(150, null, { fit: 'inside' }).jpeg({ quality: 60 }).toBuffer();
-  const [, dispUrl, thumbUrl] = await Promise.all([
+  const [fullUrl, dispUrl, thumbUrl] = await Promise.all([
     upload(spPath(bookId, pageNum, '-full.jpg'), full),
     upload(spPath(bookId, pageNum, '.jpg'), display),
     upload(spPath(bookId, pageNum, '-thumb.jpg'), thumb),
   ]);
-  return { dispUrl, thumbUrl };
+  return { fullUrl, dispUrl, thumbUrl };
 }
 
 async function uploadFullImage(buf, bookId, pageNum) {
   const display = await sharp(buf).resize(1200, null, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 85, progressive: true }).toBuffer();
   const thumb = await sharp(buf).resize(150, null, { fit: 'inside' }).jpeg({ quality: 60 }).toBuffer();
-  const [, dispUrl, thumbUrl] = await Promise.all([
+  const [fullUrl, dispUrl, thumbUrl] = await Promise.all([
     upload(spPath(bookId, pageNum, '-full.jpg'), buf),
     upload(spPath(bookId, pageNum, '.jpg'), display),
     upload(spPath(bookId, pageNum, '-thumb.jpg'), thumb),
   ]);
-  return { dispUrl, thumbUrl };
+  return { fullUrl, dispUrl, thumbUrl };
 }
 
 // --- Page type extraction ---
@@ -661,18 +661,21 @@ for (let batch = 0; batch < sourceIndices.length; batch += CONCURRENCY) {
         const urls = await uploadFullImage(buf, book.id, pageNum);
         entry._photo = urls.dispUrl;
         entry._thumb = urls.thumbUrl;
+        entry._full = urls.fullUrl;
       } else if (entry.side === 'left') {
         const splitFrac = (entry.splitPosition || 500) / 1000;
         const leftEnd = Math.round(Math.min(1, splitFrac + OVERLAP) * w);
         const urls = await cropAndUpload(buf, 0, leftEnd, h, book.id, pageNum);
         entry._photo = urls.dispUrl;
         entry._thumb = urls.thumbUrl;
+        entry._full = urls.fullUrl;
       } else if (entry.side === 'right') {
         const splitFrac = (entry.splitPosition || 500) / 1000;
         const rightStart = Math.round(Math.max(0, splitFrac - OVERLAP) * w);
         const urls = await cropAndUpload(buf, rightStart, w - rightStart, h, book.id, pageNum);
         entry._photo = urls.dispUrl;
         entry._thumb = urls.thumbUrl;
+        entry._full = urls.fullUrl;
       }
     }
 
@@ -708,6 +711,10 @@ for (let i = 0; i < newPages.length; i++) {
     page_number: pageNum,
     photo: p._photo,
     thumbnail: p._thumb,
+    archived_photo: p._full || p._photo,   // full-res crop — what archive audits key on (#829)
+    display_photo: p._photo,
+    thumbnail_blob: p._thumb,
+    ...(iiifUrls[p.sourceIdx] ? { spread_source: iiifUrls[p.sourceIdx] } : {}), // lineage to the pre-split spread
     ocr: p.ocr ? {
       data: p.ocr,
       model: ocrModel,

--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -498,11 +498,16 @@ if (GUTTER_ONLY) {
   }
   // imgFrac < 0.25 → text spread book → split it.
 
-  console.log('\n--- Step 3: Gutter detection — pixel + Gemini cross-check (no OCR) ---');
+  console.log('\n--- Step 3: Gutter detection — pixel/page (free), Gemini on a sample (no OCR) ---');
   ({ detectGutterPixel } = await import('./lib/gutter-detect.mjs'));
   let geminiReady = false;
   const stats = { portrait: 0, agree: 0, pixelOnly: 0, geminiOnly: 0, disagree: 0, centerUncertain: 0, keptWholeUncertain: 0 };
   const AGREE_TOL = 80; // 0-1000 → 8% of width
+  // The binding is stable book-wide, so Gemini (the paid call) only needs to run
+  // on a small SAMPLE to validate/establish the book gutter. Pixel runs on every
+  // page (free); non-sample pages where pixel is unsure snap to the book median.
+  const GEM_SAMPLE = Math.min(8, iiifUrls.length);
+  const gemSampleIdx = new Set(Array.from({ length: GEM_SAMPLE }, (_, k) => Math.floor(((k + 1) / (GEM_SAMPLE + 1)) * iiifUrls.length)));
 
   for (let i = 0; i < iiifUrls.length; i += CONCURRENCY) {
     const batch = iiifUrls.slice(i, i + CONCURRENCY);
@@ -523,12 +528,15 @@ if (GUTTER_ONLY) {
           return;
         }
 
-        // Pixel (free) + Gemini (preview, good prompt) in parallel-ish.
+        // Pixel every page (free). Gemini only on the sample (validates the
+        // book gutter + cross-checks pixel; the binding is stable book-wide).
         const pix = await detectGutterPixel(buf);
         const pixPos = (pix.confidence === 'high' && pix.column != null) ? Math.round((pix.column / meta.width) * 1000) : null;
-        if (!geminiReady) { await initGeminiGutter(); geminiReady = true; }
         let gemPos = null;
-        try { const g = await runGutterDetect(buf); if (typeof g === 'number') gemPos = g; } catch { /* gemini optional */ }
+        if (gemSampleIdx.has(idx)) {
+          if (!geminiReady) { await initGeminiGutter(); geminiReady = true; }
+          try { const g = await runGutterDetect(buf); if (typeof g === 'number') gemPos = g; } catch { /* gemini optional */ }
+        }
 
         if (pixPos != null && gemPos != null) {
           if (Math.abs(pixPos - gemPos) <= AGREE_TOL) {

--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -413,7 +413,7 @@ console.log('\n--- Step 2: Load existing page OCR ---');
 const allExistingPages = await db.collection('pages')
   .find({ book_id: book.id, page_number: { $gte: 0 }, page_type: { $ne: 'archived-spread' } }) // live pages only — skip spreads archived by a prior run (idempotency)
   .sort({ page_number: 1 })
-  .project({ id: 1, page_number: 1, photo: 1, 'ocr.data': 1, 'ocr.prompt_version': 1, 'ocr.model': 1 })
+  .project({ id: 1, page_number: 1, photo: 1, page_type: 1, 'ocr.data': 1, 'ocr.prompt_version': 1, 'ocr.model': 1 })
   .toArray();
 
 // Only use the first N pages matching the source image count (the original spreads).
@@ -443,6 +443,61 @@ if (GUTTER_ONLY) {
   // Book-level park: too many uncertain pages, OR confident gutter positions
   // SCATTERED across pages (a real binding is stable book-wide; scatter ⇒ not a
   // spread book — map atlas / plate album — must not be cut).
+  // ── Step 2.5: OCR-based content classification (FREE — uses existing OCR) ──
+  // These books were already OCR'd, so each page carries a <page-type>. A
+  // single map/plate book has page_type 'map'/'illustration' on most pages and
+  // almost no body text; a real text spread is page_type 'text' with thousands
+  // of chars. That separates the two cases pixels/Gemini can't (an atlas of
+  // single wide maps vs two text pages) — for free, no model call. Only 6 of
+  // the 331 #2454 books are plate books, and this finds them precisely.
+  const IMG_PAGE_TYPES = new Set(['map', 'illustration', 'diagram', 'frontispiece', 'plate']);
+  let imgPages = 0, contentPages = 0;
+  for (const pg of existingPages) {
+    if (pg.page_type === 'blank') continue;
+    const body = (pg.ocr?.data || '').replace(/<[^>]+>/g, '').trim().length;
+    const isImg = IMG_PAGE_TYPES.has(pg.page_type) || (/<image-desc>/i.test(pg.ocr?.data || '') && body < 400);
+    if (isImg) imgPages++; else contentPages++;
+  }
+  const imgFrac = (imgPages + contentPages) ? imgPages / (imgPages + contentPages) : 0;
+  console.log(`  Content class (from existing OCR): ${imgPages} image-pages / ${contentPages} text-pages → imgFrac ${imgFrac.toFixed(2)}`);
+
+  if (imgFrac >= 0.6) {
+    // Plate/map book — these are single wide images, not two-page text spreads.
+    // Splitting would bisect maps; they display best as full spreads. Stop
+    // trying to split: clear needs_splitting, leave pages intact.
+    console.log(`  PLATE/MAP BOOK (imgFrac ${imgFrac.toFixed(2)} ≥ 0.6) — not a text spread book; clearing needs_splitting, keeping pages whole.`);
+    if (!DRY_RUN) {
+      await db.collection('books').updateOne({ id: book.id }, {
+        $set: {
+          needs_splitting: false,
+          split_completed: true,
+          split_note: `OCR page_type: ${imgPages}/${imgPages + contentPages} image pages — plate/map book, kept whole (#2454)`,
+          'pipeline_auto.status': 'complete',
+          'pipeline_auto.last_updated': new Date(),
+        },
+      });
+    }
+    await client.close();
+    process.exit(0);
+  }
+  if (imgFrac >= 0.25) {
+    // Mixed (text + a meaningful share of plates) — too risky to auto-split.
+    console.log(`  MIXED BOOK (imgFrac ${imgFrac.toFixed(2)}) — text + plates; parking for review rather than auto-splitting.`);
+    if (!DRY_RUN) {
+      await db.collection('books').updateOne({ id: book.id }, {
+        $set: {
+          'pipeline_auto.status': 'needs_attention',
+          'pipeline_auto.error': `Mixed text/plate book (imgFrac ${imgFrac.toFixed(2)}) — manual split review (#2454)`,
+          'pipeline_auto.split_review_needed': true,
+          'pipeline_auto.last_updated': new Date(),
+        },
+      });
+    }
+    await client.close();
+    process.exit(0);
+  }
+  // imgFrac < 0.25 → text spread book → split it.
+
   console.log('\n--- Step 3: Gutter detection — pixel + Gemini cross-check (no OCR) ---');
   ({ detectGutterPixel } = await import('./lib/gutter-detect.mjs'));
   let geminiReady = false;
@@ -490,11 +545,10 @@ if (GUTTER_ONLY) {
         } else if (pixPos != null) {
           page._gutter = pixPos; page._splitMethod = `pixel:${pix.reason}`; page._confidentPos = pixPos; stats.pixelOnly++;
         } else if (gemPos != null) {
-          // Gemini found a gutter but PIXEL abstained — weak. A single map/plate
-          // triggers exactly this (no real binding for pixel to find). Do NOT
-          // count it as a confirmed spread position; it only splits if the book
-          // is independently confirmed a spread (then it snaps to the median).
-          page._gutter = gemPos; page._splitMethod = 'gemini-only(unconfirmed)'; stats.geminiOnly++;
+          // Text book (maps already filtered out in Step 2.5), so a Gemini-only
+          // position is a real spread that pixel found hard (e.g. faint gutter).
+          // Trust it as a confident position.
+          page._gutter = gemPos; page._splitMethod = 'gemini'; page._confidentPos = gemPos; stats.geminiOnly++;
         } else if (ar >= 1.3) {
           page._gutter = 500; page._splitMethod = 'center-uncertain'; page._uncertain = true; stats.centerUncertain++;
         } else {
@@ -522,11 +576,9 @@ if (GUTTER_ONLY) {
     ? [...sorted.map(p => Math.abs(p - median))].sort((a, b) => a - b)[Math.floor(sorted.length / 2)]
     : 0;
   const landscapeCount = existingPages.filter(p => !p._error && p._gutter !== 'single' || p._uncertain).length;
-  // Confirmed = pixel found a real gutter (alone or agreeing with Gemini). A
-  // book is a spread book only if pixel confirms a gutter on a good fraction of
-  // its landscape pages — single-map/plate books (pixel abstains, only Gemini
-  // guesses) fall below this and park.
-  const enoughSignal = confidentPositions.length >= Math.max(2, Math.ceil(landscapeCount * 0.4));
+  // Maps are already filtered out (Step 2.5), so any confident gutter — pixel OR
+  // Gemini — counts. Need at least a couple to anchor the book median.
+  const enoughSignal = confidentPositions.length >= Math.max(2, Math.ceil(landscapeCount * 0.25));
   const SCATTER_MAD = 60; // 0-1000 → 6% — robust scatter measure (MAD, not stdev: one outlier won't trip it)
   const scattered = confidentPositions.length >= 3 && mad > SCATTER_MAD;
   console.log(`  Methods: agree ${stats.agree}, pixel-only ${stats.pixelOnly}, gemini-only ${stats.geminiOnly}, disagree ${stats.disagree}, portrait ${stats.portrait}, center-unc ${stats.centerUncertain}, kept-whole-unc ${stats.keptWholeUncertain}`);
@@ -535,9 +587,9 @@ if (GUTTER_ONLY) {
   // Park only when there's no trustworthy consensus: too few confident pages, or
   // genuinely scattered positions (maps/plates, not a spread book).
   const parkReason = !enoughSignal
-    ? `only ${confidentPositions.length}/${landscapeCount} pages gave a confident gutter — too little signal to trust a book consensus`
+    ? `only ${confidentPositions.length}/${landscapeCount} landscape pages gave a confident gutter — too little signal`
     : scattered
-      ? `gutter positions scattered (MAD ${mad}/1000 > ${SCATTER_MAD}) — likely not a spread book (maps/plates)`
+      ? `gutter positions scattered (MAD ${mad}/1000 > ${SCATTER_MAD}) — inconsistent binding, needs review`
       : null;
 
   // Resolve every landscape page against the consensus: outliers and uncertain

--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -206,16 +206,21 @@ async function runSpreadOCR(imageBuf) {
 // One cheap vision call per page: where is the gutter? No transcription, so
 // output is ~10 tokens instead of ~2K. The split pages then flow through the
 // normal single-page OCR pipeline (batch, 50% off) instead of realtime.
-const GUTTER_PROMPT = `This image is a scan from a book. Decide whether it shows a TWO-PAGE SPREAD (an open book with a left and a right page) or a SINGLE page.
+// NO center hint: measured that "usually 400-600" anchors the model to ~500 and
+// it ignores the real (often offset) gutter. Without the hint, gemini-3-flash-preview
+// localizes the gutter to within ~3/1000 of the pixel detector even on strongly
+// offset RTL manuscripts. flash-lite stays center-biased — must use preview.
+const GUTTER_MODEL = 'gemini-3-flash-preview';
+const GUTTER_PROMPT = `This is a photo of an open book showing a left page and a right page. Find the GUTTER — the vertical line where the two pages meet at the binding (often a shadow, or the innermost margins of the two pages). It may NOT be at the center; look carefully.
 
 Respond with EXACTLY one tag and nothing else:
-- Two-page spread: <split-position>N</split-position> where N (0-1000) is the horizontal position of the gutter (the fold between the pages). The gutter is usually near the center (400-600).
-- Single page: <split-position>null</split-position>`;
+- Two-page spread: <split-position>N</split-position> where N (0-1000) is the gutter's horizontal position. 0 = far left edge, 1000 = far right edge.
+- Single page (not a spread): <split-position>null</split-position>`;
 
 async function initGeminiGutter() {
   const { GoogleGenerativeAI } = await import('@google/generative-ai');
   const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-  geminiModel = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
+  geminiModel = genAI.getGenerativeModel({ model: GUTTER_MODEL });
 }
 
 async function runGutterDetect(imageBuf) {
@@ -426,18 +431,23 @@ console.log(`  ${withPageBreak.length} have <page-break/>, ${withSplitPos.length
 let ocrVersion = 'existing';
 if (GUTTER_ONLY) {
   // #2454 decision tree: split images BEFORE any OCR.
-  //   portrait (AR < 1.1)        → keep whole, no detection
-  //   pixel detector confident   → cut there (FREE — no model call)
-  //   pixel low-confidence        → Gemini gutter call (the manuscript/tight tail)
-  //   both unsure + wide (≥1.3)   → center cut, marked uncertain
-  //   both unsure + tight (<1.3)  → KEEP WHOLE, marked uncertain (never blind
-  //                                 center-cut a tight page — that clips text)
-  // If too many pages end up uncertain, the book is parked for review rather
-  // than partially clipped (book-level guard after the loop).
-  console.log('\n--- Step 3: Gutter detection — pixel-primary, Gemini fallback (no OCR) ---');
+  //   portrait (AR < 1.1)               → keep whole
+  //   pixel valley + Gemini AGREE (≤8%) → cut (two independent methods concur — strongest)
+  //   only one of pixel/Gemini confident → cut on it
+  //   both confident but DISAGREE (>8%) → uncertain (don't trust either blindly)
+  //   neither confident + wide          → center, uncertain
+  //   neither confident + tight         → keep whole, uncertain
+  // Gemini = gemini-3-flash-preview with a no-center-hint prompt (it tracks
+  // offset gutters to ~3/1000; flash-lite + the old hint just guessed center).
+  // Pixel is free and runs first; Gemini cross-checks / rescues the tail.
+  // Book-level park: too many uncertain pages, OR confident gutter positions
+  // SCATTERED across pages (a real binding is stable book-wide; scatter ⇒ not a
+  // spread book — map atlas / plate album — must not be cut).
+  console.log('\n--- Step 3: Gutter detection — pixel + Gemini cross-check (no OCR) ---');
   ({ detectGutterPixel } = await import('./lib/gutter-detect.mjs'));
   let geminiReady = false;
-  const stats = { portrait: 0, pixel: 0, gemini: 0, centerUncertain: 0, keptWholeUncertain: 0 };
+  const stats = { portrait: 0, agree: 0, pixelOnly: 0, geminiOnly: 0, disagree: 0, centerUncertain: 0, keptWholeUncertain: 0 };
+  const AGREE_TOL = 80; // 0-1000 → 8% of width
 
   for (let i = 0; i < iiifUrls.length; i += CONCURRENCY) {
     const batch = iiifUrls.slice(i, i + CONCURRENCY);
@@ -454,43 +464,41 @@ if (GUTTER_ONLY) {
         const ar = meta.width / meta.height;
 
         if (ar < MIN_SPREAD_AR) {
-          page._gutter = 'single';        // portrait — keep whole
-          page._splitMethod = 'portrait';
-          stats.portrait++;
+          page._gutter = 'single'; page._splitMethod = 'portrait'; stats.portrait++;
           return;
         }
 
-        // 1. Pixel detector (free)
+        // Pixel (free) + Gemini (preview, good prompt) in parallel-ish.
         const pix = await detectGutterPixel(buf);
-        if (pix.confidence === 'high' && pix.column != null) {
-          page._gutter = Math.round((pix.column / meta.width) * 1000); // 0-1000 scale
-          page._splitMethod = `pixel:${pix.reason}`;
-          stats.pixel++;
-          return;
-        }
-
-        // 2. Gemini fallback (only fires on pixel low-confidence)
+        const pixPos = (pix.confidence === 'high' && pix.column != null) ? Math.round((pix.column / meta.width) * 1000) : null;
         if (!geminiReady) { await initGeminiGutter(); geminiReady = true; }
-        let gem = null;
-        try { gem = await runGutterDetect(buf); } catch { gem = null; }
-        if (typeof gem === 'number') {
-          page._gutter = gem;
-          page._splitMethod = 'gemini';
-          stats.gemini++;
-          return;
-        }
+        let gemPos = null;
+        try { const g = await runGutterDetect(buf); if (typeof g === 'number') gemPos = g; } catch { /* gemini optional */ }
 
-        // 3. Neither detector confident
-        if (ar >= 1.3) {
-          page._gutter = 500;             // clearly wide → almost certainly a spread; center is best guess
-          page._splitMethod = 'center-uncertain';
-          page._uncertain = true;
-          stats.centerUncertain++;
+        if (pixPos != null && gemPos != null) {
+          if (Math.abs(pixPos - gemPos) <= AGREE_TOL) {
+            page._gutter = Math.round((pixPos + gemPos) / 2); // concur → average
+            page._splitMethod = `agree(px${pixPos}/gem${gemPos})`;
+            page._confidentPos = page._gutter; stats.agree++;
+          } else {
+            // Two methods disagree — genuinely ambiguous, don't guess.
+            page._splitMethod = `disagree(px${pixPos}/gem${gemPos})`;
+            page._uncertain = true;
+            if (ar >= 1.3) { page._gutter = pixPos; stats.disagree++; } // wide: trust pixel (measures the image), flag for review
+            else { page._gutter = 'single'; stats.disagree++; }
+          }
+        } else if (pixPos != null) {
+          page._gutter = pixPos; page._splitMethod = `pixel:${pix.reason}`; page._confidentPos = pixPos; stats.pixelOnly++;
+        } else if (gemPos != null) {
+          // Gemini found a gutter but PIXEL abstained — weak. A single map/plate
+          // triggers exactly this (no real binding for pixel to find). Do NOT
+          // count it as a confirmed spread position; it only splits if the book
+          // is independently confirmed a spread (then it snaps to the median).
+          page._gutter = gemPos; page._splitMethod = 'gemini-only(unconfirmed)'; stats.geminiOnly++;
+        } else if (ar >= 1.3) {
+          page._gutter = 500; page._splitMethod = 'center-uncertain'; page._uncertain = true; stats.centerUncertain++;
         } else {
-          page._gutter = 'single';        // tight/borderline → keep whole, do NOT clip
-          page._splitMethod = 'kept-whole-uncertain';
-          page._uncertain = true;
-          stats.keptWholeUncertain++;
+          page._gutter = 'single'; page._splitMethod = 'kept-whole-uncertain'; page._uncertain = true; stats.keptWholeUncertain++;
         }
       } catch (e) {
         console.log(`  FAIL p.${page.page_number}: ${e.message?.slice(0, 50)}`);
@@ -499,24 +507,70 @@ if (GUTTER_ONLY) {
     }));
     process.stderr.write(`  Gutter: ${Math.min(i + CONCURRENCY, iiifUrls.length)}/${iiifUrls.length}\r`);
   }
+  const confidentPositions = [];
+  for (const p of existingPages) if (typeof p._confidentPos === 'number') confidentPositions.push(p._confidentPos);
   console.log();
-  console.log(`  Methods: pixel ${stats.pixel}, gemini ${stats.gemini}, portrait ${stats.portrait}, center-uncertain ${stats.centerUncertain}, kept-whole-uncertain ${stats.keptWholeUncertain}`);
 
-  // Book-level guard: if too much of the book is uncertain, don't split it at
-  // all — park for review. A few uncertain pages in a long book are fine; a
-  // book that's mostly uncertain is a detector mismatch (curved binding,
-  // unusual layout) that needs eyes, not a silent half-clipped result.
-  const uncertainCount = stats.centerUncertain + stats.keptWholeUncertain;
-  const uncertainFrac = uncertainCount / Math.max(1, existingPages.filter(p => !p._error).length);
-  if (uncertainFrac > 0.15 && DRY_RUN) {
-    console.log(`\n  WOULD PARK: ${uncertainCount}/${existingPages.length} pages uncertain (${(uncertainFrac * 100).toFixed(0)}% > 15%) — real run flags needs_attention instead of splitting.`);
+  // ── Book-level consensus (approach A) ──────────────────────────────────────
+  // The binding sits at a STABLE position book-wide, so a single page's bad
+  // detection should be overruled by the book median — not park the whole book
+  // (a 10-page book parked over one diagram page is the failure this fixes).
+  // Robust median + MAD over confident positions; scatter = no stable binding.
+  const sorted = [...confidentPositions].sort((a, b) => a - b);
+  const median = sorted.length ? sorted[Math.floor(sorted.length / 2)] : 500;
+  const mad = sorted.length
+    ? [...sorted.map(p => Math.abs(p - median))].sort((a, b) => a - b)[Math.floor(sorted.length / 2)]
+    : 0;
+  const landscapeCount = existingPages.filter(p => !p._error && p._gutter !== 'single' || p._uncertain).length;
+  // Confirmed = pixel found a real gutter (alone or agreeing with Gemini). A
+  // book is a spread book only if pixel confirms a gutter on a good fraction of
+  // its landscape pages — single-map/plate books (pixel abstains, only Gemini
+  // guesses) fall below this and park.
+  const enoughSignal = confidentPositions.length >= Math.max(2, Math.ceil(landscapeCount * 0.4));
+  const SCATTER_MAD = 60; // 0-1000 → 6% — robust scatter measure (MAD, not stdev: one outlier won't trip it)
+  const scattered = confidentPositions.length >= 3 && mad > SCATTER_MAD;
+  console.log(`  Methods: agree ${stats.agree}, pixel-only ${stats.pixelOnly}, gemini-only ${stats.geminiOnly}, disagree ${stats.disagree}, portrait ${stats.portrait}, center-unc ${stats.centerUncertain}, kept-whole-unc ${stats.keptWholeUncertain}`);
+  console.log(`  Book consensus: median ${median}/1000, MAD ${mad}/1000, ${confidentPositions.length} confident/${landscapeCount} landscape${scattered ? ' — SCATTERED' : ''}`);
+
+  // Park only when there's no trustworthy consensus: too few confident pages, or
+  // genuinely scattered positions (maps/plates, not a spread book).
+  const parkReason = !enoughSignal
+    ? `only ${confidentPositions.length}/${landscapeCount} pages gave a confident gutter — too little signal to trust a book consensus`
+    : scattered
+      ? `gutter positions scattered (MAD ${mad}/1000 > ${SCATTER_MAD}) — likely not a spread book (maps/plates)`
+      : null;
+
+  // Resolve every landscape page against the consensus: outliers and uncertain
+  // pages snap to the book median; pages near the median keep their own (more
+  // accurate per-page) cut. Only runs when we're going to split (not parking).
+  if (!parkReason) {
+    const OUTLIER_TOL = 80; // 0-1000 → 8% from median = outlier, use median instead
+    let snapped = 0;
+    for (const p of existingPages) {
+      if (p._error || p._gutter === 'single' && !p._uncertain && p._splitMethod === 'portrait') continue;
+      if (typeof p._gutter === 'number' && typeof p._confidentPos === 'number' && Math.abs(p._confidentPos - median) <= OUTLIER_TOL) {
+        continue; // confident & consistent → keep its own cut
+      }
+      // outlier, uncertain, or kept-whole landscape page → apply book median
+      if (p._gutter !== 'single' || p._uncertain) {
+        if (p._splitMethod === 'portrait') continue;
+        p._gutter = median;
+        p._splitMethod = `book-median(${median})`;
+        p._uncertain = false;
+        snapped++;
+      }
+    }
+    if (snapped) console.log(`  Snapped ${snapped} outlier/uncertain pages to book median ${median}`);
   }
-  if (uncertainFrac > 0.15 && !DRY_RUN) {
-    console.error(`\n  PARK: ${uncertainCount}/${existingPages.length} pages uncertain (${(uncertainFrac * 100).toFixed(0)}% > 15%). Not splitting — flagging needs_attention for review.`);
+  if (parkReason && DRY_RUN) {
+    console.log(`\n  WOULD PARK: ${parkReason} — real run flags needs_attention instead of splitting.`);
+  }
+  if (parkReason && !DRY_RUN) {
+    console.error(`\n  PARK: ${parkReason}. Not splitting — flagging needs_attention for review.`);
     await db.collection('books').updateOne({ id: book.id }, {
       $set: {
         'pipeline_auto.status': 'needs_attention',
-        'pipeline_auto.error': `Gutter detection uncertain on ${uncertainCount}/${existingPages.length} pages — manual split review needed (#2454)`,
+        'pipeline_auto.error': `Split review needed (#2454): ${parkReason}`,
         'pipeline_auto.split_review_needed': true,
         'pipeline_auto.last_updated': new Date(),
       },

--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -32,7 +32,8 @@ const MIN_SPREAD_AR = 1.1;   // Aspect ratio gate: below this is portrait (singl
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const WITH_OCR = args.includes('--with-ocr');
-const GUTTER_ONLY = args.includes('--gutter-only'); // #2454: split images BEFORE OCR — cheap gutter detection, pages created without OCR
+const GUTTER_ONLY = args.includes('--gutter-only');
+let detectGutterPixel; // lazy-loaded in gutter-only mode (avoids sharp import cost on OCR runs) // #2454: split images BEFORE OCR — cheap gutter detection, pages created without OCR
 const targetSlug = args.find(a => !a.startsWith('--'));
 
 if (!targetSlug) {
@@ -331,8 +332,27 @@ if (!iiifUrls && manifestUrl) {
   iiifUrls = await getOriginalImageUrls(book.id, manifestUrl, existingPageCount);
 }
 
+// Page-record fallback: providers that don't use the /archived/{id}/{n}.jpg
+// convention (e.g. cmc_kloss PDF extracts at /books/{id}/pages/NNNN.jpg, the
+// largest cohort) still carry the correct R2 URL on the page document itself.
+// Only safe for never-split books — on an already-split book `photo` is a
+// cropped half, not the spread. All #2454 first-time splits qualify.
+if (!iiifUrls && book.split_completed !== true) {
+  const srcPages = await db.collection('pages')
+    .find({ book_id: book.id }, { projection: { page_number: 1, archived_photo: 1, photo: 1 } })
+    .sort({ page_number: 1 })
+    .toArray();
+  const urls = srcPages
+    .map(p => p.archived_photo || p.photo)
+    .filter(u => typeof u === 'string' && /^https?:\/\//.test(u));
+  if (urls.length > 0 && urls.length >= srcPages.length * 0.9) {
+    iiifUrls = urls;
+    console.log(`  Using ${iiifUrls.length} page-record image URLs (provider: ${book.image_source?.provider || 'unknown'})`);
+  }
+}
+
 if (!iiifUrls || iiifUrls.length === 0) {
-  console.log('ERROR: No original images available (no archived copies, no IIIF manifest).');
+  console.log('ERROR: No original images available (no archived copies, no IIIF manifest, no usable page-record URLs).');
   process.exit(1);
 }
 
@@ -403,10 +423,20 @@ console.log(`  ${withPageBreak.length} have <page-break/>, ${withSplitPos.length
 // --- Step 3: Run OCR if needed ---
 let ocrVersion = 'existing';
 if (GUTTER_ONLY) {
-  // #2454: no transcription — one cheap gutter call per landscape page.
-  // Portrait pages (AR < MIN_SPREAD_AR) skip the call entirely.
-  console.log('\n--- Step 3: Gutter-only detection (no OCR) ---');
-  await initGeminiGutter();
+  // #2454 decision tree: split images BEFORE any OCR.
+  //   portrait (AR < 1.1)        → keep whole, no detection
+  //   pixel detector confident   → cut there (FREE — no model call)
+  //   pixel low-confidence        → Gemini gutter call (the manuscript/tight tail)
+  //   both unsure + wide (≥1.3)   → center cut, marked uncertain
+  //   both unsure + tight (<1.3)  → KEEP WHOLE, marked uncertain (never blind
+  //                                 center-cut a tight page — that clips text)
+  // If too many pages end up uncertain, the book is parked for review rather
+  // than partially clipped (book-level guard after the loop).
+  console.log('\n--- Step 3: Gutter detection — pixel-primary, Gemini fallback (no OCR) ---');
+  ({ detectGutterPixel } = await import('./lib/gutter-detect.mjs'));
+  let geminiReady = false;
+  const stats = { portrait: 0, pixel: 0, gemini: 0, centerUncertain: 0, keptWholeUncertain: 0 };
+
   for (let i = 0; i < iiifUrls.length; i += CONCURRENCY) {
     const batch = iiifUrls.slice(i, i + CONCURRENCY);
     await Promise.all(batch.map(async (url, j) => {
@@ -420,14 +450,46 @@ if (GUTTER_ONLY) {
         page._w = meta.width;
         page._h = meta.height;
         const ar = meta.width / meta.height;
+
         if (ar < MIN_SPREAD_AR) {
-          page._gutter = 'single'; // portrait — no Gemini call needed
+          page._gutter = 'single';        // portrait — keep whole
+          page._splitMethod = 'portrait';
+          stats.portrait++;
           return;
         }
-        const pos = await runGutterDetect(buf);
-        // Wide page where detection failed or said single: a landscape page in a
-        // flagged spread book is overwhelmingly a spread — default to center.
-        page._gutter = pos === 'single' && ar < 1.3 ? 'single' : (typeof pos === 'number' ? pos : 500);
+
+        // 1. Pixel detector (free)
+        const pix = await detectGutterPixel(buf);
+        if (pix.confidence === 'high' && pix.column != null) {
+          page._gutter = Math.round((pix.column / meta.width) * 1000); // 0-1000 scale
+          page._splitMethod = `pixel:${pix.reason}`;
+          stats.pixel++;
+          return;
+        }
+
+        // 2. Gemini fallback (only fires on pixel low-confidence)
+        if (!geminiReady) { await initGeminiGutter(); geminiReady = true; }
+        let gem = null;
+        try { gem = await runGutterDetect(buf); } catch { gem = null; }
+        if (typeof gem === 'number') {
+          page._gutter = gem;
+          page._splitMethod = 'gemini';
+          stats.gemini++;
+          return;
+        }
+
+        // 3. Neither detector confident
+        if (ar >= 1.3) {
+          page._gutter = 500;             // clearly wide → almost certainly a spread; center is best guess
+          page._splitMethod = 'center-uncertain';
+          page._uncertain = true;
+          stats.centerUncertain++;
+        } else {
+          page._gutter = 'single';        // tight/borderline → keep whole, do NOT clip
+          page._splitMethod = 'kept-whole-uncertain';
+          page._uncertain = true;
+          stats.keptWholeUncertain++;
+        }
       } catch (e) {
         console.log(`  FAIL p.${page.page_number}: ${e.message?.slice(0, 50)}`);
         page._error = true;
@@ -436,6 +498,30 @@ if (GUTTER_ONLY) {
     process.stderr.write(`  Gutter: ${Math.min(i + CONCURRENCY, iiifUrls.length)}/${iiifUrls.length}\r`);
   }
   console.log();
+  console.log(`  Methods: pixel ${stats.pixel}, gemini ${stats.gemini}, portrait ${stats.portrait}, center-uncertain ${stats.centerUncertain}, kept-whole-uncertain ${stats.keptWholeUncertain}`);
+
+  // Book-level guard: if too much of the book is uncertain, don't split it at
+  // all — park for review. A few uncertain pages in a long book are fine; a
+  // book that's mostly uncertain is a detector mismatch (curved binding,
+  // unusual layout) that needs eyes, not a silent half-clipped result.
+  const uncertainCount = stats.centerUncertain + stats.keptWholeUncertain;
+  const uncertainFrac = uncertainCount / Math.max(1, existingPages.filter(p => !p._error).length);
+  if (uncertainFrac > 0.15 && DRY_RUN) {
+    console.log(`\n  WOULD PARK: ${uncertainCount}/${existingPages.length} pages uncertain (${(uncertainFrac * 100).toFixed(0)}% > 15%) — real run flags needs_attention instead of splitting.`);
+  }
+  if (uncertainFrac > 0.15 && !DRY_RUN) {
+    console.error(`\n  PARK: ${uncertainCount}/${existingPages.length} pages uncertain (${(uncertainFrac * 100).toFixed(0)}% > 15%). Not splitting — flagging needs_attention for review.`);
+    await db.collection('books').updateOne({ id: book.id }, {
+      $set: {
+        'pipeline_auto.status': 'needs_attention',
+        'pipeline_auto.error': `Gutter detection uncertain on ${uncertainCount}/${existingPages.length} pages — manual split review needed (#2454)`,
+        'pipeline_auto.split_review_needed': true,
+        'pipeline_auto.last_updated': new Date(),
+      },
+    });
+    await client.close();
+    process.exit(0);
+  }
 } else if (WITH_OCR || withPageBreak.length === 0) {
   if (!WITH_OCR && withPageBreak.length === 0) {
     console.log('\n  No spread OCR found. Running Gemini OCR (use --with-ocr to force)...');
@@ -483,14 +569,15 @@ for (let idx = 0; idx < existingPages.length; idx++) {
   }
 
   if (GUTTER_ONLY) {
+    const method = page._splitMethod || 'unknown';
     if (page._gutter === 'single') {
       // Singles keep any existing OCR — it was made from this exact image.
-      newPages.push({ side: 'single', ocr: page.ocr?.data || null, sourceIdx: idx, splitPosition: null });
+      newPages.push({ side: 'single', ocr: page.ocr?.data || null, sourceIdx: idx, splitPosition: null, splitMethod: method, uncertain: !!page._uncertain });
     } else {
       // Spread: two OCR-less pages; the normal pipeline OCRs them as singles.
       const pos = typeof page._gutter === 'number' ? page._gutter : 500;
-      newPages.push({ side: 'left', ocr: null, sourceIdx: idx, splitPosition: pos });
-      newPages.push({ side: 'right', ocr: null, sourceIdx: idx, splitPosition: pos });
+      newPages.push({ side: 'left', ocr: null, sourceIdx: idx, splitPosition: pos, splitMethod: method, uncertain: !!page._uncertain });
+      newPages.push({ side: 'right', ocr: null, sourceIdx: idx, splitPosition: pos, splitMethod: method, uncertain: !!page._uncertain });
     }
     continue;
   }
@@ -522,7 +609,7 @@ if (DRY_RUN) {
   console.log('\n--- DRY RUN — would create: ---');
   for (let i = 0; i < newPages.length; i++) {
     const p = newPages[i];
-    console.log(`  p.${i + 1} ${p.side.padEnd(7)} source:${p.sourceIdx + 1} split:${p.splitPosition || '-'} type:${p.pageType || '-'} ocr:${p.ocr?.length || 0}ch`);
+    console.log(`  p.${i + 1} ${p.side.padEnd(7)} source:${p.sourceIdx + 1} split:${p.splitPosition || '-'} ${p.splitMethod ? `[${p.splitMethod}${p.uncertain ? ' UNCERTAIN' : ''}]` : ''} type:${p.pageType || '-'} ocr:${p.ocr?.length || 0}ch`);
   }
   await client.close();
   process.exit(0);
@@ -630,6 +717,8 @@ for (let i = 0; i < newPages.length; i++) {
     split_from_spread: true,
     split_side: p.side === 'error' ? 'single' : p.side,
     split_position: p.splitPosition,
+    ...(p.splitMethod ? { split_method: p.splitMethod } : {}),
+    ...(p.uncertain ? { split_uncertain: true } : {}),
     field_provenance: {
       ...(p.ocr ? { ocr: { source: 'gemini', method: 'spread-split-ocr', confidence: 1.0, date: new Date() } } : {}),
       photo: { source: 'r2', method: 'spread-split-crop', confidence: 1.0, date: new Date() },

--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -406,7 +406,7 @@ try {
 // --- Step 2: Load existing pages (for their OCR) ---
 console.log('\n--- Step 2: Load existing page OCR ---');
 const allExistingPages = await db.collection('pages')
-  .find({ book_id: book.id })
+  .find({ book_id: book.id, page_number: { $gte: 0 }, page_type: { $ne: 'archived-spread' } }) // live pages only — skip spreads archived by a prior run (idempotency)
   .sort({ page_number: 1 })
   .project({ id: 1, page_number: 1, photo: 1, 'ocr.data': 1, 'ocr.prompt_version': 1, 'ocr.model': 1 })
   .toArray();
@@ -694,8 +694,8 @@ for (let batch = 0; batch < sourceIndices.length; batch += CONCURRENCY) {
 }
 console.log();
 
-// --- Step 6: Delete old pages, insert new ones ---
-console.log('\n--- Step 6: Delete old pages, insert new ones ---');
+// --- Step 6: Archive old spreads, insert new pages ---
+console.log('\n--- Step 6: Archive old spreads, insert new pages ---');
 
 const ocrModel = WITH_OCR ? 'gemini-3.1-flash-lite' : (existingPages[0]?.ocr?.model || 'gemini-3.1-flash-lite');
 const promptVersion = WITH_OCR ? `spread-v2+ocr-v${ocrVersion}` : (existingPages[0]?.ocr?.prompt_version || 'spread-v2+ocr-v10');
@@ -757,20 +757,20 @@ if (!coverPage && newDocs.length > 0) {
   coverPage = { num: first.page_number, url: first.photo, type: first.page_type };
 }
 
-// Safety check: don't delete pages if too many failed (>20% loss = abort)
+// Safety check: don't touch old pages if too many failed (>20% loss = abort)
 const failedCount = newPages.length - newDocs.length;
 if (failedCount > 0 && failedCount / newPages.length > 0.2) {
-  console.error(`\nABORT: ${failedCount}/${newPages.length} pages failed (>${Math.round(0.2 * 100)}% threshold). Not deleting old pages.`);
+  console.error(`\nABORT: ${failedCount}/${newPages.length} pages failed (>${Math.round(0.2 * 100)}% threshold). Not archiving old pages.`);
   await client.close();
   process.exit(1);
 }
 if (newDocs.length === 0) {
-  console.error('\nABORT: Zero pages would be created. Not deleting old pages.');
+  console.error('\nABORT: Zero pages would be created. Not archiving old pages.');
   await client.close();
   process.exit(1);
 }
 
-// Save pre-split revision (lightweight snapshot before destructive delete)
+// Save pre-split revision snapshot.
 const pagesWithOcrData = allExistingPages.filter(p => p.ocr?.data);
 if (pagesWithOcrData.length > 0) {
   await db.collection('page_revisions').insertOne({
@@ -784,8 +784,22 @@ if (pagesWithOcrData.length > 0) {
   });
 }
 
-console.log(`  Deleting ${allExistingPages.length} old pages (${failedCount} failed, within threshold)...`);
-await db.collection('pages').deleteMany({ book_id: book.id });
+// Archive old spreads in place rather than delete (#1491): negate page_number
+// and tag page_type:'archived-spread' so the originals stay fully recoverable.
+// The read path filters page_number>=0 && page_type!='archived-spread' in the
+// Mongo query (PR #1441), so archived spreads never surface in the reader,
+// grids, galleries, or extraction. page_number = -(abs+1) avoids a 0 collision.
+console.log(`  Archiving ${allExistingPages.length} old spread pages (negative page_number)...`);
+await db.collection('pages').updateMany(
+  { book_id: book.id, page_number: { $gte: 0 }, page_type: { $ne: 'archived-spread' } },
+  [{ $set: {
+    page_number: { $subtract: [-1, { $abs: '$page_number' }] },
+    page_type: 'archived-spread',
+    archived_spread: true,
+    hidden: true,
+    updated_at: new Date(),
+  } }]
+);
 
 console.log(`  Inserting ${newDocs.length} new pages...`);
 if (newDocs.length > 0) {


### PR DESCRIPTION
## What

Replaces the all-Gemini, center-cut-on-failure logic in `split-book.mjs --gutter-only` (the #2464 Phase 1.3 path) with the decision tree the historical record endorses. Center-cutting is the documented way text gets clipped — BPH gutters are offset from center by up to 19% — and the pixel ink-density detector (which survived four false starts, see memory lesson-splitter-gutter-detection) is the proven primary.

### Decision tree (per page)

| Condition | Action | Cost |
|---|---|---|
| portrait (AR < 1.1) | keep whole | free |
| pixel detector confident | cut at pixel gutter | **free** |
| pixel low-confidence | Gemini gutter call | ~$0.001 |
| both unsure + wide (AR ≥ 1.3) | center cut, marked `uncertain` | — |
| both unsure + tight (AR < 1.3) | keep whole, marked `uncertain` (never blind-clip) | — |
| > 15% of book uncertain | **PARK to needs_attention**, don't split | — |

### Pieces

- **`scripts/lib/gutter-detect.mjs`** — pixel detector ported from the inline copy in `batch-split-bph.mjs`, but returns `{ column, confidence, reason }` instead of silently center-cutting. The `min(R,G,B) < 120` ink test is preserved so colored rubrication registers (grayscale missed vermillion titles historically). The proven BPH inline copy is left untouched.
- **Page-record image-URL fallback** — `cmc_kloss` (178 books, the largest cohort) stores PDF extracts at `/books/{id}/pages/NNNN.jpg`, which the `/archived/{id}/{n}.jpg` probe never finds. When patterns fail, resolve from the page doc's own `archived_photo` — guarded to never-split books only (on a split book `photo` is a cropped half).
- **Provenance** — `split_method` and `split_uncertain` stamped on each new page doc.

## Pilot (dry-run, one book per provider class)

| Provider | pixel | gemini | portrait | uncertain | verdict |
|---|---|---|---|---|---|
| Kloss | 7 | 0 | 1 | 0 | clean |
| BPH | 3 | 0 | 2 | 0 | clean |
| IA (Arabic ms) | 12 | 0 | 0 | 0 | clean |
| Tartu | 13 | 1 | 0 | 0 | clean |
| Morgan (ms) | 19 | 4 | 2 | 0 | Gemini rescued the tail |
| Gallica (Korean Atlas ms) | 0 | 1 | 6 | 10 | **WOULD PARK** (correct) |

Most pages split for free; Gemini only fires on the genuinely ambiguous tail; the one book neither detector can handle parks for review instead of getting clipped.

## Out of scope / next

- The actual 331-book remediation run (uses this path; awaiting go — pilot confirms the method)
- Phase 3.1 retirement (after legacy in-flight spreads drain)
- `batch-split-bph.mjs` is intentionally left on its own inline detector (zero risk to the proven BPH path); de-duping the two is a possible later cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)