### PR TITLE
feat(artwork): deep-zoom viewer on artwork hero, manifest-gated (#2411)

### DIFF
--- a/src/components/artwork/ArtworkHero.tsx
+++ b/src/components/artwork/ArtworkHero.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, lazy, Suspense } from 'react';
 import Link from 'next/link';
 import ImageWithMagnifier from '@/components/ui/ImageWithMagnifier';
-import { ZoomIn, Maximize, Minimize, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ZoomIn, Maximize, Minimize, ChevronLeft, ChevronRight, Search } from 'lucide-react';
+import type { DeepZoomManifest } from '@/lib/types/book';
+
+// Lazy so OpenSeadragon (and its bundle weight) only loads on user intent.
+const DeepZoomOverlay = lazy(() => import('./DeepZoomOverlay'));
 
 interface ArtworkNavItem {
   slug: string;
@@ -21,11 +25,13 @@ interface ArtworkHeroProps {
   prevWork?: ArtworkNavItem | null;
   nextWork?: ArtworkNavItem | null;
   institution?: string;
+  deepZoom?: DeepZoomManifest | null;
 }
 
-export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullResUrl, license, isLandscape, prevWork, nextWork, institution }: ArtworkHeroProps) {
+export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullResUrl, license, isLandscape, prevWork, nextWork, institution, deepZoom }: ArtworkHeroProps) {
   const [fitWidth, setFitWidth] = useState(false);
   const [showChrome, setShowChrome] = useState(true);
+  const [zoomOpen, setZoomOpen] = useState(false);
   const hasThumb = !!thumbUrl && thumbUrl !== imageUrl;
   const hasHiRes = !!hiResUrl && hiResUrl !== imageUrl;
   const [medReady, setMedReady] = useState(!hasThumb);
@@ -95,15 +101,39 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
           />
       </div>
 
-      {/* Fit toggle — appears on hover */}
-      <button
-        onClick={() => setFitWidth(!fitWidth)}
-        className={`absolute top-4 right-4 flex items-center gap-1.5 px-2.5 py-1.5 bg-black/60 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-all z-10 ${showChrome ? 'opacity-100' : 'opacity-0'}`}
-        title={fitWidth ? 'Fit to screen' : 'Fit to width'}
-      >
-        {fitWidth ? <Minimize className="w-3.5 h-3.5" /> : <Maximize className="w-3.5 h-3.5" />}
-        {fitWidth ? 'Fit screen' : 'Full width'}
-      </button>
+      {/* Top-right controls — appear on hover */}
+      <div className={`absolute top-4 right-4 flex items-center gap-2 z-10 transition-all ${showChrome ? 'opacity-100' : 'opacity-0'}`}>
+        {deepZoom && (
+          <button
+            onClick={() => setZoomOpen(true)}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 bg-black/60 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-all"
+            title="Open deep zoom — stream the full-resolution image tile by tile"
+          >
+            <Search className="w-3.5 h-3.5" />
+            Deep zoom
+          </button>
+        )}
+        <button
+          onClick={() => setFitWidth(!fitWidth)}
+          className="flex items-center gap-1.5 px-2.5 py-1.5 bg-black/60 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-all"
+          title={fitWidth ? 'Fit to screen' : 'Fit to width'}
+        >
+          {fitWidth ? <Minimize className="w-3.5 h-3.5" /> : <Maximize className="w-3.5 h-3.5" />}
+          {fitWidth ? 'Fit screen' : 'Full width'}
+        </button>
+      </div>
+
+      {/* Deep-zoom overlay — mounted only on user intent */}
+      {zoomOpen && deepZoom && (
+        <Suspense fallback={null}>
+          <DeepZoomOverlay
+            manifest={deepZoom}
+            title={title}
+            caption={captionText}
+            onClose={() => setZoomOpen(false)}
+          />
+        </Suspense>
+      )}
 
       {/* Prev/Next navigation — appears on hover */}
       {prevWork && (

--- a/src/components/artwork/ArtworkInfo.tsx
+++ b/src/components/artwork/ArtworkInfo.tsx
@@ -114,6 +114,7 @@ export default function ArtworkInfo({ book, collections, prevWork, nextWork, rel
           prevWork={prevWork}
           nextWork={nextWork}
           institution={holdingMuseum}
+          deepZoom={(book as any).deepzoom || null}
         />
       )}
 

--- a/src/components/artwork/DeepZoomOverlay.tsx
+++ b/src/components/artwork/DeepZoomOverlay.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+/**
+ * Deep-zoom fullscreen overlay (issue #2411, phase 3).
+ *
+ * A single-image OpenSeadragon viewer shown over the artwork hero when the book
+ * has a verified `deepzoom` tile-pyramid manifest. Tiles are streamed from R2
+ * (`images.sourcelibrary.org/<prefix>/...`) as plain <img> requests via an
+ * inline DZI descriptor — no `.dzi` XHR and no CORS dependency, so it loads
+ * under the existing img-src CSP. We deliberately do NOT set crossOriginPolicy:
+ * R2 tiles carry no ACAO header and a tainted canvas is fine for display-only
+ * (see memory: lesson_osd_cors_tainted_canvas — the classic blank-canvas trap).
+ *
+ * OpenSeadragon (BSD-3-Clause) is dynamically imported so its ~bundle weight
+ * only loads when a reader actually opens deep zoom — never in the shared chunk.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { X, ZoomIn, ZoomOut, Home, Loader2 } from 'lucide-react';
+import type { DeepZoomManifest } from '@/lib/types/book';
+
+const R2_BASE = 'https://images.sourcelibrary.org';
+
+interface DeepZoomOverlayProps {
+  manifest: DeepZoomManifest;
+  title: string;
+  caption?: string;
+  onClose: () => void;
+}
+
+// Inline DZI ("Deep Zoom Image") descriptor. OpenSeadragon's bundled types model
+// this imperfectly, so we hand back a plain tile-source object.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function tileSourceFor(m: DeepZoomManifest): any {
+  return {
+    Image: {
+      xmlns: 'http://schemas.microsoft.com/deepzoom/2008',
+      Url: `${R2_BASE}/${m.prefix}/`,
+      Format: m.format,
+      Overlap: String(m.overlap),
+      TileSize: String(m.tile_size),
+      Size: { Width: m.width, Height: m.height },
+    },
+  };
+}
+
+export default function DeepZoomOverlay({ manifest, title, caption, onClose }: DeepZoomOverlayProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const viewerRef = useRef<any>(null);
+  const [ready, setReady] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let disposed = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let viewer: any;
+
+    import('openseadragon')
+      .then((mod) => {
+        // UMD interop: factory may sit on .default or the module root.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const OpenSeadragon = ((mod as any).default ?? mod) as any;
+        if (disposed || !containerRef.current) return;
+        viewer = OpenSeadragon({
+          element: containerRef.current,
+          tileSources: tileSourceFor(manifest),
+          showNavigationControl: false,
+          showNavigator: true,
+          navigatorPosition: 'BOTTOM_RIGHT',
+          navigatorHeight: 88,
+          navigatorWidth: 118,
+          navigatorBorderColor: 'rgba(255,255,255,0.25)',
+          navigatorBackground: 'rgba(0,0,0,0.55)',
+          navigatorAutoFade: true,
+          gestureSettingsMouse: { clickToZoom: false, dblClickToZoom: true, scrollToZoom: true },
+          gestureSettingsTouch: { pinchToZoom: true, flickEnabled: true },
+          animationTime: 0.8,
+          springStiffness: 7,
+          minZoomImageRatio: 0.8,
+          // Never magnify past native into mush — 1:1 keeps every level real detail.
+          maxZoomPixelRatio: 1.0,
+          visibilityRatio: 1,
+          constrainDuringPan: true,
+          zoomPerScroll: 1.4,
+          immediateRender: false,
+        });
+        viewerRef.current = viewer;
+        viewer.addHandler('open', () => !disposed && setReady(true));
+        viewer.addHandler('open-failed', () => !disposed && setFailed(true));
+      })
+      .catch(() => !disposed && setFailed(true));
+
+    return () => {
+      disposed = true;
+      try {
+        viewer?.destroy();
+      } catch {
+        /* noop */
+      }
+      viewerRef.current = null;
+    };
+  }, [manifest]);
+
+  // Esc closes; lock body scroll while open.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [onClose]);
+
+  const zoomBy = (factor: number) => {
+    const v = viewerRef.current;
+    if (!v) return;
+    v.viewport.zoomBy(factor);
+    v.viewport.applyConstraints();
+  };
+  const home = () => viewerRef.current?.viewport.goHome();
+
+  return (
+    <div className="fixed inset-0 z-[60] bg-[#0b0a09]">
+      <div ref={containerRef} className="absolute inset-0" />
+
+      {!ready && !failed && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-stone-400">
+          <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+          <span className="text-sm">Loading deep zoom…</span>
+        </div>
+      )}
+
+      {failed && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-stone-300">
+          <span className="text-sm">Deep zoom couldn’t load.</span>
+          <button onClick={onClose} className="rounded-md bg-white/10 px-4 py-2 text-sm hover:bg-white/20">
+            Close
+          </button>
+        </div>
+      )}
+
+      {/* Close */}
+      <button
+        onClick={onClose}
+        aria-label="Close deep zoom"
+        title="Close (Esc)"
+        className="absolute right-3 top-3 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/55 text-stone-100 transition-colors hover:bg-black/80"
+      >
+        <X className="h-5 w-5" />
+      </button>
+
+      {/* Zoom controls */}
+      <div className="absolute left-3 top-3 z-10 flex flex-col gap-1.5">
+        <Ctrl label="Zoom in" onClick={() => zoomBy(1.6)}>
+          <ZoomIn className="h-4 w-4" />
+        </Ctrl>
+        <Ctrl label="Zoom out" onClick={() => zoomBy(1 / 1.6)}>
+          <ZoomOut className="h-4 w-4" />
+        </Ctrl>
+        <Ctrl label="Reset view" onClick={home}>
+          <Home className="h-4 w-4" />
+        </Ctrl>
+      </div>
+
+      {/* Caption */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-black/75 to-transparent px-4 pb-3 pt-10">
+        <p className="text-sm font-medium text-white">{title}</p>
+        <p className="mt-0.5 text-xs text-stone-400">
+          {manifest.width.toLocaleString()} × {manifest.height.toLocaleString()} px
+          {caption ? ` · ${caption}` : ''} · scroll / pinch to zoom, drag to pan
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function Ctrl({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className="flex h-9 w-9 items-center justify-center rounded-md bg-black/55 text-stone-100 transition-colors hover:bg-black/80"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -118,6 +118,17 @@ export interface Book {
   commons_description?: string; // Description from Commons metadata
   commons_categories?: string[]; // Categories from Commons
 
+  // Deep-zoom tile pyramid (issue #2411). Written LAST by the tile worker after
+  // the tiles are verified in R2 — this is the only field the viewer branches on,
+  // so its presence guarantees the tiles exist. See scripts/workers/deepzoom-tile-worker.mjs.
+  deepzoom?: DeepZoomManifest;
+  deepzoom_gate?: {              // Set when a master is below the tiling MP gate (so sweeps skip it)
+    mp: number;
+    below_gate: boolean;
+    gate_mp: number;
+    checked_at: Date;
+  };
+
   // Wikidata alignment (for Wikipedia/Wikidata outreach)
   wikidata_id?: string;           // Q item for the work (e.g., "Q457894")
   wikidata_label?: string;        // Wikidata label for verification
@@ -364,6 +375,20 @@ export interface TranslationEvidence {
   validated?: boolean;
   notes?: string;
   url?: string;
+}
+
+// Deep-zoom tile-pyramid manifest (issue #2411). Stored on the book doc by the
+// tile worker; the public viewer reads it to mount OpenSeadragon over R2 tiles.
+export interface DeepZoomManifest {
+  width: number;        // master pixel dimensions
+  height: number;
+  tile_size: number;    // px, 256
+  overlap: number;      // px, 1
+  format: string;       // tile extension, e.g. 'jpeg'
+  prefix: string;       // R2 key prefix, e.g. 'deepzoom/<book_id>'
+  tile_count: number;
+  source_url?: string;  // master the pyramid was generated from
+  generated_at?: Date;
 }
 
 // Pre-computed related book entry


### PR DESCRIPTION
## What
Phase 3 of #2411: the deep-zoom tile pyramids (built in #2465, ~1,650 Rijksmuseum artworks tiled so far) become reachable by readers. When an artwork has a verified `deepzoom` manifest, its hero shows a **Deep zoom** button that opens an OpenSeadragon fullscreen overlay streaming R2 tiles. When there's no manifest, the page is unchanged — the existing `<img>` + hover-magnifier stays the default (fast LCP, SEO, no-JS).

## How
- New `DeepZoomManifest` type on `Book`; **the manifest is the only gate** — its presence guarantees tiles exist (worker writes it last, after a HEAD-verify).
- `DeepZoomOverlay` **lazy-imports** OpenSeadragon so its bundle weight loads only on user intent, never in the shared chunk.
- Inline DZI descriptor → tiles load as plain `<img>` under the existing `img-src` CSP. **No `crossOriginPolicy`** (R2 tiles carry no ACAO; tainted canvas is fine for display — see `lesson_osd_cors_tainted_canvas`, the blank-canvas trap).
- `maxZoomPixelRatio: 1.0` — never magnify past native into blur.
- `open-failed` → graceful fallback message, not a silent blank canvas.

## Test
Tiled examples (high tile counts): `/artwork/goltzius-haec-pompa-funebris-spectata-fuit-batavorum-delphis-tertio-die-augusti-ao-1584` (32171×1313 panorama, 1048 tiles), `/artwork/hollar-zeegezicht-met-schepen-tijdens-een-storm` (7445×5674). Verifying on the preview headlessly before merge (blank canvas returns 200 — must confirm tiles actually render).

## License note
OpenSeadragon is **BSD-3-Clause** (permissive; no copyleft, no UI-attribution burden), already a dependency since the prototype (#2410). Loaded as an npm package — display-only, no telemetry, no network calls beyond fetching our own R2 tiles. Same engine as Mirador / Universal Viewer.

## In scope
- Artwork hero only (`/artwork/[slug]`).

## Out of scope (later #2411)
- Book-page reader integration.
- Gallery-image-viewer (extracted illustrations) — separate, tenant-sensitive.
- Lazy materialization (tile-on-first-view enqueue) + pipeline hook for new extractions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)