### PR TITLE
feat(works-catalog): language purification + provenance/rights + corrected censuses (#2453)

### DIFF
--- a/.claude/docs/works-catalog-provenance.md
+++ b/.claude/docs/works-catalog-provenance.md
@@ -1,0 +1,61 @@
+# Works catalog — data provenance & rights (#2453)
+
+Every row in the catalog is traceable to its source, and the rights that bind
+reuse are recorded *in the data*, not just here. Licenses verified 2026-06-08
+from the sources themselves (LICENSE files, Zenodo records, per-resource RDF).
+
+## Where provenance lives in the schema
+- **`works.source_catalog`** — which ingest created the row.
+- **`works.authority_ids`** (JSONB) — every external id (`kanripo_id`,
+  `openiti_uri`, `bdrc_work`, `bdrc_instances`, `siku_qid`, author QIDs). A row
+  can always be resolved back to the originating record.
+- **`work_sources.source` + `source_id` + `url`** — the exact upstream record
+  for each scan/transcription, with a resolvable URL.
+- **`work_sources.rights`** — per-ITEM rights where the source declares them
+  (BDRC `copyrightStatus`). Source-level defaults live in `catalog_sources`.
+- **`catalog_sources`** — one row per source: metadata license, content
+  license, commercial-OK flag, required attribution, notes. Query this before
+  any reuse/import decision.
+
+## Source-level summary (`catalog_sources`)
+
+| Source | Metadata license | Content license | Commercial? | Bind on import |
+|---|---|---|---|---|
+| **Wikidata** (siku denominator) | CC0 1.0 | CC0 1.0 | ✅ | none |
+| **Kanripo** (Kanseki Repository) | CC BY-SA 4.0 | CC BY-SA 4.0 | ✅ | share-alike if we import the texts |
+| **OpenITI** | CC BY-NC-SA 4.0 | CC BY-NC-SA 4.0 | ⚠️ **NO** | **NonCommercial + ShareAlike binds the TEXT** |
+| **BDRC / BUDA** | Open LOD, attribution requested | per-item | ⚠️ depends | scans carry per-record copyrightStatus |
+| **IA Universal Library / CADAL** | open metadata | per-item (mostly PD) | ⚠️ depends | check IA item rights before scan import |
+
+## What we actually hold vs. what's constrained
+We ingested **bibliographic metadata** (titles, authors, dates, ids, and for
+scans a resolvable URL) — facts, largely uncopyrightable. The license
+constraints bite when we go further and **import the underlying text or scan**:
+
+- **OpenITI (8,791 islamicate works):** the mARkdown transcriptions are
+  **CC BY-NC-SA 4.0**. Fine for the catalog and the census; importing the texts
+  for reading triggers NonCommercial — assess before using in any context that
+  could be deemed commercial. ShareAlike would also attach to derivatives.
+- **BDRC scans — rights are mixed and now stamped per item.** Distribution of
+  `work_sources.rights` (2026-06-08): CopyrightInCopyright **5,930**,
+  CopyrightUndetermined **2,233**, CopyrightClaimed **1,584**,
+  CopyrightPublicDomain **834**, CopyrightWaived 21 (rest undeclared/null).
+  **Never auto-import a BDRC scan as readable without checking
+  `work_sources.rights` first** — most declared records are *in copyright*.
+- **Kanripo (10,141 chinese works):** texts are CC BY-SA 4.0, derived from PD
+  Siku Quanshu (1773) / Daozang + CBETA. Importing transcriptions is fine with
+  attribution + share-alike.
+- **IA-CADAL (33,821 scan volumes):** mostly PD facsimiles of pre-1773 works,
+  but rights are per-item — check IA metadata before a bulk scan pull.
+- **Wikidata:** CC0, no constraint.
+
+## Attribution
+Each `catalog_sources.attribution` carries the required credit string. The
+catalog is an aggregation of others' scholarship — any public surface built on
+it (e.g. translation-gap-site) must credit Kanripo (Kyoto), OpenITI (Romanov &
+Seydi), BDRC, CADAL, and Wikidata. This mirrors the `LIBRARY_PARTNERS` /
+per-book provenance discipline already in the codebase.
+
+## Re-seed
+`node scripts/works-catalog/seed-provenance.mjs` (idempotent) — refreshes
+`catalog_sources` and re-stamps BDRC per-item rights from the harvest cache.

--- a/.claude/docs/works-catalog-translation-census.md
+++ b/.claude/docs/works-catalog-translation-census.md
@@ -1,56 +1,61 @@
 # Translation census — Tibetan & Islamicate (works catalog #2453)
 
-Run 2026-06-06 on Hetzner. First automated English-translation gap numbers for
-either corpus. Method: `scripts/works-catalog/translation-census.mjs` — seeded
-300-work sample, Gemini established-English-title resolution (null when none
-exists), Google Books + OpenLibrary recall, Gemini precision adjudication
-(complete/partial), errors excluded. **The automated rate is a RECALL FLOOR**
-(the Siku census ran ~2× higher on hand-verified ground truth).
+First automated English-translation gap numbers for either corpus. Method:
+`scripts/works-catalog/translation-census.mjs` — seeded 300-work sample, Gemini
+established-English-title resolution (null when none exists), Google Books +
+OpenLibrary recall, Gemini precision adjudication (complete/partial), errors
+excluded. **The automated rate is a RECALL FLOOR** (the Siku census ran ~2×
+higher on hand-verified ground truth).
 
-## Headline (raw, as-sampled)
+## Headline (purified denominators, 2026-06-08)
 
 | Tradition | Denominator | Sample | Translated | Rate | 95% CI | Projected works |
 |---|---|---|---|---|---|---|
-| Islamicate (OpenITI) | 8,791 | 300 | 13 | 4.3% | 2.5–7.3% | 224–639 |
-| Tibetan (BDRC) | 42,041 | 300 | 19 | 6.3% | 4.1–9.7% | 1,720–4,069 |
+| Islamicate (OpenITI, pre-1900) | 6,531 | 300 | 16 | 5.3% | 3.3–8.5% | 216–554 |
+| Tibetan (BDRC, language-purified) | 30,437 | 300 | 8 | 2.7% | 1.4–5.2% | 413–1,574 |
 
-Written back as `census-auto` claims: islamicate 10 full + 3 partial, tibetan
-18 full + 1 partial. Same order of magnitude as Latin (~2%, USTC) and Chinese
-(~1–3%, Siku): **the vast majority of the premodern written record in every
-tradition we've measured has no English translation.**
+Same order of magnitude as Latin (~2%, USTC) and Chinese (~1–3%, Siku).
+**Tibetan is now the lowest measured (~2.7%)** — a vast, deeply under-translated
+literature. Across every tradition we've measured, **the premodern written
+record is ~95–98% untranslated into English.** Written back as evidenced
+`census-auto` claims.
 
-## Denominator-purity caveats (READ before quoting a per-tradition rate)
+## Denominators were purified before these numbers (the prior raw run was wrong)
 
-Both raw rates are inflated by corpus contamination — the diligence lesson from
-the Siku census applies. Surfacing, not hiding:
+The first run (2026-06-06) reported islamicate 4.3% / tibetan 6.3% on
+*contaminated* denominators. Both were corrected at the source (fix committed in
+the same PR), not just caveated:
 
-- **Tibetan: 9 of the 19 hits are not Tibetan.** BDRC includes 11,392 FEMC
-  records (`*FEMC*` ids = Fonds pour l'Édition des Manuscrits du Cambodge —
-  Pali/Khmer palm-leaf manuscripts). The well-translated Pali canon (Dhammapada,
-  Anattalakkhana Sutta, Vessantara Jataka, Abhidhammattha-sangaha…) lands in
-  this sample and lifts the rate. **Genuine Tibetan-only rate is roughly half
-  the headline** (~3–4%), and several remaining hits are Indic Mahayana sutras
-  preserved *in* Tibetan (Perfection of Wisdom, Uttaratantra) — translated from
-  the Sanskrit/Tibetan, i.e. canon, not the indigenous Tibetan corpus.
-- **Islamicate: 2,260 of 8,791 works (26%) are post-1900.** OpenITI is "texts
-  of the Islamicate world," not "pre-1900." 2 of 13 hits are Naguib Mahfouz
-  (d. 2006) novels. Filtered to pre-1900 the rate is marginally lower and the
-  denominator drops to ~6,500.
+- **Tibetan: BDRC blanket-tagged ~11,600 non-Tibetan works as Tibetan.** The
+  records carry explicit `bdo:language` tags that the first ingest ignored.
+  Split out: **khmer 9,497, pali 1,895, sanskrit 185, newari 27** (the FEMC
+  Cambodian manuscript fund — Fonds pour l'Édition des Manuscrits du Cambodge).
+  The well-translated Pali canon (Dhammapada, Vessantara Jataka…) had been
+  inflating the "Tibetan" rate; on the genuine 30,437-work Tibetan denominator
+  it falls to 2.7%. Khmer/Pali/Sanskrit now get their own censuses if wanted.
+- **Islamicate: OpenITI carries 2,260 post-1900 works** (it's "Islamicate
+  texts," not "pre-1900"; author death-date = century). The census now filters
+  `century ≤ 19`, giving a 6,531-work pre-1900 denominator.
 - **Adjudicator occasionally affirms from parametric knowledge.** A few hits
   (al-Biruni's *India*, Mahfouz) were marked translated with the reason noting
   *no candidate matched* — the model knew a translation exists outside the
   search results. Correct for Biruni (Sachau 1910); a false-positive risk
   elsewhere. Keep `confidence` + `evidence` on every claim for audit.
 
+## Remaining caveat
+- **Adjudicator occasionally affirms from parametric knowledge.** A few hits
+  (al-Biruni's *India*) were marked translated with the reason noting *no
+  candidate matched* — the model knew a translation exists outside the search
+  results. Correct for Biruni (Sachau 1910); a false-positive risk elsewhere.
+  Every claim keeps `confidence` + `evidence` for audit.
+
 ## Recommended follow-ups
-1. **Purify denominators before publishing per-tradition rates:** split FEMC
-   into a `pali` / `khmer` tradition; add a `pre-1900` filter (century ≤ 19) to
-   the Islamicate denominator. Then re-report.
-2. Hand-verify a labeled stratum (≥30 works/tradition) to calibrate the
-   recall-floor multiplier, as done for Siku.
-3. These are the publishable gap numbers — once purified, they extend the
-   translation-gap-site story to Tibetan + Arabic (no prior published figure
-   exists for either).
+1. Hand-verify a labeled stratum (≥30 works/tradition) to calibrate the
+   recall-floor multiplier, as done for Siku — then these are publishable.
+2. Census the peeled-off traditions (khmer 9,497, pali 1,895, sanskrit 185) if
+   wanted — the Pali canon will read much higher (it's well-translated).
+3. These extend the translation-gap-site story to Tibetan + Arabic — **no prior
+   published English-translation figure exists for either corpus.**
 
 Reports: Hetzner `/root/works-catalog-cache/census-{tibetan,islamicate}-report.json`;
 verdict caches alongside (resumable).

--- a/scripts/works-catalog/ingest-bdrc.mjs
+++ b/scripts/works-catalog/ingest-bdrc.mjs
@@ -68,15 +68,29 @@ const label = v => {
   // prefLabel/altLabel values: object or array of {@value,@language}
   const arr = Array.isArray(v) ? v : v ? [v] : [];
   const by = lang => arr.find(x => x['@language'] === lang)?.['@value'];
+  const byPrefix = p => arr.find(x => (x['@language'] || '').startsWith(p))?.['@value'];
   return {
     ewts: by('bo-x-ewts') || null,
     bo: by('bo') || null,
     en: by('en') || by('en-x-mixed') || null,
     zh: by('zh-Hans') || by('zh-Hant') || null,
+    // transliteration (BDRC -x-twktt) + native script for non-Tibetan langs
+    translit: by('pi-x-twktt') || by('km-x-twktt') || by('sa-x-ndia') || by('sa-x-iast') || byPrefix('sa-x') || null,
+    native: by('km') || by('pi-khmr') || by('sa-deva') || byPrefix('km') || byPrefix('pi') || null,
     any: arr[0]?.['@value'] || (typeof v === 'string' ? v : null),
   };
 };
 const refs = v => (Array.isArray(v) ? v : v ? [v] : []).map(x => (typeof x === 'string' ? x : x['@id'])).filter(Boolean);
+
+// BDRC language id -> { tradition, iso }. Bulk Tibetan records leave language
+// implicit (inherited from the abstract Work), so absence => tibetan.
+const LANG_MAP = {
+  LangPi: { tradition: 'pali', iso: 'pli' },
+  LangKm: { tradition: 'khmer', iso: 'khm' },
+  LangSa: { tradition: 'sanskrit', iso: 'san' },
+  LangNew: { tradition: 'newari', iso: 'new' },
+  LangBo: { tradition: 'tibetan', iso: 'bod' },
+};
 
 function parseRecord(id) {
   let doc;
@@ -94,12 +108,15 @@ function parseRecord(id) {
   const event = refs(node['instanceEvent'] ?? node['bdo:instanceEvent'])
     .map(eid => graph.find(n => n['@id'] === eid)).filter(Boolean)[0];
   const when = event?.['eventWhen']?.['@value'] || event?.['eventWhen'] || null;
+  const langId = refs(node['language'] ?? node['bdo:language'])[0]?.replace(/^bdr:/, '') || null;
   return {
     mw: id,
     wa: wa?.replace(/^bdr:/, '') || null,
-    title: pref.bo || pref.ewts || pref.any,
-    title_bo: pref.bo || alts.bo || null,
-    ewts: pref.ewts || alts.ewts || null,
+    lang: langId, // LangBo/LangPi/LangKm/LangSa/LangNew or null (=> tibetan)
+    // native-script title preferred; falls back across scripts
+    title: pref.bo || pref.native || pref.ewts || pref.translit || pref.any,
+    title_bo: pref.bo || alts.bo || pref.native || alts.native || null,
+    translit: pref.ewts || alts.ewts || pref.translit || alts.translit || null,
     en: pref.en || alts.en || null,
     agents: agents.map(a => a.replace(/^bdr:/, '')),
     when: typeof when === 'string' ? when : null,
@@ -128,13 +145,18 @@ async function load() {
     // representative record: prefer one with an English title
     const best = instances.find(i => i.en) || rec;
     const year = parseInt((best.when || '').slice(0, 4), 10);
+    // tradition from the most specific explicit language across instances;
+    // absence => tibetan (bulk Tibetan records inherit language implicitly)
+    const langId = instances.map(i => i.lang).find(l => l && l !== 'LangBo')
+      || instances.map(i => i.lang).find(Boolean) || null;
+    const { tradition, iso } = LANG_MAP[langId] || { tradition: 'tibetan', iso: 'bod' };
     works.push({
       id: `bdrc:${key}`,
-      tradition: 'tibetan',
-      original_language: 'bod',
+      tradition,
+      original_language: iso,
       title: best.title_bo || best.title,
       title_normalized: (best.title_bo || best.title).trim(),
-      title_romanized: best.ewts,
+      title_romanized: best.translit,
       title_english: best.en,
       author: null, // P-ids resolved in a later pass; stored in authority_ids
       century: Number.isFinite(year) ? Math.floor(year / 100) + 1 : null,
@@ -145,7 +167,7 @@ async function load() {
       },
       corpus_tags: ['bdrc'],
       source_catalog: 'bdrc',
-      extra: { script: best.script, published: best.when },
+      extra: { script: best.script, published: best.when, bdrc_lang: langId },
     });
     for (const i of instances) {
       sources.push({
@@ -155,7 +177,7 @@ async function load() {
         kind: 'scan', // BUDA viewer record; IIIF manifests hang off the linked image instances
         url: `https://library.bdrc.io/show/bdr:${i.mw}`,
         iiif: true,
-        extra: { ewts: i.ewts },
+        extra: { translit: i.translit },
       });
     }
   }

--- a/scripts/works-catalog/lib.mjs
+++ b/scripts/works-catalog/lib.mjs
@@ -70,6 +70,8 @@ export async function upsertWorks(client, rows, { batch = 500 } = {}) {
     const res = await client.query(
       `insert into works (${cols.join(',')}) values ${values.join(',')}
        on conflict (id) do update set
+         tradition       = excluded.tradition,
+         original_language = coalesce(excluded.original_language, works.original_language),
          title_romanized = coalesce(excluded.title_romanized, works.title_romanized),
          title_english   = coalesce(excluded.title_english, works.title_english),
          author          = coalesce(excluded.author, works.author),

--- a/scripts/works-catalog/schema.sql
+++ b/scripts/works-catalog/schema.sql
@@ -73,3 +73,22 @@ create table if not exists work_holdings (
 );
 
 create index if not exists work_holdings_book_idx on work_holdings (book_id);
+
+-- Provenance / rights of each contributing source. One row per ingest source.
+-- Lets us answer "where did this come from and what may we do with it" without
+-- re-researching. Per-ITEM rights overrides (e.g. a single CopyrightUndetermined
+-- BDRC scan) live in work_sources.rights; this table is the source-level default.
+create table if not exists catalog_sources (
+  source text primary key,                -- matches work_sources.source / works.source_catalog
+  name text not null,
+  url text,
+  data_license text not null,             -- license of the METADATA we ingested
+  content_license text,                   -- license of the underlying text/scan (may differ + bind on import)
+  commercial_ok boolean,                  -- may the content be used commercially? null = depends/per-item
+  attribution text,                       -- required credit string
+  notes text,
+  updated_at timestamptz not null default now()
+);
+
+-- per-item rights override (PD / CopyrightUndetermined / etc.) for scan & text rows
+alter table work_sources add column if not exists rights text;

--- a/scripts/works-catalog/seed-provenance.mjs
+++ b/scripts/works-catalog/seed-provenance.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Seed catalog_sources with verified provenance/licensing for every source
+ * feeding the works catalog (#2453), and stamp per-item rights where the
+ * source records it (BDRC copyrightStatus).
+ *
+ * Licenses verified 2026-06-08 from the sources themselves (LICENSE files,
+ * Zenodo records, per-resource RDF) — see .claude/docs/works-catalog-provenance.md.
+ *
+ *   set -a; source .env.production.local; set +a; node scripts/works-catalog/seed-provenance.mjs
+ */
+import { pgClient } from './lib.mjs';
+
+const SOURCES = [
+  {
+    source: 'kanripo', name: 'Kanseki Repository (漢籍リポジトリ)',
+    url: 'https://github.com/kanripo',
+    data_license: 'CC BY-SA 4.0', content_license: 'CC BY-SA 4.0', commercial_ok: true,
+    attribution: 'Kanseki Repository, ed. Christian Wittern, Kyoto University',
+    notes: 'Texts derive from PD Siku Quanshu (1773), Zhengtong Daozang, Daozang jiyao + CBETA Buddhist canon. Importing transcriptions carries BY-SA (share-alike).',
+  },
+  {
+    source: 'openiti', name: 'Open Islamicate Texts Initiative',
+    url: 'https://github.com/OpenITI/RELEASE',
+    data_license: 'CC BY-NC-SA 4.0', content_license: 'CC BY-NC-SA 4.0', commercial_ok: false,
+    attribution: 'Romanov, Maxim, and Masoumeh Seydi. "OpenITI: A Machine-Readable Corpus of Islamicate Texts." Zenodo, 2019- (doi:10.5281/zenodo.3082463)',
+    notes: 'NON-COMMERCIAL + ShareAlike binds the TEXT. Bibliographic metadata we hold (titles/authors/URIs/dates) is uncopyrightable fact; importing the mARkdown transcriptions for reading triggers NC — assess before any commercial context.',
+  },
+  {
+    source: 'bdrc', name: 'Buddhist Digital Resource Center / BUDA',
+    url: 'https://library.bdrc.io',
+    data_license: 'Open (LOD, attribution requested)', content_license: null, commercial_ok: null,
+    attribution: 'Buddhist Digital Resource Center (bdrc.io)',
+    notes: 'Bibliographic LOD is openly shared with attribution. SCANS carry per-record bdo:copyrightStatus (often CopyrightUndetermined) — never auto-import a scan as readable without checking work_sources.rights. Aggregates British Library EAP, IA, CBETA, NGMCP partners.',
+  },
+  {
+    source: 'ia-cadal', name: 'Internet Archive — Universal Library / CADAL',
+    url: 'https://archive.org/details/universallibrary',
+    data_license: 'Open metadata', content_license: null, commercial_ok: null,
+    attribution: 'China-America Digital Academic Library (CADAL); Internet Archive',
+    notes: 'Volume-level facsimiles, mostly of pre-1773 PD works, but rights are per-item. Check IA item metadata (possible-copyright) before bulk scan import.',
+  },
+  {
+    source: 'wikidata-siku', name: 'Wikidata (Siku Quanshu denominator)',
+    url: 'https://www.wikidata.org',
+    data_license: 'CC0 1.0', content_license: 'CC0 1.0', commercial_ok: true,
+    attribution: 'Wikidata contributors (CC0)',
+    notes: 'Public-domain dedication — no constraint. Used for QIDs, labels, aliases.',
+  },
+];
+
+const client = pgClient();
+await client.connect();
+
+for (const s of SOURCES) {
+  await client.query(
+    `insert into catalog_sources (source, name, url, data_license, content_license, commercial_ok, attribution, notes)
+     values ($1,$2,$3,$4,$5,$6,$7,$8)
+     on conflict (source) do update set
+       name=excluded.name, url=excluded.url, data_license=excluded.data_license,
+       content_license=excluded.content_license, commercial_ok=excluded.commercial_ok,
+       attribution=excluded.attribution, notes=excluded.notes, updated_at=now()`,
+    [s.source, s.name, s.url, s.data_license, s.content_license, s.commercial_ok, s.attribution, s.notes]);
+}
+console.log(`Seeded ${SOURCES.length} catalog_sources rows`);
+
+// Per-item rights for BDRC scans: lift copyrightStatus from the cached records.
+// (Only run if the BDRC harvest cache is present.)
+import { existsSync, readdirSync, readFileSync } from 'fs';
+const CACHE = process.env.BDRC_CACHE_DIR || '/root/works-catalog-cache/bdrc';
+if (existsSync(CACHE)) {
+  const files = readdirSync(CACHE).filter(f => f.endsWith('.jsonld'));
+  let stamped = 0;
+  const updates = [];
+  for (const f of files) {
+    try {
+      const doc = JSON.parse(readFileSync(`${CACHE}/${f}`, 'utf8'));
+      const g = doc['@graph'] || [doc];
+      const id = f.replace(/\.jsonld$/, '');
+      const node = g.find(n => (n['@id'] || '').includes(id)) || {};
+      const cs = (node['copyrightStatus'] ?? node['bdo:copyrightStatus']);
+      const status = (Array.isArray(cs) ? cs[0] : cs);
+      const val = (typeof status === 'string' ? status : status?.['@id'])?.replace(/^bdr:/, '');
+      if (val) updates.push([`bdrc:${id}`, id, val]);
+    } catch { /* skip */ }
+  }
+  // bulk update work_sources.rights by (work matched via source_id = MW id)
+  for (let i = 0; i < updates.length; i += 1000) {
+    const chunk = updates.slice(i, i + 1000);
+    const values = chunk.map((_, j) => `($${j * 2 + 1},$${j * 2 + 2})`).join(',');
+    const params = chunk.flatMap(u => [u[1], u[2]]);
+    const res = await client.query(
+      `update work_sources ws set rights = v.rights
+       from (values ${values}) as v(source_id, rights)
+       where ws.source = 'bdrc' and ws.source_id = v.source_id`,
+      params);
+    stamped += res.rowCount;
+  }
+  const dist = (await client.query(
+    `select rights, count(*) n from work_sources where source='bdrc' group by 1 order by 2 desc limit 8`)).rows;
+  console.log(`Stamped ${stamped} bdrc work_sources with rights. Distribution:`, JSON.stringify(dist));
+}
+
+await client.end();

--- a/scripts/works-catalog/translation-census.mjs
+++ b/scripts/works-catalog/translation-census.mjs
@@ -178,8 +178,13 @@ Respond JSON only: {"translated": boolean, "which": <number|null>, "complete": b
 // --- main ---------------------------------------------------------------------
 const client = pgClient();
 await client.connect();
+// Pre-1900 scope: OpenITI carries modern authors (century = author death CE),
+// so exclude century > 19 from the islamicate denominator. Tibetan/etc. are
+// already purified into their own traditions, so no filter needed there.
+const scopeFilter = TRADITION === 'islamicate' ? `and (century is null or century <= 19)` : '';
 const all = (await client.query(
-  `select id, title, title_romanized, title_english, author, extra from works where tradition = $1 order by id`,
+  `select id, title, title_romanized, title_english, author, extra from works
+   where tradition = $1 ${scopeFilter} order by id`,
   [TRADITION])).rows;
 const rng = mulberry32(SEED);
 const sample = [...all].map(w => [rng(), w]).sort((a, b) => a[0] - b[0]).map(x => x[1]).slice(0, N);


### PR DESCRIPTION
Catalog-integrity pass on #2453. Three intertwined data-honesty fixes to the new works catalog, all scripts/docs only.

## 1. BDRC language purification
The BDRC ingest blanket-tagged all 42,041 works `tibetan/bod`, but the records carry explicit `bdo:language` tags it ignored. `parseRecord` now reads them; `load` derives tradition per work. Result:
- **tibetan 42,041 → 30,437** (genuine)
- split out: **khmer 9,497, pali 1,895, sanskrit 185, newari 27** (the FEMC Cambodian manuscript fund)

`upsertWorks` now refreshes `tradition`/`original_language` from source so a re-`--load` self-corrects existing rows.

## 2. Provenance & rights layer
- **`catalog_sources` table** — verified license per source (metadata + content license, commercial flag, attribution, notes).
- **`work_sources.rights`** — per-item, stamped from BDRC `copyrightStatus`.
- **Finding that matters:** of BDRC scans declaring rights, **5,930 In-Copyright / 1,584 Claimed / only 834 Public Domain.** Guard documented: never auto-import a BDRC scan or OpenITI text (CC BY-NC-SA, noncommercial) as readable without checking rights. Metadata aggregation is fine; content import is gated. Doc: `.claude/docs/works-catalog-provenance.md`.

## 3. Corrected censuses (recall floors)

| Tradition | Denominator | Translated/300 | Rate | 95% CI |
|---|---|---|---|---|
| Islamicate (pre-1900) | 6,531 | 16 | 5.3% | 3.3–8.5% |
| Tibetan (purified) | 30,437 | 8 | 2.7% | 1.4–5.2% |

Tibetan fell from a contaminated 6.3% to 2.7% once the Pali canon was removed — now the lowest measured. Census filters islamicate `century ≤ 19`. Doc: `.claude/docs/works-catalog-translation-census.md`.

First published English-translation gap figures for either corpus.

## Out of scope
Hand-verified calibration stratum; censusing the peeled-off khmer/pali/sanskrit; per-item IA-CADAL rights stamping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)