### PR TITLE
fix(reader): default-tenant page reads 404 on untagged books (stuck page-turn)

### DIFF
--- a/src/app/api/[tenant]/pages/[id]/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/route.ts
@@ -48,10 +48,18 @@ export async function GET(
     const { searchParams } = new URL(request.url);
     const full = searchParams.get('full') === 'true';
 
+    // Default tenant = the main library: untagged (global) pages ARE in scope,
+    // alongside any explicitly tagged with the default-tenant UUID. Subdomain
+    // tenants (bph / kloss / bhutan) stay strict — exact tenantId only. This
+    // mirrors findTenantBookByIdOrSlug() so per-page content reads match the
+    // book-level lookup; without it, reader page-turns 404 on every untagged
+    // book under the default tenant (the "stuck on page N" bug, 2026-05-27/06-08).
+    const tenantFilter = tenant === 'default' ? { $in: [tenantId, null] } : tenantId;
+
     // Default: exclude detected_images (large array unused by the reader)
     const projection = full ? undefined : { detected_images: 0 };
     let page = await db.collection('pages').findOne(
-      { id, tenantId },
+      { id, tenantId: tenantFilter },
       projection ? { projection } : undefined
     );
 
@@ -60,7 +68,7 @@ export async function GET(
       const { ObjectId } = await import('mongodb');
       if (ObjectId.isValid(id)) {
         page = await db.collection('pages').findOne(
-          { _id: new ObjectId(id), tenantId },
+          { _id: new ObjectId(id), tenantId: tenantFilter },
           projection ? { projection } : undefined
         );
       }

--- a/src/app/api/[tenant]/pages/batch/route.ts
+++ b/src/app/api/[tenant]/pages/batch/route.ts
@@ -36,9 +36,15 @@ export async function POST(
     // Cap at 20 pages per request
     const limitedIds = ids.slice(0, 20);
 
+    // Default tenant = the main library: untagged (global) pages are in scope.
+    // Subdomain tenants stay strict. Mirrors the [id] GET route and
+    // findTenantBookByIdOrSlug() — keeps reader prefetch working on untagged
+    // books instead of silently returning an empty batch.
+    const tenantFilter = tenant === 'default' ? { $in: [tenantId, null] } : tenantId;
+
     const db = await getDb();
     const pages = await db.collection('pages').find(
-      { id: { $in: limitedIds }, tenantId },
+      { id: { $in: limitedIds }, tenantId: tenantFilter },
       { projection: { detected_images: 0 } }
     ).toArray();
 


### PR DESCRIPTION
## Why
Two reader reports of being stuck on a page:
- *Derek* (2026-05-27): "Weirdly, I can't go to the next page from 19 — via swipe, arrows or the top UI" (`/default/book/6990616fef12272ffdc8db47/...`)
- *jean zhang* (2026-06-08): "every time I try to turn the pages, there is an error report, I can only read the first page"

## Root cause
The first page is **server-rendered** (the SSR route reads pages with no tenant filter), so it shows. Every subsequent page-turn is a **client-side fetch** through the tenant-scoped content APIs, which hard-filtered `{ id, tenantId }`. Under the **`default` tenant** (the main library), global books' pages carry `tenantId: null`, so the filter never matched → **404 → reader can't advance**.

The book-level lookup already fixes exactly this — `findTenantBookByIdOrSlug()` falls back to untagged books for the `default` tenant (PR #2071, after the **same 2026-05-27 incident**). But the per-page `pages/[id]` GET and `pages/batch` POST routes were missed, so the book resolves but its page content 404s.

### Verified on production
```
GET /api/pages/6990616fef12272ffdc8db5c          → 200
GET /api/default/pages/6990616fef12272ffdc8db5c  → 404   (Derek's book)
GET /api/pages/699060268cbcc9a4dba2cf6d          → 200
GET /api/default/pages/699060268cbcc9a4dba2cf6d  → 404   (jean's book)
```

## Fix
For `tenant === 'default'` **only**, widen the page filter to `{ $in: [tenantId, null] }` (matches default-tagged *and* untagged/global pages — `$in` with `null` also matches missing fields). Applied to both `pages/[id]` GET and `pages/batch` POST, mirroring `findTenantBookByIdOrSlug()`.

## Tenant lockdown — unchanged
Subdomain tenants (`bph` / `kloss-collection` / `bhutan`) keep the strict **exact-`tenantId`** filter; the widened filter only ever includes `null`, never another tenant's UUID, so no cross-tenant page can leak. This is read-only OCR/translation content, consistent with the SSR route that already reads these pages globally.

## Out of scope
- The `bph` subdomain serving global books at all (separate policy question; reader nav there resolves to the global `/api/pages` path and already works).
- Editor/pipeline tenant routes (auth-gated, not the reader content path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)