### PR TITLE
feat(feedback): email submitters when their feedback is addressed

### DIFF
--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -16,6 +16,9 @@ interface FeedbackItem {
   addressed_by?: string | null;
   addressed_action?: string | null;
   addressed_link?: string | null;
+  reply_message?: string | null;
+  reply_sent_at?: string | null;
+  reply_recipient?: string | null;
 }
 
 type Tab = 'unread' | 'read' | 'addressed';
@@ -30,7 +33,7 @@ export default function AdminFeedbackPage() {
   const [items, setItems] = useState<FeedbackItem[]>([]);
   const [counts, setCounts] = useState<{ unread: number; read: number; addressed: number }>({ unread: 0, read: 0, addressed: 0 });
   const [loading, setLoading] = useState(false);
-  const [actionDraft, setActionDraft] = useState<Record<string, { action: string; link: string }>>({});
+  const [actionDraft, setActionDraft] = useState<Record<string, { action: string; link: string; reply: string }>>({});
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -62,17 +65,45 @@ export default function AdminFeedbackPage() {
     return true;
   }
 
+  // Like patch(), but returns the parsed response (so callers can read `replied`).
+  async function patchRaw(id: string, body: Record<string, unknown>): Promise<{ ok: boolean; replied?: boolean } | null> {
+    const res = await fetch(`/api/feedback/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      alert(`Update failed: ${res.status}`);
+      return null;
+    }
+    return res.json();
+  }
+
   async function markRead(id: string) {
     if (await patch(id, { read: true })) load();
   }
 
-  async function markAddressed(id: string) {
-    const draft = actionDraft[id] || { action: '', link: '' };
+  async function markAddressed(item: FeedbackItem) {
+    const id = item._id;
+    const draft = actionDraft[id] || { action: '', link: '', reply: '' };
     if (!draft.action.trim()) {
       alert('Add a one-line action before marking addressed');
       return;
     }
-    if (await patch(id, { addressed: true, addressed_action: draft.action.trim(), addressed_link: draft.link.trim() || undefined })) {
+    const willEmail = !!item.email && !item.reply_sent_at;
+    if (willEmail && !confirm(`This will email ${item.email} to let them know their feedback was addressed. Continue?`)) {
+      return;
+    }
+    const res = await patchRaw(id, {
+      addressed: true,
+      addressed_action: draft.action.trim(),
+      addressed_link: draft.link.trim() || undefined,
+      reply_message: draft.reply.trim() || undefined,
+    });
+    if (res) {
+      if (willEmail && res.replied === false) {
+        alert('Marked addressed, but the reply email failed to send (check RESEND_API_KEY / logs).');
+      }
       setActionDraft(d => { const next = { ...d }; delete next[id]; return next; });
       load();
     }
@@ -86,7 +117,7 @@ export default function AdminFeedbackPage() {
   return (
     <div className="max-w-5xl mx-auto px-6 py-10">
       <h1 className="text-2xl font-semibold mb-2">Feedback</h1>
-      <p className="text-sm text-stone-500 mb-6">From the &quot;Give Feedback&quot; button in the site footer. Mark items as <em>addressed</em> once a fix ships.</p>
+      <p className="text-sm text-stone-500 mb-6">From the &quot;Give Feedback&quot; button in the site footer. Mark items as <em>addressed</em> once a fix ships &mdash; if the submitter left an email, they&apos;re automatically notified (once).</p>
 
       <div className="flex gap-2 mb-6 border-b border-stone-200">
         {(['unread', 'read', 'addressed'] as Tab[]).map(t => (
@@ -133,6 +164,11 @@ export default function AdminFeedbackPage() {
                 {item.addressed_link && (
                   <a href={item.addressed_link} target="_blank" rel="noopener noreferrer" className="text-accent-rust hover:underline mt-1 inline-block">{item.addressed_link}</a>
                 )}
+                {item.reply_sent_at ? (
+                  <p className="mt-2 text-emerald-700">↩ Replied to {item.reply_recipient || item.email} · {formatDate(item.reply_sent_at)}</p>
+                ) : item.email ? (
+                  <p className="mt-2 text-stone-400">No reply email sent.</p>
+                ) : null}
               </div>
             )}
 
@@ -148,18 +184,27 @@ export default function AdminFeedbackPage() {
                     type="text"
                     placeholder="What was done (one line)"
                     value={actionDraft[item._id]?.action || ''}
-                    onChange={e => setActionDraft(d => ({ ...d, [item._id]: { ...d[item._id] || { action: '', link: '' }, action: e.target.value } }))}
+                    onChange={e => setActionDraft(d => ({ ...d, [item._id]: { ...(d[item._id] || { action: '', link: '', reply: '' }), action: e.target.value } }))}
                     className="flex-1 min-w-[200px] text-xs px-2 py-1.5 border border-stone-200 rounded focus:outline-none focus:border-accent-rust"
                   />
                   <input
                     type="url"
                     placeholder="PR/commit URL (optional)"
                     value={actionDraft[item._id]?.link || ''}
-                    onChange={e => setActionDraft(d => ({ ...d, [item._id]: { ...d[item._id] || { action: '', link: '' }, link: e.target.value } }))}
+                    onChange={e => setActionDraft(d => ({ ...d, [item._id]: { ...(d[item._id] || { action: '', link: '', reply: '' }), link: e.target.value } }))}
                     className="w-[26ch] text-xs px-2 py-1.5 border border-stone-200 rounded focus:outline-none focus:border-accent-rust"
                   />
-                  <button onClick={() => markAddressed(item._id)} className="text-xs px-3 py-1.5 bg-accent-rust hover:bg-accent-rust/90 text-white rounded transition-colors">
-                    Mark addressed
+                  {item.email && !item.reply_sent_at && (
+                    <input
+                      type="text"
+                      placeholder={`Friendly note to ${item.email} (optional)`}
+                      value={actionDraft[item._id]?.reply || ''}
+                      onChange={e => setActionDraft(d => ({ ...d, [item._id]: { ...(d[item._id] || { action: '', link: '', reply: '' }), reply: e.target.value } }))}
+                      className="flex-1 min-w-[200px] text-xs px-2 py-1.5 border border-stone-200 rounded focus:outline-none focus:border-accent-rust"
+                    />
+                  )}
+                  <button onClick={() => markAddressed(item)} className="text-xs px-3 py-1.5 bg-accent-rust hover:bg-accent-rust/90 text-white rounded transition-colors">
+                    {item.email && !item.reply_sent_at ? 'Mark addressed & email' : 'Mark addressed'}
                   </button>
                 </>
               )}

--- a/src/app/api/feedback/[id]/route.ts
+++ b/src/app/api/feedback/[id]/route.ts
@@ -2,9 +2,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ObjectId } from 'mongodb';
 import { getDb } from '@/lib/mongodb';
 import { withAdminAuth } from '@/lib/auth-helpers';
+import { sendFeedbackReplyEmail } from '@/lib/feedback-reply-email';
 
 // PATCH /api/feedback/[id] — update lifecycle state (admin only)
-// Body: { read?: boolean, addressed?: boolean, addressed_action?: string, addressed_link?: string }
+// Body: { read?, addressed?, addressed_action?, addressed_link?, reply_message? }
+// When an item is newly marked addressed and the submitter left an email, we
+// auto-send them a "we read your feedback and made a change" note (once).
 export const PATCH = withAdminAuth(async (request: NextRequest, _session, context) => {
   try {
     const { id } = await context.params;
@@ -22,6 +25,7 @@ export const PATCH = withAdminAuth(async (request: NextRequest, _session, contex
       update.read_at = null;
     }
 
+    let replyMessage: string | null = null;
     if (body.addressed === true) {
       update.read = true;
       update.read_at = update.read_at ?? new Date();
@@ -30,23 +34,56 @@ export const PATCH = withAdminAuth(async (request: NextRequest, _session, contex
       update.addressed_by = _session.user?.email || 'admin';
       if (typeof body.addressed_action === 'string') update.addressed_action = body.addressed_action.slice(0, 1000);
       if (typeof body.addressed_link === 'string') update.addressed_link = body.addressed_link.slice(0, 500);
+      if (typeof body.reply_message === 'string' && body.reply_message.trim()) {
+        replyMessage = body.reply_message.trim().slice(0, 1000);
+        update.reply_message = replyMessage;
+      }
     } else if (body.addressed === false) {
       update.addressed = false;
       update.addressed_at = null;
       update.addressed_by = null;
       update.addressed_action = null;
       update.addressed_link = null;
+      // Note: reply_sent_at is intentionally NOT cleared, so re-addressing an
+      // item never re-emails a submitter who was already notified.
     }
 
     const db = await getDb();
-    const r = await db.collection('feedback').updateOne(
+    // Read first so we have the submitter's email + original message, and can
+    // tell whether they've already been notified.
+    const existing = await db.collection('feedback').findOne({ _id: new ObjectId(id) });
+    if (!existing) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    await db.collection('feedback').updateOne(
       { _id: new ObjectId(id) },
       { $set: update },
     );
-    if (r.matchedCount === 0) {
-      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    // Auto-reply: newly addressed + submitter left an email + not already notified.
+    let replied = false;
+    if (
+      body.addressed === true &&
+      typeof existing.email === 'string' && existing.email.includes('@') &&
+      !existing.reply_sent_at
+    ) {
+      replied = await sendFeedbackReplyEmail({
+        to: existing.email,
+        name: existing.name,
+        originalMessage: existing.message || '',
+        replyBody: replyMessage || (typeof body.addressed_action === 'string' ? body.addressed_action : null),
+        link: typeof body.addressed_link === 'string' ? body.addressed_link : null,
+      });
+      if (replied) {
+        await db.collection('feedback').updateOne(
+          { _id: new ObjectId(id) },
+          { $set: { reply_sent_at: new Date(), reply_recipient: existing.email } },
+        );
+      }
     }
-    return NextResponse.json({ ok: true });
+
+    return NextResponse.json({ ok: true, replied });
   } catch (error) {
     console.error('Feedback PATCH error:', error);
     return NextResponse.json({ error: 'Failed to update feedback' }, { status: 500 });

--- a/src/lib/feedback-reply-email.ts
+++ b/src/lib/feedback-reply-email.ts
@@ -1,0 +1,119 @@
+// Sends a "we read your feedback and made a change" email to a submitter who
+// left an address. Fired from PATCH /api/feedback/[id] when an admin marks an
+// item addressed. Best-effort: returns false (never throws) if email can't be
+// sent so it never breaks the admin action.
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function isPublicUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim());
+}
+
+interface FeedbackReplyParams {
+  to: string;
+  name?: string | null;
+  /** The submitter's original feedback message, quoted back to them. */
+  originalMessage: string;
+  /** Friendly note about what changed. Falls back to a generic line if empty. */
+  replyBody?: string | null;
+  /** Optional public link to the change (e.g. a PR or the fixed page). */
+  link?: string | null;
+}
+
+function buildHtml({ name, originalMessage, replyBody, link }: FeedbackReplyParams): string {
+  const greeting = name && name.trim() ? `Hi ${escapeHtml(name.trim())},` : 'Hi,';
+  const body = (replyBody && replyBody.trim())
+    ? escapeHtml(replyBody.trim())
+    : 'We&rsquo;ve looked into this and made a change based on what you sent.';
+  const linkBlock = link && isPublicUrl(link)
+    ? `<div style="text-align: center; margin: 28px 0 4px;">
+        <a href="${escapeHtml(link.trim())}" style="display: inline-block; padding: 11px 28px; background: #9e4a3a; color: #ffffff; text-decoration: none; border-radius: 8px; font-size: 15px; font-family: -apple-system, sans-serif;">See the change</a>
+      </div>`
+    : '';
+
+  return `
+<div style="font-family: Georgia, 'Times New Roman', serif; max-width: 520px; margin: 0 auto; padding: 40px 24px; color: #1a1612;">
+  <div style="text-align: center; margin-bottom: 28px;">
+    <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="44" height="44" style="margin-bottom: 14px;" />
+    <h1 style="font-size: 23px; font-weight: 500; margin: 0; letter-spacing: -0.01em;">Thanks for your feedback</h1>
+  </div>
+  <p style="font-size: 15px; line-height: 1.7; margin: 0 0 16px;">${greeting}</p>
+  <p style="font-size: 15px; line-height: 1.7; margin: 0 0 16px;">
+    A little while ago you sent us a note about Source Library. We wanted to let you know we read it &mdash; and acted on it.
+  </p>
+  <div style="background: #f5f0e8; border-left: 3px solid #d8cfc0; border-radius: 6px; padding: 14px 18px; margin: 0 0 20px;">
+    <div style="font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: #8a8480; margin-bottom: 6px;">You wrote</div>
+    <p style="font-size: 14px; line-height: 1.6; margin: 0; color: #4a443c; white-space: pre-wrap;">${escapeHtml(originalMessage.trim())}</p>
+  </div>
+  <p style="font-size: 15px; line-height: 1.7; margin: 0 0 8px;">${body}</p>
+  ${linkBlock}
+  <div style="border-top: 1px solid #e8e4dc; padding-top: 22px; margin-top: 28px; text-align: center;">
+    <p style="color: #8a8480; font-size: 12px; line-height: 1.6; margin: 0;">
+      Thank you for helping make these texts more readable.
+      <br />
+      <a href="https://sourcelibrary.org" style="color: #8a8480;">sourcelibrary.org</a>
+    </p>
+  </div>
+</div>
+`;
+}
+
+function buildText({ name, originalMessage, replyBody, link }: FeedbackReplyParams): string {
+  const greeting = name && name.trim() ? `Hi ${name.trim()},` : 'Hi,';
+  const body = (replyBody && replyBody.trim())
+    ? replyBody.trim()
+    : 'We’ve looked into this and made a change based on what you sent.';
+  const lines = [
+    greeting,
+    '',
+    'A little while ago you sent us a note about Source Library. We wanted to let you know we read it — and acted on it.',
+    '',
+    'You wrote:',
+    `  "${originalMessage.trim()}"`,
+    '',
+    body,
+  ];
+  if (link && isPublicUrl(link)) {
+    lines.push('', `See the change: ${link.trim()}`);
+  }
+  lines.push('', 'Thank you for helping make these texts more readable.', 'sourcelibrary.org');
+  return lines.join('\n');
+}
+
+/**
+ * Sends the reply email. Returns true if Resend accepted it, false otherwise
+ * (missing API key, send error, etc.). Never throws.
+ */
+export async function sendFeedbackReplyEmail(params: FeedbackReplyParams): Promise<boolean> {
+  if (!process.env.RESEND_API_KEY) {
+    console.warn('[feedback-reply] RESEND_API_KEY not set — skipping reply email');
+    return false;
+  }
+  if (!params.to || !params.to.includes('@')) return false;
+
+  try {
+    const { Resend } = await import('resend');
+    const resend = new Resend(process.env.RESEND_API_KEY);
+    const result = await resend.emails.send({
+      from: process.env.EMAIL_FROM || 'Source Library <noreply@sourcelibrary.org>',
+      to: params.to,
+      subject: 'We read your feedback on Source Library',
+      html: buildHtml(params),
+      text: buildText(params),
+    });
+    if (result.error) {
+      console.error('[feedback-reply] Resend error:', result.error);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('[feedback-reply] send failed:', error);
+    return false;
+  }
+}


### PR DESCRIPTION
## Why
We have a nice feedback system, but submitters never hear back. ~42% of feedback (58 of 137 items) includes an email address — so we can close the loop with them. This makes the act of giving feedback feel heard, which is exactly the kind of small thing that builds trust with readers.

## What
When an admin marks a feedback item **addressed** in `/admin/feedback` and the submitter left an email, we auto-send them a friendly, branded note via Resend (already used for the beta welcome email). The email quotes their original message back, says what changed, and links to the change if a public URL was given.

- **`src/lib/feedback-reply-email.ts`** — new module. Best-effort send (returns `false`, never throws) so it can't break the admin action. Has both HTML and plaintext bodies, brand-styled to match the beta welcome email.
- **`PATCH /api/feedback/[id]`** — on a *new* addressed transition with an email present, sends once. Guarded by a sticky `reply_sent_at` so re-addressing (or unmark→addressed) never re-emails the same person. Returns `{ ok, replied }`.
- **Optional `reply_message`** — admin can type a warmer one-line note; if blank, the email falls back to the `addressed_action` text.
- **Admin UI** — button reads "Mark addressed & email" when a reply will fire, with a confirm dialog; an optional friendly-note input; and a "↩ Replied to <addr> · <time>" status line afterward.

## Trigger model
Per the chosen design: the email fires automatically the moment an admin clicks **Mark addressed** (not a separate send step). The confirm dialog + the sticky guard are the safety rails.

## Out of scope (deliberately)
- **The ~58% of feedback with no email** can't be reached this way. A follow-up could stamp the logged-in user's id onto new feedback so registered users get an in-app "we responded" notification — not in this PR.
- No backfill: existing already-addressed items are not retro-emailed (they have no `reply_sent_at`, but we only send on a *new* addressed action).
- No unsubscribe link — this is a one-off transactional reply to someone who wrote to us first.

## Test notes
`npx tsc --noEmit` clean. Requires `RESEND_API_KEY` + `EMAIL_FROM` (already set in prod, used by beta subscribe). Did not deploy — leaving for review since it sends real email to real people.

🤖 Generated with [Claude Code](https://claude.com/claude-code)