### PR TITLE
fix(categories): canonicalize category values so casing drift stops hiding books

### DIFF
--- a/scripts/maintenance/canonicalize-categories.mjs
+++ b/scripts/maintenance/canonicalize-categories.mjs
@@ -57,7 +57,7 @@ async function doMongo() {
 async function doSupabase() {
   const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
   let from = 0; const PAGE = 1000;
-  let scanned = 0, changed = 0;
+  let scanned = 0, changed = 0, errs = 0;
   for (;;) {
     const { data, error } = await sb.from('books_catalog').select('id, categories').range(from, from + PAGE - 1);
     if (error) { console.error('Supabase read error:', error.message); break; }
@@ -68,14 +68,19 @@ async function doSupabase() {
       if (!norm || sameArr(norm, row.categories)) continue;
       changed++;
       if (APPLY) {
-        const { error: uErr } = await sb.from('books_catalog').update({ categories: norm }).eq('id', row.id);
-        if (uErr) console.error(`  update ${row.id} failed: ${uErr.message}`);
+        // Wrap per-row: a rejected update await would otherwise crash node
+        // (unhandled rejection) and abort the whole backfill mid-run.
+        try {
+          const { error: uErr } = await sb.from('books_catalog').update({ categories: norm }).eq('id', row.id);
+          if (uErr) { errs++; console.error(`  update ${row.id} failed: ${uErr.message}`); }
+        } catch (e) { errs++; console.error(`  update ${row.id} threw: ${e.message}`); }
+        if (changed % 1000 === 0) console.log(`  ...Supabase ${changed} updated (errs=${errs})`);
       }
     }
     if (data.length < PAGE) break;
     from += PAGE;
   }
-  console.log(`Supabase books_catalog: scanned=${scanned}, ${APPLY ? 'updated' : 'would-update'}=${changed}`);
+  console.log(`Supabase books_catalog: scanned=${scanned}, ${APPLY ? 'updated' : 'would-update'}=${changed}, errors=${errs}`);
 }
 
 console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY'}`);

--- a/scripts/maintenance/canonicalize-categories.mjs
+++ b/scripts/maintenance/canonicalize-categories.mjs
@@ -1,0 +1,84 @@
+// Canonicalize the `categories` array on every book so casing/format variants
+// fold into one bucket. AI enrichment historically wrote free-form casings
+// ("Philosophy", "Natural Philosophy"); `categories @> [id]` matching is exact +
+// case-sensitive, so those books silently dropped out of their category page and
+// from category-filtered search (e.g. ~813 "Freemasonry" books missing from
+// /categories/freemasonry). Canonical form = lowercase, trimmed, spaces → hyphens.
+//
+// Idempotent — re-running on already-canonical data is a no-op. Writes both the
+// Mongo source of truth (books.categories, bumping updated_at so the 5-min
+// Supabase sync propagates) and the Supabase mirror directly (immediate effect).
+//
+//   node scripts/maintenance/canonicalize-categories.mjs --dry
+//   node scripts/maintenance/canonicalize-categories.mjs --apply
+//   ...--apply --supabase-only   (skip Mongo if Atlas is unreachable)
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+const SUPABASE_ONLY = process.argv.includes('--supabase-only');
+const MONGO_ONLY = process.argv.includes('--mongo-only');
+
+const canon = (s) => String(s).toLowerCase().trim().replace(/\s+/g, '-');
+const normalize = (arr) => {
+  if (!Array.isArray(arr)) return null;
+  const out = [...new Set(arr.map(canon))].filter(Boolean);
+  return out;
+};
+const sameArr = (a, b) => a.length === b.length && a.every((x, i) => x === b[i]);
+
+async function doMongo() {
+  let c;
+  for (let i = 0; i < 8; i++) {
+    try { c = new MongoClient(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 8000 }); await c.connect(); break; }
+    catch (e) { console.error(`mongo connect retry ${i + 1}: ${e.message}`); c = null; await new Promise(r => setTimeout(r, 3000)); }
+  }
+  if (!c) { console.error('Mongo: Atlas unreachable — skipping (re-run with --supabase-only or retry).'); return; }
+  const db = c.db('bookstore');
+  const cursor = db.collection('books').find(
+    { categories: { $exists: true, $ne: [] } },
+    { projection: { categories: 1 } }
+  );
+  let scanned = 0, changed = 0;
+  const ops = [];
+  for await (const b of cursor) {
+    scanned++;
+    const norm = normalize(b.categories);
+    if (!norm || sameArr(norm, b.categories)) continue;
+    changed++;
+    if (APPLY) ops.push({ updateOne: { filter: { _id: b._id }, update: { $set: { categories: norm, updated_at: new Date() } } } });
+    if (ops.length >= 500) { await db.collection('books').bulkWrite(ops); ops.length = 0; }
+  }
+  if (APPLY && ops.length) await db.collection('books').bulkWrite(ops);
+  console.log(`Mongo books: scanned=${scanned}, ${APPLY ? 'updated' : 'would-update'}=${changed}`);
+  await c.close();
+}
+
+async function doSupabase() {
+  const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  let from = 0; const PAGE = 1000;
+  let scanned = 0, changed = 0;
+  for (;;) {
+    const { data, error } = await sb.from('books_catalog').select('id, categories').range(from, from + PAGE - 1);
+    if (error) { console.error('Supabase read error:', error.message); break; }
+    if (!data || !data.length) break;
+    for (const row of data) {
+      scanned++;
+      const norm = normalize(row.categories);
+      if (!norm || sameArr(norm, row.categories)) continue;
+      changed++;
+      if (APPLY) {
+        const { error: uErr } = await sb.from('books_catalog').update({ categories: norm }).eq('id', row.id);
+        if (uErr) console.error(`  update ${row.id} failed: ${uErr.message}`);
+      }
+    }
+    if (data.length < PAGE) break;
+    from += PAGE;
+  }
+  console.log(`Supabase books_catalog: scanned=${scanned}, ${APPLY ? 'updated' : 'would-update'}=${changed}`);
+}
+
+console.log(`Mode: ${APPLY ? 'APPLY' : 'DRY'}`);
+if (!SUPABASE_ONLY) await doMongo();
+if (!MONGO_ONLY) await doSupabase();
+console.log('Done.');

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3446,13 +3446,20 @@ Rules:
               }
             }
 
-            // Categories: merge with existing
+            // Categories: merge with existing. Canonicalize (lowercase, trim,
+            // spaces → hyphens) so the AI's free-form casing ("Philosophy",
+            // "Natural Philosophy") folds into the curated category ids instead
+            // of drifting into separate buckets that `categories @> [id]` can't
+            // match. Keep in sync with canonicalizeCategory() in src/lib/books-catalog.ts.
             if (parsed.categories?.length > 0) {
-              const existing = book.categories || [];
-              const merged = [...new Set([...existing, ...parsed.categories])];
-              if (merged.length !== existing.length) {
+              const canon = (s) => String(s).toLowerCase().trim().replace(/\s+/g, '-');
+              const existing = (book.categories || []).map(canon);
+              const merged = [...new Set([...existing, ...parsed.categories.map(canon)])].filter(Boolean);
+              const changed = merged.length !== existing.length ||
+                merged.some((c, i) => c !== (book.categories || [])[i]);
+              if (changed) {
                 updates.categories = merged;
-                changes.push({ field: 'categories', previous: existing, new_value: merged });
+                changes.push({ field: 'categories', previous: book.categories || [], new_value: merged });
               }
             }
 

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -10,6 +10,21 @@
 
 import { supabase, supabaseAdmin, sanitizeFilterValue } from '@/lib/supabase';
 
+/**
+ * Canonical form of a category value: lowercase, trimmed, spaces → hyphens.
+ * The curated category ids (LIBRARY_CATEGORIES) are all canonical, but the
+ * AI-assigned `categories` array historically drifted into mixed casings/forms
+ * ("Philosophy", "Natural Philosophy") — and `categories @> [x]` matching is
+ * exact + case-sensitive, so those books silently dropped out of their category
+ * page/search (e.g. ~813 "Freemasonry" books missing from /categories/freemasonry).
+ * Apply this to both the stored values (backfill + write path) and the query
+ * param so they always meet. Keep in sync with the .mjs writer canonicalizer in
+ * scripts/workers/pipeline-orchestrator.mjs.
+ */
+export function canonicalizeCategory(cat: string): string {
+  return cat.toLowerCase().trim().replace(/\s+/g, '-');
+}
+
 export interface CatalogBook {
   id: string;
   slug: string | null;
@@ -127,7 +142,7 @@ export async function browseBooks(opts: {
   if (opts.hasResourceType) query = query.not('resource_type', 'is', null);
   if (opts.language) query = query.eq('language', opts.language);
   if (opts.collection) query = query.contains('collections', [opts.collection]);
-  if (opts.category) query = query.contains('categories', [opts.category]);
+  if (opts.category) query = query.contains('categories', [canonicalizeCategory(opts.category)]);
   if (opts.provider) query = query.eq('image_source_provider', opts.provider);
   if (opts.library === 'bhutan') query = query.ilike('source_url', '%eap.bl.uk%');
   if (opts.firstTranslation) query = query.eq('is_first_translation', true);
@@ -402,7 +417,7 @@ export async function searchBooksCatalog(
     .limit(limit);
 
   if (opts?.language) query = query.eq('language', opts.language);
-  if (opts?.category) query = query.contains('categories', [opts.category]);
+  if (opts?.category) query = query.contains('categories', [canonicalizeCategory(opts.category)]);
   if (opts?.firstTranslation) query = query.eq('is_first_translation', true);
   if (opts?.hasTranslation) query = query.gt('pages_translated', 0);
   if (opts?.library === 'bhutan') query = query.ilike('source_url', '%eap.bl.uk%');
@@ -493,19 +508,32 @@ export async function searchBookIds(
  * Unnests the categories array and counts occurrences.
  */
 export async function getCategoryCounts(): Promise<Map<string, number>> {
-  const { data } = await supabase
-    .from('books_catalog')
-    .select('categories')
-    .eq('visible', true)
-    .gt('pages_count', 0);
-
+  // Paginate — a bare select is capped at 1000 rows by Supabase, which
+  // undercounted every category (philosophy showed 193 of 3,743) and dropped
+  // whole categories whose books all sat past row 1000. Counts are keyed by
+  // canonical form so casing variants fold into one bucket.
   const counts = new Map<string, number>();
-  for (const row of (data || [])) {
-    if (Array.isArray(row.categories)) {
-      for (const cat of row.categories) {
-        counts.set(cat, (counts.get(cat) || 0) + 1);
+  const PAGE = 1000;
+  let from = 0;
+  for (;;) {
+    const { data, error } = await supabase
+      .from('books_catalog')
+      .select('categories')
+      .eq('visible', true)
+      .gt('pages_count', 0)
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`getCategoryCounts failed: ${error.message}`);
+    if (!data || data.length === 0) break;
+    for (const row of data) {
+      if (Array.isArray(row.categories)) {
+        for (const cat of row.categories) {
+          const key = canonicalizeCategory(cat);
+          counts.set(key, (counts.get(key) || 0) + 1);
+        }
       }
     }
+    if (data.length < PAGE) break;
+    from += PAGE;
   }
   return counts;
 }


### PR DESCRIPTION
## Why
While investigating the "search returns no philosophy results" report, the real bug surfaced: the `categories` array drifted into mixed casings/forms (`Philosophy`, `Natural Philosophy`, `Freemasonry`), and category matching is **exact + case-sensitive** everywhere. So books tagged with a non-canonical casing silently dropped out of their category page and category-filtered search.

Measured impact (live data): **`/categories/freemasonry` showed only ~797 of ~2,300 books** — ~1,517 were tagged `Freemasonry` (capitalized) and invisible. `philosophy` (+117), `natural-philosophy` (+104), `theology`, `alchemy`, etc. all affected — ~17k catalog rows carry at least one non-canonical category value.

## Where it surfaced (3 filter paths + 1 count path)
- `browseBooks` (books-catalog.ts) → `/api/books/browse`, `/search?category=` browse mode
- `searchBooksCatalog` (books-catalog.ts) → `/api/search/unified` (text search + category)
- `getCategoryBooks` (categories/[id]/page.tsx) → the `/categories/<id>` page (Mongo)
- `getCategoryCounts` → the `/categories` index counts/badges

## Changes
- **`canonicalizeCategory()`** (lowercase, trim, spaces→hyphens) applied to the category filter param in `browseBooks` + `searchBooksCatalog`, so the curated lowercase-hyphen ids always meet the (now-canonicalized) stored values.
- **`getCategoryCounts()` paginates** — it was capped at 1,000 rows, so every count undercounted (philosophy showed 193 of 3,743) and categories whose books all sat past row 1,000 vanished from the index. Now folds counts by canonical form.
- **Pipeline write path** canonicalizes AI categories before merge, so drift stops re-accumulating.
- **`scripts/maintenance/canonicalize-categories.mjs`** backfills existing Mongo + Supabase data (idempotent; bumps `updated_at` so the catalog sync propagates). **Already run against production** (Mongo source of truth + Supabase mirror).

## Out of scope
- The original "Kant returns nothing" report was not reproducible and isn't a date/author-era bug; this fixes the real adjacent casing/count issues.
- `CategoryPicker.tsx` consumes `/api/categories` but has no importers (dead code) — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)