### PR TITLE
feat(reader): inline deep-zoom on desktop — zoom while reading the translation (#2411)

### DIFF
--- a/src/components/reader/DeepZoomInline.tsx
+++ b/src/components/reader/DeepZoomInline.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+/**
+ * Inline deep-zoom viewer (issue #2411) — an OpenSeadragon tiled canvas that
+ * fills its positioned parent, so a reader can zoom/pan a page scan *in place*
+ * while the translation panel stays visible beside it. Used on desktop; mobile
+ * uses the fullscreen DeepZoomOverlay instead (inline pan/zoom fights the
+ * swipe-between-pages gesture on touch).
+ *
+ * OSD config is kept in sync with components/artwork/DeepZoomOverlay.tsx (the
+ * fullscreen variant) — no crossOriginPolicy (R2 tiles have no ACAO; tainted
+ * canvas is fine for display, see lesson_osd_cors_tainted_canvas) and
+ * maxZoomPixelRatio 1.0 (never magnify past native).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { ZoomIn, ZoomOut, Home, Loader2 } from 'lucide-react';
+import type { DeepZoomManifest } from '@/lib/types/book';
+
+const R2_BASE = 'https://images.sourcelibrary.org';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function tileSourceFor(m: DeepZoomManifest): any {
+  return {
+    Image: {
+      xmlns: 'http://schemas.microsoft.com/deepzoom/2008',
+      Url: `${R2_BASE}/${m.prefix}/`,
+      Format: m.format,
+      Overlap: String(m.overlap),
+      TileSize: String(m.tile_size),
+      Size: { Width: m.width, Height: m.height },
+    },
+  };
+}
+
+export default function DeepZoomInline({ manifest }: { manifest: DeepZoomManifest }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const viewerRef = useRef<any>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let disposed = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let viewer: any;
+    import('openseadragon')
+      .then((mod) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const OpenSeadragon = ((mod as any).default ?? mod) as any;
+        if (disposed || !containerRef.current) return;
+        viewer = OpenSeadragon({
+          element: containerRef.current,
+          tileSources: tileSourceFor(manifest),
+          showNavigationControl: false,
+          showNavigator: false,
+          gestureSettingsMouse: { clickToZoom: false, dblClickToZoom: true, scrollToZoom: true },
+          gestureSettingsTouch: { pinchToZoom: true, flickEnabled: true },
+          animationTime: 0.8,
+          springStiffness: 7,
+          minZoomImageRatio: 0.9,
+          maxZoomPixelRatio: 1.0,
+          visibilityRatio: 1,
+          constrainDuringPan: true,
+          zoomPerScroll: 1.4,
+          immediateRender: false,
+        });
+        viewerRef.current = viewer;
+        viewer.addHandler('open', () => !disposed && setReady(true));
+      })
+      .catch(() => {});
+    return () => {
+      disposed = true;
+      try {
+        viewer?.destroy();
+      } catch {
+        /* noop */
+      }
+      viewerRef.current = null;
+    };
+  }, [manifest]);
+
+  const zoomBy = (f: number) => {
+    const v = viewerRef.current;
+    if (!v) return;
+    v.viewport.zoomBy(f);
+    v.viewport.applyConstraints();
+  };
+  const home = () => viewerRef.current?.viewport.goHome();
+
+  return (
+    <div className="absolute inset-0">
+      <div ref={containerRef} className="absolute inset-0" />
+      {!ready && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-stone-400">
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          <span className="text-xs">Loading deep zoom…</span>
+        </div>
+      )}
+      <div className="absolute bottom-2 left-2 z-10 flex flex-col gap-1.5">
+        <Ctrl label="Zoom in" onClick={() => zoomBy(1.6)}>
+          <ZoomIn className="h-4 w-4" />
+        </Ctrl>
+        <Ctrl label="Zoom out" onClick={() => zoomBy(1 / 1.6)}>
+          <ZoomOut className="h-4 w-4" />
+        </Ctrl>
+        <Ctrl label="Reset view" onClick={home}>
+          <Home className="h-4 w-4" />
+        </Ctrl>
+      </div>
+    </div>
+  );
+}
+
+function Ctrl({ label, onClick, children }: { label: string; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className="flex h-8 w-8 items-center justify-center rounded-md bg-black/55 text-stone-100 transition-colors hover:bg-black/80"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/reader/PageDeepZoomButton.tsx
+++ b/src/components/reader/PageDeepZoomButton.tsx
@@ -1,20 +1,26 @@
 'use client';
 
 /**
- * Self-contained deep-zoom affordance for a book page scan (issue #2411).
+ * Deep-zoom affordance for a book page scan (issue #2411).
  *
- * Renders the "Deep zoom" button and owns its own open/close state + overlay.
- * Kept as a small standalone client component (rather than wiring state into the
- * 2400-line TranslationEditor) so the open-state and the lazily-imported overlay
- * live in one simple, self-contained render — the same shape that works on the
- * artwork hero. Mounting it twice (one per reader layout) is fine; each instance
- * is independent and only one layout is visible at a time.
+ * Desktop: clicking "Deep zoom" turns the image panel itself into a tiled
+ * OpenSeadragon viewer (DeepZoomInline, overlaid on the scan) so the reader can
+ * zoom/pan the page while the translation stays visible beside it. A fullscreen
+ * button escalates to the immersive overlay.
+ *
+ * Mobile: clicking opens the fullscreen DeepZoomOverlay directly — inline
+ * pan/zoom would fight the swipe-between-pages gesture on touch.
+ *
+ * Kept as a small self-contained client component (owns its own open-state +
+ * lazy viewers) rather than wiring state into the 2400-line TranslationEditor —
+ * see memory: inline state there silently failed (reactCompiler + IIFE layout).
  */
 
-import { useState, lazy, Suspense } from 'react';
-import { Search } from 'lucide-react';
+import { useState, useEffect, lazy, Suspense } from 'react';
+import { Search, X, Maximize2 } from 'lucide-react';
 import type { DeepZoomManifest } from '@/lib/types/book';
 
+const DeepZoomInline = lazy(() => import('./DeepZoomInline'));
 const DeepZoomOverlay = lazy(() => import('@/components/artwork/DeepZoomOverlay'));
 
 export default function PageDeepZoomButton({
@@ -24,20 +30,68 @@ export default function PageDeepZoomButton({
   manifest: DeepZoomManifest;
   title: string;
 }) {
-  const [open, setOpen] = useState(false);
+  const [inline, setInline] = useState(false);
+  const [overlay, setOverlay] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(min-width: 1024px)');
+    const update = () => setIsDesktop(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  // Reset when the reader moves to a different page.
+  useEffect(() => {
+    setInline(false);
+    setOverlay(false);
+  }, [manifest]);
+
   return (
     <>
-      <button
-        onClick={() => setOpen(true)}
-        className="absolute top-2 right-2 z-10 flex items-center gap-1.5 px-2.5 py-1.5 bg-black/55 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-colors"
-        title="Open deep zoom — stream this page at full resolution"
-      >
-        <Search className="w-3.5 h-3.5" />
-        Deep zoom
-      </button>
-      {open && (
+      {!inline && (
+        <button
+          onClick={() => (isDesktop ? setInline(true) : setOverlay(true))}
+          className="absolute top-2 right-2 z-10 flex items-center gap-1.5 px-2.5 py-1.5 bg-black/55 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-colors"
+          title="Open deep zoom — stream this page at full resolution"
+        >
+          <Search className="w-3.5 h-3.5" />
+          Deep zoom
+        </button>
+      )}
+
+      {inline && (
+        <div className="absolute inset-0 z-20 bg-[#0d0c0b] rounded-lg overflow-hidden">
+          <Suspense fallback={null}>
+            <DeepZoomInline manifest={manifest} />
+          </Suspense>
+          <button
+            onClick={() => {
+              setInline(false);
+              setOverlay(true);
+            }}
+            title="Fullscreen"
+            aria-label="Fullscreen deep zoom"
+            className="absolute top-2 right-11 z-10 flex h-8 w-8 items-center justify-center rounded-md bg-black/55 text-stone-100 transition-colors hover:bg-black/80"
+          >
+            <Maximize2 className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => setInline(false)}
+            title="Exit deep zoom"
+            aria-label="Exit deep zoom"
+            className="absolute top-2 right-2 z-10 flex h-8 w-8 items-center justify-center rounded-md bg-black/55 text-stone-100 transition-colors hover:bg-black/80"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {overlay && (
         <Suspense fallback={null}>
-          <DeepZoomOverlay manifest={manifest} title={title} onClose={() => setOpen(false)} />
+          <DeepZoomOverlay manifest={manifest} title={title} onClose={() => setOverlay(false)} />
         </Suspense>
       )}
     </>


### PR DESCRIPTION
## What
Addresses the UX gap: deep-zoom shouldn't hide the translation. On **desktop**, clicking Deep zoom now turns the image panel itself into a tiled OpenSeadragon viewer overlaid on the scan, so you zoom/pan the page **in place with the translation still visible beside it**. A fullscreen button escalates to the immersive overlay; an X exits back to the plain scan.

On **mobile**, it still opens the fullscreen overlay — inline pan/zoom fights the swipe-between-pages gesture on touch.

## How
- New `DeepZoomInline` — OSD filling its positioned parent (the image panel), lazy-loaded.
- `PageDeepZoomButton` branches on a `(min-width:1024px)` media query: desktop → inline, mobile → overlay. Resets on page change.
- Lazy-mounted, so OSD only loads when the reader actually zooms — the default page view stays a plain `<img>`.

## Verifying
Browser-tested on desktop (inline viewer mounts, tiles stream, translation stays visible) and mobile width (overlay) before merge — against the confirmed-new build.

## Out of scope
- Folding the old hover-magnifier away on tiled pages (currently both coexist); separate cleanup once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)