### PR TITLE
feat(import): classify text_role at insert (close the import-pipeline gap, #2395)

### DIFF
--- a/scripts/maintenance/classify-text-role.mjs
+++ b/scripts/maintenance/classify-text-role.mjs
@@ -21,9 +21,17 @@
  * Also records `original_in_scan: true` for Loeb/facing-page so the gate knows
  * the original text is already present.
  *
+ * KEEP THE classify() HEURISTIC IN SYNC with src/lib/text-role.ts
+ * `classifyTextRole()`, which runs the same logic at import time so new books
+ * are classified on insert. This script is the catch-all sweep for import paths
+ * that bypass that hook (the direct-insert scripts) and for re-classifying after
+ * metadata enrichment (e.g. once `year` lands). Run `--only-missing` from a cron
+ * to keep the tail classified.
+ *
  * Usage:
  *   set -a; source .env.production.local; set +a; node scripts/maintenance/classify-text-role.mjs --dry-run
- *   node scripts/maintenance/classify-text-role.mjs            # live write
+ *   node scripts/maintenance/classify-text-role.mjs                    # live write, all visible books
+ *   node scripts/maintenance/classify-text-role.mjs --only-missing     # only books with no text_role (cron-friendly)
  *   node scripts/maintenance/classify-text-role.mjs --limit=50 --dry-run
  */
 
@@ -38,6 +46,18 @@ const TRANS_AUTHOR = /\btr(ans)?\.?\b|translated by|;\s*tr\b/i;
 // them is by definition a translation.
 const CLASSICAL = /\b(plato|aristotle|plotinus|proclus|iamblichus|porphyry|plutarch|pythagoras|ptolemy|galen|hippocrates|homer|hesiod|sophocles|euripides|aeschylus|epictetus|marcus aurelius|sextus empiricus|philo|origen|cicero|seneca|virgil|ovid|lucretius|apuleius|boethius|aquinas|avicenna|averroes|al-biruni|al-kindi|maimonides|hermes trismegistus|laozi|lao tzu|confucius|zhuangzi|mencius|xunzi|patanjali|shankara|kabir|rumi|hafiz|sa'di|nagarjuna|padmasambhava)\b/i;
 const LOEB = /\b(loeb|sacred books of the east)\b/i;
+
+// First 4-digit year found across the candidate fields, or NaN. Mirrors
+// coerceYear() in src/lib/text-role.ts — keep in sync.
+function coerceYear(...vals) {
+  for (const v of vals) {
+    if (v == null) continue;
+    if (typeof v === 'number' && v > 0) return v;
+    const m = String(v).match(/\d{4}/);
+    if (m) return Number(m[0]);
+  }
+  return NaN;
+}
 
 function classify(book) {
   // Non-English scan → it's an original-language source.
@@ -58,7 +78,7 @@ function classify(book) {
   // It's a translation. Loeb always counts as modern (original co-present but
   // presented as translation). Otherwise split by era.
   if (loeb) return { role: 'modern-translation', loeb: true };
-  const yr = Number(book.year);
+  const yr = coerceYear(book.year, book.published, book.original_work_year);
   if (yr && yr > 0 && yr < 1700) return { role: 'period-translation', loeb: false };
   return { role: 'modern-translation', loeb: false };
 }
@@ -66,6 +86,7 @@ function classify(book) {
 async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
+  const onlyMissing = args.includes('--only-missing');
   const limit = parseInt(args.find(a => a.startsWith('--limit='))?.split('=')[1] || '0', 10);
 
   if (!process.env.MONGODB_URI) {
@@ -76,9 +97,14 @@ async function main() {
   await client.connect();
   const col = client.db('bookstore').collection('books');
 
+  // --only-missing: classify just the books that have no text_role yet (the
+  // import tail). Default: re-classify all visible books.
+  const query = onlyMissing
+    ? { visible: true, text_role: { $exists: false } }
+    : { visible: true };
   const cursor = col.find(
-    { visible: true },
-    { projection: { _id: 0, id: 1, title: 1, author: 1, year: 1, language: 1, original_language: 1, read_count: 1 } },
+    query,
+    { projection: { _id: 0, id: 1, title: 1, author: 1, year: 1, published: 1, original_work_year: 1, language: 1, original_language: 1, read_count: 1 } },
   );
 
   const dist = { original: 0, 'period-translation': 0, 'modern-translation': 0 };

--- a/src/app/api/import/e-rara/route.ts
+++ b/src/app/api/import/e-rara/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
@@ -281,6 +282,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       updated_at: new Date()
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages

--- a/src/app/api/import/gallica/route.ts
+++ b/src/app/api/import/gallica/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
@@ -196,6 +197,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       updated_at: new Date()
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages

--- a/src/app/api/import/google-books/route.ts
+++ b/src/app/api/import/google-books/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
@@ -221,6 +222,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       updated_at: new Date(),
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages

--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
@@ -328,6 +329,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       updated_at: new Date()
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages

--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
@@ -542,6 +543,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       updated_at: new Date()
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages

--- a/src/app/api/import/loc/route.ts
+++ b/src/app/api/import/loc/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
@@ -280,6 +281,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       updated_at: new Date(),
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages

--- a/src/app/api/import/mdz/route.ts
+++ b/src/app/api/import/mdz/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
@@ -233,6 +234,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       updated_at: new Date()
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages

--- a/src/app/api/import/pdf/route.ts
+++ b/src/app/api/import/pdf/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
@@ -240,6 +241,8 @@ export const POST = withCuratorAuth(async (request) => {
       updated_at: now,
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // 5. Create page records — each page traces back to source PDF

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import fs from 'fs';
@@ -117,6 +118,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       updated_at: new Date()
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages

--- a/src/app/api/import/wellcome/route.ts
+++ b/src/app/api/import/wellcome/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { applyTextRole } from '@/lib/text-role';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
@@ -282,6 +283,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       updated_at: new Date()
     };
 
+    // Classify original-vs-translation at import (issue #2395).
+    applyTextRole(bookDoc as Record<string, unknown>);
     await db.collection('books').insertOne(bookDoc);
 
     // Create pages

--- a/src/lib/import-utils.ts
+++ b/src/lib/import-utils.ts
@@ -9,6 +9,7 @@ import { computeProcessingPriority } from '@/lib/processing-priority';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
 import { resolveLanguage, resolveDate } from '@/lib/resolve-language';
 import { storeImportedManifest } from '@/lib/iiif-manifest-store';
+import { applyTextRole } from '@/lib/text-role';
 
 // IIIF v2 manifest shape (covers most digital library providers)
 export interface IIIFManifest {
@@ -434,6 +435,10 @@ export async function importBookFromIIIF(
   // Publisher/place from IIIF manifest metadata
   if (manifestPublisher) (bookDoc as Record<string, unknown>).publisher = manifestPublisher;
   if (manifestPlace) (bookDoc as Record<string, unknown>).place_of_publication = manifestPlace;
+
+  // Classify original-vs-translation at import (issue #2395) so the book gets a
+  // real text_role immediately instead of the language-proxy fallback.
+  applyTextRole(bookDoc as Record<string, unknown>);
 
   await db.collection('books').insertOne(bookDoc);
 

--- a/src/lib/text-role.ts
+++ b/src/lib/text-role.ts
@@ -21,3 +21,82 @@ export function textRoleRank(textRole?: string | null, language?: string | null)
   if (textRole === 'modern-translation') return 2;
   return language && language !== 'English' ? 0 : 1;
 }
+
+/**
+ * Metadata-only heuristic that assigns a `text_role` at import time, so newly
+ * imported books are classified immediately instead of falling back to the
+ * language proxy (textRoleRank above) until the offline sweep runs.
+ *
+ * KEEP IN SYNC with scripts/maintenance/classify-text-role.mjs `classify()` —
+ * the two must agree, or an import-time classification and the later sweep will
+ * disagree on the same book. The regexes below are copied verbatim from there.
+ * Issue #2395.
+ *
+ * Uses only fields known at insert: language, title, author, original_language,
+ * and a year (from `year`, else parsed from `published` / `original_work_year`).
+ */
+const enLike = (v?: string | null) => !v || /^(english|en)$/i.test(String(v).trim());
+
+const TRANS_TITLE = /transl|englished|rendered into english|done into english|made english|from the (greek|latin|hebrew|arabic|sanskrit|german|french|italian|chinese|tibetan|persian|coptic|aramaic|syriac)|\bloeb\b|sacred books of the east/i;
+const TRANS_AUTHOR = /\btr(ans)?\.?\b|translated by|;\s*tr\b/i;
+const CLASSICAL = /\b(plato|aristotle|plotinus|proclus|iamblichus|porphyry|plutarch|pythagoras|ptolemy|galen|hippocrates|homer|hesiod|sophocles|euripides|aeschylus|epictetus|marcus aurelius|sextus empiricus|philo|origen|cicero|seneca|virgil|ovid|lucretius|apuleius|boethius|aquinas|avicenna|averroes|al-biruni|al-kindi|maimonides|hermes trismegistus|laozi|lao tzu|confucius|zhuangzi|mencius|xunzi|patanjali|shankara|kabir|rumi|hafiz|sa'di|nagarjuna|padmasambhava)\b/i;
+const LOEB = /\b(loeb|sacred books of the east)\b/i;
+
+export type TextRole = 'original' | 'period-translation' | 'modern-translation';
+
+export interface ClassifiableBook {
+  language?: string | null;
+  title?: string | null;
+  author?: string | null;
+  original_language?: string | null;
+  year?: number | string | null;
+  published?: string | null;
+  original_work_year?: number | string | null;
+}
+
+/** First 4-digit year found in the given values, or NaN. */
+function coerceYear(...vals: Array<number | string | null | undefined>): number {
+  for (const v of vals) {
+    if (v == null) continue;
+    if (typeof v === 'number' && v > 0) return v;
+    const m = String(v).match(/\d{4}/);
+    if (m) return Number(m[0]);
+  }
+  return NaN;
+}
+
+export function classifyTextRole(book: ClassifiableBook): { text_role: TextRole; original_in_scan: boolean } {
+  // Non-English scan → original-language source.
+  if (!enLike(book.language)) return { text_role: 'original', original_in_scan: false };
+
+  const t = book.title || '';
+  const a = book.author || '';
+  const sigOrig = book.original_language && !enLike(book.original_language);
+  const sigTitle = TRANS_TITLE.test(t);
+  const sigAuth = TRANS_AUTHOR.test(a);
+  const sigClassical = CLASSICAL.test(a) || CLASSICAL.test(t);
+  const loeb = LOEB.test(t) || LOEB.test(a);
+
+  if (!(sigOrig || sigTitle || sigAuth || sigClassical)) {
+    // English book, no translation signal → English-native original.
+    return { text_role: 'original', original_in_scan: false };
+  }
+  if (loeb) return { text_role: 'modern-translation', original_in_scan: true };
+  const yr = coerceYear(book.year, book.published, book.original_work_year);
+  if (yr && yr > 0 && yr < 1700) return { text_role: 'period-translation', original_in_scan: false };
+  return { text_role: 'modern-translation', original_in_scan: false };
+}
+
+/**
+ * Mutates a book doc in place to set `text_role` (+ `original_in_scan` for
+ * Loeb/facing-page) before insert. `text_role_source: 'import-heuristic-v1'`
+ * marks it as auto-derived at import (distinct from the offline 'heuristic-v1'
+ * sweep) and, like that sweep, still wants human QA before any gate fully
+ * trusts it. Call right before `insertOne`.
+ */
+export function applyTextRole(bookDoc: Record<string, unknown>): void {
+  const { text_role, original_in_scan } = classifyTextRole(bookDoc as ClassifiableBook);
+  bookDoc.text_role = text_role;
+  bookDoc.text_role_source = 'import-heuristic-v1';
+  if (original_in_scan) bookDoc.original_in_scan = true;
+}

--- a/tests/unit/text-role.test.ts
+++ b/tests/unit/text-role.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { classifyTextRole, applyTextRole, textRoleRank } from '@/lib/text-role';
+
+describe('classifyTextRole', () => {
+  it('non-English scan is an original-language source', () => {
+    expect(classifyTextRole({ language: 'German', title: 'Aurora', author: 'Jacob Böhme', year: 1634 }))
+      .toEqual({ text_role: 'original', original_in_scan: false });
+    expect(classifyTextRole({ language: 'Latin', title: 'De Occulta Philosophia', author: 'Agrippa' }).text_role)
+      .toBe('original');
+  });
+
+  it('English book with no translation signal is an English-native original', () => {
+    expect(classifyTextRole({ language: 'English', title: 'The Advancement of Learning', author: 'Francis Bacon', year: 1605 }).text_role)
+      .toBe('original');
+  });
+
+  it('classical author in an English edition is a translation', () => {
+    expect(classifyTextRole({ language: 'English', title: 'The Republic', author: 'Plato', year: 1901 }).text_role)
+      .toBe('modern-translation');
+  });
+
+  it('"translated" / "tr." signals mark a translation', () => {
+    expect(classifyTextRole({ language: 'English', title: 'The Dialogues', author: 'Plato; tr. Benjamin Jowett', year: 1875 }).text_role)
+      .toBe('modern-translation');
+    expect(classifyTextRole({ language: 'English', title: 'A Treatise Translated from the Latin', author: 'Anon', year: 1899 }).text_role)
+      .toBe('modern-translation');
+  });
+
+  it('Loeb / Sacred Books of the East are modern translations with the original in scan', () => {
+    expect(classifyTextRole({ language: 'English', title: 'Moralia (Loeb Classical Library)', author: 'Plutarch', year: 1927 }))
+      .toEqual({ text_role: 'modern-translation', original_in_scan: true });
+    expect(classifyTextRole({ language: 'English', title: 'The Sacred Books of the East: Upanishads', author: 'Max Müller', year: 1879 }).original_in_scan)
+      .toBe(true);
+  });
+
+  it('a pre-1700 translation is a period-translation', () => {
+    expect(classifyTextRole({ language: 'English', title: 'A Discourse Translated from the Latin', author: 'Anon', published: '1620' }).text_role)
+      .toBe('period-translation');
+  });
+
+  it('derives the year from published / original_work_year when year is absent', () => {
+    // pre-1700 → period; same signal but later year → modern
+    expect(classifyTextRole({ language: 'English', title: 'Englished out of the Greek', author: 'Anon', published: 'London, 1599' }).text_role)
+      .toBe('period-translation');
+    expect(classifyTextRole({ language: 'English', title: 'Englished out of the Greek', author: 'Anon', published: 'London, 1899' }).text_role)
+      .toBe('modern-translation');
+  });
+});
+
+describe('applyTextRole', () => {
+  it('mutates the doc with role + provenance', () => {
+    const doc: Record<string, unknown> = { language: 'English', title: 'The Dialogues', author: 'Plato; tr. Jowett', year: 1875 };
+    applyTextRole(doc);
+    expect(doc.text_role).toBe('modern-translation');
+    expect(doc.text_role_source).toBe('import-heuristic-v1');
+  });
+
+  it('sets original_in_scan only for Loeb/facing-page', () => {
+    const loeb: Record<string, unknown> = { language: 'English', title: 'Moralia (Loeb)', author: 'Plutarch', year: 1927 };
+    applyTextRole(loeb);
+    expect(loeb.original_in_scan).toBe(true);
+
+    const plain: Record<string, unknown> = { language: 'German', title: 'Aurora', author: 'Böhme' };
+    applyTextRole(plain);
+    expect(plain.original_in_scan).toBeUndefined();
+  });
+});
+
+describe('textRoleRank fallback (unchanged)', () => {
+  it('ranks by role, falling back to the language proxy when unset', () => {
+    expect(textRoleRank('original')).toBe(0);
+    expect(textRoleRank('modern-translation')).toBe(2);
+    expect(textRoleRank(null, 'Latin')).toBe(0);
+    expect(textRoleRank(null, 'English')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why
The translations-vs-originals system (#2395) classifies every book's `text_role` (`original` / `period-translation` / `modern-translation`) so search and the reader notice can prefer original-language sources over modern English translations standing in for them. But classification only ran via the offline `classify-text-role.mjs` sweep — **newly imported books had no `text_role` until that script was next run**, so they silently fell back to the language proxy (`textRoleRank`), where an unclassified English translation ranks as if it were closer to the source than it is. This closes that gap by classifying at insert.

## What
- **`src/lib/text-role.ts`** — `classifyTextRole(book)` + `applyTextRole(doc)`: a metadata-only port of the maintenance script's heuristic (regexes copied verbatim), using only fields known at insert time (`language`, `title`, `author`, `original_language`, and a year from `year` → `published` → `original_work_year`). Stamps `text_role_source: 'import-heuristic-v1'` to distinguish from the offline `'heuristic-v1'` sweep.
- **Wired before insert** at the IIIF chokepoint (`import-utils.ts`, 15 provider routes) and the 10 inline import routes (`ia`, `google-books`, `e-rara`, `loc`, `iiif`, `pdf`, `gallica`, `mdz`, `wellcome`, base `/import`).
- **`classify-text-role.mjs`** — added `--only-missing` mode (classify just the untagged tail) as the cron-friendly catch-all for the ~31 direct-insert scripts and for re-classification after enrichment fills in `year`; synced its year handling with the TS `coerceYear`. Both files carry a **KEEP IN SYNC** cross-reference.
- **`tests/unit/text-role.test.ts`** — 10 cases (Jowett's Plato, Loeb, Sacred Books of the East, English-native Bacon, pre-1700 period translation, year-from-`published` fallback) covering `classifyTextRole`, `applyTextRole`, and the unchanged rank fallback.

## Coverage
- **API imports (25 routes):** classified synchronously at insert. ✅
- **Direct-insert scripts (~31):** not hooked inline (each builds its own doc); covered by `classify-text-role.mjs --only-missing`, which can be cronned on Hetzner like the FT audit jobs. I did **not** add the cron in this PR — say the word and I'll add it.

## Verification
`npx tsc --noEmit` clean. The 10-case unit test passes. Spot-checked the classifier against known books (Jowett → modern-translation, German scan → original, Loeb/SBE → modern + `original_in_scan`, Bacon → original).

## Out of scope (deliberately)
- Human QA of the heuristic output (issue #2395 acceptance criteria) — unchanged; the import stamp is explicitly marked auto-derived.
- The MCP search demotion surface (the third search codepath) — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)