### PR TITLE
docs(works-catalog): Sanskrit sources, coverage step, Pandit recipe + gotchas (#2453)

### DIFF
--- a/scripts/works-catalog/README.md
+++ b/scripts/works-catalog/README.md
@@ -15,19 +15,43 @@ translation (evidenced claim), and do we hold it.
   (juan/volume range) for multi-volume items.
 - `work_holdings` — our Mongo books mapped to works, with coverage.
 
+## Current state (2026-06-09)
+
+~78.7K works across 7 traditions: tibetan 30.4K, chinese 10.8K, **sanskrit 10.6K**,
+khmer 9.5K, islamicate 8.8K, pali 1.9K. First evidenced **coverage** census
+(Sanskrit pilot): 14.0% of works have a scan, 8.4% have an open transcription.
+
 ## Run order (Hetzner — `SUPABASE_DB_URL` lives there)
 
 ```
-node scripts/works-catalog/apply-schema.mjs        # idempotent DDL
-node scripts/works-catalog/ingest-kanripo.mjs      # ~10.1K Chinese works (Kanseki Repository)
-node scripts/works-catalog/ingest-siku-wikidata.mjs # 3,418 Siku QIDs joined onto kr: works
-node scripts/works-catalog/ingest-openiti.mjs      # ~8.9K Islamicate works (Arabic/Persian)
-node scripts/works-catalog/ingest-bdrc.mjs         # Tibetan works (BUDA linked data; --harvest then --load)
-node scripts/works-catalog/ingest-ia-cadal.mjs     # IA-CADAL scan volumes -> chinese work_sources
-node scripts/works-catalog/build-holdings.mjs      # Mongo books -> work_holdings (title-auto)
+node scripts/works-catalog/apply-schema.mjs           # idempotent DDL
+node scripts/works-catalog/ingest-kanripo.mjs         # ~10.1K Chinese works (Kanseki Repository)
+node scripts/works-catalog/ingest-siku-wikidata.mjs   # 3,418 Siku QIDs joined onto kr: works
+node scripts/works-catalog/ingest-openiti.mjs         # ~8.9K Islamicate works (Arabic/Persian)
+node scripts/works-catalog/ingest-bdrc.mjs            # Tibetan works (BUDA linked data; --harvest then --load)
+node scripts/works-catalog/ingest-ia-cadal.mjs        # IA-CADAL scan volumes -> chinese work_sources
+# Sanskrit spine (#2453, added 2026-06):
+node scripts/works-catalog/ingest-sanskrit-wikidata.mjs  # ~3.9K Sanskrit works (Wikidata P407=Q11059)
+node scripts/works-catalog/ingest-gretil.mjs             # ~891 GRETIL works + transcription work_sources
+node scripts/works-catalog/ingest-pandit.mjs <csv> [--all]  # richest: authors/dates/disciplines (manual CSV — see Pandit note)
+# Coverage join (Phase 1) + provenance + holdings:
+node scripts/works-catalog/match-scans-ia.mjs --tradition=sanskrit --apply  # works <-> IA manifests -> work_sources(scan)
+node scripts/works-catalog/seed-provenance.mjs        # catalog_sources licensing/attribution rows
+node scripts/works-catalog/build-holdings.mjs         # Mongo books -> work_holdings (title-auto)
 ```
 
 All idempotent (upserts). Env: `set -a; source .env.production.local; set +a`.
+
+## Getting Pandit data (panditproject.org — CC-BY-NC-SA, richest Sanskrit authority)
+
+Cloudflare-gated, no API/dump; its CSV export is a broken Drupal batch. Working
+self-serve recipe (from an authenticated **browser**, not curl — TLS-fingerprint blocked):
+1. On the Works search apply a filter — for clean Sanskrit use `field_language[]=45` (=Sanskrit).
+2. Console: `fetch('/search?<filters>&op=do&_format=csv')` (GET only, csv only); parse the batch id from the HTML.
+3. Open `https://panditproject.org/batch?id=<ID>&op=do_nojs` in a NEW TAB — the browser drives the
+   batch via meta-refresh and downloads `YYYY-MM-DD-pandit-entities-export.csv`.
+4. `ingest-pandit.mjs` is column-detecting; `--all` for a language-filtered (pure-Sanskrit) export,
+   default (Sanskrit-script-guard) for mixed/year-filtered exports.
 
 ## Gotchas
 
@@ -38,4 +62,16 @@ All idempotent (upserts). Env: `set -a; source .env.production.local; set +a`.
 - **trgm indexes are on the RAW columns** — query `title_normalized` /
   `title_english` directly, no `lower()` wrapper (ustc_editions lesson).
 - Don't collapse different works; editions/copies are `work_sources` rows,
-  never separate `works` rows for the same work.
+  never separate `works` rows for the same work. (Cross-source work dedup —
+  same work as `wd:`/`gretil:`/`pandit:` rows — is a later catalog pass, #2318.)
+- **Sanskrit scan matching** (`match-scans-ia.mjs`): the catalog uses IAST
+  (Bṛhadāraṇyaka), IA titles use a different romanization (Brihadaranyaka). Bridge
+  with a **consonant skeleton** — strip diacritics + vowels + aspirate-h, collapse
+  the **anusvāra only** (m/n *before a consonant*, not before a vowel, else Mata→Nata),
+  then an 8-consonant block key + full-skeleton prefix filter (kills Gītā↔Mahāpurāṇam
+  collisions). ~90-95% precision; always print the calibration sample before `--apply`.
+- **supabase-js `.select()` caps at 1000 rows** — for `count(distinct work_id)`
+  coverage numbers use a real SQL query (node-pg) on Hetzner, not a JS-side dedup
+  of a capped select.
+- **`translation_status`**: `'none'` (evidenced absence) ≠ `'unknown'` (not checked);
+  a `transcription` work_source is NOT a `translation` — keep the `kind` distinct.


### PR DESCRIPTION
Session closeout docs: run order + Pandit export recipe + matching/coverage gotchas for the works catalog. 🤖 Generated with [Claude Code](https://claude.com/claude-code)