### PR TITLE
fix(proxy): restore provider-prefix 308 redirect (PR #2025 regression)

### DIFF
--- a/src/lib/provider-prefix.ts
+++ b/src/lib/provider-prefix.ts
@@ -1,0 +1,43 @@
+import { LIBRARY_PARTNERS } from '@/lib/library-partners';
+
+/**
+ * Tenant slugs that own real URL space (partner subdomains with scoped UI).
+ * The proxy's path-based tenant resolution is gated on this set; it must
+ * never overlap with the provider-prefix strip below.
+ */
+export const TENANT_ROOT_PATHS = new Set(['bph', 'kloss-collection', 'bhutan']);
+
+/**
+ * Contributing-library slugs that must never claim URL space. Content lives
+ * at tenant-agnostic URLs (/book/..., /gallery/..., /collections/...), but
+ * old provider-prefixed links (/internet-archive/book/foo) are still in
+ * search indexes and AI-chat citations. Derived statically from
+ * LIBRARY_PARTNERS — no DB lookup, and routing tenants are excluded so a
+ * partner that is also a subdomain tenant (kloss-collection) keeps its root.
+ */
+const PROVIDER_PREFIX_SLUGS = new Set(
+  Object.keys(LIBRARY_PARTNERS).filter(slug => !TENANT_ROOT_PATHS.has(slug))
+);
+
+/**
+ * If `pathname` starts with a provider slug, return the pathname it should
+ * 308 to; otherwise null.
+ *
+ *   /internet-archive/book/foo  → /book/foo
+ *   /internet-archive           → /libraries/internet-archive (credit page)
+ *   /bph/...                    → null (routing tenant, untouched)
+ *   /book/foo                   → null (not a provider prefix)
+ *
+ * This re-establishes the PR #2025 safety net that was removed in commit
+ * 8e348991 (it depended on `kind:'provider'` rows in the `tenants` Mongo
+ * collection, which conflicted with tenant resolution). Evidence these links
+ * still get real traffic: not_found_reports logged ~770 provider-prefixed
+ * 404s in the first week of June 2026.
+ */
+export function getProviderPrefixRedirect(pathname: string): string | null {
+  const match = pathname.match(/^\/([a-z0-9-]+)(\/.*)?$/);
+  if (!match) return null;
+  const [, firstSegment, rest] = match;
+  if (!PROVIDER_PREFIX_SLUGS.has(firstSegment)) return null;
+  return rest && rest !== '/' ? rest : `/libraries/${firstSegment}`;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import authorCanonicalRedirects from '@/lib/author-canonical-redirects.json';
+import { getProviderPrefixRedirect, TENANT_ROOT_PATHS } from '@/lib/provider-prefix';
 
 // Precomputed variant-slug → canonical-slug map for /author URL dedup (#2250).
 // Bundled because the proxy runs at the edge with no DB access; regenerate with
@@ -14,8 +15,8 @@ const AUTHOR_CANONICAL_REDIRECTS = authorCanonicalRedirects as Record<string, st
 // .claude/docs/tenant-architecture-migration.md), every other route is a
 // global root — tenant context is supplied by the proxy via x-tenant-* headers
 // when a subdomain or this set matches, and the dynamic [tenant] segment
-// rejects everything else.
-const TENANT_ROOT_PATHS = new Set(['bph', 'kloss-collection', 'bhutan']);
+// rejects everything else. Defined in provider-prefix.ts so the provider
+// strip below stays mutually exclusive with tenant routing.
 
 // Domains that enable the Ficino Society social layer
 const SOCIETY_DOMAINS = [
@@ -639,6 +640,23 @@ export async function proxy(request: NextRequest) {
     }
     // Fall through — the resolution block below picks up the subdomain
     // tenant and stamps x-tenant-* headers on the global route.
+  }
+
+  // --- Source-provider URL strip (PR #2025, restored) ---
+  // Contributing libraries (Internet Archive, Gallica, Bodleian, …) credit
+  // books but never own URL space — content is tenant-agnostic (/book/...,
+  // /gallery/...). Old provider-prefixed links are still indexed and cited,
+  // so 308 them to the global equivalent. Static LIBRARY_PARTNERS lookup,
+  // no DB — the earlier Mongo-backed version (kind:'provider' rows in
+  // `tenants`) was removed in 8e348991 because providers were wrongly
+  // resolving as tenants; this one is keyed off library-partners.ts and
+  // excludes real routing tenants, so the two can't collide. On a tenant
+  // subdomain only the pathname changes, so the redirect stays on-host.
+  const providerRedirectPath = getProviderPrefixRedirect(pathname);
+  if (providerRedirectPath) {
+    const url = request.nextUrl.clone();
+    url.pathname = providerRedirectPath;
+    return NextResponse.redirect(url, 308);
   }
 
   // Tenant-prefix canonicalizers (/{tenant}/book → /book, /{tenant}/collections

--- a/tests/unit/provider-prefix-redirect.test.ts
+++ b/tests/unit/provider-prefix-redirect.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { getProviderPrefixRedirect, TENANT_ROOT_PATHS } from '@/lib/provider-prefix';
+import { LIBRARY_PARTNERS } from '@/lib/library-partners';
+
+// Provider-prefixed content URLs (/internet-archive/book/foo) must 308 to
+// their global equivalent (/book/foo). This safety net shipped in PR #2025,
+// was removed in commit 8e348991 (its Mongo `kind:'provider'` lookup
+// conflicted with tenant resolution), and the regression showed up as ~770
+// provider-prefixed 404s/week in not_found_reports. The redirect is now
+// derived statically from LIBRARY_PARTNERS — these tests guard both the
+// mapping and the proxy wiring so it can't be silently dropped again.
+
+describe('getProviderPrefixRedirect', () => {
+  it('strips a provider prefix from content paths', () => {
+    expect(getProviderPrefixRedirect('/internet-archive/book/the-kybalion')).toBe(
+      '/book/the-kybalion'
+    );
+    expect(getProviderPrefixRedirect('/gallica/gallery/image/abc-0')).toBe(
+      '/gallery/image/abc-0'
+    );
+    expect(
+      getProviderPrefixRedirect('/internet-archive/book/foo/page-number/31')
+    ).toBe('/book/foo/page-number/31');
+  });
+
+  it('sends a bare provider root to its /libraries credit page', () => {
+    expect(getProviderPrefixRedirect('/internet-archive')).toBe(
+      '/libraries/internet-archive'
+    );
+    expect(getProviderPrefixRedirect('/bodleian/')).toBe('/libraries/bodleian');
+  });
+
+  it('never touches routing-tenant URL space', () => {
+    for (const slug of TENANT_ROOT_PATHS) {
+      expect(getProviderPrefixRedirect(`/${slug}`)).toBeNull();
+      expect(getProviderPrefixRedirect(`/${slug}/book/foo`)).toBeNull();
+    }
+  });
+
+  it('ignores non-provider paths', () => {
+    expect(getProviderPrefixRedirect('/book/foo')).toBeNull();
+    expect(getProviderPrefixRedirect('/author/marsilio-ficino')).toBeNull();
+    expect(getProviderPrefixRedirect('/libraries/internet-archive')).toBeNull();
+    expect(getProviderPrefixRedirect('/api/books/123')).toBeNull();
+    expect(getProviderPrefixRedirect('/_next/static/chunks/x.css')).toBeNull();
+    expect(getProviderPrefixRedirect('/')).toBeNull();
+  });
+
+  it('covers every LIBRARY_PARTNERS slug except routing tenants', () => {
+    for (const slug of Object.keys(LIBRARY_PARTNERS)) {
+      const redirect = getProviderPrefixRedirect(`/${slug}/book/foo`);
+      if (TENANT_ROOT_PATHS.has(slug)) {
+        expect(redirect, `${slug} is a routing tenant`).toBeNull();
+      } else {
+        expect(redirect, `${slug} must strip`).toBe('/book/foo');
+      }
+    }
+  });
+});
+
+describe('proxy wiring', () => {
+  it('proxy.ts calls getProviderPrefixRedirect and issues a 308', () => {
+    const src = readFileSync(
+      path.join(path.resolve(__dirname, '../..'), 'src/proxy.ts'),
+      'utf8'
+    );
+    expect(
+      src,
+      'src/proxy.ts must import getProviderPrefixRedirect from @/lib/provider-prefix'
+    ).toMatch(/import\s*\{[^}]*getProviderPrefixRedirect[^}]*\}\s*from\s*['"]@\/lib\/provider-prefix['"]/);
+    const callIdx = src.indexOf('getProviderPrefixRedirect(pathname)');
+    expect(callIdx, 'proxy() must call getProviderPrefixRedirect(pathname)').toBeGreaterThan(-1);
+    expect(
+      src.slice(callIdx, callIdx + 400),
+      'the provider strip must redirect with a 308'
+    ).toMatch(/NextResponse\.redirect\([^)]*,\s*308\)/);
+  });
+});


### PR DESCRIPTION
## What

Restores the provider-prefix safety net from PR #2025: `/internet-archive/book/foo` (and every other contributing-library prefix) 308s to its global equivalent `/book/foo` again. Bare provider roots (`/internet-archive`) now 308 to their `/libraries/<slug>` credit page instead of `/`.

## Why

Commit 8e348991 (May 28) removed the original strip because its Mongo lookup — `kind:'provider'` rows in the `tenants` collection — was causing providers to wrongly resolve as tenants. Removing it regressed the redirect: `not_found_reports` logged **~770 provider-prefixed 404s in the first week of June**, the single largest 404 bucket. These URLs are still in Google's index and cited by AI chats (one hit carried `utm_source=chatgpt.com`), so real readers bounce off dead links ~90×/day.

Verified live before the fix: `https://sourcelibrary.org/internet-archive/book/the-kybalion-a-study-of-the-hermetic-philosophy-of-ancient-initiates` → 404 while the same slug at `/book/...` → 200.

## How

New `src/lib/provider-prefix.ts` derives the redirect set **statically from `LIBRARY_PARTNERS`** (the documented source of truth for contributing libraries) — no DB query per request, and nothing reads the legacy `tenants` provider rows, so the conflict 8e348991 fixed cannot recur. Routing tenants (`bph`/`kloss-collection`/`bhutan`) are excluded by construction; `TENANT_ROOT_PATHS` moves into the new module so the two sets stay mutually exclusive by definition. On tenant subdomains only the pathname changes, so the redirect stays on-host (tenant-lockdown invariant #1 holds).

Tests: pure-function coverage for strip/tenant-exclusion/non-provider paths, an exhaustive sweep over every `LIBRARY_PARTNERS` slug, and a source-level guard that `proxy.ts` actually calls the helper with a 308 — so it can't be silently dropped again.

## Out of scope

- The bare `/book/<slug>/page` 404s (230/week, no route for the segment) — separate concern, separate PR.
- Deleting the 29 legacy `kind:'provider'` rows from the `tenants` collection (CLAUDE.md already marks them as deletion candidates; nothing reads them after this PR, but data deletion needs its own confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)