### PR TITLE
fix(librarian): stop killing follow-ups in long threads; restore chats on back-navigation

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -12,12 +12,19 @@ export const maxDuration = 120;
 
 const messageSchema = z.object({
   role: z.enum(['user', 'assistant']),
-  content: z.string().max(10000), // Allow empty for assistant messages (e.g., choices-only responses)
+  // History is context, not content of record — clip rather than reject. The
+  // Librarian's own answers regularly exceed 10k chars, and the client sends
+  // them back verbatim as history; rejecting here made every follow-up in such
+  // a thread fail with a bare "Invalid request" (the thread looked dead to the
+  // reader). Allow empty for assistant messages (e.g., choices-only responses).
+  content: z.string().transform(s => s.slice(0, 10000)),
 });
 
 const chatRequestSchema = z.object({
   threadId: z.string().nullable().optional(),
-  message: z.string().min(1, 'Message cannot be empty').max(5000, 'Message too long'),
+  message: z.string()
+    .min(1, 'Message cannot be empty')
+    .max(5000, 'That message is too long for the Librarian — please keep it under 5,000 characters, or share the text a section at a time.'),
   history: z.array(messageSchema).max(50).optional(),
   visibility: z.enum(['public', 'private']).optional(),
   stream: z.boolean().optional(),
@@ -65,8 +72,26 @@ export async function POST(request: NextRequest) {
   const body = await request.json();
   const parsed = chatRequestSchema.safeParse(body);
   if (!parsed.success) {
+    const fieldErrors = parsed.error.flatten().fieldErrors;
+    // The client renders `error` verbatim as the Librarian's reply, so it must
+    // read like a sentence, not a status code. Surface the first real issue.
+    const firstIssue = parsed.error.issues[0]?.message;
+    const friendly = firstIssue && firstIssue !== 'Required'
+      ? firstIssue
+      : 'I couldn\'t read that request — please refresh the page and try again.';
+    try {
+      const db = await getDb();
+      await db.collection('embassy_errors').insertOne({
+        kind: 'invalid_request',
+        fieldErrors,
+        messagePreview: typeof body?.message === 'string' ? body.message.slice(0, 500) : null,
+        messageLength: typeof body?.message === 'string' ? body.message.length : null,
+        historyLength: Array.isArray(body?.history) ? body.history.length : null,
+        createdAt: new Date(),
+      });
+    } catch { /* best effort */ }
     return NextResponse.json(
-      { error: 'Invalid request', details: parsed.error.flatten().fieldErrors },
+      { error: friendly, details: fieldErrors },
       { status: 400 },
     );
   }
@@ -136,9 +161,10 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  // Collect full text + sources for DB write
+  // Collect full text + sources + token usage for DB write
   let fullText = '';
   let allSources: SourceCard[] = [];
+  let turnUsage: LibrarianStep['usage'] | null = null;
 
   const saveAiResponse = async () => {
     if (!fullText && allSources.length === 0) return;
@@ -159,6 +185,7 @@ export async function POST(request: NextRequest) {
           snippet: s.snippet,
           inCollection: s.inCollection,
         })),
+        usage: turnUsage,
         createdAt: aiMessageTime,
       });
 
@@ -178,10 +205,21 @@ export async function POST(request: NextRequest) {
           fullText += step.text || '';
         } else if (step.type === 'sources') {
           allSources = step.sources || [];
+        } else if (step.type === 'usage') {
+          turnUsage = step.usage ?? null;
         }
       }
     } catch (err) {
       console.error('[Embassy] Agentic response error:', err);
+      try {
+        await db.collection('embassy_errors').insertOne({
+          kind: 'agent_error',
+          threadId: activeThreadId,
+          message: message.slice(0, 500),
+          error: (err instanceof Error ? `${err.message}\n${err.stack}` : String(err)).slice(0, 5000),
+          createdAt: new Date(),
+        });
+      } catch { /* best effort */ }
       return NextResponse.json(
         { error: 'The Librarian was interrupted. Please try again.' },
         { status: 500 },
@@ -272,6 +310,12 @@ export async function POST(request: NextRequest) {
 
           case 'notebook_update':
             await send({ type: 'notebook_update', notebook: step.notebook });
+            break;
+
+          case 'usage':
+            // Internal accounting only — persisted with the AI message, not
+            // sent to the client.
+            turnUsage = step.usage ?? null;
             break;
         }
       }

--- a/src/app/api/embassy/threads/[id]/route.ts
+++ b/src/app/api/embassy/threads/[id]/route.ts
@@ -27,8 +27,11 @@ export async function GET(
     return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
   }
 
-  // Private threads require auth from the creator
-  if (thread.visibility !== 'public') {
+  // Private threads require auth from the creator. 'unlisted' threads
+  // (anonymous conversations — never surfaced in the Recent feed) stay
+  // readable by anyone holding the id: the chat client restores them via
+  // /librarian?thread=<id> when an anonymous visitor navigates back.
+  if (thread.visibility === 'private') {
     const session = await auth();
     if (!session?.user?.id || thread.creatorId !== session.user.id) {
       return NextResponse.json({ error: 'Thread not found' }, { status: 404 });

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -434,7 +434,14 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
 
               switch (event.type) {
                 case 'threadId':
-                  if (!threadId) setThreadId(event.threadId);
+                  if (!threadId) {
+                    setThreadId(event.threadId);
+                    // Keep the conversation in the URL so browser Back (e.g.
+                    // after following a source link) restores it instead of
+                    // landing on an empty chat. replaceState avoids a Next.js
+                    // navigation; the restore effect reads location directly.
+                    window.history.replaceState(null, '', `${window.location.pathname}?thread=${event.threadId}`);
+                  }
                   break;
 
                 case 'thinking':
@@ -554,6 +561,34 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
     }
   }, [sending, messages.length]);
 
+  // Restore the conversation from ?thread=<id> on mount. The chat otherwise
+  // lives only in component state, so a reader who follows a source link and
+  // presses Back lands on an empty chat and has to re-ask from scratch (the
+  // top complaint in real anonymous sessions — same question re-asked in
+  // fresh threads minutes apart).
+  const threadRestoreAttempted = useRef(false);
+  useEffect(() => {
+    if (threadRestoreAttempted.current) return;
+    threadRestoreAttempted.current = true;
+    const restoreId = new URLSearchParams(window.location.search).get('thread');
+    if (!restoreId) return;
+    fetch(`/api/embassy/threads/${restoreId}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (!data?.messages?.length) return;
+        const restored: Message[] = data.messages.map((m: { authorType: string; content: string; sources?: SourceCard[] }) =>
+          m.authorType === 'human'
+            ? { role: 'user' as const, content: m.content }
+            : { role: 'assistant' as const, content: m.content, sources: m.sources || [], steps: [] },
+        );
+        // Don't clobber a conversation the user already started while the
+        // fetch was in flight.
+        setMessages(prev => (prev.length > 0 ? prev : restored));
+        setThreadId(prev => prev ?? restoreId);
+      })
+      .catch(() => { });
+  }, []);
+
   const pendingChoiceRef = useRef<string | null>(null);
 
   const handleChoiceClick = (choice: string) => {
@@ -583,6 +618,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
     setNotebookFindings([]);
     setNotebookTopic(undefined);
     setNotebookOpen(false);
+    window.history.replaceState(null, '', window.location.pathname);
     inputRef.current?.focus();
   };
 

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -67,7 +67,7 @@ export interface ResearchNotebook {
 }
 
 export interface LibrarianStep {
-  type: 'thinking' | 'tool_call' | 'tool_result' | 'choices' | 'text' | 'sources' | 'notebook_update';
+  type: 'thinking' | 'tool_call' | 'tool_result' | 'choices' | 'text' | 'sources' | 'notebook_update' | 'usage';
   text?: string;
   name?: string;
   query?: string;
@@ -76,6 +76,9 @@ export interface LibrarianStep {
   options?: string[];
   descriptions?: (string | undefined)[];
   sources?: SourceCard[];
+  // Token accounting for the whole turn (all agent rounds summed). Emitted
+  // last and persisted on the AI message; never rendered to the user.
+  usage?: TurnUsage;
   notebook?: {
     findingCount: number;
     topic?: string;
@@ -91,6 +94,15 @@ export interface LibrarianStep {
       pageNumber: number;
     };
   };
+}
+
+export interface TurnUsage {
+  model: string;
+  rounds: number;
+  promptTokens: number;
+  outputTokens: number;
+  thinkingTokens: number;
+  cachedTokens: number;
 }
 
 interface ConversationMessage {
@@ -781,6 +793,7 @@ export async function* streamAgenticResponse(
   // page citations in the final answer — see verifyCitations.
   const retrievedPageKeys = new Set<string>();
   let choicesPresented = false;
+  const usage: TurnUsage = { model: MODEL, rounds: 0, promptTokens: 0, outputTokens: 0, thinkingTokens: 0, cachedTokens: 0 };
 
   function collectSources(sources?: SourceCard[]) {
     if (!sources) return;
@@ -807,8 +820,13 @@ export async function* streamAgenticResponse(
     const allParts: Array<Record<string, unknown>> = [];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const functionCalls: Array<any> = [];
+    // usageMetadata is cumulative within one generateContentStream call —
+    // keep the last chunk's value, then sum across rounds.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let roundUsage: any = null;
 
     for await (const chunk of stream) {
+      if (chunk.usageMetadata) roundUsage = chunk.usageMetadata;
       const candidate = chunk.candidates?.[0];
       if (!candidate?.content?.parts) continue;
       for (const part of candidate.content.parts) {
@@ -821,6 +839,14 @@ export async function* streamAgenticResponse(
           yield { type: 'text', text: p.text };
         }
       }
+    }
+
+    usage.rounds++;
+    if (roundUsage) {
+      usage.promptTokens += roundUsage.promptTokenCount ?? 0;
+      usage.outputTokens += roundUsage.candidatesTokenCount ?? 0;
+      usage.thinkingTokens += roundUsage.thoughtsTokenCount ?? 0;
+      usage.cachedTokens += roundUsage.cachedContentTokenCount ?? 0;
     }
 
     if (allParts.length === 0) break;
@@ -914,6 +940,8 @@ export async function* streamAgenticResponse(
       text: `\n\n---\n*A note on sourcing: this answer contains ${clauses.join('; and ')}.*`,
     };
   }
+
+  yield { type: 'usage', usage };
 }
 
 /**

--- a/tests/integration/embassy-api.test.ts
+++ b/tests/integration/embassy-api.test.ts
@@ -43,6 +43,7 @@ vi.mock('@/lib/mongodb', async () => {
 // Import route handlers
 import { POST as chatPost } from '@/app/api/embassy/chat/route';
 import { GET as threadsGet } from '@/app/api/embassy/threads/route';
+import { GET as threadDetailGet } from '@/app/api/embassy/threads/[id]/route';
 import { GET as roomsGet, POST as roomsPost } from '@/app/api/embassy/rooms/route';
 
 function makeRequest(url: string, body?: object): Request {
@@ -134,6 +135,46 @@ describe('Embassy API', () => {
 
       const res = await chatPost(req as any);
       expect(res.status).toBe(400);
+    });
+
+    it('clips oversized history instead of rejecting the follow-up', async () => {
+      // The Librarian's own answers can exceed 10k chars; the client sends
+      // them back verbatim as history. Rejecting made every follow-up in such
+      // a thread fail with "Invalid request" — the thread looked dead.
+      const db = getTestDb();
+      await db.collection('users').insertOne({
+        _id: new ObjectId(TEST_USER_ID),
+        name: 'Test User',
+      });
+
+      const req = makeRequest('/api/embassy/chat', {
+        message: 'And where can I read that book?',
+        history: [
+          { role: 'user', content: 'Tell me about Jung' },
+          { role: 'assistant', content: 'x'.repeat(12000) },
+        ],
+      });
+
+      const res = await chatPost(req as any);
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects an overlong message with a human-readable error and logs it', async () => {
+      const req = makeRequest('/api/embassy/chat', {
+        message: 'x'.repeat(5001),
+      });
+
+      const res = await chatPost(req as any);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      // The client renders this string verbatim as the Librarian's reply.
+      expect(data.error).toMatch(/too long/i);
+
+      const logged = await getTestDb()
+        .collection('embassy_errors')
+        .findOne({ kind: 'invalid_request' });
+      expect(logged).toBeTruthy();
+      expect(logged!.messageLength).toBe(5001);
     });
 
     it('continues an existing thread', async () => {
@@ -283,6 +324,57 @@ describe('Embassy API', () => {
       const data = await res.json();
 
       expect(data.threads).toHaveLength(0);
+    });
+  });
+
+  describe('GET /api/embassy/threads/[id]', () => {
+    it('returns unlisted (anonymous) threads to anyone holding the id', async () => {
+      // The chat client restores anonymous conversations via
+      // /librarian?thread=<id> after back-navigation — unlisted means
+      // "not in the Recent feed", not "creator-only".
+      const db = getTestDb();
+      const threadId = new ObjectId();
+      await db.collection('embassy_threads').insertOne({
+        _id: threadId,
+        type: 'chat',
+        title: 'Anon question',
+        creatorId: null,
+        creatorName: 'A visitor',
+        visibility: 'unlisted',
+        messageCount: 2,
+        createdAt: new Date(),
+        lastMessageAt: new Date(),
+      });
+      await db.collection('embassy_messages').insertMany([
+        { threadId, authorType: 'human', authorName: 'A visitor', content: 'Where do I start with Jung?', createdAt: new Date() },
+        { threadId, authorType: 'ai', authorName: 'The Librarian', content: 'Start with the Red Book.', sources: [], createdAt: new Date() },
+      ]);
+
+      const req = makeRequest(`/api/embassy/threads/${threadId}`);
+      const res = await threadDetailGet(req as any, { params: Promise.resolve({ id: threadId.toString() }) });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.messages).toHaveLength(2);
+    });
+
+    it('still hides private threads from non-creators', async () => {
+      const db = getTestDb();
+      const threadId = new ObjectId();
+      await db.collection('embassy_threads').insertOne({
+        _id: threadId,
+        type: 'chat',
+        title: 'Private research',
+        creatorId: 'someone-else',
+        creatorName: 'Scholar',
+        visibility: 'private',
+        messageCount: 2,
+        createdAt: new Date(),
+        lastMessageAt: new Date(),
+      });
+
+      const req = makeRequest(`/api/embassy/threads/${threadId}`);
+      const res = await threadDetailGet(req as any, { params: Promise.resolve({ id: threadId.toString() }) });
+      expect(res.status).toBe(404);
     });
   });
 


### PR DESCRIPTION
## What

Three fixes for real-reader failure modes found by triaging production `embassy_threads` / `embassy_messages`:

1. **Follow-ups after a long answer died with a bare "Invalid request".** The Librarian's answers regularly exceed 10k chars (3 in the last 30 days); the client sends them back verbatim as history, and `messageSchema` rejected any history item over 10k — every follow-up in such a thread 400'd, the client rendered the raw `Invalid request` string as the Librarian's reply, and the thread looked dead. One visitor re-asked the same Jung question 4× in fresh threads. History is context, not content of record: it's now **clipped to 10k instead of rejected**. Overlong *messages* (>5k) still 400 but return a sentence a reader can act on.

2. **Back-navigation lost the conversation** (direct user feedback: "click on one link, go there, wanna go back… but that part is not stored, so I have to make the original query again"). The thread id now lives in the URL (`/librarian?thread=<id>`) via `replaceState`, and `LibrarianClient` restores the conversation from `GET /api/embassy/threads/[id]` on mount. Unlisted (anonymous) threads are now readable by anyone holding the id — unlisted means "not in the Recent feed", not "creator-only". Private threads stay creator-only (test pins this).

3. **Failures and cost were invisible.** Validation 400s now log to `embassy_errors` (`kind: invalid_request`), the non-stream agent path logs `agent_error` like the stream path already did, and per-turn Gemini token usage (prompt/output/thinking/cached, summed across agent rounds, with model name) is persisted on each AI message — so cache-hit rate and per-conversation cost become measurable instead of estimated.

## Out of scope (deliberately)

- Prompt reordering for implicit-cache friendliness (the per-turn `messageIndex`/notebook block sits near the top of the system prompt and breaks the cacheable prefix) — worth doing once usage data confirms the hit rate, separate PR.
- Any UI for the restored-thread state beyond the chat itself (sidebar, sharing).

## Tests

- `tests/integration/embassy-api.test.ts`: +4 cases — oversized history accepted, overlong message returns human-readable error + logs to `embassy_errors`, unlisted thread readable by id, private thread still 404s for non-creators. 14/14 pass.
- Full unit suite 306/306; `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)