### PR TITLE
feat(health): surface 404 reports and librarian errors/usage in the daily health check

### DIFF
--- a/.claude/handoffs/2026-06-10-librarian-fixes-404-followups.md
+++ b/.claude/handoffs/2026-06-10-librarian-fixes-404-followups.md
@@ -1,0 +1,61 @@
+# Librarian fixes + 404-triage follow-ups closed (2026-06-10)
+
+Continuation of `2026-06-10-404-log-triage-provider-strip.md`. All shipped
+the same session.
+
+## Librarian (Embassy chat) — PR #2508, merged + deployed
+
+Production conversation triage found ~1/3 of anonymous sessions re-asking
+the same question in fresh threads. Two causes, both fixed:
+
+1. **Dead threads after long answers.** Librarian answers exceed 10k chars;
+   client sends them back as history; `messageSchema` rejected >10k history
+   items → every follow-up 400'd and the client rendered the raw
+   `"Invalid request"` as the Librarian's reply. History is now clipped via
+   zod `.transform`, not rejected. Overlong *messages* (>5k) still 400 with
+   a human-readable sentence (the client renders `err.error` verbatim —
+   any new 400 in that route must read like a sentence).
+2. **Back-navigation lost the chat** (direct user feedback). Thread id now
+   lives at `/librarian?thread=<id>` via `replaceState`; LibrarianClient
+   restores from `GET /api/embassy/threads/[id]` on mount. That GET now
+   serves `unlisted` (anonymous) threads to anyone with the id; `private`
+   still requires creator auth.
+
+Also: per-turn Gemini token usage persisted on each AI message
+(`embassy_messages.usage`: model/rounds/prompt/output/thinking/cached) and
+agent errors logged from the non-stream path too. Known but unfixed:
+system prompt embeds `messageIndex` + notebook near the top → cross-turn
+implicit cache ≈ 0; revisit once a week of usage data exists.
+
+## 404-triage follow-ups
+
+- **29 legacy `kind:'provider'` tenants rows DELETED** (Derek-approved).
+  Backup: `scripts/output/tenants-provider-rows-backup-2026-06-10.json`
+  (main checkout, untracked). 5 rows remain (all/bph/kloss-collection/
+  default/bhutan). Verified post-delete: BPH home, provider 308s,
+  homepage, embed book all 200. CLAUDE.md §"Source Library is the
+  destination" point 4 updated.
+- **BPH catalog leak (catalog/2666 → chymische-hochzeit) self-resolved** —
+  404s ran 2026-05-29 → 06-05; today catalog, embed book, and both slug
+  variants are 200. Residual provider-prefix/embed 404 *reports* through
+  06-10 were stale CDN-cached 404 HTML from before the morning purge
+  (origin 308s verified). Lesson: a not_found_report timestamp is when a
+  *cached page* was viewed, not necessarily a live route failure — curl
+  origin before chasing.
+- **Real gap found while verifying:** `/embed/<tenant>/book/<slug>/page-number/<n>`
+  had no route (global side has one) → PR #2510, mirrors the global 308
+  handler with tenant scoping; redirect stays on the embed path.
+- **Health email now reads the write-only logs** → PR #2509:
+  `checks.not_found_404s` (24h vs prev-24h, top URLs/prefixes, warns on
+  spike ≥600 or ≥300+2× day-over-day) and `checks.librarian`
+  (embassy_errors by kind, turns, avg tokens, cached-token share). Both
+  cap at `warning`. The 07:00 routine summarizes whatever this endpoint
+  returns, so no routine change needed.
+- Still pending: `/author/*` 404 re-count ~2026-06-16 (spot-checks resolve
+  since the thesaurus read-path).
+
+## CLAUDE.md check
+
+Done — tenants point 4 updated in this PR. No new invariant needed; the
+quote/snippet and tenant-lockdown sections already cover the touched
+surfaces.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,10 +121,12 @@ encodes that:
 4. **The `tenants` Mongo collection is for subdomain partners, not for
    contributing libraries.** Subdomain tenants (`bph`, `kloss-collection`,
    `bhutan`) have their own scoped UI under a partner subdomain. The 29
-   provider rows that also live there are legacy from when routing tried to
-   double as an attribution registry — they're no longer used for routing
-   after PR #2025 and are candidates for deletion. New contributing libraries
-   go in `LIBRARY_PARTNERS`, not in the `tenants` collection.
+   legacy `kind:'provider'` rows (from when routing doubled as an attribution
+   registry) were **deleted on 2026-06-10** — backup at
+   `scripts/output/tenants-provider-rows-backup-2026-06-10.json` in Derek's
+   main checkout. Don't recreate them (`create-all-provider-tenants.mjs` is
+   the legacy writer — don't run it). New contributing libraries go in
+   `LIBRARY_PARTNERS`, not in the `tenants` collection.
 
 ## Author identity — the `authors` thesaurus (read this before touching author code)
 "Who wrote this, and is *this* Andreas the same as *that* Andreas?" is answered by the canonical **`authors`** collection — one doc per person, `_id` = canonical slug, with `variants[]` / `variant_slugs[]` / `viaf_id` / `wikidata_id`. It **supersedes** the legacy `entities` layer. Umbrella issue #2179.

--- a/src/app/api/admin/health/route.ts
+++ b/src/app/api/admin/health/route.ts
@@ -78,6 +78,8 @@ export const GET = withAdminAuth(async () => {
   // --- Run remaining checks in parallel ---
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
   const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000);
+  const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
 
   const [
     activeJobs,
@@ -88,6 +90,9 @@ export const GET = withAdminAuth(async () => {
     sqsDepths,
     recentCronRuns,
     supabaseSync,
+    notFound404s,
+    librarianErrors,
+    librarianTurns,
   ] = await Promise.all([
     // Active Lambda jobs
     db.collection('jobs').aggregate([
@@ -162,6 +167,60 @@ export const GET = withAdminAuth(async () => {
 
     // Supabase sync health
     getSupabaseSyncHealth().catch(() => null),
+
+    // 404 reports: last 24h vs previous 24h, plus top URL buckets.
+    // not_found_reports is otherwise write-only — the provider-prefix strip
+    // regression (8e348991, ~770 404s/week) sat unnoticed for two weeks
+    // because nothing read it. A day-over-day spike here is the alarm.
+    db.collection('not_found_reports').aggregate([
+      { $match: { created_at: { $gte: twoDaysAgo } } },
+      { $facet: {
+        last24h: [
+          { $match: { created_at: { $gte: oneDayAgo } } },
+          { $group: { _id: null, hits: { $sum: { $ifNull: ['$hit_count', 1] } } } },
+        ],
+        prev24h: [
+          { $match: { created_at: { $lt: oneDayAgo } } },
+          { $group: { _id: null, hits: { $sum: { $ifNull: ['$hit_count', 1] } } } },
+        ],
+        topUrls: [
+          { $match: { created_at: { $gte: oneDayAgo } } },
+          { $group: { _id: '$url', hits: { $sum: { $ifNull: ['$hit_count', 1] } } } },
+          { $sort: { hits: -1 } },
+          { $limit: 10 },
+        ],
+        topPrefixes: [
+          { $match: { created_at: { $gte: oneDayAgo } } },
+          { $group: {
+            _id: { $arrayElemAt: [{ $split: ['$url', '/'] }, 1] },
+            hits: { $sum: { $ifNull: ['$hit_count', 1] } },
+          } },
+          { $sort: { hits: -1 } },
+          { $limit: 8 },
+        ],
+      } },
+    ], { maxTimeMS: 10000 }).toArray().catch(() => null),
+
+    // Librarian errors by kind (last 24h) — embassy_errors was also
+    // write-only until 2026-06-10.
+    db.collection('embassy_errors').aggregate([
+      { $match: { createdAt: { $gte: oneDayAgo } } },
+      { $group: { _id: '$kind', count: { $sum: 1 } } },
+    ], { maxTimeMS: 10000 }).toArray().catch(() => null),
+
+    // Librarian turns + token usage (last 24h) — usage is persisted per AI
+    // message since PR #2508; this is the cost/cache-hit trend line.
+    db.collection('embassy_messages').aggregate([
+      { $match: { authorType: 'ai', createdAt: { $gte: oneDayAgo } } },
+      { $group: {
+        _id: null,
+        turns: { $sum: 1 },
+        promptTokens: { $sum: { $ifNull: ['$usage.promptTokens', 0] } },
+        outputTokens: { $sum: { $ifNull: ['$usage.outputTokens', 0] } },
+        cachedTokens: { $sum: { $ifNull: ['$usage.cachedTokens', 0] } },
+        turnsWithUsage: { $sum: { $cond: [{ $gt: ['$usage.promptTokens', 0] }, 1, 0] } },
+      } },
+    ], { maxTimeMS: 10000 }).toArray().catch(() => null),
   ]);
 
   // --- 2. Active jobs ---
@@ -258,6 +317,59 @@ export const GET = withAdminAuth(async () => {
     checks.supabase_sync = { ...supabaseSync } as CheckResult;
   } else {
     checks.supabase_sync = { status: 'warning', error: 'sync_health RPC unavailable' };
+  }
+
+  // --- 10. 404 reports (last 24h vs previous 24h) ---
+  if (notFound404s?.[0]) {
+    const nf = notFound404s[0] as {
+      last24h: Array<{ hits: number }>;
+      prev24h: Array<{ hits: number }>;
+      topUrls: Array<{ _id: string; hits: number }>;
+      topPrefixes: Array<{ _id: string | null; hits: number }>;
+    };
+    const last24h = nf.last24h[0]?.hits || 0;
+    const prev24h = nf.prev24h[0]?.hits || 0;
+    // Baseline is ~200/day. Warn on a genuine spike, not normal jitter:
+    // doubling day-over-day above a 300-hit floor, or 600+ outright.
+    const spiking = last24h >= 600 || (last24h >= 300 && last24h > prev24h * 2);
+    checks.not_found_404s = {
+      status: spiking ? 'warning' : 'ok',
+      last_24h: last24h,
+      prev_24h: prev24h,
+      top_urls: nf.topUrls.map(u => ({ url: u._id, hits: u.hits })),
+      top_prefixes: nf.topPrefixes.map(p => ({ prefix: `/${p._id ?? ''}`, hits: p.hits })),
+    };
+  } else {
+    checks.not_found_404s = { status: 'warning', error: '404-report query failed' };
+  }
+
+  // --- 11. Librarian (embassy chat) errors + usage (last 24h) ---
+  {
+    const errByKind: Record<string, number> = {};
+    for (const e of (librarianErrors || []) as Array<{ _id: string; count: number }>) {
+      errByKind[e._id || 'unknown'] = e.count;
+    }
+    const totalLibErrors = Object.values(errByKind).reduce((a, b) => a + b, 0);
+    const turns = (librarianTurns?.[0] || null) as {
+      turns: number; promptTokens: number; outputTokens: number;
+      cachedTokens: number; turnsWithUsage: number;
+    } | null;
+    const turnCount = turns?.turns || 0;
+    checks.librarian = {
+      // Errors on a meaningful share of turns = something is broken for
+      // real readers, not a one-off.
+      status: totalLibErrors > Math.max(5, turnCount * 0.2) ? 'warning' : 'ok',
+      errors_24h: totalLibErrors,
+      errors_by_kind: errByKind,
+      turns_24h: turnCount,
+      ...(turns && turns.turnsWithUsage > 0 ? {
+        avg_prompt_tokens: Math.round(turns.promptTokens / turns.turnsWithUsage),
+        avg_output_tokens: Math.round(turns.outputTokens / turns.turnsWithUsage),
+        cached_token_share: turns.promptTokens > 0
+          ? Math.round((turns.cachedTokens / turns.promptTokens) * 1000) / 10 + '%'
+          : '0%',
+      } : {}),
+    };
   }
 
   // --- Overall health ---


### PR DESCRIPTION
## What

Adds two check sections to `GET /api/admin/health` (which the 07:00 daily health routine reads), turning two write-only collections into regression alarms:

- **`not_found_404s`** — last-24h vs previous-24h hit totals from `not_found_reports`, top 10 URLs, top 8 first-path-segment buckets. Warns on a genuine spike (≥600/day, or ≥300 with day-over-day doubling; baseline is ~200/day). This is the check that would have caught the provider-prefix strip regression (8e348991, ~770 404s/week, unnoticed for two weeks) in a day.
- **`librarian`** — `embassy_errors` counts by kind over 24h (warns when errors exceed 20% of turns), turns/24h, and average prompt/output tokens + cached-token share from the per-message usage persisted since #2508. This is the librarian cost/cache-hit trend line.

Both sections cap at `warning` (never `critical` — a 404 spike shouldn't read as "site down") and swallow their own query failures so observability can't break the health check itself.

## Verification

- Aggregations dry-run against production data: 464 hits last 24h vs 273 prior; top prefixes `/book` `/author` `/default` `/internet-archive`. (The `/internet-archive` entries are stale CDN-cached 404 HTML from before today's purge — origin 308s correctly, confirmed by curl.)
- `npx tsc --noEmit` clean; unit suite 306/306.

## Out of scope

- An admin dashboard over `not_found_reports` (the daily email covers the alarm case).
- Changing the alert routine itself — it summarizes whatever this endpoint returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)