### PR TITLE
fix(health): a deliberate pause is not unhealthy

### DIFF
--- a/src/app/api/admin/health/route.ts
+++ b/src/app/api/admin/health/route.ts
@@ -374,7 +374,10 @@ export const GET = withAdminAuth(async () => {
 
   // --- Overall health ---
   const hasAnyCritical = Object.values(checks).some(c => c.status === 'critical');
-  const healthy = !hasAnyCritical && !paused;
+  // A deliberate pause is an operator choice, not an incident — the system is
+  // healthy, just paused. The pause stays visible as the system_paused
+  // warning above; only critical checks flip the overall flag.
+  const healthy = !hasAnyCritical;
 
   return NextResponse.json({
     healthy,


### PR DESCRIPTION
One-liner: `healthy` flipped false whenever `processing_control.paused` was set, so a deliberate operator pause (on since 2026-06-08) read as an incident in the daily 07:00 health email. The pause stays fully visible as the `system_paused` warning check; only `critical` checks now flip the overall flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)