### PR TITLE
feat(cite): include original imprint (place, publisher, year) in citation output

### DIFF
--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
-import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
+import { getRequestBaseUrl } from '@/lib/shortlinks';
+import { Citation, generateCitations } from '@/lib/citations';
 import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
@@ -9,18 +10,6 @@ import { resolveTenantId } from '@/lib/tenant-context';
 
 interface RouteContext {
   params: Promise<{ tenant: string; id: string }>;
-}
-
-interface Citation {
-  inline: string;           // (Drebbel 1628, p. 15)
-  footnote: string;         // Full footnote citation
-  bibliography: string;     // Bibliography entry
-  bibtex: string;           // BibTeX format
-  chicago: string;          // Chicago style
-  mla: string;              // MLA style
-  url: string;              // Direct link to page in Source Library
-  short_url: string;        // Shortlink for sharing (e.g., Twitter)
-  doi_url?: string;         // Clickable DOI URL
 }
 
 interface QuoteResponse {
@@ -45,89 +34,6 @@ interface QuoteResponse {
   context?: {
     previous_page?: string;
     next_page?: string;
-  };
-}
-
-function formatAccessedDate(): string {
-  const d = new Date();
-  const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
-  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
-}
-
-function generateCitations(
-  book: Book,
-  pageNumber: number,
-  bookId: string,
-  pageId: string,
-  baseUrl: string,
-  edition?: TranslationEdition
-): Citation {
-  const year = book.published || 'n.d.';
-  const author = book.author || 'Unknown';
-  const title = book.display_title || book.title;
-  const doi = edition?.doi || book.doi;
-  const doiUrl = doi ? `https://doi.org/${doi}` : undefined;
-  const accessed = formatAccessedDate();
-  const translationYear = edition?.published_at
-    ? new Date(edition.published_at).getFullYear()
-    : new Date().getFullYear();
-
-  // Clean author name (remove extra spaces, handle "Lastname, Firstname")
-  const authorParts = author.split(',').map(s => s.trim());
-  const authorLastFirst = authorParts.length === 2
-    ? `${authorParts[0]}, ${authorParts[1]}`
-    : author;
-  const authorFirstLast = authorParts.length === 2
-    ? `${authorParts[1]} ${authorParts[0]}`
-    : author;
-
-  // Inline citation
-  const inline = `(${authorParts[0]} ${year}, p. ${pageNumber})`;
-
-  // Footnote (Chicago style note)
-  const footnote = `${authorFirstLast}, ${title}, trans. Source Library (${translationYear}), ${pageNumber}${doi ? `. DOI: ${doi}` : ''}.`;
-
-  // Bibliography entry
-  const bibliography = `${authorLastFirst}. ${title}. Translated by Source Library. ${translationYear}.${doi ? ` DOI: ${doi}.` : ` Accessed ${accessed}.`}`;
-
-  // BibTeX
-  const bibtexKey = `${authorParts[0].toLowerCase().replace(/[^a-z]/g, '')}${year}`;
-  const bibtex = `@book{${bibtexKey},
-  author = {${authorLastFirst}},
-  title = {${title}},
-  year = {${year}},
-  translator = {Source Library},
-  note = {Translation published ${translationYear}}${doi ? `,
-  doi = {${doi}},
-  url = {${doiUrl}}` : ''}
-}`;
-
-  // Chicago (Author-Date)
-  const chicago = `${authorLastFirst}. ${year}. ${title}. Translated by Source Library. ${translationYear}.${doi ? ` ${doiUrl}.` : ` Accessed ${accessed}.`}`;
-
-  // MLA
-  const mla = `${authorLastFirst}. ${title}. Translated by Source Library, ${translationYear}.${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
-
-  // Direct URL to page in Source Library (pinned to edition version).
-  // baseUrl is the request host so citations rendered on tenant subdomains
-  // (e.g. bph.sourcelibrary.org) link back to the same subdomain.
-  const editionVersion = edition?.version;
-  const vParam = editionVersion ? `?v=${editionVersion}` : '';
-  const url = `${baseUrl}/book/${bookId}/page/${pageId}${vParam}`;
-
-  // Short URL for sharing
-  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);
-
-  return {
-    inline,
-    footnote,
-    bibliography,
-    bibtex,
-    chicago,
-    mla,
-    url,
-    short_url,
-    doi_url: doiUrl,
   };
 }
 

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
-import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
+import { getRequestBaseUrl } from '@/lib/shortlinks';
+import { Citation, generateCitations } from '@/lib/citations';
 import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
@@ -9,18 +10,6 @@ import { withApiAuth } from '@/lib/api-auth';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
-}
-
-interface Citation {
-  inline: string;           // (Drebbel 1628, p. 15)
-  footnote: string;         // Full footnote citation
-  bibliography: string;     // Bibliography entry
-  bibtex: string;           // BibTeX format
-  chicago: string;          // Chicago style
-  mla: string;              // MLA style
-  url: string;              // Direct link to page in Source Library
-  short_url: string;        // Shortlink for sharing (e.g., Twitter)
-  doi_url?: string;         // Clickable DOI URL
 }
 
 interface QuoteResponse {
@@ -45,89 +34,6 @@ interface QuoteResponse {
   context?: {
     previous_page?: string;
     next_page?: string;
-  };
-}
-
-function formatAccessedDate(): string {
-  const d = new Date();
-  const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
-  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
-}
-
-function generateCitations(
-  book: Book,
-  pageNumber: number,
-  bookId: string,
-  pageId: string,
-  baseUrl: string,
-  edition?: TranslationEdition
-): Citation {
-  const year = book.published || 'n.d.';
-  const author = book.author || 'Unknown';
-  const title = book.display_title || book.title;
-  const doi = edition?.doi || book.doi;
-  const doiUrl = doi ? `https://doi.org/${doi}` : undefined;
-  const accessed = formatAccessedDate();
-  const translationYear = edition?.published_at
-    ? new Date(edition.published_at).getFullYear()
-    : new Date().getFullYear();
-
-  // Clean author name (remove extra spaces, handle "Lastname, Firstname")
-  const authorParts = author.split(',').map(s => s.trim());
-  const authorLastFirst = authorParts.length === 2
-    ? `${authorParts[0]}, ${authorParts[1]}`
-    : author;
-  const authorFirstLast = authorParts.length === 2
-    ? `${authorParts[1]} ${authorParts[0]}`
-    : author;
-
-  // Inline citation
-  const inline = `(${authorParts[0]} ${year}, p. ${pageNumber})`;
-
-  // Footnote (Chicago style note)
-  const footnote = `${authorFirstLast}, ${title}, trans. Source Library (${translationYear}), ${pageNumber}${doi ? `. DOI: ${doi}` : ''}.`;
-
-  // Bibliography entry
-  const bibliography = `${authorLastFirst}. ${title}. Translated by Source Library. ${translationYear}.${doi ? ` DOI: ${doi}.` : ` Accessed ${accessed}.`}`;
-
-  // BibTeX
-  const bibtexKey = `${authorParts[0].toLowerCase().replace(/[^a-z]/g, '')}${year}`;
-  const bibtex = `@book{${bibtexKey},
-  author = {${authorLastFirst}},
-  title = {${title}},
-  year = {${year}},
-  translator = {Source Library},
-  note = {Translation published ${translationYear}}${doi ? `,
-  doi = {${doi}},
-  url = {${doiUrl}}` : ''}
-}`;
-
-  // Chicago (Author-Date)
-  const chicago = `${authorLastFirst}. ${year}. ${title}. Translated by Source Library. ${translationYear}.${doi ? ` ${doiUrl}.` : ` Accessed ${accessed}.`}`;
-
-  // MLA
-  const mla = `${authorLastFirst}. ${title}. Translated by Source Library, ${translationYear}.${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
-
-  // Direct URL to page in Source Library (pinned to edition version).
-  // baseUrl is derived from the request host so quotes returned from
-  // tenant subdomains link back to the same subdomain.
-  const editionVersion = edition?.version;
-  const vParam = editionVersion ? `?v=${editionVersion}` : '';
-  const url = `${baseUrl}/book/${bookId}/page/${pageId}${vParam}`;
-
-  // Short URL for sharing
-  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);
-
-  return {
-    inline,
-    footnote,
-    bibliography,
-    bibtex,
-    chicago,
-    mla,
-    url,
-    short_url,
-    doi_url: doiUrl,
   };
 }
 

--- a/src/components/ui/CiteButton.tsx
+++ b/src/components/ui/CiteButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Quote, Copy, Check } from 'lucide-react';
+import { formatImprint } from '@/lib/citations';
 
 function getRuntimeOrigin(): string {
   if (typeof window !== 'undefined' && window.location?.origin) {
@@ -84,7 +85,7 @@ function formatAccessedDate(): string {
 }
 
 function generateApa(props: CiteButtonProps, origin: string): string {
-  const { author, title, displayTitle, year, doi, bookId, pageNumber, editionVersion } = props;
+  const { author, title, displayTitle, year, publisher, placePublished, doi, pageNumber, editionVersion } = props;
   const url = buildCitableUrl(props, origin);
   const displayName = displayTitle || title;
   const yearStr = year || 'n.d.';
@@ -92,15 +93,18 @@ function generateApa(props: CiteButtonProps, origin: string): string {
   const version = editionVersion ? `, v${editionVersion}` : '';
   const page = pageNumber ? `, p. ${pageNumber}` : '';
   const accessed = formatAccessedDate();
+  const imprint = formatImprint(placePublished, publisher);
 
   if (doi) {
-    return `${authorStr}. ${displayName}, trans. Source Library (${yearStr})${version}${page}. https://doi.org/${doi}`;
+    return imprint
+      ? `${authorStr}. ${displayName} (${imprint}, ${yearStr}), trans. Source Library${version}${page}. https://doi.org/${doi}`
+      : `${authorStr}. ${displayName}, trans. Source Library (${yearStr})${version}${page}. https://doi.org/${doi}`;
   }
-  return `${authorStr}. (${yearStr}). ${displayName}. Source Library${page}. Retrieved ${accessed}, from ${url}`;
+  return `${authorStr}. (${yearStr}). ${displayName}.${imprint ? ` ${imprint}.` : ''} Source Library${page}. Retrieved ${accessed}, from ${url}`;
 }
 
 function generateBibtex(props: CiteButtonProps, origin: string): string {
-  const { author, title, year, doi, language, pageNumber, editionVersion } = props;
+  const { author, title, year, publisher, placePublished, doi, language, pageNumber, editionVersion } = props;
   const authorStr = author || 'Anonymous';
 
   const authorKey = authorStr.split(',')[0].split(' ').pop()?.toLowerCase().replace(/[^a-z]/g, '') || 'unknown';
@@ -115,7 +119,8 @@ function generateBibtex(props: CiteButtonProps, origin: string): string {
     `  translator = {{Source Library}},`,
   ];
   if (year) lines.push(`  year = {${year}},`);
-  lines.push(`  publisher = {Source Library},`);
+  lines.push(`  publisher = {${publisher || 'Source Library'}},`);
+  if (placePublished) lines.push(`  address = {${placePublished}},`);
   if (editionVersion) lines.push(`  edition = {${editionVersion}},`);
   if (language) lines.push(`  language = {${language}},`);
   if (doi) lines.push(`  doi = {${doi}},`);

--- a/src/lib/citations.ts
+++ b/src/lib/citations.ts
@@ -1,0 +1,119 @@
+import { Book, TranslationEdition } from '@/lib/types';
+import { getShortUrl } from '@/lib/shortlinks';
+
+export interface Citation {
+  inline: string;           // (Drebbel 1628, p. 15)
+  footnote: string;         // Full footnote citation
+  bibliography: string;     // Bibliography entry
+  bibtex: string;           // BibTeX format
+  chicago: string;          // Chicago style
+  mla: string;              // MLA style
+  url: string;              // Direct link to page in Source Library
+  short_url: string;        // Shortlink for sharing (e.g., Twitter)
+  doi_url?: string;         // Clickable DOI URL
+}
+
+function formatAccessedDate(): string {
+  const d = new Date();
+  const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
+}
+
+/**
+ * Original imprint for citation use: "Hamburg: Frobenius" / "Hamburg" / "Frobenius".
+ * Empty string when neither place nor publisher is recorded.
+ */
+export function formatImprint(place?: string | null, publisher?: string | null): string {
+  const p = place?.trim();
+  const pub = publisher?.trim();
+  if (p && pub) return `${p}: ${pub}`;
+  return p || pub || '';
+}
+
+export function generateCitations(
+  book: Book,
+  pageNumber: number,
+  bookId: string,
+  pageId: string,
+  baseUrl: string,
+  edition?: TranslationEdition
+): Citation {
+  const year = book.published || 'n.d.';
+  const author = book.author || 'Unknown';
+  const title = book.display_title || book.title;
+  const doi = edition?.doi || book.doi;
+  const doiUrl = doi ? `https://doi.org/${doi}` : undefined;
+  const accessed = formatAccessedDate();
+  const translationYear = edition?.published_at
+    ? new Date(edition.published_at).getFullYear()
+    : new Date().getFullYear();
+  const imprint = formatImprint(book.place_published, book.publisher);
+
+  // Clean author name (remove extra spaces, handle "Lastname, Firstname")
+  const authorParts = author.split(',').map(s => s.trim());
+  const authorLastFirst = authorParts.length === 2
+    ? `${authorParts[0]}, ${authorParts[1]}`
+    : author;
+  const authorFirstLast = authorParts.length === 2
+    ? `${authorParts[1]} ${authorParts[0]}`
+    : author;
+
+  // Inline citation
+  const inline = `(${authorParts[0]} ${year}, p. ${pageNumber})`;
+
+  // Footnote (Chicago style note) — original imprint in parentheses
+  const footnote = imprint
+    ? `${authorFirstLast}, ${title} (${imprint}, ${year}), trans. Source Library (${translationYear}), ${pageNumber}${doi ? `. DOI: ${doi}` : ''}.`
+    : `${authorFirstLast}, ${title}, trans. Source Library (${translationYear}), ${pageNumber}${doi ? `. DOI: ${doi}` : ''}.`;
+
+  // Bibliography entry
+  const bibliography = imprint
+    ? `${authorLastFirst}. ${title}. ${imprint}, ${year}. Translated by Source Library. ${translationYear}.${doi ? ` DOI: ${doi}.` : ` Accessed ${accessed}.`}`
+    : `${authorLastFirst}. ${title}. Translated by Source Library. ${translationYear}.${doi ? ` DOI: ${doi}.` : ` Accessed ${accessed}.`}`;
+
+  // BibTeX — original imprint in publisher/address, Source Library as translator
+  const bibtexKey = `${authorParts[0].toLowerCase().replace(/[^a-z]/g, '')}${year}`;
+  const bibtex = `@book{${bibtexKey},
+  author = {${authorLastFirst}},
+  title = {${title}},
+  year = {${year}},${book.publisher ? `
+  publisher = {${book.publisher}},` : ''}${book.place_published ? `
+  address = {${book.place_published}},` : ''}
+  translator = {Source Library},
+  note = {Translation published ${translationYear}}${doi ? `,
+  doi = {${doi}},
+  url = {${doiUrl}}` : ''}
+}`;
+
+  // Chicago (Author-Date)
+  const chicago = imprint
+    ? `${authorLastFirst}. ${year}. ${title}. ${imprint}. Translated by Source Library. ${translationYear}.${doi ? ` ${doiUrl}.` : ` Accessed ${accessed}.`}`
+    : `${authorLastFirst}. ${year}. ${title}. Translated by Source Library. ${translationYear}.${doi ? ` ${doiUrl}.` : ` Accessed ${accessed}.`}`;
+
+  // MLA
+  const mla = imprint
+    ? `${authorLastFirst}. ${title}. ${imprint}, ${year}. Translated by Source Library, ${translationYear}.${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`
+    : `${authorLastFirst}. ${title}. Translated by Source Library, ${translationYear}.${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
+
+  // Direct URL to page in Source Library (pinned to edition version).
+  // baseUrl is derived from the request host so quotes returned from
+  // tenant subdomains link back to the same subdomain.
+  const editionVersion = edition?.version;
+  const vParam = editionVersion ? `?v=${editionVersion}` : '';
+  const url = `${baseUrl}/book/${bookId}/page/${pageId}${vParam}`;
+
+  // Short URL for sharing
+  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);
+
+  return {
+    inline,
+    footnote,
+    bibliography,
+    bibtex,
+    chicago,
+    mla,
+    url,
+    short_url,
+    doi_url: doiUrl,
+  };
+}


### PR DESCRIPTION
## Why

Footer feedback from Derek (2026-06-04, on /book/drebbel-tractatus-duo-1628-latin-laurembergius): **"put the bibliographic info in the cite info."**

Citations generated by the Cite button and the quote API credited only "Source Library" as publisher and silently dropped the original imprint (place of publication, printer, year) — the bibliographic data scholars actually need to identify the edition.

## What

- **New `src/lib/citations.ts`** — shared `generateCitations()` + `formatImprint()`. The global (`/api/books/[id]/quote`) and tenant (`/api/[tenant]/books/[id]/quote`) routes each had a byte-identical private copy of the citation generator — the same duplication pattern that caused the #2420 quote-surface drift. Both now import the shared module.
- **All citation formats** (inline APA, Chicago footnote, bibliography, Chicago author-date, MLA, BibTeX) now include `Place: Publisher, Year` when the book records an imprint. BibTeX emits proper `publisher`/`address` fields with Source Library kept as `translator`.
- **CiteButton** already received `publisher`/`placePublished` props from both call sites (book page, TranslationEditor) but never used them — now both APA and BibTeX outputs include them.
- Graceful degradation: books with no imprint data produce the exact same citation text as before.

## Out of scope

- Shelfmark / holding-institution attribution in citations (per-book provenance stays in BibliographicInfo).
- The quote API's `license.attribution` block — unchanged.

## Testing

- `npx tsc --noEmit` clean; all 206 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)