### PR TITLE
fix(artwork): eliminate flicker when paging between artworks

### DIFF
--- a/src/components/artwork/ArtworkHero.tsx
+++ b/src/components/artwork/ArtworkHero.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, lazy, Suspense } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import ImageWithMagnifier from '@/components/ui/ImageWithMagnifier';
 import { ZoomIn, Maximize, Minimize, ChevronLeft, ChevronRight, Search } from 'lucide-react';
 import type { DeepZoomManifest } from '@/lib/types/book';
@@ -29,13 +30,11 @@ interface ArtworkHeroProps {
 }
 
 export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullResUrl, license, isLandscape, prevWork, nextWork, institution, deepZoom }: ArtworkHeroProps) {
+  const router = useRouter();
   const [fitWidth, setFitWidth] = useState(false);
   const [showChrome, setShowChrome] = useState(true);
   const [zoomOpen, setZoomOpen] = useState(false);
   const hasThumb = !!thumbUrl && thumbUrl !== imageUrl;
-  const hasHiRes = !!hiResUrl && hiResUrl !== imageUrl;
-  const [medReady, setMedReady] = useState(!hasThumb);
-  const [hiResReady, setHiResReady] = useState(false);
 
   // Auto-hide chrome after 3s
   useEffect(() => {
@@ -43,40 +42,18 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
     return () => clearTimeout(timer);
   }, []);
 
-  // Background-load medium blob
-  useEffect(() => {
-    if (!hasThumb) return;
-    const img = new window.Image();
-    img.onload = () => setMedReady(true);
-    img.src = imageUrl;
-  }, [hasThumb, imageUrl]);
-
-  // Background-load hi-res after medium is ready
-  useEffect(() => {
-    if (!medReady || !hasHiRes) return;
-    const img = new window.Image();
-    img.onload = () => setHiResReady(true);
-    img.src = hiResUrl!;
-  }, [medReady, hasHiRes, hiResUrl]);
-
-  const displaySrc = hiResReady && hiResUrl ? hiResUrl
-    : medReady ? imageUrl
-    : thumbUrl || imageUrl;
-
-  const magnifierSrc = hiResReady && hiResUrl ? hiResUrl : imageUrl;
-
-  // Keyboard navigation
+  // Keyboard navigation — client-side, same as the chevron Links
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'ArrowLeft' && prevWork) {
-        window.location.href = `/artwork/${prevWork.slug}`;
+        router.push(`/artwork/${prevWork.slug}`);
       } else if (e.key === 'ArrowRight' && nextWork) {
-        window.location.href = `/artwork/${nextWork.slug}`;
+        router.push(`/artwork/${nextWork.slug}`);
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [prevWork, nextWork]);
+  }, [prevWork, nextWork, router]);
 
   const captionText = [institution, license].filter(Boolean).join(' · ');
 
@@ -86,15 +63,21 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
       onMouseEnter={() => setShowChrome(true)}
       onMouseLeave={() => setShowChrome(false)}
     >
-      {/* Image container — viewport-height by default, natural proportions */}
+      {/* Image container — viewport-height by default, natural proportions.
+          src stays stable across the thumb→medium upgrade: ImageWithMagnifier
+          shows `thumbnail` immediately and decode-then-swaps to `src` without
+          a flash. Changing `src` mid-view resets its loaded state (black
+          "Loading..." blink) — that was the flicker on prev/next paging.
+          The fixed height keeps the upscaled thumb the same size as the
+          medium image, so the swap doesn't jump the layout either. */}
       <div className="flex items-center justify-center" style={{ minHeight: fitWidth ? undefined : 'calc(100vh - 64px)' }}>
           <ImageWithMagnifier
-            src={displaySrc}
-            thumbnail={displaySrc}
-            highResSrc={magnifierSrc}
+            src={imageUrl}
+            thumbnail={hasThumb ? thumbUrl : imageUrl}
+            highResSrc={hiResUrl || undefined}
             alt={title}
             className={`${fitWidth ? 'w-full' : ''} mx-auto`}
-            imgClassName={fitWidth ? 'w-full' : 'max-h-[calc(100vh-64px)]'}
+            imgClassName={fitWidth ? 'w-full' : 'h-[calc(100vh-64px)] object-contain'}
             magnifierSize={240}
             zoomLevel={3}
             darkMode

--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -131,12 +131,14 @@ export default function ImageWithMagnifier({
 
     if (!naturalWidth || !naturalHeight) return { width: rect.width, height: rect.height };
 
-    if (scrollable || imgClassName) {
-      // No object-contain — element box = content area
+    // Without object-contain the element box IS the content area; with it,
+    // the content may be letterboxed inside the box (custom imgClassName
+    // included — callers like ArtworkHero pass object-contain explicitly).
+    const usesObjectContain = imgClassName ? imgClassName.includes('object-contain') : !scrollable;
+    if (!usesObjectContain) {
       return { width: rect.width, height: rect.height };
     }
 
-    // Non-scrollable with object-contain: content may be smaller than element box
     const containerAspect = rect.width / rect.height;
     const imageAspect = naturalWidth / naturalHeight;
 
@@ -145,7 +147,7 @@ export default function ImageWithMagnifier({
     } else {
       return { width: rect.height * imageAspect, height: rect.height };
     }
-  }, [scrollable]);
+  }, [scrollable, imgClassName]);
 
   useEffect(() => {
     const updateDimensions = () => {


### PR DESCRIPTION
## Problem
Paging prev/next on artwork pages (e.g. https://sourcelibrary.org/artwork/art-signorelli-battesimo-di-ges) was very flickery.

## Root cause
`ArtworkHero` ran its own thumb → medium → hi-res progressive load by **swapping the `src` prop** on `ImageWithMagnifier`. That component treats any `src` change as a page navigation: it resets `isLoaded`, hides the image behind the black "Loading..." skeleton, and re-fades it in over 300ms. So every artwork view blinked twice (medium swap, hi-res swap) on top of the real loads. The internal "progressive upgrade shouldn't flash" guard in `ImageWithMagnifier` was defeated because the upgrade happened one level up, and `thumbnail={displaySrc}` disabled the component's own seamless decode-then-swap path.

A second issue: the inline `<img>` was sized with `max-h-*`, so the small thumb rendered at its tiny natural size and the layout jumped when the medium image landed.

## Fix
- **ArtworkHero**: stable `src={imageUrl}` + `thumbnail={thumbUrl}` — the component's existing decode-then-swap handles thumb→medium with no flash and no state reset. Hi-res now feeds the magnifier lens / fullscreen / touch open (loaded on first hover) instead of being swapped into the inline display — we no longer download the multi-MB `-full.jpg` just to show it at viewport size.
- **Thumb sizing**: inline image gets `h-[calc(100vh-64px)] object-contain`, so the upscaled thumb occupies exactly the same box as the medium image — no layout jump at swap time.
- **Keyboard nav**: arrow keys use `router.push` instead of `window.location.href` (was a full page reload; the chevron `<Link>`s were already client-side).
- **ImageWithMagnifier**: the rendered-content-size math now recognizes `object-contain` inside a custom `imgClassName` (and tracks `imgClassName` in its `useCallback` deps), keeping magnifier lens coordinates accurate with the new classes and after toggling fit-width.

## Out of scope
`ImageWithMagnifier`'s reset-on-src-change behavior itself is unchanged — the reader still relies on it for real page turns. Only the artwork hero stopped abusing it for progressive upgrades.

## Verification
- `npx tsc --noEmit` clean.
- Verify on the Vercel preview: page through prev/next on an artwork — image should blur-up once (thumb→sharp) with no black blink and no size jump; hover magnifier should still track the cursor correctly in both fit modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)