### PR TITLE
fix(art-collections): hidden-work leak, wrong count, collection-scoped prev/next

### DIFF
--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -26,73 +26,76 @@ async function getArtwork(slug: string) {
   // Get collections this artwork belongs to
   const collectionSlugs = (artwork.collections as string[]) || [];
 
-  // Scope prev/next navigation to the artwork's collection when it has one — so the
-  // arrows walk that set in order (e.g. the 49 hashika-e measles prints). This matters
-  // most for collections of anonymous works, where author-scoping would otherwise wander
-  // through every "Anonymous" artwork in the library. Falls back to same-artist when the
-  // work isn't in any collection — but NOT for generic/placeholder author values
-  // ("Various", "Unknown", "Anonymous", …), where same-author scoping would walk through
-  // hundreds of unrelated works (e.g. ~160 author:"Various" prints). In that case we
-  // suppress prev/next entirely: no arrows is better than jumping to something unrelated.
+  // Scope prev/next navigation to the artwork's collections — so the arrows walk
+  // that set in order (e.g. the 49 hashika-e measles prints). One pair is computed
+  // per collection the work belongs to: the page is statically rendered, so it
+  // can't read the ?from=<collection> param a visitor arrived with — ArtworkHero
+  // picks the matching pair client-side, defaulting to the first collection's pair.
+  // Falls back to same-artist when the work isn't in any collection — but NOT for
+  // generic/placeholder author values ("Various", "Unknown", "Anonymous", …), where
+  // same-author scoping would walk through hundreds of unrelated works (e.g. ~160
+  // author:"Various" prints). In that case we suppress prev/next entirely: no
+  // arrows is better than jumping to something unrelated.
   const GENERIC_AUTHOR = /^\s*(various|unknown|unidentified|unattributed|anonymous|anon|n\.?\s*a\.?)\s*$/i;
   const hasUsableAuthor =
     typeof artwork.author === 'string' && artwork.author.trim() !== '' && !GENERIC_AUTHOR.test(artwork.author);
-  const navScope: Record<string, unknown> | null =
-    collectionSlugs.length > 0
-      ? { collections: collectionSlugs[0] }
-      : hasUsableAuthor
-      ? { author: artwork.author }
-      : null;
 
-  // Get prev/next works (chronologically by published date, then title). When navScope
-  // is null (no collection + generic author) we skip the queries so no arrows render.
-  const [collections, prevWorkRaw, nextWorkRaw] = await Promise.all([
+  // Prev/next within a scope, chronologically by published date, then title.
+  // visible: true keeps the arrows off hidden works.
+  const navNeighbor = (scope: Record<string, unknown>, dir: 'prev' | 'next') =>
+    db.collection('books').findOne(
+      {
+        ...scope,
+        resource_type: { $exists: true },
+        content_type: { $ne: 'book' },
+        visible: true,
+        $or: dir === 'prev'
+          ? [
+              { published: { $lt: artwork.published || '' } },
+              { published: artwork.published || '', title: { $lt: artwork.title } },
+            ]
+          : [
+              { published: { $gt: artwork.published || '' } },
+              { published: artwork.published || '', title: { $gt: artwork.title } },
+            ],
+      },
+      {
+        projection: { slug: 1, title: 1, display_title: 1 },
+        sort: dir === 'prev' ? { published: -1, title: -1 } : { published: 1, title: 1 },
+      }
+    ).then(doc => (doc ? { slug: doc.slug as string, title: (doc.display_title || doc.title) as string } : null));
+
+  const navCollections = collectionSlugs.slice(0, 4);
+  const useAuthorScope = navCollections.length === 0 && hasUsableAuthor;
+  const [collections, authorPrev, authorNext, ...collectionPairs] = await Promise.all([
     collectionSlugs.length > 0
       ? db.collection('collections')
           .find({ slug: { $in: collectionSlugs } })
           .project({ _id: 0, slug: 1, name: 1, subtitle: 1, color: 1 })
           .toArray()
       : Promise.resolve([]),
-    // Previous: earlier in sort order within scope
-    navScope
-      ? db.collection('books').findOne(
-          {
-            ...navScope,
-            resource_type: { $exists: true },
-            content_type: { $ne: 'book' },
-            $or: [
-              { published: { $lt: artwork.published || '' } },
-              { published: artwork.published || '', title: { $lt: artwork.title } },
-            ],
-          },
-          { projection: { slug: 1, title: 1, display_title: 1 }, sort: { published: -1, title: -1 } }
-        )
-      : Promise.resolve(null),
-    // Next: later in sort order within scope
-    navScope
-      ? db.collection('books').findOne(
-          {
-            ...navScope,
-            resource_type: { $exists: true },
-            content_type: { $ne: 'book' },
-            $or: [
-              { published: { $gt: artwork.published || '' } },
-              { published: artwork.published || '', title: { $gt: artwork.title } },
-            ],
-          },
-          { projection: { slug: 1, title: 1, display_title: 1 }, sort: { published: 1, title: 1 } }
-        )
-      : Promise.resolve(null),
+    useAuthorScope ? navNeighbor({ author: artwork.author }, 'prev') : Promise.resolve(null),
+    useAuthorScope ? navNeighbor({ author: artwork.author }, 'next') : Promise.resolve(null),
+    ...navCollections.flatMap(colSlug => [
+      navNeighbor({ collections: colSlug }, 'prev'),
+      navNeighbor({ collections: colSlug }, 'next'),
+    ]),
   ]);
 
-  const prevWork = prevWorkRaw ? { slug: prevWorkRaw.slug, title: prevWorkRaw.display_title || prevWorkRaw.title } : null;
-  const nextWork = nextWorkRaw ? { slug: nextWorkRaw.slug, title: nextWorkRaw.display_title || nextWorkRaw.title } : null;
+  const navByCollection: Record<string, { prev: { slug: string; title: string } | null; next: { slug: string; title: string } | null }> = {};
+  navCollections.forEach((colSlug, i) => {
+    navByCollection[colSlug] = { prev: collectionPairs[i * 2], next: collectionPairs[i * 2 + 1] };
+  });
+
+  // Default pair when no ?from= context: first collection, else same-artist.
+  const defaultNav = navCollections.length > 0 ? navByCollection[navCollections[0]] : { prev: authorPrev, next: authorNext };
 
   return {
     artwork: JSON.parse(JSON.stringify(artwork)) as Book,
     collections: collections as { slug: string; name: string; subtitle?: string; color?: string }[],
-    prevWork,
-    nextWork,
+    prevWork: defaultNav.prev,
+    nextWork: defaultNav.next,
+    navByCollection,
   };
 }
 
@@ -109,6 +112,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: `${artwork.display_title || artwork.title} — ${artwork.author} — Source Library`,
     description: (artwork as any).commons_description?.slice(0, 200) || `${artwork.title} by ${artwork.author}`,
+    // ?from=<collection> nav-context URLs must not index as duplicates
+    alternates: { canonical: `/artwork/${artwork.slug || slug}` },
     robots: { index: true, follow: true },
     openGraph: {
       title: `${artwork.display_title || artwork.title} by ${artwork.author}`,
@@ -125,7 +130,7 @@ export default async function ArtworkPage({ params }: PageProps) {
   return (
     <div className="min-h-screen" style={{ background: 'var(--bg-cream)' }}>
       <SiteHeader variant="light" />
-      <ArtworkInfo book={data.artwork} collections={data.collections} prevWork={data.prevWork} nextWork={data.nextWork} />
+      <ArtworkInfo book={data.artwork} collections={data.collections} prevWork={data.prevWork} nextWork={data.nextWork} navByCollection={data.navByCollection} />
     </div>
   );
 }

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -16,7 +16,7 @@ import SignUpCTA from '@/components/auth/SignUpCTA';
 import { bookUrl, tenantBookUrl } from '@/lib/slugify';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
-import { bookTitle, sanitizeThumbnail, withTimeout } from '@/lib/collections-utils';
+import { ART_EXCLUDED_RESOURCE_TYPES, bookTitle, sanitizeThumbnail, withTimeout } from '@/lib/collections-utils';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import { browseBooks } from '@/lib/books-catalog';
@@ -344,10 +344,24 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     .map((m: { book_id: string }) => m.book_id)
     .filter(Boolean);
 
-  // Use cached book_count — syncCollectionCounts in scripts/workers/sync-worker.mjs
-  // (Hetzner, every 2h) updates this to reflect only translated books
-  // (pages_translated > 0). The old Vercel sync-page-counts cron is archived.
-  const total = collection.book_count || 0;
+  // Art collections share one canonical filter with the manifest API
+  // (/api/collections/[id]?mode=manifest) — keep them in sync or the
+  // server-rendered grid and the expanded grid show different works.
+  const artFilter = {
+    collections: id,
+    resource_type: { $exists: true, $nin: ART_EXCLUDED_RESOURCE_TYPES },
+    visible: true,
+  };
+
+  // book_count is cached by syncCollectionCounts in scripts/workers/sync-worker.mjs
+  // (Hetzner, every 2h) and reflects only translated books (pages_translated > 0) —
+  // meaningless for visual_art collections, whose items are artworks. Count those live.
+  const total = isArtCollection
+    ? await withTimeout(
+      db.collection('books').countDocuments(artFilter, { maxTimeMS: 8000 }),
+      8000, collection.artwork_count || 0,
+    )
+    : collection.book_count || 0;
 
   // Track gallery collection slug for linking (captured in the gallery query below)
   let galleryCollectionSlug: string | null = null;
@@ -360,7 +374,7 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     ? withTimeout(
       db.collection('books')
         .find(
-          { collections: id, resource_type: { $exists: true } },
+          { collections: id, resource_type: { $exists: true }, visible: true },
           {
             projection: {
               _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, published: 1,
@@ -381,18 +395,13 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
   // Books query: Supabase primary (fast), MongoDB fallback (has collection_scores
   // but Atlas multiplanner timeouts cause 10-15s delays or 500s).
   async function fetchBooksWithFallback() {
-    // Art collections: use MongoDB directly to sort by image resolution.
-    // Exclude photographs, modern reproductions, and museum object photos.
+    // Art collections: use MongoDB directly, curated rank first then image
+    // resolution — same filter and sort as the manifest API.
     if (isArtCollection) {
-      const EXCLUDED_TYPES = ['photograph', 'object', 'sculpture', 'architectural', 'decorative', 'ritual-object'];
-      const artFilter = {
-        collections: id,
-        resource_type: { $exists: true, $nin: EXCLUDED_TYPES },
-      };
       const docs = await withTimeout(
         db.collection('books')
           .find(artFilter, { projection, maxTimeMS: 8000 })
-          .sort({ commons_width: -1 })
+          .sort({ [`art_collection_rank.${id}`]: -1, commons_width: -1 })
           .limit(COMPACT_LIMIT)
           .toArray(),
         15000, [],
@@ -1097,7 +1106,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                 return (
                   <Link
                     key={art.id}
-                    href={`/artwork/${art.slug || art.id}`}
+                    href={`/artwork/${art.slug || art.id}?from=${id}`}
                     className="group block"
                   >
                     <div className="rounded-lg border border-border-light hover:border-accent-rust/40 hover:shadow-lg transition-[border-color,box-shadow] overflow-hidden bg-white">

--- a/src/components/artwork/ArtworkHero.tsx
+++ b/src/components/artwork/ArtworkHero.tsx
@@ -24,11 +24,13 @@ interface ArtworkHeroProps {
   isLandscape: boolean;
   prevWork?: ArtworkNavItem | null;
   nextWork?: ArtworkNavItem | null;
+  /** Per-collection prev/next pairs — when the visitor arrived via ?from=<collection>, arrows walk that collection. */
+  navByCollection?: Record<string, { prev: ArtworkNavItem | null; next: ArtworkNavItem | null }>;
   institution?: string;
   deepZoom?: DeepZoomManifest | null;
 }
 
-export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullResUrl, license, isLandscape, prevWork, nextWork, institution, deepZoom }: ArtworkHeroProps) {
+export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullResUrl, license, isLandscape, prevWork, nextWork, navByCollection, institution, deepZoom }: ArtworkHeroProps) {
   const [fitWidth, setFitWidth] = useState(false);
   const [showChrome, setShowChrome] = useState(true);
   const [zoomOpen, setZoomOpen] = useState(false);
@@ -65,18 +67,34 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
 
   const magnifierSrc = hiResReady && hiResUrl ? hiResUrl : imageUrl;
 
+  // Collection context: when the visitor arrived from a collection page
+  // (?from=<slug>), walk that collection's prev/next instead of the default
+  // scope, and keep the param on the nav links so the context persists.
+  // Read from window.location after mount — the page is statically rendered,
+  // and useSearchParams() would force a CSR bailout.
+  const [fromCollection, setFromCollection] = useState<string | null>(null);
+  useEffect(() => {
+    const from = new URLSearchParams(window.location.search).get('from');
+    if (from && navByCollection?.[from]) setFromCollection(from);
+  }, [navByCollection]);
+
+  const activeNav = fromCollection ? navByCollection![fromCollection] : { prev: prevWork ?? null, next: nextWork ?? null };
+  const navHref = (item: ArtworkNavItem) =>
+    `/artwork/${item.slug}${fromCollection ? `?from=${encodeURIComponent(fromCollection)}` : ''}`;
+
   // Keyboard navigation
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft' && prevWork) {
-        window.location.href = `/artwork/${prevWork.slug}`;
-      } else if (e.key === 'ArrowRight' && nextWork) {
-        window.location.href = `/artwork/${nextWork.slug}`;
+      if (e.key === 'ArrowLeft' && activeNav.prev) {
+        window.location.href = navHref(activeNav.prev);
+      } else if (e.key === 'ArrowRight' && activeNav.next) {
+        window.location.href = navHref(activeNav.next);
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [prevWork, nextWork]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeNav.prev, activeNav.next, fromCollection]);
 
   const captionText = [institution, license].filter(Boolean).join(' · ');
 
@@ -136,23 +154,23 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
       )}
 
       {/* Prev/Next navigation — appears on hover */}
-      {prevWork && (
+      {activeNav.prev && (
         <Link
-          href={`/artwork/${prevWork.slug}`}
+          href={navHref(activeNav.prev)}
           className={`absolute left-2 top-1/2 -translate-y-1/2 flex items-center gap-1 px-2 py-3 bg-black/40 hover:bg-black/70 text-white rounded-lg backdrop-blur-sm transition-all z-10 group ${showChrome ? 'opacity-100' : 'opacity-0'}`}
-          title={prevWork.title}
+          title={activeNav.prev.title}
         >
           <ChevronLeft className="w-5 h-5" />
-          <span className="hidden sm:block text-xs max-w-[120px] truncate opacity-0 group-hover:opacity-100 transition-opacity">{prevWork.title}</span>
+          <span className="hidden sm:block text-xs max-w-[120px] truncate opacity-0 group-hover:opacity-100 transition-opacity">{activeNav.prev.title}</span>
         </Link>
       )}
-      {nextWork && (
+      {activeNav.next && (
         <Link
-          href={`/artwork/${nextWork.slug}`}
+          href={navHref(activeNav.next)}
           className={`absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 px-2 py-3 bg-black/40 hover:bg-black/70 text-white rounded-lg backdrop-blur-sm transition-all z-10 group ${showChrome ? 'opacity-100' : 'opacity-0'}`}
-          title={nextWork.title}
+          title={activeNav.next.title}
         >
-          <span className="hidden sm:block text-xs max-w-[120px] truncate opacity-0 group-hover:opacity-100 transition-opacity">{nextWork.title}</span>
+          <span className="hidden sm:block text-xs max-w-[120px] truncate opacity-0 group-hover:opacity-100 transition-opacity">{activeNav.next.title}</span>
           <ChevronRight className="w-5 h-5" />
         </Link>
       )}

--- a/src/components/artwork/ArtworkInfo.tsx
+++ b/src/components/artwork/ArtworkInfo.tsx
@@ -57,12 +57,14 @@ interface ArtworkInfoProps {
   collections: Array<{ slug: string; name: string; subtitle?: string; color?: string }>;
   prevWork?: ArtworkNavItem | null;
   nextWork?: ArtworkNavItem | null;
+  /** Per-collection prev/next pairs — ArtworkHero picks the one matching ?from=<collection>. */
+  navByCollection?: Record<string, { prev: ArtworkNavItem | null; next: ArtworkNavItem | null }>;
   relatedBooks?: RelatedBookPreview[];
   /** When true, hide cross-tenant widgets (AuthorCrossReference renders unfiltered global data). */
   isEmbedded?: boolean;
 }
 
-export default function ArtworkInfo({ book, collections, prevWork, nextWork, relatedBooks = [], isEmbedded = false }: ArtworkInfoProps) {
+export default function ArtworkInfo({ book, collections, prevWork, nextWork, navByCollection, relatedBooks = [], isEmbedded = false }: ArtworkInfoProps) {
   const displayImage = book.thumbnail || (book as any).thumbnail_blob || '';
   const thumbImage = (book as any).thumbnail_blob || '';
   const commonsUrl = (book as any).commons_url || '';
@@ -113,6 +115,7 @@ export default function ArtworkInfo({ book, collections, prevWork, nextWork, rel
           isLandscape={isLandscape}
           prevWork={prevWork}
           nextWork={nextWork}
+          navByCollection={navByCollection}
           institution={holdingMuseum}
           deepZoom={(book as any).deepzoom || null}
         />

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -361,6 +361,7 @@ export default function CollectionAllBooks({
           onSort={handleSort}
           loading={loading}
           collectionType={collectionType}
+          fromCollection={collectionId}
         />
       ) : isArt ? (
         /* Art gallery grid — CSS grid with fixed row height for row-first loading.

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -382,7 +382,7 @@ export default function CollectionAllBooks({
               return (
                 <Link
                   key={book.id}
-                  href={`/artwork/${book.slug || book.id}`}
+                  href={`/artwork/${book.slug || book.id}?from=${collectionId}`}
                   className="group block relative"
                 >
                   <div className={`relative ${isPortrait ? 'aspect-[3/4]' : 'aspect-[4/3]'} bg-stone-900`}>

--- a/src/components/collections/CollectionListView.tsx
+++ b/src/components/collections/CollectionListView.tsx
@@ -34,6 +34,8 @@ interface CollectionListViewProps {
   onSort: (sort: string) => void;
   loading?: boolean;
   collectionType?: string;
+  /** Collection slug carried on artwork links (?from=) so prev/next walks this collection. */
+  fromCollection?: string;
 }
 
 function SortIcon({ column, currentSort }: { column: string; currentSort: string }) {
@@ -61,6 +63,7 @@ export default function CollectionListView({
   onSort,
   loading,
   collectionType,
+  fromCollection,
 }: CollectionListViewProps) {
   const handleColumnSort = (column: string) => {
     if (column === 'year') {
@@ -114,7 +117,7 @@ export default function CollectionListView({
           {books.map((book) => {
             const pct = translationPercent(book);
             const href = book.resource_type
-              ? `/artwork/${book.slug || book.id}`
+              ? `/artwork/${book.slug || book.id}${fromCollection ? `?from=${fromCollection}` : ''}`
               : `/book/${book.slug || book.id}`;
             const byline = getEffectiveByline(book);
             const bylineNode = byline.role === 'editor'


### PR DESCRIPTION
## Why

Reported on https://sourcelibrary.org/collections/kabbalah-sacred-geometry — the page read as broken:

- Hero said **"1 works"** while the grid showed hundreds. `total` came from cached `collection.book_count`, which counts only translated books — this is a `visual_art` collection holding 537 artworks and exactly 1 book.
- **Hidden artworks leaked.** The server-rendered compact grid had no `visible: true` filter (238 of the 537 tagged works are hidden), and sorted by raw `commons_width` — so modern Wikimedia uploads (a 2010 Penrose tiling, a 2023 mandala) topped a sacred-geometry collection. The manifest API already filtered/sorted correctly, so the grid silently changed contents after hydration.
- **Prev/next arrows wandered.** Artwork pages scope arrows to `collections[0]`, not the collection you navigated from (the Melencolia copy walks `esoteric-engravers` even when you came from kabbalah-sacred-geometry), and the neighbor queries had no `visible` filter either.

## What

- `collections/[id]` server query for art collections now mirrors the manifest API exactly: `visible: true`, shared `ART_EXCLUDED_RESOURCE_TYPES`, `art_collection_rank` sort. Mixed-collection "Visual Art" strip gains `visible: true` too.
- Art-collection hero/See-all count is a live `countDocuments` of what the grid shows (falls back to `artwork_count` on timeout).
- Artwork pages compute prev/next **per collection membership** (cap 4), all `visible: true`. Collection grids link with `?from=<slug>`; `ArtworkHero` picks the matching pair client-side and propagates the param on arrows and arrow keys — so left/right walks the collection you came from. The page stays statically rendered (param read from `window.location` after mount, not `searchParams`), and a canonical URL keeps `?from=` variants out of the index.

## Out of scope

- Curation of modern Wikimedia works (2010s Penrose renders, 2023 mandala) still tagged `visible: true` in this collection — data cleanup, not code.
- `syncCollectionCounts` still writes translated-books-only `book_count` for art collections; the page no longer reads it for them, so left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)