### PR TITLE
fix(gallery): crop thumbnails from the same source the bbox was detected on

### DIFF
--- a/scripts/maintenance/regen-split-gallery-images.mjs
+++ b/scripts/maintenance/regen-split-gallery-images.mjs
@@ -4,9 +4,14 @@
  *
  * Problem: Gallery backfill ran before page splitting, so bboxes (computed against
  * cropped_photo) were applied to archived_photo (full spread), producing wrong crops.
+ * The same mismatch hit generate-thumbnails.mjs, which preferred archived_photo over
+ * cropped_photo until 2026-06 — wrong crops on ALL split pages it touched, including
+ * old-era `crop`-split pages that have no split_from marker.
  *
  * Fix: Clear extracted_url/thumbnail_url on split pages' gallery_images (and their
  * detected_images subdocs), then re-run the backfill which will correctly use cropped_photo.
+ * Split pages are selected by split_from OR split_from_spread OR the old-era signature
+ * (cropped_photo + archived_photo both materialized).
  *
  * Usage:
  *   node scripts/maintenance/regen-split-gallery-images.mjs --dry-run
@@ -47,7 +52,19 @@ async function collectSplitPageIds(db) {
   console.log('Streaming split page IDs...');
   const ids = [];
   const cursor = db.collection('pages')
-    .find({ split_from: { $exists: true } })
+    .find({
+      $or: [
+        { split_from: { $exists: true } },
+        { split_from_spread: { $exists: true } },
+        // Old-era splits (crop xStart/xEnd) carry no split_from marker — the
+        // cropped half is materialized as cropped_photo while archived_photo
+        // still holds the full spread the bad backfill cropped from.
+        { $and: [
+          { cropped_photo: { $regex: '^https' } },
+          { archived_photo: { $regex: '^https' } },
+        ] },
+      ],
+    })
     .project({ id: 1, _id: 0 })
     .batchSize(2000);
 

--- a/scripts/workers/generate-thumbnails.mjs
+++ b/scripts/workers/generate-thumbnails.mjs
@@ -22,6 +22,7 @@ import { MongoClient } from 'mongodb';
 import sharp from 'sharp';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { computeDHash } from '../lib/dhash.mjs';
+import { getPageSource } from '../lib/page-image-url.mjs';
 
 // ── Config ──
 
@@ -269,6 +270,7 @@ async function main() {
       id: 1, book_id: 1,
       detected_images: 1,
       archived_photo: 1, cropped_photo: 1, photo_original: 1, photo: 1,
+      enhanced_photo: 1, split_from_spread: 1,
     })
     .toArray();
 
@@ -277,7 +279,11 @@ async function main() {
   // Flatten to individual work items
   const workItems = [];
   for (const page of pages) {
-    const sourceUrl = page.archived_photo || page.cropped_photo || page.photo_original || page.photo;
+    // MUST match the source the detection bboxes were computed against
+    // (image-extract-worker resolves it via getPageSource). On split pages
+    // archived_photo is the full two-page spread — cropping it with a
+    // cropped_photo-space bbox produces a gutter-spanning junk crop.
+    const sourceUrl = getPageSource(page);
     if (!sourceUrl) continue;
 
     for (let idx = 0; idx < (page.detected_images || []).length; idx++) {


### PR DESCRIPTION
## Problem

Reported bug on https://sourcelibrary.org/gallery/image/6984ec22d157ff67ff499c71-0 (Fludd, *Philosophia sacra*): the gallery crop spanned both pages of a two-page spread ("page split the wrong way"), and the hover magnifier showed content unrelated to the cursor position.

**Root cause:** `scripts/workers/generate-thumbnails.mjs` resolved its crop source as `archived_photo || cropped_photo || photo_original || photo`. On split pages, `archived_photo` is the **full spread**, but detection bboxes are computed by `image-extract-worker` against `getPageSource()` — `cropped_photo` (the split half) first. Applying a single-page bbox to the spread produces a gutter-spanning junk crop. The same coordinate-space mismatch broke the magnifier: the lens crops on-the-fly from the *correct* source (`getPageImageUrl`), so display and lens showed two different images.

This is the same bug class `regen-split-gallery-images.mjs` was written for, but that repair script only selects pages with `split_from` — the affected page is an old-era `crop`-split (xStart/xEnd) with no `split_from` marker, so the sweep missed it.

## Changes

- `generate-thumbnails.mjs` now resolves the crop source via `getPageSource()` from `scripts/lib/page-image-url.mjs` — identical to detection — and projects `enhanced_photo`/`split_from_spread`.
- `regen-split-gallery-images.mjs` collector broadened: `split_from` OR `split_from_spread` OR old-era signature (`cropped_photo` + `archived_photo` both materialized).

## Out of scope

- The global repair sweep (clear + regenerate across all affected split pages) — to be run after merge so the fixed worker is what Hetzner pulls. The reported book (51 detections) has already been cleared and regenerated with the fixed code; verified visually.
- `src/app/api/admin/generate-gallery-thumbnails/route.ts` already uses `getPageImageUrl` (correct) — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)