### PR TITLE
feat(podcast): anonymous listen analytics for the episode player

### DIFF
--- a/scripts/analytics/podcast-listens.mjs
+++ b/scripts/analytics/podcast-listens.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Podcast listen funnel from the `podcast_plays` collection
+ * (written by /api/podcast/events from the episode-page player).
+ *
+ * Usage: set -a; source .env.production.local; set +a; node scripts/analytics/podcast-listens.mjs [--days 30]
+ *
+ * Note: this only sees plays on sourcelibrary.org/podcast/* pages.
+ * Listens via the RSS feed in podcast apps hit R2 directly and are invisible here.
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+
+const daysArg = process.argv.indexOf('--days');
+const days = daysArg > -1 ? parseInt(process.argv[daysArg + 1], 10) : 30;
+const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+const rows = await db.collection('podcast_plays').aggregate([
+  { $match: { created_at: { $gte: since } } },
+  {
+    $group: {
+      _id: { thread: '$thread_id', event: '$event' },
+      n: { $sum: 1 },
+    },
+  },
+]).toArray();
+
+const byThread = new Map();
+for (const r of rows) {
+  if (!byThread.has(r._id.thread)) byThread.set(r._id.thread, {});
+  byThread.get(r._id.thread)[r._id.event] = r.n;
+}
+
+const threads = await db.collection('embassy_threads')
+  .find({ _id: { $in: [...byThread.keys()].filter((id) => ObjectId.isValid(id)).map((id) => new ObjectId(id)) } })
+  .project({ title: 1 })
+  .toArray();
+const titles = new Map(threads.map((t) => [t._id.toString(), t.title]));
+
+console.log(`Podcast listens — last ${days} days (episode-page player only)\n`);
+const sorted = [...byThread.entries()].sort((a, b) => (b[1].play || 0) - (a[1].play || 0));
+if (!sorted.length) console.log('No plays recorded in this window.');
+for (const [threadId, ev] of sorted) {
+  const plays = ev.play || 0;
+  const pct = (n) => (plays ? `${Math.round((100 * (n || 0)) / plays)}%` : '-');
+  console.log(`${titles.get(threadId) || threadId}`);
+  console.log(`  plays ${plays} | 25% ${pct(ev.q1)} | 50% ${pct(ev.q2)} | 75% ${pct(ev.q3)} | complete ${pct(ev.complete)}`);
+  console.log(`  https://sourcelibrary.org/podcast/${threadId}\n`);
+}
+
+await client.close();

--- a/src/app/api/podcast/events/route.ts
+++ b/src/app/api/podcast/events/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/mongodb';
+
+/**
+ * Podcast listen events from the episode-page player.
+ * Fire-and-forget — never fails to the client. No cookies, no PII:
+ * `vid` is an ephemeral per-pageview id generated in the player.
+ *
+ * POST /api/podcast/events
+ * Body: { threadId, format, event: play|q1|q2|q3|complete, position?, duration?, vid }
+ *
+ * Read the funnel with scripts/analytics/podcast-listens.mjs.
+ */
+const DB_TIMEOUT_MS = 3000;
+const EVENTS = new Set(['play', 'q1', 'q2', 'q3', 'complete']);
+
+export async function POST(request: NextRequest) {
+  try {
+    // sendBeacon posts as text/plain, so parse the raw body
+    const body = JSON.parse(await request.text());
+    const { threadId, format, event, position, duration, vid } = body || {};
+
+    if (
+      !ObjectId.isValid(threadId) ||
+      !EVENTS.has(event) ||
+      typeof vid !== 'string' || vid.length > 64
+    ) {
+      return NextResponse.json({ ok: true });
+    }
+
+    const dbWork = (async () => {
+      const db = await getDb();
+      // One row per (pageview, event) — replays within a pageview don't double-count
+      await db.collection('podcast_plays').updateOne(
+        { vid, thread_id: threadId, event },
+        {
+          $setOnInsert: {
+            vid,
+            thread_id: threadId,
+            format: typeof format === 'string' ? format.slice(0, 20) : 'deep-dive',
+            event,
+            position: Number.isFinite(position) ? Math.round(position) : null,
+            duration: Number.isFinite(duration) ? Math.round(duration) : null,
+            created_at: new Date(),
+          },
+        },
+        { upsert: true },
+      );
+    })();
+
+    const timeout = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), DB_TIMEOUT_MS)
+    );
+
+    await Promise.race([dbWork, timeout]);
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ ok: true });
+  }
+}

--- a/src/app/podcast/EpisodePlayer.tsx
+++ b/src/app/podcast/EpisodePlayer.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  threadId: string;
+  format: string;
+  audioUrl: string;
+}
+
+/**
+ * Episode audio player with anonymous listen analytics.
+ * Sends one event per pageview for: play, 25/50/75% (q1-q3), and complete (95% or ended).
+ * No cookies, no PII — `vid` lives only in this component instance.
+ */
+export default function EpisodePlayer({ threadId, format, audioUrl }: Props) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const vidRef = useRef<string>('');
+  const sentRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    vidRef.current = crypto.randomUUID();
+  }, []);
+
+  const send = (event: string) => {
+    if (!vidRef.current || sentRef.current.has(event)) return;
+    sentRef.current.add(event);
+    const audio = audioRef.current;
+    const payload = JSON.stringify({
+      threadId,
+      format,
+      event,
+      vid: vidRef.current,
+      position: audio ? Math.round(audio.currentTime) : null,
+      duration: audio && Number.isFinite(audio.duration) ? Math.round(audio.duration) : null,
+    });
+    try {
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon('/api/podcast/events', payload);
+      } else {
+        fetch('/api/podcast/events', { method: 'POST', body: payload, keepalive: true });
+      }
+    } catch {
+      // analytics must never break playback
+    }
+  };
+
+  const onTimeUpdate = () => {
+    const audio = audioRef.current;
+    if (!audio || !Number.isFinite(audio.duration) || audio.duration === 0) return;
+    const frac = audio.currentTime / audio.duration;
+    if (frac >= 0.95) send('complete');
+    else if (frac >= 0.75) send('q3');
+    else if (frac >= 0.5) send('q2');
+    else if (frac >= 0.25) send('q1');
+  };
+
+  return (
+    <audio
+      ref={audioRef}
+      controls
+      src={audioUrl}
+      className="w-full mb-6"
+      preload="metadata"
+      onPlay={() => send('play')}
+      onTimeUpdate={onTimeUpdate}
+      onEnded={() => send('complete')}
+    />
+  );
+}

--- a/src/app/podcast/[threadId]/page.tsx
+++ b/src/app/podcast/[threadId]/page.tsx
@@ -3,6 +3,7 @@ import { ObjectId } from 'mongodb';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import TranscriptToggle from '../TranscriptToggle';
+import EpisodePlayer from '../EpisodePlayer';
 
 export const revalidate = 3600;
 
@@ -43,6 +44,7 @@ interface EpisodeData {
   title: string;
   topic: string;
   audioUrl: string;
+  format: string;
   formatLabel: string;
   findingCount: number;
   generatedAt: string;
@@ -209,6 +211,7 @@ async function getEpisode(threadId: string): Promise<EpisodeData | null> {
       title: thread.title || podcast.topic,
       topic: podcast.topic,
       audioUrl: podcast.audioUrl,
+      format,
       formatLabel: FORMAT_LABELS[format] || 'Deep Dive',
       findingCount: podcast.findingCount || 0,
       generatedAt: podcast.generatedAt,
@@ -301,11 +304,10 @@ export default async function EpisodePage({ params }: Props) {
         </div>
 
         {/* Audio player */}
-        <audio
-          controls
-          src={episode.audioUrl}
-          className="w-full mb-6"
-          preload="metadata"
+        <EpisodePlayer
+          threadId={episode.threadId}
+          format={episode.format}
+          audioUrl={episode.audioUrl}
         />
 
         {/* Transcript */}


### PR DESCRIPTION
## Why
We have no idea whether anyone listens to the podcast episodes or where they drop off. PostHog only captures ~12 consent-gated events a month, so it can't answer this. Completion rates should drive whether/where we invest further (style, length, distribution).

## What
- **`POST /api/podcast/events`** — anonymous, fire-and-forget event sink writing to a new `podcast_plays` collection. Events: `play`, `q1`/`q2`/`q3` (25/50/75%), `complete` (95% or ended). Upsert on `(vid, thread_id, event)` so replays within a pageview don't double-count. Follows the `/api/analytics/not-found` pattern (3s DB timeout, always returns ok, parses text body for sendBeacon).
- **`EpisodePlayer`** — client component replacing the bare `<audio>` on `/podcast/[threadId]`. Sends each milestone once per pageview via `navigator.sendBeacon` (fetch keepalive fallback). The pageview id is an in-memory `crypto.randomUUID()` — no cookies, no localStorage, no PII.
- **`scripts/analytics/podcast-listens.mjs`** — per-episode funnel report (plays, quartiles, completion rate).

## Out of scope
- RSS/podcast-app listens (those hit R2 directly; would need CDN log analysis).
- Admin UI for the funnel — the script is enough until there's traffic worth a page.
- Indexing `podcast_plays` — volume will be tiny; add an index if it ever isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)