### PR TITLE
fix(cache): add 24h CDN edge TTL to static marketing pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -190,6 +190,24 @@ const nextConfig: NextConfig = {
         missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
+      // Static marketing/info pages. Without an edge TTL these render on every
+      // request — a June 2026 scraper flood sent ~1.3M req/day at exactly these
+      // pages and all of it reached Vercel.
+      {
+        source: '/(privacy|terms|dmca|support|sponsors|developers|contribute|beta)',
+        missing: [{ type: 'header', key: 'rsc' }],
+        headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
+      },
+      {
+        source: '/about/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
+        headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
+      },
+      {
+        source: '/blog/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
+        headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
+      },
       // Prevent Cloudflare from caching admin/auth routes
       {
         source: '/admin/:path*',

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -19,7 +19,7 @@
 15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-prewarm.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/prewarm-browse.mjs" >> /var/log/sourcelibrary/prewarm-browse.log 2>&1
 */2 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-scheduler.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/scheduler.mjs" >> /var/log/sourcelibrary/scheduler.log 2>&1
 30 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-entity-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-entities.mjs" >> /var/log/sourcelibrary/entity-sync.log 2>&1
-30 */4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-embed-gemini.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=$GEMINI_API_KEY_TIER3 && node scripts/workers/embed-gemini.mjs --incremental" >> /var/log/sourcelibrary/embed-gemini.log 2>&1
+#PAUSED-GEMINI 30 */4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-embed-gemini.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=\$GEMINI_API_KEY_TIER3 && node scripts/workers/embed-gemini.mjs --incremental" >> /var/log/sourcelibrary/embed-gemini.log 2>&1
 30 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/snapshot-stats.mjs" >> /var/log/sourcelibrary/snapshot.log 2>&1
 30 5 * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; curl -s -X POST https://sourcelibrary.org/api/admin/cache-probe -H "Authorization: Bearer $CRON_SECRET"" >> /var/log/sourcelibrary/cache-probe.log 2>&1
 45 1,3,5,7,9,11,13,15,17,19,21,23 * * * cd /root/sourcelibrary && flock -n /tmp/sl-books-catalog-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-books-catalog.mjs" >> /var/log/sourcelibrary/books-catalog-sync.log 2>&1
@@ -43,15 +43,15 @@
 # Weekly: clear image_thumb fields on books whose /pages/-thumb URL 404s (#1945)
 0 6 * * 0 cd /root/sourcelibrary && flock -n /tmp/sl-thumb-sweep.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/fix-broken-image-thumb.mjs --apply" >> /var/log/sourcelibrary/thumb-sweep.log 2>&1
 
-# R2 coverage snapshot (every 6h — updates the doc /admin/r2-coverage reads)
-30 */6 * * * cd /root/sourcelibrary && flock -n /tmp/sl-r2-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/r2-coverage-snapshot.mjs" >> /var/log/sourcelibrary/r2-snapshot.log 2>&1
+# R2 coverage snapshot (daily — was 6h; the HEAD sweep was ~27% of all site traffic, 2026-06-11)
+30 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-r2-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/r2-coverage-snapshot.mjs" >> /var/log/sourcelibrary/r2-snapshot.log 2>&1
 
 # Archive auto-unblock (daily — retry books blocked >14d ago with transient failure reasons)
 0 9 * * * cd /root/sourcelibrary && flock -n /tmp/sl-archive-unblock.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/archive-auto-unblock.mjs" >> /var/log/sourcelibrary/archive-auto-unblock.log 2>&1
 
 # First Translation verification pipeline (Stage 1 catalog search + Stage 2 disposition)
-30 2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-search.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/search-translation-evidence.mjs --apply --limit 500" >> /var/log/sourcelibrary/ft-search.log 2>&1
-15 6 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-validate.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/validate-translation-evidence.mjs --apply --limit 1000" >> /var/log/sourcelibrary/ft-validate.log 2>&1
+#PAUSED-GEMINI 30 2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-search.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/search-translation-evidence.mjs --apply --limit 500" >> /var/log/sourcelibrary/ft-search.log 2>&1
+#PAUSED-GEMINI 15 6 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-validate.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/validate-translation-evidence.mjs --apply --limit 1000" >> /var/log/sourcelibrary/ft-validate.log 2>&1
 
 # Supabase pages-content sync (PR #2026 / issue #2020)
 */5 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-sync-pages-content.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-pages-content.mjs" >> /var/log/sourcelibrary/sync-pages-content.log 2>&1
@@ -77,7 +77,7 @@
 
 # Image-side embeddings — artwork_embeddings, gallery_text_embeddings, clip_embeddings (issue #2021)
 # These tables had no recurring writer; froze for 35+ days. Uses TIER3 paid key for data-rights.
-0 2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-image-embeddings.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=$GEMINI_API_KEY_TIER3; node scripts/workers/image-embeddings-cron.mjs" >> /var/log/sourcelibrary/image-embeddings.log 2>&1
+0 2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-image-embeddings.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=\$GEMINI_API_KEY_TIER3; node scripts/workers/image-embeddings-cron.mjs" >> /var/log/sourcelibrary/image-embeddings.log 2>&1
 45 3,15 * * * cd /root/sourcelibrary && flock -n /tmp/sl-gallery-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/gallery-coverage-snapshot.mjs" >> /var/log/sourcelibrary/gallery-coverage.log 2>&1
 
 45 */6 * * * cd /root/sourcelibrary && flock -n /tmp/sl-archiving-watchdog.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/archiving-watchdog.mjs --apply --stale-hours=12 --escalate-days=7" >> /var/log/sourcelibrary/archiving-watchdog.log 2>&1
@@ -92,3 +92,7 @@
 
 # Crontab drift detector — logs if live crontab diverges from committed snapshot (#2332)
 0 4 * * * /root/sourcelibrary/scripts/workers/sync-crontab.sh >> /var/log/sourcelibrary/crontab-sync.log 2>&1
+45 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-mapcache.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/build-map-cache.mjs" >> /var/log/sourcelibrary/build-map-cache.log 2>&1
+# Materialize gallery crops for batch-path detections (batch-collector writes bbox-only rows; #2430)
+30 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-gen-thumbnails.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/generate-thumbnails.mjs --limit=8000 --concurrency=6 --min-quality=0.5 --include-sensitive" >> /var/log/sourcelibrary/generate-thumbnails.log 2>&1
+50 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-classify-text-role.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/classify-text-role.mjs --only-missing" >> /var/log/sourcelibrary/classify-text-role.log 2>&1


### PR DESCRIPTION
## Why
The June 2026 bot audit found a datacenter scraper flood (Tencent ASN 132203, Alibaba 45102, Byteplus 396986 — ~1.6M req/day with rotated fake desktop-Chrome UAs) hammering the same ten static pages: /privacy (102k/day), /developers (91k), /sponsors (77k), /support, /about/progress, /contribute, /libraries, /dmca, /terms. These pages send `cache-control: max-age=0` and no `CDN-Cache-Control`, so **every request passes through Cloudflare to Vercel** (zone-wide CF cache hit rate: 1.8%).

The same audit found the site's single largest traffic source was internal: `r2-coverage-snapshot.mjs` HEAD-sweeping ~313k image URLs through the public domain every 6h (~1.25M req/day, 27% of all traffic) to refresh an admin dashboard.

## What
1. **next.config.ts** — adds the same 24h `CDN-Cache-Control` edge TTL (with RSC-header exclusion) already used for /book, /collections, /author, etc. to `/(privacy|terms|dmca|support|sponsors|developers|contribute|beta)`, `/about/:path*`, `/blog/:path*`. Cloudflare then absorbs repeat hits at the edge.
2. **crontab.production** — re-snapshot after changing r2-coverage-snapshot from 6h to daily on the live box (already applied). Also captures pre-existing drift: PAUSED-GEMINI markers, the $-escape fix (2026-06-03), and the build-map-cache / generate-thumbnails / classify-text-role crons added by other sessions.

## Out of scope
- A managed-challenge WAF rule for the three scraper ASNs was applied directly in Cloudflare (not in this repo) — the cache header change is the structural fix that also covers future floods.
- /api/auth/session traffic (uncacheable by nature; covered by the WAF rule).
- Making r2-coverage-snapshot use the R2 S3 list API instead of per-object HTTP HEADs (~300 list calls vs 313k HEADs) — follow-up candidate.

## Verification
- `npx tsc --noEmit` clean; pre-commit import check clean.
- After merge+deploy: `curl -sI https://sourcelibrary.org/privacy | grep -i cdn-cache-control` should show `public, max-age=86400`, and second-hit `cf-cache-status: HIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)