### PR TITLE
fix(security): gate hidden (visible:false) books on reader + content APIs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -145,6 +145,17 @@ const nextConfig: NextConfig = {
         missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
+      // Editor-only hidden-book preview routes are force-dynamic + auth-gated and
+      // MUST NOT be edge-cached — a cached editor 200 would leak to anon users.
+      // Placed AFTER the broad /book rule so these specific paths override it.
+      {
+        source: '/book/:id/preview',
+        headers: [{ key: 'CDN-Cache-Control', value: 'private, no-store' }],
+      },
+      {
+        source: '/book/:id/page/:pageId/preview',
+        headers: [{ key: 'CDN-Cache-Control', value: 'private, no-store' }],
+      },
       {
         source: '/collections/:path*',
         missing: [{ type: 'header', key: 'rsc' }],

--- a/src/app/api/[tenant]/books/[id]/chat/route.ts
+++ b/src/app/api/[tenant]/books/[id]/chat/route.ts
@@ -5,6 +5,7 @@ import { withAuth } from '@/lib/auth-helpers';
 import { getChapterTexts } from '@/lib/chapter-text';
 import { z } from 'zod';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { isBookReadable } from '@/lib/book-access';
 
 // Validation schema for chat messages
 const messageSchema = z.object({
@@ -363,6 +364,11 @@ export async function GET(
 
     const book = await db.collection('books').findOne({ id, tenantId });
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor / CRON_SECRET.
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/[tenant]/books/[id]/download/route.ts
+++ b/src/app/api/[tenant]/books/[id]/download/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
 import { canDownload, classifyImageAccess, PRICES } from '@/lib/purchases';
+import { isBookReadable } from '@/lib/book-access';
 import type { Book, Page, TranslationEdition } from '@/lib/types';
 import epub from 'epub-gen-memory';
 import archiver from 'archiver';
@@ -2418,6 +2419,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // Get book
     const book = await db.collection('books').findOne({ id, tenantId });
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor / CRON_SECRET.
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/[tenant]/books/[id]/index/route.ts
+++ b/src/app/api/[tenant]/books/[id]/index/route.ts
@@ -5,6 +5,7 @@ import { logGeminiCall } from '@/lib/gemini-logger';
 import { getTriggerSource } from '@/lib/cron-auth';
 import { createBookRevisions } from '@/lib/book-revisions';
 import { withAuth } from '@/lib/auth-helpers';
+import { isBookReadable } from '@/lib/book-access';
 import { loadAliasResolver } from '@/lib/entity-aliases';
 import { getChapterTexts, type ChapterText } from '@/lib/chapter-text';
 import { resolveTenantId } from '@/lib/tenant-context';
@@ -1144,6 +1145,11 @@ export async function GET(
     // Get book
     const book = await db.collection('books').findOne({ id, tenantId });
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor / CRON_SECRET.
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -6,6 +6,7 @@ import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { isBookReadable } from '@/lib/book-access';
 
 interface RouteContext {
   params: Promise<{ tenant: string; id: string }>;
@@ -161,6 +162,12 @@ export async function GET(request: NextRequest, context: RouteContext) {
       book = await db.collection('books').findOne({ _id: new ObjectId(bookId), tenantId }) as unknown as Book | null;
     }
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor session
+    // or CRON_SECRET (pipeline / Claude Code).
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/[tenant]/books/[id]/search/route.ts
+++ b/src/app/api/[tenant]/books/[id]/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { isBookReadable } from '@/lib/book-access';
 
 interface SearchMatch {
   field: 'ocr' | 'translation';
@@ -92,6 +93,16 @@ export async function GET(
     const tenantId = await resolveTenantId(tenant);
 
     if (!tenantId) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — gate before searching their
+    // text. 404 unless editor session or CRON_SECRET (pipeline / Claude Code).
+    const gateBook = await db.collection('books').findOne(
+      { id: bookId, tenantId },
+      { projection: { id: 1, visible: 1 } }
+    );
+    if (!gateBook || !(await isBookReadable(gateBook, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/[tenant]/books/[id]/search/route.ts
+++ b/src/app/api/[tenant]/books/[id]/search/route.ts
@@ -98,11 +98,13 @@ export async function GET(
 
     // Hidden (visible:false) books are not public — gate before searching their
     // text. 404 unless editor session or CRON_SECRET (pipeline / Claude Code).
+    // A book is only "hidden" if its books doc exists with visible:false; if no
+    // doc is found we preserve prior behavior (just search pages) rather than 404.
     const gateBook = await db.collection('books').findOne(
       { id: bookId, tenantId },
       { projection: { id: 1, visible: 1 } }
     );
-    if (!gateBook || !(await isBookReadable(gateBook, request))) {
+    if (gateBook && !(await isBookReadable(gateBook, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/books/[id]/chat/route.ts
+++ b/src/app/api/books/[id]/chat/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getGeminiClient } from '@/lib/gemini-client';
 import { withAuth } from '@/lib/auth-helpers';
+import { isBookReadable } from '@/lib/book-access';
 import { getChapterTexts } from '@/lib/chapter-text';
 import { z } from 'zod';
 
@@ -348,6 +349,11 @@ export async function GET(
 
     const book = await db.collection('books').findOne({ id });
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor / CRON_SECRET.
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/books/[id]/download/route.ts
+++ b/src/app/api/books/[id]/download/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
 import { canDownload, classifyImageAccess, PRICES } from '@/lib/purchases';
+import { isBookReadable } from '@/lib/book-access';
 import type { Book, Page, TranslationEdition } from '@/lib/types';
 import epub from 'epub-gen-memory';
 import archiver from 'archiver';
@@ -2405,6 +2406,12 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // Get book
     const book = await db.collection('books').findOne({ id });
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor session
+    // or CRON_SECRET. Prevents downloading the full text of an unpublished book.
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/books/[id]/index/route.ts
+++ b/src/app/api/books/[id]/index/route.ts
@@ -5,6 +5,7 @@ import { logGeminiCall } from '@/lib/gemini-logger';
 import { getTriggerSource } from '@/lib/cron-auth';
 import { createBookRevisions } from '@/lib/book-revisions';
 import { withAuth } from '@/lib/auth-helpers';
+import { isBookReadable } from '@/lib/book-access';
 import { loadAliasResolver } from '@/lib/entity-aliases';
 import { getChapterTexts, type ChapterText } from '@/lib/chapter-text';
 import { getBookIndex } from '@/lib/book-index';
@@ -1142,6 +1143,11 @@ export async function GET(
     // Get book
     const book = await db.collection('books').findOne({ id });
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor / CRON_SECRET.
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -6,6 +6,7 @@ import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { withApiAuth } from '@/lib/api-auth';
+import { isBookReadable } from '@/lib/book-access';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -156,6 +157,12 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
       book = await db.collection('books').findOne({ _id: new ObjectId(bookId) }) as unknown as Book | null;
     }
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless the caller is an
+    // editor session or carries CRON_SECRET (pipeline / Claude Code).
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/books/[id]/search/route.ts
+++ b/src/app/api/books/[id]/search/route.ts
@@ -95,11 +95,13 @@ export async function GET(
 
     // Hidden (visible:false) books are not public — gate before searching their
     // text. 404 unless editor session or CRON_SECRET (pipeline / Claude Code).
+    // A book is only "hidden" if its books doc exists with visible:false; if no
+    // doc is found we preserve prior behavior (just search pages) rather than 404.
     const gateBook = await db.collection('books').findOne(
       { $or: [{ id: bookId }, { slug: bookId }] },
       { projection: { id: 1, visible: 1 } }
     );
-    if (!gateBook || !(await isBookReadable(gateBook, request))) {
+    if (gateBook && !(await isBookReadable(gateBook, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/books/[id]/search/route.ts
+++ b/src/app/api/books/[id]/search/route.ts
@@ -4,6 +4,7 @@ import { buildPageSearchStage, NON_CONTENT_PAGE_TYPES } from '@/lib/atlas-search
 import { semanticPageSearchScoped } from '@/lib/semantic-search';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { isBookReadable } from '@/lib/book-access';
 
 interface SearchMatch {
   field: 'ocr' | 'translation';
@@ -91,6 +92,16 @@ export async function GET(
     const isPhrase = /^".*"$/.test(trimmedQuery);
     const matchQuery = isPhrase ? trimmedQuery.slice(1, -1) : trimmedQuery;
     const db = await getDb();
+
+    // Hidden (visible:false) books are not public — gate before searching their
+    // text. 404 unless editor session or CRON_SECRET (pipeline / Claude Code).
+    const gateBook = await db.collection('books').findOne(
+      { $or: [{ id: bookId }, { slug: bookId }] },
+      { projection: { id: 1, visible: 1 } }
+    );
+    if (!gateBook || !(await isBookReadable(gateBook, request))) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
 
     // Run keyword search and semantic search in parallel
     const [keywordResults, semanticResults] = await Promise.all([

--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -5,6 +5,7 @@ import { isBot, isTrustedBot, botMaxPage, botGateResponse } from '@/lib/bot-gate
 import { getChapterTexts } from '@/lib/chapter-text';
 import { withApiAuth, type ApiIdentity } from '@/lib/api-auth';
 import { checkPageBudget, bulkBudgetExceededBody } from '@/lib/api-budget';
+import { isBookReadable } from '@/lib/book-access';
 
 export const maxDuration = 30;
 
@@ -60,15 +61,21 @@ export const GET = withApiAuth(async (
     // Find book by id or _id
     let book = await db.collection('books').findOne(
       { id: bookId },
-      { projection: { id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1, pages_count: 1 } }
+      { projection: { id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1, pages_count: 1, visible: 1 } }
     );
     if (!book && ObjectId.isValid(bookId)) {
       book = await db.collection('books').findOne(
         { _id: new ObjectId(bookId) },
-        { projection: { id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1, pages_count: 1 } }
+        { projection: { id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, year: 1, pages_count: 1, visible: 1 } }
       );
     }
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor session
+    // or CRON_SECRET (pipeline / Claude Code).
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/iiif/[id]/autocomplete/route.ts
+++ b/src/app/api/iiif/[id]/autocomplete/route.ts
@@ -12,6 +12,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { isBookReadable } from '@/lib/book-access';
 
 const BASE = 'https://sourcelibrary.org';
 const MAX_TERMS = 20;
@@ -52,10 +53,15 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 
     const book = await db.collection('books').findOne(
       { $or: [{ id }, { slug: id }] },
-      { projection: { id: 1 } }
+      { projection: { id: 1, visible: 1 } }
     );
 
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor / CRON_SECRET.
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
+++ b/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { aiGenerator } from '@/lib/iiif-provenance';
+import { isBookReadable } from '@/lib/book-access';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -60,6 +61,16 @@ export async function GET(
     }
 
     const db = await getReadDb();
+
+    // Hidden (visible:false) books are not public — gate before serving any
+    // page transcription. 404 unless editor session or CRON_SECRET.
+    const gateBook = await db.collection('books').findOne(
+      { $or: [{ id }, { slug: id }] },
+      { projection: { id: 1, visible: 1 } }
+    );
+    if (!gateBook || !(await isBookReadable(gateBook, request))) {
+      return NextResponse.json({ error: 'Page not found' }, { status: 404 });
+    }
 
     // Fetch only the field we need
     const projection =

--- a/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
+++ b/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
@@ -64,11 +64,13 @@ export async function GET(
 
     // Hidden (visible:false) books are not public — gate before serving any
     // page transcription. 404 unless editor session or CRON_SECRET.
+    // A book is only "hidden" if its books doc exists with visible:false; if no
+    // doc is found we preserve prior behavior (the page lookup below 404s).
     const gateBook = await db.collection('books').findOne(
       { $or: [{ id }, { slug: id }] },
       { projection: { id: 1, visible: 1 } }
     );
-    if (!gateBook || !(await isBookReadable(gateBook, request))) {
+    if (gateBook && !(await isBookReadable(gateBook, request))) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
     }
 

--- a/src/app/api/iiif/[id]/manifest/route.ts
+++ b/src/app/api/iiif/[id]/manifest/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { getPartnerByProvider, type LibraryPartner } from '@/lib/library-partners';
+import { isBookReadable } from '@/lib/book-access';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -210,6 +211,11 @@ export async function GET(
 
     const book = await db.collection('books').findOne({ id });
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor / CRON_SECRET.
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/api/iiif/[id]/search/route.ts
+++ b/src/app/api/iiif/[id]/search/route.ts
@@ -15,6 +15,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { aiGenerator } from '@/lib/iiif-provenance';
+import { isBookReadable } from '@/lib/book-access';
 
 const BASE = 'https://sourcelibrary.org';
 const MAX_RESULTS = 200;
@@ -89,10 +90,16 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 
     const book = await db.collection('books').findOne(
       { $or: [{ id }, { slug: id }] },
-      { projection: { id: 1, pages_count: 1, pages_ocr: 1 } }
+      { projection: { id: 1, pages_count: 1, pages_ocr: 1, visible: 1 } }
     );
 
     if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    // Hidden (visible:false) books are not public — 404 unless editor session
+    // or CRON_SECRET (pipeline / Claude Code).
+    if (!(await isBookReadable(book, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import { isHiddenBook } from '@/lib/book-access';
 import { deduplicateByDHash } from '@/lib/dhash';
 import { getBookDetail } from '@/lib/books-catalog';
 import { Calendar, Globe, FileText, BookMarked, Images, BookOpen } from 'lucide-react';
@@ -73,6 +74,10 @@ interface PageProps {
   // read from searchParams here, because this page is ISR/static (revalidate)
   // and reading request-time query params would force a render error.
   previewProposed?: boolean;
+  // Allow rendering a hidden (visible:false) book. Set ONLY by the dynamic,
+  // editor-gated /book/[id]/preview route. The public ISR route leaves this
+  // false so hidden books 404 uniformly (cache-safe — no per-user branch).
+  allowHidden?: boolean;
 }
 
 // Cached book lookup — deduplicates between generateMetadata and BookInfo
@@ -191,6 +196,17 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!book) {
     // Self-referential canonical (not the inherited root '/') so Google doesn't
     // see this as a duplicate of the homepage while it's still 200/noindex.
+    return {
+      title: 'Book Not Found - Source Library',
+      robots: { index: false, follow: false },
+      alternates: { canonical: `/book/${id}` },
+    };
+  }
+
+  // Hidden books (visible:false) are not public. Emit not-found/noindex metadata
+  // on the public ISR route — matches the notFound() the page body returns.
+  // Editors reach hidden books via /book/[id]/preview (dynamic, auth-gated).
+  if (isHiddenBook(book)) {
     return {
       title: 'Book Not Found - Source Library',
       robots: { index: false, follow: false },
@@ -544,7 +560,7 @@ function PagesGridSkeleton() {
 }
 
 // Book info component (streams in via Suspense)
-async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed = false }: { id: string; tenantId?: string; tenantSlug: string; embedPolicy: EmbedUiPolicy; previewProposed?: boolean }) {
+async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed = false, allowHidden = false }: { id: string; tenantId?: string; tenantSlug: string; embedPolicy: EmbedUiPolicy; previewProposed?: boolean; allowHidden?: boolean }) {
   let data;
   try {
     data = await getBook(id, tenantId, tenantSlug);
@@ -567,6 +583,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed
   }
 
   const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections, authorEntity } = data;
+
+  // Hidden books (visible:false) are not public — defense in depth alongside
+  // the early gate in BookDetailPage. allowHidden is set only by the dynamic,
+  // editor-gated /book/[id]/preview route.
+  if (isHiddenBook(book as any) && !allowHidden) {
+    notFound();
+  }
 
   // Enforce tenant isolation: book must belong to the tenant in the URL.
   // Books are stored with EITHER `tenantId` (UUID) or `tenant_id` (slug) — sometimes both.
@@ -1276,7 +1299,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed
   );
 }
 
-export default async function BookDetailPage({ params, tenantContext, previewProposed = false }: PageProps) {
+export default async function BookDetailPage({ params, tenantContext, previewProposed = false, allowHidden = false }: PageProps) {
   const { id } = await params;
   const ctx = tenantContext ?? null;
   const embedPolicy = getEmbedUiPolicy(ctx);
@@ -1301,6 +1324,13 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
     notFound();
   }
 
+  // Hidden books (visible:false) 404 on the public route. allowHidden is set
+  // only by the dynamic, editor-gated /book/[id]/preview route. Gating here
+  // (not on a session check) keeps the public route statically cacheable.
+  if (isHiddenBook(earlyBook) && !allowHidden) {
+    notFound();
+  }
+
   return (
     <div className={isEmbedded ? "" : "min-h-screen bg-cream"}>
       {!isEmbedded && <ConditionalSiteHeader variant="light" />}
@@ -1315,7 +1345,7 @@ export default async function BookDetailPage({ params, tenantContext, previewPro
           </main>
         </>
       }>
-        <BookInfo id={id} tenantId={tenantId} tenantSlug={tenantSlug} embedPolicy={embedPolicy} previewProposed={previewProposed} />
+        <BookInfo id={id} tenantId={tenantId} tenantSlug={tenantSlug} embedPolicy={embedPolicy} previewProposed={previewProposed} allowHidden={allowHidden} />
       </Suspense>
       {!isEmbedded && <SignUpCTA />}
     </div>

--- a/src/app/book/[id]/page/[pageId]/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/page.tsx
@@ -6,6 +6,7 @@ import { getTenantContext } from '@/lib/tenant-context';
 import type { Book, Page } from '@/lib/types';
 import PageEditorClient from '@/components/book/PageEditorClient';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
+import { isHiddenBook } from '@/lib/book-access';
 
 // ISR: 24h background revalidation. Pipeline also calls /api/admin/revalidate-book for immediate updates.
 export const revalidate = 86400;
@@ -26,10 +27,10 @@ interface PageProps {
 const BOOK_NAV_PROJECTION = {
   _id: 0, id: 1, slug: 1, title: 1, display_title: 1,
   author: 1, published: 1, language: 1, doi: 1, chapters: 1,
-  cdli_witnesses: 1, etcsl_id: 1,
+  cdli_witnesses: 1, etcsl_id: 1, visible: 1,
 };
 
-export default async function PageEditorPage({ params }: PageProps) {
+export default async function PageEditorPage({ params, allowHidden = false }: PageProps & { allowHidden?: boolean }) {
   const { id, pageId } = await params;
   const ctx = await getTenantContext();
   const db = await getReadDb();
@@ -65,6 +66,15 @@ export default async function PageEditorPage({ params }: PageProps) {
   }
 
   const book = bookResult.book as unknown as Book;
+
+  // Hidden (visible:false) books are not public. This per-page route is ISR
+  // (highest-volume URL set — must stay statically cacheable), so it gates
+  // uniformly: hidden → 404 for everyone. Editors read hidden books in-browser
+  // via the dynamic /book/[id]/page/[pageId]/preview route (allowHidden).
+  if (isHiddenBook(book as any) && !allowHidden) {
+    notFound();
+  }
+
   const scopedBookId = (book.id || (book as any)._id?.toString()) as string;
   if ((currentPage.book_id as string) !== scopedBookId) {
     notFound();

--- a/src/app/book/[id]/page/[pageId]/preview/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/preview/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * Dynamic, EDITOR-ONLY per-page reader that can render pages of HIDDEN
+ * (visible:false) books.
+ *
+ * The public /book/[id]/page/[pageId] route is ISR (it is the highest-volume
+ * URL set on the site and must stay statically cacheable), so it gates hidden
+ * books uniformly to a 404. Editors who need to read an unpublished book's
+ * scanned pages in the browser use this force-dynamic, auth-gated twin —
+ * mirrors /book/[id]/preview at the page level.
+ *
+ * Logged-out / non-editor visitors get a 404. Read-only; no mutations.
+ */
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import PageEditorPage from '../page';
+import { isInnerCircle } from '@/lib/auth-helpers';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default async function PageEditorPreviewPage({ params }: { params: Promise<{ id: string; pageId: string }> }) {
+  if (!(await isInnerCircle())) {
+    notFound();
+  }
+  return <PageEditorPage params={params} allowHidden />;
+}

--- a/src/app/book/[id]/preview/page.tsx
+++ b/src/app/book/[id]/preview/page.tsx
@@ -1,23 +1,33 @@
 /**
- * Dynamic review-preview of a book's STAGED summary candidate.
+ * Dynamic, EDITOR-ONLY review-preview of a book.
  *
- * /book/<id-or-slug>/preview renders the same book page but with the proposed
- * summary (book.summary_candidate) shown in place of the live one, plus a
- * banner. Kept as a separate route because the main /book/[id] page is
- * ISR/static (export const revalidate) and cannot read request-time params;
- * this route is force-dynamic so it always reflects the current candidate.
+ * /book/<id-or-slug>/preview renders the same book page but (a) shows the
+ * proposed summary (book.summary_candidate) in place of the live one with a
+ * banner, and (b) can render HIDDEN books (visible:false) via allowHidden.
+ * Kept as a separate route because the main /book/[id] page is ISR/static
+ * (export const revalidate) and cannot read request-time params or run a
+ * per-user auth check without losing edge caching; this route is force-dynamic.
  *
+ * Because it can expose hidden (often in-copyright) books, it is gated to
+ * editor/admin sessions. Logged-out / non-editor visitors get a 404.
  * No promotion happens here — read-only preview for reviewers.
  */
+import { notFound } from 'next/navigation';
 import BookDetailPage, { generateMetadata as parentGenerateMetadata } from '../page';
+import { isInnerCircle } from '@/lib/auth-helpers';
 import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
-  return parentGenerateMetadata({ params });
+  // Always noindex the preview surface (parent already noindexes hidden books).
+  const meta = await parentGenerateMetadata({ params });
+  return { ...meta, robots: { index: false, follow: false } };
 }
 
 export default async function BookSummaryPreviewPage({ params }: { params: Promise<{ id: string }> }) {
-  return <BookDetailPage params={params} previewProposed />;
+  if (!(await isInnerCircle())) {
+    notFound();
+  }
+  return <BookDetailPage params={params} previewProposed allowHidden />;
 }

--- a/src/lib/book-access.ts
+++ b/src/lib/book-access.ts
@@ -1,0 +1,71 @@
+import { isInnerCircle } from '@/lib/auth-helpers';
+
+/**
+ * Access control for HIDDEN books (`visible === false`).
+ *
+ * A book is hidden when an editor/pipeline explicitly set `visible: false`
+ * (the parallel `hidden: true` flag is kept in sync — see CLAUDE.md
+ * "Visibility & Stats Invariants"). Hidden books are deliberately kept out
+ * of public surfaces — often because they are in copyright (modern critical
+ * editions / translations) or not yet QA'd.
+ *
+ * Until 2026-06 `visible: false` only removed a book from listings/search/
+ * sitemap; the reader page and every content API (quote/text/IIIF) still
+ * served the full text at the direct URL. This module is the gate that
+ * closes that leak.
+ *
+ * Scope is intentionally narrow: ONLY `visible === false` is gated. Legacy
+ * books with `visible: null`/missing (~6.5k, never explicitly promoted) stay
+ * public exactly as before — do NOT widen this to `visible !== true`.
+ *
+ * Who may still read a hidden book:
+ *   - the pipeline / Claude Code scripts, via `Authorization: Bearer <CRON_SECRET>`
+ *   - a logged-in editor/admin (isInnerCircle), e.g. in the /book/[id]/preview route
+ */
+
+/**
+ * Accepts any book-shaped object. Typed as `object` (not a `{ visible? }`
+ * literal) so BOTH concrete `Book` interfaces and Mongo `WithId<Document>`
+ * values pass without a cast at the ~17 call sites — a `{ visible? }` literal
+ * is a TS "weak type" that rejects `WithId<Document>`, while an index-signature
+ * type rejects the `Book` interface. `object` accepts every non-null object.
+ */
+export type BookLike = object;
+
+/** True only for books an editor deliberately hid. null/missing = NOT hidden. */
+export function isHiddenBook(book: BookLike | null | undefined): boolean {
+  return (book as { visible?: boolean | null } | null | undefined)?.visible === false;
+}
+
+/** True if the request carries the pipeline/Claude-Code CRON_SECRET bearer token. */
+export function hasCronAuth(request: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  return request.headers.get('authorization') === `Bearer ${secret}`;
+}
+
+/**
+ * May this requester read a hidden book? CRON_SECRET bearer OR editor session.
+ * Cheap path first (header check) so most public requests never hit the
+ * session lookup.
+ */
+export async function canReadHiddenBook(request: Request): Promise<boolean> {
+  if (hasCronAuth(request)) return true;
+  try {
+    return await isInnerCircle();
+  } catch {
+    return false; // fail closed
+  }
+}
+
+/**
+ * Final gate for API routes: returns true if the book may be served to this
+ * requester. Public books (visible !== false) always pass; hidden books pass
+ * only for CRON_SECRET or an editor session. A null book never passes
+ * (callers should already 404 on not-found, but this is defensive).
+ */
+export async function isBookReadable(book: BookLike | null | undefined, request: Request): Promise<boolean> {
+  if (!book) return false;
+  if (!isHiddenBook(book)) return true;
+  return canReadHiddenBook(request);
+}

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -541,6 +541,7 @@ export async function getCategoryCounts(): Promise<Map<string, number>> {
 // All fields needed for the book detail page shell
 const BOOK_DETAIL_SELECT = [
   BOOK_SELECT,
+  'visible', // needed by the /book/[id] hidden-book gate (book-access.ts)
   'contributing_library',
   'summary_text',
   'publisher',


### PR DESCRIPTION
## Problem

`visible: false` only removed a book from listings/search/sitemap. The **reader page and every content API still served the full text at the direct URL**, so deliberately-hidden books — including in-copyright modern editions/translations — were fully readable by anyone with the link.

Found while checking the hidden 1995 Garfield translation of the *Mūlamadhyamakakārikā*: page `200`'d, `/page/1` `200`'d, and `/api/books/<id>/quote` returned the verbatim copyrighted translation, despite `visible: false`.

## What this does

Gates **every public read surface** so hidden books 404 for the public, while preserving access for **editors (logged-in browser)** and **Claude Code / the pipeline (`Authorization: Bearer $CRON_SECRET`)**. Direct Mongo/MCP access is unaffected.

### Scope boundary (important)
Gates **`visible === false` only** — not `visible !== true`. The ~6,498 legacy `visible: null`/missing books keep their current public behavior. (Counts at time of change: 30,681 visible:true · 18,364 visible:false · 6,865 of those with real OCR text = the exposure closed.)

### Surfaces
- **`src/lib/book-access.ts`** (new): `isHiddenBook` + `isBookReadable(book, request)`. Public books short-circuit before any session lookup.
- **Reader pages** `/book/[id]`, `/book/[id]/page/[pageId]`: hidden → `notFound()`, gated **statically** (no per-user session read) so the 24h ISR/CDN cache is preserved. `generateMetadata` noindexes hidden.
- **Editor browser access**: existing `/book/[id]/preview` (already `force-dynamic`) is now **editor-gated** + passes `allowHidden`; new matching `/book/[id]/page/[pageId]/preview` for per-page reading of hidden books — keeps the high-volume per-page ISR route static.
- **Content APIs** (global + tenant twins): `quote`, `text`, `search`, `download`, `index` (GET), `chat` (GET); **IIIF** `manifest`, `search`, `autocomplete`, `canvas/[n]/{ocr,translation}`. Each 404s a hidden book unless editor/CRON_SECRET.

## Why caching is safe
A naive session check on `/book/[id]` would opt the route into dynamic rendering and kill the 24h CDN cache the project depends on. Instead the public route gates on the data only (uniform 404), and editor access lives on separate `force-dynamic` preview routes.

## Verification
- `npx tsc --noEmit`: clean.
- After the Vercel preview builds: a hidden book should 404 on the reader + all listed APIs; a visible book unchanged; `/book/<id>/preview` should 404 logged-out and render logged-in as editor; `Authorization: Bearer $CRON_SECRET` should still fetch hidden text.

## Out of scope / notes
- MCP tools that call these APIs without `CRON_SECRET` will now 404 on hidden books — intended (don't serve in-copyright text to external LLMs). Derek's CC access uses CRON_SECRET/Mongo.
- Did not touch the ~6.5k null-visible books, image/asset routes, or admin/mutation routes (already editor-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)