### PR TITLE
fix(developers): correct fake book slug + add missing search_concept tool

### DIFF
--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -227,6 +227,10 @@ export default function DevelopersPage() {
                 <td className="py-2.5 text-secondary">Search inside translated text across the whole library</td>
               </tr>
               <tr>
+                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">search_concept</td>
+                <td className="py-2.5 text-secondary">Semantic / conceptual passage search &mdash; matches paraphrases and adjacent ideas, not just keywords</td>
+              </tr>
+              <tr>
                 <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">search_within_book</td>
                 <td className="py-2.5 text-secondary">Search inside a specific book&apos;s pages</td>
               </tr>
@@ -292,10 +296,10 @@ source-library search "Paracelsus" --language=German
 source-library translations "harmony of the spheres"
 
 # Read a book
-source-library text fludd-utriusque --from=1 --to=50
+source-library text history-of-both-worlds-macrocosm-fludd --from=1 --to=50
 
 # Get exact text for quoting
-source-library quote fludd-utriusque 57
+source-library quote history-of-both-worlds-macrocosm-fludd 57
 
 # Browse illustrations
 source-library images --subject=alchemy --type=emblem
@@ -386,7 +390,7 @@ source-library search "alchemy" --json | jq .results`}
                 </tbody>
               </table>
               <div className="mt-4 bg-stone-900 rounded-lg p-3">
-                <code className="text-stone-300 text-sm">GET /books/fludd-utriusque/text?content=translation&amp;from=1&amp;to=50</code>
+                <code className="text-stone-300 text-sm">GET /books/history-of-both-worlds-macrocosm-fludd/text?content=translation&amp;from=1&amp;to=50</code>
               </div>
             </div>
           </div>
@@ -448,11 +452,11 @@ source-library search "alchemy" --json | jq .results`}
         <div className="bg-white rounded-xl border border-border-light p-6 space-y-4">
           <div>
             <span className="text-sm font-medium text-muted">Page</span>
-            <p className="font-mono text-stone-700 text-sm">https://sourcelibrary.org/book/fludd-utriusque?page=57</p>
+            <p className="font-mono text-stone-700 text-sm">https://sourcelibrary.org/book/history-of-both-worlds-macrocosm-fludd?page=57</p>
           </div>
           <div>
             <span className="text-sm font-medium text-muted">Book</span>
-            <p className="font-mono text-stone-700 text-sm">https://sourcelibrary.org/book/fludd-utriusque</p>
+            <p className="font-mono text-stone-700 text-sm">https://sourcelibrary.org/book/history-of-both-worlds-macrocosm-fludd</p>
           </div>
           <div>
             <span className="text-sm font-medium text-muted">With DOI</span>


### PR DESCRIPTION
## What

Two accuracy fixes to `/developers`, both found by checking the live page against the code and live API.

**1. Fake book slug `fludd-utriusque`.** Used as a literal example in three places — the REST `GET /books/.../text` example, the CLI examples, and (worst) the **Citation URLs** section presenting it as a working citation format. It 404s on `/api/books/fludd-utriusque` and redirects on `/book/fludd-utriusque`. Replaced everywhere with the real slug `history-of-both-worlds-macrocosm-fludd` (verified 200 on both the API and the book page).

**2. `search_concept` missing from the Tools table.** The page's own "30-second start" curl **and** fetch snippets both call `search_concept`, and the metadata says "9 research tools" — but the table only listed 8 and omitted it. The live MCP server exposes it (`tools/list` confirms). Added a row.

## Verification
- `npx tsc --noEmit` clean
- New slug: `/api/books/history-of-both-worlds-macrocosm-fludd` → 200, `/book/history-of-both-worlds-macrocosm-fludd` → 200
- `search_concept` present in live `tools/list`

## Out of scope
Did not touch the API-key / rate-limit behavior or the "12,000+ / 90,000+" headline numbers (both verified accurate/conservative — gallery actually ~151K).

🤖 Generated with [Claude Code](https://claude.com/claude-code)