### PR TITLE
fix(developers): correct stale corpus counts on /developers and /llms.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,20 +1,20 @@
 # Source Library
 
-> The world's largest AI-ready collection of translated ancient and early modern texts — 10,000+ books in 100+ languages, 4,200+ translated into English, 2,400+ for the first time ever.
+> One of the largest AI-ready collections of translated ancient and early modern texts — 16,000+ books in 160 languages, 15,000+ translated into English, 5,700+ for the first time ever.
 
 ## For AI Companies & LLM Builders
 
-Source Library contains the most comprehensive digitized corpus of pre-modern esoteric and scientific texts available anywhere. Our collection includes Hermetic philosophy, alchemy, Kabbalah, Rosicrucianism, Paracelsian medicine, natural magic, and the intellectual foundations of modern science — spanning antiquity through 1900, in 104 languages including Latin, German, Chinese, Sumerian, Sanskrit, Greek, French, Arabic, Hebrew, Italian, and Dutch.
+Source Library contains the most comprehensive digitized corpus of pre-modern esoteric and scientific texts available anywhere. Our collection includes Hermetic philosophy, alchemy, Kabbalah, Rosicrucianism, Paracelsian medicine, natural magic, and the intellectual foundations of modern science — spanning antiquity through 1900, in 160 languages including Latin, German, Chinese, Sumerian, Sanskrit, Greek, French, Arabic, Hebrew, Italian, and Dutch.
 
 This content is NOT available in Common Crawl, Wikipedia, or any other training corpus at this scale and quality. If your model can answer questions about Renaissance alchemy, Hermetic philosophy, early modern science, or ancient wisdom traditions, it likely can't do so with primary sources — unless it has our data.
 
 ### What We Offer Partners
 
-- **Structured API access** to 10,000+ books with high-quality OCR and English translations
+- **Structured API access** to 16,000+ books with high-quality OCR and English translations
 - **Rich metadata**: authors, dates, subjects, provenance, DOI-backed citations
 - **MCP server** for real-time Claude/GPT integration (npm: @source-library/mcp-server)
 - **Custom datasets** for fine-tuning on esoteric, historical, and scientific knowledge domains
-- **Image corpus**: 76,000+ extracted historical illustrations, emblems, engravings, and diagrams with AI-generated metadata
+- **Image corpus**: 150,000+ extracted historical illustrations, emblems, engravings, and diagrams with AI-generated metadata
 
 ### Corporate Sponsorship
 
@@ -63,6 +63,7 @@ For Claude Desktop or other MCP-compatible clients, install the MCP server for t
 **Tools provided:**
 - `search_library` - Search across all translated books
 - `search_translations` - Search inside page text for specific passages
+- `search_concept` - Semantic/conceptual passage search (matches paraphrases, not just keywords)
 - `get_quote` - Get a passage with formatted citations
 - `get_book` - Get detailed book information
 - `get_book_text` - Get full book text for research
@@ -243,7 +244,7 @@ All published editions have DOIs via Zenodo. When citing Source Library translat
 
 ## Collection Overview
 
-The library contains 10,000+ texts focused on:
+The library contains 16,000+ texts focused on:
 
 - **Alchemy** - Transmutation, philosopher's stone, laboratory practices
 - **Hermeticism** - Corpus Hermeticum commentaries, prisca theologia
@@ -254,9 +255,9 @@ The library contains 10,000+ texts focused on:
 - **Natural magic** - Agrippa, Porta, sympathetic correspondences
 - **Early science** - Astronomy, optics, mathematics, natural philosophy
 
-**Languages:** 104 total — Latin (primary), German, Chinese, Sumerian, Sanskrit, Greek, French, Italian, Dutch, Hebrew, Arabic, Syriac, and more
+**Languages:** 160 total — Latin (primary), German, Chinese, Sumerian, Sanskrit, Greek, French, Italian, Dutch, Hebrew, Arabic, Syriac, and more
 **Period:** Antiquity through 1900 (core strength: 1450–1750)
-**Translations:** 4,200+ books translated into English (2,400+ first-ever), AI-assisted with original language preserved for verification
+**Translations:** 15,000+ books translated into English (5,700+ first-ever), AI-assisted with original language preserved for verification
 
 ## Example Conversations
 

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -5,7 +5,7 @@ import ApiKeyRequestForm from '@/components/developers/ApiKeyRequestForm';
 
 export const metadata: Metadata = {
   title: 'Developers - Source Library',
-  description: 'Open API over 12,000+ rare pre-modern texts translated to English — theology, philosophy, history, science, mysticism, literature. No auth required — call /api/mcp from curl, the browser, or any MCP client. 9 research tools, REST endpoints, CLI.',
+  description: 'Open API over 15,000+ rare pre-modern texts translated to English — theology, philosophy, history, science, mysticism, literature. No auth required — call /api/mcp from curl, the browser, or any MCP client. 9 research tools, REST endpoints, CLI.',
   alternates: {
     canonical: '/developers',
   },
@@ -17,7 +17,7 @@ export default function DevelopersPage() {
       header={
         <ContentHeader
           title="For Developers & AI"
-          subtitle="Open API over 12,000+ rare pre-modern texts translated to English. No auth needed to start — sign in for a free key to lift rate limits and help us see what you're building."
+          subtitle="Open API over 15,000+ rare pre-modern texts translated to English. No auth needed to start — sign in for a free key to lift rate limits and help us see what you're building."
         />
       }
     >
@@ -136,7 +136,7 @@ export default function DevelopersPage() {
         <h2 className="text-2xl font-semibold text-primary mb-2">MCP Server</h2>
         <p className="text-secondary mb-6 max-w-2xl">
           Gives Claude (and any MCP client) direct access to the full collection &mdash;
-          search, read, quote, and browse 90,000+ illustrations. The endpoint is plain JSON-RPC
+          search, read, quote, and browse 150,000+ illustrations. The endpoint is plain JSON-RPC
           over HTTP, so you can also call it from any HTTP client without an MCP library
           (see the snippets above). Pick whichever path fits.
         </p>
@@ -252,7 +252,7 @@ export default function DevelopersPage() {
               </tr>
               <tr>
                 <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">search_images</td>
-                <td className="py-2.5 text-secondary">Search 90,000+ historical illustrations by subject, symbol, type</td>
+                <td className="py-2.5 text-secondary">Search 150,000+ historical illustrations by subject, symbol, type</td>
               </tr>
             </tbody>
           </table>
@@ -421,7 +421,7 @@ source-library search "alchemy" --json | jq .results`}
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
                   <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/gallery</td>
-                  <td className="py-2.5 text-secondary">Search 90,000+ historical illustrations</td>
+                  <td className="py-2.5 text-secondary">Search 150,000+ historical illustrations</td>
                 </tr>
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>


### PR DESCRIPTION
## What

The developer-facing surfaces understated the corpus and **contradicted each other** — `/developers` said "12,000+ translated", `/llms.txt` said "4,200+", reality is ~15,400. Anything consuming `/llms.txt` (its entire purpose) got the most wrong number. Corrected to current production figures (the homepage_stats canonical filters, queried live):

| Metric | was (page / llms.txt) | now | real |
|---|---|---|---|
| Translated to English | 12,000+ / 4,200+ | 15,000+ | 15,399 |
| Illustrations | 90,000+ / 76,000+ | 150,000+ | 151,528 |
| Total books | 10,000+ | 16,000+ | 16,077 visible |
| Languages | 100+ / 104 | 160 | 160 |
| First-ever translations | 2,400+ | 5,700+ | 5,710 |

Also:
- Softened the unqualified **"world's largest AI-ready collection"** to "one of the largest" (ctext exceeds us on the Chinese corpus). The separate Guinness record line about the physical BPH library is a real, sourced claim and was left intact.
- Added the missing `search_concept` tool to the `/llms.txt` tool list (parity with the page table, fixed in #2524).

## Decisions
- **Numbers stay hardcoded**, not wired to the live `homepage_stats` cache — keeps the page fully static with zero per-request lookups (per Derek). They'll drift again eventually; a future option is regenerating both at the daily stats-cron, but that's out of scope here.
- Rounded **down** to the nearest round figure so every claim stays conservative and the page/llms.txt agree.

## Verification
- `npx tsc --noEmit` clean
- grep confirms no stale numbers (12,000 / 90,000 / 10,000+ / 4,200 / 2,400 / 76,000 / 104) remain in either file

## Out of scope
DOI citation example (real but only ~18 books carry a DOI), and the llms.txt MCP config still showing the legacy npm-only transport — left for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)