### PR TITLE
tools: off-Vercel PDF importer + standing language-mismatch audit

### DIFF
--- a/scripts/import/pdf-direct.ts
+++ b/scripts/import/pdf-direct.ts
@@ -1,0 +1,117 @@
+/**
+ * pdf-direct.ts — local/Hetzner PDF importer (poppler required)
+ *
+ * The Vercel `/api/import/pdf` route can't run because `pdftoppm` (poppler)
+ * is absent from the Vercel serverless runtime (`spawnSync ENOENT`). This
+ * script does the same work where poppler EXISTS (local macOS / Hetzner):
+ * download PDF -> pdftoppm -> upload page JPEGs to R2 via storagePut ->
+ * insert book + pages HIDDEN. Mirrors the route's doc shape exactly.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/import/pdf-direct.ts <jobs.json>
+ *
+ * jobs.json: [{ pdf_url, ia_identifier?, title, author, language,
+ *               categories?, source_url?, acquisition_batch? }, ...]
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/mongodb';
+import { storagePut } from '@/lib/storage';
+import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
+import { generateUniqueBookSlug } from '@/lib/slugify';
+import { applyTextRole } from '@/lib/text-role';
+
+const DPI = 150;
+
+type Job = {
+  pdf_url: string; ia_identifier?: string; title: string; author: string;
+  language: string; categories?: string[]; source_url?: string; acquisition_batch?: string;
+};
+
+async function importOne(job: Job) {
+  const db = await getDb();
+  const provider = 'internet_archive';
+  const identifier = job.ia_identifier || null;
+  const source_url = job.source_url || job.pdf_url;
+
+  // dedup (manifestation + cross-source)
+  const fp = sourceFingerprint({ image_source: { provider, identifier: identifier || undefined, pdf_url: job.pdf_url } });
+  if (await db.collection('books').findOne({ source_fingerprint: fp })) { console.log(`  SKIP (dupe fingerprint): ${job.title}`); return null; }
+  const dedup = await checkDuplicate(db, { title: job.title, author: job.author, image_source: { provider, identifier: identifier || undefined, pdf_url: job.pdf_url, source_url } });
+  if (dedup.isDuplicate) { console.log(`  SKIP (dupe ${dedup.matches[0].matchType} -> ${dedup.matches[0].matchedTitle}): ${job.title}`); return null; }
+
+  const tmp = mkdtempSync(join(tmpdir(), 'pdfimp-'));
+  try {
+    // 1. download
+    const res = await fetch(job.pdf_url, { signal: AbortSignal.timeout(180000), headers: { 'User-Agent': 'SourceLibrary/1.0 (https://sourcelibrary.org)' } });
+    if (!res.ok) { console.log(`  FAIL download ${res.status}: ${job.title}`); return null; }
+    const buf = Buffer.from(await res.arrayBuffer());
+    const pdfPath = join(tmp, 'book.pdf'); writeFileSync(pdfPath, buf);
+
+    // 2. pdftoppm
+    const pagesDir = join(tmp, 'pages'); execFileSync('mkdir', ['-p', pagesDir]);
+    execFileSync('pdftoppm', ['-jpeg', '-r', String(DPI), '-jpegopt', 'quality=85', pdfPath, join(pagesDir, 'page')], { timeout: 1_800_000 });
+    const files = readdirSync(pagesDir).filter(f => f.endsWith('.jpg')).sort();
+    if (!files.length) { console.log(`  FAIL 0 pages: ${job.title}`); return null; }
+
+    // 3. upload to R2 (canonical books/{id}/pages/{NNNN}.jpg, matches route)
+    const bookId = new ObjectId(); const bookIdStr = bookId.toHexString();
+    const urls: { photo: string; bytes: number }[] = [];
+    const C = 10;
+    for (let b = 0; b < files.length; b += C) {
+      const chunk = files.slice(b, b + C);
+      const out = await Promise.all(chunk.map(async (f, i) => {
+        const idx = b + i; const img = readFileSync(join(pagesDir, f));
+        const r = await storagePut(`books/${bookIdStr}/pages/${String(idx).padStart(4, '0')}.jpg`, img, { access: 'public', contentType: 'image/jpeg' });
+        return { idx, photo: r.url, bytes: img.length };
+      }));
+      for (const o of out) urls[o.idx] = { photo: o.photo, bytes: o.bytes };
+    }
+    const now = new Date(); const pageCount = files.length;
+
+    // 4. book doc (hidden, language explicit, QA-gated)
+    const slug = await generateUniqueBookSlug(db, job.title, job.author);
+    const bookDoc: Record<string, unknown> = {
+      _id: bookId, id: bookIdStr, slug, title: job.title, display_title: null, author: job.author,
+      language: job.language, original_language: job.language,
+      field_provenance: { language: 'manual_curator_override' },
+      curation_status: 'awaiting_qa_eval', acquisition_batch: job.acquisition_batch || 'pdf-direct',
+      categories: job.categories || [], thumbnail: urls[0]?.photo || '',
+      pages_count: pageCount, pages_ocr: 0, pages_translated: 0,
+      dublin_core: { dc_identifier: identifier ? [`IA:${identifier}`] : [], dc_source: source_url },
+      image_source: { provider, provider_name: 'Internet Archive', source_url, pdf_url: job.pdf_url, identifier, license: 'publicdomain', access_date: now,
+        extraction: { method: 'pdftoppm', dpi: DPI, jpeg_quality: 85, pdf_size_bytes: buf.length, pages_extracted: pageCount, extracted_at: now } },
+      page_count_source: 'pdf_extraction', status: 'draft', hidden: true, visible: false,
+      source_fingerprint: fp, normalized_title: normalizeTitle(job.title), normalized_author: normalizeAuthor(job.author),
+      created_at: now, updated_at: now,
+    };
+    applyTextRole(bookDoc);
+    await db.collection('books').insertOne(bookDoc as any);
+
+    // 5. pages
+    const pageDocs = files.map((_, i) => {
+      const pid = new ObjectId(); const photo = urls[i]?.photo || '';
+      return { _id: pid, id: pid.toHexString(), book_id: bookIdStr, page_number: i + 1, photo, photo_original: job.pdf_url, archived_photo: photo,
+        archive_metadata: { source_url: job.pdf_url, source_page: i + 1, archived_at: now, method: 'pdf_extraction', dpi: DPI, bytes: urls[i]?.bytes || 0 }, created_at: now, updated_at: now };
+    });
+    await db.collection('pages').insertMany(pageDocs as any);
+    console.log(`  OK ${job.title.slice(0, 48)} -> ${bookIdStr} (${pageCount}pp)`);
+    return { bookId: bookIdStr, pages: pageCount };
+  } finally { rmSync(tmp, { recursive: true, force: true }); }
+}
+
+async function main() {
+  const jobsFile = process.argv[2];
+  if (!jobsFile) { console.error('usage: pdf-direct.ts <jobs.json>'); process.exit(1); }
+  const jobs: Job[] = JSON.parse(readFileSync(jobsFile, 'utf8'));
+  console.log(`pdf-direct: ${jobs.length} job(s)`);
+  let ok = 0;
+  for (const j of jobs) { try { if (await importOne(j)) ok++; } catch (e) { console.log(`  ERROR ${j.title}: ${e instanceof Error ? e.message : e}`); } }
+  console.log(`done: ${ok}/${jobs.length} imported`);
+  process.exit(0);
+}
+main();

--- a/scripts/maintenance/audit-language-mismatch.mjs
+++ b/scripts/maintenance/audit-language-mismatch.mjs
@@ -1,0 +1,118 @@
+/**
+ * audit-language-mismatch.mjs — standing check for catalog-language mislabels.
+ *
+ * The pipeline's title-page metadata phase stores the librarian model's
+ * content-read of the language in `ai_metadata.language`. Comparing that to
+ * the catalog `language` field surfaces mislabels automatically — the
+ * content-grounded version of the 2026-06-16 hand audit (see
+ * lesson_ia_nonlatin_language_mistag).
+ *
+ * Two buckets:
+ *   ENGLISH_AS_ORIGINAL — ai says English (or a modern Euro lang) but the book
+ *     is tagged a classical language with text_role:'original'. These are
+ *     modern translations mislabeled as source texts (SBE/Loeb/Mead/etc.).
+ *   LANG_DRIFT — any other normalized mismatch (e.g. import-time IA mistag:
+ *     Sanskrit scan tagged Marathi/Hindi).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/audit-language-mismatch.mjs            # report
+ *   node scripts/maintenance/audit-language-mismatch.mjs --flag     # set language_review marker
+ *   node scripts/maintenance/audit-language-mismatch.mjs --retag-english   # retag confirmed English-as-original (guarded)
+ */
+import { MongoClient } from 'mongodb';
+
+const FLAG = process.argv.includes('--flag');
+const RETAG = process.argv.includes('--retag-english');
+
+const CLASSICAL = new Set(['sanskrit','tibetan','pali','greek','latin','chinese','hebrew','arabic','syriac','coptic','geez','avestan','prakrit','church-slavonic','aramaic','old-persian','pahlavi']);
+const MODERN_EURO = new Set(['english','french','german','italian','spanish','dutch','russian','portuguese']);
+
+// normalize a language label to a canonical token
+function norm(s) {
+  if (!s) return '';
+  let t = String(s).toLowerCase().trim();
+  const map = {
+    'ancient greek':'greek','koine greek':'greek','classical greek':'greek','grc':'greek','el':'greek',
+    'pāli':'pali','pali (transliteration)':'pali',
+    'san':'sanskrit','sa':'sanskrit',
+    'lat':'latin','la':'latin',
+    'classical chinese':'chinese','literary chinese':'chinese','mandarin':'chinese','zh':'chinese','zh-hant':'chinese',
+    'old church slavonic':'church-slavonic','church slavonic':'church-slavonic',
+    "ge'ez":'geez','geʿez':'geez','ethiopic':'geez',
+    'he':'hebrew','ar':'arabic','eng':'english','en':'english','fr':'french','de':'german','nl':'dutch','it':'italian','es':'spanish','ru':'russian',
+    'marathi':'marathi','hindi':'hindi','nepali':'nepali','ne':'nepali',
+  };
+  return map[t] || t;
+}
+// split a possibly multi-language field into a set of canonical tokens
+function langSet(s) { return new Set(String(s||'').split(/[;,/|]/).map(norm).filter(Boolean)); }
+
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const B = mc.db('bookstore').collection('books');
+
+const cursor = B.find(
+  { 'ai_metadata.language': { $exists: true, $ne: '' }, language: { $exists: true, $ne: '' } },
+  { projection: { id:1, title:1, author:1, language:1, text_role:1, visible:1, 'ai_metadata.language':1, 'ai_metadata.confidence':1, 'ai_metadata.secondary_languages':1 } }
+);
+
+// placeholder / non-single-language catalog values that aren't real mislabels
+const PLACEHOLDER = new Set(['visual','und','unknown','undetermined','multiple','various','']);
+const englishAsOriginal = [], langDrift = [];
+let scanned = 0;
+for await (const b of cursor) {
+  scanned++;
+  const curRaw = String(b.language).toLowerCase();
+  if (PLACEHOLDER.has(norm(b.language)) || /[;/]| and /.test(curRaw)) continue; // skip placeholders + multi-language fields
+  const cur = langSet(b.language);
+  const ai = norm(b.ai_metadata?.language);
+  const conf = b.ai_metadata?.confidence || 'medium';
+  if (!ai || cur.has(ai)) continue;                       // agrees (or ai lang is one of the tagged langs)
+  const secondary = new Set([...(b.ai_metadata?.secondary_languages||[])].map(norm));
+  if (secondary.has([...cur][0])) {/* book lang is a secondary of ai — still a primary-language mismatch, keep */}
+  if (conf === 'low') continue;                            // ignore low-confidence reads
+  const curIsClassical = [...cur].some(l => CLASSICAL.has(l));
+  const rec = { id:b.id, title:(b.title||'').slice(0,52), author:(b.author||'').slice(0,26), current:b.language, detected:b.ai_metadata.language, conf, text_role:b.text_role||null, visible:b.visible!==false };
+  if (MODERN_EURO.has(ai) && curIsClassical && b.text_role !== 'modern-translation') englishAsOriginal.push(rec);
+  else if (b.text_role !== 'modern-translation') langDrift.push(rec);
+}
+
+const groupPairs = (arr) => {
+  const m = {};
+  for (const r of arr) { const k = `${r.current} → ${r.detected}`; m[k] = (m[k]||0)+1; }
+  return Object.entries(m).sort((a,b)=>b[1]-a[1]);
+};
+
+console.log(`scanned ${scanned} enriched books\n`);
+console.log(`== ENGLISH/modern-as-original (likely modern translations mislabeled): ${englishAsOriginal.length} ==`);
+for (const [k,n] of groupPairs(englishAsOriginal).slice(0,20)) console.log(`   ${k}: ${n}`);
+console.log(`\n== LANG_DRIFT (other mismatches, e.g. IA import mistag): ${langDrift.length} ==`);
+for (const [k,n] of groupPairs(langDrift).slice(0,25)) console.log(`   ${k}: ${n}`);
+console.log('\n-- sample English-as-original (high conf) --');
+for (const r of englishAsOriginal.filter(r=>r.conf==='high').slice(0,25)) console.log(`   [${r.current}→${r.detected}|${r.text_role}] ${r.author} — ${r.title} (${r.id})`);
+
+import fs from 'fs';
+fs.writeFileSync('/tmp/language-mismatch-audit.json', JSON.stringify({ englishAsOriginal, langDrift }, null, 2));
+console.log('\nfull -> /tmp/language-mismatch-audit.json');
+
+if (FLAG) {
+  const all = [...englishAsOriginal, ...langDrift];
+  let n=0;
+  for (const r of all) n += (await B.updateOne({ id:r.id }, { $set: { language_review: true, language_review_detail: { detected:r.detected, current:r.current, confidence:r.conf, bucket: englishAsOriginal.includes(r)?'english_as_original':'lang_drift', flagged_at:new Date() } } })).modifiedCount;
+  console.log(`\n[--flag] set language_review on ${n} books`);
+}
+if (RETAG) {
+  // Guarded: only high-confidence ENGLISH-detected (language→English is unambiguous),
+  // English-titled (avoid native-title false positives like Arabic-original w/ translation).
+  const NATIVE=/[ऀ-ॿༀ-࿿Ͱ-Ͽἀ-῿֐-׿؀-ۿ܀-ݏⲀ-⳿一-鿿]/;
+  const targets = englishAsOriginal.filter(r=>r.conf==='high' && norm(r.detected)==='english' && !NATIVE.test(r.title));
+  let n=0;
+  for (const r of targets) {
+    const b = await B.findOne({ id:r.id }, { projection:{ language:1 } });
+    n += (await B.updateOne({ id:r.id }, { $set: { text_role:'modern-translation', is_translation:true, language:'English', original_language:b.language, 'field_provenance.text_role':'audit_language_mismatch_auto', updated_at:new Date() } })).modifiedCount;
+  }
+  console.log(`\n[--retag-english] retagged ${n}/${targets.length} high-confidence English-as-original as modern-translation`);
+}
+await mc.close();
+process.exit(0);


### PR DESCRIPTION
## What
Two data tools built during a Sanskrit/Tibetan/Greek original-language acquisition run.

### `scripts/import/pdf-direct.ts`
PDF importer for sources with no page-image derivatives — uploaded-PDF IA items (no IIIF/JP2) and multi-PDF bundles like the BORI Mahābhārata. The Vercel `/api/import/pdf` route 500s because **`pdftoppm` (poppler) isn't in the serverless runtime** (issue #2526). This runs the same `download → pdftoppm → storagePut(R2) → insert-hidden` flow **locally / on Hetzner** where poppler exists, reusing the app's `dedup` / `sourceFingerprint` / `applyTextRole` / `generateUniqueBookSlug` helpers so the doc shape matches the route exactly. Imports land hidden + `curation_status:'awaiting_qa_eval'`.

Used it this session to import Śikṣāsamuccaya (Sanskrit, 498pp) and the full 18-parvan BORI Mahābhārata.

### `scripts/maintenance/audit-language-mismatch.mjs`
Standing data-quality check. The pipeline's title-page metadata phase stores the librarian model's content-read of language in `ai_metadata.language`; comparing that to the catalog `language` field surfaces mislabels automatically — the content-grounded version of a hand audit:
- **English/modern-as-original**: modern translations (SBE, Loeb, Mead, colonial Indology) tagged as classical originals.
- **Lang-drift**: IA import-time mistags (e.g. Sanskrit Devanāgarī scan tagged Marathi/Hindi).

`--flag` sets a `language_review` marker (review queue). `--retag-english` retags only the high-confidence, **English-detected, English-titled** subset as `modern-translation` (native-title and non-English detections are left for human review to avoid clobbering bilingual editions / Arabic-original-with-translation). Intended to run weekly on Hetzner.

## Scope / out of scope
- **In scope:** the two standalone scripts only. No app/route changes.
- **Out of scope (deliberate):** fixing `/api/import/pdf` itself (tracked in #2526 — options: bundle poppler, WASM rasterizer, or route PDF imports to Hetzner); the Hetzner cron entry for the audit (added separately on the box, which auto-pulls `main`).

## Risk
Low — both are scripts, no Vercel deploy needed (Hetzner auto-pulls `main`). `pdf-direct.ts` requires poppler present; `audit-language-mismatch.mjs` defaults to a dry-run report (writes only with `--flag`/`--retag-english`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)