### PR TITLE
fix(archiver): repair --book-id matching and undefined iaId in archive-ia-bulk

### DIFF
--- a/scripts/maintenance/archive-ia-bulk.mjs
+++ b/scripts/maintenance/archive-ia-bulk.mjs
@@ -17,7 +17,7 @@
  *   node scripts/maintenance/archive-ia-bulk.mjs --dry-run           # count only
  */
 
-import { MongoClient } from 'mongodb';
+import { MongoClient, ObjectId } from 'mongodb';
 import sharp from 'sharp';
 import { execSync } from 'child_process';
 import { execFile as execFileCb } from 'child_process';
@@ -311,7 +311,7 @@ async function processBook(book, db) {
       const photoUrl = page.photo_original || page.photo;
 
       try {
-        const jpegBuffer = await fetchPageImage(photoUrl, iaId);
+        const jpegBuffer = await fetchPageImage(photoUrl, sourceId);
 
         // Upload to R2
         const key = `archived/${page.book_id}/${page.page_number}.jpg`;
@@ -371,7 +371,7 @@ async function main() {
         { 'image_source.provider': { $in: ['ia', 'internet_archive'] } },
       ]}
     : { 'image_source.provider': { $exists: true, $ne: null, $nin: ['wikimedia_commons', 'rijksmuseum', 'met', 'nga'] } };
-  if (BOOK_ID) bookQuery._id = BOOK_ID;
+  if (BOOK_ID) bookQuery._id = /^[a-f0-9]{24}$/i.test(BOOK_ID) ? ObjectId.createFromHexString(BOOK_ID) : BOOK_ID;
 
   const iaBooks = await db.collection('books')
     .find(bookQuery, { projection: { _id: 1, id: 1, title: 1, ia_identifier: 1, image_source: 1, pages_count: 1 } })


### PR DESCRIPTION
## What

Two latent bugs made `scripts/maintenance/archive-ia-bulk.mjs` fail outright. Surfaced while re-archiving the external-image tail — ~14 visible books were still hotlinking `archive.org` / `e-rara` / `wellcome` / `leiden` images instead of serving from R2.

1. **`--book-id` matched nothing.** It assigned a hex string straight to the ObjectId `_id` field (`bookQuery._id = BOOK_ID`), so a single-book run always found 0 candidates. Now coerces a 24-hex id via `ObjectId.createFromHexString` (non-hex ids fall through unchanged for string-id books).
2. **Every page threw `ReferenceError: iaId is not defined`.** `processBook` called `fetchPageImage(photoUrl, iaId)` but only `sourceId` is in scope. The second arg is unused inside `fetchPageImage`, so 0 bytes were ever downloaded. Pass `sourceId`.

## Verification

With both fixed, the IIIF providers archive cleanly — re-archived and confirmed **100% on R2**: Vesalius (884/884), Almagestum Novum (2138/2138), Regola (100/100), Sententiarum (405/405), Reliquiae (16/16), Nuovo Receptario / Wellcome (186/186), Six Flags / Leiden (56/56).

## Out of scope

IA **access-restricted lending items** (`access-restricted-item: true`, e.g. Book of Enoch, Kama Sutra) still 403 their page images to any anonymous fetch by design — they can't be rehosted and need re-sourcing or hiding. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)