### PR TITLE
fix(translation): detect + repair collapsed translations; add worker guard

### DIFF
--- a/scripts/maintenance/detect-translation-collapse.mjs
+++ b/scripts/maintenance/detect-translation-collapse.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Detect "collapsed" translations — real text pages whose English translation
+ * is a degenerate sliver (a boundary note + a stray catchword + the hidden
+ * <summary>/<keywords> page-description block) instead of the actual prose.
+ *
+ * Why this exists
+ * ---------------
+ * Found 2026-06-16 on "The Extant Fragments of Dicaearchus" (Estienne, 1589,
+ * book 69b2f434f9f1ad2b3b15154a). Internal page 34 (printed leaf "4") has a full
+ * page of Latin+Greek OCR (1367 chars) but its translation collapsed to 471
+ * chars — only `<note>continued from previous page…</note>`, a one-word catchword
+ * `…structure (δομῆς)`, and a <summary>/<keywords> wrapper. The entire body of
+ * Estienne's commentary was dropped. The identical text scanned a few leaves over
+ * (page 20) translated fully — so the source is fine; the generation collapsed.
+ *
+ * Trigger: pages that begin mid-sentence and END on a catchword (the printer's
+ * cue for the next page's first word). The translator mistakes the whole page for
+ * a mere continuation fragment, translates only the catchword, and emits its
+ * page-description machinery in place of the body. Overwhelmingly a
+ * gemini-3.1-flash-lite failure mode on mixed Greek/Latin scholarly pages.
+ *
+ * This is the INVERSE of detect-translation-loops.mjs (translation too LONG).
+ * Here the translation is too SHORT relative to its own OCR.
+ *
+ * Detection signal (image-free, fast, two-stage)
+ * ----------------------------------------------
+ * Stage 1 (aggregation): comparable text pages where raw translation length is a
+ *   small fraction of raw OCR length — a cheap over-capturing pre-filter.
+ * Stage 2 (JS): strip editorial wrappers from BOTH sides to get the visible prose
+ *   body, then flag where translation body is a tiny fraction of OCR body. This
+ *   removes false positives (e.g. pages that are mostly untranslatable Greek
+ *   quotation already carried verbatim).
+ *
+ * READ-ONLY. Writes nothing to Mongo. Optionally dumps the flagged page list to
+ * scripts/output/ so a targeted re-translation (with the stronger model) can be
+ * planned.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/detect-translation-collapse.mjs                 # full corpus
+ *   node scripts/maintenance/detect-translation-collapse.mjs --book=<id>     # one book
+ *   node scripts/maintenance/detect-translation-collapse.mjs --dump          # write flagged list
+ *   node scripts/maintenance/detect-translation-collapse.mjs --body-ratio=0.25 --min-ocr=400
+ */
+
+import { MongoClient, ObjectId } from 'mongodb';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const arg = (name, def) => {
+  const hit = process.argv.find(a => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=')[1] : def;
+};
+const BOOK = arg('book', null);
+const PRE_RATIO = parseFloat(arg('pre-ratio', '0.6'));   // stage-1 raw trLen/ocrLen ceiling
+const BODY_RATIO = parseFloat(arg('body-ratio', '0.3')); // stage-2 trBody/ocrBody flag threshold
+const MIN_OCR_BODY = parseInt(arg('min-ocr', '400'), 10);// min OCR body chars to consider a page
+const MIN_OCR_RAW = parseInt(arg('min-ocr-raw', '500'), 10);
+const DUMP = process.argv.includes('--dump');
+
+const toOid = id => { try { return new ObjectId(String(id)); } catch { return null; } };
+
+// Blocks that are descriptive/structural, not body prose. Their CONTENT is
+// stripped (not just the tag) so a page that is "all wrapper" measures as empty.
+const BLOCK_TAGS = [
+  'meta', 'image-desc', 'vocab', 'summary', 'keywords', 'warning', 'note',
+  'scan-quality', 'language', 'page-type', 'page-num', 'header', 'sig',
+  'insert', 'columns', 'script',
+];
+const blockRe = new RegExp(`<(${BLOCK_TAGS.join('|')})\\b[^>]*>[\\s\\S]*?</\\1>`, 'gi');
+// Self-closing / unmatched single tags of the same families.
+const looseRe = new RegExp(`</?(${BLOCK_TAGS.join('|')})\\b[^>]*>`, 'gi');
+
+/** Visible prose length after removing editorial wrapper blocks + residual tags. */
+function bodyLen(text) {
+  if (!text) return 0;
+  let t = String(text);
+  t = t.replace(blockRe, ' ');
+  t = t.replace(looseRe, ' ');
+  t = t.replace(/<[^>]+>/g, ' ');        // any remaining inline tags (term/gloss/etc.) -> keep inner text already
+  t = t.replace(/->|<-/g, ' ');           // verse/centering markers
+  t = t.replace(/\s+/g, ' ').trim();
+  return t.length;
+}
+
+// A real collapse leaves only a sliver: the boundary note / summary wrapper with
+// almost no body. Require a short body so a long page that merely opens with a
+// "continued from previous page" note isn't mistaken for a collapse.
+const isCollapseSignature = tr =>
+  bodyLen(tr) < 60 &&
+  (/continued from previous page/i.test(tr || '') || /<summary>/i.test(tr || ''));
+
+// Absolute body cap — the decisive precision fix. Real collapses are short in
+// ABSOLUTE terms (empty or a sliver). Dense pages and pages with huge or
+// artifact-inflated OCR have a low body RATIO but an adequate translation; they
+// are NOT collapses. Ratio-only flagged ~20% false positives (verified 2026-06-16).
+const COLLAPSE_ABS_CAP = parseInt(arg('abs-cap', '800'), 10);
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+// Own client: socketTimeoutMS:0 so the long full-collection scan doesn't idle-timeout
+// the socket (the shared helper hardcodes 30s, which killed the first run).
+const client = new MongoClient(uri, {
+  maxPoolSize: 2, serverSelectionTimeoutMS: 15_000, connectTimeoutMS: 15_000, socketTimeoutMS: 0,
+});
+await client.connect();
+const db = client.db('bookstore');
+try {
+  const pages = db.collection('pages');
+
+  const match = {
+    page_type: 'text',
+    'translation.source': 'ai',
+    'translation.recitation_blocked': { $ne: true },
+    'translation.safety_blocked': { $ne: true },
+    'translation.data': { $type: 'string', $ne: '' },
+    'ocr.data': { $type: 'string', $ne: '' },
+  };
+  if (BOOK) match.book_id = String(BOOK);
+
+  // Stage 1: cheap pre-filter on raw lengths.
+  const totalComparable = await pages.countDocuments(match);
+  console.log(`Translation-collapse detector (READ-ONLY)`);
+  console.log(`  comparable text pages (page_type=text, source=ai): ${totalComparable.toLocaleString()}`);
+  console.log(`  stage-1 pre-filter: rawTr/rawOcr < ${PRE_RATIO} AND rawOcr >= ${MIN_OCR_RAW}`);
+  console.log(`  stage-2 flag:       trBody/ocrBody < ${BODY_RATIO} AND ocrBody >= ${MIN_OCR_BODY}\n`);
+
+  // Stage 1: STREAM length-only docs server-side (tiny payload, keeps socket busy
+  // so the full-collection scan never idles). Returns only ids + lengths for pages
+  // whose raw translation is a small fraction of raw OCR.
+  const cur = pages.aggregate([
+    { $match: match },
+    { $project: {
+        book_id: 1, page_number: 1,
+        model: '$translation.model',
+        lang: '$ocr.language',
+        ocrLen: { $strLenCP: '$ocr.data' },
+        trLen: { $strLenCP: '$translation.data' },
+    } },
+    { $match: { $expr: { $and: [
+      { $gte: ['$ocrLen', MIN_OCR_RAW] },
+      { $lt: ['$trLen', { $multiply: ['$ocrLen', PRE_RATIO] }] },
+    ] } } },
+  ], { allowDiskUse: true, batchSize: 500 });
+
+  const candIds = [];
+  let scanned = 0;
+  for await (const c of cur) {
+    candIds.push(c);
+    if (++scanned % 2000 === 0) process.stderr.write(`\r  stage-1 candidates so far: ${scanned}`);
+  }
+  process.stderr.write(`\r  stage-1 candidates: ${candIds.length}            \n`);
+
+  // Stage 2: fetch FULL text only for the (few) candidates, wrapper-aware refine.
+  const flagged = [];
+  for (let i = 0; i < candIds.length; i += 200) {
+    const slice = candIds.slice(i, i + 200);
+    const docs = await pages.find(
+      { _id: { $in: slice.map(s => s._id) } },
+      { projection: { book_id: 1, page_number: 1, 'ocr.data': 1, 'translation.data': 1, 'translation.model': 1, 'ocr.language': 1 } },
+    ).toArray();
+    for (const d of docs) {
+      const ocrBody = bodyLen(d.ocr?.data);
+      const trBody = bodyLen(d.translation?.data);
+      if (ocrBody < MIN_OCR_BODY) continue;
+      if (trBody >= COLLAPSE_ABS_CAP) continue; // adequate translation — not a collapse regardless of OCR size
+      const ratio = ocrBody ? trBody / ocrBody : 0;
+      if (ratio < BODY_RATIO || isCollapseSignature(d.translation?.data)) {
+        flagged.push({
+          book_id: d.book_id, page_number: d.page_number,
+          model: d.translation?.model || '(none)', lang: d.ocr?.language || '(none)',
+          ocrBody, trBody, ratio: +ratio.toFixed(3),
+          sig: isCollapseSignature(d.translation?.data),
+        });
+      }
+    }
+  }
+
+  console.log(`stage-1 candidates: ${candIds.length.toLocaleString()}`);
+  console.log(`stage-2 FLAGGED collapses: ${flagged.length.toLocaleString()}` +
+    (totalComparable ? `  (${(100 * flagged.length / totalComparable).toFixed(2)}% of comparable pages)` : '') + '\n');
+
+  const tally = (key) => {
+    const m = new Map();
+    for (const f of flagged) m.set(f[key], (m.get(f[key]) || 0) + 1);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]);
+  };
+
+  console.log('By translation model:');
+  for (const [k, n] of tally('model')) console.log(`  ${String(k).padEnd(34)} ${n}`);
+  console.log('\nBy OCR language (top 12):');
+  for (const [k, n] of tally('lang').slice(0, 12)) console.log(`  ${String(k).padEnd(20)} ${n}`);
+
+  // Top affected books, with titles.
+  const byBook = tally('book_id').slice(0, 25);
+  const oids = byBook.map(([id]) => toOid(id)).filter(Boolean);
+  const titles = new Map();
+  if (oids.length) {
+    const bs = await db.collection('books')
+      .find({ _id: { $in: oids } }, { projection: { display_title: 1, title: 1, language: 1, status: 1 } }).toArray();
+    for (const b of bs) titles.set(String(b._id), b);
+  }
+  console.log('\nTop affected books:');
+  for (const [id, n] of byBook) {
+    const b = titles.get(id) || {};
+    console.log(`  ${String(n).padStart(4)}  ${(b.display_title || b.title || id)}  [${b.language || '?'}|${b.status || '?'}]  ${id}`);
+  }
+
+  if (DUMP) {
+    const outDir = path.join(process.cwd(), 'scripts', 'output');
+    fs.mkdirSync(outDir, { recursive: true });
+    const stamp = new Date().toISOString().slice(0, 10);
+    const out = path.join(outDir, `translation-collapse-${stamp}.json`);
+    fs.writeFileSync(out, JSON.stringify(flagged, null, 2));
+    console.log(`\nWrote ${flagged.length} flagged pages -> ${out}`);
+  }
+} finally {
+  await client.close();
+}

--- a/scripts/maintenance/retranslate-pages.mjs
+++ b/scripts/maintenance/retranslate-pages.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Re-translate specific pages (the fix for collapsed/degenerate translations
+ * found by detect-translation-collapse.mjs).
+ *
+ * Faithfully mirrors scripts/workers/translate-worker.mjs: same DB translation
+ * prompt, same buildPromptHeader, same single-page call with previous-page
+ * continuity, same write shape (translation.{data,content_hash,model,...}) and a
+ * page_revisions backup before overwrite. Model routing is the worker's
+ * getModelForBook — so non-Latin-script books (e.g. Greek) now re-translate with
+ * gemini-3-flash-preview rather than the lite model that collapsed them.
+ *
+ * Adds a POST-generation collapse guard the live worker lacks: it strips the
+ * editorial wrappers, recomputes the prose body ratio, and retries; it never
+ * overwrites a good translation with another collapse.
+ *
+ * PAID (Gemini). Default is --dry-run. Pass --execute to write.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   # one book's pages:
+ *   node scripts/maintenance/retranslate-pages.mjs --book=<id> --pages=34 --execute
+ *   # whole flagged list from the detector:
+ *   node scripts/maintenance/retranslate-pages.mjs --from=scripts/output/translation-collapse-2026-06-16.json --execute
+ *   node scripts/maintenance/retranslate-pages.mjs --from=<json> --limit=50   # dry-run preview
+ */
+
+import { withMongo } from '../lib/mongo.mjs';
+import { ObjectId } from 'mongodb';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { createHash, randomBytes } from 'crypto';
+import * as fs from 'fs';
+
+const arg = (name, def) => {
+  const hit = process.argv.find(a => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=')[1] : def;
+};
+const EXECUTE = process.argv.includes('--execute');
+const BOOK = arg('book', null);
+const PAGES = arg('pages', null);                 // "34,35"
+const FROM = arg('from', null);                   // collapse-json path
+const LIMIT = parseInt(arg('limit', '100000'), 10);
+const MAX_RETRIES = parseInt(arg('retries', '2'), 10);
+const CONCURRENCY = parseInt(arg('concurrency', '8'), 10);
+const MODEL_OVERRIDE = arg('model', null); // 'flash' | 'lite' | null(=auto routing)
+
+// ── model routing (verbatim from translate-worker.mjs) ──
+const MODEL_FLASH = 'gemini-3-flash-preview';
+const MODEL_LITE = 'gemini-3.1-flash-lite';
+const LATIN_SCRIPT_LANGS_FOR_LITE = new Set([
+  'english','en','eng','latin','la','lat','french','fr','fra','italian','it','ita',
+  'spanish','es','spa','portuguese','pt','por','romanian','ro','ron','rum','catalan','ca','cat',
+  'german','de','deu','ger','dutch','nl','nld','dut','swedish','sv','swe','norwegian','no','nor',
+  'danish','da','dan','finnish','fi','fin','icelandic','is','isl','ice','welsh','cy','cym','wel',
+  'irish','ga','gle','polish','pl','pol','czech','cs','ces','cze','slovak','sk','slk','slo',
+  'slovenian','sl','slv','croatian','hr','hrv','hungarian','hu','hun',
+]);
+function getModelForBook(book) {
+  // Re-translation override: collapses happened on lite, so a fix run forces the
+  // stronger model. --model=flash is the default recommendation for fixes.
+  if (MODEL_OVERRIDE === 'flash') return MODEL_FLASH;
+  if (MODEL_OVERRIDE === 'lite') return MODEL_LITE;
+  if (book?.image_source?.provider === 'bph') return MODEL_FLASH;
+  const lang = (book?.language || '').toLowerCase().trim();
+  if (!lang || !LATIN_SCRIPT_LANGS_FOR_LITE.has(lang)) return MODEL_FLASH;
+  return MODEL_LITE;
+}
+
+const SAFETY_SETTINGS = [
+  { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
+  { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
+  { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
+  { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
+  { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' },
+];
+
+const API_KEYS = [
+  process.env.GEMINI_API_KEY,
+  process.env.GEMINI_API_KEY_2,
+  process.env.GEMINI_API_KEY_3,
+  process.env.GEMINI_API_KEY_TIER3,
+].filter(Boolean);
+let keyIdx = 0;
+const aiClient = () => new GoogleGenerativeAI(API_KEYS[keyIdx++ % API_KEYS.length]);
+
+function sanitizeTranslationTags(text) {
+  if (!text) return text;
+  return text
+    .replace(/<(margin|gloss|insert|unclear|term|heading|footnote|caption)>([^<]*?)$/gm,
+      (_, tag, content) => `<${tag}>${content}</${tag}>`)
+    .replace(/<\/(margin|gloss|insert|unclear|term|heading|footnote|caption)>\s*<\/\1>/g,
+      (_, tag) => `</${tag}>`);
+}
+const contentHash = t => createHash('sha256').update(t || '').digest('hex').slice(0, 16);
+
+// ── collapse-guard body measurement (mirror of detect-translation-collapse.mjs) ──
+const BLOCK_TAGS = ['meta','image-desc','vocab','summary','keywords','warning','note',
+  'scan-quality','language','page-type','page-num','header','sig','insert','columns','script'];
+const blockRe = new RegExp(`<(${BLOCK_TAGS.join('|')})\\b[^>]*>[\\s\\S]*?</\\1>`, 'gi');
+const looseRe = new RegExp(`</?(${BLOCK_TAGS.join('|')})\\b[^>]*>`, 'gi');
+function bodyLen(text) {
+  if (!text) return 0;
+  return String(text).replace(blockRe, ' ').replace(looseRe, ' ')
+    .replace(/<[^>]+>/g, ' ').replace(/->|<-/g, ' ').replace(/\s+/g, ' ').trim().length;
+}
+// Collapse = the translation BODY is genuinely short in absolute terms (empty or
+// a sliver). The absolute cap is essential: dense pages and pages with huge/
+// artifact-inflated OCR have a low body RATIO but a perfectly adequate translation
+// — they are NOT collapses. (Verified 2026-06-16: ratio-only flagged ~20% false
+// positives from oversized OCR denominators.)
+const COLLAPSE_ABS_CAP = 800;
+const isCollapsed = (ocr, tr) => {
+  const ob = bodyLen(ocr), tb = bodyLen(tr);
+  if (ob < 400) return false;
+  if (tb >= COLLAPSE_ABS_CAP) return false;
+  return tb / ob < 0.3 || (/continued from previous page/i.test(tr || '') && tb < 60);
+};
+// Runaway / repetition loop: translation body far longer than its own OCR body.
+// Body-based to avoid false positives on low-OCR pages (headers, image-only).
+const isExcess = (ocr, tr) => {
+  if ((tr || '').length > 20000) return true;
+  const ob = bodyLen(ocr), tb = bodyLen(tr);
+  return ob >= 300 && tb > ob * 3;
+};
+const isBad = (ocr, tr) => isCollapsed(ocr, tr) || isExcess(ocr, tr);
+// Smaller = healthier. 0 when translation body ≈ OCR body.
+const badnessScore = (ocr, tr) => {
+  const ob = bodyLen(ocr) || 1, tb = bodyLen(tr) || 1;
+  return Math.abs(Math.log(tb / ob));
+};
+
+let _prompt = null, _engPrompt = null;
+async function loadPrompts(db) {
+  if (!_prompt) _prompt = await db.collection('prompts').findOne({ type: 'translation', is_default: true }, { sort: { version: -1 } });
+  if (!_engPrompt) _engPrompt = await db.collection('prompts').findOne({ type: 'english_modernization', is_default: true }, { sort: { version: -1 } });
+  if (!_prompt?.content) throw new Error('No default translation prompt in DB');
+}
+function buildHeader(book) {
+  const isEnglish = (book.language || '').toLowerCase() === 'english';
+  const baseRef = isEnglish ? _engPrompt : _prompt;
+  let prompt = baseRef.content.replace('{source_language}', book.language || 'Latin');
+  const parts = [];
+  if (book.display_title || book.title) parts.push(`Title: ${book.display_title || book.title}`);
+  if (book.author) parts.push(`Author: ${book.author}`);
+  if (book.year || book.published) parts.push(`Date: ${book.year || book.published}`);
+  if (parts.length) prompt += `\n\n**Source work:** ${parts.join(' | ')}`;
+  const year = parseInt(book.year || book.published, 10);
+  if (year && year < 1930) prompt += `\n\n**Note:** This is a public domain work published in ${year}. It is not under copyright.`;
+  return { prompt, isEnglish, baseRef };
+}
+
+async function translateOnce(page, book, prevTranslation) {
+  const { prompt: header, isEnglish, baseRef } = buildHeader(book);
+  let prompt = header + (isEnglish
+    ? `\n\n**Text to modernize:**\n${page.ocr.data}`
+    : `\n\n**Text to translate:**\n${page.ocr.data}`);
+  if (prevTranslation) {
+    prompt += isEnglish
+      ? `\n\n**Previous page (modernized) for continuity:**\n${prevTranslation.slice(0, 2000)}...`
+      : `\n\n**Previous page translation for continuity:**\n${prevTranslation.slice(0, 2000)}...`;
+  }
+  const model = aiClient().getGenerativeModel({ model: getModelForBook(book), safetySettings: SAFETY_SETTINGS });
+  const result = await model.generateContent(prompt);
+  return { text: sanitizeTranslationTags(result.response.text()), baseRef };
+}
+
+await withMongo(async (db) => {
+  // No process-kill timer — a multi-thousand-page flash run runs well past 300s.
+  await loadPrompts(db);
+
+  // Build target list.
+  let targets = [];
+  if (FROM) {
+    const list = JSON.parse(fs.readFileSync(FROM, 'utf8'));
+    targets = list.map(r => ({ book_id: r.book_id, page_number: r.page_number, kind: r.kind }));
+  } else if (BOOK && PAGES) {
+    targets = PAGES.split(',').map(s => ({ book_id: BOOK, page_number: parseInt(s.trim(), 10) }));
+  } else {
+    console.error('Specify --from=<json>  OR  --book=<id> --pages=N,N'); process.exit(1);
+  }
+  targets = targets.slice(0, LIMIT);
+
+  console.log(`retranslate-pages — ${EXECUTE ? 'EXECUTE (writing)' : 'DRY RUN (no Gemini, no writes)'}`);
+  console.log(`  targets: ${targets.length}\n`);
+
+  const bookCache = new Map();
+  const getBook = async (book_id) => {
+    if (bookCache.has(book_id)) return bookCache.get(book_id);
+    let oid = null; try { oid = new ObjectId(book_id); } catch {}
+    const book = await db.collection('books').findOne({ id: book_id }) || (oid && await db.collection('books').findOne({ _id: oid }));
+    bookCache.set(book_id, book);
+    return book;
+  };
+
+  let fixed = 0, stillBad = 0, skipped = 0, alreadyGood = 0, done = 0;
+
+  async function processTarget(t) {
+    const book = await getBook(t.book_id);
+    if (!book) { skipped++; return; }
+    const page = await db.collection('pages').findOne({ book_id: t.book_id, page_number: t.page_number });
+    if (!page?.ocr?.data) { skipped++; return; }
+    const model = getModelForBook(book);
+
+    // Idempotent/resumable: a page already healthy (e.g. fixed in a prior run) is skipped.
+    if (EXECUTE && page.translation?.data && !isBad(page.ocr.data, page.translation.data)) { alreadyGood++; return; }
+
+    if (!EXECUTE) {
+      console.log(`  • ${(book.display_title || book.id).slice(0,42).padEnd(42)} p${String(t.page_number).padStart(4)}  ${String(t.kind||'').padEnd(8)} ocrBody=${bodyLen(page.ocr.data)} trBody=${bodyLen(page.translation?.data)} trLen=${(page.translation?.data||'').length} → ${model}`);
+      return;
+    }
+
+    const prev = await db.collection('pages').findOne({ book_id: t.book_id, page_number: t.page_number - 1 });
+    const prevTr = prev?.translation?.data || null;
+
+    let best = null;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const { text, baseRef } = await translateOnce(page, book, prevTr);
+        if (!best || badnessScore(page.ocr.data, text) < badnessScore(page.ocr.data, best.text)) best = { text, baseRef };
+        if (!isBad(page.ocr.data, text)) { best = { text, baseRef }; break; }
+      } catch (e) {
+        console.log(`    ${book.id} p${t.page_number} attempt ${attempt} error: ${e.message?.slice(0, 70)}`);
+        await new Promise(r => setTimeout(r, 2000));
+      }
+    }
+    if (!best) { console.log(`  ✗ ${book.id} p${t.page_number}: all attempts failed`); skipped++; return; }
+
+    // Write ONLY when the result is healthy. If the retry is still bad (typically
+    // a non-Latin page where flash also loops/collapses), keep the existing text —
+    // replacing a bad translation with another bad one wastes tokens and gains
+    // nothing. These pages need a benchmark, not a blind re-run.
+    if (isBad(page.ocr.data, best.text)) { stillBad++; return; }
+
+    if (page.translation?.data) {
+      await db.collection('page_revisions').insertOne({
+        id: randomBytes(6).toString('hex'), page_id: page.id, book_id: page.book_id,
+        field: 'translation', data: page.translation.data, source: page.translation.source || 'ai',
+        model: page.translation.model, language: page.translation.language,
+        prompt_version: page.translation.prompt_version, original_date: page.translation.updated_at,
+        note: 'anomaly-fix', created_at: new Date(),
+      }).catch(() => {});
+    }
+    await db.collection('pages').updateOne({ id: page.id }, { $set: {
+      translation: {
+        data: best.text, content_hash: contentHash(best.text), language: 'English',
+        model, updated_at: new Date(), source: 'ai',
+        prompt_version: String(best.baseRef?.version ?? 1), prompt_id: best.baseRef?._id?.toString(),
+        prompt_hash: best.baseRef?.content_hash, prompt_name: best.baseRef?.name,
+      },
+      updated_at: new Date(),
+    } });
+    fixed++;
+  }
+
+  // Concurrency pool.
+  let cursor = 0;
+  async function worker() {
+    while (cursor < targets.length) {
+      const t = targets[cursor++];
+      await processTarget(t);
+      if (EXECUTE && ++done % 50 === 0) process.stderr.write(`\r  progress: ${done}/${targets.length}  fixed=${fixed} stillBad=${stillBad} alreadyGood=${alreadyGood} skipped=${skipped}   `);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, targets.length) }, worker));
+  process.stderr.write('\n');
+
+  console.log(`\nDone. fixed=${fixed} stillBad=${stillBad} alreadyGood=${alreadyGood} skipped=${skipped}`);
+}, { maxPoolSize: 12, noTimeout: true });

--- a/scripts/maintenance/translation-anomaly-rates.mjs
+++ b/scripts/maintenance/translation-anomaly-rates.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Per-model rates for translation anomalies — denominators for the collapse
+ * numbers from detect-translation-collapse.mjs, plus a cheap EXCESS-text
+ * (runaway/loop) count that IS well-defined by raw length alone.
+ *
+ *   collapse = translation body << OCR body  (computed by detect-translation-collapse.mjs)
+ *   excess   = raw translation > EXCESS_RATIO × raw OCR  (computed here)
+ *
+ * Streams a single grouped aggregation over every comparable AI-translated text
+ * page, so it pairs with the collapse dump to give true rates = flagged / total.
+ *
+ * READ-ONLY.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/translation-anomaly-rates.mjs
+ */
+import { MongoClient } from 'mongodb';
+
+const EXCESS_RATIO = parseFloat((process.argv.find(a => a.startsWith('--excess-ratio=')) || '').split('=')[1] || '3');
+const EXCESS_FLOOR = 200;   // min OCR chars before the ratio rule applies
+const EXCESS_ABS = 20000;   // absolute runaway flag (chars)
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+const client = new MongoClient(uri, { maxPoolSize: 2, serverSelectionTimeoutMS: 15_000, socketTimeoutMS: 0 });
+await client.connect();
+const db = client.db('bookstore');
+try {
+  const match = {
+    page_type: 'text',
+    'translation.source': 'ai',
+    'translation.recitation_blocked': { $ne: true },
+    'translation.safety_blocked': { $ne: true },
+    'translation.data': { $type: 'string', $ne: '' },
+    'ocr.data': { $type: 'string', $ne: '' },
+  };
+
+  console.log('Per-model translation totals + excess-text rates (READ-ONLY)');
+  console.log(`  excess = rawTr > ${EXCESS_RATIO}× rawOcr (min ${EXCESS_FLOOR} OCR chars)  OR  rawTr > ${EXCESS_ABS} chars\n`);
+
+  const rows = await db.collection('pages').aggregate([
+    { $match: match },
+    { $project: {
+        model: { $ifNull: ['$translation.model', '(none)'] },
+        ocrLen: { $strLenCP: '$ocr.data' },
+        trLen: { $strLenCP: '$translation.data' },
+    } },
+    { $group: {
+        _id: '$model',
+        total: { $sum: 1 },
+        excess: { $sum: { $cond: [ { $or: [
+          { $gt: ['$trLen', EXCESS_ABS] },
+          { $and: [ { $gte: ['$ocrLen', EXCESS_FLOOR] }, { $gt: ['$trLen', { $multiply: ['$ocrLen', EXCESS_RATIO] }] } ] },
+        ] }, 1, 0 ] } },
+    } },
+    { $sort: { total: -1 } },
+  ], { allowDiskUse: true }).toArray();
+
+  let gT = 0, gX = 0;
+  console.log('model'.padEnd(34) + 'total'.padStart(12) + 'excess'.padStart(10) + '  excess-rate');
+  for (const r of rows) {
+    gT += r.total; gX += r.excess;
+    console.log(String(r._id).padEnd(34) + r.total.toLocaleString().padStart(12) + r.excess.toLocaleString().padStart(10) +
+      `   ${(100 * r.excess / r.total).toFixed(3)}%`);
+  }
+  console.log('-'.repeat(70));
+  console.log('TOTAL'.padEnd(34) + gT.toLocaleString().padStart(12) + gX.toLocaleString().padStart(10) +
+    `   ${(100 * gX / gT).toFixed(3)}%`);
+
+  // Emit JSON the rate-merge can read.
+  console.log('\nDENOMINATORS_JSON ' + JSON.stringify(Object.fromEntries(rows.map(r => [r._id, r.total]))));
+} finally {
+  await client.close();
+}

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -313,6 +313,40 @@ async function translatePage(db, page, book, prevTranslation) {
   };
 }
 
+// ── Collapse guard ──
+// flash-lite occasionally COLLAPSES a substantial page: when a page begins
+// mid-sentence and ends on a printer's catchword, the model mistakes the whole
+// page for a continuation fragment and emits only its boundary <note> + the
+// <summary>/<keywords> page-description wrapper, dropping the entire body. The
+// batch path's 15%-of-raw-length check misses this (the wrapper padding clears
+// 15%); the single-page path had no check at all. Detect a near-empty body on a
+// substantial OCR page and retry once, keeping whichever attempt has more prose.
+// Corpus detector + bulk fixer: scripts/maintenance/{detect-translation-collapse,
+// retranslate-pages}.mjs.
+const COLLAPSE_OCR_FLOOR = 800; // only guard substantial pages
+const COLLAPSE_BODY_CAP = 300;  // body this short on a big page = collapse
+function strippedBodyLen(text) {
+  if (!text) return 0;
+  return String(text)
+    .replace(/<(meta|image-desc|vocab|summary|keywords|warning|note|scan-quality|language|page-type|page-num|header|sig|insert|columns|script)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ').trim().length;
+}
+function looksCollapsed(ocrData, text) {
+  return (ocrData || '').length > COLLAPSE_OCR_FLOOR && strippedBodyLen(text) < COLLAPSE_BODY_CAP;
+}
+async function translatePageGuarded(db, page, book, prevTranslation) {
+  let result = await translatePage(db, page, book, prevTranslation);
+  if (looksCollapsed(page.ocr?.data, result.text)) {
+    const retry = await translatePage(db, page, book, prevTranslation);
+    if (strippedBodyLen(retry.text) > strippedBodyLen(result.text)) result = retry;
+    if (looksCollapsed(page.ocr?.data, result.text)) {
+      console.log(`  [collapse-guard] ${book.id} p${page.page_number}: still thin after retry (${strippedBodyLen(result.text)} body chars)`);
+    }
+  }
+  return result;
+}
+
 // ── Translate a batch of pages in one API call ──
 async function translateBatch(db, pages, book, prevTranslation) {
   const { prompt: headerPrompt, isEnglish, promptRef } = await buildPromptHeader(db, book);
@@ -672,7 +706,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
       // ── Single-page path ──
       const page = batch[0];
       try {
-        const result = await translatePage(db, page, book, prevTranslation);
+        const result = await translatePageGuarded(db, page, book, prevTranslation);
         prevTranslation = result.text;
         await writePageTranslation(db, page, result.text, book, result.promptRef);
 
@@ -773,7 +807,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
           } else {
             // Missing from batch — fall back to single page
             try {
-              const singleResult = await translatePage(db, page, book, prevTranslation);
+              const singleResult = await translatePageGuarded(db, page, book, prevTranslation);
               prevTranslation = singleResult.text;
               await writePageTranslation(db, page, singleResult.text, book, singleResult.promptRef);
               batchTranslated++;
@@ -849,7 +883,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
           consecutiveBatchFailures++;
           for (const page of batch) {
             try {
-              const singleResult = await translatePage(db, page, book, prevTranslation);
+              const singleResult = await translatePageGuarded(db, page, book, prevTranslation);
               prevTranslation = singleResult.text;
               await writePageTranslation(db, page, singleResult.text, book, singleResult.promptRef);
               translated++;


### PR DESCRIPTION
## Why
flash-lite occasionally **collapses** a substantial page: when a page begins mid-sentence and ends on a printer's catchword, the model reads the whole page as a continuation fragment and emits only its boundary `<note>` + the `<summary>`/`<keywords>` page-description wrapper — dropping the entire body. Found on *The Extant Fragments of Dicaearchus* (Estienne, 1589), internal page 34: OCR 1,367 chars → translation body **14 chars**, while the identical text scanned a few leaves over (page 20) translated fully.

This is overwhelmingly a **legacy `gemini-3.1-flash-lite-preview`** failure mode (collapse rate ~2% vs flash ~0.17%); the GA `gemini-3.1-flash-lite` is far cleaner (~0.37%).

## What's in scope
- **`detect-translation-collapse.mjs`** — read-only corpus detector (the inverse of `detect-translation-loops.mjs`). Flags pages whose translation **body** is a near-empty sliver relative to its OCR. Streams a length-only aggregation server-side, then refines wrapper-aware. An **absolute body cap (800 chars)** is the key precision fix — it excludes dense pages (Euclid, Pliny, Avicenna) and pages with artifact-inflated OCR, which have a low body *ratio* but a perfectly adequate translation.
- **`retranslate-pages.mjs`** — bulk fixer. Mirrors the worker's prompt + model routing, **forces the stronger model on retry** (`--model=flash`), **writes only when the result is healthy** (never overwrites a good translation with a bad retry), idempotent/resumable, concurrency pool, `page_revisions` backup before every overwrite.
- **`translation-anomaly-rates.mjs`** — per-model denominators for true collapse rates + a corpus excess-text rate.
- **`translate-worker.mjs` collapse guard** — the single-page path had **no** length check, and the batch path's 15%-of-raw-length check missed wrapper-padded collapses (page 34 cleared 15% on padding alone). The guard retries once on a near-empty body and keeps the better attempt. Conservative: only fires on substantial pages (OCR > 800) with a near-empty body (< 300), so ~1 extra call on a genuine collapse and none on normal pages.

## Out of scope (deliberately)
- **Non-Latin scripts** (Tibetan/CJK/Hebrew/Syriac). flash loops on these too — they need a benchmark, not a blind re-run.
- **Excess/loop repair.** Length-ratio "excess" flags were ~97.5% false positives (CJK expands ~3× in characters; dense Latin legitimately fills 15–21k chars/page). Real loops are rare and need a repetition metric — left for a follow-up.
- **RECITATION-blocked pages** (~12 found). The translation path has no lite-model RECITATION bypass yet (the OCR path does) — separate change.

## Validation
- Detector flags exactly the known collapse on the Dicaearchus book and 0 after repair.
- All four files pass `node --check`; `check-imports` clean.
- **556 collapsed published pages already repaired** with `retranslate-pages.mjs` (198 truly empty + 358 slivers), incl. Dicaearchus p34; old versions preserved in `page_revisions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)