### PR TITLE
works-catalog: Chinese scan matcher + Arabic/Persian/Hebrew harvest presets

### DIFF
--- a/scripts/iiif-discovery/sources/ia-language.mjs
+++ b/scripts/iiif-discovery/sources/ia-language.mjs
@@ -44,6 +44,9 @@ const LANGUAGE_PRESETS = {
   latin: '(lat OR latin OR la)',
   chinese: '(chi OR zho OR zh OR cmn OR chinese)',
   sanskrit: '(san OR sanskrit OR sa)',
+  arabic: '(ara OR ar OR arabic)',
+  persian: '(per OR fas OR fa OR persian OR farsi)',
+  hebrew: '(heb OR he OR hebrew)',
 };
 
 const args = Object.fromEntries(

--- a/scripts/works-catalog/README.md
+++ b/scripts/works-catalog/README.md
@@ -39,7 +39,13 @@ node scripts/works-catalog/ingest-gretil.mjs             # ~891 GRETIL works + t
 node scripts/works-catalog/ingest-pandit.mjs <csv> [--all]  # richest: authors/dates/disciplines (manual CSV — see Pandit note)
 node scripts/works-catalog/ingest-sefaria.mjs         # ~6.6K Hebrew works (Sefaria, CC0)
 # Coverage join (Phase 1) + provenance + holdings:
-node scripts/works-catalog/match-scans-ia.mjs --tradition=sanskrit --apply  # works <-> IA manifests -> work_sources(scan)
+node scripts/works-catalog/match-scans-ia.mjs --tradition=sanskrit --apply  # works <-> IA-sanskrit manifests -> work_sources(scan)
+node scripts/works-catalog/match-scans-chinese.mjs --apply                  # works <-> IA-chinese (717K) -> work_sources(scan); CJK-prefix, high precision
+# Scan-coverage gaps: islamicate + hebrew had NO IA manifests harvested at all —
+# harvest first (presets added 2026-06), then a script-aware matcher per language:
+#   node scripts/iiif-discovery/sources/ia-language.mjs --language=arabic
+#   node scripts/iiif-discovery/sources/ia-language.mjs --language=persian
+#   node scripts/iiif-discovery/sources/ia-language.mjs --language=hebrew
 node scripts/works-catalog/seed-provenance.mjs        # catalog_sources licensing/attribution rows
 node scripts/works-catalog/build-holdings.mjs         # Mongo books -> work_holdings (title-auto)
 # Translation census + calibration (per tradition):

--- a/scripts/works-catalog/match-scans-chinese.mjs
+++ b/scripts/works-catalog/match-scans-chinese.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Chinese scan-coverage join: works (Frame B catalog) ↔ ia_language=chinese IA
+ * manifests (Frame A harvest, 717K) → work_sources(kind='scan', source='ia-chinese').
+ *
+ * Complements ingest-ia-cadal.mjs (the curated CADAL classical set). The broad
+ * 717K ia_language=chinese harvest is mostly modern/Republican reprints, so the
+ * recoverable classical-canon overlap is small (~245 works at the precise tier)
+ * but high-precision: we only accept a match when the work's CJK-normalized title
+ * is a PREFIX of the IA normalized title (work name leads; IA adds commentary /
+ * volume / edition — 太極圖說 → 太極圖說論, 淮南鴻烈解 → 淮南鴻烈解·卷一~卷三).
+ *
+ * Generic short titles collide (周易 appears in thousands of IA titles), so a
+ * minimum normalized-title length gates the match (default 4). Prints a
+ * calibration sample + per-threshold coverage; only --apply writes work_sources.
+ *
+ * Run on Hetzner (needs MONGODB_URI + SUPABASE_DB_URL).
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/works-catalog/match-scans-chinese.mjs              # measure + sample
+ *   node scripts/works-catalog/match-scans-chinese.mjs --apply      # write scan sources
+ *   node scripts/works-catalog/match-scans-chinese.mjs --min-len=5 --sample=40
+ */
+import { MongoClient } from 'mongodb';
+import { pgClient, upsertSources, normalizeCjk } from './lib.mjs';
+
+const args = Object.fromEntries(process.argv.slice(2).filter(a => a.startsWith('--')).map(a => {
+  const [k, v] = a.slice(2).split('='); return [k, v ?? true];
+}));
+const MIN_LEN = parseInt(args['min-len']) || 4;   // min normalized-title chars to accept (collision guard)
+const APPLY = 'apply' in args;
+const SAMPLE = parseInt(args.sample) || 30;
+const MAX_SRC_PER_WORK = 3;
+
+// ── 1. index IA chinese manifests by 2-char block key of normalized title ─────
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const col = mc.db('bookstore').collection('import_candidates');
+console.log('Indexing ia_language=chinese manifests by normalized-title key…');
+const byKey = new Map();
+let iaCount = 0;
+const cur = col.find(
+  { source: 'ia_language', 'metadata.discovery_query': 'chinese', manifest_url: { $ne: null } },
+  { projection: { title: 1, manifest_url: 1, source_id: 1, 'metadata.access_restricted': 1 } });
+for await (const d of cur) {
+  const n = normalizeCjk(d.title);
+  if (n.length < 2) continue;
+  const k = n.slice(0, 2);
+  if (!byKey.has(k)) byKey.set(k, []);
+  const arr = byKey.get(k);
+  if (arr.length < 400) arr.push({ n, url: d.manifest_url, ia: d.source_id, title: d.title, restricted: !!d.metadata?.access_restricted });
+  iaCount++;
+}
+console.log(`Indexed ${iaCount.toLocaleString()} manifests → ${byKey.size.toLocaleString()} keys`);
+
+// ── 2. probe chinese works that have no scan yet ──────────────────────────────
+const pg = pgClient();
+await pg.connect();
+const { rows: works } = await pg.query(
+  `select w.id, w.title, w.title_normalized from works w
+   where w.tradition = 'chinese'
+     and not exists (select 1 from work_sources s where s.work_id = w.id and s.kind = 'scan')`);
+console.log(`Probing ${works.length.toLocaleString()} chinese works WITHOUT a scan yet (min-len ${MIN_LEN})…\n`);
+
+const cov = { 3: 0, 4: 0, 5: 0 }, tot = { 3: 0, 4: 0, 5: 0 };
+let matched = 0;
+const sources = [];
+const samplePairs = [];
+for (const w of works) {
+  const wn = w.title_normalized || normalizeCjk(w.title);
+  if (wn.length < 3) continue;
+  for (const L of [3, 4, 5]) if (wn.length >= L) tot[L]++;
+  const cand = byKey.get(wn.slice(0, 2)) || [];
+  const hits = cand.filter(c => c.n.startsWith(wn));
+  if (!hits.length) continue;
+  for (const L of [3, 4, 5]) if (wn.length >= L) cov[L]++;
+  if (wn.length < MIN_LEN) continue;   // below the accept threshold: counted in coverage, not written
+  matched++;
+  if (samplePairs.length < SAMPLE) samplePairs.push({ w: w.title, ia: hits[0].title });
+  for (const h of hits.slice(0, MAX_SRC_PER_WORK)) {
+    sources.push({
+      work_id: w.id, source: 'ia-chinese', source_id: h.ia, kind: 'scan',
+      url: h.url, iiif: true, coverage: null,
+      extra: { ia_title: h.title?.slice(0, 120), access_restricted: h.restricted, match: 'cjk-prefix' },
+    });
+  }
+}
+await mc.close();
+
+// ── 3. report (always) + apply (optional) ────────────────────────────────────
+console.log('=== CALIBRATION SAMPLE (work title → matched IA title) ===');
+for (const p of samplePairs) console.log(`  ${(p.w || '').slice(0, 24).padEnd(24)} → ${(p.ia || '').slice(0, 56)}`);
+console.log('\n=== RECOVERABLE CHINESE SCAN COVERAGE (CJK-prefix match) ===');
+for (const L of [3, 4, 5]) console.log(`  min title ${L} chars: ${cov[L].toLocaleString()} / ${tot[L].toLocaleString()} (${(100 * cov[L] / tot[L]).toFixed(1)}%)`);
+console.log(`\nAccepting min-len ${MIN_LEN}: ${matched.toLocaleString()} works, ${sources.length.toLocaleString()} scan source rows prepared.`);
+console.log('NOTE: precision drops sharply below len 4 (周易, 論語 too generic). Eyeball the sample.');
+
+if (APPLY) {
+  const n = await upsertSources(pg, sources);
+  console.log(`\nApplied ${n} ia-chinese scan work_sources.`);
+} else {
+  console.log('\nMEASUREMENT ONLY — re-run with --apply to write work_sources.');
+}
+await pg.end();


### PR DESCRIPTION
## What
Expands works-catalog (#2453) scan coverage.

- **`match-scans-chinese.mjs`** — new matcher joining catalogue Chinese works to the 717K `ia_language=chinese` IA manifests (previously only the curated ~34K ia-cadal set was matched). High-precision CJK-prefix match (work title leads the IA title, e.g. 太極圖說 → 太極圖說論); min-length collision guard; measurement-first, `--apply` writes `work_sources(source='ia-chinese')`. Measured: ~245 clean additions (the broad harvest is mostly modern reprints, not the classical canon — so this is a small, safe win, not a windfall).
- **arabic / persian / hebrew presets** in the IA discovery crawler. Islamicate (8,791 works) and Hebrew (6,592) currently have **zero** scan coverage because no manifests were ever harvested for those scripts. These presets (code-union queries, per the sanskrit 28× lesson) unblock the harvest; script-aware matchers are a follow-up.
- README run-order updated.

## Scope
Out of scope: the Arabic/Hebrew matchers themselves (romanization bridge differs from Sanskrit's) and actually running the harvests — done operationally on Hetzner after merge.

## Risk
Low. New script is measurement-first. Preset edit is additive (3 keys). `check-imports` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)