### PR TITLE
works-catalog: Arabic + Hebrew scan matchers

### DIFF
--- a/scripts/works-catalog/README.md
+++ b/scripts/works-catalog/README.md
@@ -41,11 +41,13 @@ node scripts/works-catalog/ingest-sefaria.mjs         # ~6.6K Hebrew works (Sefa
 # Coverage join (Phase 1) + provenance + holdings:
 node scripts/works-catalog/match-scans-ia.mjs --tradition=sanskrit --apply  # works <-> IA-sanskrit manifests -> work_sources(scan)
 node scripts/works-catalog/match-scans-chinese.mjs --apply                  # works <-> IA-chinese (717K) -> work_sources(scan); CJK-prefix, high precision
-# Scan-coverage gaps: islamicate + hebrew had NO IA manifests harvested at all —
-# harvest first (presets added 2026-06), then a script-aware matcher per language:
-#   node scripts/iiif-discovery/sources/ia-language.mjs --language=arabic
+# Islamicate + hebrew had NO IA manifests harvested — harvest first (presets added 2026-06):
+#   node scripts/iiif-discovery/sources/ia-language.mjs --language=arabic   # ~749K manifests
 #   node scripts/iiif-discovery/sources/ia-language.mjs --language=persian
 #   node scripts/iiif-discovery/sources/ia-language.mjs --language=hebrew
+# then the Semitic-script matcher (Arabic-script for islamicate, Hebrew-script for hebrew):
+node scripts/works-catalog/match-scans-semitic.mjs --tradition=islamicate --apply  # ~53%+ of works (arabic+persian harvests)
+node scripts/works-catalog/match-scans-semitic.mjs --tradition=hebrew --apply      # low yield expected: Sefaria nodes are granular commentaries
 node scripts/works-catalog/seed-provenance.mjs        # catalog_sources licensing/attribution rows
 node scripts/works-catalog/build-holdings.mjs         # Mongo books -> work_holdings (title-auto)
 # Translation census + calibration (per tradition):

--- a/scripts/works-catalog/lib.mjs
+++ b/scripts/works-catalog/lib.mjs
@@ -29,6 +29,34 @@ export function normalizeCjk(s) {
     .replace(/[()（）\s]/g, '');
 }
 
+// Arabic-script title normalization for scan matching (OpenITI works ↔ IA Arabic
+// manifests). IA Arabic titles carry tashkeel (harakat), tatweel, and alif/ya/
+// hamza variants inconsistently; collapse them to a diacritic-free skeleton.
+const AR_DIACRITICS = /[\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E8\u06EA-\u06ED\u0640]/g; // harakat + Quranic marks + tatweel
+export function normalizeArabic(s) {
+  return (s || '')
+    .replace(AR_DIACRITICS, '')
+    .replace(/[آأإٱٲٳ]/g, 'ا') // آأإ etc → ا
+    .replace(/ى/g, 'ي')   // alif maqsura ى → ي
+    .replace(/ة/g, 'ه')   // ta marbuta ة → ه
+    .replace(/ؤ/g, 'و')   // waw-hamza ؤ → و
+    .replace(/ئ/g, 'ي')   // ya-hamza ئ → ي
+    .replace(/[ء]/g, '')       // bare hamza ء → drop
+    .replace(/[^؀-ۿ]/g, ''); // letters only (drops spaces, latin, punctuation)
+}
+
+// Hebrew-script title normalization (Sefaria works ↔ IA Hebrew manifests).
+// Strip niqqud + cantillation + gershayim/geresh (incl. ASCII " ' that Sefaria
+// uses inside abbreviations like רידב"ז), fold final letters (sofit).
+const HE_POINTS = /[֑-ֽֿׁ-ׇ׳״"']/g;
+const HE_SOFIT = { 'ך': 'כ', 'ם': 'מ', 'ן': 'נ', 'ף': 'פ', 'ץ': 'צ' };
+export function normalizeHebrew(s) {
+  return [...((s || '').replace(HE_POINTS, ''))]
+    .map(c => HE_SOFIT[c] || c)
+    .join('')
+    .replace(/[^א-ת]/g, ''); // Hebrew letters only
+}
+
 export async function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
 export async function fetchRetry(url, opts = {}, tries = 4) {

--- a/scripts/works-catalog/match-scans-semitic.mjs
+++ b/scripts/works-catalog/match-scans-semitic.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Semitic-script scan-coverage join: works (Frame B catalog) ↔ IA manifests
+ * harvested for the matching language → work_sources(kind='scan').
+ *
+ *   --tradition=islamicate  : OpenITI works (Arabic-script title) ↔ IA
+ *                             ia_language=arabic + persian manifests. source='ia-islamicate'.
+ *   --tradition=hebrew      : Sefaria works (Hebrew-script title) ↔ IA
+ *                             ia_language=hebrew manifests. source='ia-hebrew'.
+ *
+ * Both sides match on the ORIGINAL-SCRIPT title (islamicate title_romanized is a
+ * truncated URI slug; hebrew title_english is clean but the IA print volumes are
+ * Hebrew-titled), normalized to a diacritic-free skeleton (normalizeArabic /
+ * normalizeHebrew in lib.mjs). A match is accepted when one normalized title is a
+ * PREFIX of the other (work name leads the IA title, possibly with author /
+ * commentary / volume), gated by a minimum length to suppress generic collisions.
+ *
+ * Lossy → runs as MEASUREMENT by default (coverage + calibration sample); only
+ * --apply writes work_sources. ALWAYS eyeball the sample before --apply: the
+ * Hebrew corpus is mostly granular Talmud/Mishneh-Torah commentaries that have no
+ * standalone print scan, so a low hebrew yield is expected and correct.
+ *
+ * Run on Hetzner (needs MONGODB_URI + SUPABASE_DB_URL).
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/works-catalog/match-scans-semitic.mjs --tradition=islamicate
+ *   node scripts/works-catalog/match-scans-semitic.mjs --tradition=hebrew --apply
+ *   node scripts/works-catalog/match-scans-semitic.mjs --tradition=islamicate --min-len=7 --sample=40
+ */
+import { MongoClient } from 'mongodb';
+import { pgClient, upsertSources, normalizeArabic, normalizeHebrew } from './lib.mjs';
+
+const args = Object.fromEntries(process.argv.slice(2).filter(a => a.startsWith('--')).map(a => {
+  const [k, v] = a.slice(2).split('='); return [k, v ?? true];
+}));
+const TRADITION = args.tradition;
+const APPLY = 'apply' in args;
+const SAMPLE = parseInt(args.sample) || 30;
+const MAX_SRC_PER_WORK = 3;
+const KEYLEN = 3;  // block-key length on the normalized skeleton
+
+const CONFIG = {
+  islamicate: { norm: normalizeArabic, queries: ['arabic', 'persian'], source: 'ia-islamicate', minLen: 6 },
+  hebrew:     { norm: normalizeHebrew, queries: ['hebrew'],            source: 'ia-hebrew',     minLen: 5 },
+};
+const cfg = CONFIG[TRADITION];
+if (!cfg) { console.error(`--tradition must be one of: ${Object.keys(CONFIG).join(', ')}`); process.exit(1); }
+const MIN_LEN = parseInt(args['min-len']) || cfg.minLen;
+const norm = cfg.norm;
+
+// PREFIX precision filter: a key collision is a real match only if one full
+// skeleton leads the other (rejects mid-word divergence).
+function prefixCompatible(a, b) {
+  return a.length >= MIN_LEN && b.length >= MIN_LEN && (a.startsWith(b) || b.startsWith(a));
+}
+
+// ── 1. index IA manifests by skeleton block key ───────────────────────────────
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const col = mc.db('bookstore').collection('import_candidates');
+console.log(`Indexing IA ${cfg.queries.join('+')} manifests by ${TRADITION} skeleton key…`);
+const byKey = new Map();
+let iaCount = 0;
+const cur = col.find(
+  { source: 'ia_language', 'metadata.discovery_query': { $in: cfg.queries }, manifest_url: { $ne: null } },
+  { projection: { title: 1, manifest_url: 1, source_id: 1, 'metadata.access_restricted': 1 } });
+for await (const d of cur) {
+  const n = norm(d.title);
+  if (n.length < KEYLEN) continue;
+  const k = n.slice(0, KEYLEN);
+  if (!byKey.has(k)) byKey.set(k, []);
+  const arr = byKey.get(k);
+  if (arr.length < 600) arr.push({ n, url: d.manifest_url, ia: d.source_id, title: d.title, restricted: !!d.metadata?.access_restricted });
+  iaCount++;
+}
+console.log(`Indexed ${iaCount.toLocaleString()} manifests → ${byKey.size.toLocaleString()} keys`);
+
+// ── 2. probe works ────────────────────────────────────────────────────────────
+const pg = pgClient();
+await pg.connect();
+const { rows: works } = await pg.query(
+  `select w.id, w.title, w.title_romanized from works w
+   where w.tradition = $1
+     and not exists (select 1 from work_sources s where s.work_id = w.id and s.kind = 'scan')`, [TRADITION]);
+console.log(`Probing ${works.length.toLocaleString()} ${TRADITION} works WITHOUT a scan yet (min-len ${MIN_LEN})…\n`);
+
+let matched = 0, thin = 0;
+const sources = [];
+const samplePairs = [];
+for (const w of works) {
+  const wn = norm(w.title);
+  if (wn.length < MIN_LEN) { thin++; continue; }
+  const hits = (byKey.get(wn.slice(0, KEYLEN)) || []).filter(h => prefixCompatible(wn, h.n));
+  if (!hits.length) continue;
+  matched++;
+  if (samplePairs.length < SAMPLE) samplePairs.push({ w: w.title, ia: hits[0].title });
+  for (const h of hits.slice(0, MAX_SRC_PER_WORK)) {
+    sources.push({
+      work_id: w.id, source: cfg.source, source_id: h.ia, kind: 'scan',
+      url: h.url, iiif: true, coverage: null,
+      extra: { ia_title: h.title?.slice(0, 120), access_restricted: h.restricted, match: 'script-prefix' },
+    });
+  }
+}
+await mc.close();
+
+// ── 3. report (always) + apply (optional) ─────────────────────────────────────
+const keyable = works.length - thin;
+console.log('=== CALIBRATION SAMPLE (work title → matched IA title) ===');
+for (const p of samplePairs) console.log(`  ${(p.w || '').slice(0, 30).padEnd(30)} → ${(p.ia || '').slice(0, 50)}`);
+console.log(`\n=== SCAN COVERAGE (${TRADITION}, prefix match, min-len ${MIN_LEN}) ===`);
+console.log(`Works (no scan yet): ${works.length.toLocaleString()} (thin/unkeyable ${thin})`);
+console.log(`Works with ≥1 IA manifest: ${matched.toLocaleString()} (${(matched / keyable * 100).toFixed(1)}% of keyable)`);
+console.log(`Scan source rows prepared: ${sources.length.toLocaleString()}`);
+console.log('NOTE: floor — only IA-harvested manifests, only when one title leads the other. Verify the sample.');
+
+if (APPLY) {
+  const n = await upsertSources(pg, sources);
+  console.log(`\nApplied ${n} ${cfg.source} scan work_sources.`);
+} else {
+  console.log('\nMEASUREMENT ONLY — re-run with --apply to write work_sources.');
+}
+await pg.end();


### PR DESCRIPTION
## What
Closes the scan-coverage gap for Islamicate + Hebrew works (#2453), which had **zero** scans because no IA manifests existed for those scripts (PR #2535 harvested them).

- **`normalizeArabic` / `normalizeHebrew`** in `lib.mjs` — diacritic/niqqud-free original-script skeletons (Arabic: harakat/tatweel/alif-hamza folding; Hebrew: niqqud/cantillation/gershayim strip + sofit fold).
- **`match-scans-semitic.mjs`** — parameterized matcher (`--tradition=islamicate|hebrew`). Islamicate matches against the arabic **+ persian** harvests (Persian works are Arabic-script); Hebrew against the hebrew harvest. Original-script prefix match, measurement-first, `--apply` writes `work_sources(source='ia-islamicate'|'ia-hebrew')`.

## Calibration (local, partial Arabic harvest = 452K/748K manifests, Persian not yet in)
Islamicate: **52.8% of keyable works matched** with clean precision — classical diwans and their with-commentary editions captured correctly (ديوان علقمة الفحل → ديوان علقمة الفحل التميمي). Final coverage will be higher once Arabic completes + Persian lands.

Hebrew yield is measured **after** its harvest finishes; expected low (Sefaria entries are granular Talmud/Mishneh-Torah commentary nodes, not standalone print volumes) — the famous standalone works will match.

## Scope
`--apply` runs operationally on Hetzner once the harvests complete; this PR is the tooling.

## Risk
Low. Measurement-first; `check-imports` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)