### PR TITLE
works-catalog: calibrate semitic matcher (islamicate min-len 8, hebrew skipped)

### DIFF
--- a/scripts/works-catalog/README.md
+++ b/scripts/works-catalog/README.md
@@ -46,8 +46,11 @@ node scripts/works-catalog/match-scans-chinese.mjs --apply                  # wo
 #   node scripts/iiif-discovery/sources/ia-language.mjs --language=persian
 #   node scripts/iiif-discovery/sources/ia-language.mjs --language=hebrew
 # then the Semitic-script matcher (Arabic-script for islamicate, Hebrew-script for hebrew):
-node scripts/works-catalog/match-scans-semitic.mjs --tradition=islamicate --apply  # ~53%+ of works (arabic+persian harvests)
-node scripts/works-catalog/match-scans-semitic.mjs --tradition=hebrew --apply      # low yield expected: Sefaria nodes are granular commentaries
+node scripts/works-catalog/match-scans-semitic.mjs --tradition=islamicate --apply  # APPLIED 2026-06: 4,010 works (50.4%), min-len 8, ~93% precision
+# hebrew: NOT applied — structurally unproductive (Sefaria = granular commentary
+# nodes; IA has only ~2.9K usable Hebrew manifests; ~58% precision / 12 works at
+# min-len 9). Real Hebrew scans need NLI / Otzar HaHochma — a separate harvest.
+# node scripts/works-catalog/match-scans-semitic.mjs --tradition=hebrew --apply
 node scripts/works-catalog/seed-provenance.mjs        # catalog_sources licensing/attribution rows
 node scripts/works-catalog/build-holdings.mjs         # Mongo books -> work_holdings (title-auto)
 # Translation census + calibration (per tradition):

--- a/scripts/works-catalog/match-scans-semitic.mjs
+++ b/scripts/works-catalog/match-scans-semitic.mjs
@@ -38,9 +38,16 @@ const SAMPLE = parseInt(args.sample) || 30;
 const MAX_SRC_PER_WORK = 3;
 const KEYLEN = 3;  // block-key length on the normalized skeleton
 
+// minLen = min normalized-skeleton length to accept a prefix match. Calibrated
+// 2026-06: islamicate 8 (6 let through generic short IA titles — الكتاب "the
+// book", الحضارة "civilization" — that prefix longer work titles; 8 = ~93%
+// precision / 4,010 works). hebrew is structurally low-yield (Sefaria nodes are
+// granular commentaries, IA has ~2.9K usable Hebrew manifests) — even min-len 9
+// is only ~58% precision / 12 works, so hebrew is NOT applied via this path;
+// the real Hebrew scan source is NLI / Otzar HaHochma, a separate harvest.
 const CONFIG = {
-  islamicate: { norm: normalizeArabic, queries: ['arabic', 'persian'], source: 'ia-islamicate', minLen: 6 },
-  hebrew:     { norm: normalizeHebrew, queries: ['hebrew'],            source: 'ia-hebrew',     minLen: 5 },
+  islamicate: { norm: normalizeArabic, queries: ['arabic', 'persian'], source: 'ia-islamicate', minLen: 8 },
+  hebrew:     { norm: normalizeHebrew, queries: ['hebrew'],            source: 'ia-hebrew',     minLen: 9 },
 };
 const cfg = CONFIG[TRADITION];
 if (!cfg) { console.error(`--tradition must be one of: ${Object.keys(CONFIG).join(', ')}`); process.exit(1); }


### PR DESCRIPTION
Follow-up to #2537 after the harvests landed and I ran the matchers.

- **Islamicate min-len 6 → 8.** min-len 6 admitted generic short IA titles that prefix a longer work title (الكتاب 'the book', الحضارة 'civilization'). min-len 8 ≈ 93% precision on a 40-sample. **Applied operationally: 4,010 works (50.4% of keyable), 8,950 scan sources.**
- **Hebrew not applied.** Structurally unproductive: Sefaria's 6,592 entries are granular Talmud/Mishneh-Torah commentary nodes (not standalone print volumes), and IA has only ~2.9K usable Hebrew manifests — ~58% precision / 12 works even at min-len 9 (famous standalones like Sefer haMitzvot, the Haggadah, Maimonides' Eight Chapters match, but with false positives mixed in). The matcher is kept; the real Hebrew scan source is NLI / Otzar HaHochma, a separate harvest. Defaults + README updated to record this.

No data written by this PR (the islamicate apply already ran). `check-imports` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)