### PR TITLE
works-catalog: translation floor from holdings (Phase 2)

### DIFF
--- a/scripts/works-catalog/README.md
+++ b/scripts/works-catalog/README.md
@@ -53,6 +53,8 @@ node scripts/works-catalog/match-scans-semitic.mjs --tradition=islamicate --appl
 # node scripts/works-catalog/match-scans-semitic.mjs --tradition=hebrew --apply
 node scripts/works-catalog/seed-provenance.mjs        # catalog_sources licensing/attribution rows
 node scripts/works-catalog/build-holdings.mjs         # Mongo books -> work_holdings (title-auto)
+# Translation FLOOR (Phase 2, free) — evidenced 'full'/'partial' for works we hold + translated:
+node scripts/works-catalog/translation-floor-from-holdings.mjs --apply  # ~786 works (mostly tibetan SL translations)
 # Translation census + calibration (per tradition):
 node scripts/works-catalog/translation-census.mjs --tradition islamicate --sample 300 --write
 node scripts/works-catalog/calibrate-census.mjs --tradition islamicate --sample 40  # web-grounded recall-floor check

--- a/scripts/works-catalog/translation-floor-from-holdings.mjs
+++ b/scripts/works-catalog/translation-floor-from-holdings.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Translation-coverage FLOOR from our own holdings (#2453, Phase 2).
+ *
+ * The strongest evidence that a work has an English translation is that WE serve
+ * one. `work_holdings.translated_pct` (built by build-holdings.mjs from each
+ * Mongo book's pages_translated / readable-pages) gives that directly. This sets
+ * works.translation_status from it — evidenced, free, no Gemini:
+ *   translated_pct >= 90  -> 'full'
+ *   0 < translated_pct < 90 -> 'partial'
+ * Evidence records the SL book id + that it's an SL (machine) translation, so the
+ * census never conflates it with a published scholarly translation. Only upgrades
+ * 'unknown' rows — never downgrades a 'full'/'partial' set by another method.
+ *
+ * This is a FLOOR (only works we already hold + have translated). The broader
+ * census — works translated by OTHERS, which we don't hold — needs external
+ * authorities + verification (Phase 3, paid) and is out of scope here.
+ *
+ * Run on Hetzner (SUPABASE_DB_URL). Idempotent.
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/works-catalog/translation-floor-from-holdings.mjs           # measure
+ *   node scripts/works-catalog/translation-floor-from-holdings.mjs --apply   # write
+ */
+import { pgClient } from './lib.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const c = pgClient();
+await c.connect();
+
+// per work, best (highest translated_pct) held copy
+const measure = await c.query(`
+  with held as (
+    select distinct on (work_id) work_id, book_id, translated_pct as pct
+    from work_holdings where translated_pct > 0
+    order by work_id, translated_pct desc
+  )
+  select w.tradition,
+    count(*) filter (where h.pct >= 90) full,
+    count(*) filter (where h.pct > 0 and h.pct < 90) partial
+  from held h join works w on w.id = h.work_id
+  where w.translation_status = 'unknown'
+  group by 1 order by 1`);
+let tf = 0, tp = 0;
+console.log('tradition    full  partial');
+for (const r of measure.rows) { console.log(' ', String(r.tradition).padEnd(11), String(r.full).padStart(4), String(r.partial).padStart(8)); tf += +r.full; tp += +r.partial; }
+console.log(`TOTAL works gaining an evidenced translation status: ${tf} full + ${tp} partial = ${tf + tp}`);
+
+if (APPLY) {
+  const res = await c.query(`
+    update works w set
+      translation_status = case when h.pct >= 90 then 'full' else 'partial' end,
+      translation_method = 'census-auto',
+      translation_evidence = 'sl-holding ' || h.book_id || ' (SL translation, pct=' || h.pct || ')',
+      updated_at = now()
+    from (
+      select distinct on (work_id) work_id, book_id, translated_pct as pct
+      from work_holdings where translated_pct > 0
+      order by work_id, translated_pct desc
+    ) h
+    where w.id = h.work_id and w.translation_status = 'unknown'`);
+  console.log(`\nApplied: ${res.rowCount} works updated.`);
+} else {
+  console.log('\nMEASUREMENT ONLY — re-run with --apply to write.');
+}
+await c.end();


### PR DESCRIPTION
Adds the first real slice of the translation-coverage layer (the census deliverable that was ~0% computed — 78,648/78,697 works were 'unknown').

`translation-floor-from-holdings.mjs` derives `translation_status` from `work_holdings.translated_pct` (built from each Mongo book's pages_translated): >=90 → full, 0–90 → partial. This is the **evidenced, free floor** — works *we* hold and have translated. Evidence string records the SL book id + flags it as an SL translation so it's never confused with a published scholarly one. Only upgrades 'unknown' rows.

**781 works** (737 full + 44 partial), overwhelmingly Tibetan SL translations — spot-verified real (sampled books have pages_translated ≈ pages_ocr: Milarepa's rnam thar, Mahāmudrā texts, the Prajñāpāramitā), not an inflated-flag artifact.

Out of scope: works translated by *others* that we don't hold — that's the external-authority census (Phase 3, needs Gemini = paid, your call). `check-imports` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)