### PR TITLE
works-catalog: Chinese expansion — CBETA denominator + Harvard-Yenching scans

### DIFF
--- a/scripts/iiif-discovery/sources/harvard.mjs
+++ b/scripts/iiif-discovery/sources/harvard.mjs
@@ -47,6 +47,10 @@ const MAX_RECORDS = parseInt(args['max-records']) || 10000;
 const QUERY = args.query || null;
 const COLLECTION = args.collection || null;
 const RESUME = 'resume' in args;
+// LibraryCloud `language=` facet (e.g. Chinese, Sanskrit, Tibetan). When set we
+// sweep that whole language instead of the keyword queries below, and tag
+// metadata.discovery_query so the works-catalog matchers can target it.
+const LANGUAGE = args.language || null;
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
@@ -150,6 +154,9 @@ function parseItem(itemXml) {
  * Returns array of { query, description } objects.
  */
 function getSearchQueries() {
+  if (LANGUAGE) {
+    return [{ query: '', description: `Language: ${LANGUAGE}`, language: LANGUAGE }];
+  }
   if (QUERY) {
     return [{ query: QUERY, description: `Custom: ${QUERY}` }];
   }
@@ -189,17 +196,19 @@ await withMongo(async (db) => {
   const queries = getSearchQueries();
   let totalInserted = 0, totalSkipped = 0, totalErrors = 0;
 
-  for (const { query, description } of queries) {
+  for (const { query, description, language } of queries) {
     if (totalInserted >= MAX_RECORDS) break;
 
-    console.log(`\n[harvard] Searching: ${description} (q="${query}")`);
+    console.log(`\n[harvard] Searching: ${description}`);
     let start = 0;
     let queryInserted = 0;
 
     while (true) {
       if (totalInserted + queryInserted >= MAX_RECORDS) break;
 
-      const url = `${API_BASE}?q=${encodeURIComponent(query)}&digitalFormat=Books%20and%20documents&limit=${PAGE_SIZE}&start=${start}`;
+      // language facet sweep (whole language) vs keyword query
+      const selector = language ? `language=${encodeURIComponent(language)}` : `q=${encodeURIComponent(query)}`;
+      const url = `${API_BASE}?${selector}&digitalFormat=Books%20and%20documents&limit=${PAGE_SIZE}&start=${start}`;
 
       let xml;
       try {
@@ -259,6 +268,7 @@ await withMongo(async (db) => {
             nrs_urn: item.nrsUrn,
             thumbnail: item.thumbnail,
             repository: item.repoName,
+            discovery_query: LANGUAGE ? `harvard-${LANGUAGE.toLowerCase()}` : (QUERY || COLLECTION || 'sweep'),
           },
         });
 

--- a/scripts/works-catalog/README.md
+++ b/scripts/works-catalog/README.md
@@ -33,6 +33,7 @@ node scripts/works-catalog/ingest-siku-wikidata.mjs   # 3,418 Siku QIDs joined o
 node scripts/works-catalog/ingest-openiti.mjs         # ~8.9K Islamicate works (Arabic/Persian)
 node scripts/works-catalog/ingest-bdrc.mjs            # Tibetan works (BUDA linked data; --harvest then --load)
 node scripts/works-catalog/ingest-ia-cadal.mjs        # IA-CADAL scan volumes -> chinese work_sources
+node scripts/works-catalog/ingest-cbeta.mjs           # Chinese Buddhist canon (CBETA, DILA-edu/cbeta-metadata) — grows the chinese denominator (T/X-preferred, intra-CBETA deduped)
 # Sanskrit spine (#2453, added 2026-06):
 node scripts/works-catalog/ingest-sanskrit-wikidata.mjs  # ~3.9K Sanskrit works (Wikidata P407=Q11059)
 node scripts/works-catalog/ingest-gretil.mjs             # ~891 GRETIL works + transcription work_sources
@@ -41,6 +42,9 @@ node scripts/works-catalog/ingest-sefaria.mjs         # ~6.6K Hebrew works (Sefa
 # Coverage join (Phase 1) + provenance + holdings:
 node scripts/works-catalog/match-scans-ia.mjs --tradition=sanskrit --apply  # works <-> IA-sanskrit manifests -> work_sources(scan)
 node scripts/works-catalog/match-scans-chinese.mjs --apply                  # works <-> IA-chinese (717K) -> work_sources(scan); CJK-prefix, high precision
+# Chinese scans from Harvard-Yenching (better than IA's modern-reprint mass — classical CJK titles):
+node scripts/iiif-discovery/sources/harvard.mjs --language=Chinese          # ~8K digitized Chinese -> import_candidates (discovery_query=harvard-chinese)
+node scripts/works-catalog/match-scans-chinese.mjs --query=harvard-chinese --source=harvard-yenching --apply
 # Islamicate + hebrew had NO IA manifests harvested — harvest first (presets added 2026-06):
 #   node scripts/iiif-discovery/sources/ia-language.mjs --language=arabic   # ~749K manifests
 #   node scripts/iiif-discovery/sources/ia-language.mjs --language=persian

--- a/scripts/works-catalog/ingest-cbeta.mjs
+++ b/scripts/works-catalog/ingest-cbeta.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Ingest the CBETA Chinese Buddhist canon catalog into the works catalog (#2453).
+ *
+ * Source: github.com/DILA-edu/cbeta-metadata — work-info/{CANON}.json, one entry
+ * per work keyed by CBETA work id (T0001, X0001, A1057, …):
+ *   { "T0001": { title, byline, dynasty, time_from, time_to, contributors[], category, juans, vol, type } }
+ *
+ * Grows the Chinese DENOMINATOR — the Buddhist canon is largely absent from
+ * Kanripo (whose KR6 buddhist-canon section is thin). CBETA reprints the same
+ * work across many canon editions (T, X, A, B, …), so we DEDUPE within CBETA on
+ * normalized-title + byline, preferring the standard scholarly canons (T Taishō,
+ * X Xuzangjing) — one work row per distinct text, never the same text N times.
+ * Cross-SOURCE dedup (CBETA ↔ Kanripo) is the later catalog pass (#2318).
+ *
+ * Idempotent upsert. Run on Hetzner (SUPABASE_DB_URL).
+ *   set -a; source .env.production.local; set +a; node scripts/works-catalog/ingest-cbeta.mjs
+ */
+import { pgClient, normalizeCjk, fetchRetry, upsertWorks } from './lib.mjs';
+
+const UA = { headers: { 'User-Agent': 'SourceLibrary-WorksCatalog/1.0 (derek@sourcelibrary.org)' } };
+const REPO = 'DILA-edu/cbeta-metadata';
+
+// canon edition tags; preference order for dedup (earlier = kept)
+const CANON_TAG = { T: 'taisho', X: 'xuzangjing', J: 'jiaxing', A: 'zhonghua', K: 'koryo', N: 'nanchuan', L: 'qisha', M: 'mingzang' };
+const CANON_PREF = ['T', 'X', 'J', 'A', 'K', 'N', 'L', 'M'];
+const prefRank = (canon) => { const i = CANON_PREF.indexOf(canon); return i < 0 ? 99 : i; };
+
+function centuryOf(year) {
+  if (!Number.isInteger(year) || year === 0) return null;
+  return year > 0 ? Math.floor((year - 1) / 100) + 1 : -(Math.floor((-year - 1) / 100) + 1);
+}
+
+const dir = await (await fetchRetry(`https://api.github.com/repos/${REPO}/contents/work-info`, UA)).json();
+if (!Array.isArray(dir)) { console.error('GitHub API error:', dir.message); process.exit(1); }
+const files = dir.filter(f => f.name.endsWith('.json')).map(f => f.name);
+console.log(`work-info canons: ${files.map(f => f.replace('.json', '')).join(', ')}`);
+
+// collect all textbody works across canons
+const raw = [];
+for (const f of files) {
+  const canon = f.replace('.json', '');
+  const obj = await (await fetchRetry(`https://raw.githubusercontent.com/${REPO}/master/work-info/${f}`)).json();
+  for (const [wid, w] of Object.entries(obj)) {
+    if (w.type && w.type !== 'textbody') continue;       // skip non-work entries
+    if (!w.title) continue;
+    raw.push({ wid, canon, ...w });
+  }
+  process.stderr.write(`${f}: ${raw.length} works so far\n`);
+}
+
+// dedupe within CBETA on normalized title + byline, preferring standard canons
+const seen = new Map();
+for (const w of raw) {
+  const key = normalizeCjk(w.title) + '|' + normalizeCjk(w.byline || '');
+  const prev = seen.get(key);
+  if (!prev || prefRank(w.canon) < prefRank(prev.canon)) seen.set(key, w);
+}
+const deduped = [...seen.values()];
+console.log(`${raw.length} canon entries -> ${deduped.length} distinct works after intra-CBETA dedup`);
+
+const works = deduped.map(w => ({
+  id: `cbeta:${w.wid}`,
+  tradition: 'chinese',
+  original_language: 'lzh',
+  title: w.title,
+  title_normalized: normalizeCjk(w.title),
+  author: w.contributors?.[0]?.name || (w.byline ? w.byline.replace(/^\S+\s+/, '').replace(/[譯撰述著集造]$/, '') : null) || null,
+  century: centuryOf(w.time_from),
+  authority_ids: { cbeta_id: w.wid },
+  corpus_tags: ['cbeta', CANON_TAG[w.canon] || w.canon.toLowerCase()].filter(Boolean),
+  source_catalog: 'cbeta',
+  extra: { byline: w.byline || null, dynasty: w.dynasty || null, category: w.category || null, juans: w.juans || null, vol: w.vol || null, canon: w.canon },
+}));
+
+console.log(`Prepared ${works.length} works (e.g. ${works.slice(0, 3).map(w => w.id + ' ' + w.title).join(' / ')})`);
+
+const client = pgClient();
+await client.connect();
+const n = await upsertWorks(client, works);
+const count = (await client.query(`select count(*) c from works where source_catalog='cbeta'`)).rows[0].c;
+const chinese = (await client.query(`select count(*) c from works where tradition='chinese'`)).rows[0].c;
+await client.end();
+console.log(`Upserted ${n} works. works(cbeta)=${count}; total chinese works now ${chinese}.`);

--- a/scripts/works-catalog/match-scans-chinese.mjs
+++ b/scripts/works-catalog/match-scans-chinese.mjs
@@ -30,16 +30,22 @@ const MIN_LEN = parseInt(args['min-len']) || 4;   // min normalized-title chars 
 const APPLY = 'apply' in args;
 const SAMPLE = parseInt(args.sample) || 30;
 const MAX_SRC_PER_WORK = 3;
+// Which harvested manifest pool to match against, and what source tag to write.
+// Default = the IA ia_language=chinese harvest; --query=harvard-chinese matches
+// the Harvard-Yenching sweep (source tag harvard-yenching) — same CJK-prefix logic.
+const DISCOVERY_QUERY = args.query || 'chinese';
+const SOURCE_TAG = args.source || (DISCOVERY_QUERY === 'chinese' ? 'ia-chinese' : DISCOVERY_QUERY);
+const IA_SOURCE = DISCOVERY_QUERY.startsWith('harvard') ? 'harvard' : 'ia_language';
 
-// ── 1. index IA chinese manifests by 2-char block key of normalized title ─────
+// ── 1. index harvested manifests by 2-char block key of normalized title ──────
 const mc = new MongoClient(process.env.MONGODB_URI);
 await mc.connect();
 const col = mc.db('bookstore').collection('import_candidates');
-console.log('Indexing ia_language=chinese manifests by normalized-title key…');
+console.log(`Indexing ${IA_SOURCE} (discovery_query=${DISCOVERY_QUERY}) manifests by normalized-title key…`);
 const byKey = new Map();
 let iaCount = 0;
 const cur = col.find(
-  { source: 'ia_language', 'metadata.discovery_query': 'chinese', manifest_url: { $ne: null } },
+  { source: IA_SOURCE, 'metadata.discovery_query': DISCOVERY_QUERY, manifest_url: { $ne: null } },
   { projection: { title: 1, manifest_url: 1, source_id: 1, 'metadata.access_restricted': 1 } });
 for await (const d of cur) {
   const n = normalizeCjk(d.title);
@@ -78,7 +84,7 @@ for (const w of works) {
   if (samplePairs.length < SAMPLE) samplePairs.push({ w: w.title, ia: hits[0].title });
   for (const h of hits.slice(0, MAX_SRC_PER_WORK)) {
     sources.push({
-      work_id: w.id, source: 'ia-chinese', source_id: h.ia, kind: 'scan',
+      work_id: w.id, source: SOURCE_TAG, source_id: h.ia, kind: 'scan',
       url: h.url, iiif: true, coverage: null,
       extra: { ia_title: h.title?.slice(0, 120), access_restricted: h.restricted, match: 'cjk-prefix' },
     });
@@ -96,7 +102,7 @@ console.log('NOTE: precision drops sharply below len 4 (周易, 論語 too gener
 
 if (APPLY) {
   const n = await upsertSources(pg, sources);
-  console.log(`\nApplied ${n} ia-chinese scan work_sources.`);
+  console.log(`\nApplied ${n} ${SOURCE_TAG} scan work_sources.`);
 } else {
   console.log('\nMEASUREMENT ONLY — re-run with --apply to write work_sources.');
 }


### PR DESCRIPTION
Two levers for the stalled Chinese numbers (denominator was Kanripo-only ~10.1K; scans were 100% ia-cadal).

**Denominator — `ingest-cbeta.mjs`:** ingests the CBETA Chinese Buddhist canon (`DILA-edu/cbeta-metadata` work-info/*.json → work id, CJK title, byline, dynasty, century, contributors). Dedupes CBETA's cross-canon reprints on normalized-title+byline (prefers Taishō/Xuzangjing) so it adds *distinct* works, not the same sūtra under 8 canon ids. CBETA↔Kanripo cross-source dedup stays a later pass (#2318).

**Numerator — Harvard-Yenching:** `harvard.mjs` gains `--language=` (LibraryCloud language-facet sweep, tags `metadata.discovery_query=harvard-<lang>`). `--language=Chinese` harvests ~8K digitized Harvard-Yenching Chinese books — classical CJK titles + IIIF manifests, the *right* corpus vs the 717K modern reprints in `ia_language=chinese`. `match-scans-chinese.mjs` is parameterized (`--query`/`--source`) to match that pool via the same CJK-prefix logic, writing `source=harvard-yenching`.

Operational runs (ingest + harvest + match) happen on Hetzner after merge. `check-imports` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)