### PR TITLE
fix(librarian): gate results on visible (match reader), not just hidden

### DIFF
--- a/src/lib/search/librarian-search.ts
+++ b/src/lib/search/librarian-search.ts
@@ -62,6 +62,14 @@ export interface HybridSearchOptions {
 function tenantBookFilter(tenantId: string | null | undefined) {
   return {
     hidden: { $ne: true },
+    // Match the reader gate (isHiddenBook → visible === false). The reader page
+    // and content APIs 404 any book with visible:false (PR #2522), but ~1.1k
+    // books drifted into visible:false while hidden stayed unset — so a
+    // hidden-only filter surfaced them in the librarian and they 404'd on click
+    // (Rainsford "Mytho-Hermetic Dictionary", etc.). Gate on visible too so the
+    // librarian only returns books the reader will actually open. Narrow scope:
+    // only explicit visible:false is excluded; null/missing stays public.
+    visible: { $ne: false },
     // Main-site convention: tenantId null/undefined.
     // For specific tenants, equality.
     ...(tenantId


### PR DESCRIPTION
## What

Derek clicked a librarian result and got a **404** — "A Mytho-Hermetic Dictionary" (Charles Rainsford). The book exists (758 pp, mostly translated) but is `visible: false`, so the reader page 404s it.

## Root cause — two surfaces, two different flags

- **Reader gate** (`isHiddenBook`, PR #2522): a book is hidden when **`visible === false`**.
- **Librarian** (`tenantBookFilter` in `librarian-search.ts`): filtered only on **`hidden: { $ne: true }`**.

**1,105 books** drifted into `visible:false` while `hidden` stayed unset (the "visible and hidden must be opposites" invariant drifting). The hidden-only filter *includes* them, but the reader's `visible` gate 404s them → surface-then-404. **319 of those have translations**, so they're reachable librarian hits (Rainsford, plus larger titles like the Ge'ez Gospels, Mikraot Gedolot, Avicenna's Canon).

## Fix

Add `visible: { $ne: false }` to `tenantBookFilter`, mirroring `isHiddenBook`. The librarian now only returns books the reader will actually open. Narrow scope: only explicit `visible:false` is excluded; `null`/missing stays public (consistent with the reader gate).

## Scope

- **In:** librarian visibility predicate only.
- **Out (separate, deliberate):** the underlying visible/hidden data drift, and whether to *publish* the 319 hidden-but-translated books (a curation call) vs. reconcile them to `hidden:true`.

## Verify

`npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)