### PR TITLE
harvard discovery: capture CJK title + noTimeout for language sweeps

### DIFF
--- a/scripts/iiif-discovery/sources/harvard.mjs
+++ b/scripts/iiif-discovery/sources/harvard.mjs
@@ -102,10 +102,15 @@ function parseItem(itemXml) {
     return matches;
   };
 
-  // Title
-  const title = get('mods:title') || get('title') || 'Unknown';
+  // Title. CJK records carry BOTH a romanized mods:title (listed first) and an
+  // original-script one — prefer the CJK form so works-catalog matchers can use
+  // it; keep the romanized as a fallback / alternate.
+  const allTitles = getAll('mods:title');
+  const cjkTitle = allTitles.find(t => /[㐀-鿿]/.test(t)) || null;
+  const romanTitle = get('mods:title') || get('title') || 'Unknown';
+  const title = cjkTitle || romanTitle;
   const subtitle = get('mods:subTitle') || get('subTitle') || null;
-  const displayTitle = subtitle ? `${title}: ${subtitle}` : title;
+  const displayTitle = (subtitle && !cjkTitle) ? `${title}: ${subtitle}` : title;
 
   // Creator/Author
   const creators = getAll('mods:namePart') || getAll('namePart');
@@ -136,6 +141,7 @@ function parseItem(itemXml) {
 
   return {
     title: displayTitle.slice(0, 500),
+    titleRoman: cjkTitle ? romanTitle.slice(0, 500) : null,
     author,
     language,
     dateText,
@@ -268,6 +274,7 @@ await withMongo(async (db) => {
             nrs_urn: item.nrsUrn,
             thumbnail: item.thumbnail,
             repository: item.repoName,
+            title_roman: item.titleRoman,
             discovery_query: LANGUAGE ? `harvard-${LANGUAGE.toLowerCase()}` : (QUERY || COLLECTION || 'sweep'),
           },
         });
@@ -293,4 +300,4 @@ await withMongo(async (db) => {
   }
 
   console.log(`\n[harvard] Done: ${totalInserted} inserted, ${totalSkipped} skipped (dedup), ${totalErrors} errors`);
-});
+}, { noTimeout: true }); // a full language sweep (Chinese ~8K) exceeds withMongo's 300s zombie-killer


### PR DESCRIPTION
Fixes the Harvard-Yenching Chinese harvest from #2542. Two bugs surfaced when running it:

1. **Romanized title stored, CJK dropped** — MODS records list the romanized `mods:title` first; `parseItem` grabbed that, so only 1 of 2,397 harvested Chinese titles had CJK characters → unmatchable by the CJK matcher. Now prefers the original-script title (romanized kept in `metadata.title_roman`).
2. **300s timeout** — the full ~8K Chinese sweep overran `withMongo`'s zombie-killer and force-exited partway. Pass `{noTimeout:true}` (same as `ia-language.mjs`).

After merge I'll clear the partial/romanized harvest, re-run from a residential IP (Harvard 429s Hetzner), and match. `check-imports` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)