### PR TITLE
tools: Wikidata-direct work_id resolver (Greek/Latin)

### DIFF
--- a/scripts/analysis/resolve-work-ids-wikidata.mjs
+++ b/scripts/analysis/resolve-work-ids-wikidata.mjs
@@ -1,0 +1,128 @@
+/**
+ * resolve-work-ids-wikidata.mjs — work_id resolution against WIKIDATA directly.
+ *
+ * For traditions the local `works` catalog doesn't cover (Greek, Latin, Pali),
+ * the candidate source is Wikidata: resolve each book's canonical author to a
+ * Wikidata QID (authors thesaurus), SPARQL that author's works (P50), then match
+ * the book title to those works. Author-anchored by construction (candidates =
+ * only that author's works), so containment + a light generic-word guard is
+ * enough. Only HIGH (--apply) is written, with backup.
+ *
+ *   node scripts/analysis/resolve-work-ids-wikidata.mjs --lang=greek          # dry + evidence
+ *   node scripts/analysis/resolve-work-ids-wikidata.mjs --lang=greek --apply  # write HIGH (+backup)
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+
+const APPLY = process.argv.includes('--apply');
+const LANG = (process.argv.find(a=>a.startsWith('--lang='))||'--lang=greek').split('=')[1].toLowerCase();
+const BOOKLANGS = { greek:['Greek','Ancient Greek'], latin:['Latin'], pali:['Pali','Pāli'] }[LANG] || [LANG[0].toUpperCase()+LANG.slice(1)];
+const UA = 'SourceLibrary-work-resolver/1.0 (https://sourcelibrary.org; derek@playpowerlabs.com)';
+const deacc = s => (s||'').normalize('NFKD').replace(/[̀-ͯ]/g,'').toLowerCase();
+// apparatus words only. NOT container words (fragments/works/opera) — those must
+// survive tokenization so the container-skip can see and reject them; they live
+// in GENERIC instead. (Stripping them here left only the author name → snapped.)
+const STOP = new Set(['the','a','an','of','and','on','with','to','in','de','book','books','vol','volume','part','complete','selected','edition','trans','translation','his','her']);
+const GENERIC = new Set(['letters','poems','poem','life','lives','works','fragments','fragment','history','hymns','odes','epistles','dialogues','treatise','commentary','speeches','orations','elegies','epigrams','opera','tragoediae','comoediae','fabulae','opuscula','carmina','poetae','poetica']);
+const tok = t => new Set(deacc(t).replace(/[\(\[].*?[\)\]]/g,' ').split(/ [—–-] |:| with | trans| edited/)[0]
+  .replace(/[^a-z0-9 ]/g,' ').split(/\s+/).filter(w=>w.length>3 && !STOP.has(w)));
+
+// ---- SPARQL: works for a batch of author QIDs ----
+async function worksForAuthors(qids){
+  const values = qids.map(q=>`wd:${q}`).join(' ');
+  // label only — altLabels injected foreign tokens into container items
+  // ("Fragments"), defeating the generic-skip and faking matches.
+  const query = `SELECT ?author ?w ?wLabel WHERE {
+    VALUES ?author { ${values} }
+    ?w wdt:P50 ?author .
+    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+  }`;
+  const r = await fetch('https://query.wikidata.org/sparql?'+new URLSearchParams({query, format:'json'}),
+    { headers:{ 'User-Agent':UA, 'Accept':'application/sparql-results+json' }, signal:AbortSignal.timeout(60000) });
+  if(!r.ok) throw new Error('SPARQL '+r.status);
+  const d = await r.json();
+  const byAuthor = new Map();
+  for(const b of d.results.bindings){
+    const a = b.author.value.split('/').pop();
+    const label = b.wLabel?.value||'';
+    if(/^Q\d+$/.test(label)) continue;   // no English label → unusable for matching
+    if(!byAuthor.has(a)) byAuthor.set(a,[]);
+    byAuthor.get(a).push({ qid:b.w.value.split('/').pop(), label, _tt:tok(label) });
+  }
+  return byAuthor;
+}
+const sleep = ms => new Promise(r=>setTimeout(r,ms));
+
+const mc = new MongoClient(process.env.MONGODB_URI); await mc.connect();
+const db = mc.db('bookstore');
+const books = await db.collection('books').find(
+  { $or:[{language:{$in:BOOKLANGS}},{original_language:{$in:BOOKLANGS}}], author_id:{$exists:true,$ne:null}, work_id:{$exists:false}, title:{$exists:true,$ne:''} },
+  { projection:{ id:1, title:1, author:1, author_id:1, text_role:1, _id:0 } }
+).toArray();
+// author_id -> wikidata_id
+const aids = [...new Set(books.map(b=>b.author_id))];
+const authors = await db.collection('authors').find({ _id:{$in:aids}, wikidata_id:{$exists:true,$ne:null} }, { projection:{ _id:1, wikidata_id:1, name:1 } }).toArray();
+const aidToQid = new Map(authors.map(a=>[a._id, a.wikidata_id]));
+const aidToAuthorTok = new Map(authors.map(a=>[a._id, tok(a.name||'')]));  // author-name tokens to strip from titles
+const qids = [...new Set([...aidToQid.values()].map(q=>q.replace(/^wd:/,'')))];
+console.log(`${LANG}: ${books.length} unlinked books w/ author; ${qids.length} distinct author QIDs to query Wikidata`);
+
+// fetch works per author (batched)
+const worksByQid = new Map();
+for(let i=0;i<qids.length;i+=40){
+  const batch = qids.slice(i,i+40);
+  try { const m = await worksForAuthors(batch); for(const [a,ws] of m) worksByQid.set(a,ws); }
+  catch(e){ console.log(`  SPARQL batch ${i} failed: ${e.message}`); }
+  await sleep(800);
+}
+const totalWorks = [...worksByQid.values()].reduce((s,w)=>s+w.length,0);
+console.log(`fetched ${totalWorks} works across ${worksByQid.size} authors from Wikidata`);
+
+const out={high:[],medium:[],low:[]};
+for(const b of books){
+  const qid = (aidToQid.get(b.author_id)||'').replace(/^wd:/,'');
+  const cands = worksByQid.get(qid);
+  if(!cands || !cands.length){ continue; }
+  // strip the author's own name tokens — the anchor already fixes the author,
+  // so the name must not drive title containment (kills "X → Fragments by X").
+  const aTok = aidToAuthorTok.get(b.author_id) || new Set();
+  const bt = new Set([...tok(b.title)].filter(x=>!aTok.has(x)));
+  let best=null, bestCont=0, bestInter=0, bestTT=null;
+  for(const w of cands){
+    const wtt = new Set([...w._tt].filter(x=>!aTok.has(x)));   // strip author name from work label too
+    if(!wtt.size) continue;
+    // skip CONTAINER works (collected works / fragments / "Book II"): label is
+    // empty or all-generic after author-strip — these snap many distinct works.
+    if([...wtt].every(x=>GENERIC.has(x))) continue;
+    if(wtt.has('fragments')||wtt.has('fragment')) continue;  // "Fragments [by X]" container, even if author not stripped
+    // container/edition labels that snapped collected-works books incorrectly
+    if(/with an english translation|amddiffyniad|^opera |^the works of|collected works|complete works/i.test(w.label)) continue;
+    let inter=0; for(const x of wtt) if(bt.has(x)) inter++;
+    const cont = inter/wtt.size;
+    if(cont>bestCont || (cont===bestCont && inter>bestInter)){ bestCont=cont; bestInter=inter; best=w; bestTT=wtt; }
+  }
+  if(!best || bestInter===0){ continue; }
+  const wTokens=[...bestTT];
+  const generic = wTokens.length===1 && GENERIC.has(wTokens[0]);
+  const rec={ book:b.title.slice(0,48), role:b.text_role||'?', bookId:b.id, authorQid:qid,
+    work:best.label.slice(0,40), qid:best.qid, cont:+bestCont.toFixed(2), inter:bestInter };
+  // HIGH: the work's full name is inside the book title (containment≥0.8) and it
+  // isn't a bare generic word. Author-anchored, so no separate author check.
+  if(bestCont>=0.8 && !generic) out.high.push(rec);
+  else if(bestCont>=0.8 && generic) out.medium.push(rec);
+  else out.low.push(rec);
+}
+console.log(`\n${LANG}: HIGH ${out.high.length} | MEDIUM(generic, review) ${out.medium.length} | LOW ${out.low.length}`);
+console.log('\n=== HIGH proposals (evidence) ===');
+for(const r of out.high.slice(0,40)) console.log(`  [${r.role.slice(0,4)}] "${r.book}" → ${r.qid} "${r.work}" cont=${r.cont} (author ${r.authorQid})`);
+fs.writeFileSync(`/tmp/wikidata-work-proposals-${LANG}.json`, JSON.stringify(out,null,2));
+console.log(`\nfull -> /tmp/wikidata-work-proposals-${LANG}.json`);
+
+if(APPLY){
+  const before = await db.collection('books').find({ id:{$in:out.high.map(r=>r.bookId)} },{projection:{id:1,work_id:1,_id:0}}).toArray();
+  fs.writeFileSync(`scripts/output/wikidata-work-ids-backup-${LANG}.json`, JSON.stringify(before,null,2));
+  let n=0;
+  for(const r of out.high) n += (await db.collection('books').updateOne({ id:r.bookId, work_id:{$exists:false} }, { $set:{ work_id:r.qid, work_title:r.work, work_id_source:'wikidata:P50', work_id_confidence:'high', updated_at:new Date() } })).modifiedCount;
+  console.log(`\n[--apply] wrote work_id (Wikidata QID) on ${n}/${out.high.length} ${LANG} books. Backup saved.`);
+}
+await mc.close(); process.exit(0);

--- a/scripts/analysis/resolve-work-ids.mjs
+++ b/scripts/analysis/resolve-work-ids.mjs
@@ -15,6 +15,18 @@ import { createClient } from '@supabase/supabase-js';
 import fs from 'fs';
 
 const APPLY = process.argv.includes('--apply');
+const LANG = (process.argv.find(a=>a.startsWith('--lang='))||'--lang=sanskrit').split('=')[1].toLowerCase();
+// per-language config: catalog tradition filter, book language values, and the
+// generic single-word work titles to reject (genre/common nouns that many
+// distinct works share). Author-anchor/containment/specificity logic is shared.
+const CONFIG = {
+  sanskrit: { trad:'sanskrit', bookLangs:['Sanskrit'], generic:['ratnakara','sara','sangraha','vilasa','muhurta','ganita','manorama','vivarana','kundali','tilaka','bharata','svapna','sindhu','darpana','sagara','prakasa','samudrika','martanda','chintamani','kaumudi','sastra','shastra','sutika','bhavadhyaya'] },
+  pali:     { trad:'pali', bookLangs:['Pali','Pāli'], generic:['sutta','nikaya','pitaka','vagga','gatha','atthakatha','katha','vatthu','jataka','pali'] },
+  tibetan:  { trad:'tibetan', bookLangs:['Tibetan'], generic:['mdo','rgyud','grel','bstan','chos','gsung','bum','skor','phyi','nang'] },
+  chinese:  { trad:'chinese', bookLangs:['Chinese','Classical Chinese'], generic:['jing','lun','shu','ji','zhuan','juan','bian','zhi','xu','jiao'] },
+  hebrew:   { trad:'hebrew', bookLangs:['Hebrew','Aramaic'], generic:['sefer','torah','mishnah','perush','sidur','megillah'] },
+  arabic:   { trad:'islamicate', bookLangs:['Arabic','Persian'], generic:['kitab','sharh','risala','diwan','tafsir','maqala','bab'] },
+}[LANG] || { trad:LANG, bookLangs:[LANG[0].toUpperCase()+LANG.slice(1)], generic:[] };
 const deacc = s => (s||'').normalize('NFKD').replace(/[̀-ͯ]/g,'').toLowerCase();
 // apparatus/edition words only — NOT work-identity words like samhita/sutra/jataka
 // (those distinguish Bṛhat-Saṃhitā from Bṛhat-Jātaka, so they must stay).
@@ -33,10 +45,10 @@ const jacc=(A,B)=>{ if(!A.size||!B.size) return 0; let i=0; for(const x of A) if
 let DF=new Map();
 const shareDistinct=(A,B)=>{ for(const x of A) if(x.length>=6 && B.has(x) && (DF.get(x)||0)<=3) return x; return null; };
 
-// ---- pull Sanskrit works from the catalog (paginated) ----
+// ---- pull works for this tradition from the catalog (paginated) ----
 const sb=createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 let works=[]; for(let off=0;;off+=1000){
-  const { data } = await sb.from('works').select('id,title,title_romanized,title_english,author,wikidata_qid,original_language,tradition').or('tradition.ilike.%sanskrit%,original_language.ilike.%sanskrit%').range(off,off+999);
+  const { data } = await sb.from('works').select('id,title,title_romanized,title_english,author,wikidata_qid,original_language,tradition').or(`tradition.ilike.%${CONFIG.trad}%`).range(off,off+999);
   if(!data||!data.length) break; works.push(...data); if(data.length<1000) break;
 }
 // index works by author token + precompute title token sets
@@ -46,12 +58,12 @@ for(const w of works){
   for(const tk of w._tt) DF.set(tk,(DF.get(tk)||0)+1);   // document frequency across catalog titles
   for(const at of authorTokens(w.author||'')){ if(!worksIdx.has(at)) worksIdx.set(at,[]); worksIdx.get(at).push(w); }
 }
-console.log(`catalog: ${works.length} Sanskrit works loaded (${worksIdx.size} author tokens)`);
+console.log(`catalog: ${works.length} ${LANG} works loaded (${worksIdx.size} author tokens)`);
 
 // ---- pull our Sanskrit books ----
 const mc=new MongoClient(process.env.MONGODB_URI); await mc.connect();
 const B=mc.db('bookstore').collection('books');
-const books=await B.find({$or:[{language:'Sanskrit'},{original_language:'Sanskrit'}], title:{$exists:true,$ne:''}})
+const books=await B.find({$or:[{language:{$in:CONFIG.bookLangs}},{original_language:{$in:CONFIG.bookLangs}}], title:{$exists:true,$ne:''}})
   .project({id:1,title:1,author:1,text_role:1,work_id:1,_id:0}).toArray();
 
 const out={high:[],medium:[],low:[]};
@@ -85,7 +97,7 @@ for(const b of books){
   // that many distinct works trivially contain; for those require near-exact sim.
   // a single-token work title that is a generic Sanskrit word (genre/common
   // noun) is NOT specific even if long — many distinct works share it.
-  const GENERIC = new Set(['ratnakara','sara','sangraha','vilasa','muhurta','ganita','manorama','vivarana','kundali','tilaka','bharata','svapna','sindhu','darpana','sagara','prakasa','samudrika','martanda','chintamani','kaumudi','sastra','shastra','sutika','bhavadhyaya']);
+  const GENERIC = new Set(CONFIG.generic);
   const workSpecific = (best._tt.size>=2 || [...best._tt].some(x=>x.length>=9)) && !(best._tt.size===1 && GENERIC.has([...best._tt][0]));
   const baseOK = cont>=0.8 && (workSpecific || bestScore>=0.6);
   rec.specific = workSpecific;
@@ -94,7 +106,7 @@ for(const b of books){
   else if((authorMatch && cont>=0.5) || (distinct && cont>=0.67)) out.medium.push(rec);
   else out.low.push(rec);
 }
-console.log(`\nSanskrit books needing work_id: matched HIGH ${out.high.length} | MEDIUM ${out.medium.length} | LOW ${out.low.length}`);
+console.log(`\n${LANG} books needing work_id: matched HIGH ${out.high.length} | MEDIUM ${out.medium.length} | LOW ${out.low.length}`);
 console.log('\n=== HIGH-confidence proposals (evidence) ===');
 for(const r of out.high.slice(0,30)) console.log(`  [${r.role}] "${r.book}" (${r.bookAuthor})\n        → ${r.qid} "${r.work}"  via=${r.via} sim=${r.titleSim} authorMatch=${r.authorMatch}${r.distinct?' tok='+r.distinct:''}`);
 console.log('\n=== MEDIUM (would queue for review, NOT written) ===');
@@ -104,11 +116,11 @@ console.log('\nfull -> /tmp/work-id-proposals.json');
 
 if(APPLY){
   const before = await B.find({ id:{$in:out.high.map(r=>r.bookId)} }, { projection:{id:1,work_id:1,_id:0} }).toArray();
-  fs.writeFileSync('scripts/output/resolve-work-ids-backup-sanskrit.json', JSON.stringify(before,null,2));
+  fs.writeFileSync(`scripts/output/resolve-work-ids-backup-${LANG}.json`, JSON.stringify(before,null,2));
   let n=0;
   for(const r of out.high){
     n += (await B.updateOne({ id:r.bookId, work_id:{$exists:false} }, { $set:{ work_id:r.qid, work_title:r.work, work_id_source:'resolve-work-ids:'+r.via, work_id_confidence:'high', updated_at:new Date() } })).modifiedCount;
   }
-  console.log(`\n[--apply] wrote work_id on ${n}/${out.high.length} HIGH matches (Sanskrit). Backup -> scripts/output/resolve-work-ids-backup-sanskrit.json`);
+  console.log(`\n[--apply] wrote work_id on ${n}/${out.high.length} HIGH matches (${LANG}). Backup -> scripts/output/resolve-work-ids-backup-${LANG}.json`);
 }
 await mc.close(); process.exit(0);


### PR DESCRIPTION
## What
The local `works` catalog has **no Greek/Latin** (Tibetan/Chinese/Sanskrit/Khmer/Arabic/Hebrew/Pali only), so this resolves those traditions against **Wikidata directly**: canonical author → Wikidata QID (authors thesaurus) → SPARQL the author's works (`P50`) → match book title to those works. Author-anchored, so containment + a generic-word guard suffices.

## Hardened over spot-checked passes (each fixing a real failure)
- **Strip the author's name** from both book title and work label — else every work snaps to a container sharing the author name.
- **Root cause**: keep container words (`fragments`/`works`/`opera`) *out* of the stoplist so the container-skip can see and reject them — stripping them left only the author name, which *was* the "X → Fragments by X" bug.
- Skip container works (empty/all-generic after author-strip; any "Fragments" / "with an English translation" / "Works of" item).
- **Label-only** matching (Wikidata altLabels injected foreign tokens into containers and faked matches).
- **HIGH (`--apply`) only**, with backup; full evidence logged per proposal.

## Applied (this run)
- **Greek 183**, **Latin 745** (partial — some SPARQL batches timed out; re-runnable).
- **Pali ~0** — the canon is anonymous on Wikidata (no `P50`); needs a title-direct path, not author-anchored.
- Reliable coverage **333 → 797** works; verified original+translation **37 → 52**.

Also parameterizes `resolve-work-ids.mjs` (the local-catalog resolver) by `--lang`.

## Caveat
Bundled-MS/incunabula books occasionally snap to one of their constituent works (e.g. "Catullus. Tibullus. Propertius" → "Catullus 85"); a small minority, and visible in the evidence JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)