### PR TITLE
fix(cbeta-import): unique page id (pages.id unique index)

### DIFF
--- a/scripts/works-catalog/import-cbeta-text.mjs
+++ b/scripts/works-catalog/import-cbeta-text.mjs
@@ -164,11 +164,15 @@ for (const wid of ids.slice(0, LIMIT)) {
     pipeline_auto: { status: 'images_complete', ocr_deferred: true, ocr_deferred_reason: 'text-only work (CBETA digital edition); no scan' },
     created_at: now, updated_at: now,
   });
-  await Pages.insertMany(pages.map((p, idx) => ({
-    book_id: id, page_number: idx + 1, page_label: p.label,
-    ocr: { data: p.text, model: 'cbeta-tei-p5', generated_at: now },
-    created_at: now, updated_at: now,
-  })));
+  await Pages.insertMany(pages.map((p, idx) => {
+    const pid = new ObjectId();             // pages have a UNIQUE index on `id`
+    return {
+      _id: pid, id: pid.toString(),
+      book_id: id, page_number: idx + 1, page_label: p.label,
+      ocr: { data: p.text, model: 'cbeta-tei-p5', generated_at: now, updated_at: now },
+      created_at: now, updated_at: now,
+    };
+  }));
   created++;
   console.log(`  + ${wid} "${title}" — ${pages.length} pages, ${totalChars} chars (${VISIBLE ? 'visible' : 'hidden'})  /book/${slug}`);
 }


### PR DESCRIPTION
Follow-up to #2547. `pages` has a unique index on `id`; page docs lacking it collided on null, so multi-page CBETA imports wrote only the first page then aborted. Each page now gets its own ObjectId + id. Verified end-to-end: the 3 pilot sutras imported fully and render live on sourcelibrary.org. check-imports passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)