### PR TITLE
fix(gallery): drop stray metadata.language so the text index doesn't reject Greek/CJK manuscript images

### DIFF
--- a/scripts/workers/sync-worker.mjs
+++ b/scripts/workers/sync-worker.mjs
@@ -343,6 +343,11 @@ async function syncGalleryImages(db) {
         updated_at: new Date(),
       },
     },
+    // Drop any stray `metadata.language` subfield. The gallery_images text index
+    // (`language_override: "language"`) reads it as the metadata subtree's language;
+    // a value like "Greek" aborts the $merge with "language override unsupported",
+    // silently dropping the image. $unset keeps all other metadata; no-op when absent.
+    { $unset: 'metadata.language' },
     {
       $merge: {
         into: 'gallery_images',

--- a/src/app/api/admin/sync-gallery-images/route.ts
+++ b/src/app/api/admin/sync-gallery-images/route.ts
@@ -116,6 +116,13 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
           updated_at: new Date(),
         },
       },
+      // Drop any stray `metadata.language` subfield. The gallery_images text index
+      // (`language_override: "language"`) descends into the indexed `metadata`
+      // subdocument; a value like "Greek" on a Byzantine-manuscript detection is
+      // read as the subtree language and aborts the $merge with
+      // "language override unsupported", silently dropping those images. $unset is
+      // surgical (keeps subjects/figures/symbols/iconclass/cit/…) and a no-op when absent.
+      { $unset: 'metadata.language' },
     ];
 
     if (dryRun) {

--- a/src/workers/image-extraction-processor-logic.ts
+++ b/src/workers/image-extraction-processor-logic.ts
@@ -320,7 +320,12 @@ async function buildGalleryDocs(
           // these here is what left ~76% of gallery_images without `model`.
           model: img.model || null,
           detected_at: img.detected_at || null,
-          metadata: img.metadata || null,
+          // Drop any stray `language` subfield — the gallery_images text index reads
+          // metadata.language as a per-subtree language override and rejects values
+          // like "Greek" ("language override unsupported"), dropping the image (#2531).
+          metadata: img.metadata
+            ? (() => { const m = { ...(img.metadata as Record<string, unknown>) }; delete m.language; return m; })()
+            : null,
           dhash: img.dhash || null,
           book_title: book?.display_title || book?.title || 'Unknown',
           book_author: book?.author || null,


### PR DESCRIPTION
## Problem

The `gallery_images` text index (`gallery_images_text_idx`) is configured with `language_override: "language"`. MongoDB's text indexer **descends into the indexed `metadata` subdocument** (it weights `metadata.subjects/figures/symbols`) and, per the override, looks for a `language` field in that subtree to set its text-search language.

Some image detections carry a stray **`metadata.language`** — e.g. `"Greek"` on Byzantine-manuscript pages, and other unsupported values on CJK manuscripts. MongoDB reads that as the subtree's language and rejects the write with:

```
language override unsupported: Greek
```

Because the materializers write the whole book in one `$merge` aggregate, **one bad detection aborts the entire aggregate** — every image for that book is silently dropped from `gallery_images` (and thus from the gallery, which filters `extracted_url != null`). This is why Greek/CJK manuscript illustrations never appeared even when extracted.

## Fix

Surgically remove only `metadata.language` at materialization time — keep everything else:
- `src/app/api/admin/sync-gallery-images/route.ts` — add `{ $unset: 'metadata.language' }` to the pipeline.
- `scripts/workers/sync-worker.mjs` — same `$unset`.
- `src/workers/image-extraction-processor-logic.ts` (SQS path, builds the doc in JS) — strip `language` before insert.

`$unset` is a no-op when the field is absent and preserves all legitimate metadata (`subjects`, `figures`, `symbols`, `style`, `technique`, `condition`, `iconclass`, `cit`) — notably `iconclass`, which the gallery's iconclass filter depends on.

## How it was found

Surfaced while recovering ~38K silently-missed illustrations (#2533): the recovery sweep's per-book materialization hit this on a Byzantine Greek manuscript (Theon of Smyrna) and aborted a batch's materialization tail. The recovery tool already carries the equivalent fix; this PR fixes the **production** materializers so the bug can't recur on normal pipeline runs.

## Out of scope
- The recovery sweep tooling itself (separate PR).
- Cleaning the stray `metadata.language` out of stored `detected_images` (not needed — stripped at materialization; harmless where it sits).

## Test
- `npx tsc --noEmit` clean.
- Verified the fixed aggregation materializes the previously-failing Greek book (219 gallery docs, no error).
