### PR TITLE
feat(maintenance): re-extract silently-missed illustrations (#2533)

### DIFF
--- a/scripts/maintenance/reextract-missed-pages.mjs
+++ b/scripts/maintenance/reextract-missed-pages.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/**
+ * Re-extract silently-missed illustrations (issue #2533).
+ *
+ * Target ("Case 3" / the page-10-comet pattern): VISIBLE books that are ALREADY
+ * image-extracted (`detected_images_count > 0`) but contain individual pages that
+ * are valid illustration candidates — `page_type` in the candidate set OR a
+ * non-trivial high-significance `<image-desc>` OCR marker — yet have EMPTY
+ * `detected_images`. The original vision pass missed them; the book finalized as
+ * `complete`, so the catch-up cron (which only revisits books with no
+ * `detected_images_count`) never re-examines them.
+ *
+ * This re-runs the SAME extraction the production worker runs (identical prompt,
+ * pulled from image-extract-worker.mjs so it can't drift), then materializes the
+ * result through the canonical paths: generate-thumbnails (crops → R2) and the
+ * sync-gallery-images pipeline (full denormalized gallery_images docs).
+ *
+ * Idempotent & resumable: every page we test gets `miss_recheck_at` stamped, so
+ * OCR-over-claim pages (vision correctly found nothing) are never re-tested, and
+ * recovered pages drop out of the candidate filter once they have detected_images.
+ * Re-run until no candidates remain.
+ *
+ * Usage:
+ *   node scripts/maintenance/reextract-missed-pages.mjs --limit=2000 [--apply] [--concurrency=10]
+ *   --apply       actually write detected_images + materialize (default: dry-run, measure yield only)
+ *   --limit=N     max candidate pages to process this run (default 500)
+ *   --concurrency vision-call concurrency (default 10)
+ *   --book=ID     restrict to a single book (debugging)
+ */
+
+import { MongoClient } from 'mongodb';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { readFileSync } from 'fs';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { getPageSource } from '../lib/page-image-url.mjs';
+
+const args = process.argv.slice(2);
+const getArg = (n, d) => { const a = args.find(x => x.startsWith(`--${n}=`)); return a ? a.split('=')[1] : d; };
+const APPLY = args.includes('--apply');
+// Reconcile mode: don't extract — find books whose recovered pages have no
+// gallery_images doc (materialization was interrupted) and re-crop + re-materialize
+// just those. Self-healing after a partial sweep run.
+const RECONCILE = args.includes('--reconcile');
+const LIMIT = parseInt(getArg('limit', '500'));
+const CONCURRENCY = parseInt(getArg('concurrency', '10'));
+const ONLY_BOOK = getArg('book', null);
+// Random-book sampling gives a representative yield measurement (deterministic
+// _id-order iteration front-loads early-imported books that aren't typical).
+// Use for validation batches; omit for an exhaustive full sweep.
+const RANDOM_BOOKS = parseInt(getArg('random-books', '0'));
+
+const MODEL = 'gemini-3-flash-preview';
+const TRIVIAL = new Set(['symbol', 'stamp', 'ornament', 'blank', 'exlibris', 'bookplate', 'decorative', "printer's mark", 'photograph', 'photographic']);
+
+// ── Reuse the production prompt verbatim (extract from the worker source) ──
+const workerSrc = readFileSync(new URL('../workers/image-extract-worker.mjs', import.meta.url), 'utf8');
+const pm = workerSrc.match(/IMAGE_EXTRACTION_PROMPT = `([\s\S]*?)`;/);
+if (!pm) { console.error('FATAL: could not extract IMAGE_EXTRACTION_PROMPT from worker source'); process.exit(1); }
+const PROMPT = pm[1].replace(/\\`/g, '`').replace(/\\\$/g, '$');
+
+// ── Gemini keys (mirror worker: exclude free-tier KEY_4) ──
+const API_KEYS = [
+  process.env.GEMINI_API_KEY,
+  ...Array.from({ length: 9 }, (_, i) => (i + 2 === 4 ? null : process.env[`GEMINI_API_KEY_${i + 2}`])),
+  process.env.GEMINI_API_KEY_TIER3,
+].filter(Boolean);
+if (!API_KEYS.length) { console.error('FATAL: no Gemini API keys'); process.exit(1); }
+let _ki = 0;
+const nextClient = () => new GoogleGenerativeAI(API_KEYS[_ki++ % API_KEYS.length]);
+const SAFETY = ['HARM_CATEGORY_HARASSMENT', 'HARM_CATEGORY_HATE_SPEECH', 'HARM_CATEGORY_SEXUALLY_EXPLICIT', 'HARM_CATEGORY_DANGEROUS_CONTENT', 'HARM_CATEGORY_CIVIC_INTEGRITY'].map(category => ({ category, threshold: 'BLOCK_NONE' }));
+
+async function fetchImage(url) {
+  try {
+    const r = await fetch(url, { signal: AbortSignal.timeout(30000) });
+    if (!r.ok) return null;
+    const b = Buffer.from(await r.arrayBuffer());
+    return { data: b.toString('base64'), mimeType: (r.headers.get('content-type') || 'image/jpeg').split(';')[0].trim() };
+  } catch { return null; }
+}
+
+// Mirror of worker parseImageExtractionResponse (object form) + normalizeBbox.
+function parseExtracted(text) {
+  if (!text || typeof text !== 'string') return [];
+  const cleaned = text.replace(/^```(?:json)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
+  const o = cleaned.match(/\{[\s\S]*\}/);
+  if (o) { try { const p = JSON.parse(o[0]); if (p && !Array.isArray(p)) return Array.isArray(p.extracted_images) ? p.extracted_images : []; } catch {} }
+  const a = cleaned.match(/\[[\s\S]*\]/);
+  if (a) { try { const p = JSON.parse(a[0]); return Array.isArray(p) ? p : []; } catch {} }
+  return [];
+}
+function normalizeBbox(raw) {
+  const x = parseFloat(raw.x) || 0, y = parseFloat(raw.y) || 0, width = parseFloat(raw.width) || 0, height = parseFloat(raw.height) || 0;
+  if (x > 1 || y > 1 || width > 1 || height > 1) {
+    const scale = Math.max(x + width, y + height, 1000);
+    return { x: Math.min(x / scale, 0.95), y: Math.min(y / scale, 0.95), width: Math.min(width / scale, 1), height: Math.min(height / scale, 1) };
+  }
+  return { x, y, width, height };
+}
+
+function pageHasNonTrivialHighSigMarker(ocr) {
+  if (!ocr) return false;
+  if (ocr.includes('<detected-images>')) return true;
+  const tags = [...ocr.matchAll(/<image-desc([^>]*)>/g)];
+  return tags.some(m => {
+    const type = (m[1].match(/type="([^"]+)"/) || [])[1];
+    const sig = (m[1].match(/significance="([^"]+)"/) || [])[1];
+    return sig === 'high' && type && !TRIVIAL.has(type);
+  });
+}
+
+async function main() {
+  console.log(`[reextract-missed] start ${new Date().toISOString()} | apply=${APPLY} limit=${LIMIT} conc=${CONCURRENCY} keys=${API_KEYS.length}`);
+  const client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 5 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  if (RECONCILE) { await reconcile(db); await client.close(); return; }
+
+  // ── Gather candidate pages by iterating already-extracted visible books ──
+  // (book_id is indexed; scanning books with detected_images_count>0 is bounded.)
+  const bookFilter = ONLY_BOOK
+    ? { id: ONLY_BOOK }
+    : { visible: true, detected_images_count: { $gt: 0 } };
+  const bookProj = { id: 1, title: 1, author: 1, year: 1, language: 1, subjects: 1 };
+  const bookSource = RANDOM_BOOKS > 0
+    ? (await db.collection('books').aggregate([{ $match: bookFilter }, { $sample: { size: RANDOM_BOOKS } }, { $project: bookProj }]).toArray())[Symbol.iterator]()
+    : db.collection('books').find(bookFilter, { projection: bookProj }).sort({ _id: 1 });
+
+  const candidates = [];
+  let booksScanned = 0;
+  const bookMeta = new Map();
+  for await (const book of bookSource) {
+    booksScanned++;
+    const pages = await db.collection('pages').find({
+      book_id: book.id,
+      page_number: { $gt: 0 },
+      'detected_images.0': { $exists: false },
+      miss_recheck_at: { $exists: false },
+    }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, display_photo: 1, crop: 1, split_from_spread: 1, 'ocr.data': 1 } }).toArray();
+    for (const p of pages) {
+      // Require the high-significance non-trivial OCR marker — the precise
+      // "genuine miss" signal the pilot measured at ~63% recovery. (page_type
+      // alone is a weaker signal and dilutes yield.)
+      if (!pageHasNonTrivialHighSigMarker(p.ocr?.data)) continue;
+      // Keep only the fields getPageSource() needs — drop ocr.data so a 56K-page
+      // full sweep doesn't hold the entire OCR corpus in memory.
+      candidates.push({
+        id: p.id, page_number: p.page_number,
+        photo: p.photo, photo_original: p.photo_original, archived_photo: p.archived_photo,
+        cropped_photo: p.cropped_photo, display_photo: p.display_photo,
+        crop: p.crop, split_from_spread: p.split_from_spread, _book: book.id,
+      });
+      bookMeta.set(book.id, book);
+      if (candidates.length >= LIMIT) break;
+    }
+    if (candidates.length >= LIMIT) break;
+    if (booksScanned % 500 === 0) console.log(`  …scanned ${booksScanned} books, ${candidates.length} candidates so far`);
+  }
+  console.log(`[reextract-missed] ${candidates.length} candidate pages from ${bookMeta.size} books (scanned ${booksScanned} books)`);
+  if (!candidates.length) { console.log('No candidates — nothing to do.'); await client.close(); return; }
+
+  // ── Re-extract each candidate ──
+  let hits = 0, empty = 0, fetchFail = 0, errors = 0, imagesRecovered = 0;
+  const affectedBooks = new Set();
+  const examples = [];
+
+  for (let i = 0; i < candidates.length; i += CONCURRENCY) {
+    const chunk = candidates.slice(i, i + CONCURRENCY);
+    await Promise.all(chunk.map(async (page) => {
+      const url = getPageSource(page);
+      if (!url || !/^https?:/.test(url)) { fetchFail++; return; }
+      const img = await fetchImage(url);
+      if (!img) { fetchFail++; return; }
+      const book = bookMeta.get(page._book);
+      const ctx = [book.title && `Book: "${book.title}"`, book.author && `Author: ${book.author}`, book.year && `Year: ${book.year}`, book.language && `Language: ${book.language}`, book.subjects?.length && `Subjects: ${book.subjects.join(', ')}`].filter(Boolean).join(' | ');
+      const prompt = ctx ? `BOOK CONTEXT:\n${ctx}\n\n${PROMPT}` : PROMPT;
+      try {
+        const model = nextClient().getGenerativeModel({ model: MODEL, safetySettings: SAFETY, generationConfig: { temperature: 0.1, maxOutputTokens: 4096, responseMimeType: 'application/json' } });
+        const res = await model.generateContent([{ text: prompt }, { inlineData: { mimeType: img.mimeType, data: img.data } }]);
+        const now = new Date();
+        const raw = parseExtracted(res.response.text())
+          .filter(x => x && x.bbox && typeof x.gallery_quality === 'number') // drop zombie rows
+          .map(x => ({
+            description: x.description || '', type: x.type || 'unknown',
+            bbox: normalizeBbox(x.bbox), confidence: x.confidence,
+            gallery_quality: x.gallery_quality, gallery_rationale: x.gallery_rationale || undefined,
+            metadata: x.metadata || undefined, museum_description: x.museum_description || undefined,
+            detected_at: now, detection_source: 'vision_model', model: MODEL,
+          }));
+        if (raw.length) {
+          hits++; imagesRecovered += raw.length; affectedBooks.add(page._book);
+          if (examples.length < 15) examples.push(`p${page.page_number} ${page._book.slice(-6)} q=${raw.map(r => r.gallery_quality).join('/')} ${raw[0].type}: ${(raw[0].description || '').slice(0, 64)}`);
+          if (APPLY) await db.collection('pages').updateOne({ id: page.id }, { $set: { detected_images: raw, miss_recheck_at: now, image_extraction_updated_at: now, updated_at: now } });
+        } else {
+          empty++;
+          if (APPLY) await db.collection('pages').updateOne({ id: page.id }, { $set: { miss_recheck_at: now } });
+        }
+      } catch (e) {
+        errors++;
+        if (/429|RESOURCE_EXHAUSTED/.test(e.message || '')) _ki++; // rotate
+      }
+    }));
+    process.stdout.write(`\r  ${Math.min(i + CONCURRENCY, candidates.length)}/${candidates.length}  hits=${hits} empty=${empty} fetchFail=${fetchFail} err=${errors}`);
+  }
+  const answered = hits + empty;
+  console.log(`\n[reextract-missed] tested ${candidates.length}: answered=${answered} recovered=${hits} (${answered ? Math.round(100 * hits / answered) : 0}% of answered), images=${imagesRecovered}, empty=${empty}, fetchFail=${fetchFail}, err=${errors}`);
+  console.log('examples:'); examples.forEach(e => console.log('  ' + e));
+
+  if (!APPLY) { console.log('\nDRY RUN — no writes, no materialization. Re-run with --apply.'); await client.close(); return; }
+  if (!affectedBooks.size) { console.log('No images recovered — nothing to materialize.'); await client.close(); return; }
+
+  // ── Materialize: thumbnails (crops → R2) then canonical gallery_images docs ──
+  const books = [...affectedBooks];
+  console.log(`\n[reextract-missed] materializing ${books.length} affected books…`);
+  let matFail = 0;
+  for (const bid of books) {
+    try { await thumbnailAndMaterialize(db, bid); }
+    catch (e) { matFail++; console.error(`  [materialize-fail] ${bid}: ${e.codeName || ''} ${e.message}`); }
+  }
+  if (matFail) console.log(`[reextract-missed] ${matFail} books failed materialization (logged above).`);
+  console.log('[reextract-missed] done. Sample recovered gallery images:');
+  const sample = await db.collection('gallery_images').find({ book_id: { $in: books }, gallery_quality: { $gte: 0.5 }, extracted_url: { $ne: null } }).project({ page_number: 1, gallery_quality: 1, type: 1, extracted_url: 1 }).limit(15).toArray();
+  sample.forEach(g => console.log(`  p${g.page_number} q=${g.gallery_quality} ${g.type} ${g.extracted_url}`));
+  await client.close();
+}
+
+const REPO_ROOT = fileURLToPath(import.meta.url).replace(/\/scripts\/maintenance\/.*/, '');
+// Crop (→R2) then canonically materialize one book. Per-book try/catch lives at the call site
+// so one bad book never aborts a whole batch's materialization (the batch-3 FATAL root cause).
+async function thumbnailAndMaterialize(db, bid) {
+  await new Promise((resolve) => {
+    const proc = spawn('node', [`${REPO_ROOT}/scripts/workers/generate-thumbnails.mjs`, `--book-id=${bid}`], { stdio: 'ignore', env: process.env });
+    proc.on('exit', resolve); proc.on('error', resolve);
+  });
+  await materializeGalleryForBook(db, bid);
+}
+
+// ── Reconcile: re-crop + re-materialize books whose recovered pages have no gallery_images doc ──
+async function reconcile(db) {
+  console.log('[reconcile] scanning Case-3 books for recovered pages missing gallery docs…');
+  const cursor = db.collection('books').find({ visible: true, detected_images_count: { $gt: 0 } }, { projection: { id: 1 } }).sort({ _id: 1 });
+  let scanned = 0, gapBooks = 0, fixed = 0, failed = 0;
+  for await (const book of cursor) {
+    scanned++;
+    if (scanned % 1000 === 0) console.log(`  …scanned ${scanned} books, ${gapBooks} gap, ${fixed} fixed, ${failed} failed`);
+    // recovered pages with a gallery-worthy detection (these MUST end up visible)
+    const recovered = await db.collection('pages').find(
+      { book_id: book.id, miss_recheck_at: { $exists: true }, detected_images: { $elemMatch: { bbox: { $exists: true }, gallery_quality: { $gte: 0.5 } } } },
+      { projection: { id: 1, detected_images: 1 } }
+    ).toArray();
+    if (!recovered.length) continue;
+    const haveGallery = new Set(await db.collection('gallery_images').distinct('page_id', { book_id: book.id }));
+    // A page needs repair if it has no gallery doc, OR a qualifying detection has no
+    // extracted_url crop yet (thumbnails never ran → it'd be filtered from the gallery).
+    const gap = recovered.some(p =>
+      !haveGallery.has(p.id) ||
+      (p.detected_images || []).some(d => d?.bbox && (d.gallery_quality ?? 0) >= 0.5 && !d.extracted_url)
+    );
+    if (!gap) continue;
+    gapBooks++;
+    try { await thumbnailAndMaterialize(db, book.id); fixed++; }
+    catch (e) { failed++; console.error(`  [reconcile-fail] ${book.id}: ${e.codeName || ''} ${e.message}`); }
+  }
+  console.log(`[reconcile] done. scanned=${scanned} gapBooks=${gapBooks} fixed=${fixed} failed=${failed}`);
+}
+
+// Canonical gallery materialization (mirrors POST /api/admin/sync-gallery-images), scoped to one book.
+async function materializeGalleryForBook(db, bookId) {
+  const pipeline = [
+    { $match: { book_id: bookId, 'detected_images.0': { $exists: true }, $or: [{ cropped_photo: { $exists: true, $ne: '' } }, { photo_original: { $exists: true, $ne: '' } }, { photo: { $exists: true, $ne: '' } }], detected_images: { $elemMatch: { bbox: { $exists: true }, detection_source: { $in: ['vision_model', 'manual', 'ocr_tag'] }, gallery_quality: { $gte: 0.5 } } } } },
+    { $lookup: { from: 'books', localField: 'book_id', foreignField: 'id', as: 'book' } },
+    { $unwind: { path: '$book', preserveNullAndEmptyArrays: true } },
+    { $match: { 'book.visible': true } },
+    { $project: { id: 1, book_id: 1, page_number: 1, cropped_photo: 1, archived_photo: 1, photo_original: 1, photo: 1, enhanced_photo: 1, detected_images: 1, book: 1 } },
+    { $unwind: { path: '$detected_images', includeArrayIndex: 'detection_index' } },
+    { $match: { 'detected_images.bbox': { $exists: true }, 'detected_images.detection_source': { $in: ['vision_model', 'manual', 'ocr_tag'] }, 'detected_images.gallery_quality': { $gte: 0.5 } } },
+    { $setWindowFields: { partitionBy: '$book_id', sortBy: { 'detected_images.gallery_quality': -1 }, output: { book_rank: { $documentNumber: {} } } } },
+    { $project: {
+      _id: 0,
+      id: { $concat: ['$id', '-', { $toString: '$detection_index' }] },
+      page_id: '$id', book_id: '$book_id', page_number: '$page_number', detection_index: '$detection_index',
+      image_url: { $ifNull: ['$enhanced_photo', { $ifNull: ['$cropped_photo', { $ifNull: ['$archived_photo', { $ifNull: ['$photo_original', '$photo'] }] }] }] },
+      thumbnail_url: '$detected_images.thumbnail_url', extracted_url: '$detected_images.extracted_url',
+      description: { $ifNull: ['$detected_images.description', ''] }, type: '$detected_images.type', bbox: '$detected_images.bbox',
+      rotation: '$detected_images.rotation', gallery_quality: '$detected_images.gallery_quality', confidence: '$detected_images.confidence',
+      museum_description: '$detected_images.museum_description', detection_source: '$detected_images.detection_source',
+      // Rebuild metadata from known subfields ONLY. A stray `metadata.language`
+      // (e.g. "Greek" on Byzantine-manuscript detections) is read by the
+      // gallery_images text index (language_override at the metadata subtree)
+      // and aborts the $merge with "language override unsupported". Dropping it
+      // is the root fix — the same latent bug lives in the prod sync routes (#2531).
+      metadata: {
+        subjects: '$detected_images.metadata.subjects',
+        figures: '$detected_images.metadata.figures',
+        symbols: '$detected_images.metadata.symbols',
+        style: '$detected_images.metadata.style',
+        technique: '$detected_images.metadata.technique',
+      },
+      dhash: '$detected_images.dhash',
+      book_title: { $ifNull: ['$book.display_title', { $ifNull: ['$book.title', 'Unknown'] }] }, book_author: '$book.author',
+      book_year: '$book.year', book_language: '$book.language', book_visible: { $ifNull: ['$book.visible', false] },
+      book_hidden: '$book.hidden', book_provider: '$book.image_source.provider', book_rank: '$book_rank', updated_at: new Date(),
+    } },
+    { $merge: { into: 'gallery_images', on: 'id', whenMatched: 'replace', whenNotMatched: 'insert' } },
+  ];
+  await db.collection('pages').aggregate(pipeline, { allowDiskUse: true }).toArray();
+}
+
+main().catch(err => { console.error('[reextract-missed] FATAL', err); process.exit(1); });


### PR DESCRIPTION
## What

A maintenance tool that recovers gallery-worthy illustrations the image-extraction vision pass **silently missed** — pages that were valid illustration candidates (carry a high-significance `<image-desc>` OCR marker) yet ended up with empty `detected_images`. Because the book then finalizes as `complete` with `detected_images_count` set, the catch-up cron (which only revisits books with no `detected_images_count`) never re-examines them, so the illustration is absent from the gallery forever.

Originally surfaced from a single book — a 1577-comet treatise whose page-10 celestial diagram was a textbook `page_type: "diagram"` candidate with a `significance="high"` marker but zero detections.

## How

- **Targets the precise signal** the pilot measured (~63%, scaled run 71%): a non-trivial high-significance `<image-desc>` marker on a page with no detections, in already-extracted visible books.
- **Reuses the production prompt verbatim** — read out of `image-extract-worker.mjs` at runtime so it can never drift from the live extractor.
- **Materializes via the canonical paths**: `generate-thumbnails` for R2 crops, then the `sync-gallery-images` aggregation for fully-denormalized `gallery_images` docs.
- **Idempotent + resumable**: every tested page is stamped `miss_recheck_at`, so OCR-over-claim pages (vision correctly found nothing) are never re-tested, and recovered pages drop out of the candidate filter. Re-run until dry.
- **Crash-safe**: per-book `try/catch` on materialization so one bad book can't abort a batch (this matters — see the sibling fix #2549 for the `metadata.language` issue it caught).
- **`--reconcile` mode** heals partial runs (re-crops + re-materializes books whose recovered pages have no gallery doc or no crop yet).

Flags: `--apply` (writes; default is dry-run yield measurement), `--limit`, `--concurrency`, `--random-books` (representative sampling for validation), `--reconcile`.

## Validation (Hetzner, real runs)

- Pilot 200 pages → 63% recovery. Validation 2,000 pages → **71% recovery, 0 fetch failures, 0 errors**, crops verified serving and visually inspected (botanical woodcuts, codices, diagrams, Tibetan chant notation, …).
- Full corpus run: **~32,600 pages recovered → ~38K illustrations** across ~7,600 books. Reconcile pass: 50 gap books, all fixed, 0 failures.
- Known tail (inherent to vision-on-historical-scans, not tool bugs): a minority are rotated (inverted source scans) or false positives from page bleed-through.

## Notes

- Belongs on the Hetzner box (reliable image fetch; same env as the worker). Not wired to cron — it's a deliberate, operator-run sweep.
- Pairs with #2549 (prod-route `metadata.language` fix) and issue #2531 (make the extraction worker write self-sufficient gallery docs so future extractions don't need the separate materialization step).
