### PR TITLE
works-catalog: CBETA as normal books w/ representative scan (cuneiform model)

### DIFF
--- a/scripts/works-catalog/import-cbeta-text.mjs
+++ b/scripts/works-catalog/import-cbeta-text.mjs
@@ -24,7 +24,9 @@
  *   node scripts/works-catalog/import-cbeta-text.mjs --canon=T --limit=200   # bulk (hidden)
  */
 import { MongoClient, ObjectId } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { fetchRetry } from './lib.mjs';
+import { uploadPageVariants } from '../workers/lib/display-image.mjs';
 
 const args = Object.fromEntries(process.argv.slice(2).filter(a => a.startsWith('--')).map(a => { const [k, v] = a.slice(2).split('='); return [k, v ?? true]; }));
 const DRY_RUN = 'dry-run' in args;
@@ -106,13 +108,84 @@ function extract(xml) {
 function teiTitle(xml) { return (xml.match(/<title level="m"[^>]*xml:lang="zh-Hant"[^>]*>([^<]+)/) || xml.match(/<title level="m"[^>]*>([^<]+)/) || [])[1] || null; }
 function teiAuthor(xml) { return (xml.match(/<author>([^<]+)<\/author>/) || [])[1] || null; }
 
+// ── representative facsimile cover (cuneiform model) ─────────────────────────
+// Match the work to an OPENLY-LICENSED scanned edition we've harvested and use a
+// representative page as the book's cover/hero. NOT the Taishō print facsimile
+// (© Daizō Shuppansha, uncleared) — only libraries whose digitised copies are
+// freely reusable. The scan is representative of the work, not page-aligned.
+const COVER_PROVIDERS = ['sbb', 'ia_language', 'bsb', 'sat_daizokyo', 'harvard', 'goettingen'];
+const COVER_PROVIDER_NAME = { sbb: 'Staatsbibliothek zu Berlin', ia_language: 'Internet Archive', bsb: 'Bayerische Staatsbibliothek', sat_daizokyo: 'SAT Daizōkyō (partner libraries)', harvard: 'Harvard-Yenching Library', goettingen: 'Göttingen State and University Library' };
+const cjkOnly = (s) => [...(s || '')].filter(ch => /[㐀-鿿]/.test(ch)).join('');
+
+async function matchFacsimile(ICands, cjkTitle) {
+  const key = cjkOnly(cjkTitle);
+  if (key.length < 2) return null;
+  // candidates from open providers whose title CONTAINS the work title (work name leads)
+  const cands = await ICands.find(
+    { source: { $in: COVER_PROVIDERS }, manifest_url: { $ne: null }, title: { $regex: key.slice(0, 12) } },
+    { projection: { title: 1, source: 1, manifest_url: 1, source_url: 1 } }
+  ).limit(30).toArray();
+  // prefer exact-title match, then shortest (least extra commentary), provider order
+  const scored = cands
+    .map(c => ({ c, ct: cjkOnly(c.title) }))
+    .filter(x => x.ct.startsWith(key) || key.startsWith(x.ct))
+    .sort((a, b) => (a.ct === key ? -1 : b.ct === key ? 1 : 0) || a.ct.length - b.ct.length || COVER_PROVIDERS.indexOf(a.c.source) - COVER_PROVIDERS.indexOf(b.c.source));
+  return scored[0]?.c || null;
+}
+
+// First canvas image of a IIIF v2/v3 manifest → a full-ish JPEG URL.
+async function coverImageUrl(manifestUrl) {
+  try {
+    const m = await (await fetchRetry(manifestUrl)).json();
+    // IIIF v2
+    let svc = m?.sequences?.[0]?.canvases?.[0]?.images?.[0]?.resource?.service;
+    svc = Array.isArray(svc) ? svc[0] : svc;
+    let base = svc?.['@id'] || svc?.id;
+    if (base) return `${base.replace(/\/$/, '')}/full/!1000,1400/0/default.jpg`;
+    // IIIF v3
+    const body = m?.items?.[0]?.items?.[0]?.items?.[0]?.body;
+    svc = Array.isArray(body?.service) ? body.service[0] : body?.service;
+    base = svc?.id || svc?.['@id'];
+    if (base) return `${base.replace(/\/$/, '')}/full/!1000,1400/0/default.jpg`;
+    // last resort: direct image id
+    const direct = m?.sequences?.[0]?.canvases?.[0]?.images?.[0]?.resource?.['@id'] || body?.id;
+    return direct || null;
+  } catch { return null; }
+}
+
 // ── import ───────────────────────────────────────────────────────────────────
 const mc = new MongoClient(process.env.MONGODB_URI);
 await mc.connect();
 const Books = mc.db('bookstore').collection('books');
 const Pages = mc.db('bookstore').collection('pages');
+const ICands = mc.db('bookstore').collection('import_candidates');
 const now = new Date();
-let created = 0, skipped = 0;
+let created = 0, skipped = 0, withCover = 0;
+
+// R2 (rehost the representative cover, like every other SL image)
+const r2 = new S3Client({
+  region: 'auto', endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: process.env.R2_ACCESS_KEY_ID, secretAccessKey: process.env.R2_SECRET_ACCESS_KEY },
+});
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary';
+const R2_PUBLIC = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+const uploadToR2 = async (key, buf, ct = 'image/jpeg') => {
+  await r2.send(new PutObjectCommand({ Bucket: R2_BUCKET, Key: key, Body: buf, ContentType: ct, CacheControl: 'public, max-age=86400, s-maxage=86400' }));
+  return `${R2_PUBLIC}/${key}`;
+};
+async function buildCover(bookId, cjkTitle) {
+  const fac = await matchFacsimile(ICands, cjkTitle);
+  if (!fac) return null;
+  const imgUrl = await coverImageUrl(fac.manifest_url);
+  if (!imgUrl) return null;
+  try {
+    const res = await fetch(imgUrl, { signal: AbortSignal.timeout(45000) });
+    if (!res.ok) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    const v = await uploadPageVariants(buf, bookId, 1, uploadToR2);
+    return { ...v, facsimile: fac };
+  } catch { return null; }
+}
 
 for (const wid of ids.slice(0, LIMIT)) {
   const path = teiPath(wid);
@@ -145,36 +218,55 @@ for (const wid of ids.slice(0, LIMIT)) {
   const _id = new ObjectId();
   const id = _id.toString();
   const slug = `cbeta-${wid.toLowerCase()}`;
+  const cover = await buildCover(id, title);   // representative facsimile (may be null)
+  if (cover) withCover++;
+  const fac = cover?.facsimile;
   await Books.insertOne({
     _id, id, slug, title, display_title: title, author: author || 'Anonymous',
     language: 'Classical Chinese', original_language: 'lzh', published: null,
-    content_type: 'text', resource_type: 'text',
+    content_type: 'book',
     collections: ['chinese-buddhist-canon', 'world-traditions'],
     categories: ['buddhist-canon', 'chinese-literature'],
     pages_count: pages.length, pages_ocr: pages.length, pages_translated: 0, pages_blank: 0,
-    image_source: {
+    // The readable text is CBETA's digital edition; the cover is a representative
+    // scan from an open library (NOT the © Taishō print). image_source credits the
+    // scan provider; metadata.text_edition + attribution credit CBETA + the publishers.
+    image_source: cover ? {
+      provider: fac.source, provider_name: COVER_PROVIDER_NAME[fac.source] || fac.source,
+      source_url: fac.source_url || fac.manifest_url,
+      license: 'Representative facsimile from an open library (see provider); text: CC BY-NC-SA 3.0 TW (CBETA)',
+      attribution: `Representative scan: ${COVER_PROVIDER_NAME[fac.source] || fac.source}. Text: CBETA digital edition of the Taishō Tripiṭaka (© Daizō Shuppansha) / Zokuzōkyō (© Kokusho Kankōkai)`,
+      access_date: now,
+    } : {
       provider: 'cbeta', provider_name: 'CBETA (Chinese Buddhist Electronic Text Association)',
       source_url: `https://cbetaonline.dila.edu.tw/${wid}`,
-      license: 'CC BY-NC-SA 3.0 TW; base text © Taishō Tripiṭaka (Daizō Shuppansha) / Zokuzōkyō (Kokusho Kankōkai), input rights granted to CBETA',
+      license: 'CC BY-NC-SA 3.0 TW; base text © Taishō (Daizō Shuppansha) / Zokuzōkyō (Kokusho Kankōkai)',
       attribution: 'CBETA digital edition; base text: Taishō Tripiṭaka (Daizō Shuppansha) & Zokuzōkyō (Kokusho Kankōkai)',
       access_date: now,
     },
-    metadata: { source: 'cbeta', cbeta_id: wid, dynasty: wi.dynasty || null, category: wi.category || null, total_chars: totalChars, script: 'Han (Traditional)' },
+    ...(cover ? { thumbnail: cover.thumb, image_thumb: cover.thumb, image_display: cover.display, thumbnail_blob: cover.thumb, cover_page: 1 } : {}),
+    metadata: { source: 'cbeta', cbeta_id: wid, dynasty: wi.dynasty || null, category: wi.category || null, total_chars: totalChars, script: 'Han (Traditional)', text_edition: 'CBETA', cover_facsimile: fac ? `${fac.source}:${fac.manifest_url}` : null },
     source_fingerprint: fingerprint, status: 'imported', hidden: !VISIBLE, visible: VISIBLE,
-    pipeline_auto: { status: 'images_complete', ocr_deferred: true, ocr_deferred_reason: 'text-only work (CBETA digital edition); no scan' },
+    pipeline_auto: { status: 'images_complete', ocr_deferred: true, ocr_deferred_reason: 'CBETA text edition; cover is a representative facsimile, body pages are scholarly text' },
     created_at: now, updated_at: now,
   });
   await Pages.insertMany(pages.map((p, idx) => {
     const pid = new ObjectId();             // pages have a UNIQUE index on `id`
-    return {
+    const doc = {
       _id: pid, id: pid.toString(),
       book_id: id, page_number: idx + 1, page_label: p.label,
       ocr: { data: p.text, model: 'cbeta-tei-p5', generated_at: now, updated_at: now },
       created_at: now, updated_at: now,
     };
+    if (idx === 0 && cover) {               // representative scan sits on the opening page
+      doc.display_photo = cover.display; doc.archived_photo = cover.archived; doc.thumbnail_blob = cover.thumb;
+      if (cover.width) doc.image_width = cover.width;
+      if (cover.height) doc.image_height = cover.height;
+    }
+    return doc;
   }));
   created++;
-  console.log(`  + ${wid} "${title}" — ${pages.length} pages, ${totalChars} chars (${VISIBLE ? 'visible' : 'hidden'})  /book/${slug}`);
+  console.log(`  + ${wid} "${title}" — ${pages.length} pages, ${totalChars} chars${cover ? ` +cover[${fac.source}]` : ' (no facsimile match)'} (${VISIBLE ? 'visible' : 'hidden'})  /book/${slug}`);
 }
 await mc.close();
-console.log(`\nDone. created ${created}, skipped ${skipped} (existing).${DRY_RUN ? ' [DRY RUN — nothing written]' : ''}`);
+console.log(`\nDone. created ${created} (${withCover} with a representative scan), skipped ${skipped} (existing).${DRY_RUN ? ' [DRY RUN — nothing written]' : ''}`);


### PR DESCRIPTION
Reworks the CBETA importer per Derek's steer: imports are normal `content_type:book` (not a segregated text edition), each paired with a representative scan like the CDLI cuneiform entries.

- Matches the work to an **openly-licensed** harvested facsimile (SBB / IA / BSB / SAT-partners / Harvard / Göttingen) by CJK title, pulls a representative page from its IIIF manifest, rehosts to R2, sets it as cover + opening-page image.
- CBETA's clean scholarly text stays the readable body. `image_source` credits the scan library; `metadata.text_edition` + attribution credit CBETA + Taishō/Zokuzōkyō publishers.
- Deliberately does NOT rehost the © Taishō print facsimile (uncleared) — only freely-reusable library copies; works with no match import text-only (no broken scan).

Pilot live (visible): /book/cbeta-t0251 (Heart, SAT/Kyoto-NDL), /book/cbeta-t0235 (Diamond, Staatsbibliothek Berlin), /book/cbeta-t2008 (Platform, IA Zongbao) — covers on R2, books render. check-imports passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)