### PR TITLE
feat(analytics): PostHog session replay — full capture, all visitors

### DIFF
--- a/src/components/providers/AnalyticsScripts.tsx
+++ b/src/components/providers/AnalyticsScripts.tsx
@@ -110,7 +110,20 @@ export default function AnalyticsScripts() {
             api_host: '${POSTHOG_HOST}',
             person_profiles: 'identified_only',
             capture_pageview: true,
-            capture_pageleave: true
+            capture_pageleave: true,
+            // Full session replay. We only reach this code path after the user
+            // clicks "Accept" on the consent banner, so recording is consent-gated
+            // by construction. Capture everything: unmask all text + inputs so we
+            // see exactly what readers see (search queries, navigation, scroll).
+            // Passwords are always masked by PostHog regardless of this config.
+            disable_session_recording: false,
+            session_recording: {
+              maskAllInputs: false,
+              maskTextSelector: undefined,
+              maskInputOptions: { password: true },
+              recordCrossOriginIframes: true,
+            },
+            capture_performance: true,
           });
         `}
           </Script>

--- a/src/components/providers/AnalyticsScripts.tsx
+++ b/src/components/providers/AnalyticsScripts.tsx
@@ -58,6 +58,18 @@ export default function AnalyticsScripts() {
     });
   }, [consent, isEmbedded]);
 
+  // PostHog loads on entry for everyone (see below) and captures by default.
+  // Honor an explicit "Decline": opt the user out of all capture + recording.
+  // Undecided (null) and "accepted" both stay opted in — that's the point of
+  // pre-consent loading. opt_in/opt_out are queued safely by the init stub.
+  useEffect(() => {
+    if (isEmbedded || consent === null) return;
+    const ph = (window as unknown as { posthog?: { opt_in_capturing?: () => void; opt_out_capturing?: () => void } }).posthog;
+    if (!ph || typeof ph.opt_out_capturing !== 'function') return;
+    if (consent === 'declined') ph.opt_out_capturing();
+    else ph.opt_in_capturing?.();
+  }, [consent, isEmbedded]);
+
   // Closed partner reading rooms get no Source Library analytics (and no
   // third-party-iframe pings to Google from inside a partner's site).
   if (isEmbedded) return null;
@@ -93,29 +105,33 @@ export default function AnalyticsScripts() {
           gtag('config', '${GA_ID}', { anonymize_ip: true });
         `}
       </Script>
-      {/* Ahrefs + PostHog stay strictly consent-gated: load only after "Accept". */}
+      {/* Ahrefs stays strictly consent-gated: loads only after "Accept". */}
       {consent === 'accepted' && (
-        <>
-          {/* Ahrefs */}
-          <Script
-            src="https://analytics.ahrefs.com/analytics.js"
-            data-key={AHREFS_KEY}
-            strategy="lazyOnload"
-          />
-          {/* PostHog */}
-          <Script id="posthog-init" strategy="afterInteractive">
-            {`
+        <Script
+          src="https://analytics.ahrefs.com/analytics.js"
+          data-key={AHREFS_KEY}
+          strategy="lazyOnload"
+        />
+      )}
+      {/* PostHog loads on entry for ALL visitors (not accept-gated), so product
+          analytics + session replay capture the full audience, not just the
+          self-selected slice who click Accept. It captures by default; an
+          explicit "Decline" is honored via opt_out_capturing in the effect
+          above. Closed partner reading rooms are already excluded (isEmbedded
+          early-return). */}
+      <Script id="posthog-init" strategy="afterInteractive">
+        {`
           !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageviewId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
           posthog.init('${POSTHOG_KEY}', {
             api_host: '${POSTHOG_HOST}',
             person_profiles: 'identified_only',
             capture_pageview: true,
             capture_pageleave: true,
-            // Full session replay. We only reach this code path after the user
-            // clicks "Accept" on the consent banner, so recording is consent-gated
-            // by construction. Capture everything: unmask all text + inputs so we
-            // see exactly what readers see (search queries, navigation, scroll).
-            // Passwords are always masked by PostHog regardless of this config.
+            // Full session replay, capturing the whole audience (loaded pre-consent;
+            // explicit Decline is honored via opt_out in the effect above).
+            // Capture everything: unmask all text + inputs so we see exactly what
+            // readers see (search queries, navigation, scroll). Passwords are
+            // always masked by PostHog regardless of this config.
             disable_session_recording: false,
             session_recording: {
               maskAllInputs: false,
@@ -126,9 +142,7 @@ export default function AnalyticsScripts() {
             capture_performance: true,
           });
         `}
-          </Script>
-        </>
-      )}
+      </Script>
     </>
   );
 }


### PR DESCRIPTION
## What
1. **Full-capture session replay** — explicit `session_recording` config: unmask all text + inputs so replays show exactly what readers see (search, navigation, scroll). Passwords stay masked (PostHog enforces).
2. **Load PostHog pre-consent** — moved out of the `consent==='accepted'` gate so it loads on entry for **every visitor**, not just the self-selected slice who click Accept. Mirrors how GA already loads pre-consent in this same file.

## Why
Session recording is on at the PostHog project level and `/decide` returns recorder-v2 config, but (a) the client init had no explicit `session_recording` block and (b) PostHog only loaded after Accept — so ~97% of visitors were never recorded. Product decision: record the full audience.

## Privacy posture
- PostHog captures by default; an **explicit "Decline"** is honored via `opt_out_capturing` (same floor GA uses here).
- This is a deliberate GDPR/ePrivacy posture change (most traffic is EU/LatAm), accepted by the site owner.
- Ahrefs stays accept-gated. Tenant/embed partner reading rooms remain fully excluded.

## Verify after deploy
PostHog → Session Replay should start showing recordings within minutes; `/decide` already returns recording config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)