### PR TITLE
feat(auth): track lastLogin + loginCount for returning-member analytics

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -234,6 +234,23 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }
       }
     },
+    // Stamp lastLogin on every actual authentication (fires on real sign-in,
+    // not on every JWT validation / page load — so it measures returning
+    // members who re-authenticate, e.g. after their session expires). Pairs
+    // with createdAt so we can tell new sign-ups from returning ones.
+    async signIn({ user }) {
+      if (!user?.email) return;
+      try {
+        const client = await clientPromise;
+        const db = client.db(dbName);
+        await db.collection('users').updateOne(
+          { email: user.email.toLowerCase() },
+          { $set: { lastLogin: new Date() }, $inc: { loginCount: 1 } }
+        );
+      } catch (error) {
+        console.error('[auth] Failed to stamp lastLogin:', error);
+      }
+    },
   },
   callbacks: {
     // Enforce signup restrictions based on tenant allowSignup setting


### PR DESCRIPTION
## What
Add a NextAuth `events.signIn` handler that stamps `users.lastLogin` and `$inc`s `users.loginCount` on every successful authentication.

## Why
User docs only had `createdAt`, so we could see new sign-ups but had no way to answer "who's a returning member who came back today." This adds the missing signal.

## Notes
- Fires on **actual sign-in** (the `signIn` event), not on every JWT validation / page load — so `lastLogin` measures re-authentication (e.g. after a session expires), not every visit. That's the right granularity for "returning members"; per-visit activity is better read from `analytics_pageviews`.
- Matches users by lowercased email (consistent with the signIn/jwt callbacks). Failures are caught and logged, never block auth.
- Backfill: existing users get the field on their next sign-in; no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)