### PR TITLE
feat(reader): jump to a specific page from the counter

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -547,8 +547,21 @@ export default function TranslationEditor({
   const [swipeOffset, setSwipeOffset] = useState(0);
   const [isSwiping, setIsSwiping] = useState(false);
 
+  // Jump-to-page: the counter ("18/864") doubles as an editable input
+  const [isEditingPage, setIsEditingPage] = useState(false);
+  const [pageInputValue, setPageInputValue] = useState('');
+
   const previousPage = currentIndex > 0 ? pages[currentIndex - 1] : null;
   const nextPage = currentIndex < pages.length - 1 ? pages[currentIndex + 1] : null;
+
+  const commitJumpToPage = () => {
+    const n = parseInt(pageInputValue, 10);
+    setIsEditingPage(false);
+    if (Number.isNaN(n)) return;
+    const clamped = Math.min(Math.max(n, 1), pages.length);
+    const target = pages[clamped - 1];
+    if (target && target.id !== page.id) onNavigate(target.id);
+  };
 
   // Build image URLs at different quality tiers
   // Tier 1: Thumbnail (150px) - for navigation, grid views
@@ -1015,8 +1028,40 @@ export default function TranslationEditor({
               >
                 <ChevronLeft className="w-4 h-4" aria-hidden="true" />
               </button>
-              <div className="flex flex-col items-center px-1 sm:px-2">
-                <span className="text-sm font-medium" style={{ color: 'var(--text-muted)' }} aria-label={`Page ${currentIndex + 1} of ${pages.length}`}>{currentIndex + 1}/{pages.length}</span>
+              <div className="flex items-center px-1 sm:px-2">
+                {isEditingPage ? (
+                  <form
+                    onSubmit={(e) => { e.preventDefault(); commitJumpToPage(); }}
+                    className="flex items-center gap-1"
+                  >
+                    <input
+                      type="number"
+                      inputMode="numeric"
+                      min={1}
+                      max={pages.length}
+                      autoFocus
+                      value={pageInputValue}
+                      onChange={(e) => setPageInputValue(e.target.value)}
+                      onBlur={commitJumpToPage}
+                      onKeyDown={(e) => { if (e.key === 'Escape') setIsEditingPage(false); }}
+                      className="w-12 text-sm font-medium text-center bg-transparent border-b focus:outline-none"
+                      style={{ color: 'var(--text-primary)', borderColor: 'var(--accent-rust)' }}
+                      aria-label={`Jump to page (1 to ${pages.length})`}
+                    />
+                    <span className="text-sm font-medium" style={{ color: 'var(--text-muted)' }}>/{pages.length}</span>
+                  </form>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => { setPageInputValue(String(currentIndex + 1)); setIsEditingPage(true); }}
+                    className="text-sm font-medium rounded px-1 hover:bg-black/5 focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none transition-colors"
+                    style={{ color: 'var(--text-muted)' }}
+                    aria-label={`Page ${currentIndex + 1} of ${pages.length}. Click to jump to a page`}
+                    title="Jump to page"
+                  >
+                    {currentIndex + 1}/{pages.length}
+                  </button>
+                )}
               </div>
               <button
                 onClick={() => nextPage && onNavigate(nextPage.id)}


### PR DESCRIPTION
## Why

A reader on a long book (e.g. 864 pages) had no way to reach an arbitrary page — the page navigation only offered prev/next arrows. Reaching page 455 meant clicking forward hundreds of times. Reported from the BPH reader ("how to get to 455 for instance?").

## What

The `N/total` page counter in the reader nav is now interactive:
- Click it → it swaps into a focused number input (the current page pre-filled).
- Type a page and press **Enter** (or click away) → jumps to that page, clamped to `1..total`.
- **Escape** cancels with no navigation.

Jump is by display position (the number shown in the counter), so typing 455 goes to the 455th page — matching what the reader sees. Reuses the existing `onNavigate(pageId)` path; no new routes or data fetching.

## Scope

Single component: `src/components/pipeline/TranslationEditor.tsx` (the reader nav bar shared by the public reader and tenant/embed surfaces). No backend change. The arrow-key page nav already ignores typing inside inputs, so it doesn't fire while editing the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)