### PR TITLE
feat(analytics): identify signed-in members in PostHog

### DIFF
--- a/src/components/auth/PostHogIdentify.tsx
+++ b/src/components/auth/PostHogIdentify.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useEffect, useRef } from 'react';
+
+// Minimal PostHog shape we touch — the global is installed by the snippet in
+// AnalyticsScripts.tsx (and queues calls before the lib finishes loading).
+type PostHogLike = {
+  identify: (id: string, props?: Record<string, unknown>) => void;
+  reset: () => void;
+  get_distinct_id?: () => string;
+};
+
+function getPostHog(): PostHogLike | undefined {
+  return (window as unknown as { posthog?: PostHogLike }).posthog;
+}
+
+/**
+ * Links the signed-in member to their PostHog profile so anonymous analytics +
+ * session replay become attributable ("what did this member read/do?").
+ *
+ * - On sign-in: posthog.identify(userId, { email, name }) — once per user id.
+ * - On sign-out: posthog.reset() so the next visitor on a shared device starts
+ *   a fresh anonymous identity (no cross-account bleed).
+ *
+ * PostHog only exists when AnalyticsScripts mounted it (i.e. not on tenant/embed
+ * reading rooms, where it returns null) — so every call is guarded. The init
+ * snippet stubs `identify`/`reset` and queues them, but the global itself can
+ * lag this component by a tick, so we retry briefly until it appears.
+ */
+export default function PostHogIdentify() {
+  const { data: session, status } = useSession();
+  const identifiedId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (status === 'loading') return;
+
+    const userId = session?.user?.id;
+
+    // Signed in — identify once per distinct user id.
+    if (status === 'authenticated' && userId && identifiedId.current !== userId) {
+      let attempts = 0;
+      const tryIdentify = () => {
+        const ph = getPostHog();
+        if (!ph) {
+          if (attempts++ < 20) setTimeout(tryIdentify, 250); // up to ~5s
+          return;
+        }
+        ph.identify(userId, {
+          email: session.user?.email ?? undefined,
+          name: session.user?.name ?? undefined,
+        });
+        identifiedId.current = userId;
+      };
+      tryIdentify();
+      return;
+    }
+
+    // Signed out after having been identified — reset so the device's next
+    // anonymous session isn't attributed to the previous member.
+    if (status === 'unauthenticated' && identifiedId.current) {
+      getPostHog()?.reset();
+      identifiedId.current = null;
+    }
+  }, [session, status]);
+
+  return null;
+}

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -5,6 +5,7 @@ import { SiteModeProvider } from './SiteModeProvider';
 import { SiteModeConfig } from '@/lib/site-mode';
 import ErrorReporter from './ErrorReporter';
 import MigrateOnSignIn from '@/components/auth/MigrateOnSignIn';
+import PostHogIdentify from '@/components/auth/PostHogIdentify';
 import WelcomeGate from '@/components/auth/WelcomeGate';
 
 interface ProvidersProps {
@@ -18,6 +19,7 @@ export default function Providers({ children, siteMode }: ProvidersProps) {
       <SiteModeProvider initialMode={siteMode}>
         <ErrorReporter>
           <MigrateOnSignIn />
+          <PostHogIdentify />
           <WelcomeGate />
           {children}
         </ErrorReporter>


### PR DESCRIPTION
## What
Add `PostHogIdentify` — a client component (sibling of `MigrateOnSignIn`, inside `SessionProvider`) that links the signed-in member to their PostHog profile.

## Why
PostHog data and session replay were **fully anonymous** — we never called `identify()`. So we could see *that* someone read something, but never connect it to a known member, replay a specific member's session, or measure returning-member engagement. This is the multiplier that makes session replay (#2557) and `lastLogin` (#2559) answer "who did what."

## Behavior
- On sign-in: `posthog.identify(userId, { email, name })`, once per distinct user id.
- On sign-out: `posthog.reset()` so a shared device's next anonymous session isn't attributed to the previous member.
- Guarded: PostHog is absent on tenant/embed reading rooms (AnalyticsScripts returns null there); the global can also lag mount, so it retries briefly (~5s) then gives up.

## Privacy
Consistent with the pre-consent, full-capture posture already shipped in #2557 (owner-approved). Ties member email/name to their analytics profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)