### PR TITLE
fix(bph): catalog editor — revision history, VIAF link, editor privacy

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/history/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/history/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
-import { supabase } from '@/lib/supabase';
+import { supabase, supabaseAdmin } from '@/lib/supabase';
+import { getDb } from '@/lib/mongodb';
 
 /**
  * BPH catalog entry revision history — append-only log of every change
@@ -61,6 +62,51 @@ function timeAgo(iso: string): string {
   return new Date(iso).toLocaleDateString();
 }
 
+/**
+ * Mask a personal email for public display: keep the first character of the
+ * local part and the domain, redact the rest. `jbouman@efm.amsterdam` →
+ * `j••@efm.amsterdam`. This page is reachable signed-out (robots-noindexed
+ * but HTTP 200), so we never render a cataloguer's full address on the open
+ * web — only their display name when we have one, or this masked fallback.
+ */
+function maskEmail(email: string): string {
+  const at = email.indexOf('@');
+  if (at <= 0) return '—';
+  const local = email.slice(0, at);
+  const domain = email.slice(at + 1);
+  return `${local[0]}••@${domain}`;
+}
+
+/**
+ * Resolve display names for a set of editor emails. Prefers the user's
+ * `name` from the Atlas `users` collection; falls back to a masked email so
+ * a missing profile name never leaks the full address. System writers
+ * (`system:<job>`) render as-is.
+ */
+async function resolveDisplayNames(emails: string[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  const real = [...new Set(emails.filter((e) => e && !e.startsWith('system:')))];
+  let names = new Map<string, string>();
+  if (real.length > 0) {
+    try {
+      const db = await getDb();
+      const users = await db
+        .collection('users')
+        .find({ email: { $in: real } }, { projection: { email: 1, name: 1 } })
+        .toArray();
+      names = new Map(users.map((u) => [u.email as string, (u.name as string) || '']));
+    } catch {
+      // Fall through to masked emails if the lookup fails.
+    }
+  }
+  for (const e of [...new Set(emails)]) {
+    if (!e) continue;
+    if (e.startsWith('system:')) out.set(e, e);
+    else out.set(e, names.get(e)?.trim() || maskEmail(e));
+  }
+  return out;
+}
+
 export default async function CatalogHistoryPage({ params }: Props) {
   const { tenant, ubn } = await params;
   if (tenant !== 'bph') notFound();
@@ -75,7 +121,14 @@ export default async function CatalogHistoryPage({ params }: Props) {
   const work = workRow as { ubn: string; title: string | null; parallel_title: string | null; uniform_title: string | null };
   const displayTitle = work.title || work.parallel_title || work.uniform_title || `(untitled — UBN ${work.ubn})`;
 
-  const { data, error } = await supabase
+  // `bph_works_revisions` is RLS-protected — the anon client returns zero
+  // rows with no error, which used to render as a permanently-empty history
+  // even when revisions existed. Read with the service-role client (this is a
+  // server component, so it never reaches the browser). Fall back to the anon
+  // client only if the service key is missing, so the page degrades rather
+  // than crashing.
+  const reader = supabaseAdmin ?? supabase;
+  const { data, error } = await reader
     .from('bph_works_revisions')
     .select('id, ubn, change_type, field_changes, editor_email, proposed_by, applied_at, note')
     .eq('ubn', ubn)
@@ -85,6 +138,12 @@ export default async function CatalogHistoryPage({ params }: Props) {
   const tableMissing = error?.message?.toLowerCase().includes('does not exist') || error?.message?.toLowerCase().includes('could not find');
 
   const rows = (data || []) as RevisionRow[];
+
+  // Resolve cataloguer display names so we never print raw emails publicly.
+  const editorNames = await resolveDisplayNames(
+    rows.flatMap((r) => [r.editor_email, r.proposed_by].filter(Boolean) as string[]),
+  );
+  const nameFor = (email: string | null) => (email ? editorNames.get(email) || maskEmail(email) : '—');
 
   return (
     <div className="bg-cream min-h-screen">
@@ -110,7 +169,7 @@ export default async function CatalogHistoryPage({ params }: Props) {
           </div>
         ) : rows.length === 0 ? (
           <div className="p-6 rounded-lg border border-border-light bg-white text-center text-muted text-sm">
-            No revisions recorded for this work yet. New edits (from PR-C onwards) will appear here.
+            No revisions recorded for this work yet. Once an editor saves a change to this entry, it will appear here.
           </div>
         ) : (
           <ol className="space-y-3">
@@ -127,9 +186,9 @@ export default async function CatalogHistoryPage({ params }: Props) {
                     </span>
                     <span className="text-xs text-muted">{timeAgo(rev.applied_at)}</span>
                     <span className="text-xs text-muted ml-auto">
-                      by {rev.editor_email}
+                      by {nameFor(rev.editor_email)}
                       {rev.proposed_by && rev.proposed_by !== rev.editor_email && (
-                        <span> · proposed by {rev.proposed_by}</span>
+                        <span> · proposed by {nameFor(rev.proposed_by)}</span>
                       )}
                     </span>
                   </header>

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -46,6 +46,7 @@ interface BphWorkRow {
   author_entity_id: string | null;
   author_canonical_name: string | null;
   author_wikidata_qid: string | null;
+  author_viaf_id: string | null;
   place: string | null;
   printer: string | null;
   publisher: string | null;
@@ -112,7 +113,7 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
   const select = `
       ubn, title, parallel_title, uniform_title,
       author, variant_author, pseudonym, editor, variant_editor,
-      author_entity_id, author_canonical_name, author_wikidata_qid,
+      author_entity_id, author_canonical_name, author_wikidata_qid, author_viaf_id,
       place, printer, publisher, variant_printer, variant_publisher,
       year, shelf_mark, state_shelf_mark, present_location,
       keywords, language, series_title, volume_title,
@@ -130,7 +131,7 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
     '',
   );
   const fallbackNoAuthority = fallbackSelect.replace(
-    'author_entity_id, author_canonical_name, author_wikidata_qid,\n      ',
+    'author_entity_id, author_canonical_name, author_wikidata_qid, author_viaf_id,\n      ',
     '',
   );
   const first = await supabase.from('bph_works').select(select).eq('ubn', ubn).maybeSingle();
@@ -588,18 +589,18 @@ export default async function CatalogEntryPage({ params }: Props) {
               actually linked. The label uses "Standard name (VIAF)" to mirror
               the terminology in the editor's picker, so cataloguers see the
               same wording on read and write. */}
-          {(work.author_canonical_name || work.author_entity_id || work.author_wikidata_qid) && (
+          {(work.author_canonical_name || work.author_viaf_id || work.author_wikidata_qid) && (
             <FieldRaw label="Standard name (VIAF)">
               <span className="flex flex-wrap items-baseline gap-x-2 text-primary">
                 {work.author_canonical_name && <span>{work.author_canonical_name}</span>}
-                {work.author_entity_id && (
+                {work.author_viaf_id && (
                   <a
-                    href={`https://viaf.org/viaf/${work.author_entity_id}`}
+                    href={`https://viaf.org/viaf/${work.author_viaf_id}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-secondary hover:underline text-xs"
                   >
-                    VIAF {work.author_entity_id}
+                    VIAF {work.author_viaf_id}
                   </a>
                 )}
                 {work.author_wikidata_qid && (

--- a/src/components/catalog/AuthorAuthorityPicker.tsx
+++ b/src/components/catalog/AuthorAuthorityPicker.tsx
@@ -51,6 +51,28 @@ interface Props {
   debounceMs?: number;
 }
 
+/**
+ * VIAF search can return several rows for the same VIAF cluster (e.g. one
+ * with life dates, one without). Collapse them to one row per VIAF id, keeping
+ * the richest record (prefer entries that carry birth/death years or a
+ * Wikidata id). Rows without a VIAF id pass through untouched.
+ */
+function dedupeByViaf(matches: AuthorAuthorityMatch[]): AuthorAuthorityMatch[] {
+  const byViaf = new Map<string, AuthorAuthorityMatch>();
+  const passthrough: AuthorAuthorityMatch[] = [];
+  const richness = (m: AuthorAuthorityMatch) =>
+    (m.birth_year || m.death_year ? 2 : 0) + (m.wikidata_qid ? 1 : 0);
+  for (const m of matches) {
+    if (!m.viaf_id) {
+      passthrough.push(m);
+      continue;
+    }
+    const existing = byViaf.get(m.viaf_id);
+    if (!existing || richness(m) > richness(existing)) byViaf.set(m.viaf_id, m);
+  }
+  return [...byViaf.values(), ...passthrough];
+}
+
 export default function AuthorAuthorityPicker({
   authorText,
   current,
@@ -100,7 +122,7 @@ export default function AuthorAuthorityPicker({
         setResults([]);
       } else {
         const json = (await res.json()) as AuthorAuthorityResult;
-        setResults(json.matches || []);
+        setResults(dedupeByViaf(json.matches || []));
       }
       setSearched(true);
     } catch (err) {


### PR DESCRIPTION
## Why

Paul Dijstelberge and José Bouman are set up as BPH catalogue editors and about to start adding/editing records. A pass over the editor found bugs that surface the moment a real cataloguer uses it.

## What

- **Revision history blocker (real, still live).** `/catalog/<ubn>/history` always read *'No revisions recorded'* even after successful saves. `bph_works_revisions` is RLS-protected; the page read it with the **anon** client, which returns zero rows with **no error** → permanently-empty log. Now read with the service-role client (server component, never reaches the browser). 111 existing revisions render again.
- **Editor email privacy.** Once history actually renders, it would print cataloguers' raw email addresses on a signed-out-reachable page. Now resolves display names from `users`, with a masked-email fallback (`jbouman@efm.amsterdam` → `j••@efm.amsterdam`).
- **VIAF link bug.** The read-only catalog page rendered the author's Mongo ObjectId where the VIAF id belongs (`VIAF 6a17f9…` → 404). Now renders `author_viaf_id` (added to the select).
- **VIAF picker dedupe** by VIAF id (search returned duplicate rows for one cluster).
- **Copy:** removed dev-jargon empty state ('from PR-C onwards').

Also set display names for the three editor accounts in `users` so history reads as names, not masked emails.

## Out of scope
- 'Add a brand-new record' UI (editor only edits existing entries today).
- Source-citation preset menu (the handoff's UX suggestion) — separate PR.
- The reported 'edit form mounts twice' — couldn't reproduce in the server-rendered page; looks like a dev StrictMode/find-tool artifact.

Refs #1877.