### PR TITLE
feat(auth): proactive in-app-browser guidance on the sign-in page

### DIFF
--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { headers } from 'next/headers';
+import { isInAppBrowser as detectInApp, preferredBrowser } from '@/lib/in-app-browser';
 
 // NextAuth (Auth.js v5) redirects here with ?error=<code>. The codes we
 // actually see in production (PostHog, 60d): `Verification` (single-use
@@ -8,16 +9,10 @@ import { headers } from 'next/headers';
 // failed — almost always because sign-in was attempted inside an in-app browser
 // webview, e.g. Instagram, which can't preserve the OAuth state cookie). The
 // old page ignored the code and showed one generic message; this one reads the
-// code + User-Agent and gives recovery-oriented guidance.
+// code + User-Agent and gives recovery-oriented guidance. In-app browser
+// detection is shared with the sign-in page via @/lib/in-app-browser.
 
-// In-app browser webviews break OAuth (lost state cookie) and Google often
-// blocks them outright. Detect the common ones so we can tell the user to
-// reopen in their real browser — the only reliable cure for those sign-ins.
-const IN_APP_BROWSER_RE =
-  /(Instagram|FBAN|FBAV|FB_IAB|FBIOS|Line\/|Twitter|Snapchat|WhatsApp|Pinterest|TikTok|musical_ly|BytedanceWebview|GSA\/|; wv\))/i;
-
-function describe(error: string | undefined, isInAppBrowser: boolean, isIOS: boolean) {
-  const browserName = isIOS ? 'Safari' : 'Chrome';
+function describe(error: string | undefined, isInAppBrowser: boolean, browserName: 'Safari' | 'Chrome') {
   const openHint = `You appear to be in an in-app browser. Tap the ⋯ menu and choose “Open in ${browserName}”, then sign in there.`;
 
   switch (error) {
@@ -64,10 +59,9 @@ export default async function AuthErrorPage({
   // Next.js 16: searchParams arrives as a Promise and must be awaited.
   const { error } = await searchParams;
   const ua = (await headers()).get('user-agent') || '';
-  const isInAppBrowser = IN_APP_BROWSER_RE.test(ua);
-  const isIOS = /(iPhone|iPad|iPod)/i.test(ua);
+  const isInAppBrowser = detectInApp(ua);
 
-  const { title, body, cta } = describe(error, isInAppBrowser, isIOS);
+  const { title, body, cta } = describe(error, isInAppBrowser, preferredBrowser(ua));
 
   return (
     <div className="min-h-screen relative flex items-center justify-center">

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useSearchParams } from 'next/navigation';
-import { Suspense, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { signIn } from 'next-auth/react';
 import Link from 'next/link';
 import { BookLoader } from '@/components/ui/BookLoader';
+import { isInAppBrowser, preferredBrowser, inAppBrowserName } from '@/lib/in-app-browser';
 
 function SignInContent() {
   const searchParams = useSearchParams();
@@ -15,6 +16,19 @@ function SignInContent() {
   const [loading, setLoading] = useState(false);
   const [emailError, setEmailError] = useState('');
   const [googleLoading, setGoogleLoading] = useState(false);
+
+  // Detect in-app browsers (Instagram/FB/TikTok webviews) client-side after
+  // mount. These break Google OAuth, so we warn up front and steer to email —
+  // whose magic link opens in the device's real browser, escaping the webview.
+  const [inApp, setInApp] = useState(false);
+  const [browser, setBrowser] = useState<'Safari' | 'Chrome'>('Chrome');
+  const [appName, setAppName] = useState<string | null>(null);
+  useEffect(() => {
+    const ua = navigator.userAgent;
+    setInApp(isInAppBrowser(ua));
+    setBrowser(preferredBrowser(ua));
+    setAppName(inAppBrowserName(ua));
+  }, []);
 
   const handleEmailSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -94,6 +108,14 @@ function SignInContent() {
             Access the full collection of rare texts in alchemy, Hermetica, and natural philosophy.
           </p>
         </div>
+
+        {inApp && (
+          <div className="mb-6 p-3 rounded-lg text-sm" style={{ background: '#fffbeb', color: '#92400e', border: '1px solid #fde68a' }}>
+            You&rsquo;re in {appName ? `${appName}’s` : 'an'} in-app browser, where Google sign-in usually fails.
+            Use <strong>email</strong> below — the link opens in your normal browser — or tap the{' '}
+            <strong>&#8230;</strong> menu and choose &ldquo;Open in {browser}&rdquo;.
+          </div>
+        )}
 
         {(error || emailError) && (
           <div className="mb-6 p-3 rounded-lg text-sm" style={{ background: '#fef2f2', color: '#991b1b' }}>
@@ -178,6 +200,11 @@ function SignInContent() {
               </>
             )}
           </button>
+          {inApp && (
+            <p className="text-center text-xs" style={{ color: 'var(--text-faint)' }}>
+              Often blocked in in-app browsers — email is more reliable here.
+            </p>
+          )}
         </div>
 
         <p className="mt-6 text-center text-xs" style={{ color: 'var(--text-faint)' }}>

--- a/src/lib/in-app-browser.ts
+++ b/src/lib/in-app-browser.ts
@@ -1,0 +1,36 @@
+// Shared in-app browser (webview) detection. Sign-in inside an in-app browser
+// — Instagram, Facebook, TikTok, etc. — is the #1 cause of our auth failures:
+// the OAuth round-trip loses the state cookie, and Google blocks many webviews
+// outright. Used both server-side (auth error page, via UA header) and
+// client-side (sign-in page, via navigator.userAgent) so we can warn users
+// BEFORE they fail and steer them to email (whose link opens in their real
+// browser) or to reopening in Chrome/Safari.
+
+export const IN_APP_BROWSER_RE =
+  /(Instagram|FBAN|FBAV|FB_IAB|FBIOS|Line\/|Twitter|Snapchat|WhatsApp|Pinterest|TikTok|musical_ly|BytedanceWebview|GSA\/|; wv\))/i;
+
+export function isInAppBrowser(ua: string | null | undefined): boolean {
+  return !!ua && IN_APP_BROWSER_RE.test(ua);
+}
+
+export function isIOS(ua: string | null | undefined): boolean {
+  return !!ua && /(iPhone|iPad|iPod)/i.test(ua);
+}
+
+// The browser to tell the user to reopen in, by platform.
+export function preferredBrowser(ua: string | null | undefined): 'Safari' | 'Chrome' {
+  return isIOS(ua) ? 'Safari' : 'Chrome';
+}
+
+// Best-effort friendly name of the host app, for a more specific message.
+export function inAppBrowserName(ua: string | null | undefined): string | null {
+  if (!ua) return null;
+  if (/Instagram/i.test(ua)) return 'Instagram';
+  if (/(FBAN|FBAV|FB_IAB|FBIOS)/i.test(ua)) return 'Facebook';
+  if (/Line\//i.test(ua)) return 'LINE';
+  if (/(TikTok|musical_ly|BytedanceWebview)/i.test(ua)) return 'TikTok';
+  if (/Snapchat/i.test(ua)) return 'Snapchat';
+  if (/Pinterest/i.test(ua)) return 'Pinterest';
+  if (/Twitter/i.test(ua)) return 'X';
+  return null;
+}


### PR DESCRIPTION
## What
Warn in-app-browser (Instagram/FB/TikTok webview) users **on the sign-in page**, before they hit a failed Google OAuth.

## Why
Today saw an Instagram-driven traffic spike (1,131 referrals, sign-ins ~270 mobile vs 43 desktop) and `/auth/error` jumped to 38 hits (from 5). The root cause is in-app browsers that can't preserve the OAuth state cookie. PR #2558 fixed the *post-failure* page; this recovers the sign-up *before* the failure.

## Change
- New shared util `src/lib/in-app-browser.ts` — `isInAppBrowser` / `preferredBrowser` / `inAppBrowserName`. Used by both the sign-in page (client, `navigator.userAgent`) and the error page (server, UA header), replacing the error page's inline regex (single source of truth).
- **Sign-in page:** amber banner when a webview is detected → steer to **email** (its magic link opens in the device's real browser, escaping the webview) or "Open in Chrome/Safari". Caption under the Google button noting it's often blocked. Email was already the primary option; this explains *why* to use it.

## Notes
- Detection is client-side after mount (no SSR/hydration mismatch); banner appears a tick after load.
- No auth-config change. Scoped to guidance/UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)