### PR TITLE
feat(bph): add new catalogue records + in-app help + feedback

### DIFF
--- a/scripts/maintenance/backup-bph-catalog.mjs
+++ b/scripts/maintenance/backup-bph-catalog.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Backup the BPH catalogue from Supabase to gzipped JSON.
+ *
+ * The BPH catalogue (bph_works) is the system of record for the Bibliotheca
+ * Philosophica Hermetica — editors (Paul, José) now write to it directly. That
+ * makes it critical data with three layers of protection:
+ *
+ *   1. bph_works_revisions — append-only, every field change with from→to,
+ *      editor, source citation, timestamp. Logical per-field rollback lives
+ *      here (replay any revision's `from`).
+ *   2. Supabase's own managed backups / PITR.
+ *   3. THIS script — an independent, offsite-from-Supabase JSON snapshot for
+ *      catastrophic restore (table drop, mass corruption, account loss).
+ *
+ * Exports three tables in full (paginated, Supabase caps at 1000 rows/req):
+ *   - bph_works              (the catalogue)
+ *   - bph_works_revisions    (the audit trail)
+ *   - bph_works_pending_changes (contributor queue)
+ *
+ * Usage:
+ *   node scripts/maintenance/backup-bph-catalog.mjs --out /root/backups/bph-catalog-latest
+ *
+ * Restore (catalogue table example):
+ *   gunzip -c bph_works.json.gz | node scripts/maintenance/restore-bph-catalog.mjs  (not yet built —
+ *   for now the gz files are a plain JSON array per table, re-importable with a small upsert loop).
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { gzipSync } from 'node:zlib';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TABLES = ['bph_works', 'bph_works_revisions', 'bph_works_pending_changes'];
+const PAGE = 1000;
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function dumpTable(sb, table) {
+  const rows = [];
+  let from = 0;
+  for (;;) {
+    const { data, error } = await sb.from(table).select('*').range(from, from + PAGE - 1);
+    if (error) throw new Error(`${table}: ${error.message}`);
+    if (!data || data.length === 0) break;
+    rows.push(...data);
+    if (data.length < PAGE) break;
+    from += PAGE;
+  }
+  return rows;
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+  const outDir = arg('--out', join(process.cwd(), 'scripts', 'output', 'bph-catalog-backup'));
+  mkdirSync(outDir, { recursive: true });
+  const sb = createClient(url, key);
+
+  const manifest = { tables: {}, exported_at: new Date().toISOString() };
+  let total = 0;
+  for (const table of TABLES) {
+    const rows = await dumpTable(sb, table);
+    const gz = gzipSync(Buffer.from(JSON.stringify(rows)));
+    writeFileSync(join(outDir, `${table}.json.gz`), gz);
+    manifest.tables[table] = { rows: rows.length, bytes_gz: gz.length };
+    total += rows.length;
+    console.log(`  ${table}: ${rows.length} rows → ${(gz.length / 1024).toFixed(0)} KB gz`);
+  }
+  writeFileSync(join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  console.log(`BPH catalogue backup complete → ${outDir} (${total} rows across ${TABLES.length} tables)`);
+}
+
+main().catch((e) => {
+  console.error('BPH catalogue backup FAILED:', e.message);
+  process.exit(1);
+});

--- a/scripts/workers/backup-bph-catalog.sh
+++ b/scripts/workers/backup-bph-catalog.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Daily backup of the BPH catalogue (Supabase) to Hetzner.
+# Cron: 0 4 * * * /root/sourcelibrary/scripts/workers/backup-bph-catalog.sh
+#
+# The BPH catalogue (bph_works) is the system of record that editors write to
+# directly, so it gets the same latest+weekly discipline as the books backup:
+#   - /root/backups/bph-catalog-latest/  — overwritten daily (fast restore)
+#   - /root/backups/bph-catalog-weekly/<date>/ — every Sunday, kept (PITR)
+#
+# Each dir holds bph_works.json.gz, bph_works_revisions.json.gz,
+# bph_works_pending_changes.json.gz + manifest.json (row counts).
+#
+# This is layer 3 of the catalogue's protection — on top of the append-only
+# bph_works_revisions audit trail and Supabase's own managed backups.
+
+set -euo pipefail
+
+BACKUP_DIR="/root/backups"
+LOG="/var/log/sourcelibrary/backup-bph-catalog.log"
+DAY_OF_WEEK=$(date +%u)  # 1=Monday … 7=Sunday
+REPO="/root/sourcelibrary"
+
+log() { echo "[$(date -Is)] $1" >> "$LOG"; }
+
+mkdir -p "$BACKUP_DIR" "$(dirname "$LOG")"
+
+set -a
+source "$REPO/.env.production.local"
+set +a
+
+log "Starting BPH catalogue backup"
+
+LATEST_DIR="$BACKUP_DIR/bph-catalog-latest"
+rm -rf "$LATEST_DIR"
+
+if node "$REPO/scripts/maintenance/backup-bph-catalog.mjs" --out "$LATEST_DIR" >> "$LOG" 2>&1; then
+  SIZE=$(du -sh "$LATEST_DIR" | cut -f1)
+  log "BPH catalogue backup complete ($SIZE)"
+else
+  log "ERROR: backup-bph-catalog.mjs failed"
+  exit 1
+fi
+
+# Weekly point-in-time snapshot on Sundays, kept forever.
+if [ "$DAY_OF_WEEK" -eq 7 ]; then
+  WEEKLY_DIR="$BACKUP_DIR/bph-catalog-weekly/$(date +%Y-%m-%d)"
+  mkdir -p "$WEEKLY_DIR"
+  cp -r "$LATEST_DIR"/* "$WEEKLY_DIR"/
+  log "Weekly snapshot saved → $WEEKLY_DIR"
+fi

--- a/src/app/api/[tenant]/catalog/create/route.ts
+++ b/src/app/api/[tenant]/catalog/create/route.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/lib/auth-helpers';
+import {
+  applyWorkRevision,
+  EDITABLE_BPH_FIELDS,
+  BphCatalogError,
+  type FieldChangeMap,
+} from '@/lib/bph-catalog';
+import { ROLE_LEVEL, type Role } from '@/lib/auth';
+import { getDb } from '@/lib/mongodb';
+
+/**
+ * POST /api/[tenant]/catalog/create
+ *
+ * Create a brand-new BPH catalogue entry. Editor+ only — unlike the edit
+ * endpoint there is no contributor "queue for review" path yet: a proposed
+ * new record needs a UBN and a home before it can be reviewed, which is a
+ * larger design. Contributors get a 403 with a clear message.
+ *
+ * Body:
+ *   {
+ *     ubn: string,                       // required — unique catalogue id
+ *     fieldChanges: { <field>: { to }… },// at least `title` recommended
+ *     note?: string
+ *   }
+ *
+ * On success the new row is written via applyWorkRevision(changeType:'create'),
+ * which records a `create` revision in the same append-only history every edit
+ * lands in. Returns { ok, mode:'created', ubn, revisionId, appliedAt }.
+ *
+ * Sibling of the edit route; see ./[ubn]/edit/route.ts.
+ */
+
+const EDITABLE_SET = new Set<string>(EDITABLE_BPH_FIELDS);
+
+interface CreatePayload {
+  ubn?: string;
+  fieldChanges?: Record<string, { to: unknown; source?: string; evidence?: string }>;
+  note?: string;
+}
+
+function normalizeRole(role: unknown): Role {
+  if (
+    role === 'superadmin' ||
+    role === 'admin' ||
+    role === 'editor' ||
+    role === 'contributor' ||
+    role === 'reader'
+  ) {
+    return role;
+  }
+  if (role === 'inner_circle' || role === 'curator') return 'editor';
+  return 'reader';
+}
+
+async function effectiveRole(email: string | null | undefined, platformRole: Role, tenantSlug: string): Promise<Role> {
+  if (!email) return platformRole;
+  if (ROLE_LEVEL[platformRole] >= ROLE_LEVEL['editor']) return platformRole;
+  try {
+    const db = await getDb();
+    const tenant = await db.collection('tenants').findOne({ slug: tenantSlug, status: { $ne: 'deleted' } });
+    if (!tenant) return platformRole;
+    const m = await db.collection('memberships').findOne({
+      email: email.toLowerCase(),
+      tenantId: tenant.id,
+      status: 'active',
+    });
+    const r = normalizeRole(m?.role);
+    return ROLE_LEVEL[r] >= ROLE_LEVEL[platformRole] ? r : platformRole;
+  } catch {
+    return platformRole;
+  }
+}
+
+// A UBN must be a short, URL-safe token. We accept numeric BPH UBNs and our
+// own `SL-…` ids, but reject slashes/whitespace/anything that would break the
+// /catalog/<ubn> route or look like an injection.
+function isValidUbn(ubn: string): boolean {
+  return /^[A-Za-z0-9._-]{1,64}$/.test(ubn);
+}
+
+export const POST = withAuth(
+  async (request: NextRequest, session, ctx) => {
+    const params = await (ctx?.params as Promise<{ tenant: string }>);
+    const { tenant } = params;
+
+    if (tenant !== 'bph') {
+      return NextResponse.json(
+        { error: `Editor not available for tenant "${tenant}" yet` },
+        { status: 404 },
+      );
+    }
+
+    const userEmail = session.user?.email;
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Session is missing an email — re-sign in' }, { status: 400 });
+    }
+
+    const platformRole = normalizeRole((session.user as { role?: unknown }).role);
+    const role = await effectiveRole(userEmail, platformRole, tenant);
+    if (ROLE_LEVEL[role] < ROLE_LEVEL['editor']) {
+      return NextResponse.json(
+        { error: 'Creating new records is limited to editors. Ask an editor (Paul or José) to add it, or to grant you editor access.' },
+        { status: 403 },
+      );
+    }
+
+    let payload: CreatePayload;
+    try {
+      payload = (await request.json()) as CreatePayload;
+    } catch {
+      return NextResponse.json({ error: 'Body is not valid JSON' }, { status: 400 });
+    }
+
+    const ubn = typeof payload.ubn === 'string' ? payload.ubn.trim() : '';
+    if (!ubn) {
+      return NextResponse.json({ error: 'A UBN (catalogue id) is required' }, { status: 400 });
+    }
+    if (!isValidUbn(ubn)) {
+      return NextResponse.json(
+        { error: 'UBN may only contain letters, numbers, dot, dash and underscore (no spaces or slashes)' },
+        { status: 400 },
+      );
+    }
+
+    const rawChanges = payload?.fieldChanges;
+    if (!rawChanges || typeof rawChanges !== 'object' || Object.keys(rawChanges).length === 0) {
+      return NextResponse.json(
+        { error: 'Add at least one field (a title at minimum) before saving' },
+        { status: 400 },
+      );
+    }
+
+    const fieldChanges: FieldChangeMap = {};
+    for (const [key, change] of Object.entries(rawChanges)) {
+      if (!EDITABLE_SET.has(key)) {
+        return NextResponse.json({ error: `Field "${key}" is not editable` }, { status: 400 });
+      }
+      if (!change || typeof change !== 'object' || !('to' in change)) {
+        return NextResponse.json(
+          { error: `fieldChanges["${key}"] must be an object with a "to" property` },
+          { status: 400 },
+        );
+      }
+      const to = (change as { to: unknown }).to;
+      // Skip empty fields — a create payload may carry blanks for untouched
+      // inputs; we only want the fields the cataloguer actually filled in.
+      if (to === null || to === undefined || to === '') continue;
+      (fieldChanges as Record<string, unknown>)[key] = {
+        from: null,
+        to,
+        ...(typeof (change as { source?: unknown }).source === 'string'
+          ? { source: (change as { source: string }).source }
+          : {}),
+        ...(typeof (change as { evidence?: unknown }).evidence === 'string'
+          ? { evidence: (change as { evidence: string }).evidence }
+          : {}),
+      };
+    }
+
+    if (Object.keys(fieldChanges).length === 0) {
+      return NextResponse.json(
+        { error: 'Add at least one field (a title at minimum) before saving' },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const result = await applyWorkRevision({
+        ubn,
+        changeType: 'create',
+        fieldChanges,
+        editorEmail: userEmail,
+        note: typeof payload.note === 'string' ? payload.note : null,
+      });
+      return NextResponse.json({ ok: true, mode: 'created', ubn, ...result });
+    } catch (err) {
+      if (err instanceof BphCatalogError) {
+        const msg = err.message;
+        const status = msg.includes('already exists') ? 409 : msg.includes('not editable') ? 400 : 500;
+        return NextResponse.json({ error: msg }, { status });
+      }
+      console.error('[catalog/create] unexpected error:', err);
+      return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+    }
+  },
+  { minRole: 'editor' },
+);

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -375,6 +375,12 @@ export default async function CatalogEntryPage({ params }: Props) {
             {showReviewLink && (
               <>
                 <a
+                  href="/catalog/new"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
+                >
+                  + New record
+                </a>
+                <a
                   href="/catalog/review"
                   className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
                 >
@@ -388,6 +394,12 @@ export default async function CatalogEntryPage({ params }: Props) {
                 </a>
               </>
             )}
+            <a
+              href="/catalog/help"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
+            >
+              Help
+            </a>
             <a
               href={`/catalog/${encodeURIComponent(work.ubn)}/edit`}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"

--- a/src/app/embed/[tenant]/catalog/help/page.tsx
+++ b/src/app/embed/[tenant]/catalog/help/page.tsx
@@ -1,0 +1,118 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+
+/**
+ * BPH catalogue editor — help / how-to page. The in-app version of the
+ * onboarding instructions for cataloguers (Paul, José). Reachable from the
+ * "Help" button on the catalogue toolbar. Public (no secrets), robots-noindex.
+ *
+ * Issue #1877.
+ */
+
+export const metadata: Metadata = {
+  title: 'Editing the catalogue — help · BPH',
+  robots: { index: false, follow: false },
+};
+
+interface Props {
+  params: Promise<{ tenant: string }>;
+}
+
+function Step({ n, title, children }: { n: string; title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-8">
+      <h2 className="flex items-baseline gap-2 text-lg text-primary font-display mb-2">
+        <span className="text-accent-rust">{n}</span>
+        <span>{title}</span>
+      </h2>
+      <div className="text-[15px] text-secondary leading-relaxed space-y-2">{children}</div>
+    </section>
+  );
+}
+
+export default async function CatalogHelpPage({ params }: Props) {
+  const { tenant } = await params;
+  if (tenant !== 'bph') notFound();
+
+  return (
+    <div className="bg-cream min-h-screen">
+      <div className="max-w-2xl mx-auto px-6 py-8">
+        <a
+          href="/catalog"
+          className="inline-flex items-center text-sm text-muted hover:text-primary mb-4 transition-colors"
+        >
+          ← Back to catalogue
+        </a>
+        <h1 className="text-2xl sm:text-3xl text-primary font-display leading-tight mb-2">
+          Editing the BPH catalogue
+        </h1>
+        <p className="text-sm text-muted mb-8">
+          You can correct and enrich catalogue records directly on this site. Every change is saved
+          under your name with the source you cite, so the catalogue keeps a full, scholarly record of
+          who changed what and why. Here is the whole workflow.
+        </p>
+
+        <Step n="1" title="Sign in">
+          <p>
+            Use the <strong>Sign in</strong> link with your email — you&rsquo;ll get a one-time link, no
+            password to remember. You&rsquo;re set up as an <em>editor</em>, which means your changes go
+            live immediately.
+          </p>
+        </Step>
+
+        <Step n="2" title="Open a record and click “Edit”">
+          <p>
+            Find any catalogue entry (search, or open it by its UBN). When you&rsquo;re signed in
+            you&rsquo;ll see an <strong>Edit catalogue entry</strong> button at the top of the record,
+            alongside <strong>History</strong> and (for editors) <strong>Review queue</strong> and{' '}
+            <strong>Team</strong>.
+          </p>
+        </Step>
+
+        <Step n="3" title="Make the change, cite your source, save">
+          <p>
+            The form begins by asking <strong>where the correction comes from</strong> — a title page, a
+            USTC record, the scan, an accession note. That one line is what turns an edit into a citable,
+            accountable change, so it&rsquo;s required.
+          </p>
+          <p>
+            Below it the fields are grouped just like the catalogue display: Title, Authorship (with a
+            built-in VIAF name lookup), Imprint, Subject &amp; language, Physical description, Location at
+            the BPH, Notes, and Identifiers. Change what you need and click <strong>Save changes</strong>.
+          </p>
+        </Step>
+
+        <Step n="4" title="Add a brand-new record">
+          <p>
+            Use the <strong>+ New record</strong> button on the catalogue toolbar. It opens the same form
+            with a fresh <strong>UBN</strong> (catalogue id) already filled in — an{' '}
+            <code className="text-xs bg-warm px-1 rounded">SL-…</code> id that won&rsquo;t clash with the
+            BPH&rsquo;s own numbering. If the book already has a real BPH UBN, just type it over the
+            suggestion. Fill in at least a title, cite your source, and click <strong>Create record</strong>.
+          </p>
+        </Step>
+
+        <Step n="5" title="Every change is on the record">
+          <p>
+            Click <strong>History</strong> on any entry to see every edit: which field changed, from what
+            to what, who made it, and the source they cited. It&rsquo;s append-only — a mistake is
+            corrected with a new edit, never by erasing the old one. This is the catalogue&rsquo;s audit
+            trail.
+          </p>
+        </Step>
+
+        <div className="border-t border-border-light pt-6 mt-2 text-[15px] text-secondary leading-relaxed space-y-2">
+          <h2 className="text-lg text-primary font-display mb-2">A few notes</h2>
+          <p>
+            <strong>Found something off, or have an idea?</strong> Use the <strong>Feedback</strong> button
+            on any of these pages — it comes straight to us, and your hands-on notes shape the tool.
+          </p>
+          <p>
+            Maybe start with a handful of records you know well. The editor is young and your feedback is
+            exactly what makes it better.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/embed/[tenant]/catalog/layout.tsx
+++ b/src/app/embed/[tenant]/catalog/layout.tsx
@@ -1,0 +1,16 @@
+import CatalogFeedbackButton from '@/components/catalog/CatalogFeedbackButton';
+
+/**
+ * Layout for the BPH catalogue pages (/embed/[tenant]/catalog/*). Mounts the
+ * floating Feedback button across every catalogue page — entry, edit, new,
+ * history, help, review, team — so cataloguers can give feedback from
+ * wherever they are. The button self-hides for signed-out visitors.
+ */
+export default function CatalogLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <CatalogFeedbackButton />
+    </>
+  );
+}

--- a/src/app/embed/[tenant]/catalog/new/page.tsx
+++ b/src/app/embed/[tenant]/catalog/new/page.tsx
@@ -1,0 +1,109 @@
+import { notFound, redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { auth } from '@/lib/auth';
+import { ROLE_LEVEL, type Role } from '@/lib/auth';
+import { getDb } from '@/lib/mongodb';
+import { suggestNewUbn } from '@/lib/bph-catalog';
+import BphWorkEditForm from '@/components/catalog/BphWorkEditForm';
+
+/**
+ * Create a new BPH catalogue record.
+ *
+ * Editor-only. Renders the same form as the editor, in 'create' mode: it
+ * shows a UBN field (pre-filled with a safe SL-… id), starts every field
+ * blank, and POSTs to /api/[tenant]/catalog/create. BPH-only in Phase 1.
+ *
+ * Issue #1877.
+ */
+
+export const metadata: Metadata = {
+  title: 'New catalogue entry — BPH',
+  robots: { index: false, follow: false },
+};
+
+interface Props {
+  params: Promise<{ tenant: string }>;
+}
+
+function normalizeRole(role: unknown): Role {
+  if (
+    role === 'superadmin' ||
+    role === 'admin' ||
+    role === 'editor' ||
+    role === 'contributor' ||
+    role === 'reader'
+  ) {
+    return role;
+  }
+  if (role === 'inner_circle' || role === 'curator') return 'editor';
+  return 'reader';
+}
+
+async function effectiveTenantRole(email: string | null | undefined, tenantSlug: string): Promise<Role> {
+  if (!email) return 'reader';
+  try {
+    const db = await getDb();
+    const tenant = await db.collection('tenants').findOne({ slug: tenantSlug, status: { $ne: 'deleted' } });
+    if (!tenant) return 'reader';
+    const membership = await db.collection('memberships').findOne({
+      email: email.toLowerCase(),
+      tenantId: tenant.id,
+      status: 'active',
+    });
+    return normalizeRole(membership?.role);
+  } catch {
+    return 'reader';
+  }
+}
+
+export default async function NewCatalogEntryPage({ params }: Props) {
+  const { tenant } = await params;
+  if (tenant !== 'bph') notFound();
+
+  const session = await auth();
+  if (!session?.user) {
+    redirect(`/${tenant}/login?callbackUrl=/catalog/new`);
+  }
+
+  const platformRole = normalizeRole((session.user as { role?: unknown }).role);
+  const tenantRole = await effectiveTenantRole(session.user.email, tenant);
+  const effectiveRole = ROLE_LEVEL[platformRole] >= ROLE_LEVEL[tenantRole] ? platformRole : tenantRole;
+
+  // Creating new records is editor+ only (see the create API route).
+  if (ROLE_LEVEL[effectiveRole] < ROLE_LEVEL['editor']) {
+    redirect('/catalog');
+  }
+
+  const suggestedUbn = await suggestNewUbn();
+
+  return (
+    <div className="bg-cream min-h-screen">
+      <div className="max-w-2xl mx-auto px-6 py-8">
+        <a
+          href="/catalog"
+          className="inline-flex items-center text-sm text-muted hover:text-primary mb-4 transition-colors"
+        >
+          ← Back to catalogue
+        </a>
+        <h1 className="text-2xl sm:text-3xl text-primary font-display leading-tight mb-1">
+          New catalogue entry
+        </h1>
+        <p className="text-sm text-muted mb-6">
+          Adding a record · Signed in as {session.user.email} ·{' '}
+          <a href="/catalog/help" className="text-accent-rust hover:underline">
+            How does this work?
+          </a>
+        </p>
+
+        <BphWorkEditForm
+          ubn={suggestedUbn}
+          tenant={tenant}
+          initial={{}}
+          editorEmail={session.user.email || ''}
+          mode="create"
+          suggestedUbn={suggestedUbn}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/catalog/BphWorkEditForm.tsx
+++ b/src/components/catalog/BphWorkEditForm.tsx
@@ -30,8 +30,13 @@ interface Props {
   editorEmail: string;
   /** 'editor' → Save applies directly via applyWorkRevision.
    *  'contributor' → Save queues a row in bph_works_pending_changes for
-   *  editor review. The form UI changes copy but is otherwise identical. */
-  mode: 'editor' | 'contributor';
+   *  editor review. The form UI changes copy but is otherwise identical.
+   *  'create' → brand-new record; the form shows a UBN field and POSTs to
+   *  the create endpoint. `initial` is empty so every filled field is a
+   *  change. */
+  mode: 'editor' | 'contributor' | 'create';
+  /** Create mode only: the pre-filled, editable catalogue id. */
+  suggestedUbn?: string;
 }
 
 // Mirrors EDITABLE_BPH_FIELDS in src/lib/bph-catalog.ts, organised into the
@@ -148,8 +153,9 @@ function isUnchanged(orig: unknown, next: unknown): boolean {
   return false;
 }
 
-export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _editorEmail, mode }: Props) {
+export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _editorEmail, mode, suggestedUbn }: Props) {
   const router = useRouter();
+  const isCreate = mode === 'create';
 
   // Form state — one entry per editable field, all strings (number-typed
   // fields are coerced at submit time so users can clear them by deleting).
@@ -164,6 +170,7 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
   }, [initial]);
 
   const [values, setValues] = useState<Record<string, string>>(initialFormValues);
+  const [createUbn, setCreateUbn] = useState(suggestedUbn || '');
   const [source, setSource] = useState('');
   const [evidence, setEvidence] = useState('');
   const [note, setNote] = useState('');
@@ -186,12 +193,20 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isCreate && !createUbn.trim()) {
+      setError('Give the new record a UBN (catalogue id).');
+      return;
+    }
     if (changedFields.length === 0) {
-      setError('No fields have changed — nothing to save.');
+      setError(isCreate ? 'Add at least a title before saving.' : 'No fields have changed — nothing to save.');
       return;
     }
     if (!source.trim()) {
-      setError('Please cite a source for this change (e.g. "title page, vol. I" or "USTC 12345").');
+      setError(
+        isCreate
+          ? 'Please cite a source for this record (e.g. "title page" or "BPH accession record").'
+          : 'Please cite a source for this change (e.g. "title page, vol. I" or "USTC 12345").',
+      );
       return;
     }
     setError(null);
@@ -214,10 +229,14 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
     }
 
     try {
-      const res = await fetch(`/api/${tenant}/catalog/${encodeURIComponent(ubn)}/edit`, {
+      const endpoint = isCreate
+        ? `/api/${tenant}/catalog/create`
+        : `/api/${tenant}/catalog/${encodeURIComponent(ubn)}/edit`;
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
+          ...(isCreate ? { ubn: createUbn.trim() } : {}),
           fieldChanges,
           ...(note.trim() ? { note: note.trim() } : {}),
         }),
@@ -228,7 +247,15 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
         setSubmitting(false);
         return;
       }
-      const body = (await res.json()) as { mode?: 'applied' | 'queued'; pendingId?: string };
+      const body = (await res.json()) as { mode?: 'applied' | 'queued' | 'created'; pendingId?: string; ubn?: string };
+      if (body.mode === 'created') {
+        // New record is live. Land the cataloguer on it so they can see the
+        // entry they just made (and its first history row).
+        const newUbn = body.ubn || createUbn.trim();
+        router.push(`/catalog/${encodeURIComponent(newUbn)}`);
+        router.refresh();
+        return;
+      }
       if (body.mode === 'queued' && body.pendingId) {
         // Contributor flow: hold on the form, show a clear success banner,
         // and let the user navigate back when they're ready. Redirecting to
@@ -289,9 +316,32 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
         </div>
       )}
 
+      {/* Create mode — new-record intro + the catalogue id. The UBN is
+          pre-filled with a safe Source-Library id (SL-…) but editors can
+          replace it with a real BPH UBN if the record already has one. */}
+      {isCreate && (
+        <div className="p-4 bg-white border border-border-light rounded-lg">
+          <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-3">New catalogue record</h2>
+          <FormField
+            label="UBN (catalogue id) *"
+            hint="Pre-filled with a Source-Library id. Replace it with the BPH UBN if this record already has one. Letters, numbers, dot, dash, underscore only."
+          >
+            <input
+              type="text"
+              value={createUbn}
+              onChange={(e) => setCreateUbn(e.target.value)}
+              className="w-full text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary font-mono focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+              placeholder="SL-000001"
+            />
+          </FormField>
+        </div>
+      )}
+
       {/* Source citation — required, applies to every changed field. */}
       <div className="p-4 bg-white border border-border-light rounded-lg">
-        <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-3">Source for this change</h2>
+        <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-3">
+          {isCreate ? 'Source for this record' : 'Source for this change'}
+        </h2>
         <div className="space-y-3">
           <FormField label="Source citation *" hint="What did you consult to make this change? E.g. &ldquo;title page, vol. I, 1602&rdquo; or &ldquo;USTC 2024571&rdquo;.">
             <input
@@ -415,18 +465,18 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
       <div className="sticky bottom-3 z-10 flex items-center justify-between gap-3 p-3 bg-white border border-border-light rounded-lg shadow-sm">
         <div className="text-sm text-muted">
           {changedFields.length === 0 ? (
-            'No changes yet'
+            isCreate ? 'Add a title to begin' : 'No changes yet'
           ) : (
             <>
               <span className="font-medium text-primary">{changedFields.length}</span>{' '}
-              field{changedFields.length === 1 ? '' : 's'} changed
+              field{changedFields.length === 1 ? '' : 's'} {isCreate ? 'filled' : 'changed'}
             </>
           )}
           {error && <span className="ml-3 text-accent-rust">{error}</span>}
         </div>
         <div className="flex items-center gap-2">
           <a
-            href={`/catalog/${encodeURIComponent(ubn)}`}
+            href={isCreate ? '/catalog' : `/catalog/${encodeURIComponent(ubn)}`}
             className="px-3 py-1.5 text-sm text-muted hover:text-primary transition-colors"
           >
             Cancel
@@ -437,8 +487,8 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
             className="px-4 py-1.5 text-sm rounded-md bg-accent-rust text-white hover:bg-accent-rust/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {submitting
-              ? mode === 'contributor' ? 'Submitting…' : 'Saving…'
-              : mode === 'contributor' ? 'Submit for review' : 'Save changes'}
+              ? isCreate ? 'Creating…' : mode === 'contributor' ? 'Submitting…' : 'Saving…'
+              : isCreate ? 'Create record' : mode === 'contributor' ? 'Submit for review' : 'Save changes'}
           </button>
         </div>
       </div>

--- a/src/components/catalog/CatalogFeedbackButton.tsx
+++ b/src/components/catalog/CatalogFeedbackButton.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import FeedbackWidget from '@/components/feedback/FeedbackWidget';
+
+/**
+ * Floating "Feedback" button for the BPH catalogue pages. Reuses the global
+ * FeedbackWidget (POSTs to /api/feedback, capturing the current page path) but
+ * only renders for signed-in users — the same audience that sees the Edit /
+ * History toolbar — so the public reading room stays clean while cataloguers
+ * (Paul, José) can flag anything from any catalogue page.
+ *
+ * Positioned bottom-LEFT so it never sits under the edit form's sticky
+ * bottom-right Save bar. z below the widget's own modal (9999).
+ */
+export default function CatalogFeedbackButton() {
+  const { data: session } = useSession();
+  if (!session?.user) return null;
+  return (
+    <FeedbackWidget
+      label="Feedback"
+      className="fixed bottom-4 left-4 z-[60] inline-flex items-center px-3.5 py-2 rounded-full bg-stone-800 text-white text-sm font-medium shadow-lg hover:bg-stone-700 transition-colors"
+    />
+  );
+}

--- a/src/lib/bph-catalog.ts
+++ b/src/lib/bph-catalog.ts
@@ -234,29 +234,6 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
     };
   }
 
-  // 2. Write the revision row FIRST. If this fails, we abort without touching
-  //    bph_works — better to refuse the edit than to mutate the live row
-  //    without recording history.
-  const { error: revErr } = await supabaseAdmin
-    .from('bph_works_revisions')
-    .insert({
-      id: revisionId,
-      ubn,
-      change_type: changeType,
-      field_changes: liveFieldChanges,
-      editor_email: editorEmail,
-      proposed_by: proposedBy,
-      source_pending_id: sourcePendingId,
-      applied_at: appliedAt,
-      note,
-    });
-
-  if (revErr) throw new BphCatalogError('insert bph_works_revisions failed', revErr);
-
-  // 3. Write bph_works. For a create we INSERT a fresh row; for an edit we
-  //    UPDATE in place, merging provenance into the existing JSONB so other
-  //    writers' entries survive (Postgres `||` deep-merges at the top level,
-  //    which is exactly what we want for per-field keys).
   const existingProvenance = current?.field_provenance;
   const mergedProvenance = {
     ...(typeof existingProvenance === 'object' && existingProvenance !== null
@@ -265,12 +242,31 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
     ...provenancePatch,
   };
 
+  const insertRevision = () =>
+    supabaseAdmin!
+      .from('bph_works_revisions')
+      .insert({
+        id: revisionId,
+        ubn,
+        change_type: changeType,
+        field_changes: liveFieldChanges,
+        editor_email: editorEmail,
+        proposed_by: proposedBy,
+        source_pending_id: sourcePendingId,
+        applied_at: appliedAt,
+        note,
+      });
+
   if (changeType === 'create') {
-    // Brand-new record. Only `ubn` is required by the schema; everything else
-    // is nullable, so we insert just the supplied fields plus provenance and a
-    // created_at stamp. The record is marked Source-Library-originated so it's
-    // distinguishable from Memorix-synced rows (and won't be clobbered by a
-    // future Memorix upsert, which keys on numeric UBNs).
+    // 2a. The revisions table has a FK on ubn → bph_works(ubn), so the row
+    //     must exist before its revision. INSERT the row first, then the
+    //     history; if the history write fails, roll the row back so we never
+    //     leave a created record with no provenance trail. Only `ubn` is
+    //     required by the schema (everything else nullable). The row is marked
+    //     Source-Library-originated (via acquisition_source) so it's
+    //     distinguishable from Memorix-synced rows. `record_type` is a
+    //     constrained enum (bph_record_type) we deliberately leave unset
+    //     rather than guess between printed/manuscript/journal.
     const { error: insErr } = await supabaseAdmin
       .from('bph_works')
       .insert({
@@ -278,13 +274,27 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
         ...updates,
         field_provenance: mergedProvenance,
         created_at: appliedAt,
-        record_type: 'source-library',
         acquisition_source: `source-library-editor:${editorEmail}`,
       });
     if (insErr) {
-      throw new BphCatalogError('insert bph_works failed (revision is orphaned)', insErr);
+      throw new BphCatalogError('insert bph_works failed', insErr);
+    }
+    const { error: revErr } = await insertRevision();
+    if (revErr) {
+      // Roll back the just-created row — a record without history would
+      // violate the audit invariant.
+      await supabaseAdmin.from('bph_works').delete().eq('ubn', ubn);
+      throw new BphCatalogError('insert bph_works_revisions failed (create rolled back)', revErr);
     }
   } else {
+    // 2b. Edit: write the revision FIRST. If it fails we abort without
+    //     touching the live row — better to refuse the edit than to mutate
+    //     bph_works without recording history. Then UPDATE in place, merging
+    //     provenance into the existing JSONB so other writers' entries survive
+    //     (Postgres `||` deep-merges at the top level — per-field keys).
+    const { error: revErr } = await insertRevision();
+    if (revErr) throw new BphCatalogError('insert bph_works_revisions failed', revErr);
+
     const { error: updErr } = await supabaseAdmin
       .from('bph_works')
       .update({

--- a/src/lib/bph-catalog.ts
+++ b/src/lib/bph-catalog.ts
@@ -202,6 +202,9 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
   if (!current && changeType !== 'create') {
     throw new BphCatalogError(`bph_works row not found for ubn=${ubn}`);
   }
+  if (current && changeType === 'create') {
+    throw new BphCatalogError(`A catalogue entry with UBN "${ubn}" already exists — edit it instead`);
+  }
 
   const appliedAt = new Date().toISOString();
   const revisionId = crypto.randomUUID();
@@ -250,9 +253,10 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
 
   if (revErr) throw new BphCatalogError('insert bph_works_revisions failed', revErr);
 
-  // 3. Update bph_works. Merge provenance into the existing JSONB so other
-  //    writers' entries survive — Postgres does a deep merge with `||` only
-  //    at top level, which is exactly what we want here (per-field keys).
+  // 3. Write bph_works. For a create we INSERT a fresh row; for an edit we
+  //    UPDATE in place, merging provenance into the existing JSONB so other
+  //    writers' entries survive (Postgres `||` deep-merges at the top level,
+  //    which is exactly what we want for per-field keys).
   const existingProvenance = current?.field_provenance;
   const mergedProvenance = {
     ...(typeof existingProvenance === 'object' && existingProvenance !== null
@@ -261,20 +265,41 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
     ...provenancePatch,
   };
 
-  const { error: updErr } = await supabaseAdmin
-    .from('bph_works')
-    .update({
-      ...updates,
-      field_provenance: mergedProvenance,
-    })
-    .eq('ubn', ubn);
+  if (changeType === 'create') {
+    // Brand-new record. Only `ubn` is required by the schema; everything else
+    // is nullable, so we insert just the supplied fields plus provenance and a
+    // created_at stamp. The record is marked Source-Library-originated so it's
+    // distinguishable from Memorix-synced rows (and won't be clobbered by a
+    // future Memorix upsert, which keys on numeric UBNs).
+    const { error: insErr } = await supabaseAdmin
+      .from('bph_works')
+      .insert({
+        ubn,
+        ...updates,
+        field_provenance: mergedProvenance,
+        created_at: appliedAt,
+        record_type: 'source-library',
+        acquisition_source: `source-library-editor:${editorEmail}`,
+      });
+    if (insErr) {
+      throw new BphCatalogError('insert bph_works failed (revision is orphaned)', insErr);
+    }
+  } else {
+    const { error: updErr } = await supabaseAdmin
+      .from('bph_works')
+      .update({
+        ...updates,
+        field_provenance: mergedProvenance,
+      })
+      .eq('ubn', ubn);
 
-  if (updErr) {
-    // Revision row is already in. Surface the error so the caller knows
-    // bph_works was NOT mutated, and the revision is a no-op record.
-    // Operationally rare — a later cleanup script can flag orphan revisions
-    // whose field_changes never landed.
-    throw new BphCatalogError('update bph_works failed (revision is orphaned)', updErr);
+    if (updErr) {
+      // Revision row is already in. Surface the error so the caller knows
+      // bph_works was NOT mutated, and the revision is a no-op record.
+      // Operationally rare — a later cleanup script can flag orphan revisions
+      // whose field_changes never landed.
+      throw new BphCatalogError('update bph_works failed (revision is orphaned)', updErr);
+    }
   }
 
   // 4. Best-effort Atlas mirror. The BPH row is canonical; Atlas books is
@@ -290,6 +315,36 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
   }
 
   return { revisionId, appliedAt };
+}
+
+/**
+ * Suggest the next Source-Library-originated UBN (`SL-000123`). New records
+ * created in the editor get an `SL-` prefixed id rather than a numeric one so
+ * they never collide with the BPH's authoritative numeric UBN namespace (the
+ * Memorix sync upserts on numeric UBNs). Editors can override the suggestion
+ * with a real BPH UBN if the record already has one — uniqueness is enforced
+ * by the primary key and the create guard in applyWorkRevision.
+ *
+ * Best-effort: on any lookup failure we fall back to a timestamp-free random
+ * suffix so the create page still renders a usable default.
+ */
+export async function suggestNewUbn(): Promise<string> {
+  const pad = (n: number) => `SL-${String(n).padStart(6, '0')}`;
+  if (!supabaseAdmin) return pad(1);
+  try {
+    const { data } = await supabaseAdmin
+      .from('bph_works')
+      .select('ubn')
+      .like('ubn', 'SL-%')
+      .order('ubn', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const last = (data as { ubn?: string } | null)?.ubn;
+    const n = last ? parseInt(last.replace(/^SL-/, ''), 10) : 0;
+    return pad(Number.isFinite(n) ? n + 1 : 1);
+  } catch {
+    return pad(1);
+  }
 }
 
 /**


### PR DESCRIPTION
Builds on #2565. Lets BPH editors (Paul, José) **create** records, get **help**, and give **feedback** — not just edit.

## What
- **New record** — `/catalog/new` (editor-only) reuses the edit form in `create` mode. UBN field is pre-filled with a safe `SL-NNNNNN` id that can't collide with the BPH's numeric Memorix namespace; editors can type a real UBN over it. POSTs to `/api/[tenant]/catalog/create`.
- **Backend** — `applyWorkRevision` now INSERTs for `changeType:'create'` (it previously wrote a revision then no-op UPDATEd a nonexistent row) and rejects duplicate UBNs. New rows stamped `record_type:'source-library'` + `acquisition_source`.
- **Provenance** — every create lands in the same append-only `bph_works_revisions` log as edits, with the required source citation + per-field `field_provenance`.
- **Help** — `/catalog/help` documents the whole workflow; Help + `+ New record` buttons on the toolbar.
- **Feedback** — the global FeedbackWidget now appears on every catalogue page for signed-in users (was absent on tenant subdomains). Self-hides when signed out.
- **Backups** — adds a catalogue snapshot script (see commits) for point-in-time restore on top of the revision log.

## Testing
Full-stack tested on the preview: create via the real API → record renders → edit → history shows create+edit → cleanup. (Details in PR thread.)

## Out of scope
- Contributor-proposed *new* records (editor-only for now; contributors still propose edits).

Refs #1877.