### PR TITLE
feat(ft): evidence-quality guard for prior citations + 536-book audit (#2564)

### DIFF
--- a/scripts/eval/ft-guard-audit-report.md
+++ b/scripts/eval/ft-guard-audit-report.md
@@ -1,0 +1,144 @@
+# First-Translation Prior Evidence-Quality Guard: Audit Report
+
+**Date:** 2026-06-19  
+**Module:** `src/lib/ft-prior-guard.ts`  
+**Tests:** `tests/unit/ft-prior-guard.test.ts`
+
+---
+
+## Background
+
+The `is_first_translation` flag is derived from `translation_verification.disposition`. A reconcile run trusted `disposition: translation_found` as evidence a book is not a first translation. That disposition is fallible: the cited prior may be fake evidence. This guard module evaluates whether a cited prior is *trustworthy evidence* before accepting a demotion.
+
+---
+
+## Guard Logic
+
+`evaluatePrior(book, citedPrior) → { trustworthy, failedGuards, confidence }`
+
+Four guards, applied to `book { title, author, language }` and `citedPrior { english_title, translator, pub_year, completeness, publisher, series, notes }`:
+
+### SELF_MATCH (definitive, high confidence)
+Fires when the cited prior is the same publication as the book itself. Logic:
+- Computes *book-title coverage* (fraction of book title tokens present in prior title) and Jaccard similarity
+- Fires when `(coverage ≥ 0.80 AND author-translator overlap) OR (coverage ≥ 0.60 AND author tokens match translator tokens) OR (Jaccard ≥ 0.75 AND author-translator overlap)`
+- Author-translator overlap is REQUIRED to prevent false positives on genuine prior translations of the same work by a different person (Erasmus's Paraphrases translated by Udall does not self-match)
+- Handles variant spellings ("Bhagavatam" / "Bhagawatam") via the lower coverage threshold when translator names match exactly
+
+### ANTHOLOGY (definitive, high confidence)
+Fires when the cited prior contains anthology/study keywords in its title or series — indicating it is a collected-works or scholarly study, not a translation of the specific work. Keywords include: `anthology`, `collected works`, `theatre of the world`, `reader`, `companion`, `works of`, `sourcebook`, `complete works`, etc.
+- Suppressed when book-title tokens are well-represented in the prior title (`Jaccard ≥ 0.45 OR coverage ≥ 0.80`) — prevents firing when the prior title IS an expanded version of the specific work
+
+### PARTIAL (definitive, high confidence)
+Fires when `completeness === 'partial' | 'excerpts'`, or when partial-signal keywords appear in the title/notes and completeness is not explicitly `complete`. Partial citations do not defeat a "first complete translation" claim.
+
+### LOW_CONFIDENCE (heuristic, low confidence)
+Fires when no token from the book author appears anywhere in the cited prior's text fields. This is a weak heuristic flagging possible namesakes or misattributions. LOW_CONFIDENCE alone does NOT set `trustworthy: false`.
+
+**`trustworthy: false` requires at least one definitive guard (SELF_MATCH, ANTHOLOGY, or PARTIAL) to fire.**
+
+---
+
+## Unit Test Results
+
+**24/24 tests passing.** Run: `npx vitest run tests/unit/ft-prior-guard.test.ts`
+
+| Test case | Book | Expected guard | Result |
+|-----------|------|----------------|--------|
+| Arithmologia (id=69af0a0a...) | Kircher Arithmologia | ANTHOLOGY fires | ✓ PASS |
+| Arithmologia | Kircher | SELF_MATCH does not fire | ✓ PASS |
+| Arithmologia | Kircher | PARTIAL does not fire | ✓ PASS |
+| Arithmologia | Kircher | confidence=high | ✓ PASS |
+| Vijnanananda (id=69925911...) | Devi Bhagavatam | SELF_MATCH fires | ✓ PASS |
+| Vijnanananda | Devi Bhagavatam | confidence=high | ✓ PASS |
+| Boas (id=6992598b...) | Bella Coola Indians | SELF_MATCH fires | ✓ PASS |
+| Boas | Bella Coola Indians | confidence=high | ✓ PASS |
+| Naladiyar (id=69946ec1...) | Kural of Tiruvalluvar | SELF_MATCH fires | ✓ PASS |
+| Naladiyar | Kural | confidence=high | ✓ PASS |
+| Avicenna (id=69b3e5fb...) | Canon of Medicine / Gruner | PARTIAL fires | ✓ PASS |
+| Avicenna | Gruner cited | SELF_MATCH does not fire | ✓ PASS |
+| Avicenna | Gruner cited | ANTHOLOGY does not fire | ✓ PASS |
+| Avicenna | Gruner cited | confidence=high | ✓ PASS |
+| Avicenna Limits test | Bakhtiar 1999 synthetic | trustworthy=true (guard-pass) | ✓ PASS |
+| Erasmus (id=69b2ffe2...) | Paraphrases / Udall | trustworthy=true | ✓ PASS |
+| Erasmus | Paraphrases / Udall | SELF_MATCH does not fire | ✓ PASS |
+| Erasmus | Paraphrases / Udall | ANTHOLOGY does not fire | ✓ PASS |
+| Erasmus | Paraphrases / Udall | PARTIAL does not fire | ✓ PASS |
+| Edge: excerpts → PARTIAL | Paracelsus | PARTIAL fires | ✓ PASS |
+| Edge: anthology series keyword | Agrippa | ANTHOLOGY fires | ✓ PASS |
+| Edge: high overlap suppresses ANTHOLOGY | Arithmologia edge | ANTHOLOGY does not fire | ✓ PASS |
+| Edge: empty prior | any book | result is defined | ✓ PASS |
+
+---
+
+## Population Audit
+
+Query: `is_first_translation:false AND visible:true AND pages_translated>0 AND translation_verification.disposition:'translation_found'`
+
+| Metric | Count |
+|--------|-------|
+| **Total books in query** | **3,934** |
+| Any definitive guard fired | **536** (13.6%) |
+| SELF_MATCH guard | **251** (6.4%) |
+| ANTHOLOGY guard | **190** (4.8%) |
+| PARTIAL guard | **109** (2.8%) |
+| Multiple guards on same book | 14 |
+
+### High-confidence false-match sample (SELF_MATCH)
+
+The following books have `is_first_translation: false` demoted via a cited prior that is the same publication as the book itself:
+
+| Book ID | Title (truncated) | Author | Prior Translator |
+|---------|-------------------|--------|-----------------|
+| `69ef217fb3e2d3a0927f3054` | Charaka-Samhita | Charaka; Avinash Chandra Kaviratna (trans.) | Avinash Chandra Kaviratna |
+| `69ee4f206dd925d126f42ff8` | Barddas | Iolo Morganwg; J. Williams ab Ithel (ed.) | J. Williams ab Ithel |
+| `69e961c22beefe2f6f72cce6` | Ancient India as Described by Megasthenes and Arrian | Megasthenes (ed. McCrindle) | John Watson McCrindle |
+| `69e75deacc48e59ad74eb6e9` | Kinjeketile | Ebrahim Hussein | Ebrahim Hussein |
+| `69e72b98a409200ea79f2eac` | Georgian Folk Tales | Marjory Wardrop | Marjory Scott Wardrop |
+
+Pattern: books originally written in English (or where the editor/translator IS the author) were incorrectly assigned `is_first_translation: false` because the system cited the book itself as its own "prior translation."
+
+### High-confidence false-match sample (ANTHOLOGY)
+
+| Book ID | Title (truncated) | Prior Title (cited as "translation") |
+|---------|-------------------|--------------------------------------|
+| `69ee941af2c6312502f6ab06` | Cuatro Libros... Francisco Hernández | The Mexican Treasury: The Writings of Dr. Francisco Hernández |
+| `69e747ae85f786e884a49391` | Bucolica, Georgica, et Aeneis (Virgil) | The Works of Virgil |
+| `69e3ff6bb142e5dd9d6b0167` | Luciani Samosatensis Opera (Vol. 4) | The Works of Lucian of Samosata |
+| `69de100b5cedf736edb84e84` | Loukianou Hapanta / Luciani Opera | The Works of Lucian of Samosata |
+| `69e012e94e6773d060856934` | Contes Populaires des Bassoutos | The Treasury of Ba-Suto Lore: Being Original Selections... |
+
+Pattern: collected-works ("Works of Virgil", "Works of Lucian") cited to demote a specific volume. Being in the Works of Lucian does not mean a specific Latin edition of a single Lucian text has been translated.
+
+### Partial guard sample
+
+| Book ID | Title | Prior Title | Completeness |
+|---------|-------|-------------|--------------|
+| `69ef2f4d55d5fee247f6cc53` | Kitab al-Qanun fi al-Tibb | The Canon of Medicine of Avicenna | unknown |
+| `69ef2cb085daccce30f2ee22` | Aristoxenus, Nicomachus, Alypius | Greek Musical Writings: Vol. 2 | partial |
+| `69e792ea80b52390feb17135` | Hor gling g.yul 'gyed (Gesar Epic) | The Epic of Gesar of Ling | partial |
+| `69e534bfd48480a386967015` | Diwan of Abu Nuwas | O Tribe That Loves Boys: The Poetry of Abu Nuwas | partial |
+
+---
+
+## Limits
+
+**This module evaluates the *cited evidence* only, not the full bibliographic record.**
+
+1. **Guard-pass ≠ "book is a first translation."** The Avicenna al-Qanun case (id=69b3e5fb...) demonstrates this clearly: the PARTIAL guard fires on the Gruner 1930 citation (partial, only Book 1), which means that citation doesn't justify the demotion. However, a complete prior translation by Laleh Bakhtiar (1999) exists and is simply *uncited* in the verification record. The guard-pass on Gruner does not change the correct answer. Guards can only reject bad evidence; they cannot certify first-translation status. A guard-fired book still needs fresh verification to confirm.
+
+2. **Guard-fail ≠ "demotion is wrong."** A SELF_MATCH or ANTHOLOGY guard firing means "this specific evidence doesn't support the demotion." There may be other (uncited) complete translations that do.
+
+3. **Heuristic limits:** The anthology keyword list is not exhaustive. A "Complete Works" of Virgil cited for a specific Virgil MS will correctly fire the ANTHOLOGY guard, but a cleverly titled anthology without common keywords will not. The self-match detection relies on title token overlap + author-translator name matching; it will miss cases where the book author has a very short name (<4 chars) or where the translator name is written in a very different form.
+
+4. **`completeness: 'unknown'` is treated as partial when partial-signal keywords appear in the text.** This is conservative (will fire more on unknowns) but appropriate — "unknown completeness" should not justify a demotion.
+
+5. **Population numbers are lower-bounds.** Books with no `translations_found` field (no cited prior at all) are counted but not evaluated (they were already excluded from the 536 count). Additionally, the query `pages_translated > 0` may miss books with pipeline issues.
+
+---
+
+## Files
+
+- Guard module: `src/lib/ft-prior-guard.ts`
+- Unit tests: `tests/unit/ft-prior-guard.test.ts`
+- This report: `scripts/eval/ft-guard-audit-report.md`

--- a/src/lib/ft-prior-guard.ts
+++ b/src/lib/ft-prior-guard.ts
@@ -1,0 +1,380 @@
+/**
+ * Evidence-Quality Guard for First-Translation Prior Citations
+ *
+ * Evaluates whether a cited "prior translation" is trustworthy evidence
+ * that a book is NOT a first translation. Four guard types:
+ *
+ * 1. SELF_MATCH     — the cited prior IS the book's own catalog record
+ * 2. ANTHOLOGY      — the cited prior is an anthology/collected-works, not a
+ *                     translation of this specific work
+ * 3. PARTIAL        — the cited prior is partial/excerpts (doesn't defeat "first complete")
+ * 4. LOW_CONFIDENCE — source-language mismatch or namesake heuristics (low confidence only)
+ *
+ * Guards see only the *cited evidence* — passing all guards does NOT prove
+ * the book IS a first translation, only that the cited evidence doesn't justify
+ * a "not first" determination. See Avicenna case: guard-pass on the partial Gruner
+ * citation, but the correct demotion stands because Bakhtiar 1999 (complete)
+ * is uncited.
+ *
+ * This module is standalone — it does NOT import from src/lib/first-translation/*.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface BookInput {
+  title: string;
+  author?: string;
+  language?: string;
+}
+
+export interface CitedPriorInput {
+  english_title?: string;
+  translator?: string;
+  pub_year?: string;
+  completeness?: 'complete' | 'partial' | 'excerpts' | 'unknown';
+  publisher?: string;
+  series?: string;
+  notes?: string;
+}
+
+export type GuardId =
+  | 'SELF_MATCH'
+  | 'ANTHOLOGY'
+  | 'PARTIAL'
+  | 'LOW_CONFIDENCE';
+
+export interface GuardResult {
+  /** true = cited prior is trustworthy evidence; false = at least one guard fired */
+  trustworthy: boolean;
+  /** Guards that fired (prior is untrustworthy for these reasons) */
+  failedGuards: GuardId[];
+  /** high = one or more definitive guards fired; low = only heuristic guards fired */
+  confidence: 'high' | 'low';
+  /** Per-guard detail for debugging */
+  detail: Record<GuardId, { fired: boolean; reason: string }>;
+}
+
+// ── Text normalisation helpers ─────────────────────────────────────────────────
+
+/**
+ * Normalise a string for comparison: lowercase, strip diacritics and punctuation,
+ * collapse whitespace.
+ */
+function normalise(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')  // strip combining diacritics
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')          // punctuation → space
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Extract significant tokens (length ≥ 4, skip stop-words).
+ */
+const STOP_WORDS = new Set([
+  'the', 'and', 'with', 'from', 'that', 'this', 'for', 'are', 'was',
+  'been', 'have', 'has', 'its', 'into', 'upon', 'also', 'very', 'more',
+  'some', 'such', 'than', 'being', 'over', 'both', 'each', 'only',
+  'english', 'translation', 'translated', 'works', 'text',
+]);
+
+function sigTokens(s: string): string[] {
+  return normalise(s)
+    .split(/\s+/)
+    .filter(t => t.length >= 4 && !STOP_WORDS.has(t));
+}
+
+/**
+ * Jaccard similarity over significant tokens. Returns 0–1.
+ */
+function tokenOverlap(a: string, b: string): number {
+  const ta = new Set(sigTokens(a));
+  const tb = new Set(sigTokens(b));
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let intersection = 0;
+  for (const t of ta) {
+    if (tb.has(t)) intersection++;
+  }
+  return intersection / Math.max(ta.size, tb.size);
+}
+
+// ── Title coverage helper ─────────────────────────────────────────────────────
+
+/**
+ * Returns the fraction of book-title tokens that appear in the prior title.
+ * This is an asymmetric "containment" score: 1.0 means all book-title tokens
+ * are present in the (possibly longer) prior title.
+ */
+function bookTitleCoverage(bookTitle: string, priorTitle: string): number {
+  const bookToks = sigTokens(bookTitle);
+  const priorToks = new Set(sigTokens(priorTitle));
+  if (bookToks.length === 0) return 0;
+  const found = bookToks.filter(t => priorToks.has(t));
+  return found.length / bookToks.length;
+}
+
+// ── Guard 1: Self-match ───────────────────────────────────────────────────────
+
+/**
+ * Fires when the cited prior appears to be the SAME PUBLICATION as the book itself.
+ * This is not about same underlying work — it's about identical or near-identical
+ * publication metadata: a translation that IS the book being evaluated.
+ *
+ * Logic:
+ *   All book-title significant tokens appear in the prior title (coverage = 1.0)
+ *   AND at least one of:
+ *     (a) The book's author appears as the cited translator (same person = same pub)
+ *     (b) The book's author's most distinctive name token appears in the prior title
+ *         as non-author context (e.g. "Boas" in title of "Mythology of the Bella Coola
+ *         Indians" by Franz Boas where translator = "Franz Boas")
+ *
+ * The author-overlap check is REQUIRED to prevent false positives on genuine prior
+ * translations of the same underlying work by a different person (e.g. Udall 1548
+ * translating Erasmus is NOT the same publication as Erasmus's Latin original on SL).
+ */
+function checkSelfMatch(
+  book: BookInput,
+  prior: CitedPriorInput,
+): { fired: boolean; reason: string } {
+  if (!prior.english_title) return { fired: false, reason: 'no prior title to compare' };
+
+  const coverage = bookTitleCoverage(book.title, prior.english_title);
+
+  // Author-translator overlap: does the book author match the cited translator?
+  const bookAuthorNorm = normalise(book.author ?? '');
+  const priorTranslatorNorm = normalise(prior.translator ?? '');
+  const priorTitleNorm = normalise(prior.english_title);
+
+  let authorMatchesTranslator = false;
+  if (bookAuthorNorm && priorTranslatorNorm) {
+    const bookTokens = sigTokens(book.author ?? '');
+    const priorTranslatorTokens = sigTokens(prior.translator ?? '');
+    const directMatches = bookTokens.filter(t =>
+      priorTranslatorTokens.includes(t) || priorTranslatorNorm.includes(t)
+    );
+    // Require at least one token AND ≥ 33% of book-author tokens matched
+    authorMatchesTranslator =
+      directMatches.length >= 1 &&
+      directMatches.length >= Math.ceil(bookTokens.length * 0.33);
+  }
+
+  // Author's main name token appears in the prior title AND matches translator
+  // (handles: "Boas" in title + translator = "Franz Boas")
+  let authorInTitleWithTranslator = false;
+  if (!authorMatchesTranslator && bookAuthorNorm) {
+    const authorTokens = sigTokens(book.author ?? '').filter(t => t.length >= 4);
+    const longestToken = [...authorTokens].sort((a, b) => b.length - a.length)[0];
+    if (longestToken && priorTitleNorm.includes(longestToken) && priorTranslatorNorm.includes(longestToken)) {
+      authorInTitleWithTranslator = true;
+    }
+  }
+
+  const authorSignal = authorMatchesTranslator || authorInTitleWithTranslator;
+
+  const jaccard = tokenOverlap(book.title, prior.english_title);
+  // Fire when: title coverage ≥ 0.80 AND author signal
+  // -or- title coverage ≥ 0.60 AND strong author-translator match (covers variant spellings
+  //   like "Bhagavatam" vs "Bhagawatam" where 2/3 tokens match but author matches exactly)
+  // -or- very high Jaccard (≥ 0.75) AND author signal
+  const heuristicA = coverage >= 0.80 && authorSignal;
+  const heuristicA2 = coverage >= 0.60 && authorMatchesTranslator;
+  const heuristicB = jaccard >= 0.75 && authorSignal;
+
+  if (heuristicA || heuristicA2 || heuristicB) {
+    return {
+      fired: true,
+      reason: `Cited prior appears to be the same publication as the book (coverage=${coverage.toFixed(2)}, jaccard=${jaccard.toFixed(2)}, authorMatchesTranslator=${authorMatchesTranslator})`,
+    };
+  }
+
+  return {
+    fired: false,
+    reason: `coverage=${coverage.toFixed(2)}, jaccard=${jaccard.toFixed(2)}, authorSignal=${authorSignal}`,
+  };
+}
+
+// ── Guard 2: Anthology / study ────────────────────────────────────────────────
+
+/**
+ * Keywords that, when found in the cited prior's title or series, suggest it
+ * is an anthology, collected-works, or scholarly study — not a translation of
+ * this specific work.
+ */
+const ANTHOLOGY_TITLE_KEYWORDS = [
+  'anthology',
+  'collected works',
+  'collected letters',
+  'selected works',
+  'selected writings',
+  'selections from',
+  'theatre of the world',
+  'theater of the world',
+  'reader',                   // "The Kircher Reader" — anthology-form
+  'companion',                // "Companion to …" — scholarly study
+  'works of',
+  'writings of',
+  'sources in',
+  'sourcebook',
+  'collected papers',
+  'complete works',           // often a different work from the specific title
+];
+
+const ANTHOLOGY_SERIES_KEYWORDS = [
+  'collected works',
+  'complete works',
+  'selected works',
+  'opera omnia',
+  'omnia opera',
+];
+
+/**
+ * Fires when the cited prior's title or series contains anthology/study keywords
+ * AND the overlap with the book's specific title is low (≤ 0.20).
+ *
+ * The low-overlap condition prevents false positives: e.g. a book genuinely
+ * titled "Selected Works of Paracelsus" that happens to be the specific work.
+ */
+function checkAnthology(
+  book: BookInput,
+  prior: CitedPriorInput,
+): { fired: boolean; reason: string } {
+  const titleToSearch = normalise(prior.english_title ?? '');
+  const seriesToSearch = normalise(prior.series ?? '');
+  const notesToSearch = normalise(prior.notes ?? '');
+
+  const foundInTitle = ANTHOLOGY_TITLE_KEYWORDS.find(kw => titleToSearch.includes(kw));
+  const foundInSeries = ANTHOLOGY_SERIES_KEYWORDS.find(kw => seriesToSearch.includes(kw));
+  const keyword = foundInTitle ?? foundInSeries;
+
+  if (!keyword) return { fired: false, reason: 'no anthology keywords found' };
+
+  // If most book-title tokens appear in the prior title, the prior IS about this work
+  // (use coverage/containment, not Jaccard, to handle the case where the prior title
+  //  is a longer version of the book title: "Arithmologia: The Art of Numbers — Complete Works")
+  const titleOverlap = tokenOverlap(book.title, prior.english_title ?? '');
+  const coverage = bookTitleCoverage(book.title, prior.english_title ?? '');
+  if (titleOverlap >= 0.45 || coverage >= 0.80) {
+    return {
+      fired: false,
+      reason: `keyword "${keyword}" found but title overlap/coverage is high (jaccard=${titleOverlap.toFixed(2)}, coverage=${coverage.toFixed(2)}) — likely is this work`,
+    };
+  }
+
+  return {
+    fired: true,
+    reason: `Cited prior contains anthology/study keyword "${keyword}" with low title overlap (${titleOverlap.toFixed(2)}) — likely not a translation of this specific work`,
+  };
+}
+
+// ── Guard 3: Partial completeness ─────────────────────────────────────────────
+
+/**
+ * Fires when the cited prior is explicitly partial, excerpts, or an annotated
+ * selection — which does not defeat a claim of being the "first complete" English
+ * translation.
+ */
+function checkPartial(
+  _book: BookInput,
+  prior: CitedPriorInput,
+): { fired: boolean; reason: string } {
+  const completeness = prior.completeness;
+  if (completeness === 'partial' || completeness === 'excerpts') {
+    return {
+      fired: true,
+      reason: `Cited prior completeness is "${completeness}" — does not defeat a first-complete-translation claim`,
+    };
+  }
+  // Also check title / notes for partial signals when completeness field is unknown
+  const textToSearch = normalise(
+    [prior.english_title, prior.notes].filter(Boolean).join(' ')
+  );
+  const partialKeywords = ['excerpts', 'selections', 'partial', 'first book', 'book 1', 'abridged', 'extract'];
+  const found = partialKeywords.find(kw => textToSearch.includes(kw));
+  if (found && completeness !== 'complete') {
+    return {
+      fired: true,
+      reason: `Cited prior contains partial-signal keyword "${found}" and completeness is not "complete"`,
+    };
+  }
+  return { fired: false, reason: `completeness=${completeness ?? 'not set'}` };
+}
+
+// ── Guard 4: Low-confidence heuristics ───────────────────────────────────────
+
+/**
+ * Heuristic guard (low confidence): fires when there are weak signals that the
+ * cited prior may be a namesake or different work from a different source language.
+ *
+ * This guard fires at LOW confidence only — it should not be the sole basis for
+ * treating a demotion as invalid.
+ */
+function checkLowConfidence(
+  book: BookInput,
+  prior: CitedPriorInput,
+): { fired: boolean; reason: string } {
+  // If the book's author surname doesn't appear anywhere in the cited prior
+  const bookAuthorNorm = normalise(book.author ?? '');
+  const bookTokens = sigTokens(book.author ?? '');
+  if (bookTokens.length === 0) return { fired: false, reason: 'no book author to compare' };
+
+  const priorText = normalise(
+    [prior.english_title, prior.translator, prior.publisher, prior.notes].filter(Boolean).join(' ')
+  );
+
+  const authorFound = bookTokens.some(t => priorText.includes(t));
+
+  if (!authorFound) {
+    return {
+      fired: true,
+      reason: `No token from book author "${book.author}" found in cited prior — possible namesake or different author`,
+    };
+  }
+
+  return { fired: false, reason: 'author token found in cited prior' };
+}
+
+// ── Main evaluator ────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate whether a cited prior is trustworthy evidence that a book is not
+ * a first translation.
+ *
+ * @param book       The book being assessed
+ * @param citedPrior The first cited prior from translation_verification
+ * @returns GuardResult — trustworthy=false means at least one definitive guard fired
+ */
+export function evaluatePrior(
+  book: BookInput,
+  citedPrior: CitedPriorInput,
+): GuardResult {
+  const selfMatch = checkSelfMatch(book, citedPrior);
+  const anthology = checkAnthology(book, citedPrior);
+  const partial = checkPartial(book, citedPrior);
+  const lowConf = checkLowConfidence(book, citedPrior);
+
+  const detail: GuardResult['detail'] = {
+    SELF_MATCH: { fired: selfMatch.fired, reason: selfMatch.reason },
+    ANTHOLOGY:  { fired: anthology.fired, reason: anthology.reason },
+    PARTIAL:    { fired: partial.fired, reason: partial.reason },
+    LOW_CONFIDENCE: { fired: lowConf.fired, reason: lowConf.reason },
+  };
+
+  // Definitive guards (high confidence when fired)
+  const definitiveGuards: GuardId[] = [];
+  if (selfMatch.fired) definitiveGuards.push('SELF_MATCH');
+  if (anthology.fired) definitiveGuards.push('ANTHOLOGY');
+  if (partial.fired) definitiveGuards.push('PARTIAL');
+
+  // Heuristic guard (low confidence)
+  const heuristicGuards: GuardId[] = [];
+  if (lowConf.fired) heuristicGuards.push('LOW_CONFIDENCE');
+
+  const failedGuards: GuardId[] = [...definitiveGuards, ...heuristicGuards];
+  // trustworthy = no definitive guard fired (LOW_CONFIDENCE alone does not make untrustworthy)
+  const trustworthy = definitiveGuards.length === 0;
+  const confidence: 'high' | 'low' = definitiveGuards.length > 0 ? 'high' : 'low';
+
+  return { trustworthy, failedGuards, confidence, detail };
+}

--- a/tests/unit/ft-prior-guard.test.ts
+++ b/tests/unit/ft-prior-guard.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Unit tests for the First-Translation Evidence-Quality Guard
+ *
+ * Each labeled test case uses real data fetched from MongoDB (read-only).
+ * The cited priors are exactly as stored in translation_verification.
+ *
+ * Book IDs used:
+ *   69af0a0a4c57359b8d2d0f49  Kircher Arithmologia     (synthetic anthology case from manual_correction note)
+ *   699259118812793469fe177f  Vijnanananda Devi Bhag.  (self-match)
+ *   6992598b3d2d40d1b05915ba  Boas Bella Coola         (self-match)
+ *   69946ec1f6f3426e298f0309  Tiruvalluvar / Lazarus   (self-match)
+ *   69b3e5fb304c1c6b3950aad2  Avicenna al-Qanun        (partial guard — but see LIMITS note)
+ *   69b2ffe2e5d6d64d8e1979e7  Erasmus Paraphrases      (all guards pass — genuine demotion)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluatePrior, type BookInput, type CitedPriorInput } from '@/lib/ft-prior-guard';
+
+// ── Shared expectation helpers ────────────────────────────────────────────────
+
+function expectGuardFired(result: ReturnType<typeof evaluatePrior>, guard: string) {
+  expect(result.failedGuards).toContain(guard);
+  expect(result.trustworthy).toBe(false);
+}
+
+function expectAllGuardsPassed(result: ReturnType<typeof evaluatePrior>) {
+  expect(result.trustworthy).toBe(true);
+  const definitiveGuards = result.failedGuards.filter(g => g !== 'LOW_CONFIDENCE');
+  expect(definitiveGuards).toHaveLength(0);
+}
+
+// ── Case 1: Arithmologia → Godwin anthology (ANTHOLOGY guard) ─────────────────
+
+describe('Arithmologia (id=69af0a0a4c57359b8d2d0f49) — anthology guard', () => {
+  /**
+   * Context: A previous reconcile run demoted this book by citing Godwin's
+   * "Theatre of the World" as a "translation" of Kircher's Arithmologia.
+   * Theatre of the World is an anthology/study of Kircher's work, NOT a
+   * translation of the Arithmologia specifically. The book was manually
+   * restored to confirmed_first (2026-06-19).
+   *
+   * The cited prior below is the data that caused the false demotion.
+   */
+  const book: BookInput = {
+    title: 'Arithmologia',
+    author: 'Athanasius Kircher',
+    language: 'Latin',
+  };
+
+  const citedPrior: CitedPriorInput = {
+    english_title: "The Theatre of the World: Ars Magna of Athanasius Kircher",
+    translator: "Joscelyn Godwin",
+    pub_year: "2009",
+    publisher: "Inner Traditions",
+    completeness: 'complete',
+    series: undefined,
+    notes: "Godwin's Theatre of the World is a collected anthology of Kircher's major works including sections of Arithmologia",
+  };
+
+  it('ANTHOLOGY guard fires', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expectGuardFired(result, 'ANTHOLOGY');
+  });
+
+  it('confidence is high (definitive guard fired)', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.confidence).toBe('high');
+  });
+
+  it('SELF_MATCH guard does not fire (different title)', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.failedGuards).not.toContain('SELF_MATCH');
+  });
+
+  it('PARTIAL guard does not fire (completeness is complete)', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.failedGuards).not.toContain('PARTIAL');
+  });
+});
+
+// ── Case 2: Vijnanananda Devi Bhagavatam → self-match ────────────────────────
+
+describe('Vijnanananda Devi Bhagavatam (id=699259118812793469fe177f) — self-match guard', () => {
+  /**
+   * The book IS the 1915 Swami Vijnanananda English translation of the Devi Bhagavatam.
+   * The cited prior is that exact same translation — same title (modulo variant spelling),
+   * same translator. A system that treated this as "a prior translation exists" would
+   * incorrectly demote the book.
+   */
+  const book: BookInput = {
+    title: 'The Srimad Devi Bhagavatam',
+    author: 'Swami Vijnanananda',
+    language: 'English',
+  };
+
+  const citedPrior: CitedPriorInput = {
+    english_title: 'The Srimad Devi Bhagawatam',
+    translator: 'Swami Vijnanananda',
+    pub_year: '1915',
+    publisher: 'Unknown',
+    completeness: 'complete',
+  };
+
+  it('SELF_MATCH guard fires', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expectGuardFired(result, 'SELF_MATCH');
+  });
+
+  it('confidence is high', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.confidence).toBe('high');
+  });
+});
+
+// ── Case 3: Boas Bella Coola → self-match ────────────────────────────────────
+
+describe('Boas Bella Coola (id=6992598b3d2d40d1b05915ba) — self-match guard', () => {
+  /**
+   * "The Mythology of the Bella Coola Indians" by Franz Boas (1898) was
+   * originally written in English — it is an ethnographic record, not a
+   * translation from Nuxalk. The system cited the same work as a "prior
+   * English translation." Title and author match exactly.
+   */
+  const book: BookInput = {
+    title: 'The Mythology of the Bella Coola Indians',
+    author: 'Franz Boas',
+    language: 'Nuxalk',
+  };
+
+  const citedPrior: CitedPriorInput = {
+    english_title: 'The Mythology of the Bella Coola Indians',
+    translator: 'Franz Boas',
+    pub_year: '1898',
+    publisher: 'American Museum of Natural History',
+    completeness: 'complete',
+  };
+
+  it('SELF_MATCH guard fires', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expectGuardFired(result, 'SELF_MATCH');
+  });
+
+  it('confidence is high', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.confidence).toBe('high');
+  });
+});
+
+// ── Case 4: Pope Naladiyar / Tiruvalluvar Kural → self-match ─────────────────
+
+describe('Pope Naladiyar / Tiruvalluvar Kural (id=69946ec1f6f3426e298f0309) — self-match guard', () => {
+  /**
+   * The book IS the Lazarus 1885 English translation of the Kural.
+   * The cited prior is that same Lazarus 1885 translation. Title overlap
+   * is very high (both contain "Kural" and "Tiruvalluvar") and the
+   * translator (Lazarus) also appears in the book's author string.
+   */
+  const book: BookInput = {
+    title: 'The Kural of Tiruvalluvar',
+    author: 'Tiruvalluvar (ed. Mrugesa Mudaliyar, trans. John Lazarus)',
+    language: 'Tamil',
+  };
+
+  const citedPrior: CitedPriorInput = {
+    english_title: 'The Kural of Tiruvalluvar : with the commentary of Parimelazagar and a simple and clear padavuray; to which is added an English translation of the text',
+    translator: 'John Lazarus',
+    pub_year: '1885',
+    publisher: 'Madras, W.P. Chettiar',
+    completeness: 'complete',
+  };
+
+  it('SELF_MATCH guard fires', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expectGuardFired(result, 'SELF_MATCH');
+  });
+
+  it('confidence is high', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.confidence).toBe('high');
+  });
+});
+
+// ── Case 5: Avicenna al-Qanun → partial guard ────────────────────────────────
+
+describe('Avicenna al-Qanun (id=69b3e5fb304c1c6b3950aad2) — partial guard on cited evidence', () => {
+  /**
+   * The cited prior is Gruner 1930, "A Treatise on the Canon of Medicine …
+   * Incorporating a Translation of the First Book" — explicitly partial.
+   *
+   * GUARD LOGIC: PARTIAL guard fires (cited evidence is partial → does not
+   * defeat a "first complete translation" claim).
+   *
+   * LIMITS (document here): The guard-pass is *necessary but NOT sufficient*.
+   * The CORRECT disposition for this book is "translation_found" (demotion is valid)
+   * because a complete prior translation exists — Bakhtiar 1999 — which was simply
+   * NOT CITED in the translation_verification record. The guard module sees only the
+   * cited evidence, not the full bibliographic record. A guard-pass on the Gruner
+   * citation does not mean the book is a first translation; it means Gruner alone
+   * does not justify the demotion. The Bakhtiar translation, if cited, would pass
+   * all guards (complete, different author, different title) and correctly demote.
+   */
+  const book: BookInput = {
+    title: 'The Canon of Medicine',
+    author: 'Avicenna',
+    language: 'Arabic',
+  };
+
+  const citedPrior: CitedPriorInput = {
+    english_title: 'A Treatise on the Canon of Medicine of Avicenna: Incorporating a Translation of the First Book',
+    translator: 'O. Cameron Gruner',
+    pub_year: '1930',
+    publisher: 'Luzac & Co.',
+    completeness: 'partial',
+  };
+
+  it('PARTIAL guard fires on cited evidence (Gruner 1930 is incomplete)', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expectGuardFired(result, 'PARTIAL');
+  });
+
+  it('confidence is high (definitive guard)', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.confidence).toBe('high');
+  });
+
+  it('SELF_MATCH does not fire (Gruner is a different person from Avicenna)', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.failedGuards).not.toContain('SELF_MATCH');
+  });
+
+  it('ANTHOLOGY does not fire', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.failedGuards).not.toContain('ANTHOLOGY');
+  });
+
+  /**
+   * IMPORTANT LIMIT: This test is a reminder that guard-pass ≠ "book is first translation."
+   * Bakhtiar 1999 (complete translation, uncited) would pass all guards and correctly
+   * establish the demotion. The guard module cannot see uncited evidence.
+   */
+  it('LIMITS: guard-pass here does NOT prove book is first translation — Bakhtiar 1999 complete prior is uncited', () => {
+    // Synthetic: what the Bakhtiar prior would look like if cited
+    const bakhtiarPrior: CitedPriorInput = {
+      english_title: 'The Canon of Medicine (Al-Qanun fi al-Tibb)',
+      translator: 'Laleh Bakhtiar',
+      pub_year: '1999',
+      publisher: 'Kazi Publications',
+      completeness: 'complete',
+    };
+    const result = evaluatePrior(book, bakhtiarPrior);
+    // All definitive guards pass → correct demotion is justified
+    expect(result.trustworthy).toBe(true);
+    const definitiveGuards = result.failedGuards.filter(g => g !== 'LOW_CONFIDENCE');
+    expect(definitiveGuards).toHaveLength(0);
+  });
+});
+
+// ── Case 6: Erasmus Paraphrases → all guards pass ────────────────────────────
+
+describe('Erasmus Paraphrases (id=69b2ffe2e5d6d64d8e1979e7) — all guards pass (genuine demotion)', () => {
+  /**
+   * The cited prior is Udall 1548–1549, a complete real English translation of
+   * Erasmus's Latin Paraphrases. This is a genuine prior translation:
+   * - Not the same work as the book itself (different translator, 16th-century)
+   * - Not an anthology or study
+   * - Complete (not partial)
+   * → All definitive guards pass → the cited prior IS trustworthy evidence
+   *   → the demotion (is_first_translation: false) is justified by this evidence.
+   */
+  const book: BookInput = {
+    title: 'Paraphrases on the New Testament',
+    author: 'Erasmus',
+    language: 'Latin',
+  };
+
+  const citedPrior: CitedPriorInput = {
+    english_title: 'Paraphrases of Erasmus on the New Testament',
+    translator: 'Nicholas Udall (editor)',
+    pub_year: '1548-1549',
+    publisher: 'Edward Whitchurch',
+    completeness: 'complete',
+  };
+
+  it('all definitive guards pass (no SELF_MATCH, ANTHOLOGY, or PARTIAL)', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expectAllGuardsPassed(result);
+  });
+
+  it('trustworthy is true', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.trustworthy).toBe(true);
+  });
+
+  it('SELF_MATCH does not fire (Udall is a different person from Erasmus)', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.failedGuards).not.toContain('SELF_MATCH');
+  });
+
+  it('ANTHOLOGY does not fire', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.failedGuards).not.toContain('ANTHOLOGY');
+  });
+
+  it('PARTIAL does not fire (completeness is complete)', () => {
+    const result = evaluatePrior(book, citedPrior);
+    expect(result.failedGuards).not.toContain('PARTIAL');
+  });
+});
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+describe('Edge cases', () => {
+  it('empty cited prior returns trustworthy=false via LOW_CONFIDENCE', () => {
+    const book: BookInput = { title: 'Some Book', author: 'Some Author', language: 'Latin' };
+    const prior: CitedPriorInput = {};
+    const result = evaluatePrior(book, prior);
+    // With no prior data at all, LOW_CONFIDENCE fires (no author token found)
+    // but we don't assert on this strongly — the guard system is designed for real data
+    expect(result).toBeDefined();
+    expect(typeof result.trustworthy).toBe('boolean');
+  });
+
+  it('completeness=excerpts triggers PARTIAL guard', () => {
+    const book: BookInput = { title: 'Opus Magnum', author: 'Paracelsus', language: 'German' };
+    const prior: CitedPriorInput = {
+      english_title: 'Selected Writings of Paracelsus',
+      translator: 'Norbert Guterman',
+      pub_year: '1951',
+      completeness: 'excerpts',
+    };
+    const result = evaluatePrior(book, prior);
+    expect(result.failedGuards).toContain('PARTIAL');
+  });
+
+  it('anthology keyword in series triggers ANTHOLOGY guard', () => {
+    const book: BookInput = { title: 'De Occulta Philosophia', author: 'Heinrich Cornelius Agrippa', language: 'Latin' };
+    const prior: CitedPriorInput = {
+      english_title: 'Agrippa on Occult Philosophy',
+      translator: 'John Freake',
+      pub_year: '1651',
+      completeness: 'complete',
+      series: 'Collected Works of Agrippa',
+    };
+    const result = evaluatePrior(book, prior);
+    expect(result.failedGuards).toContain('ANTHOLOGY');
+  });
+
+  it('high title overlap prevents false ANTHOLOGY fire when book IS that work', () => {
+    const book: BookInput = { title: 'Arithmologia', author: 'Kircher', language: 'Latin' };
+    const prior: CitedPriorInput = {
+      english_title: 'Arithmologia: The Art of Numbers — Complete Works',
+      translator: 'Joscelyn Godwin',
+      pub_year: '2009',
+      completeness: 'complete',
+    };
+    // "complete works" is in ANTHOLOGY_SERIES keywords but title overlap is high
+    const result = evaluatePrior(book, prior);
+    // ANTHOLOGY should NOT fire because title overlap is high
+    expect(result.failedGuards).not.toContain('ANTHOLOGY');
+  });
+});


### PR DESCRIPTION
Tested reference implementation of the **demotion preconditions** from #2564's failure-mode analysis, plus the read-only audit they enable. Built/tested by a Sonnet agent; zero DB writes.

## Why
The single-writer reconcile demoted books by trusting `disposition: translation_found` as truth — but that's a *fallible match*. It demoted a verified first (the **Arithmologia**, whose cited "prior" was Godwin's *anthology*). The fix: a cited prior must be a **real sighting** before it can justify `is_first_translation=false`.

## What
- `src/lib/ft-prior-guard.ts` — `evaluatePrior(book, citedPrior) → { trustworthy, failedGuards, confidence }`. Guards: **SELF_MATCH** / **ANTHOLOGY** / **PARTIAL** + **LOW_CONFIDENCE** namesake heuristic.
- `tests/unit/ft-prior-guard.test.ts` — **24/24 passing**, `tsc` clean. Covers the Arithmologia/Godwin anthology match (fires), the three self-matches, Erasmus→Udall (genuine pass), and Avicenna as the boundary (PARTIAL fires on cited Gruner, but a complete Bakhtiar prior is *uncited* → guard-pass ≠ "first").
- `scripts/eval/ft-guard-audit-report.md` — audit of **3,934** `translation_found` books: **536 (13.6%)** rest on evidence that doesn't justify the demotion — **251 self-match, 190 anthology, 109 partial**.

## Scope
- **In:** the tested guard predicate + the audit + the candid Limits section.
- **Out (deliberately):** integration into `src/lib/first-translation/derive` (the reconcile owner's layer, #2564) and any DB writes. Port the predicate into `derive`'s demotion precondition, then **this standalone module can be removed**.
- **The 536 are a Tier-2 re-verification queue, not an auto-restore list** — a guard-fail means "this citation doesn't justify not-first," not "the book is a first."

Refs #2564 · cluster map #2567

🤖 Generated with [Claude Code](https://claude.com/claude-code)