### PR TITLE
fix(archive): decouple archiving from the global spend-pause

### DIFF
--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -230,10 +230,13 @@ async function main() {
   const client = await MongoClient.connect(process.env.MONGODB_URI, { maxPoolSize: 10 });
   const db = client.db('bookstore');
 
-  // Check processing_control pause
+  // Archiving is decoupled from the global `paused` (Gemini-spend) flag: archiving
+  // fetches source images into R2 and costs no Gemini, so it should keep running
+  // while OCR/translation are paused for spend. It has its own dedicated
+  // off-switch — `archiving_paused` — for when archiving specifically must stop.
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
-  if (control?.paused) {
-    console.log(`[archive-ocr] Pipeline paused. Exiting.`);
+  if (control?.archiving_paused) {
+    console.log(`[archive-ocr] Archiving paused (archiving_paused flag set). Exiting.`);
     await client.close();
     process.exit(0);
   }


### PR DESCRIPTION
## Why
`archive-ocr.mjs` exited whenever `processing_control.paused` was set. That flag pauses Gemini **spend** (OCR/translation). Archiving only fetches source images into R2 — **zero Gemini cost** — so it was needlessly halted, leaving the draft backlog (~23k books, ~2.3k English) unarchived while the spend-pause was on.

## Change
Gate archiving on a dedicated `processing_control.archiving_paused` flag instead of the global `paused`. Archiving keeps running while OCR/translation are paused, with its own off-switch.

## Context / out of scope
- Pipeline core crons (archive, OCR submit/collect, orchestrator phases 1–8) are currently disabled on Hetzner pending a scheduler migration — this change removes the spend-pause as a blocker but doesn't re-schedule archiving (migration-owned).
- IA / Gallica / Harvard archive from the Mac side (block Hetzner IPs); `archive-ocr.mjs` covers Hetzner-reachable providers (IIIF/BSB/Cambridge/Vatican/etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)