### PR TITLE
fix(search): stop Google-Translate insertBefore crash in highlighted snippets

### DIFF
--- a/src/components/search/HighlightedText.tsx
+++ b/src/components/search/HighlightedText.tsx
@@ -8,28 +8,43 @@ interface HighlightedTextProps {
   className?: string;
 }
 
+const MARK_CLASS = 'bg-accent-gold/25 text-accent-gold-dark rounded-sm px-0.5';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /**
  * Renders text with query matches highlighted.
- * XSS-safe by construction — React escapes all text, no dangerouslySetInnerHTML.
+ *
+ * Why dangerouslySetInnerHTML (and why it stays XSS-safe): in-page translators
+ * — Google Translate above all — rewrite and MERGE text nodes across element
+ * boundaries to reflow a sentence. When the snippet is built from React's own
+ * <mark>/<span> children, Translate desyncs the live DOM from React's fiber
+ * tree, and the next render throws "Failed to execute 'insertBefore' on 'Node'"
+ * (3k+/day on /search during the Spanish-speaking traffic surge). Rendering the
+ * snippet as a single innerHTML string makes React treat the inner DOM as
+ * opaque: it never reconciles the individual nodes Translate touched, it only
+ * replaces innerHTML wholesale when props change. Every segment is HTML-escaped;
+ * the only markup we inject is our own fixed-class <mark>, so there's no
+ * injection surface.
  */
 export default function HighlightedText({ text, query, className }: HighlightedTextProps) {
-  if (!query || !text) {
-    return <span className={className}>{text}</span>;
-  }
+  const html =
+    !query || !text
+      ? escapeHtml(text ?? '')
+      : splitByMatches(text, query)
+          .map((segment) =>
+            segment.highlight
+              ? `<mark class="${MARK_CLASS}">${escapeHtml(segment.text)}</mark>`
+              : escapeHtml(segment.text),
+          )
+          .join('');
 
-  const segments = splitByMatches(text, query);
-
-  return (
-    <span className={className}>
-      {segments.map((segment, i) =>
-        segment.highlight ? (
-          <mark key={i} className="bg-accent-gold/25 text-accent-gold-dark rounded-sm px-0.5">
-            {segment.text}
-          </mark>
-        ) : (
-          <span key={i}>{segment.text}</span>
-        )
-      )}
-    </span>
-  );
+  return <span className={className} dangerouslySetInnerHTML={{ __html: html }} />;
 }


### PR DESCRIPTION
## What
Render search-result highlight snippets as a single `dangerouslySetInnerHTML` string instead of React-managed `<mark>`/`<span>` children.

## Why
`application_errors` logged **3,275 client crashes today**, nearly all identical: `Failed to execute 'insertBefore' on 'Node'` on `/search` — concentrated on today's heavily Spanish-speaking Instagram surge. Root cause: **Google Translate** rewrites and merges text nodes across element boundaries to reflow sentences, desyncing the live DOM from React's fiber tree; React's next reconciliation then throws. `HighlightedText` (one per result snippet, many per search) was the hot spot.

## Fix
Build the highlighted snippet as one escaped HTML string and set it via `dangerouslySetInnerHTML`. React then treats the inner DOM as **opaque** — it never reconciles the individual text nodes Translate mutated, only replaces innerHTML wholesale on prop change. This is the canonical mitigation for the Translate-vs-React class of crash.

## Safety
Still XSS-safe by construction: every text segment is HTML-escaped; the only markup injected is our own fixed-class `<mark>`. Props/signature unchanged, so all 6 consumers (search page, book search, unified search, search panel, experiments) benefit with no caller changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)