### PR TITLE
feat(search): stamp country on search_query events for geo analytics

### DIFF
--- a/src/app/api/search/index/route.ts
+++ b/src/app/api/search/index/route.ts
@@ -65,6 +65,9 @@ export async function GET(request: NextRequest) {
       filters: { type, source: 'index' },
       timestamp: new Date(),
       ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
+      // Geo from the edge header (same source pageviews use) so search interests
+      // can be broken down by country. Forward-only — past searches have none.
+      country: request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || 'Unknown',
       created_at: new Date(),
     }).catch(() => {});
 

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -820,6 +820,9 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       filters: { language, category, year, bookId, library, source: 'global' },
       timestamp: new Date(),
       ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
+      // Geo from the edge header (same source pageviews use) so search interests
+      // can be broken down by country. Forward-only — past searches have none.
+      country: request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || 'Unknown',
       created_at: new Date(),
     }).catch(() => {});
 

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -393,6 +393,9 @@ export async function GET(request: NextRequest) {
       filters: { language, category, library, source: 'unified', tenantId: tenantContext.id || null },
       timestamp: new Date(),
       ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
+      // Geo from the edge header (same source pageviews use) so search interests
+      // can be broken down by country. Forward-only — past searches have none.
+      country: request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || 'Unknown',
       created_at: new Date(),
     }).catch(() => {});
 


### PR DESCRIPTION
## What
Add `country` (from the edge geo header) to the three global search-query writers — `/api/search`, `/api/search/unified`, `/api/search/index`.

## Why
You asked to break search interests down by location. That isn't possible from current data: search_query events store only a **Cloudflare proxy IP** and no country; the pageview log *has* country but strips the `?q=`; and PostHog barely captured `/search` (consent-gated for most of the window). So geography has to be **collected going forward**.

## Change
`country: x-vercel-ip-country || cf-ipcountry || 'Unknown'` — the exact source the pageview tracker already uses. Fire-and-forget insert, no added latency. Forward-only: historical searches stay un-geotagged, but the geographic view populates from deploy onward (fast, given current traffic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)