### PR TITLE
feat(analytics): track value moments — cite, share, quote-copy, download

### DIFF
--- a/src/app/api/analytics/event/route.ts
+++ b/src/app/api/analytics/event/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { anonymizeIp } from '@/lib/anonymize-ip';
+
+/**
+ * General-purpose analytics event sink for value-moment interactions that the
+ * book-centric /api/analytics/track route doesn't cover — citing, sharing,
+ * copying a quote, viewing a DOI, etc. These are the moments that show the
+ * mission ("read and quote the original") is actually happening.
+ *
+ * POST /api/analytics/event  Body: { event: string, props?: object }
+ * Fire-and-forget; writes one row to analytics_events. Public (consistent with
+ * /api/track) but locked down by an event-name allowlist + prop whitelist so it
+ * can't be used to write arbitrary documents.
+ */
+
+const ALLOWED_EVENTS = new Set([
+  'cite', 'share', 'quote_copy', 'doi_view', 'download',
+]);
+
+// Only these prop keys are persisted; everything else is dropped.
+const ALLOWED_PROPS = new Set([
+  'bookId', 'format', 'channel', 'page', 'title', 'url', 'hasDoi', 'edition', 'source',
+]);
+
+const DB_TIMEOUT_MS = 3000;
+
+function sanitizeProps(props: unknown): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {};
+  if (!props || typeof props !== 'object') return out;
+  for (const [k, v] of Object.entries(props as Record<string, unknown>)) {
+    if (!ALLOWED_PROPS.has(k)) continue;
+    if (typeof v === 'string') out[k] = v.slice(0, 300);
+    else if (typeof v === 'number' && Number.isFinite(v)) out[k] = v;
+    else if (typeof v === 'boolean') out[k] = v;
+  }
+  return out;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const event = typeof body?.event === 'string' ? body.event : '';
+    if (!ALLOWED_EVENTS.has(event)) {
+      return NextResponse.json({ error: 'Invalid event type' }, { status: 400 });
+    }
+
+    const rawIp = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+      || request.headers.get('x-real-ip')
+      || 'unknown';
+
+    const now = new Date();
+    const doc = {
+      event,
+      ...sanitizeProps(body?.props),
+      country: request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || 'Unknown',
+      ip: anonymizeIp(rawIp),
+      timestamp: now,
+      created_at: now,
+    };
+
+    // Race the write against a short timeout — never hold a slot on DB stress.
+    await Promise.race([
+      (async () => {
+        const db = await getDb();
+        await db.collection('analytics_events').insertOne(doc);
+      })(),
+      new Promise((resolve) => setTimeout(resolve, DB_TIMEOUT_MS)),
+    ]);
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    // Analytics must never surface an error to the user.
+    return NextResponse.json({ ok: false }, { status: 200 });
+  }
+}

--- a/src/components/ui/CiteButton.tsx
+++ b/src/components/ui/CiteButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Quote, Copy, Check } from 'lucide-react';
+import { trackEvent } from '@/lib/track-event';
 
 function getRuntimeOrigin(): string {
   if (typeof window !== 'undefined' && window.location?.origin) {
@@ -174,6 +175,7 @@ export default function CiteButton({
   const copyToClipboard = async (text: string, id: string) => {
     await navigator.clipboard.writeText(text);
     setCopiedId(id);
+    trackEvent('cite', { bookId, format: id, page: pageNumber, hasDoi: !!doi });
     setTimeout(() => setCopiedId(null), 2000);
   };
 

--- a/src/components/ui/DownloadButton.tsx
+++ b/src/components/ui/DownloadButton.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { toast } from 'sonner';
+import { trackEvent } from '@/lib/track-event';
 import { Download, ChevronDown, FileText, Languages, Layers, BookOpen, Columns, Image, GraduationCap } from 'lucide-react';
 import { BookDownloadFormats, books } from '@/lib/api-client';
 
@@ -112,6 +113,7 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
       window.URL.revokeObjectURL(url);
       document.body.removeChild(a);
 
+      trackEvent('download', { bookId, format });
       setIsOpen(false);
     } catch (error) {
       console.error('Download error:', error);

--- a/src/components/ui/ShareButton.tsx
+++ b/src/components/ui/ShareButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Share2, Twitter, Link2, Check, MessageCircle, Phone } from 'lucide-react';
+import { trackEvent } from '@/lib/track-event';
 
 function getRuntimeOrigin(): string {
   if (typeof window !== 'undefined' && window.location?.origin) {
@@ -101,11 +102,15 @@ export default function ShareButton({
   const tweetText = buildTweetText();
 
   // Share handlers
+  const logShare = (channel: string) =>
+    trackEvent('share', { channel, url: shareUrl, page, hasDoi: !!doi });
+
   const shareToTwitter = () => {
     const twitterUrl = new URL('https://twitter.com/intent/tweet');
     twitterUrl.searchParams.set('text', tweetText);
     twitterUrl.searchParams.set('url', shareUrl);
     window.open(twitterUrl.toString(), '_blank', 'width=550,height=420');
+    logShare('twitter');
     setShowMenu(false);
   };
 
@@ -116,6 +121,7 @@ export default function ShareButton({
       : `${citation}\n\n${shareUrl}`;
     bskyUrl.searchParams.set('text', fullText);
     window.open(bskyUrl.toString(), '_blank', 'width=550,height=420');
+    logShare('bluesky');
     setShowMenu(false);
   };
 
@@ -125,6 +131,7 @@ export default function ShareButton({
       : `${citation}\n${shareUrl}`;
     const waUrl = `https://wa.me/?text=${encodeURIComponent(waText)}`;
     window.open(waUrl, '_blank');
+    logShare('whatsapp');
     setShowMenu(false);
   };
 
@@ -134,6 +141,7 @@ export default function ShareButton({
       : `${citation} — Source Library`;
     const pinUrl = `https://pinterest.com/pin/create/button/?url=${encodeURIComponent(shareUrl)}&description=${encodeURIComponent(desc)}`;
     window.open(pinUrl, '_blank', 'width=750,height=550');
+    logShare('pinterest');
     setShowMenu(false);
   };
 
@@ -144,6 +152,7 @@ export default function ShareButton({
 
     await navigator.clipboard.writeText(textToCopy);
     setCopied(true);
+    logShare('link');
     setTimeout(() => setCopied(false), 2000);
     setShowMenu(false);
   };
@@ -153,6 +162,7 @@ export default function ShareButton({
     const quoteToCopy = `"${text}"\n\n— ${citation}${doi ? `\nDOI: ${doi}` : ''}`;
     await navigator.clipboard.writeText(quoteToCopy);
     setCopied(true);
+    trackEvent('quote_copy', { url: shareUrl, page, hasDoi: !!doi });
     setTimeout(() => setCopied(false), 2000);
     setShowMenu(false);
   };

--- a/src/lib/track-event.ts
+++ b/src/lib/track-event.ts
@@ -1,0 +1,34 @@
+/**
+ * Fire-and-forget client tracker for value-moment events (cite, share, quote
+ * copy, DOI view, download) → POST /api/analytics/event. Uses sendBeacon so it
+ * survives navigation (e.g. a share that opens a new tab); falls back to a
+ * keepalive fetch. Never throws — analytics must not break an interaction.
+ */
+export function trackEvent(
+  event: 'cite' | 'share' | 'quote_copy' | 'doi_view' | 'download',
+  props?: Record<string, string | number | boolean | undefined>,
+): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const clean: Record<string, string | number | boolean> = {};
+    if (props) {
+      for (const [k, v] of Object.entries(props)) {
+        if (v !== undefined) clean[k] = v;
+      }
+    }
+    const body = JSON.stringify({ event, props: clean });
+    const url = '/api/analytics/event';
+    if (navigator.sendBeacon) {
+      const ok = navigator.sendBeacon(url, new Blob([body], { type: 'application/json' }));
+      if (ok) return;
+    }
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    /* never throw */
+  }
+}


### PR DESCRIPTION
## What
Instrument the mission's core value moments: **citing, sharing, copying a quote, and downloading**.

## Why
We can see people open books (3,095 today) but never whether they got value out — the read-and-quote moment that distinguishes Source Library from every rival was completely uninstrumented.

## Change
- New general event sink `POST /api/analytics/event` — allowlisted events (`cite`/`share`/`quote_copy`/`doi_view`/`download`) + whitelisted props, fire-and-forget with a 3s DB-timeout race, country-stamped, anonymized IP. Public but locked down so it can't write arbitrary docs.
- `trackEvent()` client helper — `sendBeacon` (survives navigation, e.g. a share opening a tab) with keepalive-fetch fallback; never throws.
- Wired: **CiteButton** (cite, per APA/BibTeX format), **ShareButton** (share per channel: twitter/bluesky/whatsapp/pinterest/link, plus quote_copy), **DownloadButton** (download per format).

## Result
We can now answer 'which passages and books actually get cited/shared', not just opened — and feed that into curation. Events land in `analytics_events` alongside the existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)