### PR TITLE
feat(shwep): inline-linked reading list — flagship episode #76

### DIFF
--- a/.claude/docs/work-identity-matching-research.md
+++ b/.claude/docs/work-identity-matching-research.md
@@ -1,0 +1,106 @@
+# Fixing citation → work → holdings matching (research, 2026-06-20)
+
+How to match a **cited work** (in a reading list, footnote, bibliography) to the
+**books we hold**, without the two failure modes that plague fuzzy/embedding
+matching:
+
+- **False negatives** — miss a work we hold under a divergent title/language
+  ("Golden Ass" ≠ our "Apuleii Metamorphoseos"; "Corpus Hermeticum" ≠ "Poimandres").
+- **False positives** — "same author, wrong work" (Porphyry's *lost* *De regressu
+  animae* → his *Sententiae*; Damascius *In Phaedonem* → *De principiis*) and
+  cross-author title coincidence (Middleton's play *A Game at Chess* → Cessolis's
+  medieval *Game of Chess*).
+
+Source: deep-research pass (`wf_3389a3b3-75d`, 21 sources, 24/25 claims verified
+3-0 / 2-1). This is the design basis for rebuilding the SHWEP reading-room matcher
+and for trusting the acquisition gap list.
+
+## The core principle
+**Resolve BOTH sides to the same canonical work-identity space, then match on ID
+equality — never fuzzy title/embedding matching.** Our books already carry
+`work_id` (a Wikidata QID; see `work-identity-coverage.md`). The missing half is
+resolving the **citation** to a work_id with the same rigor. Match on
+`citation.work_id == book.work_id`:
+- Solves false negatives — every edition/translation of a work shares one QID,
+  regardless of title or language (this is the FRBR/IFLA-LRM Work entity: a
+  translation is a new *Expression* of the *same Work*, the same collocation
+  library uniform-title authority control has always done).
+- Solves false positives — distinct works have distinct QIDs; a *lost* work has
+  **no edition pointing at its QID** → correctly "we don't hold it," not a
+  same-author guess.
+
+**False-positive guard (from IFLA-LRM, verbatim):** "similarity of factual or
+thematic content alone is not enough to group several expressions as realizing
+the same work." So the rule is **author-anchor agreement AND work-id match** —
+never thematic/title similarity. That kills Middleton→Cessolis (different authors)
+and De regressu→Sententiae (different work-ids).
+
+## Identifier systems (what to use as backbone vs. fallback)
+
+| System | What it is | Use |
+|---|---|---|
+| **Wikidata QID** | Universal work id; covers ALL traditions incl. Islamicate, Byzantine, Renaissance | **Backbone** — already our `work_id`. The only viable id outside Greek/Latin antiquity. |
+| **CTS URN** (CITE Architecture: TLG Greek + PHI Latin + Stoa) | `textgroup.work` e.g. `tlg0059.tlg030` = Plato *Republic*. Language-/edition-independent, FRBR Work-level, persistent | **High-precision overlay for Greek/Latin/patristic.** Bridged from author via Wikidata **P12869 (LAGL Author ID)** → author CTS URN, then work-level match within that author. |
+| **VIAF** | Aggregates ~37 national authority files → one id/author (variant names across LC/BNF/DNB) | **Cross-lingual author anchor** (Latin↔vernacular name variants). Author-level only — its work lists are non-exhaustive. |
+| **LAGL / Iowa Canon** (catalog.lagl.org) | Models lost-by-title + fragmentary works as **separate entries** with a `status` field (complete/fragmentary/lost), **attested abbreviations**, and Perseus URI cross-refs | **Fallback for lost/fragmentary/anonymous**, AND the **abbreviation→work decoder** for scholarly forms ("de myst.", "civ. dei"). |
+| **Clavis Patrum (Graecorum/Latinorum)** | Catalogs patristic works extant only in translation or lost (*deperdita*) | Fallback for patristic lost/translation-only works. |
+| **Trismegistos Authors** (KU Leuven) | All-languages author/work ids, 800 BC–AD 800 | Supplementary breadth (WIP, partial). |
+
+**Critical coverage caveat:** TLG/PHI/Stoa/Clavis/LAGL are overwhelmingly
+**Greek/Latin classical–patristic**. SHWEP's Islamicate, Byzantine, and
+Renaissance/early-modern material is NOT well-covered by these canons — there,
+**Wikidata QID is the only work-id**. So Wikidata is the backbone; CTS URN is a
+precision booster where it exists.
+
+## The structural gap that maps to our hard cases
+Lost / fragmentary / anonymous works are **exactly where canonical TLG/PHI numbers
+are missing** (Perseus documents this directly). So:
+- **Lost works** (De regressu animae, fragments/testimonia) → resolve via LAGL/
+  Clavis `status=lost`; the pipeline returns **explicit "no holding / lost work"**,
+  never a same-author fallback.
+- **Anonymous works** (Chaldaean Oracles, Nag Hammadi) → no author to anchor on;
+  resolve title-direct against Wikidata/LAGL (our existing rare-token fallback).
+- **Same-author-many-works** (Proclus's ~10 commentaries) → VIAF/Wikidata fixes the
+  author anchor; the work-level CTS URN / QID disambiguates which work.
+
+## Recommended pipeline (citation → canonical work → holdings)
+Mirrors the proven two-stage design (Romanello's CitationExtractor: CRF/NER extract
+→ separate disambiguation/matcher; modern transformer NER replaces the CRF stage):
+
+1. **EXTRACT** cited work + author from the reading list (LLM, as today). Also
+   capture the scholarly **abbreviation** form ("de myst.").
+2. **NORMALIZE** abbreviation → canonical work title via a classical-abbreviation
+   table (OCD/LSJ/Lewis-Short/Perseus `abbrevhelp`/LAGL attested-abbreviations).
+3. **RESOLVE AUTHOR** via the existing author thesaurus → VIAF/Wikidata (cross-
+   lingual anchor). Anonymous → skip to title-direct.
+4. **RESOLVE WORK to a work_id:** Wikidata QID (existing resolver) as the universal
+   key; add CTS URN for Greek/Latin via the author's work list (P12869 bridge).
+   Honor LAGL `status=lost` → return "no holding."
+5. **MATCH holdings by ID equality:** `citation.work_id == book.work_id` (our books
+   already carry `work_id`). No fuzzy match.
+6. **GUARDS:** require author-anchor agreement AND work-id match; never thematic/
+   title similarity; explicit "lost/anonymous/uncertain" outcomes instead of a
+   forced match.
+
+## What this means for Source Library concretely
+- **Reuse, don't rebuild.** The book side already has `work_id` (Wikidata,
+  ~95–98% on Greek/Latin via `resolve-work-ids-wikidata.mjs`). The fix is to run
+  the *same* author-anchored resolver on the **cited works**, then match on QID.
+- The SHWEP embedding+LLM matcher should be **replaced** by this for the
+  classics-heavy episodes; keep LLM only for extraction + the anonymous title-
+  direct tail.
+- **Acquisition gap is currently inflated** by work-level false negatives (we
+  flagged "acquire" for works we hold under divergent titles — Golden Ass, Hamlet
+  in the First Folio, Theologumena arithmeticae, Ecclesiastical History). Re-derive
+  the gap from `work_id` clusters (`work-coverage.mjs`), not title matching.
+
+## Open questions (verify before building)
+1. **Work-level Wikidata↔CTS crosswalk** — a claim that "no LAGL *Work* ID property
+   exists" was *refuted* (0-3), so a work-level bridge may now exist. Check Wikidata
+   for a LAGL Work ID property; if present, our QID `work_id`s bridge straight to
+   CTS URNs.
+2. **Machine-readable abbreviation→work table** — LAGL "attested abbreviations" and
+   Perseus `abbrevhelp` were referenced but the downloadable crosswalk wasn't
+   pinned. Need the actual file/API.
+3. **Non-Greek/Latin coverage** — confirm Wikidata QID is the only fallback for
+   SHWEP's Islamicate/Byzantine/Renaissance works (likely yes).

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ src/data/*
 !src/data/carbon-ledger/
 !src/data/carbon-ledger/*.json
 !src/data/shwep-bibliographies.ts
+!src/data/shwep-linked-bibliographies.ts
 
 # User uploads and test files
 public/uploads/

--- a/src/app/shwep/[number]/page.tsx
+++ b/src/app/shwep/[number]/page.tsx
@@ -127,9 +127,9 @@ export default async function EpisodePage({ params }: Props) {
       {/* Content */}
       <div className="max-w-5xl mx-auto px-6 py-8">
         {/* Earl Fontainelle's reading list, scraped from the episode page on shwep.net */}
-        {episode.bibliography && (
+        {(episode.linkedBibliography || episode.bibliography) && (
           <section className="mb-10">
-            <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 mb-4">
+            <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 mb-2">
               <h2 className="text-xl font-serif text-stone-800">Reading List</h2>
               <p className="text-xs text-stone-500">
                 Compiled by{' '}
@@ -138,33 +138,42 @@ export default async function EpisodePage({ params }: Props) {
                 <a href={episode.url} target="_blank" rel="noopener noreferrer" className="text-accent-rust underline">view on shwep.net</a>
               </p>
             </div>
+            {episode.linkedBibliography && (
+              <p className="text-sm text-stone-500 mb-4">
+                The works <span className="text-accent-rust font-medium">underlined in rust</span> are in Source Library — click any to read the original.
+              </p>
+            )}
             <div className="rounded-xl bg-white border border-stone-200 shadow-sm p-6 md:p-7">
-              <ReadingList markdown={episode.bibliography} />
+              <ReadingList markdown={episode.linkedBibliography || episode.bibliography!} />
             </div>
           </section>
         )}
 
-        {episode.bookCount > 0 ? (
-          <>
-            <h2 className="text-xl font-serif text-stone-800 mb-1">
-              Read in Source Library
-            </h2>
-            <p className="text-sm text-stone-500 mb-6">
-              Primary sources from this episode that you can read here — {episode.bookCount} title{episode.bookCount !== 1 ? 's' : ''} in the collection.
-            </p>
-            <div className="space-y-4">
-              {episode.books.map(book => (
-                <BookCard key={book.id} book={book} />
-              ))}
+        {/* When the bibliography has inline "read here" links, it IS the integrated experience —
+            skip the separate book list. Otherwise fall back to the matched-books list. */}
+        {!episode.linkedBibliography && (
+          episode.bookCount > 0 ? (
+            <>
+              <h2 className="text-xl font-serif text-stone-800 mb-1">
+                Read in Source Library
+              </h2>
+              <p className="text-sm text-stone-500 mb-6">
+                Primary sources from this episode that you can read here — {episode.bookCount} title{episode.bookCount !== 1 ? 's' : ''} in the collection.
+              </p>
+              <div className="space-y-4">
+                {episode.books.map(book => (
+                  <BookCard key={book.id} book={book} />
+                ))}
+              </div>
+            </>
+          ) : (
+            <div className="text-center py-12 text-stone-500">
+              <p className="text-lg mb-2">None of this episode&rsquo;s sources are in the collection yet.</p>
+              <p className="text-sm">
+                <Link href="/contribute" className="text-accent-rust underline">Suggest a book</Link> to help expand coverage.
+              </p>
             </div>
-          </>
-        ) : (
-          <div className="text-center py-12 text-stone-500">
-            <p className="text-lg mb-2">None of this episode&rsquo;s sources are in the collection yet.</p>
-            <p className="text-sm">
-              <Link href="/contribute" className="text-accent-rust underline">Suggest a book</Link> to help expand coverage.
-            </p>
-          </div>
+          )
         )}
 
         {/* Back link */}
@@ -194,7 +203,22 @@ function ReadingList({ markdown }: { markdown: string }) {
           li: ({ children }) => <li className="pl-1">{children}</li>,
           em: ({ children }) => <em className="italic">{children}</em>,
           strong: ({ children }) => <strong className="font-semibold text-stone-800">{children}</strong>,
-          a: ({ href, children }) => <a href={href} target="_blank" rel="noopener noreferrer" className="text-accent-rust underline">{children}</a>,
+          a: ({ href, children }) => {
+            // Internal /book/ links are works we hold — render as a same-tab Source Library
+            // link with a "read here" book affordance. External refs (Earl's own links,
+            // JSTOR, Wikipedia, cross-episode) open in a new tab as before.
+            if (href?.startsWith('/')) {
+              return (
+                <Link href={href} className="text-accent-rust underline decoration-accent-rust/40 underline-offset-2 hover:decoration-accent-rust font-medium whitespace-nowrap">
+                  {children}
+                  <svg className="inline-block w-3.5 h-3.5 ml-0.5 -mt-0.5 align-middle" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                  </svg>
+                </Link>
+              );
+            }
+            return <a href={href} target="_blank" rel="noopener noreferrer" className="text-stone-500 underline decoration-stone-300 underline-offset-2 hover:text-stone-700">{children}</a>;
+          },
           hr: () => <hr className="my-4 border-stone-200" />,
         }}
       >

--- a/src/app/shwep/shwep-data.ts
+++ b/src/app/shwep/shwep-data.ts
@@ -5,6 +5,7 @@ import { EPISODE_DESCRIPTIONS } from '@/data/shwep-descriptions';
 import { EPISODE_DATES } from '@/data/shwep-dates';
 import { SHWEP_BOOK_MATCHES } from '@/data/shwep-book-matches';
 import { SHWEP_BIBLIOGRAPHIES } from '@/data/shwep-bibliographies';
+import { SHWEP_LINKED_BIBLIOGRAPHIES } from '@/data/shwep-linked-bibliographies';
 
 export interface MatchedBook {
   id: string;
@@ -32,6 +33,8 @@ export interface EnrichedEpisode {
   publishDate?: string;
   /** Earl Fontainelle's reading list / works-cited for this episode (markdown), scraped from shwep.net. */
   bibliography?: string;
+  /** Hand-curated variant of `bibliography` with the works we hold turned into inline /book/ links. When present, the page renders this instead of the plain bibliography + separate book list. */
+  linkedBibliography?: string;
   books: MatchedBook[];
   bookCount: number;
 }
@@ -251,6 +254,7 @@ export async function getEpisodeData(episodeNumber: number): Promise<EnrichedEpi
     description: EPISODE_DESCRIPTIONS[episodeNumber] || undefined,
     publishDate: EPISODE_DATES[episodeNumber] || undefined,
     bibliography: SHWEP_BIBLIOGRAPHIES[episodeNumber] || undefined,
+    linkedBibliography: SHWEP_LINKED_BIBLIOGRAPHIES[episodeNumber] || undefined,
     books,
     bookCount: books.length,
   };

--- a/src/data/shwep-linked-bibliographies.ts
+++ b/src/data/shwep-linked-bibliographies.ts
@@ -1,0 +1,69 @@
+/**
+ * Hand-curated inline-linked reading lists for the SHWEP Reading Room.
+ * Earl Fontainelle's bibliography with the works WE HOLD turned into "read here" links
+ * (/book/...) right inside his text. One verified episode at a time — the auto-matcher
+ * is a draft; these links are hand-checked (correct work + edition), so a "same author,
+ * wrong work" mismatch never ships. Episodes here render inline instead of the separate
+ * "Read in Source Library" list.
+ */
+export const SHWEP_LINKED_BIBLIOGRAPHIES: Record<number, string> = {
+  76: `### Works Cited in this Episode:
+
+### Primary:
+
+- The [*Chaldæan Oracles*](/book/magia-philosophica-oracula-chaldaica-patrizi): Two types of people, theurgists and the ‘herd’, who are subject to fate: frr. 153-4.
+
+- Augustine on *theurgia*, *goëtia*, and *magia*: [*civ. dei*](/book/de-civitate-dei-hippo) X, 9, 1.
+
+- Damascius: On the philosophic vs. hieratic distinction: *in Phd*. 123, 113 ff. On arming oneself for the ascent with *synthemata*: fr. 2=Damascius [*Dub*.](/book/problemes-et-solutions-touchant-les-premiers-principes-vol-3-damascius) I, 155, 11-15.
+
+- Iamblichus: On theurgy vs *goëteia*: [*de myst*.](/book/jamblichus-de-mysteriis-aegyptiorum-chaldaeorum-assyriorum-iamblichus-2)1.12, 14; 2.6; 3.1, 10, 18; 4.2. On animating statues: *de myst.* 5.83.
+
+- Marinus on Proclus' ritual sea-bathing (between once and three times a month): [*Vit. Proc*.](/book/life-of-proclus-by-marinus-neapolis) 18. Proclus uses a *iunx* to make it rain: *Vit. Proc*. 28. He uses the Chaldæan ‘conjunctions’: *Vit. Proc.* 28.
+
+- Porphyry argues that this immortalisation through theurgy is impossible:* de regressu an.* p. 32, 2 (see also 28, 20)* purgatione theurgica  animam  immortalem  non posse fieri*. Numenius does not think humans have a tripartite or double soul, but two separate souls, the rational and irrational; Porph. *ap*. Stob. I 350, 25 f.
+
+- Proclus: On theurgy's precedence over philosophy: [*theol. Plat*.](/book/proclus-theologia-platonica-michael-psellos-psellos) 1.25. On lustration/sprinkling: fr. 133=[*in Crat.*](/book/in-platonis-cratylum-commentaria-bsb-cod-graec-29-proclus) 101, 3-8. On the ‘shape of the light’: fr. 145=*in Crat*. 31, 12-14. Various visions attendant on Chaldæan ritual: [*in rem. pub.*](/book/proclus-in-politiam-platonis-proklos-eis-politeian-tou-proclus) I, 111, 1-12. On the paternal *Nous' symbola* sown throughout the cosmos: fr. 108=*in Crat*. 20, 31-21, 2. On immortalisation of the soul:* in rem. pub.* I, 152, 10: τὸν παρὰ τοῖς θεουργοῖς τῆς ψυχῆς ἀπαθανατισμόν.
+
+- Psellus: On breathing out the soul: fr. 124= *P.G*. 122, 1133 c 9. On the ‘voice of the fire’: fr. 147=*P.G.* 122, 1133 b 5-8. Do not change the *nomina barbara*: Fr 150=*P.G.* 122, 1132 c 1. On animating statues: *P.G*. 122, 1132 a. ‘Those who, by inhaling, drive out the soul, are free’: Fr. 124=P.G. 122, 1144 c 4. The ‘pure, paternal *synthema*’: Fr. 109=Psellus *P.G.* 122, 1148, a 12-14.
+
+### Secondary:
+
+- Dillon and Finnamore, introduction to *Iamblichus. De anima*. Brill, Leiden, 2002. We cite p. 7.
+
+- Johnston 1997 (see below). We cite p. 165.
+
+- Lewy 1978 (see below), we cite pp. 240-60 on Chaldæan fire-visions as manifestations of Hekate.
+
+### Recommended Reading:
+
+- C. Addey. 'The Role of Divine Providence, Will and Love in Iamblichus’ Theory of Theurgic Prayer and Religious Invocation'. In Eugene Afonasin, John Dillon, and John F. Finnamore, editors, *Iamblichus and the Foundations of Late Platonism*, pages 133–150. Brill, Leiden, 2012.
+
+- *Idem*. *Divination and Theurgy in Neoplatonism: Oracles of the Gods*. Ashgate, Dorchester, 2014.
+
+- P. Boyancé. 'Théurgie et télestique néoplatoniciennes'. *Revue de l’histoire des religions*, (147):189–209, 1955.
+
+- E. D. Des Places. *Oracles chaldaïques*. Les Belles Lettres, Paris, 2003.
+
+- E.R. Dodds. 'Theurgy and its Relationship to Neoplatonism'. *Journal of Roman Studies*, 37(1+2):55–69, 1947.
+
+- Álvaro Fernández Fernández. [*La teúrgia de los Oráculos caldeos: cuestiones de léxico y*](https://digibug.ugr.es/handle/10481/20325)
+
+*de contexto historico*. PhD thesis, Universidad de Granada, 2011.
+
+- Sarah Iles Johnston. 'Rising to the Occasion: Theurgical Ascent in its Cultural Milieu'. In P. Schäfer and H.G. Kippenberg, editors, *Envisioning Magic: A Princeton Seminar and Symposium*, pages 165–94. Brill, Leiden, 1997.
+
+- Arien Lecerf, Lucia Saudelli, and Helmut Seng, editors. *Oracles Chaldaïques: fragments et philosophie*. Universitätsverlag Winter, Heidelberg, 2014. [plenty of useful discussions]
+
+- Hans Lewy. *Chaldaean Oracles and Theurgy*. Études Augustiniennes, Paris, 1978.
+
+- Carine van Liefferinge. *La théurgie: des Oracles Chaldaïques à Proclus*. Centre International d’Étude de la Religion Grecque Antique, Liège, 1999.
+
+- Ruth Majercik, editor. *The Chaldean Oracles*. Brill, Leiden, 1989. Greek text based on Des Places (1971) with translation and introduction.
+
+- Gregory Shaw. 'Theurgy: Rituals of Unification in the Neoplatonism of Iamblichus'. *Traditio*, 41:1–28, 1985.
+
+- *Idem*. *Theurgy and the Soul: The Neoplatonism of Iamblichus.* Pennsylvania State University Press, University Park, PA, 1995.
+
+- Anne Sheppard. 'Proclus’ Attitude to Theurgy'. *CQ*, New Series 32(1):212–24, 1982.`,
+};


### PR DESCRIPTION
**Make one episode genuinely good before scaling** (per Derek's steer). Episode 76 *"The Chaldaean Oracles and Theurgy"* now renders Earl Fontainelle's bibliography with the works **we hold turned into inline "read here" links right inside his text** — his authoritative list, our library woven in where he cites each work. The separate "Read in Source Library" list is dropped for linked episodes; the bibliography *is* the integrated experience.

**8 hand-verified links:** Chaldaean Oracles→Patrizi, *civ. dei*→Augustine, *de myst.*→Iamblichus, *Vit. Proc.*→Marinus, *theol. Plat.* / *in Crat.* / *in rem. pub.*→Proclus, Damascius *Dub.*→De principiis. All slugs confirmed live (200).

**Why hand-curated:** the auto-matcher has a "same author, wrong work" failure mode — it mislinked Porphyry's *lost* *de regressu animae* and Damascius' *in Phaedonem* to unrelated same-author texts. Those are left as Earl's plain text rather than shipping a wrong link. This is the exemplar; scaling needs a work-identity-grade matcher (#2318), not author+title fuzzy match.

**UX:** internal `/book/` links render same-tab, rust + book icon (clearly "read here"); Earl's external refs (JSTOR/Wikipedia/cross-episode) muted. New `src/data/shwep-linked-bibliographies.ts` holds one episode; all others fall back to the existing plain bibliography + matched-books list (unchanged).

`tsc` + `check-imports` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)