### PR TITLE
feat(analytics): log AI feature usage + cost (explain, ai-expand, voice)

### DIFF
--- a/src/app/api/embassy/voice/route.ts
+++ b/src/app/api/embassy/voice/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { anonActionGate, SIGNIN_URL } from '@/lib/anon-gate';
+import { logAiUsage } from '@/lib/log-ai-usage';
 
 export const dynamic = 'force-dynamic';
 
@@ -53,6 +54,13 @@ export async function GET(request: Request) {
     }
 
     const data = await res.json();
+    // Usage volume for the voice feature (cost is ElevenLabs, not Gemini, so
+    // no token-based estimate here — this tracks how often it's used).
+    logAiUsage({
+      feature: 'voice',
+      ok: true,
+      country: request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || null,
+    });
     return NextResponse.json({ signedUrl: data.signed_url });
   } catch (err) {
     console.error('[voice] ElevenLabs signed URL error:', err);

--- a/src/app/api/explain/route.ts
+++ b/src/app/api/explain/route.ts
@@ -3,6 +3,7 @@ import { getGeminiClient } from '@/lib/gemini-client';
 import { DEFAULT_MODEL } from '@/lib/types';
 import { MODEL_PRICING } from '@/lib/ai';
 import { withAuth } from '@/lib/auth-helpers';
+import { logAiUsage } from '@/lib/log-ai-usage';
 
 function calculateCost(inputTokens: number, outputTokens: number, model: string): number {
   const pricing = MODEL_PRICING[model] || MODEL_PRICING['default'];
@@ -134,6 +135,7 @@ async function fetchBookContext(bookId: string, currentPage: number): Promise<st
 }
 
 export const POST = withAuth(async (request: NextRequest) => {
+  const _aiStart = Date.now();
   try {
     const body = await request.json();
     const {
@@ -206,6 +208,16 @@ export const POST = withAuth(async (request: NextRequest) => {
     const usageMetadata = response.usageMetadata;
     const inputTokens = usageMetadata?.promptTokenCount || 0;
     const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+    logAiUsage({
+      feature: `explain:${mode}`,
+      model: DEFAULT_MODEL,
+      inputTokens,
+      outputTokens,
+      costUsd: calculateCost(inputTokens, outputTokens, DEFAULT_MODEL),
+      ms: Date.now() - _aiStart,
+      ok: true,
+      country: request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || null,
+    });
 
     // For analyze mode, parse the JSON response
     if (mode === 'analyze') {

--- a/src/app/api/search/ai-expand/route.ts
+++ b/src/app/api/search/ai-expand/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getGeminiClient } from '@/lib/gemini-client';
+import { logAiUsage } from '@/lib/log-ai-usage';
 
 export const preferredRegion = 'fra1';
 
@@ -52,6 +53,8 @@ export async function POST(request: NextRequest) {
     });
   }
 
+  const _aiStart = Date.now();
+  const country = request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || null;
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
     async start(controller) {
@@ -135,6 +138,20 @@ The terms and image_terms are the most important part — they expand the search
             }
           }
         }
+
+        // Log AI usage + cost (usageMetadata is available once the stream drains)
+        try {
+          const meta = (await result.response)?.usageMetadata;
+          logAiUsage({
+            feature: 'ai_search_expand',
+            model: 'gemini-3.1-flash-lite',
+            inputTokens: meta?.promptTokenCount || 0,
+            outputTokens: meta?.candidatesTokenCount || 0,
+            ms: Date.now() - _aiStart,
+            ok: true,
+            country,
+          });
+        } catch { /* never block the stream on logging */ }
 
         // Parse everything from complete text — no streaming narration (avoids tag leaks)
         console.log('[ai-expand] Full output:', JSON.stringify(fullText));

--- a/src/lib/log-ai-usage.ts
+++ b/src/lib/log-ai-usage.ts
@@ -1,0 +1,51 @@
+import { getDb } from '@/lib/mongodb';
+import { MODEL_PRICING } from '@/lib/ai';
+
+/**
+ * Per-call usage + cost logging for user-facing AI features (explain, ai-search
+ * expansion, voice, …). There was no visibility into AI spend on the request
+ * path even though the pipeline is paused over Gemini cost — this fills that gap.
+ * Writes one row per call to the `ai_usage` collection; fire-and-forget so it
+ * never adds latency or fails a request.
+ */
+
+export function estimateCostUsd(model: string, inputTokens = 0, outputTokens = 0): number {
+  const p = MODEL_PRICING[model] || MODEL_PRICING['default'];
+  return (inputTokens / 1_000_000) * p.input + (outputTokens / 1_000_000) * p.output;
+}
+
+interface AiUsage {
+  feature: string;            // 'explain' | 'ai_search_expand' | 'voice' | ...
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;           // if omitted, estimated from model + tokens
+  ms?: number;                // latency
+  ok?: boolean;
+  anon?: boolean;             // unauthenticated caller
+  country?: string | null;
+}
+
+export function logAiUsage(u: AiUsage): void {
+  try {
+    const costUsd = u.costUsd ?? (u.model ? estimateCostUsd(u.model, u.inputTokens, u.outputTokens) : 0);
+    const doc = {
+      ...u,
+      inputTokens: u.inputTokens ?? 0,
+      outputTokens: u.outputTokens ?? 0,
+      costUsd,
+      timestamp: new Date(),
+      created_at: new Date(),
+    };
+    // Don't await — never hold the request on the log write.
+    Promise.race([
+      (async () => {
+        const db = await getDb();
+        await db.collection('ai_usage').insertOne(doc);
+      })(),
+      new Promise((resolve) => setTimeout(resolve, 3000)),
+    ]).catch(() => {});
+  } catch {
+    /* never throw */
+  }
+}


### PR DESCRIPTION
## What
Per-call usage + cost logging for the user-facing AI features, into a new `ai_usage` collection.

## Why
The pipeline is paused over Gemini spend, but the **request-path** AI features (explain, AI search expansion, voice) had no usage or cost visibility at all. `explain` even computed cost already and threw it away.

## Change
- `src/lib/log-ai-usage.ts` — `logAiUsage()` (fire-and-forget, 3s timeout race) + `estimateCostUsd()` reusing the existing `MODEL_PRICING`.
- **explain**: persist the token cost it already calculates (per mode).
- **ai-expand** (streaming): read `usageMetadata` once the stream drains, log tokens + cost.
- **voice**: log usage volume (cost is ElevenLabs, not token-based, so no estimate).
- All country-stamped for per-region cost.

## Result
A queryable `ai_usage` log: calls, tokens, est. cost, latency, by feature and country — so AI spend on the live site is finally observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)