### PR TITLE
feat(analytics): log librarian + voice-search AI cost

### DIFF
--- a/src/app/api/embassy/voice-search/route.ts
+++ b/src/app/api/embassy/voice-search/route.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb';
 import { supabase } from '@/lib/supabase';
 import { CLIP_URL } from '@/lib/clip';
 import { stripAnnotations } from '@/lib/semantic-alignment';
+import { logAiUsage } from '@/lib/log-ai-usage';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -147,6 +148,15 @@ export async function GET(req: NextRequest) {
       sources.slice(0, 4).map((s) => `"${s.title}" by ${s.author}${s.pageNumber ? `, page ${s.pageNumber}` : ''}`).join('; ') + '.' +
       (images.length ? ` ${images.length} illustration${images.length === 1 ? '' : 's'} also found.` : '')
     : 'No matching passages found in the library for that query.';
+
+  // Usage volume for the voice search surface. Its AI cost is Cohere rerank
+  // (inside hybridSearch) + self-hosted CLIP, not Gemini tokens, so we record
+  // occurrence rather than a token-based estimate.
+  logAiUsage({
+    feature: 'voice_search',
+    ok: true,
+    country: req.headers.get('x-vercel-ip-country') || req.headers.get('cf-ipcountry') || null,
+  });
 
   return NextResponse.json({ spoken, found: sources.length, sources, images });
 }

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -1,5 +1,6 @@
 import { getDb } from '@/lib/mongodb';
 import { GoogleGenAI, Type, type FunctionDeclaration } from '@google/genai';
+import { logAiUsage } from '@/lib/log-ai-usage';
 // Atlas keyword + Supabase semantic are now combined in @/lib/search/librarian-search.
 // Atlas-search builders no longer imported here directly.
 import { supabase } from '@/lib/supabase';
@@ -767,6 +768,8 @@ export async function* streamAgenticResponse(
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) throw new Error('GEMINI_API_KEY not set');
 
+  const _t0 = Date.now();
+
   const ai = new GoogleGenAI({ apiKey });
 
   // Load research notebook if thread exists
@@ -940,6 +943,18 @@ export async function* streamAgenticResponse(
       text: `\n\n---\n*A note on sourcing: this answer contains ${clauses.join('; and ')}.*`,
     };
   }
+
+  // Persist AI cost for the librarian — the heaviest request-path AI feature
+  // (agentic, several Gemini calls per turn). usage is already summed across
+  // rounds; thinking tokens bill at the output rate, so fold them in for cost.
+  logAiUsage({
+    feature: 'librarian',
+    model: usage.model,
+    inputTokens: usage.promptTokens,
+    outputTokens: usage.outputTokens + usage.thinkingTokens,
+    ms: Date.now() - _t0,
+    ok: true,
+  });
 
   yield { type: 'usage', usage };
 }


### PR DESCRIPTION
## What
Add the **librarian** (the agentic Gemini chat) and **voice-search** to the `ai_usage` log started in #2599.

## Why
The librarian is the heaviest request-path AI feature — agentic, several Gemini calls per turn — and the biggest cost center (720 messages / 43 distinct users in 30d, growing with the Instagram surge), yet it logged no cost. #2599 covered explain/ai-expand/voice but missed this. Closing it is the difference between 'some AI cost tracked' and 'the AI cost tracked'.

## Change
- **librarian** (`streamAgenticResponse`): it already sums `TurnUsage` across the agentic rounds — persist it via `logAiUsage` (`feature: 'librarian'`, model gemini-3-flash-preview, prompt + output+thinking tokens; thinking bills at the output rate, so folded into output for cost).
- **voice-search**: log a usage-volume row — its AI cost is Cohere rerank (inside `hybridSearch`) + self-hosted CLIP, not Gemini tokens, so occurrence rather than a token estimate.

## Result
`ai_usage` now covers the real spend: librarian (with per-turn token cost), explain, ai-expand, voice, voice-search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)