### PR TITLE
feat(analytics): tag sign-in source (limit-driven vs direct)

### DIFF
--- a/src/app/api/analytics/event/route.ts
+++ b/src/app/api/analytics/event/route.ts
@@ -15,12 +15,12 @@ import { anonymizeIp } from '@/lib/anonymize-ip';
  */
 
 const ALLOWED_EVENTS = new Set([
-  'cite', 'share', 'quote_copy', 'doi_view', 'download',
+  'cite', 'share', 'quote_copy', 'doi_view', 'download', 'signin_view',
 ]);
 
 // Only these prop keys are persisted; everything else is dropped.
 const ALLOWED_PROPS = new Set([
-  'bookId', 'format', 'channel', 'page', 'title', 'url', 'hasDoi', 'edition', 'source',
+  'bookId', 'format', 'channel', 'page', 'title', 'url', 'hasDoi', 'edition', 'source', 'reason',
 ]);
 
 const DB_TIMEOUT_MS = 3000;

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,16 +1,21 @@
 'use client';
 
 import { useSearchParams } from 'next/navigation';
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import { signIn } from 'next-auth/react';
 import Link from 'next/link';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { isInAppBrowser, preferredBrowser, inAppBrowserName } from '@/lib/in-app-browser';
+import { trackEvent } from '@/lib/track-event';
 
 function SignInContent() {
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get('callbackUrl') || '/';
   const error = searchParams.get('error');
+  // 'limit' when arriving from an anon-gate wall (search/librarian/voice tag
+  // their sign-in links with reason=limit); 'direct' otherwise (nav, etc.).
+  // Lets us answer "do people sign in proactively or only when blocked?"
+  const reason = searchParams.get('reason') === 'limit' ? 'limit' : 'direct';
   const [email, setEmail] = useState('');
   const [emailSent, setEmailSent] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -23,6 +28,14 @@ function SignInContent() {
   const [inApp, setInApp] = useState(false);
   const [browser, setBrowser] = useState<'Safari' | 'Chrome'>('Chrome');
   const [appName, setAppName] = useState<string | null>(null);
+  // Log the sign-in page view once, tagged with why they arrived.
+  const loggedView = useRef(false);
+  useEffect(() => {
+    if (loggedView.current) return;
+    loggedView.current = true;
+    trackEvent('signin_view', { reason, source: callbackUrl });
+  }, [reason, callbackUrl]);
+
   useEffect(() => {
     const ua = navigator.userAgent;
     setInApp(isInAppBrowser(ua));

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -405,7 +405,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
           // to sign in (free) to continue.
           updateLastAssistant(m => ({
             ...m,
-            content: 'You\'ve used your free questions for now. [Sign in](/auth/signin?callbackUrl=/librarian) (free) to keep talking with the Librarian — create an account or sign in with Google.',
+            content: 'You\'ve used your free questions for now. [Sign in](/auth/signin?callbackUrl=/librarian&reason=limit) (free) to keep talking with the Librarian — create an account or sign in with Google.',
           }));
         } else {
           updateLastAssistant(m => ({ ...m, content: err.error || 'Something went wrong. Please try again.' }));

--- a/src/app/librarian/voice/VoiceAgentClient.tsx
+++ b/src/app/librarian/voice/VoiceAgentClient.tsx
@@ -282,7 +282,7 @@ function VoiceAgentInner() {
             )}
             {errorMsg && <p className="text-red-300 text-sm mt-5 font-sans max-w-[360px]">{errorMsg}</p>}
             {signInRequired && (
-              <Link href="/auth/signin?callbackUrl=/librarian/voice"
+              <Link href="/auth/signin?callbackUrl=/librarian/voice&reason=limit"
                 className="mt-3 inline-block px-5 py-2.5 rounded-full bg-[#c9a86c]/90 hover:bg-[#c9a86c] text-[#0e0c0a] text-sm font-sans font-medium transition-colors">
                 Sign in &mdash; free
               </Link>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1137,7 +1137,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             <p className="text-secondary mb-6">
               You&rsquo;ve used your free searches for now. Sign in &mdash; it&rsquo;s free &mdash; to keep exploring over 10,000 primary sources.
             </p>
-            <Link href="/auth/signin?callbackUrl=/search"
+            <Link href="/auth/signin?callbackUrl=/search&reason=limit"
               className="inline-block px-6 py-3 rounded-xl bg-accent-rust text-white font-medium hover:bg-accent-rust/90 transition-colors">
               Sign in &mdash; free
             </Link>

--- a/src/lib/track-event.ts
+++ b/src/lib/track-event.ts
@@ -5,7 +5,7 @@
  * keepalive fetch. Never throws — analytics must not break an interaction.
  */
 export function trackEvent(
-  event: 'cite' | 'share' | 'quote_copy' | 'doi_view' | 'download',
+  event: 'cite' | 'share' | 'quote_copy' | 'doi_view' | 'download' | 'signin_view',
   props?: Record<string, string | number | boolean | undefined>,
 ): void {
   if (typeof window === 'undefined') return;


### PR DESCRIPTION
## What
Distinguish **why** someone lands on `/auth/signin`: because they hit an anon-gate limit, or proactively.

## Why
You asked whether people sign in right away or only when they hit a limit. Today it's unanswerable — the gate prompts and the proactive nav links both point to `/auth/signin?callbackUrl=…`, so `callbackUrl` tells us *where* they were, not *why* they came.

## Change
- Tag the three **gate-driven** sign-in links with `reason=limit`: librarian chat wall (`LibrarianClient`), voice wall (`VoiceAgentClient`), search wall (`search/page`). Proactive links stay untagged.
- Log a `signin_view` event on the sign-in page with `reason` (`limit` | `direct`) + `source` (callbackUrl), via the existing `/api/analytics/event` sink (added `signin_view` + `reason` to the allowlists).

## Result
A queryable split of sign-in intent. Forward-only — fills in fast given current traffic; query `analytics_events` `{event:'signin_view'}` grouped by `reason`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)