### PR TITLE
fix(mineru-worker): id-space-agnostic --book lookup

### DIFF
--- a/scripts/workers/mineru-ocr-worker.mjs
+++ b/scripts/workers/mineru-ocr-worker.mjs
@@ -205,7 +205,11 @@ async function processBook(db, book) {
 
   let candidates;
   if (ONE_BOOK) {
-    candidates = await books.find({ _id: (await import('mongodb')).ObjectId.createFromHexString(ONE_BOOK) }).toArray();
+    // id-space-agnostic lookup: this corpus mixes ObjectId `_id`s, string `_id`s,
+    // and a separate string `id` field. Match all so --book works on any book.
+    const or = [{ _id: ONE_BOOK }, { id: ONE_BOOK }];
+    try { or.push({ _id: (await import('mongodb')).ObjectId.createFromHexString(ONE_BOOK) }); } catch { /* not a valid ObjectId hex */ }
+    candidates = await books.find({ $or: or }).toArray();
   } else {
     candidates = await books.find({
       language: /english/i,


### PR DESCRIPTION
## Why
`--book <id>` did `{ _id: ObjectId.createFromHexString(id) }`, which silently matched **nothing** for books whose `_id` is stored as a string. This corpus mixes ObjectId `_id`s, string `_id`s, and a separate string `id` field (the documented id-space hazard). Symptom: `candidates fetched: 0`, book skipped, 0 pages written, **no error** — looked like a no-op.

Hit this running MinerU on the RECITATION-blocked English books (string-`_id` batch): the first test wrote 0 pages until the lookup was made id-space-agnostic.

## Change
Match string `_id`, ObjectId `_id`, and the `id` field via `$or`, so `--book` resolves any book regardless of which id-space it lives in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)