### PR TITLE
feat(prototype): Deep Time — Palaeolithic art gallery (noindex, not public)

### DIFF
--- a/src/app/prototype/prehistoric-art/page.tsx
+++ b/src/app/prototype/prehistoric-art/page.tsx
@@ -1,0 +1,282 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Deep Time: The First Images — prototype · Source Library',
+  description:
+    'A prototype gallery of Palaeolithic art — the oldest surviving images and sculptures made by human hands.',
+  robots: { index: false, follow: false },
+};
+
+/**
+ * PROTOTYPE ONLY — not linked from any public surface, noindex.
+ *
+ * Question being explored: does Palaeolithic art ("the deep time of human
+ * image-making") belong in Source Library, and if so does the `artwork`
+ * content-type / gallery visual language carry it?
+ *
+ * Images are hot-linked from Don Hitchcock's donsmaps.com, which licenses his
+ * photographs under CC BY 4.0 (attribution requested; see his copyright page).
+ * The objects themselves are prehistoric → public domain. Third-party museum
+ * house-rules on object images are a theoretical (low) risk, hence: not public.
+ *
+ * If this graduates to a real feature, these become hidden `content_type:
+ * 'artwork'` DB entries sourced from museum open-access / Wikimedia (cleaner
+ * provenance than a single personal site), with per-image credit. Don's Maps
+ * stays the index/inspiration, not the import target.
+ */
+
+const DONSMAPS = 'https://donsmaps.com';
+
+type Artwork = {
+  id: string;
+  title: string;
+  date: string;
+  site: string;
+  museum: string;
+  medium: string;
+  img: string; // path on donsmaps.com
+  blurb: string;
+};
+
+const ARTWORKS: Artwork[] = [
+  {
+    id: 'lion-man',
+    title: 'The Lion Man (Löwenmensch)',
+    date: 'c. 40,000 BP',
+    site: 'Hohlenstein-Stadel, Germany',
+    museum: 'Museum Ulm',
+    medium: 'Mammoth ivory',
+    img: '/images23/lionladyrect.jpg',
+    blurb:
+      'A standing figure with a lion’s head — the oldest known representation of a being that never existed. Roughly 300 hours of carving with a flint blade, made when the last ice age was at its coldest.',
+  },
+  {
+    id: 'hohle-fels',
+    title: 'Venus of Hohle Fels',
+    date: 'c. 35,000–40,000 BP',
+    site: 'Hohle Fels Cave, Germany',
+    museum: 'Urgeschichtliches Museum, Blaubeuren',
+    medium: 'Mammoth ivory',
+    img: '/images14/hohlefelsrect.jpg',
+    blurb:
+      'The oldest undisputed depiction of a human being yet found. A carved ring in place of a head suggests it was worn as a pendant.',
+  },
+  {
+    id: 'adorant',
+    title: 'The Adorant (Worshipper)',
+    date: 'c. 40,000 BP',
+    site: 'Geißenklösterle, Germany',
+    museum: 'Württembergisches Landesmuseum',
+    medium: 'Carved ivory relief',
+    img: '/images24/adorantrect.jpg',
+    blurb:
+      'A tiny relief of a figure with raised arms. On the reverse, rows of incised notches may be one of the earliest attempts at a calendar or tally.',
+  },
+  {
+    id: 'willendorf',
+    title: 'Venus of Willendorf',
+    date: 'c. 28,000 BP',
+    site: 'Willendorf, Austria',
+    museum: 'Naturhistorisches Museum, Vienna',
+    medium: 'Oolitic limestone, traces of red ochre',
+    img: '/clickphotos/venusw200x100.jpg',
+    blurb:
+      'The most famous Palaeolithic figurine. The stone is not local — it travelled, or its maker did — and was once coloured with red ochre.',
+  },
+  {
+    id: 'lespugue',
+    title: 'Venus of Lespugue',
+    date: 'c. 24,000–26,000 BP',
+    site: 'Rideaux Cave, Lespugue, France',
+    museum: 'Musée de l’Homme, Paris',
+    medium: 'Tusk ivory',
+    img: '/images23/lespuguerect.jpg',
+    blurb:
+      'Carved with a near-geometric symmetry that fascinated 20th-century artists — Picasso kept two casts of it in his studio.',
+  },
+  {
+    id: 'dolni-vestonice',
+    title: 'Venus of Dolní Věstonice',
+    date: 'c. 25,000–29,000 BP',
+    site: 'Dolní Věstonice, Moravia',
+    museum: 'Pavilon Anthropos, Brno',
+    medium: 'Fired clay',
+    img: '/clickphotos/dolni200x100.jpg',
+    blurb:
+      'Among the oldest known ceramics anywhere — fired more than ten thousand years before pottery vessels existed. A fingerprint of a child is baked into a nearby fragment.',
+  },
+  {
+    id: 'brassempouy',
+    title: 'The Lady of Brassempouy',
+    date: 'c. 25,000 BP',
+    site: 'Brassempouy, France',
+    museum: 'Musée d’Archéologie Nationale',
+    medium: 'Mammoth ivory',
+    img: '/clickphotos/ayla200x100.jpg',
+    blurb:
+      'One of the earliest realistic representations of a human face — a hood or hairstyle rendered in fine cross-hatching above calm, deliberate features.',
+  },
+  {
+    id: 'laussel',
+    title: 'Venus of Laussel',
+    date: 'c. 22,000–27,000 BP',
+    site: 'Laussel, Dordogne, France',
+    museum: 'Musée d’Aquitaine, Bordeaux',
+    medium: 'Limestone bas-relief',
+    img: '/images23/lausselrect.jpg',
+    blurb:
+      'A figure carved into a rock shelter wall, holding a crescent — possibly a horn — incised with thirteen marks, read by some as a lunar count.',
+  },
+  {
+    id: 'menton',
+    title: 'Venus of Menton',
+    date: 'c. 23,000 BP',
+    site: 'Barma Grande, Grimaldi',
+    museum: 'Musée d’Archéologie Nationale',
+    medium: 'Yellow steatite',
+    img: '/images24/mentonrect.jpg',
+    blurb:
+      'One of the Balzi Rossi figurines from the Italian–French Riviera caves — a series carved in soft, jewel-coloured stones.',
+  },
+  {
+    id: 'double-venus',
+    title: 'The Double Venus',
+    date: 'c. 23,000 BP',
+    site: 'Balzi Rossi, Italy',
+    museum: 'Private collection',
+    medium: 'Serpentine',
+    img: '/images24/doublerect.jpg',
+    blurb:
+      'Two figures sharing a single body, carved from green serpentine — an early image of pairing, or of two states of one being.',
+  },
+  {
+    id: 'hohle-phallus',
+    title: 'The Hohle Fels Phallus',
+    date: 'c. 28,000 BP',
+    site: 'Hohle Fels Cave, Germany',
+    museum: 'Urgeschichtliches Museum, Blaubeuren',
+    medium: 'Polished siltstone',
+    img: '/images26/hohlephallusrect.jpg',
+    blurb:
+      'A finely polished stone, reassembled from fragments — one of the oldest unambiguous representations of male anatomy, and possibly also a tool.',
+  },
+  {
+    id: 'berekhat-ram',
+    title: 'The Berekhat Ram Figure',
+    date: 'c. 230,000+ BP',
+    site: 'Berekhat Ram, Golan Heights',
+    museum: 'Hebrew University of Jerusalem',
+    medium: 'Modified volcanic pebble',
+    img: '/images26/berekhatrect.jpg',
+    blurb:
+      'A pebble whose natural shape suggests a figure, deliberately enhanced with a few grooves — possibly made by Homo erectus, which would make it almost ten times older than anything else here.',
+  },
+];
+
+export default function PrehistoricArtPrototype() {
+  return (
+    <div className="min-h-screen bg-[#0d0c0b] text-stone-200">
+      <div className="mx-auto max-w-6xl px-5 py-12 sm:px-8 sm:py-16">
+        {/* Prototype banner */}
+        <div className="mb-10 rounded-lg border border-amber-500/25 bg-amber-500/[0.06] px-4 py-3 text-xs text-amber-200/80">
+          <span className="font-semibold text-amber-200">Prototype</span> — not
+          public, not indexed. Exploring whether Palaeolithic art belongs in
+          Source Library. Images © Don Hitchcock,{' '}
+          <a
+            href="https://donsmaps.com"
+            className="underline hover:text-amber-100"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            donsmaps.com
+          </a>
+          , reused under CC BY 4.0.
+        </div>
+
+        {/* Header */}
+        <header className="mb-12 max-w-2xl">
+          <p className="mb-3 text-xs font-medium uppercase tracking-[0.2em] text-stone-500">
+            The deep time of human image-making
+          </p>
+          <h1 className="font-serif text-4xl leading-tight text-stone-100 sm:text-5xl">
+            Deep Time: The First Images
+          </h1>
+          <p className="mt-5 text-base leading-relaxed text-stone-400">
+            Before writing, before the city, before the wheel — people carved
+            faces, bodies, and impossible beings from ivory and stone. These are
+            among the oldest surviving works of human imagination, made across
+            forty thousand years of the last ice age. Source Library is built
+            around the read-and-quote experience of historical texts; this asks
+            what it would mean to hold the images that came before any text at
+            all.
+          </p>
+        </header>
+
+        {/* Grid */}
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {ARTWORKS.map((a) => (
+            <figure
+              key={a.id}
+              className="group overflow-hidden rounded-xl bg-[#161412] ring-1 ring-white/10 transition-all hover:ring-white/25"
+            >
+              <div className="relative aspect-[4/3] overflow-hidden bg-black">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={`${DONSMAPS}${a.img}`}
+                  alt={a.title}
+                  loading="lazy"
+                  className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                />
+              </div>
+              <figcaption className="p-4">
+                <div className="flex items-baseline justify-between gap-3">
+                  <h2 className="font-serif text-lg text-stone-100">
+                    {a.title}
+                  </h2>
+                  <span className="shrink-0 font-mono text-xs tabular-nums text-amber-300/70">
+                    {a.date}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-stone-500">
+                  {a.site} · {a.medium}
+                </p>
+                <p className="mt-3 text-sm leading-relaxed text-stone-400">
+                  {a.blurb}
+                </p>
+                <p className="mt-3 text-[11px] uppercase tracking-wide text-stone-600">
+                  {a.museum}
+                </p>
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+
+        {/* Footer note */}
+        <footer className="mt-14 border-t border-white/10 pt-6 text-sm text-stone-500">
+          <p>
+            All photographs by Don Hitchcock and reproduced under{' '}
+            <a
+              href="https://creativecommons.org/licenses/by/4.0/"
+              className="underline hover:text-stone-300"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              CC BY 4.0
+            </a>{' '}
+            from{' '}
+            <a
+              href="https://donsmaps.com"
+              className="underline hover:text-stone-300"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Don’s Maps
+            </a>
+            , a remarkable independent archive of Palaeolithic archaeology. The
+            artefacts depicted are public domain by virtue of age.
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/app/prototype/prehistoric-art/page.tsx
+++ b/src/app/prototype/prehistoric-art/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import data from './provenance.json';
 
 export const metadata: Metadata = {
   title: 'Deep Time: The First Images — prototype · Source Library',
@@ -14,230 +15,23 @@ export const metadata: Metadata = {
  * image-making") belong in Source Library, and if so does the `artwork`
  * content-type / gallery visual language carry it?
  *
- * Images are self-hosted on R2 under prototype/prehistoric-art/<id>.jpg,
- * mirrored from Don Hitchcock's donsmaps.com (photographs licensed CC BY 4.0;
- * attribution requested). Mirror script: scripts/_tmp_mirror_prehistoric.mjs.
- * The objects themselves are prehistoric → public domain. Third-party museum
- * house-rules on object images are a theoretical (low) risk, hence: not public.
- *
- * If this graduates to a real feature, these become hidden `content_type:
- * 'artwork'` DB entries sourced from museum open-access / Wikimedia (cleaner
- * provenance than a single personal site), with per-image credit. Don's Maps
- * stays the index/inspiration, not the import target.
+ * All metadata + provenance lives in ./provenance.json (single source of truth,
+ * models how these would be stored as content_type:'artwork' DB entries). Images
+ * are self-hosted on R2 (prototype/prehistoric-art/<id>.jpg), mirrored from Don
+ * Hitchcock's donsmaps.com (photographs CC BY 4.0). Mirror script:
+ * scripts/_tmp_mirror_prehistoric.mjs. The depicted objects are public domain
+ * by age. If this graduates, source from museum open-access / Wikimedia for
+ * cleaner provenance; Don's Maps stays the index, not the import target.
  */
 
-const R2 = 'https://images.sourcelibrary.org/prototype/prehistoric-art';
-const imgUrl = (id: string) => `${R2}/${id}.jpg`;
+const D = data.defaults;
+const imgUrl = (id: string) => `${D.r2Base}/${id}.jpg`;
 
-type Artwork = {
-  id: string;
-  title: string;
-  date: string;
-  site: string;
-  museum: string;
-  medium: string;
-  blurb: string;
-};
+type Work = (typeof data.works)[number];
 
-const FIGURINES: Artwork[] = [
-  {
-    id: 'lion-man',
-    title: 'The Lion Man (Löwenmensch)',
-    date: 'c. 40,000 BP',
-    site: 'Hohlenstein-Stadel, Germany',
-    museum: 'Museum Ulm',
-    medium: 'Mammoth ivory',
-    blurb:
-      'A standing figure with a lion’s head — the oldest known representation of a being that never existed. Roughly 300 hours of carving with a flint blade, made when the last ice age was at its coldest.',
-  },
-  {
-    id: 'hohle-fels',
-    title: 'Venus of Hohle Fels',
-    date: 'c. 35,000–40,000 BP',
-    site: 'Hohle Fels Cave, Germany',
-    museum: 'Urgeschichtliches Museum, Blaubeuren',
-    medium: 'Mammoth ivory',
-    blurb:
-      'The oldest undisputed depiction of a human being yet found. A carved ring in place of a head suggests it was worn as a pendant.',
-  },
-  {
-    id: 'adorant',
-    title: 'The Adorant (Worshipper)',
-    date: 'c. 40,000 BP',
-    site: 'Geißenklösterle, Germany',
-    museum: 'Württembergisches Landesmuseum',
-    medium: 'Carved ivory relief',
-    blurb:
-      'A tiny relief of a figure with raised arms. On the reverse, rows of incised notches may be one of the earliest attempts at a calendar or tally.',
-  },
-  {
-    id: 'willendorf',
-    title: 'Venus of Willendorf',
-    date: 'c. 28,000 BP',
-    site: 'Willendorf, Austria',
-    museum: 'Naturhistorisches Museum, Vienna',
-    medium: 'Oolitic limestone, traces of red ochre',
-    blurb:
-      'The most famous Palaeolithic figurine. The stone is not local — it travelled, or its maker did — and was once coloured with red ochre.',
-  },
-  {
-    id: 'lespugue',
-    title: 'Venus of Lespugue',
-    date: 'c. 24,000–26,000 BP',
-    site: 'Rideaux Cave, Lespugue, France',
-    museum: 'Musée de l’Homme, Paris',
-    medium: 'Tusk ivory',
-    blurb:
-      'Carved with a near-geometric symmetry that fascinated 20th-century artists — Picasso kept two casts of it in his studio.',
-  },
-  {
-    id: 'dolni-vestonice',
-    title: 'Venus of Dolní Věstonice',
-    date: 'c. 25,000–29,000 BP',
-    site: 'Dolní Věstonice, Moravia',
-    museum: 'Pavilon Anthropos, Brno',
-    medium: 'Fired clay',
-    blurb:
-      'Among the oldest known ceramics anywhere — fired more than ten thousand years before pottery vessels existed. A fingerprint of a child is baked into a nearby fragment.',
-  },
-  {
-    id: 'brassempouy',
-    title: 'The Lady of Brassempouy',
-    date: 'c. 25,000 BP',
-    site: 'Brassempouy, France',
-    museum: 'Musée d’Archéologie Nationale',
-    medium: 'Mammoth ivory',
-    blurb:
-      'One of the earliest realistic representations of a human face — a hood or hairstyle rendered in fine cross-hatching above calm, deliberate features.',
-  },
-  {
-    id: 'laussel',
-    title: 'Venus of Laussel',
-    date: 'c. 22,000–27,000 BP',
-    site: 'Laussel, Dordogne, France',
-    museum: 'Musée d’Aquitaine, Bordeaux',
-    medium: 'Limestone bas-relief',
-    blurb:
-      'A figure carved into a rock shelter wall, holding a crescent — possibly a horn — incised with thirteen marks, read by some as a lunar count.',
-  },
-  {
-    id: 'menton',
-    title: 'Venus of Menton',
-    date: 'c. 23,000 BP',
-    site: 'Barma Grande, Grimaldi',
-    museum: 'Musée d’Archéologie Nationale',
-    medium: 'Yellow steatite',
-    blurb:
-      'One of the Balzi Rossi figurines from the Italian–French Riviera caves — a series carved in soft, jewel-coloured stones.',
-  },
-  {
-    id: 'double-venus',
-    title: 'The Double Venus',
-    date: 'c. 23,000 BP',
-    site: 'Balzi Rossi, Italy',
-    museum: 'Private collection',
-    medium: 'Serpentine',
-    blurb:
-      'Two figures sharing a single body, carved from green serpentine — an early image of pairing, or of two states of one being.',
-  },
-  {
-    id: 'hohle-phallus',
-    title: 'The Hohle Fels Phallus',
-    date: 'c. 28,000 BP',
-    site: 'Hohle Fels Cave, Germany',
-    museum: 'Urgeschichtliches Museum, Blaubeuren',
-    medium: 'Polished siltstone',
-    blurb:
-      'A finely polished stone, reassembled from fragments — one of the oldest unambiguous representations of male anatomy, and possibly also a tool.',
-  },
-  {
-    id: 'berekhat-ram',
-    title: 'The Berekhat Ram Figure',
-    date: 'c. 230,000+ BP',
-    site: 'Berekhat Ram, Golan Heights',
-    museum: 'Hebrew University of Jerusalem',
-    medium: 'Modified volcanic pebble',
-    blurb:
-      'A pebble whose natural shape suggests a figure, deliberately enhanced with a few grooves — possibly made by Homo erectus, which would make it almost ten times older than anything else here.',
-  },
-];
-
-const CAVE_PAINTINGS: Artwork[] = [
-  {
-    id: 'chauvet-horses',
-    title: 'Panel of the Horses',
-    date: 'c. 36,000 BP',
-    site: 'Chauvet Cave, Ardèche, France',
-    museum: 'In situ (UNESCO World Heritage)',
-    medium: 'Charcoal on limestone',
-    blurb:
-      'Four horses’ heads drawn in overlapping profile, with stumping and shading to model the muzzles — perspective and volume tens of thousands of years before either was “invented.”',
-  },
-  {
-    id: 'chauvet-handprints',
-    title: 'Panel of Hand Prints',
-    date: 'c. 36,000 BP',
-    site: 'Chauvet Cave, Ardèche, France',
-    museum: 'In situ (UNESCO World Heritage)',
-    medium: 'Red ochre on limestone',
-    blurb:
-      'Hands pressed and stencilled onto the wall — the most direct trace any of these makers left: the print of a living hand, held up in the dark.',
-  },
-  {
-    id: 'lascaux-bulls',
-    title: 'The Hall of the Bulls',
-    date: 'c. 17,300 BP',
-    site: 'Lascaux, Dordogne, France',
-    museum: 'In situ (closed; replica Lascaux IV)',
-    medium: 'Ochre and manganese on limestone',
-    blurb:
-      'A frieze of aurochs, horses and stags wrapping a chamber, including the enigmatic spotted “unicorn.” One of the supreme achievements of ice-age painting.',
-  },
-  {
-    id: 'lascaux-black-bull',
-    title: 'The Great Black Bull',
-    date: 'c. 17,300 BP',
-    site: 'Lascaux (Axial Gallery), France',
-    museum: 'In situ (closed; replica Lascaux IV)',
-    medium: 'Manganese pigment on limestone',
-    blurb:
-      'At 3.7 metres long, the largest single figure at Lascaux — its body left as bare rock, its outline and head rendered in dense black.',
-  },
-  {
-    id: 'lascaux-shaft',
-    title: 'The Shaft Scene',
-    date: 'c. 17,300 BP',
-    site: 'Lascaux (the Well), France',
-    museum: 'In situ (closed; replica Lascaux IV)',
-    medium: 'Pigment on limestone',
-    blurb:
-      'A disembowelled bison, a bird-headed falling man, a spear, a rhinoceros — the most argued-over image in all of cave art, and a candidate for the oldest narrative scene.',
-  },
-  {
-    id: 'altamira-ceiling',
-    title: 'The Polychrome Ceiling',
-    date: 'c. 15,000–22,000 BP',
-    site: 'Altamira, Cantabria, Spain',
-    museum: 'In situ (Museo de Altamira)',
-    medium: 'Ochre, haematite and charcoal',
-    blurb:
-      'A herd of bison painted across a low ceiling, the artists using the rock’s natural bulges to give each animal a three-dimensional swell. Dismissed as a forgery when first published in 1880 — too good to be ancient.',
-  },
-  {
-    id: 'altamira-bison',
-    title: 'Polychrome Bison (detail)',
-    date: 'c. 15,000–22,000 BP',
-    site: 'Altamira, Cantabria, Spain',
-    museum: 'In situ (Museo de Altamira)',
-    medium: 'Ochre, haematite and charcoal',
-    blurb:
-      'A single curled bison from the great ceiling — pigment diluted to grade from deep red to soft brown, conjuring muscle and weight out of stone.',
-  },
-];
-
-function Card({ a }: { a: Artwork }) {
+function Card({ a }: { a: Work }) {
   return (
-    <figure className="group overflow-hidden rounded-xl bg-[#161412] ring-1 ring-white/10 transition-all hover:ring-white/25">
+    <figure className="group flex flex-col overflow-hidden rounded-xl bg-[#161412] ring-1 ring-white/10 transition-all hover:ring-white/25">
       <div className="relative aspect-[4/3] overflow-hidden bg-black">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
@@ -246,8 +40,11 @@ function Card({ a }: { a: Artwork }) {
           loading="lazy"
           className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
         />
+        <span className="absolute left-2.5 top-2.5 rounded-full bg-black/55 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-200/80 backdrop-blur">
+          {a.period}
+        </span>
       </div>
-      <figcaption className="p-4">
+      <figcaption className="flex flex-1 flex-col p-4">
         <div className="flex items-baseline justify-between gap-3">
           <h3 className="font-serif text-lg text-stone-100">{a.title}</h3>
           <span className="shrink-0 font-mono text-xs tabular-nums text-amber-300/70">
@@ -256,17 +53,45 @@ function Card({ a }: { a: Artwork }) {
         </div>
         <p className="mt-1 text-xs text-stone-500">
           {a.site} · {a.medium}
+          {a.dimensions ? ` · ${a.dimensions}` : ''}
         </p>
         <p className="mt-3 text-sm leading-relaxed text-stone-400">{a.blurb}</p>
         <p className="mt-3 text-[11px] uppercase tracking-wide text-stone-600">
           {a.museum}
         </p>
+
+        {/* Provenance footer */}
+        <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-white/[0.06] pt-3 text-[11px] text-stone-500">
+          <a
+            href={a.object.reference}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline decoration-stone-700 underline-offset-2 hover:text-stone-300"
+          >
+            Reference
+          </a>
+          <a
+            href={a.image.documentationPage}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline decoration-stone-700 underline-offset-2 hover:text-stone-300"
+          >
+            Source
+          </a>
+          <span className="text-stone-600">
+            Photo: {D.photographer} · CC BY 4.0
+          </span>
+        </div>
       </figcaption>
     </figure>
   );
 }
 
 export default function PrehistoricArtPrototype() {
+  const works = data.works as Work[];
+  const figurines = works.filter((w) => w.category === 'figurine');
+  const caves = works.filter((w) => w.category === 'cave-painting');
+
   return (
     <div className="min-h-screen bg-[#0d0c0b] text-stone-200">
       <div className="mx-auto max-w-6xl px-5 py-12 sm:px-8 sm:py-16">
@@ -276,14 +101,14 @@ export default function PrehistoricArtPrototype() {
           public, not indexed. Exploring whether Palaeolithic art belongs in
           Source Library. Images © Don Hitchcock,{' '}
           <a
-            href="https://donsmaps.com"
+            href={D.photographerSite}
             className="underline hover:text-amber-100"
             target="_blank"
             rel="noopener noreferrer"
           >
             donsmaps.com
           </a>
-          , reused under CC BY 4.0.
+          , reused under CC BY 4.0; depicted objects are public domain by age.
         </div>
 
         {/* Header */}
@@ -314,7 +139,7 @@ export default function PrehistoricArtPrototype() {
             Ivory, stone and fired clay — the oldest sculptures in the world.
           </p>
           <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {FIGURINES.map((a) => (
+            {figurines.map((a) => (
               <Card key={a.id} a={a} />
             ))}
           </div>
@@ -329,18 +154,19 @@ export default function PrehistoricArtPrototype() {
             Animals and signs drawn by firelight, deep underground.
           </p>
           <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {CAVE_PAINTINGS.map((a) => (
+            {caves.map((a) => (
               <Card key={a.id} a={a} />
             ))}
           </div>
         </section>
 
-        {/* Footer note */}
+        {/* Footer / provenance note */}
         <footer className="mt-14 border-t border-white/10 pt-6 text-sm text-stone-500">
           <p>
-            All photographs by Don Hitchcock, mirrored with attribution under{' '}
+            {works.length} works. All photographs by {D.photographer}, mirrored
+            with attribution under{' '}
             <a
-              href="https://creativecommons.org/licenses/by/4.0/"
+              href={D.licenseUrl}
               className="underline hover:text-stone-300"
               target="_blank"
               rel="noopener noreferrer"
@@ -349,15 +175,18 @@ export default function PrehistoricArtPrototype() {
             </a>{' '}
             from{' '}
             <a
-              href="https://donsmaps.com"
+              href={D.photographerSite}
               className="underline hover:text-stone-300"
               target="_blank"
               rel="noopener noreferrer"
             >
               Don’s Maps
             </a>
-            , a remarkable independent archive of Palaeolithic archaeology. The
-            artefacts and paintings depicted are public domain by virtue of age.
+            , a remarkable independent archive of Palaeolithic archaeology. Each
+            card links to the object’s encyclopaedia entry (“Reference”) and the
+            donsmaps documentation page (“Source”). The artefacts and paintings
+            depicted are public domain by virtue of age. Full machine-readable
+            provenance: <code className="text-stone-400">provenance.json</code>.
           </p>
         </footer>
       </div>

--- a/src/app/prototype/prehistoric-art/page.tsx
+++ b/src/app/prototype/prehistoric-art/page.tsx
@@ -14,8 +14,9 @@ export const metadata: Metadata = {
  * image-making") belong in Source Library, and if so does the `artwork`
  * content-type / gallery visual language carry it?
  *
- * Images are hot-linked from Don Hitchcock's donsmaps.com, which licenses his
- * photographs under CC BY 4.0 (attribution requested; see his copyright page).
+ * Images are self-hosted on R2 under prototype/prehistoric-art/<id>.jpg,
+ * mirrored from Don Hitchcock's donsmaps.com (photographs licensed CC BY 4.0;
+ * attribution requested). Mirror script: scripts/_tmp_mirror_prehistoric.mjs.
  * The objects themselves are prehistoric → public domain. Third-party museum
  * house-rules on object images are a theoretical (low) risk, hence: not public.
  *
@@ -25,7 +26,8 @@ export const metadata: Metadata = {
  * stays the index/inspiration, not the import target.
  */
 
-const DONSMAPS = 'https://donsmaps.com';
+const R2 = 'https://images.sourcelibrary.org/prototype/prehistoric-art';
+const imgUrl = (id: string) => `${R2}/${id}.jpg`;
 
 type Artwork = {
   id: string;
@@ -34,11 +36,10 @@ type Artwork = {
   site: string;
   museum: string;
   medium: string;
-  img: string; // path on donsmaps.com
   blurb: string;
 };
 
-const ARTWORKS: Artwork[] = [
+const FIGURINES: Artwork[] = [
   {
     id: 'lion-man',
     title: 'The Lion Man (Löwenmensch)',
@@ -46,7 +47,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Hohlenstein-Stadel, Germany',
     museum: 'Museum Ulm',
     medium: 'Mammoth ivory',
-    img: '/images23/lionladyrect.jpg',
     blurb:
       'A standing figure with a lion’s head — the oldest known representation of a being that never existed. Roughly 300 hours of carving with a flint blade, made when the last ice age was at its coldest.',
   },
@@ -57,7 +57,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Hohle Fels Cave, Germany',
     museum: 'Urgeschichtliches Museum, Blaubeuren',
     medium: 'Mammoth ivory',
-    img: '/images14/hohlefelsrect.jpg',
     blurb:
       'The oldest undisputed depiction of a human being yet found. A carved ring in place of a head suggests it was worn as a pendant.',
   },
@@ -68,7 +67,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Geißenklösterle, Germany',
     museum: 'Württembergisches Landesmuseum',
     medium: 'Carved ivory relief',
-    img: '/images24/adorantrect.jpg',
     blurb:
       'A tiny relief of a figure with raised arms. On the reverse, rows of incised notches may be one of the earliest attempts at a calendar or tally.',
   },
@@ -79,7 +77,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Willendorf, Austria',
     museum: 'Naturhistorisches Museum, Vienna',
     medium: 'Oolitic limestone, traces of red ochre',
-    img: '/clickphotos/venusw200x100.jpg',
     blurb:
       'The most famous Palaeolithic figurine. The stone is not local — it travelled, or its maker did — and was once coloured with red ochre.',
   },
@@ -90,7 +87,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Rideaux Cave, Lespugue, France',
     museum: 'Musée de l’Homme, Paris',
     medium: 'Tusk ivory',
-    img: '/images23/lespuguerect.jpg',
     blurb:
       'Carved with a near-geometric symmetry that fascinated 20th-century artists — Picasso kept two casts of it in his studio.',
   },
@@ -101,7 +97,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Dolní Věstonice, Moravia',
     museum: 'Pavilon Anthropos, Brno',
     medium: 'Fired clay',
-    img: '/clickphotos/dolni200x100.jpg',
     blurb:
       'Among the oldest known ceramics anywhere — fired more than ten thousand years before pottery vessels existed. A fingerprint of a child is baked into a nearby fragment.',
   },
@@ -112,7 +107,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Brassempouy, France',
     museum: 'Musée d’Archéologie Nationale',
     medium: 'Mammoth ivory',
-    img: '/clickphotos/ayla200x100.jpg',
     blurb:
       'One of the earliest realistic representations of a human face — a hood or hairstyle rendered in fine cross-hatching above calm, deliberate features.',
   },
@@ -123,7 +117,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Laussel, Dordogne, France',
     museum: 'Musée d’Aquitaine, Bordeaux',
     medium: 'Limestone bas-relief',
-    img: '/images23/lausselrect.jpg',
     blurb:
       'A figure carved into a rock shelter wall, holding a crescent — possibly a horn — incised with thirteen marks, read by some as a lunar count.',
   },
@@ -134,7 +127,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Barma Grande, Grimaldi',
     museum: 'Musée d’Archéologie Nationale',
     medium: 'Yellow steatite',
-    img: '/images24/mentonrect.jpg',
     blurb:
       'One of the Balzi Rossi figurines from the Italian–French Riviera caves — a series carved in soft, jewel-coloured stones.',
   },
@@ -145,7 +137,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Balzi Rossi, Italy',
     museum: 'Private collection',
     medium: 'Serpentine',
-    img: '/images24/doublerect.jpg',
     blurb:
       'Two figures sharing a single body, carved from green serpentine — an early image of pairing, or of two states of one being.',
   },
@@ -156,7 +147,6 @@ const ARTWORKS: Artwork[] = [
     site: 'Hohle Fels Cave, Germany',
     museum: 'Urgeschichtliches Museum, Blaubeuren',
     medium: 'Polished siltstone',
-    img: '/images26/hohlephallusrect.jpg',
     blurb:
       'A finely polished stone, reassembled from fragments — one of the oldest unambiguous representations of male anatomy, and possibly also a tool.',
   },
@@ -167,11 +157,114 @@ const ARTWORKS: Artwork[] = [
     site: 'Berekhat Ram, Golan Heights',
     museum: 'Hebrew University of Jerusalem',
     medium: 'Modified volcanic pebble',
-    img: '/images26/berekhatrect.jpg',
     blurb:
       'A pebble whose natural shape suggests a figure, deliberately enhanced with a few grooves — possibly made by Homo erectus, which would make it almost ten times older than anything else here.',
   },
 ];
+
+const CAVE_PAINTINGS: Artwork[] = [
+  {
+    id: 'chauvet-horses',
+    title: 'Panel of the Horses',
+    date: 'c. 36,000 BP',
+    site: 'Chauvet Cave, Ardèche, France',
+    museum: 'In situ (UNESCO World Heritage)',
+    medium: 'Charcoal on limestone',
+    blurb:
+      'Four horses’ heads drawn in overlapping profile, with stumping and shading to model the muzzles — perspective and volume tens of thousands of years before either was “invented.”',
+  },
+  {
+    id: 'chauvet-handprints',
+    title: 'Panel of Hand Prints',
+    date: 'c. 36,000 BP',
+    site: 'Chauvet Cave, Ardèche, France',
+    museum: 'In situ (UNESCO World Heritage)',
+    medium: 'Red ochre on limestone',
+    blurb:
+      'Hands pressed and stencilled onto the wall — the most direct trace any of these makers left: the print of a living hand, held up in the dark.',
+  },
+  {
+    id: 'lascaux-bulls',
+    title: 'The Hall of the Bulls',
+    date: 'c. 17,300 BP',
+    site: 'Lascaux, Dordogne, France',
+    museum: 'In situ (closed; replica Lascaux IV)',
+    medium: 'Ochre and manganese on limestone',
+    blurb:
+      'A frieze of aurochs, horses and stags wrapping a chamber, including the enigmatic spotted “unicorn.” One of the supreme achievements of ice-age painting.',
+  },
+  {
+    id: 'lascaux-black-bull',
+    title: 'The Great Black Bull',
+    date: 'c. 17,300 BP',
+    site: 'Lascaux (Axial Gallery), France',
+    museum: 'In situ (closed; replica Lascaux IV)',
+    medium: 'Manganese pigment on limestone',
+    blurb:
+      'At 3.7 metres long, the largest single figure at Lascaux — its body left as bare rock, its outline and head rendered in dense black.',
+  },
+  {
+    id: 'lascaux-shaft',
+    title: 'The Shaft Scene',
+    date: 'c. 17,300 BP',
+    site: 'Lascaux (the Well), France',
+    museum: 'In situ (closed; replica Lascaux IV)',
+    medium: 'Pigment on limestone',
+    blurb:
+      'A disembowelled bison, a bird-headed falling man, a spear, a rhinoceros — the most argued-over image in all of cave art, and a candidate for the oldest narrative scene.',
+  },
+  {
+    id: 'altamira-ceiling',
+    title: 'The Polychrome Ceiling',
+    date: 'c. 15,000–22,000 BP',
+    site: 'Altamira, Cantabria, Spain',
+    museum: 'In situ (Museo de Altamira)',
+    medium: 'Ochre, haematite and charcoal',
+    blurb:
+      'A herd of bison painted across a low ceiling, the artists using the rock’s natural bulges to give each animal a three-dimensional swell. Dismissed as a forgery when first published in 1880 — too good to be ancient.',
+  },
+  {
+    id: 'altamira-bison',
+    title: 'Polychrome Bison (detail)',
+    date: 'c. 15,000–22,000 BP',
+    site: 'Altamira, Cantabria, Spain',
+    museum: 'In situ (Museo de Altamira)',
+    medium: 'Ochre, haematite and charcoal',
+    blurb:
+      'A single curled bison from the great ceiling — pigment diluted to grade from deep red to soft brown, conjuring muscle and weight out of stone.',
+  },
+];
+
+function Card({ a }: { a: Artwork }) {
+  return (
+    <figure className="group overflow-hidden rounded-xl bg-[#161412] ring-1 ring-white/10 transition-all hover:ring-white/25">
+      <div className="relative aspect-[4/3] overflow-hidden bg-black">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={imgUrl(a.id)}
+          alt={a.title}
+          loading="lazy"
+          className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+        />
+      </div>
+      <figcaption className="p-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <h3 className="font-serif text-lg text-stone-100">{a.title}</h3>
+          <span className="shrink-0 font-mono text-xs tabular-nums text-amber-300/70">
+            {a.date}
+          </span>
+        </div>
+        <p className="mt-1 text-xs text-stone-500">
+          {a.site} · {a.medium}
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-stone-400">{a.blurb}</p>
+        <p className="mt-3 text-[11px] uppercase tracking-wide text-stone-600">
+          {a.museum}
+        </p>
+      </figcaption>
+    </figure>
+  );
+}
 
 export default function PrehistoricArtPrototype() {
   return (
@@ -203,58 +296,49 @@ export default function PrehistoricArtPrototype() {
           </h1>
           <p className="mt-5 text-base leading-relaxed text-stone-400">
             Before writing, before the city, before the wheel — people carved
-            faces, bodies, and impossible beings from ivory and stone. These are
-            among the oldest surviving works of human imagination, made across
-            forty thousand years of the last ice age. Source Library is built
-            around the read-and-quote experience of historical texts; this asks
-            what it would mean to hold the images that came before any text at
-            all.
+            faces, bodies, and impossible beings from ivory and stone, and
+            painted living animals across the walls of caves. These are among
+            the oldest surviving works of human imagination, made across forty
+            thousand years of the last ice age. Source Library is built around
+            the read-and-quote experience of historical texts; this asks what it
+            would mean to hold the images that came before any text at all.
           </p>
         </header>
 
-        {/* Grid */}
-        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {ARTWORKS.map((a) => (
-            <figure
-              key={a.id}
-              className="group overflow-hidden rounded-xl bg-[#161412] ring-1 ring-white/10 transition-all hover:ring-white/25"
-            >
-              <div className="relative aspect-[4/3] overflow-hidden bg-black">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={`${DONSMAPS}${a.img}`}
-                  alt={a.title}
-                  loading="lazy"
-                  className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                />
-              </div>
-              <figcaption className="p-4">
-                <div className="flex items-baseline justify-between gap-3">
-                  <h2 className="font-serif text-lg text-stone-100">
-                    {a.title}
-                  </h2>
-                  <span className="shrink-0 font-mono text-xs tabular-nums text-amber-300/70">
-                    {a.date}
-                  </span>
-                </div>
-                <p className="mt-1 text-xs text-stone-500">
-                  {a.site} · {a.medium}
-                </p>
-                <p className="mt-3 text-sm leading-relaxed text-stone-400">
-                  {a.blurb}
-                </p>
-                <p className="mt-3 text-[11px] uppercase tracking-wide text-stone-600">
-                  {a.museum}
-                </p>
-              </figcaption>
-            </figure>
-          ))}
-        </div>
+        {/* Carved figures */}
+        <section className="mb-16">
+          <h2 className="mb-1 font-serif text-2xl text-stone-100">
+            Carved figures
+          </h2>
+          <p className="mb-6 text-sm text-stone-500">
+            Ivory, stone and fired clay — the oldest sculptures in the world.
+          </p>
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {FIGURINES.map((a) => (
+              <Card key={a.id} a={a} />
+            ))}
+          </div>
+        </section>
+
+        {/* Painted caves */}
+        <section className="mb-4">
+          <h2 className="mb-1 font-serif text-2xl text-stone-100">
+            The painted caves
+          </h2>
+          <p className="mb-6 text-sm text-stone-500">
+            Animals and signs drawn by firelight, deep underground.
+          </p>
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {CAVE_PAINTINGS.map((a) => (
+              <Card key={a.id} a={a} />
+            ))}
+          </div>
+        </section>
 
         {/* Footer note */}
         <footer className="mt-14 border-t border-white/10 pt-6 text-sm text-stone-500">
           <p>
-            All photographs by Don Hitchcock and reproduced under{' '}
+            All photographs by Don Hitchcock, mirrored with attribution under{' '}
             <a
               href="https://creativecommons.org/licenses/by/4.0/"
               className="underline hover:text-stone-300"
@@ -273,7 +357,7 @@ export default function PrehistoricArtPrototype() {
               Don’s Maps
             </a>
             , a remarkable independent archive of Palaeolithic archaeology. The
-            artefacts depicted are public domain by virtue of age.
+            artefacts and paintings depicted are public domain by virtue of age.
           </p>
         </footer>
       </div>

--- a/src/app/prototype/prehistoric-art/provenance.json
+++ b/src/app/prototype/prehistoric-art/provenance.json
@@ -1,0 +1,355 @@
+{
+  "_comment": "PROTOTYPE provenance record for /prototype/prehistoric-art. Single source of truth, imported by page.tsx. Models how these would be stored as content_type:'artwork' DB entries if the prototype graduates. Every image is mirrored to R2 from Don Hitchcock's donsmaps.com (CC BY 4.0); the depicted objects are public domain by age. image.source = exact original file; image.documentationPage = the donsmaps page documenting the object; object.reference = canonical encyclopaedia entry. All URLs verified 200 on 2026-06-19.",
+  "defaults": {
+    "photographer": "Don Hitchcock",
+    "photographerSite": "https://donsmaps.com",
+    "license": "CC BY 4.0",
+    "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+    "objectRights": "public domain (by age)",
+    "r2Base": "https://images.sourcelibrary.org/prototype/prehistoric-art"
+  },
+  "works": [
+    {
+      "id": "lion-man",
+      "category": "figurine",
+      "title": "The Lion Man (Löwenmensch)",
+      "date": "c. 40,000 BP",
+      "period": "Aurignacian",
+      "site": "Hohlenstein-Stadel, Germany",
+      "region": "Swabian Jura",
+      "museum": "Museum Ulm",
+      "medium": "Mammoth ivory",
+      "dimensions": "31.1 cm tall",
+      "blurb": "A standing figure with a lion’s head — the oldest known representation of a being that never existed. Roughly 300 hours of carving with a flint blade, made when the last ice age was at its coldest.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Lion-man" },
+      "image": {
+        "source": "https://donsmaps.com/images23/lionman2.jpg",
+        "documentationPage": "https://donsmaps.com/aurignacian.html"
+      }
+    },
+    {
+      "id": "hohle-fels",
+      "category": "figurine",
+      "title": "Venus of Hohle Fels",
+      "date": "c. 35,000–40,000 BP",
+      "period": "Aurignacian",
+      "site": "Hohle Fels Cave, Germany",
+      "region": "Swabian Jura",
+      "museum": "Urgeschichtliches Museum, Blaubeuren",
+      "medium": "Mammoth ivory",
+      "dimensions": "6 cm tall",
+      "blurb": "The oldest undisputed depiction of a human being yet found. A carved ring in place of a head suggests it was worn as a pendant.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Venus_of_Hohle_Fels" },
+      "image": {
+        "source": "https://donsmaps.com/images12/hohlefelsvenuslge.jpg",
+        "documentationPage": "https://donsmaps.com/aurignacian.html"
+      }
+    },
+    {
+      "id": "adorant",
+      "category": "figurine",
+      "title": "The Adorant (Worshipper)",
+      "date": "c. 40,000 BP",
+      "period": "Aurignacian",
+      "site": "Geißenklösterle, Germany",
+      "region": "Swabian Jura",
+      "museum": "Württembergisches Landesmuseum",
+      "medium": "Carved ivory relief",
+      "dimensions": "c. 3.8 cm tall",
+      "blurb": "A tiny relief of a figure with raised arms. On the reverse, rows of incised notches may be one of the earliest attempts at a calendar or tally.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Geißenklösterle" },
+      "image": {
+        "source": "https://donsmaps.com/images33/img_3259adorantarmshead.jpg",
+        "documentationPage": "https://donsmaps.com/aurignacian.html"
+      }
+    },
+    {
+      "id": "willendorf",
+      "category": "figurine",
+      "title": "Venus of Willendorf",
+      "date": "c. 28,000 BP",
+      "period": "Gravettian",
+      "site": "Willendorf, Austria",
+      "region": "Wachau, Lower Austria",
+      "museum": "Naturhistorisches Museum, Vienna",
+      "medium": "Oolitic limestone, traces of red ochre",
+      "dimensions": "11.1 cm tall",
+      "blurb": "The most famous Palaeolithic figurine. The stone is not local — it travelled, or its maker did — and was once coloured with red ochre.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Venus_of_Willendorf" },
+      "image": {
+        "source": "https://donsmaps.com/images28/venuswillendorfbigimg_1676.jpg",
+        "documentationPage": "https://donsmaps.com/willendorf.html"
+      }
+    },
+    {
+      "id": "lespugue",
+      "category": "figurine",
+      "title": "Venus of Lespugue",
+      "date": "c. 24,000–26,000 BP",
+      "period": "Gravettian",
+      "site": "Rideaux Cave, Lespugue, France",
+      "region": "Haute-Garonne",
+      "museum": "Musée de l’Homme, Paris",
+      "medium": "Tusk ivory",
+      "dimensions": "c. 14.7 cm tall",
+      "blurb": "Carved with a near-geometric symmetry that fascinated 20th-century artists — Picasso kept two casts of it in his studio.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Venus_of_Lespugue" },
+      "image": {
+        "source": "https://donsmaps.com/images40/DSC04530lespuguefront.jpg",
+        "documentationPage": "https://donsmaps.com/lespuguevenus.html"
+      }
+    },
+    {
+      "id": "dolni-vestonice",
+      "category": "figurine",
+      "title": "Venus of Dolní Věstonice",
+      "date": "c. 25,000–29,000 BP",
+      "period": "Gravettian (Pavlovian)",
+      "site": "Dolní Věstonice, Moravia",
+      "region": "Czech Republic",
+      "museum": "Pavilon Anthropos, Brno",
+      "medium": "Fired clay",
+      "dimensions": "11.1 cm tall",
+      "blurb": "Among the oldest known ceramics anywhere — fired more than ten thousand years before pottery vessels existed. A fingerprint of a child is baked into a nearby fragment.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Venus_of_Dolní_Věstonice" },
+      "image": {
+        "source": "https://donsmaps.com/images28/dolnivenusimg_1510.jpg",
+        "documentationPage": "https://donsmaps.com/dolnivenus.html"
+      }
+    },
+    {
+      "id": "brassempouy",
+      "category": "figurine",
+      "title": "The Lady of Brassempouy",
+      "date": "c. 25,000 BP",
+      "period": "Gravettian",
+      "site": "Brassempouy, France",
+      "region": "Landes",
+      "museum": "Musée d’Archéologie Nationale",
+      "medium": "Mammoth ivory",
+      "dimensions": "3.65 cm tall (head)",
+      "blurb": "One of the earliest realistic representations of a human face — a hood or hairstyle rendered in fine cross-hatching above calm, deliberate features.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Venus_of_Brassempouy" },
+      "image": {
+        "source": "https://donsmaps.com/images28/venusbrass.jpg",
+        "documentationPage": "https://donsmaps.com/brassempouy.html"
+      }
+    },
+    {
+      "id": "laussel",
+      "category": "figurine",
+      "title": "Venus of Laussel",
+      "date": "c. 22,000–27,000 BP",
+      "period": "Gravettian",
+      "site": "Laussel, Dordogne, France",
+      "region": "Dordogne",
+      "museum": "Musée d’Aquitaine, Bordeaux",
+      "medium": "Limestone bas-relief",
+      "dimensions": "c. 54 cm (block)",
+      "blurb": "A figure carved into a rock shelter wall, holding a crescent — possibly a horn — incised with thirteen marks, read by some as a lunar count.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Venus_of_Laussel" },
+      "image": {
+        "source": "https://donsmaps.com/images33/img_6531lausselcorne.jpg",
+        "documentationPage": "https://donsmaps.com/venus.html"
+      }
+    },
+    {
+      "id": "menton",
+      "category": "figurine",
+      "title": "Venus of Menton",
+      "date": "c. 23,000 BP",
+      "period": "Gravettian",
+      "site": "Barma Grande, Grimaldi (Balzi Rossi)",
+      "region": "Liguria / Riviera",
+      "museum": "Musée d’Archéologie Nationale",
+      "medium": "Yellow steatite",
+      "dimensions": null,
+      "blurb": "One of the Balzi Rossi figurines from the Italian–French Riviera caves — a series carved in soft, jewel-coloured stones.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Venus_figurines_of_Balzi_Rossi" },
+      "image": {
+        "source": "https://donsmaps.com/images24/balzirossi1.jpg",
+        "documentationPage": "https://donsmaps.com/venus.html"
+      }
+    },
+    {
+      "id": "double-venus",
+      "category": "figurine",
+      "title": "The Double Venus",
+      "date": "c. 23,000 BP",
+      "period": "Gravettian",
+      "site": "Balzi Rossi, Italy",
+      "region": "Liguria / Riviera",
+      "museum": "Private collection",
+      "medium": "Serpentine",
+      "dimensions": null,
+      "blurb": "Two figures sharing a single body, carved from green serpentine — an early image of pairing, or of two states of one being.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Venus_figurines_of_Balzi_Rossi" },
+      "image": {
+        "source": "https://donsmaps.com/images29/doubleimg405.jpg",
+        "documentationPage": "https://donsmaps.com/venus.html"
+      }
+    },
+    {
+      "id": "hohle-phallus",
+      "category": "figurine",
+      "title": "The Hohle Fels Phallus",
+      "date": "c. 28,000 BP",
+      "period": "Gravettian",
+      "site": "Hohle Fels Cave, Germany",
+      "region": "Swabian Jura",
+      "museum": "Urgeschichtliches Museum, Blaubeuren",
+      "medium": "Polished siltstone",
+      "dimensions": "19.2 cm long",
+      "blurb": "A finely polished stone, reassembled from fragments — one of the oldest unambiguous representations of male anatomy, and possibly also a tool.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Hohle_Fels" },
+      "image": {
+        "source": "https://donsmaps.com/images10/hohlefelsphallus.jpg",
+        "documentationPage": "https://donsmaps.com/aurignacian.html"
+      }
+    },
+    {
+      "id": "berekhat-ram",
+      "category": "figurine",
+      "title": "The Berekhat Ram Figure",
+      "date": "c. 230,000+ BP",
+      "period": "Acheulean",
+      "site": "Berekhat Ram, Golan Heights",
+      "region": "Golan Heights",
+      "museum": "Hebrew University of Jerusalem",
+      "medium": "Modified volcanic pebble",
+      "dimensions": "3.5 cm tall",
+      "blurb": "A pebble whose natural shape suggests a figure, deliberately enhanced with a few grooves — possibly made by Homo erectus, which would make it almost ten times older than anything else here.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Berekhat_Ram" },
+      "image": {
+        "source": "https://donsmaps.com/images33/berekhatramhires.jpg",
+        "documentationPage": "https://donsmaps.com/berekhatram.html"
+      }
+    },
+    {
+      "id": "chauvet-horses",
+      "category": "cave-painting",
+      "title": "Panel of the Horses",
+      "date": "c. 36,000 BP",
+      "period": "Aurignacian",
+      "site": "Chauvet Cave, Ardèche, France",
+      "region": "Ardèche",
+      "museum": "In situ (UNESCO World Heritage)",
+      "medium": "Charcoal on limestone",
+      "dimensions": null,
+      "blurb": "Four horses’ heads drawn in overlapping profile, with stumping and shading to model the muzzles — perspective and volume tens of thousands of years before either was “invented.”",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Chauvet_Cave" },
+      "image": {
+        "source": "https://donsmaps.com/images22/chauvethorsessm.jpg",
+        "documentationPage": "https://donsmaps.com/chauvetcave.html"
+      }
+    },
+    {
+      "id": "chauvet-handprints",
+      "category": "cave-painting",
+      "title": "Panel of Hand Prints",
+      "date": "c. 36,000 BP",
+      "period": "Aurignacian",
+      "site": "Chauvet Cave, Ardèche, France",
+      "region": "Ardèche",
+      "museum": "In situ (UNESCO World Heritage)",
+      "medium": "Red ochre on limestone",
+      "dimensions": null,
+      "blurb": "Hands pressed and stencilled onto the wall — the most direct trace any of these makers left: the print of a living hand, held up in the dark.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Chauvet_Cave" },
+      "image": {
+        "source": "https://donsmaps.com/images22/handprintspositivesm.jpg",
+        "documentationPage": "https://donsmaps.com/chauvetcave.html"
+      }
+    },
+    {
+      "id": "lascaux-bulls",
+      "category": "cave-painting",
+      "title": "The Hall of the Bulls",
+      "date": "c. 17,300 BP",
+      "period": "Magdalenian",
+      "site": "Lascaux, Dordogne, France",
+      "region": "Dordogne",
+      "museum": "In situ (closed; replica Lascaux IV)",
+      "medium": "Ochre and manganese on limestone",
+      "dimensions": null,
+      "blurb": "A frieze of aurochs, horses and stags wrapping a chamber, including the enigmatic spotted “unicorn.” One of the supreme achievements of ice-age painting.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Lascaux" },
+      "image": {
+        "source": "https://donsmaps.com/images25/lascauxmainhallunicornmed.jpg",
+        "documentationPage": "https://donsmaps.com/lascaux.html"
+      }
+    },
+    {
+      "id": "lascaux-black-bull",
+      "category": "cave-painting",
+      "title": "The Great Black Bull",
+      "date": "c. 17,300 BP",
+      "period": "Magdalenian",
+      "site": "Lascaux (Axial Gallery), France",
+      "region": "Dordogne",
+      "museum": "In situ (closed; replica Lascaux IV)",
+      "medium": "Manganese pigment on limestone",
+      "dimensions": "3.7 m long",
+      "blurb": "At 3.7 metres long, the largest single figure at Lascaux — its body left as bare rock, its outline and head rendered in dense black.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Lascaux" },
+      "image": {
+        "source": "https://donsmaps.com/images37/lascaux_greatblackbullsm.jpg",
+        "documentationPage": "https://donsmaps.com/lascaux.html"
+      }
+    },
+    {
+      "id": "lascaux-shaft",
+      "category": "cave-painting",
+      "title": "The Shaft Scene",
+      "date": "c. 17,300 BP",
+      "period": "Magdalenian",
+      "site": "Lascaux (the Well), France",
+      "region": "Dordogne",
+      "museum": "In situ (closed; replica Lascaux IV)",
+      "medium": "Pigment on limestone",
+      "dimensions": null,
+      "blurb": "A disembowelled bison, a bird-headed falling man, a spear, a rhinoceros — the most argued-over image in all of cave art, and a candidate for the oldest narrative scene.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Lascaux" },
+      "image": {
+        "source": "https://donsmaps.com/images19/lascauxIMG_1097sm.jpg",
+        "documentationPage": "https://donsmaps.com/lascaux.html"
+      }
+    },
+    {
+      "id": "altamira-ceiling",
+      "category": "cave-painting",
+      "title": "The Polychrome Ceiling",
+      "date": "c. 15,000–22,000 BP",
+      "period": "Magdalenian",
+      "site": "Altamira, Cantabria, Spain",
+      "region": "Cantabria",
+      "museum": "In situ (Museo de Altamira)",
+      "medium": "Ochre, haematite and charcoal",
+      "dimensions": null,
+      "blurb": "A herd of bison painted across a low ceiling, the artists using the rock’s natural bulges to give each animal a three-dimensional swell. Dismissed as a forgery when first published in 1880 — too good to be ancient.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Cave_of_Altamira" },
+      "image": {
+        "source": "https://donsmaps.com/images25/ceilingaltamira.jpg",
+        "documentationPage": "https://donsmaps.com/altamirapaintings.html"
+      }
+    },
+    {
+      "id": "altamira-bison",
+      "category": "cave-painting",
+      "title": "Polychrome Bison (detail)",
+      "date": "c. 15,000–22,000 BP",
+      "period": "Magdalenian",
+      "site": "Altamira, Cantabria, Spain",
+      "region": "Cantabria",
+      "museum": "In situ (Museo de Altamira)",
+      "medium": "Ochre, haematite and charcoal",
+      "dimensions": null,
+      "blurb": "A single curled bison from the great ceiling — pigment diluted to grade from deep red to soft brown, conjuring muscle and weight out of stone.",
+      "object": { "reference": "https://en.wikipedia.org/wiki/Cave_of_Altamira" },
+      "image": {
+        "source": "https://donsmaps.com/images25/bisonaltamira2img_0156.jpg",
+        "documentationPage": "https://donsmaps.com/altamirapaintings.html"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

A self-contained **prototype** exploring whether Palaeolithic art — "the deep time of human image-making" — belongs in Source Library, and whether the `artwork` content-type / gallery visual language carries it.

**Live preview:** `/prototype/prehistoric-art`

19 works in two sections:
- **Carved figures** (12) — Lion Man, Venus of Hohle Fels, Willendorf, Lespugue, Dolní Věstonice, Brassempouy, Laussel, the Balzi Rossi figurines, Berekhat Ram, the Hohle Fels phallus.
- **The painted caves** (7) — Chauvet (Panel of the Horses, Hand Prints), Lascaux (Hall of the Bulls, Great Black Bull, Shaft Scene), Altamira (Polychrome Ceiling + bison detail).

## Data & provenance

All metadata lives in `provenance.json` (single source of truth), modelling how these would be stored as `content_type:'artwork'` DB records. Each work carries: date, archaeological period, site, region, museum, medium, dimensions (where reliable), a canonical encyclopaedia reference (Wikipedia — all verified 200), and full image provenance (donsmaps source file + documentation page, photographer, license).

Images are **self-hosted on R2** (`prototype/prehistoric-art/<id>.jpg`), mirrored at full resolution from Don Hitchcock's [donsmaps.com](https://donsmaps.com) — photographs licensed **CC BY 4.0** (attributed in a banner, per-card footer, and footer). The depicted objects are public domain by age. Mirror was a throwaway script (untracked, not in this PR).

## Safety

- `robots: noindex`, **not linked from any nav / sitemap / public surface** — only reachable at the URL.
- **Zero DB writes.** No catalog impact.

## In scope
- Standalone prototype page + provenance dataset. A thinking-piece to react to.

## Out of scope (deliberately left undone)
- **No DB entries.** This is a static page, not real `artwork` records — kept separate so the catalog is untouched while we decide if the direction is worth it.
- **Source remains donsmaps.** If this graduates, the right move is sourcing from museum open-access / Wikimedia for cleaner institutional provenance; donsmaps stays the index/inspiration, not the import target. Noted in the page's source comment.
- One residual rights nuance (museum house-rules on third-party object photos) is exactly why it stays non-public for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)