### PR TITLE
polish(vision): share preview metadata + paragraph tighten

### DIFF
--- a/src/app/vision/content.ts
+++ b/src/app/vision/content.ts
@@ -63,7 +63,8 @@ export const visionContent: VisionContent = {
     linkLabel: 'read it at the source',
   },
   bodyBeforeImage1: [
-    'That is the whole idea behind Source Library: to go back to the source, and to make it possible for anyone — any reader, any scholar, any AI — to do the same. Today it is the world’s largest library of translated ancient texts. We have translated more than **15,000 books** from over fifty languages, more than half of them into English for the first time. Our word count has already passed English Wikipedia. Every translation sits beside the original scanned page, so any line can be verified, quoted, and trusted. It is almost entirely free, Creative Commons share-alike, and open by API and MCP — so that the AI you use can reach for the actual source.',
+    'That is the whole idea behind Source Library: to go back to the source, and to make it possible for anyone — any reader, any scholar, any AI — to do the same. Today it is the world’s largest library of translated ancient texts: more than **15,000 books** from over fifty languages, more than half of them into English for the first time. Our word count has already passed English Wikipedia.',
+    'Every translation sits beside the original scanned page, so any line can be verified, quoted, and trusted. It is almost entirely free, Creative Commons share-alike, and open by API and MCP — so that the AI you use can reach for the actual source.',
   ],
   image1: {
     src: 'https://images.sourcelibrary.org/pages/69520c46ab34727b1f044141/0019.jpg',

--- a/src/app/vision/page.tsx
+++ b/src/app/vision/page.tsx
@@ -2,11 +2,27 @@ import { Metadata } from 'next';
 import { visionContent } from './content';
 import VisionView from './VisionView';
 
+const OG_TITLE = 'Bringing ancient wisdom into the future';
+const OG_DESCRIPTION =
+  'A letter from Source Library founder Derek Lomas on bringing the ancient wisdom of every civilization into the age of AI — and a brief plan for the institution we are building.';
+
 export const metadata: Metadata = {
   title: 'Our Vision — A Letter from the Founder | Source Library',
-  description:
-    'A letter from Source Library founder Derek Lomas on bringing the ancient wisdom of every civilization into the age of AI — and a brief plan for the institution we are building.',
+  description: OG_DESCRIPTION,
   alternates: { canonical: '/vision' },
+  openGraph: {
+    title: OG_TITLE,
+    description: OG_DESCRIPTION,
+    url: '/vision',
+    type: 'article',
+    images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: OG_TITLE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: OG_TITLE,
+    description: OG_DESCRIPTION,
+    images: ['/og-image.jpg'],
+  },
 };
 
 export default async function VisionPage({


### PR DESCRIPTION
Adds page-level OpenGraph/Twitter metadata so sharing /vision shows the letter's framing (title: 'Bringing ancient wisdom into the future') instead of the generic site OG card. Splits one overloaded paragraph in two for skim-ability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)