### PR TITLE
fix(pipeline): scoped mode must raise phase limits or scoped books starve

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2608,6 +2608,21 @@ async function run() {
     errors: [],
   };
 
+  // Selective-unpause: in scoped mode every phase post-filters its candidate
+  // list down to the allowlist (applyBookOverride), so the per-phase limits
+  // would otherwise hide scoped books behind the larger backlog (e.g. ~200+
+  // un-enrolled imports ahead of them). Raise the limits past any realistic
+  // backlog — real work stays capped to the allowlist by the post-filter, so
+  // this only widens the candidate window, it does not widen what gets acted on.
+  // Done here, after all health-grade and limit_overrides adjustments.
+  if (SCOPED_MODE) {
+    const SCOPE_LIMIT = 100000;
+    ENROLL_LIMIT = ARCHIVE_LIMIT = OCR_SUBMIT_LIMIT = METADATA_ENRICH_LIMIT =
+      TRANSLATE_SUBMIT_LIMIT = ENRICH_LIMIT = CHAPTER_LIMIT = IMAGE_SUBMIT_LIMIT =
+      FINALIZE_LIMIT = TRANSLITERATE_LIMIT = PREVIEW_LIMIT = SCOPE_LIMIT;
+    console.log(`[pipeline-orchestrator] Scoped mode: per-phase candidate limits raised to ${SCOPE_LIMIT} (work still confined to ${_scopeIds.size} allowlisted book(s)).`);
+  }
+
   try {
     // ── Phase 0: Auto-enroll recently imported books ──
     if (shouldRun(0)) {


### PR DESCRIPTION
Follow-up to #2616 (selective unpause). Found while verifying it live on the cannabis collection.

## Bug
Scoped mode post-filters each phase's candidate list to the allowlist (via `applyBookOverride`), but the per-phase **limits run first**. With ~214 un-enrolled imports ahead of them and `ENROLL_LIMIT=100`, the 3 allowlisted books never entered the candidate window → the orchestrator ran `success` with all-zero counters (`E:0 A:0 O:0/0…`). The pause-bypass worked; the books just never surfaced. This is the post-filter caveat noted in #2616, now hit in practice.

## Fix
In scoped mode, raise every per-phase candidate limit past any realistic backlog (after health-grade/override adjustments, before phases run). The existing post-filter still caps **actual work** to the allowlist — this only widens the read window, not what's acted on. Occasional scoped runs, so the wider read is fine.

Verified: `node --check` clean. (A query-level scope injection would be tighter at runtime but touches ~15 query sites; the limit-raise reuses the merged plumbing with one block — preferred for a low-risk hotfix.)

Note: a separate issue — `batch-collector-worker` had been exiting silently on the pause; with #2616 + scope live it should resume and land already-submitted jobs (e.g. Ibn al-Baytar's 20). Verifying after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)