### PR TITLE
fix(dedup): make title+author dedup edition-aware (year + volume)

### DIFF
--- a/src/app/api/import/e-rara/route.ts
+++ b/src/app/api/import/e-rara/route.ts
@@ -192,7 +192,7 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     // Cross-source dedup check
     const dedupResult = await checkDuplicate(db, {
-      title, author: authorForLookup,
+      title, author: authorForLookup, published,
       image_source: { provider: 'e-rara', identifier: numericId, iiif_manifest: manifestUrl },
     });
     if (dedupResult.isDuplicate) {

--- a/src/app/api/import/gallica/route.ts
+++ b/src/app/api/import/gallica/route.ts
@@ -112,7 +112,7 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     // Cross-source dedup check
     const dedupResult = await checkDuplicate(db, {
-      title, author, display_title, gallica_ark: ark,
+      title, author, display_title, gallica_ark: ark, published,
       image_source: { provider: 'gallica', identifier: ark, iiif_manifest: manifestUrl, source_url: `https://gallica.bnf.fr/ark:/12148/${ark}` },
     });
     if (dedupResult.isDuplicate) {

--- a/src/app/api/import/google-books/route.ts
+++ b/src/app/api/import/google-books/route.ts
@@ -97,7 +97,7 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     // Cross-source dedup check
     const dedupResult = await checkDuplicate(db, {
-      title, author, display_title, ia_identifier, google_books_id,
+      title, author, display_title, ia_identifier, google_books_id, published,
       image_source: { provider: 'google_books', identifier: google_books_id, source_url: `https://books.google.com/books?id=${google_books_id}` },
     });
     if (dedupResult.isDuplicate) {

--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -130,11 +130,13 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     const db = await getDb();
 
-    // Check if book already exists
+    // Check if this exact IA item already exists. Match only on same-item
+    // identifiers — NOT on `title`, which collides across distinct editions
+    // that share IA's publisher-supplied title (e.g. a 1728 vs 1730 printing).
+    // Edition-aware title+author dedup happens in checkDuplicate() below.
     const existing = await db.collection('books').findOne({
       $or: [
         { ia_identifier },
-        { title },
         { 'dublin_core.dc_identifier': `IA:${ia_identifier}` }
       ]
     });
@@ -151,6 +153,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       title,
       author,
       display_title,
+      year,
+      published,
       ia_identifier,
       image_source: {
         provider: 'internet_archive',

--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -296,7 +296,7 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     // Cross-source dedup check
     const dedupResult = await checkDuplicate(db, {
-      title, author, display_title,
+      title, author, display_title, year, published,
       image_source: { provider: 'iiif', iiif_manifest: manifest_url, source_url: manifest_url },
     });
     if (dedupResult.isDuplicate) {

--- a/src/app/api/import/loc/route.ts
+++ b/src/app/api/import/loc/route.ts
@@ -215,7 +215,7 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     // Cross-source dedup check
     const dedupResult = await checkDuplicate(db, {
-      title: bookTitle, author: bookAuthor, display_title,
+      title: bookTitle, author: bookAuthor, display_title, published: bookPublished,
       image_source: { provider: 'loc', identifier: lccn, source_url: `https://www.loc.gov/item/${lccn}/` },
     });
     if (dedupResult.isDuplicate) {

--- a/src/app/api/import/mdz/route.ts
+++ b/src/app/api/import/mdz/route.ts
@@ -128,6 +128,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       title,
       author,
       display_title,
+      year,
       mdz_id: normalizedId,
       bsb_id: normalizedId,
       image_source: {

--- a/src/app/api/import/pdf/route.ts
+++ b/src/app/api/import/pdf/route.ts
@@ -109,7 +109,7 @@ export const POST = withCuratorAuth(async (request) => {
 
     // Cross-source dedup check
     const dedupResult = await checkDuplicate(db, {
-      title, author,
+      title, author, published,
       image_source: { provider, identifier: identifier || undefined, pdf_url, source_url: source_url || pdf_url },
     });
     if (dedupResult.isDuplicate) {

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { resolveLanguage } from '@/lib/resolve-language';
+import { checkDuplicate } from '@/lib/dedup';
 
 /**
  * Import a book from a local directory
@@ -69,17 +70,26 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     const db = await getDb();
 
-    // Check if book already exists
-    const existing = await db.collection('books').findOne({
-      $or: [
-        { title },
-        { display_title: display_title || title }
-      ]
+    // Edition-aware dedup. The old exact `{ title }` check blocked distinct
+    // editions that share a title; checkDuplicate() lets a different year/volume
+    // through while still catching true duplicates by source + title+author.
+    const dedupResult = await checkDuplicate(db, {
+      title,
+      author,
+      display_title,
+      published,
+      ia_identifier,
+      dublin_core,
+      image_source,
     });
-
-    if (existing) {
+    if (dedupResult.isDuplicate) {
+      const best = dedupResult.matches[0];
       return NextResponse.json(
-        { error: 'Book already exists', existingId: existing.id || existing._id.toString() },
+        {
+          error: `Book already exists (${best.matchType}): matches "${best.matchedTitle}"`,
+          existingId: best.matchedBookId,
+          matches: dedupResult.matches,
+        },
         { status: 409 }
       );
     }

--- a/src/app/api/import/wellcome/route.ts
+++ b/src/app/api/import/wellcome/route.ts
@@ -193,7 +193,7 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     // Cross-source dedup check
     const dedupResult = await checkDuplicate(db, {
-      title, author,
+      title, author, year, published,
       image_source: { provider: 'wellcome', identifier: work_id, iiif_manifest: manifestUrl, source_url: `https://wellcomecollection.org/works/${work_id}` },
     });
     if (dedupResult.isDuplicate) {

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -79,6 +79,67 @@ export function normalizeAuthor(author: string): string {
 }
 
 /**
+ * Latin ordinals and roman numerals used to mark volumes ("Tomus primus",
+ * "Tom. II"). Kept small and explicit — we only resolve them when a volume
+ * KEYWORD precedes them, so false positives are unlikely.
+ */
+const LATIN_ORDINALS: Record<string, number> = {
+  primus: 1, prima: 1, secundus: 2, secunda: 2, tertius: 3, tertia: 3,
+  quartus: 4, quarta: 4, quintus: 5, quinta: 5, sextus: 6, septimus: 7,
+  octavus: 8, nonus: 9, decimus: 10,
+};
+
+function romanToInt(s: string): number | null {
+  const map: Record<string, number> = { i: 1, v: 5, x: 10, l: 50, c: 100, d: 500, m: 1000 };
+  let total = 0;
+  for (let i = 0; i < s.length; i++) {
+    const cur = map[s[i]];
+    const next = map[s[i + 1]];
+    if (cur == null) return null;
+    total += next != null && cur < next ? -cur : cur;
+  }
+  return total > 0 ? total : null;
+}
+
+/**
+ * Extract a volume/part number from a raw title, when one is explicitly marked.
+ * Returns null if no marker is present (callers then fall back to other
+ * discriminators). `normalizeTitle()` STRIPS these markers, so vol. 1 and vol. 2
+ * of the same set collapse to the same `normalized_title` — extracting the
+ * volume from the raw title is how we tell two volumes of one work apart.
+ * Handles arabic ("Vol. 2", "(Vol 2)", "Tome 3"), roman ("Tomus II"), and
+ * common Latin ordinals ("Tomus primus").
+ */
+export function extractVolume(title?: string | null): number | null {
+  if (!title) return null;
+  const t = title.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  const KW = '(?:vol(?:ume)?|tom(?:us|o|e)?|band|part|pt|liber|deel|teil)\\.?\\s*\\(?\\s*';
+  // keyword + arabic number
+  let m = t.match(new RegExp(`\\b${KW}(\\d{1,3})\\b`));
+  if (m) return parseInt(m[1], 10);
+  // keyword + Latin ordinal word
+  m = t.match(new RegExp(`\\b${KW}(${Object.keys(LATIN_ORDINALS).join('|')})\\b`));
+  if (m) return LATIN_ORDINALS[m[1]] ?? null;
+  // keyword + roman numeral (whole token must be roman letters)
+  m = t.match(new RegExp(`\\b${KW}([ivxlcdm]{1,6})\\b`));
+  if (m) return romanToInt(m[1]);
+  return null;
+}
+
+/**
+ * Best-effort publication year for edition comparison. Prefers a numeric
+ * `year`, else parses the first 3–4 digit run out of `published`.
+ */
+export function editionYear(book: { year?: number | null; published?: string | null }): number | null {
+  if (typeof book.year === 'number' && book.year > 0) return book.year;
+  if (book.published) {
+    const m = String(book.published).match(/\b(\d{3,4})\b/);
+    if (m) return parseInt(m[1], 10);
+  }
+  return null;
+}
+
+/**
  * Generate a source fingerprint for a book.
  * Returns null if no identifiable source info is available.
  */
@@ -148,6 +209,11 @@ export async function checkDuplicate(
     title: string;
     author: string;
     display_title?: string;
+    /** Edition discriminators — two records that share a normalized title+author
+     * but differ in publication year (or volume, parsed from the title) are
+     * distinct editions, NOT duplicates. Pass these so Tier 2 can tell them apart. */
+    year?: number;
+    published?: string;
     ia_identifier?: string;
     gallica_ark?: string;
     bodleian_uuid?: string;
@@ -172,7 +238,7 @@ export async function checkDuplicate(
   // or not the existing copy is public — and imports land hidden, so a
   // visible-only check is blind to the entire hidden backlog (the regime we now
   // import into at volume). We surface the match's visibility instead of hiding it.
-  const VIS_PROJ = { id: 1, title: 1, visible: 1, hidden: 1 };
+  const VIS_PROJ = { id: 1, title: 1, display_title: 1, year: 1, published: 1, visible: 1, hidden: 1 };
 
   // Check BOTH the live library and the warehouse. `books_warehouse` holds books
   // we've already acquired + archived that are awaiting promotion to `books`
@@ -204,8 +270,18 @@ export async function checkDuplicate(
   }
 
   // Tier 2: Normalized title+author match (high)
+  //
+  // Holding multiple EDITIONS of one work is a first-class case here (the
+  // work_id / original_edition_id / text_role layers exist for exactly this).
+  // A normalized title+author collision is therefore only a duplicate when the
+  // candidate and the match are the SAME edition. Two records that differ in
+  // publication year — or in volume, which normalizeTitle() strips out — are
+  // distinct editions and must be allowed through. (Tiers 1 and 3 still
+  // hard-block a true same-item re-import regardless of year.)
   const normTitle = normalizeTitle(book.title);
   const normAuthor = normalizeAuthor(book.author);
+  const candYear = editionYear(book);
+  const candVol = extractVolume(book.display_title) ?? extractVolume(book.title);
 
   if (normTitle.length >= 5) {
     for (const cn of COLLECTIONS) {
@@ -219,7 +295,18 @@ export async function checkDuplicate(
 
       for (const tm of titleMatches) {
         const id = tm.id || tm._id.toString();
-        if (!seen(id)) matches.push({
+        if (seen(id)) continue;
+
+        // Different edition? Only conclude so when BOTH sides carry the signal —
+        // a missing year/volume can't distinguish editions, so fall back to
+        // treating the title+author collision as a duplicate (the safe error).
+        const tmYear = editionYear(tm as { year?: number | null; published?: string | null });
+        const tmVol = extractVolume(tm.display_title) ?? extractVolume(tm.title);
+        const differentYear = candYear != null && tmYear != null && candYear !== tmYear;
+        const differentVolume = candVol != null && tmVol != null && candVol !== tmVol;
+        if (differentYear || differentVolume) continue;
+
+        matches.push({
           matchedBookId: id,
           matchedTitle: tm.title,
           matchType: 'title_author',

--- a/tests/unit/dedup-edition-aware.test.ts
+++ b/tests/unit/dedup-edition-aware.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { extractVolume, editionYear, checkDuplicate } from '@/lib/dedup';
+
+describe('extractVolume', () => {
+  it('reads arabic volume markers', () => {
+    expect(extractVolume('Harmonia Macrocosmica Vol. 2')).toBe(2);
+    expect(extractVolume('Rig-Veda-Sanhita (Vol. 2)')).toBe(2);
+    expect(extractVolume('Some Work, Tome 3')).toBe(3);
+    expect(extractVolume('Werk Band 4')).toBe(4);
+  });
+
+  it('reads roman and Latin-ordinal volume markers', () => {
+    expect(extractVolume('Utriusque Cosmi Historia Tomus II')).toBe(2);
+    expect(extractVolume('Summa Astensis Tomus primus')).toBe(1);
+    expect(extractVolume('Opera Tom. III')).toBe(3);
+  });
+
+  it('returns null when no volume marker is present', () => {
+    expect(extractVolume('Theatrum Politicum')).toBeNull();
+    expect(extractVolume('')).toBeNull();
+    expect(extractVolume(undefined)).toBeNull();
+  });
+});
+
+describe('editionYear', () => {
+  it('prefers a numeric year', () => {
+    expect(editionYear({ year: 1730, published: '1728' })).toBe(1730);
+  });
+  it('parses a year out of published', () => {
+    expect(editionYear({ published: 'Venetiis, 1728' })).toBe(1728);
+    expect(editionYear({ published: '1660' })).toBe(1660);
+  });
+  it('returns null when there is no usable year', () => {
+    expect(editionYear({ published: 'Unknown' })).toBeNull();
+    expect(editionYear({})).toBeNull();
+  });
+});
+
+// Minimal fake Mongo Db. Tier 1 (fingerprint) and Tier 3 (iiif) findOne return
+// null; Tier 2 find() returns the canned existing edition(s) for `books`.
+function makeDb(titleMatches: Record<string, unknown>[]) {
+  const collection = (name: string) => ({
+    findOne: async () => null,
+    find: () => ({ limit: () => ({ toArray: async () => (name === 'books' ? titleMatches : []) }) }),
+  });
+  return { collection } as unknown as Parameters<typeof checkDuplicate>[0];
+}
+
+describe('checkDuplicate edition-awareness', () => {
+  const existing1730 = { id: 'b1730', title: 'Summa Astensis', year: 1730 };
+
+  it('does NOT flag a different-year edition as a duplicate', async () => {
+    const db = makeDb([existing1730]);
+    const res = await checkDuplicate(db, {
+      title: 'Summa Astensis', author: 'Astesanus de Ast', year: 1728,
+    });
+    expect(res.isDuplicate).toBe(false);
+  });
+
+  it('DOES flag the same-year edition as a duplicate', async () => {
+    const db = makeDb([existing1730]);
+    const res = await checkDuplicate(db, {
+      title: 'Summa Astensis', author: 'Astesanus de Ast', year: 1730,
+    });
+    expect(res.isDuplicate).toBe(true);
+    expect(res.matches[0].matchType).toBe('title_author');
+  });
+
+  it('does NOT flag a different-volume set as a duplicate', async () => {
+    const db = makeDb([{ id: 'v1', title: 'Utriusque Cosmi Historia Tomus I', year: 1617 }]);
+    const res = await checkDuplicate(db, {
+      title: 'Utriusque Cosmi Historia Tomus II', author: 'Robert Fludd', year: 1617,
+    });
+    expect(res.isDuplicate).toBe(false);
+  });
+
+  it('falls back to flagging when the year is unknown on either side (safe default)', async () => {
+    const db = makeDb([{ id: 'bNoYear', title: 'Summa Astensis' }]);
+    const res = await checkDuplicate(db, {
+      title: 'Summa Astensis', author: 'Astesanus de Ast', year: 1728,
+    });
+    expect(res.isDuplicate).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Importing a second **edition** of a work we already hold gets rejected as a duplicate whenever the two records share an identical normalized title + author. The signals that actually distinguish editions — publication **year** and the source/IIIF identifier — were ignored by the Tier 2 title+author match and by the importer routes' blunt exact-`{ title }` pre-check.

Surfaced by a real import: the *Summa Astensis* 1728 and 1730 printings carry byte-identical IA titles, so the 1730 import blocked the 1728 as a "duplicate."

A corpus scan found **180 works (397 books)** we already hold across multiple editions distinguished only by year — including core holdings like Fludd's *Utriusque Cosmi Historia* (1617/1619), Cellarius *Harmonia Macrocosmica* (1660/1708), and the *Haiguo Tuzhi* 海國圖志 (9 editions). Multiple editions of one work is a first-class case here (`work_id` / `original_edition_id` / `text_role` exist precisely for it).

## Change

- **`dedup.ts` Tier 2 is now edition-aware.** A normalized title+author collision counts as a duplicate **only when the candidate and the match are the same edition**. A different publication year — or a different **volume** (parsed from the raw title, since `normalizeTitle()` strips volume markers, so vol. 1 / vol. 2 collide) — means a distinct edition and is allowed through.
- **Safe default preserved.** When year/volume is absent on either side, it still falls back to treating the collision as a duplicate (the recoverable error). Tiers 1 (source fingerprint) and 3 (IIIF manifest) still hard-block a true same-item re-import regardless of year.
- New exported helpers `extractVolume()` and `editionYear()`.
- Removed the blunt exact-`{ title }` pre-check in the IA route and the local-directory import route. The local-dir route previously had *no* real dedup beyond that check — it now routes through `checkDuplicate`.
- Passed `year`/`published` into `checkDuplicate` from all 9 importer routes.
- Unit tests for the helpers and the edition gate.

## Out of scope

- No backfill / re-dedup of the existing 180 multi-edition collisions — they're already in the corpus and correct; this only changes future import behavior.
- Did not touch `normalizeTitle()` itself (it's baked into ~46K stored `normalized_title` values); volume handling is done at compare time instead.

## Test

- `tests/unit/dedup-edition-aware.test.ts` — 10 cases (different-year allowed, same-year blocked, different-volume allowed, unknown-year safe fallback, helper parsing).
- Full unit suite: 325 passing. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)