### PR TITLE
fix(bph): decode URL-encoded UBN in catalog route (dead BPH shelf-mark links)

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -24,6 +24,20 @@ interface Props {
   params: Promise<{ tenant: string; ubn: string }>;
 }
 
+// UBNs like "BPH 151" contain a space, which arrives URL-encoded ("BPH%20151")
+// in the route segment. The stored value in bph_works has a real space, so an
+// undecoded param never matches and the page 404s (the entire reason BPH-shelf-
+// mark catalogue links were dead). Numeric UBNs have nothing to encode, which
+// is why they always worked. Decode defensively — for already-decoded values
+// (no '%') this is a no-op, and a malformed escape sequence falls back to raw.
+function normalizeUbn(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
 interface FieldProvenance {
   source: string;
   evidence?: string;
@@ -269,7 +283,8 @@ async function fetchSlBook(ubn: string): Promise<SlBook | null> {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { tenant, ubn } = await params;
+  const { tenant, ubn: rawUbn } = await params;
+  const ubn = normalizeUbn(rawUbn);
   const partner = getPartnerBySlug(tenant);
   if (partner && partner.providerKey !== 'bph' && partner.hasUnifiedCatalogue) {
     return generateGenericMetadata(tenant, ubn, partner) as Promise<Metadata>;
@@ -320,7 +335,8 @@ async function effectiveCatalogRole(
 }
 
 export default async function CatalogEntryPage({ params }: Props) {
-  const { tenant, ubn } = await params;
+  const { tenant, ubn: rawUbn } = await params;
+  const ubn = normalizeUbn(rawUbn);
 
   // Generic unified-catalogue tenants (kloss-collection, …) — render via the
   // shared component that reads library_catalog_records. BPH falls through.


### PR DESCRIPTION
## What

BPH catalogue links like `/embed/bph/catalog/BPH 151` were returning a soft-404 ('Page Not Found' with HTTP 200). The UBN `BPH 151` contains a space that arrives URL-encoded (`BPH%20151`) in the `[ubn]` route segment; the stored `bph_works.ubn` value has a real space, so the undecoded param never matched and the page `notFound()`'d. Numeric UBNs have nothing to encode — which is exactly why only the BPH-shelf-mark manuscript entries (Books of Hours, the Theatrum Chemicum compilation, etc.) were dead.

## Why it matters now

These dead links were the **top not-found URLs during the 2026-06-19 Instagram traffic spike** (`BPH 163`/`151`/`134` — 13/9/6 hits), landing right in the `/embed/bph` reading room that the EFM/Instagram campaign points visitors to.

## Fix

Decode the `ubn` param defensively (`decodeURIComponent` with a try/catch fallback) in both `generateMetadata` and the page component. Idempotent for already-decoded values (stored UBNs contain no `%`), and the generic-catalogue path (kloss-collection, …) inherits the decoded value.

## Out of scope

- `/book/corpus-hermeticum` (3 direct hits): a *hidden empty stub book* is squatting that slug, so the page reads 'Book Not Found'. Fixing it is a content decision (which of 6 editions to land on / free the slug), not a routing bug — handled separately.
- Genuinely missing books (e.g. `BPH 163` had no `bph_works` row) are acquisition gaps, not routing bugs.

## Verification

Verified the row resolves via the anon key for the decoded value; numeric UBNs already worked. Pending preview-deploy curl against the BPH-shelf-mark UBNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)