### PR TITLE
fix(redirect): /book/corpus-hermeticum → library search

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,15 @@ import { getProviderPrefixRedirect, TENANT_ROOT_PATHS } from '@/lib/provider-pre
 // scripts/maintenance/build-author-redirect-map.mjs when the authors thesaurus changes.
 const AUTHOR_CANONICAL_REDIRECTS = authorCanonicalRedirects as Record<string, string>;
 
+// Famous-text slugs that readers guess as a book URL but that we hold across
+// several editions (no single canonical book to land on). Map the guessed slug
+// to a library search so they see every edition and choose. `corpus-hermeticum`
+// itself is a hidden, empty stub book squatting the slug, so the /book route
+// would otherwise render "Book Not Found" (it arrives as direct-typed traffic).
+const BOOK_SLUG_SEARCH_REDIRECTS: Record<string, string> = {
+  'corpus-hermeticum': 'corpus hermeticum',
+};
+
 // --- Tenant routing ---
 
 // First-segment slugs that map to a subdomain tenant via path-based access
@@ -602,6 +611,23 @@ export async function proxy(request: NextRequest) {
     const url = request.nextUrl.clone();
     url.pathname = `/book/${barePageMatch[1]}`;
     return NextResponse.redirect(url, 308);
+  }
+
+  // --- Guessed famous-text book slug → library search ---
+  // Single-segment /book/<slug> only; real book slugs aren't in the map, so
+  // they fall through to normal routing untouched. Pathname-only change keeps
+  // the redirect on-host on tenant subdomains (lands on that tenant's search).
+  const bookSlugMatch = pathname.match(/^\/book\/([^/]+)\/?$/);
+  if (bookSlugMatch) {
+    let slug = bookSlugMatch[1];
+    try { slug = decodeURIComponent(slug); } catch { /* keep raw */ }
+    const searchQuery = BOOK_SLUG_SEARCH_REDIRECTS[slug];
+    if (searchQuery) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/search';
+      url.search = `?q=${encodeURIComponent(searchQuery)}`;
+      return NextResponse.redirect(url, 308);
+    }
   }
 
   // --- Tenant subdomain rewrite ---

--- a/tests/unit/book-slug-search-redirect.test.ts
+++ b/tests/unit/book-slug-search-redirect.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+// Famous-text slugs that readers type as a book URL but that we hold across
+// several editions (e.g. `corpus-hermeticum`, which is also a hidden empty
+// stub book squatting the slug → the /book route would render "Book Not
+// Found"). The proxy 308s these to a library search so the reader sees every
+// edition. Like the author/bare-page blocks, it must live in the proxy and not
+// a page component, where a redirect() in the streamed RSC tree commits a 200
+// shell first.
+
+const PROXY = path.join(path.resolve(__dirname, '../..'), 'src/proxy.ts');
+
+describe('guessed famous-text book slug → search proxy redirect', () => {
+  const src = readFileSync(PROXY, 'utf8');
+
+  it('maps corpus-hermeticum to a corpus hermeticum search', () => {
+    expect(
+      src,
+      "BOOK_SLUG_SEARCH_REDIRECTS must map 'corpus-hermeticum' → 'corpus hermeticum'"
+    ).toMatch(/'corpus-hermeticum':\s*'corpus hermeticum'/);
+  });
+
+  it('matches single-segment /book/<slug> and 308s to /search', () => {
+    const idx = src.search(/\/\^\\\/book\\\/\(\[\^\/\]\+\)\\\/\?\$\//);
+    expect(
+      idx,
+      String.raw`src/proxy.ts must match pathname against /^\/book\/([^/]+)\/?$/`
+    ).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 500);
+    expect(block, 'the slug match must target /search').toMatch(/url\.pathname\s*=\s*'\/search'/);
+    expect(block, 'and issue a 308').toMatch(/NextResponse\.redirect\([^)]*,\s*308\)/);
+  });
+});


### PR DESCRIPTION
## What

`/book/corpus-hermeticum` rendered **'Book Not Found'** — a hidden, empty stub book (`visible:false, hidden:true, pages_count:0`) squats that exact slug, so the read-path gate blocks it. It's direct-typed traffic (people guessing the URL for the #1 search term during the 2026-06-19 spike).

We hold the Corpus Hermeticum across ~6 editions (Ficino's Pimander, the Cambridge Greek first-translation, the Alexandria Greek, etc.) with no single canonical landing. So rather than arbitrarily pick one, the proxy now **308s `/book/corpus-hermeticum` → `/search?q=corpus%20hermeticum`** — the reader sees every edition and chooses.

## How

A small `BOOK_SLUG_SEARCH_REDIRECTS` map + a single-segment `/book/<slug>` match in `src/proxy.ts`, mirroring the existing author-canonical and bare-page redirect blocks. It lives in the proxy (not a page component) for the documented reason: a `redirect()` inside the streamed `/book` RSC tree commits a 200 shell before the redirect resolves, so crawlers would index the junk URL. Real book slugs aren't in the map and fall through to normal routing untouched. Pathname-only change keeps the redirect on-host on tenant subdomains.

Extensible: drop another `'slug': 'search terms'` entry for the next famous-text slug readers guess.

## Test

`tests/unit/book-slug-search-redirect.test.ts`, mirroring `bare-page-redirect.test.ts` — asserts the map entry, the single-segment match, the `/search` target, and the 308.

## Out of scope

- The hidden stub book itself is left in place (the redirect fires before routing reaches it). Cleaning up the stub is a separate data decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)