### PR TITLE
feat(vision): link emblem to source page + tax-deductible gift link

### DIFF
--- a/src/app/vision/VisionView.tsx
+++ b/src/app/vision/VisionView.tsx
@@ -257,21 +257,32 @@ export default function VisionView({
             F({ as: 'p', path: `bodyBeforeImage1.${i}`, value: p, className: 'mb-6' })
           )}
 
-          {/* Image 1 */}
+          {/* Image 1 — links to the source page */}
           <figure className="my-12 -mx-2 md:-mx-8">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={content.image1.src}
-              alt={content.image1.alt}
-              className="w-full h-auto rounded-lg border border-primary/10 shadow-sm"
-              loading="lazy"
-            />
+            <Link
+              href={content.image1.href}
+              className="block group"
+              aria-label="Read this page on Source Library"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={content.image1.src}
+                alt={content.image1.alt}
+                className="w-full h-auto rounded-lg border border-primary/10 shadow-sm transition group-hover:opacity-95"
+                loading="lazy"
+              />
+            </Link>
             {F({
               as: 'figcaption',
               path: 'image1.caption',
               value: content.image1.caption,
               className: 'mt-3 text-sm text-muted italic text-center block',
             })}
+            <div className="text-center mt-1">
+              <Link href={content.image1.href} className="text-sm text-accent-rust hover:underline">
+                Read this page &rarr;
+              </Link>
+            </div>
           </figure>
 
           {content.bodyAfterImage1.map((p, i) =>

--- a/src/app/vision/content.ts
+++ b/src/app/vision/content.ts
@@ -20,7 +20,7 @@ export interface VisionContent {
   bodyBeforeQuote: string[];
   quote: { en: string; la: string; source: string; url: string; linkLabel: string };
   bodyBeforeImage1: string[];
-  image1: { src: string; alt: string; caption: string };
+  image1: { src: string; alt: string; caption: string; href: string };
   bodyAfterImage1: string[];
   buildHeading: string;
   bodyBuild: string[];
@@ -70,9 +70,10 @@ export const visionContent: VisionContent = {
     src: 'https://images.sourcelibrary.org/pages/69520c46ab34727b1f044141/0019.jpg',
     alt: "An emblem from Michael Maier's Atalanta Fugiens (1618)",
     caption: 'One of thousands of pages now readable and quotable — an emblem from Maier’s *Atalanta Fugiens*, 1618.',
+    href: '/book/atalanta-fleeing-new-chemical-emblems-of-the-secrets-of-maier/page/19',
   },
   bodyAfterImage1: [
-    'We are embedded within one of the world’s great collections of ancient texts: the [Embassy of the Free Mind](https://embassyofthefreemind.com) in Amsterdam, home to the Bibliotheca Philosophica Hermetica, a UNESCO “Memory of the World” rare-book library. Source Library was created with the support of the Wisdom Frontiers Society of La Jolla, California, and runs as an open initiative of the Embassy, a Dutch nonprofit with 501(c)(3) status.',
+    'We are embedded within one of the world’s great collections of ancient texts: the [Embassy of the Free Mind](https://embassyofthefreemind.com) in Amsterdam, home to the Bibliotheca Philosophica Hermetica, a UNESCO “Memory of the World” rare-book library. Source Library was created with the support of the Wisdom Frontiers Society of La Jolla, California, and runs as an open initiative of the Embassy, a Dutch nonprofit with 501(c)(3) status. You can make a tax-deductible gift [here](/support).',
   ],
   buildHeading: 'What I want to build',
   bodyBuild: [


### PR DESCRIPTION
The Atalanta emblem image now links to its book page (Emblem I) with a 'Read this page →' cue. Adds a tax-deductible gift link to /support in the Embassy paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)