### PR TITLE
Use native auto-hiding scrollbars

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -339,24 +339,10 @@ h1, h2, h3, h4 {
   color: #fff;
 }
 
-/* Scrollbar styling */
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--bg-warm);
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--border-medium);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--text-muted);
-}
+/* Scrollbars: use the platform-native overlay scrollbar so it auto-hides and
+ * only appears while scrolling (normal macOS behavior). Defining custom
+ * ::-webkit-scrollbar rules opts out of the overlay/auto-hide and forces an
+ * always-visible track — so we intentionally leave scrollbars unstyled. */
 
 /* Search highlight */
 mark {


### PR DESCRIPTION
## What
Remove the global custom `::-webkit-scrollbar` styling so the page uses the platform-native overlay scrollbar — which auto-hides and only appears while scrolling (normal macOS behavior).

## Why
Defining `::-webkit-scrollbar` (track + thumb) opts the page out of the macOS overlay scrollbar and forces an always-visible track on the right edge on desktop. Reported as "the scrollbar is always showing."

## Scope
- One change in `src/app/globals.css`: the scrollbar block is replaced with a comment explaining why scrollbars are intentionally left unstyled.
- Affects scrollbars site-wide (page + inner scroll containers), all reverting to native. No JS, layout, or behavior changes otherwise.
- Trade-off noted: on platforms without overlay scrollbars (e.g. Windows/Linux Chrome) scrollbars revert to the default native style rather than the thin 8px bar; this is the cost of getting native auto-hide, since a custom `::-webkit-scrollbar` cannot also auto-hide.