### PR TITLE
fix(auth): prefetch-safe magic links + sharper webview steer

### DIFF
--- a/src/app/auth/confirm/page.tsx
+++ b/src/app/auth/confirm/page.tsx
@@ -1,0 +1,107 @@
+import Link from 'next/link';
+import { headers } from 'next/headers';
+
+/**
+ * Prefetch-safe magic-link interstitial.
+ *
+ * The email's "Sign in" button points here (/auth/confirm?next=<callback url>)
+ * instead of straight at the one-time-token callback. Mail clients and security
+ * scanners — Gmail's link prefetcher above all — GET links in an email to build
+ * previews / scan for malware; pointed at the raw callback that GET burns the
+ * single-use token before the human clicks, which is the dominant
+ * /auth/error?error=Verification failure. They land HERE instead (no token
+ * consumed) and stop; only a real click on the button below follows through to
+ * the callback, so the token survives until the person actually uses it.
+ *
+ * Deliberately a static server component with NO auto-redirect — an auto
+ * redirect (meta-refresh / JS) would re-introduce the prefetch consumption.
+ * The button is a plain <a> to the absolute callback URL so Next.js never
+ * prefetches it.
+ */
+
+// Only forward to a same-site NextAuth callback — never an arbitrary URL
+// (open-redirect / token-leak guard).
+function isSafeNext(next: string | undefined, requestHost: string | null): next is string {
+  if (!next) return false;
+  let u: URL;
+  try {
+    u = new URL(next);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return false;
+  if (!u.pathname.startsWith('/api/auth/callback/')) return false;
+  // Same host as this request, or any *.sourcelibrary.org (shared-cookie
+  // subdomains), or localhost in dev.
+  const host = u.host.toLowerCase();
+  if (requestHost && host === requestHost.toLowerCase()) return true;
+  if (host === 'sourcelibrary.org' || host.endsWith('.sourcelibrary.org')) return true;
+  if (host.startsWith('localhost') || host.startsWith('127.0.0.1')) return true;
+  return false;
+}
+
+export default async function ConfirmSignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const { next } = await searchParams;
+  const requestHost = (await headers()).get('host');
+  const safe = isSafeNext(next, requestHost);
+
+  return (
+    <div className="min-h-screen relative flex items-center justify-center">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/auth-bg.jpg" alt="" className="absolute inset-0 w-full h-full object-cover" />
+      <div className="absolute inset-0 bg-black/50" />
+
+      <div className="relative z-10 w-full max-w-md p-8 rounded-2xl text-center bg-white/95 backdrop-blur-sm border border-white/20 mx-4">
+        <svg className="w-12 h-12 mx-auto mb-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" stroke="var(--text-primary)" strokeWidth="1" />
+          <circle cx="12" cy="12" r="7" stroke="var(--text-primary)" strokeWidth="1" />
+          <circle cx="12" cy="12" r="4" stroke="var(--text-primary)" strokeWidth="1" />
+        </svg>
+
+        {safe ? (
+          <>
+            <h1 className="text-2xl font-medium mb-2" style={{ color: 'var(--text-primary)' }}>
+              You&rsquo;re one tap away
+            </h1>
+            <p className="text-base mb-6" style={{ color: 'var(--text-muted)' }}>
+              Confirm to finish signing in to Source Library.
+            </p>
+            {/* Plain <a> (not next/link) to the absolute callback URL so Next.js
+                never prefetches it — only a human click consumes the token. */}
+            <a
+              href={next}
+              rel="nofollow"
+              className="inline-block w-full px-4 py-3 rounded-lg text-base font-medium transition-all hover:brightness-110"
+              style={{ background: 'var(--accent-rust)', color: '#ffffff' }}
+            >
+              Sign in
+            </a>
+            <p className="mt-6 text-xs" style={{ color: 'var(--text-faint)' }}>
+              For your security this link can only be used once and expires in 24 hours.
+            </p>
+          </>
+        ) : (
+          <>
+            <h1 className="text-2xl font-medium mb-2" style={{ color: 'var(--text-primary)' }}>
+              This link can&rsquo;t be confirmed
+            </h1>
+            <p className="text-base mb-6" style={{ color: 'var(--text-muted)' }}>
+              It may have expired or already been used. Request a fresh sign-in link to continue.
+            </p>
+            <Link
+              href="/auth/signin"
+              className="inline-block w-full px-4 py-3 rounded-lg text-base font-medium transition-all hover:brightness-110"
+              style={{ background: 'var(--accent-rust)', color: '#ffffff' }}
+            >
+              Request a fresh link
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -28,20 +28,26 @@ function SignInContent() {
   const [inApp, setInApp] = useState(false);
   const [browser, setBrowser] = useState<'Safari' | 'Chrome'>('Chrome');
   const [appName, setAppName] = useState<string | null>(null);
-  // Log the sign-in page view once, tagged with why they arrived.
+  // Detect the host browser, then log the sign-in page view once — tagged with
+  // why they arrived AND whether they're trapped in an in-app browser, so we
+  // can measure how much of the funnel is webview traffic and whether the
+  // steer-to-email recovery is working.
   const loggedView = useRef(false);
   useEffect(() => {
-    if (loggedView.current) return;
-    loggedView.current = true;
-    trackEvent('signin_view', { reason, source: callbackUrl });
-  }, [reason, callbackUrl]);
-
-  useEffect(() => {
     const ua = navigator.userAgent;
-    setInApp(isInAppBrowser(ua));
+    const webview = isInAppBrowser(ua);
+    setInApp(webview);
     setBrowser(preferredBrowser(ua));
     setAppName(inAppBrowserName(ua));
-  }, []);
+
+    if (loggedView.current) return;
+    loggedView.current = true;
+    trackEvent('signin_view', {
+      reason,
+      source: callbackUrl,
+      channel: webview ? `in-app:${inAppBrowserName(ua) ?? 'unknown'}` : 'browser',
+    });
+  }, [reason, callbackUrl]);
 
   const handleEmailSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -124,9 +130,9 @@ function SignInContent() {
 
         {inApp && (
           <div className="mb-6 p-3 rounded-lg text-sm" style={{ background: '#fffbeb', color: '#92400e', border: '1px solid #fde68a' }}>
-            You&rsquo;re in {appName ? `${appName}’s` : 'an'} in-app browser, where Google sign-in usually fails.
-            Use <strong>email</strong> below — the link opens in your normal browser — or tap the{' '}
-            <strong>&#8230;</strong> menu and choose &ldquo;Open in {browser}&rdquo;.
+            You&rsquo;re in {appName ? `${appName}’s` : 'an'} in-app browser, where Google sign-in is usually blocked.
+            <strong> Use email below</strong> — we&rsquo;ll send a link that opens in your normal browser and signs you in.
+            (Or tap the <strong>&#8230;</strong> menu and choose &ldquo;Open in {browser}&rdquo;.)
           </div>
         )}
 
@@ -191,7 +197,7 @@ function SignInContent() {
             }}
             disabled={googleLoading}
             className="w-full flex items-center justify-center gap-3 px-4 py-3 rounded-lg font-medium transition-all hover:opacity-90 disabled:opacity-50"
-            style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)', border: '1px solid var(--border-medium)' }}
+            style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)', border: '1px solid var(--border-medium)', opacity: inApp ? 0.6 : 1 }}
           >
             {googleLoading ? (
               <>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -106,6 +106,26 @@ if (process.env.RESEND_API_KEY) {
     from: process.env.EMAIL_FROM || 'Source Library <noreply@sourcelibrary.org>',
     sendVerificationRequest: async ({ identifier: email, url }) => {
       try {
+        // Prefetch-safe magic link. The raw `url` is the one-time-token GET
+        // callback (/api/auth/callback/nodemailer?...token=...). Email clients
+        // and security scanners (Gmail's com.google.android.gm especially)
+        // PREFETCH links to render previews / scan for malware — which fires
+        // that GET and burns the single-use token before the human ever clicks,
+        // surfacing as the dominant /auth/error?error=Verification failure.
+        //
+        // So the button instead points at /auth/confirm?next=<real url>: a
+        // static interstitial with a "Sign in" button. A prefetcher GETs the
+        // interstitial (harmless — no token consumed) and stops; only a human
+        // click follows through to the real callback. Token survives until then.
+        let confirmUrl = url;
+        try {
+          const origin = new URL(url).origin;
+          confirmUrl = `${origin}/auth/confirm?next=${encodeURIComponent(url)}`;
+        } catch {
+          // If url can't be parsed for some reason, fall back to the raw link
+          // rather than failing the whole sign-in.
+        }
+        const linkUrl = confirmUrl;
         await resend.emails.send({
           from: process.env.EMAIL_FROM || 'Source Library <noreply@sourcelibrary.org>',
           to: email,
@@ -120,7 +140,7 @@ if (process.env.RESEND_API_KEY) {
                 </p>
               </div>
               <div style="text-align: center; margin: 32px 0;">
-                <a href="${url}" style="display: inline-block; padding: 14px 40px; background: #9e4a3a; color: #ffffff; text-decoration: none; border-radius: 8px; font-size: 16px; font-family: -apple-system, sans-serif;">
+                <a href="${linkUrl}" style="display: inline-block; padding: 14px 40px; background: #9e4a3a; color: #ffffff; text-decoration: none; border-radius: 8px; font-size: 16px; font-family: -apple-system, sans-serif;">
                   Sign In
                 </a>
               </div>


### PR DESCRIPTION
## Why

While digging into PostHog to understand what triggers sign-ups, the dominant auth failure surfaced: **`/auth/error?error=Verification` (178 in the last 7 days) vs OAuth `Configuration` (45)** — email magic-link loss is ~4× the social-webview OAuth loss we'd been focused on.

Root cause: the magic link points straight at the one-time-token callback (`/api/auth/callback/nodemailer?...token=...`). Email clients and security scanners — **Gmail (`com.google.android.gm`) above all** — prefetch links to preview/scan them, firing that GET and **burning the single-use token before the human clicks**. Verification-error referrers confirm it: Gmail app + "direct/Chrome" (link clicked after a scanner already spent it).

## What

**(a) Prefetch-safe magic links.** The email button now points at `/auth/confirm?next=<callback>` — a static, **no-auto-redirect** interstitial with a "Sign in" button. A prefetcher GETs the interstitial (no token consumed) and stops; only a human click follows through to the real callback, so the token survives until it's actually used. `next` is validated to be a same-site `/api/auth/callback/` URL (open-redirect guard); the auth layout's `force-dynamic` keeps the token URL uncached.

**(b) Sharper webview steer.** On the sign-in page, make **email the clear primary path in in-app browsers** (the emailed link now reliably escapes the webview into the real browser), de-emphasize the usually-blocked Google button there, and tag `signin_view` with a `channel` (`in-app:<App>` | `browser`) so we can measure webview share and recovery.

## Scope

- In scope: the email-link consumption fix (a) and the webview UX/measurement (b).
- Out of scope: the homepage conversion finding (sign-ups are homepage-driven and happen *before* reading — 1,169 of ~1,386 sign-in sessions viewed zero books first). Noted for a separate CTA experiment, not touched here.

## Test notes

- `npx tsc --noEmit` clean.
- Manual: request an email link on the preview → click → lands on `/auth/confirm` → "Sign in" completes. A prefetch/HEAD of the email link should NOT consume the token.
- `/auth/confirm` with a missing/foreign `next` shows the "request a fresh link" recovery state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)