### PR TITLE
fix(pipeline): archive workers honor the selective-unpause scope

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -29,6 +29,7 @@ import { pipeline } from 'stream/promises';
 import { createWriteStream } from 'fs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
+import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 
 // CLI args
 const args = process.argv.slice(2);
@@ -491,10 +492,21 @@ async function main() {
   // should run regardless of the queue-level pause (matching the "bypassing the queue"
   // intent of --book-id). The pause only gates the automatic queue path.
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
-  if (control?.paused && !TARGET_BOOK_ID) {
+  if (!shouldBypassPause(control, { bookOverride: !!TARGET_BOOK_ID })) {
     console.log(`[archive-bulk] Pipeline paused. Exiting.`);
     await client.close();
     process.exit(0);
+  }
+  // Selective unpause: when globally paused but a scope is configured (and this
+  // isn't an explicit --book-id one-off), proceed but confine archiving to the
+  // scoped books — mirrors what the orchestrator does for the paid path (#2616),
+  // so the free archiving step doesn't strand scoped books at `queued` with no
+  // images on R2. SCOPE_IDS stays null in normal operation (full queue) and for
+  // a --book-id run (TARGET_BOOK_ID already confines).
+  let SCOPE_IDS = null;
+  if (control?.paused && !TARGET_BOOK_ID && hasScope(control)) {
+    SCOPE_IDS = [...await resolveScopeBookIds(db, control)];
+    console.log(`[archive-bulk] PAUSED globally, selective-unpause scope active — confining to ${SCOPE_IDS.length} allowlisted book(s).`);
   }
 
   // Find IA books with pages that may need archiving (regardless of pipeline status).
@@ -513,6 +525,8 @@ async function main() {
           { ia_identifier: { $exists: true, $ne: null, $ne: '' } },
           { 'image_source.provider': 'internet_archive' },
         ],
+        // Selective-unpause scope: confine to allowlisted books while paused.
+        ...(SCOPE_IDS ? { id: { $in: SCOPE_IDS } } : {}),
       }};
   const iaBooks = await db.collection('books')
     .aggregate([
@@ -548,6 +562,7 @@ async function main() {
           { ia_identifier: { $exists: true, $ne: null, $ne: '' } },
           { 'image_source.provider': 'internet_archive' },
         ],
+        ...(SCOPE_IDS ? { id: { $in: SCOPE_IDS } } : {}),
       }},
       { $addFields: {
         _priority: {

--- a/scripts/workers/archive-gallica.mjs
+++ b/scripts/workers/archive-gallica.mjs
@@ -16,6 +16,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
+import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -118,10 +119,19 @@ async function main() {
 
   // Check pause
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
-  if (control?.paused) {
+  if (!shouldBypassPause(control)) {
     console.log(`[archive-gallica] Pipeline paused. Exiting.`);
     await client.close();
     return;
+  }
+  // Selective unpause: confine to scoped books while globally paused (free
+  // archiving must honor the same scope as the paid path, #2616). Empty in
+  // normal operation.
+  let SCOPE_FILTER = {};
+  if (control?.paused && hasScope(control)) {
+    const scopeIds = [...await resolveScopeBookIds(db, control)];
+    SCOPE_FILTER = { id: { $in: scopeIds } };
+    console.log(`[archive-gallica] PAUSED globally, scope active — confining to ${scopeIds.length} allowlisted book(s).`);
   }
 
   // Find Gallica books with unarchived pages
@@ -129,6 +139,7 @@ async function main() {
     .find({
       'image_source.provider': { $in: ['gallica', 'iiif'] },
       pages_count: { $gt: 0 },
+      ...SCOPE_FILTER,
     }, { projection: { id: 1, title: 1, pages_count: 1, pages_archived: 1 } })
     .limit(1000)
     .maxTimeMS(30_000)

--- a/scripts/workers/archive-harvard.mjs
+++ b/scripts/workers/archive-harvard.mjs
@@ -20,6 +20,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
+import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -118,10 +119,19 @@ async function main() {
 
   // Check pause
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
-  if (control?.paused) {
+  if (!shouldBypassPause(control)) {
     console.log(`[archive-harvard] Pipeline paused. Exiting.`);
     await client.close();
     return;
+  }
+  // Selective unpause: confine to scoped books while globally paused (free
+  // archiving must honor the same scope as the paid path, #2616). Empty in
+  // normal operation.
+  let SCOPE_FILTER = {};
+  if (control?.paused && hasScope(control)) {
+    const scopeIds = [...await resolveScopeBookIds(db, control)];
+    SCOPE_FILTER = { id: { $in: scopeIds } };
+    console.log(`[archive-harvard] PAUSED globally, scope active — confining to ${scopeIds.length} allowlisted book(s).`);
   }
 
   // Find Harvard books with unarchived pages. Books with pages_archived < pages_count
@@ -132,6 +142,7 @@ async function main() {
       pages_count: { $gt: 0 },
       $expr: { $lt: [{ $ifNull: ['$pages_archived', 0] }, '$pages_count'] },
       'archive_metadata.blocked': { $ne: true },
+      ...SCOPE_FILTER,
     }, { projection: { id: 1, title: 1, pages_count: 1, pages_archived: 1 } })
     .limit(1000)
     .maxTimeMS(30_000)

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -15,6 +15,7 @@ import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
 import { upgradeToFullRes } from '../lib/iiif-utils.mjs';
+import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 
 const MAX_PAGES = 10_000;
 // MAX_PAGES_PER_DOMAIN caps how many pages from a single source make it into one
@@ -232,10 +233,21 @@ async function main() {
 
   // Check processing_control pause
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
-  if (control?.paused) {
+  if (!shouldBypassPause(control)) {
     console.log(`[archive-ocr] Pipeline paused. Exiting.`);
     await client.close();
     process.exit(0);
+  }
+  // Selective unpause: when globally paused but a scope is configured, proceed
+  // but confine archiving to the scoped books (free archiving must honor the
+  // same scope as the paid path, #2616, or scoped books strand at `queued` with
+  // no R2 images). SCOPE_FILTER spreads into every candidate query; it's empty
+  // in normal (unpaused) operation, so the full queue is unaffected.
+  let SCOPE_FILTER = {};
+  if (control?.paused && hasScope(control)) {
+    const scopeIds = [...await resolveScopeBookIds(db, control)];
+    SCOPE_FILTER = { id: { $in: scopeIds } };
+    console.log(`[archive-ocr] PAUSED globally, selective-unpause scope active — confining to ${scopeIds.length} allowlisted book(s).`);
   }
 
   console.log(`[archive-ocr] Looking for books with unarchived pages...`);
@@ -268,6 +280,7 @@ async function main() {
         'archive_metadata.blocked': { $ne: true },
         'image_source.provider': { $in: PRIORITY_PROVIDERS },
         ...NEEDS_ARCHIVE_EXPR,
+        ...SCOPE_FILTER,
       },
       { projection: { id: 1, title: 1, 'image_source.provider': 1 } }
     )
@@ -288,6 +301,7 @@ async function main() {
         // Routed to Mac-side via scripts/workers/archive-harvard.mjs.
         'image_source.provider': { $nin: ['e-rara', 'gallica', 'internet_archive', 'harvard', ...PRIORITY_PROVIDERS] },
         ...NEEDS_ARCHIVE_EXPR,
+        ...SCOPE_FILTER,
       },
       { projection: { id: 1, title: 1, 'image_source.provider': 1 } }
     )
@@ -306,6 +320,7 @@ async function main() {
         'archive_metadata.blocked': { $ne: true },
         'image_source.provider': { $in: HETZNER_SAFE_PROVIDERS },
         ...NEEDS_ARCHIVE_EXPR,
+        ...SCOPE_FILTER,
       },
       { projection: { id: 1, title: 1, 'image_source.provider': 1, language: 1, is_first_translation: 1 } }
     )
@@ -327,6 +342,7 @@ async function main() {
         'archive_metadata.bulk_unsuitable': true,
         'image_source.provider': 'internet_archive',
         ...NEEDS_ARCHIVE_EXPR,
+        ...SCOPE_FILTER,
       },
       { projection: { id: 1, title: 1, 'image_source.provider': 1 } }
     )

--- a/scripts/workers/lib/selective-unpause.mjs
+++ b/scripts/workers/lib/selective-unpause.mjs
@@ -41,3 +41,27 @@ export function shouldBypassPause(control, { bookOverride = false } = {}) {
   if (!control?.paused) return true;
   return Boolean(bookOverride) || hasScope(control);
 }
+
+/**
+ * Resolve the full set of book ids a selective-unpause scope covers:
+ * allow_book_ids[] ∪ (book ids in allow_collections[]). DB-backed, so it lives
+ * here rather than in the pure helpers above — callers confine their candidate
+ * queries to this set while the global pause is active. Mirrors the inline
+ * resolution the pipeline-orchestrator already does for the paid path (#2616);
+ * the archive workers reuse it so the FREE archiving step honors the same scope
+ * (otherwise scoped books never get their images to R2 and nothing downstream
+ * can run — the gap this closes).
+ *
+ * Returns a Set<string> of book ids (empty if no scope configured).
+ */
+export async function resolveScopeBookIds(db, control) {
+  const { bookIds, collections } = getScopeConfig(control);
+  const ids = new Set(bookIds);
+  if (collections.length) {
+    const scoped = await db.collection('books')
+      .find({ collections: { $in: collections } }, { projection: { id: 1 } })
+      .toArray();
+    for (const b of scoped) ids.add(String(b.id));
+  }
+  return ids;
+}

--- a/tests/unit/selective-unpause.test.ts
+++ b/tests/unit/selective-unpause.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — plain .mjs helper, no types
-import { getScopeConfig, hasScope, shouldBypassPause } from '../../scripts/workers/lib/selective-unpause.mjs';
+import { getScopeConfig, hasScope, shouldBypassPause, resolveScopeBookIds } from '../../scripts/workers/lib/selective-unpause.mjs';
+
+// Minimal Mongo-ish stub: books.find({collections:{$in}}).toArray() returns the
+// rows whose `collections` intersect the queried slugs.
+function mockDb(booksByCollection: Record<string, string[]>) {
+  return {
+    collection() {
+      return {
+        find(query: any) {
+          const slugs: string[] = query?.collections?.$in ?? [];
+          const ids = new Set<string>();
+          for (const slug of slugs) for (const id of booksByCollection[slug] ?? []) ids.add(id);
+          return { toArray: async () => [...ids].map(id => ({ id })) };
+        },
+      };
+    },
+  };
+}
 
 describe('selective-unpause scope helpers', () => {
   describe('shouldBypassPause — the load-bearing invariant', () => {
@@ -38,6 +55,22 @@ describe('selective-unpause scope helpers', () => {
     it('is true when either list is non-empty', () => {
       expect(hasScope({ allow_book_ids: ['x'] })).toBe(true);
       expect(hasScope({ allow_collections: ['y'] })).toBe(true);
+    });
+  });
+
+  describe('resolveScopeBookIds — book ids ∪ collection-resolved ids', () => {
+    it('returns explicit allow_book_ids when no collections', async () => {
+      const ids = await resolveScopeBookIds(mockDb({}), { allow_book_ids: ['a', 'b'] });
+      expect([...ids].sort()).toEqual(['a', 'b']);
+    });
+    it('unions allow_book_ids with books in allow_collections (deduped)', async () => {
+      const db = mockDb({ 'cannabis-western-record': ['b', 'c'] });
+      const ids = await resolveScopeBookIds(db, { allow_book_ids: ['a', 'b'], allow_collections: ['cannabis-western-record'] });
+      expect([...ids].sort()).toEqual(['a', 'b', 'c']);
+    });
+    it('is empty when no scope is configured', async () => {
+      const ids = await resolveScopeBookIds(mockDb({}), {});
+      expect(ids.size).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Problem

Selective unpause (#2616) let the **paid** orchestrator process allowlisted books while globally paused, but the **free archiving** workers still hard-exited on `processing_control.paused` (bypassing only via per-invocation `--book-id` / `--ignore-pause`). They never read `allow_book_ids` / `allow_collections`.

**Net effect:** scoped books got enrolled at `status: queued` but their images were never pulled to R2, so OCR couldn't start — the entire scope sat frozen. Observed live: 49 scoped books (Derek's esoterica + cannabis work + 3 newly-imported Augustinus tomes), zero progress over an hour, even an 8-page book stuck. The orchestrator ran every 15 min doing zero work because nothing was ever archived.

## Fix

Archive workers now reuse the existing `selective-unpause.mjs` helper:
- New DB-backed `resolveScopeBookIds(db, control)` → `allow_book_ids` ∪ (books in `allow_collections`), mirroring the inline resolution the orchestrator already does.
- Each worker: replace the hard `if (paused) exit` with `shouldBypassPause(control, …)`; when globally paused **with a scope set**, proceed but confine candidate queries to the scoped set (`SCOPE_FILTER` / `SCOPE_IDS`).
- Empty in normal (unpaused) operation → full-queue path unchanged. A `--book-id` one-off is unchanged.

Applied to **archive-bulk** (IA — covers the current all-IA scope), **archive-ocr** (IIIF/other), **archive-gallica**, **archive-harvard** — every tracked worker that gated on the pause. (`archive-iiif-local` is untracked/Mac-local; not part of the Hetzner cron path.)

## Validation

Against prod: with the scope active, `archive-bulk`'s candidate query now returns **65 scoped IA books** (incl. all 3 Augustinus tomes) — was **0** (it exited on the pause). New unit test covers `resolveScopeBookIds` (union + dedup); all 12 selective-unpause tests pass.

## Rollout

Pure `scripts/**` change — no Vercel deploy. The Hetzner box auto-pulls `main` every ~5 min, so the next `archive-bulk` run after merge will start archiving the scoped books, then OCR/translation flows through the (already scope-aware) orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)