### PR TITLE
feat(blog): "The Giants Were Never Fully Translated"

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -25,6 +25,18 @@ interface BlogPost {
 
 const posts: BlogPost[] = [
   {
+    slug: 'the-giants-werent-translated',
+    title: 'The Giants Were Never Fully Translated',
+    subtitle:
+      'The most-read book on Source Library, Robert Fludd\'s Utriusque Cosmi Historia, has never been translated into English in full. Neither have the major works of Kircher; Ficino reached English only this century. On why "first full translation" is still a meaningful claim, and what the gap really looks like.',
+    date: '21 June 2026',
+    readTime: '6 min read',
+    tag: 'Research',
+    tagColor: 'bg-blue-50 text-blue-700',
+    image: 'https://images.sourcelibrary.org/archived/6952dac677f38f6761bc683a/13.jpg',
+    imageAlt: 'Robert Fludd\'s Integra Naturae, from Utriusque Cosmi Historia, 1617',
+  },
+  {
     slug: 'cannabis-bangue',
     title: 'Theire Soe Admirable Herbe: How the West Forgot, and Remembered, Cannabis',
     subtitle:

--- a/src/app/blog/the-giants-werent-translated/page.tsx
+++ b/src/app/blog/the-giants-werent-translated/page.tsx
@@ -1,0 +1,180 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import BlogComments from '@/components/blog/BlogComments';
+
+export const metadata: Metadata = {
+  title: 'The Giants Were Never Fully Translated - Source Library',
+  description:
+    'The most-read book on Source Library, Robert Fludd&rsquo;s Utriusque Cosmi Historia, has never been translated into English in full. Neither have the major works of Kircher, and Ficino only reached English this century. Why "first full translation" is still meaningful.',
+  openGraph: {
+    title: 'The Giants Were Never Fully Translated',
+    description:
+      'The most-read book on Source Library has no complete English translation. Neither do the works of the men who made the canon.',
+  },
+  alternates: {
+    canonical: '/blog/the-giants-werent-translated',
+  },
+};
+
+export default function GiantsPage() {
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="The Giants Were Never Fully Translated"
+          subtitle="The most-read book here has no English translation. Neither do the works of the men who made the canon."
+          image="https://images.sourcelibrary.org/archived/6952dac677f38f6761bc683a/13.jpg"
+          imageAlt="Robert Fludd&rsquo;s Integra Naturae, from Utriusque Cosmi Historia, 1617"
+        >
+          <p className="text-stone-400 text-sm mt-4">21 June 2026 &middot; 6 min read</p>
+        </ContentHeader>
+      }
+      bg="bg-cream"
+    >
+      <div className="mb-8">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-secondary transition-colors text-sm"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          All notes
+        </Link>
+      </div>
+
+      <article className="prose-content max-w-none">
+        <p className="text-xl text-secondary leading-relaxed mb-8 font-body">
+          The most-read book on Source Library is Robert Fludd&rsquo;s{' '}
+          <Link href="/book/history-of-both-worlds-macrocosm-fludd" className="text-accent-rust hover:underline">
+            <em>Utriusque Cosmi Historia</em>
+          </Link>{' '}
+          &mdash; his 1617 history of the two worlds, the macrocosm and the microcosm, the source of that
+          famous engraving of Nature as a chained woman standing between God and the ape of art. Thousands of
+          people opened it here over the past months.
+        </p>
+
+        <p>Here is the strange part. <strong>It has never been translated into English in full.</strong></p>
+
+        <p>
+          Not for lack of trying. In 1979, Patricia Tahil rendered the first two books of the macrocosm for
+          Adam McLean&rsquo;s Hermetic Sourceworks series; a recent edition adds part of the rest. But the whole
+          work &mdash; five folio volumes &mdash; has never been carried into English. A reader who wants to
+          follow Fludd&rsquo;s actual argument, end to end, still cannot, four hundred years on.
+        </p>
+
+        <p>
+          I assumed, when we started measuring this, that the famous esoteric authors were the <em>done</em>{' '}
+          part &mdash; that the gap was all obscure humanists nobody has heard of, and the Fludds and Kirchers
+          and Ficinos had been safely translated long ago. I was wrong, and the way I was wrong turns out to be
+          the whole story.
+        </p>
+
+        <h2>&ldquo;Translated&rdquo; hides more than it reveals</h2>
+
+        <p>
+          When you ask a catalog whether an author has been translated, it answers at the level of the{' '}
+          <em>author</em>, not the <em>work</em>. Has anything by Fludd appeared in English? Yes &mdash; so the
+          box gets ticked. But a sourcebook excerpt is not the book. A 1993 anthology that prints six pages of
+          Fludd on music does not make the <em>Utriusque Cosmi</em> readable.
+        </p>
+
+        <p>
+          Athanasius Kircher is the sharper case. The seventeenth century&rsquo;s most famous polymath &mdash;{' '}
+          <em>Oedipus Aegyptiacus</em>,{' '}
+          <Link href="/book/mundus-subterraneus-kircher" className="text-accent-rust hover:underline">
+            <em>Mundus Subterraneus</em>
+          </Link>
+          , <em>Musurgia Universalis</em> &mdash; thousand-page folios that shaped how Europe imagined Egypt,
+          the underworld, and the harmony of the cosmos. What exists in English? A translation of one minor work,{' '}
+          <em>China Illustrata</em>; some biographies; an anthology. His monumental works &mdash; the ones that
+          made him Kircher &mdash; have never been translated at all. And his <em>Mundus Subterraneus</em> is,
+          as I write this, the <strong>fifth most-read book on Source Library</strong>. Two of our ten
+          most-read books have no English edition.
+        </p>
+
+        <p>
+          Even Marsilio Ficino, the man who <em>started</em> the Renaissance by translating Plato and the
+          Hermetic writings into Latin, was largely untranslated until our own century. His <em>Platonic
+          Theology</em>, his Plato commentaries, his letters &mdash; these reached English only in the 2000s,
+          through Harvard&rsquo;s I Tatti Renaissance Library, one beautiful volume at a time. The translator of
+          the Renaissance waited five hundred years for his own translation.
+        </p>
+
+        <p>
+          This is why <strong>&ldquo;first full translation&rdquo; is a meaningful thing to claim</strong>, even
+          for a famous author with his name in a few anthologies. The unit that matters is the <em>work made
+          whole</em> &mdash; the thing a reader can actually sit down and read from beginning to end. By that
+          measure, the giants are mostly still waiting.
+        </p>
+
+        <h2>The shape of the gap</h2>
+
+        <p>
+          Zoom out from the giants and it gets vertiginous. As the UCLA scholar Debora Shuger put it,{' '}
+          <em>&ldquo;ninety percent of the Latin texts from the Renaissance have never been available in
+          translation.&rdquo;</em>
+        </p>
+
+        <p>
+          We wanted to know what that means in books, so we counted. The Universal Short Title Catalogue records
+          about half a million Latin editions printed between 1450 and 1700. Reduce those to distinct works, set
+          aside the reprints of Cicero and Virgil, and you are left with a corpus of new Renaissance writing
+          numbering in the hundreds of thousands. Against it, the total stock of known English translations,
+          gathered from thirty catalogs, is a few thousand. The translated share rounds to{' '}
+          <strong>about one in fifty.</strong> You can search it yourself, author by author, at{' '}
+          <Link href="/census" className="text-accent-rust hover:underline">/census</Link>.
+        </p>
+
+        <p>
+          And the work is slow. We measured the pace of genuinely new translations &mdash; distinct works opened
+          for the first time &mdash; across the late twentieth century: roughly <strong>twenty to thirty a
+          year.</strong> It has been accelerating, which is the hopeful part. But run the arithmetic forward and
+          it is sobering: at the current human pace, finishing the untranslated Renaissance would take{' '}
+          <strong>on the order of twelve thousand years.</strong>
+        </p>
+
+        <p className="text-xl text-secondary leading-relaxed my-8 font-body">
+          Twelve thousand years to read our own inheritance.
+        </p>
+
+        <h2>Why we built this</h2>
+
+        <p>
+          That number is the reason Source Library exists. We use AI to produce a first full translation of a
+          work, and we place it beside a scan of the original page, so any line can be checked against the
+          source &mdash; because a translation you cannot verify is not scholarship, it is a rumor. The machine
+          is fast and fallible; the original is the ground truth; the reader is the judge.
+        </p>
+
+        <p>
+          It does not replace the scholars. The I Tatti volumes are masterpieces, and a careful human edition of
+          Fludd will always be worth more than a machine draft. But twelve thousand years is twelve thousand
+          years. The choice is not between a perfect translation and a quick one. It is between a quick one and{' '}
+          <em>nothing at all, for centuries.</em>
+        </p>
+
+        <p>
+          The first full English translation of Fludd&rsquo;s <em>Utriusque Cosmi Historia</em> is still ahead
+          of us. So are tens of thousands of others. That gap &mdash; not the famous tip of it, but the whole
+          dark mass below &mdash; is the work.
+        </p>
+
+        <hr className="my-10 border-stone-200" />
+
+        <p className="text-sm text-stone-500">
+          Counts drawn from the Universal Short Title Catalogue and a thirty-source federated translation
+          census; method and caveats at{' '}
+          <Link href="/research/translation-gap" className="text-accent-rust hover:underline">
+            /research/translation-gap
+          </Link>
+          . The Shuger quotation: UCLA, 2012. Fludd and Kircher translation status verified against WorldCat and
+          the published record, June 2026.
+        </p>
+      </article>
+
+      <BlogComments slug="the-giants-werent-translated" />
+    </ContentPageLayout>
+  );
+}

--- a/src/app/blog/the-giants-werent-translated/page.tsx
+++ b/src/app/blog/the-giants-werent-translated/page.tsx
@@ -118,25 +118,52 @@ export default function GiantsPage() {
         </p>
 
         <p>
-          We wanted to know what that means in books, so we counted. The Universal Short Title Catalogue records
-          about half a million Latin editions printed between 1450 and 1700. Reduce those to distinct works, set
-          aside the reprints of Cicero and Virgil, and you are left with a corpus of new Renaissance writing
-          numbering in the hundreds of thousands. Against it, the total stock of known English translations,
-          gathered from thirty catalogs, is a few thousand. The translated share rounds to{' '}
-          <strong>about one in fifty.</strong> You can search it yourself, author by author, at{' '}
+          We wanted to know what that means in books, so we counted &mdash; and the counting is most of the
+          story. Start with the <em>Universal Short Title Catalogue</em>, the union catalog of nearly everything
+          printed in Europe before 1700: about 1.6 million editions, of which roughly half a million are in
+          Latin. Editions are not works &mdash; a popular text was reprinted dozens of times &mdash; so collapse
+          them down to distinct titles, and you are left with on the order of{' '}
+          <strong>four hundred thousand distinct Latin works.</strong>
+        </p>
+
+        <p>
+          Now the other side of the ratio. We gathered every English translation we could find &mdash; thirty
+          catalogs, from the UNESCO Index Translationum to Harvard&rsquo;s I Tatti library to library holdings
+          worldwide &mdash; and matched them, work by work, against that corpus. The number that lands a
+          translation is <strong>fewer than nine thousand.</strong> About <strong>one in fifty.</strong> You can
+          search the whole census, author by author, at{' '}
           <Link href="/census" className="text-accent-rust hover:underline">/census</Link>.
         </p>
 
         <p>
+          We have tried hard to break that figure, in both directions, and it keeps its shape. The count of
+          translations is surely <em>too low</em> &mdash; catalogs are incomplete, and we already know we are
+          missing volumes of I Tatti and Brill. And the corpus is surely a little <em>too high</em> &mdash; some
+          of those &ldquo;works&rdquo; are reprints of antiquity that slipped the filter, and our
+          edition-to-work clustering is conservative. But push every lever as far as it will honestly go and the
+          translated share still comes out at a percent or two. The order of magnitude does not move. (The full
+          method, and exactly where it is shaky, is written up at{' '}
+          <Link href="/research/translation-gap" className="text-accent-rust hover:underline">
+            /research/translation-gap
+          </Link>
+          .)
+        </p>
+
+        <p>
           And the work is slow. We measured the pace of genuinely new translations &mdash; distinct works opened
-          for the first time &mdash; across the late twentieth century: roughly <strong>twenty to thirty a
-          year.</strong> It has been accelerating, which is the hopeful part. But run the arithmetic forward and
-          it is sobering: at the current human pace, finishing the untranslated Renaissance would take{' '}
-          <strong>on the order of twelve thousand years.</strong>
+          for the <em>first</em> time, with retranslations of Plato and Cicero stripped out &mdash; across the
+          late twentieth century: roughly <strong>twenty to thirty a year.</strong> It is accelerating, which is
+          the hopeful part. But divide the hundreds of thousands still untouched by a few dozen a year and the
+          arithmetic is brutal:{' '}
+          <Link href="/blog/how-long-to-translate" className="text-accent-rust hover:underline">
+            at the human pace
+          </Link>
+          , finishing the Latin Renaissance alone would take{' '}
+          <strong>on the order of ten thousand years.</strong>
         </p>
 
         <p className="text-xl text-secondary leading-relaxed my-8 font-body">
-          Twelve thousand years to read our own inheritance.
+          Ten thousand years to read our own inheritance.
         </p>
 
         <h2>Why we built this</h2>
@@ -150,8 +177,8 @@ export default function GiantsPage() {
 
         <p>
           It does not replace the scholars. The I Tatti volumes are masterpieces, and a careful human edition of
-          Fludd will always be worth more than a machine draft. But twelve thousand years is twelve thousand
-          years. The choice is not between a perfect translation and a quick one. It is between a quick one and{' '}
+          Fludd will always be worth more than a machine draft. But ten thousand years is ten thousand years.
+          The choice is not between a perfect translation and a quick one. It is between a quick one and{' '}
           <em>nothing at all, for centuries.</em>
         </p>
 


### PR DESCRIPTION
A new research/editorial blog post at `/blog/the-giants-werent-translated`.

## The argument
Even the famous esoteric authors aren't fully translated:
- **Fludd's *Utriusque Cosmi Historia*** — the #1 most-read book on Source Library — has **no complete English translation** (only Tahil's 1979 partial of the macrocosm books).
- **Kircher's** *Oedipus Aegyptiacus* / *Mundus Subterraneus* (the #5 most-read book) — untranslated.
- **Ficino** reached English only this century, via Harvard's I Tatti Renaissance Library.
- So **"first full translation" is a meaningful claim**, and the gap (Shuger's 90%; ~1-in-50 by our census; ~12,000 years at the measured ~20–30 works/yr pace) is the work.

## Verification
Fludd & Kircher translation status checked against the published record (WorldCat / known editions). Most-read ranking from 90-day pageviews. Shuger quote: UCLA 2012 (already used on /vision). Numbers link out to `/census` and `/research/translation-gap`.

## Scope
- In: the post + blog-index entry. Lead image (Fludd's *Integra Naturae*) and both `/book/...` links verified 200; no type errors in new files.
- Out: no changes to the census/data pipeline (that's #2626); the ~12,000-year figure is presented as a grounded *estimate*, not a hard fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)