### PR TITLE
feat(ft): clickable badge evidence panel + 'Existing translations' + structured priors (#2639)

### DIFF
--- a/scripts/eval/ft-ingest-verdicts.ts
+++ b/scripts/eval/ft-ingest-verdicts.ts
@@ -74,6 +74,14 @@ async function main() {
       queries: v.queries ?? [], // the actual searches issued — load-bearing absence evidence
       result: (found ? 'found' : 'none') as 'found' | 'none',
       found_refs: [], // registry ids assigned when #2453 registry exists
+      priors: priors.map((p) => ({          // structured, for per-book consumers (badge panel, work-linking)
+        english_title: p.english_title,
+        translator: p.translator,
+        pub_year: p.pub_year,
+        publisher: p.publisher,
+        completeness: p.completeness,
+        source_url: p.source_url,
+      })),
       evidence_strength: v.evidence_strength,
       model: v.model,
       cost_usd: v.cost_usd,

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -44,7 +44,7 @@ import { AuthCheck } from '@/components/auth/AuthCheck';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { authorUrl } from '@/lib/slugify';
-import { firstTranslationBadge, firstTranslationDescription } from '@/lib/first-translation-labels';
+import FirstTranslationEvidence from '@/components/book/FirstTranslationEvidence';
 import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
 import { getEffectiveByline } from '@/lib/byline';
 import AuthorName from '@/components/AuthorName';
@@ -881,49 +881,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed
                 )}
               </div>
 
-              {book.is_first_translation && (
-                <div className="mt-3">
-                  <details className="group">
-                    <summary className="inline-flex px-2.5 py-1 bg-accent-gold/20 text-accent-gold hover:bg-accent-gold/30 text-xs font-medium rounded-full border border-accent-gold/30 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden">
-                      {firstTranslationBadge(book.translation_verification?.disposition, book.language)}
-                    </summary>
-                    <div className="mt-2 p-3 bg-stone-800/50 rounded-lg border border-stone-700/50 text-xs space-y-2">
-                      <p className="text-stone-300">
-                        {firstTranslationDescription(book.translation_verification?.disposition)}
-                      </p>
-                      {book.translation_verification?.reasoning && (
-                        <p className="text-stone-400">{book.translation_verification.reasoning}</p>
-                      )}
-                      {(book.translation_verification?.translations_found?.length ?? 0) > 0 && (
-                        <div className="space-y-1">
-                          <span className="text-stone-500">Related translations found:</span>
-                          {book.translation_verification!.translations_found!.map((t, i: number) => (
-                            <p key={i} className="text-stone-400 pl-2">
-                              <span className="italic">{t.english_title}</span>
-                              {t.translator && t.translator !== 'unknown' && `, trans. ${t.translator}`}
-                              {t.pub_year && ` (${t.pub_year})`}
-                              {t.completeness && t.completeness !== 'unknown' && <span className="text-stone-500"> [{t.completeness}]</span>}
-                              {t.url && (
-                                <>{' '}<a href={t.url} target="_blank" rel="noopener noreferrer" className="text-accent-gold hover:text-accent-gold/80 underline">source</a></>
-                              )}
-                            </p>
-                          ))}
-                        </div>
-                      )}
-                      {book.translation_verification?.tools_called && (
-                        <p className="text-stone-600 text-[10px]">
-                          Verified {book.translation_verification.verified_at ? new Date(book.translation_verification.verified_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : ''} via{' '}
-                          {book.translation_verification.tools_called
-                            .filter((t: string) => t !== 'make_determination')
-                            .map((t: string) => t.replace('search_', '').replace(/_/g, ' '))
-                            .join(', ')}
-                          {embedPolicy.showExternalLinks && <>{' '}&middot;{' '}<a href="/blog/first-translation-methodology" className="underline hover:text-stone-500">methodology</a></>}
-                        </p>
-                      )}
-                    </div>
-                  </details>
-                </div>
-              )}
+              {/* #2564/#2639: graded verdict + grounded evidence, with legacy fallback.
+                  Renders the "First Translation" or "Existing translations" badge,
+                  or null when neither applies. */}
+              <FirstTranslationEvidence
+                book={book as never}
+                showExternalLinks={embedPolicy.showExternalLinks}
+              />
 
               {/* Dedication */}
               <div className="mt-3">

--- a/src/components/book/FirstTranslationEvidence.tsx
+++ b/src/components/book/FirstTranslationEvidence.tsx
@@ -1,0 +1,250 @@
+/**
+ * First-translation badge + click-through evidence panel (#2564 / #2639).
+ *
+ * Two reader-facing surfaces, one panel:
+ *  - a FIRST-family verdict  → "First Translation" badge (varied label)
+ *  - a `not_first` verdict    → "Existing translations" badge (points the reader
+ *    at the English version that already exists)
+ *
+ * Prefers the graded #2564 model (`book.first_translation` + the strongest
+ * `first_translation_attempts` row: grounded queries, sources consulted,
+ * evidence strength, structured priors). Falls back to the legacy
+ * `translation_verification` panel so nothing regresses before the enumeration
+ * has populated attempts at scale.
+ *
+ * #2232 discipline: render the STRUCTURED prior (title/translator/year + link)
+ * and the real sources — never the AI's free prose as if it were source text.
+ */
+import { getReadDb } from '@/lib/mongodb';
+import {
+  getAttempts,
+  strongestAttempt,
+  type FirstTranslationAttempt,
+} from '@/lib/first-translation/attempt-log';
+import {
+  FIRST_FAMILY,
+  DISPOSITION_TO_VERDICT,
+  VERDICT_TO_DISPOSITION,
+  type FirstTranslationVerdict,
+  type LegacyDisposition,
+} from '@/lib/first-translation/types';
+import { firstTranslationBadge, firstTranslationDescription } from '@/lib/first-translation-labels';
+
+interface LegacyPrior {
+  english_title?: string;
+  translator?: string;
+  pub_year?: string;
+  completeness?: string;
+  url?: string;
+}
+
+interface EvidenceBook {
+  id: string;
+  language?: string;
+  is_first_translation?: boolean;
+  pages_translated?: number | null;
+  first_translation?: {
+    verdict?: FirstTranslationVerdict;
+    evidence_strength?: string;
+    best_attempt_id?: string;
+  } | null;
+  translation_verification?: {
+    disposition?: string;
+    reasoning?: string;
+    translations_found?: LegacyPrior[];
+    tools_called?: string[];
+    verified_at?: string | Date;
+  } | null;
+}
+
+interface NormalizedPrior {
+  title?: string;
+  translator?: string;
+  pub_year?: string;
+  completeness?: string;
+  url?: string;
+}
+
+function fmtDate(d?: string | Date): string {
+  if (!d) return '';
+  try {
+    return new Date(d).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
+function normalizePriors(attempt: FirstTranslationAttempt | null, legacy?: LegacyPrior[]): NormalizedPrior[] {
+  if (attempt?.priors?.length) {
+    return attempt.priors
+      .filter((p) => p.english_title)
+      .map((p) => ({ title: p.english_title, translator: p.translator, pub_year: p.pub_year, completeness: p.completeness, url: p.source_url }));
+  }
+  return (legacy ?? [])
+    .filter((p) => p.english_title)
+    .map((p) => ({ title: p.english_title, translator: p.translator, pub_year: p.pub_year, completeness: p.completeness, url: p.url }));
+}
+
+function PriorList({ priors }: { priors: NormalizedPrior[] }) {
+  return (
+    <div className="space-y-1">
+      {priors.map((t, i) => (
+        <p key={i} className="text-stone-400 pl-2">
+          <span className="italic">{t.title}</span>
+          {t.translator && t.translator !== 'unknown' && `, trans. ${t.translator}`}
+          {t.pub_year && ` (${t.pub_year})`}
+          {t.completeness && t.completeness !== 'unknown' && <span className="text-stone-500"> [{t.completeness}]</span>}
+          {t.url && (
+            <>{' '}<a href={t.url} target="_blank" rel="noopener noreferrer" className="text-accent-gold hover:text-accent-gold/80 underline">source</a></>
+          )}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+/** The grounded search trail (new model) or the legacy "verified via tools" line. */
+function EvidenceFooter({
+  attempt,
+  legacy,
+  showExternalLinks,
+}: {
+  attempt: FirstTranslationAttempt | null;
+  legacy?: EvidenceBook['translation_verification'];
+  showExternalLinks: boolean;
+}) {
+  const methodology = showExternalLinks ? (
+    <>{' '}&middot;{' '}<a href="/blog/first-translation-methodology" className="underline hover:text-stone-500">methodology</a></>
+  ) : null;
+
+  if (attempt) {
+    const sources = (attempt.sources_checked ?? []).filter(Boolean);
+    const queries = (attempt.queries ?? []).filter(Boolean);
+    return (
+      <div className="text-stone-600 text-[10px] space-y-1">
+        <p>
+          {sources.length ? `Searched ${sources.slice(0, 6).join(', ')}` : 'Searched library catalogs'}
+          {attempt.date ? ` · ${fmtDate(attempt.date)}` : ''}
+          {methodology}
+        </p>
+        {queries.length > 0 && (
+          <details className="group/q">
+            <summary className="cursor-pointer hover:text-stone-500 list-none [&::-webkit-details-marker]:hidden">
+              show {queries.length} search{queries.length === 1 ? '' : 'es'}
+            </summary>
+            <ul className="mt-1 pl-3 space-y-0.5">
+              {queries.slice(0, 12).map((q, i) => (
+                <li key={i} className="text-stone-500">“{q}”</li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </div>
+    );
+  }
+
+  if (legacy?.tools_called) {
+    return (
+      <p className="text-stone-600 text-[10px]">
+        Verified {fmtDate(legacy.verified_at)} via{' '}
+        {legacy.tools_called
+          .filter((t) => t !== 'make_determination')
+          .map((t) => t.replace('search_', '').replace(/_/g, ' '))
+          .join(', ')}
+        {methodology}
+      </p>
+    );
+  }
+  return null;
+}
+
+function StrengthChip({ strength }: { strength?: string }) {
+  if (strength !== 'strong' && strength !== 'moderate') return null;
+  return (
+    <span className="inline-block text-[10px] px-1.5 py-0.5 rounded bg-stone-700/60 text-stone-400">
+      {strength} evidence
+    </span>
+  );
+}
+
+export default async function FirstTranslationEvidence({
+  book,
+  showExternalLinks,
+}: {
+  book: EvidenceBook;
+  showExternalLinks: boolean;
+}) {
+  const ft = book.first_translation ?? null;
+  const legacy = book.translation_verification ?? null;
+  const legacyDisp = legacy?.disposition as LegacyDisposition | undefined;
+
+  // Resolve the verdict: prefer the graded model, else map the legacy disposition.
+  const verdict: FirstTranslationVerdict | undefined =
+    ft?.verdict ?? (legacyDisp ? DISPOSITION_TO_VERDICT[legacyDisp] : undefined);
+
+  const published = !!book.is_first_translation && (book.pages_translated ?? 0) > 0;
+  const isFirst = !!verdict && FIRST_FAMILY.has(verdict) && published;
+  const isExisting = verdict === 'not_first';
+
+  if (!isFirst && !isExisting) return null;
+
+  // Only hit the DB for the grounded attempt when the graded model is present.
+  let attempt: FirstTranslationAttempt | null = null;
+  if (ft) {
+    try {
+      const db = await getReadDb();
+      attempt = strongestAttempt(await getAttempts(db, book.id));
+    } catch {
+      attempt = null;
+    }
+  }
+
+  const priors = normalizePriors(attempt, legacy?.translations_found);
+
+  // "Existing translations" only earns a badge if we actually have priors to show.
+  if (isExisting && priors.length === 0) return null;
+
+  // Label uses the verdict's legacy-equivalent disposition (keeps badge text in sync).
+  const dispForLabel = (verdict && VERDICT_TO_DISPOSITION[verdict]) ?? legacyDisp;
+
+  if (isExisting) {
+    return (
+      <div className="mt-3">
+        <details className="group">
+          <summary className="inline-flex px-2.5 py-1 bg-stone-700/40 text-stone-300 hover:bg-stone-700/60 text-xs font-medium rounded-full border border-stone-600/50 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+            Existing translation{priors.length === 1 ? '' : 's'}{priors.length > 1 ? ` (${priors.length})` : ''}
+          </summary>
+          <div className="mt-2 p-3 bg-stone-800/50 rounded-lg border border-stone-700/50 text-xs space-y-2">
+            <p className="text-stone-300">This text has already been translated into English:</p>
+            <PriorList priors={priors} />
+            <EvidenceFooter attempt={attempt} legacy={legacy} showExternalLinks={showExternalLinks} />
+          </div>
+        </details>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3">
+      <details className="group">
+        <summary className="inline-flex items-center gap-2 px-2.5 py-1 bg-accent-gold/20 text-accent-gold hover:bg-accent-gold/30 text-xs font-medium rounded-full border border-accent-gold/30 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+          {firstTranslationBadge(dispForLabel, book.language)}
+        </summary>
+        <div className="mt-2 p-3 bg-stone-800/50 rounded-lg border border-stone-700/50 text-xs space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <p className="text-stone-300">{firstTranslationDescription(dispForLabel)}</p>
+            <StrengthChip strength={ft?.evidence_strength ?? (attempt?.evidence_strength)} />
+          </div>
+          {legacy?.reasoning && <p className="text-stone-400">{legacy.reasoning}</p>}
+          {priors.length > 0 && (
+            <div className="space-y-1">
+              <span className="text-stone-500">Related translations found:</span>
+              <PriorList priors={priors} />
+            </div>
+          )}
+          <EvidenceFooter attempt={attempt} legacy={legacy} showExternalLinks={showExternalLinks} />
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/src/lib/first-translation/attempt-log.ts
+++ b/src/lib/first-translation/attempt-log.ts
@@ -23,6 +23,23 @@ export const ATTEMPTS_COLLECTION = 'first_translation_attempts';
 /** How an attempt was carried out. Superset of {@link Resolver} (adds gemini). */
 export type AttemptMethod = Resolver | 'gemini_verifier';
 
+/**
+ * A prior English translation found during an attempt, kept STRUCTURED (not just
+ * a notes string) so per-book consumers — the badge evidence panel, the
+ * "Existing translations" surface, work-cluster linking — can render it without
+ * re-parsing. `found_refs` (registry ids) supersedes this once #2453 exists; until
+ * then this is the queryable record of what was found.
+ */
+export interface PriorTranslation {
+  english_title?: string;
+  translator?: string;
+  pub_year?: string;
+  publisher?: string;
+  completeness?: string;
+  /** The grounding link to where the prior actually is (archive.org / publisher / WorldCat). */
+  source_url?: string;
+}
+
 /** One row in the append-only provenance log. */
 export interface FirstTranslationAttempt {
   /** Stable id for this attempt; referenced by book.first_translation.best_attempt_id. */
@@ -41,6 +58,8 @@ export interface FirstTranslationAttempt {
   result: 'found' | 'none';
   /** Registry ids of priors found (empty when result==='none'). */
   found_refs?: string[];
+  /** Structured priors found this attempt (translator/year/title/link). */
+  priors?: PriorTranslation[];
   evidence_strength: EvidenceStrength;
   /**
    * 0..1 — how independent the consulted sources are from each other and from


### PR DESCRIPTION
## Clickable first-translation evidence panel (#2639), on the #2564 grounded model
**Stacked on #2573** (base `worktree-feat+ft-rebuild`) — uses `book.first_translation`, `first_translation_attempts`, and the lib types that live on that branch.

### Run-readiness fix included (surfaced while building this)
The enumeration's structured priors (translator/year/title/link) were being stored **only** as a free-text `notes` string + unlinked Supabase rows — **not queryable per book**. If the full 7,306 run fired as-is, every result would bake priors into text. Fixed: added a structured **`priors[]`** field to `FirstTranslationAttempt` and populated it in Sink A (`ft-ingest-verdicts.ts`). Now the run stores per-book structured priors. **Worth folding into the run-readiness checklist.**

### The panel (`FirstTranslationEvidence.tsx`)
Replaces the inline book-page `<details>` block. Prefers the graded model, falls back to legacy so nothing regresses before attempts are populated:
- **FIRST-family verdict** → "First Translation" badge (varied label: *First from Latin / First Complete / First Modern*) → panel shows the claim, evidence-strength chip, structured priors it supersedes, and the **grounded search trail** (domains consulted + the actual queries behind a "show searches" disclosure).
- **`not_first` verdict** → new **"Existing translations"** badge → same panel, pointing the reader at the English translation(s) that already exist. Shows only when priors exist; **not** gated on `pages_translated` (it's useful on a source-language original we hold).
- Falls back to the legacy `translation_verification` panel (disposition label, reasoning, "verified via tools") when there's no graded verdict yet.

### Invariants
- **#2232:** renders the structured prior (title/translator/year + real link), never the AI's prose as source text. Reasoning shown as our assessment.
- First-badge render gate unchanged (`is_first_translation && pages_translated > 0`).
- DB hit for the attempt is gated on `book.first_translation` existing — books without it (the majority, pre-run) take the cheap legacy path, no extra query.

### Verification
`tsc --noEmit` clean project-wide; import hook green. Data is sparse (~5 books have attempts) until the grounded run, so most books render via the legacy fallback today — by design ("lights up as data lands").

### Held-vs-offsite priors (noted in #2639, not in this PR)
When a prior is one we *hold*, "Existing translations" should link internally via `work_id` (#2318) and lead with it. This PR links the prior's `source_url` (often external); internal-edition preference is a fast-follow once work-clustering is wired.

Issue: #2639 · relates to #2564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)