### PR TITLE
fix(ft): track source_url migration + stop blocking translator='unknown' (#2564)

### DIFF
--- a/scripts/enrichment/harvest-ft-into-translation-catalogs.mjs
+++ b/scripts/enrichment/harvest-ft-into-translation-catalogs.mjs
@@ -102,7 +102,7 @@ function canonicalWork(book) {
 // "unknown" is intentionally NOT in this list — anonymous early-modern
 // translations are legitimately catalogued with translator='unknown' (e.g.
 // 1688 Diogenes Laertius). Only block the clear LLM-placeholder forms.
-const JUNK_TRANSLATOR_RE = /^(n\/a|not specified|tbd|none|unknown|original author|original|various|multiple|several|ongoing)\b/i;
+const JUNK_TRANSLATOR_RE = /^(n\/a|not specified|tbd|none|original author|original|various|multiple|several|ongoing)\b/i;
 const ORIGINAL_AUTHOR_RE = /\b(original author|original compiler)\b/i;
 
 function isEnglishLanguage(language) {

--- a/supabase/migrations/20260621000000_translation_catalogs_source_url.sql
+++ b/supabase/migrations/20260621000000_translation_catalogs_source_url.sql
@@ -1,0 +1,14 @@
+-- translation_catalogs.source_url (#2564, Sink C)
+--
+-- The grounded FT enumeration captures a link to where each prior English
+-- translation actually lives (archive.org / publisher / WorldCat). The Sink C
+-- harvester (scripts/enrichment/harvest-ft-into-translation-catalogs.mjs,
+-- --from-enum) writes it into this column. Without the column, `--apply`
+-- inserts 400 on every row.
+--
+-- Applied to the live `secondrenaissance` project on 2026-06-21 via the Supabase
+-- Management API; committed here so the schema change is reproducible and tracked
+-- alongside the other migrations. Idempotent.
+
+ALTER TABLE public.translation_catalogs
+  ADD COLUMN IF NOT EXISTS source_url text;


### PR DESCRIPTION
Two `translation_catalogs` / Sink C corrections, both surfaced while wiring the badge panel (#2639).

### 1. Document the `source_url` column (migration)
The merged Sink C harvester writes `translation_catalogs.source_url`, but the column was only `ALTER`ed onto the live `secondrenaissance` DB **by hand** (2026-06-21, via the Supabase Management API) — there was no migration, so the schema change wasn't reproducible. Adds `supabase/migrations/20260621000000_translation_catalogs_source_url.sql` (idempotent, `ADD COLUMN IF NOT EXISTS`) so it's tracked like the others. **No-op against the live DB** (already applied); this is for version control.

### 2. Stop blocking `translator='unknown'`
A prior commit added `unknown` to `JUNK_TRANSLATOR_RE`, but the comment directly above it (unchanged) documents that `translator='unknown'` is **legitimate** for anonymous early-modern translations (e.g. the 1688 Diogenes Laertius). Blocking it silently dropped those real priors from the catalog. Removed `unknown`; the genuine LLM-placeholder forms (`various/multiple/several/ongoing/n-a/none/original author`) stay blocked.

Clears the last of the Sink C readiness items before the gated grounded run. Relates to #2564 / #2639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)