### PR TITLE
fix(download): explain the sign-in gate instead of a silent redirect

### DIFF
--- a/src/components/ui/DownloadButton.tsx
+++ b/src/components/ui/DownloadButton.tsx
@@ -69,10 +69,20 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
   const isNcFreeFormat = (f: BookDownloadFormats) =>
     imageAccess === 'nc-free' && isImageFormat(f);
 
+  const goToSignIn = () => {
+    window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.pathname)}`;
+  };
+
   const handleDownload = async (format: BookDownloadFormats) => {
-    // Anonymous → send to sign-in
+    // Anonymous → explain the gate, then offer sign-in. A bare redirect here
+    // read as "the download errored" (real feedback, 2026-06-19): the page just
+    // jumped to a login screen with no reason given. The toast names the gate
+    // at the moment of the click and lets them choose to continue.
     if (!session?.user) {
-      window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.pathname)}`;
+      toast('Sign in to download', {
+        description: 'Members download every format. Sign in to get started.',
+        action: { label: 'Sign in', onClick: goToSignIn },
+      });
       return;
     }
 
@@ -89,7 +99,7 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
 
       if (response.status === 401) {
         setDownloading(null);
-        window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.pathname)}`;
+        goToSignIn();
         return;
       }
       if (response.status === 402) {
@@ -125,7 +135,7 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
 
   const handlePurchase = async () => {
     if (!session?.user) {
-      window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.pathname)}`;
+      goToSignIn();
       return;
     }
     setPurchasing(true);
@@ -183,9 +193,7 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
           {isAnonymous && (
             <div className="px-3 py-3 border-b border-stone-100">
               <button
-                onClick={() => {
-                  window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.pathname)}`;
-                }}
+                onClick={goToSignIn}
                 className="w-full py-2.5 bg-stone-900 hover:bg-stone-800 text-white rounded-lg text-sm font-medium transition-colors"
               >
                 Sign in to download


### PR DESCRIPTION
## What

A logged-out reader who clicked a download format was sent straight to `/auth/signin` **with no message** — the page just jumped to a login screen. It read as "the download broke," which is exactly the footer feedback that prompted this (a Spanish-speaking Instagram visitor, 2026-06-19: *"no deja descargar los libros, y da error"*). It also suppresses downloads from the large logged-out surge audience.

## Change

An anonymous format click now shows a toast — **"Sign in to download — Members download every format"** with a **Sign in** action button — naming the gate at the moment of the click and letting the reader choose to continue. The dropdown's existing *"Sign in to download / Free for members"* wall still renders above the format list.

Wording stays **honest**: the real gate is anonymous → sign-in, then members download free while non-members route through the existing $5 purchase flow. So no "free for everyone" promise — just "members download every format," matching the existing caption.

Also extracts `goToSignIn()` to DRY the four redirect sites.

## Not included (your call, noted earlier)

- Whether to allow a limited **anonymous** download at all (product/monetization decision — downloads are intentionally gated).
- The Instagram in-app-browser OAuth failure after redirect is the separate PR #2558 issue.

## Verify

Logged out, open a book's Download menu → click any format → toast appears (no silent jump); click **Sign in** → `/auth/signin`. Signed-in flows (member download, non-member $5) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)