### PR TITLE
fix(pipeline): complete selective-unpause across scheduler + paid workers

### DIFF
--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -40,6 +40,11 @@ import { logUsage as logUsageToSupabase } from './lib/supabase-usage-logger.mjs'
 import { createBookRevisions } from './lib/book-revisions.mjs';
 import { buildSummaryPrompt, SUMMARY_GEN_CONFIG } from './lib/summary-prompt.mjs';
 import { createClient } from '@supabase/supabase-js';
+import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
+
+// Selective-unpause scope confinement, set in main() after the pause check.
+// Empty {} in normal operation so the full enrich queue is unaffected.
+let SCOPE_FILTER = {};
 
 /** Trigger on-demand revalidation for a book page after enrichment completes. */
 async function revalidateBookPage(bookId) {
@@ -1415,8 +1420,10 @@ async function main() {
 
   // Check pause status
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
-  if (control?.paused || control?.paused_phases?.includes('enrichment')) {
-    const reason = control?.paused ? 'pipeline paused' : 'enrichment phase paused';
+  // Selective unpause: scoped books enrich while globally paused; the explicit
+  // enrichment-phase pause still hard-stops regardless of scope.
+  if (control?.paused_phases?.includes('enrichment') || !shouldBypassPause(control)) {
+    const reason = control?.paused_phases?.includes('enrichment') ? 'enrichment phase paused' : 'pipeline paused';
     console.log(`[ENRICH] ${reason}, exiting`);
     await db.collection('cron_runs').insertOne({
       cron: 'hetzner-enrich-worker', timestamp: new Date(),
@@ -1426,6 +1433,12 @@ async function main() {
     }).catch(() => {});
     await client.close();
     return;
+  }
+  // When globally paused with a scope, confine every candidate query to it.
+  if (control?.paused && hasScope(control)) {
+    const scopeIds = [...await resolveScopeBookIds(db, control)];
+    SCOPE_FILTER = { id: { $in: scopeIds } };
+    console.log(`[ENRICH] PAUSED globally, scope active — confining to ${scopeIds.length} allowlisted book(s).`);
   }
 
   let enriched = 0;
@@ -1461,7 +1474,7 @@ async function main() {
 
       // Priority: first translations first, then by retry count (fewer retries first)
       books = await db.collection('books')
-        .find({ 'pipeline_auto.status': 'translate_complete' })
+        .find({ 'pipeline_auto.status': 'translate_complete', ...SCOPE_FILTER })
         .sort({ is_first_translation: -1, pages_count: 1, 'pipeline_auto.retry_count': 1 })  // First translations first, then small books
         .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1, year: 1, chapters: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1, pages_count: 1 })
         .limit(PHASE_6_LIMIT)
@@ -1521,7 +1534,7 @@ async function main() {
       books = book ? [book] : [];
     } else {
       books = await db.collection('books')
-        .find({ 'pipeline_auto.status': 'summary_indexed' })
+        .find({ 'pipeline_auto.status': 'summary_indexed', ...SCOPE_FILTER })
         .sort({ hidden: 1 })
         .project({ id: 1, title: 1, pages_count: 1, 'pipeline_auto.retry_count': 1 })
         .limit(PHASE_7_LIMIT)
@@ -1601,6 +1614,7 @@ async function main() {
         ],
         hidden: { $ne: true },
         pages_count: { $gt: 0 },
+        ...SCOPE_FILTER,
       })
       .sort({ read_count: -1 })
       .project({
@@ -1788,6 +1802,7 @@ NO explanation, just the JSON array.`;
             'pipeline_auto.status': status,
             pages_count: { $gt: 0 },
             hidden: { $ne: true },
+            ...SCOPE_FILTER,
           })
           .project({
             id: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, categories: 1,

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -20,6 +20,7 @@ import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { nanoid } from 'nanoid';
 import sharp from 'sharp';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
+import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 
 // Structured-output schema. Forces scan_quality to be present as an object with the
 // required fields populated; extracted_images is left loosely shaped because its
@@ -985,17 +986,25 @@ async function main() {
   await client.connect();
   const db = client.db('bookstore');
 
-  // Check processing control
+  // Check processing control. Selective unpause: scoped books extract while
+  // globally paused; SCOPE_FILTER confines every candidate query (empty {} in
+  // normal operation).
   const ctrl = await db.collection('system_config').findOne({ _id: 'processing_control' });
-  if (ctrl?.paused) {
+  if (!shouldBypassPause(ctrl)) {
     console.log('[IMAGE-EXTRACT] Pipeline paused, exiting');
     await client.close();
     return;
   }
+  let SCOPE_FILTER = {};
+  if (ctrl?.paused && hasScope(ctrl)) {
+    const scopeIds = [...await resolveScopeBookIds(db, ctrl)];
+    SCOPE_FILTER = { id: { $in: scopeIds } };
+    console.log(`[IMAGE-EXTRACT] PAUSED globally, scope active — confining to ${scopeIds.length} allowlisted book(s).`);
+  }
 
   // Find books ready for image extraction
   const books = await db.collection('books')
-    .find({ 'pipeline_auto.status': 'chapters_complete' })
+    .find({ 'pipeline_auto.status': 'chapters_complete', ...SCOPE_FILTER })
     .sort({ processing_priority: -1, hidden: 1 })
     .project({ id: 1, title: 1, author: 1, year: 1, language: 1, subjects: 1 })
     .limit(BOOKS_PER_RUN)
@@ -1011,6 +1020,7 @@ async function main() {
         ],
         pages_ocr: { $gt: 0 },
         detected_images_count: { $exists: false },
+        ...SCOPE_FILTER,
       })
       .sort({ visible: -1, pages_count: -1 })
       .project({ id: 1, title: 1, author: 1, year: 1, language: 1, subjects: 1 })

--- a/scripts/workers/scheduler.mjs
+++ b/scripts/workers/scheduler.mjs
@@ -20,6 +20,7 @@
 import { MongoClient } from 'mongodb';
 import { execSync, spawn } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, openSync, closeSync, appendFileSync } from 'fs';
+import { shouldBypassPause, hasScope } from './lib/selective-unpause.mjs';
 
 // ── Config ──
 
@@ -358,8 +359,14 @@ async function main() {
     const db = client.db('bookstore');
 
     // 1. Check pause state — NO auto-resume. The scheduler does not second-guess manual pauses.
+    // Selective unpause: when globally paused but a scope is configured
+    // (allow_book_ids / allow_collections), the scheduler still runs and
+    // dispatches the workers — each scope-aware worker confines itself to the
+    // allowlisted books. Without this the scheduler short-circuits before
+    // dispatching anything, so the orchestrator's and archive workers' scope
+    // logic (#2616/#2641) never executes and the whole scope stays frozen.
     const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
-    if (control?.paused) {
+    if (!shouldBypassPause(control)) {
       const ageMin = control.paused_at
         ? Math.round((Date.now() - new Date(control.paused_at).getTime()) / 60000)
         : '?';
@@ -373,6 +380,9 @@ async function main() {
 
       await client.close();
       return;
+    }
+    if (control?.paused && hasScope(control)) {
+      console.log('[scheduler] PAUSED globally, but selective-unpause scope is active — dispatching workers; each confines to the allowlisted books.');
     }
 
     // 2. Probe DB health

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -27,6 +27,14 @@ import { createHash, randomBytes } from 'crypto';
 import { nanoid } from 'nanoid';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
 import { syncPageUpdate, syncPageBatch } from './lib/supabase-page-writer.mjs';
+import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
+
+// Selective-unpause scope confinement, set in main() after the pause check and
+// read by the candidate queries (incl. selfDispatch). In normal operation
+// SCOPE_IDS is null and SCOPE_FILTER is {} so nothing is confined.
+let SCOPE_IDS = null;          // string[] of allowlisted book ids, or null
+let SCOPE_SET = null;          // Set form for cheap membership tests
+let SCOPE_FILTER = {};         // { id: { $in: SCOPE_IDS } } for collision-free queries
 
 // ── Config ──
 const CONCURRENCY = 40;          // Max books translating simultaneously
@@ -1090,6 +1098,7 @@ async function selfDispatch(db, limit) {
     { $match: {
       'pipeline_auto.status': { $in: ['ocr_complete'] },
       $or: [{ needs_splitting: { $ne: true } }, { split_completed: true }],
+      ...SCOPE_FILTER,
     } },
     { $addFields: { _speedTier: { $switch: {
       branches: [
@@ -1115,6 +1124,7 @@ async function selfDispatch(db, limit) {
         'pipeline_auto.status': 'translate_partial',
         // Spread guard (#2449)
         $or: [{ needs_splitting: { $ne: true } }, { split_completed: true }],
+        ...SCOPE_FILTER,
       } },
       { $addFields: { _denominator: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] } } },
       { $match: { _denominator: { $gt: 0 }, $expr: { $gte: [{ $divide: ['$pages_translated', '$_denominator'] }, 0] } } },
@@ -1209,7 +1219,10 @@ async function main() {
   // Check pause status — no auto-resume (scheduler owns resume decisions)
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
   const translationPhasePaused = control?.paused_phases?.includes('translation');
-  if (control?.paused || translationPhasePaused) {
+  // Selective unpause: a configured scope (allow_book_ids/allow_collections)
+  // lets scoped books translate while globally paused. The translation-phase
+  // pause still hard-stops regardless of scope.
+  if (translationPhasePaused || !shouldBypassPause(control)) {
     const reason = translationPhasePaused ? 'translation phase paused' : 'pipeline paused';
     const pauseAgeMs = control.paused_at ? Date.now() - new Date(control.paused_at).getTime() : Infinity;
     console.log(`[TRANSLATE] ${reason} (${Math.round(pauseAgeMs / 60000)}min ago), exiting`);
@@ -1222,6 +1235,14 @@ async function main() {
     await client.close();
     return;
   }
+  // When globally paused with a scope, confine candidate selection to it
+  // (module-level SCOPE_FILTER read by selfDispatch).
+  if (control?.paused && hasScope(control)) {
+    SCOPE_IDS = [...await resolveScopeBookIds(db, control)];
+    SCOPE_SET = new Set(SCOPE_IDS);
+    SCOPE_FILTER = { id: { $in: SCOPE_IDS } };
+    console.log(`[TRANSLATE] PAUSED globally, scope active — confining to ${SCOPE_IDS.length} allowlisted book(s).`);
+  }
 
   // Find books — fresh (0 translated) first, then partials sorted by most remaining pages.
   // Grouping similar workloads per batch minimizes convoy tail waste.
@@ -1231,7 +1252,7 @@ async function main() {
 
   // Auto-complete near-zero books — job setup overhead exceeds the work
   const nearZero = await db.collection('books').aggregate([
-    { $match: { 'pipeline_auto.status': { $in: ['translate_submitted', 'translate_partial'] } } },
+    { $match: { 'pipeline_auto.status': { $in: ['translate_submitted', 'translate_partial'] }, ...SCOPE_FILTER } },
     { $addFields: { _remaining: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $add: [{ $ifNull: ['$pages_translated', 0] }, { $ifNull: ['$pages_blank', 0] }] }] } } },
     { $match: { _remaining: { $lt: MIN_REMAINING } } },
     { $limit: 100 },
@@ -1254,7 +1275,7 @@ async function main() {
   // Priority: fresh (untranslated) books first, then any % partials to finish them off.
   // All partials are eligible when no fresh books remain.
   let books = await db.collection('books')
-    .find({ 'pipeline_auto.status': 'translate_submitted', $or: [{ pages_translated: 0 }, { pages_translated: { $exists: false } }] })
+    .find({ 'pipeline_auto.status': 'translate_submitted', $or: [{ pages_translated: 0 }, { pages_translated: { $exists: false } }], ...SCOPE_FILTER })
     .project(proj).limit(CONCURRENCY).toArray();
 
   // Only allow any % translated partials to fill remaining slots
@@ -1262,7 +1283,7 @@ async function main() {
     const needed = CONCURRENCY - books.length;
     const freshIds = new Set(books.map(b => b.id));
     const nearComplete = await db.collection('books').aggregate([
-      { $match: { 'pipeline_auto.status': { $in: ['translate_submitted', 'translate_partial'] }, pages_translated: { $gt: 0 } } },
+      { $match: { 'pipeline_auto.status': { $in: ['translate_submitted', 'translate_partial'] }, pages_translated: { $gt: 0 }, ...SCOPE_FILTER } },
       { $addFields: {
         _denominator: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] },
         _remaining: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $add: [{ $ifNull: ['$pages_translated', 0] }, { $ifNull: ['$pages_blank', 0] }] }] },
@@ -1291,7 +1312,7 @@ async function main() {
       const DONE_STATUSES = ['needs_attention', 'complete', 'failed', 'translate_complete', 'summarizing', 'summary_indexed', 'chapters', 'chapters_complete'];
       const orphanBookIds = orphanJobs.map(j => j.book_id);
       const orphanBooks = await db.collection('books')
-        .find({ id: { $in: orphanBookIds }, 'pipeline_auto.status': { $nin: DONE_STATUSES } })
+        .find({ id: { $in: SCOPE_SET ? orphanBookIds.filter(i => SCOPE_SET.has(i)) : orphanBookIds }, 'pipeline_auto.status': { $nin: DONE_STATUSES } })
         .project(proj).toArray();
       const resumedIds = new Set(orphanBooks.map(b => b.id));
       books = [...books, ...orphanBooks.filter(b => !bookIds.has(b.id))].slice(0, CONCURRENCY);
@@ -1389,13 +1410,14 @@ async function main() {
   // Fetch more books for the queue (excluding already processed)
   async function fetchMoreBooks(limit) {
     const excludeIds = [...processedIds];
+    const excludeSet = new Set(excludeIds);
     const fresh = await db.collection('books')
-      .find({ 'pipeline_auto.status': 'translate_submitted', id: { $nin: excludeIds } })
+      .find({ 'pipeline_auto.status': 'translate_submitted', id: SCOPE_IDS ? { $in: SCOPE_IDS.filter(i => !excludeSet.has(i)) } : { $nin: excludeIds } })
       .project(proj).limit(limit).toArray();
     // Only backfill with any % translated partials
     if (fresh.length < limit) {
       const partial = await db.collection('books').aggregate([
-        { $match: { 'pipeline_auto.status': { $in: ['translate_submitted', 'translate_partial'] }, pages_translated: { $gt: 0 }, id: { $nin: [...excludeIds, ...fresh.map(b => b.id)] } } },
+        { $match: { 'pipeline_auto.status': { $in: ['translate_submitted', 'translate_partial'] }, pages_translated: { $gt: 0 }, ...(SCOPE_IDS ? { id: { $in: SCOPE_IDS.filter(i => !excludeSet.has(i) && !fresh.some(b => b.id === i)) } } : { id: { $nin: [...excludeIds, ...fresh.map(b => b.id)] } }) } },
         { $addFields: {
           _denominator: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] },
           _remaining: { $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $add: [{ $ifNull: ['$pages_translated', 0] }, { $ifNull: ['$pages_blank', 0] }] }] },


### PR DESCRIPTION
## Problem

#2641 made the archive workers scope-aware — but they were **never dispatched**. `scheduler.mjs` short-circuits on the global pause **before dispatching any worker**, so #2616 (orchestrator scope) and #2641 (archive scope) never executed while paused. The entire selective-unpause scope has been frozen the whole time. On top of that, three paid workers — **translate-worker, enrich-worker, image-extract-worker** — also hard-exit on the pause and have no scope awareness.

## Fix

- **scheduler.mjs**: `shouldBypassPause()` — when globally paused *with a scope configured*, the scheduler runs and dispatches the workers (each confines itself). Full-stop unchanged when paused with no scope.
- **translate / enrich / image-extract workers**: proceed under a scope and confine **every** candidate query to the allowlisted books (`SCOPE_FILTER` spread; the `id`-collision queries — orphan-job resume, `$nin: excludeIds` — intersect the id array in JS instead of spreading, to avoid clobbering the existing `id` clause). The explicit translation/enrichment **phase** pauses still hard-stop regardless of scope.

## Cost-safety (validated against prod)

Without confinement, running these workers while scoped would process **non-scoped** books:

| query | unconfined | confined |
|---|---|---|
| enrich phase 6 (translate_complete) | 1,910 | 0 |
| enrich phase 7 (summary_indexed) | 365 | 0 |
| enrich phase 7.6 (classify) | 11,649 | 0 |
| image-extract catch-up | 95 | 0 |

That's the unintended Gemini spend this prevents. With the scope active, every candidate query returns **only** allowlisted books (verified: every returned id ∈ scope). 12 selective-unpause unit tests pass.

## Rollout

Pure `scripts/**` — no Vercel deploy; Hetzner auto-pulls `main` ~every 5 min. **Scope is currently trimmed to the 3 Augustinus tomes** (~1,528 pages, a few $ of Gemini), so on merge only those drain end-to-end (archive → OCR → translate → enrich). The full 49-book + cannabis-collection scope is backed up (`scripts/output/processing-scope-backup-2026-06-21.json`) and can be restored once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)