### PR TITLE
feat(pipeline): namespaced additive selective-unpause scope (multi-session safe)

### DIFF
--- a/scripts/maintenance/unpause-scope.mjs
+++ b/scripts/maintenance/unpause-scope.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Manage selective-unpause scopes ADDITIVELY (multi-session safe).
+//
+// The pipeline pause is global; selective unpause lets specific books run while
+// the rest stay paused. Because ~10 Claude sessions share this DB, scopes are
+// namespaced under processing_control.allow_scopes['<tag>'] so each task edits
+// ONLY its own key and never clobbers another session's books.
+//
+// Usage (always source prod env first: `set -a; source .env.production.local; set +a`):
+//   node scripts/maintenance/unpause-scope.mjs list
+//   node scripts/maintenance/unpause-scope.mjs add <tag> [--collections a,b] [--books id1,id2] [--reason "..."]
+//   node scripts/maintenance/unpause-scope.mjs remove <tag>
+//   node scripts/maintenance/unpause-scope.mjs resolve            # print total book-id count in scope
+//
+// Examples:
+//   node scripts/maintenance/unpause-scope.mjs add cannabis --collections cannabis-western-record
+//   node scripts/maintenance/unpause-scope.mjs add manly-hall --books 6a35...,6a36...
+//   node scripts/maintenance/unpause-scope.mjs remove cannabis
+//
+// NOTE: an empty scope (no allow_scopes entries, no legacy arrays) means the
+// global pause is a full stop — removing the last scope re-pauses everything.
+
+import { MongoClient } from 'mongodb';
+import { getScopeConfig, resolveScopeBookIds } from '../workers/lib/selective-unpause.mjs';
+
+const uri = process.env.MONGODB_URI || process.env.MONGO_URI;
+if (!uri) { console.error('No MONGODB_URI in env (source .env.production.local).'); process.exit(1); }
+
+const [cmd, tag] = process.argv.slice(2);
+const args = process.argv.slice(2);
+const flag = (name) => { const i = args.indexOf(name); return i >= 0 ? args[i + 1] : null; };
+const list = (v) => (v ? v.split(',').map(s => s.trim()).filter(Boolean) : []);
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const cfg = db.collection('system_config');
+const CTRL = { _id: 'processing_control' };
+
+async function show() {
+  const control = await cfg.findOne(CTRL);
+  const scopes = control?.allow_scopes || {};
+  console.log(`paused: ${control?.paused}`);
+  console.log(`legacy allow_book_ids: ${(control?.allow_book_ids || []).length}, allow_collections: ${JSON.stringify(control?.allow_collections || [])}`);
+  console.log(`allow_scopes (${Object.keys(scopes).length} tag(s)):`);
+  for (const [k, v] of Object.entries(scopes)) {
+    console.log(`  • ${k}: books=${(v.book_ids || []).length} collections=${JSON.stringify(v.collections || [])}${v.reason ? `  — ${v.reason}` : ''}`);
+  }
+  const union = getScopeConfig(control);
+  console.log(`union: ${union.bookIds.length} explicit book ids + ${union.collections.length} collection(s)`);
+}
+
+if (cmd === 'list') {
+  await show();
+} else if (cmd === 'resolve') {
+  const control = await cfg.findOne(CTRL);
+  const ids = await resolveScopeBookIds(db, control);
+  console.log(`scope resolves to ${ids.size} book ids`);
+} else if (cmd === 'add') {
+  if (!tag) { console.error('add requires a <tag>'); process.exit(1); }
+  const collections = list(flag('--collections'));
+  const books = list(flag('--books'));
+  const reason = flag('--reason') || `selective-unpause: ${tag}`;
+  if (!collections.length && !books.length) { console.error('provide --collections and/or --books'); process.exit(1); }
+  await cfg.updateOne(CTRL, {
+    $set: {
+      [`allow_scopes.${tag}`]: { book_ids: books, collections, reason, set_at: new Date(), set_by: process.env.USER || 'claude-session' },
+      updated_at: new Date(),
+    },
+  }, { upsert: true });
+  console.log(`✓ added/updated scope "${tag}" (books=${books.length}, collections=${collections.length}) — did NOT touch other scopes`);
+  await show();
+} else if (cmd === 'remove') {
+  if (!tag) { console.error('remove requires a <tag>'); process.exit(1); }
+  await cfg.updateOne(CTRL, { $unset: { [`allow_scopes.${tag}`]: '' }, $set: { updated_at: new Date() } });
+  console.log(`✓ removed scope "${tag}"`);
+  await show();
+} else {
+  console.log('Usage: list | add <tag> [--collections a,b] [--books id1,id2] [--reason "..."] | remove <tag> | resolve');
+}
+
+await client.close();

--- a/scripts/workers/lib/selective-unpause.mjs
+++ b/scripts/workers/lib/selective-unpause.mjs
@@ -2,27 +2,44 @@
 //
 // The pipeline pause (system_config.processing_control.paused) is a global
 // stop on the paid OCR/translation path. Selective unpause lets a chosen set
-// of books run *while the rest stay paused*, via:
-//   processing_control.allow_book_ids: string[]      // explicit book ids
-//   processing_control.allow_collections: string[]   // collection slugs
+// of books run *while the rest stay paused*. The scope is the UNION of:
+//   processing_control.allow_scopes: { '<tag>': { book_ids:[], collections:[] } }
+//       ← additive, namespaced per task/session — USE THIS (see below)
+//   processing_control.allow_book_ids: string[]      // legacy, still honored
+//   processing_control.allow_collections: string[]   // legacy, still honored
 //
 // When a scope is set, the global pause is bypassed but every pipeline phase
 // is confined to the allowlisted books. An empty scope means the pause is a
-// full stop (unchanged). Mirrors the per-book bypass the free archiving
-// workers already have (archive-bulk --book-id, archive-iiif-local --ignore-pause).
+// full stop (unchanged).
+//
+// WHY allow_scopes (namespaced): the legacy top-level arrays are a SINGLE shared
+// field. With ~10 concurrent Claude sessions on this DB, one session setting its
+// own books clobbers another's (this really happened 2026-06-20: a session
+// narrowed the scope to 3 books and silently knocked a 60-book collection out of
+// the allowlist for ~21h). allow_scopes fixes that: each task owns one key and
+// edits ONLY that key (`$set: {'allow_scopes.<tag>': {...}}` / `$unset`), so
+// scopes accumulate instead of overwriting. Manage it via
+// scripts/maintenance/unpause-scope.mjs, never by hand-overwriting the arrays.
 //
 // These helpers are intentionally pure (no DB) so the pause/bypass invariant
 // is unit-testable; collection-slug → book-id resolution is done by the caller.
 
 export function getScopeConfig(control) {
-  // filter falsy BEFORE coercing, so null/'' don't become the string "null"/""
-  const bookIds = Array.isArray(control?.allow_book_ids)
-    ? control.allow_book_ids.filter(Boolean).map(String)
-    : [];
-  const collections = Array.isArray(control?.allow_collections)
-    ? control.allow_collections.filter(Boolean).map(String)
-    : [];
-  return { bookIds, collections };
+  // filter falsy BEFORE coercing, so null/'' don't become the string "null"/"";
+  // dedupe via Set since legacy + namespaced scopes can overlap.
+  const bookIds = new Set();
+  const collections = new Set();
+  const add = (arr, set) => { if (Array.isArray(arr)) for (const x of arr) if (x) set.add(String(x)); };
+  add(control?.allow_book_ids, bookIds);          // legacy
+  add(control?.allow_collections, collections);   // legacy
+  const scopes = control?.allow_scopes;           // namespaced additive map
+  if (scopes && typeof scopes === 'object') {
+    for (const key of Object.keys(scopes)) {
+      add(scopes[key]?.book_ids, bookIds);
+      add(scopes[key]?.collections, collections);
+    }
+  }
+  return { bookIds: [...bookIds], collections: [...collections] };
 }
 
 /** Is a selective-unpause scope configured at all? */

--- a/tests/unit/selective-unpause.test.ts
+++ b/tests/unit/selective-unpause.test.ts
@@ -44,6 +44,40 @@ describe('selective-unpause scope helpers', () => {
     it('proceeds when paused but a single --book override is active', () => {
       expect(shouldBypassPause({ paused: true }, { bookOverride: true })).toBe(true);
     });
+
+    it('proceeds when paused but a namespaced allow_scopes entry is set', () => {
+      expect(shouldBypassPause({ paused: true, allow_scopes: { cannabis: { collections: ['cannabis-western-record'] } } })).toBe(true);
+      expect(shouldBypassPause({ paused: true, allow_scopes: { hall: { book_ids: ['x'] } } })).toBe(true);
+    });
+  });
+
+  describe('allow_scopes — additive, multi-session-safe union', () => {
+    it('unions legacy fields AND every namespaced scope, deduped', () => {
+      const control = {
+        allow_book_ids: ['legacy1'],
+        allow_collections: ['legacy-coll'],
+        allow_scopes: {
+          cannabis: { collections: ['cannabis-western-record'], book_ids: ['legacy1'] }, // overlaps legacy → deduped
+          hall: { book_ids: ['hall1', 'hall2'] },
+          augustinus: { book_ids: ['aug1'] },
+        },
+      };
+      const { bookIds, collections } = getScopeConfig(control);
+      expect(bookIds.sort()).toEqual(['aug1', 'hall1', 'hall2', 'legacy1']);
+      expect(collections.sort()).toEqual(['cannabis-western-record', 'legacy-coll']);
+    });
+
+    it('removing one scope key does not affect the others (the collision fix)', () => {
+      const after = { allow_scopes: { hall: { book_ids: ['hall1'] }, augustinus: { book_ids: ['aug1'] } } };
+      // simulate `remove cannabis` having $unset only its key
+      expect(hasScope(after)).toBe(true);
+      expect(getScopeConfig(after).bookIds.sort()).toEqual(['aug1', 'hall1']);
+    });
+
+    it('empty allow_scopes map = no scope = full stop', () => {
+      expect(hasScope({ paused: true, allow_scopes: {} })).toBe(false);
+      expect(shouldBypassPause({ paused: true, allow_scopes: {} })).toBe(false);
+    });
   });
 
   describe('hasScope', () => {


### PR DESCRIPTION
## Problem
Selective-unpause scope (#2616/#2641) lives in single shared fields on `processing_control` (`allow_book_ids` / `allow_collections`). With ~10 concurrent Claude sessions on one DB, sessions **clobber** each other. This actually happened 2026-06-20: a session narrowed the scope to 3 books for its own task and silently knocked a 60-book collection (+ 44 other books) out of the allowlist for ~21h — nothing processed.

## Fix
Add a **namespaced additive** map: `allow_scopes: { '<tag>': { book_ids:[], collections:[] } }`. `getScopeConfig` now returns the **union** of the legacy arrays AND every namespaced scope (deduped via Set). Each task edits only its own key — `$set: {'allow_scopes.<tag>': …}` / `$unset` — so scopes accumulate instead of overwriting.

- Legacy `allow_book_ids` / `allow_collections` stay honored (back-compat).
- `hasScope` / `shouldBypassPause` / `resolveScopeBookIds` all flow through `getScopeConfig`, so the orchestrator, batch-collector, and the archive workers (#2641) inherit this with **no further changes**.
- New `scripts/maintenance/unpause-scope.mjs` (`list` / `add` / `remove` / `resolve`) so sessions manage scopes additively instead of hand-editing the raw arrays.

## Tests
`selective-unpause.test.ts`: 16 pass — union of legacy + namespaced, per-key removal isolation (the collision fix), and the empty-scope = full-stop invariant. `node --check` clean on both scripts. Scripts-only → no Vercel deploy; Hetzner auto-pulls.

Follow-up (separate): migrate live scopes into namespaces and have sessions adopt the helper so the legacy shared arrays stop being written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)