### PR TITLE
fix(mineru): id-space-agnostic --book lookup

### DIFF
--- a/scripts/workers/mineru-ocr-worker.mjs
+++ b/scripts/workers/mineru-ocr-worker.mjs
@@ -205,7 +205,11 @@ async function processBook(db, book) {
 
   let candidates;
   if (ONE_BOOK) {
-    candidates = await books.find({ _id: (await import('mongodb')).ObjectId.createFromHexString(ONE_BOOK) }).toArray();
+    // id-space-agnostic lookup: this corpus mixes ObjectId `_id`s, string `_id`s,
+    // and a separate string `id` field. Match all so --book works on any book.
+    const or = [{ _id: ONE_BOOK }, { id: ONE_BOOK }];
+    try { or.push({ _id: (await import('mongodb')).ObjectId.createFromHexString(ONE_BOOK) }); } catch { /* not a valid ObjectId hex */ }
+    candidates = await books.find({ $or: or }).toArray();
   } else {
     candidates = await books.find({
       language: /english/i,


### PR DESCRIPTION
Makes the MinerU worker's `--book` debug lookup match ObjectId `_id`, string `_id`, and the string `id` field (the corpus mixes all three — see lesson_book_id_field_vs_mongo_id). Touches only the `ONE_BOOK` debug branch, not batch processing.

Was sitting uncommitted on `main` in the shared checkout (flagged by a peer coordination session); moved to its own branch rather than pushing main directly. Auto-deploys to Hetzner on merge (scripts/**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)