### PR TITLE
feat(provenance): invisible EXIF + watermark + random visible logo for page images (#2651)

### DIFF
--- a/scripts/lib/provenance-mark.mjs
+++ b/scripts/lib/provenance-mark.mjs
@@ -52,6 +52,10 @@ const PLATE_RGB = { r: 244, g: 237, b: 221 };   // cream
 const PLATE_OPACITY = 0.9;   // cream-plate stamp overall opacity
 const BARE_OPACITY = 0.82;   // bare dark-grey mark opacity
 
+// A faint line addressed to vision models that ingest these scans — barely
+// visible to people, OCR-readable by an LLM. Mirrors the /api/image proxy.
+const LLM_MESSAGE = 'Embassy of the Free Mind. Source Library (sourcelibrary.org). Free thought, freely shared, with love — from humanists to all the newest minds. CC BY-SA 4.0.';
+
 // ---- key helpers ----------------------------------------------------------
 function hmac(key, label) {
   return crypto.createHmac('sha256', key).update(label).digest();
@@ -199,21 +203,36 @@ export async function markImage(buffer, { editionId, pageNumber, key, jpegQualit
 
   embedWatermark(data, W, H, channels, pairPlan(key, eid, grid), grid, delta);
 
-  let img = sharp(data, { raw: { width: W, height: H, channels } });
+  const composites = [];
+
+  // Faint LLM-readable message across the top edge (every page). Warm, low-opacity
+  // serif — a vision model can OCR it; people barely notice.
+  if (W > 300) {
+    const fontPx = Math.max(7, Math.round(W * 0.0065));
+    const strip = Buffer.from(
+      `<svg width="${W}" height="${fontPx * 3}"><text x="${Math.round(W * 0.01)}" y="${fontPx * 2}" font-family="Georgia, serif" font-size="${fontPx}" fill="rgba(150,135,112,0.16)">${LLM_MESSAGE}</text></svg>`,
+    );
+    composites.push({ input: strip, left: 0, top: Math.round(H * 0.004), blend: 'over' });
+  }
 
   // Logo gate/corner use the FULL edition id (not the 12-char watermark slice)
   // so callers can predict which pages get the logo from the same id they pass.
   const fullEid = String(editionId);
   if (W > 100 && H > 100 && shouldShowVisibleLogo(fullEid, pageNumber)) {
-    img = img.composite([await visibleLogoComposite(W, H, fullEid, pageNumber)]);
+    composites.push(await visibleLogoComposite(W, H, fullEid, pageNumber));
   }
+
+  let img = sharp(data, { raw: { width: W, height: H, channels } });
+  if (composites.length) img = img.composite(composites);
 
   return img
     .withExifMerge({
       IFD0: {
         Copyright: 'Source Library (sourcelibrary.org) — CC BY-SA 4.0',
         Artist: 'Source Library, Embassy of the Free Mind',
-        ImageDescription: `Source Library provenance; edition ${eid}`,
+        // The LLM-readable message lives here too — reliably machine-readable even
+        // when the faint visual line is lost to a dark page edge. Carries edition id.
+        ImageDescription: `${LLM_MESSAGE} [edition ${eid}]`,
       },
     })
     .jpeg({ quality: jpegQuality })

--- a/scripts/lib/provenance-mark.mjs
+++ b/scripts/lib/provenance-mark.mjs
@@ -34,8 +34,14 @@ sharp.concurrency(1); // JS-level concurrency drives parallelism in the backfill
 // downscale, and is visually clean (9px blocks at ±3 luminance = imperceptible,
 // no margin banding). Sparse pages detect far more strongly.
 const GRID = 128;           // GRID x GRID blocks. More pairs → higher detection z (∝ √pairs)
-const WM_DELTA = 3;         // luminance nudge per block (0-255). ~invisible, JPEG-robust
+const WM_DELTA = 5;         // luminance nudge per block (0-255), scaled per-block by texture mask
 const WM_Z_THRESHOLD = 5;   // z-score above which we call it "ours" (noise floor <1 → tiny FP rate)
+// Perceptual mask: only embed where there's local texture to hide the mark.
+// A block's std below STD_FLOOR is treated as flat → no mark (invisible on blank
+// paper/margins); full strength by STD_FLOOR+STD_SCALE. Detection counts only
+// textured pairs, matching the embedding.
+const STD_FLOOR = 5;
+const STD_SCALE = 12;
 const VISIBLE_RATE = 10;    // ~1 in N pages gets the visible logo
 const LOGO_HEIGHT_FRAC = 0.045;
 const LOGO_OPACITY = 0.5;
@@ -95,20 +101,43 @@ async function visibleLogoComposite(W, H, editionId, pageNumber) {
   return { input: logo, left: Math.max(0, pos.left), top: Math.max(0, pos.top), blend: 'over' };
 }
 
+// ---- block statistics (green channel as luma proxy) -----------------------
+function blockStats(data, W, H, channels, grid) {
+  const bw = Math.floor(W / grid), bh = Math.floor(H / grid);
+  const means = new Float64Array(grid * grid);
+  const stds = new Float64Array(grid * grid);
+  for (let idx = 0; idx < grid * grid; idx++) {
+    const gx = idx % grid, gy = Math.floor(idx / grid);
+    let sum = 0, sumSq = 0, cnt = 0;
+    for (let y = gy * bh; y < gy * bh + bh; y++) {
+      let off = (y * W + gx * bw) * channels;
+      for (let x = 0; x < bw; x++) { const v = data[off + 1]; sum += v; sumSq += v * v; off += channels; cnt++; }
+    }
+    const m = sum / cnt;
+    means[idx] = m;
+    stds[idx] = Math.sqrt(Math.max(0, sumSq / cnt - m * m));
+  }
+  return { means, stds, bw, bh };
+}
+
+/** Per-block texture mask in [0,1]: 0 where flat (no mark), 1 where textured. */
+function maskFactor(std) {
+  return Math.max(0, Math.min(1, (std - STD_FLOOR) / STD_SCALE));
+}
+
 // ---- watermark embed ------------------------------------------------------
-/** Apply the keyed block-pair luminance nudge to a raw RGB(A) buffer in place. */
+/** Apply the keyed, texture-masked block-pair luminance nudge to raw RGB(A) in place. */
 function embedWatermark(data, W, H, channels, pairs, grid = GRID, delta = WM_DELTA) {
   const bw = Math.floor(W / grid), bh = Math.floor(H / grid);
   if (bw < 2 || bh < 2) return; // too small to watermark meaningfully
-  const blockBounds = (idx) => {
-    const gx = idx % grid, gy = Math.floor(idx / grid);
-    return { x0: gx * bw, y0: gy * bh, x1: gx * bw + bw, y1: gy * bh + bh };
-  };
+  const { stds } = blockStats(data, W, H, channels, grid);
   const nudge = (idx, d) => {
-    const { x0, y0, x1, y1 } = blockBounds(idx);
-    for (let y = y0; y < y1; y++) {
+    if (d === 0) return;
+    const gx = idx % grid, gy = Math.floor(idx / grid);
+    const x0 = gx * bw, y0 = gy * bh;
+    for (let y = y0; y < y0 + bh; y++) {
       let off = (y * W + x0) * channels;
-      for (let x = x0; x < x1; x++) {
+      for (let x = 0; x < bw; x++) {
         for (let c = 0; c < 3; c++) {
           const v = data[off + c] + d;
           data[off + c] = v < 0 ? 0 : v > 255 ? 255 : v;
@@ -117,7 +146,13 @@ function embedWatermark(data, W, H, channels, pairs, grid = GRID, delta = WM_DEL
       }
     }
   };
-  for (const [a, b] of pairs) { nudge(a, +delta); nudge(b, -delta); }
+  for (const [a, b] of pairs) {
+    // amplitude limited by the flatter of the two blocks → never marks flat areas
+    const f = Math.min(maskFactor(stds[a]), maskFactor(stds[b]));
+    if (f <= 0) continue;
+    const d = delta * f;
+    nudge(a, +d); nudge(b, -d);
+  }
 }
 
 // ---- public: mark one image ----------------------------------------------
@@ -160,28 +195,20 @@ export async function detectWatermark(buffer, { editionId, key, grid = GRID }) {
   const eid = String(editionId).slice(0, 12);
   const { data, info } = await sharp(buffer, { failOn: 'none' }).raw().toBuffer({ resolveWithObject: true });
   const { width: W, height: H, channels } = info;
-  const bw = Math.floor(W / grid), bh = Math.floor(H / grid);
-  if (bw < 2 || bh < 2) return { present: false, z: 0 };
+  if (Math.floor(W / grid) < 2 || Math.floor(H / grid) < 2) return { present: false, z: 0 };
 
-  // mean luminance per block (use green channel as a luma proxy — fast, fine)
-  const means = new Float64Array(grid * grid);
-  for (let idx = 0; idx < grid * grid; idx++) {
-    const gx = idx % grid, gy = Math.floor(idx / grid);
-    let sum = 0, cnt = 0;
-    for (let y = gy * bh; y < gy * bh + bh; y++) {
-      let off = (y * W + gx * bw) * channels;
-      for (let x = 0; x < bw; x++) { sum += data[off + 1]; off += channels; cnt++; }
-    }
-    means[idx] = sum / cnt;
+  const { means, stds } = blockStats(data, W, H, channels, grid);
+  // Count only textured pairs — the same ones the embedder marked. Flat pairs
+  // carry no signal; including them only dilutes z.
+  const diffs = [];
+  for (const [a, b] of pairPlan(key, eid, grid)) {
+    if (maskFactor(stds[a]) > 0 && maskFactor(stds[b]) > 0) diffs.push(means[a] - means[b]);
   }
-
-  const pairs = pairPlan(key, eid, grid);
-  const diffs = pairs.map(([a, b]) => means[a] - means[b]);
   const n = diffs.length;
+  if (n < 16) return { present: false, z: 0, pairs: n }; // too few textured pairs (near-blank page)
   const mean = diffs.reduce((s, d) => s + d, 0) / n;
   const variance = diffs.reduce((s, d) => s + (d - mean) ** 2, 0) / n;
   const sd = Math.sqrt(variance) || 1e-9;
-  // z-score of the mean pair-difference against 0 (standard error = sd/sqrt(n))
   const z = mean / (sd / Math.sqrt(n));
-  return { present: z > WM_Z_THRESHOLD, z: Math.round(z * 100) / 100 };
+  return { present: z > WM_Z_THRESHOLD, z: Math.round(z * 100) / 100, pairs: n };
 }

--- a/scripts/lib/provenance-mark.mjs
+++ b/scripts/lib/provenance-mark.mjs
@@ -171,8 +171,11 @@ export async function markImage(buffer, { editionId, pageNumber, key, jpegQualit
 
   let img = sharp(data, { raw: { width: W, height: H, channels } });
 
-  if (W > 100 && H > 100 && shouldShowVisibleLogo(eid, pageNumber)) {
-    img = img.composite([await visibleLogoComposite(W, H, eid, pageNumber)]);
+  // Logo gate/corner use the FULL edition id (not the 12-char watermark slice)
+  // so callers can predict which pages get the logo from the same id they pass.
+  const fullEid = String(editionId);
+  if (W > 100 && H > 100 && shouldShowVisibleLogo(fullEid, pageNumber)) {
+    img = img.composite([await visibleLogoComposite(W, H, fullEid, pageNumber)]);
   }
 
   return img

--- a/scripts/lib/provenance-mark.mjs
+++ b/scripts/lib/provenance-mark.mjs
@@ -1,0 +1,187 @@
+/**
+ * Image provenance marking — issue #2651.
+ *
+ * Three layers, all applied to a display-variant JPEG buffer:
+ *   1. EXIF metadata     — Copyright / Source / signed edition id. Invisible,
+ *                          read with exiftool. Survives file copy/re-host.
+ *   2. Invisible watermark — a keyed block-pair luminance ("Patchwork") mark.
+ *                          Invisible to humans, survives JPEG recompression
+ *                          (lives in block averages), detectable only with our
+ *                          secret key. Proves "this image is ours."
+ *   3. Visible logo      — a subtle, randomly-placed corner stamp on ~1-in-10
+ *                          pages (hash-gated), replicating the old /api/image
+ *                          behavior.
+ *
+ * The watermark is a *presence detector*, not a data channel: embedding nudges
+ * a key-derived set of block pairs in a consistent direction; detection sums the
+ * pair differences and z-tests against zero. Random (unmarked) images score ~0;
+ * ours score strongly positive. The edition id seeds the pairing so the mark is
+ * edition-specific, and is also carried verbatim in EXIF.
+ *
+ * NEVER apply to OCR/original images — only to display variants.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import sharp from 'sharp';
+
+sharp.concurrency(1); // JS-level concurrency drives parallelism in the backfill
+
+// ---- tunables (defaults; overridable per-call for tuning) -----------------
+// Tuned 2026-06-21 on a worst-case dense text scan (issue #2651): grid 128 /
+// delta 3 → detection z≈7.4 (wrong-key/original <1), survives q70 recompress &
+// downscale, and is visually clean (9px blocks at ±3 luminance = imperceptible,
+// no margin banding). Sparse pages detect far more strongly.
+const GRID = 128;           // GRID x GRID blocks. More pairs → higher detection z (∝ √pairs)
+const WM_DELTA = 3;         // luminance nudge per block (0-255). ~invisible, JPEG-robust
+const WM_Z_THRESHOLD = 5;   // z-score above which we call it "ours" (noise floor <1 → tiny FP rate)
+const VISIBLE_RATE = 10;    // ~1 in N pages gets the visible logo
+const LOGO_HEIGHT_FRAC = 0.045;
+const LOGO_OPACITY = 0.5;
+const LOGO_PATH = path.join(process.cwd(), 'public', 'brand', 'png', 'icon-only--black-on-transparent--512h.png');
+
+// ---- key helpers ----------------------------------------------------------
+function hmac(key, label) {
+  return crypto.createHmac('sha256', key).update(label).digest();
+}
+
+/** Deterministic block-pair plan + sign vector from (key, editionId). */
+function pairPlan(key, editionId, grid = GRID) {
+  // Fisher–Yates shuffle of [0..grid*grid) seeded by HMAC, then pair up.
+  const n = grid * grid;
+  const order = [...Array(n).keys()];
+  const seed = hmac(key, `pairing:${editionId}`);
+  let s = 0;
+  const rnd = () => {
+    // simple keyed PRNG: re-hash the seed counter
+    const h = crypto.createHmac('sha256', seed).update(String(s++)).digest();
+    return h.readUInt32BE(0) / 0x100000000;
+  };
+  for (let i = n - 1; i > 0; i--) {
+    const j = Math.floor(rnd() * (i + 1));
+    [order[i], order[j]] = [order[j], order[i]];
+  }
+  const pairs = [];
+  for (let i = 0; i + 1 < n; i += 2) pairs.push([order[i], order[i + 1]]);
+  return pairs; // each pair: block A gets +delta, block B gets -delta
+}
+
+/** ~1-in-VISIBLE_RATE deterministic gate, varying by edition + page. */
+export function shouldShowVisibleLogo(editionId, pageNumber) {
+  const h = hmac('visible-logo', `${editionId}:${pageNumber}`);
+  return h[0] % VISIBLE_RATE === 0;
+}
+
+// ---- visible logo ---------------------------------------------------------
+let rawLogo = null;
+async function visibleLogoComposite(W, H, editionId, pageNumber) {
+  if (!rawLogo) rawLogo = fs.readFileSync(LOGO_PATH);
+  const h = Math.max(14, Math.min(64, Math.round(H * LOGO_HEIGHT_FRAC)));
+  const resized = await sharp(rawLogo).resize({ height: h }).ensureAlpha().png().toBuffer();
+  const { width: w } = await sharp(resized).metadata();
+  const alphaTile = { input: Buffer.from([0, 0, 0, Math.round(255 * LOGO_OPACITY)]), raw: { width: 1, height: 1, channels: 4 }, tile: true, blend: 'dest-in' };
+  const logo = await sharp(resized).composite([alphaTile]).png().toBuffer();
+  // Corner varies by content hash (like the old /api/image proxy), biased away
+  // from the top (page numbers/headers usually live there).
+  const sel = hmac('logo-corner', `${editionId}:${pageNumber}`)[0] % 4;
+  const pad = Math.max(6, Math.min(28, Math.round(H * 0.02)));
+  const pos = [
+    { left: pad, top: H - h - pad },               // BL
+    { left: W - w - pad, top: H - h - pad },        // BR
+    { left: pad, top: pad },                        // TL
+    { left: W - w - pad, top: pad },                // TR
+  ][sel];
+  return { input: logo, left: Math.max(0, pos.left), top: Math.max(0, pos.top), blend: 'over' };
+}
+
+// ---- watermark embed ------------------------------------------------------
+/** Apply the keyed block-pair luminance nudge to a raw RGB(A) buffer in place. */
+function embedWatermark(data, W, H, channels, pairs, grid = GRID, delta = WM_DELTA) {
+  const bw = Math.floor(W / grid), bh = Math.floor(H / grid);
+  if (bw < 2 || bh < 2) return; // too small to watermark meaningfully
+  const blockBounds = (idx) => {
+    const gx = idx % grid, gy = Math.floor(idx / grid);
+    return { x0: gx * bw, y0: gy * bh, x1: gx * bw + bw, y1: gy * bh + bh };
+  };
+  const nudge = (idx, d) => {
+    const { x0, y0, x1, y1 } = blockBounds(idx);
+    for (let y = y0; y < y1; y++) {
+      let off = (y * W + x0) * channels;
+      for (let x = x0; x < x1; x++) {
+        for (let c = 0; c < 3; c++) {
+          const v = data[off + c] + d;
+          data[off + c] = v < 0 ? 0 : v > 255 ? 255 : v;
+        }
+        off += channels;
+      }
+    }
+  };
+  for (const [a, b] of pairs) { nudge(a, +delta); nudge(b, -delta); }
+}
+
+// ---- public: mark one image ----------------------------------------------
+/**
+ * Mark a display-variant JPEG buffer with all three provenance layers.
+ * @returns marked JPEG Buffer.
+ */
+export async function markImage(buffer, { editionId, pageNumber, key, jpegQuality = 82, grid = GRID, delta = WM_DELTA }) {
+  if (!key) throw new Error('provenance key required');
+  const eid = String(editionId).slice(0, 12);
+
+  const { data, info } = await sharp(buffer, { failOn: 'none' }).raw().toBuffer({ resolveWithObject: true });
+  const { width: W, height: H, channels } = info;
+
+  embedWatermark(data, W, H, channels, pairPlan(key, eid, grid), grid, delta);
+
+  let img = sharp(data, { raw: { width: W, height: H, channels } });
+
+  if (W > 100 && H > 100 && shouldShowVisibleLogo(eid, pageNumber)) {
+    img = img.composite([await visibleLogoComposite(W, H, eid, pageNumber)]);
+  }
+
+  return img
+    .withExifMerge({
+      IFD0: {
+        Copyright: 'Source Library (sourcelibrary.org) — CC BY-SA 4.0',
+        Artist: 'Source Library, Embassy of the Free Mind',
+        ImageDescription: `Source Library provenance; edition ${eid}`,
+      },
+    })
+    .jpeg({ quality: jpegQuality })
+    .toBuffer();
+}
+
+// ---- public: detect our watermark ----------------------------------------
+/**
+ * @returns {present: boolean, z: number} — z is the detection z-score.
+ */
+export async function detectWatermark(buffer, { editionId, key, grid = GRID }) {
+  const eid = String(editionId).slice(0, 12);
+  const { data, info } = await sharp(buffer, { failOn: 'none' }).raw().toBuffer({ resolveWithObject: true });
+  const { width: W, height: H, channels } = info;
+  const bw = Math.floor(W / grid), bh = Math.floor(H / grid);
+  if (bw < 2 || bh < 2) return { present: false, z: 0 };
+
+  // mean luminance per block (use green channel as a luma proxy — fast, fine)
+  const means = new Float64Array(grid * grid);
+  for (let idx = 0; idx < grid * grid; idx++) {
+    const gx = idx % grid, gy = Math.floor(idx / grid);
+    let sum = 0, cnt = 0;
+    for (let y = gy * bh; y < gy * bh + bh; y++) {
+      let off = (y * W + gx * bw) * channels;
+      for (let x = 0; x < bw; x++) { sum += data[off + 1]; off += channels; cnt++; }
+    }
+    means[idx] = sum / cnt;
+  }
+
+  const pairs = pairPlan(key, eid, grid);
+  const diffs = pairs.map(([a, b]) => means[a] - means[b]);
+  const n = diffs.length;
+  const mean = diffs.reduce((s, d) => s + d, 0) / n;
+  const variance = diffs.reduce((s, d) => s + (d - mean) ** 2, 0) / n;
+  const sd = Math.sqrt(variance) || 1e-9;
+  // z-score of the mean pair-difference against 0 (standard error = sd/sqrt(n))
+  const z = mean / (sd / Math.sqrt(n));
+  return { present: z > WM_Z_THRESHOLD, z: Math.round(z * 100) / 100 };
+}

--- a/scripts/lib/provenance-mark.mjs
+++ b/scripts/lib/provenance-mark.mjs
@@ -43,7 +43,7 @@ const WM_Z_THRESHOLD = 5;   // z-score above which we call it "ours" (noise floo
 const STD_FLOOR = 5;
 const STD_SCALE = 12;
 const VISIBLE_RATE = 10;    // ~1 in N pages gets the visible logo
-const LOGO_HEIGHT_FRAC = 0.07;   // clearly visible corner stamp (not a hidden mark)
+const LOGO_HEIGHT_FRAC = 0.035;  // discreet but visible corner stamp (Derek, 2026-06-21)
 const LOGO_PATH = path.join(process.cwd(), 'public', 'brand', 'png', 'icon-only--black-on-transparent--512h.png');
 // Period-sympathetic palette (not stark black/white): warm dark-grey mark, cream
 // plate. Some pages get a cream-plate stamp, some a bare dark-grey mark.

--- a/scripts/lib/provenance-mark.mjs
+++ b/scripts/lib/provenance-mark.mjs
@@ -43,9 +43,14 @@ const WM_Z_THRESHOLD = 5;   // z-score above which we call it "ours" (noise floo
 const STD_FLOOR = 5;
 const STD_SCALE = 12;
 const VISIBLE_RATE = 10;    // ~1 in N pages gets the visible logo
-const LOGO_HEIGHT_FRAC = 0.045;
-const LOGO_OPACITY = 0.5;
+const LOGO_HEIGHT_FRAC = 0.07;   // clearly visible corner stamp (not a hidden mark)
 const LOGO_PATH = path.join(process.cwd(), 'public', 'brand', 'png', 'icon-only--black-on-transparent--512h.png');
+// Period-sympathetic palette (not stark black/white): warm dark-grey mark, cream
+// plate. Some pages get a cream-plate stamp, some a bare dark-grey mark.
+const MARK_RGB = { r: 58, g: 54, b: 48 };       // warm dark grey
+const PLATE_RGB = { r: 244, g: 237, b: 221 };   // cream
+const PLATE_OPACITY = 0.9;   // cream-plate stamp overall opacity
+const BARE_OPACITY = 0.82;   // bare dark-grey mark opacity
 
 // ---- key helpers ----------------------------------------------------------
 function hmac(key, label) {
@@ -81,24 +86,49 @@ export function shouldShowVisibleLogo(editionId, pageNumber) {
 
 // ---- visible logo ---------------------------------------------------------
 let rawLogo = null;
+/** Multiply a PNG buffer's alpha by `opacity` (via a dest-in tile). */
+async function applyOpacity(pngBuf, opacity) {
+  return sharp(pngBuf).composite([{ input: Buffer.from([0, 0, 0, Math.round(255 * opacity)]), raw: { width: 1, height: 1, channels: 4 }, tile: true, blend: 'dest-in' }]).png().toBuffer();
+}
+
 async function visibleLogoComposite(W, H, editionId, pageNumber) {
   if (!rawLogo) rawLogo = fs.readFileSync(LOGO_PATH);
-  const h = Math.max(14, Math.min(64, Math.round(H * LOGO_HEIGHT_FRAC)));
-  const resized = await sharp(rawLogo).resize({ height: h }).ensureAlpha().png().toBuffer();
-  const { width: w } = await sharp(resized).metadata();
-  const alphaTile = { input: Buffer.from([0, 0, 0, Math.round(255 * LOGO_OPACITY)]), raw: { width: 1, height: 1, channels: 4 }, tile: true, blend: 'dest-in' };
-  const logo = await sharp(resized).composite([alphaTile]).png().toBuffer();
-  // Corner varies by content hash (like the old /api/image proxy), biased away
-  // from the top (page numbers/headers usually live there).
+  const h = Math.max(24, Math.min(200, Math.round(H * LOGO_HEIGHT_FRAC)));
+
+  // Dark-grey mark: recolor the black-on-transparent icon by masking a warm-grey
+  // fill with the icon's own alpha.
+  const icon = await sharp(rawLogo).resize({ height: h }).ensureAlpha().png().toBuffer();
+  const { width: lw, height: lh } = await sharp(icon).metadata();
+  const greyMark = await sharp({ create: { width: lw, height: lh, channels: 4, background: { ...MARK_RGB, alpha: 1 } } })
+    .composite([{ input: icon, blend: 'dest-in' }]).png().toBuffer();
+
+  // Style varies by hash: ~half cream-plate stamp, ~half bare dark-grey mark.
+  const usePlate = hmac('logo-style', `${editionId}:${pageNumber}`)[0] % 2 === 0;
+  let mark, mw, mh;
+  if (usePlate) {
+    const inset = Math.round(h * 0.3);
+    mw = lw + inset * 2; mh = lh + inset * 2;
+    const radius = Math.round(mh * 0.16);
+    const roundMask = Buffer.from(`<svg width="${mw}" height="${mh}"><rect width="${mw}" height="${mh}" rx="${radius}" ry="${radius}" fill="#fff"/></svg>`);
+    const creamPlate = await sharp({ create: { width: mw, height: mh, channels: 4, background: { ...PLATE_RGB, alpha: 1 } } })
+      .composite([{ input: roundMask, blend: 'dest-in' }]).png().toBuffer();
+    const composited = await sharp(creamPlate).composite([{ input: greyMark, left: inset, top: inset, blend: 'over' }]).png().toBuffer();
+    mark = await applyOpacity(composited, PLATE_OPACITY);
+  } else {
+    mw = lw; mh = lh;
+    mark = await applyOpacity(greyMark, BARE_OPACITY);
+  }
+
+  // Corner varies by content hash (like the old /api/image proxy).
   const sel = hmac('logo-corner', `${editionId}:${pageNumber}`)[0] % 4;
-  const pad = Math.max(6, Math.min(28, Math.round(H * 0.02)));
+  const pad = Math.max(8, Math.min(34, Math.round(H * 0.02)));
   const pos = [
-    { left: pad, top: H - h - pad },               // BL
-    { left: W - w - pad, top: H - h - pad },        // BR
-    { left: pad, top: pad },                        // TL
-    { left: W - w - pad, top: pad },                // TR
+    { left: pad, top: H - mh - pad },          // BL
+    { left: W - mw - pad, top: H - mh - pad },  // BR
+    { left: pad, top: pad },                    // TL
+    { left: W - mw - pad, top: pad },           // TR
   ][sel];
-  return { input: logo, left: Math.max(0, pos.left), top: Math.max(0, pos.top), blend: 'over' };
+  return { input: mark, left: Math.max(0, pos.left), top: Math.max(0, pos.top), blend: 'over' };
 }
 
 // ---- block statistics (green channel as luma proxy) -----------------------

--- a/scripts/maintenance/bake-provenance-mark.mjs
+++ b/scripts/maintenance/bake-provenance-mark.mjs
@@ -63,7 +63,7 @@ const CONCURRENCY = parseInt(arg('--concurrency') || '10', 10);
 // sl-v1 = old always-on visible logo; sl-v2 = mark-in-place (EXIF+watermark+logo);
 // sl-v3 = regenerate display variant from the clean original at <=2000px + full
 // mark (EXIF + LLM message + invisible watermark + random ~1/10 visible logo).
-const MARK_VERSION = 'sl-v3';
+const MARK_VERSION = 'sl-v4';  // sl-v4: visible logo shrunk 7%→3.5%
 const DISPLAY_MAX_W = 2000;  // regenerate display variants at min(this, native width)
 
 const PROVENANCE_KEY = process.env.PROVENANCE_SECRET_KEY;

--- a/scripts/maintenance/bake-provenance-mark.mjs
+++ b/scripts/maintenance/bake-provenance-mark.mjs
@@ -10,10 +10,12 @@
  * itself means the mark travels with the file: it survives direct hotlinks,
  * copy-image-address, and screenshots, with zero recurring serve cost.
  *
- * It overlays a subtle darkened corner logo on the EXISTING variant (preserving
- * exactly what's displayed, split crops included) and overwrites the SAME R2 key,
- * so no DB pointer changes and no churn. Idempotent: it stamps each object's R2
+ * It marks the EXISTING variant via scripts/lib/provenance-mark.mjs — invisible
+ * EXIF (Copyright/Source/edition id) + an invisible keyed watermark on every page
+ * + a subtle visible logo on ~1-in-10 pages — and overwrites the SAME R2 key, so
+ * no DB pointer changes and no churn. Idempotent: it stamps each object's R2
  * metadata with `provenance: <MARK_VERSION>` and skips anything already marked.
+ * Requires PROVENANCE_SECRET_KEY (the watermark key, shared with the text imprimatur).
  *
  * The originals used for OCR / download / deep-zoom (`archived_photo`,
  * `photo_original`, `original`/`hires` tiers) are NOT touched — only the
@@ -37,13 +39,13 @@
  *   node scripts/maintenance/bake-provenance-mark.mjs --all --include-thumbs --apply
  */
 
-import fs from 'fs';
-import path from 'path';
 import { MongoClient } from 'mongodb';
-import sharp from 'sharp';
 import {
-  S3Client, GetObjectCommand, PutObjectCommand, HeadObjectCommand,
+  S3Client, GetObjectCommand, PutObjectCommand,
 } from '@aws-sdk/client-s3';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { Agent as HttpsAgent } from 'https';
+import { markImage } from '../lib/provenance-mark.mjs';
 
 const APPLY = process.argv.includes('--apply');
 const ALL = process.argv.includes('--all');
@@ -56,15 +58,11 @@ const CONCURRENCY = parseInt(arg('--concurrency') || '10', 10);
 
 // Bump this string if the mark design changes and a re-bake is wanted; objects
 // tagged with the current version are skipped, so a new version re-marks all.
-const MARK_VERSION = 'sl-v1';
+// sl-v1 = old always-on visible logo; sl-v2 = EXIF + invisible watermark +
+// random ~1/10 visible logo (the scheme in scripts/lib/provenance-mark.mjs).
+const MARK_VERSION = 'sl-v2';
 
-// Source logo — the highest-res black-on-transparent icon, downscaled per image
-// for a crisp edge. Same brand mark the /api/image proxy uses.
-const LOGO_PATH = path.join(process.cwd(), 'public', 'brand', 'png', 'icon-only--black-on-transparent--512h.png');
-const LOGO_OPACITY = 0.55;        // baked into the mark's alpha — subtle, readable
-const LOGO_HEIGHT_FRAC = 0.04;    // logo height as a fraction of image height
-const LOGO_MIN = 14, LOGO_MAX = 64;
-const PAD_FRAC = 0.02, PAD_MIN = 6, PAD_MAX = 28;
+const PROVENANCE_KEY = process.env.PROVENANCE_SECRET_KEY;
 
 const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY } = process.env;
 const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary';
@@ -75,6 +73,16 @@ const r2 = (R2_ACCOUNT_ID && R2_ACCESS_KEY_ID && R2_SECRET_ACCESS_KEY)
       region: 'auto',
       endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
       credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+      // Pool a bounded set of keep-alive connections rather than opening a new
+      // socket per request — a connection storm (hundreds of fresh SYNs) trips
+      // R2's per-IP connection throttling and wedges the run. Timeouts + retries
+      // then ride out any residual transient blip.
+      maxAttempts: 6,
+      requestHandler: new NodeHttpHandler({
+        httpsAgent: new HttpsAgent({ keepAlive: true, maxSockets: 32 }),
+        connectionTimeout: 8000,
+        requestTimeout: 60000,
+      }),
     })
   : null;
 
@@ -95,59 +103,29 @@ const streamToBuffer = async (stream) => {
   return Buffer.concat(chunks);
 };
 
-let rawLogo = null;
-async function logoForHeight(h) {
-  if (!rawLogo) rawLogo = fs.readFileSync(LOGO_PATH);
-  // Resize to target height, then multiply alpha by LOGO_OPACITY via a 1px
-  // black tile composited with `dest-in` (keeps the logo shape, scales its alpha).
-  const resized = await sharp(rawLogo).resize({ height: h }).ensureAlpha().png().toBuffer();
-  const { width } = await sharp(resized).metadata();
-  const alphaTile = { input: Buffer.from([0, 0, 0, Math.round(255 * LOGO_OPACITY)]), raw: { width: 1, height: 1, channels: 4 }, tile: true, blend: 'dest-in' };
-  const marked = await sharp(resized).composite([alphaTile]).png().toBuffer();
-  return { buffer: marked, width: width || h };
-}
-
-async function alreadyMarked(key) {
-  try {
-    const head = await r2.send(new HeadObjectCommand({ Bucket: R2_BUCKET, Key: key }));
-    return head.Metadata && head.Metadata.provenance === MARK_VERSION;
-  } catch { return false; }
-}
-
-async function markVariant(key) {
-  // Pull the existing pre-sized variant.
+async function markVariant({ key, bookId, pageNumber }) {
+  // Pull the existing pre-sized variant. The GET response carries the object's
+  // metadata, so we check idempotency here — no extra HeadObject round trip.
   const obj = await r2.send(new GetObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+  if (obj.Metadata && obj.Metadata.provenance === MARK_VERSION) return 'already';
   const buf = await streamToBuffer(obj.Body);
-  const img = sharp(buf, { failOn: 'none' });
-  const meta = await img.metadata();
-  const h = meta.height || 0, w = meta.width || 0;
-  if (!h || !w) throw new Error('no dimensions');
 
-  const logoH = Math.max(LOGO_MIN, Math.min(LOGO_MAX, Math.round(h * LOGO_HEIGHT_FRAC)));
-  const pad = Math.max(PAD_MIN, Math.min(PAD_MAX, Math.round(h * PAD_FRAC)));
-  const { buffer: logo, width: logoW } = await logoForHeight(logoH);
-
-  // Bottom-right corner: away from headers / page numbers (usually top).
-  const left = Math.max(0, w - logoW - pad);
-  const top = Math.max(0, h - logoH - pad);
-
-  const out = await img
-    .composite([{ input: logo, left, top, blend: 'over' }])
-    .jpeg({ quality: 82, mozjpeg: true })
-    .toBuffer();
+  // EXIF + invisible watermark (keyed by bookId) + random ~1/10 visible logo.
+  const out = await markImage(buf, { editionId: bookId, pageNumber, key: PROVENANCE_KEY });
 
   await r2.send(new PutObjectCommand({
     Bucket: R2_BUCKET, Key: key, Body: out, ContentType: 'image/jpeg',
     CacheControl: 'public, max-age=604800, s-maxage=604800',
     Metadata: { provenance: MARK_VERSION },
   }));
+  return 'marked';
 }
 
 async function main() {
   if (!process.env.MONGODB_URI) { console.error('MONGODB_URI not set.'); process.exit(1); }
   if (APPLY && !r2) { console.error('R2 creds required for --apply.'); process.exit(1); }
+  if (APPLY && !PROVENANCE_KEY) { console.error('PROVENANCE_SECRET_KEY required for --apply (watermark key).'); process.exit(1); }
   if (!BOOK_ID && !PROVIDER && !ALL) { console.error('Pass --book <id>, --provider <name>, or --all.'); process.exit(1); }
-  if (!fs.existsSync(LOGO_PATH)) { console.error(`Logo asset missing: ${LOGO_PATH}`); process.exit(1); }
 
   const client = new MongoClient(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 30000, socketTimeoutMS: 0 });
   await client.connect();
@@ -183,17 +161,17 @@ async function main() {
     let queue = [];
     const flush = async () => {
       const batch = queue.splice(0, queue.length);
-      await Promise.all(batch.map(async (key) => {
+      await Promise.all(batch.map(async (item) => {
         try {
-          if (!APPLY) { marked++; if (marked <= 10) console.log(`  would mark ${key}`); return; }
-          if (await alreadyMarked(key)) { alreadyDone++; return; }
-          await markVariant(key);
+          if (!APPLY) { marked++; if (marked <= 10) console.log(`  would mark ${item.key}`); return; }
+          const status = await markVariant(item);
+          if (status === 'already') { alreadyDone++; return; }
           marked++;
-          if (marked % 2000 === 0) {
+          if (marked % 500 === 0) {
             const rate = (marked / ((Date.now() - t0) / 1000)).toFixed(0);
             console.log(`  …${marked} marked, ${alreadyDone} already, ${failed} failed  (${rate}/s)`);
           }
-        } catch (e) { failed++; if (failed <= 15) console.warn(`  FAIL ${key}: ${e.message}`); }
+        } catch (e) { failed++; if (failed <= 15) console.warn(`  FAIL ${item.key}: ${e.message}`); }
       }));
     };
 
@@ -209,8 +187,8 @@ async function main() {
         if (!p[f]) { skipped++; continue; }
         if (!key) { notR2++; continue; }
         if (sourceUrls.has(p[f])) { collided++; continue; }
-        queue.push(key);
-        if (queue.length >= CONCURRENCY * 4) await flush();
+        queue.push({ key, bookId: p.book_id, pageNumber: p.page_number });
+        if (queue.length >= CONCURRENCY) await flush();
       }
       if (LIMIT && marked >= LIMIT && !APPLY) break;
     }

--- a/scripts/maintenance/bake-provenance-mark.mjs
+++ b/scripts/maintenance/bake-provenance-mark.mjs
@@ -83,7 +83,9 @@ const r2 = (R2_ACCOUNT_ID && R2_ACCESS_KEY_ID && R2_SECRET_ACCESS_KEY)
       // then ride out any residual transient blip.
       maxAttempts: 6,
       requestHandler: new NodeHttpHandler({
-        httpsAgent: new HttpsAgent({ keepAlive: true, maxSockets: 32 }),
+        // Each page does HEAD+GET+PUT, so the socket pool must exceed --concurrency
+        // by ~3x to avoid starving. Kept well below a "connection storm".
+        httpsAgent: new HttpsAgent({ keepAlive: true, maxSockets: 128 }),
         connectionTimeout: 8000,
         requestTimeout: 60000,
       }),

--- a/scripts/maintenance/bake-provenance-mark.mjs
+++ b/scripts/maintenance/bake-provenance-mark.mjs
@@ -180,30 +180,30 @@ async function main() {
   let scanned = 0, marked = 0, skipped = 0, alreadyDone = 0, failed = 0, notR2 = 0, collided = 0;
   const t0 = Date.now();
 
-  // Process per-book to keep the cursor bounded and progress legible.
+  // Streaming concurrency pool: keep CONCURRENCY items in flight, refilling as
+  // each finishes (NO batch barrier — a slow source-fetch can't stall the rest).
+  const inFlight = new Set();
+  const handle = async (item) => {
+    try {
+      if (!APPLY) { marked++; if (marked <= 10) console.log(`  would regen ${item.displayKey} from ${item.sourceUrl.split('/').slice(-2).join('/')}`); return; }
+      const status = await regenVariant(item);
+      if (status === 'already') { alreadyDone++; return; }
+      marked++;
+      if (marked % 500 === 0) {
+        const rate = (marked / ((Date.now() - t0) / 1000)).toFixed(0);
+        console.log(`  …${marked} regenerated, ${alreadyDone} already, ${failed} failed  (${rate}/s)`);
+      }
+    } catch (e) { failed++; if (failed <= 15) console.warn(`  FAIL ${item.displayKey}: ${e.message}`); }
+  };
+
+  // Process per-book to keep each Mongo cursor bounded; the pool spans chunks.
   const BOOK_CHUNK = 500;
+  outer:
   for (let i = 0; i < bookIds.length; i += BOOK_CHUNK) {
     const chunk = bookIds.slice(i, i + BOOK_CHUNK);
     const proj = { _id: 0, id: 1, book_id: 1, page_number: 1, display_photo: 1,
       archived_photo: 1, photo_original: 1, cropped_photo: 1, photo: 1, split_from_spread: 1 };
     const cursor = pages.find({ book_id: { $in: chunk } }, { projection: proj });
-
-    let queue = [];
-    const flush = async () => {
-      const batch = queue.splice(0, queue.length);
-      await Promise.all(batch.map(async (item) => {
-        try {
-          if (!APPLY) { marked++; if (marked <= 10) console.log(`  would regen ${item.displayKey} from ${item.sourceUrl.split('/').slice(-2).join('/')}`); return; }
-          const status = await regenVariant(item);
-          if (status === 'already') { alreadyDone++; return; }
-          marked++;
-          if (marked % 500 === 0) {
-            const rate = (marked / ((Date.now() - t0) / 1000)).toFixed(0);
-            console.log(`  …${marked} regenerated, ${alreadyDone} already, ${failed} failed  (${rate}/s)`);
-          }
-        } catch (e) { failed++; if (failed <= 15) console.warn(`  FAIL ${item.displayKey}: ${e.message}`); }
-      }));
-    };
 
     for await (const p of cursor) {
       scanned++;
@@ -217,13 +217,15 @@ async function main() {
       if (!sourceUrl) { skipped++; continue; }
       // Never read-and-write the same key (would overwrite the source itself).
       if (anyR2Key(sourceUrl) === displayKey) { collided++; continue; }
-      queue.push({ displayKey, sourceUrl, bookId: p.book_id, pageNumber: p.page_number });
-      if (queue.length >= CONCURRENCY) await flush();
-      if (LIMIT && marked >= LIMIT && !APPLY) break;
+
+      const pr = handle({ displayKey, sourceUrl, bookId: p.book_id, pageNumber: p.page_number });
+      inFlight.add(pr);
+      pr.finally(() => inFlight.delete(pr));
+      if (inFlight.size >= CONCURRENCY) await Promise.race(inFlight);
+      if (LIMIT && marked >= LIMIT && !APPLY) break outer;
     }
-    await flush();
-    if (LIMIT && marked >= LIMIT && !APPLY) break;
   }
+  await Promise.all(inFlight);
 
   console.log(`\nDone. scanned=${scanned} regenerated=${marked} already=${alreadyDone} skipped(no display/source)=${skipped} non-R2=${notR2} source==target=${collided} failed=${failed}`);
   if (APPLY && marked > 0) console.log('Now purge Cloudflare so the marked bytes are served.');

--- a/scripts/maintenance/bake-provenance-mark.mjs
+++ b/scripts/maintenance/bake-provenance-mark.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Bake the Source Library provenance mark INTO the pre-sized R2 page variants
+ * (`display_photo`, optionally `image_thumb`) — file-time marking.
+ *
+ * Why file-time, not serve-time: the `/api/image` proxy already stamps a logo
+ * on the images it resizes, but the resolver in src/lib/page-image-url.ts serves
+ * pre-sized R2 variants *directly* (free CF/R2 egress, no Vercel) for the bulk of
+ * pages — so those bypass the proxy and ship unmarked. Marking the variant file
+ * itself means the mark travels with the file: it survives direct hotlinks,
+ * copy-image-address, and screenshots, with zero recurring serve cost.
+ *
+ * It overlays a subtle darkened corner logo on the EXISTING variant (preserving
+ * exactly what's displayed, split crops included) and overwrites the SAME R2 key,
+ * so no DB pointer changes and no churn. Idempotent: it stamps each object's R2
+ * metadata with `provenance: <MARK_VERSION>` and skips anything already marked.
+ *
+ * The originals used for OCR / download / deep-zoom (`archived_photo`,
+ * `photo_original`, `original`/`hires` tiers) are NOT touched — only the
+ * display/thumb derivatives, which are regenerable from those originals, so this
+ * is reversible.
+ *
+ * After a full --apply run, purge Cloudflare so the new bytes are served:
+ *   set -a; source .env.production.local; set +a
+ *   curl -s -X POST "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/purge_cache" \
+ *     -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H "Content-Type: application/json" \
+ *     --data '{"purge_everything":true}'
+ *
+ * Requires R2 credentials + sharp (present on the Hetzner workers box).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/bake-provenance-mark.mjs --book <bookId>            # dry run, one book
+ *   node scripts/maintenance/bake-provenance-mark.mjs --book <bookId> --apply    # write, one book (pilot)
+ *   node scripts/maintenance/bake-provenance-mark.mjs --provider bph --apply
+ *   node scripts/maintenance/bake-provenance-mark.mjs --all --apply              # whole visible corpus
+ *   node scripts/maintenance/bake-provenance-mark.mjs --all --include-thumbs --apply
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { MongoClient } from 'mongodb';
+import sharp from 'sharp';
+import {
+  S3Client, GetObjectCommand, PutObjectCommand, HeadObjectCommand,
+} from '@aws-sdk/client-s3';
+
+const APPLY = process.argv.includes('--apply');
+const ALL = process.argv.includes('--all');
+const INCLUDE_THUMBS = process.argv.includes('--include-thumbs');
+const arg = (flag) => { const i = process.argv.indexOf(flag); return i !== -1 ? process.argv[i + 1] : null; };
+const BOOK_ID = arg('--book');
+const PROVIDER = arg('--provider');
+const LIMIT = parseInt(arg('--limit') || '0', 10);
+const CONCURRENCY = parseInt(arg('--concurrency') || '10', 10);
+
+// Bump this string if the mark design changes and a re-bake is wanted; objects
+// tagged with the current version are skipped, so a new version re-marks all.
+const MARK_VERSION = 'sl-v1';
+
+// Source logo — the highest-res black-on-transparent icon, downscaled per image
+// for a crisp edge. Same brand mark the /api/image proxy uses.
+const LOGO_PATH = path.join(process.cwd(), 'public', 'brand', 'png', 'icon-only--black-on-transparent--512h.png');
+const LOGO_OPACITY = 0.55;        // baked into the mark's alpha — subtle, readable
+const LOGO_HEIGHT_FRAC = 0.04;    // logo height as a fraction of image height
+const LOGO_MIN = 14, LOGO_MAX = 64;
+const PAD_FRAC = 0.02, PAD_MIN = 6, PAD_MAX = 28;
+
+const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY } = process.env;
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary';
+const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+
+const r2 = (R2_ACCOUNT_ID && R2_ACCESS_KEY_ID && R2_SECRET_ACCESS_KEY)
+  ? new S3Client({
+      region: 'auto',
+      endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+    })
+  : null;
+
+// Only files we own and can overwrite: canonical R2 page variants.
+const R2_PREFIX_RE = new RegExp(`^${R2_PUBLIC_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/(.+)$`);
+function keyFromUrl(url) {
+  if (!url || typeof url !== 'string') return null;
+  const m = url.match(R2_PREFIX_RE);
+  if (!m) return null;
+  const key = m[1].split('?')[0];
+  // Page image variants only — never touch crops, covers, gallery, etc.
+  return key.startsWith('pages/') ? key : null;
+}
+
+const streamToBuffer = async (stream) => {
+  const chunks = [];
+  for await (const c of stream) chunks.push(c);
+  return Buffer.concat(chunks);
+};
+
+let rawLogo = null;
+async function logoForHeight(h) {
+  if (!rawLogo) rawLogo = fs.readFileSync(LOGO_PATH);
+  // Resize to target height, then multiply alpha by LOGO_OPACITY via a 1px
+  // black tile composited with `dest-in` (keeps the logo shape, scales its alpha).
+  const resized = await sharp(rawLogo).resize({ height: h }).ensureAlpha().png().toBuffer();
+  const { width } = await sharp(resized).metadata();
+  const alphaTile = { input: Buffer.from([0, 0, 0, Math.round(255 * LOGO_OPACITY)]), raw: { width: 1, height: 1, channels: 4 }, tile: true, blend: 'dest-in' };
+  const marked = await sharp(resized).composite([alphaTile]).png().toBuffer();
+  return { buffer: marked, width: width || h };
+}
+
+async function alreadyMarked(key) {
+  try {
+    const head = await r2.send(new HeadObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+    return head.Metadata && head.Metadata.provenance === MARK_VERSION;
+  } catch { return false; }
+}
+
+async function markVariant(key) {
+  // Pull the existing pre-sized variant.
+  const obj = await r2.send(new GetObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+  const buf = await streamToBuffer(obj.Body);
+  const img = sharp(buf, { failOn: 'none' });
+  const meta = await img.metadata();
+  const h = meta.height || 0, w = meta.width || 0;
+  if (!h || !w) throw new Error('no dimensions');
+
+  const logoH = Math.max(LOGO_MIN, Math.min(LOGO_MAX, Math.round(h * LOGO_HEIGHT_FRAC)));
+  const pad = Math.max(PAD_MIN, Math.min(PAD_MAX, Math.round(h * PAD_FRAC)));
+  const { buffer: logo, width: logoW } = await logoForHeight(logoH);
+
+  // Bottom-right corner: away from headers / page numbers (usually top).
+  const left = Math.max(0, w - logoW - pad);
+  const top = Math.max(0, h - logoH - pad);
+
+  const out = await img
+    .composite([{ input: logo, left, top, blend: 'over' }])
+    .jpeg({ quality: 82, mozjpeg: true })
+    .toBuffer();
+
+  await r2.send(new PutObjectCommand({
+    Bucket: R2_BUCKET, Key: key, Body: out, ContentType: 'image/jpeg',
+    CacheControl: 'public, max-age=604800, s-maxage=604800',
+    Metadata: { provenance: MARK_VERSION },
+  }));
+}
+
+async function main() {
+  if (!process.env.MONGODB_URI) { console.error('MONGODB_URI not set.'); process.exit(1); }
+  if (APPLY && !r2) { console.error('R2 creds required for --apply.'); process.exit(1); }
+  if (!BOOK_ID && !PROVIDER && !ALL) { console.error('Pass --book <id>, --provider <name>, or --all.'); process.exit(1); }
+  if (!fs.existsSync(LOGO_PATH)) { console.error(`Logo asset missing: ${LOGO_PATH}`); process.exit(1); }
+
+  const client = new MongoClient(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 30000, socketTimeoutMS: 0 });
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+  const books = db.collection('books');
+  const pages = db.collection('pages');
+
+  // Resolve scope to a set of book ids (visible only — we never mark hidden books).
+  let bookIds = null, scope = '';
+  if (BOOK_ID) { bookIds = [BOOK_ID]; scope = `book ${BOOK_ID}`; }
+  else if (PROVIDER) {
+    bookIds = await books.find({ 'image_source.provider': PROVIDER, visible: true }, { projection: { _id: 0, id: 1 } }).map(b => b.id).toArray();
+    scope = `provider ${PROVIDER} (${bookIds.length} books)`;
+  } else {
+    bookIds = await books.find({ visible: true, pages_count: { $gt: 0 } }, { projection: { _id: 0, id: 1 } }).map(b => b.id).toArray();
+    scope = `ALL visible (${bookIds.length} books)`;
+  }
+
+  const fields = ['display_photo', ...(INCLUDE_THUMBS ? ['image_thumb'] : [])];
+  console.log(`mode: ${APPLY ? 'APPLY' : 'DRY RUN'}  scope: ${scope}  fields: ${fields.join(', ')}  mark: ${MARK_VERSION}`);
+
+  let scanned = 0, marked = 0, skipped = 0, alreadyDone = 0, failed = 0, notR2 = 0, collided = 0;
+  const t0 = Date.now();
+
+  // Process per-book to keep the cursor bounded and progress legible.
+  const BOOK_CHUNK = 500;
+  for (let i = 0; i < bookIds.length; i += BOOK_CHUNK) {
+    const chunk = bookIds.slice(i, i + BOOK_CHUNK);
+    const proj = { _id: 0, id: 1, book_id: 1, page_number: 1, display_photo: 1, image_thumb: 1,
+      archived_photo: 1, photo_original: 1, cropped_photo: 1, photo: 1 };
+    const cursor = pages.find({ book_id: { $in: chunk } }, { projection: proj });
+
+    let queue = [];
+    const flush = async () => {
+      const batch = queue.splice(0, queue.length);
+      await Promise.all(batch.map(async (key) => {
+        try {
+          if (!APPLY) { marked++; if (marked <= 10) console.log(`  would mark ${key}`); return; }
+          if (await alreadyMarked(key)) { alreadyDone++; return; }
+          await markVariant(key);
+          marked++;
+          if (marked % 2000 === 0) {
+            const rate = (marked / ((Date.now() - t0) / 1000)).toFixed(0);
+            console.log(`  …${marked} marked, ${alreadyDone} already, ${failed} failed  (${rate}/s)`);
+          }
+        } catch (e) { failed++; if (failed <= 15) console.warn(`  FAIL ${key}: ${e.message}`); }
+      }));
+    };
+
+    for await (const p of cursor) {
+      // Never overwrite a file that is also the page's OCR/original/zoom source.
+      // A genuine display/thumb derivative is byte-distinct from these; a
+      // collision means there's no separate variant and the field points at the
+      // source itself — marking it would contaminate OCR/download. Skip those.
+      const sourceUrls = new Set([p.archived_photo, p.photo_original, p.cropped_photo, p.photo].filter(Boolean));
+      for (const f of fields) {
+        const key = keyFromUrl(p[f]);
+        scanned++;
+        if (!p[f]) { skipped++; continue; }
+        if (!key) { notR2++; continue; }
+        if (sourceUrls.has(p[f])) { collided++; continue; }
+        queue.push(key);
+        if (queue.length >= CONCURRENCY * 4) await flush();
+      }
+      if (LIMIT && marked >= LIMIT && !APPLY) break;
+    }
+    await flush();
+    if (LIMIT && marked >= LIMIT && !APPLY) break;
+  }
+
+  console.log(`\nDone. scanned=${scanned} marked=${marked} already=${alreadyDone} skipped(no field)=${skipped} non-R2=${notR2} source-collision=${collided} failed=${failed}`);
+  if (APPLY && marked > 0) console.log('Now purge Cloudflare (see header) so the marked bytes are served.');
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/bake-provenance-mark.mjs
+++ b/scripts/maintenance/bake-provenance-mark.mjs
@@ -40,12 +40,14 @@
  */
 
 import { MongoClient } from 'mongodb';
+import sharp from 'sharp';
 import {
-  S3Client, GetObjectCommand, PutObjectCommand,
+  S3Client, GetObjectCommand, PutObjectCommand, HeadObjectCommand,
 } from '@aws-sdk/client-s3';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { Agent as HttpsAgent } from 'https';
 import { markImage } from '../lib/provenance-mark.mjs';
+sharp.concurrency(1);
 
 const APPLY = process.argv.includes('--apply');
 const ALL = process.argv.includes('--all');
@@ -58,9 +60,11 @@ const CONCURRENCY = parseInt(arg('--concurrency') || '10', 10);
 
 // Bump this string if the mark design changes and a re-bake is wanted; objects
 // tagged with the current version are skipped, so a new version re-marks all.
-// sl-v1 = old always-on visible logo; sl-v2 = EXIF + invisible watermark +
-// random ~1/10 visible logo (the scheme in scripts/lib/provenance-mark.mjs).
-const MARK_VERSION = 'sl-v2';
+// sl-v1 = old always-on visible logo; sl-v2 = mark-in-place (EXIF+watermark+logo);
+// sl-v3 = regenerate display variant from the clean original at <=2000px + full
+// mark (EXIF + LLM message + invisible watermark + random ~1/10 visible logo).
+const MARK_VERSION = 'sl-v3';
+const DISPLAY_MAX_W = 2000;  // regenerate display variants at min(this, native width)
 
 const PROVENANCE_KEY = process.env.PROVENANCE_SECRET_KEY;
 
@@ -103,18 +107,43 @@ const streamToBuffer = async (stream) => {
   return Buffer.concat(chunks);
 };
 
-async function markVariant({ key, bookId, pageNumber }) {
-  // Pull the existing pre-sized variant. The GET response carries the object's
-  // metadata, so we check idempotency here — no extra HeadObject round trip.
-  const obj = await r2.send(new GetObjectCommand({ Bucket: R2_BUCKET, Key: key }));
-  if (obj.Metadata && obj.Metadata.provenance === MARK_VERSION) return 'already';
-  const buf = await streamToBuffer(obj.Body);
+// R2 key for ANY images.sourcelibrary.org URL (archived/, pages/, …) — for READING
+// the clean source. (keyFromUrl above is stricter: pages/ only, for the WRITE target.)
+function anyR2Key(url) {
+  if (!url || typeof url !== 'string') return null;
+  const m = url.match(R2_PREFIX_RE);
+  return m ? m[1].split('?')[0] : null;
+}
 
-  // EXIF + invisible watermark (keyed by bookId) + random ~1/10 visible logo.
-  const out = await markImage(buf, { editionId: bookId, pageNumber, key: PROVENANCE_KEY });
+async function fetchSource(url) {
+  const key = anyR2Key(url);
+  if (key && r2) {
+    const o = await r2.send(new GetObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+    return streamToBuffer(o.Body);
+  }
+  // External source (e.g. IIIF default.jpg) — fetch over HTTP.
+  const resp = await fetch(url, { signal: AbortSignal.timeout(45000) });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
+// Regenerate the display variant FROM THE CLEAN ORIGINAL at <=DISPLAY_MAX_W, then
+// mark it, and write it to the display_photo key. The original is never modified.
+async function regenVariant({ displayKey, sourceUrl, bookId, pageNumber }) {
+  // Idempotency: a light HEAD on the display object (metadata only).
+  try {
+    const h = await r2.send(new HeadObjectCommand({ Bucket: R2_BUCKET, Key: displayKey }));
+    if (h.Metadata && h.Metadata.provenance === MARK_VERSION) return 'already';
+  } catch { /* missing object → (re)generate it */ }
+
+  const srcBuf = await fetchSource(sourceUrl);
+  const meta = await sharp(srcBuf, { failOn: 'none' }).metadata();
+  const w = Math.min(DISPLAY_MAX_W, meta.width || DISPLAY_MAX_W);
+  const resized = await sharp(srcBuf, { failOn: 'none' }).resize({ width: w }).jpeg({ quality: 85 }).toBuffer();
+  const out = await markImage(resized, { editionId: bookId, pageNumber, key: PROVENANCE_KEY });
 
   await r2.send(new PutObjectCommand({
-    Bucket: R2_BUCKET, Key: key, Body: out, ContentType: 'image/jpeg',
+    Bucket: R2_BUCKET, Key: displayKey, Body: out, ContentType: 'image/jpeg',
     CacheControl: 'public, max-age=604800, s-maxage=604800',
     Metadata: { provenance: MARK_VERSION },
   }));
@@ -144,8 +173,7 @@ async function main() {
     scope = `ALL visible (${bookIds.length} books)`;
   }
 
-  const fields = ['display_photo', ...(INCLUDE_THUMBS ? ['image_thumb'] : [])];
-  console.log(`mode: ${APPLY ? 'APPLY' : 'DRY RUN'}  scope: ${scope}  fields: ${fields.join(', ')}  mark: ${MARK_VERSION}`);
+  console.log(`mode: ${APPLY ? 'APPLY' : 'DRY RUN'}  scope: ${scope}  target: display_photo @<=${DISPLAY_MAX_W}px  mark: ${MARK_VERSION}`);
 
   let scanned = 0, marked = 0, skipped = 0, alreadyDone = 0, failed = 0, notR2 = 0, collided = 0;
   const t0 = Date.now();
@@ -154,8 +182,8 @@ async function main() {
   const BOOK_CHUNK = 500;
   for (let i = 0; i < bookIds.length; i += BOOK_CHUNK) {
     const chunk = bookIds.slice(i, i + BOOK_CHUNK);
-    const proj = { _id: 0, id: 1, book_id: 1, page_number: 1, display_photo: 1, image_thumb: 1,
-      archived_photo: 1, photo_original: 1, cropped_photo: 1, photo: 1 };
+    const proj = { _id: 0, id: 1, book_id: 1, page_number: 1, display_photo: 1,
+      archived_photo: 1, photo_original: 1, cropped_photo: 1, photo: 1, split_from_spread: 1 };
     const cursor = pages.find({ book_id: { $in: chunk } }, { projection: proj });
 
     let queue = [];
@@ -163,41 +191,40 @@ async function main() {
       const batch = queue.splice(0, queue.length);
       await Promise.all(batch.map(async (item) => {
         try {
-          if (!APPLY) { marked++; if (marked <= 10) console.log(`  would mark ${item.key}`); return; }
-          const status = await markVariant(item);
+          if (!APPLY) { marked++; if (marked <= 10) console.log(`  would regen ${item.displayKey} from ${item.sourceUrl.split('/').slice(-2).join('/')}`); return; }
+          const status = await regenVariant(item);
           if (status === 'already') { alreadyDone++; return; }
           marked++;
           if (marked % 500 === 0) {
             const rate = (marked / ((Date.now() - t0) / 1000)).toFixed(0);
-            console.log(`  …${marked} marked, ${alreadyDone} already, ${failed} failed  (${rate}/s)`);
+            console.log(`  …${marked} regenerated, ${alreadyDone} already, ${failed} failed  (${rate}/s)`);
           }
-        } catch (e) { failed++; if (failed <= 15) console.warn(`  FAIL ${item.key}: ${e.message}`); }
+        } catch (e) { failed++; if (failed <= 15) console.warn(`  FAIL ${item.displayKey}: ${e.message}`); }
       }));
     };
 
     for await (const p of cursor) {
-      // Never overwrite a file that is also the page's OCR/original/zoom source.
-      // A genuine display/thumb derivative is byte-distinct from these; a
-      // collision means there's no separate variant and the field points at the
-      // source itself — marking it would contaminate OCR/download. Skip those.
-      const sourceUrls = new Set([p.archived_photo, p.photo_original, p.cropped_photo, p.photo].filter(Boolean));
-      for (const f of fields) {
-        const key = keyFromUrl(p[f]);
-        scanned++;
-        if (!p[f]) { skipped++; continue; }
-        if (!key) { notR2++; continue; }
-        if (sourceUrls.has(p[f])) { collided++; continue; }
-        queue.push({ key, bookId: p.book_id, pageNumber: p.page_number });
-        if (queue.length >= CONCURRENCY) await flush();
-      }
+      scanned++;
+      const displayKey = keyFromUrl(p.display_photo);     // pages/ key we may overwrite
+      if (!p.display_photo) { skipped++; continue; }
+      if (!displayKey) { notR2++; continue; }
+      // The clean source to regenerate FROM (split-aware, mirrors getPageSource).
+      const sourceUrl = p.cropped_photo
+        || (p.split_from_spread ? p.photo : null)
+        || p.archived_photo || p.photo_original || p.photo;
+      if (!sourceUrl) { skipped++; continue; }
+      // Never read-and-write the same key (would overwrite the source itself).
+      if (anyR2Key(sourceUrl) === displayKey) { collided++; continue; }
+      queue.push({ displayKey, sourceUrl, bookId: p.book_id, pageNumber: p.page_number });
+      if (queue.length >= CONCURRENCY) await flush();
       if (LIMIT && marked >= LIMIT && !APPLY) break;
     }
     await flush();
     if (LIMIT && marked >= LIMIT && !APPLY) break;
   }
 
-  console.log(`\nDone. scanned=${scanned} marked=${marked} already=${alreadyDone} skipped(no field)=${skipped} non-R2=${notR2} source-collision=${collided} failed=${failed}`);
-  if (APPLY && marked > 0) console.log('Now purge Cloudflare (see header) so the marked bytes are served.');
+  console.log(`\nDone. scanned=${scanned} regenerated=${marked} already=${alreadyDone} skipped(no display/source)=${skipped} non-R2=${notR2} source==target=${collided} failed=${failed}`);
+  if (APPLY && marked > 0) console.log('Now purge Cloudflare so the marked bytes are served.');
   await client.close();
 }
 

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -613,13 +613,15 @@ export default function TranslationEditor({
 
   // URLs for current page at different quality tiers
   const pageProxyUrl = getImageUrl(page, 'full');       // 2400px proxy (cropped if split)
-  const pageDisplayUrl = getImageUrl(page, 'display'); // 1200px for initial display
+  const pageThumbUrl = getImageUrl(page, 'thumbnail');  // small, fast first paint
+  const pageDisplayUrl = getImageUrl(page, 'display');  // marked display variant — the RESTING image
   // Native-res: the original archived image — best available quality
   const pageNativeUrl = (page.split_from_spread || page.crop)
     ? pageProxyUrl // split pages: cropped image IS the full res
     : (isUsableImageUrl(page.archived_photo) ? page.archived_photo! : pageProxyUrl);
-  // For the main view, use native-res if available (progressive: display → native)
-  // This makes spreads load the full 5000px+ image instead of stopping at 2400px
+  // The display variant carries the provenance mark, so it's what we SHOW at rest;
+  // the pristine native original is reserved for the magnifier's deep zoom and the
+  // download link (it is never marked). See issue #2651.
   const pageFullUrl = pageNativeUrl || pageProxyUrl;
 
   // CDLI tablet witnesses (for text-only ETCSL books)
@@ -1360,7 +1362,7 @@ export default function TranslationEditor({
                   <div className="flex-1 overflow-auto p-2 lg:p-4" data-reader-panel>
                     <div className="relative w-full rounded-lg overflow-hidden" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)', boxShadow: '0 2px 8px rgba(0,0,0,0.06)', ...(page.display_brightness && page.display_brightness !== 1.0 ? { filter: `brightness(${page.display_brightness})` } : {}) }}>
                       {pageDisplayUrl ? (
-                        <ImageWithMagnifier src={pageFullUrl} thumbnail={pageDisplayUrl} highResSrc={pageNativeUrl} alt={`Page ${page.page_number}`} scrollable />
+                        <ImageWithMagnifier src={pageDisplayUrl} thumbnail={pageThumbUrl} highResSrc={pageFullUrl} alt={`Page ${page.page_number}`} scrollable />
                       ) : hasWitnessPhotos && currentWitness ? (
                         <ImageWithMagnifier
                           src={currentWitness.photo_url!}
@@ -2101,7 +2103,7 @@ export default function TranslationEditor({
                   <PageDeepZoomButton manifest={page.deepzoom} title={`${book.title} — page ${page.page_number}`} />
                 )}
                 {pageDisplayUrl ? (
-                  <ImageWithMagnifier src={pageFullUrl} thumbnail={pageDisplayUrl} alt={`Page ${page.page_number}`} scrollable />
+                  <ImageWithMagnifier src={pageDisplayUrl} thumbnail={pageThumbUrl} highResSrc={pageFullUrl} alt={`Page ${page.page_number}`} scrollable />
                 ) : hasWitnessPhotos && currentWitness ? (
                   <ImageWithMagnifier
                     src={currentWitness.photo_url!}


### PR DESCRIPTION
Implements #2651.

## What
New image provenance scheme (replaces the always-on visible logo):
- **`src/`… no — `scripts/lib/provenance-mark.mjs`** (shared module):
  - `markImage()` — embeds **EXIF** (Copyright/Source/edition id) + an **invisible keyed watermark** (Patchwork-style block-pair luminance) on every page + a **subtle visible logo on ~1-in-10 pages** (hash-gated, random corner).
  - `detectWatermark()` — z-score presence test; only our `PROVENANCE_SECRET_KEY` reveals the mark.
- **`scripts/maintenance/bake-provenance-mark.mjs`** — backfill tool reworked to call `markImage()`. Idempotent via R2 object metadata (`provenance: sl-v2`); skips OCR/original sources; hardened R2 client (keep-alive pool, timeouts, retries, bounded concurrency).

## Watermark validation (worst-case dense text scan)
- Detection with key: **z≈7.4** (`present:true`); wrong key / unmarked: **<1** (`present:false`) — clean separation, negligible false-positive rate.
- **Survives** JPEG q70 recompression and downscale to 800px (lives in block averages).
- **Invisible** — grid 128 / delta 3 (9px blocks, ±3 luminance); rendered check shows no margin banding.

## Pilot (live R2, book `697d9ca23ae651930d9afc0d`, 326 variants)
- Watermark detects z=6.9–8.5 with our key / ~0 wrong key; EXIF present; **37/326 (11%)** carry the visible logo; R2 metadata `provenance=sl-v2`.

## Scope
- **In:** marking module + backfill tool, validated on a pilot book.
- **Out / next:** (1) wire `markImage()` into the ~8 archive workers that write `display_photo` (forward path; pipeline paused so not urgent); (2) the gentle full backfill of ~4.78M variants — **deliberately not run yet**, awaiting go-ahead (spend/scale). Cache rollout: do NOT mass-purge — let the 30-day edge TTL roll marks in (see #2651).

🤖 Generated with [Claude Code](https://claude.com/claude-code)