### PR TITLE
fix(analytics): sample ~30% of session replays to stay under PostHog free tier

### DIFF
--- a/src/components/providers/AnalyticsScripts.tsx
+++ b/src/components/providers/AnalyticsScripts.tsx
@@ -122,17 +122,24 @@ export default function AnalyticsScripts() {
       <Script id="posthog-init" strategy="afterInteractive">
         {`
           !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageviewId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+          // Session-replay sampling: record ~30% of loads to stay under the
+          // PostHog free tier (5K web replays/cycle; full capture overshot at
+          // ~8K). The roll runs in the BROWSER, not at render time — rendering
+          // it server-side would bake one value into the 24h edge-cached HTML
+          // and hand every cached visitor the same decision. Analytics events
+          // are unaffected; only the replay recording is gated.
+          var _slRecordSession = Math.random() < 0.3;
           posthog.init('${POSTHOG_KEY}', {
             api_host: '${POSTHOG_HOST}',
             person_profiles: 'identified_only',
             capture_pageview: true,
             capture_pageleave: true,
-            // Full session replay, capturing the whole audience (loaded pre-consent;
-            // explicit Decline is honored via opt_out in the effect above).
+            // Session replay for the sampled ~30% (loaded pre-consent; explicit
+            // Decline is honored via opt_out in the effect above).
             // Capture everything: unmask all text + inputs so we see exactly what
             // readers see (search queries, navigation, scroll). Passwords are
             // always masked by PostHog regardless of this config.
-            disable_session_recording: false,
+            disable_session_recording: !_slRecordSession,
             session_recording: {
               maskAllInputs: false,
               maskTextSelector: undefined,


### PR DESCRIPTION
## Why
Session replay (added in #2557 with full pre-consent capture for the whole audience) is the one PostHog product over the free tier this cycle: **7.08K / 5K** web replays, projected **~8.18K** by cycle end — recordings past the cap silently drop. Everything else (product analytics gated to ~3%, surveys, flags, etc.) sits comfortably under free tier.

## What
Gate session-replay recording behind a per-load `Math.random() < 0.3` roll so only ~1 in 3 browsers records. That lands ~2.5K/cycle, well under the 5K limit with headroom.

- The roll runs **in the browser**, not at render time. A server-side roll would be evaluated once and baked into the 24h edge-cached HTML, handing every cached visitor the same decision.
- **Product analytics events are unaffected** — only the replay recording is sampled. Pageviews, custom events, identify, etc. still fire for everyone (subject to existing consent posture).
- Explicit **Decline** still opts the user out entirely via the existing consent effect.

## Out of scope
- Project-level PostHog sampling settings (can't be set from code).
- The full-capture *masking* posture (unmask text/inputs) is unchanged — this only changes *how many* sessions record, not *what* a recorded session captures.

## Trade-off
Derek chose ~30% (tighter than 50%) for maximum free-tier headroom, accepting a thinner sample over full-audience coverage.