### PR TITLE
feat(analytics): mirror client errors into PostHog Error Tracking

### DIFF
--- a/src/app/auth/error/AuthErrorCapture.tsx
+++ b/src/app/auth/error/AuthErrorCapture.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Reports the NextAuth (Auth.js v5) error code to PostHog Error Tracking as a
+ * real `$exception`, so the auth-failure classes — `Verification` (spent magic
+ * link) and `Configuration` (OAuth handshake dying inside an in-app browser
+ * webview, e.g. Instagram) — show up grouped, trended, and alertable, not just
+ * as `$pageview`s on /auth/error. The page itself is a server component that
+ * renders an error STATE rather than throwing, so the global window.onerror /
+ * React-boundary funnel never sees it — this is the one place that does.
+ *
+ * Best-effort and dedup-safe: fires once per mount. Respects the same Decline
+ * opt-out that gates all PostHog capture.
+ */
+export default function AuthErrorCapture({ code }: { code?: string }) {
+  useEffect(() => {
+    const ph = (window as unknown as {
+      posthog?: { captureException?: (e: unknown, p?: Record<string, unknown>) => void };
+    }).posthog;
+    if (!ph || typeof ph.captureException !== 'function') return;
+
+    const err = new Error(`Auth sign-in failed: ${code || 'unknown'}`);
+    err.name = 'AuthError';
+    ph.captureException(err, {
+      error_source: 'auth_error_page',
+      auth_error_code: code || 'unknown',
+    });
+  }, [code]);
+
+  return null;
+}

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { headers } from 'next/headers';
 import { isInAppBrowser as detectInApp, preferredBrowser } from '@/lib/in-app-browser';
+import AuthErrorCapture from './AuthErrorCapture';
 
 // NextAuth (Auth.js v5) redirects here with ?error=<code>. The codes we
 // actually see in production (PostHog, 60d): `Verification` (single-use
@@ -73,6 +74,7 @@ export default async function AuthErrorPage({
       />
       <div className="absolute inset-0 bg-black/50" />
 
+      <AuthErrorCapture code={error} />
       <div className="relative z-10 w-full max-w-md p-8 rounded-2xl text-center bg-white/95 backdrop-blur-sm border border-white/20 mx-4">
         <svg className="w-12 h-12 mx-auto mb-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="var(--text-primary)" strokeWidth="1" />

--- a/src/components/providers/ErrorReporter.tsx
+++ b/src/components/providers/ErrorReporter.tsx
@@ -26,6 +26,26 @@ export function reportError(data: {
         keepalive: true,
       }).catch(() => {});
     }
+
+    // Mirror into PostHog Error Tracking. The win over the Mongo /api/errors
+    // pipeline above is correlation: a captured exception links to the session
+    // replay of the visit it happened in, plus PostHog's grouping/trends/alerts.
+    // This is the SINGLE client-error funnel (window.onerror, unhandledrejection
+    // and the React boundary all route through reportError), so we deliberately
+    // do NOT enable PostHog exception autocapture — that would double-count.
+    // Capture respects the same Decline opt-out that gates all PostHog capture.
+    const ph = (window as unknown as {
+      posthog?: { captureException?: (e: unknown, p?: Record<string, unknown>) => void };
+    }).posthog;
+    if (ph && typeof ph.captureException === 'function') {
+      const err = new Error(data.message);
+      if (data.stack) err.stack = data.stack;
+      ph.captureException(err, {
+        error_source: data.source,
+        component_stack: data.componentStack,
+        page_url: window.location.href,
+      });
+    }
   } catch {
     // Silently fail — error reporting should never cause errors
   }


### PR DESCRIPTION
## Why
PostHog Error Tracking is free up to 100K events and currently **unused** (0/100K), while we have a known live error class (the `/auth/error` in-app-browser OAuth failures). We already log errors to Mongo (`application_errors`) with an admin dashboard at `/admin/errors`, so this isn't a replacement — it adds what Mongo can't:
- **Replay correlation** — a captured exception links to the session replay of the visit it happened in.
- PostHog's grouping / trends / alerting UI, for free.

## What
- **`ErrorReporter.tsx`** — hook `posthog.captureException` into the existing single client-error funnel `reportError()`. `window.onerror`, `unhandledrejection`, and the React error boundary all already route through it, so this captures every client error in one place. We deliberately **do not** enable PostHog exception autocapture (it would double-count against our own global handlers). Best-effort; honors the existing Decline opt-out.
- **`/auth/error`** — this route renders an error *state* (NextAuth `Verification` / `Configuration` codes) rather than throwing, so the global handlers never see it. A small client component (`AuthErrorCapture.tsx`) fires one `$exception` with the error code on mount, turning a known failure class from `$pageview`s into grouped, trended errors.

## Out of scope
- **Server-side → PostHog.** Server errors keep flowing to Mongo `application_errors` via `onRequestError` as before. Sending them to PostHog would need `posthog-node` + a per-invocation flush in the serverless error path, and there's no session replay to correlate against on the server — low value for the added complexity/dependency. Called out deliberately rather than left ambiguous.
- No change to the Mongo pipeline or the admin dashboard.

## Verify after deploy
Hit `https://sourcelibrary.org/auth/error?error=Configuration` in a browser, then check PostHog → Error Tracking for an `AuthError` group. Client crashes elsewhere will appear grouped by message with a replay link.