### PR TITLE
fix(email): round the logo into a medallion for dark mode

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -31,7 +31,7 @@ export const ROLE_LEVEL: Record<Role, number> = {
 const WELCOME_HTML = `
 <div style="font-family: Georgia, 'Times New Roman', serif; max-width: 520px; margin: 0 auto; padding: 40px 24px; color: #1a1612;">
   <div style="text-align: center; margin-bottom: 32px;">
-    <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 16px;" />
+    <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 16px; border-radius: 50%; border: 1px solid #e7ddcc;" />
     <h1 style="font-size: 26px; font-weight: 500; margin: 0 0 8px; letter-spacing: -0.01em;">Welcome to Source Library</h1>
     <p style="color: #6b6560; font-size: 15px; line-height: 1.6; margin: 0;">
       Your account is ready. Your likes and reading history will sync across all your devices.
@@ -133,7 +133,7 @@ if (process.env.RESEND_API_KEY) {
           html: `
             <div style="font-family: Georgia, 'Times New Roman', serif; max-width: 520px; margin: 0 auto; padding: 40px 24px; color: #1a1612;">
               <div style="text-align: center; margin-bottom: 32px;">
-                <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 16px;" />
+                <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 16px; border-radius: 50%; border: 1px solid #e7ddcc;" />
                 <h1 style="font-size: 24px; font-weight: 500; margin: 0 0 8px; letter-spacing: -0.01em;">Sign in to Source Library</h1>
                 <p style="color: #6b6560; font-size: 15px; line-height: 1.6; margin: 0;">
                   Click the button below to access the collection.

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -101,7 +101,7 @@ export function renderDigestHtml(content: DigestContent): string {
 <body style="margin: 0; padding: 0; background: #fdfcf9; -webkit-font-smoothing: antialiased;">
 <div style="font-family: Georgia, 'Times New Roman', serif; max-width: 520px; margin: 0 auto; padding: 40px 24px; color: #1a1612;">
   <div style="text-align: center; margin-bottom: 32px;">
-    <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 16px;" />
+    <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 16px; border-radius: 50%; border: 1px solid #e7ddcc;" />
     <h1 style="font-size: 26px; font-weight: 500; margin: 0 0 8px; letter-spacing: -0.01em;">${content.subject}</h1>
   </div>
   <div style="font-size: 15px; line-height: 1.7; margin-bottom: 24px; color: #1a1612;">
@@ -144,7 +144,7 @@ export function wrapInEmailShell(subject: string, bodyHtml: string): string {
 <body style="margin: 0; padding: 0; background: #fdfcf9; -webkit-font-smoothing: antialiased;">
 <div style="font-family: Georgia, 'Times New Roman', serif; max-width: 520px; margin: 0 auto; padding: 40px 24px; color: #1a1612;">
   <div style="text-align: center; margin-bottom: 32px;">
-    <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 16px;" />
+    <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 16px; border-radius: 50%; border: 1px solid #e7ddcc;" />
     <h1 style="font-size: 26px; font-weight: 500; margin: 0 0 8px; letter-spacing: -0.01em;">${subject}</h1>
   </div>
   <div style="font-size: 15px; line-height: 1.7; color: #1a1612;">


### PR DESCRIPTION
## Problem
The email logo (`icon-only--black-on-white.svg`) renders as a bare white square. On **dark-mode mobile — notably the Gmail app, which doesn't honor `prefers-color-scheme`** — the white square reads as a broken floating box. (Screenshot from the re-signin email.)

## Fix
Round the logo into a **medallion** — `border-radius: 50%` + a faint `1px #e7ddcc` border. Since the mark is concentric circles, the coin shape is intentional, and it reads correctly on **both** light and dark with **no dark-mode detection** (the reliable path, since Gmail ignores media queries).

Applies to all four email logos: `auth.ts` (welcome + re-signin) and `email-templates.ts` ×2.

## Considered & rejected
A `prefers-color-scheme: dark` swap to `icon-only--white-on-dark.svg` would fix iOS Mail but **not Gmail** (where the bug was seen), so it wouldn't actually solve the reported case. The medallion works everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)