### PR TITLE
feat(about): acknowledge the Gambrell Foundation as a supporter

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -173,6 +173,18 @@ export default function AboutPage() {
           Senior researcher <strong>Dr. Carlos Gilly</strong> (University of Basel), a pillar of the BPH for over thirty years and one of the world&apos;s foremost scholars of Rosicrucianism and early modern Hermetism, contributes to the Institute&apos;s research and curation.
         </p>
 
+        {/* Supporters */}
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          With the Generous Support Of
+        </h2>
+
+        <p className="text-secondary mb-8 leading-relaxed">
+          Source Library and the Embassy of the Free Mind are made possible by the
+          generosity of those who believe in this work. We gratefully acknowledge the{' '}
+          <strong>Wisdom Frontiers Society</strong> of La Jolla, California, and the{' '}
+          <strong>Gambrell Foundation</strong> for their support.
+        </p>
+
         {/* Links */}
         <div className="flex flex-wrap gap-4 pt-8 border-t border-border-light">
           <Link

--- a/src/app/vision/content.ts
+++ b/src/app/vision/content.ts
@@ -73,7 +73,7 @@ export const visionContent: VisionContent = {
     href: '/book/atalanta-fleeing-new-chemical-emblems-of-the-secrets-of-maier/page/19',
   },
   bodyAfterImage1: [
-    'We are embedded within one of the world’s great collections of ancient texts: the [Embassy of the Free Mind](https://embassyofthefreemind.com) in Amsterdam, home to the Bibliotheca Philosophica Hermetica, a UNESCO “Memory of the World” rare-book library. Source Library was created with the support of the Wisdom Frontiers Society of La Jolla, California, and runs as an open initiative of the Embassy, a Dutch nonprofit with 501(c)(3) status. You can make a tax-deductible gift [here](/support).',
+    'We are embedded within one of the world’s great collections of ancient texts: the [Embassy of the Free Mind](https://embassyofthefreemind.com) in Amsterdam, home to the Bibliotheca Philosophica Hermetica, a UNESCO “Memory of the World” rare-book library. Source Library was created with the support of the Wisdom Frontiers Society of La Jolla, California, and the Gambrell Foundation, and runs as an open initiative of the Embassy, a Dutch nonprofit with 501(c)(3) status. You can make a tax-deductible gift [here](/support).',
   ],
   buildHeading: 'What I want to build',
   bodyBuild: [


### PR DESCRIPTION
Sally Gambrell of the Gambrell Foundation has given generously to the Embassy of the Free Mind and asked to be acknowledged on the site. This adds that acknowledgment.

## Changes
- **`/about`** — new "With the Generous Support Of" section crediting the **Wisdom Frontiers Society** and the **Gambrell Foundation** (the most visible place a visitor learns who's behind the project).
- **`/vision`** — added the **Gambrell Foundation** to the existing "support of the Wisdom Frontiers Society…" line in Derek's letter.

Per the user's choices: credited as **"The Gambrell Foundation"** (institutional), placed in **both** `/about` and `/vision`.

## Out of scope
- No new `/founding-donors` page (the reserved route stays empty); no donor data file — kept this as plain editorial text matching the existing About-page style.
- No external link (none provided).

🤖 Generated with [Claude Code](https://claude.com/claude-code)