### PR TITLE
feat(ficino): no-login email signup + de-gated donate

### DIFF
--- a/src/app/api/beta/subscribe/route.ts
+++ b/src/app/api/beta/subscribe/route.ts
@@ -137,6 +137,8 @@ export async function POST(request: NextRequest) {
       country,
       source: source === 'reader_gate' ? 'reader_gate'
         : source === 'reader_gate_magic' ? 'reader_gate_magic'
+        : source === 'ficino_society' ? 'ficino_society'
+        : source === 'support' ? 'support'
         : 'beta_landing',
       subscribed_at: new Date(),
       notified: false,

--- a/src/app/ficino-society/page.tsx
+++ b/src/app/ficino-society/page.tsx
@@ -5,6 +5,10 @@ import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 
+// No-login giving link — Embassy of the Free Mind Stripe donation page.
+// Lets a logged-out reader give without creating an account first.
+const EFM_STRIPE_URL = 'https://donate.stripe.com/9B67sLbO1bOg2GxfxP9fW08';
+
 export default function FicinoSocietyPage() {
   return (
     <Suspense>
@@ -29,6 +33,33 @@ function FicinoSocietyContent() {
   const [joining, setJoining] = useState(false);
   const [contributing, setContributing] = useState(false);
   const [activating, setActivating] = useState(false);
+
+  // No-login email signup (logged-out visitors). One field, straight into the list.
+  const [email, setEmail] = useState('');
+  const [subscribing, setSubscribing] = useState(false);
+  const [subscribed, setSubscribed] = useState(false);
+  const [subscribeError, setSubscribeError] = useState('');
+
+  const handleEmailJoin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim() || subscribing) return;
+    setSubscribing(true);
+    setSubscribeError('');
+    try {
+      const res = await fetch('/api/beta/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim(), source: 'ficino_society' }),
+      });
+      const data = await res.json();
+      if (res.ok) setSubscribed(true);
+      else setSubscribeError(data.error || 'Something went wrong');
+    } catch {
+      setSubscribeError('Something went wrong');
+    } finally {
+      setSubscribing(false);
+    }
+  };
 
   useEffect(() => {
     if (session?.user && !success) {
@@ -216,13 +247,44 @@ function FicinoSocietyContent() {
               >
                 {joining ? 'Joining...' : 'Join'}
               </button>
+            ) : subscribed ? (
+              <p className="text-white/60 text-[15px] font-body">
+                You&apos;re in. Welcome to the circle — check your inbox.
+              </p>
             ) : (
-              <Link
-                href={`/auth/signin?callbackUrl=${encodeURIComponent('/ficino-society')}`}
-                className="inline-block px-10 py-3.5 rounded text-white text-[15px] font-sans tracking-wide transition-all hover:brightness-110 bg-[#9e4a3a]"
-              >
-                Sign in to join
-              </Link>
+              <>
+                <form onSubmit={handleEmailJoin} className="flex flex-col sm:flex-row gap-2 max-w-sm mx-auto">
+                  <input
+                    type="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="you@email.com"
+                    aria-label="Email address"
+                    className="flex-1 px-4 py-3.5 rounded bg-white/5 border border-white/15 text-white placeholder-white/30 text-[15px] font-body focus:outline-none focus:border-[#9e4a3a] transition-colors"
+                  />
+                  <button
+                    type="submit"
+                    disabled={subscribing}
+                    className="px-8 py-3.5 rounded text-white text-[15px] font-sans tracking-wide transition-all hover:brightness-110 disabled:opacity-50 bg-[#9e4a3a]"
+                  >
+                    {subscribing ? 'Joining...' : 'Join'}
+                  </button>
+                </form>
+                {subscribeError && (
+                  <p className="mt-3 text-[#d98a7a] text-sm font-body">{subscribeError}</p>
+                )}
+                <p className="mt-4 text-white/25 text-xs font-body">
+                  Just your email — no account needed.{' '}
+                  <Link
+                    href={`/auth/signin?callbackUrl=${encodeURIComponent('/ficino-society')}`}
+                    className="underline hover:text-white/50 transition-colors"
+                  >
+                    Sign in
+                  </Link>{' '}
+                  for the forums.
+                </p>
+              </>
             )}
           </div>
         </section>
@@ -248,12 +310,14 @@ function FicinoSocietyContent() {
               {isContributor ? 'Thank you' : contributing ? 'Redirecting...' : 'Contribute $100/year'}
             </button>
           ) : (
-            <Link
-              href={`/auth/signin?callbackUrl=${encodeURIComponent('/ficino-society')}`}
+            <a
+              href={EFM_STRIPE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-block px-8 py-3 rounded text-sm font-sans tracking-wide border border-[#1a1612]/20 text-[#1a1612] hover:brightness-110 transition-all"
             >
-              Sign in to contribute
-            </Link>
+              Contribute
+            </a>
           )}
           <p className="mt-6 text-[12px] text-[#8a8480] font-body">
             Any amount welcome &mdash;{' '}

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Metadata } from 'next';
 import SiteHeader from '@/components/layout/SiteHeader';
 import DonationIntentionForm from '@/components/donate/DonationIntentionForm';
+import QuickSubscribe from '@/components/donate/QuickSubscribe';
 import { getReadDb } from '@/lib/mongodb';
 
 export const revalidate = 600;
@@ -177,6 +178,18 @@ export default async function SupportPage() {
               </div>
             ))}
           </div>
+        </div>
+      </section>
+
+      {/* Not ready to give? Follow the work. */}
+      <section className="bg-white border-t border-stone-200 py-12 md:py-16">
+        <div className="px-6 md:px-12 max-w-5xl mx-auto">
+          <h2 className="text-xl md:text-2xl text-stone-900 mb-2 font-display">Follow the work</h2>
+          <p className="text-stone-600 text-sm leading-relaxed mb-6 max-w-md">
+            Not ready to give? Leave your email and we&apos;ll send word as new
+            first-ever translations come online. No account needed.
+          </p>
+          <QuickSubscribe source="support" />
         </div>
       </section>
 

--- a/src/components/donate/QuickSubscribe.tsx
+++ b/src/components/donate/QuickSubscribe.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * A one-field email capture that feeds the same mailing list as the beta
+ * signup (Mongo `beta_subscribers` + Resend audience). No account required.
+ * `source` tags where the signup came from so it's traceable in the data.
+ */
+export default function QuickSubscribe({ source = 'support' }: { source?: string }) {
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim() || submitting) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const res = await fetch('/api/beta/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim(), source }),
+      });
+      const data = await res.json();
+      if (res.ok) setDone(true);
+      else setError(data.error || 'Something went wrong');
+    } catch {
+      setError('Something went wrong');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <p className="text-stone-600 text-sm">
+        Thank you — you&apos;re on the list. We&apos;ll share new translations as they land.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2 max-w-md">
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@email.com"
+          aria-label="Email address"
+          className="flex-1 px-4 py-3 rounded-lg border border-stone-300 text-stone-900 placeholder-stone-400 text-sm focus:outline-none focus:border-accent-rust transition-colors"
+        />
+        <button
+          type="submit"
+          disabled={submitting}
+          className="px-6 py-3 rounded-lg bg-accent-rust text-white text-sm font-semibold hover:brightness-110 disabled:opacity-50 transition-all whitespace-nowrap"
+        >
+          {submitting ? 'Joining…' : 'Keep me posted'}
+        </button>
+      </form>
+      {error && <p className="mt-2 text-sm text-accent-rust">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Why
The Ficino Society had ~20+ real signups, but they came through a **legacy Webflow form** straight to Derek's inbox — disconnected from the mailing list. Root cause: the in-app "Join free" button was gated behind **account creation** (Google OAuth / magic link), which is *more* friction than the old Webflow email box. People took the simpler path. The donate button was login-gated too.

This removes the wall. One email field, no account.

## What
- **`/ficino-society`** — logged-out Join is now a single email-capture form posting to the existing `/api/beta/subscribe` (Mongo `beta_subscribers` + the Resend audience that beta signups already feed). Authenticated Join still grants forum access; sign-in is offered as a secondary path "for the forums."
- **`/ficino-society`** — logged-out "Sign in to contribute" → **direct EFM Stripe donate link** (give without an account). The authenticated $100/yr Stripe *subscription* is unchanged.
- **`/support`** — adds a `QuickSubscribe` "Follow the work" email box for visitors not ready to give.
- **`/api/beta/subscribe`** — whitelists `ficino_society` and `support` as `source` values so signups are traceable in the data (otherwise coerced to `beta_landing`).

## Out of scope (deliberately)
- Not touching the authenticated membership/subscription flow or the forum gate (those genuinely need an account).
- Not redesigning the `/support` donate buttons (already no-login Stripe/DonorPerfect links).
- The 24 historical Webflow signups were already synced into the Resend audience manually. Retiring the Webflow project itself is a DNS/ops step, not a code change.

## Test plan
- `npx tsc --noEmit` clean.
- Preview: on `/ficino-society` logged out, enter an email → "You're in"; "Contribute" opens Stripe. On `/support`, the "Follow the work" box subscribes. Verify a new `beta_subscribers` doc with `source: 'ficino_society'` / `'support'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)