### PR TITLE
feat(home): client-side Spanish hero for es-locale visitors

### DIFF
--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -7,8 +7,9 @@ import { useStableSession } from '@/hooks/useStableSession';
 import { recordLoadingMetric } from '@/lib/analytics';
 import UnifiedSearch from '@/components/search/UnifiedSearch';
 import SiteHeader from '@/components/layout/SiteHeader';
+import { useHeroLang, HERO_STRINGS, type HeroStrings } from '@/lib/hero-i18n';
 
-function HeroSignUp() {
+function HeroSignUp({ t }: { t: HeroStrings }) {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -31,13 +32,13 @@ function HeroSignUp() {
     return (
       <div className="max-w-xl">
         <p className="text-white text-lg">
-          Check your email &mdash; we sent a sign-in link to <strong>{email}</strong>
+          {t.checkEmail} <strong>{email}</strong>
         </p>
         <button
           onClick={() => setSent(false)}
           className="mt-3 text-sm text-white/60 hover:text-white/90 transition-colors underline"
         >
-          Use a different email
+          {t.differentEmail}
         </button>
       </div>
     );
@@ -50,7 +51,7 @@ function HeroSignUp() {
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          placeholder="Your email address"
+          placeholder={t.emailPlaceholder}
           required
           className="flex-1 px-5 py-3.5 rounded-lg bg-white text-stone-900 placeholder-stone-400 text-base outline-none border border-white focus:ring-2 focus:ring-white/50 transition-colors"
         />
@@ -60,7 +61,7 @@ function HeroSignUp() {
           className="px-7 py-3.5 rounded-lg text-base font-medium transition-all hover:brightness-110 disabled:opacity-50 shrink-0"
           style={{ background: 'var(--accent-rust)', color: '#fff' }}
         >
-          {loading ? 'Sending...' : 'Join us'}
+          {loading ? t.sending : t.join}
         </button>
       </form>
       <div className="flex items-center gap-4 mt-4">
@@ -74,14 +75,14 @@ function HeroSignUp() {
             <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
             <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
           </svg>
-          Or continue with Google
+          {t.google}
         </button>
         <span className="text-white/30">|</span>
         <Link
           href="/auth/signin"
           className="text-sm text-white/60 hover:text-white/90 transition-colors"
         >
-          Already have an account?
+          {t.haveAccount}
         </Link>
       </div>
     </div>
@@ -92,6 +93,8 @@ export default function HeroSection() {
   const { status } = useStableSession();
   const hasRecorded = useRef(false);
   const [videoReady, setVideoReady] = useState(false);
+  const [lang, setLang] = useHeroLang();
+  const t = HERO_STRINGS[lang];
 
   const handleVideoLoad = () => {
     setVideoReady(true);
@@ -132,10 +135,10 @@ export default function HeroSection() {
           <h1
             className="text-4xl md:text-5xl lg:text-6xl text-white mb-6 leading-tight tracking-wide font-display text-balance"
           >
-            A New Renaissance of Ancient Wisdom
+            {t.title}
           </h1>
           <p className="text-xl md:text-2xl lg:text-3xl font-light text-white/90 leading-relaxed max-w-2xl mb-8">
-            Welcome to the world&rsquo;s largest library<br /> of AI-translated ancient sources.
+            {t.subtitleLine1}<br /> {t.subtitleLine2}
           </p>
 
           {/* Reserve min-height to prevent layout shift while session loads */}
@@ -149,9 +152,29 @@ export default function HeroSection() {
               </div>
             ) : (
               <div className="animate-fade-in">
-                <HeroSignUp />
+                <HeroSignUp t={t} />
               </div>
             )}
+          </div>
+
+          {/* Language toggle — lets anyone the navigator.language guess got wrong
+              switch in one tap; the choice persists via localStorage. */}
+          <div className="mt-6 flex items-center gap-2 text-sm">
+            <button
+              onClick={() => setLang('en')}
+              aria-pressed={lang === 'en'}
+              className={`transition-colors ${lang === 'en' ? 'text-white font-medium' : 'text-white/50 hover:text-white/80'}`}
+            >
+              English
+            </button>
+            <span className="text-white/30">·</span>
+            <button
+              onClick={() => setLang('es')}
+              aria-pressed={lang === 'es'}
+              className={`transition-colors ${lang === 'es' ? 'text-white font-medium' : 'text-white/50 hover:text-white/80'}`}
+            >
+              Español
+            </button>
           </div>
         </div>
         </div>
@@ -168,7 +191,7 @@ export default function HeroSection() {
         aria-label="Scroll to library"
       >
         <span className="text-xs uppercase tracking-[0.2em] text-white/70 group-hover:text-white transition-colors">
-          Explore the collection
+          {t.explore}
         </span>
         <svg className="w-5 h-5 text-white/70 group-hover:text-white animate-bounce transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />

--- a/src/lib/hero-i18n.ts
+++ b/src/lib/hero-i18n.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// Minimal, client-side-only localization for the homepage hero — the
+// bounce-critical first screen. We deliberately do NOT localize server-side:
+// the homepage HTML is edge-cached for 24h, and branching SSR output on
+// Accept-Language without a cache-key change would serve a cached Spanish page
+// to English visitors (same failure class as the stale-CSS incident). Keeping
+// this purely client-side leaves the cache untouched — English renders first,
+// then this swaps to Spanish after hydration for es-locale visitors.
+//
+// Audience context: ~84% mobile, mostly from Instagram webviews where the
+// browser "translate" button does not exist — but navigator.language still
+// reflects the device language, so detection works there too.
+
+export type Lang = 'en' | 'es';
+
+const STORAGE_KEY = 'sl_lang';
+
+export const HERO_STRINGS = {
+  en: {
+    title: 'A New Renaissance of Ancient Wisdom',
+    subtitleLine1: 'Welcome to the world’s largest library',
+    subtitleLine2: 'of AI-translated ancient sources.',
+    emailPlaceholder: 'Your email address',
+    join: 'Join us',
+    sending: 'Sending…',
+    checkEmail: 'Check your email — we sent a sign-in link to',
+    differentEmail: 'Use a different email',
+    google: 'Or continue with Google',
+    haveAccount: 'Already have an account?',
+    explore: 'Explore the collection',
+  },
+  es: {
+    title: 'Un nuevo Renacimiento de la sabiduría antigua',
+    subtitleLine1: 'Bienvenido a la mayor biblioteca del mundo',
+    subtitleLine2: 'de fuentes antiguas traducidas con IA.',
+    emailPlaceholder: 'Tu correo electrónico',
+    join: 'Únete',
+    sending: 'Enviando…',
+    checkEmail: 'Revisa tu correo — enviamos un enlace de acceso a',
+    differentEmail: 'Usar otro correo',
+    google: 'O continúa con Google',
+    haveAccount: '¿Ya tienes una cuenta?',
+    explore: 'Explora la colección',
+  },
+} as const;
+
+export type HeroStrings = { readonly [K in keyof (typeof HERO_STRINGS)['en']]: string };
+
+/**
+ * Resolve the hero language client-side. Priority: saved override (the toggle)
+ * > navigator.language > English. Starts at 'en' so SSR and first paint match
+ * the cached English HTML; updates after mount.
+ */
+export function useHeroLang(): [Lang, (l: Lang) => void] {
+  const [lang, setLangState] = useState<Lang>('en');
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved === 'en' || saved === 'es') {
+        setLangState(saved);
+        return;
+      }
+      const nav = (navigator.language || '').toLowerCase();
+      if (nav.startsWith('es')) setLangState('es');
+    } catch {
+      // localStorage/navigator unavailable — stay English.
+    }
+  }, []);
+
+  const setLang = (l: Lang) => {
+    setLangState(l);
+    try {
+      localStorage.setItem(STORAGE_KEY, l);
+    } catch {
+      // ignore persistence failure
+    }
+  };
+
+  return [lang, setLang];
+}


### PR DESCRIPTION
## Why
Analytics this week showed the homepage's real audience is overwhelmingly **Spanish-speaking** (Mexico #1, then Spain/Chile/Colombia/Argentina — US only #3), **~84% mobile**, mostly arriving from **Instagram** — landing on a fully English page with ~70% bounce. This is a cheap test of whether a Spanish first screen moves that.

## Approach — deliberately client-side only
The homepage HTML is edge-cached 24h. Branching SSR output on `Accept-Language` without a cache-key change would serve a cached Spanish page to English visitors (same failure class as the stale-CSS incident). So this touches **no SSR, no middleware, no cache**:

- English renders first (matches the cached HTML).
- A small hook (`useHeroLang`) swaps the hero to Spanish after hydration for es-locale visitors.
- Detection: **saved toggle override > `navigator.language` > English**. `navigator.language` reflects device language even inside Instagram/FB webviews — where the browser "translate" button doesn't exist, which is exactly this audience.

## What's localized
Title, subtitle, the sign-up CTA (placeholder / Join / Google / "already have an account" / check-email state), and the scroll label. Plus an unobtrusive **English · Español toggle** that persists to localStorage so anyone the guess got wrong fixes it in one tap.

## Tradeoffs (accepted)
- **Sub-second flash of English** before the swap on first paint — the price of not touching the cache.
- **No SEO** — HTML stays English; ranking for Spanish queries is a separate, later project.
- Out of scope: deep book content, emails.

One isolated component + one strings file. Fully reversible — delete the file and nothing else changes. If the bounce drops, expand; if not, we lean on browser translation for the rest.