### PR TITLE
feat(email): Resend webhook + broadcast stats

### DIFF
--- a/scripts/email-broadcast-stats.mjs
+++ b/scripts/email-broadcast-stats.mjs
@@ -1,0 +1,52 @@
+/**
+ * Aggregate Resend email events (logged by /api/webhooks/resend) into
+ * bounce / open / complaint / click rates, per broadcast.
+ *
+ *   node scripts/email-broadcast-stats.mjs                 # all broadcasts, summary
+ *   node scripts/email-broadcast-stats.mjs <broadcast_id>  # one broadcast
+ *
+ * Source via: set -a; source .env.production.local; set +a
+ */
+
+import { getScriptClient } from './lib/mongo.mjs';
+
+const wantId = process.argv[2] || null;
+
+const { db, cleanup } = await getScriptClient({ timeoutMs: 60000 });
+try {
+  const match = wantId ? { broadcast_id: wantId } : {};
+  const rows = await db.collection('email_events').aggregate([
+    { $match: match },
+    // one row per (broadcast, email, type)
+    { $group: { _id: { b: '$broadcast_id', e: '$to', t: '$type' } } },
+    // collapse to per-(broadcast,email): which event types fired
+    { $group: { _id: { b: '$_id.b', e: '$_id.e' }, types: { $addToSet: '$_id.t' } } },
+    // tally per broadcast
+    { $group: {
+      _id: '$_id.b',
+      recipients: { $sum: 1 },
+      delivered: { $sum: { $cond: [{ $in: ['email.delivered', '$types'] }, 1, 0] } },
+      bounced:   { $sum: { $cond: [{ $in: ['email.bounced', '$types'] }, 1, 0] } },
+      complained:{ $sum: { $cond: [{ $in: ['email.complained', '$types'] }, 1, 0] } },
+      opened:    { $sum: { $cond: [{ $in: ['email.opened', '$types'] }, 1, 0] } },
+      clicked:   { $sum: { $cond: [{ $in: ['email.clicked', '$types'] }, 1, 0] } },
+    } },
+    { $sort: { _id: 1 } },
+  ]).toArray();
+
+  if (!rows.length) {
+    console.log('No email_events yet' + (wantId ? ` for broadcast ${wantId}` : '') + '.');
+  }
+  for (const r of rows) {
+    const denom = r.delivered || r.recipients || 1;
+    const pct = (n) => `${((100 * n) / denom).toFixed(1)}%`;
+    console.log(`\nBroadcast ${r._id || '(none)'}`);
+    console.log(`  recipients seen: ${r.recipients}  delivered: ${r.delivered}`);
+    console.log(`  bounced:    ${r.bounced} (${pct(r.bounced)})`);
+    console.log(`  complaints: ${r.complained} (${pct(r.complained)})`);
+    console.log(`  opened:     ${r.opened} (${pct(r.opened)})`);
+    console.log(`  clicked:    ${r.clicked} (${pct(r.clicked)})`);
+  }
+} finally {
+  cleanup();
+}

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { getDb } from '@/lib/mongodb';
+
+/**
+ * Resend webhook receiver — logs email delivery events (sent, delivered,
+ * bounced, complained, opened, clicked, failed) into the `email_events`
+ * collection so we can compute bounce/open/complaint/click rates for
+ * broadcasts (e.g. the staged user broadcast in
+ * scripts/send-user-broadcast.mjs). Aggregate with
+ * scripts/email-broadcast-stats.mjs.
+ *
+ * Resend signs webhooks with Svix-style headers (svix-id / svix-timestamp /
+ * svix-signature). We verify the HMAC so the public endpoint can't be spoofed.
+ */
+
+const RELEVANT = new Set([
+  'email.sent',
+  'email.delivered',
+  'email.delivery_delayed',
+  'email.bounced',
+  'email.complained',
+  'email.opened',
+  'email.clicked',
+  'email.failed',
+]);
+
+/** Verify the Svix signature Resend sends. Returns true if any v1 sig matches. */
+function verifySignature(secret: string, headers: Headers, body: string): boolean {
+  const id = headers.get('svix-id');
+  const timestamp = headers.get('svix-timestamp');
+  const sigHeader = headers.get('svix-signature');
+  if (!id || !timestamp || !sigHeader) return false;
+
+  // secret is "whsec_<base64>"; the HMAC key is the decoded base64.
+  const key = Buffer.from(secret.replace(/^whsec_/, ''), 'base64');
+  const signedContent = `${id}.${timestamp}.${body}`;
+  const expected = createHmac('sha256', key).update(signedContent).digest('base64');
+
+  // svix-signature is a space-separated list of "v1,<sig>" entries.
+  return sigHeader.split(' ').some((part) => {
+    const sig = part.split(',')[1];
+    if (!sig) return false;
+    const a = Buffer.from(sig);
+    const b = Buffer.from(expected);
+    return a.length === b.length && timingSafeEqual(a, b);
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.RESEND_WEBHOOK_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 503 });
+  }
+
+  const body = await request.text();
+  if (!verifySignature(secret, request.headers, body)) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  let event: { type?: string; created_at?: string; data?: Record<string, unknown> };
+  try {
+    event = JSON.parse(body);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const type = event.type || 'unknown';
+  if (!RELEVANT.has(type)) {
+    return NextResponse.json({ received: true, ignored: type });
+  }
+
+  const data = event.data || {};
+  const to = Array.isArray(data.to) ? (data.to[0] as string) : (data.to as string | undefined);
+
+  try {
+    const db = await getDb();
+    // Idempotent on (email_id, type) so Resend retries don't double-count.
+    await db.collection('email_events').updateOne(
+      { email_id: data.email_id ?? null, type },
+      {
+        $set: {
+          email_id: data.email_id ?? null,
+          type,
+          to: to ?? null,
+          broadcast_id: (data.broadcast_id as string) ?? null,
+          subject: (data.subject as string) ?? null,
+          bounce: data.bounce ?? null,
+          click: data.click ?? null,
+          event_at: event.created_at ? new Date(event.created_at) : null,
+          received_at: new Date(),
+          raw: data,
+        },
+      },
+      { upsert: true }
+    );
+  } catch (error) {
+    console.error('[resend-webhook] store failed:', error);
+    return NextResponse.json({ error: 'Store failed' }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
+}


### PR DESCRIPTION
## What
Real delivery monitoring for the staged user broadcast (and all future Resend sends).

- **`/api/webhooks/resend`** — Svix-verified webhook that logs `email.{sent,delivered,bounced,complained,opened,clicked,failed}` events into a new `email_events` collection. Idempotent on `(email_id, type)` so Resend retries don't double-count.
- **`scripts/email-broadcast-stats.mjs`** — aggregates bounce / open / complaint / click rates per `broadcast_id`.

## Why
The user-welcome broadcast (`scripts/send-user-broadcast.mjs`) sends in 3 staged batches; we need Batch N's bounce/complaint rate before sending Batch N+1. Resend's broadcast API exposes no aggregate stats, so we capture events ourselves.

## Go-live (after merge + deploy)
1. `npm run deploy:prod` so the endpoint is live.
2. Set `RESEND_WEBHOOK_SECRET` in Vercel prod env (the secret Resend returns when the webhook is registered).
3. Register the webhook in Resend pointing at `https://sourcelibrary.org/api/webhooks/resend`.

## Scope
Out of scope: no UI; stats are CLI-only for now. Signature verification mirrors the existing Stripe webhook pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)