### PR TITLE
Validate the translation-gap figure against ground truth (#2626)

### DIFF
--- a/.claude/docs/translation-gap-methodology.md
+++ b/.claude/docs/translation-gap-methodology.md
@@ -144,11 +144,63 @@ numbers and never mix them:
 | claim | status | why |
 |---|---|---|
 | 503k Latin editions; 366k Latin work-clusters 1400–1700 | **solid** | direct counts from USTC |
-| ~97% of those clusters have no external English translation | **conservative floor** | residual ~10–15% false-positive matches mark some untranslated works as translated → the *true* gap is ≥97% |
-| "~2.7% translated" / "90%+ untranslated" | **solid, agrees with Shuger** | independent scholarly estimate corroborates |
-| denominator = *Renaissance-composed* works | **upper bound only** | USTC year is print year; includes ancient/medieval reprints |
+| ~97% of USTC-print clusters have no external English translation | **overstates the Renaissance gap** | validation: the raw figure inflates because the print-year denominator includes *translated* ancient/medieval reprints (3/5 of the sampled misses) |
+| **~85–90% of genuinely Renaissance-composed Latin works untranslated** | **validated (pilot, 95% CI 60–96%, n=30)** | blind stratified independent-verification eval (see Validation); now *measured*, agrees with Shuger's "90%" |
+| translation-match precision ~92% | **validated** | 11/12 of "translated" confirmed by independent grounded search |
+| denominator = *Renaissance-composed* works | **upper bound only** | USTC year is print year; includes ancient/medieval reprints — confirmed by the eval |
 | "~20 new works translated per year" (the rate) | **order-of-magnitude** | from the per-decade first-translation series; gross retranslation removed |
 | "X years to finish" | **deliberately not stated** | numerator and denominator are both order-of-magnitude; honest answer is "millennia" |
+
+## Validation against ground truth (pilot, 2026-06-21)
+
+The figures above come from our matching pipeline. To convert them from a
+*hypothesis* into a *defensible estimate with error bars*, we ran a **blind,
+stratified, independently-verified** pilot — the eval that closes the loop the
+novelty review flagged (a self-published number is a hypothesis until validated).
+
+**Design.** Drew a random sample of 30 Latin works in two strata — 12 the
+pipeline calls **translated**, 18 it calls **gap (untranslated)** — stripped the
+labels, and handed each to one of three **independent grounded-search agents**
+(blind to our label) that searched WorldCat/Google Books/archive.org/scholarly
+bibliographies for any published English translation, with strict rules (a modern
+Latin reprint or a critical edition *without* a translation does not count).
+Artifact: `scripts/analysis/eval-data/translation-gap-validation-2026-06-21.json`.
+
+**Results.**
+- **Translated-stratum precision = 11/12 (92%).** When the pipeline says
+  "translated," it is right ~92% of the time. The one false positive — Ziegler's
+  *Schondia* — exists only in Latin; a stray catalog match flagged it.
+- **Gap-stratum: 13/18 (72%) genuinely untranslated; 5 false negatives (28%)** —
+  works we called "gap" that *do* have a translation we missed.
+- **The denominator caveat, now measured:** **3 of those 5 false negatives are
+  ancient/medieval works** (Themistius 4th c., Theophylact 11th c., Sacrobosco
+  13th c.) merely *reprinted* in the 1480–1620 Latin window — exactly the
+  print-year-not-composition-year inflation we flagged. These classics are
+  translated *because they're ancient classics*, not because the Renaissance gap
+  is smaller.
+- **Restricted to genuinely Renaissance-composed works, the gap holds up:
+  12/14 (86%) untranslated** (95% Wilson CI 60–96%). The only two real misses
+  (Dickson's *De umbra rationis*, tr. Ferguson 2013; Haedus's Malta description,
+  tr. Vella 1980) are obscure works with a *single* recent scholarly translation —
+  the long-tail under-capture we already named.
+
+**What it means for the headline.** Two corrections, opposite signs, both small:
+the pipeline slightly *over*-counts translations (92% precision ⇒ a few "translated"
+are not) and slightly *under*-counts them on the gap side (recall ~86% on
+Renaissance works ⇒ the true translated fraction is a little higher than 2.7%).
+Net: the honest estimate for **genuinely Renaissance-composed Latin works is
+~85–90% untranslated** — squarely consistent with Shuger's "90%," now *measured*
+rather than asserted, but with an explicit (and, at n=30, wide) confidence band.
+The raw "97% of USTC-print clusters" overstates the Renaissance gap because the
+denominator includes translated ancient/medieval reprints.
+
+**Caveats on the eval itself.** n=30 is a *pilot* — the CIs are wide, and a
+publishable figure needs n≈200–300 stratified, ideally with a human-adjudicated
+gold-standard subset and a Rogan–Gladen correction for adjudicator
+sensitivity/specificity (the framework already used for the first-translation
+badge audit — see `ft-first-translation-paper.md`). The pilot's value is that it
+(a) confirms the *direction and rough magnitude*, (b) quantifies the two error
+channels, and (c) proves the print-vs-composition denominator effect with data.
 
 ## Known limitations (stated plainly)
 

--- a/scripts/analysis/eval-data/translation-gap-validation-2026-06-21.json
+++ b/scripts/analysis/eval-data/translation-gap-validation-2026-06-21.json
@@ -1,0 +1,246 @@
+{
+ "generated": "2026-06-21",
+ "method": "blind stratified sample, 3 independent grounded-search agents",
+ "works": [
+  {
+   "key": "T0",
+   "label": "translated_claim",
+   "author": "Ziegler Jacob",
+   "title": "Schondia",
+   "century": 16,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "T1",
+   "label": "translated_claim",
+   "author": "Barclay John",
+   "title": "The mirror of minds",
+   "century": 17,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T2",
+   "label": "translated_claim",
+   "author": "Catholic Church",
+   "title": "Catechism of the Catholic Church",
+   "century": 16,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T3",
+   "label": "translated_claim",
+   "author": "Desiderius Erasmus",
+   "title": "Paraphrase on Matthew",
+   "century": 16,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T4",
+   "label": "translated_claim",
+   "author": "Erasmus, Desiderius",
+   "title": "The education of a Christian prince",
+   "century": 16,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T5",
+   "label": "translated_claim",
+   "author": "Francis Bacon",
+   "title": "Essays, including his moral and historical works",
+   "century": 17,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T6",
+   "label": "translated_claim",
+   "author": "Giovanni Aurelio Augurello",
+   "title": "Giovanni Aurelio Augurello (1441-1524) and Renaissance Alchemy: A Critical Edition of Chrysopoeia and Other Alchemical Poems",
+   "century": 16,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T7",
+   "label": "translated_claim",
+   "author": "Heinrich Nollius",
+   "title": "The Birthing Bed of the Philosophers' Stone",
+   "century": 17,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T8",
+   "label": "translated_claim",
+   "author": "Jean Calvin",
+   "title": "Concerning Scandals",
+   "century": 16,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T9",
+   "label": "translated_claim",
+   "author": "John Calvin",
+   "title": "Institutes of the Christian religion",
+   "century": 16,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T10",
+   "label": "translated_claim",
+   "author": "Leon Battista Alberti",
+   "title": "On the Art of Building",
+   "century": 15,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "T11",
+   "label": "translated_claim",
+   "author": "Marlorat, Augustin",
+   "title": "A catholike exposition upon the Revelation of Sainct Iohn",
+   "century": 16,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "G0",
+   "label": "gap_claim",
+   "author": "Matthaeus, Johann",
+   "title": "Oratio de passione Christi / scripta a Johanne Mattaei ... publice nec non memoriter in Ac",
+   "year": 1614,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G1",
+   "label": "gap_claim",
+   "author": "Pétau, Denis",
+   "title": "Opera poetica",
+   "year": 1620,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G2",
+   "label": "gap_claim",
+   "author": "Paul V, Pope",
+   "title": "S.D.N. Pauli papae quinti Indictio quatuor decimarum super fructibus omnium ecclesiasticor",
+   "year": 1607,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G3",
+   "label": "gap_claim",
+   "author": "Spee, Sibert",
+   "title": "Positiones Juris Ex Tit. FF. C. Et Inst. Si Quadrupedes Pauperiem Fecisse Dicatur Et L. Aq",
+   "year": 1608,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G4",
+   "label": "gap_claim",
+   "author": "Chaves, Tomás de",
+   "title": "Summa sacramentorum Ecclesiae, ex doctrina reverendi patris fratris Francisci a Victoria. ",
+   "year": 1584,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G5",
+   "label": "gap_claim",
+   "author": "Herold, Philipp",
+   "title": "Carmen heroicum Philippi heroldi Lipsici, de laudibus musarum.",
+   "year": 1558,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G6",
+   "label": "gap_claim",
+   "author": "Carboni, Ludovico",
+   "title": "De officio oratoris libri V In quorum tribus, qua ratione orator docere, delectare, ac mov",
+   "year": 1596,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G7",
+   "label": "gap_claim",
+   "author": "Beleth, Jean",
+   "title": "Rationale divinorum officiorum Ioanne Beletho authore opus nunc demum operae [!] Cornelii ",
+   "year": 1563,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G8",
+   "label": "gap_claim",
+   "author": "Negri, Giacomo",
+   "title": "Repetitio super rubrica et lege prima digesti de legatis I. edita in gymnasio Romano",
+   "year": 1530,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G9",
+   "label": "gap_claim",
+   "author": "Dickson, Alexander",
+   "title": "De umbra rationis et judicii, sive de memoriae virtute prosopoeia",
+   "year": 1597,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "G10",
+   "label": "gap_claim",
+   "author": "Themistius",
+   "title": "Paraphrasis in duodecimum librum Aristotelis de prima philosophia. Mose Finzio interprete",
+   "year": 1576,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "G11",
+   "label": "gap_claim",
+   "author": "Theophylactus Achridensis",
+   "title": "In quatuor domini nostri Jesu Christi evangelia enarrationes luculentissimae",
+   "year": 1543,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "G12",
+   "label": "gap_claim",
+   "author": "Stephanius, Hans",
+   "title": "De fallaciis theses",
+   "year": 1606,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G13",
+   "label": "gap_claim",
+   "author": "L'Oulmeau, Conrad de",
+   "title": "De advocati studio libri quinque",
+   "year": 1537,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G14",
+   "label": "gap_claim",
+   "author": "Haedus, Joannes Quintinus",
+   "title": "Insulae Melitae descriptio ex commentariis rerum quotidianorum",
+   "year": 1536,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "G15",
+   "label": "gap_claim",
+   "author": "Petrejus, Paul",
+   "title": "Locus Doctrinae Christianae De Naturis, Persona Et Officio Jesu Christi : In Theses resolu",
+   "year": 1606,
+   "independent_verdict": "untranslated"
+  },
+  {
+   "key": "G16",
+   "label": "gap_claim",
+   "author": "Sacro Bosco, Johannes de",
+   "title": "Algorismus Magistri Joannis De sacro busto ex vetustissimis [..] exemplaribus collectus & ",
+   "year": 1511,
+   "independent_verdict": "translated"
+  },
+  {
+   "key": "G17",
+   "label": "gap_claim",
+   "author": "Finck, Kaspar",
+   "title": "De Natura Et Conditione Corporum Glorificatorum Disputatio Scholastica , Ad cuius subiecta",
+   "year": 1607,
+   "independent_verdict": "untranslated"
+  }
+ ]
+}


### PR DESCRIPTION
Closes the validation gap the novelty review flagged. **Blind stratified pilot (n=30)**: 12 pipeline-'translated' + 18 pipeline-'gap' Latin works, labels stripped, each verified by an **independent grounded-search agent**.

**Results:**
- Translation-match **precision 92%** (11/12 confirmed)
- Gap-stratum **72% truly untranslated**; of the 5 false negatives, **3 are ancient/medieval works** (Themistius, Theophylact, Sacrobosco) merely *reprinted* in the Latin window — the print-vs-composition denominator effect, now **measured**
- Restricted to genuinely Renaissance-composed works: **86% untranslated (95% CI 60–96%)** — Shuger's '90%' now measured, not asserted

Net: the raw '97% of USTC-print clusters' overstates the Renaissance gap; the honest validated figure is **~85–90% untranslated** for Renaissance-composed Latin, with a wide pilot CI (publishable wants n≈200–300 + Rogan–Gladen, per the FT paper). Adds the Validation section to the methodology paper + the reproducible eval artifact. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)