### PR TITLE
feat(feedback): translation-request notify loop + reader search leak fix

### DIFF
--- a/scripts/maintenance/notify-addressed-feedback.mjs
+++ b/scripts/maintenance/notify-addressed-feedback.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Backstop notifier for addressed feedback.
+ *
+ * The admin route PATCH /api/feedback/[id] already emails a submitter the moment
+ * an item is marked addressed (via src/lib/feedback-reply-email.ts). But feedback
+ * can also be addressed out-of-band — batch fulfillment scripts, direct DB edits,
+ * bulk triage. This script catches those: any feedback row that is
+ *   addressed:true  AND  has an email  AND  has no reply_sent_at
+ * gets the same "we read your feedback and acted on it" email, then is stamped
+ * reply_sent_at so it never double-sends (matching the route's idempotency guard).
+ *
+ * Usage:
+ *   node scripts/maintenance/notify-addressed-feedback.mjs            # dry-run
+ *   node scripts/maintenance/notify-addressed-feedback.mjs --go       # send
+ *
+ * Env: MONGODB_URI, RESEND_API_KEY, EMAIL_FROM (optional).
+ */
+import { MongoClient } from 'mongodb';
+
+const GO = process.argv.includes('--go');
+
+function escapeHtml(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+const isPublicUrl = (u) => /^https?:\/\//i.test((u || '').trim());
+
+function buildHtml({ name, originalMessage, replyBody, link }) {
+  const greeting = name && name.trim() ? `Hi ${escapeHtml(name.trim())},` : 'Hi,';
+  const body = replyBody && replyBody.trim()
+    ? escapeHtml(replyBody.trim())
+    : 'We&rsquo;ve looked into this and made a change based on what you sent.';
+  const linkBlock = link && isPublicUrl(link)
+    ? `<div style="text-align:center;margin:28px 0 4px;"><a href="${escapeHtml(link.trim())}" style="display:inline-block;padding:11px 28px;background:#9e4a3a;color:#fff;text-decoration:none;border-radius:8px;font-size:15px;font-family:-apple-system,sans-serif;">See the change</a></div>`
+    : '';
+  return `
+<div style="font-family:Georgia,'Times New Roman',serif;max-width:520px;margin:0 auto;padding:40px 24px;color:#1a1612;">
+  <div style="text-align:center;margin-bottom:28px;">
+    <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="44" height="44" style="margin-bottom:14px;" />
+    <h1 style="font-size:23px;font-weight:500;margin:0;letter-spacing:-0.01em;">Thanks for your feedback</h1>
+  </div>
+  <p style="font-size:15px;line-height:1.7;margin:0 0 16px;">${greeting}</p>
+  <p style="font-size:15px;line-height:1.7;margin:0 0 16px;">A little while ago you sent us a note about Source Library. We wanted to let you know we read it &mdash; and acted on it.</p>
+  <div style="background:#f5f0e8;border-left:3px solid #d8cfc0;border-radius:6px;padding:14px 18px;margin:0 0 20px;">
+    <div style="font-size:12px;text-transform:uppercase;letter-spacing:0.04em;color:#8a8480;margin-bottom:6px;">You wrote</div>
+    <p style="font-size:14px;line-height:1.6;margin:0;color:#4a443c;white-space:pre-wrap;">${escapeHtml((originalMessage || '').trim())}</p>
+  </div>
+  <p style="font-size:15px;line-height:1.7;margin:0 0 8px;">${body}</p>
+  ${linkBlock}
+  <div style="border-top:1px solid #e8e4dc;padding-top:22px;margin-top:28px;text-align:center;">
+    <p style="color:#8a8480;font-size:12px;line-height:1.6;margin:0;">Thank you for helping make these texts more readable.<br /><a href="https://sourcelibrary.org" style="color:#8a8480;">sourcelibrary.org</a></p>
+  </div>
+</div>`;
+}
+
+function buildText({ name, originalMessage, replyBody, link }) {
+  const greeting = name && name.trim() ? `Hi ${name.trim()},` : 'Hi,';
+  const body = replyBody && replyBody.trim() ? replyBody.trim() : 'We’ve looked into this and made a change based on what you sent.';
+  const lines = [greeting, '', 'A little while ago you sent us a note about Source Library. We wanted to let you know we read it — and acted on it.', '', 'You wrote:', `  "${(originalMessage || '').trim()}"`, '', body];
+  if (link && isPublicUrl(link)) lines.push('', `See the change: ${link.trim()}`);
+  lines.push('', 'Thank you for helping make these texts more readable.', 'sourcelibrary.org');
+  return lines.join('\n');
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const fb = client.db('bookstore').collection('feedback');
+
+const pending = await fb.find({
+  addressed: true,
+  email: { $type: 'string', $regex: /@/ },
+  $or: [{ reply_sent_at: { $exists: false } }, { reply_sent_at: null }],
+}).toArray();
+
+console.log(`Addressed + email + not-yet-notified: ${pending.length}`);
+if (pending.length === 0) { await client.close(); process.exit(0); }
+
+let resend = null;
+if (GO) {
+  if (!process.env.RESEND_API_KEY) { console.error('RESEND_API_KEY not set — cannot send'); await client.close(); process.exit(1); }
+  const { Resend } = await import('resend');
+  resend = new Resend(process.env.RESEND_API_KEY);
+}
+const from = process.env.EMAIL_FROM || 'Source Library <noreply@sourcelibrary.org>';
+
+let sent = 0, failed = 0;
+for (const row of pending) {
+  const params = { name: row.name, originalMessage: row.message, replyBody: row.addressed_action, link: row.addressed_link };
+  console.log(`  ${GO ? 'SEND' : 'would send'} → ${row.email}  «${(row.message || '').slice(0, 50)}»`);
+  if (!GO) continue;
+  try {
+    const r = await resend.emails.send({ from, to: row.email, subject: 'We read your feedback on Source Library', html: buildHtml(params), text: buildText(params) });
+    if (r.error) { console.error(`    Resend error: ${JSON.stringify(r.error).slice(0, 120)}`); failed++; continue; }
+    await fb.updateOne({ _id: row._id }, { $set: { reply_sent_at: new Date(), reply_recipient: row.email } });
+    sent++;
+  } catch (e) { console.error(`    send failed: ${e.message?.slice(0, 100)}`); failed++; }
+}
+console.log(`\n${GO ? `Sent: ${sent}, failed: ${failed}` : '(dry-run — re-run with --go to send)'}`);
+await client.close();

--- a/src/app/api/books/search/route.ts
+++ b/src/app/api/books/search/route.ts
@@ -40,7 +40,12 @@ export async function GET(request: NextRequest) {
     let books: Record<string, unknown>[] = [];
     if (pageIds.length > 0) {
       const db = await getReadDb();
-      const filter: Record<string, unknown> = { id: { $in: pageIds } };
+      // Re-apply visible:true at the Mongo fetch as a defensive gate. searchBookIds
+      // already filters visible:true in Supabase, but the catalog lags Mongo — a
+      // book hidden in Mongo but still visible in the stale catalog would otherwise
+      // surface here and then 404 in the reader (the "search returns a hidden book"
+      // class — e.g. the imageless Toltec artwork stub, 2026-06-21).
+      const filter: Record<string, unknown> = { id: { $in: pageIds }, visible: true };
       if (tenantContext.id) filter.tenantId = tenantContext.id;
       books = await db.collection('books').find(
         filter,

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -467,6 +467,8 @@ export default function TranslationEditor({
 
   // Translation request (guest users)
   const [translationRequested, setTranslationRequested] = useState(false);
+  // Optional email so we can notify the requester once the page is translated.
+  const [requestEmail, setRequestEmail] = useState('');
 
   // Reset split state
   const [showResetSplitConfirm, setShowResetSplitConfirm] = useState(false);
@@ -1794,31 +1796,45 @@ export default function TranslationEditor({
                         <AuthCheck fallback={
                           translationRequested ? (
                             <p className="text-sm font-medium" style={{ color: 'var(--accent-sage-dark)' }}>
-                              Thanks! We&apos;ll prioritize this book.
+                              {requestEmail.trim()
+                                ? "Thanks! We'll email you when this page is translated."
+                                : "Thanks! We'll prioritize this book."}
                             </p>
                           ) : (
-                            <button
-                              onClick={async () => {
-                                try {
-                                  await fetch('/api/feedback', {
-                                    method: 'POST',
-                                    headers: { 'Content-Type': 'application/json' },
-                                    body: JSON.stringify({
-                                      message: `Translation requested for "${book.display_title || book.title}" (${book.language || 'unknown language'}) — page ${page.page_number}`,
-                                      page: `/book/${book.id}/page/${page.id}`,
-                                    }),
-                                  });
-                                } catch { /* best effort */ }
-                                setTranslationRequested(true);
-                              }}
-                              className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90"
-                              style={{ background: 'var(--bg-warm)', color: 'var(--text-secondary)' }}
-                            >
-                              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-                              </svg>
-                              Request translation
-                            </button>
+                            <div className="flex flex-col items-center gap-2 max-w-xs">
+                              <input
+                                type="email"
+                                value={requestEmail}
+                                onChange={(e) => setRequestEmail(e.target.value)}
+                                placeholder="Email (optional) — we'll notify you"
+                                className="w-full px-3 py-1.5 rounded-lg text-sm border"
+                                style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)', borderColor: 'var(--border-subtle, #ddd)' }}
+                              />
+                              <button
+                                onClick={async () => {
+                                  const email = requestEmail.trim();
+                                  try {
+                                    await fetch('/api/feedback', {
+                                      method: 'POST',
+                                      headers: { 'Content-Type': 'application/json' },
+                                      body: JSON.stringify({
+                                        message: `Translation requested for "${book.display_title || book.title}" (${book.language || 'unknown language'}) — page ${page.page_number}`,
+                                        page: `/book/${book.id}/page/${page.id}`,
+                                        email: email && email.includes('@') ? email : null,
+                                      }),
+                                    });
+                                  } catch { /* best effort */ }
+                                  setTranslationRequested(true);
+                                }}
+                                className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90"
+                                style={{ background: 'var(--bg-warm)', color: 'var(--text-secondary)' }}
+                              >
+                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                                </svg>
+                                Request translation
+                              </button>
+                            </div>
                           )
                         }>
                           <button


### PR DESCRIPTION
From triaging the **102 unread footer-feedback** items. Three focused changes.

## What's here
1. **Translation-request button captures an optional email** (`TranslationEditor.tsx`). The per-page "Request translation" button (shown to logged-out readers) previously POSTed anonymously, so we had no way to notify the requester. Now it offers an optional "Email (optional) — we'll notify you" field and confirms accordingly.
2. **`/api/books/search` re-applies `visible: true`** at the Mongo fetch. `searchBookIds` filters visible in Supabase, but the catalog lags Mongo, so a book hidden in Mongo but stale-visible in the catalog leaked into search and then 404'd in the reader. Repro: searching "toltec" returned the imageless `Eagle Relief — Toltec Temple` artwork stub (`visible:false` in Mongo). Defensive read-time gate, consistent with the visibility invariant in CLAUDE.md.
3. **`scripts/maintenance/notify-addressed-feedback.mjs`** — idempotent backstop that emails any `addressed:true` feedback with an email and no `reply_sent_at`, for items addressed out-of-band. Mirrors `src/lib/feedback-reply-email.ts`; stamps `reply_sent_at` so it never double-sends.

## Context (done outside this PR)
- Translated the **33 unique pages** behind the 46 "Translation requested" feedback items (all already had OCR; the pipeline pause was not a blocker). Cost ~$0.15. One giant table-of-contents page (Histoire de la magie p15) only partially translated — the model balks at the 16K-char TOC.
- Marked those 46 feedback rows `addressed`. All were anonymous, so none could be emailed — which is exactly what change #1 fixes going forward.

## Out of scope
- The download "error" reports are the sign-in/purchase gate (401/402) surfacing as a raw error in the UI — a frontend polish item for a separate PR.
- Whole-book translation of high-demand but barely-OCR'd books (esp. Histoire de la magie, 17 requests) needs a full OCR+translate pass = real Gemini spend behind the deliberate pipeline pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)