### PR TITLE
copy(about): defensible 50+ language count + sharper stakes paragraph

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -17,7 +17,10 @@ export default async function AboutPage() {
 
   const headlineStats: { value: string; label: string; href?: string }[] = [
     { value: fmt(stats.totalBooks), label: 'books digitized', href: '/search' },
-    { value: `${stats.languageCount}+`, label: 'languages' },
+    // Conservative floor: ~50 languages have 5+ translated books each. The raw
+    // distinct-language count (stats.languageCount) is higher but padded with
+    // singletons, compound strings, and junk tokens — not a defensible claim.
+    { value: '50+', label: 'languages' },
     { value: fmt(stats.translatedToEnglish), label: 'translated to English', href: '/search?has_translation=true' },
     { value: fmt(stats.firstTranslationCount), label: 'first-ever English translations', href: '/search?first_translation=true' },
     { value: fmt(stats.illustrationCount), label: 'illustrations cataloged', href: '/gallery' },
@@ -41,7 +44,7 @@ export default async function AboutPage() {
         </p>
 
         <p className="text-xl text-secondary leading-relaxed mb-6">
-          Source Library is a digital library of historical primary sources &mdash; the foundational works of philosophy, science, religion, and mysticism from cultures across the world, in more than 160 languages. It spans the Sanskrit and Tibetan canons, the Chinese classics, the sciences of the Arabic and Hebrew worlds, the Hermetic and Neoplatonist currents of the Renaissance, and far beyond. We digitize rare books and manuscripts, translate them with AI alongside the original scanned page, and make them free to read, quote, and cite.
+          Source Library is a digital library of historical primary sources &mdash; the foundational works of philosophy, science, religion, and mysticism from cultures across the world, in more than 50 languages. It spans the Sanskrit and Tibetan canons, the Chinese classics, the sciences of the Arabic and Hebrew worlds, the Hermetic and Neoplatonist currents of the Renaissance, and far beyond. We digitize rare books and manuscripts, translate them with AI alongside the original scanned page, and make them free to read, quote, and cite.
         </p>
 
         <p className="text-xl text-secondary leading-relaxed mb-12">
@@ -77,7 +80,7 @@ export default async function AboutPage() {
         </p>
 
         <p className="text-secondary mb-12 leading-relaxed">
-          As we enter an uncertain age, a strong foundation in wisdom &mdash; and the preservation of our full inheritance &mdash; has never felt more pressing. Translating the world&apos;s ancient wisdom may make a global renaissance more likely than its opposite. That is the work.
+          We trained today&apos;s AI on Reddit, not the Renaissance. The large models now shaping how we think learned mostly from the open internet &mdash; its forums, its hot takes, the churn of the present moment &mdash; while the greater part of humanity&apos;s accumulated wisdom sits untranslated, undigitized, and out of their reach. As we enter an uncertain age, putting that inheritance within reach of every reader &mdash; and every machine &mdash; may make a global renaissance more likely than its opposite. That is the work.
         </p>
 
         {/* A glimpse — show, don't tell */}


### PR DESCRIPTION
Two copy fixes on /about:

1. **Language count: 162+ → 50+.** The 162 came from raw distinct `language` values (203 total), padded with singletons, compound strings ("Latin-German"), near-dupes, and junk ("Multiple", "auto-detect"). Defensible floor: ~50 languages have 5+ translated books each (72 have ≥3). Also matches the /vision letter's "over fifty languages." Applied to both the lead sentence and the stats band.

2. **Sharper "Why It Matters" paragraph** — reframed around: *we trained today's AI on Reddit, not the Renaissance* — most of humanity's wisdom is untranslated and out of the models' reach.

Note: the homepage (src/app/page.tsx) still shows the live `languageCount` (162). Left untouched here; can standardize the source if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)