### PR TITLE
fix(collections): stop exhibition layout flipping to generic on slow reads

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -586,13 +586,19 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
       };
     });
 
-  // Fetch curated exhibition data (if available)
+  // Fetch curated exhibition data (if available).
+  // This decides the WHOLE page layout: when a draft exists, ExhibitionLayout renders
+  // and the standard Featured/highlights/gallery/description bands are suppressed
+  // (they all gate on `!exhibition?.layout`). A timeout here therefore silently FLIPS
+  // a curated collection (e.g. /collections/yoga) back to the generic layout — so this
+  // fetch must be reliable. Backed by the `collection_slug_status_idx` index (IXSCAN,
+  // ~1ms), with a generous timeout so a transient slow read never drops the exhibition.
   const curationDraft = await withTimeout(
     db.collection('curation_drafts').findOne(
       { collection_slug: id, status: 'draft' },
       { projection: { curation: 1 } },
     ),
-    5000, null,
+    12000, null,
   );
 
   // Resolve book references in curation layout — attach thumbnails and slugs


### PR DESCRIPTION
## Problem
The collection page's curated-exhibition fetch (`curation_drafts`) decides the **whole page layout**: when a draft exists, `ExhibitionLayout` renders and the standard Featured / curated-highlights / gallery / description bands are all suppressed (they gate on `!exhibition?.layout`).

That fetch had a **5s `withTimeout(..., null)`**, and `curation_drafts` had **no index** on `collection_slug`/`status` — so the lookup collscanned. Warm it's ~50ms, but on a cold serverless connection under load it could blow 5s → `null` → the exhibition silently vanished and the page **flipped to the generic layout**. This was the root of the "/collections/yoga keeps changing / the books/highlights disappear" confusion — the page was non-deterministically rendering two completely different layouts depending on render speed.

## Fix (two parts)
- **DB index** (already created in prod): `collection_slug_status_idx` `{collection_slug:1, status:1}` on `curation_drafts`. Verified `IXSCAN`, 1 doc examined, ~1ms. This alone removes the flip.
- **Code**: raised the exhibition fetch timeout **5s → 12s** as belt-and-suspenders, with a comment explaining why this particular fetch must be reliable (it gates the entire layout).

## Scope / safety
- No behavior change for collections without an exhibition draft.
- `npx tsc --noEmit` clean; `check-imports` passes.
- Index was created directly against prod (21-doc collection, instant, additive). There's no central index-registry script in the repo, so it's documented here rather than added as a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)