### PR TITLE
copy(about): replace 'that is the work' closer with a plain purpose line

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -80,7 +80,7 @@ export default async function AboutPage() {
         </p>
 
         <p className="text-secondary mb-12 leading-relaxed">
-          Did we build today&apos;s AI more on Reddit than on the Renaissance? The large models now shaping how we think learned heavily from the open internet &mdash; its forums, its commerce, the churn of the present moment &mdash; while much of humanity&apos;s accumulated wisdom remains untranslated, undigitized, and out of their reach. Bringing that inheritance within reach of every reader &mdash; and every machine &mdash; may make a global renaissance more likely than its opposite. That is the work.
+          Did we build today&apos;s AI more on Reddit than on the Renaissance? The large models now shaping how we think learned heavily from the open internet &mdash; its forums, its commerce, the churn of the present moment &mdash; while much of humanity&apos;s accumulated wisdom remains untranslated, undigitized, and out of their reach. Source Library exists to close that gap: to get the world&apos;s primary sources translated, online, and free &mdash; within reach of every reader, and every machine.
         </p>
 
         {/* A glimpse — show, don't tell */}


### PR DESCRIPTION
Per Derek — the closer read as AI-cute. Drops 'may make a global renaissance more likely than its opposite. That is the work.' and ends on what Source Library actually does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)