### PR TITLE
content(blog): swap Naked Philosophers hero to the Alexander/gymnosophists miniature

### DIFF
--- a/src/app/blog/naked-philosophers/page.tsx
+++ b/src/app/blog/naked-philosophers/page.tsx
@@ -24,8 +24,8 @@ export default function NakedPhilosophersPage() {
         <ContentHeader
           title="The Naked Philosophers"
           subtitle="How Alexander&rsquo;s India became the Rosicrucians&rsquo; ancestor"
-          image="https://images.sourcelibrary.org/pages/69b2217608069e96e842fd0d/0001.jpg"
-          imageAlt="Title page of the 1504 Aldine edition of Philostratus' Life of Apollonius of Tyana, printed in Venice by Aldus Manutius"
+          image="https://images.sourcelibrary.org/gallery/69c1bd308522835be8468096/69c1bd308522835be8468107-0.jpg"
+          imageAlt="Alexander the Great, crowned and enthroned, in dialogue with three naked top-knotted gymnosophists — a 1544 Armenian manuscript miniature from the Romance of Alexander"
         >
           <p className="text-stone-400 text-sm mt-4">21 June 2026 &middot; 8 min read</p>
         </ContentHeader>
@@ -296,6 +296,10 @@ export default function NakedPhilosophersPage() {
             <li>
               J. W. McCrindle, <em>Ancient India as Described by Megasthenes and Arrian</em> (1877) &mdash; Calanus &amp; Dandamis.{' '}
               <Link href="/book/ancient-india-as-described-by-megasthenes-and-arrian-mccrindle" className="text-accent-rust hover:text-accent-rust">Read &rarr;</Link>
+            </li>
+            <li>
+              <em>Romance of Alexander</em> (Armenian manuscript, 1544) &mdash; the medieval legend; source of the header miniature of Alexander and the three gymnosophists.{' '}
+              <Link href="/book/romance-of-alexander-anonymous/page/69c1bd308522835be8468107" className="text-accent-rust hover:text-accent-rust">Read &rarr;</Link>
             </li>
             <li>
               García de Orta, <em>History of Aromatics&hellip; of the Indies</em> (Clusius, 1567).{' '}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -33,8 +33,8 @@ const posts: BlogPost[] = [
     readTime: '8 min read',
     tag: 'Research',
     tagColor: 'bg-blue-50 text-blue-700',
-    image: 'https://images.sourcelibrary.org/gallery/6952587bab34727b1f045546/6959068695a91542b28bd75a-0.jpg',
-    imageAlt: 'Engraved frontispiece of Michael Maier\'s Symbola Aureae Mensae, 1617',
+    image: 'https://images.sourcelibrary.org/gallery/69c1bd308522835be8468096/69c1bd308522835be8468107-0.jpg',
+    imageAlt: 'Alexander the Great enthroned before three naked gymnosophists, a 1544 Armenian Romance of Alexander miniature',
   },
   {
     slug: 'the-giants-werent-translated',


### PR DESCRIPTION
## Why
Reviewing the live essay, the Aldine title-page hero was too pale to survive the header's dark overlay. A Maier frontispiece was considered, but on reflection that's the *twelve-nations prisca-sapientia* emblem — robed European sages, **not** naked philosophers.

## What
Swapped the hero to a far more on-theme image already in the corpus: a **1544 Armenian *Romance of Alexander* manuscript miniature** (gallery_quality 0.95) showing **Alexander enthroned in dialogue with three naked, top-knotted gymnosophists** — literally the encounter the essay opens with, in vivid colour, and a source we hold.

- Post header image + alt updated.
- `/blog` index card image + alt updated to match.
- Added **Romance of Alexander** to "The books" with a deep link to the miniature page.

## Validation
- Hero image returns `200`. New deep link `/book/romance-of-alexander-anonymous/page/69c1bd308522835be8468107` validated (soft-404 grep = 0).
- `check-imports` hook passes; `tsc` (string-only JSX changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)