### PR TITLE
fix(voice): voice Librarian answers in the user's language (multilingual)

### DIFF
--- a/src/app/librarian/voice/VoiceAgentClient.tsx
+++ b/src/app/librarian/voice/VoiceAgentClient.tsx
@@ -16,6 +16,10 @@ Your role is to help users find and explore books in the collection. You have to
 ## What Source Library contains
 The collection covers the full breadth of pre-modern intellectual history: alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, Indian philosophy, Sanskrit texts, Daoist texts, Egyptian sources, Tibetan Buddhism, Sufi mysticism, early modern science, demonology, angelology, mathematics, medicine, botany, and much more. Nearly all texts are translated into English. This is NOT only an esoteric or occult library — it covers the entire history of ideas.
 
+## Language
+- Respond in the SAME language the user speaks. If they speak Spanish, reply entirely in Spanish; French, reply in French; and so on — match their language for the whole conversation. Only use English if the user is speaking English.
+- Never silently translate the user's request into English, and never answer in English when they addressed you in another language.
+
 ## How to behave
 - Be concise. This is voice — keep responses under 3 sentences unless the user asks for detail.
 - Search first, talk second. When a user asks about a topic, use your search tools to find actual books and passages before answering.


### PR DESCRIPTION
## Problem
A Spanish-speaking user reported two bugs in the voice Librarian (`/librarian/voice`):
1. It **auto-translated their spoken request to English** and answered in English.
2. When prompted for Spanish, it **read Spanish text with an English-accented voice**.

## Root cause
Both live in the ElevenLabs Conversational AI agent ("Hermes — Source Library"), whose STT/LLM/TTS config is dashboard state, not repo code:
- Primary language `en`, **no additional languages**, and the **language-detection system tool was off** → everything steered back to English.
- TTS model was **`eleven_flash_v2`**, which is **English-only** → Spanish rendered with English phonemes.

## Fix
**Agent config (applied via the ElevenLabs API — out of repo):**
- Enabled the `language_detection` built-in tool.
- Added additional languages: **es, fr, de, it, pt**. Per ElevenLabs, additional-language turns auto-switch to the **v2.5 multilingual** model; English stays on `flash_v2` (no regression to the English experience). You cannot pin the model per-language — the platform manages it (it strips `model_id` from per-language overrides).
- Full pre-change config backed up to `scripts/output/_tmp-elevenlabs-agent-backup-*.json` in the main checkout (restorable).

**This PR (code half):**
- The voice system prompt (`VoiceAgentClient.tsx`) now instructs the LLM to reply in the **same language the user speaks** and never silently translate to English — so it *generates* Spanish, not just renders it.

## Caveat / UX note
ElevenLabs language detection is most reliable **at call start**, so the dependable flow is "just start speaking Spanish," rather than asking for Spanish mid-call. The first greeting is still English (it plays before the user speaks).

## Scope
- Out of scope: localizing the pre-speech greeting per language, and the podcast TTS (separate Gemini path). The user also noted the *podcast* voice sounds slightly clipped between words — that's Gemini TTS, tracked separately.

## Testing
- `npx tsc --noEmit` clean.
- Agent config verified via API GET: detection on, 5 languages present, English model unchanged.
- Voice E2E can't be asserted headlessly; verification is config-level + prompt.