### PR TITLE
fix(book): credit the real digitizer, not the holding institution

### DIFF
--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -503,9 +503,15 @@ export default function BibliographicInfo({
                     )}
                   </div>
                 )}
-                {book.image_source.contributing_library && (
+                {book.image_source.digitized_by && (
                   <div className="flex gap-2">
                     <span className="text-stone-500 w-24 flex-shrink-0">Digitized by:</span>
+                    <span className="text-stone-200">{book.image_source.digitized_by}</span>
+                  </div>
+                )}
+                {book.image_source.contributing_library && (
+                  <div className="flex gap-2">
+                    <span className="text-stone-500 w-24 flex-shrink-0">Provided by:</span>
                     <span className="text-stone-200">{book.image_source.contributing_library}</span>
                   </div>
                 )}

--- a/src/lib/types/image-source.ts
+++ b/src/lib/types/image-source.ts
@@ -81,6 +81,8 @@ export interface ImageSource {
   notes?: string;               // Additional context (e.g., "Scans provided by X library")
   iiif_manifest?: string;       // IIIF Presentation API manifest URL
   shelfmark?: string;           // Physical shelfmark/classmark (e.g., "Pal.lat.1885", "MS. Arab. c. 90")
-  contributing_library?: string; // Physical library that provided/digitized the item (e.g., IA contributor field)
+  contributing_library?: string; // Institution that holds/provided the item (e.g., IA contributor field) — NOT necessarily the digitizer
+  digitized_by?: string;        // Who actually digitized the scans (e.g., "Allard Pierson (University of Amsterdam)")
+  digital_host?: string;        // Host serving the digital images (e.g., "uvaerfgoed.nl")
   sponsor?: string;             // Funding entity for digitization (e.g., "Google", "Sloan Foundation")
 }


### PR DESCRIPTION
From footer feedback — EFM's Joost Bouman (jbouman@efm.amsterdam) on the Adair Book of Hours (BPH 131).

## Problem
`BibliographicInfo.tsx` labeled `image_source.contributing_library` as **"Digitized by:"**. That field is the *holding/contributing* institution, not the digitizer. On the Adair Book of Hours it rendered "Digitized by: Embassy of the Free Mind (BPH)" — but BPH didn't digitize it; Allard Pierson (University of Amsterdam) did, and `image_source.digitized_by` already held that value (just never displayed).

## Fix
- Display `image_source.digitized_by` as "Digitized by:" when present.
- Relabel `contributing_library` as **"Provided by:"** — accurate for both IA contributors and BPH-held items.
- Declare `digitized_by` / `digital_host` on the `ImageSource` type (present in data, previously untyped).

Adair page now reads:
- **Digitized by:** Allard Pierson (University of Amsterdam)
- **Provided by:** Embassy of the Free Mind (Bibliotheca Philosophica Hermetica)

The rest of jbouman's suggested metadata (title, author "Master of the Adair Book of Hours", language Dutch, 1490, first-translation) was already correct in the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)