### PR TITLE
fix(blog): correct gymnosophist hero (was a mislabeled wrestling scene) + discuss source in-text

### DIFF
--- a/src/app/blog/naked-philosophers/page.tsx
+++ b/src/app/blog/naked-philosophers/page.tsx
@@ -24,8 +24,8 @@ export default function NakedPhilosophersPage() {
         <ContentHeader
           title="The Naked Philosophers"
           subtitle="How Alexander&rsquo;s India became the Rosicrucians&rsquo; ancestor"
-          image="https://images.sourcelibrary.org/gallery/69c1bd308522835be8468096/69c1bd308522835be8468107-0.jpg"
-          imageAlt="Alexander the Great, crowned and enthroned, in dialogue with three naked top-knotted gymnosophists — a 1544 Armenian manuscript miniature from the Romance of Alexander"
+          image="https://images.sourcelibrary.org/gallery/69c1bd308522835be8468096/69c1bd308522835be8468180-0.jpg"
+          imageAlt="Alexander the Great, crowned and haloed, gesturing toward three naked bearded philosophers among flowering plants — labelled in the manuscript's Armenian as 'the Brahmans who speak.' A 1544 Armenian Romance of Alexander miniature"
         >
           <p className="text-stone-400 text-sm mt-4">21 June 2026 &middot; 8 min read</p>
         </ContentHeader>
@@ -134,6 +134,37 @@ export default function NakedPhilosophersPage() {
           </Link>{' '}
           The sage who went over to power and burned, against the one who stayed in the forest and won: it is the
           tradition&rsquo;s central argument about what wisdom is worth.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-primary mt-12 mb-4 font-display">The sages in their own voice</h2>
+
+        <p className="text-secondary leading-relaxed mb-6 font-body">
+          The encounter did not stay in the Greek libraries. All through the Middle Ages the{' '}
+          <Link href="/book/romance-of-alexander-anonymous/page/69c1bd308522835be8468180" className="text-accent-rust hover:text-accent-rust underline">
+            <em>Romance of Alexander</em>
+          </Link>{' '}
+          &mdash; the wildly embroidered legend of the conqueror, copied in every language from Latin to Armenian &mdash;
+          kept retelling the meeting with the naked philosophers, and illustrating it. The miniature at the head of
+          this essay comes from a 1544 Armenian copy in the library: Alexander, crowned and haloed, faces three naked
+          sages among flowering stalks, captioned in the margin in Armenian &mdash; &ldquo;the Brahmans who speak,&rdquo;
+          &ldquo;they are naked philosophers.&rdquo; Here, uniquely, the gymnosophists are given their own lines:
+        </p>
+
+        <blockquote className="border-l-2 border-accent-rust/40 pl-6 my-8 text-secondary italic leading-relaxed font-body">
+          &ldquo;We were born naked philosophers and we remain naked in this world. We enter the earth as naked members;
+          we have no great needs in this world. If we die tomorrow or the day after, we are invited to our own
+          earth.&rdquo;
+          <span className="block mt-3 text-sm not-italic text-muted">
+            &mdash; <em>Romance of Alexander</em>, Armenian manuscript, 1544.{' '}
+            <Link href="/book/romance-of-alexander-anonymous/page/69c1bd308522835be8468180" className="text-accent-rust hover:text-accent-rust">Read the page &rarr;</Link>
+          </span>
+        </blockquote>
+
+        <p className="text-secondary leading-relaxed mb-6 font-body">
+          It is the same ethic Onesicritus had watched in silence &mdash; endurance, indifference to the body, freedom
+          from need &mdash; now put in the sages&rsquo; own mouths and bound into a book that Christian Armenian scribes
+          were still copying fourteen centuries after the meeting it describes. The naked philosophers had become a
+          story Europe could not stop retelling.
         </p>
 
         <h2 className="text-2xl font-semibold text-primary mt-12 mb-4 font-display">The Renaissance meets India again</h2>
@@ -298,8 +329,8 @@ export default function NakedPhilosophersPage() {
               <Link href="/book/ancient-india-as-described-by-megasthenes-and-arrian-mccrindle" className="text-accent-rust hover:text-accent-rust">Read &rarr;</Link>
             </li>
             <li>
-              <em>Romance of Alexander</em> (Armenian manuscript, 1544) &mdash; the medieval legend; source of the header miniature of Alexander and the three gymnosophists.{' '}
-              <Link href="/book/romance-of-alexander-anonymous/page/69c1bd308522835be8468107" className="text-accent-rust hover:text-accent-rust">Read &rarr;</Link>
+              <em>Romance of Alexander</em> (Armenian manuscript, 1544) &mdash; the medieval legend; source of the header miniature of Alexander and the three naked philosophers.{' '}
+              <Link href="/book/romance-of-alexander-anonymous/page/69c1bd308522835be8468180" className="text-accent-rust hover:text-accent-rust">Read &rarr;</Link>
             </li>
             <li>
               García de Orta, <em>History of Aromatics&hellip; of the Indies</em> (Clusius, 1567).{' '}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -33,8 +33,8 @@ const posts: BlogPost[] = [
     readTime: '8 min read',
     tag: 'Research',
     tagColor: 'bg-blue-50 text-blue-700',
-    image: 'https://images.sourcelibrary.org/gallery/69c1bd308522835be8468096/69c1bd308522835be8468107-0.jpg',
-    imageAlt: 'Alexander the Great enthroned before three naked gymnosophists, a 1544 Armenian Romance of Alexander miniature',
+    image: 'https://images.sourcelibrary.org/gallery/69c1bd308522835be8468096/69c1bd308522835be8468180-0.jpg',
+    imageAlt: 'Alexander the Great gesturing toward three naked philosophers among flowering plants, a 1544 Armenian Romance of Alexander miniature',
   },
   {
     slug: 'the-giants-werent-translated',


### PR DESCRIPTION
## What & why
Two fixes to the *Naked Philosophers* essay, both prompted by the question **"is that source discussed and linked in the text?"** — which, on checking the actual page, surfaced a misattribution.

1. **Wrong hero image.** The header used *Romance of Alexander* **p113**, which the gallery AI captioned "Alexander with three gymnosophists." But the page text + the manuscript's own image description show it's an **athletic/wrestling scene** (semi-nude wrestlers, loincloths, top-knots, two grappling). Presenting it as the gymnosophist encounter was a fabricated visual claim. Swapped to the **genuine** scene on **p234** (pageId `...8180`): Alexander gesturing to three naked bearded philosophers among flowering plants, labelled in the manuscript's own Armenian as "the Brahmans who speak / they are naked philosophers" — verified via `get_quote`.

2. **Source now discussed in-text.** Added a section, **"The sages in their own voice,"** introducing the *Romance of Alexander*, grounding the header image, and quoting the gymnosophists' own verified lines from p234 (*"We were born naked philosophers and we remain naked in this world…"*). Updated the `/blog` card image and the books-list deep link to `...8180`.

## Validation
- `get_quote` p234 confirms both the image identity (manuscript's Armenian captions) and the quoted text.
- No stale `...8107` references remain; new deep link soft-404 grep = 0; image returns 200; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)