### PR TITLE
fix(seo): compound index so sitemap reader-page chunks aren't empty (#2688)

### DIFF
--- a/scripts/seo/flag-indexable-pages.mjs
+++ b/scripts/seo/flag-indexable-pages.mjs
@@ -61,6 +61,14 @@ const db = client.db('bookstore');
 const pages = db.collection('pages');
 const books = db.collection('books');
 
+// Partial index on the flag — without it, the reconcile `$nin` below and the
+// sitemap's count/find on seo_indexable full-scan the millions-row pages
+// collection. Idempotent; only indexes the ~few-thousand flagged docs.
+await pages.createIndex(
+  { seo_indexable: 1 },
+  { partialFilterExpression: { seo_indexable: true }, name: 'seo_indexable_partial' }
+);
+
 if (CLEAR) {
   const before = await pages.countDocuments({ seo_indexable: true });
   if (DRY_RUN) {

--- a/scripts/seo/flag-indexable-pages.mjs
+++ b/scripts/seo/flag-indexable-pages.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * SEO: flag demand-proven reader pages as indexable (issue #2688).
+ *
+ * Individual reader pages (`/book/<slug>/page/<pageId>`) are noindex by default
+ * (see src/app/book/[id]/page/[pageId]/layout.tsx). This script opens up the
+ * *demand-proven* subset: pages humans actually read, plus — optionally — the
+ * uncontested first-translation long tail.
+ *
+ * It writes `seo_indexable: true` + `seo_url` onto qualifying `pages` docs.
+ * The render gate (layout generateMetadata) and the sitemap both read those
+ * fields. Fully reversible: `--clear` unsets the flag everywhere.
+ *
+ * Eligibility (a page must have substantial text AND one of):
+ *   - read >= MIN_READS in analytics_pageviews (rolling ~90d TTL window), OR
+ *   - (--include-ft) the book is is_first_translation + translated and the
+ *     page itself is translated. This arm is ~1.4M pages — OFF by default;
+ *     ramp it deliberately (--ft-language=Latin, --ft-cap=N per book).
+ *
+ * Usage:
+ *   node scripts/seo/flag-indexable-pages.mjs --dry-run        # size only
+ *   node scripts/seo/flag-indexable-pages.mjs                  # apply (read>=5)
+ *   node scripts/seo/flag-indexable-pages.mjs --min-reads=3
+ *   node scripts/seo/flag-indexable-pages.mjs --include-ft --ft-language=Latin
+ *   node scripts/seo/flag-indexable-pages.mjs --clear          # revert
+ */
+import { MongoClient } from 'mongodb';
+
+const args = process.argv.slice(2);
+const has = (f) => args.includes(f);
+const val = (f, d) => {
+  const a = args.find((x) => x.startsWith(`${f}=`));
+  return a ? a.split('=')[1] : d;
+};
+
+const DRY_RUN = has('--dry-run');
+const CLEAR = has('--clear');
+const MIN_READS = parseInt(val('--min-reads', '5'), 10);
+const INCLUDE_FT = has('--include-ft');
+const FT_LANGUAGE = val('--ft-language', null); // restrict FT arm to one language
+const FT_CAP = parseInt(val('--ft-cap', '0'), 10); // 0 = no per-book cap
+
+// A page needs real text to be worth indexing — never open blank/thin scans.
+const MIN_OCR_CHARS = 120;
+function hasSubstantialText(page) {
+  const t = (page.translation?.data || '').trim();
+  if (t.length > 0) return true;
+  const o = (page.ocr?.data || '').trim();
+  return o.length >= MIN_OCR_CHARS;
+}
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI not set — run with: set -a; source .env.production.local; set +a; node ...');
+  process.exit(1);
+}
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const pages = db.collection('pages');
+const books = db.collection('books');
+
+if (CLEAR) {
+  const before = await pages.countDocuments({ seo_indexable: true });
+  if (DRY_RUN) {
+    console.log(`[dry-run] would clear seo_indexable on ${before} pages`);
+  } else {
+    const r = await pages.updateMany(
+      { seo_indexable: true },
+      { $unset: { seo_indexable: '', seo_url: '' } }
+    );
+    console.log(`cleared seo_indexable on ${r.modifiedCount} pages (was ${before})`);
+  }
+  await client.close();
+  process.exit(0);
+}
+
+// --- Arm 1: demand (analytics_pageviews, human reads, rolling ~90d) ---
+console.log(`Arm 1 — readership: collecting reader-page URLs with read >= ${MIN_READS}...`);
+const readAgg = await db.collection('analytics_pageviews').aggregate([
+  { $match: { path: { $regex: '^/book/[^/]+/page/[^/]+$' } } },
+  // last path segment is the pageId (book-id form — slug vs hex — is irrelevant)
+  { $project: { pageId: { $arrayElemAt: [{ $split: ['$path', '/'] }, 4] } } },
+  { $group: { _id: '$pageId', reads: { $sum: 1 } } },
+  { $match: { reads: { $gte: MIN_READS } } },
+  { $project: { _id: 1 } },
+], { maxTimeMS: 120000, allowDiskUse: true }).toArray();
+const readPageIds = new Set(readAgg.map((r) => r._id).filter(Boolean));
+console.log(`  ${readPageIds.size} pageIds meet the read threshold`);
+
+// --- Arm 2 (optional): first-translation long tail ---
+let ftBookIds = new Set();
+if (INCLUDE_FT) {
+  const ftMatch = { is_first_translation: true, pages_translated: { $gt: 0 }, visible: true };
+  if (FT_LANGUAGE) ftMatch.language = FT_LANGUAGE;
+  const ftBooks = await books.find(ftMatch, { projection: { id: 1 } }).toArray();
+  ftBookIds = new Set(ftBooks.map((b) => b.id).filter(Boolean));
+  console.log(`Arm 2 — first-translations${FT_LANGUAGE ? ` (${FT_LANGUAGE})` : ''}: ${ftBookIds.size} books`);
+}
+
+// Resolve book slugs (needed for seo_url) for every candidate book.
+// Gather candidate book_ids: from read pages we don't know book_id yet, so we
+// stream the pages and look up slugs as we go (cached).
+const slugCache = new Map(); // book_id -> slug | null
+async function slugFor(bookId) {
+  if (slugCache.has(bookId)) return slugCache.get(bookId);
+  const b = await books.findOne({ id: bookId }, { projection: { _id: 0, slug: 1, visible: 1 } });
+  const slug = b && b.visible !== false ? (b.slug || null) : null;
+  slugCache.set(bookId, slug);
+  return slug;
+}
+
+// Build the qualifying set by streaming candidate pages.
+// Candidates = pages whose id is in readPageIds, OR (FT) book_id in ftBookIds.
+const orClauses = [];
+if (readPageIds.size) orClauses.push({ id: { $in: [...readPageIds] } });
+if (ftBookIds.size) orClauses.push({ book_id: { $in: [...ftBookIds] }, 'translation.data': { $exists: true, $ne: '' } });
+if (!orClauses.length) {
+  console.log('No candidates — nothing to do.');
+  await client.close();
+  process.exit(0);
+}
+
+const cursor = pages.find(
+  { $or: orClauses, page_number: { $gte: 0 } },
+  { projection: { _id: 0, id: 1, book_id: 1, page_number: 1, page_type: 1, 'translation.data': 1, 'ocr.data': 1 } }
+).batchSize(500);
+
+const ftPerBook = new Map(); // book_id -> count (for --ft-cap)
+const qualified = []; // { id, seo_url }
+let scanned = 0, skippedThin = 0, skippedNoSlug = 0, skippedType = 0, skippedCap = 0;
+
+for await (const page of cursor) {
+  scanned++;
+  if (page.page_type === 'digitizer-insert' || page.page_type === 'archived-spread') { skippedType++; continue; }
+  if (!hasSubstantialText(page)) { skippedThin++; continue; }
+
+  const viaRead = readPageIds.has(page.id);
+  const viaFt = ftBookIds.has(page.book_id) && (page.translation?.data || '').trim().length > 0;
+  if (!viaRead && !viaFt) continue;
+
+  // per-book cap applies to the FT arm only (read-proven pages always qualify)
+  if (!viaRead && viaFt && FT_CAP > 0) {
+    const n = ftPerBook.get(page.book_id) || 0;
+    if (n >= FT_CAP) { skippedCap++; continue; }
+    ftPerBook.set(page.book_id, n + 1);
+  }
+
+  const slug = await slugFor(page.book_id);
+  if (!slug) { skippedNoSlug++; continue; }
+
+  qualified.push({ id: page.id, seo_url: `/book/${slug}/page/${page.id}` });
+}
+
+console.log(`\nScanned ${scanned} candidate pages:`);
+console.log(`  qualified      : ${qualified.length}`);
+console.log(`  skipped (thin) : ${skippedThin}`);
+console.log(`  skipped (type) : ${skippedType}`);
+console.log(`  skipped (slug) : ${skippedNoSlug} (hidden book / no slug)`);
+if (FT_CAP > 0) console.log(`  skipped (cap)  : ${skippedCap}`);
+
+if (DRY_RUN) {
+  console.log('\n[dry-run] no writes. Sample:');
+  for (const q of qualified.slice(0, 10)) console.log('   ', q.seo_url);
+  await client.close();
+  process.exit(0);
+}
+
+// Apply: set the flag on qualifying pages, unset on pages that no longer qualify.
+const qualifiedIds = new Set(qualified.map((q) => q.id));
+
+let modified = 0;
+const BATCH = 1000;
+for (let i = 0; i < qualified.length; i += BATCH) {
+  const slice = qualified.slice(i, i + BATCH);
+  const ops = slice.map((q) => ({
+    updateOne: {
+      filter: { id: q.id },
+      update: { $set: { seo_indexable: true, seo_url: q.seo_url } },
+    },
+  }));
+  const r = await pages.bulkWrite(ops, { ordered: false });
+  modified += r.modifiedCount;
+}
+console.log(`\nset seo_indexable on ${qualified.length} pages (${modified} newly modified)`);
+
+// Reconcile: drop the flag from previously-flagged pages that fell out of the set.
+const stale = await pages.find(
+  { seo_indexable: true, id: { $nin: [...qualifiedIds] } },
+  { projection: { _id: 0, id: 1 } }
+).toArray();
+if (stale.length) {
+  const r = await pages.updateMany(
+    { id: { $in: stale.map((s) => s.id) } },
+    { $unset: { seo_indexable: '', seo_url: '' } }
+  );
+  console.log(`unset seo_indexable on ${r.modifiedCount} now-stale pages`);
+}
+
+const total = await pages.countDocuments({ seo_indexable: true });
+console.log(`\nTotal indexable reader pages now: ${total}`);
+await client.close();

--- a/scripts/seo/flag-indexable-pages.mjs
+++ b/scripts/seo/flag-indexable-pages.mjs
@@ -67,10 +67,13 @@ const books = db.collection('books');
 
 // Partial index on the flag — without it, the reconcile `$nin` below and the
 // sitemap's count/find on seo_indexable full-scan the millions-row pages
-// collection. Idempotent; only indexes the ~few-thousand flagged docs.
+// collection. Compound on _id so the sitemap's `sort({_id:1})` paginated
+// query is served by the index (a single-field {seo_indexable:1} index makes
+// the planner full-scan in _id order to satisfy the sort → timeout → empty
+// page chunks). Idempotent; only indexes the ~tens-of-thousands flagged docs.
 await pages.createIndex(
-  { seo_indexable: 1 },
-  { partialFilterExpression: { seo_indexable: true }, name: 'seo_indexable_partial' }
+  { seo_indexable: 1, _id: 1 },
+  { partialFilterExpression: { seo_indexable: true }, name: 'seo_indexable_id_partial' }
 );
 // Partial index on the read counter so Arm 1's candidate query doesn't
 // full-scan the millions-row pages collection (an unindexed count/find here

--- a/scripts/seo/flag-indexable-pages.mjs
+++ b/scripts/seo/flag-indexable-pages.mjs
@@ -12,15 +12,19 @@
  * fields. Fully reversible: `--clear` unsets the flag everywhere.
  *
  * Eligibility (a page must have substantial text AND one of):
- *   - read >= MIN_READS in analytics_pageviews (rolling ~90d TTL window), OR
+ *   - pages.read_count >= MIN_READS — the *all-time* human read counter
+ *     (incremented by /api/analytics/track on page_read; populated for
+ *     anonymous main-site readers, not just editors — verified 99.9% coverage
+ *     on the read-proven set). Unlike analytics_pageviews (90d TTL), this never
+ *     ages out, so the indexable set is stable and needs no refresh cron.
  *   - (--include-ft) the book is is_first_translation + translated and the
  *     page itself is translated. This arm is ~1.4M pages — OFF by default;
  *     ramp it deliberately (--ft-language=Latin, --ft-cap=N per book).
  *
  * Usage:
  *   node scripts/seo/flag-indexable-pages.mjs --dry-run        # size only
- *   node scripts/seo/flag-indexable-pages.mjs                  # apply (read>=5)
- *   node scripts/seo/flag-indexable-pages.mjs --min-reads=3
+ *   node scripts/seo/flag-indexable-pages.mjs                  # apply (read_count>=3)
+ *   node scripts/seo/flag-indexable-pages.mjs --min-reads=5
  *   node scripts/seo/flag-indexable-pages.mjs --include-ft --ft-language=Latin
  *   node scripts/seo/flag-indexable-pages.mjs --clear          # revert
  */
@@ -35,7 +39,7 @@ const val = (f, d) => {
 
 const DRY_RUN = has('--dry-run');
 const CLEAR = has('--clear');
-const MIN_READS = parseInt(val('--min-reads', '5'), 10);
+const MIN_READS = parseInt(val('--min-reads', '3'), 10);
 const INCLUDE_FT = has('--include-ft');
 const FT_LANGUAGE = val('--ft-language', null); // restrict FT arm to one language
 const FT_CAP = parseInt(val('--ft-cap', '0'), 10); // 0 = no per-book cap
@@ -68,6 +72,16 @@ await pages.createIndex(
   { seo_indexable: 1 },
   { partialFilterExpression: { seo_indexable: true }, name: 'seo_indexable_partial' }
 );
+// Partial index on the read counter so Arm 1's candidate query doesn't
+// full-scan the millions-row pages collection (an unindexed count/find here
+// times out). Filter is constant at 3 (our default floor); --min-reads below 3
+// falls back to a scan, which is fine for an occasional manual run.
+if (!CLEAR) {
+  await pages.createIndex(
+    { read_count: 1 },
+    { partialFilterExpression: { read_count: { $gte: 3 } }, name: 'read_count_ge3_partial' }
+  );
+}
 
 if (CLEAR) {
   const before = await pages.countDocuments({ seo_indexable: true });
@@ -84,18 +98,10 @@ if (CLEAR) {
   process.exit(0);
 }
 
-// --- Arm 1: demand (analytics_pageviews, human reads, rolling ~90d) ---
-console.log(`Arm 1 — readership: collecting reader-page URLs with read >= ${MIN_READS}...`);
-const readAgg = await db.collection('analytics_pageviews').aggregate([
-  { $match: { path: { $regex: '^/book/[^/]+/page/[^/]+$' } } },
-  // last path segment is the pageId (book-id form — slug vs hex — is irrelevant)
-  { $project: { pageId: { $arrayElemAt: [{ $split: ['$path', '/'] }, 4] } } },
-  { $group: { _id: '$pageId', reads: { $sum: 1 } } },
-  { $match: { reads: { $gte: MIN_READS } } },
-  { $project: { _id: 1 } },
-], { maxTimeMS: 120000, allowDiskUse: true }).toArray();
-const readPageIds = new Set(readAgg.map((r) => r._id).filter(Boolean));
-console.log(`  ${readPageIds.size} pageIds meet the read threshold`);
+// --- Arm 1: demand (pages.read_count — all-time human reads) ---
+// No analytics window: read_count accumulates for the life of the page, so the
+// indexable set is stable. The candidate query below matches it directly.
+console.log(`Arm 1 — readership: pages with all-time read_count >= ${MIN_READS}`);
 
 // --- Arm 2 (optional): first-translation long tail ---
 let ftBookIds = new Set();
@@ -120,19 +126,13 @@ async function slugFor(bookId) {
 }
 
 // Build the qualifying set by streaming candidate pages.
-// Candidates = pages whose id is in readPageIds, OR (FT) book_id in ftBookIds.
-const orClauses = [];
-if (readPageIds.size) orClauses.push({ id: { $in: [...readPageIds] } });
+// Candidates = pages with read_count >= MIN_READS, OR (FT) book_id in ftBookIds.
+const orClauses = [{ read_count: { $gte: MIN_READS } }];
 if (ftBookIds.size) orClauses.push({ book_id: { $in: [...ftBookIds] }, 'translation.data': { $exists: true, $ne: '' } });
-if (!orClauses.length) {
-  console.log('No candidates — nothing to do.');
-  await client.close();
-  process.exit(0);
-}
 
 const cursor = pages.find(
   { $or: orClauses, page_number: { $gte: 0 } },
-  { projection: { _id: 0, id: 1, book_id: 1, page_number: 1, page_type: 1, 'translation.data': 1, 'ocr.data': 1 } }
+  { projection: { _id: 0, id: 1, book_id: 1, page_number: 1, page_type: 1, read_count: 1, 'translation.data': 1, 'ocr.data': 1 } }
 ).batchSize(500);
 
 const ftPerBook = new Map(); // book_id -> count (for --ft-cap)
@@ -144,7 +144,7 @@ for await (const page of cursor) {
   if (page.page_type === 'digitizer-insert' || page.page_type === 'archived-spread') { skippedType++; continue; }
   if (!hasSubstantialText(page)) { skippedThin++; continue; }
 
-  const viaRead = readPageIds.has(page.id);
+  const viaRead = (page.read_count || 0) >= MIN_READS;
   const viaFt = ftBookIds.has(page.book_id) && (page.translation?.data || '').trim().length > 0;
   if (!viaRead && !viaFt) continue;
 

--- a/src/app/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/book/[id]/page/[pageId]/layout.tsx
@@ -17,7 +17,7 @@ const BOOK_META_PROJECTION = {
 };
 const PAGE_META_PROJECTION = {
   _id: 0, id: 1, book_id: 1, page_number: 1, photo: 1,
-  'translation.data': 1, 'ocr.data': 1,
+  'translation.data': 1, 'ocr.data': 1, seo_indexable: 1,
 };
 
 async function getPageData(bookId: string, pageId: string, tenantId?: string): Promise<{ book: Book | null; page: Page | null }> {
@@ -52,10 +52,10 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
 
   if (!book || !page) {
     // Self-referential canonical so this URL isn't seen as a duplicate of '/'
-    // (inherited root canonical). Per-page URLs are already noindex via the
-    // page-level metadata export.
+    // (inherited root canonical).
     return {
       title: 'Page Not Found - Source Library',
+      robots: { index: false, follow: true },
       alternates: { canonical: `/book/${id}/page/${pageId}` },
     };
   }
@@ -79,9 +79,19 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
   const bookPath = (book as unknown as { slug?: string }).slug || id;
   const pageUrl = `/book/${bookPath}/page/${pageId}`;
 
+  // Reader pages are noindex by default (they outnumber book URLs ~100:1 and
+  // are thin on their own). Demand-proven pages — read >=5 in the rolling 90d
+  // window, or translated first-translations — are opened to indexing by
+  // scripts/seo/flag-indexable-pages.mjs (issue #2688), which sets
+  // `seo_indexable` on the page doc. Canonical is already self-referential, so
+  // an opened page indexes on its own URL. See robots.ts (crawling stays open
+  // for all; this gate controls *indexing*).
+  const indexable = (page as unknown as { seo_indexable?: boolean }).seo_indexable === true;
+
   return {
     title: `${title} - Source Library`,
     description,
+    robots: { index: indexable, follow: true },
     alternates: {
       canonical: pageUrl,
     },

--- a/src/app/book/[id]/page/[pageId]/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
@@ -11,13 +10,11 @@ import { isHiddenBook } from '@/lib/book-access';
 // ISR: 24h background revalidation. Pipeline also calls /api/admin/revalidate-book for immediate updates.
 export const revalidate = 86400;
 
-// Per-page URLs are thin content (one scanned page) and outnumber book URLs
-// 100:1. Keeping them out of the index concentrates Google's attention on the
-// book-level URL (richer metadata, title, description) and avoids soft-404 /
-// duplicate-canonical noise in GSC. They remain crawlable and follow links.
-export const metadata: Metadata = {
-  robots: { index: false, follow: true },
-};
+// robots (index/noindex) is decided per-page in this route's layout.tsx
+// generateMetadata, gated on the page's `seo_indexable` flag (issue #2688).
+// Per-page URLs outnumber book URLs ~100:1, so they stay noindex by default;
+// only demand-proven pages (read >=5, or translated first-translations) open
+// to indexing. They remain crawlable + follow links regardless.
 
 interface PageProps {
   params: Promise<{ id: string; pageId: string }>;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,9 +9,15 @@ import { getReadDb } from '@/lib/mongodb';
 //   0 = static pages + blog + categories
 //   1 = collections + libraries + languages + works
 //   2+ = books (up to 5000 per chunk)
+//   1000+ = indexable reader pages (seo_indexable; up to 5000 per chunk)
 
 const BASE_URL = 'https://sourcelibrary.org';
 const BOOKS_PER_CHUNK = 5000;
+const PAGES_PER_CHUNK = 5000;
+// Indexable reader-page chunks get a high id offset so they never collide with
+// the dynamically-counted book chunks (2..N). Books realistically span a
+// handful of chunks; 1000 is a safe gap. See issue #2688.
+const PAGE_CHUNK_OFFSET = 1000;
 
 // Helper: run a DB query with independent error handling
 async function safeQuery<T>(
@@ -43,10 +49,22 @@ export async function generateSitemaps() {
 
   const bookChunks = Math.ceil(bookCount / BOOKS_PER_CHUNK);
 
-  // Chunk 0 = static, 1 = dynamic non-books, 2+ = books
+  // Count indexable reader pages (issue #2688) for their own chunk range.
+  const pageCount = await safeQuery('indexable-page-count', async (db) => {
+    return db.collection('pages').countDocuments(
+      { seo_indexable: true },
+      { maxTimeMS: 10000 }
+    );
+  }, 0);
+  const pageChunks = Math.ceil(pageCount / PAGES_PER_CHUNK);
+
+  // Chunk 0 = static, 1 = dynamic non-books, 2+ = books, 1000+ = reader pages
   const ids = [{ id: 0 }, { id: 1 }];
   for (let i = 0; i < bookChunks; i++) {
     ids.push({ id: 2 + i });
+  }
+  for (let i = 0; i < pageChunks; i++) {
+    ids.push({ id: PAGE_CHUNK_OFFSET + i });
   }
 
   return ids;
@@ -86,6 +104,11 @@ export default async function sitemap({
       getWorks(),
     ]);
     return [...collectionPages, ...libraryPages, ...languagePages, ...workPages];
+  }
+
+  // Chunk 1000+: indexable reader pages (paginated)
+  if (Number.isFinite(chunkId) && chunkId >= PAGE_CHUNK_OFFSET) {
+    return getIndexablePages(chunkId - PAGE_CHUNK_OFFSET);
   }
 
   // Chunk 2+: Books (paginated)
@@ -199,6 +222,42 @@ async function getBooks(chunkIndex: number): Promise<MetadataRoute.Sitemap> {
           lastModified,
           changeFrequency: 'weekly' as const,
           priority,
+        };
+      });
+  }, [] as MetadataRoute.Sitemap);
+}
+
+// Indexable reader pages — the demand-proven subset opened to indexing by
+// scripts/seo/flag-indexable-pages.mjs (issue #2688). `seo_url` is precomputed
+// (`/book/<slug>/page/<id>`) so no per-page book join is needed here.
+async function getIndexablePages(chunkIndex: number): Promise<MetadataRoute.Sitemap> {
+  return safeQuery('indexable-pages', async (db) => {
+    const pages = await db.collection('pages').find(
+      { seo_indexable: true, seo_url: { $exists: true, $ne: null } },
+      {
+        projection: { _id: 0, seo_url: 1, updated_at: 1 },
+        sort: { _id: 1 },
+        skip: chunkIndex * PAGES_PER_CHUNK,
+        limit: PAGES_PER_CHUNK,
+        maxTimeMS: 25000,
+      }
+    ).toArray();
+
+    return pages
+      .filter((p) => typeof p.seo_url === 'string' && p.seo_url.startsWith('/book/'))
+      .map((p) => {
+        let lastModified: Date;
+        try {
+          lastModified = p.updated_at ? new Date(p.updated_at) : new Date();
+          if (isNaN(lastModified.getTime())) lastModified = new Date();
+        } catch {
+          lastModified = new Date();
+        }
+        return {
+          url: `${BASE_URL}${p.seo_url}`,
+          lastModified,
+          changeFrequency: 'monthly' as const,
+          priority: 0.7,
         };
       });
   }, [] as MetadataRoute.Sitemap);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -50,10 +50,13 @@ export async function generateSitemaps() {
   const bookChunks = Math.ceil(bookCount / BOOKS_PER_CHUNK);
 
   // Count indexable reader pages (issue #2688) for their own chunk range.
+  // Generous timeout: if this times out it falls back to 0 and silently drops
+  // EVERY page chunk from the index (the seo_indexable_id_partial index makes
+  // the count ~50ms, but Atlas can be slow mid-build).
   const pageCount = await safeQuery('indexable-page-count', async (db) => {
     return db.collection('pages').countDocuments(
       { seo_indexable: true },
-      { maxTimeMS: 10000 }
+      { maxTimeMS: 30000 }
     );
   }, 0);
   const pageChunks = Math.ceil(pageCount / PAGES_PER_CHUNK);
@@ -232,6 +235,9 @@ async function getBooks(chunkIndex: number): Promise<MetadataRoute.Sitemap> {
 // (`/book/<slug>/page/<id>`) so no per-page book join is needed here.
 async function getIndexablePages(chunkIndex: number): Promise<MetadataRoute.Sitemap> {
   return safeQuery('indexable-pages', async (db) => {
+    // sort by _id so skip/limit pagination is stable across chunks; served by
+    // the seo_indexable_id_partial compound index (a single-field index on
+    // seo_indexable alone makes the planner full-scan in _id order → timeout).
     const pages = await db.collection('pages').find(
       { seo_indexable: true, seo_url: { $exists: true, $ne: null } },
       {
@@ -239,7 +245,7 @@ async function getIndexablePages(chunkIndex: number): Promise<MetadataRoute.Site
         sort: { _id: 1 },
         skip: chunkIndex * PAGES_PER_CHUNK,
         limit: PAGES_PER_CHUNK,
-        maxTimeMS: 25000,
+        maxTimeMS: 60000,
       }
     ).toArray();
 


### PR DESCRIPTION
Follow-up to #2691 — post-deploy verification caught the sitemap serving **empty page chunks** (`/sitemap/1000.xml` returned an empty `<urlset>`, and the index omitted the `1000+` chunks entirely).

## Root causes (both fixed)
1. **`getIndexablePages` timed out.** It sorts by `_id` for stable skip/limit pagination, but the single-field `{seo_indexable:1}` partial index made the planner full-scan the `pages` collection in `_id` order to satisfy the sort → `MaxTimeMSExpired` → `safeQuery` returns `[]` → empty chunk. Fixed with a **compound `{seo_indexable:1, _id:1}` partial index** (verified on prod: a skip-10k/limit-5k query went from timeout to **~7s**). Query timeout bumped to 60s for the deepest chunks.
2. **`generateSitemaps` silently dropped all page chunks.** Its page-count `safeQuery` falls back to `0` on timeout, which zeroes out the entire `1000+` chunk range. Atlas was slow during the last deploy (the build logs show the unrelated `entities` aggregate timing out too). Bumped its `maxTimeMS` 10s → 30s; the compound index makes the count ~50ms anyway.

## State
The compound index is **already created on prod**, so the runtime query is fixed now. This redeploys so the **static sitemap rebuilds** with the page chunks listed and populated.

The core robots gate (live since #2691) is unaffected — flagged pages already serve `index, follow`, unflagged serve `noindex, follow`, both verified in prod. This only fixes sitemap-driven discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)