### PR TITLE
fix(image-extraction): ground captions in page text + free mismatch detector

### DIFF
--- a/scripts/analysis/detect-caption-page-mismatch.mjs
+++ b/scripts/analysis/detect-caption-page-mismatch.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * detect-caption-page-mismatch.mjs
+ *
+ * FREE (no model calls) triage for the image-extraction failure mode where the
+ * gallery `museum_description` (written from the image + book topic, with no page
+ * text) disagrees with what the picture actually shows — the "wrestlers labelled
+ * gymnosophists" bug.
+ *
+ * Signal: the OCR pass emits a context-grounded `<image-desc>` for the same image
+ * (it read the whole page, including captions). Both that and `museum_description`
+ * are English prose describing the SAME picture, so they should share content
+ * words. Low overlap = the two descriptions disagree = candidate mislabel. These
+ * are CANDIDATES for review (or a cheap LLM judge), not confirmed errors.
+ *
+ * Usage:
+ *   node scripts/analysis/detect-caption-page-mismatch.mjs [--sample N] [--book ID]
+ *        [--threshold 0.12] [--limit-print 25]
+ */
+import { MongoClient } from 'mongodb';
+
+const args = process.argv.slice(2);
+const getArg = (k, d) => { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : d; };
+const SAMPLE = parseInt(getArg('--sample', '4000'), 10);
+const BOOK = getArg('--book', null);
+const THRESH = parseFloat(getArg('--threshold', '0.12'));
+const PRINT = parseInt(getArg('--limit-print', '25'), 10);
+
+const STOP = new Set(['the','this','these','those','that','with','from','into','among','around','toward','towards',
+  'and','or','but','for','its','his','her','their','they','are','was','were','has','have','had','been','being',
+  'depicts','depicting','shows','showing','shown','illustration','illustrates','illustrating','image','scene',
+  'figure','figures','figure.','large','small','vibrant','colorful','colourful','detailed','striking','manuscript',
+  'miniature','painting','woodcut','engraving','emblem','portrait','frontispiece','illumination','plate','print',
+  'left','right','center','centre','top','bottom','above','below','upper','lower','side','background','foreground',
+  'wearing','holding','seated','standing','sitting','dressed','adorned','featuring','appears','appear','identified',
+  'page','book','text','script','inscription','inscriptions','armenian','latin','greek','style','traditional',
+  'royal','king','figure','figures','men','man','woman','women','people','group','three','four','five','two','one',
+  'who','which','where','while','when','also','such','here','there','their','some','many','other','another','within']);
+
+const tokens = (s) => {
+  if (!s) return new Set();
+  return new Set((s.toLowerCase().match(/[a-zà-ÿ]+/g) || [])
+    .filter(w => w.length >= 4 && !STOP.has(w)));
+};
+
+const imgDescRx = /<image-desc[^>]*>([\s\S]*?)<\/image-desc>/i;
+// the OCR <note> rendering also carries the same description in translation.data
+const noteRx = /<note>([\s\S]*?illustration[\s\S]*?)<\/note>/i;
+
+function overlap(a, b) {
+  if (a.size === 0 || b.size === 0) return null;
+  let inter = 0;
+  for (const w of a) if (b.has(w)) inter++;
+  return inter / Math.min(a.size, b.size); // containment of the smaller in the larger
+}
+
+(async () => {
+  const c = new MongoClient(process.env.MONGODB_URI);
+  await c.connect();
+  const db = c.db('bookstore');
+
+  const match = BOOK ? { book_id: BOOK, museum_description: { $type: 'string' } }
+                     : { museum_description: { $type: 'string' } };
+  const pipeline = BOOK
+    ? [{ $match: match }, { $project: { page_id: 1, book_id: 1, book_title: 1, museum_description: 1, page_number: 1 } }]
+    : [{ $match: match }, { $sample: { size: SAMPLE } },
+       { $project: { page_id: 1, book_id: 1, book_title: 1, museum_description: 1, page_number: 1 } }];
+
+  const imgs = await db.collection('gallery_images').aggregate(pipeline).toArray();
+  const pageIds = [...new Set(imgs.map(i => i.page_id).filter(Boolean))];
+
+  const pageDesc = new Map();
+  for (let i = 0; i < pageIds.length; i += 2000) {
+    const chunk = pageIds.slice(i, i + 2000);
+    const pages = await db.collection('pages')
+      .find({ id: { $in: chunk } }, { projection: { id: 1, 'ocr.data': 1, 'translation.data': 1 } })
+      .toArray();
+    for (const p of pages) {
+      const ocr = p.ocr?.data || '', tr = p.translation?.data || '';
+      const m = ocr.match(imgDescRx) || tr.match(imgDescRx) || tr.match(noteRx) || ocr.match(noteRx);
+      pageDesc.set(p.id, m ? m[1] : null);
+    }
+  }
+
+  let scanned = 0, noImgDesc = 0, flagged = 0;
+  const examples = [];
+  for (const im of imgs) {
+    const gd = pageDesc.get(im.page_id);
+    if (!gd) { noImgDesc++; continue; }
+    scanned++;
+    const ov = overlap(tokens(im.museum_description), tokens(gd));
+    if (ov == null) continue;
+    if (ov < THRESH) {
+      flagged++;
+      if (examples.length < PRINT) examples.push({
+        book: im.book_title, page: im.page_number, ov: ov.toFixed(2),
+        museum: (im.museum_description || '').replace(/\s+/g, ' ').slice(0, 130),
+        ocrDesc: gd.replace(/\s+/g, ' ').slice(0, 130),
+        url: `https://sourcelibrary.org/book/${im.book_id}/page/${im.page_id}`,
+      });
+    }
+  }
+
+  console.log(`\n=== caption ↔ page-image-description disagreement triage (threshold ${THRESH}) ===`);
+  console.log(`gallery images examined  : ${imgs.length}${BOOK ? ` (book ${BOOK})` : ` (random sample of ${SAMPLE})`}`);
+  console.log(`comparable (have <image-desc>): ${scanned}  | no <image-desc>: ${noImgDesc}`);
+  console.log(`FLAGGED (descriptions disagree): ${flagged}  (${(100 * flagged / (scanned || 1)).toFixed(1)}% of comparable)`);
+  console.log(`\n--- examples (low word-overlap; review or LLM-judge) ---`);
+  for (const e of examples) {
+    console.log(`\n[${e.book}] p${e.page}  overlap=${e.ov}`);
+    console.log(`  museum : ${e.museum}…`);
+    console.log(`  ocrDesc: ${e.ocrDesc}…`);
+    console.log(`  ${e.url}`);
+  }
+  await c.close();
+})().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -687,6 +687,24 @@ async function revalidateBookPage(bookId) {
 }
 
 // ── Process one page ──
+/** Context-grounded page description from the OCR/translation pass (which read the
+ *  whole page). Feeding the captioner its `<image-desc>` / `<summary>` stops it
+ *  inventing a subject from the book's topic alone (e.g. wrestlers → "gymnosophists").
+ *  ~100-150 tokens; the data is already on the page doc. */
+function buildPageGrounding(page) {
+  const ocr = page?.ocr?.data || '';
+  const tr = page?.translation?.data || '';
+  const imgDesc = (ocr.match(/<image-desc[^>]*>([\s\S]*?)<\/image-desc>/i)
+    || tr.match(/<image-desc[^>]*>([\s\S]*?)<\/image-desc>/i))?.[1]?.trim();
+  const summary = (tr.match(/<summary>([\s\S]*?)<\/summary>/i)
+    || ocr.match(/<summary>([\s\S]*?)<\/summary>/i))?.[1]?.trim();
+  const lines = [];
+  if (imgDesc) lines.push(`Illustration on this page, transcribed FROM the page itself: ${imgDesc}`);
+  if (summary) lines.push(`Page summary: ${summary}`);
+  if (lines.length === 0) return '';
+  return `\nPAGE TEXT CONTEXT — written with the page's full text and any caption/label in view. Trust it over the book's general subject; do NOT name a figure or scene it contradicts:\n${lines.join('\n')}\n`;
+}
+
 async function extractImagesFromPage(page, prompt, db, bookId) {
   const url = getPageImageUrl(page);
   if (!url || (!url.startsWith('http://') && !url.startsWith('https://'))) return null;
@@ -716,7 +734,7 @@ async function extractImagesFromPage(page, prompt, db, bookId) {
   });
 
   const result = await model.generateContent([
-    { text: prompt },
+    { text: prompt + buildPageGrounding(page) },
     { inlineData: { mimeType: image.mimeType, data: image.data } },
   ]);
 
@@ -745,7 +763,7 @@ async function processBook(db, book) {
         { page_type: { $in: IMAGE_CANDIDATE_PAGE_TYPES } },
         { 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
       ],
-    }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1, 'ocr.data': 1 } })
+    }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1, 'ocr.data': 1, 'translation.data': 1 } })
     .toArray();
 
   // Pre-filter: drop pages where OCR has already classified all illustrations

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2069,8 +2069,15 @@ async function submitImageExtractionBatch(db, book, candidatePages) {
   if (book.language) contextParts.push(`Language: ${book.language}`);
   if (book.subjects?.length) contextParts.push(`Subjects: ${book.subjects.join(', ')}`);
   const contextPrefix = contextParts.length > 0
-    ? `BOOK CONTEXT (use this to inform your analysis — identify figures, symbols, and traditions specific to this work):\n${contextParts.join(' | ')}\n\n`
+    ? `BOOK CONTEXT (background only — a hint for reading inscriptions and recognising a tradition; do NOT assert a person, figure, or scene unless it is actually visible in THIS image — a book about a subject does not mean every illustration depicts it):\n${contextParts.join(' | ')}\n\n`
     : '';
+  // TODO(image-grounding): feed each page's own OCR `<image-desc>` / `<summary>` into
+  // the per-item prompt here, the way src/lib/image-extraction.ts and
+  // scripts/workers/image-extract-worker.mjs (buildPageGrounding) now do. The batch
+  // builders below assemble one prompt per page, so add ocr.data/translation.data to
+  // the `pages` projection and append buildPageGrounding(page) per item. Until then,
+  // the softened BOOK CONTEXT above is what keeps this batch path from confabulating a
+  // subject from the book's topic (e.g. wrestlers → "gymnosophists").
   const prompt = contextPrefix + IMAGE_EXTRACTION_PROMPT;
 
   const useFileBased = downloaded.length > IMAGE_EXTRACTION_INLINE_SIZE;
@@ -2247,7 +2254,7 @@ function buildPagePrompt(book) {
   if (book.language) contextParts.push(`Language: ${book.language}`);
   if (book.subjects?.length) contextParts.push(`Subjects: ${book.subjects.join(', ')}`);
   const contextPrefix = contextParts.length > 0
-    ? `BOOK CONTEXT (use this to inform your analysis — identify figures, symbols, and traditions specific to this work):\n${contextParts.join(' | ')}\n\n`
+    ? `BOOK CONTEXT (background only — a hint for reading inscriptions and recognising a tradition; do NOT assert a person, figure, or scene unless it is actually visible in THIS image — a book about a subject does not mean every illustration depicts it):\n${contextParts.join(' | ')}\n\n`
     : '';
   return contextPrefix + IMAGE_EXTRACTION_PROMPT;
 }

--- a/src/lib/image-extraction.ts
+++ b/src/lib/image-extraction.ts
@@ -80,7 +80,27 @@ function buildContextPrefix(ctx: BookContext): string {
   if (ctx.language) parts.push(`Language: ${ctx.language}`);
   if (ctx.subjects?.length) parts.push(`Subjects: ${ctx.subjects.join(', ')}`);
   if (parts.length === 0) return '';
-  return `BOOK CONTEXT (use this to inform your analysis — identify figures, symbols, and traditions specific to this work):\n${parts.join(' | ')}\n\n`;
+  return `BOOK CONTEXT (background only — a hint for reading inscriptions and recognising a tradition; do NOT assert a person, figure, or scene unless it is actually visible in THIS image or named in the PAGE TEXT below — a book about a subject does not mean every illustration depicts it):\n${parts.join(' | ')}\n\n`;
+}
+
+/** Pull the transcription pipeline's own page/illustration context. Unlike this
+ *  image-only captioner, the OCR pass read the whole page (text, captions, marginal
+ *  labels), so its `<image-desc>` / `<summary>` are context-grounded — feeding them
+ *  here stops the captioner inventing a subject from the book's topic alone.
+ *  Cheap: ~100-150 tokens, already stored on the page. */
+function buildPageGrounding(ocrData?: string): string {
+  if (!ocrData) return '';
+  const imgDesc = ocrData.match(/<image-desc[^>]*>([\s\S]*?)<\/image-desc>/i)?.[1]?.trim();
+  const summary = ocrData.match(/<summary>([\s\S]*?)<\/summary>/i)?.[1]?.trim();
+  const lines: string[] = [];
+  if (imgDesc) lines.push(`Illustration on this page, transcribed FROM the page itself: ${imgDesc}`);
+  if (summary) lines.push(`Page summary: ${summary}`);
+  if (lines.length === 0) {
+    const txt = ocrData.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 1200);
+    if (txt) lines.push(`Page text (transcribed): ${txt}`);
+  }
+  if (lines.length === 0) return '';
+  return `\nPAGE TEXT CONTEXT — written with the page's full text and any caption/label in view. Trust it over the book's general subject; do NOT name a figure or scene it contradicts:\n${lines.join('\n')}\n`;
 }
 
 export interface ImageMetadata {
@@ -126,13 +146,14 @@ export interface DetectedImage {
   model: string;
 }
 
-/** Build the complete prompt with book context + classification system context. */
-function buildFullPrompt(bookContext?: BookContext, customPrompt?: string): string {
+/** Build the complete prompt with book context + page grounding + classification context. */
+function buildFullPrompt(bookContext?: BookContext, customPrompt?: string, ocrData?: string): string {
   const base = customPrompt || IMAGE_EXTRACTION_PROMPT;
   const prefix = bookContext ? buildContextPrefix(bookContext) : '';
+  const grounding = buildPageGrounding(ocrData);
   const systems = getClassificationSystems(bookContext);
   const classificationSuffix = buildClassificationPrompt(systems);
-  return prefix + base + classificationSuffix;
+  return prefix + base + grounding + classificationSuffix;
 }
 
 const DEFAULT_MODEL = 'gemini-3-flash-preview';
@@ -197,7 +218,7 @@ export async function extractWithGemini(
       body: JSON.stringify({
         contents: [{
           parts: [
-            { text: buildFullPrompt(options?.bookContext, options?.promptText) },
+            { text: buildFullPrompt(options?.bookContext, options?.promptText, options?.ocrData) },
             { inline_data: { mime_type: mimeType, data: base64Image } }
           ]
         }],


### PR DESCRIPTION
## The bug (from the gymnosophist/wrestling catch)
The gallery captioner received the **page image + book-level metadata** but **never the page's own transcribed text**, and the prompt actively primed it: *"identify figures… specific to this work."* So on ambiguous figurative scenes with a strong topical prior it confabulated — labelling an **Isthmian-Games wrestling scene** in the *Romance of Alexander* as *"Alexander with three gymnosophists."* The OCR pass's own `<image-desc>` (which **does** read the page) had it right: *"wrestlers… two grappling."*

## Forward fix — uses existing summaries, so cost is negligible
Per the cost analysis, 83% of gallery pages already store an OCR `<image-desc>` (~101 tok) and 64% a `<summary>` (~52 tok). The image dominates input cost; adding ~100-150 tok of grounding is a rounding error.

- **`src/lib/image-extraction.ts`** — wire the previously-**dead** `ocrData` param into the prompt via `buildPageGrounding()` (feeds the context-grounded `<image-desc>`/`<summary>`); soften the `BOOK CONTEXT` priming to a hint.
- **`scripts/workers/image-extract-worker.mjs`** — same grounding from the already-fetched `ocr.data` (+ `translation.data` added to projection), appended per page.
- **`scripts/workers/pipeline-orchestrator.mjs`** (Gemini Batch path) — soften the priming across its builders now; full per-page grounding for its **3 batch code paths is TODO'd in-place** (deliberately out of scope — it's a risky sprawling edit to the batch JSONL builders that wants its own tested PR; the lib + worker establish the exact pattern).

## Detector — FREE, no model calls
`scripts/analysis/detect-caption-page-mismatch.mjs` compares each `museum_description` against the OCR-side `<image-desc>` (both English, both already stored) by word overlap. Validated: **flags the wrestling page, not the real gymnosophist page.** Corpus sample: ~14% of comparable images flagged as candidates (a triage — includes vocabulary-difference false positives; concentrated in narrative manuscripts where the captioner defaults to the book's hero: Ptolemy/Porus/saints all mislabelled "Alexander"). Narrows ~110k → ~15k for an **optional** cheap flash-lite judge before any **paid** re-caption.

## Out of scope (not done — flagged)
- Re-captioning existing images (paid Gemini run) — would estimate cost from the detector's confirmed count first and ask.
- Per-page grounding in the orchestrator's batch JSONL builders (TODO in code).

`tsc` clean; workers `node --check` clean; detector validated against the known case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)