### PR TITLE
fix(seo): compound index so sitemap reader-page chunks aren't empty (#2688)

### DIFF
--- a/scripts/seo/flag-indexable-pages.mjs
+++ b/scripts/seo/flag-indexable-pages.mjs
@@ -67,10 +67,13 @@ const books = db.collection('books');
 
 // Partial index on the flag — without it, the reconcile `$nin` below and the
 // sitemap's count/find on seo_indexable full-scan the millions-row pages
-// collection. Idempotent; only indexes the ~few-thousand flagged docs.
+// collection. Compound on _id so the sitemap's `sort({_id:1})` paginated
+// query is served by the index (a single-field {seo_indexable:1} index makes
+// the planner full-scan in _id order to satisfy the sort → timeout → empty
+// page chunks). Idempotent; only indexes the ~tens-of-thousands flagged docs.
 await pages.createIndex(
-  { seo_indexable: 1 },
-  { partialFilterExpression: { seo_indexable: true }, name: 'seo_indexable_partial' }
+  { seo_indexable: 1, _id: 1 },
+  { partialFilterExpression: { seo_indexable: true }, name: 'seo_indexable_id_partial' }
 );
 // Partial index on the read counter so Arm 1's candidate query doesn't
 // full-scan the millions-row pages collection (an unindexed count/find here

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -50,10 +50,13 @@ export async function generateSitemaps() {
   const bookChunks = Math.ceil(bookCount / BOOKS_PER_CHUNK);
 
   // Count indexable reader pages (issue #2688) for their own chunk range.
+  // Generous timeout: if this times out it falls back to 0 and silently drops
+  // EVERY page chunk from the index (the seo_indexable_id_partial index makes
+  // the count ~50ms, but Atlas can be slow mid-build).
   const pageCount = await safeQuery('indexable-page-count', async (db) => {
     return db.collection('pages').countDocuments(
       { seo_indexable: true },
-      { maxTimeMS: 10000 }
+      { maxTimeMS: 30000 }
     );
   }, 0);
   const pageChunks = Math.ceil(pageCount / PAGES_PER_CHUNK);
@@ -232,6 +235,9 @@ async function getBooks(chunkIndex: number): Promise<MetadataRoute.Sitemap> {
 // (`/book/<slug>/page/<id>`) so no per-page book join is needed here.
 async function getIndexablePages(chunkIndex: number): Promise<MetadataRoute.Sitemap> {
   return safeQuery('indexable-pages', async (db) => {
+    // sort by _id so skip/limit pagination is stable across chunks; served by
+    // the seo_indexable_id_partial compound index (a single-field index on
+    // seo_indexable alone makes the planner full-scan in _id order → timeout).
     const pages = await db.collection('pages').find(
       { seo_indexable: true, seo_url: { $exists: true, $ne: null } },
       {
@@ -239,7 +245,7 @@ async function getIndexablePages(chunkIndex: number): Promise<MetadataRoute.Site
         sort: { _id: 1 },
         skip: chunkIndex * PAGES_PER_CHUNK,
         limit: PAGES_PER_CHUNK,
-        maxTimeMS: 25000,
+        maxTimeMS: 60000,
       }
     ).toArray();
 


### PR DESCRIPTION
Follow-up to #2691 (re-cut clean from main; supersedes #2703). Post-deploy verification caught the sitemap serving **empty page chunks** — `/sitemap/1000.xml` returned an empty `<urlset>` and the index omitted the `1000+` chunks.

## Root causes (both fixed)
1. **`getIndexablePages` timed out.** It sorts by `_id` for stable skip/limit pagination, but the single-field `{seo_indexable:1}` partial index made the planner full-scan `pages` in `_id` order to satisfy the sort → `MaxTimeMSExpired` → `safeQuery` returns `[]` → empty chunk. Fixed with a **compound `{seo_indexable:1, _id:1}` partial index** (verified on prod: skip-10k/limit-5k went from timeout to **~7s**). Query timeout 25s → 60s for the deepest chunks.
2. **`generateSitemaps` dropped all page chunks.** Its page-count `safeQuery` falls back to `0` on timeout, zeroing the whole `1000+` range. Atlas was slow during the last deploy. `maxTimeMS` 10s → 30s (the compound index makes the count ~50ms regardless).

## State
Compound index already created on prod (and the redundant single-field one dropped), so the runtime query is fixed now. This redeploys so the **static sitemap rebuilds** with the chunks listed + populated. The robots gate (live since #2691) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)