### PR TITLE
fix(seo): list reader-page chunks in the sitemap index (#2688)

### DIFF
--- a/src/app/sitemap-index/route.ts
+++ b/src/app/sitemap-index/route.ts
@@ -14,24 +14,43 @@ import { getReadDb } from '@/lib/mongodb';
 
 const BASE_URL = 'https://sourcelibrary.org';
 const BOOKS_PER_CHUNK = 5000;
+// Indexable reader-page chunks (issue #2688) live at /sitemap/{1000+i}.xml —
+// the offset must match PAGE_CHUNK_OFFSET / PAGES_PER_CHUNK in src/app/sitemap.ts.
+// This index route (not Next's auto-index) is what robots.txt's /sitemap.xml
+// resolves to, so page chunks must be listed HERE or Google never sees them.
+const PAGES_PER_CHUNK = 5000;
+const PAGE_CHUNK_OFFSET = 1000;
 
 export const revalidate = 3600;
 
 export async function GET() {
   let bookCount = 0;
+  let pageCount = 0;
   try {
     const db = await getReadDb();
     bookCount = await db.collection('books').countDocuments(
       { visible: true, slug: { $exists: true, $ne: null }, pages_ocr: { $gt: 0 } },
       { maxTimeMS: 10000 }
     );
+    // seo_indexable_id_partial makes this ~50ms; on failure we simply omit the
+    // page chunks (the chunk routes still serve, just undiscovered until next ok).
+    pageCount = await db.collection('pages').countDocuments(
+      { seo_indexable: true },
+      { maxTimeMS: 30000 }
+    );
   } catch (error) {
-    console.error('sitemap-index: book count failed', error);
-    bookCount = 20000;
+    console.error('sitemap-index: count failed', error);
+    if (!bookCount) bookCount = 20000;
   }
 
   const bookChunks = Math.max(1, Math.ceil(bookCount / BOOKS_PER_CHUNK));
-  const chunkIds = [0, 1, ...Array.from({ length: bookChunks }, (_, i) => i + 2)];
+  const pageChunks = Math.ceil(pageCount / PAGES_PER_CHUNK);
+  const chunkIds = [
+    0,
+    1,
+    ...Array.from({ length: bookChunks }, (_, i) => i + 2),
+    ...Array.from({ length: pageChunks }, (_, i) => PAGE_CHUNK_OFFSET + i),
+  ];
   const lastmod = new Date().toISOString();
 
   const entries = chunkIds


### PR DESCRIPTION
Final piece of #2688. The reader-page chunks serve correctly at runtime (`/sitemap/1000.xml`..`1011.xml` hold all 58,647 URLs), but **the sitemap index never listed them**, so Google couldn't discover them.

## Cause
`robots.txt` points to `/sitemap.xml`, which `next.config.ts` rewrites to a **custom `/sitemap-index` route** (Next's `generateSitemaps` doesn't emit an index here — see the route's own header comment). That custom route only enumerated book chunks. So editing `sitemap.ts`'s `generateSitemaps` (the earlier PRs) had no effect on the index — wrong layer.

## Fix
Add the `seo_indexable` page count to `/sitemap-index` and emit the `1000+` chunk ids, mirroring the offset in `sitemap.ts`. On count failure the page chunks are simply omitted (chunk routes still serve; rediscovered next OK build).

## Verified before this fix
- `/sitemap/1000.xml` → 5000 URLs, `/sitemap/1011.xml` → 3647, `/sitemap/1012.xml` → 0 (= 58,647 total, matches the flagged set).
- Compound index from #2706 makes the deep-skip queries fast.

After merge+deploy, `/sitemap.xml` will list `/sitemap/1000.xml`…`1011.xml` alongside the book chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)