### PR TITLE
docs: add gymnosophists research dossier

### DIFF
--- a/.claude/docs/gymnosophists-research.md
+++ b/.claude/docs/gymnosophists-research.md
@@ -1,0 +1,417 @@
+# The Gymnosophists: A Research & Curatorial Dossier
+
+*Internal research document — Source Library. Compiled 2026-06-21.*
+
+This dossier weaves together (1) the broader scholarly/historical record on the
+**Gymnosophists** — the "naked philosophers" the Greeks met (or imagined) at the
+edge of the known world — and (2) what Source Library actually holds, with
+verified, citable passages from our own corpus. Quotations in quote marks are
+verbatim from the Source Library MCP (`get_quote`), wrapper-stripped, each linked
+to its exact page via a `short_url`. Everything outside quote marks is general
+historical exposition.
+
+The headline finding: this is one of the *best-attested* minor topics in the
+library. The single search term "gymnosophist" returns **69 matched passages**;
+"gymnosophistae" another 51, "naked philosophers" 54, "Brachmans" 41. The figure
+threads from the original Greek ethnographers (Strabo, Arrian, Megasthenes,
+Diogenes Laertius, Plutarch) straight through to its Renaissance afterlife in our
+Hermetic and Rosicrucian core (Maier, Della Porta, the Pymander, Agrippa). We
+hold both ends of the chain — primary witness and esoteric reception — which is
+unusual and curatorially valuable.
+
+---
+
+## 1. Who they were, and the name
+
+**Gymnosophist** is a Greek compound: *gymnós* (γυμνός, "naked") + *sophistḗs*
+(σοφιστής, "wise man / sophist / teacher"). It is a Greek exonym, never a
+self-designation — the people so labelled called themselves nothing of the kind.
+The Renaissance dictionaries in our corpus preserve the etymology with almost
+pedantic care. Reuchlin's *Vocabularius breviloquus* (1478) glosses it directly:
+"Gymnos in Greek is translated in Latin as naked… Gymnosophista… doctor or
+teacher in the gymnasium. And… the same gymnosophistae are said to be certain
+philosophe[rs]" ([short_url](https://sourcelibrary.org/q/BhPS2Tp6l4XUxVQ1H0Y)).
+Perotti's *Cornucopia* (1492) ties the word to the gymnasium where Greeks
+exercised naked, then to "the wise men of the Indians, who used to walk naked"
+([short_url](https://sourcelibrary.org/q/BiPwM24PSQTjmEtlp2T)).
+
+The term carries a built-in ambiguity that runs through the whole tradition.
+"Naked philosophers" was applied to at least two distinct realities:
+
+- **Indian ascetics** — the original referent. In modern terms these are best
+  understood as Brahmanical forest-dwellers (*vānaprastha*), Jain *digambara*
+  ("sky-clad") monks, and Ājīvika renunciants — ascetics for whom nudity, sun-
+  endurance, and indifference to the body were religious disciplines.
+- **"Ethiopian gymnosophists"** — a later, secondary class invented largely to
+  give Apollonius of Tyana an African counterpart to his Indian sages (see §4).
+
+The word also carries a faint note of Greek mockery, which one of our sources
+catches explicitly. Martin Fumée (1612) sniffs that he held no high opinion of
+"the wisdom of these Gymnosophists, considering their name is composed of the
+word Sophiste… which we commonly take in mockery"
+([short_url](https://sourcelibrary.org/q/BhqC4HZWS34A82kK7U1)). For most authors,
+though, the connotation was overwhelmingly positive: the gymnosophist was the
+philosopher stripped — literally — of everything inessential.
+
+---
+
+## 2. The Greek encounter: Alexander's expedition and its reporters
+
+The gymnosophists enter Western literature with Alexander's invasion of the
+Punjab (327–325 BCE). The defining encounter is **Onesicritus' embassy** to the
+sages at Taxila. Onesicritus, a helmsman in Alexander's fleet and a student of
+Diogenes the Cynic, was dispatched precisely because the ascetics would not come
+when summoned. Source Library holds the key witness directly — Strabo's
+*Geography*, Book 15, which preserves Onesicritus' first-person report:
+
+> "Onesicritus says that he himself was sent to converse with these sophists; for
+> Alexander had heard that the people always went naked and devoted themselves to
+> endurance, and that they were held in very great honor, and that they did not
+> visit other people when invited, but commanded them to visit them if they
+> wished to participate in anything they did or said… he himself was sent; and
+> that he found fifteen men at a distance of twenty stadia from the city, who
+> were in different postures, standing or sitting or lying naked and motionless
+> until evening… and that it was very hard to endure the sun."
+> — Strabo, *Geography* 15.1.63 ([short_url](https://sourcelibrary.org/q/BhF59r2QG7PMITdyyfj))
+
+This is the *ur-scene* of the whole tradition: the Cynic-trained Greek standing,
+notebook in hand, before motionless naked men who refuse to flatter the
+world-conqueror.
+
+Two named sages dominate the accounts, and their contrast became a literary
+topos:
+
+- **Calanus (Kalanos)** — the gymnosophist who *did* follow Alexander west, and
+  who, falling ill in Persis, had himself burned alive on a pyre rather than live
+  diminished. Cicero (in our 1523 Aldine *De philosophia*) preserves his exit
+  line as he climbed the pyre: "What a glorious departure from life…"
+  ([short_url](https://sourcelibrary.org/q/Bjbvtyp4BRjlC4tKc5S)). Robert
+  Estienne's *Dictionarium propriorum nominum* (1512) gives the capsule
+  biography: "Calanus, an Indian Gymnosophist who spoke with Alexander the Great,
+  and having followed him, ordered himself to be burned alive on a constructed
+  pyre" ([short_url](https://sourcelibrary.org/q/BhK4Rcp3gDiaq8Azlrk)). The
+  self-immolation made Calanus the West's first vivid image of Indian ascetic
+  fearlessness in the face of death.
+
+- **Dandamis / Mandanis** — the elder who *refused* Alexander, the foil to
+  Calanus. (Strabo calls him Mandanis; Arrian and Plutarch, Dandamis — our Loeb
+  Strabo footnotes the doublet at [short_url](https://sourcelibrary.org/q/BhF59r2QG7PMITdyyfl).)
+  His defiant reply to Alexander's summons is preserved in McCrindle's
+  *Ancient India as Described by Megasthenes and Arrian* (1877), quoting the
+  Palladius/Ambrose tradition:
+
+  > "The emperor Alexander, the son of the great Jupiter, who is lord of the
+  > human race, has ordered that you should hasten to him… but if you refuse he
+  > will behead you…" When these words came to the ears of Dandamis, he rose not
+  > from his leaves whereon he lay, but reclining and smiling he replied… "The
+  > greatest God… can do injury to no one…"
+  > — McCrindle, *Ancient India* (1877) ([short_url](https://sourcelibrary.org/q/BimWWAmlmChATPLXahm))
+
+The same page preserves the gymnosophists' withering verdict on Calanus, whom
+they regarded as a sellout: "Calanus is your friend, but he is despised and
+trodden upon by us… those things we certainly do not seek, please Calanus because
+of his greediness for money." The Calanus-vs-Dandamis pairing — the ascetic who
+went over to power and burned, against the one who stayed in the forest and
+won — is the tradition's central moral diptych.
+
+**The ethnographers behind the scenes.** Beyond Onesicritus, the corpus
+preserves the whole reporting apparatus. **Megasthenes**, Seleucid ambassador to
+Chandragupta Maurya's court, wrote the *Indica* that became the West's standard
+account of Indian wisdom — we hold McCrindle's reconstruction of its fragments
+([book](https://sourcelibrary.org/book/ancient-india-as-described-by-megasthenes-and-arrian-mccrindle)).
+Megasthenes' crucial distinction — between the **Brachmanes** (Brahmins, holy by
+birth) and the **Sarmanes / Garmanes** (the Śramaṇas, ascetics by election,
+i.e. Buddhist/Jain renunciants) — is preserved and explicitly footnoted in our
+edition as the moment "the followers of Buddha are clearly distinguished from the
+Brachmanes and Sarmanes"
+([short_url](https://sourcelibrary.org/q/BimWWAmlmChATPLXahQ)). This two-class
+(or three-class) taxonomy of Indian sages recurs in Clement of Alexandria, in
+Cælius Rhodiginus (1516, [short_url](https://sourcelibrary.org/q/Bjbx8J5lOfbTMD5Y16n)),
+and faithfully in Claude Duret's *Trésor* (1613), which reproduces Strabo's split
+between "the Brahmins… and the Germanes [Garmanes]"
+([short_url](https://sourcelibrary.org/q/BgopBC9NC7YCxdDZlMg)).
+
+We also hold **Arrian** (the *Periplus* / *Anabasis* in Estienne's 1575 Greek
+edition), **Diodorus Siculus** Book 17, **Plutarch's** *Life of Alexander* (both
+in the 1429 Greek manuscript and Perrin's Loeb), **Diogenes Laertius**, and
+**Pliny's** *Natural History* — the entire Greco-Roman documentary base for the
+encounter sits in the collection.
+
+---
+
+## 3. Hellenistic–Roman and late-antique reception: the ascetic ideal
+
+Once detached from the Punjab, the gymnosophist became a free-floating moral
+exemplar — the perfect Stoic, the perfect Cynic, the proof that virtue needs no
+possessions. **Philo of Alexandria** put Calanus to work in *Every Good Man Is
+Free*, and we hold this in three Latin Philos (Gelenius 1554, the 1561 Operum,
+Yonge's English). Philo introduces him as the witness to liberty: "Calanus was an
+Indian by birth, one of the gymnosophists. He, considered the most patient of all
+men of that age…" ([short_url](https://sourcelibrary.org/q/BgV7CiTve60ZaeeQGFU)).
+Philo elsewhere notes the gymnosophists "combine moral philosophy with natural,
+preferring in their whole life the love of honesty and uprightness"
+([short_url](https://sourcelibrary.org/q/BgV7EHBLTHSM56saZCw)) — and, more
+darkly, records the custom of voluntary self-cremation in old age or incurable
+illness ([short_url](https://sourcelibrary.org/q/BjolW1R6WxGt8o3p11z)).
+
+The Church Fathers turned the topos to apologetic ends — the virtuous pagan who
+shames lax Christians. **Augustine**, *City of God* (our 1542 edition), observes
+that "throughout the dark solitudes of India, although some go naked and
+philosophize — whence they are named gymnosophistae… they nevertheless apply
+coverings to their genitals" ([short_url](https://sourcelibrary.org/q/BhK91ryIM4N8fM7sIWy)).
+**Lactantius** pairs "Brachmanae… or Gymnosophistae… forest-dwellers and exiles
+from life" ([short_url](https://sourcelibrary.org/q/Bjbx9fhkkCs22MHkmOc)).
+**Hippolytus'** *Refutation of All Heresies* (our 1921 English) gives the
+sharpest theological reading: "the Brachmans consider Dandamis, whom Alexander of
+Macedon visited, to be divine, as one who had won the war within the body. They
+accuse Calanus of having impiously fallen [away]…"
+([short_url](https://sourcelibrary.org/q/Bh9WQsyRwmJXG7dXxot)). The crucial
+late-antique conduit is **Bardaisan of Edessa (Bardesanes)**, whose report (via
+Porphyry) that the Indian sages divide into Brahmins-by-birth and Samanaeans-by-
+election is quoted in Pico della Mirandola's *De rerum praenotione* (1506), in
+our corpus in the original Latin: "Porphyrius ex institutione Bardesanis Babylonij
+sapientes Indorum Gymnosophistas… Brachmanes… Sammaneos appellari"
+([short_url](https://sourcelibrary.org/q/BhNfGaT1dycmKhLf80L)).
+
+---
+
+## 4. The India → Ethiopia migration
+
+A peculiar feature of the later tradition is that the gymnosophists *moved*. By
+the imperial and Renaissance periods, writers routinely place them not (or not
+only) in India but in **Ethiopia**. Three forces drove the drift: (a) Greek
+geography had long imagined "the Ethiopians" and "the Indians" as the twin
+peoples at the eastern/southern rim of the world, easily conflated; (b) the
+sun-gazing motif (gymnosophists staring at the sun "from its rising to its
+setting," as Solinus has it,
+[short_url](https://sourcelibrary.org/q/BhDxVdebfLEb4L7UJ7g)) fit a torrid African
+setting; and, decisively, (c) **Philostratus' *Life of Apollonius*** sent its
+hero from the Indian Brahmins on to a parallel college of **Ethiopian
+gymnosophists** (§6), which fixed the African location in the imagination of
+every later reader of that immensely popular text.
+
+The result is that many of our Renaissance sources name the gymnosophists as
+flatly *Ethiopian*. Agrippa's *Occult Philosophy* (1550) speaks of "the Brahmans
+of the Indians, the Gymnosophists… of the Ethiopians"
+([short_url](https://sourcelibrary.org/q/Bg4FP6y7FDXJvgj8EgY)); the Pymander
+preface assigns them to the Ethiopians outright (§6). The "Persian gymnosophists"
+of Augustine's *De haeresibus* (1576,
+[short_url](https://sourcelibrary.org/q/BhbmhxNJGxyh4gBkMbx)) show the same
+floating geography. The lesson for a curator: in the early-modern sources,
+"gymnosophist" is less a fixed ethnos than a *role* — the naked sage of the
+distant East/South — and the Indian and Ethiopian versions coexist, often on the
+same page.
+
+---
+
+## 5. Patristic and medieval afterlife
+
+In the Latin Middle Ages the gymnosophists survived mainly through two channels.
+First, the **Alexander Romance** and its offshoot the *Collatio Alexandri cum
+Dindimo* (the letter-exchange between Alexander and "Dindimus," king of the
+Brahmins) made the naked philosophers a fixture of vernacular Alexander legend.
+Source Library holds an **Armenian *Romance of Alexander*** (1544 manuscript)
+whose Brahmin episode survives in translation: "The naked philosophers, the
+Brahmans, who are different from me, We are all sons of our father Adam…"
+([short_url](https://sourcelibrary.org/q/BhidjZaBdAn3d3ewhVi)). Second, encyclopedic
+geography — **Solinus'** *Polyhistor* (we hold the 1554 Vinet edition and the
+1895 Mommsen) — kept the sun-gazing Indian "Gymnosophistae" in every medieval
+mappa-mundi tradition. A charming witness to the topos's reach is the
+**Einsiedeln** chess-and-cosmography codex (c. 1000), which versifies them: "But
+others live naked with a wise heart" — glossed in our text as the
+"Gymnosophistae… famous in Greek and Latin literature for their wisdom and
+endurance" ([short_url](https://sourcelibrary.org/q/BgyQKjNzCOOWLBPjCsY)).
+**Palladius' *De Bragmanibus*** and the pseudo-Ambrosian *De moribus
+Brachmanorum* — the moralizing "ideal ascetic" treatises — survive in our corpus
+indirectly, quoted at length inside McCrindle's Megasthenes (§2).
+
+---
+
+## 6. Renaissance and early-modern reception: prisca sapientia, Hermes, the Rosy Cross
+
+This is where Source Library's holdings are richest, and where the gymnosophists
+matter most to our mission. In Renaissance esotericism the naked philosophers
+became a fixed station in the **prisca sapientia** — the imagined genealogy of a
+single ancient wisdom passed down through a relay of priestly castes. The
+standard list runs: Hebrew Prophets → Persian Magi → Indian Brahmins → Egyptian
+Priests → Ethiopian Gymnosophists → Greek poets/philosophers. We hold this list,
+verbatim, in the preface to the **Pymander of Hermes Trismegistus with Hannibal
+Rosseli's commentary** (1584):
+
+> "…just as among the **Hebrews** they are called **Prophets**, among the
+> **Persians** the **Magi**, among the **Indians** the **Brahmins**, among the
+> **Egyptians** the **Priests**, among the **Ethiopians** the **Gymnosophists**,
+> among the **Greeks** the most ancient **Poets**, and among the **Romans** the
+> **Orators**."
+> — *Pymander* w/ Rosseli (1584) ([short_url](https://sourcelibrary.org/q/BhNfDu5bYWXNtkxverd))
+
+The identical genealogy structures **Pererius (Benet Perera), *De magia*** (1598):
+"the Brahmins among the Indians, the Gymnosophists among the Ethiopians, the
+Philosophers among the Greeks, and the Prophets among the Jews"
+([short_url](https://sourcelibrary.org/q/Bhbmo05Y63abECcuNay)); **Della Porta's
+*Magia Naturalis*** (1571 French / 1607 German), which puts a named gymnosophist
+into the relay — "Thespion among the… Gymnosophists, Hermes among the Egyptians,
+Buddha among the Babylonians"
+([short_url](https://sourcelibrary.org/q/BhNfNWhu7dFHdNg7rMg)); and Claude Duret's
+*Trésor de l'histoire des langues* (1613). The gymnosophist is, in these texts,
+the *Indian/Ethiopian node* in a chain whose whole point is to show that
+Christian Hermetic wisdom is older than Greece.
+
+**Michael Maier** is the centre of gravity. The Rosicrucian alchemist made the
+gymnosophists a chartered ancestor of the Brotherhood. In *Symbola Aureae Mensae*
+(*Symbols of the Golden Table*, 1617) he gives them their own founding chapter —
+"**I. The College of the Gymnosophists among the Ethiopians**" — and dates it
+with mock precision to "the year 60 after the birth of Christ," when Apollonius of
+Tyana, "after he had returned from his travels in India, also crossed over to the
+Ethiopian Gymnosophists," meeting their elder Thespion under a talking elm
+([short_url](https://sourcelibrary.org/q/BejVnndJ5CZhPCM3KE0)). A few pages later
+Maier folds them into the alchemical lineage by way of metempsychosis: "The
+Brachmans believed in Metempsychosis, from whom Pythagoras learned it… the
+primary mysteries of the Brachmans were chemical"
+([short_url](https://sourcelibrary.org/q/BhNey0A9J3S6vuBkkw3)) — a striking move
+that recasts the Indian sages as proto-alchemists. The same chartering recurs in
+Maier's *Themis Aurea* (*The Golden Themis*, 1618), where the Rosicrucian
+brothers are likened to "the Magi among the Persians, the Gymnosophistæ… among
+the Ethiopians, the Brahmins among the Indians, and the priests among the
+Egyptians" ([short_url](https://sourcelibrary.org/q/BhNezXddaad4VEw94Db)), and in
+his *Silentium post Clamores* (1617, [short_url](https://sourcelibrary.org/q/Bgmrp78RdYeqAlWBQ2C)).
+The motif outlives Maier: Charles Rainsford's 18th-century *Collection of Extracts
+Related to the Fraternity of the RC* still lists "the Persian Magi, the Ethiopian
+gymnosophists, the Indian Brachmans, and the priests of Egypt" as the Brotherhood's
+forebears ([short_url](https://sourcelibrary.org/q/BiGyXDwN91Bb2l0bIkQ)).
+
+The vehicle for all of this is the **Apollonius of Tyana revival**. Philostratus'
+*Life* — which we hold complete in the 1504 Aldine Latin, 430 pages, fully
+translated — is the primary text that made the gymnosophists matter to the
+Hermetic Renaissance. Its preface frames Apollonius as a sage "more divine in
+philosophy than Pythagoras himself," slandered as a magician only because "he had
+spent time in Babylonia with the Magi, in India with the Brahmins, and in Egypt
+with the Gymnosophists"
+([short_url](https://sourcelibrary.org/q/BhIhSXR1gTZEprAy9fX)). Book VI narrates
+the actual meeting with the Ethiopian gymnosophists and their president Thespion
+([short_url](https://sourcelibrary.org/q/BhIhSXR1gTZEprAy9jZ)); Book III gives the
+Indian Brahmins under Iarchas and their five-element cosmology, the direct source
+for Maier's alchemical reading. The Grataroli alchemical anthology (1561) already
+read Apollonius this way: he "traveled to both the Brachmanes and the
+Gymnosophistae… and… progressed so far in the secrets of Nature that he never
+had… an equal" ([short_url](https://sourcelibrary.org/q/Bhbmcz8v4wMVsqpIvPo)).
+
+The transmigration thread — Brahmins teaching metempsychosis to Pythagoras, who
+carried it to Greece — is independently attested across the corpus (Maier above;
+Montanus' *Memorable Embassies*, [short_url](https://sourcelibrary.org/q/BhIGQidMSApfp1C8q0F);
+Diogenes Laertius on Pythagoras), making the gymnosophists a load-bearing link in
+the Renaissance argument that Greek philosophy was an Eastern inheritance.
+
+---
+
+## 7. What Source Library holds (curated list)
+
+**Primary witnesses to the historical encounter:**
+- **Strabo, *Geography* Vol. VII** (Loeb 1917) — Onesicritus' embassy, Calanus,
+  Mandanis. The single best primary passage. ([book](https://sourcelibrary.org/book/the-geography-of-strabo-vol-vii-loeb-jones-1917-jones))
+- **Megasthenes / Arrian**, ed. McCrindle, *Ancient India* (1877) — the *Indica*
+  fragments, the Brahmin/Sarmane distinction, Calanus & Dandamis via
+  Palladius/Ambrose. ([book](https://sourcelibrary.org/book/ancient-india-as-described-by-megasthenes-and-arrian-mccrindle))
+- **Arrian**, *Periplus / Anabasis* (Estienne, 1575 Greek) — execution of the
+  rebel Brachmans, the author-list of Alexander's reporters. ([book](https://sourcelibrary.org/book/arriani-et-hannonis-periplus-estienne))
+- **Plutarch**, *Lives* (1429 Greek MS; Perrin Loeb 1919) — *Life of Alexander*,
+  the riddling questions.
+- **Diodorus Siculus** Book 17; **Pliny**, *Natural History*; **Diogenes
+  Laertius** (Greek 1533, Traversari 1493, Yonge 1853); **Solinus**, *Polyhistor*
+  (1554, 1895); **Cicero**, *De philosophia* (1523) for Calanus' pyre.
+
+**Hellenistic / patristic reception:**
+- **Philo of Alexandria**, *Every Good Man Is Free* (Latin 1554 / 1561; Yonge) —
+  Calanus as exemplar of freedom. ([book](https://sourcelibrary.org/book/philonis-judaei-operum-quotquot-ad-hunc-diem-haberi-philo-2))
+- **Augustine**, *City of God* (1542) and *De haeresibus* (1576).
+- **Lactantius**, *Divine Institutes* (1535).
+- **Hippolytus**, *Refutation of All Heresies* (1921) — Dandamis as divine.
+- **Clement of Alexandria**, *Opera* (1869 Greek) — Sarmanes / Samanaeans.
+- **Pico della Mirandola**, *De rerum praenotione* (1506) — Bardaisan via
+  Porphyry.
+
+**Medieval:**
+- **Romance of Alexander** (Armenian MS, 1544) — the Dindimus/Brahmin material. ([book](https://sourcelibrary.org/book/romance-of-alexander-anonymous))
+- **Einsiedeln cosmography codex** (c. 1000) — versified gymnosophists.
+
+**Renaissance / early-modern reception (the core of our holdings):**
+- **Philostratus**, *Life of Apollonius of Tyana* (Aldine 1504, complete; also a
+  1611 French) — *the* keystone text. ([book](https://sourcelibrary.org/book/philostratus-life-of-apollonius-of-tyana-aldine-press-philostratus))
+- **Michael Maier** — *Symbola Aureae Mensae* (1617), *Themis Aurea* (1618),
+  *Silentium post Clamores* (1617). The Rosicrucian chartering of the
+  gymnosophists.
+- **Pymander of Hermes Trismegistus** w/ Rosseli (1584) — the prisca-sapientia list.
+- **Della Porta**, *Magia Naturalis* (French 1571 / German 1607); **Pererius**,
+  *De magia* (1598); **Agrippa**, *De occulta philosophia* (1550) & *De
+  vanitate* (1584); **Reuchlin**, *Vocabularius breviloquus* (1478/1483) —
+  etymology; **Duret**, *Trésor des langues* (1613); **García de Orta**,
+  *Aromatum… historia* (Clusius, 1567) — gymnosophist dress & transmigration;
+  **Iamblichus**, *De mysteriis* (Ficino, multiple eds.).
+
+Reception note: many of the Renaissance hits (Reuchlin, Perotti, the dictionaries)
+are *lexical/encyclopedic* — they define the word — while Maier, the Pymander, and
+Philostratus *use* the gymnosophists as live argumentative furniture. The Maier
+and Pymander passages are the ones with editorial weight.
+
+---
+
+## 8. Curatorial opportunities
+
+**This should become a Source Library collection, and it is essay-ready.**
+
+**The strongest narrative hook** — and the recommended spine for both a
+collection and a `/blog` essay — is the **double life of the gymnosophists as a
+"first encounter" story**: the literal moment a Cynic-trained Greek (Onesicritus)
+is sent, because the sages won't come to the king, to sit before fifteen naked
+men "standing or sitting or lying naked and motionless until evening" under a sun
+"so hot that at midday no one else could easily endure walking on the ground with
+bare feet." That is the West's founding image of meeting Indian spirituality on
+its own terms — power summons wisdom, and wisdom declines to come. Pair it with
+the Calanus/Dandamis diptych (the sage who followed Alexander and burned, vs. the
+one who stayed in the forest and refused), then follow the figure *forward* 1,900
+years to Maier dating a "College of the Gymnosophists" to 60 AD and enrolling them
+as ancestors of the Rosy Cross. The arc — **eyewitness ethnography → moral
+exemplar → Hermetic ancestor** — is exactly the kind of "how a single idea
+travels and mutates" story the library does well, and we hold verified text at
+every stage.
+
+A working title: *"The Naked Philosophers: How Alexander's India Became the
+Rosicrucians' Ancestor."*
+
+**Collection build.** The §7 list is essentially the collection manifest. Lead
+image candidates: a Della Porta or Maier engraving; the Apollonius/Thespion
+"talking elm" scene is the most evocable. Highlighted books: Strabo (primary),
+McCrindle's Megasthenes (the fragment-base), Philostratus (the hinge), Maier's
+*Symbola* (the esoteric payoff). The verified quotes in this dossier are ready to
+drop straight into an `expanded_description` — all already wrapper-stripped and
+`short_url`-linked.
+
+**Gaps / acquisition targets:**
+- **Palladius, *De gentibus Indiae et Bragmanibus*** and the pseudo-Ambrosian
+  *De moribus Brachmanorum* — we only hold them *quoted inside* McCrindle. A
+  standalone early-modern edition (these were printed together, e.g. London 1665/
+  1668, the "Pallad. Londin." our McCrindle cites) would let us cite the Dandamis
+  correspondence as a primary text rather than a fragment.
+- **The *Collatio Alexandri cum Dindimo*** as a discrete Latin text — we have the
+  Armenian Romance and scattered references, but not the standalone Dindimus
+  letter-exchange that medieval Europe actually read.
+- **Megasthenes' *Indica*** survives only in fragments anywhere; McCrindle is the
+  right scholarly vehicle and we have it. No further acquisition needed, but the
+  *Fragmenta* edition (Schwanbeck) would strengthen the apparatus.
+- **Apuleius, *Florida*** §6 (the famous gymnosophist set-piece) — we hold a 1521
+  Apuleius but should confirm the *Florida* passage is OCR'd/translated.
+
+**Cross-link opportunities:** the gymnosophists naturally connect existing or
+plausible collections on the *prisca sapientia* / ancient-wisdom genealogy, on
+Apollonius of Tyana, on Rosicrucianism (Maier), and on early European encounters
+with India (García de Orta, the *Banians* literature). The transmigration thread
+links them to a Pythagoras/metempsychosis cluster. The figure is a connective
+node, not an isolated curiosity — which is precisely why it is worth surfacing.
+
+---
+
+*All bracketed `short_url` links resolve to the exact cited page on
+sourcelibrary.org and carry CC-BY-SA-4.0 attribution. Quotations were retrieved
+verbatim via the `get_quote` MCP tool (wrapper-stripped). General historical
+exposition outside quote marks reflects the standard scholarly record and is not
+attributed to library text.*


### PR DESCRIPTION
Internal research/curatorial dossier behind the /blog/naked-philosophers essay — the gymnosophists across the corpus, with verified `get_quote` citations. §7 doubles as a manifest for a future curated collection. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)