### PR TITLE
feat(feedback): route volunteers to /welcome instead of dead-ending

### DIFF
--- a/src/components/feedback/FeedbackWidget.tsx
+++ b/src/components/feedback/FeedbackWidget.tsx
@@ -11,6 +11,10 @@ export default function FeedbackWidget({ className, style, initialMessage, label
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [wantsToHelp, setWantsToHelp] = useState(false);
+  // Tracks whether the just-sent submission opted in to helping, so the success
+  // state can route them to /welcome (the real onboarding capture) instead of
+  // dead-ending at "we'll be in touch".
+  const [submittedAsVolunteer, setSubmittedAsVolunteer] = useState(false);
   const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
   const [mounted, setMounted] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -44,8 +48,11 @@ export default function FeedbackWidget({ className, style, initialMessage, label
       setName('');
       setEmail('');
       const sentWithVolunteer = wantsToHelp;
+      setSubmittedAsVolunteer(sentWithVolunteer);
       setWantsToHelp(false);
-      setTimeout(() => { setOpen(false); setStatus('idle'); }, sentWithVolunteer ? 2400 : 2000);
+      // Volunteers get a persistent success state with a link to /welcome — don't
+      // auto-close it out from under them. Plain feedback still auto-dismisses.
+      if (!sentWithVolunteer) setTimeout(() => { setOpen(false); setStatus('idle'); }, 2000);
     } catch {
       setStatus('error');
     }
@@ -60,9 +67,28 @@ export default function FeedbackWidget({ className, style, initialMessage, label
         {status === 'sent' ? (
           <div className="text-center py-4">
             <p className="text-lg font-medium text-stone-800">Thank you!</p>
-            <p className="text-sm text-stone-500 mt-1">
-              {wantsToHelp ? "We'll be in touch about helping out." : 'Your feedback has been received.'}
-            </p>
+            {submittedAsVolunteer ? (
+              <>
+                <p className="text-sm text-stone-500 mt-1">
+                  We&rsquo;d love your help. Tell us a little about yourself and how you&rsquo;d like to contribute.
+                </p>
+                <a
+                  href="/welcome"
+                  className="inline-block mt-4 px-5 py-2 rounded-lg text-sm font-medium text-white transition-all hover:opacity-90"
+                  style={{ background: 'var(--accent-rust, #9e4a3a)' }}
+                >
+                  Tell us how you&rsquo;d like to help →
+                </a>
+                <button
+                  onClick={() => { setOpen(false); setStatus('idle'); setSubmittedAsVolunteer(false); }}
+                  className="block w-full mt-3 text-xs text-stone-400 hover:text-stone-600"
+                >
+                  Maybe later
+                </button>
+              </>
+            ) : (
+              <p className="text-sm text-stone-500 mt-1">Your feedback has been received.</p>
+            )}
           </div>
         ) : (
           <>
@@ -143,7 +169,7 @@ export default function FeedbackWidget({ className, style, initialMessage, label
     <>
       <button
         ref={buttonRef}
-        onClick={() => { if (initialMessage && !message) setMessage(initialMessage); setOpen(true); }}
+        onClick={() => { if (initialMessage && !message) setMessage(initialMessage); setStatus('idle'); setSubmittedAsVolunteer(false); setOpen(true); }}
         className={className || "text-accent-rust hover:text-accent-gold transition-colors"}
         style={style}
       >


### PR DESCRIPTION
From footer-feedback triage — multiple people clicked "I'd like to help" and got nothing back.

## Problem
The feedback widget's "I'd like to help" checkbox created a `volunteers` record, then showed "We'll be in touch about helping out" and auto-closed. Nobody was ever contacted, and the willing helper went nowhere. Meanwhile `/welcome` already exists as a proper onboarding capture (about-you + how-you'd-like-to-help, mirrored into `volunteers` via `/api/me/welcome`) — just unreachable from this flow.

## Fix
- On a volunteer submission, the success state shows **"Tell us how you'd like to help →"** linking to `/welcome` (which handles sign-in via `callbackUrl`).
- Don't auto-dismiss the success state for volunteers (so the link is clickable); plain feedback still auto-closes after 2s.
- Add `submittedAsVolunteer` state — the old success copy read `wantsToHelp` after it had been reset, so the volunteer message was unreliable.

Closes the onboarding gap: willing helpers now get a concrete next step that captures their languages/interests instead of a dead end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)