### PR TITLE
fix(gallery): unify gallery_images writers behind one buildGalleryDoc helper (#2531)

### DIFF
--- a/scripts/lib/gallery-doc.mjs
+++ b/scripts/lib/gallery-doc.mjs
@@ -1,0 +1,150 @@
+/**
+ * gallery-doc.mjs — canonical builder for `gallery_images` documents.
+ *
+ * `gallery_images` is a flat, fully-denormalized materialization of each
+ * detected illustration (one doc per detection). It has historically been
+ * written by FOUR paths that drifted apart (issue #2531,
+ * `lesson_gallery_images_provenance_sync`):
+ *   - scripts/workers/image-extract-worker.mjs   (Hetzner realtime worker)
+ *   - src/workers/image-extraction-processor-logic.ts  (SQS path)
+ *   - scripts/workers/sync-worker.mjs            (Mongo aggregation sweep)
+ *   - src/app/api/admin/sync-gallery-images      (Mongo aggregation, admin)
+ *
+ * Each had a slightly different field set, so a freshly-extracted image was
+ * often INVISIBLE on the gallery read path (which requires `book_visible:true`
+ * + `image_url`) until a separate sync ran. This module is the single source
+ * of truth for the field set so it can't drift again.
+ *
+ * TS twin: `src/lib/gallery-doc.ts` (keep the two in sync — the guard test
+ * `tests/unit/gallery-doc-schema.test.ts` pins the key set across both).
+ *
+ * The two Mongo-aggregation writers can't call this JS function (they build
+ * docs server-side via `$project`); they must mirror `GALLERY_DOC_KEYS`.
+ */
+
+/** Resolve the full-page display image for the gallery doc's `image_url`.
+ *  This is the image the on-the-fly magnifier lens crops from, so it must be
+ *  the page-display source — NOT the pre-cropped `extracted_url`. Mirrors the
+ *  `$ifNull` chain used by the admin sync route / SQS path. */
+export function galleryImageUrl(page) {
+  return (
+    page?.enhanced_photo ||
+    page?.cropped_photo ||
+    page?.archived_photo ||
+    page?.photo_original ||
+    page?.photo ||
+    ''
+  );
+}
+
+/** Keys every gallery_images doc carries (book_rank / scan_quality /
+ *  page_image_characteristics are conditional and listed separately). The
+ *  guard test asserts each writer produces exactly this set. */
+export const GALLERY_DOC_KEYS = [
+  'id',
+  'page_id',
+  'book_id',
+  'page_number',
+  'detection_index',
+  'image_url',
+  'thumbnail_url',
+  'extracted_url',
+  'description',
+  'type',
+  'bbox',
+  'rotation',
+  'gallery_quality',
+  'confidence',
+  'gallery_rationale',
+  'museum_description',
+  'detection_source',
+  'model',
+  'detected_at',
+  'metadata',
+  'dhash',
+  'book_title',
+  'book_author',
+  'book_year',
+  'book_language',
+  'book_visible',
+  'book_hidden',
+  'book_provider',
+  'updated_at',
+];
+
+/** Conditional keys: present only when the caller supplies the data. */
+export const GALLERY_DOC_OPTIONAL_KEYS = [
+  'book_rank',
+  'scan_quality',
+  'page_image_characteristics',
+];
+
+/**
+ * Build a fully-denormalized gallery_images document from a page, its book, and
+ * one detected image. Callers stay responsible for the gallery-quality gate
+ * (>= 0.5) and any scan-quality adjustment BEFORE calling this — pass the final
+ * quality via `galleryQuality` so the doc reflects what was actually filtered.
+ *
+ * @param {object}  p
+ * @param {object}  p.page          page doc (needs id, book_id, page_number, photo fields)
+ * @param {object}  p.book          book doc (display_title/title/author/year/language/visible/hidden/image_source)
+ * @param {object}  p.detectedImage one entry from page.detected_images
+ * @param {number}  p.index         detection index within the page (== detected_images position)
+ * @param {Date}    [p.now]         timestamp for updated_at
+ * @param {number}  [p.galleryQuality]  final (possibly scan-adjusted) quality; defaults to detectedImage.gallery_quality
+ * @param {number}  [p.bookRank]    1-based rank within book by quality; omitted if not provided
+ * @param {object}  [p.scanQuality] page-inherited scan_quality block for this image
+ * @param {object}  [p.pageImageCharacteristics]  page-level image characteristics summary
+ * @returns {object} gallery_images doc
+ */
+export function buildGalleryDoc({
+  page,
+  book,
+  detectedImage,
+  index,
+  now = new Date(),
+  galleryQuality,
+  bookRank,
+  scanQuality,
+  pageImageCharacteristics,
+}) {
+  const img = detectedImage || {};
+  const doc = {
+    id: `${page.id}-${index}`,
+    page_id: page.id,
+    book_id: book?.id ?? page.book_id,
+    page_number: page.page_number ?? null,
+    detection_index: index,
+    image_url: galleryImageUrl(page),
+    thumbnail_url: img.thumbnail_url ?? null,
+    extracted_url: img.extracted_url ?? null,
+    description: img.description || '',
+    type: img.type ?? null,
+    bbox: img.bbox,
+    rotation: img.rotation ?? null,
+    gallery_quality: typeof galleryQuality === 'number' ? galleryQuality : (img.gallery_quality ?? null),
+    confidence: img.confidence ?? null,
+    gallery_rationale: img.gallery_rationale ?? null,
+    museum_description: img.museum_description ?? null,
+    detection_source: img.detection_source ?? null,
+    model: img.model ?? null,
+    detected_at: img.detected_at ?? null,
+    metadata: img.metadata ?? null,
+    dhash: img.dhash ?? null,
+    book_title: book?.display_title || book?.title || 'Unknown',
+    book_author: book?.author ?? null,
+    book_year: book?.year ?? null,
+    book_language: book?.language ?? null,
+    book_visible: book?.visible ?? false,
+    book_hidden: book?.hidden ?? null,
+    book_provider: book?.image_source?.provider ?? null,
+    updated_at: now,
+  };
+  // book_rank is cross-page (computed within a book); only the writers that
+  // rank set it. Omit otherwise so a per-page upsert never clobbers a rank
+  // written by the dedicated rank pass.
+  if (typeof bookRank === 'number') doc.book_rank = bookRank;
+  if (scanQuality) doc.scan_quality = scanQuality;
+  if (pageImageCharacteristics) doc.page_image_characteristics = pageImageCharacteristics;
+  return doc;
+}

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -17,6 +17,7 @@
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI, SchemaType } from '@google/generative-ai';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
+import { buildGalleryDoc } from '../lib/gallery-doc.mjs';
 import { nanoid } from 'nanoid';
 import sharp from 'sharp';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
@@ -745,6 +746,7 @@ async function extractImagesFromPage(page, prompt, db, bookId) {
 
   return {
     pageId: page.id,
+    page, // carry the page doc forward so the gallery materializer can read photo fields + page_number
     text,
     characteristics,
     inputTokens: usage.promptTokenCount || 0,
@@ -763,7 +765,7 @@ async function processBook(db, book) {
         { page_type: { $in: IMAGE_CANDIDATE_PAGE_TYPES } },
         { 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
       ],
-    }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, split_from_spread: 1, 'ocr.data': 1, 'translation.data': 1 } })
+    }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, enhanced_photo: 1, crop: 1, split_from_spread: 1, 'ocr.data': 1, 'translation.data': 1 } })
     .toArray();
 
   // Pre-filter: drop pages where OCR has already classified all illustrations
@@ -825,7 +827,7 @@ async function processBook(db, book) {
         continue;
       }
 
-      const { pageId, text, characteristics, inputTokens, outputTokens } = settled.value;
+      const { pageId, page, text, characteristics, inputTokens, outputTokens } = settled.value;
       totalInputTokens += inputTokens;
       totalOutputTokens += outputTokens;
       pagesProcessed++;
@@ -874,32 +876,10 @@ async function processBook(db, book) {
         // Threshold is under review; coordinate any change with the SQS path
         // and scripts/workers/batch-collector.mjs.
         const QUALITY_THRESHOLD = 0.5;
-        for (let di = 0; di < detectedImages.length; di++) {
-          const img = detectedImages[di];
-          if (!img.bbox) continue;
-          if (typeof img.gallery_quality !== 'number') continue;
-          if (img.gallery_quality < QUALITY_THRESHOLD) continue;
-          const galleryDoc = {
-            id: `${pageId}-${di}`,
-            page_id: pageId,
-            book_id: book.id,
-            detection_index: di,
-            description: img.description,
-            type: img.type,
-            bbox: img.bbox,
-            gallery_quality: img.gallery_quality,
-            gallery_rationale: img.gallery_rationale,
-            museum_description: img.museum_description,
-            metadata: img.metadata,
-            detected_at: now,
-            detection_source: 'vision_model',
-            model: MODEL,
-            updated_at: now,
-          };
-          // Inherit page-level scan quality so the gallery_image carries it standalone.
-          // Per-crop sharpness can be added later in a separate pass on extracted_url.
-          if (pageScanQuality) {
-            galleryDoc.scan_quality = {
+        // Inherit page-level scan quality so the gallery_image carries it standalone.
+        // Per-crop sharpness can be added later in a separate pass on extracted_url.
+        const inheritedScanQuality = pageScanQuality
+          ? {
               score: pageScanQuality.scan_score,
               scan_class: pageScanQuality.scan_class,
               illustration_fidelity: pageScanQuality.illustration_fidelity,
@@ -908,17 +888,34 @@ async function processBook(db, book) {
               source: 'page_inherited',
               version: SCAN_QUALITY_VERSION,
               assessed_at: now,
-            };
-          }
-          if (characteristics) {
-            galleryDoc.page_image_characteristics = {
+            }
+          : null;
+        const pageImageCharacteristics = characteristics
+          ? {
               megapixels: characteristics.megapixels,
               sharpness_var: characteristics.sharpness_var,
               chroma_spread: characteristics.chroma_spread,
               flags: characteristics.flags,
-            };
-          }
-          galleryDocs.push(galleryDoc);
+            }
+          : null;
+        for (let di = 0; di < detectedImages.length; di++) {
+          const img = detectedImages[di];
+          if (!img.bbox) continue;
+          if (typeof img.gallery_quality !== 'number') continue;
+          if (img.gallery_quality < QUALITY_THRESHOLD) continue;
+          // Build the fully-denormalized doc via the shared helper so the field
+          // set stays identical across all writers (#2531). `page` is the source
+          // page doc with photo fields + page_number; `book` carries visible/
+          // hidden/provider so the image is gallery-visible without a sync pass.
+          galleryDocs.push(buildGalleryDoc({
+            page,
+            book,
+            detectedImage: img,
+            index: di,
+            now,
+            scanQuality: inheritedScanQuality,
+            pageImageCharacteristics,
+          }));
         }
       }
 
@@ -1024,7 +1021,7 @@ async function main() {
   const books = await db.collection('books')
     .find({ 'pipeline_auto.status': 'chapters_complete', ...SCOPE_FILTER })
     .sort({ processing_priority: -1, hidden: 1 })
-    .project({ id: 1, title: 1, author: 1, year: 1, language: 1, subjects: 1 })
+    .project({ id: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, subjects: 1, visible: 1, hidden: 1, 'image_source.provider': 1 })
     .limit(BOOKS_PER_RUN)
     .toArray();
 
@@ -1041,7 +1038,7 @@ async function main() {
         ...SCOPE_FILTER,
       })
       .sort({ visible: -1, pages_count: -1 })
-      .project({ id: 1, title: 1, author: 1, year: 1, language: 1, subjects: 1 })
+      .project({ id: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, subjects: 1, visible: 1, hidden: 1, 'image_source.provider': 1 })
       .limit(BOOKS_PER_RUN - books.length)
       .toArray();
     if (catchUp.length > 0) {

--- a/scripts/workers/sync-worker.mjs
+++ b/scripts/workers/sync-worker.mjs
@@ -331,14 +331,24 @@ async function syncGalleryImages(db) {
         rotation: '$detected_images.rotation',
         gallery_quality: '$detected_images.gallery_quality',
         confidence: '$detected_images.confidence',
+        gallery_rationale: '$detected_images.gallery_rationale',
         museum_description: '$detected_images.museum_description',
         detection_source: '$detected_images.detection_source',
+        // AI provenance — must be carried so re-sync doesn't strip model/date
+        // (the #2406 / lesson_gallery_images_provenance_sync gap).
+        model: '$detected_images.model',
+        detected_at: '$detected_images.detected_at',
         metadata: '$detected_images.metadata',
+        dhash: '$detected_images.dhash',
         book_title: { $ifNull: ['$book.display_title', { $ifNull: ['$book.title', 'Unknown'] }] },
         book_author: '$book.author',
         book_year: '$book.year',
         book_language: '$book.language',
+        // book_visible is what the gallery read path filters on — omitting it
+        // here is what left freshly-synced images invisible (#2531).
+        book_visible: { $ifNull: ['$book.visible', false] },
         book_hidden: '$book.hidden',
+        book_provider: '$book.image_source.provider',
         book_rank: { $literal: 0 },
         updated_at: new Date(),
       },

--- a/src/app/api/admin/sync-gallery-images/route.ts
+++ b/src/app/api/admin/sync-gallery-images/route.ts
@@ -101,8 +101,13 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
           rotation: '$detected_images.rotation',
           gallery_quality: '$detected_images.gallery_quality',
           confidence: '$detected_images.confidence',
+          gallery_rationale: '$detected_images.gallery_rationale',
           museum_description: '$detected_images.museum_description',
           detection_source: '$detected_images.detection_source',
+          // AI provenance — carry model/detected_at so a re-sync doesn't strip
+          // them (the #2406 / lesson_gallery_images_provenance_sync gap).
+          model: '$detected_images.model',
+          detected_at: '$detected_images.detected_at',
           metadata: '$detected_images.metadata',
           dhash: '$detected_images.dhash',
           book_title: { $ifNull: ['$book.display_title', { $ifNull: ['$book.title', 'Unknown'] }] },
@@ -130,12 +135,15 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
       });
     }
 
-    // Write to gallery_images via $merge (upsert by id)
+    // Write to gallery_images via $merge (upsert by id).
+    // `merge` (not `replace`) so a re-sync updates the projected fields without
+    // wiping worker-only fields the aggregation can't reconstruct — page-level
+    // scan_quality / page_image_characteristics (#2531).
     pipeline.push({
       $merge: {
         into: 'gallery_images',
         on: 'id',
-        whenMatched: 'replace',
+        whenMatched: 'merge',
         whenNotMatched: 'insert',
       },
     });

--- a/src/lib/gallery-doc.ts
+++ b/src/lib/gallery-doc.ts
@@ -1,0 +1,170 @@
+/**
+ * gallery-doc.ts — canonical builder for `gallery_images` documents (TS twin).
+ *
+ * See `scripts/lib/gallery-doc.mjs` for the full rationale. `gallery_images` is
+ * written by four paths that drifted apart (#2531); this is the single source
+ * of truth for the field set on the TypeScript side (SQS path). Keep in sync
+ * with the `.mjs` twin — the guard test `tests/unit/gallery-doc-schema.test.ts`
+ * pins the key set across both.
+ */
+
+/** Minimal page shape needed to build a gallery doc. */
+export interface GalleryDocPage {
+  id: string;
+  book_id?: string;
+  page_number?: number | null;
+  enhanced_photo?: string | null;
+  cropped_photo?: string | null;
+  archived_photo?: string | null;
+  photo_original?: string | null;
+  photo?: string | null;
+}
+
+/** Minimal book shape needed to build a gallery doc. */
+export interface GalleryDocBook {
+  id?: string;
+  display_title?: string | null;
+  title?: string | null;
+  author?: string | null;
+  year?: number | string | null;
+  language?: string | null;
+  visible?: boolean | null;
+  hidden?: boolean | null;
+  image_source?: { provider?: string | null } | null;
+}
+
+/** One detected illustration (subset of `pages.detected_images[]`). */
+export interface GalleryDocDetection {
+  thumbnail_url?: string | null;
+  extracted_url?: string | null;
+  description?: string | null;
+  type?: string | null;
+  bbox?: { x: number; y: number; width: number; height: number };
+  rotation?: number | null;
+  gallery_quality?: number | null;
+  confidence?: number | null;
+  gallery_rationale?: string | null;
+  museum_description?: string | null;
+  detection_source?: string | null;
+  model?: string | null;
+  detected_at?: Date | null;
+  metadata?: Record<string, unknown> | null;
+  dhash?: string | null;
+}
+
+export interface BuildGalleryDocArgs {
+  page: GalleryDocPage;
+  book?: GalleryDocBook | null;
+  detectedImage: GalleryDocDetection;
+  index: number;
+  now?: Date;
+  galleryQuality?: number;
+  bookRank?: number;
+  scanQuality?: Record<string, unknown> | null;
+  pageImageCharacteristics?: Record<string, unknown> | null;
+}
+
+/** Keys every gallery_images doc carries. Mirrors `GALLERY_DOC_KEYS` in the
+ *  `.mjs` twin; the guard test asserts both produce exactly this set. */
+export const GALLERY_DOC_KEYS = [
+  'id',
+  'page_id',
+  'book_id',
+  'page_number',
+  'detection_index',
+  'image_url',
+  'thumbnail_url',
+  'extracted_url',
+  'description',
+  'type',
+  'bbox',
+  'rotation',
+  'gallery_quality',
+  'confidence',
+  'gallery_rationale',
+  'museum_description',
+  'detection_source',
+  'model',
+  'detected_at',
+  'metadata',
+  'dhash',
+  'book_title',
+  'book_author',
+  'book_year',
+  'book_language',
+  'book_visible',
+  'book_hidden',
+  'book_provider',
+  'updated_at',
+] as const;
+
+export const GALLERY_DOC_OPTIONAL_KEYS = [
+  'book_rank',
+  'scan_quality',
+  'page_image_characteristics',
+] as const;
+
+/** Resolve the full-page display image for `image_url` (the source the lens
+ *  magnifier crops from — never the pre-cropped `extracted_url`). */
+export function galleryImageUrl(page: GalleryDocPage): string {
+  return (
+    page?.enhanced_photo ||
+    page?.cropped_photo ||
+    page?.archived_photo ||
+    page?.photo_original ||
+    page?.photo ||
+    ''
+  );
+}
+
+/** Build a fully-denormalized gallery_images document. See the `.mjs` twin for
+ *  the full contract; callers apply the quality gate before calling. */
+export function buildGalleryDoc({
+  page,
+  book,
+  detectedImage,
+  index,
+  now = new Date(),
+  galleryQuality,
+  bookRank,
+  scanQuality,
+  pageImageCharacteristics,
+}: BuildGalleryDocArgs): Record<string, unknown> {
+  const img = detectedImage || ({} as GalleryDocDetection);
+  const doc: Record<string, unknown> = {
+    id: `${page.id}-${index}`,
+    page_id: page.id,
+    book_id: book?.id ?? page.book_id,
+    page_number: page.page_number ?? null,
+    detection_index: index,
+    image_url: galleryImageUrl(page),
+    thumbnail_url: img.thumbnail_url ?? null,
+    extracted_url: img.extracted_url ?? null,
+    description: img.description || '',
+    type: img.type ?? null,
+    bbox: img.bbox,
+    rotation: img.rotation ?? null,
+    gallery_quality:
+      typeof galleryQuality === 'number' ? galleryQuality : (img.gallery_quality ?? null),
+    confidence: img.confidence ?? null,
+    gallery_rationale: img.gallery_rationale ?? null,
+    museum_description: img.museum_description ?? null,
+    detection_source: img.detection_source ?? null,
+    model: img.model ?? null,
+    detected_at: img.detected_at ?? null,
+    metadata: img.metadata ?? null,
+    dhash: img.dhash ?? null,
+    book_title: book?.display_title || book?.title || 'Unknown',
+    book_author: book?.author ?? null,
+    book_year: book?.year ?? null,
+    book_language: book?.language ?? null,
+    book_visible: book?.visible ?? false,
+    book_hidden: book?.hidden ?? null,
+    book_provider: book?.image_source?.provider ?? null,
+    updated_at: now,
+  };
+  if (typeof bookRank === 'number') doc.book_rank = bookRank;
+  if (scanQuality) doc.scan_quality = scanQuality;
+  if (pageImageCharacteristics) doc.page_image_characteristics = pageImageCharacteristics;
+  return doc;
+}

--- a/src/workers/image-extraction-processor-logic.ts
+++ b/src/workers/image-extraction-processor-logic.ts
@@ -8,6 +8,12 @@ import { DEFAULT_MODEL } from '@/lib/types/ai-models';
 import { PROMPT_VERSION } from '@/lib/types/prompts/defaults';
 import { classifyError } from '@/lib/errors';
 import { sendWriteResult } from '@/lib/sqs-client';
+import {
+  buildGalleryDoc,
+  type GalleryDocPage,
+  type GalleryDocBook,
+  type GalleryDocDetection,
+} from '@/lib/gallery-doc';
 
 /**
  * Image Extraction Processor - processes one page at a time
@@ -281,11 +287,10 @@ async function buildGalleryDocs(
     // Fetch book metadata for denormalization
     const book = await db.collection('books').findOne(
       { id: bookId },
-      { projection: { display_title: 1, title: 1, author: 1, year: 1, language: 1, visible: 1, hidden: 1 } }
+      { projection: { id: 1, display_title: 1, title: 1, author: 1, year: 1, language: 1, visible: 1, hidden: 1, 'image_source.provider': 1 } }
     );
 
-    const imageUrl = (page as any).enhanced_photo || page.cropped_photo || page.archived_photo || page.photo_original || page.photo || '';
-
+    const now = new Date();
     const docs = images
       .map((img, idx) => {
         if (!img.bbox) return null;
@@ -298,39 +303,18 @@ async function buildGalleryDocs(
         // Re-check threshold after adjustment — low-res scans may drop below 0.5
         if (adjustedQuality < 0.5) return null;
 
-        return {
-          id: `${pageId}-${idx}`,
-          page_id: pageId,
-          book_id: bookId,
-          page_number: page.page_number,
-          detection_index: idx,
-          image_url: imageUrl,
-          thumbnail_url: img.thumbnail_url || null,
-          extracted_url: img.extracted_url || null,
-          description: img.description || '',
-          type: img.type || null,
-          bbox: img.bbox,
-          rotation: img.rotation || null,
-          gallery_quality: adjustedQuality,
-          confidence: img.confidence || null,
-          museum_description: img.museum_description || null,
-          detection_source: img.detection_source || null,
-          // AI provenance — keep in sync with detected_images so the gallery
-          // page can attribute the generating model (issue #2406). Omitting
-          // these here is what left ~76% of gallery_images without `model`.
-          model: img.model || null,
-          detected_at: img.detected_at || null,
-          metadata: img.metadata || null,
-          dhash: img.dhash || null,
-          book_title: book?.display_title || book?.title || 'Unknown',
-          book_author: book?.author || null,
-          book_year: book?.year || null,
-          book_language: book?.language || null,
-          book_visible: book?.visible ?? false,
-          book_hidden: book?.hidden || null,
-          book_rank: 0,
-          updated_at: new Date(),
-        };
+        // Shared builder so the field set stays identical across all four
+        // gallery_images writers (#2531). Preserve this path's provisional
+        // book_rank: 0 (the dedicated rank pass overwrites it).
+        return buildGalleryDoc({
+          page: page as unknown as GalleryDocPage,
+          book: book as unknown as GalleryDocBook,
+          detectedImage: img as unknown as GalleryDocDetection,
+          index: idx,
+          now,
+          galleryQuality: adjustedQuality,
+          bookRank: 0,
+        });
       })
       .filter((d): d is NonNullable<typeof d> => d !== null);
 

--- a/tests/unit/gallery-doc-schema.test.ts
+++ b/tests/unit/gallery-doc-schema.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildGalleryDoc,
+  galleryImageUrl,
+  GALLERY_DOC_KEYS,
+  GALLERY_DOC_OPTIONAL_KEYS,
+} from '@/lib/gallery-doc';
+import {
+  buildGalleryDoc as buildGalleryDocJs,
+  galleryImageUrl as galleryImageUrlJs,
+  GALLERY_DOC_KEYS as GALLERY_DOC_KEYS_JS,
+  GALLERY_DOC_OPTIONAL_KEYS as GALLERY_DOC_OPTIONAL_KEYS_JS,
+} from '../../scripts/lib/gallery-doc.mjs';
+
+// `gallery_images` is written by four paths that historically drifted apart
+// (#2531). A freshly-extracted image was invisible on the gallery read path
+// (which requires `book_visible` + `image_url`) until a separate sync ran.
+// These tests pin the canonical field set across the two JS twins so a future
+// edit to one without the other fails CI. The two Mongo-aggregation writers
+// (admin sync route + sync-worker) build docs server-side via `$project` and
+// must mirror GALLERY_DOC_KEYS by hand — see the helper module docs.
+
+const PAGE = {
+  id: 'page123',
+  book_id: 'book999',
+  page_number: 42,
+  archived_photo: 'https://images.sourcelibrary.org/archived/book999/42.jpg',
+  photo: 'https://images.sourcelibrary.org/pages/book999/0042-full.jpg',
+};
+
+const BOOK = {
+  id: 'book999',
+  display_title: 'Atalanta Fugiens',
+  title: 'Atalanta',
+  author: 'Michael Maier',
+  year: 1617,
+  language: 'la',
+  visible: true,
+  hidden: false,
+  image_source: { provider: 'internet-archive' },
+};
+
+const DETECTION = {
+  bbox: { x: 0.1, y: 0.1, width: 0.5, height: 0.5 },
+  description: 'An emblem',
+  type: 'engraving',
+  gallery_quality: 0.85,
+  gallery_rationale: 'figural emblem',
+  museum_description: 'A compelling allegorical scene.',
+  detection_source: 'vision_model',
+  model: 'gemini-3-flash-preview',
+  detected_at: new Date('2026-06-22T00:00:00Z'),
+  metadata: { subjects: ['alchemy'] },
+  confidence: 0.9,
+};
+
+const baseArgs = {
+  page: PAGE,
+  book: BOOK,
+  detectedImage: DETECTION,
+  index: 0,
+  now: new Date('2026-06-22T00:00:00Z'),
+};
+
+describe('gallery-doc twins stay in sync', () => {
+  it('both twins export an identical canonical key list', () => {
+    expect([...GALLERY_DOC_KEYS]).toEqual([...GALLERY_DOC_KEYS_JS]);
+    expect([...GALLERY_DOC_OPTIONAL_KEYS]).toEqual([...GALLERY_DOC_OPTIONAL_KEYS_JS]);
+  });
+
+  it('both twins produce the same document for the same input', () => {
+    const ts = buildGalleryDoc(baseArgs as never);
+    const js = buildGalleryDocJs(baseArgs);
+    expect(ts).toEqual(js);
+  });
+
+  it('galleryImageUrl twins agree', () => {
+    expect(galleryImageUrl(PAGE)).toBe(galleryImageUrlJs(PAGE));
+  });
+});
+
+describe('buildGalleryDoc produces the canonical schema', () => {
+  it('emits exactly the base key set (no rank/scan unless supplied)', () => {
+    const doc = buildGalleryDoc(baseArgs as never);
+    expect(Object.keys(doc).sort()).toEqual([...GALLERY_DOC_KEYS].sort());
+  });
+
+  it('includes the fields the gallery read path requires (#2531 regression)', () => {
+    const doc = buildGalleryDoc(baseArgs as never);
+    // These three were the silent omissions that left images invisible.
+    expect(doc.book_visible).toBe(true);
+    expect(doc.image_url).toBe(PAGE.archived_photo);
+    expect(doc.page_number).toBe(42);
+    expect(doc.id).toBe('page123-0');
+    expect(doc.book_provider).toBe('internet-archive');
+  });
+
+  it('carries AI provenance (model + detected_at)', () => {
+    const doc = buildGalleryDoc(baseArgs as never);
+    expect(doc.model).toBe('gemini-3-flash-preview');
+    expect(doc.detected_at).toEqual(DETECTION.detected_at);
+  });
+
+  it('book_visible defaults to false when the book is missing/unknown', () => {
+    const doc = buildGalleryDoc({ ...baseArgs, book: null } as never);
+    expect(doc.book_visible).toBe(false);
+    expect(doc.book_title).toBe('Unknown');
+  });
+
+  it('omits book_rank/scan_quality unless supplied; includes them when given', () => {
+    const plain = buildGalleryDoc(baseArgs as never);
+    expect(plain).not.toHaveProperty('book_rank');
+    expect(plain).not.toHaveProperty('scan_quality');
+
+    const enriched = buildGalleryDoc({
+      ...baseArgs,
+      bookRank: 3,
+      scanQuality: { scan_class: 'color_photo', source: 'page_inherited' },
+      pageImageCharacteristics: { megapixels: 4 },
+    } as never);
+    expect(enriched.book_rank).toBe(3);
+    expect(enriched.scan_quality).toMatchObject({ scan_class: 'color_photo' });
+    expect(enriched.page_image_characteristics).toMatchObject({ megapixels: 4 });
+  });
+
+  it('uses a scan-adjusted gallery_quality when passed explicitly', () => {
+    const doc = buildGalleryDoc({ ...baseArgs, galleryQuality: 0.55 } as never);
+    expect(doc.gallery_quality).toBe(0.55);
+  });
+
+  it('image_url prefers the full-page source, never the crop', () => {
+    // extracted_url is the crop; the lens magnifier crops on the fly from the
+    // full page, so image_url must resolve to the page-display source.
+    const doc = buildGalleryDoc({
+      ...baseArgs,
+      detectedImage: { ...DETECTION, extracted_url: 'https://crop.example/x.jpg' },
+    } as never);
+    expect(doc.image_url).toBe(PAGE.archived_photo);
+    expect(doc.extracted_url).toBe('https://crop.example/x.jpg');
+  });
+});


### PR DESCRIPTION
## Why
`gallery_images` is a flat, fully-denormalized materialization of each detected illustration. It was being written by **four** paths that had quietly drifted apart, so a freshly-extracted image was often **invisible** on the public gallery — which filters on `book_visible: true` + `image_url` — until a *separate* sync step ran (#2531).

This is **PR A** in the gallery-fidelity stack (#2531 → #2707 → #2430, with #2533 the paid recovery sweep). It lands the shared write helper that the caption reroute (#2707) and the batch path (#2430) build on. No caption-behavior change here — pure write-path consolidation.

## What
- **New shared helper, twin pair:** `scripts/lib/gallery-doc.mjs` + `src/lib/gallery-doc.ts` — `buildGalleryDoc({ page, book, detectedImage, index, ... })` is now the single source of truth for the gallery doc field set.
- **Realtime worker** (`image-extract-worker.mjs`) now writes **fully self-sufficient** docs via the helper — `book_visible`, `image_url`, `page_number`, `book_title/author/year/language/hidden/provider` — so re-extraction makes images appear in `/api/gallery?bookId=…` with **no separate sync**. Its book projection was extended to include `visible/hidden/display_title/image_source.provider` (the root omission behind #2531).
- **SQS path** (`image-extraction-processor-logic.ts`) routes through the same helper; preserves its scan-quality adjustment and provisional `book_rank: 0`.
- **Aggregation writers** (admin `sync-gallery-images` route, `sync-worker.mjs`): project the previously-missing provenance fields (`model`/`detected_at`/`gallery_rationale`) plus `book_visible`/`book_provider`; the admin route switches `whenMatched: 'replace' → 'merge'` so a re-sync no longer **wipes** worker-only fields (`scan_quality`, `page_image_characteristics`) the aggregation can't reconstruct.
- **Guard test** (`tests/unit/gallery-doc-schema.test.ts`) pins the canonical key set across both twins and asserts the #2531 fields are present — so the writers can't silently drift again.

## Scope / out of scope
- **In:** the field-set consolidation + worker self-sufficiency (the #2531 acceptance).
- **Out (deliberate):** `sync-worker`'s crop-preferred `image_url` resolution is left untouched — it has a documented IIIF-leak rationale (preferring the CDN crop over upstream Gallica/BSB URLs), so changing it is a separate decision, not a mechanical refactor. The two Mongo-aggregation writers still mirror the key set by hand (they build docs server-side via `$project`); the helper docstring + guard test note this.
- **Not touched:** gallery API filters; the paid re-caption/recovery work (#2533).

## Test
- `tests/unit/gallery-doc-schema.test.ts` (10 tests) — twins agree, schema is complete, #2531 fields present.
- `npx tsc --noEmit` clean; `node --check` on all modified workers; existing `page-image-url` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)