### PR TITLE
fix(pipeline): selective-unpause strands scoped books behind backlog (phase-local limits + Phase 1.97 scope)

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2871,7 +2871,11 @@ async function run() {
     if (shouldRun(1.25)) {
       console.log('\n--- Phase 1.25: Split detection (AR screen → Gemini confirm) ---');
 
-      const SPLIT_LIMIT = 100; // Max books per cycle
+      // Scoped mode raises the window so allowlisted books behind the backlog
+      // aren't stranded (work stays confined by applyBookOverride below). The
+      // module-level phase limits get this raise already; phase-local consts
+      // like this one were missed — the selective-unpause stall bug.
+      const SPLIT_LIMIT = SCOPED_MODE ? 100000 : 100; // Max books per cycle
       const ASPECT_RATIO_THRESHOLD = 1.2; // Width/height > 1.2 = likely spread
 
       // Find archive_complete books that haven't been split-checked yet
@@ -3067,7 +3071,7 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
     if (shouldRun(1.3)) {
       console.log('\n--- Phase 1.3: Pre-OCR spread split (gutter-only) ---');
 
-      const PRE_SPLIT_LIMIT = 8; // each book downloads + crops + uploads all its images
+      const PRE_SPLIT_LIMIT = SCOPED_MODE ? 100000 : 8; // each book downloads + crops + uploads all its images (scoped mode raises the window; work confined by applyBookOverride below)
 
       let readyForPreSplit = await db.collection('books')
         .find({
@@ -3760,13 +3764,18 @@ Rules:
     // Independently pausable via paused_phases:[1.97]. When paused, Phase 2's
     // dedup_complete gate is relaxed (see below) so books flow straight to OCR.
     if (shouldRun(1.97)) {
-      const DEDUP_LIMIT = 50;        // per tick — bounds runtime (~30+ R2 HEADs/book); drains backlog across ticks
+      const DEDUP_LIMIT = SCOPED_MODE ? 100000 : 50;  // per tick — bounds runtime (~30+ R2 HEADs/book); drains backlog across ticks. Scoped mode raises the window so allowlisted books behind the backlog aren't stranded (work confined by the scope filter below).
       const DEDUP_MAX_ATTEMPTS = 3;  // transient-failure giveup; release the book so Phase 2 isn't blocked forever
-      const candidates = await db.collection('books').find({
+      let candidates = await db.collection('books').find({
         'pipeline_auto.status': 'archive_complete',
         'pipeline_auto.dedup_complete': { $ne: true },
       }).project({ id: 1, title: 1, pages_count: 1, 'pipeline_auto.dedup_attempts': 1 })
         .limit(DEDUP_LIMIT).toArray();
+      // Selective-unpause: confine dedup to the allowlist, like every other phase.
+      // This phase previously had NO scope filter, so when globally paused with a
+      // scope set, scoped books behind the backlog never got dedup_complete and
+      // stalled at Phase 2's dedup gate (never reaching OCR).
+      if (SCOPE_ACTIVE) candidates = await applyBookOverride(db, candidates, { id: 1, title: 1, pages_count: 1, 'pipeline_auto.dedup_attempts': 1 });
 
       if (candidates.length > 0) {
         console.log('\n--- Phase 1.97: Trailing-dupe dedup ---');
@@ -4242,7 +4251,7 @@ Rules:
     if (shouldRun(3.1) || shouldRun(3)) {
       console.log('\n--- Phase 3.1: Post-OCR spread split ---');
 
-      const SPLIT_BATCH_LIMIT = 10; // Books per cycle (each book is heavy: downloads + crops + uploads)
+      const SPLIT_BATCH_LIMIT = SCOPED_MODE ? 100000 : 10; // Books per cycle (each book is heavy: downloads + crops + uploads; scoped mode raises the window, work confined by applyBookOverride below)
 
       let readyForSplit = await db.collection('books')
         .find({


### PR DESCRIPTION
## Problem

Selective unpause (`processing_control.allow_book_ids` / `allow_collections`) is supposed to let a chosen set of books run while the global OCR pause holds. In scoped mode the orchestrator raises every phase's candidate-window limit to 100000 so allowlisted books aren't crowded out by the backlog, then each phase post-filters to the allowlist via `applyBookOverride`.

**The raise only covered the module-level limit vars.** Four phase-**local** `const` limits were missed, so any scoped book sitting behind a large backlog never entered those phases' first-N window and **silently stalled — never reaching OCR**:

| Phase | Limit | Was |
|---|---|---|
| 1.25 split-check | `SPLIT_LIMIT` | 100 |
| 1.3 pre-OCR spread split | `PRE_SPLIT_LIMIT` | 8 |
| 3.1 post-OCR spread split | `SPLIT_BATCH_LIMIT` | 10 |
| 1.97 trailing-dupe dedup | `DEDUP_LIMIT` | 50 |

Phase **1.97 was worse**: it had **no `applyBookOverride` at all**, so in scoped mode it processed the *global* first-50 `archive_complete` books and never set `dedup_complete` on the scoped ones — which then failed Phase 2's `dedup_complete` gate, so they never OCR'd even if split-check passed.

## Observed live

A scoped hidden import sat behind ~1,189 hidden `archive_complete` books awaiting split-check. Phase 1.25 fetched the first 100 (sorted visible-first) then scope-filtered → **0 candidates**. The book stalled at `archive_complete`, OCR frozen at the 25-page preview, while the orchestrator logged `[healthy] … O:0`. This is a cause of the cannabis run (#2610) and any scoped batch stalling.

## Fix

- Raise the four phase-local limits to 100000 **in scoped mode only** (`SCOPED_MODE ? 100000 : <default>`) — work stays confined to the allowlist by the existing/added scope filter; this only widens the candidate window.
- Add the missing `applyBookOverride` scope filter to Phase 1.97.

## Out of scope / deliberate

- Warehouse phases (`WAREHOUSE_ARCHIVE_CHECK_LIMIT`, `PROMOTE_LIMIT`) operate on `books_warehouse` and aren't part of the selective-unpause scope flow — left unchanged.
- **Normal (non-scoped) operation is unchanged** — limits keep their defaults unless `SCOPED_MODE`.
- No unit test: the logic lives in the monolithic orchestrator worker (not structured for unit testing this path without a refactor). Verified via `node --check` + a scoped `--dry-run` (runs clean) and against the documented failure mode above.

## Deploy note

This is a `scripts/**` worker — the Hetzner box auto-pulls `main` every ~5 min, so it goes live on merge with no Vercel deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)