### PR TITLE
fix(image-extraction): ground caption subject in page text, not a topic guess (#2707)

### DIFF
--- a/scripts/lib/page-grounding.mjs
+++ b/scripts/lib/page-grounding.mjs
@@ -1,0 +1,171 @@
+/**
+ * page-grounding.mjs — build the PAGE TEXT CONTEXT block fed to the image
+ * captioner so it identifies an illustration's SUBJECT from the page's own
+ * transcription instead of guessing from the book's topic (#2707).
+ *
+ * Principle: subject identity of a figurative scene is a text-grounded fact,
+ * not a pixel fact. The OCR pass already read the caption/labels printed beside
+ * the picture; this surfaces them to the vision pass with an explicit authority
+ * hierarchy so a neighbour's topic can never override what's labelled on THIS
+ * page (the "wrestlers → gymnosophists" failure).
+ *
+ * Authority, high → low:
+ *   1. <image-desc> labelled ON this page (all of them, in order)
+ *   2. this page's <summary>
+ *   3. nearest substantive neighbour page (only when text-dense around the image)
+ *   4. the book summary (last resort — only for a plate isolated among blanks)
+ *
+ * Text input is ~free next to the image, so we supplement generously; but when
+ * an illustration sits among blank pages there are no useful neighbours, so we
+ * fall back to the book summary rather than padding the prompt with blanks.
+ *
+ * TS twin: `src/lib/page-grounding.ts` (keep in sync; guard test
+ * `tests/unit/page-grounding.test.ts` pins both).
+ */
+
+// Mirror of SKIP_MARKUP_RULES in src/lib/image-extraction-filter.ts — drop
+// drop-caps, stamps, ornaments etc. so they don't pose as the illustration.
+const TRIVIAL_RULES = [
+  { type: 'symbol', significance: '*' },
+  { type: 'stamp', significance: '*' },
+  { type: 'ornament', significance: '*' },
+  { type: 'blank', significance: '*' },
+  { type: 'exlibris', significance: '*' },
+  { type: 'bookplate', significance: '*' },
+  { type: 'decorative', significance: 'low' },
+  { type: "printer's mark", significance: 'low' },
+  { type: 'photograph', significance: 'low' },
+  { type: 'photographic', significance: 'low' },
+];
+
+/** A page with < this many stripped body chars is "sparse" (likely a plate or blank). */
+export const SUBSTANTIVE_CHARS = 200;
+
+const IMG_DESC_RE = /<image-desc([^>]*)>([\s\S]*?)<\/image-desc>/gi;
+const SUMMARY_RE = /<summary>([\s\S]*?)<\/summary>/i;
+
+function isTrivial(type, sig) {
+  return TRIVIAL_RULES.some(
+    (r) => r.type === type && (r.significance === '*' || r.significance === sig),
+  );
+}
+
+/** All non-trivial <image-desc> descriptions, in document order. Reads the
+ *  first source that carries any (OCR usually; translation as fallback). */
+export function extractImageDescs(...sources) {
+  for (const src of sources) {
+    if (!src) continue;
+    const out = [];
+    for (const m of src.matchAll(IMG_DESC_RE)) {
+      const attrs = m[1] || '';
+      const type = (attrs.match(/type="([^"]+)"/) || [])[1] || null;
+      const sig = (attrs.match(/significance="([^"]+)"/) || [])[1] || null;
+      const desc = (m[2] || '').trim();
+      if (!desc) continue;
+      if (isTrivial(type, sig)) continue;
+      out.push(desc);
+    }
+    if (out.length) return out;
+  }
+  return [];
+}
+
+function firstSummary(...sources) {
+  for (const src of sources) {
+    if (!src) continue;
+    const m = src.match(SUMMARY_RE);
+    if (m && m[1].trim()) return m[1].trim();
+  }
+  return '';
+}
+
+/** Strip all tags and collapse whitespace — the page's readable body text. */
+export function strippedBody(text) {
+  if (!text) return '';
+  return text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Build the grounding block.
+ *
+ * @param {object}   p
+ * @param {string}   [p.ocr]          this page's ocr.data
+ * @param {string}   [p.translation]  this page's translation.data
+ * @param {number}   [p.pageNumber]   this page's page_number (for neighbour distance)
+ * @param {Array<{page_number:number, ocr?:string, translation?:string}>} [p.neighbors]
+ *                                    nearby pages (need NOT be illustration pages)
+ * @param {string}   [p.bookSummary]  book-level summary, isolated-plate fallback
+ * @param {number}   [p.radius]       neighbour search radius in pages (default 3)
+ * @returns {string} grounding text (prefixed with a newline) or '' if nothing to add
+ */
+export function buildPageGrounding({
+  ocr,
+  translation,
+  pageNumber,
+  neighbors = [],
+  bookSummary = '',
+  radius = 3,
+} = {}) {
+  const imageDescs = extractImageDescs(ocr, translation);
+  const pageSummary = firstSummary(translation, ocr);
+  const localBody = strippedBody(ocr || translation);
+
+  // Nearest neighbour with substantive text within radius (skip blanks).
+  let neighborLine = '';
+  if (typeof pageNumber === 'number' && neighbors.length) {
+    const near = neighbors
+      .filter((n) => typeof n.page_number === 'number' && n.page_number !== pageNumber)
+      .map((n) => ({
+        dist: Math.abs(n.page_number - pageNumber),
+        signed: n.page_number - pageNumber,
+        page_number: n.page_number,
+        summary: firstSummary(n.translation, n.ocr),
+        body: strippedBody(n.ocr || n.translation),
+      }))
+      .filter((n) => n.dist <= radius && (n.summary || n.body.length >= SUBSTANTIVE_CHARS))
+      .sort((a, b) => a.dist - b.dist)[0];
+    if (near) {
+      const txt = near.summary || near.body.slice(0, 400);
+      const rel = near.signed < 0 ? `${near.dist} page(s) before` : `${near.dist} page(s) after`;
+      neighborLine = `Nearby text (page ${near.page_number}, ${rel}): ${txt}`;
+    }
+  }
+
+  // Isolated plate: little local text AND no usable neighbour → lean on the book.
+  const isolated = localBody.length < SUBSTANTIVE_CHARS && !neighborLine;
+
+  const lines = [];
+  if (imageDescs.length === 1) {
+    lines.push(
+      `Illustration labelled/transcribed ON this page (highest authority — describe THIS subject): ${imageDescs[0]}`,
+    );
+  } else if (imageDescs.length > 1) {
+    lines.push(
+      'Illustrations labelled/transcribed ON this page (highest authority — match each to what you see, in order):',
+    );
+    imageDescs.forEach((d, i) => lines.push(`  ${i + 1}. ${d}`));
+  }
+  if (pageSummary) lines.push(`Page summary: ${pageSummary}`);
+  if (neighborLine) lines.push(neighborLine);
+  if (isolated && bookSummary) {
+    lines.push(
+      `Book context (last resort only — lower authority than anything above; never use it to override a label on this image): ${bookSummary.slice(0, 500)}`,
+    );
+  }
+
+  // Nothing structured — fall back to raw page text, then the book summary.
+  if (lines.length === 0) {
+    const txt = localBody.slice(0, 1200);
+    if (txt) lines.push(`Page text (transcribed): ${txt}`);
+    else if (bookSummary) lines.push(`Book context (no page text available): ${bookSummary.slice(0, 500)}`);
+  }
+
+  if (lines.length === 0) return '';
+  return (
+    "\nPAGE TEXT CONTEXT — grounded in the page's own transcription. Identify the " +
+    "illustration's SUBJECT from this text; the book's general topic is background " +
+    'only and must NEVER override a caption or label that appears on this page:\n' +
+    lines.join('\n') +
+    '\n'
+  );
+}

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -18,6 +18,7 @@ import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI, SchemaType } from '@google/generative-ai';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { buildGalleryDoc } from '../lib/gallery-doc.mjs';
+import { buildPageGrounding } from '../lib/page-grounding.mjs';
 import { nanoid } from 'nanoid';
 import sharp from 'sharp';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
@@ -688,25 +689,24 @@ async function revalidateBookPage(bookId) {
 }
 
 // ── Process one page ──
-/** Context-grounded page description from the OCR/translation pass (which read the
- *  whole page). Feeding the captioner its `<image-desc>` / `<summary>` stops it
- *  inventing a subject from the book's topic alone (e.g. wrestlers → "gymnosophists").
- *  ~100-150 tokens; the data is already on the page doc. */
-function buildPageGrounding(page) {
-  const ocr = page?.ocr?.data || '';
-  const tr = page?.translation?.data || '';
-  const imgDesc = (ocr.match(/<image-desc[^>]*>([\s\S]*?)<\/image-desc>/i)
-    || tr.match(/<image-desc[^>]*>([\s\S]*?)<\/image-desc>/i))?.[1]?.trim();
-  const summary = (tr.match(/<summary>([\s\S]*?)<\/summary>/i)
-    || ocr.match(/<summary>([\s\S]*?)<\/summary>/i))?.[1]?.trim();
-  const lines = [];
-  if (imgDesc) lines.push(`Illustration on this page, transcribed FROM the page itself: ${imgDesc}`);
-  if (summary) lines.push(`Page summary: ${summary}`);
-  if (lines.length === 0) return '';
-  return `\nPAGE TEXT CONTEXT — written with the page's full text and any caption/label in view. Trust it over the book's general subject; do NOT name a figure or scene it contradicts:\n${lines.join('\n')}\n`;
+const GROUNDING_RADIUS = 3; // pages each side scanned for substantive neighbour text
+
+/** Window of nearby page docs (page_number ± GROUNDING_RADIUS) for a page,
+ *  shaped for buildPageGrounding(). Neighbours need NOT be illustration pages —
+ *  they supply the surrounding narrative (or, when blank, trigger the book-summary
+ *  fallback). */
+function neighborsFor(pageNumber, pagesByNumber) {
+  if (typeof pageNumber !== 'number') return [];
+  const out = [];
+  for (let n = pageNumber - GROUNDING_RADIUS; n <= pageNumber + GROUNDING_RADIUS; n++) {
+    if (n === pageNumber) continue;
+    const p = pagesByNumber.get(n);
+    if (p) out.push({ page_number: n, ocr: p.ocr?.data, translation: p.translation?.data });
+  }
+  return out;
 }
 
-async function extractImagesFromPage(page, prompt, db, bookId) {
+async function extractImagesFromPage(page, prompt, groundingCtx) {
   const url = getPageImageUrl(page);
   if (!url || (!url.startsWith('http://') && !url.startsWith('https://'))) return null;
 
@@ -734,8 +734,17 @@ async function extractImagesFromPage(page, prompt, db, bookId) {
     },
   });
 
+  const grounding = buildPageGrounding({
+    ocr: page?.ocr?.data,
+    translation: page?.translation?.data,
+    pageNumber: page?.page_number,
+    neighbors: neighborsFor(page?.page_number, groundingCtx?.pagesByNumber || new Map()),
+    bookSummary: groundingCtx?.bookSummary || '',
+    radius: GROUNDING_RADIUS,
+  });
+
   const result = await model.generateContent([
-    { text: prompt + buildPageGrounding(page) },
+    { text: prompt + grounding },
     { inlineData: { mimeType: image.mimeType, data: image.data } },
   ]);
 
@@ -804,6 +813,29 @@ async function processBook(db, book) {
     : '';
   const prompt = contextPrefix + IMAGE_EXTRACTION_PROMPT;
 
+  // Surrounding-text grounding (#2707): fetch the page window around each
+  // illustration so the captioner can read the narrative the picture sits in.
+  // Neighbours are usually NOT illustration pages (text / blank), so they need a
+  // separate light fetch. One query per book over the union of windows. When an
+  // illustration is isolated among blanks, buildPageGrounding falls back to the
+  // book summary instead.
+  const candidateNumbers = candidatePages.map(p => p.page_number).filter(n => typeof n === 'number');
+  const windowNumbers = new Set();
+  for (const n of candidateNumbers) {
+    for (let d = -GROUNDING_RADIUS; d <= GROUNDING_RADIUS; d++) windowNumbers.add(n + d);
+  }
+  const pagesByNumber = new Map();
+  if (windowNumbers.size > 0) {
+    const windowPages = await db.collection('pages')
+      .find(
+        { book_id: book.id, page_number: { $in: [...windowNumbers] } },
+        { projection: { page_number: 1, 'ocr.data': 1, 'translation.data': 1 } },
+      )
+      .toArray();
+    for (const wp of windowPages) pagesByNumber.set(wp.page_number, wp);
+  }
+  const groundingCtx = { pagesByNumber, bookSummary: book.summary || '' };
+
   const now = new Date();
   let totalImages = 0;
   let pagesProcessed = 0;
@@ -816,7 +848,7 @@ async function processBook(db, book) {
   for (let i = 0; i < candidatePages.length; i += PAGE_CONCURRENCY) {
     const chunk = candidatePages.slice(i, i + PAGE_CONCURRENCY);
     const results = await Promise.allSettled(
-      chunk.map(page => extractImagesFromPage(page, prompt, db, book.id))
+      chunk.map(page => extractImagesFromPage(page, prompt, groundingCtx))
     );
 
     for (const settled of results) {
@@ -1021,7 +1053,7 @@ async function main() {
   const books = await db.collection('books')
     .find({ 'pipeline_auto.status': 'chapters_complete', ...SCOPE_FILTER })
     .sort({ processing_priority: -1, hidden: 1 })
-    .project({ id: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, subjects: 1, visible: 1, hidden: 1, 'image_source.provider': 1 })
+    .project({ id: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, subjects: 1, summary: 1, visible: 1, hidden: 1, 'image_source.provider': 1 })
     .limit(BOOKS_PER_RUN)
     .toArray();
 
@@ -1038,7 +1070,7 @@ async function main() {
         ...SCOPE_FILTER,
       })
       .sort({ visible: -1, pages_count: -1 })
-      .project({ id: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, subjects: 1, visible: 1, hidden: 1, 'image_source.provider': 1 })
+      .project({ id: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, subjects: 1, summary: 1, visible: 1, hidden: 1, 'image_source.provider': 1 })
       .limit(BOOKS_PER_RUN - books.length)
       .toArray();
     if (catchUp.length > 0) {

--- a/src/lib/image-extraction.ts
+++ b/src/lib/image-extraction.ts
@@ -6,6 +6,7 @@
 import Replicate from 'replicate';
 import { images } from '@/lib/api-client';
 import { buildClassificationPrompt, getClassificationSystems } from '@/lib/iconography';
+import { buildPageGrounding as buildGroundingBlock } from '@/lib/page-grounding';
 
 export const IMAGE_EXTRACTION_PROMPT = `You are a museum curator analyzing a historical book page scan. Extract only significant illustrations — skip decorative elements like ornaments, borders, printer's marks, and initials.
 
@@ -86,21 +87,11 @@ function buildContextPrefix(ctx: BookContext): string {
 /** Pull the transcription pipeline's own page/illustration context. Unlike this
  *  image-only captioner, the OCR pass read the whole page (text, captions, marginal
  *  labels), so its `<image-desc>` / `<summary>` are context-grounded — feeding them
- *  here stops the captioner inventing a subject from the book's topic alone.
- *  Cheap: ~100-150 tokens, already stored on the page. */
+ *  here stops the captioner inventing a subject from the book's topic alone (#2707).
+ *  Delegates to the shared grounding builder (page-only mode; the realtime worker
+ *  additionally supplies neighbour + book-summary context). */
 function buildPageGrounding(ocrData?: string): string {
-  if (!ocrData) return '';
-  const imgDesc = ocrData.match(/<image-desc[^>]*>([\s\S]*?)<\/image-desc>/i)?.[1]?.trim();
-  const summary = ocrData.match(/<summary>([\s\S]*?)<\/summary>/i)?.[1]?.trim();
-  const lines: string[] = [];
-  if (imgDesc) lines.push(`Illustration on this page, transcribed FROM the page itself: ${imgDesc}`);
-  if (summary) lines.push(`Page summary: ${summary}`);
-  if (lines.length === 0) {
-    const txt = ocrData.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 1200);
-    if (txt) lines.push(`Page text (transcribed): ${txt}`);
-  }
-  if (lines.length === 0) return '';
-  return `\nPAGE TEXT CONTEXT — written with the page's full text and any caption/label in view. Trust it over the book's general subject; do NOT name a figure or scene it contradicts:\n${lines.join('\n')}\n`;
+  return buildGroundingBlock({ ocr: ocrData });
 }
 
 export interface ImageMetadata {

--- a/src/lib/page-grounding.ts
+++ b/src/lib/page-grounding.ts
@@ -1,0 +1,153 @@
+/**
+ * page-grounding.ts — TS twin of `scripts/lib/page-grounding.mjs`.
+ *
+ * Builds the PAGE TEXT CONTEXT block fed to the image captioner so it identifies
+ * an illustration's SUBJECT from the page's own transcription instead of the
+ * book's topic (#2707). See the `.mjs` twin for the full rationale and the
+ * authority hierarchy. Keep the two in sync — the guard test
+ * `tests/unit/page-grounding.test.ts` pins both.
+ */
+
+// Mirror of SKIP_MARKUP_RULES in image-extraction-filter.ts.
+const TRIVIAL_RULES: ReadonlyArray<{ type: string; significance: string }> = [
+  { type: 'symbol', significance: '*' },
+  { type: 'stamp', significance: '*' },
+  { type: 'ornament', significance: '*' },
+  { type: 'blank', significance: '*' },
+  { type: 'exlibris', significance: '*' },
+  { type: 'bookplate', significance: '*' },
+  { type: 'decorative', significance: 'low' },
+  { type: "printer's mark", significance: 'low' },
+  { type: 'photograph', significance: 'low' },
+  { type: 'photographic', significance: 'low' },
+];
+
+/** A page with < this many stripped body chars is "sparse" (plate or blank). */
+export const SUBSTANTIVE_CHARS = 200;
+
+const IMG_DESC_RE = /<image-desc([^>]*)>([\s\S]*?)<\/image-desc>/gi;
+const SUMMARY_RE = /<summary>([\s\S]*?)<\/summary>/i;
+
+function isTrivial(type: string | null, sig: string | null): boolean {
+  return TRIVIAL_RULES.some(
+    (r) => r.type === type && (r.significance === '*' || r.significance === sig),
+  );
+}
+
+/** All non-trivial <image-desc> descriptions, in document order. */
+export function extractImageDescs(...sources: Array<string | null | undefined>): string[] {
+  for (const src of sources) {
+    if (!src) continue;
+    const out: string[] = [];
+    for (const m of src.matchAll(IMG_DESC_RE)) {
+      const attrs = m[1] || '';
+      const type = (attrs.match(/type="([^"]+)"/) || [])[1] || null;
+      const sig = (attrs.match(/significance="([^"]+)"/) || [])[1] || null;
+      const desc = (m[2] || '').trim();
+      if (!desc) continue;
+      if (isTrivial(type, sig)) continue;
+      out.push(desc);
+    }
+    if (out.length) return out;
+  }
+  return [];
+}
+
+function firstSummary(...sources: Array<string | null | undefined>): string {
+  for (const src of sources) {
+    if (!src) continue;
+    const m = src.match(SUMMARY_RE);
+    if (m && m[1].trim()) return m[1].trim();
+  }
+  return '';
+}
+
+/** Strip all tags and collapse whitespace — the page's readable body text. */
+export function strippedBody(text: string | null | undefined): string {
+  if (!text) return '';
+  return text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export interface GroundingNeighbor {
+  page_number: number;
+  ocr?: string | null;
+  translation?: string | null;
+}
+
+export interface BuildPageGroundingArgs {
+  ocr?: string | null;
+  translation?: string | null;
+  pageNumber?: number;
+  neighbors?: GroundingNeighbor[];
+  bookSummary?: string;
+  radius?: number;
+}
+
+export function buildPageGrounding({
+  ocr,
+  translation,
+  pageNumber,
+  neighbors = [],
+  bookSummary = '',
+  radius = 3,
+}: BuildPageGroundingArgs = {}): string {
+  const imageDescs = extractImageDescs(ocr, translation);
+  const pageSummary = firstSummary(translation, ocr);
+  const localBody = strippedBody(ocr || translation);
+
+  let neighborLine = '';
+  if (typeof pageNumber === 'number' && neighbors.length) {
+    const near = neighbors
+      .filter((n) => typeof n.page_number === 'number' && n.page_number !== pageNumber)
+      .map((n) => ({
+        dist: Math.abs(n.page_number - pageNumber),
+        signed: n.page_number - pageNumber,
+        page_number: n.page_number,
+        summary: firstSummary(n.translation, n.ocr),
+        body: strippedBody(n.ocr || n.translation),
+      }))
+      .filter((n) => n.dist <= radius && (!!n.summary || n.body.length >= SUBSTANTIVE_CHARS))
+      .sort((a, b) => a.dist - b.dist)[0];
+    if (near) {
+      const txt = near.summary || near.body.slice(0, 400);
+      const rel = near.signed < 0 ? `${near.dist} page(s) before` : `${near.dist} page(s) after`;
+      neighborLine = `Nearby text (page ${near.page_number}, ${rel}): ${txt}`;
+    }
+  }
+
+  const isolated = localBody.length < SUBSTANTIVE_CHARS && !neighborLine;
+
+  const lines: string[] = [];
+  if (imageDescs.length === 1) {
+    lines.push(
+      `Illustration labelled/transcribed ON this page (highest authority — describe THIS subject): ${imageDescs[0]}`,
+    );
+  } else if (imageDescs.length > 1) {
+    lines.push(
+      'Illustrations labelled/transcribed ON this page (highest authority — match each to what you see, in order):',
+    );
+    imageDescs.forEach((d, i) => lines.push(`  ${i + 1}. ${d}`));
+  }
+  if (pageSummary) lines.push(`Page summary: ${pageSummary}`);
+  if (neighborLine) lines.push(neighborLine);
+  if (isolated && bookSummary) {
+    lines.push(
+      `Book context (last resort only — lower authority than anything above; never use it to override a label on this image): ${bookSummary.slice(0, 500)}`,
+    );
+  }
+
+  if (lines.length === 0) {
+    const txt = localBody.slice(0, 1200);
+    if (txt) lines.push(`Page text (transcribed): ${txt}`);
+    else if (bookSummary) lines.push(`Book context (no page text available): ${bookSummary.slice(0, 500)}`);
+  }
+
+  if (lines.length === 0) return '';
+  return (
+    "\nPAGE TEXT CONTEXT — grounded in the page's own transcription. Identify the " +
+    "illustration's SUBJECT from this text; the book's general topic is background " +
+    'only and must NEVER override a caption or label that appears on this page:\n' +
+    lines.join('\n') +
+    '\n'
+  );
+}

--- a/tests/unit/page-grounding.test.ts
+++ b/tests/unit/page-grounding.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { buildPageGrounding, extractImageDescs, SUBSTANTIVE_CHARS } from '@/lib/page-grounding';
+import {
+  buildPageGrounding as buildPageGroundingJs,
+  extractImageDescs as extractImageDescsJs,
+} from '../../scripts/lib/page-grounding.mjs';
+
+// The captioner used to guess an illustration's subject from the book's topic
+// (wrestlers → "gymnosophists"). Grounding feeds it the page's own transcription
+// with an explicit authority hierarchy so a topic prior can't override a label
+// printed on the page (#2707).
+
+const LONG = 'x '.repeat(SUBSTANTIVE_CHARS); // > substantive threshold
+
+describe('extractImageDescs', () => {
+  it('returns ALL non-trivial descriptions in order (not just the first)', () => {
+    const ocr =
+      '<image-desc type="illustration">Two wrestlers grappling</image-desc> body ' +
+      '<image-desc type="illustration">A king observing</image-desc>';
+    expect(extractImageDescs(ocr)).toEqual(['Two wrestlers grappling', 'A king observing']);
+  });
+
+  it('drops trivial markup (drop-caps, ornaments, stamps)', () => {
+    const ocr =
+      '<image-desc type="ornament">Ornamental initial C</image-desc>' +
+      '<image-desc type="illustration">A real engraving</image-desc>' +
+      '<image-desc type="stamp">Library stamp</image-desc>';
+    expect(extractImageDescs(ocr)).toEqual(['A real engraving']);
+  });
+
+  it('falls back to translation when OCR has none', () => {
+    expect(extractImageDescs('', '<image-desc>From translation</image-desc>')).toEqual([
+      'From translation',
+    ]);
+  });
+});
+
+describe('buildPageGrounding authority + adaptivity', () => {
+  it('puts the on-page label first and warns against topic override', () => {
+    const g = buildPageGrounding({
+      ocr: '<image-desc type="illustration">Two wrestlers grappling</image-desc>',
+    });
+    expect(g).toContain('highest authority');
+    expect(g).toContain('Two wrestlers grappling');
+    expect(g).toContain('NEVER override');
+  });
+
+  it('lists multiple illustrations as a numbered, ordered list', () => {
+    const g = buildPageGrounding({
+      ocr:
+        '<image-desc type="illustration">First scene</image-desc>' +
+        '<image-desc type="illustration">Second scene</image-desc>',
+    });
+    expect(g).toContain('match each to what you see, in order');
+    expect(g).toContain('1. First scene');
+    expect(g).toContain('2. Second scene');
+  });
+
+  it('uses a substantive neighbour when the page sits in running text', () => {
+    const g = buildPageGrounding({
+      ocr: '<image-desc type="illustration">A scene</image-desc>',
+      pageNumber: 10,
+      neighbors: [
+        { page_number: 9, ocr: 'blank' },
+        { page_number: 11, ocr: `<summary>The chapter discusses the Isthmian games.</summary> ${LONG}` },
+      ],
+    });
+    expect(g).toContain('Nearby text (page 11');
+    expect(g).toContain('Isthmian games');
+  });
+
+  it('falls back to the book summary for a plate isolated among blanks', () => {
+    const g = buildPageGrounding({
+      ocr: '<image-desc type="illustration">A full-page plate</image-desc>',
+      pageNumber: 5,
+      neighbors: [
+        { page_number: 4, ocr: '' },
+        { page_number: 6, ocr: '<page-type>blank</page-type>' },
+      ],
+      bookSummary: 'An alchemical emblem book by Michael Maier.',
+    });
+    expect(g).toContain('Book context (last resort only');
+    expect(g).toContain('Michael Maier');
+    expect(g).not.toContain('Nearby text');
+  });
+
+  it('does NOT add the book summary when a good neighbour exists', () => {
+    const g = buildPageGrounding({
+      ocr: '<image-desc type="illustration">A scene</image-desc>',
+      pageNumber: 10,
+      neighbors: [{ page_number: 11, ocr: `running narrative text ${LONG}` }],
+      bookSummary: 'Should not appear.',
+    });
+    expect(g).toContain('Nearby text (page 11');
+    expect(g).not.toContain('Should not appear');
+  });
+
+  it('returns empty string when there is nothing to ground on', () => {
+    expect(buildPageGrounding({ ocr: '', translation: '' })).toBe('');
+  });
+
+  it('ignores blank/sparse neighbours (no Nearby text line)', () => {
+    const g = buildPageGrounding({
+      ocr: '<image-desc type="illustration">A scene</image-desc>',
+      pageNumber: 10,
+      neighbors: [{ page_number: 11, ocr: 'tiny' }],
+    });
+    expect(g).not.toContain('Nearby text');
+  });
+});
+
+describe('twin parity (mjs vs ts)', () => {
+  const fixtures = [
+    { ocr: '<image-desc type="illustration">Two wrestlers</image-desc><image-desc>A king</image-desc>' },
+    {
+      ocr: '<image-desc type="illustration">A plate</image-desc>',
+      pageNumber: 5,
+      neighbors: [{ page_number: 6, ocr: `narrative ${LONG}` }],
+      bookSummary: 'Book about X.',
+    },
+    { ocr: '', translation: '', bookSummary: 'fallback' },
+  ];
+  it('produces identical output across both twins', () => {
+    for (const f of fixtures) {
+      expect(buildPageGrounding(f as never)).toBe(buildPageGroundingJs(f));
+      expect(extractImageDescs(f.ocr)).toEqual(extractImageDescsJs(f.ocr));
+    }
+  });
+});


### PR DESCRIPTION
## Why
The gallery captioner (`museum_description`) described each illustration from **pixels + the book's topic**, blind to the page's own text. On ambiguous figurative scenes with a strong topical prior it confabulated a subject — the canonical case: a **wrestling match** in the *Romance of Alexander* captioned *"Alexander engaging with three gymnosophists,"* when the page's own OCR `<image-desc>` already said *"wrestlers… grappling"* and the margin glosses literally read *"wrestlers."*

**Subject identity of a figurative scene is a text-grounded fact, not a pixel fact** — the label beside the picture answers "wrestlers or gymnosophists," not the bodies. So this strengthens the page-text grounding fed to the vision pass (and stops it re-identifying from the topic) rather than adding a second vision pass.

**PR B** in the gallery-fidelity stack — **stacked on #2531 (PR #2712)**; review/merge that first. Per our design discussion, this is the "strong grounding, one pass" approach (not a divergence-override branch): ground the single vision call hard with the cheap page text we already have, and keep the free divergence detector as a QA gate, not runtime logic.

## What
- **New shared grounding builder** (twin pair `scripts/lib/page-grounding.mjs` + `src/lib/page-grounding.ts`) with an explicit **authority hierarchy**: on-page `<image-desc>` (ALL of them, in order) → page `<summary>` → nearest substantive neighbour page → book summary — plus an instruction that the book's topic is background and must **NEVER** override a label on this page.
- **Fixes the first-`<image-desc>`-only bug.** The old grounding grabbed only the first match; multi-illustration pages now list every illustration, which also lets the model map descriptions to the regions it sees (the issue's "key open question").
- **Adaptive surrounding context** (your point — text is ~free next to the image): the realtime worker fetches the page window (±3). When an illustration sits in **running text**, it feeds the nearest substantive neighbour; when it's a **plate isolated among blank pages**, it falls back to the **book summary** instead of padding the prompt with blanks. Same bias caution — neighbour/book topic ranks *below* the on-page label.
- Worker `book` projection gains `summary`; the SQS/API path (`image-extraction.ts`) routes its grounding through the same builder (page-only mode).
- **Guard test** pins the authority order, the multi-desc listing, neighbour-vs-isolated-plate fallback, and mjs/ts twin parity.

## Validated
- 11 grounding tests + 10 schema tests pass; `tsc --noEmit` clean; `node --check` on the worker.
- Ran the builder against live page data — it emits the ordered multi-illustration list + nearby-page context exactly as designed.

## Out of scope
- Re-captioning existing images (paid Gemini run — size from the detector + a cheap judge first, #2707 notes).
- Orchestrator batch JSONL builders (#2430) — same builder, follow-up.
- The divergence detector stays a measurement/QA gate, not a runtime override (by design — earn extra logic with evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)