### PR TITLE
fix(image-extraction): batch path adopts gallery-fidelity helpers (#2707, #2430)

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -22,6 +22,7 @@ import { GoogleGenAI } from '@google/genai';
 import { logUsageAsync } from './lib/supabase-usage-logger.mjs';
 import { syncPageBatch } from './lib/supabase-page-writer.mjs';
 import { hasScope } from './lib/selective-unpause.mjs';
+import { buildGalleryDoc } from '../lib/gallery-doc.mjs';
 
 /**
  * Save current page content as a revision before overwriting.
@@ -512,29 +513,15 @@ async function processOneJob(db, job) {
           // and scripts/workers/image-extract-worker.mjs.
           const QUALITY_THRESHOLD = 0.5;
           if (!galleryDocs) galleryDocs = [];
+          // Collect the gated detections; the full denormalized docs are built
+          // after the loop (once page + book metadata is fetched) via the shared
+          // buildGalleryDoc helper so the field set matches every other writer.
           for (let di = 0; di < detectedImages.length; di++) {
             const img = detectedImages[di];
             if (!img.bbox) continue;
             if (typeof img.gallery_quality !== 'number') continue;
             if (img.gallery_quality < QUALITY_THRESHOLD) continue;
-            galleryDocs.push({
-              id: `${pageId}-${di}`,
-              page_id: pageId,
-              book_id: job.book_id,
-              detection_index: di,
-              description: img.description,
-              type: img.type,
-              bbox: img.bbox,
-              gallery_quality: img.gallery_quality,
-              gallery_rationale: img.gallery_rationale,
-              museum_description: img.museum_description,
-              metadata: img.metadata,
-              detected_at: now,
-              detection_source: 'vision_model',
-              model: job.model,
-              batch_job_id: jobIdStr,
-              updated_at: now,
-            });
+            galleryDocs.push({ pageId, detectedImage: img, index: di });
           }
         } else {
           // No images detected — still mark as processed
@@ -594,34 +581,33 @@ async function processOneJob(db, job) {
     if (galleryDocs && galleryDocs.length > 0) {
       try {
         // Fetch page numbers + image URLs for gallery docs
-        const pageIdsForGallery = [...new Set(galleryDocs.map(d => d.page_id))];
+        const pageIdsForGallery = [...new Set(galleryDocs.map(d => d.pageId))];
         const pageInfoMap = new Map();
         const pageInfos = await db.collection('pages')
           .find({ id: { $in: pageIdsForGallery } })
-          .project({ id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1 })
+          .project({ id: 1, book_id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, enhanced_photo: 1, crop: 1 })
           .toArray();
         for (const p of pageInfos) pageInfoMap.set(p.id, p);
 
-        // Fetch book metadata for gallery docs
+        // Fetch book metadata for gallery docs (incl. visible/hidden/provider so
+        // batch-collected images are gallery-visible without a separate sync — #2531).
         const bookDoc = await db.collection('books').findOne(
           { id: job.book_id },
-          { projection: { display_title: 1, title: 1, author: 1, year: 1, language: 1 } }
+          { projection: { id: 1, display_title: 1, title: 1, author: 1, year: 1, language: 1, visible: 1, hidden: 1, 'image_source.provider': 1 } }
         );
 
-        for (const doc of galleryDocs) {
-          const pageInfo = pageInfoMap.get(doc.page_id);
-          if (pageInfo) {
-            doc.page_number = pageInfo.page_number;
-            // Image URL fallback chain (same as image-extraction-processor)
-            doc.image_url = pageInfo.cropped_photo || pageInfo.archived_photo || pageInfo.photo_original || pageInfo.photo;
-          }
-          if (bookDoc) {
-            doc.book_title = bookDoc.display_title || bookDoc.title;
-            doc.book_author = bookDoc.author;
-            doc.book_year = bookDoc.year;
-            doc.book_language = bookDoc.language;
-          }
-        }
+        // Build the full denormalized docs via the shared helper; override the
+        // provenance fields the batch path owns (model / detected_at / batch id).
+        const builtDocs = galleryDocs.map(({ pageId: pid, detectedImage, index }) => {
+          const pageInfo = pageInfoMap.get(pid) || { id: pid, book_id: job.book_id };
+          const doc = buildGalleryDoc({ page: pageInfo, book: bookDoc, detectedImage, index, now });
+          doc.model = job.model;
+          doc.detected_at = now;
+          doc.detection_source = 'vision_model';
+          doc.batch_job_id = jobIdStr;
+          return doc;
+        });
+        galleryDocs = builtDocs;
 
         const galleryOps = galleryDocs.map(doc => ({
           updateOne: {

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -24,6 +24,7 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
+import { buildPageGrounding } from '../lib/page-grounding.mjs';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { GoogleGenAI } from '@google/genai';
@@ -2028,6 +2029,59 @@ MUSEUM DESCRIPTION: Write 2-3 sentences for a museum label - what the viewer see
 
 Return ONLY a valid JSON array. If no significant illustrations, return: []`;
 
+// Per-page text grounding for the batch image-extraction path (#2707), mirroring
+// the realtime worker. Returns Map<pageId, groundingString>. Reads each candidate
+// page's own OCR/translation, a ±radius window of neighbour pages (usually text/
+// blank pages not in the candidate set), and the book summary as the isolated-
+// plate fallback. One window query per book.
+const BATCH_GROUNDING_RADIUS = 3;
+async function buildGroundingByPageId(db, book, candidatePages) {
+  const ids = candidatePages.map(p => p.id);
+  const cps = await db.collection('pages')
+    .find({ id: { $in: ids } }, { projection: { id: 1, page_number: 1, 'ocr.data': 1, 'translation.data': 1 } })
+    .toArray();
+
+  const windowNumbers = new Set();
+  for (const p of cps) {
+    if (typeof p.page_number !== 'number') continue;
+    for (let d = -BATCH_GROUNDING_RADIUS; d <= BATCH_GROUNDING_RADIUS; d++) windowNumbers.add(p.page_number + d);
+  }
+  const pagesByNumber = new Map();
+  if (windowNumbers.size > 0) {
+    const wp = await db.collection('pages')
+      .find({ book_id: book.id, page_number: { $in: [...windowNumbers] } }, { projection: { page_number: 1, 'ocr.data': 1, 'translation.data': 1 } })
+      .toArray();
+    for (const p of wp) pagesByNumber.set(p.page_number, p);
+  }
+
+  let bookSummary = book.summary;
+  if (bookSummary === undefined) {
+    const b = await db.collection('books').findOne({ id: book.id }, { projection: { summary: 1 } });
+    bookSummary = b?.summary || '';
+  }
+
+  const map = new Map();
+  for (const p of cps) {
+    const neighbors = [];
+    if (typeof p.page_number === 'number') {
+      for (let n = p.page_number - BATCH_GROUNDING_RADIUS; n <= p.page_number + BATCH_GROUNDING_RADIUS; n++) {
+        if (n === p.page_number) continue;
+        const np = pagesByNumber.get(n);
+        if (np) neighbors.push({ page_number: n, ocr: np.ocr?.data, translation: np.translation?.data });
+      }
+    }
+    map.set(p.id, buildPageGrounding({
+      ocr: p.ocr?.data,
+      translation: p.translation?.data,
+      pageNumber: p.page_number,
+      neighbors,
+      bookSummary,
+      radius: BATCH_GROUNDING_RADIUS,
+    }));
+  }
+  return map;
+}
+
 async function submitImageExtractionBatch(db, book, candidatePages) {
   // Guard: check for existing active batch_jobs for this book
   const activeBatchForBook = await db.collection('batch_jobs').countDocuments({
@@ -2071,14 +2125,12 @@ async function submitImageExtractionBatch(db, book, candidatePages) {
   const contextPrefix = contextParts.length > 0
     ? `BOOK CONTEXT (background only — a hint for reading inscriptions and recognising a tradition; do NOT assert a person, figure, or scene unless it is actually visible in THIS image — a book about a subject does not mean every illustration depicts it):\n${contextParts.join(' | ')}\n\n`
     : '';
-  // TODO(image-grounding): feed each page's own OCR `<image-desc>` / `<summary>` into
-  // the per-item prompt here, the way src/lib/image-extraction.ts and
-  // scripts/workers/image-extract-worker.mjs (buildPageGrounding) now do. The batch
-  // builders below assemble one prompt per page, so add ocr.data/translation.data to
-  // the `pages` projection and append buildPageGrounding(page) per item. Until then,
-  // the softened BOOK CONTEXT above is what keeps this batch path from confabulating a
-  // subject from the book's topic (e.g. wrestlers → "gymnosophists").
   const prompt = contextPrefix + IMAGE_EXTRACTION_PROMPT;
+
+  // Per-page text grounding (#2707): subject identity comes from the page's own
+  // OCR <image-desc>/<summary> + nearby text, not the book's topic. Appended per
+  // item below so each page's prompt carries its own grounding.
+  const groundingByPageId = await buildGroundingByPageId(db, book, candidatePages);
 
   const useFileBased = downloaded.length > IMAGE_EXTRACTION_INLINE_SIZE;
   const batchSize = useFileBased ? IMAGE_EXTRACTION_BATCH_SIZE : IMAGE_EXTRACTION_INLINE_SIZE;
@@ -2100,7 +2152,7 @@ async function submitImageExtractionBatch(db, book, candidatePages) {
         request: {
           contents: [{
             parts: [
-              { text: prompt },
+              { text: prompt + (groundingByPageId.get(item.pageId) || '') },
               { inlineData: { mimeType: item.image.mimeType, data: item.image.data } },
             ],
           }],
@@ -2171,7 +2223,7 @@ async function submitImageExtractionBatch(db, book, candidatePages) {
         request: {
           contents: [{
             parts: [
-              { text: prompt },
+              { text: prompt + (groundingByPageId.get(item.pageId) || '') },
               { inlineData: { mimeType: item.image.mimeType, data: item.image.data } },
             ],
           }],
@@ -2308,8 +2360,10 @@ async function submitCrossBookImageBatches(db, bookItems) {
     console.log(`    Downloaded ${downloaded.length}/${pages.length} images for ${book.title}`);
 
     const prompt = buildPagePrompt(book);
+    // Per-page text grounding (#2707) for each book in the cross-book pool.
+    const groundingByPageId = await buildGroundingByPageId(db, book, candidatePages);
     for (const item of downloaded) {
-      allDownloaded.push({ pageId: item.pageId, image: item.image, prompt, bookId: book.id });
+      allDownloaded.push({ pageId: item.pageId, image: item.image, prompt, grounding: groundingByPageId.get(item.pageId) || '', bookId: book.id });
     }
   }
 
@@ -2334,7 +2388,7 @@ async function submitCrossBookImageBatches(db, bookItems) {
       request: {
         contents: [{
           parts: [
-            { text: item.prompt },
+            { text: item.prompt + (item.grounding || '') },
             { inlineData: { mimeType: item.image.mimeType, data: item.image.data } },
           ],
         }],


### PR DESCRIPTION
## Why
The Gemini **Batch** image-extraction path (`pipeline-orchestrator.mjs` + `batch-collector.mjs`) is a major production route, but it lagged the realtime worker on both fronts this stack fixes:

- It appended **one shared prompt** to every page, blind to page text — the `TODO(image-grounding)` left in PR #2705. Same confabulation risk as the worker had (wrestlers → "gymnosophists").
- `batch-collector` wrote **thin** `gallery_images` docs (no `book_visible`/`book_provider`), so batch-extracted images were invisible on the gallery read path until a separate sync — the #2531/#2430 overlap.

**PR C**, stacked on #2715 (#2707) → #2712 (#2531). Same helpers, batch twin.

## What
**Grounding (#2707)** — the three batch JSONL builders (`submitImageExtractionBatch`'s file-based + inline, and `submitCrossBookImageBatches`) now append **per-page** grounding via a shared `buildGroundingByPageId()` that reads each page's own OCR `<image-desc>`/`<summary>`, a **±3 neighbour window**, and the **book summary** as the isolated-plate fallback — the identical authority hierarchy to the worker (PR B). One window query per book. Replaces the TODO.

**Schema (#2531/#2430)** — `batch-collector` builds the **full denormalized doc** via the shared `buildGalleryDoc` helper (book projection extended with `visible`/`hidden`/`image_source.provider`), overriding only the batch-owned provenance fields (`model`/`detected_at`/`batch_job_id`). Batch-extracted images are now gallery-visible without a separate sync.

## Out of scope
- **Crop materialization scheduling** (#2430's core `extracted_url`/`thumbnail_url` question) is **unchanged** — the nightly `generate-thumbnails` cron still owns it. This PR makes the metadata self-sufficient and grounds the captions; whether `batch-collector` should crop inline vs. via the sweep is a separate operational decision.
- The paid recovery sweep (#2533) stays parked.

## Validated
- `tsc --noEmit` clean; `node --check` on both workers; 21 unit tests (gallery-doc + page-grounding) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)