### PR TITLE
fix(librarian): stop fabricating author-page URLs that 404

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -298,7 +298,7 @@ function tenantVisibilityFilter() {
 // executeSearchSemantic (book-then-page only) with a single unified path.
 async function executeSearch(query: string): Promise<{
   passages: Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; text: string; score: number; source: string }>;
-  books: Array<{ id: string; title: string; author?: string; year?: number; slug?: string }>;
+  books: Array<{ id: string; title: string; author?: string; authorSlug?: string; year?: number; slug?: string }>;
 }> {
   const { hybridSearch } = await import('@/lib/search/librarian-search');
   // Main-site only; pass tenant UUID here for per-tenant Librarian instances.
@@ -484,7 +484,15 @@ async function executeTool(
       if (data.books.length > 0) {
         context += 'Books found:\n';
         for (const b of data.books) {
-          context += `- "${b.title}" by ${b.author || 'Unknown'}${b.year ? ` (${b.year})` : ''} — https://sourcelibrary.org/book/${b.slug || b.id}\n`;
+          // Give the model the resolvable author URL (or none) so it never has
+          // to invent one by slugifying a name form it chose in prose — the
+          // cause of 404 author links like /author/robert-bellarmine.
+          const authorPart = b.author
+            ? (b.authorSlug
+              ? `[${b.author}](https://sourcelibrary.org/author/${b.authorSlug})`
+              : b.author)
+            : 'Unknown';
+          context += `- "${b.title}" by ${authorPart}${b.year ? ` (${b.year})` : ''} — https://sourcelibrary.org/book/${b.slug || b.id}\n`;
         }
       }
       if (data.passages.length > 0) {
@@ -709,9 +717,9 @@ For visual or symbolic topics (emblems, alchemical apparatus, diagrams, seals, p
 **Step 5: Save and cite with links.**
 Use add_to_notebook for quotes directly relevant to the research question. The notebook persists across messages.
 
-Cite with page-level links: "quoted text" — *[Title](https://sourcelibrary.org/book/SLUG)* by [Author](https://sourcelibrary.org/author/AUTHOR-NAME), [Page N](https://sourcelibrary.org/book/SLUG?page=N).
+Cite with page-level links: "quoted text" — *[Title](https://sourcelibrary.org/book/SLUG)* by [Author](https://sourcelibrary.org/author/AUTHOR-SLUG), [Page N](https://sourcelibrary.org/book/SLUG?page=N).
 
-Every mention of a book should link to it. Every mention of an author should link to their author page. Every quote should cite a specific page number with a direct link. Use the URLs from tool results — they contain the correct slugs. Author page URLs use the author name in URL form: /author/Cornelius Agrippa → /author/Cornelius%20Agrippa.
+Every mention of a book should link to it. Every mention of an author should link to their author page WHEN the tool results give you that author's link. Use the URLs from tool results verbatim — they contain the correct slugs, including the pre-built author link in each "Books found" line. **NEVER construct an author URL yourself by slugifying or translating a name.** The author's name in our catalog is often a different form than the one you'd write in prose (e.g. "Robert Bellarmine" is stored as "Bellarmino, Roberto, S.J"; "Bartholomaeus Fumus" as "Bartolomeo Fumo"), and a hand-built /author/... link will 404. If a tool result has no author link for someone, write their name as plain text — do not invent a link.
 
 When quoting a key passage, include the original language text (Latin, German, Hebrew, etc.) alongside the English if it is notable or if the user appears to be working in that language. Use a blockquote with both versions.
 
@@ -747,7 +755,7 @@ Source Library has over 10,000 rare books spanning antiquity through the 18th ce
 - Use paragraph breaks between distinct ideas — leave a blank line between paragraphs. Don't write walls of text
 - Conversational but substantive — a research conversation, not a lecture
 - Cite 2-4 key passages rather than dumping everything. Every passage needs a page number and link
-- Link authors to their author pages: [Author Name](https://sourcelibrary.org/author/Author%20Name)
+- Link authors to their author pages ONLY with the author link supplied in the tool results — never a self-built /author/... URL. No tool-supplied link → plain text name.
 - Link books to their book pages: *[Book Title](https://sourcelibrary.org/book/slug)*
 - Link quotes to specific pages: [Page 42](https://sourcelibrary.org/book/slug?page=42)
 - Make clear when speaking from general knowledge vs. specific texts`;

--- a/src/lib/search/librarian-search.ts
+++ b/src/lib/search/librarian-search.ts
@@ -21,6 +21,7 @@ import {
   semanticPageSearchGlobal,
 } from '@/lib/semantic-search';
 import { buildBookSearchStage, buildPageSearchStage } from '@/lib/atlas-search';
+import { authorSlug as toAuthorSlug } from '@/lib/slugify';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -39,6 +40,15 @@ export interface SearchBook {
   id: string;
   title: string;
   author?: string;
+  /**
+   * Resolvable slug for the author's page (`/author/<authorSlug>`). Prefers the
+   * canonical thesaurus id (`books.author_id`); falls back to the slug of the
+   * exact stored author name, which the `/author/[name]` route resolves via its
+   * name→slug cache. Undefined only when the book has no author. The Librarian
+   * MUST link authors with this — never by slugifying a name form it chose in
+   * prose (Latinized/anglicized variants like "Robert Bellarmine" 404).
+   */
+  authorSlug?: string;
   year?: number;
   slug?: string;
 }
@@ -295,13 +305,14 @@ async function findBooks(query: string, opts: HybridSearchOptions, limit: number
       stage,
       { $match: filter },
       { $limit: limit },
-      { $project: { id: 1, title: 1, display_title: 1, author: 1, year: 1, slug: 1 } },
+      { $project: { id: 1, title: 1, display_title: 1, author: 1, author_id: 1, year: 1, slug: 1 } },
     ])
     .toArray();
   return rows.map(b => ({
     id: b.id,
     title: b.display_title || b.title,
     author: b.author,
+    authorSlug: b.author ? (b.author_id || toAuthorSlug(b.author)) : undefined,
     year: b.year,
     slug: b.slug,
   }));


### PR DESCRIPTION
## The bug

Derek noticed the Librarian linked **Bartholomaeus Fumus** (the inquisitor) and **Robert Bellarmine** (the Jesuit) as author links that 404'd.

They're Next.js **soft-404s** (HTTP 200, real `<title>`, but a "page not found" body), so they look alive but are dead.

## Root cause

The Librarian built author URLs by slugifying whatever author-name form it wrote in prose — the system prompt literally instructed `/author/Author%20Name`. Unlike book links (which copy a real slug from tool output), author links were **invented from the name string**. The `/author/[name]` route resolves a slug → name via a cache / exact-name match, which fails whenever the model's name form differs from the catalog's stored string:

- **Robert Bellarmine** — stored as `Bellarmino, Roberto, S.J` (canonical page `/author/bellarmino-roberto-s-j` works). The model wrote the English name → `/author/robert-bellarmine` → 404.
- **Bartholomaeus Fumus** — stored as `Bartolomeo Fumo` (`/author/bartolomeo-fumo` works). The model Latinized it → 404.

Systemic, not just these two: any author named in a normalized/translated/Latin form 404'd.

## Fix

Carry a **resolvable** author slug through search results — `books.author_id` (canonical thesaurus id) or the slug of the exact stored author name — and emit the author as a pre-built markdown link in the tool context. The prompt now says: use the supplied author link verbatim, never construct one yourself, plain text when none is supplied.

This resolves both reported links: Bellarmino now links via `bellarmino-roberto-s-j`, Fumo via `bartolomeo-fumo` — both verified to resolve.

## Scope / out of scope

- In: Librarian tool-context + prompt (`src/lib/embassy/librarian.ts`), search-result plumbing (`src/lib/search/librarian-search.ts`).
- Out: deeper data items surfaced during diagnosis — the two `Bartolomeo Fumo` records have `author_id: undefined`, aren't in the `authors` thesaurus, and are a **duplicate pair** (993pp each, both visible); Bellarmino's thesaurus entry has no English-name alias. These are data-pipeline / dedup concerns (and dedup needs sign-off), deliberately left for a separate pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)