### PR TITLE
feat(book): 'Digitized thanks to ___' adopt-a-book sponsor credit

### DIFF
--- a/scripts/maintenance/set-digitization-sponsor.mjs
+++ b/scripts/maintenance/set-digitization-sponsor.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Set (or clear) the "adopt a book" digitization sponsor credit on a book.
+ *
+ * Writes `digitization_sponsor` (+ optional `digitization_sponsor_url`) on the
+ * books doc. The book page renders this as a gracious "Digitized thanks to ___"
+ * line in the bibliographic panel (see src/components/book/BibliographicInfo.tsx).
+ *
+ * This is distinct from `image_source.sponsor`, which records the *institutional*
+ * digitization funder (Google, Sloan, …). Use this for individual donors who
+ * adopt a specific book.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/set-digitization-sponsor.mjs --book <id|slug> --name "Jane Smith" [--url "https://…"]
+ *   node scripts/maintenance/set-digitization-sponsor.mjs --book <id|slug> --clear
+ *
+ * Flags:
+ *   --book   Book `id` (string id field) or `slug`. Required.
+ *   --name   Sponsor display name. Required unless --clear.
+ *   --url    Optional link (donor page / tribute).
+ *   --clear  Remove the sponsor credit instead of setting it.
+ */
+import { withMongo } from '../lib/mongo.mjs';
+
+function arg(flag) {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+const has = (flag) => process.argv.includes(flag);
+
+const bookRef = arg('--book');
+const name = arg('--name');
+const url = arg('--url');
+const clear = has('--clear');
+
+if (!bookRef || (!clear && !name)) {
+  console.error('Usage: --book <id|slug> --name "Name" [--url "https://…"]  |  --book <id|slug> --clear');
+  process.exit(1);
+}
+
+await withMongo(async (db) => {
+  const books = db.collection('books');
+  const book = await books.findOne(
+    { $or: [{ id: bookRef }, { slug: bookRef }] },
+    { projection: { id: 1, slug: 1, title: 1, display_title: 1, digitization_sponsor: 1 } }
+  );
+
+  if (!book) {
+    console.error(`No book found with id or slug "${bookRef}".`);
+    process.exit(1);
+  }
+
+  const label = book.display_title || book.title || book.slug || book.id;
+
+  let update;
+  if (clear) {
+    update = { $unset: { digitization_sponsor: '', digitization_sponsor_url: '' } };
+  } else {
+    update = { $set: { digitization_sponsor: name } };
+    if (url) update.$set.digitization_sponsor_url = url;
+    else update.$unset = { digitization_sponsor_url: '' };
+  }
+
+  const res = await books.updateOne({ id: book.id }, update);
+
+  if (clear) {
+    console.log(`Cleared digitization sponsor on "${label}" (was: ${book.digitization_sponsor || 'none'}). modified=${res.modifiedCount}`);
+  } else {
+    console.log(`Set "${label}" → "Digitized thanks to ${name}${url ? ` (${url})` : ''}". modified=${res.modifiedCount}`);
+  }
+}, { timeoutMs: 60000 });

--- a/scripts/maintenance/set-digitization-sponsor.mjs
+++ b/scripts/maintenance/set-digitization-sponsor.mjs
@@ -55,9 +55,9 @@ await withMongo(async (db) => {
 
   let update;
   if (clear) {
-    update = { $unset: { digitization_sponsor: '', digitization_sponsor_url: '' } };
+    update = { $unset: { digitization_sponsor: '', digitization_sponsor_url: '', digitization_adopted_at: '' } };
   } else {
-    update = { $set: { digitization_sponsor: name } };
+    update = { $set: { digitization_sponsor: name, digitization_adopted_at: new Date() } };
     if (url) update.$set.digitization_sponsor_url = url;
     else update.$unset = { digitization_sponsor_url: '' };
   }

--- a/src/app/adopt/certificate/[token]/PrintButton.tsx
+++ b/src/app/adopt/certificate/[token]/PrintButton.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export default function PrintButton() {
+  return (
+    <button
+      onClick={() => window.print()}
+      className="no-print mt-8 px-5 py-2.5 rounded-md bg-[#9e4a3a] text-white text-sm hover:bg-[#7e3a2e]"
+    >
+      Print / Save as PDF
+    </button>
+  );
+}

--- a/src/app/adopt/certificate/[token]/page.tsx
+++ b/src/app/adopt/certificate/[token]/page.tsx
@@ -1,0 +1,87 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { getDb } from '@/lib/mongodb';
+import PrintButton from './PrintButton';
+
+export const metadata: Metadata = {
+  title: 'Certificate of Adoption — Source Library',
+  robots: { index: false, follow: false },
+};
+
+interface AdoptionRecord {
+  bookTitle?: string;
+  bookSlug?: string | null;
+  bookId?: string;
+  sponsor?: string | null;
+  payer_name?: string | null;
+  created_at?: Date | string;
+}
+
+function formatDate(d: Date | string | undefined): string {
+  if (!d) return '';
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+export default async function CertificatePage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+
+  const db = await getDb();
+  const adoption = (await db
+    .collection('book_adoptions')
+    .findOne({ stripe_session_id: token })) as AdoptionRecord | null;
+
+  if (!adoption) notFound();
+
+  const name = adoption.payer_name || adoption.sponsor || 'A patron of Source Library';
+  const bookTitle = adoption.bookTitle || 'a book from the Bibliotheca Philosophica Hermetica';
+  const date = formatDate(adoption.created_at);
+  const bookPath = adoption.bookSlug || adoption.bookId ? `/book/${adoption.bookSlug || adoption.bookId}` : null;
+
+  return (
+    <main className="min-h-screen bg-stone-100 flex flex-col items-center justify-center py-12 px-4 print:bg-white print:py-0">
+      <style>{`@media print { .no-print { display: none !important; } @page { margin: 1.5cm; } body { background: #fff; } }`}</style>
+
+      <div
+        className="w-full max-w-2xl bg-[#fbf7ee] text-[#1e1a16] px-10 py-14 text-center"
+        style={{ boxShadow: '0 0 0 1px #d8c9a8, 0 0 0 10px #fbf7ee, 0 0 0 11px #c9a24a' }}
+      >
+        <p style={{ letterSpacing: '0.25em' }} className="text-xs uppercase text-[#9c6b2e] mb-6">
+          Embassy of the Free Mind · Amsterdam
+        </p>
+
+        <h1 className="font-serif text-3xl md:text-4xl mb-2" style={{ fontFamily: 'Georgia, serif' }}>
+          Certificate of Adoption
+        </h1>
+        <div className="mx-auto my-5 h-px w-24 bg-[#c9a24a]" />
+
+        <p className="text-base text-[#4a4138] mb-3">This certifies that</p>
+        <p className="font-serif text-2xl md:text-3xl text-[#7a1f1f] mb-5" style={{ fontFamily: 'Georgia, serif' }}>
+          {name}
+        </p>
+
+        <p className="text-base leading-relaxed text-[#1e1a16] max-w-xl mx-auto">
+          has given <em>{bookTitle}</em> to the world — digitized, translated, and made freely
+          readable by anyone, anywhere, for as long as the internet endures.
+        </p>
+
+        {date && <p className="mt-8 text-sm text-[#8a8480]">{date}</p>}
+
+        <p className="mt-2 text-sm text-[#8a8480]">
+          Source Library · Bibliotheca Philosophica Hermetica
+        </p>
+      </div>
+
+      <div className="no-print mt-6 text-center">
+        {bookPath && (
+          <a href={bookPath} className="text-sm text-[#9e4a3a] hover:underline">
+            View the book →
+          </a>
+        )}
+        <div>
+          <PrintButton />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/adopt/checkout/route.ts
+++ b/src/app/api/adopt/checkout/route.ts
@@ -1,69 +1,47 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { stripe } from '@/lib/stripe';
 import { getDb } from '@/lib/mongodb';
+import { ADOPT_TIERS, ADOPT_MAX_CENTS, resolveAdoptTier, formatEuros } from '@/lib/adopt-tiers';
+import type { Book } from '@/lib/types';
 
 /**
  * Adopt-a-book checkout.
  *
- * Creates a Stripe Checkout Session for a single book. The donor names a gift
- * (minimum €222.22, open-ended above) and, on success, the Stripe webhook
- * (src/app/api/stripe/webhook/route.ts → checkout.session.completed, kind=adopt_book)
- * attaches their credit to the book as `digitization_sponsor`, which renders as
+ * Creates a Stripe Checkout Session for a single book at the donor-chosen
+ * amount (validated server-side against the book's tier minimum). On success
+ * the Stripe webhook (src/app/api/stripe/webhook/route.ts → checkout.session.completed,
+ * kind=adopt_book) attaches their credit as `digitization_sponsor`, rendered as
  * "Digitized thanks to ___" on the book page.
- *
- * Pay-what-you-want with a minimum requires a real Stripe Price with
- * `custom_unit_amount` (inline price_data does not support it). We create one
- * reusable Price lazily, keyed by a stable lookup_key, so no dashboard setup is
- * needed. The specific book is tracked via session metadata + the return URL.
  */
 
-const MIN_ADOPT_CENTS = 25000; // €250 minimum; donors may give more
 const ADOPT_CURRENCY = 'eur';
-const ADOPT_PRICE_LOOKUP_KEY = 'adopt_book_eur_250';
-
-let cachedPriceId: string | null = null;
-
-async function getAdoptPriceId(): Promise<string> {
-  if (cachedPriceId) return cachedPriceId;
-  const existing = await stripe!.prices.list({
-    lookup_keys: [ADOPT_PRICE_LOOKUP_KEY],
-    active: true,
-    limit: 1,
-  });
-  if (existing.data[0]) {
-    cachedPriceId = existing.data[0].id;
-    return cachedPriceId;
-  }
-  const price = await stripe!.prices.create({
-    currency: ADOPT_CURRENCY,
-    custom_unit_amount: { enabled: true, minimum: MIN_ADOPT_CENTS },
-    lookup_key: ADOPT_PRICE_LOOKUP_KEY,
-    product_data: { name: 'Adopt a book — Embassy of the Free Mind' },
-  });
-  cachedPriceId = price.id;
-  return cachedPriceId;
-}
 
 export async function POST(request: NextRequest) {
   if (!stripe) {
     return NextResponse.json({ error: 'Payments not configured' }, { status: 503 });
   }
 
-  let bookRef: string | undefined;
+  let bookRef: unknown;
+  let amount: unknown;
   try {
     const body = await request.json();
     bookRef = body?.bookId;
+    amount = body?.amount;
   } catch {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
   }
   if (!bookRef || typeof bookRef !== 'string') {
     return NextResponse.json({ error: 'bookId is required' }, { status: 400 });
   }
+  if (!Number.isInteger(amount)) {
+    return NextResponse.json({ error: 'A valid amount is required' }, { status: 400 });
+  }
+  const amountCents = amount as number;
 
   const db = await getDb();
   const book = await db.collection('books').findOne(
     { $or: [{ id: bookRef }, { slug: bookRef }] },
-    { projection: { id: 1, slug: 1, title: 1, display_title: 1, visible: 1, hidden: 1, digitization_sponsor: 1 } }
+    { projection: { id: 1, slug: 1, title: 1, display_title: 1, visible: 1, hidden: 1, resource_type: 1, adopt_tier: 1, digitization_sponsor: 1 } }
   );
 
   if (!book || book.visible === false || book.hidden === true) {
@@ -73,16 +51,36 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'This book has already been adopted' }, { status: 409 });
   }
 
+  const tier = resolveAdoptTier(book as { adopt_tier?: 'standard' | 'rare'; resource_type?: Book['resource_type'] });
+  const minCents = ADOPT_TIERS[tier].minCents;
+  if (amountCents < minCents || amountCents > ADOPT_MAX_CENTS) {
+    return NextResponse.json(
+      { error: `Amount must be between ${formatEuros(minCents)} and ${formatEuros(ADOPT_MAX_CENTS)}` },
+      { status: 400 }
+    );
+  }
+
   const title = (book.display_title || book.title || 'a book') as string;
   const bookPath = `/book/${book.slug || book.id}`;
   const origin = request.nextUrl.origin;
 
   try {
-    const priceId = await getAdoptPriceId();
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
       submit_type: 'donate',
-      line_items: [{ price: priceId, quantity: 1 }],
+      line_items: [
+        {
+          quantity: 1,
+          price_data: {
+            currency: ADOPT_CURRENCY,
+            unit_amount: amountCents,
+            product_data: {
+              name: `Adopt a book: ${title}`.slice(0, 250),
+              description: 'Digitize this book in your name, with a lasting credit on its page.',
+            },
+          },
+        },
+      ],
       custom_fields: [
         {
           key: 'creditname',
@@ -92,9 +90,16 @@ export async function POST(request: NextRequest) {
         },
       ],
       custom_text: {
-        submit: { message: `You are adopting "${title}". It will be digitized with your name credited on its page.`.slice(0, 1200) },
+        submit: {
+          message: `You are adopting "${title}". It will be digitized with your name credited on its page.`.slice(0, 1200),
+        },
       },
-      metadata: { kind: 'adopt_book', bookId: String(book.id), bookSlug: (book.slug as string) || '' },
+      metadata: {
+        kind: 'adopt_book',
+        bookId: String(book.id),
+        bookSlug: (book.slug as string) || '',
+        tier,
+      },
       success_url: `${origin}${bookPath}?adopted=1`,
       cancel_url: `${origin}${bookPath}`,
     });

--- a/src/app/api/adopt/checkout/route.ts
+++ b/src/app/api/adopt/checkout/route.ts
@@ -93,6 +93,9 @@ export async function POST(request: NextRequest) {
         submit: {
           message: `You are adopting "${title}". It will be digitized with your name credited on its page.`.slice(0, 1200),
         },
+        after_submit: {
+          message: 'Tax-deductible: ANBI (Netherlands) and, for US donors, 501(c)(3) via the Netherland-America Foundation.',
+        },
       },
       metadata: {
         kind: 'adopt_book',

--- a/src/app/api/adopt/checkout/route.ts
+++ b/src/app/api/adopt/checkout/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { stripe } from '@/lib/stripe';
+import { getDb } from '@/lib/mongodb';
+
+/**
+ * Adopt-a-book checkout.
+ *
+ * Creates a Stripe Checkout Session for a single book. The donor names a gift
+ * (minimum €222.22, open-ended above) and, on success, the Stripe webhook
+ * (src/app/api/stripe/webhook/route.ts → checkout.session.completed, kind=adopt_book)
+ * attaches their credit to the book as `digitization_sponsor`, which renders as
+ * "Digitized thanks to ___" on the book page.
+ *
+ * Pay-what-you-want with a minimum requires a real Stripe Price with
+ * `custom_unit_amount` (inline price_data does not support it). We create one
+ * reusable Price lazily, keyed by a stable lookup_key, so no dashboard setup is
+ * needed. The specific book is tracked via session metadata + the return URL.
+ */
+
+const MIN_ADOPT_CENTS = 22222; // €222.22 minimum; donors may give more
+const ADOPT_CURRENCY = 'eur';
+const ADOPT_PRICE_LOOKUP_KEY = 'adopt_book_eur';
+
+let cachedPriceId: string | null = null;
+
+async function getAdoptPriceId(): Promise<string> {
+  if (cachedPriceId) return cachedPriceId;
+  const existing = await stripe!.prices.list({
+    lookup_keys: [ADOPT_PRICE_LOOKUP_KEY],
+    active: true,
+    limit: 1,
+  });
+  if (existing.data[0]) {
+    cachedPriceId = existing.data[0].id;
+    return cachedPriceId;
+  }
+  const price = await stripe!.prices.create({
+    currency: ADOPT_CURRENCY,
+    custom_unit_amount: { enabled: true, minimum: MIN_ADOPT_CENTS },
+    lookup_key: ADOPT_PRICE_LOOKUP_KEY,
+    product_data: { name: 'Adopt a book — Embassy of the Free Mind' },
+  });
+  cachedPriceId = price.id;
+  return cachedPriceId;
+}
+
+export async function POST(request: NextRequest) {
+  if (!stripe) {
+    return NextResponse.json({ error: 'Payments not configured' }, { status: 503 });
+  }
+
+  let bookRef: string | undefined;
+  try {
+    const body = await request.json();
+    bookRef = body?.bookId;
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+  if (!bookRef || typeof bookRef !== 'string') {
+    return NextResponse.json({ error: 'bookId is required' }, { status: 400 });
+  }
+
+  const db = await getDb();
+  const book = await db.collection('books').findOne(
+    { $or: [{ id: bookRef }, { slug: bookRef }] },
+    { projection: { id: 1, slug: 1, title: 1, display_title: 1, visible: 1, hidden: 1, digitization_sponsor: 1 } }
+  );
+
+  if (!book || book.visible === false || book.hidden === true) {
+    return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+  }
+  if (book.digitization_sponsor) {
+    return NextResponse.json({ error: 'This book has already been adopted' }, { status: 409 });
+  }
+
+  const title = (book.display_title || book.title || 'a book') as string;
+  const bookPath = `/book/${book.slug || book.id}`;
+  const origin = request.nextUrl.origin;
+
+  try {
+    const priceId = await getAdoptPriceId();
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      submit_type: 'donate',
+      line_items: [{ price: priceId, quantity: 1 }],
+      custom_fields: [
+        {
+          key: 'creditname',
+          label: { type: 'custom', custom: 'How to credit you (blank = your name)' },
+          type: 'text',
+          optional: true,
+        },
+      ],
+      custom_text: {
+        submit: { message: `You are adopting "${title}". It will be digitized with your name credited on its page.`.slice(0, 1200) },
+      },
+      metadata: { kind: 'adopt_book', bookId: String(book.id), bookSlug: (book.slug as string) || '' },
+      success_url: `${origin}${bookPath}?adopted=1`,
+      cancel_url: `${origin}${bookPath}`,
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (err) {
+    console.error('[adopt] Failed to create checkout session:', err);
+    return NextResponse.json({ error: 'Could not start checkout' }, { status: 500 });
+  }
+}

--- a/src/app/api/adopt/checkout/route.ts
+++ b/src/app/api/adopt/checkout/route.ts
@@ -41,13 +41,13 @@ export async function POST(request: NextRequest) {
   const db = await getDb();
   const book = await db.collection('books').findOne(
     { $or: [{ id: bookRef }, { slug: bookRef }] },
-    { projection: { id: 1, slug: 1, title: 1, display_title: 1, visible: 1, hidden: 1, resource_type: 1, adopt_tier: 1, digitization_sponsor: 1 } }
+    { projection: { id: 1, slug: 1, title: 1, display_title: 1, visible: 1, hidden: 1, resource_type: 1, adopt_tier: 1, digitization_sponsor: 1, digitization_adopted_at: 1 } }
   );
 
   if (!book || book.visible === false || book.hidden === true) {
     return NextResponse.json({ error: 'Book not found' }, { status: 404 });
   }
-  if (book.digitization_sponsor) {
+  if (book.digitization_sponsor || book.digitization_adopted_at) {
     return NextResponse.json({ error: 'This book has already been adopted' }, { status: 409 });
   }
 
@@ -84,7 +84,7 @@ export async function POST(request: NextRequest) {
       custom_fields: [
         {
           key: 'creditname',
-          label: { type: 'custom', custom: 'How to credit you (blank = your name)' },
+          label: { type: 'custom', custom: 'Name or dedication to show (blank = anonymous)' },
           type: 'text',
           optional: true,
         },

--- a/src/app/api/adopt/checkout/route.ts
+++ b/src/app/api/adopt/checkout/route.ts
@@ -17,9 +17,9 @@ import { getDb } from '@/lib/mongodb';
  * needed. The specific book is tracked via session metadata + the return URL.
  */
 
-const MIN_ADOPT_CENTS = 22222; // €222.22 minimum; donors may give more
+const MIN_ADOPT_CENTS = 25000; // €250 minimum; donors may give more
 const ADOPT_CURRENCY = 'eur';
-const ADOPT_PRICE_LOOKUP_KEY = 'adopt_book_eur';
+const ADOPT_PRICE_LOOKUP_KEY = 'adopt_book_eur_250';
 
 let cachedPriceId: string | null = null;
 

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -5,6 +5,7 @@ import { sendMembershipWelcomeEmail } from '@/lib/membership-email';
 import { recordPurchase, PurchaseType } from '@/lib/purchases';
 import Stripe from 'stripe';
 import { getDb } from '@/lib/mongodb';
+import { sendAdoptionThankYou } from '@/lib/adoption-email';
 
 /**
  * Look up the Source Library userId from a Stripe customer ID.
@@ -71,32 +72,63 @@ export async function POST(request: NextRequest) {
           console.log(`[stripe] Purchase recorded: ${purchaseType} ${purchaseItemId} for user ${userId}`);
         }
 
-        // Adopt-a-book — attach the donor's credit to the book
+        // Adopt-a-book — record the adoption, attach the credit (or keep anonymous), email a certificate
         if (session.metadata?.kind === 'adopt_book' && session.payment_status === 'paid') {
           const adoptBookId = session.metadata.bookId;
-          const creditField = session.custom_fields?.find((f) => f.key === 'creditname');
-          const creditName = (creditField?.text?.value || session.customer_details?.name || '').trim();
-          if (adoptBookId && creditName) {
+          if (adoptBookId) {
             const db = await getDb();
-            await db.collection('books').updateOne(
+            const creditField = session.custom_fields?.find((f) => f.key === 'creditname');
+            // Blank = anonymous. Never publish the payer's card name as the public credit.
+            const publicCredit = (creditField?.text?.value || '').trim();
+            const payerName = session.customer_details?.name || null;
+            const email = session.customer_details?.email || null;
+            const now = new Date();
+
+            const bookDoc = await db.collection('books').findOne(
               { id: adoptBookId },
-              { $set: { digitization_sponsor: creditName, updated_at: new Date() } }
+              { projection: { title: 1, display_title: 1, slug: 1 } }
             );
-            // Audit trail — a reversible record of who adopted what
+            const bookTitle = (bookDoc?.display_title || bookDoc?.title || 'a book') as string;
+            const bookSlug = (session.metadata.bookSlug || bookDoc?.slug || adoptBookId) as string;
+
+            // Mark adopted (hides the CTA, even when anonymous); set the public credit only if given.
+            const set: Record<string, unknown> = { digitization_adopted_at: now, updated_at: now };
+            if (publicCredit) set.digitization_sponsor = publicCredit;
+            await db.collection('books').updateOne({ id: adoptBookId }, { $set: set });
+
             await db.collection('book_adoptions').insertOne({
               bookId: adoptBookId,
-              bookSlug: session.metadata.bookSlug || null,
-              sponsor: creditName,
+              bookSlug,
+              bookTitle,
+              sponsor: publicCredit || null,
+              anonymous: !publicCredit,
+              payer_name: payerName,
+              email,
               amount_total: session.amount_total,
               currency: session.currency,
-              email: session.customer_details?.email || null,
+              tier: session.metadata.tier || null,
               stripe_session_id: session.id,
               payment_intent: (session.payment_intent as string) || null,
-              created_at: new Date(),
+              created_at: now,
             });
-            console.log(`[stripe] Book adopted: ${adoptBookId} → "${creditName}" (${session.amount_total} ${session.currency})`);
+            console.log(`[stripe] Book adopted: ${adoptBookId} → "${publicCredit || 'anonymous'}" (${session.amount_total} ${session.currency})`);
+
+            if (email) {
+              const amountLabel = typeof session.amount_total === 'number'
+                ? `€${Math.round(session.amount_total / 100).toLocaleString('en-IE')}`
+                : undefined;
+              sendAdoptionThankYou({
+                to: email,
+                payerName,
+                publicCredit: publicCredit || null,
+                bookTitle,
+                bookPath: `/book/${bookSlug}`,
+                sessionId: session.id,
+                amountLabel,
+              }).catch((e) => console.error('[stripe] adoption thank-you email failed:', e));
+            }
           } else {
-            console.warn(`[stripe] adopt_book session ${session.id} missing bookId or credit name`);
+            console.warn(`[stripe] adopt_book session ${session.id} missing bookId`);
           }
         }
         break;

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -70,6 +70,35 @@ export async function POST(request: NextRequest) {
           await recordPurchase(userId, purchaseType, purchaseItemId, session.payment_intent as string);
           console.log(`[stripe] Purchase recorded: ${purchaseType} ${purchaseItemId} for user ${userId}`);
         }
+
+        // Adopt-a-book — attach the donor's credit to the book
+        if (session.metadata?.kind === 'adopt_book' && session.payment_status === 'paid') {
+          const adoptBookId = session.metadata.bookId;
+          const creditField = session.custom_fields?.find((f) => f.key === 'creditname');
+          const creditName = (creditField?.text?.value || session.customer_details?.name || '').trim();
+          if (adoptBookId && creditName) {
+            const db = await getDb();
+            await db.collection('books').updateOne(
+              { id: adoptBookId },
+              { $set: { digitization_sponsor: creditName, updated_at: new Date() } }
+            );
+            // Audit trail — a reversible record of who adopted what
+            await db.collection('book_adoptions').insertOne({
+              bookId: adoptBookId,
+              bookSlug: session.metadata.bookSlug || null,
+              sponsor: creditName,
+              amount_total: session.amount_total,
+              currency: session.currency,
+              email: session.customer_details?.email || null,
+              stripe_session_id: session.id,
+              payment_intent: (session.payment_intent as string) || null,
+              created_at: new Date(),
+            });
+            console.log(`[stripe] Book adopted: ${adoptBookId} → "${creditName}" (${session.amount_total} ${session.currency})`);
+          } else {
+            console.warn(`[stripe] adopt_book session ${session.id} missing bookId or credit name`);
+          }
+        }
         break;
       }
 

--- a/src/components/book/AdoptBookPanel.tsx
+++ b/src/components/book/AdoptBookPanel.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+import type { Book } from '@/lib/types';
+import { ADOPT_TIERS, ADOPT_MAX_CENTS, resolveAdoptTier, formatEuros } from '@/lib/adopt-tiers';
+
+/**
+ * Adopt-a-book amount selector + checkout launcher.
+ *
+ * Shows "Adopt this book →"; on open, the donor picks a suggested amount (or
+ * types their own, ≥ the tier minimum), then we create a Stripe Checkout
+ * Session (/api/adopt/checkout) for that amount and redirect.
+ */
+export default function AdoptBookPanel({
+  book,
+}: {
+  book: Pick<Book, 'id' | 'slug' | 'adopt_tier' | 'resource_type'>;
+}) {
+  const tier = resolveAdoptTier(book);
+  const cfg = ADOPT_TIERS[tier];
+
+  const [open, setOpen] = useState(false);
+  const [presetCents, setPresetCents] = useState(cfg.defaultCents);
+  const [customEuros, setCustomEuros] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const customCents = customEuros.trim()
+    ? Math.round(parseFloat(customEuros.replace(',', '.')) * 100)
+    : null;
+  const finalCents = customCents ?? presetCents;
+  const valid = Number.isFinite(finalCents) && finalCents >= cfg.minCents && finalCents <= ADOPT_MAX_CENTS;
+
+  async function start() {
+    if (!valid) {
+      setError(`Minimum ${formatEuros(cfg.minCents)}.`);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/adopt/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bookId: book.slug || book.id, amount: finalCents }),
+      });
+      const data = await res.json();
+      if (data?.url) {
+        window.location.href = data.url;
+        return;
+      }
+      setLoading(false);
+      setError(data?.error || 'Could not start checkout. Please try again.');
+    } catch {
+      setLoading(false);
+      setError('Could not start checkout. Please try again.');
+    }
+  }
+
+  if (!open) {
+    return (
+      <div className="mt-4 pt-4 border-t border-stone-700">
+        <button onClick={() => setOpen(true)} className="text-sm text-accent-gold hover:underline">
+          Adopt this book →
+        </button>
+        <p className="text-xs text-stone-500 mt-1">
+          Support its digitization and have your name credited here, forever — from {formatEuros(cfg.minCents)}.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 pt-4 border-t border-stone-700">
+      <p className="text-sm text-stone-300 mb-2">Choose your gift</p>
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        {cfg.suggestedCents.map((c) => {
+          const selected = customCents === null && presetCents === c;
+          return (
+            <button
+              key={c}
+              onClick={() => {
+                setPresetCents(c);
+                setCustomEuros('');
+                setError(null);
+              }}
+              className={`px-3 py-1.5 rounded text-sm border transition-colors ${
+                selected
+                  ? 'border-accent-gold text-accent-gold'
+                  : 'border-stone-600 text-stone-300 hover:border-stone-400'
+              }`}
+            >
+              {formatEuros(c)}
+            </button>
+          );
+        })}
+        <span className="inline-flex items-center gap-1">
+          <span className="text-stone-500 text-sm">€</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={cfg.minCents / 100}
+            placeholder="Other"
+            value={customEuros}
+            onChange={(e) => {
+              setCustomEuros(e.target.value);
+              setError(null);
+            }}
+            className="w-20 px-2 py-1.5 rounded text-sm bg-stone-800 border border-stone-600 text-stone-200 placeholder:text-stone-500"
+          />
+        </span>
+      </div>
+      {error && <p className="text-xs text-red-400 mb-2">{error}</p>}
+      <button
+        onClick={start}
+        disabled={loading || !valid}
+        className="px-4 py-2 rounded text-sm border border-accent-gold text-accent-gold font-medium hover:bg-accent-gold/10 disabled:opacity-60"
+      >
+        {loading ? 'Starting…' : `Continue${valid ? ` — ${formatEuros(finalCents)}` : ''} →`}
+      </button>
+      <p className="text-xs text-stone-500 mt-2">
+        You&apos;ll be credited on this book&apos;s page, forever. Minimum {formatEuros(cfg.minCents)}.
+      </p>
+    </div>
+  );
+}

--- a/src/components/book/AdoptBookPanel.tsx
+++ b/src/components/book/AdoptBookPanel.tsx
@@ -121,6 +121,9 @@ export default function AdoptBookPanel({
       <p className="text-xs text-stone-500 mt-2">
         You&apos;ll be credited on this book&apos;s page, forever. Minimum {formatEuros(cfg.minCents)}.
       </p>
+      <p className="text-xs text-stone-500 mt-1">
+        Tax-deductible: ANBI (Netherlands) · 501(c)(3) (US, via the NAF).
+      </p>
     </div>
   );
 }

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, ChevronUp, Copy, Check, ExternalLink, Image as ImageIcon, 
 import type { Book, ImageSource, FieldProvenanceEntry } from '@/lib/types';
 import { IMAGE_LICENSES } from '@/lib/types';
 import BookEditModal from './BookEditModal';
+import AdoptBookPanel from './AdoptBookPanel';
 import { useRouter } from 'next/navigation';
 import { AuthCheck } from '@/components/auth/AuthCheck';
 import { firstTranslationDescription } from '@/lib/first-translation-labels';
@@ -130,29 +131,6 @@ export default function BibliographicInfo({
   const [copied, setCopied] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [provenanceExpanded, setProvenanceExpanded] = useState(false);
-  const [adopting, setAdopting] = useState(false);
-
-  // Adopt-a-book: start a Stripe checkout for this book, then redirect to it.
-  async function handleAdopt() {
-    setAdopting(true);
-    try {
-      const res = await fetch('/api/adopt/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bookId: book.slug || book.id }),
-      });
-      const data = await res.json();
-      if (data?.url) {
-        window.location.href = data.url;
-        return;
-      }
-      setAdopting(false);
-      alert(data?.error || 'Could not start checkout. Please try again.');
-    } catch {
-      setAdopting(false);
-      alert('Could not start checkout. Please try again.');
-    }
-  }
 
   // Format a bibliographic citation
   const formatCitation = () => {
@@ -604,18 +582,7 @@ export default function BibliographicInfo({
               </p>
             </div>
           ) : showExternalLinks ? (
-            <div className="mt-4 pt-4 border-t border-stone-700">
-              <button
-                onClick={handleAdopt}
-                disabled={adopting}
-                className="text-sm text-accent-gold hover:underline disabled:opacity-60 disabled:no-underline"
-              >
-                {adopting ? 'Starting…' : 'Adopt this book →'}
-              </button>
-              <p className="text-xs text-stone-500 mt-1">
-                Support its digitization and have your name credited here, from €250.
-              </p>
-            </div>
+            <AdoptBookPanel book={book} />
           ) : null}
 
           {/* Translation credit */}

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -130,6 +130,29 @@ export default function BibliographicInfo({
   const [copied, setCopied] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [provenanceExpanded, setProvenanceExpanded] = useState(false);
+  const [adopting, setAdopting] = useState(false);
+
+  // Adopt-a-book: start a Stripe checkout for this book, then redirect to it.
+  async function handleAdopt() {
+    setAdopting(true);
+    try {
+      const res = await fetch('/api/adopt/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bookId: book.slug || book.id }),
+      });
+      const data = await res.json();
+      if (data?.url) {
+        window.location.href = data.url;
+        return;
+      }
+      setAdopting(false);
+      alert(data?.error || 'Could not start checkout. Please try again.');
+    } catch {
+      setAdopting(false);
+      alert('Could not start checkout. Please try again.');
+    }
+  }
 
   // Format a bibliographic citation
   const formatCitation = () => {
@@ -560,7 +583,7 @@ export default function BibliographicInfo({
           ) : null}
 
           {/* Digitization sponsor credit — "adopt a book" donor acknowledgement */}
-          {book.digitization_sponsor && (
+          {book.digitization_sponsor ? (
             <div className="mt-4 pt-4 border-t border-stone-700">
               <p className="text-sm text-stone-300">
                 Digitized thanks to{' '}
@@ -580,7 +603,20 @@ export default function BibliographicInfo({
                 .
               </p>
             </div>
-          )}
+          ) : showExternalLinks ? (
+            <div className="mt-4 pt-4 border-t border-stone-700">
+              <button
+                onClick={handleAdopt}
+                disabled={adopting}
+                className="text-sm text-accent-gold hover:underline disabled:opacity-60 disabled:no-underline"
+              >
+                {adopting ? 'Starting…' : 'Adopt this book →'}
+              </button>
+              <p className="text-xs text-stone-500 mt-1">
+                Support its digitization and have your name credited here, from €222.22.
+              </p>
+            </div>
+          ) : null}
 
           {/* Translation credit */}
           {hasTranslations && (

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -581,6 +581,10 @@ export default function BibliographicInfo({
                 .
               </p>
             </div>
+          ) : book.digitization_adopted_at ? (
+            <div className="mt-4 pt-4 border-t border-stone-700">
+              <p className="text-sm text-stone-400">Digitization supported by an anonymous patron.</p>
+            </div>
           ) : showExternalLinks ? (
             <AdoptBookPanel book={book} />
           ) : null}

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -613,7 +613,7 @@ export default function BibliographicInfo({
                 {adopting ? 'Starting…' : 'Adopt this book →'}
               </button>
               <p className="text-xs text-stone-500 mt-1">
-                Support its digitization and have your name credited here, from €222.22.
+                Support its digitization and have your name credited here, from €250.
               </p>
             </div>
           ) : null}

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -559,6 +559,29 @@ export default function BibliographicInfo({
             </div>
           ) : null}
 
+          {/* Digitization sponsor credit — "adopt a book" donor acknowledgement */}
+          {book.digitization_sponsor && (
+            <div className="mt-4 pt-4 border-t border-stone-700">
+              <p className="text-sm text-stone-300">
+                Digitized thanks to{' '}
+                {showExternalLinks && book.digitization_sponsor_url ? (
+                  <a
+                    href={book.digitization_sponsor_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent-gold hover:text-accent-gold font-medium inline-flex items-center gap-1"
+                  >
+                    {book.digitization_sponsor}
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                ) : (
+                  <span className="text-accent-gold font-medium">{book.digitization_sponsor}</span>
+                )}
+                .
+              </p>
+            </div>
+          )}
+
           {/* Translation credit */}
           {hasTranslations && (
             <div className="mt-4 pt-4 border-t border-stone-700">

--- a/src/lib/adopt-tiers.ts
+++ b/src/lib/adopt-tiers.ts
@@ -1,0 +1,37 @@
+import type { Book } from '@/lib/types';
+
+/**
+ * Adopt-a-book pricing tiers. Shared by the client amount-selector
+ * (AdoptBookPanel) and the server checkout route so the suggested amounts and
+ * minimums can never drift apart. All amounts are in euro cents.
+ */
+
+export type AdoptTier = 'standard' | 'rare';
+
+export interface AdoptTierConfig {
+  minCents: number;          // hard minimum gift
+  suggestedCents: number[];  // buttons shown to the donor
+  defaultCents: number;      // pre-selected suggestion (the anchor)
+}
+
+/** Sanity ceiling so a typo can't create a €1,000,000 charge. */
+export const ADOPT_MAX_CENTS = 100_000_00; // €100,000
+
+export const ADOPT_TIERS: Record<AdoptTier, AdoptTierConfig> = {
+  // €250 floor, anchored at €500
+  standard: { minCents: 250_00, suggestedCents: [250_00, 500_00, 1000_00], defaultCents: 500_00 },
+  // rare/notable books and manuscripts — €500 floor, anchored at €1,000
+  rare: { minCents: 500_00, suggestedCents: [500_00, 1000_00, 2500_00], defaultCents: 1000_00 },
+};
+
+/** A book is "rare" if explicitly flagged, otherwise manuscripts default to rare. */
+export function resolveAdoptTier(book: Pick<Book, 'adopt_tier' | 'resource_type'>): AdoptTier {
+  if (book.adopt_tier === 'rare') return 'rare';
+  if (book.adopt_tier === 'standard') return 'standard';
+  return book.resource_type === 'manuscript' ? 'rare' : 'standard';
+}
+
+/** "€1,250" — no decimals, thousands separator. */
+export function formatEuros(cents: number): string {
+  return `€${Math.round(cents / 100).toLocaleString('en-IE')}`;
+}

--- a/src/lib/adoption-email.ts
+++ b/src/lib/adoption-email.ts
@@ -1,0 +1,84 @@
+import { Resend } from 'resend';
+
+/**
+ * Thank-you email sent when a donor adopts a book (Stripe webhook → adopt_book).
+ * Includes a link to a personalized, printable certificate.
+ */
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://sourcelibrary.org';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export interface AdoptionEmailParams {
+  to: string;
+  payerName?: string | null;
+  publicCredit?: string | null; // shown on the book; blank/absent = anonymous
+  bookTitle: string;
+  bookPath: string;             // "/book/<slug>"
+  sessionId: string;            // certificate token
+  amountLabel?: string;         // "€500"
+}
+
+export async function sendAdoptionThankYou(p: AdoptionEmailParams): Promise<void> {
+  if (!process.env.RESEND_API_KEY) return;
+  const resend = new Resend(process.env.RESEND_API_KEY);
+
+  const firstName = escapeHtml((p.payerName || '').split(' ')[0] || 'friend');
+  const title = escapeHtml(p.bookTitle);
+  const bookUrl = `${SITE_URL}${p.bookPath}`;
+  const certUrl = `${SITE_URL}/adopt/certificate/${encodeURIComponent(p.sessionId)}`;
+
+  const creditLine = p.publicCredit
+    ? `Your credit &mdash; <strong>&ldquo;Digitized thanks to ${escapeHtml(p.publicCredit)}&rdquo;</strong> &mdash; now appears on the book&rsquo;s page, and will for as long as it is read.`
+    : `At your request your gift is credited anonymously; the book&rsquo;s page simply records that a patron made its digitization possible.`;
+
+  await resend.emails.send({
+    from: process.env.EMAIL_FROM || 'Source Library <noreply@sourcelibrary.org>',
+    to: p.to,
+    replyTo: 'derek@sourcelibrary.org',
+    subject: `Thank you for adopting "${p.bookTitle}"`,
+    html: `
+    <div style="font-family: Georgia, 'Times New Roman', serif; max-width: 540px; margin: 0 auto; padding: 40px 24px; color: #1a1612;">
+      <div style="text-align: center; margin-bottom: 28px;">
+        <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 14px;" />
+        <h1 style="font-size: 22px; font-weight: 400; margin: 0; letter-spacing: -0.01em;">Source Library</h1>
+      </div>
+
+      <div style="line-height: 1.8; font-size: 15px;">
+        <p>Dear ${firstName},</p>
+        <p>
+          Thank you for adopting <a href="${bookUrl}" style="color:#9e4a3a; text-decoration:none;"><em>${title}</em></a>${p.amountLabel ? ` with a gift of ${escapeHtml(p.amountLabel)}` : ''}.
+          Because of you, this book will be digitized, translated, and made freely readable by anyone, anywhere &mdash; permanently.
+        </p>
+        <p>${creditLine}</p>
+      </div>
+
+      <div style="text-align:center; margin: 30px 0;">
+        <a href="${certUrl}" style="display:inline-block; background:#9e4a3a; color:#fff; text-decoration:none; padding:12px 22px; border-radius:6px; font-size:14px;">
+          View your certificate
+        </a>
+      </div>
+
+      <div style="background:#f5f0e8; border-radius:8px; padding:18px 22px; margin: 22px 0; line-height:1.7; font-size:14px;">
+        <strong>Your point of contact:</strong><br>
+        Derek Lomas, Project Director<br>
+        <a href="mailto:derek@sourcelibrary.org" style="color:#9e4a3a; text-decoration:none;">derek@sourcelibrary.org</a>
+      </div>
+
+      <div style="margin-top: 30px; padding-top: 18px; border-top: 1px solid #e8e4dc; line-height:1.7; font-size:13px; color:#8a8480;">
+        <p style="margin:0;">With gratitude,</p>
+        <p style="margin:4px 0 0; color:#1a1612;">The Source Library team</p>
+        <p style="margin:14px 0 0; font-size:12px;">
+          <a href="https://sourcelibrary.org" style="color:#8a8480;">sourcelibrary.org</a> &nbsp;&middot;&nbsp; Embassy of the Free Mind, Amsterdam
+        </p>
+      </div>
+    </div>`,
+  });
+}

--- a/src/lib/adoption-email.ts
+++ b/src/lib/adoption-email.ts
@@ -58,6 +58,11 @@ export async function sendAdoptionThankYou(p: AdoptionEmailParams): Promise<void
           Because of you, this book will be digitized, translated, and made freely readable by anyone, anywhere &mdash; permanently.
         </p>
         <p>${creditLine}</p>
+        <p style="font-size:14px; color:#4a4138;">
+          Your gift is tax-deductible &mdash; ANBI in the Netherlands, and (for US donors) via our 501(c)(3) partner,
+          the Netherland-America Foundation. Your Stripe receipt is your record; just reply to this email if you need
+          anything further for your taxes.
+        </p>
       </div>
 
       <div style="text-align:center; margin: 30px 0;">

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -108,6 +108,8 @@ export interface Book {
   // "Digitized thanks to ___" credit. Set via scripts/maintenance/set-digitization-sponsor.mjs.
   digitization_sponsor?: string;       // Display name (e.g., "Jane Smith", "In memory of …")
   digitization_sponsor_url?: string;   // Optional link (donor page / tribute), shown only when external links are allowed
+  // Adopt-a-book pricing tier. Defaults by resource_type (manuscripts → 'rare'); set explicitly to override.
+  adopt_tier?: 'standard' | 'rare';
 
   // Internet Archive identifier (for reimport)
   ia_identifier?: string;

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -106,8 +106,9 @@ export interface Book {
   // through the "adopt a book" programme. Distinct from image_source.sponsor (institutional
   // digitization funders such as Google/Sloan). Rendered on the book page as a gracious
   // "Digitized thanks to ___" credit. Set via scripts/maintenance/set-digitization-sponsor.mjs.
-  digitization_sponsor?: string;       // Display name (e.g., "Jane Smith", "In memory of …")
+  digitization_sponsor?: string;       // Public credit name (e.g., "Jane Smith", "In memory of …"). Absent = adopted anonymously.
   digitization_sponsor_url?: string;   // Optional link (donor page / tribute), shown only when external links are allowed
+  digitization_adopted_at?: string;    // Set when the book is adopted (even anonymously) — hides the "Adopt this book" CTA
   // Adopt-a-book pricing tier. Defaults by resource_type (manuscripts → 'rare'); set explicitly to override.
   adopt_tier?: 'standard' | 'rare';
 

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -102,6 +102,13 @@ export interface Book {
   // Image source and licensing (for scans/digitizations)
   image_source?: ImageSource;
 
+  // Digitization sponsor — an individual/donor who funded the digitization of THIS book
+  // through the "adopt a book" programme. Distinct from image_source.sponsor (institutional
+  // digitization funders such as Google/Sloan). Rendered on the book page as a gracious
+  // "Digitized thanks to ___" credit. Set via scripts/maintenance/set-digitization-sponsor.mjs.
+  digitization_sponsor?: string;       // Display name (e.g., "Jane Smith", "In memory of …")
+  digitization_sponsor_url?: string;   // Optional link (donor page / tribute), shown only when external links are allowed
+
   // Internet Archive identifier (for reimport)
   ia_identifier?: string;
 


### PR DESCRIPTION
## What
Adds a donor-facing **"Digitized thanks to <name>"** credit on book pages, for the **adopt-a-book** giving incentive (give €80, a book is digitized in your name). Suggested by Maria Marqués (EFM).

## Changes
- **`Book` type** (`src/lib/types/book.ts`): two optional top-level fields — `digitization_sponsor` (display name) and `digitization_sponsor_url` (optional link).
- **`BibliographicInfo.tsx`**: renders a gracious credit line (donor name in `accent-gold`); the optional link is gated behind `showExternalLinks`, so it stays clean in tenant/embed mode.
- **`scripts/maintenance/set-digitization-sponsor.mjs`**: set/clear the credit by book id or slug.

## Why a new field (not `image_source.sponsor`)
`image_source.sponsor` records the **institutional** digitization funder (Google, Sloan…) and renders as a dry "Sponsor:" provenance row. Conflating an individual donor with a corporate funder there read poorly. This is a distinct, warmer acknowledgement.

## In scope / out of scope
- **In:** the field, the render, a manual setter script.
- **Out (deliberate):** auto-attaching a sponsor from a Stripe webhook, and any admin UI — those are a follow-up once the donation flow is wired. The script covers the interim.

## Data path
No read-path plumbing needed: the book page already fetches the full doc via an *exclusion* projection + `JSON.parse(JSON.stringify(book))`, so the new top-level fields flow through automatically.

## Test plan
- Set on a book: `node scripts/maintenance/set-digitization-sponsor.mjs --book <id|slug> --name "Jane Smith" --url https://example.org`
- Load the book page → bibliographic panel shows "Digitized thanks to Jane Smith." (linked).
- `--clear` removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)