### PR TITLE
feat(es): feature the Spanish podcast on /es + Spanish RSS feed

### DIFF
--- a/src/app/api/podcast/feed.es.xml/route.ts
+++ b/src/app/api/podcast/feed.es.xml/route.ts
@@ -5,13 +5,13 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 3600; // 1 hour
 
 /**
- * GET /api/podcast/feed.xml — English podcast RSS 2.0 feed.
- * Spanish episodes are served separately at /api/podcast/feed.es.xml so each
- * show is labeled with the correct <language> for Apple/Spotify.
+ * GET /api/podcast/feed.es.xml — Spanish-language podcast RSS 2.0 feed.
+ * Only episodes tagged language === 'es', with <language>es</language> so it
+ * registers as a Spanish show on Apple Podcasts / Spotify.
  */
 export async function GET() {
-  const episodes = (await getPublishedEpisodes(50)).filter((ep) => ep.language !== 'es');
-  const xml = buildPodcastFeed(episodes, 'en');
+  const episodes = (await getPublishedEpisodes(50)).filter((ep) => ep.language === 'es');
+  const xml = buildPodcastFeed(episodes, 'es');
 
   return new Response(xml, {
     headers: {

--- a/src/app/podcast/[threadId]/page.tsx
+++ b/src/app/podcast/[threadId]/page.tsx
@@ -90,7 +90,7 @@ async function getEpisode(threadId: string): Promise<EpisodeData | null> {
     );
     if (!thread) return null;
 
-    let podcast: { topic: string; audioUrl: string; findingCount?: number; generatedAt: string; script?: string } | null = null;
+    let podcast: { topic: string; audioUrl: string; findingCount?: number; generatedAt: string; script?: string; sources?: Array<{ bookId: string; slug?: string; title: string; author?: string; origin?: string }> } | null = null;
     let format = 'deep-dive';
     for (const f of ['deep-dive', 'brief', 'critique', 'guided-reading']) {
       const p = thread.podcasts?.[f];
@@ -126,6 +126,30 @@ async function getEpisode(threadId: string): Promise<EpisodeData | null> {
           findingCount: rawFindings.filter(f => f.source?.bookId === bid).length,
         };
       }).sort((a, b) => b.findingCount - a.findingCount);
+    }
+
+    // Fallback: episodes without research-notebook findings can carry a curated
+    // `sources` list (links only). Use it for the Sources section + thumbnails.
+    if (sourceBooks.length === 0 && Array.isArray(podcast.sources) && podcast.sources.length > 0) {
+      const curatedIds = podcast.sources.map(s => s.bookId).filter(Boolean);
+      const bookDocs = curatedIds.length > 0
+        ? await db.collection('books')
+            .find({ id: { $in: curatedIds } })
+            .project({ id: 1, slug: 1, thumbnail: 1, thumbnail_blob: 1 })
+            .toArray()
+        : [];
+      const bookMap = new Map(bookDocs.map(b => [b.id, b]));
+      sourceBooks = podcast.sources.map(s => {
+        const b = bookMap.get(s.bookId);
+        return {
+          id: s.bookId,
+          title: s.title,
+          author: [s.author, s.origin].filter(Boolean).join(' · '),
+          slug: s.slug || b?.slug,
+          thumbnail: b?.thumbnail_blob || b?.thumbnail || null,
+          findingCount: 0,
+        };
+      });
     }
 
     // Load gallery images for referenced books — for page-level matching and gallery

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -15,7 +15,7 @@ import { HOME_STRINGS, type HomeLang, collectionName } from '@/lib/home-i18n';
 
 export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLang }) {
   const t = HOME_STRINGS[lang];
-  const { featuredItems, discoverBooks, showcase, counts, collections, blogPosts } = data;
+  const { featuredItems, discoverBooks, showcase, counts, collections, blogPosts, spanishPodcast } = data;
   const nf = (n: number) => n.toLocaleString(t.locale);
 
   return (
@@ -24,6 +24,78 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
 
       {/* Video Hero */}
       <HeroSection lang={lang} />
+
+      {/* Spanish podcast feature — the first real Spanish content a /es visitor
+          meets. Only rendered on /es, so the English homepage is unchanged. */}
+      {lang === 'es' && spanishPodcast && (
+        <section className="py-14 md:py-20" style={{ background: 'var(--bg-dark)' }}>
+          <div className="px-6 md:px-12 max-w-[1100px] mx-auto">
+            <div className="grid md:grid-cols-[1fr_1.2fr] gap-8 md:gap-12 items-center">
+              {spanishPodcast.heroImageUrl && (
+                <Link href={`/podcast/${spanishPodcast.threadId}`} className="block rounded-xl overflow-hidden bg-black/30">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={`/api/image?url=${encodeURIComponent(spanishPodcast.heroImageUrl)}&w=720&q=85`}
+                    alt=""
+                    className="w-full max-h-[360px] object-contain"
+                    loading="lazy"
+                  />
+                </Link>
+              )}
+              <div>
+                <p className="text-sm uppercase tracking-[0.2em] mb-3" style={{ color: 'var(--accent-gold)' }}>
+                  {t.podcastEyebrow}
+                </p>
+                <h2 className="text-2xl md:text-3xl font-display mb-4 leading-snug" style={{ color: '#f5f0e8' }}>
+                  {spanishPodcast.title}
+                </h2>
+                <p className="text-base leading-relaxed mb-5" style={{ color: '#b8b2a8' }}>
+                  {spanishPodcast.topic}
+                </p>
+
+                <audio controls preload="none" src={spanishPodcast.audioUrl} className="w-full mb-5">
+                  <a href={spanishPodcast.audioUrl}>{t.podcastListen}</a>
+                </audio>
+
+                {spanishPodcast.sources.length > 0 && (
+                  <div className="mb-5">
+                    <p className="text-xs uppercase tracking-wider mb-2" style={{ color: '#8a8480' }}>
+                      {t.podcastSourcesLabel}
+                    </p>
+                    <ul className="space-y-1.5">
+                      {spanishPodcast.sources.map((s) => (
+                        <li key={s.bookId}>
+                          <Link
+                            href={`/book/${s.slug || s.bookId}`}
+                            className="text-[15px] hover:underline"
+                            style={{ color: '#e8e2d8' }}
+                          >
+                            <span className="font-serif">{s.title}</span>
+                            {(s.author || s.origin) && (
+                              <span style={{ color: '#8a8480' }}>
+                                {' — '}{[s.author, s.origin].filter(Boolean).join(' · ')}
+                              </span>
+                            )}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                <Link
+                  href={`/podcast/${spanishPodcast.threadId}`}
+                  className="inline-flex items-center gap-1.5 text-sm font-medium px-5 py-2.5 rounded-full transition-all hover:brightness-110"
+                  style={{ background: 'var(--accent-rust)', color: '#fff' }}
+                >
+                  {t.podcastFullEpisode}
+                  <span className="text-xs">&rarr;</span>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Collections Grid */}
       <section id="library" className="bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6] py-16 md:py-24">

--- a/src/lib/embassy/podcast-feed.ts
+++ b/src/lib/embassy/podcast-feed.ts
@@ -1,0 +1,114 @@
+import { PODCAST_FORMATS, type PodcastMetadata } from './podcast';
+
+// Shared RSS 2.0 builder for the podcast feeds. We serve one feed per language
+// (English at /api/podcast/feed.xml, Spanish at /api/podcast/feed.es.xml) so
+// Apple/Spotify label each show with the correct <language> and Spanish-
+// speaking listeners can find a Spanish show. Episode `topic` text is already
+// in the episode's own language; only the channel chrome differs per locale.
+
+export type FeedEpisode = {
+  threadId: string;
+  threadTitle: string;
+  creatorName: string;
+  language: string;
+  podcast: PodcastMetadata;
+};
+
+type Locale = 'en' | 'es';
+
+const CHANNEL: Record<Locale, {
+  title: string;
+  description: string;
+  language: string;
+  self: string;
+  formatPrefix: (label: string, topic: string) => string;
+  itemDescription: (label: string, topic: string, findings: number, creator: string) => string;
+}> = {
+  en: {
+    title: 'Source Library Deep Dive',
+    description:
+      "AI-generated scholarly podcasts from the Embassy of the Free Mind's rare book collection. Explore alchemy, Hermetica, Kabbalah, and the Western esoteric tradition through primary sources from the 15th-18th centuries.",
+    language: 'en',
+    self: 'https://sourcelibrary.org/api/podcast/feed.xml',
+    formatPrefix: (label, topic) => `${label}: ${topic}`,
+    itemDescription: (label, topic, findings, creator) =>
+      `${label} episode exploring "${topic}" — generated from ${findings} research findings in Source Library. By ${creator}.`,
+  },
+  es: {
+    title: 'Source Library — Deep Dive en español',
+    description:
+      'Pódcast académico generado con IA a partir de las fuentes primarias de Source Library: alquimia, hermética, astrología, filosofía y ciencia del mundo antiguo y moderno temprano, narrado en español.',
+    language: 'es',
+    self: 'https://sourcelibrary.org/api/podcast/feed.es.xml',
+    formatPrefix: (_label, topic) => topic,
+    itemDescription: (_label, topic, _findings, creator) =>
+      `Un episodio que explora «${topic}», a partir de fuentes primarias en Source Library. Por ${creator}.`,
+  },
+};
+
+export function buildPodcastFeed(episodes: FeedEpisode[], locale: Locale): string {
+  const ch = CHANNEL[locale];
+
+  const lastBuildDate = episodes.length > 0
+    ? new Date(episodes[0].podcast.generatedAt).toUTCString()
+    : new Date().toUTCString();
+
+  const items = episodes.map((ep) => {
+    const pubDate = new Date(ep.podcast.generatedAt).toUTCString();
+    const formatLabel = PODCAST_FORMATS[ep.podcast.format]?.label || 'Deep Dive';
+    const title = escapeXml(ch.formatPrefix(formatLabel, ep.podcast.topic));
+    const description = escapeXml(ch.itemDescription(formatLabel, ep.podcast.topic, ep.podcast.findingCount, ep.creatorName));
+    // Link to the public episode page (not the auth-gated thread view).
+    const episodeUrl = `https://sourcelibrary.org/podcast/${ep.threadId}`;
+    const guid = `sourcelibrary-podcast-${ep.threadId}-${ep.podcast.format}`;
+
+    return `    <item>
+      <title>${title}</title>
+      <description>${description}</description>
+      <enclosure url="${escapeXml(ep.podcast.audioUrl)}" type="${ep.podcast.audioUrl.endsWith('.wav') ? 'audio/wav' : 'audio/mpeg'}" />
+      <guid isPermaLink="false">${guid}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <link>${episodeUrl}</link>
+      <itunes:author>${escapeXml(ep.creatorName)}</itunes:author>
+      <itunes:subtitle>${escapeXml(ep.podcast.topic)}</itunes:subtitle>
+      <itunes:summary>${description}</itunes:summary>
+      <podcast:transcript url="${episodeUrl}" type="text/html" />
+    </item>`;
+  }).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+  xmlns:podcast="https://podcastindex.org/namespace/1.0"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(ch.title)}</title>
+    <link>https://sourcelibrary.org/podcast</link>
+    <description>${escapeXml(ch.description)}</description>
+    <language>${ch.language}</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${ch.self}" rel="self" type="application/rss+xml" />
+    <itunes:author>Source Library</itunes:author>
+    <itunes:owner>
+      <itunes:name>Source Library</itunes:name>
+      <itunes:email>hello@sourcelibrary.org</itunes:email>
+    </itunes:owner>
+    <itunes:image href="https://sourcelibrary.org/brand/png/logo-dark--512.png" />
+    <itunes:category text="Education">
+      <itunes:category text="Higher Education" />
+    </itunes:category>
+    <itunes:category text="History" />
+    <itunes:explicit>false</itunes:explicit>
+${items}
+  </channel>
+</rss>`;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/src/lib/embassy/podcast.ts
+++ b/src/lib/embassy/podcast.ts
@@ -66,6 +66,15 @@ export interface PodcastResult {
   duration?: number;
 }
 
+/** A curated source book linked from an episode (no quotes — links only). */
+export interface PodcastSource {
+  bookId: string;
+  slug?: string;
+  title: string;
+  author?: string;
+  origin?: string;
+}
+
 export interface PodcastMetadata {
   audioUrl: string;
   r2Key: string;
@@ -75,6 +84,10 @@ export interface PodcastMetadata {
   topic: string;
   findingCount: number;
   published?: boolean;
+  /** ISO 639 language of the episode audio (e.g. 'es'); defaults to English. */
+  language?: string;
+  /** Curated source books, used when no research-notebook findings exist. */
+  sources?: PodcastSource[];
 }
 
 /**
@@ -448,6 +461,7 @@ export async function getPublishedEpisodes(limit = 50): Promise<Array<{
   threadId: string;
   threadTitle: string;
   creatorName: string;
+  language: string;
   podcast: PodcastMetadata;
 }>> {
   const db = await getDb();
@@ -464,13 +478,14 @@ export async function getPublishedEpisodes(limit = 50): Promise<Array<{
     })
     .sort({ 'podcasts.deep-dive.generatedAt': -1 })
     .limit(limit)
-    .project({ title: 1, creatorName: 1, podcasts: 1 })
+    .project({ title: 1, creatorName: 1, language: 1, podcasts: 1 })
     .toArray();
 
   const episodes: Array<{
     threadId: string;
     threadTitle: string;
     creatorName: string;
+    language: string;
     podcast: PodcastMetadata;
   }> = [];
 
@@ -482,6 +497,7 @@ export async function getPublishedEpisodes(limit = 50): Promise<Array<{
           threadId: thread._id.toString(),
           threadTitle: thread.title || p.topic,
           creatorName: thread.creatorName || 'Anonymous',
+          language: thread.language || p.language || 'en',
           podcast: p,
         });
       }

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -597,6 +597,49 @@ const BLOG_POSTS: HomeBlogPost[] = [
   },
 ];
 
+// ---------- Spanish podcast (featured on /es) ----------
+
+export interface SpanishPodcastSource {
+  bookId: string;
+  slug?: string;
+  title: string;
+  author?: string;
+  origin?: string;
+}
+
+export interface SpanishPodcast {
+  threadId: string;
+  title: string;
+  topic: string;
+  audioUrl: string;
+  heroImageUrl: string | null;
+  sources: SpanishPodcastSource[];
+}
+
+// Latest published Spanish-language deep-dive episode, for the /es feature.
+async function getSpanishPodcast(): Promise<SpanishPodcast | null> {
+  const db = await getReadDb();
+  const thread = await db.collection('embassy_threads').findOne(
+    { language: 'es', 'podcasts.deep-dive.published': true, 'podcasts.deep-dive.audioUrl': { $exists: true } },
+    {
+      projection: { title: 1, heroImage: 1, 'podcasts.deep-dive': 1 },
+      sort: { 'podcasts.deep-dive.generatedAt': -1 },
+      maxTimeMS: 5000,
+    } as any,
+  );
+  const p = thread?.podcasts?.['deep-dive'];
+  if (!thread || !p?.audioUrl) return null;
+
+  return {
+    threadId: thread._id.toString(),
+    title: thread.title || p.topic || '',
+    topic: p.topic || '',
+    audioUrl: p.audioUrl,
+    heroImageUrl: thread.heroImage?.url || null,
+    sources: Array.isArray(p.sources) ? p.sources : [],
+  };
+}
+
 // ---------- Aggregate ----------
 
 export interface HomeData {
@@ -606,16 +649,18 @@ export interface HomeData {
   counts: HomeCounts;
   collections: CollectionForGrid[];
   blogPosts: HomeBlogPost[];
+  spanishPodcast: SpanishPodcast | null;
 }
 
 export async function getHomeData(): Promise<HomeData> {
-  const [featuredItems, discoverBooks, showcase, counts, collections] = await Promise.all([
+  const [featuredItems, discoverBooks, showcase, counts, collections, spanishPodcast] = await Promise.all([
     withTimeout(getFeaturedCollections(), 20000, [] as FeaturedItem[]),
     withTimeout(getDiscoverBooks(), 20000, FALLBACK_DISCOVER_BOOKS),
     withTimeout(getCollectionShowcase(), 20000, [] as any[]),
     getBookCounts(),
     withTimeout(getRemainingCollections(), 20000, SORTED_FALLBACK_COLLECTIONS),
+    withTimeout(getSpanishPodcast(), 8000, null),
   ]);
 
-  return { featuredItems, discoverBooks, showcase, counts, collections, blogPosts: BLOG_POSTS };
+  return { featuredItems, discoverBooks, showcase, counts, collections, blogPosts: BLOG_POSTS, spanishPodcast };
 }

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -89,6 +89,12 @@ export interface HomeStrings {
   byYear: string;
   byImages: string;
 
+  // Spanish podcast feature (rendered only on /es)
+  podcastEyebrow: string;
+  podcastListen: string;
+  podcastSourcesLabel: string;
+  podcastFullEpisode: string;
+
   // Footer essay
   inSpiritOf: string;
   ficinoRole: string;
@@ -171,6 +177,11 @@ const en: HomeStrings = {
   byAuthor: 'author',
   byYear: 'year',
   byImages: 'images',
+
+  podcastEyebrow: 'Spanish podcast',
+  podcastListen: 'Listen to the episode',
+  podcastSourcesLabel: 'The four books in this episode',
+  podcastFullEpisode: 'Full episode & transcript',
 
   inSpiritOf: 'In the spirit of',
   ficinoRole: '1433–1499 · Philosopher & Translator',
@@ -256,6 +267,11 @@ const es: HomeStrings = {
   byAuthor: 'autor',
   byYear: 'año',
   byImages: 'imágenes',
+
+  podcastEyebrow: 'Pódcast en español',
+  podcastListen: 'Escuchar el episodio',
+  podcastSourcesLabel: 'Los cuatro libros de este episodio',
+  podcastFullEpisode: 'Episodio completo y transcripción',
 
   inSpiritOf: 'En el espíritu de',
   ficinoRole: '1433–1499 · Filósofo y traductor',


### PR DESCRIPTION
## Why
Our first genuinely **Spanish content** — the Deep Dive *"La astrología que cruzó el mundo"* — was published but buried: it only appeared in the English RSS feed and the generic `/podcast` list, with no source links and no hero image. Meanwhile `/es` (which gets real Latin-American Spanish traffic) had no Spanish content at all. This connects them.

## What
- **`/es` feature:** a Spanish-podcast block (Saturn-woodcut hero, topic, inline `<audio>` player, links to the four primary sources the episode discusses, and a button to the full episode + transcript). Rendered **only when `lang === 'es'`** — the English `/` is untouched. Data via `getSpanishPodcast()` in `home-data`.
- **Language-split podcast feeds:** `getPublishedEpisodes()` now returns `language`. `/api/podcast/feed.xml` excludes Spanish; new **`/api/podcast/feed.es.xml`** serves a Spanish show with `<language>es</language>` so Apple/Spotify list it as a Spanish podcast. Shared builder in `src/lib/embassy/podcast-feed.ts`. Feed item links now point at the public `/podcast/<id>` page instead of the auth-gated thread view.
- **Episode page:** when an episode has no `research_notebooks` findings, it falls back to a curated `podcast.sources` list (links only — no fabricated quotes) for the Sources section.
- i18n strings for the feature (`home-i18n`, en/es).

## Data
The episode's curated `sources` (4 verified books) + hero image (Flores Astrologiae Saturn woodcut, p.17 — the page the episode cites) were set on the `embassy_threads` doc. All four book links verified to resolve (200, no soft-404):
- Albumasar, *Flores Astrologiae* · Haly Abenragel, *De judiciis astrorum* · Nīlakaṇṭha, *Tājika* · Roger Bacon, *Opus Majus*

## Verification
- `npx tsc --noEmit` clean; check-imports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)