### PR TITLE
i18n: localize the global footer + move EN/ES toggle into the header

### DIFF
--- a/src/components/layout/GlobalFooter.tsx
+++ b/src/components/layout/GlobalFooter.tsx
@@ -7,44 +7,52 @@ import Image from 'next/image';
 import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 import FeedbackCallout from '@/components/feedback/FeedbackCallout';
 import { clearConsent } from '@/lib/consent';
+import { useLocale, FOOTER_STRINGS, type FooterStrings } from '@/lib/i18n';
 
-const NAV_COLUMNS = [
+// Labels are resolved per-locale from FOOTER_STRINGS via `key`; hrefs are
+// constant and point at the English pages (deep pages have no `/es` route).
+type FooterLinkKey = Exclude<keyof FooterStrings, 'colLibrary' | 'colAbout' | 'colParticipate'>;
+
+const NAV_COLUMNS: ReadonlyArray<{
+  titleKey: keyof FooterStrings;
+  links: ReadonlyArray<{ key: FooterLinkKey; href: string }>;
+}> = [
   {
-    title: 'Library',
+    titleKey: 'colLibrary',
     links: [
-      { label: 'Browse Books', href: '/' },
-      { label: 'Browse A–Z', href: '/browse' },
-      { label: 'Gallery', href: '/gallery' },
-      { label: 'Collections', href: '/collections' },
-      { label: 'Explore', href: '/explore' },
-      { label: 'Search', href: '/search' },
+      { key: 'browseBooks', href: '/' },
+      { key: 'browseAZ', href: '/browse' },
+      { key: 'gallery', href: '/gallery' },
+      { key: 'collections', href: '/collections' },
+      { key: 'explore', href: '/explore' },
+      { key: 'search', href: '/search' },
     ],
   },
   {
-    title: 'About',
+    titleKey: 'colAbout',
     links: [
-      { label: 'About', href: '/about' },
-      { label: 'Our Vision', href: '/vision' },
-      { label: 'Translation Census', href: '/census' },
-      { label: 'Progress', href: '/about/progress' },
-      { label: 'Research Notes', href: '/blog' },
-      { label: 'Privacy', href: '/privacy' },
-      { label: 'Cookie Settings', href: '#cookie-settings' },
-      { label: 'Terms', href: '/terms' },
-      { label: 'Copyright & DMCA', href: '/dmca' },
+      { key: 'about', href: '/about' },
+      { key: 'vision', href: '/vision' },
+      { key: 'census', href: '/census' },
+      { key: 'progress', href: '/about/progress' },
+      { key: 'researchNotes', href: '/blog' },
+      { key: 'privacy', href: '/privacy' },
+      { key: 'cookieSettings', href: '#cookie-settings' },
+      { key: 'terms', href: '/terms' },
+      { key: 'copyright', href: '/dmca' },
     ],
   },
   {
-    title: 'Participate',
+    titleKey: 'colParticipate',
     links: [
-      { label: 'Libraries', href: '/libraries' },
-      { label: 'Contribute', href: '/contribute' },
-      { label: 'Support', href: '/support' },
-      { label: 'Corporate Sponsorship', href: '/sponsors' },
-      { label: 'Developers', href: '/developers' },
+      { key: 'libraries', href: '/libraries' },
+      { key: 'contribute', href: '/contribute' },
+      { key: 'support', href: '/support' },
+      { key: 'sponsorship', href: '/sponsors' },
+      { key: 'developers', href: '/developers' },
     ],
   },
-] as const;
+];
 
 type Partner = {
   name: string;
@@ -67,6 +75,7 @@ const PARTNERS: Partner[] = [
 
 export default function GlobalFooter() {
   const pathname = usePathname();
+  const t = FOOTER_STRINGS[useLocale()];
   const [hasFavorites, setHasFavorites] = useState(false);
 
   useEffect(() => {
@@ -108,52 +117,52 @@ export default function GlobalFooter() {
         {/* Zone 2: Navigation Columns */}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 sm:gap-12 py-10 border-b border-white/[0.08]">
           {NAV_COLUMNS.map((col) => (
-            <div key={col.title}>
+            <div key={col.titleKey}>
               <h3 className="text-accent-gold text-xs font-semibold uppercase tracking-[0.15em] mb-4">
-                {col.title}
+                {t[col.titleKey]}
               </h3>
               <ul className="space-y-2.5">
                 {col.links.map((link) => (
                   <li key={link.href}>
-                    {link.label === 'Support' ? (
+                    {link.key === 'support' ? (
                       <Link
                         href={link.href}
                         className="text-sm text-white/50 hover:text-white transition-colors inline-flex items-center gap-1.5"
                       >
-                        {link.label}
+                        {t[link.key]}
                         <span className="text-[11px] bg-accent-rust/20 text-accent-rust px-2 py-0.5 rounded-full font-bold">
-                          Donate
+                          {t.donate}
                         </span>
                       </Link>
-                    ) : link.label === 'Cookie Settings' ? (
+                    ) : link.key === 'cookieSettings' ? (
                       <button
                         onClick={() => clearConsent()}
                         className="text-sm text-white/50 hover:text-white transition-colors"
                       >
-                        {link.label}
+                        {t[link.key]}
                       </button>
                     ) : (
                       <Link
                         href={link.href}
                         className="text-sm text-white/50 hover:text-white transition-colors"
                       >
-                        {link.label}
+                        {t[link.key]}
                       </Link>
                     )}
                   </li>
                 ))}
                 {/* Conditional personal links under Library */}
-                {col.title === 'Library' && hasFavorites && (
+                {col.titleKey === 'colLibrary' && hasFavorites && (
                   <li>
                     <Link href="/favorites" className="text-sm text-white/50 hover:text-white transition-colors">
-                      Favorites
+                      {t.favorites}
                     </Link>
                   </li>
                 )}
                 {/* Feedback widget under Participate */}
-                {col.title === 'Participate' && (
+                {col.titleKey === 'colParticipate' && (
                   <li>
-                    <FeedbackWidget label="Give Feedback" className="text-sm font-bold text-accent-rust hover:text-white transition-colors" />
+                    <FeedbackWidget label={t.giveFeedback} className="text-sm font-bold text-accent-rust hover:text-white transition-colors" />
                   </li>
                 )}
               </ul>

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -197,26 +197,8 @@ export default function HeroSection({ lang = 'en' }: { lang?: HomeLang }) {
             )}
           </div>
 
-          {/* Language switch — real routes (`/` ↔ `/es`) so each language is a
-              distinct, indexable page rather than a client-only string swap. */}
-          <div className="mt-6 flex items-center gap-2 text-sm">
-            <Link
-              href="/"
-              aria-current={lang === 'en' ? 'page' : undefined}
-              className={`transition-colors ${lang === 'en' ? 'text-white font-medium' : 'text-white/50 hover:text-white/80'}`}
-            >
-              {t.langEnglish}
-            </Link>
-            <span className="text-white/30">·</span>
-            <Link
-              href="/es"
-              aria-current={lang === 'es' ? 'page' : undefined}
-              className={`transition-colors ${lang === 'es' ? 'text-white font-medium' : 'text-white/50 hover:text-white/80'}`}
-            >
-              {t.langSpanish}
-            </Link>
-          </div>
-
+          {/* Language switch lives in the site header now (top-right EN · ES),
+              so it's discoverable above the fold on every homepage visit. */}
           {lang === 'en' && <LangSuggestBanner t={t} />}
         </div>
         </div>

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -62,6 +62,10 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
   const locale = useLocale();
   const t = NAV_STRINGS[locale];
   const NAV_LINKS = buildNavLinks(t);
+  // The EN/ES toggle only appears where a Spanish route exists — i.e. the
+  // homepage (`/` ↔ `/es`). Deep pages have no `/es` equivalent (thin i18n),
+  // so a global toggle there would dead-end on a 404.
+  const isHome = pathname === '/' || pathname === '/es';
 
   // Close menus on route change
   useEffect(() => { setMenuOpen(false); setDropdownOpen(null); }, [pathname]);
@@ -172,6 +176,35 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
               );
             })}
           </nav>
+
+          {/* Language toggle (homepage only — `/es` exists only for the home front door) */}
+          {isHome && (
+            <div className="flex items-center gap-1.5 text-xs font-medium tracking-wide" aria-label="Language">
+              <Link
+                href="/"
+                aria-current={locale === 'en' ? 'page' : undefined}
+                className={
+                  locale === 'en'
+                    ? (isWhiteText ? 'text-white' : 'text-primary')
+                    : (isWhiteText ? 'text-white/50 hover:text-white' : 'text-secondary hover:text-primary')
+                }
+              >
+                EN
+              </Link>
+              <span className={isWhiteText ? 'text-white/30' : 'text-stone-300'}>·</span>
+              <Link
+                href="/es"
+                aria-current={locale === 'es' ? 'page' : undefined}
+                className={
+                  locale === 'es'
+                    ? (isWhiteText ? 'text-white' : 'text-primary')
+                    : (isWhiteText ? 'text-white/50 hover:text-white' : 'text-secondary hover:text-primary')
+                }
+              >
+                ES
+              </Link>
+            </div>
+          )}
 
           {/* Desktop search icon */}
           <Link

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -63,3 +63,100 @@ export const NAV_STRINGS: Record<Locale, NavStrings> = {
     menu: 'Menú de navegación',
   },
 };
+
+// ---------- Shared site-shell strings (global footer) ----------
+// Labels only — hrefs are unchanged and still point at the English pages.
+// The thin-i18n design localizes only the homepage front door (`/es`); deep
+// pages have no `/es` route, so footer links must NOT be locale-prefixed.
+
+export interface FooterStrings {
+  // column titles
+  colLibrary: string;
+  colAbout: string;
+  colParticipate: string;
+  // Library column
+  browseBooks: string;
+  browseAZ: string;
+  gallery: string;
+  collections: string;
+  explore: string;
+  search: string;
+  favorites: string;
+  // About column
+  about: string;
+  vision: string;
+  census: string;
+  progress: string;
+  researchNotes: string;
+  privacy: string;
+  cookieSettings: string;
+  terms: string;
+  copyright: string;
+  // Participate column
+  libraries: string;
+  contribute: string;
+  support: string;
+  donate: string;
+  sponsorship: string;
+  developers: string;
+  giveFeedback: string;
+}
+
+export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
+  en: {
+    colLibrary: 'Library',
+    colAbout: 'About',
+    colParticipate: 'Participate',
+    browseBooks: 'Browse Books',
+    browseAZ: 'Browse A–Z',
+    gallery: 'Gallery',
+    collections: 'Collections',
+    explore: 'Explore',
+    search: 'Search',
+    favorites: 'Favorites',
+    about: 'About',
+    vision: 'Our Vision',
+    census: 'Translation Census',
+    progress: 'Progress',
+    researchNotes: 'Research Notes',
+    privacy: 'Privacy',
+    cookieSettings: 'Cookie Settings',
+    terms: 'Terms',
+    copyright: 'Copyright & DMCA',
+    libraries: 'Libraries',
+    contribute: 'Contribute',
+    support: 'Support',
+    donate: 'Donate',
+    sponsorship: 'Corporate Sponsorship',
+    developers: 'Developers',
+    giveFeedback: 'Give Feedback',
+  },
+  es: {
+    colLibrary: 'Biblioteca',
+    colAbout: 'Acerca de',
+    colParticipate: 'Participar',
+    browseBooks: 'Explorar libros',
+    browseAZ: 'Índice A–Z',
+    gallery: 'Galería',
+    collections: 'Colecciones',
+    explore: 'Descubrir',
+    search: 'Buscar',
+    favorites: 'Favoritos',
+    about: 'Acerca de',
+    vision: 'Nuestra visión',
+    census: 'Censo de traducciones',
+    progress: 'Progreso',
+    researchNotes: 'Notas de investigación',
+    privacy: 'Privacidad',
+    cookieSettings: 'Preferencias de cookies',
+    terms: 'Términos',
+    copyright: 'Derechos de autor y DMCA',
+    libraries: 'Bibliotecas',
+    contribute: 'Contribuir',
+    support: 'Apoyar',
+    donate: 'Donar',
+    sponsorship: 'Patrocinio corporativo',
+    developers: 'Desarrolladores',
+    giveFeedback: 'Enviar comentarios',
+  },
+};


### PR DESCRIPTION
## Feedback addressed

From footer feedback (Chiara Mancini, on `/`, 2026-06-22):
> "Spanish UI is only working for title hero text, it does not work for nav bar/footer or any other text. Also, I would put the language EN / ES, in the nav bar at the top!"

## What I found (verified on live `/es`)

- **Nav bar already localizes** — "Colecciones / Galería / Explorar / Bibliotecario / Catálogo" all render on `/es` via `NAV_STRINGS`. Her "nav bar doesn't work" was almost certainly a caching/timing artifact (her note predates the nav-i18n deploy).
- **Footer was 100% English** on `/es` ("Browse Books", "Our Vision", "Participate", "Give Feedback"…). **This was the real gap.**
- **`/es/collections` 404s** — deep pages have no Spanish route (thin-i18n by design). So footer/nav links must NOT be locale-prefixed.
- The EN/ES toggle existed only buried at the bottom of the hero, below the sign-up form.

## Changes

- **Footer localized** — `FOOTER_STRINGS` (en/es) added to `src/lib/i18n.ts`; every column title and link label resolves per-locale in `GlobalFooter.tsx`. **Hrefs unchanged** — they still point at the English pages (consistent with the deliberate thin-i18n decision; deep `/es/*` routes don't exist).
- **EN · ES toggle moved into `SiteHeader`** — top-right, shown only on the homepage (`/` ↔ `/es`, the one place a Spanish route exists), styled for both the transparent (hero) and light header variants. Removed the redundant buried hero toggle.

## Scope / out of scope

- In: footer labels + header toggle placement.
- Out (by design): deep-page content localization — that's English + browser-translate per the thin-i18n decision (memory: "don't re-propose a framework absent traffic data"). No new routes, no locale-prefixed links. `<html lang>` stays `en` (it's set in the root layout, which can't see the locale without middleware — separate change if wanted).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)