### PR TITLE
feat(bph-catalog): repeatable 'Add author' contributors, linked to our author thesaurus

### DIFF
--- a/src/app/api/catalog/author-search/route.ts
+++ b/src/app/api/catalog/author-search/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+
+/**
+ * Search OUR canonical author thesaurus (the `authors` collection) by name for
+ * the catalogue contributor picker. This is deliberately backed by the
+ * thesaurus that drives /author/[slug], variant→canonical redirects, and
+ * dedup — NOT VIAF (which has ~0.2% coverage on this corpus and grabs famous
+ * same-name people). When a cataloguer links a contributor here, it's the same
+ * canonical entity the public author page resolves to.
+ *
+ * Returns the canonical slug (`author_id` = authors._id) plus VIAF/Wikidata
+ * anchors carried on the thesaurus doc. Public bibliographic data, mirroring
+ * the existing /api/authority/author/search precedent.
+ */
+export const runtime = 'nodejs';
+
+interface AuthorDoc {
+  _id: string;
+  canonical_name?: string;
+  variants?: string[];
+  viaf_id?: string | null;
+  wikidata_id?: string | null;
+  book_count?: number;
+}
+
+export async function GET(req: NextRequest) {
+  const q = (new URL(req.url).searchParams.get('q') || '').trim();
+  if (q.length < 2) return NextResponse.json({ matches: [] });
+
+  const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const rx = new RegExp(escaped, 'i');
+
+  const db = await getDb();
+  const rows = (await db
+    .collection('authors')
+    .find(
+      { $or: [{ canonical_name: rx }, { variants: rx }, { _id: rx }] },
+      { projection: { canonical_name: 1, variants: 1, viaf_id: 1, wikidata_id: 1, book_count: 1 } },
+    )
+    .limit(40)
+    .toArray()) as unknown as AuthorDoc[];
+
+  // Rank: prefix match on the canonical name first, then by corpus weight.
+  const ql = q.toLowerCase();
+  rows.sort((a, b) => {
+    const ap = (a.canonical_name || a._id).toLowerCase().startsWith(ql) ? 1 : 0;
+    const bp = (b.canonical_name || b._id).toLowerCase().startsWith(ql) ? 1 : 0;
+    if (ap !== bp) return bp - ap;
+    return (b.book_count || 0) - (a.book_count || 0);
+  });
+
+  const matches = rows.slice(0, 12).map((r) => ({
+    author_id: r._id,
+    canonical_name: r.canonical_name || r._id,
+    viaf_id: r.viaf_id || null,
+    wikidata_id: r.wikidata_id || null,
+    // A couple of variant spellings help disambiguate same-name people.
+    variants: (r.variants || []).filter((v) => v !== r.canonical_name).slice(0, 3),
+  }));
+
+  return NextResponse.json({ matches });
+}

--- a/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
@@ -102,7 +102,7 @@ export default async function EditCatalogEntryPage({ params }: Props) {
   // from 20260624000000), retry without them. The form silently shows those
   // fields empty, and a save would fail at write time with the same error —
   // the right behaviour (don't pretend to save what we can't write).
-  const maybeMissingCols = ['author_entity_id', 'author_canonical_name', 'author_wikidata_qid', 'collection', 'impressum_original'];
+  const maybeMissingCols = ['author_entity_id', 'author_canonical_name', 'author_wikidata_qid', 'collection', 'impressum_original', 'contributors'];
   const cols = ['ubn', ...EDITABLE_BPH_FIELDS, 'field_provenance', 'sl_book_id'].join(', ');
   const fallbackCols = ['ubn', ...EDITABLE_BPH_FIELDS.filter((c) => !maybeMissingCols.includes(c)), 'field_provenance', 'sl_book_id'].join(', ');
   let { data, error } = await supabase

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -9,6 +9,7 @@ import { isPublishedFirstTranslation } from '@/lib/book';
 import { getPartnerBySlug } from '@/lib/library-partners';
 import { auth } from '@/lib/auth';
 import { ROLE_LEVEL, type Role } from '@/lib/auth';
+import type { BphContributor } from '@/lib/bph-catalog';
 import { AISection } from '@/components/embed/AISection';
 import GenericCatalogEntry, { generateGenericMetadata } from './GenericCatalogEntry';
 
@@ -82,6 +83,9 @@ interface BphWorkRow {
   binding: string | null;
   bound_with: string | null;
   provenance: string | null;
+  collection: string | null;
+  impressum_original: string | null;
+  contributors: BphContributor[] | null;
   ia_identifier: string | null;
   ustc_sn: string | null;
   sl_book_id: string | null;
@@ -133,17 +137,20 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
       keywords, language, series_title, volume_title,
       bibliography, remarks, number_of_copies, object_size_cm, bibliographic_format,
       binding, bound_with,
-      provenance, ia_identifier, ustc_sn, sl_book_id, sl_book_slug,
+      provenance, collection, impressum_original, contributors,
+      ia_identifier, ustc_sn, sl_book_id, sl_book_slug,
       sl_external_book_id, sl_external_slug, sl_external_source,
       field_provenance
     `;
-  // Two stacked fallbacks: drop external-link columns if not migrated, then
-  // drop author-authority columns. Each migration runs independently in
-  // different environments — the page renders if either is missing.
-  const fallbackSelect = select.replace(
-    'sl_external_book_id, sl_external_slug, sl_external_source,\n      ',
-    '',
-  );
+  // Stacked fallbacks: drop newer columns (collection/impressum/contributors),
+  // then external-link columns, then author-authority columns. Each migration
+  // runs independently per environment — the page renders if any are missing.
+  const fallbackSelect = select
+    .replace('provenance, collection, impressum_original, contributors,', 'provenance,')
+    .replace(
+      'sl_external_book_id, sl_external_slug, sl_external_source,\n      ',
+      '',
+    );
   const fallbackNoAuthority = fallbackSelect.replace(
     'author_entity_id, author_canonical_name, author_wikidata_qid, author_viaf_id,\n      ',
     '',
@@ -657,6 +664,25 @@ export default async function CatalogEntryPage({ params }: Props) {
               </span>
             </FieldRaw>
           )}
+          {work.contributors && work.contributors.length > 0 && (
+            <FieldRaw label="Other contributors">
+              <ul className="space-y-1 text-primary">
+                {work.contributors.map((c, i) => (
+                  <li key={i} className="flex flex-wrap items-baseline gap-x-2">
+                    <span className="text-muted text-xs uppercase tracking-wide">{c.role}</span>
+                    {c.author_id ? (
+                      <a href={`/author/${c.author_id}`} className="text-accent-rust hover:underline">
+                        {c.name || c.canonical_name}
+                      </a>
+                    ) : (
+                      <span>{c.name}</span>
+                    )}
+                    {c.variant_name && <span className="text-secondary text-xs">(&ldquo;{c.variant_name}&rdquo;)</span>}
+                  </li>
+                ))}
+              </ul>
+            </FieldRaw>
+          )}
         </Section>
 
         <Section title="Imprint">
@@ -666,6 +692,7 @@ export default async function CatalogEntryPage({ params }: Props) {
           <Field label="Printer (variant)" value={work.variant_printer} />
           <Field label="Publisher" value={work.publisher} />
           <Field label="Publisher (variant)" value={work.variant_publisher} />
+          <Field label="Original impressum" value={work.impressum_original} />
         </Section>
 
         <Section title="Subject & Language">
@@ -695,7 +722,8 @@ export default async function CatalogEntryPage({ params }: Props) {
           <Field label="Present location" value={work.present_location} />
           <Field label="Shelf mark" value={work.shelf_mark} mono />
           <Field label="State Collection shelf mark" value={work.state_shelf_mark?.trim().toLowerCase() === 'neen' ? null : work.state_shelf_mark} mono />
-          <Field label="Provenance / collection" value={work.provenance} />
+          <Field label="Provenance" value={work.provenance} />
+          <Field label="Collection" value={work.collection} />
         </Section>
 
         <Section title="Notes">

--- a/src/components/catalog/BphWorkEditForm.tsx
+++ b/src/components/catalog/BphWorkEditForm.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import AuthorAuthorityPicker, { type AuthorAuthoritySelection } from '@/components/catalog/AuthorAuthorityPicker';
+import ContributorsEditor from '@/components/catalog/ContributorsEditor';
+import type { BphContributor } from '@/lib/bph-catalog';
 
 /**
  * BPH catalogue entry edit form. Renders every whitelisted editable field
@@ -16,11 +18,10 @@ import AuthorAuthorityPicker, { type AuthorAuthoritySelection } from '@/componen
  * accurate revision history; the worst case is a noisy diff showing the
  * intervening change being overwritten.
  *
- * Repeatable schema (TEXT[]/JSONB for binding, notes, keywords, etc.) is
- * deferred — the current bph_works schema has these as single TEXT, and
- * the existing data convention (comma-separated for keywords, free-form
- * for notes) is preserved here. Real repeatables get their own PR with
- * the schema migration; the field whitelist already covers them.
+ * Repeatable authors/contributors ARE supported via the `contributors` JSONB
+ * column (BphContributor[]), edited through ContributorsEditor and linked to
+ * our canonical author thesaurus. Other repeatables (binding, keywords, …)
+ * remain single TEXT with the existing comma-separated convention.
  */
 
 interface Props {
@@ -132,6 +133,33 @@ const SECTIONS: Array<{
   },
 ];
 
+/** Normalise the stored `contributors` JSONB into editable rows. */
+function parseContributors(v: unknown): BphContributor[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .filter((c): c is Record<string, unknown> => !!c && typeof c === 'object')
+    .map((c) => ({
+      role: typeof c.role === 'string' && c.role ? c.role : 'Author',
+      name: typeof c.name === 'string' ? c.name : '',
+      variant_name: typeof c.variant_name === 'string' ? c.variant_name : '',
+      author_id: typeof c.author_id === 'string' ? c.author_id : null,
+      canonical_name: typeof c.canonical_name === 'string' ? c.canonical_name : null,
+    }));
+}
+
+/** Drop blank rows and trim before diffing / saving. */
+function cleanContributors(rows: BphContributor[]): BphContributor[] {
+  return rows
+    .map((c) => ({
+      role: c.role || 'Author',
+      name: (c.name || '').trim(),
+      variant_name: (c.variant_name || '').trim() || undefined,
+      author_id: c.author_id || undefined,
+      canonical_name: c.author_id ? c.canonical_name || undefined : undefined,
+    }))
+    .filter((c) => c.name.length > 0);
+}
+
 /** Convert null/undefined to '' for form inputs, numbers to strings. */
 function toFormValue(v: unknown): string {
   if (v === null || v === undefined) return '';
@@ -176,6 +204,12 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
   }, [initial]);
 
   const [values, setValues] = useState<Record<string, string>>(initialFormValues);
+  const initialContributors = useMemo(() => parseContributors(initial.contributors), [initial]);
+  const [contributors, setContributors] = useState<BphContributor[]>(initialContributors);
+  const contributorsChanged = useMemo(
+    () => JSON.stringify(cleanContributors(contributors)) !== JSON.stringify(cleanContributors(initialContributors)),
+    [contributors, initialContributors],
+  );
   const [createUbn, setCreateUbn] = useState(suggestedUbn || '');
   const [source, setSource] = useState('');
   const [evidence, setEvidence] = useState('');
@@ -203,7 +237,7 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
       setError('Give the new record a UBN (catalogue id).');
       return;
     }
-    if (changedFields.length === 0) {
+    if (changedFields.length === 0 && !contributorsChanged) {
       setError(isCreate ? 'Add at least a title before saving.' : 'No fields have changed — nothing to save.');
       return;
     }
@@ -232,6 +266,15 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
           ...(evidence.trim() ? { evidence: evidence.trim() } : {}),
         };
       }
+    }
+    // Repeatable contributors are a single JSONB field, edited outside the flat
+    // value map — include the cleaned array when it changed.
+    if (contributorsChanged) {
+      fieldChanges.contributors = {
+        to: cleanContributors(contributors),
+        source: source.trim(),
+        ...(evidence.trim() ? { evidence: evidence.trim() } : {}),
+      };
     }
 
     try {
@@ -472,6 +515,19 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
                 </FormField>
               );
             })}
+            {/* Repeatable authors / contributors (Paul D.) — the "Add author"
+                layer beyond the lead author, each linkable to our thesaurus. */}
+            {section.title === 'Authorship' && (
+              <div className="pt-2 border-t border-stone-100">
+                <label className="flex items-baseline gap-2 mb-2">
+                  <span className="text-xs text-muted">Additional authors &amp; contributors</span>
+                  {contributorsChanged && (
+                    <span className="text-[10px] uppercase text-accent-rust font-medium">changed</span>
+                  )}
+                </label>
+                <ContributorsEditor value={contributors} onChange={setContributors} />
+              </div>
+            )}
           </div>
         </section>
       ))}
@@ -480,12 +536,12 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
           scroll back to the top after editing the bottom of the form. */}
       <div className="sticky bottom-3 z-10 flex items-center justify-between gap-3 p-3 bg-white border border-border-light rounded-lg shadow-sm">
         <div className="text-sm text-muted">
-          {changedFields.length === 0 ? (
+          {changedFields.length + (contributorsChanged ? 1 : 0) === 0 ? (
             isCreate ? 'Add a title to begin' : 'No changes yet'
           ) : (
             <>
-              <span className="font-medium text-primary">{changedFields.length}</span>{' '}
-              field{changedFields.length === 1 ? '' : 's'} {isCreate ? 'filled' : 'changed'}
+              <span className="font-medium text-primary">{changedFields.length + (contributorsChanged ? 1 : 0)}</span>{' '}
+              field{changedFields.length + (contributorsChanged ? 1 : 0) === 1 ? '' : 's'} {isCreate ? 'filled' : 'changed'}
             </>
           )}
           {error && <span className="ml-3 text-accent-rust">{error}</span>}
@@ -499,7 +555,7 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
           </a>
           <button
             type="submit"
-            disabled={submitting || changedFields.length === 0}
+            disabled={submitting || (changedFields.length === 0 && !contributorsChanged)}
             className="px-4 py-1.5 text-sm rounded-md bg-accent-rust text-white hover:bg-accent-rust/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {submitting

--- a/src/components/catalog/BphWorkEditForm.tsx
+++ b/src/components/catalog/BphWorkEditForm.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import AuthorAuthorityPicker, { type AuthorAuthoritySelection } from '@/components/catalog/AuthorAuthorityPicker';
 import ContributorsEditor from '@/components/catalog/ContributorsEditor';
-import type { BphContributor } from '@/lib/bph-catalog';
+import type { BphContributor } from '@/lib/bph-contributors';
 
 /**
  * BPH catalogue entry edit form. Renders every whitelisted editable field

--- a/src/components/catalog/ContributorsEditor.tsx
+++ b/src/components/catalog/ContributorsEditor.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, Search, Plus, X, Link2, Check } from 'lucide-react';
+import { BPH_CONTRIBUTOR_ROLES, type BphContributor } from '@/lib/bph-catalog';
+
+/**
+ * Repeatable "Add author" editor for the catalogue (Paul D., 2026-06-24).
+ * Each row is a BphContributor with a role; rows can be linked to our canonical
+ * author thesaurus (the `authors` collection) via /api/catalog/author-search —
+ * the same identity that drives /author/[slug], not VIAF.
+ */
+
+interface AuthorMatch {
+  author_id: string;
+  canonical_name: string;
+  viaf_id: string | null;
+  wikidata_id: string | null;
+  variants: string[];
+}
+
+interface Props {
+  value: BphContributor[];
+  onChange: (next: BphContributor[]) => void;
+}
+
+export default function ContributorsEditor({ value, onChange }: Props) {
+  const addRow = () =>
+    onChange([...value, { role: 'Author', name: '', variant_name: '', author_id: null, canonical_name: null }]);
+  const removeRow = (i: number) => onChange(value.filter((_, idx) => idx !== i));
+  const patchRow = (i: number, patch: Partial<BphContributor>) =>
+    onChange(value.map((c, idx) => (idx === i ? { ...c, ...patch } : c)));
+
+  return (
+    <div className="space-y-3">
+      {value.length === 0 && (
+        <p className="text-xs text-muted">
+          No additional contributors. Use this for co-authors, editors, translators, engravers, and others beyond the lead author above.
+        </p>
+      )}
+
+      {value.map((c, i) => (
+        <ContributorRow
+          key={i}
+          contributor={c}
+          onPatch={(patch) => patchRow(i, patch)}
+          onRemove={() => removeRow(i)}
+        />
+      ))}
+
+      <button
+        type="button"
+        onClick={addRow}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
+      >
+        <Plus className="w-3.5 h-3.5" />
+        Add author
+      </button>
+    </div>
+  );
+}
+
+function ContributorRow({
+  contributor,
+  onPatch,
+  onRemove,
+}: {
+  contributor: BphContributor;
+  onPatch: (patch: Partial<BphContributor>) => void;
+  onRemove: () => void;
+}) {
+  const inputCls =
+    'w-full text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30';
+
+  return (
+    <div className="p-3 rounded-lg border border-border-light bg-warm/30 space-y-2">
+      <div className="flex gap-2">
+        <select
+          value={contributor.role}
+          onChange={(e) => onPatch({ role: e.target.value })}
+          className="text-sm border border-border-light rounded-md px-2 py-2 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+          aria-label="Role"
+        >
+          {BPH_CONTRIBUTOR_ROLES.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          value={contributor.name}
+          onChange={(e) => onPatch({ name: e.target.value })}
+          placeholder="Name (standard form)"
+          className={inputCls}
+        />
+        <button
+          type="button"
+          onClick={onRemove}
+          className="px-2 text-muted hover:text-accent-rust transition-colors"
+          aria-label="Remove contributor"
+          title="Remove"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+      <input
+        type="text"
+        value={contributor.variant_name || ''}
+        onChange={(e) => onPatch({ variant_name: e.target.value })}
+        placeholder="Name as on title page (optional)"
+        className={inputCls}
+      />
+      <AuthorLink contributor={contributor} onPatch={onPatch} />
+    </div>
+  );
+}
+
+/** Compact per-row search-and-link against our canonical author thesaurus. */
+function AuthorLink({
+  contributor,
+  onPatch,
+}: {
+  contributor: BphContributor;
+  onPatch: (patch: Partial<BphContributor>) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<AuthorMatch[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const debounce = useRef<NodeJS.Timeout | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(
+    () => () => {
+      if (debounce.current) clearTimeout(debounce.current);
+      if (abortRef.current) abortRef.current.abort();
+    },
+    [],
+  );
+
+  async function doSearch(q: string) {
+    const trimmed = q.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      setSearched(false);
+      return;
+    }
+    if (abortRef.current) abortRef.current.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/catalog/author-search?q=${encodeURIComponent(trimmed)}`, { signal: ctrl.signal });
+      const json = (await res.json()) as { matches?: AuthorMatch[] };
+      setResults(json.matches || []);
+      setSearched(true);
+    } catch (err) {
+      if ((err as { name?: string }).name !== 'AbortError') setResults([]);
+    } finally {
+      if (abortRef.current === ctrl) setLoading(false);
+    }
+  }
+
+  function onQueryChange(v: string) {
+    setQuery(v);
+    if (debounce.current) clearTimeout(debounce.current);
+    debounce.current = setTimeout(() => doSearch(v), 350);
+  }
+
+  // Linked state — show the canonical name + clear.
+  if (contributor.author_id) {
+    return (
+      <div className="flex items-center gap-2 flex-wrap text-xs">
+        <span className="inline-flex items-center gap-1 text-emerald-700">
+          <Check className="w-3.5 h-3.5" />
+          Linked: <span className="font-medium">{contributor.canonical_name || contributor.author_id}</span>
+        </span>
+        <a
+          href={`/author/${contributor.author_id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent-rust hover:underline"
+        >
+          view
+        </a>
+        <button
+          type="button"
+          onClick={() => onPatch({ author_id: null, canonical_name: null })}
+          className="text-muted hover:text-accent-rust underline"
+        >
+          unlink
+        </button>
+      </div>
+    );
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setOpen(true);
+          if (contributor.name.trim().length >= 2) {
+            setQuery(contributor.name);
+            doSearch(contributor.name);
+          }
+        }}
+        className="inline-flex items-center gap-1.5 text-xs text-secondary hover:text-primary transition-colors"
+      >
+        <Link2 className="w-3.5 h-3.5" />
+        Link to our author index
+      </button>
+    );
+  }
+
+  return (
+    <div className="p-2 border border-border-light rounded-md bg-white">
+      <div className="flex items-center justify-between mb-1.5">
+        <label className="text-[11px] uppercase tracking-wide text-muted">Search our author index</label>
+        <button type="button" onClick={() => setOpen(false)} className="text-muted hover:text-primary" aria-label="Close">
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              doSearch(query);
+            }
+          }}
+          placeholder="e.g. Kircher, Athanasius"
+          className="flex-1 px-2 py-1 text-sm border border-border-light rounded-md bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+          autoFocus
+        />
+        <span className="inline-flex items-center px-2 text-muted">
+          {loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Search className="w-3.5 h-3.5" />}
+        </span>
+      </div>
+
+      {searched && !loading && results.length === 0 && (
+        <p className="mt-2 text-xs text-muted italic">
+          No match in our index — leave it as a typed name, or it&rsquo;ll be created as a canonical author later.
+        </p>
+      )}
+
+      {results.length > 0 && (
+        <ul className="mt-2 space-y-1 max-h-56 overflow-y-auto">
+          {results.map((m) => (
+            <li key={m.author_id}>
+              <button
+                type="button"
+                onClick={() =>
+                  onPatch({
+                    author_id: m.author_id,
+                    canonical_name: m.canonical_name,
+                    name: contributor.name.trim() || m.canonical_name,
+                  })
+                }
+                className="w-full text-left px-2 py-1.5 rounded-md bg-white border border-border-light hover:border-accent-rust hover:bg-accent-rust/5 transition-colors"
+              >
+                <div className="text-sm font-medium text-primary">{m.canonical_name}</div>
+                <div className="flex items-center gap-2 text-[11px] text-muted mt-0.5">
+                  {m.viaf_id && <span>VIAF {m.viaf_id}</span>}
+                  {m.wikidata_id && <span>{m.wikidata_id}</span>}
+                  {m.variants.length > 0 && <span className="truncate">also: {m.variants.join(' · ')}</span>}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/catalog/ContributorsEditor.tsx
+++ b/src/components/catalog/ContributorsEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { Loader2, Search, Plus, X, Link2, Check } from 'lucide-react';
-import { BPH_CONTRIBUTOR_ROLES, type BphContributor } from '@/lib/bph-catalog';
+import { BPH_CONTRIBUTOR_ROLES, type BphContributor } from '@/lib/bph-contributors';
 
 /**
  * Repeatable "Add author" editor for the catalogue (Paul D., 2026-06-24).

--- a/src/lib/bph-catalog.ts
+++ b/src/lib/bph-catalog.ts
@@ -55,6 +55,11 @@ export const EDITABLE_BPH_FIELDS = [
   'author_canonical_name',
   'author_wikidata_qid',
   'author_viaf_id',
+  // Repeatable authors/contributors (Paul D., 2026-06-24) — a JSONB array of
+  // BphContributor, each optionally linked to a canonical authors._id. The
+  // primary `author` above stays the lead author (display/search/Atlas mirror);
+  // this is the additive "Add author" layer for co-authors, editors, etc.
+  'contributors',
   // Imprint
   'place',
   'printer',
@@ -93,6 +98,39 @@ export const EDITABLE_BPH_FIELDS = [
 ] as const;
 
 export type EditableBphField = (typeof EDITABLE_BPH_FIELDS)[number];
+
+/**
+ * Contributor roles for early-modern books, anticipating a book-historian's
+ * needs (Paul Dijstelberge). The lead author still lives in the scalar `author`
+ * field; this vocabulary covers the repeatable additional contributors.
+ */
+export const BPH_CONTRIBUTOR_ROLES = [
+  'Author',
+  'Editor',
+  'Translator',
+  'Commentator',
+  'Compiler',
+  'Engraver',
+  'Illustrator',
+  'Dedicatee',
+  'Contributor',
+  'Other',
+] as const;
+
+export type BphContributorRole = (typeof BPH_CONTRIBUTOR_ROLES)[number];
+
+/** One entry in `bph_works.contributors` (JSONB array). */
+export interface BphContributor {
+  role: string;
+  /** Name as catalogued (standard form). */
+  name: string;
+  /** Name as printed on the title page, if it differs. */
+  variant_name?: string;
+  /** Canonical `authors._id` (slug) when linked to our thesaurus. */
+  author_id?: string | null;
+  /** Denormalised canonical name for display without a join. */
+  canonical_name?: string | null;
+}
 
 /** Subset of bph_works that mirrors back to Atlas `books` (one-way). */
 const ATLAS_MIRROR_FIELDS: Record<string, string> = {

--- a/src/lib/bph-catalog.ts
+++ b/src/lib/bph-catalog.ts
@@ -99,38 +99,12 @@ export const EDITABLE_BPH_FIELDS = [
 
 export type EditableBphField = (typeof EDITABLE_BPH_FIELDS)[number];
 
-/**
- * Contributor roles for early-modern books, anticipating a book-historian's
- * needs (Paul Dijstelberge). The lead author still lives in the scalar `author`
- * field; this vocabulary covers the repeatable additional contributors.
- */
-export const BPH_CONTRIBUTOR_ROLES = [
-  'Author',
-  'Editor',
-  'Translator',
-  'Commentator',
-  'Compiler',
-  'Engraver',
-  'Illustrator',
-  'Dedicatee',
-  'Contributor',
-  'Other',
-] as const;
-
-export type BphContributorRole = (typeof BPH_CONTRIBUTOR_ROLES)[number];
-
-/** One entry in `bph_works.contributors` (JSONB array). */
-export interface BphContributor {
-  role: string;
-  /** Name as catalogued (standard form). */
-  name: string;
-  /** Name as printed on the title page, if it differs. */
-  variant_name?: string;
-  /** Canonical `authors._id` (slug) when linked to our thesaurus. */
-  author_id?: string | null;
-  /** Denormalised canonical name for display without a join. */
-  canonical_name?: string | null;
-}
+// Contributor type + role vocabulary live in a client-safe module (no server
+// deps) so 'use client' components can import them without pulling this
+// mongodb/supabase-bound module into the browser bundle. Re-exported here for
+// server-side callers.
+export { BPH_CONTRIBUTOR_ROLES } from './bph-contributors';
+export type { BphContributor, BphContributorRole } from './bph-contributors';
 
 /** Subset of bph_works that mirrors back to Atlas `books` (one-way). */
 const ATLAS_MIRROR_FIELDS: Record<string, string> = {

--- a/src/lib/bph-contributors.ts
+++ b/src/lib/bph-contributors.ts
@@ -1,0 +1,37 @@
+// Client-safe contributor types + role vocabulary. Kept separate from
+// bph-catalog.ts (which imports mongodb/supabase) so 'use client' components
+// can import these without dragging server-only modules into the browser
+// bundle. bph-catalog.ts re-exports them for server-side use.
+
+/**
+ * Contributor roles for early-modern books, anticipating a book-historian's
+ * needs (Paul Dijstelberge). The lead author still lives in the scalar `author`
+ * field; this vocabulary covers the repeatable additional contributors.
+ */
+export const BPH_CONTRIBUTOR_ROLES = [
+  'Author',
+  'Editor',
+  'Translator',
+  'Commentator',
+  'Compiler',
+  'Engraver',
+  'Illustrator',
+  'Dedicatee',
+  'Contributor',
+  'Other',
+] as const;
+
+export type BphContributorRole = (typeof BPH_CONTRIBUTOR_ROLES)[number];
+
+/** One entry in `bph_works.contributors` (JSONB array). */
+export interface BphContributor {
+  role: string;
+  /** Name as catalogued (standard form). */
+  name: string;
+  /** Name as printed on the title page, if it differs. */
+  variant_name?: string;
+  /** Canonical `authors._id` (slug) when linked to our thesaurus. */
+  author_id?: string | null;
+  /** Denormalised canonical name for display without a join. */
+  canonical_name?: string | null;
+}

--- a/supabase/migrations/20260624010000_bph_works_contributors.sql
+++ b/supabase/migrations/20260624010000_bph_works_contributors.sql
@@ -1,0 +1,18 @@
+-- bph_works: repeatable authors / contributors.
+-- From Paul Dijstelberge's feedback (2026-06-24): "There is only one field for
+-- author and secondary author. Both should be three / repeatable." Implemented
+-- as an "Add author" button backed by our own canonical authors thesaurus
+-- (better than VIAF for this corpus), with a role per entry.
+--
+-- `contributors` is an ordered JSONB array of:
+--   { role, name, variant_name?, author_id?, canonical_name? }
+-- where author_id links to the canonical `authors` collection (Mongo _id slug).
+-- The existing scalar `author`/`editor` columns are kept (primary author drives
+-- display, search, and the Atlas mirror); `contributors` is the additive,
+-- repeatable layer for co-authors, editors, translators, engravers, etc.
+--
+-- Additive and reversible (DROP COLUMN). Run via Supabase SQL editor or
+-- scripts/migration/run-supabase-sql.mjs.
+
+ALTER TABLE bph_works
+  ADD COLUMN IF NOT EXISTS contributors JSONB NOT NULL DEFAULT '[]'::jsonb;


### PR DESCRIPTION
## What & why

Paul Dijstelberge (2026-06-24): *"There is only one field for author and secondary author. Both should be three / repeatable."*

Built as an open-ended **"Add author" button** (not fixed slots), with each contributor linkable to **our canonical author thesaurus** — the `authors` collection that drives `/author/[slug]`, variant→canonical redirects, and dedup — rather than VIAF (which has ~0.2% coverage on this corpus and grabs famous same-name people).

## Changes

- **`contributors` JSONB column** on `bph_works` (migration `20260624010000`, already applied): ordered array of `{ role, name, variant_name?, author_id?, canonical_name? }`. The scalar `author` stays the lead author (display/search/Atlas mirror); this is the additive repeatable layer.
- **`ContributorsEditor`** — add/remove rows, a **role** per row (Author, Editor, Translator, Commentator, Compiler, Engraver, Illustrator, Dedicatee, Contributor, Other — anticipating a book-historian's needs), and a compact per-row search-and-link against our thesaurus. Unmatched names stay as typed text (and can be promoted to canonical authors later) — no dead-end.
- **`/api/catalog/author-search`** — name search over the `authors` thesaurus; returns the canonical slug + VIAF/Wikidata anchors. Verified: "Kircher" → athanasius-kircher (193 books), "Bellarmin" → bellarmino-roberto-s-j.
- **Detail page** now renders contributors (linked names → `/author/[slug]`), and also surfaces the **collection** + **original impressum** fields from the prior PR (previously write-only). Edit-loader and detail SELECT both degrade gracefully if a column isn't migrated.

## Notes

- The **primary** author still uses the legacy VIAF picker; moving that to the thesaurus too is a clean follow-up (didn't want to disturb the existing `author_entity_id`/Atlas-mirror path in this PR).
- Anticipated Paul's intent (open-ended + roles) so we can ship and get his feedback on the live feature. The one thing to confirm with him is the **role vocabulary**.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)