### PR TITLE
feat(adopt): gate adopt-a-book behind NEXT_PUBLIC_ADOPT_ENABLED flag

### DIFF
--- a/src/app/api/adopt/checkout/route.ts
+++ b/src/app/api/adopt/checkout/route.ts
@@ -17,6 +17,11 @@ import type { Book } from '@/lib/types';
 const ADOPT_CURRENCY = 'eur';
 
 export async function POST(request: NextRequest) {
+  // Feature flag — adopt-a-book stays dark until NEXT_PUBLIC_ADOPT_ENABLED=true,
+  // so the merged code is safe to ship before the Stripe/donation side is ready.
+  if (process.env.NEXT_PUBLIC_ADOPT_ENABLED !== 'true') {
+    return NextResponse.json({ error: 'Adopt-a-book is not yet available' }, { status: 503 });
+  }
   if (!stripe) {
     return NextResponse.json({ error: 'Payments not configured' }, { status: 503 });
   }

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -585,7 +585,7 @@ export default function BibliographicInfo({
             <div className="mt-4 pt-4 border-t border-stone-700">
               <p className="text-sm text-stone-400">Digitization supported by an anonymous patron.</p>
             </div>
-          ) : showExternalLinks ? (
+          ) : showExternalLinks && process.env.NEXT_PUBLIC_ADOPT_ENABLED === 'true' ? (
             <AdoptBookPanel book={book} />
           ) : null}
 


### PR DESCRIPTION
## Why
Adopt-a-book (#2719) is merged, but the Stripe/donation side isn't live yet. Without a flag, the **next `npm run deploy:prod` — for any reason, in any session — would expose live "Adopt this book" buttons and a real-charge checkout** before we're ready. This makes the merged code safe to ship anytime.

## What
Gate both surfaces on `NEXT_PUBLIC_ADOPT_ENABLED`:
- **Button:** `BibliographicInfo` only renders `AdoptBookPanel` when the flag is `'true'`.
- **Route:** `/api/adopt/checkout` 503s unless the flag is `'true'` (defense in depth, in case a stale client calls it).

**Default (unset) = dark.** Flip the Vercel env var `NEXT_PUBLIC_ADOPT_ENABLED=true` when Stripe is ready (prod, and preview if you want to demo). The `Digitized thanks to ___` credit and the anonymous-patron line still render regardless — they're display-only and harmless.

## Go-live checklist (when flipping the flag on)
- Confirm the donation entity / ANBI with Maria
- A test adoption (Stripe test mode, or a small live one you refund) end-to-end: checkout → webhook attaches credit → thank-you email → certificate page
- Re-point the campaign page's adopt section back to the live flow (currently says "coming soon")

## Test plan
- Flag unset → no "Adopt this book" button on book pages; `POST /api/adopt/checkout` returns 503.
- Flag `true` → button appears; checkout works as in #2719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)