### PR TITLE
fix(languages): page past PostgREST 1000-row cap (Chinese showed 49, really 683)

### DIFF
--- a/src/app/languages/page.tsx
+++ b/src/app/languages/page.tsx
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabase';
+import { fetchAllVisibleCatalogRows } from '@/lib/books-catalog';
 import Link from 'next/link';
 import Image from 'next/image';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
@@ -30,16 +30,17 @@ function languageSlug(name: string): string {
 }
 
 async function fetchLanguageStats(): Promise<{ languages: LanguageStats[]; totalBooks: number }> {
-  // Query books_catalog in Supabase — instant vs 10s+ MongoDB aggregation
-  const { data, error } = await supabase
-    .from('books_catalog')
-    .select('language, published, thumbnail, thumbnail_blob')
-    .eq('visible', true)
-    .gt('pages_count', 0)
-    .not('language', 'is', null)
-    .neq('language', '');
-
-  if (error) throw new Error(`Language stats query failed: ${error.message}`);
+  // Query books_catalog in Supabase — instant vs 10s+ MongoDB aggregation.
+  // Paginated: PostgREST caps each response at 1000 rows, so a single select
+  // would silently count languages from only ~6% of the catalog.
+  const data = await fetchAllVisibleCatalogRows<{
+    language: string | null;
+    published: string | null;
+    thumbnail: string | null;
+    thumbnail_blob: string | null;
+  }>('language, published, thumbnail, thumbnail_blob', (q) =>
+    q.not('language', 'is', null).neq('language', ''),
+  );
 
   // Group by language
   const langMap = new Map<string, { count: number; minYear?: string; maxYear?: string; heroImage?: string }>();

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -191,24 +191,57 @@ export async function countBooks(filter: {
 /**
  * Get distinct language counts for a provider or collection.
  */
+/**
+ * Fetch ALL visible, processed books_catalog rows for the given columns,
+ * paginating past PostgREST's hard 1000-row response cap.
+ *
+ * CRITICAL: `.limit(20000)` does NOT raise this cap — PostgREST clamps every
+ * response to its server-side `db-max-rows` (1000 here), so any code that pulls
+ * rows to aggregate in JS must page with `.range()`. Counting from a single
+ * 1000-row page silently undercounts everything (e.g. Chinese once read 49 of
+ * its real 683). `apply` adds per-call filters (provider, collection, …).
+ */
+export async function fetchAllVisibleCatalogRows<T = Record<string, unknown>>(
+  columns: string,
+  apply?: (q: any) => any,
+): Promise<T[]> {
+  const PAGE = 1000;
+  const all: T[] = [];
+  let offset = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    let query = supabase
+      .from('books_catalog')
+      .select(columns)
+      .eq('visible', true)
+      .gt('pages_count', 0)
+      .range(offset, offset + PAGE - 1);
+    if (apply) query = apply(query);
+
+    const { data, error } = await query;
+    if (error) throw new Error(`books_catalog page query failed: ${error.message}`);
+    if (!data || data.length === 0) break;
+    all.push(...(data as T[]));
+    if (data.length < PAGE) break;
+    offset += PAGE;
+  }
+  return all;
+}
+
 export async function getLanguageCounts(filter: {
   provider?: string;
   collection?: string;
 }): Promise<{ lang: string; count: number }[]> {
-  let query = supabase
-    .from('books_catalog')
-    .select('language')
-    .eq('visible', true)
-    .gt('pages_count', 0);
+  const rows = await fetchAllVisibleCatalogRows<{ language: string | null }>('language', (q) => {
+    let query = q;
+    if (filter.provider) query = query.eq('image_source_provider', filter.provider);
+    if (filter.collection) query = query.contains('collections', [filter.collection]);
+    return query;
+  });
 
-  if (filter.provider) query = query.eq('image_source_provider', filter.provider);
-  if (filter.collection) query = query.contains('collections', [filter.collection]);
-
-  // Supabase default limit is 1000 — need explicit limit for 17K+ books.
-  // Only fetching the language column, so this is lightweight.
-  const { data } = await query.limit(20000);
   const counts = new Map<string, number>();
-  for (const row of (data || [])) {
+  for (const row of rows) {
     if (row.language) counts.set(row.language, (counts.get(row.language) || 0) + 1);
   }
   return [...counts.entries()]


### PR DESCRIPTION
## Problem
`/languages` and `/api/languages` reported **Chinese at ~49** when the catalog holds **683 visible Chinese books** — a ~14× under-count that hid most of our largest non-English corpus from discovery. Every other language was undercounted too.

## Root cause
Both `getLanguageCounts()` and the `/languages` page's `fetchLanguageStats()` pull `books_catalog` rows and tally languages in JS. **PostgREST clamps every response to `db-max-rows` (1000)** — `.limit(20000)` does *not* override it. So languages were counted from only the first 1,000 of 16,335 rows (~6%). The sibling `browseAuthors()` already paginates for exactly this reason.

Verified against Supabase directly: `Range: 0-0` count headers show 16,335 total / 683 Chinese — the data was correct all along, only the read was truncated. **No re-sync needed.**

## Fix
Shared `fetchAllVisibleCatalogRows(columns, apply?)` helper that pages with `.range()` until exhausted; both call sites use it.

## Verify after deploy
`/api/languages` should report Chinese ≈ 683 (was 49); `/languages` page likewise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)