### PR TITLE
feat(qa-eval): ctext-grounded OCR accuracy metric for Chinese

### DIFF
--- a/.claude/skills/qa-eval/SKILL.md
+++ b/.claude/skills/qa-eval/SKILL.md
@@ -137,6 +137,23 @@ Place reference transcriptions and translations in `scripts/eval/ground-truth/` 
 
 Sources: BDRC etexts, OpenPecha, Esukhia Derge Kangyur, Lotsawa House, scholarly editions.
 
+### OCR vs. ctext (Chinese)
+
+For the Chinese corpus, OCR ground truth is auto-built from [ctext.org](https://ctext.org) canonical transcriptions:
+
+```bash
+node scripts/eval/build-ctext-groundtruth.mjs           # dry run — shows alignment + which works pass the guard
+node scripts/eval/build-ctext-groundtruth.mjs --write    # write pinned ground-truth files
+node scripts/eval/qa-eval.mjs compare --corpus=chinese --against=ocr
+```
+
+Two things make this work where a naive CER fails:
+
+- **Subsequence alignment** (`subsequenceCER` in `lib/metrics.mjs`). Most of our Chinese editions are *commentary* editions — the canonical main text is interleaved with small-character annotation that ctext's main-text-only transcription lacks. The reference is matched as an in-order subsequence of the OCR with extra (commentary) characters skipped free, so the metric scores OCR error on the canonical text only. A plain edit distance scored the Book of Odes at 6% when it was really 99%.
+- **Pinned book + page = identity guard.** `compare` fetches the exact `book_id`/`page_number` from each ground-truth file (no fuzzy title matching that could grab a same-phrase decoy). The generator only writes a file when the passage aligns below `--threshold` (default 0.30); anything above is skipped as a wrong book or a divergent recension (e.g. Zhu Xi's reordered *Great Learning*, the *Shiji* with 三家注) — reported, not counted as OCR error.
+
+Coverage caveat: ctext holds canonical **printed** texts only — manuscripts, tables, and rare/regional works (the actual OCR frontier) are out of scope and need MCR / cross-model / embedding checks instead. Baseline run (2026-06-25): **98.5% character accuracy** across 7 canonical works.
+
 ## Architecture
 
 ```

--- a/scripts/eval/build-ctext-groundtruth.mjs
+++ b/scripts/eval/build-ctext-groundtruth.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Build ctext-sourced OCR ground-truth files for the Chinese corpus.
+ *
+ * For each canonical work we hold, this finds the book + page where the work's
+ * opening passage appears, scores our OCR against ctext's canonical text with the
+ * subsequence aligner (commentary skipped free), and — only if it aligns cleanly
+ * (the book-identity / recension guard) — writes a pinned ground-truth file to
+ * scripts/eval/ground-truth/.  `qa-eval compare --against=ocr --corpus=chinese`
+ * then re-scores those pages into a repeatable corpus accuracy number.
+ *
+ * The reference snippets are short, public-domain classical passages; ctext is
+ * credited as the source. We compare against them, never re-host them.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/eval/build-ctext-groundtruth.mjs [--threshold=0.30] [--write]
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { subsequenceCER } from './lib/metrics.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const args = Object.fromEntries(process.argv.slice(2).map(a => {
+  const m = a.match(/^--([^=]+)(?:=(.*))?$/); return m ? [m[1], m[2] ?? true] : [a, true];
+}));
+const THRESHOLD = parseFloat(args.threshold || '0.30');
+const WRITE = !!args.write;
+const ZH = ['Chinese', 'Classical Chinese', 'Literary Chinese'];
+
+// work, slug, title regex, opening anchor, ctext source url, canonical reference text
+const WORKS = [
+  ['Daodejing ch.1', 'daodejing-1', '道德經|Tao Te Ching|Laozi|道德真經', '道可道', 'https://ctext.org/dao-de-jing/zh',
+    '道可道，非常道。名可名，非常名。無名天地之始；有名萬物之母。故常無欲，以觀其妙；常有欲，以觀其徼。此兩者，同出而異名，同謂之玄。玄之又玄，衆妙之門。'],
+  ['Analects 1.1', 'analects-xue-er', '論語|Analects|Four Books|四書', '學而時習之', 'https://ctext.org/analects/xue-er/zh',
+    '學而時習之，不亦說乎？有朋自遠方來，不亦樂乎？人不知而不慍，不亦君子乎？'],
+  ['Mengzi 1.1', 'mengzi-liang-hui-wang', '孟子|Mencius|Four Books|四書', '孟子見梁惠王', 'https://ctext.org/mengzi/liang-hui-wang-i/zh',
+    '孟子見梁惠王。王曰：叟不遠千里而來，亦將有以利吾國乎？孟子對曰：王何必曰利？亦有仁義而已矣。'],
+  ['Great Learning', 'da-xue', '大學|Great Learning|Four Books|四書', '大學之道', 'https://ctext.org/liji/da-xue/zh',
+    '大學之道，在明明德，在親民，在止於至善。知止而后有定，定而后能靜，靜而后能安，安而后能慮，慮而后能得。物有本末，事有終始，知所先後，則近道矣。'],
+  ['Doctrine of the Mean', 'zhong-yong', '中庸|Doctrine of the Mean|Four Books|四書', '天命之謂性', 'https://ctext.org/liji/zhong-yong/zh',
+    '天命之謂性，率性之謂道，修道之謂教。道也者，不可須臾離也，可離非道也。是故君子戒慎乎其所不睹，恐懼乎其所不聞。莫見乎隱，莫顯乎微。'],
+  ['Zhuangzi 1', 'zhuangzi-xiaoyaoyou', '莊子|Zhuangzi|南華', '北冥有魚', 'https://ctext.org/zhuangzi/enjoyment-in-untroubled-ease/zh',
+    '北冥有魚，其名為鯤。鯤之大，不知其幾千里也。化而為鳥，其名為鵬。鵬之背，不知其幾千里也；怒而飛，其翼若垂天之雲。是鳥也，海運則將徙於南冥。'],
+  ['Xunzi (Quan Xue)', 'xunzi-quan-xue', '荀子|Xunzi', '學不可以已', 'https://ctext.org/xunzi/quan-xue/zh',
+    '君子曰：學不可以已。青、取之於藍，而青於藍；冰、水為之，而寒於水。木直中繩，輮以為輪，其曲中規，雖有槁暴，不復挺者，輮使之然也。'],
+  ['Book of Odes (Guan Ju)', 'shijing-guan-ju', '詩經|Book of Poetry|Odes|毛詩|Collected Interpretations', '關關雎鳩', 'https://ctext.org/book-of-poetry/guan-ju/zh',
+    '關關雎鳩、在河之洲。窈窕淑女、君子好逑。參差荇菜、左右流之。窈窕淑女、寤寐求之。求之不得、寤寐思服。悠哉悠哉、輾轉反側。參差荇菜、左右采之。窈窕淑女、琴瑟友之。參差荇菜、左右芼之。窈窕淑女、鍾鼓樂之。'],
+  ['Shiji (Wu Di)', 'shiji-wu-di', '史記|Records of the Grand|Shiji', '黃帝者', 'https://ctext.org/shiji/wu-di-ben-ji/zh',
+    '黃帝者，少典之子，姓公孫，名曰軒轅。生而神靈，弱而能言，幼而徇齊，長而敦敏，成而聰明。軒轅之時，神農氏世衰。'],
+  ['Han Feizi (Nan Yan)', 'hanfeizi-nan-yan', '韓非子|Han Feizi', '臣非非難言也', 'https://ctext.org/hanfeizi/nan-yan/zh',
+    '臣非非難言也，所以難言者：言順比滑澤，洋洋纚纚然，則見以為華而不實。敦祗恭厚，鯁固慎完，則見以為掘而不倫。多言繁稱，連類比物，則見以為虛而無用。'],
+];
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set (source .env.production.local)'); process.exit(1); }
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const B = db.collection('books'), P = db.collection('pages');
+const gtDir = path.join(__dirname, 'ground-truth');
+if (WRITE) fs.mkdirSync(gtDir, { recursive: true });
+
+let written = 0, skipped = 0;
+for (const [work, slug, rx, anchor, sourceUrl, ref] of WORKS) {
+  const books = await B.find(
+    { language: { $in: ZH }, $or: [{ title: { $regex: rx, $options: 'i' } }, { display_title: { $regex: rx, $options: 'i' } }] },
+    { projection: { id: 1, _id: 1, title: 1, display_title: 1 }, sort: { pages_translated: -1 } },
+  ).limit(10).toArray();
+
+  let best = null;
+  for (const bk of books) {
+    const bookId = bk.id || bk._id.toString();
+    const pg = await P.findOne({ book_id: bookId, 'ocr.data': { $regex: anchor } }, { projection: { page_number: 1, 'ocr.data': 1 } });
+    if (!pg) continue;
+    const { cer } = subsequenceCER(ref, pg.ocr.data);
+    if (!best || cer < best.cer) best = { bookId, page: pg.page_number, cer, title: bk.display_title || bk.title };
+  }
+
+  if (!best) { console.log(`SKIP  ${work}: no book holds this passage`); skipped++; continue; }
+  if (best.cer > THRESHOLD) {
+    console.log(`SKIP  ${work}: best CER ${(best.cer * 100).toFixed(0)}% > ${(THRESHOLD * 100).toFixed(0)}% (wrong book or divergent recension) — [${best.title.slice(0, 30)}]`);
+    skipped++; continue;
+  }
+
+  const gt = {
+    work, book_id: best.bookId, page_number: best.page, script: 'cjk',
+    language: 'Chinese', source: 'ctext', source_url: sourceUrl,
+    anchor, ocr_ground_truth: ref,
+  };
+  console.log(`WRITE ${work}: ${best.bookId} p${best.page}  CER=${(best.cer * 100).toFixed(1)}%  [${best.title.slice(0, 30)}]`);
+  if (WRITE) fs.writeFileSync(path.join(gtDir, `chinese-${slug}.json`), JSON.stringify(gt, null, 2) + '\n');
+  written++;
+}
+
+console.log(`\n${WRITE ? 'Wrote' : 'Would write'} ${written} ground-truth files, skipped ${skipped}. ${WRITE ? '' : '(dry run — pass --write to save)'}`);
+await client.close();

--- a/scripts/eval/ground-truth/chinese-analects-xue-er.json
+++ b/scripts/eval/ground-truth/chinese-analects-xue-er.json
@@ -1,0 +1,11 @@
+{
+  "work": "Analects 1.1",
+  "book_id": "69e8b24d2ff2a8dc09e77295",
+  "page_number": 156,
+  "script": "cjk",
+  "language": "Chinese",
+  "source": "ctext",
+  "source_url": "https://ctext.org/analects/xue-er/zh",
+  "anchor": "學而時習之",
+  "ocr_ground_truth": "學而時習之，不亦說乎？有朋自遠方來，不亦樂乎？人不知而不慍，不亦君子乎？"
+}

--- a/scripts/eval/ground-truth/chinese-daodejing-1.json
+++ b/scripts/eval/ground-truth/chinese-daodejing-1.json
@@ -1,0 +1,11 @@
+{
+  "work": "Daodejing ch.1",
+  "book_id": "69935b692c63944063133f67",
+  "page_number": 13,
+  "script": "cjk",
+  "language": "Chinese",
+  "source": "ctext",
+  "source_url": "https://ctext.org/dao-de-jing/zh",
+  "anchor": "道可道",
+  "ocr_ground_truth": "道可道，非常道。名可名，非常名。無名天地之始；有名萬物之母。故常無欲，以觀其妙；常有欲，以觀其徼。此兩者，同出而異名，同謂之玄。玄之又玄，衆妙之門。"
+}

--- a/scripts/eval/ground-truth/chinese-hanfeizi-nan-yan.json
+++ b/scripts/eval/ground-truth/chinese-hanfeizi-nan-yan.json
@@ -1,0 +1,11 @@
+{
+  "work": "Han Feizi (Nan Yan)",
+  "book_id": "69e8b2742ff2a8dc09e77bdb",
+  "page_number": 549,
+  "script": "cjk",
+  "language": "Chinese",
+  "source": "ctext",
+  "source_url": "https://ctext.org/hanfeizi/nan-yan/zh",
+  "anchor": "臣非非難言也",
+  "ocr_ground_truth": "臣非非難言也，所以難言者：言順比滑澤，洋洋纚纚然，則見以為華而不實。敦祗恭厚，鯁固慎完，則見以為掘而不倫。多言繁稱，連類比物，則見以為虛而無用。"
+}

--- a/scripts/eval/ground-truth/chinese-shijing-guan-ju.json
+++ b/scripts/eval/ground-truth/chinese-shijing-guan-ju.json
@@ -1,0 +1,11 @@
+{
+  "work": "Book of Odes (Guan Ju)",
+  "book_id": "69d5ae594dc55b8478de1380",
+  "page_number": 34,
+  "script": "cjk",
+  "language": "Chinese",
+  "source": "ctext",
+  "source_url": "https://ctext.org/book-of-poetry/guan-ju/zh",
+  "anchor": "關關雎鳩",
+  "ocr_ground_truth": "關關雎鳩、在河之洲。窈窕淑女、君子好逑。參差荇菜、左右流之。窈窕淑女、寤寐求之。求之不得、寤寐思服。悠哉悠哉、輾轉反側。參差荇菜、左右采之。窈窕淑女、琴瑟友之。參差荇菜、左右芼之。窈窕淑女、鍾鼓樂之。"
+}

--- a/scripts/eval/ground-truth/chinese-xunzi-quan-xue.json
+++ b/scripts/eval/ground-truth/chinese-xunzi-quan-xue.json
@@ -1,0 +1,11 @@
+{
+  "work": "Xunzi (Quan Xue)",
+  "book_id": "69e8b26b2ff2a8dc09e77afc",
+  "page_number": 34,
+  "script": "cjk",
+  "language": "Chinese",
+  "source": "ctext",
+  "source_url": "https://ctext.org/xunzi/quan-xue/zh",
+  "anchor": "學不可以已",
+  "ocr_ground_truth": "君子曰：學不可以已。青、取之於藍，而青於藍；冰、水為之，而寒於水。木直中繩，輮以為輪，其曲中規，雖有槁暴，不復挺者，輮使之然也。"
+}

--- a/scripts/eval/ground-truth/chinese-zhong-yong.json
+++ b/scripts/eval/ground-truth/chinese-zhong-yong.json
@@ -1,0 +1,11 @@
+{
+  "work": "Doctrine of the Mean",
+  "book_id": "69aebb3439a4307877772f55",
+  "page_number": 50,
+  "script": "cjk",
+  "language": "Chinese",
+  "source": "ctext",
+  "source_url": "https://ctext.org/liji/zhong-yong/zh",
+  "anchor": "天命之謂性",
+  "ocr_ground_truth": "天命之謂性，率性之謂道，修道之謂教。道也者，不可須臾離也，可離非道也。是故君子戒慎乎其所不睹，恐懼乎其所不聞。莫見乎隱，莫顯乎微。"
+}

--- a/scripts/eval/ground-truth/chinese-zhuangzi-xiaoyaoyou.json
+++ b/scripts/eval/ground-truth/chinese-zhuangzi-xiaoyaoyou.json
@@ -1,0 +1,11 @@
+{
+  "work": "Zhuangzi 1",
+  "book_id": "69e72c60a409200ea79f46f6",
+  "page_number": 46,
+  "script": "cjk",
+  "language": "Chinese",
+  "source": "ctext",
+  "source_url": "https://ctext.org/zhuangzi/enjoyment-in-untroubled-ease/zh",
+  "anchor": "北冥有魚",
+  "ocr_ground_truth": "北冥有魚，其名為鯤。鯤之大，不知其幾千里也。化而為鳥，其名為鵬。鵬之背，不知其幾千里也；怒而飛，其翼若垂天之雲。是鳥也，海運則將徙於南冥。"
+}

--- a/scripts/eval/lib/metrics.mjs
+++ b/scripts/eval/lib/metrics.mjs
@@ -242,3 +242,64 @@ export function pairwiseMetrics(runs, script = 'default') {
   const avgSyl = pairs.reduce((s, p) => s + p.syllableSimilarity, 0) / (pairs.length || 1);
   return { pairs, avgCharSimilarity: avgChar, avgSyllableSimilarity: avgSyl };
 }
+
+// ── CJK OCR vs. canonical-text comparison (ctext ground truth) ──────
+// Most of our Chinese editions are COMMENTARY editions: the canonical main text
+// is interleaved with small-character annotation that ctext's main-text-only
+// transcription lacks. A plain edit distance counts that commentary as error and
+// reports false OCR failures (the Book of Odes scored 6% when it was really 99%).
+// subsequenceCER() instead matches the reference as an in-order subsequence of the
+// OCR, skipping extra OCR characters for free — so it measures OCR error on the
+// canonical text without penalizing correctly-read commentary.
+
+const OCR_WRAPPER_BLOCKS = ['meta', 'summary', 'keywords', 'vocab', 'language', 'scan-quality', 'script', 'page-type', 'columns', 'warning'];
+
+/** Strip editorial annotation wrapper blocks (content + tag) and inline gloss tags. */
+export function stripWrappers(s) {
+  if (!s) return '';
+  let t = s;
+  for (const w of OCR_WRAPPER_BLOCKS) t = t.replace(new RegExp(`<${w}[^>]*>[\\s\\S]*?</${w}>`, 'gi'), '');
+  return t.replace(/<\/?(note|term|margin|gloss|unclear|insert|header|catchword|sig|page-num)[^>]*>/gi, '');
+}
+
+/** Reduce CJK text to comparable characters: drop wrappers, punctuation, latin, digits, whitespace. */
+export function normalizeCJK(s) {
+  return stripWrappers(s).replace(/[。、，；：！？「」『』（）〈〉《》【】\s·．,.;:!?()0-9a-zA-Z○◯●－—\-]/g, '');
+}
+
+/**
+ * Subsequence character error rate of an OCR string against a canonical reference.
+ * Cost = substitutions + reference-character deletions (OCR dropped a main char);
+ * OCR-only characters (commentary, marginalia) are skipped at zero cost.
+ * Returns { cer, refLen, matched }. cer is a slight LOWER bound on true OCR error
+ * (free skips can match a coincidental subsequence), so treat as an optimistic
+ * estimate; a high cer (> ~0.30) means the reference is NOT cleanly present —
+ * i.e. wrong page/book or a divergent recension, not a salvageable OCR read.
+ */
+export function subsequenceCER(reference, ocr) {
+  const R = normalizeCJK(reference);
+  let O = normalizeCJK(ocr);
+  if (!R.length) return { cer: 0, refLen: 0, matched: 0 };
+  // Bound O to a window around the reference head so we don't match across a whole
+  // book and so the DP stays cheap.
+  const head = R.slice(0, 8);
+  const idx = O.indexOf(head);
+  const cap = R.length * 6 + 60;
+  O = idx >= 0 ? O.slice(idx, idx + cap) : O.slice(0, Math.max(cap, 400));
+  const m = R.length, n = O.length;
+  let prev = new Array(n + 1).fill(0); // dp[0][j] = 0: leading/extra O skips are free
+  for (let i = 1; i <= m; i++) {
+    const cur = new Array(n + 1);
+    cur[0] = i; // O exhausted → must delete remaining R chars
+    for (let j = 1; j <= n; j++) {
+      cur[j] = Math.min(
+        cur[j - 1],                                   // skip O[j-1] (commentary) — free
+        prev[j - 1] + (R[i - 1] === O[j - 1] ? 0 : 1), // match / substitute
+        prev[j] + 1,                                  // delete R[i-1] (OCR dropped it)
+      );
+    }
+    prev = cur;
+  }
+  const dist = prev[n];
+  return { cer: dist / m, refLen: m, matched: m - dist };
+}

--- a/scripts/eval/qa-eval.mjs
+++ b/scripts/eval/qa-eval.mjs
@@ -21,9 +21,9 @@
  * See: https://github.com/JDerekLomas/sourcelibrary/issues/1329
  */
 
-import { loadEnv, samplePages, disconnect, loadCorpusRegistry } from './lib/sampling.mjs';
+import { loadEnv, samplePages, getPage, disconnect, loadCorpusRegistry } from './lib/sampling.mjs';
 import { runModel, resolveModel, fetchImage, estimateCost } from './lib/runners.mjs';
-import { mcr, pairwiseMetrics, charSimilarity, syllableSimilarity, cleanText, cer, bleu4, rougeL } from './lib/metrics.mjs';
+import { mcr, pairwiseMetrics, charSimilarity, syllableSimilarity, cleanText, cer, bleu4, rougeL, subsequenceCER } from './lib/metrics.mjs';
 import { saveResults, loadLatestResults, listResults, generateConsistencyReport, generateEmbeddingReport, generateMatrixReport, saveBlogPost } from './lib/report.mjs';
 import { evaluateCorpus, evaluateRunConsistency } from './lib/embedding-eval.mjs';
 import fs from 'fs';
@@ -331,68 +331,66 @@ async function cmdCompare() {
     process.exit(1);
   }
 
-  const sampleSize = parseInt(args.sample || '10');
-
-  // Load ground truth
   const gtDir = path.join(__dirname, 'ground-truth');
   if (!fs.existsSync(gtDir)) {
     console.error(`No ground truth directory found at ${gtDir}`);
     process.exit(1);
   }
 
-  const groundTruth = new Map();
+  // Scope ground truth to the corpus's script so a Chinese run ignores e.g. Tibetan GT.
+  const registry = loadCorpusRegistry();
+  const corpusScript = registry[corpus]?.script;
+  const entries = [];
   for (const file of fs.readdirSync(gtDir).filter(f => f.endsWith('.json'))) {
     try {
       const gt = JSON.parse(fs.readFileSync(path.join(gtDir, file), 'utf8'));
-      const key = `${gt.book_id}-${gt.page_number}`;
-      groundTruth.set(key, gt);
+      if (corpusScript && gt.script && gt.script !== corpusScript) continue;
+      entries.push(gt);
     } catch { /* skip */ }
   }
 
-  if (groundTruth.size === 0) {
-    console.error('No ground truth files found. Add JSON files to scripts/eval/ground-truth/');
+  if (entries.length === 0) {
+    console.error('No matching ground truth files. Add JSON files to scripts/eval/ground-truth/');
     process.exit(1);
   }
 
   console.log(`\nGround Truth Comparison (${against})`);
-  console.log(`  Corpus: ${corpus}`);
-  console.log(`  Ground truth entries: ${groundTruth.size}\n`);
+  console.log(`  Corpus: ${corpus}  |  Ground truth entries: ${entries.length}\n`);
 
-  // Sample pages that have ground truth
-  const pages = await samplePages(corpus, sampleSize);
+  // Above this subsequence-CER, the reference isn't cleanly present in the page —
+  // i.e. wrong page/book or a divergent recension, not a salvageable OCR read.
+  const DIVERGENCE = parseFloat(args.threshold || '0.30');
   const results = [];
 
-  for (const page of pages) {
-    const key = `${page.bookId}-${page.pageNumber}`;
-    const gt = groundTruth.get(key);
-    if (!gt) continue;
+  for (const gt of entries) {
+    // Fetch the EXACT pinned book+page. Pinning by id is the book-identity guard —
+    // no fuzzy title matching that could grab a same-phrase decoy.
+    const page = await getPage(gt.book_id, gt.page_number);
+    const label = gt.work || gt.book_id;
+    if (!page) { console.log(`  - ${label}: page not found (${gt.book_id} p${gt.page_number})`); continue; }
+    const ocrText = page.ocr?.data || null;
+    const translationText = page.translation?.data || null;
+    const script = corpusScript || 'default';
 
-    if (against === 'ocr' && gt.ocr_ground_truth && page.ocrText) {
-      const cerScore = cer(page.ocrText, gt.ocr_ground_truth);
-      const charSim = charSimilarity(page.ocrText, gt.ocr_ground_truth);
+    if (against === 'ocr' && gt.ocr_ground_truth && ocrText) {
+      const { cer: score, refLen, matched } = subsequenceCER(gt.ocr_ground_truth, ocrText);
+      const aligned = score <= DIVERGENCE;
       results.push({
-        bookId: page.bookId,
-        bookTitle: page.bookTitle,
-        pageNumber: page.pageNumber,
-        cer: cerScore,
-        charSimilarity: charSim,
-        source: gt.source,
+        work: label, bookId: gt.book_id, pageNumber: gt.page_number,
+        cer: score, charAccuracy: 1 - score, refLen, matched, aligned,
+        source: gt.source, source_url: gt.source_url,
       });
-      console.log(`  ${page.bookTitle} p${page.pageNumber}: CER=${(cerScore * 100).toFixed(1)}% charSim=${(charSim * 100).toFixed(1)}%`);
+      console.log(`  ${aligned ? 'OK ' : 'XX '} ${label.padEnd(22)} CER=${(score * 100).toFixed(1).padStart(5)}%  acc=${((1 - score) * 100).toFixed(1).padStart(5)}%  (ref ${refLen})${aligned ? '' : '  [unalignable: wrong page / divergent recension]'}`);
     }
 
-    if (against === 'translation' && gt.translation_ground_truth && page.translationText) {
-      const bleuScore = bleu4(page.translationText, gt.translation_ground_truth, page.script);
-      const rougeLScore = rougeL(page.translationText, gt.translation_ground_truth, page.script);
+    if (against === 'translation' && gt.translation_ground_truth && translationText) {
+      const bleuScore = bleu4(translationText, gt.translation_ground_truth, script);
+      const rougeLScore = rougeL(translationText, gt.translation_ground_truth, script);
       results.push({
-        bookId: page.bookId,
-        bookTitle: page.bookTitle,
-        pageNumber: page.pageNumber,
-        bleu4: bleuScore,
-        rougeL: rougeLScore,
-        source: gt.translation_source,
+        work: label, bookId: gt.book_id, pageNumber: gt.page_number,
+        bleu4: bleuScore, rougeL: rougeLScore, source: gt.translation_source,
       });
-      console.log(`  ${page.bookTitle} p${page.pageNumber}: BLEU-4=${bleuScore.toFixed(3)} ROUGE-L=${rougeLScore.toFixed(3)}`);
+      console.log(`  ${label}: BLEU-4=${bleuScore.toFixed(3)} ROUGE-L=${rougeLScore.toFixed(3)}`);
     }
   }
 
@@ -401,12 +399,15 @@ async function cmdCompare() {
     process.exit(1);
   }
 
-  // Summary
   if (against === 'ocr') {
-    const avgCer = results.reduce((s, r) => s + r.cer, 0) / results.length;
-    const avgCharSim = results.reduce((s, r) => s + r.charSimilarity, 0) / results.length;
-    console.log(`\nAvg CER: ${(avgCer * 100).toFixed(1)}%`);
-    console.log(`Avg Char Similarity: ${(avgCharSim * 100).toFixed(1)}%`);
+    const aligned = results.filter(r => r.aligned);
+    const totalRef = aligned.reduce((s, r) => s + r.refLen, 0);
+    const charAcc = totalRef ? aligned.reduce((s, r) => s + r.matched, 0) / totalRef : 0;
+    console.log(`\n  Cleanly aligned: ${aligned.length}/${results.length}`);
+    console.log(`  Char-weighted OCR accuracy: ${(charAcc * 100).toFixed(2)}%  (CER ${((1 - charAcc) * 100).toFixed(2)}%)`);
+    const excluded = results.filter(r => !r.aligned);
+    if (excluded.length) console.log(`  Excluded (>${(DIVERGENCE * 100).toFixed(0)}% — wrong page / divergent recension, NOT an OCR failure): ${excluded.map(r => r.work).join(', ')}`);
+    console.log(`  Note: ctext covers canonical PRINTED texts only — manuscripts, tables and rare works are out of scope for this metric.`);
   } else {
     const avgBleu = results.reduce((s, r) => s + r.bleu4, 0) / results.length;
     const avgRouge = results.reduce((s, r) => s + r.rougeL, 0) / results.length;


### PR DESCRIPTION
## What
A repeatable OCR character-accuracy metric for the Chinese corpus, scored against **ctext.org** canonical transcriptions, wired into the existing `qa-eval compare` harness.

```
node scripts/eval/build-ctext-groundtruth.mjs --write
node scripts/eval/qa-eval.mjs compare --corpus=chinese --against=ocr
→ Char-weighted OCR accuracy: 98.47%  (CER 1.53%), 7/7 cleanly aligned
```

## Why a new scorer
Most of our Chinese editions are **commentary editions**: the canonical main text is interleaved with small-character annotation that ctext's main-text-only transcription lacks. A plain edit distance counts that commentary as error and reports false OCR failures — the Book of Odes scored **6%** under naive CER when it's really **99%**.

- **`subsequenceCER`** (`lib/metrics.mjs`) matches the reference as an in-order subsequence of the OCR, skipping extra (commentary) characters free → scores OCR error on the canonical text only.
- **Pinned book+page = identity guard.** `compare --against=ocr` now fetches the exact `book_id`/`page_number` from each ground-truth file (`getPage`) instead of random-sampling and hoping to hit it. No fuzzy title matching that could grab a same-phrase decoy (an earlier ad-hoc run matched a non-Yijing book that merely contained 元亨利貞).
- **Divergence threshold** (default `0.30`): above it, the reference isn't cleanly present — wrong page or a divergent recension (Zhu Xi's reordered *Great Learning*, the *Shiji* 三家注) — so it's reported and **excluded, not counted as OCR error**. The generator skips those; 7 of 10 candidates pass.

## Scope / caveat
ctext covers canonical **printed** texts only. Manuscripts, tables, and rare/regional works — the actual OCR frontier — are out of scope here and need MCR / cross-model / embedding checks (already in the framework). Reference snippets are short public-domain classical passages; ctext is credited as source, compared-against not re-hosted.

## Files
- `lib/metrics.mjs` (+`subsequenceCER`, `stripWrappers`, `normalizeCJK`)
- `qa-eval.mjs` (`compare` rewritten to fetch pinned GT pages + subsequence scorer + threshold + char-weighted aggregate)
- `build-ctext-groundtruth.mjs` (generator)
- `ground-truth/chinese-*.json` (7 pinned references)
- `SKILL.md` (docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)