### PR TITLE
fix(search): artwork lexical recall + stop semantic lane silently reading as 'no results' (#2735)

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -11,6 +11,7 @@ import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { anonSearchGate, SIGNIN_URL } from '@/lib/anon-gate';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { CLIP_URL } from '@/lib/clip';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 const ENTITIES_SEARCH_INDEX = 'entities_search';
 const GALLERY_SEARCH_INDEX = 'gallery_search';
@@ -165,11 +166,14 @@ export async function GET(request: NextRequest) {
       genre: string | null;
       period: string | null;
       similarity: number;
+      slug?: string | null;
     }
     const emptyArtworks = { results: [] as ArtworkSearchResult[], total: 0 };
     const emptyCollections = { results: [] as CollectionResult[] };
 
-    const [booksResultRaw, indexResult, galleryResult, visualResult, semanticResultRaw, artworkResult, collectionsResult] = await Promise.all([
+    const emptyLexicalArtworks: ArtworkSearchResult[] = [];
+
+    const [booksResultRaw, indexResult, galleryResult, visualResult, semanticResultRaw, artworkResult, lexicalArtworkResult, collectionsResult] = await Promise.all([
       withTimeout(searchBooks(query, limit, searchFilters, library), emptyBooks, 'books'),
       // Skip index/entity search for quoted phrases — autocomplete returns loose single-word noise
       isPhrase ? Promise.resolve(emptyIndex) : withTimeout(
@@ -237,6 +241,16 @@ export async function GET(request: NextRequest) {
           }))
           .catch(() => emptyArtworks),
         emptyArtworks, 'artworks', 6000,
+      ),
+      // Artwork lexical recall: exact title/author match on content_type:'artwork'
+      // books. The semantic lane above only returns the nearest few by vector, so a
+      // literal query ("tarot", "emblem", "ouroboros") under-returns — ~115 tarot
+      // cards exist but vector search surfaced 4. This lane fuses in every artwork
+      // that literally contains the term (#2735).
+      withTimeout(
+        lexicalArtworkSearch(db, queryRegex, 24, tenantContext.id || undefined)
+          .catch(() => emptyLexicalArtworks),
+        emptyLexicalArtworks, 'artworks-lexical', 3000,
       ),
       // Collection search: match collection names/descriptions (~300 docs, fast)
       withTimeout(
@@ -322,7 +336,16 @@ export async function GET(request: NextRequest) {
     };
     filteredSemantic.total = filteredSemantic.results.length;
 
-    const artworksAboveFloor = artworkResult.results.filter(r => r.similarity >= ARTWORK_SIM_FLOOR);
+    // Fuse lexical + semantic artwork recall. Exact title/author matches lead
+    // (they literally contain the query — they always belong); semantic fills in
+    // conceptually-near artworks above the similarity floor, deduped by book_id.
+    const lexicalArtworkIds = new Set(lexicalArtworkResult.map(a => a.book_id));
+    const semanticArtworksAboveFloor = artworkResult.results.filter(
+      r => r.similarity >= ARTWORK_SIM_FLOOR && !lexicalArtworkIds.has(r.book_id),
+    );
+    const ARTWORK_RESULT_LIMIT = 24;
+    const artworksAboveFloor = [...lexicalArtworkResult, ...semanticArtworksAboveFloor]
+      .slice(0, ARTWORK_RESULT_LIMIT);
     // Enrich artworks with slugs from MongoDB (needed for /artwork/[slug] links)
     if (artworksAboveFloor.length > 0) {
       try {
@@ -763,6 +786,69 @@ async function searchVisual(query: string, limit: number): Promise<{ results: Ga
   } catch {
     return { results: [], total: 0 };
   }
+}
+
+/**
+ * Lexical (term) recall for artworks — substring match on artwork title/author.
+ *
+ * The semantic artwork lane returns only the nearest few by vector, so a literal
+ * query under-returns (e.g. "tarot" → 4, while ~115 `content_type:'artwork'`
+ * records have "tarot" in the title). This surfaces every artwork whose title or
+ * author literally contains the term, to be fused with the semantic results (#2735).
+ */
+async function lexicalArtworkSearch(
+  db: any,
+  queryRegex: RegExp,
+  limit: number,
+  tenantId?: string,
+): Promise<Array<{
+  book_id: string;
+  title: string;
+  display_title: string | null;
+  author: string | null;
+  thumbnail_url: string | null;
+  genre: string | null;
+  period: string | null;
+  similarity: number;
+  slug?: string | null;
+}>> {
+  const docs = await db.collection('books').find(
+    {
+      content_type: 'artwork',
+      visible: true,
+      ...(tenantId ? { tenantId } : {}),
+      $or: [
+        { display_title: queryRegex },
+        { title: queryRegex },
+        { author: queryRegex },
+      ],
+    },
+    {
+      projection: {
+        _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1,
+        genre: 1, period: 1, resource_type: 1,
+        image_display: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1,
+        quality_score: 1,
+      },
+    },
+  )
+    .sort({ quality_score: -1 })
+    .limit(limit)
+    .maxTimeMS(3000)
+    .toArray();
+
+  return docs.map((d: any) => ({
+    book_id: d.id,
+    title: d.title,
+    display_title: d.display_title ?? null,
+    author: d.author ?? null,
+    thumbnail_url: getBookThumbnailUrl(d, 'thumb'),
+    genre: d.genre ?? d.resource_type ?? null,
+    period: d.period ?? null,
+    // Exact term match — rank ahead of vector neighbours (which sit below 1.0).
+    similarity: 1,
+    slug: d.slug ?? null,
+  }));
 }
 
 /**

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -452,8 +452,10 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
               type: g.type,
             } as GalleryItem);
           }
-          // Merge artwork semantic results as image cards (cap at 3 to avoid flooding)
-          const maxArtworks = 3;
+          // Merge artwork results as image cards. With lexical recall (#2735) a
+          // term like "tarot" now matches many artworks by title — show a real
+          // set of them, not just the 3 nearest by vector.
+          const maxArtworks = 8;
           let artworkCount = 0;
           for (const a of artworkResults) {
             if (artworkCount >= maxArtworks) break;

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -103,6 +103,11 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
   // Semantic results (parallel search agent)
   const [semanticResults, setSemanticResults] = useState<any[]>([]);
   const [semanticLoading, setSemanticLoading] = useState(false);
+  // True when the semantic lane errored/timed out (vs. genuinely returned nothing).
+  // Without this, a degraded 6s lane silently collapses to [] and the page presents
+  // "no related results" as if it were a fact — the "looks like 1 result" bug, where
+  // held editions catalogued under another name (Pimander ≈ Corpus Hermeticum) vanish.
+  const [semanticDegraded, setSemanticDegraded] = useState(false);
 
   // Page-content passage results (for quoted phrase searches)
   const [passageResults, setPassageResults] = useState<SearchResult[]>([]);
@@ -521,7 +526,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             setBookResults([]); setBookTotal(0);
             setIndexResults([]); setIndexTotal(0);
             setImageResults([]); setImageTotal(0);
-            setCollectionResults([]); setSemanticResults([]);
+            setCollectionResults([]); setSemanticResults([]); setSemanticDegraded(false);
             // Stop the parallel AI-expand stream so nothing leaks past the wall.
             aiAbortRef.current?.();
             setAiResults([]); setAiNarration(''); setAiStreaming(false);
@@ -536,19 +541,25 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
 
         // Fire semantic search in parallel (independent agent)
         setSemanticLoading(true);
+        setSemanticDegraded(false);
         const semanticParams = new URLSearchParams({ q, limit: '8' });
         if (language) semanticParams.set('language', language);
         if (dateFrom) semanticParams.set('year_min', dateFrom);
         if (dateTo) semanticParams.set('year_max', dateTo);
         fetch(`/api/search/semantic?${semanticParams.toString()}`)
-          .then(r => r.json())
+          .then(r => {
+            // A non-200 (timeout, 5xx) must NOT be parsed as an empty result set —
+            // r.json() on an error body yields {} → [], silently hiding held editions.
+            if (!r.ok) throw new Error(`semantic ${r.status}`);
+            return r.json();
+          })
           .then(data => {
             // Dedup against keyword book results
             const keywordIds = new Set(bookResults.map(b => b.id || b.book_id));
             const deduped = (data.results || []).filter((s: any) => !keywordIds.has(s.book_id));
             setSemanticResults(deduped);
           })
-          .catch(() => setSemanticResults([]))
+          .catch(() => { setSemanticResults([]); setSemanticDegraded(true); })
           .finally(() => setSemanticLoading(false));
 
         // Fire BPH catalog metadata search in parallel — only on a BPH tenant.
@@ -790,7 +801,9 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
 
   // Fuzzy suggestions on zero results
   const totalResults = bookTotal + indexTotal + imageTotal;
-  const noResults = !signInRequired && query.length >= 2 && !loading && !semanticLoading && !passageLoading && !catalogLoading && totalResults === 0 && semanticResults.length === 0 && passageResults.length === 0 && catalogResults.length === 0;
+  // Don't declare "no results" when the semantic lane errored out — that empty set
+  // is a failure, not a fact, and the page would otherwise claim nothing exists.
+  const noResults = !signInRequired && query.length >= 2 && !loading && !semanticLoading && !semanticDegraded && !passageLoading && !catalogLoading && totalResults === 0 && semanticResults.length === 0 && passageResults.length === 0 && catalogResults.length === 0;
   useEffect(() => {
     if (!noResults || query.length < 3) { setSuggestion(null); return; }
     let cancelled = false;
@@ -1471,6 +1484,11 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
 
           const bookSection = (
             <>
+              {semanticDegraded && !semanticLoading && (
+                <p className="text-xs text-muted italic mt-2">
+                  Related results couldn&apos;t be loaded just now — you may be seeing fewer matches than we hold. Try again in a moment.
+                </p>
+              )}
               {hasBoth && (
                 <h2 className="text-xs font-medium text-muted uppercase tracking-wide flex items-center gap-2 mt-4">
                   <span className="w-1.5 h-1.5 rounded-full bg-violet-400" />


### PR DESCRIPTION
Closes part of #2735 (the artwork-recall gap + the silent-semantic findability bug). Companion issue for the agent-facing work: #2740.

## Two focused findability fixes on the search surfaces

### 1. Lexical recall for artworks in `/api/search/unified`
The `artworks` bucket was fed only by `semanticArtworkSearch` (vector similarity), so a literal term massively under-returned: `?q=tarot` surfaced **4** artworks while **~158** `content_type:'artwork'` records have "tarot" in the title (all with live thumbnails). The cards existed but were invisible.

- New `lexicalArtworkSearch` — title/author substring recall on `content_type:'artwork'` books, **fused ahead of** the semantic neighbours, deduped by `book_id`, tenant-scoped, sorted by `quality_score`.
- Raised the `/search` artwork display cap 3 → 8 so the matches actually surface alongside books.
- Verified on the preview: `?q=tarot` now returns **24 artworks** (was 4); thumbnails resolve 200.

### 2. Stop the semantic lane silently reading as "no results"
The `/search` page renders "Conceptual matches" from a **separate** `fetch('/api/search/semantic')` that had **no `r.ok` check** and `.catch(() => setSemanticResults([]))`. That endpoint has **no anon gate** and a **6 s** lane — so on any timeout/5xx the held editions catalogued under another name (Pimander ≈ Corpus Hermeticum) vanished with no signal. This is the actual cause of the "corpus hermeticum looks like 1 result" symptom in #2735 — a bug, not a missing-unified-wiring gap (the box already calls `/unified`).

- Throw on non-200 instead of parsing an error body into `[]`.
- Track `semanticDegraded`; keep the full "no results" empty-state from firing when the lane errored (an empty set from a failure is not a fact).
- Show a subtle "you may be seeing fewer matches than we hold" notice.

## Scope
- **In:** the two findability fixes above. `npx tsc --noEmit` clean.
- **Out:** the agent-facing search rework (MCP `search_library` is books-only, more limited than `/unified`) — specced separately as **#2740**. Re-OCR/processing backlog. The `/catalog/scholar` bare-`/api/search` surface.

## Verification
- Preview deploy: `/api/search/unified?q=tarot` → `artworks.total: 24`, `books.total: 6`.
- Lexical lane returns 24 tarot artworks, all thumbnails 200.
- No ranking-ladder change to the book lane; artwork lane is additive. (Eval-guard recommended before any book-ranking change — none here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
