### PR TITLE
feat(blog): RSS feed + related-post links

### DIFF
--- a/src/app/api/feed/blog/route.ts
+++ b/src/app/api/feed/blog/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { posts } from '@/app/blog/page';
+
+// Atom feed for the Research Notes blog. Reads the same `posts` array the index
+// renders, so the feed never drifts from the site.
+
+export const dynamic = 'force-static';
+export const revalidate = 3600;
+
+const BASE_URL = 'https://sourcelibrary.org';
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+const MONTHS: Record<string, number> = {
+  january: 0, february: 1, march: 2, april: 3, may: 4, june: 5,
+  july: 6, august: 7, september: 8, october: 9, november: 10, december: 11,
+};
+
+// Parse the human date strings the blog uses ("25 June 2026") to ISO. Falls back
+// to now() on anything unexpected so a malformed date never breaks the feed.
+function toISO(date: string): string {
+  const m = date.trim().match(/^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/);
+  if (m) {
+    const month = MONTHS[m[2].toLowerCase()];
+    if (month !== undefined) {
+      return new Date(Date.UTC(Number(m[3]), month, Number(m[1]), 12)).toISOString();
+    }
+  }
+  const parsed = Date.parse(date);
+  return Number.isNaN(parsed) ? new Date().toISOString() : new Date(parsed).toISOString();
+}
+
+export async function GET() {
+  const dated = posts.map((p) => ({ ...p, iso: toISO(p.date) }))
+    .sort((a, b) => b.iso.localeCompare(a.iso));
+  const updated = dated[0]?.iso || new Date().toISOString();
+
+  const entries = dated.map((post) => {
+    const url = `${BASE_URL}/blog/${post.slug}`;
+    const image = post.image
+      ? `<img src="${escapeXml(post.image.startsWith('/') ? BASE_URL + post.image : post.image)}" alt="${escapeXml(post.imageAlt || post.title)}" /><br/>`
+      : '';
+    return `  <entry>
+    <id>${escapeXml(url)}</id>
+    <title>${escapeXml(post.title)}</title>
+    <link href="${escapeXml(url)}" rel="alternate" type="text/html"/>
+    <updated>${post.iso}</updated>
+    <published>${post.iso}</published>
+    <summary type="text">${escapeXml(post.subtitle)}</summary>
+    <content type="html"><![CDATA[${image}<p>${escapeXml(post.subtitle)}</p><p><a href="${url}">Read the full note &rarr;</a></p>]]></content>
+    ${post.tag ? `<category term="${escapeXml(post.tag)}"/>` : ''}
+    <author><name>Source Library</name></author>
+  </entry>`;
+  });
+
+  const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>${BASE_URL}/blog</id>
+  <title>Source Library — Research Notes</title>
+  <subtitle>AI-assisted research on the collection: OCR, translation, the history of science, and the texts behind it.</subtitle>
+  <link href="${BASE_URL}/blog" rel="alternate" type="text/html"/>
+  <link href="${BASE_URL}/api/feed/blog" rel="self" type="application/atom+xml"/>
+  <updated>${updated}</updated>
+  <icon>${BASE_URL}/favicon.ico</icon>
+  <author><name>Source Library</name><uri>${BASE_URL}</uri></author>
+${entries.join('\n')}
+</feed>`;
+
+  return new NextResponse(feed, {
+    headers: {
+      'Content-Type': 'application/atom+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   },
 };
 
-interface BlogPost {
+export interface BlogPost {
   slug: string;
   title: string;
   subtitle: string;
@@ -23,7 +23,8 @@ interface BlogPost {
   imageAlt?: string;
 }
 
-const posts: BlogPost[] = [
+// Exported so the RSS feed (/api/feed/blog) reads the same list — single source of truth.
+export const posts: BlogPost[] = [
   {
     slug: 'reading-classical-chinese',
     title: 'Can AI Read Classical Chinese?',
@@ -575,6 +576,19 @@ export default function BlogPage() {
       }
       bg="bg-cream"
     >
+      <div className="flex justify-end mb-6">
+        <a
+          href="/api/feed/blog"
+          className="inline-flex items-center gap-1.5 text-sm text-muted hover:text-accent-rust transition-colors"
+          title="Subscribe to Research Notes via RSS"
+        >
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 11a9 9 0 0 1 9 9h2.5A11.5 11.5 0 0 0 4 8.5V11zm0 4a5 5 0 0 1 5 5h2.5A7.5 7.5 0 0 0 4 12.5V15zm1.6 2.4A1.6 1.6 0 1 0 4 19a1.6 1.6 0 0 0 1.6-1.6z" />
+          </svg>
+          RSS
+        </a>
+      </div>
+
       {/* Hero post — editorial side-by-side feature */}
       <Link
         href={`/blog/${hero.slug}`}

--- a/src/app/blog/reading-classical-chinese/page.tsx
+++ b/src/app/blog/reading-classical-chinese/page.tsx
@@ -214,6 +214,20 @@ export default function ReadingClassicalChinesePage() {
           The OCR benchmark is reproducible from the open evaluation framework in the Source Library repository (<code>scripts/eval</code>): ground truth is built from ctext, and scored with the subsequence aligner described above. Translation comparisons quote the exact page text, linked above.
         </p>
 
+        {/* --- Related notes --- */}
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">Related notes</h2>
+        <p className="text-secondary leading-relaxed mb-4">
+          This is part of a running series on whether AI can read historical scripts:
+        </p>
+        <ul className="list-disc pl-6 text-secondary leading-relaxed mb-6 space-y-2">
+          <li><Link href="/blog/tibetan-ocr" className="text-accent-rust hover:underline">Benchmarking AI OCR on 232,000 Pages of Bhutanese Manuscripts</Link> &mdash; the same question for handwritten Tibetan.</li>
+          <li><Link href="/blog/cuneiform-ocr" className="text-accent-rust hover:underline">Can AI Read Cuneiform?</Link></li>
+          <li><Link href="/blog/hieroglyph-ocr" className="text-accent-rust hover:underline">Can AI Read Hieroglyphs? (No.)</Link></li>
+          <li><Link href="/blog/rashi-ocr" className="text-accent-rust hover:underline">The Rashi Problem: When AI OCR Hallucinates in Hebrew</Link></li>
+          <li><Link href="/blog/ocr-consistency" className="text-accent-rust hover:underline">How Consistent Is AI OCR?</Link> &mdash; the consistency metric, in depth.</li>
+          <li><Link href="/blog/confident-hallucinator" className="text-accent-rust hover:underline">The Confident Hallucinator</Link> &mdash; how AI translation fails, and how to catch it.</li>
+        </ul>
+
       </article>
 
       <BlogComments slug="reading-classical-chinese" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,6 +50,7 @@ export const metadata: Metadata = {
       'application/atom+xml': [
         { url: '/api/feed/books', title: 'Source Library - New Books' },
         { url: '/api/feed/gallery', title: 'Source Library Gallery' },
+        { url: '/api/feed/blog', title: 'Source Library - Research Notes' },
       ],
     },
   },


### PR DESCRIPTION
Two blog-distribution improvements surfaced while publishing the Chinese OCR post.

**RSS feed** — we had feeds for new books, the gallery, and the podcast, but none for the blog. Adds an Atom feed at **`/api/feed/blog`** (Research Notes), modeled on `/api/feed/books`, reading the same exported `posts` array as the index so the two never drift. Declared in `<head>` alternates for reader auto-discovery, plus a visible RSS link on the blog index.

**Related-post links** — a "Related notes" section on the Chinese post linking the running "Can AI Read X?" series (Tibetan, Cuneiform, Hieroglyphs, Rashi) + `ocr-consistency` + `confident-hallucinator`. All link targets curl-verified to resolve.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)