### PR TITLE
fix(search): flatten markdown tables in snippets (Vasari index pipe-soup)

### DIFF
--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -35,12 +35,38 @@
 const EDITORIAL_WRAPPERS =
   'meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning';
 
+/**
+ * Flatten GFM markdown tables to plain text.
+ *
+ * OCR/translation of tabular pages — most often the alphabetical "tavola"/index
+ * of a book — is stored as a markdown table, frequently with an EMPTY header row
+ * (`| | |` + `|---|---|`). In the reader that renders fine (react-markdown +
+ * remark-gfm), but every *snippet/quote* surface serves plain text, so the table
+ * leaks as raw pipe-soup: "# TABLE OF | | | |---|---| | Luigi Pulci s. | 493 |".
+ * Flatten each row to readable text ("Luigi Pulci s.  493") and drop the
+ * separator/empty-header scaffolding. Only the snippet/quote path routes through
+ * here — the reader keeps the real markdown and is unaffected.
+ */
+function flattenMarkdownTables(text: string): string {
+  return text
+    // Drop GFM alignment/separator rows (cells are only dashes + optional colons).
+    .replace(/^[ \t]*\|?[ \t]*:?-+:?[ \t]*(?:\|[ \t]*:?-+:?[ \t]*)+\|?[ \t]*$/gm, '')
+    // Flatten remaining table rows "| a | b |" → "a  b"; drop empty cells so an
+    // empty header row collapses to nothing rather than a row of blanks.
+    .replace(/^[ \t]*\|(.+)\|[ \t]*$/gm, (_m, inner: string) =>
+      inner.split('|').map(c => c.trim()).filter(Boolean).join('  '))
+    // Collapse the blank lines those removals leave behind.
+    .replace(/\n[ \t]*\n[ \t]*\n+/g, '\n\n');
+}
+
 export function stripEditorialWrappers(text: string): string {
   if (!text) return text;
-  return text
-    // Paired blocks, content and all (multiline). Backreference keeps it from
-    // swallowing text between two different wrapper types.
-    .replace(new RegExp(`<(${EDITORIAL_WRAPPERS})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
-    // Any orphan opening/closing wrapper tag left by malformed AI output.
-    .replace(new RegExp(`<\\/?(?:${EDITORIAL_WRAPPERS})>`, 'gi'), ' ');
+  return flattenMarkdownTables(
+    text
+      // Paired blocks, content and all (multiline). Backreference keeps it from
+      // swallowing text between two different wrapper types.
+      .replace(new RegExp(`<(${EDITORIAL_WRAPPERS})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
+      // Any orphan opening/closing wrapper tag left by malformed AI output.
+      .replace(new RegExp(`<\\/?(?:${EDITORIAL_WRAPPERS})>`, 'gi'), ' '),
+  );
 }

--- a/tests/unit/strip-editorial-wrappers.test.ts
+++ b/tests/unit/strip-editorial-wrappers.test.ts
@@ -66,4 +66,29 @@ describe('stripEditorialWrappers', () => {
     const out = stripEditorialWrappers(t).replace(/\s+/g, ' ').trim();
     expect(out).toBe('Lorem ipsum dolor sit amet');
   });
+
+  // ── Markdown table flattening (Vasari "tavola"/index pages) ──────────────
+  it('flattens an empty-header markdown table to readable lines, no pipe-soup', () => {
+    // The Vasari Vol.1 1568 index, p.42 — leaked into a search snippet as
+    // "# TABLE OF | | | |---|---| | Luigi Pulci s. | 493 | ...".
+    const t = `# TABLE OF\n\n| | |\n|---|---|\n| Luigi Pulci s. | 493 |\n| Gaddo Gaddi p. | 13 |`;
+    const out = stripEditorialWrappers(t);
+    expect(out).not.toMatch(/\|/);          // no raw pipes survive
+    expect(out).not.toMatch(/---/);         // no separator scaffolding
+    expect(out).toContain('Luigi Pulci s.  493');
+    expect(out).toContain('Gaddo Gaddi p.  13');
+  });
+
+  it('flattens aligned separator rows and multi-cell rows', () => {
+    const t = `| Name | Page |\n| :--- | ---: |\n| Thomas Aquinas, saint p. | 187 |`;
+    const out = stripEditorialWrappers(t).trim();
+    expect(out).not.toMatch(/[|]|:---|---:/);
+    expect(out).toContain('Name  Page');
+    expect(out).toContain('Thomas Aquinas, saint p.  187');
+  });
+
+  it('leaves prose containing an inline pipe untouched', () => {
+    const t = 'the choice of good | evil is the soul’s';
+    expect(stripEditorialWrappers(t)).toBe(t);
+  });
 });


### PR DESCRIPTION
## Problem
A search result for **Vasari, *Lives of the Painters*, vol.1 1568, p.42** rendered as raw markdown pipe-soup:
`# TABLE OF | | | |---|---| | Luigi Pulci s. | 493 | ...`

The OCR/translation of tabular pages — most often a book's alphabetical **"tavola"/index** — is stored as a GFM markdown table, frequently with an **empty header row** (`| | |` + `|---|---|`). The reader renders that fine (`react-markdown` + `remark-gfm`), but every **snippet/quote** surface serves plain text, so the table leaks as literal pipes. The OCR content itself is correct — this is purely a plain-text-rendering leak.

**Widespread, not one book:** a capped scan hit **400 pages across 48 distinct books** instantly.

## Fix
`stripEditorialWrappers` is the single cleaner every snippet/quote surface already routes through (`/api/search` `cleanText`, the quote API, IIIF annotation + content-search, likes). Teach it to **flatten table rows to readable lines** and drop the separator/empty-header scaffolding:

- `| Luigi Pulci s. | 493 |` → `Luigi Pulci s.  493`
- `| | |` / `|---|---|` / `| :--- | ---: |` → removed
- empty cells dropped, so an empty header row collapses to nothing

The reader keeps the real markdown (renders proper tables) and is untouched — only the plain-text snippet/quote path changes.

## Scope
- **In:** table flattening in the shared cleaner + 3 unit tests (12/12 pass). Verified end-to-end on the real Vasari p.42 text — snippet now reads as clean index lines.
- **Out:** leading `#`/`###` markdown heading markers still show literally in snippets (mild, separate class — left for a follow-up if wanted). Re-OCR (not needed — data is correct). The empty-header table also renders an ugly blank header *row* in the reader; a render-side `thead` tidy is a separate optional change.

## Test
- `tests/unit/strip-editorial-wrappers.test.ts` — added empty-header flatten, aligned/multi-cell flatten, and an "inline pipe in prose is untouched" guard. `npx vitest run` → 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
