### PR TITLE
feat(libraries): add IMSLP / Petrucci Music Library as a contributing library

### DIFF
--- a/src/lib/library-partners.ts
+++ b/src/lib/library-partners.ts
@@ -259,6 +259,16 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     color: 'violet',
     heroImageOverride: 'https://images.sourcelibrary.org/archived/6991bf67734f402cad489bb9/24.jpg',
   },
+  'imslp': {
+    slug: 'imslp',
+    name: 'IMSLP / Petrucci Music Library',
+    shortName: 'IMSLP',
+    providerKey: 'imslp',
+    url: 'https://imslp.org',
+    description: 'The International Music Score Library Project (IMSLP), also known as the Petrucci Music Library, is a volunteer-run free library of public-domain musical scores and printed music. As a re-hosting digital library it preserves scans contributed from collections worldwide — the works held here come from the British Library copy of "The Apollonian Harmony" (ca. 1790), digitized through IMSLP.',
+    color: 'gold',
+    heroImageOverride: 'https://images.sourcelibrary.org/books/6a3cef9ba907e2ce38470f7a/pages/0000.jpg',
+  },
   'sbb-berlin': {
     slug: 'sbb-berlin',
     name: 'Staatsbibliothek zu Berlin',

--- a/src/lib/types/image-source.ts
+++ b/src/lib/types/image-source.ts
@@ -15,6 +15,7 @@ export type ImageSourceProvider =
   | 'vatlib'         // Vatican Library (alternative endpoint)
   | 'europeana'      // Europeana aggregator
   | 'bl'             // British Library
+  | 'imslp'          // IMSLP / Petrucci Music Library (public-domain scores; re-host)
   | 'sbb'            // Staatsbibliothek zu Berlin
   | 'onb'            // Austrian National Library (Österreichische Nationalbibliothek)
   | 'loc'            // Library of Congress


### PR DESCRIPTION
## What
Adds **IMSLP / Petrucci Music Library** as a contributing library:
- New `imslp` value in `ImageSourceProvider`
- New `LIBRARY_PARTNERS['imslp']` entry → renders a `/libraries/imslp` credit page

## Why
First books from IMSLP just landed: both volumes of **The Apollonian Harmony** (Thompson's Music Warehouse, ca. 1790), a collection of glees/catches/madrigals. IMSLP is a volunteer-run free library of public-domain scores (the "Internet Archive of sheet music") — a re-hosting digital library like IA/Gallica, so it belongs in `LIBRARY_PARTNERS` per the project's contributing-library model. The underlying physical copy is the British Library's (shelfmark E.255.a), credited in the book metadata's `dc_source`.

## Scope
- Pure metadata/type addition — no DB changes, no runtime logic touched.
- The partner card on `/libraries` only surfaces once books with `providerKey: 'imslp'` are **visible** and synced to Supabase. The two Apollonian Harmony volumes are currently imported **hidden** pending QA, so the card appears after they're flipped visible. This PR is the standing infrastructure.

## Out of scope
- Flipping the books visible (QA pass first).
- OCR/translation of the scores (pipeline is paused; mostly engraved staves anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)