### PR TITLE
fix(syndication): OAI-PMH global catalog + self-maintaining blog sitemap

### DIFF
--- a/src/app/api/oai/route.ts
+++ b/src/app/api/oai/route.ts
@@ -165,9 +165,9 @@ function decodeToken(token: string): TokenData | null {
 
 // ─── Query builder ───
 
-function buildQuery(tenantId: string, from?: string, until?: string, set?: string): Document {
+function buildQuery(baseFilter: Document, from?: string, until?: string, set?: string): Document {
   const query: Document = {
-    tenantId,
+    ...baseFilter,
     pages_count: { $gt: 0 },
     pages_ocr: { $gt: 0 },
   };
@@ -186,10 +186,10 @@ function buildQuery(tenantId: string, from?: string, until?: string, set?: strin
 
 // ─── Verb handlers ───
 
-async function handleIdentify(now: string, tenantId: string): Promise<NextResponse> {
+async function handleIdentify(now: string, baseFilter: Document): Promise<NextResponse> {
   const db = await getReadDb();
   const earliest = await db.collection('books').findOne(
-    { tenantId, pages_count: { $gt: 0 } },
+    { ...baseFilter, pages_count: { $gt: 0 } },
     { sort: { created_at: 1 }, projection: { created_at: 1 }, maxTimeMS: 15000 }
   );
   const earliestDate = earliest?.created_at
@@ -232,9 +232,9 @@ function handleListMetadataFormats(now: string): NextResponse {
   );
 }
 
-async function handleListSets(now: string, tenantId: string): Promise<NextResponse> {
+async function handleListSets(now: string, baseFilter: Document): Promise<NextResponse> {
   const db = await getReadDb();
-  const categories = await db.collection('books').distinct('categories', { tenantId, pages_count: { $gt: 0 } });
+  const categories = await db.collection('books').distinct('categories', { ...baseFilter, pages_count: { $gt: 0 } }, { maxTimeMS: 20000 });
   const sets = categories
     .filter(Boolean)
     .sort()
@@ -255,7 +255,7 @@ ${sets}
 async function handleListRecords(
   now: string,
   params: URLSearchParams,
-  tenantId: string,
+  baseFilter: Document,
   headersOnly: boolean
 ): Promise<NextResponse> {
   const verbName = headersOnly ? 'ListIdentifiers' : 'ListRecords';
@@ -284,7 +284,7 @@ async function handleListRecords(
   }
 
   const db = await getReadDb();
-  const query = buildQuery(tenantId, from, until, set);
+  const query = buildQuery(baseFilter, from, until, set);
   const total = await db.collection('books').countDocuments(query, { maxTimeMS: 30000 });
 
   if (total === 0) return oaiError('noRecordsMatch', 'No records match the request', verbName);
@@ -317,7 +317,7 @@ ${records}${tokenXml}
   );
 }
 
-async function handleGetRecord(now: string, params: URLSearchParams, tenantId: string): Promise<NextResponse> {
+async function handleGetRecord(now: string, params: URLSearchParams, baseFilter: Document): Promise<NextResponse> {
   const identifier = params.get('identifier');
   const metadataPrefix = params.get('metadataPrefix');
 
@@ -331,7 +331,7 @@ async function handleGetRecord(now: string, params: URLSearchParams, tenantId: s
 
   const db = await getReadDb();
   const book = await db.collection('books').findOne({
-    tenantId,
+    ...baseFilter,
     $or: [{ id: bookId }, { slug: bookId }],
   });
 
@@ -348,10 +348,11 @@ ${bookToRecord(book)}
 // ─── Main handler ───
 
 export async function GET(request: NextRequest) {
+  // Scope: a tenant subdomain harvests its own subset; the main domain (no tenant)
+  // harvests the GLOBAL public catalog. `visible: true` keeps hidden / in-copyright
+  // books out of the harvest, matching every other public surface.
   const { id: tenantId } = getTenantContextFromRequest(request);
-  if (!tenantId) {
-    return oaiError('badArgument', 'Tenant context not found');
-  }
+  const baseFilter: Document = tenantId ? { tenantId } : { visible: true };
 
   const { searchParams } = new URL(request.url);
   const verb = searchParams.get('verb');
@@ -361,17 +362,17 @@ export async function GET(request: NextRequest) {
 
   switch (verb) {
     case 'Identify':
-      return handleIdentify(now, tenantId);
+      return handleIdentify(now, baseFilter);
     case 'ListMetadataFormats':
       return handleListMetadataFormats(now);
     case 'ListSets':
-      return handleListSets(now, tenantId);
+      return handleListSets(now, baseFilter);
     case 'ListIdentifiers':
-      return handleListRecords(now, searchParams, tenantId, true);
+      return handleListRecords(now, searchParams, baseFilter, true);
     case 'ListRecords':
-      return handleListRecords(now, searchParams, tenantId, false);
+      return handleListRecords(now, searchParams, baseFilter, false);
     case 'GetRecord':
-      return handleGetRecord(now, searchParams, tenantId);
+      return handleGetRecord(now, searchParams, baseFilter);
     default:
       return oaiError('badVerb', `"${verb}" is not a valid OAI-PMH verb`);
   }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from 'next';
 import { getReadDb } from '@/lib/mongodb';
+import { posts as blogPostList } from '@/app/blog/page';
 
 // Next.js sitemap with generateSitemaps() for multi-file output.
 // Google handles chunked sitemaps much better for large sites (10K+ URLs).
@@ -147,19 +148,12 @@ function staticPages(): MetadataRoute.Sitemap {
   ];
 }
 
+// Read the same `posts` array the blog index renders — single source of truth,
+// so the sitemap never drifts from the published posts (the old hardcoded list
+// was missing ~half of them, including every recent post).
 function blogPosts(): MetadataRoute.Sitemap {
-  return [
-    'astrological-diagrams', 'chakra-tradition', 'demonology', 'fechner-bohme',
-    'fire-horse', 'first-translation-methodology', 'first-translations',
-    'hidden-engineers', 'history-of-astrology', 'indigenous-traditions',
-    'invisible-hand', 'mcp-server', 'ocr-consistency', 'cuneiform-ocr',
-    'rithmomachia', 'progress-studies', '2000-first-translations',
-    'worlds-largest-collection', 'origin-story', 'counting-the-gap',
-    'untranslated-renaissance', 'translation-rate', 'hieroglyph-ocr',
-    'rashi-ocr', 'clustering', 'history-of-classification',
-    'visualizing-classification', 'philosophers-stone',
-  ].map((slug) => ({
-    url: `${BASE_URL}/blog/${slug}`,
+  return blogPostList.map((post) => ({
+    url: `${BASE_URL}/blog/${post.slug}`,
     lastModified: new Date(),
     changeFrequency: 'monthly' as const,
     priority: 0.8,


### PR DESCRIPTION
Two harvesting/discovery gaps found while auditing how the library syndicates.

**OAI-PMH was broken for the global catalog.** `https://sourcelibrary.org/api/oai?verb=Identify` returned `badArgument: Tenant context not found` and `ListRecords` returned zero records — the endpoint required a tenant context and filtered every query by `tenantId`. So the 16,000-book global catalog was invisible to the library aggregators OAI-PMH exists to feed (**BASE**, **CORE**, **OpenAIRE**, **Europeana**). Now the main domain harvests the global **public** catalog (`visible: true` — hidden/in-copyright books stay out), while tenant subdomains keep their scoped subset. Implemented by threading a `baseFilter` (`{tenantId}` | `{visible:true}`) through every verb handler.

**Blog sitemap had drifted.** `blogPosts()` was a hardcoded slug list missing ~half the posts (including `tibetan-ocr`, the new Chinese OCR post, and others) — so search engines weren't told they exist. Now it reads the same exported `posts` array the blog index renders → single source of truth, can't drift.

`tsc --noEmit` clean. After deploy: `/api/oai?verb=Identify` should return a valid `Identify` (not an error), `ListRecords&metadataPrefix=oai_dc` should emit records, and `/sitemap/0.xml` should list all blog posts.

Follow-up (not code): register the OAI-PMH base URL with BASE / CORE / OpenAIRE to actually start the harvest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)