### PR TITLE
fix(search): strip residual markdown markers from snippets (headings, emphasis, rules)

### DIFF
--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -59,14 +59,44 @@ function flattenMarkdownTables(text: string): string {
     .replace(/\n[ \t]*\n[ \t]*\n+/g, '\n\n');
 }
 
+/**
+ * Strip residual markdown *markup* (not content) that leaks into plain-text
+ * snippets/quotes alongside tables: ATX heading markers ("# TABLE OF" → "TABLE
+ * OF", "### G" → "G"), paired asterisk emphasis ("**B**" → "B"), and the
+ * "->centered<-" markers the reader pre-processes (e.g. "->THE END.<-"). The
+ * reader renders these properly; only the plain-text path needs them gone.
+ *
+ * Deliberately conservative: emphasis must hug non-whitespace (real markdown
+ * rule) so spaced-out literal asterisks survive, and underscore emphasis is left
+ * alone — "_" appears too often as a literal in OCR/transliteration to strip safely.
+ */
+function stripMarkdownMarkers(text: string): string {
+  return text
+    // ATX headings: drop the leading #'s + space, keep the heading text.
+    .replace(/^[ \t]*#{1,6}[ \t]+/gm, '')
+    // Thematic-break rules (a whole line of only --- or ***). Underscore rules
+    // are left alone to honour the "never touch _" guarantee below.
+    .replace(/^[ \t]*(?:-{3,}|\*{3,})[ \t]*$/gm, '')
+    // ->centered<- markers (content kept).
+    .replace(/->\s*(.+?)\s*<-/g, '$1')
+    // Paired bold/italic asterisks (content must start & end non-space).
+    .replace(/\*\*\*(\S(?:[^*]*?\S)?)\*\*\*/g, '$1')
+    .replace(/\*\*(\S(?:[^*]*?\S)?)\*\*/g, '$1')
+    .replace(/\*(\S(?:[^*]*?\S)?)\*/g, '$1')
+    // Collapse blank lines left by removed headings/rules.
+    .replace(/\n[ \t]*\n[ \t]*\n+/g, '\n\n');
+}
+
 export function stripEditorialWrappers(text: string): string {
   if (!text) return text;
-  return flattenMarkdownTables(
-    text
-      // Paired blocks, content and all (multiline). Backreference keeps it from
-      // swallowing text between two different wrapper types.
-      .replace(new RegExp(`<(${EDITORIAL_WRAPPERS})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
-      // Any orphan opening/closing wrapper tag left by malformed AI output.
-      .replace(new RegExp(`<\\/?(?:${EDITORIAL_WRAPPERS})>`, 'gi'), ' '),
+  return stripMarkdownMarkers(
+    flattenMarkdownTables(
+      text
+        // Paired blocks, content and all (multiline). Backreference keeps it from
+        // swallowing text between two different wrapper types.
+        .replace(new RegExp(`<(${EDITORIAL_WRAPPERS})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
+        // Any orphan opening/closing wrapper tag left by malformed AI output.
+        .replace(new RegExp(`<\\/?(?:${EDITORIAL_WRAPPERS})>`, 'gi'), ' '),
+    ),
   );
 }

--- a/tests/unit/strip-editorial-wrappers.test.ts
+++ b/tests/unit/strip-editorial-wrappers.test.ts
@@ -91,4 +91,35 @@ describe('stripEditorialWrappers', () => {
     const t = 'the choice of good | evil is the soul’s';
     expect(stripEditorialWrappers(t)).toBe(t);
   });
+
+  // ── Residual markdown markers in plain-text snippets ─────────────────────
+  it('strips ATX heading markers but keeps the heading text', () => {
+    const t = '# TABLE OF\n\n### G\nGaddo Gaddi p.  13';
+    const out = stripEditorialWrappers(t);
+    expect(out).not.toMatch(/^#/m);
+    expect(out).toContain('TABLE OF');
+    expect(out).toContain('G\n');
+    expect(out).toContain('Gaddo Gaddi p.  13');
+  });
+
+  it('strips paired asterisk emphasis and ->centered<- markers', () => {
+    expect(stripEditorialWrappers('->**B**<-')).toBe('B');
+    expect(stripEditorialWrappers('->THE END.<-')).toBe('THE END.');
+    expect(stripEditorialWrappers('a **bold** and *italic* word')).toBe('a bold and italic word');
+  });
+
+  it('drops --- / *** thematic-break rules', () => {
+    const t = 'Zanobi Stradi s 467\n\n---\n\nTHE END.';
+    const out = stripEditorialWrappers(t);
+    expect(out).not.toMatch(/^---$/m);
+    expect(out).toContain('Zanobi Stradi s 467');
+    expect(out).toContain('THE END.');
+  });
+
+  it('leaves spaced-out or literal asterisks and underscores alone', () => {
+    // Not markdown emphasis (spaces hug the asterisks) — must survive.
+    expect(stripEditorialWrappers('see footnote * and ** below')).toBe('see footnote * and ** below');
+    // Underscores are never touched (literal in OCR/transliteration).
+    expect(stripEditorialWrappers('istimnāʾ _ or jing_preservation')).toBe('istimnāʾ _ or jing_preservation');
+  });
 });


### PR DESCRIPTION
Follow-up to #2744. With the table pipes gone, the Vasari index snippet still leaked literal markup: `# TABLE OF`, `### G`, `---`, and `->THE END.<-`.

Extends the shared snippet/quote cleaner (`stripEditorialWrappers`) to drop:
- ATX heading markers (`# `/`### `) — keeps the heading text
- thematic-break rules (`---` / `***`)
- `->centered<-` markers
- paired asterisk emphasis (`**bold**`, `*italic*`)

**Conservative by design:** emphasis must hug non-whitespace (the real markdown rule), so spaced-out or literal asterisks survive; **underscores are never touched** (`_` is a common literal in OCR/transliteration — e.g. `jing_preservation`, `istimnāʾ`). The reader renders real markdown and is unaffected — only the plain-text snippet/quote path changes.

Verified end-to-end on the real Vasari p.42 text. +4 unit tests (16/16 pass), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)