### PR TITLE
fix(search): broaden AI search-guide scope to the global premodern library

### DIFF
--- a/src/app/api/search/ai-expand/route.ts
+++ b/src/app/api/search/ai-expand/route.ts
@@ -67,11 +67,14 @@ export async function POST(request: NextRequest) {
           contents: [{
             role: 'user',
             parts: [{
-              text: `You are a search guide for Source Library (15K+ books, 24K+ artworks).
+              text: `You are a search guide for Source Library (16K+ books across 150+ languages, 24K+ artworks).
 
-LIBRARY SCOPE — what's actually here:
-- Texts and artworks from antiquity through ~1850 CE. Sparse coverage 1850–1920; almost nothing after 1920.
-- Core traditions: alchemy (Dorn, Khunrath, Ripley, Maier, Mylius, Trismosin, Flamel), Hermetica (Corpus Hermeticum, Ficino, Bruno, Trismegistus), Kabbalah (Zohar, Luria, Reuchlin, Knorr von Rosenroth), Renaissance natural magic (Agrippa, Della Porta, Dee, Paracelsus), Neoplatonism (Plotinus, Proclus, Iamblichus), Rosicrucian and Masonic texts, gnostic and apocryphal sources, early modern science and medicine, devotional and theological works.
+LIBRARY SCOPE — a global library of premodern thought. Strongest from antiquity through the 19th century; ancient and medieval sources are well represented and there are real (not sparse) holdings into the early 20th century. Western esoterica is the historic core, but the collection is much broader now — when a subject sits near one we hold, guide toward the nearest rich tradition rather than calling it out of scope. What's actually here:
+- Western esoterica (the founding core): alchemy (Dorn, Khunrath, Ripley, Maier, Mylius, Trismosin, Flamel), Hermetica (Corpus Hermeticum, Ficino, Bruno, Trismegistus), Kabbalah (Zohar, Luria, Reuchlin, Knorr von Rosenroth), Renaissance natural magic (Agrippa, Della Porta, Dee, Paracelsus), Rosicrucian and Masonic texts, gnostic and apocryphal sources.
+- Philosophy & religion (the largest core): classical philosophy and Neoplatonism (Plotinus, Proclus, Iamblichus), the history of philosophy broadly, Christian theology, biblical and patristic studies, mysticism.
+- Science & medicine: natural philosophy, astronomy, mathematics, optics, medicine, botany and herbalism, materia medica — Newton, Galileo, Kepler, Huygens, and into the 19th century (Maxwell, Faraday, Rayleigh appear, though hard modern science is thinner).
+- World traditions: the Tibetan Buddhist canon (large), Chinese classics and science, Sanskrit and Indic traditions, the ancient Near East (Sumerian/cuneiform, Egyptian, Syriac), Arabic and Hebrew sources.
+- Also: literature, history, law, politics, geography, linguistics.
 - Many post-1900 scholars studied this corpus but their OWN works are NOT here. When a visitor searches for one of them, redirect to the primary sources they drew on.
 
 MODERN-FIGURE RULE — if the query names a scholar/author working primarily after ~1900 whose subject IS in the library:
@@ -97,7 +100,7 @@ Reply in this EXACT XML format:
 HINT = images_first | books_first | not_in_collection
 - images_first: visual art, painting, diagram, illustration
 - books_first: texts, concepts, authors, traditions
-- not_in_collection: outside scope OR post-1900 figure whose sources we have
+- not_in_collection: use SPARINGLY — only when the subject is genuinely far outside a premodern global library (e.g. a living pop-culture figure, a modern brand, a contemporary news event), OR a post-1900 scholar whose primary sources we hold. A premodern or 19th-century person, place, science, or tradition is almost never out of scope — narrate toward the nearest holdings instead, and never assert we lack something the search itself can find.
 
 STRATEGY = navigational | conceptual | verbatim — how search should rank results
 - navigational: looking for a specific known book/author/title (e.g. "boehme", "de occulta philosophia", "agrippa")


### PR DESCRIPTION
## What
The `/api/search/ai-expand` prompt described the collection as Western-esoterica-only with 'almost nothing after 1920', and returned `not_in_collection` freely. The library is now a global library of premodern thought (large Tibetan canon, Chinese/Sanskrit/Near-East, science & medicine into the 19th c.).

## Change
- Rewrote the LIBRARY SCOPE block to reflect real current holdings (esoterica core + philosophy/religion + science/medicine + world traditions).
- Made `not_in_collection` fire **sparingly** — only for genuinely far-out queries (living pop-culture, modern brands/news) or post-1900 scholars whose primary sources we hold. A premodern/19th-c. subject narrates toward the nearest holdings instead.

## Out of scope
Prompt-only change; no routing/ranking logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)