### PR TITLE
feat(ft): wire prior-guard into derive demotion precondition (#2564)

### DIFF
--- a/src/lib/first-translation/derive.ts
+++ b/src/lib/first-translation/derive.ts
@@ -23,6 +23,33 @@ import {
   type FirstTranslationVerdict,
   type LegacyDisposition,
 } from './types';
+import { evaluatePrior, type CitedPriorInput } from '../ft-prior-guard';
+
+/**
+ * Map a legacy `translations_found[]` entry (untyped Mongo shape) to the
+ * guard's {@link CitedPriorInput}. Field names mirror what the badge panel's
+ * normalizePriors reads, so the guard sees the same prior the reader does.
+ */
+function toCitedPrior(p: unknown): CitedPriorInput {
+  const o = (p ?? {}) as Record<string, unknown>;
+  const str = (v: unknown) => (typeof v === 'string' ? v : undefined);
+  const completeness = str(o.completeness);
+  return {
+    english_title: str(o.english_title) ?? str(o.title),
+    translator: str(o.translator),
+    pub_year: str(o.pub_year) ?? str(o.year),
+    completeness:
+      completeness === 'complete' ||
+      completeness === 'partial' ||
+      completeness === 'excerpts' ||
+      completeness === 'unknown'
+        ? completeness
+        : undefined,
+    publisher: str(o.publisher),
+    series: str(o.series),
+    notes: str(o.notes),
+  };
+}
 
 /**
  * Normalize a book to a graded {@link FirstTranslation} record.
@@ -63,7 +90,24 @@ export function resolveFirstTranslation(
   if (verdict === 'not_first') {
     const priors = book.translation_verification?.translations_found;
     if (!Array.isArray(priors) || priors.length === 0) {
+      // No cited prior at all — an evidence-free defeat. Escalate, don't demote.
       verdict = 'needs_review';
+    } else {
+      // A cited prior only defeats a first if it is a TRUSTWORTHY sighting.
+      // The #2564 Arithmologia demotion trusted a prior that was actually
+      // Godwin's *anthology* — a real citation to the wrong kind of source. Run
+      // the evidence-quality guard (#2579): if NO cited prior survives it, the
+      // demotion isn't justified → needs_review (a Tier-2 re-verification, not
+      // a restored first).
+      const bookInput = {
+        title: book.title ?? '',
+        author: book.author,
+        language: book.original_language ?? book.language ?? undefined,
+      };
+      const anyTrustworthy = priors.some(
+        (p) => evaluatePrior(bookInput, toCitedPrior(p)).trustworthy,
+      );
+      if (!anyTrustworthy) verdict = 'needs_review';
     }
   }
 

--- a/src/lib/first-translation/types.ts
+++ b/src/lib/first-translation/types.ts
@@ -164,4 +164,10 @@ export interface FirstTranslationBook {
   } | null;
   visible?: boolean;
   pages_translated?: number | null;
+  // Read only by the evidence-quality guard (#2579) when validating a legacy
+  // `translation_found` demotion against its cited priors.
+  title?: string;
+  author?: string;
+  language?: string | null;
+  original_language?: string | null;
 }

--- a/tests/unit/first-translation-derive.test.ts
+++ b/tests/unit/first-translation-derive.test.ts
@@ -129,6 +129,38 @@ describe('legacy disposition fallback (transition compatibility)', () => {
     expect(isFirstTranslation(withEmpty)).toBe(false); // needs_review still doesn't badge
   });
 
+  it('evidence-UNTRUSTWORTHY translation_found → needs_review, NOT a demotion (#2564 Arithmologia/Godwin)', () => {
+    // The #2564 incident: a genuine first was demoted because its cited "prior"
+    // was Godwin's *anthology*, not a translation of the specific work. The
+    // evidence-quality guard (#2579) must catch an anthology-class prior and
+    // escalate to needs_review rather than honor the not_first.
+    const arithmologia: FirstTranslationBook = {
+      visible: true, pages_translated: 50,
+      title: 'Arithmologia', author: 'Athanasius Kircher', original_language: 'lat',
+      translation_verification: {
+        disposition: 'translation_found',
+        translations_found: [
+          { english_title: 'The Harmony of the Spheres: A Sourcebook of the Pythagorean Tradition', translator: 'Joscelyn Godwin', pub_year: '1993' },
+        ],
+      },
+    };
+    expect(firstTranslationVerdict(arithmologia)).toBe('needs_review');
+    expect(isFirstTranslation(arithmologia)).toBe(false); // needs_review still doesn't badge
+
+    // A clean, specific prior still demotes for real — the guard is not blanket-permissive.
+    const realDemotion: FirstTranslationBook = {
+      visible: true, pages_translated: 50,
+      title: 'Arithmologia', author: 'Athanasius Kircher', original_language: 'lat',
+      translation_verification: {
+        disposition: 'translation_found',
+        translations_found: [
+          { english_title: 'Arithmologia, or the Mystical Properties of Numbers', translator: 'Jane Doe', pub_year: '1901', completeness: 'complete' },
+        ],
+      },
+    };
+    expect(firstTranslationVerdict(realDemotion)).toBe('not_first');
+  });
+
   it('treats legacy first_complete_translation as our-complete (passes the gate)', () => {
     expect(isFirstTranslation(legacy('first_complete_translation'))).toBe(true);
   });


### PR DESCRIPTION
Closes the safety gap that caused the **#2564 Arithmologia destructive flip**, and the binding precondition for ever running the reconcile `--apply`.

## Why
`derive.ts` (merged in #2573) already escalates **evidence-free** `translation_found` dispositions to `needs_review`. But #2564 was a **cited-but-untrustworthy** prior — Godwin's *anthology*, a real citation to the wrong kind of source. The empty-priors check can't catch that.

## What
Ports #2579's `evaluatePrior` guard into the `not_first` precondition: when a legacy `translation_found` cites priors, **at least one must be a trustworthy sighting** (not SELF_MATCH / ANTHOLOGY / PARTIAL) for the demotion to stand. If none survives, the verdict escalates to `needs_review` — a Tier-2 re-verification queue entry, **not** a restored first.

- **Imports** `evaluatePrior` from `src/lib/ft-prior-guard` (#2579) rather than reimplementing it — the standalone module stays the single source of guard logic; `derive` consumes it. No drift, nothing to delete (supersedes #2579's "remove the module after porting" note).
- **Scope:** only the legacy-disposition shim. Rigorous graded verdicts (`book.first_translation`) return early (derive.ts:46) and are untouched.
- `FirstTranslationBook` gains `title`/`author`/`language` (the guard's inputs).
- **Regression test:** the Arithmologia/Godwin anthology prior → `needs_review`; a clean specific prior still demotes (the guard is not blanket-permissive).

## Verification
`tsc --noEmit` clean; 54/54 derive + guard unit tests pass.

## Out of scope / still gated
- The reconcile `--apply` run (the 181 demotions) — **must not run until this lands**, and even then wants a Tier-2 spot-check of the `not_first` demotions first. Needs Derek's explicit sign-off (paid + public bibliographic-claim change).

Refs #2564 · #2579 · cluster #2567

🤖 Generated with [Claude Code](https://claude.com/claude-code)