### PR TITLE
fix(ft): load translations_found in reconcile projection (guard was bypassed)

### DIFF
--- a/scripts/maintenance/reconcile-first-translation-flag.ts
+++ b/scripts/maintenance/reconcile-first-translation-flag.ts
@@ -52,9 +52,16 @@ async function main() {
 
   const cursor = books.find(query, {
     projection: {
-      id: 1, title: 1, author: 1, language: 1, visible: 1, pages_translated: 1,
+      id: 1, title: 1, author: 1, language: 1, original_language: 1,
+      visible: 1, pages_translated: 1,
       is_first_translation: 1, 'translation_verification.disposition': 1,
-      'translation_verification.source': 1, first_translation: 1,
+      'translation_verification.source': 1,
+      // Required by the evidence-quality guard in derive (#2579/#2751): without
+      // the cited priors, every `translation_found` looks evidence-free and the
+      // guard escalates it to needs_review — silently bypassing the guard and
+      // breaking the `--verdict=not_first` scoped-apply path.
+      'translation_verification.translations_found': 1,
+      first_translation: 1,
     },
   });
 


### PR DESCRIPTION
## Bug
`reconcile-first-translation-flag.ts` projected `translation_verification.disposition` but **not** `.translations_found`. The derived rule's evidence-quality guard (#2579, wired in #2751) reads the cited priors — so inside the reconcile it always saw *empty* priors. Effect:
- Every `translation_found` escalated to `needs_review` via the empty-priors gate → the guard's non-empty branch **never ran**.
- The `--verdict=not_first` scoped-apply path would write **zero** (nothing is ever labeled `not_first`).

## Fix
Add `translation_verification.translations_found` (and `original_language`, the guard's language input) to the projection.

## Honest impact (verified against live data)
**Latent on today's data** — of 6,846 flagged books only 14 are `translation_found` and **0 of those carry any cited priors**, so no demotion label changes right now. But it's required for correctness *before any `--apply`*, and for the scoped `not_first` write path to function at all. Caught while prepping the gated reconcile.

Refs #2564 · #2751 · cluster #2567

🤖 Generated with [Claude Code](https://claude.com/claude-code)