### PR TITLE
fix(stats): honest distinct-language count (162 → 102)

### DIFF
--- a/scripts/lib/language-count.mjs
+++ b/scripts/lib/language-count.mjs
@@ -1,0 +1,91 @@
+// Honest distinct-language count for corpus stats.
+//
+// The `books.language` field is free-text and messy: it mixes compound labels
+// ("Hebrew and Judeo-Arabic", "Greek/Latin", "Latin-German"), script/stage
+// variants ("Geez"/"Ge'ez", "Egyptian"/"Egyptian hieroglyphs"/"Demotic"),
+// and junk tokens ("auto-detect", "Multiple", "mul", "Undetermined"). A naive
+// `distinct('language').length` therefore badly over-counts — it reported 162
+// when the real number of distinct languages with books is ~105 (2026-06-26).
+//
+// countDistinctLanguages(rawLabels) splits compounds into atomic languages,
+// normalizes the obvious variants, drops the junk, and returns the honest count.
+// Pass the array returned by `books.distinct('language', filter)`.
+
+// Tokens that are not languages at all.
+const JUNK = new Set([
+  'auto-detect', 'auto', 'detect', 'multiple', 'mul', 'lit', 'undetermined',
+  'unknown', 'various', 'various caucasian', 'n/a', 'zxx', 'roa', '',
+]);
+
+// Variant / stage / script labels folded into one canonical language.
+const VARIANTS = {
+  "ge'ez": 'geez', 'ethiopic': 'geez',
+  'egyptian hieroglyphs': 'egyptian', 'demotic': 'egyptian',
+  'maya hieroglyphs': 'maya', 'yucatec maya': 'maya', "k'iche' maya": 'maya', "k'iche'": 'maya', 'cakchiquel': 'maya',
+  'classical armenian': 'armenian',
+  'samaritan hebrew': 'hebrew',
+  'classical chinese': 'chinese', 'literary chinese': 'chinese',
+  'middle english': 'english', 'old english': 'english',
+  'middle french': 'french', 'old french': 'french', 'anglo-norman': 'french',
+  'middle high german': 'german', 'low german': 'german',
+  'old javanese': 'javanese',
+  'ancient greek': 'greek',
+  'old spanish': 'spanish',
+  'scottish gaelic': 'gaelic',
+  'old irish': 'irish',
+  'ottoman turkish': 'turkish', 'chagatai turkish': 'turkish',
+  'church slavonic': 'slavonic',
+};
+
+// Hyphenated names that are a SINGLE language — never split these on the hyphen.
+const KEEP_HYPHEN = new Set([
+  'judeo-arabic', 'judeo-greek', 'judeo-italian', 'judeo-occitan', 'judeo-persian',
+  'anglo-norman', 'anglo-saxon',
+]);
+
+function normalizeAtom(raw) {
+  let x = String(raw).trim().toLowerCase();
+  x = x.replace(/\(.*?\)/g, '');                    // drop parentheticals
+  x = x.replace(/\s+with\s+.*$/, '');               // "hebrew with marginal glosses…" -> hebrew
+  x = x.replace(/\s+in\s+[a-z' -]+script.*$/, '');  // "italian in italian script" -> italian
+  x = x.replace(/[.)\]]+$/, '').trim();
+  return VARIANTS[x] || x;
+}
+
+// Split one raw label into its atomic languages.
+export function atomsOfLabel(label) {
+  if (!label) return [];
+  const out = [];
+  // Strong separators first: / ; , & and the word "and".
+  for (let seg of String(label).split(/\s*(?:[;,/&]|\band\b)\s*/i)) {
+    seg = seg.trim();
+    if (!seg) continue;
+    const lower = seg.toLowerCase();
+    if (lower.includes('-') && !KEEP_HYPHEN.has(lower)) {
+      // Hyphen compound (e.g. "Latin-German", "Nahuatl-Spanish") -> split.
+      for (const piece of lower.split('-')) {
+        const a = normalizeAtom(piece);
+        if (a) out.push(a);
+      }
+      continue;
+    }
+    const a = normalizeAtom(seg);
+    if (a) out.push(a);
+  }
+  return out;
+}
+
+export function distinctLanguageSet(rawLabels) {
+  const set = new Set();
+  for (const label of rawLabels) {
+    for (const atom of atomsOfLabel(label)) {
+      if (!atom || atom.length < 2 || JUNK.has(atom) || atom.startsWith('multiple')) continue;
+      set.add(atom);
+    }
+  }
+  return set;
+}
+
+export function countDistinctLanguages(rawLabels) {
+  return distinctLanguageSet(rawLabels).size;
+}

--- a/scripts/maintenance/prewarm-browse.mjs
+++ b/scripts/maintenance/prewarm-browse.mjs
@@ -55,6 +55,7 @@ console.log(`Done: ${ok} OK, ${fail} failed (${new Date().toISOString()})`);
 if (process.env.MONGODB_URI) {
   try {
     const { MongoClient } = await import('mongodb');
+    const { countDistinctLanguages } = await import('../lib/language-count.mjs');
     const client = await MongoClient.connect(process.env.MONGODB_URI);
     const db = client.db('bookstore');
     const books = db.collection('books');
@@ -73,7 +74,10 @@ if (process.env.MONGODB_URI) {
       books.countDocuments(readableFilter),
       books.countDocuments({ ...translatedFilter, is_first_translation: true }),
       books.distinct('author', translatedFilter).then(a => a.length),
-      books.distinct('language', translatedFilter).then(l => l.filter(x => x && !x.includes(',') && !x.includes(' and ')).length),
+      // Distinct SOURCE languages across the opened corpus (same `filter` as totalBooks).
+      // countDistinctLanguages splits compound labels and drops variants/junk; a naive
+      // distinct().length over-counts ~1.6x. Keep in sync with update-homepage-stats.mjs.
+      books.distinct('language', filter).then(countDistinctLanguages),
       books.countDocuments(artworkFilter),
       db.collection('gallery_images').countDocuments({}),
       // First-translation verification coverage (#2332 Task 3): of all readable+visible

--- a/scripts/maintenance/update-homepage-stats.mjs
+++ b/scripts/maintenance/update-homepage-stats.mjs
@@ -6,6 +6,7 @@
  * Usage: set -a; source .env.production.local; set +a; node scripts/maintenance/update-homepage-stats.mjs
  */
 import { MongoClient } from 'mongodb';
+import { countDistinctLanguages } from '../lib/language-count.mjs';
 
 const uri = process.env.MONGODB_URI;
 if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -36,7 +37,10 @@ const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, lang
   books.countDocuments(readableFilter),
   books.countDocuments({ ...translatedFilter, is_first_translation: true }),
   books.distinct('author', translatedFilter).then(a => a.length),
-  books.distinct('language', translatedFilter).then(l => l.filter(x => x && !x.includes(',') && !x.includes(' and ')).length),
+  // Distinct SOURCE languages across the opened corpus (same `filter` as totalBooks,
+  // so the two stats are consistent). countDistinctLanguages splits compound labels
+  // and drops variants/junk — a naive distinct().length over-counts ~1.6x (#lang-count).
+  books.distinct('language', filter).then(countDistinctLanguages),
   books.countDocuments(artworkFilter),
   db.collection('gallery_images').countDocuments({}),
   // First-translation verification coverage (#2332 Task 3): of all readable+visible

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -17,10 +17,11 @@ export default async function AboutPage() {
 
   const headlineStats: { value: string; label: string; href?: string }[] = [
     { value: fmt(stats.totalBooks), label: 'books digitized', href: '/search' },
-    // Conservative floor: ~50 languages have 5+ translated books each. The raw
-    // distinct-language count (stats.languageCount) is higher but padded with
-    // singletons, compound strings, and junk tokens — not a defensible claim.
-    { value: '50+', label: 'languages' },
+    // stats.languageCount is now an honest distinct-language count: compound
+    // labels are split into atomic languages and variants/junk are dropped
+    // (scripts/lib/language-count.mjs). ~105 as of 2026-06-26, so 100+ is a
+    // defensible floor.
+    { value: '100+', label: 'languages' },
     { value: fmt(stats.translatedToEnglish), label: 'translated to English', href: '/search?has_translation=true' },
     { value: fmt(stats.firstTranslationCount), label: 'first-ever English translations', href: '/search?first_translation=true' },
     { value: fmt(stats.illustrationCount), label: 'illustrations cataloged', href: '/gallery' },

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -427,7 +427,7 @@ export interface HomeCounts {
 }
 
 // Last refreshed from production 2026-05-26. Only used if Mongo + Supabase are both unreachable.
-const FALLBACK_COUNTS: HomeCounts = { totalBooks: 13869, translatedToEnglish: 13534, firstTranslationCount: 6911, authorCount: 5523, languageCount: 170, artworkCount: 13743, illustrationCount: 122550 };
+const FALLBACK_COUNTS: HomeCounts = { totalBooks: 13869, translatedToEnglish: 13534, firstTranslationCount: 6911, authorCount: 5523, languageCount: 105, artworkCount: 13743, illustrationCount: 122550 };
 
 async function getBookCounts(): Promise<HomeCounts> {
   // 1. MongoDB system_config cache (refreshed daily by scripts/maintenance/prewarm-browse.mjs;

--- a/tests/unit/language-count.test.ts
+++ b/tests/unit/language-count.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain ESM util shared with scripts (no types)
+import { countDistinctLanguages, atomsOfLabel } from '../../scripts/lib/language-count.mjs';
+
+// The books.language field is free-text and messy. A naive
+// distinct('language').length over-counts because it treats compound labels,
+// script/stage variants, and junk tokens as separate languages — it reported
+// 162 when the real distinct-language count was ~102 (2026-06-26). This guards
+// the normalizer so the homepage "languages" stat stays honest.
+
+describe('atomsOfLabel', () => {
+  it('splits compound labels on / , ; & and "and"', () => {
+    expect(atomsOfLabel('Greek/Latin')).toEqual(['greek', 'latin']);
+    expect(atomsOfLabel('Hebrew and Judeo-Arabic')).toEqual(['hebrew', 'judeo-arabic']);
+    expect(atomsOfLabel('Hebrew, Aramaic, and Judeo-Arabic')).toEqual(['hebrew', 'aramaic', 'judeo-arabic']);
+  });
+
+  it('splits hyphen compounds but keeps single hyphenated languages whole', () => {
+    expect(atomsOfLabel('Latin-German')).toEqual(['latin', 'german']);
+    expect(atomsOfLabel('Nahuatl-Spanish')).toEqual(['nahuatl', 'spanish']);
+    expect(atomsOfLabel('Judeo-Arabic')).toEqual(['judeo-arabic']);
+    expect(atomsOfLabel('Anglo-Norman')).toEqual(['french']); // variant-folded
+  });
+
+  it('folds script/stage variants into one canonical language', () => {
+    expect(atomsOfLabel("Ge'ez")).toEqual(['geez']);
+    expect(atomsOfLabel('Egyptian hieroglyphs')).toEqual(['egyptian']);
+    expect(atomsOfLabel('Classical Chinese')).toEqual(['chinese']);
+    expect(atomsOfLabel('Middle English')).toEqual(['english']);
+  });
+
+  it('strips "in X script" and parenthetical noise', () => {
+    expect(atomsOfLabel('Italian in Italian script')).toEqual(['italian']);
+    expect(atomsOfLabel('Aromanian (in Greek alphabet)')).toEqual(['aromanian']);
+  });
+});
+
+describe('countDistinctLanguages', () => {
+  it('drops junk tokens entirely', () => {
+    expect(countDistinctLanguages(['auto-detect', 'Multiple', 'mul', 'Undetermined', ''])).toBe(0);
+  });
+
+  it('deduplicates variants and compounds to atomic languages', () => {
+    const labels = ['Latin', 'Greek/Latin', 'Greek-Latin', "Ge'ez", 'Ethiopic', 'Hebrew and Aramaic'];
+    // -> latin, greek, geez, hebrew, aramaic = 5
+    expect(countDistinctLanguages(labels)).toBe(5);
+  });
+
+  it('counts far fewer than the naive distinct().length on realistic data', () => {
+    const labels = [
+      'Latin', 'German', 'Greek/Latin', 'Latin-German', 'Hebrew and Judeo-Arabic',
+      'Hebrew and Aramaic', "Ge'ez", 'Ethiopic', 'auto-detect', 'Multiple',
+    ];
+    const naive = labels.filter((x) => x && !x.includes(',') && !x.includes(' and ')).length;
+    const honest = countDistinctLanguages(labels);
+    expect(honest).toBeLessThan(naive);
+    // atomic set: latin, german, greek, hebrew, judeo-arabic, aramaic, geez = 7
+    expect(honest).toBe(7);
+  });
+});


### PR DESCRIPTION
## What

The homepage **"languages"** stat was inflated ~1.6×. `languageCount` was a naive `distinct('language').length` guarded only by a `,`/` and ` filter, so it counted as separate languages:
- **compound labels** — "Hebrew and Judeo-Arabic", "Greek/Latin", "Latin-German", "Maya hieroglyphs / French"
- **script/stage variants** — "Geez"/"Ge'ez", "Egyptian"/"Egyptian hieroglyphs"/"Demotic", "Classical Chinese"/"Chinese"
- **junk tokens** — "auto-detect", "Multiple", "mul", "Lit", "Undetermined"

It reported **162**; the true count of distinct source languages with books is **~102**.

## How
- New shared util `scripts/lib/language-count.mjs` — `countDistinctLanguages()` splits compound labels into atomic languages, folds variants/stages, drops junk.
- Wired into both stat writers (`update-homepage-stats.mjs`, `prewarm-browse.mjs`), now counting over the **opened corpus** (same `filter` as `totalBooks`) so the two stats are consistent.
- Stale `home-data.ts` fallback 170 → 105; about-page conservative floor "50+" → "100+" (now a defensible, data-backed number).
- Guard test `tests/unit/language-count.test.ts` (7 cases).
- **Live `system_config.homepage_stats` already refreshed: 162 → 102.**

## Out of scope
- `/api/languages` (browse facets) has its own `normalizeLanguage` and isn't a count stat — left as-is.
- `contribute/page.tsx` hardcodes `90` for a different reason (avoids a slow distinct on 28K docs) — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)