### PR TITLE
fix(provenance): full-delta watermark — 58%→94% per-page detection

### DIFF
--- a/scripts/lib/provenance-mark.mjs
+++ b/scripts/lib/provenance-mark.mjs
@@ -181,11 +181,15 @@ function embedWatermark(data, W, H, channels, pairs, grid = GRID, delta = WM_DEL
     }
   };
   for (const [a, b] of pairs) {
-    // amplitude limited by the flatter of the two blocks → never marks flat areas
-    const f = Math.min(maskFactor(stds[a]), maskFactor(stds[b]));
-    if (f <= 0) continue;
-    const d = delta * f;
-    nudge(a, +d); nudge(b, -d);
+    // Texture mask GATES which pairs we mark (never touch flat areas → invisible),
+    // but every marked pair gets the FULL delta. Scaling amplitude by texture
+    // (delta*f) diluted mild-texture pairs to a sub-JPEG-quantization nudge that
+    // q82 erased, dropping per-page detection to ~58%. Constant delta on textured
+    // blocks stays invisible (verified on blank-paper + dense-text crops) and lifts
+    // detection to ~94% (36-page pilot; the ~6% misses are near-blank pages with
+    // too few textured blocks to carry an invisible mark — left unmarked by design).
+    if (maskFactor(stds[a]) <= 0 || maskFactor(stds[b]) <= 0) continue;
+    nudge(a, +delta); nudge(b, -delta);
   }
 }
 

--- a/scripts/maintenance/bake-provenance-mark.mjs
+++ b/scripts/maintenance/bake-provenance-mark.mjs
@@ -63,7 +63,9 @@ const CONCURRENCY = parseInt(arg('--concurrency') || '10', 10);
 // sl-v1 = old always-on visible logo; sl-v2 = mark-in-place (EXIF+watermark+logo);
 // sl-v3 = regenerate display variant from the clean original at <=2000px + full
 // mark (EXIF + LLM message + invisible watermark + random ~1/10 visible logo).
-const MARK_VERSION = 'sl-v4';  // sl-v4: visible logo shrunk 7%→3.5%
+// sl-v5: watermark robustness — full-delta on textured blocks (was texture-scaled
+// and diluted to ~58% per-page detection); now ~94%, still invisible. Re-marks v4.
+const MARK_VERSION = 'sl-v5';
 const DISPLAY_MAX_W = 2000;  // regenerate display variants at min(this, native width)
 
 const PROVENANCE_KEY = process.env.PROVENANCE_SECRET_KEY;


### PR DESCRIPTION
## Problem
The pilot re-bake of #2653 revealed the invisible keyed watermark only detected on **~58% of pages** (21/36), not the near-100% the PR implied. Root cause: the embedder scaled amplitude by per-block texture (`delta * f`). On mild-texture pairs that's a sub-1-luminance nudge JPEG q82 quantization erases — so sparse/light pages (few strongly-textured blocks) barely registered (median z 6.6, min 0.2).

## Fix
Keep the texture mask as a **gate** (never mark flat blocks → stays invisible) but apply the **full `delta`** to every marked pair. Detection is already texture-aware (it counts the same textured pairs), so this lifts signal without diluting it. One-line change in `embedWatermark`.

## Validation (36-page pilot, re-baked to R2, detected from origin bytes)
| metric | before | after |
|---|---|---|
| detection (correct key) | 21/36 (58%) | **34/36 (94%)** |
| median z | 6.6 | **10.3** |
| false positives (wrong key) | 0/36 | **0/36** (max wrong-z 2.3, threshold 5) |
| invisible | yes | **yes** — confirmed on blank-paper + dense-text 500px crops |

## Scope
- **In:** the amplitude fix + `MARK_VERSION` sl-v4→sl-v5 (so the eventual backfill re-marks old images).
- **Out:** the full ~4.78M-variant backfill is still gated (separate go/no-go); the ~6% misses are near-blank pages with too few textured blocks to carry an invisible mark — lowering the texture floor to force them introduced visible mottling, so they're left unmarked **by design**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)