### PR TITLE
feat: serve launch talk on-domain at /launch

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -243,6 +243,14 @@ const nextConfig: NextConfig = {
       // /sitemap/[__metadata_id__] route and breaks the build, so the
       // index lives at /sitemap-index and we rewrite from /sitemap.xml.
       { source: '/sitemap.xml', destination: '/sitemap-index' },
+      // The Source Library beta launch talk (embedded video + audio-aligned
+      // transcript) lives in a standalone static deployment. Proxy it on-domain
+      // at /launch so the email and site link to sourcelibrary.org, not a
+      // *.vercel.app URL. The page sets
+      // <base href="https://sourcelib-launch-talk.vercel.app/">, so its relative
+      // assets (transcript.json, lecture.mp3, clips/) load from that deployment
+      // directly — only the HTML document needs proxying here.
+      { source: '/launch', destination: 'https://sourcelib-launch-talk.vercel.app/' },
     ];
   },
   async redirects() {


### PR DESCRIPTION
Proxies the standalone launch-talk page (embedded video + audio-aligned transcript) at `sourcelibrary.org/launch` so the user welcome email and site link to our own domain instead of a `*.vercel.app` URL.

**How it works**
- One rewrite: `/launch` → the standalone deployment's HTML.
- The page carries `<base href="https://sourcelib-launch-talk.vercel.app/">`, so its relative assets (transcript.json with CORS header, lecture.mp3, clips/) load from the source deployment directly — only the HTML document is proxied. No 54MB of media enters this repo.

**Scope**
- In: the single `/launch` rewrite in `next.config.ts`.
- Out: porting the page into the Next app / hosting media on R2 — deliberately kept lightweight; can revisit if we want it as a fully styled blog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)