### PR TITLE
fix: book-URL + SEO health — hidden-book search leak, 500→404, soft-404 page numbers, log noise

### DIFF
--- a/src/app/api/analytics/not-found/route.ts
+++ b/src/app/api/analytics/not-found/route.ts
@@ -23,6 +23,23 @@ export async function POST(request: NextRequest) {
     const dbWork = (async () => {
       const db = await getDb();
 
+      // Don't log 404s for books that are deliberately hidden from the public
+      // reader. Hidden/in-copyright books correctly 404 via the reader gate
+      // (isBookReadable, PR #2522), but bots and stale links keep re-crawling
+      // their /book/<slug>[/page/<id>] URLs — ~27k/week of noise that buries the
+      // real broken links. If the URL points at a known-hidden book, skip it.
+      const bookSlug = url.match(/^\/book\/([^/?#]+)/)?.[1];
+      if (bookSlug) {
+        const slug = decodeURIComponent(bookSlug);
+        const book = await db.collection('books').findOne(
+          { $or: [{ slug }, { id: slug }] },
+          { projection: { visible: 1, hidden: 1 } },
+        );
+        if (book && (book.hidden === true || book.visible === false)) {
+          return; // deliberately hidden — expected 404, not worth recording
+        }
+      }
+
       // Deduplicate: same URL + IP within 1 hour
       const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
       const anonIp = ip.replace(/\.\d+$/, '.0');

--- a/src/app/api/errors/route.ts
+++ b/src/app/api/errors/route.ts
@@ -39,6 +39,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'message required' }, { status: 400 });
     }
 
+    // Drop opaque cross-origin noise. Browsers report errors thrown by
+    // third-party scripts (extensions, embeds, ad/analytics tags) as the bare
+    // string "Script error." with no stack or source — they're not our bugs and
+    // not actionable, yet they were ~75% of all logged errors (1.6k/day), burying
+    // the real ones. Accept the report (ok) but don't store it.
+    const msg = String(message).trim();
+    if (/^Script error\.?$/i.test(msg)) {
+      return NextResponse.json({ ok: true, skipped: 'noise' });
+    }
+
     const db = await getDb();
     await db.collection('application_errors').insertOne({
       message: String(message).slice(0, 2000),

--- a/src/app/api/redirect/book-slug/route.ts
+++ b/src/app/api/redirect/book-slug/route.ts
@@ -20,22 +20,29 @@ export async function GET(request: NextRequest) {
   const db = await getReadDb();
   const result = await findBookByIdOrSlug(db, bookIdOrSlug, { id: 1, slug: 1 });
 
+  // "No redirect needed" — either the book isn't found (page renders its 404),
+  // or its canonical URL already IS /book/<input> (a book with no distinct slug,
+  // or matched directly by slug). We can't `NextResponse.next()` here: this is a
+  // route handler (not middleware), so next() throws "NextResponse.next() was used
+  // in a route handler" and surfaces as a 500 — which is exactly what was breaking
+  // every invalid book id and the ~29 visible books that have no slug.
+  //
+  // Instead, bounce back to /book/<input> with an `ns` marker. The proxy skips its
+  // id→resolver rewrite when `ns` is present (so no loop), and /book/[id] renders
+  // the book or calls notFound() for a real, styled 404.
+  const renderInPlace = () =>
+    NextResponse.redirect(new URL(`/book/${encodeURIComponent(bookIdOrSlug)}?ns=1`, request.url), 302);
+
   if (!result) {
-    // Book not found — let the page handle 404
-    return NextResponse.next();
+    return renderInPlace();
   }
 
   const slug = (result.book.slug || result.book.id || result.book._id?.toString()) as string;
 
-  // If the lookup matched by slug, no redirect needed — pass through
-  if (result.matchedBySlug) {
-    return NextResponse.next();
-  }
-
-  // If the resolved slug is the same as the input (no real slug exists), pass through
-  // to avoid infinite redirect loops
-  if (slug === bookIdOrSlug) {
-    return NextResponse.next();
+  // Lookup matched by slug, or the canonical slug is the same as the input → no
+  // real redirect target; render in place.
+  if (result.matchedBySlug || slug === bookIdOrSlug) {
+    return renderInPlace();
   }
 
   // Redirect non-slug URL to canonical slug URL

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -52,20 +52,30 @@ export async function GET(request: NextRequest) {
       const pages = await semanticPageSearchGlobal(searchQuery, limit, { language, languages, excludeLanguages, yearMin, yearMax, maxPerBook });
       const bookIds = [...new Set(pages.map(p => p.book_id))];
       let slugMap: Record<string, string> = {};
+      // Books hidden from the public reader (visible:false OR hidden:true). Embeddings
+      // live in Supabase and aren't pruned when a book is hidden, so we drop them here —
+      // otherwise they surface in search and 404 on click (matches the reader gate
+      // isBookReadable / isHiddenBook, PR #2522).
+      const hiddenBookIds = new Set<string>();
       if (bookIds.length > 0) {
         try {
           const db = await getDb();
           const books = await db.collection('books').find(
             { id: { $in: bookIds } },
-            { projection: { id: 1, slug: 1 } }
+            { projection: { id: 1, slug: 1, visible: 1, hidden: 1 } }
           ).toArray();
-          for (const b of books) if (b.id && b.slug) slugMap[b.id as string] = b.slug as string;
+          for (const b of books) {
+            if (b.id && b.slug) slugMap[b.id as string] = b.slug as string;
+            if (b.id && (b.hidden === true || b.visible === false)) hiddenBookIds.add(b.id as string);
+          }
         } catch { /* slug enrichment is best-effort */ }
       }
-      const enriched = pages.map(p => ({
-        ...p,
-        slug: slugMap[p.book_id] || null,
-      }));
+      const enriched = pages
+        .filter(p => !hiddenBookIds.has(p.book_id))
+        .map(p => ({
+          ...p,
+          slug: slugMap[p.book_id] || null,
+        }));
       logSearchQuery({
         request, route: 'search.semantic.page', query: query!,
         total: enriched.length, ms: Date.now() - _searchStart, ok: true,
@@ -103,16 +113,22 @@ export async function GET(request: NextRequest) {
     // Enrich with thumbnail + slug from MongoDB
     const bookIds = books.map(b => b.book_id);
     let thumbnailMap: Record<string, { thumbnail?: string; thumbnail_blob?: string; slug?: string }> = {};
+    // Books hidden from the public reader (visible:false OR hidden:true). Embeddings
+    // live in Supabase and aren't pruned when a book is hidden, so we drop them here —
+    // otherwise they surface in search and 404 on click (matches the reader gate
+    // isBookReadable / isHiddenBook, PR #2522).
+    const hiddenBookIds = new Set<string>();
     if (bookIds.length > 0) {
       try {
         const db = await getDb();
         const mongoBooks = await db.collection('books').find(
           { id: { $in: bookIds } },
-          { projection: { id: 1, _id: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, slug: 1 } }
+          { projection: { id: 1, _id: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, slug: 1, visible: 1, hidden: 1 } }
         ).toArray();
         for (const mb of mongoBooks) {
           const bid = mb.id || mb._id?.toString();
           if (bid) thumbnailMap[bid] = { thumbnail: mb.thumbnail, thumbnail_blob: mb.thumbnail_blob, slug: mb.slug };
+          if (bid && (mb.hidden === true || mb.visible === false)) hiddenBookIds.add(bid);
         }
       } catch (e) {
         // Non-fatal — results still work without thumbnails
@@ -126,6 +142,7 @@ export async function GET(request: NextRequest) {
     const SEMANTIC_SIM_FLOOR = 0.55;
     const enriched = books
       .filter(b => b.similarity >= SEMANTIC_SIM_FLOOR)
+      .filter(b => !hiddenBookIds.has(b.book_id))
       .map(b => ({
         ...b,
         thumbnail: thumbnailMap[b.book_id]?.thumbnail || null,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -763,6 +763,26 @@ export async function proxy(request: NextRequest) {
     }
   }
 
+  // Reader page URLs that use a page *number* instead of a page *id*
+  // (/book/<slug>/page/5). The reader route keys off the page id, so a numeric
+  // segment renders notFound() — but that route is ISR, so it returns HTTP 200
+  // with a "Page Not Found" body (a Next.js soft-404). Google had ~1.2k of these
+  // indexed as soft-404s. Resolve the number → real page id via the existing
+  // book-page resolver, which 301s to /book/<slug>/page/<pageId> (or 302s to the
+  // book if the number is out of range). Real page ids (24-hex, met-*, etc.) are
+  // never purely numeric, so they fall through to the normal ISR page route.
+  const bookPageNumMatch = pathname.match(/^\/book\/([^/]+)\/page\/([1-9]\d{0,5})$/);
+  if (bookPageNumMatch) {
+    const [, segment, pageNum] = bookPageNumMatch;
+    const url = request.nextUrl.clone();
+    url.pathname = '/api/redirect/book-page';
+    url.search = '';
+    const headers = new Headers(request.headers);
+    headers.set('x-redirect-book', segment);
+    headers.set('x-redirect-page', pageNum);
+    return NextResponse.rewrite(url, { request: { headers } });
+  }
+
   // --- Bot rate limiting (soft) ---
   // Browser rate limiting is handled by Vercel WAF (dashboard config).
   // This in-memory limiter only applies to bots as a defense-in-depth layer.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -744,8 +744,11 @@ export async function proxy(request: NextRequest) {
     // Slugs contain hyphens and are >24 chars. ObjectIds are exactly 24 hex chars.
     // Custom IDs are shorter hex strings with at least one hex letter (a-f).
     // Pure numeric strings (e.g. "13") are not valid IDs and should 404 normally.
+    // `ns=1` means the book-slug resolver already ran and decided there's no
+    // redirect target (no-slug book or 404) — skip re-rewriting so /book/[id]
+    // renders in place. Without this guard, bouncing back here would loop.
     const looksLikeId = /^[0-9a-f]{24}$/.test(segment) || (!segment.includes('-') && /^[0-9a-f]+$/.test(segment) && /[a-f]/.test(segment));
-    if (looksLikeId) {
+    if (looksLikeId && !request.nextUrl.searchParams.has('ns')) {
       const url = request.nextUrl.clone();
       url.pathname = '/api/redirect/book-slug';
       url.search = '';

--- a/tests/unit/page-number-redirect.test.ts
+++ b/tests/unit/page-number-redirect.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+// /book/<slug>/page/<number> (a page NUMBER where the reader expects a page ID)
+// must be resolved at the proxy level to the real page id. The reader route is
+// ISR, so its notFound() renders HTTP 200 with a "Page Not Found" body — a
+// Next.js soft-404. Google had ~1.2k of these indexed. The proxy rewrites the
+// numeric form to the book-page resolver, which 301s to /book/<slug>/page/<id>.
+// Real page ids (24-hex, met-*, base64-ish) are never purely 1–6 digit numbers,
+// so they fall through to the normal page route untouched.
+
+const PROXY = path.join(path.resolve(__dirname, '../..'), 'src/proxy.ts');
+
+describe('/book/<slug>/page/<number> proxy resolution', () => {
+  it('proxy.ts matches a numeric page segment and rewrites to the book-page resolver', () => {
+    const src = readFileSync(PROXY, 'utf8');
+    const idx = src.search(/\/\^\\\/book\\\/\(\[\^\/\]\+\)\\\/page\\\/\(\[1-9\]\\d\{0,5\}\)\$\//);
+    expect(
+      idx,
+      String.raw`src/proxy.ts must match /^\/book\/([^/]+)\/page\/([1-9]\d{0,5})$/`
+    ).toBeGreaterThan(-1);
+    expect(
+      src.slice(idx, idx + 500),
+      'the numeric-page match must rewrite to /api/redirect/book-page with the page header'
+    ).toMatch(/\/api\/redirect\/book-page/);
+  });
+});


### PR DESCRIPTION
## Why
A 404 spike in `not_found_reports` plus the GSC 'why pages aren't indexed' report surfaced a cluster of book-URL / indexability bugs. Fixed together.

## Changes

### 1. Search leaked hidden books → 404 on click
`/api/search/semantic` hydrated from Mongo with **no `visible`/`hidden` filter** (embeddings live in Supabase, not pruned on hide). Hidden books surfaced and 404'd via the reader gate. Both branches now drop `hidden:true`/`visible:false`.

### 2. Invalid/no-slug book ids returned HTTP 500 (should be 404) — GSC 'Server error (5xx)' ≈253
The `/book/<id>` redirect resolver used `NextResponse.next()` (middleware-only) in a route handler → throws → 500. Every dead book id 500'd, and **~29 visible no-slug books were fully inaccessible**. Now bounces no-redirect cases to `/book/<id>?ns=1`; proxy skips its rewrite when `ns` is set (no loop) so `/book/[id]` renders the book or a real styled 404.

### 3. `/book/<slug>/page/<number>` soft-404s — GSC 'Soft 404' ≈1,243
The reader route keys off page *id*; a numeric page-*number* renders `notFound()`, but the route is ISR so that returns **HTTP 200 + 'Page Not Found'** (a soft-404). Proxy now resolves numeric page URLs to the real page id via the existing book-page resolver → 301 to `/book/<slug>/page/<pageId>` (302 to the book if out of range). Guard test pins the wiring.

### 4. Log-noise filters
- `analytics/not-found`: skip logging 404s for known-hidden book URLs (~27k/week crawl noise).
- `api/errors`: drop opaque cross-origin `Script error.` reports (~1.6k/day, ~75% of logged errors).

## Verification
- `test` CI green (336 unit tests); local `tsc` + import-check clean. New guard test for the page-number wiring.
- The page-number resolver is already prod-proven (it powers `/book/<id>?page=N`).
- Vercel check shows the usual first-build flake; `search-eval` red is a pre-existing prod Sanskrit-filter data issue, unrelated to this branch.

## Out of scope
- Broken images: investigated, found mostly transient (self-heal to 200; stragglers are `/api/image` timing out on slow external sources). No fix.
- The 22,571 GSC '403 blocked' pile is stale from the fixed Cloudflare WAF rule — needs a 'Validate Fix' click in GSC, no code change.
- 3 Instagram deep-links use gallery-image ids as page ids (external social scheduler); diagnosis handed off.
- Hanuman/Besant/Gommatsara artworks/books un-hidden directly in Mongo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)