### PR TITLE
feat(vision): $1M Year One ask with grounded budget + giving menu

### DIFF
--- a/src/app/vision/VisionView.tsx
+++ b/src/app/vision/VisionView.tsx
@@ -405,6 +405,53 @@ export default function VisionView({
           })}
         </section>
 
+        {/* ── Ways to take part ── */}
+        {content.ways && (
+          <section className="mt-20 max-w-[68ch]">
+            {F({
+              as: 'h2',
+              path: 'ways.heading',
+              value: content.ways.heading,
+              className: 'font-serif text-2xl md:text-3xl text-primary leading-snug mb-3',
+            })}
+            {F({
+              as: 'p',
+              path: 'ways.intro',
+              value: content.ways.intro,
+              className: 'text-secondary leading-relaxed mb-8',
+            })}
+
+            <dl className="divide-y divide-primary/10 border-y border-primary/10">
+              {content.ways.tiers.map((tier, i) => (
+                <div
+                  key={`${version}:tier:${i}`}
+                  className="grid grid-cols-1 sm:grid-cols-[auto_1fr] gap-1 sm:gap-8 py-4 items-baseline"
+                >
+                  {F({
+                    as: 'dt',
+                    path: `ways.tiers.${i}.gift`,
+                    value: tier.gift,
+                    className: 'font-serif text-primary text-lg whitespace-nowrap',
+                  })}
+                  {F({
+                    as: 'dd',
+                    path: `ways.tiers.${i}.label`,
+                    value: tier.label,
+                    className: 'text-secondary leading-relaxed',
+                  })}
+                </div>
+              ))}
+            </dl>
+
+            {F({
+              as: 'p',
+              path: 'ways.footnote',
+              value: content.ways.footnote,
+              className: 'text-muted text-sm leading-relaxed mt-6',
+            })}
+          </section>
+        )}
+
         {/* ── CTA ── */}
         <section className="mt-20 max-w-[68ch] border-t border-primary/10 pt-12">
           {F({

--- a/src/app/vision/content.ts
+++ b/src/app/vision/content.ts
@@ -29,6 +29,12 @@ export interface VisionContent {
   signoff: string;
   signature: { name: string; role: string; email: string; photo: string };
   plan: { heading: string; intro: string; items: PlanItem[]; footnote: string };
+  ways: {
+    heading: string;
+    intro: string;
+    tiers: { gift: string; label: string }[];
+    footnote: string;
+  };
   cta: {
     heading: string;
     body: string;
@@ -100,18 +106,30 @@ export const visionContent: VisionContent = {
     photo: '/founder-derek.jpg',
   },
   plan: {
-    heading: 'A brief plan',
-    intro: 'Over the next five years we aim to grow Source Library into a permanent institution. We are seeking roughly **$15 million** in philanthropic support to make it possible. Here is the work, and what each part of it asks for.',
+    heading: 'Year One',
+    intro: 'This is **Year One** of a five-year build. The full vision — translating hundreds of thousands of works, scanning tens of thousands that have never been online, partnering with a thousand libraries — is roughly a **$15 million** undertaking. But it starts with proving the engine. We are raising a **first round of $1 million** to run Source Library as a real institution for its first year (it costs about **$550,000 a year**), make good on the six months of work already delivered, and hold a reserve for the next. Here is what that first million builds.',
     items: [
-      { work: 'Translate 250,000+ more ancient works', resource: '$1M' },
-      { work: 'Scan 50,000+ works that have never been online', resource: '$3M' },
-      { work: 'Partner with 1,000+ libraries and archives worldwide', resource: '$2M' },
-      { work: 'Convene a braintrust of linguists and scholars', resource: '$2M' },
-      { work: 'Build a technical foundation that will last', resource: '$1M' },
-      { work: 'Gatherings and expeditions to bring the community together', resource: '$2M' },
-      { work: 'A small full-time team and direct support for partner libraries', resource: '$4M' },
+      { work: 'A small founding team — a director, a scanning specialist at the Embassy, community & partnerships, and visiting scholars', resource: '$500K' },
+      { work: 'Core technology & AI translation infrastructure — engineering, and keeping every page online', resource: '$270K' },
+      { work: 'Begin a Spanish edition of the library — AI-drafted across the collection, validated by expert translators', resource: '$25K' },
+      { work: 'Begin expert validation of our Tibetan translations — Tibetan scholars checking the AI against the canon', resource: '$10K' },
+      { work: 'A first expedition — endangered Javanese manuscripts with Javanologi (UNS) and B-NICE Amsterdam', resource: '$60K' },
+      { work: 'Contingency and a reserve into year two', resource: '$135K' },
     ],
-    footnote: 'These figures are illustrative of the scale of the work, not a fixed budget. As much as they fund translation and scanning, they sustain people: the gatherings that bring the community together, the expeditions that gather and preserve materials, and the libraries we partner with around the world.',
+    footnote: 'These figures are illustrative of the scale of the work, not a fixed budget. Prove the engine in year one and the rest follows: over five years, hundreds of thousands of works translated and checked by experts into every major language, tens of thousands scanned for the first time, a thousand libraries joined together, and an endowment to keep it all online for good — the full **$15 million** vision, and the permanence it secures. More than half of this first round funds people, because the careful act of bringing an irreplaceable book into the light — and the scholars who validate every translation — is the part AI cannot do.',
+  },
+  ways: {
+    heading: 'A place in the lineage',
+    intro: 'The men and women who translated the last Renaissance are five centuries gone — and their names are still on the work. This is your turn. Every gift below rescues real books and carries your name with them, in perpetuity.',
+    tiers: [
+      { gift: '$275', label: 'Adopt a rare manuscript — one irreplaceable hand-written treasure brought to the world, named for you' },
+      { gift: '$8,500', label: 'A named shelf — 100 books rescued, translated, and yours to name' },
+      { gift: '$60K', label: 'Underwrite the Javanese expedition — rescue endangered manuscripts before they are lost' },
+      { gift: '$80K', label: 'A named wing — 1,000 books of the digital library' },
+      { gift: 'from $150K', label: 'Underwrite a language edition — bring the entire library into Spanish (or Arabic, Hindi, and beyond), expert-validated, your name on it' },
+      { gift: '$250K', label: 'Founding patron — underwrite all of Year One; your name on the institution, and a hand in what we translate next' },
+    ],
+    footnote: 'Every tier funds the people and the careful work behind it — the digitizer at the Embassy, the scholars who validate, the pipeline that keeps each page online. You are not funding overhead; you are rescuing a book for the world, with your name beside it.',
   },
   cta: {
     heading: 'Let’s talk',


### PR DESCRIPTION
## What

Reframes `/vision` from an abstract \$15M five-year ask into a concrete **\$1M Year One** round that leads into the bigger vision.

- **Year One plan (\$1M)** — founding team (\$500K), core tech (\$270K), expert-validated Spanish (\$25K) + Tibetan (\$10K) launches, named Javanese expedition with Javanologi/UNS + B-NICE (\$60K), reserve (\$135K). Grounded in a real ~\$550K/yr run-rate; covers the past 6 months + next 12 + a reserve.
- **Honesty fixes** — drops "forever" from the annual hosting line (a year of hosting buys a year); permanence reframed as the mission an endowment secures. Spanish/Tibetan framed as "begin," validated by experts.
- **New "A place in the lineage" giving menu** before the CTA — prestige-priced naming tiers (adopt a manuscript → named shelf → expedition → wing → language edition → founding patron) to convert the two strongest donor motivations (prevent lost knowledge + join the lineage).

## Out of scope

- The internal donor budget (run-rate detail, comparables, menu-vs-cost reconciliation) lives in the private ops repo, not here.
- No changes to `/support` or the giving backend — menu tiers are presentational; "Make a gift" still routes to `/support`.

## Test plan

- `npx tsc --noEmit` — clean (exit 0)
- New `ways` section is guarded (`content.ways && ...`) so older pasted JSON in the `?edit` editor degrades gracefully
- Visual check of `/vision` after deploy: Year One plan sums to \$1M; lineage menu renders before "Let's talk"

🤖 Generated with [Claude Code](https://claude.com/claude-code)