### PR TITLE
fix(seo): hard 404 (not soft-404 200) for missing/hidden book + page URLs

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -195,24 +195,21 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 
   if (!book) {
-    // Self-referential canonical (not the inherited root '/') so Google doesn't
-    // see this as a duplicate of the homepage while it's still 200/noindex.
-    return {
-      title: 'Book Not Found - Source Library',
-      robots: { index: false, follow: false },
-      alternates: { canonical: `/book/${id}` },
-    };
+    // Genuinely missing book → hard 404. Calling notFound() here in
+    // generateMetadata (awaited BEFORE the response shell streams) sets a real
+    // 404 status; the same call from the page body comes too late — loading.tsx
+    // has already flushed a 200 shell — and only soft-404s (200 + not-found UI).
+    // getBookForMetadata retries once and rethrows transient DB errors, which the
+    // catch above turns into generic 200 metadata, so we only reach here for a
+    // genuine miss, never a blip. (Was a 200 soft-404; GSC flagged ~1.2k of these.)
+    notFound();
   }
 
-  // Hidden books (visible:false) are not public. Emit not-found/noindex metadata
-  // on the public ISR route — matches the notFound() the page body returns.
-  // Editors reach hidden books via /book/[id]/preview (dynamic, auth-gated).
+  // Hidden books (visible:false) are not public — hard 404 on the public ISR
+  // route, matching the notFound() the page body returns. Editors reach hidden
+  // books via /book/[id]/preview (dynamic, auth-gated).
   if (isHiddenBook(book)) {
-    return {
-      title: 'Book Not Found - Source Library',
-      robots: { index: false, follow: false },
-      alternates: { canonical: `/book/${id}` },
-    };
+    notFound();
   }
 
   const title = book.display_title || book.title;

--- a/src/app/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/book/[id]/page/[pageId]/layout.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { getTenantContext } from '@/lib/tenant-context';
+import { isHiddenBook } from '@/lib/book-access';
 import { Book, Page } from '@/lib/types';
 
 export const preferredRegion = 'fra1';
@@ -14,14 +16,19 @@ interface LayoutProps {
 // Only fetch the fields needed for metadata — skip index, reading_summary, etc.
 const BOOK_META_PROJECTION = {
   _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, published: 1, language: 1,
+  visible: 1, hidden: 1,
 };
 const PAGE_META_PROJECTION = {
   _id: 0, id: 1, book_id: 1, page_number: 1, photo: 1,
   'translation.data': 1, 'ocr.data': 1, seo_indexable: 1,
 };
 
+// Returns {null,null} ONLY for a genuine miss (no such page, or wrong tenant).
+// A DB/connection error propagates (after one retry) so the caller can tell a
+// transient blip apart from a real 404 — without this distinction an Atlas
+// hiccup during ISR rebuild would 404 a page that actually exists.
 async function getPageData(bookId: string, pageId: string, tenantId?: string): Promise<{ book: Book | null; page: Page | null }> {
-  try {
+  const run = async () => {
     const db = await getReadDb();
     const [bookResult, page] = await Promise.all([
       findBookByIdOrSlug(db, bookId, BOOK_META_PROJECTION, tenantId),
@@ -36,28 +43,46 @@ async function getPageData(bookId: string, pageId: string, tenantId?: string): P
       }
     }
 
-    return {
-      book,
-      page: page as unknown as Page | null,
-    };
+    return { book, page: page as unknown as Page | null };
+  };
+  try {
+    return await run();
   } catch {
-    return { book: null, page: null };
+    // Transient error — retry once; a second failure propagates to the caller.
+    await new Promise((r) => setTimeout(r, 200 + Math.random() * 300));
+    return await run();
   }
 }
 
 export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
   const { id, pageId } = await params;
   const ctx = await getTenantContext();
-  const { book, page } = await getPageData(id, pageId, ctx?.id ?? undefined);
 
-  if (!book || !page) {
-    // Self-referential canonical so this URL isn't seen as a duplicate of '/'
-    // (inherited root canonical).
+  let book: Book | null;
+  let page: Page | null;
+  try {
+    ({ book, page } = await getPageData(id, pageId, ctx?.id ?? undefined));
+  } catch {
+    // Persistent DB error — emit generic noindex metadata, NEVER a false 404.
     return {
-      title: 'Page Not Found - Source Library',
+      title: 'Source Library',
       robots: { index: false, follow: true },
       alternates: { canonical: `/book/${id}/page/${pageId}` },
     };
+  }
+
+  if (!book || !page) {
+    // Genuine miss (bad page id, or page belongs to another tenant) → hard 404.
+    // notFound() runs here in generateMetadata, awaited before the loading.tsx
+    // shell streams, so it sets a real 404 status. The page body's notFound()
+    // comes too late (200 already flushed) and only soft-404s. (Was a 200
+    // soft-404 — GSC's "Soft 404" bucket.)
+    notFound();
+  }
+
+  // Hidden (visible:false) book → hard 404, matching the page body's gate.
+  if (isHiddenBook(book as any)) {
+    notFound();
   }
 
   const bookTitle = book.display_title || book.title;


### PR DESCRIPTION
## Why
Follow-up to #2758. Nonexistent or hidden `/book/<id>` and `/book/<id>/page/<id>` URLs render the not-found UI but return **HTTP 200** — a soft-404 — because both routes have a `loading.tsx`: Next streams a 200 shell before the page body's `notFound()` runs, so the status is already committed. GSC flags these in the **Soft 404** bucket (~1.2k).

## Fix
Move the existence/hidden check into `generateMetadata`, which is awaited **before** the shell streams, so `notFound()` there sets a real 404 status.

- **`book/[id]/page.tsx`** — `notFound()` for genuinely-missing and hidden books (was 200 noindex metadata). `getBookForMetadata` already retries and rethrows transient DB errors (caught → generic 200 metadata), so this never 404s on a blip — only a real miss.
- **`book/[id]/page/[pageId]/layout.tsx`** — same for missing/wrong-tenant/hidden pages. `getPageData` now retries once and **propagates** a persistent DB error (→ generic 200 metadata) instead of swallowing it to `{null,null}`, preserving the blip-vs-miss distinction. Added `visible`/`hidden` to the metadata projection.

Pairs with the page-number redirect (#2758) to clear the Soft-404 bucket: numeric page URLs 301 to the real page; genuinely-dead URLs now hard-404.

## Verification (must confirm on preview before merge)
The `notFound()`-in-generateMetadata → 404 behavior needs a live check under Next 16 + Turbopack. Will verify on the preview that: missing book → 404, missing page → 404, hidden book → 404, valid book/page → 200, before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)