### PR TITLE
fix(reading-history): record global (non-tenant) books (#2759)

### DIFF
--- a/src/app/api/reading-history/route.ts
+++ b/src/app/api/reading-history/route.ts
@@ -38,6 +38,9 @@ export async function POST(request: NextRequest) {
       const db = await getDb();
 
       // Tenant from proxy header if available; otherwise look up the book.
+      // Global (non-tenant) books resolve to tenantId: null — they must still
+      // be recorded. Only bail when the book genuinely can't be resolved
+      // (mirrors the likes fix, #2407).
       let tenantId = getTenantContextFromRequest(request).id;
       let resolvedBookId = book_id;
       if (!tenantId) {
@@ -45,20 +48,21 @@ export async function POST(request: NextRequest) {
           { $or: [{ id: book_id }, { slug: book_id }] },
           { projection: { id: 1, tenantId: 1 } }
         );
-        tenantId = (book?.tenantId as string) || null;
-        if (book?.id) resolvedBookId = book.id as string;
+        if (!book) return; // unknown book — silent fail
+        tenantId = (book.tenantId as string) || null;
+        if (book.id) resolvedBookId = book.id as string;
       }
-      if (!tenantId) return; // unknown book/tenant — silent fail
 
       const collection = db.collection('reading_history');
       const cutoff = new Date(now.getTime() - SESSION_GAP_MS);
 
-      // Session collapse: find recent entry for same user+book
+      // Session collapse: find recent entry for same user+book.
+      // tenantId is null for global books — match it explicitly.
       const existing = await collection.findOne(
         {
           user_id: userId,
           book_id: resolvedBookId,
-          tenantId,
+          tenantId: tenantId ?? null,
           updated_at: { $gte: cutoff },
         },
         { sort: { updated_at: -1 } }


### PR DESCRIPTION
Closes #2759

## Problem
`POST /api/reading-history` bailed out for any book without a `tenantId` — which is every normal global book, i.e. the entire public catalog. Reading history has recorded **nothing** for global books since ~2026-05-14. Surfaced by founder QA ("I was reading some Chinese book… not in my history").

## Fix
Mirror the likes fix (#2407): resolve the book and store the row with `tenantId: null` when it's a global book. Only bail when the book genuinely can't be resolved. The session-collapse `findOne` now matches `tenantId: null` explicitly, and the `GET` path already shows global books on the canonical `/reading-history` page (no tenant header ⇒ no `tenantId` constraint).

## Scope
- In: the POST write path only.
- Out: no schema/index changes; existing tenant rows keep scoping correctly (tenant subdomains still filter by `tenantId`).

## Acceptance
- Reading a global book creates/updates a `reading_history` row.
- `/reading-history` shows global books read after the fix.
- Tenant books still scope correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)