### PR TITLE
fix(ocr): read-time safety net — collapse lacuna dot-walls + strip LaTeX leakage (#2764)

### DIFF
--- a/src/components/reader/NotesRenderer.tsx
+++ b/src/components/reader/NotesRenderer.tsx
@@ -8,6 +8,7 @@ import rehypeRaw from 'rehype-raw';
 import { ChevronDown, ChevronRight, Info } from 'lucide-react';
 import { isRTLLanguage } from '@/lib/types';
 import { NOTE_TAG_STYLES } from '@/lib/style-constants';
+import { collapseLacunaWalls, latexToReadable } from '@/lib/clean-ocr-artifacts';
 
 // Page types where the entire "translation" is AI-generated description (no original text)
 const DESCRIPTION_ONLY_PAGE_TYPES = new Set(['blank', 'frontispiece', 'illustration', 'cover', 'map', 'diagram', 'musical-score', 'table']);
@@ -783,7 +784,9 @@ export default function NotesRenderer({ text, className = '', showMetadata = tru
   const isDescriptionOnly = DESCRIPTION_ONLY_PAGE_TYPES.has(pageType ?? '') ||
     DESCRIPTION_ONLY_PAGE_TYPES.has(metadata.pageType ?? '');
 
-  const withBracketTags = useMemo(() => preprocessBracketTags(cleanText, showNotes), [cleanText, showNotes]);
+  // Collapse runaway dot/lacuna walls before anything else parses the text (#2764).
+  const withLacuna = useMemo(() => collapseLacunaWalls(cleanText), [cleanText]);
+  const withBracketTags = useMemo(() => preprocessBracketTags(withLacuna, showNotes), [withLacuna, showNotes]);
   // Drop dangling vocabulary chips when notes are off (see preprocessTerms).
   const withTerms = useMemo(() => preprocessTerms(withBracketTags, showNotes), [withBracketTags, showNotes]);
   // On description-only pages, render the whole AI description uniformly (no half-highlighting).
@@ -793,7 +796,11 @@ export default function NotesRenderer({ text, className = '', showMetadata = tru
   );
   const withGreek = useMemo(() => preprocessLatexGreek(withDescription), [withDescription]);
   const withLatex = useMemo(() => preprocessLatexSuperscripts(withGreek), [withGreek]);
-  const withAnnotationMd = useMemo(() => preprocessAnnotationInlineMarkdown(withLatex), [withLatex]);
+  // Mop up remaining LaTeX leakage the dedicated handlers above don't cover —
+  // \frac{a}{b}, \sqrt{x}, stray $…$ math, symbol commands (#2764). Runs AFTER
+  // the Greek/superscript/overline handlers so their nicer HTML output stands.
+  const withMathClean = useMemo(() => latexToReadable(withLatex), [withLatex]);
+  const withAnnotationMd = useMemo(() => preprocessAnnotationInlineMarkdown(withMathClean), [withMathClean]);
   const withCentering = useMemo(() => preprocessCentering(withAnnotationMd), [withAnnotationMd]);
   // Ensure blank lines around block-level HTML tags so markdown parser resumes inline processing.
   // Without this, text like "</div>\n**bold**" is treated as one HTML block and ** renders literally.

--- a/src/lib/clean-ocr-artifacts.ts
+++ b/src/lib/clean-ocr-artifacts.ts
@@ -1,0 +1,105 @@
+/**
+ * Read-time OCR artifact cleaners (#2764).
+ *
+ * Two classes of OCR artifact reach readers / search / quotes as garbage text:
+ *
+ *  1. Runaway dot/lacuna walls — degenerate model repetition that emits
+ *     hundreds–thousands of "." (papyrus / critical-edition lacunae), or long
+ *     dash/underscore rules. The OCR prompt (v14) prevents most at write time,
+ *     but legacy pages and any residual loop still need a read-time guard.
+ *  2. LaTeX math leakage — literal `$\frac{a}{b}$`, `\sqrt{x}`, stray `\times`
+ *     etc. rendered raw to readers (~thousands of pages).
+ *
+ * These run at READ time (zero re-OCR cost). They are deliberately separate
+ * from `stripEditorialWrappers` (which flattens markdown tables — wrong for the
+ * reader, which keeps real markdown): the two transforms here are safe for BOTH
+ * the reader and the snippet/quote surfaces, so both import from one place.
+ */
+
+/**
+ * Collapse a run of ≥12 repeated dot / ellipsis / middot / dash / underscore
+ * "units" (each optionally followed by a few spaces, so ". . . ." and a solid
+ * "............" both match) down to a single `[…]` lacuna marker.
+ *
+ * Threshold 12 so ordinary ellipses ("…", "...") and short rules ("---") are
+ * untouched; only genuine walls collapse. `[ \t]` (not `\s`) between units so a
+ * wall never swallows a newline and merges two lines.
+ */
+export function collapseLacunaWalls(input: string): string {
+  if (!input) return input;
+  return input
+    .replace(/(?:[.․‧·…_-][ \t]{0,3}){12,}/g, ' […] ')
+    // tidy only the runs of 3+ spaces the marker insertion can create; leave
+    // ordinary single/double spacing alone.
+    .replace(/ {3,}/g, ' ');
+}
+
+// Common LaTeX symbol commands → Unicode. Greek is included so the snippet
+// path (which has no other Greek handling) renders \alpha as α; the reader
+// already converts Greek before this runs, so those are no-ops there.
+const LATEX_SYMBOLS: Record<string, string> = {
+  times: '×', cdot: '·', div: '÷', pm: '±', mp: '∓', ast: '∗',
+  leq: '≤', le: '≤', geq: '≥', ge: '≥', neq: '≠', ne: '≠',
+  ll: '≪', gg: '≫', approx: '≈', equiv: '≡', cong: '≅', sim: '∼', propto: '∝',
+  infty: '∞', partial: '∂', nabla: '∇', sum: '∑', prod: '∏', int: '∫',
+  pi: 'π', alpha: 'α', beta: 'β', gamma: 'γ', delta: 'δ', epsilon: 'ε',
+  zeta: 'ζ', eta: 'η', theta: 'θ', iota: 'ι', kappa: 'κ', lambda: 'λ',
+  mu: 'μ', nu: 'ν', xi: 'ξ', rho: 'ρ', sigma: 'σ', tau: 'τ', upsilon: 'υ',
+  phi: 'φ', chi: 'χ', psi: 'ψ', omega: 'ω',
+  Gamma: 'Γ', Delta: 'Δ', Theta: 'Θ', Lambda: 'Λ', Xi: 'Ξ', Pi: 'Π',
+  Sigma: 'Σ', Phi: 'Φ', Psi: 'Ψ', Omega: 'Ω',
+  ldots: '…', cdots: '…', dots: '…', to: '→', rightarrow: '→', leftarrow: '←',
+};
+
+/**
+ * Convert stray LaTeX math leakage to a readable plain-text form. Handles the
+ * reported cases (`$\frac{a}{b}$`, `\sqrt{x}`) plus common symbols and inline
+ * math delimiters. NOT a full LaTeX renderer — unknown `\commands` are left
+ * intact rather than risk mangling legitimate text.
+ *
+ * Order matters: strip math *delimiters* first (so `$\frac{a}{b}$` becomes
+ * `\frac{a}{b}`), then expand commands. Delimiter stripping is guarded to only
+ * fire when the inner text actually looks like math (contains `\`, `^`, `_` or
+ * `{`), so historical currency like "$5 and $10" survives.
+ */
+export function latexToReadable(input: string): string {
+  if (!input || (input.indexOf('\\') === -1 && input.indexOf('$') === -1)) return input;
+  let t = input;
+
+  // Display + inline math delimiters → keep inner. `\(...\)` / `\[...\]` always;
+  // `$$...$$` always; `$...$` only when the inner looks like math.
+  t = t.replace(/\$\$([\s\S]*?)\$\$/g, '$1');
+  t = t.replace(/\\\(([\s\S]*?)\\\)/g, '$1');
+  t = t.replace(/\\\[([\s\S]*?)\\\]/g, '$1');
+  t = t.replace(/\$([^$\n]*?[\\^_{][^$\n]*?)\$/g, '$1');
+
+  // \frac{a}{b} → a/b (two passes cover one level of nesting). Includes \dfrac/\tfrac.
+  const fracRe = /\\[dt]?frac\s*\{([^{}]*)\}\s*\{([^{}]*)\}/g;
+  t = t.replace(fracRe, '$1/$2').replace(fracRe, '$1/$2');
+  // \sqrt{x} → √(x)
+  t = t.replace(/\\sqrt\s*\{([^{}]*)\}/g, '√($1)');
+  // Font/box commands → inner content.
+  t = t.replace(
+    /\\(?:text(?:bf|it|rm|sf|tt)?|math(?:bf|it|rm|bb|cal|frak|sf)?|operatorname|boldsymbol|overline|underline)\s*\{([^{}]*)\}/g,
+    '$1',
+  );
+  // Sizing/spacing commands → drop.
+  t = t.replace(/\\(?:left|right|big|Big|bigg|Bigg|displaystyle|quad|qquad)\b/g, '');
+  t = t.replace(/\\[,;:! ]/g, ' ');
+  // Symbol commands → Unicode (unknown names left untouched).
+  t = t.replace(/\\([a-zA-Z]+)/g, (m, name: string) => LATEX_SYMBOLS[name] ?? m);
+  // Braced super/subscripts → readable parenthesized form.
+  t = t.replace(/\^\{([^{}]*)\}/g, '^($1)').replace(/_\{([^{}]*)\}/g, '_($1)');
+
+  return t;
+}
+
+/**
+ * Both read-time cleaners in sequence: LaTeX first, then lacuna-wall collapse.
+ * Use on plain-text snippet/quote surfaces. (The reader applies the two pieces
+ * individually so they slot around its existing Greek/superscript handling.)
+ */
+export function cleanOcrArtifacts(input: string): string {
+  if (!input) return input;
+  return collapseLacunaWalls(latexToReadable(input));
+}

--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -30,6 +30,8 @@
  * can't reopen on one surface.
  */
 
+import { cleanOcrArtifacts } from '@/lib/clean-ocr-artifacts';
+
 // Translation-side page-description blocks ∪ OCR-side page-level metadata
 // envelope. All *describe* the page; none are verbatim source text.
 const EDITORIAL_WRAPPERS =
@@ -89,14 +91,19 @@ function stripMarkdownMarkers(text: string): string {
 
 export function stripEditorialWrappers(text: string): string {
   if (!text) return text;
-  return stripMarkdownMarkers(
-    flattenMarkdownTables(
-      text
-        // Paired blocks, content and all (multiline). Backreference keeps it from
-        // swallowing text between two different wrapper types.
-        .replace(new RegExp(`<(${EDITORIAL_WRAPPERS})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
-        // Any orphan opening/closing wrapper tag left by malformed AI output.
-        .replace(new RegExp(`<\\/?(?:${EDITORIAL_WRAPPERS})>`, 'gi'), ' '),
+  // OCR artifact cleanup (#2764): collapse runaway dot/lacuna walls and convert
+  // stray LaTeX leakage to readable plain text. Sequenced AFTER wrapper/markdown
+  // stripping so it operates on the body text that surfaces in snippets/quotes.
+  return cleanOcrArtifacts(
+    stripMarkdownMarkers(
+      flattenMarkdownTables(
+        text
+          // Paired blocks, content and all (multiline). Backreference keeps it from
+          // swallowing text between two different wrapper types.
+          .replace(new RegExp(`<(${EDITORIAL_WRAPPERS})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
+          // Any orphan opening/closing wrapper tag left by malformed AI output.
+          .replace(new RegExp(`<\\/?(?:${EDITORIAL_WRAPPERS})>`, 'gi'), ' '),
+      ),
     ),
   );
 }

--- a/src/lib/types/prompts/defaults.ts
+++ b/src/lib/types/prompts/defaults.ts
@@ -2,7 +2,7 @@ import { ProcessingPrompts } from "./core";
 import type { DetectedImage } from "../page";
 
 // Bump this when DEFAULT_PROMPTS change. Stored on every page record for audit trail.
-export const PROMPT_VERSION = 'v6.1.2026-05';
+export const PROMPT_VERSION = 'v6.2.2026-06';
 
 const VALID_PAGE_TYPES = new Set([
   'title-page', 'frontispiece', 'dedication', 'preface', 'toc', 'index',
@@ -181,13 +181,19 @@ export const DEFAULT_PROMPTS: ProcessingPrompts = {
 
 **Column layout:** If the page has two (or more) text columns, transcribe the left column first, then insert <column-break/> on its own line, then transcribe the right column. Do NOT use <column-break/> for single-column pages.
 
+**Lacunae & runaway repetition (CRITICAL):**
+- Critical and papyrological editions mark missing or illegible text with runs of dots, dashes, or underscores. Transcribe SHORT gaps using the edition's own bracket notation, but NEVER emit more than ~10 repeated characters in a row. If a gap/rule/dotted line is longer, collapse it to a single [...] marker — do NOT reproduce it dot-for-dot.
+- NEVER output the same character more than ~10 times consecutively. A long run of one repeated character is always an error.
+- A lacuna or gap NEVER ends the page. After a [...] marker, CONTINUE transcribing everything else on the page (surrounding text, commentary, footnotes, apparatus). Transcribe the whole page top to bottom.
+
 **Critical rules:**
 1. Preserve original spelling, capitalization, punctuation
 2. Page numbers/headers/signatures go in metadata tags ONLY — NEVER duplicate as ## headings or body text. Example: "DISCURSUS IV." at top of page → <header>DISCURSUS IV.</header> and nothing else
 3. Decorative initials (drop caps): merge large ornamental first letters with the word they begin. A large "L" followed by "EX" → "Lex", not "L Ex"
 4. IGNORE partial text at left/right edges (from facing page in spread)
 5. Capture ALL text including margins and annotations
-6. End with <vocab>key terms, names, concepts</vocab>
+6. Check the physical margins carefully — transcribe ALL marginal text using <margin> tags, placed BEFORE the paragraph they annotate. Do not skip margin text because it is small, faint, or in a different hand.
+7. End with <vocab>key terms, names, concepts</vocab>
 
 **If image has quality issues**, start with <warning>describe issue</warning>
 

--- a/tests/unit/clean-ocr-artifacts.test.ts
+++ b/tests/unit/clean-ocr-artifacts.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { collapseLacunaWalls, latexToReadable, cleanOcrArtifacts } from '@/lib/clean-ocr-artifacts';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+
+// Read-time OCR safety net (#2764): runaway dot/lacuna walls must collapse to a
+// single marker and stray LaTeX must render as readable text, on the reader and
+// every snippet/quote surface.
+
+describe('collapseLacunaWalls', () => {
+  it('collapses a solid wall of hundreds of dots to one marker', () => {
+    const wall = '.'.repeat(500);
+    const out = collapseLacunaWalls(`before ${wall} after`);
+    expect(out).not.toMatch(/\.{12,}/);
+    expect(out).toContain('[…]');
+    expect(out).toContain('before');
+    expect(out).toContain('after');
+  });
+
+  it('collapses a spaced ". . . ." lacuna run', () => {
+    const out = collapseLacunaWalls('text ' + '. '.repeat(40) + 'more');
+    expect(out).toContain('[…]');
+    expect(out).toContain('more');
+  });
+
+  it('collapses long dash and underscore rules', () => {
+    expect(collapseLacunaWalls('a ' + '-'.repeat(30) + ' b')).toContain('[…]');
+    expect(collapseLacunaWalls('a ' + '_'.repeat(30) + ' b')).toContain('[…]');
+  });
+
+  it('leaves ordinary ellipses and short rules untouched', () => {
+    expect(collapseLacunaWalls('wait... really')).toBe('wait... really');
+    expect(collapseLacunaWalls('a — b … c')).toBe('a — b … c');
+    expect(collapseLacunaWalls('--- divider ---')).toBe('--- divider ---');
+  });
+
+  it('does not swallow a newline / merge lines', () => {
+    const out = collapseLacunaWalls('line one\n' + '.'.repeat(20) + '\nline two');
+    expect(out).toContain('line one');
+    expect(out).toContain('line two');
+    expect(out).toContain('\n');
+  });
+});
+
+describe('latexToReadable', () => {
+  it('converts $\\frac{a}{b}$ to a/b', () => {
+    expect(latexToReadable('value $\\frac{a}{b}$ here')).toContain('a/b');
+    expect(latexToReadable('value $\\frac{a}{b}$ here')).not.toContain('\\frac');
+    expect(latexToReadable('value $\\frac{a}{b}$ here')).not.toContain('$');
+  });
+
+  it('handles a bare \\frac with no math delimiters', () => {
+    expect(latexToReadable('\\frac{1}{2}')).toBe('1/2');
+  });
+
+  it('converts \\sqrt{x} to √(x)', () => {
+    expect(latexToReadable('$\\sqrt{2}$')).toBe('√(2)');
+  });
+
+  it('maps common symbol + Greek commands to Unicode', () => {
+    expect(latexToReadable('$a \\times b$')).toBe('a × b');
+    expect(latexToReadable('$\\alpha + \\beta$')).toBe('α + β');
+  });
+
+  it('leaves historical currency like "$5 and $10" untouched', () => {
+    expect(latexToReadable('paid $5 and $10 more')).toBe('paid $5 and $10 more');
+  });
+
+  it('is a no-op on text with no backslash or dollar', () => {
+    const plain = 'just ordinary prose, nothing to do here';
+    expect(latexToReadable(plain)).toBe(plain);
+  });
+
+  it('leaves unknown commands intact rather than mangling', () => {
+    expect(latexToReadable('\\somethingweird')).toBe('\\somethingweird');
+  });
+});
+
+describe('cleanOcrArtifacts (combined)', () => {
+  it('cleans both artifacts in one pass', () => {
+    const input = `The ratio $\\frac{1}{2}$ then ${'.'.repeat(40)} continues`;
+    const out = cleanOcrArtifacts(input);
+    expect(out).toContain('1/2');
+    expect(out).toContain('[…]');
+    expect(out).not.toMatch(/\.{12,}/);
+  });
+});
+
+describe('stripEditorialWrappers wires the OCR cleaner (#2764)', () => {
+  it('the snippet/quote path collapses dot-walls and cleans LaTeX', () => {
+    const input = `Real body text. ${'.'.repeat(300)} The fraction $\\frac{a}{b}$.`;
+    const out = stripEditorialWrappers(input);
+    expect(out).not.toMatch(/\.{12,}/);
+    expect(out).toContain('[…]');
+    expect(out).toContain('a/b');
+  });
+});


### PR DESCRIPTION
Closes #2764

Two classes of OCR artifact reached readers / search / quotes as garbage text. This adds a **read-time** safety net (zero re-OCR cost) plus the matching write-time **prompt-seed** sync.

## Read-time cleaners — new `src/lib/clean-ocr-artifacts.ts`
- `collapseLacunaWalls` — collapses a run of ≥12 repeated dot/ellipsis/middot/dash/underscore "units" (solid `............` **and** spaced `. . . .`) to a single `[…]` marker. Threshold 12 so ordinary ellipses/short rules are untouched; uses `[ \t]` between units so a wall never merges two lines.
- `latexToReadable` — `$\frac{a}{b}$` → `a/b`, `\sqrt{x}` → `√(x)`, common symbol/Greek commands → Unicode, strips inline-math `$…$` delimiters **only when the inner looks like math** (so historical currency `$5 and $10` survives). Unknown `\commands` are left intact rather than risk mangling text.

## Wiring (every surface reads its own copy — CLAUDE.md)
- **Reader** (`NotesRenderer`): lacuna collapse before parsing; LaTeX mop-up *after* the existing Greek/superscript/overline handlers so their nicer HTML output stands.
- **Snippet/quote/search/embedding**: folded into `stripEditorialWrappers` (after wrapper + markdown stripping), so all of `/api/search`, `/api/books/[id]/{search,quote}`, IIIF, likes, embeddings, and the tenant twins are covered in one place.

## Write-time seed sync (per issue comment)
Synced the OCR prompt **seed** `DEFAULT_PROMPTS.ocr` to the live DB **v14** — some batch OCR paths read the seed, not the DB: added the lacunae/anti-repetition block and the margin-transcription rule; bumped `PROMPT_VERSION`.

## Out of scope
Re-OCR of truly-broken legacy pages (owned by the OCR-reprocessing session); rendering math via a full formatter (KaTeX) — readable plain-text form is sufficient here.

## Tests
`tests/unit/clean-ocr-artifacts.test.ts` (14 passing) covers dot-walls (solid/spaced/dash/underscore), ellipsis/short-rule preservation, newline safety, frac/sqrt/symbol conversion, currency preservation, and the `stripEditorialWrappers` integration. Existing `strip-editorial-wrappers` suite still green (16). `tsc --noEmit` clean.

## Acceptance
- No multi-hundred-dot wall renders in the reader. ✓
- No raw `$\frac{}{}$` renders in the reader. ✓
- Quote/snippet APIs return cleaned text. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)