### PR TITLE
fix(ocr): read-time safety net — collapse lacuna dot-walls + strip LaTeX leakage (#2764)

### DIFF
--- a/src/components/reader/NotesRenderer.tsx
+++ b/src/components/reader/NotesRenderer.tsx
@@ -8,6 +8,7 @@ import rehypeRaw from 'rehype-raw';
 import { ChevronDown, ChevronRight, Info } from 'lucide-react';
 import { isRTLLanguage } from '@/lib/types';
 import { NOTE_TAG_STYLES } from '@/lib/style-constants';
+import { cleanOcrArtifacts } from '@/lib/strip-editorial-wrappers';
 
 // Page types where the entire "translation" is AI-generated description (no original text)
 const DESCRIPTION_ONLY_PAGE_TYPES = new Set(['blank', 'frontispiece', 'illustration', 'cover', 'map', 'diagram', 'musical-score', 'table']);
@@ -783,7 +784,12 @@ export default function NotesRenderer({ text, className = '', showMetadata = tru
   const isDescriptionOnly = DESCRIPTION_ONLY_PAGE_TYPES.has(pageType ?? '') ||
     DESCRIPTION_ONLY_PAGE_TYPES.has(metadata.pageType ?? '');
 
-  const withBracketTags = useMemo(() => preprocessBracketTags(cleanText, showNotes), [cleanText, showNotes]);
+  // Read-time OCR safety net (#2764): collapse runaway dot/dash/underscore
+  // lacuna walls to […] and convert leaked LaTeX (\frac, \sqrt, operators) to
+  // readable text BEFORE any markdown/annotation preprocessing. Superscript
+  // spans ($^{n}$) are left for preprocessLatexSuperscripts below.
+  const withArtifacts = useMemo(() => cleanOcrArtifacts(cleanText), [cleanText]);
+  const withBracketTags = useMemo(() => preprocessBracketTags(withArtifacts, showNotes), [withArtifacts, showNotes]);
   // Drop dangling vocabulary chips when notes are off (see preprocessTerms).
   const withTerms = useMemo(() => preprocessTerms(withBracketTags, showNotes), [withBracketTags, showNotes]);
   // On description-only pages, render the whole AI description uniformly (no half-highlighting).

--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -87,16 +87,63 @@ function stripMarkdownMarkers(text: string): string {
     .replace(/\n[ \t]*\n[ \t]*\n+/g, '\n\n');
 }
 
+/**
+ * Collapse runaway lacuna fills and convert leaked LaTeX math to readable text.
+ *
+ * Two OCR-artifact classes reach readers/search/quotes as garbage text:
+ *  1. Runaway dot/dash/underscore loops — papyrus and critical-edition lacunae
+ *     the model reproduces character-for-character (sometimes thousands long).
+ *     OCR prompt v14 prevents most at write-time; this is the read-time guard for
+ *     legacy pages and any residual loop.
+ *  2. LaTeX math leakage — literal `$\frac{a}{b}$` etc. rendered raw to readers.
+ *
+ * Safe for BOTH the reader (run before markdown) and the plain-text snippet/quote
+ * surfaces. Deliberately leaves `$^{n}$` superscript spans alone — the reader
+ * turns those into <sup>, and on snippet surfaces they're harmless. Markdown
+ * table separator rows (`|---|`) are left intact (the dash guard skips any run
+ * adjacent to a `|`). See issue #2764.
+ */
+export function cleanOcrArtifacts(text: string): string {
+  if (!text) return text;
+  return text
+    // 1a. 12+ of the same dot-class char, optionally space-separated (". . . ."),
+    //     collapse to a single […] lacuna marker.
+    .replace(/([.·•…])(?:[ \t ]*\1){11,}/g, '[…]')
+    // 1b. Blank-fill underscore runs (12+).
+    .replace(/_{12,}/g, '[…]')
+    // 1c. Dash rules (12+), incl. spaced ("- - - -"). The leading guard skips any
+    //     run that starts adjacent to a `|` or another dash, so markdown table
+    //     separators (`|------------|`) are never collapsed.
+    .replace(/(?<![|\-–—])[-–—](?:[ \t ]*[-–—]){11,}(?![-–—|])/g, ' […]')
+    // 2a. \frac{a}{b} (optionally $-wrapped) → (a)/(b); \sqrt{x} → √(x).
+    .replace(/\$?\\[dt]?frac\s*\{([^{}]*)\}\s*\{([^{}]*)\}\$?/g, '($1)/($2)')
+    .replace(/\$?\\sqrt\s*\{([^{}]*)\}\$?/g, '√($1)')
+    // 2b. Common operators leaked as bare LaTeX commands.
+    .replace(/\\times(?![a-z])/gi, '×')
+    .replace(/\\cdot(?![a-z])/gi, '·')
+    .replace(/\\div(?![a-z])/gi, '÷')
+    .replace(/\\pm(?![a-z])/gi, '±')
+    .replace(/\\(?:leq|le)(?![a-z])/gi, '≤')
+    .replace(/\\(?:geq|ge)(?![a-z])/gi, '≥')
+    .replace(/\\neq(?![a-z])/gi, '≠')
+    .replace(/\\infty(?![a-z])/gi, '∞');
+}
+
 export function stripEditorialWrappers(text: string): string {
   if (!text) return text;
-  return stripMarkdownMarkers(
-    flattenMarkdownTables(
-      text
-        // Paired blocks, content and all (multiline). Backreference keeps it from
-        // swallowing text between two different wrapper types.
-        .replace(new RegExp(`<(${EDITORIAL_WRAPPERS})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
-        // Any orphan opening/closing wrapper tag left by malformed AI output.
-        .replace(new RegExp(`<\\/?(?:${EDITORIAL_WRAPPERS})>`, 'gi'), ' '),
+  // cleanOcrArtifacts runs LAST so lacuna/LaTeX cleanup applies to the final
+  // plain text (after table flattening + marker stripping). Every snippet/quote
+  // surface routes through here, so they all inherit the OCR safety net.
+  return cleanOcrArtifacts(
+    stripMarkdownMarkers(
+      flattenMarkdownTables(
+        text
+          // Paired blocks, content and all (multiline). Backreference keeps it from
+          // swallowing text between two different wrapper types.
+          .replace(new RegExp(`<(${EDITORIAL_WRAPPERS})>[\\s\\S]*?<\\/\\1>`, 'gi'), ' ')
+          // Any orphan opening/closing wrapper tag left by malformed AI output.
+          .replace(new RegExp(`<\\/?(?:${EDITORIAL_WRAPPERS})>`, 'gi'), ' '),
+      ),
     ),
   );
 }

--- a/src/lib/types/prompts/defaults.ts
+++ b/src/lib/types/prompts/defaults.ts
@@ -181,13 +181,19 @@ export const DEFAULT_PROMPTS: ProcessingPrompts = {
 
 **Column layout:** If the page has two (or more) text columns, transcribe the left column first, then insert <column-break/> on its own line, then transcribe the right column. Do NOT use <column-break/> for single-column pages.
 
+**Lacunae & runaway repetition (CRITICAL):**
+- Critical and papyrological editions mark missing or illegible text with runs of dots, dashes, or underscores. Transcribe SHORT gaps using the edition's own bracket notation, but NEVER emit more than ~10 repeated characters in a row. If a gap/rule/dotted line is longer, collapse it to a single [...] marker — do NOT reproduce it dot-for-dot.
+- NEVER output the same character more than ~10 times consecutively. A long run of one repeated character is always an error.
+- A lacuna or gap NEVER ends the page. After a [...] marker, CONTINUE transcribing everything else on the page (surrounding text, commentary, footnotes, apparatus). Transcribe the whole page top to bottom.
+
 **Critical rules:**
 1. Preserve original spelling, capitalization, punctuation
 2. Page numbers/headers/signatures go in metadata tags ONLY — NEVER duplicate as ## headings or body text. Example: "DISCURSUS IV." at top of page → <header>DISCURSUS IV.</header> and nothing else
 3. Decorative initials (drop caps): merge large ornamental first letters with the word they begin. A large "L" followed by "EX" → "Lex", not "L Ex"
 4. IGNORE partial text at left/right edges (from facing page in spread)
 5. Capture ALL text including margins and annotations
-6. End with <vocab>key terms, names, concepts</vocab>
+6. Check the physical margins carefully — top, bottom, left, and right. Transcribe ALL marginal text using <margin> tags, placed BEFORE the paragraph they annotate. Do not skip margin text because it is small, faint, or in a different hand.
+7. End with <vocab>key terms, names, concepts</vocab>
 
 **If image has quality issues**, start with <warning>describe issue</warning>
 

--- a/tests/unit/strip-editorial-wrappers.test.ts
+++ b/tests/unit/strip-editorial-wrappers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { stripEditorialWrappers, cleanOcrArtifacts } from '@/lib/strip-editorial-wrappers';
 
 describe('stripEditorialWrappers', () => {
   it('drops a <meta> block content-and-all', () => {
@@ -121,5 +121,61 @@ describe('stripEditorialWrappers', () => {
     expect(stripEditorialWrappers('see footnote * and ** below')).toBe('see footnote * and ** below');
     // Underscores are never touched (literal in OCR/transliteration).
     expect(stripEditorialWrappers('istimnāʾ _ or jing_preservation')).toBe('istimnāʾ _ or jing_preservation');
+  });
+
+  // ── OCR safety net is inherited by every snippet/quote surface (#2764) ──────
+  it('collapses a runaway dot wall served through a snippet surface', () => {
+    const t = 'the temple of [...] before the ' + '.'.repeat(800) + ' and then the river';
+    const out = stripEditorialWrappers(t);
+    expect(out).not.toMatch(/\.{12}/);            // no dot wall survives
+    expect(out).toContain('the temple of');
+    expect(out).toContain('and then the river'); // text after the lacuna survives
+  });
+});
+
+describe('cleanOcrArtifacts', () => {
+  it('collapses 12+ literal dots to a single […] marker', () => {
+    expect(cleanOcrArtifacts('before ' + '.'.repeat(2000) + ' after')).toBe('before […] after');
+  });
+
+  it('collapses spaced-out dot lacunae (". . . .")', () => {
+    expect(cleanOcrArtifacts('μῆνιν ' + '. '.repeat(20).trim() + ' θεά')).toBe('μῆνιν […] θεά');
+  });
+
+  it('collapses long underscore blank-fills', () => {
+    expect(cleanOcrArtifacts('name: ' + '_'.repeat(30))).toBe('name: […]');
+  });
+
+  it('collapses a long dash rule but NOT a markdown table separator', () => {
+    expect(cleanOcrArtifacts('section ' + '—'.repeat(20))).toContain('[…]');
+    // A wide table separator must survive intact (dashes touch a pipe).
+    const sep = '| Name | Page |\n|--------------|--------------|\n| Aquinas | 187 |';
+    expect(cleanOcrArtifacts(sep)).toBe(sep);
+  });
+
+  it('leaves short, normal punctuation runs alone', () => {
+    expect(cleanOcrArtifacts('wait... what? — yes')).toBe('wait... what? — yes');
+    expect(cleanOcrArtifacts('a --- thematic break')).toBe('a --- thematic break');
+  });
+
+  it('converts leaked LaTeX fractions and roots to readable form', () => {
+    expect(cleanOcrArtifacts('the ratio $\\frac{a}{b}$ holds')).toBe('the ratio (a)/(b) holds');
+    expect(cleanOcrArtifacts('bare \\frac{1}{2} too')).toBe('bare (1)/(2) too');
+    expect(cleanOcrArtifacts('side $\\sqrt{2}$')).toBe('side √(2)');
+  });
+
+  it('converts common LaTeX operators', () => {
+    expect(cleanOcrArtifacts('3 \\times 4 \\div 2 \\pm 1')).toBe('3 × 4 ÷ 2 ± 1');
+    expect(cleanOcrArtifacts('a \\leq b \\geq c \\neq d')).toBe('a ≤ b ≥ c ≠ d');
+  });
+
+  it('leaves $^{n}$ superscript spans for the reader to render', () => {
+    // The reader turns these into <sup> downstream — cleanOcrArtifacts must not touch them.
+    expect(cleanOcrArtifacts('verse $^{19}$ here')).toBe('verse $^{19}$ here');
+  });
+
+  it('is a no-op on ordinary prose and prices', () => {
+    expect(cleanOcrArtifacts('a plain sentence with no artifacts.')).toBe('a plain sentence with no artifacts.');
+    expect(cleanOcrArtifacts('it cost $5 to $10')).toBe('it cost $5 to $10');
   });
 });


### PR DESCRIPTION
Closes #2764.

## Problem
Two OCR-artifact classes reached readers / search / quotes as garbage text:
1. **Runaway dot/dash/underscore lacuna loops** — papyrus and critical-edition gaps the model reproduced character-for-character (sometimes thousands long). Founder feedback: *"ocr went nuts on the dots."*
2. **LaTeX math leakage** — literal `$\frac{a}{b}$` etc. rendered raw (Treatise on Universal Harmony p.506).

## Fix (read-time, zero re-OCR cost)
New `cleanOcrArtifacts()` in the shared cleaner (`src/lib/strip-editorial-wrappers.ts`):
- Collapses runs of 12+ repeated dot/middot/bullet/ellipsis, `_`, or dash chars (incl. spaced `". . . ."`) to a single `[…]` marker.
- Converts `\frac{a}{b}` → `(a)/(b)`, `\sqrt{x}` → `√(x)`, and common operators (`\times`/`\cdot`/`\div`/`\pm`/`\leq`/`\geq`/`\neq`/`\infty`).
- **Deliberately safe:** markdown table separators (`|---|`) survive (dash guard skips runs touching a `|`), `$^{n}$` superscript spans are left for the reader's `<sup>` handler, and prices like `$5` are untouched.

### Wired into both surface families
- **Snippet/quote surfaces** — folded into `stripEditorialWrappers` (runs last), so all 11 call sites inherit it automatically: `/api/search`, book search, the quote API + tenant twins, IIIF ocr/translation + search, likes popular/mine. Per CLAUDE.md "every surface reads its own copy," this keeps the net from reopening on one path.
- **Reader** — added to the `NotesRenderer` chain before markdown/annotation preprocessing, ahead of the existing superscript handler.

### Seed-sync (from the issue comment)
`DEFAULT_PROMPTS.ocr` in `src/lib/types/prompts/defaults.ts` now carries the live DB **v14** additions — the lacuna / anti-repetition block and the margin-transcription rule — because some batch OCR paths read the seed, not the DB prompt.

## Tests
10 new unit tests (26 total green): dot-wall (literal + spaced), underscore fill, dash rule vs table separator, `\frac`/`\sqrt`/operators, superscript pass-through, price pass-through, and end-to-end through `stripEditorialWrappers` (incl. text-after-lacuna survival). `npx tsc --noEmit` clean.

## Out of scope
- Write-time prompt fix (OCR v14) — already shipped in the DB; this PR only mirrors it into the seed.
- Page-level re-OCR of truly-broken legacy pages — owned by the OCR-reprocessing session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)