### PR TITLE
feat(reader): EN/ES language toggle for Spanish editions

### DIFF
--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -30,6 +30,8 @@ export default function PageEditorClient({
   const [pageList] = useState<Page[]>(initialPageList);
   const [currentPageId, setCurrentPageId] = useState<string>(initialPage.id);
   const [currentPage, setCurrentPage] = useState<Page>(initialPage);
+  // Reading language: 'en' (default) or 'es' (Spanish edition, when available).
+  const [lang, setLang] = useState<'en' | 'es'>('en');
   const params = useParams<{ tenant: string }>();
   const pathname = usePathname();
   const isOnTenantSubdomain = typeof window !== 'undefined' && /^[a-z]+\.sourcelibrary\.org$/.test(window.location.hostname);
@@ -256,15 +258,28 @@ export default function PageEditorClient({
     }
   };
 
-  // When version-pinned, overlay the versioned translation onto the page object
-  const displayPage = pinnedVersion && versionedTranslation != null
-    ? {
+  // Spanish edition availability (per-page; pivot-translated from English).
+  const hasSpanish = !!currentPage.translation_es?.data;
+  // Version pinning is English-edition-specific, so it disables the ES view.
+  const showSpanish = lang === 'es' && hasSpanish && !pinnedVersion;
+
+  // Build the page handed to the reader, overlaying (in precedence order):
+  //   1. Spanish edition when the ES toggle is active
+  //   2. the version-pinned English translation when ?v= is set
+  let displayPage = currentPage;
+  if (showSpanish) {
+    displayPage = {
+      ...currentPage,
+      translation: { ...(currentPage.translation || {}), ...currentPage.translation_es!, language: 'Spanish' },
+    } as Page;
+  } else if (pinnedVersion && versionedTranslation != null) {
+    displayPage = {
       ...currentPage,
       translation: currentPage.translation
         ? { ...currentPage.translation, data: versionedTranslation }
         : { data: versionedTranslation, language: 'en', model: 'versioned' },
-    } as Page
-    : currentPage;
+    } as Page;
+  }
 
   return (
     <>
@@ -282,6 +297,30 @@ export default function PageEditorClient({
           doiUrl={versionEdition.doiUrl}
           bookUrl={`${tenantPrefix}/book/${book.id}/page/${currentPageId}`}
         />
+      )}
+
+      {hasSpanish && !pinnedVersion && (
+        <div className="flex items-center justify-center gap-2 py-2 text-sm" role="group" aria-label="Reading language">
+          <span className="text-neutral-500">Read in:</span>
+          <div className="inline-flex overflow-hidden rounded-full border border-neutral-300">
+            <button
+              type="button"
+              onClick={() => setLang('en')}
+              aria-pressed={lang === 'en'}
+              className={`px-3 py-1 transition-colors ${lang === 'en' ? 'bg-neutral-800 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-100'}`}
+            >
+              English
+            </button>
+            <button
+              type="button"
+              onClick={() => setLang('es')}
+              aria-pressed={lang === 'es'}
+              className={`px-3 py-1 transition-colors ${lang === 'es' ? 'bg-neutral-800 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-100'}`}
+            >
+              Español
+            </button>
+          </div>
+        </div>
       )}
 
       <TranslationEditor

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -12,6 +12,7 @@ export interface Page {
   compressed_photo?: string;
   ocr?: OcrData;
   translation?: TranslationData;
+  translation_es?: TranslationData;  // Spanish edition (pivot-translated from English); read-time toggle in the reader
   summary?: SummaryData;
   modernized?: ModernizedData;  // Modernized text for reading dashboard
   transliteration?: TransliterationData;  // Romanized transliteration for non-Latin scripts


### PR DESCRIPTION
## What
Adds a read-time **English / Español** toggle to the page reader, shown only when a page has a Spanish edition (`pages.translation_es`). Selecting Español overlays `translation_es` onto the rendered translation via the existing display pipeline (`stripEditorialWrappers` + `NotesRenderer`).

## Why
First step of the Spanish **content** rollout (#2770) — make the pivot-translated Spanish editions readable. Companion to the UI-localization issues #2763 / #2701 (chrome).

## How it works
- **No API changes.** SSR (`/book/[id]/page/[pageId]`) and the pages `get`/`batch` routes already project the full doc (`detected_images:0`), so `translation_es` reaches the client and survives client-side navigation.
- Mirrors the existing version-pinning overlay pattern in `PageEditorClient`.
- Toggle is **hidden when no ES exists** and **disabled while version-pinned** (`?v=`, since editions are English-specific).

## Scope
- `src/lib/types/page.ts` — add optional `translation_es?: TranslationData`.
- `src/components/book/PageEditorClient.tsx` — `lang` state, ES overlay, toggle UI.

## Out of scope (follow-ups)
- Populating ES at scale: currently seeded for the most-popular/most-searched books (pivot from English, Gemini 3.1 Flash-Lite). Production rollout = extend `translate-worker` with ES as a target language (tracked in #2770).
- Sitewide language preference / persistence and localized chrome (#2763).
- `hreflang`/SEO for ES pages.

## Testing
- `tsc --noEmit`: clean. Pre-commit `check-imports`: pass.
- Verify on the Vercel preview using a book with ES content (e.g. *Course on the Book of Thoth*): toggle appears, Español renders, English remains default, nav preserves the choice's availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)