### PR TITLE
feat(i18n): show EN/ES toggle in the header sitewide (#2763)

### DIFF
--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 import Logo from './Logo';
 import UserMenu from './UserMenu';
 import { Search, ChevronDown } from 'lucide-react';
-import { useLocale, NAV_STRINGS, type NavStrings, type Locale } from '@/lib/i18n';
+import { useLocale, localeHref, NAV_STRINGS, type NavStrings, type Locale } from '@/lib/i18n';
 
 interface NavLink {
   label: string;
@@ -73,10 +73,13 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
   const locale = homeLocale ?? pathnameLocale;
   const t = NAV_STRINGS[locale];
   const NAV_LINKS = buildNavLinks(t);
-  // The EN/ES toggle only appears where a Spanish route exists — i.e. the
-  // homepage (`/` ↔ `/es`). Deep pages have no `/es` equivalent (thin i18n),
-  // so a global toggle there would dead-end on a 404.
-  const isHome = homeLocale != null || pathname === '/' || pathname === '/es';
+  // The EN/ES toggle is shown sitewide (#2763): Spanish-speaking visitors lose
+  // all language control once they leave `/es`, and the funnel pages reach
+  // Instagram/webview users who have no browser translate button. EN always
+  // links to the canonical page (reader stays put); ES links to the `/es` twin
+  // when one exists, else the Spanish homepage front door (see localeHref).
+  const enHref = localeHref('en', pathname);
+  const esHref = localeHref('es', pathname);
 
   // Close menus on route change
   useEffect(() => { setMenuOpen(false); setDropdownOpen(null); }, [pathname]);
@@ -189,34 +192,32 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
             })}
           </nav>
 
-          {/* Language toggle (homepage only — `/es` exists only for the home front door) */}
-          {isHome && (
-            <div className="flex items-center gap-1.5 text-xs font-medium tracking-wide" aria-label="Language">
-              <Link
-                href="/"
-                aria-current={locale === 'en' ? 'page' : undefined}
-                className={
-                  locale === 'en'
-                    ? (isWhiteText ? 'text-white' : 'text-primary')
-                    : (isWhiteText ? 'text-white/50 hover:text-white' : 'text-secondary hover:text-primary')
-                }
-              >
-                EN
-              </Link>
-              <span className={isWhiteText ? 'text-white/30' : 'text-stone-300'}>·</span>
-              <Link
-                href="/es"
-                aria-current={locale === 'es' ? 'page' : undefined}
-                className={
-                  locale === 'es'
-                    ? (isWhiteText ? 'text-white' : 'text-primary')
-                    : (isWhiteText ? 'text-white/50 hover:text-white' : 'text-secondary hover:text-primary')
-                }
-              >
-                ES
-              </Link>
-            </div>
-          )}
+          {/* Language toggle — shown sitewide (#2763) */}
+          <div className="flex items-center gap-1.5 text-xs font-medium tracking-wide" aria-label="Language">
+            <Link
+              href={enHref}
+              aria-current={locale === 'en' ? 'page' : undefined}
+              className={
+                locale === 'en'
+                  ? (isWhiteText ? 'text-white' : 'text-primary')
+                  : (isWhiteText ? 'text-white/50 hover:text-white' : 'text-secondary hover:text-primary')
+              }
+            >
+              EN
+            </Link>
+            <span className={isWhiteText ? 'text-white/30' : 'text-stone-300'}>·</span>
+            <Link
+              href={esHref}
+              aria-current={locale === 'es' ? 'page' : undefined}
+              className={
+                locale === 'es'
+                  ? (isWhiteText ? 'text-white' : 'text-primary')
+                  : (isWhiteText ? 'text-white/50 hover:text-white' : 'text-secondary hover:text-primary')
+              }
+            >
+              ES
+            </Link>
+          </div>
 
           {/* Desktop search icon */}
           <Link

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -25,6 +25,36 @@ export function useLocale(): Locale {
   return localeFromPathname(usePathname());
 }
 
+// ---------- Locale switching (sitewide EN/ES toggle, #2763) ----------
+
+// EN base paths that have a real Spanish (`/es…`) twin route. Keep this in sync
+// with the `src/app/es/**` route folders. Today only the homepage; the funnel
+// pages (`/support`, `/auth/signin`) are added here when their `/es` routes
+// land. The header toggle is shown on EVERY page, but on a page with no twin the
+// ES link falls back to the Spanish homepage (`/es`) as a front door rather than
+// dead-ending on a 404 — the thin-i18n bargain (deep pages rely on the browser's
+// own translate).
+export const LOCALIZED_PATHS = new Set<string>(['/']);
+
+/** Strip the `/es` locale prefix to get the canonical English path. */
+export function canonicalPath(pathname: string | null | undefined): string {
+  if (!pathname || pathname === '/es') return '/';
+  if (pathname.startsWith('/es/')) return pathname.slice(3); // '/es/x' → '/x'
+  return pathname;
+}
+
+/**
+ * Href for switching the current page to `target` locale.
+ * - English: the canonical page (any `/es` prefix dropped) so the reader stays put.
+ * - Spanish: the `/es` twin when one exists, else the Spanish homepage (`/es`).
+ */
+export function localeHref(target: Locale, pathname: string | null | undefined): string {
+  const canonical = canonicalPath(pathname);
+  if (target === 'en') return canonical;
+  if (LOCALIZED_PATHS.has(canonical)) return canonical === '/' ? '/es' : `/es${canonical}`;
+  return '/es';
+}
+
 // ---------- Shared site-shell strings (header nav) ----------
 
 export interface NavStrings {

--- a/tests/unit/i18n-locale-href.test.ts
+++ b/tests/unit/i18n-locale-href.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalPath, localeHref, localeFromPathname, LOCALIZED_PATHS } from '@/lib/i18n';
+
+describe('canonicalPath', () => {
+  it('drops the /es prefix', () => {
+    expect(canonicalPath('/es')).toBe('/');
+    expect(canonicalPath('/es/support')).toBe('/support');
+    expect(canonicalPath('/es/auth/signin')).toBe('/auth/signin');
+  });
+  it('leaves English paths and null/undefined sane', () => {
+    expect(canonicalPath('/support')).toBe('/support');
+    expect(canonicalPath('/')).toBe('/');
+    expect(canonicalPath(null)).toBe('/');
+    expect(canonicalPath(undefined)).toBe('/');
+  });
+  it('does not mis-strip a non-locale path that merely starts with "es"', () => {
+    // '/esoterica' must NOT become '/oterica'
+    expect(canonicalPath('/esoterica')).toBe('/esoterica');
+  });
+});
+
+describe('localeHref (sitewide toggle, #2763)', () => {
+  it('EN always returns the canonical page so the reader stays put', () => {
+    expect(localeHref('en', '/es')).toBe('/');
+    expect(localeHref('en', '/es/support')).toBe('/support');
+    expect(localeHref('en', '/book/foo')).toBe('/book/foo');
+  });
+
+  it('ES links to the /es twin when one exists', () => {
+    expect(localeHref('es', '/')).toBe('/es');
+    expect(localeHref('es', '/es')).toBe('/es');
+  });
+
+  it('ES falls back to the Spanish homepage on pages with no twin', () => {
+    // Deep pages (no /es twin) front-door to /es rather than 404.
+    expect(localeHref('es', '/book/foo')).toBe('/es');
+    expect(localeHref('es', '/gallery')).toBe('/es');
+  });
+
+  it('round-trips a localized twin path', () => {
+    // Simulate the funnel PR registering /support as localized.
+    LOCALIZED_PATHS.add('/support');
+    try {
+      expect(localeHref('es', '/support')).toBe('/es/support');
+      expect(localeHref('es', '/es/support')).toBe('/es/support');
+      expect(localeHref('en', '/es/support')).toBe('/support');
+    } finally {
+      LOCALIZED_PATHS.delete('/support');
+    }
+  });
+});
+
+describe('localeFromPathname (unchanged, guarded here)', () => {
+  it('detects /es and /es/* as Spanish, everything else English', () => {
+    expect(localeFromPathname('/es')).toBe('es');
+    expect(localeFromPathname('/es/support')).toBe('es');
+    expect(localeFromPathname('/')).toBe('en');
+    expect(localeFromPathname('/esoterica')).toBe('en');
+  });
+});


### PR DESCRIPTION
Part 1 of #2763 (the sitewide toggle). Part 2 (native Spanish `/support` & `/auth/signin`) is a focused follow-up — different size and risk.

## Problem
The EN/ES toggle was gated behind `isHome`, so Spanish-speaking visitors lost all language control once they navigated off `/es`. This is a recurring feedback theme ("Spanish UI only works for the hero text", "no sé inglés", multiple thank-yous).

## Change
Un-gates the toggle so it renders on **every** page, with path-aware targets via a new `localeHref()` helper in `src/lib/i18n.ts`:
- **EN** → the canonical page (any `/es` prefix dropped) so the reader stays put.
- **ES** → the `/es` twin when one exists (`LOCALIZED_PATHS`), else the Spanish homepage `/es` as a front door — no 404 dead-ends. This is the thin-i18n bargain: deep pages rely on the browser's own translate; the control still gives webview/Instagram users (no translate button) a way back to a native page.

`LOCALIZED_PATHS` holds only `/` today; the funnel pages register themselves when their `/es` routes land in part 2. `canonicalPath` guards against mis-stripping non-locale paths like `/esoterica`.

## Tests
8 new unit tests (`tests/unit/i18n-locale-href.test.ts`) covering `canonicalPath`, `localeHref` (EN stay-put, ES twin, ES fallback, round-trip), and the `localeFromPathname` boundary. `npx tsc --noEmit` clean.

## Out of scope
- Native Spanish funnel pages (`/support`, `/auth/signin`, `/beta`) — part 2, separate PR. They need new `/es/**` routes + string dicts + child-form labels and touch auth/donation copy.
- No deep-content localization (by design — see memory `project_i18n_thin_localization`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)