### PR TITLE
feat(pipeline): Spanish edition worker (EN→ES, guarded, popular-first)

### DIFF
--- a/.claude/docs/spanish-translation.md
+++ b/.claude/docs/spanish-translation.md
@@ -1,0 +1,56 @@
+# Spanish editions (corpus translation → ES)
+
+Translating the existing **English** corpus into **Spanish** to open the library to
+~500M Spanish speakers. This is *content* translation (the books), distinct from
+*UI* localization (chrome) — tracked separately in #2763 / #2701. Umbrella: **#2770**.
+
+## Data model
+- Spanish lives on `pages.translation_es` — same shape as `pages.translation`
+  (`{ data, language:'Spanish', model, source, prompt_version, updated_at }`).
+- Book-level counter `books.pages_translated_es` drives popular-first selection
+  and progress (synced by the worker after each book).
+- It is a **pivot from English** (`source:'ai-pivot-en'`): the worker translates
+  `pages.translation.data`, not the original-language OCR. Pro: EN→ES is the
+  best-supported direction, reuses cleaned text, cheap. Con: it's a translation
+  of a translation. For scholarly fidelity, high-value / first-translation works
+  should be (re)translated **original→ES** directly and labelled accordingly.
+
+## Pipeline
+- `scripts/workers/es-translate-worker.mjs` — runs on the Hetzner scheduler
+  (`es-translate`, every 10 min, `--books=4 --max-pages=300`), submitting to
+  Gemini `gemini-3.1-flash-lite` **directly** (no Vercel/Cloudflare edge timeout,
+  the reason ad-hoc route loops failed on large books).
+- **Most-popular-first** (`read_count` desc) so spend tracks reader demand.
+- **Guards** (why a dedicated worker, not a script):
+  - *collapse guard* — a substantial page (>800 EN chars) whose ES body is
+    near-empty (<300 chars) is retried.
+  - *length-sanity band* — ES body must be **0.5–2.0×** the English body; out of
+    band ⇒ retry; still out of band after 3 tries ⇒ **skip** (don't store). This
+    prevents both collapses (header-only output) and runaway loops (10–30×
+    bloat) — both observed when translating without guards.
+- **Cost** ≈ $0.0007/page (flash-lite batch-equiv); full corpus ≈ **$3K** Gemini
+  / ~$1.5K if ever moved to DeepSeek-V4-Flash. Bounded per run; ramps gradually.
+- **Pause:** `system_config._id:'processing_control'` → `paused:true` (worker
+  checks on each run and exits).
+
+## Reader UI
+- `PageEditorClient` shows an **English / Español** toggle when a page has
+  `translation_es`; selecting Español overlays it through the existing
+  `stripEditorialWrappers` + `NotesRenderer` pipeline (PR #2776). No API changes
+  — SSR and the pages get/batch routes already project the full doc.
+- Toggle is hidden where no ES exists and disabled while version-pinned (`?v=`).
+
+## Quality (measured)
+- Pilot + spot checks (French/German/Latin originals): faithful, structure-
+  preserving Spanish even on flash-lite; proper nouns Hispanized, Spanish
+  typography, markdown/tags preserved. ES/EN length ≈ **1.05×** (median).
+- Defects are confined to the failure modes the guards above catch (~0.5%
+  collapse, rare runaway). Native-speaker QA should sample-check + review all
+  flagged high-value works (per the CLAUDE.md quote-integrity rules).
+
+## Open follow-ups (#2770)
+- original→ES tier for high-value / first-translation works (fidelity).
+- chunking for oversized merged/spread pages (>~40K chars) that exceed the
+  output token cap.
+- sitewide language preference + `hreflang`/SEO for ES pages.
+- move bulk to DeepSeek if cost ever matters at corpus scale.

--- a/scripts/workers/es-translate-worker.mjs
+++ b/scripts/workers/es-translate-worker.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Spanish edition worker — pivots the existing English translation
+ * (pages.translation.data) into Spanish (pages.translation_es), most-popular
+ * books first. Runs on the Hetzner scheduler alongside the English
+ * translate-worker; submits to Gemini directly (no Vercel/Cloudflare edge limit).
+ *
+ * Guards (the reason this exists vs. an ad-hoc script — see #2770):
+ *   - collapse guard: a substantial page whose ES body is near-empty is retried
+ *   - length-sanity band: ES body must be 0.5–2.0x the English body, else retry;
+ *     if still out-of-band after retries the page is SKIPPED (not stored), so
+ *     collapses and runaway loops never reach the reader.
+ *
+ * Cost: ~$0.0007/page (flash-lite batch-equiv); full corpus ≈ $3K. Bounded per
+ * run by --limit; respects the processing_control pause flag. Popular-first so
+ * spend tracks reader demand. Pause: system_config._id:'processing_control' paused:true.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/workers/es-translate-worker.mjs [--books=4] [--max-pages=300] [--book=<id>] [--dry-run]
+ */
+import { MongoClient } from 'mongodb';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+const args = process.argv.slice(2);
+const getArg = (n, d) => { const m = args.find(a => a.startsWith(`--${n}=`)); return m ? m.split('=')[1] : d; };
+const BOOK_LIMIT = parseInt(getArg('books', '4'), 10);
+const MAX_PAGES = parseInt(getArg('max-pages', '300'), 10);
+const BOOK_OVERRIDE = getArg('book', null);
+const DRY_RUN = args.includes('--dry-run');
+const CONC = 6;
+const MODEL = 'gemini-3.1-flash-lite';
+const PROMPT_VERSION = 'es-pivot-v1';
+const LO = 0.5, HI = 2.0;          // ES/EN body length sanity band
+const COLLAPSE_EN_FLOOR = 800;     // only collapse-guard substantial pages
+const COLLAPSE_ES_CAP = 300;       // ES body this short on a big page = collapse
+
+const API_KEYS = [
+  process.env.GEMINI_API_KEY,
+  ...Array.from({ length: 9 }, (_, i) => (i + 2 === 4 ? null : process.env[`GEMINI_API_KEY_${i + 2}`])),
+  process.env.GEMINI_API_KEY_TIER3,
+].filter(Boolean);
+if (!API_KEYS.length) { console.error('[ES] No Gemini API keys'); process.exit(1); }
+let keyIdx = 0;
+const nextModel = () => new GoogleGenerativeAI(API_KEYS[keyIdx++ % API_KEYS.length]).getGenerativeModel({
+  model: MODEL,
+  safetySettings: ['HARM_CATEGORY_HARASSMENT', 'HARM_CATEGORY_HATE_SPEECH', 'HARM_CATEGORY_SEXUALLY_EXPLICIT', 'HARM_CATEGORY_DANGEROUS_CONTENT'].map(category => ({ category, threshold: 'BLOCK_NONE' })),
+});
+
+const WRAP = /<(meta|image-desc|vocab|summary|keywords|warning|scan-quality|language|page-type|page-num|columns|script)\b[^>]*>[\s\S]*?<\/\1>/gi;
+const clean = t => String(t || '').replace(WRAP, ' ').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+
+const PROMPT = txt => `You are producing the Spanish edition of a historical primary-source reader. Translate the ENTIRE English text below into faithful, scholarly Spanish.
+RULES: do NOT summarize, drop, or repeat sentences. Preserve all XML-like tags (<meta>, <note>, <header>…), markdown, and numerals; translate readable text inside tags too. Localize names (Iamblichus→Jámblico) and use Spanish typography (« », d. C./a. C.). Output ONLY the full translation, once.
+
+English:
+${txt}
+
+Spanish:`;
+
+// Translate one page with guards. Returns {data} or null if it can't be made sane.
+async function translatePage(eng) {
+  const enLen = clean(eng).length;
+  const sane = es => {
+    const esLen = clean(es).length;
+    if (enLen < 200) return esLen > 0;                              // tiny page: any non-empty output ok
+    if (enLen > COLLAPSE_EN_FLOOR && esLen < COLLAPSE_ES_CAP) return false; // collapse
+    const r = esLen / enLen;
+    return r >= LO && r <= HI;                                      // length-sanity band
+  };
+  let best = null, bestDist = Infinity;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    let text;
+    try { text = (await nextModel().generateContent(PROMPT(eng))).response.text(); }
+    catch (e) { if (/quota|429|RESOURCE_EXHAUSTED/i.test(e.message || '')) await new Promise(r => setTimeout(r, 4000)); continue; }
+    if (sane(text)) {
+      const dist = enLen < 200 ? 0 : Math.abs(clean(text).length / enLen - 1);
+      if (dist < bestDist) { best = text; bestDist = dist; }
+      if (bestDist < 0.3) break;
+    }
+  }
+  return best;
+}
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 4 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  const control = await db.collection('system_config').findOne({ _id: 'processing_control' }).catch(() => null);
+  if (control?.paused) { console.log('[ES] processing_control paused — exiting'); await client.close(); return; }
+
+  // Popular-first: most-read books that still have English pages without a Spanish edition.
+  const match = BOOK_OVERRIDE
+    ? { id: BOOK_OVERRIDE }
+    : { visible: true, pages_translated: { $gt: 0 }, $expr: { $gt: ['$pages_translated', { $ifNull: ['$pages_translated_es', 0] }] } };
+  const books = await db.collection('books')
+    .find(match, { projection: { id: 1, title: 1, display_title: 1, read_count: 1, pages_translated: 1, pages_translated_es: 1 } })
+    .sort({ read_count: -1 }).limit(BOOK_LIMIT).toArray();
+
+  console.log(`[ES] ${books.length} candidate book(s); cap ${MAX_PAGES} pages this run; model ${MODEL}; keys ${API_KEYS.length}`);
+  let pagesDone = 0, skipped = 0;
+
+  for (const b of books) {
+    if (pagesDone >= MAX_PAGES) break;
+    const pages = await db.collection('pages').find(
+      { book_id: b.id, 'translation.data': { $type: 'string', $ne: '' },
+        $or: [{ 'translation_es.data': { $exists: false } }, { 'translation_es.data': '' }, { 'translation_es.data': null }] },
+      { projection: { _id: 1, page_number: 1, 'translation.data': 1 } }
+    ).limit(MAX_PAGES - pagesDone).toArray();
+    if (!pages.length) {
+      // Already fully translated (e.g. by the pilot) but missing the book-level
+      // counter — stamp it so this book drops out of future selection.
+      const esCount = await db.collection('pages').countDocuments({ book_id: b.id, 'translation_es.data': { $type: 'string', $ne: '' } });
+      if (!DRY_RUN) await db.collection('books').updateOne({ id: b.id }, { $set: { pages_translated_es: esCount } });
+      continue;
+    }
+    console.log(`[ES] ${(b.display_title || b.title || b.id).slice(0, 48)} — ${pages.length} pages (reads=${b.read_count || 0})`);
+    if (DRY_RUN) { pagesDone += pages.length; continue; }
+
+    let i = 0;
+    const worker = async () => {
+      while (i < pages.length) {
+        const p = pages[i++];
+        const es = await translatePage(p.translation.data);
+        if (!es) { skipped++; console.log(`  [skip] ${b.id} p${p.page_number}: no sane translation after retries`); continue; }
+        await db.collection('pages').updateOne({ _id: p._id }, { $set: { translation_es: {
+          data: es, language: 'Spanish', model: MODEL, source: 'ai-pivot-en', prompt_version: PROMPT_VERSION, updated_at: new Date(),
+        } } });
+        pagesDone++;
+      }
+    };
+    await Promise.all(Array.from({ length: CONC }, worker));
+
+    // Sync the book-level Spanish counter (drives popular-first selection + progress).
+    const esCount = await db.collection('pages').countDocuments({ book_id: b.id, 'translation_es.data': { $type: 'string', $ne: '' } });
+    await db.collection('books').updateOne({ id: b.id }, { $set: { pages_translated_es: esCount, updated_at: new Date() } });
+  }
+
+  console.log(`[ES] done — ${pagesDone} pages translated, ${skipped} skipped (out-of-band)`);
+  await client.close();
+}
+
+main().catch(e => { console.error('[ES] fatal', e); process.exit(1); });

--- a/scripts/workers/scheduler.mjs
+++ b/scripts/workers/scheduler.mjs
@@ -129,6 +129,19 @@ const WORKERS = [
     healthMin: 'degraded',
     log: '/var/log/sourcelibrary/translate-complete.log',
   },
+  {
+    // Spanish edition: pivots existing English → Spanish (translation_es), most
+    // popular books first. Conservative cap so spend ramps gradually + visibly
+    // (gemini_usage). Pause via processing_control.paused. See #2770.
+    name: 'es-translate',
+    cmd: 'node scripts/workers/es-translate-worker.mjs --books=4 --max-pages=300',
+    lock: '/tmp/sl-es-translate.lock',
+    connections: 6,
+    tier: 2,
+    interval: 600,      // every 10 min
+    healthMin: 'healthy',
+    log: '/var/log/sourcelibrary/es-translate.log',
+  },
 
   // Tier 3: Batch collection — lightweight, collects Gemini results
   {


### PR DESCRIPTION
## What
A dedicated Hetzner worker that pivots the existing **English** corpus into **Spanish** (`pages.translation_es`), most-read books first. Pairs with the reader EN/ES toggle in #2776. Part of #2770.

## Why a new worker (not retrofitting `translate-worker`)
One concern, **zero risk** to the load-bearing English translation path. The ad-hoc laptop loop I used for the pilot couldn't cover even the top-25 popular books (dies at ~2.6K pages/run) and produced real defects (collapses + runaway loops) — both fixed here by guards.

## How it works
- Translates `pages.translation.data` → `pages.translation_es` via Gemini `gemini-3.1-flash-lite`, submitted **directly from Hetzner** (no Vercel/Cloudflare edge timeout — the reason route-based loops failed on >300pp books).
- **Most-popular-first** (`read_count` desc); `pages_translated_es` counter drives selection + progress.
- **Guards** (the point of the worker):
  - *collapse guard* — retry near-empty ES on substantial pages.
  - *length-sanity band* — ES body must be **0.5–2.0×** English; out of band ⇒ retry ⇒ skip (never stores collapses or 10–30× runaway loops).
- Scheduler entry `es-translate` (every 10 min, `--books=4 --max-pages=300`) so spend ramps **gradually + visibly** (`gemini_usage`). Respects `processing_control.paused`.

## Cost
~$0.0007/page (flash-lite batch-equiv); full corpus ≈ **$3K** (measured in a 141-page pilot; ~$1.5K if ever moved to DeepSeek). Bounded per run.

## Scope
- `scripts/workers/es-translate-worker.mjs` (new), `scripts/workers/scheduler.mjs` (+1 entry), `.claude/docs/spanish-translation.md` (new).

## Out of scope (#2770)
- original→ES tier for high-value/first-translation works (fidelity).
- chunking for oversized merged/spread pages (>~40K chars).
- sitewide language preference + `hreflang`/SEO.

## Testing / rollout notes
- `node --check` clean on both scripts; pre-commit `check-imports` passed.
- **Pipeline is currently `processing_control.paused: true`** — the worker (like all workers) will no-op until unpaused. Scripts go live on Hetzner via the ~5-min auto-pull (no Vercel deploy needed). Watch `gemini_usage` + `es-translate.log` on first runs; pause via `processing_control` if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)