### PR TITLE
fix(reader): translation panel label follows EN/ES toggle

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -444,6 +444,11 @@ export default function TranslationEditor({
   const hasRashiScript = !!bookMetadata.metadata?.scriptType?.toLowerCase().includes('rashi');
   const [ocrText, setOcrText] = useState(page.ocr?.data || '');
   const [translationText, setTranslationText] = useState(page.translation?.data || '');
+  // Label for the translation panel/toggle. Reflects the language actually being
+  // shown (the reader's EN/ES toggle overlays page.translation with translation_es
+  // and sets language:'Spanish'), so the UI never says "English" over Spanish text.
+  const translationLang = (page.translation?.language || '').toLowerCase();
+  const translationLangLabel = (translationLang.startsWith('es') || translationLang.includes('span')) ? 'Español' : 'English';
   const [summaryText, setSummaryText] = useState(page.summary?.data || '');
   // Save state for the inline page editor. The previous design auto-saved on
   // blur with no UI feedback — editors (Paul Dijstelberge, May 2026) reported
@@ -1157,7 +1162,7 @@ export default function TranslationEditor({
                   aria-pressed={showTranslationPanel}
                 >
                   <Languages className="w-4 h-4" aria-hidden="true" />
-                  <span className="hidden sm:inline">English</span>
+                  <span className="hidden sm:inline">{translationLangLabel}</span>
                 </button>
               )}
             </div>
@@ -1653,7 +1658,7 @@ export default function TranslationEditor({
                   <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                        {translationText ? 'English' : 'Step 2: Translate'}
+                        {translationText ? translationLangLabel : 'Step 2: Translate'}
                       </span>
                       {translationText && (
                         <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--accent-sage)' }}>
@@ -2034,7 +2039,7 @@ export default function TranslationEditor({
               title="Toggle translation panel"
             >
               <Languages className="w-4 h-4" />
-              <span className="hidden sm:inline">English</span>
+              <span className="hidden sm:inline">{translationLangLabel}</span>
             </button>
           </div>
 


### PR DESCRIPTION
## Problem
Selecting **Read in: Español** correctly switches the content to Spanish, but the translation panel header and toggle buttons stayed hardcoded **"English"** — so Spanish text rendered under an "ENGLISH" label (reported with a screenshot). Content switching was already correct; this is label-only.

## Fix
Derive a `translationLangLabel` from `page.translation?.language` (the reader's EN/ES toggle overlays `translation_es` and sets `language:'Spanish'` when ES is active) and use it for all three label sites in `TranslationEditor.tsx`:
- the panel header (`ENGLISH ▾` → `ESPAÑOL`)
- the desktop translation toggle button
- the mobile translation toggle button

→ "Español" over Spanish, "English" otherwise.

## Scope
- `src/components/pipeline/TranslationEditor.tsx` only.

## Testing
- Verified content-switch works on prod before the fix (Spanish renders, model label flips to 3.1-flash-lite); this PR fixes the stale text labels. Re-verify on the preview: load a page with ES (e.g. *Course on the Book of Thoth*), toggle Español → header + buttons read "Español".

Follow-up to #2776 / part of #2770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)