### PR TITLE
fix(feedback): reading-history records global books + search fail-open/hidden-artwork leaks

### DIFF
--- a/src/app/api/reading-history/route.ts
+++ b/src/app/api/reading-history/route.ts
@@ -38,6 +38,9 @@ export async function POST(request: NextRequest) {
       const db = await getDb();
 
       // Tenant from proxy header if available; otherwise look up the book.
+      // Global (non-tenant) books legitimately have no tenantId — we still
+      // record their history with tenantId: null. Only bail when the book
+      // itself can't be resolved (unknown id/slug).
       let tenantId = getTenantContextFromRequest(request).id;
       let resolvedBookId = book_id;
       if (!tenantId) {
@@ -45,10 +48,10 @@ export async function POST(request: NextRequest) {
           { $or: [{ id: book_id }, { slug: book_id }] },
           { projection: { id: 1, tenantId: 1 } }
         );
-        tenantId = (book?.tenantId as string) || null;
-        if (book?.id) resolvedBookId = book.id as string;
+        if (!book) return; // unknown book — silent fail
+        tenantId = (book.tenantId as string) || null;
+        if (book.id) resolvedBookId = book.id as string;
       }
-      if (!tenantId) return; // unknown book/tenant — silent fail
 
       const collection = db.collection('reading_history');
       const cutoff = new Date(now.getTime() - SESSION_GAP_MS);

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -308,9 +308,11 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
               .project({ id: 1 })
               .toArray();
             const allowedBookIds = filteredBooks.map(b => b.id);
-            if (allowedBookIds.length > 0) {
-              pageFilter.book_id = { $in: allowedBookIds };
-            }
+            // Always apply the constraint we computed. If the book-level filter
+            // (e.g. a language that matches no books) yields an empty set, the
+            // page search must return nothing — NOT fall through to an
+            // unconstrained whole-corpus search (fail-open bug).
+            pageFilter.book_id = { $in: allowedBookIds };
           }
 
           const pageLimit = (bookId || pagesOnly) ? limit : MAX_PAGE_RESULTS;

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -347,22 +347,29 @@ export async function GET(request: NextRequest) {
     const artworksAboveFloor = [...lexicalArtworkResult, ...semanticArtworksAboveFloor]
       .slice(0, ARTWORK_RESULT_LIMIT);
     // Enrich artworks with slugs from MongoDB (needed for /artwork/[slug] links)
+    // AND filter out non-visible artworks. The artwork_embeddings table has no
+    // visibility column, so hidden/invisible artworks can surface from the
+    // vector lane and 404 on click. Re-check visible:true here and drop any
+    // artwork the query doesn't return.
+    let visibleArtworks = artworksAboveFloor;
     if (artworksAboveFloor.length > 0) {
       try {
         const artworkIds = artworksAboveFloor.map(a => a.book_id);
         const artworkDocs = await db.collection('books').find(
-          { id: { $in: artworkIds } },
+          { id: { $in: artworkIds }, visible: true },
           { projection: { id: 1, slug: 1 } }
         ).maxTimeMS(2000).toArray();
         const slugMap = new Map(artworkDocs.map(d => [d.id, d.slug]));
         for (const a of artworksAboveFloor) {
           (a as any).slug = slugMap.get(a.book_id) || null;
         }
-      } catch { /* non-fatal */ }
+        // Keep only artworks confirmed visible (present in slugMap).
+        visibleArtworks = artworksAboveFloor.filter(a => slugMap.has(a.book_id));
+      } catch { /* non-fatal — fall through with unfiltered list */ }
     }
     let filteredArtworks = {
-      results: artworksAboveFloor,
-      total: artworksAboveFloor.length,
+      results: visibleArtworks,
+      total: visibleArtworks.length,
     };
 
     // Defense-in-depth tenant filter. When a tenant header is present,


### PR DESCRIPTION
Fixes three confirmed bugs surfaced by footer feedback. Each is small and independently verified against current code + data.

## Changes

### 1. Reading history records nothing for global books — #2759 (P0)
`POST /api/reading-history` bailed with `if (!tenantId) return`. Only tenant-promoted books (bph, etc.) carry a `tenantId`, so **every normal global book recorded nothing** — confirmed by founder QA ("not all of the books I've read are in my history"). The GET side already matches on `user_id` only (no tenant), so global rows just needed to be written.
**Fix:** bail only when the book can't be resolved; store global history with `tenantId: null`.

### 2. Search language filter fails OPEN — #2760 (P0)
The page-content lane left `pageFilter.book_id` unset when the book-level filter (e.g. a language matching zero books) produced an empty allow-list, falling through to an **unconstrained whole-corpus search**. Reported by MCP/LLM users ("languages / exclude_languages appear silently ignored").
**Fix:** always apply the computed `book_id: { $in: allowedBookIds }` — empty set ⇒ empty results.

### 3. Search surfaces hidden artworks → 404 — #2760 (P0)
`search/unified` enriched artwork slugs by `id` without re-checking visibility. `artwork_embeddings` has no visibility column, so hidden/invisible artworks surfaced and 404'd on click (the "toltec" report).
**Fix:** add `visible: true` to the enrichment query and drop artworks it doesn't return.

## Scope
Out of scope (separate issues): MCP content-filter over-eagerness (#2760 remainder), i18n (#2763), P2 batch (#2785). This PR is the three confirmed correctness bugs only.

## Testing
Root-caused each against live code + data. `pages.book_id` is a string (verified). Standalone tsc on the changed files shows only pre-existing ES5-target noise (project targets es2015+); no new type errors on edited lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)