### PR TITLE
fix(search): AI suggestion chips re-run the search in every view (#2789)

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -718,6 +718,20 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewMode, indexType, language, category, dateFrom, dateTo, hasDoi, hasTranslation, firstTranslation, library, sortBy, offset, performSearch, updateUrl]);
 
+  // Clicking an AI suggestion chip = search FOR that term. Must change the query,
+  // re-run the result search, update the URL, and refresh the narration — in every
+  // view. The unified ("All") view previously only re-streamed narration via
+  // startAiStream(term, true) and never ran performSearch, so the results never
+  // changed (issue #2789). Centralized here so the two chip render sites can't drift.
+  const runSearchForTerm = useCallback((term: string) => {
+    setQuery(term);
+    setOffset(0);
+    performSearch(term, viewMode, 0);
+    updateUrl(term, viewMode, 0);
+    startAiStream(term, true); // append=true keeps the narration trail
+    aiTriggeredForQuery.current = term; // guard the deps-effect from re-streaming a fresh one
+  }, [viewMode, performSearch, updateUrl, startAiStream]);
+
   // Browse mode: fetch books when no query
   const isBrowseMode = !query || query.length < 2;
   const prefetchUsed = useRef(false);
@@ -1358,7 +1372,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                 {aiTerms.map(term => (
                   <button
                     key={term}
-                    onClick={() => { setQuery(term); setOffset(0); performSearch(term, viewMode, 0); updateUrl(term, viewMode, 0); }}
+                    onClick={() => runSearchForTerm(term)}
                     className="px-2.5 py-1 bg-white/60 text-secondary text-xs rounded-full hover:bg-accent-rust/10 hover:text-accent-rust transition-colors"
                   >
                     {term}
@@ -1450,7 +1464,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                   {aiTerms.map(term => (
                     <button
                       key={term}
-                      onClick={() => { startAiStream(term, true); }}
+                      onClick={() => runSearchForTerm(term)}
                       className="px-2.5 py-1 bg-white/60 text-secondary text-xs rounded-full hover:bg-accent-rust/10 hover:text-accent-rust transition-colors"
                     >
                       {term}


### PR DESCRIPTION
Fixes #2789.

## Problem

On `/search`, clicking an AI suggestion chip (e.g. searching "shwep" → *Papyrus of Ani / funerary papyri*) did nothing in the **unified "All" view** — the default most users see. That chip's onClick was `startAiStream(term, true)`, which only appended another narration block; it never ran `performSearch`, set the query, or updated the URL, so the results didn't change. The Books/Index/Images views had a separate, correct handler.

## Fix

One shared `runSearchForTerm(term)` helper, called by both chip render sites:
- sets the query, resets offset, runs `performSearch`, updates the URL
- refreshes the AI narration (`startAiStream(term, true)`, keeping the narration trail)
- pins `aiTriggeredForQuery` so the deps-effect doesn't double-stream a fresh narration

Centralizing it means the two render sites can't drift apart again (the root cause here).

## Test plan

- Search a term that yields chips (e.g. "shwep"), in the **All** view click a chip → query box, results, URL, and narration all update to that term.
- Repeat in **Books / Index / Images** views → same behavior (unchanged from before).

## Note

Local `tsc --noEmit` was impractically slow on a fresh worktree (cold cache, full 5k-file check). The change is a `useCallback` over already-typed in-scope functions + two onClick swaps (no new type surface); relying on the `test` CI check for authoritative type validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)