### PR TITLE
feat(search): capture known collection/page names (e.g. "shwep" → SHWEP) (#2790)

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { toast } from 'sonner';
 import Link from 'next/link';
 import Image from 'next/image';
@@ -26,6 +26,7 @@ import {
   type Collection,
 } from '@/lib/api-client';
 import { tenantBookUrl } from '@/lib/slugify';
+import { matchKnownEntity } from '@/lib/known-entities';
 import HighlightedText from '@/components/search/HighlightedText';
 import { SEARCH_TYPE_STYLES, type SearchIndexType } from '@/lib/style-constants';
 import { BookLoader } from '@/components/ui/BookLoader';
@@ -732,6 +733,16 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
     aiTriggeredForQuery.current = term; // guard the deps-effect from re-streaming a fresh one
   }, [viewMode, performSearch, updateUrl, startAiStream]);
 
+  // Known-entity capture (#2790): a query that names a place in the library (a
+  // reading room like "shwep", a collection, a library partner) gets a direct
+  // entry card above results instead of being left to the LLM's guess. Suppressed
+  // in embed/tenant mode — these hrefs (/shwep, /collections, /libraries) point
+  // off-tenant and would leak past the subdomain lockdown.
+  const knownEntity = useMemo(
+    () => (embed ? null : matchKnownEntity(query, { collections: collectionsList })),
+    [embed, query, collectionsList]
+  );
+
   // Browse mode: fetch books when no query
   const isBrowseMode = !query || query.length < 2;
   const prefetchUsed = useRef(false);
@@ -1349,6 +1360,26 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
 
             <Pagination total={browseTotal} offset={offset} setOffset={setOffset} loading={browseLoading} pageSize={resultsPerPage} />
           </div>
+        )}
+
+        {/* Known-entity capture (#2790): direct entry for a query that names a
+            place in the library (reading room / collection / library partner). */}
+        {knownEntity && query.length >= 2 && (
+          <Link
+            href={knownEntity.href}
+            className="group flex items-center gap-3 mb-6 px-4 py-3 bg-warm rounded-lg border border-border-light hover:border-accent-rust/40 transition-colors"
+          >
+            <span className="text-2xl shrink-0" aria-hidden>{knownEntity.icon || '📚'}</span>
+            <div className="min-w-0 flex-1">
+              <div className="text-xs uppercase tracking-wide text-muted">
+                {knownEntity.kind === 'reading-room' ? 'Reading room' : knownEntity.kind === 'library' ? 'Library partner' : 'Collection'}
+              </div>
+              <div className="font-serif font-medium text-primary group-hover:text-accent-rust transition-colors">
+                {knownEntity.title} <span aria-hidden>→</span>
+              </div>
+              <p className="text-sm text-muted line-clamp-2">{knownEntity.description}</p>
+            </div>
+          </Link>
         )}
 
         {/* Loading */}

--- a/src/lib/known-entities.ts
+++ b/src/lib/known-entities.ts
@@ -1,0 +1,93 @@
+import { LIBRARY_PARTNERS } from '@/lib/library-partners';
+import type { Collection } from '@/lib/api-client/types/collections';
+
+/**
+ * Known-entity search capture (issue #2790).
+ *
+ * Some queries name a *place in the library*, not a topic — "shwep" is the SHWEP
+ * reading room, "internet archive" is a library partner, "alchemy" may be a
+ * collection. Without this, the query is handed straight to the LLM, which guesses
+ * (e.g. "shwep" → ancient-Egyptian "shwep-t"). matchKnownEntity() does a cheap,
+ * exact, case-insensitive lookup against three registries and returns a direct
+ * entry so the results page can surface a "go here" card above the AI narration.
+ *
+ * Matching is deliberately STRICT — only an exact normalized or slugified match
+ * qualifies — so generic words ("history", "the") never resolve to a collection.
+ */
+export type KnownEntityKind = 'reading-room' | 'collection' | 'library';
+
+export interface KnownEntity {
+  title: string;
+  description: string;
+  href: string;
+  kind: KnownEntityKind;
+  /** emoji or short glyph for the card; optional */
+  icon?: string;
+}
+
+/** Bespoke pages that aren't collections or library partners (hand-maintained). */
+const BESPOKE_ENTITIES: Array<KnownEntity & { aliases: string[] }> = [
+  {
+    aliases: [
+      'shwep',
+      'secret history of western esotericism',
+      'secret history of western esotericism podcast',
+    ],
+    title: 'SHWEP — Secret History of Western Esotericism',
+    description:
+      'Episode-by-episode reading lists cross-referencing the Secret History of Western Esotericism Podcast with the primary sources we hold.',
+    href: '/shwep',
+    kind: 'reading-room',
+    icon: '🎙️',
+  },
+];
+
+const norm = (s: string) => s.toLowerCase().trim().replace(/\s+/g, ' ');
+const slugify = (s: string) =>
+  norm(s).replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+export interface MatchOptions {
+  /** Live collections list (from /api/collections) to match against. */
+  collections?: Pick<Collection, 'slug' | 'name' | 'description' | 'subtitle'>[];
+}
+
+/**
+ * Resolve a query to a known library destination, or null. Order: bespoke pages
+ * → collections → library partners. Exact normalized/slug match only.
+ */
+export function matchKnownEntity(query: string, opts: MatchOptions = {}): KnownEntity | null {
+  const q = norm(query);
+  if (q.length < 2) return null;
+  const qs = slugify(query);
+
+  for (const e of BESPOKE_ENTITIES) {
+    if (e.aliases.some((a) => norm(a) === q || slugify(a) === qs)) {
+      const { aliases: _aliases, ...entity } = e;
+      return entity;
+    }
+  }
+
+  for (const c of opts.collections || []) {
+    if (slugify(c.slug || '') === qs || norm(c.name || '') === q || slugify(c.name || '') === qs) {
+      return {
+        title: c.name,
+        description: c.subtitle || c.description || `Browse the ${c.name} collection.`,
+        href: `/collections/${c.slug}`,
+        kind: 'collection',
+      };
+    }
+  }
+
+  for (const p of Object.values(LIBRARY_PARTNERS)) {
+    if (slugify(p.slug) === qs || norm(p.name) === q || norm(p.shortName) === q || slugify(p.name) === qs) {
+      return {
+        title: p.name,
+        description: p.description,
+        href: `/libraries/${p.slug}`,
+        kind: 'library',
+      };
+    }
+  }
+
+  return null;
+}

--- a/tests/unit/known-entities.test.ts
+++ b/tests/unit/known-entities.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { matchKnownEntity } from '@/lib/known-entities';
+
+// Known-entity capture (#2790): a query naming a place in the library resolves
+// to a direct destination; generic words must NOT resolve (strict match only).
+
+describe('matchKnownEntity', () => {
+  it('resolves the SHWEP reading room by short alias', () => {
+    const m = matchKnownEntity('shwep');
+    expect(m?.href).toBe('/shwep');
+    expect(m?.kind).toBe('reading-room');
+  });
+
+  it('is case-insensitive and tolerant of spacing', () => {
+    expect(matchKnownEntity('  SHWEP ')?.href).toBe('/shwep');
+    expect(matchKnownEntity('Secret History of Western Esotericism')?.href).toBe('/shwep');
+  });
+
+  it('resolves a collection by slug or name', () => {
+    const collections = [
+      { slug: 'alchemy', name: 'Alchemy', description: 'The art', subtitle: 'Transmutation' },
+    ];
+    expect(matchKnownEntity('alchemy', { collections })?.href).toBe('/collections/alchemy');
+    expect(matchKnownEntity('Alchemy', { collections })?.kind).toBe('collection');
+  });
+
+  it('resolves a library partner', () => {
+    const m = matchKnownEntity('internet archive');
+    expect(m?.href).toBe('/libraries/internet-archive');
+    expect(m?.kind).toBe('library');
+  });
+
+  it('does NOT resolve generic words or partial matches', () => {
+    expect(matchKnownEntity('history')).toBeNull();
+    expect(matchKnownEntity('the')).toBeNull();
+    expect(matchKnownEntity('mercury')).toBeNull();
+    // a substring of an alias must not match (strict, not contains)
+    expect(matchKnownEntity('secret history')).toBeNull();
+  });
+
+  it('returns null for empty / too-short queries', () => {
+    expect(matchKnownEntity('')).toBeNull();
+    expect(matchKnownEntity('a')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #2790.

## Problem

Searching **"shwep"** handed the raw token to the LLM, which guessed ancient-Egyptian "shwep-t" — it had no idea `shwep` is the **SHWEP reading room** (`/shwep`). Same gap for collection names and library partners.

## What

`matchKnownEntity(query)` resolves a query that *names a place in the library* to a direct destination, and the `/search` results page surfaces a "go here" card above the AI narration (the LLM interpretation still renders below as fallback).

Three registries, checked in order:
1. **Bespoke pages** — hand-maintained in `src/lib/known-entities.ts` (SHWEP today; extensible).
2. **Collections** — the live `/api/collections` list already loaded by the page → `/collections/<slug>`.
3. **Library partners** — `LIBRARY_PARTNERS` → `/libraries/<slug>`.

## Strictness

Match is **exact** (normalized + slugified, case-insensitive) — generic words never resolve. Unit-tested: `shwep`/`Secret History of Western Esotericism`/`internet archive`/a collection name all resolve; `history`/`the`/`mercury`/`secret history` (partial) → `null`.

## Tenant safety

The card is suppressed when `embed` is true — `/shwep`, `/collections/*`, `/libraries/*` point off-tenant and would breach the subdomain lockdown.

## Test plan

- `npx vitest run tests/unit/known-entities.test.ts` → 6 pass.
- Live: search "shwep" → card linking to the SHWEP reading room appears above results; search a collection name → card to that collection; search a topic word → no card (LLM narration as before).

## Note

Local full `tsc` is impractically slow on a fresh worktree (cold cache); relying on the `test` CI check for authoritative type validation. New code is a pure module + a memoized call + one card render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)