### PR TITLE
feat(gallery): admin can re-tag image type (ex-libris mislabeled as emblem)

### DIFF
--- a/src/app/api/gallery/image/[id]/route.ts
+++ b/src/app/api/gallery/image/[id]/route.ts
@@ -438,6 +438,18 @@ export async function PATCH(
       updateFields[`detected_images.${detectionIndex}.gallery_quality`] = Math.max(0, Math.min(1, body.galleryQuality));
     }
 
+    // Re-tag the image type (e.g. an ex-libris bookplate auto-classified as
+    // "emblem"). Validate against the known type vocabulary; ex-libris and
+    // bookplates are provenance, not the book's own illustrations.
+    const VALID_IMAGE_TYPES = new Set([
+      'woodcut', 'diagram', 'chart', 'illustration', 'symbol', 'table', 'map',
+      'decorative', 'emblem', 'engraving', 'portrait', 'frontispiece',
+      'musical_score', 'exlibris', 'bookplate', 'unknown',
+    ]);
+    if (typeof body.type === 'string' && VALID_IMAGE_TYPES.has(body.type)) {
+      updateFields[`detected_images.${detectionIndex}.type`] = body.type;
+    }
+
     if (typeof body.featured === 'boolean') {
       updateFields[`detected_images.${detectionIndex}.featured`] = body.featured;
     }
@@ -592,6 +604,7 @@ export async function PATCH(
       if (typeof body.galleryQuality === 'number') {
         galleryUpdate.gallery_quality = Math.max(0, Math.min(1, body.galleryQuality));
       }
+      if (typeof body.type === 'string' && VALID_IMAGE_TYPES.has(body.type)) galleryUpdate.type = body.type;
       if (typeof body.featured === 'boolean') galleryUpdate.featured = body.featured;
       if (typeof body.museumDescription === 'string') galleryUpdate.museum_description = body.museumDescription;
       if (typeof body.description === 'string') galleryUpdate.description = body.description;

--- a/src/app/gallery/image/[id]/page.tsx
+++ b/src/app/gallery/image/[id]/page.tsx
@@ -410,6 +410,22 @@ export default function ImageDetailPage({
     }
   };
 
+  const saveType = async (newType: string) => {
+    if (!data || newType === data.type) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await gallery.update(data.id, { type: newType });
+      prefetchCache.delete(data.id);
+      setData({ ...data, type: newType });
+    } catch (e) {
+      console.error('Failed to save type:', e);
+      setError(e instanceof Error ? `Save failed: ${e.message}` : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const saveMuseumDescription = async () => {
     if (!data) return;
     setSaving(true);
@@ -1135,6 +1151,25 @@ export default function ImageDetailPage({
                       </div>
                     )}
                     {data.galleryRationale && <p className="text-xs text-stone-500 mt-2 italic">{data.galleryRationale}</p>}
+                  </div>
+
+                  {/* Image Type — re-tag a mis-classified image (e.g. an
+                      ex-libris bookplate auto-labelled "emblem"). */}
+                  <div className="bg-stone-800 rounded-lg p-5">
+                    <div className="flex items-center justify-between">
+                      <h3 className="text-base font-medium text-stone-300">Image Type</h3>
+                      <select
+                        value={data.type || 'unknown'}
+                        disabled={saving}
+                        onChange={(e) => saveType(e.target.value)}
+                        className="bg-stone-700 text-stone-200 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus-visible:ring-accent-rust disabled:opacity-50 capitalize"
+                      >
+                        {['woodcut', 'diagram', 'chart', 'illustration', 'symbol', 'table', 'map', 'decorative', 'emblem', 'engraving', 'portrait', 'frontispiece', 'musical_score', 'exlibris', 'bookplate', 'unknown'].map((t) => (
+                          <option key={t} value={t}>{t}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <p className="text-xs text-stone-500 mt-2">Ex-libris and bookplates are provenance marks, not the book&apos;s own illustrations.</p>
                   </div>
 
                   {/* Bounding Box Editor */}


### PR DESCRIPTION
Fixes the ex-libris re-tag item from #2785.

## Problem
Ownership bookplates (ex-libris) were auto-classified as `emblem`, and there was no way to correct it. The `PATCH /api/gallery/image/[id]` handler silently ignored `type` (even though the API client type already declared `type?: string`), and the gallery image editor rendered the type as a read-only badge. Reported via footer feedback: "Many exlibris marked as emblems. And I can't save low gallery quality."

## Changes
- **Server** (`api/gallery/image/[id]`): accept `body.type`, validated against the known image-type vocabulary, and write it to both `pages.detected_images[].type` (source of truth) and the materialized `gallery_images` row.
- **UI** (`gallery/image/[id]`): add an admin "Image Type" selector that PATCHes the new value (mirrors the existing Gallery Quality control).

## Not a bug (clarified, not changed)
The companion "can't save low gallery quality" was investigated: low quality **does** persist — the row is intentionally hidden below the 0.5 materialization threshold and is recoverable by raising quality back. This is documented inline in the route and is correct behavior, so no change.

## Out of scope (remain in #2785)
Cover-change refresh and the low-res-image audit need the app running to verify; left for a focused follow-up. The download sign-in UX item in #2785 is already implemented (toast + Sign in action in `DownloadButton.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)