### PR TITLE
feat(ft): durable evidence reuse — read-before-verify (#2780)

### DIFF
--- a/.claude/docs/first-translation-census-methodology.md
+++ b/.claude/docs/first-translation-census-methodology.md
@@ -37,6 +37,39 @@ verified. Everything else rests on the weak legacy `translation_verification.dis
 
 ---
 
+## 1b. The durability principle — evidence outlives the approach
+The verification *approach* will keep changing (it already went heuristic →
+Gemini → Claude → whatever's next). The **evidence** a run leaves behind must
+not. So separate the two:
+
+- **Evidence = durable, approach-agnostic facts.** "On date D, approach A ran
+  queries Q against sources S and found / didn't find prior P (with URL)." True
+  forever, regardless of who produced it or who reads it. Stored append-only in
+  `first_translation_attempts`, tagged with `method` (the approach) so a future
+  instrument can tell whose evidence it is.
+- **Verdict = a disposable interpretation** derived from the accumulated pile.
+  Any new approach recomputes the verdict over all prior evidence; it never
+  resets the pile.
+
+Three consequences every approach must honor:
+1. **Read before you spend.** Before verifying a book, load its prior attempts
+   (`loadPriorEvidence` / `summarizePriorEvidence` in `prior-evidence.ts`):
+   short-circuit on an already-found, URL-backed prior; skip queries/sources
+   already covered; treat absence from N *independent* approaches as stronger
+   than one pass.
+2. **Land findings in the durable registry.** A found prior is the most reusable
+   artifact in the system — write it to `translation_catalogs` (Sink C) so other
+   approaches *and* other features (work-identity census #2567) inherit it
+   instead of re-discovering it.
+3. **Derive the verdict from the pile, not from the run.** Swapping approaches
+   should recompute, never overwrite. `strongestAttempt` + the derived rule are
+   the start; the goal is verdict = f(accumulated evidence + independence).
+
+The payoff: when the approach changes again, the next instrument inherits every
+attempt ever logged as a head start. Years of search evidence keep paying off
+instead of evaporating — the antidote to the history's "every approach starts
+over" waste.
+
 ## 2. Why a tiered census, not a single pass
 
 Two hard-won constraints shape the design:

--- a/src/lib/first-translation/prior-evidence.ts
+++ b/src/lib/first-translation/prior-evidence.ts
@@ -1,0 +1,106 @@
+/**
+ * Durable, approach-agnostic evidence reuse (issue #2564 / #2780).
+ *
+ * The verification *approach* keeps changing (heuristic → Gemini → Claude → …),
+ * but the evidence each run leaves in `first_translation_attempts` is a set of
+ * atemporal facts: "on date D, approach A ran queries Q against sources S and
+ * found / didn't find prior P". Those facts stay true regardless of who produced
+ * them or who reads them later.
+ *
+ * This module lets ANY future approach READ that accumulated pile before it
+ * spends — so absence accumulates monotonically (the systematic-review model)
+ * instead of every run starting cold. It is pure over an injected attempts array
+ * (mirrors resolve.ts's injected-tier pattern) so it's unit-testable without a DB;
+ * `loadPriorEvidence` is the thin Mongo fetch wrapper.
+ *
+ * It writes nothing. The verdict is still produced by the resolver/derive layer;
+ * this only surfaces what's already known so the resolver can short-circuit,
+ * skip already-covered ground, and weight absence by cross-approach independence.
+ */
+
+import type { Db } from 'mongodb';
+import {
+  ATTEMPTS_COLLECTION,
+  strongestAttempt,
+  type FirstTranslationAttempt,
+  type PriorTranslation,
+} from './attempt-log';
+
+/** What the accumulated evidence pile says about a book, before any new work. */
+export interface PriorEvidenceSummary {
+  /** Total prior attempts on record (any approach). */
+  attemptCount: number;
+  /** A trustworthy prior was already found (presence is decisive, checkable). */
+  priorFound: boolean;
+  /** The strongest found prior with a real URL, if any — ready to reuse. */
+  foundPrior: PriorTranslation | null;
+  /** Union of every source any approach has already consulted (don't re-run). */
+  searchedSources: string[];
+  /** Union of every query already issued (don't re-run verbatim). */
+  searchedQueries: string[];
+  /**
+   * Distinct approaches (methods) that independently returned "none". Absence
+   * from N *independent* approaches is far stronger than N correlated misses —
+   * this is the number that should raise an absence claim's evidence_strength.
+   */
+  independentAbsenceMethods: number;
+  /**
+   * What a new approach should do given the pile:
+   *  - 'reuse_prior'      a trustworthy prior already exists → don't re-search; demote.
+   *  - 'absence_strong'   ≥2 independent approaches found nothing → a fresh pass adds little.
+   *  - 'absence_weak'     some absence evidence, but not yet independent/bounded.
+   *  - 'unverified'       nothing on record → full verification warranted.
+   */
+  recommendation: 'reuse_prior' | 'absence_strong' | 'absence_weak' | 'unverified';
+}
+
+const hasUrl = (p?: PriorTranslation): boolean => !!p?.source_url && /^https?:\/\//.test(p.source_url);
+
+/** Pure: summarize what the accumulated attempts already establish. */
+export function summarizePriorEvidence(
+  attempts: FirstTranslationAttempt[],
+): PriorEvidenceSummary {
+  const searchedSources = [...new Set(attempts.flatMap((a) => a.sources_checked ?? []).filter(Boolean))];
+  const searchedQueries = [...new Set(attempts.flatMap((a) => a.queries ?? []).filter(Boolean))];
+
+  // A reusable found-prior: the strongest attempt that actually found one, with a
+  // real grounding URL (presence claims must be checkable, never bare prose).
+  const found = attempts.filter((a) => a.result === 'found');
+  const strongestFound = strongestAttempt(found);
+  const foundPrior =
+    strongestFound?.priors?.find((p) => hasUrl(p)) ?? strongestFound?.priors?.[0] ?? null;
+  const priorFound = !!strongestFound && hasUrl(foundPrior ?? undefined);
+
+  // Cross-approach independence of the absence: distinct methods returning none.
+  const independentAbsenceMethods = new Set(
+    attempts.filter((a) => a.result === 'none').map((a) => a.method),
+  ).size;
+
+  let recommendation: PriorEvidenceSummary['recommendation'];
+  if (priorFound) recommendation = 'reuse_prior';
+  else if (independentAbsenceMethods >= 2) recommendation = 'absence_strong';
+  else if (independentAbsenceMethods === 1) recommendation = 'absence_weak';
+  else recommendation = 'unverified';
+
+  return {
+    attemptCount: attempts.length,
+    priorFound,
+    foundPrior,
+    searchedSources,
+    searchedQueries,
+    independentAbsenceMethods,
+    recommendation,
+  };
+}
+
+/** Thin Mongo fetch + summarize. Reads only; writes nothing. */
+export async function loadPriorEvidence(
+  db: Db,
+  bookId: string,
+): Promise<PriorEvidenceSummary> {
+  const attempts = await db
+    .collection<FirstTranslationAttempt>(ATTEMPTS_COLLECTION)
+    .find({ book_id: bookId })
+    .toArray();
+  return summarizePriorEvidence(attempts);
+}

--- a/tests/unit/first-translation-prior-evidence.test.ts
+++ b/tests/unit/first-translation-prior-evidence.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { summarizePriorEvidence } from '@/lib/first-translation/prior-evidence';
+import type { FirstTranslationAttempt } from '@/lib/first-translation/attempt-log';
+
+const at = (over: Partial<FirstTranslationAttempt>): FirstTranslationAttempt => ({
+  attempt_id: 'a', book_id: 'b', date: '2026-06-27T00:00:00Z',
+  method: 'tier2_agent', match_key: 'author_title', sources_checked: [],
+  result: 'none', evidence_strength: 'moderate', ...over,
+});
+
+describe('summarizePriorEvidence — durable, approach-agnostic reuse', () => {
+  it('empty pile → unverified, nothing to reuse', () => {
+    const s = summarizePriorEvidence([]);
+    expect(s.recommendation).toBe('unverified');
+    expect(s.priorFound).toBe(false);
+    expect(s.attemptCount).toBe(0);
+  });
+
+  it('a found prior WITH a real url → reuse_prior (presence is decisive)', () => {
+    const s = summarizePriorEvidence([
+      at({ method: 'gemini_verifier', result: 'found', evidence_strength: 'strong',
+        priors: [{ english_title: 'The Foo', translator: 'Bar', pub_year: '1900', source_url: 'https://archive.org/x' }] }),
+    ]);
+    expect(s.recommendation).toBe('reuse_prior');
+    expect(s.priorFound).toBe(true);
+    expect(s.foundPrior?.english_title).toBe('The Foo');
+  });
+
+  it('a "found" prior with NO url does not count as reusable presence', () => {
+    const s = summarizePriorEvidence([
+      at({ result: 'found', priors: [{ english_title: 'Unsourced claim' }] }),
+    ]);
+    expect(s.priorFound).toBe(false);
+    expect(s.recommendation).not.toBe('reuse_prior');
+  });
+
+  it('two DIFFERENT approaches finding none → absence_strong (independence)', () => {
+    const s = summarizePriorEvidence([
+      at({ method: 'gemini_verifier', result: 'none' }),
+      at({ method: 'tier2_agent', result: 'none' }),
+    ]);
+    expect(s.independentAbsenceMethods).toBe(2);
+    expect(s.recommendation).toBe('absence_strong');
+  });
+
+  it('two attempts from the SAME approach → still only weak (correlated)', () => {
+    const s = summarizePriorEvidence([
+      at({ method: 'gemini_verifier', result: 'none' }),
+      at({ method: 'gemini_verifier', result: 'none' }),
+    ]);
+    expect(s.independentAbsenceMethods).toBe(1);
+    expect(s.recommendation).toBe('absence_weak');
+  });
+
+  it('unions sources + queries across attempts so a new pass skips covered ground', () => {
+    const s = summarizePriorEvidence([
+      at({ method: 'gemini_verifier', result: 'none', sources_checked: ['worldcat', 'archive.org'], queries: ['q1'] }),
+      at({ method: 'tier2_agent', result: 'none', sources_checked: ['archive.org', 'hathitrust'], queries: ['q1', 'q2'] }),
+    ]);
+    expect(s.searchedSources.sort()).toEqual(['archive.org', 'hathitrust', 'worldcat']);
+    expect(s.searchedQueries.sort()).toEqual(['q1', 'q2']);
+  });
+
+  it('a real found-prior outranks absence even when absence is independent', () => {
+    const s = summarizePriorEvidence([
+      at({ method: 'gemini_verifier', result: 'none' }),
+      at({ method: 'tier2_agent', result: 'none' }),
+      at({ method: 'human', result: 'found', evidence_strength: 'strong',
+        priors: [{ english_title: 'Real', source_url: 'https://worldcat.org/x' }] }),
+    ]);
+    expect(s.recommendation).toBe('reuse_prior');
+  });
+});


### PR DESCRIPTION
Makes verification evidence persist + be reusable ACROSS approaches (Derek's durability principle). New `src/lib/first-translation/prior-evidence.ts`: `summarizePriorEvidence()` (pure, unit-tested) reads the accumulated `first_translation_attempts` pile and returns the reusable URL-backed found-prior, the union of already-searched sources/queries (so a new pass skips covered ground), and the count of *independent* approaches that found absence → a recommendation (reuse_prior / absence_strong / absence_weak / unverified). `loadPriorEvidence()` = thin Mongo fetch. **Writes nothing** — the resolver still produces the verdict; this just surfaces what's already known so it can short-circuit and weight absence by cross-approach independence.

Also adds §1b 'evidence outlives the approach' to the methodology doc. tsc clean; 7/7 new tests. Next in this lane (separate PRs): wire the resolver to call this before spending; Sink C (found priors → translation_catalogs). Refs #2564 / #2780.