### PR TITLE
feat(ft): language-mislabel detector + dry-run fix (#2780)

### DIFF
--- a/scripts/analysis/detect-language-mislabels.mjs
+++ b/scripts/analysis/detect-language-mislabels.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * detect-language-mislabels.mjs — REPORT-ONLY language-mislabel detector (#2780)
+ *
+ * Some books are tagged `language: 'English'` (en/eng/...) but are actually
+ * non-English works. The bug has two harms:
+ *   (1) it risks a wrong FT demote if anyone treats language=English as
+ *       "English original";
+ *   (2) it wrongly EXCLUDES them from the FT-eligible census denominator
+ *       (eligibility = readable + non-English `language`).
+ * Correcting `language` KEEPS the first-translation badge and fixes the count.
+ * This script NEVER touches the badge and NEVER writes — it only reports.
+ *
+ * For each English-tagged book, the likely TRUE source language is inferred,
+ * in priority order:
+ *   (a) `original_language` if set and non-English  -> HIGH confidence
+ *   (b) an explicit cataloguer prefix `[Hebrew: ...]` / `[Greek:] ...`
+ *                                                     -> MEDIUM confidence
+ *   (c) a non-Latin script in the title (Hebrew/Greek/Cyrillic/Arabic/CJK/...)
+ *                                                     -> LOW confidence
+ *                                                        (title-script inferred)
+ *   (d) no signal                                      -> AMBIGUOUS / needs-review
+ *       (could be a genuine English original — left alone)
+ *
+ * Output: scripts/output/ft-language-mislabel-<date>.{json,md}
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/analysis/detect-language-mislabels.mjs
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { withMongo } from '../lib/mongo.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+
+// "English" in all the forms the corpus uses.
+const ENGLISH_TAGS = ['en', 'eng', 'English', 'english', 'en-US', 'en-GB'];
+const ENGLISH_SET = new Set(ENGLISH_TAGS.map((s) => s.toLowerCase()));
+
+function isEnglishValue(v) {
+  if (!v) return false;
+  return ENGLISH_SET.has(String(v).trim().toLowerCase());
+}
+
+// Cataloguer prefix like "[Hebrew: ...]" or "[Greek:] ...".
+const PREFIX_RE =
+  /^\s*\[\s*(Hebrew|Greek|Arabic|Sanskrit|Chinese|Syriac|Coptic|Cyrillic|Russian|Japanese|Korean|Tibetan|Persian|Latin|Aramaic|Ethiopic|Ge'ez|Geez|Armenian|Georgian)\b/i;
+
+// Unicode-script blocks -> a coarse language guess. Title-script is the weakest
+// signal: a CJK string in parentheses ("浮生六记") next to an English title is a
+// genuine English translation, so this is LOW confidence only.
+const SCRIPT_BLOCKS = [
+  { name: 'Hebrew', re: /[֐-׿יִ-ﭏ]/ },
+  { name: 'Greek', re: /[Ͱ-Ͽἀ-῿]/ },
+  { name: 'Cyrillic', re: /[Ѐ-ӿ]/ },
+  { name: 'Arabic', re: /[؀-ۿݐ-ݿ]/ },
+  { name: 'Syriac', re: /[܀-ݏ]/ },
+  { name: 'Chinese', re: /[一-鿿㐀-䶿]/ },
+  { name: 'Japanese', re: /[぀-ヿ]/ }, // hiragana/katakana
+  { name: 'Korean', re: /[가-힯]/ },
+  { name: 'Devanagari', re: /[ऀ-ॿ]/ }, // Sanskrit/Hindi
+  { name: 'Tibetan', re: /[ༀ-࿿]/ },
+  { name: 'Armenian', re: /[԰-֏]/ },
+  { name: 'Georgian', re: /[Ⴀ-ჿ]/ },
+];
+
+// Devanagari script -> Sanskrit is the historically-correct default for this
+// corpus (overwhelmingly Sanskrit, not modern Hindi).
+const SCRIPT_TO_LANGUAGE = { Devanagari: 'Sanskrit' };
+
+function scriptLanguage(title) {
+  if (!title) return null;
+  for (const { name, re } of SCRIPT_BLOCKS) {
+    if (re.test(title)) return SCRIPT_TO_LANGUAGE[name] || name;
+  }
+  return null;
+}
+
+function prefixLanguage(title) {
+  if (!title) return null;
+  const m = title.match(PREFIX_RE);
+  if (!m) return null;
+  let lang = m[1];
+  if (/^ge'?ez$/i.test(lang)) lang = "Ge'ez";
+  // Title-cased canonical form.
+  return lang.charAt(0).toUpperCase() + lang.slice(1).toLowerCase().replace(/^ge'ez$/i, "Ge'ez");
+}
+
+function classify(book) {
+  const ol = book.original_language;
+
+  // (a) original_language non-English -> HIGH confidence, unambiguous.
+  if (ol && String(ol).trim() && !isEnglishValue(ol)) {
+    return {
+      proposed: String(ol).trim(),
+      signal: 'original_language',
+      confidence: 'high',
+    };
+  }
+
+  // (b) cataloguer prefix -> MEDIUM.
+  const pref = prefixLanguage(book.title);
+  if (pref) {
+    return { proposed: pref, signal: 'title-prefix', confidence: 'medium' };
+  }
+
+  // (c) non-Latin title script -> LOW.
+  const scr = scriptLanguage(book.title);
+  if (scr) {
+    return { proposed: scr, signal: 'title-script', confidence: 'low' };
+  }
+
+  // (d) no signal -> needs review (could be a genuine English original).
+  return { proposed: null, signal: 'none', confidence: 'ambiguous' };
+}
+
+async function main() {
+  const date = new Date().toISOString().slice(0, 10);
+  const rows = [];
+  const summary = {
+    date,
+    total_english_tagged: 0,
+    by_confidence: {},
+    by_proposed_language: {},
+    badged_total: 0,
+    badged_mislabel: { high: 0, medium: 0, low: 0 },
+    denominator_impact_note: '',
+  };
+
+  await withMongo(
+    async (db) => {
+      const cursor = db
+        .collection('books')
+        .find({ language: { $in: ENGLISH_TAGS } })
+        .project({
+          id: 1,
+          title: 1,
+          language: 1,
+          original_language: 1,
+          is_first_translation: 1,
+        });
+
+      for await (const book of cursor) {
+        summary.total_english_tagged += 1;
+        const badged = book.is_first_translation === true;
+        if (badged) summary.badged_total += 1;
+
+        const { proposed, signal, confidence } = classify(book);
+
+        summary.by_confidence[confidence] =
+          (summary.by_confidence[confidence] || 0) + 1;
+
+        // Only mislabel candidates (proposed != null) count as "would change".
+        if (proposed) {
+          summary.by_proposed_language[proposed] =
+            (summary.by_proposed_language[proposed] || 0) + 1;
+          if (badged && summary.badged_mislabel[confidence] !== undefined) {
+            summary.badged_mislabel[confidence] += 1;
+          }
+        }
+
+        rows.push({
+          id: book.id,
+          mongo_id: String(book._id),
+          title: book.title || '',
+          current_language: book.language,
+          proposed_language: proposed,
+          signal,
+          confidence,
+          is_first_translation: badged,
+        });
+      }
+    },
+    { timeoutMs: 180000 },
+  );
+
+  // Sort: high first, then medium, low, ambiguous; within each by language.
+  const order = { high: 0, medium: 1, low: 2, ambiguous: 3 };
+  rows.sort(
+    (a, b) =>
+      (order[a.confidence] ?? 9) - (order[b.confidence] ?? 9) ||
+      String(a.proposed_language).localeCompare(String(b.proposed_language)),
+  );
+
+  const highMislabels = rows.filter(
+    (r) => r.confidence === 'high' && r.proposed_language,
+  );
+  summary.denominator_impact_note =
+    `${highMislabels.length} high-confidence mislabels would move from the ` +
+    `English bucket into a non-English bucket — adding them to the ` +
+    `FT-eligible census denominator (readable + non-English) and removing ` +
+    `the risk of a wrong "English original" FT demote. ` +
+    `${summary.badged_mislabel.high} of them are currently FT-badged.`;
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const jsonPath = path.join(OUT_DIR, `ft-language-mislabel-${date}.json`);
+  const mdPath = path.join(OUT_DIR, `ft-language-mislabel-${date}.md`);
+
+  fs.writeFileSync(jsonPath, JSON.stringify({ summary, rows }, null, 2));
+  fs.writeFileSync(mdPath, renderMarkdown(summary, rows));
+
+  // ---- console report --------------------------------------------------
+  console.log('\n=== Language-mislabel detector (#2780) ===');
+  console.log(`English-tagged books scanned: ${summary.total_english_tagged}`);
+  console.log('\nBy confidence:');
+  for (const [k, v] of Object.entries(summary.by_confidence)) {
+    console.log(`  ${k.padEnd(10)} ${v}`);
+  }
+  console.log('\nMislabel candidates by proposed language (top 20):');
+  const langSorted = Object.entries(summary.by_proposed_language).sort(
+    (a, b) => b[1] - a[1],
+  );
+  for (const [lang, n] of langSorted.slice(0, 20)) {
+    console.log(`  ${String(lang).padEnd(20)} ${n}`);
+  }
+  console.log('\n--- Buckets (the spec asks these be explicit) ---');
+  const high = rows.filter((r) => r.confidence === 'high').length;
+  const med = rows.filter((r) => r.confidence === 'medium').length;
+  const low = rows.filter((r) => r.confidence === 'low').length;
+  const amb = rows.filter((r) => r.confidence === 'ambiguous').length;
+  console.log(`  HIGH  (non-English original_language) : ${high}`);
+  console.log(`  MED   (cataloguer [Lang:] prefix)     : ${med}`);
+  console.log(`  LOW   (title-script inferred)         : ${low}`);
+  console.log(`  AMBIG (no signal / leave as English)  : ${amb}`);
+  console.log('\nDenominator / badge impact:');
+  console.log(`  Currently FT-badged English-tagged    : ${summary.badged_total}`);
+  console.log(`  ... that are HIGH-conf mislabels       : ${summary.badged_mislabel.high}`);
+  console.log(`  ... that are MED-conf mislabels        : ${summary.badged_mislabel.medium}`);
+  console.log(`  ... that are LOW-conf mislabels        : ${summary.badged_mislabel.low}`);
+  console.log(`\n${summary.denominator_impact_note}`);
+  console.log(`\nWrote:\n  ${jsonPath}\n  ${mdPath}`);
+  console.log(
+    '\nNEXT: review the report, then run (gated on Derek):\n' +
+      `  node scripts/maintenance/fix-language-mislabels.mjs ${jsonPath} --apply`,
+  );
+}
+
+function renderMarkdown(summary, rows) {
+  const L = [];
+  L.push(`# Language-mislabel report (#2780) — ${summary.date}`);
+  L.push('');
+  L.push(
+    'Books tagged `language: English` that are actually non-English works. ' +
+      'Fixing `language` KEEPS any first-translation badge and corrects the ' +
+      'FT-eligible census denominator. **Nothing here demotes a badge.**',
+  );
+  L.push('');
+  L.push(`- English-tagged books scanned: **${summary.total_english_tagged}**`);
+  L.push(`- Currently FT-badged: **${summary.badged_total}**`);
+  L.push('');
+  L.push('## Buckets by confidence');
+  L.push('| Confidence | Signal | Count |');
+  L.push('|---|---|---|');
+  L.push(`| high | non-English \`original_language\` | ${summary.by_confidence.high || 0} |`);
+  L.push(`| medium | cataloguer \`[Lang:]\` title prefix | ${summary.by_confidence.medium || 0} |`);
+  L.push(`| low | non-Latin title script | ${summary.by_confidence.low || 0} |`);
+  L.push(`| ambiguous | no signal (left as English) | ${summary.by_confidence.ambiguous || 0} |`);
+  L.push('');
+  L.push('## Denominator / badge impact');
+  L.push('');
+  L.push(summary.denominator_impact_note);
+  L.push('');
+  L.push('## Mislabel candidates by proposed language');
+  L.push('| Proposed language | Count |');
+  L.push('|---|---|');
+  for (const [lang, n] of Object.entries(summary.by_proposed_language).sort(
+    (a, b) => b[1] - a[1],
+  )) {
+    L.push(`| ${lang} | ${n} |`);
+  }
+  L.push('');
+  L.push('## Rows (high & medium confidence)');
+  L.push('| id | title | current | proposed | signal | conf | FT |');
+  L.push('|---|---|---|---|---|---|---|');
+  for (const r of rows.filter(
+    (r) => r.confidence === 'high' || r.confidence === 'medium',
+  )) {
+    const t = (r.title || '').slice(0, 70).replace(/\|/g, '\\|');
+    L.push(
+      `| ${r.id} | ${t} | ${r.current_language} | ${r.proposed_language} | ${r.signal} | ${r.confidence} | ${r.is_first_translation ? 'yes' : ''} |`,
+    );
+  }
+  L.push('');
+  return L.join('\n');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/maintenance/fix-language-mislabels.mjs
+++ b/scripts/maintenance/fix-language-mislabels.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * fix-language-mislabels.mjs — apply HIGH-confidence language fixes (#2780)
+ *
+ * Reads a report produced by
+ *   scripts/analysis/detect-language-mislabels.mjs
+ * and corrects `books.language` for HIGH-CONFIDENCE rows only — the
+ * unambiguous ones, where a non-English `original_language` proves the book
+ * is not an English original.
+ *
+ * Why: those books are mistagged `language: English`. The bug (a) risks a
+ * wrong FT demote if anything treats language=English as "English original",
+ * and (b) wrongly excludes them from the FT-eligible census denominator
+ * (readable + non-English). Fixing `language` KEEPS the badge and fixes the
+ * count.
+ *
+ * SAFETY:
+ *   - DRY-RUN by default. Writes only with --apply.
+ *   - Touches ONLY the `language` field. Never the is_first_translation badge,
+ *     never original_language, never anything else.
+ *   - Backs up (id, mongo_id, old language) to a timestamped JSON BEFORE any
+ *     write.
+ *   - HIGH-confidence rows only (confidence === 'high' && proposed_language set).
+ *     Medium/low/ambiguous rows are skipped — they need human review.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   # dry run (default):
+ *   node scripts/maintenance/fix-language-mislabels.mjs scripts/output/ft-language-mislabel-<date>.json
+ *   # apply (gated on Derek):
+ *   node scripts/maintenance/fix-language-mislabels.mjs scripts/output/ft-language-mislabel-<date>.json --apply
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ObjectId } from 'mongodb';
+import { withMongo } from '../lib/mongo.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const apply = args.includes('--apply');
+  const reportPath = args.find((a) => !a.startsWith('--'));
+  return { apply, reportPath };
+}
+
+async function main() {
+  const { apply, reportPath } = parseArgs(process.argv);
+
+  if (!reportPath) {
+    console.error(
+      'Usage: node scripts/maintenance/fix-language-mislabels.mjs <report.json> [--apply]',
+    );
+    process.exit(1);
+  }
+  if (!fs.existsSync(reportPath)) {
+    console.error(`Report not found: ${reportPath}`);
+    process.exit(1);
+  }
+
+  const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+  const allRows = Array.isArray(report.rows) ? report.rows : [];
+
+  // HIGH-confidence only, with a concrete proposed language.
+  const targets = allRows.filter(
+    (r) =>
+      r.confidence === 'high' &&
+      r.proposed_language &&
+      String(r.proposed_language).trim(),
+  );
+
+  console.log(`\n=== fix-language-mislabels (#2780) ===`);
+  console.log(`Report:        ${reportPath}`);
+  console.log(`Mode:          ${apply ? 'APPLY (writing)' : 'DRY-RUN (no writes)'}`);
+  console.log(`Total rows:    ${allRows.length}`);
+  console.log(`HIGH-conf targets (would change): ${targets.length}`);
+  console.log(
+    `Skipped (medium/low/ambiguous, need review): ${allRows.length - targets.length}`,
+  );
+
+  if (targets.length === 0) {
+    console.log('Nothing to do.');
+    return;
+  }
+
+  await withMongo(
+    async (db) => {
+      const books = db.collection('books');
+      const backup = [];
+      const diffPreview = [];
+      let changed = 0;
+      let alreadyCorrect = 0;
+      let notFound = 0;
+
+      for (const row of targets) {
+        // Prefer string `id`; fall back to Mongo _id. (books.id != _id.)
+        let book = null;
+        if (row.id) book = await books.findOne({ id: row.id }, { projection: { language: 1 } });
+        if (!book && row.mongo_id) {
+          try {
+            book = await books.findOne(
+              { _id: new ObjectId(row.mongo_id) },
+              { projection: { language: 1 } },
+            );
+          } catch {
+            /* non-ObjectId _id (e.g. uuid stored as _id) — ignore */
+          }
+        }
+        if (!book) {
+          notFound += 1;
+          continue;
+        }
+
+        const oldLang = book.language;
+        const newLang = String(row.proposed_language).trim();
+
+        if (oldLang === newLang) {
+          alreadyCorrect += 1;
+          continue;
+        }
+
+        backup.push({
+          id: row.id,
+          mongo_id: String(book._id),
+          old_language: oldLang,
+          new_language: newLang,
+        });
+        diffPreview.push(
+          `  ${(row.id || row.mongo_id || '').padEnd(40)} ${String(oldLang).padEnd(10)} -> ${newLang}   ${(row.title || '').slice(0, 40)}`,
+        );
+        changed += 1;
+      }
+
+      console.log(`\nWould change: ${changed}`);
+      console.log(`Already correct (skip): ${alreadyCorrect}`);
+      console.log(`Not found in DB (skip): ${notFound}`);
+      console.log('\nDiff preview (old -> new):');
+      console.log(diffPreview.slice(0, 50).join('\n'));
+      if (diffPreview.length > 50) {
+        console.log(`  ... and ${diffPreview.length - 50} more`);
+      }
+
+      if (!apply) {
+        console.log(
+          '\nDRY-RUN — no writes made. Re-run with --apply to write (touches ONLY `language`).',
+        );
+        return;
+      }
+
+      if (backup.length === 0) {
+        console.log('\nNothing to write after diffing. Done.');
+        return;
+      }
+
+      // Back up BEFORE writing.
+      fs.mkdirSync(OUT_DIR, { recursive: true });
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const backupPath = path.join(
+        OUT_DIR,
+        `language-mislabel-backup-${stamp}.json`,
+      );
+      fs.writeFileSync(backupPath, JSON.stringify(backup, null, 2));
+      console.log(`\nBackup written: ${backupPath} (${backup.length} rows)`);
+
+      // Apply — ONLY the `language` field. Match by the same _id we read.
+      let written = 0;
+      for (const b of backup) {
+        const res = await books.updateOne(
+          { _id: ObjectIdOrString(b.mongo_id) },
+          { $set: { language: b.new_language } },
+        );
+        if (res.modifiedCount === 1) written += 1;
+      }
+      console.log(`\nApplied: ${written}/${backup.length} language fields updated.`);
+      if (written !== backup.length) {
+        console.warn(
+          `WARNING: ${backup.length - written} updates did not modify a doc. ` +
+            `Backup at ${backupPath} reflects intended changes.`,
+        );
+      }
+    },
+    { timeoutMs: 300000 },
+  );
+}
+
+// Some books store a uuid string as _id; most use ObjectId. Match either.
+function ObjectIdOrString(idStr) {
+  try {
+    return new ObjectId(idStr);
+  } catch {
+    return idStr;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Language-mislabel detector + dry-run fix (#2780)

### The harm
Some books are tagged `language: English` (en/eng/...) but are actually non-English works — their `original_language` is Latin/Greek/Sanskrit/Hebrew/etc., or the cataloguer left a `[Hebrew: ...]` title prefix. Confirmed examples: *De methodo plantarum* (Latin), *Jyothisha Marga Deepika* (Sanskrit), *Sacramentarium Leonianum* (Latin), Roger Bacon's *Part of the Opus Tertium* (Latin). These are **genuine non-English first translations with a wrong `language` tag**.

Two harms:
1. **Wrong FT demote risk** — anything that treats `language=English` as "English original" could demote a real first translation.
2. **Census undercount** — FT-eligibility = readable + non-English `language`, so a wrong English tag silently **excludes** these books from the FT denominator.

Correcting `language` **KEEPS** the first-translation badge and fixes the count. **Nothing here demotes anything.**

### Detection logic (FREE, no LLM)
For each English-tagged book, infer the true source language in priority order:
- **(a) `original_language` non-English → HIGH confidence** (unambiguous; the only thing the fix script touches)
- **(b) cataloguer `[Lang: ...]` title prefix → MEDIUM** (needs review)
- **(c) non-Latin title script** (Hebrew/Greek/Cyrillic/Arabic/Syriac/CJK/Devanagari→Sanskrit/Tibetan/...) **→ LOW** (a parenthetical CJK title next to an English one is a genuine translation, hence low)
- **(d) no signal → AMBIGUOUS** — left as English (could be a genuine English original)

### Summary counts (2026-06-27)
- English-tagged books scanned: **2,707**
- **HIGH** (non-English `original_language`): **547**
- **MEDIUM** (cataloguer prefix): **8**
- **LOW** (title-script): **3**
- **AMBIGUOUS** (left as English): **2,149**

Top proposed languages (HIGH): Latin 157, Sanskrit 135, Greek 104, Arabic 28, Chinese 23, Syriac 20, Hebrew 16, German 12, Pali 11, Persian 9, French 9, Tibetan 5, ...

### Denominator / badge impact
- Currently FT-badged among English-tagged: **56**
- ...that are HIGH-conf mislabels (badge would move to non-English bucket): **21**
- ...that are MEDIUM-conf mislabels: **7**

The **547 HIGH-confidence** fixes would move those books from the English bucket into a non-English bucket — adding them to the FT-eligible census denominator and removing the wrong-demote risk. All four brief examples land in HIGH.

### Files
- `scripts/analysis/detect-language-mislabels.mjs` — REPORT-ONLY. Writes `scripts/output/ft-language-mislabel-<date>.{json,md}` (gitignored). Buckets logged explicitly: HIGH (original_language) vs MEDIUM (prefix) vs LOW (title-script) vs AMBIGUOUS.
- `scripts/maintenance/fix-language-mislabels.mjs` — reads the report JSON, sets `books.language` to the proposed value for **HIGH-confidence rows only**. **DRY-RUN by default**, writes only with `--apply`, prints a before/after diff, and backs up `(id, old language)` to a timestamped JSON before any write. Touches **only** the `language` field — never the badge.

### Out of scope / gated
- **`--apply` is gated on Derek** — not run here. Dry-run verified: 547 targets, 0 not-found, only `language` changes.
- MEDIUM/LOW rows are **not** auto-fixed — they need human review.
- Does not touch the census denominator computation itself; this just corrects the source data it reads.

Refs #2780

🤖 Generated with [Claude Code](https://claude.com/claude-code)
