### PR TITLE
feat(ft): Stage B Tier-0 catalog-match reuse (#2780)

### DIFF
--- a/scripts/eval/ft-catalog-match.mjs
+++ b/scripts/eval/ft-catalog-match.mjs
@@ -1,0 +1,511 @@
+#!/usr/bin/env node
+/**
+ * Stage B / Tier-0 — First-Translation catalog-match reuse  (#2780)
+ *
+ * REPORT-ONLY. FREE. No LLM/API calls — pure DB matching.
+ *
+ * We badge ~5,800 books "First Translation" but hold a 24K-row
+ * `translation_catalogs` collection (Mongo, db `bookstore`) of KNOWN published
+ * English translations. This tool surfaces, for free, the badged books for
+ * which a prior English translation ALREADY EXISTS in our own catalog —
+ * candidate over-claims we could demote *without any web research*.
+ *
+ * The history's repeated lesson is "matching/reconcile failure, not a seeding
+ * gap" — so this is a matching pass over data we already hold.
+ *
+ * IMPORTANT — this script NEVER writes a verdict or flips a flag. It emits a
+ * report (JSON + Markdown) of demote *candidates* that queue for Derek's
+ * consolidated sign-off. False demotes are the #1 historical failure (the
+ * "Arithmologia" incident), so matching is conservative and guarded.
+ *
+ * MATCHING
+ *   A badged book matches a catalog row when BOTH signals hold:
+ *     (1) author signal  — surname match AND normalized canonical-author overlap
+ *     (2) title  signal  — book-title token CONTAINMENT in the catalog
+ *                          english_title / canonical_work (asymmetric coverage)
+ *   Author-only or title-only is too loose and is dropped.
+ *
+ * EVIDENCE-QUALITY GUARDS (mirrors src/lib/ft-prior-guard.ts + a source-language
+ * guard the TS module does not cover). A catalog match is an auto-demote
+ * CANDIDATE only when ALL guards pass:
+ *   (a) TRANSLATION not anthology/study      (ANTHOLOGY guard)
+ *   (b) completeness == complete             (PARTIAL guard; `unknown` does NOT
+ *                                             pass — it is not "complete")
+ *   (c) SAME source_language as the book's    (SOURCE_LANG guard) — the catalog
+ *       original  (a Latin→En translation      is 100% Latin-source, so it can
+ *       does NOT defeat a Greek→En first)      only defeat Latin-source books
+ *   (d) person-disambiguated, not a namesake  (NAMESAKE guard) — surname match
+ *                                             alone is low-confidence
+ * Anything failing a guard → "needs_review", never an auto-demote candidate.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/eval/ft-catalog-match.mjs
+ *
+ * Output:
+ *   scripts/output/ft-catalog-match-<date>.json
+ *   scripts/output/ft-catalog-match-<date>.md
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+const DATE = new Date().toISOString().slice(0, 10);
+
+// ── Text normalisation (mirrors src/lib/ft-prior-guard.ts) ─────────────────────
+
+function normalise(s) {
+  return (s || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // strip combining diacritics
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const STOP_WORDS = new Set([
+  'the', 'and', 'with', 'from', 'that', 'this', 'for', 'are', 'was',
+  'been', 'have', 'has', 'its', 'into', 'upon', 'also', 'very', 'more',
+  'some', 'such', 'than', 'being', 'over', 'both', 'each', 'only',
+  'english', 'translation', 'translated', 'works', 'text',
+  // bibliographic / latin filler that creates spurious title overlap
+  'liber', 'libri', 'opus', 'opera', 'book', 'books', 'volume', 'tractatus',
+]);
+
+function sigTokens(s) {
+  return normalise(s)
+    .split(/\s+/)
+    .filter((t) => t.length >= 4 && !STOP_WORDS.has(t));
+}
+
+function tokenOverlap(a, b) {
+  const ta = new Set(sigTokens(a));
+  const tb = new Set(sigTokens(b));
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let inter = 0;
+  for (const t of ta) if (tb.has(t)) inter++;
+  return inter / Math.max(ta.size, tb.size);
+}
+
+/** Fraction of book-title tokens that appear in the prior title (asymmetric). */
+function bookTitleCoverage(bookTitle, priorTitle) {
+  const bookToks = sigTokens(bookTitle);
+  const priorToks = new Set(sigTokens(priorTitle));
+  if (bookToks.length === 0) return 0;
+  const found = bookToks.filter((t) => priorToks.has(t));
+  return found.length / bookToks.length;
+}
+
+// Generic / collective "authors" whose surname is a meaningless join key — a
+// surname match on these is pure noise, never person-disambiguation.
+const GENERIC_AUTHORS = new Set([
+  'anonymous', 'anon', 'unknown', 'various', 'collective', 'multiple authors',
+  'catholic church', 'catholica romana ecclesia',
+]);
+
+function isGenericAuthor(author) {
+  const n = normalise(author);
+  return !n || GENERIC_AUTHORS.has(n) || n.length < 3;
+}
+
+function extractSurname(author) {
+  const norm = normalise(author);
+  if (!norm) return '';
+  // catalog authors are often "Surname, Forename"
+  const raw = (author || '');
+  if (raw.includes(',')) return normalise(raw.split(',')[0]);
+  const parts = norm.split(/\s+/).filter(Boolean);
+  return parts[parts.length - 1] || '';
+}
+
+// ── Source-language normalisation ──────────────────────────────────────────────
+// The catalog is entirely `source_language: 'la'`. Map a book's language to the
+// same ISO-ish bucket so guard (c) can compare like with like.
+
+const LANG_TO_ISO = {
+  latin: 'la', 'latin-german': 'la', la: 'la',
+  greek: 'grc', 'ancient greek': 'grc', 'classical greek': 'grc', grc: 'grc',
+  german: 'de', dutch: 'nl', french: 'fr', italian: 'it', spanish: 'es',
+  hebrew: 'he', arabic: 'ar', sanskrit: 'sa', tibetan: 'bo', chinese: 'zh',
+  syriac: 'syc', armenian: 'hy', akkadian: 'akk',
+};
+
+function bookSourceIso(book) {
+  // prefer original_language when present; else the surface language
+  const ol = normalise(book.original_language || '');
+  const l = normalise(book.language || '');
+  for (const key of [ol, l]) {
+    if (!key) continue;
+    if (LANG_TO_ISO[key]) return LANG_TO_ISO[key];
+    // handle compound like "latin-german" → first segment
+    const first = key.split(/[-\/, ]/)[0];
+    if (LANG_TO_ISO[first]) return LANG_TO_ISO[first];
+  }
+  return l || ol || 'unknown';
+}
+
+// ── Guards ─────────────────────────────────────────────────────────────────────
+
+const ANTHOLOGY_KEYWORDS = [
+  'anthology', 'collected works', 'collected letters', 'selected works',
+  'selected writings', 'selections from', 'reader', 'companion', 'works of',
+  'writings of', 'sources in', 'sourcebook', 'collected papers',
+  'complete works', 'miscellany', 'omnibus',
+];
+
+/** (a) Anthology/study guard. Pass = looks like a real translation of THIS work. */
+function guardAnthology(book, row) {
+  const title = normalise(row.english_title || '');
+  const work = normalise(row.canonical_work || '');
+  const kw = ANTHOLOGY_KEYWORDS.find((k) => title.includes(k) || work.includes(k));
+  if (!kw) return { pass: true, reason: 'no anthology/study keywords' };
+  // high containment ⇒ the anthology IS this specific work — don't fire
+  const cov = Math.max(
+    bookTitleCoverage(book.title, row.english_title || ''),
+    bookTitleCoverage(book.title, row.canonical_work || ''),
+  );
+  if (cov >= 0.8) return { pass: true, reason: `keyword "${kw}" but coverage=${cov.toFixed(2)} — likely this work` };
+  return { pass: false, reason: `anthology/study keyword "${kw}" with coverage=${cov.toFixed(2)}` };
+}
+
+/** (b) Completeness guard. Pass only when explicitly `complete`. */
+function guardComplete(row) {
+  const c = (row.completeness || 'unknown').toLowerCase().trim();
+  if (c === 'complete') return { pass: true, reason: 'completeness=complete' };
+  // partial / excerpts / unknown / "partial/..." → does not defeat first-complete
+  return { pass: false, reason: `completeness="${row.completeness ?? 'unset'}" (not complete)` };
+}
+
+/** (c) Source-language guard. Pass only when the catalog source matches the book's. */
+function guardSourceLang(book, row) {
+  const bookIso = bookSourceIso(book);
+  const catIso = normalise(row.source_language || '');
+  if (!catIso) return { pass: false, reason: 'catalog row has no source_language' };
+  if (bookIso === 'unknown') return { pass: false, reason: `book source-language unknown (lang="${book.language}")` };
+  if (bookIso === catIso) return { pass: true, reason: `source_language match (${catIso})` };
+  return { pass: false, reason: `source-language mismatch: book=${bookIso} ("${book.language}") vs catalog=${catIso}` };
+}
+
+/** (d) Namesake / person-disambiguation guard. Pass = strong author signal. */
+function guardNamesake(book, row, authorJaccard) {
+  // A bare surname collision is the classic namesake trap. Require either a
+  // strong normalized-author overlap OR a forename token corroboration.
+  if (authorJaccard >= 0.5) return { pass: true, reason: `author overlap=${authorJaccard.toFixed(2)}` };
+  // forename corroboration: any non-surname book-author token present in catalog author
+  const bookAuthTokens = sigTokens(book.author || '');
+  const catAuthNorm = normalise(
+    [row.canonical_author, row.author, row.author_normalized].filter(Boolean).join(' '),
+  );
+  const corrob = bookAuthTokens.filter((t) => catAuthNorm.includes(t));
+  if (corrob.length >= 2) return { pass: true, reason: `multi-token author corroboration (${corrob.join('+')})` };
+  return { pass: false, reason: `weak author signal (overlap=${authorJaccard.toFixed(2)}) — possible namesake` };
+}
+
+// ── Matching ───────────────────────────────────────────────────────────────────
+
+const MIN_TITLE_COVERAGE = 0.6; // book-title tokens contained in catalog title/work
+const MIN_AUTHOR_JACCARD_FOR_MATCH = 0.34; // at least some normalized-author overlap
+
+function authorOverlap(book, row) {
+  const bookAuthNorm = book.author || '';
+  const catAuthNorm = [row.canonical_author, row.author].filter(Boolean).join(' ');
+  // jaccard over significant author tokens (drop surname-only stop effect)
+  return tokenOverlap(bookAuthNorm, catAuthNorm);
+}
+
+function titleSignal(book, row) {
+  // containment of book title in the catalog english_title OR canonical_work
+  const cTitle = bookTitleCoverage(book.title, row.english_title || '');
+  const cWork = bookTitleCoverage(book.title, row.canonical_work || '');
+  return Math.max(cTitle, cWork);
+}
+
+async function main() {
+  await withMongo(async (db) => {
+    const badgeQ = {
+      is_first_translation: true,
+      visible: true,
+      pages_translated: { $gt: 0 },
+      language: { $nin: [null, 'en', 'eng', 'English', 'english'] },
+    };
+
+    const nBadged = await db.collection('books').countDocuments(badgeQ);
+    console.log(`Badged books (FT, visible, translated, non-English): ${nBadged}`);
+
+    const books = await db
+      .collection('books')
+      .find(badgeQ)
+      .project({ _id: 0, id: 1, author: 1, title: 1, language: 1, original_language: 1, work_id: 1 })
+      .toArray();
+    console.log(`Loaded ${books.length} badged books.`);
+
+    const catRows = await db
+      .collection('translation_catalogs')
+      .find({})
+      .project({
+        _id: 1, source: 1, author: 1, author_normalized: 1, author_surname: 1,
+        canonical_author: 1, canonical_author_normalized: 1,
+        english_title: 1, english_title_normalized: 1, canonical_work: 1, canonical_work_normalized: 1,
+        translator: 1, pub_year: 1, pub_year_int: 1, publisher: 1, completeness: 1,
+        source_language: 1, url: 1, source_url: 1,
+      })
+      .toArray();
+    console.log(`Loaded ${catRows.length} catalog rows.`);
+
+    // Index catalog rows by author surname for cheap candidate lookup.
+    const bySurname = new Map();
+    for (const row of catRows) {
+      const sn = row.author_surname ? normalise(row.author_surname) : extractSurname(row.canonical_author || row.author);
+      if (!sn || sn.length < 3) continue;
+      if (!bySurname.has(sn)) bySurname.set(sn, []);
+      bySurname.get(sn).push(row);
+    }
+    console.log(`Indexed ${bySurname.size} distinct catalog surnames.`);
+
+    const results = [];
+    let scanned = 0;
+
+    for (const book of books) {
+      scanned++;
+      if (!book.id || !book.author || !book.title) continue;
+      if (isGenericAuthor(book.author)) continue; // generic-author surname = noise
+      const sn = extractSurname(book.author);
+      if (!sn || sn.length < 3) continue;
+      const candidates = bySurname.get(sn);
+      if (!candidates || candidates.length === 0) continue;
+
+      // Score every same-surname candidate; keep those clearing match thresholds.
+      const matches = [];
+      for (const row of candidates) {
+        const aJac = authorOverlap(book, row);
+        const tCov = titleSignal(book, row);
+        if (tCov < MIN_TITLE_COVERAGE) continue; // need title signal
+        if (aJac < MIN_AUTHOR_JACCARD_FOR_MATCH) {
+          // surname matched but the rest of the name doesn't — keep ONLY if a
+          // strong forename corroboration exists; otherwise drop as too loose.
+          const bookAuthTokens = sigTokens(book.author || '');
+          const catAuthNorm = normalise([row.canonical_author, row.author].filter(Boolean).join(' '));
+          const corrob = bookAuthTokens.filter((t) => catAuthNorm.includes(t));
+          if (corrob.length < 2) continue;
+        }
+
+        const gAnth = guardAnthology(book, row);
+        const gComp = guardComplete(row);
+        const gLang = guardSourceLang(book, row);
+        const gName = guardNamesake(book, row, aJac);
+
+        const guards = {
+          ANTHOLOGY: gAnth,
+          COMPLETENESS: gComp,
+          SOURCE_LANG: gLang,
+          NAMESAKE: gName,
+        };
+        const allPass = gAnth.pass && gComp.pass && gLang.pass && gName.pass;
+        const failed = Object.entries(guards).filter(([, g]) => !g.pass).map(([k]) => k);
+
+        matches.push({
+          catalog_id: String(row._id),
+          source: row.source || null,
+          catalog_author: row.canonical_author || row.author || null,
+          english_title: row.english_title || null,
+          canonical_work: row.canonical_work || null,
+          translator: row.translator || null,
+          pub_year: row.pub_year_int ?? row.pub_year ?? null,
+          publisher: row.publisher || null,
+          completeness: row.completeness ?? null,
+          source_language: row.source_language || null,
+          url: row.url || row.source_url || null,
+          author_overlap: Number(aJac.toFixed(3)),
+          title_coverage: Number(tCov.toFixed(3)),
+          guards: {
+            ANTHOLOGY: gAnth,
+            COMPLETENESS: gComp,
+            SOURCE_LANG: gLang,
+            NAMESAKE: gName,
+          },
+          all_guards_pass: allPass,
+          failed_guards: failed,
+        });
+      }
+
+      if (matches.length === 0) continue;
+
+      // Best match = most guards passed, then highest combined signal.
+      matches.sort((a, b) => {
+        const ap = 4 - a.failed_guards.length;
+        const bp = 4 - b.failed_guards.length;
+        if (ap !== bp) return bp - ap;
+        return (b.author_overlap + b.title_coverage) - (a.author_overlap + a.title_coverage);
+      });
+
+      const best = matches[0];
+      const tier = best.all_guards_pass ? 'demote_candidate' : 'needs_review';
+
+      results.push({
+        book_id: book.id,
+        author: book.author,
+        title: book.title,
+        language: book.language,
+        original_language: book.original_language ?? null,
+        work_id: book.work_id ?? null,
+        book_source_iso: bookSourceIso(book),
+        tier,
+        match_count: matches.length,
+        best_match: best,
+        // include up to 3 supporting matches for the report (dedupe by catalog_id)
+        matches: matches.slice(0, 3),
+      });
+    }
+
+    // ── Summaries ────────────────────────────────────────────────────────────
+    const demote = results.filter((r) => r.tier === 'demote_candidate');
+    const review = results.filter((r) => r.tier === 'needs_review');
+
+    const byTier = { demote_candidate: demote.length, needs_review: review.length };
+
+    const countBy = (arr, key) => {
+      const m = {};
+      for (const r of arr) {
+        const k = r[key] || 'unknown';
+        m[k] = (m[k] || 0) + 1;
+      }
+      return Object.fromEntries(Object.entries(m).sort((a, b) => b[1] - a[1]));
+    };
+
+    // Why needs_review? tally of which guard most-commonly fails on the best match.
+    const reviewGuardFails = {};
+    for (const r of review) {
+      for (const g of r.best_match.failed_guards) reviewGuardFails[g] = (reviewGuardFails[g] || 0) + 1;
+    }
+
+    const summary = {
+      generated_at: new Date().toISOString(),
+      db: 'bookstore',
+      badged_books_total: nBadged,
+      badged_books_scanned: scanned,
+      catalog_rows: catRows.length,
+      catalog_source_languages: Object.fromEntries(
+        Object.entries(
+          catRows.reduce((m, r) => {
+            const k = r.source_language || 'unset';
+            m[k] = (m[k] || 0) + 1;
+            return m;
+          }, {}),
+        ).sort((a, b) => b[1] - a[1]),
+      ),
+      books_with_any_match: results.length,
+      by_tier: byTier,
+      demote_candidates_by_language: countBy(demote, 'language'),
+      needs_review_by_language: countBy(review, 'language'),
+      needs_review_failed_guard_tally: reviewGuardFails,
+    };
+
+    // ── Empty-bucket assertions (catalog APIs once silently returned 100% NONE)
+    console.log('\n=== SUMMARY ===');
+    console.log(JSON.stringify(summary, null, 2));
+    if (results.length === 0) {
+      console.warn('\n[ASSERT] ZERO books matched any catalog row. This is suspicious — '
+        + 'verify the catalog is populated and matching fields exist before trusting this.');
+    } else {
+      console.log(`\n[ASSERT] ${results.length} books matched (${demote.length} demote candidates, ${review.length} needs_review).`);
+    }
+    if (demote.length === 0) {
+      console.warn('[ASSERT] ZERO demote candidates — every match failed at least one guard. '
+        + 'Expected for a Latin-only catalog vs a multilingual badged set; not necessarily an error.');
+    }
+
+    // ── Write report ─────────────────────────────────────────────────────────
+    fs.mkdirSync(OUT_DIR, { recursive: true });
+    const jsonPath = path.join(OUT_DIR, `ft-catalog-match-${DATE}.json`);
+    const mdPath = path.join(OUT_DIR, `ft-catalog-match-${DATE}.md`);
+
+    fs.writeFileSync(
+      jsonPath,
+      JSON.stringify({ summary, demote_candidates: demote, needs_review: review }, null, 2),
+    );
+
+    fs.writeFileSync(mdPath, renderMarkdown(summary, demote, review));
+
+    console.log(`\nWrote ${jsonPath}`);
+    console.log(`Wrote ${mdPath}`);
+  });
+}
+
+// ── Markdown rendering ─────────────────────────────────────────────────────────
+
+function renderMarkdown(summary, demote, review) {
+  const L = [];
+  L.push('# Stage B / Tier-0 — First-Translation catalog-match reuse (#2780)');
+  L.push('');
+  L.push('**REPORT-ONLY.** No verdict written, no flag flipped. Demote candidates queue for Derek\'s consolidated sign-off.');
+  L.push('');
+  L.push(`Generated: ${summary.generated_at}`);
+  L.push('');
+  L.push('## Summary');
+  L.push('');
+  L.push(`- Badged books (total): **${summary.badged_books_total}**`);
+  L.push(`- Catalog rows: **${summary.catalog_rows}** (source languages: ${Object.entries(summary.catalog_source_languages).map(([k, v]) => `${k}=${v}`).join(', ')})`);
+  L.push(`- Books with any catalog match: **${summary.books_with_any_match}**`);
+  L.push(`- **Demote candidates (all guards pass): ${summary.by_tier.demote_candidate}**`);
+  L.push(`- Needs review (a guard failed/ambiguous): ${summary.by_tier.needs_review}`);
+  L.push('');
+  L.push('### Demote candidates by language');
+  L.push('');
+  for (const [k, v] of Object.entries(summary.demote_candidates_by_language)) L.push(`- ${k}: ${v}`);
+  if (Object.keys(summary.demote_candidates_by_language).length === 0) L.push('- (none)');
+  L.push('');
+  L.push('### Needs-review by language');
+  L.push('');
+  for (const [k, v] of Object.entries(summary.needs_review_by_language)) L.push(`- ${k}: ${v}`);
+  if (Object.keys(summary.needs_review_by_language).length === 0) L.push('- (none)');
+  L.push('');
+  L.push('### Needs-review: which guard failed (best match)');
+  L.push('');
+  for (const [k, v] of Object.entries(summary.needs_review_failed_guard_tally)) L.push(`- ${k}: ${v}`);
+  if (Object.keys(summary.needs_review_failed_guard_tally).length === 0) L.push('- (none)');
+  L.push('');
+
+  const renderRow = (r) => {
+    const m = r.best_match;
+    L.push(`### ${r.title}`);
+    L.push('');
+    L.push(`- Book id: \`${r.book_id}\` — https://sourcelibrary.org/book/${r.book_id}`);
+    L.push(`- Author: ${r.author}`);
+    L.push(`- Book language: ${r.language} (source ISO: ${r.book_source_iso}${r.original_language ? `, original_language: ${r.original_language}` : ''})`);
+    if (r.work_id) L.push(`- work_id: \`${r.work_id}\``);
+    L.push(`- Matched catalog row: "${m.english_title}"${m.canonical_work ? ` (work: ${m.canonical_work})` : ''}`);
+    L.push(`  - Translator: ${m.translator || '—'} · Year: ${m.pub_year ?? '—'} · Publisher: ${m.publisher || '—'}`);
+    L.push(`  - Source: ${m.source || '—'} · catalog source_language: ${m.source_language || '—'} · completeness: ${m.completeness ?? '—'}`);
+    if (m.url) L.push(`  - URL: ${m.url}`);
+    L.push(`  - Signal: author_overlap=${m.author_overlap}, title_coverage=${m.title_coverage}`);
+    L.push(`  - Guards: ${Object.entries(m.guards).map(([k, g]) => `${k}=${g.pass ? 'PASS' : 'FAIL'}`).join(', ')}`);
+    for (const [k, g] of Object.entries(m.guards)) {
+      if (!g.pass) L.push(`    - ${k} FAIL: ${g.reason}`);
+    }
+    if (r.match_count > 1) L.push(`  - (${r.match_count} catalog rows matched this book in total)`);
+    L.push('');
+  };
+
+  L.push('## Demote candidates (all guards pass — candidate over-claims)');
+  L.push('');
+  if (demote.length === 0) L.push('_None. Every catalog match failed at least one evidence-quality guard._');
+  for (const r of demote) renderRow(r);
+  L.push('');
+  L.push('## Needs review (matched but a guard failed — NOT auto-demote)');
+  L.push('');
+  L.push(`_${review.length} entries. Showing detail; these require human/web verification before any flag change._`);
+  L.push('');
+  for (const r of review) renderRow(r);
+
+  return L.join('\n');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

A **report-only, free** (no LLM/API calls — pure DB matching) tool for the first-translation census (#2780). It surfaces FT-badged books for which a prior English translation **already exists in our own `translation_catalogs` collection** (24,040 known published English translations) — candidate over-claims we could demote without any web research.

The history's repeated lesson is "matching/reconcile failure, not a seeding gap." This is Tier-0: reuse data we already hold before spending anything.

`scripts/eval/ft-catalog-match.mjs` — **never writes a verdict or flips a flag.** Demote candidates queue for Derek's consolidated sign-off.

## Match logic

Population: `is_first_translation:true, visible:true, pages_translated>0, language ∉ {en,…}` — **5,772 badged books**. Matches on the string `books.id` (not Mongo `_id`).

A badged book matches a catalog row only when **BOTH** signals hold:
1. **Author** — surname match AND normalized canonical-author token overlap (author-only is too loose; generic/anonymous "authors" are excluded as pure-noise join keys)
2. **Title** — book-title token **containment** in the catalog `english_title` / `canonical_work` (>= 0.6 coverage)

## Evidence-quality guards (the Arithmologia lesson — false demotes are the #1 historical failure)

Mirrors `src/lib/ft-prior-guard.ts`, plus a source-language guard the TS module doesn't cover. A match is a **demote candidate only when ALL guards pass**; any failure -> **needs_review**:

- **ANTHOLOGY** — prior must be a translation, not an anthology/collected-works/biography/study
- **COMPLETENESS** — prior must be `complete`; `unknown`/`partial`/`excerpts` do **not** defeat a "first complete" claim
- **SOURCE_LANG** — prior must share the book's source language. *The catalog is 100% `source_language: la` (Latin)* — so a Latin->En translation **cannot** defeat a Greek/German/etc.->En first. This guard does most of the conservative work.
- **NAMESAKE** — surname-only match is low-confidence; requires strong normalized-author overlap or multi-token forename corroboration

## Summary counts (report: `scripts/output/ft-catalog-match-2026-06-27.{json,md}`, gitignored scratch — not committed)

- Catalog rows: **24,040** (source languages: `la=24040`)
- Books with any catalog match: **50**
- **Demote candidates (all guards pass): 1** — `Liber de verbo mirifico` (Reuchlin, Latin) -> catalog "Wonder-Working Word: A translation of De Verbo Mirifico" (completeness=complete, source=la, title_coverage=1.0). A clean, well-formed candidate over-claim.
- **Needs review: 49** — by language: Latin 46, German 1, Italian 1, Latin-German 1
- Needs-review failed-guard tally: **COMPLETENESS 49**, SOURCE_LANG 2 — i.e. nearly every match is held back because the catalog row's completeness is `unknown` (mostly Kircher *Musurgia* vs biographies/"Theatre of the World" anthologies). Correct behavior: an `unknown`-completeness prior is not proof of a complete prior translation.

Empty-bucket assertions are logged explicitly (a 0-match result is asserted, not silently passed — catalog APIs once silently returned 100% NONE).

## Out of scope

- **Does NOT apply any demotion.** The single demote candidate + the 49 needs_review queue for Derek's consolidated FT sign-off / `ft-verify` Stage-2 before any flag change.
- The Latin-only catalog limits reach to Latin-source books; broadening to other source languages needs a non-Latin catalog (separate seeding work).

Refs #2780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)