### PR TITLE
feat(ft): resolver reads prior evidence before spending (#2803)

### DIFF
--- a/src/lib/first-translation/prior-evidence.ts
+++ b/src/lib/first-translation/prior-evidence.ts
@@ -34,6 +34,8 @@ export interface PriorEvidenceSummary {
   priorFound: boolean;
   /** The strongest found prior with a real URL, if any — ready to reuse. */
   foundPrior: PriorTranslation | null;
+  /** attempt_id behind the reusable prior, for best_attempt_id on a reuse verdict. */
+  foundAttemptId: string | null;
   /** Union of every source any approach has already consulted (don't re-run). */
   searchedSources: string[];
   /** Union of every query already issued (don't re-run verbatim). */
@@ -86,6 +88,7 @@ export function summarizePriorEvidence(
     attemptCount: attempts.length,
     priorFound,
     foundPrior,
+    foundAttemptId: priorFound ? (strongestFound?.attempt_id ?? null) : null,
     searchedSources,
     searchedQueries,
     independentAbsenceMethods,

--- a/src/lib/first-translation/resolve.ts
+++ b/src/lib/first-translation/resolve.ts
@@ -20,6 +20,7 @@
 import type { FirstTranslation, FirstTranslationBook } from './types';
 import type { FirstTranslationAttempt } from './attempt-log';
 import { strongestAttempt } from './attempt-log';
+import type { PriorEvidenceSummary } from './prior-evidence';
 
 /** Result of running a single tier: a candidate verdict + its attempt record. */
 export interface TierOutcome {
@@ -56,6 +57,15 @@ export interface ResolveContext {
    * cheap tiers would have resolved it.
    */
   forceTier2?: boolean;
+  /**
+   * Durable evidence already on record for this book (loaded by the caller via
+   * `loadPriorEvidence`), so the resolver doesn't re-pay for work a prior
+   * approach already did (#2780). When it shows a trustworthy, URL-backed prior
+   * (`recommendation === 'reuse_prior'`), the cascade short-circuits with a
+   * not_first verdict and runs NO tiers. `forceTier2` overrides this (the
+   * sampler still wants a fresh ground-truth pass).
+   */
+  priorEvidence?: PriorEvidenceSummary;
 }
 
 export interface Tiers {
@@ -86,6 +96,26 @@ export async function resolve(
 ): Promise<ResolveResult> {
   const attempts: FirstTranslationAttempt[] = [];
   let resolved: FirstTranslation | null = null;
+
+  // Read-before-verify (#2780): if the accumulated evidence already holds a
+  // trustworthy, URL-backed prior, reuse it — run NO tiers, spend nothing. The
+  // sampler's forceTier2 still gets its fresh ground-truth pass.
+  const pe = ctx.priorEvidence;
+  if (pe?.recommendation === 'reuse_prior' && pe.foundPrior && !ctx.forceTier2) {
+    return {
+      resolved: {
+        verdict: 'not_first',
+        evidence_strength: 'strong',
+        our_completeness: 'unknown',
+        match_key: 'author_title',
+        prior_relationship: 'same_text',
+        resolver: 'tier0_linked',
+        best_attempt_id: pe.foundAttemptId ?? undefined,
+        resolved_at: ctx.now,
+      },
+      attempts: [],
+    };
+  }
 
   const cascade: Tier[] = [tiers.tier0, tiers.tier1];
   if (tiers.tier2) cascade.push(tiers.tier2);

--- a/tests/unit/first-translation-resolve-reuse.test.ts
+++ b/tests/unit/first-translation-resolve-reuse.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { resolve, type Tier, type Tiers } from '@/lib/first-translation/resolve';
+import { summarizePriorEvidence } from '@/lib/first-translation/prior-evidence';
+import type { FirstTranslationAttempt } from '@/lib/first-translation/attempt-log';
+
+const at = (over: Partial<FirstTranslationAttempt>): FirstTranslationAttempt => ({
+  attempt_id: 'a', book_id: 'b', date: '2026-06-27T00:00:00Z', method: 'tier2_agent',
+  match_key: 'author_title', sources_checked: [], result: 'none', evidence_strength: 'moderate', ...over,
+});
+
+// A tier that records whether it ran, so we can prove the short-circuit spends nothing.
+function spyTier(ran: { count: number }): Tier {
+  return async (_book, ctx) => {
+    ran.count++;
+    return {
+      verdict: { verdict: 'first_no_prior', evidence_strength: 'moderate', our_completeness: 'unknown', match_key: 'none', resolver: 'tier1_catalog', resolved_at: ctx.now },
+      attempt: at({ attempt_id: 'fresh' }),
+      terminal: true,
+    };
+  };
+}
+
+describe('resolve — read-before-verify short-circuit (#2780)', () => {
+  const now = '2026-06-27T00:00:00Z';
+
+  it('reuse_prior → NOT_FIRST with zero tier calls and zero new attempts', async () => {
+    const ran = { count: 0 };
+    const tiers: Tiers = { tier0: spyTier(ran), tier1: spyTier(ran), tier2: spyTier(ran) };
+    const pe = summarizePriorEvidence([
+      at({ attempt_id: 'gem-1', method: 'gemini_verifier', result: 'found', evidence_strength: 'strong',
+        priors: [{ english_title: 'The Foo', source_url: 'https://archive.org/x' }] }),
+    ]);
+    const res = await resolve({ id: 'b' }, tiers, { now, priorEvidence: pe });
+    expect(ran.count).toBe(0); // spent nothing
+    expect(res.attempts).toEqual([]);
+    expect(res.resolved.verdict).toBe('not_first');
+    expect(res.resolved.best_attempt_id).toBe('gem-1'); // points at the reused evidence
+  });
+
+  it('forceTier2 overrides reuse — the sampler still gets a fresh pass', async () => {
+    const ran = { count: 0 };
+    const tiers: Tiers = { tier0: spyTier(ran), tier1: spyTier(ran), tier2: spyTier(ran) };
+    const pe = summarizePriorEvidence([
+      at({ result: 'found', evidence_strength: 'strong', priors: [{ english_title: 'X', source_url: 'https://x.org' }] }),
+    ]);
+    const res = await resolve({ id: 'b' }, tiers, { now, priorEvidence: pe, forceTier2: true });
+    expect(ran.count).toBeGreaterThan(0); // did NOT short-circuit
+    expect(res.resolved.verdict).toBe('first_no_prior');
+  });
+
+  it('no reusable prior (absence only) → runs the cascade normally', async () => {
+    const ran = { count: 0 };
+    const tiers: Tiers = { tier0: spyTier(ran), tier1: spyTier(ran) };
+    const pe = summarizePriorEvidence([at({ method: 'gemini_verifier', result: 'none' })]);
+    const res = await resolve({ id: 'b' }, tiers, { now, priorEvidence: pe });
+    expect(ran.count).toBeGreaterThan(0);
+    expect(res.resolved.verdict).toBe('first_no_prior');
+  });
+
+  it('no priorEvidence at all → unchanged behaviour (runs cascade)', async () => {
+    const ran = { count: 0 };
+    const tiers: Tiers = { tier0: spyTier(ran), tier1: spyTier(ran) };
+    const res = await resolve({ id: 'b' }, tiers, { now });
+    expect(ran.count).toBeGreaterThan(0);
+  });
+
+  it('summarizePriorEvidence exposes foundAttemptId for the reuse path', () => {
+    const s = summarizePriorEvidence([
+      at({ attempt_id: 'keep-me', result: 'found', evidence_strength: 'strong',
+        priors: [{ english_title: 'Y', source_url: 'https://y.org' }] }),
+    ]);
+    expect(s.foundAttemptId).toBe('keep-me');
+    const none = summarizePriorEvidence([at({ result: 'none' })]);
+    expect(none.foundAttemptId).toBeNull();
+  });
+});


### PR DESCRIPTION
The re-pay fix for the durable-evidence lane (#2780). `resolve()` accepts `ctx.priorEvidence` (from `loadPriorEvidence`); on `reuse_prior` (a trustworthy URL-backed prior already in the pile) it short-circuits to `not_first` with **zero tier calls / zero spend**, pointing `best_attempt_id` at the reused attempt. `forceTier2` overrides (sampler keeps its fresh pass); no `priorEvidence` → unchanged. With 13,359 books now carrying durable evidence (backfill #2802), a rerun skips already-found priors instead of re-paying. Pure routing change — caller does the I/O. tsc clean; 12/12 tests. Closes #2803. Refs #2780.