### PR TITLE
fix(ui): map controls, ES toggle on deep pages, homepage auth, clean catalog languages

### DIFF
--- a/src/components/explore/BookMap.tsx
+++ b/src/components/explore/BookMap.tsx
@@ -61,11 +61,24 @@ export default function BookMap({ locations }: BookMapProps) {
   const [selected, setSelected] = useState<BookLocation | null>(null);
   const [filters, setFilters] = useState({
     types: new Set(['publication', 'author_birth', 'author_death', 'origin']),
-    minBooks: 1,
     yearFrom: 800,
     yearTo: 2025,
   });
+  // The year fields hold their own editable string so typing/clearing never
+  // snaps back to the default mid-edit (the old `Number(value) || 800` bug).
+  // Committed to `filters` (clamped) on blur or Enter.
+  const [yearFromInput, setYearFromInput] = useState('800');
+  const [yearToInput, setYearToInput] = useState('2025');
   const [zoom, setZoom] = useState(5);
+
+  const commitYear = useCallback((which: 'yearFrom' | 'yearTo', raw: string) => {
+    const n = parseInt(raw, 10);
+    const fallback = which === 'yearFrom' ? 800 : 2025;
+    const val = Number.isFinite(n) ? Math.min(2025, Math.max(800, n)) : fallback;
+    if (which === 'yearFrom') setYearFromInput(String(val));
+    else setYearToInput(String(val));
+    setFilters((f) => ({ ...f, [which]: val }));
+  }, []);
 
   // Filter by type
   const typeFiltered = useMemo(() => {
@@ -109,12 +122,12 @@ export default function BookMap({ locations }: BookMapProps) {
         if (!b.year) return true;
         return b.year >= filters.yearFrom && b.year <= filters.yearTo;
       });
-      if (yearFiltered.length < filters.minBooks) continue;
+      if (yearFiltered.length === 0) continue;
       result.push({ ...pin, books: yearFiltered, totalBooks: yearFiltered.length });
     }
 
     return result.sort((a, b) => b.totalBooks - a.totalBooks);
-  }, [typeFiltered, filters.minBooks, filters.yearFrom, filters.yearTo]);
+  }, [typeFiltered, filters.yearFrom, filters.yearTo]);
 
   // Initialize map
   useEffect(() => {
@@ -231,12 +244,16 @@ export default function BookMap({ locations }: BookMapProps) {
 
           <span className="w-px h-4" style={{ background: 'rgba(0,0,0,0.08)' }} />
 
-          {/* Year range */}
+          {/* Year range — type freely; applied on blur or Enter (no snap-back) */}
           <div className="flex items-center gap-1.5">
             <input
               type="number"
-              value={filters.yearFrom}
-              onChange={(e) => setFilters(f => ({ ...f, yearFrom: Number(e.target.value) || 800 }))}
+              inputMode="numeric"
+              value={yearFromInput}
+              onChange={(e) => setYearFromInput(e.target.value)}
+              onBlur={(e) => commitYear('yearFrom', e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+              aria-label="From year"
               className="w-16 rounded-md px-2 py-1 text-xs text-center"
               style={{ border: '1px solid rgba(0,0,0,0.08)', color: 'var(--text-secondary)', background: 'transparent' }}
               min={800} max={2025}
@@ -244,26 +261,17 @@ export default function BookMap({ locations }: BookMapProps) {
             <span className="text-xs" style={{ color: 'var(--text-muted)' }}>to</span>
             <input
               type="number"
-              value={filters.yearTo}
-              onChange={(e) => setFilters(f => ({ ...f, yearTo: Number(e.target.value) || 2025 }))}
+              inputMode="numeric"
+              value={yearToInput}
+              onChange={(e) => setYearToInput(e.target.value)}
+              onBlur={(e) => commitYear('yearTo', e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+              aria-label="To year"
               className="w-16 rounded-md px-2 py-1 text-xs text-center"
               style={{ border: '1px solid rgba(0,0,0,0.08)', color: 'var(--text-secondary)', background: 'transparent' }}
               min={800} max={2025}
             />
           </div>
-
-          <span className="w-px h-4 hidden sm:block" style={{ background: 'rgba(0,0,0,0.08)' }} />
-
-          <select
-            value={filters.minBooks}
-            onChange={(e) => setFilters((f) => ({ ...f, minBooks: Number(e.target.value) }))}
-            className="rounded-md px-2 py-1 text-xs"
-            style={{ border: '1px solid rgba(0,0,0,0.08)', color: 'var(--text-secondary)', background: 'transparent' }}
-          >
-            {[1, 2, 5, 10, 20, 50].map((n) => (
-              <option key={n} value={n}>{n === 1 ? 'All' : `${n}+`}</option>
-            ))}
-          </select>
         </div>
       </div>
 

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { signIn } from 'next-auth/react';
+import { isInAppBrowser } from '@/lib/in-app-browser';
 import { useStableSession } from '@/hooks/useStableSession';
 import { recordLoadingMetric } from '@/lib/analytics';
 import UnifiedSearch from '@/components/search/UnifiedSearch';
@@ -13,16 +14,26 @@ function HeroSignUp({ t }: { t: HomeStrings }) {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  // Google OAuth is blocked inside Instagram/Facebook/LinkedIn webviews
+  // (disallowed_useragent), so the button silently fails there. Detect it and
+  // steer the visitor to the email magic link, which always works.
+  const [inApp, setInApp] = useState(false);
+  useEffect(() => { setInApp(isInAppBrowser(navigator.userAgent)); }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!email) return;
     setLoading(true);
+    setError(false);
     try {
-      await signIn('email', { email, callbackUrl: '/', redirect: false });
-      setSent(true);
+      // Provider id is 'nodemailer' (next-auth v5 renamed Email→Nodemailer);
+      // the old 'email' id silently no-ops and faked a "check your email".
+      const result = await signIn('nodemailer', { email, callbackUrl: '/', redirect: false });
+      if (result?.error) setError(true);
+      else setSent(true);
     } catch {
-      // fall through
+      setError(true);
     } finally {
       setLoading(false);
     }
@@ -64,9 +75,13 @@ function HeroSignUp({ t }: { t: HomeStrings }) {
           {loading ? t.sending : t.join}
         </button>
       </form>
+      {error && (
+        <p className="mt-2 text-sm text-red-200">{t.emailError}</p>
+      )}
       <div className="flex items-center gap-4 mt-4">
         <button
           onClick={() => signIn('google', { callbackUrl: '/' })}
+          style={{ opacity: inApp ? 0.5 : 1 }}
           className="inline-flex items-center gap-2 text-sm text-white/60 hover:text-white/90 transition-colors"
         >
           <svg className="w-4 h-4" viewBox="0 0 24 24">
@@ -85,6 +100,9 @@ function HeroSignUp({ t }: { t: HomeStrings }) {
           {t.haveAccount}
         </Link>
       </div>
+      {inApp && (
+        <p className="mt-2 max-w-md text-xs text-white/50">{t.googleBlockedNote}</p>
+      )}
     </div>
   );
 }

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 import Logo from './Logo';
 import UserMenu from './UserMenu';
 import { Search, ChevronDown } from 'lucide-react';
-import { useLocale, localeHref, NAV_STRINGS, type NavStrings, type Locale } from '@/lib/i18n';
+import { useLocale, localeHref, hasLocalizedTwin, NAV_STRINGS, type NavStrings, type Locale } from '@/lib/i18n';
 
 interface NavLink {
   label: string;
@@ -73,11 +73,13 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
   const locale = homeLocale ?? pathnameLocale;
   const t = NAV_STRINGS[locale];
   const NAV_LINKS = buildNavLinks(t);
-  // The EN/ES toggle is shown sitewide (#2763): Spanish-speaking visitors lose
-  // all language control once they leave `/es`, and the funnel pages reach
-  // Instagram/webview users who have no browser translate button. EN always
-  // links to the canonical page (reader stays put); ES links to the `/es` twin
-  // when one exists, else the Spanish homepage front door (see localeHref).
+  // The EN/ES toggle shows only where a real Spanish twin exists (home, sign-in,
+  // support) — the thin-i18n bargain (#2763). On deep English-only pages the
+  // toggle is hidden, so clicking ES never bounces the reader to the `/es`
+  // homepage (deep pages rely on the browser's own translate instead).
+  // `homeLocale` is set on the statically-prerendered homepage, where pathname
+  // is null at build — treat that as localized so the toggle renders server-side.
+  const showLangToggle = homeLocale !== undefined || hasLocalizedTwin(pathname);
   const enHref = localeHref('en', pathname);
   const esHref = localeHref('es', pathname);
 
@@ -192,7 +194,8 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
             })}
           </nav>
 
-          {/* Language toggle — shown sitewide (#2763) */}
+          {/* Language toggle — only on pages with a real Spanish twin (#2763) */}
+          {showLangToggle && (
           <div className="flex items-center gap-1.5 text-xs font-medium tracking-wide" aria-label="Language">
             <Link
               href={enHref}
@@ -218,6 +221,7 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
               ES
             </Link>
           </div>
+          )}
 
           {/* Desktop search icon */}
           <Link

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -9,6 +9,7 @@
  */
 
 import { supabase, supabaseAdmin, sanitizeFilterValue } from '@/lib/supabase';
+import { isSingleRealLanguage } from '@/lib/language-canonical';
 
 /**
  * Canonical form of a category value: lowercase, trimmed, spaces → hyphens.
@@ -246,6 +247,11 @@ export async function getLanguageCounts(filter: {
   }
   return [...counts.entries()]
     .map(([lang, count]) => ({ lang, count }))
+    // Drop junk labels ("e") and multi-language "collab" labels ("Greek/Latin",
+    // "German-English"): keep only single real languages, whose raw label still
+    // matches the exact `eq('language', value)` filter in browseBooks. See
+    // src/lib/language-canonical.ts.
+    .filter(({ lang }) => isSingleRealLanguage(lang))
     .sort((a, b) => b.count - a.count);
 }
 

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -26,6 +26,8 @@ export interface HomeStrings {
   checkEmail: string;
   differentEmail: string;
   google: string;
+  googleBlockedNote: string;
+  emailError: string;
   haveAccount: string;
   explore: string;
   langEnglish: string;
@@ -117,6 +119,8 @@ const en: HomeStrings = {
   checkEmail: 'Check your email — we sent a sign-in link to',
   differentEmail: 'Use a different email',
   google: 'Or continue with Google',
+  googleBlockedNote: 'Google sign-in is usually blocked in in-app browsers — use email above, or open this page in Safari/Chrome.',
+  emailError: 'Could not send the sign-in link. Please try again.',
   haveAccount: 'Already have an account?',
   explore: 'Explore the collection',
   langEnglish: 'English',
@@ -207,6 +211,8 @@ const es: HomeStrings = {
   checkEmail: 'Revisa tu correo — enviamos un enlace de acceso a',
   differentEmail: 'Usar otro correo',
   google: 'O continúa con Google',
+  googleBlockedNote: 'El acceso con Google suele estar bloqueado en navegadores internos — usa el correo de arriba, o abre esta página en Safari/Chrome.',
+  emailError: 'No se pudo enviar el enlace de acceso. Inténtalo de nuevo.',
   haveAccount: '¿Ya tienes una cuenta?',
   explore: 'Explora la colección',
   langEnglish: 'English',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -43,6 +43,16 @@ export function canonicalPath(pathname: string | null | undefined): string {
 }
 
 /**
+ * Whether the current page has a real Spanish twin (i.e. switching to ES keeps
+ * the reader on the same page rather than dumping them on the `/es` homepage).
+ * The header uses this to HIDE the EN/ES toggle on deep, English-only pages —
+ * the thin-i18n bargain — so clicking ES never bounces you to the front page.
+ */
+export function hasLocalizedTwin(pathname: string | null | undefined): boolean {
+  return LOCALIZED_PATHS.has(canonicalPath(pathname));
+}
+
+/**
  * Href for switching the current page to `target` locale.
  * - English: the canonical page (any `/es` prefix dropped) so the reader stays put.
  * - Spanish: the `/es` twin when one exists, else the Spanish homepage (`/es`).

--- a/src/lib/language-canonical.ts
+++ b/src/lib/language-canonical.ts
@@ -1,0 +1,109 @@
+// TypeScript twin of scripts/lib/language-count.mjs — keep the two in sync.
+//
+// The `books.language` field is free-text and messy: it mixes compound labels
+// ("Hebrew and Judeo-Arabic", "Greek/Latin", "Latin-German"), script/stage
+// variants ("Geez"/"Ge'ez", "Ancient Greek", "Ottoman Turkish"), and junk
+// tokens ("auto-detect", "Multiple", "e"). A naive distinct() over-counts and
+// surfaces non-languages in the catalog language filter.
+//
+// Two uses here:
+//  - isSingleRealLanguage(label): gate for the catalog language dropdown —
+//    keeps a label only when it resolves to exactly ONE real language, so the
+//    raw value still works with the exact `eq('language', value)` filter while
+//    junk ("e") and multi-language "collab" labels ("Greek/Latin") drop out.
+//  - countDistinctLanguages(labels): the honest distinct-language count for
+//    corpus stats (splits compounds, folds variants, drops junk).
+
+// Tokens that are not languages at all.
+const JUNK = new Set<string>([
+  'auto-detect', 'auto', 'detect', 'multiple', 'mul', 'lit', 'undetermined',
+  'unknown', 'various', 'various caucasian', 'n/a', 'zxx', 'roa', '',
+]);
+
+// Variant / stage / script labels folded into one canonical language.
+const VARIANTS: Record<string, string> = {
+  "ge'ez": 'geez', 'ethiopic': 'geez',
+  'egyptian hieroglyphs': 'egyptian', 'demotic': 'egyptian',
+  'maya hieroglyphs': 'maya', 'yucatec maya': 'maya', "k'iche' maya": 'maya', "k'iche'": 'maya', 'cakchiquel': 'maya',
+  'classical armenian': 'armenian',
+  'samaritan hebrew': 'hebrew',
+  'classical chinese': 'chinese', 'literary chinese': 'chinese',
+  'middle english': 'english', 'old english': 'english',
+  'middle french': 'french', 'old french': 'french', 'anglo-norman': 'french',
+  'middle high german': 'german', 'low german': 'german',
+  'old javanese': 'javanese',
+  'ancient greek': 'greek',
+  'old spanish': 'spanish',
+  'scottish gaelic': 'gaelic',
+  'old irish': 'irish',
+  'ottoman turkish': 'turkish', 'chagatai turkish': 'turkish',
+  'church slavonic': 'slavonic',
+};
+
+// Hyphenated names that are a SINGLE language — never split these on the hyphen.
+const KEEP_HYPHEN = new Set<string>([
+  'judeo-arabic', 'judeo-greek', 'judeo-italian', 'judeo-occitan', 'judeo-persian',
+  'anglo-norman', 'anglo-saxon',
+]);
+
+function normalizeAtom(raw: string): string {
+  let x = String(raw).trim().toLowerCase();
+  x = x.replace(/\(.*?\)/g, '');                    // drop parentheticals
+  x = x.replace(/\s+with\s+.*$/, '');               // "hebrew with marginal glosses…" -> hebrew
+  x = x.replace(/\s+in\s+[a-z' -]+script.*$/, '');  // "italian in italian script" -> italian
+  x = x.replace(/[.)\]]+$/, '').trim();
+  return VARIANTS[x] || x;
+}
+
+/** Split one raw label into its atomic, normalized languages. */
+export function atomsOfLabel(label: string | null | undefined): string[] {
+  if (!label) return [];
+  const out: string[] = [];
+  // Strong separators first: / ; , & and the word "and".
+  for (let seg of String(label).split(/\s*(?:[;,/&]|\band\b)\s*/i)) {
+    seg = seg.trim();
+    if (!seg) continue;
+    const lower = seg.toLowerCase();
+    if (lower.includes('-') && !KEEP_HYPHEN.has(lower)) {
+      for (const piece of lower.split('-')) {
+        const a = normalizeAtom(piece);
+        if (a) out.push(a);
+      }
+      continue;
+    }
+    const a = normalizeAtom(seg);
+    if (a) out.push(a);
+  }
+  return out;
+}
+
+/** A normalized atom that is a real, nameable language (not junk/too short). */
+function isRealAtom(atom: string): boolean {
+  return !!atom && atom.length >= 2 && !JUNK.has(atom) && !atom.startsWith('multiple');
+}
+
+/**
+ * True when `label` resolves to exactly ONE real language. Used to filter the
+ * catalog language dropdown: single real languages keep their raw label (so the
+ * exact-match filter still works), while junk ("e") and multi-language "collab"
+ * labels ("Greek/Latin", "German-English", "Judeo-Arabic and Hebrew") drop out.
+ */
+export function isSingleRealLanguage(label: string | null | undefined): boolean {
+  return atomsOfLabel(label).filter(isRealAtom).length === 1;
+}
+
+/** The set of distinct real languages across raw labels (compounds split out). */
+export function distinctLanguageSet(rawLabels: Array<string | null | undefined>): Set<string> {
+  const set = new Set<string>();
+  for (const label of rawLabels) {
+    for (const atom of atomsOfLabel(label)) {
+      if (isRealAtom(atom)) set.add(atom);
+    }
+  }
+  return set;
+}
+
+/** Honest distinct-language count for corpus stats. */
+export function countDistinctLanguages(rawLabels: Array<string | null | undefined>): number {
+  return distinctLanguageSet(rawLabels).size;
+}


### PR DESCRIPTION
Addresses a batch of UI issues Derek caught on mobile.

## Map (`/explore/map`)
- **Date-range field no longer "buggy".** The year inputs used `Number(value) || 800`, so clearing the field to retype snapped it back instantly (painful on mobile). They now hold an editable string and commit a clamped value on blur/Enter.
- **Removed the cryptic `+2/+5/+10…+50` dropdown.** It was a min-books-per-city filter but read as "50 more what — books? cities? years?". Dropped it; the automatic zoom-based density (kept) handles decluttering without a confusing control.
- Multilingual basemap labels ("North Sea / Nordsee / …") were left as-is per Derek — they come from the CARTO/OSM tiles, and keeping place labels aids orientation.

## Language toggle (sitewide header)
- **Hide the EN/ES toggle on pages with no Spanish twin.** Clicking ES on the map (or any deep page) used to bounce the reader to the `/es` homepage. Now the toggle only shows on localized pages (home, sign-in, support) — the thin-i18n model (deep pages stay English + browser-translate). New `hasLocalizedTwin()` in `src/lib/i18n.ts`.

## Homepage auth (`HeroSection`)
- **Email "Join" was silently broken.** It called `signIn('email', …)` but the next-auth v5 provider id is `nodemailer` (Email→Nodemailer rename), so it faked a "check your email" without sending. Fixed the id + surface a real error.
- **"Continue with Google" does nothing in in-app browsers.** Google blocks OAuth in Instagram/LinkedIn/Facebook webviews (`disallowed_useragent`) — the likely report. The homepage hero had none of the in-app handling the `/auth/signin` page already has (#2763). Now it detects webviews, dims Google, and steers to the email magic link. (Works normally in real Safari/Chrome.)

## Catalog language filter (`/catalog`)
- **Dropped junk + "collab" entries.** The dropdown showed `e (8)`, `Greek/Latin`, `German-English`, `Judeo-Arabic and Hebrew`, etc. Now keeps only single real languages (raw label preserved so the exact `eq('language', …)` filter still works). New `src/lib/language-canonical.ts` is a TS twin of `scripts/lib/language-count.mjs`.
- **Accurate count:** live data has **211 raw language strings → 113 clean dropdown entries**; the honest distinct-language count is **103** (the homepage stat already uses this via `countDistinctLanguages`, so "100+ languages" is correct).

## Out of scope
- No basemap swap (Derek chose to keep labels).
- No `/es/explore/mapa` (kept thin-i18n; toggle hidden instead).
- Variant labels like "Ancient Greek" / "Ottoman Turkish" are intentionally kept as distinct dropdown entries (a rare-texts library wants that granularity); only junk and multi-language compounds are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)