### PR TITLE
feat(ft): canonical attemptFamily() for cross-family independence (#2805)

### DIFF
--- a/src/lib/first-translation/prior-evidence.ts
+++ b/src/lib/first-translation/prior-evidence.ts
@@ -47,6 +47,15 @@ export interface PriorEvidenceSummary {
    */
   independentAbsenceMethods: number;
   /**
+   * Distinct evidence FAMILIES that independently returned "none" (see
+   * {@link attemptFamily}). This is the honest independence signal — it collapses
+   * correlated same-model-family checks to one vote. Use THIS (not
+   * independentAbsenceMethods) to weight an absence claim's strength.
+   */
+  independentAbsenceFamilies: number;
+  /** Distinct families that returned "found" — cross-family agreement on a prior. */
+  foundFamilies: number;
+  /**
    * What a new approach should do given the pile:
    *  - 'reuse_prior'      a trustworthy prior already exists → don't re-search; demote.
    *  - 'absence_strong'   ≥2 independent approaches found nothing → a fresh pass adds little.
@@ -54,6 +63,40 @@ export interface PriorEvidenceSummary {
    *  - 'unverified'       nothing on record → full verification warranted.
    */
   recommendation: 'reuse_prior' | 'absence_strong' | 'absence_weak' | 'unverified';
+}
+
+/**
+ * Evidence *family* — for cross-family independence (#2805). Independence must be
+ * by family, NOT raw `method`: `method='gemini_verifier'` is overloaded (it tags
+ * the real grounded adjudicator AND every backfilled legacy store), and two
+ * outputs of the same model family are correlated, not independent votes.
+ *
+ *  - 'model_knowledge'  unverified model belief: ai_metadata (legacy_ai),
+ *                       llm guesses (legacy_llm), Gemini classification (legacy_tc).
+ *                       All Gemini-family → ONE vote however many tags.
+ *  - 'catalog'          catalog/registry lookup: translation_verification tool
+ *                       sweep (legacy_tv), ft_reverify_proposal catalog_counts
+ *                       (legacy_rp — queries the SAME OL/GB/IA catalogs, so it is
+ *                       correlated WITH this family, not its own), and the real
+ *                       grounded gemini adjudicator (gemini_verifier w/ queries[]).
+ *  - 'agent'            independent cross-model agent (Claude Tier-2 = tier2_agent).
+ *  - 'human'            human specialist.
+ *  - 'unknown'          unclassifiable.
+ */
+export type AttemptFamily = 'model_knowledge' | 'catalog' | 'agent' | 'human' | 'unknown';
+
+export function attemptFamily(a: FirstTranslationAttempt): AttemptFamily {
+  if (a.method === 'tier2_agent') return 'agent';
+  if (a.method === 'human') return 'human';
+  const notes = a.notes ?? '';
+  if (/^\[legacy_(ai|llm|tc)\]/.test(notes)) return 'model_knowledge';
+  if (/^\[legacy_(tv|rp)\]/.test(notes)) return 'catalog';
+  if (a.method === 'gemini_verifier') {
+    // Real grounded adjudicator (has queries) → catalog; bare/legacy → model_knowledge.
+    return (a.queries?.length ?? 0) > 0 ? 'catalog' : 'model_knowledge';
+  }
+  if (a.method === 'tier0_linked' || a.method === 'tier1_catalog') return 'catalog';
+  return 'unknown';
 }
 
 const hasUrl = (p?: PriorTranslation): boolean => !!p?.source_url && /^https?:\/\//.test(p.source_url);
@@ -77,6 +120,13 @@ export function summarizePriorEvidence(
   const independentAbsenceMethods = new Set(
     attempts.filter((a) => a.result === 'none').map((a) => a.method),
   ).size;
+  // The honest version: distinct FAMILIES (correlated same-model checks collapse).
+  const independentAbsenceFamilies = new Set(
+    attempts.filter((a) => a.result === 'none').map((a) => attemptFamily(a)),
+  ).size;
+  const foundFamilies = new Set(
+    attempts.filter((a) => a.result === 'found').map((a) => attemptFamily(a)),
+  ).size;
 
   let recommendation: PriorEvidenceSummary['recommendation'];
   if (priorFound) recommendation = 'reuse_prior';
@@ -89,6 +139,8 @@ export function summarizePriorEvidence(
     priorFound,
     foundPrior,
     foundAttemptId: priorFound ? (strongestFound?.attempt_id ?? null) : null,
+    independentAbsenceFamilies,
+    foundFamilies,
     searchedSources,
     searchedQueries,
     independentAbsenceMethods,

--- a/tests/unit/first-translation-attempt-family.test.ts
+++ b/tests/unit/first-translation-attempt-family.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { attemptFamily, summarizePriorEvidence } from '@/lib/first-translation/prior-evidence';
+import type { FirstTranslationAttempt } from '@/lib/first-translation/attempt-log';
+
+const at = (over: Partial<FirstTranslationAttempt>): FirstTranslationAttempt => ({
+  attempt_id: 'a', book_id: 'b', date: '2026-06-27T00:00:00Z', method: 'gemini_verifier',
+  match_key: 'none', sources_checked: [], result: 'none', evidence_strength: 'weak', ...over,
+});
+
+describe('attemptFamily — independence by family, not raw method', () => {
+  it('buckets the legacy backfill tags correctly', () => {
+    expect(attemptFamily(at({ notes: '[legacy_ai] status=uncertain' }))).toBe('model_knowledge');
+    expect(attemptFamily(at({ notes: '[legacy_llm] unverified model knowledge' }))).toBe('model_knowledge');
+    expect(attemptFamily(at({ notes: '[legacy_tc] classification=previously_translated' }))).toBe('model_knowledge');
+    expect(attemptFamily(at({ notes: '[legacy_tv] disposition=confirmed_first' }))).toBe('catalog');
+    expect(attemptFamily(at({ notes: '[legacy_rp] verdict=not_first' }))).toBe('catalog');
+  });
+
+  it('disambiguates overloaded gemini_verifier by queries[]', () => {
+    expect(attemptFamily(at({ method: 'gemini_verifier', queries: ['real search'] }))).toBe('catalog');
+    expect(attemptFamily(at({ method: 'gemini_verifier', queries: [] }))).toBe('model_knowledge');
+  });
+
+  it('agent + human are their own families', () => {
+    expect(attemptFamily(at({ method: 'tier2_agent' }))).toBe('agent');
+    expect(attemptFamily(at({ method: 'human' }))).toBe('human');
+  });
+
+  it('three same-model-family absences = ONE independent family (no false confidence)', () => {
+    const s = summarizePriorEvidence([
+      at({ notes: '[legacy_ai] x' }), at({ notes: '[legacy_llm] y' }), at({ notes: '[legacy_tc] z' }),
+    ]);
+    expect(s.independentAbsenceMethods).toBe(1); // all method=gemini_verifier
+    expect(s.independentAbsenceFamilies).toBe(1); // all model_knowledge — correctly ONE
+  });
+
+  it('catalog + agent absences = TWO independent families (real cross-family signal)', () => {
+    const s = summarizePriorEvidence([
+      at({ notes: '[legacy_tv] x' }), at({ method: 'tier2_agent', result: 'none' }),
+    ]);
+    expect(s.independentAbsenceFamilies).toBe(2);
+  });
+
+  it('foundFamilies counts cross-family agreement on a prior', () => {
+    const s = summarizePriorEvidence([
+      at({ notes: '[legacy_tc] x', result: 'found', priors: [{ english_title: 'T' }] }),
+      at({ method: 'tier2_agent', result: 'found', evidence_strength: 'strong', priors: [{ english_title: 'T', source_url: 'https://x.org' }] }),
+    ]);
+    expect(s.foundFamilies).toBe(2); // model_knowledge + agent agree
+  });
+});


### PR DESCRIPTION
Answers the #2805 correlated-error question: independence by FAMILY, not raw method (gemini_verifier is overloaded across real search + 5 backfilled legacy stores). `attemptFamily()` → model_knowledge | catalog | agent | human | unknown; `summarizePriorEvidence` gains independentAbsenceFamilies + foundFamilies. Collapses the three Gemini stores (ai/llm/tc) to one vote; legacy_rp→catalog (same OL/GB/IA catalogs = correlated). Shared helper so resolve.ts and the panel don't diverge. tsc clean, 18/18 tests. Refs #2805 / #2780.