### PR TITLE
perf(map): lazy-load per-city books (7.1MB → 0.6MB initial payload)

### DIFF
--- a/src/app/api/explore/map/city/route.ts
+++ b/src/app/api/explore/map/city/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+
+// Lazy book list for a single map city. The map page ships only lightweight
+// per-city marker data (~0.4 MB); the full book list for the clicked city is
+// fetched here on demand, so the initial payload stays small.
+//
+// Source of truth is the same precomputed system_config.map_data cache the page
+// reads. We build a city index once per warm instance (the doc is large), then
+// serve slices filtered by the active role toggles and year range.
+
+export const dynamic = 'force-dynamic';
+
+interface RawBook {
+  id: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  year: number | null;
+  slug: string;
+}
+interface RawLoc {
+  city: string;
+  country: string | null;
+  type: string;
+  books: RawBook[];
+}
+
+type CityIndex = Map<string, RawLoc[]>;
+let indexPromise: Promise<CityIndex> | null = null;
+
+async function buildIndex(): Promise<CityIndex> {
+  const db = await getReadDb();
+  const doc = await db
+    .collection('system_config')
+    .findOne({ _id: 'map_data' as never }, { maxTimeMS: 15000 });
+  const locations: RawLoc[] = (doc?.data?.locations as RawLoc[]) || [];
+  const idx: CityIndex = new Map();
+  for (const loc of locations) {
+    const key = `${loc.city}|${loc.country || ''}`;
+    const arr = idx.get(key);
+    if (arr) arr.push(loc);
+    else idx.set(key, [loc]);
+  }
+  return idx;
+}
+
+function getIndex(): Promise<CityIndex> {
+  if (!indexPromise) {
+    // Cache the build; on failure clear it so the next request retries.
+    indexPromise = buildIndex().catch((e) => {
+      indexPromise = null;
+      throw e;
+    });
+  }
+  return indexPromise;
+}
+
+export async function GET(req: NextRequest) {
+  const sp = req.nextUrl.searchParams;
+  const city = sp.get('city');
+  if (!city) return NextResponse.json({ books: [] });
+
+  const country = sp.get('country') || '';
+  const from = Number(sp.get('from')) || 0;
+  const to = Number(sp.get('to')) || 9999;
+  const typesParam = sp.get('types');
+  const types = typesParam ? new Set(typesParam.split(',').filter(Boolean)) : null;
+
+  let idx: CityIndex;
+  try {
+    idx = await getIndex();
+  } catch {
+    return NextResponse.json({ books: [] }, { status: 200 });
+  }
+
+  const groups = idx.get(`${city}|${country}`) || [];
+  const seen = new Set<string>();
+  const books: RawBook[] = [];
+  for (const g of groups) {
+    if (types && !types.has(g.type)) continue;
+    for (const b of g.books || []) {
+      if (seen.has(b.id)) continue;
+      // Undated books always show (matches the marker count); dated ones are
+      // gated by the active year range.
+      if (b.year != null && (b.year < from || b.year > to)) continue;
+      seen.add(b.id);
+      books.push(b);
+      if (books.length >= 200) break;
+    }
+    if (books.length >= 200) break;
+  }
+
+  // Stable reading order: by year ascending, undated last.
+  books.sort((a, b) => (a.year ?? 99999) - (b.year ?? 99999));
+
+  return NextResponse.json(
+    { books },
+    { headers: { 'Cache-Control': 'public, max-age=300, s-maxage=300' } },
+  );
+}

--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -3,7 +3,66 @@ import { getReadDb } from '@/lib/mongodb';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import ExploreTabBar from '@/components/explore/ExploreTabBar';
 import BookMapLoader from '@/components/explore/BookMapLoader';
-import type { BookLocation } from '@/components/explore/BookMap';
+import type { BookLocation, LocationType } from '@/components/explore/BookMap';
+
+/**
+ * The shape stored in system_config.map_data (and the live-fallback build):
+ * each per-(city,type) group carries its full book list. The page strips these
+ * down to the lightweight {years, undated} the client needs and lazy-loads the
+ * full lists per city — keeping the initial payload ~350 KB instead of ~7 MB.
+ */
+interface RawLocation {
+  city: string;
+  country: string | null;
+  lat: number;
+  lng: number;
+  type: LocationType;
+  books: Array<{ id: string; title: string; display_title?: string; author: string; year: number | null; slug: string }>;
+}
+interface RawMapData {
+  locations: RawLocation[];
+  stats: { total_books: number; total_locations: number; by_type: Record<string, number> };
+}
+
+// Role bitmask — mirrors TYPE_BIT in BookMap.tsx (kept local so this server
+// component doesn't import from the 'use client' module).
+const TYPE_BIT: Record<string, number> = { publication: 1, author_birth: 2, author_death: 4, origin: 8 };
+
+/**
+ * Collapse the per-(city,type) cache groups into one lightweight record per city.
+ * Books are deduped by id across roles (OR-ing their role bits) and stripped to
+ * {y: year, m: role-mask} — no titles/authors/slugs/ids ship to the client; those
+ * load lazily per city from /api/explore/map/city.
+ */
+function slimLocations(locations: RawLocation[]): BookLocation[] {
+  const byCity = new Map<string, {
+    city: string; country: string | null; lat: number; lng: number;
+    books: Map<string, { y: number | null; m: number }>;
+  }>();
+
+  for (const loc of locations) {
+    const key = `${loc.city}|${loc.country || ''}`;
+    let entry = byCity.get(key);
+    if (!entry) {
+      entry = { city: loc.city, country: loc.country, lat: loc.lat, lng: loc.lng, books: new Map() };
+      byCity.set(key, entry);
+    }
+    // Prefer the publication group's coords for the pin (matches prior behavior).
+    if (loc.type === 'publication') { entry.lat = loc.lat; entry.lng = loc.lng; }
+    const bit = TYPE_BIT[loc.type] || 0;
+    for (const b of loc.books || []) {
+      const ex = entry.books.get(b.id);
+      if (ex) ex.m |= bit;
+      else entry.books.set(b.id, { y: typeof b.year === 'number' ? b.year : null, m: bit });
+    }
+  }
+
+  const out: BookLocation[] = [];
+  for (const e of byCity.values()) {
+    out.push({ city: e.city, country: e.country, lat: e.lat, lng: e.lng, books: [...e.books.values()] });
+  }
+  return out;
+}
 
 // Daily ISR so the page re-reads the system_config.map_data cache that the
 // Hetzner cron rebuilds at 05:45 — `revalidate = false` froze the rendered
@@ -41,7 +100,7 @@ export const metadata: Metadata = {
   },
 };
 
-async function fetchMapData() {
+async function fetchMapData(): Promise<RawMapData> {
   const db = await getReadDb();
 
   // Read pre-computed map data from system_config (fast single-doc read)
@@ -50,10 +109,7 @@ async function fetchMapData() {
     .findOne({ _id: 'map_data' as any }, { maxTimeMS: 10000 });
 
   if (cached?.data) {
-    return cached.data as {
-      locations: BookLocation[];
-      stats: { total_books: number; total_locations: number; by_type: Record<string, number> };
-    };
+    return cached.data as RawMapData;
   }
 
   // Fallback: compute live (slow but works if cache is empty)
@@ -68,7 +124,7 @@ async function fetchMapData() {
     )
     .toArray();
 
-  const groups = new Map<string, BookLocation>();
+  const groups = new Map<string, RawLocation>();
   const byType: Record<string, number> = {};
   let totalBooks = 0;
 
@@ -85,7 +141,7 @@ async function fetchMapData() {
       if (!groups.has(key)) {
         groups.set(key, {
           city: loc.city, country: loc.country, lat: loc.lat, lng: loc.lng,
-          type: loc.type as BookLocation['type'], books: [],
+          type: loc.type as LocationType, books: [],
         });
       }
 
@@ -115,6 +171,7 @@ async function fetchMapData() {
 export default async function MapPage() {
   try {
     const data = await fetchMapData();
+    const locations = slimLocations(data.locations);
     const locationCount = data.stats.total_locations;
     return (
       <ContentPageLayout
@@ -131,7 +188,7 @@ export default async function MapPage() {
         maxWidth="full"
         noPadding
       >
-        <BookMapLoader locations={data.locations} stats={data.stats} />
+        <BookMapLoader locations={locations} stats={data.stats} />
       </ContentPageLayout>
     );
   } catch (err) {

--- a/src/components/explore/BookMap.tsx
+++ b/src/components/explore/BookMap.tsx
@@ -4,20 +4,45 @@ import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
+export type LocationType = 'publication' | 'author_birth' | 'author_death' | 'origin';
+
+// Type bitmask — a book can have several roles in the same city (published here
+// AND author born here). Storing the roles as bits lets the client filter by the
+// active type toggles and still count each book once.
+export const TYPE_BIT: Record<LocationType, number> = {
+  publication: 1, author_birth: 2, author_death: 4, origin: 8,
+};
+const TYPE_BY_PRIORITY: LocationType[] = ['publication', 'author_birth', 'author_death', 'origin'];
+
+/**
+ * Lightweight per-city record shipped to the client. To keep the initial payload
+ * small (~0.4 MB vs the old ~7 MB), each book is just its year (`y`, null if
+ * undated) and a role bitmask (`m`); the full book list loads lazily from
+ * /api/explore/map/city on click. Books are already deduped per city server-side.
+ */
 export interface BookLocation {
   city: string;
   country: string | null;
   lat: number;
   lng: number;
-  type: 'publication' | 'author_birth' | 'author_death' | 'origin';
-  books: Array<{
-    id: string;
-    title: string;
-    display_title?: string;
-    author: string;
-    year: number | null;
-    slug: string;
-  }>;
+  books: Array<{ y: number | null; m: number }>;
+}
+
+/** Full book record, fetched lazily for the clicked city's sidebar. */
+export interface CityBook {
+  id: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  year: number | null;
+  slug: string;
+}
+
+interface SelectedCity {
+  city: string;
+  country: string | null;
+  type: LocationType;
+  count: number;
 }
 
 interface BookMapProps {
@@ -58,7 +83,9 @@ export default function BookMap({ locations }: BookMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const markersRef = useRef<L.LayerGroup | null>(null);
 
-  const [selected, setSelected] = useState<BookLocation | null>(null);
+  const [selected, setSelected] = useState<SelectedCity | null>(null);
+  const [cityBooks, setCityBooks] = useState<CityBook[]>([]);
+  const [booksLoading, setBooksLoading] = useState(false);
   const [filters, setFilters] = useState({
     types: new Set(['publication', 'author_birth', 'author_death', 'origin']),
     yearFrom: 800,
@@ -80,54 +107,41 @@ export default function BookMap({ locations }: BookMapProps) {
     setFilters((f) => ({ ...f, [which]: val }));
   }, []);
 
-  // Filter by type
-  const typeFiltered = useMemo(() => {
-    return locations.filter((loc) => filters.types.has(loc.type));
-  }, [locations, filters.types]);
+  // Bitmask of the currently-active type toggles.
+  const selectedMask = useMemo(() => {
+    let m = 0;
+    for (const t of filters.types) m |= TYPE_BIT[t as LocationType] || 0;
+    return m;
+  }, [filters.types]);
 
-  // Merge by city NAME (not coords) to fix duplicate pin issue
+  // Per-city pins: count books whose role is active and whose year is in range
+  // (undated always counts), and derive the marker's dominant role. Books are
+  // already deduped per city server-side, so each is counted once.
   const cityPins = useMemo(() => {
-    const byCity = new Map<string, {
+    const result: Array<{
       city: string; country: string | null; lat: number; lng: number;
-      books: BookLocation['books']; types: Set<string>; totalBooks: number;
-    }>();
+      totalBooks: number; dominantType: LocationType; roles: LocationType[];
+    }> = [];
 
-    for (const loc of typeFiltered) {
-      const key = `${loc.city}|${loc.country || ''}`;
-      const existing = byCity.get(key);
-      if (existing) {
-        const existingIds = new Set(existing.books.map(b => b.id));
-        for (const b of loc.books) {
-          if (!existingIds.has(b.id) && existing.books.length < 200) {
-            existing.books.push(b);
-          }
-        }
-        existing.types.add(loc.type);
-        existing.totalBooks += loc.books.length;
-        if (loc.type === 'publication') {
-          existing.lat = loc.lat;
-          existing.lng = loc.lng;
-        }
-      } else {
-        byCity.set(key, {
-          city: loc.city, country: loc.country, lat: loc.lat, lng: loc.lng,
-          books: [...loc.books], types: new Set([loc.type]), totalBooks: loc.books.length,
-        });
+    for (const loc of locations) {
+      let count = 0;
+      let orMask = 0;
+      for (const b of loc.books) {
+        if (!(b.m & selectedMask)) continue;
+        if (b.y != null && (b.y < filters.yearFrom || b.y > filters.yearTo)) continue;
+        count++;
+        orMask |= b.m & selectedMask;
       }
-    }
-
-    const result: Array<typeof byCity extends Map<string, infer V> ? V : never> = [];
-    for (const pin of byCity.values()) {
-      const yearFiltered = pin.books.filter(b => {
-        if (!b.year) return true;
-        return b.year >= filters.yearFrom && b.year <= filters.yearTo;
+      if (count === 0) continue;
+      const roles = TYPE_BY_PRIORITY.filter((t) => orMask & TYPE_BIT[t]);
+      result.push({
+        city: loc.city, country: loc.country, lat: loc.lat, lng: loc.lng,
+        totalBooks: count, dominantType: roles[0] ?? 'origin', roles,
       });
-      if (yearFiltered.length === 0) continue;
-      result.push({ ...pin, books: yearFiltered, totalBooks: yearFiltered.length });
     }
 
     return result.sort((a, b) => b.totalBooks - a.totalBooks);
-  }, [typeFiltered, filters.yearFrom, filters.yearTo]);
+  }, [locations, selectedMask, filters.yearFrom, filters.yearTo]);
 
   // Initialize map
   useEffect(() => {
@@ -147,7 +161,29 @@ export default function BookMap({ locations }: BookMapProps) {
     return () => { map.remove(); mapRef.current = null; markersRef.current = null; };
   }, []);
 
-  const handleSelect = useCallback((loc: BookLocation) => setSelected(loc), []);
+  const handleSelect = useCallback((city: SelectedCity) => setSelected(city), []);
+
+  // Lazy-load the clicked city's full book list (kept out of the initial payload).
+  // Refetches when the year range or active types change while a city is open,
+  // so the sidebar list stays consistent with the markers.
+  useEffect(() => {
+    if (!selected) { setCityBooks([]); setBooksLoading(false); return; }
+    const ctrl = new AbortController();
+    setBooksLoading(true);
+    const params = new URLSearchParams({
+      city: selected.city,
+      country: selected.country ?? '',
+      from: String(filters.yearFrom),
+      to: String(filters.yearTo),
+      types: [...filters.types].join(','),
+    });
+    fetch(`/api/explore/map/city?${params.toString()}`, { signal: ctrl.signal })
+      .then((r) => (r.ok ? r.json() : { books: [] }))
+      .then((d) => setCityBooks(d.books || []))
+      .catch(() => { if (!ctrl.signal.aborted) setCityBooks([]); })
+      .finally(() => { if (!ctrl.signal.aborted) setBooksLoading(false); });
+    return () => ctrl.abort();
+  }, [selected, filters.types, filters.yearFrom, filters.yearTo]);
 
   // Render city pins
   useEffect(() => {
@@ -160,15 +196,13 @@ export default function BookMap({ locations }: BookMapProps) {
 
     for (const pin of cityPins) {
       if (pin.totalBooks < minBooksForZoom) continue;
-      const dominantType = pin.types.has('publication') ? 'publication'
-        : pin.types.has('author_birth') ? 'author_birth'
-        : pin.types.has('author_death') ? 'author_death' : 'origin';
+      const dominantType = pin.dominantType;
 
       const marker = L.marker([pin.lat, pin.lng], {
         icon: createLocationIcon(dominantType, pin.totalBooks),
       });
 
-      const typeLabels = [...pin.types].map(t => TYPE_CONFIG[t]?.label || t).join(' · ');
+      const typeLabels = pin.roles.map(t => TYPE_CONFIG[t]?.label || t).join(' · ');
       marker.bindTooltip(
         `<strong>${pin.city}</strong>${pin.country ? `<br/><span style="opacity:0.7">${pin.country}</span>` : ''}<br/>${pin.totalBooks} book${pin.totalBooks !== 1 ? 's' : ''}<br/><span style="opacity:0.5;font-size:10px">${typeLabels}</span>`,
         { direction: 'top', offset: [0, -6], className: 'book-tooltip' }
@@ -177,8 +211,7 @@ export default function BookMap({ locations }: BookMapProps) {
       marker.on('click', () => {
         handleSelect({
           city: pin.city, country: pin.country,
-          lat: pin.lat, lng: pin.lng, type: dominantType,
-          books: pin.books.slice(0, 200),
+          type: dominantType, count: pin.totalBooks,
         });
       });
       layerGroup.addLayer(marker);
@@ -308,24 +341,30 @@ export default function BookMap({ locations }: BookMapProps) {
                 </button>
               </div>
               <p className="text-xs mt-2" style={{ color: 'var(--text-muted)' }}>
-                {selected.books.length} book{selected.books.length !== 1 ? 's' : ''}
+                {selected.count} book{selected.count !== 1 ? 's' : ''}
               </p>
             </div>
 
             <div className="px-5 py-3 space-y-0.5">
-              {selected.books.slice(0, 50).map((book, i) => (
-                <a key={i} href={`/book/${book.slug || book.id}`} className="block px-2.5 py-2 -mx-2.5 rounded-lg hover:bg-black/[0.03] transition-colors">
-                  <div className="text-[13px] leading-snug font-medium" style={{ color: 'var(--text-primary)' }}>
-                    {(() => { const t = book.display_title || book.title; return t.length > 65 ? t.substring(0, 65) + '\u2026' : t; })()}
-                  </div>
-                  <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
-                    {book.author.length > 40 ? book.author.substring(0, 40) + '\u2026' : book.author}
-                    {book.year ? `, ${book.year}` : ''}
-                  </div>
-                </a>
-              ))}
-              {selected.books.length > 50 && (
-                <p className="text-[11px] px-2.5 py-2" style={{ color: 'var(--text-muted)' }}>and {selected.books.length - 50} more</p>
+              {booksLoading && cityBooks.length === 0 ? (
+                <p className="text-[11px] px-2.5 py-2" style={{ color: 'var(--text-muted)' }}>Loading\u2026</p>
+              ) : (
+                <>
+                  {cityBooks.slice(0, 50).map((book, i) => (
+                    <a key={i} href={`/book/${book.slug || book.id}`} className="block px-2.5 py-2 -mx-2.5 rounded-lg hover:bg-black/[0.03] transition-colors">
+                      <div className="text-[13px] leading-snug font-medium" style={{ color: 'var(--text-primary)' }}>
+                        {(() => { const t = book.display_title || book.title; return t.length > 65 ? t.substring(0, 65) + '\u2026' : t; })()}
+                      </div>
+                      <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
+                        {book.author.length > 40 ? book.author.substring(0, 40) + '\u2026' : book.author}
+                        {book.year ? `, ${book.year}` : ''}
+                      </div>
+                    </a>
+                  ))}
+                  {cityBooks.length > 50 && (
+                    <p className="text-[11px] px-2.5 py-2" style={{ color: 'var(--text-muted)' }}>and {cityBooks.length - 50} more</p>
+                  )}
+                </>
               )}
             </div>
           </div>


### PR DESCRIPTION
Follow-up to #2814 — fixes the "map is a bit slow" report.

## Problem
`/explore/map` shipped the full book list for **every** city inline (up to 200 books each): a measured **7.12 MB** payload. The browser parses and holds all of it, then renders ~2,400 markers — but the per-city book lists are only ever shown in the sidebar *after* you click a city.

## Fix
Ship one lightweight record per city instead — coords + a compact `{y: year, m: role-bitmask}` per book — and lazy-load the clicked city's full list from a new `/api/explore/map/city` route.

- **Initial payload 7.12 MB → 0.61 MB** (measured on live `map_data`; ~12× smaller).
- Marker sizing, the year filter, the role toggles, and the "N books across N cities" headline all still compute client-side from the slim data.
- The role **bitmask** preserves the old per-city cross-role dedup (27,723 raw associations → 25,119 deduped). Counts match prior behavior — a simpler years-only payload would have double-counted ~2,600 books that have two roles in one city (e.g. published + author-born).
- The new route reads the **same** `system_config.map_data` cache, indexed once per warm instance; responses are filtered by the active roles + year range, capped at 200, cached 5 min. The sidebar shows a "Loading…" state during the fetch.

## Verification
- `tsc --noEmit` clean; pre-commit import check clean.
- Simulated the slim transform + API filtering against live `map_data`: payload 0.61 MB, Amsterdam resolves to 346 books all-roles / 200 publication-only.

## Out of scope
- The `system_config.map_data` cache builder (Hetzner cron) is unchanged — still capped at 200 books per (city, role) group; the slimming happens at read time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)