### PR TITLE
feat(reader): bottom like + "Tell Derek" discovery prompt in reader footer

### DIFF
--- a/src/components/feedback/FeedbackWidget.tsx
+++ b/src/components/feedback/FeedbackWidget.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useSession } from 'next-auth/react';
 
-export default function FeedbackWidget({ className, style, initialMessage, label }: { className?: string; style?: React.CSSProperties; initialMessage?: string; label?: string }) {
+export default function FeedbackWidget({ className, style, initialMessage, label, heading, intro, placeholder, contactEmail }: { className?: string; style?: React.CSSProperties; initialMessage?: string; label?: string; heading?: string; intro?: string; placeholder?: string; contactEmail?: string }) {
   const { data: session } = useSession();
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState('');
@@ -92,9 +92,12 @@ export default function FeedbackWidget({ className, style, initialMessage, label
           </div>
         ) : (
           <>
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-medium text-stone-800">Send feedback</h3>
-              <button onClick={() => setOpen(false)} className="text-stone-400 hover:text-stone-600">
+            <div className="flex items-start justify-between mb-4">
+              <div>
+                <h3 className="text-lg font-medium text-stone-800">{heading || 'Send feedback'}</h3>
+                {intro && <p className="text-sm text-stone-500 mt-0.5">{intro}</p>}
+              </div>
+              <button onClick={() => setOpen(false)} className="text-stone-400 hover:text-stone-600 flex-shrink-0 ml-2">
                 <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -104,7 +107,7 @@ export default function FeedbackWidget({ className, style, initialMessage, label
             <textarea
               value={message}
               onChange={(e) => setMessage(e.target.value)}
-              placeholder="Spot an error? Have an idea? Anything at all..."
+              placeholder={placeholder || 'Spot an error? Have an idea? Anything at all...'}
               rows={4}
               className="w-full px-3 py-2 rounded-lg border border-stone-300 text-sm text-stone-800 placeholder-stone-400 focus:outline-none focus:border-accent-gold resize-none"
               autoFocus
@@ -158,6 +161,15 @@ export default function FeedbackWidget({ className, style, initialMessage, label
                 {status === 'sending' ? 'Sending...' : status === 'error' ? 'Try again' : 'Send'}
               </button>
             </div>
+
+            {contactEmail && (
+              <p className="text-xs text-stone-400 mt-3 text-center">
+                Prefer email?{' '}
+                <a href={`mailto:${contactEmail}`} className="text-accent-rust hover:text-accent-gold underline">
+                  {contactEmail}
+                </a>
+              </p>
+            )}
           </>
         )}
       </div>

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -44,6 +44,7 @@ import type { Page, Book, Prompt, ContentSource } from '@/lib/types';
 import { GEMINI_MODELS, DEFAULT_MODEL } from '@/lib/types';
 import { AuthCheck } from '../auth/AuthCheck';
 import TranslationFeedbackPrompt from '@/components/feedback/TranslationFeedbackPrompt';
+import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 import { useIsEmbedded } from '@/hooks/useEmbedContext';
 
 // Languages that use non-Latin scripts and benefit from transliteration
@@ -1898,7 +1899,7 @@ export default function TranslationEditor({
 
         {/* Footer: like + nav hint + search */}
         <div style={{ background: 'var(--bg-warm)', color: 'var(--text-muted)', borderTop: '1px solid var(--border-light)' }}>
-          <div className="px-4 pt-2 pb-1 flex items-center justify-center">
+          <div className="px-4 pt-2 pb-1 flex items-center justify-center gap-3 flex-wrap text-xs">
             <LikeButton
               key={`footer-${page.id}`}
               targetType="page"
@@ -1907,6 +1908,20 @@ export default function TranslationEditor({
               size="sm"
               showCount={true}
             />
+            {!isEmbedded && (
+              <>
+                <span style={{ color: 'var(--border-light)' }}>·</span>
+                <FeedbackWidget
+                  label="Found something? Tell Derek"
+                  heading="Tell Derek what you found"
+                  intro="A passage that struck you, a connection, a question — Derek reads every note."
+                  placeholder="What caught your eye on this page…"
+                  contactEmail="derek@sourcelibrary.org"
+                  className="hover:underline"
+                  style={{ color: 'var(--text-muted)' }}
+                />
+              </>
+            )}
           </div>
           <div className="px-4 py-1 flex items-center justify-center gap-4 text-xs flex-wrap">
             <span className="hidden lg:inline">Use ← → arrow keys to navigate</span>

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -1896,8 +1896,18 @@ export default function TranslationEditor({
           );
         })()}
 
-        {/* Footer: nav hint + search */}
+        {/* Footer: like + nav hint + search */}
         <div style={{ background: 'var(--bg-warm)', color: 'var(--text-muted)', borderTop: '1px solid var(--border-light)' }}>
+          <div className="px-4 pt-2 pb-1 flex items-center justify-center">
+            <LikeButton
+              key={`footer-${page.id}`}
+              targetType="page"
+              targetId={page.id}
+              bookId={book.id}
+              size="sm"
+              showCount={true}
+            />
+          </div>
           <div className="px-4 py-1 flex items-center justify-center gap-4 text-xs flex-wrap">
             <span className="hidden lg:inline">Use ← → arrow keys to navigate</span>
             <span className="lg:hidden">Swipe left/right to navigate</span>


### PR DESCRIPTION
## What

Two small, related reader-footer engagement adds at the moment of reading:

1. **Bottom like** — a second page-like control at the foot of the reader (closes #2824). The existing like was header-only; user feedback asked to make liking easier from the bottom.
2. **"Found something? Tell Derek"** — a discovery-framed message prompt next to the bottom like. The page reader previously had *no* general feedback channel (only a translation-quality rating), so the only outlet at the moment of discovery was a silent heart.

## Why

Real reader engagement happens *in the reader*, but the only signal we captured there was a like — which you can't reply to. This adds a low-friction, page-context-attached way for readers to send what they found (a passage, a connection, a question), framed as discovery rather than bug-reporting, and signed by a person ("Derek reads every note") because people write to a human, not a form. An "or email me" fallback is included.

## How

- Bottom `LikeButton` mirrors the header instance (`targetType="page"`, keyed per page).
- Reuses the existing `FeedbackWidget` (auto-attaches `page` path, writes to the `feedback` collection already triaged via the admin GET / `submit_feedback` flow) with **new optional copy props** — `heading` / `intro` / `placeholder` / `contactEmail` — all backward-compatible (defaults preserve current "Send feedback" behavior, so existing mounts are unchanged).
- Hidden in embed / tenant-subdomain mode (`!isEmbedded`) so partner reading rooms stay closed.
- No new backend, no new design primitives.

## Scope
- In scope: read-mode reader footer only.
- Out of scope: the heart→"what caught your eye?" follow-up hook, and per-passage margin annotations (a real build) — both deliberately left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)