### PR TITLE
fix(mcp): structured machine-readable tool errors (#2823)

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-library/mcp-server",
-  "version": "4.3.4",
+  "version": "4.4.0",
   "mcpName": "io.github.Embassy-of-the-Free-Mind/source-library",
   "description": "Search, read, and cite ~22,000 rare pre-modern texts (alchemy, Hermetica, Kabbalah, theology, early science) with AI-generated English translations. CLI + MCP server, no API key needed.",
   "type": "module",

--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -10,12 +10,40 @@ const MCP_HEADERS = {
 
 // ── API Helpers ────────────────────────────────────────────────────────
 
+/**
+ * Carries the HTTP status and parsed body of a failed upstream call so the
+ * MCP layer can emit a structured, machine-readable error (see index.ts)
+ * instead of an opaque string. This is what lets a research agent branch on
+ * `rate_limited` vs `auth_required` vs `transient` rather than guessing from
+ * prose — the in-repo half of the fix for issue #2823 (the bare opaque error).
+ */
+export class ApiError extends Error {
+  status: number;
+  body: unknown;
+  constructor(status: number, body: unknown, rawText: string) {
+    super(`API ${status}: ${rawText}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function failFromResponse(response: Response): Promise<never> {
+  const rawText = await response.text().catch(() => response.statusText);
+  let body: unknown = rawText;
+  try {
+    body = JSON.parse(rawText);
+  } catch {
+    // non-JSON body — keep the raw text
+  }
+  throw new ApiError(response.status, body, rawText);
+}
+
 export async function apiGet(path: string, params?: URLSearchParams): Promise<unknown> {
   const url = params ? `${API_BASE}${path}?${params}` : `${API_BASE}${path}`;
   const response = await fetch(url, { headers: MCP_HEADERS });
   if (!response.ok) {
-    const text = await response.text().catch(() => response.statusText);
-    throw new Error(`API ${response.status}: ${text}`);
+    return failFromResponse(response);
   }
   return response.json();
 }
@@ -28,8 +56,7 @@ export async function apiPost(path: string, body: unknown): Promise<unknown> {
     body: JSON.stringify(body),
   });
   if (!response.ok) {
-    const text = await response.text().catch(() => response.statusText);
-    throw new Error(`API ${response.status}: ${text}`);
+    return failFromResponse(response);
   }
   return response.json();
 }
@@ -38,8 +65,7 @@ export async function apiGetText(path: string, params?: URLSearchParams): Promis
   const url = params ? `${API_BASE}${path}?${params}` : `${API_BASE}${path}`;
   const response = await fetch(url, { headers: MCP_HEADERS });
   if (!response.ok) {
-    const text = await response.text().catch(() => response.statusText);
-    throw new Error(`API ${response.status}: ${text}`);
+    return failFromResponse(response);
   }
   return response.text();
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -20,7 +20,83 @@ import {
   searchImages,
   submitFeedback,
   checkDuplicate,
+  ApiError,
 } from "./api.js";
+
+/**
+ * Map a failed upstream call to a structured, machine-readable error envelope.
+ * Agents should branch on `error` (the category) and honor `retry_after` —
+ * never parse the human `message`. Categories:
+ *   auth_required — sign in / supply an API key (401/403)
+ *   rate_limited  — daily page budget reached; retry after the window (429)
+ *   not_found     — the book/page/chapter does not exist (404)
+ *   bad_request   — malformed call; fix params, do not retry as-is (400/422)
+ *   transient     — upstream hiccup or network blip; a plain retry may succeed (5xx / fetch failure)
+ *
+ * NOTE: the bare "No approval received" string some agents see on get_book_text
+ * is emitted by the MCP *client's* tool-approval gate (an approval timeout),
+ * not by this server — see issue #2823. This envelope makes every error WE own
+ * branchable so that, at minimum, real server-side gates never look opaque.
+ */
+function structuredError(error: unknown): {
+  error: string;
+  message: string;
+  retryable: boolean;
+  retry_after_seconds?: number;
+  status?: number;
+  details?: unknown;
+} {
+  if (error instanceof ApiError) {
+    const body = error.body as Record<string, unknown> | undefined;
+    const retryAfter =
+      body && typeof body === "object" && typeof body.retry_after_seconds === "number"
+        ? (body.retry_after_seconds as number)
+        : undefined;
+    const message =
+      body && typeof body === "object" && typeof body.error === "string"
+        ? (body.error as string)
+        : error.message;
+
+    let category: string;
+    let retryable = false;
+    let fallbackRetryAfter: number | undefined;
+    if (error.status === 401 || error.status === 403) {
+      category = "auth_required";
+    } else if (error.status === 429) {
+      category = "rate_limited";
+      retryable = true;
+      fallbackRetryAfter = 3600;
+    } else if (error.status === 404) {
+      category = "not_found";
+    } else if (error.status === 400 || error.status === 422) {
+      category = "bad_request";
+    } else if (error.status >= 500) {
+      category = "transient";
+      retryable = true;
+    } else {
+      category = "error";
+    }
+
+    return {
+      error: category,
+      message,
+      retryable,
+      ...(retryAfter ?? fallbackRetryAfter
+        ? { retry_after_seconds: retryAfter ?? fallbackRetryAfter }
+        : {}),
+      status: error.status,
+      ...(body && typeof body === "object" ? { details: body } : {}),
+    };
+  }
+
+  // Network failure, JSON parse error, or anything else — treat as transient
+  // so a research agent retries rather than silently falling back to web search.
+  return {
+    error: "transient",
+    message: error instanceof Error ? error.message : "Unknown error",
+    retryable: true,
+  };
+}
 
 // ── Tool Definitions ──────────────────────────────────────────────────
 
@@ -547,11 +623,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
     };
   } catch (error) {
+    // Structured, machine-readable error so agents can branch on the category
+    // (auth_required / rate_limited / transient / …) and honor retry_after,
+    // instead of regexing an opaque "Error: …" string. See issue #2823.
     return {
       content: [
         {
           type: "text" as const,
-          text: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+          text: JSON.stringify(structuredError(error), null, 2),
         },
       ],
       isError: true,
@@ -563,7 +642,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error(`Source Library MCP server v4.3.0 running (${TOOLS.length} tools)`);
+  console.error(`Source Library MCP server v4.4.0 running (${TOOLS.length} tools)`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Closes #2823.

## What the report described
`get_book_text` (with `from`/`to`) intermittently returned the bare string `"No approval received"`, then succeeded on an identical retry — and the agent silently fell back to web search.

## Root cause (where the string actually comes from)
`"No approval received"` appears **nowhere** in this repo. Intermittent + succeeds-on-immediate-retry is the signature of the **MCP client's tool-approval gate** (an approval timeout in the host agent), not a server gate — a budget gate would persist for 24h, not flip to success on retry. So there is no server bug emitting that string. The issue's own triage reached the same conclusion.

## What this PR fixes (the part we own)
Every MCP tool previously collapsed any upstream HTTP failure into an opaque `"Error: API 429: …"` string an agent can't branch on. Now:

- `api.ts` throws a typed `ApiError` carrying the HTTP `status` + parsed JSON `body`.
- `index.ts` emits a structured envelope: `{ error: <category>, message, retryable, retry_after_seconds?, status, details }`.
- Categories: `auth_required` (401/403), `rate_limited` (429, retryable, `retry_after`), `not_found` (404), `bad_request` (400/422), `transient` (5xx + network/parse failures, retryable).

So when a real server gate fires (e.g. the `/text` page budget, which already returns a structured 429 body), the agent sees a branchable category and an honest `retry_after` instead of prose — and a transient blip maps to `transient`/`retryable:true` so it retries rather than falling back to web search.

## In scope / out of scope
- **In scope:** MCP server error surfacing only. Server route + budget already return structured bodies; this stops the MCP layer from flattening them.
- **Out of scope:** the client approval-timeout itself (not our code). The anon `/text` budget is already generous (100 pages/24h) and only enforced when `API_AUTH_ENFORCE=1`, so single-feature reading already stays on-platform — no route change needed.

## Verification
- `npx tsc --noEmit` clean.
- Runtime smoke against a real 404: `ApiError` carries `status: 404`, `body: {"error":"Book not found"}` → maps to `not_found`.
- CLI output unchanged (still prints `err.message`, identical string).

## Shipping note
`dist/` is gitignored and built at publish. This reaches users only on the next `npm publish` of `@source-library/mcp-server` (version bumped 4.3.4 → 4.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)