### PR TITLE
fix(librarian): force a final synthesis when the agentic loop hits MAX_ROUNDS

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -804,6 +804,11 @@ export async function* streamAgenticResponse(
   // page citations in the final answer — see verifyCitations.
   const retrievedPageKeys = new Set<string>();
   let choicesPresented = false;
+  // True once the model voluntarily stops searching and writes its answer. If it
+  // instead runs out of search rounds (MAX_ROUNDS) while still calling tools, we
+  // force a final synthesis turn below so the reader never gets a stub or an
+  // empty reply (see the "kites" regression, issue #2826).
+  let answeredNaturally = false;
   const usage: TurnUsage = { model: MODEL, rounds: 0, promptTokens: 0, outputTokens: 0, thinkingTokens: 0, cachedTokens: 0 };
 
   function collectSources(sources?: SourceCard[]) {
@@ -863,7 +868,7 @@ export async function* streamAgenticResponse(
     if (allParts.length === 0) break;
     contents.push({ role: 'model', parts: allParts });
 
-    if (functionCalls.length === 0) break;
+    if (functionCalls.length === 0) { answeredNaturally = true; break; }
 
     // Emit tool_call events for all pending calls
     for (const part of functionCalls) {
@@ -918,6 +923,59 @@ export async function* streamAgenticResponse(
     contents.push({ role: 'user', parts: responseParts });
 
     if (choicesPresented) break;
+  }
+
+  // Forced synthesis. If the loop exited because it exhausted MAX_ROUNDS while
+  // the model was still issuing tool calls, the model never got a turn to read
+  // its last results and write an answer — so the reader gets a shallow stub or
+  // (when no text was ever emitted) an empty reply. Give it one final turn with
+  // NO tools available, which compels a text answer synthesized from everything
+  // gathered above. Skipped when the model already answered on its own or ended
+  // the turn with present_choices.
+  if (!answeredNaturally && !choicesPresented) {
+    contents.push({
+      role: 'user',
+      parts: [{
+        text: 'You have gathered enough material. Stop searching now and write your answer for the reader using ONLY the sources and pages you retrieved above. Synthesize them into a focused, well-cited response with page links — do not call any more tools.',
+      }],
+    });
+
+    try {
+      const finalStream = await ai.models.generateContentStream({
+        model: MODEL,
+        // No tools in the config → the model cannot search and must answer.
+        contents,
+        config: { temperature: TEMPERATURE },
+      });
+
+      const finalParts: Array<Record<string, unknown>> = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let finalUsage: any = null;
+      for await (const chunk of finalStream) {
+        if (chunk.usageMetadata) finalUsage = chunk.usageMetadata;
+        const candidate = chunk.candidates?.[0];
+        if (!candidate?.content?.parts) continue;
+        for (const part of candidate.content.parts) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const p = part as any;
+          if (p.text) {
+            finalParts.push(p);
+            yield { type: 'text', text: p.text };
+          }
+        }
+      }
+
+      usage.rounds++;
+      if (finalUsage) {
+        usage.promptTokens += finalUsage.promptTokenCount ?? 0;
+        usage.outputTokens += finalUsage.candidatesTokenCount ?? 0;
+        usage.thinkingTokens += finalUsage.thoughtsTokenCount ?? 0;
+        usage.cachedTokens += finalUsage.cachedContentTokenCount ?? 0;
+      }
+      if (finalParts.length > 0) contents.push({ role: 'model', parts: finalParts });
+    } catch (err) {
+      console.error('[Librarian] Forced synthesis failed:', err instanceof Error ? err.message : err);
+    }
   }
 
   if (allSources.length > 0) {


### PR DESCRIPTION
## Problem
Reader feedback (the "kites" thread, 2026-06-27): the Librarian "gave an immediate response, did searches, but didn't synthesize — behaving differently than normal."

## Root cause
`streamAgenticResponse` in `src/lib/embassy/librarian.ts` runs up to `MAX_ROUNDS = 6` search rounds with **no forced synthesis step**. When the model keeps issuing tool calls through the final round, the loop executes them, pushes the results into `contents`, and then just exits the `for` — the model never gets a turn to read the last results and write an answer. On a turn that was tool-calls-only, `fullText` comes out empty. The system prompt *asks* the model to stop and synthesize after 2-3 rounds, but nothing *enforces* it, so the behavior is non-deterministic.

### Evidence — kites thread `6a3f2de79d006495b453604a`
| Turn | Rounds | Output | Result |
|------|--------|--------|--------|
| "What do we have about kites?" | **6** | 246 tok | 2-sentence stub, no citations |
| "Go on" | **6** | — | **empty** saved message |
| "Summarize" | 4 (stopped early) | 1446 tok | rich, properly-cited synthesis ✅ |

Every turn that hit the 6-round ceiling lost its synthesis; the turn that stopped on its own answered well.

## Fix
Track whether the model finished on its own (`answeredNaturally`, set when a round returns no function calls). If the loop instead exhausts the round budget mid-search — and didn't end on `present_choices` — make one final `generateContentStream` call with **no tools in the config**, which compels a text answer synthesized from everything already gathered. Usage accounting is folded in; failures are caught and logged.

This also fixes the empty-message case: the forced synthesis runs whenever the model didn't answer naturally, so a tool-calls-only turn now ends with a real answer instead of "(empty)".

## Scope
- One file: `src/lib/embassy/librarian.ts`.
- **In scope:** forced final synthesis on round-budget exhaustion.
- **Out of scope:** raising `MAX_ROUNDS`, prompt tuning, or changing the tool set — deliberately left alone; this is the minimal correctness fix.

Closes #2826