### PR TITLE
feat(mcp): citation_link headline + symmetric tips + pipeline framing + get_quotes batch (#2820)

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -267,9 +267,62 @@ async function getBookText(args: Record<string, unknown>) {
   return result;
 }
 
+// The shareable shortlink lives at result.citation.short_url. Lift it to a
+// headline `citation_link` (and keep `short_url` for back-compat) so an LLM
+// caller treats the quote-plus-link as the deliverable instead of burying the
+// link in a citation sub-object and paraphrasing without it (#2820).
+function withCitationLink(result: Record<string, unknown>) {
+  const citation = result.citation as Record<string, unknown> | undefined;
+  const link = citation?.short_url as string | undefined;
+  return link ? { citation_link: link, short_url: link, ...result } : result;
+}
+
+const QUOTE_TIP =
+  'Copy the translation text exactly when quoting — do not paraphrase. ' +
+  'Present the citation_link to the user alongside the quote. Render as:\n' +
+  '> [exact translation text, verbatim]\n' +
+  '> — [Author], p. [N]. [citation_link]';
+
 async function getQuote(args: Record<string, unknown>) {
   const result = await apiGet(`/books/${args.book_id}/quote`, new URLSearchParams({ page: String(args.page) })) as Record<string, unknown>;
-  return { ...result, tip: 'Copy the translation text exactly when quoting. Do not paraphrase.' };
+  return { ...withCitationLink(result), tip: QUOTE_TIP };
+}
+
+// Assemble a multi-passage dossier in one round-trip: fetch several pages of a
+// single book by explicit list (pages:[...]) or inclusive range (from/to).
+async function getQuotes(args: Record<string, unknown>) {
+  const bookId = String(args.book_id);
+  let pageNums: number[] = [];
+  if (Array.isArray(args.pages)) {
+    pageNums = (args.pages as unknown[]).map(Number).filter((n) => Number.isFinite(n));
+  } else if (args.from !== undefined && args.to !== undefined) {
+    const from = Number(args.from);
+    const to = Number(args.to);
+    for (let p = from; p <= to; p++) pageNums.push(p);
+  }
+  // De-dupe, keep order, and cap the batch so one call can't fan out unboundedly.
+  pageNums = [...new Set(pageNums)].slice(0, 25);
+  if (pageNums.length === 0) {
+    return { error: 'Provide either pages:[...] or both from and to (a page range).', book_id: bookId };
+  }
+
+  const settled = await Promise.all(
+    pageNums.map(async (page) => {
+      try {
+        const result = await apiGet(`/books/${bookId}/quote`, new URLSearchParams({ page: String(page) })) as Record<string, unknown>;
+        return withCitationLink(result);
+      } catch (err) {
+        return { page, error: err instanceof Error ? err.message : 'Failed to fetch page' };
+      }
+    })
+  );
+
+  return {
+    book_id: bookId,
+    pages_requested: pageNums,
+    quotes: settled,
+    tip: QUOTE_TIP,
+  };
 }
 
 async function searchImages(args: Record<string, unknown>) {
@@ -426,7 +479,7 @@ const TOOLS: Tool[] = [
   {
     name: 'get_book',
     title: 'Get Book',
-    description: 'Get a book\'s AI-generated summary, chapter list, edition metadata, DOI, and page counts. THIS IS THE RIGHT FIRST CALL whenever the user has named a specific author or work — the summary is typically a multi-paragraph orientation covering the book\'s argument, structure, and significance, often answering the question without any further searching. Pair with get_book_text to read selected chapters, or search_within_book to locate passages inside it.',
+    description: 'READ PIPELINE step 1 — DISCOVER. START HERE for any named work or author. Returns the book\'s AI-generated summary, chapter list, edition metadata, DOI, page counts, and IIIF manifest. The summary is typically a multi-paragraph orientation covering the book\'s argument, structure, and significance — often answering the question without further searching. Then: get_book_text to read a chapter or page range (step 2), get_quote / get_quotes to lock specific pages with full citation apparatus (step 3). search_within_book locates passages inside this book.',
     annotations: { title: 'Get Book', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -437,7 +490,7 @@ const TOOLS: Tool[] = [
   {
     name: 'get_book_text',
     title: 'Read Book Text',
-    description: 'Read a book\'s text. Preferred: use the chapter param to read one chapter at a time (includes [Page N] markers for citation) — call get_book first to get the chapter list. Alternatively, use from/to for explicit page ranges (e.g. from=1 to=50). TRUNCATION: the response always includes truncated: true/false. When truncated=true, the truncation_note field gives the exact next from/to values to call — this means content was cut short by a page-budget limit, NOT that the book ended. An AI agent MUST NOT infer end-of-book from pages_returned alone; check truncated first. Budget limits apply to anonymous callers (~50 pages per 24h); sign in at sourcelibrary.org/auth/signin or get an API key at sourcelibrary.org/developers for higher limits.',
+    description: 'READ PIPELINE step 2 — READ. Read a book\'s text. Call get_book first (step 1) for the chapter list, then come here. Preferred: use the chapter param to read one chapter at a time (includes [Page N] markers for citation). Alternatively, use from/to for explicit page ranges (e.g. from=1 to=50). When you find passages worth quoting, hand the page numbers to get_quote / get_quotes (step 3) for verbatim text + a citation link. TRUNCATION: the response always includes truncated: true/false. When truncated=true, the truncation_note field gives the exact next from/to values to call — this means content was cut short by a page-budget limit, NOT that the book ended. An AI agent MUST NOT infer end-of-book from pages_returned alone; check truncated first. Budget limits apply to anonymous callers (~50 pages per 24h); sign in at sourcelibrary.org/auth/signin or get an API key at sourcelibrary.org/developers for higher limits.',
     annotations: { title: 'Read Book Text', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -456,7 +509,7 @@ const TOOLS: Tool[] = [
   {
     name: 'get_quote',
     title: 'Get Quote',
-    description: 'Get exact text of a single page for quoting, with citation URL. ALWAYS use before putting text in quotation marks.',
+    description: 'READ PIPELINE step 3 — CITE. Get the exact verbatim text of a single page plus its citation apparatus. ALWAYS use before putting text in quotation marks. The response headline is citation_link (the stable sourcelibrary.org/q/… shortlink) — present it to the user alongside the quote. Render as:\n> [exact translation text, verbatim]\n> — [Author], p. [N]. [citation_link]\nFor several pages of one book at once, use get_quotes.',
     annotations: { title: 'Get Quote', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -465,6 +518,22 @@ const TOOLS: Tool[] = [
         page: { type: 'number', description: 'Page number' },
       },
       required: ['book_id', 'page'],
+    },
+  },
+  {
+    name: 'get_quotes',
+    title: 'Get Quotes (batch)',
+    description: 'READ PIPELINE step 3 — CITE, in batch. Get verbatim text + citation_link for SEVERAL pages of a single book in one round-trip, to assemble a multi-passage dossier. Specify either pages (an explicit array, e.g. [12, 40, 41]) or an inclusive from/to range. Max 25 pages per call. Each entry carries its own citation_link to present alongside the quote.',
+    annotations: { title: 'Get Quotes (batch)', ...READ_ONLY },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        book_id: { type: 'string', description: 'The book ID' },
+        pages: { type: 'array', items: { type: 'number' }, description: 'Explicit list of page numbers (e.g. [12, 40, 41]). Use this OR from/to.' },
+        from: { type: 'number', description: 'Start page (inclusive) of a range. Use with to.' },
+        to: { type: 'number', description: 'End page (inclusive) of a range. Use with from.' },
+      },
+      required: ['book_id'],
     },
   },
   {
@@ -514,6 +583,7 @@ async function handleToolCall(name: string, args: ToolArgs) {
     case 'get_book': return getBook(args);
     case 'get_book_text': return getBookText(args);
     case 'get_quote': return getQuote(args);
+    case 'get_quotes': return getQuotes(args);
     case 'search_images': return searchImages(args);
     case 'submit_feedback': return submitFeedback(args);
     default: throw new Error(`Unknown tool: ${name}`);


### PR DESCRIPTION
Closes #2820.

Makes correct-citation the path of least resistance for LLM callers of the in-app MCP route (`src/app/api/mcp/route.ts`). The reported failure mode: a client calls `get_quote`, gets verbatim text + a shortlink, then paraphrases **without the link** because the link reads like buried metadata.

## Changes
1. **`citation_link` as headline output.** The shortlink lives at `citation.short_url`; lifted to a top-level `citation_link` (and `short_url` kept for back-compat) so the quote-plus-link is the obvious deliverable.
2. **Symmetric `get_quote` tip + render template.** Now: "copy verbatim AND present `citation_link`," with a baked-in template the model can copy:
   ```
   > [exact translation text, verbatim]
   > — [Author], p. [N]. [citation_link]
   ```
3. **Read-pipeline framing** across the three read tools: `get_book` (DISCOVER — START HERE) → `get_book_text` (READ) → `get_quote`/`get_quotes` (CITE), cross-referenced both ways.
4. **New `get_quotes` batch tool** — verbatim text + `citation_link` for up to 25 pages of one book (explicit `pages:[…]` or inclusive `from`/`to`) in a single round-trip, for assembling a multi-passage dossier. Per-page failures are returned inline, not fatal.

## Validated against current code (per the issue's instruction)
The feedback claimed `get_book` already returns "curated quotes carrying page + page_id." It does **not** — the book API exposes no quotes field. So the `get_book` description does **not** assert it. Everything else checked out.

- `citation.short_url` confirmed live: `/api/books/<id>/quote?page=2` → `citation.short_url: …/q/…`.
- `npx tsc --noEmit` clean.

## In scope / out of scope
- **In scope:** the in-app HTTP MCP route (`src/app/api/mcp/route.ts`) — the file the issue names. No change to underlying data or citation-block contents.
- **Out of scope (deliberate):** mirroring `citation_link`/`get_quotes` into the npm `@source-library/mcp-server` package — a separate publish surface, follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)