### PR TITLE
fix(search): close residual language-filter fail-open on empty allow-list (#2760)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -308,10 +308,13 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
               .project({ id: 1 })
               .toArray();
             const allowedBookIds = filteredBooks.map(b => b.id);
-            // Always apply the constraint we computed. If the book-level filter
-            // (e.g. a language that matches no books) yields an empty set, the
-            // page search must return nothing — NOT fall through to an
-            // unconstrained whole-corpus search (fail-open bug).
+            // If the book-level filter (e.g. a language that matches no books)
+            // yields an empty set, the page search must return NOTHING — never
+            // fall through to an unconstrained whole-corpus search (fail-open).
+            // Short-circuit here: `$in: []` does NOT survive the trip through
+            // buildPageSearchStage (it drops an empty array, reopening the
+            // leak), so bail at the lane rather than rely on it. (#2760)
+            if (allowedBookIds.length === 0) return [];
             pageFilter.book_id = { $in: allowedBookIds };
           }
 

--- a/src/lib/atlas-search.ts
+++ b/src/lib/atlas-search.ts
@@ -134,11 +134,18 @@ export function buildPageSearchStage(query: string, bookIds?: string | string[])
   const filter: Document[] = [];
   // Hidden / deduped pages live at page_number ≤ 0. Exclude them from search.
   filter.push({ range: { path: 'page_number', gt: 0 } });
-  if (bookIds) {
+  if (bookIds !== undefined) {
     if (typeof bookIds === 'string') {
       filter.push({ equals: { path: 'book_id', value: bookIds } });
     } else if (bookIds.length > 0) {
       filter.push({ in: { path: 'book_id', value: bookIds } });
+    } else {
+      // Empty allow-list ⇒ match nothing. `undefined` means "no book filter";
+      // an empty *array* is a computed allow-list that resolved to zero books
+      // (e.g. a language with no matching titles) and must NOT fail open to the
+      // whole corpus. Atlas `in` rejects an empty value array, so use an
+      // impossible equals sentinel. (#2760)
+      filter.push({ equals: { path: 'book_id', value: ' __no_match__' } });
     }
   }
 

--- a/tests/unit/page-search-filter.test.ts
+++ b/tests/unit/page-search-filter.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { buildPageSearchStage } from '@/lib/atlas-search';
+
+// Guards the residual language-filter fail-open (#2760). The page lane computes
+// a book-ID allow-list; when a filter (e.g. a zero-match language) resolves it
+// to an EMPTY array, page search must return nothing — never fall back to the
+// whole corpus. The earlier route fix applied `$in: []` unconditionally, but an
+// empty array does NOT survive `buildPageSearchStage` unless it emits a
+// match-nothing sentinel: `undefined` = no book filter, empty array = an
+// allow-list that matched nothing.
+
+type Filter = { equals?: { path: string; value: string }; in?: { path: string; value: string[] } };
+const filtersOf = (stage: any): Filter[] => stage.$search.compound.filter as Filter[];
+
+describe('buildPageSearchStage book_id filter', () => {
+  it('applies no book filter when bookIds is undefined', () => {
+    const filters = filtersOf(buildPageSearchStage('mercury'));
+    expect(filters.some(f => f.equals?.path === 'book_id' || f.in?.path === 'book_id')).toBe(false);
+  });
+
+  it('filters to a single book for a string bookId', () => {
+    expect(filtersOf(buildPageSearchStage('mercury', 'book-123')))
+      .toContainEqual({ equals: { path: 'book_id', value: 'book-123' } });
+  });
+
+  it('filters to the allow-list for a non-empty array', () => {
+    expect(filtersOf(buildPageSearchStage('mercury', ['a', 'b'])))
+      .toContainEqual({ in: { path: 'book_id', value: ['a', 'b'] } });
+  });
+
+  it('matches NOTHING for an empty allow-list — must not fail open (#2760)', () => {
+    const filters = filtersOf(buildPageSearchStage('mercury', []));
+    const bookFilter = filters.find(f => f.equals?.path === 'book_id' || f.in?.path === 'book_id');
+    expect(bookFilter).toBeDefined();          // not absent (whole-corpus leak)
+    expect(bookFilter?.in).toBeUndefined();    // not an empty `$in`
+    expect(bookFilter?.equals?.path).toBe('book_id');
+    expect(bookFilter?.equals?.value).not.toBe('');
+  });
+});


### PR DESCRIPTION
Follow-up to the inline #2760 fix already on `main`.

`main` applies the page-lane book-id constraint unconditionally (`$in: allowedBookIds`) — good — but an **empty** allow-list (e.g. a zero-match language filter) still leaks the whole corpus: `$in: []` doesn't survive `buildPageSearchStage`, which drops an empty array and emits **no** `book_id` filter, reopening the fail-open at the Atlas layer.

Two-layer fix:
- **route**: short-circuit the page lane to `[]` when the allow-list is empty.
- **`buildPageSearchStage`**: an empty array now emits an impossible-equals sentinel (match nothing) instead of dropping the filter — defends every caller; `undefined` still means "no book filter".

Test: `tests/unit/page-search-filter.test.ts` pins the empty-allow-list invariant (4 passing). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)