### PR TITLE
feat(ft): implement Tier-0 deterministic catalog/work_id match (#2780)

### DIFF
--- a/scripts/maintenance/ft-tier0-resolve.ts
+++ b/scripts/maintenance/ft-tier0-resolve.ts
@@ -1,0 +1,119 @@
+/**
+ * Tier-0 catalog resolver — runs the deterministic catalog/work_id match
+ * (`src/lib/first-translation/tier0-catalog.ts`) over the badged set and reports
+ * the books for which we ALREADY hold a complete, same-language, guard-passing
+ * prior English translation. These are over-claims the badge-setting cron never
+ * caught because it never queried our own `translation_catalogs`.
+ *
+ * Dry-run by default. With --apply it writes ONLY the verdict (book.first_translation
+ * = not_first) + appends the attempt — it does NOT flip is_first_translation. The
+ * single-writer reconcile materializes the demote afterwards:
+ *   npx tsx scripts/maintenance/reconcile-first-translation-flag.ts --apply
+ * (gate on Derek's sign-off). This keeps the single-writer invariant (#2564).
+ *
+ * Only `completeness: complete` catalog rows can be decisive, so we load those
+ * once (~hundreds) and match in memory — no per-book DB round-trip.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/maintenance/ft-tier0-resolve.ts            # dry-run report
+ *   npx tsx scripts/maintenance/ft-tier0-resolve.ts --apply    # write verdicts (gated)
+ */
+import { getDb } from '@/lib/mongodb';
+import { makeTier0Catalog, type CatalogPrior, type CatalogLookup } from '@/lib/first-translation/tier0-catalog';
+import type { ResolvableBook } from '@/lib/first-translation/resolve';
+import { appendAttempt } from '@/lib/first-translation/attempt-log';
+
+const APPLY = process.argv.includes('--apply');
+const LIMIT = parseInt(process.argv.find((a) => a.startsWith('--limit='))?.split('=')[1] || '0', 10);
+
+const norm = (s?: string) =>
+  (s || '').toLowerCase().normalize('NFKD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+const surnameOf = (author?: string) => {
+  const a = norm(author);
+  if (!a) return '';
+  return a.includes(',') ? a.split(',')[0].trim() : a.split(' ').slice(-1)[0];
+};
+const tokens = (s?: string) => new Set(norm(s).split(' ').filter((t) => t.length > 3));
+function overlap(a: Set<string>, b: Set<string>): number {
+  if (!a.size || !b.size) return 0;
+  let n = 0; for (const t of a) if (b.has(t)) n++;
+  return n / Math.min(a.size, b.size);
+}
+
+async function main() {
+  const db = await getDb();
+  const books = db.collection('books');
+
+  // Load decisive-eligible catalog rows once (only complete priors can defeat).
+  const completeRows = await db.collection('translation_catalogs')
+    .find({ completeness: 'complete' },
+      { projection: { _id: 0, author_surname: 1, canonical_author_normalized: 1, canonical_work_normalized: 1, english_title: 1, english_title_normalized: 1, translator: 1, pub_year: 1, completeness: 1, source_language: 1, source_url: 1, source: 1 } })
+    .toArray();
+  // Index by author surname for O(1) candidate fetch.
+  const bySurname = new Map<string, any[]>();
+  for (const r of completeRows) {
+    const sn = (r.author_surname && norm(r.author_surname)) || surnameOf(r.canonical_author_normalized);
+    if (!sn) continue;
+    (bySurname.get(sn) ?? bySurname.set(sn, []).get(sn)!).push(r);
+  }
+  console.log(`loaded ${completeRows.length} complete catalog rows, ${bySurname.size} distinct surnames`);
+
+  const lookup: CatalogLookup = async (book) => {
+    const sn = surnameOf(book.author);
+    const rows = bySurname.get(sn);
+    if (!rows) return [];
+    const wt = tokens(book.title);
+    const out: CatalogPrior[] = [];
+    for (const r of rows) {
+      // title overlap against the work key or the english title (coarse containment)
+      const ov = Math.max(overlap(wt, tokens(r.canonical_work_normalized)), overlap(wt, tokens(r.english_title_normalized)));
+      if (ov >= 0.6) {
+        out.push({
+          english_title: r.english_title, translator: r.translator, pub_year: r.pub_year,
+          completeness: r.completeness, source_language: r.source_language, source_url: r.source_url,
+          source: r.source, matched_by: 'author_title',
+        });
+      }
+    }
+    return out;
+  };
+  const tier0 = makeTier0Catalog(lookup);
+
+  const query = { is_first_translation: true, visible: true, pages_translated: { $gt: 0 }, language: { $nin: [null, 'en', 'eng', 'English', 'english'] } };
+  const cursor = books.find(query, { projection: { _id: 0, id: 1, title: 1, author: 1, language: 1, original_language: 1, work_id: 1 } });
+  if (LIMIT) cursor.limit(LIMIT);
+
+  const now = new Date().toISOString();
+  let scanned = 0, hits = 0, applied = 0;
+  const candidates: any[] = [];
+  for await (const b of cursor) {
+    scanned++;
+    const book = b as ResolvableBook;
+    const outcome = await tier0(book, { now });
+    if (outcome.terminal && outcome.verdict) {
+      hits++;
+      const p = outcome.attempt.priors?.[0];
+      candidates.push({ id: b.id, title: b.title, author: b.author, language: b.language, prior: p });
+      if (APPLY) {
+        await appendAttempt(db as any, outcome.attempt);
+        await books.updateOne({ id: b.id }, { $set: { first_translation: { ...outcome.verdict, best_attempt_id: outcome.attempt.attempt_id } } });
+        applied++;
+      }
+    }
+  }
+
+  console.log(`\nscanned ${scanned} badged-eligible books — Tier-0 decisive priors held: ${hits}`);
+  for (const c of candidates.slice(0, 50)) {
+    console.log(`  ${c.id} [${c.language}] ${(c.author || '').slice(0, 24)} — ${(c.title || '').slice(0, 44)}`);
+    console.log(`      prior: ${(c.prior?.english_title || '').slice(0, 60)} (${c.prior?.translator || '?'}, ${c.prior?.pub_year || '?'}) ${c.prior?.source_url || ''}`);
+  }
+  if (APPLY) {
+    console.log(`\nAPPLIED ${applied} not_first verdicts (verdict-only). Now run the reconcile to materialize the demotes:`);
+    console.log('  npx tsx scripts/maintenance/reconcile-first-translation-flag.ts --apply');
+  } else {
+    console.log('\nDRY-RUN — no writes. Re-run with --apply after sign-off, then reconcile.');
+  }
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/src/lib/first-translation/tier0-catalog.ts
+++ b/src/lib/first-translation/tier0-catalog.ts
@@ -1,0 +1,179 @@
+/**
+ * Tier 0 — deterministic catalog / work_id match (issue #2780).
+ *
+ * The free, deterministic front of the effort cascade specified in resolve.ts
+ * but never implemented: before spending a single model call, ask "do we ALREADY
+ * hold a checkable prior English translation of THIS text?" by matching the book
+ * against our own `translation_catalogs` registry (UNESCO, LoC, Loeb, the
+ * harvested census priors, …) and the `work_id` cluster.
+ *
+ * Why this matters (Derek, 2026-06-27): the badge-setting cron only ever queried
+ * Open Library / Google Books / Internet Archive — never our own registry — so
+ * 358 books are badged "first" while we hold a checkable contradicting prior.
+ * Tier 0 is the step that closes that gap, for free, on every book.
+ *
+ * The asymmetry (principle #1) is wired in:
+ *  - a FOUND prior is decisive ONLY when it survives the evidence-quality guard
+ *    (same source-language, complete, not anthology/self-match, person-
+ *    disambiguated). Then: verdict not_first, strong, TERMINAL — done, no spend.
+ *  - a catalog MISS is weak absence ("effectively unsearched" — our catalog is
+ *    incomplete), so it never terminates: it escalates to the paid tiers.
+ *
+ * I/O is injected (a `CatalogLookup`), keeping this module pure and unit-testable
+ * and keeping the Mongo query in the caller — exactly the resolve.ts contract.
+ */
+import type { Tier, ResolvableBook } from './resolve';
+import type { FirstTranslationAttempt, PriorTranslation } from './attempt-log';
+import { makeAttemptId } from './attempt-log';
+import type { FirstTranslation, MatchKey } from './types';
+import { evaluatePrior, type CitedPriorInput } from '../ft-prior-guard';
+
+/** A candidate prior row as returned from `translation_catalogs`. */
+export interface CatalogPrior {
+  english_title?: string;
+  translator?: string;
+  pub_year?: string;
+  /** 'complete' | 'partial' | 'excerpts' | 'unknown' */
+  completeness?: string;
+  /** Source language of the translated text (catalog stores ISO or name). */
+  source_language?: string;
+  /** Grounding link — a prior is only checkable with one. */
+  source_url?: string;
+  publisher?: string;
+  series?: string;
+  /** Which catalog the row came from (unesco_master, loeb, …). */
+  source?: string;
+  /** How the lookup matched this row to the book. */
+  matched_by?: 'work_id' | 'author_title';
+}
+
+/** Injected I/O: given a book, return candidate priors from the registry. */
+export type CatalogLookup = (book: ResolvableBook) => Promise<CatalogPrior[]>;
+
+/** Normalize a language label (ISO code or name) to a comparison key. */
+export function langKey(l?: string | null): string {
+  if (!l) return '';
+  const s = l.toLowerCase().trim();
+  const map: Record<string, string> = {
+    la: 'latin', lat: 'latin', latin: 'latin',
+    el: 'greek', grc: 'greek', gre: 'greek', greek: 'greek', 'ancient greek': 'greek',
+    he: 'hebrew', heb: 'hebrew', hebrew: 'hebrew',
+    ar: 'arabic', ara: 'arabic', arabic: 'arabic',
+    sa: 'sanskrit', san: 'sanskrit', sanskrit: 'sanskrit',
+    zh: 'chinese', chi: 'chinese', chinese: 'chinese', 'classical chinese': 'chinese',
+    de: 'german', ger: 'german', german: 'german',
+    fr: 'french', fre: 'french', french: 'french',
+    it: 'italian', ita: 'italian', italian: 'italian',
+    nl: 'dutch', dut: 'dutch', dutch: 'dutch',
+  };
+  // strip a compound like "latin-german" to its first token for a coarse compare
+  const first = s.split(/[-/;,]/)[0].trim();
+  return map[s] ?? map[first] ?? first;
+}
+
+function toCited(p: CatalogPrior): CitedPriorInput {
+  const c = p.completeness;
+  return {
+    english_title: p.english_title,
+    translator: p.translator,
+    pub_year: p.pub_year,
+    completeness:
+      c === 'complete' || c === 'partial' || c === 'excerpts' || c === 'unknown' ? c : undefined,
+    publisher: p.publisher,
+    series: p.series,
+  };
+}
+
+function toPrior(p: CatalogPrior): PriorTranslation {
+  return {
+    english_title: p.english_title,
+    translator: p.translator,
+    pub_year: p.pub_year,
+    publisher: p.publisher,
+    completeness: p.completeness,
+    source_url: p.source_url,
+  };
+}
+
+/** Is this catalog row a trustworthy, decisive defeat of a first-translation claim? */
+export function isDecisivePrior(book: ResolvableBook, p: CatalogPrior): boolean {
+  const bookLang = langKey(book.original_language ?? book.language);
+  // Same source-language: a Greek→En translation does NOT defeat a Latin→En first.
+  // (If either side is unknown we don't block on it, but completeness + guard still apply.)
+  const sameLang = !p.source_language || !bookLang || langKey(p.source_language) === bookLang;
+  // Only a COMPLETE prior defeats a first; partial/excerpt/unknown does not.
+  const complete = p.completeness === 'complete';
+  // Evidence-quality guard (#2579): not an anthology / self-match / namesake.
+  const guard = evaluatePrior(
+    { title: book.title ?? '', author: book.author, language: book.original_language ?? book.language ?? undefined },
+    toCited(p),
+  ).trustworthy;
+  return sameLang && complete && guard;
+}
+
+/**
+ * Build the Tier-0 catalog matcher. `lookup` supplies candidate priors (the I/O);
+ * this function owns only the deterministic decision.
+ */
+export function makeTier0Catalog(lookup: CatalogLookup): Tier {
+  return async (book, ctx) => {
+    const bookId = book.id ?? String(book._id ?? 'unknown');
+    const date = ctx.now;
+    const candidates = await lookup(book);
+    const defeats = candidates.filter((p) => isDecisivePrior(book, p));
+
+    if (defeats.length > 0) {
+      const matchKey: MatchKey = defeats.some((p) => p.matched_by === 'work_id') ? 'work_id' : 'author_title';
+      const sources = [...new Set(['translation_catalogs', ...defeats.map((p) => p.source).filter(Boolean) as string[]])];
+      const attempt: FirstTranslationAttempt = {
+        attempt_id: makeAttemptId(bookId, 'tier0_linked', date),
+        book_id: bookId,
+        work_id: book.work_id ?? null,
+        date,
+        method: 'tier0_linked',
+        match_key: matchKey,
+        sources_checked: sources,
+        queries: [],
+        result: 'found',
+        priors: defeats.map(toPrior),
+        evidence_strength: 'strong', // a checkable, complete, same-language prior is decisive
+        independence_score: 0.5, // registry match — deterministic, but a single catalog family
+        model: 'deterministic-catalog',
+        notes: `Tier-0 catalog match (${matchKey}): ${defeats.length} complete same-language prior(s) in ${sources.join(', ')}.`,
+      };
+      const verdict: FirstTranslation = {
+        verdict: 'not_first',
+        evidence_strength: 'strong',
+        our_completeness: 'unknown',
+        match_key: matchKey,
+        prior_relationship: 'same_text',
+        resolver: 'tier0_linked',
+        resolved_at: date,
+      };
+      return { verdict, attempt, terminal: true };
+    }
+
+    // No decisive prior. The registry is incomplete, so a miss is WEAK absence —
+    // never terminal; escalate to the paid tiers. We still log the attempt so the
+    // search coverage accumulates (and so a later identical run can see it ran).
+    const attempt: FirstTranslationAttempt = {
+      attempt_id: makeAttemptId(bookId, 'tier0_linked', date),
+      book_id: bookId,
+      work_id: book.work_id ?? null,
+      date,
+      method: 'tier0_linked',
+      match_key: 'none',
+      sources_checked: ['translation_catalogs'],
+      queries: [],
+      result: 'none',
+      priors: [],
+      evidence_strength: 'weak',
+      independence_score: 0.5,
+      model: 'deterministic-catalog',
+      notes: candidates.length
+        ? `${candidates.length} catalog candidate(s) but none complete + same-language + guard-passing.`
+        : 'No matching row in translation_catalogs.',
+    };
+    return { verdict: null, attempt, terminal: false };
+  };
+}

--- a/tests/unit/first-translation-tier0-catalog.test.ts
+++ b/tests/unit/first-translation-tier0-catalog.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  makeTier0Catalog,
+  isDecisivePrior,
+  langKey,
+  type CatalogPrior,
+} from '@/lib/first-translation/tier0-catalog';
+import type { ResolvableBook, ResolveContext } from '@/lib/first-translation/resolve';
+
+const ctx: ResolveContext = { now: '2026-06-27T00:00:00.000Z' };
+
+const book: ResolvableBook = {
+  id: 'b1',
+  title: 'De Mysteriis',
+  author: 'Iamblichus',
+  original_language: 'Latin',
+  language: 'Latin',
+  work_id: null,
+};
+
+const completePrior: CatalogPrior = {
+  english_title: 'On the Mysteries',
+  translator: 'Emma Clarke',
+  pub_year: '2003',
+  completeness: 'complete',
+  source_language: 'la',
+  source_url: 'https://archive.org/x',
+  source: 'loeb',
+  matched_by: 'author_title',
+};
+
+const run = (priors: CatalogPrior[], b: ResolvableBook = book) =>
+  makeTier0Catalog(async () => priors)(b, ctx);
+
+describe('langKey', () => {
+  it('maps ISO code and name to the same key', () => {
+    expect(langKey('la')).toBe(langKey('Latin'));
+    expect(langKey('grc')).toBe('greek');
+    expect(langKey('Latin-German')).toBe('latin'); // coarse: first token
+  });
+});
+
+describe('isDecisivePrior', () => {
+  it('accepts a complete, same-language, guard-passing prior', () => {
+    expect(isDecisivePrior(book, completePrior)).toBe(true);
+  });
+  it('rejects a partial prior', () => {
+    expect(isDecisivePrior(book, { ...completePrior, completeness: 'partial' })).toBe(false);
+  });
+  it('rejects a different-source-language prior (Greek prior for a Latin text)', () => {
+    expect(isDecisivePrior(book, { ...completePrior, source_language: 'grc' })).toBe(false);
+  });
+  it('rejects a self-match (prior == the book itself)', () => {
+    expect(
+      isDecisivePrior(book, { ...completePrior, english_title: 'De Mysteriis', translator: 'Iamblichus' }),
+    ).toBe(false);
+  });
+});
+
+describe('makeTier0Catalog', () => {
+  it('TERMINATES with not_first/strong when a decisive prior is held', async () => {
+    const o = await run([completePrior]);
+    expect(o.terminal).toBe(true);
+    expect(o.verdict?.verdict).toBe('not_first');
+    expect(o.verdict?.evidence_strength).toBe('strong');
+    expect(o.verdict?.resolver).toBe('tier0_linked');
+    expect(o.attempt.result).toBe('found');
+    expect(o.attempt.method).toBe('tier0_linked');
+    expect(o.attempt.priors?.[0]?.source_url).toBe('https://archive.org/x');
+  });
+
+  it('marks the match_key work_id when matched via the work cluster', async () => {
+    const o = await run([{ ...completePrior, matched_by: 'work_id' }]);
+    expect(o.verdict?.match_key).toBe('work_id');
+  });
+
+  it('ESCALATES (non-terminal, weak) on a partial-only candidate', async () => {
+    const o = await run([{ ...completePrior, completeness: 'partial' }]);
+    expect(o.terminal).toBe(false);
+    expect(o.verdict).toBeNull();
+    expect(o.attempt.result).toBe('none');
+    expect(o.attempt.evidence_strength).toBe('weak');
+    expect(o.attempt.notes).toMatch(/candidate/i);
+  });
+
+  it('ESCALATES on no catalog match, recording the miss', async () => {
+    const o = await run([]);
+    expect(o.terminal).toBe(false);
+    expect(o.verdict).toBeNull();
+    expect(o.attempt.result).toBe('none');
+    expect(o.attempt.match_key).toBe('none');
+    expect(o.attempt.notes).toMatch(/No matching row/i);
+  });
+
+  it('never terminates on a different-source-language prior (the Iamblichus rule)', async () => {
+    const o = await run([{ ...completePrior, source_language: 'grc' }]);
+    expect(o.terminal).toBe(false);
+    expect(o.verdict).toBeNull();
+  });
+});


### PR DESCRIPTION
Implements the **Tier-0** step that `resolve.ts` has *specified* since #2564 but never had: a free, deterministic match of every book against our own `translation_catalogs` registry + `work_id` cluster, run before any paid search.

**Why:** the badge-setting cron only ever queried Open Library / Google Books / Internet Archive — never our own 28k-row registry — so books get badged "first" while we already hold a checkable contradicting prior (the reliability instrument, PR #2831, found 358 such cases). Tier-0 is the step that closes that gap, for free, on every book. Derek flagged this directly.

### What's here
- **`src/lib/first-translation/tier0-catalog.ts`** — `makeTier0Catalog(lookup)`, a pure `Tier` (I/O injected, per the resolve.ts contract). The asymmetry of principle #1 is wired in:
  - a FOUND prior **terminates** the cascade (`not_first` / strong) **only** when it is **complete**, **same source-language**, and passes the evidence-quality guard (#2579) — the Iamblichus (different-source-language) and Arithmologia (anthology/self-match) rules, in code.
  - a catalog **MISS** is weak absence (our registry is incomplete) and **never terminates** — it escalates to the paid tiers.
- **`tests/unit/first-translation-tier0-catalog.test.ts`** — 10 cases (decisive prior, partial-only, different-source-language, self-match, no-match, work_id match). All green.
- **`scripts/maintenance/ft-tier0-resolve.ts`** — dry-run runner; `--apply` writes the **verdict only** (never the flag), so the single-writer reconcile materializes the demote afterward (#2564 invariant preserved).

### Live dry-run
5,772 badged books × 399 complete catalog rows → **1 decisive prior held today** (Plato *Axiochus* → Spenser 1592). Low yield is honest: the catalog is Latin-heavy and mostly `completeness: unknown`, so **catalog enrichment (`source_language` / `completeness`) is the lever that makes Tier-0 bite** — tracked separately. The architecture is correct and runs first/free; yield scales with the registry.

### Out of scope (deliberate)
- Wiring Tier-0 into a production `defaultTiers()` cascade alongside Tier-1/Tier-2 — this lands the implementation + a standalone runner; the full cascade wiring is a follow-up once Tier-1/Tier-2 are also wired.
- Catalog enrichment (the yield lever).

Free, no LLM. `tsc` + unit tests green. Refs #2780 · #2564 · #2567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)