### PR TITLE
feat(seo): /verify cite alias + page JSON-LD + developers doc (#2822)

### DIFF
--- a/src/app/api/verify/route.ts
+++ b/src/app/api/verify/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { GET as quoteGET } from '@/app/api/books/[id]/quote/route';
+
+/**
+ * GET /api/verify?book_id=<id>&page=<n>
+ *
+ * A stable, flat, documented alias of the per-page quote endpoint, for
+ * web-based research agents whose fetcher only allows URLs of a known shape.
+ * It returns the SAME gated, wrapper-stripped verbatim text + full citation
+ * block as /api/books/[id]/quote — by re-dispatching to that handler, so the
+ * security gate (isBookReadable / hidden + in-copyright refusal), editorial
+ * wrapper stripping, bot gating, and rate-limit budget all live in ONE place
+ * and cannot drift between the two routes (#2822).
+ *
+ * Passthrough query params (read by the quote handler from the same request
+ * URL): page (required, default 1), include_original, include_context.
+ */
+export const GET = async (request: NextRequest): Promise<Response> => {
+  const bookId = new URL(request.url).searchParams.get('book_id');
+  if (!bookId) {
+    return NextResponse.json(
+      {
+        error: 'book_id is required. Usage: /api/verify?book_id=<id>&page=<n>',
+        docs: 'https://sourcelibrary.org/developers',
+      },
+      { status: 400 },
+    );
+  }
+  // Re-dispatch to the quote handler — same request (so page/include_* and the
+  // auth/bot/budget gating all apply), with the book id supplied as the route param.
+  return quoteGET(request, { params: Promise.resolve({ id: bookId }) });
+};

--- a/src/app/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/book/[id]/page/[pageId]/layout.tsx
@@ -3,6 +3,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { getTenantContext } from '@/lib/tenant-context';
 import { Book, Page } from '@/lib/types';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 
 export const preferredRegion = 'fra1';
 
@@ -65,8 +66,10 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
   const ogBookTitle = book.published ? `${bookTitle} (${book.published})` : bookTitle;
   const title = `${ogBookTitle} - Page ${pageNum}`;
 
-  // Use translation excerpt if available, otherwise OCR excerpt
-  const textContent = page.translation?.data || page.ocr?.data || '';
+  // Use translation excerpt if available, otherwise OCR excerpt. Strip editorial
+  // wrapper blocks first so <meta>/<summary>/… prose never lands in the OG
+  // description / search snippet (#2232 invariant).
+  const textContent = stripEditorialWrappers(page.translation?.data || page.ocr?.data || '').trim();
   const excerpt = textContent.length > 200
     ? textContent.substring(0, 197) + '...'
     : textContent;

--- a/src/app/book/[id]/page/[pageId]/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/page.tsx
@@ -6,6 +6,39 @@ import type { Book, Page } from '@/lib/types';
 import PageEditorClient from '@/components/book/PageEditorClient';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
 import { isHiddenBook } from '@/lib/book-access';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+
+// Schema.org structured data for a translated page, so it surfaces as a
+// citable scholarly work in web search (#2822). Only emitted for indexable
+// pages (same seo_indexable gate as robots, #2688) — structured data on a
+// noindex page is wasted. The excerpt is wrapper-stripped (the #2232 invariant:
+// never expose editorial <meta>/<summary>/… blocks as page text).
+function buildPageJsonLd(book: Book, page: Page, pageUrl: string): Record<string, unknown> | null {
+  if ((page as unknown as { seo_indexable?: boolean }).seo_indexable !== true) return null;
+  const bookTitle = book.display_title || book.title;
+  const raw = page.translation?.data || page.ocr?.data || '';
+  const clean = stripEditorialWrappers(raw).trim();
+  const excerpt = clean.length > 500 ? clean.slice(0, 497) + '…' : clean;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CreativeWork',
+    name: `${bookTitle} — Page ${page.page_number}`,
+    url: pageUrl,
+    inLanguage: book.language || undefined,
+    datePublished: book.published || undefined,
+    author: book.author ? { '@type': 'Person', name: book.author } : undefined,
+    translator: { '@type': 'Organization', name: 'Source Library' },
+    isPartOf: {
+      '@type': 'Book',
+      name: bookTitle,
+      ...(book.author ? { author: { '@type': 'Person', name: book.author } } : {}),
+      ...(book.doi ? { sameAs: `https://doi.org/${book.doi}` } : {}),
+    },
+    license: 'https://creativecommons.org/licenses/by-sa/4.0/',
+    isAccessibleForFree: true,
+    ...(excerpt ? { text: excerpt } : {}),
+  };
+}
 
 // ISR: 24h background revalidation. Pipeline also calls /api/admin/revalidate-book for immediate updates.
 export const revalidate = 86400;
@@ -81,8 +114,17 @@ export default async function PageEditorPage({ params, allowHidden = false }: Pa
   const serializedPage = JSON.parse(JSON.stringify(currentPage)) as Page;
   const serializedNavPages = JSON.parse(JSON.stringify(navPages)) as Page[];
 
+  const bookPath = book.slug || scopedBookId;
+  const jsonLd = buildPageJsonLd(book, serializedPage, `https://sourcelibrary.org/book/${bookPath}/page/${pageId}`);
+
   return (
     <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
       <EmbedNavigationReporter book={book.slug || book.id} page={pageId} />
       <PageEditorClient
         initialBook={book}

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -420,6 +420,11 @@ source-library search "alchemy" --json | jq .results`}
                 </tr>
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
+                  <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/verify?book_id=&amp;page=</td>
+                  <td className="py-2.5 text-secondary">Flat alias of /books/:id/quote — verbatim page text + citation block, for web agents with URL allow-lists</td>
+                </tr>
+                <tr>
+                  <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
                   <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/gallery</td>
                   <td className="py-2.5 text-secondary">Search 150,000+ historical illustrations</td>
                 </tr>


### PR DESCRIPTION
Closes #2822.

Per the audit, #2822's core ask — a public, unauthenticated, fetchable cite endpoint — **already exists** (the quote API: `isBookReadable`-gated, wrapper-stripped, full citation). The real gap is **discoverability**: a web-based agent whose fetcher only allows URLs that appeared in web-search results can't find our pages, so it falls back to other public-domain editions. This PR adds the discoverability layer.

## Changes
- **`GET /api/verify?book_id=&page=`** — a flat, stable, documented alias that **re-dispatches to the existing quote handler** (`quoteGET(request, { params })`). Zero gate duplication: `isBookReadable`, editorial-wrapper stripping, bot gating, and the rate-limit budget all stay single-sourced and cannot drift between the two routes. Returns the same verbatim text + citation block. Passthrough: `page`, `include_original`, `include_context`.
- **Schema.org `CreativeWork` JSON-LD** on the per-page reader route — `name`, `author`, `translator`, `inLanguage`, `isPartOf` (the Book, with DOI `sameAs`), `license`, `text` excerpt. Gated on the same `seo_indexable` flag as robots (#2688), so structured data ships only on indexable pages. Excerpt is wrapper-stripped.
- **OG/description excerpt** on the per-page route is now wrapper-stripped too, so `<meta>`/`<summary>` prose never lands in a search snippet (#2232).
- **`/developers`** documents `/verify`.

## Security (this issue was flagged security-sensitive)
No new unauthenticated text path. `/verify` *is* the quote gate reused verbatim — it refuses `visible:false` / hidden / in-copyright books exactly as the quote API does, so there's no #2522 regression. Per-page sitemap coverage stays demand-gated (#2688) on purpose; not widened here.

## Out of scope
- Per-page OAI-PMH records (book-level only today) — low priority, separate.
- Book-page (`/book/[id]`) JSON-LD — could add a `Book` node in a follow-up; this PR targets the per-page citation surface the issue is about.
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)