### PR TITLE
feat(i18n): language-keyed translations model (#2835 keystone)

### DIFF
--- a/scripts/maintenance/backfill-translations-map.mjs
+++ b/scripts/maintenance/backfill-translations-map.mjs
@@ -1,0 +1,60 @@
+/**
+ * Backfill the language-keyed translations map (#2835).
+ *
+ * Copies the legacy per-language field `pages.translation_es` into the general
+ * `pages.translations.es` map, so the new read path (src/lib/page-translations.ts)
+ * sees pilot Spanish content under the canonical model.
+ *
+ * - Additive + idempotent: only sets translations.es when translation_es exists
+ *   and translations.es is absent. Never deletes translation_es (the legacy
+ *   field stays readable; the es-translate worker can be migrated separately).
+ * - $0, no model calls.
+ *
+ *   node scripts/maintenance/backfill-translations-map.mjs            # dry-run
+ *   node scripts/maintenance/backfill-translations-map.mjs --apply
+ */
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const uri = process.env.MONGODB_URI || process.env.MONGODB_URL || process.env.DATABASE_URL;
+const c = new MongoClient(uri, { serverSelectionTimeoutMS: 10000 });
+await c.connect();
+const db = c.db(process.env.MONGODB_DB || 'bookstore');
+const pages = db.collection('pages');
+
+const filter = {
+  'translation_es.data': { $type: 'string', $ne: '' },
+  $or: [{ 'translations.es.data': { $exists: false } }, { 'translations.es.data': '' }, { 'translations.es.data': null }],
+};
+
+const total = await pages.countDocuments(filter, { maxTimeMS: 60000 }).catch((e) => `err:${e.codeName}`);
+console.log(`MODE: ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+console.log(`pages with legacy translation_es needing translations.es backfill: ${total}`);
+
+if (!APPLY) {
+  const sample = await pages.find(filter, { projection: { id: 1, book_id: 1, page_number: 1, 'translation_es.model': 1 } }).limit(5).toArray();
+  console.log('sample:', sample.map((p) => `${p.book_id} p${p.page_number}`).join(', '));
+  console.log('\nDRY-RUN — re-run with --apply to write translations.es from translation_es.');
+  await c.close();
+  process.exit(0);
+}
+
+// Copy in batches via aggregation-pipeline update ($set translations.es = translation_es).
+let modified = 0;
+const cursor = pages.find(filter, { projection: { _id: 1, translation_es: 1 } }).batchSize(500);
+const ops = [];
+for await (const p of cursor) {
+  ops.push({ updateOne: { filter: { _id: p._id }, update: { $set: { 'translations.es': p.translation_es } } } });
+  if (ops.length >= 500) {
+    const r = await pages.bulkWrite(ops, { ordered: false });
+    modified += r.modifiedCount;
+    ops.length = 0;
+    await new Promise((r) => setTimeout(r, 50)); // throttle IOPS
+  }
+}
+if (ops.length) {
+  const r = await pages.bulkWrite(ops, { ordered: false });
+  modified += r.modifiedCount;
+}
+console.log(`backfilled translations.es on ${modified} pages.`);
+await c.close();

--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -7,6 +7,7 @@ import VersionBanner from '@/components/ui/VersionBanner';
 import { useLoadingMetrics } from '@/hooks/useLoadingMetrics';
 import { useSearchHighlight } from '@/hooks/useSearchHighlight';
 import type { Book, Page } from '@/lib/types';
+import { getTranslation } from '@/lib/page-translations';
 import { pages as pagesApi, readingHistory } from '@/lib/api-client';
 
 interface PageEditorClientProps {
@@ -259,7 +260,10 @@ export default function PageEditorClient({
   };
 
   // Spanish edition availability (per-page; pivot-translated from English).
-  const hasSpanish = !!currentPage.translation_es?.data;
+  // Read via the language-keyed model (translations.es) with legacy
+  // translation_es fallback, so this keeps working through the #2835 migration.
+  const spanishTranslation = getTranslation(currentPage, 'es');
+  const hasSpanish = !!spanishTranslation?.data;
   // Version pinning is English-edition-specific, so it disables the ES view.
   const showSpanish = lang === 'es' && hasSpanish && !pinnedVersion;
 
@@ -270,7 +274,7 @@ export default function PageEditorClient({
   if (showSpanish) {
     displayPage = {
       ...currentPage,
-      translation: { ...(currentPage.translation || {}), ...currentPage.translation_es!, language: 'Spanish' },
+      translation: { ...(currentPage.translation || {}), ...spanishTranslation!, language: 'Spanish' },
     } as Page;
   } else if (pinnedVersion && versionedTranslation != null) {
     displayPage = {

--- a/src/lib/page-translations.ts
+++ b/src/lib/page-translations.ts
@@ -1,0 +1,61 @@
+import type { Page, TranslationData } from '@/lib/types/page';
+
+/**
+ * Language-keyed translation access (#2835).
+ *
+ * The general model for non-English content translations is the
+ * `pages.translations` map (ISO code → TranslationData). It supersedes the
+ * one-off `pages.translation_es` field. During migration both may exist, so all
+ * READ paths go through these helpers — they fold the legacy `translation_es`
+ * into the unified view (the map wins if a language is present in both).
+ *
+ * English is NOT in this map; it lives on `pages.translation` (the pivot base).
+ * These helpers cover the *other* target languages a reader can switch to.
+ */
+
+/** Human-facing language names by ISO 639-1 code (extend as languages ship). */
+export const TARGET_LANGUAGE_NAMES: Record<string, string> = {
+  es: 'Español',
+  zh: '中文',
+  fr: 'Français',
+  de: 'Deutsch',
+  pt: 'Português',
+  it: 'Italiano',
+  ar: 'العربية',
+};
+
+/**
+ * All non-English translations available for a page, keyed by ISO code.
+ * Folds the legacy `translation_es` into the map (map entry wins on conflict).
+ */
+export function availableTranslations(page: Pick<Page, 'translations' | 'translation_es'>): Record<string, TranslationData> {
+  const out: Record<string, TranslationData> = {};
+  // Legacy first so an explicit map entry overrides it.
+  if (page.translation_es?.data) out.es = page.translation_es;
+  if (page.translations) {
+    for (const [lang, data] of Object.entries(page.translations) as [string, TranslationData][]) {
+      if (data?.data) out[lang] = data;
+    }
+  }
+  return out;
+}
+
+/** Get one language's translation (map preferred, legacy es fallback). Null if absent. */
+export function getTranslation(
+  page: Pick<Page, 'translations' | 'translation_es'>,
+  lang: string,
+): TranslationData | null {
+  if (page.translations?.[lang]?.data) return page.translations[lang];
+  if (lang === 'es' && page.translation_es?.data) return page.translation_es;
+  return null;
+}
+
+/** ISO codes a page can be read in (excludes English). */
+export function availableLanguageCodes(page: Pick<Page, 'translations' | 'translation_es'>): string[] {
+  return Object.keys(availableTranslations(page));
+}
+
+/** True if a page has any non-English translation. */
+export function hasAnyTranslation(page: Pick<Page, 'translations' | 'translation_es'>): boolean {
+  return availableLanguageCodes(page).length > 0;
+}

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -11,8 +11,16 @@ export interface Page {
   thumbnail?: string;
   compressed_photo?: string;
   ocr?: OcrData;
-  translation?: TranslationData;
-  translation_es?: TranslationData;  // Spanish edition (pivot-translated from English); read-time toggle in the reader
+  translation?: TranslationData;  // canonical English translation (pivot base for other languages)
+  translation_es?: TranslationData;  // LEGACY Spanish field — superseded by translations.es; kept readable during migration (#2835)
+  /**
+   * Language-keyed content translations (ISO code → TranslationData), e.g.
+   * { es: {...}, zh: {...} }. The general model that replaces per-language
+   * fields like translation_es (#2835). English stays on `translation` as the
+   * pivot base. Read via availableTranslations()/getTranslation() in
+   * src/lib/page-translations.ts, which also folds in the legacy translation_es.
+   */
+  translations?: Record<string, TranslationData>;
   summary?: SummaryData;
   modernized?: ModernizedData;  // Modernized text for reading dashboard
   transliteration?: TransliterationData;  // Romanized transliteration for non-Latin scripts


### PR DESCRIPTION
The keystone from RFC #2835 (§1): generalize content translation off the one-off `translation_es` field **before** a second language (Chinese) hardens the pattern. Read-path + model only; non-breaking.

## Changes
- **`Page.translations: Record<lang, TranslationData>`** — the general model. English stays on `translation` (pivot base). `translation_es` kept readable (legacy, marked superseded).
- **`src/lib/page-translations.ts`** — single read path (`availableTranslations` / `getTranslation` / `availableLanguageCodes` / `hasAnyTranslation`) that folds the legacy `translation_es` into the map (map wins on conflict).
- **Reader** reads Spanish via `getTranslation(page, 'es')` with legacy fallback — transparent: the existing EN/ES toggle keeps working and auto-picks up `translations.es` once backfilled.
- **`backfill-translations-map.mjs`** — additive, idempotent, $0 migration `translation_es` → `translations.es` (dry-run verified: finds the pilot Hermetic Museum pages).

## Why non-breaking
Page routes use *exclusion* projections (`{ detected_images: 0 }`), so the new `translations` field flows to the reader/SSR with no projection changes. The es-translate worker (PR #2781) still writes `translation_es`; it can migrate to the map separately since the read path folds both.

## Scope (deliberately deferred)
- Full **N-language picker UI** → RFC §5, lands when a 2nd language actually exists (no point building a 3-way picker with only ES).
- **On-demand route + cross-page continuity + pre-warmer** → RFC §2–4.
- Migrating the **es-worker's write path** to the map → coordinate with PR #2781's author.

## Post-merge step
Run `node scripts/maintenance/backfill-translations-map.mjs --apply` after deploy to populate `translations.es` from the pilot's existing Spanish pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)