### PR TITLE
feat: 'share back' research dossiers — a feedback-style submission inbox (#2821)

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-library/mcp-server",
-  "version": "4.3.4",
+  "version": "4.5.0",
   "mcpName": "io.github.Embassy-of-the-Free-Mind/source-library",
   "description": "Search, read, and cite ~22,000 rare pre-modern texts (alchemy, Hermetica, Kabbalah, theology, early science) with AI-generated English translations. CLI + MCP server, no API key needed.",
   "type": "module",

--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -65,6 +65,28 @@ export async function submitFeedback(args: {
   };
 }
 
+export async function shareFindings(args: {
+  title: string;
+  summary?: string;
+  citations: { book_id: string; page: number; note?: string }[];
+  name?: string;
+  email?: string;
+}) {
+  const result = await apiPost("/share-findings", {
+    title: args.title,
+    summary: args.summary || null,
+    citations: args.citations || [],
+    name: args.name || null,
+    email: args.email || null,
+  }) as Record<string, unknown>;
+
+  return {
+    ok: true,
+    id: result.id,
+    message: result.message || "Findings shared with the Source Library team. Thank you!",
+  };
+}
+
 export async function checkDuplicate(args: {
   title: string;
   author?: string;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -19,6 +19,7 @@ import {
   getQuote,
   searchImages,
   submitFeedback,
+  shareFindings,
   checkDuplicate,
 } from "./api.js";
 
@@ -450,6 +451,49 @@ const TOOLS: Tool[] = [
       required: ["message"],
     },
   },
+  {
+    name: "share_findings",
+    title: "Share Findings",
+    description:
+      "Share a research dossier back to the Source Library team — a title, an optional summary, and an ordered list of citations (the passages your thesis rests on). Each citation is a reference { book_id, page, note }, NOT copied text: the library re-renders the canonical quote from the reference, so links stay authoritative. Use this when the user has assembled a thesis backed by passages across one or more books and wants to contribute it back. Like submit_feedback, it goes to the team for review (not an instant public page).",
+    annotations: {
+      title: "Share Findings",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        title: {
+          type: "string",
+          description: "Title of the dossier / thesis (2-300 characters)",
+        },
+        summary: {
+          type: "string",
+          description: "Optional prose summarizing the argument (max 5000 characters)",
+        },
+        citations: {
+          type: "array",
+          description:
+            "Ordered list of supporting passages (1-50). Get book_id + page from get_quote / search_translations.",
+          items: {
+            type: "object",
+            properties: {
+              book_id: { type: "string", description: "The book ID" },
+              page: { type: "number", description: "Page number" },
+              note: { type: "string", description: "Optional note on why this passage matters" },
+            },
+            required: ["book_id", "page"],
+          },
+        },
+        name: { type: "string", description: "Your name (optional)" },
+        email: { type: "string", description: "Your email for follow-up (optional)" },
+      },
+      required: ["title", "citations"],
+    },
+  },
 ];
 
 // ── Server Setup ──────────────────────────────────────────────────────
@@ -468,7 +512,7 @@ Feedback: submit_feedback. Partnerships: derek@sourcelibrary.org.`;
 const server = new Server(
   {
     name: "source-library",
-    version: "4.3.0",
+    version: "4.5.0",
   },
   {
     capabilities: {
@@ -531,6 +575,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "submit_feedback":
         result = await submitFeedback(args as Parameters<typeof submitFeedback>[0]);
         break;
+      case "share_findings":
+        result = await shareFindings(args as Parameters<typeof shareFindings>[0]);
+        break;
       default:
         return {
           content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
@@ -563,7 +610,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error(`Source Library MCP server v4.3.0 running (${TOOLS.length} tools)`);
+  console.error(`Source Library MCP server v4.5.0 running (${TOOLS.length} tools)`);
 }
 
 main().catch((error) => {

--- a/src/app/admin/shared-findings/page.tsx
+++ b/src/app/admin/shared-findings/page.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+interface Citation {
+  book_id: string;
+  page: number;
+  note: string | null;
+}
+
+interface FindingItem {
+  _id: string;
+  title: string;
+  summary: string | null;
+  citations: Citation[];
+  name: string | null;
+  email: string | null;
+  created_at: string;
+  read?: boolean;
+}
+
+type Tab = 'unread' | 'read';
+
+function formatDate(s: string) {
+  const d = new Date(s);
+  return d.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+export default function AdminSharedFindingsPage() {
+  const [tab, setTab] = useState<Tab>('unread');
+  const [items, setItems] = useState<FindingItem[]>([]);
+  const [counts, setCounts] = useState<{ unread: number; read: number }>({ unread: 0, read: 0 });
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/share-findings?status=${tab}&limit=200`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setItems(data.findings || []);
+      setCounts(data.counts || { unread: 0, read: 0 });
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [tab]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function setRead(id: string, read: boolean) {
+    const res = await fetch(`/api/share-findings/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ read }),
+    });
+    if (res.ok) load();
+    else alert(`Update failed: ${res.status}`);
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-6 py-10">
+      <h1 className="text-2xl font-semibold mb-2">Shared findings</h1>
+      <p className="text-sm text-stone-500 mb-6">Research dossiers shared back via the <code>share_findings</code> tool / <code>/api/share-findings</code>. Each is a title + summary + ordered citations (references, not copied text). Review and, if worthwhile, curate into a collection.</p>
+
+      <div className="flex gap-2 mb-6 border-b border-stone-200">
+        {(['unread', 'read'] as Tab[]).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${tab === t ? 'border-accent-rust text-accent-rust' : 'border-transparent text-stone-500 hover:text-stone-800'}`}
+          >
+            {t.charAt(0).toUpperCase() + t.slice(1)} <span className="ml-1 text-xs text-stone-400">({counts[t]})</span>
+          </button>
+        ))}
+      </div>
+
+      {loading && <p className="text-sm text-stone-500">Loading…</p>}
+      {!loading && items.length === 0 && (
+        <p className="text-sm text-stone-500">No items in <em>{tab}</em>.</p>
+      )}
+
+      <div className="space-y-4">
+        {items.map(item => (
+          <article key={item._id} className="border border-stone-200 rounded-lg p-4 bg-white">
+            <header className="flex items-baseline justify-between gap-4 mb-2">
+              <h2 className="text-base font-semibold text-stone-800">{item.title}</h2>
+              <div className="text-xs text-stone-500 whitespace-nowrap">
+                {formatDate(item.created_at)}
+                {item.name && <span> · <span className="text-stone-700">{item.name}</span></span>}
+                {item.email && <span className="text-stone-400"> &lt;{item.email}&gt;</span>}
+              </div>
+            </header>
+
+            {item.summary && (
+              <p className="text-sm whitespace-pre-wrap text-stone-700 leading-relaxed mb-3">{item.summary}</p>
+            )}
+
+            <ol className="space-y-1.5 mb-3 list-decimal list-inside">
+              {item.citations.map((c, i) => (
+                <li key={i} className="text-sm text-stone-700">
+                  <a
+                    href={`https://sourcelibrary.org/book/${c.book_id}?page=${c.page}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent-rust hover:underline font-mono text-xs"
+                  >
+                    {c.book_id} · p.{c.page}
+                  </a>
+                  {c.note && <span className="text-stone-500"> — {c.note}</span>}
+                </li>
+              ))}
+            </ol>
+
+            <div className="flex gap-2">
+              {tab === 'unread' ? (
+                <button onClick={() => setRead(item._id, true)} className="text-xs px-3 py-1.5 bg-stone-100 hover:bg-stone-200 text-stone-700 rounded transition-colors">
+                  Mark read
+                </button>
+              ) : (
+                <button onClick={() => setRead(item._id, false)} className="text-xs px-3 py-1.5 bg-stone-100 hover:bg-stone-200 text-stone-700 rounded transition-colors">
+                  Mark unread
+                </button>
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -328,6 +328,17 @@ async function submitFeedback(args: Record<string, unknown>) {
   return { ok: true, message: 'Feedback submitted successfully. Thank you!' };
 }
 
+async function shareFindings(args: Record<string, unknown>) {
+  const result = await apiPost('/share-findings', {
+    title: args.title,
+    summary: args.summary || null,
+    citations: args.citations || [],
+    name: args.name || null,
+    email: args.email || null,
+  }) as Record<string, unknown>;
+  return { ok: true, id: result.id, message: result.message || 'Findings shared with the Source Library team. Thank you!' };
+}
+
 // ── Tool definitions ───────────────────────────────────────────────
 
 // Shared annotation for all read-only tools
@@ -497,6 +508,34 @@ const TOOLS: Tool[] = [
       required: ['message'],
     },
   },
+  {
+    name: 'share_findings',
+    title: 'Share Findings',
+    description: 'Share a research dossier back to the Source Library team — a title, an optional summary, and an ordered list of citations (the passages your thesis rests on). Each citation is a reference { book_id, page, note }, NOT copied text: the library re-renders the canonical quote from the reference, so links stay authoritative. Use this when the user has assembled a thesis backed by passages across one or more books and wants to contribute it back. Like submit_feedback, this goes to the team for review (not an instant public page).',
+    annotations: { title: 'Share Findings', readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        title: { type: 'string', description: 'Title of the dossier / thesis (2-300 chars)' },
+        summary: { type: 'string', description: 'Optional prose summarizing the argument (max 5000 chars)' },
+        citations: {
+          type: 'array',
+          description: 'Ordered list of supporting passages (1-50). Get book_id + page from get_quote / search_translations.',
+          items: {
+            type: 'object',
+            properties: {
+              book_id: { type: 'string', description: 'The book ID' },
+              page: { type: 'number', description: 'Page number' },
+              note: { type: 'string', description: 'Optional note on why this passage matters' },
+            },
+            required: ['book_id', 'page'],
+          },
+        },
+        name: { type: 'string' }, email: { type: 'string' },
+      },
+      required: ['title', 'citations'],
+    },
+  },
 ];
 
 // ── Tool dispatch ──────────────────────────────────────────────────
@@ -516,6 +555,7 @@ async function handleToolCall(name: string, args: ToolArgs) {
     case 'get_quote': return getQuote(args);
     case 'search_images': return searchImages(args);
     case 'submit_feedback': return submitFeedback(args);
+    case 'share_findings': return shareFindings(args);
     default: throw new Error(`Unknown tool: ${name}`);
   }
 }

--- a/src/app/api/share-findings/[id]/route.ts
+++ b/src/app/api/share-findings/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { ObjectId } from 'mongodb';
+import { withAdminAuth } from '@/lib/auth-helpers';
+
+// PATCH /api/share-findings/[id] — mark a submission read/unread (admin only)
+export const PATCH = withAdminAuth(async (
+  request: NextRequest,
+  _session,
+  context?: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await context!.params;
+    if (!ObjectId.isValid(id)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+    }
+    const body = await request.json();
+    const read = body.read === true;
+
+    const db = await getDb();
+    const result = await db.collection('shared_findings').updateOne(
+      { _id: new ObjectId(id) },
+      { $set: { read, read_at: read ? new Date() : null } },
+    );
+    if (result.matchedCount === 0) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Share-findings patch error:', error);
+    return NextResponse.json({ error: 'Failed to update' }, { status: 500 });
+  }
+});

--- a/src/app/api/share-findings/route.ts
+++ b/src/app/api/share-findings/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { withAdminAuth } from '@/lib/auth-helpers';
+
+/**
+ * "Share back" — a lightweight submission inbox, modeled on /api/feedback.
+ *
+ * Once a reader or an AI research agent has assembled a thesis backed by an
+ * ordered set of passages across several books, they can share it back to the
+ * library. We store REFERENCES ({book_id, page, note}), never copied text —
+ * the canonical quote stays authoritative and links stay live. This is an
+ * inbox the team reviews (and may later curate into a published collection),
+ * NOT a public publishing surface — so there's no auth, ownership, visibility
+ * tier, or moderation to build. See issue #2821.
+ */
+
+interface CitationInput {
+  book_id?: unknown;
+  page?: unknown;
+  note?: unknown;
+}
+
+const MAX_CITATIONS = 50;
+
+// POST /api/share-findings — submit a dossier (anonymous, like feedback)
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { title, summary, citations, name, email } = body as {
+      title?: unknown; summary?: unknown; citations?: unknown; name?: unknown; email?: unknown;
+    };
+
+    if (!title || typeof title !== 'string' || title.trim().length < 2) {
+      return NextResponse.json({ error: 'A title (min 2 chars) is required' }, { status: 400 });
+    }
+    if (title.length > 300) {
+      return NextResponse.json({ error: 'Title too long (max 300)' }, { status: 400 });
+    }
+    if (summary !== undefined && (typeof summary !== 'string' || summary.length > 5000)) {
+      return NextResponse.json({ error: 'Summary must be a string under 5000 chars' }, { status: 400 });
+    }
+    if (!Array.isArray(citations) || citations.length === 0) {
+      return NextResponse.json({ error: 'At least one citation { book_id, page } is required' }, { status: 400 });
+    }
+    if (citations.length > MAX_CITATIONS) {
+      return NextResponse.json({ error: `Too many citations (max ${MAX_CITATIONS})` }, { status: 400 });
+    }
+
+    // Validate + normalize each citation. We store only the reference, so the
+    // rendered quote is always re-derived from the canonical (wrapper-stripped)
+    // page text at view time — copied text is never persisted here.
+    const cleanCitations: { book_id: string; page: number; note: string | null }[] = [];
+    for (const c of citations as CitationInput[]) {
+      const bookId = typeof c.book_id === 'string' ? c.book_id.trim() : '';
+      const page = Number(c.page);
+      if (!bookId || !Number.isInteger(page) || page < 1) {
+        return NextResponse.json(
+          { error: 'Each citation needs a non-empty book_id and a positive integer page' },
+          { status: 400 },
+        );
+      }
+      const note = typeof c.note === 'string' ? c.note.trim().slice(0, 1000) : null;
+      cleanCitations.push({ book_id: bookId, page, note: note || null });
+    }
+
+    const db = await getDb();
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || null;
+
+    const doc = {
+      title: title.trim(),
+      summary: typeof summary === 'string' ? summary.trim() || null : null,
+      citations: cleanCitations,
+      name: typeof name === 'string' ? name.trim() || null : null,
+      email: typeof email === 'string' ? email.trim().toLowerCase() || null : null,
+      ip,
+      user_agent: request.headers.get('user-agent') || null,
+      created_at: new Date(),
+      read: false,
+    };
+
+    const result = await db.collection('shared_findings').insertOne(doc);
+
+    return NextResponse.json({
+      ok: true,
+      id: result.insertedId.toString(),
+      message: 'Thank you — your findings were shared with the Source Library team.',
+    });
+  } catch (error) {
+    console.error('Share-findings error:', error);
+    return NextResponse.json({ error: 'Failed to save submission' }, { status: 500 });
+  }
+}
+
+// GET /api/share-findings — list submissions (admin only; contains IPs/emails)
+//   ?status=unread|read   filter by lifecycle state (default: all)
+export const GET = withAdminAuth(async (request: NextRequest) => {
+  try {
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get('status');
+    const limit = Math.min(parseInt(searchParams.get('limit') || '200'), 500);
+
+    const filter: Record<string, unknown> =
+      status === 'unread' ? { read: { $ne: true } } :
+      status === 'read' ? { read: true } : {};
+
+    const db = await getDb();
+    const [items, unread, read] = await Promise.all([
+      db.collection('shared_findings').find(filter).sort({ created_at: -1 }).limit(limit).toArray(),
+      db.collection('shared_findings').countDocuments({ read: { $ne: true } }),
+      db.collection('shared_findings').countDocuments({ read: true }),
+    ]);
+
+    return NextResponse.json({
+      findings: items.map((d) => ({ ...d, _id: (d._id as { toString(): string }).toString() })),
+      counts: { unread, read },
+    });
+  } catch (error) {
+    console.error('Share-findings list error:', error);
+    return NextResponse.json({ error: 'Failed to list submissions' }, { status: 500 });
+  }
+});


### PR DESCRIPTION
Addresses #2821 with a deliberately light design (the full essay object was overbuilt — agreed with Derek this session).

## The need, lightly
Once a reader or AI research agent has assembled a thesis backed by an ordered set of passages across one or more books, there's nowhere to **share it back**. This adds exactly that, modeled on the existing **feedback system**: an anonymous structured submission that lands in a team-reviewed inbox. No accounts, no private/public tiers, no moderation surface, no publishing platform.

## Stores references, never copied text
Each citation is `{ book_id, page, note }`. The canonical (wrapper-stripped) quote is re-derived from the reference at view time, so links stay authoritative and nothing copyrighted is persisted (the design principle from the issue).

## What's in it
- **`POST /api/share-findings`** — anonymous submit (`title` + optional `summary` + ordered `citations[]`), validated, mirrors `/api/feedback`.
- **`GET /api/share-findings`** + **`PATCH /api/share-findings/[id]`** — admin-only (`withAdminAuth`) review + read/unread lifecycle.
- **`/admin/shared-findings`** — light review page (no email-reply workflow); citations render as click-through `/book/<id>?page=<n>` links.
- **`share_findings` MCP tool on BOTH surfaces** — the in-app `/api/mcp` route **and** the npm `@source-library/mcp-server` package (the one agents `claude mcp add`), so an agent can actually publish a dossier back. npm bumped 4.3.4 → **4.5.0** (ships on next publish; #2823's branch uses 4.4.0 → no version collision in either merge order).

## Scope / out of scope
- **In scope:** submission + admin review.
- **Out of scope (deliberate):** auto-publishing a submission as a public page. Curating a worthwhile dossier into a public collection stays a manual editorial step using existing tools.

## Verification
- `npx tsc --noEmit` clean for both the app and `mcp-server`.
- Endpoint mirrors the proven `/api/feedback` POST/GET pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)