### PR TITLE
feat(librarian): weighted collection-scoped search

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -28,6 +28,10 @@ const chatRequestSchema = z.object({
   history: z.array(messageSchema).max(50).optional(),
   visibility: z.enum(['public', 'private']).optional(),
   stream: z.boolean().optional(),
+  // Optional collection slug/topic to weight the search toward. Set by the
+  // "Ask the Librarian" entry point on a collection page; the Librarian biases
+  // results toward this collection while still surfacing strong outside matches.
+  collection: z.string().max(120).nullable().optional(),
 });
 
 /**
@@ -96,7 +100,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { threadId, message, history = [], visibility = 'public', stream = false } = parsed.data;
+  const { threadId, message, history = [], visibility = 'public', stream = false, collection = null } = parsed.data;
   const db = await getDb();
 
   // Get user display name (anonymous visitors skip the lookup)
@@ -200,7 +204,7 @@ export async function POST(request: NextRequest) {
 
   if (!stream) {
     try {
-      for await (const step of streamAgenticResponse(message, history, activeThreadId)) {
+      for await (const step of streamAgenticResponse(message, history, activeThreadId, { collection })) {
         if (step.type === 'text') {
           fullText += step.text || '';
         } else if (step.type === 'sources') {
@@ -272,7 +276,7 @@ export async function POST(request: NextRequest) {
     try {
       await send({ type: 'threadId', threadId: activeThreadId });
 
-      for await (const step of streamAgenticResponse(message, history, activeThreadId)) {
+      for await (const step of streamAgenticResponse(message, history, activeThreadId, { collection })) {
         lastStepType = step.type;
         switch (step.type) {
           case 'thinking':

--- a/src/lib/embassy/collection-catalog.ts
+++ b/src/lib/embassy/collection-catalog.ts
@@ -1,0 +1,107 @@
+/**
+ * Collection catalog + fuzzy resolver for the Librarian.
+ *
+ * Two jobs:
+ *  1. Give the model a compact list of real collection slugs so it can map a
+ *     user's topic ("fungi and mushrooms") to the right collection ("mycology")
+ *     and pass it to the `search` tool — no verbatim slug required.
+ *  2. Resolve whatever the model (or a collection page) passes — a slug, a name,
+ *     or a loose topic phrase — to a canonical collection slug. Soft: returns
+ *     null when nothing matches well, and the search falls back to unweighted
+ *     global (weighting is a bias, never a hard gate).
+ *
+ * The catalog is cached in-process for an hour; it changes rarely and a stale
+ * entry only affects which collection a search leans toward.
+ */
+
+import { getDb } from '@/lib/mongodb';
+
+export interface CollectionEntry {
+  slug: string;
+  name: string;
+  bookCount: number;
+}
+
+let cache: { at: number; entries: CollectionEntry[] } | null = null;
+const TTL_MS = 60 * 60 * 1000;
+
+export async function getCollectionCatalog(): Promise<CollectionEntry[]> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.entries;
+  try {
+    const db = await getDb();
+    const rows = await db.collection('collections')
+      .find({ visible: { $ne: false }, hidden: { $ne: true }, tenantId: { $in: [null, undefined] } })
+      .project({ _id: 0, slug: 1, name: 1, book_count: 1 })
+      .toArray();
+    const entries: CollectionEntry[] = rows
+      .filter(r => r.slug && r.name)
+      .map(r => ({ slug: r.slug, name: r.name, bookCount: r.book_count || 0 }))
+      .sort((a, b) => b.bookCount - a.bookCount);
+    cache = { at: Date.now(), entries };
+    return entries;
+  } catch {
+    return cache?.entries ?? [];
+  }
+}
+
+/** Compact catalog block for the system prompt: "slug — Name (N)" per line. */
+export async function formatCatalogForPrompt(): Promise<string> {
+  const entries = await getCollectionCatalog();
+  if (entries.length === 0) return '';
+  const lines = entries.map(e => `${e.slug} — ${e.name}`).join('\n');
+  return lines;
+}
+
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+function tokens(s: string): string[] {
+  return normalize(s).split(' ').filter(t => t.length > 2);
+}
+
+/**
+ * Resolve an arbitrary input (slug / name / topic phrase) to a collection slug.
+ * Returns null when no confident match — caller then searches unweighted.
+ */
+export async function resolveCollectionSlug(input: string | null | undefined): Promise<string | null> {
+  if (!input || !input.trim()) return null;
+  const entries = await getCollectionCatalog();
+  if (entries.length === 0) return null;
+
+  const raw = input.trim().toLowerCase();
+  const normInput = normalize(input);
+
+  // 1. exact slug
+  const bySlug = entries.find(e => e.slug.toLowerCase() === raw || e.slug.toLowerCase() === normInput.replace(/ /g, '-'));
+  if (bySlug) return bySlug.slug;
+
+  // 2. exact name (case-insensitive)
+  const byName = entries.find(e => e.name.toLowerCase() === raw);
+  if (byName) return byName.slug;
+
+  // 3. substring either direction on slug or name
+  const sub = entries.find(e => {
+    const slugN = normalize(e.slug);
+    const nameN = normalize(e.name);
+    return slugN === normInput || nameN === normInput ||
+      slugN.includes(normInput) || normInput.includes(slugN) ||
+      nameN.includes(normInput);
+  });
+  if (sub) return sub.slug;
+
+  // 4. token-overlap scoring (handles "fungi mushrooms" → "mycology" only weakly;
+  //    real topic→collection mapping is the model's job via the prompt catalog,
+  //    this is the typo/loose-phrase safety net).
+  const inTokens = new Set(tokens(input));
+  if (inTokens.size === 0) return null;
+  let best: { slug: string; score: number } | null = null;
+  for (const e of entries) {
+    const cand = new Set([...tokens(e.name), ...tokens(e.slug)]);
+    let shared = 0;
+    for (const t of inTokens) if (cand.has(t)) shared++;
+    const score = shared / Math.max(inTokens.size, 1);
+    if (score > 0 && (!best || score > best.score)) best = { slug: e.slug, score };
+  }
+  // Require a majority token overlap to avoid spurious weighting.
+  return best && best.score >= 0.5 ? best.slug : null;
+}

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -154,11 +154,12 @@ function formatNotebookForPrompt(notebook: ResearchNotebook | null): string {
 const TOOL_DECLARATIONS: FunctionDeclaration[] = [
   {
     name: 'search',
-    description: 'Search Source Library — fuses keyword search (Atlas) with semantic search (AI embeddings) across the collection. Returns the strongest matching passages plus relevant books. Works for both verbatim queries (Latin/German phrases, technical terms) and conceptual queries (modern paraphrases of historical ideas). Search in English for best coverage — nearly all books are translated.',
+    description: 'Search Source Library — fuses keyword search (Atlas) with semantic search (AI embeddings) across the whole library. Returns the strongest matching passages plus relevant books. Works for both verbatim queries (Latin/German phrases, technical terms) and conceptual queries (modern paraphrases of historical ideas). Search in English for best coverage — nearly all books are translated.',
     parameters: {
       type: Type.OBJECT,
       properties: {
         query: { type: Type.STRING, description: 'Search query — use period-appropriate terms when known (e.g., "sympathetic magic" not "resonance", "flying ointment" not "psychedelics"). Modern paraphrases also work — semantic matching handles the mapping.' },
+        collection: { type: Type.STRING, description: 'Optional. A collection slug from the "Collections" list in your instructions to FOCUS the search on. Results are weighted toward that collection but still include strong matches from the rest of the library — it is a lean, not a filter. Set this whenever the user\'s question is clearly about one collection\'s subject (e.g. a question about fungi or mushrooms → "mycology"; about tarot or planetary seals → "astrology"). Pick the single most relevant slug; if unsure or the topic spans the whole library, omit it.' },
       },
       required: ['query'],
     },
@@ -296,14 +297,24 @@ function tenantVisibilityFilter() {
 //
 // Replaces the prior executeSearchCollection (keyword-only) and
 // executeSearchSemantic (book-then-page only) with a single unified path.
-async function executeSearch(query: string): Promise<{
+async function executeSearch(query: string, collection?: string | null): Promise<{
   passages: Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; text: string; score: number; source: string }>;
   books: Array<{ id: string; title: string; author?: string; authorSlug?: string; year?: number; slug?: string }>;
+  collectionUsed: string | null;
 }> {
   const { hybridSearch } = await import('@/lib/search/librarian-search');
+  // The model may pass a slug, a name, or a loose topic phrase — normalize it to
+  // a real slug (or null → plain global search). Weighting is soft, so a missed
+  // resolution just searches the whole library unweighted.
+  const { resolveCollectionSlug } = await import('@/lib/embassy/collection-catalog');
+  const collectionUsed = await resolveCollectionSlug(collection);
   // Main-site only; pass tenant UUID here for per-tenant Librarian instances.
-  const { passages, books } = await hybridSearch(query, { tenantId: null });
-  return { passages, books };
+  const { passages, books } = await hybridSearch(query, {
+    tenantId: null,
+    collection: collectionUsed,
+    // collectionWeight defaults to 2 in hybridSearch.
+  });
+  return { passages, books, collectionUsed };
 }
 
 async function executeSearchWikipedia(query: string): Promise<{ title: string; summary: string; url: string } | null> {
@@ -468,6 +479,7 @@ async function executeTool(
   name: string,
   args: Record<string, unknown>,
   threadId?: string,
+  collectionContext?: string | null,
 ): Promise<{ result: unknown; step: LibrarianStep; sources?: SourceCard[] }> {
   switch (name) {
     case 'search':
@@ -477,7 +489,11 @@ async function executeTool(
     case 'search_collection':
     case 'search_semantic': {
       const query = args.query as string;
-      const data = await executeSearch(query);
+      // Explicit per-call collection wins; otherwise fall back to the thread's
+      // collection context (set when the user opened the Librarian from a
+      // collection page). Either way the weighting is soft.
+      const collection = (args.collection as string | undefined) || collectionContext || null;
+      const data = await executeSearch(query, collection);
       const totalFound = data.passages.length + data.books.length;
 
       let context = '';
@@ -509,10 +525,11 @@ async function executeTool(
         pageNumber: p.page_number, snippet: stripAnnotations(p.text).slice(0, 200), inCollection: true,
       }));
 
+      const focusNote = data.collectionUsed ? `, focused on ${data.collectionUsed}` : '';
       return {
-        result: { found: totalFound, context },
+        result: { found: totalFound, context, collection: data.collectionUsed },
         step: { type: 'tool_result', name: 'search', query, found: totalFound,
-          summary: totalFound > 0 ? `Found ${data.passages.length} passages across ${data.books.length} books` : 'No results' },
+          summary: totalFound > 0 ? `Found ${data.passages.length} passages across ${data.books.length} books${focusNote}` : `No results${focusNote}` },
         sources,
       };
     }
@@ -682,7 +699,32 @@ async function executeTool(
 
 // ── System Prompt ─────────────────────────────────────────────────────
 
-function buildSystemPrompt(notebookContext: string, messageIndex: number): string {
+function buildSystemPrompt(
+  notebookContext: string,
+  messageIndex: number,
+  collectionOpts?: { catalog?: string; collectionContext?: string | null },
+): string {
+  const catalog = collectionOpts?.catalog?.trim();
+  const collectionContext = collectionOpts?.collectionContext;
+
+  // Tell the model it can focus a search on a collection, list the real slugs,
+  // and — if the session started from a collection page — that it should lean
+  // that way by default.
+  const collectionSection = catalog
+    ? `## Collections — focusing a search
+
+The library is organized into thematic collections. The **search** tool takes an optional \`collection\` argument: pass the slug of the most relevant collection and results are *weighted toward* it while still surfacing strong matches from the rest of the library (a lean, not a filter). Set it whenever a question is clearly about one collection's subject — map the user's topic to the closest slug yourself (e.g. "mushrooms / fungi" → \`mycology\`; "tarot" → \`astrology\`). If a question spans the whole library or none fits, omit it.
+${collectionContext ? `\n**This conversation started inside the "${collectionContext}" collection.** Unless the user clearly shifts to a different subject, pass \`collection: "${collectionContext}"\` on your searches so results stay focused there.\n` : ''}
+Available collection slugs (slug — name):
+${catalog}
+
+`
+    : '';
+
+  return buildSystemPromptBody(notebookContext, messageIndex, collectionSection);
+}
+
+function buildSystemPromptBody(notebookContext: string, messageIndex: number, collectionSection: string): string {
   return `You are the Librarian of the Embassy of the Free Mind — a research agent for scholars exploring rare historical texts across the pre-modern intellectual tradition. Your knowledge spans alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, Indian philosophy, Sanskrit texts, Egyptian sources, early modern science, demonology, and the broader history of ideas from antiquity through the Enlightenment.
 
 You are warm, knowledgeable, and genuinely enthusiastic about these texts. You speak like a learned scholar who loves sharing discoveries.
@@ -747,7 +789,7 @@ After 2-3 rounds of searching (4-6 tool calls total), stop and synthesize what y
 
 Source Library has over 10,000 rare books spanning antiquity through the 18th century, many translated into English for the first time. The collection covers alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, demonology, Indian philosophy, Sanskrit texts, Egyptian sources, early modern science, and related traditions across Western, Middle Eastern, and Asian intellectual history.
 
-## Formatting
+${collectionSection}## Formatting
 
 - Use markdown headers (## and ###) to organize longer responses into clear sections
 - Use **bold** for key terms and *italics* for book titles (linked: *[Title](url)*)
@@ -772,6 +814,7 @@ export async function* streamAgenticResponse(
   userMessage: string,
   history: ConversationMessage[] = [],
   threadId?: string,
+  options?: { collection?: string | null },
 ): AsyncGenerator<LibrarianStep> {
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) throw new Error('GEMINI_API_KEY not set');
@@ -785,7 +828,17 @@ export async function* streamAgenticResponse(
   const notebookContext = formatNotebookForPrompt(notebook);
   // User messages in history = prior user turns. This message is the next one.
   const messageIndex = history.filter(m => m.role === 'user').length + 1;
-  const systemPrompt = buildSystemPrompt(notebookContext, messageIndex);
+
+  // Collection catalog (so the model can map a topic → the right slug) and the
+  // optional collection context (when the Librarian was opened from a collection
+  // page, searches lean toward it by default). Resolve the context to a real
+  // slug so a stray value can't silently break weighting.
+  const { formatCatalogForPrompt, resolveCollectionSlug } = await import('@/lib/embassy/collection-catalog');
+  const [catalog, collectionContext] = await Promise.all([
+    formatCatalogForPrompt(),
+    resolveCollectionSlug(options?.collection),
+  ]);
+  const systemPrompt = buildSystemPrompt(notebookContext, messageIndex, { catalog, collectionContext });
 
   const contents: Array<{ role: string; parts: Array<Record<string, unknown>> }> = [
     { role: 'user', parts: [{ text: systemPrompt }] },
@@ -876,7 +929,7 @@ export async function* streamAgenticResponse(
       functionCalls.map(async part => {
         const fc = (part as { functionCall: { name: string; args: Record<string, unknown> } }).functionCall;
         try {
-          return await executeTool(fc.name, fc.args || {}, threadId);
+          return await executeTool(fc.name, fc.args || {}, threadId, collectionContext);
         } catch (err) {
           console.error(`[Librarian] Tool ${fc.name} failed:`, err instanceof Error ? err.message : err);
           return {

--- a/src/lib/search/librarian-search.ts
+++ b/src/lib/search/librarian-search.ts
@@ -65,7 +65,28 @@ export interface HybridSearchOptions {
   limit?: number;
   /** Max book-level results in `books` (default 5). */
   bookLimit?: number;
+  /**
+   * Optional collection slug to WEIGHT (not filter) results toward. When set,
+   * the collection's own pages get extra weighted votes in the RRF merge, so
+   * they dominate the top of the list while strong matches from the rest of the
+   * library still surface. Soft bias — an unknown/empty slug is a no-op.
+   */
+  collection?: string | null;
+  /**
+   * How hard to lean toward `collection`. The collection-scoped lists contribute
+   * `collectionWeight / (k + rank)` each in the RRF merge vs 1/(k+rank) for the
+   * global lists. ~2 = strong lean but outsiders still break through; 1 = mild;
+   * higher → closer to a hard filter. Default 2.
+   */
+  collectionWeight?: number;
 }
+
+// Atlas $in and the scoped page-vector scan both degrade on huge id lists, so
+// cap how many of a collection's books we scope to. Larger collections
+// contribute their most substantial books first (Mongo sorts by book_count);
+// keyword recall across the rest still flows via the global keyword path, so
+// nothing is hard-excluded — those pages just don't get the extra boost.
+const MAX_SCOPED_BOOKS = 400;
 
 // ── Tenant visibility (Mongo book metadata enrichment) ───────────────
 
@@ -175,6 +196,74 @@ async function globalPageSource(query: string, opts: HybridSearchOptions): Promi
   }
 }
 
+// ── Collection-scoped sources (the weighting input) ──────────────────
+
+/**
+ * Resolve a collection slug to the book_ids we'll scope to (visibility/tenant
+ * gated, capped at MAX_SCOPED_BOOKS, largest books first).
+ */
+async function collectionBookIds(slug: string, opts: HybridSearchOptions): Promise<string[]> {
+  const db = await getDb();
+  const rows = await db.collection('books')
+    .find({ collections: slug, ...tenantBookFilter(opts.tenantId) })
+    .project({ id: 1 })
+    .sort({ book_count: -1, pages_count: -1 })
+    .limit(MAX_SCOPED_BOOKS)
+    .toArray();
+  return rows.map(r => r.id).filter(Boolean);
+}
+
+/**
+ * Run keyword + semantic search restricted to a collection's books. These two
+ * ranked lists become extra, weighted inputs to the RRF merge — that's the
+ * whole mechanism behind "lean toward this collection." Returns [] when the
+ * collection is empty/unknown so the caller cleanly falls back to global only.
+ */
+async function collectionScopedSources(
+  query: string,
+  bookIds: string[],
+): Promise<{ scopedKeyword: RawHit[]; scopedSemantic: RawHit[] }> {
+  if (bookIds.length === 0) return { scopedKeyword: [], scopedSemantic: [] };
+  const db = await getDb();
+
+  const [kwRows, semRows] = await Promise.all([
+    db.collection('pages')
+      .aggregate([
+        buildPageSearchStage(query, bookIds),
+        { $limit: 24 },
+        { $project: { book_id: 1, page_number: 1, 'translation.data': 1, score: { $meta: 'searchScore' } } },
+      ])
+      .toArray()
+      .catch(() => [] as Record<string, unknown>[]),
+    semanticPageSearchScoped(query, bookIds, 20).catch(() => []),
+  ]);
+
+  const scopedKeyword: RawHit[] = [];
+  const perBook = new Map<string, number>();
+  for (const r of kwRows as Array<{ book_id: string; page_number: number; translation?: { data?: string }; score: number }>) {
+    const n = (perBook.get(r.book_id) || 0) + 1;
+    if (n > 2) continue;
+    perBook.set(r.book_id, n);
+    scopedKeyword.push({
+      book_id: r.book_id,
+      page_number: r.page_number,
+      text: (r.translation?.data || '').slice(0, 1200),
+      score: r.score,
+      source: 'cp_kw',
+    });
+  }
+
+  const scopedSemantic: RawHit[] = semRows.map(p => ({
+    book_id: p.book_id,
+    page_number: p.page_number,
+    text: p.snippet,
+    score: p.score,
+    source: 'cp_sem',
+  }));
+
+  return { scopedKeyword, scopedSemantic };
+}
+
 // ── RRF merge ────────────────────────────────────────────────────────
 
 /**
@@ -183,13 +272,15 @@ async function globalPageSource(query: string, opts: HybridSearchOptions): Promi
  * k=60 is the canonical default. Eval showed k=20 vs k=60 produce identical
  * rankings on the current golden set — stick with 60 for posterity.
  */
-function rrfMerge(rankedLists: RawHit[][], k = 60): RawHit[] {
+function rrfMerge(rankedLists: RawHit[][], k = 60, weights?: number[]): RawHit[] {
   const scores = new Map<string, { hit: RawHit; score: number; sources: Set<string> }>();
-  for (const list of rankedLists) {
+  for (let li = 0; li < rankedLists.length; li++) {
+    const list = rankedLists[li];
+    const weight = weights?.[li] ?? 1;
     for (let i = 0; i < list.length; i++) {
       const hit = list[i];
       const key = `${hit.book_id}:${hit.page_number}`;
-      const contribution = 1 / (k + i + 1);
+      const contribution = weight / (k + i + 1);
       const existing = scores.get(key);
       if (existing) {
         existing.score += contribution;
@@ -351,17 +442,36 @@ export async function hybridSearch(
 ): Promise<HybridSearchResult> {
   const limit = opts.limit ?? 8;
   const bookLimit = opts.bookLimit ?? 5;
+  const collectionWeight = opts.collectionWeight ?? 2;
 
-  // Fan out to all three sources + book-level Atlas in parallel
-  const [kw, btp, gp, books] = await Promise.all([
+  // If a collection is requested, resolve its books up front so the scoped
+  // searches can run alongside the global ones.
+  const scopedIds = opts.collection
+    ? await collectionBookIds(opts.collection, opts)
+    : [];
+
+  // Fan out to all three global sources + book-level Atlas + (optionally) the
+  // collection-scoped sources, all in parallel.
+  const [kw, btp, gp, books, scoped] = await Promise.all([
     keywordSource(query, opts),
     bookThenPageSource(query, opts),
     globalPageSource(query, opts),
     findBooks(query, opts, bookLimit),
+    scopedIds.length > 0
+      ? collectionScopedSources(query, scopedIds)
+      : Promise.resolve({ scopedKeyword: [] as RawHit[], scopedSemantic: [] as RawHit[] }),
   ]);
 
-  // RRF merge passages
-  let merged = rrfMerge([kw, btp, gp]);
+  // RRF merge. Global lists weight 1; the collection-scoped lists weight
+  // `collectionWeight` (~2) so a page that's both relevant AND in the
+  // collection outranks an equally-relevant page from elsewhere — without
+  // excluding the elsewhere page. Collection hits also tend to appear in the
+  // global lists too, compounding the lean.
+  let merged = rrfMerge(
+    [kw, btp, gp, scoped.scopedKeyword, scoped.scopedSemantic],
+    60,
+    [1, 1, 1, collectionWeight, collectionWeight],
+  );
 
   // Optional cross-encoder rerank (no-op without API key)
   merged = await maybeRerank(query, merged);


### PR DESCRIPTION
## What

Adds an optional **collection focus** to the Librarian's hybrid search. When a collection is supplied, its books contribute two extra **weighted** ranked lists (keyword + semantic) to the existing RRF merge, so results lean toward that collection while strong matches from the rest of the library still surface. It's a soft bias (default weight 2), **not** a hard filter.

Two ways it activates:
1. **In chat** — the model gets the collection slug list in its system prompt and maps a topic itself ("fungi/mushrooms" → `mycology`), passing a new optional `collection` arg on the `search` tool.
2. **From a collection page** — the chat API now accepts an optional `collection` in the request body; the Librarian then defaults its searches to that collection. This is the contract for a future "Ask the Librarian" button on collection pages.

## Files
- `src/lib/embassy/collection-catalog.ts` *(new)* — cached catalog + fuzzy slug resolver (slug / name / loose phrase → canonical slug).
- `src/lib/search/librarian-search.ts` — `collection`/`collectionWeight` opts, bounded scoped sources (cap 400 books), per-list weights in `rrfMerge`.
- `src/lib/embassy/librarian.ts` — `collection` tool param, catalog + context injected into the system prompt, threaded through `executeTool`.
- `src/app/api/embassy/chat/route.ts` — optional `collection` in the request schema, passed to `streamAgenticResponse`.

## How to test (preview)
- Ask about a clearly-collection topic (e.g. *"what did people believe about mushrooms and visions"*) → mycology passages should lead, with the occasional strong outside hit.
- POST with `{ "message": "...", "collection": "mycology" }` → searches should lean to that collection regardless of wording.
- Sanity: a broad cross-library question (e.g. *"the soul"*) should be unaffected.

## Out of scope (deliberately left for follow-ups)
- The **books[] side panel** stays a global search; only passages are weighted.
- No collection-page UI button yet — this PR only adds the backend contract.
- A native collection filter inside the Supabase `match_semantic` RPC (single-pass boosted ANN) — not needed; the two-list app-side weighting covers it.
- Note: if a Cohere/Voyage rerank key is ever set, the cross-encoder rerank would partially dilute the lean (no-op today, no key set).

## Risk
Type-checks clean (`tsc --noEmit`). No schema/RPC migration, no data writes. When no collection is passed, behavior is identical to today (the new lists are empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)