### PR TITLE
feat(mcp-server): citation_link headline + publish-ready 4.5.0

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@source-library%2Fmcp-server.svg)](https://www.npmjs.com/package/@source-library/mcp-server)
 
-Search, read, and cite 22,000+ rare pre-modern texts (alchemy, Hermetica, Kabbalah, theology, early science) with AI-generated English translations. 11 tools (full-text + semantic search, reading, exact quoting, image search, duplicate detection, feedback). CLI + MCP server, no API key needed.
+Search, read, and cite 22,000+ rare pre-modern texts (alchemy, Hermetica, Kabbalah, theology, early science) with AI-generated English translations. 12 tools (full-text + semantic search, reading, exact quoting, image search, duplicate detection, feedback, sharing findings back). CLI + MCP server, no API key needed.
 
 ## Quick Start
 
@@ -49,7 +49,7 @@ npm install && npm run build
 npm start
 ```
 
-## 11 Tools
+## 12 Tools
 
 ### Search & Discovery
 
@@ -141,7 +141,7 @@ Read a book. Prefer `chapter` for chapter-at-a-time reading; falls back to `from
 
 #### get_quote
 
-Get the exact translated text of a single page for quoting. Returns the full translation, original OCR, and a formatted citation. Always use this before putting text in quotation marks — never paraphrase from memory.
+Get the exact translated text of a single page for quoting. Returns the verbatim translation, original OCR, and a formatted citation. The response headline is `citation_link` — the stable `sourcelibrary.org/q/…` shortlink to present alongside the quote and its page number. Always use this before putting text in quotation marks — never paraphrase from memory. Suggested render: `> [quote]` then `— [Author], p. [N]. [citation_link]`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -195,6 +195,18 @@ Submit feedback, bug reports, or feature requests directly to the Source Library
 | `name` | string | No | Your name |
 | `email` | string | No | Email for follow-up |
 | `page` | string | No | Related page URL |
+
+#### share_findings
+
+Share a research dossier back to the Source Library team — a title, optional summary, and an ordered list of citations (`{ book_id, page, note }`, references not copied text). Like `submit_feedback`, it goes to the team for review.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `title` | string | Yes | Title of the dossier / thesis (2-300 chars) |
+| `summary` | string | No | Prose summarizing the argument (max 5000 chars) |
+| `citations` | array | Yes | Ordered `{ book_id, page, note }` passages (1-50) |
+| `name` | string | No | Your name |
+| `email` | string | No | Email for follow-up |
 
 ## CLI
 

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "mcp-server"
   },
-  "version": "4.3.4",
+  "version": "4.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@source-library/mcp-server",
-      "version": "4.3.4",
+      "version": "4.5.0",
       "transport": {
         "type": "stdio"
       }

--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -456,12 +456,32 @@ export async function getBookText(args: {
     }
   }
 
-  // Add quoting guidance when returning page text
+  // Add quoting guidance when returning page text. Reinforce the house style:
+  // every quote shown to the user carries its page number and the page's
+  // sourcelibrary.org url (each page entry includes both).
   (result as Record<string, unknown>).tip =
-    "When quoting from these pages, copy text verbatim from the translation field. Do not paraphrase or reconstruct from memory.";
+    "When quoting from these pages, copy text verbatim from the translation field — do not paraphrase or reconstruct from memory. " +
+    "Present each quote to the user with its page number and the page's url (sourcelibrary.org link).";
 
   return result;
 }
+
+// The shareable shortlink lives at result.citation.short_url. Lift it to a
+// headline `citation_link` (and keep `short_url` for back-compat) so an LLM
+// caller treats the quote-plus-link as the deliverable instead of burying the
+// link in a citation sub-object and paraphrasing without it (#2820).
+function withCitationLink(result: Record<string, unknown>): Record<string, unknown> {
+  const citation = result.citation as Record<string, unknown> | undefined;
+  const link = citation?.short_url as string | undefined;
+  return link ? { citation_link: link, short_url: link, ...result } : result;
+}
+
+const QUOTE_TIP =
+  "Copy the translation text exactly when quoting — do not paraphrase or " +
+  "reconstruct from memory, even if you know this text from other sources. " +
+  "Present the citation_link to the user alongside the quote. Render as:\n" +
+  "> [exact translation text, verbatim]\n" +
+  "> — [Author], p. [N]. [citation_link]";
 
 export async function getQuote(args: {
   book_id: string;
@@ -470,10 +490,7 @@ export async function getQuote(args: {
   const params = new URLSearchParams({ page: String(args.page) });
   const result = await apiGet(`/books/${args.book_id}/quote`, params) as Record<string, unknown>;
 
-  return {
-    ...result,
-    tip: "Copy the translation text exactly when quoting. Do not paraphrase or reconstruct from memory, even if you know this text from other sources.",
-  };
+  return { ...withCitationLink(result), tip: QUOTE_TIP };
 }
 
 type ImageSource = "gallery" | "artworks" | "all";

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -376,7 +376,7 @@ const TOOLS: Tool[] = [
     name: "get_quote",
     title: "Get Quote",
     description:
-      "Get the exact translated text of a single page for quoting. Returns the full translation, original OCR text, and a formatted citation. ALWAYS use this tool before putting text in quotation marks — copy the exact text from the response. Do not paraphrase or reconstruct from memory.",
+      "Get the exact translated text of a single page for quoting. Returns the verbatim translation, original OCR text, and a formatted citation. ALWAYS use this tool before putting text in quotation marks — copy the exact text from the response, do not paraphrase or reconstruct from memory. The response headline is citation_link (the stable sourcelibrary.org/q/… shortlink) — present it to the user alongside the quote and its page number. Render as:\n> [exact translation text, verbatim]\n> — [Author], p. [N]. [citation_link]",
     annotations: { title: "Get Quote", readOnlyHint: true },
     inputSchema: {
       type: "object" as const,


### PR DESCRIPTION
Makes the npm `@source-library/mcp-server` package do the thing that actually matters: **every quote comes back with its page number and a sourcelibrary.org link, headlined, so the assistant shows it by default.**

Mirrors the proven half of #2820 (which had only landed on the in-app `/api/mcp` route) into the installed package.

## Changes
- **`get_quote`** lifts the shortlink to a headline `citation_link` (`short_url` kept for back-compat) + a render-template tip: `> [quote]` / `— [Author], p. [N]. [citation_link]`.
- **`get_book_text`** tip now tells the model to present each quote with its `page_number` and the page's `url`.
- **Deliberately did NOT port `get_quotes`** (the batch tool). After a step-back review, it doesn't change cite behavior — just adds surface. Toolset stays lean at **12 tools**.

## Publish-ready housekeeping (npm is currently at 4.3.0)
- **README:** `11 → 12` tools, document `share_findings`, note `citation_link` on `get_quote`.
- **server.json:** version `4.3.4 → 4.5.0` (was stale; matters for the MCP registry, not the npm tarball).

## Verified on the built `dist/`
- 12 tools incl. `share_findings`, **no** `get_quotes`.
- `get_quote` returns `citation_link` + `short_url` + `page` + render-template tip (smoke-tested against the live quote API).
- `tsc` clean; pack is `dist/` + README + package.json only, no secrets.

## Note on the publish itself
Publishing 4.5.0 ships everything merged since 4.3.0: structured errors (#2828), `share_findings` (#2844), this `citation_link` change, plus the earlier unpublished #2621/#2618/lang-filter work. The `npm publish` is a manual step (Derek's npm auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)