### PR TITLE
feat(analytics): /metrics skill — one-shot audience, engagement & cost report

### DIFF
--- a/.claude/skills/metrics/SKILL.md
+++ b/.claude/skills/metrics/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: metrics
+description: One-shot audience & usage report — signups, DAU/MAU, time on-site, traffic, top content, search behavior, referrers, countries, and user journeys. Use when asked "what's our usage?", "how many signups?", "time on site?", "traffic?", or any audience/engagement metrics question.
+---
+
+# Metrics Snapshot
+
+Runs the two analytics scripts that together give the full audience + usage
+picture, then summarizes the numbers and surfaces qualitative texture. Both read
+production Mongo (`bookstore`) — purely read-only, no cost, no permission needed.
+
+## Run all three (in order)
+
+```bash
+set -a; source .env.production.local; set +a
+node scripts/analytics/audience-metrics.mjs            # signups, DAU/MAU, dwell, nudge list
+node scripts/analytics/usage-deepdive.mjs --days 30    # traffic, content, search, journeys
+node scripts/analytics/engagement-metrics.mjs          # retention, conversion, reading depth, demand, social, AI, cost
+```
+
+`usage-deepdive.mjs` also writes a dated markdown report to
+`scripts/output/analytics/`. All three take `--days N` (default 30) except
+reading-depth in engagement-metrics, which is fixed at 7d for query speed.
+
+## What each surfaces
+
+**`audience-metrics.mjs`** — the numbers people ask for first:
+- Signups: total, email-verified, has-logged-in, new in 30d / 7d / 24h
+- beta_subscribers / newsletter_subscribers counts
+- MAU (30d unique fingerprints), avg DAU (14d), last-3-day DAU
+- **Time on-site:** median + mean session duration (multi-pageview sessions, 7d)
+- Incomplete-signup nudge list size (verification started, never finished)
+
+**`usage-deepdive.mjs`** — the context:
+- Daily pageviews (spot spikes — Instagram/EFM pushes show up here)
+- Path categories + top 30 books + top collections + library pages
+- Referrers (direct / embassyofthefreemind.com / l.instagram.com / search engines / AI bots)
+- Countries (US + a strong Spanish-language tail: AR, ES, BR)
+- **Search behavior:** top queries, zero-result queries, latency, refinement chains
+- User journeys: entry/exit kinds, transitions, bounce rate, funnel
+
+**`engagement-metrics.mjs`** — the dimensions the other two leave out:
+- Conversion: visitor→signup rate (~15%), verify % (~43%), ever-logged-in %
+- Retention: returning visitors (>1 day, ~25%), returning accounts (login≥2), DAU:MAU stickiness (~11%)
+- Reading depth: pages read per reader-book pair — sobering: median=1, ~84% read a single page, deep reads (10+) ~0.2%
+- Mission actions: download / share / cite / gate_hit event counts (share & cite are near-zero — flag it)
+- Content demand: top `not_found_reports` URLs = what people want and we lack (broken BPH/legacy links + genuinely missing pages)
+- Social: likes (count + distinct visitors + by target), feedback (count, unread, wants_to_help)
+- AI surfaces: `ai_usage` by feature (librarian / search-expand / voice + cost + latency), `api_usage` by route/identity (the `mcp` route = external agents), distinct active API keys
+- Pipeline cost: `gemini_usage_daily` spend (⚠ the daily rollup goes stale when the pipeline is paused — the script flags it; raw `gemini_usage` + `ai_usage` stay current)
+
+## Reporting guidance
+
+Lead with the headline numbers (signups + growth, MAU/DAU, time on-site), then
+traffic and top content. **Always add qualitative texture** — the richest signal
+is in `usage-deepdive`'s **search refinement chains** (you can read individual
+sessions: a HEMA scholar hopping through Fechtbücher → Talhoffer → Liechtenauer;
+a Gnostic seeker hitting zero-results on bardo / Iamblichus / Gnostic ascent =
+unmet acquisition need).
+
+Caveats to state, not hide:
+- **The refinement-chain table is a CROSS-USER aggregate sample, not per-session
+  journeys.** Adjacent rows where `to` of one = `from` of the next ARE one
+  ip_hash's real sequence, but most of the table stitches unrelated users. Do
+  NOT narrate it as one person's trail without pulling that ip_hash's raw rows
+  from `search_queries` first (sort by ts). `to_n` is the query's result count,
+  and a lone `0` is usually one anomalous search (e.g. Corpus Hermeticum medians
+  ~13 results), not a content gap. Verify before storytelling.
+- **Sessionization is ip+ua with last-octet-zeroed IPs** — a coarse proxy, not
+  true users. DAU/MAU are fingerprints, not accounts.
+- **Most zero-result queries are truncated typeahead** (`parace`, `fludd`, `th`)
+  logged mid-keystroke — not real content gaps. Only conceptual zero-results
+  (bardo, Gnostic ascent) point at genuine missing content.
+- Bot filtering is on; bot share is normally ~0%.
+- For deeper behavioral signal (scroll, rage-clicks, replays) the source is
+  PostHog (EU project 148667) + session replay — gated to ~3% of visitors, good
+  for behavior, not absolute counts. Mongo is truth for totals.
+```

--- a/scripts/analytics/audience-metrics.mjs
+++ b/scripts/analytics/audience-metrics.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Audience metrics: signups, verification funnel, DAU/MAU, dwell time, and the
+// incomplete-signup nudge list. Companion to usage-deepdive.mjs (which covers
+// traffic, content, search, and journeys). Run both for the full picture — the
+// /metrics skill does exactly that.
+//
+// Source: users, analytics_pageviews, verification_tokens, beta_subscribers.
+// Sessionization: (ip + first-60-chars-of-userAgent) within a 30-minute idle
+//   window. IPs have their last octet zeroed at ingest, so this is a coarse but
+//   honest proxy. Dwell only counts multi-pageview sessions (a single hit has
+//   no measurable duration).
+//
+// Run:  set -a; source .env.production.local; set +a; \
+//       node scripts/analytics/audience-metrics.mjs
+
+import { withMongo } from '../lib/mongo.mjs';
+
+const norm = (e) => (e || '').trim().toLowerCase();
+
+await withMongo(async (db) => {
+  const now = new Date();
+  const d30 = new Date(now - 30 * 864e5), d7 = new Date(now - 7 * 864e5), d1 = new Date(now - 864e5);
+
+  // ---- USERS / SIGNUPS ----
+  const users = db.collection('users');
+  const total = await users.countDocuments({});
+  const verified = await users.countDocuments({ emailVerified: { $ne: null, $exists: true } });
+  const new30 = await users.countDocuments({ createdAt: { $gt: d30 } });
+  const new7 = await users.countDocuments({ createdAt: { $gt: d7 } });
+  const new1 = await users.countDocuments({ createdAt: { $gt: d1 } });
+  const hasLogin = await users.countDocuments({ lastLogin: { $exists: true } });
+  console.log('=== USERS ===');
+  console.log(`total signups        ${total}`);
+  console.log(`emailVerified        ${verified}`);
+  console.log(`has logged in        ${hasLogin}`);
+  console.log(`new last 30d         ${new30}`);
+  console.log(`new last 7d          ${new7}`);
+  console.log(`new last 24h         ${new1}`);
+
+  // beta / newsletter subscribers
+  for (const cn of ['beta_subscribers', 'newsletter_subscribers']) {
+    try { const c = await db.collection(cn).countDocuments({}); console.log(`${cn}: ${c}`); } catch {}
+  }
+
+  // ---- DAU / MAU / DWELL from analytics_pageviews ----
+  const pv = db.collection('analytics_pageviews');
+  // MAU = distinct fingerprints in 30d
+  const mau = (await pv.aggregate([
+    { $match: { timestamp: { $gt: d30 } } },
+    { $group: { _id: { ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] } } } },
+    { $count: 'n' },
+  ]).toArray())[0]?.n || 0;
+  // avg DAU over last 14 days
+  const dau = await pv.aggregate([
+    { $match: { timestamp: { $gt: new Date(now - 14 * 864e5) } } },
+    { $group: { _id: { day: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp' } }, ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] } } } },
+    { $group: { _id: '$_id.day', users: { $sum: 1 } } },
+    { $sort: { _id: 1 } },
+  ]).toArray();
+  const avgDau = Math.round(dau.reduce((s, d) => s + d.users, 0) / (dau.length || 1));
+  console.log('\n=== ENGAGEMENT ===');
+  console.log(`MAU (30d unique ip+ua)   ${mau}`);
+  console.log(`avg DAU (last 14d)       ${avgDau}`);
+  console.log(`DAU last 3 days: ${dau.slice(-3).map((d) => d._id + '=' + d.users).join('  ')}`);
+
+  // Dwell time: per session (ip+ua, 30-min gap) duration. last7d for speed.
+  const rows = await pv.find({ timestamp: { $gt: d7 } }, { projection: { ip: 1, userAgent: 1, timestamp: 1 } }).toArray();
+  const byFp = new Map();
+  for (const r of rows) {
+    const k = r.ip + '|' + (r.userAgent || '').slice(0, 60);
+    (byFp.get(k) || byFp.set(k, []).get(k)).push(+new Date(r.timestamp));
+  }
+  const durations = []; let multiHit = 0;
+  for (const ts of byFp.values()) {
+    ts.sort((a, b) => a - b);
+    let start = ts[0], prev = ts[0], n = 1;
+    for (let i = 1; i < ts.length; i++) {
+      if (ts[i] - prev > 30 * 60 * 1000) { if (n > 1) { durations.push((prev - start) / 1000); multiHit++; } start = ts[i]; n = 1; }
+      else n++;
+      prev = ts[i];
+    }
+    if (n > 1) { durations.push((prev - start) / 1000); multiHit++; }
+  }
+  durations.sort((a, b) => a - b);
+  const med = durations[Math.floor(durations.length / 2)] || 0;
+  const mean = durations.reduce((s, x) => s + x, 0) / (durations.length || 1);
+  const fmt = (s) => `${Math.floor(s / 60)}m${Math.round(s % 60)}s`;
+  console.log('\n=== DWELL (last 7d, multi-pageview sessions only) ===');
+  console.log(`multi-page sessions      ${multiHit}`);
+  console.log(`median session duration  ${fmt(med)}`);
+  console.log(`mean session duration    ${fmt(mean)}`);
+
+  // ---- INCOMPLETE SIGNUPS: verification token issued, never became a user ----
+  const userEmails = new Set((await users.find({}, { projection: { email: 1 } }).toArray()).map((u) => norm(u.email)).filter(Boolean));
+  let vt = [];
+  try { vt = await db.collection('verification_tokens').find({}).project({ identifier: 1, expires: 1 }).toArray(); } catch {}
+  const pendingEmails = new Set();
+  for (const t of vt) { const e = norm(t.identifier); if (e && !userEmails.has(e)) pendingEmails.add(e); }
+  console.log('\n=== INCOMPLETE SIGNUPS (nudge candidates) ===');
+  console.log(`verification_tokens rows      ${vt.length}`);
+  console.log(`distinct emails started but never completed signup: ${pendingEmails.size}`);
+}, { timeoutMs: 120000 });

--- a/scripts/analytics/engagement-metrics.mjs
+++ b/scripts/analytics/engagement-metrics.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// Engagement, retention, conversion, demand, and mission-action metrics.
+// Third leg of the /metrics trio (audience-metrics.mjs = signups/DAU/dwell;
+// usage-deepdive.mjs = traffic/content/search/journeys; this = everything those
+// two leave on the table). All read-only against Mongo `bookstore`. No cost.
+//
+// Run:  set -a; source .env.production.local; set +a; \
+//       node scripts/analytics/engagement-metrics.mjs [--days N]
+//
+// Sections:
+//   1. Conversion & retention   (visitor->signup, verify %, returning, stickiness)
+//   2. Reading depth            (pages read per reader-book, from page_read events)
+//   3. Mission actions          (download / share / cite / gate_hit events)
+//   4. Content demand           (not_found_reports — what people want we lack)
+//   5. Social                   (likes, feedback)
+//   6. AI surfaces              (ai_usage by feature; api_usage by route / agent)
+//   7. Pipeline cost            (gemini_usage_daily)
+
+import { withMongo } from '../lib/mongo.mjs';
+
+const DAYS = (() => { const i = process.argv.indexOf('--days'); return i > -1 ? Number(process.argv[i + 1]) : 30; })();
+const now = Date.now();
+const since = (d) => new Date(now - d * 864e5);
+const SINCE = since(DAYS), D7 = since(7), D1 = since(1);
+const pct = (a, b) => b ? (100 * a / b).toFixed(1) + '%' : '—';
+const fmtUsd = (n) => '$' + (n || 0).toFixed(2);
+const sec = (s) => `${Math.floor(s / 60)}m${Math.round(s % 60)}s`;
+
+// Section runner so one failing block never kills the rest.
+async function section(title, fn) {
+  console.log(`\n## ${title}`);
+  try { await fn(); } catch (e) { console.log(`  (skipped: ${e.message})`); }
+}
+
+await withMongo(async (db) => {
+  const pv = db.collection('analytics_pageviews');
+  const ev = db.collection('analytics_events');
+  const users = db.collection('users');
+
+  console.log(`# Source Library — Engagement & Retention (last ${DAYS}d)`);
+  console.log(`Window since ${SINCE.toISOString()}`);
+
+  // ---- 1. CONVERSION & RETENTION ----
+  await section('1. Conversion & retention', async () => {
+    const fp = { _id: { ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] } } };
+    const uniq = (await pv.aggregate([{ $match: { timestamp: { $gt: SINCE } } }, { $group: fp }, { $count: 'n' }]).toArray())[0]?.n || 0;
+    const newSignups = await users.countDocuments({ createdAt: { $gt: SINCE } });
+    const totalUsers = await users.countDocuments({});
+    const verified = await users.countDocuments({ emailVerified: { $ne: null, $exists: true } });
+    const everLoggedIn = await users.countDocuments({ loginCount: { $gte: 1 } });
+    const repeatLogin = await users.countDocuments({ loginCount: { $gte: 2 } });
+    console.log(`unique visitors (${DAYS}d)      ${uniq}`);
+    console.log(`new signups (${DAYS}d)          ${newSignups}`);
+    console.log(`visitor -> signup conversion  ${pct(newSignups, uniq)}`);
+    console.log(`email verified                ${verified}/${totalUsers}  (${pct(verified, totalUsers)})`);
+    console.log(`ever logged in                ${everLoggedIn}/${totalUsers}  (${pct(everLoggedIn, totalUsers)})`);
+    console.log(`returning accounts (login>=2) ${repeatLogin}/${totalUsers}  (${pct(repeatLogin, totalUsers)})`);
+
+    // Returning visitors: fingerprints active on >1 distinct calendar day in window.
+    const byDays = await pv.aggregate([
+      { $match: { timestamp: { $gt: SINCE } } },
+      { $group: { _id: { ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] }, d: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp' } } } } },
+      { $group: { _id: { ip: '$_id.ip', ua: '$_id.ua' }, days: { $sum: 1 } } },
+      { $group: { _id: '$days', n: { $sum: 1 } } }, { $sort: { _id: 1 } },
+    ], { allowDiskUse: true }).toArray();
+    const totalFp = byDays.reduce((s, x) => s + x.n, 0);
+    const multiDay = byDays.filter((x) => x._id > 1).reduce((s, x) => s + x.n, 0);
+    console.log(`returning visitors (>1 day)   ${multiDay}/${totalFp}  (${pct(multiDay, totalFp)})`);
+
+    // Stickiness DAU:MAU (avg DAU last 14d / MAU 30d).
+    const dau = await pv.aggregate([
+      { $match: { timestamp: { $gt: since(14) } } },
+      { $group: { _id: { d: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp' } }, ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] } } } },
+      { $group: { _id: '$_id.d', n: { $sum: 1 } } },
+    ], { allowDiskUse: true }).toArray();
+    const avgDau = Math.round(dau.reduce((s, d) => s + d.n, 0) / (dau.length || 1));
+    console.log(`stickiness (DAU:MAU)          ${pct(avgDau, uniq)}  (avgDAU ${avgDau} / MAU ${uniq})`);
+  });
+
+  // ---- 2. READING DEPTH ----
+  await section('2. Reading depth (page_read events, last 7d)', async () => {
+    // distinct pages read per (reader ip, book) — proxy for how far into a book a reader gets.
+    const depth = await ev.aggregate([
+      { $match: { event: 'page_read', timestamp: { $gt: D7 }, book_id: { $ne: null } } },
+      { $group: { _id: { ip: '$ip', b: '$book_id' }, pages: { $addToSet: '$page_id' } } },
+      { $project: { n: { $size: '$pages' } } },
+      { $group: { _id: '$n', sessions: { $sum: 1 } } }, { $sort: { _id: 1 } },
+    ], { allowDiskUse: true }).toArray();
+    const all = []; for (const d of depth) for (let i = 0; i < d.sessions; i++) all.push(d._id);
+    all.sort((a, b) => a - b);
+    const n = all.length, med = all[Math.floor(n / 2)] || 0, p90 = all[Math.floor(n * 0.9)] || 0;
+    const oneOnly = depth.find((d) => d._id === 1)?.sessions || 0;
+    const deep = depth.filter((d) => d._id >= 10).reduce((s, d) => s + d.sessions, 0);
+    console.log(`reader-book pairs (7d)        ${n}`);
+    console.log(`pages read / pair  median=${med}  p90=${p90}`);
+    console.log(`read only 1 page              ${oneOnly}  (${pct(oneOnly, n)})`);
+    console.log(`read 10+ pages (deep read)    ${deep}  (${pct(deep, n)})`);
+    const opens = await ev.countDocuments({ event: 'book_read', timestamp: { $gt: D7 } });
+    console.log(`book opens (book_read, 7d)    ${opens}`);
+  });
+
+  // ---- 3. MISSION ACTIONS ----
+  await section(`3. Mission actions (events, last ${DAYS}d)`, async () => {
+    const rows = await ev.aggregate([
+      { $match: { timestamp: { $gt: SINCE }, event: { $in: ['download', 'share', 'cite', 'gate_hit', 'signin_view'] } } },
+      { $group: { _id: '$event', n: { $sum: 1 } } }, { $sort: { n: -1 } },
+    ]).toArray();
+    const map = Object.fromEntries(rows.map((r) => [r._id, r.n]));
+    for (const e of ['download', 'share', 'cite', 'gate_hit', 'signin_view']) console.log(`${e.padEnd(14)} ${map[e] || 0}`);
+    console.log(`NOTE: share/cite near-zero = the core "quote the source" action is barely instrumented or barely used.`);
+  });
+
+  // ---- 4. CONTENT DEMAND ----
+  await section(`4. Content demand — not_found_reports (last ${DAYS}d)`, async () => {
+    const nf = db.collection('not_found_reports');
+    const total = await nf.aggregate([{ $match: { created_at: { $gt: SINCE } } }, { $group: { _id: null, n: { $sum: { $ifNull: ['$hit_count', 1] } } } }]).toArray();
+    console.log(`total 404 hits                ${total[0]?.n || 0}`);
+    const top = await nf.aggregate([
+      { $match: { created_at: { $gt: SINCE } } },
+      { $group: { _id: '$url', n: { $sum: { $ifNull: ['$hit_count', 1] } } } },
+      { $sort: { n: -1 } }, { $limit: 20 },
+    ]).toArray();
+    console.log('top 20 missing URLs:');
+    for (const t of top) console.log(`  ${String(t.n).padStart(5)}  ${decodeURIComponent(t._id || '').slice(0, 70)}`);
+  });
+
+  // ---- 5. SOCIAL ----
+  await section(`5. Social — likes & feedback (last ${DAYS}d)`, async () => {
+    const likes = db.collection('likes');
+    const lk = await likes.countDocuments({ created_at: { $gt: SINCE } });
+    const lkVisitors = (await likes.aggregate([{ $match: { created_at: { $gt: SINCE } } }, { $group: { _id: '$visitor_id' } }, { $count: 'n' }]).toArray())[0]?.n || 0;
+    const byType = await likes.aggregate([{ $match: { created_at: { $gt: SINCE } } }, { $group: { _id: '$target_type', n: { $sum: 1 } } }, { $sort: { n: -1 } }]).toArray();
+    console.log(`likes (${DAYS}d)               ${lk}  from ${lkVisitors} distinct visitors`);
+    console.log(`  by target: ${byType.map((b) => `${b._id}=${b.n}`).join('  ')}`);
+    const fb = db.collection('feedback');
+    const fbN = await fb.countDocuments({ created_at: { $gt: SINCE } });
+    const fbUnread = await fb.countDocuments({ created_at: { $gt: SINCE }, read: { $ne: true } });
+    const fbHelp = await fb.countDocuments({ created_at: { $gt: SINCE }, wants_to_help: true });
+    console.log(`feedback (${DAYS}d)            ${fbN}   unread=${fbUnread}   wants_to_help=${fbHelp}`);
+  });
+
+  // ---- 6. AI SURFACES ----
+  await section(`6. AI surfaces (last ${DAYS}d)`, async () => {
+    const ai = db.collection('ai_usage');
+    const byFeat = await ai.aggregate([
+      { $match: { timestamp: { $gt: SINCE } } },
+      { $group: { _id: '$feature', calls: { $sum: 1 }, cost: { $sum: '$costUsd' }, p50ms: { $avg: '$ms' } } },
+      { $sort: { calls: -1 } }, { $limit: 12 },
+    ]).toArray();
+    console.log('ai_usage by feature:  calls | cost | avg_ms');
+    for (const f of byFeat) console.log(`  ${String(f._id).padEnd(22)} ${String(f.calls).padStart(6)} | ${fmtUsd(f.cost).padStart(8)} | ${Math.round(f.p50ms || 0)}`);
+
+    const api = db.collection('api_usage');
+    const byKind = await api.aggregate([{ $match: { ts: { $gt: SINCE } } }, { $group: { _id: '$identity_kind', n: { $sum: 1 } } }, { $sort: { n: -1 } }]).toArray();
+    console.log(`\napi_usage by identity: ${byKind.map((k) => `${k._id || 'null'}=${k.n}`).join('  ')}`);
+    const topRoutes = await api.aggregate([{ $match: { ts: { $gt: SINCE } } }, { $group: { _id: '$route', n: { $sum: 1 } } }, { $sort: { n: -1 } }, { $limit: 10 }]).toArray();
+    console.log('top API routes:');
+    for (const r of topRoutes) console.log(`  ${String(r.n).padStart(7)}  ${r._id}`);
+    const keyed = await api.aggregate([{ $match: { ts: { $gt: SINCE }, api_key_id: { $ne: null } } }, { $group: { _id: '$api_key_id', n: { $sum: 1 } } }, { $count: 'n' }]).toArray();
+    console.log(`distinct API keys active      ${keyed[0]?.n || 0}`);
+  });
+
+  // ---- 7. PIPELINE COST ----
+  await section('7. Pipeline cost (gemini_usage_daily)', async () => {
+    const gud = db.collection('gemini_usage_daily');
+    const rows = await gud.find({}).sort({ date: -1 }).limit(60).toArray();
+    if (!rows.length) { console.log('  (no rows)'); return; }
+    // date is a 'YYYY-MM-DD' string, so lexical >= is a valid date filter.
+    const cut7 = new Date(now - 7 * 864e5).toISOString().slice(0, 10);
+    const cut30 = new Date(now - 30 * 864e5).toISOString().slice(0, 10);
+    const sumSince = (cut) => rows.filter((r) => r.date >= cut).reduce((s, r) => s + (r.totalCost || 0), 0);
+    const latest = rows[0].date;
+    const stale = latest < cut7;
+    console.log(`latest recorded day           ${latest}${stale ? '  ⚠ STALE — daily rollup not updating (pipeline pause? check the aggregator)' : ''}`);
+    console.log(`Gemini spend  last 7 cal-days=${fmtUsd(sumSince(cut7))}  last 30=${fmtUsd(sumSince(cut30))}`);
+    console.log('most recent recorded days (date | cost | records):');
+    for (const r of rows.slice(0, 7)) console.log(`  ${r.date}  ${fmtUsd(r.totalCost).padStart(9)}  ${r.totalRecords || 0}`);
+  });
+}, { timeoutMs: 180000 });


### PR DESCRIPTION
## What

A `/metrics` skill that answers \"what's our usage / signups / time on-site / engagement?\" in one shot. Runs three **read-only** Mongo scripts and reports the full picture.

**In scope (3 files, additive only):**
- `scripts/analytics/audience-metrics.mjs` — promoted from a throwaway temp (`_tmp_user_metrics.mjs`) to a documented permanent script. Signups, verify funnel, DAU/MAU, dwell, incomplete-signup nudge list.
- `scripts/analytics/engagement-metrics.mjs` — **new.** The dimensions our existing `usage-deepdive.mjs` left out:
  - Conversion (visitor→signup ~15%, verify ~43%)
  - Retention (returning visitors ~25%, DAU:MAU stickiness ~11%)
  - Reading depth (pages per reader-book — median 1, ~84% single-page)
  - Mission actions (download/share/cite event counts — surfaces that share/cite are near-zero)
  - Content demand (`not_found_reports` — what people want we lack; mostly broken BPH/legacy links)
  - Social (likes, feedback)
  - AI surfaces (`ai_usage` by feature, `api_usage` by route — the `mcp` route shows external agents reading the library)
  - Pipeline cost (`gemini_usage_daily`, with a stale-rollup guard)
- `.claude/skills/metrics/SKILL.md` — ties the three together (with `usage-deepdive.mjs`), with analysis caveats baked in.

## Out of scope (deliberately left for later)
- **No new instrumentation.** This only reports existing data. True cohort retention, new-vs-returning split, scroll depth, UTM attribution, and GSC organic all need new events or external pulls — separate PR.
- The near-zero share/cite counts suggest the quote-action events may not be fully wired; diagnosing that is follow-up, not part of this PR.

## Safety
All three scripts are read-only (`countDocuments`/`aggregate`/`find`) against Mongo `bookstore`. No writes, no Gemini/API spend. `audience-metrics.mjs` was verified against the temp it replaces (identical output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)