### PR TITLE
feat(legal): AI-training/TDM reservation — robots split + TDMRep + /licensing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -115,6 +115,13 @@ const nextConfig: NextConfig = {
           // Next.js uses these headers for client-side navigation — without Vary,
           // CF caches the RSC payload and serves it to fresh page loads as raw text.
           { key: 'Vary', value: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
+          // Text-and-data-mining reservation (TDMRep / EU DSM Art. 4 opt-out).
+          // Expressly reserves AI-training / TDM rights site-wide in a
+          // machine-readable way; the policy URL explains the separate license
+          // required for training use. Mirrors /.well-known/tdmrep.json and the
+          // robots.ts training-crawler reservation. See /licensing.
+          { key: 'TDM-Reservation', value: '1' },
+          { key: 'TDM-Policy', value: 'https://sourcelibrary.org/licensing' },
         ],
       },
       // Prevent Cloudflare from caching RSC (React Server Component) responses.

--- a/public/.well-known/tdmrep.json
+++ b/public/.well-known/tdmrep.json
@@ -1,0 +1,7 @@
+[
+  {
+    "location": "/",
+    "tdm-reservation": 1,
+    "tdm-policy": "https://sourcelibrary.org/licensing"
+  }
+]

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -37,9 +37,11 @@ We respond within 24 hours.
 
 ## Licensing
 
-Original texts are public domain. AI-generated translations and content are licensed under CC BY-SA 4.0 — free for individuals, researchers, and small organizations with attribution.
+Original texts are public domain. AI-generated translations and editorial content are licensed under CC BY-SA 4.0 — free for individuals, researchers, and organizations with attribution and ShareAlike.
 
-**Large-scale AI use (organizations with 5M+ users):** Please use our API or MCP server rather than scraping, and contact us about a partnership. We want these texts in AI training data — we just ask for attribution and a conversation. See https://sourcelibrary.org/terms
+**Search indexing and reading on a user's behalf are welcome** — when you quote a page, show the quote with its page number and the page's sourcelibrary.org link.
+
+**AI training / text-and-data-mining is expressly RESERVED and requires a separate license.** CC BY-SA's ShareAlike term is incompatible with proprietary model training, so the free license does not authorize it. We reserve TDM rights (EU Directive 2019/790 Art. 4), expressed machine-readably via /.well-known/tdmrep.json, the `TDM-Reservation: 1` HTTP header, and /robots.txt. We genuinely want these texts in the models that shape how people learn — please use our API or MCP server under a partnership rather than scraping, and reach out. Full policy: https://sourcelibrary.org/licensing — contact derek@sourcelibrary.org ("AI Licensing Inquiry").
 
 ## MCP Server (Recommended)
 

--- a/src/app/licensing/page.tsx
+++ b/src/app/licensing/page.tsx
@@ -1,0 +1,116 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+
+export const metadata: Metadata = {
+  title: 'AI & Data-Mining Licensing - Source Library',
+  description:
+    'How AI training and text-and-data-mining use of Source Library works. Search indexing and individual use are welcome; large-scale AI training requires a separate license.',
+  alternates: {
+    canonical: '/licensing',
+  },
+};
+
+export default function LicensingPage() {
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="AI & Data-Mining Licensing"
+          subtitle="What's open, what's reserved, and how to license training use"
+        />
+      }
+      bg="bg-cream"
+    >
+      <div className="prose-content max-w-none space-y-8">
+        <p className="text-xl text-secondary leading-relaxed">
+          We want these texts read, cited, and built upon — including by AI. This
+          page states plainly how that works, so there&rsquo;s no ambiguity about
+          what is freely permitted and what requires a separate license.
+        </p>
+
+        <p className="text-sm text-muted">
+          <strong>Effective date:</strong> June 28, 2026
+          &middot; Operated by the Embassy of the Free Mind, Amsterdam, the Netherlands.
+          &middot; Companion to our <Link href="/terms" className="text-accent-rust hover:underline">Terms &amp; Licensing</Link>.
+        </p>
+
+        {/* ── Open ── */}
+        <section className="bg-white rounded-xl p-8 border border-border-light">
+          <h2 className="text-2xl text-primary mb-4">Freely permitted — no license needed</h2>
+          <ul className="space-y-2 text-secondary leading-relaxed list-disc pl-5">
+            <li>
+              <strong>Original texts &amp; page images</strong> are in the public domain.
+              Use them freely.
+            </li>
+            <li>
+              <strong>Our AI-generated translations and editorial content</strong> are
+              licensed <strong>CC&nbsp;BY-SA&nbsp;4.0</strong> — free for individuals,
+              researchers, and organizations, with attribution and ShareAlike.
+            </li>
+            <li>
+              <strong>Search indexing.</strong> Search engines and AI search crawlers
+              (Googlebot, Bingbot, Claude-SearchBot, OAI-SearchBot, …) are welcome to
+              index our pages so readers can discover and cite them.
+            </li>
+            <li>
+              <strong>AI assistants reading on a user&rsquo;s behalf.</strong> When a
+              person asks an assistant to read or quote a specific Source Library page,
+              that&rsquo;s welcome — please show the quote with its page number and the
+              page&rsquo;s sourcelibrary.org link.
+            </li>
+            <li>
+              <strong>The public API &amp; MCP server</strong>, within posted rate limits,
+              for research and individual use. See <Link href="/developers" className="text-accent-rust hover:underline">/developers</Link>.
+            </li>
+          </ul>
+        </section>
+
+        {/* ── Reserved ── */}
+        <section className="bg-white rounded-xl p-8 border border-border-light">
+          <h2 className="text-2xl text-primary mb-4">Reserved — a separate license is required</h2>
+          <p className="text-secondary leading-relaxed mb-4">
+            <strong>Using our content to train, fine-tune, or build AI models, and
+            bulk text-and-data-mining (TDM) for those purposes, is expressly
+            reserved and requires a separate license from us.</strong> This is true
+            even though the translations are CC&nbsp;BY-SA&nbsp;4.0: that license&rsquo;s
+            <em> ShareAlike</em> term would require any model built on this material to
+            be released under CC&nbsp;BY-SA — which proprietary models do not do. So the
+            free license does not authorize proprietary AI training. We reserve those
+            rights and offer them under a separate agreement.
+          </p>
+          <p className="text-secondary leading-relaxed mb-4">
+            We reserve text-and-data-mining rights within the meaning of Article&nbsp;4
+            of EU Directive 2019/790, expressed in machine-readable form via:
+          </p>
+          <ul className="space-y-2 text-secondary leading-relaxed list-disc pl-5">
+            <li><code>/.well-known/tdmrep.json</code> (TDM Reservation Protocol)</li>
+            <li>the <code>TDM-Reservation: 1</code> HTTP header on every response</li>
+            <li>the training-crawler rules in <code>/robots.txt</code></li>
+          </ul>
+          <p className="text-secondary leading-relaxed mt-4">
+            Bulk or training access is available — through the API or a dataset
+            license, under a partnership. We&rsquo;d genuinely like these texts in the
+            models that shape how people learn; we just ask for a conversation and
+            attribution. Please don&rsquo;t scrape the full corpus around the controls.
+          </p>
+        </section>
+
+        {/* ── Get a license ── */}
+        <section className="bg-white rounded-xl p-8 border border-border-light">
+          <h2 className="text-2xl text-primary mb-4">Licensing &amp; partnerships</h2>
+          <p className="text-secondary leading-relaxed">
+            For an AI-training or bulk-dataset license, or a research partnership,
+            contact <a href="mailto:derek@sourcelibrary.org?subject=AI%20Licensing%20Inquiry" className="text-accent-rust hover:underline">derek@sourcelibrary.org</a> with
+            the subject &ldquo;AI Licensing Inquiry.&rdquo; We respond within a day.
+          </p>
+        </section>
+
+        <p className="text-sm text-muted">
+          This page states our position and our express reservation of rights; it is
+          not legal advice. Nothing here waives any right not expressly granted.
+        </p>
+      </div>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,42 @@
 import { MetadataRoute } from 'next';
 
+/**
+ * Robots policy. Two intents, deliberately separated:
+ *
+ *  1. SEARCH-INDEX crawlers (Googlebot, Bingbot, Claude-SearchBot, OAI-SearchBot)
+ *     are ALLOWED on content. They are how readers discover and are sent to us;
+ *     surfacing our pages in search/answers serves the mission.
+ *
+ *  2. TRAINING / BULK crawlers (ClaudeBot, GPTBot, Google-Extended, CCBot,
+ *     Applebot-Extended, Meta-ExternalAgent, anthropic-ai, …) are RESERVED.
+ *     Our translations are CC-BY-SA 4.0 — whose ShareAlike term is incompatible
+ *     with proprietary model training — so AI training / text-and-data-mining
+ *     requires a SEPARATE license. See https://sourcelibrary.org/licensing and
+ *     the machine-readable reservation at /.well-known/tdmrep.json (TDMRep) plus
+ *     the TDM-Reservation HTTP header. Bulk/training access is available through
+ *     the API or MCP server under a partnership — not by scraping.
+ *
+ * This is the honor-system + express-reservation layer; the server-side bot gate
+ * (src/lib/bot-gate.ts) is the enforcement layer.
+ */
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = 'https://sourcelibrary.org';
+
+  // Endpoints a reserved AI crawler MAY still reach: the structured API, the
+  // partnership/licensing docs, and the blog. Everything else (full text) is reserved.
+  const aiAllowList = [
+    '/blog/',
+    '/api/search',
+    '/api/books/',
+    '/api/verify',
+    '/api/mcp',
+    '/llms.txt',
+    '/terms',
+    '/licensing',
+    '/developers',
+  ];
+  // Reserved crawlers that aren't given API access still get the public docs + blog.
+  const docsOnly = ['/blog/', '/llms.txt', '/terms', '/licensing', '/developers'];
 
   return {
     rules: [
@@ -43,80 +78,34 @@ export default function robots(): MetadataRoute.Robots {
         ],
       },
 
-      // AI training crawlers: block bulk scraping, point to API
-      // These companies should use our API or MCP server instead.
-      // See https://sourcelibrary.org/terms for licensing details.
-      {
-        userAgent: 'CCBot',
-        allow: '/blog/',
-        disallow: '/',
-      },
-      {
-        userAgent: 'Bytespider',
-        allow: '/blog/',
-        disallow: '/',
-      },
-      {
-        userAgent: 'Diffbot',
-        allow: '/blog/',
-        disallow: '/',
-      },
-      {
-        userAgent: 'Omgilibot',
-        allow: '/blog/',
-        disallow: '/',
-      },
-      {
-        userAgent: 'FacebookBot',
-        allow: '/blog/',
-        disallow: '/',
-      },
-      {
-        userAgent: 'Applebot',
-        allow: '/blog/',
-        disallow: '/',
-      },
-      {
-        userAgent: 'Google-Extended',
-        allow: '/blog/',
-        disallow: '/',
-      },
-      {
-        userAgent: 'PerplexityBot',
-        allow: '/blog/',
-        disallow: '/',
-      },
-      {
-        userAgent: 'Amazonbot',
-        allow: '/blog/',
-        disallow: '/',
-      },
-      {
-        userAgent: 'ClaudeBot',
-        disallow: '/',
-      },
-      {
-        userAgent: 'cohere-ai',
-        allow: '/blog/',
-        disallow: '/',
-      },
+      // ── SEARCH-INDEX crawlers: explicitly welcome on content ──
+      // Discovery + citability serve the mission. (Googlebot/Bingbot are already
+      // allowed via '*'; these AI search crawlers are named so the intent is
+      // unambiguous and they're never swept up with the training crawlers below.)
+      { userAgent: 'Claude-SearchBot', allow: '/' },
+      { userAgent: 'OAI-SearchBot', allow: '/' },
 
-      // AI assistants: welcome to use the API and llms.txt
-      // GPTBot, Claude-Web, etc. — access the structured API
-      {
-        userAgent: 'GPTBot',
-        allow: ['/blog/', '/api/search', '/api/books/', '/api/mcp', '/llms.txt', '/terms', '/developers'],
-        disallow: '/',
-      },
-      {
-        userAgent: 'Claude-Web',
-        allow: ['/blog/', '/api/search', '/api/books/', '/api/mcp', '/llms.txt', '/terms', '/developers'],
-        disallow: '/',
-      },
-      {
-        userAgent: 'Anthropic-AI',
-        disallow: '/',
-      },
+      // ── TRAINING / BULK crawlers: RESERVED — see /licensing ──
+      // CC-BY-SA's ShareAlike makes proprietary training incompatible with the
+      // free license; training/TDM needs a separate license. GPTBot/Claude-Web
+      // keep structured-API access (use the API/MCP, not scraping); the rest get
+      // the public docs + blog only. None get the full text.
+      { userAgent: 'GPTBot', allow: aiAllowList, disallow: '/' },
+      { userAgent: 'Claude-Web', allow: aiAllowList, disallow: '/' },
+      { userAgent: 'ClaudeBot', allow: docsOnly, disallow: '/' },
+      { userAgent: 'Anthropic-AI', allow: docsOnly, disallow: '/' },
+      { userAgent: 'Google-Extended', allow: docsOnly, disallow: '/' },
+      { userAgent: 'Applebot-Extended', allow: docsOnly, disallow: '/' },
+      { userAgent: 'Meta-ExternalAgent', allow: '/blog/', disallow: '/' },
+      { userAgent: 'CCBot', allow: '/blog/', disallow: '/' },
+      { userAgent: 'Bytespider', allow: '/blog/', disallow: '/' },
+      { userAgent: 'Diffbot', allow: '/blog/', disallow: '/' },
+      { userAgent: 'Omgilibot', allow: '/blog/', disallow: '/' },
+      { userAgent: 'FacebookBot', allow: '/blog/', disallow: '/' },
+      { userAgent: 'Applebot', allow: '/blog/', disallow: '/' },
+      { userAgent: 'PerplexityBot', allow: '/blog/', disallow: '/' },
+      { userAgent: 'Amazonbot', allow: '/blog/', disallow: '/' },
+      { userAgent: 'cohere-ai', allow: '/blog/', disallow: '/' },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,
     // Note: Next.js generateSitemaps() automatically creates a sitemap index

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -138,6 +138,11 @@ export default function TermsPage() {
               derek@sourcelibrary.org
             </a>
           </p>
+          <p className="text-secondary mt-4 text-sm">
+            For our full position on AI training and text-and-data-mining — including
+            our express reservation of those rights — see{' '}
+            <Link href="/licensing" className="text-accent-rust hover:underline">AI &amp; Data-Mining Licensing</Link>.
+          </p>
         </section>
 
         {/* ── API & MCP Access ── */}


### PR DESCRIPTION
Makes our position on AI use **explicit and machine-readable**: search/discovery is welcome, AI **training / text-and-data-mining is expressly reserved** and requires a separate license. This operationalizes the search-allowed / training-reserved split we discussed, and gives the EU DSM Art. 4 opt-out (and a US fair-use rebuttal) real machine-readable teeth — at zero cost and fully reversible.

## The four pieces
1. **`robots.ts`** — restructured into two clearly-commented groups:
   - **Search-index crawlers** (`Claude-SearchBot`, `OAI-SearchBot`) explicitly allowed on content (Googlebot/Bingbot already allowed via `*`). Discovery serves the mission.
   - **Training/bulk crawlers** (`ClaudeBot`, `GPTBot`, `Google-Extended`, `Applebot-Extended`, `Meta-ExternalAgent`, `CCBot`, …) reserved to docs/API only — never full text. Added `Applebot-Extended` + `Meta-ExternalAgent` (were missing).
2. **`/.well-known/tdmrep.json`** — TDM Reservation Protocol: `tdm-reservation: 1` + policy URL.
3. **`next.config.ts`** — `TDM-Reservation: 1` + `TDM-Policy` headers site-wide.
4. **`/licensing` page** — plain-English statement: what's free (PD originals, CC-BY-SA translations, search indexing, user-initiated reads, API within limits) vs reserved (proprietary training/TDM, with the ShareAlike rationale), the machine-readable reservation pointers, and a licensing contact. Plus `llms.txt` sharpened and a reciprocal link from `/terms`.

## Behavior changes
- `ClaudeBot` was fully blocked; now allowed the blog + licensing docs (so it can actually read the reservation), still no full text.
- `Claude-SearchBot` / `OAI-SearchBot` named explicitly (already allowed via `*` — no functional change, just legible intent).
- `Applebot-Extended`, `Meta-ExternalAgent` newly reserved.

## Important caveats (flagged, not resolved here)
- **Not legal advice.** The underlying claim — including whether AI-generated translations are even copyrightable, vs leaning on compilation / EU database / sui-generis rights — wants an **IP attorney** before being relied on. Asserting the reservation, however, costs nothing and is reversible.
- **Enforcement layer unchanged.** The server-side bot gate (`bot-gate.ts`, 20% of pages) still treats some search crawlers conservatively; reconciling it to match the new robots split (open search crawlers to full text) is a separate, deliberate follow-up since it changes access control.
- `tsc` clean; `tdmrep.json` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)