### PR TITLE
feat(bot-gate): open search crawlers to full text, keep training gated

### DIFF
--- a/src/app/api/iiif/[id]/search/route.ts
+++ b/src/app/api/iiif/[id]/search/route.ts
@@ -106,9 +106,11 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
     const bookId = book.id as string;
     const pagesCount = (book.pages_count as number) || 0;
 
-    // Bot gating
+    // Bot gating. NB: isTrustedBot is async — must be awaited, or the Promise
+    // is always truthy and no bot is ever gated (search crawlers are exempted
+    // inside isTrustedBot; training/bulk crawlers stay gated).
     const bot = isBot(request);
-    const trusted = bot && isTrustedBot(request);
+    const trusted = bot && (await isTrustedBot(request));
     const maxPage = bot && !trusted ? botMaxPage(pagesCount) : pagesCount;
 
     // Use MongoDB $regex to filter pages server-side (scoped to one book, safe)

--- a/src/lib/bot-gate.ts
+++ b/src/lib/bot-gate.ts
@@ -24,24 +24,43 @@ const KNOWN_BOTS = [
   'youbot',
   'cohere-ai',
   'meta-externalagent',
+  'ccbot',              // Common Crawl — a primary training-data source; gate it
+  'applebot-extended',  // Apple's AI-training crawler (distinct from search Applebot)
   'sourcelibrary-mcp', // our own MCP server — always allow
 ];
 
 // MCP server should never be gated
 const ALWAYS_ALLOW = ['sourcelibrary-mcp'];
 
+// Search-index crawlers we deliberately allow FULL read access. Discovery and
+// citability serve the mission, so these bypass the page gate; training/bulk
+// crawlers do NOT (they stay gated and must license bulk/training use). Matches
+// the robots.ts search-allow list and the /licensing policy. NB: this is UA-based
+// (honor system) — consistent with the rest of this gate, which only ever applied
+// to self-identifying bots; a scraper using a browser UA was never gated anyway.
+const SEARCH_CRAWLERS = ['googlebot', 'bingbot', 'duckduckbot', 'claude-searchbot', 'oai-searchbot'];
+
 export function isBot(request: Request): boolean {
   const ua = (request.headers.get('user-agent') || '').toLowerCase();
   return KNOWN_BOTS.some(bot => ua.includes(bot));
 }
 
+/** True for search-index crawlers we allow full read access (not training crawlers). */
+export function isSearchCrawler(request: Request): boolean {
+  const ua = (request.headers.get('user-agent') || '').toLowerCase();
+  return SEARCH_CRAWLERS.some(bot => ua.includes(bot));
+}
+
 /**
- * Check if the request is trusted — either via whitelisted User-Agent
- * or a valid API key (Bearer sl_data_...).
+ * Check if the request is trusted (bypasses the page gate) — our own MCP, a
+ * search-index crawler, or a valid API key (Bearer sl_data_...).
  */
 export async function isTrustedBot(request: Request): Promise<boolean> {
   const ua = (request.headers.get('user-agent') || '').toLowerCase();
   if (ALWAYS_ALLOW.some(bot => ua.includes(bot))) return true;
+
+  // Search-index crawlers get full access; training/bulk crawlers do not.
+  if (SEARCH_CRAWLERS.some(bot => ua.includes(bot))) return true;
 
   // Check for API key — holders bypass bot gating on all endpoints
   const authHeader = request.headers.get('authorization');


### PR DESCRIPTION
The enforcement counterpart to the TDM-reservation PR (#2849). Your call: **open it for search crawlers, not training.** This aligns the server-side page gate with the robots/licensing policy.

## What changes
- **Search-index crawlers get FULL read access** — `Googlebot`, `Bingbot`, `Claude-SearchBot`, `OAI-SearchBot`, `DuckDuckBot`. Discovery + citability serve the mission, so they bypass the 20% page gate.
- **Training/bulk crawlers stay gated** to the first 20% and must license bulk/training use.
- Done in **one place**: `isTrustedBot()` now exempts the search list, so all five gate call sites (`/text`, `/quote`, tenant quote, `dts/document`, `iiif/search`) open to search crawlers without touching each. Added an `isSearchCrawler()` helper.

## Two gaps closed while here
- **`ccbot` (Common Crawl)** and **`applebot-extended`** added to `KNOWN_BOTS` — both are training crawlers that were slipping through *ungated*. (Common Crawl is a primary LLM training-data source, so this matters.)
- **IIIF search route bug:** `isTrustedBot` was called **without `await`**, so the Promise was always truthy and *no* bot was ever gated on that endpoint. Now awaited — training crawlers are actually gated there too.

## Verified
Hand-checked the full UA matrix (tsc clean): Googlebot / Claude-SearchBot / OAI-SearchBot → full; ClaudeBot / GPTBot / Google-Extended / CCBot / Applebot-Extended → gated 20%; Applebot (search) + browser UAs → full as before.

## Honest notes
- The gate is **UA-based (honor system)** — unchanged in nature. It only ever applied to self-identifying bots; a scraper using a browser UA was never gated (the real anti-bulk control is the identity-based page budget). Robust hardening would be reverse-DNS verification of crawler identity — a separate follow-up if you want spoofing protection.
- **`ChatGPT-User`** (user-initiated reads) stays gated as before; ungating user-initiated assistant reads (to match how `Claude-User` already behaves) is a small separate follow-up.
- Pairs with #2849 — merge that one too for the policy + enforcement to be consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)