### PR TITLE
feat(feedback): /feedback skill — triage & respond to the feedback queue

### DIFF
--- a/.claude/skills/feedback/SKILL.md
+++ b/.claude/skills/feedback/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: feedback
+description: Triage and respond to the user-feedback queue — pull open feedback, detect items already fixed but never marked, route translation-requests and metadata-corrections, mark items resolved, and (on approval) email submitters. Use when asked to check/triage/answer/clear feedback, "what are people saying?", or "respond to feedback."
+---
+
+# Feedback triage & response
+
+The `feedback` collection (Mongo `bookstore`) collects messages from the
+FeedbackWidget, the translation-request prompt, and the MCP `submit_feedback`
+tool. The infra to resolve it already exists — this skill runs the loop instead
+of the throwaway `_tmp_fb_*` scripts that used to do it ad-hoc.
+
+## Lifecycle (don't invent new states)
+- **unread** — `read != true`
+- **read** — `read == true && addressed != true` (triaged, not resolved)
+- **addressed** — `addressed == true` (done)
+
+Resolving via the admin API (`PATCH /api/feedback/[id]`) auto-emails the
+submitter once if they left an email (`feedback-reply-email.ts`, idempotent via
+`reply_sent_at`). The `/admin/feedback` page is the human UI for this.
+
+## Step 1 — pull & classify the queue (read-only)
+
+```bash
+set -a; source .env.production.local; set +a
+node scripts/analytics/feedback-triage.mjs           # all open items, grouped
+node scripts/analytics/feedback-triage.mjs --days 45 # recent only
+```
+
+Groups: **bug · translation-request · metadata-correction · partner-cms ·
+feature-request · praise · other.** Each line shows the `_id`, date, state,
+whether an email was left (✉), and the page. The footer splits emailed (reply
+candidates) vs anonymous (bulk-resolvable).
+
+## Step 2 — the already-fixed detector (the point of this skill)
+
+For each open item, decide if it's **already shipped but never marked** — this
+is the main backlog source. Cross-check, don't guess:
+- `git log --oneline --since=<feedback date> -S "<keyword>"` and search merged PRs (`gh pr list --search`).
+- Check `memory/` + `MEMORY.md` for a matching lesson (e.g. librarian "kites" → PR #2829; Spanish voice → PR #2699).
+- For "broken X" reports, verify against **live code/data** the way the metrics work taught us: the data is often fine and the report was transient (victorio's "can't load pages" was healthy R2 images served through a degraded CF colo — already addressed). Curl the asset / query the book before believing the complaint.
+
+Propose a disposition per item: `already-fixed (link PR/page)` · `real, route it` · `wontfix/explain` · `praise (ack)`.
+
+## Step 3 — route the real ones
+- **translation-request** → page-precise pipeline demand. Collect the `book_id`/page and hand to the daily pipeline queue (the corpus is paused as of 2026-06-08 — note that; don't unpause without Derek's say-so). Mark addressed once queued.
+- **metadata-correction** (scholars correcting editions/dates) → fix the record or open an issue; these are high-trust. Reply if email present.
+- **partner-cms** (Paul's `/catalog/*/edit` notes) → one GitHub issue for the BPH catalog editor; tag EFM-facing.
+- **feature-request** → issue or note; ack the submitter.
+- **praise** → mark addressed; reply with thanks if email present (many are Spanish — reply in kind).
+
+## Step 4 — resolve
+
+**Anonymous / no-email items (the bulk):** mark directly — no email is sent.
+```bash
+node scripts/analytics/feedback-triage.mjs --mark-addressed <id,id,...> --note "what was done" [--link URL] --apply
+# or just triage without resolving:
+node scripts/analytics/feedback-triage.mjs --mark-read <id,id,...> --apply
+```
+Always dry-run first (omit `--apply`). The note becomes `addressed_action`.
+
+**Items WITH an email that deserve a reply:** these must go through the
+`/admin/feedback` UI (or the authed `PATCH /api/feedback/[id]`) so the canonical
+reply email fires. Script-marking sets state but does NOT email — the script
+warns when a marked id has an email. **Sending an email is outward-facing and
+unsendable: draft it, show Derek, and only resolve-with-reply on his explicit
+approval.** Per-item, not blanket.
+
+## Guardrails
+- **Never blanket-resolve.** Mark by explicit `_id` list, after classifying. A wrong "addressed" can fire a wrong email.
+- **Verify "already fixed" against code/data**, not memory of a fix. The whole reason for the backlog is fixes that landed without the row being marked — so confirm the fix is live before claiming it.
+- **Geo caveat:** submitter IPs are often Cloudflare edge addresses (`172.x`), so logged country ≠ real location. Don't infer audience geography from feedback rows.
+- The corpus pipeline is **paused** (`system_config.processing_control.paused`) — translation-requests queue but won't process until unpaused.

--- a/scripts/analytics/feedback-triage.mjs
+++ b/scripts/analytics/feedback-triage.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Feedback triage — pull the open feedback queue, classify each item, and flag
+// the ones that need a human (emailed replies, partner-CMS notes). Read-only by
+// default. The /feedback skill drives this; see .claude/skills/feedback.
+//
+// Lifecycle (mirrors src/app/api/feedback/route.ts):
+//   unread     read != true
+//   read       read == true && addressed != true   <- triaged but not resolved
+//   addressed  addressed == true                    <- done (auto-emailed submitter if email present)
+//
+// Run (report):   set -a; source .env.production.local; set +a; node scripts/analytics/feedback-triage.mjs [--days N] [--all]
+// Mark read:      ... feedback-triage.mjs --mark-read <id,id,...> --apply
+// Mark addressed: ... feedback-triage.mjs --mark-addressed <id,id,...> --note "what was done" [--link URL] --apply
+//
+// NOTE: --mark-addressed here writes Mongo state ONLY. It does NOT send the
+// submitter the auto-reply email — that fires solely from the admin API
+// (PATCH /api/feedback/[id]). Use script-marking for anonymous / no-email rows
+// (the bulk); for rows WITH an email that deserve a reply, resolve them in the
+// /admin/feedback UI so the canonical email + idempotency guard run. The report
+// flags which rows have an email.
+
+import { withMongo } from '../lib/mongo.mjs';
+import { ObjectId } from 'mongodb';
+
+const arg = (k) => { const i = process.argv.indexOf(k); return i > -1 ? process.argv[i + 1] : null; };
+const has = (k) => process.argv.includes(k);
+const DAYS = Number(arg('--days') || 0);            // 0 = all open, regardless of age
+const APPLY = has('--apply');
+
+// --- classification: priority cascade, first match wins ---
+const CLASSIFIERS = [
+  ['translation-request', /translation requested for|needs? translation|not (yet )?translated|please translate|translation\?/i],
+  ['praise', /\bthank|gracias|grazie|amazing|wonderful|beautiful|\blove (it|this)|so happy|incre[ií]ble|bello esfuerzo|maravillos/i],
+  ['bug', /not loading|won.?t (load|open|work)|can.?t (load|see|open)|error|broken|isn.?t working|doesn.?t work|blank|hides everything|went nuts|stuck|404|missing|no se ve|no carga|no puedo ver/i],
+  ['metadata-correction', /\bnot \d{3,4}\b|wrong|incorrect|should be|actually the|you (claim|are using)|edition|impressum|provenance|\bUBN\b|repeatable|separate field|two separate/i],
+  ['feature-request', /feature request|would be (nice|great|good)|please add|could you add|suggestion|i.?d like|i wish|make it easier|add a (button|field|way)/i],
+];
+function classify(r) {
+  if ((r.page || '').startsWith('/catalog/')) return 'partner-cms';
+  const m = (r.message || '');
+  for (const [label, re] of CLASSIFIERS) if (re.test(m)) return label;
+  return 'other';
+}
+
+await withMongo(async (db) => {
+  const fb = db.collection('feedback');
+
+  // --- write modes ---
+  const markRead = arg('--mark-read');
+  const markAddr = arg('--mark-addressed');
+  if (markRead || markAddr) {
+    const ids = (markRead || markAddr).split(',').map((s) => s.trim()).filter((s) => ObjectId.isValid(s));
+    if (!ids.length) { console.log('No valid ObjectIds given.'); return; }
+    const set = markAddr
+      ? { read: true, read_at: new Date(), addressed: true, addressed_at: new Date(), addressed_by: 'feedback-triage-skill', addressed_action: (arg('--note') || '').slice(0, 1000), ...(arg('--link') ? { addressed_link: arg('--link') } : {}), updated_at: new Date() }
+      : { read: true, read_at: new Date(), updated_at: new Date() };
+    console.log(`${APPLY ? 'APPLYING' : 'DRY-RUN'} ${markAddr ? 'mark-addressed' : 'mark-read'} on ${ids.length} rows`);
+    if (markAddr) {
+      const withEmail = await fb.countDocuments({ _id: { $in: ids.map((i) => new ObjectId(i)) }, email: { $regex: '@' } });
+      if (withEmail) console.log(`⚠ ${withEmail} of these have an email — script-marking does NOT send the reply. Resolve those in /admin/feedback to email the submitter.`);
+    }
+    if (!APPLY) { console.log('(add --apply to write)'); return; }
+    const res = await fb.updateMany({ _id: { $in: ids.map((i) => new ObjectId(i)) } }, { $set: set });
+    console.log(`modified ${res.modifiedCount}`);
+    return;
+  }
+
+  // --- report mode ---
+  const q = has('--all') ? {} : { $or: [{ read: { $ne: true } }, { read: true, addressed: { $ne: true } }] };
+  if (DAYS) q.created_at = { $gt: new Date(Date.now() - DAYS * 864e5) };
+  const counts = {
+    unread: await fb.countDocuments({ read: { $ne: true } }),
+    read_unaddressed: await fb.countDocuments({ read: true, addressed: { $ne: true } }),
+    addressed: await fb.countDocuments({ addressed: true }),
+  };
+  const rows = await fb.find(q).sort({ created_at: -1 }).toArray();
+
+  console.log('# Feedback triage');
+  console.log(`Queue: ${counts.unread} unread · ${counts.read_unaddressed} read-but-unresolved · ${counts.addressed} addressed (done)`);
+  console.log(`Showing ${rows.length} open items${DAYS ? ` (last ${DAYS}d)` : ''}\n`);
+
+  const groups = {};
+  for (const r of rows) (groups[classify(r)] ??= []).push(r);
+  const order = ['bug', 'translation-request', 'metadata-correction', 'partner-cms', 'feature-request', 'praise', 'other'];
+  for (const g of order) {
+    const items = groups[g]; if (!items?.length) continue;
+    console.log(`\n## ${g}  (${items.length})`);
+    for (const r of items) {
+      const email = (r.email || '').includes('@') ? ` ✉ ${r.email}` : '';
+      const state = r.read ? '[read]' : '[unread]';
+      console.log(`- ${r._id}  ${new Date(r.created_at).toISOString().slice(0, 10)} ${state}${email}  ${r.name ? '~' + r.name : ''}`);
+      console.log(`    page: ${r.page || '?'}`);
+      console.log(`    ${(r.message || '').replace(/\s+/g, ' ').trim().slice(0, 200)}`);
+    }
+  }
+  const emailed = rows.filter((r) => (r.email || '').includes('@')).length;
+  console.log(`\n— ${emailed} open items left an email (reply candidates) · ${rows.length - emailed} anonymous (bulk-resolvable)`);
+}, { timeoutMs: 90000 });


### PR DESCRIPTION
## What

A `/feedback` skill that runs the feedback-triage loop as a repeatable playbook, replacing the throwaway `_tmp_fb_*` scripts. The resolve infrastructure already exists (admin UI at `/admin/feedback`, `PATCH /api/feedback/[id]` with idempotent auto-reply email) — this just drives it.

**Why now:** the queue is **106 open** (10 unread + 96 read-but-unresolved) against 139 already addressed. Most of the backlog is items that were *fixed but never marked* — so the queue overstates how much is actually outstanding.

**Two files:**
- `scripts/analytics/feedback-triage.mjs` — read-only pull + classify (bug / translation-request / metadata-correction / partner-cms / feature-request / praise / other), flags emailed vs anonymous rows. Guarded write modes `--mark-read` / `--mark-addressed` (explicit ids + `--apply`, dry-run by default). Script-marking sets Mongo state **only** and never emails — it warns when a marked row has an email, so emailed replies are routed through the admin UI where the canonical reply fires.
- `.claude/skills/feedback/SKILL.md` — the playbook. Core is an **already-fixed detector**: cross-check each open item against `git log` / merged PRs / memory / live code+data to catch shipped-but-unmarked fixes. Routes translation-requests (page-precise pipeline demand) to the queue, scholar metadata corrections to fixes, and partner-CMS notes to a BPH-catalog issue.

## Out of scope (deliberately)
- **No new resolve infrastructure** — reuses the existing API/UI/email.
- **No automated outward emails.** Reply sends require explicit per-item approval and go through the admin API; the script can't and won't blanket-email.
- Actually clearing the 106-item backlog is a *run* of this skill, not part of the PR.

## Safety
Read-only by default. Writes are opt-in (`--apply`), by explicit `_id` only, and never send email. Verified against the live queue (classification + counts correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)