### PR TITLE
docs: clarify works-system layers (work_id vs USTC)

### DIFF
--- a/.claude/docs/finding-missing-works-acquisition.md
+++ b/.claude/docs/finding-missing-works-acquisition.md
@@ -1,74 +1,92 @@
-# Finding works we're missing (esp. Latin) — the acquisition map
+# Finding works we're missing — the acquisition map
 
-**Read this before building any "what works are we missing / let's bulk-import"
-tooling.** This capability is ~80% built and spread across MongoDB, Supabase, and
-a dozen scripts. People (including AI sessions) keep re-deriving it badly. Don't.
+**For future sessions / systems: read this before building any "what works are we
+missing / let's bulk-import" tooling.** This is ~80% built and spread across MongoDB,
+Supabase, and a dozen scripts, so people (human + AI) keep re-deriving it badly. Don't.
 
-## The trap (2026-06-28)
+---
+
+## Get this right first: there are TWO layers, and they are NOT the same thing
+
+Conflating them is what produces wrong gap lists and redundant imports.
+
+### Layer 1 — OUR works system: `books.work_id` (USTC-INDEPENDENT)
+This **is** "our works system." It clusters **our own holdings** into distinct works.
+It does not depend on USTC or any single external catalog.
+- **Tradition-agnostic, ~99% coverage everywhere:** Chinese 100%, German 100%,
+  Tibetan 100%, Latin 99%, Greek 99%, Hebrew 95%, Sanskrit 98%, Pali 97%, Arabic 85%.
+- **Sources of the work_ids:** `local-mint` (~21.8k), `kanripo-catalog` (~12.1k),
+  `work-merge:llm-verified` (~2.5k), `wikidata:P50` (683), hand/deterministic merges.
+  **Zero come from USTC.**
+- **What it answers:** "do we hold this work / which editions of it / is this
+  translation's original in the library / dedup." Cluster by `work_id`; read coverage
+  with `scripts/analysis/work-coverage.mjs`.
+- **Design / model / fit-rule / coverage census:** `.claude/docs/work-identity-coverage.md`.
+- **Known limit — the divergent-title tail:** famous classics with many title variants
+  across languages/authors don't fully collapse. Our *own* 35 Pymander editions sit
+  under **12 distinct work_ids** (+2 authors). This is the documented residual ~8%,
+  not a bug to "discover." Any holdings diff must account for it.
+
+### Layer 2 — EXTERNAL universes: "what works exist that we DON'T have"
+The acquisition gap = **diff( Layer-1 work_ids , an external universe of what exists )**.
+There is more than one external universe; **USTC is just one of them, NOT special, and
+NOT "our works system":**
+- **USTC** (Supabase `ustc_editions` ~1.63M, work-clustered by `work_cluster_id`) —
+  continental **printed** editions, **1450–1700**. Best for the Latin / German / French
+  / Italian printed-book slice. Holdings link via `books.ustc_id`
+  (`catalog-coverage/backfill-ustc-matches.mjs`; the match is also written back to
+  `ustc_editions.in_source_library` / `source_library_id`). **Limits:** misses
+  manuscripts, English alchemy, grimoires, and everything outside early-modern European
+  print. A high *no-match* rate on our esoterica is **expected and correct** (Key of
+  Solomon, Boehme's *Aurora*, Vatican shelfmarks are simply not in USTC) — not a matcher
+  failure. The matcher is conservative (rejects with reasoning); trust its no-matches.
+- **Wikidata P50** (an author's complete works) — tradition-agnostic; the path for
+  everything USTC misses (Greek, Arabic, Hebrew, manuscript esoterica, non-European).
+  `scripts/analysis/resolve-work-ids-wikidata.mjs`.
+
+**Rule of thumb:** continental printed-Latin gap → USTC. Anything else → our `work_id`
+layer + Wikidata. **Never treat USTC as "our works system."**
+
+---
+
+## The trap (validated 2026-06-28 — do not reinvent)
 
 The intuitive approach — "enumerate IA's Latin, cluster by title, diff against our
 holdings, import the gaps" — **fails**, and fails in the worst way: it *over*-reports
 missing works and would have us **re-importing texts we already hold**.
 
-Validated example: a naive title-key engine flagged 136 "missing" works across 16
-esoteric authors (Pymander, Ficino *De vita*, Libavius *Neoparacelsica* 1594…).
-**We hold every one of them** — often in multiple editions. The diff failed because
-crude title normalization can't recognize a held work under variant transcriptions
-(*Libaui* vs *Libavii*), a different author-field value, or a divergent title
-(Pymander / Pimander / Poimandres / Corpus Hermeticum). A weak work-matcher inverts
-the goal. **The matcher must be real work identity, not title strings.**
+A naive title-key engine flagged 136 "missing" works across 16 esoteric authors
+(Pymander, Ficino *De vita*, Libavius *Neoparacelsica* 1594…). **We hold every one** —
+often in multiple editions. The diff failed because crude title normalization can't
+recognize a held work under variant transcriptions (*Libaui* vs *Libavii*), a different
+author-field value, or a divergent title (Pymander / Pimander / Poimandres / Corpus
+Hermeticum). A weak work-matcher inverts the goal. **The matcher must be real work
+identity (Layer 1 + a real external universe), not title strings.**
 
-## What already exists (the real system)
+## How to produce a trustworthy missing-works list
 
-### 1. Internal work identity — `books.work_id` (~97% coverage)
-- Editions cluster under a shared `work_id`; coverage census + design in
-  **`.claude/docs/work-identity-coverage.md`**. Latin ~95% (Wikidata-direct, 745
-  works); cross-language merge layer at 91.6% (`work-merge:llm-verified`, the 2,491
-  LLM-verified merges).
-- **Known limitation — the divergent-title tail:** famous classics with many title
-  variants across languages/authors don't fully collapse. Our *own* 35 Pymander
-  editions sit under **12 distinct work_ids** (+ 2 authors, Iamblichus bundled in).
-  This is the documented residual ~8%, not a bug to "discover." Any holdings diff
-  must account for it.
-- Tools: `scripts/analysis/{mint-local-work-ids,resolve-work-ids,resolve-work-ids-wikidata,llm-verify-work-merges,cluster-works-by-embedding}.mjs`.
-
-### 2. The Latin universe — USTC in Supabase (the thing to diff against)
-- **`ustc_editions`: 1,628,578 rows**; **`ustc_enrichments`: 1,624,437** — every
-  early-modern European edition, collapsed to `work_cluster_id` (`author::norm-title`).
-  ~503k Latin → ~366k distinct Latin work clusters. *This is the "universe of distinct
-  Latin works" — it already exists. Don't re-cluster IA from scratch.*
-- Digitisation links (which editions are scanned + where, by source) are harvested by
-  `scripts/catalog-coverage/harvest-ustc-holdings.mjs`.
-
-### 3. Holdings → USTC match — `books.ustc_id` (PARTIAL — the loose end)
-- `scripts/catalog-coverage/backfill-ustc-matches.mjs` links our books to USTC
-  (fast word-overlap + Gemini flash-lite fallback, ~$0.001/book).
-- **Current coverage: only ~2,763 / 8,169 Latin books matched (~34%).** Finishing
-  this backfill is the prerequisite for a trustworthy gap.
-
-## How to actually produce the "missing works to acquire" list
-
-1. **Finish the holdings match** — run `backfill-ustc-matches.mjs` to ~full Latin
-   coverage (the other ~66%). Cost ≈ books × ~$0.001.
-2. **Diff** USTC work clusters that (a) have a digitisation link and (b) have **no**
+1. **Pick the right external universe for the tradition** (USTC for printed Latin;
+   Wikidata P50 otherwise).
+2. **Make sure holdings are linked to it.** For USTC: `backfill-ustc-matches.mjs`
+   (word-overlap free + Gemini flash-lite fallback, ~$0.001/book; run with `tsx`, it
+   imports `.ts` libs). Conservative — trust its no-matches.
+3. **Diff:** external work clusters that (a) have a digitisation link and (b) have **no**
    matched Source Library holding → genuine missing works, one cluster each.
-3. **Rank** by `scan_quality` (bsb/e-rara → high, gallica/biblissima → medium,
-   ia_microfilm → low — see `catalog-coverage/_tmp-backfill-import-candidates.mjs`)
-   and import the best edition per cluster (hidden → archive → OCR → translate).
-4. **The `import_candidates` table was scripted but never materialized** — that final
-   step (build the table from the diff) is the remaining work. It does not exist yet
-   in Supabase; the upstream pieces (universe, match, digitisation) do.
+4. **Rank** by `scan_quality` (bsb/e-rara → high, gallica/biblissima → medium,
+   ia_microfilm → low) and import the best edition per cluster (hidden → archive → OCR
+   → translate). **The `import_candidates` table was scripted
+   (`catalog-coverage/_tmp-backfill-import-candidates.mjs`) but never materialized** —
+   building it from the diff is the remaining work.
 
 ## Reality check before any Latin "dump"
 
 We are **not** thin on Latin: 8,169 Latin books, deep canonical-esoterica coverage
-(Pymander, *De vita*, *Platonica theologia*, Libavius, Kircher, Fludd, Agrippa all
-held in multiple editions). The treemap "imbalance" is mostly the hidden 13k Chinese
-dwarfing everything, not a Latin deficit. Acquire by **verified gap** (the procedure
-above), never by volume.
+(Pymander, *De vita*, *Platonica theologia*, Libavius, Kircher, Fludd, Agrippa all held
+in multiple editions). The treemap "imbalance" is mostly the hidden 13k Chinese dwarfing
+everything, not a Latin deficit. Acquire by **verified gap** (above), never by volume.
 
 ## Related docs (don't duplicate — link)
-- `work-identity-coverage.md` — work_id model, fit rule, coverage census, merge layer
+- `work-identity-coverage.md` — Layer 1: work_id model, fit rule, coverage census, merge layer
 - `translation-works-architecture.md` — the whole stack (work id + catalog + gap + holdings + FT)
 - `work-dedup-methods.md`, `work-identity-matching-research.md` — clustering method research
 - `translation-gap-methodology.md` / `translation-gap-paper.md` — the USTC translation-prior gap (#2626)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,14 +159,15 @@ NOT by the `original_edition_id` link (which is half-filled). Umbrella: #2318.
   Sanskrit) and `resolve-work-ids-wikidata.mjs` (Wikidata P50 — Greek/Latin).
 - Full design, tool list, per-tradition candidate coverage, and open levers:
   **`.claude/docs/work-identity-coverage.md`**.
-- **Acquiring works we're missing (esp. Latin) — read FIRST, don't reinvent:**
-  **`.claude/docs/finding-missing-works-acquisition.md`**. The "enumerate IA →
-  title-cluster → diff → import" approach is a known trap (it over-reports gaps and
-  re-imports works we hold — the divergent-title tail, e.g. our own Pymander is 35
-  editions across 12 work_ids). The real universe is the **USTC layer in Supabase**
-  (`ustc_editions` ~1.63M, work-clustered); holdings link via `books.ustc_id`
-  (`catalog-coverage/backfill-ustc-matches.mjs`, currently ~34% of Latin). We are
-  NOT thin on Latin — verify a gap before any "dump."
+- **Acquiring works we're missing — read FIRST, don't reinvent:**
+  **`.claude/docs/finding-missing-works-acquisition.md`**. TWO layers, don't conflate:
+  **(1) our works system IS `books.work_id`** — ~99% coverage across ALL traditions
+  (Chinese, Latin, Greek, Tibetan, Arabic…), USTC-independent; **(2) USTC is just ONE
+  external universe** (continental print, 1450–1700) to diff against for *unheld* works,
+  NOT our works system (use Wikidata P50 for what USTC misses). The "enumerate IA →
+  title-cluster → diff → import" shortcut is a known trap — it over-reports gaps and
+  re-imports works we hold (the divergent-title tail; our own Pymander is 35 editions
+  across 12 work_ids). We are NOT thin on Latin — verify a gap before any "dump."
 
 ## Authentication across subdomains
 


### PR DESCRIPTION
Follow-up to #2852. The prior version leaned USTC-centric and could read as 'USTC is our works system' — it isn't. Now leads with the two-layer distinction so future sessions/systems get it right:

- **Layer 1 — `books.work_id`**: OUR works system, USTC-independent, ~99% coverage across **every** tradition (Chinese 100%, Latin 99%, Greek 99%, Tibetan 100%, Arabic 85%…). Sources: local-mint, kanripo, work-merge:llm-verified, wikidata:P50 — **zero from USTC**.
- **Layer 2 — external universes** to find *unheld* works: USTC (continental print 1450–1700) is **just one**, best for printed Latin; **Wikidata P50** covers what USTC misses (Greek, Arabic, manuscript esoterica). The gap = diff(Layer-1 work_id, an external universe).

Also keeps the title-cluster trap + reality-check sections. Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)