### PR TITLE
feat(bot-gate): ungate user-initiated assistant fetches (ChatGPT-User)

### DIFF
--- a/src/lib/bot-gate.ts
+++ b/src/lib/bot-gate.ts
@@ -40,6 +40,15 @@ const ALWAYS_ALLOW = ['sourcelibrary-mcp'];
 // to self-identifying bots; a scraper using a browser UA was never gated anyway.
 const SEARCH_CRAWLERS = ['googlebot', 'bingbot', 'duckduckbot', 'claude-searchbot', 'oai-searchbot'];
 
+// User-INITIATED assistant fetches: an AI assistant retrieving a page because a
+// human asked it to (not a crawler). These get full access too — reading on a
+// user's behalf is exactly the use we want. Claude-User already passes (it's not
+// in KNOWN_BOTS); ChatGPT-User is gated only because 'chatgpt' is in KNOWN_BOTS,
+// so name it here to ungate it. Matches the /licensing policy ("reading on a
+// user's behalf is welcome"). The training/crawler variants (GPTBot, ClaudeBot)
+// are NOT here and stay gated.
+const USER_FETCH_AGENTS = ['claude-user', 'chatgpt-user', 'perplexity-user'];
+
 export function isBot(request: Request): boolean {
   const ua = (request.headers.get('user-agent') || '').toLowerCase();
   return KNOWN_BOTS.some(bot => ua.includes(bot));
@@ -61,6 +70,9 @@ export async function isTrustedBot(request: Request): Promise<boolean> {
 
   // Search-index crawlers get full access; training/bulk crawlers do not.
   if (SEARCH_CRAWLERS.some(bot => ua.includes(bot))) return true;
+
+  // User-initiated assistant fetches (a human asked an assistant to read a page).
+  if (USER_FETCH_AGENTS.some(bot => ua.includes(bot))) return true;
 
   // Check for API key — holders bypass bot gating on all endpoints
   const authHeader = request.headers.get('authorization');


### PR DESCRIPTION
Follow-up to the search/training gate split. Reading a page **on a user's behalf** (a human asks ChatGPT/Claude to read a URL) is exactly the use we want — same category as `Claude-User`, which already gets full access because it's not in `KNOWN_BOTS`. `ChatGPT-User` was gated only as collateral from the `chatgpt` entry.

- Adds a `USER_FETCH_AGENTS` bypass (`claude-user`, `chatgpt-user`, `perplexity-user`) in `isTrustedBot`.
- Crawler variants (`GPTBot`, `ClaudeBot`, `PerplexityBot`) stay gated; generic `ChatGPT/*` (non-`-User`) stays gated.
- Verified: ChatGPT-User / Claude-User → full; GPTBot / ClaudeBot → 20%. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)