### PR TITLE
feat(admin): audience & usage metrics dashboard at /platform/admin/metrics

### DIFF
--- a/scripts/analytics/snapshot-metrics.mjs
+++ b/scripts/analytics/snapshot-metrics.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+// Daily metrics snapshot writer.
+//
+// Computes the headline audience + usage + engagement numbers (the same
+// aggregations the /metrics skill runs across audience-metrics.mjs,
+// usage-deepdive.mjs, and engagement-metrics.mjs) and writes ONE structured
+// document to system_config.metrics_snapshot. The protected admin page at
+// /platform/admin/metrics reads that doc and renders instantly — it never runs
+// these aggregations on page load (the deep-dive scans are too slow for that).
+//
+// Same pattern as system_config.homepage_stats (refreshed daily by
+// prewarm-browse.mjs). Purely read-only against Mongo `bookstore`. No cost.
+//
+// Run:  set -a; source .env.production.local; set +a; \
+//       node scripts/analytics/snapshot-metrics.mjs [--days N]
+//
+// Cron (Hetzner, daily): see scripts/workers/crontab.production.
+
+import { withMongo } from '../lib/mongo.mjs';
+
+const DAYS = (() => { const i = process.argv.indexOf('--days'); return i > -1 ? Number(process.argv[i + 1]) : 30; })();
+const norm = (e) => (e || '').trim().toLowerCase();
+const BOT_RE = /(bot|crawler|spider|preview|monitor|uptime|wget|curl|python-requests|libwww|http-client|headless|chrome-lighthouse|MCP)/i;
+const isBot = (ua) => !ua || BOT_RE.test(ua);
+
+await withMongo(async (db) => {
+  const now = Date.now();
+  const since = (d) => new Date(now - d * 864e5);
+  const SINCE = since(DAYS), d30 = since(30), d14 = since(14), d7 = since(7), d1 = since(1);
+
+  const fpGroup = { _id: { ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] } } };
+
+  // ─── USERS / SIGNUPS ──────────────────────────────────────────────────────
+  const users = db.collection('users');
+  const [total, verified, hasLogin, everLoggedIn, repeatLogin, new30, new7, new1] = await Promise.all([
+    users.countDocuments({}),
+    users.countDocuments({ emailVerified: { $ne: null, $exists: true } }),
+    users.countDocuments({ lastLogin: { $exists: true } }),
+    users.countDocuments({ loginCount: { $gte: 1 } }),
+    users.countDocuments({ loginCount: { $gte: 2 } }),
+    users.countDocuments({ createdAt: { $gt: d30 } }),
+    users.countDocuments({ createdAt: { $gt: d7 } }),
+    users.countDocuments({ createdAt: { $gt: d1 } }),
+  ]);
+  const subscribers = {};
+  for (const cn of ['beta_subscribers', 'newsletter_subscribers']) {
+    try { subscribers[cn] = await db.collection(cn).countDocuments({}); } catch { subscribers[cn] = null; }
+  }
+
+  // ─── DAU / MAU / DWELL ────────────────────────────────────────────────────
+  const pv = db.collection('analytics_pageviews');
+  const mau = (await pv.aggregate([
+    { $match: { timestamp: { $gt: d30 } } }, { $group: fpGroup }, { $count: 'n' },
+  ]).toArray())[0]?.n || 0;
+  const dau = await pv.aggregate([
+    { $match: { timestamp: { $gt: d14 } } },
+    { $group: { _id: { day: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp' } }, ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] } } } },
+    { $group: { _id: '$_id.day', users: { $sum: 1 } } }, { $sort: { _id: 1 } },
+  ], { allowDiskUse: true }).toArray();
+  const avgDau = Math.round(dau.reduce((s, d) => s + d.users, 0) / (dau.length || 1));
+
+  // Dwell: per-session (ip+ua, 30-min idle gap) duration, last 7d, multi-hit only.
+  const rows = await pv.find({ timestamp: { $gt: d7 } }, { projection: { ip: 1, userAgent: 1, timestamp: 1 } }).toArray();
+  const byFp = new Map();
+  for (const r of rows) {
+    const k = r.ip + '|' + (r.userAgent || '').slice(0, 60);
+    (byFp.get(k) || byFp.set(k, []).get(k)).push(+new Date(r.timestamp));
+  }
+  const durations = []; let multiHit = 0;
+  for (const ts of byFp.values()) {
+    ts.sort((a, b) => a - b);
+    let start = ts[0], prev = ts[0], n = 1;
+    for (let i = 1; i < ts.length; i++) {
+      if (ts[i] - prev > 30 * 60 * 1000) { if (n > 1) { durations.push((prev - start) / 1000); multiHit++; } start = ts[i]; n = 1; }
+      else n++;
+      prev = ts[i];
+    }
+    if (n > 1) { durations.push((prev - start) / 1000); multiHit++; }
+  }
+  durations.sort((a, b) => a - b);
+  const dwellMedian = Math.round(durations[Math.floor(durations.length / 2)] || 0);
+  const dwellMean = Math.round(durations.reduce((s, x) => s + x, 0) / (durations.length || 1));
+
+  // ─── CONVERSION / RETENTION ───────────────────────────────────────────────
+  const uniqVisitors = (await pv.aggregate([{ $match: { timestamp: { $gt: SINCE } } }, { $group: fpGroup }, { $count: 'n' }]).toArray())[0]?.n || 0;
+  const newSignupsWin = await users.countDocuments({ createdAt: { $gt: SINCE } });
+  const byDays = await pv.aggregate([
+    { $match: { timestamp: { $gt: SINCE } } },
+    { $group: { _id: { ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] }, d: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp' } } } } },
+    { $group: { _id: { ip: '$_id.ip', ua: '$_id.ua' }, days: { $sum: 1 } } },
+    { $group: { _id: '$days', n: { $sum: 1 } } }, { $sort: { _id: 1 } },
+  ], { allowDiskUse: true }).toArray();
+  const totalFp = byDays.reduce((s, x) => s + x.n, 0);
+  const multiDay = byDays.filter((x) => x._id > 1).reduce((s, x) => s + x.n, 0);
+
+  // ─── READING DEPTH (page_read events, 7d) ─────────────────────────────────
+  const ev = db.collection('analytics_events');
+  let reading = null;
+  try {
+    const depth = await ev.aggregate([
+      { $match: { event: 'page_read', timestamp: { $gt: d7 }, book_id: { $ne: null } } },
+      { $group: { _id: { ip: '$ip', b: '$book_id' }, pages: { $addToSet: '$page_id' } } },
+      { $project: { n: { $size: '$pages' } } },
+      { $group: { _id: '$n', sessions: { $sum: 1 } } }, { $sort: { _id: 1 } },
+    ], { allowDiskUse: true }).toArray();
+    const flat = []; for (const d of depth) for (let i = 0; i < d.sessions; i++) flat.push(d._id);
+    flat.sort((a, b) => a - b);
+    const rn = flat.length;
+    reading = {
+      pairs: rn,
+      median: flat[Math.floor(rn / 2)] || 0,
+      p90: flat[Math.floor(rn * 0.9)] || 0,
+      oneOnly: depth.find((d) => d._id === 1)?.sessions || 0,
+      deep: depth.filter((d) => d._id >= 10).reduce((s, d) => s + d.sessions, 0),
+      opens: await ev.countDocuments({ event: 'book_read', timestamp: { $gt: d7 } }),
+    };
+  } catch { /* events collection may be sparse */ }
+
+  // ─── MISSION ACTIONS ──────────────────────────────────────────────────────
+  let missionActions = {};
+  try {
+    const rowsM = await ev.aggregate([
+      { $match: { timestamp: { $gt: SINCE }, event: { $in: ['download', 'share', 'cite', 'gate_hit', 'signin_view'] } } },
+      { $group: { _id: '$event', n: { $sum: 1 } } },
+    ]).toArray();
+    missionActions = Object.fromEntries(rowsM.map((r) => [r._id, r.n]));
+  } catch { /* noop */ }
+
+  // ─── TRAFFIC SHAPE / TOP CONTENT / REFERRERS (last DAYS, human-filtered) ──
+  const pvCursor = pv.find({ timestamp: { $gte: SINCE } }, { projection: { path: 1, userAgent: 1, referrer: 1, country: 1, timestamp: 1 } });
+  let humanPvs = 0, botPvs = 0;
+  const dailyHits = new Map(), bookHits = new Map(), collectionHits = new Map(), referrers = new Map(), countries = new Map();
+  const kindOf = (p) => {
+    if (!p) return 'other';
+    const s = p.split('?')[0];
+    if (s.startsWith('/book/')) return 'book';
+    if (s.startsWith('/collections/')) return 'collection';
+    return 'other';
+  };
+  while (await pvCursor.hasNext()) {
+    const d = await pvCursor.next();
+    if (isBot(d.userAgent)) { botPvs++; continue; }
+    humanPvs++;
+    const s = (d.path || '').split('?')[0];
+    const day = new Date(d.timestamp).toISOString().slice(0, 10);
+    dailyHits.set(day, (dailyHits.get(day) || 0) + 1);
+    if (kindOf(s) === 'book') { const slug = s.split('/')[2] || ''; if (slug) bookHits.set(slug, (bookHits.get(slug) || 0) + 1); }
+    if (kindOf(s) === 'collection') { const slug = s.split('/')[2] || ''; if (slug) collectionHits.set(slug, (collectionHits.get(slug) || 0) + 1); }
+    const refDomain = (d.referrer || 'direct').replace(/^https?:\/\//, '').split('/')[0] || 'direct';
+    referrers.set(refDomain, (referrers.get(refDomain) || 0) + 1);
+    countries.set(d.country || 'unknown', (countries.get(d.country || 'unknown') || 0) + 1);
+  }
+  const topN = (m, n) => [...m.entries()].sort((a, b) => b[1] - a[1]).slice(0, n);
+  const dailyPageviews = [...dailyHits.entries()].sort((a, b) => a[0].localeCompare(b[0])).map(([date, hits]) => ({ date, hits }));
+
+  // Resolve top book slugs/ids to titles.
+  const topBookKeys = topN(bookHits, 15);
+  const { ObjectId } = await import('mongodb');
+  const slugLike = [], idLike = [];
+  for (const [s] of topBookKeys) { if (/^[a-f0-9]{24}$/i.test(s)) { try { idLike.push(new ObjectId(s)); } catch {} } else slugLike.push(s); }
+  const proj = { projection: { slug: 1, title: 1, author: 1, language: 1 } };
+  const bMeta = new Map();
+  for (const b of slugLike.length ? await db.collection('books').find({ slug: { $in: slugLike } }, proj).toArray() : []) bMeta.set(b.slug, b);
+  for (const b of idLike.length ? await db.collection('books').find({ _id: { $in: idLike } }, proj).toArray() : []) bMeta.set(b._id.toString(), b);
+  const topBooks = topBookKeys.map(([key, hits]) => {
+    const m = bMeta.get(key) || {};
+    return { key, hits, title: (m.title || key).slice(0, 70), author: (Array.isArray(m.author) ? m.author[0] : m.author || '') || '', language: m.language || '' };
+  });
+  const topCollections = topN(collectionHits, 10).map(([slug, hits]) => ({ slug, hits }));
+  const topReferrers = topN(referrers, 12).map(([referrer, hits]) => ({ referrer, hits }));
+  const topCountries = topN(countries, 12).map(([country, hits]) => ({ country, hits }));
+
+  // ─── SEARCH BEHAVIOR ──────────────────────────────────────────────────────
+  let search = null;
+  try {
+    const sqAll = await db.collection('search_queries').find({ ts: { $gte: SINCE } }, { projection: { query: 1, total: 1, ms: 1, user_agent: 1 } }).toArray();
+    const sqHuman = sqAll.filter((s) => !isBot(s.user_agent));
+    const zero = sqHuman.filter((s) => (s.total || 0) === 0);
+    const qCounts = new Map(), zCounts = new Map();
+    for (const s of sqHuman) { const q = (s.query || '').toLowerCase().trim(); if (q) qCounts.set(q, (qCounts.get(q) || 0) + 1); }
+    for (const s of zero) { const q = (s.query || '').toLowerCase().trim(); if (q) zCounts.set(q, (zCounts.get(q) || 0) + 1); }
+    const lat = sqHuman.map((s) => s.ms).filter((n) => typeof n === 'number').sort((a, b) => a - b);
+    search = {
+      total: sqAll.length,
+      human: sqHuman.length,
+      zeroResult: zero.length,
+      topQueries: topN(qCounts, 15).map(([query, count]) => ({ query: query.slice(0, 80), count })),
+      zeroQueries: topN(zCounts, 15).map(([query, count]) => ({ query: query.slice(0, 80), count })),
+      latencyP50: lat.length ? lat[Math.floor(lat.length * 0.5)] : null,
+      latencyP90: lat.length ? lat[Math.floor(lat.length * 0.9)] : null,
+    };
+  } catch { /* noop */ }
+
+  // ─── SOCIAL ───────────────────────────────────────────────────────────────
+  let social = null;
+  try {
+    const likes = db.collection('likes');
+    const lk = await likes.countDocuments({ created_at: { $gt: SINCE } });
+    const lkVisitors = (await likes.aggregate([{ $match: { created_at: { $gt: SINCE } } }, { $group: { _id: '$visitor_id' } }, { $count: 'n' }]).toArray())[0]?.n || 0;
+    const fb = db.collection('feedback');
+    social = {
+      likes: lk,
+      likeVisitors: lkVisitors,
+      feedback: await fb.countDocuments({ created_at: { $gt: SINCE } }),
+      feedbackUnread: await fb.countDocuments({ created_at: { $gt: SINCE }, read: { $ne: true } }),
+      feedbackWantsHelp: await fb.countDocuments({ created_at: { $gt: SINCE }, wants_to_help: true }),
+    };
+  } catch { /* noop */ }
+
+  // ─── AI SURFACES ──────────────────────────────────────────────────────────
+  let ai = null;
+  try {
+    const byFeat = await db.collection('ai_usage').aggregate([
+      { $match: { timestamp: { $gt: SINCE } } },
+      { $group: { _id: '$feature', calls: { $sum: 1 }, cost: { $sum: '$costUsd' }, avgMs: { $avg: '$ms' } } },
+      { $sort: { calls: -1 } }, { $limit: 10 },
+    ]).toArray();
+    ai = byFeat.map((f) => ({ feature: String(f._id || 'unknown'), calls: f.calls, cost: Number((f.cost || 0).toFixed(2)), avgMs: Math.round(f.avgMs || 0) }));
+  } catch { /* noop */ }
+
+  // ─── PIPELINE COST ────────────────────────────────────────────────────────
+  let pipelineCost = null;
+  try {
+    const gud = await db.collection('gemini_usage_daily').find({}).sort({ date: -1 }).limit(60).toArray();
+    if (gud.length) {
+      const cut7 = new Date(now - 7 * 864e5).toISOString().slice(0, 10);
+      const cut30 = new Date(now - 30 * 864e5).toISOString().slice(0, 10);
+      const sumSince = (cut) => gud.filter((r) => r.date >= cut).reduce((s, r) => s + (r.totalCost || 0), 0);
+      pipelineCost = {
+        latestDay: gud[0].date,
+        stale: gud[0].date < cut7,
+        last7: Number(sumSince(cut7).toFixed(2)),
+        last30: Number(sumSince(cut30).toFixed(2)),
+        recentDays: gud.slice(0, 7).map((r) => ({ date: r.date, cost: Number((r.totalCost || 0).toFixed(2)), records: r.totalRecords || 0 })),
+      };
+    }
+  } catch { /* noop */ }
+
+  // ─── ASSEMBLE + WRITE ─────────────────────────────────────────────────────
+  const snapshot = {
+    generatedAt: new Date(now),
+    windowDays: DAYS,
+    users: {
+      total, verified, hasLogin, everLoggedIn, repeatLogin,
+      new30, new7, new1,
+      ...subscribers,
+    },
+    engagement: {
+      mau, avgDau,
+      dauLast3: dau.slice(-3).map((d) => ({ date: d._id, users: d.users })),
+      dwellMedianSec: dwellMedian, dwellMeanSec: dwellMean, dwellSessions: multiHit,
+    },
+    conversion: {
+      uniqVisitors, newSignups: newSignupsWin,
+      returningVisitors: multiDay, returningTotal: totalFp,
+    },
+    reading,
+    missionActions,
+    traffic: { humanPvs, botPvs, dailyPageviews, topBooks, topCollections, topReferrers, topCountries },
+    search,
+    social,
+    ai,
+    pipelineCost,
+  };
+
+  const res = await db.collection('system_config').updateOne(
+    { _id: 'metrics_snapshot' },
+    { $set: { ...snapshot, _id: 'metrics_snapshot' } },
+    { upsert: true },
+  );
+  console.log(`metrics_snapshot written (matched=${res.matchedCount} upserted=${res.upsertedCount ? 1 : 0}). generatedAt=${snapshot.generatedAt.toISOString()}`);
+  console.log(`  users.total=${total}  MAU=${mau}  avgDAU=${avgDau}  humanPV(${DAYS}d)=${humanPvs}  dwellMedian=${dwellMedian}s`);
+}, { timeoutMs: 240000 });

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -17,6 +17,7 @@
 0 8 * * * /usr/local/bin/oura-digest >> /var/log/oura-digest.log 2>&1
 15 1,3,5,7,9,11,13,15,17,19,21,23 * * * cd /root/sourcelibrary && flock -n /tmp/sl-enrichment-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/enrichment-snapshot.mjs" >> /var/log/sourcelibrary/enrichment-snapshot.log 2>&1
 15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-prewarm.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/prewarm-browse.mjs" >> /var/log/sourcelibrary/prewarm-browse.log 2>&1
+45 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-metrics-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analytics/snapshot-metrics.mjs" >> /var/log/sourcelibrary/metrics-snapshot.log 2>&1
 */2 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-scheduler.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/scheduler.mjs" >> /var/log/sourcelibrary/scheduler.log 2>&1
 30 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-entity-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-entities.mjs" >> /var/log/sourcelibrary/entity-sync.log 2>&1
 #PAUSED-GEMINI 30 */4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-embed-gemini.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=\$GEMINI_API_KEY_TIER3 && node scripts/workers/embed-gemini.mjs --incremental" >> /var/log/sourcelibrary/embed-gemini.log 2>&1

--- a/src/app/platform/(protected)/admin/metrics/page.tsx
+++ b/src/app/platform/(protected)/admin/metrics/page.tsx
@@ -1,0 +1,249 @@
+/**
+ * Audience & usage metrics dashboard.
+ *
+ * Reads the daily snapshot from system_config.metrics_snapshot (written by
+ * scripts/analytics/snapshot-metrics.mjs on a Hetzner cron) and renders it.
+ * The page never runs the heavy analytics aggregations itself — same
+ * read-a-precomputed-doc pattern as the homepage_stats surfaces. Gated by the
+ * protected layout (requireSuperAdmin). Numbers are "as of" the snapshot's
+ * generatedAt, shown in the header.
+ *
+ * The snapshot shape is produced by snapshot-metrics.mjs — keep the two in sync
+ * if you add fields there.
+ */
+import { getDb } from '@/lib/mongodb';
+
+export const dynamic = 'force-dynamic';
+
+interface MetricsSnapshot {
+  generatedAt?: Date | string;
+  windowDays?: number;
+  users?: Record<string, number | null>;
+  engagement?: {
+    mau?: number; avgDau?: number;
+    dauLast3?: { date: string; users: number }[];
+    dwellMedianSec?: number; dwellMeanSec?: number; dwellSessions?: number;
+  };
+  conversion?: { uniqVisitors?: number; newSignups?: number; returningVisitors?: number; returningTotal?: number };
+  reading?: { pairs?: number; median?: number; p90?: number; oneOnly?: number; deep?: number; opens?: number } | null;
+  missionActions?: Record<string, number>;
+  traffic?: {
+    humanPvs?: number; botPvs?: number;
+    dailyPageviews?: { date: string; hits: number }[];
+    topBooks?: { key: string; hits: number; title: string; author: string; language: string }[];
+    topCollections?: { slug: string; hits: number }[];
+    topReferrers?: { referrer: string; hits: number }[];
+    topCountries?: { country: string; hits: number }[];
+  };
+  search?: {
+    total?: number; human?: number; zeroResult?: number;
+    topQueries?: { query: string; count: number }[];
+    zeroQueries?: { query: string; count: number }[];
+    latencyP50?: number | null; latencyP90?: number | null;
+  } | null;
+  social?: { likes?: number; likeVisitors?: number; feedback?: number; feedbackUnread?: number; feedbackWantsHelp?: number } | null;
+  ai?: { feature: string; calls: number; cost: number; avgMs: number }[] | null;
+  pipelineCost?: {
+    latestDay?: string; stale?: boolean; last7?: number; last30?: number;
+    recentDays?: { date: string; cost: number; records: number }[];
+  } | null;
+}
+
+const num = (n: number | null | undefined) => (n ?? 0).toLocaleString('en-US');
+const pct = (a?: number | null, b?: number | null) => (b ? ((100 * (a || 0)) / b).toFixed(1) + '%' : '—');
+const dur = (s?: number | null) => `${Math.floor((s || 0) / 60)}m ${Math.round((s || 0) % 60)}s`;
+
+const C = {
+  card: { background: '#161b22', border: '1px solid #30363d', borderRadius: 8, padding: '16px 18px' } as const,
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 12 } as const,
+  big: { fontSize: 30, fontWeight: 700, color: '#e6edf3', lineHeight: 1.1 } as const,
+  label: { fontSize: 12, color: '#8b949e', marginTop: 4, textTransform: 'uppercase', letterSpacing: 0.4 } as const,
+  sub: { fontSize: 12, color: '#6e7681', marginTop: 2 } as const,
+  h2: { fontSize: 16, fontWeight: 600, color: '#e6edf3', margin: '28px 0 12px' } as const,
+  th: { textAlign: 'left' as const, fontSize: 11, color: '#8b949e', textTransform: 'uppercase' as const, letterSpacing: 0.4, padding: '6px 10px', borderBottom: '1px solid #30363d' },
+  td: { fontSize: 13, color: '#c9d1d9', padding: '6px 10px', borderBottom: '1px solid #21262d' },
+};
+
+function Stat({ value, label, sub }: { value: string; label: string; sub?: string }) {
+  return (
+    <div style={C.card}>
+      <div style={C.big}>{value}</div>
+      <div style={C.label}>{label}</div>
+      {sub ? <div style={C.sub}>{sub}</div> : null}
+    </div>
+  );
+}
+
+function Bars({ data }: { data: { date: string; hits: number }[] }) {
+  if (!data?.length) return null;
+  const max = Math.max(...data.map((d) => d.hits), 1);
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', gap: 2, height: 90, ...C.card, paddingTop: 18 }}>
+      {data.map((d) => (
+        <div key={d.date} title={`${d.date}: ${num(d.hits)}`} style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', height: '100%' }}>
+          <div style={{ height: `${(d.hits / max) * 100}%`, background: '#2f81f7', borderRadius: '2px 2px 0 0', minHeight: 1 }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Table({ headers, rows }: { headers: string[]; rows: (string | number)[][] }) {
+  if (!rows?.length) return <p style={{ color: '#6e7681', fontSize: 13 }}>No data.</p>;
+  return (
+    <div style={{ ...C.card, padding: 0, overflow: 'hidden' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead><tr>{headers.map((h, i) => <th key={i} style={{ ...C.th, textAlign: i === 0 ? 'left' : i === headers.length - 1 ? 'right' : 'left' }}>{h}</th>)}</tr></thead>
+        <tbody>
+          {rows.map((r, ri) => (
+            <tr key={ri}>{r.map((c, ci) => <td key={ci} style={{ ...C.td, textAlign: ci === r.length - 1 ? 'right' : 'left', color: ci === 0 ? '#c9d1d9' : '#8b949e' }}>{c}</td>)}</tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default async function MetricsPage() {
+  const db = await getDb();
+  const s = (await db.collection('system_config').findOne({ _id: 'metrics_snapshot' } as never)) as MetricsSnapshot | null;
+
+  if (!s) {
+    return (
+      <div>
+        <h1 style={{ fontSize: 22, fontWeight: 700, color: '#e6edf3' }}>Metrics</h1>
+        <p style={{ color: '#8b949e', marginTop: 12 }}>
+          No snapshot yet. Run <code style={{ color: '#e6edf3' }}>node scripts/analytics/snapshot-metrics.mjs</code> to populate it
+          (it also runs daily on the Hetzner cron).
+        </p>
+      </div>
+    );
+  }
+
+  const u = s.users || {};
+  const e = s.engagement || {};
+  const c = s.conversion || {};
+  const t = s.traffic || {};
+  const win = s.windowDays || 30;
+  const gen = s.generatedAt ? new Date(s.generatedAt) : null;
+  const ageH = gen ? Math.round((Date.now() - gen.getTime()) / 36e5) : null;
+
+  return (
+    <div style={{ maxWidth: 1100 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', flexWrap: 'wrap', gap: 8 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, color: '#e6edf3', margin: 0 }}>Audience &amp; Usage</h1>
+        <span style={{ fontSize: 12, color: ageH !== null && ageH > 30 ? '#d29922' : '#6e7681' }}>
+          snapshot {gen ? gen.toISOString().slice(0, 16).replace('T', ' ') + ' UTC' : 'unknown'}
+          {ageH !== null ? ` · ${ageH}h ago` : ''} · {win}-day window
+        </span>
+      </div>
+
+      <h2 style={C.h2}>Audience</h2>
+      <div style={C.grid}>
+        <Stat value={num(u.total)} label="Signups" sub={`${num(u.new30)} new in ${win}d · ${num(u.new7)} in 7d`} />
+        <Stat value={num(u.verified)} label="Email verified" sub={pct(u.verified, u.total) + ' of signups'} />
+        <Stat value={num(u.everLoggedIn)} label="Ever logged in" sub={`${num(u.repeatLogin)} returning (2+)`} />
+        <Stat value={num(e.mau)} label="MAU" sub="30d unique ip+ua" />
+        <Stat value={num(e.avgDau)} label="Avg DAU" sub="last 14 days" />
+        <Stat value={dur(e.dwellMedianSec)} label="Median dwell" sub={`mean ${dur(e.dwellMeanSec)} · 7d`} />
+        <Stat value={num(u.beta_subscribers)} label="Beta subscribers" />
+        <Stat value={num(u.newsletter_subscribers)} label="Newsletter" />
+      </div>
+
+      <h2 style={C.h2}>Conversion &amp; retention ({win}d)</h2>
+      <div style={C.grid}>
+        <Stat value={num(c.uniqVisitors)} label="Unique visitors" />
+        <Stat value={pct(c.newSignups, c.uniqVisitors)} label="Visitor → signup" sub={`${num(c.newSignups)} signups`} />
+        <Stat value={pct(c.returningVisitors, c.returningTotal)} label="Returning visitors" sub={`>1 day · ${num(c.returningVisitors)}`} />
+        <Stat value={pct(e.avgDau, e.mau)} label="Stickiness" sub="DAU : MAU" />
+      </div>
+
+      {s.reading ? (
+        <>
+          <h2 style={C.h2}>Reading depth (7d)</h2>
+          <div style={C.grid}>
+            <Stat value={num(s.reading.opens)} label="Book opens" />
+            <Stat value={String(s.reading.median ?? 0)} label="Median pages / book" sub={`p90 ${s.reading.p90 ?? 0}`} />
+            <Stat value={pct(s.reading.oneOnly, s.reading.pairs)} label="Read 1 page only" />
+            <Stat value={pct(s.reading.deep, s.reading.pairs)} label="Deep read (10+ pages)" sub={`${num(s.reading.deep)} of ${num(s.reading.pairs)}`} />
+          </div>
+        </>
+      ) : null}
+
+      <h2 style={C.h2}>Traffic ({win}d)</h2>
+      <div style={{ ...C.grid, marginBottom: 12 }}>
+        <Stat value={num(t.humanPvs)} label="Human pageviews" sub={`${num(t.botPvs)} bot/auto`} />
+      </div>
+      <Bars data={t.dailyPageviews || []} />
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginTop: 16 }}>
+        <div>
+          <h2 style={C.h2}>Top books</h2>
+          <Table headers={['title', 'hits']} rows={(t.topBooks || []).map((b) => [`${b.title}${b.author ? ' · ' + b.author : ''}`, num(b.hits)])} />
+        </div>
+        <div>
+          <h2 style={C.h2}>Top collections</h2>
+          <Table headers={['collection', 'hits']} rows={(t.topCollections || []).map((x) => [x.slug, num(x.hits)])} />
+        </div>
+        <div>
+          <h2 style={C.h2}>Referrers</h2>
+          <Table headers={['source', 'hits']} rows={(t.topReferrers || []).map((x) => [x.referrer, num(x.hits)])} />
+        </div>
+        <div>
+          <h2 style={C.h2}>Countries</h2>
+          <Table headers={['country', 'hits']} rows={(t.topCountries || []).map((x) => [x.country, num(x.hits)])} />
+        </div>
+      </div>
+
+      {s.search ? (
+        <>
+          <h2 style={C.h2}>Search ({win}d)</h2>
+          <div style={{ ...C.grid, marginBottom: 12 }}>
+            <Stat value={num(s.search.human)} label="Human searches" sub={`${num(s.search.total)} total incl. bots`} />
+            <Stat value={pct(s.search.zeroResult, s.search.human)} label="Zero-result" />
+            <Stat value={s.search.latencyP50 != null ? `${s.search.latencyP50}ms` : '—'} label="Latency p50" sub={s.search.latencyP90 != null ? `p90 ${s.search.latencyP90}ms` : undefined} />
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+            <div>
+              <h2 style={C.h2}>Top queries</h2>
+              <Table headers={['query', 'count']} rows={(s.search.topQueries || []).map((q) => [q.query, num(q.count)])} />
+            </div>
+            <div>
+              <h2 style={C.h2}>Zero-result queries</h2>
+              <Table headers={['query', 'count']} rows={(s.search.zeroQueries || []).map((q) => [q.query, num(q.count)])} />
+            </div>
+          </div>
+        </>
+      ) : null}
+
+      {s.social ? (
+        <>
+          <h2 style={C.h2}>Social &amp; feedback ({win}d)</h2>
+          <div style={C.grid}>
+            <Stat value={num(s.social.likes)} label="Likes" sub={`${num(s.social.likeVisitors)} visitors`} />
+            <Stat value={num(s.social.feedback)} label="Feedback" sub={`${num(s.social.feedbackUnread)} unread · ${num(s.social.feedbackWantsHelp)} want to help`} />
+          </div>
+        </>
+      ) : null}
+
+      {s.ai?.length ? (
+        <>
+          <h2 style={C.h2}>AI surfaces ({win}d)</h2>
+          <Table headers={['feature', 'calls', 'cost', 'avg ms']} rows={s.ai.map((a) => [a.feature, num(a.calls), '$' + a.cost.toFixed(2), num(a.avgMs)])} />
+        </>
+      ) : null}
+
+      {s.pipelineCost ? (
+        <>
+          <h2 style={C.h2}>Pipeline cost (Gemini)</h2>
+          <div style={{ ...C.grid, marginBottom: 12 }}>
+            <Stat value={'$' + (s.pipelineCost.last7 ?? 0).toFixed(2)} label="Last 7 days" />
+            <Stat value={'$' + (s.pipelineCost.last30 ?? 0).toFixed(2)} label="Last 30 days" />
+            <Stat value={s.pipelineCost.latestDay || '—'} label="Latest day" sub={s.pipelineCost.stale ? '⚠ rollup stale (pipeline paused?)' : undefined} />
+          </div>
+          <Table headers={['date', 'cost', 'records']} rows={(s.pipelineCost.recentDays || []).map((d) => [d.date, '$' + d.cost.toFixed(2), num(d.records)])} />
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/platform/PlatformNav.tsx
+++ b/src/app/platform/PlatformNav.tsx
@@ -7,6 +7,7 @@ import { useSession, signOut } from 'next-auth/react';
 
 const navLinks = [
   { href: '/platform/dashboard', label: 'Dashboard' },
+  { href: '/platform/admin/metrics', label: 'Metrics' },
   { href: '/platform/admin/translation-failures', label: 'Translation Failures' },
   { href: '/platform/tenants/new', label: 'New Library' },
 ];


### PR DESCRIPTION
## What

A super-admin **Metrics** page at `/platform/admin/metrics` — the `/metrics` skill's numbers as a live dashboard instead of a terminal-only report.

It renders signups, MAU/DAU, median dwell, conversion & retention, reading depth, traffic (daily pageview sparkline + top books/collections/referrers/countries), search behavior (top + zero-result queries, latency), social/feedback, AI surfaces, and Gemini pipeline cost.

## How (and why it's fast/free)

- **`scripts/analytics/snapshot-metrics.mjs`** computes the headline aggregations — reusing the exact queries from `audience-metrics.mjs`, `usage-deepdive.mjs`, and `engagement-metrics.mjs` — and writes **one** structured doc to `system_config.metrics_snapshot`. Read-only against Mongo, no Gemini cost.
- The **page is a server component** that reads that snapshot and renders instantly. It never runs the heavy deep-dive scans on page load (they're too slow for a request).
- This is the same "read a precomputed doc" pattern as `system_config.homepage_stats`.
- Gated by the existing protected layout (`requireSuperAdmin`) — no new auth surface.

## Daily refresh

Cron line added to `crontab.production` (05:45, after the prewarm job).

**Out of scope / manual follow-up:** the *live* Hetzner crontab is the source of truth (`crontab.production` is a derived snapshot). After this merges and the Hetzner box auto-pulls the new script, the cron line must be installed on the box (`crontab -e`) for the daily refresh to actually run. Until then the page shows the snapshot already written during development.

## Verification

- `npx tsc --noEmit` clean.
- `snapshot-metrics.mjs` run against prod Mongo: wrote `metrics_snapshot` (2,598 signups, 15.3K MAU, 405K human pageviews/30d, ~4.7m median dwell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)