### PR TITLE
fix: newsletter refresh targets bookstore DB

### DIFF
--- a/scripts/workers/refresh-newsletter-audience.mjs
+++ b/scripts/workers/refresh-newsletter-audience.mjs
@@ -66,7 +66,7 @@ async function main() {
   // 3) Build the deduped union of every Mongo email source (+ first names).
   const client = new MongoClient(MONGODB_URI, { maxPoolSize: 2 });
   await client.connect();
-  const db = client.db();
+  const db = client.db('bookstore'); // prod DB — the connection-string default is not it
   const union = new Map(); // email -> firstName|null
   const addFrom = async (coll, field = 'email') => {
     try {


### PR DESCRIPTION
One-line fix: `client.db()` resolved to the URI default instead of `bookstore`, so the Mongo union returned ~nothing (`union=1`) on the first Hetzner run. Pin `db('bookstore')` to match the other workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)