### PR TITLE
fix(search): pages_only excludes book-level semantic results (MCP passage search)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -529,9 +529,16 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
     // Semantic search finds conceptually related books that keyword search missed.
     // These should rank alongside Supabase trigram hits, not be buried as page entries.
     // Lower floor when keyword search found nothing — semantic becomes the primary results.
+    //
+    // SKIP entirely in pages_only mode (the MCP passage-search contract): book-level
+    // results carry no page_number/snippet, so the MCP filters them out — but they
+    // still rank above page hits and inflate `total`. With a small limit they fill the
+    // whole window and the caller gets 0 passages despite a high total_matches. The
+    // keyword book lane already short-circuits for pagesOnly (see line ~231); mirror it
+    // here so pages_only means pages only. (Saves the semBooks lookup too.)
     const hasKeywordResults = bookDocs.length > 0 || pageDocs.length > 0;
     const SEMANTIC_SIM_FLOOR = hasKeywordResults ? 0.65 : 0.55;
-    if (semanticDocs.length > 0) {
+    if (semanticDocs.length > 0 && !pagesOnly) {
       // Collect unique book IDs from semantic results (skip books already in results)
       const semanticBookIds = [...new Set(
         semanticDocs


### PR DESCRIPTION
## Problem

The MCP `search_translations` tool (passage search) calls `/api/search?pages_only=true`. In that mode the response still merged **book-level semantic results** into `results`. Those rows have no `page_number`/snippet, so the MCP filters them out — but they:

1. **rank above** the real page hits, and
2. are counted in `total`.

With a small `limit`, the book results fill the entire fetch window, so the caller gets **0 passages despite a high `total_matches`**.

Repro (production):
- `search_translations "prima materia"` at `limit=3` → `total 34, returned 0`
- `search_translations "philosopher stone"` at `limit=3` → `total 31, returned 0`
- same queries at the default `limit=20` → 20 clean passages

So it presented as "multi-word queries are broken" but is really a small-limit + inflated-total ranking bug. Single-word queries (e.g. `mercury`) happened to rank pages above books, masking it.

## Fix

The keyword book lane already short-circuits for `pagesOnly` (returns `[]`). This mirrors that on the **semantic book lane**: skip the book-level merge entirely when `pagesOnly`, so `pages_only` means pages only. `total` then reflects only page passages, and small limits return real passages. Also avoids the now-pointless `semBooks` lookup.

Page-level semantic results are untouched — passage search keeps its semantic recall.

## Scope
- In: one gate (`&& !pagesOnly`) on the semantic book merge in `src/app/api/search/route.ts`.
- Out: the global (non-`pages_only`) search path is unchanged — book-level semantic results still appear there as intended. Not touching the separate `total` semantics for the global path.

## Test
- `npx tsc --noEmit` clean.
- Verified against prod that the page rows exist and only ranking/inclusion was the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)