### PR TITLE
fix(search): language filter must constrain semantic lanes (Sanskrit→English leak)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -557,8 +557,15 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
               // partner reading room (Tenant Subdomain Lockdown). See keyword
               // page-lane materialization which already does this.
               ...(tenantId ? { tenantId } : {}),
-              ...(languages.length > 0 ? { language: { $in: languages } } : {}),
-              ...(excludeLanguages.length > 0 && languages.length === 0 ? { language: { $nin: excludeLanguages } } : {}),
+              // Honor the singular `language` param too — not just the `languages`
+              // array. buildBookFilters() (keyword lane) checks all three, but these
+              // semantic lanes only checked the array, so `?language=Sanskrit` leaked
+              // English-edition translations of Sanskrit works through semantic
+              // promotion (the search-eval "Sanskrit filter" failure). Mirror the
+              // keyword-lane precedence: languages → excludeLanguages → language.
+              ...(languages.length > 0 ? { language: { $in: languages } }
+                : excludeLanguages.length > 0 ? { language: { $nin: excludeLanguages } }
+                : language ? { language } : {}),
             },
             { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1, summary: 1, reading_summary: 1, text_role: 1 } }
           )
@@ -630,8 +637,15 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
               // defense-in-depth — but keep it consistent with the book lane so a
               // future RPC change can't silently leak cross-tenant pages.
               ...(tenantId ? { tenantId } : {}),
-              ...(languages.length > 0 ? { language: { $in: languages } } : {}),
-              ...(excludeLanguages.length > 0 && languages.length === 0 ? { language: { $nin: excludeLanguages } } : {}),
+              // Honor the singular `language` param too — not just the `languages`
+              // array. buildBookFilters() (keyword lane) checks all three, but these
+              // semantic lanes only checked the array, so `?language=Sanskrit` leaked
+              // English-edition translations of Sanskrit works through semantic
+              // promotion (the search-eval "Sanskrit filter" failure). Mirror the
+              // keyword-lane precedence: languages → excludeLanguages → language.
+              ...(languages.length > 0 ? { language: { $in: languages } }
+                : excludeLanguages.length > 0 ? { language: { $nin: excludeLanguages } }
+                : language ? { language } : {}),
             },
             { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, quality_score: 1, work_id: 1, text_role: 1 } }
           )


### PR DESCRIPTION
## Problem

`GET /api/search?q=philosophy&language=Sanskrit` returns **English-edition** books — English translations of Sanskrit/Indic works (Samkhya, Jaina sutras, Diamond Sutra). Surfaced by the `search-eval` "Sanskrit filter returns only Sanskrit books" test.

**The book data is correct.** Those books are tagged `language: "English"` (right for a `text_role: "modern-translation"` edition) with `original_language: "Sanskrit"`. Per the project invariant, `language` is the *edition* language. So this is a filter bug, not a data fix.

## Root cause

`buildBookFilters()` (the keyword book lane) honors all three of `languages` (array), `excludeLanguages`, and the singular `language` param. The two **semantic lanes** — book promotion (~L560) and page (~L633) — only checked the `languages` array. So a singular `?language=Sanskrit` never constrained semantically-promoted books, and English editions (conceptually near "philosophy") leaked straight through.

## Fix

Mirror the keyword-lane precedence in both semantic lanes:

```
languages.length ? { language: { $in: languages } }
  : excludeLanguages.length ? { language: { $nin: excludeLanguages } }
  : language ? { language } : {}
```

No book data touched.

## Scope
- In: language-filter precedence on the two semantic lanes in `src/app/api/search/route.ts`.
- Out: no change to `languages`-array / `excludeLanguages` behavior; no change to the keyword lanes; no data edits.

## Test
- `npx tsc --noEmit` clean.
- Verified the 7 leaking results are all `type:'book'` (semantic promotion) and that the keyword lane already excluded them.
- After deploy, re-run `scripts/eval/search-quality-eval.mjs` — the Sanskrit-filter test should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)