### PR TITLE
feat(admin): metrics dashboard v2 — trends, deltas, charts & methodology

### DIFF
--- a/.claude/skills/metrics/SKILL.md
+++ b/.claude/skills/metrics/SKILL.md
@@ -9,6 +9,15 @@ Runs the two analytics scripts that together give the full audience + usage
 picture, then summarizes the numbers and surfaces qualitative texture. Both read
 production Mongo (`bookstore`) — purely read-only, no cost, no permission needed.
 
+> **Live dashboard:** a daily-refreshed version of these numbers (with trends,
+> deltas, growth/DAU charts, and a methodology panel) lives at
+> https://sourcelibrary.org/platform/admin/metrics (super-admin gated). It reads
+> `system_config.metrics_snapshot`, written by `scripts/analytics/snapshot-metrics.mjs`
+> on the Hetzner cron (05:45 UTC) and accumulated daily into `metrics_history`.
+> Use the scripts below when you need fresher-than-daily numbers, a custom window
+> (`--days N`), or the deeper qualitative texture (search chains, journeys) the
+> dashboard intentionally omits.
+
 ## Run all three (in order)
 
 ```bash

--- a/scripts/analytics/snapshot-metrics.mjs
+++ b/scripts/analytics/snapshot-metrics.mjs
@@ -23,10 +23,42 @@ const norm = (e) => (e || '').trim().toLowerCase();
 const BOT_RE = /(bot|crawler|spider|preview|monitor|uptime|wget|curl|python-requests|libwww|http-client|headless|chrome-lighthouse|MCP)/i;
 const isBot = (ua) => !ua || BOT_RE.test(ua);
 
+// Provider prefixes that PR #2025 now 308-redirects away. Before that they
+// served live content; we collapse them so /internet-archive/book/foo counts as
+// /book/foo (mirrors usage-deepdive.mjs::normalizePath so "top books" is faithful).
+const PROVIDER_PREFIXES = new Set([
+  'internet-archive', 'gallica', 'bavarian-state-library', 'e-codices', 'bodleian',
+  'manchester', 'laurenziana', 'e-rara', 'library-of-congress', 'vatican-library',
+  'wellcome-collection', 'bdrc', 'kloss-collection', 'allard-pierson', 'cambridge',
+  'leiden', 'google-books', 'qatar-digital-library', 'oraec',
+  'bibliotheca-philosophica-hermetica', 'tu-delft', 'kyoto', 'british-library',
+]);
+
+// Collapse a raw pageview path to its canonical form and classify it.
+// Handles provider prefixes and /embed/<tenant>/book|collections/... so books
+// reached through a tenant or legacy provider URL still count toward the totals.
+function classifyPath(raw) {
+  if (!raw) return { kind: 'other', slug: '' };
+  let s = raw.split('?')[0];
+  const parts = s.split('/').filter(Boolean);
+  if (parts.length && PROVIDER_PREFIXES.has(parts[0])) parts.shift();
+  if (parts[0] === 'embed' && parts.length > 2) {
+    const inner = parts[2];
+    if (inner === 'book') return { kind: 'book', slug: parts[3] || '' };
+    if (inner === 'collections') return { kind: 'collection', slug: parts[3] || '' };
+    return { kind: 'other', slug: '' };
+  }
+  if (parts[0] === 'book') return { kind: 'book', slug: parts[1] || '' };
+  if (parts[0] === 'collections') return { kind: 'collection', slug: parts[1] || '' };
+  return { kind: 'other', slug: '' };
+}
+
 await withMongo(async (db) => {
   const now = Date.now();
   const since = (d) => new Date(now - d * 864e5);
+  const day = (d) => new Date(now - d * 864e5).toISOString().slice(0, 10);
   const SINCE = since(DAYS), d30 = since(30), d14 = since(14), d7 = since(7), d1 = since(1);
+  const todayStr = new Date(now).toISOString().slice(0, 10);
 
   const fpGroup = { _id: { ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] } } };
 
@@ -46,17 +78,32 @@ await withMongo(async (db) => {
   for (const cn of ['beta_subscribers', 'newsletter_subscribers']) {
     try { subscribers[cn] = await db.collection(cn).countDocuments({}); } catch { subscribers[cn] = null; }
   }
+  // Prior-period signups for week-over-week / month-over-month deltas.
+  const [prev7, prev30] = await Promise.all([
+    users.countDocuments({ createdAt: { $gt: d14, $lte: d7 } }),
+    users.countDocuments({ createdAt: { $gt: since(60), $lte: d30 } }),
+  ]);
+  // Daily new signups over 90 days, for the growth chart (cumulative derived on read).
+  const signupSeries = await users.aggregate([
+    { $match: { createdAt: { $gt: since(90) } } },
+    { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, n: { $sum: 1 } } },
+    { $sort: { _id: 1 } },
+  ]).toArray();
+  const signupsByDay = signupSeries.map((r) => ({ date: r._id, n: r.n }));
+  const signupsBefore90 = total - signupsByDay.reduce((s, r) => s + r.n, 0); // cumulative baseline
 
   // ─── DAU / MAU / DWELL ────────────────────────────────────────────────────
   const pv = db.collection('analytics_pageviews');
   const mau = (await pv.aggregate([
     { $match: { timestamp: { $gt: d30 } } }, { $group: fpGroup }, { $count: 'n' },
   ]).toArray())[0]?.n || 0;
-  const dau = await pv.aggregate([
-    { $match: { timestamp: { $gt: d14 } } },
+  // 30-day DAU series (drives the trend chart); avg DAU uses the last 14 days.
+  const dauSeries = await pv.aggregate([
+    { $match: { timestamp: { $gt: d30 } } },
     { $group: { _id: { day: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp' } }, ip: '$ip', ua: { $substr: ['$userAgent', 0, 60] } } } },
     { $group: { _id: '$_id.day', users: { $sum: 1 } } }, { $sort: { _id: 1 } },
   ], { allowDiskUse: true }).toArray();
+  const dau = dauSeries.filter((d) => d._id >= day(14));
   const avgDau = Math.round(dau.reduce((s, d) => s + d.users, 0) / (dau.length || 1));
 
   // Dwell: per-session (ip+ua, 30-min idle gap) duration, last 7d, multi-hit only.
@@ -130,28 +177,24 @@ await withMongo(async (db) => {
   const pvCursor = pv.find({ timestamp: { $gte: SINCE } }, { projection: { path: 1, userAgent: 1, referrer: 1, country: 1, timestamp: 1 } });
   let humanPvs = 0, botPvs = 0;
   const dailyHits = new Map(), bookHits = new Map(), collectionHits = new Map(), referrers = new Map(), countries = new Map();
-  const kindOf = (p) => {
-    if (!p) return 'other';
-    const s = p.split('?')[0];
-    if (s.startsWith('/book/')) return 'book';
-    if (s.startsWith('/collections/')) return 'collection';
-    return 'other';
-  };
   while (await pvCursor.hasNext()) {
     const d = await pvCursor.next();
     if (isBot(d.userAgent)) { botPvs++; continue; }
     humanPvs++;
-    const s = (d.path || '').split('?')[0];
-    const day = new Date(d.timestamp).toISOString().slice(0, 10);
-    dailyHits.set(day, (dailyHits.get(day) || 0) + 1);
-    if (kindOf(s) === 'book') { const slug = s.split('/')[2] || ''; if (slug) bookHits.set(slug, (bookHits.get(slug) || 0) + 1); }
-    if (kindOf(s) === 'collection') { const slug = s.split('/')[2] || ''; if (slug) collectionHits.set(slug, (collectionHits.get(slug) || 0) + 1); }
+    const cls = classifyPath(d.path || '');
+    const dstr = new Date(d.timestamp).toISOString().slice(0, 10);
+    dailyHits.set(dstr, (dailyHits.get(dstr) || 0) + 1);
+    if (cls.kind === 'book' && cls.slug) bookHits.set(cls.slug, (bookHits.get(cls.slug) || 0) + 1);
+    if (cls.kind === 'collection' && cls.slug) collectionHits.set(cls.slug, (collectionHits.get(cls.slug) || 0) + 1);
     const refDomain = (d.referrer || 'direct').replace(/^https?:\/\//, '').split('/')[0] || 'direct';
     referrers.set(refDomain, (referrers.get(refDomain) || 0) + 1);
     countries.set(d.country || 'unknown', (countries.get(d.country || 'unknown') || 0) + 1);
   }
   const topN = (m, n) => [...m.entries()].sort((a, b) => b[1] - a[1]).slice(0, n);
   const dailyPageviews = [...dailyHits.entries()].sort((a, b) => a[0].localeCompare(b[0])).map(([date, hits]) => ({ date, hits }));
+  // Pageviews week-over-week, from the per-day human series (last 7 vs prior 7).
+  const pvLast7 = dailyPageviews.filter((r) => r.date >= day(7)).reduce((s, r) => s + r.hits, 0);
+  const pvPrev7 = dailyPageviews.filter((r) => r.date >= day(14) && r.date < day(7)).reduce((s, r) => s + r.hits, 0);
 
   // Resolve top book slugs/ids to titles.
   const topBookKeys = topN(bookHits, 15);
@@ -237,13 +280,26 @@ await withMongo(async (db) => {
   } catch { /* noop */ }
 
   // ─── ASSEMBLE + WRITE ─────────────────────────────────────────────────────
+  // `deltas` express period-over-period change so the page can show momentum,
+  // not just a static level. Each is { now, prev } — the page derives the %.
   const snapshot = {
     generatedAt: new Date(now),
     windowDays: DAYS,
+    schemaVersion: 2,
     users: {
       total, verified, hasLogin, everLoggedIn, repeatLogin,
       new30, new7, new1,
       ...subscribers,
+    },
+    deltas: {
+      signups7: { now: new7, prev: prev7 },
+      signups30: { now: new30, prev: prev30 },
+      pageviews7: { now: pvLast7, prev: pvPrev7 },
+    },
+    series: {
+      signupsByDay,          // [{date,n}] daily NEW signups, 90d
+      signupsBaseline: signupsBefore90, // cumulative total before the 90d window
+      dau: dauSeries.map((d) => ({ date: d._id, users: d.users })), // 30d
     },
     engagement: {
       mau, avgDau,
@@ -268,6 +324,27 @@ await withMongo(async (db) => {
     { $set: { ...snapshot, _id: 'metrics_snapshot' } },
     { upsert: true },
   );
+
+  // Accumulate a daily time series so trends for the EXPENSIVE rolling metrics
+  // (MAU, dwell, stickiness) can be charted over time — these aren't
+  // reconstructable from raw events after the fact the way signups/DAU are.
+  // Idempotent per calendar day (a re-run overwrites the same dated doc).
+  const histDoc = {
+    date: todayStr, generatedAt: new Date(now),
+    signupsTotal: total, verified, everLoggedIn,
+    new7, new30, mau, avgDau,
+    dwellMedianSec: dwellMedian, dwellMeanSec: dwellMean,
+    uniqVisitors, returningVisitors: multiDay, returningTotal: totalFp,
+    humanPvs7: pvLast7,
+  };
+  let histRes;
+  try {
+    histRes = await db.collection('metrics_history').updateOne(
+      { date: todayStr }, { $set: histDoc }, { upsert: true },
+    );
+  } catch (e) { console.error(`  (metrics_history write skipped: ${e.message})`); }
+
   console.log(`metrics_snapshot written (matched=${res.matchedCount} upserted=${res.upsertedCount ? 1 : 0}). generatedAt=${snapshot.generatedAt.toISOString()}`);
-  console.log(`  users.total=${total}  MAU=${mau}  avgDAU=${avgDau}  humanPV(${DAYS}d)=${humanPvs}  dwellMedian=${dwellMedian}s`);
+  console.log(`  users.total=${total} (+${new7}/7d, prev ${prev7})  MAU=${mau}  avgDAU=${avgDau}  humanPV(${DAYS}d)=${humanPvs}  dwellMedian=${dwellMedian}s`);
+  if (histRes) console.log(`  metrics_history[${todayStr}] ${histRes.upsertedCount ? 'inserted' : 'updated'}.`);
 }, { timeoutMs: 240000 });

--- a/src/app/platform/(protected)/admin/metrics/page.tsx
+++ b/src/app/platform/(protected)/admin/metrics/page.tsx
@@ -8,17 +8,28 @@
  * protected layout (requireSuperAdmin). Numbers are "as of" the snapshot's
  * generatedAt, shown in the header.
  *
- * The snapshot shape is produced by snapshot-metrics.mjs — keep the two in sync
- * if you add fields there.
+ * Every metric carries a plain-language definition (the `def` prop on each
+ * Stat) and the page closes with a Methodology panel — the numbers here come
+ * from coarse proxies (ip+ua fingerprints, not accounts) and must be read with
+ * their caveats, or they mislead. Keep the snapshot shape in sync with
+ * snapshot-metrics.mjs.
  */
 import { getDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 
+interface Delta { now?: number; prev?: number }
 interface MetricsSnapshot {
   generatedAt?: Date | string;
   windowDays?: number;
+  schemaVersion?: number;
   users?: Record<string, number | null>;
+  deltas?: { signups7?: Delta; signups30?: Delta; pageviews7?: Delta };
+  series?: {
+    signupsByDay?: { date: string; n: number }[];
+    signupsBaseline?: number;
+    dau?: { date: string; users: number }[];
+  };
   engagement?: {
     mau?: number; avgDau?: number;
     dauLast3?: { date: string; users: number }[];
@@ -55,35 +66,98 @@ const dur = (s?: number | null) => `${Math.floor((s || 0) / 60)}m ${Math.round((
 
 const C = {
   card: { background: '#161b22', border: '1px solid #30363d', borderRadius: 8, padding: '16px 18px' } as const,
-  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 12 } as const,
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(190px, 1fr))', gap: 12 } as const,
   big: { fontSize: 30, fontWeight: 700, color: '#e6edf3', lineHeight: 1.1 } as const,
   label: { fontSize: 12, color: '#8b949e', marginTop: 4, textTransform: 'uppercase', letterSpacing: 0.4 } as const,
   sub: { fontSize: 12, color: '#6e7681', marginTop: 2 } as const,
-  h2: { fontSize: 16, fontWeight: 600, color: '#e6edf3', margin: '28px 0 12px' } as const,
+  def: { fontSize: 11, color: '#56606b', marginTop: 8, lineHeight: 1.45 } as const,
+  h2: { fontSize: 16, fontWeight: 600, color: '#e6edf3', margin: '30px 0 4px' } as const,
+  h2sub: { fontSize: 12, color: '#6e7681', margin: '0 0 12px' } as const,
   th: { textAlign: 'left' as const, fontSize: 11, color: '#8b949e', textTransform: 'uppercase' as const, letterSpacing: 0.4, padding: '6px 10px', borderBottom: '1px solid #30363d' },
   td: { fontSize: 13, color: '#c9d1d9', padding: '6px 10px', borderBottom: '1px solid #21262d' },
 };
 
-function Stat({ value, label, sub }: { value: string; label: string; sub?: string }) {
+// Period-over-period change chip. Direction-neutral colour: up=green, down=red,
+// flat=grey. `prev` is shown so the reader sees what it's measured against.
+function DeltaChip({ d, suffix = '' }: { d?: Delta; suffix?: string }) {
+  if (!d || d.now == null || d.prev == null) return null;
+  const diff = d.now - d.prev;
+  const p = d.prev ? (100 * diff) / d.prev : 0;
+  const up = diff > 0, flat = diff === 0;
+  const color = flat ? '#8b949e' : up ? '#3fb950' : '#f85149';
+  const arrow = flat ? '→' : up ? '▲' : '▼';
+  return (
+    <div style={{ fontSize: 12, color, marginTop: 6, fontWeight: 600 }}>
+      {arrow} {Math.abs(p).toFixed(0)}%{suffix}
+      <span style={{ color: '#56606b', fontWeight: 400 }}> vs prev {num(d.prev)}</span>
+    </div>
+  );
+}
+
+function Stat({ value, label, sub, def, delta }: { value: string; label: string; sub?: string; def?: string; delta?: React.ReactNode }) {
   return (
     <div style={C.card}>
       <div style={C.big}>{value}</div>
       <div style={C.label}>{label}</div>
       {sub ? <div style={C.sub}>{sub}</div> : null}
+      {delta}
+      {def ? <div style={C.def}>{def}</div> : null}
     </div>
   );
 }
 
-function Bars({ data }: { data: { date: string; hits: number }[] }) {
-  if (!data?.length) return null;
-  const max = Math.max(...data.map((d) => d.hits), 1);
+function SectionHead({ title, sub }: { title: string; sub?: string }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'flex-end', gap: 2, height: 90, ...C.card, paddingTop: 18 }}>
+    <>
+      <h2 style={C.h2}>{title}</h2>
+      {sub ? <p style={C.h2sub}>{sub}</p> : null}
+    </>
+  );
+}
+
+function Bars({ data, color = '#2f81f7', height = 90 }: { data: { date: string; value: number }[]; color?: string; height?: number }) {
+  if (!data?.length) return null;
+  const max = Math.max(...data.map((d) => d.value), 1);
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', gap: 2, height, ...C.card, paddingTop: 18 }}>
       {data.map((d) => (
-        <div key={d.date} title={`${d.date}: ${num(d.hits)}`} style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', height: '100%' }}>
-          <div style={{ height: `${(d.hits / max) * 100}%`, background: '#2f81f7', borderRadius: '2px 2px 0 0', minHeight: 1 }} />
+        <div key={d.date} title={`${d.date}: ${num(d.value)}`} style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', height: '100%' }}>
+          <div style={{ height: `${(d.value / max) * 100}%`, background: color, borderRadius: '2px 2px 0 0', minHeight: 1 }} />
         </div>
       ))}
+    </div>
+  );
+}
+
+// Cumulative-signups line over a faint daily-new histogram. Pure SVG, no client JS.
+function GrowthChart({ daily, baseline }: { daily: { date: string; n: number }[]; baseline: number }) {
+  if (!daily?.length) return null;
+  const W = 1000, H = 200, pad = 4;
+  let cum = baseline;
+  const cumPts = daily.map((d) => { cum += d.n; return cum; });
+  const cumMax = Math.max(...cumPts, 1), cumMin = baseline;
+  const dailyMax = Math.max(...daily.map((d) => d.n), 1);
+  const x = (i: number) => pad + (i * (W - 2 * pad)) / Math.max(daily.length - 1, 1);
+  const yC = (v: number) => H - pad - ((v - cumMin) / Math.max(cumMax - cumMin, 1)) * (H - 2 * pad);
+  const path = cumPts.map((v, i) => `${i === 0 ? 'M' : 'L'}${x(i).toFixed(1)},${yC(v).toFixed(1)}`).join(' ');
+  const area = `${path} L${x(daily.length - 1).toFixed(1)},${H - pad} L${x(0).toFixed(1)},${H - pad} Z`;
+  const barW = (W - 2 * pad) / daily.length * 0.7;
+  return (
+    <div style={C.card}>
+      <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: 200, display: 'block' }}>
+        {daily.map((d, i) => {
+          const h = (d.n / dailyMax) * (H - 2 * pad) * 0.55;
+          return <rect key={d.date} x={x(i) - barW / 2} y={H - pad - h} width={barW} height={h} fill="#21364e" />;
+        })}
+        <path d={area} fill="rgba(63,185,80,0.08)" />
+        <path d={path} fill="none" stroke="#3fb950" strokeWidth={2} vectorEffect="non-scaling-stroke" />
+      </svg>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: '#56606b', marginTop: 6 }}>
+        <span>{daily[0]?.date}</span>
+        <span style={{ color: '#3fb950' }}>━ cumulative signups</span>
+        <span style={{ color: '#21364e' }}>▮ new/day</span>
+        <span>{daily[daily.length - 1]?.date}</span>
+      </div>
     </div>
   );
 }
@@ -93,7 +167,7 @@ function Table({ headers, rows }: { headers: string[]; rows: (string | number)[]
   return (
     <div style={{ ...C.card, padding: 0, overflow: 'hidden' }}>
       <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-        <thead><tr>{headers.map((h, i) => <th key={i} style={{ ...C.th, textAlign: i === 0 ? 'left' : i === headers.length - 1 ? 'right' : 'left' }}>{h}</th>)}</tr></thead>
+        <thead><tr>{headers.map((h, i) => <th key={i} style={{ ...C.th, textAlign: i === headers.length - 1 ? 'right' : 'left' }}>{h}</th>)}</tr></thead>
         <tbody>
           {rows.map((r, ri) => (
             <tr key={ri}>{r.map((c, ci) => <td key={ci} style={{ ...C.td, textAlign: ci === r.length - 1 ? 'right' : 'left', color: ci === 0 ? '#c9d1d9' : '#8b949e' }}>{c}</td>)}</tr>
@@ -103,6 +177,17 @@ function Table({ headers, rows }: { headers: string[]; rows: (string | number)[]
     </div>
   );
 }
+
+const METHODOLOGY: [string, string][] = [
+  ['Snapshot cadence', 'Numbers are precomputed once a day at 05:45 UTC by scripts/analytics/snapshot-metrics.mjs and read from system_config.metrics_snapshot — they are NOT live. The header shows when this snapshot was generated; if it is more than ~30h old the timestamp turns amber.'],
+  ['Visitors are fingerprints, not people', 'MAU, DAU, unique visitors, dwell and retention are all keyed on (IP + first 60 chars of user-agent), with the last IP octet zeroed at ingest. One person on phone + laptop counts twice; a shared office IP can collapse several people into one. Treat these as a consistent proxy for trend, not a true headcount. Accounts (signups, verified, logins) ARE real per-person counts.'],
+  ['Dwell = multi-pageview sessions only', 'Median/mean session duration is measured over the last 7 days and only counts sessions with 2+ pageviews (a single-hit visit has no measurable duration), so it skews high relative to "average time on site across everyone."'],
+  ['Reading depth median = 1 is normal', 'Most reader↔book pairs touch a single page (≈83%). This is the expected shape of a reference library — people land on one page from search or a citation. "Deep reads" (10+ pages) are the signal to watch.'],
+  ['Zero-result searches are mostly typeahead', 'A large share of zero-result queries are truncated keystrokes logged mid-type (e.g. "flu", "parace"), not genuine content gaps. Only conceptual misses (a real subject we lack) indicate acquisition need.'],
+  ['Traffic is bot-filtered & path-normalized', 'Pageview counts exclude known bots/crawlers/automation by user-agent. Legacy provider-prefixed and tenant /embed/ book URLs are folded to their canonical /book/<slug> so a book is counted however it was reached.'],
+  ['share / cite are under-instrumented', 'The download/share/cite mission-action counts reflect what is currently wired to fire events; near-zero share/cite means the events are barely instrumented, not necessarily that nobody quotes.'],
+  ['Pipeline cost can read stale', 'Gemini spend comes from the gemini_usage_daily rollup, which stops advancing while the OCR pipeline is paused. A stale "latest day" is flagged inline and means the rollup, not necessarily real spend, is behind.'],
+];
 
 export default async function MetricsPage() {
   const db = await getDb();
@@ -124,6 +209,8 @@ export default async function MetricsPage() {
   const e = s.engagement || {};
   const c = s.conversion || {};
   const t = s.traffic || {};
+  const dl = s.deltas || {};
+  const ser = s.series || {};
   const win = s.windowDays || 30;
   const gen = s.generatedAt ? new Date(s.generatedAt) : null;
   const ageH = gen ? Math.round((Date.now() - gen.getTime()) / 36e5) : null;
@@ -137,79 +224,110 @@ export default async function MetricsPage() {
           {ageH !== null ? ` · ${ageH}h ago` : ''} · {win}-day window
         </span>
       </div>
+      <p style={{ fontSize: 12, color: '#6e7681', margin: '6px 0 0' }}>
+        Precomputed daily. Visitor metrics are ip+ua fingerprints (a proxy, not a headcount); account metrics are real. See methodology at the bottom.
+      </p>
 
-      <h2 style={C.h2}>Audience</h2>
+      <SectionHead title="Audience" sub="Signups & accounts are real per-person counts; MAU/DAU are fingerprint proxies." />
       <div style={C.grid}>
-        <Stat value={num(u.total)} label="Signups" sub={`${num(u.new30)} new in ${win}d · ${num(u.new7)} in 7d`} />
-        <Stat value={num(u.verified)} label="Email verified" sub={pct(u.verified, u.total) + ' of signups'} />
-        <Stat value={num(u.everLoggedIn)} label="Ever logged in" sub={`${num(u.repeatLogin)} returning (2+)`} />
-        <Stat value={num(e.mau)} label="MAU" sub="30d unique ip+ua" />
-        <Stat value={num(e.avgDau)} label="Avg DAU" sub="last 14 days" />
-        <Stat value={dur(e.dwellMedianSec)} label="Median dwell" sub={`mean ${dur(e.dwellMeanSec)} · 7d`} />
+        <Stat value={num(u.total)} label="Signups" sub={`${num(u.new30)} new in ${win}d · ${num(u.new7)} in 7d`}
+          delta={<DeltaChip d={dl.signups7} suffix=" wk/wk" />}
+          def="Total registered accounts, all time. The week-over-week delta compares the last 7 days of new signups to the 7 before." />
+        <Stat value={num(u.verified)} label="Email verified" sub={pct(u.verified, u.total) + ' of signups'}
+          def="Accounts that completed email verification. The rest started signup but never confirmed." />
+        <Stat value={num(u.everLoggedIn)} label="Ever logged in" sub={`${num(u.repeatLogin)} returning (2+)`}
+          def="Accounts with at least one login; 'returning' have logged in 2+ times." />
+        <Stat value={num(e.mau)} label="MAU" sub="30d unique ip+ua"
+          def="Distinct visitor fingerprints active in the last 30 days. A proxy — not deduplicated to real people." />
+        <Stat value={num(e.avgDau)} label="Avg DAU" sub="mean of last 14 days"
+          def="Average daily unique fingerprints over the last 14 days." />
+        <Stat value={dur(e.dwellMedianSec)} label="Median dwell" sub={`mean ${dur(e.dwellMeanSec)} · 7d`}
+          def="Median session length over 7 days, counting only sessions with 2+ pageviews, so it skews high." />
         <Stat value={num(u.beta_subscribers)} label="Beta subscribers" />
         <Stat value={num(u.newsletter_subscribers)} label="Newsletter" />
       </div>
 
-      <h2 style={C.h2}>Conversion &amp; retention ({win}d)</h2>
-      <div style={C.grid}>
-        <Stat value={num(c.uniqVisitors)} label="Unique visitors" />
-        <Stat value={pct(c.newSignups, c.uniqVisitors)} label="Visitor → signup" sub={`${num(c.newSignups)} signups`} />
-        <Stat value={pct(c.returningVisitors, c.returningTotal)} label="Returning visitors" sub={`>1 day · ${num(c.returningVisitors)}`} />
-        <Stat value={pct(e.avgDau, e.mau)} label="Stickiness" sub="DAU : MAU" />
+      <SectionHead title="Growth" sub="Cumulative signups (line) over daily new signups (bars), last 90 days." />
+      <GrowthChart daily={ser.signupsByDay || []} baseline={ser.signupsBaseline || 0} />
+      <div style={{ ...C.grid, marginTop: 12 }}>
+        <Stat value={num(dl.signups30?.now)} label={`Signups this ${win}d`} delta={<DeltaChip d={dl.signups30} suffix=" vs prior 30d" />}
+          def="New accounts in this window vs the window before it — the headline growth signal." />
+        <Stat value={num(dl.pageviews7?.now)} label="Pageviews 7d" delta={<DeltaChip d={dl.pageviews7} suffix=" wk/wk" />}
+          def="Human (bot-filtered) pageviews in the last 7 days vs the 7 before." />
       </div>
+
+      <SectionHead title="Conversion & retention" sub={`Over the last ${win} days.`} />
+      <div style={C.grid}>
+        <Stat value={num(c.uniqVisitors)} label="Unique visitors" def="Distinct fingerprints in the window." />
+        <Stat value={pct(c.newSignups, c.uniqVisitors)} label="Visitor → signup" sub={`${num(c.newSignups)} signups`}
+          def="New signups divided by unique visitors. A rough funnel rate — numerator is accounts, denominator is fingerprints." />
+        <Stat value={pct(c.returningVisitors, c.returningTotal)} label="Returning visitors" sub={`>1 day · ${num(c.returningVisitors)}`}
+          def="Fingerprints seen on more than one calendar day in the window." />
+        <Stat value={pct(e.avgDau, e.mau)} label="Stickiness" sub="DAU : MAU"
+          def="Avg DAU as a share of MAU — how much of the monthly audience shows up on a given day." />
+      </div>
+
+      {ser.dau?.length ? (
+        <>
+          <SectionHead title="Daily active (30d)" sub="Unique fingerprints per day — momentum at a glance." />
+          <Bars data={ser.dau.map((d) => ({ date: d.date, value: d.users }))} color="#3fb950" />
+        </>
+      ) : null}
 
       {s.reading ? (
         <>
-          <h2 style={C.h2}>Reading depth (7d)</h2>
+          <SectionHead title="Reading depth" sub="From page_read events, last 7 days. Median 1 page is normal for a reference library." />
           <div style={C.grid}>
-            <Stat value={num(s.reading.opens)} label="Book opens" />
-            <Stat value={String(s.reading.median ?? 0)} label="Median pages / book" sub={`p90 ${s.reading.p90 ?? 0}`} />
-            <Stat value={pct(s.reading.oneOnly, s.reading.pairs)} label="Read 1 page only" />
-            <Stat value={pct(s.reading.deep, s.reading.pairs)} label="Deep read (10+ pages)" sub={`${num(s.reading.deep)} of ${num(s.reading.pairs)}`} />
+            <Stat value={num(s.reading.opens)} label="Book opens" def="book_read events in the last 7 days." />
+            <Stat value={String(s.reading.median ?? 0)} label="Median pages / book" sub={`p90 ${s.reading.p90 ?? 0}`}
+              def="Distinct pages a reader views per book. Most land on one page from search or a citation." />
+            <Stat value={pct(s.reading.oneOnly, s.reading.pairs)} label="Read 1 page only" def="Share of reader-book pairs that touched a single page." />
+            <Stat value={pct(s.reading.deep, s.reading.pairs)} label="Deep read (10+)" sub={`${num(s.reading.deep)} of ${num(s.reading.pairs)}`}
+              def="The engaged tail — pairs where someone read 10+ pages." />
           </div>
         </>
       ) : null}
 
-      <h2 style={C.h2}>Traffic ({win}d)</h2>
+      <SectionHead title="Traffic" sub={`Human, bot-filtered pageviews over the last ${win} days; book URLs normalized across providers & tenants.`} />
       <div style={{ ...C.grid, marginBottom: 12 }}>
-        <Stat value={num(t.humanPvs)} label="Human pageviews" sub={`${num(t.botPvs)} bot/auto`} />
+        <Stat value={num(t.humanPvs)} label="Human pageviews" sub={`${num(t.botPvs)} bot/auto filtered out`} />
       </div>
-      <Bars data={t.dailyPageviews || []} />
+      <Bars data={(t.dailyPageviews || []).map((d) => ({ date: d.date, value: d.hits }))} />
 
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginTop: 16 }}>
         <div>
-          <h2 style={C.h2}>Top books</h2>
+          <SectionHead title="Top books" />
           <Table headers={['title', 'hits']} rows={(t.topBooks || []).map((b) => [`${b.title}${b.author ? ' · ' + b.author : ''}`, num(b.hits)])} />
         </div>
         <div>
-          <h2 style={C.h2}>Top collections</h2>
+          <SectionHead title="Top collections" />
           <Table headers={['collection', 'hits']} rows={(t.topCollections || []).map((x) => [x.slug, num(x.hits)])} />
         </div>
         <div>
-          <h2 style={C.h2}>Referrers</h2>
+          <SectionHead title="Referrers" />
           <Table headers={['source', 'hits']} rows={(t.topReferrers || []).map((x) => [x.referrer, num(x.hits)])} />
         </div>
         <div>
-          <h2 style={C.h2}>Countries</h2>
+          <SectionHead title="Countries" />
           <Table headers={['country', 'hits']} rows={(t.topCountries || []).map((x) => [x.country, num(x.hits)])} />
         </div>
       </div>
 
       {s.search ? (
         <>
-          <h2 style={C.h2}>Search ({win}d)</h2>
+          <SectionHead title="Search" sub={`Last ${win} days. Many zero-result queries are truncated typeahead, not content gaps.`} />
           <div style={{ ...C.grid, marginBottom: 12 }}>
             <Stat value={num(s.search.human)} label="Human searches" sub={`${num(s.search.total)} total incl. bots`} />
-            <Stat value={pct(s.search.zeroResult, s.search.human)} label="Zero-result" />
+            <Stat value={pct(s.search.zeroResult, s.search.human)} label="Zero-result" def="Share returning no results — mostly mid-type keystrokes; conceptual misses signal real gaps." />
             <Stat value={s.search.latencyP50 != null ? `${s.search.latencyP50}ms` : '—'} label="Latency p50" sub={s.search.latencyP90 != null ? `p90 ${s.search.latencyP90}ms` : undefined} />
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
             <div>
-              <h2 style={C.h2}>Top queries</h2>
+              <SectionHead title="Top queries" />
               <Table headers={['query', 'count']} rows={(s.search.topQueries || []).map((q) => [q.query, num(q.count)])} />
             </div>
             <div>
-              <h2 style={C.h2}>Zero-result queries</h2>
+              <SectionHead title="Zero-result queries" />
               <Table headers={['query', 'count']} rows={(s.search.zeroQueries || []).map((q) => [q.query, num(q.count)])} />
             </div>
           </div>
@@ -218,7 +336,7 @@ export default async function MetricsPage() {
 
       {s.social ? (
         <>
-          <h2 style={C.h2}>Social &amp; feedback ({win}d)</h2>
+          <SectionHead title="Social & feedback" sub={`Last ${win} days.`} />
           <div style={C.grid}>
             <Stat value={num(s.social.likes)} label="Likes" sub={`${num(s.social.likeVisitors)} visitors`} />
             <Stat value={num(s.social.feedback)} label="Feedback" sub={`${num(s.social.feedbackUnread)} unread · ${num(s.social.feedbackWantsHelp)} want to help`} />
@@ -228,14 +346,14 @@ export default async function MetricsPage() {
 
       {s.ai?.length ? (
         <>
-          <h2 style={C.h2}>AI surfaces ({win}d)</h2>
+          <SectionHead title="AI surfaces" sub={`Last ${win} days — librarian, search-expand, voice, and external MCP agents.`} />
           <Table headers={['feature', 'calls', 'cost', 'avg ms']} rows={s.ai.map((a) => [a.feature, num(a.calls), '$' + a.cost.toFixed(2), num(a.avgMs)])} />
         </>
       ) : null}
 
       {s.pipelineCost ? (
         <>
-          <h2 style={C.h2}>Pipeline cost (Gemini)</h2>
+          <SectionHead title="Pipeline cost (Gemini)" sub="From the gemini_usage_daily rollup — can read stale while OCR is paused." />
           <div style={{ ...C.grid, marginBottom: 12 }}>
             <Stat value={'$' + (s.pipelineCost.last7 ?? 0).toFixed(2)} label="Last 7 days" />
             <Stat value={'$' + (s.pipelineCost.last30 ?? 0).toFixed(2)} label="Last 30 days" />
@@ -244,6 +362,16 @@ export default async function MetricsPage() {
           <Table headers={['date', 'cost', 'records']} rows={(s.pipelineCost.recentDays || []).map((d) => [d.date, '$' + d.cost.toFixed(2), num(d.records)])} />
         </>
       ) : null}
+
+      <SectionHead title="Methodology & caveats" sub="What these numbers mean — and what they do not." />
+      <div style={{ ...C.card, display: 'grid', gap: 14 }}>
+        {METHODOLOGY.map(([title, body]) => (
+          <div key={title}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#c9d1d9' }}>{title}</div>
+            <div style={{ fontSize: 12.5, color: '#8b949e', marginTop: 3, lineHeight: 1.5 }}>{body}</div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Builds on #2856 (the daily metrics snapshot + page). Takes it from a static current-state readout to a **trend** dashboard, and adds an honesty layer so every number is read correctly.

## Level-up

**Script (`snapshot-metrics.mjs`)**
- **Period-over-period deltas** — signups 7d & 30d, pageviews 7d (now vs prior period), so the page shows momentum, not just a level.
- **Time series** — 90d daily-new signups (+ cumulative baseline) and 30d DAU, for the charts.
- **Faithful path normalization** — folds provider-prefixed (`/internet-archive/book/…`) and `/embed/<tenant>/book/…` URLs to canonical `/book/<slug>`, mirroring `usage-deepdive.mjs`. Previously only bare `/book/` counted, undercounting top books. (Top book now resolves correctly: Fludd, *Utriusque Cosmi*.)
- **`metrics_history`** — accumulates one row per calendar day (idempotent) so the *expensive rolling* metrics (MAU, dwell, stickiness) can be charted over time later; unlike signups/DAU they aren't reconstructable from raw events after the fact.

**Page (`/platform/admin/metrics`)**
- **Delta chips** with direction arrows (green up / red down) + the prior value for context.
- **SVG charts** — cumulative-signups growth (line over daily-new bars, 90d) and a 30d DAU trend. Pure server-rendered SVG, no client JS.
- **Definition on every metric** + a **Methodology & caveats** panel: fingerprints-not-people, dwell is multi-pageview-only, reading-median-1-is-normal, zero-result-searches-are-mostly-typeahead, traffic-is-bot-filtered, share/cite under-instrumented, pipeline-cost-can-read-stale.

## Validated
Cross-checked the snapshot against the canonical `/metrics` scripts (`audience`/`usage`/`engagement`): dwell 4m43s, conversion 15.0%, returning 25.0%, stickiness 11.2%, reading median 1 / 83.4% one-page, mission actions — **all match**. Script run end-to-end against prod; `metrics_snapshot` (schemaVersion 2) + `metrics_history` populated. `npx tsc --noEmit` clean.

## What it surfaces (read honestly)
The deltas show the site **spiked then tapered**: 2,290 of 2,601 signups (88%) are in the last 30d (vs 191 the prior 30d), but week-over-week is now *down* (606 vs 1,335 signups; 136K vs 218K pageviews). The page renders that with down-arrows, not as growth.

## Out of scope
- Backfilling `metrics_history` (no past snapshots exist — it accumulates forward).
- A "refresh now" button (snapshot stays daily, per the original decision).
- The qualitative search-chain / journey narratives the skill warns against auto-storytelling — left to the on-demand scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)