### PR TITLE
feat(ft): live producers keep their search evidence (append-only ledger)

### DIFF
--- a/scripts/analysis/ft-ground-remediation.mjs
+++ b/scripts/analysis/ft-ground-remediation.mjs
@@ -40,6 +40,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
+import { appendAttempt, makeAttemptId } from '../lib/ft-attempt-log.mjs';
 
 const MODEL = 'gemini-3.1-flash-lite';
 const CONCURRENCY = 3;
@@ -352,6 +353,33 @@ async function main() {
         } },
         { upsert: true },
       );
+
+      // Keep the search. A NOT_FIRST is a catalog-grounded prior sighting;
+      // a FIRST_LIKELY is a documented absence across 3 catalogs. Either way
+      // the durable evidence (sources, query, priors found) outlives this run.
+      const isoDate = new Date().toISOString();
+      const found = b.verdict === 'NOT_FIRST';
+      await appendAttempt(db, {
+        attempt_id: makeAttemptId(book.id, 'tier1_catalog', isoDate),
+        book_id: book.id,
+        date: isoDate,
+        method: 'tier1_catalog',
+        match_key: 'author_title',
+        sources_checked: ['open_library', 'google_books', 'internet_archive'],
+        queries: [[book.display_title || book.title, book.author].filter(Boolean).join(' ').trim()].filter(Boolean),
+        result: found ? 'found' : 'none',
+        found_refs: [],
+        priors: (result.translations || []).map(t => ({
+          english_title: t.english_title, translator: t.translator, pub_year: t.pub_year,
+          publisher: t.publisher, completeness: t.completeness, source_url: t.source_url || undefined,
+        })),
+        // Single-pass catalog grounding: a found prior is moderate; an absence is weak.
+        evidence_strength: found ? 'moderate' : 'weak',
+        independence_score: 0.3,
+        model: MODEL,
+        notes: `[ground ${b.verdict}] ${(result.reasoning || '').slice(0, 300)}${result.search_limitations ? ` | ${result.search_limitations.slice(0, 120)}` : ''}`.trim(),
+        _src: 'ft-ground-remediation',
+      });
     }
     if (i + CONCURRENCY < books.length) await new Promise(r => setTimeout(r, BATCH_DELAY_MS));
   }

--- a/scripts/enrichment/audit-translation-claims.mjs
+++ b/scripts/enrichment/audit-translation-claims.mjs
@@ -49,6 +49,7 @@
 import { GoogleGenAI } from '@google/genai';
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
+import { appendAttempt, makeAttemptId, domainsFromEvidence } from '../lib/ft-attempt-log.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 const MODEL = 'gemini-3.1-flash-lite';
@@ -321,6 +322,33 @@ async function main() {
           cost_usd: ((r.tokens?.input || 0) / 1_000_000) * 0.15 + ((r.tokens?.output || 0) / 1_000_000) * 3.50,
           status: 'success',
           endpoint: 'script/audit-translation-claims',
+        });
+
+        // Keep the search. This audit verified a specific CITED prior via real
+        // Google-grounded search — record what was queried, what was consulted,
+        // and whether a prior was confirmed, so the evidence outlives the run.
+        const isoDate = new Date().toISOString();
+        const priorFound = r.verdict === 'confirmed' || !!r.alternative_translation_found;
+        const prior = r.verdict === 'confirmed'
+          ? { english_title: claim.english_title, translator: claim.translator, pub_year: claim.pub_year, publisher: claim.publisher }
+          : (r.alternative_translation_found || null);
+        const domains = domainsFromEvidence(r.evidence);
+        await appendAttempt(db, {
+          attempt_id: makeAttemptId(book.id, 'gemini_verifier', isoDate),
+          book_id: book.id,
+          date: isoDate,
+          method: 'gemini_verifier',
+          match_key: 'author_title',
+          sources_checked: domains,
+          queries: r.searchQueries || [],
+          result: priorFound ? 'found' : 'none',
+          found_refs: [],
+          priors: prior ? [prior] : [],
+          evidence_strength: priorFound ? 'moderate' : 'weak',
+          independence_score: domains.length ? 0.3 : 0.1,
+          model: MODEL,
+          notes: `[audit ${r.verdict}/${r.confidence}] ${(r.reasoning || '').slice(0, 300)}`.trim(),
+          _src: 'audit-translation-claims',
         });
       }
     } catch (err) {

--- a/scripts/enrichment/discover-translations-estimate.mjs
+++ b/scripts/enrichment/discover-translations-estimate.mjs
@@ -23,6 +23,7 @@
 import { GoogleGenAI } from '@google/genai';
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
+import { appendAttempt, makeAttemptId, domainsFromEvidence } from '../lib/ft-attempt-log.mjs';
 
 const MODEL = 'gemini-3.1-flash-lite';
 const CONCURRENCY = 3;
@@ -101,14 +102,15 @@ async function discoverOne(book) {
   const text = resp.text || '';
   const grounding = resp.candidates?.[0]?.groundingMetadata;
   const evidence = (grounding?.groundingChunks || []).filter(c => c.web?.uri).slice(0, 5).map(c => ({ url: c.web.uri, title: c.web.title || '' }));
+  const searchQueries = grounding?.webSearchQueries || [];
   let parsed;
   try {
     const m = text.match(/```(?:json)?\s*([\s\S]*?)```/) || text.match(/\{[\s\S]*\}/);
     parsed = JSON.parse((m ? m[1] || m[0] : text).trim());
   } catch {
-    return { error: 'parse_failed', raw: text.slice(0, 300), evidence };
+    return { error: 'parse_failed', raw: text.slice(0, 300), evidence, searchQueries };
   }
-  return { ...parsed, evidence, tokens: { input: resp.usageMetadata?.promptTokenCount || 0, output: resp.usageMetadata?.candidatesTokenCount || 0 } };
+  return { ...parsed, evidence, searchQueries, tokens: { input: resp.usageMetadata?.promptTokenCount || 0, output: resp.usageMetadata?.candidatesTokenCount || 0 } };
 }
 
 async function pool(items, fn, n) {
@@ -179,6 +181,29 @@ async function main() {
             },
           }}
         );
+
+        // Keep the search. This is a documented look for ANY prior English
+        // translation of the work — record it append-only so the absence (or
+        // the missed prior) is durable evidence, not a one-night side note.
+        const isoDate = new Date().toISOString();
+        const domains = domainsFromEvidence(r.evidence);
+        await appendAttempt(db, {
+          attempt_id: makeAttemptId(book.id, 'gemini_verifier', isoDate),
+          book_id: book.id,
+          date: isoDate,
+          method: 'gemini_verifier',
+          match_key: 'author_title',
+          sources_checked: domains,
+          queries: r.searchQueries || [],
+          result: r.translation_exists ? 'found' : 'none',
+          found_refs: [],
+          priors: r.translation ? [r.translation] : [],
+          evidence_strength: r.translation_exists ? 'moderate' : 'weak',
+          independence_score: domains.length ? 0.3 : 0.1,
+          model: MODEL,
+          notes: `[discover ${r.confidence}] ${(r.reasoning || '').slice(0, 300)}`.trim(),
+          _src: 'discover-translations-estimate',
+        });
       }
     } catch (err) {
       errors.push({ book, error: err.message });

--- a/scripts/lib/ft-attempt-log.mjs
+++ b/scripts/lib/ft-attempt-log.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * ft-attempt-log.mjs — node/.mjs twin of src/lib/first-translation/attempt-log.ts.
+ *
+ * The live first-translation producers (the nightly grounded-Gemini crons) run
+ * real catalog/web searches every night and, until now, threw the search away —
+ * writing only a transient verdict to a side field. A "first translation" claim
+ * is a claim of ABSENCE, and an absence claim is only ever as strong as the
+ * documented search behind it. So the search itself is the durable asset: keep
+ * it append-only in `first_translation_attempts`, and any future approach
+ * inherits it instead of re-paying for it.
+ *
+ * This helper lets the .mjs cron scripts append an attempt without importing the
+ * TS module (node can't load .ts directly). It mirrors the schema in
+ * attempt-log.ts — keep the two in sync. Logging is best-effort: a failure here
+ * must never break the producer's primary job.
+ */
+
+export const ATTEMPTS_COLLECTION = 'first_translation_attempts';
+
+/** Deterministic id so a re-run of the same book in the same instant is idempotent. */
+export function makeAttemptId(bookId, method, isoDate) {
+  return `${bookId}:${method}:${isoDate}`;
+}
+
+/** Host domains from grounding URLs — the durable record of what was consulted. */
+export function domainsFromEvidence(evidence) {
+  return [
+    ...new Set(
+      (evidence || [])
+        .map((e) => {
+          try {
+            return new URL(e.url).hostname.replace(/^www\./, '');
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean),
+    ),
+  ];
+}
+
+/**
+ * Append one attempt. Idempotent on attempt_id (upsert + $setOnInsert), so a
+ * cron retry won't duplicate. Never throws into the caller.
+ * @returns {Promise<boolean>} true if a new attempt was written.
+ */
+export async function appendAttempt(db, attempt) {
+  try {
+    const res = await db.collection(ATTEMPTS_COLLECTION).updateOne(
+      { attempt_id: attempt.attempt_id },
+      { $setOnInsert: attempt },
+      { upsert: true },
+    );
+    return res.upsertedCount > 0;
+  } catch (e) {
+    console.warn(`  [attempt-log] skip ${attempt.book_id}: ${e.message}`);
+    return false;
+  }
+}


### PR DESCRIPTION
## The problem

The first-translation system stores the **conclusion** (the `is_first_translation` boolean) and throws away the **search** that justified it. A "first translation" is an *absence* claim ("no prior English translation exists"), which can never be proven — only bounded by how hard you looked. So the documented search is the only thing that gives the claim any strength, and it's exactly what the live system discards.

The durable evidence ledger (`first_translation_attempts`, #2564) is the right home for that search record — but it was a **one-time backfill, frozen at 2026-06-27**. None of the live nightly producers fed it: they run real grounded searches every night and write only a transient verdict to a side field, then the queries/sources/found-priors evaporate.

## The fix

Wire the three live grounded producers to append one row to the ledger each time they search — recording method, the queries issued, the source domains consulted, whether a prior was found, the structured priors, and an honest single-pass `evidence_strength` (**a found prior = moderate; an absence = weak — never strong from one pass**).

| Producer | Cron | method |
|---|---|---|
| `scripts/analysis/ft-ground-remediation.mjs` | 08:00 | `tier1_catalog` |
| `scripts/enrichment/audit-translation-claims.mjs` | 03:40 | `gemini_verifier` |
| `scripts/enrichment/discover-translations-estimate.mjs` | 04:40 | `gemini_verifier` |

Plus `scripts/lib/ft-attempt-log.mjs` — a small node/.mjs twin of `src/lib/first-translation/attempt-log.ts` (node can't import the `.ts` directly). Appends are **idempotent** on `attempt_id` and **best-effort** (a logging failure can never break the producer's primary job).

## Safety

- **No model spend** — the search already runs; this only records its output.
- **No badge/count change** — appends to the evidence log only; nothing reads it to change a flag.
- Append path proven end-to-end against the live `bookstore` DB (insert → idempotent retry → readback → cleanup) before opening.
- The two `gemini_verifier` appends are gated behind the scripts' existing `--apply`/`--save` flags, so dry-runs stay clean.

## In scope vs out of scope

**In scope (one concern):** make the live producers *keep* their search.

**Out of scope — deliberate follow-ups:**
- Wire a live *consumer* that reads the ledger before spending (the `resolve.ts` tier cascade is still unwired).
- Derive `is_first_translation` from the ledger on a schedule (the single-writer reconcile is still manual; legacy direct-writers still live).
- Internal-registry-first lookup (check our own work clusters + `translation_catalogs` before any external search).
- Switch the public count to the evidence-strength-gated read (`isPublicFirst` is defined but unwired).

This is the foundational piece: it stops the system throwing evidence away, so the follow-ups have an accumulating record to read from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)