### PR TITLE
feat(ft): producers read prior evidence before spending (read-before-verify)

### DIFF
--- a/scripts/analysis/ft-ground-remediation.mjs
+++ b/scripts/analysis/ft-ground-remediation.mjs
@@ -40,7 +40,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
-import { appendAttempt, makeAttemptId } from '../lib/ft-attempt-log.mjs';
+import { appendAttempt, makeAttemptId, findTrustworthyPrior } from '../lib/ft-attempt-log.mjs';
 
 const MODEL = 'gemini-3.1-flash-lite';
 const CONCURRENCY = 3;
@@ -323,28 +323,45 @@ async function main() {
   if (books.length === 0) { await client.close(); return; }
 
   const tally = { NOT_FIRST: 0, FIRST_LIKELY: 0, NEEDS_HUMAN: 0 };
-  let processed = 0, errors = 0;
+  let processed = 0, errors = 0, reusedCount = 0;
 
   for (let i = 0; i < books.length; i += CONCURRENCY) {
     const batch = books.slice(i, i + CONCURRENCY);
-    const settled = await Promise.allSettled(batch.map(async book => ({ book, result: await groundBook(book) })));
+    const settled = await Promise.allSettled(batch.map(async book => {
+      // Read before you spend: if a trustworthy prior is already on record,
+      // skip the 3-catalog search + Gemini synthesis and reuse the evidence.
+      const known = await findTrustworthyPrior(db, book.id);
+      if (known) {
+        return { book, result: {
+          reused: true,
+          has_english_translation: true,
+          translations: known.priors || [],
+          evidence_strength: known.evidence_strength || null,
+          confidence: 'high',
+          reasoning: `Reused prior evidence on record (${known._src || known.method}, attempt ${known.attempt_id}).`,
+          raw: {},
+        } };
+      }
+      return { book, result: await groundBook(book) };
+    }));
     for (const s of settled) {
       processed++;
       if (s.status === 'rejected') { errors++; console.log(`  [${processed}/${books.length}] FAIL ${s.reason}`); continue; }
       const { book, result } = s.value;
+      if (result.reused) reusedCount++;
       const b = bucket(result);
       tally[b.verdict]++;
       const short = (book.display_title || book.title || '').substring(0, 50);
       const t0 = (result.translations || [])[0];
       const ev = t0 ? ` -> "${(t0.english_title || '').substring(0, 45)}" (${t0.pub_year || '?'}, ${t0.translator || '?'})` : '';
-      console.log(`  [${processed}/${books.length}] ${b.verdict.padEnd(12)} ${short}${ev}`);
+      console.log(`  [${processed}/${books.length}] ${result.reused ? 'REUSE ' : ''}${b.verdict.padEnd(12)} ${short}${ev}`);
       await proposals.updateOne(
         { book_id: book.id },
         { $set: {
             book_id: book.id, title: book.display_title || book.title, author: book.author || '', language: book.language,
             old_flag: book.is_first_translation ?? null, old_disposition: book.translation_verification?.disposition ?? null,
             verdict: b.verdict, proposed_flag: b.proposed_flag, reason_code: b.why,
-            grounded: true, source: 'catalog_search',
+            grounded: !result.reused, source: result.reused ? 'ledger_reuse' : 'catalog_search',
             has_english_translation: result.has_english_translation ?? null,
             translations: result.translations || [], evidence_strength: result.evidence_strength || null,
             confidence: result.confidence || null, reasoning: result.reasoning || null,
@@ -357,6 +374,8 @@ async function main() {
       // Keep the search. A NOT_FIRST is a catalog-grounded prior sighting;
       // a FIRST_LIKELY is a documented absence across 3 catalogs. Either way
       // the durable evidence (sources, query, priors found) outlives this run.
+      // Skip on reuse — the prior is already on record; don't duplicate it.
+      if (result.reused) continue;
       const isoDate = new Date().toISOString();
       const found = b.verdict === 'NOT_FIRST';
       await appendAttempt(db, {
@@ -384,7 +403,7 @@ async function main() {
     if (i + CONCURRENCY < books.length) await new Promise(r => setTimeout(r, BATCH_DELAY_MS));
   }
 
-  console.log(`\n=== done: ${processed} grounded, ${errors} errors ===`);
+  console.log(`\n=== done: ${processed} processed (${reusedCount} reused from ledger, no spend), ${errors} errors ===`);
   console.log('verdicts:', JSON.stringify(tally));
   console.log('NOTE: proposals only. No is_first_translation flag written. NOT_FIRST(catalog-grounded) is safe to confirm false after review; FIRST_LIKELY needs human sign-off before any true.');
   await client.close();

--- a/scripts/enrichment/discover-translations-estimate.mjs
+++ b/scripts/enrichment/discover-translations-estimate.mjs
@@ -23,7 +23,7 @@
 import { GoogleGenAI } from '@google/genai';
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
-import { appendAttempt, makeAttemptId, domainsFromEvidence } from '../lib/ft-attempt-log.mjs';
+import { appendAttempt, makeAttemptId, domainsFromEvidence, findTrustworthyPrior } from '../lib/ft-attempt-log.mjs';
 
 const MODEL = 'gemini-3.1-flash-lite';
 const CONCURRENCY = 3;
@@ -150,11 +150,21 @@ async function main() {
   console.log(`Pulled ${sample.length} books\n`);
 
   const found = [], missed = [], errors = [];
+  const reused = [];
   let totalIn = 0, totalOut = 0;
 
   await pool(sample, async (book) => {
     const t = (book.display_title || book.title || '').slice(0, 55);
     try {
+      // Read before you spend: if a trustworthy prior is already on record
+      // (e.g. a guard-passing match in our own registry), don't pay for a
+      // fresh grounded search — we already know a prior exists.
+      const known = await findTrustworthyPrior(db, book.id);
+      if (known) {
+        reused.push({ book, prior: known });
+        console.log(`  REUSE       ${t} — prior already on record (${known._src || known.method})`);
+        return;
+      }
       const r = await discoverOne(book);
       if (r.error) { errors.push({ book, error: r.error }); console.log(`  PARSE-FAIL  ${t}`); return; }
       totalIn += r.tokens?.input || 0;
@@ -215,6 +225,7 @@ async function main() {
 
   console.log('\n=== Estimate ===');
   console.log(`  Sample size:                ${sample.length}`);
+  console.log(`  Reused (prior on record):   ${reused.length} — search skipped, no spend`);
   console.log(`  Translation found (missed): ${found.length} (${(100 * found.length / sample.length).toFixed(0)}%)`);
   console.log(`  No translation found:       ${missed.length} (${(100 * missed.length / sample.length).toFixed(0)}%)`);
   console.log(`  Errors / parse fails:       ${errors.length}`);

--- a/scripts/lib/ft-attempt-log.mjs
+++ b/scripts/lib/ft-attempt-log.mjs
@@ -41,6 +41,44 @@ export function domainsFromEvidence(evidence) {
 }
 
 /**
+ * Read before you spend. Return an existing attempt that already found a
+ * TRUSTWORTHY prior English translation for this book, or null.
+ *
+ * The bar is deliberately high (precision over recall) because the consequence
+ * is skipping a paid re-search: a prior counts only when it carries a concrete,
+ * resolvable reference — a registry id (`found_refs`, e.g. our own
+ * translation_catalogs match) or a `source_url` on the prior — AND its
+ * evidence_strength is not 'weak'. A grounded model "found" with no resolvable
+ * sighting does NOT qualify (that is exactly the ~63%-fabrication risk), so it
+ * never short-circuits a search. This mirrors the First Principle: only a
+ * confirmed sighting is trusted enough to stop looking.
+ *
+ * @returns {Promise<object|null>} the strongest qualifying attempt, or null.
+ */
+export async function findTrustworthyPrior(db, bookId) {
+  const found = await db
+    .collection(ATTEMPTS_COLLECTION)
+    .find({ book_id: bookId, result: 'found' })
+    .toArray();
+  const qualifying = found.filter((a) => {
+    if (a.evidence_strength === 'weak') return false;
+    const hasRef = Array.isArray(a.found_refs) && a.found_refs.length > 0;
+    const hasUrl = Array.isArray(a.priors) && a.priors.some((p) => p && p.source_url);
+    return hasRef || hasUrl;
+  });
+  if (qualifying.length === 0) return null;
+  // Prefer the strongest: a registry/structured ref over a bare URL, then strength.
+  const rank = { strong: 2, moderate: 1, weak: 0 };
+  qualifying.sort((a, b) => {
+    const aRef = Array.isArray(a.found_refs) && a.found_refs.length > 0 ? 1 : 0;
+    const bRef = Array.isArray(b.found_refs) && b.found_refs.length > 0 ? 1 : 0;
+    if (aRef !== bRef) return bRef - aRef;
+    return (rank[b.evidence_strength] ?? 0) - (rank[a.evidence_strength] ?? 0);
+  });
+  return qualifying[0];
+}
+
+/**
  * Append one attempt. Idempotent on attempt_id (upsert + $setOnInsert), so a
  * cron retry won't duplicate. Never throws into the caller.
  * @returns {Promise<boolean>} true if a new attempt was written.


### PR DESCRIPTION
## What & why

Third in the series. #2865 made the live producers **write** their searches to the ledger; #2866 made the registry matcher **record** its finds. This closes the loop: the paid producers now **read** the ledger *before* they spend.

The durability principle, made operational: one approach's finding saves another approach's search. We already pay to discover a prior once — we shouldn't pay to re-discover it.

## Change

New `findTrustworthyPrior(db, bookId)` in `scripts/lib/ft-attempt-log.mjs`. Returns an existing attempt that already found a prior English translation — but only when the prior carries a **concrete, resolvable sighting**: a registry id (`found_refs`, e.g. our own `translation_catalogs` match) **or** a `source_url`, **and** `evidence_strength !== 'weak'`.

A grounded model "found" with no resolvable reference does **not** qualify — that's exactly the ~63%-fabrication risk, and it must never short-circuit a search. Precision over recall, because the consequence of a hit is *skipping a paid re-search*.

Wired into the two per-book paid producers:
- **`discover-translations-estimate.mjs`** (04:40 cron): trustworthy prior on record → skip the grounded Gemini call entirely (logged `REUSE`, no spend).
- **`ft-ground-remediation.mjs`** (08:00 cron): short-circuit to a `NOT_FIRST` proposal (`source: 'ledger_reuse'`) without the 3-catalog search + synthesis; does not re-append an attempt (the prior is already recorded).

## Safety

- **No flag change, no new spend** — this PR only *avoids* spend.
- The reuse bar is deliberately strict (resolvable reference + non-weak), so it can't be triggered by a fabricated grounded "found".
- Verified against prod: reader returns the registry match for Reuchlin (*De Verbo Mirifico*), `null` for a book with no attempts, and `null` for a grounded `found` lacking a url/ref (precision bar holds).

## The arc so far

| PR | the loop |
|---|---|
| #2865 | live producers **keep** their search (external) |
| #2866 | registry matcher **records** its finds (our own DB) |
| **this** | producers **read** the ledger **before spending** |

Result: the system looks at what it already knows first, keeps every search, and stops re-paying for answers it has. Remaining follow-up: derive the flag from the accumulated ledger on a schedule (single-writer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)