### PR TITLE
feat(ft): derive graded verdict from the accumulated attempt ledger (#2805)

### DIFF
--- a/scripts/maintenance/derive-ft-verdict-from-attempts.ts
+++ b/scripts/maintenance/derive-ft-verdict-from-attempts.ts
@@ -1,0 +1,160 @@
+/**
+ * Derive `book.first_translation` (graded verdict) from the accumulated attempt
+ * ledger (issue #2564 / #2805). The bridge that makes the durable evidence
+ * actionable: verdict = f(accumulated evidence).
+ *
+ * WRITES ONLY `book.first_translation` (the verdict object) on --apply. It NEVER
+ * writes the public `is_first_translation` boolean — that stays a derived read,
+ * materialized only by the sign-off-gated reconcile
+ * (reconcile-first-translation-flag.ts). So this is one safe step short of the
+ * public flip: it reports the downstream flag diff the reconcile WOULD produce,
+ * for review, but does not produce it.
+ *
+ * Dry-run by default. Even --apply is non-public (the verdict feeds the badge
+ * only once the separate reconcile runs).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/maintenance/derive-ft-verdict-from-attempts.ts                 # dry-run report
+ *   npx tsx scripts/maintenance/derive-ft-verdict-from-attempts.ts --book-id ID    # one book
+ *   npx tsx scripts/maintenance/derive-ft-verdict-from-attempts.ts --apply         # write verdicts (NOT the flag)
+ */
+import { getDb } from '@/lib/mongodb';
+import { deriveVerdictFromAttempts } from '@/lib/first-translation/derive-from-evidence';
+import { isFirstByVerdict, canPromoteToFirst } from '@/lib/first-translation/derive';
+import { ATTEMPTS_COLLECTION, type FirstTranslationAttempt } from '@/lib/first-translation/attempt-log';
+import type { FirstTranslation, FirstTranslationBook } from '@/lib/first-translation/types';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const BOOK_ID = args.find((a) => a.startsWith('--book-id='))?.split('=')[1]
+  ?? (args.includes('--book-id') ? args[args.indexOf('--book-id') + 1] : undefined);
+const SAMPLE = parseInt(args.find((a) => a.startsWith('--sample='))?.split('=')[1] || '15', 10);
+
+interface BookDoc extends FirstTranslationBook {
+  _id: unknown;
+  id?: string;
+  title?: string;
+  author?: string;
+  language?: string;
+  visible?: boolean;
+  pages_translated?: number;
+  is_first_translation?: boolean;
+}
+
+function chunk<T>(arr: T[], n: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
+  return out;
+}
+
+async function main() {
+  const db = await getDb();
+  const attemptsCol = db.collection<FirstTranslationAttempt>(ATTEMPTS_COLLECTION);
+  const books = db.collection<BookDoc>('books');
+
+  // 1) Pull attempts grouped by book.
+  const attemptQuery = BOOK_ID ? { book_id: BOOK_ID } : {};
+  const byBook = new Map<string, FirstTranslationAttempt[]>();
+  const cur = attemptsCol.find(attemptQuery);
+  for await (const a of cur) {
+    if (!a.book_id) continue;
+    const arr = byBook.get(a.book_id) ?? [];
+    arr.push(a);
+    byBook.set(a.book_id, arr);
+  }
+  console.log(`Books with attempts on record: ${byBook.size}`);
+
+  // 2) Fetch the books those attempts refer to (book_id = books.id, the string id).
+  const ids = [...byBook.keys()];
+  const bookById = new Map<string, BookDoc>();
+  for (const part of chunk(ids, 5000)) {
+    const docs = await books.find(
+      { id: { $in: part } },
+      { projection: {
+        id: 1, title: 1, author: 1, language: 1, original_language: 1,
+        visible: 1, pages_translated: 1,
+        is_first_translation: 1, first_translation: 1,
+        'translation_verification.disposition': 1,
+      } },
+    ).toArray();
+    for (const d of docs) if (d.id) bookById.set(d.id, d);
+  }
+
+  // 3) Derive + classify.
+  const stats = {
+    derived: 0, no_verdict: 0, book_missing: 0,
+    by_verdict: {} as Record<string, number>,
+    new_verdict: 0, changed_verdict: 0, same_verdict: 0,
+    would_demote: 0, would_promote: 0, blocked_promote: 0, no_flag_change: 0,
+  };
+  const writes: { _id: unknown; ft: FirstTranslation }[] = [];
+  const demoteSamples: string[] = [];
+  const promoteSamples: string[] = [];
+
+  for (const [bookId, attempts] of byBook) {
+    const book = bookById.get(bookId);
+    if (!book) { stats.book_missing++; continue; }
+    const ft = deriveVerdictFromAttempts(attempts);
+    if (!ft) { stats.no_verdict++; continue; }
+    stats.derived++;
+    stats.by_verdict[ft.verdict] = (stats.by_verdict[ft.verdict] || 0) + 1;
+
+    // Verdict delta vs what's already stored.
+    const prev = book.first_translation?.verdict;
+    if (!prev) stats.new_verdict++;
+    else if (prev !== ft.verdict) stats.changed_verdict++;
+    else stats.same_verdict++;
+
+    // Downstream flag effect IF the reconcile then ran on this verdict.
+    const synthetic: FirstTranslationBook = { ...book, first_translation: ft };
+    const proposedFlag = isFirstByVerdict(synthetic);
+    const currentFlag = book.is_first_translation === true;
+    const desc = `  ${book.id} [${book.language ?? '?'}] ${(book.author ?? '').slice(0, 24)} — ${(book.title ?? '').slice(0, 44)} (${ft.verdict}/${ft.evidence_strength})`;
+    if (proposedFlag && !currentFlag) {
+      if (canPromoteToFirst(synthetic)) { stats.would_promote++; if (promoteSamples.length < SAMPLE) promoteSamples.push(desc); }
+      else stats.blocked_promote++;
+    } else if (!proposedFlag && currentFlag) {
+      stats.would_demote++; if (demoteSamples.length < SAMPLE) demoteSamples.push(desc);
+    } else {
+      stats.no_flag_change++;
+    }
+
+    writes.push({ _id: book._id, ft });
+  }
+
+  // 4) Report.
+  console.log(`\n=== derive-ft-verdict-from-attempts (${APPLY ? 'APPLY (verdict only)' : 'DRY-RUN'}) ===`);
+  console.log(`verdicts derived: ${stats.derived}  (no-verdict/unverified: ${stats.no_verdict}, book missing: ${stats.book_missing})`);
+  console.log('by verdict:', JSON.stringify(stats.by_verdict));
+  console.log(`verdict delta vs stored: new=${stats.new_verdict} changed=${stats.changed_verdict} same=${stats.same_verdict}`);
+  console.log('\nDownstream flag effect IF reconcile then ran (this script does NOT flip the flag):');
+  console.log(`  would PROMOTE (evidence-backed): ${stats.would_promote}`);
+  console.log(`  blocked promotions (weak/ungated, held): ${stats.blocked_promote}`);
+  console.log(`  would DEMOTE: ${stats.would_demote}`);
+  console.log(`  no flag change: ${stats.no_flag_change}`);
+  if (promoteSamples.length) { console.log('\n  sample would-promote:'); promoteSamples.forEach((s) => console.log(s)); }
+  if (demoteSamples.length) { console.log('\n  sample would-demote:'); demoteSamples.forEach((s) => console.log(s)); }
+
+  if (!APPLY) {
+    console.log('\nDRY-RUN — no writes. Re-run with --apply to write book.first_translation (verdict only; still NOT the public flag).');
+    return;
+  }
+
+  // 5) Write path — ONLY book.first_translation. Never is_first_translation.
+  const now = new Date().toISOString();
+  let written = 0;
+  for (const part of chunk(writes, 500)) {
+    const ops = part.map((w) => ({
+      updateOne: {
+        filter: { _id: w._id as any },
+        update: { $set: { first_translation: { ...w.ft, resolved_at: now } } },
+      },
+    }));
+    const r = await books.bulkWrite(ops, { ordered: false });
+    written += r.modifiedCount;
+  }
+  console.log(`\nAPPLIED — wrote ${written} book.first_translation verdicts. The public is_first_translation flag is UNCHANGED (run the reconcile, gated on sign-off, to materialize it).`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/derive-ft-verdict-from-attempts.ts
+++ b/scripts/maintenance/derive-ft-verdict-from-attempts.ts
@@ -95,7 +95,7 @@ async function main() {
   for (const [bookId, attempts] of byBook) {
     const book = bookById.get(bookId);
     if (!book) { stats.book_missing++; continue; }
-    const ft = deriveVerdictFromAttempts(attempts);
+    const ft = deriveVerdictFromAttempts(attempts, book);
     if (!ft) { stats.no_verdict++; continue; }
     stats.derived++;
     stats.by_verdict[ft.verdict] = (stats.by_verdict[ft.verdict] || 0) + 1;

--- a/src/lib/first-translation/attempt-log.ts
+++ b/src/lib/first-translation/attempt-log.ts
@@ -54,8 +54,14 @@ export interface FirstTranslationAttempt {
   sources_checked: string[];
   /** The actual queries issued, for auditability. */
   queries?: string[];
-  /** Did this attempt find a prior translation, or confirm absence? */
-  result: 'found' | 'none';
+  /**
+   * Did this attempt find a prior translation, confirm absence, or judge the
+   * book not an English-translation candidate at all? `not_applicable` (an agent
+   * deciding it's an original-language edition / container / translation into
+   * another language) is NOT an absence vote — it must not be counted toward a
+   * "first" claim. (Legacy rows encoded it in `notes` as "not_applicable: …".)
+   */
+  result: 'found' | 'none' | 'not_applicable';
   /** Registry ids of priors found (empty when result==='none'). */
   found_refs?: string[];
   /** Structured priors found this attempt (translator/year/title/link). */

--- a/src/lib/first-translation/derive-from-evidence.ts
+++ b/src/lib/first-translation/derive-from-evidence.ts
@@ -3,42 +3,45 @@
  *
  * The attempt log (`first_translation_attempts`) is the durable, approach-agnostic
  * record of every search ever run for a book. This module turns that pile into a
- * single `book.first_translation` verdict — "verdict = f(accumulated evidence)",
- * the consequence the durability principle has been building toward. It does NOT
- * write the public `is_first_translation` boolean; that stays a derived read of
- * the verdict (see derive.ts) materialized only by the sign-off-gated reconcile.
+ * single `book.first_translation` verdict — "verdict = f(accumulated evidence)".
+ * It does NOT write the public `is_first_translation` boolean; that stays a
+ * derived read materialized only by the sign-off-gated reconcile (derive.ts).
  *
- * Pure over an injected attempts array (mirrors prior-evidence.ts / resolve.ts) so
- * it is unit-testable without a DB.
+ * Pure over an injected attempts array + the book (the book is needed to run the
+ * evidence-quality guard on cited priors), so it is unit-testable without a DB.
  *
- * The mapping is deliberately conservative — it is the input to a public claim:
- *  - reuse_prior (a URL-checkable prior found) → not_first.
- *      strength = strong only on CROSS-FAMILY agreement (≥2 families found it),
- *      else moderate.
- *  - absence (nobody found a prior) → first_no_prior.
- *      strength weighed by INDEPENDENT FAMILIES, not raw method count (two
- *      correlated catalog checks are one vote): ≥2 families → moderate, else weak.
- *      Never 'strong' from absence here — a strong absence needs an independent
- *      agent/human family this deriver doesn't manufacture.
- *  - unverified (no usable evidence) → null (write nothing).
+ * HARDENED against the real, legacy-backfilled ledger (a spot-check found two
+ * failure modes the naive mapping produced):
  *
- * Why weak vs moderate matters: canPromoteToFirst() (derive.ts) only lets a
- * currently-unbadged book be PROMOTED on a non-weak verdict from a real
- * adjudicator. So a single-family (e.g. catalog-only) absence stays weak →
- * badges but never auto-promotes and never enters the public headline. Promotion
- * requires genuinely independent corroboration.
+ *  1. Studies miscounted as translations → FALSE DEMOTES. The legacy backfill
+ *     recorded scholarly studies that merely CITE a work (e.g. Needham's
+ *     *Science and Civilisation in China* for 武備志) as "found" priors, with a
+ *     URL. A bare URL proves a URL exists, not that a *translation* exists. So a
+ *     found prior now defeats a first ONLY when it is a TRUSTWORTHY sighting:
+ *     non-weak evidence AND (a registry `found_refs` id OR a prior that passes
+ *     `evaluatePrior`). All the legacy study/guess rows are `weak` → excluded.
+ *
+ *  2. `not_applicable` collapsed into absence → FALSE PROMOTES. An agent judging
+ *     a book "not an English-translation candidate" was stored as `result:none`
+ *     and counted as an absence vote. It is now detected (result or legacy
+ *     "not_applicable: …" notes) and either yields a `not_applicable` verdict
+ *     (from an independent agent/human) or is excluded from the absence count.
+ *
+ * The asymmetry is enforced: a DEMOTE needs a trustworthy positive sighting; a
+ * PROMOTE needs clean, independent absence with NO prior hint at all. Anything
+ * ambiguous (a weak/unconfirmable "found" hint) returns null — change nothing,
+ * defer to the existing/legacy state — rather than guess in either direction.
  */
 
-import {
-  summarizePriorEvidence,
-  attemptFamily,
-} from './prior-evidence';
+import { attemptFamily } from './prior-evidence';
 import {
   strongestAttempt,
   type FirstTranslationAttempt,
 } from './attempt-log';
+import { evaluatePrior, type BookInput, type CitedPriorInput } from '../ft-prior-guard';
 import type {
   FirstTranslation,
+  FirstTranslationBook,
   MatchKey,
   Resolver,
 } from './types';
@@ -46,82 +49,126 @@ import type {
 /** Map an attempt's method to the resolver tier that should own the verdict. */
 function methodToResolver(method: FirstTranslationAttempt['method']): Resolver {
   switch (method) {
-    case 'tier2_agent':
-      return 'tier2_agent';
-    case 'human':
-      return 'human';
-    case 'tier0_linked':
-      return 'tier0_linked';
+    case 'tier2_agent': return 'tier2_agent';
+    case 'human': return 'human';
+    case 'tier0_linked': return 'tier0_linked';
     // tier1_catalog and gemini_verifier are both catalog-grounded searches.
-    default:
-      return 'tier1_catalog';
+    default: return 'tier1_catalog';
   }
 }
 
-const MATCH_RANK: Record<MatchKey, number> = {
-  work_id: 3,
-  transliteration: 2,
-  author_title: 1,
-  none: 0,
-};
+const MATCH_RANK: Record<MatchKey, number> = { work_id: 3, transliteration: 2, author_title: 1, none: 0 };
 
-/** Best (most specific) match_key across a set of attempts. */
 function bestMatchKey(attempts: FirstTranslationAttempt[]): MatchKey {
   let best: MatchKey = 'none';
-  for (const a of attempts) {
-    if (MATCH_RANK[a.match_key] > MATCH_RANK[best]) best = a.match_key;
-  }
+  for (const a of attempts) if (MATCH_RANK[a.match_key] > MATCH_RANK[best]) best = a.match_key;
   return best;
+}
+
+function bookInput(book: FirstTranslationBook): BookInput {
+  return {
+    title: book.title ?? '',
+    author: book.author,
+    language: book.original_language ?? book.language ?? undefined,
+  };
+}
+
+function toCited(p: NonNullable<FirstTranslationAttempt['priors']>[number]): CitedPriorInput {
+  const c = p.completeness;
+  const completeness =
+    c === 'complete' || c === 'partial' || c === 'excerpts' || c === 'unknown' ? c : undefined;
+  return {
+    english_title: p.english_title,
+    translator: p.translator,
+    pub_year: p.pub_year,
+    completeness,
+    publisher: p.publisher,
+  };
+}
+
+const NOT_APPLICABLE_RE = /^\s*not[_ ]applicable\b/i;
+function isNotApplicable(a: FirstTranslationAttempt): boolean {
+  return a.result === 'not_applicable' || NOT_APPLICABLE_RE.test(a.notes ?? '');
+}
+
+/**
+ * A found prior counts as a real defeat only when it is a TRUSTWORTHY sighting:
+ * non-weak evidence AND (a concrete registry id OR a prior that survives the
+ * evidence-quality guard). This is what excludes the legacy study/guess rows.
+ */
+function isTrustworthyFound(a: FirstTranslationAttempt, bi: BookInput): boolean {
+  if (a.result !== 'found') return false;
+  if (a.evidence_strength === 'weak') return false;
+  if (a.found_refs && a.found_refs.length > 0) return true;
+  return (a.priors ?? []).some((p) => evaluatePrior(bi, toCited(p)).trustworthy);
 }
 
 /**
  * Resolve the accumulated attempts for ONE book into a graded verdict, or null
- * when the pile doesn't yet justify any verdict. Pure — no DB, no clock.
+ * when the pile doesn't justify any verdict (ambiguous → defer, change nothing).
+ * Pure — no DB, no clock.
  */
 export function deriveVerdictFromAttempts(
   attempts: FirstTranslationAttempt[],
+  book: FirstTranslationBook,
 ): FirstTranslation | null {
   if (attempts.length === 0) return null;
-  const s = summarizePriorEvidence(attempts);
+  const bi = bookInput(book);
 
-  if (s.recommendation === 'reuse_prior') {
-    const found = attempts.filter((a) => a.result === 'found');
-    const strongest = strongestAttempt(found);
+  // 1) A trustworthy prior sighting → not_first. The ONLY thing that demotes.
+  const trustFound = attempts.filter((a) => isTrustworthyFound(a, bi));
+  if (trustFound.length > 0) {
+    const families = new Set(trustFound.map(attemptFamily)).size;
+    const strongest = strongestAttempt(trustFound)!;
     return {
       verdict: 'not_first',
-      // Cross-family agreement on a prior is the strong signal; one family = moderate.
-      evidence_strength: s.foundFamilies >= 2 ? 'strong' : 'moderate',
+      evidence_strength: families >= 2 ? 'strong' : 'moderate',
       our_completeness: 'unknown',
-      match_key: bestMatchKey(found),
+      match_key: bestMatchKey(trustFound),
       prior_relationship: 'same_text',
-      prior_refs: strongest?.found_refs && strongest.found_refs.length > 0
-        ? strongest.found_refs
-        : undefined,
-      resolver: methodToResolver(strongest?.method ?? 'tier1_catalog'),
-      best_attempt_id: s.foundAttemptId ?? strongest?.attempt_id,
+      prior_refs: strongest.found_refs?.length ? strongest.found_refs : undefined,
+      resolver: methodToResolver(strongest.method),
+      best_attempt_id: strongest.attempt_id,
     };
   }
 
-  if (s.recommendation === 'absence_strong' || s.recommendation === 'absence_weak') {
-    const absences = attempts.filter((a) => a.result === 'none');
-    const strongest = strongestAttempt(absences);
-    // Prefer the most independent family as the verdict's owner (agent > human > catalog).
-    const ownerMethod =
-      absences.find((a) => attemptFamily(a) === 'agent')?.method ??
-      absences.find((a) => attemptFamily(a) === 'human')?.method ??
-      strongest?.method ??
-      'tier1_catalog';
+  // 2) An independent agent/human judged it not a candidate → not_applicable.
+  const naHi = attempts.find(
+    (a) => isNotApplicable(a) && (attemptFamily(a) === 'agent' || attemptFamily(a) === 'human'),
+  );
+  if (naHi) {
     return {
-      verdict: 'first_no_prior',
-      // Independence by FAMILY, not raw count. Never strong from absence here.
-      evidence_strength: s.independentAbsenceFamilies >= 2 ? 'moderate' : 'weak',
+      verdict: 'not_applicable',
+      evidence_strength: 'moderate',
       our_completeness: 'unknown',
-      match_key: bestMatchKey(absences),
-      resolver: methodToResolver(ownerMethod),
-      best_attempt_id: strongest?.attempt_id,
+      match_key: 'none',
+      resolver: methodToResolver(naHi.method),
+      best_attempt_id: naHi.attempt_id,
     };
   }
 
-  // 'unverified' — usable evidence isn't on record yet. Write nothing.
-  return null;
+  // 3) Any UNconfirmable "found" hint (weak/guard-failing) makes a "first" claim
+  //    unsafe — we can't demote (not trustworthy) but mustn't promote over a
+  //    possible prior either. Defer: change nothing.
+  if (attempts.some((a) => a.result === 'found')) return null;
+
+  // 4) Clean absence only. Count independent FAMILIES (not raw methods);
+  //    exclude not_applicable rows — they aren't absence votes.
+  const absences = attempts.filter((a) => a.result === 'none' && !isNotApplicable(a));
+  if (absences.length === 0) return null;
+  const families = new Set(absences.map(attemptFamily)).size;
+  const strongest = strongestAttempt(absences)!;
+  const ownerMethod =
+    absences.find((a) => attemptFamily(a) === 'agent')?.method ??
+    absences.find((a) => attemptFamily(a) === 'human')?.method ??
+    strongest.method;
+  return {
+    verdict: 'first_no_prior',
+    // Independence by family. Never 'strong' from absence here.
+    evidence_strength: families >= 2 ? 'moderate' : 'weak',
+    our_completeness: 'unknown',
+    match_key: bestMatchKey(absences),
+    resolver: methodToResolver(ownerMethod),
+    best_attempt_id: strongest.attempt_id,
+  };
 }

--- a/src/lib/first-translation/derive-from-evidence.ts
+++ b/src/lib/first-translation/derive-from-evidence.ts
@@ -1,0 +1,127 @@
+/**
+ * Derive a graded verdict from the accumulated attempt ledger (issue #2564 / #2805).
+ *
+ * The attempt log (`first_translation_attempts`) is the durable, approach-agnostic
+ * record of every search ever run for a book. This module turns that pile into a
+ * single `book.first_translation` verdict — "verdict = f(accumulated evidence)",
+ * the consequence the durability principle has been building toward. It does NOT
+ * write the public `is_first_translation` boolean; that stays a derived read of
+ * the verdict (see derive.ts) materialized only by the sign-off-gated reconcile.
+ *
+ * Pure over an injected attempts array (mirrors prior-evidence.ts / resolve.ts) so
+ * it is unit-testable without a DB.
+ *
+ * The mapping is deliberately conservative — it is the input to a public claim:
+ *  - reuse_prior (a URL-checkable prior found) → not_first.
+ *      strength = strong only on CROSS-FAMILY agreement (≥2 families found it),
+ *      else moderate.
+ *  - absence (nobody found a prior) → first_no_prior.
+ *      strength weighed by INDEPENDENT FAMILIES, not raw method count (two
+ *      correlated catalog checks are one vote): ≥2 families → moderate, else weak.
+ *      Never 'strong' from absence here — a strong absence needs an independent
+ *      agent/human family this deriver doesn't manufacture.
+ *  - unverified (no usable evidence) → null (write nothing).
+ *
+ * Why weak vs moderate matters: canPromoteToFirst() (derive.ts) only lets a
+ * currently-unbadged book be PROMOTED on a non-weak verdict from a real
+ * adjudicator. So a single-family (e.g. catalog-only) absence stays weak →
+ * badges but never auto-promotes and never enters the public headline. Promotion
+ * requires genuinely independent corroboration.
+ */
+
+import {
+  summarizePriorEvidence,
+  attemptFamily,
+} from './prior-evidence';
+import {
+  strongestAttempt,
+  type FirstTranslationAttempt,
+} from './attempt-log';
+import type {
+  FirstTranslation,
+  MatchKey,
+  Resolver,
+} from './types';
+
+/** Map an attempt's method to the resolver tier that should own the verdict. */
+function methodToResolver(method: FirstTranslationAttempt['method']): Resolver {
+  switch (method) {
+    case 'tier2_agent':
+      return 'tier2_agent';
+    case 'human':
+      return 'human';
+    case 'tier0_linked':
+      return 'tier0_linked';
+    // tier1_catalog and gemini_verifier are both catalog-grounded searches.
+    default:
+      return 'tier1_catalog';
+  }
+}
+
+const MATCH_RANK: Record<MatchKey, number> = {
+  work_id: 3,
+  transliteration: 2,
+  author_title: 1,
+  none: 0,
+};
+
+/** Best (most specific) match_key across a set of attempts. */
+function bestMatchKey(attempts: FirstTranslationAttempt[]): MatchKey {
+  let best: MatchKey = 'none';
+  for (const a of attempts) {
+    if (MATCH_RANK[a.match_key] > MATCH_RANK[best]) best = a.match_key;
+  }
+  return best;
+}
+
+/**
+ * Resolve the accumulated attempts for ONE book into a graded verdict, or null
+ * when the pile doesn't yet justify any verdict. Pure — no DB, no clock.
+ */
+export function deriveVerdictFromAttempts(
+  attempts: FirstTranslationAttempt[],
+): FirstTranslation | null {
+  if (attempts.length === 0) return null;
+  const s = summarizePriorEvidence(attempts);
+
+  if (s.recommendation === 'reuse_prior') {
+    const found = attempts.filter((a) => a.result === 'found');
+    const strongest = strongestAttempt(found);
+    return {
+      verdict: 'not_first',
+      // Cross-family agreement on a prior is the strong signal; one family = moderate.
+      evidence_strength: s.foundFamilies >= 2 ? 'strong' : 'moderate',
+      our_completeness: 'unknown',
+      match_key: bestMatchKey(found),
+      prior_relationship: 'same_text',
+      prior_refs: strongest?.found_refs && strongest.found_refs.length > 0
+        ? strongest.found_refs
+        : undefined,
+      resolver: methodToResolver(strongest?.method ?? 'tier1_catalog'),
+      best_attempt_id: s.foundAttemptId ?? strongest?.attempt_id,
+    };
+  }
+
+  if (s.recommendation === 'absence_strong' || s.recommendation === 'absence_weak') {
+    const absences = attempts.filter((a) => a.result === 'none');
+    const strongest = strongestAttempt(absences);
+    // Prefer the most independent family as the verdict's owner (agent > human > catalog).
+    const ownerMethod =
+      absences.find((a) => attemptFamily(a) === 'agent')?.method ??
+      absences.find((a) => attemptFamily(a) === 'human')?.method ??
+      strongest?.method ??
+      'tier1_catalog';
+    return {
+      verdict: 'first_no_prior',
+      // Independence by FAMILY, not raw count. Never strong from absence here.
+      evidence_strength: s.independentAbsenceFamilies >= 2 ? 'moderate' : 'weak',
+      our_completeness: 'unknown',
+      match_key: bestMatchKey(absences),
+      resolver: methodToResolver(ownerMethod),
+      best_attempt_id: strongest?.attempt_id,
+    };
+  }
+
+  // 'unverified' — usable evidence isn't on record yet. Write nothing.
+  return null;
+}

--- a/tests/unit/first-translation-derive-from-evidence.test.ts
+++ b/tests/unit/first-translation-derive-from-evidence.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { deriveVerdictFromAttempts } from '@/lib/first-translation/derive-from-evidence';
+import { isFirstByVerdict, canPromoteToFirst } from '@/lib/first-translation/derive';
+import type { FirstTranslationAttempt } from '@/lib/first-translation/attempt-log';
+import type { FirstTranslationBook } from '@/lib/first-translation/types';
+
+const at = (over: Partial<FirstTranslationAttempt>): FirstTranslationAttempt => ({
+  attempt_id: 'a', book_id: 'b', date: '2026-06-29T00:00:00Z',
+  method: 'tier1_catalog', match_key: 'author_title', sources_checked: [],
+  result: 'none', evidence_strength: 'moderate', ...over,
+});
+
+// A book wrapper so we can run the downstream gates on a derived verdict.
+const withVerdict = (ft: ReturnType<typeof deriveVerdictFromAttempts>): FirstTranslationBook => ({
+  title: 'T', author: 'A', language: 'la', visible: true, pages_translated: 10,
+  first_translation: ft ?? undefined,
+} as FirstTranslationBook);
+
+describe('deriveVerdictFromAttempts — verdict = f(accumulated evidence)', () => {
+  it('empty pile → null (write nothing)', () => {
+    expect(deriveVerdictFromAttempts([])).toBeNull();
+  });
+
+  it('"found" with no resolvable url → unverified → null (not a demote)', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ result: 'found', priors: [{ english_title: 'Unsourced claim' }] }),
+    ]);
+    expect(ft).toBeNull();
+  });
+
+  it('a URL-checkable prior → not_first (single family = moderate)', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'tier1_catalog', result: 'found', found_refs: ['cat:1'],
+        priors: [{ english_title: 'The Foo', source_url: 'https://archive.org/x' }] }),
+    ]);
+    expect(ft?.verdict).toBe('not_first');
+    expect(ft?.evidence_strength).toBe('moderate');
+    expect(ft?.prior_refs).toEqual(['cat:1']);
+    expect(isFirstByVerdict(withVerdict(ft))).toBe(false); // a defeat removes the badge
+  });
+
+  it('a prior found by TWO families → not_first, strong (cross-family agreement)', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'tier1_catalog', result: 'found',
+        priors: [{ english_title: 'Foo', source_url: 'https://archive.org/x' }] }),
+      at({ method: 'tier2_agent', result: 'found', evidence_strength: 'strong', found_refs: ['cat:9'],
+        priors: [{ english_title: 'Foo', source_url: 'https://worldcat.org/y' }] }),
+    ]);
+    expect(ft?.verdict).toBe('not_first');
+    expect(ft?.evidence_strength).toBe('strong');
+  });
+
+  it('SINGLE-family absence (2 correlated catalog checks) → first_no_prior, WEAK — cannot auto-promote', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'tier1_catalog', result: 'none' }),                      // catalog family
+      at({ method: 'gemini_verifier', result: 'none', queries: ['q'] }),    // ALSO catalog family
+    ]);
+    expect(ft?.verdict).toBe('first_no_prior');
+    // Two methods but ONE family → weak (independence is by family, not count).
+    expect(ft?.evidence_strength).toBe('weak');
+    expect(isFirstByVerdict(withVerdict(ft))).toBe(true);   // badges...
+    expect(canPromoteToFirst(withVerdict(ft))).toBe(false); // ...but never auto-promotes on weak
+  });
+
+  it('CROSS-family absence (catalog + agent) → first_no_prior, moderate — promotable', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'tier1_catalog', result: 'none' }),  // catalog
+      at({ method: 'tier2_agent', result: 'none' }),    // agent (independent)
+    ]);
+    expect(ft?.verdict).toBe('first_no_prior');
+    expect(ft?.evidence_strength).toBe('moderate');
+    expect(ft?.resolver).toBe('tier2_agent'); // the independent family owns the verdict
+    expect(canPromoteToFirst(withVerdict(ft))).toBe(true);
+  });
+
+  it('presence beats absence: a found prior + many absences → not_first', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'tier1_catalog', result: 'none' }),
+      at({ method: 'tier2_agent', result: 'none' }),
+      at({ method: 'human', result: 'found',
+        priors: [{ english_title: 'Real prior', source_url: 'https://hdl.handle.net/z' }] }),
+    ]);
+    expect(ft?.verdict).toBe('not_first');
+  });
+});

--- a/tests/unit/first-translation-derive-from-evidence.test.ts
+++ b/tests/unit/first-translation-derive-from-evidence.test.ts
@@ -4,82 +4,117 @@ import { isFirstByVerdict, canPromoteToFirst } from '@/lib/first-translation/der
 import type { FirstTranslationAttempt } from '@/lib/first-translation/attempt-log';
 import type { FirstTranslationBook } from '@/lib/first-translation/types';
 
+const BOOK: FirstTranslationBook = {
+  title: 'Wubei Zhi', author: 'Mao Yuanyi', language: 'Chinese',
+  visible: true, pages_translated: 10,
+} as FirstTranslationBook;
+
 const at = (over: Partial<FirstTranslationAttempt>): FirstTranslationAttempt => ({
   attempt_id: 'a', book_id: 'b', date: '2026-06-29T00:00:00Z',
   method: 'tier1_catalog', match_key: 'author_title', sources_checked: [],
   result: 'none', evidence_strength: 'moderate', ...over,
 });
 
-// A book wrapper so we can run the downstream gates on a derived verdict.
-const withVerdict = (ft: ReturnType<typeof deriveVerdictFromAttempts>): FirstTranslationBook => ({
-  title: 'T', author: 'A', language: 'la', visible: true, pages_translated: 10,
-  first_translation: ft ?? undefined,
-} as FirstTranslationBook);
+const withVerdict = (ft: ReturnType<typeof deriveVerdictFromAttempts>): FirstTranslationBook =>
+  ({ ...BOOK, first_translation: ft ?? undefined } as FirstTranslationBook);
 
-describe('deriveVerdictFromAttempts — verdict = f(accumulated evidence)', () => {
-  it('empty pile → null (write nothing)', () => {
-    expect(deriveVerdictFromAttempts([])).toBeNull();
+describe('deriveVerdictFromAttempts — hardened against the real ledger', () => {
+  it('empty pile → null', () => {
+    expect(deriveVerdictFromAttempts([], BOOK)).toBeNull();
   });
 
-  it('"found" with no resolvable url → unverified → null (not a demote)', () => {
+  // FAILURE MODE 1: a study miscounted as a prior must NOT demote a genuine first.
+  it('weak "found" study with a URL does NOT demote (Needham-cites-it case)', () => {
     const ft = deriveVerdictFromAttempts([
-      at({ result: 'found', priors: [{ english_title: 'Unsourced claim' }] }),
-    ]);
+      at({ method: 'gemini_verifier', result: 'found', evidence_strength: 'weak',
+        priors: [{ english_title: 'Science and Civilisation in China', source_url: 'https://archive.org/x' }],
+        notes: '[legacy_tv] disposition=confirmed_first; No results from any of the 3' }),
+    ], BOOK);
+    // A weak found hint → defer (null), never not_first.
     expect(ft).toBeNull();
   });
 
-  it('a URL-checkable prior → not_first (single family = moderate)', () => {
+  // A registry-backed (found_refs) non-weak prior IS trustworthy → not_first.
+  it('non-weak prior with a registry found_ref → not_first', () => {
     const ft = deriveVerdictFromAttempts([
-      at({ method: 'tier1_catalog', result: 'found', found_refs: ['cat:1'],
-        priors: [{ english_title: 'The Foo', source_url: 'https://archive.org/x' }] }),
-    ]);
+      at({ method: 'tier1_catalog', result: 'found', evidence_strength: 'moderate',
+        found_refs: ['cat:1'], priors: [{ english_title: 'A real translation', source_url: 'https://archive.org/y' }] }),
+    ], BOOK);
     expect(ft?.verdict).toBe('not_first');
-    expect(ft?.evidence_strength).toBe('moderate');
     expect(ft?.prior_refs).toEqual(['cat:1']);
-    expect(isFirstByVerdict(withVerdict(ft))).toBe(false); // a defeat removes the badge
+    expect(isFirstByVerdict(withVerdict(ft))).toBe(false);
   });
 
-  it('a prior found by TWO families → not_first, strong (cross-family agreement)', () => {
+  it('two trustworthy families finding a prior → not_first, strong', () => {
     const ft = deriveVerdictFromAttempts([
-      at({ method: 'tier1_catalog', result: 'found',
-        priors: [{ english_title: 'Foo', source_url: 'https://archive.org/x' }] }),
-      at({ method: 'tier2_agent', result: 'found', evidence_strength: 'strong', found_refs: ['cat:9'],
-        priors: [{ english_title: 'Foo', source_url: 'https://worldcat.org/y' }] }),
-    ]);
+      at({ method: 'tier1_catalog', result: 'found', evidence_strength: 'moderate', found_refs: ['cat:1'],
+        priors: [{ english_title: 'X', source_url: 'https://a/x' }] }),
+      at({ method: 'tier2_agent', result: 'found', evidence_strength: 'strong', found_refs: ['cat:2'],
+        priors: [{ english_title: 'X', source_url: 'https://b/y' }] }),
+    ], BOOK);
     expect(ft?.verdict).toBe('not_first');
     expect(ft?.evidence_strength).toBe('strong');
   });
 
-  it('SINGLE-family absence (2 correlated catalog checks) → first_no_prior, WEAK — cannot auto-promote', () => {
+  // FAILURE MODE 2: agent not_applicable must NOT count as an absence/promote.
+  it('agent not_applicable (legacy notes form) → not_applicable, not a promote', () => {
     const ft = deriveVerdictFromAttempts([
-      at({ method: 'tier1_catalog', result: 'none' }),                      // catalog family
-      at({ method: 'gemini_verifier', result: 'none', queries: ['q'] }),    // ALSO catalog family
-    ]);
-    expect(ft?.verdict).toBe('first_no_prior');
-    // Two methods but ONE family → weak (independence is by family, not count).
-    expect(ft?.evidence_strength).toBe('weak');
-    expect(isFirstByVerdict(withVerdict(ft))).toBe(true);   // badges...
-    expect(canPromoteToFirst(withVerdict(ft))).toBe(false); // ...but never auto-promotes on weak
+      at({ method: 'tier2_agent', result: 'none', evidence_strength: 'strong',
+        notes: 'not_applicable: the book is a 1629 reprint of the original' }),
+      at({ method: 'tier1_catalog', result: 'none', evidence_strength: 'weak' }),
+    ], BOOK);
+    expect(ft?.verdict).toBe('not_applicable');
+    expect(isFirstByVerdict(withVerdict(ft))).toBe(false);
   });
 
-  it('CROSS-family absence (catalog + agent) → first_no_prior, moderate — promotable', () => {
+  it('agent not_applicable via the result field → not_applicable', () => {
     const ft = deriveVerdictFromAttempts([
-      at({ method: 'tier1_catalog', result: 'none' }),  // catalog
-      at({ method: 'tier2_agent', result: 'none' }),    // agent (independent)
-    ]);
+      at({ method: 'tier2_agent', result: 'not_applicable', evidence_strength: 'strong' }),
+    ], BOOK);
+    expect(ft?.verdict).toBe('not_applicable');
+  });
+
+  // A weak/url-less "found" hint blocks a confident promote (Bacon/Davis case).
+  it('an unconfirmable found hint blocks promotion → null (defer)', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'gemini_verifier', result: 'found', evidence_strength: 'weak',
+        priors: [{ english_title: 'Roger Bacon\'s Letter', translator: 'Tenney Davis', pub_year: '1923' }],
+        notes: '[legacy_llm] unverified model knowledge' }),
+      at({ method: 'tier1_catalog', result: 'none', evidence_strength: 'weak' }),
+      at({ method: 'tier2_agent', result: 'none', evidence_strength: 'moderate' }),
+    ], BOOK);
+    expect(ft).toBeNull();
+  });
+
+  it('CLEAN cross-family absence (no found hint) → first_no_prior, moderate, promotable', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'tier1_catalog', result: 'none' }),   // catalog
+      at({ method: 'tier2_agent', result: 'none' }),     // agent (independent)
+    ], BOOK);
     expect(ft?.verdict).toBe('first_no_prior');
     expect(ft?.evidence_strength).toBe('moderate');
-    expect(ft?.resolver).toBe('tier2_agent'); // the independent family owns the verdict
+    expect(ft?.resolver).toBe('tier2_agent');
     expect(canPromoteToFirst(withVerdict(ft))).toBe(true);
   });
 
-  it('presence beats absence: a found prior + many absences → not_first', () => {
+  it('single-family absence (2 correlated catalog checks) → first_no_prior, WEAK, NOT promotable', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'tier1_catalog', result: 'none' }),                   // catalog
+      at({ method: 'gemini_verifier', result: 'none', queries: ['q'] }), // ALSO catalog family
+    ], BOOK);
+    expect(ft?.verdict).toBe('first_no_prior');
+    expect(ft?.evidence_strength).toBe('weak');
+    expect(isFirstByVerdict(withVerdict(ft))).toBe(true);
+    expect(canPromoteToFirst(withVerdict(ft))).toBe(false);
+  });
+
+  it('not_applicable rows are excluded from the absence family count', () => {
+    // one real catalog absence + one not_applicable (must not become a 2nd family)
     const ft = deriveVerdictFromAttempts([
       at({ method: 'tier1_catalog', result: 'none' }),
-      at({ method: 'tier2_agent', result: 'none' }),
-      at({ method: 'human', result: 'found',
-        priors: [{ english_title: 'Real prior', source_url: 'https://hdl.handle.net/z' }] }),
-    ]);
-    expect(ft?.verdict).toBe('not_first');
+      at({ method: 'human', result: 'none', notes: 'not_applicable: original-language critical edition' }),
+    ], BOOK);
+    // human not_applicable yields a not_applicable verdict (rule 2 fires first).
+    expect(ft?.verdict).toBe('not_applicable');
   });
 });


### PR DESCRIPTION
## What & why

Fourth in the series, and the one that connects evidence to claim. #2865/#2866/#2868 made the system **keep** every search and **read** it before spending — the attempt ledger holds ~46K rows across ~28K books. But nothing turned that ledger **into** a verdict, so the accumulated evidence never reached the flag. This is the bridge: **verdict = f(accumulated evidence)** — one safe step short of the public flip.

## Two cuts: naive → hardened (a spot-check caught real bugs)

The first cut passed unit tests on synthetic data but a **prod dry-run + spot-check** found it was wrong on the real, legacy-backfilled ledger:

1. **False demotes** — the legacy backfill recorded scholarly *studies* that merely cite a work (Needham's *Science and Civilisation* for 武備志; Shahar's *Shaolin Monastery*) as "found" priors with a URL. A URL proves a URL exists, not a *translation*. → 328 would-demotes, almost all famous Chinese sci/tech firsts.
2. **False promotes** — an agent's `not_applicable` ("this is a 1629 reprint, not a candidate") was stored as `result:none` and counted as an absence vote → would promote Roger Bacon's work, which has a known 1923 translation.

### Hardening
- A found prior defeats a first **only when trustworthy**: non-weak evidence AND (a registry `found_refs` id OR a prior that passes `evaluatePrior`). All legacy study/guess rows are `weak` → excluded.
- `not_applicable` is detected (new attempt result value + legacy `not_applicable: …` notes) → yields a `not_applicable` verdict from an independent agent/human, or is excluded from the absence count.
- **Asymmetry enforced**: a DEMOTE needs a trustworthy positive sighting; a PROMOTE needs clean independent absence with **no** prior hint; anything ambiguous (a weak/unconfirmable "found") returns `null` — defer, change nothing.

## Validated on prod (dry-run, no writes)

| | naive cut | hardened |
|---|---|---|
| would-DEMOTE | 328 | **1** (the genuine Reuchlin registry match) |
| would-PROMOTE | 1,513 | 1,353 |
| 本草綱目拾遺 (Zhao Xuemin) | not_first/strong (false demote) | **null** (defers, no demote) |
| Roger Bacon *De mirabili* | first_no_prior (false promote) | **not_applicable** (no promote) |

## Safety / scope

- **Writes only `book.first_translation` on `--apply`; never `is_first_translation`** (that stays a derived read materialized only by the sign-off-gated reconcile). This PR's dry-run writes nothing.
- `canPromoteToFirst()` still gates the flag: single-family (catalog-only) absence badges but never auto-promotes / never enters the public headline.
- 10 unit tests incl. both failure modes.

## The arc

| PR | the loop |
|---|---|
| #2865 | producers **keep** their search |
| #2866 | registry matcher **records** its finds |
| #2868 | producers **read** the ledger before spending |
| **this** | **derive the verdict from the ledger** (hardened; verdict-only; flag still gated) |

Held for sign-off: run `--apply` to write verdicts (promote 1,353 / demote 1 once the reconcile then runs), review, then schedule (derive → reconcile) as the single-writer path and retire the legacy direct-writers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)