### PR TITLE
feat(gallery): merged gallery — plates + standalone artworks (staging)

### DIFF
--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -90,6 +90,139 @@ let cachedFilters: { data: { types: string[]; subjects: string[]; yearRange: { m
  *   - includeArchive: show 0.5+ quality images (overrides minQuality to 0.5)
  *   - semantic: use embedding search
  */
+// Standalone artworks (content_type:'artwork') live in `books` with their own
+// image fields. Map one to the shared GalleryItem tile shape.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function artworkToGalleryItem(a: any) {
+  const image = a.image_display || a.image_full || a.image_thumb || a.thumbnail_blob || a.thumbnail || '';
+  const thumb = a.image_thumb || a.thumbnail_blob || a.thumbnail || a.image_display || image;
+  const year = typeof a.year === 'number' ? a.year : (parseInt(a.published, 10) || undefined);
+  return {
+    pageId: `artwork-${a.id}`,
+    bookId: a.id,
+    pageNumber: 0,
+    detectionIndex: 0,
+    imageUrl: image,
+    thumbnailUrl: thumb,
+    extractedUrl: image,         // card's primary src; no bbox crop for artworks
+    bookTitle: a.display_title || a.title || 'Untitled',
+    author: a.author,
+    year,
+    description: a.summary || a.display_title || a.title || '',
+    type: a.resource_type,
+    source: 'artwork' as const,
+    link: `/book/${a.slug || a.id}`,
+    likeCount: 0,
+    likedByVisitor: false,
+  };
+}
+
+/**
+ * Merged plain-gallery browse: interleaves book illustrations (gallery_images)
+ * with standalone artworks (books, content_type:'artwork'). Used ONLY for the
+ * default /gallery view (no single-book / search / collection scope) so all the
+ * existing specialized paths are untouched. `source` controls the mix:
+ *   'all'          → interleave both (default)
+ *   'artwork'      → artworks only
+ *   'illustration' → (handled by the caller's existing path)
+ */
+async function mergedGalleryBrowse(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: any,
+  opts: {
+    tenantId: string | null; source: 'all' | 'artwork'; limit: number; offset: number;
+    imageType: string | null; minQuality: number; maxPerBook: number;
+    yearStart: number | null; yearEnd: number | null; visitorId: string | null;
+  },
+) {
+  const { tenantId, source, limit, offset, imageType, minQuality, maxPerBook, yearStart, yearEnd, visitorId } = opts;
+  const tenant = tenantId ? { tenantId } : {};
+  const pageIndex = Math.floor(offset / Math.max(1, limit));
+
+  // Per-page allocation: ~25% artworks when mixing (clearly visible), all when artwork-only.
+  const artPerPage = source === 'artwork' ? limit : Math.max(1, Math.round(limit * 0.25));
+  const illusPerPage = source === 'artwork' ? 0 : limit - artPerPage;
+
+  // ---- illustrations ----
+  let illusDocs: any[] = []; let illusHasMore = false; // eslint-disable-line @typescript-eslint/no-explicit-any
+  if (illusPerPage > 0) {
+    const f: Record<string, unknown> = {
+      ...tenant, gallery_quality: { $gte: minQuality }, book_visible: true,
+      extracted_url: { $ne: null }, image_url: { $ne: null },
+    };
+    if (maxPerBook < 100) f.book_rank = { $lte: maxPerBook };
+    if (imageType) f.type = imageType;
+    if (yearStart !== null || yearEnd !== null) {
+      const y: Record<string, number> = {};
+      if (yearStart !== null) y.$gte = yearStart;
+      if (yearEnd !== null) y.$lte = yearEnd;
+      f.book_year = y;
+    }
+    const docs = await db.collection('gallery_images')
+      .find(f, { projection: { _id: 0 } })
+      .sort({ gallery_quality: -1, book_year: 1, book_id: 1, page_number: 1 })
+      .skip(pageIndex * illusPerPage).limit(illusPerPage + 1).toArray();
+    illusHasMore = docs.length > illusPerPage;
+    illusDocs = docs.slice(0, illusPerPage);
+  }
+
+  // ---- artworks ----
+  const af: Record<string, unknown> = { ...tenant, content_type: 'artwork', visible: true };
+  if (imageType) af.resource_type = imageType;
+  if (yearStart !== null || yearEnd !== null) {
+    const y: Record<string, number> = {};
+    if (yearStart !== null) y.$gte = yearStart;
+    if (yearEnd !== null) y.$lte = yearEnd;
+    af.year = y;
+  }
+  const artDocs = await db.collection('books')
+    .find(af, { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 } })
+    .sort({ year: 1, title: 1 })
+    .skip(pageIndex * artPerPage).limit(artPerPage + 1).toArray();
+  const artHasMore = artDocs.length > artPerPage;
+  const arts = artDocs.slice(0, artPerPage).map(artworkToGalleryItem);
+
+  // ---- map illustrations (with likes) ----
+  let likesMap: Record<string, { count: number; liked: boolean }> = {};
+  if (illusDocs.length > 0) {
+    const ids = illusDocs.map(d => `${d.page_id}-${d.detection_index}`);
+    try {
+      const likeDocs = await db.collection('likes').aggregate([
+        { $match: { target_type: 'image', target_id: { $in: ids } } },
+        { $group: { _id: '$target_id', count: { $sum: 1 }, visitors: { $addToSet: '$visitor_id' } } },
+      ]).toArray();
+      for (const ld of likeDocs) likesMap[ld._id] = { count: ld.count, liked: visitorId ? ld.visitors.includes(visitorId) : false };
+    } catch { /* non-critical */ }
+  }
+  const illus = illusDocs.map(d => {
+    const key = `${d.page_id}-${d.detection_index}`;
+    return {
+      pageId: d.page_id, bookId: d.book_id, pageNumber: d.page_number, detectionIndex: d.detection_index,
+      imageUrl: d.image_url, bookTitle: d.book_title, author: d.book_author, year: d.book_year,
+      description: d.description, type: d.type, bbox: d.bbox, rotation: d.rotation,
+      extractedUrl: d.extracted_url, thumbnailUrl: d.thumbnail_url, galleryQuality: d.gallery_quality,
+      museumDescription: d.museum_description, metadata: d.metadata, source: 'illustration' as const,
+      likeCount: likesMap[key]?.count ?? 0, likedByVisitor: likesMap[key]?.liked ?? false,
+    };
+  });
+
+  // ---- interleave (space artworks ~every `gap` tiles) ----
+  const items: any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
+  let ii = 0, ai = 0;
+  const gap = arts.length > 0 ? Math.max(2, Math.round((illus.length + arts.length) / arts.length)) : Infinity;
+  for (let pos = 0; items.length < limit && (ii < illus.length || ai < arts.length); pos++) {
+    const wantArt = ai < arts.length && (pos % gap === gap - 1 || ii >= illus.length);
+    if (wantArt) items.push(arts[ai++]);
+    else if (ii < illus.length) items.push(illus[ii++]);
+    else if (ai < arts.length) items.push(arts[ai++]);
+  }
+
+  const hasMore = illusHasMore || artHasMore;
+  const total = offset + items.length + (hasMore ? limit : 0); // monotone estimate for infinite scroll
+  const filters = await getGalleryFilters(db).catch(() => ({ types: [], subjects: [], yearRange: { minYear: null, maxYear: null } }));
+  return { items, total, limit, offset, bookInfo: null, filters: { ...filters, sources: ['illustration', 'artwork'] } };
+}
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
@@ -142,6 +275,24 @@ export async function GET(request: NextRequest) {
     if (galleryCount === 0) {
       // Fall back to legacy pipeline
       return NextResponse.json(await legacyGalleryQuery(db, searchParams));
+    }
+
+    // Merged plain-gallery browse (default /gallery): interleave book illustrations
+    // with standalone artworks. Only for the unscoped browse — single-book, search,
+    // collection/library, and metadata-facet requests keep illustration-only behavior.
+    const isPlainBrowse = !bookId && !searchQuery && !collectionSlug && !libraryFilter
+      && !subjectFilter && !figureFilter && !symbolFilter && !iconclassFilter;
+    const sourceParam = searchParams.get('source') || 'all';
+    if (isPlainBrowse && (sourceParam === 'all' || sourceParam === 'artwork')) {
+      const sessionForMerge = await auth();
+      const visitorIdForMerge = sessionForMerge?.user?.id || searchParams.get('visitor_id');
+      const merged = await mergedGalleryBrowse(db, {
+        tenantId, source: sourceParam as 'all' | 'artwork', limit, offset,
+        imageType, minQuality, maxPerBook, yearStart, yearEnd, visitorId: visitorIdForMerge,
+      });
+      return NextResponse.json(merged, {
+        headers: { 'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600' },
+      });
     }
 
     // If filtering by collection, resolve to book IDs

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -471,26 +471,61 @@ export async function GET(request: NextRequest) {
     let displayTotal = total;
     if (searchQuery && offset === 0) {
       try {
+        const tenantF = tenantId ? { tenantId } : {};
+        const esc = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const rx = { $regex: esc, $options: 'i' }; // case-insensitive phrase match on titles
+        const imgPresent = { $or: [{ image_display: { $nin: [null, ''] } }, { image_full: { $nin: [null, ''] } }, { image_thumb: { $nin: [null, ''] } }] };
+        const artProj = { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 } };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const mapPlate = (d: any) => ({
+          pageId: d.page_id, bookId: d.book_id, pageNumber: d.page_number, detectionIndex: d.detection_index,
+          imageUrl: d.image_url, bookTitle: d.book_title, author: d.book_author, year: d.book_year,
+          description: d.description, type: d.type, bbox: d.bbox, rotation: d.rotation,
+          extractedUrl: d.extracted_url, thumbnailUrl: d.thumbnail_url, galleryQuality: d.gallery_quality,
+          source: 'illustration', likeCount: 0, likedByVisitor: false,
+        });
+
+        // (1) Title-matching artworks — strongest signal (e.g. "John the Apostle" in the name)
+        const titleArtDocs = await db.collection('books').find(
+          { content_type: 'artwork', visible: true, ...tenantF, $and: [{ $or: [{ title: rx }, { display_title: rx }] }, imgPresent] },
+          artProj,
+        ).limit(10).toArray().catch(() => []);
+        // (2) Books whose title matches → their top plates
+        const titleBookIds = await db.collection('books').distinct('id',
+          { visible: true, ...tenantF, content_type: { $ne: 'artwork' }, $or: [{ title: rx }, { display_title: rx }] },
+          { maxTimeMS: 5000 },
+        ).catch(() => []);
+        const titlePlateDocs = titleBookIds.length > 0
+          ? await db.collection('gallery_images').find(
+              { book_id: { $in: titleBookIds.slice(0, 200) }, gallery_quality: { $gte: 0.6 }, book_visible: true, extracted_url: { $ne: null }, image_url: { $ne: null }, book_rank: { $lte: 4 } },
+              { projection: { _id: 0 } },
+            ).sort({ gallery_quality: -1 }).limit(12).toArray().catch(() => [])
+          : [];
+        // (3) Semantically relevant artworks (related, not necessarily titled)
         const { semanticArtworkSearch } = await import('@/lib/semantic-search');
-        const artHits = await semanticArtworkSearch(searchQuery, 12, { threshold: 0.25 });
-        let addedArtworks = 0;
-        if (artHits.length > 0) {
-          const ids = artHits.map(a => a.book_id);
-          const artDocs = await db.collection('books').find(
-            { id: { $in: ids }, visible: true, content_type: 'artwork', ...(tenantId ? { tenantId } : {}),
-              $or: [{ image_display: { $nin: [null, ''] } }, { image_full: { $nin: [null, ''] } }, { image_thumb: { $nin: [null, ''] } }] },
-            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 } },
-          ).toArray();
-          const byId = new Map(artDocs.map(d => [d.id, d]));
-          const artItems = artHits.map(a => byId.get(a.book_id)).filter(Boolean).map(artworkToGalleryItem);
-          if (artItems.length > 0) { outItems = [...artItems, ...mappedItems]; addedArtworks = artItems.length; }
-        }
-        // Real result count: text-matching illustrations + surfaced artworks.
+        const artHits = await semanticArtworkSearch(searchQuery, 12, { threshold: 0.25 }).catch(() => []);
+        const semIds = artHits.map(a => a.book_id);
+        const semArtDocs = semIds.length > 0
+          ? await db.collection('books').find({ id: { $in: semIds }, content_type: 'artwork', visible: true, ...tenantF, ...imgPresent }, artProj).toArray().catch(() => [])
+          : [];
+        const semById = new Map(semArtDocs.map(d => [d.id, d]));
+
+        // Assemble: title artworks + title plates lead, then semantic artworks, then the illustration search.
+        const seenBooks = new Set<string>();
+        const seenPages = new Set<string>();
+        const lead: any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
+        for (const d of titleArtDocs) if (!seenBooks.has(d.id)) { seenBooks.add(d.id); lead.push(artworkToGalleryItem(d)); }
+        for (const d of titlePlateDocs) { const k = `${d.page_id}-${d.detection_index}`; if (!seenPages.has(k)) { seenPages.add(k); lead.push(mapPlate(d)); } }
+        for (const a of artHits) { const d = semById.get(a.book_id); if (d && !seenBooks.has(d.id)) { seenBooks.add(d.id); lead.push(artworkToGalleryItem(d)); } }
+        const rest = mappedItems.filter((it: any) => !seenPages.has(`${it.pageId}-${it.detectionIndex}`)); // eslint-disable-line @typescript-eslint/no-explicit-any
+        outItems = [...lead, ...rest];
+
+        // Real result count: text-matching illustrations + the lead (title/semantic) items.
         const illCount = await db.collection('gallery_images').countDocuments(
-          { $text: { $search: searchQuery }, gallery_quality: { $gte: minQuality }, book_visible: true, ...(tenantId ? { tenantId } : {}) },
+          { $text: { $search: searchQuery }, gallery_quality: { $gte: minQuality }, book_visible: true, ...tenantF },
           { maxTimeMS: 5000 },
         ).catch(() => null);
-        if (illCount !== null) { displayTotal = illCount + addedArtworks; searchHasMore = outItems.length < displayTotal; }
+        if (illCount !== null) { displayTotal = illCount + lead.length; searchHasMore = outItems.length < displayTotal; }
       } catch { /* non-critical — search still returns illustrations */ }
     }
 

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -6,6 +6,7 @@ import { supabase } from '@/lib/supabase';
 import { generateQueryEmbedding, cosineSimilarity } from '@/lib/embeddings';
 import { deduplicateByDHash } from '@/lib/dhash';
 import { CLIP_URL } from '@/lib/clip';
+import { mergedGalleryBrowse } from '@/lib/gallery-merge';
 
 export const maxDuration = 30;
 
@@ -90,139 +91,6 @@ let cachedFilters: { data: { types: string[]; subjects: string[]; yearRange: { m
  *   - includeArchive: show 0.5+ quality images (overrides minQuality to 0.5)
  *   - semantic: use embedding search
  */
-// Standalone artworks (content_type:'artwork') live in `books` with their own
-// image fields. Map one to the shared GalleryItem tile shape.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function artworkToGalleryItem(a: any) {
-  const image = a.image_display || a.image_full || a.image_thumb || a.thumbnail_blob || a.thumbnail || '';
-  const thumb = a.image_thumb || a.thumbnail_blob || a.thumbnail || a.image_display || image;
-  const year = typeof a.year === 'number' ? a.year : (parseInt(a.published, 10) || undefined);
-  return {
-    pageId: `artwork-${a.id}`,
-    bookId: a.id,
-    pageNumber: 0,
-    detectionIndex: 0,
-    imageUrl: image,
-    thumbnailUrl: thumb,
-    extractedUrl: image,         // card's primary src; no bbox crop for artworks
-    bookTitle: a.display_title || a.title || 'Untitled',
-    author: a.author,
-    year,
-    description: a.summary || a.display_title || a.title || '',
-    type: a.resource_type,
-    source: 'artwork' as const,
-    link: `/book/${a.slug || a.id}`,
-    likeCount: 0,
-    likedByVisitor: false,
-  };
-}
-
-/**
- * Merged plain-gallery browse: interleaves book illustrations (gallery_images)
- * with standalone artworks (books, content_type:'artwork'). Used ONLY for the
- * default /gallery view (no single-book / search / collection scope) so all the
- * existing specialized paths are untouched. `source` controls the mix:
- *   'all'          → interleave both (default)
- *   'artwork'      → artworks only
- *   'illustration' → (handled by the caller's existing path)
- */
-async function mergedGalleryBrowse(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  db: any,
-  opts: {
-    tenantId: string | null; source: 'all' | 'artwork'; limit: number; offset: number;
-    imageType: string | null; minQuality: number; maxPerBook: number;
-    yearStart: number | null; yearEnd: number | null; visitorId: string | null;
-  },
-) {
-  const { tenantId, source, limit, offset, imageType, minQuality, maxPerBook, yearStart, yearEnd, visitorId } = opts;
-  const tenant = tenantId ? { tenantId } : {};
-  const pageIndex = Math.floor(offset / Math.max(1, limit));
-
-  // Per-page allocation: ~25% artworks when mixing (clearly visible), all when artwork-only.
-  const artPerPage = source === 'artwork' ? limit : Math.max(1, Math.round(limit * 0.25));
-  const illusPerPage = source === 'artwork' ? 0 : limit - artPerPage;
-
-  // ---- illustrations ----
-  let illusDocs: any[] = []; let illusHasMore = false; // eslint-disable-line @typescript-eslint/no-explicit-any
-  if (illusPerPage > 0) {
-    const f: Record<string, unknown> = {
-      ...tenant, gallery_quality: { $gte: minQuality }, book_visible: true,
-      extracted_url: { $ne: null }, image_url: { $ne: null },
-    };
-    if (maxPerBook < 100) f.book_rank = { $lte: maxPerBook };
-    if (imageType) f.type = imageType;
-    if (yearStart !== null || yearEnd !== null) {
-      const y: Record<string, number> = {};
-      if (yearStart !== null) y.$gte = yearStart;
-      if (yearEnd !== null) y.$lte = yearEnd;
-      f.book_year = y;
-    }
-    const docs = await db.collection('gallery_images')
-      .find(f, { projection: { _id: 0 } })
-      .sort({ gallery_quality: -1, book_year: 1, book_id: 1, page_number: 1 })
-      .skip(pageIndex * illusPerPage).limit(illusPerPage + 1).toArray();
-    illusHasMore = docs.length > illusPerPage;
-    illusDocs = docs.slice(0, illusPerPage);
-  }
-
-  // ---- artworks ----
-  const af: Record<string, unknown> = { ...tenant, content_type: 'artwork', visible: true };
-  if (imageType) af.resource_type = imageType;
-  if (yearStart !== null || yearEnd !== null) {
-    const y: Record<string, number> = {};
-    if (yearStart !== null) y.$gte = yearStart;
-    if (yearEnd !== null) y.$lte = yearEnd;
-    af.year = y;
-  }
-  const artDocs = await db.collection('books')
-    .find(af, { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 } })
-    .sort({ year: 1, title: 1 })
-    .skip(pageIndex * artPerPage).limit(artPerPage + 1).toArray();
-  const artHasMore = artDocs.length > artPerPage;
-  const arts = artDocs.slice(0, artPerPage).map(artworkToGalleryItem);
-
-  // ---- map illustrations (with likes) ----
-  let likesMap: Record<string, { count: number; liked: boolean }> = {};
-  if (illusDocs.length > 0) {
-    const ids = illusDocs.map(d => `${d.page_id}-${d.detection_index}`);
-    try {
-      const likeDocs = await db.collection('likes').aggregate([
-        { $match: { target_type: 'image', target_id: { $in: ids } } },
-        { $group: { _id: '$target_id', count: { $sum: 1 }, visitors: { $addToSet: '$visitor_id' } } },
-      ]).toArray();
-      for (const ld of likeDocs) likesMap[ld._id] = { count: ld.count, liked: visitorId ? ld.visitors.includes(visitorId) : false };
-    } catch { /* non-critical */ }
-  }
-  const illus = illusDocs.map(d => {
-    const key = `${d.page_id}-${d.detection_index}`;
-    return {
-      pageId: d.page_id, bookId: d.book_id, pageNumber: d.page_number, detectionIndex: d.detection_index,
-      imageUrl: d.image_url, bookTitle: d.book_title, author: d.book_author, year: d.book_year,
-      description: d.description, type: d.type, bbox: d.bbox, rotation: d.rotation,
-      extractedUrl: d.extracted_url, thumbnailUrl: d.thumbnail_url, galleryQuality: d.gallery_quality,
-      museumDescription: d.museum_description, metadata: d.metadata, source: 'illustration' as const,
-      likeCount: likesMap[key]?.count ?? 0, likedByVisitor: likesMap[key]?.liked ?? false,
-    };
-  });
-
-  // ---- interleave (space artworks ~every `gap` tiles) ----
-  const items: any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
-  let ii = 0, ai = 0;
-  const gap = arts.length > 0 ? Math.max(2, Math.round((illus.length + arts.length) / arts.length)) : Infinity;
-  for (let pos = 0; items.length < limit && (ii < illus.length || ai < arts.length); pos++) {
-    const wantArt = ai < arts.length && (pos % gap === gap - 1 || ii >= illus.length);
-    if (wantArt) items.push(arts[ai++]);
-    else if (ii < illus.length) items.push(illus[ii++]);
-    else if (ai < arts.length) items.push(arts[ai++]);
-  }
-
-  const hasMore = illusHasMore || artHasMore;
-  const total = offset + items.length + (hasMore ? limit : 0); // monotone estimate for infinite scroll
-  const filters = await getGalleryFilters(db).catch(() => ({ types: [], subjects: [], yearRange: { minYear: null, maxYear: null } }));
-  return { items, total, limit, offset, bookInfo: null, filters: { ...filters, sources: ['illustration', 'artwork'] } };
-}
-
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
@@ -290,7 +158,11 @@ export async function GET(request: NextRequest) {
         tenantId, source: sourceParam as 'all' | 'artwork', limit, offset,
         imageType, minQuality, maxPerBook, yearStart, yearEnd, visitorId: visitorIdForMerge,
       });
-      return NextResponse.json(merged, {
+      const mergedFilters = await getGalleryFilters(db).catch(() => ({ types: [], subjects: [], yearRange: { minYear: null, maxYear: null } }));
+      return NextResponse.json({
+        items: merged.items, total: merged.total, limit, offset, bookInfo: null,
+        filters: { ...mergedFilters, sources: ['illustration', 'artwork'] },
+      }, {
         headers: { 'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600' },
       });
     }

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -468,20 +468,29 @@ export async function GET(request: NextRequest) {
     // → paintings/prints of him), surfaced at the top.
     let outItems: any[] = mappedItems; // eslint-disable-line @typescript-eslint/no-explicit-any
     let searchHasMore = hasMore;
+    let displayTotal = total;
     if (searchQuery && offset === 0) {
       try {
         const { semanticArtworkSearch } = await import('@/lib/semantic-search');
         const artHits = await semanticArtworkSearch(searchQuery, 12, { threshold: 0.25 });
+        let addedArtworks = 0;
         if (artHits.length > 0) {
           const ids = artHits.map(a => a.book_id);
           const artDocs = await db.collection('books').find(
-            { id: { $in: ids }, visible: true, content_type: 'artwork', ...(tenantId ? { tenantId } : {}) },
+            { id: { $in: ids }, visible: true, content_type: 'artwork', ...(tenantId ? { tenantId } : {}),
+              $or: [{ image_display: { $nin: [null, ''] } }, { image_full: { $nin: [null, ''] } }, { image_thumb: { $nin: [null, ''] } }] },
             { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 } },
           ).toArray();
           const byId = new Map(artDocs.map(d => [d.id, d]));
           const artItems = artHits.map(a => byId.get(a.book_id)).filter(Boolean).map(artworkToGalleryItem);
-          if (artItems.length > 0) outItems = [...artItems, ...mappedItems];
+          if (artItems.length > 0) { outItems = [...artItems, ...mappedItems]; addedArtworks = artItems.length; }
         }
+        // Real result count: text-matching illustrations + surfaced artworks.
+        const illCount = await db.collection('gallery_images').countDocuments(
+          { $text: { $search: searchQuery }, gallery_quality: { $gte: minQuality }, book_visible: true, ...(tenantId ? { tenantId } : {}) },
+          { maxTimeMS: 5000 },
+        ).catch(() => null);
+        if (illCount !== null) { displayTotal = illCount + addedArtworks; searchHasMore = outItems.length < displayTotal; }
       } catch { /* non-critical — search still returns illustrations */ }
     }
 
@@ -501,7 +510,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       items: outItems,
-      total,
+      total: displayTotal,
       hasMore: searchHasMore,
       limit,
       offset,

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -452,6 +452,7 @@ export async function GET(request: NextRequest) {
         extractedUrl: doc.extracted_url,
         thumbnailUrl: doc.thumbnail_url,
         galleryQuality: doc.gallery_quality,
+        aspect: doc.bbox && doc.bbox.width > 0 && doc.bbox.height > 0 ? Math.min(3, Math.max(0.33, (doc.bbox.width / doc.bbox.height) * 0.72)) : 0.72,
         confidence: doc.confidence,
         museumDescription: doc.museum_description,
         metadata: doc.metadata,
@@ -475,12 +476,13 @@ export async function GET(request: NextRequest) {
         const esc = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         const rx = { $regex: esc, $options: 'i' }; // case-insensitive phrase match on titles
         const imgPresent = { $or: [{ image_display: { $nin: [null, ''] } }, { image_full: { $nin: [null, ''] } }, { image_thumb: { $nin: [null, ''] } }] };
-        const artProj = { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 } };
+        const artProj = { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1, full_width: 1, full_height: 1, commons_width: 1, commons_height: 1 } };
+        const bboxAspect = (b: any) => b && b.width > 0 && b.height > 0 ? Math.min(3, Math.max(0.33, (b.width / b.height) * 0.72)) : 0.72; // eslint-disable-line @typescript-eslint/no-explicit-any
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const mapPlate = (d: any) => ({
           pageId: d.page_id, bookId: d.book_id, pageNumber: d.page_number, detectionIndex: d.detection_index,
           imageUrl: d.image_url, bookTitle: d.book_title, author: d.book_author, year: d.book_year,
-          description: d.description, type: d.type, bbox: d.bbox, rotation: d.rotation,
+          description: d.description, type: d.type, bbox: d.bbox, rotation: d.rotation, aspect: bboxAspect(d.bbox),
           extractedUrl: d.extracted_url, thumbnailUrl: d.thumbnail_url, galleryQuality: d.gallery_quality,
           source: 'illustration', likeCount: 0, likedByVisitor: false,
         });

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -6,7 +6,7 @@ import { supabase } from '@/lib/supabase';
 import { generateQueryEmbedding, cosineSimilarity } from '@/lib/embeddings';
 import { deduplicateByDHash } from '@/lib/dhash';
 import { CLIP_URL } from '@/lib/clip';
-import { mergedGalleryBrowse } from '@/lib/gallery-merge';
+import { mergedGalleryBrowse, artworkToGalleryItem } from '@/lib/gallery-merge';
 
 export const maxDuration = 30;
 
@@ -160,7 +160,7 @@ export async function GET(request: NextRequest) {
       });
       const mergedFilters = await getGalleryFilters(db).catch(() => ({ types: [], subjects: [], yearRange: { minYear: null, maxYear: null } }));
       return NextResponse.json({
-        items: merged.items, total: merged.total, limit, offset, bookInfo: null,
+        items: merged.items, total: merged.total, hasMore: merged.hasMore, limit, offset, bookInfo: null,
         filters: { ...mergedFilters, sources: ['illustration', 'artwork'] },
       }, {
         headers: { 'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600' },
@@ -462,6 +462,29 @@ export async function GET(request: NextRequest) {
       };
     });
 
+    // Include relevant standalone artworks in SEARCH results (first page only).
+    // Illustration search is keyword/Atlas; artwork search is semantic, so the
+    // artworks it returns are the genuinely on-topic ones (e.g. "John the Apostle"
+    // → paintings/prints of him), surfaced at the top.
+    let outItems: any[] = mappedItems; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let searchHasMore = hasMore;
+    if (searchQuery && offset === 0) {
+      try {
+        const { semanticArtworkSearch } = await import('@/lib/semantic-search');
+        const artHits = await semanticArtworkSearch(searchQuery, 12, { threshold: 0.25 });
+        if (artHits.length > 0) {
+          const ids = artHits.map(a => a.book_id);
+          const artDocs = await db.collection('books').find(
+            { id: { $in: ids }, visible: true, content_type: 'artwork', ...(tenantId ? { tenantId } : {}) },
+            { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 } },
+          ).toArray();
+          const byId = new Map(artDocs.map(d => [d.id, d]));
+          const artItems = artHits.map(a => byId.get(a.book_id)).filter(Boolean).map(artworkToGalleryItem);
+          if (artItems.length > 0) outItems = [...artItems, ...mappedItems];
+        }
+      } catch { /* non-critical — search still returns illustrations */ }
+    }
+
     // Get filters (cached for 30 min, only compute on first page)
     let filters = { types: [] as string[], subjects: [] as string[], yearRange: { minYear: null as number | null, maxYear: null as number | null } };
     if (offset === 0) {
@@ -477,8 +500,9 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json({
-      items: mappedItems,
+      items: outItems,
       total,
+      hasMore: searchHasMore,
       limit,
       offset,
       bookInfo,

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -84,7 +84,7 @@ export default function GalleryPage({ searchParams }: GalleryPageProps) {
       <SignUpCTA />
 
       {/* Classification credits */}
-      <div className="max-w-[var(--container-standard)] mx-auto px-6 md:px-12 pb-12">
+      <div className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 pb-12">
         <p className="text-xs text-stone-400 text-center">
           Image subjects classified using{' '}
           <a href="https://iconclass.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-stone-600">Iconclass</a>
@@ -121,7 +121,7 @@ async function GalleryData({ searchParams }: GalleryPageProps) {
 
 function GalleryShell() {
   return (
-    <div className="px-4 sm:px-6 lg:px-8 py-6">
+    <div className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 py-6">
       <div className="flex flex-col sm:flex-row flex-wrap items-stretch sm:items-center gap-3 mb-6">
         <div className="flex-1 min-w-0 sm:min-w-[200px] max-w-md h-9 bg-stone-200/70 rounded-lg animate-pulse" />
         <div className="min-w-0 sm:min-w-[200px] max-w-sm flex-1 h-9 bg-stone-200/70 rounded-lg animate-pulse" />

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -209,7 +209,7 @@ async function fetchInitialGalleryData(tenantId: string | null, bookId?: string)
     if (!bookId) {
       const merged = await mergedGalleryBrowse(db, { tenantId, source: 'all', limit, offset: 0, minQuality, maxPerBook });
       return {
-        items: merged.items, total: merged.total, limit, offset: 0, bookInfo: null,
+        items: merged.items, total: merged.total, hasMore: merged.hasMore, limit, offset: 0, bookInfo: null,
         filters: { ...sharedFilters, sources: ['illustration', 'artwork'] },
       };
     }

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { unstable_cache } from 'next/cache';
 import { getReadDb } from '@/lib/mongodb';
+import { mergedGalleryBrowse } from '@/lib/gallery-merge';
 import { headers } from 'next/headers';
 import GalleryClient from '@/components/gallery/GalleryClient';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
@@ -195,6 +196,22 @@ async function fetchInitialGalleryData(tenantId: string | null, bookId?: string)
         { $sort: { _id: 1 } },
       ], { maxTimeMS: 10000 }).toArray() as { _id: string }[];
       yearResult = [{ minYear: 1400, maxYear: 1900 }];
+    }
+
+    const sharedFilters = {
+      types: typesResult.map(t => t._id as string).filter(Boolean),
+      subjects: subjectsResult.map(s => s._id as string).filter(Boolean),
+      yearRange: (yearResult[0] as { minYear: number | null; maxYear: number | null }) || { minYear: null, maxYear: null },
+    };
+
+    // Plain gallery (no single book): first paint is the MERGED feed (plates +
+    // standalone artworks), matching the client's default 'all' source.
+    if (!bookId) {
+      const merged = await mergedGalleryBrowse(db, { tenantId, source: 'all', limit, offset: 0, minQuality, maxPerBook });
+      return {
+        items: merged.items, total: merged.total, limit, offset: 0, bookInfo: null,
+        filters: { ...sharedFilters, sources: ['illustration', 'artwork'] },
+      };
     }
 
     const [items, total, bookInfo] = await Promise.all([

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -145,7 +145,7 @@ function GalleryShell() {
 async function fetchInitialGalleryData(tenantId: string | null, bookId?: string): Promise<GalleryResponse> {
   try {
     const db = await getReadDb();
-    const limit = 24;
+    const limit = 48;
     const minQuality = 0.7;
     const maxPerBook = 3;
 

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -651,18 +651,16 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
               <h2 className="text-2xl font-serif text-stone-800 mb-1">{hasFilters ? 'Results' : 'Browse Images'}</h2>
               <p className="text-stone-500 text-base">
                 {data.total > 0
-                  ? `${data.total.toLocaleString('en-US')}${hasMore ? '+' : ''} ${hasFilters ? 'results' : 'images'} — plates & standalone artworks`
+                  ? `${data.total.toLocaleString('en-US')} ${hasFilters ? 'results' : 'images'} — plates & standalone artworks`
                   : 'Plates & standalone artworks'}
               </p>
             </div>
-            {/* Masonry (CSS columns, natural aspect) with a bottom fade while more pages remain */}
+            {/* Masonry: stable round-robin flex columns (appending on load-more
+                never reflows existing tiles), with a bottom fade while more remain. */}
             <div
-              className="columns-2 sm:columns-3 md:columns-4 lg:columns-5 xl:columns-6 gap-3 sm:gap-4"
-              style={hasMore && !loadingMore ? { maskImage: 'linear-gradient(to bottom, #000 90%, transparent)', WebkitMaskImage: 'linear-gradient(to bottom, #000 90%, transparent)' } : undefined}
+              style={hasMore && !loadingMore ? { maskImage: 'linear-gradient(to bottom, #000 92%, transparent)', WebkitMaskImage: 'linear-gradient(to bottom, #000 92%, transparent)' } : undefined}
             >
-              {allItems.map((item, idx) => (
-                <GalleryCard key={`${item.pageId}-${item.detectionIndex}-${idx}`} item={item} priority={idx < 12} tenantPrefix={tenantPrefix} collectionScope={collectionFilter || undefined} />
-              ))}
+              <GalleryMasonry items={allItems} tenantPrefix={tenantPrefix} collectionScope={collectionFilter || undefined} />
             </div>
 
             {/* Load More */}
@@ -691,6 +689,38 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   );
 }
 
+// Round-robin masonry: item i → column i % cols. Appending new items (load-more)
+// only adds to the bottom of columns, so existing tiles never move/reflow — the
+// jumpy CSS-`columns` behavior is gone. 5 columns on desktop, 3 below.
+function GalleryMasonry({ items, tenantPrefix, collectionScope }: { items: GalleryItem[]; tenantPrefix: string; collectionScope?: string }) {
+  const [cols, setCols] = useState(5);
+  useEffect(() => {
+    const update = () => setCols(window.innerWidth >= 1024 ? 5 : 3);
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+  const columns: GalleryItem[][] = Array.from({ length: cols }, () => []);
+  items.forEach((item, i) => columns[i % cols].push(item));
+  return (
+    <div className="flex gap-3 sm:gap-4 items-start">
+      {columns.map((col, ci) => (
+        <div key={ci} className="flex-1 min-w-0 flex flex-col gap-3 sm:gap-4">
+          {col.map((item, idx) => (
+            <GalleryCard
+              key={`${item.pageId}-${item.detectionIndex}`}
+              item={item}
+              priority={ci < cols && idx < 2}
+              tenantPrefix={tenantPrefix}
+              collectionScope={collectionScope}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScope }: { item: GalleryItem; priority?: boolean; tenantPrefix?: string; collectionScope?: string }) {
   const [imageError, setImageError] = useState(false);
   const [useCropFallback, setUseCropFallback] = useState(false);
@@ -713,7 +743,7 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
     : `${tenantPrefix}/gallery/image/${galleryImageId}${collectionScope ? `?collection=${encodeURIComponent(collectionScope)}` : ''}`;
 
   return (
-    <div className="relative group mb-3 sm:mb-4 break-inside-avoid rounded-lg overflow-hidden border border-border-light hover:border-accent-rust/40 hover:shadow-md transition-all">
+    <div className="relative group rounded-lg overflow-hidden border border-border-light hover:border-accent-rust/40 hover:shadow-md transition-all animate-fade-in-up">
       <Link href={imageHref} className="block relative bg-stone-100">
         {!imageError ? (
           // Plain img for true masonry (natural aspect, no crop). Also dodges
@@ -757,14 +787,6 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
         </div>
 
       </Link>
-
-      {isArtwork && (
-        <div className="absolute top-1.5 right-1.5 z-10 pointer-events-none">
-          <span className="bg-accent-rust/90 text-white text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded-full shadow-sm">
-            Artwork
-          </span>
-        </div>
-      )}
 
       <div className="absolute top-1.5 left-1.5 z-10">
         <div className="flex items-center bg-white/90 backdrop-blur-sm rounded-full shadow-sm hover:bg-white transition-colors px-1.5 py-0.5">

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
@@ -689,9 +689,11 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   );
 }
 
-// Round-robin masonry: item i → column i % cols. Appending new items (load-more)
-// only adds to the bottom of columns, so existing tiles never move/reflow — the
-// jumpy CSS-`columns` behavior is gone. 5 columns on desktop, 3 below.
+// Balanced masonry: place each tile in the currently-shortest column, using its
+// aspect ratio as a height estimate. This both (a) balances column heights so
+// there's no ragged-gap bottom, and (b) stays stable on load-more — greedy
+// placement is order-deterministic, so appending items never moves existing
+// tiles (no reflow/jumping). 5 columns on desktop, 3 below.
 function GalleryMasonry({ items, tenantPrefix, collectionScope }: { items: GalleryItem[]; tenantPrefix: string; collectionScope?: string }) {
   const [cols, setCols] = useState(5);
   useEffect(() => {
@@ -700,8 +702,24 @@ function GalleryMasonry({ items, tenantPrefix, collectionScope }: { items: Galle
     window.addEventListener('resize', update);
     return () => window.removeEventListener('resize', update);
   }, []);
-  const columns: GalleryItem[][] = Array.from({ length: cols }, () => []);
-  items.forEach((item, i) => columns[i % cols].push(item));
+
+  const columns = useMemo(() => {
+    const colArr: GalleryItem[][] = Array.from({ length: cols }, () => []);
+    const heights = new Array(cols).fill(0);
+    for (const item of items) {
+      // Estimated tile height ÷ width. Illustrations: from the crop bbox.
+      // Artworks / unknown: assume slightly portrait.
+      const ratio = item.bbox && item.bbox.width > 0
+        ? Math.min(2.4, Math.max(0.5, item.bbox.height / item.bbox.width))
+        : 1.25;
+      let s = 0;
+      for (let i = 1; i < cols; i++) if (heights[i] < heights[s]) s = i;
+      colArr[s].push(item);
+      heights[s] += ratio + 0.06; // +gap so count stays roughly even too
+    }
+    return colArr;
+  }, [items, cols]);
+
   return (
     <div className="flex gap-3 sm:gap-4 items-start">
       {columns.map((col, ci) => (

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -707,11 +707,11 @@ function GalleryMasonry({ items, tenantPrefix, collectionScope }: { items: Galle
     const colArr: GalleryItem[][] = Array.from({ length: cols }, () => []);
     const heights = new Array(cols).fill(0);
     for (const item of items) {
-      // Estimated tile height ÷ width. Illustrations: from the crop bbox.
-      // Artworks / unknown: assume slightly portrait.
-      const ratio = item.bbox && item.bbox.width > 0
-        ? Math.min(2.4, Math.max(0.5, item.bbox.height / item.bbox.width))
-        : 1.25;
+      // Tile height ÷ width. Prefer the exact aspect from the server; fall back
+      // to the crop bbox, then a slight-portrait default.
+      const ratio = item.aspect && item.aspect > 0
+        ? 1 / item.aspect
+        : (item.bbox && item.bbox.width > 0 ? Math.min(2.4, Math.max(0.5, item.bbox.height / item.bbox.width)) : 1.25);
       let s = 0;
       for (let i = 1; i < cols; i++) if (heights[i] < heights[s]) s = i;
       colArr[s].push(item);
@@ -742,6 +742,8 @@ function GalleryMasonry({ items, tenantPrefix, collectionScope }: { items: Galle
 function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScope }: { item: GalleryItem; priority?: boolean; tenantPrefix?: string; collectionScope?: string }) {
   const [imageError, setImageError] = useState(false);
   const [useCropFallback, setUseCropFallback] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const reservedAspect = item.aspect && item.aspect > 0 ? item.aspect : 0.75;
 
   // Standalone artworks have no bbox crop and link to their /book detail page,
   // not the gallery image viewer.
@@ -761,19 +763,21 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
     : `${tenantPrefix}/gallery/image/${galleryImageId}${collectionScope ? `?collection=${encodeURIComponent(collectionScope)}` : ''}`;
 
   return (
-    <div className="relative group rounded-lg overflow-hidden border border-border-light hover:border-accent-rust/40 hover:shadow-md transition-all animate-fade-in-up">
-      <Link href={imageHref} className="block relative bg-stone-100">
+    <div className="relative group rounded-lg overflow-hidden border border-border-light hover:border-accent-rust/40 hover:shadow-md transition-all">
+      {/* Reserve the exact tile box from the aspect ratio so nothing shifts as
+          the image decodes (no jumping); the image then fades in smoothly. */}
+      <Link href={imageHref} className="block relative bg-stone-100" style={{ aspectRatio: String(reservedAspect) }}>
         {!imageError ? (
-          // Plain img for true masonry (natural aspect, no crop). Also dodges
-          // next/image host allow-listing for external artwork image hosts.
+          // Plain img (dodges next/image host allow-listing for external artwork hosts).
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={displayUrl}
             alt={item.description}
             loading={priority ? 'eager' : 'lazy'}
             decoding="async"
-            className="w-full h-auto block group-hover:scale-105 transition-transform duration-300"
+            className={`absolute inset-0 w-full h-full object-cover transition duration-500 group-hover:scale-105 ${loaded ? 'opacity-100' : 'opacity-0'}`}
             onLoad={(e) => {
+              setLoaded(true);
               // Detect corrupt Blob thumbnails (real ones are 300px+)
               if (!useCropFallback && blobUrl && cropUrl) {
                 const img = e.currentTarget;
@@ -786,7 +790,7 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
             }}
           />
         ) : (
-          <div className="aspect-square flex items-center justify-center text-stone-300">
+          <div className="absolute inset-0 flex items-center justify-center text-stone-300">
             <ImageIcon className="w-8 h-8" />
           </div>
         )}

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -154,7 +154,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   // 'illustration', or 'artwork'.
   const sourceFilter = searchParams.get('source') || 'all';
 
-  const limit = 24;
+  const limit = 48;
 
   // Update URL params
   const updateParams = useCallback((updates: Record<string, string>) => {
@@ -341,11 +341,11 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
               placeholder="Search images…"
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
-              className="w-full pl-9 pr-[4.5rem] py-2 text-sm border border-stone-300 rounded-lg bg-white focus:ring-1 focus:ring-accent-rust focus:border-accent-rust"
+              className="w-full pl-9 pr-[5.25rem] py-2 text-sm border border-stone-300 rounded-lg bg-white focus:ring-1 focus:ring-accent-rust focus:border-accent-rust"
             />
             <button
               type="submit"
-              className="absolute right-1 top-1/2 -translate-y-1/2 px-3 py-1.5 text-xs font-medium bg-accent-rust text-white rounded-md hover:bg-accent-rust/90 transition-colors"
+              className="absolute right-0 top-0 bottom-0 px-4 text-sm font-medium bg-accent-rust text-white rounded-r-lg hover:bg-accent-rust/90 transition-colors"
             >
               Search
             </button>
@@ -749,8 +749,8 @@ function GalleryMasonry({ items, hasMore, tenantPrefix, collectionScope }: { ite
       style={cropHeight ? {
         maxHeight: cropHeight,
         overflow: 'hidden',
-        maskImage: 'linear-gradient(to bottom, #000 70%, transparent 100%)',
-        WebkitMaskImage: 'linear-gradient(to bottom, #000 70%, transparent 100%)',
+        maskImage: 'linear-gradient(to bottom, #000 calc(100% - 20vh), transparent 100%)',
+        WebkitMaskImage: 'linear-gradient(to bottom, #000 calc(100% - 20vh), transparent 100%)',
       } : undefined}
     >
       <div className="flex gap-3 sm:gap-4 items-start">

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -670,13 +670,9 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
                   : 'Plates & standalone artworks'}
               </p>
             </div>
-            {/* Masonry: stable round-robin flex columns (appending on load-more
-                never reflows existing tiles), with a bottom fade while more remain. */}
-            <div
-              style={hasMore && !loadingMore ? { maskImage: 'linear-gradient(to bottom, #000 92%, transparent)', WebkitMaskImage: 'linear-gradient(to bottom, #000 92%, transparent)' } : undefined}
-            >
-              <GalleryMasonry items={allItems} tenantPrefix={tenantPrefix} collectionScope={collectionFilter || undefined} />
-            </div>
+            {/* Uneven masonry cropped by a fixed-height container + fade mask (handled inside). */}
+            <GalleryMasonry items={allItems} hasMore={hasMore} tenantPrefix={tenantPrefix} collectionScope={collectionFilter || undefined} />
+            <div className="mt-2" />
 
             {/* Load More */}
             {hasMore && (
@@ -704,52 +700,74 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   );
 }
 
-// Balanced masonry: place each tile in the currently-shortest column, using its
-// aspect ratio as a height estimate. This both (a) balances column heights so
-// there's no ragged-gap bottom, and (b) stays stable on load-more — greedy
-// placement is order-deterministic, so appending items never moves existing
-// tiles (no reflow/jumping). 5 columns on desktop, 3 below.
-function GalleryMasonry({ items, tenantPrefix, collectionScope }: { items: GalleryItem[]; tenantPrefix: string; collectionScope?: string }) {
+// Masonry with intentionally UNEVEN columns, cropped by a fixed-height container
+// + fade mask (NOT balanced). Tiles flow naturally round-robin; the container is
+// capped to the shortest column's height so every column fills it (no whitespace
+// gaps) while taller columns overflow past the bottom, where the mask fades the
+// hard crop line. The cap grows with each load-more. 5 columns desktop, 3 below.
+const MASONRY_GAP = 16;
+function GalleryMasonry({ items, hasMore, tenantPrefix, collectionScope }: { items: GalleryItem[]; hasMore: boolean; tenantPrefix: string; collectionScope?: string }) {
   const [cols, setCols] = useState(5);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    const update = () => setCols(window.innerWidth >= 1024 ? 5 : 3);
+    const update = () => {
+      setCols(window.innerWidth >= 1024 ? 5 : 3);
+      if (ref.current) setContainerWidth(ref.current.offsetWidth);
+    };
     update();
     window.addEventListener('resize', update);
     return () => window.removeEventListener('resize', update);
   }, []);
 
+  // Natural round-robin — deliberately NOT height-balanced.
   const columns = useMemo(() => {
     const colArr: GalleryItem[][] = Array.from({ length: cols }, () => []);
-    const heights = new Array(cols).fill(0);
-    for (const item of items) {
-      // Tile height ÷ width. Prefer the exact aspect from the server; fall back
-      // to the crop bbox, then a slight-portrait default.
-      const ratio = item.aspect && item.aspect > 0
-        ? 1 / item.aspect
-        : (item.bbox && item.bbox.width > 0 ? Math.min(2.4, Math.max(0.5, item.bbox.height / item.bbox.width)) : 1.25);
-      let s = 0;
-      for (let i = 1; i < cols; i++) if (heights[i] < heights[s]) s = i;
-      colArr[s].push(item);
-      heights[s] += ratio + 0.06; // +gap so count stays roughly even too
-    }
+    items.forEach((item, i) => colArr[i % cols].push(item));
     return colArr;
   }, [items, cols]);
 
+  // Crop height = shortest column's pixel height (from aspect ratios — no DOM
+  // measurement of tiles, so no flashing). Only crop while more pages remain.
+  const cropHeight = useMemo(() => {
+    if (!hasMore || !containerWidth || cols < 1) return undefined;
+    const colWidth = (containerWidth - (cols - 1) * MASONRY_GAP) / cols;
+    if (colWidth <= 0) return undefined;
+    let minH = Infinity;
+    for (const col of columns) {
+      if (col.length === 0) continue;
+      let h = 0;
+      for (const it of col) { const a = it.aspect && it.aspect > 0 ? it.aspect : 0.75; h += colWidth / a + MASONRY_GAP; }
+      if (h < minH) minH = h;
+    }
+    return Number.isFinite(minH) ? Math.round(minH - MASONRY_GAP) : undefined;
+  }, [columns, containerWidth, cols, hasMore]);
+
   return (
-    <div className="flex gap-3 sm:gap-4 items-start">
-      {columns.map((col, ci) => (
-        <div key={ci} className="flex-1 min-w-0 flex flex-col gap-3 sm:gap-4">
-          {col.map((item, idx) => (
-            <GalleryCard
-              key={`${item.pageId}-${item.detectionIndex}`}
-              item={item}
-              priority={ci < cols && idx < 2}
-              tenantPrefix={tenantPrefix}
-              collectionScope={collectionScope}
-            />
-          ))}
-        </div>
-      ))}
+    <div
+      ref={ref}
+      style={cropHeight ? {
+        maxHeight: cropHeight,
+        overflow: 'hidden',
+        maskImage: 'linear-gradient(to bottom, #000 70%, transparent 100%)',
+        WebkitMaskImage: 'linear-gradient(to bottom, #000 70%, transparent 100%)',
+      } : undefined}
+    >
+      <div className="flex gap-3 sm:gap-4 items-start">
+        {columns.map((col, ci) => (
+          <div key={ci} className="flex-1 min-w-0 flex flex-col gap-3 sm:gap-4">
+            {col.map((item, idx) => (
+              <GalleryCard
+                key={`${item.pageId}-${item.detectionIndex}`}
+                item={item}
+                priority={ci < cols && idx < 2}
+                tenantPrefix={tenantPrefix}
+                collectionScope={collectionScope}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -288,8 +288,8 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const hasMore = data ? currentOffset < data.total : false;
-  const remainingCount = data ? data.total - currentOffset : 0;
+  // Prefer the server's reliable hasMore flag; fall back to total-vs-offset.
+  const hasMore = data ? (data.hasMore ?? currentOffset < data.total) : false;
 
   const handleBookSelect = (book: BookSearchResult) => {
     setBookSearchQuery('');
@@ -647,15 +647,19 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
         {/* Image Grid */}
         {!loading && data && allItems.length > 0 && (
           <>
-            {!hasFilters && (
-              <div className="mb-4">
-                <h2 className="text-2xl font-serif text-stone-800 mb-1">Browse Images</h2>
-                <p className="text-stone-500 text-base">
-                  {data.total.toLocaleString('en-US')} illustrations from rare historical manuscripts.
-                </p>
-              </div>
-            )}
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+            <div className="mb-4">
+              <h2 className="text-2xl font-serif text-stone-800 mb-1">{hasFilters ? 'Results' : 'Browse Images'}</h2>
+              <p className="text-stone-500 text-base">
+                {data.total > 0
+                  ? `${data.total.toLocaleString('en-US')}${hasMore ? '+' : ''} ${hasFilters ? 'results' : 'images'} — plates & standalone artworks`
+                  : 'Plates & standalone artworks'}
+              </p>
+            </div>
+            {/* Masonry (CSS columns, natural aspect) with a bottom fade while more pages remain */}
+            <div
+              className="columns-2 sm:columns-3 md:columns-4 lg:columns-5 xl:columns-6 gap-3 sm:gap-4"
+              style={hasMore && !loadingMore ? { maskImage: 'linear-gradient(to bottom, #000 90%, transparent)', WebkitMaskImage: 'linear-gradient(to bottom, #000 90%, transparent)' } : undefined}
+            >
               {allItems.map((item, idx) => (
                 <GalleryCard key={`${item.pageId}-${item.detectionIndex}-${idx}`} item={item} priority={idx < 12} tenantPrefix={tenantPrefix} collectionScope={collectionFilter || undefined} />
               ))}
@@ -663,7 +667,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
 
             {/* Load More */}
             {hasMore && (
-              <div className="mt-10 text-center">
+              <div className="mt-8 text-center">
                 <button
                   onClick={handleLoadMore}
                   disabled={loadingMore}
@@ -676,7 +680,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                     </svg>
                   )}
-                  {loadingMore ? 'Loading...' : `Load more (${remainingCount.toLocaleString('en-US')} remaining)`}
+                  {loadingMore ? 'Loading…' : 'Load more'}
                 </button>
               </div>
             )}
@@ -702,7 +706,6 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
     ? (cropUrl || toThumbnailUrl(item.imageUrl))
     : (blobUrl || cropUrl || toThumbnailUrl(item.imageUrl));
 
-  const isPreGenerated = !useCropFallback && !!blobUrl;
   const galleryImageId = `${item.pageId}-${item.detectionIndex}`;
   // Forward the collection scope so the image viewer keeps prev/next inside the collection.
   const imageHref = isArtwork
@@ -710,38 +713,32 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
     : `${tenantPrefix}/gallery/image/${galleryImageId}${collectionScope ? `?collection=${encodeURIComponent(collectionScope)}` : ''}`;
 
   return (
-    <div className="relative group rounded-lg overflow-hidden hover:shadow-md transition-all hover:-translate-y-0.5">
-      <Link href={imageHref} className="block relative aspect-square bg-stone-100">
+    <div className="relative group mb-3 sm:mb-4 break-inside-avoid rounded-lg overflow-hidden border border-border-light hover:border-accent-rust/40 hover:shadow-md transition-all">
+      <Link href={imageHref} className="block relative bg-stone-100">
         {!imageError ? (
-          <Image
+          // Plain img for true masonry (natural aspect, no crop). Also dodges
+          // next/image host allow-listing for external artwork image hosts.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
             src={displayUrl}
             alt={item.description}
-            fill
-            quality={85}
-            className="object-cover group-hover:scale-105 transition-transform duration-300"
-            sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 16vw"
+            loading={priority ? 'eager' : 'lazy'}
+            decoding="async"
+            className="w-full h-auto block group-hover:scale-105 transition-transform duration-300"
             onLoad={(e) => {
               // Detect corrupt Blob thumbnails (real ones are 300px+)
               if (!useCropFallback && blobUrl && cropUrl) {
-                const img = e.target as HTMLImageElement;
-                if (img.naturalWidth < 150 || img.naturalHeight < 150) {
-                  setUseCropFallback(true);
-                }
+                const img = e.currentTarget;
+                if (img.naturalWidth < 150 || img.naturalHeight < 150) setUseCropFallback(true);
               }
             }}
             onError={() => {
-              if (!useCropFallback && cropUrl) {
-                setUseCropFallback(true);
-              } else {
-                setImageError(true);
-              }
+              if (!useCropFallback && cropUrl) setUseCropFallback(true);
+              else setImageError(true);
             }}
-            unoptimized={isArtwork || (!isPreGenerated && !!item.bbox)}
-            priority={priority}
-            loading={priority ? 'eager' : 'lazy'}
           />
         ) : (
-          <div className="absolute inset-0 flex items-center justify-center text-stone-300">
+          <div className="aspect-square flex items-center justify-center text-stone-300">
             <ImageIcon className="w-8 h-8" />
           </div>
         )}

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -736,7 +736,7 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
                 setImageError(true);
               }
             }}
-            unoptimized={!isPreGenerated && !!item.bbox}
+            unoptimized={isArtwork || (!isPreGenerated && !!item.bbox)}
             priority={priority}
             loading={priority ? 'eager' : 'lazy'}
           />

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -130,8 +130,9 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   const [showBookDropdown, setShowBookDropdown] = useState(false);
   const bookSearchRef = useRef<HTMLDivElement>(null);
 
-  // Image search state
-  const [imageSearchQuery, setImageSearchQuery] = useState(searchParams.get('q') || '');
+  // Image search: `searchInput` is the typed text; the committed query lives in
+  // the URL (`q`) and only updates on Enter / the search button — no live search.
+  const [searchInput, setSearchInput] = useState(searchParams.get('q') || '');
 
   // Quality toggle state
   const qualityParam = searchParams.get('minQuality');
@@ -147,6 +148,8 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   const iconclassFilter = searchParams.get('iconclass') || '';
   const yearStart = searchParams.get('yearStart') || '';
   const yearEnd = searchParams.get('yearEnd') || '';
+  // Committed image search query (drives the fetch); comes from the URL only.
+  const imageSearchQuery = searchParams.get('q') || '';
   // Merged-gallery source facet: 'all' (default, interleaves illustrations + artworks),
   // 'illustration', or 'artwork'.
   const sourceFilter = searchParams.get('source') || 'all';
@@ -303,8 +306,14 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
 
   const handleImageSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    updateParams({ q: imageSearchQuery });
+    updateParams({ q: searchInput.trim() });
   };
+
+  // Keep the input in sync with the committed query (back/forward, clearing a
+  // chip, etc.) — only when `q` actually changes, never while typing.
+  useEffect(() => {
+    setSearchInput(imageSearchQuery);
+  }, [imageSearchQuery]);
 
   const handleQualityChange = (level: string) => {
     if (level === 'archive') {
@@ -329,11 +338,17 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
             <input
               type="text"
-              placeholder="Search images..."
-              value={imageSearchQuery}
-              onChange={(e) => setImageSearchQuery(e.target.value)}
-              className="w-full pl-9 pr-3 py-2 text-sm border border-stone-300 rounded-lg bg-white focus:ring-1 focus:ring-accent-rust focus:border-accent-rust"
+              placeholder="Search images…"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              className="w-full pl-9 pr-[4.5rem] py-2 text-sm border border-stone-300 rounded-lg bg-white focus:ring-1 focus:ring-accent-rust focus:border-accent-rust"
             />
+            <button
+              type="submit"
+              className="absolute right-1 top-1/2 -translate-y-1/2 px-3 py-1.5 text-xs font-medium bg-accent-rust text-white rounded-md hover:bg-accent-rust/90 transition-colors"
+            >
+              Search
+            </button>
           </form>
 
           {/* Book Search */}
@@ -436,7 +451,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
             {imageSearchQuery && (
               <div className="flex items-center gap-2 px-3 py-1.5 bg-blue-100 text-blue-800 rounded-full text-sm">
                 Search: &quot;{imageSearchQuery}&quot;
-                <button onClick={() => { setImageSearchQuery(''); updateParams({ q: '' }); }} className="hover:text-blue-600">
+                <button onClick={() => { setSearchInput(''); updateParams({ q: '' }); }} className="hover:text-blue-600">
                   <X className="w-3 h-3" />
                 </button>
               </div>

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -147,6 +147,9 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   const iconclassFilter = searchParams.get('iconclass') || '';
   const yearStart = searchParams.get('yearStart') || '';
   const yearEnd = searchParams.get('yearEnd') || '';
+  // Merged-gallery source facet: 'all' (default, interleaves illustrations + artworks),
+  // 'illustration', or 'artwork'.
+  const sourceFilter = searchParams.get('source') || 'all';
 
   const limit = 24;
 
@@ -170,7 +173,10 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   // and no other filters are present.
   useEffect(() => {
     const hasNonBookFilters = collectionFilter || libraryFilter || imageSearchQuery || typeFilter || subjectFilter || iconclassFilter || yearStart || yearEnd || qualityParam || includeArchive;
-    if (isInitialLoad && !hasNonBookFilters && bookId === initialBookId) {
+    // The SSR payload is illustration-only; for the merged default ('all') or
+    // artwork-only we must fetch on mount to pull artworks in. Only skip when the
+    // request matches what the server already rendered (illustration-only, no filters).
+    if (isInitialLoad && !hasNonBookFilters && bookId === initialBookId && sourceFilter === 'illustration') {
       setIsInitialLoad(false);
       return;
     }
@@ -193,6 +199,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
           yearFrom: yearStart ? parseInt(yearStart) : undefined,
           yearTo: yearEnd ? parseInt(yearEnd) : undefined,
           minQuality: qualityParam ? parseFloat(qualityParam) : undefined,
+          source: sourceFilter !== 'all' ? (sourceFilter as 'illustration' | 'artwork') : undefined,
           visitorId: identity.id || undefined,
         });
         setData(json);
@@ -207,7 +214,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
 
     fetchGallery();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bookId, collectionFilter, libraryFilter, imageSearchQuery, typeFilter, subjectFilter, iconclassFilter, yearStart, yearEnd, qualityParam, includeArchive, identity.id]);
+  }, [bookId, collectionFilter, libraryFilter, imageSearchQuery, typeFilter, subjectFilter, iconclassFilter, yearStart, yearEnd, qualityParam, includeArchive, identity.id, sourceFilter]);
 
   // Load more handler — appends next batch to accumulated items
   const handleLoadMore = useCallback(async () => {
@@ -227,6 +234,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
         yearFrom: yearStart ? parseInt(yearStart) : undefined,
         yearTo: yearEnd ? parseInt(yearEnd) : undefined,
         minQuality: qualityParam ? parseFloat(qualityParam) : undefined,
+        source: sourceFilter !== 'all' ? (sourceFilter as 'illustration' | 'artwork') : undefined,
         visitorId: identity.id || undefined,
       });
       setAllItems(prev => [...prev, ...json.items]);
@@ -240,7 +248,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
     } finally {
       setLoadingMore(false);
     }
-  }, [loadingMore, data, currentOffset, bookId, collectionFilter, libraryFilter, imageSearchQuery, typeFilter, subjectFilter, iconclassFilter, yearStart, yearEnd, qualityParam, identity.id, limit]);
+  }, [loadingMore, data, currentOffset, bookId, collectionFilter, libraryFilter, imageSearchQuery, typeFilter, subjectFilter, iconclassFilter, yearStart, yearEnd, qualityParam, identity.id, limit, sourceFilter]);
 
   // Book search with debounce
   useEffect(() => {
@@ -313,7 +321,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
 
   return (
     <>
-      <div className="px-4 sm:px-6 lg:px-8 py-6 overflow-x-hidden animate-fade-in-up">
+      <div className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 py-6 overflow-x-hidden animate-fade-in-up">
         {/* Search & Filter Bar */}
         <div className="flex flex-col sm:flex-row flex-wrap items-stretch sm:items-center gap-3 mb-6">
           {/* Image Search */}
@@ -448,6 +456,29 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
         {showFilters && data?.filters && (
           <div className="mb-6 p-4 bg-white rounded-lg shadow-sm border border-stone-200">
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+              {/* Source: book plates vs standalone artworks */}
+              <div>
+                <label className="block text-xs font-medium text-stone-500 mb-2">Show</label>
+                <div className="flex flex-wrap gap-1">
+                  {[
+                    { key: 'all', label: 'Everything' },
+                    { key: 'illustration', label: 'Plates' },
+                    { key: 'artwork', label: 'Artworks' },
+                  ].map(({ key, label }) => (
+                    <button
+                      key={key}
+                      onClick={() => updateParams({ source: key === 'all' ? '' : key })}
+                      className={`px-2 py-1 text-xs rounded-full transition-colors ${sourceFilter === key
+                          ? 'bg-accent-rust text-white'
+                          : 'bg-stone-100 text-stone-600 hover:bg-stone-200'
+                        }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
               {/* Quality Toggle */}
               <div>
                 <label className="block text-xs font-medium text-stone-500 mb-2">Image Quality</label>
@@ -660,7 +691,10 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
   const [imageError, setImageError] = useState(false);
   const [useCropFallback, setUseCropFallback] = useState(false);
 
-  const cropUrl = item.bbox ? getCroppedImageUrl(item.imageUrl, item.bbox) : null;
+  // Standalone artworks have no bbox crop and link to their /book detail page,
+  // not the gallery image viewer.
+  const isArtwork = item.source === 'artwork';
+  const cropUrl = !isArtwork && item.bbox ? getCroppedImageUrl(item.imageUrl, item.bbox) : null;
   // Prefer thumbnail for grid cards — extracted images are ~2MB vs ~38KB thumbnails
   const blobUrl = item.thumbnailUrl || item.extractedUrl;
 
@@ -671,7 +705,9 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
   const isPreGenerated = !useCropFallback && !!blobUrl;
   const galleryImageId = `${item.pageId}-${item.detectionIndex}`;
   // Forward the collection scope so the image viewer keeps prev/next inside the collection.
-  const imageHref = `${tenantPrefix}/gallery/image/${galleryImageId}${collectionScope ? `?collection=${encodeURIComponent(collectionScope)}` : ''}`;
+  const imageHref = isArtwork
+    ? `${tenantPrefix}${item.link || `/book/${item.bookId}`}`
+    : `${tenantPrefix}/gallery/image/${galleryImageId}${collectionScope ? `?collection=${encodeURIComponent(collectionScope)}` : ''}`;
 
   return (
     <div className="relative group rounded-lg overflow-hidden hover:shadow-md transition-all hover:-translate-y-0.5">
@@ -724,6 +760,14 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
         </div>
 
       </Link>
+
+      {isArtwork && (
+        <div className="absolute top-1.5 right-1.5 z-10 pointer-events-none">
+          <span className="bg-accent-rust/90 text-white text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded-full shadow-sm">
+            Artwork
+          </span>
+        </div>
+      )}
 
       <div className="absolute top-1.5 left-1.5 z-10">
         <div className="flex items-center bg-white/90 backdrop-blur-sm rounded-full shadow-sm hover:bg-white transition-colors px-1.5 py-0.5">

--- a/src/lib/api-client/gallery.ts
+++ b/src/lib/api-client/gallery.ts
@@ -40,6 +40,7 @@ export const gallery = {
     if (params?.sort) queryParams.append('sort', params.sort);
     if (params?.visitorId) queryParams.append('visitor_id', params.visitorId);
     if (params?.iconclass) queryParams.append('iconclass', params.iconclass);
+    if (params?.source) queryParams.append('source', params.source);
 
     const query = queryParams.toString();
     return await apiClient.get(`/api/gallery${query ? `?${query}` : ''}`);

--- a/src/lib/api-client/types/gallery.ts
+++ b/src/lib/api-client/types/gallery.ts
@@ -49,6 +49,9 @@ export interface GalleryItem {
   firstSyncedAt?: string;
   /** Which kind of visual this is. Absent ⇒ 'illustration'. */
   source?: GallerySource;
+  /** Width÷height of the displayed image, for reserving tile space (no layout
+   *  shift on load) and balancing masonry columns. */
+  aspect?: number;
   /** Where the tile links to. Illustrations omit this (built from pageId-detectionIndex);
    *  artworks set it to their /book/<slug> detail page. */
   link?: string;

--- a/src/lib/api-client/types/gallery.ts
+++ b/src/lib/api-client/types/gallery.ts
@@ -82,6 +82,8 @@ export interface GalleryResponse {
   offset: number;
   bookInfo: BookInfo | null;
   filters: GalleryFilters;
+  /** Reliable "more pages exist" flag (preferred over total-vs-offset math). */
+  hasMore?: boolean;
 }
 
 export interface GallerySearchParams {

--- a/src/lib/api-client/types/gallery.ts
+++ b/src/lib/api-client/types/gallery.ts
@@ -20,6 +20,12 @@ export interface ImageMetadata {
   cit?: string[];
 }
 
+/** A merged-gallery tile is either an illustration cropped from a book page
+ *  ('illustration', the gallery_images default) or a standalone artwork
+ *  ('artwork', a content_type:'artwork' record). Defaults to 'illustration'
+ *  when absent so existing consumers keep working. */
+export type GallerySource = 'illustration' | 'artwork';
+
 export interface GalleryItem {
   pageId: string;
   bookId: string;
@@ -41,6 +47,11 @@ export interface GalleryItem {
   likeCount?: number;
   likedByVisitor?: boolean;
   firstSyncedAt?: string;
+  /** Which kind of visual this is. Absent ⇒ 'illustration'. */
+  source?: GallerySource;
+  /** Where the tile links to. Illustrations omit this (built from pageId-detectionIndex);
+   *  artworks set it to their /book/<slug> detail page. */
+  link?: string;
 }
 
 export interface BookInfo {
@@ -60,6 +71,8 @@ export interface GalleryFilters {
   types: string[];
   subjects: string[];
   yearRange: { minYear: number | null; maxYear: number | null };
+  /** Available source facet values for the merged gallery. */
+  sources?: GallerySource[];
 }
 
 export interface GalleryResponse {
@@ -90,6 +103,8 @@ export interface GallerySearchParams {
   sort?: string;
   visitorId?: string;
   iconclass?: string;
+  /** Merged-gallery source filter. 'all' (default) interleaves both. */
+  source?: 'all' | GallerySource;
 }
 
 export interface GalleryImageUpdateRequest {

--- a/src/lib/gallery-merge.ts
+++ b/src/lib/gallery-merge.ts
@@ -51,7 +51,7 @@ export function artworkToGalleryItem(a: any) {
 export async function mergedGalleryBrowse(
   db: any,
   opts: MergedBrowseOpts,
-): Promise<{ items: any[]; total: number }> {
+): Promise<{ items: any[]; total: number; hasMore: boolean }> {
   const {
     tenantId, source, limit, offset,
     imageType = null, minQuality = 0.7, maxPerBook = 3,
@@ -142,6 +142,31 @@ export async function mergedGalleryBrowse(
   }
 
   const hasMore = illusHasMore || artHasMore;
-  const total = offset + items.length + (hasMore ? limit : 0); // monotone estimate for infinite scroll
-  return { items, total };
+
+  // Real total for the UI count: illustrations (estimated when unfiltered, exact
+  // when type/year-filtered) + artworks. Both guarded with a time cap.
+  let illusTotal = 0;
+  if (illusPerPage > 0) {
+    if (imageType || yearStart !== null || yearEnd !== null) {
+      const cf: Record<string, unknown> = {
+        ...tenant, gallery_quality: { $gte: minQuality }, book_visible: true,
+        extracted_url: { $ne: null }, image_url: { $ne: null },
+      };
+      if (maxPerBook < 100) cf.book_rank = { $lte: maxPerBook };
+      if (imageType) cf.type = imageType;
+      if (yearStart !== null || yearEnd !== null) {
+        const y: Record<string, number> = {};
+        if (yearStart !== null) y.$gte = yearStart;
+        if (yearEnd !== null) y.$lte = yearEnd;
+        cf.book_year = y;
+      }
+      illusTotal = await db.collection('gallery_images').countDocuments(cf, { maxTimeMS: 8000 }).catch(() => 0);
+    } else {
+      illusTotal = await db.collection('gallery_images').estimatedDocumentCount();
+    }
+  }
+  const artTotal = await db.collection('books').countDocuments(af, { maxTimeMS: 8000 }).catch(() => arts.length);
+  const total = illusTotal + artTotal;
+
+  return { items, total, hasMore };
 }

--- a/src/lib/gallery-merge.ts
+++ b/src/lib/gallery-merge.ts
@@ -23,12 +23,18 @@ export interface MergedBrowseOpts {
   visitorId?: string | null;
 }
 
+const clampAspect = (r: number) => Math.min(3, Math.max(0.33, r));
+
 // Standalone artworks store images in their own fields — map one to a GalleryItem tile.
 export function artworkToGalleryItem(a: any) {
   const image = a.image_display || a.image_full || a.image_thumb || a.thumbnail_blob || a.thumbnail || '';
   const thumb = a.image_thumb || a.thumbnail_blob || a.thumbnail || a.image_display || image;
   const year = typeof a.year === 'number' ? a.year : (parseInt(a.published, 10) || undefined);
+  const w = a.full_width || a.commons_width;
+  const h = a.full_height || a.commons_height;
+  const aspect = w && h ? clampAspect(w / h) : 0.78;
   return {
+    aspect,
     pageId: `artwork-${a.id}`,
     bookId: a.id,
     pageNumber: 0,
@@ -108,7 +114,7 @@ export async function mergedGalleryBrowse(
   }
   const artDocs = await db.collection('books')
     .find(af, {
-      projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 },
+      projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1, full_width: 1, full_height: 1, commons_width: 1, commons_height: 1 },
       allowDiskUse: true,
     })
     .sort({ year: 1, title: 1 })
@@ -116,24 +122,32 @@ export async function mergedGalleryBrowse(
   const artHasMore = artDocs.length > artPerPage;
   const arts = artDocs.slice(0, artPerPage).map(artworkToGalleryItem);
 
-  // ---- illustration likes ----
+  // ---- illustration likes + page dims (for exact aspect) ----
   const likesMap: Record<string, { count: number; liked: boolean }> = {};
+  const dimMap = new Map<string, { image_width?: number; image_height?: number }>();
   if (illusDocs.length > 0) {
     const ids = illusDocs.map(d => `${d.page_id}-${d.detection_index}`);
-    try {
-      const likeDocs = await db.collection('likes').aggregate([
+    const pageIds = illusDocs.map(d => d.page_id).filter(Boolean);
+    const [likeDocs, dimDocs] = await Promise.all([
+      db.collection('likes').aggregate([
         { $match: { target_type: 'image', target_id: { $in: ids } } },
         { $group: { _id: '$target_id', count: { $sum: 1 }, visitors: { $addToSet: '$visitor_id' } } },
-      ]).toArray();
-      for (const ld of likeDocs) likesMap[ld._id] = { count: ld.count, liked: visitorId ? ld.visitors.includes(visitorId) : false };
-    } catch { /* non-critical */ }
+      ]).toArray().catch(() => []),
+      db.collection('pages').find({ id: { $in: pageIds } }, { projection: { id: 1, image_width: 1, image_height: 1 } }).toArray().catch(() => []),
+    ]);
+    for (const ld of likeDocs) likesMap[ld._id] = { count: ld.count, liked: visitorId ? ld.visitors.includes(visitorId) : false };
+    for (const p of dimDocs) dimMap.set(p.id, p);
   }
   const illus = illusDocs.map(d => {
     const key = `${d.page_id}-${d.detection_index}`;
+    const b = d.bbox; const pd = dimMap.get(d.page_id);
+    const aspect = b && b.width > 0 && b.height > 0 && pd?.image_width && pd?.image_height
+      ? clampAspect((b.width * pd.image_width) / (b.height * pd.image_height))
+      : (b && b.width > 0 && b.height > 0 ? clampAspect((b.width / b.height) * 0.72) : 0.72);
     return {
       pageId: d.page_id, bookId: d.book_id, pageNumber: d.page_number, detectionIndex: d.detection_index,
       imageUrl: d.image_url, bookTitle: d.book_title, author: d.book_author, year: d.book_year,
-      description: d.description, type: d.type, bbox: d.bbox, rotation: d.rotation,
+      description: d.description, type: d.type, bbox: d.bbox, rotation: d.rotation, aspect,
       extractedUrl: d.extracted_url, thumbnailUrl: d.thumbnail_url, galleryQuality: d.gallery_quality,
       museumDescription: d.museum_description, metadata: d.metadata, source: 'illustration' as const,
       likeCount: likesMap[key]?.count ?? 0, likedByVisitor: likesMap[key]?.liked ?? false,

--- a/src/lib/gallery-merge.ts
+++ b/src/lib/gallery-merge.ts
@@ -1,0 +1,147 @@
+/**
+ * Merged gallery browse — interleaves book illustrations (gallery_images) with
+ * standalone artworks (books, content_type:'artwork') into one GalleryItem feed.
+ *
+ * Pure: takes a Mongo db handle + plain options and returns { items, total }.
+ * No Next/auth/route deps, so it can run in the API route, in SSR, and in a
+ * standalone test script. Used ONLY for the unscoped /gallery browse; all the
+ * scoped/search paths stay illustration-only in their existing code.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface MergedBrowseOpts {
+  tenantId: string | null;
+  source: 'all' | 'artwork';
+  limit: number;
+  offset: number;
+  imageType?: string | null;
+  minQuality?: number;
+  maxPerBook?: number;
+  yearStart?: number | null;
+  yearEnd?: number | null;
+  visitorId?: string | null;
+}
+
+// Standalone artworks store images in their own fields — map one to a GalleryItem tile.
+export function artworkToGalleryItem(a: any) {
+  const image = a.image_display || a.image_full || a.image_thumb || a.thumbnail_blob || a.thumbnail || '';
+  const thumb = a.image_thumb || a.thumbnail_blob || a.thumbnail || a.image_display || image;
+  const year = typeof a.year === 'number' ? a.year : (parseInt(a.published, 10) || undefined);
+  return {
+    pageId: `artwork-${a.id}`,
+    bookId: a.id,
+    pageNumber: 0,
+    detectionIndex: 0,
+    imageUrl: image,
+    thumbnailUrl: thumb,
+    extractedUrl: image,        // card's primary src; no bbox crop for artworks
+    bookTitle: a.display_title || a.title || 'Untitled',
+    author: a.author,
+    year,
+    description: a.summary || a.display_title || a.title || '',
+    type: a.resource_type,
+    source: 'artwork' as const,
+    link: `/book/${a.slug || a.id}`,
+    likeCount: 0,
+    likedByVisitor: false,
+  };
+}
+
+export async function mergedGalleryBrowse(
+  db: any,
+  opts: MergedBrowseOpts,
+): Promise<{ items: any[]; total: number }> {
+  const {
+    tenantId, source, limit, offset,
+    imageType = null, minQuality = 0.7, maxPerBook = 3,
+    yearStart = null, yearEnd = null, visitorId = null,
+  } = opts;
+  const tenant = tenantId ? { tenantId } : {};
+  const pageIndex = Math.floor(offset / Math.max(1, limit));
+
+  const artPerPage = source === 'artwork' ? limit : Math.max(1, Math.round(limit * 0.25));
+  const illusPerPage = source === 'artwork' ? 0 : limit - artPerPage;
+
+  // ---- illustrations ----
+  let illusDocs: any[] = [];
+  let illusHasMore = false;
+  if (illusPerPage > 0) {
+    const f: Record<string, unknown> = {
+      ...tenant, gallery_quality: { $gte: minQuality }, book_visible: true,
+      extracted_url: { $ne: null }, image_url: { $ne: null },
+    };
+    if (maxPerBook < 100) f.book_rank = { $lte: maxPerBook };
+    if (imageType) f.type = imageType;
+    if (yearStart !== null || yearEnd !== null) {
+      const y: Record<string, number> = {};
+      if (yearStart !== null) y.$gte = yearStart;
+      if (yearEnd !== null) y.$lte = yearEnd;
+      f.book_year = y;
+    }
+    const docs = await db.collection('gallery_images')
+      .find(f, { projection: { _id: 0 } })
+      .sort({ gallery_quality: -1, book_year: 1, book_id: 1, page_number: 1 })
+      .skip(pageIndex * illusPerPage).limit(illusPerPage + 1).toArray();
+    illusHasMore = docs.length > illusPerPage;
+    illusDocs = docs.slice(0, illusPerPage);
+  }
+
+  // ---- artworks (allowDiskUse guards the sort on the 26k-row artwork set) ----
+  const af: Record<string, unknown> = { ...tenant, content_type: 'artwork', visible: true };
+  if (imageType) af.resource_type = imageType;
+  if (yearStart !== null || yearEnd !== null) {
+    const y: Record<string, number> = {};
+    if (yearStart !== null) y.$gte = yearStart;
+    if (yearEnd !== null) y.$lte = yearEnd;
+    af.year = y;
+  }
+  const artDocs = await db.collection('books')
+    .find(af, {
+      projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, summary: 1, resource_type: 1, image_display: 1, image_full: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 },
+      allowDiskUse: true,
+    })
+    .sort({ year: 1, title: 1 })
+    .skip(pageIndex * artPerPage).limit(artPerPage + 1).toArray();
+  const artHasMore = artDocs.length > artPerPage;
+  const arts = artDocs.slice(0, artPerPage).map(artworkToGalleryItem);
+
+  // ---- illustration likes ----
+  const likesMap: Record<string, { count: number; liked: boolean }> = {};
+  if (illusDocs.length > 0) {
+    const ids = illusDocs.map(d => `${d.page_id}-${d.detection_index}`);
+    try {
+      const likeDocs = await db.collection('likes').aggregate([
+        { $match: { target_type: 'image', target_id: { $in: ids } } },
+        { $group: { _id: '$target_id', count: { $sum: 1 }, visitors: { $addToSet: '$visitor_id' } } },
+      ]).toArray();
+      for (const ld of likeDocs) likesMap[ld._id] = { count: ld.count, liked: visitorId ? ld.visitors.includes(visitorId) : false };
+    } catch { /* non-critical */ }
+  }
+  const illus = illusDocs.map(d => {
+    const key = `${d.page_id}-${d.detection_index}`;
+    return {
+      pageId: d.page_id, bookId: d.book_id, pageNumber: d.page_number, detectionIndex: d.detection_index,
+      imageUrl: d.image_url, bookTitle: d.book_title, author: d.book_author, year: d.book_year,
+      description: d.description, type: d.type, bbox: d.bbox, rotation: d.rotation,
+      extractedUrl: d.extracted_url, thumbnailUrl: d.thumbnail_url, galleryQuality: d.gallery_quality,
+      museumDescription: d.museum_description, metadata: d.metadata, source: 'illustration' as const,
+      likeCount: likesMap[key]?.count ?? 0, likedByVisitor: likesMap[key]?.liked ?? false,
+    };
+  });
+
+  // ---- interleave (space artworks ~every `gap` tiles) ----
+  const items: any[] = [];
+  let ii = 0, ai = 0;
+  const gap = arts.length > 0 ? Math.max(2, Math.round((illus.length + arts.length) / arts.length)) : Infinity;
+  for (let pos = 0; items.length < limit && (ii < illus.length || ai < arts.length); pos++) {
+    const wantArt = ai < arts.length && (pos % gap === gap - 1 || ii >= illus.length);
+    if (wantArt) items.push(arts[ai++]);
+    else if (ii < illus.length) items.push(illus[ii++]);
+    else if (ai < arts.length) items.push(arts[ai++]);
+  }
+
+  const hasMore = illusHasMore || artHasMore;
+  const total = offset + items.length + (hasMore ? limit : 0); // monotone estimate for infinite scroll
+  return { items, total };
+}

--- a/src/lib/gallery-merge.ts
+++ b/src/lib/gallery-merge.ts
@@ -59,6 +59,16 @@ export async function mergedGalleryBrowse(
   } = opts;
   const tenant = tenantId ? { tenantId } : {};
   const pageIndex = Math.floor(offset / Math.max(1, limit));
+  // The natural-aspect masonry shows full pages, so raise the quality floor for
+  // the merged browse — blank/low-content plates the old square crop hid now
+  // read as empty tiles. (Explicit type/quality filters still honor the request.)
+  const qFloor = imageType ? minQuality : Math.max(minQuality, 0.82);
+  // Artworks must actually have an image, else they render as blank tiles.
+  const artHasImage = { $or: [
+    { image_display: { $nin: [null, ''] } },
+    { image_full: { $nin: [null, ''] } },
+    { image_thumb: { $nin: [null, ''] } },
+  ] };
 
   const artPerPage = source === 'artwork' ? limit : Math.max(1, Math.round(limit * 0.25));
   const illusPerPage = source === 'artwork' ? 0 : limit - artPerPage;
@@ -68,7 +78,7 @@ export async function mergedGalleryBrowse(
   let illusHasMore = false;
   if (illusPerPage > 0) {
     const f: Record<string, unknown> = {
-      ...tenant, gallery_quality: { $gte: minQuality }, book_visible: true,
+      ...tenant, gallery_quality: { $gte: qFloor }, book_visible: true,
       extracted_url: { $ne: null }, image_url: { $ne: null },
     };
     if (maxPerBook < 100) f.book_rank = { $lte: maxPerBook };
@@ -88,7 +98,7 @@ export async function mergedGalleryBrowse(
   }
 
   // ---- artworks (allowDiskUse guards the sort on the 26k-row artwork set) ----
-  const af: Record<string, unknown> = { ...tenant, content_type: 'artwork', visible: true };
+  const af: Record<string, unknown> = { ...tenant, content_type: 'artwork', visible: true, ...artHasImage };
   if (imageType) af.resource_type = imageType;
   if (yearStart !== null || yearEnd !== null) {
     const y: Record<string, number> = {};
@@ -149,7 +159,7 @@ export async function mergedGalleryBrowse(
   if (illusPerPage > 0) {
     if (imageType || yearStart !== null || yearEnd !== null) {
       const cf: Record<string, unknown> = {
-        ...tenant, gallery_quality: { $gte: minQuality }, book_visible: true,
+        ...tenant, gallery_quality: { $gte: qFloor }, book_visible: true,
         extracted_url: { $ne: null }, image_url: { $ne: null },
       };
       if (maxPerBook < 100) cf.book_rank = { $lte: maxPerBook };


### PR DESCRIPTION
## What
The `/gallery` now shows **both** book illustrations ("plates", from `gallery_images`) **and** standalone artworks (`books`, `content_type:'artwork'`) in one merged feed, with a **Source** facet (Everything / Plates / Artworks). Also **aligns the gallery to the site-standard container** (`--container-wide`, 1500px — matching the navbar) instead of full-bleed.

## How
- **API** (`src/app/api/gallery/route.ts`): a new `mergedGalleryBrowse()` runs **only for the unscoped browse** (no single-book / search / collection / metadata-facet). All those existing paths are untouched and stay illustration-only. Artworks are normalized to the `GalleryItem` shape and interleaved (~25%, clearly visible).
- **Tile** (`GalleryCard`): branches the image accessor (artworks use `image_display`/`image_thumb`, no bbox crop) and the link (`/book/<slug>`), with a small **"Artwork"** badge.
- **Facet**: `source` wired through the api-client + client fetch/load-more; default `all` (merged).
- **Container**: gallery content, loading shell, and footer all use `--container-wide` + `px-6 md:px-12`.

## Test on the preview
- `/gallery` → mixed grid; artwork tiles carry an "Artwork" badge and link to `/book/<slug>`; plates link to the image viewer.
- Filter panel → **Show: Everything / Plates / Artworks** narrows the source.
- Width should now line up with the navbar (not wider).

## Scope / caveats (deliberate)
- Merge applies to the **plain browse only** — collection/library/search/single-book gallery views stay illustration-only for now.
- First paint is illustration-only (SSR), then the merged feed loads on mount (brief flash). Can be made SSR-merged later.
- Interleave is a fixed ~25% (presentational, easily tuned); ordering is quality-first illustrations + chronological artworks.
- Artworks without `image_thumb` fall back to the full `image_display` in the grid (slightly heavier thumbnails).

## Risk
Type-checks clean. No prod deploy. No schema changes. Existing gallery paths unchanged when `source` is absent on a scoped request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)