### PR TITLE
catalog: search on Enter/button instead of live-as-you-type

### DIFF
--- a/src/components/catalog/CatalogBrowser.tsx
+++ b/src/components/catalog/CatalogBrowser.tsx
@@ -53,7 +53,8 @@ export default function CatalogBrowser({ initialBooks, initialTotal, languages, 
   const [loading, setLoading] = useState(false);
   const [sort, setSort] = useState('popular');
   const [language, setLanguage] = useState('');
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState('');        // committed query (drives fetch/URL)
+  const [searchInput, setSearchInput] = useState(''); // typed text, committed on submit
   const [collection, setCollection] = useState(initialCollection || '');
   const [currentPage, setCurrentPage] = useState(1);
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
@@ -123,6 +124,7 @@ export default function CatalogBrowser({ initialBooks, initialTotal, languages, 
     setSort(urlSort);
     setLanguage(urlLang);
     setQuery(urlQ);
+    setSearchInput(urlQ);
     setCurrentPage(urlPage);
     setViewMode(urlView || storedView || 'grid');
 
@@ -167,15 +169,24 @@ export default function CatalogBrowser({ initialBooks, initialTotal, languages, 
     fetchBooks({ sort, language, query, page: 1 });
   }, [sort, language, query, viewMode, updateUrl, fetchBooks]);
 
-  const handleSearch = useCallback((value: string) => {
-    setQuery(value);
-    setCurrentPage(1);
-    // Debounce API call
+  // Search runs only on Enter / the Search button — no live-as-you-type.
+  const submitSearch = useCallback(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      updateUrl(sort, language, 1, value, viewMode);
-      fetchBooks({ sort, language, query: value, page: 1 });
-    }, 300);
+    const q = searchInput.trim();
+    setQuery(q);
+    setCurrentPage(1);
+    updateUrl(sort, language, 1, q, viewMode);
+    fetchBooks({ sort, language, query: q, page: 1 });
+  }, [searchInput, sort, language, viewMode, updateUrl, fetchBooks]);
+
+  const clearSearch = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setSearchInput('');
+    setQuery('');
+    setCurrentPage(1);
+    updateUrl(sort, language, 1, '', viewMode);
+    fetchBooks({ sort, language, query: '', page: 1 });
+    searchRef.current?.focus();
   }, [sort, language, viewMode, updateUrl, fetchBooks]);
 
   const handlePage = useCallback((page: number) => {
@@ -193,33 +204,34 @@ export default function CatalogBrowser({ initialBooks, initialTotal, languages, 
 
   return (
     <div>
-      {/* Search bar — prominent */}
-      <div className="relative mb-6">
-        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted" />
+      {/* Search bar — prominent. Searches on Enter / the Search button only. */}
+      <form onSubmit={e => { e.preventDefault(); submitSearch(); }} className="relative mb-6">
+        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted pointer-events-none" />
         <input
           ref={searchRef}
           type="text"
-          value={query}
-          onChange={e => handleSearch(e.target.value)}
+          value={searchInput}
+          onChange={e => setSearchInput(e.target.value)}
           placeholder="Search titles and authors..."
-          className="w-full text-base border border-border-light rounded-xl pl-12 pr-10 py-3 bg-white text-primary placeholder:text-muted/50 focus:outline-none focus:border-accent-rust focus:ring-1 focus:ring-accent-rust/20"
+          className="w-full text-base border border-border-light rounded-xl pl-12 pr-[9.5rem] py-3 bg-white text-primary placeholder:text-muted/50 focus:outline-none focus:border-accent-rust focus:ring-1 focus:ring-accent-rust/20"
         />
-        {query && (
+        {searchInput && (
           <button
-            onClick={() => {
-              setQuery('');
-              setCurrentPage(1);
-              if (debounceRef.current) clearTimeout(debounceRef.current);
-              updateUrl(sort, language, 1, '', viewMode);
-              fetchBooks({ sort, language, query: '', page: 1 });
-              searchRef.current?.focus();
-            }}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-primary cursor-pointer"
+            type="button"
+            onClick={clearSearch}
+            className="absolute right-[6.75rem] top-1/2 -translate-y-1/2 text-muted hover:text-primary cursor-pointer"
+            aria-label="Clear search"
           >
             <X className="w-5 h-5" />
           </button>
         )}
-      </div>
+        <button
+          type="submit"
+          className="absolute right-0 top-0 bottom-0 px-6 text-sm font-medium bg-accent-rust text-white rounded-r-xl hover:bg-accent-rust/90 transition-colors"
+        >
+          Search
+        </button>
+      </form>
 
       {/* Controls */}
       <div className="flex flex-wrap items-center justify-between gap-4 mb-6">


### PR DESCRIPTION
## What

The catalogue search box now fetches **only when the user presses Enter or clicks the Search button**, instead of firing a debounced request on every keystroke. This matches the gallery's search behaviour (shipped in #2877).

## Why

Live-as-you-type search fires a request mid-word, reorders results while the user is still typing, and burns API calls. An explicit trigger is calmer and cheaper.

## How

- Decouple typed text (`searchInput`) from the committed query (`query`). Only `query` drives the fetch and the URL.
- `submitSearch()` commits `searchInput.trim()` → `query`, resets to page 1, updates the URL, and fetches.
- Form `onSubmit` (Enter) and a full-height **Search** button both call `submitSearch`.
- The **X** clear button resets both states and refetches the unfiltered list.
- `searchInput` initialises from `?q=` on mount so deep links still populate the box.

Type-checks clean; no behaviour change to sort/language/collection/pagination (they still read the committed `query`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)