### PR TITLE
fix(reader): complete the mobile page-flip fix (data-reader-section + gating)

### DIFF
--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -16,27 +16,27 @@ interface PageEditorClientProps {
   initialPageList: Page[];
 }
 
-// Which reader panel ('image' | 'ocr' | 'translation') is currently filling the
-// viewport? Returns the panel whose box straddles the viewport's vertical centre,
-// else the nearest one. Used to keep a mobile reader in the same panel across a
-// page flip. Returns null when no panels are mounted.
-function getActiveReaderPanel(): string | null {
-  const panels = Array.from(
-    document.querySelectorAll<HTMLElement>('[data-reader-panel]')
+// Which reader section ('image' | 'ocr' | 'translation') is currently filling the
+// viewport? Returns the section whose box straddles the viewport's vertical centre,
+// else the nearest one. Used to keep a mobile reader in the same section across a
+// page flip. Returns null when no sections are mounted.
+function getActiveReaderSection(): string | null {
+  const sections = Array.from(
+    document.querySelectorAll<HTMLElement>('[data-reader-section]')
   );
-  if (panels.length === 0) return null;
+  if (sections.length === 0) return null;
   const center = window.innerHeight / 2;
   let best: string | null = null;
   let bestDist = Infinity;
-  for (const el of panels) {
+  for (const el of sections) {
     const r = el.getBoundingClientRect();
     if (r.top <= center && r.bottom >= center) {
-      return el.dataset.readerPanel ?? null;
+      return el.dataset.readerSection ?? null;
     }
     const dist = Math.min(Math.abs(r.top - center), Math.abs(r.bottom - center));
     if (dist < bestDist) {
       bestDist = dist;
-      best = el.dataset.readerPanel ?? null;
+      best = el.dataset.readerSection ?? null;
     }
   }
   return best;
@@ -249,7 +249,7 @@ export default function PageEditorClient({
     // same panel of the new page. (Reader feedback: "going to the next page from
     // the OCR or translation should take you to the same part of the next page.")
     const isMobile = window.innerWidth < 1024;
-    const activePanel = isMobile ? getActiveReaderPanel() : null;
+    const activeSection = isMobile ? (getActiveReaderSection() || 'image') : null;
 
     setCurrentPageId(newPageId);
     // Build URL with supported query params (version pinning)
@@ -258,18 +258,18 @@ export default function PageEditorClient({
     const suffix = newParams.toString() ? `?${newParams.toString()}` : '';
     window.history.pushState(null, '', `${tenantPrefix}/book/${book.id}/page/${newPageId}${suffix}`);
 
-    if (isMobile && activePanel && activePanel !== 'image') {
-      // Keep the reader in the text panel they were reading, at its top. The
-      // panel <div>s persist across the page swap (only their content changes),
-      // so the same selector resolves on the new page. rAF lets the swap settle.
-      requestAnimationFrame(() => {
-        const el = document.querySelector(`[data-reader-panel="${activePanel}"]`);
+    if (isMobile) {
+      // Land on the same section the reader was in (image / OCR / translation),
+      // at its top. The section <div>s persist across the page swap (only their
+      // content changes), so the same selector resolves on the new page. Two rAFs
+      // wait for the swap + the child's content render before measuring/scrolling.
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        const el = document.querySelector(`[data-reader-section="${activeSection}"]`);
         if (el) el.scrollIntoView({ behavior: 'instant', block: 'start' });
         else window.scrollTo({ top: 0, behavior: 'instant' });
-      });
+      }));
     } else {
-      // Desktop, or a reader who was looking at the scan: go to the top so the
-      // next page's image is in view.
+      // Desktop: go to the top.
       window.scrollTo({ top: 0, behavior: 'instant' });
     }
 

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -857,11 +857,17 @@ export default function TranslationEditor({
     setModernizedText(page.modernized?.data || null);
     lastSavedRef.current = { ocr, translation, summary };
     setSaveStatus('idle');
-    // Reset scroll on all content panels and the outer panel container (mobile stacked layout)
+    // Reset each content panel's internal scroll (desktop: panels scroll independently).
     document.querySelectorAll('[data-reader-panel]').forEach(el => {
       el.scrollTop = 0;
     });
-    document.querySelector('[data-reader-panels-container]')?.scrollTo(0, 0);
+    // On mobile the stacked panels share one outer scroller, and PageEditorClient
+    // positions it so the reader stays in the panel they were reading across a
+    // flip — don't reset it to the top here or the two fight. Desktop keeps the
+    // top-reset (panels are side-by-side, overflow hidden).
+    if (typeof window !== 'undefined' && window.innerWidth >= 1024) {
+      document.querySelector('[data-reader-panels-container]')?.scrollTo(0, 0);
+    }
   }, [page]);
 
   // Toggle modernized mode and persist to localStorage
@@ -1359,7 +1365,7 @@ export default function TranslationEditor({
             >
               {/* Source Image Panel */}
               {showImagePanel && (
-                <div data-reader-panel="image" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1 relative`} style={{ background: 'var(--bg-warm)', borderRight: '1px solid var(--border-light)' }}>
+                <div data-reader-section="image" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1 relative`} style={{ background: 'var(--bg-warm)', borderRight: '1px solid var(--border-light)' }}>
                   <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
                       {!pageDisplayUrl && hasWitnessPhotos ? 'Tablet Photo' : 'Source Image'}
@@ -1502,7 +1508,7 @@ export default function TranslationEditor({
 
               {/* OCR Panel */}
               {showOcrPanel && (
-                <div id="reader-text" data-reader-panel="ocr" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-cream)', borderRight: '1px solid var(--border-light)' }}>
+                <div id="reader-text" data-reader-section="ocr" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-cream)', borderRight: '1px solid var(--border-light)' }}>
                   <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
@@ -1665,7 +1671,7 @@ export default function TranslationEditor({
 
               {/* Translation Panel — suppressed for English-source books (OCR is the reading view) */}
               {showTranslationPanel && !isEnglishSource && (
-                <div id={showOcrPanel ? undefined : 'reader-text'} data-reader-panel="translation" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-white)' }}>
+                <div id={showOcrPanel ? undefined : 'reader-text'} data-reader-section="translation" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-white)' }}>
                   <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>


### PR DESCRIPTION
Follow-up to #2890. That PR merged only the first commit of the work — the second commit (which fixes a real collision bug) was committed locally but never pushed before the PR opened, so main shipped a half-version.

## What this adds (on top of #2890)

- **Rename the section markers `data-reader-panel` → `data-reader-section`.** #2890's markers collided with a pre-existing boolean `data-reader-panel` on the inner scroll divs, so the active-section detector could resolve to the wrong (inner) element.
- **Gate the outer-container scroll reset to desktop**, so the mobile same-section landing isn't immediately reset to the top.
- **Double-rAF the post-nav scroll** so the new page renders before we measure/scroll.

## Verified

Cherry-picked cleanly onto current main; sibling reader features (Leave comment, Tell Derek, login-gated requests) untouched. Re-tested on a Vercel preview under mobile emulation: reading translation → flip (button + swipe) lands at the translation top; reading the scan → flip lands at the image top; desktop resets to top. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)