### PR TITLE
fix(ft): exclude contaminated discovery harvest from Tier-0 catalog matching

### DIFF
--- a/scripts/eval/ft-catalog-match.mjs
+++ b/scripts/eval/ft-catalog-match.mjs
@@ -259,9 +259,17 @@ async function main() {
       .toArray();
     console.log(`Loaded ${books.length} badged books.`);
 
+    // EXCLUDE the contaminated discovery harvest (2026-06-30). 302 rows carry
+    // `source: ft_verification_discovery` — unverified Gemini discovery-pass
+    // output (all url-less, often fabricated, e.g. "Madame Dupin" translating a
+    // 1494 Latin Kabbalistic work). They are NOT real catalog records, and
+    // trusting them as a `found_refs` prior produces FALSE DEMOTES (this matcher
+    // flagged Reuchlin's De Verbo Mirifico off one). A Tier-0 demote must rest on
+    // a real curated catalogue, never a discovery hallucination. (#2885; sibling
+    // of the discovery-cron guard #2892.)
     const catRows = await db
       .collection('translation_catalogs')
-      .find({})
+      .find({ source: { $ne: 'ft_verification_discovery' } })
       .project({
         _id: 1, source: 1, author: 1, author_normalized: 1, author_surname: 1,
         canonical_author: 1, canonical_author_normalized: 1,


### PR DESCRIPTION
Sibling of #2892 — seals the *other* path the discovery contamination flows through.

**Problem:** the registry/Tier-0 matcher (`ft-catalog-match.mjs`) trusted 302 `source: ft_verification_discovery` rows in `translation_catalogs` — unverified, url-less, often-fabricated Gemini discovery output (e.g. "Madame Dupin" translating Reuchlin's 1494 Latin *De Verbo Mirifico*). Matching a badged first to one as a `found_refs` prior = a **false demote** (this is how Reuchlin got flagged).

**Fix:** exclude `source: ft_verification_discovery` from the catalog candidate query. **Verified:** catalog rows 24,040 → 23,738; demote candidates **1 → 0** (the Reuchlin false demote disappears). No spend, no prod deploy (scripts/**, Hetzner auto-pull).

**Follow-ups (not here):** the 302 rows still sit in `translation_catalogs` (now ignored by this matcher; should be quarantined/removed with a backup — needs confirmation, no batch-delete); the 1 stale Reuchlin `ft-catalog-match` attempt in the ledger is cleaned separately. Root cause logged on #2885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)