### PR TITLE
fix(books): purge Cloudflare cache on admin book edits (cover changes now show)

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -10,6 +10,7 @@ import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { mirrorBookToCatalog } from '@/lib/books-catalog';
 import { COVER_WRITE_FIELDS } from '@/lib/cover-fields';
+import { purgeCloudflareUrls } from '@/lib/cloudflare-cache';
 
 export const preferredRegion = 'fra1';
 
@@ -309,9 +310,15 @@ export const PATCH = withCuratorAuth(async (request, session, context) => {
       }
     }
 
-    // Revalidate book page for any field change (pages are statically cached)
+    // Revalidate book page for any field change (pages are statically cached).
+    // revalidatePath alone is NOT enough: /book/* HTML is also held at the
+    // Cloudflare edge for 24h (CDN-Cache-Control), so an admin cover/title edit
+    // stays invisible for up to a day and reads as "changing the cover isn't
+    // working" (feedback, 2026-06-22). Mirror what /api/admin/revalidate-book
+    // does — revalidatePath + an explicit Cloudflare purge of the same paths.
     const bookSlug = book.slug || bookId;
     if (changedFields.length > 0) {
+      const purgePaths: string[] = [`/book/${bookSlug}`, `/book/${bookId}`];
       revalidatePath(`/book/${bookSlug}`);
       revalidatePath(`/book/${bookSlug}`, 'layout');
       revalidatePath(`/book/${bookId}`);
@@ -325,11 +332,30 @@ export const PATCH = withCuratorAuth(async (request, session, context) => {
           revalidatePath(`/${tenant.slug}/book/${bookSlug}`);
           revalidatePath(`/${tenant.slug}/book/${bookSlug}`, 'layout');
           revalidatePath(`/${tenant.slug}/book/${bookId}`);
+          // Tenant subdomains route to /embed/[tenant]/book/[slug] via proxy.ts.
+          revalidatePath(`/embed/${tenant.slug}/book/${bookSlug}`);
+          revalidatePath(`/embed/${tenant.slug}/book/${bookSlug}`, 'layout');
+          revalidatePath(`/embed/${tenant.slug}/book/${bookId}`);
+          purgePaths.push(
+            `/${tenant.slug}/book/${bookSlug}`,
+            `/${tenant.slug}/book/${bookId}`,
+            `/embed/${tenant.slug}/book/${bookSlug}`,
+            `/embed/${tenant.slug}/book/${bookId}`,
+          );
         }
       }
       // Thumbnail/title changes also affect listing pages (home, collections, search)
-      if (changedFields.some(f => ['thumbnail', 'thumbnail_blob', 'title', 'display_title', 'author'].includes(f))) {
+      if (changedFields.some(f => ['thumbnail', 'thumbnail_blob', 'image_display', 'image_thumb', 'title', 'display_title', 'author'].includes(f))) {
         revalidatePath('/', 'layout');
+        purgePaths.push('/');
+      }
+      // Bust the Cloudflare edge HTML cache too (best-effort; never block the
+      // response on it). Without this the revalidatePath above is shadowed by
+      // the 24h CDN cache and the edit looks like it did nothing.
+      try {
+        await purgeCloudflareUrls(purgePaths);
+      } catch (err) {
+        console.error('Cloudflare purge after book update failed (non-fatal):', err);
       }
     }
 

--- a/src/components/book/CoverImagePicker.tsx
+++ b/src/components/book/CoverImagePicker.tsx
@@ -31,6 +31,7 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
   const embed = useEmbed();
   const [isOpen, setIsOpen] = useState(false);
   const [saving, setSaving] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [displayThumbnail, setDisplayThumbnail] = useState(currentThumbnail || currentThumbnailBlob);
   const [thumbnailError, setThumbnailError] = useState(false);
 
@@ -57,6 +58,7 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
 
   const selectCover = async (page: Page) => {
     setSaving(page.id);
+    setSaveError(null);
     try {
       const update = buildCoverUpdate(page, {
         source: 'manual',
@@ -66,6 +68,7 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
       });
       if (!update) {
         console.error('Cover Picker: page has no usable image URL', page);
+        setSaveError('That page has no usable image to use as a cover.');
         return;
       }
       await books.update(bookId, update as unknown as Record<string, unknown>);
@@ -73,7 +76,11 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
       setIsOpen(false);
       router.refresh();
     } catch (error) {
+      // Surface the failure instead of silently doing nothing — the picker used
+      // to swallow every error, which is how a failed save read as "changing the
+      // cover isn't working" with no clue why.
       console.error('Error setting cover:', error);
+      setSaveError(error instanceof Error ? error.message : 'Could not save the cover. Please try again.');
     } finally {
       setSaving(null);
     }
@@ -157,6 +164,12 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
                 <X className="w-5 h-5" aria-hidden="true" />
               </button>
             </div>
+
+            {saveError && (
+              <div role="alert" className="mx-4 mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                {saveError}
+              </div>
+            )}
 
             {/* Pages Grid */}
             <div className="p-4 overflow-y-auto max-h-[calc(85vh-80px)]">


### PR DESCRIPTION
## Why
Feedback (Derek, 2026-06-22): *"Changing cover isn't working"* on /book/on-the-triple-anatomy-fludd.

Investigated: the cover change **did** persist — the audit log shows the PATCH wrote all canonical cover fields (image_display/image_thumb/thumbnail/thumbnail_blob/cover_page) and the DB is consistent (cover = page 7, source 'manual'). The problem was purely **cache**: `/book/*` HTML is held at the Cloudflare edge for 24h (CDN-Cache-Control), and `PATCH /api/books/[id]` only called `revalidatePath` — which doesn't clear that. So the edit was invisible for up to a day. (Prod now shows page 7, i.e. it eventually took once the TTL expired.)

## What
- `PATCH /api/books/[id]` now also calls `purgeCloudflareUrls()` for the book paths — exactly what `/api/admin/revalidate-book` already does. Covers tenant + `/embed/[tenant]` variants, and `/` for thumbnail/title changes. Best-effort, never blocks the response, no-ops without the CF token.
- Cover picker now **surfaces save errors** instead of swallowing them (`selectCover` previously logged to console and showed nothing — a failed save looked identical to 'nothing happened').

## Out of scope
The `isCurrentCover` highlight in the picker compares mismatched URL shapes (canonical `image_display` vs `archived_photo`) so the current cover rarely shows its checkmark — noted, left for a separate small PR.

## Testing
`tsc` clean. Purge path mirrors the proven `revalidate-book` flow. Verified the DB write was already correct (audit log + direct read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)