### PR TITLE
fix(artwork): 404 hidden artworks on the public /artwork route

### DIFF
--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { Book } from '@/lib/types';
 import SiteHeader from '@/components/layout/SiteHeader';
 import ArtworkInfo from '@/components/artwork/ArtworkInfo';
+import { isHiddenBook } from '@/lib/book-access';
 
 export const revalidate = false;
 export const dynamicParams = true;
@@ -22,6 +23,12 @@ async function getArtwork(slug: string) {
     { slug: { $in: slugsToTry }, resource_type: { $exists: true }, content_type: { $ne: 'book' } },
   );
   if (!artwork) return null;
+  // Hidden (visible:false) artworks are not public — mirror the /book route's
+  // gate. The main lookup above had no visibility filter, so a hidden artwork
+  // rendered fully via a direct /artwork/<slug> URL even though it's excluded
+  // from search/gallery (hidden-readpath-gate invariant; this is how Julika's
+  // "searched toltec → clicked → error" hit a record that should never resolve).
+  if (isHiddenBook(artwork)) return null;
 
   // Get collections this artwork belongs to
   const collectionSlugs = (artwork.collections as string[]) || [];


### PR DESCRIPTION
## Why
Feedback (Julika, 2026-06-21): searched *toltec*, clicked the one hit (`/book/art-eagle-relief-toltec-temple`), got an error.

That record is an **artwork** (`content_type: artwork`, `resource_type: sculpture`) that is **hidden** (`visible:false`). The `/book` route correctly soft-404s it — but `/artwork/<slug>` rendered it fully, because the artwork lookup had **no visibility filter**. So hidden artworks (11,691 of 26,392) were publicly viewable by direct URL even though they're excluded from search and the gallery — a hidden-readpath-gate leak.

## What
Gate `getArtwork()` with `isHiddenBook()` (`visible === false`), mirroring the `/book` route. Hidden artworks now 404 consistently. `generateMetadata` shares `getArtwork`, so metadata is gated too. Visible and visible-unset artworks are unaffected (the gate keys only on explicit `visible:false`, matching the canonical helper).

## Note (not in scope)
Whether *this specific* sculpture should be **made visible** is a curation call, not a code fix — flagged to Derek separately. This PR only stops hidden artworks from leaking; it doesn't change what's hidden.

## Testing
`tsc` clean. Gate matches `isHiddenBook` used across the book read-path (PR #2522).

🤖 Generated with [Claude Code](https://claude.com/claude-code)