### PR TITLE
gallery: fix Load More re-fetching the same page on short feeds

### DIFF
--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -207,7 +207,14 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
         });
         setData(json);
         setAllItems(json.items);
-        setCurrentOffset(json.items.length);
+        // Paginate by page boundary, NOT cumulative item count. The merged
+        // browse derives its page from `floor(offset / limit)`, so the next
+        // offset must be a clean multiple of `limit`. Tracking the running
+        // item count desynced whenever a page returned < limit items (e.g. a
+        // type filter where artworks don't contribute → 36/page), which made
+        // `floor(36/limit)` re-fetch page 0 → Load More showed duplicates or
+        // appeared to do nothing.
+        setCurrentOffset(limit);
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Failed to load gallery');
       } finally {
@@ -240,8 +247,15 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
         source: sourceFilter !== 'all' ? (sourceFilter as 'illustration' | 'artwork') : undefined,
         visitorId: identity.id || undefined,
       });
-      setAllItems(prev => [...prev, ...json.items]);
-      setCurrentOffset(prev => prev + json.items.length);
+      // Advance by a full page (see initial-fetch note). Dedup on append is a
+      // belt-and-suspenders guard against any residual overlap (e.g. the
+      // search path prepends one-off "lead" artworks on page 0).
+      setAllItems(prev => {
+        const seen = new Set(prev.map(it => `${it.pageId}-${it.detectionIndex}`));
+        const fresh = json.items.filter((it: GalleryItem) => !seen.has(`${it.pageId}-${it.detectionIndex}`));
+        return [...prev, ...fresh];
+      });
+      setCurrentOffset(prev => prev + limit);
       // Keep filters/total from the response
       if (json.total) {
         setData(prev => prev ? { ...prev, total: json.total } : json);


### PR DESCRIPTION
## The bug
On the gallery page, **Load More doesn't always work** — sometimes it shows duplicates, sometimes nothing new appears.

## Root cause
The merged gallery browse derives its page from `floor(offset / limit)`, but the client advanced `offset` by the **running item count**. Those agree only when every page returns *exactly* `limit` (48) items.

The merged feed returns fewer whenever artworks don't contribute to a page — e.g. **any type filter** (`type=woodcut` → 36 illustrations + 0 artworks per page). After a 36-item page the client sent `offset=36`; the server computed `floor(36/48)=0` and returned **page 0 again**. Hence duplicates / no progress. Intermittent → "doesn't always work."

## Fix
Paginate by **page boundary** (`offset = page * limit`) so the client always aligns with the server's `floor(offset/limit)`. Plus dedup-on-append as a guard against the search path's one-off page-0 "lead" artworks.

## Verification (against prod API)
| offsets sent | overlap | result |
|---|---|---|
| page-based 0, 48 (`type=woodcut`) | **0** | distinct pages ✓ |
| old cumulative 0, 36 | **36/36** | full duplicate of page 0 ✗ |

Type-checks clean. No server change — purely the client's offset bookkeeping.

## Out of scope
- The merged `total` is an estimate that fluctuates slightly between requests (cosmetic count wobble); not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)