### PR TITLE
feat(ft): expand non-Latin Tier-0 seed to the PD canon + measure the canon-grounding premise (#2901)

### DIFF
--- a/.claude/docs/ft-tier0-nonlatin-catalog.md
+++ b/.claude/docs/ft-tier0-nonlatin-catalog.md
@@ -103,13 +103,52 @@ Note: most seed-matched works aren't *currently* FT-badged, so immediate badged-
 book impact is small; the value is the proven mechanism + correct priors for
 future FT decisions on these works.
 
-## Recommended follow-up (to cover the canon at scale)
-The anonymity + cross-script blockers above need a **cross-lingual work-identity**
-layer, not more fuzzy author/title rows:
-- Give the Tibetan/Sanskrit/Chinese canon books **external work ids** (BDRC for
-  84000/Kangyur-Tengyur; Wikidata QIDs elsewhere), then key a work-id-anchored
-  Tier-0 path off those — deterministic, no surname/title fuzz. This is the
-  natural extension of the work-identity system (`work-identity-coverage.md`,
-  #2318) and the only thing that unlocks 84000's 727 anonymous published sūtras.
-- Expand the named-author seed (Murty/Clay/AITM series; more SBE volumes) where
-  the author appears in Latin script in our corpus.
+## Round 2 (2026-06-30, #2901): canon-grounding is EMPTY for our holdings
+The "give the canon external work-ids → work-id-anchored Tier-0" idea (below) was
+tested before building it, and the premise does not hold **for what we actually
+hold**:
+- **84000 ↔ our Tibetan corpus: ZERO overlap.** Parsed 480 published 84000 texts
+  (CC0 RDF) and token-matched (Sanskrit-IAST + English titles) against all 1,470
+  visible/translated Tibetan books → **0 hits**. Our Tibetan corpus is indigenous
+  Tibetan literature (Nyingma termas, Milarepa songs, Tsongkhapa/lamrim treatises),
+  NOT the Kangyur/Tengyur sūtras 84000 translates. We don't hold those sūtras, so a
+  prior-catalog of them can't match anything.
+- **External work-ids are ~absent on the non-Latin corpus**: of 3,998 visible/
+  translated non-Latin books, only **194 (5%)** carry a Wikidata QID (179 Greek +
+  15 Sanskrit — already from the classical resolver); **3,743 (94%)** carry
+  internal `local:` slugs that join to nothing external.
+- **General lesson**: a prior-translation catalog's value = overlap between {works
+  it says have English} and {works we hold and badge FT}. Our corpus is *selected*
+  for untranslated/obscure material, so external "complete English exists" catalogs
+  structurally MISS it — which is the CORRECT answer (those books genuinely ARE
+  firsts). Building the BDRC/84000 pipeline would have produced ~0 matches.
+
+So the only lever that pays off is the **named-author famous-work seed**, expanded
+to the full public-domain canon (18 rows: + Mahābhārata/Ganguli, Rāmāyaṇa/Griffith,
+Arthaśāstra/Shamasastry, Kāma Sūtra/Burton, Mencius/Sunzi/I-Ching/Legge-Giles,
+Milinda/Rhys Davids (pli), Tirukkural/Pope (ta)). Across ALL non-Latin a broad
+author scan finds only **7 famous-author FT badges total** — confirming the corpus
+is overwhelmingly genuine firsts.
+
+### The "famous base text + classical commentary" pattern (route-to-human)
+The two LIVE famous-work FT badges are both *text + named commentary* editions:
+- **老子元翼** (Jiao Hong's 64-commentary anthology of the Daodejing) — base text
+  Englished since Chalmers 1868/Legge 1891.
+- **Tirukkural with Parimelazagar commentary** — base text Englished since
+  Pope 1886; the *commentary* is Tamil-only even in our own Lazarus 1885 holding,
+  so a narrow "first complete English of the Parimelazagar commentary" claim is
+  plausible (one ambiguous 1955 prior unresolved).
+In both, the badge MISLEADS as catalogued (titled as the famous base text) but a
+narrow commentary-first claim may be genuine. **Decision (Derek, 2026-06-30): KEEP
+the badge + reframe the metadata** to foreground the commentary (recorded in each
+book's `translation_verification.ft_reframe_needed_2026_06_30`; evidence in
+`scripts/output/ft-evidence-2026-06-30/commentary-edition-ft-verify-2026-06-30.json`).
+This is the FT runbook's "route famous-adjacent works to a human specialist" case.
+
+## Superseded follow-up (kept for the record — do NOT build the 84000 path)
+The anonymity + cross-script blockers suggested a cross-lingual work-identity
+layer (BDRC for 84000, Wikidata elsewhere). Round 2 above shows this yields ~0 for
+our holdings — **do not build it for Tier-0 prior-matching.** (Work-ids are still
+worth pursuing for OTHER reasons — clustering, dedup — under #2318, just not as a
+Tier-0 prior-catalog lever.) Expanding the named-author seed where the author
+appears in Latin script remains the only productive direction.

--- a/scripts/import/build-nonlatin-catalog-seed.mjs
+++ b/scripts/import/build-nonlatin-catalog-seed.mjs
@@ -77,7 +77,59 @@ const SANSKRIT = [
     translator: 'Kenneth K. Inada', pub_year: 1970, publisher: 'Hokuseido Press',
     source: 'scholarly_complete', source_url: 'https://www.worldcat.org/title/nagarjuna/oclc/137109',
   },
+  // ── Epics & classical treatises with genuinely COMPLETE public-domain English ──
+  {
+    author: 'Vyasa', canonical_work: 'Mahabharata Maha Bharata',
+    english_title: 'The Mahabharata of Krishna-Dwaipayana Vyasa (complete, 12 vols)',
+    translator: 'Kisari Mohan Ganguli', pub_year: 1896, publisher: 'Bharata Press',
+    source: 'scholarly_pd', source_url: 'https://archive.org/details/mahabharata01ramauoft',
+  },
+  {
+    author: 'Valmiki', canonical_work: 'Ramayana Ramayan',
+    english_title: 'The Rámáyan of Válmíki (complete, 5 vols)',
+    translator: 'Ralph T. H. Griffith', pub_year: 1874, publisher: 'Trübner & Co.',
+    source: 'scholarly_pd', source_url: 'https://archive.org/details/rmyanofvlmki01valm',
+  },
+  {
+    author: 'Kautilya', canonical_work: 'Arthashastra Arthasastra Kautilya',
+    english_title: "Kautilya's Arthaśāstra",
+    translator: 'R. Shamasastry', pub_year: 1915, publisher: 'Government Press, Bangalore',
+    source: 'scholarly_pd', source_url: 'https://archive.org/details/arthasastra00kautuoft',
+  },
+  {
+    author: 'Vatsyayana', canonical_work: 'Kama Sutra Kamasutra',
+    english_title: 'The Kama Sutra of Vatsyayana',
+    translator: 'Richard Burton & F. F. Arbuthnot', pub_year: 1883, publisher: 'Kama Shastra Society',
+    source: 'scholarly_pd', source_url: 'https://archive.org/details/kamasutraofvatsy00vatsyaya',
+  },
 ];
+
+// ── Pali (pli) ───────────────────────────────────────────────────────────────
+const PALI = [
+  {
+    author: 'Nagasena', canonical_work: 'Milinda Panha Questions of King Milinda',
+    english_title: 'The Questions of King Milinda (complete, 2 vols, SBE 35–36)',
+    translator: 'T. W. Rhys Davids', pub_year: 1890, publisher: 'Clarendon Press (Sacred Books of the East, Vols. 35 & 36)',
+    source: 'sacred_books_east', source_url: 'https://archive.org/details/questionsofkingm01davi',
+  },
+];
+
+// ── Tamil (ta) ───────────────────────────────────────────────────────────────
+const TAMIL = [
+  {
+    author: 'Tiruvalluvar', canonical_work: 'Tirukkural Kural Thirukkural Tiruvalluvar',
+    english_title: 'The Sacred Kurral of Tiruvalluva-Nayanar',
+    translator: 'G. U. Pope', pub_year: 1886, publisher: 'W. H. Allen & Co.',
+    source: 'scholarly_pd', source_url: 'https://archive.org/details/sacredkurraloft00popeuoft',
+  },
+];
+
+// NOTE: deliberately NO Hebrew seed rows. Our Hebrew corpus is obscure Kabbalah
+// (commentaries, manuscript miscellanies, misattributions) where prior complete
+// English is genuinely scarce — verified case-by-case in #2899's ft-verify round,
+// not by catalog rows. And the one famous candidate, Maimonides' Guide for the
+// Perplexed, was written in Judeo-Arabic (source-language ambiguity), so it does
+// not belong in a Hebrew-tagged seed. Hebrew over-claims go through ft-verify.
 
 // ── Chinese (zh) ─────────────────────────────────────────────────────────────
 const CHINESE = [
@@ -99,12 +151,32 @@ const CHINESE = [
     translator: 'James Legge', pub_year: 1861, publisher: 'Trübner & Co.',
     source: 'legge_chinese_classics', source_url: 'https://archive.org/details/chineseclassics01legggoog',
   },
+  {
+    author: 'Mencius', canonical_work: 'Mencius Mengzi Meng Tzu Chinese Classics',
+    english_title: 'The Works of Mencius (The Chinese Classics, Vol. II)',
+    translator: 'James Legge', pub_year: 1861, publisher: 'Trübner & Co.',
+    source: 'legge_chinese_classics', source_url: 'https://archive.org/details/chineseclassics00legggoog',
+  },
+  {
+    author: 'Sunzi', canonical_work: 'Art of War Sunzi Sun Tzu Bingfa',
+    english_title: 'Sun Tzu on the Art of War',
+    translator: 'Lionel Giles', pub_year: 1910, publisher: 'Luzac & Co.',
+    source: 'scholarly_pd', source_url: 'https://archive.org/details/suntzuonartofwar00suntuoft',
+  },
+  {
+    author: 'Confucius', canonical_work: 'I Ching Yi Jing Book of Changes Yijing Zhouyi',
+    english_title: 'The Yî King (Book of Changes, SBE Vol. 16)',
+    translator: 'James Legge', pub_year: 1882, publisher: 'Clarendon Press (Sacred Books of the East, Vol. 16)',
+    source: 'sacred_books_east', source_url: 'https://archive.org/details/sacredbooksofch16conf',
+  },
 ];
 
 function rows() {
   const out = [];
   for (const r of SANSKRIT) out.push({ ...r, source_language: 'sa', completeness: 'complete' });
   for (const r of CHINESE) out.push({ ...r, source_language: 'zh', completeness: 'complete' });
+  for (const r of PALI) out.push({ ...r, source_language: 'pli', completeness: 'complete' });
+  for (const r of TAMIL) out.push({ ...r, source_language: 'ta', completeness: 'complete' });
   return out;
 }
 


### PR DESCRIPTION
Round 2 of the non-Latin Tier-0 work (follows #2900). Closes the investigation half of #2901.

## TL;DR
Before building the work-id-anchored canon-grounding pipeline #2901 proposed, I **measured whether it pays off — it does not for our holdings** — so this ships the lever that does: a wider famous-named-author seed.

## The measurement that killed the 84000/BDRC build
- **84000 (480 published CC0 texts) ↔ our 1,470 Tibetan books: ZERO token overlap.** Our Tibetan corpus is indigenous literature (Nyingma termas, Milarepa, Tsongkhapa/lamrim), not the Kangyur/Tengyur sūtras 84000 translates. **We don't hold those works**, so a prior-catalog of them matches nothing.
- **Only 5% of non-Latin books carry external work-ids** (194/3,998 — 179 Greek + 15 Sanskrit, already from the classical resolver). 94% have internal `local:` slugs that join to nothing external.
- **General principle:** a prior-catalog's value = overlap between {works it says have English} and {works we hold AND badge FT}. Our corpus is *selected* for untranslated material, so external "complete English exists" catalogs structurally miss it — which is the *correct* answer (those books genuinely are firsts).

## What ships
- **Seed builder expanded 9→18 rows** (`scripts/import/build-nonlatin-catalog-seed.mjs`), all genuinely-complete public-domain English: + Mahābhārata/Ganguli, Rāmāyaṇa/Griffith, Arthaśāstra/Shamasastry, Kāma Sūtra/Burton (sa); Mencius, Sun Tzu/Giles, I-Ching/Legge (zh); Questions of Milinda/Rhys Davids (pli); Tirukkural/Pope (ta). **No Hebrew rows** (obscure Kabbalah → ft-verify case-by-case; the one famous candidate, Maimonides' *Guide*, is Judeo-Arabic — wrong for a `he`-tagged seed).
- **Doc updated** (`.claude/docs/ft-tier0-nonlatin-catalog.md`) with the Round-2 findings + an explicit "do NOT build the 84000 Tier-0 path" note.
- **Data applied to prod:** 9 new seed rows (`sa:13 zh:8 pli:1 ta:1`); evidence + provenance in `first_translation_attempts` + `scripts/output/ft-evidence-2026-06-30/`.

## The only 2 live famous-work over-claims — "base text + classical commentary"
Across ALL non-Latin, only **7 famous-author FT badges exist** (corpus is overwhelmingly genuine firsts). The 2 live ones, both verified by independent Sonnet subagents:
- **老子元翼** — Jiao Hong's 64-commentary anthology of the Daodejing. Base text Englished since Chalmers 1868 / Legge 1891.
- **Tirukkural with Parimelazagar commentary** — base text Englished since Pope 1886; the commentary is Tamil-only even in our own Lazarus 1885 holding, so a narrow "first complete English of the Parimelazagar commentary" claim is plausible (one ambiguous 1955 prior unresolved).

In both, the badge **misleads as catalogued** (titled as the famous base text) but a narrow commentary-first claim may be genuine — the FT runbook's "route to human" case. **Decision (Derek): KEEP the badge + reframe the metadata** to foreground the commentary. Recorded on each book (`translation_verification.ft_reframe_needed_2026_06_30`) + tracked separately for the retitle.

## Out of scope / follow-up
- The metadata **retitle** of the 2 commentary editions (separate task — keeps the FT claim true-as-stated).
- The matcher's title-coverage threshold (0.6) misses commentary-laden titles (the Tirukkural didn't auto-match because "Parimelazagar Commentary" dilutes coverage); deliberately NOT loosened (precision over recall) — verification handled those.
- Report-only throughout; **no badges flipped** this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)