### PR TITLE
docs(ft): title/work-identity principles, the counting consequence, + proposal blog draft

### DIFF
--- a/.claude/docs/blog-first-translation-is-not-a-book-draft.md
+++ b/.claude/docs/blog-first-translation-is-not-a-book-draft.md
@@ -1,0 +1,55 @@
+# A First Translation Is Not a Book
+
+*Draft blog post. ~6 min read. Suggested tag: Research / blue. Lead image: a multi-volume spread — the Wubei Zhi (武備志) or Sancai Tuhui (三才圖會) plates. Links to /census. Numbers are from an internal audit of the live catalog (2026-06-30); re-run before publishing as they drift. A few claims flagged [verify].*
+
+---
+
+We have quoted a number, on this site and to funders and to ourselves: roughly **5,800 first English translations**. It is the number the catalog returns when you ask how many of our books carry the "First Translation" badge. I have said it out loud more than once.
+
+It is wrong. Not by a rounding error — wrong in two opposite directions at the same time, which is the most interesting way to be wrong. Chasing down *why* turned out to change how we think the whole library should be counted, and maybe how anyone should count a thing like this.
+
+## The book that is a first translation twenty times over
+
+Start with the *Wubei Zhi* (武備志), the great Ming military encyclopedia — two hundred and forty chapters on everything from naval tactics to the famous chart of Zheng He's voyages. We hold it. We translated it. It had never been in English. A real first.
+
+It is also enormous, so we hold it as many physical volumes, and each volume is its own record in our catalog, and each record earned the "First Translation" badge. So the *Wubei Zhi* — one work, one first event in the history of the world — is sitting in our headline number **more than twenty times.** The *Sancai Tuhui* (三才圖會), a Ming illustrated encyclopedia, is in there about fifty times. Huygens' collected *Œuvres* over a dozen.
+
+When we actually deduplicated — counted distinct *works* instead of distinct book records — the 5,814 badges collapsed to about **5,030 distinct works.** Nearly **800 of our "first translations" were the same handful of works, counted again and again** because they happen to be long. [verify: 784 redundant across 384 multi-volume works]
+
+## The book that hides a dozen first translations
+
+Now the other direction. Open the *Articella* — the medieval medical textbook that trained Europe's physicians for four centuries. One book, in our catalog; one badge. But it is not one work. It is a *bundle*: Hippocrates' aphorisms, Galen, the Persian physician Ḥunayn ibn Isḥāq, all bound together by a teaching tradition. If those texts had never been Englished, that single badge is hiding not one first translation but several.
+
+The catalog is full of these. "Collected Drukpa Kagyu texts." "Writings of the Chief Abbots of Bhutan." Ritual collections, manuscript miscellanies, collected works. We counted **more than 500** first-translation books that are really *containers* of many works — each one a single badge sitting on top of an unknown number of actual firsts. [verify: 515 container-signal, 305 volume-signal]
+
+So the headline is too **high** because of the long books, and too **low** because of the bundled ones, and the two errors have nothing to do with each other, so they don't cancel. We are not slightly off. We are counting the wrong kind of thing.
+
+## The realization
+
+Here is the sentence that reorganized everything for us:
+
+**A first translation is not a property of a book. It is an event — the first time a work crosses into a language.**
+
+A book is *where you go to read* that translation. It is not the unit you *count*. Once you say it that way, both errors are obvious. A work split across twenty volumes is still one crossing. A bundle of twelve never-translated works is twelve crossings wearing one cover. The book and the event were never the same thing; we just had no other handle to grab, so we grabbed the book.
+
+There is a beautiful wrinkle that proves the point. Take the *Laozi Yuanyi* (老子元翼), a Ming scholar's anthology of sixty-four classic commentaries on the *Tao Te Ching*. Every one of those sixty-four commentaries has been translated into English somewhere, by someone. And yet the *anthology itself* — this particular scholar's selection and arrangement, the thing he made — had never been rendered in English as a whole. So it is a genuine first translation **built entirely out of already-translated parts.** A first made of not-firsts. That only makes sense if the unit is the *work*, and the editor's arrangement is itself a work. Count books and the sentence is nonsense; count works and it is simply true.
+
+## What we are proposing to build
+
+The fix is not a better badge. It is to stop pretending a title can carry a work's identity, and to model the thing underneath directly:
+
+- **Every book declares its contents** — which works are actually inside it. The *Articella* stops being one row and becomes a cover over Hippocrates, Galen, and Ḥunayn.
+- **Every work is one entity**, with all its names (the original script, the transliteration, the famous English name, the variants), its author, its language — so the twenty volumes of the *Wubei Zhi* resolve to one work you can read in twenty places.
+- **A first translation is recorded as an event on a (work, source-language) pair** — not stamped on a book. Then you count events, and the number finally means what it says.
+
+This also fixes a quieter problem. A "first translation" claim has always been treated as a coin with two sides — first, or not first. But the honest world has a third side: **we don't yet know.** Sometimes a prior translation might exist in a library we can't reach, in a 1955 Madras edition no one has digitized. [verify: the Tirukkural–Parimēlaḻakar case] The right thing to show a reader there is not a confident gold badge and not silence, but *"plausibly first — help us check."* Uncertainty deserves to be a state you can see, not a coin flip hidden behind a badge.
+
+## Why tell you the number is wrong
+
+We could have quietly deduplicated, picked a cleaner figure, and kept quoting it. The reason we are writing this instead is that the honesty *is* the product. Source Library exists to make a specific, checkable promise — *this work has never been readable in English before, and now it is.* A promise like that is only worth anything if we hold ourselves to knowing exactly what we are claiming, and admitting the edges where we don't.
+
+So here is the honest version, which is less tidy and much more true: **we do not currently know how many first translations we have made.** It is somewhere around five thousand distinct works, minus the long books we double-counted, plus the hundreds of works still hiding inside bundles we have counted as one. The real number is unknowable until every book tells us what is inside it and every work is counted once.
+
+We think that number, once we can finally see it, will be both larger and humbler than the one we have been quoting — larger because of everything bundled out of sight, humbler because some of what looked certain is really *probably*. We would rather get there honestly than keep a rounder number that is wrong in two directions at once.
+
+*If you want to watch the count get more honest, the work is open: [sourcelibrary.org/census](https://sourcelibrary.org/census).* [verify: link target]

--- a/.claude/docs/ft-tier0-nonlatin-catalog.md
+++ b/.claude/docs/ft-tier0-nonlatin-catalog.md
@@ -139,11 +139,22 @@ The two LIVE famous-work FT badges are both *text + named commentary* editions:
   so a narrow "first complete English of the Parimelazagar commentary" claim is
   plausible (one ambiguous 1955 prior unresolved).
 In both, the badge MISLEADS as catalogued (titled as the famous base text) but a
-narrow commentary-first claim may be genuine. **Decision (Derek, 2026-06-30): KEEP
-the badge + reframe the metadata** to foreground the commentary (recorded in each
-book's `translation_verification.ft_reframe_needed_2026_06_30`; evidence in
-`scripts/output/ft-evidence-2026-06-30/commentary-edition-ft-verify-2026-06-30.json`).
-This is the FT runbook's "route famous-adjacent works to a human specialist" case.
+narrow commentary-first claim may be genuine. This is the FT runbook's "route
+famous-adjacent works to a human specialist" case, and it generalized into a
+principles doc — **`.claude/docs/title-and-work-identity-principles.md`** (titles
+do five conflicting jobs; the FT claim is a three-state predicate on
+`(work, source-language)`; the famous base text and its commentary are *distinct
+works*). Resolution (applied 2026-06-30, #2905):
+- **老子元翼** — retitled to lead with Jiao Hong's anthology (Tao Te Ching kept
+  in-title for findability); badge KEPT and now honest (first English of the
+  *anthology*; base-text translations render as "Related translations found").
+- **Tirukkural** — the narrow commentary-first claim is **unproven** (Thangaiya
+  1955 exists but its commentary-language is unverifiable without a physical copy).
+  Badge HEDGED (`is_first_translation:false`, `verdict:needs_review`) — no confident
+  first while a credible prior is unresolved; physical-copy todo logged on the book.
+Evidence: `scripts/output/ft-evidence-2026-06-30/commentary-edition-ft-verify-2026-06-30.json`;
+per-book notes in `translation_verification.ft_reframe_needed_2026_06_30` /
+`.open_question_2026_06_30`.
 
 ## Superseded follow-up (kept for the record — do NOT build the 84000 path)
 The anonymity + cross-script blockers suggested a cross-lingual work-identity

--- a/.claude/docs/title-and-work-identity-principles.md
+++ b/.claude/docs/title-and-work-identity-principles.md
@@ -1,0 +1,185 @@
+# Titles, names, and work identity — principles
+
+Why this exists: a recurring class of bug (most visibly in first-translation
+badges) traces to one root cause — **a book's title is asked to be the work's
+identity, and it can't be.** This doc states the principles that resolve it. It
+is the conceptual companion to the build specs in the work-identity system
+(`work-identity-coverage.md`, #2318), the works catalog (#2453), and the FT
+verification runbook (`ft-verification-runbook.md`). Worked examples at the end
+are real cases from the 2026-06-30 non-Latin audit (#2900/#2904/#2905).
+
+## The root problem: a title does five jobs, and they conflict
+A single title string is silently asked to be all of:
+1. **Identity** — *what work is this?*
+2. **Findability** — the strings a reader will search (famous name, script, gloss).
+3. **Claim-bearing** — the "First Translation" / completeness badges attach to
+   whatever the title appears to be *about*.
+4. **Provenance honesty** — it must not imply we did more than we did.
+5. **Language** — original script, transliteration, and English gloss all pull on it.
+
+Almost every over-claim we have found is the title optimized for **findability**
+("call it *Tao Te Ching* so people find it") at the cost of **identity** and
+**claim-accuracy** (the FT badge then reads as "first English of the Tao Te Ching"
+— false). You cannot satisfy all five in one string. Stop trying; separate them.
+
+## Principle set A — the title itself
+1. **The title names the work we hold, not the famous ancestor it descends from.**
+   The unit of identity is the specific edition / recension / commentary, because
+   that is what a first-translation claim is *about*.
+2. **Lead with identity; keep the famous name in a findable-but-secondary slot.**
+   Never drop "Daodejing" — put it in the tail/alt-names. The claim-bearing *head*
+   must be a thing we can truthfully claim a first of.
+3. **Title and claim are coupled — never ship them diverging.** Before any badge:
+   "first translation of *what, exactly* — and does the title say that?" If they
+   disagree, fix one.
+4. **Name the layer.** Base text / recension-edition / apparatus (commentary) are
+   three different things; a claim must say which. Most over-claims are
+   layer-confusion.
+5. **Lead with the work's own name** (transliteration + script), gloss in English —
+   not an English retelling as the primary title. (Same *ad fontes* instinct as
+   `feedback_go_to_original_sources`.)
+6. **A commentary is part of identity when it is what the book substantively is**
+   (Or Yakar, Parimelazagar, 老子元翼). The commentator often belongs at the front.
+7. **Title is stable identity; the slug/URL is frozen.** Correct titles freely;
+   never regenerate the slug (it breaks links). Title edits are additive-corrective.
+
+## Principle set B — the language axis
+Two things people conflate and must not:
+- **The work's name** is *multilingual and plural*: original script, transliteration,
+  conventional English name, variants. Carry **every** form; findability is the
+  *union*, never a choice. (Tirukkural must be found by "Tirukkural," "திருக்குறள்,"
+  "Kural," and "Sacred Couplets" alike.)
+- **"We have it in English"** is a *state of our holding* (`pages_translated` → the
+  green "Translated" badge / filter), surfaced **beside** the title, never inside
+  it. The moment "(English Translation)" goes into a title you get collisions and
+  false claims.
+
+8. **Display leads with what the reader can read, anchored to the original**
+   (transliteration + short gloss; script secondary). Not bare script (unreadable),
+   not bare English (loses identity).
+9. **The English title is a gloss, not the identity.** Conventional names are fine
+   labels; an invented English title that implies we Englished the whole work, or
+   that collides with a real published translation, is the failure.
+10. **Display and SEO emphasize different forms of the same name-set.** Most
+    discovery traffic is English, so `<title>`/meta/structured-data foreground the
+    English-findable forms even while the on-page H1 leads with the transliteration.
+    Same data, context-tuned rendering — findability never requires corrupting the
+    display identity.
+
+## Principle set C — canonical works (the cure)
+The title problems are symptoms; the canonical **work** is the cure.
+- A **work** (one canonical entity) owns the multilingual name-set, the author
+  (via the thesaurus), the language, and relationships to other works.
+- A **book** is a *manifestation* of a work; it owns *this* recension, *this*
+  commentary, our scan, our translation.
+- **The first-translation claim is a predicate on `(work, source-language)`** — not
+  a property of a title string. This single move makes the over-claim class
+  structurally impossible: a claim can't misread onto the wrong text because it's
+  bound to a work.
+
+**The grain question is the only hard one.** What counts as one work? The test:
+
+> **Two things are the same work iff a first-translation claim about one is a claim
+> about the other.**
+
+- Daodejing ≠ Jiao Hong's 老子元翼 (translating the base text doesn't translate the
+  commentary) → **distinct works**, edge `commentary-on`.
+- Ibn Tibbon's Hebrew *Moreh* vs the Judeo-Arabic *Dalālat* → same work, different
+  source-language recensions; the FT predicate is **per source-language** (which is
+  exactly why source-language is a matcher guard).
+
+**Canonical cuts both ways — beware false canonicalization.** "Canonical" must not
+mean "lump." The author thesaurus already taught this (name-matching anchored
+"William Law" → the famous Shirer; see `lesson_author_grounding_wrong_famous_person`).
+The works analogue is merging a commentary into its base work, or a recension into
+"the work," collapsing the very distinctions that carry the claim. The #2318 fit
+rule (containment + specificity, reject generic containers) is the guardrail.
+Canonical means *resolve to the right grain*, not *collapse to the famous one*.
+
+## Principle set D — sub/supertitles are a tree, not a string
+A title is a **path through a typed graph**, and the hard cases are disagreements
+about the tree. Above a work: series ("SBE Vol. 39"), canon (Kangyur, Daozang,
+Taishō), collected-works ("Ekiken Zenshū"), parent-work (the Gītā inside the
+Mahābhārata). Below: volume/part, recension, commentary, scope. Complications:
+
+1. **Grain floats — "part-of" doesn't decide the work.** The Gītā is a *section* of
+   the Mahābhārata yet a primary work; the Bhīṣma Parva isn't. **Reception decides,
+   not containment** — so clean part-of metadata (Toh hierarchy, TEI) never settles
+   work-grain.
+2. **Fragmentation — one work scattered across many books** (Mahābhārata Vols. 1–7).
+   The FT claim is about the *complete* text; completeness must be **assembled
+   across manifestations**, never asserted per volume.
+3. **The super-relation is overloaded** — series ≠ canon ≠ collected-works ≠
+   parent-work. A series is a publication container (no intellectual identity); a
+   canon is a curated corpus (its own significance + name-set). Don't flatten them.
+4. **Claims hide in the sub/supertitle.** "Vol. 1" implies *incomplete*; "Complete
+   Works" implies *complete*; "Selected" implies *partial*. The completeness
+   classifier already keys off these tokens — the subtitle is doing claim-bearing
+   work on the completeness axis.
+5. **The famous name sits at an unpredictable level** (canon / work / sub-section).
+   You cannot assume "the searchable name is the top title" — index every level.
+6. **Multilingual × levels multiplies** — the canon has its own names (Kangyur =
+   བཀའ་འགྱུར་ = "Translated Word"), the work its own, the commentary its own. The
+   name-set is a bag **per node of the path**, not per book.
+7. **Display must linearize a tree** — and every linearization can drop the
+   load-bearing level. A card wants the recognizable name; a citation wants the full
+   path; SEO wants the English forms. Require each linearization to preserve the
+   claim-bearing node and ≥1 searchable name.
+8. **Super/sub is relative, not a fixed field.** The Vinayavastu is *sub* to the
+   Kangyur but *super* to the Pravrajyāvastu. Model parent/child edges; super/sub
+   are directions of traversal.
+9. **Two overlapping trees that disagree (the deep one):** a *structural*
+   containment tree and a *reception/significance* tree. **The FT grain follows
+   reception; structure follows the other.** Their divergence is where over-claims
+   breed.
+
+## Principle set E — the claim has three states, not two
+A first-translation predicate on `(work, source-language)` is **proven-first /
+proven-not / unproven** — uncertainty is first-class. Today the system can render
+"confident first" (gold badge) or "hide it," and *both lie* about an unproven case.
+The honest surface must be able to say *"plausibly first, one unresolved prior —
+help us check,"* not collapse to a badge. `needs_review` is that state; render it,
+don't override it with a confident verdict. **Operational rule: never show a
+confident first badge while a credible prior is unresolved.**
+
+## The one-line synthesis
+**Identity lives on the work; the book is a manifestation; the FT claim is a
+three-state predicate on `(work, source-language)`; and titles, names, layers, and
+"we translated it" are all projections of that.** Pathological as a string, trivial
+as a typed work-graph.
+
+## The cheap test (use this until the graph exists)
+> If a reader who knows the field would read the title + "First Translation" badge
+> together and think *"wait, that's been translated for a century,"* the title is
+> naming the wrong layer.
+
+That one mental test catches the whole class.
+
+---
+
+## Worked examples (2026-06-30 non-Latin audit)
+- **老子元翼 / "Dao de jing yuan yi" (Chinese)** — was titled "Tao Te Ching with
+  Commentary," so the FT badge read as *first English of the Tao Te Ching* (false —
+  Chalmers 1868 / Legge 1891). The book is actually Jiao Hong's **老子元翼**, an
+  anthology of 64 commentaries — a *distinct work* (`commentary-on` the Daodejing),
+  with no prior English of the anthology. **Action:** retitled to lead with the
+  anthology (Tao Te Ching kept in-title for findability); badge KEPT and now honest;
+  base-text translations render as the soft "Related translations found." A clean
+  *proven-first* after reframe.
+- **Tirukkural with Parimelazagar commentary (Tamil)** — base text Englished since
+  Pope 1886 → base-text claim false. The narrow claim (first complete English of the
+  *Parimelazagar commentary*) is **unproven**: Issac T. Thangaiya, *Tirukkural in
+  English with Parimelazhakar Commentary* (Madras, 1955) exists but its
+  commentary-language is unverifiable without a physical copy (balance leans
+  Tamil-only). **Action:** title kept (already names the commentary); badge HEDGED
+  (`is_first_translation:false`, `verdict:needs_review`) — no confident first while
+  the prior is unresolved; physical-copy todo logged (Roja Muthiah / IAS Chennai).
+  The keystone *unproven* example.
+- **Pa'amon ve-Rimon (Hebrew)** — recorded author "Cordovero" corrected to Mordechai
+  ben Jacob Peshibrom (composite volume); the stored Gemini disposition had even
+  reasoned about the wrong work (*Pardes Rimonim*). Lesson: re-derive work identity
+  from the title yourself; don't trust a stored disposition's identity.
+- **"Immanuel Franco — Tercera parte del sedur" / "Abulafia — Collection of
+  kabbalistic works" (Hebrew)** — *proven-not* and *ill-posed*: liturgy with a
+  complete prior English (Levi 1789–93), and a manuscript miscellany (a container,
+  not a work). Demoted. Containers and liturgy fail the grain test outright.

--- a/.claude/docs/title-and-work-identity-principles.md
+++ b/.claude/docs/title-and-work-identity-principles.md
@@ -148,12 +148,61 @@ three-state predicate on `(work, source-language)`; and titles, names, layers, a
 "we translated it" are all projections of that.** Pathological as a string, trivial
 as a typed work-graph.
 
+## Principle set F — counting: first-translations are events in the graph
+If the FT claim is a predicate on `(work, source-language)`, then **a
+first-translation is an event in the work-graph, not a property of a book.** A
+book is *where you can read one* — it is not the unit you *count*. The two
+cardinalities (books vs first-translated works) are independent, and they diverge
+in **both directions at once**, so the errors don't even cancel:
+
+- **Overcount:** one work spread across many books (multi-volume sets,
+  multi-edition holdings) badges the *same* first N times.
+- **Undercount:** one book that is a multi-work container holds many works; badged
+  as 1, it hides N first-events (or 0, if its constituents were each translated
+  before — see the container-vs-edited-work distinction below).
+
+**Compilation-as-work vs compilation-as-container** (the subtle case): a
+compilation *can itself* be a first-translation even if every constituent was
+translated elsewhere — **but only when the compilation is an edited work, not a
+container.** Test: is translating all the parts separately the *same thing* as
+translating this compilation? If no — because the selection + arrangement +
+editorial apparatus is itself content — it is a distinct work with its own FT
+status. 老子元翼 is the live proof: its 64 constituent commentaries exist in
+English piecemeal, but Jiao Hong's *anthology* (his selection/arrangement) had
+never been Englished as such → a genuine first *of the compilation*. A bare
+container ("Collection of kabbalistic works") has no such identity → it decomposes
+to its constituents and bears no claim of its own.
+
+### Measured proxy error (FT-badged set, 2026-06-30)
+`scripts/_tmp_ft_proxy_error.mjs` (read-only) against the live `is_first_translation`
++ `visible` + `pages_translated>0` set:
+- **N_books = 5,814** (the current headline unit).
+- **distinct `work_id` ≈ 5,030** → **~784 badges are the same work re-counted**
+  across volumes/editions (≈13% overcount). Concentrated in multi-volume Chinese
+  encyclopedias: 三才圖會 / Sancai Tuhui (52× + 39×), 武備志 / Wubei Zhi
+  (42× + 21× + 20×), 海國圖志 (17×), Huygens *Œuvres* (13×).
+- **515 FT-badged books carry multi-work container signals** (collected/works/
+  various/anthology/miscellany) and **305 carry volume/part signals** — each
+  container holds many works, an *undercount* of unknown-but-large magnitude
+  (Articella = Hippocrates+Galen+Ḥunayn; "Collected Drukpa Kagyu texts"; etc.).
+
+So the honest statement of the headline is: **we do not know the
+first-translated-works count** from book-badges — deduping multi-manifestation
+pulls 5,814 → ~5,030, while decomposing the 515 containers pushes it back up by an
+amount we can't know without their contents manifests. The true number is
+unknowable until firsts are counted as work-graph events. The error is *bounded
+and enumerable*, not mysterious — the divergent set is exactly the
+multi-volume + container books, which are findable by signal.
+
 ## The cheap test (use this until the graph exists)
 > If a reader who knows the field would read the title + "First Translation" badge
 > together and think *"wait, that's been translated for a century,"* the title is
 > naming the wrong layer.
 
-That one mental test catches the whole class.
+That one mental test catches the whole class. For counting, the parallel test:
+**if you're counting books, you are not counting first-translations** — you are
+counting *places to read them*, off by the multi-volume sets (too high) and the
+anthologies (too low) simultaneously.
 
 ---
 

--- a/.claude/docs/work-identity-coverage.md
+++ b/.claude/docs/work-identity-coverage.md
@@ -7,6 +7,8 @@ translation?"** — reliably, by query, instead of guessing. Umbrella: issue #23
 
 > **Classifying a confusing record? Start with the [work-identity casebook](./work-identity-casebook.md)** — worked examples of every hard pattern (original / period-translation / modern-translation / container / volume / recension / commentary / miscellany / artwork), each with the correct role + badge call. The Iamblichus *De mysteriis* cluster is the flagship (one work, five hard patterns at once).
 
+> **Designing titles, naming, or the count?** See **[title-and-work-identity-principles.md](./title-and-work-identity-principles.md)** — why a title can't carry work identity (it does five conflicting jobs), the canonical-work grain test, sub/supertitle tree, the three-state claim, and **why first-translations are counted over WORKS not books** (wrong in both directions: multi-volume over-counts, containers under-count). **Measuring the resolver?** the probe (`scripts/eval/work-resolver-probe.mjs`, zero-token lower-bound) + the stratified gold instrument (`build-work-gold-set.mjs` / `score-work-gold-set.mjs` + **[work-identity-gold-rubric.md](./work-identity-gold-rubric.md)**, precision/recall + κ). Build plan + the open multi-volume grain decision: issue #2909.
+
 ## The mistake this exists to prevent (2026-06-17)
 `books.text_role = 'modern-translation'` does **NOT** mean we lack the original.
 The original almost always sits in the catalog as a **separate, unlinked book**.


### PR DESCRIPTION
The framework that came out of the non-Latin first-translation audit, the data that proves it, the two live reframes, and a public-facing proposal.

## `.claude/docs/title-and-work-identity-principles.md` (new)
Why a book **title cannot carry work identity**, and how to fix it:
- **A title does five conflicting jobs** — identity / findability / claim-bearing / provenance / language. Over-claims are findability winning.
- **Language axis:** names are a multilingual *set*; "we translated it" is a *state* beside the title, never inside it.
- **Canonical works are the cure:** identity lives on the **work**; the book is a *manifestation*; the FT claim is a predicate on **`(work, source-language)`**. The grain test, plus the false-canonicalization warning.
- **Sub/supertitles are a typed graph** with structural-vs-reception overlays; the FT grain follows reception.
- **Three-state claim:** proven-first / proven-not / **unproven** — never a confident badge while a credible prior is unresolved.
- **NEW — Principle F, counting:** *a first-translation is an event in the work-graph, not a property of a book.* Measured proxy error on the live FT set (2026-06-30): **5,814 badged books → ~5,030 distinct works** (~784 same-work re-counts across volumes — Wubei Zhi, Sancai Tuhui), **plus 515 multi-work container books** each hiding many firsts. The headline first-count is **wrong in both directions at once** and unknowable from book-badges until books declare their contents.

## `.claude/docs/blog-first-translation-is-not-a-book-draft.md` (new, draft)
Public-facing proposal in the existing blog voice — "A First Translation Is Not a Book." Leads with the Wubei Zhi (one first counted 20×+) and the Articella (a dozen firsts under one badge), lands the work-graph + contents-manifest proposal, and makes the epistemic-honesty case. `[verify]` flags on numbers/links before publishing.

## Applied to prod (data, already live — recorded here)
The two #2905 commentary editions, after independent Sonnet verification:
- **老子元翼** — retitled to foreground Jiao Hong's anthology (Tao Te Ching kept for search); badge kept, now honest (first English of the *anthology*).
- **Tirukkural** — badge **hedged** (`is_first_translation:false`, `verdict:needs_review`): the commentary-first claim is *unproven* (Thangaiya 1955 needs a physical-copy check, logged on the book).

## Scope / follow-up
- Docs + 2 prod data writes (reversible). Blog is a **draft for review**, not published.
- Out of scope: the work-graph + contents-manifest build itself (#2318/#2453), a UI for the unproven state, the Thangaiya physical-copy resolution, and an honest re-count once works are the unit.

Refs: #2900, #2904, #2905, #2318, #2453, #2567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)