### PR TITLE
feat(works): work_id resolver-quality measurement — probe + gold-labeling instrument

### DIFF
--- a/.claude/docs/work-identity-gold-rubric.md
+++ b/.claude/docs/work-identity-gold-rubric.md
@@ -1,0 +1,82 @@
+# Work-identity gold-labeling rubric
+
+The instrument that turns the resolver probe's *lower bounds* into a real
+precision/recall number + inter-rater κ. You are labeling **book PAIRS** as
+**same work / different work / ambiguous**. Companion to
+`title-and-work-identity-principles.md`, issue #2909.
+
+## The question
+> Are book A and book B **manifestations of the same work**?
+
+A *work* is one intellectual creation. A *manifestation* is a particular edition,
+printing, translation, or volume of it. You are judging the work, not the copy.
+
+## Decision rules (these encode the grain policy — apply them, don't re-litigate)
+**SAME work:**
+- Two editions / printings of the same text (incl. different years): *Horologium
+  Oscillatorium* (1673) and *Horologium Oscillatorium* → **same**.
+- A translation and its original, or two translations of one text: source-language
+  recensions of one work are **same** (the first-translation predicate is then
+  per *source-language* — that's a separate axis, not this label).
+- Volumes / parts of ONE work: *Plauti Comoediae* Vol. I and Vol. II → **same**
+  (one work, read in two volumes). *(Policy under decision #2909-B; for the gold,
+  label volumes of one work as SAME and let κ on `hard_volume` reveal disagreement.)*
+
+**DIFFERENT works:**
+- A base text and a commentary ON it: Cicero's *Epistolae* vs Manuzio's
+  *Commentarius in epistolas Ciceronis* → **different** (the commentary is its own
+  creation, even if bound together).
+- **Numbered / lettered SERIES ITEMS** — distinct texts that share a generic base
+  title and differ only by a number, dedicatee, or section-letter:
+  "Proverbs: collection 10" vs "collection 11"; "A Balbale to Inana" vs "…for
+  Šu-Suen"; Tibetan pecha "…rgyud mi" vs "…rgyud phi"; "Bodleian MS Barocci 6"
+  texts → **different**. *(This is the #1 false-positive in the probe's over-split
+  tiers — the tokenizer drops the distinguishing token. Watch for it.)*
+- Different works merely sharing an author, editor, or publisher: Sallust's
+  *Catilina* and Cicero's *Epistolae*, both ed. Aldo Manuzio → **different**.
+- A multi-work container vs one of its constituents: an anthology vs a text inside
+  it → **different** (the container is a separate question; see the compilation-
+  as-work vs container test in the principles doc).
+
+**AMBIGUOUS** (use it honestly — these define the grain boundary, they are not
+labeler failures):
+- Collected-works editions with different titles ("Opera Omnia" vs "Lucubrationes
+  Omnes" of Jerome) — same work or different compilation?
+- An edited compilation whose selection/arrangement may itself be a work (Jiao
+  Hong's 老子元翼).
+- Recension vs revision where you can't tell if the text is materially different.
+
+## Process
+1. **Two independent labelers.** Do not confer. Each labels every pair from the
+   metadata + the two book URLs (open them if unsure).
+2. Fill `label` ∈ {`same`,`different`,`ambiguous`}, optional `confidence`
+   ∈ {`high`,`low`}, and `notes` (esp. *why* on ambiguous).
+3. Do **not** look at `probe_prediction` while labeling — it's there for the
+   scorer, not for you. (Ideally strip it first.)
+4. Run `scripts/eval/score-work-gold-set.mjs A.jsonl B.jsonl` → probe precision per
+   stratum + Cohen's κ between labelers.
+
+## What each stratum measures
+- `control_same` / `control_diff` — sanity floor; labelers must agree ~100% or the
+  labeling is broken.
+- `random_within` — resolver **precision** on the *ordinary* "same"-assertion
+  (de-biased, not cherry-picked).
+- `random_pair` — base rate / **specificity** (almost all different; surprises are
+  interesting).
+- `oversplit_high` / `oversplit_med` — the probe's "you missed a merge" calls;
+  fraction labeled `same` = probe over-split **precision** (expect series-item
+  contamination to drag `high` below the "near-certain" I first claimed).
+- `overmerge` — the probe's "you merged wrongly" calls; fraction labeled
+  `different` = probe over-merge precision (expect many false positives from
+  name-variants / translation editions).
+- `anchor_miss` — recall against external (Wikidata QID) truth.
+- `hard_commentary` / `hard_volume` — the grain-boundary strata; κ here is the real
+  signal (low κ ⇒ the policy is under-specified, not the resolver wrong).
+
+## Reading the result
+- κ per stratum **first**: a resolver can't beat the ceiling set by human
+  agreement. Low κ on `hard_*` = fix the *policy*, not the code.
+- Then probe precision per stratum → the ranked fix-list.
+- **Recall caveat:** this pair set bounds recall (via oversplit + anchor_miss) but
+  does not close it. A true recall number needs a per-book sibling-search frame —
+  a separate, costlier labeling task.

--- a/scripts/eval/build-work-gold-set.mjs
+++ b/scripts/eval/build-work-gold-set.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * build-work-gold-set.mjs — generate a stratified human-labeling set of book
+ * PAIRS for calibrating the work_id resolver (issue #2909).
+ *
+ * The probe harness gives a LOWER BOUND on error; this set turns that into a real
+ * precision/recall number + inter-rater κ, by sampling the hard cases (where κ is
+ * low = the grain boundary) and the probe's own predictions (to score it), plus
+ * easy controls (to anchor κ and catch labeler error). Deterministic — no RNG —
+ * so re-running yields the identical set.
+ *
+ * Each pair carries the probe's PREDICTION (same/different) so the scorer can
+ * compute the probe's precision per stratum. A human marks `label`
+ * (same/different/ambiguous) and `notes`. Two independent labelers → κ.
+ *
+ * Strata:
+ *   oversplit_high  probe=same  — identical sig-title set + same surname
+ *   oversplit_med   probe=same  — title Jaccard ≥0.7
+ *   anchor_miss     probe=same  — QID work vs local-id sibling
+ *   overmerge       probe=diff  — two books inside one work_id, different authors
+ *   hard_commentary probe=?     — a base-text vs a "with X commentary" sibling
+ *   hard_volume     probe=?     — "Vol. N" vs "Vol. M" of the same title (grain Q)
+ *   control_same    probe=same  — two books in one work_id, high title overlap
+ *   control_diff    probe=diff  — different work_id + author + tradition
+ *   random_within   probe=same  — UNIFORM-random pair sharing a work_id (de-biases
+ *                                 the curated strata: measures resolver precision on
+ *                                 the ORDINARY cluster, not just suspicious ones)
+ *   random_pair     probe=diff  — UNIFORM-random pair across the whole corpus
+ *                                 (anchors the base rate / specificity; catches
+ *                                 surprise same-works the probe never flagged)
+ *
+ * SCOPE LIMIT (be honest): pair-labeling measures the PRECISION of the resolver's
+ * "same" assertions (random_within) and of the probe's flags (oversplit_*,
+ * anchor_miss are partial recall candidates). It does NOT give full RECALL — "what
+ * same-work siblings did we MISS?" needs a per-book sibling-search labeling frame,
+ * a separate (costlier) task. random_within + the oversplit strata bound it; they
+ * don't close it.
+ *
+ * Usage:
+ *   node scripts/eval/build-work-gold-set.mjs [--per-stratum 40] [--out FILE]
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+
+const PER = (() => { const i = process.argv.indexOf('--per-stratum'); return i > -1 ? +process.argv[i + 1] : 40; })();
+const OUT = (() => { const i = process.argv.indexOf('--out'); return i > -1 ? process.argv[i + 1] : 'scripts/output/work-gold-set-unlabeled.jsonl'; })();
+
+const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+const STOP = new Set(['the', 'and', 'with', 'from', 'vol', 'volume', 'part', 'tome', 'band', 'book', 'der', 'die', 'des', 'von', 'und', 'of', 'les', 'la', 'le', 'el', 'für', 'mit', 'thor', 'bu', 'sogs', 'rnam', 'pa', 'ba']);
+const sig = (s) => [...new Set(norm(s).split(' ').filter((t) => t.length >= 4 && !STOP.has(t)))];
+const surname = (a) => norm(a).split(' ').filter(Boolean).pop() || '';
+const commentRe = /\b(comm(\.|entary)?|with .* commentary|bhashya|bhāṣya|tika|ṭīkā|glossa|scholia|annotation|cum commento|espositione|notes by)\b/i;
+const volRe = /\b(vol|volume|part|tome|band|tomus)\.?\s*[ivxlcdm0-9]/i;
+// stable string hash → deterministic order (no RNG; RNG is unavailable anyway)
+const hash = (s) => { let h = 2166136261; for (let i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); } return (h >>> 0); };
+const pairId = (a, b) => [a, b].sort().join('__');
+
+function thin(b) { return { id: b.id, author: b.author, title: b.title, language: b.language, year: b.published ?? b.year ?? null, url: `https://sourcelibrary.org/book/${b.id}` }; }
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI); await client.connect();
+  const books = client.db(process.env.MONGODB_DB || 'bookstore').collection('books');
+  const all = await books.find({ visible: true, pages_translated: { $gt: 0 } })
+    .project({ _id: 0, id: 1, work_id: 1, author: 1, title: 1, language: 1, published: 1 }).toArray();
+  const withW = all.filter((b) => b.work_id && b.id);
+
+  const byWid = new Map();
+  for (const b of withW) { if (!byWid.has(b.work_id)) byWid.set(b.work_id, []); byWid.get(b.work_id).push(b); }
+  const repByWid = new Map(); for (const [w, arr] of byWid) repByWid.set(w, arr[0]);
+  const bySurname = new Map();
+  for (const [w, b] of repByWid) { const sn = surname(b.author); if (sn.length < 4) continue; if (!bySurname.has(sn)) bySurname.set(sn, []); bySurname.get(sn).push({ w, b, toks: new Set(sig(b.title)) }); }
+
+  const strata = {}; const add = (s, a, b, pred) => { (strata[s] = strata[s] || []).push({ stratum: s, probe_prediction: pred, a: thin(a), b: thin(b), _k: pairId(a.id, b.id) }); };
+
+  // OVER-SPLIT high/med + ANCHOR-MISS (cross-work_id, same surname)
+  for (const [sn, items] of bySurname) {
+    for (let i = 0; i < items.length; i++) for (let j = i + 1; j < items.length; j++) {
+      const A = items[i], B = items[j]; if (A.toks.size < 2 || B.toks.size < 2) continue;
+      const inter = [...A.toks].filter((t) => B.toks.has(t)).length;
+      const jac = inter / new Set([...A.toks, ...B.toks]).size;
+      const aKey = [...A.toks].sort().join(' '), bKey = [...B.toks].sort().join(' ');
+      const isQ = (x) => /^Q\d+$/.test(x);
+      if (isQ(A.w) !== isQ(B.w) && jac >= 0.6 && inter >= 2) add('anchor_miss', A.b, B.b, 'same');
+      else if (aKey === bKey && A.b.language !== 'Tibetan') add('oversplit_high', A.b, B.b, 'same');
+      else if (jac >= 0.7 && inter >= 3 && A.b.language !== 'Tibetan') add('oversplit_med', A.b, B.b, 'same');
+    }
+  }
+  // OVER-MERGE: two books inside one work_id with different surnames
+  for (const [w, arr] of byWid) {
+    if (arr.length < 2) continue;
+    for (let i = 0; i < arr.length; i++) for (let j = i + 1; j < arr.length; j++) {
+      if (surname(arr[i].author) && surname(arr[j].author) && surname(arr[i].author) !== surname(arr[j].author)) add('overmerge', arr[i], arr[j], 'different');
+    }
+  }
+  // CONTROL same: two books in one work_id, high title overlap (easy same)
+  for (const [w, arr] of byWid) {
+    if (arr.length < 2) continue;
+    const A = arr[0], B = arr[1]; const ta = new Set(sig(A.title)), tb = new Set(sig(B.title));
+    const inter = [...ta].filter((t) => tb.has(t)).length;
+    if (inter >= 2 && surname(A.author) === surname(B.author)) add('control_same', A, B, 'same');
+  }
+  // CONTROL diff: stride-paired across different work_id + surname + language (easy different)
+  const sorted = [...withW].sort((x, y) => (x.id < y.id ? -1 : 1));
+  for (let i = 0; i + 137 < sorted.length; i += 53) {
+    const A = sorted[i], B = sorted[i + 137];
+    if (A.work_id !== B.work_id && surname(A.author) !== surname(B.author) && A.language !== B.language) add('control_diff', A, B, 'different');
+  }
+  // HARD commentary: same surname, one title has a commentary marker, the other doesn't, share ≥2 tokens
+  for (const [sn, items] of bySurname) {
+    for (let i = 0; i < items.length; i++) for (let j = i + 1; j < items.length; j++) {
+      const A = items[i].b, B = items[j].b; const ca = commentRe.test(A.title), cb = commentRe.test(B.title);
+      if (ca === cb) continue; const inter = [...items[i].toks].filter((t) => items[j].toks.has(t)).length;
+      if (inter >= 2) add('hard_commentary', A, B, '?');
+    }
+  }
+  // HARD volume: same surname, both volume-marked, share ≥3 tokens, different work_id
+  for (const [sn, items] of bySurname) {
+    for (let i = 0; i < items.length; i++) for (let j = i + 1; j < items.length; j++) {
+      const A = items[i].b, B = items[j].b; if (!volRe.test(A.title) || !volRe.test(B.title)) continue;
+      const inter = [...items[i].toks].filter((t) => items[j].toks.has(t)).length;
+      if (inter >= 3 && items[i].w !== items[j].w) add('hard_volume', A, B, '?');
+    }
+  }
+
+  // RANDOM_WITHIN: uniform-random pair sharing a work_id (multi-book works, sorted
+  // by hash for a deterministic uniform draw — NOT the suspicious ones).
+  const multiWorks = [...byWid.entries()].filter(([, arr]) => arr.length >= 2).sort((a, b) => hash(a[0]) - hash(b[0]));
+  for (const [w, arr] of multiWorks) { const A = arr[0], B = arr[1]; add('random_within', A, B, 'same'); }
+  // RANDOM_PAIR: uniform-random pairs across the whole corpus (deterministic walk
+  // with a large coprime stride → spread-out draws; almost all truly different).
+  const N = sorted.length, OFF = 7919;
+  for (let i = 0; i < N; i += 29) { const A = sorted[i], B = sorted[(i + OFF) % N]; if (A.id !== B.id && A.work_id !== B.work_id) add('random_pair', A, B, 'different'); }
+
+  // deterministic sample per stratum (sort by hash of pair key, take PER)
+  const picked = [];
+  for (const [s, arr] of Object.entries(strata)) {
+    const uniq = [...new Map(arr.map((p) => [p._k, p])).values()].sort((x, y) => hash(x._k) - hash(y._k));
+    picked.push(...uniq.slice(0, PER));
+  }
+  // pseudo-shuffle the final set so labelers don't see a stratum in a block
+  picked.sort((x, y) => hash('z' + x._k) - hash('z' + y._k));
+  const rows = picked.map((p, i) => ({ pair_id: i + 1, stratum: p.stratum, probe_prediction: p.probe_prediction, a: p.a, b: p.b, label: '', confidence: '', notes: '' }));
+
+  fs.mkdirSync('scripts/output', { recursive: true });
+  fs.writeFileSync(OUT, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  const tally = {}; for (const r of rows) tally[r.stratum] = (tally[r.stratum] || 0) + 1;
+  console.log(`Wrote ${rows.length} pairs → ${OUT}`);
+  console.log('by stratum:', JSON.stringify(tally, null, 1));
+  console.log('\nLabel each pair: label ∈ {same, different, ambiguous}. See .claude/docs/work-identity-gold-rubric.md');
+  console.log('Two independent labelers → run scripts/eval/score-work-gold-set.mjs for probe P/R + κ.');
+  await client.close();
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/eval/score-work-gold-set.mjs
+++ b/scripts/eval/score-work-gold-set.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * score-work-gold-set.mjs — score the labeled work-identity gold set.
+ *
+ * Given one or two labeled JSONL files (from build-work-gold-set.mjs, with `label`
+ * filled in ∈ {same,different,ambiguous}), compute:
+ *   - PROBE precision per stratum (does the probe's prediction match the human?),
+ *   - Cohen's κ between two labelers (inter-rater reliability) when two files given,
+ *   - overall and per-tradition rollups.
+ *
+ * No DB, no tokens. Pure measurement.
+ *
+ * Usage:
+ *   node scripts/eval/score-work-gold-set.mjs labeled.jsonl
+ *   node scripts/eval/score-work-gold-set.mjs labelerA.jsonl labelerB.jsonl
+ */
+import fs from 'fs';
+
+const files = process.argv.slice(2).filter((a) => a.endsWith('.jsonl'));
+if (!files.length) { console.error('Usage: score-work-gold-set.mjs labeled.jsonl [labelerB.jsonl]'); process.exit(1); }
+const load = (f) => fs.readFileSync(f, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+const norm = (l) => (l || '').trim().toLowerCase();
+
+function cohenKappa(pairs) {
+  // pairs: [{a,b}] of two labelers' labels over the same items (a,b ∈ categories)
+  const cats = ['same', 'different', 'ambiguous'];
+  const n = pairs.length; if (!n) return null;
+  let agree = 0; const ma = {}, mb = {};
+  for (const p of pairs) { if (p.a === p.b) agree++; ma[p.a] = (ma[p.a] || 0) + 1; mb[p.b] = (mb[p.b] || 0) + 1; }
+  const po = agree / n;
+  let pe = 0; for (const c of cats) pe += ((ma[c] || 0) / n) * ((mb[c] || 0) / n);
+  return { kappa: (po - pe) / (1 - pe || 1), po, pe, n };
+}
+
+const A = load(files[0]);
+const B = files[1] ? load(files[1]) : null;
+
+// consensus label for probe scoring: if two labelers, use agreed label; drop disagreements + ambiguous
+const byId = new Map(A.map((r) => [r.pair_id, r]));
+const labeled = [];
+for (const r of A) {
+  let lab = norm(r.label);
+  if (B) { const r2 = (B.find((x) => x.pair_id === r.pair_id) || {}); const l2 = norm(r2.label); if (lab !== l2) { lab = '__disagree__'; } }
+  labeled.push({ ...r, _label: lab });
+}
+
+// ── Probe precision per stratum ───────────────────────────────────────────────
+const strata = {};
+for (const r of labeled) {
+  if (!['same', 'different'].includes(r._label)) continue; // skip ambiguous/disagree/unlabeled
+  const s = (strata[r.stratum] = strata[r.stratum] || { n: 0, correct: 0, same: 0, diff: 0 });
+  s.n++;
+  if (r._label === 'same') s.same++; else s.diff++;
+  if (norm(r.probe_prediction) === r._label) s.correct++;
+}
+console.log('── PROBE prediction vs human label (per stratum) ──');
+console.log('  stratum'.padEnd(20) + 'n'.padStart(5) + 'same'.padStart(6) + 'diff'.padStart(6) + 'probe-acc'.padStart(11));
+for (const [s, v] of Object.entries(strata).sort()) {
+  const acc = v.n ? (100 * v.correct / v.n).toFixed(0) + '%' : '—';
+  console.log(`  ${s.padEnd(18)}${String(v.n).padStart(5)}${String(v.same).padStart(6)}${String(v.diff).padStart(6)}${acc.padStart(11)}`);
+}
+
+// derived: over-split precision (oversplit_* + anchor_miss: fraction truly same),
+// over-merge precision (overmerge: fraction truly different)
+const frac = (names, want) => {
+  let n = 0, hit = 0;
+  for (const r of labeled) { if (!names.includes(r.stratum) || !['same', 'different'].includes(r._label)) continue; n++; if (r._label === want) hit++; }
+  return n ? `${hit}/${n} = ${(100 * hit / n).toFixed(0)}%` : 'n/a';
+};
+console.log('\n── Derived probe quality ──');
+console.log(`  over-split precision (oversplit_high+med+anchor truly SAME): ${frac(['oversplit_high', 'oversplit_med', 'anchor_miss'], 'same')}`);
+console.log(`  over-split HIGH only (truly SAME):                          ${frac(['oversplit_high'], 'same')}`);
+console.log(`  over-merge precision (overmerge truly DIFFERENT):           ${frac(['overmerge'], 'different')}`);
+console.log(`  resolver precision on ordinary clusters (random_within SAME):${frac(['random_within'], 'same')}`);
+console.log(`  control sanity (control_same SAME / control_diff DIFF):     ${frac(['control_same'], 'same')} / ${frac(['control_diff'], 'different')}`);
+
+// ── Inter-rater κ ─────────────────────────────────────────────────────────────
+if (B) {
+  const pairs = [];
+  for (const r of A) { const r2 = B.find((x) => x.pair_id === r.pair_id); if (r2 && norm(r.label) && norm(r2.label)) pairs.push({ a: norm(r.label), b: norm(r2.label) }); }
+  const k = cohenKappa(pairs);
+  console.log('\n── Inter-rater reliability (Cohen κ) ──');
+  if (k) console.log(`  κ = ${k.kappa.toFixed(3)}  (observed agreement ${(100 * k.po).toFixed(0)}%, chance ${(100 * k.pe).toFixed(0)}%, n=${k.n})`);
+  // κ per stratum (where the grain boundary is)
+  console.log('  κ by stratum:');
+  const byStr = {};
+  for (const r of A) { const r2 = B.find((x) => x.pair_id === r.pair_id); if (r2 && norm(r.label) && norm(r2.label)) (byStr[r.stratum] = byStr[r.stratum] || []).push({ a: norm(r.label), b: norm(r2.label) }); }
+  for (const [s, ps] of Object.entries(byStr).sort()) { const kk = cohenKappa(ps); console.log(`    ${s.padEnd(18)} κ=${kk ? kk.kappa.toFixed(2) : '—'} (n=${ps.length})`); }
+} else {
+  const unl = A.filter((r) => !norm(r.label)).length;
+  console.log(`\n(one file — no κ. ${unl}/${A.length} pairs still unlabeled. Provide a second labeler's file for κ.)`);
+}

--- a/scripts/eval/work-resolver-probe.mjs
+++ b/scripts/eval/work-resolver-probe.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * work-resolver-probe.mjs — measure how well the work_id resolver clusters books
+ * into works, WITHOUT a gold set. Read-only, zero-token. (Issue: canonical work
+ * identity #2909; method described in title-and-work-identity-principles.md.)
+ *
+ * The resolver maps each book → a work_id (a cluster). It fails two ways:
+ *   - OVER-MERGE  (precision): one work_id groups books that aren't the same work.
+ *   - OVER-SPLIT  (recall):    the same work scattered across several work_ids.
+ * Both are self-revealing, so we can compute a LOWER BOUND on each error rate for
+ * free. This proves the resolver is *bad where flagged*; it cannot prove it is
+ * *good* (no flags ≠ correct). Only a stratified human gold + κ gives the true
+ * rate — this harness is the cheap first rung that finds errors and a fix-list.
+ *
+ * Probes:
+ *  1. HEALTH    — id-format fragmentation + coverage gaps (no/weak work_id).
+ *  2. OVER-MERGE — multi-book work_ids whose members don't share a title core
+ *                  AND span different author-surnames (precision-suspect).
+ *  3. OVER-SPLIT — distinct work_ids that are near-certainly one work, tiered:
+ *                  HIGH (identical full title+author) / MED (high token overlap),
+ *                  with a generic-token guard (the "thor bu"/pecha trap) and
+ *                  Tibetan reported separately (algorithmic clustering unsafe).
+ *  4. ANCHOR-MISS — a work known by a Wikidata QID, with a sibling edition
+ *                   (same author+title) filed under a *local* id instead → a
+ *                   recall miss measured against real external truth.
+ * All probes are rolled up PER TRADITION (difficulty varies wildly).
+ *
+ * Usage: node scripts/eval/work-resolver-probe.mjs [--limit-examples N]
+ */
+import { MongoClient } from 'mongodb';
+
+const EX = (() => { const i = process.argv.indexOf('--limit-examples'); return i > -1 ? +process.argv[i + 1] : 10; })();
+const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '')
+  .toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+const STOP = new Set(['the', 'and', 'with', 'from', 'vol', 'volume', 'part', 'tome', 'band', 'book', 'der', 'die',
+  'des', 'von', 'und', 'of', 'les', 'la', 'le', 'el', 'des', 'für', 'mit', 'thor', 'bu', 'sogs', 'rnam', 'pa', 'ba']);
+const sig = (s) => [...new Set(norm(s).split(' ').filter((t) => t.length >= 4 && !STOP.has(t)))];
+const surname = (a) => norm(a).split(' ').filter(Boolean).pop() || '';
+const trad = (b) => b.language || '?';
+
+function fmt(w) {
+  if (/^Q\d+$/.test(w)) return 'wikidata_QID';
+  if (/^local:a:/.test(w)) return 'local:a:';
+  if (/^local:n:/.test(w)) return 'local:n:';
+  if (/^local:/.test(w)) return 'local:other';
+  if (/[一-鿿]/.test(w)) return 'cjk-chars';
+  return 'bare-slug';
+}
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const books = client.db(process.env.MONGODB_DB || 'bookstore').collection('books');
+  const LIVE = { visible: true, pages_translated: { $gt: 0 } };
+
+  const all = await books.find(LIVE).project({ _id: 0, id: 1, work_id: 1, author: 1, title: 1, language: 1 }).toArray();
+  const withWid = all.filter((b) => b.work_id);
+  console.log(`Live books: ${all.length} | with work_id: ${withWid.length} (${(100 * withWid.length / all.length).toFixed(1)}%)\n`);
+
+  // ── Probe 1: HEALTH ──────────────────────────────────────────────────────────
+  const fmtCount = {};
+  for (const b of withWid) fmtCount[fmt(b.work_id)] = (fmtCount[fmt(b.work_id)] || 0) + 1;
+  const distinct = new Set(withWid.map((b) => b.work_id)).size;
+  console.log('── HEALTH ──');
+  console.log(`  distinct work_ids: ${distinct}  (avg ${(withWid.length / distinct).toFixed(2)} books/work)`);
+  console.log(`  id formats: ${Object.entries(fmtCount).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join(' · ')}`);
+  console.log(`  coverage gap: ${all.length - withWid.length} live books with NO work_id`);
+  const weak = withWid.filter((b) => /^(bare-slug|cjk-chars|local:other)$/.test(fmt(b.work_id))).length;
+  console.log(`  pre-scheme ids (bare-slug/cjk/other): ${weak}`);
+
+  // cluster books by work_id
+  const byWid = new Map();
+  for (const b of withWid) { if (!byWid.has(b.work_id)) byWid.set(b.work_id, []); byWid.get(b.work_id).push(b); }
+
+  // ── Probe 2: OVER-MERGE (precision lower bound) ──────────────────────────────
+  // A multi-book work_id is suspect if its members don't form one title-core AND
+  // carry ≥2 distinct author-surnames.
+  const overMerge = [];
+  for (const [w, arr] of byWid) {
+    if (arr.length < 2) continue;
+    const surs = new Set(arr.map((b) => surname(b.author)).filter((s) => s.length >= 3));
+    if (surs.size < 2) continue; // single author across the cluster — fine
+    // title cohesion: is there a token shared by a majority of members?
+    const counts = {};
+    for (const b of arr) for (const t of sig(b.title)) counts[t] = (counts[t] || 0) + 1;
+    const maj = Object.values(counts).some((c) => c > arr.length / 2);
+    if (!maj) overMerge.push({ w, n: arr.length, surnames: [...surs].slice(0, 4), titles: arr.slice(0, 3).map((b) => b.title) });
+  }
+  overMerge.sort((a, b) => b.n - a.n);
+  console.log(`\n── OVER-MERGE candidates (≥2 authors, no shared title core): ${overMerge.length} ──`);
+  for (const m of overMerge.slice(0, EX)) console.log(`  ${m.n}× ${m.w}\n     surnames: ${m.surnames.join(', ')}\n     titles: ${m.titles.map((t) => `"${(t || '').slice(0, 32)}"`).join(' | ')}`);
+
+  // ── Probe 3: OVER-SPLIT (recall lower bound) ─────────────────────────────────
+  // Representative book per work_id; cluster work_ids that are near-certainly one
+  // work. HIGH = identical full sig-title set + same surname. MED = Jaccard ≥ 0.7
+  // on ≥3 non-generic tokens. Tibetan reported separately (pecha unsafe).
+  const repByWid = new Map();
+  for (const [w, arr] of byWid) repByWid.set(w, arr[0]);
+  const bySurname = new Map();
+  for (const [w, b] of repByWid) {
+    const sn = surname(b.author);
+    if (sn.length < 4) continue;
+    if (!bySurname.has(sn)) bySurname.set(sn, []);
+    bySurname.get(sn).push({ w, b, toks: new Set(sig(b.title)) });
+  }
+  const splitHigh = [], splitMed = [], splitTib = [];
+  const seen = new Set();
+  for (const [sn, items] of bySurname) {
+    for (let i = 0; i < items.length; i++) {
+      if (seen.has(items[i].w)) continue;
+      const a = items[i]; if (a.toks.size < 2) continue;
+      const akey = [...a.toks].sort().join(' ');
+      const cluster = [a];
+      for (let j = i + 1; j < items.length; j++) {
+        const b = items[j]; if (seen.has(b.w) || b.toks.size < 2) continue;
+        const bkey = [...b.toks].sort().join(' ');
+        const inter = [...a.toks].filter((t) => b.toks.has(t)).length;
+        const jac = inter / new Set([...a.toks, ...b.toks]).size;
+        if (akey === bkey) { b.tier = 'high'; cluster.push(b); }
+        else if (jac >= 0.7 && inter >= 3) { b.tier = 'med'; cluster.push(b); }
+      }
+      if (cluster.length < 2) continue;
+      cluster.forEach((x) => seen.add(x.w));
+      const isTib = trad(a.b) === 'Tibetan';
+      const rec = { sn, n: cluster.length, tier: cluster.some((x) => x.tier === 'med') ? 'med' : 'high', lang: trad(a.b), title: a.b.title, author: a.b.author, ids: cluster.map((x) => x.w) };
+      if (isTib) splitTib.push(rec);
+      else if (rec.tier === 'high') splitHigh.push(rec);
+      else splitMed.push(rec);
+    }
+  }
+  const sumDup = (arr) => arr.reduce((s, r) => s + r.n - 1, 0);
+  console.log(`\n── OVER-SPLIT candidates (same work, multiple work_ids) ──`);
+  console.log(`  HIGH conf (identical title+author, non-Tibetan): ${splitHigh.length} clusters, ~${sumDup(splitHigh)} redundant ids`);
+  console.log(`  MED conf  (token Jaccard ≥0.7, non-Tibetan):     ${splitMed.length} clusters, ~${sumDup(splitMed)} redundant ids`);
+  console.log(`  TIBETAN   (pecha — NOT safe to auto-merge):      ${splitTib.length} clusters, ~${sumDup(splitTib)} ids — human review`);
+  console.log('  HIGH examples:');
+  for (const r of splitHigh.slice(0, EX)) console.log(`    ${r.n}× [${r.lang}] "${(r.author || '').slice(0, 18)}" / "${(r.title || '').slice(0, 30)}"`);
+
+  // ── Probe 4: ANCHOR-MISS (recall vs external QID truth) ──────────────────────
+  // A work known by a QID, with a sibling edition (same surname + high title
+  // overlap) filed under a non-QID local id → a recall miss against real truth.
+  let anchorMiss = 0; const anchorEx = [];
+  for (const [sn, items] of bySurname) {
+    const qids = items.filter((x) => /^Q\d+$/.test(x.w));
+    const locals = items.filter((x) => !/^Q\d+$/.test(x.w));
+    for (const q of qids) {
+      for (const l of locals) {
+        const inter = [...q.toks].filter((t) => l.toks.has(t)).length;
+        const jac = inter / new Set([...q.toks, ...l.toks]).size;
+        if (jac >= 0.6 && inter >= 2) { anchorMiss++; if (anchorEx.length < EX) anchorEx.push(`    QID ${q.w} ↔ ${l.w}  "${(l.b.title || '').slice(0, 30)}" [${trad(l.b)}]`); break; }
+      }
+    }
+  }
+  console.log(`\n── ANCHOR-MISS (QID work with a sibling edition under a local id): ${anchorMiss} ──`);
+  console.log(anchorEx.join('\n'));
+
+  // ── Per-tradition rollup ─────────────────────────────────────────────────────
+  const tr = {};
+  for (const b of withWid) { const t = trad(b); (tr[t] = tr[t] || { books: 0, works: new Set() }).books++; tr[t].works.add(b.work_id); }
+  const splitByLang = {};
+  for (const r of [...splitHigh, ...splitMed]) splitByLang[r.lang] = (splitByLang[r.lang] || 0) + (r.n - 1);
+  console.log(`\n── PER-TRADITION (top 12 by books) ──`);
+  console.log('  tradition'.padEnd(16) + 'books'.padStart(7) + 'works'.padStart(7) + 'split-dups'.padStart(12));
+  for (const [t, v] of Object.entries(tr).sort((a, b) => b[1].books - a[1].books).slice(0, 12)) {
+    console.log(`  ${t.padEnd(14)}${String(v.books).padStart(7)}${String(v.works.size).padStart(7)}${String(splitByLang[t] || 0).padStart(12)}`);
+  }
+
+  console.log(`\n── INTERPRETATION ──`);
+  console.log(`  These are LOWER BOUNDS on error (found cases), not the true rate.`);
+  console.log(`  Over-split (recall) dominates: ~${sumDup(splitHigh) + sumDup(splitMed)} non-Tibetan redundant ids + ${anchorMiss} anchor-misses.`);
+  console.log(`  Over-merge (precision) candidates: ${overMerge.length} (verify — multi-author works produce false positives).`);
+  console.log(`  Grain & Tibetan (~${sumDup(splitTib)} ids) are policy/expertise-gated, not resolver bugs.`);
+  console.log(`  True precision/recall needs a stratified human gold + κ; calibrate over-split HIGH tier first (it's near-certain).`);
+  await client.close();
+}
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Answers "how well does the work_id resolver work?" with the full measurement toolkit: an automatic lower-bound probe **and** a stratified human-gold instrument to calibrate it. Companion to #2909; built like the FT quality harness (#2879).

## 1. `work-resolver-probe.mjs` — automatic lower-bound (zero-token)
Finds errors both directions: over-merge (precision) and over-split (recall). Baseline (live, 15,616 books / 12,417 works, **98.7% coverage**): over-split dominates; 12 anchor-misses vs Wikidata-QID truth; 73 over-merge candidates (mostly the *grain* question — Corpus Hermeticum lumps 22 editions). Per-tradition rollup. **Proves bad-where-flagged; cannot prove good.**

## 2. Gold-labeling instrument — calibrates the probe into real P/R + κ
- `build-work-gold-set.mjs` — deterministic stratified 375-pair sampler, 10 strata: the probe's prediction strata + grain-boundary hard cases (commentary, volume) + easy controls + **two uniform-random strata** (`random_within`, `random_pair`) so it isn't biased to flagged cases.
- `work-identity-gold-rubric.md` — labeling guide encoding the grain rules (so two labelers are consistent → meaningful κ).
- `score-work-gold-set.mjs` — probe precision per stratum + Cohen κ.
- Scope: measures **precision**; full recall needs a separate per-book sibling frame.

## Honesty notes (from a manual spotcheck of the 375 pairs)
- The probe's **over-split HIGH tier is contaminated by numbered/lettered series** (Sumerian "Proverbs collection 10" vs "11") — the token matcher drops the distinguishing token. So my first "near-certain fix queue" claim was overstated (corrected on #2909). **The #2908 merge is unaffected** (it used identical full titles, numbers preserved).
- Follow-up: a **series-guard** (preserve small numeric/roman/letter distinguishers; drop 4-digit years) on probe + merge, then re-run for a clean number.
- Everything else spotchecked good: controls, random strata, anchor_miss, hard_volume, and overmerge (correctly full of probe false-positives like Ptolemy *Cosmographia*↔*Geographia*).

Refs: #2318, #2908, #2909, #2879, `.claude/docs/title-and-work-identity-principles.md`, `.claude/docs/work-identity-gold-rubric.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)