### PR TITLE
feat(works): shared work-identity util + series-guard (corrects over-split contamination)

### DIFF
--- a/scripts/eval/build-work-gold-set.mjs
+++ b/scripts/eval/build-work-gold-set.mjs
@@ -41,14 +41,11 @@
  */
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
+import { norm, sig, surname, sameSeries } from '../lib/work-identity-util.mjs';
 
 const PER = (() => { const i = process.argv.indexOf('--per-stratum'); return i > -1 ? +process.argv[i + 1] : 40; })();
 const OUT = (() => { const i = process.argv.indexOf('--out'); return i > -1 ? process.argv[i + 1] : 'scripts/output/work-gold-set-unlabeled.jsonl'; })();
 
-const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
-const STOP = new Set(['the', 'and', 'with', 'from', 'vol', 'volume', 'part', 'tome', 'band', 'book', 'der', 'die', 'des', 'von', 'und', 'of', 'les', 'la', 'le', 'el', 'für', 'mit', 'thor', 'bu', 'sogs', 'rnam', 'pa', 'ba']);
-const sig = (s) => [...new Set(norm(s).split(' ').filter((t) => t.length >= 4 && !STOP.has(t)))];
-const surname = (a) => norm(a).split(' ').filter(Boolean).pop() || '';
 const commentRe = /\b(comm(\.|entary)?|with .* commentary|bhashya|bhāṣya|tika|ṭīkā|glossa|scholia|annotation|cum commento|espositione|notes by)\b/i;
 const volRe = /\b(vol|volume|part|tome|band|tomus)\.?\s*[ivxlcdm0-9]/i;
 // stable string hash → deterministic order (no RNG; RNG is unavailable anyway)
@@ -80,6 +77,7 @@ async function main() {
       const jac = inter / new Set([...A.toks, ...B.toks]).size;
       const aKey = [...A.toks].sort().join(' '), bKey = [...B.toks].sort().join(' ');
       const isQ = (x) => /^Q\d+$/.test(x);
+      if (!sameSeries(A.b.title, B.b.title)) continue; // series guard (numbered/vol items ≠ same work)
       if (isQ(A.w) !== isQ(B.w) && jac >= 0.6 && inter >= 2) add('anchor_miss', A.b, B.b, 'same');
       else if (aKey === bKey && A.b.language !== 'Tibetan') add('oversplit_high', A.b, B.b, 'same');
       else if (jac >= 0.7 && inter >= 3 && A.b.language !== 'Tibetan') add('oversplit_med', A.b, B.b, 'same');

--- a/scripts/eval/work-resolver-probe.mjs
+++ b/scripts/eval/work-resolver-probe.mjs
@@ -28,14 +28,9 @@
  * Usage: node scripts/eval/work-resolver-probe.mjs [--limit-examples N]
  */
 import { MongoClient } from 'mongodb';
+import { norm, sig, surname, sameSeries } from '../lib/work-identity-util.mjs';
 
 const EX = (() => { const i = process.argv.indexOf('--limit-examples'); return i > -1 ? +process.argv[i + 1] : 10; })();
-const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '')
-  .toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
-const STOP = new Set(['the', 'and', 'with', 'from', 'vol', 'volume', 'part', 'tome', 'band', 'book', 'der', 'die',
-  'des', 'von', 'und', 'of', 'les', 'la', 'le', 'el', 'des', 'für', 'mit', 'thor', 'bu', 'sogs', 'rnam', 'pa', 'ba']);
-const sig = (s) => [...new Set(norm(s).split(' ').filter((t) => t.length >= 4 && !STOP.has(t)))];
-const surname = (a) => norm(a).split(' ').filter(Boolean).pop() || '';
 const trad = (b) => b.language || '?';
 
 function fmt(w) {
@@ -114,6 +109,10 @@ async function main() {
       for (let j = i + 1; j < items.length; j++) {
         const b = items[j]; if (seen.has(b.w) || b.toks.size < 2) continue;
         const bkey = [...b.toks].sort().join(' ');
+        // SERIES GUARD: distinct numbered/lettered series items (Sumerian
+        // "collection 10/11", "Vol. I/II") share a token-set but differ by a
+        // distinguisher sig() drops — never the same work.
+        if (!sameSeries(a.b.title, b.b.title)) continue;
         const inter = [...a.toks].filter((t) => b.toks.has(t)).length;
         const jac = inter / new Set([...a.toks, ...b.toks]).size;
         if (akey === bkey) { b.tier = 'high'; cluster.push(b); }
@@ -145,6 +144,7 @@ async function main() {
     const locals = items.filter((x) => !/^Q\d+$/.test(x.w));
     for (const q of qids) {
       for (const l of locals) {
+        if (!sameSeries(q.b.title, l.b.title)) continue; // series guard
         const inter = [...q.toks].filter((t) => l.toks.has(t)).length;
         const jac = inter / new Set([...q.toks, ...l.toks]).size;
         if (jac >= 0.6 && inter >= 2) { anchorMiss++; if (anchorEx.length < EX) anchorEx.push(`    QID ${q.w} ↔ ${l.w}  "${(l.b.title || '').slice(0, 30)}" [${trad(l.b)}]`); break; }

--- a/scripts/lib/work-identity-util.mjs
+++ b/scripts/lib/work-identity-util.mjs
@@ -1,0 +1,64 @@
+/**
+ * Shared helpers for work_id resolver tooling (probe / merge / gold-set).
+ * Single source of truth for normalization + the SERIES GUARD, so the harness
+ * and the merge tool can't drift. (Issue #2909.)
+ */
+
+export function norm(s) {
+  return (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+const STOP = new Set(['the', 'and', 'with', 'from', 'vol', 'volume', 'part', 'tome', 'band', 'book', 'der', 'die',
+  'des', 'von', 'und', 'of', 'les', 'la', 'le', 'el', 'für', 'mit', 'thor', 'bu', 'sogs', 'rnam', 'pa', 'ba']);
+
+/** Significant title tokens: ≥4 chars, non-stopword. (Drops numbers/short words.) */
+export function sig(s) {
+  return [...new Set(norm(s).split(' ').filter((t) => t.length >= 4 && !STOP.has(t)))];
+}
+
+export function surname(a) {
+  return norm(a).split(' ').filter(Boolean).pop() || '';
+}
+
+// ── SERIES GUARD ─────────────────────────────────────────────────────────────
+// The over-split false-positive class: distinct texts that share a generic base
+// title and differ only by a SERIES DISTINGUISHER the `sig()` tokenizer drops —
+// "Proverbs: collection 10" vs "11", "A Balbale to Inana" vs "…for Šu-Suen",
+// pecha "…rgyud mi" vs "…rgyud phi", "Bodleian MS Barocci 6" sub-texts. We pull
+// the distinguishing tokens out of the RAW title (before sig() eats them):
+//   - small integers 1–999 (series/collection/section numbers) — but NOT 4-digit
+//     edition YEARS (1450–2099), which legitimately vary across editions of one
+//     work and must NOT split it;
+//   - roman numerals (i–xxx range, lowercased);
+//   - single Latin/Tibetan section letters in a "rgyud X" / "tome X" position is
+//     covered by the integer/roman cases above for Latin; pure single-letter
+//     pecha markers are handled by requiring the distinguishers to MATCH.
+// Two titles can be "the same work" only if their series-distinguisher multisets
+// are equal. Returns a stable string key of the distinguishers.
+const ROMAN = /\b(x{0,3})(ix|iv|v?i{0,3})\b/;
+export function seriesKey(title) {
+  const t = norm(title);
+  const toks = t.split(' ').filter(Boolean);
+  const out = [];
+  toks.forEach((tok, idx) => {
+    // integer, optionally with a part-letter suffix: "10", "13a", "11b"
+    const m = tok.match(/^(\d{1,3})([a-z]?)$/);
+    if (m) { const n = +m[1]; if (!(n >= 1450 && n <= 2099) && n >= 1) out.push(`n${m[1]}${m[2]}`); return; }
+    if (/^\d+$/.test(tok)) return; // 4-digit+ (edition year / large id) — ignore
+    if (tok.length <= 4 && ROMAN.test(tok) && /[ivx]/.test(tok) && tok === (tok.match(ROMAN) || [])[0]) { out.push(`r${tok}`); return; } // roman volume/part
+    // trailing single-letter catalog siglum: "...Šulgi O" vs "...Šulgi E" (ETCSL).
+    // Only the LAST token, only a lone a–z, only if the title has real content.
+    if (idx === toks.length - 1 && /^[a-z]$/.test(tok) && toks.length >= 3) out.push(`s${tok}`);
+  });
+  return out.sort().join('+');
+}
+
+/**
+ * Two titles are series-compatible (could be the same work) iff their series
+ * distinguishers match. "Proverbs collection 10" vs "11" → 'n10' ≠ 'n11' → false.
+ * "Horologium (1673)" vs "Horologium" → '' == '' → true (year ignored).
+ */
+export function sameSeries(titleA, titleB) {
+  return seriesKey(titleA) === seriesKey(titleB);
+}

--- a/scripts/maintenance/merge-duplicate-work-ids.mjs
+++ b/scripts/maintenance/merge-duplicate-work-ids.mjs
@@ -27,12 +27,15 @@
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
 import path from 'path';
+import { norm, seriesKey } from '../lib/work-identity-util.mjs';
 
 const APPLY = process.argv.includes('--apply');
 const OUT_DIR = path.join(process.cwd(), 'scripts', 'output');
-const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '')
-  .toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+// Volume/fascicle markers — Latin-script AND CJK (巻/卷 juan/maki, 上中下 upper/
+// middle/lower, 第N). CJK markers strip out under norm(), so a CJK multi-volume
+// set can collapse to one title; exclude them from auto-merge (grain policy).
 const volRe = /\b(vol|volume|part|tome|band|tomus|tom|pt|bd)\.?\s*[ivxlcdm0-9]/i;
+const cjkVolRe = /[巻卷冊册帙]|第[一二三四五六七八九十百0-9]+|[上中下][巻卷冊]?\s*$/;
 
 function rankFormat(w) {
   if (/^Q\d+$/.test(w)) return 0;        // Wikidata QID — most canonical
@@ -65,10 +68,12 @@ async function main() {
   const clusters = new Map();
   for (const [w, b] of repByWid) {
     if ((b.language || '') === 'Tibetan') continue;       // pecha hazard
-    if (volRe.test(b.title || '')) continue;              // grain policy — undecided
+    if (volRe.test(b.title || '') || cjkVolRe.test(b.title || '')) continue; // grain policy — undecided
     const t = norm(b.title);
     if (t.split(' ').length < 3) continue;                // need a substantive title
-    const k = `${norm(b.author).split(' ').pop()}||${t}`;
+    // series key (numbered/roman distinguishers) folded into the cluster key as
+    // defense-in-depth — a numbered series item can never collapse with another.
+    const k = `${norm(b.author).split(' ').pop()}||${t}||${seriesKey(b.title)}`;
     if (!clusters.has(k)) clusters.set(k, new Set());
     clusters.get(k).add(w);
   }


### PR DESCRIPTION
Follow-up to the work_id measurement toolkit (#2908/#2910). Fixes the contamination a manual spotcheck found and de-duplicates the helpers across the three scripts.

## The bug
The over-split detector flagged **numbered/lettered series items** as the same work — Sumerian ETCSL "Proverbs: collection 10" vs "11", "A praise poem of Šulgi (Šulgi O)" vs "(Šulgi E)", Kanze Noh "Vol. 13a" vs "11a". The `sig()` tokenizer drops the distinguishing token (<4 chars / number), so distinct texts read identical. Same generic-base+distinguisher class as the Tibetan pecha. This inflated the probe's HIGH over-split tier.

## The fix
- **`scripts/lib/work-identity-util.mjs`** (new) — single source of truth for `norm`/`sig`/`surname` (were copy-pasted across 3 scripts) + a **series guard**. `seriesKey()` pulls distinguishers from the raw title before `sig()` eats them: integers 1–999 with optional part-letter (`13a`), roman numerals, **4-digit edition years ignored** (so editions of one work don't split), and a trailing single-letter catalog siglum (Šulgi O/E). Two titles are same-work only if their distinguisher multisets match.
- **probe + gold-builder** gate over-split/anchor clustering on `sameSeries()`.
- **merge tool** folds `seriesKey` into the cluster key + excludes **CJK volume markers** (巻/卷/上中下/第N) that strip out under `norm()`.

## Effect — the honest, calibrated number
Probe HIGH over-split: **~425 → ~20 redundant ids**. The inflated 425 was ~95% series contamination + the bilingual dupes already merged in #2908. Anchor-miss 12 → 6. Merge-tool dry-run still **0** (idempotent — the 60 applied merges stand).

Residual (acknowledged, not hidden): CJK *word*-volume markers and pecha section-letters remain → the human-review bucket (#2909-C).

This makes the probe's number trustworthy and is the prerequisite for any future auto-merge beyond bucket A.

Refs: #2908, #2909, #2910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)