### PR TITLE
docs(works): lock grain policy — book-floored work count

### DIFF
--- a/.claude/docs/blog-first-translation-is-not-a-book-draft.md
+++ b/.claude/docs/blog-first-translation-is-not-a-book-draft.md
@@ -1,55 +1,55 @@
 # A First Translation Is Not a Book
 
-*Draft blog post. ~6 min read. Suggested tag: Research / blue. Lead image: a multi-volume spread — the Wubei Zhi (武備志) or Sancai Tuhui (三才圖會) plates. Links to /census. Numbers are from an internal audit of the live catalog (2026-06-30); re-run before publishing as they drift. A few claims flagged [verify].*
+*Draft blog post. ~6 min read. Suggested tag: Research / blue. Lead image: the Articella or a "collected works" title page — a single binding that holds many texts. Links to /census. Numbers are from an internal audit of the live catalog (2026-06-30); re-run before publishing as they drift. A few claims flagged [verify].*
 
 ---
 
-We have quoted a number, on this site and to funders and to ourselves: roughly **5,800 first English translations**. It is the number the catalog returns when you ask how many of our books carry the "First Translation" badge. I have said it out loud more than once.
+We have quoted a number, on this site and to funders and to ourselves: roughly **5,800 first English translations** — the count of books carrying our "First Translation" badge. I have said it out loud more than once.
 
-It is wrong. Not by a rounding error — wrong in two opposite directions at the same time, which is the most interesting way to be wrong. Chasing down *why* turned out to change how we think the whole library should be counted, and maybe how anyone should count a thing like this.
-
-## The book that is a first translation twenty times over
-
-Start with the *Wubei Zhi* (武備志), the great Ming military encyclopedia — two hundred and forty chapters on everything from naval tactics to the famous chart of Zheng He's voyages. We hold it. We translated it. It had never been in English. A real first.
-
-It is also enormous, so we hold it as many physical volumes, and each volume is its own record in our catalog, and each record earned the "First Translation" badge. So the *Wubei Zhi* — one work, one first event in the history of the world — is sitting in our headline number **more than twenty times.** The *Sancai Tuhui* (三才圖會), a Ming illustrated encyclopedia, is in there about fifty times. Huygens' collected *Œuvres* over a dozen.
-
-When we actually deduplicated — counted distinct *works* instead of distinct book records — the 5,814 badges collapsed to about **5,030 distinct works.** Nearly **800 of our "first translations" were the same handful of works, counted again and again** because they happen to be long. [verify: 784 redundant across 384 multi-volume works]
+It is wrong, and the interesting part is the *direction*. I assumed, when we went to check, that we'd been over-counting — inflating the number somehow. The opposite is true. We have been **under-counting**, and badly, because we kept counting the wrong thing: books, when the thing that matters is works.
 
 ## The book that hides a dozen first translations
 
-Now the other direction. Open the *Articella* — the medieval medical textbook that trained Europe's physicians for four centuries. One book, in our catalog; one badge. But it is not one work. It is a *bundle*: Hippocrates' aphorisms, Galen, the Persian physician Ḥunayn ibn Isḥāq, all bound together by a teaching tradition. If those texts had never been Englished, that single badge is hiding not one first translation but several.
+Open the *Articella* — the medieval medical textbook that trained Europe's physicians for four centuries. One book in our catalog; one badge; one tick toward that 5,800. But it is not one work. It is a *bundle*: Hippocrates' aphorisms, Galen, the Persian physician Ḥunayn ibn Isḥāq, bound together by a teaching tradition. If those texts had never been Englished before — and several hadn't — then that single badge is standing in for not one first translation but many.
 
-The catalog is full of these. "Collected Drukpa Kagyu texts." "Writings of the Chief Abbots of Bhutan." Ritual collections, manuscript miscellanies, collected works. We counted **more than 500** first-translation books that are really *containers* of many works — each one a single badge sitting on top of an unknown number of actual firsts. [verify: 515 container-signal, 305 volume-signal]
+The catalog is full of these. "Collected Drukpa Kagyu texts." "Writings of the Chief Abbots of Bhutan." Ritual collections, manuscript miscellanies, collected works. We counted **more than 500** first-translation books that are really *containers* of many works each — every one a single badge sitting on top of a stack of actual firsts we never counted. [verify: 515 container-signal books]
 
-So the headline is too **high** because of the long books, and too **low** because of the bundled ones, and the two errors have nothing to do with each other, so they don't cancel. We are not slightly off. We are counting the wrong kind of thing.
+That is the whole error, and it runs one way: **a book is the floor, not the ceiling.** A book is *at least* one work. Very often it is several. We had been counting the bindings and ignoring what was inside them.
 
-## The realization
+## "More works, the better" — and why that's not inflation
+
+There is a principle underneath this, and it's worth saying plainly: **count works as finely as the works really divide.** A multi-volume encyclopedia like the *Wubei Zhi* (武備志) — two hundred and forty chapters across some twenty volumes, each a distinct treatise we translated — is twenty works, not one. We are not going to flatten twenty volumes of real, separately-rendered scholarship into a single line because they happen to share a spine.
+
+This is the opposite of padding. Padding is claiming a thing you didn't do. This is the reverse: refusing to *hide* things we did do by lumping them together. The honest unit is the work — the actual piece of intellectual content a reader sits down with — and you should resolve it as finely as the content genuinely divides, never more coarsely.
+
+## The wrinkle that proves the unit is the work
+
+Take the *Laozi Yuanyi* (老子元翼), a Ming scholar's anthology of sixty-four classic commentaries on the *Tao Te Ching*. Every one of those sixty-four commentaries has been translated into English somewhere, by someone. And yet the *anthology itself* — Jiao Hong's particular selection and arrangement, the thing *he* made — had never been rendered in English as a whole. So it is a genuine first translation **built entirely out of already-translated parts.** A first made of not-firsts.
+
+That sentence is nonsense if you count books and obvious if you count works. The editor's arrangement is itself a work; it sits *above* its constituents, which are themselves works; and a book can hold any of these. Works within works. The binding tells you nothing about how many works you're holding — only opening it does.
+
+## A first translation is an event, not a property of a book
 
 Here is the sentence that reorganized everything for us:
 
 **A first translation is not a property of a book. It is an event — the first time a work crosses into a language.**
 
-A book is *where you go to read* that translation. It is not the unit you *count*. Once you say it that way, both errors are obvious. A work split across twenty volumes is still one crossing. A bundle of twelve never-translated works is twelve crossings wearing one cover. The book and the event were never the same thing; we just had no other handle to grab, so we grabbed the book.
+A book is *where you go to read* that crossing. It is not the unit you *count*. Once you say it that way, the under-count is obvious: a bundle of twelve never-translated works is twelve crossings wearing one cover, and we'd been writing down "one."
 
-There is a beautiful wrinkle that proves the point. Take the *Laozi Yuanyi* (老子元翼), a Ming scholar's anthology of sixty-four classic commentaries on the *Tao Te Ching*. Every one of those sixty-four commentaries has been translated into English somewhere, by someone. And yet the *anthology itself* — this particular scholar's selection and arrangement, the thing he made — had never been rendered in English as a whole. So it is a genuine first translation **built entirely out of already-translated parts.** A first made of not-firsts. That only makes sense if the unit is the *work*, and the editor's arrangement is itself a work. Count books and the sentence is nonsense; count works and it is simply true.
+This also surfaces a quieter problem — the opposite of over-confidence. A "first translation" claim has been treated as a coin with two sides: first, or not first. But the honest world has a third side: **we don't yet know.** Sometimes a prior translation might exist in a library we can't reach — a 1955 Madras edition no one has digitized. [verify: the Tirukkural–Parimēlaḻakar case] The right thing to show a reader there is not a confident gold badge and not silence, but *"plausibly first — help us check."* Uncertainty deserves to be a state you can see.
 
 ## What we are proposing to build
 
-The fix is not a better badge. It is to stop pretending a title can carry a work's identity, and to model the thing underneath directly:
+The fix is to stop pretending a title can carry a work's identity, and to model the thing underneath directly:
 
 - **Every book declares its contents** — which works are actually inside it. The *Articella* stops being one row and becomes a cover over Hippocrates, Galen, and Ḥunayn.
-- **Every work is one entity**, with all its names (the original script, the transliteration, the famous English name, the variants), its author, its language — so the twenty volumes of the *Wubei Zhi* resolve to one work you can read in twenty places.
-- **A first translation is recorded as an event on a (work, source-language) pair** — not stamped on a book. Then you count events, and the number finally means what it says.
+- **Every work is one entity**, with all of its names — the original script, the transliteration, the famous English name, the variants — its author, its language. A reader finds it by any of those, and the badge attaches to the work, not to a string on a spine.
+- **A first translation is recorded as an event on a (work, source-language) pair.** Then you count events, and the number finally means what it says.
 
-This also fixes a quieter problem. A "first translation" claim has always been treated as a coin with two sides — first, or not first. But the honest world has a third side: **we don't yet know.** Sometimes a prior translation might exist in a library we can't reach, in a 1955 Madras edition no one has digitized. [verify: the Tirukkural–Parimēlaḻakar case] The right thing to show a reader there is not a confident gold badge and not silence, but *"plausibly first — help us check."* Uncertainty deserves to be a state you can see, not a coin flip hidden behind a badge.
+## Why tell you the number is soft
 
-## Why tell you the number is wrong
+We could have quietly picked a cleaner figure and kept quoting it. We are writing this instead because the honesty *is* the product. Source Library exists to make a specific, checkable promise — *this work has never been readable in English before, and now it is.* A promise like that is only worth anything if we hold ourselves to knowing exactly what we are claiming, and admitting the edges where we don't.
 
-We could have quietly deduplicated, picked a cleaner figure, and kept quoting it. The reason we are writing this instead is that the honesty *is* the product. Source Library exists to make a specific, checkable promise — *this work has never been readable in English before, and now it is.* A promise like that is only worth anything if we hold ourselves to knowing exactly what we are claiming, and admitting the edges where we don't.
-
-So here is the honest version, which is less tidy and much more true: **we do not currently know how many first translations we have made.** It is somewhere around five thousand distinct works, minus the long books we double-counted, plus the hundreds of works still hiding inside bundles we have counted as one. The real number is unknowable until every book tells us what is inside it and every work is counted once.
-
-We think that number, once we can finally see it, will be both larger and humbler than the one we have been quoting — larger because of everything bundled out of sight, humbler because some of what looked certain is really *probably*. We would rather get there honestly than keep a rounder number that is wrong in two directions at once.
+So here is the honest version, less tidy and much more true: **we have almost certainly made *more* first translations than the 5,800 we've been quoting — not fewer.** Hundreds of works are still folded inside containers we've been counting as one apiece. We can't give you the exact figure yet; we can give you the direction, and it points up. The number will land both larger and humbler — larger, because of everything bundled out of sight; humbler, because some of what looked certain is really *probably*.
 
 *If you want to watch the count get more honest, the work is open: [sourcelibrary.org/census](https://sourcelibrary.org/census).* [verify: link target]

--- a/.claude/docs/title-and-work-identity-principles.md
+++ b/.claude/docs/title-and-work-identity-principles.md
@@ -106,9 +106,11 @@ Mahābhārata). Below: volume/part, recension, commentary, scope. Complications:
    the Mahābhārata yet a primary work; the Bhīṣma Parva isn't. **Reception decides,
    not containment** — so clean part-of metadata (Toh hierarchy, TEI) never settles
    work-grain.
-2. **Fragmentation — one work scattered across many books** (Mahābhārata Vols. 1–7).
-   The FT claim is about the *complete* text; completeness must be **assembled
-   across manifestations**, never asserted per volume.
+2. **Fragmentation — one *named* work scattered across many books** (Mahābhārata
+   Vols. 1–7). For the **`work_id` clustering** relation, completeness can be read
+   across manifestations. For the **count**, the decided grain policy (Set F) is
+   the opposite: each volume is ≥1 work, so volumes are *not* collapsed. Clustering
+   and counting pull apart here — that's expected, they're different relations.
 3. **The super-relation is overloaded** — series ≠ canon ≠ collected-works ≠
    parent-work. A series is a publication container (no intellectual identity); a
    canon is a curated corpus (its own significance + name-set). Don't flatten them.
@@ -148,61 +150,62 @@ three-state predicate on `(work, source-language)`; and titles, names, layers, a
 "we translated it" are all projections of that.** Pathological as a string, trivial
 as a typed work-graph.
 
-## Principle set F — counting: first-translations are events in the graph
-If the FT claim is a predicate on `(work, source-language)`, then **a
-first-translation is an event in the work-graph, not a property of a book.** A
-book is *where you can read one* — it is not the unit you *count*. The two
-cardinalities (books vs first-translated works) are independent, and they diverge
-in **both directions at once**, so the errors don't even cancel:
+## Principle set F — counting: the work is book-floored and only grows
+**GRAIN POLICY (decided, Derek 2026-06-30):** *every book is **at least** one
+work; a book may contain **more** (works within works); never fewer.* So the work
+count is **floored at the book count and only grows** — monotonic. "More works the
+better." Two consequences:
 
-- **Overcount:** one work spread across many books (multi-volume sets,
-  multi-edition holdings) badges the *same* first N times.
-- **Undercount:** one book that is a multi-work container holds many works; badged
-  as 1, it hides N first-events (or 0, if its constituents were each translated
-  before — see the container-vs-edited-work distinction below).
+- **A multi-volume set is many works**, one per volume (at least). The Mahābhārata
+  in 7 volumes counts as ≥7; the Wubei Zhi in ~20 volumes as ≥20. We do **not**
+  collapse volumes into one work for the count. (This reverses the earlier
+  "volumes = one work" lean.)
+- **A container decomposes into the works within it.** The Articella = Hippocrates
+  + Galen + Ḥunayn (≥3 works under one book); "Collected Drukpa Kagyu texts" = its
+  constituents. This is where most of the *growth* comes from.
 
-**Compilation-as-work vs compilation-as-container** (the subtle case): a
-compilation *can itself* be a first-translation even if every constituent was
-translated elsewhere — **but only when the compilation is an edited work, not a
-container.** Test: is translating all the parts separately the *same thing* as
-translating this compilation? If no — because the selection + arrangement +
-editorial apparatus is itself content — it is a distinct work with its own FT
-status. 老子元翼 is the live proof: its 64 constituent commentaries exist in
-English piecemeal, but Jiao Hong's *anthology* (his selection/arrangement) had
-never been Englished as such → a genuine first *of the compilation*. A bare
-container ("Collection of kabbalistic works") has no such identity → it decomposes
-to its constituents and bears no claim of its own.
+### Two different notions — do NOT conflate them
+This is the load-bearing distinction. There are **two** "work" relations with
+opposite cardinalities:
 
-### Measured proxy error (FT-badged set, 2026-06-30)
-`scripts/_tmp_ft_proxy_error.mjs` (read-only) against the live `is_first_translation`
-+ `visible` + `pages_translated>0` set:
-- **N_books = 5,814** (the current headline unit).
-- **distinct `work_id` ≈ 5,030** → **~784 badges are the same work re-counted**
-  across volumes/editions (≈13% overcount). Concentrated in multi-volume Chinese
-  encyclopedias: 三才圖會 / Sancai Tuhui (52× + 39×), 武備志 / Wubei Zhi
-  (42× + 21× + 20×), 海國圖志 (17×), Huygens *Œuvres* (13×).
-- **515 FT-badged books carry multi-work container signals** (collected/works/
-  various/anthology/miscellany) and **305 carry volume/part signals** — each
-  container holds many works, an *undercount* of unknown-but-large magnitude
-  (Articella = Hippocrates+Galen+Ḥunayn; "Collected Drukpa Kagyu texts"; etc.).
+| | what it is | cardinality |
+|---|---|---|
+| **`work_id` (clustering)** | groups editions + translations of one work, so we can answer *"do we hold the source-language original of this translation?"* | **≤ books** (one work, many manifestations) |
+| **the work *count*** (this policy) | the curatorial tally of distinct intellectual works we hold | **≥ books** (book-floored, grows with decomposition) |
 
-So the honest statement of the headline is: **we do not know the
-first-translated-works count** from book-badges — deduping multi-manifestation
-pulls 5,814 → ~5,030, while decomposing the 515 containers pushes it back up by an
-amount we can't know without their contents manifests. The true number is
-unknowable until firsts are counted as work-graph events. The error is *bounded
-and enumerable*, not mysterious — the divergent set is exactly the
-multi-volume + container books, which are findable by signal.
+`work_id` clustering legitimately puts several books under one id (a translation +
+its original share a `work_id` — that's the whole point). The **count is never
+`distinct work_id`** — that would violate the floor. The bilingual-slug merge
+(#2908) operates on `work_id` *clustering*; it does not reduce the count.
+
+**Compilation-as-work vs container** still applies *above* the book floor: when a
+book is a container, you decompose it into its constituent works — and an *edited*
+compilation (Jiao Hong's 老子元翼: a selection/arrangement that is itself a work)
+is its own work even though its 64 constituent commentaries exist in English
+elsewhere. A bare miscellany decomposes to its parts and bears no claim of its own.
+
+### What this does to the headline (FT-badged set, 2026-06-30: 5,814 books)
+Under the floor, the earlier "dedupe 5,814 → ~5,030" is **wrong** — those ~784
+multi-volume "re-counts" are legitimate distinct works (each volume ≥1 work). The
+only true over-count is **exact duplicate *records*** (the same single edition
+catalogued twice — a small set), not multi-volume sets and not multi-edition
+holdings. The dominant correction is **upward**: the **515 container books**
+decompose into many works each. So:
+
+> **The honest headline is HIGHER than 5,814, not lower** — book-floored, plus
+> container decomposition, minus only true duplicate records. We still can't state
+> the exact number until containers carry a contents manifest (issue #2909), but
+> the *direction* is settled: we have been **under-counting**, by hiding works
+> inside containers.
 
 ## The cheap test (use this until the graph exists)
 > If a reader who knows the field would read the title + "First Translation" badge
 > together and think *"wait, that's been translated for a century,"* the title is
 > naming the wrong layer.
 
-That one mental test catches the whole class. For counting, the parallel test:
-**if you're counting books, you are not counting first-translations** — you are
-counting *places to read them*, off by the multi-volume sets (too high) and the
-anthologies (too low) simultaneously.
+That one mental test catches the whole class. For counting, the parallel:
+**count at the book floor, then look inside containers for more** — never collapse
+volumes or editions to shrink the number.
 
 ---
 

--- a/.claude/docs/work-identity-gold-rubric.md
+++ b/.claude/docs/work-identity-gold-rubric.md
@@ -12,17 +12,23 @@ A *work* is one intellectual creation. A *manifestation* is a particular edition
 printing, translation, or volume of it. You are judging the work, not the copy.
 
 ## Decision rules (these encode the grain policy — apply them, don't re-litigate)
-**SAME work:**
-- Two editions / printings of the same text (incl. different years): *Horologium
-  Oscillatorium* (1673) and *Horologium Oscillatorium* → **same**.
-- A translation and its original, or two translations of one text: source-language
-  recensions of one work are **same** (the first-translation predicate is then
-  per *source-language* — that's a separate axis, not this label).
-- Volumes / parts of ONE work: *Plauti Comoediae* Vol. I and Vol. II → **same**
-  (one work, read in two volumes). *(Policy under decision #2909-B; for the gold,
-  label volumes of one work as SAME and let κ on `hard_volume` reveal disagreement.)*
+> **This rubric labels the `work_id` *clustering* relation** ("are these the same
+> work, for the do-we-hold-the-original question?"). Note the separate **count**
+> policy (Derek 2026-06-30): *every book is **at least** one work; containers hold
+> **more**; count ≥ books.* Clustering can still put two manifestations of one
+> work/volume under one id (count ≥ books does not).
+
+**SAME work (one cluster):**
+- Two editions / printings of the *same* single work or *the same volume* (incl.
+  different years): *Horologium Oscillatorium* (1673) and *Horologium
+  Oscillatorium* → **same**.
+- A translation and its original (of the same work/volume): they cluster — the
+  first-translation predicate is then per *source-language*, a separate axis.
 
 **DIFFERENT works:**
+- **Volumes / parts of a multi-volume set:** *Plauti Comoediae* Vol. I and Vol. II;
+  Wubei Zhi Vol. 6 and Vol. 7 → **different** (decided: each volume is ≥1 work;
+  vol. N clusters only with its *own* editions/original, not with vol. M).
 - A base text and a commentary ON it: Cicero's *Epistolae* vs Manuzio's
   *Commentarius in epistolas Ciceronis* → **different** (the commentary is its own
   creation, even if bound together).
@@ -70,7 +76,9 @@ labeler failures):
   `different` = probe over-merge precision (expect many false positives from
   name-variants / translation editions).
 - `anchor_miss` — recall against external (Wikidata QID) truth.
-- `hard_commentary` / `hard_volume` — the grain-boundary strata; κ here is the real
+- `hard_volume` — under the decided policy these are **different** (each volume ≥1
+  work); the stratum now mostly tests whether labelers apply that consistently.
+- `hard_commentary` — the grain-boundary stratum; κ here is the real
   signal (low κ ⇒ the policy is under-specified, not the resolver wrong).
 
 ## Reading the result


### PR DESCRIPTION
Records the grain decision (Derek, 2026-06-30) that was the open item on #2909, and propagates it through the principles doc, the gold rubric, and the blog draft.

## The decision
**Every book is at least one work; a book may contain more (works within works); never fewer.** The work count is **floored at the book count and only grows** — "more works the better," monotonic.
- Multi-volume sets = many works (one per volume, at least). Reverses the earlier "volumes = one work" lean.
- Containers decompose into the works within — the main source of growth.

## The clarification that makes it coherent (now in the principles doc)
Two relations that must **not** be conflated:
| | role | cardinality |
|---|---|---|
| `work_id` (clustering) | groups editions + translations of one work, for "do we hold the original?" | ≤ books |
| the work **count** | curatorial tally of distinct works | ≥ books (book-floored) |

The count is never "distinct `work_id`." The bilingual-slug merge (#2908) operates on *clustering*, not the count — so it stands, no revert.

## Consequence for the headline
The earlier "dedupe 5,814 → ~5,030" is **wrong** under this policy (multi-volume re-counts are legitimate works). The only true over-count is exact duplicate *records*. The dominant correction is **upward** (decompose the 515 containers): **the honest number is higher than 5,814, not lower.** We've been under-counting.

## Files
- `title-and-work-identity-principles.md` — Set F rewritten; Set D fragmentation note.
- `work-identity-gold-rubric.md` — volumes → different works (clustering); `hard_volume` expectation flipped.
- `blog-first-translation-is-not-a-book-draft.md` — reframed from volume-overcount to container-undercount; still a draft for editorial review.

Refs: #2909, #2908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)