### PR TITLE
feat(works): contents-manifest layer + book-floored FT work count (#2913/#2916)

### DIFF
--- a/.claude/docs/contents-works-schema.md
+++ b/.claude/docs/contents-works-schema.md
@@ -1,0 +1,110 @@
+# `contents_works[]` — the contents-manifest layer
+
+Issues: #2913 (the honest book-floored count) · #2916 (ingest container sub-works).
+Source of truth for the model: `.claude/docs/title-and-work-identity-principles.md`
+(Set F — counting). Read that first; this doc is the schema + operational contract.
+
+## Why this layer exists
+
+The works DB tracks works at the **book grain** — each container book is modeled as
+**one** `work_id`. But a *container* book (Articella = Hippocrates + Galen + Ḥunayn;
+"Collected Drukpa Kagyu texts") holds **many** works. The first-translation headline,
+computed book-by-book, therefore **under-counts**: ~463 FT containers with a chapter
+index hold ~3,157 constituent works we demonstrably already hold.
+
+`contents_works[]` is a **book → sub-works decomposition**. It is *additive* and does
+not touch `work_id`.
+
+> **Two relations, never conflate** (the load-bearing distinction):
+> | | what it is | cardinality |
+> |---|---|---|
+> | `work_id` (clustering) | groups editions+translations of one work → "do we hold the original?" | **≤ books** |
+> | `contents_works[]` + the count | distinct works inside a book; the curatorial tally | **≥ books** (book-floored) |
+>
+> The count is **never** `distinct work_id`. A book is **at least** one work.
+
+## Where it lives
+
+A subdoc array on the **`books`** document (chosen over works-catalog rows: simple,
+local, and the book is the natural floor). One entry per constituent work:
+
+```jsonc
+book.contents_works = [
+  {
+    "title":              "Liber Azoth",        // as it appears in the source
+    "title_en":           "The Book of Azoth",  // English form if distinct, else null
+    "source_language":    null,                  // language we translated FROM (null until set)
+    "page_from":          12,                    // 1-based page index in this book
+    "page_to":            48,
+    "work_id":            null,                  // optional link into the work cluster (#2453)
+    "is_first_translation": null,                // tri-state: true | false | null(unproven)
+    "verified":           false,                 // has this constituent been ft-verify'd? (#2880)
+    "provenance":         "chapter_index",       // how this entry was derived
+    "confidence":         0.96                   // [0,1] — index-reach × thin-penalty
+  }
+]
+```
+
+And a small derivation marker on the book:
+
+```jsonc
+book.contents_works_meta = {
+  "provenance":  "chapter_index",   // seeder that wrote contents_works
+  "index_reach": 1.0,               // chapter index coverage of the book (validation)
+  "est_works":   7,                 // contents_works.length at seed time
+  "derived_at":  "2026-06-30T…Z"
+}
+```
+
+### Field contract
+
+- **`provenance`** — `chapter_index` (derived free from `books.chapters[]`, #2914),
+  later `ai_toc` (AI extraction of chapterless containers — paid, cost-gated), or
+  `manual`. Lets consumers filter provisional from authoritative.
+- **`confidence`** — derived rows: book index-reach, ×0.4 if the entry is "thin"
+  (<2pp extent → likely a mis-leveled section-head). A floor signal, not a verdict.
+- **`is_first_translation` is tri-state** (`true` / `false` / `null=unproven`), per
+  Principle Set E. **A container being FT-badged does NOT make its constituents
+  firsts.** Every `true` must pass ft-verify (`verified: true`) before it is
+  authoritative or counts.
+- **`verified`** — `false` for everything chapter-derived. Flips to `true` only after
+  the #2880 / catalog-match discipline confirms the per-constituent claim.
+
+## Provisional → verified pipeline
+
+1. **Seed (free).** `scripts/maintenance/seed-contents-works.mjs` writes the
+   chapter-derived manifest as **provisional** (`provenance: 'chapter_index'`,
+   `verified: false`). Dry-run by default; `--apply` writes; `--clear` reverses.
+   Backup written before any write.
+2. **Clean.** Thin (<2pp) entries carry low confidence — they are kept but
+   down-weighted, not silently dropped. The 76 chapterless containers + thin/low-reach
+   residual route to AI extraction — **paid, ask before scaling** (Derek's rule).
+3. **Verify per constituent.** ft-verify each `is_first_translation` before it counts.
+4. **Promote.** `verified: true` only after validation. `confidence`/`provenance`
+   stay so consumers can filter.
+
+## The count
+
+`countFirstTranslatedWorks(ftBooks, { mode })` in `scripts/lib/contents-works.mjs` is
+the single canonical function, wired into **both** stats writers
+(`update-homepage-stats.mjs`, `prewarm-browse.mjs`):
+
+- **`mode: 'verified'`** (default, surfaceable) — `Σ max(1, verified-FT constituents)`.
+  Book-floored. Equals the book count until the ft-verify pass lands, then grows.
+  Written to `homepage_stats.firstTranslatedWorks`.
+- **`mode: 'provisional'`** (internal upper bound) — `Σ max(1, contents_works.length)`.
+  Written to `homepage_stats.firstTranslatedWorksProvisional`, clearly an upper bound.
+
+The existing **book** count (`firstTranslationCount`) is unchanged and stays the
+rendered headline — the new figures are additive until verification justifies the
+swap (#2913 Phase 4). Hard invariant, asserted in code: **count ≥ books** — a result
+below the floor means clustering was conflated with counting (a bug).
+
+## Guardrails (carried from #2913 / #2916)
+
+- Provisional by default; never seed unverified sub-works as authoritative.
+- Per-constituent FT is **unverified** until ft-verify'd — ~3,157 is an **upper
+  bound** on first-translated works, not a fact.
+- Reversible writes only (dry-run + backup, #2318 discipline). Ask before paid AI.
+- The only downward correction to the count is **exact duplicate records** — never
+  multi-volume sets, never multi-edition holdings.

--- a/scripts/lib/contents-works.mjs
+++ b/scripts/lib/contents-works.mjs
@@ -38,6 +38,7 @@ export function deriveContentsWorks(book) {
   const chs = book.chapters || [];
   if (!chs.length) return [];
   const top = Math.min(...chs.map((c) => c.level ?? 1));
+  const pages = Number(book.pages_count) || null;
   const seen = new Set();
   const out = [];
   for (const c of chs) {
@@ -51,8 +52,23 @@ export function deriveContentsWorks(book) {
       title: t,
       title_en: c.titleEn && c.titleEn !== c.title ? c.titleEn : null,
       page_from: Number(c.pageNumber) || null,
-      page_to: Number(c.endPage) || Number(c.pageNumber) || null,
+      _rawEnd: Number(c.endPage) || null,
     });
+  }
+  // Resolve page_to. The stored level-1 `endPage` is unreliable — it stops before
+  // its level-2 children and is sometimes malformed (endPage = pageNumber-1, an
+  // inverted range). So: trust a stored end only when it's >= page_from; otherwise
+  // tile to the NEXT level-1 start (page order), clamped to the book's pages_count.
+  // Never emit page_to < page_from.
+  const starts = out.map((e) => e.page_from).filter((n) => n).sort((a, b) => a - b);
+  const nextStart = (from) => { for (const s of starts) if (s > from) return s; return null; };
+  for (const e of out) {
+    if (e.page_from == null) { e.page_to = null; delete e._rawEnd; continue; }
+    let end = e._rawEnd && e._rawEnd >= e.page_from ? e._rawEnd : null;
+    if (end == null) { const ns = nextStart(e.page_from); end = ns ? ns - 1 : (pages || e.page_from); }
+    if (pages) end = Math.min(end, pages);
+    e.page_to = Math.max(e.page_from, end);
+    delete e._rawEnd;
   }
   return out;
 }

--- a/scripts/lib/contents-works.mjs
+++ b/scripts/lib/contents-works.mjs
@@ -1,0 +1,131 @@
+// contents-works.mjs — the contents-manifest layer (#2913 / #2916).
+//
+// Two relations, do NOT conflate (see .claude/docs/title-and-work-identity-principles.md, Set F):
+//   • `work_id` (clustering)    — groups editions+translations of ONE work; ≤ books.
+//   • the work COUNT (this file) — curatorial tally of distinct works; ≥ books (book-floored).
+//
+// A book is AT LEAST one work (grain policy #2909). A *container* book carries
+// several works in `contents_works[]`. This module is the single source of truth
+// for (a) deriving that manifest from the existing `books.chapters[]` index — free,
+// no AI — and (b) the canonical book-floored count.
+//
+// Provenance/confidence ride on every entry so consumers can filter provisional
+// (chapter-derived, unverified) from authoritative (ft-verify'd). Per the grain
+// policy the COUNT is never `distinct work_id`, and is asserted ≥ books.
+
+// Title signals that a book is a multi-work container (mirrors the #2914 estimator).
+export const CONTAINER_RE = /\b(collected works|complete works|collected|selected works|anthology|miscellany|compilation|omnibus|works of|writings of|various|samhita|collection|opera omnia|sammlung)\b/i;
+export const AUTHOR_CONTAINER_RE = /various|multiple|anonymous|collective/i;
+
+// Generic section / apparatus titles that are NOT distinct works.
+const GENERIC_RE = /^\s*(capitulum|caput|chapter|kapitel|chap|part|pars|liber|book|buch|tomus|vol|section|§|canto|sectio|cap\.?|chapitre)\s*[ivxlcdm0-9.]*\s*$|^\s*[ivxlcdm0-9.]+\s*$|^(vorrede|preface|vorwort|introduction|einleitung|index|register|title|titlepage|titelblatt|inhalt|contents|appendix|errata|colophon|dedication|widmung|frontispiece|prologue|prologus|epilogue|notes|bibliography)\b/i;
+
+/** True if the book's title/author carry a container signal. */
+export function isContainerSignal(book) {
+  return CONTAINER_RE.test(book.title || '') || AUTHOR_CONTAINER_RE.test(book.author || '');
+}
+
+/**
+ * Derive the constituent works of a container from its `books.chapters[]` index.
+ * The LEVEL-1 chapters with distinct, non-generic titles ARE the constituent works.
+ * Returns [] when there are no chapters (route those to AI extraction — #2913 Phase 3).
+ *
+ * Each entry: { title, page_from, page_to } — the raw manifest. `confidence`,
+ * `provenance`, `source_language`, `work_id`, `is_first_translation`, `verified`
+ * are layered on by the seeder (they are catalog state, not derivation output).
+ */
+export function deriveContentsWorks(book) {
+  const chs = book.chapters || [];
+  if (!chs.length) return [];
+  const top = Math.min(...chs.map((c) => c.level ?? 1));
+  const seen = new Set();
+  const out = [];
+  for (const c of chs) {
+    if ((c.level ?? 1) !== top) continue;
+    const t = (c.titleEn || c.title || '').trim();
+    if (!t || GENERIC_RE.test(t)) continue;
+    const k = t.toLowerCase().slice(0, 40);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push({
+      title: t,
+      title_en: c.titleEn && c.titleEn !== c.title ? c.titleEn : null,
+      page_from: Number(c.pageNumber) || null,
+      page_to: Number(c.endPage) || Number(c.pageNumber) || null,
+    });
+  }
+  return out;
+}
+
+/**
+ * Validate a derived manifest against the book's pages (two honest signals):
+ *  - reach: max endPage across ALL chapters / pages_count — does the chapter INDEX
+ *           span the whole book? (low reach ⇒ truncated index = real gap).
+ *  - thin:  constituents whose extent (start_i → next level-1 start) is <2pp —
+ *           likely a section-head mis-leveled as a work (over-count).
+ * NB: a level-1 chapter's own `endPage` stops before its level-2 children, so we
+ * tile by next-start, not stored endPage (which under-reports and is sometimes
+ * malformed start>end). Matches the #2914 estimator.
+ */
+export function validateManifest(constituents, allChapters, pagesCount) {
+  const reach = pagesCount
+    ? Math.min(1, Math.max(0, ...allChapters.map((c) => Number(c.endPage) || Number(c.pageNumber) || 0)) / pagesCount)
+    : null;
+  const starts = constituents.map((c) => c.page_from).filter((n) => n).sort((a, b) => a - b);
+  const thinIdx = new Set();
+  for (let i = 0; i < starts.length; i++) {
+    const extent = (i + 1 < starts.length ? starts[i + 1] : (pagesCount || starts[i] + 2)) - starts[i];
+    if (extent < 2) thinIdx.add(starts[i]);
+  }
+  return { reach, thinStarts: thinIdx, thin: thinIdx.size };
+}
+
+/**
+ * Per-constituent confidence in [0,1]: anchored by the book's index reach, with a
+ * penalty for thin (likely mis-leveled) entries. A coarse but honest signal that
+ * lets the count/holdings consumers filter the weakest provisional rows.
+ */
+export function entryConfidence({ reach, isThin }) {
+  let c = reach == null ? 0.5 : Math.max(0, Math.min(1, reach));
+  if (isThin) c *= 0.4;
+  return +c.toFixed(2);
+}
+
+/**
+ * THE CANONICAL COUNT (#2913). Book-floored work count over the FT-eligible set.
+ *
+ * Per the grain policy (Set F): count = Σ over books of max(1, qualifying
+ * constituents). Every book contributes ≥1 (the floor); a container contributes
+ * its decomposed works instead. The result is ALWAYS ≥ books — asserted by callers.
+ *
+ * modes:
+ *   'verified'    — only constituents that are individually FT-verified count above
+ *                   the floor (`is_first_translation === true && verified === true`).
+ *                   This is the HONEST, surfaceable number. With nothing verified yet
+ *                   it equals the book count — and rises as the ft-verify pass lands.
+ *   'provisional' — every chapter-derived constituent counts (max(1, contents_works.length)).
+ *                   An UPPER BOUND on first-translated works, not a fact — for internal
+ *                   sizing only, never the public headline until verified.
+ *
+ * `dupRecords` is the only downward correction (exact duplicate *records* — the same
+ * single edition catalogued twice). NOT multi-volume sets, NOT multi-edition holdings.
+ * Defaults to 0 (we do not auto-detect it here).
+ */
+export function countFirstTranslatedWorks(ftBooks, { mode = 'verified', dupRecords = 0 } = {}) {
+  let count = 0;
+  for (const b of ftBooks) {
+    const cw = Array.isArray(b.contents_works) ? b.contents_works : [];
+    if (mode === 'provisional') {
+      count += Math.max(1, cw.length);
+    } else {
+      const verified = cw.filter((e) => e.is_first_translation === true && e.verified === true);
+      count += Math.max(1, verified.length);
+    }
+  }
+  count -= Math.max(0, dupRecords);
+  // Hard invariant: the count is book-floored (minus only true duplicate records).
+  if (count < ftBooks.length - Math.max(0, dupRecords)) {
+    throw new Error(`countFirstTranslatedWorks: ${count} < book floor ${ftBooks.length} — clustering was conflated with counting`);
+  }
+  return count;
+}

--- a/scripts/maintenance/prewarm-browse.mjs
+++ b/scripts/maintenance/prewarm-browse.mjs
@@ -56,6 +56,7 @@ if (process.env.MONGODB_URI) {
   try {
     const { MongoClient } = await import('mongodb');
     const { countDistinctLanguages } = await import('../lib/language-count.mjs');
+    const { countFirstTranslatedWorks } = await import('../lib/contents-works.mjs');
     const client = await MongoClient.connect(process.env.MONGODB_URI);
     const db = client.db('bookstore');
     const books = db.collection('books');
@@ -91,7 +92,12 @@ if (process.env.MONGODB_URI) {
       readable: verificationReadable,
       pct: verificationReadable ? +(100 * verificationChecked / verificationReadable).toFixed(1) : 0,
     };
-    const stats = { totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, updatedAt: new Date() };
+    // Book-floored FT WORK count (#2913) — see update-homepage-stats.mjs. Keep in sync.
+    const ftBooks = await books.find({ ...translatedFilter, is_first_translation: true })
+      .project({ _id: 0, contents_works: 1 }).toArray();
+    const firstTranslatedWorks = countFirstTranslatedWorks(ftBooks, { mode: 'verified' });
+    const firstTranslatedWorksProvisional = countFirstTranslatedWorks(ftBooks, { mode: 'provisional' });
+    const stats = { totalBooks, translatedToEnglish, firstTranslationCount, firstTranslatedWorks, firstTranslatedWorksProvisional, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, updatedAt: new Date() };
     await db.collection('system_config').updateOne(
       { _id: 'homepage_stats' },
       { $set: stats },

--- a/scripts/maintenance/seed-contents-works.mjs
+++ b/scripts/maintenance/seed-contents-works.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * seed-contents-works.mjs — ingest the chapter-derived contents manifest into
+ * `books.contents_works[]` as PROVISIONAL entries (#2916 Phase 2 / #2913 Phase 2a).
+ *
+ * Free (no AI): the constituent works come from the existing `books.chapters[]`
+ * index (level-1, non-generic titles) — see scripts/lib/contents-works.mjs and the
+ * #2914 estimator. Every entry is provisional: provenance:'chapter_index',
+ * verified:false, is_first_translation:null. A container being FT-badged does NOT
+ * make its constituents firsts — that needs the ft-verify pass before it counts.
+ *
+ * SAFE BY DEFAULT: dry-run unless --apply. Before any write, a backup of the prior
+ * state of every touched book is dumped to scripts/output/. Fully reversible: --clear
+ * removes chapter-derived manifests.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; \
+ *     node scripts/maintenance/seed-contents-works.mjs            # dry-run report
+ *     node scripts/maintenance/seed-contents-works.mjs --apply    # write (with backup)
+ *     node scripts/maintenance/seed-contents-works.mjs --all-ft   # all FT books, not just container-signal
+ *     node scripts/maintenance/seed-contents-works.mjs --clear --apply   # reverse: drop chapter-derived manifests
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+import {
+  isContainerSignal,
+  deriveContentsWorks,
+  validateManifest,
+  entryConfidence,
+} from '../lib/contents-works.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const ALL_FT = process.argv.includes('--all-ft');
+const CLEAR = process.argv.includes('--clear');
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+const FT = { is_first_translation: true, visible: true, pages_translated: { $gt: 0 } };
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+  const c = new MongoClient(uri); await c.connect();
+  const books = c.db(process.env.MONGODB_DB || 'bookstore').collection('books');
+  fs.mkdirSync('scripts/output', { recursive: true });
+
+  if (CLEAR) return clear(books, c);
+
+  const all = await books.find(FT)
+    .project({ _id: 0, id: 1, title: 1, author: 1, pages_count: 1, chapters: 1, contents_works: 1 })
+    .toArray();
+  const containers = ALL_FT ? all : all.filter(isContainerSignal);
+  const withCh = containers.filter((b) => Array.isArray(b.chapters) && b.chapters.length);
+
+  const ops = [];
+  const backup = [];
+  let sumWorks = 0, singleton = 0, thinTotal = 0, lowReach = 0, reachN = 0;
+
+  for (const b of withCh) {
+    const cons = deriveContentsWorks(b);
+    const v = validateManifest(cons, b.chapters, b.pages_count);
+    if (v.reach != null) { reachN++; if (v.reach < 0.7) lowReach++; }
+    thinTotal += v.thin;
+    if (cons.length <= 1) singleton++;          // false-positive container — manifest implicit
+    if (cons.length < 2) continue;              // don't seed singletons (book floor already = 1)
+
+    const contents_works = cons.map((e) => ({
+      title: e.title,
+      title_en: e.title_en || null,
+      source_language: null,                    // language we translated FROM — set later, not derivable here
+      page_from: e.page_from,
+      page_to: e.page_to,
+      work_id: null,                            // optional cluster link (#2453) — set later
+      is_first_translation: null,               // tri-state; unproven until ft-verify'd
+      verified: false,
+      provenance: 'chapter_index',
+      confidence: entryConfidence({ reach: v.reach, isThin: v.thinStarts.has(e.page_from) }),
+    }));
+    sumWorks += contents_works.length;
+
+    backup.push({ book_id: b.id, prev_contents_works: b.contents_works ?? null });
+    ops.push({
+      updateOne: {
+        filter: { id: b.id },
+        update: { $set: {
+          contents_works,
+          contents_works_meta: {
+            provenance: 'chapter_index',
+            index_reach: v.reach,
+            est_works: contents_works.length,
+            derived_at: new Date(),
+          },
+        } },
+      },
+    });
+  }
+
+  console.log(`FT books: ${all.length} | containers (${ALL_FT ? 'ALL FT' : 'signal'}): ${containers.length} | with chapters: ${withCh.length}`);
+  console.log(`seedable (≥2 constituents): ${ops.length} books → ${sumWorks} provisional constituent works (+${sumWorks - ops.length} over 1-each)`);
+  console.log(`singletons skipped (book floor already 1): ${singleton} | thin entries (<2pp): ${thinTotal} | low-reach books (<70%): ${lowReach}/${reachN}`);
+
+  if (!APPLY) {
+    const preview = `scripts/output/contents-works-seed-preview-${stamp}.jsonl`;
+    fs.writeFileSync(preview, backup.map((_, i) => JSON.stringify({
+      book_id: ops[i].updateOne.filter.id,
+      est_works: ops[i].updateOne.update.$set.contents_works.length,
+      titles: ops[i].updateOne.update.$set.contents_works.map((w) => w.title).slice(0, 12),
+    })).join('\n') + '\n');
+    console.log(`\nDRY RUN — nothing written. Preview → ${preview}`);
+    console.log('Re-run with --apply to write (a backup of prior state is saved first).');
+    return c.close();
+  }
+
+  const backupPath = `scripts/output/contents-works-backup-${stamp}.jsonl`;
+  fs.writeFileSync(backupPath, backup.map((x) => JSON.stringify(x)).join('\n') + '\n');
+  console.log(`\nBackup of prior state (${backup.length} books) → ${backupPath}`);
+  const res = ops.length ? await books.bulkWrite(ops, { ordered: false }) : { modifiedCount: 0, upsertedCount: 0 };
+  console.log(`APPLIED: matched=${res.matchedCount ?? '—'} modified=${res.modifiedCount}`);
+  await c.close();
+}
+
+async function clear(books, c) {
+  const q = { 'contents_works_meta.provenance': 'chapter_index' };
+  const n = await books.countDocuments(q);
+  console.log(`chapter-derived manifests present on ${n} books`);
+  if (!APPLY) { console.log('DRY RUN — re-run with --clear --apply to remove them.'); return c.close(); }
+  const res = await books.updateMany(q, { $unset: { contents_works: '', contents_works_meta: '' } });
+  console.log(`CLEARED: modified=${res.modifiedCount}`);
+  await c.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/update-homepage-stats.mjs
+++ b/scripts/maintenance/update-homepage-stats.mjs
@@ -7,6 +7,7 @@
  */
 import { MongoClient } from 'mongodb';
 import { countDistinctLanguages } from '../lib/language-count.mjs';
+import { countFirstTranslatedWorks } from '../lib/contents-works.mjs';
 
 const uri = process.env.MONGODB_URI;
 if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -55,7 +56,18 @@ const verification_coverage = {
   pct: verificationReadable ? +(100 * verificationChecked / verificationReadable).toFixed(1) : 0,
 };
 
-const stats = { totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, updatedAt: new Date() };
+// Book-floored FT WORK count (#2913). firstTranslationCount above counts FT *books*;
+// a container book holds several works. `firstTranslatedWorks` decomposes containers
+// via the provisional contents_works[] manifest (#2916), counting only individually
+// ft-verify'd constituents above the book floor (honest, == books until verification
+// lands), and `…Provisional` counts every chapter-derived constituent (upper bound).
+// Both are book-floored (≥ firstTranslationCount), asserted by countFirstTranslatedWorks.
+const ftBooks = await books.find({ ...translatedFilter, is_first_translation: true })
+  .project({ _id: 0, contents_works: 1 }).toArray();
+const firstTranslatedWorks = countFirstTranslatedWorks(ftBooks, { mode: 'verified' });
+const firstTranslatedWorksProvisional = countFirstTranslatedWorks(ftBooks, { mode: 'provisional' });
+
+const stats = { totalBooks, translatedToEnglish, firstTranslationCount, firstTranslatedWorks, firstTranslatedWorksProvisional, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, updatedAt: new Date() };
 
 await db.collection('system_config').updateOne(
   { _id: 'homepage_stats' },


### PR DESCRIPTION
Builds the free, reversible foundation for the honest first-translation number under the locked grain policy (#2912): **every book is ≥1 work; containers hold more; the count is floored at the book count and only grows.** Sibling of the read-only estimator shipped in #2914.

## What this adds

- **`scripts/lib/contents-works.mjs`** — single source of truth:
  - `deriveContentsWorks(book)` — level-1, non-generic chapter titles ARE the constituent works (free; no AI).
  - `validateManifest()` — index-reach + thin-entry detection (mirrors the #2914 estimator).
  - **`countFirstTranslatedWorks(ftBooks, { mode })`** — the canonical count. Book-floored, `count ≥ books` asserted in code. `'verified'` (only individually ft-verify'd constituents count above the floor) vs `'provisional'` (every chapter-derived constituent — an upper bound).
- **`scripts/maintenance/seed-contents-works.mjs`** — ingests the chapter-derived manifest into `books.contents_works[]` as **provisional** (`verified:false`, `is_first_translation` tri-state `null`). **Dry-run by default**; `--apply` writes with a prior-state backup; `--clear` reverses.
- **Wired `countFirstTranslatedWorks()` into both stats writers** (`update-homepage-stats.mjs` + `prewarm-browse.mjs`) — adds `firstTranslatedWorks` (verified) and `firstTranslatedWorksProvisional` (upper bound) alongside the **unchanged** `firstTranslationCount` headline.
- **`.claude/docs/contents-works-schema.md`** — schema + provisional→verified contract.

## Measured result (applied to prod)

| figure | value |
|---|---|
| `firstTranslationCount` (FT **books**, headline — unchanged) | **5,814** |
| `firstTranslatedWorks` (verified, book-floored) | **5,814** |
| `firstTranslatedWorksProvisional` (upper bound) | **8,508** |

388 FT containers seeded → 3,082 provisional constituents (+2,694 over 1-each). Matches the issue's ~8,500 estimate. Invariant `count ≥ books` holds.

## In scope / out of scope

**In:** schema, the free chapter-derived seed (reversible, backed up), the canonical count, both stats wirings, the invariant assertion.

**Out (deliberately, gated behind cost sign-off — Derek's rule):**
- Per-constituent **ft-verify** — so the **public headline does NOT change**; the verified figure stays book-floored at 5,814 and rises only as constituents are verified. 8,508 is an *upper bound* on first-translated works, not a fact.
- The **76 chapterless containers** (need paid AI extraction).
- Frontend rendering of the new figures (stats are populated additively; no surface reads them yet).

## Reversibility
`node scripts/maintenance/seed-contents-works.mjs --clear --apply` removes every chapter-derived manifest. Prior state backed up to `scripts/output/contents-works-backup-*.jsonl`.

Refs: #2913 #2916 #2909 #2453 #2318 #2914. Source of truth: `.claude/docs/title-and-work-identity-principles.md` (Set F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)