### PR TITLE
feat(works): multilingual container signal — close the non-Latin recall gap (#2916)

### DIFF
--- a/.claude/docs/contents-works-schema.md
+++ b/.claude/docs/contents-works-schema.md
@@ -75,7 +75,15 @@ book.contents_works_meta = {
 1. **Seed (free).** `scripts/maintenance/seed-contents-works.mjs` writes the
    chapter-derived manifest as **provisional** (`provenance: 'chapter_index'`,
    `verified: false`). Dry-run by default; `--apply` writes; `--clear` reverses.
-   Backup written before any write.
+   Backup written before any write. The container set is identified by
+   `isContainerSignal()` (title/author tokens) — kept **multilingual but
+   high-precision** (`CONTAINER_RE`): English/Latin collected-works tokens plus
+   precision-validated Tibetan (`thor bu`, `bka' 'bum`, `gsung 'bum`) and Greek/
+   Latin (`operum`, `corpus`). A broad "decompose anything with ≥2 chapters" rule
+   is **deliberately rejected** — Latin/German/Sanskrit FT books are
+   monograph-dominated (descriptive chapter titles ≠ distinct works), so it would
+   over-count. CJK collected-works tokens were measured and dropped (no genuine
+   yield in this corpus). Re-validate any new token against a sample before adding.
 2. **Clean.** Thin (<2pp) entries carry low confidence — they are kept but
    down-weighted, not silently dropped. The 76 chapterless containers + thin/low-reach
    residual route to AI extraction — **paid, ask before scaling** (Derek's rule).

--- a/scripts/lib/contents-works.mjs
+++ b/scripts/lib/contents-works.mjs
@@ -13,8 +13,21 @@
 // (chapter-derived, unverified) from authoritative (ft-verify'd). Per the grain
 // policy the COUNT is never `distinct work_id`, and is asserted ≥ books.
 
-// Title signals that a book is a multi-work container (mirrors the #2914 estimator).
-export const CONTAINER_RE = /\b(collected works|complete works|collected|selected works|anthology|miscellany|compilation|omnibus|works of|writings of|various|samhita|collection|opera omnia|sammlung)\b/i;
+// Title signals that a book is a multi-work container.
+//
+// The English/Latin set mirrors the #2914 estimator. The non-English tokens were
+// added in a precision-validated pass (#2916): each was measured against the FT
+// corpus and kept only where the books it catches are GENUINE containers, not
+// monographs whose chapters merely have descriptive titles. Deliberately EXCLUDED
+// after measuring: a broad "derive >=2 over everything" rule (Latin/German/Sanskrit
+// FT books are monograph-dominated — "Codicillus" has 93 chapters but is one work),
+// and CJK collected-works tokens 全集/文集 (catch ~nothing in this corpus) and 全書
+// (only hits illustrated encyclopedias whose "sections" are plates, not works).
+// Validated high-precision additions:
+//   • Tibetan  `thor bu` (miscellanea), `bka' 'bum` / `gsung 'bum` (collected works)
+//   • Latin/Gk `operum` (genitive of opera — "[Epitome] of all the works of …"),
+//              `corpus` (Corpus Hermeticum, Hippocratic Corpus, Corpus Medicorum)
+export const CONTAINER_RE = /\b(collected works|complete works|collected|selected works|anthology|miscellany|compilation|omnibus|works of|writings of|various|samhita|collection|opera omnia|operum|corpus|sammlung)\b|thor bu|bka.{0,2}\s?.?bum|gsung\s?.?bum/i;
 export const AUTHOR_CONTAINER_RE = /various|multiple|anonymous|collective/i;
 
 // Generic section / apparatus titles that are NOT distinct works.


### PR DESCRIPTION
Follow-up to #2917. Spot-checking the contents-manifest seed found the container signal (`CONTAINER_RE`) was English-script-biased — genuine non-Latin containers were silently unseeded.

## The gap (and why it needed care, not a blanket rule)
Measured over the FT corpus: **3,248 unsignaled FT books derive ≥2 works**, but that pool is *ambiguous* — Latin (1,218), German (694) and Sanskrit (70) are **monograph-dominated** (e.g. "Codicillus seu vade mecum" = 93 chapters but **one** work; "De legibus Hebraeorum libri tres" = one work in 3 books). Dropping the signal filter would over-count to a false ~28k. So this adds only **precision-validated** tokens, each measured against a real sample:

| token | script | books | verdict |
|---|---|---|---|
| `thor bu` | Tibetan (miscellanea) | 40 | genuine — distinct rituals/sutras/tantras |
| `bka' 'bum` / `gsung 'bum` | Tibetan (collected works) | 4 | genuine |
| `operum` | Greek/Latin (genitive of *opera*) | 5 | genuine — Galen/Aristotle/Augustine collected works |
| `corpus` | Greek/Latin | 7 | genuine — Corpus Hermeticum, Hippocratic Corpus (24 treatises), Corpus Medicorum |

**Deliberately excluded** (tested, dropped): the blanket "≥2 chapters" rule (monograph over-decomposition), and CJK `全集`/`文集`/`全書` (no genuine yield in this corpus — the CJK FT books are individual works or illustrated encyclopedias whose "sections" are plates, not works).

## Result (re-seeded on prod, reversible + backed up)
- container books: 388 → **441**
- provisional constituents: 3,082 → **3,620**
- `firstTranslatedWorksProvisional`: 8,508 → **8,993**
- `firstTranslatedWorks` (verified) unchanged at **5,814**; headline unchanged; invariants hold.

## Spot-checked the new additions
Galen's *Epitomes Omnium Operum* → 42 treatises, *Operum Aristotelis* → 29, *Corpus Hermeticum and Plotinus* → Poimandres + the discourses, *Hippocratic Corpus* → the 24 treatises, multiple Tibetan *thor bu* → distinct sutras/rituals. Page ranges clean (the #2917 tiling fix applied). All genuine distinct works.

Out of scope (still gated): per-constituent ft-verify (paid), the 76 chapterless containers (paid AI).

Refs: #2916 #2913 #2917. Source of truth: `.claude/docs/title-and-work-identity-principles.md` (Set F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)