### PR TITLE
feat(libraries): register Biblioteca Nazionale Marciana as a partner

### DIFF
--- a/src/lib/library-partners.ts
+++ b/src/lib/library-partners.ts
@@ -185,6 +185,16 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     color: 'violet',
     heroImageOverride: 'https://images.sourcelibrary.org/pages/69b52c393dd6d9423027eb56/0003.jpg',
   },
+  'marciana': {
+    slug: 'marciana',
+    name: 'Biblioteca Nazionale Marciana',
+    shortName: 'Marciana',
+    providerKey: 'marciana',
+    url: 'https://bibliotecanazionalemarciana.cultura.gov.it',
+    description: 'The Biblioteca Nazionale Marciana in Venice, founded on Cardinal Bessarion\'s 1468 bequest of his Greek library, is one of the greatest surviving collections of Greek manuscripts. Among its treasures is the Codex Marcianus (Gr. Z. 299), the earliest and most important witness to the corpus of the Greek alchemists.',
+    color: 'gold',
+    heroImageOverride: 'https://images.sourcelibrary.org/manuscripts/marciana-gr-299/399.jpg',
+  },
   'leiden': {
     slug: 'leiden',
     name: 'Leiden University Library',

--- a/src/lib/types/image-source.ts
+++ b/src/lib/types/image-source.ts
@@ -43,6 +43,7 @@ export type ImageSourceProvider =
   | 'qdl'            // Qatar Digital Library / British Library
   | 'escorial'       // Real Biblioteca del Monasterio de El Escorial
   | 'bnp'            // Biblioteca Nacional de Portugal
+  | 'marciana'       // Biblioteca Nazionale Marciana, Venice
   | 'irht'           // IRHT (CNRS)
   | 'bdrc'           // Buddhist Digital Resource Center
   | 'ndl'            // National Diet Library of Japan (alternate key)


### PR DESCRIPTION
## What
Registers the **Biblioteca Nazionale Marciana** (Venice) as a Source Library partner:
- Adds `'marciana'` to the `ImageSourceProvider` union (`src/lib/types/image-source.ts`).
- Adds a `LIBRARY_PARTNERS['marciana']` entry (`src/lib/library-partners.ts`) → renders `/libraries/marciana`.

## Why
We just imported the **Codex Marcianus** (Gr. Z. 299), the earliest witness to the Greek alchemical corpus. The `/libraries/*` credit page is driven by `LIBRARY_PARTNERS`; without an entry the provider has no home page.

## Hero image
fol. 188v — the **Chrysopoeia of Cleopatra** (the ouroboros inscribed *ἓν τὸ πᾶν*, 'the One is the All'), the most iconic image in the history of alchemy.

## No DB change needed
Books already carry `image_source.provider='marciana'` and the Supabase catalog has `image_source_provider='marciana'` (verified), so `/libraries/marciana` populates on deploy. `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)