### PR TITLE
docs(marciana): edition/facsimile pairing + concordance & confidence builders

### DIFF
--- a/.claude/docs/edition-facsimile-pairing.md
+++ b/.claude/docs/edition-facsimile-pairing.md
@@ -1,0 +1,188 @@
+# Edition-of-record ↔ facsimile-of-record — the manuscript/edition pairing
+
+**Read this first** before adding a text layer to any manuscript whose script is
+hard to OCR (Greek minuscule, cuneiform, hieroglyphic, dense/abbreviated hands),
+or before "fixing" the OCR on such a book. The short version:
+
+> **For hard scripts, the published critical edition carries the *text*; the
+> manuscript carries the *facsimile* and everything that is only true of *this
+> physical object*.** Don't try to make raw OCR of the manuscript into the
+> authoritative transcription — pair it with the edition instead.
+
+Worked reference case: **Marcianus graecus Z. 299** (the *Codex Marcianus*, book
+`6a45298cc6d95bc278fbc8c3`) paired with **Berthelot & Ruelle,
+*Collection des anciens alchimistes grecs*** (1887–88; the Greek text volume is
+`6994383a6879ff0184cb803a`). Cross-linked via the shared work
+`corpus-of-the-greek-alchemists` (see [[work-identity-coverage]]).
+
+## The precedent this generalizes
+
+We already do this, implicitly, for the shelves where the ancient script is
+effectively un-OCR-able: the **Akkadian (~390)** and **Egyptian (~154)**
+holdings are carried by *printed scholarly editions* — King's *Seven Tablets of
+Creation* (Enuma Elish), Budge's *Book of the Dead* — whose transliteration +
+translation OCR cleanly, with the wedges/glyphs shown as plates/facsimile. We do
+not OCR cuneiform or hieroglyphs directly. This doc makes that pattern explicit
+and extends it to difficult **Greek minuscule**, where the same failure mode
+appears.
+
+## Why: the OCR on a 10th-c. minuscule hand cannot be trusted verbatim
+
+Measured on Marcianus 299 (full-quality `gemini-3-flash-preview`, ~1400px scans —
+Internet Culturale's public ceiling):
+
+- **Run-to-run self-agreement ≈ 0.62** (word-level Dice, accent-normalized, 393
+  text pages). The same model on the same images disagrees with itself on ~38%
+  of word-tokens. A faithful reader is deterministic; a model that *interpolates*
+  diverges. (We hold two independent passes — see "confidence layer" below.)
+- **Image-adjudicated hallucination.** On Carta 93r the manuscript plainly reads
+  `τῶν μετάλλων· καὶ τὰ ὑγρόδρυα τῶν βοτανῶν` (= Berthelot); our OCR *dropped the
+  legible words* and substituted invented text, and garbled the famous line
+  `ὁ Ἴων ὁ ἱερεὺς τῶν ἀδύτων` ("Ion, priest of the sanctuaries") into
+  non-Greek. The output *reads fluently* — that is the danger.
+- **Strongly content-dependent.** Display text / inscriptions / diagram labels
+  are near-perfect (the Chrysopoeia ring `ἓν τὸ πᾶν…` matched verbatim); recipe /
+  apparatus prose is largely reliable; dense allegorical/narrative folios
+  (Zosimos's *Visions*) are where it fabricates.
+
+**Consequence for scholars:** the facsimile is sound; reading/translation-for-
+sense is fine with care; **quoting the Greek verbatim from the OCR is not safe**
+without collation. The translation inherits OCR errors (garbled Greek →
+confidently wrong English — the [[lesson_meta_annotation_quote_leak]] failure
+mode, one layer down). Berthelot (whose base manuscript *is* M) remains the
+scholarly authority for the text.
+
+## The layer stack (per folio)
+
+| Layer | Source of record | Notes |
+|---|---|---|
+| **Facsimile image** | Marcianus manuscript | primary evidence; the reason to hold the object |
+| **Transcription (Greek)** | **Berthelot**, via concordance | our OCR body demoted to a *flagged* rough aid |
+| **Translation (EN / FR)** | **Berthelot** | AI-from-clean-Greek (EN) + Berthelot's human French (PD) |
+| **Diagrams / gallery** | Marcianus **image extraction** | Chrysopoeia, kerotakis, alembics — cropped from the real folios |
+| **Annotations** (`<image-desc>`, `<page-type>`, `<margin>`, `<note>`, `<vocab>`, `<scan-quality>`) | Marcianus **OCR annotation layer** | manuscript-native; the *reliable* part of our OCR |
+| **Confidence / provenance** | two-pass OCR agreement + Berthelot coverage | research/QA signal, not shown as authority |
+
+The governing split: **edition carries the words; manuscript carries everything
+that is only true of *this object*.**
+
+## The OCR splits in two — keep vs demote
+
+"Demoting the OCR" is **not** deleting it. Our OCR output is two different things
+welded together:
+
+- **KEEP — the annotation/metadata layer.** `<image-desc>` (drove image
+  extraction; the Chrysopoeia description checked out against the image),
+  `<page-type>` (classification that selects illustration candidates),
+  `<margin>` / `<note>` / `<gloss>` (physical marginalia of *this* folio),
+  `<vocab>` (search terms), `<scan-quality>`. These describe the object, are
+  vision/classification work the model does *well*, and have no equivalent in a
+  printed edition. Keep them live.
+- **DEMOTE — the verbatim Greek transcription body.** Unreliable on hard folios.
+  Replace as text-of-record with Berthelot (via concordance); keep the OCR body
+  as a clearly-flagged aid plus the confidence layer, never presented as the
+  authoritative transcription.
+
+## The concordance (the join table)
+
+Berthelot prints **M-folio marks** throughout ("f. 93 r.", inline `(f. 171 r.)`,
+headnote *"Transcrit sur M, f. 92 v."*), and the digitization's page labels carry
+the **same foliation** ("Carta: 93r"). They lock together directly on M's
+foliation — verified against independent anchors (Zosimos *On Virtue* headnote
+f.92v→Marc p207/Bert p13; the *ἀφροσέληνον* inline mark f.171r→Marc p364/Bert
+p30). Artifact: **`scripts/output/marcianus-berthelot-concordance.json`** —
+195 folios locked page-for-page; the running sequence is monotonic (consecutive
+folios → consecutive pages on both sides), the signature of a correct alignment.
+
+**Gotcha — M-only extraction.** A naive `f. NN r/v` regex over-counts badly: it
+sweeps in Berthelot's *apparatus references to other manuscripts* ("collated
+with A, f. 85r; with K, f. 1r"). Restrict to **M signals only** — the base-
+manuscript inline parentheticals `(f. NNr)` plus explicit `M, f. NN` headnotes —
+and exclude other-siglum refs. (First pass wrongly claimed 74%; M-only gave a
+trustworthy 195 and the anchors then landed.)
+
+**Open refinements:** ~79 referenced folios don't yet resolve to a Carta label
+(edge folios, the `M²` duplicate f.115r, a few mislabeled tags); multi-page rows
+(`f.112v → 44,52`) need "primary transcription page" disambiguation (the running-
+sequence page, not the lowest number — the lowest is often an apparatus/intro/
+translation page); extend the join to the French-translation volume.
+
+## Translation — from the Greek, not a relay
+
+We already hold both options:
+- Berthelot's **Greek** volume is fully AI-translated to English (518/518 pp) —
+  from clean printed Greek, not from the manuscript OCR.
+- Berthelot's own **human French** translation (Vol 3 + the *livraisons*), PD.
+
+For a *definitive* English layer, re-translate from Berthelot's **Greek** at full
+model (source-language, no relay through French — the *ad fontes* rule,
+[[feedback_go_to_original_sources]]), with the French as a human cross-check.
+Never translate from the demoted manuscript OCR body.
+
+## Versioning — prior OCR is preserved automatically
+
+Content changes to `ocr`/`translation` are versioned in the **`page_revisions`**
+collection: both the realtime route (`createRevision`, `src/lib/page-revisions.ts`)
+and the batch collector (`saveRevisionBeforeOverwrite`,
+`scripts/workers/batch-collector.mjs`) snapshot current content *before*
+overwriting. Marcianus 299 already carries 432 prior-OCR snapshots (a redundant
+double-submission — see [[lesson_ocr_double_submit_check_too_early]] — left one
+pass live and one in revisions; harmless, and a free second opinion).
+
+**Invariant:** any custom writer (an import/overlay script) that touches
+`pages.ocr.data`/`translation.data` **must** call `createRevision` first, or it
+silently bypasses versioning. **Preferred design avoids the issue entirely:**
+surface Berthelot as an *additive* aligned layer keyed by the concordance —
+**do not overwrite `pages.ocr.data`.** Then nothing is destroyed and every folio
+offers a three-way comparison: facsimile ↔ AI-OCR ↔ critical edition.
+
+## Confidence layer — honest about what it measures
+
+Two signals, saved in **`scripts/output/marcianus-ocr-confidence.json`**:
+
+- **OCR self-agreement** (pass-1 vs pass-2 Dice): clean, fully computable, ranks
+  the least-stable folios (re-OCR/collation candidates). Blind spot: two passes
+  can share a *correlated* misreading.
+- **OCR vs Berthelot coverage** (fraction of our Greek tokens found in Berthelot's
+  folio): a **noisy lower bound, NOT an accuracy rate.** Berthelot is a *critical*
+  edition (normalized spelling, emendations, other-ms readings), so even a perfect
+  diplomatic transcription scores well under 1.0; best folios cap ~0.60. Use the
+  *ranking*, not the absolute number. Self-agreement predicts coverage only weakly
+  (Pearson r ≈ 0.27) — soft triage, not a substitute for collation.
+
+To turn coverage into a *publishable* accuracy figure, make a small **hand
+diplomatic gold set** (~3–5 folios transcribed directly from the image) to
+calibrate the ceiling.
+
+## Implementation plan
+
+1. **Non-destructive overlay (do first).** Store the concordance as a join table;
+   on the Marcianus reader, surface Berthelot's aligned Greek + translation as the
+   reading text, with the OCR body flagged as a rough aid. Keep image extraction +
+   annotations from the manuscript side. No overwrite of `pages.ocr.data`.
+2. **Provenance/quality note on the record** — "AI-assisted transcription; verify
+   quotations against the facsimile / critical edition." Gate any "quote the Greek"
+   affordance behind it.
+3. **Confidence surfacing** — per-folio badge from the two signals (green on
+   clean display/recipe folios, flag on dense narrative folios).
+4. **Definitive translation** — re-run EN from Berthelot's Greek at full model.
+5. **Coverage/calibration** — lift the concordance past 195; build the gold set.
+
+## The generalized rule
+
+> **Where a public-domain critical edition of a work exists — especially one whose
+> base manuscript we're digitizing — prefer the edition's text over OCR for hard
+> hands/scripts.** OCR the *edition* (clean print), not the manuscript's ancient
+> script; keep the manuscript for facsimile, image extraction, and object-native
+> annotation. This already governs the Akkadian/Egyptian shelves; apply it to any
+> comparable case.
+
+## Pointers
+
+- Concordance: `scripts/output/marcianus-berthelot-concordance.json`
+- Confidence data: `scripts/output/marcianus-ocr-confidence.json`
+- Work cluster / cross-reference: `/work/corpus-of-the-greek-alchemists`;
+  work-field backup `scripts/output/marc299-berthelot-workid-backup-2026-07-01.json`
+- Related: [[work-identity-coverage]] · [[lesson_meta_annotation_quote_leak]] ·
+  [[feedback_go_to_original_sources]] · [[lesson_tibetan_lite_ocr_fails]]
+  (same OCR-trust failure mode on another script) · quote-integrity rules in `CLAUDE.md`

--- a/scripts/analysis/marcianus-berthelot-concordance.mjs
+++ b/scripts/analysis/marcianus-berthelot-concordance.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Folio concordance: Marcianus gr. Z. 299 (the manuscript) <-> Berthelot &
+ * Ruelle, "Collection des anciens alchimistes grecs", Greek text volume.
+ *
+ * Berthelot's edition is transcribed FROM M (Marcianus 299 is his base
+ * manuscript), and prints M-folio marks throughout ("f. 93 r.", inline
+ * "(f. 171 r.)", headnote "Transcrit sur M, f. 92 v."). The digitization's page
+ * labels carry the SAME foliation ("Carta: 93r"), so the two lock together on
+ * M's foliation. This builds that join table.
+ *
+ * CRITICAL — extract M-folio refs ONLY. A naive /f\. NN [rv]/ over-counts badly
+ * because Berthelot's apparatus cites OTHER manuscripts ("collated with A, f.85r;
+ * with K, f.1r"). We take only base-manuscript signals: inline parentheticals
+ * "(f. NNr)" + explicit "M, f. NN" headnotes.
+ *
+ * See .claude/docs/edition-facsimile-pairing.md for the design rationale.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/analysis/marcianus-berthelot-concordance.mjs
+ * Output: scripts/output/marcianus-berthelot-concordance.json
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'node:fs';
+
+const MARC = '6a45298cc6d95bc278fbc8c3';               // Marcianus gr. Z. 299
+const BERT = '6994383a6879ff0184cb803a';               // Berthelot Vols 2-3 (Greek text)
+const OUT = 'scripts/output/marcianus-berthelot-concordance.json';
+
+// M-only folio extractors (see header):
+const RE_M = /(?:sur\s+)?\bM\s*[²2]?\s*,?\s*f\.?\s*([0-9]{1,3})\s*,?\s*([rv])\b/gi; // "M, f. 92 v", "sur M, f. 92v", "M2 f. 115r"
+const RE_PAR = /\(\s*f\.?\s*([0-9]{1,3})\s*,?\s*([rv])\.?\s*\)/gi;                        // inline "(f. 171 r.)" = base ms (M)
+
+async function main() {
+  const c = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 });
+  await c.connect();
+  const db = c.db('bookstore');
+
+  // 1) Marcianus folio ("Carta: NNr") -> page
+  const mpages = await db.collection('pages')
+    .find({ book_id: MARC }, { projection: { page_number: 1, id: 1, page_label: 1 } }).toArray();
+  const folioToMarc = {};
+  for (const p of mpages) {
+    const m = /Carta:\s*([0-9]+)\s*([rv])/i.exec(p.page_label || '');
+    if (m) folioToMarc[m[1] + m[2].toLowerCase()] = { pn: p.page_number, id: p.id };
+  }
+
+  // 2) Berthelot page -> M folio refs (M-only)
+  const bpages = await db.collection('pages')
+    .find({ book_id: BERT, 'ocr.data': { $exists: true } }, { projection: { page_number: 1, 'ocr.data': 1 } })
+    .sort({ page_number: 1 }).toArray();
+  const folioToBert = {};
+  let nM = 0, nPar = 0;
+  for (const p of bpages) {
+    const txt = p.ocr?.data || '';
+    const add = (f) => { (folioToBert[f] = folioToBert[f] || new Set()).add(p.page_number); };
+    let m;
+    RE_M.lastIndex = 0; while ((m = RE_M.exec(txt))) { add(m[1] + m[2].toLowerCase()); nM++; }
+    RE_PAR.lastIndex = 0; while ((m = RE_PAR.exec(txt))) { add(m[1] + m[2].toLowerCase()); nPar++; }
+  }
+
+  // 3) Join
+  const rows = Object.keys(folioToBert).map((f) => {
+    const marc = folioToMarc[f];
+    return { folio: f, marc_page: marc?.pn ?? null, marc_id: marc?.id ?? null, bert_pages: [...folioToBert[f]].sort((a, b) => a - b) };
+  }).sort((a, b) => parseInt(a.folio) - parseInt(b.folio) || a.folio.localeCompare(b.folio));
+  const aligned = rows.filter((r) => r.marc_page != null);
+
+  console.log(`M-folio refs: explicit-M=${nM} parenthetical=${nPar} | distinct M folios=${rows.length}`);
+  console.log(`aligned to a Marcianus page: ${aligned.length}/${rows.length}`);
+  console.log('anchor checks (should be non-null and consistent):');
+  for (const f of ['92v', '93r', '170r', '171r']) {
+    const r = rows.find((x) => x.folio === f);
+    console.log(`  f.${f}: ${r ? `Marc p${r.marc_page} <-> Bert ${r.bert_pages.join(',')}` : 'NOT referenced'}`);
+  }
+
+  mkdirSync('scripts/output', { recursive: true });
+  writeFileSync(OUT, JSON.stringify({
+    note: 'M-folio concordance (M-only refs: explicit-M + inline parentheticals). bert_pages may include multiple contexts; the running-sequence page is the transcription, others are apparatus cross-refs.',
+    marcianus_book: MARC, berthelot_book: BERT,
+    folios_referenced: rows.length, folios_aligned: aligned.length, rows,
+  }, null, 1));
+  console.log(`\nsaved -> ${OUT}`);
+  await c.close();
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/analysis/marcianus-ocr-confidence.mjs
+++ b/scripts/analysis/marcianus-ocr-confidence.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * OCR confidence signals for Marcianus gr. Z. 299 — two independent measures:
+ *
+ *  (1) SELF-AGREEMENT: we hold two full OCR passes (same model, same images) —
+ *      one live on pages.ocr.data, one snapshotted in page_revisions. Word-level
+ *      Dice (accent-normalized) between them. Low = the model is interpolating,
+ *      not reading. Clean, fully computable; ranks the least-stable folios.
+ *
+ *  (2) OCR vs BERTHELOT COVERAGE: fraction of our OCR's Greek word-tokens that
+ *      appear in Berthelot's aligned folio (best-matching candidate page from the
+ *      concordance). A NOISY LOWER BOUND, not an accuracy rate — Berthelot is a
+ *      critical edition (normalized/emended/other-ms readings), so even a perfect
+ *      diplomatic transcription scores well under 1.0. Use the ranking, not the
+ *      absolute number.
+ *
+ * Also reports Pearson r(self-agreement, coverage) — self-agreement predicts
+ * accuracy only weakly (~0.27): soft triage, not a substitute for collation.
+ *
+ * See .claude/docs/edition-facsimile-pairing.md. Requires the concordance:
+ *   node scripts/analysis/marcianus-berthelot-concordance.mjs   (run first)
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/analysis/marcianus-ocr-confidence.mjs
+ * Output: scripts/output/marcianus-ocr-confidence.json
+ */
+import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+
+const MARC = '6a45298cc6d95bc278fbc8c3';
+const BERT = '6994383a6879ff0184cb803a';
+const CONC = 'scripts/output/marcianus-berthelot-concordance.json';
+const OUT = 'scripts/output/marcianus-ocr-confidence.json';
+
+// Greek tokens: strip diacritics (NFD + combining), lowercase, final sigma -> sigma,
+// keep only Greek-letter words length >= 2. Naturally ignores wrapper tags, French, numbers.
+function gtok(s) {
+  return (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .replace(/ς/g, 'σ').match(/[Ͱ-Ͽ]{2,}/g) || [];
+}
+function count(a) { const m = new Map(); for (const t of a) m.set(t, (m.get(t) || 0) + 1); return m; }
+function dice(a, b) { if (!a.length && !b.length) return 1; const ma = count(a), mb = count(b); let i = 0; for (const [k, v] of ma) i += Math.min(v, mb.get(k) || 0); const tot = a.length + b.length; return tot ? 2 * i / tot : 0; }
+function contain(sub, sup) { if (!sub.length) return 0; const ms = count(sup); let i = 0; for (const [k, v] of count(sub)) i += Math.min(v, ms.get(k) || 0); return i / sub.length; }
+const mean = (a) => a.length ? a.reduce((s, x) => s + x, 0) / a.length : 0;
+
+async function main() {
+  const c = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 });
+  await c.connect();
+  const db = c.db('bookstore');
+
+  const pages = await db.collection('pages').find({ book_id: MARC }, { projection: { page_number: 1, id: 1, page_label: 1, 'ocr.data': 1 } }).toArray();
+  const live = new Map(); const byPn = new Map();
+  for (const p of pages) { const t = gtok(p.ocr?.data); live.set(p.id, { pn: p.page_number, label: p.page_label, tok: t }); byPn.set(p.page_number, t); }
+  const revs = await db.collection('page_revisions').find({ book_id: MARC, field: 'ocr' }, { projection: { page_id: 1, data: 1 } }).toArray();
+  const prior = new Map(); for (const r of revs) prior.set(r.page_id, gtok(r.data));
+
+  // (1) self-agreement
+  const selfRows = [];
+  for (const [id, L] of live) { const P = prior.get(id); if (P === undefined || L.tok.length < 8) continue; selfRows.push({ pn: L.pn, label: L.label, dice: dice(L.tok, P), n: L.tok.length }); }
+  selfRows.sort((a, b) => a.dice - b.dice);
+  const selfByPn = new Map(selfRows.map((r) => [r.pn, r.dice]));
+  const sd = selfRows.map((r) => r.dice);
+  console.log(`SELF-AGREEMENT (pass1 vs pass2, n=${selfRows.length}): mean Dice=${mean(sd).toFixed(3)} median=${sd.slice().sort((a, b) => a - b)[Math.floor(sd.length / 2)].toFixed(3)}`);
+  console.log('  10 least self-consistent:', selfRows.slice(0, 10).map((r) => `p${r.pn}(${r.dice.toFixed(2)})`).join(' '));
+
+  // (2) OCR vs Berthelot — best-matching candidate page (true transcription self-selects)
+  const bpages = await db.collection('pages').find({ book_id: BERT }, { projection: { page_number: 1, 'ocr.data': 1 } }).toArray();
+  const bmap = new Map(); for (const b of bpages) bmap.set(b.page_number, gtok(b.ocr?.data));
+  const conc = JSON.parse(readFileSync(CONC, 'utf8'));
+  const bRows = [];
+  for (const row of conc.rows) {
+    if (row.marc_page == null) continue; const ours = byPn.get(row.marc_page); if (!ours || ours.length < 10) continue;
+    const cands = new Set(); for (const bp of row.bert_pages) { cands.add(bp); cands.add(bp + 1); } // folio may span 2 print pages
+    let best = 0, bestp = null; for (const bp of cands) { const bt = bmap.get(bp); if (!bt) continue; const cov = contain(ours, bt); if (cov > best) { best = cov; bestp = bp; } }
+    bRows.push({ folio: row.folio, pn: row.marc_page, cover: best, bert: bestp, self: selfByPn.get(row.marc_page) ?? null });
+  }
+  const cv = bRows.map((r) => r.cover);
+  console.log(`OCR vs BERTHELOT (best candidate, n=${bRows.length}): mean coverage=${mean(cv).toFixed(3)} median=${cv.slice().sort((a, b) => a - b)[Math.floor(cv.length / 2)].toFixed(3)}  [LOWER BOUND, not an accuracy rate]`);
+
+  // predictive validity
+  const paired = bRows.filter((r) => r.self != null);
+  const xs = paired.map((r) => r.self), ys = paired.map((r) => r.cover), mx = mean(xs), my = mean(ys);
+  let num = 0, dx = 0, dy = 0; for (let i = 0; i < xs.length; i++) { num += (xs[i] - mx) * (ys[i] - my); dx += (xs[i] - mx) ** 2; dy += (ys[i] - my) ** 2; }
+  const r = dx && dy ? num / Math.sqrt(dx * dy) : 0;
+  console.log(`Pearson r(self-agreement, Berthelot-coverage) = ${r.toFixed(3)} (n=${paired.length}) — weak: soft triage, not a collation substitute`);
+
+  mkdirSync('scripts/output', { recursive: true });
+  writeFileSync(OUT, JSON.stringify({
+    note: 'self_agreement = pass1-vs-pass2 word Dice (clean). ocr_vs_berthelot.cover = fraction of our Greek tokens in best-matching Berthelot page (NOISY LOWER BOUND, not accuracy). See .claude/docs/edition-facsimile-pairing.md.',
+    pearson_self_vs_coverage: r,
+    self_agreement: selfRows, ocr_vs_berthelot: bRows,
+  }, null, 1));
+  console.log(`\nsaved -> ${OUT}`);
+  await c.close();
+}
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## What
- **`.claude/docs/edition-facsimile-pairing.md`** — design doc for pairing hard-to-OCR manuscripts with a PD critical edition (edition = text-of-record; manuscript = facsimile + image extraction + object-native annotations). Reference case: **Marcianus gr. Z. 299 ↔ Berthelot** (M is his base manuscript). Generalizes the pattern already used for Akkadian/Egyptian (King/Budge carry the text).
- **`scripts/analysis/marcianus-berthelot-concordance.mjs`** — M-folio join table (M-only extraction to avoid apparatus-siglum contamination; 195 folios locked page-for-page, anchor-verified).
- **`scripts/analysis/marcianus-ocr-confidence.mjs`** — two-pass OCR self-agreement (~0.62) + OCR-vs-Berthelot coverage (documented as a lower bound, not an accuracy rate).

## Why
Measured OCR-trust findings on the 10th-c. Greek minuscule (self-agreement ~0.62; image-adjudicated confident hallucination on dense folios) → don't treat raw OCR as the transcription; pair with the edition. Doc is the spec for the follow-up overlay implementation.

## Scope
Docs + analysis scripts only — **no runtime/UI changes**. Output JSON is regenerable (`scripts/output/`, uncommitted). `check-imports` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)