### PR TITLE
feat(reader): non-destructive Berthelot critical-edition overlay for Marcianus 299

### DIFF
--- a/.claude/docs/edition-facsimile-pairing.md
+++ b/.claude/docs/edition-facsimile-pairing.md
@@ -1,0 +1,188 @@
+# Edition-of-record ↔ facsimile-of-record — the manuscript/edition pairing
+
+**Read this first** before adding a text layer to any manuscript whose script is
+hard to OCR (Greek minuscule, cuneiform, hieroglyphic, dense/abbreviated hands),
+or before "fixing" the OCR on such a book. The short version:
+
+> **For hard scripts, the published critical edition carries the *text*; the
+> manuscript carries the *facsimile* and everything that is only true of *this
+> physical object*.** Don't try to make raw OCR of the manuscript into the
+> authoritative transcription — pair it with the edition instead.
+
+Worked reference case: **Marcianus graecus Z. 299** (the *Codex Marcianus*, book
+`6a45298cc6d95bc278fbc8c3`) paired with **Berthelot & Ruelle,
+*Collection des anciens alchimistes grecs*** (1887–88; the Greek text volume is
+`6994383a6879ff0184cb803a`). Cross-linked via the shared work
+`corpus-of-the-greek-alchemists` (see [[work-identity-coverage]]).
+
+## The precedent this generalizes
+
+We already do this, implicitly, for the shelves where the ancient script is
+effectively un-OCR-able: the **Akkadian (~390)** and **Egyptian (~154)**
+holdings are carried by *printed scholarly editions* — King's *Seven Tablets of
+Creation* (Enuma Elish), Budge's *Book of the Dead* — whose transliteration +
+translation OCR cleanly, with the wedges/glyphs shown as plates/facsimile. We do
+not OCR cuneiform or hieroglyphs directly. This doc makes that pattern explicit
+and extends it to difficult **Greek minuscule**, where the same failure mode
+appears.
+
+## Why: the OCR on a 10th-c. minuscule hand cannot be trusted verbatim
+
+Measured on Marcianus 299 (full-quality `gemini-3-flash-preview`, ~1400px scans —
+Internet Culturale's public ceiling):
+
+- **Run-to-run self-agreement ≈ 0.62** (word-level Dice, accent-normalized, 393
+  text pages). The same model on the same images disagrees with itself on ~38%
+  of word-tokens. A faithful reader is deterministic; a model that *interpolates*
+  diverges. (We hold two independent passes — see "confidence layer" below.)
+- **Image-adjudicated hallucination.** On Carta 93r the manuscript plainly reads
+  `τῶν μετάλλων· καὶ τὰ ὑγρόδρυα τῶν βοτανῶν` (= Berthelot); our OCR *dropped the
+  legible words* and substituted invented text, and garbled the famous line
+  `ὁ Ἴων ὁ ἱερεὺς τῶν ἀδύτων` ("Ion, priest of the sanctuaries") into
+  non-Greek. The output *reads fluently* — that is the danger.
+- **Strongly content-dependent.** Display text / inscriptions / diagram labels
+  are near-perfect (the Chrysopoeia ring `ἓν τὸ πᾶν…` matched verbatim); recipe /
+  apparatus prose is largely reliable; dense allegorical/narrative folios
+  (Zosimos's *Visions*) are where it fabricates.
+
+**Consequence for scholars:** the facsimile is sound; reading/translation-for-
+sense is fine with care; **quoting the Greek verbatim from the OCR is not safe**
+without collation. The translation inherits OCR errors (garbled Greek →
+confidently wrong English — the [[lesson_meta_annotation_quote_leak]] failure
+mode, one layer down). Berthelot (whose base manuscript *is* M) remains the
+scholarly authority for the text.
+
+## The layer stack (per folio)
+
+| Layer | Source of record | Notes |
+|---|---|---|
+| **Facsimile image** | Marcianus manuscript | primary evidence; the reason to hold the object |
+| **Transcription (Greek)** | **Berthelot**, via concordance | our OCR body demoted to a *flagged* rough aid |
+| **Translation (EN / FR)** | **Berthelot** | AI-from-clean-Greek (EN) + Berthelot's human French (PD) |
+| **Diagrams / gallery** | Marcianus **image extraction** | Chrysopoeia, kerotakis, alembics — cropped from the real folios |
+| **Annotations** (`<image-desc>`, `<page-type>`, `<margin>`, `<note>`, `<vocab>`, `<scan-quality>`) | Marcianus **OCR annotation layer** | manuscript-native; the *reliable* part of our OCR |
+| **Confidence / provenance** | two-pass OCR agreement + Berthelot coverage | research/QA signal, not shown as authority |
+
+The governing split: **edition carries the words; manuscript carries everything
+that is only true of *this object*.**
+
+## The OCR splits in two — keep vs demote
+
+"Demoting the OCR" is **not** deleting it. Our OCR output is two different things
+welded together:
+
+- **KEEP — the annotation/metadata layer.** `<image-desc>` (drove image
+  extraction; the Chrysopoeia description checked out against the image),
+  `<page-type>` (classification that selects illustration candidates),
+  `<margin>` / `<note>` / `<gloss>` (physical marginalia of *this* folio),
+  `<vocab>` (search terms), `<scan-quality>`. These describe the object, are
+  vision/classification work the model does *well*, and have no equivalent in a
+  printed edition. Keep them live.
+- **DEMOTE — the verbatim Greek transcription body.** Unreliable on hard folios.
+  Replace as text-of-record with Berthelot (via concordance); keep the OCR body
+  as a clearly-flagged aid plus the confidence layer, never presented as the
+  authoritative transcription.
+
+## The concordance (the join table)
+
+Berthelot prints **M-folio marks** throughout ("f. 93 r.", inline `(f. 171 r.)`,
+headnote *"Transcrit sur M, f. 92 v."*), and the digitization's page labels carry
+the **same foliation** ("Carta: 93r"). They lock together directly on M's
+foliation — verified against independent anchors (Zosimos *On Virtue* headnote
+f.92v→Marc p207/Bert p13; the *ἀφροσέληνον* inline mark f.171r→Marc p364/Bert
+p30). Artifact: **`scripts/output/marcianus-berthelot-concordance.json`** —
+195 folios locked page-for-page; the running sequence is monotonic (consecutive
+folios → consecutive pages on both sides), the signature of a correct alignment.
+
+**Gotcha — M-only extraction.** A naive `f. NN r/v` regex over-counts badly: it
+sweeps in Berthelot's *apparatus references to other manuscripts* ("collated
+with A, f. 85r; with K, f. 1r"). Restrict to **M signals only** — the base-
+manuscript inline parentheticals `(f. NNr)` plus explicit `M, f. NN` headnotes —
+and exclude other-siglum refs. (First pass wrongly claimed 74%; M-only gave a
+trustworthy 195 and the anchors then landed.)
+
+**Open refinements:** ~79 referenced folios don't yet resolve to a Carta label
+(edge folios, the `M²` duplicate f.115r, a few mislabeled tags); multi-page rows
+(`f.112v → 44,52`) need "primary transcription page" disambiguation (the running-
+sequence page, not the lowest number — the lowest is often an apparatus/intro/
+translation page); extend the join to the French-translation volume.
+
+## Translation — from the Greek, not a relay
+
+We already hold both options:
+- Berthelot's **Greek** volume is fully AI-translated to English (518/518 pp) —
+  from clean printed Greek, not from the manuscript OCR.
+- Berthelot's own **human French** translation (Vol 3 + the *livraisons*), PD.
+
+For a *definitive* English layer, re-translate from Berthelot's **Greek** at full
+model (source-language, no relay through French — the *ad fontes* rule,
+[[feedback_go_to_original_sources]]), with the French as a human cross-check.
+Never translate from the demoted manuscript OCR body.
+
+## Versioning — prior OCR is preserved automatically
+
+Content changes to `ocr`/`translation` are versioned in the **`page_revisions`**
+collection: both the realtime route (`createRevision`, `src/lib/page-revisions.ts`)
+and the batch collector (`saveRevisionBeforeOverwrite`,
+`scripts/workers/batch-collector.mjs`) snapshot current content *before*
+overwriting. Marcianus 299 already carries 432 prior-OCR snapshots (a redundant
+double-submission — see [[lesson_ocr_double_submit_check_too_early]] — left one
+pass live and one in revisions; harmless, and a free second opinion).
+
+**Invariant:** any custom writer (an import/overlay script) that touches
+`pages.ocr.data`/`translation.data` **must** call `createRevision` first, or it
+silently bypasses versioning. **Preferred design avoids the issue entirely:**
+surface Berthelot as an *additive* aligned layer keyed by the concordance —
+**do not overwrite `pages.ocr.data`.** Then nothing is destroyed and every folio
+offers a three-way comparison: facsimile ↔ AI-OCR ↔ critical edition.
+
+## Confidence layer — honest about what it measures
+
+Two signals, saved in **`scripts/output/marcianus-ocr-confidence.json`**:
+
+- **OCR self-agreement** (pass-1 vs pass-2 Dice): clean, fully computable, ranks
+  the least-stable folios (re-OCR/collation candidates). Blind spot: two passes
+  can share a *correlated* misreading.
+- **OCR vs Berthelot coverage** (fraction of our Greek tokens found in Berthelot's
+  folio): a **noisy lower bound, NOT an accuracy rate.** Berthelot is a *critical*
+  edition (normalized spelling, emendations, other-ms readings), so even a perfect
+  diplomatic transcription scores well under 1.0; best folios cap ~0.60. Use the
+  *ranking*, not the absolute number. Self-agreement predicts coverage only weakly
+  (Pearson r ≈ 0.27) — soft triage, not a substitute for collation.
+
+To turn coverage into a *publishable* accuracy figure, make a small **hand
+diplomatic gold set** (~3–5 folios transcribed directly from the image) to
+calibrate the ceiling.
+
+## Implementation plan
+
+1. **Non-destructive overlay (do first).** Store the concordance as a join table;
+   on the Marcianus reader, surface Berthelot's aligned Greek + translation as the
+   reading text, with the OCR body flagged as a rough aid. Keep image extraction +
+   annotations from the manuscript side. No overwrite of `pages.ocr.data`.
+2. **Provenance/quality note on the record** — "AI-assisted transcription; verify
+   quotations against the facsimile / critical edition." Gate any "quote the Greek"
+   affordance behind it.
+3. **Confidence surfacing** — per-folio badge from the two signals (green on
+   clean display/recipe folios, flag on dense narrative folios).
+4. **Definitive translation** — re-run EN from Berthelot's Greek at full model.
+5. **Coverage/calibration** — lift the concordance past 195; build the gold set.
+
+## The generalized rule
+
+> **Where a public-domain critical edition of a work exists — especially one whose
+> base manuscript we're digitizing — prefer the edition's text over OCR for hard
+> hands/scripts.** OCR the *edition* (clean print), not the manuscript's ancient
+> script; keep the manuscript for facsimile, image extraction, and object-native
+> annotation. This already governs the Akkadian/Egyptian shelves; apply it to any
+> comparable case.
+
+## Pointers
+
+- Concordance: `scripts/output/marcianus-berthelot-concordance.json`
+- Confidence data: `scripts/output/marcianus-ocr-confidence.json`
+- Work cluster / cross-reference: `/work/corpus-of-the-greek-alchemists`;
+  work-field backup `scripts/output/marc299-berthelot-workid-backup-2026-07-01.json`
+- Related: [[work-identity-coverage]] · [[lesson_meta_annotation_quote_leak]] ·
+  [[feedback_go_to_original_sources]] · [[lesson_tibetan_lite_ocr_fails]]
+  (same OCR-trust failure mode on another script) · quote-integrity rules in `CLAUDE.md`

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ src/data/*
 !src/data/concept-diffusion-research.json
 !src/data/book-constellation.json
 !src/data/image-constellation.json
+!src/data/marcianus-berthelot-overlay.json
 !src/data/jung-bph-alignment-2026-05-22.json
 !src/data/carbon-ledger/
 !src/data/carbon-ledger/*.json

--- a/scripts/analysis/build-marcianus-overlay.mjs
+++ b/scripts/analysis/build-marcianus-overlay.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Build the app-consumable Marcianus 299 <-> Berthelot reading-overlay table.
+ *
+ * Merges the two analysis artifacts into a single static JSON the Next.js reader
+ * imports at build time (no runtime DB round-trip for the join itself; only the
+ * aligned Berthelot page TEXT is fetched from Mongo per request):
+ *   - scripts/output/marcianus-berthelot-concordance.json  (folio -> marc/bert pages)
+ *   - scripts/output/marcianus-ocr-confidence.json          (self-agreement + coverage)
+ *
+ * The "primary transcription page" for a folio is taken from the confidence
+ * artifact's `bert` field — the best-coverage candidate among the folio's
+ * referenced Berthelot pages, which self-selects the running-sequence
+ * transcription page over apparatus/intro cross-refs (see the doc's "multi-page
+ * rows" gotcha). Output is keyed by Marcianus page_number, with marc_id echoed
+ * so the reader can index by either.
+ *
+ * This is a NON-DESTRUCTIVE overlay: it never touches pages.ocr.data /
+ * pages.translation.data. See .claude/docs/edition-facsimile-pairing.md.
+ *
+ * Usage:
+ *   node scripts/analysis/marcianus-berthelot-concordance.mjs   # run first
+ *   node scripts/analysis/marcianus-ocr-confidence.mjs          # then this
+ *   node scripts/analysis/build-marcianus-overlay.mjs
+ * Output: src/data/marcianus-berthelot-overlay.json
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+
+const CONC = 'scripts/output/marcianus-berthelot-concordance.json';
+const CONF = 'scripts/output/marcianus-ocr-confidence.json';
+const OUT = 'src/data/marcianus-berthelot-overlay.json';
+
+const conc = JSON.parse(readFileSync(CONC, 'utf8'));
+const conf = JSON.parse(readFileSync(CONF, 'utf8'));
+
+const confByPn = new Map(conf.ocr_vs_berthelot.map((r) => [r.pn, r]));
+const selfByPn = new Map(conf.self_agreement.map((r) => [r.pn, r.dice]));
+
+const byMarcPage = {};
+let aligned = 0;
+for (const row of conc.rows) {
+  if (row.marc_page == null) continue;
+  const cf = confByPn.get(row.marc_page);
+  // primary transcription page: confidence's best-coverage candidate, else the
+  // lowest referenced Berthelot page as a fallback.
+  const bertPrimary = cf?.bert ?? row.bert_pages[0] ?? null;
+  if (bertPrimary == null) continue;
+  aligned++;
+  byMarcPage[row.marc_page] = {
+    folio: row.folio,
+    marc_id: row.marc_id,
+    bert_page: bertPrimary,
+    bert_pages: row.bert_pages,
+    self: cf?.self ?? selfByPn.get(row.marc_page) ?? null,   // pass1-vs-pass2 Dice (0..1)
+    cover: cf?.cover ?? null,                                 // OCR-in-Berthelot coverage (0..1) — LOWER BOUND
+  };
+}
+
+mkdirSync('src/data', { recursive: true });
+writeFileSync(OUT, JSON.stringify({
+  note: 'Non-destructive reading overlay: Marcianus gr. Z. 299 folios paired to Berthelot & Ruelle (Greek text vol) page-for-page. by_marc_page keyed by Marcianus page_number. bert_page = primary transcription page (best-coverage candidate). self = pass1-vs-pass2 OCR Dice (stability). cover = OCR-in-Berthelot token coverage — a NOISY LOWER BOUND, never an accuracy rate. See .claude/docs/edition-facsimile-pairing.md.',
+  marcianus_book: conc.marcianus_book,
+  berthelot_book: conc.berthelot_book,
+  berthelot_citation: 'Berthelot & Ruelle, Collection des anciens alchimistes grecs (1887–88)',
+  work_id: 'local:corpus-alchemicorum-graecorum',
+  stats: {
+    folios_aligned: aligned,
+    self_agreement_mean: conf.self_agreement.length
+      ? conf.self_agreement.reduce((s, r) => s + r.dice, 0) / conf.self_agreement.length : null,
+    pearson_self_vs_coverage: conf.pearson_self_vs_coverage ?? null,
+  },
+  by_marc_page: byMarcPage,
+}, null, 1));
+
+console.log(`overlay: ${aligned} aligned folios -> ${OUT}`);

--- a/scripts/analysis/marcianus-berthelot-concordance.mjs
+++ b/scripts/analysis/marcianus-berthelot-concordance.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Folio concordance: Marcianus gr. Z. 299 (the manuscript) <-> Berthelot &
+ * Ruelle, "Collection des anciens alchimistes grecs", Greek text volume.
+ *
+ * Berthelot's edition is transcribed FROM M (Marcianus 299 is his base
+ * manuscript), and prints M-folio marks throughout ("f. 93 r.", inline
+ * "(f. 171 r.)", headnote "Transcrit sur M, f. 92 v."). The digitization's page
+ * labels carry the SAME foliation ("Carta: 93r"), so the two lock together on
+ * M's foliation. This builds that join table.
+ *
+ * CRITICAL — extract M-folio refs ONLY. A naive /f\. NN [rv]/ over-counts badly
+ * because Berthelot's apparatus cites OTHER manuscripts ("collated with A, f.85r;
+ * with K, f.1r"). We take only base-manuscript signals: inline parentheticals
+ * "(f. NNr)" + explicit "M, f. NN" headnotes.
+ *
+ * See .claude/docs/edition-facsimile-pairing.md for the design rationale.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/analysis/marcianus-berthelot-concordance.mjs
+ * Output: scripts/output/marcianus-berthelot-concordance.json
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync } from 'node:fs';
+
+const MARC = '6a45298cc6d95bc278fbc8c3';               // Marcianus gr. Z. 299
+const BERT = '6994383a6879ff0184cb803a';               // Berthelot Vols 2-3 (Greek text)
+const OUT = 'scripts/output/marcianus-berthelot-concordance.json';
+
+// M-only folio extractors (see header):
+const RE_M = /(?:sur\s+)?\bM\s*[²2]?\s*,?\s*f\.?\s*([0-9]{1,3})\s*,?\s*([rv])\b/gi; // "M, f. 92 v", "sur M, f. 92v", "M2 f. 115r"
+const RE_PAR = /\(\s*f\.?\s*([0-9]{1,3})\s*,?\s*([rv])\.?\s*\)/gi;                        // inline "(f. 171 r.)" = base ms (M)
+
+async function main() {
+  const c = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 });
+  await c.connect();
+  const db = c.db('bookstore');
+
+  // 1) Marcianus folio ("Carta: NNr") -> page
+  const mpages = await db.collection('pages')
+    .find({ book_id: MARC }, { projection: { page_number: 1, id: 1, page_label: 1 } }).toArray();
+  const folioToMarc = {};
+  for (const p of mpages) {
+    const m = /Carta:\s*([0-9]+)\s*([rv])/i.exec(p.page_label || '');
+    if (m) folioToMarc[m[1] + m[2].toLowerCase()] = { pn: p.page_number, id: p.id };
+  }
+
+  // 2) Berthelot page -> M folio refs (M-only)
+  const bpages = await db.collection('pages')
+    .find({ book_id: BERT, 'ocr.data': { $exists: true } }, { projection: { page_number: 1, 'ocr.data': 1 } })
+    .sort({ page_number: 1 }).toArray();
+  const folioToBert = {};
+  let nM = 0, nPar = 0;
+  for (const p of bpages) {
+    const txt = p.ocr?.data || '';
+    const add = (f) => { (folioToBert[f] = folioToBert[f] || new Set()).add(p.page_number); };
+    let m;
+    RE_M.lastIndex = 0; while ((m = RE_M.exec(txt))) { add(m[1] + m[2].toLowerCase()); nM++; }
+    RE_PAR.lastIndex = 0; while ((m = RE_PAR.exec(txt))) { add(m[1] + m[2].toLowerCase()); nPar++; }
+  }
+
+  // 3) Join
+  const rows = Object.keys(folioToBert).map((f) => {
+    const marc = folioToMarc[f];
+    return { folio: f, marc_page: marc?.pn ?? null, marc_id: marc?.id ?? null, bert_pages: [...folioToBert[f]].sort((a, b) => a - b) };
+  }).sort((a, b) => parseInt(a.folio) - parseInt(b.folio) || a.folio.localeCompare(b.folio));
+  const aligned = rows.filter((r) => r.marc_page != null);
+
+  console.log(`M-folio refs: explicit-M=${nM} parenthetical=${nPar} | distinct M folios=${rows.length}`);
+  console.log(`aligned to a Marcianus page: ${aligned.length}/${rows.length}`);
+  console.log('anchor checks (should be non-null and consistent):');
+  for (const f of ['92v', '93r', '170r', '171r']) {
+    const r = rows.find((x) => x.folio === f);
+    console.log(`  f.${f}: ${r ? `Marc p${r.marc_page} <-> Bert ${r.bert_pages.join(',')}` : 'NOT referenced'}`);
+  }
+
+  mkdirSync('scripts/output', { recursive: true });
+  writeFileSync(OUT, JSON.stringify({
+    note: 'M-folio concordance (M-only refs: explicit-M + inline parentheticals). bert_pages may include multiple contexts; the running-sequence page is the transcription, others are apparatus cross-refs.',
+    marcianus_book: MARC, berthelot_book: BERT,
+    folios_referenced: rows.length, folios_aligned: aligned.length, rows,
+  }, null, 1));
+  console.log(`\nsaved -> ${OUT}`);
+  await c.close();
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/analysis/marcianus-ocr-confidence.mjs
+++ b/scripts/analysis/marcianus-ocr-confidence.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * OCR confidence signals for Marcianus gr. Z. 299 — two independent measures:
+ *
+ *  (1) SELF-AGREEMENT: we hold two full OCR passes (same model, same images) —
+ *      one live on pages.ocr.data, one snapshotted in page_revisions. Word-level
+ *      Dice (accent-normalized) between them. Low = the model is interpolating,
+ *      not reading. Clean, fully computable; ranks the least-stable folios.
+ *
+ *  (2) OCR vs BERTHELOT COVERAGE: fraction of our OCR's Greek word-tokens that
+ *      appear in Berthelot's aligned folio (best-matching candidate page from the
+ *      concordance). A NOISY LOWER BOUND, not an accuracy rate — Berthelot is a
+ *      critical edition (normalized/emended/other-ms readings), so even a perfect
+ *      diplomatic transcription scores well under 1.0. Use the ranking, not the
+ *      absolute number.
+ *
+ * Also reports Pearson r(self-agreement, coverage) — self-agreement predicts
+ * accuracy only weakly (~0.27): soft triage, not a substitute for collation.
+ *
+ * See .claude/docs/edition-facsimile-pairing.md. Requires the concordance:
+ *   node scripts/analysis/marcianus-berthelot-concordance.mjs   (run first)
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/analysis/marcianus-ocr-confidence.mjs
+ * Output: scripts/output/marcianus-ocr-confidence.json
+ */
+import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+
+const MARC = '6a45298cc6d95bc278fbc8c3';
+const BERT = '6994383a6879ff0184cb803a';
+const CONC = 'scripts/output/marcianus-berthelot-concordance.json';
+const OUT = 'scripts/output/marcianus-ocr-confidence.json';
+
+// Greek tokens: strip diacritics (NFD + combining), lowercase, final sigma -> sigma,
+// keep only Greek-letter words length >= 2. Naturally ignores wrapper tags, French, numbers.
+function gtok(s) {
+  return (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .replace(/ς/g, 'σ').match(/[Ͱ-Ͽ]{2,}/g) || [];
+}
+function count(a) { const m = new Map(); for (const t of a) m.set(t, (m.get(t) || 0) + 1); return m; }
+function dice(a, b) { if (!a.length && !b.length) return 1; const ma = count(a), mb = count(b); let i = 0; for (const [k, v] of ma) i += Math.min(v, mb.get(k) || 0); const tot = a.length + b.length; return tot ? 2 * i / tot : 0; }
+function contain(sub, sup) { if (!sub.length) return 0; const ms = count(sup); let i = 0; for (const [k, v] of count(sub)) i += Math.min(v, ms.get(k) || 0); return i / sub.length; }
+const mean = (a) => a.length ? a.reduce((s, x) => s + x, 0) / a.length : 0;
+
+async function main() {
+  const c = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 });
+  await c.connect();
+  const db = c.db('bookstore');
+
+  const pages = await db.collection('pages').find({ book_id: MARC }, { projection: { page_number: 1, id: 1, page_label: 1, 'ocr.data': 1 } }).toArray();
+  const live = new Map(); const byPn = new Map();
+  for (const p of pages) { const t = gtok(p.ocr?.data); live.set(p.id, { pn: p.page_number, label: p.page_label, tok: t }); byPn.set(p.page_number, t); }
+  const revs = await db.collection('page_revisions').find({ book_id: MARC, field: 'ocr' }, { projection: { page_id: 1, data: 1 } }).toArray();
+  const prior = new Map(); for (const r of revs) prior.set(r.page_id, gtok(r.data));
+
+  // (1) self-agreement
+  const selfRows = [];
+  for (const [id, L] of live) { const P = prior.get(id); if (P === undefined || L.tok.length < 8) continue; selfRows.push({ pn: L.pn, label: L.label, dice: dice(L.tok, P), n: L.tok.length }); }
+  selfRows.sort((a, b) => a.dice - b.dice);
+  const selfByPn = new Map(selfRows.map((r) => [r.pn, r.dice]));
+  const sd = selfRows.map((r) => r.dice);
+  console.log(`SELF-AGREEMENT (pass1 vs pass2, n=${selfRows.length}): mean Dice=${mean(sd).toFixed(3)} median=${sd.slice().sort((a, b) => a - b)[Math.floor(sd.length / 2)].toFixed(3)}`);
+  console.log('  10 least self-consistent:', selfRows.slice(0, 10).map((r) => `p${r.pn}(${r.dice.toFixed(2)})`).join(' '));
+
+  // (2) OCR vs Berthelot — best-matching candidate page (true transcription self-selects)
+  const bpages = await db.collection('pages').find({ book_id: BERT }, { projection: { page_number: 1, 'ocr.data': 1 } }).toArray();
+  const bmap = new Map(); for (const b of bpages) bmap.set(b.page_number, gtok(b.ocr?.data));
+  const conc = JSON.parse(readFileSync(CONC, 'utf8'));
+  const bRows = [];
+  for (const row of conc.rows) {
+    if (row.marc_page == null) continue; const ours = byPn.get(row.marc_page); if (!ours || ours.length < 10) continue;
+    const cands = new Set(); for (const bp of row.bert_pages) { cands.add(bp); cands.add(bp + 1); } // folio may span 2 print pages
+    let best = 0, bestp = null; for (const bp of cands) { const bt = bmap.get(bp); if (!bt) continue; const cov = contain(ours, bt); if (cov > best) { best = cov; bestp = bp; } }
+    bRows.push({ folio: row.folio, pn: row.marc_page, cover: best, bert: bestp, self: selfByPn.get(row.marc_page) ?? null });
+  }
+  const cv = bRows.map((r) => r.cover);
+  console.log(`OCR vs BERTHELOT (best candidate, n=${bRows.length}): mean coverage=${mean(cv).toFixed(3)} median=${cv.slice().sort((a, b) => a - b)[Math.floor(cv.length / 2)].toFixed(3)}  [LOWER BOUND, not an accuracy rate]`);
+
+  // predictive validity
+  const paired = bRows.filter((r) => r.self != null);
+  const xs = paired.map((r) => r.self), ys = paired.map((r) => r.cover), mx = mean(xs), my = mean(ys);
+  let num = 0, dx = 0, dy = 0; for (let i = 0; i < xs.length; i++) { num += (xs[i] - mx) * (ys[i] - my); dx += (xs[i] - mx) ** 2; dy += (ys[i] - my) ** 2; }
+  const r = dx && dy ? num / Math.sqrt(dx * dy) : 0;
+  console.log(`Pearson r(self-agreement, Berthelot-coverage) = ${r.toFixed(3)} (n=${paired.length}) — weak: soft triage, not a collation substitute`);
+
+  mkdirSync('scripts/output', { recursive: true });
+  writeFileSync(OUT, JSON.stringify({
+    note: 'self_agreement = pass1-vs-pass2 word Dice (clean). ocr_vs_berthelot.cover = fraction of our Greek tokens in best-matching Berthelot page (NOISY LOWER BOUND, not accuracy). See .claude/docs/edition-facsimile-pairing.md.',
+    pearson_self_vs_coverage: r,
+    self_agreement: selfRows, ocr_vs_berthelot: bRows,
+  }, null, 1));
+  console.log(`\nsaved -> ${OUT}`);
+  await c.close();
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/api/books/[id]/paired-edition/route.ts
+++ b/src/app/api/books/[id]/paired-edition/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+import { isBookReadable } from '@/lib/book-access';
+import type { Book } from '@/lib/types';
+import { getPairedEdition, MARCIANUS_BOOK_ID } from '@/lib/marcianus-overlay';
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/books/[id]/paired-edition?pageId=<pages.id>[&page=<page_number>]
+ *
+ * Reader-support endpoint for the non-destructive edition/facsimile overlay:
+ * for a Marcianus gr. Z. 299 folio, returns Berthelot & Ruelle's aligned
+ * critical Greek + English (the text of record) plus per-folio confidence
+ * badges and a provenance note. Returns `{ paired: null }` for any other book
+ * or any folio with no aligned edition page.
+ *
+ * Plain GET (no withApiAuth): this is browser reader UI for anonymous readers,
+ * and the text it surfaces is Berthelot's public edition — the same text served
+ * on Berthelot's own reader. Hidden-book access is still gated via
+ * isBookReadable. Never writes; see .claude/docs/edition-facsimile-pairing.md.
+ */
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { id: bookId } = await context.params;
+  const { searchParams } = new URL(request.url);
+  const pageId = searchParams.get('pageId');
+  const pageParam = searchParams.get('page');
+  const pageNumber = pageParam != null && pageParam !== '' ? parseInt(pageParam, 10) : null;
+
+  const db = await getReadDb();
+
+  // Resolve by id / slug / _id, mirroring the quote route.
+  let book = (await db.collection('books').findOne({ id: bookId })) as unknown as Book | null;
+  if (!book) book = (await db.collection('books').findOne({ slug: bookId })) as unknown as Book | null;
+  if (!book && /^[a-f0-9]{24}$/i.test(bookId)) {
+    const { ObjectId } = await import('mongodb');
+    book = (await db.collection('books').findOne({ _id: new ObjectId(bookId) })) as unknown as Book | null;
+  }
+
+  // Overlay is registered for exactly one manuscript today; everything else is a
+  // clean no-op so the client panel can be mounted unconditionally.
+  if (!book || book.id !== MARCIANUS_BOOK_ID) {
+    return NextResponse.json({ paired: null });
+  }
+  if (!(await isBookReadable(book, request))) {
+    return NextResponse.json({ paired: null }, { status: 404 });
+  }
+
+  const result = await getPairedEdition(db, {
+    pageId,
+    pageNumber: pageNumber != null && !Number.isNaN(pageNumber) ? pageNumber : null,
+  });
+  return NextResponse.json(result);
+}

--- a/src/components/book/PairedEditionPanel.tsx
+++ b/src/components/book/PairedEditionPanel.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { BookOpen, Info } from 'lucide-react';
+import NotesRenderer from '@/components/reader/NotesRenderer';
+import {
+  MARCIANUS_BOOK_ID,
+  BERTHELOT_LAYER_LABEL,
+  type PairedEditionResponse,
+} from '@/lib/marcianus-overlay.shared';
+
+type Paired = NonNullable<PairedEditionResponse['paired']>;
+
+interface PairedEditionPanelProps {
+  bookId: string;
+  pageId: string;
+  pageNumber?: number | null;
+  /** Notifies the parent reader so it can flag / demote the manuscript OCR. */
+  onLoaded?: (hasPaired: boolean) => void;
+}
+
+/**
+ * Non-destructive reading overlay: when the current Marcianus 299 folio is
+ * aligned to Berthelot & Ruelle's critical edition, surface Berthelot's Greek +
+ * English as the reading text of record above the manuscript's own OCR columns,
+ * with honest per-folio confidence badges and a provenance note.
+ *
+ * Self-fetches per page (reader navigation is client-side), and renders nothing
+ * for any book other than Marcianus 299 — so it can be mounted unconditionally.
+ * See .claude/docs/edition-facsimile-pairing.md.
+ */
+export default function PairedEditionPanel({
+  bookId,
+  pageId,
+  pageNumber,
+  onLoaded,
+}: PairedEditionPanelProps) {
+  const [paired, setPaired] = useState<Paired | null>(null);
+  const onLoadedRef = useRef(onLoaded);
+  onLoadedRef.current = onLoaded;
+
+  useEffect(() => {
+    // Only the registered manuscript has an overlay; skip the fetch otherwise.
+    if (bookId !== MARCIANUS_BOOK_ID) {
+      setPaired(null);
+      onLoadedRef.current?.(false);
+      return;
+    }
+    const ctrl = new AbortController();
+    const params = new URLSearchParams();
+    if (pageId) params.set('pageId', pageId);
+    if (pageNumber != null) params.set('page', String(pageNumber));
+
+    fetch(`/api/books/${encodeURIComponent(bookId)}/paired-edition?${params.toString()}`, {
+      signal: ctrl.signal,
+    })
+      .then((r) => (r.ok ? r.json() : { paired: null }))
+      .then((data: PairedEditionResponse) => {
+        setPaired(data.paired);
+        onLoadedRef.current?.(!!data.paired);
+      })
+      .catch((err) => {
+        if (err?.name === 'AbortError') return;
+        setPaired(null);
+        onLoadedRef.current?.(false);
+      });
+    return () => ctrl.abort();
+  }, [bookId, pageId, pageNumber]);
+
+  if (!paired) return null;
+
+  return (
+    <section
+      data-reader-section="paired-edition"
+      // Bounded + internally scrollable so this reading pane never crushes the
+      // fixed-height facsimile / OCR columns below it (the shell is h-screen).
+      className="flex-shrink-0 border-b overflow-y-auto max-h-[50vh] lg:max-h-[55vh]"
+      style={{ background: 'var(--bg-cream)', borderColor: 'var(--border-light)' }}
+      aria-label="Critical edition reading text"
+    >
+      <div className="mx-auto w-full max-w-5xl px-4 py-3">
+        {/* Header: edition label + honest confidence chips */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide"
+            style={{ color: 'var(--accent-gold-dark)' }}
+          >
+            <BookOpen className="w-3.5 h-3.5" />
+            {BERTHELOT_LAYER_LABEL}
+          </span>
+          <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+            f. {paired.folio}
+          </span>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {paired.badges.map((b) => (
+              <span
+                key={b.label}
+                className={`px-1.5 py-0.5 rounded text-[11px] cursor-help ${b.className}`}
+                title={b.tooltip}
+              >
+                {b.label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Provenance / quality note */}
+        <p
+          className="mt-2 flex items-start gap-1.5 text-xs"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          <Info className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+          <span>{paired.provenanceNote}</span>
+        </p>
+
+        {/* Reading text of record: Greek transcription + English translation */}
+        <div className="mt-3 grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {paired.transcription && (
+            <div>
+              <div
+                className="text-[11px] font-medium uppercase tracking-wide mb-1"
+                style={{ color: 'var(--text-muted)' }}
+              >
+                Greek (Berthelot)
+              </div>
+              <div className="prose-manuscript leading-relaxed" style={{ color: 'var(--text-secondary)' }} lang="el">
+                <NotesRenderer text={paired.transcription} showNotes showMetadata={false} language="Ancient Greek" />
+              </div>
+            </div>
+          )}
+          {paired.translation && (
+            <div>
+              <div
+                className="text-[11px] font-medium uppercase tracking-wide mb-1"
+                style={{ color: 'var(--text-muted)' }}
+              >
+                English (Berthelot)
+              </div>
+              <div className="prose-manuscript leading-relaxed" style={{ color: 'var(--text-secondary)' }} lang="en">
+                <NotesRenderer text={paired.translation} showNotes showMetadata={false} />
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -29,6 +29,9 @@ import {
 } from 'lucide-react';
 import { useReaderPreferences } from '@/hooks/useReaderPreferences';
 import NotesRenderer from '@/components/reader/NotesRenderer';
+import PairedEditionPanel from '@/components/book/PairedEditionPanel';
+import AiBadge from '@/components/ui/AiBadge';
+import { MANUSCRIPT_OCR_FLAG } from '@/lib/marcianus-overlay.shared';
 import ImageWithMagnifier from '@/components/ui/ImageWithMagnifier';
 import PageDeepZoomButton from '@/components/reader/PageDeepZoomButton';
 import PageMetadataPanel from '@/components/reader/PageMetadataPanel';
@@ -568,6 +571,11 @@ export default function TranslationEditor({
 
   // Jump-to-page: the counter ("18/864") doubles as an editable input
   const [isEditingPage, setIsEditingPage] = useState(false);
+
+  // Paired critical-edition overlay (Marcianus 299 ↔ Berthelot). When an aligned
+  // folio is showing, the manuscript's own OCR/translation is demoted to a
+  // flagged aid — see .claude/docs/edition-facsimile-pairing.md.
+  const [hasPairedEdition, setHasPairedEdition] = useState(false);
   const [pageInputValue, setPageInputValue] = useState('');
 
   const previousPage = currentIndex > 0 ? pages[currentIndex - 1] : null;
@@ -1341,6 +1349,15 @@ export default function TranslationEditor({
           </div>
         )}
 
+        {/* Paired critical edition (Marcianus 299 ↔ Berthelot) — the reading
+            text of record, surfaced above the facsimile + demoted AI OCR. */}
+        <PairedEditionPanel
+          bookId={book.id}
+          pageId={page.id}
+          pageNumber={page.page_number}
+          onLoaded={setHasPairedEdition}
+        />
+
         {/* Panel layout - dynamic based on visibility */}
         {(() => {
           const visibleCount = [showImagePanel, showOcrPanel, showTranslationPanel, showTransliterationPanel && hasTransliteration, showGermanSourcePanel && hasGermanSource].filter(Boolean).length;
@@ -1514,9 +1531,19 @@ export default function TranslationEditor({
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
                         {ocrText ? (book.language || 'Original') : 'Step 1: Transcribe'}
                       </span>
-                      {ocrText && (
+                      {ocrText && !hasPairedEdition && (
                         <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--accent-sage)' }}>
                           <Check className="w-3 h-3" />
+                        </span>
+                      )}
+                      {ocrText && hasPairedEdition && (
+                        <span
+                          className="inline-flex items-center gap-1 text-[11px] normal-case"
+                          style={{ color: 'var(--text-muted)' }}
+                          title={MANUSCRIPT_OCR_FLAG.tooltip}
+                        >
+                          <AiBadge title={MANUSCRIPT_OCR_FLAG.tooltip} />
+                          {MANUSCRIPT_OCR_FLAG.label}
                         </span>
                       )}
                     </div>
@@ -1677,9 +1704,19 @@ export default function TranslationEditor({
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
                         {translationText ? translationLangLabel : 'Step 2: Translate'}
                       </span>
-                      {translationText && (
+                      {translationText && !hasPairedEdition && (
                         <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--accent-sage)' }}>
                           <Check className="w-3 h-3" />
+                        </span>
+                      )}
+                      {translationText && hasPairedEdition && (
+                        <span
+                          className="inline-flex items-center gap-1 text-[11px] normal-case"
+                          style={{ color: 'var(--text-muted)' }}
+                          title={MANUSCRIPT_OCR_FLAG.tooltip}
+                        >
+                          <AiBadge title={MANUSCRIPT_OCR_FLAG.tooltip} />
+                          {MANUSCRIPT_OCR_FLAG.label}
                         </span>
                       )}
                       {translationText && (

--- a/src/data/marcianus-berthelot-overlay.json
+++ b/src/data/marcianus-berthelot-overlay.json
@@ -1,0 +1,2030 @@
+{
+ "note": "Non-destructive reading overlay: Marcianus gr. Z. 299 folios paired to Berthelot & Ruelle (Greek text vol) page-for-page. by_marc_page keyed by Marcianus page_number. bert_page = primary transcription page (best-coverage candidate). self = pass1-vs-pass2 OCR Dice (stability). cover = OCR-in-Berthelot token coverage — a NOISY LOWER BOUND, never an accuracy rate. See .claude/docs/edition-facsimile-pairing.md.",
+ "marcianus_book": "6a45298cc6d95bc278fbc8c3",
+ "berthelot_book": "6994383a6879ff0184cb803a",
+ "berthelot_citation": "Berthelot & Ruelle, Collection des anciens alchimistes grecs (1887–88)",
+ "work_id": "local:corpus-alchemicorum-graecorum",
+ "stats": {
+  "folios_aligned": 195,
+  "self_agreement_mean": 0.616474964163231,
+  "pearson_self_vs_coverage": 0.2664893399451278
+ },
+ "by_marc_page": {
+  "28": {
+   "folio": "3r",
+   "marc_id": "6a45298cc6d95bc278fbc8df",
+   "bert_page": 431,
+   "bert_pages": [
+    430
+   ],
+   "self": 0.1844484629294756,
+   "cover": 0.130859375
+  },
+  "37": {
+   "folio": "7v",
+   "marc_id": "6a45298cc6d95bc278fbc8e8",
+   "bert_page": 422,
+   "bert_pages": [
+    422
+   ],
+   "self": 0.7681159420289855,
+   "cover": 0.028985507246376812
+  },
+  "40": {
+   "folio": "9r",
+   "marc_id": "6a45298cc6d95bc278fbc8eb",
+   "bert_page": 27,
+   "bert_pages": [
+    27
+   ],
+   "self": 0.6295503211991434,
+   "cover": 0.17180616740088106
+  },
+  "44": {
+   "folio": "11r",
+   "marc_id": "6a45298cc6d95bc278fbc8ef",
+   "bert_page": 109,
+   "bert_pages": [
+    108
+   ],
+   "self": 0.6813186813186813,
+   "cover": 0.15486725663716813
+  },
+  "100": {
+   "folio": "39r",
+   "marc_id": "6a45298cc6d95bc278fbc927",
+   "bert_page": 335,
+   "bert_pages": [
+    334
+   ],
+   "self": 0.6299212598425197,
+   "cover": 0.2607003891050584
+  },
+  "103": {
+   "folio": "40v",
+   "marc_id": "6a45298cc6d95bc278fbc92a",
+   "bert_page": 332,
+   "bert_pages": [
+    331
+   ],
+   "self": 0.6233269598470363,
+   "cover": 0.3203125
+  },
+  "146": {
+   "folio": "62r",
+   "marc_id": "6a45298cc6d95bc278fbc955",
+   "bert_page": 430,
+   "bert_pages": [
+    429
+   ],
+   "self": 0.585949177877429,
+   "cover": 0.2765957446808511
+  },
+  "147": {
+   "folio": "62v",
+   "marc_id": "6a45298cc6d95bc278fbc956",
+   "bert_page": 295,
+   "bert_pages": [
+    295
+   ],
+   "self": 0.5894206549118388,
+   "cover": 0.28717948717948716
+  },
+  "148": {
+   "folio": "63r",
+   "marc_id": "6a45298cc6d95bc278fbc957",
+   "bert_page": 296,
+   "bert_pages": [
+    295
+   ],
+   "self": 0.5864077669902913,
+   "cover": 0.37109375
+  },
+  "149": {
+   "folio": "63v",
+   "marc_id": "6a45298cc6d95bc278fbc958",
+   "bert_page": 297,
+   "bert_pages": [
+    296
+   ],
+   "self": 0.5383177570093458,
+   "cover": 0.4714828897338403
+  },
+  "150": {
+   "folio": "64r",
+   "marc_id": "6a45298cc6d95bc278fbc959",
+   "bert_page": 298,
+   "bert_pages": [
+    297
+   ],
+   "self": 0.6064981949458483,
+   "cover": 0.4981132075471698
+  },
+  "151": {
+   "folio": "64v",
+   "marc_id": "6a45298cc6d95bc278fbc95a",
+   "bert_page": 299,
+   "bert_pages": [
+    299
+   ],
+   "self": 0.6900584795321637,
+   "cover": 0.5137254901960784
+  },
+  "152": {
+   "folio": "65r",
+   "marc_id": "6a45298cc6d95bc278fbc95b",
+   "bert_page": 300,
+   "bert_pages": [
+    300
+   ],
+   "self": 0.6291666666666667,
+   "cover": 0.5432098765432098
+  },
+  "153": {
+   "folio": "65v",
+   "marc_id": "6a45298cc6d95bc278fbc95c",
+   "bert_page": 301,
+   "bert_pages": [
+    301
+   ],
+   "self": 0.6666666666666666,
+   "cover": 0.46511627906976744
+  },
+  "154": {
+   "folio": "66r",
+   "marc_id": "6a45298cc6d95bc278fbc95d",
+   "bert_page": 303,
+   "bert_pages": [
+    303
+   ],
+   "self": 0.6772908366533864,
+   "cover": 0.4263565891472868
+  },
+  "155": {
+   "folio": "66v",
+   "marc_id": "6a45298cc6d95bc278fbc95e",
+   "bert_page": 304,
+   "bert_pages": [
+    303
+   ],
+   "self": 0.6172344689378757,
+   "cover": 0.4743083003952569
+  },
+  "171": {
+   "folio": "74v",
+   "marc_id": "6a45298cc6d95bc278fbc96e",
+   "bert_page": 333,
+   "bert_pages": [
+    332
+   ],
+   "self": 0.6883910386965377,
+   "cover": 0.2784313725490196
+  },
+  "172": {
+   "folio": "75r",
+   "marc_id": "6a45298cc6d95bc278fbc96f",
+   "bert_page": 334,
+   "bert_pages": [
+    333
+   ],
+   "self": 0.6,
+   "cover": 0.2446351931330472
+  },
+  "173": {
+   "folio": "75v",
+   "marc_id": "6a45298cc6d95bc278fbc970",
+   "bert_page": 335,
+   "bert_pages": [
+    334
+   ],
+   "self": 0.6564885496183206,
+   "cover": 0.27586206896551724
+  },
+  "174": {
+   "folio": "76r",
+   "marc_id": "6a45298cc6d95bc278fbc971",
+   "bert_page": 336,
+   "bert_pages": [
+    335
+   ],
+   "self": 0.5394495412844037,
+   "cover": 0.2883895131086142
+  },
+  "175": {
+   "folio": "76v",
+   "marc_id": "6a45298cc6d95bc278fbc972",
+   "bert_page": 336,
+   "bert_pages": [
+    336
+   ],
+   "self": 0.642570281124498,
+   "cover": 0.276
+  },
+  "176": {
+   "folio": "77r",
+   "marc_id": "6a45298cc6d95bc278fbc973",
+   "bert_page": 338,
+   "bert_pages": [
+    337
+   ],
+   "self": 0.6283524904214559,
+   "cover": 0.2696629213483146
+  },
+  "177": {
+   "folio": "77v",
+   "marc_id": "6a45298cc6d95bc278fbc974",
+   "bert_page": 338,
+   "bert_pages": [
+    338
+   ],
+   "self": 0.5957446808510638,
+   "cover": 0.2364341085271318
+  },
+  "178": {
+   "folio": "78r",
+   "marc_id": "6a45298cc6d95bc278fbc975",
+   "bert_page": 463,
+   "bert_pages": [
+    339,
+    463
+   ],
+   "self": 0.70020964360587,
+   "cover": 0.4125
+  },
+  "179": {
+   "folio": "78v",
+   "marc_id": "6a45298cc6d95bc278fbc976",
+   "bert_page": 465,
+   "bert_pages": [
+    339,
+    464
+   ],
+   "self": 0.6603053435114504,
+   "cover": 0.4679245283018868
+  },
+  "180": {
+   "folio": "79r",
+   "marc_id": "6a45298cc6d95bc278fbc977",
+   "bert_page": 466,
+   "bert_pages": [
+    465,
+    466
+   ],
+   "self": 0.6666666666666666,
+   "cover": 0.4880382775119617
+  },
+  "181": {
+   "folio": "79v",
+   "marc_id": "6a45298cc6d95bc278fbc978",
+   "bert_page": 467,
+   "bert_pages": [
+    341,
+    467
+   ],
+   "self": 0.559652928416486,
+   "cover": 0.45535714285714285
+  },
+  "182": {
+   "folio": "80r",
+   "marc_id": "6a45298cc6d95bc278fbc979",
+   "bert_page": 469,
+   "bert_pages": [
+    468
+   ],
+   "self": 0.7178423236514523,
+   "cover": 0.5269709543568465
+  },
+  "183": {
+   "folio": "80v",
+   "marc_id": "6a45298cc6d95bc278fbc97a",
+   "bert_page": 470,
+   "bert_pages": [
+    469
+   ],
+   "self": 0.5909980430528375,
+   "cover": 0.4763779527559055
+  },
+  "184": {
+   "folio": "81r",
+   "marc_id": "6a45298cc6d95bc278fbc97b",
+   "bert_page": 471,
+   "bert_pages": [
+    470
+   ],
+   "self": 0.7204968944099379,
+   "cover": 0.5450819672131147
+  },
+  "185": {
+   "folio": "81v",
+   "marc_id": "6a45298cc6d95bc278fbc97c",
+   "bert_page": 472,
+   "bert_pages": [
+    472
+   ],
+   "self": 0.6480446927374302,
+   "cover": 0.5168539325842697
+  },
+  "186": {
+   "folio": "82r",
+   "marc_id": "6a45298cc6d95bc278fbc97d",
+   "bert_page": 473,
+   "bert_pages": [
+    473
+   ],
+   "self": 0.718978102189781,
+   "cover": 0.5407407407407407
+  },
+  "187": {
+   "folio": "82v",
+   "marc_id": "6a45298cc6d95bc278fbc97e",
+   "bert_page": 474,
+   "bert_pages": [
+    474
+   ],
+   "self": 0.5566600397614314,
+   "cover": 0.324
+  },
+  "193": {
+   "folio": "85v",
+   "marc_id": "6a45298cc6d95bc278fbc984",
+   "bert_page": 108,
+   "bert_pages": [
+    107
+   ],
+   "self": 0.7024952015355086,
+   "cover": 0.25984251968503935
+  },
+  "199": {
+   "folio": "88v",
+   "marc_id": "6a45298cc6d95bc278fbc98a",
+   "bert_page": 23,
+   "bert_pages": [
+    23
+   ],
+   "self": 0.6356589147286822,
+   "cover": 0.26
+  },
+  "207": {
+   "folio": "92v",
+   "marc_id": "6a45298cc6d95bc278fbc992",
+   "bert_page": 14,
+   "bert_pages": [
+    13
+   ],
+   "self": 0.6979591836734694,
+   "cover": 0.21951219512195122
+  },
+  "208": {
+   "folio": "93r",
+   "marc_id": "6a45298cc6d95bc278fbc993",
+   "bert_page": 14,
+   "bert_pages": [
+    13
+   ],
+   "self": 0.6747967479674797,
+   "cover": 0.5532786885245902
+  },
+  "210": {
+   "folio": "94r",
+   "marc_id": "6a45298cc6d95bc278fbc995",
+   "bert_page": 16,
+   "bert_pages": [
+    16
+   ],
+   "self": 0.6998087954110899,
+   "cover": 0.5975609756097561
+  },
+  "211": {
+   "folio": "94v",
+   "marc_id": "6a45298cc6d95bc278fbc996",
+   "bert_page": 17,
+   "bert_pages": [
+    17
+   ],
+   "self": 0.6914498141263941,
+   "cover": 0.5111940298507462
+  },
+  "212": {
+   "folio": "95r",
+   "marc_id": "6a45298cc6d95bc278fbc997",
+   "bert_page": 19,
+   "bert_pages": [
+    18,
+    19
+   ],
+   "self": 0.626746506986028,
+   "cover": 0.4150197628458498
+  },
+  "213": {
+   "folio": "95v",
+   "marc_id": "6a45298cc6d95bc278fbc998",
+   "bert_page": 20,
+   "bert_pages": [
+    19,
+    21
+   ],
+   "self": 0.6521739130434783,
+   "cover": 0.528
+  },
+  "214": {
+   "folio": "96r",
+   "marc_id": "6a45298cc6d95bc278fbc999",
+   "bert_page": 314,
+   "bert_pages": [
+    314
+   ],
+   "self": 0.6380368098159509,
+   "cover": 0.4745762711864407
+  },
+  "215": {
+   "folio": "96v",
+   "marc_id": "6a45298cc6d95bc278fbc99a",
+   "bert_page": 316,
+   "bert_pages": [
+    315
+   ],
+   "self": 0.5579399141630901,
+   "cover": 0.3624454148471616
+  },
+  "216": {
+   "folio": "97r",
+   "marc_id": "6a45298cc6d95bc278fbc99b",
+   "bert_page": 316,
+   "bert_pages": [
+    316
+   ],
+   "self": 0.672566371681416,
+   "cover": 0.3930131004366812
+  },
+  "217": {
+   "folio": "97v",
+   "marc_id": "6a45298cc6d95bc278fbc99c",
+   "bert_page": 318,
+   "bert_pages": [
+    317
+   ],
+   "self": 0.5467980295566502,
+   "cover": 0.39436619718309857
+  },
+  "218": {
+   "folio": "98r",
+   "marc_id": "6a45298cc6d95bc278fbc99d",
+   "bert_page": 319,
+   "bert_pages": [
+    318
+   ],
+   "self": 0.7639484978540773,
+   "cover": 0.42127659574468085
+  },
+  "219": {
+   "folio": "98v",
+   "marc_id": "6a45298cc6d95bc278fbc99e",
+   "bert_page": 320,
+   "bert_pages": [
+    319
+   ],
+   "self": 0.6227272727272727,
+   "cover": 0.4090909090909091
+  },
+  "220": {
+   "folio": "99r",
+   "marc_id": "6a45298cc6d95bc278fbc99f",
+   "bert_page": 321,
+   "bert_pages": [
+    320,
+    321
+   ],
+   "self": 0.6853146853146853,
+   "cover": 0.48623853211009177
+  },
+  "221": {
+   "folio": "99v",
+   "marc_id": "6a45298cc6d95bc278fbc9a0",
+   "bert_page": 322,
+   "bert_pages": [
+    322
+   ],
+   "self": 0.6093023255813953,
+   "cover": 0.3611111111111111
+  },
+  "222": {
+   "folio": "100r",
+   "marc_id": "6a45298cc6d95bc278fbc9a1",
+   "bert_page": 324,
+   "bert_pages": [
+    323
+   ],
+   "self": 0.6582914572864321,
+   "cover": 0.4635416666666667
+  },
+  "223": {
+   "folio": "100v",
+   "marc_id": "6a45298cc6d95bc278fbc9a2",
+   "bert_page": 325,
+   "bert_pages": [
+    324
+   ],
+   "self": 0.5652173913043478,
+   "cover": 0.31666666666666665
+  },
+  "225": {
+   "folio": "101v",
+   "marc_id": "6a45298cc6d95bc278fbc9a4",
+   "bert_page": 442,
+   "bert_pages": [
+    442
+   ],
+   "self": 0.6936708860759494,
+   "cover": 0.4175257731958763
+  },
+  "226": {
+   "folio": "102r",
+   "marc_id": "6a45298cc6d95bc278fbc9a5",
+   "bert_page": 443,
+   "bert_pages": [
+    443
+   ],
+   "self": 0.6185567010309279,
+   "cover": 0.4178082191780822
+  },
+  "228": {
+   "folio": "103r",
+   "marc_id": "6a45298cc6d95bc278fbc9a7",
+   "bert_page": 444,
+   "bert_pages": [
+    444
+   ],
+   "self": 0.680365296803653,
+   "cover": 0.4304932735426009
+  },
+  "229": {
+   "folio": "103v",
+   "marc_id": "6a45298cc6d95bc278fbc9a8",
+   "bert_page": 446,
+   "bert_pages": [
+    445
+   ],
+   "self": 0.48847926267281105,
+   "cover": 0.4
+  },
+  "230": {
+   "folio": "104r",
+   "marc_id": "6a45298cc6d95bc278fbc9a9",
+   "bert_page": 385,
+   "bert_pages": [
+    384,
+    389
+   ],
+   "self": 0.6067415730337079,
+   "cover": 0.40476190476190477
+  },
+  "231": {
+   "folio": "104v",
+   "marc_id": "6a45298cc6d95bc278fbc9aa",
+   "bert_page": 385,
+   "bert_pages": [
+    385
+   ],
+   "self": 0.5392781316348195,
+   "cover": 0.46638655462184875
+  },
+  "232": {
+   "folio": "105r",
+   "marc_id": "6a45298cc6d95bc278fbc9ab",
+   "bert_page": 386,
+   "bert_pages": [
+    386
+   ],
+   "self": 0.6948775055679287,
+   "cover": 0.5570776255707762
+  },
+  "233": {
+   "folio": "105v",
+   "marc_id": "6a45298cc6d95bc278fbc9ac",
+   "bert_page": 387,
+   "bert_pages": [
+    386
+   ],
+   "self": 0.5619834710743802,
+   "cover": 0.36065573770491804
+  },
+  "234": {
+   "folio": "106r",
+   "marc_id": "6a45298cc6d95bc278fbc9ad",
+   "bert_page": 387,
+   "bert_pages": [
+    387
+   ],
+   "self": 0.5458248472505092,
+   "cover": 0.25833333333333336
+  },
+  "236": {
+   "folio": "107r",
+   "marc_id": "6a45298cc6d95bc278fbc9af",
+   "bert_page": 126,
+   "bert_pages": [
+    126
+   ],
+   "self": 0.767816091954023,
+   "cover": 0.1981981981981982
+  },
+  "237": {
+   "folio": "107v",
+   "marc_id": "6a45298cc6d95bc278fbc9b0",
+   "bert_page": 127,
+   "bert_pages": [
+    126
+   ],
+   "self": 0.48130841121495327,
+   "cover": 0.6064814814814815
+  },
+  "238": {
+   "folio": "108r",
+   "marc_id": "6a45298cc6d95bc278fbc9b1",
+   "bert_page": 128,
+   "bert_pages": [
+    127
+   ],
+   "self": 0.6446280991735537,
+   "cover": 0.45714285714285713
+  },
+  "242": {
+   "folio": "110r",
+   "marc_id": "6a45298cc6d95bc278fbc9b5",
+   "bert_page": 438,
+   "bert_pages": [
+    437
+   ],
+   "self": 0.6536796536796536,
+   "cover": 0.3920704845814978
+  },
+  "243": {
+   "folio": "110v",
+   "marc_id": "6a45298cc6d95bc278fbc9b6",
+   "bert_page": 439,
+   "bert_pages": [
+    438
+   ],
+   "self": 0.5369127516778524,
+   "cover": 0.46153846153846156
+  },
+  "246": {
+   "folio": "112r",
+   "marc_id": "6a45298cc6d95bc278fbc9b9",
+   "bert_page": 44,
+   "bert_pages": [
+    44,
+    116
+   ],
+   "self": 0.5916114790286976,
+   "cover": 0.3333333333333333
+  },
+  "247": {
+   "folio": "112v",
+   "marc_id": "6a45298cc6d95bc278fbc9ba",
+   "bert_page": 45,
+   "bert_pages": [
+    44,
+    52
+   ],
+   "self": 0.5986394557823129,
+   "cover": 0.5161290322580645
+  },
+  "248": {
+   "folio": "113r",
+   "marc_id": "6a45298cc6d95bc278fbc9bb",
+   "bert_page": 45,
+   "bert_pages": [
+    45
+   ],
+   "self": 0.7215496368038741,
+   "cover": 0.47029702970297027
+  },
+  "249": {
+   "folio": "113v",
+   "marc_id": "6a45298cc6d95bc278fbc9bc",
+   "bert_page": 47,
+   "bert_pages": [
+    47
+   ],
+   "self": 0.4924406047516199,
+   "cover": 0.42731277533039647
+  },
+  "250": {
+   "folio": "114r",
+   "marc_id": "6a45298cc6d95bc278fbc9bd",
+   "bert_page": 48,
+   "bert_pages": [
+    47
+   ],
+   "self": 0.6370023419203747,
+   "cover": 0.5475113122171946
+  },
+  "251": {
+   "folio": "114v",
+   "marc_id": "6a45298cc6d95bc278fbc9be",
+   "bert_page": 48,
+   "bert_pages": [
+    48
+   ],
+   "self": 0.502262443438914,
+   "cover": 0.36363636363636365
+  },
+  "252": {
+   "folio": "115r",
+   "marc_id": "6a45298cc6d95bc278fbc9bf",
+   "bert_page": 49,
+   "bert_pages": [
+    13,
+    49,
+    50
+   ],
+   "self": 0.6149870801033591,
+   "cover": 0.35978835978835977
+  },
+  "253": {
+   "folio": "115v",
+   "marc_id": "6a45298cc6d95bc278fbc9c0",
+   "bert_page": 51,
+   "bert_pages": [
+    50
+   ],
+   "self": 0.7428571428571429,
+   "cover": 0.5047619047619047
+  },
+  "254": {
+   "folio": "116r",
+   "marc_id": "6a45298cc6d95bc278fbc9c1",
+   "bert_page": 391,
+   "bert_pages": [
+    390
+   ],
+   "self": 0.6612244897959184,
+   "cover": 0.4819277108433735
+  },
+  "255": {
+   "folio": "116v",
+   "marc_id": "6a45298cc6d95bc278fbc9c2",
+   "bert_page": 156,
+   "bert_pages": [
+    156,
+    391
+   ],
+   "self": 0.5874125874125874,
+   "cover": 0.3175355450236967
+  },
+  "256": {
+   "folio": "117r",
+   "marc_id": "6a45298cc6d95bc278fbc9c3",
+   "bert_page": 157,
+   "bert_pages": [
+    157
+   ],
+   "self": 0.5990783410138248,
+   "cover": 0.5209302325581395
+  },
+  "257": {
+   "folio": "117v",
+   "marc_id": "6a45298cc6d95bc278fbc9c4",
+   "bert_page": 158,
+   "bert_pages": [
+    157
+   ],
+   "self": 0.6498740554156172,
+   "cover": 0.6060606060606061
+  },
+  "258": {
+   "folio": "118r",
+   "marc_id": "6a45298cc6d95bc278fbc9c5",
+   "bert_page": 388,
+   "bert_pages": [
+    117,
+    158,
+    388
+   ],
+   "self": 0.7010309278350515,
+   "cover": 0.41708542713567837
+  },
+  "259": {
+   "folio": "118v",
+   "marc_id": "6a45298cc6d95bc278fbc9c6",
+   "bert_page": 389,
+   "bert_pages": [
+    388,
+    389
+   ],
+   "self": 0.578088578088578,
+   "cover": 0.4027777777777778
+  },
+  "260": {
+   "folio": "119r",
+   "marc_id": "6a45298cc6d95bc278fbc9c7",
+   "bert_page": 446,
+   "bert_pages": [
+    446,
+    447
+   ],
+   "self": 0.6863157894736842,
+   "cover": 0.4583333333333333
+  },
+  "261": {
+   "folio": "119v",
+   "marc_id": "6a45298cc6d95bc278fbc9c8",
+   "bert_page": 448,
+   "bert_pages": [
+    447
+   ],
+   "self": 0.5394736842105263,
+   "cover": 0.3744292237442922
+  },
+  "262": {
+   "folio": "120r",
+   "marc_id": "6a45298cc6d95bc278fbc9c9",
+   "bert_page": 448,
+   "bert_pages": [
+    448
+   ],
+   "self": 0.5882352941176471,
+   "cover": 0.3333333333333333
+  },
+  "263": {
+   "folio": "120v",
+   "marc_id": "6a45298cc6d95bc278fbc9ca",
+   "bert_page": 450,
+   "bert_pages": [
+    449
+   ],
+   "self": 0.6738197424892703,
+   "cover": 0.46153846153846156
+  },
+  "264": {
+   "folio": "121r",
+   "marc_id": "6a45298cc6d95bc278fbc9cb",
+   "bert_page": 450,
+   "bert_pages": [
+    450,
+    451
+   ],
+   "self": 0.729064039408867,
+   "cover": 0.46116504854368934
+  },
+  "265": {
+   "folio": "121v",
+   "marc_id": "6a45298cc6d95bc278fbc9cc",
+   "bert_page": 452,
+   "bert_pages": [
+    451
+   ],
+   "self": 0.6025974025974026,
+   "cover": 0.43147208121827413
+  },
+  "266": {
+   "folio": "122r",
+   "marc_id": "6a45298cc6d95bc278fbc9cd",
+   "bert_page": 453,
+   "bert_pages": [
+    452
+   ],
+   "self": 0.7300771208226221,
+   "cover": 0.576530612244898
+  },
+  "267": {
+   "folio": "122v",
+   "marc_id": "6a45298cc6d95bc278fbc9ce",
+   "bert_page": 454,
+   "bert_pages": [
+    453
+   ],
+   "self": 0.6014319809069213,
+   "cover": 0.4854368932038835
+  },
+  "268": {
+   "folio": "123r",
+   "marc_id": "6a45298cc6d95bc278fbc9cf",
+   "bert_page": 454,
+   "bert_pages": [
+    454
+   ],
+   "self": 0.618925831202046,
+   "cover": 0.40414507772020725
+  },
+  "269": {
+   "folio": "123v",
+   "marc_id": "6a45298cc6d95bc278fbc9d0",
+   "bert_page": 455,
+   "bert_pages": [
+    455
+   ],
+   "self": 0.5714285714285714,
+   "cover": 0.37438423645320196
+  },
+  "270": {
+   "folio": "124r",
+   "marc_id": "6a45298cc6d95bc278fbc9d1",
+   "bert_page": 456,
+   "bert_pages": [
+    456
+   ],
+   "self": 0.5860215053763441,
+   "cover": 0.48333333333333334
+  },
+  "271": {
+   "folio": "124v",
+   "marc_id": "6a45298cc6d95bc278fbc9d2",
+   "bert_page": 457,
+   "bert_pages": [
+    457
+   ],
+   "self": 0.5026737967914439,
+   "cover": 0.3351063829787234
+  },
+  "272": {
+   "folio": "125r",
+   "marc_id": "6a45298cc6d95bc278fbc9d3",
+   "bert_page": 458,
+   "bert_pages": [
+    458
+   ],
+   "self": 0.6474820143884892,
+   "cover": 0.4492753623188406
+  },
+  "273": {
+   "folio": "125v",
+   "marc_id": "6a45298cc6d95bc278fbc9d4",
+   "bert_page": 459,
+   "bert_pages": [
+    459
+   ],
+   "self": 0.612987012987013,
+   "cover": 0.5372340425531915
+  },
+  "274": {
+   "folio": "126r",
+   "marc_id": "6a45298cc6d95bc278fbc9d5",
+   "bert_page": 460,
+   "bert_pages": [
+    459
+   ],
+   "self": 0.6256410256410256,
+   "cover": 0.4642857142857143
+  },
+  "275": {
+   "folio": "126v",
+   "marc_id": "6a45298cc6d95bc278fbc9d6",
+   "bert_page": 461,
+   "bert_pages": [
+    460
+   ],
+   "self": 0.5815602836879432,
+   "cover": 0.45410628019323673
+  },
+  "276": {
+   "folio": "127r",
+   "marc_id": "6a45298cc6d95bc278fbc9d7",
+   "bert_page": 462,
+   "bert_pages": [
+    461
+   ],
+   "self": 0.5056433408577878,
+   "cover": 0.35185185185185186
+  },
+  "277": {
+   "folio": "127v",
+   "marc_id": "6a45298cc6d95bc278fbc9d8",
+   "bert_page": 462,
+   "bert_pages": [
+    415,
+    462
+   ],
+   "self": 0.6305418719211823,
+   "cover": 0.36585365853658536
+  },
+  "279": {
+   "folio": "128v",
+   "marc_id": "6a45298cc6d95bc278fbc9da",
+   "bert_page": 417,
+   "bert_pages": [
+    417
+   ],
+   "self": 0.6318537859007833,
+   "cover": 0.2513089005235602
+  },
+  "280": {
+   "folio": "129r",
+   "marc_id": "6a45298cc6d95bc278fbc9db",
+   "bert_page": 418,
+   "bert_pages": [
+    417
+   ],
+   "self": 0.6879271070615034,
+   "cover": 0.48148148148148145
+  },
+  "281": {
+   "folio": "129v",
+   "marc_id": "6a45298cc6d95bc278fbc9dc",
+   "bert_page": 418,
+   "bert_pages": [
+    418
+   ],
+   "self": 0.5849056603773585,
+   "cover": 0.47368421052631576
+  },
+  "282": {
+   "folio": "130r",
+   "marc_id": "6a45298cc6d95bc278fbc9dd",
+   "bert_page": 419,
+   "bert_pages": [
+    419
+   ],
+   "self": 0.6141732283464567,
+   "cover": 0.40625
+  },
+  "283": {
+   "folio": "130v",
+   "marc_id": "6a45298cc6d95bc278fbc9de",
+   "bert_page": 421,
+   "bert_pages": [
+    420
+   ],
+   "self": 0.5388888888888889,
+   "cover": 0.32085561497326204
+  },
+  "284": {
+   "folio": "131r",
+   "marc_id": "6a45298cc6d95bc278fbc9df",
+   "bert_page": 421,
+   "bert_pages": [
+    421
+   ],
+   "self": 0.5076923076923077,
+   "cover": 0.24875621890547264
+  },
+  "295": {
+   "folio": "136v",
+   "marc_id": "6a45298cc6d95bc278fbc9ea",
+   "bert_page": 111,
+   "bert_pages": [
+    111
+   ],
+   "self": 0.671875,
+   "cover": 0.505
+  },
+  "296": {
+   "folio": "137r",
+   "marc_id": "6a45298cc6d95bc278fbc9eb",
+   "bert_page": 113,
+   "bert_pages": [
+    104,
+    112,
+    113
+   ],
+   "self": 0.5977653631284916,
+   "cover": 0.31693989071038253
+  },
+  "297": {
+   "folio": "137v",
+   "marc_id": "6a45298cc6d95bc278fbc9ec",
+   "bert_page": 114,
+   "bert_pages": [
+    105,
+    113,
+    114,
+    495
+   ],
+   "self": 0.7436619718309859,
+   "cover": 0.48314606741573035
+  },
+  "298": {
+   "folio": "138r",
+   "marc_id": "6a45298cc6d95bc278fbc9ed",
+   "bert_page": 106,
+   "bert_pages": [
+    106,
+    496
+   ],
+   "self": 0.543859649122807,
+   "cover": 0.23008849557522124
+  },
+  "299": {
+   "folio": "138v",
+   "marc_id": "6a45298cc6d95bc278fbc9ee",
+   "bert_page": 498,
+   "bert_pages": [
+    497
+   ],
+   "self": 0.5476673427991886,
+   "cover": 0.18907563025210083
+  },
+  "300": {
+   "folio": "139r",
+   "marc_id": "6a45298cc6d95bc278fbc9ef",
+   "bert_page": 109,
+   "bert_pages": [
+    64,
+    108,
+    499
+   ],
+   "self": 0.4782608695652174,
+   "cover": 0.2231404958677686
+  },
+  "301": {
+   "folio": "139v",
+   "marc_id": "6a45298cc6d95bc278fbc9f0",
+   "bert_page": 501,
+   "bert_pages": [
+    501
+   ],
+   "self": 0.5458248472505092,
+   "cover": 0.10931174089068826
+  },
+  "302": {
+   "folio": "140r",
+   "marc_id": "6a45298cc6d95bc278fbc9f1",
+   "bert_page": 109,
+   "bert_pages": [
+    109
+   ],
+   "self": 0.5372549019607843,
+   "cover": 0.26693227091633465
+  },
+  "305": {
+   "folio": "141v",
+   "marc_id": "6a45298cc6d95bc278fbc9f4",
+   "bert_page": 54,
+   "bert_pages": [
+    54,
+    406
+   ],
+   "self": 0.488,
+   "cover": 0.328125
+  },
+  "306": {
+   "folio": "142r",
+   "marc_id": "6a45298cc6d95bc278fbc9f5",
+   "bert_page": 55,
+   "bert_pages": [
+    54,
+    407
+   ],
+   "self": 0.6363636363636364,
+   "cover": 0.40239043824701193
+  },
+  "307": {
+   "folio": "142v",
+   "marc_id": "6a45298cc6d95bc278fbc9f6",
+   "bert_page": 56,
+   "bert_pages": [
+    55,
+    408
+   ],
+   "self": 0.5193370165745856,
+   "cover": 0.34782608695652173
+  },
+  "308": {
+   "folio": "143r",
+   "marc_id": "6a45298cc6d95bc278fbc9f7",
+   "bert_page": 58,
+   "bert_pages": [
+    57,
+    408
+   ],
+   "self": 0.5675675675675675,
+   "cover": 0.4007352941176471
+  },
+  "309": {
+   "folio": "143v",
+   "marc_id": "6a45298cc6d95bc278fbc9f8",
+   "bert_page": 58,
+   "bert_pages": [
+    58,
+    409
+   ],
+   "self": 0.6525911708253359,
+   "cover": 0.40234375
+  },
+  "310": {
+   "folio": "144r",
+   "marc_id": "6a45298cc6d95bc278fbc9f9",
+   "bert_page": 60,
+   "bert_pages": [
+    59,
+    60,
+    410
+   ],
+   "self": 0.5714285714285714,
+   "cover": 0.3161764705882353
+  },
+  "311": {
+   "folio": "144v",
+   "marc_id": "6a45298cc6d95bc278fbc9fa",
+   "bert_page": 62,
+   "bert_pages": [
+    61,
+    62,
+    411
+   ],
+   "self": 0.5523156089193825,
+   "cover": 0.3333333333333333
+  },
+  "312": {
+   "folio": "145r",
+   "marc_id": "6a45298cc6d95bc278fbc9fb",
+   "bert_page": 63,
+   "bert_pages": [
+    62,
+    412
+   ],
+   "self": 0.5985663082437276,
+   "cover": 0.3118279569892473
+  },
+  "313": {
+   "folio": "145v",
+   "marc_id": "6a45298cc6d95bc278fbc9fc",
+   "bert_page": 64,
+   "bert_pages": [
+    63,
+    65,
+    412
+   ],
+   "self": 0.6666666666666666,
+   "cover": 0.4980392156862745
+  },
+  "314": {
+   "folio": "146r",
+   "marc_id": "6a45298cc6d95bc278fbc9fd",
+   "bert_page": 66,
+   "bert_pages": [
+    65,
+    413
+   ],
+   "self": 0.5714285714285714,
+   "cover": 0.39069767441860465
+  },
+  "316": {
+   "folio": "147r",
+   "marc_id": "6a45298cc6d95bc278fbc9ff",
+   "bert_page": 68,
+   "bert_pages": [
+    67
+   ],
+   "self": 0.5962962962962963,
+   "cover": 0.3511450381679389
+  },
+  "317": {
+   "folio": "147v",
+   "marc_id": "6a45298cc6d95bc278fbca00",
+   "bert_page": 69,
+   "bert_pages": [
+    68,
+    393
+   ],
+   "self": 0.5609756097560976,
+   "cover": 0.436426116838488
+  },
+  "318": {
+   "folio": "148r",
+   "marc_id": "6a45298cc6d95bc278fbca01",
+   "bert_page": 70,
+   "bert_pages": [
+    69,
+    393
+   ],
+   "self": 0.611764705882353,
+   "cover": 0.5247148288973384
+  },
+  "319": {
+   "folio": "148v",
+   "marc_id": "6a45298cc6d95bc278fbca02",
+   "bert_page": 71,
+   "bert_pages": [
+    71,
+    394
+   ],
+   "self": 0.58195211786372,
+   "cover": 0.37037037037037035
+  },
+  "320": {
+   "folio": "149r",
+   "marc_id": "6a45298cc6d95bc278fbca03",
+   "bert_page": 396,
+   "bert_pages": [
+    395
+   ],
+   "self": 0.5569620253164557,
+   "cover": 0.22262773722627738
+  },
+  "321": {
+   "folio": "149v",
+   "marc_id": "6a45298cc6d95bc278fbca04",
+   "bert_page": 74,
+   "bert_pages": [
+    73,
+    396
+   ],
+   "self": 0.5939849624060151,
+   "cover": 0.48698884758364314
+  },
+  "322": {
+   "folio": "150r",
+   "marc_id": "6a45298cc6d95bc278fbca05",
+   "bert_page": 75,
+   "bert_pages": [
+    74,
+    75,
+    397
+   ],
+   "self": 0.6294964028776978,
+   "cover": 0.4064748201438849
+  },
+  "323": {
+   "folio": "150v",
+   "marc_id": "6a45298cc6d95bc278fbca06",
+   "bert_page": 76,
+   "bert_pages": [
+    76,
+    397
+   ],
+   "self": 0.6796116504854369,
+   "cover": 0.41568627450980394
+  },
+  "324": {
+   "folio": "151r",
+   "marc_id": "6a45298cc6d95bc278fbca07",
+   "bert_page": 78,
+   "bert_pages": [
+    77,
+    398
+   ],
+   "self": 0.6976744186046512,
+   "cover": 0.4883720930232558
+  },
+  "325": {
+   "folio": "151v",
+   "marc_id": "6a45298cc6d95bc278fbca08",
+   "bert_page": 79,
+   "bert_pages": [
+    78,
+    399
+   ],
+   "self": 0.49320388349514566,
+   "cover": 0.46613545816733065
+  },
+  "326": {
+   "folio": "152r",
+   "marc_id": "6a45298cc6d95bc278fbca09",
+   "bert_page": 80,
+   "bert_pages": [
+    80,
+    400
+   ],
+   "self": 0.6307977736549165,
+   "cover": 0.44727272727272727
+  },
+  "327": {
+   "folio": "152v",
+   "marc_id": "6a45298cc6d95bc278fbca0a",
+   "bert_page": 81,
+   "bert_pages": [
+    81,
+    400
+   ],
+   "self": 0.6137566137566137,
+   "cover": 0.3867595818815331
+  },
+  "328": {
+   "folio": "153r",
+   "marc_id": "6a45298cc6d95bc278fbca0b",
+   "bert_page": 83,
+   "bert_pages": [
+    83,
+    401
+   ],
+   "self": 0.6601178781925344,
+   "cover": 0.34901960784313724
+  },
+  "329": {
+   "folio": "153v",
+   "marc_id": "6a45298cc6d95bc278fbca0c",
+   "bert_page": 84,
+   "bert_pages": [
+    83
+   ],
+   "self": 0.6213592233009708,
+   "cover": 0.40234375
+  },
+  "330": {
+   "folio": "154r",
+   "marc_id": "6a45298cc6d95bc278fbca0d",
+   "bert_page": 85,
+   "bert_pages": [
+    85
+   ],
+   "self": 0.5989110707803993,
+   "cover": 0.4119718309859155
+  },
+  "331": {
+   "folio": "154v",
+   "marc_id": "6a45298cc6d95bc278fbca0e",
+   "bert_page": 86,
+   "bert_pages": [
+    86,
+    87,
+    403
+   ],
+   "self": 0.588,
+   "cover": 0.45934959349593496
+  },
+  "332": {
+   "folio": "155r",
+   "marc_id": "6a45298cc6d95bc278fbca0f",
+   "bert_page": 88,
+   "bert_pages": [
+    87,
+    404
+   ],
+   "self": 0.593128390596745,
+   "cover": 0.3546099290780142
+  },
+  "333": {
+   "folio": "155v",
+   "marc_id": "6a45298cc6d95bc278fbca10",
+   "bert_page": 89,
+   "bert_pages": [
+    88,
+    405
+   ],
+   "self": 0.5031712473572939,
+   "cover": 0.3673469387755102
+  },
+  "334": {
+   "folio": "156r",
+   "marc_id": "6a45298cc6d95bc278fbca11",
+   "bert_page": 90,
+   "bert_pages": [
+    90
+   ],
+   "self": 0.72,
+   "cover": 0.5355648535564853
+  },
+  "335": {
+   "folio": "156v",
+   "marc_id": "6a45298cc6d95bc278fbca12",
+   "bert_page": 91,
+   "bert_pages": [
+    91
+   ],
+   "self": 0.5670498084291188,
+   "cover": 0.5037037037037037
+  },
+  "336": {
+   "folio": "157r",
+   "marc_id": "6a45298cc6d95bc278fbca13",
+   "bert_page": 92,
+   "bert_pages": [
+    91,
+    92
+   ],
+   "self": 0.5073529411764706,
+   "cover": 0.3143939393939394
+  },
+  "337": {
+   "folio": "157v",
+   "marc_id": "6a45298cc6d95bc278fbca14",
+   "bert_page": 94,
+   "bert_pages": [
+    93,
+    94
+   ],
+   "self": 0.5978947368421053,
+   "cover": 0.4152542372881356
+  },
+  "338": {
+   "folio": "158r",
+   "marc_id": "6a45298cc6d95bc278fbca15",
+   "bert_page": 95,
+   "bert_pages": [
+    94
+   ],
+   "self": 0.7001862197392924,
+   "cover": 0.45387453874538747
+  },
+  "339": {
+   "folio": "158v",
+   "marc_id": "6a45298cc6d95bc278fbca16",
+   "bert_page": 96,
+   "bert_pages": [
+    96
+   ],
+   "self": 0.6378986866791745,
+   "cover": 0.44649446494464945
+  },
+  "340": {
+   "folio": "159r",
+   "marc_id": "6a45298cc6d95bc278fbca17",
+   "bert_page": 98,
+   "bert_pages": [
+    97
+   ],
+   "self": 0.5916030534351145,
+   "cover": 0.38636363636363635
+  },
+  "341": {
+   "folio": "159v",
+   "marc_id": "6a45298cc6d95bc278fbca18",
+   "bert_page": 99,
+   "bert_pages": [
+    98,
+    484
+   ],
+   "self": 0.5673249551166966,
+   "cover": 0.45126353790613716
+  },
+  "342": {
+   "folio": "160r",
+   "marc_id": "6a45298cc6d95bc278fbca19",
+   "bert_page": 100,
+   "bert_pages": [
+    99,
+    485
+   ],
+   "self": 0.6748681898066784,
+   "cover": 0.4912891986062718
+  },
+  "343": {
+   "folio": "160v",
+   "marc_id": "6a45298cc6d95bc278fbca1a",
+   "bert_page": 101,
+   "bert_pages": [
+    101,
+    486
+   ],
+   "self": 0.5661764705882353,
+   "cover": 0.4473684210526316
+  },
+  "344": {
+   "folio": "161r",
+   "marc_id": "6a45298cc6d95bc278fbca1b",
+   "bert_page": 487,
+   "bert_pages": [
+    487
+   ],
+   "self": 0.708256880733945,
+   "cover": 0.2572463768115942
+  },
+  "345": {
+   "folio": "161v",
+   "marc_id": "6a45298cc6d95bc278fbca1c",
+   "bert_page": 103,
+   "bert_pages": [
+    103,
+    110,
+    488
+   ],
+   "self": 0.5685884691848907,
+   "cover": 0.3769230769230769
+  },
+  "346": {
+   "folio": "162r",
+   "marc_id": "6a45298cc6d95bc278fbca1d",
+   "bert_page": 414,
+   "bert_pages": [
+    110,
+    414
+   ],
+   "self": 0.6016949152542372,
+   "cover": 0.3598326359832636
+  },
+  "347": {
+   "folio": "162v",
+   "marc_id": "6a45298cc6d95bc278fbca1e",
+   "bert_page": 415,
+   "bert_pages": [
+    414
+   ],
+   "self": 0.6263736263736264,
+   "cover": 0.41935483870967744
+  },
+  "348": {
+   "folio": "163r",
+   "marc_id": "6a45298cc6d95bc278fbca1f",
+   "bert_page": 415,
+   "bert_pages": [
+    415
+   ],
+   "self": 0.635814889336016,
+   "cover": 0.25
+  },
+  "360": {
+   "folio": "169r",
+   "marc_id": "6a45298cc6d95bc278fbca2b",
+   "bert_page": 25,
+   "bert_pages": [
+    25
+   ],
+   "self": 0.7442680776014109,
+   "cover": 0.28321678321678323
+  },
+  "361": {
+   "folio": "169v",
+   "marc_id": "6a45298cc6d95bc278fbca2c",
+   "bert_page": 27,
+   "bert_pages": [
+    26
+   ],
+   "self": 0.4628975265017668,
+   "cover": 0.2052980132450331
+  },
+  "362": {
+   "folio": "170r",
+   "marc_id": "6a45298cc6d95bc278fbca2d",
+   "bert_page": 28,
+   "bert_pages": [
+    28
+   ],
+   "self": 0.5576208178438662,
+   "cover": 0.2222222222222222
+  },
+  "364": {
+   "folio": "171r",
+   "marc_id": "6a45298cc6d95bc278fbca2f",
+   "bert_page": 30,
+   "bert_pages": [
+    30
+   ],
+   "self": 0.6219081272084805,
+   "cover": 0.29225352112676056
+  },
+  "365": {
+   "folio": "171v",
+   "marc_id": "6a45298cc6d95bc278fbca30",
+   "bert_page": 31,
+   "bert_pages": [
+    31
+   ],
+   "self": 0.6463414634146342,
+   "cover": 0.24369747899159663
+  },
+  "367": {
+   "folio": "172v",
+   "marc_id": "6a45298cc6d95bc278fbca32",
+   "bert_page": 34,
+   "bert_pages": [
+    33
+   ],
+   "self": 0.5346153846153846,
+   "cover": 0.25555555555555554
+  },
+  "368": {
+   "folio": "173r",
+   "marc_id": "6a45298cc6d95bc278fbca33",
+   "bert_page": 34,
+   "bert_pages": [
+    34
+   ],
+   "self": 0.5783132530120482,
+   "cover": 0.2901960784313726
+  },
+  "369": {
+   "folio": "173v",
+   "marc_id": "6a45298cc6d95bc278fbca34",
+   "bert_page": 36,
+   "bert_pages": [
+    35
+   ],
+   "self": 0.6431226765799256,
+   "cover": 0.26996197718631176
+  },
+  "371": {
+   "folio": "174v",
+   "marc_id": "6a45298cc6d95bc278fbca36",
+   "bert_page": 36,
+   "bert_pages": [
+    36
+   ],
+   "self": 0.5672268907563025,
+   "cover": 0.20920502092050208
+  },
+  "373": {
+   "folio": "175v",
+   "marc_id": "6a45298cc6d95bc278fbca38",
+   "bert_page": 39,
+   "bert_pages": [
+    39
+   ],
+   "self": 0.6810344827586207,
+   "cover": 0.24050632911392406
+  },
+  "374": {
+   "folio": "176r",
+   "marc_id": "6a45298cc6d95bc278fbca39",
+   "bert_page": 41,
+   "bert_pages": [
+    40
+   ],
+   "self": 0.708502024291498,
+   "cover": 0.27419354838709675
+  },
+  "375": {
+   "folio": "176v",
+   "marc_id": "6a45298cc6d95bc278fbca3a",
+   "bert_page": 42,
+   "bert_pages": [
+    41
+   ],
+   "self": 0.6056910569105691,
+   "cover": 0.2834008097165992
+  },
+  "377": {
+   "folio": "177v",
+   "marc_id": "6a45298cc6d95bc278fbca3c",
+   "bert_page": 43,
+   "bert_pages": [
+    43
+   ],
+   "self": 0.6604477611940298,
+   "cover": 0.22794117647058823
+  },
+  "380": {
+   "folio": "179r",
+   "marc_id": "6a45298cc6d95bc278fbca3f",
+   "bert_page": 121,
+   "bert_pages": [
+    121
+   ],
+   "self": 0.6263048016701461,
+   "cover": 0.5147679324894515
+  },
+  "381": {
+   "folio": "179v",
+   "marc_id": "6a45298cc6d95bc278fbca40",
+   "bert_page": 122,
+   "bert_pages": [
+    121
+   ],
+   "self": 0.6594827586206896,
+   "cover": 0.5256410256410257
+  },
+  "382": {
+   "folio": "180r",
+   "marc_id": "6a45298cc6d95bc278fbca41",
+   "bert_page": 123,
+   "bert_pages": [
+    122
+   ],
+   "self": 0.5879732739420935,
+   "cover": 0.5135135135135135
+  },
+  "383": {
+   "folio": "180v",
+   "marc_id": "6a45298cc6d95bc278fbca42",
+   "bert_page": 124,
+   "bert_pages": [
+    123
+   ],
+   "self": 0.6171003717472119,
+   "cover": 0.4690909090909091
+  },
+  "384": {
+   "folio": "181r",
+   "marc_id": "6a45298cc6d95bc278fbca43",
+   "bert_page": 476,
+   "bert_pages": [
+    475
+   ],
+   "self": 0.6666666666666666,
+   "cover": 0.5298507462686567
+  },
+  "385": {
+   "folio": "181v",
+   "marc_id": "6a45298cc6d95bc278fbca44",
+   "bert_page": 477,
+   "bert_pages": [
+    477
+   ],
+   "self": 0.6756238003838771,
+   "cover": 0.5037878787878788
+  },
+  "386": {
+   "folio": "182r",
+   "marc_id": "6a45298cc6d95bc278fbca45",
+   "bert_page": 478,
+   "bert_pages": [
+    478
+   ],
+   "self": 0.6279569892473118,
+   "cover": 0.3728813559322034
+  },
+  "387": {
+   "folio": "182v",
+   "marc_id": "6a45298cc6d95bc278fbca46",
+   "bert_page": 126,
+   "bert_pages": [
+    126
+   ],
+   "self": 0.5920303605313093,
+   "cover": 0.1895910780669145
+  },
+  "388": {
+   "folio": "183r",
+   "marc_id": "6a45298cc6d95bc278fbca47",
+   "bert_page": 480,
+   "bert_pages": [
+    480
+   ],
+   "self": 0.540952380952381,
+   "cover": 0.40671641791044777
+  },
+  "389": {
+   "folio": "183v",
+   "marc_id": "6a45298cc6d95bc278fbca48",
+   "bert_page": 481,
+   "bert_pages": [
+    481
+   ],
+   "self": 0.6422764227642277,
+   "cover": 0.390625
+  },
+  "391": {
+   "folio": "184v",
+   "marc_id": "6a45298cc6d95bc278fbca4a",
+   "bert_page": 483,
+   "bert_pages": [
+    483
+   ],
+   "self": 0.626984126984127,
+   "cover": 0.36947791164658633
+  },
+  "394": {
+   "folio": "186r",
+   "marc_id": "6a45298cc6d95bc278fbca4d",
+   "bert_page": 130,
+   "bert_pages": [
+    130
+   ],
+   "self": 0.6177105831533477,
+   "cover": 0.3
+  },
+  "395": {
+   "folio": "186v",
+   "marc_id": "6a45298cc6d95bc278fbca4e",
+   "bert_page": 131,
+   "bert_pages": [
+    130
+   ],
+   "self": 0.6325411334552102,
+   "cover": 0.40148698884758366
+  },
+  "396": {
+   "folio": "187r",
+   "marc_id": "6a45298cc6d95bc278fbca4f",
+   "bert_page": 131,
+   "bert_pages": [
+    131
+   ],
+   "self": 0.6194331983805668,
+   "cover": 0.42168674698795183
+  },
+  "397": {
+   "folio": "187v",
+   "marc_id": "6a45298cc6d95bc278fbca50",
+   "bert_page": 133,
+   "bert_pages": [
+    132
+   ],
+   "self": 0.5215686274509804,
+   "cover": 0.35269709543568467
+  },
+  "398": {
+   "folio": "188r",
+   "marc_id": "6a45298cc6d95bc278fbca51",
+   "bert_page": 50,
+   "bert_pages": [
+    49,
+    133
+   ],
+   "self": 0.6419213973799127,
+   "cover": 0.3869565217391304
+  },
+  "400": {
+   "folio": "189r",
+   "marc_id": "6a45298cc6d95bc278fbca53",
+   "bert_page": 134,
+   "bert_pages": [
+    134
+   ],
+   "self": 0.5681818181818182,
+   "cover": 0.3755656108597285
+  },
+  "401": {
+   "folio": "189v",
+   "marc_id": "6a45298cc6d95bc278fbca54",
+   "bert_page": 135,
+   "bert_pages": [
+    135
+   ],
+   "self": 0.6354166666666666,
+   "cover": 0.5157894736842106
+  },
+  "402": {
+   "folio": "190r",
+   "marc_id": "6a45298cc6d95bc278fbca55",
+   "bert_page": 136,
+   "bert_pages": [
+    135
+   ],
+   "self": 0.6344827586206897,
+   "cover": 0.45871559633027525
+  },
+  "404": {
+   "folio": "191r",
+   "marc_id": "6a45298cc6d95bc278fbca57",
+   "bert_page": 137,
+   "bert_pages": [
+    137
+   ],
+   "self": 0.5654885654885655,
+   "cover": 0.44621513944223107
+  },
+  "406": {
+   "folio": "192r",
+   "marc_id": "6a45298cc6d95bc278fbca59",
+   "bert_page": 139,
+   "bert_pages": [
+    139
+   ],
+   "self": 0.6458333333333334,
+   "cover": 0.5271966527196653
+  },
+  "407": {
+   "folio": "192v",
+   "marc_id": "6a45298cc6d95bc278fbca5a",
+   "bert_page": 140,
+   "bert_pages": [
+    140
+   ],
+   "self": 0.6028513238289206,
+   "cover": 0.5
+  },
+  "408": {
+   "folio": "193r",
+   "marc_id": "6a45298cc6d95bc278fbca5b",
+   "bert_page": 141,
+   "bert_pages": [
+    141
+   ],
+   "self": 0.608955223880597,
+   "cover": 0.48520710059171596
+  },
+  "410": {
+   "folio": "194r",
+   "marc_id": "6a45298cc6d95bc278fbca5d",
+   "bert_page": 142,
+   "bert_pages": [
+    142
+   ],
+   "self": 0.6384976525821596,
+   "cover": 0.49295774647887325
+  },
+  "411": {
+   "folio": "194v",
+   "marc_id": "6a45298cc6d95bc278fbca5e",
+   "bert_page": 431,
+   "bert_pages": [
+    143,
+    431
+   ],
+   "self": 0.4716981132075472,
+   "cover": 0.33636363636363636
+  },
+  "412": {
+   "folio": "195r",
+   "marc_id": "6a45298cc6d95bc278fbca5f",
+   "bert_page": 143,
+   "bert_pages": [
+    143
+   ],
+   "self": 0.6545454545454545,
+   "cover": 0.51440329218107
+  },
+  "413": {
+   "folio": "195v",
+   "marc_id": "6a45298cc6d95bc278fbca60",
+   "bert_page": 144,
+   "bert_pages": [
+    144
+   ],
+   "self": 0.6056782334384858,
+   "cover": 0.5308641975308642
+  },
+  "414": {
+   "folio": "196r",
+   "marc_id": "6a45298cc6d95bc278fbca61",
+   "bert_page": 144,
+   "bert_pages": [
+    144
+   ],
+   "self": 0.535031847133758,
+   "cover": 0.5061728395061729
+  }
+ }
+}

--- a/src/lib/marcianus-overlay.shared.ts
+++ b/src/lib/marcianus-overlay.shared.ts
@@ -1,0 +1,53 @@
+/**
+ * Client-safe constants + types for the Marcianus 299 ↔ Berthelot reading
+ * overlay. Kept separate from `marcianus-overlay.ts` so client components can
+ * import the book id / response shape WITHOUT pulling the ~20 KB concordance
+ * JSON (server-only) into the browser bundle.
+ *
+ * Design + rationale: .claude/docs/edition-facsimile-pairing.md
+ */
+
+/** Marcianus graecus Z. 299 — the manuscript this overlay applies to. */
+export const MARCIANUS_BOOK_ID = '6a45298cc6d95bc278fbc8c3';
+
+/** Berthelot & Ruelle, Collection des anciens alchimistes grecs (Greek text vol). */
+export const BERTHELOT_BOOK_ID = '6994383a6879ff0184cb803a';
+
+/** Verbatim heading over the promoted critical-edition reading text. */
+export const BERTHELOT_LAYER_LABEL = 'Critical edition · Berthelot & Ruelle 1887–88';
+
+/**
+ * Short flag + tooltip for the demoted manuscript-OCR body. Shared so the
+ * reader panel header (client) and the API payload (server) stay in sync.
+ */
+export const MANUSCRIPT_OCR_FLAG = {
+  label: 'Rough AI transcription — flagged',
+  tooltip:
+    'Unverified — this folio’s OCR may contain fabricated wording; check the critical edition or facsimile before quoting.',
+};
+
+/** One confidence chip: label + honest tooltip + a design-token colour class. */
+export interface OverlayBadge {
+  label: string;
+  tooltip: string;
+  /** Existing status-token classes only — no new design primitives. */
+  className: string;
+}
+
+/** Payload returned by GET /api/books/[id]/paired-edition. */
+export interface PairedEditionResponse {
+  paired: {
+    folio: string;
+    bertPage: number;
+    citation: string;
+    /** Berthelot's Greek transcription, editorial wrappers stripped. */
+    transcription: string;
+    /** Berthelot's English translation, editorial wrappers stripped. */
+    translation: string;
+    badges: OverlayBadge[];
+    /** Provenance/quality note for this folio (record-level honesty). */
+    provenanceNote: string;
+    /** Short flag + tooltip for the demoted manuscript-OCR body. */
+    ocrFlag: { label: string; tooltip: string };
+  } | null;
+}

--- a/src/lib/marcianus-overlay.ts
+++ b/src/lib/marcianus-overlay.ts
@@ -1,0 +1,135 @@
+/**
+ * Server-side accessor for the Marcianus 299 ↔ Berthelot reading overlay.
+ *
+ * NON-DESTRUCTIVE read-time join: for a Marcianus folio, look up the aligned
+ * Berthelot page (via the bundled concordance) and surface Berthelot's critical
+ * Greek + English as the reading text of record, while the manuscript's own OCR
+ * is demoted to a flagged aid. Nothing in `pages.ocr.data` / `translation.data`
+ * is ever mutated. See .claude/docs/edition-facsimile-pairing.md.
+ *
+ * The concordance JSON is imported here (server-only). Client components should
+ * import from `./marcianus-overlay.shared` to avoid bundling it.
+ */
+import type { Db } from 'mongodb';
+import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import overlay from '@/data/marcianus-berthelot-overlay.json';
+import {
+  MARCIANUS_BOOK_ID,
+  BERTHELOT_BOOK_ID,
+  BERTHELOT_LAYER_LABEL,
+  MANUSCRIPT_OCR_FLAG,
+  type OverlayBadge,
+  type PairedEditionResponse,
+} from './marcianus-overlay.shared';
+
+export { MARCIANUS_BOOK_ID, BERTHELOT_BOOK_ID, BERTHELOT_LAYER_LABEL };
+
+interface OverlayEntry {
+  folio: string;
+  marc_id: string;
+  bert_page: number;
+  bert_pages: number[];
+  self: number | null; // pass1-vs-pass2 OCR Dice (stability)
+  cover: number | null; // OCR-in-Berthelot coverage — LOWER BOUND, never shown as a number
+}
+
+const byMarcPage = overlay.by_marc_page as Record<string, OverlayEntry>;
+// Secondary index on the Marcianus page id (marc_id === pages.id).
+const byMarcId = new Map<string, OverlayEntry>();
+for (const e of Object.values(byMarcPage)) byMarcId.set(e.marc_id, e);
+
+/**
+ * Stability threshold: dice ≥ 0.55 reads as "Stable". 0.55 sits just under the
+ * empirical p25 (0.571), so it flags the genuine dense-narrative tail without
+ * over-flagging the median folio. See the doc's confidence-layer section.
+ */
+const STABLE_DICE = 0.55;
+
+/** Look up the overlay entry for a Marcianus folio by page id or page number. */
+export function getMarcianusOverlayEntry(opts: {
+  pageId?: string | null;
+  pageNumber?: number | null;
+}): OverlayEntry | null {
+  if (opts.pageId && byMarcId.has(opts.pageId)) return byMarcId.get(opts.pageId)!;
+  if (opts.pageNumber != null && byMarcPage[String(opts.pageNumber)]) {
+    return byMarcPage[String(opts.pageNumber)];
+  }
+  return null;
+}
+
+/** Build the honest per-folio confidence chips (two additive signals). */
+function buildBadges(entry: OverlayEntry): OverlayBadge[] {
+  const badges: OverlayBadge[] = [];
+
+  // (1) Stability — self-agreement of two independent OCR passes.
+  if (entry.self != null) {
+    if (entry.self >= STABLE_DICE) {
+      badges.push({
+        label: 'Stable',
+        className: 'bg-status-success/10 text-status-success',
+        tooltip:
+          "Two independent AI passes agree on most of this folio's word-tokens — one of the more consistent folios in this manuscript. This is a relative stability signal, not a verified-accurate rating; the transcription is still unverified against the facsimile.",
+      });
+    } else {
+      badges.push({
+        label: 'Unstable',
+        className: 'bg-status-warning/10 border border-status-warning/20 text-status-warning',
+        tooltip:
+          "Two independent AI passes disagree on much of this folio's wording — one of the least stable folios in this manuscript, a sign the model may be interpolating (inventing plausible-looking text) rather than reading it. Treat this folio's transcription with extra caution.",
+      });
+    }
+  }
+
+  // (2) Critical-edition availability — a boolean fact (never the coverage number).
+  badges.push({
+    label: 'Critical edition available',
+    className: 'bg-status-info/10 border border-status-info/20 text-status-info',
+    tooltip:
+      "This folio is matched, page for page, to Berthelot & Ruelle's 1887–88 critical edition of the Greek text. Read their transcription as the text of record; our AI transcription is a rough, unverified aid.",
+  });
+
+  return badges;
+}
+
+const PROVENANCE_NOTE =
+  "This manuscript's Greek transcription is AI-assisted and unverified. Where a critical edition is aligned, read that as the text of record — verify any quotation against it or the facsimile before citing the Greek.";
+
+const OCR_FLAG = MANUSCRIPT_OCR_FLAG;
+
+/**
+ * Fetch + assemble the full paired-edition payload for a Marcianus folio.
+ * Returns `{ paired: null }` when the folio has no aligned Berthelot page or the
+ * Berthelot page carries no usable text.
+ */
+export async function getPairedEdition(
+  db: Db,
+  opts: { pageId?: string | null; pageNumber?: number | null },
+): Promise<PairedEditionResponse> {
+  const entry = getMarcianusOverlayEntry(opts);
+  if (!entry) return { paired: null };
+
+  const bertPage = (await db.collection('pages').findOne(
+    { book_id: BERTHELOT_BOOK_ID, page_number: entry.bert_page },
+    { projection: { _id: 0, 'ocr.data': 1, 'translation.data': 1 }, maxTimeMS: 5000 },
+  ).catch(() => null)) as { ocr?: { data?: string }; translation?: { data?: string } } | null;
+
+  // Editorial-wrapper stripping BEFORE the text leaves the server (quote-safety
+  // per CLAUDE.md). NotesRenderer on the client then handles the remaining real
+  // page-marks / <note> apparatus + any markdown.
+  const transcription = stripEditorialWrappers(bertPage?.ocr?.data || '').trim();
+  const translation = stripEditorialWrappers(bertPage?.translation?.data || '').trim();
+  if (!transcription && !translation) return { paired: null };
+
+  return {
+    paired: {
+      folio: entry.folio,
+      bertPage: entry.bert_page,
+      citation: overlay.berthelot_citation,
+      transcription,
+      translation,
+      badges: buildBadges(entry),
+      provenanceNote: PROVENANCE_NOTE,
+      ocrFlag: OCR_FLAG,
+    },
+  };
+}


### PR DESCRIPTION
## What & why

For hard-to-OCR scripts (here, 10th-c. Greek minuscule), the published **critical edition carries the *text***; the **manuscript carries the *facsimile*** and everything only true of the physical object. This surfaces **Berthelot & Ruelle's *Collection des anciens alchimistes grecs*** aligned Greek + English as the *reading text of record* on the **Marcianus gr. Z. 299** reader, joined by a folio concordance — as an **additive layer**. Full rationale: `.claude/docs/edition-facsimile-pairing.md`.

## Core invariant (non-negotiable)

**Nothing overwrites `pages.ocr.data` / `pages.translation.data`.** Berthelot is a read-time join; the manuscript's image extraction (gallery) and OCR annotation layer stay intact. Verified: Marcianus p208 `ocr.data` hash is identical before/after the overlay path runs.

## How it renders

- **Berthelot as reading text** — a bounded, scrollable band above the facsimile/OCR columns shows the aligned Greek + English (via `NotesRenderer`, editorial wrappers stripped server-side for quote-safety).
- **OCR demoted** — the manuscript's own AI OCR/translation panels get a `Rough AI transcription — flagged` badge; the facsimile image is preserved below.
- **Honest confidence** — two additive chips, all existing status tokens (no new primitives): `Stable`/`Unstable` (pass-1-vs-pass-2 self-agreement, threshold 0.55) and `Critical edition available`. The OCR-vs-Berthelot coverage is a noisy lower bound and is **never shown as a number**.
- **Provenance note** — "AI-assisted and unverified… verify any quotation against it or the facsimile before citing the Greek."

## Data layer (regenerable)

- `scripts/analysis/marcianus-berthelot-concordance.mjs` — 195 folios locked page-for-page (M-only refs; anchors f.92v→Bert p13, f.171r→Bert p30).
- `scripts/analysis/marcianus-ocr-confidence.mjs` — self-agreement 0.616, coverage lower-bound, Pearson r≈0.27.
- `scripts/analysis/build-marcianus-overlay.mjs` → `src/data/marcianus-berthelot-overlay.json` (bundled join table).

## New surfaces

- `GET /api/books/[id]/paired-edition` — reader-support route; returns `{paired:null}` for any book other than Marcianus and for unaligned folios; browser UI so no `withApiAuth`; hidden-book gated via `isBookReadable`.
- `src/lib/marcianus-overlay.ts` (server) + `.shared.ts` (client-safe consts/types); `PairedEditionPanel.tsx` (self-fetching, since reader nav is client-side).

## Verification

- `npx tsc --noEmit` clean.
- Folios **93r** (Bert p13/14, contains the "Ion, priest of the sanctuaries" line) and **Chrysopoeia 150r** (Bert p75, contains ἓν τὸ πᾶν) both render the critical text with the facsimile preserved and native OCR flagged (screenshots taken locally).
- Non-destructive hash check passes.

## Out of scope (deliberately deferred, per the spec's plan)

- Definitive re-translation of Berthelot's Greek at full model (step 4).
- Lifting the concordance past 195 folios + a hand diplomatic gold set for calibration (step 5).
- Multi-page-row "primary transcription page" disambiguation beyond the best-coverage heuristic already used.

`TranslationEditor.tsx` changes are additive and gated on `hasPairedEdition` (false for every book except Marcianus), so the rest of the library reader is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)