### PR TITLE
fix(ft): absence votes require recorded search coverage (closes two false-promote leaks)

### DIFF
--- a/src/lib/first-translation/derive-from-evidence.ts
+++ b/src/lib/first-translation/derive-from-evidence.ts
@@ -23,9 +23,18 @@
  *
  *  2. `not_applicable` collapsed into absence → FALSE PROMOTES. An agent judging
  *     a book "not an English-translation candidate" was stored as `result:none`
- *     and counted as an absence vote. It is now detected (result or legacy
- *     "not_applicable: …" notes) and either yields a `not_applicable` verdict
- *     (from an independent agent/human) or is excluded from the absence count.
+ *     and counted as an absence vote. It is now detected (result, legacy
+ *     "not_applicable: …" notes, or the backfill's mid-notes
+ *     "status=not_applicable" / "disposition=not_applicable" form) and either
+ *     yields a `not_applicable` verdict (from an independent agent/human) or is
+ *     excluded from the absence count.
+ *
+ *  3. Undocumented "none" counted as an absence vote → FALSE PROMOTES. Legacy
+ *     rows with `result:none` but NO recorded sources_checked/queries are a
+ *     stored opinion, not a search; counting them let two miscoded legacy rows
+ *     fake cross-family independence and promote English originals (found in
+ *     the 2026-07-02 reconcile dry-run). Absence votes now require recorded
+ *     search coverage.
  *
  * The asymmetry is enforced: a DEMOTE needs a trustworthy positive sighting; a
  * PROMOTE needs clean, independent absence with NO prior hint at all. Anything
@@ -87,8 +96,27 @@ function toCited(p: NonNullable<FirstTranslationAttempt['priors']>[number]): Cit
 }
 
 const NOT_APPLICABLE_RE = /^\s*not[_ ]applicable\b/i;
+// Legacy backfills embed the judgment mid-notes ("[legacy_ai] status=not_applicable; …"),
+// which the anchored form misses — so an "original English work, FT does not apply"
+// row counted as an absence vote and promoted English originals to first_no_prior
+// (the Book of Kells / Religio Medici class in the 2026-07-02 reconcile dry-run).
+const LEGACY_NA_RE = /\b(?:status|disposition|result)=not[_ ]applicable\b/i;
 function isNotApplicable(a: FirstTranslationAttempt): boolean {
-  return a.result === 'not_applicable' || NOT_APPLICABLE_RE.test(a.notes ?? '');
+  return (
+    a.result === 'not_applicable'
+    || NOT_APPLICABLE_RE.test(a.notes ?? '')
+    || LEGACY_NA_RE.test(a.notes ?? '')
+  );
+}
+
+/**
+ * An absence vote is only evidence when the attempt documents what it searched.
+ * A negative claim is exactly as strong as its recorded coverage (the module's
+ * first principle) — a legacy row with no sources and no queries is a stored
+ * opinion, not a search, and must not count toward first_no_prior independence.
+ */
+function hasSearchCoverage(a: FirstTranslationAttempt): boolean {
+  return (a.sources_checked?.length ?? 0) > 0 || (a.queries?.length ?? 0) > 0;
 }
 
 /**
@@ -153,8 +181,11 @@ export function deriveVerdictFromAttempts(
   if (attempts.some((a) => a.result === 'found')) return null;
 
   // 4) Clean absence only. Count independent FAMILIES (not raw methods);
-  //    exclude not_applicable rows — they aren't absence votes.
-  const absences = attempts.filter((a) => a.result === 'none' && !isNotApplicable(a));
+  //    exclude not_applicable rows (not absence votes) and rows with no recorded
+  //    search coverage (an undocumented "none" is not evidence of absence).
+  const absences = attempts.filter(
+    (a) => a.result === 'none' && !isNotApplicable(a) && hasSearchCoverage(a),
+  );
   if (absences.length === 0) return null;
   const families = new Set(absences.map(attemptFamily)).size;
   const strongest = strongestAttempt(absences)!;

--- a/tests/unit/first-translation-derive-from-evidence.test.ts
+++ b/tests/unit/first-translation-derive-from-evidence.test.ts
@@ -11,7 +11,8 @@ const BOOK: FirstTranslationBook = {
 
 const at = (over: Partial<FirstTranslationAttempt>): FirstTranslationAttempt => ({
   attempt_id: 'a', book_id: 'b', date: '2026-06-29T00:00:00Z',
-  method: 'tier1_catalog', match_key: 'author_title', sources_checked: [],
+  method: 'tier1_catalog', match_key: 'author_title',
+  sources_checked: ['search_local_catalogs'],
   result: 'none', evidence_strength: 'moderate', ...over,
 });
 
@@ -106,6 +107,38 @@ describe('deriveVerdictFromAttempts — hardened against the real ledger', () =>
     expect(ft?.evidence_strength).toBe('weak');
     expect(isFirstByVerdict(withVerdict(ft))).toBe(true);
     expect(canPromoteToFirst(withVerdict(ft))).toBe(false);
+  });
+
+  // FAILURE MODE 2b: the legacy backfill's mid-notes NA form must also be caught.
+  it('legacy "[legacy_ai] status=not_applicable; …" row is not an absence vote (Book of Kells case)', () => {
+    const ft = deriveVerdictFromAttempts([
+      // real legacy_tv catalog search that found nothing
+      at({ method: 'gemini_verifier', evidence_strength: 'weak',
+        notes: '[legacy_tv] disposition=translation_found; original English-language scholarly work' }),
+      // legacy_ai judgment: FT does not apply — miscoded as result:none, no search
+      at({ method: 'gemini_verifier', evidence_strength: 'weak', sources_checked: [],
+        notes: '[legacy_ai] status=not_applicable; This book is an original publication in English.' }),
+    ], BOOK);
+    // Only ONE real absence family remains → weak → never promote-qualifying.
+    expect(ft?.verdict).toBe('first_no_prior');
+    expect(ft?.evidence_strength).toBe('weak');
+    expect(canPromoteToFirst(withVerdict(ft))).toBe(false);
+  });
+
+  // FAILURE MODE 3: an absence with no recorded search coverage is not evidence.
+  it('result:none with no sources_checked and no queries → null (no absence evidence)', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'gemini_verifier', sources_checked: [], notes: '[legacy_llm] model belief: none known' }),
+    ], BOOK);
+    expect(ft).toBeNull();
+  });
+
+  it('queries alone count as coverage for an absence vote', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'gemini_verifier', sources_checked: [], queries: ['smith english translation 1650'] }),
+    ], BOOK);
+    expect(ft?.verdict).toBe('first_no_prior');
+    expect(ft?.evidence_strength).toBe('weak');
   });
 
   it('not_applicable rows are excluded from the absence family count', () => {


### PR DESCRIPTION
## Why

Running the #2564 pipeline end-to-end today (derive over the full 47.6k-row attempt ledger, then the reconcile dry-run) surfaced **1,349 "evidence-backed" promote candidates that included English originals and famous existing translations** — Book of Kells facsimile, Browne's *Religio Medici* (1642), R.H. Charles's *Apocrypha and Pseudepigrapha*, G.R.S. Mead. Root-caused to two leaks in `deriveVerdictFromAttempts` (both instances of the failure modes its own doc-comment claims to be hardened against):

1. **Legacy `not_applicable` form missed.** The detector only matched notes *anchored* at `not_applicable…`; the backfill writes `[legacy_ai] status=not_applicable; This book is an original publication in English.` mid-notes. Those rows counted as absence votes.
2. **Undocumented "none" counted as absence.** Rows with `result:none` but empty `sources_checked`/`queries` are a stored opinion, not a search. Two such miscoded legacy rows fake cross-family independence → `first_no_prior` at *moderate* strength → passes `canPromoteToFirst`.

Worked example (Book of Kells, `6953cc0c77f38f6761be0ed8`): `[legacy_tv]` row (family *catalog*) + `[legacy_ai] status=not_applicable` row with zero sources (family *model_knowledge*) = 2 "independent families" of absence → moderate `first_no_prior`, resolver `tier1_catalog` → promote-qualifying.

## Fix

- `isNotApplicable` also matches the backfill's `status=|disposition=|result=not_applicable` mid-notes form.
- Absence votes now require recorded search coverage (`sources_checked` or `queries` non-empty) — a negative claim is exactly as strong as its documented search (the module's first principle).

## Measured effect (prod ledger, dry-run)

| | before | after |
|---|---|---|
| derivable verdicts | 10,531 | 2,314 |
| would-promote (gate-passing) | **1,349** | **36** |
| blocked (weak, held) | 4,271 | 1,552 |
| would-demote | 186 | 186 (unchanged — demotes rest on positive sightings) |

The 2,314 surviving verdicts are unchanged in value vs the pre-fix derivation (`same=2314, changed=0`) — the guards only remove unjustified derivations, they don't alter justified ones.

## Scope

In scope: the two absence-vote guards + regression tests (Book of Kells case, bare-opinion row, queries-only coverage). Out of scope, deliberately: candidate-eligibility gating (some of the surviving 36 are English-edition originals like Southcott pamphlets — that's an eligibility question for the resolve/reconcile layer, and promote application stays sign-off-gated regardless); the ~8.4k orphaned ledger book_ids (data hygiene, separate).

Tests: 50/50 unit tests pass, `npx tsc --noEmit` clean.

Part of #2564 / #2780 / #2805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)