### PR TITLE
feat(ft): three-sink ingest for ft-verify rounds; commit the skill to the repo

### DIFF
--- a/.claude/skills/ft-verify/SKILL.md
+++ b/.claude/skills/ft-verify/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: ft-verify
+description: Stage-2 verification of first-translation flips using INDEPENDENT Claude subagents (subscription, not API key) with full evidence capture. Use to verify proposed badge changes (demotes/promotes) before writing any public claim — the binding step that catches AI-fabricated priors. Each subagent reports its actual search queries + sources, persisted to the first_translation_attempts provenance log.
+---
+
+# FT Verification (Stage 2) — independent Claude subagents
+
+The first-translation pipeline is **two-stage**: a cheap Gemini adjudicator generates candidate
+verdicts (Stage 1), then **this** skill independently verifies the consequential ones (Stage 2)
+before anything touches a public surface. We proved a single pass can't be trusted — ~63% of the
+Gemini adjudicator's "a prior exists" claims were fabricated. So every flip gets re-checked by a
+**different model family** (Claude, not Gemini) to break correlated error.
+
+Why Claude subagents (not the Gemini gate): (1) genuine independence — different training/search,
+so the blind spots don't correlate; (2) far richer, auditable evidence (the subagent reports every
+query + every source + what each showed); (3) runs on the subscription, no API key / no Gemini rate
+limit. Context: issue #2564; `.claude/docs/ft-verification-runbook.md`.
+
+## When to use
+- After a Stage-1 adjudication run (`ft-gemini-adjudicate.mjs`) proposes badge changes.
+- Before applying ANY `is_first_translation` flip or catalog write. Never write a public claim on a
+  single-pass verdict.
+
+## Inputs
+A set of flips, each with: `book_id`, `work` (title), `author`, `lang`, and a **direction**:
+- `demote` — Stage 1 said *a prior exists* → verify the prior is REAL and COMPLETE.
+- `promote` — Stage 1 said *first / no prior* → try to REFUTE by FINDING a prior.
+
+## Process
+1. **Batch** the flips (~6–8 per round) and spawn one `general-purpose` subagent **per book**
+   (model: `sonnet`), in parallel (one message, multiple Agent calls).
+2. Each subagent uses the appropriate prompt below. It MUST do real `WebSearch`/`WebFetch` and
+   return ONLY the JSON contract (no prose).
+3. **Capture the evidence — ALL sinks, one command.** Write the round's results to
+   `scripts/output/ft-evidence-<date>/roundN-results.json` (include a `registry_rows[]` array on
+   every result whose prior was CONFIRMED real — structured translator/year/title/completeness/
+   source_language/source_url), then run:
+   `node scripts/maintenance/ingest-ft-verify-results.mjs <roundN-results.json> --apply`
+   That single command writes **Sink A** (the `first_translation_attempts` ledger row with the
+   verbatim queries + per-source findings) and **Sink C** (every confirmed real translation into
+   the `translation_catalogs` registry, dedup-on-write, with `completeness` set). Sink B (the
+   verdict) stays derived-from-evidence; the public flag stays behind the sign-off reconcile.
+   **A round is not done until this script has run.** Do not hand-roll the writes — three sinks
+   scattered across sessions is exactly how the six-store evidence sprawl happened (#2780).
+4. **Output** survivors vs rejects as a reviewable diff. Do NOT apply badge flips — bring the diff
+   to Derek for sign-off (public bibliographic claims need explicit approval; back up before any write).
+
+### The three sinks (write contract — spec: `.claude/docs/ft-enumeration-three-sink-spec.md`)
+| Sink | Store | Written by |
+|---|---|---|
+| A — evidence | `first_translation_attempts` (append-only) | `ingest-ft-verify-results.mjs` (step 3) |
+| B — verdict | `book.first_translation` | `derive-ft-verdict-from-attempts.ts` (never this skill) |
+| C — registry | `translation_catalogs` (the flywheel of verified positives) | `ingest-ft-verify-results.mjs` (step 3) |
+
+### Survivor rules
+- **demote** survives (the demote is valid) only if `result == confirmed_complete` with a real URL.
+  `confirmed_partial` / `not_found` → the badge was right; KEEP it.
+- **promote** survives (the first stands) if `result == none_found` or `only_partial_exists`.
+  `complete_prior_found` → a prior exists; do NOT promote.
+
+## Subagent prompt — DEMOTE (verify a claimed prior is real)
+> You are verifying a "first English translation" claim for a library audit. Stage 1 says a PRIOR
+> English translation of this work exists — **be skeptical, AI invents plausible translators/years.**
+> WORK: "<work>" by <author> (<lang>). CLAIMED prior: <translator>, <year>.
+> Do REAL web research (WebSearch/WebFetch): WorldCat, archive.org, Google Books, HathiTrust, the
+> publisher, tradition-appropriate catalogues, scholarship. Confirm whether THIS specific translation
+> actually exists, and whether it is COMPLETE or only partial/excerpt. Disambiguate same-named works
+> and authors. Return ONLY JSON:
+> `{"result":"confirmed_complete|confirmed_partial|not_found|uncertain","prior":"<translator,year,title or empty>","evidence_url":"<real url or empty>","queries_run":["every search you ran, verbatim"],"sources_consulted":[{"url":"...","found":"<one line: what it showed>"}],"reasoning":"<2-3 sentences>"}`
+
+## Subagent prompt — PROMOTE (try to refute "it's a first")
+> You are verifying a "first English translation" claim. We are about to claim "<work>" by <author>
+> (<lang>) is a FIRST English translation — NO complete prior exists. **BE SKEPTICAL: try to REFUTE
+> it by FINDING a prior complete English translation.** AI tends to wrongly assume "no prior" — fight
+> that. Do REAL web research (WorldCat, archive.org, Google Books, HathiTrust, publisher,
+> tradition-appropriate sources for <lang>, scholarship). Separate THIS work from related works /
+> other editions; flag if it's a multi-work container/anthology/manuscript-miscellany (the claim is
+> then ill-posed). Return ONLY JSON:
+> `{"result":"complete_prior_found|only_partial_exists|none_found|uncertain","prior":"<translator,year,title or empty>","evidence_url":"<real url or empty>","queries_run":["every search, verbatim"],"sources_consulted":[{"url":"...","found":"<one line>"}],"reasoning":"<2-3 sentences>"}`
+
+## Notes
+- Quality observed (2026-06-21): Claude subagents disambiguated authors (Johann vs Georgius
+  Agricola), corrected authorship (Detharding vs Agricola), and caught container/miscellany cases
+  the Gemini gate missed — at 45–72 tool calls each.
+- For famous-adjacent works where BOTH a Gemini and a Claude pass may share a blind spot (e.g. an old
+  scholarly edition like Allberry's 1938 Manichaean Psalm-Book), route to a human specialist — that's
+  the only layer that removes correlated error.
+- The Gemini equivalent (`scripts/eval/ft-verify-gate.mjs`) is the cheap/scalable fallback when the
+  flip volume is large; prefer Claude subagents for the high-stakes, smaller sets.

--- a/scripts/maintenance/ingest-ft-verify-results.mjs
+++ b/scripts/maintenance/ingest-ft-verify-results.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * ingest-ft-verify-results.mjs — persist an ft-verify round into ALL its sinks
+ * in one command, so no session can "complete" a round with a sink dropped.
+ *
+ * The ft-verify skill (Stage-2 Claude-subagent verification) produces a
+ * round-results JSON. The write contract for FT evidence is THREE sinks
+ * (.claude/docs/ft-enumeration-three-sink-spec.md); this script owns two of
+ * them and the third is deliberately excluded:
+ *
+ *   Sink A  first_translation_attempts (Mongo)  — append-only evidence rows,
+ *           method claude_subagent_verify, idempotent attempt_id.
+ *   Sink C  translation_catalogs (Mongo)        — every CONFIRMED real prior
+ *           becomes a registry row (dedup-on-write), with completeness,
+ *           source_language and source_url set. The flywheel: verified
+ *           positives make the next check a free membership test.
+ *   Sink B  book.first_translation (verdict)    — NOT written here. Verdicts
+ *           stay derived-from-evidence (derive-ft-verdict-from-attempts.ts),
+ *           and the public flag stays behind the sign-off-gated reconcile.
+ *
+ * Input file: JSON array; per entry:
+ *   book_id, work, author, direction (demote|promote), result
+ *   (confirmed_complete|confirmed_partial|not_found|uncertain|none_found|
+ *   only_partial_exists|complete_prior_found), survivor (bool), bucket,
+ *   prior (string), evidence_url, queries_run[], sources_consulted[{url,found}],
+ *   reasoning, registry_rows?[{author, english_title, translator, pub_year,
+ *   publisher?, original_title?, source_language?, completeness, source_url?, notes?}]
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/ingest-ft-verify-results.mjs <round-results.json>          # dry-run
+ *   node scripts/maintenance/ingest-ft-verify-results.mjs <round-results.json> --apply
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+
+const file = process.argv.slice(2).find((a) => a.endsWith('.json'));
+const APPLY = process.argv.includes('--apply');
+if (!file || !fs.existsSync(file)) {
+  console.error('usage: ingest-ft-verify-results.mjs <round-results.json> [--apply]');
+  process.exit(1);
+}
+const rows = JSON.parse(fs.readFileSync(file, 'utf8'));
+if (!Array.isArray(rows) || rows.length === 0) {
+  console.error('input must be a non-empty JSON array');
+  process.exit(1);
+}
+const runDate = new Date().toISOString().slice(0, 10);
+
+const c = new MongoClient(process.env.MONGODB_URI);
+await c.connect();
+const db = c.db('bookstore');
+const attempts = db.collection('first_translation_attempts');
+const registry = db.collection('translation_catalogs');
+
+const FOUND = new Set(['confirmed_complete', 'confirmed_partial', 'complete_prior_found', 'only_partial_exists']);
+let aIns = 0, aSkip = 0, cIns = 0, cSkip = 0, badRows = 0;
+
+for (const r of rows) {
+  if (!r.book_id || !r.result || !Array.isArray(r.queries_run)) { badRows++; continue; }
+
+  // ---- Sink A: evidence ledger (idempotent) ----
+  const attempt_id = `${r.book_id}:claude_subagent_verify:${runDate}`;
+  const exists = await attempts.findOne({ attempt_id });
+  if (exists) aSkip++;
+  else {
+    if (APPLY) {
+      await attempts.insertOne({
+        attempt_id,
+        book_id: r.book_id,
+        date: new Date().toISOString(),
+        method: 'claude_subagent_verify',
+        model: 'claude-sonnet',
+        match_key: 'author_title',
+        queries: r.queries_run,
+        sources_checked: (r.sources_consulted ?? []).map((s) => s.url),
+        sources_detail: r.sources_consulted ?? [],
+        result: FOUND.has(r.result) ? 'found' : 'none',
+        verdict: r.result,
+        priors: r.prior
+          ? [{
+              english_title: r.prior,
+              completeness: r.result === 'confirmed_complete' || r.result === 'complete_prior_found'
+                ? 'complete'
+                : r.result === 'confirmed_partial' || r.result === 'only_partial_exists'
+                  ? 'partial'
+                  : 'unknown',
+              source_url: r.evidence_url || undefined,
+            }]
+          : [],
+        evidence_strength: 'strong',
+        independence_score: 1,
+        notes: `[ft-verify-${runDate} ${r.direction ?? 'demote'}-check bucket=${r.bucket ?? 'unbucketed'}] ${r.reasoning ?? ''}`,
+        _src: 'claude-subagent-gate',
+      });
+    }
+    aIns++;
+  }
+
+  // ---- Sink C: registry harvest (dedup-on-write) ----
+  for (const t of r.registry_rows ?? []) {
+    if (!t.english_title || !t.pub_year) { badRows++; continue; }
+    const dupQuery = { english_title: t.english_title, pub_year: String(t.pub_year) };
+    if (t.translator) dupQuery.translator = t.translator;
+    const dup = await registry.findOne(dupQuery);
+    if (dup) { cSkip++; continue; }
+    if (APPLY) {
+      await registry.insertOne({
+        ...t,
+        pub_year: String(t.pub_year),
+        author_normalized: (t.author ?? '').toLowerCase(),
+        source: 'claude_subagent_verify',
+        source_language_provenance: `ft-verify-${runDate}`,
+        imported_at: new Date(),
+      });
+    }
+    cIns++;
+  }
+}
+
+console.log(`${APPLY ? 'APPLIED' : 'DRY-RUN'} — ${rows.length} results from ${file}`);
+console.log(`  Sink A (attempts ledger): +${aIns} inserted, ${aSkip} already present`);
+console.log(`  Sink C (translation_catalogs): +${cIns} inserted, ${cSkip} deduped`);
+if (badRows) console.log(`  WARNING: ${badRows} malformed rows/registry entries skipped`);
+console.log('  Sink B (verdict) deliberately untouched — run derive-ft-verdict-from-attempts.ts; the public flag stays behind the reconcile.');
+await c.close();


### PR DESCRIPTION
Structural fix for the recurring 'intended to log it, didn't' failure (Derek, 2026-07-02; same class as the six-store evidence sprawl in #2780).

**Root cause:** the ft-verify skill's capture step encoded Sink A (evidence ledger) + disk but not Sink C (`translation_catalogs` registry harvest) — the three-sink contract lived in a different doc. And the skill was untracked, so only one machine ever saw it.

**Fix:**
- `scripts/maintenance/ingest-ft-verify-results.mjs` — one command persists a verification round to ALL its sinks: attempts ledger (idempotent `attempt_id`) + registry (dedup-on-write, `completeness`/`source_language`/`source_url` set). Sink B (verdict) deliberately excluded: verdicts stay derived-from-evidence, the public flag stays behind the sign-off reconcile.
- ft-verify SKILL.md updated (three-sink table, 'a round is not done until the script has run') and committed to the repo.

First real use: today's round 2 (8 evidence rows). Part of #2933 (execution checklist) / #2804 (Sink C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)