### PR TITLE
fix(data): /data 500 — tolerate collections without book_count (#1582)

### DIFF
--- a/scripts/workers/enrichment-snapshot.mjs
+++ b/scripts/workers/enrichment-snapshot.mjs
@@ -313,7 +313,9 @@ async function computeDataPageSnapshot(db) {
     centuries: centuriesAgg.map(c => ({ century: c._id, label: formatCentury(c._id), count: c.count })),
     categories: categoriesAgg.map(c => ({ slug: c._id, name: c._id.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '), count: c.count })),
     providers: providersAgg.filter(p => p._id).map(p => ({ name: p._id, count: p.count })),
-    collections: collectionsAgg,
+    // Coerce book_count: a collection created without the field would otherwise
+    // put `undefined` in the snapshot and 500 the /data render.
+    collections: collectionsAgg.map(c => ({ slug: c.slug, name: c.name, book_count: c.book_count ?? 0 })),
   };
 
   await db.collection('system_config').updateOne(

--- a/src/app/api/admin/data-snapshot/route.ts
+++ b/src/app/api/admin/data-snapshot/route.ts
@@ -247,7 +247,11 @@ async function computeDataPageSnapshot(db: any): Promise<LibraryData> {
     providers: providersAgg
       .filter((p: any) => p._id)
       .map((p: any) => ({ name: p._id, count: p.count })),
-    collections: collectionsAgg as Array<{ slug: string; name: string; book_count: number }>,
+    // Coerce book_count: a collection created without the field would otherwise
+    // put `undefined` in the snapshot and 500 the /data render.
+    collections: (collectionsAgg as Array<{ slug: string; name: string; book_count?: number }>).map(
+      (c) => ({ slug: c.slug, name: c.name, book_count: c.book_count ?? 0 }),
+    ),
   };
 }
 

--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -453,7 +453,7 @@ export default async function DataPage({
             >
               <span className="text-secondary font-medium">{c.name}</span>
               <span className="text-sm text-muted tabular-nums shrink-0">
-                {formatNumber(c.book_count)} books
+                {formatNumber(c.book_count ?? 0)} books
               </span>
             </Link>
           ))}


### PR DESCRIPTION
## What

`/data` has returned HTTP 500 in production since ~2026-06-02. Root cause: the **East Asian History of Health** collection was created without a `book_count` field; the next `data_page_snapshot` rebuild copied `undefined` into the snapshot, and `formatNumber(c.book_count)` threw `Cannot read properties of undefined (reading 'toLocaleString')` at `src/app/data/page.tsx:456` on every render. Reproduced locally with the exact stack trace.

This was flagged daily by the e2e crawl spec but buried in the #1582 noise — no other monitoring caught it.

## Changes

- `src/app/data/page.tsx`: `formatNumber(c.book_count ?? 0)` — one bad snapshot row can no longer 500 the page
- `src/app/api/admin/data-snapshot/route.ts` + `scripts/workers/enrichment-snapshot.mjs` (the two snapshot writers): coerce `book_count ?? 0` at build time so the snapshot is always well-formed

## Data repair (already applied in prod)

- `collections` doc for `east-asian-history-of-health` set to its real count (344 tagged books)
- the live snapshot's bad row patched in place

**Verified: /data now returns 200 on sourcelibrary.org, the Vercel preview alias, and local dev.** The code changes are belt-and-suspenders so this class of bug can't recur when the next collection is created without the field.

## Out of scope

- The stale e2e specs themselves — parallel PR for #1582
- Why new collections can be created without `book_count` (writer-side invariant; worth a follow-up if it recurs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)