### PR TITLE
chore(ops): re-snapshot crontab.production — restore supabase-sync + capture out-of-band jobs (#2335)

### DIFF
--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -17,7 +17,6 @@
 0 8 * * * /usr/local/bin/oura-digest >> /var/log/oura-digest.log 2>&1
 15 1,3,5,7,9,11,13,15,17,19,21,23 * * * cd /root/sourcelibrary && flock -n /tmp/sl-enrichment-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/enrichment-snapshot.mjs" >> /var/log/sourcelibrary/enrichment-snapshot.log 2>&1
 15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-prewarm.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/prewarm-browse.mjs" >> /var/log/sourcelibrary/prewarm-browse.log 2>&1
-45 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-metrics-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analytics/snapshot-metrics.mjs" >> /var/log/sourcelibrary/metrics-snapshot.log 2>&1
 */2 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-scheduler.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/scheduler.mjs" >> /var/log/sourcelibrary/scheduler.log 2>&1
 30 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-entity-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-entities.mjs" >> /var/log/sourcelibrary/entity-sync.log 2>&1
 #PAUSED-GEMINI 30 */4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-embed-gemini.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=\$GEMINI_API_KEY_TIER3 && node scripts/workers/embed-gemini.mjs --incremental" >> /var/log/sourcelibrary/embed-gemini.log 2>&1
@@ -100,3 +99,19 @@
 30 6 * * 0 cd /root/sourcelibrary && flock -n /tmp/sl-lang-audit.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/audit-language-mismatch.mjs --flag" >> /var/log/sourcelibrary/lang-audit.log 2>&1
 0 4 * * * /root/sourcelibrary/scripts/workers/backup-bph-catalog.sh
 30 2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-work-id-mint.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analysis/mint-local-work-ids.mjs --apply --include-anon --include-parts --include-hidden && node scripts/analysis/assign-work-slugs.mjs --apply" >> /var/log/sourcelibrary/work-id-mint.log 2>&1
+# Refresh book locations[] (publication/author/tradition) before the map-cache rebuild at 05:45
+15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-geocode.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/geocode-publication-places.mjs && node scripts/enrichment/backfill-author-locations.mjs --write-books && node scripts/enrichment/geocode-origin-by-tradition.mjs" >> /var/log/sourcelibrary/geocode-locations.log 2>&1
+# Thesaurus-grounded author locations (canonical authors path); file-guarded until PR #2783 merges + box pulls
+30 5 * * * cd /root/sourcelibrary && [ -f scripts/enrichment/backfill-thesaurus-author-locations.mjs ] && flock -n /tmp/sl-thesaurus-loc.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/backfill-thesaurus-author-locations.mjs --write-books" >> /var/log/sourcelibrary/geocode-locations.log 2>&1
+0 9 * * * cd /root/sourcelibrary && flock -n /tmp/sl-newsletter-refresh.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/refresh-newsletter-audience.mjs" >> /var/log/sourcelibrary/newsletter-refresh.log 2>&1
+45 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-metrics-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analytics/snapshot-metrics.mjs" >> /var/log/sourcelibrary/metrics-snapshot.log 2>&1
+# On-mission acquisition: daily bounded batch (USTC gap -> IA/e-rara -> verify -> import hidden)
+# e-rara IIIF catalog refresh: weekly
+0 2 * * 0 cd /root/sourcelibrary && flock -n /tmp/sl-erara.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/harvest-erara-catalog.mjs" >> /var/log/sourcelibrary/erara-harvest.log 2>&1
+# On-mission acquisition: hourly bounded concurrent batch
+30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-acquire.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/acquire-gap-batch.mjs --batch 400 --concurrency 12" >> /var/log/sourcelibrary/acquire.log 2>&1
+# Archive newly-acquired gap books to R2 (companion to acquisition)
+45 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-arch-acq.lock bash -c "set -a; source .env.production.local; set +a; npx tsx scripts/catalog-coverage/archive-acquired.ts --batch 120 --concurrency 6" >> /var/log/sourcelibrary/archive-acquired.log 2>&1
+# catchup-watchdog: keep the acquisition catch-up alive while pending work remains
+*/20 * * * * tmux has-session -t catchup 2>/dev/null || ( cd /root/sourcelibrary && P=$(bash -c "set -a; source .env.production.local; set +a; node -e \"const {MongoClient}=require(process.cwd()+\x27/node_modules/mongodb\x27);(async()=>{const c=new MongoClient(process.env.MONGODB_URI);await c.connect();console.log(await c.db(\x27bookstore\x27).collection(\x27acquisition_queue\x27).countDocuments({status:\x27pending\x27}));await c.close();})()\"" 2>/dev/null); [ "$P" -gt 500 ] 2>/dev/null && tmux new-session -d -s catchup "/tmp/acquire_catchup.sh" )
+30 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-supabase-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/supabase-sync.mjs" >> /var/log/sourcelibrary/supabase-sync.log 2>&1


### PR DESCRIPTION
## What

Brings `scripts/workers/crontab.production` back in sync with the live Hetzner crontab.

## Why

The **supabase-sync.mjs cron line was dropped from the live crontab ~2026-04-13** (evidence: last clean log entry 14:30 UTC that day, all six mirrored Supabase tables frozen at ~19:00 UTC, line absent from `crontab -l` today). Probable cause: a hand-edit during the Apr 10–13 pages-migration session. Result: `pipeline_snapshots`/`cron_runs` mirrors went stale and the **admin Pipeline tab has shown nothing since ~May 13** (its widest query window is 30 days).

**Why no alarm fired for 2.7 months:** the line was never in this tracked baseline (it was installed out-of-band on 2026-04-10), so the daily `sync-crontab.sh` drift check couldn't see it — both the baseline and the live crontab agreed it was missing. And the drift check only writes to `/var/log/sourcelibrary/crontab-sync.log`, which nobody reads (it HAS been flagging the other drift below since at least today's 04:00 run).

## Ops actions already taken (on the box, 2026-07-02)

- Re-added the supabase-sync cron line (`30 */2 * * *`)
- Kicked off a manual catch-up run (2.7 months of `pipeline_snapshots`/`cron_runs` backlog; streaming cursor + batched inserts, verified running)

## Also captured in this snapshot

7 other jobs added to the live crontab out-of-band since the last snapshot: geocode-locations (2 entries), newsletter-refresh, e-rara catalog harvest, acquisition gap-batch + archive-acquired, catchup-watchdog. These were all invisible to drift detection until now.

## Follow-ups (left on #2335)

- Decide whether to trim the vestigial sync legs (`analytics_pageviews`/`analytics_events`/`loading_metrics`/`pages_images` have zero live consumers since #2334)
- Wire `pipeline_snapshots`/`cron_runs` lag into the admin Supabase health check so a repeat stall actually surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)