### PR TITLE
fix(e2e): update specs to current app contracts (catalog grid default, search-on-submit, anon-gate Librarian, dead routes) (#1582)

### DIFF
--- a/e2e/catalog.spec.ts
+++ b/e2e/catalog.spec.ts
@@ -30,7 +30,8 @@ test.describe('Catalog', () => {
     await page.goto('/catalog');
     await expect(page.locator('#main-content').getByText(/\d[\d,]+ books/).first()).toBeVisible({ timeout: 15_000 });
 
-    // Default is list view — should have table rows
+    // Default is grid view — explicitly toggle to list view to check the table.
+    await page.getByLabel('List view').click();
     const rows = page.locator('table tbody tr');
     await expect(rows.first()).toBeVisible({ timeout: 5_000 });
     expect(await rows.count()).toBeGreaterThan(10);
@@ -40,7 +41,9 @@ test.describe('Catalog', () => {
     await page.goto('/catalog');
     await expect(page.locator('#main-content').getByText(/\d[\d,]+ books/).first()).toBeVisible({ timeout: 15_000 });
 
+    // Search runs on submit (Enter / Search button), not live-as-you-type.
     await page.fill('input[placeholder*="Search"]', 'Agrippa');
+    await page.keyboard.press('Enter');
     // Should show filtered count ("N of M books")
     await expect(page.locator('text=/\\d+ of \\d[\\d,]+ books/')).toBeVisible({ timeout: 5_000 });
   });
@@ -67,8 +70,9 @@ test.describe('Catalog', () => {
     const start = Date.now();
     await page.goto('/catalog');
     await expect(page.locator('#main-content').getByText(/\d[\d,]+ books/).first()).toBeVisible({ timeout: 15_000 });
-    const rows = page.locator('table tbody tr');
-    await expect(rows.first()).toBeVisible({ timeout: 5_000 });
+    // Default view is grid — assert on book cards rather than the (list-only) table.
+    const cards = page.locator('a[href^="/book/"]');
+    await expect(cards.first()).toBeVisible({ timeout: 5_000 });
     const tti = Date.now() - start;
 
     console.log(`Catalog TTI: ${tti}ms`);

--- a/e2e/crawl-all-pages.spec.ts
+++ b/e2e/crawl-all-pages.spec.ts
@@ -99,7 +99,6 @@ const STATIC_PAGES = [
   '/ficino-society',
   '/ficino-society/discussions',
   '/ficino-society/members',
-  '/founding-donors',
   '/gallery',
   '/gallery/collections',
   '/gallery/curate',
@@ -208,14 +207,13 @@ const ERROR_PATTERNS = [
 // URL patterns that are KNOWN to be broken in production but not yet fixed.
 // The crawl reports them but does not fail the test. Remove an entry once its
 // bug is fixed — that converts the test into a regression guard automatically.
-const EXPECTED_BROKEN_PATTERNS: RegExp[] = [
-  // #2083: /browse/{authors,artists,titles,years}/* all return 500. Real
-  // production bug, not a test issue. The handler's try/catch swallows the
-  // Supabase error but the 500 originates outside it (header read or
-  // render-time).
-  /^\/browse\/(authors|artists|titles)\/[A-Z]$/,
-  /^\/browse\/years\/(ancient|medieval|\d{4}s)$/,
-];
+//
+// #2083 (/browse/{authors,artists,titles}/[A-Z] and /browse/years/*) is fixed
+// and verified (all return 200) — entries removed 2026-07-02. Nothing to
+// suppress right now; /data is a known-broken page tracked separately (fix in
+// flight in a parallel PR) and is deliberately NOT allowlisted here so it
+// still fails this test until it's actually fixed.
+const EXPECTED_BROKEN_PATTERNS: RegExp[] = [];
 
 function isExpectedBroken(path: string): boolean {
   return EXPECTED_BROKEN_PATTERNS.some(re => re.test(path));

--- a/e2e/embassy.spec.ts
+++ b/e2e/embassy.spec.ts
@@ -48,9 +48,14 @@ test.describe('Librarian', () => {
     }
   });
 
-  test('shows sign-in prompt when not authenticated', async ({ page }) => {
-    await expect(page.locator('textarea')).toBeDisabled();
-    await expect(page.locator('textarea')).toHaveAttribute('placeholder', /Sign in/);
+  test('anonymous visitors can use the Librarian input', async ({ page }) => {
+    // Anonymous access was deliberately opened up (5 free actions/hour via
+    // src/lib/anon-gate.ts) — the textarea is enabled for everyone, with a
+    // soft "sign in to save your conversations" note below the input rather
+    // than a hard disabled-input gate.
+    await expect(page.locator('textarea')).toBeEnabled();
+    await expect(page.locator('textarea')).toHaveAttribute('placeholder', 'Ask the Librarian...');
+    await expect(page.getByText('to save your conversations and keep them private')).toBeVisible();
   });
 
   test('shows Recent tab', async ({ page }) => {
@@ -97,11 +102,23 @@ test.describe('Librarian - API Routes', () => {
     expect(data.rooms[0]).toHaveProperty('name');
   });
 
-  test('POST /api/embassy/chat requires auth', async ({ request }) => {
+  test('POST /api/embassy/chat allows a first anonymous request', async ({ request }) => {
+    // Commit 4516ebc7 deliberately opened anonymous Librarian access — the
+    // old "auth required" contract is gone. Anonymous visitors get 5 free
+    // actions/hour (src/app/api/embassy/chat/route.ts, checkRateLimit). We
+    // only assert the happy path here to avoid burning 5 real LLM calls to
+    // prove the 429-after-quota path; that path is untested by this suite.
     const res = await request.post('/api/embassy/chat', {
-      data: { message: 'Hello' },
+      data: { message: 'What is the Emerald Tablet?' },
     });
-    expect([401, 429]).toContain(res.status());
+    // 429 is still acceptable if a prior test/run in this window already
+    // used up the shared IP's quota.
+    expect([200, 429]).toContain(res.status());
+    if (res.status() === 200) {
+      const data = await res.json();
+      expect(data).toHaveProperty('threadId');
+      expect(data).toHaveProperty('message');
+    }
   });
 
   test('GET /api/embassy/rooms/general/messages returns messages', async ({ request }) => {


### PR DESCRIPTION
## Summary

Fixes the four stale e2e failures pinned in #1582. Each is a spec-vs-app
drift, not an app regression — the app already works as intended, the
tests just asserted an outdated contract.

- **`e2e/catalog.spec.ts:29` "list view renders book rows" + `:66` "time to
  interactive under 8s"** — `CatalogBrowser`'s default `viewMode` flipped
  `'list' -> 'grid'` in ee6c631a (2026-06-28), so there's no `<table>` on
  the default view anymore. "list view renders book rows" now clicks the
  list-view toggle (`getByLabel('List view')`) before asserting the
  table — list view is still a real, reachable UI state. The TTI test now
  asserts against grid book cards (`a[href^="/book/"]`) since grid is the
  actual default.
- **`e2e/catalog.spec.ts:39` "search filters results"** — catalog search
  moved from live-as-you-type to submit-on-Enter/button in d0952ddd
  (2026-06-30). The test now presses Enter after filling the search input
  before asserting the filtered count.
- **`e2e/embassy.spec.ts:51` "shows sign-in prompt when not authenticated"
  + `:100` "POST /api/embassy/chat requires auth"** — commit 4516ebc7
  (2026-06-03) deliberately opened anonymous Librarian access (5 free
  actions/hour via `src/lib/anon-gate.ts`); the old "auth required"
  contract no longer exists. Rewritten to assert the current contract:
  the textarea is enabled with placeholder `"Ask the Librarian..."` and a
  soft "sign in to save your conversations" note underneath; a first
  anonymous `POST /api/embassy/chat` returns 200 with `threadId` +
  `message`. The 429-after-quota path is deliberately left untested here
  to avoid burning 5 real LLM calls per CI run — noted in a code comment.
- **`e2e/crawl-all-pages.spec.ts`** — removed `/founding-donors` from
  `STATIC_PAGES` (route deliberately deleted in 10cf7e0f); cleared the
  stale `EXPECTED_BROKEN_PATTERNS` entries for `/browse/{authors,titles,years}`
  (#2083 — verified fixed, all return 200 in prod as of 2026-07-02, per
  the block's own "remove once fixed" comment).

## `/data` note

Per the task brief, `/data` stays in `STATIC_PAGES` and is **not**
allowlisted — a parallel PR is fixing a 500 there (missing `book_count`
in a snapshot row). A live check while writing this PR shows `/data`
already returning 200 in prod, so it's possible that fix has landed or
the issue was transient; either way this PR makes no change to the
`/data` handling and the crawl will correctly re-flag it if it
regresses.

## Test plan

Ran against the prod preview (`BASE_URL=https://sourcelibrary-v2.vercel.app`):

- [x] `npx playwright test e2e/catalog.spec.ts e2e/embassy.spec.ts --project=chromium` — **18/18 passed**
- [x] `npx playwright test e2e/crawl-all-pages.spec.ts --project=chromium` — **passed clean**: 155/155 static crawl, 340/340 link-follower (including `/data`)
- [x] `npx tsc --noEmit` — clean

## Out of scope

- bph-iframe specs — currently passing, untouched.
- The `/data` 500 itself — that's the parallel PR's job; this PR only
  keeps the crawl test honest about it.
- Adding real coverage for the Librarian's 429-after-quota path (would
  require 5 real LLM calls per CI run to prove — not worth the cost for
  this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)