### PR TITLE
chore: gitignore the underscore _tmp_ scratch convention + agent-comms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,9 +76,14 @@ check-books.js
 tmp/
 tmp_*
 _tmp-*
+_tmp_*
 scripts/_tmp-*
+scripts/_tmp_*
 scripts/output/
 /check-*.mjs
+
+# Session coordination scratch (its own README says: never commit)
+.claude/agent-comms/
 
 # Experimental tools
 tools/


### PR DESCRIPTION
One-line-class fix from the 2026-07-02 hygiene audit.

The `.gitignore` temp rules covered `scripts/_tmp-*` (hyphen) but the actual convention in use is `scripts/_tmp_*` (underscore) — all ~297 current scratch files were unprotected, one `git add -A` away from permanent public-repo commitment (several likely contain user-email lists). Verified with `git check-ignore`: underscore files now ignored, and zero tracked files match the new patterns so nothing drops out of tracking.

Also adds `.claude/agent-comms/` (the session-coordination mailbox whose own README says never commit it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)