### PR TITLE
docs: fix stale model names, concurrency, and public stats

### DIFF
--- a/.claude/docs/system-map.md
+++ b/.claude/docs/system-map.md
@@ -1,6 +1,6 @@
 # Source Library System Map
 
-> Last audited: 2026-04-24. Use this as the primary navigation reference.
+> Last audited: 2026-04-24; spot-refreshed 2026-07-03 (model names, concurrency, file counts). Use this as the primary navigation reference.
 
 ## Architecture Overview
 
@@ -37,7 +37,7 @@ Users ──> Vercel (Next.js 16) ──> MongoDB Atlas (bookstore)
 | **AWS SQS** (eu-central-1) | Job queues (FIFO) | 4 queues: OCR, translation, images, write |
 | **Cloudflare R2** | Image/page storage | `images.sourcelibrary.org` |
 | **Hetzner** (cax31) | Pipeline orchestration, translation, embeddings | `root@46.224.122.120`, unified scheduler |
-| **Gemini AI** | OCR, translation, enrichment | 3 unique keys (3 GCP projects). BPH: `gemini-3-flash-preview`, others: `gemini-3.1-flash-lite-preview` |
+| **Gemini AI** | OCR, translation, enrichment | 3 unique keys (3 GCP projects). BPH: `gemini-3-flash-preview`, others: `gemini-3.1-flash-lite` |
 | **Stripe** | Payments | Ficino Society membership |
 | **Zenodo** | DOI publishing | Scholarly editions |
 | **Twitter/X** | Social automation | 3h posting cron |
@@ -58,7 +58,7 @@ Import (IA/Gallica/IIIF/Wellcome/etc.)
        └─> Phase 3.5: Metadata enrichment (catalog lookups, no Gemini) ──> metadata_enriched
        └─> Phase 3.7: Transliteration (non-Latin scripts, 3.1-flash-lite)
        └─> Phase 4: Translation dispatch (creates job for translate-worker)
-            │  translate-worker.mjs (15 concurrent books) ──> Gemini realtime ──> MongoDB pages
+            │  translate-worker.mjs (40 concurrent books) ──> Gemini realtime ──> MongoDB pages
             │  ⚠ Realtime API only. NEVER use Batch API for translation.
             └─> Phase 5: Translation completion ──> translate_complete
 
@@ -219,7 +219,7 @@ src/
 │   ├── tablets/            # Cuneiform tablets page
 │   ├── rithmomachia/       # Mathematical board game (guide, scenarios)
 │   ├── admin/              # Admin dashboard pages
-│   ├── blog/               # 39 blog posts (hardcoded JSX, no CMS)
+│   ├── blog/               # 58 blog posts (hardcoded JSX, no CMS)
 │   ├── press-release/      # Press release page
 │   ├── research/           # Research tools (atlas, diffusion, timeline)
 │   ├── explore/            # Map & timeline visualizations
@@ -227,9 +227,9 @@ src/
 │   ├── catalog/, census/, encyclopedia/  # Reference browse pages
 │   ├── languages/, timeline/, topics/    # Content browse pages
 │   ├── about/, support/, terms/, privacy/  # Static info pages
-│   └── ...                 # 68 top-level app directories
+│   └── ...                 # 87 top-level app directories
 │
-├── components/             # 174 React components (.tsx files)
+├── components/             # 250 React components (.tsx files)
 │   ├── book/               # Book detail, reader, processing
 │   ├── layout/             # GlobalHeader, GlobalFooter, FeaturedCollections
 │   ├── gallery/            # Gallery views (+ IconclassFilter)
@@ -241,7 +241,7 @@ src/
 │   ├── rithmomachia/       # Game components (14, live feature)
 │   └── ...
 │
-├── lib/                    # ~95 top-level modules + 10 subdirectories
+├── lib/                    # ~166 top-level modules + subdirectories
 │   ├── mongodb.ts          # DB connection (singleton, pool management)
 │   ├── supabase.ts         # Supabase client (analytics, browse, search)
 │   ├── ai.ts               # Core Gemini operations
@@ -290,7 +290,7 @@ scripts/                    # Operational scripts
 │   ├── scheduler.mjs       # Unified cron scheduler
 │   ├── pipeline-orchestrator.mjs  # Main pipeline (every 2 min)
 │   ├── enrich-worker.mjs   # Enrichment phases (every 5 min)
-│   ├── translate-worker.mjs # Realtime translation (15 concurrent)
+│   ├── translate-worker.mjs # Realtime translation (40 concurrent)
 │   ├── batch-collector.mjs  # Gemini Batch API results (every 10 min)
 │   ├── embed-gemini.mjs     # Embedding generation
 │   ├── clip-server.mjs      # CLIP visual search server
@@ -299,7 +299,7 @@ scripts/                    # Operational scripts
 └── lib/                    # Shared script utilities
 ```
 
-## Pages Breakdown (68 top-level dirs)
+## Pages Breakdown (87 top-level dirs)
 
 | Category | Count | Content Source | Examples |
 |----------|-------|---------------|----------|
@@ -331,7 +331,7 @@ scripts/                    # Operational scripts
 6. **Key rotation for Gemini** — 3 API keys (3 GCP projects) with cooldown. `gemini-client.ts` handles rotation.
 7. **Hetzner for heavy crons** — Pipeline orchestration moved off Vercel to reduce costs/timeouts. Unified scheduler manages all workers.
 8. **Supabase for read-heavy paths** — Browse, analytics, search, and libraries queries hit Supabase for speed. MongoDB remains source of truth; Supabase mirrors derived data via sync crons.
-9. **Model routing by source** — BPH books get `gemini-3-flash-preview` (premium), all others get `gemini-3.1-flash-lite-preview` (50% cheaper). See `src/lib/types/ai-models.ts`.
+9. **Model routing by source** — BPH books get `gemini-3-flash-preview` (premium), all others get `gemini-3.1-flash-lite` (50% cheaper). See `src/lib/types/ai-models.ts`.
 10. **Two quality systems on image extraction** — One Gemini call emits both `gallery_quality` (per illustration, curatorial: "worth showing?") and `scan_quality` (per page, technical: "how cleanly digitized?"). They look similar but answer different questions. Design + extension plan in `.claude/docs/automated-image-quality-system.md`. Public-facing version: `/blog/what-makes-a-good-scan`. The live prompt + rubric live in `scripts/workers/image-extract-worker.mjs:117` and `scripts/workers/pipeline-orchestrator.mjs:1836`; `prompts/image-extraction/image-extraction-v0.md` is an out-of-date archive.
 
 ## Known Dead Code & Duplicates

--- a/README.md
+++ b/README.md
@@ -568,11 +568,13 @@ See [CLAUDE.md Security](./CLAUDE.md#security---critical) for detailed security 
 
 ## 📊 Current Status
 
+_As of July 2026 — these move weekly; live numbers at [sourcelibrary.org/data](https://sourcelibrary.org/data)._
+
 **📈 Active Corpus:**
 - 📚 ~29K books with `visible: true`
 - ✅ ~15K fully processed (OCR'd and translated)
 - 🌍 ~14K with full English translations
-- 🖼️ ~5K gallery images curated
+- 🖼️ 200K+ catalogued illustrations in the [gallery](https://sourcelibrary.org/gallery)
 
 **⚙️ Processing Capacity:**
 - 📥 15K+ pages/month ingestion

--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -8,7 +8,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 |-----------|-------|-----|
 | Pipeline orchestrator | **Hetzner** (`pipeline-orchestrator.mjs`) | All phases, every 2 min |
 | Full-book OCR | **Hetzner → Gemini Batch API** | Direct submission, 50% cost discount |
-| Translation | **Hetzner** (`translate-worker.mjs`) | Direct Gemini calls, 20 concurrent books |
+| Translation | **Hetzner** (`translate-worker.mjs`) | Direct Gemini calls, 40 concurrent books |
 | Batch result collection | **Hetzner** (`batch-collector.mjs`) | Polls Gemini API every 10 min |
 | Archiving | **Hetzner** (`archive-ocr.mjs`, `archive-bulk.mjs`) | Downloads → Cloudflare R2 |
 | Preview OCR (25 pages) | **Lambda** via SQS | Fast preview path, still active |
@@ -27,10 +27,10 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 
 | Task | BPH books | All others |
 |------|-----------|------------|
-| OCR (batch) | `gemini-3-flash-preview` | `gemini-3.1-flash-lite-preview` |
-| Translation | `gemini-3-flash-preview` | `gemini-3.1-flash-lite-preview` |
-| Transliteration | `gemini-3.1-flash-lite-preview` | `gemini-3.1-flash-lite-preview` |
-| Summary/Index/Chapters | `gemini-3.1-flash-lite-preview` | `gemini-3.1-flash-lite-preview` |
+| OCR (batch) | `gemini-3-flash-preview` | `gemini-3.1-flash-lite` |
+| Translation | `gemini-3-flash-preview` | `gemini-3.1-flash-lite` |
+| Transliteration | `gemini-3.1-flash-lite` | `gemini-3.1-flash-lite` |
+| Summary/Index/Chapters | `gemini-3.1-flash-lite` | `gemini-3.1-flash-lite` |
 
 ## Emergency Controls
 
@@ -47,7 +47,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 
 - MongoDB Atlas saturates at ~40 concurrent Lambda jobs (global backpressure limit)
 - Per-phase maximums: OCR 200/cycle (hardcoded default), translation 30 (in-flight cap 40 books), images 50
-- Translate-worker runs 20 concurrent books, 8000 pages/run cap
+- Translate-worker runs 40 concurrent books, 8000 pages/run cap
 - Tested higher (2026-03-26): `global_active_max` 50, `translate_lambda_max` 50 — Atlas stayed healthy. Adaptive system will auto-dial back if needed (ensure `locked: false`).
 
 ## Critical Rules
@@ -58,7 +58,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 - Any script overwriting `ocr.data` or `translation.data` MUST call `createRevision(pageId, field, jobId?)` first
 - **Never patch Hetzner directly without committing to git.** Local-only patches cause drift that's invisible to other devs and future sessions. Apply fixes in git first, then `git pull` on Hetzner.
 - **Health grading uses DB latency only** (findMs, countMs), not job count. Job count stopped correlating with DB load when translation moved to Hetzner. See lesson 2026-03-30.
-- Summary/Index/Chapters generation: enrich-worker uses `gemini-3.1-flash-lite-preview` for ALL phases (per CLAUDE.md, verified in `scripts/workers/enrich-worker.mjs`).
+- Summary/Index/Chapters generation: enrich-worker uses `gemini-3.1-flash-lite` for ALL phases (per CLAUDE.md, verified in `scripts/workers/enrich-worker.mjs` — the GA name, no `-preview` suffix; the preview name 404s since its retirement).
 - Stale Vercel connection pools after DB recovery → redeploy to reset
 
 ## Lessons Learned


### PR DESCRIPTION
Doc-drift fixes from the 2026-07-02 hygiene audit, each verified against code before changing:

| Doc | Was | Now | Evidence |
|---|---|---|---|
| memory/pipeline-ops.md | `gemini-3.1-flash-lite-preview` ×4, with a false 'verified in enrich-worker.mjs' claim | `gemini-3.1-flash-lite` | enrich-worker.mjs defines `LITE_MODEL = 'gemini-3.1-flash-lite'`; the -preview name 404s since retirement (known MEMORY lesson — it once broke ~20 call sites) |
| memory/pipeline-ops.md + system-map.md | translate concurrency 20 / 15 | 40 | `translate-worker.mjs:40` `const CONCURRENCY = 40` |
| system-map.md | counts from April (68 app dirs / 174 components / ~95 lib / 39 blog) | 87 / 250 / ~166 / 58 | live `ls`/count |
| README.md | '~5K gallery images curated' | '200K+ catalogued illustrations' + as-of date + /data pointer | `gallery_images.estimatedDocumentCount()` = 201,235 today |

The most important one is the first row: a contributor grepping pipeline-ops for the model name got a 404ing model with a footnote telling them it was verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)