### PR TITLE
fix: re-land rescued worktree fixes — tenant Overview-link scoping / BrokenImageReporter prod gate

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1232,8 +1232,12 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed
 
       {/* Stats + Pages Grid */}
       <main className="max-w-[1500px] mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-6">
-        {/* Overview link — Pages heading is rendered by PagesGrid */}
-        {pages.length > 0 && (
+        {/* Overview link — Pages heading is rendered by PagesGrid.
+            Hidden in embed mode: it points at the tenant-agnostic
+            /book/<slug>/overview route, which has no /embed/<tenant>/...
+            counterpart. Following it from a partner iframe would navigate
+            the frame to the global site and hit X-Frame-Options: DENY. */}
+        {pages.length > 0 && embedPolicy.showBookOverviewLink && (
           <div className="flex items-center justify-end">
             <Link
               href={`/book/${book.slug || book.id}/overview`}

--- a/src/components/BrokenImageReporter.tsx
+++ b/src/components/BrokenImageReporter.tsx
@@ -42,6 +42,12 @@ function flush() {
   }).catch(() => {});
 }
 
+function isProductionHost(): boolean {
+  if (typeof window === 'undefined') return false;
+  const host = window.location.hostname;
+  return host === 'sourcelibrary.org' || host.endsWith('.sourcelibrary.org');
+}
+
 function handleError(e: Event) {
   const el = e.target;
   if (!(el instanceof HTMLImageElement)) return;
@@ -71,6 +77,7 @@ function handleError(e: Event) {
 
 export default function BrokenImageReporter() {
   useEffect(() => {
+    if (!isProductionHost()) return;
     // Capture phase so we catch errors before any component swallows them
     document.addEventListener('error', handleError, true);
     return () => document.removeEventListener('error', handleError, true);

--- a/src/lib/embed-ui-policy.ts
+++ b/src/lib/embed-ui-policy.ts
@@ -24,6 +24,13 @@ export interface EmbedUiPolicy {
   enableBookIndexNavigation: boolean;
   showBookReadCta: boolean;
   showBookRelatedBooks: boolean;
+  // The Overview link points at the tenant-agnostic `/book/<slug>/overview`
+  // route — there is no `/embed/<tenant>/book/<slug>/overview` counterpart.
+  // Following it from inside a partner iframe navigates the frame to the
+  // global site (no tenant resolves there, so X-Frame-Options: DENY kicks
+  // in and the iframe goes blank). Hide it in embed mode rather than ship a
+  // link that breaks the iframe. See CLAUDE.md "Tenant Subdomain Lockdown".
+  showBookOverviewLink: boolean;
   showTranslationMethodologyLink: boolean;
   showExternalLinks: boolean;
   showGalleryImages: boolean;
@@ -52,6 +59,7 @@ export function getEmbedUiPolicy(ctx: TenantContext | null): EmbedUiPolicy {
       enableBookIndexNavigation: true,
       showBookReadCta: true,
       showBookRelatedBooks: true,
+      showBookOverviewLink: true,
       showTranslationMethodologyLink: true,
       showExternalLinks: true,
       showGalleryImages: true,
@@ -68,6 +76,7 @@ export function getEmbedUiPolicy(ctx: TenantContext | null): EmbedUiPolicy {
     enableBookIndexNavigation: false,
     showBookReadCta: false,
     showBookRelatedBooks: false,
+    showBookOverviewLink: false,
     showTranslationMethodologyLink: false,
     showExternalLinks: false,
     showGalleryImages: false,


### PR DESCRIPTION
## Summary

Two patches from an abandoned worktree (2026-05-27) were rescued but never merged (`.claude/worktree-rescue/fix-overview-link-embed-leak.patch`, `.claude/worktree-rescue/fix-broken-image-reporter-prod-gate.patch`). Both bugs were re-verified against current code before reimplementing — neither had landed inline.

### Patch 1: Overview link on the embedded book page

**Original target:** `src/app/[tenant]/book/[id]/page.tsx` — this file **no longer exists**. Book detail is now a single `src/app/book/[id]/page.tsx` (`BookDetailPage`), rendered either directly (global) or via `src/app/embed/[tenant]/book/[slug]/page.tsx`, which passes `tenantContext={ isEmbedded: true, ... }` as a plain prop (not a route — Next.js's own router never populates `tenantContext`, only the embed wrapper does).

**Verify:** the Overview link at `src/app/book/[id]/page.tsx` still hardcodes `href={`/book/${book.slug || book.id}/overview`}` with no embed-aware branch, and `BookInfo` isn't threaded an `isEmbedded` flag at all. **The bug is still present, but the shape changed:** there is no `/embed/<tenant>/book/<slug>/overview` route today. Following the unscoped link from inside a partner iframe (`/embed/<tenant>/book/<slug>`) navigates the frame to the plain global route; no tenant resolves there (main host, non-`/embed/` path), so `proxy.ts`'s `X-Frame-Options: DENY` fires and the iframe goes blank — a broken feature for embed partners, not just a soft leak.

**Fix:** re-implementing the original patch's *href-swap* approach isn't safe here since the destination route doesn't exist. Instead, added `showBookOverviewLink` to `EmbedUiPolicy` (`src/lib/embed-ui-policy.ts`), following the same pattern already used to hide other cross-tenant-unsafe widgets (`showBookRelatedBooks`, `showRelatedEditions`, etc.), and gated the link's JSX on it. `embedPolicy` was already threaded into `BookInfo` — no new props needed.

### Patch 2: BrokenImageReporter prod gate

**Verify:** `src/components/BrokenImageReporter.tsx` still has no host/env gate — it's mounted unconditionally in `src/app/layout.tsx` and fires `document.addEventListener('error', ...)` on every host, previews and localhost included.

**Fix:** re-applied verbatim — added `isProductionHost()` (checks `sourcelibrary.org` / `*.sourcelibrary.org`) and an early return in the `useEffect` before attaching the listener.

## Out of scope

`node scripts/audit-bph-leaks.mjs` run against the live `bph.sourcelibrary.org` found 6 pre-existing anchor leaks (`https://sourcelibrary.org/q/...` shortlinks on `/about` and `/vision`) — unrelated to either patch, not touched in this PR.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `node scripts/audit-bph-leaks.mjs` run against production (pre-existing unrelated leaks noted above; not introduced or worsened by this diff)
- [ ] Manual: load a book inside `/embed/bph/book/<slug>` and confirm the Overview link is absent
- [ ] Manual: confirm `/book/<slug>` (non-embedded) still shows the Overview link

🤖 Generated with [Claude Code](https://claude.com/claude-code)