### PR TITLE
fix(ft): attemptFamily recognizes the live verification instruments

### DIFF
--- a/src/lib/first-translation/attempt-log.ts
+++ b/src/lib/first-translation/attempt-log.ts
@@ -20,8 +20,13 @@ import type {
 
 export const ATTEMPTS_COLLECTION = 'first_translation_attempts';
 
-/** How an attempt was carried out. Superset of {@link Resolver} (adds gemini). */
-export type AttemptMethod = Resolver | 'gemini_verifier';
+/** How an attempt was carried out. Superset of {@link Resolver} (adds the live instruments). */
+export type AttemptMethod =
+  | Resolver
+  | 'gemini_verifier'
+  | 'gemini_grounded_search'
+  | 'claude_subagent_verify'
+  | 'llm_prior_adjudicate';
 
 /**
  * A prior English translation found during an attempt, kept STRUCTURED (not just

--- a/src/lib/first-translation/derive-from-evidence.ts
+++ b/src/lib/first-translation/derive-from-evidence.ts
@@ -68,9 +68,10 @@ import type {
 function methodToResolver(method: FirstTranslationAttempt['method']): Resolver {
   switch (method) {
     case 'tier2_agent': return 'tier2_agent';
+    case 'claude_subagent_verify': return 'tier2_agent';
     case 'human': return 'human';
     case 'tier0_linked': return 'tier0_linked';
-    // tier1_catalog and gemini_verifier are both catalog-grounded searches.
+    // tier1_catalog and the gemini instruments are all catalog-grounded searches.
     default: return 'tier1_catalog';
   }
 }

--- a/src/lib/first-translation/prior-evidence.ts
+++ b/src/lib/first-translation/prior-evidence.ts
@@ -86,8 +86,13 @@ export interface PriorEvidenceSummary {
 export type AttemptFamily = 'model_knowledge' | 'catalog' | 'agent' | 'human' | 'unknown';
 
 export function attemptFamily(a: FirstTranslationAttempt): AttemptFamily {
-  if (a.method === 'tier2_agent') return 'agent';
+  if (a.method === 'tier2_agent' || a.method === 'claude_subagent_verify') return 'agent';
   if (a.method === 'human') return 'human';
+  // Gemini prior-adjudicator reasons over cited priors from model knowledge.
+  if (a.method === 'llm_prior_adjudicate') return 'model_knowledge';
+  // Google-Search-grounded Gemini enumeration — catalog-grounded, same model
+  // family as the grounded gemini_verifier (correlated, NOT independent of it).
+  if (a.method === 'gemini_grounded_search') return 'catalog';
   const notes = a.notes ?? '';
   if (/^\[legacy_(ai|llm|tc)\]/.test(notes)) return 'model_knowledge';
   if (/^\[legacy_(tv|rp)\]/.test(notes)) return 'catalog';


### PR DESCRIPTION
Follow-up to #2945, found by cross-checking the reconcile dry-run against the census: `claude_subagent_verify` rows (the census evidence) fell into the 'unknown' family at tier 0, so refute-precedence never fired against fabricated catalog-tier priors — 22 census keep-badge books still derived `not_first`. Maps the live instruments into their correct families (claude→agent, grounded-gemini→catalog, prior-adjudicate→model_knowledge). Effect: needs_review 10→39; the fabricated-prior conflicts are now held for review instead of demoted. 36/36 tests, tsc clean. Part of #2933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)