### PR TITLE
fix(librarian): repair hallucinated book links instead of just disclaiming them

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -4,6 +4,7 @@ import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { streamAgenticResponse, type LibrarianStep, type SourceCard } from '@/lib/embassy/librarian';
+import { applyCitationFixes, type CitationFix } from '@/lib/embassy/citation-fixes';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { z } from 'zod';
 
@@ -46,6 +47,8 @@ const chatRequestSchema = z.object({
  *   choices    — branching options for the user to select
  *   chunk      — response text chunk
  *   sources    — source cards array
+ *   citation_fixes — broken book links repaired post-verification; clients
+ *                    apply these rewrites to the streamed text
  *   done       — stream complete
  *   error      — something went wrong
  */
@@ -169,6 +172,10 @@ export async function POST(request: NextRequest) {
   let fullText = '';
   let allSources: SourceCard[] = [];
   let turnUsage: LibrarianStep['usage'] | null = null;
+  // Link repairs from the post-response citation check. Applied to the
+  // persisted message (and the non-stream JSON reply); streaming clients get
+  // the same fixes as a `citation_fixes` event and apply them on-screen.
+  let citationFixes: CitationFix[] = [];
 
   const saveAiResponse = async () => {
     if (!fullText && allSources.length === 0) return;
@@ -179,7 +186,7 @@ export async function POST(request: NextRequest) {
         threadId: new ObjectId(activeThreadId),
         authorType: 'ai',
         authorName: 'The Librarian',
-        content: fullText,
+        content: applyCitationFixes(fullText, citationFixes),
         sources: allSources.map(s => ({
           bookId: s.book_id,
           bookTitle: s.bookTitle,
@@ -209,6 +216,8 @@ export async function POST(request: NextRequest) {
           fullText += step.text || '';
         } else if (step.type === 'sources') {
           allSources = step.sources || [];
+        } else if (step.type === 'citation_fixes') {
+          citationFixes = step.fixes || [];
         } else if (step.type === 'usage') {
           turnUsage = step.usage ?? null;
         }
@@ -236,7 +245,7 @@ export async function POST(request: NextRequest) {
       threadId: activeThreadId,
       message: {
         role: 'assistant',
-        content: fullText,
+        content: applyCitationFixes(fullText, citationFixes),
         sources: allSources,
       },
     });
@@ -310,6 +319,11 @@ export async function POST(request: NextRequest) {
           case 'sources':
             allSources = step.sources || [];
             await send({ type: 'sources', sources: step.sources });
+            break;
+
+          case 'citation_fixes':
+            citationFixes = step.fixes || [];
+            await send({ type: 'citation_fixes', fixes: step.fixes });
             break;
 
           case 'notebook_update':

--- a/src/app/experiments/search-v2/page.tsx
+++ b/src/app/experiments/search-v2/page.tsx
@@ -13,6 +13,7 @@ import { search as searchApi } from '@/lib/api-client';
 import type { SearchResult, IndexSearchResult } from '@/lib/api-client';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { bookUrl } from '@/lib/slugify';
+import { applyCitationFixes } from '@/lib/embassy/citation-fixes';
 import HighlightedText from '@/components/search/HighlightedText';
 import { ENTITY_TYPE_STYLES, type EntityType } from '@/lib/style-constants';
 import SiteHeader from '@/components/layout/SiteHeader';
@@ -168,6 +169,10 @@ export default function SearchV2Page() {
                   break;
                 case 'chunk':
                   contentAccum += event.text || '';
+                  setLibrarianContent(contentAccum);
+                  break;
+                case 'citation_fixes':
+                  contentAccum = applyCitationFixes(contentAccum, event.fixes || []);
                   setLibrarianContent(contentAccum);
                   break;
                 case 'choices':

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { tenantBookUrl } from '@/lib/slugify';
+import { applyCitationFixes } from '@/lib/embassy/citation-fixes';
 // remarkBreaks removed — we use ensureParagraphBreaks() instead for proper spacing
 import SiteHeader from '@/components/layout/SiteHeader';
 import LibrarianMessageBody from './_components/MessageBody';
@@ -484,6 +485,16 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                   updateLastAssistant(m => ({
                     ...m,
                     content: m.content + (event.text || ''),
+                  }));
+                  break;
+
+                case 'citation_fixes':
+                  // Server-side citation check repaired broken book links after
+                  // the text streamed — apply the same rewrites on-screen (the
+                  // persisted message is repaired server-side).
+                  updateLastAssistant(m => ({
+                    ...m,
+                    content: applyCitationFixes(m.content, event.fixes || []),
                   }));
                   break;
 

--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { tenantBookUrl } from '@/lib/slugify';
+import { applyCitationFixes } from '@/lib/embassy/citation-fixes';
 // remarkBreaks removed — we use ensureParagraphBreaks() instead for proper spacing
 import SiteHeader from '@/components/layout/SiteHeader';
 import LibrarianMessageBody from '@/app/librarian/_components/MessageBody';
@@ -372,6 +373,15 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                   updateLastAssistant(m => ({
                     ...m,
                     content: m.content + (event.text || ''),
+                  }));
+                  break;
+
+                case 'citation_fixes':
+                  // Server-side citation check repaired broken book links after
+                  // the text streamed — mirror the rewrites on-screen.
+                  updateLastAssistant(m => ({
+                    ...m,
+                    content: applyCitationFixes(m.content, event.fixes || []),
                   }));
                   break;
 

--- a/src/lib/embassy/citation-fixes.ts
+++ b/src/lib/embassy/citation-fixes.ts
@@ -1,0 +1,46 @@
+/**
+ * Citation link repair — shared between the Librarian server (which computes
+ * fixes after verifying citations) and the chat clients (which apply the same
+ * fixes to already-streamed text).
+ *
+ * A "fix" rewrites every https://sourcelibrary.org/book/<fromSlug> link in a
+ * response to point at <toSlug> — the edition we actually hold. Any page
+ * suffix (?page=N, /page-number/N, /page/<id>) is deliberately DROPPED in the
+ * rewrite: the page number was cited against a book that doesn't exist (or
+ * isn't public), so carrying it onto a different edition would deep-link to
+ * the wrong page. Landing on the book page is honest; page 427 of the wrong
+ * edition is a misquote.
+ *
+ * Client-safe: no server imports.
+ */
+
+export interface CitationFix {
+  fromSlug: string;
+  toSlug: string;
+  /** Display title of the replacement book (for logging/debugging). */
+  toTitle?: string;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Apply citation fixes to a response text. Matches the base book URL plus any
+ * page suffix, bounded so a slug that prefixes another slug can't match it
+ * (e.g. a fix for `corpus-hermeticum` must not touch
+ * `corpus-hermeticum-with-pneumatica-...`).
+ */
+export function applyCitationFixes(text: string, fixes: CitationFix[]): string {
+  let out = text;
+  for (const fix of fixes) {
+    if (!fix?.fromSlug || !fix?.toSlug || fix.fromSlug === fix.toSlug) continue;
+    const pattern = new RegExp(
+      `https://sourcelibrary\\.org/book/${escapeRegex(fix.fromSlug)}(?![a-z0-9-])` +
+      `(?:\\?page=\\d+|/page-number/\\d+|/page/[A-Za-z0-9-]+)?`,
+      'g',
+    );
+    out = out.replace(pattern, `https://sourcelibrary.org/book/${fix.toSlug}`);
+  }
+  return out;
+}

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -1,4 +1,5 @@
 import { getDb } from '@/lib/mongodb';
+import type { CitationFix } from '@/lib/embassy/citation-fixes';
 import { GoogleGenAI, Type, type FunctionDeclaration } from '@google/genai';
 import { logAiUsage } from '@/lib/log-ai-usage';
 // Atlas keyword + Supabase semantic are now combined in @/lib/search/librarian-search.
@@ -68,8 +69,12 @@ export interface ResearchNotebook {
 }
 
 export interface LibrarianStep {
-  type: 'thinking' | 'tool_call' | 'tool_result' | 'choices' | 'text' | 'sources' | 'notebook_update' | 'usage';
+  type: 'thinking' | 'tool_call' | 'tool_result' | 'choices' | 'text' | 'sources' | 'notebook_update' | 'usage' | 'citation_fixes';
   text?: string;
+  // Link repairs computed after citation verification — the route and the
+  // streaming clients apply these to the already-emitted text (see
+  // src/lib/embassy/citation-fixes.ts).
+  fixes?: CitationFix[];
   name?: string;
   query?: string;
   summary?: string;
@@ -763,6 +768,8 @@ Cite with page-level links: "quoted text" — *[Title](https://sourcelibrary.org
 
 Every mention of a book should link to it. Every mention of an author should link to their author page WHEN the tool results give you that author's link. Use the URLs from tool results verbatim — they contain the correct slugs, including the pre-built author link in each "Books found" line. **NEVER construct an author URL yourself by slugifying or translating a name.** The author's name in our catalog is often a different form than the one you'd write in prose (e.g. "Robert Bellarmine" is stored as "Bellarmino, Roberto, S.J"; "Bartholomaeus Fumus" as "Bartolomeo Fumo"), and a hand-built /author/... link will 404. If a tool result has no author link for someone, write their name as plain text — do not invent a link.
 
+**The same rule applies to book URLs.** Only write a /book/... link whose slug appeared verbatim in a tool result THIS turn. Our slugs encode edition, volume, and cataloguing details you cannot guess (the Corpus Hermeticum lives at slugs like \`poimandres-corpus-hermeticum-ficino\`, never \`the-corpus-hermeticum\`), so a slug built from a title will 404 even when we hold the book. If you mention a book the tools did not return this turn, give its title in plain italics with no link — or run a quick search for it first if a link would genuinely help.
+
 When quoting a key passage, include the original language text (Latin, German, Hebrew, etc.) alongside the English if it is notable or if the user appears to be working in that language. Use a blockquote with both versions.
 
 **Step 6: Show images and suggest next steps.**
@@ -798,7 +805,7 @@ ${collectionSection}## Formatting
 - Conversational but substantive — a research conversation, not a lecture
 - Cite 2-4 key passages rather than dumping everything. Every passage needs a page number and link
 - Link authors to their author pages ONLY with the author link supplied in the tool results — never a self-built /author/... URL. No tool-supplied link → plain text name.
-- Link books to their book pages: *[Book Title](https://sourcelibrary.org/book/slug)*
+- Link books to their book pages: *[Book Title](https://sourcelibrary.org/book/slug)* — slug copied exactly from a tool result this turn, never built from the title
 - Link quotes to specific pages: [Page 42](https://sourcelibrary.org/book/slug?page=42)
 - Make clear when speaking from general knowledge vs. specific texts`;
 }
@@ -1043,11 +1050,33 @@ export async function* streamAgenticResponse(
     .map((p: Record<string, unknown>) => p.text as string)
     .join('');
 
-  const { brokenBooks, unverifiedPages } = await verifyCitations(fullText, retrievedPageKeys);
+  const { brokenBooks, hiddenBooks, unverifiedPages } = await verifyCitations(fullText, retrievedPageKeys);
+
+  // Repair before disclaiming: a broken slug is almost always a title-composed
+  // near-miss of a book we hold under a different slug (and a hidden book often
+  // has a public edition). Resolve each to a held, visible book and emit the
+  // rewrites — the route applies them to the persisted message, the streaming
+  // clients to the on-screen text. Only what can't be repaired gets the note.
+  const badSlugs = [...new Set([...brokenBooks, ...hiddenBooks])].slice(0, 6);
+  const fixes: CitationFix[] = [];
+  const unrepaired: string[] = [];
+  for (const slug of badSlugs) {
+    try {
+      const held = await resolveSlugToHeldBook(slug);
+      if (held) fixes.push({ fromSlug: slug, toSlug: held.slug, toTitle: held.title });
+      else unrepaired.push(slug);
+    } catch {
+      unrepaired.push(slug);
+    }
+  }
+  if (fixes.length > 0) {
+    yield { type: 'citation_fixes', fixes };
+  }
+
   const clauses: string[] = [];
-  if (brokenBooks.length > 0) {
+  if (unrepaired.length > 0) {
     clauses.push(
-      `${brokenBooks.length === 1 ? 'a book link that points' : `${brokenBooks.length} book links that point`} to a record not in the collection (${brokenBooks.map(b => `\`${b}\``).join(', ')}) — these may be books we don't yet hold`,
+      `${unrepaired.length === 1 ? 'a book link that points' : `${unrepaired.length} book links that point`} to a record not currently available in the collection (${unrepaired.map(s => `\`sourcelibrary.org/book/${s}\``).join(', ')})`,
     );
   }
   if (unverifiedPages.length > 0) {
@@ -1056,11 +1085,29 @@ export async function* streamAgenticResponse(
     );
   }
   if (clauses.length > 0) {
-    console.warn('[Librarian] citation check flagged', { brokenBooks, unverifiedPages });
     yield {
       type: 'text',
       text: `\n\n---\n*A note on sourcing: this answer contains ${clauses.join('; and ')}.*`,
     };
+  }
+
+  // Leave a trace for monitoring — broken citations were previously invisible
+  // outside per-message disclaimers (and soft-404s never hit status-code logs).
+  if (badSlugs.length > 0 || unverifiedPages.length > 0) {
+    console.warn('[Librarian] citation check flagged', { brokenBooks, hiddenBooks, unverifiedPages, fixes });
+    try {
+      const db = await getDb();
+      await db.collection('embassy_errors').insertOne({
+        kind: 'broken_citation',
+        threadId: threadId ?? null,
+        brokenBooks,
+        hiddenBooks,
+        unverifiedPages,
+        repaired: fixes,
+        unrepaired,
+        createdAt: new Date(),
+      });
+    } catch { /* best effort */ }
   }
 
   // Persist AI cost for the librarian — the heaviest request-path AI feature
@@ -1081,11 +1128,18 @@ export async function* streamAgenticResponse(
 /**
  * Verify the book + page citations in a response against the library.
  *
- * Two failure modes matter for a scholarly tool:
- *  - brokenBooks: links to /book/<slug> for a book that doesn't exist.
+ * Three failure modes matter for a scholarly tool:
+ *  - brokenBooks: links to /book/<slug> for a book that doesn't exist —
+ *    usually a slug the model composed from a title instead of copying from a
+ *    tool result (the real book almost always exists under another slug).
+ *  - hiddenBooks: links to a book that exists but is not public
+ *    (visible: false) — the reader 404s these just like missing books.
  *  - unverifiedPages: a specific page the model never actually retrieved this
  *    turn AND that doesn't exist in the page store (or is out of range) — the
  *    signature of a fabricated or misremembered page number.
+ *
+ * brokenBooks/hiddenBooks are returned as bare slugs so the caller can try to
+ * repair them (see resolveSlugToHeldBook).
  *
  * `retrievedPageKeys` holds `${bookId}:${page}` for every page the model read
  * (via search, get_book_page, or read_nearby_pages) during this turn; anything
@@ -1094,7 +1148,7 @@ export async function* streamAgenticResponse(
 export async function verifyCitations(
   text: string,
   retrievedPageKeys: Set<string>,
-): Promise<{ brokenBooks: string[]; unverifiedPages: string[] }> {
+): Promise<{ brokenBooks: string[]; hiddenBooks: string[]; unverifiedPages: string[] }> {
   // /book/<slug>, optionally followed by ?page=N, /page-number/N, or /page/N.
   const citePattern = /sourcelibrary\.org\/book\/([a-z0-9-]+)(?:(?:\/page-number\/|\/page\/|\?page=)(\d+))?/g;
   const citedPages = new Map<string, Set<number>>();
@@ -1108,18 +1162,19 @@ export async function verifyCitations(
       citedPages.get(slug)!.add(Number(match[2]));
     }
   }
-  if (allSlugs.size === 0) return { brokenBooks: [], unverifiedPages: [] };
+  if (allSlugs.size === 0) return { brokenBooks: [], hiddenBooks: [], unverifiedPages: [] };
 
   const db = await getDb();
   const books = await db.collection('books')
     .find({ slug: { $in: [...allSlugs] } })
-    .project({ slug: 1, id: 1, pages_count: 1 })
+    .project({ slug: 1, id: 1, pages_count: 1, visible: 1 })
     .toArray();
 
   const slugToBook = new Map(
-    books.map(b => [b.slug as string, { id: b.id as string, pagesCount: b.pages_count as number | undefined }]),
+    books.map(b => [b.slug as string, { id: b.id as string, pagesCount: b.pages_count as number | undefined, visible: b.visible as boolean | undefined }]),
   );
-  const brokenBooks = [...allSlugs].filter(s => !slugToBook.has(s)).map(s => `sourcelibrary.org/book/${s}`);
+  const brokenBooks = [...allSlugs].filter(s => !slugToBook.has(s));
+  const hiddenBooks = [...allSlugs].filter(s => slugToBook.get(s)?.visible === false);
 
   // A cited page is trusted if the model read it this turn; otherwise it must
   // exist in the page store and sit within the book's range.
@@ -1149,7 +1204,96 @@ export async function verifyCitations(
     }
   }
 
-  return { brokenBooks, unverifiedPages: [...unverified] };
+  return { brokenBooks, hiddenBooks, unverifiedPages: [...unverified] };
+}
+
+// Slug tokens too generic to anchor a repair lookup on their own.
+const SLUG_STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'from', 'les', 'des', 'der', 'die', 'das',
+  'von', 'van', 'del', 'della', 'sive', 'seu', 'cum', 'per', 'quae', 'qua',
+  'vol', 'volume', 'tome', 'tomus', 'pars', 'part', 'complete', 'edition',
+  'trans', 'translated', 'translation', 'various', 'anonymous',
+]);
+
+/**
+ * Try to resolve a broken/hidden book slug to a public book we actually hold.
+ *
+ * The failure mode this repairs: the model links a famous work with a slug it
+ * composed from the title (`oedipus-aegyptiacus-kircher`) while the library
+ * holds the book under a catalogued slug
+ * (`oedipus-aegyptiacus-volume-i-1652-kircher`). Match strategy: every
+ * significant token of the broken slug must appear in the candidate's slug,
+ * title, or author (conservative — a wrong-book substitution would be worse
+ * than a dead link). Among candidates, prefer the most-read edition.
+ *
+ * Returns null when no candidate matches — the caller falls back to the
+ * sourcing disclaimer.
+ */
+// Extract a volume designator ("vol-ix", "volume-2", "tomus-i") from a slug so
+// a repair never silently swaps volumes of a multi-volume work. Roman numerals
+// are normalized so vol-ix and vol-9 compare equal.
+function volumeOf(slug: string): number | null {
+  const m = slug.match(/(?:^|-)(?:vol|volume|tome|tomus|pars|part)-?([0-9]+|[ivxlc]+)(?:-|$)/i);
+  if (!m) return null;
+  const v = m[1].toLowerCase();
+  if (/^\d+$/.test(v)) return parseInt(v, 10);
+  const R: Record<string, number> = { i: 1, v: 5, x: 10, l: 50, c: 100 };
+  let n = 0;
+  for (let i = 0; i < v.length; i++) {
+    const cur = R[v[i]];
+    const next = R[v[i + 1]] || 0;
+    n += cur < next ? -cur : cur;
+  }
+  return n;
+}
+
+export async function resolveSlugToHeldBook(
+  slug: string,
+): Promise<{ slug: string; title: string } | null> {
+  const tokens = slug
+    .split('-')
+    .filter(t => t.length >= 3 && !SLUG_STOPWORDS.has(t) && !/^\d+$/.test(t));
+  if (tokens.length === 0) return null;
+
+  // Longest tokens are the most distinctive; cap the clause count.
+  const anchors = [...tokens].sort((a, b) => b.length - a.length).slice(0, 4);
+
+  const db = await getDb();
+  const lookup = async (toks: string[]) => {
+    const conds = toks.map(t => {
+      const rx = new RegExp(t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+      return { $or: [{ slug: rx }, { title: rx }, { author: rx }] };
+    });
+    return db.collection('books')
+      .find({ $and: conds, visible: true, pages_count: { $gt: 0 }, slug: { $exists: true, $nin: [null, slug] } })
+      .project({ slug: 1, title: 1, display_title: 1, read_count: 1, pages_count: 1 })
+      .limit(5)
+      .toArray();
+  };
+
+  let candidates = await lookup(anchors);
+  // Conservative relaxation: a composed slug often carries one word the
+  // catalogue lacks ("extrakt", "reformatum"). Leave each anchor out in turn —
+  // every remaining token must still match, so this drops exactly one bad
+  // token rather than loosening the whole query.
+  if (candidates.length === 0 && anchors.length >= 3) {
+    for (let i = anchors.length - 1; i >= 0 && candidates.length === 0; i--) {
+      candidates = await lookup(anchors.filter((_, j) => j !== i));
+    }
+  }
+
+  // Never swap volumes: if both slugs carry a volume designator and they
+  // disagree, the candidate is a different physical book of the same work.
+  const wantVol = volumeOf(slug);
+  candidates = candidates.filter(cand => {
+    const candVol = volumeOf(cand.slug as string);
+    return !(wantVol && candVol && wantVol !== candVol);
+  });
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => (b.read_count || 0) - (a.read_count || 0) || (b.pages_count || 0) - (a.pages_count || 0));
+  const best = candidates[0];
+  return { slug: best.slug as string, title: (best.display_title || best.title || best.slug) as string };
 }
 
 function deduplicateSources(sources: SourceCard[]): SourceCard[] {

--- a/tests/unit/citation-fixes.test.ts
+++ b/tests/unit/citation-fixes.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { applyCitationFixes } from '@/lib/embassy/citation-fixes';
+
+describe('applyCitationFixes', () => {
+  const fix = { fromSlug: 'oedipus-aegyptiacus-kircher', toSlug: 'oedipus-aegyptiacus-volume-i-1652-kircher' };
+
+  it('rewrites a bare book link', () => {
+    const text = 'See *[Oedipus](https://sourcelibrary.org/book/oedipus-aegyptiacus-kircher)* for more.';
+    expect(applyCitationFixes(text, [fix])).toBe(
+      'See *[Oedipus](https://sourcelibrary.org/book/oedipus-aegyptiacus-volume-i-1652-kircher)* for more.',
+    );
+  });
+
+  it('drops ?page=N, /page-number/N and /page/<id> suffixes — page numbers from the wrong edition must not carry over', () => {
+    for (const suffix of ['?page=427', '/page-number/427', '/page/69a5d8114d84314297c08acf']) {
+      const text = `[Page 427](https://sourcelibrary.org/book/oedipus-aegyptiacus-kircher${suffix})`;
+      expect(applyCitationFixes(text, [fix])).toBe(
+        '[Page 427](https://sourcelibrary.org/book/oedipus-aegyptiacus-volume-i-1652-kircher)',
+      );
+    }
+  });
+
+  it('rewrites every occurrence', () => {
+    const text = 'A https://sourcelibrary.org/book/oedipus-aegyptiacus-kircher B https://sourcelibrary.org/book/oedipus-aegyptiacus-kircher?page=3 C';
+    const out = applyCitationFixes(text, [fix]);
+    expect(out).not.toContain('book/oedipus-aegyptiacus-kircher?');
+    expect(out.match(/oedipus-aegyptiacus-volume-i-1652-kircher/g)).toHaveLength(2);
+  });
+
+  it('does not touch a longer slug that the broken slug prefixes', () => {
+    const text = 'https://sourcelibrary.org/book/corpus-hermeticum-with-pneumatica-and-ocellus-lucanus-alexandria';
+    const out = applyCitationFixes(text, [{ fromSlug: 'corpus-hermeticum', toSlug: 'poimandres-corpus-hermeticum-ficino' }]);
+    expect(out).toBe(text);
+  });
+
+  it('ignores no-op and malformed fixes', () => {
+    const text = 'https://sourcelibrary.org/book/some-book';
+    expect(applyCitationFixes(text, [{ fromSlug: 'some-book', toSlug: 'some-book' }])).toBe(text);
+    expect(applyCitationFixes(text, [{ fromSlug: '', toSlug: 'x' }])).toBe(text);
+    expect(applyCitationFixes(text, [])).toBe(text);
+  });
+});


### PR DESCRIPTION
## Why

An audit of the last 800 Librarian messages found **69 of 1,185 distinct `/book/` links (5.8%) pointing at slugs that don't exist** — they render as soft-404 "Book Not Found" pages (HTTP 200, invisible to status-code monitoring). In late June, 21% of link-bearing messages contained at least one broken link. 19 more links pointed at hidden (`visible:false`) books, which 404 identically for readers.

Root cause: the model composes plausible slugs from titles (`oedipus-aegyptiacus-kircher`, `the-corpus-hermeticum`) instead of copying tool-result URLs — **in almost every case we hold the book under a different catalogued slug** (`oedipus-aegyptiacus-volume-i-1652-kircher`). The existing `verifyCitations` pass detected these but only appended a disclaimer; the dead links stayed clickable and were persisted to threads.

## What

- **`verifyCitations`** also flags hidden books now, and returns bare slugs for repair.
- **`resolveSlugToHeldBook`** (new): conservative token-anchored lookup — every significant slug token must match the candidate's slug/title/author; leave-one-out retry drops exactly one bogus token; a volume guard (roman-numeral aware) never swaps volumes of a multi-volume work. **Validated against the 35 real broken/hidden slugs from production: 31 repaired correctly, 4 fall back to the disclaimer** (incl. a correct rejection of Pliny vol IX → vol 1).
- **`citation_fixes` step + shared `applyCitationFixes()`** (`src/lib/embassy/citation-fixes.ts`): the chat route applies repairs to the persisted message and non-stream response; LibrarianClient / ReadingRoom / search-v2 apply the same rewrites to already-streamed text. Rewrites deliberately **drop page suffixes** — a page number cited against the wrong edition must not deep-link (misquote risk, cf. #2232).
- **Monitoring**: broken citations now insert `embassy_errors` docs (`kind: 'broken_citation'`) with repaired/unrepaired lists.
- **Prompt**: the "NEVER construct a URL" rule was author-only; extended to book links with a concrete slug example.

## Out of scope

- Author-link 404s (48/207 sampled author slugs don't resolve in the `authors` collection) — separate surface, needs the author-thesaurus redirect story, not link rewriting.
- The 31K `/book/*/page/<id>` 404 wave in `not_found_reports` — that's scraper traffic hitting books mass-hidden on ~June 21; the hidden-book gate is working as designed.

## Testing

- `tests/unit/citation-fixes.test.ts` — rewrite, suffix-drop, prefix-slug boundary, no-op cases (5 passing).
- Full unit suite: 428 passing. `npx tsc --noEmit` clean.
- Resolver precision validated against all 35 production broken/hidden slugs (script run against prod Atlas, read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)