### PR TITLE
fix(gallery): leaked non-viewer ids in /gallery/image links

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -355,8 +355,17 @@ async function searchImages(args: Record<string, unknown>) {
     description: item.description, type: item.type, quality: item.galleryQuality,
     book: { title: item.bookTitle, author: item.author, year: item.year },
     page: item.pageNumber, image_url: item.imageUrl,
-    url: `https://sourcelibrary.org/gallery/image/${item.pageId}-${item.detectionIndex}`,
-    book_url: item.bookId ? `https://sourcelibrary.org/book/${item.bookId}?page=${item.pageNumber}` : undefined,
+    // Standalone artworks (source:'artwork') have no page in the gallery viewer —
+    // their pageId is the synthetic `artwork-<bookId>`, and /gallery/image/artwork-…-0
+    // 404s. Link them to their own detail page (item.link) instead.
+    url: item.source === 'artwork'
+      ? `https://sourcelibrary.org${item.link || `/book/${item.bookId}`}`
+      : `https://sourcelibrary.org/gallery/image/${item.pageId}-${item.detectionIndex}`,
+    book_url: item.bookId
+      ? (item.source === 'artwork'
+        ? `https://sourcelibrary.org/book/${item.bookId}`
+        : `https://sourcelibrary.org/book/${item.bookId}?page=${item.pageNumber}`)
+      : undefined,
   })) || [];
 
   const artworks = (artworkResult.items as Array<Record<string, unknown>>)?.map((item) => ({

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -766,12 +766,19 @@ async function searchVisual(query: string, limit: number): Promise<{ results: Ga
     });
     if (error || !data) return { results: [], total: 0 };
 
-    // Deduplicate by book (max 2 per book)
+    // Keep only gallery-image rows and strip the clip_embeddings id prefix.
+    // The clip table mixes three id namespaces: `gallery-<pageId>-<n>`,
+    // `artwork-<bookId>`, and `cover-<bookId>`. Consumers link these ids to
+    // /gallery/image/<id>, which only resolves bare `<pageId>-<n>` — the raw
+    // clip ids all 404 there. Artworks/covers already have their own lanes
+    // (artwork semantic+lexical, book search), so dropping them loses nothing.
+    // Deduplicate by book (max 2 per book).
     const byBook = new Map<string, number>();
     const deduped = (data as Array<{
-      id: string; book_id: string; image_url: string; thumbnail_url: string;
+      id: string; source_type: string; book_id: string; image_url: string; thumbnail_url: string;
       title: string; author: string; resource_type: string; similarity: number;
     }>).filter(m => {
+      if (m.source_type !== 'gallery_image') return false;
       const count = byBook.get(m.book_id) || 0;
       if (count >= 2) return false;
       byBook.set(m.book_id, count + 1);
@@ -780,7 +787,7 @@ async function searchVisual(query: string, limit: number): Promise<{ results: Ga
 
     return {
       results: deduped.map(m => ({
-        id: m.id,
+        id: m.id.replace(/^gallery-/, ''),
         imageUrl: m.thumbnail_url || m.image_url || '',
         description: m.title || '',
         type: m.resource_type || undefined,

--- a/src/app/gallery/image/[id]/layout.tsx
+++ b/src/app/gallery/image/[id]/layout.tsx
@@ -8,8 +8,34 @@
 
 import { cache } from 'react';
 import { Metadata } from 'next';
+import { permanentRedirect } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
 import GalleryImageSchema from '@/components/seo/GalleryImageSchema';
+
+/**
+ * Rescue non-viewer ids that leaked into /gallery/image/ links.
+ *
+ * Several producers (clip_embeddings rows, the merged gallery browse) use
+ * prefixed id namespaces that are NOT viewer ids:
+ *   - artwork-<bookId>[-<n>]  — standalone artwork (books collection)
+ *   - cover-<bookId>[-<n>]    — book cover clip row
+ *   - gallery-<pageId>-<n>    — clip row for a real gallery image
+ * The viewer only resolves bare `<pageId>-<n>`, so these all soft-404.
+ * Redirect them to where the content actually lives instead.
+ */
+function redirectLeakedId(id: string): void {
+  const decoded = decodeURIComponent(id);
+  const prefixed = decoded.match(/^(artwork|cover|gallery)-(.+)$/);
+  if (!prefixed) return;
+  const [, prefix, rest] = prefixed;
+  if (prefix === 'gallery') {
+    permanentRedirect(`/gallery/image/${rest}`);
+  }
+  // artwork/cover: the payload is a book id, sometimes with a synthetic
+  // detection-index suffix (`artwork-<bookId>-0` from the merged browse).
+  const bookId = rest.replace(/-\d+$/, '');
+  permanentRedirect(`/book/${bookId}`);
+}
 
 interface PageWithBook {
   id: string;
@@ -104,6 +130,7 @@ export async function generateMetadata({
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {
   const { id } = await params;
+  redirectLeakedId(id);
   let data;
   try {
     data = await getImageData(id);
@@ -173,6 +200,7 @@ export default async function ImageLayout({
   children: React.ReactNode;
 }) {
   const { id } = await params;
+  redirectLeakedId(id);
   const data = await getImageData(id);
   const urlSafeId = decodeURIComponent(id).replace(/:(\d+)$/, '-$1');
 

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -455,7 +455,7 @@ async function executeSearchImages(query: string, bookId?: string): Promise<{
   // in the gallery). An exact keyword hit on the curated description is
   // stronger evidence than borderline visual similarity, so the merged order
   // is: corroborated by both → keyword-only → CLIP-only.
-  const projection = { image_url: 1, description: 1, museum_description: 1, book_id: 1, book_title: 1, book_author: 1, book_slug: 1, page_number: 1, type: 1 };
+  const projection = { id: 1, page_id: 1, detection_index: 1, image_url: 1, description: 1, museum_description: 1, book_id: 1, book_title: 1, book_author: 1, book_slug: 1, page_number: 1, type: 1 };
 
   // The keyword arm uses the weighted $text index (gallery_images_text_idx:
   // description ×5, museum_description ×3, subjects/figures/symbols ×2), NOT a
@@ -517,7 +517,10 @@ async function executeSearchImages(query: string, bookId?: string): Promise<{
 
   return {
     images: images.slice(0, 6).map(img => ({
-      id: img._id.toString(),
+      // Viewer id is the compound `<pageId>-<detectionIndex>` (gallery_images.id),
+      // NOT the Mongo ObjectId — /gallery/image/<objectIdHex> can't be parsed
+      // by the viewer route and soft-404s.
+      id: img.id || `${img.page_id}-${img.detection_index}`,
       imageUrl: img.image_url,
       description: (img.museum_description || img.description || '').slice(0, 300),
       bookTitle: img.book_title || 'Unknown',


### PR DESCRIPTION
## Why

https://sourcelibrary.org/gallery/image/artwork-69e536ee860f4574c2e71542-0 (surfaced in search) soft-404s. The record is a visible standalone artwork (*Historia Mundi Naturalis, Plinii Secundi*) whose real page is /artwork/historia-mundi-naturalis-plinii-secundi — the URL itself was never a valid viewer id.

Tracing the minting surfaces found four producers of `/gallery/image/<id>` links the viewer cannot resolve:

1. **MCP `search_images`** (`src/app/api/mcp/route.ts`) built `gallery/image/${pageId}-${detectionIndex}` for every `/api/gallery` item, including artwork tiles whose synthetic pageId is `artwork-<bookId>` (from `gallery-merge.ts`). This is the source of the reported URL. Artwork items now link to their detail page.
2. **Unified-search visual (CLIP) lane** (`src/app/api/search/unified/route.ts`) passed raw `clip_embeddings` ids through: `gallery-<pageId>-<n>`, `artwork-<bookId>`, `cover-<bookId>`. Verified live: **every visual-lane image link on /search was broken** (e.g. `/gallery/image/gallery-6992ce60…-0` → "Page not found"). Now filtered to `source_type: gallery_image` (artworks/covers already have dedicated lanes) with the `gallery-` prefix stripped.
3. **Librarian `search_images`** (`src/lib/embassy/librarian.ts`) linked `gallery/image/<ObjectId hex>` (`gallery_images._id`) instead of the compound `<pageId>-<n>` id — unparseable by the viewer route.
4. **Defense in depth** for links already shared/indexed: the viewer layout (server component) now `permanentRedirect`s `artwork-`/`cover-` ids to `/book/<bookId>` (which 301s on to `/artwork/<slug>` for artworks) and `gallery-` ids to the canonical bare viewer id.

## Out of scope
- `src/app/experiments/search-v2` (experiment page) builds the same link shape but only from the gallery lane; left alone.
- Backfilling/re-keying `clip_embeddings` ids — the prefix strip at read time is sufficient.

## Verification
- `npx tsc --noEmit` clean; `tests/unit/provider-prefix-redirect.test.ts` passes.
- Live probes confirmed the broken shapes pre-fix: `/api/gallery/image/gallery-<id>-0` → 404, bare `<id>-0` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)