### PR TITLE
fix(blog): repair 51 dead /book links across 9 posts

### DIFF
--- a/src/app/blog/chakra-tradition/page.tsx
+++ b/src/app/blog/chakra-tradition/page.tsx
@@ -82,11 +82,11 @@ export default function ChakraTraditionPage() {
         </p>
 
         <h3 className="text-xl text-stone-800 mb-3 mt-10">
-          <Link href="/book/6953e2f677f38f6761bea397" className="hover:text-accent-gold-dark transition-colors">The Tantraloka of Abhinavagupta</Link>
+          <Link href="/book/6953e2ff77f38f6761beb2fa" className="hover:text-accent-gold-dark transition-colors">The Tantraloka of Abhinavagupta</Link>
         </h3>
 
         <p className="text-secondary leading-relaxed mb-6">
-          The <Link href="/book/6953e2f677f38f6761bea397" className="text-accent-rust hover:text-accent-rust underline"><em>Tantraloka</em></Link> (&ldquo;Light on Tantra&rdquo;) is the masterwork of the Kashmiri Shaiva philosopher Abhinavagupta (c. 950&ndash;1016 CE). At nearly 4,000 pages in its Sanskrit editions, it is the most comprehensive synthesis of tantric philosophy and practice ever composed. No complete English translation exists. Source Library is currently translating the full text &mdash; 3,931 pages &mdash; which would represent the first time the complete <em>Tantraloka</em> has been available in English.
+          The <Link href="/book/6953e2ff77f38f6761beb2fa" className="text-accent-rust hover:text-accent-rust underline"><em>Tantraloka</em></Link> (&ldquo;Light on Tantra&rdquo;) is the masterwork of the Kashmiri Shaiva philosopher Abhinavagupta (c. 950&ndash;1016 CE). At nearly 4,000 pages in its Sanskrit editions, it is the most comprehensive synthesis of tantric philosophy and practice ever composed. No complete English translation exists. Source Library is currently translating the full text &mdash; 3,931 pages &mdash; which would represent the first time the complete <em>Tantraloka</em> has been available in English.
         </p>
 
         <p className="text-secondary leading-relaxed mb-8">
@@ -94,27 +94,27 @@ export default function ChakraTraditionPage() {
         </p>
 
         <h3 className="text-xl text-stone-800 mb-3 mt-10">
-          <Link href="/book/6991d44821124c9ad694347c" className="hover:text-accent-gold-dark transition-colors">The Svacchanda Tantra</Link>
+          <Link href="/book/sri-svacchanda-tantra-i-ed" className="hover:text-accent-gold-dark transition-colors">The Svacchanda Tantra</Link>
         </h3>
 
         <p className="text-secondary leading-relaxed mb-8">
-          One of the oldest surviving Bhairava Tantras (perhaps 7th&ndash;8th century), the <Link href="/book/6991d44821124c9ad694347c" className="text-accent-rust hover:text-accent-rust underline"><em>Svacchanda Tantra</em></Link> presents an early and detailed map of the subtle body that differs in important ways from later standardizations. Source Library holds the complete <Link href="/book/6991d44821124c9ad694347c" className="text-accent-rust hover:text-accent-rust underline">five-volume Sanskrit edition</Link> with commentary (2,717 pages), recently imported and now being processed.
+          One of the oldest surviving Bhairava Tantras (perhaps 7th&ndash;8th century), the <Link href="/book/sri-svacchanda-tantra-i-ed" className="text-accent-rust hover:text-accent-rust underline"><em>Svacchanda Tantra</em></Link> presents an early and detailed map of the subtle body that differs in important ways from later standardizations. Source Library holds the <Link href="/book/sri-svacchanda-tantra-i-ed" className="text-accent-rust hover:text-accent-rust underline">first volume of the Sanskrit edition</Link> with commentary (440 pages), fully translated.
         </p>
 
         <h3 className="text-xl text-stone-800 mb-3 mt-10">
-          <Link href="/book/6991d46421124c9ad6943f2b" className="hover:text-accent-gold-dark transition-colors">The Netra Tantra</Link>
+          <Link href="/book/69e13b030dae29249d20bde5" className="hover:text-accent-gold-dark transition-colors">The Netra Tantra</Link>
         </h3>
 
         <p className="text-secondary leading-relaxed mb-8">
-          A Shaiva text focused on the deity Amriteshvara, the <Link href="/book/6991d46421124c9ad6943f2b" className="text-accent-rust hover:text-accent-rust underline"><em>Netra Tantra</em></Link> (&ldquo;Tantra of the Eye&rdquo;) contains important material on kundalini yoga and the relationship between breath, consciousness, and the energy channels. Our edition runs to 616 pages. Like the <em>Svacchanda Tantra</em>, it has never been fully translated.
+          A Shaiva text focused on the deity Amriteshvara, the <Link href="/book/69e13b030dae29249d20bde5" className="text-accent-rust hover:text-accent-rust underline"><em>Netra Tantra</em></Link> (&ldquo;Tantra of the Eye&rdquo;) contains important material on kundalini yoga and the relationship between breath, consciousness, and the energy channels. Our edition, with K&#7779;emar&#257;ja&apos;s commentary, runs to 318 pages. Like the <em>Svacchanda Tantra</em>, it has never had a complete published English translation.
         </p>
 
         <h3 className="text-xl text-stone-800 mb-3 mt-10">
-          <Link href="/book/6991d43921124c9ad6942bb9" className="hover:text-accent-gold-dark transition-colors">The Goraksha Samhita</Link>
+          The Goraksha Samhita
         </h3>
 
         <p className="text-secondary leading-relaxed mb-8">
-          Attributed to Gorakhnath, the legendary founder of the Nath tradition, this text bridges the gap between the high philosophy of Kashmir Shaivism and the practical hatha yoga that would become popular across India. The Nath yogis were the primary carriers of chakra knowledge into mainstream Indian religious culture. Our <Link href="/book/6991d43921124c9ad6942bb9" className="text-accent-rust hover:text-accent-rust underline">edition (655 pages)</Link> preserves teachings on the six chakras, kundalini awakening, and the network of nadis that became standard in later yoga manuals.
+          Attributed to Gorakhnath, the legendary founder of the Nath tradition, this text bridges the gap between the high philosophy of Kashmir Shaivism and the practical hatha yoga that would become popular across India. The Nath yogis were the primary carriers of chakra knowledge into mainstream Indian religious culture. The text preserves teachings on the six chakras, kundalini awakening, and the network of nadis that became standard in later yoga manuals.
         </p>
 
         <h3 className="text-xl text-stone-800 mb-3 mt-10">
@@ -145,13 +145,13 @@ export default function ChakraTraditionPage() {
           <li className="flex items-start gap-3">
             <span className="text-accent-rust mt-1.5 shrink-0">&bull;</span>
             <span>
-              <Link href="/book/6991d43e21124c9ad6942e4d" className="text-accent-rust hover:text-accent-rust underline"><strong>Kaulajnana Nirnaya</strong></Link> (attributed to Matsyendranath) &mdash; Perhaps the oldest surviving Kaula text, this 1,414-page work describes a chakra system embedded in transgressive ritual and goddess worship that predates the &ldquo;cleaned up&rdquo; versions found in later yoga manuals.
+              <strong>Kaulajnana Nirnaya</strong> (attributed to Matsyendranath) &mdash; Perhaps the oldest surviving Kaula text, this work describes a chakra system embedded in transgressive ritual and goddess worship that predates the &ldquo;cleaned up&rdquo; versions found in later yoga manuals.
             </span>
           </li>
           <li className="flex items-start gap-3">
             <span className="text-accent-rust mt-1.5 shrink-0">&bull;</span>
             <span>
-              <Link href="/book/6991d44321124c9ad69433d6" className="text-accent-rust hover:text-accent-rust underline"><strong>Siddha Siddhanta Paddhati</strong></Link> (attributed to Gorakhnath) &mdash; This text maps nine chakras (not six or seven) and describes the body as a microcosm containing the entire universe &mdash; mountains, rivers, sacred sites, and celestial realms all located within the practitioner&apos;s own subtle anatomy. 161 pages.
+              <strong>Siddha Siddhanta Paddhati</strong> (attributed to Gorakhnath) &mdash; This text maps nine chakras (not six or seven) and describes the body as a microcosm containing the entire universe &mdash; mountains, rivers, sacred sites, and celestial realms all located within the practitioner&apos;s own subtle anatomy.
             </span>
           </li>
           <li className="flex items-start gap-3">
@@ -216,34 +216,22 @@ export default function ChakraTraditionPage() {
             </thead>
             <tbody className="divide-y divide-stone-200">
               <tr>
-                <td className="py-3 pr-4"><Link href="/book/6953e2f677f38f6761bea397" className="text-accent-rust hover:text-accent-rust underline">Tantraloka</Link></td>
-                <td className="py-3 pr-4">3,931</td>
+                <td className="py-3 pr-4"><Link href="/book/6953e2ff77f38f6761beb2fa" className="text-accent-rust hover:text-accent-rust underline">Tantraloka, Vol. 1 (with Jayaratha&apos;s commentary)</Link></td>
+                <td className="py-3 pr-4">372</td>
                 <td className="py-3 pr-4">Internet Archive</td>
-                <td className="py-3">Translating</td>
+                <td className="py-3">Translated</td>
               </tr>
               <tr>
-                <td className="py-3 pr-4"><Link href="/book/6991d44821124c9ad694347c" className="text-accent-rust hover:text-accent-rust underline">Svacchanda Tantra (5 vols)</Link></td>
-                <td className="py-3 pr-4">2,717</td>
+                <td className="py-3 pr-4"><Link href="/book/sri-svacchanda-tantra-i-ed" className="text-accent-rust hover:text-accent-rust underline">Svacchanda Tantra (Vol. I)</Link></td>
+                <td className="py-3 pr-4">440</td>
                 <td className="py-3 pr-4">Internet Archive</td>
-                <td className="py-3">Digitized</td>
+                <td className="py-3">Translated</td>
               </tr>
               <tr>
-                <td className="py-3 pr-4"><Link href="/book/6991d43e21124c9ad6942e4d" className="text-accent-rust hover:text-accent-rust underline">Kaulajnana Nirnaya</Link></td>
-                <td className="py-3 pr-4">1,414</td>
+                <td className="py-3 pr-4"><Link href="/book/69e13b030dae29249d20bde5" className="text-accent-rust hover:text-accent-rust underline">Netra Tantra</Link></td>
+                <td className="py-3 pr-4">318</td>
                 <td className="py-3 pr-4">Internet Archive</td>
-                <td className="py-3">Digitized</td>
-              </tr>
-              <tr>
-                <td className="py-3 pr-4"><Link href="/book/6991d43921124c9ad6942bb9" className="text-accent-rust hover:text-accent-rust underline">Goraksha Samhita</Link></td>
-                <td className="py-3 pr-4">655</td>
-                <td className="py-3 pr-4">Internet Archive</td>
-                <td className="py-3">Digitized</td>
-              </tr>
-              <tr>
-                <td className="py-3 pr-4"><Link href="/book/6991d46421124c9ad6943f2b" className="text-accent-rust hover:text-accent-rust underline">Netra Tantra</Link></td>
-                <td className="py-3 pr-4">616</td>
-                <td className="py-3 pr-4">Internet Archive</td>
-                <td className="py-3">Digitized</td>
+                <td className="py-3">Translated</td>
               </tr>
               <tr>
                 <td className="py-3 pr-4"><Link href="/book/6991d46721124c9ad6944195" className="text-accent-rust hover:text-accent-rust underline">Tantraraja Tantra</Link></td>
@@ -255,12 +243,6 @@ export default function ChakraTraditionPage() {
                 <td className="py-3 pr-4"><Link href="/book/6991d89a8c1030b12444c076" className="text-accent-rust hover:text-accent-rust underline">Hathayogapradipika (with commentaries)</Link></td>
                 <td className="py-3 pr-4">200</td>
                 <td className="py-3 pr-4">Wellcome Collection</td>
-                <td className="py-3">Digitized</td>
-              </tr>
-              <tr>
-                <td className="py-3 pr-4"><Link href="/book/6991d44321124c9ad69433d6" className="text-accent-rust hover:text-accent-rust underline">Siddha Siddhanta Paddhati</Link></td>
-                <td className="py-3 pr-4">161</td>
-                <td className="py-3 pr-4">Internet Archive</td>
                 <td className="py-3">Digitized</td>
               </tr>
               <tr>

--- a/src/app/blog/fechner-bohme/page.tsx
+++ b/src/app/blog/fechner-bohme/page.tsx
@@ -146,9 +146,7 @@ export default function FechnerBohmePage() {
           <Link href="/book/699062f0ef12272ffdc8e403" className="text-accent-rust hover:text-accent-rust underline"><em>Elemente der Psychophysik</em>, Volume I</Link>
           {' '}and{' '}
           <Link href="/book/699062f2ef12272ffdc8e789" className="text-accent-rust hover:text-accent-rust underline">Volume II</Link>
-          {' '}(1860) laid out the experimental evidence and mathematical framework. The work founded a new science. Wundt built his laboratory on it. Helmholtz, Weber, and the entire tradition of German experimental psychology descends from it. The{' '}
-          <Link href="/book/6992cbf9018b80967354c7b7" className="text-accent-rust hover:text-accent-rust underline">English translation</Link>
-          {' '}(1966) made Volume I accessible to Anglophone readers &mdash; but only the experimental content, stripped of its metaphysical context.
+          {' '}(1860) laid out the experimental evidence and mathematical framework. The work founded a new science. Wundt built his laboratory on it. Helmholtz, Weber, and the entire tradition of German experimental psychology descends from it. The English translation (1966) made Volume I accessible to Anglophone readers &mdash; but only the experimental content, stripped of its metaphysical context.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
@@ -262,7 +260,7 @@ export default function FechnerBohmePage() {
                 <td className="py-3 px-4"><Link href="/book/699062f0ef12272ffdc8e403" className="text-accent-rust hover:text-accent-rust underline"><em>Elemente der Psychophysik</em> I</Link> &amp; <Link href="/book/699062f2ef12272ffdc8e789" className="text-accent-rust hover:text-accent-rust underline">II</Link></td>
                 <td className="py-3 px-4">1860</td>
                 <td className="py-3 px-4">The founding text of experimental psychology</td>
-                <td className="py-3 px-4"><Link href="/book/6992cbf9018b80967354c7b7" className="text-accent-rust hover:text-accent-rust underline">Vol. I only</Link></td>
+                <td className="py-3 px-4">Vol. I only</td>
               </tr>
               <tr className="border-b border-stone-200">
                 <td className="py-3 px-4"><Link href="/book/6992cbcc018b80967354b218" className="text-accent-rust hover:text-accent-rust underline"><em>&Uuml;ber die Seelenfrage</em></Link></td>
@@ -348,7 +346,7 @@ export default function FechnerBohmePage() {
             {' '}&mdash; B&ouml;hme&apos;s spiritual practice
           </li>
           <li>
-            <Link href="/book/697c8e0f6000fdec2f130604" className="text-accent-rust hover:text-accent-rust underline"><em>Von der Genaden-Wahl</em></Link>
+            <Link href="/book/697b0799fe56d93a87bdc790" className="text-accent-rust hover:text-accent-rust underline"><em>Von der Genaden-Wahl</em></Link>
             {' '}&mdash; on the election of grace
           </li>
           <li>

--- a/src/app/blog/fire-horse/page.tsx
+++ b/src/app/blog/fire-horse/page.tsx
@@ -124,10 +124,8 @@ export default function FireHorsePage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          Source Library holds seven editions of the I Ching, from{' '}
+          Source Library holds multiple editions of the I Ching, from{' '}
           <Link href="/book/6953e27477f38f6761be8d28" className="text-accent-rust hover:text-accent-rust underline">James Legge&apos;s 1882 English translation</Link>
-          {' '}and{' '}
-          <Link href="/book/6990653a726f64800c10a225" className="text-accent-rust hover:text-accent-rust underline">Richard Wilhelm&apos;s German edition</Link>
           {' '}to three Chinese originals, including a{' '}
           <Link href="/book/6992c92869b777d72c763513" className="text-accent-rust hover:text-accent-rust underline">64-hexagram illustrated diagram set</Link>
           {' '}and a{' '}
@@ -252,14 +250,12 @@ export default function FireHorsePage() {
         <h3 className="text-xl text-primary mt-10 mb-4">The I Ching</h3>
 
         <p className="text-secondary leading-relaxed mb-6">
-          Seven editions span the collection &mdash; from{' '}
+          Multiple editions span the collection &mdash; from{' '}
           <Link href="/book/6992c92869b777d72c763513" className="text-accent-rust hover:text-accent-rust underline">original Chinese hexagram diagrams</Link>
           {' '}and{' '}
-          <Link href="/book/6992cb54d4d545ae73feef31" className="text-accent-rust hover:text-accent-rust underline"><em>Zhou Yi Xixin</em> (Cleansing the Heart through the Book of Changes)</Link>
-          {' '}to the landmark English translations by{' '}
+          <Link href="/book/6992cb54d4d545ae73feefd4" className="text-accent-rust hover:text-accent-rust underline"><em>Zhou Yi Xixin</em> (Cleansing the Heart through the Book of Changes)</Link>
+          {' '}to the landmark English translation by{' '}
           <Link href="/book/6953e27477f38f6761be8d28" className="text-accent-rust hover:text-accent-rust underline">Legge (1882)</Link>
-          {' '}and{' '}
-          <Link href="/book/6990653a726f64800c10a225" className="text-accent-rust hover:text-accent-rust underline">Wilhelm</Link>
           . The Chinese originals preserve notation and commentary that no translation can fully convey &mdash; the visual structure of the hexagrams, the interlinear glosses, the layers of commentary accumulated over centuries.
         </p>
 
@@ -279,18 +275,16 @@ export default function FireHorsePage() {
           These astrological texts sit within a larger collection of Chinese source material: the{' '}
           <Link href="/book/695924fa1cac2ce31a4a8a33" className="text-accent-rust hover:text-accent-rust underline">Daozang (道藏, Taoist Canon)</Link>
           , the{' '}
-          <Link href="/book/699249eda2d53df4853c123d" className="text-accent-rust hover:text-accent-rust underline">Analects of Confucius</Link>
+          <Link href="/book/69e8b24d2ff2a8dc09e77295" className="text-accent-rust hover:text-accent-rust underline">Analects of Confucius</Link>
           {' '}(in both{' '}
           <Link href="/book/697a30536dc6ae6bd18cd1e1" className="text-accent-rust hover:text-accent-rust underline">the 1687 Latin Jesuit translation</Link>
           {' '}and modern English), the{' '}
-          <Link href="/book/6990659a3dc2ed39a49f1e7b" className="text-accent-rust hover:text-accent-rust underline">Huang Di Nei Jing (Yellow Emperor&apos;s Classic of Internal Medicine)</Link>
+          <Link href="/book/6992ca85d4d545ae73fee420" className="text-accent-rust hover:text-accent-rust underline">Huang Di Nei Jing (Yellow Emperor&apos;s Classic of Internal Medicine)</Link>
           , the{' '}
-          <Link href="/book/699065663dc2ed39a49f0c60" className="text-accent-rust hover:text-accent-rust underline">Tao Te Ching</Link>
+          <Link href="/book/69935b692c63944063133f67" className="text-accent-rust hover:text-accent-rust underline">Tao Te Ching</Link>
           , the{' '}
-          <Link href="/book/6990656b3dc2ed39a49f0f07" className="text-accent-rust hover:text-accent-rust underline">Zhuangzi</Link>
-          , and the{' '}
-          <Link href="/book/695363bc77f38f6761bcddfa" className="text-accent-rust hover:text-accent-rust underline">Secret of the Golden Flower</Link>
-          . Together, they constitute a philosophical tradition in which astrology, medicine, politics, ethics, and metaphysics are not separate disciplines but facets of a single cosmological vision.
+          <Link href="/book/69935b6c2c6394406313403a" className="text-accent-rust hover:text-accent-rust underline">Zhuangzi</Link>
+          , and the <em>Secret of the Golden Flower</em>. Together, they constitute a philosophical tradition in which astrology, medicine, politics, ethics, and metaphysics are not separate disciplines but facets of a single cosmological vision.
         </p>
 
         <div className="overflow-x-auto mb-8">

--- a/src/app/blog/history-of-astrology/page.tsx
+++ b/src/app/blog/history-of-astrology/page.tsx
@@ -114,8 +114,8 @@ export default function HistoryOfAstrologyPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          The clearest evidence of this transmission is one of the stranger books in Source Library:{' '}
-          <Link href="/book/6990670d249ce014347d2594" className="text-accent-rust hover:text-accent-rust underline">the <em>Vriddha Yavanajataka</em></Link>
+          The clearest evidence of this transmission is one of the stranger texts in the tradition:
+          the <em>Vriddha Yavanajataka</em>
           {' '}(&ldquo;The Old Greek Horoscopy&rdquo;), a Sanskrit text attributed to Mīnarāja. The title is its own thesis: &ldquo;Old Greek Horoscopy.&rdquo; This is an Indian author explicitly acknowledging a Greek source tradition &mdash; <em>Yavana</em> being the Sanskrit word for Greek (derived from &ldquo;Ionian&rdquo;). The text transmits Hellenistic horoscopic techniques in Sanskrit verse, adapted to Indian conventions. It is one of the clearest surviving documents of what historians of science call the &ldquo;Hellenistic transmission&rdquo; to India.
         </p>
 
@@ -434,11 +434,6 @@ export default function HistoryOfAstrologyPage() {
                 <li>
                   <Link href="/book/69905f4440bc3a0478efb9b2" className="text-accent-rust hover:text-accent-rust text-sm">
                     Varahamihira, <em>Brihat Jataka</em> (966 CE)
-                  </Link>
-                </li>
-                <li>
-                  <Link href="/book/6990670d249ce014347d2594" className="text-accent-rust hover:text-accent-rust text-sm">
-                    Mīnarāja, <em>Vriddha Yavanajataka</em> (&ldquo;Old Greek Horoscopy&rdquo;)
                   </Link>
                 </li>
                 <li>

--- a/src/app/blog/history-of-classification/page.tsx
+++ b/src/app/blog/history-of-classification/page.tsx
@@ -108,7 +108,7 @@ export default function HistoryOfClassificationPage() {
 
         <p className="text-secondary leading-relaxed mb-6">
           Before anyone classified <em>books</em>, Aristotle classified <em>reality</em>. His{' '}
-          <Link href="/book/works-of-aristotle-vol-1-organon-categories-de-smith" className="text-accent-rust hover:underline">
+          <Link href="/book/aristotelis-opera-vol-1-organon-aristotle" className="text-accent-rust hover:underline">
             <em>Categories</em>
           </Link>{' '}
           (part of the <Link href="/book/aristotelis-opera-omnia-greek-aristotle" className="text-accent-rust hover:underline"><em>Organon</em></Link>,
@@ -126,7 +126,7 @@ export default function HistoryOfClassificationPage() {
 
         <p className="text-secondary leading-relaxed mb-12">
           We hold multiple Aristotle editions including a{' '}
-          <Link href="/book/vat-gr-244-aristotle" className="text-accent-rust hover:underline">Vatican Greek manuscript (Vat.gr.244)</Link>,
+          <Link href="/book/vat-gr-243-aristotle" className="text-accent-rust hover:underline">Vatican Greek manuscript (Vat.gr.243)</Link>,
           a{' '}
           <Link href="/book/bodleian-library-ms-barocci-87-aristotle" className="text-accent-rust hover:underline">Bodleian manuscript (MS Barocci 87)</Link>,
           and the{' '}
@@ -143,10 +143,10 @@ export default function HistoryOfClassificationPage() {
         <p className="text-secondary leading-relaxed mb-6">
           Six centuries later, the Neoplatonist Porphyry wrote a short introduction to Aristotle&rsquo;s
           <em>Categories</em> that became more influential than the original. The{' '}
-          <Link href="/book/porphyrii-introductio-ammonii-procli-diadochi-commentarii-porphyry" className="text-accent-rust hover:underline">
+          <Link href="/book/porphyry-isagoge-neoplatonic-commentaries-proclus-ammonius-ammonius" className="text-accent-rust hover:underline">
             <em>Isagoge</em>
           </Link>{' '}
-          (which we have in a 1000 CE Latin manuscript with Ammonius&rsquo;s commentary)
+          (which we have in a Greek manuscript with the commentaries of Proclus and Ammonius)
           demonstrated classification through binary branching: start with the most general
           category (Substance), then split with a <em>differentia</em>. Corporeal or incorporeal?
           Living or non-living? Rational or irrational?
@@ -173,7 +173,7 @@ export default function HistoryOfClassificationPage() {
         <p className="text-secondary leading-relaxed mb-6">
           While Porphyry classified by <em>type</em>, an anonymous Syrian monk proposed a different
           model. In the{' '}
-          <Link href="/book/pseudo-dionysius-areopagita-ficino-translation" className="text-accent-rust hover:underline">
+          <Link href="/book/celestial-hierarchy-divine-names-ficino-ficino" className="text-accent-rust hover:underline">
             <em>Celestial Hierarchy</em>
           </Link>{' '}
           (Ficino&rsquo;s translation, 140 of 142 pages translated), knowledge is not a tree
@@ -246,7 +246,7 @@ export default function HistoryOfClassificationPage() {
 
         <p className="text-secondary leading-relaxed mb-6">
           The most radical model came from a 13th-century Majorcan mystic. Llull&rsquo;s{' '}
-          <Link href="/book/ars-brevis-cum-approbatione-lullus" className="text-accent-rust hover:underline">
+          <Link href="/book/the-short-art-ars-brevis-lull" className="text-accent-rust hover:underline">
             <em>Ars Brevis</em>
           </Link>{' '}
           proposed that knowledge is not a tree at all. Instead, it emerges from the <strong>combination
@@ -269,10 +269,10 @@ export default function HistoryOfClassificationPage() {
 
         <p className="text-secondary leading-relaxed mb-12">
           Athanasius Kircher expanded this in{' '}
-          <Link href="/book/kircher-ars-magna-sciendi-1669" className="text-accent-rust hover:underline">
+          <Link href="/book/kircher-ars-magna-sciendi-1669-kircher" className="text-accent-rust hover:underline">
             <em>Ars Magna Sciendi</em>
           </Link>{' '}
-          (1669, 93 of 532 pages translated), adding a question dimension: each letter maps to
+          (1669, 532 pages, fully translated), adding a question dimension: each letter maps to
           Whether? What? Of what? Why? How much? When? Where? How?
         </p>
 
@@ -282,17 +282,12 @@ export default function HistoryOfClassificationPage() {
         </h2>
 
         <p className="text-secondary leading-relaxed mb-6">
-          Peter Ramus&rsquo;s{' '}
-          <Link href="/book/dialecticae-institutiones-ramus" className="text-accent-rust hover:underline">
-            <em>Dialecticae Institutiones</em>
-          </Link>{' '}
-          (1543, 320 pages) proposed replacing Aristotelian logic with <strong>dichotomous
+          Peter Ramus&rsquo;s <em>Dialecticae Institutiones</em>{' '}
+          (1543) proposed replacing Aristotelian logic with <strong>dichotomous
           division</strong>: take any subject, split it into two, split each part into two, repeat.
           Where Porphyry&rsquo;s tree was metaphysical, Ramus&rsquo;s was pedagogical &mdash; not classifying
           reality but organizing <em>how to teach</em> it. These &ldquo;Ramist tables&rdquo; conquered
-          Protestant education across Europe and, crucially, crossed the Atlantic. We have{' '}
-          <Link href="/book/p-rami-dialectica-ramus" className="text-accent-rust hover:underline">nine Ramus texts</Link> in
-          the collection, all untranslated.
+          Protestant education across Europe and, crucially, crossed the Atlantic.
         </p>
 
         <p className="text-secondary leading-relaxed mb-12">
@@ -313,7 +308,7 @@ export default function HistoryOfClassificationPage() {
 
         <p className="text-secondary leading-relaxed mb-6">
           Francis Bacon&rsquo;s{' '}
-          <Link href="/book/de-augmentis-scientiarum-bacon" className="text-accent-rust hover:underline">
+          <Link href="/book/the-advancement-of-learning-bacon" className="text-accent-rust hover:underline">
             <em>De Augmentis Scientiarum</em>
           </Link>{' '}
           (fully translated, 696 pages) grounded classification in <strong>the cognitive operations
@@ -376,7 +371,7 @@ export default function HistoryOfClassificationPage() {
 
         <p className="text-secondary leading-relaxed mb-6">
           Comenius argued in{' '}
-          <Link href="/book/naturall-philosophie-reformed" className="text-accent-rust hover:underline">
+          <Link href="/book/naturall-philosophie-reformed-by-divine-light-1651-comenius" className="text-accent-rust hover:underline">
             <em>Naturall Philosophie Reformed by Divine Light</em>
           </Link>{' '}
           (308 pages, fully translated) that classification <strong>is</strong> curriculum. You learn
@@ -389,11 +384,8 @@ export default function HistoryOfClassificationPage() {
           A century later, this idea crossed the Atlantic. Samuel Johnson (1696&ndash;1772) &mdash;
           not the English lexicographer, but the first president of King&rsquo;s College (now Columbia) &mdash;
           created an <em>Encyclopaedia of Philosophy</em> that organized all knowledge into Ramist-style
-          dichotomous trees blended with Lockean empiricism. Published in his{' '}
-          <Link href="/book/samuel-johnson-president-of-kings-college-his-career-and-schneider" className="text-accent-rust hover:underline">
-            <em>Career and Writings</em>
-          </Link>{' '}
-          (3 volumes, ~1,700 pages), it became a textbook at King&rsquo;s College and shaped how the
+          dichotomous trees blended with Lockean empiricism. Published in his collected
+          <em> Career and Writings</em>, it became a textbook at King&rsquo;s College and shaped how the
           colonial generation organized knowledge.
         </p>
 
@@ -419,19 +411,17 @@ export default function HistoryOfClassificationPage() {
           in 1735 &mdash; just 21 pages in the first edition, but it contained the most successful
           classification system ever created. <strong>Binomial nomenclature</strong> (Kingdom &rarr;
           Phylum &rarr; Class &rarr; Order &rarr; Family &rarr; Genus &rarr; Species) is Porphyry&rsquo;s
-          tree made operational for biology. It&rsquo;s still in use 290 years later. We hold the{' '}
-          <Link href="/book/caroli-linn-i-systema-natur-per-regna-tria-natur-secundum-linne" className="text-accent-rust hover:underline">
-            expanded 1,417-page <em>Systema Naturae</em>
+          tree made operational for biology. It&rsquo;s still in use 290 years later. We hold the
+          1735 first edition and several companion works, including Linnaeus&rsquo;s{' '}
+          <Link href="/book/carl-linnaeus-hortus-cliffortianus-1737-linnaeus" className="text-accent-rust hover:underline">
+            <em>Hortus Cliffortianus</em>
           </Link>{' '}
-          and several companion works.
+          (1737).
         </p>
 
         <p className="text-secondary leading-relaxed mb-12">
           In 1751, Diderot and d&rsquo;Alembert published the first volume of the{' '}
-          <Link href="/book/encyclopedie-d-alembert" className="text-accent-rust hover:underline">
-            <em>Encyclop&eacute;die</em>
-          </Link>{' '}
-          (976 pages in our collection). Its famous &ldquo;Syst&egrave;me Figur&eacute; des
+          <em>Encyclop&eacute;die</em>. Its famous &ldquo;Syst&egrave;me Figur&eacute; des
           Connaissances Humaines&rdquo; diagram &mdash; viewable in the{' '}
           <ExtLink href="https://encyclopedie.uchicago.edu/content/syst%C3%A8me-figur%C3%A9-des-connaissances-humaines">
             ARTFL Encyclop&eacute;die Project
@@ -692,35 +682,29 @@ export default function HistoryOfClassificationPage() {
             translated. External links point to the best available digital editions.
           </p>
           <div className="flex flex-wrap gap-x-3 gap-y-1 text-sm">
-            <Link href="/book/works-of-aristotle-vol-1-organon-categories-de-smith" className="text-accent-rust hover:underline">Aristotle, Categories</Link>
+            <Link href="/book/aristotelis-opera-vol-1-organon-aristotle" className="text-accent-rust hover:underline">Aristotle, Categories</Link>
             <span className="text-stone-300">&middot;</span>
-            <Link href="/book/porphyrii-introductio-ammonii-procli-diadochi-commentarii-porphyry" className="text-accent-rust hover:underline">Porphyry, Isagoge</Link>
+            <Link href="/book/porphyry-isagoge-neoplatonic-commentaries-proclus-ammonius-ammonius" className="text-accent-rust hover:underline">Porphyry, Isagoge</Link>
             <span className="text-stone-300">&middot;</span>
-            <Link href="/book/pseudo-dionysius-areopagita-ficino-translation" className="text-accent-rust hover:underline">Pseudo-Dionysius, Celestial Hierarchy</Link>
+            <Link href="/book/celestial-hierarchy-divine-names-ficino-ficino" className="text-accent-rust hover:underline">Pseudo-Dionysius, Celestial Hierarchy</Link>
             <span className="text-stone-300">&middot;</span>
             <Link href="/book/sancai-tuhui-illustrated-encyclopedia-of-the-three-realms" className="text-accent-rust hover:underline">Sancai Tuhui (Chinese Encyclopedia)</Link>
             <span className="text-stone-300">&middot;</span>
-            <Link href="/book/ars-brevis-cum-approbatione-lullus" className="text-accent-rust hover:underline">Llull, Ars Brevis</Link>
+            <Link href="/book/the-short-art-ars-brevis-lull" className="text-accent-rust hover:underline">Llull, Ars Brevis</Link>
             <span className="text-stone-300">&middot;</span>
-            <Link href="/book/kircher-ars-magna-sciendi-1669" className="text-accent-rust hover:underline">Kircher, Ars Magna Sciendi</Link>
-            <span className="text-stone-300">&middot;</span>
-            <Link href="/book/dialecticae-institutiones-ramus" className="text-accent-rust hover:underline">Ramus, Dialecticae Institutiones</Link>
+            <Link href="/book/kircher-ars-magna-sciendi-1669-kircher" className="text-accent-rust hover:underline">Kircher, Ars Magna Sciendi</Link>
             <span className="text-stone-300">&middot;</span>
             <Link href="/book/bibliotheca-universalis-gessner" className="text-accent-rust hover:underline">Gessner, Bibliotheca Universalis</Link>
             <span className="text-stone-300">&middot;</span>
-            <Link href="/book/de-augmentis-scientiarum-bacon" className="text-accent-rust hover:underline">Bacon, De Augmentis Scientiarum</Link>
+            <Link href="/book/the-advancement-of-learning-bacon" className="text-accent-rust hover:underline">Bacon, De Augmentis Scientiarum</Link>
             <span className="text-stone-300">&middot;</span>
             <Link href="/book/die-philosophischen-schriften-vol-7-leibniz" className="text-accent-rust hover:underline">Leibniz, Philosophical Writings VII</Link>
             <span className="text-stone-300">&middot;</span>
             <Link href="/book/the-posthumous-works-of-robert-hooke-hooke" className="text-accent-rust hover:underline">Hooke, Posthumous Works</Link>
             <span className="text-stone-300">&middot;</span>
-            <Link href="/book/naturall-philosophie-reformed" className="text-accent-rust hover:underline">Comenius, Naturall Philosophie Reformed</Link>
-            <span className="text-stone-300">&middot;</span>
-            <Link href="/book/samuel-johnson-president-of-kings-college-his-career-and-schneider" className="text-accent-rust hover:underline">Samuel Johnson, Career and Writings</Link>
+            <Link href="/book/naturall-philosophie-reformed-by-divine-light-1651-comenius" className="text-accent-rust hover:underline">Comenius, Naturall Philosophie Reformed</Link>
             <span className="text-stone-300">&middot;</span>
             <Link href="/book/carl-linnaeus-systema-naturae-1735-linnaeus" className="text-accent-rust hover:underline">Linnaeus, Systema Naturae (1735)</Link>
-            <span className="text-stone-300">&middot;</span>
-            <Link href="/book/encyclopedie-d-alembert" className="text-accent-rust hover:underline">Diderot, Encyclopedie</Link>
           </div>
           <div className="flex flex-wrap gap-x-3 gap-y-1 text-sm mt-3">
             <span className="text-stone-400 text-xs">External:</span>

--- a/src/app/blog/hogwarts-library/page.tsx
+++ b/src/app/blog/hogwarts-library/page.tsx
@@ -287,13 +287,8 @@ export default function HogwartsLibraryPage() {
             (&ldquo;Garden of Health&rdquo;), Mainz, 1491 &mdash; a proto-encyclopaedia that catalogues
             every plant, animal, bird, fish, and stone known to its compiler, with woodcuts that read
             like the inventory of <em>Fantastic Beasts and Where to Find Them</em>. The first English
-            herbal a working witch or wizard would reach for is{' '}
-            <Link
-              href="/book/the-herball-or-generall-historie-of-plantes-gerard"
-              className="text-accent-rust hover:underline"
-            >
-              John Gerard&rsquo;s <em>Herball</em>
-            </Link>{' '}
+            herbal a working witch or wizard would reach for is
+            John Gerard&rsquo;s <em>Herball</em>{' '}
             (1597). Nicholas Culpeper&rsquo;s{' '}
             <Link href="/book/the-english-physitian-enlarged-culpeper" className="text-accent-rust hover:underline">
               <em>English Physitian</em>

--- a/src/app/blog/indigenous-traditions/page.tsx
+++ b/src/app/blog/indigenous-traditions/page.tsx
@@ -73,21 +73,15 @@ export default function IndigenousTraditionsPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          These are supplemented by Gladys Reichard&apos;s{' '}
-          <Link href="/book/699259693d2d40d1b058dd6d" className="text-accent-rust hover:text-accent-rust underline"><em>Navaho Religion: A Study of Symbolism</em></Link>
-          , a mid-20th-century synthesis that remains the standard scholarly treatment of Navajo religious thought as a coherent system &mdash; one in which every colour, direction, plant, and animal participates in a web of symbolic relationships that the ceremonies activate and maintain.
+          These are supplemented by Gladys Reichard&apos;s <em>Navaho Religion: A Study of Symbolism</em>, a mid-20th-century synthesis that remains the standard scholarly treatment of Navajo religious thought as a coherent system &mdash; one in which every colour, direction, plant, and animal participates in a web of symbolic relationships that the ceremonies activate and maintain.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
           For the Hopi, the collection holds{' '}
           <Link href="/book/699249b3a2d53df4853beb43" className="text-accent-rust hover:text-accent-rust underline"><em>The Traditions of the Hopi</em></Link>
-          {' '}(H. R. Voth) and{' '}
-          <Link href="/book/699249b8a2d53df4853beede" className="text-accent-rust hover:text-accent-rust underline"><em>Truth of a Hopi</em></Link>
-          {' '}(Edmund Nequatewa) &mdash; the latter notable as a Hopi author&apos;s own account, a corrective to the outsider&apos;s perspective. For the Zuni, Frank Hamilton Cushing&apos;s{' '}
-          <Link href="/book/6992596e3d2d40d1b058e957" className="text-accent-rust hover:text-accent-rust underline"><em>Zuni Fetishes</em></Link>
-          ,{' '}
-          <Link href="/book/699259743d2d40d1b058f0c3" className="text-accent-rust hover:text-accent-rust underline"><em>Zuni Folk Tales</em></Link>
-          , and{' '}
+          {' '}(H. R. Voth) and Edmund Nequatewa&apos;s <em>Truth of a Hopi</em> &mdash; the latter notable as a Hopi author&apos;s own account, a corrective to the outsider&apos;s perspective. For the Zuni, Frank Hamilton Cushing&apos;s{' '}
+          <Link href="/book/69a565b95a8a09c1b325e47f" className="text-accent-rust hover:text-accent-rust underline"><em>Zuni Fetishes</em></Link>
+          {' '}and{' '}
           <Link href="/book/6992597c3d2d40d1b058fa83" className="text-accent-rust hover:text-accent-rust underline"><em>Zuni Breadstuff</em></Link>
           {' '}document a tradition in which the sacred is embedded in every aspect of daily life &mdash; agriculture, craft, architecture, and ceremony forming an indivisible whole.
         </p>
@@ -95,8 +89,7 @@ export default function IndigenousTraditionsPage() {
         <h3 className="text-xl text-primary mt-10 mb-4">The Plains: Sioux, Pawnee, Arapaho</h3>
 
         <p className="text-secondary leading-relaxed mb-6">
-          <Link href="/book/6992595a3d2d40d1b058d304" className="text-accent-rust hover:text-accent-rust underline"><em>Black Elk Speaks</em></Link>
-          {' '}(1932) is probably the most famous Native American spiritual text in English &mdash; the Oglala Lakota holy man&apos;s account of his Great Vision, the Ghost Dance, and the destruction of his people&apos;s way of life. John G. Neihardt shaped the narrative, and the degree to which the published text reflects Black Elk&apos;s own voice has been debated for decades. But the power of the vision &mdash; the sacred hoop of the nation, the flowering tree at the centre of the world, the six grandfathers &mdash; is undeniable.
+          <em>Black Elk Speaks</em> (1932) is probably the most famous Native American spiritual text in English &mdash; the Oglala Lakota holy man&apos;s account of his Great Vision, the Ghost Dance, and the destruction of his people&apos;s way of life. John G. Neihardt shaped the narrative, and the degree to which the published text reflects Black Elk&apos;s own voice has been debated for decades. But the power of the vision &mdash; the sacred hoop of the nation, the flowering tree at the centre of the world, the six grandfathers &mdash; is undeniable.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
@@ -121,7 +114,7 @@ export default function IndigenousTraditionsPage() {
           The collection spans the continent. For the Cherokee, James Mooney&apos;s{' '}
           <Link href="/book/69907c3b5f855ec553e723bb" className="text-accent-rust hover:text-accent-rust underline"><em>Myths of the Cherokee</em></Link>
           {' '}and the{' '}
-          <Link href="/book/699249ada2d53df4853be569" className="text-accent-rust hover:text-accent-rust underline"><em>Cherokee Sacred Formulas (Swimmer Manuscript)</em></Link>
+          <Link href="/book/69a55355bab4924e15759949" className="text-accent-rust hover:text-accent-rust underline"><em>Sacred Formulas of the Cherokees</em></Link>
           {' '}preserve healing chants in the Cherokee syllabary &mdash; one of the few cases where an indigenous writing system was used to record sacred knowledge. For the Iroquois,{' '}
           <Link href="/book/699249bea2d53df4853bf40c" className="text-accent-rust hover:text-accent-rust underline"><em>The Iroquois Book of Rites</em></Link>
           {' '}(Horatio Hale) documents the condolence ceremonies of the Six Nations &mdash; the ritual core of the oldest continuous democratic confederation in the Americas.
@@ -129,10 +122,8 @@ export default function IndigenousTraditionsPage() {
 
         <p className="text-secondary leading-relaxed mb-6">
           Henry Rowe Schoolcraft&apos;s{' '}
-          <Link href="/book/69907ad35df68efe400d8f3e" className="text-accent-rust hover:text-accent-rust underline"><em>Algic Researches</em></Link>
-          {' '}(1839) was the first systematic collection of Native American oral literature in English &mdash; the Ojibwe and Ottawa stories that inspired Longfellow&apos;s <em>Hiawatha</em>. The{' '}
-          <Link href="/book/699249a0a2d53df4853bd8ae" className="text-accent-rust hover:text-accent-rust underline"><em>Walam Olum</em></Link>
-          {' '}(Daniel G. Brinton) claims to be the Lenape creation narrative recorded in pictographs &mdash; a contested document whose authenticity has been debated for over a century, but which remains an important artefact of 19th-century attempts to understand indigenous cosmology.
+          <Link href="/book/69e719750b32e23d63bf76a3" className="text-accent-rust hover:text-accent-rust underline"><em>Algic Researches</em></Link>
+          {' '}(1839) was the first systematic collection of Native American oral literature in English &mdash; the Ojibwe and Ottawa stories that inspired Longfellow&apos;s <em>Hiawatha</em>. The <em>Walam Olum</em> (Daniel G. Brinton) claims to be the Lenape creation narrative recorded in pictographs &mdash; a contested document whose authenticity has been debated for over a century, but which remains an important artefact of 19th-century attempts to understand indigenous cosmology.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
@@ -169,14 +160,11 @@ export default function IndigenousTraditionsPage() {
         <p className="text-secondary leading-relaxed mb-6">
           The most important survivor is the{' '}
           <Link href="/book/6992499aa2d53df4853bd50d" className="text-accent-rust hover:text-accent-rust underline"><em>Popol Vuh</em></Link>
-          , the K&apos;iche&apos; Maya creation epic, which tells the story of the Hero Twins&apos; descent into Xibalba, the underworld, and the creation of humanity from maize. Source Library holds Lewis Spence&apos;s English edition and{' '}
-          <Link href="/book/69924997a2d53df4853bd36f" className="text-accent-rust hover:text-accent-rust underline">Brasseur de Bourbourg&apos;s French-K&apos;iche&apos; bilingual edition</Link>
-          , which was the first scholarly publication of the text (1861) and remains philologically important.
+          , the K&apos;iche&apos; Maya creation epic, which tells the story of the Hero Twins&apos; descent into Xibalba, the underworld, and the creation of humanity from maize. Source Library holds Lewis Spence&apos;s English edition; Brasseur de Bourbourg&apos;s French-K&apos;iche&apos; bilingual edition of 1861, the first scholarly publication of the text, remains philologically important.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          For the Aztec world,{' '}
-          <Link href="/book/6992499ea2d53df4853bd7ae" className="text-accent-rust hover:text-accent-rust underline"><em>History and Mythology of the Aztecs: Codex Chimalpopoca</em></Link>
+          For the Aztec world, the <em>Codex Chimalpopoca</em>
           {' '}preserves two Nahuatl texts: the <em>Annals of Cuauhtitl&aacute;n</em> and the <em>Legend of the Suns</em>, which contain the Aztec creation mythology &mdash; the five ages of the world, each destroyed and remade. The{' '}
           <Link href="/book/6953cbc877f38f6761be004a" className="text-accent-rust hover:text-accent-rust underline"><em>Codex Nuttall</em></Link>
           {' '}is a pre-Columbian Mixtec screenfold manuscript, one of the few surviving original books from the Americas before European contact. The{' '}
@@ -212,15 +200,13 @@ export default function IndigenousTraditionsPage() {
 
         <p className="text-secondary leading-relaxed mb-6">
           Robert Sutherland Rattray&apos;s{' '}
-          <Link href="/book/69907a10db8b55d19ec68e8a" className="text-accent-rust hover:text-accent-rust underline"><em>Ashanti</em></Link>
-          {' '}and{' '}
-          <Link href="/book/69907a14db8b55d19ec68ef0" className="text-accent-rust hover:text-accent-rust underline"><em>Religion and Art in Ashanti</em></Link>
-          {' '}are among the finest ethnographic works of the early 20th century. Rattray, a colonial administrator who became a genuine scholar of Ashanti culture, documented a religious system of extraordinary complexity &mdash; the <em>sunsum</em> (spirit), <em>kra</em> (soul), <em>ntoro</em> (patrilineal spirit), and <em>mogya</em> (matrilineal blood) forming a multi-layered anthropology of the person that most Western psychology has yet to equal.
+          <Link href="/book/69a552ed9760c5efd612058b" className="text-accent-rust hover:text-accent-rust underline"><em>Ashanti</em></Link>
+          {' '}and <em>Religion and Art in Ashanti</em> are among the finest ethnographic works of the early 20th century. Rattray, a colonial administrator who became a genuine scholar of Ashanti culture, documented a religious system of extraordinary complexity &mdash; the <em>sunsum</em> (spirit), <em>kra</em> (soul), <em>ntoro</em> (patrilineal spirit), and <em>mogya</em> (matrilineal blood) forming a multi-layered anthropology of the person that most Western psychology has yet to equal.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
           Mary Kingsley&apos;s{' '}
-          <Link href="/book/699079d6db8b55d19ec67fb6" className="text-accent-rust hover:text-accent-rust underline"><em>West African Studies</em></Link>
+          <Link href="/book/69a552e542054c7ce7176515" className="text-accent-rust hover:text-accent-rust underline"><em>West African Studies</em></Link>
           {' '}and{' '}
           <Link href="/book/69907c5f5f855ec553e74b98" className="text-accent-rust hover:text-accent-rust underline"><em>Travels in West Africa</em></Link>
           {' '}offer a more personal account. Kingsley was one of the first Europeans to argue that African religious systems were genuine philosophies, not &ldquo;superstition&rdquo; &mdash; a position that was radical in the 1890s.
@@ -246,8 +232,7 @@ export default function IndigenousTraditionsPage() {
 
         <p className="text-secondary leading-relaxed mb-6">
           Source Library holds the core texts of the Welsh and Irish mythological traditions.{' '}
-          <Link href="/book/699249c0a2d53df4853bfb8e" className="text-accent-rust hover:text-accent-rust underline"><em>The Mabinogion</em></Link>
-          {' '}(Lady Charlotte Guest&apos;s translation) collects the Four Branches &mdash; tales of Pwyll, Branwen, Manawydan, and Math &mdash; which are the Welsh equivalent of the Homeric epics: the stories that encode a civilisation&apos;s deepest understanding of sovereignty, the otherworld, transformation, and the obligations between the human and the divine.
+          <em>The Mabinogion</em> collects the Four Branches &mdash; tales of Pwyll, Branwen, Manawydan, and Math &mdash; which are the Welsh equivalent of the Homeric epics: the stories that encode a civilisation&apos;s deepest understanding of sovereignty, the otherworld, transformation, and the obligations between the human and the divine.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
@@ -267,8 +252,7 @@ export default function IndigenousTraditionsPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          <Link href="/book/699249c9a2d53df4853bff47" className="text-accent-rust hover:text-accent-rust underline"><em>The Fairy-Faith in Celtic Countries</em></Link>
-          {' '}by W. Y. Evans-Wentz deserves special mention. Evans-Wentz &mdash; who would later become the first English translator of the <em>Tibetan Book of the Dead</em> &mdash; conducted fieldwork in Ireland, Scotland, Wales, Cornwall, Brittany, and the Isle of Man in 1908-1909, interviewing people who still held to the belief in fairies, the s&iacute;dh, and the otherworld. His conclusion was that the &ldquo;fairy faith&rdquo; was not folklore but the survival of pre-Christian Celtic religion &mdash; a thesis that remains influential in Celtic studies.
+          <em>The Fairy-Faith in Celtic Countries</em> by W. Y. Evans-Wentz deserves special mention. Evans-Wentz &mdash; who would later become the first English translator of the <em>Tibetan Book of the Dead</em> &mdash; conducted fieldwork in Ireland, Scotland, Wales, Cornwall, Brittany, and the Isle of Man in 1908-1909, interviewing people who still held to the belief in fairies, the s&iacute;dh, and the otherworld. His conclusion was that the &ldquo;fairy faith&rdquo; was not folklore but the survival of pre-Christian Celtic religion &mdash; a thesis that remains influential in Celtic studies.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
@@ -333,14 +317,12 @@ export default function IndigenousTraditionsPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          Martha Beckwith&apos;s{' '}
-          <Link href="/book/699249dda2d53df4853c0b62" className="text-accent-rust hover:text-accent-rust underline"><em>The Kumulipo: A Hawaiian Creation Chant</em></Link>
-          {' '}translates and annotates the Hawaiian royal genealogical prayer, a 2,000-line poem that traces creation from the emergence of coral polyps and sea creatures through progressively complex life forms to the birth of the Hawaiian ruling lineage. It is simultaneously a creation myth, an evolutionary taxonomy, and a political charter. Nothing quite like it exists in any other tradition.
+          Martha Beckwith&apos;s <em>The Kumulipo: A Hawaiian Creation Chant</em> translates and annotates the Hawaiian royal genealogical prayer, a 2,000-line poem that traces creation from the emergence of coral polyps and sea creatures through progressively complex life forms to the birth of the Hawaiian ruling lineage. It is simultaneously a creation myth, an evolutionary taxonomy, and a political charter. Nothing quite like it exists in any other tradition.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
           For Aboriginal Australia, Baldwin Spencer and F. J. Gillen&apos;s{' '}
-          <Link href="/book/69907a2adb8b55d19ec691c5" className="text-accent-rust hover:text-accent-rust underline"><em>The Native Tribes of Central Australia</em></Link>
+          <Link href="/book/69a553040aade5c1d01fe95d" className="text-accent-rust hover:text-accent-rust underline"><em>The Native Tribes of Central Australia</em></Link>
           {' '}(1899) remains a foundational text. Their account of the <em>Alcheringa</em> (Dreaming) &mdash; the eternal present in which ancestral beings shaped the land, and which is re-enacted through ceremony &mdash; was the first detailed description of a religious system that challenges Western categories of time, space, and personhood at a fundamental level. The Dreaming is not a past event but an ongoing reality accessed through ritual, song, and the reading of landscape.
         </p>
 

--- a/src/app/blog/invisible-hand/page.tsx
+++ b/src/app/blog/invisible-hand/page.tsx
@@ -132,8 +132,7 @@ export default function InvisibleHandPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          <Link href="/book/6991e7c5c91ce7d733e4fc19" className="text-accent-rust hover:text-accent-rust underline"><strong>Leon Battista Alberti</strong></Link>
-          {' '}(<em>I Libri della Famiglia</em>, c. 1434) codified the Florentine merchant ethic into a treatise on household economy. Book III, on <em>masserizia</em> (thrift, prudent management), describes the ideal that every Florentine banker aspired to &mdash; rational allocation of resources, avoidance of waste, the virtuous accumulation of wealth through industry. This is the domestic counterpart to the commercial world Pegolotti documented.
+          <strong>Leon Battista Alberti</strong> (<em>I Libri della Famiglia</em>, c. 1434) codified the Florentine merchant ethic into a treatise on household economy. Book III, on <em>masserizia</em> (thrift, prudent management), describes the ideal that every Florentine banker aspired to &mdash; rational allocation of resources, avoidance of waste, the virtuous accumulation of wealth through industry. This is the domestic counterpart to the commercial world Pegolotti documented.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
@@ -177,7 +176,7 @@ export default function InvisibleHandPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          <Link href="/book/6991e18b339ebc8509949bf0" className="text-accent-rust hover:text-accent-rust underline"><strong>Mart&iacute;n de Azpilcueta</strong></Link>
+          <Link href="/book/6991e18b339ebc8509949b83" className="text-accent-rust hover:text-accent-rust underline"><strong>Mart&iacute;n de Azpilcueta</strong></Link>
           {' '}(<em>Comentario Resolutorio de Usuras</em>, 1568) formulated the quantity theory of money decades before Jean Bodin usually gets the credit. Watching Spanish prices soar as American silver flooded the markets, Azpilcueta reasoned that money, like any commodity, is worth less where it is abundant. A simple observation with enormous consequences.
         </p>
 
@@ -255,7 +254,7 @@ export default function InvisibleHandPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          <Link href="/book/6991e175b53cae6bb602477b" className="text-accent-rust hover:text-accent-rust underline"><strong>Nicholas Barbon</strong></Link>
+          <Link href="/book/6991e175b53cae6bb602470e" className="text-accent-rust hover:text-accent-rust underline"><strong>Nicholas Barbon</strong></Link>
           {' '}(<em>A Discourse of Trade</em>, 1690) stated the subjective theory of value with startling clarity: &ldquo;the Value of all Wares arises from their Use.&rdquo; Things have no intrinsic value; all value comes from the wants and needs of the user. This directly contradicts the labour theory of value that would mislead economists from Smith through Marx.
         </p>
 

--- a/src/app/blog/philosophers-stone/page.tsx
+++ b/src/app/blog/philosophers-stone/page.tsx
@@ -532,7 +532,7 @@ export default function PhilosophersStonePage() {
             </p>
             <p className="text-sm text-muted">
               <Link
-                href="/book/690c3a0ce0787282ad593939?page=1"
+                href="/book/69819203084978306e4933f6?page=1"
                 className="text-accent-rust hover:underline"
               >
                 The Revealer of the Great Secret, p. 186
@@ -687,7 +687,7 @@ export default function PhilosophersStonePage() {
                 detail: 'Basel, 1571 — systematic laboratory method',
               },
               {
-                href: '/book/690c3a0ce0787282ad593939',
+                href: '/book/69819203084978306e4933f6',
                 title: 'The Revealer of the Great Secret',
                 detail: '1688 — recipe for potable gold and the red powder',
               },


### PR DESCRIPTION
Fixes #2959 (the link inventory filed earlier today).

## What
Every broken `/book/` deep link in the blog is now either **relinked** to a held, publicly visible edition of the same work, or **unlinked** (title kept as plain text) where we hold nothing linkable — with the surrounding 'Source Library holds…' claims corrected to match reality.

## Treatments
- **Relinked (~30)**: near-miss id typos (Barbon `…477b`→`…470e`, Azpilcueta, Zhou Yi Xixin), re-imported copies of deleted books (Revealer of the Great Secret 1688, Algic Researches, Kingsley, Rattray, Spencer & Gillen, Mooney's Sacred Formulas), wrong slug guesses in history-of-classification (Kircher `…-1669-kircher`, Bacon De Augmentis = the 1662 Latin *Advancement of Learning* — 696pp fully translated, exactly as the prose claimed; Comenius 1651; Ficino's *Celestial Hierarchy* — the '140 of 142 pages' claim matches; Llull *Ars Brevis*; Aristotle *Organon* 1495; Porphyry *Isagoge* with Proclus & Ammonius commentaries; Vat.gr.243 for Vat.gr.244), and visible KSTS editions for the chakra tantras (Tantraloka Vol. 1 w/ Jayaratha, Svacchanda Vol. I 1950, Netra Tantra 1926) with page counts and table statuses corrected.
- **Unlinked (~20)**: books deliberately removed in copyright cleanup (Wilhelm's I Ching & *Secret of the Golden Flower*, *Black Elk Speaks*, Watson's *Zhuangzi*, *Truth of a Hopi*, *Kumulipo* 1972, Reichard 1950, Alberti 1994, Fechner 1966 translation, Codex Chimalpopoca 1992) — titles stay as italic text.
- **False-claims removed**: 'nine Ramus texts, all untranslated', 'expanded 1,417-page Systema Naturae', 'Encyclopédie (976 pages in our collection)', Samuel Johnson *Career and Writings*, Brasseur's Popol Vuh — none have a backing record anywhere in the catalog (incl. hidden/draft).

## Verification
- `npx tsc --noEmit` clean.
- All 268 deep links in the 9 touched posts curl-verified against production, grepping bodies for soft-404 markers (HTTP status is useless here — Next soft-404s return 200). Zero broken.

## Out of scope / follow-up finding
While tracing 4 books that exist in Mongo yet 404 on the site (Gerard's *Herball*, *Ars brevis cum Approbatione*, Vat.gr.244, *Fairy-Faith in Celtic Countries*): their Supabase `books_catalog` rows carry `visible:false` while Mongo has `visible` **unset** — the reader's Supabase-first lookup wins and 404s them, contradicting the documented 'visible:null/missing stays public' invariant. Also, books absent from the catalog 404 on **/book/<id>** URLs while their slug URLs render (verified with Svacchanda Vol. I). Both need a separate reconcile/fix — commented on #2959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)