### PR TITLE
blog: restore links to books un-hidden in the visibility-drift reconcile

### DIFF
--- a/src/app/blog/history-of-classification/page.tsx
+++ b/src/app/blog/history-of-classification/page.tsx
@@ -126,7 +126,7 @@ export default function HistoryOfClassificationPage() {
 
         <p className="text-secondary leading-relaxed mb-12">
           We hold multiple Aristotle editions including a{' '}
-          <Link href="/book/vat-gr-243-aristotle" className="text-accent-rust hover:underline">Vatican Greek manuscript (Vat.gr.243)</Link>,
+          <Link href="/book/vat-gr-244-aristotle" className="text-accent-rust hover:underline">Vatican Greek manuscript (Vat.gr.244)</Link>,
           a{' '}
           <Link href="/book/bodleian-library-ms-barocci-87-aristotle" className="text-accent-rust hover:underline">Bodleian manuscript (MS Barocci 87)</Link>,
           and the{' '}

--- a/src/app/blog/hogwarts-library/page.tsx
+++ b/src/app/blog/hogwarts-library/page.tsx
@@ -287,8 +287,13 @@ export default function HogwartsLibraryPage() {
             (&ldquo;Garden of Health&rdquo;), Mainz, 1491 &mdash; a proto-encyclopaedia that catalogues
             every plant, animal, bird, fish, and stone known to its compiler, with woodcuts that read
             like the inventory of <em>Fantastic Beasts and Where to Find Them</em>. The first English
-            herbal a working witch or wizard would reach for is
-            John Gerard&rsquo;s <em>Herball</em>{' '}
+            herbal a working witch or wizard would reach for is{' '}
+            <Link
+              href="/book/the-herball-or-generall-historie-of-plantes-gerard"
+              className="text-accent-rust hover:underline"
+            >
+              John Gerard&rsquo;s <em>Herball</em>
+            </Link>{' '}
             (1597). Nicholas Culpeper&rsquo;s{' '}
             <Link href="/book/the-english-physitian-enlarged-culpeper" className="text-accent-rust hover:underline">
               <em>English Physitian</em>

--- a/src/app/blog/indigenous-traditions/page.tsx
+++ b/src/app/blog/indigenous-traditions/page.tsx
@@ -252,7 +252,7 @@ export default function IndigenousTraditionsPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          <em>The Fairy-Faith in Celtic Countries</em> by W. Y. Evans-Wentz deserves special mention. Evans-Wentz &mdash; who would later become the first English translator of the <em>Tibetan Book of the Dead</em> &mdash; conducted fieldwork in Ireland, Scotland, Wales, Cornwall, Brittany, and the Isle of Man in 1908-1909, interviewing people who still held to the belief in fairies, the s&iacute;dh, and the otherworld. His conclusion was that the &ldquo;fairy faith&rdquo; was not folklore but the survival of pre-Christian Celtic religion &mdash; a thesis that remains influential in Celtic studies.
+          <Link href="/book/the-fairy-faith-in-celtic-countries-evans-wentz" className="text-accent-rust hover:text-accent-rust underline"><em>The Fairy-Faith in Celtic Countries</em></Link> by W. Y. Evans-Wentz deserves special mention. Evans-Wentz &mdash; who would later become the first English translator of the <em>Tibetan Book of the Dead</em> &mdash; conducted fieldwork in Ireland, Scotland, Wales, Cornwall, Brittany, and the Isle of Man in 1908-1909, interviewing people who still held to the belief in fairies, the s&iacute;dh, and the otherworld. His conclusion was that the &ldquo;fairy faith&rdquo; was not folklore but the survival of pre-Christian Celtic religion &mdash; a thesis that remains influential in Celtic studies.
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">


### PR DESCRIPTION
Follow-up to #2960 / #2959.

Derek approved un-hiding the drift class. Applied (data side, already live):
- **1,466 books un-hidden**: Mongo `visible:true, hidden:false` (+`updated_at` bump for the sync) and `books_catalog.visible=true`, with backup at `scripts/output/visibility-drift-2026-07-03.json` in the main checkout. Guarded update (`visible: {$exists: false}` only), counts matched exactly on both stores.
- **Held back** (in `visibility-drift-hold-2026-07-03.json`): 1,660 docs with `hidden:true` + `visible` unset (deliberately hidden artworks needing the OPPOSITE reconcile — `visible:false`) and 21 textual books with explicit year ≥1930 (copyright review).
- Vercel data cache + Cloudflare purged so the cached 404s unstick.

This PR restores the three blog links that #2960 had to degrade because their targets 404'd: Vat.gr.244 (was substituted with Vat.gr.243), Gerard's *Herball*, and *The Fairy-Faith in Celtic Countries*. All three targets verified rendering on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)