### PR TITLE
fix(reader): don't 404 readable books off a stale catalog visible:false

### DIFF
--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -79,6 +79,12 @@ function transformBook(book) {
     pages_translated: book.pages_translated || 0,
     pages_blank: book.pages_blank || 0,
     is_first_translation: book.is_first_translation === true,
+    // LISTING predicate: matches the canonical public-listing filter
+    // (visible: true), so Mongo's unset-visible legacy books collapse to
+    // false here. This is intentionally STRICTER than the reader gate
+    // (book-access.ts hides only an explicit visible === false) — readers
+    // of this row must not treat visible:false as "not readable"; the
+    // /book/[id] lookup falls through to Atlas for that case (issue #2959).
     visible: book.visible === true,
     quality_score: book.quality_score || 0,
     photo: book.photo || null,

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -96,7 +96,14 @@ const getCachedBookLookup = cache(async (id: string): Promise<{
   // Try Supabase first — instant lookup from the books_catalog mirror
   try {
     const catalogResult = await getBookDetail(id);
-    if (catalogResult) {
+    // A catalog row with visible:false is NOT authoritative for the reader.
+    // The catalog's `visible` is the LISTING predicate (mirrored as
+    // `book.visible === true`, so Mongo's unset-visible legacy books collapse
+    // to false), while the reader gate (book-access.ts isHiddenBook) hides
+    // only an explicit Mongo `visible === false`. Trusting the catalog here
+    // 404'd ~3k readable books (issue #2959). Fall through to Atlas and let
+    // the Mongo doc decide — truly hidden books still 404 via isHiddenBook.
+    if (catalogResult && (catalogResult.book as { visible?: boolean | null }).visible !== false) {
       return {
         book: catalogResult.book as unknown as Record<string, unknown>,
         matchedBySlug: catalogResult.matchedBySlug,


### PR DESCRIPTION
Closes the root cause left open on #2959.

## The two-predicate design
`books_catalog.visible` is the **listing** predicate — the sync mirrors it as `book.visible === true`, matching the canonical public-listing filter, so Mongo's unset-visible legacy books (deliberately readable per `book-access.ts`) collapse to `false` in the catalog. The reader's Supabase-first lookup then treated that listing flag as the **readable** predicate and 404'd ~3k readable books; the full-sync cleanup re-writes `visible:false` for any non-listed book, so yesterday's data reconcile alone wouldn't stop the drift re-accumulating.

## Fix
`getCachedBookLookup` no longer trusts a catalog row with `visible === false` — it falls through to Atlas and lets the Mongo doc decide via `isHiddenBook`. The extra Atlas query only runs on the rare hidden-looking path. Also documents the two-predicate design at the sync worker's `visible` mapping (comment only, no behavior change) so the listing semantics don't get "fixed" into breakage.

## Verification (end-to-end on a preview deploy)
Reproduced the drift live with an obscure test book (`via-regia…knittel-2`), catalog row temporarily flipped to `visible:false` while Mongo stayed `visible:true`:
- **preview (this fix): renders** the book
- **prod (current code): "Book Not Found"**
- truly hidden book (`netra-tantra-chaturvedi`, Mongo `visible:false`): still 404s on the preview
- catalog row restored afterwards; the test book's prod ISR entry cached the 404 during the window and will reset on the next prod deploy.

## Retraction
The "by-id 404 for catalog-missing books" claim from the #2959 comments was **my error** — the probed id was a typo (fused two real ids); the slug resolver behaves correctly for nonexistent ids. No code issue there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)