### PR TITLE
fix(licensing): remove false 'CC0 Public Domain' claims (support footer, blog, outreach templates)

### DIFF
--- a/src/app/admin/marketing/page.tsx
+++ b/src/app/admin/marketing/page.tsx
@@ -177,7 +177,7 @@ Key features:
 - Full-text search across all translations
 - Side-by-side original/translation view
 - MCP server integration for AI research tools
-- CC0 public domain licensing
+- Public domain originals; translations CC BY-SA 4.0
 - REST API for programmatic access
 
 We believe Source Library would be a valuable addition to your resource directory. The entire collection is freely accessible with no registration required.
@@ -202,7 +202,7 @@ We've digitized and translated over 1,200 works in the Western esoteric traditio
 - [Relevant text 1 to their research]
 - [Relevant text 2 to their research]
 
-Our translations are generated using multimodal AI (Gemini) with human review, and the entire corpus is available under CC0 public domain licensing for research purposes.
+Our translations are generated using multimodal AI (Gemini) with human review. The original texts are public domain and our translations are CC BY-SA 4.0 — free for research use with attribution.
 
 I'd be happy to:
 - Prioritize specific texts relevant to your research
@@ -226,7 +226,7 @@ Features:
 - Side-by-side original/translation view
 - MCP server for AI assistants
 - REST API access
-- CC0 public domain
+- Free to read & share (public domain originals, CC BY-SA translations)
 
 No registration. No paywall. Just the sources.
 
@@ -259,7 +259,7 @@ I've been working on Source Library (https://sourcelibrary.org), a free digital 
 
 The translations are AI-generated (Gemini) from OCR of the original texts. They're not perfect scholarly editions, but they make these texts accessible for the first time in English.
 
-Everything is CC0 public domain - use however you like.
+The originals are public domain and our translations are CC BY-SA 4.0 - free to use and share with attribution.
 
 Happy to answer questions or take requests for specific texts!`,
   },

--- a/src/app/blog/chakra-tradition/page.tsx
+++ b/src/app/blog/chakra-tradition/page.tsx
@@ -292,7 +292,7 @@ export default function ChakraTraditionPage() {
         </div>
 
         <p className="text-secondary leading-relaxed mb-8">
-          All texts are freely available under CC0. The Sanskrit originals are preserved alongside any translations, and every page links back to its source institution. This is a growing collection &mdash; as we process, translate, and verify these texts, their status will update on the site.
+          All texts are freely readable &mdash; the Sanskrit originals are public domain, and our translations are <Link href="/licensing" className="text-accent-rust hover:text-accent-rust underline">CC BY-SA 4.0</Link>. The originals are preserved alongside any translations, and every page links back to its source institution. This is a growing collection &mdash; as we process, translate, and verify these texts, their status will update on the site.
         </p>
 
         <div className="bg-accent-gold/5 rounded-lg p-6 border border-accent-gold/15 mb-8">

--- a/src/components/donate/SupportView.tsx
+++ b/src/components/donate/SupportView.tsx
@@ -241,7 +241,9 @@ export default function SupportView({ stats, locale = 'en' }: { stats: SupportSt
             <span>&copy; {new Date().getFullYear()} Source Library — Embassy of the Free Mind</span>
             <div className="flex flex-wrap items-center gap-4">
               <Link href={homeHref} className="hover:text-stone-900 transition-colors">{s.home}</Link>
-              <span>CC0 Public Domain</span>
+              <Link href="/licensing" className="hover:text-stone-900 transition-colors">
+                Public domain originals · CC BY-SA translations
+              </Link>
               <a href={`mailto:${CONTACT_EMAIL}`} className="text-accent-rust hover:text-accent-gold-dark transition-colors">
                 {CONTACT_EMAIL}
               </a>


### PR DESCRIPTION
## What

Three user-facing surfaces claimed Source Library content is **CC0 Public Domain** — which waives ALL rights and directly contradicts the actual policy (public-domain originals, **CC BY-SA 4.0** translations, TDM/training rights expressly reserved — see /licensing and issue #2963, where a training rate card is being added on top of exactly these reserved rights).

Fixed:
- `src/components/donate/SupportView.tsx` — /support footer said "CC0 Public Domain"; now "Public domain originals · CC BY-SA translations" linking to /licensing. **This is the surface reported via footer feedback on 2026-07-03** (feedback id 6a482d610df474635a0f8868, "CC0 Public Domain - thats not true"); same footer was flagged 2026-03-29.
- `src/app/blog/chakra-tradition/page.tsx` — "All texts are freely available under CC0" → accurate PD-originals + CC BY-SA statement linking /licensing.
- `src/app/admin/marketing/page.tsx` — four outreach templates told recipients the corpus is "CC0 public domain — use however you like". These are copy templates meant to be sent externally; they now state the real terms. (Admin-only page, but the copy leaves the building.)

## Out of scope (deliberate)

- `/terms` image-license summary + `/about/sources` OPenn note — their CC0 mentions correctly describe **source institutions' image licenses**, not our content. Left as is.
- `src/app/api/[tenant]/books/[id]/pipeline/route.ts` default `license: 'CC0-1.0'` for tenant pipeline config — data-level default, needs its own verification before changing.
- Stale "1,200+ works" counts in the same marketing templates — stat drift, separate concern.
- The rate card + license-propagation work itself: #2963.

## Verification

`npx tsc --noEmit` clean; both edited pages only change static JSX/template strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)