### PR TITLE
ci: blog deep-link checker — PR gate + weekly rot sweep

### DIFF
--- a/.github/workflows/blog-link-check.yml
+++ b/.github/workflows/blog-link-check.yml
@@ -1,0 +1,82 @@
+name: blog-link-check
+
+# Two jobs, one script (scripts/maintenance/check-blog-links.mjs):
+#  - PR: validate deep links in changed blog posts before they ship.
+#  - Weekly sweep: catch rot in ALL posts (books deleted/renamed after
+#    publication — how the 51 dead links in issue #2959 accumulated).
+# HTTP-only against production; no secrets, so it also runs on fork PRs.
+
+on:
+  pull_request:
+    paths:
+      - 'src/app/blog/**'
+  schedule:
+    - cron: '20 6 * * 1' # Mondays 06:20 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  changed-posts:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Check links in changed blog posts
+        run: |
+          FILES=$(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}"...HEAD -- 'src/app/blog/**/page.tsx')
+          if [ -z "$FILES" ]; then
+            echo "No blog page files changed."
+            exit 0
+          fi
+          echo "$FILES"
+          # shellcheck disable=SC2086
+          node scripts/maintenance/check-blog-links.mjs $FILES
+
+  weekly-sweep:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Check all blog links
+        id: check
+        run: |
+          set +e
+          node scripts/maintenance/check-blog-links.mjs --all | tee report.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+      - name: Open/update rot issue
+        if: steps.check.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Blog link rot: weekly sweep found broken deep links"
+          BODY_FILE=issue-body.md
+          {
+            echo "The weekly blog link sweep found broken deep links (soft-404s)."
+            echo
+            echo '```'
+            sed -n '/BROKEN link/,$p' report.txt
+            echo '```'
+            echo
+            echo "Run locally: \`node scripts/maintenance/check-blog-links.mjs --all\`"
+            echo "Playbook: relink to a held edition or unlink (see issue #2959 history)."
+          } > "$BODY_FILE"
+          EXISTING=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file "$BODY_FILE"
+          else
+            gh issue create --title "$TITLE" --label "user-feedback" --body-file "$BODY_FILE"
+          fi
+      - name: Fail job if links broken
+        if: steps.check.outputs.exit_code == '1'
+        run: exit 1

--- a/scripts/maintenance/check-blog-links.mjs
+++ b/scripts/maintenance/check-blog-links.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Blog deep-link checker — catches soft-404s in hardcoded blog links.
+ *
+ * Blog posts hardcode /book/, /gallery/image/ and /collections/ hrefs, and
+ * those rot silently: books get deleted (copyright cleanups), slugs change,
+ * ids get typo'd. Because Next.js soft-404s (HTTP 200 with a "… Not Found"
+ * body), status-code checks are useless — this script fetches each link and
+ * greps the rendered <title> for the not-found markers instead. See issue
+ * #2959 (51 dead links across 9 posts) and the cannabis-essay incident
+ * (PRs #2584/#2587) for why this exists.
+ *
+ * Usage:
+ *   node scripts/maintenance/check-blog-links.mjs --all
+ *   node scripts/maintenance/check-blog-links.mjs src/app/blog/foo/page.tsx [...]
+ *
+ * Options:
+ *   --all                 Check every src/app/blog/⋆⋆/page.tsx
+ *   --base-url <url>      Target site (default https://sourcelibrary.org)
+ *   --concurrency <n>     Parallel fetches (default 8)
+ *
+ * Exit codes: 0 = all links resolve (network warnings don't fail),
+ *             1 = at least one broken link, 2 = usage error.
+ *
+ * No dependencies — safe to run in CI on fork PRs (no secrets needed).
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+const args = process.argv.slice(2);
+const getOpt = (name, dflt) => {
+  const i = args.indexOf(name);
+  if (i === -1) return dflt;
+  const v = args[i + 1];
+  args.splice(i, 2);
+  return v;
+};
+const BASE_URL = (getOpt('--base-url', 'https://sourcelibrary.org')).replace(/\/$/, '');
+const CONCURRENCY = parseInt(getOpt('--concurrency', '8'), 10);
+const ALL = args.includes('--all');
+if (ALL) args.splice(args.indexOf('--all'), 1);
+
+const BLOG_DIR = 'src/app/blog';
+
+function allBlogPages(dir = BLOG_DIR, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) allBlogPages(p, out);
+    else if (entry === 'page.tsx') out.push(p);
+  }
+  return out;
+}
+
+const files = ALL ? allBlogPages() : args;
+if (files.length === 0) {
+  console.log('No files to check.');
+  process.exit(ALL ? 2 : 0);
+}
+
+// Only literal string hrefs are checkable statically; template-literal hrefs
+// (href={`/book/${id}`}) are skipped. Author links are excluded — the author
+// page renders a shell for any name, so there's no not-found marker to detect.
+const LINK_RE = /href="(\/(?:book|gallery\/image|collections)\/[^"]+)"/g;
+
+const links = new Map(); // path -> Set<sourceFile>
+for (const file of files) {
+  let src;
+  try {
+    src = readFileSync(file, 'utf8');
+  } catch {
+    console.error(`Cannot read ${file} — skipping`);
+    continue;
+  }
+  for (const m of src.matchAll(LINK_RE)) {
+    const path = m[1];
+    if (!links.has(path)) links.set(path, new Set());
+    links.get(path).add(file);
+  }
+}
+
+console.log(`Checking ${links.size} unique links from ${files.length} file(s) against ${BASE_URL}\n`);
+if (links.size === 0) process.exit(0);
+
+// Soft-404 markers rendered into <title> by the dynamic routes.
+const NOT_FOUND = /<title>[^<]*(Book Not Found|Page Not Found|Image Not Found|Collection Not Found)/i;
+// Streamed server redirect (routes with a loading.tsx boundary emit the
+// redirect as an in-body instruction with HTTP 200 — follow it once).
+const NEXT_REDIRECT = /NEXT_REDIRECT;replace;([^;]+);30[78]/;
+
+async function fetchBody(url, redirectsLeft = 3) {
+  const res = await fetch(url, {
+    redirect: 'follow',
+    signal: AbortSignal.timeout(25000),
+    headers: { 'User-Agent': 'sourcelibrary-blog-link-check' },
+  });
+  const body = await res.text();
+  const streamed = body.match(NEXT_REDIRECT);
+  if (streamed && redirectsLeft > 0) {
+    return fetchBody(new URL(streamed[1], BASE_URL).href, redirectsLeft - 1);
+  }
+  return body;
+}
+
+async function checkLink(path) {
+  const url = `${BASE_URL}${path}`;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const body = await fetchBody(url);
+      if (!body) throw new Error('empty body');
+      return NOT_FOUND.test(body) ? 'broken' : 'ok';
+    } catch (err) {
+      if (attempt === 1) return `error: ${err.message || err}`;
+      await new Promise(r => setTimeout(r, 1500));
+    }
+  }
+}
+
+const paths = [...links.keys()];
+const broken = [];
+const warnings = [];
+let done = 0;
+
+await Promise.all(
+  Array.from({ length: Math.min(CONCURRENCY, paths.length) }, async () => {
+    while (paths.length > 0) {
+      const path = paths.shift();
+      const result = await checkLink(path);
+      done++;
+      if (result === 'broken') broken.push(path);
+      else if (result !== 'ok') warnings.push(`${path} (${result})`);
+      if (done % 50 === 0) console.log(`  …${done}/${links.size}`);
+    }
+  })
+);
+
+if (warnings.length > 0) {
+  console.log(`\n⚠ ${warnings.length} link(s) could not be checked (network):`);
+  for (const w of warnings) console.log(`  ${w}`);
+}
+
+if (broken.length > 0) {
+  console.log(`\n✗ ${broken.length} BROKEN link(s):\n`);
+  for (const path of broken.sort()) {
+    console.log(`  ${BASE_URL}${path}`);
+    for (const f of links.get(path)) console.log(`    in ${f}`);
+  }
+  console.log('\nFix by relinking to a held edition, or unlink (keep the title as plain text).');
+  console.log('See .claude/handoffs/2026-07-04-link-integrity-visibility-drift.md for the playbook.');
+  process.exit(1);
+}
+
+console.log(`\n✓ All ${links.size} links resolve.`);


### PR DESCRIPTION
Implements the guardrail proposed on #2959 so blog deep-link rot can't ship or accumulate silently again.

## What
- **`scripts/maintenance/check-blog-links.mjs`** — extracts literal `/book/`, `/gallery/image/`, `/collections/` hrefs from blog pages and fetches each against production. Detects Next.js **soft-404s by `<title>` marker** (Book/Page/Image/Collection Not Found), since these return HTTP 200; follows streamed `NEXT_REDIRECT` bodies (routes with a `loading.tsx` boundary). Zero dependencies, HTTP-only, no secrets — safe on fork PRs. Author links are deliberately excluded (the author page renders a shell for any name, so there is no detectable marker).
- **`.github/workflows/blog-link-check.yml`** — two jobs:
  - **PR gate** (`paths: src/app/blog/**`): validates links in changed posts only.
  - **Weekly sweep** (Mondays 06:20 UTC + manual dispatch): checks ALL posts and opens/updates a rot issue via `gh` when links break *after* publication — the failure mode a PR-time check can't see, and how #2959's 51 dead links accumulated.

## Out of scope
- Template-literal hrefs (`href={\`/book/${id}\`}`) — not statically checkable; all current blog deep links are literals.
- Non-blog surfaces (collection descriptions, editorial pages) — same technique would work; separate PR if wanted.

## Verification
- Full sweep passes clean against production: **433 links across 59 posts, zero broken** (confirming yesterday's #2960/#2961 repairs).
- Synthetic dead link (`/book/this-book-definitely-does-not-exist-xyz`) correctly flagged, exit 1; live book, rescued `artwork-…` gallery redirect, and a collection link all pass.
- Workflow YAML parses; the PR-gate job doesn't trigger on this PR (no blog files touched) — first live run will be the next blog PR or a manual dispatch of the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)