### PR TITLE
feat(licensing): embed license + TDM reservation in every copy of the content (#2963)

### DIFF
--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -4,6 +4,7 @@ import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { CONTENT_LICENSE, type ContentLicense } from '@/lib/license-info';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { resolveTenantId } from '@/lib/tenant-context';
 import { isBookReadable } from '@/lib/book-access';
@@ -37,12 +38,7 @@ interface QuoteResponse {
     language: string;
   };
   citation: Citation;
-  license: {
-    spdx: string;
-    url: string;
-    attribution: string;
-    terms: string;
-  };
+  license: ContentLicense;
   context?: {
     previous_page?: string;
     next_page?: string;
@@ -239,12 +235,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         language: book.language,
       },
       citation: generateCitations(book, pageNumber, resolvedBookId, page.id, getRequestBaseUrl(request.headers), currentEdition),
-      license: {
-        spdx: 'CC-BY-SA-4.0',
-        url: 'https://creativecommons.org/licenses/by-sa/4.0/',
-        attribution: 'Source Library (https://sourcelibrary.org)',
-        terms: 'https://sourcelibrary.org/terms',
-      },
+      license: CONTENT_LICENSE,
     };
 
     // Include original text if requested

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -4,6 +4,7 @@ import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { CONTENT_LICENSE, type ContentLicense } from '@/lib/license-info';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { withApiAuth } from '@/lib/api-auth';
 import { isBookReadable } from '@/lib/book-access';
@@ -37,12 +38,7 @@ interface QuoteResponse {
     language: string;
   };
   citation: Citation;
-  license: {
-    spdx: string;
-    url: string;
-    attribution: string;
-    terms: string;
-  };
+  license: ContentLicense;
   context?: {
     previous_page?: string;
     next_page?: string;
@@ -233,12 +229,7 @@ export const GET = withApiAuth(async (request: NextRequest, context: RouteContex
         language: book.language,
       },
       citation: generateCitations(book, pageNumber, resolvedBookId, page.id, getRequestBaseUrl(request.headers), currentEdition),
-      license: {
-        spdx: 'CC-BY-SA-4.0',
-        url: 'https://creativecommons.org/licenses/by-sa/4.0/',
-        attribution: 'Source Library (https://sourcelibrary.org)',
-        terms: 'https://sourcelibrary.org/terms',
-      },
+      license: CONTENT_LICENSE,
     };
 
     // Include original text if requested

--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -6,6 +6,7 @@ import { getChapterTexts } from '@/lib/chapter-text';
 import { withApiAuth, type ApiIdentity } from '@/lib/api-auth';
 import { checkPageBudget, bulkBudgetExceededBody } from '@/lib/api-budget';
 import { isBookReadable } from '@/lib/book-access';
+import { CONTENT_LICENSE } from '@/lib/license-info';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 
 // This route serves quotable page text (get_book_text tells agents to "copy
@@ -316,12 +317,7 @@ export const GET = withApiAuth(async (
         year: book.year,
         url: `https://sourcelibrary.org/book/${resolvedBookId}`,
       },
-      license: {
-        spdx: 'CC-BY-SA-4.0',
-        url: 'https://creativecommons.org/licenses/by-sa/4.0/',
-        attribution: 'Source Library (https://sourcelibrary.org)',
-        terms: 'https://sourcelibrary.org/terms',
-      },
+      license: CONTENT_LICENSE,
       content_type: content,
       total_pages: book.pages_count || pages.length,
       pages_returned: pagesWithContent.length,

--- a/src/app/api/iiif/[id]/manifest/route.ts
+++ b/src/app/api/iiif/[id]/manifest/route.ts
@@ -363,6 +363,25 @@ export async function GET(
         },
       });
     }
+    // License + TDM reservation travel inside the manifest (headers are
+    // stripped when manifests are harvested/re-hosted). Prices live on
+    // /licensing only.
+    metadata.push({
+      label: { en: ['License'] },
+      value: {
+        en: [
+          'Original texts: public domain. OCR, translations and annotations: <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>, attribution: Source Library (https://sourcelibrary.org).',
+        ],
+      },
+    });
+    metadata.push({
+      label: { en: ['AI Training / TDM'] },
+      value: {
+        en: [
+          'Reserved (EU Directive 2019/790 Art. 4). A standard license is available — see <a href="https://sourcelibrary.org/licensing">sourcelibrary.org/licensing</a>.',
+        ],
+      },
+    });
 
     // Summary
     const summaryText =

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -4,6 +4,7 @@ import { textRoleRank } from '@/lib/text-role';
 import { Book } from '@/lib/types';
 import type { SearchResult, SearchResponse } from '@/lib/api-client/types/search';
 import { buildPageSearchStage, NON_CONTENT_PAGE_TYPES } from '@/lib/atlas-search';
+import { CONTENT_LICENSE } from '@/lib/license-info';
 import { searchBookIds } from '@/lib/books-catalog';
 import { semanticBookSearch, semanticPageSearchGlobal } from '@/lib/semantic-search';
 import { rrfScores } from '@/lib/search/rrf';
@@ -877,12 +878,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       limit,
       sort: sortBy,
       ranking: rankingApplied,
-      license: {
-        spdx: 'CC-BY-SA-4.0',
-        url: 'https://creativecommons.org/licenses/by-sa/4.0/',
-        attribution: 'Source Library (https://sourcelibrary.org)',
-        terms: 'https://sourcelibrary.org/terms',
-      },
+      license: CONTENT_LICENSE,
       results: paginatedResults,
       ...(nearby.length > 0 && { nearby, nearby_range: `${parseInt(year!) - 5}-${parseInt(year!) + 5}` }),
       filters: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -77,6 +77,11 @@ export const metadata: Metadata = {
   other: {
     'msapplication-TileColor': '#1a1612',
     'pinterest-rich-pin': 'true',
+    // TDMRep in-document form (embedded so the reservation survives archiving
+    // and dataset snapshots, which strip the equivalent HTTP headers set in
+    // next.config.ts). See https://sourcelibrary.org/licensing
+    'tdm-reservation': '1',
+    'tdm-policy': 'https://sourcelibrary.org/licensing',
   },
   openGraph: {
     siteName: "Source Library",

--- a/src/components/layout/GlobalFooter.tsx
+++ b/src/components/layout/GlobalFooter.tsx
@@ -193,6 +193,13 @@ export default function GlobalFooter() {
             ))}
           </div>
         </div>
+
+        {/* Zone 4: License line */}
+        <div className="pb-6 -mt-2 text-center">
+          <Link href="/licensing" className="text-xs text-white/35 hover:text-white/60 transition-colors">
+            {t.licenseLine}
+          </Link>
+        </div>
       </div>
     </footer>
     </>

--- a/src/lib/bot-gate.ts
+++ b/src/lib/bot-gate.ts
@@ -11,6 +11,7 @@
  */
 
 import { validateApiKey } from '@/lib/dataset/api-keys';
+import { CONTENT_LICENSE } from '@/lib/license-info';
 
 const BOT_PAGE_PERCENT = 20; // % of pages bots can read from each book
 
@@ -128,10 +129,6 @@ export function botGateResponse(book: {
       subject: 'AI Partnership — Full Corpus Access',
       info: 'https://sourcelibrary.org/llms.txt',
     },
-    license: {
-      spdx: 'CC-BY-SA-4.0',
-      url: 'https://creativecommons.org/licenses/by-sa/4.0/',
-      terms: 'https://sourcelibrary.org/terms',
-    },
+    license: CONTENT_LICENSE,
   };
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -139,6 +139,7 @@ export interface FooterStrings {
   sponsorship: string;
   developers: string;
   giveFeedback: string;
+  licenseLine: string;
 }
 
 export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
@@ -169,6 +170,7 @@ export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
     sponsorship: 'Corporate Sponsorship',
     developers: 'Developers',
     giveFeedback: 'Give Feedback',
+    licenseLine: 'Public domain originals · Translations CC BY-SA 4.0 · AI training requires a license',
   },
   es: {
     colLibrary: 'Biblioteca',
@@ -197,5 +199,6 @@ export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
     sponsorship: 'Patrocinio corporativo',
     developers: 'Desarrolladores',
     giveFeedback: 'Enviar comentarios',
+    licenseLine: 'Originales de dominio público · Traducciones CC BY-SA 4.0 · El entrenamiento de IA requiere licencia',
   },
 };

--- a/src/lib/license-info.ts
+++ b/src/lib/license-info.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical machine-readable license block for content API responses.
+ *
+ * Embedded in JSON payloads so the license and the TDM/AI-training
+ * reservation travel INSIDE the data — bulk consumers keep the payload,
+ * not the HTTP headers set in next.config.ts. Companion to the site-wide
+ * TDMRep declarations (/.well-known/tdmrep.json, TDM-Reservation header,
+ * tdm-reservation meta tags). Full terms + rate card: /licensing.
+ *
+ * Keep this the single source of truth — don't re-inline the block in new
+ * routes, and don't put dollar figures here (prices live on /licensing only).
+ */
+export const CONTENT_LICENSE = {
+  spdx: 'CC-BY-SA-4.0',
+  url: 'https://creativecommons.org/licenses/by-sa/4.0/',
+  attribution: 'Source Library (https://sourcelibrary.org)',
+  terms: 'https://sourcelibrary.org/terms',
+  original_texts: 'public-domain',
+  tdm_reservation: 1,
+  tdm_policy: 'https://sourcelibrary.org/licensing',
+  ai_training: 'reserved — standard license available, see tdm_policy',
+} as const;
+
+export type ContentLicense = typeof CONTENT_LICENSE;


### PR DESCRIPTION
Implements PR 2 of #2963 — the propagation layer. The principle: the **reservation travels with every copy of the content**; the **price lives only on /licensing**.

## What

- **TDMRep in-document form**: root layout now emits `tdm-reservation` / `tdm-policy` meta tags on every page. The HTTP headers in next.config.ts don't survive archiving or dataset snapshots — scraped corpora keep the document, not the response headers. Meta tags embed the reservation in every copy. (Root layout covers tenant subdomains too, per the BPH-serves-global-routes wiring.)
- **`src/lib/license-info.ts`** — new single source of truth (`CONTENT_LICENSE`). Replaces five hand-copied inline license blocks: `/api/books/[id]/text`, `/api/books/[id]/quote`, tenant quote twin, `/api/search`, and `bot-gate.ts`'s gated-response body. Each now additionally declares `original_texts: public-domain`, `tdm_reservation: 1`, `tdm_policy`, and `ai_training: reserved — standard license available`. This is the highest-value surface: bulk consumers take the API JSON, so the reservation now sits inside the data itself. Additive fields only — no existing field removed or renamed.
- **IIIF manifests** gain `License` and `AI Training / TDM` metadata entries (manifests get harvested and re-hosted without our headers).
- **GlobalFooter** gains a one-line notice (en + es): "Public domain originals · Translations CC BY-SA 4.0 · AI training requires a license" → /licensing.

## Deliberately unchanged

- **DTS text/plain documents** — already covered by the site-wide `TDM-Reservation` header (`source: '/(.*)'`), and license prose must never be injected into body text (the #2232 quote-integrity rule: envelope only).
- **No dollar figures** anywhere in this PR — prices live on /licensing (PR #2967) only.
- **No enforcement changes** (bot gate thresholds, budgets, CF WAF untouched).

## Verification

`npx tsc --noEmit` clean. `license` fields are additive in all five JSON surfaces; quote-route response interfaces updated to the shared `ContentLicense` type.

Companion PRs: #2967 (rate card), #2965 (CC0 drift cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)