### PR TITLE
fix(acquire): union resolver candidates so the German-library catalog is reached

### DIFF
--- a/scripts/catalog-coverage/acquire-gap-batch.mjs
+++ b/scripts/catalog-coverage/acquire-gap-batch.mjs
@@ -113,11 +113,14 @@ async function processWork(w) {
     const have = await books.findOne({ $and: [{ $or: [{ author: new RegExp(surname, 'i') }, { title: new RegExp(surname, 'i') }] }, { title: new RegExp(tk.join('|'), 'i') }] }, { projection: { _id: 1 } });
     if (have) { await queue.updateOne({ sn: w.sn }, { $set: { status: 'held', done_at: new Date() } }); return 'held'; }
   }
-  let cands = await iaResolve(w);
-  if (!cands.length) cands = await eraraResolve(w);
-  if (!cands.length) cands = await catalogResolve(w);
+  // Combine candidates from ALL sources — don't stop at the first non-empty one. IA search
+  // usually returns weak candidates that already failed verify, which would starve the
+  // higher-precision German-library catalog (catalogResolve) of a chance. Gather IA + catalog
+  // (+ e-rara), then let verify() pick the true match from the union.
+  const [ia, cat, er] = await Promise.all([iaResolve(w), catalogResolve(w), eraraResolve(w)]);
+  const cands = [...ia, ...cat, ...er];
   if (!cands.length) { await queue.updateOne({ sn: w.sn }, { $set: { status: 'no-source', done_at: new Date() } }); return 'no-source'; }
-  const v = await verify(w, cands.slice(0, 6));
+  const v = await verify(w, cands.slice(0, 9));
   if (!v) { await queue.updateOne({ sn: w.sn }, { $set: { status: 'no-match', done_at: new Date() } }); return 'no-match'; }
   if (DRY) return 'acquired';
   const bookId = await importWork(w, v);


### PR DESCRIPTION
## Problem

`catalogResolve` (#2966, the ~100K German-library IIIF catalog) was wired into the chain but effectively **dead code**. The chain was first-non-empty-wins:

```
let cands = await iaResolve(w);
if (!cands.length) cands = await eraraResolve(w);
if (!cands.length) cands = await catalogResolve(w);
```

`iaResolve` almost always returns *some* candidate — the same weak IA hits that already failed `verify()` on these `no-match` works — so `catalogResolve` never ran. Observed in the live catch-up: `acquired ~1, no-match ~275` per 300-work batch, despite a measured **68% catalog candidate rate**. Only works where IA returned literally nothing (e.g. Hornius) fell through to the catalog.

## Fix

Gather candidates from **all three** resolvers in parallel and verify the **union** (cap 9), so the higher-precision German-library match competes with — and beats — the weak IA candidate instead of being starved by it.

```
const [ia, cat, er] = await Promise.all([iaResolve(w), catalogResolve(w), eraraResolve(w)]);
const cands = [...ia, ...cat, ...er];
```

`catalogResolve` is a fast indexed local lookup (~57ms), so running it for every work is cheap.

## Context

Third in the sequence: #2966 (catalog resolver) → #2970 (timeout guards; the hang is fixed and batches now complete) → this (make the catalog actually reachable). After this, the ~73K no-match re-queue should convert at a high rate and carry Latin past 10K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)