### PR TITLE
fix(explore): unfreeze /explore/timeline — indexed entity queries + real ISR window

### DIFF
--- a/scripts/maintenance/create-entities-wikidata-indexes.mjs
+++ b/scripts/maintenance/create-entities-wikidata-indexes.mjs
@@ -28,7 +28,8 @@ const INDEXES = [
 ];
 
 const client = await MongoClient.connect(uri);
-const col = client.db('bookstore').collection('entities');
+const db = client.db('bookstore');
+const col = db.collection('entities');
 
 for (const { field, name } of INDEXES) {
   try {
@@ -44,6 +45,24 @@ for (const { field, name } of INDEXES) {
       console.error(`ERROR: entities.${name} — ${e.message}`);
       process.exitCode = 1;
     }
+  }
+}
+
+// Covered index for the timeline's book-language lookup: books average ~25KB
+// per doc, so point-fetching ~14K of them read ~360MB and timed out. With
+// this index and an _id-excluding projection the query never touches docs.
+try {
+  await db.collection('books').createIndex(
+    { id: 1, language: 1 },
+    { name: 'id_language_covered' },
+  );
+  console.log('OK: books.id_language_covered');
+} catch (e) {
+  if (e.codeName === 'IndexOptionsConflict' || e.code === 85 || e.code === 86) {
+    console.log('EXISTS: books.id_language_covered');
+  } else {
+    console.error(`ERROR: books.id_language_covered — ${e.message}`);
+    process.exitCode = 1;
   }
 }
 

--- a/scripts/maintenance/create-entities-wikidata-indexes.mjs
+++ b/scripts/maintenance/create-entities-wikidata-indexes.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Partial indexes on entities.wikidata_* fields.
+ *
+ * The entities collection is ~1M docs (~1.9GB), but only a few thousand have
+ * Wikidata enrichment. /explore/timeline, /explore (hub stats), and
+ * /api/explore/map filter on these fields — without indexes each query was a
+ * full collection scan that timed out (the 2026-07-04 timeline outage: the
+ * error fallback then got frozen into the static page cache).
+ *
+ * Idempotent — safe to re-run. Already applied to prod 2026-07-04.
+ *
+ * Usage: set -a; source .env.production.local; set +a; node scripts/maintenance/create-entities-wikidata-indexes.mjs
+ */
+import { MongoClient } from 'mongodb';
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI not set');
+  process.exit(1);
+}
+
+const INDEXES = [
+  { field: 'wikidata_birth_date', name: 'wikidata_birth_date_partial' },
+  { field: 'wikidata_death_date', name: 'wikidata_death_date_partial' },
+  { field: 'wikidata_coordinates', name: 'wikidata_coordinates_partial' },
+  { field: 'wikidata_id', name: 'wikidata_id_partial' },
+];
+
+const client = await MongoClient.connect(uri);
+const col = client.db('bookstore').collection('entities');
+
+for (const { field, name } of INDEXES) {
+  try {
+    await col.createIndex(
+      { [field]: 1 },
+      { name, partialFilterExpression: { [field]: { $exists: true } } },
+    );
+    console.log(`OK: entities.${name}`);
+  } catch (e) {
+    if (e.codeName === 'IndexOptionsConflict' || e.code === 85 || e.code === 86) {
+      console.log(`EXISTS: entities.${name}`);
+    } else {
+      console.error(`ERROR: entities.${name} — ${e.message}`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+await client.close();

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -23,27 +23,41 @@ async function fetchExploreStats() {
   try {
     const db = await getReadDb();
 
-    // Use estimatedDocumentCount (instant, uses collection metadata)
-    // and a single aggregation for all entity stats to avoid multiple slow scans
+    // Use estimatedDocumentCount (instant, uses collection metadata) and
+    // separate indexed counts for the filtered stats. A single $facet used to
+    // bundle these, but $facet sub-pipelines can't use indexes — at ~1M
+    // entities that was a full collection scan that blew the 25s budget.
+    // Each count below is answered by its own partial index
+    // (wikidata_{birth,death}_date_partial, wikidata_coordinates_partial,
+    // wikidata_id_partial) plus type_1 for the distribution.
     const [
       totalEntities,
       totalBooks,
-      entityStats,
+      typeDistribution,
+      withDates,
+      withCoordinates,
+      withWikidata,
       heatmapData,
     ] = await Promise.all([
       db.collection('entities').estimatedDocumentCount(),
       db.collection('books').estimatedDocumentCount(),
-      // Single aggregation for type distribution + filtered counts
       db.collection('entities').aggregate([
-        {
-          $facet: {
-            byType: [{ $group: { _id: '$type', count: { $sum: 1 } } }],
-            withDates: [{ $match: { $or: [{ wikidata_birth_date: { $exists: true, $ne: null } }, { wikidata_death_date: { $exists: true, $ne: null } }] } }, { $count: 'n' }],
-            withCoords: [{ $match: { wikidata_coordinates: { $exists: true, $ne: null } } }, { $count: 'n' }],
-            withWikidata: [{ $match: { wikidata_id: { $exists: true, $ne: null } } }, { $count: 'n' }],
-          },
-        },
+        { $group: { _id: '$type', count: { $sum: 1 } } },
       ], { maxTimeMS: 25000 }).toArray(),
+      db.collection('entities').countDocuments({
+        $or: [
+          { wikidata_birth_date: { $exists: true, $ne: null } },
+          { wikidata_death_date: { $exists: true, $ne: null } },
+        ],
+      }, { maxTimeMS: 25000 }),
+      db.collection('entities').countDocuments(
+        { wikidata_coordinates: { $exists: true, $ne: null } },
+        { maxTimeMS: 25000 },
+      ),
+      db.collection('entities').countDocuments(
+        { wikidata_id: { $exists: true, $ne: null } },
+        { maxTimeMS: 25000 },
+      ),
 
       // Books by century — fast aggregation on books collection
       db.collection('books').aggregate([
@@ -62,12 +76,6 @@ async function fetchExploreStats() {
         { $sort: { _id: 1 } },
       ], { maxTimeMS: 15000 }).toArray(),
     ]);
-
-    const facets = entityStats[0] || { byType: [], withDates: [], withCoords: [], withWikidata: [] };
-    const withDates = facets.withDates[0]?.n || 0;
-    const withCoordinates = facets.withCoords[0]?.n || 0;
-    const withWikidata = facets.withWikidata[0]?.n || 0;
-    const typeDistribution = facets.byType;
 
     const heatmap = heatmapData.map((row) => ({
       century: row._id as number,

--- a/src/app/explore/timeline/page.tsx
+++ b/src/app/explore/timeline/page.tsx
@@ -3,7 +3,9 @@ import { getReadDb } from '@/lib/mongodb';
 import TimelineLoader from '@/components/explore/TimelineLoader';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const revalidate = false;
+// Must be a finite number — `false` caches forever, which froze the error
+// fallback into the static cache when the entities query timed out (2026-07-04).
+export const revalidate = 21600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {
@@ -183,14 +185,10 @@ async function fetchTimelineData() {
 }
 
 export default async function TimelinePage() {
-  try {
-    const data = await fetchTimelineData();
-    return <TimelineLoader entities={data.entities} stats={data.stats} />;
-  } catch {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p className="text-stone-500">Timeline data is temporarily unavailable. Please try again shortly.</p>
-      </div>
-    );
-  }
+  // No try/catch: a thrown error during ISR revalidation keeps serving the
+  // last good page, while catching it here would render (and cache) an
+  // "unavailable" fallback for the full revalidate window. Cold failures
+  // land on src/app/error.tsx.
+  const data = await fetchTimelineData();
+  return <TimelineLoader entities={data.entities} stats={data.stats} />;
 }

--- a/src/app/explore/timeline/page.tsx
+++ b/src/app/explore/timeline/page.tsx
@@ -85,11 +85,14 @@ async function fetchTimelineData() {
     }
   }
 
-  // Query by `id` field (app-level ID) — avoids needing ObjectId/string split
+  // Query by `id` field (app-level ID) — avoids needing ObjectId/string split.
+  // Projection must exclude _id so the id_language_covered index answers this
+  // without fetching documents: books average ~25KB each, and ~14K point
+  // fetches (~360MB of random reads) blew the 30s budget on 2026-07-04.
   const bookDocs = allBookIds.size > 0
     ? await db.collection('books').find(
         { id: { $in: [...allBookIds] } },
-        { projection: { id: 1, language: 1 }, maxTimeMS: 30000 }
+        { projection: { _id: 0, id: 1, language: 1 }, maxTimeMS: 30000 }
       ).toArray()
     : [];
 


### PR DESCRIPTION
## What happened

`/explore/timeline` was down — serving a permanently cached "Timeline data is temporarily unavailable" fallback.

**Root cause chain:**
1. The `entities` collection grew to ~1M docs (~1.9GB) from enrichment (places/concepts/people). Only ~8K have Wikidata dates.
2. The timeline page's aggregation filters on `wikidata_birth_date`/`wikidata_death_date` with **no index** → full collection scan → exceeded its 45s `maxTimeMS`.
3. The page's `try/catch` rendered the error fallback **successfully**, and `revalidate = false` (the comment claimed "6 hours") cached that error page **forever**.

## In scope

- **`/explore/timeline`**: `revalidate = 21600` (the 6h the comment always claimed); removed the try/catch so a failed ISR revalidation keeps serving the last good page instead of caching the fallback (cold failures land on `src/app/error.tsx`).
- **`/explore` hub**: split the `$facet` over entities into separate indexed `countDocuments` calls — `$facet` sub-pipelines can't use indexes, so it was a 1.9GB collection scan against a 25s budget (it was intermittently surviving; same failure waiting to happen).
- **`scripts/maintenance/create-entities-wikidata-indexes.mjs`**: idempotent record of the four partial indexes (`wikidata_{birth,death}_date`, `wikidata_coordinates`, `wikidata_id`) — **already applied to prod 2026-07-04**.

## Verified

- Timeline aggregation: timeout → **~12s** (within the 45s budget; 7,948 entities returned).
- `/api/explore/map`: **43s → 0.2s** with zero code change (the `wikidata_coordinates` index).
- Explain plans confirm SUBPLAN/IXSCAN on the new partial indexes.
- `npx tsc --noEmit` clean.

## Out of scope (follow-ups)

- **Site-wide `revalidate = false` audit**: ~28 pages use it; the dangerous combo (DB fetch + catch-into-rendered-fallback + revalidate=false) exists on several (`/data`, `/dataset`, `/work/[id]`, `/topics/[slug]`, `/artwork/artist/[slug]`, …). Spot-checked prod — none currently frozen — but each is one bad render away. Separate issue.
- **Dead code**: `src/app/timeline/` + `/api/books/timeline` are unreachable on the global site (`/timeline` 308s to `/explore/timeline` via next.config) and the API returns empty without a tenant header. Deletion deserves its own grep-verified PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFtJFc4fduQ4HDJHxSM1y3