### PR TITLE
fix(caching): eliminate revalidate=false + fallible fetch + catch-into-fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Source Library is a digital library of historical primary sources — alchemy, H
 When making product decisions, lead with: who reads this, what experience are they having, and does this serve the goal of putting primary sources into people's hands. Technical choices flow from that. The CRITICAL sections below are scar tissue from real incidents — read them, but don't mistake them for the point of the project.
 
 ## Development Workflow — CRITICAL
+- **Never combine `export const revalidate = false` + a fallible fetch (Mongo/Supabase/fetch) + a `try/catch` that renders a fallback.** One bad render caches that fallback (an "unavailable" message, or zeroed/empty stats) permanently, until the next deploy — this is how `/explore/timeline` froze (#2973) and how `/explore/map` froze before it. If a static page's data can fail, let the error **throw** (ISR then serves the last good page on revalidation failure — `src/app/error.tsx` handles cold failures) and give the page a real numeric `revalidate` window instead of `false`. Audited and fixed across the app in #2974; don't reintroduce the pattern on a new page.
 - **Feature branches off `main`.** One branch per feature/task: `feat/ai-search`, `fix/cover-thumbnails`, etc. No long-running dev branches.
 - **Create a branch via worktree:** Use `EnterWorktree` at session start — it creates an isolated checkout with its own branch. Do NOT `git checkout -b` in the main directory (see Multi-Session Awareness above).
 - **PR when done:** `gh pr create --base main`. Keep PRs focused (5-15 commits). Small PRs merge fast.

--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -6,7 +6,9 @@ import SiteHeader from '@/components/layout/SiteHeader';
 import ArtworkInfo from '@/components/artwork/ArtworkInfo';
 import { isHiddenBook } from '@/lib/book-access';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever
+// (e.g. the noindex metadata below) until the next deploy.
+export const revalidate = 21600;
 export const dynamicParams = true;
 
 interface PageProps {
@@ -108,12 +110,9 @@ async function getArtwork(slug: string) {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  let data: Awaited<ReturnType<typeof getArtwork>>;
-  try {
-    data = await getArtwork(slug);
-  } catch {
-    return { title: 'Source Library', robots: { index: false, follow: false } };
-  }
+  // No try/catch: letting a fetch failure throw here keeps ISR serving the
+  // last good page instead of permanently caching noindex fallback metadata.
+  const data = await getArtwork(slug);
   if (!data) return { title: 'Not Found', robots: { index: false, follow: true } };
   const { artwork } = data;
   return {

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -6,7 +6,9 @@ import { getReadDb } from '@/lib/mongodb';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever
+// (e.g. the noindex metadata below) until the next deploy.
+export const revalidate = 21600;
 export const dynamicParams = true;
 
 interface PageProps {
@@ -88,12 +90,9 @@ async function getArtist(slug: string) {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  let data: Awaited<ReturnType<typeof getArtist>>;
-  try {
-    data = await getArtist(slug);
-  } catch {
-    return { title: 'Source Library', robots: { index: false, follow: false } };
-  }
+  // No try/catch: letting a fetch failure throw here keeps ISR serving the
+  // last good page instead of permanently caching noindex fallback metadata.
+  const data = await getArtist(slug);
   if (!data) return { title: 'Not Found', robots: { index: false, follow: true } };
   return {
     title: `${data.name} — Source Library Visual Art`,

--- a/src/app/collections/contemplative-traditions/page.tsx
+++ b/src/app/collections/contemplative-traditions/page.tsx
@@ -5,7 +5,9 @@ import { ArrowLeft, BookOpen } from 'lucide-react';
 import { getReadDb } from '@/lib/mongodb';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever
+// (e.g. the "Temporarily Unavailable" / empty-list render below).
+export const revalidate = 21600;
 
 export const metadata: Metadata = {
   title: 'The Contemplative Traditions - Source Library',
@@ -100,40 +102,37 @@ interface TraditionCollection {
 
 /* ── Data fetching ── */
 
+// No try/catch: letting a fetch failure throw here keeps ISR serving the
+// last good page instead of permanently caching an empty tradition list.
 async function getTraditions(): Promise<{ traditions: TraditionCollection[]; totalBooks: number }> {
-  try {
-    const db = await Promise.race([
-      getReadDb(),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 10000)),
-    ]);
+  const db = await Promise.race([
+    getReadDb(),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 10000)),
+  ]);
 
-    const traditions = await db
-      .collection('collections')
-      .find({ parent: 'contemplative-traditions' })
-      .sort({ order: 1 })
-      .toArray();
+  const traditions = await db
+    .collection('collections')
+    .find({ parent: 'contemplative-traditions' })
+    .sort({ order: 1 })
+    .toArray();
 
-    const parent = await db.collection('collections').findOne({ slug: 'contemplative-traditions' });
-    const totalBooks = parent?.book_count || traditions.reduce((sum, t) => sum + (t.book_count || 0), 0);
+  const parent = await db.collection('collections').findOne({ slug: 'contemplative-traditions' });
+  const totalBooks = parent?.book_count || traditions.reduce((sum, t) => sum + (t.book_count || 0), 0);
 
-    return {
-      traditions: traditions.map(t => ({
-        slug: t.slug,
-        name: t.name,
-        subtitle: t.subtitle || '',
-        description: t.description || '',
-        book_count: t.book_count || 0,
-        order: t.order || 99,
-        color: t.color,
-        languages: t.languages || [],
-        sample_books: t.sample_books || [],
-      })) as TraditionCollection[],
-      totalBooks,
-    };
-  } catch (e) {
-    console.warn('[Contemplative Traditions portal] Failed to load:', (e as Error).message);
-    return { traditions: [], totalBooks: 0 };
-  }
+  return {
+    traditions: traditions.map(t => ({
+      slug: t.slug,
+      name: t.name,
+      subtitle: t.subtitle || '',
+      description: t.description || '',
+      book_count: t.book_count || 0,
+      order: t.order || 99,
+      color: t.color,
+      languages: t.languages || [],
+      sample_books: t.sample_books || [],
+    })) as TraditionCollection[],
+    totalBooks,
+  };
 }
 
 /* ── Components ── */
@@ -212,23 +211,7 @@ function TraditionCard({ tradition }: { tradition: TraditionCollection }) {
 /* ── Page ── */
 
 export default async function ContemplativeTraditionsPage() {
-  let data: { traditions: TraditionCollection[]; totalBooks: number };
-  try {
-    data = await getTraditions();
-  } catch (err) {
-    console.error('[Contemplative Traditions portal] Failed to load:', err instanceof Error ? err.message : err);
-    return (
-      <div className="min-h-screen bg-stone-50 flex items-center justify-center">
-        <div className="text-center max-w-md px-6">
-          <h1 className="text-2xl font-display text-stone-900 mb-3">Temporarily Unavailable</h1>
-          <p className="text-stone-600 mb-6">Please try again in a moment.</p>
-          <Link href="/" className="text-accent-rust hover:underline">Return to Library</Link>
-        </div>
-      </div>
-    );
-  }
-
-  const { traditions, totalBooks } = data;
+  const { traditions, totalBooks } = await getTraditions();
   const traditionsWithBooks = traditions.filter(t => t.book_count > 0);
 
   const allLanguages = [

--- a/src/app/collections/sacred-texts/page.tsx
+++ b/src/app/collections/sacred-texts/page.tsx
@@ -7,7 +7,9 @@ import { getReadDb } from '@/lib/mongodb';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever
+// (e.g. the "Temporarily Unavailable" / empty-list render below).
+export const revalidate = 21600;
 
 export const metadata: Metadata = {
   title: 'Sacred Texts - Source Library',
@@ -36,8 +38,12 @@ interface TraditionCollection {
   hero_image: string | null;
 }
 
+// No outer try/catch: letting a fetch failure throw here keeps ISR serving
+// the last good page instead of permanently caching an empty tradition list.
+// (Per-tradition enrichment below still uses Promise.allSettled + narrow
+// .catch()s so one slow tradition doesn't sink the whole list — that's
+// graceful degradation of a secondary stat, not the dangerous pattern.)
 async function getTraditions(): Promise<{ traditions: TraditionCollection[]; totalBooks: number }> {
-  try {
   const db = await Promise.race([
     getReadDb(),
     new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 10000)),
@@ -111,10 +117,6 @@ async function getTraditions(): Promise<{ traditions: TraditionCollection[]; tot
   const totalBooks = enriched.reduce((sum, t) => sum + t.book_count, 0);
 
   return { traditions: enriched, totalBooks };
-  } catch (e) {
-    console.warn('[Sacred Texts portal] Failed to load:', (e as Error).message);
-    return { traditions: [], totalBooks: 0 };
-  }
 }
 
 function TraditionCard({ tradition }: { tradition: TraditionCollection }) {
@@ -153,23 +155,7 @@ function TraditionCard({ tradition }: { tradition: TraditionCollection }) {
 }
 
 export default async function SacredTextsPortal() {
-  let data: { traditions: TraditionCollection[]; totalBooks: number };
-  try {
-    data = await getTraditions();
-  } catch (err) {
-    console.error('[Sacred Texts portal] Failed to load:', err instanceof Error ? err.message : err);
-    return (
-      <div className="min-h-screen bg-cream flex items-center justify-center">
-        <div className="text-center max-w-md px-6">
-          <h1 className="text-2xl font-display text-primary mb-3">Temporarily Unavailable</h1>
-          <p className="text-secondary mb-6">Please try again in a moment.</p>
-          <Link href="/" className="text-accent-rust hover:underline">Return to Library</Link>
-        </div>
-      </div>
-    );
-  }
-
-  const { traditions, totalBooks } = data;
+  const { traditions, totalBooks } = await getTraditions();
   const traditionsWithBooks = traditions
     .filter(t => t.book_count > 0)
     .sort((a, b) => b.scripture_count - a.scripture_count || b.book_count - a.book_count);

--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -6,7 +6,8 @@ import { CenturyChart } from './DataCharts';
 
 // ISR: rebuild every 10 minutes. The page reads from a pre-computed snapshot
 // so rendering is fast — no heavy Atlas aggregations at request time.
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever.
+export const revalidate = 600;
 export const maxDuration = 15;
 
 export const metadata: Metadata = {
@@ -154,12 +155,11 @@ export default async function DataPage({
 }) {
   const params = await searchParams;
   const showAdmin = params.admin === 'true';
-  let data: LibraryData;
-  try {
-    data = await fetchLibraryData();
-  } catch {
-    data = EMPTY_DATA;
-  }
+  // No try/catch: a thrown error during ISR revalidation keeps serving the
+  // last good page, while catching it here would render (and cache) an
+  // all-zero stats page for the full revalidate window. Cold failures land
+  // on src/app/error.tsx.
+  const data = await fetchLibraryData();
 
   const uniqueLanguages = data.languages.length;
   const earliestCentury = data.centuries[0]?.label ?? '';

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -4,7 +4,8 @@ import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPag
 import { getReadDb } from '@/lib/mongodb';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever.
+export const revalidate = 21600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {
@@ -23,68 +24,59 @@ function formatNumber(n: number): string {
   return n.toLocaleString('en-US');
 }
 
+// No try/catch: a thrown error during ISR revalidation keeps serving the
+// last good page, while catching it here would render (and cache) stale
+// snapshot numbers as if they were live for the full revalidate window.
+// Cold failures land on src/app/error.tsx.
 async function fetchDatasetStats() {
   const db = await getReadDb();
 
-  try {
-    const books = db.collection('books');
-    const visible = { visible: true };
-    const maxTimeMS = 45000;
+  const books = db.collection('books');
+  const visible = { visible: true };
+  const maxTimeMS = 45000;
 
-    const [totalBooks, pageTotalsAgg, languagesAgg] = await Promise.all([
-      books.countDocuments(visible, { maxTimeMS }),
-      books
-        .aggregate<{ _id: null; pages: number; ocr: number; translated: number }>([
-          { $match: visible },
-          {
-            $group: {
-              _id: null,
-              pages: { $sum: { $ifNull: ['$pages_count', 0] } },
-              ocr: { $sum: { $ifNull: ['$pages_ocr', 0] } },
-              translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
-            },
+  const [totalBooks, pageTotalsAgg, languagesAgg] = await Promise.all([
+    books.countDocuments(visible, { maxTimeMS }),
+    books
+      .aggregate<{ _id: null; pages: number; ocr: number; translated: number }>([
+        { $match: visible },
+        {
+          $group: {
+            _id: null,
+            pages: { $sum: { $ifNull: ['$pages_count', 0] } },
+            ocr: { $sum: { $ifNull: ['$pages_ocr', 0] } },
+            translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
           },
-        ], { maxTimeMS })
-        .toArray(),
-      books
-        .aggregate<{ _id: string; count: number; translated: number }>([
-          { $match: { ...visible, language: { $exists: true, $ne: 'Unknown' } } },
-          {
-            $group: {
-              _id: '$language',
-              count: { $sum: 1 },
-              translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
-            },
+        },
+      ], { maxTimeMS })
+      .toArray(),
+    books
+      .aggregate<{ _id: string; count: number; translated: number }>([
+        { $match: { ...visible, language: { $exists: true, $ne: 'Unknown' } } },
+        {
+          $group: {
+            _id: '$language',
+            count: { $sum: 1 },
+            translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
           },
-          { $sort: { count: -1 } },
-        ], { maxTimeMS })
-        .toArray(),
-    ]);
+        },
+        { $sort: { count: -1 } },
+      ], { maxTimeMS })
+      .toArray(),
+  ]);
 
-    const totals = pageTotalsAgg[0] ?? { pages: 0, ocr: 0, translated: 0 };
-    return {
-      totalBooks,
-      totalPages: totals.pages,
-      pagesOcr: totals.ocr,
-      pagesTranslated: totals.translated,
-      languages: languagesAgg.map((l) => ({
-        language: l._id,
-        books: l.count,
-        pagesTranslated: l.translated,
-      })),
-    };
-  } catch {
-    // Fallback to dashboard snapshot on timeout
-    const snap = await db.collection('system_config').findOne({ _id: 'dashboard_snapshot' as unknown as import('mongodb').ObjectId });
-    const d = snap?.data as Record<string, Record<string, number>> | undefined;
-    return {
-      totalBooks: d?.canon?.total_books ?? 5000,
-      totalPages: d?.coverage?.ocr_pages ?? 1000000,
-      pagesOcr: d?.coverage?.ocr_pages ?? 900000,
-      pagesTranslated: d?.coverage?.translated_pages ?? 800000,
-      languages: [],
-    };
-  }
+  const totals = pageTotalsAgg[0] ?? { pages: 0, ocr: 0, translated: 0 };
+  return {
+    totalBooks,
+    totalPages: totals.pages,
+    pagesOcr: totals.ocr,
+    pagesTranslated: totals.translated,
+    languages: languagesAgg.map((l) => ({
+      language: l._id,
+      books: l.count,
+      pagesTranslated: l.translated,
+    })),
+  };
 }
 
 export default async function DatasetPage() {

--- a/src/app/encyclopedia/page.tsx
+++ b/src/app/encyclopedia/page.tsx
@@ -7,7 +7,8 @@ import { ENTITY_TYPE_STYLES, type EntityType } from '@/lib/style-constants';
 import EncyclopediaFilters from './EncyclopediaFilters';
 import { unstable_cache } from 'next/cache';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever.
+export const revalidate = 3600;
 export const maxDuration = 30;
 
 const TYPE_ICONS = {
@@ -37,118 +38,111 @@ interface SearchParams {
   page?: string;
 }
 
+// No outer try/catch: letting a fetch failure throw here keeps ISR serving
+// the last good page instead of permanently caching an all-empty results
+// page. (The inner letter-count try/catch below is a narrow, non-fatal
+// degradation of a secondary stat — that's fine to keep.)
 async function getEntitiesRaw(searchParams: SearchParams) {
+  const type = searchParams.type && searchParams.type !== 'all' ? searchParams.type : null;
+  const minBooks = parseInt(searchParams.min_books || '2') || 2;
+  const query = searchParams.q?.trim() || null;
+  const letter = searchParams.letter?.trim().toUpperCase() || null;
+  const sortMode = searchParams.sort || 'relevance';
+  const page = Math.max(1, parseInt(searchParams.page || '1') || 1);
+  const offset = (page - 1) * PER_PAGE;
+
+  // Build Supabase query for entities
+  let baseQuery = supabase
+    .from('entities')
+    .select('id, name, type, book_count, total_mentions, description, wikidata_birth_date, wikidata_death_date', { count: 'exact' })
+    .gte('book_count', minBooks);
+
+  if (type) baseQuery = baseQuery.eq('type', type);
+  if (query) baseQuery = baseQuery.ilike('name', `%${query}%`);
+  if (letter && !query) baseQuery = baseQuery.ilike('name', `${letter}%`);
+
+  if (sortMode === 'alpha') {
+    baseQuery = baseQuery.order('name', { ascending: true });
+  } else {
+    baseQuery = baseQuery.order('book_count', { ascending: false }).order('total_mentions', { ascending: false });
+  }
+
+  baseQuery = baseQuery.range(offset, offset + PER_PAGE - 1);
+
+  // Stats query: count by type (with same filters except type)
+  let statsQuery = supabase
+    .from('entities')
+    .select('type', { count: 'exact' })
+    .gte('book_count', minBooks);
+  if (query) statsQuery = statsQuery.ilike('name', `%${query}%`);
+  if (letter && !query) statsQuery = statsQuery.ilike('name', `${letter}%`);
+
+  // Run queries in parallel
+  const [entitiesResult, personCount, placeCount, conceptCount] = await Promise.all([
+    baseQuery,
+    supabase.from('entities').select('id', { count: 'exact', head: true }).gte('book_count', minBooks).eq('type', 'person')
+      .then(r => r.count || 0),
+    supabase.from('entities').select('id', { count: 'exact', head: true }).gte('book_count', minBooks).eq('type', 'place')
+      .then(r => r.count || 0),
+    supabase.from('entities').select('id', { count: 'exact', head: true }).gte('book_count', minBooks).eq('type', 'concept')
+      .then(r => r.count || 0),
+  ]);
+
+  const entities = entitiesResult.data || [];
+  const total = entitiesResult.count || 0;
+
+  // Letter distribution: use a single RPC call or lightweight query
+  // Instead of paginating all names, use SQL to count by first letter
+  const letterMap: Record<string, number> = {};
   try {
-    const type = searchParams.type && searchParams.type !== 'all' ? searchParams.type : null;
-    const minBooks = parseInt(searchParams.min_books || '2') || 2;
-    const query = searchParams.q?.trim() || null;
-    const letter = searchParams.letter?.trim().toUpperCase() || null;
-    const sortMode = searchParams.sort || 'relevance';
-    const page = Math.max(1, parseInt(searchParams.page || '1') || 1);
-    const offset = (page - 1) * PER_PAGE;
-
-    // Build Supabase query for entities
-    let baseQuery = supabase
+    // Build a raw SQL approach via Supabase RPC, falling back to sampling
+    // For performance, just fetch first 5000 names (covers most cases)
+    let letterQuery = supabase
       .from('entities')
-      .select('id, name, type, book_count, total_mentions, description, wikidata_birth_date, wikidata_death_date', { count: 'exact' })
-      .gte('book_count', minBooks);
+      .select('name')
+      .gte('book_count', minBooks)
+      .order('name', { ascending: true })
+      .limit(5000);
+    if (type) letterQuery = letterQuery.eq('type', type);
+    if (query) letterQuery = letterQuery.ilike('name', `%${query}%`);
 
-    if (type) baseQuery = baseQuery.eq('type', type);
-    if (query) baseQuery = baseQuery.ilike('name', `%${query}%`);
-    if (letter && !query) baseQuery = baseQuery.ilike('name', `${letter}%`);
-
-    if (sortMode === 'alpha') {
-      baseQuery = baseQuery.order('name', { ascending: true });
-    } else {
-      baseQuery = baseQuery.order('book_count', { ascending: false }).order('total_mentions', { ascending: false });
-    }
-
-    baseQuery = baseQuery.range(offset, offset + PER_PAGE - 1);
-
-    // Stats query: count by type (with same filters except type)
-    let statsQuery = supabase
-      .from('entities')
-      .select('type', { count: 'exact' })
-      .gte('book_count', minBooks);
-    if (query) statsQuery = statsQuery.ilike('name', `%${query}%`);
-    if (letter && !query) statsQuery = statsQuery.ilike('name', `${letter}%`);
-
-    // Run queries in parallel
-    const [entitiesResult, personCount, placeCount, conceptCount] = await Promise.all([
-      baseQuery,
-      supabase.from('entities').select('id', { count: 'exact', head: true }).gte('book_count', minBooks).eq('type', 'person')
-        .then(r => r.count || 0),
-      supabase.from('entities').select('id', { count: 'exact', head: true }).gte('book_count', minBooks).eq('type', 'place')
-        .then(r => r.count || 0),
-      supabase.from('entities').select('id', { count: 'exact', head: true }).gte('book_count', minBooks).eq('type', 'concept')
-        .then(r => r.count || 0),
-    ]);
-
-    const entities = entitiesResult.data || [];
-    const total = entitiesResult.count || 0;
-
-    // Letter distribution: use a single RPC call or lightweight query
-    // Instead of paginating all names, use SQL to count by first letter
-    const letterMap: Record<string, number> = {};
-    try {
-      // Build a raw SQL approach via Supabase RPC, falling back to sampling
-      // For performance, just fetch first 5000 names (covers most cases)
-      let letterQuery = supabase
-        .from('entities')
-        .select('name')
-        .gte('book_count', minBooks)
-        .order('name', { ascending: true })
-        .limit(5000);
-      if (type) letterQuery = letterQuery.eq('type', type);
-      if (query) letterQuery = letterQuery.ilike('name', `%${query}%`);
-
-      const { data: letterData } = await letterQuery;
-      if (letterData) {
-        for (const row of letterData) {
-          const firstLetter = (row.name as string)?.[0]?.toUpperCase();
-          if (firstLetter && /[A-Z]/.test(firstLetter)) {
-            letterMap[firstLetter] = (letterMap[firstLetter] || 0) + 1;
-          }
+    const { data: letterData } = await letterQuery;
+    if (letterData) {
+      for (const row of letterData) {
+        const firstLetter = (row.name as string)?.[0]?.toUpperCase();
+        if (firstLetter && /[A-Z]/.test(firstLetter)) {
+          letterMap[firstLetter] = (letterMap[firstLetter] || 0) + 1;
         }
       }
-    } catch {
-      // If letter counting fails, the page still renders — just without letter counts
     }
-
-    return {
-      entities: entities.map(e => ({
-        _id: e.id as string,
-        name: e.name as string,
-        type: e.type as 'person' | 'place' | 'concept',
-        book_count: (e.book_count || 0) as number,
-        total_mentions: (e.total_mentions || 0) as number,
-        description: (e.description || null) as string | null,
-        wikidata_birth_date: (e.wikidata_birth_date || undefined) as string | undefined,
-        wikidata_death_date: (e.wikidata_death_date || undefined) as string | undefined,
-        books: [] as Array<{ book_id: string; book_title: string }>,
-      })),
-      total,
-      page,
-      totalPages: Math.ceil(total / PER_PAGE),
-      stats: {
-        total: (personCount as number) + (placeCount as number) + (conceptCount as number),
-        people: personCount as number,
-        places: placeCount as number,
-        concepts: conceptCount as number,
-      },
-      letterMap,
-    };
-  } catch (err) {
-    console.error('Encyclopedia data fetch failed:', err);
-    return {
-      entities: [],
-      total: 0,
-      page: 1,
-      totalPages: 0,
-      stats: { total: 0, people: 0, places: 0, concepts: 0 },
-      letterMap: {},
-    };
+  } catch {
+    // If letter counting fails, the page still renders — just without letter counts.
+    // (Narrow, non-fatal degradation of a secondary stat — not the dangerous pattern.)
   }
+
+  return {
+    entities: entities.map(e => ({
+      _id: e.id as string,
+      name: e.name as string,
+      type: e.type as 'person' | 'place' | 'concept',
+      book_count: (e.book_count || 0) as number,
+      total_mentions: (e.total_mentions || 0) as number,
+      description: (e.description || null) as string | null,
+      wikidata_birth_date: (e.wikidata_birth_date || undefined) as string | undefined,
+      wikidata_death_date: (e.wikidata_death_date || undefined) as string | undefined,
+      books: [] as Array<{ book_id: string; book_title: string }>,
+    })),
+    total,
+    page,
+    totalPages: Math.ceil(total / PER_PAGE),
+    stats: {
+      total: (personCount as number) + (placeCount as number) + (conceptCount as number),
+      people: personCount as number,
+      places: placeCount as number,
+      concepts: conceptCount as number,
+    },
+    letterMap,
+  };
 }
 
 // Cache encyclopedia queries so Supabase fetch() calls don't make the page dynamic
@@ -157,7 +151,7 @@ async function getEntities(params: SearchParams) {
   const cached = unstable_cache(
     () => getEntitiesRaw(params),
     ['encyclopedia', cacheKey],
-    { revalidate: false },
+    { revalidate: 3600 },
   );
   return cached();
 }

--- a/src/app/research/[id]/page.tsx
+++ b/src/app/research/[id]/page.tsx
@@ -7,7 +7,9 @@ import ConversationView from '@/components/research/ConversationView';
 import type { CuratorSession, BookRef } from '@/lib/api-client/types/research';
 import Link from 'next/link';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever
+// (e.g. the noindex metadata below) until the next deploy.
+export const revalidate = 21600;
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -15,16 +17,13 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  let session;
-  try {
-    const db = await getReadDb();
-    session = await db.collection('curator_sessions').findOne(
-      { id },
-      { projection: { title: 1, themes: 1, date: 1 } }
-    );
-  } catch {
-    return { title: 'Source Library', robots: { index: false, follow: false } };
-  }
+  // No try/catch: letting a fetch failure throw here keeps ISR serving the
+  // last good page instead of permanently caching noindex fallback metadata.
+  const db = await getReadDb();
+  const session = await db.collection('curator_sessions').findOne(
+    { id },
+    { projection: { title: 1, themes: 1, date: 1 } }
+  );
 
   if (!session) return { title: 'Session Not Found' };
 

--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -5,7 +5,9 @@ import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPag
 import ResearchClient from '@/components/research/ResearchClient';
 import type { CuratorSessionListItem } from '@/lib/api-client/types/research';
 
-export const revalidate = false;
+// ISR: rebuild every hour. Must be a finite number — `false` would cache an
+// empty-fallback render forever if the sessions query ever fails.
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: 'Research Sessions - Source Library',
@@ -38,39 +40,38 @@ export default async function ResearchPage() {
   );
 }
 
+// No try/catch: a thrown error during ISR revalidation keeps serving the
+// last good page, while catching it here would render (and cache) an empty
+// session list for the full revalidate window. Cold failures land on
+// src/app/error.tsx.
 async function fetchInitialData() {
-  try {
-    const db = await getReadDb();
-    const collection = db.collection('curator_sessions');
+  const db = await getReadDb();
+  const collection = db.collection('curator_sessions');
 
-    const [sessions, total, themesAgg, typesAgg] = await Promise.all([
-      collection
-        .find({}, { projection: { messages: 0 } })
-        .sort({ date: -1 })
-        .limit(20)
-        .toArray(),
-      collection.countDocuments(),
-      collection.aggregate([
-        { $unwind: '$themes' },
-        { $group: { _id: '$themes', count: { $sum: 1 } } },
-        { $sort: { count: -1 } },
-      ]).toArray(),
-      collection.aggregate([
-        { $group: { _id: '$session_type', count: { $sum: 1 } } },
-        { $sort: { count: -1 } },
-      ]).toArray(),
-    ]);
+  const [sessions, total, themesAgg, typesAgg] = await Promise.all([
+    collection
+      .find({}, { projection: { messages: 0 } })
+      .sort({ date: -1 })
+      .limit(20)
+      .toArray(),
+    collection.countDocuments(),
+    collection.aggregate([
+      { $unwind: '$themes' },
+      { $group: { _id: '$themes', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+    ]).toArray(),
+    collection.aggregate([
+      { $group: { _id: '$session_type', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+    ]).toArray(),
+  ]);
 
-    const cleaned = sessions.map(({ _id, ...rest }) => rest) as unknown as CuratorSessionListItem[];
+  const cleaned = sessions.map(({ _id, ...rest }) => rest) as unknown as CuratorSessionListItem[];
 
-    return {
-      sessions: cleaned,
-      total,
-      themes: themesAgg.map(t => t._id as string),
-      types: typesAgg.map(t => t._id as string),
-    };
-  } catch (error) {
-    console.error('Failed to fetch research sessions:', error);
-    return { sessions: [], total: 0, themes: [], types: [] };
-  }
+  return {
+    sessions: cleaned,
+    total,
+    themes: themesAgg.map(t => t._id as string),
+    types: typesAgg.map(t => t._id as string),
+  };
 }

--- a/src/app/shwep/[number]/page.tsx
+++ b/src/app/shwep/[number]/page.tsx
@@ -6,7 +6,9 @@ import remarkGfm from 'remark-gfm';
 import { getEpisodeData, getAllEpisodeNumbers } from '../shwep-data';
 import type { MatchedBook } from '../shwep-data';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever
+// (e.g. the noindex metadata below) until the next deploy.
+export const revalidate = 21600;
 
 interface Props {
   params: Promise<{ number: string }>;
@@ -14,12 +16,9 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { number } = await params;
-  let ep;
-  try {
-    ep = await getEpisodeData(parseInt(number));
-  } catch {
-    return { title: 'Source Library', robots: { index: false, follow: false } };
-  }
+  // No try/catch: letting a fetch failure throw here keeps ISR serving the
+  // last good page instead of permanently caching noindex fallback metadata.
+  const ep = await getEpisodeData(parseInt(number));
   if (!ep) return { title: 'Episode Not Found - SHWEP Reading Room', robots: { index: false, follow: true } };
   return {
     title: `${ep.title} - SHWEP Reading Room`,

--- a/src/app/shwep/page.tsx
+++ b/src/app/shwep/page.tsx
@@ -3,7 +3,8 @@ import { getShwepIndexData } from './shwep-data';
 import ShwepClient from './ShwepClient';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever.
+export const revalidate = 21600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {
@@ -17,18 +18,12 @@ export const metadata: Metadata = {
   },
 };
 
+// No try/catch: a thrown error during ISR revalidation keeps serving the
+// last good page, while catching it here would render (and cache) an
+// all-zero episode index for the full revalidate window. Cold failures land
+// on src/app/error.tsx.
 export default async function ShwepPage() {
-  let data;
-  try {
-    data = await getShwepIndexData();
-  } catch (err) {
-    console.error('SHWEP data fetch failed:', err);
-    data = {
-      periods: [],
-      galleryImages: [],
-      stats: { totalEpisodes: 0, episodesWithBooks: 0, totalMatches: 0, totalBooksInCollection: 0 },
-    };
-  }
+  const data = await getShwepIndexData();
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -9,7 +9,9 @@ import { bookUrl } from '@/lib/slugify';
 import { FACETS, facetDbField } from '@/lib/taxonomy/faceted-vocabulary';
 import { getBookThumbnailUrl } from '@/lib/utils';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever
+// (e.g. the noindex metadata below) until the next deploy.
+export const revalidate = 21600;
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -78,17 +80,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   // Fall back to old cluster slug
-  let match;
-  try {
-    const db = await getReadDb();
-    const allClusters = await db.collection('books').aggregate([
-      { $match: { visible: true, 'taxonomy.cluster': { $exists: true, $ne: null } } },
-      { $group: { _id: '$taxonomy.cluster' } },
-    ]).toArray();
-    match = allClusters.find((c) => topicSlug(c._id) === slug);
-  } catch {
-    return { title: 'Source Library', robots: { index: false, follow: false } };
-  }
+  // No try/catch: letting a fetch failure throw here keeps ISR serving the
+  // last good page instead of permanently caching noindex fallback metadata.
+  const db = await getReadDb();
+  const allClusters = await db.collection('books').aggregate([
+    { $match: { visible: true, 'taxonomy.cluster': { $exists: true, $ne: null } } },
+    { $group: { _id: '$taxonomy.cluster' } },
+  ]).toArray();
+  const match = allClusters.find((c) => topicSlug(c._id) === slug);
   if (!match) return {
     title: 'Topic Not Found - Source Library',
     robots: { index: false, follow: true },

--- a/src/app/topics/clusters/page.tsx
+++ b/src/app/topics/clusters/page.tsx
@@ -4,7 +4,9 @@ import Image from 'next/image';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import type { Metadata } from 'next';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a zeroed-out fallback forever
+// (e.g. if the aggregation below times out) until the next deploy.
+export const revalidate = 21600;
 
 export const metadata: Metadata = {
   title: 'AI-Discovered Topic Clusters | Source Library',
@@ -73,11 +75,12 @@ async function fetchTopics(): Promise<{ topics: TopicSummary[]; totalBooks: numb
     { $sort: { count: -1 as const } },
   ];
 
+  // No .catch() here: letting a timeout throw keeps ISR serving the last good
+  // page instead of permanently caching a "0 books, 0 topics" render.
   const results = await db
     .collection('books')
     .aggregate(pipeline, { allowDiskUse: true, maxTimeMS: 30000 })
-    .toArray()
-    .catch(() => [] as Record<string, unknown>[]);
+    .toArray();
 
   let totalBooks = 0;
   const topics: TopicSummary[] = results.map((r) => {

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -6,7 +6,9 @@ import type { Book } from '@/lib/types';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { getBookThumbnailUrl } from '@/lib/utils';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad-render fallback forever
+// (e.g. the noindex metadata below) until the next deploy.
+export const revalidate = 21600;
 export const dynamicParams = true;
 export async function generateStaticParams() {
   return [];
@@ -57,12 +59,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   // arrives percent-encoded, so decode before matching against Mongo — otherwise
   // the query silently finds 0 editions and 404s. Same pattern as /author/[name].
   const id = decodeURIComponent(rawId);
-  let editions: Awaited<ReturnType<typeof getWorkEditions>>;
-  try {
-    editions = await getWorkEditions(id);
-  } catch {
-    return { title: 'Source Library', robots: { index: false, follow: false } };
-  }
+  // No try/catch: letting a fetch failure throw here keeps ISR serving the
+  // last good page instead of permanently caching noindex fallback metadata.
+  const editions = await getWorkEditions(id);
   if (editions.length === 0) return { title: 'Work Not Found', robots: { index: false, follow: true } };
 
   const title = workTitleFromEditions(editions as { work_title?: string | null }[], id);


### PR DESCRIPTION
## Summary

Fixes #2974. Audited every page in `src/app/` using `export const revalidate = false` (28 as of 2026-07-05) against the dangerous combo identified in the /explore/timeline outage (#2973): a static page whose data fetch can fail, wrapped in a try/catch (or inline `.catch()`) that renders/returns a fallback. One bad render caches that fallback — an "unavailable" message, or zeroed/empty stats — permanently, until the next deploy.

**Fixed (full combo — catch renders a fallback body/data):**
- `src/app/research/page.tsx` — removed catch around session list fetch, `revalidate: 3600`
- `src/app/dataset/page.tsx` — removed catch that fell back to stale snapshot numbers, `revalidate: 21600` (matches existing "rebuild every 6 hours" comment, which `false` was silently contradicting)
- `src/app/data/page.tsx` — removed catch to `EMPTY_DATA`, `revalidate: 600` (matches existing "rebuild every 10 minutes" comment)
- `src/app/encyclopedia/page.tsx` — removed the outer catch-to-empty-results (kept the inner letter-count catch, which is a narrow non-fatal degradation of a secondary stat, not the dangerous pattern), `revalidate: 3600`, and matched the `unstable_cache` `revalidate: false` to the same finite window
- `src/app/shwep/page.tsx` — removed catch to all-zero episode index, `revalidate: 21600` (matches existing comment)
- `src/app/topics/clusters/page.tsx` — removed an inline `.catch(() => [])` on the taxonomy aggregate that silently rendered "0 books, 0 topics", `revalidate: 21600`
- `src/app/collections/contemplative-traditions/page.tsx` and `src/app/collections/sacred-texts/page.tsx` — these weren't in the issue's list but have the *worst* version of the pattern: an inner catch swallowing to an empty tradition list, wrapped in an outer page-level catch that explicitly renders "Temporarily Unavailable" — both catches removed, `revalidate: 21600`
- `src/app/work/[id]/page.tsx`, `src/app/topics/[slug]/page.tsx`, `src/app/artwork/artist/[slug]/page.tsx` (named in the issue), plus `src/app/artwork/[slug]/page.tsx`, `src/app/research/[id]/page.tsx`, `src/app/shwep/[number]/page.tsx` (found during the audit, same shape but not named in the issue) — `generateMetadata` swallowed fetch failures into `{ title: 'Source Library', robots: { index: false, follow: false } }`, which would then get baked into the static render and deindex the page until the next deploy. Removed the catch; the page body in all of these already threw correctly. `revalidate: 21600`.

**Verified and left alone (throw-on-failure, no catch — safe even under `revalidate = false` since a thrown error is never cached, only a caught fallback is):** `/artwork`, `/curated`, `/ficino-society/members`, `/contribute/wikipedia`, `/work/[id]/compare`, `/design-options`, `/design-options/all-editorial`.

**Verified genuinely static (no server-side fetch — client-driven pages, `false` is fine):** `/explore/constellation`, `/taxonomy`, `/research/image-atlas`, `/research/image-pixplot`, `/research/translation-gap`, `/research/translation-registry`.

**Out of scope:** `/explore/map` and `/explore/timeline` — already fixed in prior PRs (#2973 and the map fix referenced in its comment). No lint rule or grep guard was added to statically prevent the pattern from returning (the issue's acceptance criteria offered a CLAUDE.md note as an alternative) — added a short invariant to `CLAUDE.md` under Development Workflow instead. A follow-up CI grep/lint check would be a reasonable next step if this pattern recurs.

## Test plan
- [x] `npx tsc --noEmit` passes clean
- [ ] Spot-check a couple of the fixed pages in the Vercel preview once deployed (`/data`, `/dataset`, `/shwep`, `/collections/sacred-texts`) to confirm they still render correctly