### PR TITLE
fix(acquire): pass USTC language on import so catalog books aren't 'Unknown'

### DIFF
--- a/scripts/catalog-coverage/acquire-gap-batch.mjs
+++ b/scripts/catalog-coverage/acquire-gap-batch.mjs
@@ -101,7 +101,9 @@ async function verify(w, cands) {
 async function importWork(w, hit) {
   const colls = w.category === 'witch-trials' ? ['witchcraft'] : ['astrology', 'natural-philosophy'];
   const ep = hit.src === 'ia' ? '/api/import/ia' : '/api/import/iiif';
-  const body = hit.src === 'ia' ? { ia_identifier: hit.ref, title: w.title, author: w.author, collections: colls } : { manifest_url: hit.ref, title: w.title, author: w.author, collections: colls };
+  // Pass the USTC language (authoritative) — the IIIF import otherwise stores 'Unknown',
+  // which keeps genuine Latin acquisitions out of the Latin filter / held count.
+  const body = hit.src === 'ia' ? { ia_identifier: hit.ref, title: w.title, author: w.author, collections: colls, language: w.lang } : { manifest_url: hit.ref, title: w.title, author: w.author, collections: colls, language: w.lang };
   const r = await fetch(BASE + ep, { method: 'POST', headers: { Authorization: 'Bearer ' + process.env.CRON_SECRET, 'Content-Type': 'application/json' }, body: JSON.stringify(body), signal: AbortSignal.timeout(60000) });
   const j = await r.json(); return (r.ok && (j.success || j.bookId)) ? j.bookId : null;
 }


### PR DESCRIPTION
## Problem

`/api/import/iiif` defaults `language` to `'Unknown'` when the body doesn't supply one. `importWork` never passed a language, so every German-library (catalog-resolved) acquisition landed as `'Unknown'` — **1,252 genuine Latin books** were invisible to the Latin filter and the held count (which rose only +153 despite 1,882 catalog imports overnight).

## Fix

`importWork` now passes the authoritative USTC language (`w.lang`) in the import body for both IA and IIIF. USTC `language_1` is reliable bibliographic metadata (1,252 Latin / 630 German across the current catalog acquisitions).

Existing 1,882 rows were backfilled operationally (Latin held 13,199 → 14,451). This stops the ongoing drain (~99K pending → ~25K more catalog imports) from re-accumulating `'Unknown'`.

## Context

Follow-up to #2966/#2970/#2971. The acquisition engine is healthy (~26% acquire rate); this just makes the results correctly counted and discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)