### PR TITLE
fix(about): align /about/processing revalidate with stated 6h intent

### DIFF
--- a/src/app/about/processing/page.tsx
+++ b/src/app/about/processing/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 };
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const revalidate = 60;
+export const revalidate = 21600;
 export const maxDuration = 60;
 
 /* ── Data fetching ── */


### PR DESCRIPTION
## Summary
- `src/app/about/processing/page.tsx` had `revalidate = 60` while the comment directly above it says "rebuild every 6 hours" — a drift that made ISR re-run the page's four full `books` collection `$group` aggregations (one measured at 66s) roughly every minute under traffic instead of every 6 hours.
- Sets `revalidate` to `21600` (6h) to match the stated intent. `maxDuration` (60s, for first-hit generation) is untouched.

## Scope
In scope: the single `revalidate` value. Out of scope (deliberately, for a focused review): restructuring the page's queries, adding caching layers, or touching `maxDuration` — those are separate concerns if still needed after this fix.

Identified by the #2980 render-query inventory: https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2980#issuecomment-4883999912

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Vercel preview: confirm `/about/processing` renders correctly and stats still populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)