### PR TITLE
fix(gallery): read opengraph-image featured images from gallery_images

### DIFF
--- a/src/app/gallery/opengraph-image.tsx
+++ b/src/app/gallery/opengraph-image.tsx
@@ -13,39 +13,31 @@ export const contentType = 'image/png';
  * Fetch high-quality gallery images that have pre-extracted URLs.
  * Never use /api/crop-image here — it's unreliable during OG generation
  * and produces garbled previews on social platforms.
+ *
+ * Reads the materialized `gallery_images` collection (already filtered to
+ * visible books at sync time) instead of scanning `pages.detected_images`
+ * with an $elemMatch — the pages-collection version of this query measured
+ * >120s against 13.1M docs vs ~0.2s here (see #2980).
  */
 async function getFeaturedImages(): Promise<string[]> {
   try {
     const db = await getReadDb();
-    const results = await db.collection('pages').aggregate([
-      {
-        $match: {
-          'detected_images': {
-            $elemMatch: {
-              extracted_url: { $exists: true, $ne: '' },
-              gallery_quality: { $gte: 0.85 },
-            },
-          },
+    const results = await db
+      .collection('gallery_images')
+      .find(
+        {
+          gallery_quality: { $gte: 0.85 },
+          extracted_url: { $exists: true, $ne: '' },
+          book_visible: true,
+          book_hidden: { $ne: true },
         },
-      },
-      { $unwind: '$detected_images' },
-      {
-        $match: {
-          'detected_images.extracted_url': { $exists: true, $ne: '' },
-          'detected_images.gallery_quality': { $gte: 0.85 },
-        },
-      },
-      { $sort: { 'detected_images.gallery_quality': -1 } },
-      { $limit: 3 },
-      {
-        $project: {
-          _id: 0,
-          url: '$detected_images.extracted_url',
-        },
-      },
-    ]).toArray();
+        { projection: { _id: 0, extracted_url: 1 } }
+      )
+      .sort({ gallery_quality: -1 })
+      .limit(3)
+      .toArray();
 
-    return results.map((r) => r.url as string).filter(Boolean);
+    return results.map((r) => r.extracted_url as string).filter(Boolean);
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- `src/app/gallery/opengraph-image.tsx` scanned the `pages` collection (13.1M docs) with an `$elemMatch` + `$unwind` over `detected_images` to pick 3 high-quality featured images — measured at >120s under the #2980 render-query inventory.
- The materialized `gallery_images` collection (written by `sync-gallery-images`, already filtered to `book.visible: true` at sync time) holds the same data; the equivalent query against it measured ~0.2s.
- Rewrote `getFeaturedImages()` to read from `gallery_images` directly instead of `pages`.

## Field mapping verified
Confirmed against a live prod read (read-only sample, `bookstore.gallery_images`):
- `detected_images.extracted_url` → `gallery_images.extracted_url` (present)
- `detected_images.gallery_quality` → `gallery_images.gallery_quality` (present, same 0–1 scale)
- Added `book_visible: true` + `book_hidden: { $ne: true }` filters for defense in depth (matches the pattern used elsewhere, e.g. `src/app/api/gallery/route.ts`), even though `sync-gallery-images` already restricts writes to visible books.
- 47,424 docs match `gallery_quality >= 0.85` with these filters, so the route has plenty of candidates.

## Graceful degradation preserved
The `try/catch` around the query still returns `[]` on any failure, and the render path already falls back to placeholder tiles when `images.length === 0` — unchanged, so a query failure can never 500 the route.

## Scope
In scope: swapping the query source only. Out of scope: changing the OG image's visual design or the 0.85 quality threshold.

Identified by the #2980 render-query inventory: https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2980#issuecomment-4883999912

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Verified `gallery_images` field shapes against a live prod sample (read-only)
- [ ] Vercel preview: fetch `/gallery/opengraph-image` and confirm it renders with real images

🤖 Generated with [Claude Code](https://claude.com/claude-code)