### PR TITLE
feat(acquire): map collections by seed category (Greek gets none, not astrology)

### DIFF
--- a/scripts/catalog-coverage/acquire-gap-batch.mjs
+++ b/scripts/catalog-coverage/acquire-gap-batch.mjs
@@ -99,7 +99,11 @@ async function verify(w, cands) {
   try { const r = await withTimeout(ai.models.generateContent({ model: MODEL, contents: prompt, config: { temperature: 0, maxOutputTokens: 60 } }), 30000, 'verify'); const j = JSON.parse((r.text || '').match(/\{[^}]*\}/)[0]); return (j.match >= 0 && j.confidence === 'high') ? cands[j.match] : null; } catch { return null; }
 }
 async function importWork(w, hit) {
-  const colls = w.category === 'witch-trials' ? ['witchcraft'] : ['astrology', 'natural-philosophy'];
+  // Collections by seed category. Unknown categories (e.g. broad Greek classics) get NO
+  // collection — imported hidden and curated later — rather than being forced into
+  // astrology/natural-philosophy where they don't belong.
+  const COLL_MAP = { 'witch-trials': ['witchcraft'], 'mission': ['astrology', 'natural-philosophy'] };
+  const colls = COLL_MAP[w.category] || [];
   const ep = hit.src === 'ia' ? '/api/import/ia' : '/api/import/iiif';
   // Pass the USTC language (authoritative) — the IIIF import otherwise stores 'Unknown',
   // which keeps genuine Latin acquisitions out of the Latin filter / held count.


### PR DESCRIPTION
## What

`importWork` hard-coded every non-witch acquisition into `['astrology','natural-philosophy']`. Correct for the science/medicine mission works, but wrong for a broad-language seed like Greek (classical literature, grammars, Church Fathers).

Replace with a category→collections map; unknown categories import **hidden with no collection** and get curated later. This lets us seed Greek (and other languages) without mis-filing them into astrology.

## Context

Extends the USTC-gap acquisition (#2966/#2970/#2971/#2985) toward Greek. We hold 1,234 Greek; USTC has 10,491 Greek editions (3,364 with scans). Greek recovery leans on IA (Aldine/classical), not the German-library catalog. A measured pilot follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)