### PR TITLE
fix(api): add maxTimeMS guards + edge caching to unbudgeted public routes

### DIFF
--- a/src/app/api/catalog/coverage/route.ts
+++ b/src/app/api/catalog/coverage/route.ts
@@ -3,6 +3,22 @@ import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
+// No maxDuration was previously set (defaulted to the plan default). The
+// mode=timeline $group over the full 2.45M-doc catalog_coverage collection
+// measured >120s uncapped, so an explicit, tight budget is needed here —
+// the query-time guard below (TIMELINE_QUERY_TIMEOUT_MS) is what actually
+// stops the aggregation; this just bounds the function itself.
+export const maxDuration = 15;
+
+// Kept well below maxDuration so Mongo aborts the aggregation and we can
+// return a clean 503 before Vercel force-kills the function (at which point
+// the aggregation would keep running server-side on Atlas).
+const TIMELINE_QUERY_TIMEOUT_MS = 10_000;
+
+function isMongoTimeout(err: unknown): boolean {
+  const e = err as { codeName?: string; code?: number } | null;
+  return e?.codeName === 'MaxTimeMSExpired' || e?.code === 50;
+}
 
 /**
  * Catalog Coverage API — query the unified USTC coverage database.
@@ -38,8 +54,17 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: `Unknown mode: ${mode}` }, { status: 400 });
     }
   } catch (err) {
+    if (isMongoTimeout(err)) {
+      return NextResponse.json(
+        { error: 'Catalog coverage data is temporarily unavailable — the database is under load. Try again shortly.' },
+        { status: 503, headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
     console.error('Catalog coverage API error:', err);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
   }
 }
 
@@ -169,7 +194,7 @@ async function handleTimeline(db: any, params: URLSearchParams) {
       }
     },
     { $sort: { _id: 1 } },
-  ]).toArray();
+  ], { maxTimeMS: TIMELINE_QUERY_TIMEOUT_MS }).toArray();
 
   return NextResponse.json({
     language: language || 'all',
@@ -182,6 +207,14 @@ async function handleTimeline(db: any, params: URLSearchParams) {
       pct_translated: d.editions > 0 ? +(d.with_translation / d.editions * 100).toFixed(1) : 0,
       in_source_library: d.in_source_library,
     })),
+  }, {
+    // Full-collection $group over 2.45M docs — cache the result at the edge
+    // so repeat traffic doesn't re-trigger the scan. Only set on success;
+    // the 503 timeout path above is explicitly no-store.
+    headers: {
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      'CDN-Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
   });
 }
 

--- a/src/app/api/dataset/v1/stats/route.ts
+++ b/src/app/api/dataset/v1/stats/route.ts
@@ -4,6 +4,18 @@ import { getReadDb } from '@/lib/mongodb';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 15;
 
+// Query-time guard: 4 aggregations run in parallel via Promise.all, so each
+// gets up to this budget concurrently. Kept well below maxDuration (15s) to
+// leave headroom for connection setup + response serialization, and so a
+// slow Mongo query fails cleanly (503) instead of the whole function getting
+// hard-killed at 15s while the aggregation keeps running server-side.
+const QUERY_TIMEOUT_MS = 10_000;
+
+function isMongoTimeout(err: unknown): boolean {
+  const e = err as { codeName?: string; code?: number } | null;
+  return e?.codeName === 'MaxTimeMSExpired' || e?.code === 50;
+}
+
 /**
  * GET /api/dataset/v1/stats
  *
@@ -15,57 +27,77 @@ export async function GET() {
   const books = db.collection('books');
   const visible = { visible: true };
 
-  const [
-    totalBooks,
-    languagesAgg,
-    clustersAgg,
-    pageTotalsAgg,
-    dateRangeAgg,
-  ] = await Promise.all([
-    books.countDocuments(visible),
+  let totalBooks: number;
+  let languagesAgg: Array<{ _id: string; count: number; pages_ocr: number; pages_translated: number }>;
+  let clustersAgg: Array<{ _id: string; count: number; pages_translated: number }>;
+  let pageTotalsAgg: Array<{ _id: null; pages: number; ocr: number; translated: number }>;
+  let dateRangeAgg: Array<{ _id: null; earliest: number; latest: number }>;
 
-    books.aggregate<{ _id: string; count: number; pages_ocr: number; pages_translated: number }>([
-      { $match: { ...visible, language: { $exists: true, $ne: 'Unknown' } } },
-      {
-        $group: {
-          _id: '$language',
-          count: { $sum: 1 },
-          pages_ocr: { $sum: { $ifNull: ['$pages_ocr', 0] } },
-          pages_translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
+  try {
+    [
+      totalBooks,
+      languagesAgg,
+      clustersAgg,
+      pageTotalsAgg,
+      dateRangeAgg,
+    ] = await Promise.all([
+      books.countDocuments(visible, { maxTimeMS: QUERY_TIMEOUT_MS }),
+
+      books.aggregate<{ _id: string; count: number; pages_ocr: number; pages_translated: number }>([
+        { $match: { ...visible, language: { $exists: true, $ne: 'Unknown' } } },
+        {
+          $group: {
+            _id: '$language',
+            count: { $sum: 1 },
+            pages_ocr: { $sum: { $ifNull: ['$pages_ocr', 0] } },
+            pages_translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
+          },
         },
-      },
-      { $sort: { count: -1 } },
-    ]).toArray(),
+        { $sort: { count: -1 } },
+      ], { maxTimeMS: QUERY_TIMEOUT_MS }).toArray(),
 
-    books.aggregate<{ _id: string; count: number; pages_translated: number }>([
-      { $match: { ...visible, 'taxonomy.cluster': { $exists: true } } },
-      {
-        $group: {
-          _id: '$taxonomy.cluster',
-          count: { $sum: 1 },
-          pages_translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
+      books.aggregate<{ _id: string; count: number; pages_translated: number }>([
+        { $match: { ...visible, 'taxonomy.cluster': { $exists: true } } },
+        {
+          $group: {
+            _id: '$taxonomy.cluster',
+            count: { $sum: 1 },
+            pages_translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
+          },
         },
-      },
-      { $sort: { count: -1 } },
-    ]).toArray(),
+        { $sort: { count: -1 } },
+      ], { maxTimeMS: QUERY_TIMEOUT_MS }).toArray(),
 
-    books.aggregate<{ _id: null; pages: number; ocr: number; translated: number }>([
-      { $match: visible },
-      {
-        $group: {
-          _id: null,
-          pages: { $sum: { $ifNull: ['$pages_count', 0] } },
-          ocr: { $sum: { $ifNull: ['$pages_ocr', 0] } },
-          translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
+      books.aggregate<{ _id: null; pages: number; ocr: number; translated: number }>([
+        { $match: visible },
+        {
+          $group: {
+            _id: null,
+            pages: { $sum: { $ifNull: ['$pages_count', 0] } },
+            ocr: { $sum: { $ifNull: ['$pages_ocr', 0] } },
+            translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
+          },
         },
-      },
-    ]).toArray(),
+      ], { maxTimeMS: QUERY_TIMEOUT_MS }).toArray(),
 
-    books.aggregate<{ _id: null; earliest: number; latest: number }>([
-      { $match: { ...visible, year: { $exists: true, $type: 'number' } } },
-      { $group: { _id: null, earliest: { $min: '$year' }, latest: { $max: '$year' } } },
-    ]).toArray(),
-  ]);
+      books.aggregate<{ _id: null; earliest: number; latest: number }>([
+        { $match: { ...visible, year: { $exists: true, $type: 'number' } } },
+        { $group: { _id: null, earliest: { $min: '$year' }, latest: { $max: '$year' } } },
+      ], { maxTimeMS: QUERY_TIMEOUT_MS }).toArray(),
+    ]);
+  } catch (err) {
+    if (isMongoTimeout(err)) {
+      return NextResponse.json(
+        { error: 'Corpus stats are temporarily unavailable — the database is under load. Try again shortly.' },
+        { status: 503, headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+    console.error('Dataset stats API error:', err);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
 
   const pageTotals = pageTotalsAgg[0] ?? { pages: 0, ocr: 0, translated: 0 };
   const dateRange = dateRangeAgg[0] ?? { earliest: 0, latest: 0 };
@@ -93,5 +125,13 @@ export async function GET() {
     })),
     pricing_url: 'https://sourcelibrary.org/dataset',
     api_docs_url: 'https://sourcelibrary.org/dataset#api',
+  }, {
+    // Corpus stats change slowly (daily pipeline cadence at most) — cache at
+    // the edge so repeat/bot traffic doesn't re-run these 4 scans. Mirrors
+    // the CDN-Cache-Control convention in next.config.ts / api/image.
+    headers: {
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      'CDN-Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
   });
 }


### PR DESCRIPTION
## Summary
- Closes the two unbudgeted public routes flagged in #2980's inventory (https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2980#issuecomment-4883999912):
  - `/api/dataset/v1/stats` — 4 parallel books-collection scans, measured 25.4s shape vs the route's `maxDuration 15`. The function hard-times-out while the Mongo aggregations keep running server-side on Atlas.
  - `/api/catalog/coverage?mode=timeline` — full `$group` over the 2.45M-doc `catalog_coverage` collection, measured >120s, with no `maxDuration` set at all.
- Both routes are unauthenticated, so an unbounded slow query is a pile-up risk under load/bot traffic.

## What changed (guards + caching only — no query restructuring)
- Added `maxTimeMS: 10_000` to every aggregation/`countDocuments` call in both routes, kept well below each route's `maxDuration` (now explicit `15` on both) so Mongo aborts the query and the function returns cleanly instead of either a platform 504 or a runaway server-side scan.
- On `MaxTimeMSExpired`, both routes now return `503` + `Cache-Control: no-store` with a short JSON error — never zeroed/empty stats served as if real (the #2974 anti-pattern).
- On success, both routes now set `Cache-Control`/`CDN-Cache-Control` (`s-maxage=3600` / `max-age=3600`, `stale-while-revalidate=86400`) so repeat traffic doesn't re-trigger the scans. Matches the existing house pattern (`next.config.ts`, `src/app/api/image/route.ts`, `src/app/api/books/timeline/route.ts`).

## Out of scope
- No changes to the aggregation pipelines themselves, no pre-computed snapshot/materialized-view work — that's separate follow-up (the `catalog_coverage` timeline query is a known heavy scan; a snapshot table is the real fix but out of scope for this PR).
- Other `mode=` handlers in `catalog/coverage/route.ts` (`search`, `works`, `summary`) were left untouched — they weren't flagged as unbudgeted and already have limits/pre-computed sources.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Read both routes' current code and confirmed the measured timeout numbers in #2980 against the actual query shapes before adding guards
- [ ] Manual curl of `/api/dataset/v1/stats` and `/api/catalog/coverage?mode=timeline` on the preview deploy to confirm 200 + cache headers under normal load

Refs #2980

🤖 Generated with [Claude Code](https://claude.com/claude-code)