### PR TITLE
feat(explore): /api/explore/map reads canonical_entities behind CANONICAL_ENTITIES_READPATH (#2979)

### DIFF
--- a/scripts/maintenance/build-canonical-entities.mjs
+++ b/scripts/maintenance/build-canonical-entities.mjs
@@ -121,19 +121,30 @@ for (const a of authorDocs) {
 }
 console.log(`authors thesaurus: ${authorDocs.length} docs (${slugByQid.size} QIDs, ${slugByEntityId.size} legacy entity links)`);
 
-// ── 4. book id -> language map (covered by books.id_language_covered, #2973).
+// ── 4. book id -> language + year maps. Adding `year` to the projection means
+// this is no longer fully covered by books.id_language_covered (#2973) — the
+// year fetch touches documents. That's fine HERE (offline nightly build,
+// measured ~+90s for ~14K docs); it is exactly the cost we're removing from
+// the /api/explore/map read path, which needs per-entity book years for its
+// century fallback (all 1,924 coord entities lack bio dates — measured
+// 2026-07-05, so century_range is entirely book-year driven).
 const allBookIds = new Set();
 for (const r of rows) for (const b of r.books || []) if (b.book_id) allBookIds.add(b.book_id);
 const langByBook = new Map();
+const yearByBook = new Map();
 const bookIdArr = [...allBookIds];
 for (let i = 0; i < bookIdArr.length; i += 5000) {
   const docs = await db.collection('books').find(
     { id: { $in: bookIdArr.slice(i, i + 5000) } },
-    { projection: { _id: 0, id: 1, language: 1 }, maxTimeMS: 120000 },
+    { projection: { _id: 0, id: 1, language: 1, year: 1 }, maxTimeMS: 120000 },
   ).toArray();
-  for (const d of docs) if (d.language) langByBook.set(d.id, d.language);
+  for (const d of docs) {
+    if (d.language) langByBook.set(d.id, d.language);
+    // same predicate as the map route's legacy $lookup: year exists and > 0
+    if (typeof d.year === 'number' && d.year > 0) yearByBook.set(d.id, d.year);
+  }
 }
-console.log(`book language map: ${langByBook.size}/${allBookIds.size} referenced book ids resolved`);
+console.log(`book language map: ${langByBook.size}/${allBookIds.size} referenced book ids resolved (${yearByBook.size} with year)`);
 
 // ── 5. Assemble one doc per canonical entity.
 const typeRank = { person: 3, place: 2, concept: 1 };
@@ -156,9 +167,16 @@ for (const [key, members] of groups) {
   }
   const rankedBooks = [...mentionsByBook.entries()].sort((a, b) => b[1] - a[1] || String(a[0]).localeCompare(String(b[0])));
   const languages = {};
+  let minYear = Infinity;
+  let maxYear = -Infinity;
   for (const [bookId] of rankedBooks) {
     const lang = langByBook.get(bookId);
     if (lang) languages[lang] = (languages[lang] || 0) + 1;
+    const year = yearByBook.get(bookId);
+    if (year) {
+      if (year < minYear) minYear = year;
+      if (year > maxYear) maxYear = year;
+    }
   }
 
   const pick = (field) => members.map(m => m[field]).find(v => v != null) ?? null;
@@ -194,6 +212,9 @@ for (const [key, members] of groups) {
     total_mentions: [...mentionsByBook.values()].reduce((s, n) => s + n, 0),
     book_ids: rankedBooks.slice(0, BOOK_IDS_CAP).map(([id]) => id),
     languages,                             // { la: 12, de: 3, ... } — timeline tradition rollup
+    // [min, max] publication year (>0) across ALL mentioning books (not capped
+    // by BOOK_IDS_CAP) — the map's century fallback (#2979 read-path PR 1).
+    book_year_range: minYear !== Infinity ? [minYear, maxYear] : null,
     entity_ids: members.map(m => String(m._id)),  // provenance: source rows merged
     source: 'build-canonical-entities',
     built_at: new Date(),

--- a/src/app/api/explore/map/route.ts
+++ b/src/app/api/explore/map/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from 'next/server';
+import type { Document } from 'mongodb';
 import { getReadDb } from '@/lib/mongodb';
+import {
+  CANONICAL_ENTITIES_COLLECTION,
+  canonicalEntitiesReadpathEnabled,
+} from '@/lib/canonical-entities';
 
 export const dynamic = 'force-dynamic';
 
@@ -8,13 +13,59 @@ export const dynamic = 'force-dynamic';
  *
  * Returns all entities with geographic coordinates, projected to minimal fields.
  * Includes century ranges derived from associated books.
+ *
+ * Two read paths (#2979): with CANONICAL_ENTITIES_READPATH on, reads the
+ * ~1,900-doc `canonical_entities` collection (pre-merged per QID, with the
+ * book-year rollup baked in) instead of scanning the ~1M-doc `entities`
+ * collection and $lookup-ing `books` for years.
  */
 export async function GET() {
   try {
     const db = await getReadDb();
 
-    // Get all entities with coordinates — lookup books for century data
-    const entities = await db.collection('entities').aggregate([
+    let entities: Document[];
+    if (canonicalEntitiesReadpathEnabled()) {
+      // Canonical read model: `book_year_range` is the pre-computed
+      // [min, max] of mentioning books' years (> 0) — exactly what the
+      // legacy $lookup derives — so the century math below is unchanged
+      // (it only ever takes min/max of `years`).
+      const docs = await db.collection(CANONICAL_ENTITIES_COLLECTION).find(
+        { wikidata_coordinates: { $ne: null } },
+        {
+          projection: {
+            _id: 0,
+            name: 1,
+            type: 1,
+            wikidata_coordinates: 1,
+            book_count: 1,
+            total_mentions: 1,
+            description: 1,
+            wikidata_id: 1,
+            wikidata_birth_date: 1,
+            wikidata_death_date: 1,
+            book_year_range: 1,
+          },
+          maxTimeMS: 15000,
+        },
+      ).toArray();
+      // All coord entities currently lack bio dates (measured 2026-07-05), so
+      // century_range is entirely book-year driven. If the flag is flipped
+      // before a rebuild that includes book_year_range, every century_range
+      // would silently become null — fail loudly instead (#2974: no silent
+      // degraded output).
+      if (docs.length > 0 && docs.every((d) => !('book_year_range' in d))) {
+        throw new Error(
+          'canonical_entities docs have no book_year_range — rerun build-canonical-entities.mjs before enabling CANONICAL_ENTITIES_READPATH',
+        );
+      }
+      entities = docs.map((d) => ({
+        ...d,
+        coordinates: d.wikidata_coordinates,
+        years: (d.book_year_range as number[] | null | undefined) ?? [],
+      }));
+    } else {
+      // Legacy path: scan `entities` with coordinates — lookup books for century data
+      entities = await db.collection('entities').aggregate([
       { $match: { wikidata_coordinates: { $exists: true, $ne: null } } },
       {
         $lookup: {
@@ -43,7 +94,8 @@ export async function GET() {
           years: '$book_docs.year',
         },
       },
-    ]).toArray();
+      ]).toArray();
+    }
 
     // Compute century range + stats
     const byType: Record<string, number> = {};

--- a/src/lib/canonical-entities.ts
+++ b/src/lib/canonical-entities.ts
@@ -66,6 +66,12 @@ export interface CanonicalEntityDoc {
   book_ids: string[];
   /** Language rollup of mentioning books, e.g. { la: 12, de: 3 } — timeline traditions. */
   languages: Record<string, number>;
+  /**
+   * [min, max] publication year (>0) across ALL mentioning books, or null —
+   * the map's century fallback (added in the read-path phase; docs built
+   * before 2026-07-05 lack the field, so readers must guard on presence).
+   */
+  book_year_range: [number, number] | null;
   /** Provenance: `entities._id`s merged into this doc. */
   entity_ids: string[];
   source: 'build-canonical-entities';


### PR DESCRIPTION
Read-path migration PR 1 of 3 for #2979 (order per the design comment: map → hub → timeline).

## What
- `/api/explore/map`: when `CANONICAL_ENTITIES_READPATH` is on, reads the ~1,924-doc coord sliver of `canonical_entities` with one indexed `find` — no 1M-row `entities` scan, no `$lookup` into `books`. **Flag off (default): byte-identical legacy path** (the original aggregate is untouched inside the else branch).
- Builder (`scripts/maintenance/build-canonical-entities.mjs`): adds a per-entity `book_year_range: [min, max]` rollup (publication year > 0 across ALL mentioning books, uncapped) + the matching field in `CanonicalEntityDoc`.

## Why the builder change (schema gap found)
The design assumed the map could just drop its `$lookup` — but **all 1,924 coord entities lack bio dates** (measured on prod 2026-07-05, legacy side: 0 of 2,257 coord rows have dates), so `century_range` is 100% book-year driven. Without year data in `canonical_entities`, the map's century filter would silently die. `book_year_range` is exactly what the legacy `$lookup` + min/max derives, so the route's century math is unchanged (it only ever takes min/max of `years`).

Cost: the builder's books fetch now projects `year` too, so it's no longer fully covered by `id_language_covered` — measured ~+90s on the offline nightly build, which is precisely the cost this PR removes from the read path (the legacy aggregate timed out at **240s** cache-cold when I tried to run it for the equivalence check).

## Equivalence (both paths run read-only against prod, 2026-07-05)
| | legacy (live API) | canonical | note |
|---|---|---|---|
| entities | 2,257 | 1,924 | −333 = duplicate QID rows merged (expected dedup) |
| with century_range | 2,241 (99.3%) | 1,909 (99.2%) | coverage parity |
| by_type | place 2,255 / concept 2 | place 1,917 / person 6 / concept 1 | 6 persons = merged rows where the majority type is person |
| by_century shape | — | — | deltas proportional to dedup (−12% in dense centuries, ±1 in early ones); no bucket appears/disappears |

## Rollout gate
A guard in the route **throws** if the flag is flipped before a rebuild that carries `book_year_range` (prod docs built 2026-07-04 lack it; the nightly 03:45 UTC cron picks up this script automatically via Hetzner auto-pull). No silent degraded output (#2974 spirit; the route's existing 500-JSON catch is unchanged — it is force-dynamic, not ISR-cached).

## Out of scope
- `/explore` hub and `/explore/timeline` (PRs 2 and 3 — independent branches off main, no stacking; all shared types/flag already merged in #2989).
- Flag default stays **off** until Derek/orchestrator flips `CANONICAL_ENTITIES_READPATH=1` on Vercel after the first nightly cron build proves stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)