### PR TITLE
feat(explore): hub reads system_config.entity_stats behind CANONICAL_ENTITIES_READPATH (#2979)

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -5,6 +5,11 @@ import CenturyHeatmap from '@/components/explore/CenturyHeatmap';
 import ExploreNav from '@/components/explore/ExploreNav';
 import DataSources from '@/components/explore/DataSources';
 import { getReadDb } from '@/lib/mongodb';
+import {
+  ENTITY_STATS_CONFIG_ID,
+  canonicalEntitiesReadpathEnabled,
+  type EntityStatsDoc,
+} from '@/lib/canonical-entities';
 
 export const revalidate = 86400;
 export const maxDuration = 30;
@@ -18,6 +23,104 @@ export const metadata: Metadata = {
     description: 'Interactive visualizations of the Western esoteric tradition, enriched with Wikidata.',
   },
 };
+
+/**
+ * Canonical read path (#2979, behind CANONICAL_ENTITIES_READPATH): all
+ * entity-side counts come from `system_config.entity_stats`, written nightly
+ * by scripts/maintenance/build-canonical-entities.mjs — zero queries against
+ * the ~1M-doc `entities` collection. The two `books` queries (total + century
+ * heatmap) are unchanged from the legacy path.
+ *
+ * Count semantics shift deliberately: with_dates / with_coordinates /
+ * with_wikidata are CANONICAL counts (one per merged QID: 6,291 / 1,924 /
+ * 20,861 at build time) instead of raw `entities`-row counts (7,948 / 2,257 /
+ * 27,854 measured 2026-07-05) — consistent with what the migrated timeline
+ * and map pages actually display. `total` and the per-type distribution stay
+ * raw row counts, same semantics as today.
+ */
+async function fetchExploreStatsCanonical() {
+  const db = await getReadDb();
+
+  const [statsDocRaw, totalBooks, heatmapData] = await Promise.all([
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db.collection('system_config').findOne({ _id: ENTITY_STATS_CONFIG_ID as any }),
+    db.collection('books').estimatedDocumentCount(),
+    db.collection('books').aggregate([
+      { $match: { year: { $exists: true, $gt: 0 }, visible: true } },
+      {
+        $group: {
+          _id: {
+            $add: [
+              { $floor: { $divide: [{ $subtract: ['$year', 1] }, 100] } },
+              1,
+            ],
+          },
+          count: { $sum: 1 },
+        },
+      },
+      { $sort: { _id: 1 } },
+    ], { maxTimeMS: 15000 }).toArray(),
+  ]);
+  const statsDoc = statsDocRaw as unknown as EntityStatsDoc | null;
+
+  // No catch-into-fallback (#2974): a missing stats doc means the nightly
+  // build has not run — throw so ISR keeps serving the last good page rather
+  // than caching zeroed stats for the 24h revalidate window.
+  if (!statsDoc) {
+    throw new Error(
+      'system_config.entity_stats missing — run build-canonical-entities.mjs before enabling CANONICAL_ENTITIES_READPATH',
+    );
+  }
+
+  const heatmap = heatmapData.map((row) => ({
+    century: row._id as number,
+    type: 'book' as string,
+    count: row.count as number,
+  }));
+
+  const dataSources = {
+    entities: {
+      label: 'Entity Index',
+      description: 'Extracted from AI-generated book indexes (people, places, concepts)',
+      count: statsDoc.total,
+    },
+    wikidata: {
+      label: 'Wikidata Alignment',
+      description: 'Entities linked to Wikidata via Wikipedia URLs and name matching',
+      count: statsDoc.with_wikidata_id,
+      coverage: statsDoc.total > 0 ? +(statsDoc.with_wikidata_id / statsDoc.total * 100).toFixed(1) : 0,
+    },
+    dates: {
+      label: 'Biographical Dates',
+      description: 'Birth/death years from Wikidata claims P569/P570',
+      count: statsDoc.with_dates,
+    },
+    coordinates: {
+      label: 'Geographic Coordinates',
+      description: 'Lat/lon from Wikidata claim P625 (places) and P19 (birthplaces)',
+      count: statsDoc.with_coordinates,
+    },
+    books: {
+      label: 'Source Books',
+      description: 'Digitized historical texts from 13 partner libraries',
+      count: totalBooks,
+    },
+  };
+
+  return {
+    totals: {
+      entities: statsDoc.total,
+      with_dates: statsDoc.with_dates,
+      with_coordinates: statsDoc.with_coordinates,
+      with_wikidata: statsDoc.with_wikidata_id,
+      books: totalBooks,
+    },
+    type_distribution: { ...statsDoc.by_type },
+    heatmap,
+    top_entities_by_era: [],
+    data_sources: dataSources,
+  };
+}
 
 async function fetchExploreStats() {
   const db = await getReadDb();
@@ -143,7 +246,9 @@ async function fetchExploreStats() {
 }
 
 export default async function ExplorePage() {
-  const stats = await fetchExploreStats();
+  const stats = canonicalEntitiesReadpathEnabled()
+    ? await fetchExploreStatsCanonical()
+    : await fetchExploreStats();
 
   return (
     <ContentPageLayout


### PR DESCRIPTION
Read-path migration PR 2 of 3 for #2979 (map → **hub** → timeline). Independent branch off main — no dependency on PR #2995 (the flag, `ENTITY_STATS_CONFIG_ID`, and `EntityStatsDoc` all merged in #2989).

## What
`/explore`: when `CANONICAL_ENTITIES_READPATH` is on, all entity-side counts come from one `findOne` on `system_config.entity_stats` (written nightly by `build-canonical-entities.mjs`) — zero queries against the ~1M-doc `entities` collection. The two `books` queries (estimated total + century heatmap, incl. its `visible: true` filter) are carried over unchanged. **Flag off (default): byte-identical legacy path** — `fetchExploreStats()` is untouched.

## Deliberate count-semantics shift when the flag is on
`with_dates` / `with_coordinates` / `with_wikidata` become **canonical** (one per merged QID) counts instead of raw `entities`-row counts — consistent with what the migrated timeline (#2980) and map (#2995) pages actually display. `total` and the per-type distribution stay raw row counts.

## Equivalence (read-only against prod, 2026-07-05)
| stat | legacy (live queries) | entity_stats (builder output) | note |
|---|---|---|---|
| total entities | 1,013,304 (estimatedDocumentCount) | 1,014,902 (exact $group) | 0.16% metadata drift, same semantics |
| by_type | concept 533,230 / person 339,732 / place 141,940 | identical, exact match | verified against live COUNT_SCAN per type |
| with_dates | 7,948 rows | 6,291 canonical | dedup (intended) |
| with_coordinates | 2,257 rows | 1,924 canonical | dedup (intended) |
| with_wikidata | 27,854 rows | 20,861 canonical | dedup — 3,591 QIDs had >1 row |

## Rollout gate
`system_config.entity_stats` does **not exist on prod yet** (the 2026-07-04 trial build ran `--apply --skip-stats`; the first nightly 03:45 UTC cron run writes it). If the flag is flipped before then, the page **throws** rather than rendering zeroed stats — per #2974, an ISR error keeps serving the last good page instead of caching a bad one for the 24h window. `revalidate = 86400` / `maxDuration = 30` unchanged.

## Out of scope
- Map (PR #2995) and timeline (PR 3).
- Flag default stays off until the first nightly cron build proves stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)