### PR TITLE
Nightly storage-stats cron + admin endpoint (closes #2972)

### DIFF
--- a/scripts/storage-stats-fullscan.mjs
+++ b/scripts/storage-stats-fullscan.mjs
@@ -1,0 +1,69 @@
+/**
+ * Exact text-byte measurement + seed recalibration for the nightly
+ * storage-stats cron (issue #2972).
+ *
+ * Full-scans `pages` summing byte lengths of ocr.data and translation.data
+ * (~80 min server-side on 13M docs), then writes the result as
+ * system_config.storage_stats.text_seed. The nightly cron scales this seed
+ * by pages-collection growth; rerun this occasionally (quarterly, or after
+ * schema changes) to recalibrate.
+ *
+ * Usage: set -a; source .env.production.local; set +a; node scripts/storage-stats-fullscan.mjs
+ */
+import { MongoClient } from 'mongodb';
+
+const client = new MongoClient(process.env.MONGODB_URI, {
+  socketTimeoutMS: 0,
+  serverSelectionTimeoutMS: 15000,
+});
+await client.connect();
+const db = client.db('bookstore');
+
+const strBytes = (f) => ({
+  $cond: [{ $eq: [{ $type: f }, 'string'] }, { $strLenBytes: f }, 0],
+});
+
+console.log('Full scan of pages (expect ~80 min)...');
+const t0 = Date.now();
+const [agg] = await db
+  .collection('pages')
+  .aggregate(
+    [
+      {
+        $project: {
+          ocrB: strBytes('$ocr.data'),
+          trB: strBytes('$translation.data'),
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          docs: { $sum: 1 },
+          ocr_bytes: { $sum: '$ocrB' },
+          translation_bytes: { $sum: '$trB' },
+          pages_with_ocr: { $sum: { $cond: [{ $gt: ['$ocrB', 0] }, 1, 0] } },
+          pages_with_translation: { $sum: { $cond: [{ $gt: ['$trB', 0] }, 1, 0] } },
+        },
+      },
+    ],
+    { allowDiskUse: true },
+  )
+  .toArray();
+console.log(JSON.stringify(agg), `(${((Date.now() - t0) / 60000).toFixed(1)} min)`);
+
+const collStats = await db.command({ collStats: 'pages' });
+const seed = {
+  measured_at: new Date().toISOString(),
+  ocr_bytes: agg.ocr_bytes,
+  translation_bytes: agg.translation_bytes,
+  pages_logical_bytes: collStats.size,
+  pages_with_ocr: agg.pages_with_ocr,
+  pages_with_translation: agg.pages_with_translation,
+  docs_scanned: agg.docs,
+};
+
+await db
+  .collection('system_config')
+  .updateOne({ _id: 'storage_stats' }, { $set: { text_seed: seed } }, { upsert: true });
+console.log('text_seed updated:', JSON.stringify(seed, null, 2));
+await client.close();

--- a/src/app/api/admin/storage-stats/route.ts
+++ b/src/app/api/admin/storage-stats/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { withAdminAuth } from '@/lib/auth-helpers';
+
+/**
+ * Latest library storage snapshot (written nightly by /api/cron/storage-stats).
+ * Image bytes are exact (Cloudflare R2 analytics); text bytes are a
+ * seed-calibrated estimate — see issue #2972.
+ */
+export const GET = withAdminAuth(async () => {
+  try {
+    const db = await getDb();
+    const stats = await db
+      .collection('system_config')
+      .findOne({ _id: 'storage_stats' } as object);
+    if (!stats) {
+      return NextResponse.json(
+        { error: 'No snapshot yet — run /api/cron/storage-stats once' },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(stats);
+  } catch (error) {
+    console.error('storage-stats read error:', error);
+    return NextResponse.json({ error: 'Failed to read storage stats' }, { status: 500 });
+  }
+});

--- a/src/app/api/cron/storage-stats/route.ts
+++ b/src/app/api/cron/storage-stats/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { verifyCronAuth } from '@/lib/cron-auth';
+import { createCronLogger } from '@/lib/cron-logger';
+
+export const maxDuration = 120;
+export const preferredRegion = 'fra1';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Nightly storage stats (issue #2972).
+ *
+ * Writes a snapshot of "how big is the library?" to system_config
+ * (_id: 'storage_stats') and a dated entry to metrics_history:
+ *  - Image bytes/objects: exact, from Cloudflare R2 analytics (~1s).
+ *  - Text bytes: estimated as pages-collection logical size x a ratio
+ *    calibrated against a full scan (scripts/storage-stats-fullscan.mjs
+ *    re-measures and updates the seed; exact scan takes ~80 min so it
+ *    can't run in a cron).
+ *  - Book/page counts: single aggregation over books.
+ */
+
+// Fallback calibration from the 2026-07-04 full scan. The live seed is read
+// from system_config.storage_stats.text_seed when present (written by
+// scripts/storage-stats-fullscan.mjs).
+const DEFAULT_TEXT_SEED = {
+  measured_at: '2026-07-04T22:00:00Z',
+  ocr_bytes: 21_101_759_643,
+  translation_bytes: 16_866_086_800,
+  pages_logical_bytes: 54_910_000_000,
+};
+
+interface TextSeed {
+  measured_at: string;
+  ocr_bytes: number;
+  translation_bytes: number;
+  pages_logical_bytes: number;
+}
+
+async function fetchR2Analytics(): Promise<
+  { bucket: string; bytes: number; objects: number }[]
+> {
+  const since = new Date(Date.now() - 3 * 86400e3).toISOString();
+  const query = `query { viewer { accounts(filter: {accountTag: "${process.env.R2_ACCOUNT_ID}"}) {
+    r2StorageAdaptiveGroups(limit: 100, filter: {datetime_geq: "${since}"}) {
+      max { payloadSize objectCount } dimensions { bucketName } } } } }`;
+  const res = await fetch('https://api.cloudflare.com/client/v4/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.CF_ANALYTICS_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query }),
+  });
+  const json = await res.json();
+  const groups = json?.data?.viewer?.accounts?.[0]?.r2StorageAdaptiveGroups;
+  if (!Array.isArray(groups) || groups.length === 0) {
+    throw new Error(`R2 analytics query failed: ${JSON.stringify(json?.errors || json).slice(0, 300)}`);
+  }
+  return groups.map((g: { dimensions: { bucketName: string }; max: { payloadSize: number; objectCount: number } }) => ({
+    bucket: g.dimensions.bucketName,
+    bytes: g.max.payloadSize,
+    objects: g.max.objectCount,
+  }));
+}
+
+export async function GET(request: NextRequest) {
+  const authError = verifyCronAuth(request);
+  if (authError) return authError;
+
+  const log = createCronLogger('storage-stats');
+  try {
+    const db = await getDb();
+
+    const [r2, existing, bookAgg, collections] = await Promise.all([
+      fetchR2Analytics().catch((e: Error) => {
+        log.error(e.message, { phase: 'r2-analytics' });
+        return null;
+      }),
+      db.collection('system_config').findOne({ _id: 'storage_stats' } as object),
+      db
+        .collection('books')
+        .aggregate([
+          {
+            $group: {
+              _id: null,
+              total: { $sum: 1 },
+              visible: {
+                $sum: {
+                  $cond: [
+                    {
+                      $and: [
+                        { $ne: ['$hidden', true] },
+                        { $ne: ['$visible', false] },
+                      ],
+                    },
+                    1,
+                    0,
+                  ],
+                },
+              },
+              fully_translated: {
+                $sum: { $cond: [{ $eq: ['$is_fully_translated', true] }, 1, 0] },
+              },
+              pages_total: { $sum: { $ifNull: ['$pages_count', 0] } },
+              pages_ocr: { $sum: { $ifNull: ['$pages_ocr', 0] } },
+              pages_translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
+            },
+          },
+        ])
+        .toArray()
+        .then((r) => r[0] as Record<string, number> | undefined),
+      Promise.all(
+        ['pages', 'chapter_texts', 'books'].map(async (c) => {
+          const s = await db.command({ collStats: c });
+          return [c, { docs: s.count, logical_bytes: s.size, on_disk_bytes: s.storageSize }] as const;
+        }),
+      ).then(Object.fromEntries),
+    ]);
+
+    // Text estimate: scale the seed's exact bytes by pages logical-size growth.
+    const seed: TextSeed = existing?.text_seed || DEFAULT_TEXT_SEED;
+    const pagesLogical = collections.pages.logical_bytes as number;
+    const scale = pagesLogical / seed.pages_logical_bytes;
+    const text = {
+      ocr_bytes_est: Math.round(seed.ocr_bytes * scale),
+      translation_bytes_est: Math.round(seed.translation_bytes * scale),
+      method: 'seed-ratio',
+      seed_measured_at: seed.measured_at,
+    };
+
+    const snapshot = {
+      updatedAt: new Date(),
+      r2,
+      text,
+      text_seed: seed,
+      collections,
+      books: bookAgg
+        ? {
+            total: bookAgg.total,
+            visible: bookAgg.visible,
+            fully_translated: bookAgg.fully_translated,
+          }
+        : null,
+      pages: bookAgg
+        ? {
+            total: bookAgg.pages_total,
+            ocr: bookAgg.pages_ocr,
+            translated: bookAgg.pages_translated,
+          }
+        : null,
+    };
+
+    await db
+      .collection('system_config')
+      .updateOne({ _id: 'storage_stats' } as object, { $set: snapshot }, { upsert: true });
+    log.action('system_config_updated');
+
+    const date = new Date().toISOString().slice(0, 10);
+    await db.collection('metrics_history').updateOne(
+      { date },
+      {
+        $set: {
+          date,
+          storage: {
+            r2_bytes: r2?.reduce((s, b) => s + b.bytes, 0) ?? null,
+            r2_objects: r2?.reduce((s, b) => s + b.objects, 0) ?? null,
+            text_bytes_est: text.ocr_bytes_est + text.translation_bytes_est,
+            books_total: bookAgg?.total ?? null,
+            books_visible: bookAgg?.visible ?? null,
+            pages_total: bookAgg?.pages_total ?? null,
+            pages_translated: bookAgg?.pages_translated ?? null,
+          },
+          storage_updated_at: new Date(),
+        },
+      },
+      { upsert: true },
+    );
+    log.action('metrics_history_upserted');
+
+    await log.flush();
+    return NextResponse.json({ ok: true, snapshot });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error('storage-stats cron error:', error);
+    log.error(msg);
+    log.setFailed();
+    await log.flush();
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/lib/cron-logger.ts
+++ b/src/lib/cron-logger.ts
@@ -10,7 +10,8 @@ export type CronName =
   | 'submit-batch-ocr'
   | 'social-post'
   | 'social-reset'
-  | 'daily-pipeline-report';
+  | 'daily-pipeline-report'
+  | 'storage-stats';
 
 export type CronRunStatus = 'success' | 'partial' | 'failed';
 

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,10 @@
     {
       "path": "/api/cron/enrich-entities",
       "schedule": "15 2 * * *"
+    },
+    {
+      "path": "/api/cron/storage-stats",
+      "schedule": "45 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
Implements the plan in #2972 (slice 2 of 2; slice 1 was #2984).

## What
- **`/api/cron/storage-stats`** (daily 03:45, after collection-health, before warm): snapshots library size to `system_config` (`_id: 'storage_stats'`) and a dated `metrics_history` entry for trendlines.
  - Images: exact bytes + object count via Cloudflare R2 analytics GraphQL (`CF_ANALYTICS_TOKEN`, already in prod env)
  - Books/pages: one aggregation over `books` (total / visible / fully-translated, page counts from book-level caches — no 13M-page scans)
  - Text bytes: estimate = seed bytes × pages-collection growth ratio. Exact measurement takes ~80 min (13M-doc scan), far beyond cron limits, so a calibrated estimate is stored with its method + seed date.
- **`/api/admin/storage-stats`**: admin-gated read of the latest snapshot, answers in <2s.
- **`scripts/storage-stats-fullscan.mjs`**: the exact 80-min scan; writes `text_seed` back to `system_config` to recalibrate. DB already seeded from the 2026-07-04 full scan (OCR 21.10 GB / translations 16.87 GB / pages logical 54.92 GB).
- `storage-stats` added to the `CronName` union so runs land in `cron_runs`.

## Verify after deploy
`curl -H "Authorization: Bearer $CRON_SECRET" https://sourcelibrary.org/api/cron/storage-stats` then `curl -H "Authorization: Bearer $CRON_SECRET" https://sourcelibrary.org/api/admin/storage-stats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK7DtbUeNKts2gZbWB2itp