### PR TITLE
fix(batch): retranslate-stale — real prompt provenance + load prompts from DB

### DIFF
--- a/scripts/batch/retranslate-stale.mjs
+++ b/scripts/batch/retranslate-stale.mjs
@@ -33,40 +33,39 @@ const BATCH_KEYS = [
 ].filter(Boolean);
 const UNIQUE_KEYS = [...new Set(BATCH_KEYS)];
 
-// English modernization prompt (simplified — real one fetched from DB)
-const ENGLISH_MODERNIZATION_PROMPT = `You are a specialist in Early Modern English literature. Modernize the following Early Modern English text into clear, readable Modern English.
-
-Rules:
-- Update archaic spelling, grammar, and vocabulary to modern equivalents
-- Preserve the author's meaning, tone, and style as closely as possible
-- Keep proper nouns unchanged
-- Maintain paragraph structure
-- Do not add commentary or notes — output only the modernized text`;
+// Prompts are loaded from the DB `prompts` collection (single source of truth,
+// same as pipeline-orchestrator / translate-worker). The returned promptRef is
+// stamped onto batch_jobs so batch-collector writes true provenance
+// (prompt_id/hash/name/version) onto each page.
+const _promptCache = new Map();
 
 async function getTranslationPrompt(db, language) {
   const isEnglish = language?.toLowerCase() === 'english';
+  const type = isEnglish ? 'english_modernization' : 'translation';
 
-  if (isEnglish) {
-    return { text: ENGLISH_MODERNIZATION_PROMPT, isEnglish: true };
+  let prompt = _promptCache.get(type);
+  if (!prompt) {
+    prompt = await db.collection('prompts').findOne(
+      { type, is_default: true },
+      { sort: { version: -1 } }
+    );
+    if (!prompt?.content) throw new Error(`No default ${type} prompt found in DB`);
+    _promptCache.set(type, prompt);
   }
 
-  // Fetch from prompts collection
-  const prompt = await db.collection('prompts').findOne({
-    type: 'translation',
-    is_default: true,
-  });
+  const filled = prompt.content
+    .replace(/\{source_language\}/g, language || 'the original language')
+    .replace(/\{target_language\}/g, 'English');
 
-  if (prompt?.text) {
-    const filled = prompt.text
-      .replace(/\{sourceLanguage\}/g, language || 'the original language')
-      .replace(/\{targetLanguage\}/g, 'English');
-    return { text: filled, isEnglish: false };
-  }
-
-  // Fallback
   return {
-    text: `Translate the following ${language || ''} text into English. Preserve the original meaning and scholarly tone. Output only the translation.`,
-    isEnglish: false,
+    text: filled,
+    isEnglish,
+    promptRef: {
+      id: prompt._id?.toString(),
+      name: prompt.name,
+      version: String(prompt.version ?? 1),
+      content_hash: prompt.content_hash,
+    },
   };
 }
 
@@ -236,7 +235,10 @@ async function main() {
           source_language: language,
           target_language: 'English',
           force: true,
-          prompt_version: 'v5.2026-02',
+          prompt_version: promptInfo.promptRef.version,
+          prompt_id: promptInfo.promptRef.id,
+          prompt_hash: promptInfo.promptRef.content_hash,
+          prompt_name: promptInfo.promptRef.name,
           page_ids: batchRequests.map(r => r.key),
           page_count: batchRequests.length,
           status: job.state,


### PR DESCRIPTION
## What

Fixes three bugs in `scripts/batch/retranslate-stale.mjs`, found while investigating why Boyle's Philosophical Works pages carry meaningless prompt provenance.

1. **False provenance**: batch_jobs rows were stamped `prompt_version: 'v5.2026-02'` hardcoded, with no `prompt_id`/`prompt_name`/`prompt_hash`. batch-collector propagates whatever the job says onto every page, so pages could not be audited for which prompt (Standard Translation vs English Modernization) actually produced them.
2. **Wrong English prompt**: English books got an inline "simplified" modernization prompt instead of the canonical `english_modernization` prompt in the `prompts` collection. The comment claimed the real one was fetched from DB — it wasn't.
3. **Dead non-English DB path**: the code read `prompt.text` but the collection stores `content`, so every non-English book silently fell through to a one-line generic fallback prompt. The placeholder regexes were also camelCase (`{sourceLanguage}`) while the DB prompt uses `{source_language}`.

## How

`getTranslationPrompt` now loads both prompt types from the DB (`is_default: true`, sorted by version, cached per run — same pattern as pipeline-orchestrator/translate-worker), fills the correct placeholders, throws if the default prompt is missing, and returns a `promptRef` that gets stamped onto the batch job. batch-collector already copies `job.prompt_id/hash/name/version` to pages (batch-collector.mjs:547-550), so no collector change is needed.

## Verification

- `node --check` passes.
- Dry-run against Boyle Philosophical Works Vol 1 (English, 497 stale pages): prompt loads from DB without error, aggregation and summary unchanged.
- Confirmed in prod DB that both default prompts have `content`, `version`, `content_hash`, and that the translation prompt uses `{source_language}`/`{target_language}`.

## Out of scope

- Historical pages already stamped with bogus `v10`/`v5.2026-02` labels (e.g. ~2,200 Boyle pages from 2026-04-01) — a backfill is possible (language + date implies which prompt was live) but is a separate data-migration decision.
- Other batch submitters were audited: pipeline-orchestrator OCR jobs and translate-worker realtime writes already stamp full promptRef; this script was the only remaining offender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)