### PR TITLE
Collections reorg — data-migration side: kind backfill, reorganize script, slug redirects, guard (#3002)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import { withBotId } from 'botid/next/config';
+import collectionRedirects from './src/lib/collection-redirects.json';
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
@@ -262,6 +263,16 @@ const nextConfig: NextConfig = {
   },
   async redirects() {
     return [
+      // Merged/retired collection slugs → successors (issue #3002). True HTTP
+      // 308s at the routing layer — the page-level permanentRedirect in
+      // /collections/[id] only yields a streamed meta-refresh because the
+      // shell has already started streaming. Path-relative destinations keep
+      // the request host (tenant-subdomain safe).
+      ...Object.entries(collectionRedirects as Record<string, string>).map(([from, to]) => ({
+        source: `/collections/${from}`,
+        destination: `/collections/${to}`,
+        permanent: true,
+      })),
       {
         source: '/translation/:bookId/:pageId',
         destination: '/book/:bookId',

--- a/scripts/maintenance/audit-collections.mjs
+++ b/scripts/maintenance/audit-collections.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * Guard script for the `collections` Mongo collection (db `bookstore`),
+ * per GitHub issue #3002 section F.
+ *
+ * Read-only. Runs a battery of structural/data-quality checks over
+ * `collections` (and, for membership integrity, `books`) and reports
+ * PASS/FAIL/WARN per check:
+ *
+ *   1. FAIL — duplicate display `name` among visible collections
+ *   2. FAIL — visible collection missing `kind` or `kind` outside the enum
+ *   3. FAIL — visible tradition/region collections under the minimum book_count
+ *   4. FAIL — parent slugs that don't resolve to an existing collection doc
+ *   5. FAIL — hierarchy depth > 4, or a parent cycle
+ *   6. WARN — visible tradition collections with no curation content
+ *   7. FAIL/WARN — book membership integrity vs `books.collections`
+ *   8. FAIL — merged docs missing from the redirect map / stale redirect targets
+ *   9. WARN — visible collections with no `hero_image`
+ *
+ * This script NEVER writes to the database.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/audit-collections.mjs               # normal (FAILs exit 1)
+ *   node scripts/maintenance/audit-collections.mjs --warn-only   # downgrade all FAILs to WARN, always exit 0
+ */
+import { MongoClient } from 'mongodb';
+import { readFileSync } from 'fs';
+
+const WARN_ONLY = process.argv.includes('--warn-only');
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI not set. Try: set -a; source .env.production.local; set +a');
+  process.exit(1);
+}
+
+const MAIN_TENANT_ID = 'bce03f71-c18d-4460-b8ad-224c817f9aa0';
+const VALID_KINDS = new Set(['tradition', 'region', 'provenance', 'exhibit', 'artwork']);
+const MIN_BOOK_COUNT = { tradition: 15, region: 50 };
+// Depth convention: a root is depth 1. Prod's real max today is 4 (e.g. the
+// Chinese/Islamic/Indian sub-tradition trees) — the issue #3002 "max depth 3"
+// snapshot counted edges from the root. Guard against going DEEPER than today.
+const MAX_DEPTH = 4;
+
+const results = []; // { check, level: 'FAIL'|'WARN', count }
+
+function isMainTenant(doc) {
+  return doc.tenantId == null || doc.tenantId === MAIN_TENANT_ID;
+}
+
+function parentsOf(doc) {
+  if (doc.parent == null) return [];
+  if (Array.isArray(doc.parent)) return doc.parent.filter(Boolean);
+  return [doc.parent];
+}
+
+function section(title) {
+  console.log(`\n--- ${title} ---`);
+}
+
+function report(checkName, level, items, formatFn) {
+  const effectiveLevel = WARN_ONLY ? 'WARN' : level;
+  if (items.length === 0) {
+    console.log('PASS: no issues found');
+    return;
+  }
+  console.log(`${effectiveLevel}: ${items.length} issue(s) found`);
+  for (const item of items) {
+    console.log(`  - ${formatFn(item)}`);
+  }
+  results.push({ check: checkName, level: effectiveLevel, count: items.length });
+}
+
+const client = await MongoClient.connect(uri);
+const db = client.db('bookstore');
+const collections = db.collection('collections');
+const books = db.collection('books');
+
+const allDocs = await collections.find({}).toArray();
+const bySlug = new Map(allDocs.map((d) => [d.slug, d]));
+const mainDocs = allDocs.filter(isMainTenant);
+const visibleMainDocs = mainDocs.filter((d) => d.visible === true);
+
+console.log(`Loaded ${allDocs.length} collection docs (${mainDocs.length} main-tenant, ${visibleMainDocs.length} visible main-tenant).`);
+
+// ---------------------------------------------------------------------------
+// 1. Duplicate display `name` among visible collections (case-insensitive, trimmed)
+// ---------------------------------------------------------------------------
+section('1. Duplicate names among visible collections');
+{
+  const byName = new Map(); // normalized name -> [slugs]
+  for (const d of visibleMainDocs) {
+    const norm = String(d.name ?? '').trim().toLowerCase();
+    if (!norm) continue;
+    if (!byName.has(norm)) byName.set(norm, []);
+    byName.get(norm).push(d.slug);
+  }
+  const dupes = [...byName.entries()].filter(([, slugs]) => slugs.length > 1);
+  report('1-duplicate-names', 'FAIL', dupes, ([name, slugs]) => `"${name}" — ${slugs.join(', ')}`);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Missing/invalid `kind` on visible collections
+// ---------------------------------------------------------------------------
+section('2. Missing or invalid `kind` on visible collections');
+{
+  const bad = visibleMainDocs.filter((d) => !d.kind || !VALID_KINDS.has(d.kind));
+  report('2-invalid-kind', 'FAIL', bad, (d) => `${d.slug} — kind=${JSON.stringify(d.kind ?? null)}`);
+}
+
+// ---------------------------------------------------------------------------
+// 3. book_count minimums for visible tradition/region collections (skip merged)
+// ---------------------------------------------------------------------------
+section('3. book_count below minimum for visible tradition/region collections');
+{
+  // The size bar is a FRONT-DOOR rule: it applies to root collections (the
+  // ones the /collections bands surface), not to sub-shelves under a hall.
+  const under = visibleMainDocs.filter((d) => {
+    if (d.merged_into) return false;
+    if (parentsOf(d).length > 0) return false;
+    const min = MIN_BOOK_COUNT[d.kind];
+    if (min == null) return false;
+    return (d.book_count ?? 0) < min;
+  });
+  report(
+    '3-under-min-book-count',
+    'FAIL',
+    under,
+    (d) => `${d.slug} (kind=${d.kind}) — book_count=${d.book_count ?? 0}, min=${MIN_BOOK_COUNT[d.kind]}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Parent slugs that don't resolve, across ALL docs (incl. tenant docs)
+// ---------------------------------------------------------------------------
+section('4. Unresolvable parent slugs (all docs, incl. tenant)');
+{
+  const broken = [];
+  for (const d of allDocs) {
+    for (const p of parentsOf(d)) {
+      if (!bySlug.has(p)) broken.push({ slug: d.slug, parent: p });
+    }
+  }
+  report('4-unresolvable-parent', 'FAIL', broken, (b) => `${b.slug} -> parent "${b.parent}" (not found)`);
+}
+
+// ---------------------------------------------------------------------------
+// 5. hierarchy depth > 4, and parent cycles (main-tenant docs; multi-parent = max depth)
+// ---------------------------------------------------------------------------
+section('5. hierarchy depth > 4 / parent cycles');
+{
+  const depthCache = new Map(); // slug -> depth (or 'CYCLE')
+  const tooDeep = [];
+  const cycles = [];
+
+  function depthOf(slug, stack) {
+    if (depthCache.has(slug)) return depthCache.get(slug);
+    if (stack.has(slug)) {
+      cycles.push([...stack, slug].join(' -> '));
+      depthCache.set(slug, 1); // avoid infinite recursion / cascading depth errors
+      return 1;
+    }
+    const doc = bySlug.get(slug);
+    if (!doc) {
+      depthCache.set(slug, 1);
+      return 1;
+    }
+    const parents = parentsOf(doc).filter((p) => bySlug.has(p));
+    if (parents.length === 0) {
+      depthCache.set(slug, 1);
+      return 1;
+    }
+    const nextStack = new Set(stack);
+    nextStack.add(slug);
+    const maxParentDepth = Math.max(...parents.map((p) => depthOf(p, nextStack)));
+    const d = maxParentDepth + 1;
+    depthCache.set(slug, d);
+    return d;
+  }
+
+  for (const d of mainDocs) {
+    const depth = depthOf(d.slug, new Set());
+    if (depth > MAX_DEPTH) tooDeep.push({ slug: d.slug, depth });
+  }
+
+  // de-dupe cycle strings (same cycle can be discovered from multiple entry points)
+  const uniqueCycles = [...new Set(cycles)];
+
+  report('5-hierarchy-too-deep', 'FAIL', tooDeep, (t) => `${t.slug} — depth=${t.depth} (max ${MAX_DEPTH})`);
+  report('5-parent-cycle', 'FAIL', uniqueCycles, (c) => c);
+}
+
+// ---------------------------------------------------------------------------
+// 6. WARN: visible tradition collections with no curation content
+// ---------------------------------------------------------------------------
+section('6. Visible tradition collections with no curation content');
+{
+  const uncurated = visibleMainDocs.filter((d) => {
+    if (d.kind !== 'tradition') return false;
+    const noDesc = !d.expanded_description || String(d.expanded_description).trim() === '';
+    const noHighlights = !Array.isArray(d.highlighted_books) || d.highlighted_books.length === 0;
+    return noDesc || noHighlights;
+  });
+  report(
+    '6-uncurated-traditions',
+    'WARN',
+    uncurated,
+    (d) => {
+      const missing = [];
+      if (!d.expanded_description || String(d.expanded_description).trim() === '') missing.push('expanded_description');
+      if (!Array.isArray(d.highlighted_books) || d.highlighted_books.length === 0) missing.push('highlighted_books');
+      return `${d.slug} — missing: ${missing.join(', ')}`;
+    }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Book membership integrity vs books.collections
+// ---------------------------------------------------------------------------
+section('7. Book membership integrity (books.collections vs collections)');
+{
+  const referencedSlugs = await books.distinct('collections', { visible: true, pages_count: { $gt: 0 } });
+  const missing = referencedSlugs.filter((s) => s && !bySlug.has(s));
+  const mergedButReferenced = referencedSlugs.filter((s) => s && bySlug.has(s) && bySlug.get(s).merged_into);
+
+  report('7-missing-collection-docs', 'FAIL', missing, (s) => `"${s}" — referenced by live books, no collection doc exists`);
+  report(
+    '7-referenced-merged-collections',
+    'WARN',
+    mergedButReferenced,
+    (s) => `"${s}" -> merged_into "${bySlug.get(s).merged_into}" but still referenced by live books (re-tag missed)`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Redirect map coverage for merged docs
+// ---------------------------------------------------------------------------
+section('8. Redirect map coverage for merged collections');
+{
+  const mergedDocs = allDocs.filter((d) => d.merged_into);
+  let redirectMap = null;
+  try {
+    redirectMap = JSON.parse(
+      readFileSync(new URL('../../src/lib/collection-redirects.json', import.meta.url))
+    );
+  } catch (err) {
+    console.log(`WARN: redirect map not found or unreadable (${err.code ?? err.message}) — skipping check 8`);
+    results.push({ check: '8-redirect-map-missing', level: 'WARN', count: 1 });
+    redirectMap = null;
+  }
+
+  if (redirectMap) {
+    const missingFromMap = mergedDocs.filter((d) => !(d.slug in redirectMap));
+    report(
+      '8-merged-not-in-redirect-map',
+      'FAIL',
+      missingFromMap,
+      (d) => `${d.slug} — merged_into "${d.merged_into}" but absent from collection-redirects.json`
+    );
+
+    const staleTargets = Object.entries(redirectMap).filter(([, target]) => {
+      const targetDoc = bySlug.get(target);
+      return !targetDoc || targetDoc.merged_into;
+    });
+    report(
+      '8-stale-redirect-targets',
+      'FAIL',
+      staleTargets,
+      ([from, target]) => `"${from}" -> "${target}" — target ${bySlug.has(target) ? 'is itself merged' : 'does not exist'}`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 9. WARN: visible collections with no hero_image
+// ---------------------------------------------------------------------------
+section('9. Visible collections with no hero_image');
+{
+  const noHero = visibleMainDocs.filter((d) => !d.hero_image || String(d.hero_image).trim() === '');
+  report('9-no-hero-image', 'WARN', noHero, (d) => d.slug);
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+section('SUMMARY');
+const failCount = results.filter((r) => r.level === 'FAIL').reduce((sum, r) => sum + r.count, 0);
+const warnCount = results.filter((r) => r.level === 'WARN').reduce((sum, r) => sum + r.count, 0);
+
+if (results.length === 0) {
+  console.log('No issues found across any check.');
+} else {
+  for (const r of results) {
+    console.log(`  [${r.level}] ${r.check}: ${r.count}`);
+  }
+}
+console.log(`\nTotal: ${failCount} failure(s), ${warnCount} warning(s).`);
+
+await client.close();
+
+const hasFailures = results.some((r) => r.level === 'FAIL');
+if (hasFailures) {
+  console.log(`\nAUDIT FAILED (${failCount} failures)`);
+  process.exit(1);
+} else {
+  console.log('\nAUDIT PASSED');
+  process.exit(0);
+}

--- a/scripts/maintenance/backfill-collection-kind.mjs
+++ b/scripts/maintenance/backfill-collection-kind.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+/**
+ * Backfill the `kind` enum on every doc in the `collections` collection.
+ *
+ * Issue #3002: /collections mixes five different kinds of thing on one axis.
+ * `kind` makes the axis explicit so the front door can render bands:
+ *
+ *   tradition  — subject taxonomy (Alchemy, Kabbalah, Theology)
+ *   region     — geographic/cultural corpus (East Asia, South Asia)
+ *   provenance — a historical library / list / press (Jung, Kloss, Aldine)
+ *   exhibit    — small editorial essay-collection (Cannabis, Sibyls)
+ *   artwork    — image-first sets (today's collection_type: 'visual_art')
+ *
+ * Assignment precedence:
+ *   1. Explicit table below (the 57 roots + re-tagged children from #3002B)
+ *   2. collection_type === 'visual_art'          → artwork
+ *   3. type === 'curated'                        → exhibit
+ *   4. any ancestor is a region-kind collection  → region
+ *   5. everything else                           → tradition
+ *
+ * Pure metadata, reversible (`kind` is unread until the /collections
+ * kind-banded layout ships). Legacy `type` / `collection_type` are left
+ * untouched. Dry-run by default; pass --apply to write.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/backfill-collection-kind.mjs
+ *   node scripts/maintenance/backfill-collection-kind.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb';
+
+const KINDS = ['tradition', 'region', 'provenance', 'exhibit', 'artwork'];
+
+// Explicit assignments from the issue #3002 section-B table. Slugs absent
+// from prod are tolerated (logged) so the script stays re-runnable.
+const EXPLICIT = {
+  // tradition — top-level subject halls (incl. the two promoted philosophy
+  // children and roots that #3002 folds under other halls; folding is done
+  // by reorganize-collections.mjs, kind stays 'tradition' either way)
+  ...Object.fromEntries([
+    'theology', 'literature', 'natural-philosophy', 'sacred-texts', 'medicine',
+    'mysticism', 'hermetica', 'alchemy', 'astrology', 'magic',
+    'secret-societies', 'psychology', 'kabbalah', 'history-political-thought',
+    'demonology', 'art-illustrated', 'philosophy', 'classical-philosophy',
+    'renaissance-philosophy', 'renaissance-natural-philosophy',
+    'architecture', 'renaissance-architecture', 'arabic-medicine',
+    'pharmacopeias', 'education', 'aesthetic-theory',
+    'theosophy', 'theosophical-tradition', 'theosophical-society',
+    'mathematics', 'science-mathematics', 'gnostic-texts', 'hermetica-sacred',
+    'music-sound', 'miscellany',
+  ].map(s => [s, 'tradition'])),
+
+  // region — geographic/cultural corpora
+  ...Object.fromEntries([
+    'east-asia', 'south-asia', 'world-traditions', 'middle-east-africa',
+    'americas',
+  ].map(s => [s, 'region'])),
+
+  // provenance — historical libraries, lists, presses, partner corpora
+  ...Object.fromEntries([
+    'shwep', 'bhutan', 'index-librorum-prohibitorum', 'mahabharata-bori',
+    'atharvaveda-pandit', 'javanese-kraton', 'east-asian-history-of-health',
+    'indonesian-manuscripts', 'balinese-narrative-drawings',
+    'jungs-library', 'kloss-collection', 'aldine-press',
+  ].map(s => [s, 'provenance'])),
+
+  // exhibit — small editorial essay-collections
+  ...Object.fromEntries([
+    'cannabis-western-record', 'prehistory-of-ai', 'hogwarts-library',
+    'signs-in-the-sky', 'chariots-of-the-gods', 'taken-up-to-the-heavens',
+    'spirits-of-the-air', 'eros-esoteric', 'gardens-festivals-ephemeral',
+    'druids-megaliths', 'sibyls', 'sacred-plants', 'norse-antiquities',
+    'microscopy', 'games', 'yoga', 'the-human-condition', 'connoisseurship',
+  ].map(s => [s, 'exhibit'])),
+
+  // artwork — image-first sets
+  ...Object.fromEntries([
+    'leonardo-drawings', 'alchemists-studio', 'art-of-altdorfer-baldung',
+    'venetian-mystery', 'hashika-e-measles-prints', 'book-of-the-dead',
+  ].map(s => [s, 'artwork'])),
+};
+
+function parentsOf(doc) {
+  if (!doc.parent) return [];
+  return Array.isArray(doc.parent) ? doc.parent.filter(Boolean) : [doc.parent];
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const uri = process.env.MONGODB_URI || process.env.MONGODB_URL;
+  if (!uri) {
+    console.error('Set MONGODB_URI before running. Hint: set -a; source .env.production.local; set +a');
+    process.exit(1);
+  }
+
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db('bookstore');
+  const collections = db.collection('collections');
+
+  const docs = await collections
+    .find({})
+    .project({ slug: 1, name: 1, parent: 1, type: 1, collection_type: 1, kind: 1, tenantId: 1 })
+    .toArray();
+  console.log(`Found ${docs.length} collection docs.\n`);
+
+  const bySlug = new Map(docs.map(d => [d.slug, d]));
+
+  const missingExplicit = Object.keys(EXPLICIT).filter(s => !bySlug.has(s));
+  if (missingExplicit.length) {
+    console.warn(`NOTE: ${missingExplicit.length} explicit slugs not in prod: ${missingExplicit.join(', ')}\n`);
+  }
+
+  // "Descends from a region" — walk parent chains with cycle protection.
+  const regionMemo = new Map();
+  function descendsFromRegion(slug, seen = new Set()) {
+    if (regionMemo.has(slug)) return regionMemo.get(slug);
+    if (seen.has(slug)) return false; // cycle guard
+    seen.add(slug);
+    const doc = bySlug.get(slug);
+    if (!doc) return false;
+    const result = parentsOf(doc).some(p =>
+      EXPLICIT[p] === 'region' || descendsFromRegion(p, seen)
+    );
+    regionMemo.set(slug, result);
+    return result;
+  }
+
+  function classify(doc) {
+    if (EXPLICIT[doc.slug]) return { kind: EXPLICIT[doc.slug], via: 'explicit' };
+    if (doc.collection_type === 'visual_art') return { kind: 'artwork', via: 'collection_type' };
+    if (doc.type === 'curated') return { kind: 'exhibit', via: 'type:curated' };
+    if (descendsFromRegion(doc.slug)) return { kind: 'region', via: 'region-ancestor' };
+    return { kind: 'tradition', via: 'default' };
+  }
+
+  const summary = Object.fromEntries(KINDS.map(k => [k, 0]));
+  summary.unchanged = 0;
+  const viaCounts = {};
+  const ops = [];
+
+  for (const doc of docs.sort((a, b) => (a.slug || '').localeCompare(b.slug || ''))) {
+    const { kind, via } = classify(doc);
+    if (!KINDS.includes(kind)) throw new Error(`Bad kind ${kind} for ${doc.slug}`);
+    if (doc.kind === kind) {
+      summary.unchanged++;
+      continue;
+    }
+    summary[kind]++;
+    viaCounts[via] = (viaCounts[via] || 0) + 1;
+    console.log(`  ${String(doc.slug).padEnd(36)} ${(doc.kind || '(none)').padEnd(12)} → ${kind.padEnd(11)} [${via}]`);
+    ops.push({
+      updateOne: {
+        filter: { _id: doc._id },
+        update: { $set: { kind, kind_updated_at: new Date() } },
+      },
+    });
+  }
+
+  console.log('\nSummary:');
+  for (const [k, v] of Object.entries(summary)) console.log(`  ${k}: ${v}`);
+  console.log('By rule:', JSON.stringify(viaCounts));
+  console.log(`\n${ops.length} docs need updates.`);
+
+  if (!apply) {
+    console.log('\nDRY RUN — pass --apply to write changes.');
+  } else if (ops.length > 0) {
+    const res = await collections.bulkWrite(ops);
+    console.log(`\nWrote: ${res.modifiedCount} modified.`);
+    const stillMissing = await collections.countDocuments({ kind: { $nin: KINDS } });
+    console.log(`Docs still without a valid kind: ${stillMissing} (expect 0).`);
+  }
+
+  await client.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/maintenance/reorganize-collections.mjs
+++ b/scripts/maintenance/reorganize-collections.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+/**
+ * Apply the issue #3002 collection reorganization (migration-order steps 2+3):
+ *
+ *   RENAME    renaissance-natural-philosophy display name, which today is
+ *             byte-identical to natural-philosophy's ("Natural Philosophy &
+ *             Science" twice on one page).
+ *   REPARENT  promote classical-/renaissance-philosophy to roots (retire the
+ *             thin `philosophy` umbrella); fold architecture, arabic-medicine,
+ *             pharmacopeias, education, aesthetic-theory under their halls;
+ *             fix the music-sound inversion (179 books under a 10-book
+ *             exhibit) by adding art-illustrated as primary parent.
+ *   VISIBILITY unhide the region roots (east-asia, south-asia,
+ *             world-traditions); hide the retired `philosophy` umbrella.
+ *   MERGE     theosophy → theosophical-tradition;
+ *             science-mathematics → mathematics;
+ *             hermetica-sacred → hermetica + gnostic-texts.
+ *             Merges only re-tag books.collections ($addToSet targets, $pull
+ *             source, bump updated_at) and retire the source doc
+ *             (visible:false + merged_into). NOTHING is deleted.
+ *   FEATURED  seed featured:true + featured_order from the (soon retired)
+ *             hardcoded CURATED_PATHWAYS array so /collections can go
+ *             data-driven (#3002 E).
+ *
+ * ⚠ ORDER MATTERS: deploy src/lib/collection-redirects.json to prod BEFORE
+ *   running with --apply — merged slugs 404 until the 308 redirects are live.
+ *   The redirect map and this script's MERGES table must stay in sync
+ *   (audit-collections.mjs check #8 enforces it).
+ *
+ * After --apply:
+ *   1. node scripts/workers/sync-books-catalog.mjs        (Supabase grid lags Mongo)
+ *   2. book_count snapshots refresh via scripts/workers/sync-worker.mjs (cron)
+ *   3. purge CDN (collection pages carry 24h edge cache) — npm run deploy:prod does this
+ *
+ * Dry-run by default; --apply writes. A full-doc backup of every touched
+ * collection doc + the affected book ids is written to scripts/output/
+ * before any write.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/reorganize-collections.mjs
+ *   node scripts/maintenance/reorganize-collections.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb';
+import { writeFileSync, mkdirSync, readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const RENAMES = [
+  { slug: 'renaissance-natural-philosophy', name: 'Renaissance Natural Philosophy' },
+];
+
+// null = promote to root ($unset parent)
+const REPARENTS = [
+  { slug: 'classical-philosophy', parent: null },
+  { slug: 'renaissance-philosophy', parent: null },
+  { slug: 'architecture', parent: ['art-illustrated'] },
+  { slug: 'renaissance-architecture', parent: ['architecture'] },
+  { slug: 'arabic-medicine', parent: ['medicine'] },
+  { slug: 'pharmacopeias', parent: ['medicine'] },
+  { slug: 'education', parent: ['literature'] },
+  { slug: 'aesthetic-theory', parent: ['art-illustrated'] },
+  { slug: 'music-sound', parent: ['art-illustrated', 'the-human-condition'] },
+];
+
+const VISIBILITY = [
+  { slug: 'east-asia', visible: true },
+  { slug: 'south-asia', visible: true },
+  { slug: 'world-traditions', visible: true },
+  // Retired umbrella: its two children are promoted above; the public URL
+  // 308s via src/lib/collection-redirects.json. Its 85 direct book
+  // memberships are kept (harmless on a hidden collection) — flagged for
+  // curator re-shelving in the issue.
+  { slug: 'philosophy', visible: false },
+];
+
+// Must stay in sync with src/lib/collection-redirects.json.
+const MERGES = [
+  { from: 'theosophy', into: ['theosophical-tradition'] },
+  { from: 'science-mathematics', into: ['mathematics'] },
+  { from: 'hermetica-sacred', into: ['hermetica', 'gnostic-texts'] },
+];
+
+// Snapshot of CURATED_PATHWAYS (src/app/collections/page.tsx) at migration
+// time — seeds the data-driven featured flag. Order = display order.
+const FEATURED = [
+  'courts-of-wonder', 'maps-of-the-invisible', 'rosicrucian-moment',
+  'grimoire-tradition', 'women-of-the-secret-tradition', 'alchemical-emblem',
+  'ficinos-florence', 'dance-of-death', 'bestiary-tradition',
+  'ancient-egyptian', 'art-of-memory', 'behmenist-underground',
+  'visions-ecstasies', 'yokai-oni', 'sumerian-mesopotamian',
+  'forbidden-books', 'music-of-the-spheres', 'rudolf-prague',
+  'contemplative-traditions', 'newtons-other-science',
+  'sympathy-of-all-things', 'kepler-fludd-debate', 'neoplatonism',
+  'the-cosmos', 'indic-traditions', 'chinese-classics', 'great-manuscripts',
+  'herbalism', 'jungs-library', 'kloss-collection',
+];
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const uri = process.env.MONGODB_URI || process.env.MONGODB_URL;
+  if (!uri) {
+    console.error('Set MONGODB_URI before running. Hint: set -a; source .env.production.local; set +a');
+    process.exit(1);
+  }
+
+  // Guard: the redirect map must cover every merge source + the retired umbrella.
+  const redirectMap = JSON.parse(
+    readFileSync(path.join(__dirname, '../../src/lib/collection-redirects.json'), 'utf8')
+  );
+  const needRedirect = [...MERGES.map(m => m.from), 'philosophy'];
+  const missingRedirects = needRedirect.filter(s => !redirectMap[s]);
+  if (missingRedirects.length) {
+    console.error(`ABORT: src/lib/collection-redirects.json is missing entries for: ${missingRedirects.join(', ')}`);
+    process.exit(1);
+  }
+
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db('bookstore');
+  const collections = db.collection('collections');
+  const books = db.collection('books');
+
+  const touchedSlugs = [
+    ...RENAMES.map(r => r.slug),
+    ...REPARENTS.map(r => r.slug),
+    ...VISIBILITY.map(v => v.slug),
+    ...MERGES.flatMap(m => [m.from, ...m.into]),
+    ...FEATURED,
+  ];
+  const existing = await collections.find({ slug: { $in: touchedSlugs } }).toArray();
+  const bySlug = new Map(existing.map(d => [d.slug, d]));
+
+  const missing = [...new Set(touchedSlugs)].filter(s => !bySlug.has(s));
+  if (missing.length) {
+    console.warn(`NOTE: slugs not found in prod (skipped): ${missing.join(', ')}\n`);
+  }
+
+  // ---- Plan ----
+  const colOps = [];
+  const plan = [];
+
+  for (const r of RENAMES) {
+    const doc = bySlug.get(r.slug);
+    if (!doc || doc.name === r.name) continue;
+    plan.push(`RENAME     ${r.slug}: "${doc.name}" → "${r.name}"`);
+    colOps.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { name: r.name, updated_at: new Date() } } } });
+  }
+
+  for (const r of REPARENTS) {
+    const doc = bySlug.get(r.slug);
+    if (!doc) continue;
+    const current = JSON.stringify(doc.parent ?? null);
+    const wanted = JSON.stringify(r.parent);
+    if (current === wanted) continue;
+    plan.push(`REPARENT   ${r.slug}: ${current} → ${wanted}`);
+    const update = r.parent === null
+      ? { $unset: { parent: '' }, $set: { updated_at: new Date() } }
+      : { $set: { parent: r.parent, updated_at: new Date() } };
+    colOps.push({ updateOne: { filter: { _id: doc._id }, update } });
+  }
+
+  for (const v of VISIBILITY) {
+    const doc = bySlug.get(v.slug);
+    if (!doc || doc.visible === v.visible) continue;
+    plan.push(`VISIBILITY ${v.slug}: ${doc.visible} → ${v.visible}`);
+    colOps.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { visible: v.visible, updated_at: new Date() } } } });
+  }
+
+  const mergeBookIds = {};
+  for (const m of MERGES) {
+    const doc = bySlug.get(m.from);
+    if (!doc) continue;
+    const ids = await books.find({ collections: m.from }).project({ _id: 1 }).map(d => d._id).toArray();
+    mergeBookIds[m.from] = ids;
+    plan.push(`MERGE      ${m.from} → ${m.into.join(' + ')} (${ids.length} books re-tagged, doc retired)`);
+    if (!doc.merged_into) {
+      colOps.push({
+        updateOne: {
+          filter: { _id: doc._id },
+          update: { $set: { visible: false, merged_into: m.into[0], retired_at: new Date(), updated_at: new Date() } },
+        },
+      });
+    }
+  }
+
+  for (let i = 0; i < FEATURED.length; i++) {
+    const doc = bySlug.get(FEATURED[i]);
+    if (!doc) continue;
+    if (doc.featured === true && doc.featured_order === i) continue;
+    plan.push(`FEATURED   ${FEATURED[i]}: featured_order=${i}`);
+    colOps.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { featured: true, featured_order: i, updated_at: new Date() } } } });
+  }
+
+  console.log(plan.length ? plan.join('\n') : 'Nothing to do — all changes already applied.');
+  console.log(`\n${colOps.length} collection-doc updates, ${Object.values(mergeBookIds).reduce((a, b) => a + b.length, 0)} book re-tags planned.`);
+
+  if (!apply) {
+    console.log('\nDRY RUN — pass --apply to write changes.');
+    console.log('⚠ Before --apply: the redirect map must already be DEPLOYED to prod.');
+    await client.close();
+    return;
+  }
+
+  // ---- Backup, then write ----
+  const outDir = path.join(__dirname, '../output');
+  mkdirSync(outDir, { recursive: true });
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backupPath = path.join(outDir, `collections-reorg-backup-${stamp}.json`);
+  writeFileSync(backupPath, JSON.stringify({ collections: existing, mergeBookIds }, null, 2));
+  console.log(`\nBackup written: ${backupPath}`);
+
+  if (colOps.length) {
+    const res = await collections.bulkWrite(colOps);
+    console.log(`Collection docs: ${res.modifiedCount} modified.`);
+  }
+
+  for (const m of MERGES) {
+    const ids = mergeBookIds[m.from];
+    if (!ids || !ids.length) continue;
+    // Two passes: $addToSet and $pull can't target the same field in one update.
+    const add = await books.updateMany(
+      { _id: { $in: ids } },
+      { $addToSet: { collections: { $each: m.into } }, $set: { updated_at: new Date() } }
+    );
+    const pull = await books.updateMany(
+      { _id: { $in: ids } },
+      { $pull: { collections: m.from }, $set: { updated_at: new Date() } }
+    );
+    const remaining = await books.countDocuments({ collections: m.from });
+    console.log(`Merge ${m.from}: +tags on ${add.modifiedCount}, -tag on ${pull.modifiedCount}, remaining tagged: ${remaining} (expect 0).`);
+  }
+
+  console.log('\nDone. Next steps:');
+  console.log('  1. node scripts/workers/sync-books-catalog.mjs   (Supabase collection grid)');
+  console.log('  2. node scripts/maintenance/audit-collections.mjs (verify invariants)');
+  console.log('  3. CDN purge on next deploy (npm run deploy:prod handles it)');
+
+  await client.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -7,7 +7,8 @@ import { headers } from 'next/headers';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { getReadDb } from '@/lib/mongodb';
-import { notFound } from 'next/navigation';
+import { notFound, permanentRedirect } from 'next/navigation';
+import collectionRedirects from '@/lib/collection-redirects.json';
 import CollectionSchema from '@/components/seo/CollectionSchema';
 import CollectionAllBooks from '@/components/collections/CollectionAllBooks';
 import IndexCatalogBrowser from '@/components/collections/IndexCatalogBrowser';
@@ -43,6 +44,8 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
+  const redirectTarget = (collectionRedirects as Record<string, string>)[id];
+  if (redirectTarget) permanentRedirect(`/collections/${redirectTarget}`);
   try {
     const db = await Promise.race([
       getReadDb(),
@@ -696,6 +699,13 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
 
 export default async function CollectionDetailPage({ params, provider }: Props & { provider?: string }) {
   const { id } = await params;
+
+  // Merged/retired collection slugs 308 to their successor — the old URLs are
+  // public and indexed (see issue #3002; map maintained alongside
+  // scripts/maintenance/reorganize-collections.mjs).
+  const redirectTarget = (collectionRedirects as Record<string, string>)[id];
+  if (redirectTarget) permanentRedirect(`/collections/${redirectTarget}`);
+
   const { slug: tenantSlug, id: tenantId } = getTenantContextFromRequest(await headers());
 
   let data;

--- a/src/lib/collection-redirects.json
+++ b/src/lib/collection-redirects.json
@@ -1,0 +1,6 @@
+{
+  "philosophy": "classical-philosophy",
+  "theosophy": "theosophical-tradition",
+  "science-mathematics": "mathematics",
+  "hermetica-sacred": "hermetica"
+}


### PR DESCRIPTION
Implements the **data-migration side** of #3002 (migration-order steps 1–3 + section F guard + the data half of E). The /collections kind-banded front door (step 4) is a separate PR by another session — **it should build against the `kind` enum landed here**.

## In scope

- **`scripts/maintenance/backfill-collection-kind.mjs`** — step 1. Classifies all 369 collection docs into `kind ∈ {tradition, region, provenance, exhibit, artwork}`: explicit table for the 57 roots + re-tagged children (Jung/Kloss/Aldine → provenance, etc.), then defaults (`collection_type:'visual_art'` → artwork, `type:'curated'` → exhibit, region-ancestor → region, else tradition). Dry-run against prod: **tradition 170 / exhibit 97 / region 62 / artwork 28 / provenance 12**, zero unclassified. Writes `kind` + `kind_updated_at` only; legacy `type`/`collection_type` untouched. Reversible.
- **`scripts/maintenance/reorganize-collections.mjs`** — steps 2+3, dry-run by default, full-doc backup to `scripts/output/` before any write:
  - Rename `renaissance-natural-philosophy` → "Renaissance Natural Philosophy" (kills the exact-duplicate display name).
  - Promote `classical-philosophy` + `renaissance-philosophy` to roots; hide the retired `philosophy` umbrella (option (a) from the issue). Its 85 direct memberships are kept for curator re-shelving.
  - Folds: architecture→art-illustrated, renaissance-architecture→architecture, arabic-medicine/pharmacopeias→medicine, education→literature, aesthetic-theory→art-illustrated. `music-sound` gets `['art-illustrated','the-human-condition']` (multi-parent fixes the 179-books-under-a-10-book-exhibit inversion without breaking the exhibit).
  - Unhide region roots: east-asia (734), south-asia (512), world-traditions (98).
  - Merges: theosophy→theosophical-tradition (122 books), science-mathematics→mathematics (18), hermetica-sacred→hermetica+gnostic-texts (59). Books get `$addToSet` targets + `$pull` source + `updated_at` bump (Supabase sync lag rule); source docs are **retired** (`visible:false` + `merged_into`), never deleted. No book documents deleted anywhere.
  - Seeds `featured:true` + `featured_order` from the current `CURATED_PATHWAYS` array (data half of E, so the page can go data-driven). Found: `dance-of-death` in that array doesn't exist in prod — the live page silently drops it today.
- **`src/lib/collection-redirects.json` + `/collections/[id]` wiring** — merged/retired slugs (philosophy, theosophy, science-mathematics, hermetica-sacred) 308 to their successors via `permanentRedirect`. The reorganize script refuses to run if the map doesn't cover its merge table.
- **`scripts/maintenance/audit-collections.mjs`** — section F guard, read-only, exit 1 on failure, `--warn-only` mode. Checks: duplicate visible names, kind enum coverage, root size bars (tradition ≥15 / region ≥50, roots only), parent resolution, depth ≤4 + cycle detection, curation warns, `books.collections` membership integrity, redirect-map ↔ `merged_into` sync, hero-image warns. Verified against prod; current failures are exactly the pre-migration expected set.

## Out of scope
- The kind-banded /collections layout + fixed/rotating bands (step 4) — second session, after this merges.
- Coverage backfill (D) — gated on Gemini spend approval, processing is paused.
- Consuming `featured` in page code — page-side PR.
- The 19 orphan slugs referenced by live books with no collection doc (found by the guard) — filing separately as a curation issue.

## Execution order after merge (operator notes)
1. Run `backfill-collection-kind.mjs --apply` (pure metadata, safe immediately).
2. **Deploy prod first** (redirect map must be live), then `reorganize-collections.mjs --apply`.
3. `scripts/workers/sync-books-catalog.mjs`, then `audit-collections.mjs` to verify.
4. CDN purge (deploy via `npm run deploy:prod` covers it).

Dry-runs of both migration scripts were verified against production data; `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)