### PR TITLE
feat(entities): occupation + entity-level tradition from Wikidata claims (#2979)

### DIFF
--- a/scripts/lib/wikidata-tradition-occupation.mjs
+++ b/scripts/lib/wikidata-tradition-occupation.mjs
@@ -1,0 +1,132 @@
+/**
+ * Shared mapping: Wikidata claims → Source Library tradition buckets and
+ * coarse occupation groups (#2979 occupation/tradition slice).
+ *
+ * Used by scripts/maintenance/fetch-wikidata-claims.mjs (label harvest) and
+ * scripts/maintenance/build-canonical-entities.mjs (doc assembly). Matching is
+ * on ENGLISH LABELS (lowercased substring), not QIDs — labels are stable for
+ * these categories and it keeps the tables readable/extensible.
+ */
+
+/**
+ * Entity-level tradition from claims. Priority:
+ *   1. religion (P140) where it is decisive (Judaism/Islam/Indian/East-Asian
+ *      religions, Greco-Roman paganism). Christianity is NOT decisive (spans
+ *      most buckets) and Buddhism is deliberately left to language (Indian vs
+ *      Tibetan/Chinese Buddhism split).
+ *   2. native language (P103) — Plato's native Ancient Greek → classical,
+ *      regardless of which translations of him we hold. (Sparse on Wikidata:
+ *      ~3% of our persons carry it — hence the citizenship tier.)
+ *   3. country of citizenship (P27), decisive polities only — Ancient Rome →
+ *      classical, Ming dynasty → east_asian, Kingdom of Judah → jewish.
+ *      European states deliberately return null here: the book-language
+ *      fallback already lands those on 'european'.
+ * Returns one of the site's tradition keys, or null (caller falls back to the
+ * book-language rollup).
+ */
+export function traditionFromClaims({ religions = [], nativeLanguages = [], citizenships = [] }) {
+  for (const r of religions) {
+    const l = (r.label || '').toLowerCase();
+    if (!l) continue;
+    if (l.includes('judaism') || l.includes('jewish')) return 'jewish';
+    if (l.includes('islam') || l.includes('sunni') || l.includes('shia') || l.includes('sufi')) return 'islamic';
+    if (l.includes('hinduism') || l.includes('jainism') || l.includes('sikhism')) return 'indian';
+    if (l.includes('taoism') || l.includes('daoism') || l.includes('confucian') || l.includes('shinto')) return 'east_asian';
+    if (l.includes('ancient roman religion') || l.includes('ancient greek religion') ||
+        l.includes('religion in ancient greece') || l.includes('greco-roman')) return 'classical';
+  }
+  for (const lang of nativeLanguages) {
+    const t = nativeLanguageToTradition(lang.label);
+    if (t) return t;
+  }
+  for (const c of citizenships) {
+    const t = citizenshipToTradition(c.label);
+    if (t) return t;
+  }
+  return null;
+}
+
+/** Citizenship (P27) label → tradition, decisive polities only (else null). */
+export function citizenshipToTradition(label) {
+  const l = (label || '').toLowerCase();
+  if (!l) return null;
+  if (l.includes('ancient rome') || l.includes('roman empire') || l.includes('roman republic') ||
+      l.includes('classical athens') || l.includes('ancient greece') || l.includes('sparta') ||
+      l.includes('byzantine') || l.includes('macedon')) return 'classical';
+  if (l.includes('caliphate') || l.includes('ottoman') || l.includes('al-andalus') ||
+      l.includes('safavid') || l.includes('seljuk') || l.includes('mamluk') ||
+      l.includes('timurid') || l.includes('mughal') || l.includes('ayyubid') ||
+      l.includes('qajar') || l.includes('nasrid')) return 'islamic';
+  if (l.includes('dynasty') || l.includes('imperial china') || l.includes('western han') ||
+      l.includes('eastern han') || l === 'china' || l.includes("people's republic of china") ||
+      l === 'japan' || l.includes('joseon') || l === 'korea' || l.includes('tibet') ||
+      l === 'vietnam' || l.includes('mongol empire')) return 'east_asian';
+  if (l === 'india' || l.includes('british raj') || l.includes('maurya') ||
+      l.includes('gupta empire') || l.includes('vijayanagara') || l.includes('maratha')) return 'indian';
+  if (l.includes('kingdom of judah') || l.includes('kingdom of israel') || l.includes('judea')) return 'jewish';
+  if (l.includes('ancient egypt') || l.includes('assyria') || l.includes('babylon') ||
+      l.includes('achaemenid') || l.includes('sasanian') || l.includes('parthian') ||
+      l.includes('phoenicia') || l.includes('sumer')) return 'near_eastern';
+  return null;
+}
+
+/** Native-language (P103) label → tradition. Order matters: specific first. */
+export function nativeLanguageToTradition(label) {
+  const l = (label || '').toLowerCase();
+  if (!l) return null;
+  if (l.includes('greek')) return 'classical';
+  // P103 'Latin' in practice means Greco-Roman antiquity — medieval and early
+  // modern scholars have vernacular native languages on Wikidata.
+  if (l.includes('latin') && !l.includes('ladin')) return 'classical';
+  if (l.includes('arabic') || l.includes('persian') || l.includes('turkish') || l.includes('pashto')) return 'islamic';
+  if (l.includes('hebrew') || l.includes('yiddish') || l.includes('ladino') || l.includes('aramaic')) return 'jewish';
+  if (l.includes('sanskrit') || l.includes('pali') || l.includes('prakrit') ||
+      l.includes('tamil') || l.includes('telugu') || l.includes('hindi') ||
+      l.includes('bengali') || l.includes('marathi') || l.includes('kannada') ||
+      l.includes('malayalam') || l.includes('gujarati') || l.includes('punjabi') ||
+      l.includes('urdu') || l.includes('kashmiri') || l.includes('odia')) return 'indian';
+  if (l.includes('chinese') || l.includes('mandarin') || l.includes('cantonese') ||
+      l.includes('japanese') || l.includes('korean') || l.includes('tibetan') ||
+      l.includes('mongolian') || l.includes('manchu') || l.includes('vietnamese') ||
+      l.includes('burmese') || l.includes('thai') || l.includes('javanese') ||
+      l.includes('malay')) return 'east_asian';
+  if (l.includes('coptic') || l.includes('egyptian') || l.includes('akkadian') ||
+      l.includes('sumerian') || l.includes('syriac') || l.includes('geʿez') ||
+      l.includes('geez') || l.includes('amharic') || l.includes('armenian') ||
+      l.includes('georgian')) return 'near_eastern';
+  if (l.includes('nahuatl') || l.includes('quechua') || l.includes('maya') ||
+      l.includes('navajo') || l.includes('maori') || l.includes('aymara') ||
+      l.includes('guaran')) return 'indigenous';
+  // Any other attested native language (European vernaculars, English, …)
+  return 'european';
+}
+
+/**
+ * Coarse occupation groups for the timeline's "categories of people" lens.
+ * Order = display order. An occupation label can hit several groups; an
+ * entity's groups are the union over its P106 values.
+ */
+export const OCCUPATION_GROUPS = [
+  { key: 'philosopher',  label: 'Philosophers',       match: ['philosoph', 'logician'] },
+  { key: 'theologian',   label: 'Theologians & clergy', match: ['theolog', 'priest', 'bishop', 'pope', 'rabbi', 'imam', 'monk', 'nun', 'cleric', 'cardinal', 'pastor', 'missionary', 'preacher', 'friar', 'abbot', 'lama'] },
+  { key: 'mystic',       label: 'Mystics & alchemists', match: ['mystic', 'alchemist', 'astrolog', 'occult', 'kabbal', 'magician', 'hermeticist', 'esoteric', 'diviner', 'prophet'] },
+  { key: 'physician',    label: 'Physicians',          match: ['physician', 'surgeon', 'apothecary', 'doctor of medicine', 'medic'] },
+  { key: 'scientist',    label: 'Scientists & mathematicians', match: ['mathematician', 'astronomer', 'physicist', 'chemist', 'naturalist', 'botanist', 'scientist', 'engineer', 'geographer', 'cartographer', 'zoologist', 'geologist', 'anatomist', 'inventor'] },
+  { key: 'writer',       label: 'Writers & poets',     match: ['writer', 'poet', 'author', 'playwright', 'novelist', 'essayist', 'dramatist'] },
+  { key: 'scholar',      label: 'Scholars & historians', match: ['historian', 'philolog', 'grammarian', 'lexicograph', 'librarian', 'professor', 'scholar', 'academic', 'translator', 'orientalist', 'linguist', 'antiquarian'] },
+  { key: 'ruler',        label: 'Rulers & statesmen',  match: ['monarch', 'king', 'queen', 'emperor', 'sultan', 'caliph', 'sovereign', 'politician', 'statesman', 'diplomat', 'military', 'general', 'ruler', 'prince', 'duke', 'pharaoh', 'shah'] },
+  { key: 'artist',       label: 'Artists & printers',  match: ['painter', 'sculptor', 'engraver', 'printmaker', 'architect', 'composer', 'musician', 'illustrator', 'artist', 'printer', 'publisher', 'bookseller', 'typograph'] },
+];
+
+/** P106 labels → sorted unique group keys. */
+export function occupationGroupsFor(occupationLabels) {
+  const keys = new Set();
+  for (const label of occupationLabels) {
+    const l = (label || '').toLowerCase();
+    if (!l) continue;
+    for (const g of OCCUPATION_GROUPS) {
+      if (g.match.some((m) => l.includes(m))) keys.add(g.key);
+    }
+  }
+  return OCCUPATION_GROUPS.map((g) => g.key).filter((k) => keys.has(k));
+}

--- a/scripts/maintenance/build-canonical-entities.mjs
+++ b/scripts/maintenance/build-canonical-entities.mjs
@@ -44,6 +44,7 @@
  *   45 3 * * * ... flock -n /tmp/sl-canonical-entities.lock ... --apply
  */
 import { MongoClient } from 'mongodb';
+import { traditionFromClaims, occupationGroupsFor } from '../lib/wikidata-tradition-occupation.mjs';
 
 const APPLY = process.argv.includes('--apply');
 /** --skip-stats: build/swap the collection but do NOT touch system_config
@@ -146,6 +147,13 @@ for (let i = 0; i < bookIdArr.length; i += 5000) {
 }
 console.log(`book language map: ${langByBook.size}/${allBookIds.size} referenced book ids resolved (${yearByBook.size} with year)`);
 
+// ── 4b. wikidata_claims join (durable cache written by fetch-wikidata-claims.mjs;
+// #2979 occupation/tradition slice). Missing docs are fine — fields stay null/[]
+// and the timeline falls back to the book-language tradition rollup.
+const claimsById = new Map();
+for await (const c of db.collection('wikidata_claims').find({})) claimsById.set(c._id, c);
+console.log(`wikidata_claims: ${claimsById.size} QIDs cached`);
+
 // ── 5. Assemble one doc per canonical entity.
 const typeRank = { person: 3, place: 2, concept: 1 };
 const docs = [];
@@ -181,6 +189,20 @@ for (const [key, members] of groups) {
 
   const pick = (field) => members.map(m => m[field]).find(v => v != null) ?? null;
   const wikidataId = primary.wikidata_id || null;
+
+  // Entity-level tradition + occupations from the wikidata_claims cache.
+  // Tradition here reflects who the person WAS (religion → native language),
+  // not which languages our copies of them happen to be in — Plato via Latin
+  // translations stays 'classical'. Readers fall back to `languages` when null.
+  const claims = wikidataId ? claimsById.get(wikidataId) : null;
+  const occupationLabels = (claims?.occupations || []).map(o => o.label).filter(Boolean);
+  const tradition = claims
+    ? traditionFromClaims({
+        religions: claims.religions || [],
+        nativeLanguages: claims.native_languages || [],
+        citizenships: claims.citizenships || [],
+      })
+    : null;
   const authorSlug = type === 'person'
     ? (wikidataId && slugByQid.get(wikidataId))
       || members.map(m => slugByEntityId.get(String(m._id))).find(Boolean)
@@ -212,6 +234,10 @@ for (const [key, members] of groups) {
     total_mentions: [...mentionsByBook.values()].reduce((s, n) => s + n, 0),
     book_ids: rankedBooks.slice(0, BOOK_IDS_CAP).map(([id]) => id),
     languages,                             // { la: 12, de: 3, ... } — timeline tradition rollup
+    // Entity-level presentation data from wikidata_claims (#2979 slice):
+    tradition,                             // site tradition key or null (fallback: languages rollup)
+    occupations: occupationLabels.slice(0, 10),      // raw P106 English labels
+    occupation_groups: occupationGroupsFor(occupationLabels),  // coarse timeline-lens buckets
     // [min, max] publication year (>0) across ALL mentioning books (not capped
     // by BOOK_IDS_CAP) — the map's century fallback (#2979 read-path PR 1).
     book_year_range: minYear !== Infinity ? [minYear, maxYear] : null,
@@ -231,6 +257,9 @@ const merged = docs.filter(d => d.entity_ids.length > 1).length;
 console.log(`\ncanonical entities: ${docs.length} (from ${rows.length} rows; ${merged} QIDs merged >1 row)`);
 console.log(`  by type: ${JSON.stringify(byType)}`);
 console.log(`  with dates: ${withDates}  with coordinates: ${withCoords}  persons linked to authors: ${withAuthor}`);
+const withTradition = docs.filter(d => d.tradition).length;
+const withOccupations = docs.filter(d => d.occupation_groups.length > 0).length;
+console.log(`  with entity-level tradition: ${withTradition}  with occupation groups: ${withOccupations}`);
 
 // ── 6. Whole-collection stats for the /explore hub (replaces its 1M-row counts).
 const statTypes = await ents.aggregate(

--- a/scripts/maintenance/fetch-wikidata-claims.mjs
+++ b/scripts/maintenance/fetch-wikidata-claims.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Fetch person-level Wikidata claims into the durable `wikidata_claims`
+ * collection (#2979 occupation/tradition slice).
+ *
+ * Why a side collection: `canonical_entities` is a derived, droppable read
+ * model rebuilt nightly — anything fetched from the network must live
+ * somewhere durable so the rebuild is a pure local join, not 400+ API calls
+ * a night. This collection is the durable cache: one doc per QID, fetched
+ * once, refreshed only explicitly (--refresh).
+ *
+ * Claims fetched (person-level presentation data only — identity stays in
+ * `authors`, #2179):
+ *   P106 occupation · P103 native language · P140 religion/worldview ·
+ *   P27 country of citizenship
+ * Value QIDs are resolved to English labels in a second batched pass and
+ * stored inline, so consumers never need the Wikidata API.
+ *
+ * Doc shape:
+ *   { _id: 'Q859', occupations: [{id,label}], native_languages: [{id,label}],
+ *     religions: [{id,label}], citizenships: [{id,label}], fetched_at }
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/fetch-wikidata-claims.mjs --limit 100   # trial
+ *   node scripts/maintenance/fetch-wikidata-claims.mjs               # all missing QIDs
+ *   node scripts/maintenance/fetch-wikidata-claims.mjs --refresh     # refetch everything
+ */
+import { MongoClient } from 'mongodb';
+
+const REFRESH = process.argv.includes('--refresh');
+const limitArg = process.argv.indexOf('--limit');
+const LIMIT = limitArg > -1 ? parseInt(process.argv[limitArg + 1], 10) : Infinity;
+
+const CLAIM_PROPS = {
+  P106: 'occupations',
+  P103: 'native_languages',
+  P140: 'religions',
+  P27: 'citizenships',
+};
+
+const UA = 'SourceLibraryBot/1.0 (https://sourcelibrary.org; hello@sourcelibrary.org) wikidata-claims';
+const BATCH = 50; // wbgetentities max ids per request
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+const mc = new MongoClient(uri);
+await mc.connect();
+const db = mc.db('bookstore');
+const claimsCol = db.collection('wikidata_claims');
+await claimsCol.createIndex({ fetched_at: 1 }).catch(() => {});
+
+// ── 1. QIDs to fetch: everything canonical_entities references, minus done.
+const qids = await db.collection('canonical_entities')
+  .distinct('wikidata_id', { wikidata_id: { $ne: null } });
+const have = REFRESH ? new Set() : new Set(
+  (await claimsCol.find({}, { projection: { _id: 1 } }).toArray()).map((d) => d._id),
+);
+const todo = qids.filter((q) => /^Q\d+$/.test(q) && !have.has(q)).slice(0, LIMIT);
+console.log(`QIDs: ${qids.length} referenced · ${have.size} already fetched · ${todo.length} to fetch`);
+if (todo.length === 0) { await mc.close(); process.exit(0); }
+
+async function wdGet(params, attempt = 0) {
+  const url = `https://www.wikidata.org/w/api.php?${new URLSearchParams({ format: 'json', maxlag: '5', ...params })}`;
+  const res = await fetch(url, { headers: { 'User-Agent': UA } });
+  if (!res.ok || res.status === 429) {
+    if (attempt >= 4) throw new Error(`wikidata ${res.status} after ${attempt} retries`);
+    await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
+    return wdGet(params, attempt + 1);
+  }
+  const data = await res.json();
+  if (data.error?.code === 'maxlag') {
+    if (attempt >= 4) throw new Error('wikidata maxlag persists');
+    await new Promise((r) => setTimeout(r, 3000 * (attempt + 1)));
+    return wdGet(params, attempt + 1);
+  }
+  return data;
+}
+
+// ── 2. Fetch claims in batches; collect referenced value QIDs for the label pass.
+const parsed = new Map(); // qid -> { occupations: [valueQid,...], ... }
+const valueQids = new Set();
+for (let i = 0; i < todo.length; i += BATCH) {
+  const batch = todo.slice(i, i + BATCH);
+  const data = await wdGet({ action: 'wbgetentities', ids: batch.join('|'), props: 'claims' });
+  for (const qid of batch) {
+    const claims = data?.entities?.[qid]?.claims || {};
+    const doc = {};
+    for (const [prop, field] of Object.entries(CLAIM_PROPS)) {
+      const ids = (claims[prop] || [])
+        .map((c) => c?.mainsnak?.datavalue?.value?.id)
+        .filter((v) => typeof v === 'string');
+      doc[field] = [...new Set(ids)].slice(0, 12);
+      for (const v of doc[field]) valueQids.add(v);
+    }
+    parsed.set(qid, doc);
+  }
+  if ((i / BATCH) % 20 === 0) console.log(`  claims ${Math.min(i + BATCH, todo.length)}/${todo.length}`);
+  await new Promise((r) => setTimeout(r, 120));
+}
+
+// ── 3. Resolve value QIDs → English labels (batched, cached across runs via
+// existing docs' inline labels being reused only within this run — the value
+// set is small, ~2-4K distinct).
+const labelById = new Map();
+const values = [...valueQids];
+console.log(`resolving ${values.length} distinct value labels…`);
+for (let i = 0; i < values.length; i += BATCH) {
+  const batch = values.slice(i, i + BATCH);
+  const data = await wdGet({ action: 'wbgetentities', ids: batch.join('|'), props: 'labels', languages: 'en' });
+  for (const q of batch) {
+    labelById.set(q, data?.entities?.[q]?.labels?.en?.value ?? null);
+  }
+  await new Promise((r) => setTimeout(r, 120));
+}
+
+// ── 4. Write docs.
+const now = new Date();
+const ops = [...parsed.entries()].map(([qid, doc]) => ({
+  replaceOne: {
+    filter: { _id: qid },
+    replacement: {
+      _id: qid,
+      ...Object.fromEntries(
+        Object.values(CLAIM_PROPS).map((field) => [
+          field,
+          doc[field].map((id) => ({ id, label: labelById.get(id) ?? null })),
+        ]),
+      ),
+      fetched_at: now,
+    },
+    upsert: true,
+  },
+}));
+let written = 0;
+for (let i = 0; i < ops.length; i += 1000) {
+  const res = await claimsCol.bulkWrite(ops.slice(i, i + 1000), { ordered: false });
+  written += res.upsertedCount + res.modifiedCount + res.matchedCount;
+}
+const withOcc = [...parsed.values()].filter((d) => d.occupations.length > 0).length;
+const withLang = [...parsed.values()].filter((d) => d.native_languages.length > 0).length;
+const withRel = [...parsed.values()].filter((d) => d.religions.length > 0).length;
+console.log(`\nwrote ${ops.length} claim docs (bulk acks ${written}).`);
+console.log(`coverage of this batch: occupations ${withOcc} · native language ${withLang} · religion ${withRel}`);
+await mc.close();

--- a/src/app/explore/timeline/page.tsx
+++ b/src/app/explore/timeline/page.tsx
@@ -87,6 +87,8 @@ async function fetchTimelineDataCanonical() {
           wikidata_birth_date: 1,
           wikidata_death_date: 1,
           languages: 1,
+          tradition: 1,
+          occupation_groups: 1,
         },
         maxTimeMS: 15000,
       },
@@ -152,7 +154,12 @@ async function fetchTimelineDataCanonical() {
         book_count: (e.book_count as number) || 0,
         total_mentions: (e.total_mentions as number) || 0,
         description: (e.description as string) || undefined,
-        tradition: traditionFromLanguages(e.languages as Record<string, number> | undefined),
+        // Entity-level tradition (who they were) wins over the book-language
+        // rollup (which languages our copies are in) — fixes Plato-in-Latin
+        // rendering as 'european'. Null/absent → same fallback as before.
+        tradition: (e.tradition as string | null)
+          || traditionFromLanguages(e.languages as Record<string, number> | undefined),
+        occupations: (e.occupation_groups as string[] | undefined) ?? [],
       };
     })
     .filter(Boolean) as {
@@ -164,6 +171,7 @@ async function fetchTimelineDataCanonical() {
     total_mentions: number;
     description?: string;
     tradition: string;
+    occupations: string[];
   }[];
 
   return {

--- a/src/components/explore/Timeline.tsx
+++ b/src/components/explore/Timeline.tsx
@@ -12,6 +12,8 @@ export interface TimelineEntity {
   total_mentions: number;
   description?: string;
   tradition?: string;
+  /** Coarse occupation-group keys (canonical read path only; absent on legacy). */
+  occupations?: string[];
 }
 
 interface TimelineProps {
@@ -38,7 +40,7 @@ const TYPE_COLORS: Record<string, string> = {
 // on the cream surface); keep legend order in sync with this object's order.
 const TRADITION_COLORS: Record<string, { color: string; label: string }> = {
   european:     { color: '#8b8178', label: 'European' },
-  classical:    { color: '#a16207', label: 'Classical Greek' },
+  classical:    { color: '#a16207', label: 'Classical' },
   islamic:      { color: '#15803d', label: 'Islamic' },
   indian:       { color: '#c2410c', label: 'Indian' },
   jewish:       { color: '#2563eb', label: 'Jewish' },
@@ -60,6 +62,20 @@ const FEATURED_CAP = 120;    // max labeled figures per viewport
 const C_BAR_HEIGHT = 4;
 const C_LANE_HEIGHT = 7;
 const C_MAX_LANES = 40;
+
+// Display labels for occupation-group keys emitted by the canonical build
+// (scripts/lib/wikidata-tradition-occupation.mjs). Key order = display order.
+const OCCUPATION_LABELS: Record<string, string> = {
+  philosopher: 'Philosophers',
+  theologian: 'Theologians & clergy',
+  mystic: 'Mystics & alchemists',
+  physician: 'Physicians',
+  scientist: 'Scientists & mathematicians',
+  writer: 'Writers & poets',
+  scholar: 'Scholars & historians',
+  ruler: 'Rulers & statesmen',
+  artist: 'Artists & printers',
+};
 
 const HISTOGRAM_HEIGHT = 80;
 const HEADER_HEIGHT = 30;
@@ -406,6 +422,7 @@ export default function Timeline({ entities, stats }: TimelineProps) {
 
   // Filters
   const [minBooks, setMinBooks] = useState(3);
+  const [occupation, setOccupation] = useState('all');
   const [colorMode, setColorMode] = useState<'type' | 'books' | 'tradition'>('tradition');
   const [showTypes, setShowTypes] = useState(new Set(['person', 'concept']));
 
@@ -449,14 +466,23 @@ export default function Timeline({ entities, stats }: TimelineProps) {
   const parsed = useMemo(() => dedupeEntities(entities), [entities]);
 
   // Apply filters
+  // Occupation groups present in the data (empty on the legacy read path,
+  // which hides the control entirely).
+  const occupationOptions = useMemo(() => {
+    const present = new Set<string>();
+    for (const e of parsed) for (const o of e.occupations || []) present.add(o);
+    return Object.keys(OCCUPATION_LABELS).filter((k) => present.has(k));
+  }, [parsed]);
+
   const filtered = useMemo(() => {
     return parsed.filter((e) => {
       if (!showTypes.has(e.type)) return false;
       if (e.book_count < minBooks) return false;
       if (e.birth_year === null) return false;
+      if (occupation !== 'all' && !(e.occupations || []).includes(occupation)) return false;
       return true;
     });
-  }, [parsed, showTypes, minBooks]);
+  }, [parsed, showTypes, minBooks, occupation]);
 
   const svgWidth = containerWidth;
   const pxPerYear = svgWidth / (viewEnd - viewStart);
@@ -822,6 +848,26 @@ export default function Timeline({ entities, stats }: TimelineProps) {
             ))}
           </select>
         </label>
+
+        {occupationOptions.length > 0 && (
+          <>
+            <span className="w-px h-5 mx-1" style={{ background: 'var(--border-light)' }} />
+            <label className="flex items-center gap-1.5" style={{ color: 'var(--text-muted)' }}>
+              Category
+              <select
+                value={occupation}
+                onChange={(e) => setOccupation(e.target.value)}
+                className="rounded px-1.5 py-0.5 text-sm"
+                style={{ border: '1px solid var(--border-light)', color: 'var(--text-secondary)' }}
+              >
+                <option value="all">All</option>
+                {occupationOptions.map((k) => (
+                  <option key={k} value={k}>{OCCUPATION_LABELS[k]}</option>
+                ))}
+              </select>
+            </label>
+          </>
+        )}
 
         <span className="w-px h-5 mx-1" style={{ background: 'var(--border-light)' }} />
 

--- a/src/lib/canonical-entities.ts
+++ b/src/lib/canonical-entities.ts
@@ -72,6 +72,17 @@ export interface CanonicalEntityDoc {
    * before 2026-07-05 lack the field, so readers must guard on presence).
    */
   book_year_range: [number, number] | null;
+  /**
+   * Entity-level tradition (who the person WAS: religion → native language,
+   * from the durable `wikidata_claims` cache) — or null, in which case readers
+   * fall back to the `languages` book rollup. Docs built before 2026-07-05
+   * lack these three fields; guard on presence.
+   */
+  tradition: string | null;
+  /** Raw P106 occupation labels (English, capped at 10). */
+  occupations: string[];
+  /** Coarse occupation buckets for the timeline lens (see scripts/lib/wikidata-tradition-occupation.mjs). */
+  occupation_groups: string[];
   /** Provenance: `entities._id`s merged into this doc. */
   entity_ids: string[];
   source: 'build-canonical-entities';


### PR DESCRIPTION
Completes the occupation/tradition slice of #2979 (claimed in the issue thread) — the two data gaps called out in the #2991 timeline redesign.

## What

**`wikidata_claims` durable cache** (`scripts/maintenance/fetch-wikidata-claims.mjs`): one doc per QID — P106 occupation, P103 native language, P140 religion, P27 citizenship, English labels resolved inline. Fetched for all 20,759 canonical QIDs on 2026-07-05 (occupations 6,584 · religion 2,360 · native language 672). Durable by design: the nightly `canonical_entities` rebuild stays a pure local join, not 400+ API calls a night.

**Claims → tradition/occupation mapping** (`scripts/lib/wikidata-tradition-occupation.mjs`): tradition priority is religion → native language → decisive citizenship (Ancient Rome → classical, Ming dynasty → east_asian, Kingdom of Judah → jewish; European states deliberately fall through to the existing book-language rollup). P106 labels map to 9 coarse occupation groups. Unit-checked: Plato → classical, Maimonides → jewish (religion beats his Arabic), Nagarjuna → indian (Buddhism defers to Sanskrit), Paracelsus → theologian/mystic/physician/scientist.

**Builder join** (`build-canonical-entities.mjs`): docs gain `tradition` / `occupations` / `occupation_groups`. Applied to prod 2026-07-05 (atomic swap, 659s): tradition 2,309 · occupation groups 5,798 of 8,001 persons. This run also wrote `system_config.entity_stats` for the first time and the docs carry `book_year_range` — both rollout prerequisites from the read-path PRs are now met.

**Timeline** (canonical path only, invisible while the flag is off): entity-level `tradition` wins over the book-language rollup — **Plato/Aristotle/Cicero now render Classical gold instead of European gray in Antiquity**; a **Category** filter (Philosophers / Mystics & alchemists / Physicians / Rulers / …) appears when occupation data is present. Legend label 'Classical Greek' → 'Classical' (Latin natives map there).

## Verified

Playwright against local dev with `CANONICAL_ENTITIES_READPATH=1` on the freshly rebuilt prod collection: Antiquity colors correct (screenshots in session), 'Mystics & alchemists' lens shows 146 figures in the Renaissance range (Flamel, Trithemius, Agrippa, Paracelsus, Fludd, Maier, Ashmole, Sendivogius — plus Karo/Vital in Jewish blue, Ulugh Beg in Islamic green). No console errors; `tsc --noEmit` clean. Legacy path untouched (byte-identical with flag off).

## Out of scope

- Flipping `CANONICAL_ENTITIES_READPATH` on Vercel (rollout step, coordinated in #2979).
- The handful of wrong-QID alignments visible in the data (e.g. one Antiochus rendering East Asian) — upstream wikidata-align issue, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFtJFc4fduQ4HDJHxSM1y3