### PR TITLE
sync-books-catalog: guard against literal-\n env pollution, log real batch errors

### DIFF
--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -18,9 +18,15 @@
 import { MongoClient } from 'mongodb';
 import { createClient } from '@supabase/supabase-js';
 
+// Locally-sourced .env.production.local values can carry a literal "\n"
+// suffix (vercel env pull escaping — same footgun as the R2 vars, #3000).
+// A polluted SUPABASE_URL makes every upsert a phantom success: this script
+// reported "31,236 synced" on 2026-07-05 while writing nothing.
+const cleanEnv = (v) => (v || '').replace(/\\n/g, '').trim();
+
 const MONGODB_URI = process.env.MONGODB_URI;
-const SUPABASE_URL = process.env.SUPABASE_URL || 'https://ykhxaecbbxaaqlujuzde.supabase.co';
-const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const SUPABASE_URL = cleanEnv(process.env.SUPABASE_URL) || 'https://ykhxaecbbxaaqlujuzde.supabase.co';
+const SUPABASE_SERVICE_KEY = cleanEnv(process.env.SUPABASE_SERVICE_ROLE_KEY);
 
 if (!MONGODB_URI || !SUPABASE_SERVICE_KEY) {
   console.error('Missing MONGODB_URI or SUPABASE_SERVICE_ROLE_KEY');
@@ -211,7 +217,7 @@ for await (const book of cursor) {
       .from('books_catalog')
       .upsert(batch, { onConflict: 'id' });
     if (error) {
-      console.error(`Batch error: ${error.message}`);
+      console.error(`Batch error: ${error.message || JSON.stringify(error)}`);
       errors += batch.length;
     } else {
       synced += batch.length;
@@ -225,7 +231,7 @@ if (batch.length > 0) {
     .from('books_catalog')
     .upsert(batch, { onConflict: 'id' });
   if (error) {
-    console.error(`Batch error: ${error.message}`);
+    console.error(`Batch error: ${error.message || JSON.stringify(error)}`);
     errors += batch.length;
   } else {
     synced += batch.length;


### PR DESCRIPTION
Hardening follow-up from the #3002 migration run.

**What happened:** running `sync-books-catalog.mjs` locally with `set -a; source .env.production.local` picked up a `SUPABASE_URL` value carrying a literal `\n` suffix (the `vercel env pull` escaping footgun — same class as the R2 vars fixed in #3000). Every upsert became a phantom success: the run reported **"31,236 synced, 1,200 errors"** while writing **nothing** — the `books_catalog` watermark never advanced, which is how it was caught. The 1,200 "errors" printed as `Batch error: undefined` because the failure wasn't a PostgrestError shape.

**Fix (two lines of behavior):**
- Trim literal `\n` sequences + whitespace from `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` at startup (no-op for clean envs, incl. Hetzner cron).
- Batch-error logging falls back to `JSON.stringify(error)` when `error.message` is undefined, so the next failure of this class is diagnosable from the log.

Out of scope: sweeping the other ~30 scripts that read these env vars — if this bites again, promote `cleanEnv` to a shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)