### PR TITLE
R2 storage-reclamation measurement tooling (#3005)

### DIFF
--- a/.claude/handoffs/2026-07-05-r2-reclaim-3005.md
+++ b/.claude/handoffs/2026-07-05-r2-reclaim-3005.md
@@ -1,0 +1,69 @@
+# R2 storage reclamation (#3005) — measurement complete, deletes/regen pending sign-off
+
+**Date:** 2026-07-05
+**PR:** #3013 (branch `worktree-r2-reclaim-3005`) — tooling only, no deletes, no prod writes
+**Tooling:** `scripts/maintenance/r2-reclaim/` (see its README.md)
+**Outputs (gitignored scratch, main checkout):** `scripts/output/r2-reclaim/manifest-*.ndjson`, `summary-*.json`
+
+## What was asked
+
+Implement #3005: measure (dry-run) all four reclamation passes on the 16.5 TB / 46.7M-object
+`sourcelibrary` R2 bucket, run the display regeneration, and bring the delete manifests for sign-off.
+
+## The critical finding — #3005's estimates were built on an id-space bug
+
+R2 folders are keyed by the book's **string `id`** (`books.id` == `pages.book_id`), NOT the Mongo
+`_id`; crop filenames are the page's string `id` (and page `_id`/`id` are both stored as strings and
+differ from each other). The sampling probes behind #3005 used `ObjectId(_id)` joins, which match
+nothing → they flagged live books/pages as orphans. My first drafts of Pass 3/4 had the same bug (a
+run showed a false 75% stale crops). Fixed with `loadLiveBookIds()` (string join over
+books ∪ deleted_books ∪ failed_imports). Recorded in memory `lesson_book_id_field_vs_mongo_id`.
+
+## Measured results (full-bucket crawls, correct joins)
+
+Crawl scope: 57,669 books; `pages/` 25.7M objs / 5.17 TB, `archived/` 11.6M / 7.93 TB.
+
+| Pass | What | Result | Action type |
+|---|---|---|---|
+| 1 | display never downsized | 3,987,467 pages (32.5% of displays); **~433 GB** reclaim + ~4× lighter loads | **regen** (reversible) |
+| 2 | byte-identical `-full`/`archived` | 58,561 pairs / 161 GB; **1,770 / ~3 GB cleanly safe**, 54,240 / 153 GB need repoint/verify, 2,540 both-referenced | delete after repoint |
+| 3 | `archive/` JP2 orphans | **0 GB** (est. was 186 GB — the bug) | none |
+| 4 | `cropped/` stale | **18,422 files / 18.37 GB safe**; +367,214 / 618 GB "alive-but-unreferenced" needs its own call | delete + review |
+
+**Bottom line:** the feared multi-TB wholesale `archived/`↔`pages/` duplication does not exist. The
+real safe win is Pass 1 display regeneration (~433 GB + UX), plus ~21 GB of clean deletes (Pass 2's
+3 GB + Pass 4's 18 GB). ~771 GB more sits behind verify/repoint decisions; 368 GB is the separate
+"keep JP2 masters for live books?" policy question.
+
+## Pass 1 regen nuance (important for execution)
+
+Most of the 4M flagged displays have a *small* master (they trip the ≥0.9 ratio but reclaim little);
+the bytes AND the UX win concentrate in a heavy tail (1–2 MB pages). The manifest carries a per-row
+`reclaimEst`, so `regen-display-bloat.mjs --min-reclaim=<bytes>` targets the high-value tail instead
+of re-encoding all ~4M pages (which would be ~8M R2 PUTs + ~1 TB of downloads + hours of sharp).
+`regen-display-bloat.mjs` is source-correct: resolves via `getPageSource()`, **skips old-era split
+pages** (`cropped_photo` set — the #1814 footgun), and never touches the master → fully reversible.
+
+## What was NOT done (deliberate — sign-off gate + it was gnite)
+
+- No deletes. No display-regen prod run. No dry-run of regen executed yet.
+- The ~26M bucket objects outside pages/archived/archive/cropped (gallery/, thumbnails/, covers/,
+  uploads/) were not measured — out of scope for #3005's four passes.
+
+## Next steps (morning)
+
+1. Review `scripts/output/r2-reclaim/summary-*.json` + `manifest-full-dup-enriched.ndjson`.
+2. Merge PR #3013.
+3. Pass 1: `regen-display-bloat.mjs --dry-run`, then a small `--limit --verify` pilot (confirm files
+   shrink + pages still render), then run the high-value tail with `--min-reclaim`.
+4. Clean deletes (~21 GB): Pass 2's 1,770 safe pairs + Pass 4's 18,422 stale crops — write a
+   delete script (not yet built) that re-lists each key at delete time and logs a manifest to
+   system_config per the no-batch-delete rule.
+5. Decide on the two big "needs-a-decision" buckets: Pass 2's 153 GB neither-referenced dups, and
+   Pass 4's 618 GB alive-but-unreferenced crops.
+6. Re-run `scripts/storage-stats.mjs` before/after each pass to confirm actual reclaim.
+
+## CLAUDE.md check
+
+No new invariant needed — the id-space rule already lives in CLAUDE.md ("Author identity" / data
+sections reference `id` vs `_id`) and is now reinforced in memory with the R2-folder-key instance.

--- a/scripts/maintenance/r2-reclaim/README.md
+++ b/scripts/maintenance/r2-reclaim/README.md
@@ -1,0 +1,80 @@
+# R2 storage reclamation (issue #3005)
+
+Measurement + execution tooling for the four reclamation passes on the
+`sourcelibrary` R2 bucket (16.5 TB, ~46.7M objects). **All measurement is
+read-only** — it LISTs the bucket (Size + ETag come back on every
+`ListObjectsV2` Content, so we never HEAD per object) and writes NDJSON
+manifests + a JSON summary to `scripts/output/r2-reclaim/`. Deletion is a
+separate, sign-off-gated step and is **not** implemented here.
+
+```
+set -a; source .env.production.local; set +a
+node scripts/maintenance/r2-reclaim/measure-pages-archived.mjs   # Pass 1 + Pass 2
+node scripts/maintenance/r2-reclaim/measure-jp2-orphans.mjs      # Pass 3
+node scripts/maintenance/r2-reclaim/measure-stale-crops.mjs      # Pass 4
+node scripts/maintenance/r2-reclaim/enrich-full-dup-pointers.mjs # Pass 2 decision enrichment
+node scripts/maintenance/r2-reclaim/regen-display-bloat.mjs --dry-run  # Pass 1 execution
+```
+
+## The identity join is the whole game — read this first
+
+R2 folders are keyed by the book's **string `id`** (`books.id`, ==
+`pages.book_id`), **not** the Mongo `_id`. Page `_id` and `id` are themselves
+stored as strings and differ from each other; crop filenames are the page's
+**`id`**. Any existence check that wraps the folder id in `new ObjectId(...)`
+and matches `_id` silently finds nothing and flags live books/pages as orphans.
+
+This bug was baked into the original sampling probes behind #3005's estimates,
+which is why they were wildly high:
+
+| Pass | #3005 sampled estimate | Measured (full crawl, correct join) |
+|---|---|---|
+| 3 — `archive/` JP2 orphans | ~150–190 GB | **0 GB** — all 2,142 dirs are live books |
+| 4 — `cropped/` stale | ~20% of files | **~3.4%** (a first buggy run showed a false 75%) |
+| 2 — `pages/-full` vs `archived/` dup | ~0.5–1 TB | far smaller — ~58K pairs; see summary for bytes |
+| 1 — display never downsized | ~1–1.5 TB | the real prize — 2.8M+ candidates, ~TB reclaim |
+
+`lib.mjs :: loadLiveBookIds()` is the shared, correct join (string ids from
+`books` ∪ `deleted_books` ∪ `failed_imports`). Never re-introduce an
+ObjectId-keyed existence check against these R2 folder ids.
+
+## Passes
+
+- **Pass 1 — display bloat** (`measure-pages-archived.mjs`). A
+  `pages/{id}/{NNNN}.jpg` display whose size is ≥90% of its master (`-full` if
+  present, else `archived/{id}/{N}.jpg`) was never downsized. Manifest =
+  **regeneration** candidates (not deletes). Executed by
+  `regen-display-bloat.mjs`, which force-overwrites the bloated display with a
+  true 1200px variant via the shared `generateDisplayVariants()`, resolving the
+  source with `getPageSource()` and **skipping old-era split pages**
+  (`cropped_photo` set) — the #1814 footgun. The master is untouched, so the
+  pass is reversible.
+- **Pass 2 — full-res duplicates** (same crawl). `pages/{id}/{NNNN}-full.jpg`
+  and `archived/{id}/{N}.jpg` with equal ETag (or size within 2%) are
+  byte-identical. Which copy is redundant is **per-page** — it depends on which
+  key the reader's pointer resolves through (`getPageSource`). Run
+  `enrich-full-dup-pointers.mjs` to attach that decision before any delete.
+- **Pass 3 — JP2 orphans** (`measure-jp2-orphans.mjs`). `archive/{id}/` dirs
+  whose id is in no live-book collection. Measured empty.
+- **Pass 4 — stale crops** (`measure-stale-crops.mjs`). `cropped/{id}/{oid}.jpg`
+  whose page `id` (the filename) is absent from `pages`. Delete manifest is the
+  absent-from-`pages` set only; "page alive but unreferenced" is reported
+  separately for a second decision.
+
+## Efficiency notes
+
+- Pass 1/2 does a streaming **merge-join** of `pages/` and `archived/` by bookId
+  (both prefixes share id-space and lexicographic order), sharded into 4096
+  three-hex-char bookId prefixes through a concurrency pool (`SHARD_CONCURRENCY`,
+  default 24) — the ObjectId cluster (`6xx-`) balances across 256 sub-buckets.
+  Constant memory (one book at a time). `ONLY_SHARDS=6a0,6a1` restricts for
+  smoke tests.
+- `pages/` + `archived/` hold ~11M+ / ~9M objects; the remaining ~26M bucket
+  objects live in other prefixes (gallery/, thumbnails/, covers/, uploads/, …)
+  outside these four passes.
+
+## Ground rules (from the issue)
+
+Every delete pass: dry-run with counts/bytes → explicit sign-off (the
+`sourcelibrary` no-batch-delete rule) → delete with a manifest logged for audit.
+Re-run `scripts/storage-stats.mjs` before/after to measure actual reclaim.

--- a/scripts/maintenance/r2-reclaim/enrich-full-dup-pointers.mjs
+++ b/scripts/maintenance/r2-reclaim/enrich-full-dup-pointers.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Pass 2 enrichment: for each byte-identical (pages/-full, archived/) pair in
+ * manifest-full-dup.ndjson, look up the page doc and decide WHICH copy is
+ * redundant — i.e. which key no reader pointer resolves through — so the delete
+ * manifest is unambiguous. Read-only.
+ *
+ * Reader model (src/lib/page-image-url.ts getPageSource): the original/full-res
+ * path returns cropped_photo → split photo → enhanced_photo → archived_photo →
+ * photo_original → photo. display/thumb come from pages/{n}.jpg|-thumb, never
+ * from these two keys. So a copy is safe to delete iff NO page field references
+ * it. We classify each pair and recommend the redundant key.
+ *
+ * Usage: set -a; source .env.production.local; set +a;
+ *        node scripts/maintenance/r2-reclaim/enrich-full-dup-pointers.mjs
+ */
+import fs from 'node:fs';
+import readline from 'node:readline';
+import { getPageSource } from '../../lib/page-image-url.mjs';
+import { mongo, outPath, human, NdjsonWriter } from './lib.mjs';
+
+const MANIFEST = outPath('manifest-full-dup.ndjson');
+const PROJECTION = {
+  _id: 1, id: 1, book_id: 1, page_number: 1,
+  photo: 1, photo_original: 1, archived_photo: 1, enhanced_photo: 1,
+  cropped_photo: 1, display_photo: 1, thumbnail: 1, split_from_spread: 1,
+};
+const FIELDS = ['photo', 'photo_original', 'archived_photo', 'enhanced_photo', 'cropped_photo', 'display_photo', 'thumbnail'];
+
+const client = await mongo();
+const db = client.db('bookstore');
+const out = new NdjsonWriter(outPath('manifest-full-dup-enriched.ndjson'));
+
+const s = {
+  pairs: 0, pageNotFound: 0,
+  delete_full: 0, delete_full_bytes: 0,   // archived is live → -full redundant
+  delete_archived: 0, delete_archived_bytes: 0, // -full is live → archived redundant
+  both_referenced: 0, neither_referenced: 0, neither_bytes: 0,
+};
+
+function refs(page, keyPath) {
+  for (const f of FIELDS) {
+    const v = page[f];
+    if (typeof v === 'string' && v.includes(keyPath)) return f;
+  }
+  return null;
+}
+
+let curBook = null;
+let bucket = [];
+async function flush() {
+  if (!bucket.length) return;
+  const bookId = curBook;
+  const nums = bucket.map((r) => r.page);
+  const docs = await db.collection('pages')
+    .find({ book_id: bookId, page_number: { $in: nums } }, { projection: PROJECTION }).toArray();
+  const byNum = new Map(docs.map((d) => [d.page_number, d]));
+  for (const r of bucket) {
+    s.pairs++;
+    const page = byNum.get(r.page);
+    if (!page) { s.pageNotFound++; continue; }
+    const refFull = refs(page, r.fullKey);
+    const refArch = refs(page, r.archivedKey);
+    const src = getPageSource(page) || '';
+    const srcKind = src.includes(r.fullKey) ? 'full' : src.includes(r.archivedKey) ? 'archived' : (src ? 'other' : 'none');
+
+    let recommend, deleteKey, deleteSize;
+    if (refArch && !refFull) { recommend = 'delete_full'; deleteKey = r.fullKey; deleteSize = r.fullSize; }
+    else if (refFull && !refArch) { recommend = 'delete_archived'; deleteKey = r.archivedKey; deleteSize = r.archivedSize; }
+    else if (refFull && refArch) { recommend = 'both_referenced'; }
+    else { recommend = 'neither_referenced'; deleteKey = r.fullKey; deleteSize = r.fullSize; } // default drop -full
+
+    if (recommend === 'delete_full') { s.delete_full++; s.delete_full_bytes += deleteSize; }
+    else if (recommend === 'delete_archived') { s.delete_archived++; s.delete_archived_bytes += deleteSize; }
+    else if (recommend === 'both_referenced') { s.both_referenced++; }
+    else { s.neither_referenced++; s.neither_bytes += deleteSize; }
+
+    out.write({
+      bookId, page: r.page,
+      fullKey: r.fullKey, archivedKey: r.archivedKey,
+      etagMatch: r.etagMatch, sizeNear: r.sizeNear,
+      refFull, refArch, sourceResolvesTo: srcKind,
+      recommend, deleteKey: deleteKey || null, deleteSize: deleteSize || 0,
+    });
+  }
+  bucket = [];
+}
+
+const rl = readline.createInterface({ input: fs.createReadStream(MANIFEST), crlfDelay: Infinity });
+for await (const line of rl) {
+  if (!line) continue;
+  const r = JSON.parse(line);
+  if (r.bookId !== curBook) { await flush(); curBook = r.bookId; }
+  bucket.push(r);
+}
+await flush();
+out.close();
+await client.close();
+
+const summary = {
+  measured_at: new Date().toISOString(),
+  pairs: s.pairs, page_not_found: s.pageNotFound,
+  recommend_delete_full: { pairs: s.delete_full, bytes: s.delete_full_bytes, human: human(s.delete_full_bytes), note: 'archived/ copy is the live reader pointer; the pages/-full twin is redundant.' },
+  recommend_delete_archived: { pairs: s.delete_archived, bytes: s.delete_archived_bytes, human: human(s.delete_archived_bytes), note: 'pages/-full is the live pointer; archived/ twin is redundant.' },
+  both_referenced: { pairs: s.both_referenced, note: 'both keys referenced by page fields — keep both, review.' },
+  neither_referenced: { pairs: s.neither_referenced, bytes: s.neither_bytes, human: human(s.neither_bytes), note: 'no page field references either key — defaulted to dropping the -full copy; review.' },
+  total_reclaimable_bytes: s.delete_full_bytes + s.delete_archived_bytes + s.neither_bytes,
+  total_reclaimable_human: human(s.delete_full_bytes + s.delete_archived_bytes + s.neither_bytes),
+  manifest: 'manifest-full-dup-enriched.ndjson',
+};
+fs.writeFileSync(outPath('summary-full-dup-enriched.json'), JSON.stringify(summary, null, 2));
+console.log(JSON.stringify(summary, null, 2));

--- a/scripts/maintenance/r2-reclaim/lib.mjs
+++ b/scripts/maintenance/r2-reclaim/lib.mjs
@@ -1,0 +1,208 @@
+/**
+ * Shared helpers for the R2 storage-reclamation passes (issue #3005).
+ *
+ * All four passes are READ-ONLY measurement here: they LIST the bucket
+ * (Size + ETag come back on every ListObjectsV2 Content, so we never HEAD
+ * per-object) and write NDJSON manifests + a JSON summary to
+ * scripts/output/r2-reclaim/. Deletion is a separate, sign-off-gated step.
+ *
+ * Env (source .env.production.local): R2_ACCOUNT_ID, R2_ACCESS_KEY_ID,
+ * R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME, MONGODB_URI.
+ */
+import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const BUCKET = process.env.R2_BUCKET_NAME;
+
+export function makeS3() {
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${process.env.R2_ACCOUNT_ID.trim()}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+    },
+  });
+}
+
+export async function mongo() {
+  const c = new MongoClient(process.env.MONGODB_URI, {
+    socketTimeoutMS: 300000,
+    serverSelectionTimeoutMS: 20000,
+  });
+  await c.connect();
+  return c;
+}
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const OUT_DIR = path.resolve(HERE, '../../output/r2-reclaim');
+export function ensureOut() {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  return OUT_DIR;
+}
+export function outPath(name) {
+  ensureOut();
+  return path.join(OUT_DIR, name);
+}
+
+/**
+ * Async generator yielding every object under `prefix` as {key, size, etag}.
+ * Streams pages via ContinuationToken — constant memory. Retries transient
+ * errors with backoff.
+ */
+export async function* listPrefix(s3, prefix, { onPage } = {}) {
+  let token;
+  let pages = 0;
+  do {
+    let resp;
+    for (let attempt = 0; ; attempt++) {
+      try {
+        resp = await s3.send(
+          new ListObjectsV2Command({
+            Bucket: BUCKET,
+            Prefix: prefix,
+            ContinuationToken: token,
+            MaxKeys: 1000,
+          }),
+        );
+        break;
+      } catch (e) {
+        if (attempt >= 6) throw e;
+        await sleep(500 * 2 ** attempt);
+      }
+    }
+    for (const o of resp.Contents || []) {
+      yield { key: o.Key, size: o.Size, etag: o.ETag };
+    }
+    token = resp.IsTruncated ? resp.NextContinuationToken : undefined;
+    pages++;
+    if (onPage) onPage(pages, resp.KeyCount || 0);
+  } while (token);
+}
+
+/**
+ * Wrap listPrefix so it yields per-bookId groups: {bookId, entries[]}.
+ * Assumes keys are `<basePrefix><bookId>/<file>` and that R2 returns keys in
+ * lexicographic order (so all of one book's keys are contiguous). entries
+ * carry {file, key, size, etag}.
+ *
+ * `prefix` is what we LIST (may include shard chars of the bookId, e.g.
+ * `pages/6a`); `opts.basePrefix` is the level at which the bookId starts
+ * (e.g. `pages/`) — defaults to `prefix`. bookId is always sliced at basePrefix
+ * so shard prefixes don't truncate the id.
+ */
+export async function* bookGroups(s3, prefix, opts = {}) {
+  const base = opts.basePrefix || prefix;
+  let curId = null;
+  let entries = [];
+  for await (const o of listPrefix(s3, prefix, opts)) {
+    const rest = o.key.slice(base.length); // "<bookId>/<file>"
+    const slash = rest.indexOf('/');
+    if (slash < 0) continue; // a bare object directly under prefix — skip
+    const bookId = rest.slice(0, slash);
+    const file = rest.slice(slash + 1);
+    if (bookId !== curId) {
+      if (curId !== null) yield { bookId: curId, entries };
+      curId = bookId;
+      entries = [];
+    }
+    entries.push({ file, key: o.key, size: o.size, etag: o.etag });
+  }
+  if (curId !== null) yield { bookId: curId, entries };
+}
+
+/**
+ * Merge two bookGroups generators (both sorted by bookId, same ordering) and
+ * invoke cb(bookId, aEntries, bEntries) once per bookId present in either.
+ */
+export async function mergeBookGroups(genA, genB, cb) {
+  let a = await genA.next();
+  let b = await genB.next();
+  while (!a.done || !b.done) {
+    if (a.done) {
+      await cb(b.value.bookId, [], b.value.entries);
+      b = await genB.next();
+    } else if (b.done) {
+      await cb(a.value.bookId, a.value.entries, []);
+      a = await genA.next();
+    } else if (a.value.bookId === b.value.bookId) {
+      await cb(a.value.bookId, a.value.entries, b.value.entries);
+      a = await genA.next();
+      b = await genB.next();
+    } else if (a.value.bookId < b.value.bookId) {
+      await cb(a.value.bookId, a.value.entries, []);
+      a = await genA.next();
+    } else {
+      await cb(b.value.bookId, [], b.value.entries);
+      b = await genB.next();
+    }
+  }
+}
+
+export function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * R2 folders are keyed by the book's STRING `id` (== pages.book_id), NOT the
+ * Mongo `_id` — and page `_id`/`id` are themselves stored as strings, differing
+ * from each other. So existence must be a string join, never an ObjectId one
+ * (the id-vs-_id footgun; getting this wrong falsely flags live books/pages).
+ *
+ * Returns a Set of every string id that means "this book is accounted for":
+ * books.id, String(books._id), and the id fields of deleted_books /
+ * failed_imports — so a dir is an orphan only if it's in NONE of them.
+ */
+export async function loadLiveBookIds(db) {
+  const live = new Set();
+  const add = (v) => { if (v != null) live.add(String(v)); };
+  for await (const b of db.collection('books').find({}, { projection: { id: 1 } })) {
+    add(b.id); add(b._id);
+  }
+  for (const coll of ['deleted_books', 'failed_imports']) {
+    try {
+      for await (const d of db.collection(coll).find({}, { projection: { id: 1, book_id: 1 } })) {
+        add(d.id); add(d._id); add(d.book_id);
+      }
+    } catch { /* collection may not exist */ }
+  }
+  return live;
+}
+
+export const human = (b) => {
+  const u = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let i = 0;
+  let n = b;
+  while (n >= 1024 && i < u.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(2)} ${u[i]}`;
+};
+
+/** Buffered NDJSON writer — flushes in chunks to avoid a fd write per row. */
+export class NdjsonWriter {
+  constructor(file) {
+    this.fd = fs.openSync(file, 'w');
+    this.buf = [];
+    this.count = 0;
+  }
+  write(obj) {
+    this.buf.push(JSON.stringify(obj));
+    this.count++;
+    if (this.buf.length >= 2000) this.flush();
+  }
+  flush() {
+    if (this.buf.length) {
+      fs.writeSync(this.fd, this.buf.join('\n') + '\n');
+      this.buf = [];
+    }
+  }
+  close() {
+    this.flush();
+    fs.closeSync(this.fd);
+  }
+}

--- a/scripts/maintenance/r2-reclaim/measure-jp2-orphans.mjs
+++ b/scripts/maintenance/r2-reclaim/measure-jp2-orphans.mjs
@@ -1,0 +1,62 @@
+/**
+ * Pass 3: `archive/` JP2 orphans.
+ *
+ * Every `archive/{bookId}/...` dir is a set of JP2 source masters. A dir is an
+ * ORPHAN when its bookId exists in NONE of: books, deleted_books, failed_imports
+ * (purged books whose R2 masters were never cleaned up). Read-only; writes a
+ * delete manifest of orphan dir prefixes (re-listed at delete time — we store
+ * the prefix + count + bytes, not the keys).
+ *
+ * Usage: set -a; source .env.production.local; set +a;
+ *        node scripts/maintenance/r2-reclaim/measure-jp2-orphans.mjs
+ */
+import { makeS3, mongo, bookGroups, NdjsonWriter, outPath, human, loadLiveBookIds } from './lib.mjs';
+import fs from 'node:fs';
+
+const s3 = makeS3();
+const client = await mongo();
+const db = client.db('bookstore');
+
+// 1. Aggregate archive/ per book dir (constant memory — one group at a time).
+const dirs = []; // { bookId, objects, bytes }
+let objs = 0, bytes = 0, lastLog = Date.now();
+for await (const g of bookGroups(s3, 'archive/', {})) {
+  const b = g.entries.reduce((sum, e) => sum + e.size, 0);
+  dirs.push({ bookId: g.bookId, objects: g.entries.length, bytes: b });
+  objs += g.entries.length; bytes += b;
+  if (Date.now() - lastLog > 15000) {
+    lastLog = Date.now();
+    process.stderr.write(`[archive/] dirs=${dirs.length} objs=${objs} ${human(bytes)}\n`);
+  }
+}
+process.stderr.write(`archive/ crawl done: ${dirs.length} dirs, ${objs} objs, ${human(bytes)}\n`);
+
+// 2. Classify each dir's bookId against the live-book id set. R2 dirs are keyed
+// by the book's STRING id (books.id / pages.book_id), so this is a string join,
+// never an ObjectId one — see loadLiveBookIds (the id-vs-_id footgun).
+process.stderr.write('loading live book id set…\n');
+const alive = await loadLiveBookIds(db);
+process.stderr.write(`live book ids: ${alive.size}\n`);
+
+const mani = new NdjsonWriter(outPath('manifest-jp2-orphans.ndjson'));
+let orphanDirs = 0, orphanObjs = 0, orphanBytes = 0;
+let liveDirs = 0, liveObjs = 0, liveBytes = 0;
+for (const d of dirs) {
+  if (alive.has(d.bookId)) {
+    liveDirs++; liveObjs += d.objects; liveBytes += d.bytes;
+  } else {
+    orphanDirs++; orphanObjs += d.objects; orphanBytes += d.bytes;
+    mani.write({ dir: `archive/${d.bookId}/`, bookId: d.bookId, objects: d.objects, bytes: d.bytes, reason: 'no book/deleted_books/failed_imports record' });
+  }
+}
+mani.close();
+await client.close();
+
+const summary = {
+  measured_at: new Date().toISOString(),
+  archive_total: { dirs: dirs.length, objects: objs, bytes, human: human(bytes) },
+  live_masters: { dirs: liveDirs, objects: liveObjs, bytes: liveBytes, human: human(liveBytes), note: 'JP2 masters for books we still hold — separate keep/convert policy decision, NOT in delete manifest.' },
+  orphans: { dirs: orphanDirs, objects: orphanObjs, bytes: orphanBytes, human: human(orphanBytes), manifest: 'manifest-jp2-orphans.ndjson' },
+};
+fs.writeFileSync(outPath('summary-jp2-orphans.json'), JSON.stringify(summary, null, 2));
+console.log(JSON.stringify(summary, null, 2));

--- a/scripts/maintenance/r2-reclaim/measure-pages-archived.mjs
+++ b/scripts/maintenance/r2-reclaim/measure-pages-archived.mjs
@@ -1,0 +1,221 @@
+/**
+ * Pass 1 (display bloat) + Pass 2 (byte-identical full-res duplicates).
+ *
+ * Both need the same two prefixes joined by (bookId, pageNum), so we do ONE
+ * streaming merge-join of `pages/` and `archived/` — constant memory (one book
+ * at a time), no per-object HEADs. Read-only.
+ *
+ *   Pass 1: a `pages/{id}/{NNNN}.jpg` (display) whose size is >= RATIO of its
+ *           master (`-full` if present else `archived/{id}/{N}.jpg`) was never
+ *           downsized. Manifest = regeneration candidates (NOT deletes).
+ *   Pass 2: `pages/{id}/{NNNN}-full.jpg` and `archived/{id}/{N}.jpg` with equal
+ *           ETag (or size within 2%) are byte-identical. Manifest = one copy is
+ *           redundant; deletion decision is per-page (which key the reader's
+ *           pointer resolves through) and is left for the sign-off/repoint step.
+ *
+ * Usage: set -a; source .env.production.local; set +a;
+ *        node scripts/maintenance/r2-reclaim/measure-pages-archived.mjs
+ */
+import {
+  makeS3, bookGroups, mergeBookGroups, NdjsonWriter, outPath, human,
+} from './lib.mjs';
+import fs from 'node:fs';
+
+const RATIO = Number(process.env.BLOAT_RATIO || 0.9); // display >= 90% of master = "not downsized"
+const TARGET_KB = Number(process.env.DISPLAY_TARGET_KB || 220); // expected size of a true 1200px display
+const DUP_SIZE_TOL = 0.02;
+const SHARD_CONCURRENCY = Number(process.env.SHARD_CONCURRENCY || 24);
+
+const s3 = makeS3();
+
+// Shard the crawl by the first 3 hex chars of the bookId (4096 shards) run
+// through a concurrency pool. bookIds are lowercase-hex-ish (UUIDs + ObjectIds,
+// the latter clustered in the 6xx- range), so 3-char sharding parallelizes ~24×
+// AND balances the heavy ObjectId cluster across 256 sub-buckets (near-uniform
+// work per active worker). Empty prefixes cost one fast 0-key list. Each shard
+// is an independent merge-join writing its own manifest parts; concat at the end.
+const HEX = '0123456789abcdef';
+const SHARDS = [];
+for (const a of HEX) for (const b of HEX) for (const d of HEX) SHARDS.push(a + b + d);
+// ONLY_SHARDS=6a,6b restricts the crawl (smoke tests / resume of a subset).
+if (process.env.ONLY_SHARDS) {
+  const only = new Set(process.env.ONLY_SHARDS.split(',').map((x) => x.trim()));
+  SHARDS.length = 0;
+  for (const p of only) SHARDS.push(p);
+}
+
+const s = {
+  books: 0,
+  pagesObjs: 0, archivedObjs: 0,
+  pagesBytes: 0, archivedBytes: 0,
+  displayN: 0, displayBytes: 0,
+  fullN: 0, fullBytes: 0,
+  thumbN: 0, thumbBytes: 0,
+  otherPagesN: 0, otherPagesBytes: 0, // BPH sp*, unexpected shapes
+  // Pass 1
+  bloatN: 0, bloatCurrentBytes: 0, bloatMasterBytes: 0, bloatReclaimEst: 0,
+  // Pass 2
+  dupPairs: 0, dupEtagMatch: 0, dupSizeNear: 0, dupReclaimBytes: 0,
+  fullWithArchived: 0,
+};
+
+let lastLog = Date.now();
+let shardsDone = 0;
+function progress() {
+  if (Date.now() - lastLog < 15000) return;
+  lastLog = Date.now();
+  process.stderr.write(
+    `[${new Date().toISOString()}] shards ${shardsDone}/${SHARDS.length} ` +
+    `books=${s.books} pagesObjs=${s.pagesObjs} archivedObjs=${s.archivedObjs} ` +
+    `bloat=${s.bloatN} dup=${s.dupPairs}\n`,
+  );
+}
+
+function parsePages(entries) {
+  const map = new Map(); // pageNum -> {display, full, thumb}
+  for (const e of entries) {
+    s.pagesObjs++; s.pagesBytes += e.size;
+    let m;
+    if ((m = e.file.match(/^(\d{4,})-full\.jpg$/))) {
+      const n = parseInt(m[1], 10);
+      const p = map.get(n) || {}; p.full = e; map.set(n, p);
+      s.fullN++; s.fullBytes += e.size;
+    } else if ((m = e.file.match(/^(\d{4,})-thumb\.jpg$/))) {
+      const n = parseInt(m[1], 10);
+      const p = map.get(n) || {}; p.thumb = e; map.set(n, p);
+      s.thumbN++; s.thumbBytes += e.size;
+    } else if ((m = e.file.match(/^(\d{4,})\.jpg$/))) {
+      const n = parseInt(m[1], 10);
+      const p = map.get(n) || {}; p.display = e; map.set(n, p);
+      s.displayN++; s.displayBytes += e.size;
+    } else {
+      // BPH sp*, spdm*, or anything unexpected — count, don't analyze
+      s.otherPagesN++; s.otherPagesBytes += e.size;
+    }
+  }
+  return map;
+}
+
+function parseArchived(entries) {
+  const map = new Map(); // pageNum -> entry
+  for (const e of entries) {
+    s.archivedObjs++; s.archivedBytes += e.size;
+    const m = e.file.match(/^(\d+)\.jpg$/);
+    if (!m) continue;
+    map.set(parseInt(m[1], 10), e);
+  }
+  return map;
+}
+
+function detect(bookId, pmap, amap, bloatW, dupW) {
+  for (const [n, p] of pmap) {
+    const master = p.full || amap.get(n);
+    // Pass 1: display never downsized
+    if (p.display && master && p.display.size > master.size * RATIO) {
+      s.bloatN++;
+      s.bloatCurrentBytes += p.display.size;
+      s.bloatMasterBytes += master.size;
+      const reclaim = Math.max(0, p.display.size - TARGET_KB * 1024);
+      s.bloatReclaimEst += reclaim;
+      bloatW.write({
+        bookId, page: n,
+        displayKey: p.display.key, displaySize: p.display.size,
+        masterKey: master.key, masterSize: master.size,
+        ratio: +(p.display.size / master.size).toFixed(3),
+        reclaimEst: reclaim,
+      });
+    }
+    // Pass 2: byte-identical -full vs archived
+    if (p.full && amap.has(n)) {
+      const a = amap.get(n);
+      s.fullWithArchived++;
+      const etagMatch = p.full.etag && a.etag && p.full.etag === a.etag;
+      const sizeNear = Math.abs(p.full.size - a.size) <= Math.max(p.full.size, a.size) * DUP_SIZE_TOL;
+      if (etagMatch || sizeNear) {
+        s.dupPairs++;
+        if (etagMatch) s.dupEtagMatch++;
+        if (sizeNear) s.dupSizeNear++;
+        s.dupReclaimBytes += Math.min(p.full.size, a.size);
+        dupW.write({
+          bookId, page: n,
+          fullKey: p.full.key, fullSize: p.full.size, fullEtag: p.full.etag,
+          archivedKey: a.key, archivedSize: a.size, archivedEtag: a.etag,
+          etagMatch: !!etagMatch, sizeNear,
+        });
+      }
+    }
+  }
+}
+
+async function runShard(prefix) {
+  const bloatW = new NdjsonWriter(outPath(`.part-bloat-${prefix}.ndjson`));
+  const dupW = new NdjsonWriter(outPath(`.part-dup-${prefix}.ndjson`));
+  const pagesGen = bookGroups(s3, `pages/${prefix}`, { basePrefix: 'pages/', onPage: progress });
+  const archGen = bookGroups(s3, `archived/${prefix}`, { basePrefix: 'archived/', onPage: progress });
+  await mergeBookGroups(pagesGen, archGen, (bookId, pagesEntries, archEntries) => {
+    s.books++;
+    detect(bookId, parsePages(pagesEntries), parseArchived(archEntries), bloatW, dupW);
+  });
+  bloatW.close();
+  dupW.close();
+  shardsDone++;
+}
+
+// Pool the shards.
+{
+  let idx = 0;
+  await Promise.all(Array.from({ length: SHARD_CONCURRENCY }, async () => {
+    while (idx < SHARDS.length) {
+      const prefix = SHARDS[idx++];
+      await runShard(prefix);
+    }
+  }));
+}
+
+// Concat shard manifest parts into the canonical files, then clean up.
+for (const [glob, out] of [['bloat', 'manifest-display-bloat.ndjson'], ['dup', 'manifest-full-dup.ndjson']]) {
+  const outFd = fs.openSync(outPath(out), 'w');
+  for (const prefix of SHARDS) {
+    const part = outPath(`.part-${glob}-${prefix}.ndjson`);
+    if (fs.existsSync(part)) {
+      const data = fs.readFileSync(part);
+      if (data.length) fs.writeSync(outFd, data);
+      fs.unlinkSync(part);
+    }
+  }
+  fs.closeSync(outFd);
+}
+
+const summary = {
+  measured_at: new Date().toISOString(),
+  config: { RATIO, TARGET_KB, DUP_SIZE_TOL },
+  crawl: {
+    books: s.books,
+    pages_objects: s.pagesObjs, pages_bytes: s.pagesBytes, pages_human: human(s.pagesBytes),
+    archived_objects: s.archivedObjs, archived_bytes: s.archivedBytes, archived_human: human(s.archivedBytes),
+    display: { n: s.displayN, bytes: s.displayBytes, human: human(s.displayBytes) },
+    full: { n: s.fullN, bytes: s.fullBytes, human: human(s.fullBytes) },
+    thumb: { n: s.thumbN, bytes: s.thumbBytes, human: human(s.thumbBytes) },
+    other_pages: { n: s.otherPagesN, bytes: s.otherPagesBytes, human: human(s.otherPagesBytes) },
+  },
+  pass1_display_bloat: {
+    candidates: s.bloatN,
+    pct_of_displays: s.displayN ? +(100 * s.bloatN / s.displayN).toFixed(1) : 0,
+    current_bytes: s.bloatCurrentBytes, current_human: human(s.bloatCurrentBytes),
+    reclaim_est_bytes: s.bloatReclaimEst, reclaim_est_human: human(s.bloatReclaimEst),
+    manifest: 'manifest-display-bloat.ndjson',
+    note: 'Regeneration candidates (re-resize to ~1200px). NOT deletes.',
+  },
+  pass2_full_dup: {
+    full_with_archived_counterpart: s.fullWithArchived,
+    duplicate_pairs: s.dupPairs,
+    etag_identical: s.dupEtagMatch,
+    size_within_2pct: s.dupSizeNear,
+    reclaim_bytes: s.dupReclaimBytes, reclaim_human: human(s.dupReclaimBytes),
+    manifest: 'manifest-full-dup.ndjson',
+    note: 'One copy of each pair is redundant. Which key to delete is per-page (reader pointer); resolve in the repoint step. Enrich with pointers via enrich-full-dup-pointers.mjs before deleting.',
+  },
+};
+fs.writeFileSync(outPath('summary-pages-archived.json'), JSON.stringify(summary, null, 2));
+process.stderr.write('\nDONE\n');
+console.log(JSON.stringify(summary, null, 2));

--- a/scripts/maintenance/r2-reclaim/measure-stale-crops.mjs
+++ b/scripts/maintenance/r2-reclaim/measure-stale-crops.mjs
@@ -1,0 +1,112 @@
+/**
+ * Pass 4: `cropped/` stale generations.
+ *
+ * Crop filenames are page ObjectIds: `cropped/{bookId}/{pageOid}.jpg`. Re-split
+ * a book and the old crops are orphaned. A crop is STALE when its pageOid is
+ * absent from the `pages` collection (the issue's GC rule). Read-only; writes a
+ * per-file delete manifest for stale crops only.
+ *
+ * Also reported (NOT deleted): crops whose page still exists but no longer
+ * references the crop key (page alive, superseded) — a separate decision.
+ *
+ * Usage: set -a; source .env.production.local; set +a;
+ *        node scripts/maintenance/r2-reclaim/measure-stale-crops.mjs
+ */
+import { makeS3, mongo, bookGroups, NdjsonWriter, outPath, human, loadLiveBookIds } from './lib.mjs';
+import fs from 'node:fs';
+
+const s3 = makeS3();
+const client = await mongo();
+const db = client.db('bookstore');
+const pages = db.collection('pages');
+
+// Crop filenames are the page's STRING `id` (not `_id`), and R2 dirs are the
+// book's STRING id — so every existence check here is a string join. Using
+// ObjectId(_id) here falsely flagged ~75% of live crops as stale (the id-vs-_id
+// footgun). Preload the live-book id set for the whole-dir-orphan check.
+process.stderr.write('loading live book id set…\n');
+const liveBooks = await loadLiveBookIds(db);
+process.stderr.write(`live book ids: ${liveBooks.size}\n`);
+
+const mani = new NdjsonWriter(outPath('manifest-stale-crops.ndjson'));
+
+const s = {
+  dirs: 0, files: 0, bytes: 0,
+  unknownShape: 0, unknownBytes: 0,
+  staleFiles: 0, staleBytes: 0,
+  nobookDirs: 0, nobookFiles: 0, nobookBytes: 0,
+  aliveUnref: 0, aliveUnrefBytes: 0,
+};
+let lastLog = Date.now();
+
+for await (const g of bookGroups(s3, 'cropped/', {})) {
+  s.dirs++;
+  const bookId = g.bookId;
+  // Parse pageOid from each crop filename.
+  const items = []; // { key, size, oid|null }
+  for (const e of g.entries) {
+    s.files++; s.bytes += e.size;
+    const m = e.file.match(/^([0-9a-f]{24})(?:[-_][a-z0-9]+)?\.jpg$/i);
+    if (!m) { s.unknownShape++; s.unknownBytes += e.size; items.push({ ...e, oid: null }); continue; }
+    items.push({ key: e.key, size: e.size, oid: m[1].toLowerCase() });
+  }
+  const oidStrs = [...new Set(items.filter((i) => i.oid).map((i) => i.oid))];
+
+  // Page existence is a STRING join on `id` (the crop filename) with `_id` as a
+  // backstop — both are stored as strings in this corpus.
+  const livePages = oidStrs.length
+    ? await pages.find(
+        { $or: [{ id: { $in: oidStrs } }, { _id: { $in: oidStrs } }] },
+        { projection: { _id: 1, id: 1, cropped_photo: 1 } },
+      ).toArray()
+    : [];
+  const liveById = new Map();
+  for (const p of livePages) {
+    if (p.id != null) liveById.set(String(p.id), p);
+    if (p._id != null) liveById.set(String(p._id), p);
+  }
+  const bookExists = liveBooks.has(bookId);
+  if (!bookExists) s.nobookDirs++;
+
+  for (const it of items) {
+    if (!it.oid) continue; // unknown shape — never auto-flag
+    const page = liveById.get(it.oid);
+    if (!page) {
+      // pageOid absent from pages → stale (delete candidate)
+      s.staleFiles++; s.staleBytes += it.size;
+      if (!bookExists) { s.nobookFiles++; s.nobookBytes += it.size; }
+      mani.write({
+        key: it.key, bookId, pageOid: it.oid, size: it.size,
+        reason: bookExists ? 'page oid absent from pages (re-split orphan)' : 'book absent (whole dir orphan)',
+      });
+    } else {
+      // page alive: is this exact key still referenced?
+      const referenced = typeof page.cropped_photo === 'string' && page.cropped_photo.includes(`cropped/${bookId}/${it.oid}`);
+      if (!referenced) { s.aliveUnref++; s.aliveUnrefBytes += it.size; }
+    }
+  }
+  if (Date.now() - lastLog > 15000) {
+    lastLog = Date.now();
+    process.stderr.write(`[cropped/] dirs=${s.dirs} files=${s.files} stale=${s.staleFiles} ${human(s.bytes)}\n`);
+  }
+}
+mani.close();
+await client.close();
+
+const summary = {
+  measured_at: new Date().toISOString(),
+  cropped_total: { dirs: s.dirs, files: s.files, bytes: s.bytes, human: human(s.bytes) },
+  unknown_shape: { files: s.unknownShape, bytes: s.unknownBytes, human: human(s.unknownBytes), note: 'filename not a page ObjectId — never auto-flagged.' },
+  stale_delete_candidates: {
+    files: s.staleFiles, bytes: s.staleBytes, human: human(s.staleBytes),
+    of_which_whole_dir_no_book: { dirs: s.nobookDirs, files: s.nobookFiles, bytes: s.nobookBytes, human: human(s.nobookBytes) },
+    manifest: 'manifest-stale-crops.ndjson',
+    note: 'pageOid absent from pages — safe delete per issue GC rule.',
+  },
+  alive_but_unreferenced: {
+    files: s.aliveUnref, bytes: s.aliveUnrefBytes, human: human(s.aliveUnrefBytes),
+    note: 'page still exists but its cropped_photo no longer points here (superseded). Separate decision — NOT in delete manifest.',
+  },
+};
+fs.writeFileSync(outPath('summary-stale-crops.json'), JSON.stringify(summary, null, 2));
+console.log(JSON.stringify(summary, null, 2));

--- a/scripts/maintenance/r2-reclaim/regen-display-bloat.mjs
+++ b/scripts/maintenance/r2-reclaim/regen-display-bloat.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Pass 1 execution: regenerate the "never downsized" display variants flagged by
+ * measure-pages-archived.mjs (manifest-display-bloat.ndjson). Reclaims the bytes
+ * AND makes those pages ~4× lighter to load (#3005).
+ *
+ * Unlike backfill-display-images.mjs (which SKIPS pages whose display file
+ * already exists), this FORCE-OVERWRITES the existing bloated display key with a
+ * true 1200px variant. It reuses the same machinery and the same source-
+ * correctness discipline:
+ *   - resolve the source via getPageSource() on the real Mongo page doc,
+ *   - SKIP old-era split pages (cropped_photo set): the read side proxies+crops
+ *     those and never serves the display variant, so regenerating from the
+ *     spread master would bake a wrong (full-spread) image for no benefit (#1814),
+ *   - resize with the shared generateDisplayVariants() (1200px + provenance mark),
+ *   - overwrite display + thumb keys, update Mongo display_photo/image_thumb.
+ *
+ * The master (archived/ or -full) is never touched, so every regenerated display
+ * is re-derivable — this pass is reversible.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/r2-reclaim/regen-display-bloat.mjs --dry-run
+ *   node scripts/maintenance/r2-reclaim/regen-display-bloat.mjs --limit=200 --verify   # pilot
+ *   node scripts/maintenance/r2-reclaim/regen-display-bloat.mjs --min-reclaim=51200    # real run
+ */
+import fs from 'node:fs';
+import readline from 'node:readline';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { generateDisplayVariants } from '../../workers/lib/display-image.mjs';
+import { getPageSource, isUsableImageUrl } from '../../lib/page-image-url.mjs';
+import { mongo, outPath, human } from './lib.mjs';
+
+const args = process.argv.slice(2);
+const getArg = (n) => args.find((a) => a.startsWith(`--${n}=`))?.split('=')[1];
+const has = (n) => args.includes(`--${n}`);
+
+const DRY_RUN = has('dry-run');
+const VERIFY = has('verify');
+const LIMIT = parseInt(getArg('limit') || '0', 10) || Infinity; // candidate rows to consider
+const CONCURRENCY = parseInt(getArg('concurrency') || '8', 10);
+const MIN_RECLAIM = parseInt(getArg('min-reclaim') || '0', 10); // skip rows below this reclaimEst (bytes)
+const MANIFEST = getArg('manifest') || outPath('manifest-display-bloat.ndjson');
+
+const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+const BUCKET = process.env.R2_BUCKET_NAME;
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID.trim()}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: process.env.R2_ACCESS_KEY_ID, secretAccessKey: process.env.R2_SECRET_ACCESS_KEY },
+});
+
+const PAGE_PROJECTION = {
+  _id: 1, id: 1, book_id: 1, page_number: 1,
+  photo: 1, photo_original: 1, archived_photo: 1, enhanced_photo: 1,
+  cropped_photo: 1, display_photo: 1, image_thumb: 1, split_from_spread: 1,
+};
+
+const st = {
+  rows: 0, considered: 0,
+  regen: 0, skipSplit: 0, skipNoSource: 0, skipNotFound: 0, failed: 0,
+  oldBytes: 0, newBytes: 0, reclaimed: 0, downloadBytes: 0,
+  start: Date.now(),
+};
+
+async function upload(key, buf) {
+  await s3.send(new PutObjectCommand({
+    Bucket: BUCKET, Key: key, Body: buf,
+    ContentType: 'image/jpeg', CacheControl: 'public, max-age=86400',
+  }));
+}
+async function download(url) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 45000);
+  try {
+    const r = await fetch(url, { signal: ctrl.signal });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return Buffer.from(await r.arrayBuffer());
+  } finally { clearTimeout(t); }
+}
+
+function resolveSource(page) {
+  if (isUsableImageUrl(page.cropped_photo)) return { skip: 'split' };
+  const source = getPageSource(page);
+  if (!source || !/^https?:\/\//.test(source) || /\.(jp2|jpx|jpf|j2k|tiff?)(\?|$)/i.test(source)) {
+    return { skip: 'nosource' };
+  }
+  return { source };
+}
+
+async function processRow(row, page, db) {
+  const { source, skip } = resolveSource(page);
+  if (skip === 'split') { st.skipSplit++; return; }
+  if (skip === 'nosource') { st.skipNoSource++; return; }
+
+  const num = String(page.page_number).padStart(4, '0');
+  const displayKey = `pages/${page.book_id}/${num}.jpg`;
+  const thumbKey = `pages/${page.book_id}/${num}-thumb.jpg`;
+
+  if (DRY_RUN) { st.regen++; st.oldBytes += row.displaySize; return; }
+
+  try {
+    const buf = await download(source);
+    if (!buf || buf.length === 0) throw new Error(`empty source: ${source.slice(0, 80)}`);
+    st.downloadBytes += buf.length;
+    const { display, thumb } = await generateDisplayVariants(buf);
+    if (VERIFY) {
+      const dir = outPath('verify-samples');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(`${dir}/${page.book_id}_${num}.new.jpg`, display);
+    }
+    await upload(displayKey, display);
+    await upload(thumbKey, thumb);
+    await db.collection('pages').updateOne(
+      { $or: [{ id: page.id || page._id }, { _id: page.id || page._id }] },
+      { $set: { display_photo: `${R2_PUBLIC_URL}/${displayKey}`, image_thumb: `${R2_PUBLIC_URL}/${thumbKey}`, updated_at: new Date() } },
+    );
+    st.regen++;
+    st.oldBytes += row.displaySize;
+    st.newBytes += display.length;
+    st.reclaimed += Math.max(0, row.displaySize - display.length);
+  } catch (e) {
+    st.failed++;
+    if (st.failed <= 20) console.error(`  FAIL ${page.book_id}/${num}: ${e.message?.slice(0, 90)}`);
+  }
+}
+
+// Pool over an array of {row, page} tasks.
+async function runPool(tasks, db) {
+  let i = 0;
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, tasks.length) }, async () => {
+    while (i < tasks.length) {
+      const t = tasks[i++];
+      await processRow(t.row, t.page, db);
+      if ((st.regen + st.failed) % 200 === 0) logProgress();
+    }
+  }));
+}
+
+function logProgress() {
+  const el = (Date.now() - st.start) / 1000;
+  console.error(`  considered=${st.considered} regen=${st.regen} split=${st.skipSplit} nosrc=${st.skipNoSource} nf=${st.skipNotFound} fail=${st.failed} reclaimed=${human(st.reclaimed)} (${(st.regen / el).toFixed(1)}/s)`);
+}
+
+async function main() {
+  if (!fs.existsSync(MANIFEST)) { console.error(`Manifest not found: ${MANIFEST} — run measure-pages-archived.mjs first.`); process.exit(1); }
+  console.error(`[regen-display-bloat]${DRY_RUN ? ' DRY RUN' : ''} manifest=${MANIFEST} min-reclaim=${MIN_RECLAIM} limit=${LIMIT === Infinity ? 'all' : LIMIT}`);
+  const client = await mongo();
+  const db = client.db('bookstore');
+
+  const rl = readline.createInterface({ input: fs.createReadStream(MANIFEST), crlfDelay: Infinity });
+  // Buffer rows grouped by book; flush per book (manifest is already book-ordered).
+  let curBook = null;
+  let bucket = [];
+
+  async function flush() {
+    if (!bucket.length) return;
+    const bookId = curBook;
+    const nums = bucket.map((r) => r.page);
+    const docs = await db.collection('pages')
+      .find({ book_id: bookId, page_number: { $in: nums } }, { projection: PAGE_PROJECTION }).toArray();
+    const byNum = new Map(docs.map((d) => [d.page_number, d]));
+    const tasks = [];
+    for (const r of bucket) {
+      const page = byNum.get(r.page);
+      if (!page) { st.skipNotFound++; continue; }
+      tasks.push({ row: r, page });
+    }
+    await runPool(tasks, db);
+    bucket = [];
+  }
+
+  for await (const line of rl) {
+    if (!line) continue;
+    if (st.considered >= LIMIT) break;
+    const r = JSON.parse(line);
+    st.rows++;
+    if (r.reclaimEst < MIN_RECLAIM) continue;
+    st.considered++;
+    if (r.bookId !== curBook) { await flush(); curBook = r.bookId; }
+    bucket.push(r);
+  }
+  await flush();
+  await client.close();
+
+  const el = (Date.now() - st.start) / 1000;
+  const summary = {
+    ran_at: new Date().toISOString(), dry_run: DRY_RUN,
+    config: { MIN_RECLAIM, LIMIT: LIMIT === Infinity ? 'all' : LIMIT, CONCURRENCY },
+    manifest_rows: st.rows, considered: st.considered,
+    regenerated: st.regen, skip_split: st.skipSplit, skip_no_source: st.skipNoSource,
+    skip_not_found: st.skipNotFound, failed: st.failed,
+    old_display_bytes: st.oldBytes, old_human: human(st.oldBytes),
+    new_display_bytes: st.newBytes, new_human: human(st.newBytes),
+    reclaimed_bytes: st.reclaimed, reclaimed_human: human(st.reclaimed),
+    downloaded_human: human(st.downloadBytes),
+    elapsed_s: Math.round(el),
+  };
+  fs.writeFileSync(outPath(DRY_RUN ? 'summary-regen-dryrun.json' : 'summary-regen-run.json'), JSON.stringify(summary, null, 2));
+  console.log(JSON.stringify(summary, null, 2));
+}
+main().catch((e) => { console.error('Fatal:', e); process.exit(1); });


### PR DESCRIPTION
Implements the measurement + execution tooling for #3005. **All measurement is read-only** (full-bucket LIST crawls — Size+ETag come back free, no per-object HEADs). Deletion is deliberately **not** implemented — every delete pass is sign-off-gated per the `sourcelibrary` no-batch-delete rule.

## The headline correction

R2 folders are keyed by the book's **string `id`** (`books.id` == `pages.book_id`), not the Mongo `_id`; crop filenames are the page's string `id`. #3005's sampling probes used `ObjectId(_id)` joins, so they flagged live books/pages as orphans. Full crawls with the correct join (`loadLiveBookIds()`) revise the estimates sharply:

| Pass | #3005 estimate | Measured |
|---|---|---|
| 3 — `archive/` JP2 orphans | ~150–190 GB | **0 GB** (all 2,142 dirs live) |
| 4 — `cropped/` stale | ~20% | **~3.4%** (a first buggy run here showed a false 75%) |
| 2 — `-full`/`archived` dup | ~0.5–1 TB | far smaller (~58K pairs — see summary for bytes) |
| 1 — display never downsized | ~1–1.5 TB | the real prize — 2.8M+ candidates |

## What's here

- `measure-pages-archived.mjs` — Pass 1 (display bloat) + Pass 2 (byte-identical dup) via a sharded streaming merge-join of `pages/`+`archived/` (4096 bookId-prefix shards, constant memory).
- `measure-jp2-orphans.mjs` / `measure-stale-crops.mjs` — Pass 3 / Pass 4.
- `regen-display-bloat.mjs` — Pass 1 execution: force-overwrites bloated displays with true 1200px variants via the shared `generateDisplayVariants()`; source-correct (`getPageSource`, skips old-era split — the #1814 footgun); master untouched → reversible.
- `enrich-full-dup-pointers.mjs` — attaches the per-page reader-pointer decision to each Pass 2 dup pair before any delete.
- `README.md` — method + findings.

## Out of scope (deliberate)

- No deletes and no display-regen prod run in this PR — those are gated on Derek's sign-off of the manifests (in `scripts/output/r2-reclaim/`, gitignored scratch).
- The ~26M bucket objects outside `pages/`/`archived/`/`archive/`/`cropped/` (gallery/, thumbnails/, covers/, uploads/) are not measured here.
- Whether to keep JP2 masters for *live* books (368 GB) after JPG conversion is a separate policy decision, not a delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)