### PR TITLE
fix(bph): don't link catalogue entries to hidden (unreadable) books

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -247,7 +247,16 @@ async function fetchSlBook(ubn: string): Promise<SlBook | null> {
   try {
     const db = await getReadDb();
     const book = await db.collection('books').findOne(
-      { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': ubn },
+      {
+        'image_source.provider': 'bph',
+        'dublin_core.dc_identifier': ubn,
+        // Only surface a readable book. A hidden book (`visible: false`) 404s at
+        // the reader's visibility gate, so the "Read in Source Library" link
+        // built below would dead-end. When the mapped book isn't readable, fall
+        // through to null and the entry renders as a catalogue-only record.
+        visible: { $ne: false },
+        pages_count: { $gt: 0 },
+      },
       {
         projection: {
           id: 1, slug: 1, title: 1, display_title: 1, english_title: 1,

--- a/src/lib/tenant-library-loaders.ts
+++ b/src/lib/tenant-library-loaders.ts
@@ -422,6 +422,13 @@ export async function fetchTenantBphDigitizedMap(tenantId: string): Promise<Reco
         tenantId,
         'image_source.provider': 'bph',
         'dublin_core.dc_identifier': { $exists: true },
+        // Only map catalogue entries to a *readable* book. Hidden books
+        // (`visible: false`) 404 at the reader's visibility gate, so a "Read"
+        // link built from them is dead — the catalogue then reads as broken.
+        // Match the reader gate exactly (only `visible === false` is blocked;
+        // null/missing stays public) and require digitised pages.
+        visible: { $ne: false },
+        pages_count: { $gt: 0 },
       },
       { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 }, maxTimeMS: 4_000 }
     ).toArray();
@@ -570,6 +577,10 @@ export async function fetchTenantCatalogDigitizedMap(
         tenantId,
         'image_source.provider': providerKey,
         'image_source.identifier': { $exists: true },
+        // Readable-only, same as fetchTenantBphDigitizedMap: a catalogue "Read"
+        // link to a hidden book (`visible: false`) dead-ends at the reader gate.
+        visible: { $ne: false },
+        pages_count: { $gt: 0 },
       },
       { projection: { id: 1, slug: 1, 'image_source.identifier': 1 }, maxTimeMS: 4_000 }
     ).toArray();


### PR DESCRIPTION
## What
BPH catalogue "Read in Source Library" links were built from any book matching the catalogue's provider + identifier, with **no visibility filter**. When the mapped book is hidden (`visible: false` — typically imported-but-unprocessed BPH holdings), the reader's visibility gate 404s it, so the link dead-ends.

## Why (from the metrics /not_found_reports)
This was the top live content-demand signal. Over the last 30 days:
- **374** `/embed/bph/book/<slug>` 404s, still climbing daily (spike of **107** on the highest-traffic day, June 22).
- Every one traces to the **111** catalogue-mapped books that are `visible: false`.
- Referrers are the BPH catalogue's own list view and record detail pages — not stale external links.

The sibling `/embed/bph/catalog/<shelfmark>` 404 family was already fixed by #2625 (decode URL-encoded UBN, deployed 2026-06-20) — zero hits after that date, so this PR does not touch it.

## Fix
Guard all three catalogue→book resolvers with the same readable predicate the reader gate (`src/lib/book-access.ts`) uses — `visible: { \$ne: false }` (only explicit hides are blocked; legacy null/missing stays public, so no working links regress) plus `pages_count > 0`:
- `fetchTenantBphDigitizedMap` — catalogue **list**-view "Read" links (highest volume)
- `fetchTenantCatalogDigitizedMap` — generic unified-catalogue tenants (Kloss, …)
- `fetchSlBook` — catalogue **record detail** page

## Effect (verified against prod data)
Keeps exactly the **2,149** readable mapped books, drops exactly the **111** hidden ones — zero collateral (all 111 are `visible:false`; no `visible:null`/missing and no `visible:true`-but-0-pages among the mapped set). A catalogue entry whose scan isn't yet public now renders as a bibliographic-only record with no dead Read link — which is truthful.

## Scope / out of scope
- In scope: catalogue→book link generation (the dead-link source).
- Out of scope: the underlying 111 hidden books (deliberately hidden/unprocessed — not a data bug); Family A shelfmark links (already fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)