### PR TITLE
fix(tenant): host-relative robots.txt link on /terms

### DIFF
--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -190,7 +190,7 @@ export default function TermsPage() {
           </h2>
           <p className="text-secondary mb-4">
             Automated access to Source Library is governed by our{' '}
-            <a href="https://sourcelibrary.org/robots.txt" className="text-accent-rust hover:underline">robots.txt</a>{' '}
+            <a href="/robots.txt" className="text-accent-rust hover:underline">robots.txt</a>{' '}
             file, which constitutes a binding directive under these terms. Crawlers that
             access pages or resources disallowed by robots.txt are accessing the service
             without authorization.


### PR DESCRIPTION
One-line follow-up to #2948 (PR #3014): the post-deploy `audit-bph-leaks.mjs` re-run came back clean of the 6 shortlink leaks but flagged one remaining absolute anchor — `https://sourcelibrary.org/robots.txt` on `/terms` (from the recent crawler-policy copy). Made it relative; `/robots.txt` is served on every host (dotted paths never reach the proxy) and `bph.sourcelibrary.org/robots.txt` returns 200, so the legal reference stays correct on both hosts.

After this deploys, `node scripts/audit-bph-leaks.mjs` should exit 0 with zero leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)