### PR TITLE
fix(census): live data, validated gap figures, editorial redesign (#3015)

### DIFF
--- a/scripts/maintenance/prewarm-browse.mjs
+++ b/scripts/maintenance/prewarm-browse.mjs
@@ -97,7 +97,13 @@ if (process.env.MONGODB_URI) {
       .project({ _id: 0, contents_works: 1 }).toArray();
     const firstTranslatedWorks = countFirstTranslatedWorks(ftBooks, { mode: 'verified' });
     const firstTranslatedWorksProvisional = countFirstTranslatedWorks(ftBooks, { mode: 'provisional' });
-    const stats = { totalBooks, translatedToEnglish, firstTranslationCount, firstTranslatedWorks, firstTranslatedWorksProvisional, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, updatedAt: new Date() };
+    // Corpus-census ledger coverage (#2933, surfaced on /census) — see update-homepage-stats.mjs. Keep in sync.
+    const attempts = db.collection('first_translation_attempts');
+    const census_ledger = {
+      attempts: await attempts.estimatedDocumentCount(),
+      booksSearched: (await attempts.distinct('book_id', { 'queries.0': { $exists: true } })).length,
+    };
+    const stats = { totalBooks, translatedToEnglish, firstTranslationCount, firstTranslatedWorks, firstTranslatedWorksProvisional, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, census_ledger, updatedAt: new Date() };
     await db.collection('system_config').updateOne(
       { _id: 'homepage_stats' },
       { $set: stats },

--- a/scripts/maintenance/update-homepage-stats.mjs
+++ b/scripts/maintenance/update-homepage-stats.mjs
@@ -67,7 +67,16 @@ const ftBooks = await books.find({ ...translatedFilter, is_first_translation: tr
 const firstTranslatedWorks = countFirstTranslatedWorks(ftBooks, { mode: 'verified' });
 const firstTranslatedWorksProvisional = countFirstTranslatedWorks(ftBooks, { mode: 'provisional' });
 
-const stats = { totalBooks, translatedToEnglish, firstTranslationCount, firstTranslatedWorks, firstTranslatedWorksProvisional, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, updatedAt: new Date() };
+// Corpus-census ledger coverage (#2933, surfaced on /census): how many books
+// have a documented grounded prior-translation search in the append-only
+// first_translation_attempts ledger. Keep in sync with prewarm-browse.mjs.
+const attempts = db.collection('first_translation_attempts');
+const census_ledger = {
+  attempts: await attempts.estimatedDocumentCount(),
+  booksSearched: (await attempts.distinct('book_id', { 'queries.0': { $exists: true } })).length,
+};
+
+const stats = { totalBooks, translatedToEnglish, firstTranslationCount, firstTranslatedWorks, firstTranslatedWorksProvisional, authorCount, languageCount, artworkCount, illustrationCount, verification_coverage, census_ledger, updatedAt: new Date() };
 
 await db.collection('system_config').updateOne(
   { _id: 'homepage_stats' },

--- a/src/app/about/progress/page.tsx
+++ b/src/app/about/progress/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
+import { getSiteStats } from '@/lib/site-stats';
 import Link from 'next/link';
 import ContentPageLayout, { SubPageHeader } from '@/components/layout/ContentPageLayout';
 import { BarChart3, BookOpen, Languages, Globe2, Scan, Sparkles, Library } from 'lucide-react';
@@ -231,7 +232,11 @@ function fmt(n: number): string {
 // ── Page ──────────────────────────────────────────────────────────────
 
 export default async function ProgressPage() {
-  const [data, live] = await Promise.all([getCoverageData(), getLiveStats()]);
+  const [data, live, siteStats] = await Promise.all([getCoverageData(), getLiveStats(), getSiteStats()]);
+  // One FT number site-wide (#3015): the get_sl_progress RPC re-derives the raw
+  // is_first_translation flag, which drifts above the verified public count.
+  // Always show the canonical homepage_stats figure instead.
+  if (live) live.first_translations = siteStats.firstTranslationCount;
 
   if (!data) {
     return (

--- a/src/app/census/CensusSearch.tsx
+++ b/src/app/census/CensusSearch.tsx
@@ -27,7 +27,13 @@ interface CensusResult {
   catalog_matches: CatalogMatch[];
 }
 
-export default function CensusSearch() {
+export default function CensusSearch({
+  editionCount,
+  catalogCount: catalogTotal,
+}: {
+  editionCount?: number;
+  catalogCount?: number;
+}) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<CensusResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -70,19 +76,21 @@ export default function CensusSearch() {
               onChange={e => setQuery(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="Search by author or title... e.g. Ficino, Paracelsus, De Vita"
-              className="w-full pl-10 pr-4 py-3 border border-stone-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
+              className="w-full pl-10 pr-4 py-3 border border-stone-300 rounded-sm text-sm bg-white focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
             />
           </div>
           <button
             onClick={search}
             disabled={loading || query.trim().length < 2}
-            className="px-5 py-3 bg-stone-900 text-white rounded-lg text-sm font-medium hover:bg-stone-800 disabled:opacity-40 transition-colors"
+            className="px-5 py-3 bg-stone-900 text-white rounded-sm text-sm font-medium hover:bg-stone-800 disabled:opacity-40 transition-colors"
           >
             {loading ? 'Searching...' : 'Search'}
           </button>
         </div>
         <p className="text-xs text-stone-400 mt-2">
-          Searches 1.57 million editions from the Universal Short Title Catalogue and 13,800+ known English translations.
+          Searches {editionCount ? `${(editionCount / 1_000_000).toFixed(2)} million` : 'over 1.5 million'} editions
+          from the Universal Short Title Catalogue and{' '}
+          {catalogTotal ? catalogTotal.toLocaleString('en-US') : 'tens of thousands of'} known English translations.
         </p>
       </div>
 
@@ -146,7 +154,7 @@ function ResultCard({ result }: { result: CensusResult }) {
   const isTranslated = result.translation_status === 'translated';
 
   return (
-    <div className={`border rounded-lg p-3 ${isTranslated ? 'border-emerald-200 bg-emerald-50/30' : 'border-stone-200 bg-white'}`}>
+    <div className={`border rounded-sm p-3 ${isTranslated ? 'border-emerald-200 bg-emerald-50/30' : 'border-stone-200 bg-white'}`}>
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium text-primary truncate">{result.title}</div>
@@ -165,12 +173,10 @@ function ResultCard({ result }: { result: CensusResult }) {
           )}
           {result.in_source_library && (
             <a
-              href={`https://sourcelibrary.org/search?q=${encodeURIComponent(result.author?.split(',')[0] || result.title)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[10px] px-1.5 py-0.5 rounded bg-purple-100 text-purple-700 hover:bg-purple-200 transition-colors flex items-center gap-0.5"
+              href={`/search?q=${encodeURIComponent(result.author?.split(',')[0] || result.title)}`}
+              className="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-800 hover:bg-amber-200 transition-colors flex items-center gap-0.5"
             >
-              In SL <ExternalLink className="w-2.5 h-2.5" />
+              In Source Library <ExternalLink className="w-2.5 h-2.5" />
             </a>
           )}
           {result.has_iiif_scan && (

--- a/src/app/census/page.tsx
+++ b/src/app/census/page.tsx
@@ -1,137 +1,150 @@
 import { Metadata } from 'next';
+import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { supabase } from '@/lib/supabase';
-import ContentPageLayout, { SubPageHeader } from '@/components/layout/ContentPageLayout';
-import { BookOpen, Languages, Search, BarChart3, Sparkles, ExternalLink } from 'lucide-react';
+import { getReadDb } from '@/lib/mongodb';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import CensusSearch from './CensusSearch';
 
 export const metadata: Metadata = {
   title: 'Translation Census | Source Library',
-  description: 'The first comprehensive record of which pre-modern European texts have been translated into English. Of 1.4 million editions printed before 1700, less than 2% have known translations.',
+  description:
+    'A living record of which pre-modern European texts have been translated into English. Validated estimate: ~85% of all early-modern print — and ~93% of Renaissance-composed Latin — has never been Englished.',
   alternates: { canonical: '/census' },
 };
 
 export const revalidate = 3600; // 1 hour — census data changes slowly
 
+// ── Validated gap estimates ──────────────────────────────────────────
+// From the n=1000 dual-model validation (Gemini grounded-search adjudicator
+// over all 1000 + independent Claude cross-check, blind, stratified,
+// era post-stratified; 2026-06-22). These are study results, not live counts —
+// they change only when the study is re-run. Source of truth:
+// .claude/docs/translation-gap-methodology.md + translation-gap-paper.md;
+// artifacts in scripts/analysis/eval-data/gap-validation-*.json (#2684).
+// Doctrine: quote these with method + CI + denominator; the raw catalog join
+// rate appears only as a labeled methodological footnote, never as a headline.
+const VALIDATED = {
+  allPrintGapPct: 84.9,
+  allPrintCI: '82.3–87.3',
+  renaissanceGapPct: 93.3,
+  renaissanceCI: '91.3–95.2',
+  matcherPrecisionPct: 78.7,
+  sampleSize: 1000,
+  evalDate: 'June 2026',
+  crossModelKappa: 0.82,
+};
+
 // ── Data ─────────────────────────────────────────────────────────────
 
 interface CensusLanguage {
   language: string;
-  editions: number;
-  distinct_works: number;
-  estimated_translated: number;
-  pct_works_translated: number;
-  top_untranslated: { surname: string; works: number }[];
+  works: number;
+  translated: number;
+  pct: number;
 }
 
 interface CensusData {
   total_editions: number;
   total_works: number;
   total_translated: number;
-  pct_translated: number;
+  raw_pct_translated: number;
   catalog_records: number;
   languages: CensusLanguage[];
+  // Site-wide canonical counts (system_config.homepage_stats — same source as
+  // the homepage; never re-derive these from a parallel query, see #3015)
   sl_first_translations: number;
-  sl_books_translated: number;
+  sl_books_readable: number;
+  // State of our own corpus census (#2933)
+  corpus_readable: number;
+  corpus_checked: number;
+  corpus_checked_pct: number;
+  corpus_searched: number | null;
+  stats_updated_at: Date | null;
 }
 
-async function getCensusData(): Promise<CensusData | null> {
-  try {
-    // Primary source: Supabase materialized view via RPC
-    // Built by scripts/catalog-coverage/build-census.mjs
-    const [censusResult, slResult] = await Promise.all([
-      supabase.rpc('get_translation_census'),
-      supabase.rpc('get_sl_progress'),
-    ]);
+async function getCensusData(): Promise<CensusData> {
+  const db = await getReadDb();
+  const [censusResult, catalogResult, homepageStats] = await Promise.all([
+    // Materialized USTC × translation-catalog join, built by
+    // scripts/catalog-coverage/build-census.mjs
+    supabase.rpc('get_translation_census'),
+    supabase.from('translation_catalogs').select('id', { count: 'exact', head: true }),
+    db.collection('system_config').findOne({ _id: 'homepage_stats' } as never, { maxTimeMS: 5000 }),
+  ]);
 
-    const census = censusResult.data as any;
-    const slData = slResult.data as any;
-
-    if (census?.totals && census?.by_language) {
-      // Live census data from materialized view
-      const languages: CensusLanguage[] = (census.by_language as any[])
-        .filter((l: any) => parseInt(l.total_works) >= 500)
-        .map((l: any) => ({
-          language: l.language || 'Unknown',
-          editions: Number(l.total_editions),
-          distinct_works: Number(l.total_works),
-          estimated_translated: Number(l.works_with_translation),
-          pct_works_translated: Number(l.pct_works_translated),
-          top_untranslated: [], // populated separately if needed
-        }));
-
-      const t = census.totals;
-      return {
-        total_editions: Number(t.total_editions),
-        total_works: Number(t.total_works),
-        total_translated: Number(t.works_with_translation),
-        pct_translated: Number(t.pct_works_translated),
-        catalog_records: 13862,
-        languages,
-        sl_first_translations: Number(slData?.totals?.first_translations || 0),
-        sl_books_translated: Number(slData?.totals?.translated_by_sl || 0),
-      };
-    }
-
-    // Fallback: use coverage stats RPC (edition-level, less precise)
-    // This is the surname-level matching — honest about its limitations
-    console.warn('Translation census RPC not available — falling back to coverage stats');
-    return getCensusFromCoverageStats(slData);
-  } catch (err) {
-    console.error('Census data load error:', err);
-    return null;
+  const census = censusResult.data as any;
+  // Let a failed load throw: with revalidate=3600, ISR keeps serving the last
+  // good page on refresh failure. Rendering a fallback here would cache the
+  // fallback instead (the #2974 pattern — don't reintroduce it).
+  if (!census?.totals || !census?.by_language) {
+    throw new Error(`Translation census RPC unavailable: ${censusResult.error?.message || 'no totals returned'}`);
   }
-}
+  if (!homepageStats?.firstTranslationCount) {
+    throw new Error('homepage_stats unavailable — census page needs the canonical site counts');
+  }
 
-async function getCensusFromCoverageStats(slData: any): Promise<CensusData | null> {
-  // Falls back to edition-level coverage stats from get_coverage_stats()
-  // These use surname-level matching (less precise) and count editions not works
-  const { data: coverageRows, error } = await supabase.rpc('get_coverage_stats');
-  if (error || !coverageRows) return null;
-
-  const languages: CensusLanguage[] = (coverageRows as any[])
-    .filter((r: any) => Number(r.editions) >= 1000)
-    .map((r: any) => ({
-      language: r.language,
-      editions: Number(r.editions),
-      distinct_works: 0, // not available in this mode
-      estimated_translated: Number(r.with_translation),
-      pct_works_translated: Number(r.editions) > 0
-        ? +((Number(r.with_translation) / Number(r.editions)) * 100).toFixed(1)
-        : 0,
-      top_untranslated: [],
+  const t = census.totals;
+  const languages: CensusLanguage[] = (census.by_language as any[])
+    .filter((l: any) => Number(l.total_works) >= 500 && l.language)
+    .map((l: any) => ({
+      language: l.language,
+      works: Number(l.total_works),
+      translated: Number(l.works_with_translation),
+      pct: Number(l.pct_works_translated),
     }))
-    .sort((a, b) => b.editions - a.editions);
+    .sort((a, b) => b.works - a.works)
+    .slice(0, 12);
 
-  const totalEditions = languages.reduce((s, l) => s + l.editions, 0);
-  const totalTranslated = languages.reduce((s, l) => s + l.estimated_translated, 0);
-
+  const vc = homepageStats.verification_coverage || {};
   return {
-    total_editions: totalEditions,
-    total_works: 0, // not available in fallback
-    total_translated: totalTranslated,
-    pct_translated: totalEditions > 0 ? +((totalTranslated / totalEditions) * 100).toFixed(1) : 0,
-    catalog_records: 13862,
+    total_editions: Number(t.total_editions),
+    total_works: Number(t.total_works),
+    total_translated: Number(t.works_with_translation),
+    raw_pct_translated: Number(t.pct_works_translated),
+    catalog_records: catalogResult.count ?? 0,
     languages,
-    sl_first_translations: Number(slData?.totals?.first_translations || 0),
-    sl_books_translated: Number(slData?.totals?.translated_by_sl || 0),
+    sl_first_translations: Number(homepageStats.firstTranslationCount),
+    sl_books_readable: Number(homepageStats.translatedToEnglish || 0),
+    corpus_readable: Number(vc.readable || 0),
+    corpus_checked: Number(vc.checked || 0),
+    corpus_checked_pct: Number(vc.pct || 0),
+    corpus_searched: homepageStats.census_ledger?.booksSearched ?? null,
+    stats_updated_at: homepageStats.updatedAt ? new Date(homepageStats.updatedAt) : null,
   };
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────
+// ── Presentation (tokens shared with /research/translation-gap) ─────
 
-function fmt(n: number): string {
-  return n.toLocaleString('en-US');
+const fmt = (n: number) => n.toLocaleString('en-US');
+
+function Stat({ n, unit, label }: { n: string; unit?: string; label: string }) {
+  return (
+    <div className="px-5 py-6 border-stone-200 [&:not(:last-child)]:border-r max-sm:[&:nth-child(odd)]:border-r max-sm:[&:nth-child(-n+2)]:border-b">
+      <div className="font-serif text-3xl md:text-4xl text-stone-900 tracking-tight">
+        {n}
+        {unit && <span className="text-amber-800 text-2xl">{unit}</span>}
+      </div>
+      <div className="font-body text-sm text-stone-500 mt-1.5 leading-snug">{label}</div>
+    </div>
+  );
 }
 
-function ProgressBar({ value, max, color = 'bg-amber-600' }: { value: number; max: number; color?: string }) {
-  const pct = max > 0 ? Math.min((value / max) * 100, 100) : 0;
+function Section({ kicker, title, children }: { kicker: string; title: string; children: ReactNode }) {
   return (
-    <div className="w-full bg-stone-200 rounded-full h-2.5 overflow-hidden">
-      <div
-        className={`h-full rounded-full transition-all duration-500 ${color}`}
-        style={{ width: `${Math.max(pct, 0.5)}%` }}
-      />
+    <section className="py-12 border-b border-stone-200">
+      <div className="font-body text-xs tracking-[0.16em] uppercase text-amber-700 font-semibold mb-3">{kicker}</div>
+      <h2 className="font-serif text-2xl md:text-3xl text-stone-900 mb-4 tracking-tight">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Callout({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="mt-6 bg-stone-50 border-l-2 border-amber-600 rounded-r-sm px-5 py-4 text-base text-stone-700">
+      <div className="font-body text-xs tracking-wider uppercase text-amber-700 font-semibold mb-1">{label}</div>
+      {children}
     </div>
   );
 }
@@ -140,260 +153,242 @@ function ProgressBar({ value, max, color = 'bg-amber-600' }: { value: number; ma
 
 export default async function CensusPage() {
   const data = await getCensusData();
-
-  if (!data) {
-    return (
-      <ContentPageLayout maxWidth="narrow" bg="bg-stone-50">
-        <SubPageHeader title="Translation Census" subtitle="Census data is loading..." />
-      </ContentPageLayout>
-    );
-  }
-
-  // Work-level data available when census view exists, otherwise edition-level
-  const hasWorkData = data.total_works > 0;
-  const denominator = hasWorkData ? data.total_works : data.total_editions;
-  const gap = denominator - data.total_translated;
-  const unitLabel = hasWorkData ? 'works' : 'editions';
+  const maxPct = Math.max(...data.languages.map(l => l.pct), 0.1);
+  const asOf = data.stats_updated_at
+    ? data.stats_updated_at.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+    : null;
 
   return (
-    <ContentPageLayout maxWidth="narrow" bg="bg-stone-50">
-      <SubPageHeader
-        title="The Translation Census"
-        subtitle="The first comprehensive record of which pre-modern European texts have been translated into English"
-      />
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="The Translation Census"
+          subtitle="A living record of which pre-modern European texts have been translated into English — and which never have. The validated answer: most of early-modern thought has never been Englished. We are closing that gap, verifiably."
+        />
+      }
+    >
+      <div className="max-w-3xl mx-auto font-body text-stone-700 text-lg leading-relaxed">
+        {/* stat band */}
+        <div className="grid grid-cols-2 md:grid-cols-4 border border-stone-200 rounded-sm bg-stone-50 my-8">
+          <Stat
+            n={(data.total_works / 1_000_000).toFixed(2)}
+            unit="M"
+            label="distinct early-modern works recorded in the USTC"
+          />
+          <Stat
+            n={`~${Math.round(100 - VALIDATED.allPrintGapPct)}`}
+            unit="%"
+            label="of all early-modern print translated (validated estimate)"
+          />
+          <Stat
+            n={`~${Math.round(100 - VALIDATED.renaissanceGapPct)}`}
+            unit="%"
+            label="of Renaissance-composed Latin works translated"
+          />
+          <Stat
+            n={fmt(data.catalog_records)}
+            label="translation records federated from 30+ catalogs, counted live"
+          />
+        </div>
 
-      {/* ── Hero: The Gap ───────────────────────────────────── */}
-      <section className="bg-white rounded-xl border border-border-light p-6 md:p-8 mb-6">
-        <div className="text-center mb-8">
-          <div className="text-5xl md:text-6xl font-bold text-primary mb-2">
-            {data.pct_translated}%
-          </div>
-          <p className="text-secondary text-lg">
-            of pre-1700 European {unitLabel} have a known English translation
+        {/* ── The gap, measured ───────────────────────────────── */}
+        <Section kicker="The finding" title="Most of early-modern thought has never been Englished">
+          <p className="mb-4">
+            Between the invention of the printing press and 1700, European presses produced{' '}
+            {fmt(data.total_editions)} recorded editions — roughly {fmt(data.total_works)} distinct
+            works — in Latin, German, French, Italian, Dutch, Spanish, and other languages. The
+            intellectual output of the Renaissance, the Reformation, and the Scientific Revolution.
           </p>
-          {!hasWorkData && (
-            <p className="text-xs text-stone-400 mt-2">
-              Counted at the edition level. The true figure at the work level is likely lower
-              &mdash; one translated work covers many editions.
-            </p>
-          )}
-        </div>
-
-        <div className={`grid grid-cols-2 ${hasWorkData ? 'md:grid-cols-4' : 'md:grid-cols-3'} gap-4 mb-8`}>
-          <div className="text-center">
-            <div className="text-2xl font-semibold text-primary">{fmt(data.total_editions)}</div>
-            <div className="text-xs text-stone-500 mt-0.5">editions cataloged</div>
-          </div>
-          {hasWorkData && (
-            <div className="text-center">
-              <div className="text-2xl font-semibold text-primary">{fmt(data.total_works)}</div>
-              <div className="text-xs text-stone-500 mt-0.5">distinct works</div>
-            </div>
-          )}
-          <div className="text-center">
-            <div className="text-2xl font-semibold text-emerald-700">{fmt(data.total_translated)}</div>
-            <div className="text-xs text-stone-500 mt-0.5">with English translation</div>
-          </div>
-          <div className="text-center">
-            <div className="text-2xl font-semibold text-stone-400">{fmt(gap)}</div>
-            <div className="text-xs text-stone-500 mt-0.5">waiting to be translated</div>
-          </div>
-        </div>
-
-        <ProgressBar value={data.total_translated} max={denominator} color="bg-emerald-600" />
-        <div className="flex justify-between text-xs text-stone-400 mt-1.5">
-          <span>0%</span>
-          <span>{data.pct_translated}% translated</span>
-          <span>100%</span>
-        </div>
-      </section>
-
-      {/* ── The Story ────────────────────────────────────────── */}
-      <section className="bg-white rounded-xl border border-border-light p-6 mb-6">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 bg-amber-100 rounded-lg">
-            <BookOpen className="w-5 h-5 text-amber-700" />
-          </div>
-          <h2 className="text-xl font-semibold text-primary">The Scale of the Gap</h2>
-        </div>
-        <div className="prose-content text-secondary text-sm space-y-3">
-          <p>
-            Between the invention of the printing press (c. 1450) and 1700, European presses
-            produced over {fmt(data.total_editions)} recorded editions in Latin, German, French,
-            Italian, Dutch, Spanish, Portuguese, and other languages.
-            {hasWorkData && <> These represent roughly {fmt(data.total_works)} distinct works &mdash;</>}
-            {' '}The intellectual output of the Renaissance, Reformation, and Scientific Revolution.
+          <p className="mb-4">
+            How much of it can an English reader actually read? Our validated estimate: across{' '}
+            <strong>all</strong> early-modern print, <strong>{VALIDATED.allPrintGapPct}%</strong>{' '}
+            <span className="text-stone-500">[{VALIDATED.allPrintCI}]</span> has no known English
+            translation. Restricted to works actually <em>composed</em> in the Renaissance — not
+            reprints of ancient classics — the Latin gap rises to{' '}
+            <strong>{VALIDATED.renaissanceGapPct}%</strong>{' '}
+            <span className="text-stone-500">[{VALIDATED.renaissanceCI}]</span>: essentially the
+            whole of Renaissance Latin thought.
           </p>
           <p>
-            Of these, {hasWorkData ? 'only about' : 'roughly'} {fmt(data.total_translated)} {unitLabel} have
-            a known English translation. That&apos;s {data.pct_translated}%.
-            The other {(100 - data.pct_translated).toFixed(1)}% &mdash;
-            roughly {fmt(gap)} {unitLabel} &mdash; remain inaccessible to English readers.
+            These figures come from a blind, stratified validation of n={fmt(VALIDATED.sampleSize)}{' '}
+            works ({VALIDATED.evalDate}): a grounded-search adjudicator over the full sample,
+            an independent second model cross-checking an overlap set (agreement κ=
+            {VALIDATED.crossModelKappa}), post-stratified by composition era. Denominator: the{' '}
+            <a
+              href="https://www.ustc.ac.uk"
+              className="text-amber-800 underline hover:text-amber-900"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Universal Short Title Catalogue
+            </a>
+            &rsquo;s record of European print to 1700.
           </p>
-          {!hasWorkData && (
-            <p className="text-stone-400 italic">
-              Note: These counts are at the edition level. Multiple editions of the same work
-              (e.g. 14 printings of Cicero&apos;s <em>De Officiis</em>) are each counted separately.
-              An author-level match also means all editions by that author are marked as &ldquo;translated&rdquo;
-              even if only one of their works has a translation. The true percentage of distinct
-              works translated is lower &mdash; likely between 1% and 4%.
-            </p>
-          )}
-          <p>
-            This census is built by joining the <a href="https://www.ustc.ac.uk" className="text-amber-700 hover:underline" target="_blank" rel="noopener noreferrer">Universal Short Title Catalogue</a> ({fmt(data.total_editions)} editions) against {fmt(data.catalog_records)} known
-            English translations from UNESCO Index Translationum, Open Library, HathiTrust,
-            the Loeb Classical Library, Penguin Classics, Brill, Cambridge University Press, and other sources.
+          <Callout label="Why not quote the raw catalog number?">
+            A naive join of the USTC against our {fmt(data.catalog_records)} federated translation
+            records finds a match for only {data.raw_pct_translated}% of works. That raw figure{' '}
+            <strong>overstates the gap</strong>: translated ancient and medieval classics hide in
+            it under divergent titles, and author-level matches inflate the translated side where
+            it matters least. The validation run measured both errors and corrected for them —
+            which is why we headline the debiased estimates above, with their confidence
+            intervals, and treat the raw join only as a lower-bound floor. Full method, data, and
+            robustness checks:{' '}
+            <Link href="/research/translation-gap" className="text-amber-800 underline hover:text-amber-900">
+              The Translation Gap
+            </Link>
+            .
+          </Callout>
+        </Section>
+
+        {/* ── Search ──────────────────────────────────────────── */}
+        <Section kicker="Look it up" title="Has it been translated?">
+          <p className="mb-6 text-stone-600">
+            Search by author or title to check whether a pre-1700 work has a known English
+            translation — and whether Source Library holds the original.
           </p>
-        </div>
-      </section>
+          <CensusSearch editionCount={data.total_editions} catalogCount={data.catalog_records} />
+        </Section>
 
-      {/* ── Search ────────────────────────────────────────── */}
-      <section className="bg-white rounded-xl border border-border-light p-6 mb-6">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 bg-stone-100 rounded-lg">
-            <Search className="w-5 h-5 text-stone-600" />
-          </div>
-          <h2 className="text-xl font-semibold text-primary">Has It Been Translated?</h2>
-        </div>
-        <p className="text-secondary text-sm mb-4">
-          Search by author or title to check whether a pre-1700 work has a known English translation.
-        </p>
-        <CensusSearch />
-      </section>
-
-      {/* ── By Language ──────────────────────────────────────── */}
-      <section className="bg-white rounded-xl border border-border-light p-6 mb-6">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 bg-stone-100 rounded-lg">
-            <Languages className="w-5 h-5 text-stone-600" />
-          </div>
-          <h2 className="text-xl font-semibold text-primary">By Language</h2>
-        </div>
-        <p className="text-secondary text-sm mb-6">
-          Translation coverage varies by language. Latin is the largest corpus but also the
-          most studied; German, French, and Dutch literatures have vast untranslated portions.
-        </p>
-
-        <div className="space-y-6">
-          {data.languages.map(lang => (
-            <div key={lang.language} className="border-b border-stone-100 pb-5 last:border-0 last:pb-0">
-              <div className="flex items-baseline justify-between mb-2">
-                <h3 className="font-medium text-primary">{lang.language}</h3>
-                <div className="text-sm">
-                  <span className="text-emerald-700 font-medium">{fmt(lang.estimated_translated)}</span>
-                  <span className="text-stone-400"> / {fmt(hasWorkData ? lang.distinct_works : lang.editions)} {unitLabel}</span>
-                  <span className="text-stone-400 ml-1">({lang.pct_works_translated}%)</span>
+        {/* ── By language ─────────────────────────────────────── */}
+        <Section kicker="The map of the gap" title="Documented translations by language">
+          <p className="mb-6 text-stone-600">
+            Each bar shows the share of distinct works in that original language with a translation
+            documented in our federated catalogs. These are <strong>raw catalog floors, not the
+            debiased estimates</strong> — they count only translations we could locate and match,
+            so every bar understates the true rate. They are shown for their <em>shape</em>: the
+            relative neglect of German, Dutch, and Spanish print is real however you count.
+          </p>
+          <div className="space-y-2.5">
+            {data.languages.map(d => (
+              <div key={d.language} className="grid grid-cols-[7rem_1fr_6.5rem] items-center gap-3">
+                <div className="text-right font-body text-sm text-stone-800">
+                  {d.language}
+                  <span className="block text-[11px] text-stone-400">{fmt(d.works)} works</span>
+                </div>
+                <div className="h-5 bg-stone-200 rounded-sm overflow-hidden">
+                  <div
+                    className="h-full rounded-sm bg-gradient-to-r from-amber-800 to-amber-900"
+                    style={{ width: `${Math.max((d.pct / maxPct) * 100, 1.5)}%` }}
+                  />
+                </div>
+                <div className="font-body text-sm font-semibold text-amber-800">
+                  {d.pct.toFixed(2)}% <span className="text-stone-400 font-normal">· {fmt(d.translated)}</span>
                 </div>
               </div>
-              <ProgressBar value={lang.estimated_translated} max={hasWorkData ? lang.distinct_works : lang.editions} color="bg-emerald-600" />
-
-              {/* Top untranslated authors */}
-              {lang.top_untranslated.length > 0 && (
-                <div className="mt-2">
-                  <span className="text-[10px] uppercase tracking-wider text-stone-400">Notable untranslated authors: </span>
-                  <span className="text-xs text-stone-500">
-                    {lang.top_untranslated.map((a, i) => (
-                      <span key={a.surname}>
-                        {i > 0 && ', '}
-                        {a.surname}
-                        <span className="text-stone-300"> ({fmt(a.works)})</span>
-                      </span>
-                    ))}
-                  </span>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ── Source Library's Contribution ─────────────────────── */}
-      {(data.sl_first_translations > 0 || data.sl_books_translated > 0) && (
-        <section className="bg-white rounded-xl border border-border-light p-6 mb-6">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="p-2 bg-purple-100 rounded-lg">
-              <Sparkles className="w-5 h-5 text-purple-700" />
-            </div>
-            <h2 className="text-xl font-semibold text-primary">Source Library&apos;s Contribution</h2>
+            ))}
           </div>
-          <p className="text-secondary text-sm mb-4">
-            Source Library is actively translating books from this census &mdash; many for the first
-            time in any modern language. Each translation updates the count.
+        </Section>
+
+        {/* ── State of our census (#2933) ─────────────────────── */}
+        <Section kicker="The state of the census" title="Verifying our own shelves">
+          <p className="mb-6 text-stone-600">
+            The census is not only a measurement of the world&rsquo;s catalogs — it runs over our
+            own corpus too. Every readable non-English book in Source Library is being put through
+            a documented, grounded search for prior English translations, so that every
+            &ldquo;first translation&rdquo; claim we make is evidenced, not asserted.
+            {asOf && <> Figures as of {asOf}.</>}
           </p>
-          <div className="flex items-center gap-8">
-            <div>
-              <div className="text-3xl font-bold text-amber-700">{fmt(data.sl_first_translations)}</div>
-              <div className="text-xs text-stone-500">first English translations</div>
-            </div>
-            <div>
-              <div className="text-3xl font-bold text-primary">{fmt(data.sl_books_translated)}</div>
-              <div className="text-xs text-stone-500">books translated</div>
-            </div>
+          <div className="grid grid-cols-2 md:grid-cols-4 border border-stone-200 rounded-sm bg-stone-50">
+            <Stat n={fmt(data.corpus_readable)} label="readable books in the first-translation pool" />
+            <Stat
+              n={fmt(data.corpus_checked)}
+              label={`checked against the catalogs (${data.corpus_checked_pct}% of the pool)`}
+            />
+            {data.corpus_searched !== null && (
+              <Stat n={fmt(data.corpus_searched)} label="books with a documented grounded search on file" />
+            )}
+            <Stat n={fmt(data.sl_first_translations)} label="verified first English translations, readable now" />
           </div>
-          <div className="mt-4">
+          <Callout label="One number, site-wide">
+            The first-translation count above is the same canonical figure shown on the{' '}
+            <Link href="/" className="text-amber-800 underline hover:text-amber-900">homepage</Link>{' '}
+            — verified badges on books you can actually read, refreshed nightly. Claims that fail
+            verification are demoted; the count only ever reflects the evidence on file.
+          </Callout>
+        </Section>
+
+        {/* ── Source Library's contribution ───────────────────── */}
+        <Section kicker="Closing it" title="Source Library&rsquo;s contribution">
+          <p className="mb-6">
+            Source Library pairs facsimiles of the originals with complete English translations —{' '}
+            {fmt(data.sl_books_readable)} books readable in English so far, including{' '}
+            {fmt(data.sl_first_translations)} first-ever English translations. Each one moves a
+            work from the untranslated column of this census into the translated one.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/search?first_translation=true"
+              className="font-body text-sm font-semibold bg-amber-800 hover:bg-amber-900 text-stone-50 px-6 py-3 rounded-sm transition-colors"
+            >
+              Browse the first translations
+            </Link>
             <Link
               href="/about/progress"
-              className="text-sm text-amber-700 hover:underline inline-flex items-center gap-1"
+              className="font-body text-sm font-semibold border border-amber-800 text-amber-800 hover:bg-amber-50 px-6 py-3 rounded-sm transition-colors"
             >
-              See full progress breakdown <ExternalLink className="w-3 h-3" />
+              Full progress breakdown
             </Link>
           </div>
-        </section>
-      )}
+        </Section>
 
-      {/* ── Methodology ──────────────────────────────────────── */}
-      <section className="bg-white rounded-xl border border-border-light p-6 mb-6">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 bg-stone-100 rounded-lg">
-            <BarChart3 className="w-5 h-5 text-stone-600" />
+        {/* ── Methodology ─────────────────────────────────────── */}
+        <Section kicker="How to read the numbers" title="Methodology &amp; caveats">
+          <ul className="list-disc pl-5 space-y-2.5 text-base">
+            <li>
+              <strong>Two kinds of figures.</strong> The headline gap estimates (
+              {VALIDATED.allPrintGapPct}% all-print, {VALIDATED.renaissanceGapPct}%
+              Renaissance-composed Latin) are debiased, validated measurements with confidence
+              intervals. The per-language bars and the raw {data.raw_pct_translated}% join rate
+              are catalog floors — lower bounds from record matching, useful for shape, not for
+              headlines.
+            </li>
+            <li>
+              <strong>&ldquo;Works,&rdquo; not editions.</strong> The USTC records{' '}
+              {fmt(data.total_editions)} editions; we deduplicate to ~{fmt(data.total_works)}{' '}
+              distinct works so that fourteen printings of the same text count once. A translation
+              of any edition covers the work.
+            </li>
+            <li>
+              <strong>The catalogs are a floor.</strong> Our {fmt(data.catalog_records)} federated
+              records (counted live, growing daily) miss translations buried in dissertations,
+              anthologies, and out-of-print editions. The validation step exists precisely to
+              measure what the catalogs miss.
+            </li>
+            <li>
+              <strong>Match precision is era-dependent.</strong> Of pipeline-matched
+              &ldquo;translated&rdquo; works, {VALIDATED.matcherPrecisionPct}% have a confirmed
+              real translation — higher for classics, lower for Renaissance titles, which is one
+              of the biases the debiased estimates correct.
+            </li>
+            <li>
+              <strong>A human gold standard is pending.</strong> The current estimates rest on two
+              independent AI adjudicators in high agreement; a human-scored gold subset is the
+              next binding step and may shift the figures within their stated intervals.
+            </li>
+          </ul>
+        </Section>
+
+        {/* ── Data sources ────────────────────────────────────── */}
+        <div className="py-10">
+          <div className="font-body text-xs tracking-[0.16em] uppercase text-stone-500 font-semibold mb-3">
+            Data sources
           </div>
-          <h2 className="text-xl font-semibold text-primary">Methodology &amp; Caveats</h2>
-        </div>
-        <div className="prose-content text-secondary text-sm space-y-3">
-          <p>
-            <strong>What we count:</strong> &ldquo;Works&rdquo; are distinct titles by the same author,
-            deduplicated from USTC editions. &ldquo;Translated&rdquo; means at least one English-language
-            version exists in our catalog of {fmt(data.catalog_records)} records from 12 sources.
-          </p>
-          <p>
-            <strong>This is a lower bound.</strong> The translation catalogs are not exhaustive.
-            Translations in dissertations, obscure journals, out-of-print 19th-century editions,
-            and anthology excerpts may not appear. The true number of translated works is likely
-            higher &mdash; but probably not dramatically so.
-          </p>
-          <p>
-            <strong>Editions vs. works:</strong> The USTC records multiple editions of the same work.
-            A translation of one edition covers the work, not just that edition. We count at the
-            work level to avoid inflating the untranslated figure.
-          </p>
-          <p>
-            <strong>Not all editions are books.</strong> The USTC includes broadsides, pamphlets,
-            and single-sheet prints. Some may not need &ldquo;translation&rdquo; in the traditional sense.
+          <p className="font-body text-sm text-stone-500 leading-relaxed">
+            Denominator: the Universal Short Title Catalogue (University of St Andrews).
+            Translation records federated from the UNESCO Index Translationum, Library of Congress,
+            Open Library / Internet Archive, HathiTrust, the Loeb Classical Library, I Tatti and
+            Dumbarton Oaks, Brill, Oxford, Cambridge, Yale, Chicago, Penguin Classics, and other
+            catalogs and publisher series — {fmt(data.catalog_records)} records at last count.
+            Author reconciliation via VIAF, Wikidata, GND, and CERL. Gap estimates validated
+            against an n={fmt(VALIDATED.sampleSize)} blind sample, {VALIDATED.evalDate}.{' '}
+            Know of a translation we missed?{' '}
+            <Link href="/contribute" className="text-amber-800 underline hover:text-amber-900">
+              Let us know
+            </Link>
+            .
           </p>
         </div>
-      </section>
-
-      {/* ── Data Sources ─────────────────────────────────────── */}
-      <section className="bg-stone-100/50 rounded-xl border border-stone-200/50 p-6 mb-6">
-        <h3 className="text-sm font-medium text-stone-500 mb-3">Data Sources</h3>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-1 text-xs text-stone-500">
-          <div>Universal Short Title Catalogue (USTC)</div>
-          <div>UNESCO Index Translationum</div>
-          <div>Open Library / Internet Archive</div>
-          <div>HathiTrust Digital Library</div>
-          <div>Loeb Classical Library</div>
-          <div>Penguin Classics catalog</div>
-          <div>Brill Publishers</div>
-          <div>Cambridge University Press</div>
-          <div>Routledge / De Gruyter</div>
-          <div>CUA / Paulist Press (Church Fathers)</div>
-          <div>Broadview / Norton / Hackett</div>
-          <div>University of Chicago / Indiana UP</div>
-        </div>
-        <p className="text-[10px] text-stone-400 mt-3">
-          Know of a translation we missed? <Link href="/contribute" className="underline hover:text-stone-600">Let us know</Link>.
-        </p>
-      </section>
+      </div>
     </ContentPageLayout>
   );
 }


### PR DESCRIPTION
Closes #3015 — /census was stale (wrong FT count vs homepage, hardcoded catalog size, superseded '<2%' headline) and off-brand.

## Data
- **One FT number site-wide:** the page (and `/about/progress`) now shows `system_config.homepage_stats.firstTranslationCount` — the verified public count the homepage uses (5,966 today) — instead of `get_sl_progress`'s raw `is_first_translation` re-derivation (6,839).
- **Live catalog count:** `translation_catalogs` counted with a head-count query (31,267 at time of writing, grows daily); removed hardcoded 13,862 in the page and 1.57M/13,800+ in `CensusSearch` (now props).
- **Validated headline:** the gap is quoted from the #2684 n=1000 dual-model, era post-stratified validation — all-print gap **84.9% [82.3–87.3]**, Renaissance-composed Latin **93.3% [91.3–95.2]** — with method, CI, and denominator in the prose. The raw USTC join rate (0.93%) appears only in a labeled 'why not quote the raw number' callout and the per-language bars, explicitly framed as catalog floors. Figures are cited constants (study results, not live counts) sourced to `translation-gap-methodology.md` + `scripts/analysis/eval-data/gap-validation-*.json`.
- **State of the census (#2933):** new section showing our own corpus coverage — readable FT pool / checked against catalogs / books with a documented grounded search / verified badges — dated from `homepage_stats.updatedAt`. Both nightly writers (`prewarm-browse.mjs`, `update-homepage-stats.mjs`, kept in sync) now roll `first_translation_attempts` ledger coverage into a new `homepage_stats.census_ledger` key; backfilled once by hand so the section renders immediately.
- **Fallback doctrine (#2974):** data load now throws on failure (ISR keeps the last good page at revalidate=3600) instead of rendering a cacheable 'loading…' fallback. Removed the `get_coverage_stats` edition-level fallback path entirely — it produced the misleading edition-counted numbers.

## Design
Rebuilt on the house editorial system already used by `/research/translation-gap`: `ContentHeader` serif hero, kicker + serif-heading sections, stone/amber tonal palette, stat bands, border-left callouts, gradient bar rows. No new primitives — every class already exists on that page. Dropped the lucide icon chips, rounded-xl white cards, and purple/emerald accents. The two pages now read as siblings, and cross-link.

## Out of scope (deliberate)
- `/research/translation-gap` still presents the raw-join study (May 2026, carefully framed as lower bounds with robustness checks). It's a dated data study rather than a live page; aligning its headline with the #2684 debiased figures is a separate editorial decision.
- The `get_sl_progress` RPC itself is unchanged — its other totals are still used by `/about/progress`; only the FT figure is overridden with the canonical count.
- Noticed while testing: 10 Vercel env vars carry a trailing newline (`SUPABASE_URL`, `GEMINI_API_KEY_3`, `PROVENANCE_SECRET_KEY`, …) — the same pollution f3436af9 worked around. Needs a source-level fix in Vercel; reported to Derek separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)