### PR TITLE
fix(bph): catalogue never dead-ends — graceful fallback instead of 404

### DIFF
--- a/src/app/embed/[tenant]/book/[slug]/page.tsx
+++ b/src/app/embed/[tenant]/book/[slug]/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { getReadDb } from '@/lib/mongodb';
+import { isInnerCircle } from '@/lib/auth-helpers';
+import CatalogueUnavailable from '@/components/embed/CatalogueUnavailable';
 import BookDetailPage, { generateMetadata as parentGenerateMetadata } from '@/app/book/[id]/page';
 
 // Iframe-target wrapper. Partner Webflow sites embed Source Library via
@@ -24,6 +27,27 @@ export default async function EmbedBookPage({ params }: { params: Promise<{ tena
     const tenantId = await resolveTenantId(tenant);
 
     if (!tenantId) notFound();
+
+    // The catalogue must never dead-end. A hidden/unpublished book that is still
+    // catalogued (imported-but-unprocessed holdings, or an item held back for
+    // rights review) would otherwise soft-404 at the reader's visibility gate.
+    // Instead, send the reader to its catalogue record — which always renders
+    // the bibliographic entry. Editors keep their hidden-book preview.
+    const db = await getReadDb();
+    const book = await db.collection('books').findOne(
+        { $or: [{ slug }, { id: slug }] },
+        { projection: { visible: 1, 'dublin_core.dc_identifier': 1 } },
+    );
+    if (book && book.visible === false && !(await isInnerCircle())) {
+        const ubn = (book.dublin_core as { dc_identifier?: string } | undefined)?.dc_identifier;
+        if (ubn) redirect(`/embed/${tenant}/catalog/${encodeURIComponent(ubn)}`);
+        return (
+            <CatalogueUnavailable
+                heading="Not yet available to read"
+                detail="This item is catalogued but not currently available to read online in this reading room."
+            />
+        );
+    }
 
     return (
         <BookDetailPage

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -1,4 +1,3 @@
-import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { BookMarked, ExternalLink, BookOpen, Pencil, Search } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
@@ -11,6 +10,7 @@ import { auth } from '@/lib/auth';
 import { ROLE_LEVEL, type Role } from '@/lib/auth';
 import type { BphContributor } from '@/lib/bph-catalog';
 import { AISection } from '@/components/embed/AISection';
+import CatalogueUnavailable from '@/components/embed/CatalogueUnavailable';
 import GenericCatalogEntry, { generateGenericMetadata } from './GenericCatalogEntry';
 
 // Catalogue entry routing
@@ -367,7 +367,17 @@ export default async function CatalogEntryPage({ params }: Props) {
     fetchSlBook(ubn),
     auth(),
   ]);
-  if (!work) notFound();
+  // The catalogue must never dead-end. If there's no catalogue row for this
+  // reference (mis-typed UBN, re-catalogued, or an incomplete link), render a
+  // graceful in-catalogue landing with a "New search" link — not a hard 404.
+  if (!work) {
+    return (
+      <CatalogueUnavailable
+        heading="Catalogue entry unavailable"
+        detail={`We couldn't find a catalogue record for reference “${ubn}”. It may have been re-catalogued, or the reference may be incomplete. Try a new search.`}
+      />
+    );
+  }
 
   const platformRole = normalizeRoleSafe((session?.user as { role?: unknown } | undefined)?.role);
   const role = await effectiveCatalogRole(session?.user?.email, platformRole, tenant);

--- a/src/components/embed/CatalogueUnavailable.tsx
+++ b/src/components/embed/CatalogueUnavailable.tsx
@@ -1,0 +1,40 @@
+import { Search } from 'lucide-react';
+
+/**
+ * Graceful in-catalogue landing for when a reading-room URL can't resolve to a
+ * readable book or a catalogue record. The catalogue is a finding aid — it must
+ * never dead-end on a 404. Used by:
+ *   - the catalogue record page ([tenant]/catalog/[ubn]) when no catalogue row
+ *     is found, and
+ *   - the reading-room book route ([tenant]/book/[slug]) when a catalogued item
+ *     is hidden/not-yet-available and has no catalogue entry to redirect to.
+ *
+ * Server component (no client hooks) so it can render inside either route. The
+ * `/catalog` "New search" link is host-relative and proxy-rewritten to the
+ * tenant's catalogue search view — never an off-subdomain URL (tenant lockdown).
+ */
+export default function CatalogueUnavailable({
+  heading,
+  detail,
+}: {
+  heading: string;
+  detail: string;
+}) {
+  return (
+    <div className="bg-cream min-h-screen">
+      <div className="max-w-2xl mx-auto px-6 py-12">
+        <div className="mb-4">
+          <a
+            href="/catalog"
+            className="inline-flex items-center gap-1.5 text-sm text-secondary hover:text-primary transition-colors"
+          >
+            <Search className="w-3.5 h-3.5" />
+            New search
+          </a>
+        </div>
+        <h1 className="text-xl font-semibold text-primary mb-2">{heading}</h1>
+        <p className="text-secondary text-sm leading-relaxed">{detail}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Principle
A catalogue is a finding aid — every path through it must lead to something real (at minimum the bibliographic record), never a 404. This closes the last two routes that could still dead-end.

## Changes
**1. Catalogue record page** (`[tenant]/catalog/[ubn]`) — called `notFound()` when no `bph_works` row matched the reference. Now renders a graceful in-catalogue landing (heading + detail + "New search").

**2. Reading-room book route** (`[tenant]/book/[slug]`) — delegated straight to the global reader, which soft-404s hidden books at the visibility gate. This is how a **direct / bookmarked / partner (EFM) link** to a catalogued-but-hidden item dead-ended (e.g. the 12 items held back for rights review, or imported-but-unprocessed holdings). Now:
- hidden book → **redirect to its catalogue record** (always renders, per #1);
- no catalogue reference → same graceful "not yet available to read" landing;
- **editors keep hidden-book preview** (`isInnerCircle` bypasses the redirect).

New shared server component `CatalogueUnavailable` renders the landing for both routes. Its "New search" link is host-relative (proxy-rewritten) — no off-subdomain URL, per the tenant lockdown.

## Relationship to #3016
#3016 stopped the catalogue **list/grid** from *generating* links to hidden books. This PR handles everything that still reaches a reader/record route directly. Together: **no path in or into the reading room returns a 404.**

## Scope
- The reader-route fallback (#2) applies to **every** tenant's `/embed/[tenant]/book/*`, not just BPH — so it also covers other tenants' catalogue tables that link rows straight to `/book/<slug>`.
- Out of scope: unhiding the 12 rights-review items (separate decision); the underlying pipeline/processing of unprocessed holdings.

## Cost
One extra minimal Mongo lookup (`{visible, dublin_core.dc_identifier}` projection) per reading-room book load. Negligible vs the book fetch the reader already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)