### PR TITLE
fix(bph): hotfix — reader fallback renders inline (redirect() was 500ing)

### DIFF
--- a/src/app/embed/[tenant]/book/[slug]/page.tsx
+++ b/src/app/embed/[tenant]/book/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { resolveTenantId } from '@/lib/tenant-context';
 import { getReadDb } from '@/lib/mongodb';
 import { isInnerCircle } from '@/lib/auth-helpers';
@@ -31,20 +31,18 @@ export default async function EmbedBookPage({ params }: { params: Promise<{ tena
     // The catalogue must never dead-end. A hidden/unpublished book that is still
     // catalogued (imported-but-unprocessed holdings, or an item held back for
     // rights review) would otherwise soft-404 at the reader's visibility gate.
-    // Instead, send the reader to its catalogue record — which always renders
-    // the bibliographic entry. Editors keep their hidden-book preview.
+    // Instead, render a graceful "catalogued, not yet available" landing with a
+    // "New search" link. Editors keep their hidden-book preview.
     const db = await getReadDb();
     const book = await db.collection('books').findOne(
         { $or: [{ slug }, { id: slug }] },
-        { projection: { visible: 1, 'dublin_core.dc_identifier': 1 } },
+        { projection: { visible: 1 } },
     );
     if (book && book.visible === false && !(await isInnerCircle())) {
-        const ubn = (book.dublin_core as { dc_identifier?: string } | undefined)?.dc_identifier;
-        if (ubn) redirect(`/embed/${tenant}/catalog/${encodeURIComponent(ubn)}`);
         return (
             <CatalogueUnavailable
                 heading="Not yet available to read"
-                detail="This item is catalogued but not currently available to read online in this reading room."
+                detail="This item is catalogued but not currently available to read online in this reading room. Browse the catalogue to find related works."
             />
         );
     }


### PR DESCRIPTION
## Live-500 hotfix for #3021
#3021's reading-room reader fallback called `next/navigation` `redirect()` to hop a hidden book to its catalogue record. In this embed server-component context that **threw and surfaced as HTTP 500** on every hidden-book URL.

Verified on prod after the #3021 deploy:
- readable books → 200 ✓
- the redirect *target* (`/embed/bph/catalog/<ubn>`) → 200 ✓
- the garbage-UBN catalogue page (renders `CatalogueUnavailable`) → 200 ✓
- **only** the redirecting hidden-book path → 500

By elimination every element is proven working except `redirect()`, which was exercised solely on the failing path. This renders `CatalogueUnavailable` **inline** instead of redirecting — simpler, no surprise hop, and still satisfies "never 404" (graceful landing, not a soft-404 or a 500).

Editors keep their hidden-book preview (`isInnerCircle` bypass unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)