### PR TITLE
revert(bph): remove reader-route hidden-book fallback (was 500ing)

### DIFF
--- a/src/app/embed/[tenant]/book/[slug]/page.tsx
+++ b/src/app/embed/[tenant]/book/[slug]/page.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { resolveTenantId } from '@/lib/tenant-context';
-import { getReadDb } from '@/lib/mongodb';
-import { isInnerCircle } from '@/lib/auth-helpers';
-import CatalogueUnavailable from '@/components/embed/CatalogueUnavailable';
 import BookDetailPage, { generateMetadata as parentGenerateMetadata } from '@/app/book/[id]/page';
 
 // Iframe-target wrapper. Partner Webflow sites embed Source Library via
@@ -27,25 +24,6 @@ export default async function EmbedBookPage({ params }: { params: Promise<{ tena
     const tenantId = await resolveTenantId(tenant);
 
     if (!tenantId) notFound();
-
-    // The catalogue must never dead-end. A hidden/unpublished book that is still
-    // catalogued (imported-but-unprocessed holdings, or an item held back for
-    // rights review) would otherwise soft-404 at the reader's visibility gate.
-    // Instead, render a graceful "catalogued, not yet available" landing with a
-    // "New search" link. Editors keep their hidden-book preview.
-    const db = await getReadDb();
-    const book = await db.collection('books').findOne(
-        { $or: [{ slug }, { id: slug }] },
-        { projection: { visible: 1 } },
-    );
-    if (book && book.visible === false && !(await isInnerCircle())) {
-        return (
-            <CatalogueUnavailable
-                heading="Not yet available to read"
-                detail="This item is catalogued but not currently available to read online in this reading room. Browse the catalogue to find related works."
-            />
-        );
-    }
 
     return (
         <BookDetailPage


### PR DESCRIPTION
Reverts the reading-room reader fallback from #3021/#3022. It called `getReadDb()/findOne()` unwrapped in the embed book route, which threw → **HTTP 500** on hidden-book URLs (readable pages are CDN-cached so the throw only showed on uncached hidden paths). Restores the pre-#3021 wrapper (hidden direct hits soft-404, not 500). #3016 and #3021's catalogue-record graceful fallback stay. A correct reader-route fallback will follow after a local repro pins the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)