### PR TITLE
collections cards: use hero_image (override > hero > featured_images)

### DIFF
--- a/src/app/collections/all/page.tsx
+++ b/src/app/collections/all/page.tsx
@@ -55,14 +55,14 @@ async function fetchWings(): Promise<Wing[]> {
     type: { $ne: 'curated' },
     collection_type: { $ne: 'visual_art' },
     visible: true,
-  }).project({ slug: 1, tenantId: 1, name: 1, book_count: 1, artwork_count: 1, featured_images: { $slice: 1 }, _id: 0 }).sort({ name: 1 }).toArray();
+  }).project({ slug: 1, tenantId: 1, name: 1, book_count: 1, artwork_count: 1, hero_image: 1, featured_images: { $slice: 1 }, _id: 0 }).sort({ name: 1 }).toArray();
 
   // Get all subcollections with their first featured image
   const subs = await db.collection('collections').find({
     parent: { $exists: true },
   }).project({
     slug: 1, tenantId: 1, name: 1, book_count: 1, artwork_count: 1, parent: 1, visible: 1, type: 1,
-    featured_images: { $slice: 1 }, _id: 0,
+    hero_image: 1, featured_images: { $slice: 1 }, _id: 0,
   }).toArray();
 
   const tenantIds = [...new Set([
@@ -91,7 +91,7 @@ async function fetchWings(): Promise<Wing[]> {
         artwork_count: sub.artwork_count || 0,
         visible: sub.visible !== false,
         type: sub.type,
-        image: coverOverride(sub.slug) || pickImage(sub.featured_images),
+        image: coverOverride(sub.slug) || sub.hero_image || pickImage(sub.featured_images),
       });
     }
   }
@@ -107,7 +107,7 @@ async function fetchWings(): Promise<Wing[]> {
     name: w.name,
     book_count: w.book_count || 0,
     artwork_count: w.artwork_count || 0,
-    image: coverOverride(w.slug) || pickImage(w.featured_images),
+    image: coverOverride(w.slug) || w.hero_image || pickImage(w.featured_images),
     children: childMap.get(w.slug) || [],
   }));
 }

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -41,6 +41,7 @@ interface CollectionDoc {
   type?: 'category' | 'curated';
   published?: boolean;
   featured_images?: FeaturedImage[];
+  hero_image?: string;
   languages: { lang: string; count: number }[];
   children_count?: number;
   collection_type?: string;
@@ -172,13 +173,14 @@ async function fetchTimelineDecades(): Promise<{ decades: DecadeBucket[]; total:
  *  thumbnails, then extracted, then the raw page, across all featured images.
  *  The card renders these with a fallback chain so a single dead/slow source
  *  doesn't leave a broken thumbnail. */
-function cardImageCandidates(images: FeaturedImage[] | undefined, override?: string): string[] {
+function cardImageCandidates(images: FeaturedImage[] | undefined, override?: string, heroImage?: string): string[] {
   const urls: string[] = [];
   const add = (u: string | undefined | null) => {
     const s = sanitizeThumbnail(u);
     if (s && !urls.includes(s)) urls.push(s);
   };
-  add(override); // curated cover wins over stored featured_images
+  add(override); // curated cover wins over everything
+  add(heroImage); // curated hero_image (set per-collection in Mongo) beats auto featured_images
   if (!images?.length) return urls;
   for (const img of images) {
     if (typeof img === 'string') { add(img); continue; }
@@ -197,7 +199,7 @@ function CollectionCard({ col, tenantSlug, priority = false }: { col: Collection
       className="group relative block overflow-hidden rounded-lg aspect-square animate-fade-in-up"
     >
       <CollectionCardImage
-        candidates={cardImageCandidates(col.featured_images, coverOverride(col.slug))}
+        candidates={cardImageCandidates(col.featured_images, coverOverride(col.slug), col.hero_image)}
         alt={`Illustration from ${col.name}`}
         sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
         priority={priority}
@@ -225,7 +227,7 @@ function CuratedCard({ col, tenantSlug, priority = false }: { col: CollectionDoc
       className="group relative block overflow-hidden rounded-lg aspect-square animate-fade-in-up"
     >
       <CollectionCardImage
-        candidates={cardImageCandidates(col.featured_images, coverOverride(col.slug))}
+        candidates={cardImageCandidates(col.featured_images, coverOverride(col.slug), col.hero_image)}
         alt={`Illustration from ${col.name}`}
         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
         priority={priority}


### PR DESCRIPTION
Derek's screenshot showed gray placeholder cards on /collections for Gardens/Festivals and the new American Founding collection — despite hero images being set in #3007. Cause: the /collections and /collections/all cards only read the hardcoded `coverOverride` map + `featured_images`; `collection.hero_image` (what the #3007 curation populated, and what the homepage already uses) was never consulted.

- `cardImageCandidates` chain is now **override → hero_image → featured_images** on /collections; same fallback on /collections/all (+ `hero_image` added to its projections).
- Data-side (already applied to prod, no code): `american-founding` (created today by another session) carried `kind: 'book'` — outside the #3002 enum, failing audit check 2 — retagged `tradition`, and given a hero (stipple-engraved Washington portrait from the Farewell Address).

`npx tsc --noEmit` clean. After deploy, both gray cards on Derek's screenshot render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)