### PR TITLE
Retire merged collection slugs from AI assignment vocabularies (#3002 follow-up)

### DIFF
--- a/scripts/cache-temperature.mjs
+++ b/scripts/cache-temperature.mjs
@@ -166,7 +166,7 @@ const SUB_COLLECTIONS = [
   "enlightenment-political-philosophy","experimental-philosophy",
   "faculty-psychology-de-anima","falsafa","florentine-neoplatonism","freemasonry",
   "galenic-classical-medicine","geography-exploration","german-speculative-mysticism",
-  "papyri-magical","hermetic-revival","hermetica-sacred","hinduism","papyri-historical",
+  "papyri-magical","hermetic-revival","gnostic-texts","hinduism","papyri-historical",
   "horoscopic-western-astrology","humanist-scholarship","illuminati-radical-orders",
   "indian-mathematics-astronomy","indian-natural-philosophy","indigenous-traditions",
   "islam","islamic-medicine-science","islamic-occult-sciences","jainism",

--- a/scripts/enrichment/assign-sacred-subcollections.mjs
+++ b/scripts/enrichment/assign-sacred-subcollections.mjs
@@ -24,7 +24,8 @@ const TRADITIONS = [
   { slug: 'confucianism', hint: 'Analects, Mencius, Four Books, Five Classics, Xunzi, neo-Confucian texts' },
   { slug: 'zoroastrianism', hint: 'Avesta, Gathas, Zend-Avesta, Bundahishn, Pahlavi texts, Zoroastrian liturgy' },
   { slug: 'manichaeism', hint: 'Mani, Manichaean texts, anti-Manichaean writings, Kephalaia, Manichaean psalms' },
-  { slug: 'hermetica-sacred', hint: 'Corpus Hermeticum, Asclepius, Nag Hammadi, Gnostic gospels, Valentinian texts. Only truly sacred/scriptural Hermetic texts' },
+  // 'hermetica-sacred' retired 2026-07-05 (#3002) — sacred/Gnostic Hermetic texts now route to gnostic-texts.
+  { slug: 'gnostic-texts', hint: 'Nag Hammadi, Gnostic gospels, Valentinian texts, Corpus Hermeticum and Asclepius as scripture' },
   { slug: 'orphism-mysteries', hint: 'Orphic hymns, Eleusinian mysteries, Dionysian rites, mystery religion initiation texts' },
   { slug: 'ancient-greek-religion', hint: 'Hesiod Theogony, Homeric Hymns, Greek temple practices, Greek religious ritual (NOT philosophy)' },
   { slug: 'ancient-egyptian', hint: 'Book of the Dead, Pyramid Texts, Coffin Texts, Egyptian funerary literature, Egyptian religious ritual' },

--- a/scripts/enrichment/assign-sacred-traditions.mjs
+++ b/scripts/enrichment/assign-sacred-traditions.mjs
@@ -201,26 +201,7 @@ const TRADITIONS = [
       /\bbundahishn/i, /\bdenkard/i,
     ],
   },
-  {
-    slug: 'hermetica-sacred',
-    name: 'Hermetica & Gnostic Texts',
-    subtitle: 'Ancient Wisdom Revealed',
-    description: 'The Corpus Hermeticum, the Asclepius, and the Gnostic scriptures recovered at Nag Hammadi. Texts attributed to Hermes Trismegistus that Renaissance thinkers like Ficino treated as sacred revelation — the prisca theologia, an ancient theology believed to predate Moses.',
-    order: 8,
-    exactCategories: [
-      'gnostic', 'gnosticism', 'nag-hammadi', 'corpus-hermeticum',
-    ],
-    patterns: [
-      'gnostic', 'nag-hammadi', 'corpus-hermetic',
-    ],
-    titlePatterns: [
-      /\bcorpus hermeticum/i, /\basclepius\b/i, /\bpoimandres/i, /\bpimander/i,
-      /\bnag hammadi/i, /\bgnostic/i,
-      /\bpistis sophia/i, /\bhermes trismegist/i,
-      /\btrismegist/i,
-    ],
-    // Only primary scripture, not the broader Hermetic commentary tradition
-  },
+  // 'hermetica-sacred' retired 2026-07-05 (#3002): merged into hermetica + gnostic-texts.
   {
     slug: 'mandaeanism',
     name: 'Mandaeanism',

--- a/scripts/maintenance/backfill-collection-relevance.mjs
+++ b/scripts/maintenance/backfill-collection-relevance.mjs
@@ -84,7 +84,7 @@ const COLLECTIONS = [
 
 const TRADITIONS = [
   'christianity', 'judaism', 'islam', 'buddhism', 'hinduism', 'daoism',
-  'zoroastrianism', 'hermetica-sacred', 'manichaeism', 'mandaeanism',
+  'zoroastrianism', 'gnostic-texts', 'manichaeism', 'mandaeanism',
   'jainism', 'confucianism', 'ancient-egyptian', 'orphism-mysteries',
   'norse-germanic', 'shinto', 'sikhism', 'indigenous-traditions',
   'druze', 'bahai', 'sumerian-mesopotamian', 'ancient-greek-religion',

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -1748,8 +1748,20 @@ Guidelines:
   if (RUN_PHASE_7_6) {
     console.log('\n=== Phase 7.6: Collection Assignment ===');
 
-    // Load collection definitions from DB
-    let collections = await db.collection('collections').find({}).toArray();
+    // Load collection definitions from DB. Exclude retired collections —
+    // merged docs (merged_into set) and slugs in the redirect map (e.g. the
+    // retired `philosophy` umbrella). Offering them as assignment targets
+    // silently re-tags books with slugs the #3002 merges already cleaned.
+    let retiredSlugs = [];
+    try {
+      const { readFileSync } = await import('fs');
+      retiredSlugs = Object.keys(JSON.parse(
+        readFileSync(new URL('../../src/lib/collection-redirects.json', import.meta.url), 'utf8')
+      ));
+    } catch { /* map absent on an old checkout — merged_into filter still applies */ }
+    let collections = await db.collection('collections')
+      .find({ merged_into: { $exists: false }, slug: { $nin: retiredSlugs } })
+      .toArray();
     if (collections.length === 0) {
       console.log('  No collections in DB — skipping phase 7.6');
     } else {

--- a/src/lib/collection-relevance.ts
+++ b/src/lib/collection-relevance.ts
@@ -30,10 +30,9 @@ const COLLECTIONS = [
   { slug: 'poetry', name: 'Poetry', desc: 'Lyric, epic, didactic, and occasional verse across traditions' },
   { slug: 'drama', name: 'Drama', desc: 'Tragedy, comedy, morality plays, theatrical texts' },
   { slug: 'prose-fiction', name: 'Prose Fiction', desc: 'Romances, novels, satire, utopias, picaresque, early fiction' },
-  { slug: 'philosophy', name: 'Philosophy', desc: 'Ethics, metaphysics, logic, epistemology — broader than classical or Renaissance subsets' },
   { slug: 'geography-exploration', name: 'Geography & Exploration', desc: 'Travel accounts, cosmography, cartography, voyages of discovery' },
   { slug: 'agriculture', name: 'Agriculture', desc: 'Farming, husbandry, viticulture, estate management, georgic literature' },
-  { slug: 'science-mathematics', name: 'Science & Mathematics', desc: 'Arithmetic, geometry, astronomy, optics, mechanics, natural science' },
+  { slug: 'mathematics', name: 'Mathematics & Sacred Number', desc: 'Arithmetic, geometry, astronomy, optics, mechanics, natural science' },
   { slug: 'music-harmony', name: 'Music, Harmony & Resonance', desc: 'Music theory, Pythagorean harmonics, acoustic science' },
   { slug: 'herbalism', name: 'Herbalism & Botany', desc: 'Herbals, materia medica, botanical illustration, plant taxonomy' },
   { slug: 'leonardo-da-vinci', name: 'Leonardo da Vinci', desc: 'Manuscripts, codices, treatises by Leonardo da Vinci' },
@@ -42,7 +41,7 @@ const COLLECTIONS = [
 
 const TRADITIONS = [
   'christianity', 'judaism', 'islam', 'buddhism', 'hinduism', 'daoism',
-  'zoroastrianism', 'hermetica-sacred', 'manichaeism', 'mandaeanism',
+  'zoroastrianism', 'gnostic-texts', 'manichaeism', 'mandaeanism',
   'jainism', 'confucianism', 'ancient-egyptian', 'orphism-mysteries',
   'norse-germanic', 'shinto', 'sikhism', 'indigenous-traditions',
   'druze', 'bahai', 'sumerian-mesopotamian', 'ancient-greek-religion',


### PR DESCRIPTION
The #3002 audit's membership check caught a book that re-acquired `hermetica-sacred` within a day of the merge. Cause: every AI collection-assignment surface still listed retired slugs as valid targets, so assignment passes would silently undo the merge cleanup indefinitely.

- **enrich-worker Phase 7.6** now excludes `merged_into` docs and any slug in `src/lib/collection-redirects.json` (the retirement registry — covers the hidden `philosophy` umbrella, which has no `merged_into` marker) from its valid-target set.
- **`src/lib/collection-relevance.ts`** + **`backfill-collection-relevance.mjs`**: `science-mathematics` → `mathematics`, `philosophy` entry dropped, `hermetica-sacred` → `gnostic-texts` in TRADITIONS.
- **`assign-sacred-traditions.mjs`**: the full `hermetica-sacred` collection *definition* removed (this script can create collection docs — it could resurrect the retired one). **`assign-sacred-subcollections.mjs`** routes sacred-Hermetic/Gnostic texts to `gnostic-texts`.
- `cache-temperature.mjs` warm list updated.
- Straggler book re-cleaned (data, already applied).

Scripts-only + one src lib; Hetzner picks the worker change up on auto-pull. `audit-collections.mjs` check 7 continues to flag any recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)