### PR TITLE
feat(first-translation): credit verified prior human translations (#3026)

### DIFF
--- a/scripts/maintenance/apply-tibetan-container-verdicts.mjs
+++ b/scripts/maintenance/apply-tibetan-container-verdicts.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * apply-tibetan-container-verdicts.mjs — write graded verdicts for the Tibetan
+ * work-identity resolution (#2318/#3026), the DEMOTE side.
+ *
+ * Two demote reasons, distinct verdicts:
+ *   - miscellany_container / collected_works → verdict `not_applicable`. A thor bu
+ *     / lettered-volume / monastery liturgical bundle is not a single work, so a
+ *     first-translation claim never applied. NOT a "someone beat us" defeat — the
+ *     content itself (multiple distinct texts under one cover) is the evidence.
+ *   - already-translated canonical work → verdict `not_first` with its prior.
+ *
+ * Writes book.first_translation (verdict) + a claude_subagent_verify provenance
+ * attempt (result:none for na/container is wrong — use result 'na'/'found').
+ * Does NOT touch is_first_translation; the --ids-scoped reconcile flips the flag.
+ *
+ * Dry-run by default. --apply writes. --in <classification.jsonl> --ids <demote-ids.txt>
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+const args = process.argv.slice(2);
+const getArg = (n, d) => { const i = args.indexOf(n); return i >= 0 && args[i + 1] ? args[i + 1] : d; };
+const APPLY = args.includes('--apply');
+const IN = getArg('--in', null);
+const IDS = getArg('--ids', null);
+if (!IN || !IDS || !process.env.MONGODB_URI) { console.error('need --in <classification.jsonl> --ids <ids.txt> and MONGODB_URI'); process.exit(1); }
+
+const nowIso = new Date().toISOString();
+const attemptId = (bid) => 'a_' + createHash('sha1').update(`${bid}|tibetan-workid|na`).digest('hex').slice(0, 20);
+
+const demoteIds = new Set(readFileSync(IDS, 'utf8').trim().split('\n').map(s => s.trim()).filter(Boolean));
+const cls = new Map();
+for (const line of readFileSync(IN, 'utf8').trim().split('\n').filter(Boolean)) {
+  const r = JSON.parse(line);
+  cls.set(r.book_id, r);
+}
+
+const c = await MongoClient.connect(process.env.MONGODB_URI);
+const db = c.db('bookstore');
+const books = db.collection('books');
+const attempts = db.collection('first_translation_attempts');
+
+const stats = { na: 0, nf: 0, notFound: 0, wrote: 0, skippedNoClass: 0 };
+for (const bid of demoteIds) {
+  const r = cls.get(bid);
+  if (!r) { stats.skippedNoClass++; continue; }
+  const verdict = r.ft_verdict === 'not_first' ? 'not_first' : 'not_applicable';
+  const or = [{ id: String(bid) }];
+  if (/^[0-9a-f]{24}$/.test(String(bid))) or.push({ _id: new ObjectId(String(bid)) });
+  const book = await books.findOne({ $or: or }, { projection: { _id: 1, id: 1, work_id: 1 } });
+  if (!book) { stats.notFound++; continue; }
+  const aid = attemptId(String(book.id || book._id));
+  const ft = {
+    verdict,
+    evidence_strength: r.confidence === 'high' ? 'strong' : 'moderate',
+    our_completeness: 'unknown',
+    match_key: 'none',
+    ...(verdict === 'not_first' ? { prior_relationship: 'same_text' } : {}),
+    resolver: 'tier2_agent',
+    best_attempt_id: aid,
+    resolved_at: nowIso,
+  };
+  const attemptDoc = {
+    attempt_id: aid, book_id: String(book.id || book._id), work_id: book.work_id || null,
+    date: nowIso, method: 'claude_subagent_verify', match_key: 'none',
+    sources_checked: r.sources || [], queries: [],
+    result: verdict === 'not_first' ? 'found' : 'na',
+    evidence_strength: ft.evidence_strength,
+    model: 'claude-sonnet (tibetan work-identity #2318, content-verified)',
+    notes: `[tibetan-workid ${r.classification || verdict}] ${(r.reasoning || '').slice(0, 500)}`,
+    _src: 'tibetan-workid-resolution',
+    ...(r.prior ? { priors: [{ english_title: r.prior.work_title, translator: (r.prior.translators || [])[0], pub_year: r.prior.year, publisher: r.prior.publisher, source_url: r.prior.url }] } : {}),
+  };
+  if (verdict === 'not_first') stats.nf++; else stats.na++;
+  if (APPLY) {
+    await attempts.updateOne({ attempt_id: aid }, { $set: attemptDoc }, { upsert: true });
+    await books.updateOne({ _id: book._id }, { $set: { first_translation: ft } });
+    stats.wrote++;
+  }
+}
+
+console.log(`not_applicable: ${stats.na} | not_first: ${stats.nf} | notFound: ${stats.notFound} | no-classification: ${stats.skippedNoClass}`);
+if (!APPLY) console.log(`\nDRY-RUN. Would write ${stats.na + stats.nf} verdicts. Re-run --apply, then reconcile-first-translation-flag.ts --ids=<ids> --apply`);
+else console.log(`\nAPPLIED. Wrote ${stats.wrote} verdicts + attempts. NOW: reconcile-first-translation-flag.ts --ids=<ids> --apply`);
+await c.close();

--- a/scripts/maintenance/badge-verified-firsts.mjs
+++ b/scripts/maintenance/badge-verified-firsts.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * badge-verified-firsts.mjs — write the graded first_translation VERDICT for
+ * two-stage-verified new firsts found by the #3026 inverse search, plus their
+ * provenance attempt. It does NOT set the public is_first_translation boolean —
+ * that stays the single job of reconcile-first-translation-flag.ts (run it
+ * after, scoped `--resolver=tier2_agent`, gated on Derek's sign-off).
+ *
+ * Each input row is a confirmed_first that survived adversarial ft-verify
+ * (Stage-2). We write:
+ *   Sink A  first_translation_attempts — one claude_subagent_verify row per book
+ *           (result:'none' = searched, no prior), with the actual queries+sources.
+ *   Sink B  book.first_translation — the graded verdict (first_no_prior /
+ *           first_modern / first_complete), resolver tier2_agent, evidence
+ *           moderate|strong (never weak → clears canPromoteToFirst).
+ *
+ * our_completeness:'complete' — our items are complete translations (required so
+ * a first_complete verdict actually badges via isFirstByVerdict).
+ *
+ * Dry-run by default. --apply writes. --limit N caps.
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/badge-verified-firsts.mjs --in <file.jsonl>
+ *   node scripts/maintenance/badge-verified-firsts.mjs --in <file.jsonl> --apply
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+const args = process.argv.slice(2);
+const getArg = (n, d) => { const i = args.indexOf(n); return i >= 0 && args[i + 1] ? args[i + 1] : d; };
+const APPLY = args.includes('--apply');
+const IN = getArg('--in', null);
+const LIMIT = parseInt(getArg('--limit', '0'), 10) || 0;
+if (!IN || !process.env.MONGODB_URI) { console.error('need --in <file> and MONGODB_URI'); process.exit(1); }
+
+const TYPE_TO_VERDICT = { no_prior: 'first_no_prior', first_modern: 'first_modern', first_complete: 'first_complete' };
+const nowIso = new Date().toISOString();
+
+function attemptId(bookId) {
+  return 'a_' + createHash('sha1').update(`${bookId}|claude_subagent_verify|3026-inverse`).digest('hex').slice(0, 20);
+}
+
+const rows = readFileSync(IN, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+const batch = LIMIT ? rows.slice(0, LIMIT) : rows;
+console.log(`Loaded ${rows.length} verified firsts${LIMIT ? `, capped to ${batch.length}` : ''}`);
+
+const c = await MongoClient.connect(process.env.MONGODB_URI);
+const db = c.db('bookstore');
+const books = db.collection('books');
+const attempts = db.collection('first_translation_attempts');
+
+const stats = { matched: 0, notFound: 0, alreadyFirst: 0, wroteVerdict: 0, wroteAttempt: 0, byVerdict: {} };
+for (const r of batch) {
+  const verdict = TYPE_TO_VERDICT[r.first_type];
+  if (!verdict) { console.log('  skip unknown first_type', r.first_type, r.book_id); continue; }
+  const or = [{ id: String(r.book_id) }];
+  if (/^[0-9a-f]{24}$/.test(String(r.book_id))) or.push({ _id: new ObjectId(String(r.book_id)) });
+  const book = await books.findOne({ $or: or }, { projection: { _id: 1, id: 1, title: 1, is_first_translation: 1, first_translation: 1, work_id: 1 } });
+  if (!book) { stats.notFound++; console.log('  NOT FOUND', r.book_id, r.title); continue; }
+  stats.matched++;
+  if (book.is_first_translation === true) stats.alreadyFirst++;
+
+  const aid = attemptId(String(book.id || book._id));
+  const ft = {
+    verdict,
+    evidence_strength: r.confidence === 'high' ? 'strong' : 'moderate',
+    our_completeness: 'complete',
+    match_key: (book.work_id || r.work_id) ? 'work_id' : 'author_title',
+    resolver: 'tier2_agent',
+    best_attempt_id: aid,
+    resolved_at: nowIso,
+  };
+  stats.byVerdict[verdict] = (stats.byVerdict[verdict] || 0) + 1;
+
+  const attemptDoc = {
+    attempt_id: aid,
+    book_id: String(book.id || book._id),
+    work_id: book.work_id || r.work_id || null,
+    date: nowIso,
+    method: 'claude_subagent_verify',
+    match_key: ft.match_key,
+    sources_checked: r.sources || [],
+    queries: r.queries || [],
+    result: 'none',
+    evidence_strength: ft.evidence_strength,
+    model: 'claude-sonnet (inverse-search #3026, two-stage)',
+    notes: `[3026-inverse ${r.first_type}] ${r.reasoning || ''}`,
+    _src: '3026-inverse-search',
+  };
+
+  if (APPLY) {
+    await attempts.updateOne({ attempt_id: aid }, { $set: attemptDoc }, { upsert: true });
+    await books.updateOne({ _id: book._id }, { $set: { first_translation: ft } });
+    stats.wroteAttempt++; stats.wroteVerdict++;
+  }
+}
+
+console.log(`\nmatched ${stats.matched} / notFound ${stats.notFound} / already-badged-first ${stats.alreadyFirst}`);
+console.log('verdicts:', JSON.stringify(stats.byVerdict));
+if (!APPLY) console.log(`\nDRY-RUN. Would write ${stats.matched} verdicts + attempts. Re-run --apply, then reconcile-first-translation-flag.ts --apply --resolver=tier2_agent`);
+else console.log(`\nAPPLIED. Wrote ${stats.wroteVerdict} verdicts + ${stats.wroteAttempt} attempts. NOW RUN: reconcile-first-translation-flag.ts --apply --resolver=tier2_agent`);
+await c.close();

--- a/scripts/maintenance/badge-verified-firsts.mjs
+++ b/scripts/maintenance/badge-verified-firsts.mjs
@@ -33,7 +33,7 @@ const IN = getArg('--in', null);
 const LIMIT = parseInt(getArg('--limit', '0'), 10) || 0;
 if (!IN || !process.env.MONGODB_URI) { console.error('need --in <file> and MONGODB_URI'); process.exit(1); }
 
-const TYPE_TO_VERDICT = { no_prior: 'first_no_prior', first_modern: 'first_modern', first_complete: 'first_complete' };
+const TYPE_TO_VERDICT = { no_prior: 'first_no_prior', first_modern: 'first_modern', first_complete: 'first_complete', first_from_source: 'first_from_source' };
 const nowIso = new Date().toISOString();
 
 function attemptId(bookId) {
@@ -66,6 +66,11 @@ for (const r of batch) {
     evidence_strength: r.confidence === 'high' ? 'strong' : 'moderate',
     our_completeness: 'complete',
     match_key: (book.work_id || r.work_id) ? 'work_id' : 'author_title',
+    // first_from_source: the work exists in English from a DIFFERENT source (or
+    // is itself a translation, e.g. the Dutch-from-English voyages) — ours is
+    // the first translation of THIS text/witness. The relationship records why
+    // the existing English does not defeat the claim.
+    ...(verdict === 'first_from_source' ? { prior_relationship: 'different_source_language' } : {}),
     resolver: 'tier2_agent',
     best_attempt_id: aid,
     resolved_at: nowIso,

--- a/scripts/maintenance/ingest-prior-translations.mjs
+++ b/scripts/maintenance/ingest-prior-translations.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Ingest verified prior-translation credits into books.prior_translation (issue #3026).
+ *
+ * Input: the adversarially-verified sweep output (JSONL, one record per book)
+ * produced by the Sonnet parse+verify workflow. Each record carries a parsed
+ * edition, a verification block, and a publishable verdict.
+ *
+ * THE GATE (same bar as quotes — verified, not trusted): we write ONLY records
+ * that are publishable AND verified AND carry a resolvable http(s) URL. A named
+ * translator with no reachable source is exactly the fabrication risk the whole
+ * first-translation stack exists to prevent — those never ship. We also refuse
+ * to write a credit onto a book we currently badge as a FIRST translation
+ * (is_first_translation true with pages translated): a verified prior and a
+ * first badge contradict each other, and that conflict is a human-review item,
+ * not something to paper over.
+ *
+ * Default is DRY-RUN. Pass --apply to write. --limit N caps writes.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/ingest-prior-translations.mjs --in <file.jsonl>            # dry-run
+ *   node scripts/maintenance/ingest-prior-translations.mjs --in <file.jsonl> --apply    # write
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+const getArg = (name, def) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : def;
+};
+const APPLY = args.includes('--apply');
+const IN = getArg('--in', null);
+const LIMIT = parseInt(getArg('--limit', '0'), 10) || 0;
+const REPORT = getArg('--report', null);
+
+if (!IN) {
+  console.error('Missing --in <verified-sweep.jsonl>');
+  process.exit(1);
+}
+if (!process.env.MONGODB_URI) {
+  console.error('MONGODB_URI not set — source .env.production.local first');
+  process.exit(1);
+}
+
+const URL_RE = /^https?:\/\/\S+$/i;
+
+/** Map a sweep record → the PriorTranslationCredit doc, or a rejection reason. */
+function toCredit(rec, nowIso) {
+  if (!rec || !rec.book_id) return { skip: 'no book_id' };
+  if (!rec.publishable) return { skip: 'not marked publishable' };
+  if (!rec.verified) return { skip: 'not verified' };
+  const p = rec.parsed || {};
+  const v = rec.verification || {};
+  const url = (v.url || '').trim();
+  if (!URL_RE.test(url)) return { skip: 'no resolvable url' };
+  const work_title = (p.work_title || '').trim();
+  if (!work_title) return { skip: 'no work_title' };
+
+  const translators = Array.isArray(p.translators)
+    ? p.translators.map((s) => String(s).trim()).filter(Boolean).filter((s) => !/^unknown$/i.test(s))
+    : [];
+  const scope = ['complete', 'partial', 'unclear'].includes(p.scope) ? p.scope : 'unclear';
+  const method = ['worldcat', 'publisher', 'google_books', 'library_catalog', 'other'].includes(v.method)
+    ? v.method
+    : 'other';
+
+  const credit = {
+    work_title,
+    translators,
+    scope,
+    url,
+    verification_method: method,
+    verified_at: nowIso,
+  };
+  if (Number.isInteger(p.year)) credit.year = p.year;
+  if (p.publisher) credit.publisher = String(p.publisher).trim();
+  if (p.series) credit.series = String(p.series).trim();
+  if (v.oclc) credit.oclc = String(v.oclc).trim();
+  if (v.isbn) credit.isbn = String(v.isbn).trim();
+  if (v.evidence) credit.evidence = String(v.evidence).trim();
+  if (rec.attempt_id) credit.source_attempt_id = String(rec.attempt_id);
+  return { credit };
+}
+
+async function main() {
+  const nowIso = new Date().toISOString();
+  const lines = readFileSync(IN, 'utf8').trim().split('\n').filter(Boolean);
+  const recs = lines.map((l) => JSON.parse(l));
+  console.log(`Loaded ${recs.length} sweep records from ${IN}`);
+
+  const client = await MongoClient.connect(process.env.MONGODB_URI);
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+
+  const stats = { total: recs.length, publishable: 0, skipped: {}, firstBadgeConflict: 0, notFound: 0, wrote: 0 };
+  const conflicts = [];
+  const toWrite = [];
+
+  for (const rec of recs) {
+    const { credit, skip } = toCredit(rec, nowIso);
+    if (skip) {
+      stats.skipped[skip] = (stats.skipped[skip] || 0) + 1;
+      continue;
+    }
+    stats.publishable++;
+
+    // Resolve the book by string id OR Mongo _id.
+    const or = [{ id: String(rec.book_id) }];
+    if (/^[0-9a-f]{24}$/.test(String(rec.book_id))) or.push({ _id: new ObjectId(String(rec.book_id)) });
+    const book = await books.findOne(
+      { $or: or },
+      { projection: { _id: 1, id: 1, title: 1, is_first_translation: 1, pages_translated: 1 } },
+    );
+    if (!book) {
+      stats.notFound++;
+      continue;
+    }
+
+    // Never overwrite a live first-translation badge with a "prior exists" credit.
+    if (book.is_first_translation && (book.pages_translated ?? 0) > 0) {
+      stats.firstBadgeConflict++;
+      conflicts.push({ book_id: String(rec.book_id), title: book.title, credit });
+      continue;
+    }
+
+    toWrite.push({ _id: book._id, id: book.id, title: book.title, credit });
+  }
+
+  console.log('\n── Gate summary ──');
+  console.log(`  publishable (verified + linked): ${stats.publishable}`);
+  console.log(`  first-badge conflicts (need review, NOT written): ${stats.firstBadgeConflict}`);
+  console.log(`  book not found: ${stats.notFound}`);
+  console.log(`  writable: ${toWrite.length}`);
+  console.log('  skips:', JSON.stringify(stats.skipped));
+
+  if (REPORT) {
+    writeFileSync(REPORT, JSON.stringify({ nowIso, stats, conflicts, toWrite: toWrite.map(w => ({ id: w.id, title: w.title, credit: w.credit })) }, null, 2));
+    console.log(`\nWrote report → ${REPORT}`);
+  }
+
+  const batch = LIMIT ? toWrite.slice(0, LIMIT) : toWrite;
+  console.log('\n── Sample (first 5 writable) ──');
+  for (const w of batch.slice(0, 5)) {
+    const t = w.credit.translators.join(', ') || '—';
+    console.log(`  ${w.title} → "${w.credit.work_title}" trans. ${t}${w.credit.year ? ` (${w.credit.year})` : ''} [${w.credit.verification_method}] ${w.credit.url}`);
+  }
+
+  if (!APPLY) {
+    console.log(`\nDRY-RUN. Would write ${batch.length} credits. Re-run with --apply to write.`);
+    await client.close();
+    return;
+  }
+
+  for (const w of batch) {
+    const r = await books.updateOne({ _id: w._id }, { $set: { prior_translation: w.credit } });
+    if (r.modifiedCount === 1 || r.matchedCount === 1) stats.wrote++;
+  }
+  console.log(`\nAPPLIED. Wrote prior_translation to ${stats.wrote} books.`);
+  await client.close();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/maintenance/reconcile-first-translation-flag.ts
+++ b/scripts/maintenance/reconcile-first-translation-flag.ts
@@ -15,6 +15,7 @@
  *   npx tsx scripts/maintenance/reconcile-first-translation-flag.ts --only-demotions   # just flag:true -> derived:false
  *   npx tsx scripts/maintenance/reconcile-first-translation-flag.ts --apply    # WRITE (asks nothing — be sure)
  */
+import { readFileSync } from 'node:fs';
 import { getDb } from '@/lib/mongodb';
 import { isFirstByVerdict, firstTranslationVerdict, canPromoteToFirst } from '@/lib/first-translation/derive';
 import type { FirstTranslationBook } from '@/lib/first-translation/types';
@@ -35,6 +36,18 @@ const VERDICT_FILTER = (args.find((a) => a.startsWith('--verdict='))?.split('=')
  */
 const RESOLVER_FILTER = (args.find((a) => a.startsWith('--resolver='))?.split('=')[1] || '')
   .split(',').map((s) => s.trim()).filter(Boolean);
+/**
+ * Restrict the write (BOTH promotions and demotions) to an explicit set of book
+ * ids/_ids from a newline-separated file. This is the surgical, multi-session-safe
+ * path: apply exactly the flips you signed off on, without sweeping in the rest
+ * of the pending queue. Unlike --verdict/--resolver (which scope demotions and
+ * suppress promotions), --ids scopes and PERMITS promotions within the id set.
+ */
+const IDS_FILE = args.find((a) => a.startsWith('--ids='))?.split('=')[1] || '';
+const IDS = new Set(
+  IDS_FILE ? readFileSync(IDS_FILE, 'utf8').split('\n').map((s) => s.trim()).filter(Boolean) : [],
+);
+const inIds = (b: BookDoc) => IDS.has(String(b.id ?? '')) || IDS.has(String(b._id));
 
 interface BookDoc extends FirstTranslationBook {
   _id: unknown;
@@ -135,8 +148,19 @@ async function main() {
     demoteSet = demoteSet.filter((b) => RESOLVER_FILTER.includes(b.first_translation?.resolver ?? 'none'));
     console.log(`--resolver filter ${JSON.stringify(RESOLVER_FILTER)} -> writing ${demoteSet.length} of ${before} demotions`);
   }
+  // --ids: surgical scope. Restrict BOTH directions to the signed-off id set;
+  // promotions ARE permitted here (the id set IS the sign-off).
+  let promoteSet = promotions;
+  if (IDS.size) {
+    const beforeD = demoteSet.length, beforeP = promoteSet.length;
+    demoteSet = demoteSet.filter(inIds);
+    promoteSet = promoteSet.filter(inIds);
+    console.log(`--ids filter (${IDS.size} ids) -> ${demoteSet.length} of ${beforeD} demotions, ${promoteSet.length} of ${beforeP} promotions`);
+  }
   const toDemote = demoteSet.map((b) => b._id);
-  const toPromote = (ONLY_DEMOTIONS || VERDICT_FILTER.length || RESOLVER_FILTER.length) ? [] : promotions.map((b) => b._id);
+  const toPromote = IDS.size
+    ? promoteSet.map((b) => b._id)
+    : (ONLY_DEMOTIONS || VERDICT_FILTER.length || RESOLVER_FILTER.length) ? [] : promotions.map((b) => b._id);
   let demoted = 0, promoted = 0;
   if (toDemote.length) {
     const r = await books.updateMany(

--- a/src/components/book/FirstTranslationEvidence.tsx
+++ b/src/components/book/FirstTranslationEvidence.tsx
@@ -33,6 +33,12 @@ import {
   type LegacyDisposition,
 } from '@/lib/first-translation/types';
 import { firstTranslationBadge, firstTranslationDescription } from '@/lib/first-translation-labels';
+import type { PriorTranslationCredit } from '@/lib/types/book';
+import {
+  hasPublishablePriorTranslation,
+  priorLinkLabel,
+  priorTranslationSentence,
+} from '@/lib/prior-translation';
 
 interface LegacyPrior {
   english_title?: string;
@@ -47,6 +53,7 @@ interface EvidenceBook {
   language?: string;
   is_first_translation?: boolean;
   pages_translated?: number | null;
+  prior_translation?: PriorTranslationCredit;
   first_translation?: {
     verdict?: FirstTranslationVerdict;
     evidence_strength?: string;
@@ -103,6 +110,43 @@ function PriorList({ priors }: { priors: NormalizedPrior[] }) {
           )}
         </p>
       ))}
+    </div>
+  );
+}
+
+/**
+ * The verified prior-translation credit (issue #3026) — the un-extractive move.
+ *
+ * Shown, quietly and always-visible, ONLY when the prior human edition resolved
+ * to a real bibliographic record with a live link. Courtesy framing, not a
+ * storefront: name the translator, and point the reader to where the scholar's
+ * edition can be read or found. The link is a hard requirement — a credit with
+ * no reachable destination doesn't ship, so `hasPublishablePriorTranslation`
+ * has already guaranteed `url` before we render.
+ */
+function PriorTranslationCreditLine({
+  prior,
+  showExternalLinks,
+}: {
+  prior: PriorTranslationCredit;
+  showExternalLinks: boolean;
+}) {
+  return (
+    <div className="mt-3 text-xs text-stone-400 leading-relaxed">
+      <span className="italic text-stone-300">{priorTranslationSentence(prior)}</span>
+      {showExternalLinks && (
+        <>
+          {' '}
+          <a
+            href={prior.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-gold hover:text-accent-gold/80 whitespace-nowrap"
+          >
+            {priorLinkLabel(prior)} &rarr;
+          </a>
+        </>
+      )}
     </div>
   );
 }
@@ -253,7 +297,22 @@ export default async function FirstTranslationEvidence({
   const isFirst = !!verdict && FIRST_FAMILY.has(verdict) && published;
   const isExisting = verdict === 'not_first';
 
-  if (!isFirst && !isExisting) return null;
+  // A verified, publishable prior-translation credit (#3026). Populated only on
+  // non-first books whose prior edition resolved to a real record with a link.
+  // It's the honest headline for a not_first book, so it shows even when the
+  // verdict resolution is thin — but never on a book we badge as a first.
+  const publishablePrior = !isFirst && hasPublishablePriorTranslation(book)
+    ? book.prior_translation
+    : null;
+
+  if (!isFirst && !isExisting && !publishablePrior) return null;
+
+  // A verified credit is self-contained (no attempt-log read needed) and
+  // supersedes the unverified "Existing translations" panel — render the quiet,
+  // always-visible courtesy line with its link and stop.
+  if (publishablePrior) {
+    return <PriorTranslationCreditLine prior={publishablePrior} showExternalLinks={showExternalLinks} />;
+  }
 
   // Always read the accumulated evidence pile. Since the #2802 backfill lifted
   // legacy disposition evidence into the attempt log (13k+ books), most claims —

--- a/src/lib/prior-translation.ts
+++ b/src/lib/prior-translation.ts
@@ -1,0 +1,70 @@
+/**
+ * Prior human translation credit — reader gate + link labeling (issue #3026).
+ *
+ * When a book is NOT the first English translation, we credit the human
+ * translation that came before and point the reader to where it can be read or
+ * bought. This is the un-extractive move: name the (usually invisible, often
+ * underpaid) translator and send serious readers to the scholar's edition.
+ *
+ * The hard rule — same bar as quotes — is VERIFIED, not trusted. The prose
+ * these credits are parsed from was written by Gemini, and the entire
+ * first-translation stack exists because AI fabricates priors. A credit only
+ * renders once its named edition resolved to a real bibliographic record AND
+ * carries a resolvable link. A name with no reachable source is just a name, so
+ * a missing/empty `url` is disqualifying on its own.
+ */
+
+import type { Book, PriorTranslationCredit } from '@/lib/types/book';
+
+/** Does this book carry a publishable prior-translation credit? */
+export function hasPublishablePriorTranslation(
+  book: Pick<Book, 'prior_translation'>,
+): book is Pick<Book, 'prior_translation'> & { prior_translation: PriorTranslationCredit } {
+  const p = book.prior_translation;
+  return !!p && typeof p.url === 'string' && /^https?:\/\//.test(p.url) && !!p.work_title;
+}
+
+/** Human label for the outbound link, by how the edition was confirmed. */
+export function priorLinkLabel(p: PriorTranslationCredit): string {
+  switch (p.verification_method) {
+    case 'worldcat':
+      return 'Find it in a library';
+    case 'publisher':
+      return 'View at publisher';
+    case 'google_books':
+      return 'View on Google Books';
+    case 'library_catalog':
+      return 'Find it in a library';
+    default:
+      return 'Find it';
+  }
+}
+
+/** "trans. A, B and C" — Oxford-free join of translator names. */
+export function formatTranslators(translators: string[]): string {
+  const names = (translators || []).filter(Boolean);
+  if (names.length === 0) return '';
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+}
+
+/**
+ * The one-line courtesy sentence, minus the link.
+ * e.g. "A published English translation exists: De Subtilitate, trans. John M.
+ * Forrester (ACMRS, 2013)."  Partial editions say so, honestly.
+ */
+export function priorTranslationSentence(p: PriorTranslationCredit): string {
+  const lead =
+    p.scope === 'partial'
+      ? 'A partial published English translation exists:'
+      : 'A published English translation exists:';
+  const bits: string[] = [p.work_title];
+  const translators = formatTranslators(p.translators);
+  if (translators) bits.push(`trans. ${translators}`);
+  const paren: string[] = [];
+  if (p.publisher) paren.push(p.publisher);
+  if (p.year) paren.push(String(p.year));
+  const tail = paren.length ? ` (${paren.join(', ')})` : '';
+  return `${lead} ${bits.join(', ')}${tail}.`;
+}

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -96,6 +96,14 @@ export interface Book {
   // Translation verification (catalog search + LLM knowledge check)
   translation_verification?: TranslationVerification;
 
+  // Prior human English translation credit (issue #3026). Present ONLY on books
+  // that are NOT the first English translation AND whose prior edition has been
+  // independently confirmed to exist in a real bibliographic record (WorldCat /
+  // publisher / library catalog) with a resolvable link. This is the verified,
+  // publishable half of the first-translation search — never render an
+  // unverified `translation_verification.translations_found` row as this credit.
+  prior_translation?: PriorTranslationCredit;
+
   // Dublin Core metadata for library interoperability
   dublin_core?: DublinCoreMetadata;
 
@@ -372,6 +380,41 @@ export interface TranslationVerification {
   tools_called?: string[];
   verified_at?: Date;
   model?: string;
+}
+
+/**
+ * A verified prior human English translation (issue #3026).
+ *
+ * Written ONLY after the named edition resolves to a real bibliographic record
+ * with a live, resolvable URL. The whole point of the credit is that a reader
+ * can act on it — so `url` is required and no record publishes without one.
+ * Populated by scripts/maintenance/ingest-prior-translations.mjs from the
+ * adversarially-verified sweep output; the reader gate is
+ * `hasPublishablePriorTranslation()` in src/lib/prior-translation.ts.
+ */
+export interface PriorTranslationCredit {
+  /** Title of the prior English edition. */
+  work_title: string;
+  /** Named translator(s). May be empty for anonymous/committee editions. */
+  translators: string[];
+  year?: number;
+  publisher?: string;
+  /** Scholarly series, e.g. "I Tatti Renaissance Library". */
+  series?: string;
+  /** Whether the prior edition is a complete or partial rendering. */
+  scope: 'complete' | 'partial' | 'unclear';
+  /** Live URL a reader follows to reach the edition (publisher / WorldCat / catalog). */
+  url: string;
+  /** How the edition was confirmed — drives outbound-link framing/priority. */
+  verification_method: 'worldcat' | 'publisher' | 'google_books' | 'library_catalog' | 'other';
+  oclc?: string;
+  isbn?: string;
+  /** One-sentence record of what confirmed the edition, for auditability. */
+  evidence?: string;
+  /** attempt_id in first_translation_attempts this credit was parsed from. */
+  source_attempt_id?: string;
+  /** ISO timestamp the credit was verified/ingested. */
+  verified_at?: string;
 }
 
 export interface TranslationEvidence {


### PR DESCRIPTION
Closes the P1 (data) + P2 (reader) core of #3026 — stop discarding the *positive* half of the first-translation search. When a book is **not** the first English translation, credit the human translation that came before and link the reader to where it can be read or found.

## What ships here (P2 reader + writer)

- **`book.prior_translation` (`PriorTranslationCredit`)** — a verified prior edition with a **required** resolvable URL, distinct from the unverified `translation_verification`. Same bar as quotes: verified, not trusted.
- **`src/lib/prior-translation.ts`** — reader gate (`hasPublishablePriorTranslation` requires an `http(s)` url + title), courtesy sentence, link labeling (WorldCat → "Find it in a library", publisher → "View at publisher").
- **`FirstTranslationEvidence.tsx`** — a quiet, always-visible credit line that supersedes the unverified "Existing translations" panel and **never renders on a book badged as a first**. The book page needs no change — its fetch uses exclusion projections so the field flows through.
- **`scripts/maintenance/ingest-prior-translations.mjs`** — dry-run-by-default writer. Gates on publishable + verified + resolvable url; **refuses to write a credit onto a live first-translation badge** and files those as review conflicts.

## The data (P1) — verified, not trusted

Ran the parse + adversarial-verify loop over all **2,175** `not_first` seed books (Sonnet agents, subscription — **zero Gemini spend**; the Gemini adjudicator already paid for the underlying search). Each named edition was independently confirmed against WorldCat / publisher / library catalog / Google Books before it could publish.

| outcome | count |
|---|---|
| publishable (verified + resolvable link) | 1,879 |
| — of which **clean writable credits** (non-first) | **1,417** |
| — of which **first-badge conflicts** (held for FT review) | **460** |
| verified but no resolvable link | 27 |
| unverified / rejected (fabrication gate) | 269 |

Writable set: 1,369/1,417 name a translator; scope 1,099 complete / 293 partial / 25 unclear; link mix even across WorldCat / publisher / library-catalog / other.

**The fabrication gate earned its keep** — 269 (~12%) failed independent verification (anonymous AI Substacks, phantom translators, 404'd publisher pages). None publish.

## Out of scope / follow-up

- **The 460 first-badge conflicts are demote _candidates_, not demotes.** A verified prior does not always defeat "first" — partial/excerpt priors, anthologies, and different-source-language editions survive under the graded-verdict rules (#2564). They route to the `ft-verify` flow; this PR only withholds the credit, it flips no badge.
- Mongo write (`--apply`) is **not** run in this PR — the field renders nothing until this deploys, and the writable set awaits sign-off.
- P3 (affiliate/buy links, "standard scholarly" edition selection) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)