### PR TITLE
fix(collections): remove phantom dance-of-death pathway (#3008 part 2)

### DIFF
--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -91,7 +91,10 @@ const CURATED_PATHWAYS = [
   'women-of-the-secret-tradition',
   'alchemical-emblem',
   'ficinos-florence',
-  'dance-of-death',
+  // 'dance-of-death' removed: no collection doc with this slug exists, so
+  // fetchCuratedPathways silently dropped it (one fewer card than intended).
+  // 47 books are tagged with it — if a real Dance of Death collection is
+  // created later, re-add the slug here. See issue #3008.
   'bestiary-tradition',
   'ancient-egyptian',
   'art-of-memory',


### PR DESCRIPTION
## What
Removes `dance-of-death` from the `CURATED_PATHWAYS` array in `src/app/collections/page.tsx`.

No collection doc has `slug: 'dance-of-death'` (verified against prod: 29/30 pathway slugs resolve, this is the only phantom). `fetchCuratedPathways` already filters out nulls, so the live front door was silently rendering one fewer card than the array implied — no user-facing breakage, just a dead entry.

## Scope
- **In scope:** the phantom pathway removal (issue #3008 part 2).
- **Out of scope:** #3008 part 1 (19 dangling collection slugs on live books) — that edits book documents and per the Data Protection rule needs per-slug curator review, so it's left for a separate, reviewed pass.
- The 47 books tagged `dance-of-death` are untouched. If a real Dance of Death / danse macabre collection is created later (the material exists in the gallery), re-add the slug.

Resolves part 2 of #3008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)