### PR TITLE
fix(api): enforce Explorer-tier page cap on /text (close free bulk-extraction hole)

### DIFF
--- a/scripts/maintenance/api-key-usage-monitor.mjs
+++ b/scripts/maintenance/api-key-usage-monitor.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * api-key-usage-monitor.mjs — usage across ALL dataset API keys.
+ *
+ * Two independent usage signals exist and they measure different things:
+ *   1. api_usage            — every gated content-API call (/text, /quote, …),
+ *                             tagged with api_key_id + pages_served. THE real
+ *                             per-key traffic log (millions of docs).
+ *   2. dataset_access_log   — only the bulk dump route /api/dataset/v1/pages.
+ * `api_keys.last_used_at` is bumped on every key validation (both paths), so it
+ * shows liveness but not volume.
+ *
+ * NOTE on the business-model hole this surfaces: /text treats ANY valid key as
+ * the unlimited "apikey" tier (src/lib/api-budget.ts pickLimit), so a *free*
+ * explorer key is never page-capped on /text. Heavy explorer-tier extraction
+ * flagged below is exactly the bulk use the paid tiers are meant to price.
+ *
+ * Usage: node scripts/maintenance/api-key-usage-monitor.mjs [--days 7] [--json]
+ */
+import { MongoClient } from 'mongodb';
+
+const argv = process.argv.slice(2);
+const days = Number(argv[argv.indexOf('--days') + 1]) || 7;
+const asJson = argv.includes('--json');
+const since = new Date(Date.now() - days * 24 * 3600 * 1000);
+
+// Explorer keys pulling more than this many pages ever = bulk extraction worth a look.
+const BULK_PAGE_FLAG = 50000;
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+const keys = await db.collection('api_keys').find({}).project({ key_hash: 0 }).toArray();
+const kmap = new Map(keys.map((k) => [String(k._id), k]));
+
+// All-time per-key content traffic.
+const perKey = await db.collection('api_usage').aggregate([
+  { $match: { api_key_id: { $ne: null } } },
+  { $group: {
+      _id: '$api_key_id',
+      calls: { $sum: 1 },
+      pages: { $sum: '$pages_served' },
+      last: { $max: '$ts' },
+      blocked: { $sum: { $cond: ['$blocked', 1, 0] } },
+  } },
+  { $sort: { pages: -1 } },
+]).toArray();
+
+// Windowed per-key traffic (last N days).
+const perKeyWin = await db.collection('api_usage').aggregate([
+  { $match: { api_key_id: { $ne: null }, ts: { $gte: since } } },
+  { $group: { _id: '$api_key_id', calls: { $sum: 1 }, pages: { $sum: '$pages_served' } } },
+]).toArray();
+const winMap = new Map(perKeyWin.map((r) => [String(r._id), r]));
+
+const rows = perKey.map((r) => {
+  const k = kmap.get(String(r._id)) || {};
+  const w = winMap.get(String(r._id)) || { calls: 0, pages: 0 };
+  const bulk = (k.tier === 'explorer') && r.pages >= BULK_PAGE_FLAG;
+  return {
+    name: k.name || '?', tier: k.tier || '?', status: k.status || '?',
+    user_id: k.user_id, key_prefix: k.key_prefix,
+    all_calls: r.calls, all_pages: r.pages, blocked: r.blocked,
+    [`calls_${days}d`]: w.calls, [`pages_${days}d`]: w.pages,
+    last_used: r.last?.toISOString() || null, bulk_flag: bulk,
+  };
+});
+
+// Global context.
+const byKind = await db.collection('api_usage').aggregate([
+  { $match: { ts: { $gte: since } } },
+  { $group: { _id: '$identity_kind', calls: { $sum: 1 }, pages: { $sum: '$pages_served' } } },
+  { $sort: { calls: -1 } },
+]).toArray();
+
+if (asJson) {
+  console.log(JSON.stringify({ days, generated: new Date().toISOString(), rows, byKind }, null, 2));
+} else {
+  console.log(`\nAPI KEY USAGE — ${keys.length} keys total, window = last ${days}d\n`);
+  console.log('  key                              tier       all-time pages   all-time calls   ' + `${days}d pages   last used`);
+  for (const r of rows) {
+    const flag = r.bulk_flag ? '  ⚠ BULK' : '';
+    console.log(
+      '  ' + (r.name.slice(0, 30)).padEnd(32) +
+      r.tier.padEnd(11) +
+      String(r.all_pages).padStart(14) +
+      String(r.all_calls).padStart(17) +
+      String(r[`pages_${days}d`]).padStart(12) +
+      '   ' + (r.last_used?.slice(0, 16) || '-') + flag
+    );
+  }
+  const idle = keys.length - rows.length;
+  console.log(`\n  (${idle} keys have never made a gated content-API call)`);
+  console.log(`\n  Traffic by identity, last ${days}d:`);
+  for (const r of byKind) console.log(`    ${r._id.padEnd(9)} ${String(r.calls).padStart(10)} calls  ${String(r.pages).padStart(9)} pages`);
+  const flagged = rows.filter((r) => r.bulk_flag);
+  if (flagged.length) {
+    console.log(`\n  ⚠ ${flagged.length} explorer key(s) over ${BULK_PAGE_FLAG.toLocaleString()} pages — free-tier bulk extraction (uncapped on /text):`);
+    for (const r of flagged) console.log(`    ${r.name} — ${r.all_pages.toLocaleString()} pages (${r.user_id})`);
+  }
+}
+
+await client.close();

--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -337,12 +337,19 @@ export const GET = withApiAuth(async (
           last_page_served: budgetMaxPage,
           used_24h: budget.used,
           limit_24h: budget.limit,
-          note: `Served up to p.${budgetMaxPage}; the rest of this range is beyond your remaining daily page budget (${budget.used}/${budget.limit} used in 24h). Retrying immediately will be rate-limited — sign in or use an API key for a higher limit, or bulk-export instead.`,
-          next_steps: {
-            sign_in: 'https://sourcelibrary.org/auth/signin',
-            get_api_key: 'https://sourcelibrary.org/developers',
-            bulk_export: 'https://sourcelibrary.org/api/dataset/v1/pages',
-          },
+          note: budget.tier === 'apikey'
+            ? `Served up to p.${budgetMaxPage}; the rest of this range is beyond your Explorer key's daily page budget (${budget.used}/${budget.limit} used in 24h). Upgrade for uncapped /text access (https://sourcelibrary.org/licensing) or bulk-export instead.`
+            : `Served up to p.${budgetMaxPage}; the rest of this range is beyond your remaining daily page budget (${budget.used}/${budget.limit} used in 24h). Retrying immediately will be rate-limited — sign in or use an API key for a higher limit, or bulk-export instead.`,
+          next_steps: budget.tier === 'apikey'
+            ? {
+                upgrade: 'https://sourcelibrary.org/licensing',
+                bulk_export: 'https://sourcelibrary.org/api/dataset/v1/pages',
+              }
+            : {
+                sign_in: 'https://sourcelibrary.org/auth/signin',
+                get_api_key: 'https://sourcelibrary.org/developers',
+                bulk_export: 'https://sourcelibrary.org/api/dataset/v1/pages',
+              },
         },
       } : {}),
       pages: pagesWithContent.map(p => {

--- a/src/lib/api-budget.ts
+++ b/src/lib/api-budget.ts
@@ -17,6 +17,7 @@
 import type { ApiIdentity } from '@/lib/api-auth';
 import type { NextRequest } from 'next/server';
 import { getPagesServedLast24h } from '@/lib/api-usage';
+import { DATASET_TIERS, type DatasetTier } from '@/lib/dataset/types';
 
 export interface BudgetCheck {
   allowed: boolean;
@@ -38,9 +39,31 @@ export interface BudgetCheck {
 const ANON_DAILY_PAGES = Number(process.env.API_ANON_PAGES_PER_DAY || 500);
 const SESSION_DAILY_PAGES = Number(process.env.API_SESSION_PAGES_PER_DAY || 1000);
 
-function pickLimit(identity: ApiIdentity): { limit: number; tier: BudgetCheck['tier'] } {
-  if (identity.kind === 'apikey' || identity.kind === 'bot') {
+/**
+ * Map a caller identity to its daily /text page limit. Exported for unit tests
+ * that pin the business-model invariant (free Explorer keys are capped; paid
+ * tiers are not). `Number.POSITIVE_INFINITY` means uncapped.
+ */
+export function pickLimit(identity: ApiIdentity): { limit: number; tier: BudgetCheck['tier'] } {
+  // Verified bots (Googlebot etc.) stay unlimited — SEO indexing must never wall.
+  if (identity.kind === 'bot') {
     return { limit: Number.POSITIVE_INFINITY, tier: 'apikey' };
+  }
+  // API keys honour their TIER's published daily page cap on /text — not a blanket
+  // pass. Paid tiers (language/domain/full/enterprise) carry pagesPerDay: 0 =
+  // unlimited, so they're unaffected. The free Explorer tier keeps its published
+  // 100 pages/day here too; without this a free key was an uncapped bulk-extraction
+  // token (the /text budget treated every valid key as unlimited), letting explorer
+  // keys pull ~2M pages for free — exactly the bulk use the paid tiers exist to price.
+  // An unknown/absent tier is treated as Explorer (the safe floor), never unlimited.
+  if (identity.kind === 'apikey') {
+    const cfg = identity.apiKeyTier
+      ? DATASET_TIERS[identity.apiKeyTier as DatasetTier]
+      : undefined;
+    const perDay = (cfg ? cfg.pagesPerDay : DATASET_TIERS.explorer.pagesPerDay);
+    return perDay > 0
+      ? { limit: perDay, tier: 'apikey' }
+      : { limit: Number.POSITIVE_INFINITY, tier: 'apikey' };
   }
   if (identity.kind === 'session') {
     return { limit: SESSION_DAILY_PAGES, tier: 'session' };
@@ -68,7 +91,9 @@ export async function checkPageBudget(input: {
 
 /** Friendly 429 body explaining what to do next. */
 export function bulkBudgetExceededBody(check: BudgetCheck) {
-  const next = check.tier === 'session'
+  const next = check.tier === 'apikey'
+    ? `Your free Explorer key is capped at ${check.limit} pages/day on /text. Upgrade for uncapped access — see https://sourcelibrary.org/licensing — or bulk-export at https://sourcelibrary.org/api/dataset/v1/pages.`
+    : check.tier === 'session'
     ? 'Generate a free API key at https://sourcelibrary.org/developers (no daily cap on /text).'
     : 'Sign in (free) at https://sourcelibrary.org/auth/signin for a higher limit, or grab an API key at https://sourcelibrary.org/developers.';
   return {
@@ -78,6 +103,7 @@ export function bulkBudgetExceededBody(check: BudgetCheck) {
     tier: check.tier,
     next_steps: {
       get_api_key: 'https://sourcelibrary.org/developers',
+      upgrade: 'https://sourcelibrary.org/licensing',
       sign_in: 'https://sourcelibrary.org/auth/signin',
       bulk_export: 'https://sourcelibrary.org/api/dataset/v1/pages',
     },

--- a/tests/unit/api-budget-tier-cap.test.ts
+++ b/tests/unit/api-budget-tier-cap.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { pickLimit } from '@/lib/api-budget';
+import { DATASET_TIERS } from '@/lib/dataset/types';
+import type { ApiIdentity } from '@/lib/api-auth';
+
+/**
+ * Business-model invariant (the "/text hole", closed 2026-07-05): the free
+ * Explorer API tier must be page-capped on /api/books/[id]/text, while paid
+ * tiers stay uncapped. Before the fix, pickLimit handed EVERY apikey identity
+ * Infinity — so a free Explorer key could pull the whole corpus (one key had
+ * extracted ~1.9M pages). These tests pin the mapping so it can't regress.
+ */
+
+const key = (tier?: string): ApiIdentity => ({
+  kind: 'apikey',
+  apiKeyId: 'k1',
+  userId: 'u1',
+  apiKeyTier: tier,
+});
+
+describe('pickLimit — API key tier caps on /text', () => {
+  it('caps the free Explorer tier at its published 100 pages/day', () => {
+    const { limit, tier } = pickLimit(key('explorer'));
+    expect(limit).toBe(DATASET_TIERS.explorer.pagesPerDay);
+    expect(limit).toBe(100);
+    expect(Number.isFinite(limit)).toBe(true);
+    expect(tier).toBe('apikey');
+  });
+
+  it('leaves paid tiers uncapped (pagesPerDay: 0 → Infinity)', () => {
+    for (const t of ['language', 'domain', 'full', 'enterprise'] as const) {
+      expect(pickLimit(key(t)).limit).toBe(Number.POSITIVE_INFINITY);
+    }
+  });
+
+  it('treats an unknown or absent tier as Explorer (safe floor, never unlimited)', () => {
+    expect(pickLimit(key('bogus')).limit).toBe(DATASET_TIERS.explorer.pagesPerDay);
+    expect(pickLimit(key(undefined)).limit).toBe(DATASET_TIERS.explorer.pagesPerDay);
+  });
+
+  it('keeps verified bots (SEO crawlers) uncapped', () => {
+    expect(pickLimit({ kind: 'bot', bot: 'googlebot' }).limit).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('applies the session and anon page budgets unchanged', () => {
+    expect(pickLimit({ kind: 'session', userId: 'u1' }).tier).toBe('session');
+    expect(pickLimit({ kind: 'anon' }).tier).toBe('anon');
+  });
+});


### PR DESCRIPTION
## Problem

`/api/books/[id]/text` treated **any** valid API key as the unlimited `apikey` tier (`api-budget.ts` → `pickLimit`), so the free **Explorer** tier's published **100 pages/day** cap was never enforced there — only the dataset dump routes (`/dataset/v1/*`) checked it. A free Explorer key was therefore an uncapped whole-corpus extraction token.

Observed on prod (via the new monitor script):

| key | tier | all-time pages | status |
|---|---|---|---|
| conocimiento fundamental | explorer (free) | **1,886,877** | never blocked |
| kutsaladonus | explorer (free) | **275,958** (still climbing) | never blocked |

This is exactly the bulk use the paid tiers exist to price.

## Fix

`pickLimit` now reads the key's tier `pagesPerDay` from `DATASET_TIERS`:

- **Explorer** → capped at its published 100/day on `/text`
- **language / domain / full / enterprise** (`pagesPerDay: 0`) → unchanged, uncapped
- **verified bots** (Googlebot etc.) → unchanged, uncapped (SEO must never wall)
- **unknown / absent tier** → falls back to the Explorer floor, never unlimited

The existing per-request clamp (`budgetPageCap`), truncation note, and 429 body already key off `budget.limit > 0`, so they activate for Explorer keys with **no further wiring**. The 429 + partial-serve copy is made tier-aware — key holders are pointed at `/licensing` to upgrade rather than the nonsensical "sign in / get an API key."

## Scope / out of scope

- **In:** the `/text` budget only. Dataset routes already enforced tier caps (`getDailyPageCount`) — untouched.
- **Out:** no change to `/quote` (not page-billable), rate limits, or the enforce flag. `API_AUTH_ENFORCE=1` is already on in prod, so this takes effect on deploy.
- **Not auto-remediated:** the two heavy Explorer keys above will start getting 429s past 100/day. If either is a partner you want uncapped, upgrade their key's tier (as with `makemode`) — I left that decision to you.

## Tests

- `tests/unit/api-budget-tier-cap.test.ts` pins the tier→limit mapping (5 assertions, all green).
- Adds `scripts/maintenance/api-key-usage-monitor.mjs` — per-key usage report over `api_usage` with a ⚠ BULK flag for Explorer keys over 50K pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)