### PR TITLE
fix(monitor): scope api-key usage monitor to dataset keys only

### DIFF
--- a/scripts/maintenance/api-key-usage-monitor.mjs
+++ b/scripts/maintenance/api-key-usage-monitor.mjs
@@ -31,7 +31,15 @@ const client = new MongoClient(process.env.MONGODB_URI);
 await client.connect();
 const db = client.db('bookstore');
 
-const keys = await db.collection('api_keys').find({}).project({ key_hash: 0 }).toArray();
+// The `api_keys` collection is SHARED by two unrelated systems: dataset keys
+// (generateApiKey — carry `key_hash`/`tier`/`rate_limit`, validated on /text)
+// and collection-editor keys (editor-auth.ts — carry plaintext `key`/`role`/
+// `scopes`/`active`, no tier). Only dataset keys are relevant here; scope to
+// `key_hash` so editor keys aren't misreported as tier-less "malformed" rows.
+const keys = await db.collection('api_keys')
+  .find({ key_hash: { $exists: true } })
+  .project({ key_hash: 0 })
+  .toArray();
 const kmap = new Map(keys.map((k) => [String(k._id), k]));
 
 // All-time per-key content traffic.


### PR DESCRIPTION
Follow-up to #3031. The `api_keys` Mongo collection is shared by **two unrelated systems**:

- **dataset keys** — `generateApiKey`, carry `key_hash`/`tier`/`rate_limit`, validated on `/text` (`src/lib/dataset/api-keys.ts`)
- **collection-editor keys** — carry plaintext `key`/`role`/`scopes`/`active`, no tier, validated by `authenticateEditor` (`src/lib/editor-auth.ts:30`)

`api-key-usage-monitor.mjs` iterated **all** docs, so an editor key (Mike Etherhill's "Collection Editor" grant) surfaced as a tier-less `[undefined]` row that read like a malformed/junk record — it isn't, it's a live editor credential. This scopes the query to `{ key_hash: { $exists: true } }` so only real dataset keys are reported.

Pure reporting-script change — no runtime code, no deploy needed (Hetzner auto-pulls `main`). Verified: monitor now lists 30 dataset keys with no phantom row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)