### PR TITLE
fix(artwork): stop hidden artworks leaking through semantic search

### DIFF
--- a/scripts/migration/add-artwork-visible-filter.mjs
+++ b/scripts/migration/add-artwork-visible-filter.mjs
@@ -1,0 +1,148 @@
+/**
+ * Add a `visible` column to artwork_embeddings and teach match_artworks_semantic
+ * to hide non-visible artworks — the RPC-layer half of the hidden-artwork
+ * semantic-leak fix (issue: hidden artworks surfacing in semantic search).
+ *
+ * Background: backfill-artwork-embeddings.mjs only embeds `visible: true`
+ * artworks, but in --incremental mode it never removes rows for artworks that
+ * are hidden *after* embedding. At the time this migration was written 7,484 of
+ * 22,200 embedding rows (33.7%) were for artworks now hidden in Mongo, and the
+ * RPC had no visibility filter — so librarian search_artworks, /api/search/unified
+ * and /api/identify (which consume RPC rows directly) could surface hidden
+ * artworks. This is the parallel of the books visible/hidden invariant.
+ *
+ * What it does (idempotent):
+ *   1. ADD COLUMN visible boolean DEFAULT true (fail-safe default)
+ *   2. Backfill `visible` from Mongo (UPDATE-only — no re-embed, no Gemini cost)
+ *   3. Index (visible)
+ *   4. Replace match_artworks_semantic with `AND ae.visible IS NOT FALSE`
+ *      — IS NOT FALSE (not `= true`) so partial backfill / new NULL inserts
+ *      fail safe as visible rather than silently vanishing.
+ *
+ * Ongoing sync: run this script (or its backfill step) whenever artwork
+ * visibility changes at scale; the insert path in backfill-artwork-embeddings.mjs
+ * also stamps visible=true. Cheap to re-run — it's UPDATE-only.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/migration/add-artwork-visible-filter.mjs [--dry-run] [--skip-rpc]
+ */
+import pg from 'pg';
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const SKIP_RPC = process.argv.includes('--skip-rpc');
+
+const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL;
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!SUPABASE_DB_URL || !MONGODB_URI) {
+  console.error('Missing SUPABASE_DB_URL or MONGODB_URI');
+  process.exit(1);
+}
+
+const RPC_SQL = `
+CREATE OR REPLACE FUNCTION public.match_artworks_semantic(
+  query_embedding halfvec,
+  match_threshold double precision DEFAULT 0.3,
+  match_count integer DEFAULT 20,
+  filter_genre text DEFAULT NULL,
+  filter_period text DEFAULT NULL,
+  filter_culture text DEFAULT NULL,
+  filter_collection text DEFAULT NULL
+) RETURNS TABLE (
+  book_id text, title text, display_title text, author text, summary_text text,
+  subjects text[], figures text[], symbols text[], iconclass text[],
+  technique text, period text, culture text, genre text, collections text[],
+  resource_type text, thumbnail_url text, ulan_artist integer, similarity double precision
+) LANGUAGE plpgsql AS $$
+BEGIN
+  RETURN QUERY SELECT
+    ae.book_id, ae.title, ae.display_title, ae.author, ae.summary_text,
+    ae.subjects, ae.figures, ae.symbols, ae.iconclass, ae.technique, ae.period, ae.culture,
+    ae.genre, ae.collections, ae.resource_type, ae.thumbnail_url, ae.ulan_artist,
+    (1 - (ae.embedding <=> query_embedding))::float AS similarity
+  FROM artwork_embeddings ae
+  WHERE (1 - (ae.embedding <=> query_embedding)) > match_threshold
+    AND ae.visible IS NOT FALSE
+    AND (filter_genre IS NULL OR ae.genre = filter_genre)
+    AND (filter_period IS NULL OR ae.period = filter_period)
+    AND (filter_culture IS NULL OR ae.culture = filter_culture)
+    AND (filter_collection IS NULL OR filter_collection = ANY(ae.collections))
+  ORDER BY ae.embedding <=> query_embedding
+  LIMIT match_count;
+END; $$;
+`;
+
+async function main() {
+  const c = new pg.Client({ connectionString: SUPABASE_DB_URL, ssl: { rejectUnauthorized: false } });
+  await c.connect();
+  const mongo = new MongoClient(MONGODB_URI);
+  await mongo.connect();
+  const db = mongo.db('bookstore');
+
+  // 1. Add column
+  console.log('1. Adding `visible` column (DEFAULT true)...');
+  if (!DRY_RUN) {
+    await c.query(`ALTER TABLE artwork_embeddings ADD COLUMN IF NOT EXISTS visible boolean DEFAULT true`);
+  }
+
+  // 2. Backfill from Mongo — collect all book_ids, look up visibility, UPDATE hidden ones.
+  const { rows } = await c.query('SELECT book_id FROM artwork_embeddings');
+  const ids = rows.map(r => r.book_id);
+  console.log(`2. Backfilling visibility for ${ids.length} embedding rows...`);
+
+  // Fetch hidden ids from Mongo (the minority). Anything not returned stays visible.
+  const hidden = new Set();
+  for (let i = 0; i < ids.length; i += 5000) {
+    const chunk = ids.slice(i, i + 5000);
+    const docs = await db.collection('books')
+      .find({ id: { $in: chunk }, visible: { $ne: true } }, { projection: { id: 1 } })
+      .toArray();
+    for (const d of docs) hidden.add(d.id);
+  }
+  console.log(`   ${hidden.size} of ${ids.length} rows are hidden in Mongo (${(100 * hidden.size / ids.length).toFixed(1)}%)`);
+
+  if (!DRY_RUN) {
+    // Reset all to visible, then flip the hidden set false — keeps the column
+    // in sync even if a row was previously mismarked.
+    await c.query(`UPDATE artwork_embeddings SET visible = true WHERE visible IS DISTINCT FROM true`);
+    const hiddenArr = [...hidden];
+    for (let i = 0; i < hiddenArr.length; i += 2000) {
+      const chunk = hiddenArr.slice(i, i + 2000);
+      await c.query(`UPDATE artwork_embeddings SET visible = false WHERE book_id = ANY($1)`, [chunk]);
+    }
+    console.log(`   Marked ${hidden.size} rows visible=false.`);
+  }
+
+  // 3. Index
+  console.log('3. Indexing (visible)...');
+  if (!DRY_RUN) {
+    await c.query(`CREATE INDEX IF NOT EXISTS artwork_embeddings_visible_idx ON artwork_embeddings (visible)`);
+  }
+
+  // 4. Replace RPC
+  if (SKIP_RPC) {
+    console.log('4. Skipping RPC swap (--skip-rpc).');
+  } else {
+    console.log('4. Replacing match_artworks_semantic RPC with `visible IS NOT FALSE` filter...');
+    if (!DRY_RUN) {
+      // Drop both possible signatures first — CREATE OR REPLACE can't change the
+      // return type / arg defaults cleanly across the vector→halfvec migration.
+      await c.query(`DROP FUNCTION IF EXISTS public.match_artworks_semantic(halfvec, double precision, integer, text, text, text, text)`);
+      await c.query(RPC_SQL);
+    }
+  }
+
+  // Verify
+  if (!DRY_RUN && !SKIP_RPC) {
+    const check = await c.query(`SELECT count(*) FILTER (WHERE visible = false) AS hidden, count(*) AS total FROM artwork_embeddings`);
+    console.log(`\nDone. artwork_embeddings: ${check.rows[0].total} rows, ${check.rows[0].hidden} now marked hidden (excluded by RPC).`);
+  } else {
+    console.log(`\n${DRY_RUN ? 'DRY RUN — no writes.' : 'Done.'}`);
+  }
+
+  await c.end();
+  await mongo.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/migration/add-artwork-visible-filter.sql
+++ b/scripts/migration/add-artwork-visible-filter.sql
@@ -1,0 +1,48 @@
+-- Hidden-artwork semantic-leak fix, DDL half (Layer 1).
+-- Paste into the Supabase SQL editor when SUPABASE_DB_URL isn't available to the
+-- Node migration script (scripts/migration/add-artwork-visible-filter.mjs, which
+-- also does the Mongo-driven `visible=false` backfill).
+--
+-- Order is safe: the column defaults true and the RPC filters `visible IS NOT
+-- FALSE`, so nothing disappears before the hidden-flip backfill runs. After this
+-- DDL, run the backfill step (add-artwork-visible-filter.mjs, or the JS-client
+-- hidden-flip) to mark the currently-hidden artworks false.
+
+-- 1. Column (fail-safe default)
+ALTER TABLE artwork_embeddings ADD COLUMN IF NOT EXISTS visible boolean DEFAULT true;
+
+-- 2. Index
+CREATE INDEX IF NOT EXISTS artwork_embeddings_visible_idx ON artwork_embeddings (visible);
+
+-- 3. RPC — same as before plus `AND ae.visible IS NOT FALSE`
+DROP FUNCTION IF EXISTS public.match_artworks_semantic(halfvec, double precision, integer, text, text, text, text);
+CREATE OR REPLACE FUNCTION public.match_artworks_semantic(
+  query_embedding halfvec,
+  match_threshold double precision DEFAULT 0.3,
+  match_count integer DEFAULT 20,
+  filter_genre text DEFAULT NULL,
+  filter_period text DEFAULT NULL,
+  filter_culture text DEFAULT NULL,
+  filter_collection text DEFAULT NULL
+) RETURNS TABLE (
+  book_id text, title text, display_title text, author text, summary_text text,
+  subjects text[], figures text[], symbols text[], iconclass text[],
+  technique text, period text, culture text, genre text, collections text[],
+  resource_type text, thumbnail_url text, ulan_artist integer, similarity double precision
+) LANGUAGE plpgsql AS $$
+BEGIN
+  RETURN QUERY SELECT
+    ae.book_id, ae.title, ae.display_title, ae.author, ae.summary_text,
+    ae.subjects, ae.figures, ae.symbols, ae.iconclass, ae.technique, ae.period, ae.culture,
+    ae.genre, ae.collections, ae.resource_type, ae.thumbnail_url, ae.ulan_artist,
+    (1 - (ae.embedding <=> query_embedding))::float AS similarity
+  FROM artwork_embeddings ae
+  WHERE (1 - (ae.embedding <=> query_embedding)) > match_threshold
+    AND ae.visible IS NOT FALSE
+    AND (filter_genre IS NULL OR ae.genre = filter_genre)
+    AND (filter_period IS NULL OR ae.period = filter_period)
+    AND (filter_culture IS NULL OR ae.culture = filter_culture)
+    AND (filter_collection IS NULL OR filter_collection = ANY(ae.collections))
+  ORDER BY ae.embedding <=> query_embedding
+  LIMIT match_count;
+END; $$;

--- a/scripts/migration/artwork-embeddings-halfvec.mjs
+++ b/scripts/migration/artwork-embeddings-halfvec.mjs
@@ -59,6 +59,7 @@ BEGIN
     (1 - (ae.embedding <=> query_embedding))::float AS similarity
   FROM artwork_embeddings ae
   WHERE (1 - (ae.embedding <=> query_embedding)) > match_threshold
+    AND ae.visible IS NOT FALSE
     AND (filter_genre IS NULL OR ae.genre = filter_genre)
     AND (filter_period IS NULL OR ae.period = filter_period)
     AND (filter_culture IS NULL OR ae.culture = filter_culture)

--- a/scripts/migration/artwork-embeddings-schema.sql
+++ b/scripts/migration/artwork-embeddings-schema.sql
@@ -7,6 +7,10 @@ CREATE TABLE IF NOT EXISTS artwork_embeddings (
   -- 2000 dims, so the only way to index a 3072-dim Gemini embedding is via
   -- halfvec (supported up to 4000 dims). See scripts/migration/artwork-embeddings-halfvec.mjs.
   embedding halfvec(3072), resource_type TEXT, thumbnail_url TEXT,
+  -- Mirrors books.visible in Mongo. Hidden artworks are excluded by the RPC
+  -- (`visible IS NOT FALSE`). Kept in sync by add-artwork-visible-filter.mjs
+  -- and stamped on insert by backfill-artwork-embeddings.mjs.
+  visible BOOLEAN DEFAULT true,
   created_at TIMESTAMPTZ DEFAULT now(), updated_at TIMESTAMPTZ DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS artwork_embeddings_embedding_idx ON artwork_embeddings USING hnsw (embedding halfvec_cosine_ops) WITH (m = 16, ef_construction = 64);
@@ -14,6 +18,7 @@ CREATE INDEX IF NOT EXISTS artwork_embeddings_collections_idx ON artwork_embeddi
 CREATE INDEX IF NOT EXISTS artwork_embeddings_genre_idx ON artwork_embeddings (genre);
 CREATE INDEX IF NOT EXISTS artwork_embeddings_period_idx ON artwork_embeddings (period);
 CREATE INDEX IF NOT EXISTS artwork_embeddings_culture_idx ON artwork_embeddings (culture);
+CREATE INDEX IF NOT EXISTS artwork_embeddings_visible_idx ON artwork_embeddings (visible);
 
 CREATE OR REPLACE FUNCTION match_artworks_semantic(
   query_embedding halfvec, match_threshold float DEFAULT 0.5, match_count int DEFAULT 20,
@@ -32,6 +37,7 @@ BEGIN
     1 - (ae.embedding <=> query_embedding) AS similarity
   FROM artwork_embeddings ae
   WHERE 1 - (ae.embedding <=> query_embedding) > match_threshold
+    AND ae.visible IS NOT FALSE
     AND (filter_genre IS NULL OR ae.genre = filter_genre)
     AND (filter_period IS NULL OR ae.period = filter_period)
     AND (filter_culture IS NULL OR ae.culture = filter_culture)

--- a/scripts/migration/backfill-artwork-embeddings.mjs
+++ b/scripts/migration/backfill-artwork-embeddings.mjs
@@ -148,8 +148,8 @@ async function main() {
           INSERT INTO artwork_embeddings (book_id, title, display_title, author, summary_text,
             subjects, figures, symbols, iconclass, technique, material, style, period, culture,
             genre, ulan_artist, collections, embedding, resource_type, thumbnail_url, updated_at,
-            embedding_model)
-          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,now(),$21)
+            embedding_model, visible)
+          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,now(),$21,true)
           ON CONFLICT (book_id) DO UPDATE SET
             summary_text=EXCLUDED.summary_text, embedding=EXCLUDED.embedding,
             subjects=EXCLUDED.subjects, figures=EXCLUDED.figures, symbols=EXCLUDED.symbols,
@@ -157,7 +157,7 @@ async function main() {
             style=EXCLUDED.style, period=EXCLUDED.period, culture=EXCLUDED.culture,
             genre=EXCLUDED.genre, ulan_artist=EXCLUDED.ulan_artist, collections=EXCLUDED.collections,
             display_title=EXCLUDED.display_title, thumbnail_url=EXCLUDED.thumbnail_url,
-            embedding_model=EXCLUDED.embedding_model, updated_at=now()
+            embedding_model=EXCLUDED.embedding_model, visible=true, updated_at=now()
         `, [
           art.id, art.title, art.display_title || art.title, art.author, texts[idx],
           e.figures_depicted || [], e.figures_depicted || [], e.symbols || [],

--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -598,8 +598,11 @@ Return JSON only:
       }
     }
 
-    // Merge semantic artwork results (found via identification metadata)
-    const semanticArtworks = await semanticArtworkPromise;
+    // Merge semantic artwork results (found via identification metadata).
+    // Drop any that are hidden in Mongo — the RPC rows are consumed directly
+    // here (thumbnail/title/id), so guard against a stale visible column.
+    const { filterVisibleArtworks } = await import('@/lib/artwork-visibility');
+    const semanticArtworks = await filterVisibleArtworks(db, await semanticArtworkPromise);
     for (const sa of semanticArtworks) {
       if (existingMatchIds.has(sa.book_id)) continue;
       const semanticScore = Math.round(sa.similarity * 30); // Scale similarity to 0-30

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -7,6 +7,7 @@ import type { SearchResult } from '@/lib/api-client/types/search';
 import { searchBooksCatalog } from '@/lib/books-catalog';
 import { searchBookIds } from '@/lib/books-catalog';
 import { semanticBookSearch, semanticArtworkSearch } from '@/lib/semantic-search';
+import { filterVisibleArtworks } from '@/lib/artwork-visibility';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { anonSearchGate, SIGNIN_URL } from '@/lib/anon-gate';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
@@ -226,6 +227,9 @@ export async function GET(request: NextRequest) {
       // Artwork semantic search: dedicated artwork_embeddings table (3072 dims)
       withTimeout(
         semanticArtworkSearch(matchQuery, 4)
+          // Drop hidden artworks — these RPC rows are returned to the client
+          // directly (title/thumbnail), not re-resolved against Mongo below.
+          .then(raw => filterVisibleArtworks(db, raw))
           .then(artworks => ({
             results: artworks.map(a => ({
               book_id: a.book_id,

--- a/src/lib/artwork-visibility.ts
+++ b/src/lib/artwork-visibility.ts
@@ -1,0 +1,29 @@
+import type { Db } from 'mongodb';
+
+/**
+ * App-layer guard against hidden artworks leaking out of semantic search.
+ *
+ * `match_artworks_semantic` (Supabase) now filters `visible IS NOT FALSE`, but
+ * that column is a snapshot of Mongo `books.visible` and can drift if an artwork
+ * is hidden without re-running the sync. Callers that consume RPC rows *directly*
+ * (librarian search_artworks, /api/search/unified, /api/identify) — i.e. without
+ * re-resolving each result against Mongo the way /api/artwork/search and
+ * /api/gallery do — run their results through this to drop anything not currently
+ * visible in Mongo. Defense in depth for the books visible/hidden invariant.
+ *
+ * Returns the input rows minus any whose book is not `visible: true` in Mongo.
+ */
+export async function filterVisibleArtworks<T extends { book_id: string }>(
+  db: Db,
+  rows: T[],
+): Promise<T[]> {
+  if (rows.length === 0) return rows;
+  const ids = rows.map(r => r.book_id);
+  const hiddenDocs = await db.collection('books')
+    .find({ id: { $in: ids }, visible: { $ne: true } }, { projection: { _id: 0, id: 1 }, maxTimeMS: 3000 })
+    .toArray()
+    .catch(() => [] as Array<{ id?: string }>);
+  if (hiddenDocs.length === 0) return rows;
+  const hidden = new Set(hiddenDocs.map(d => d.id));
+  return rows.filter(r => !hidden.has(r.book_id));
+}

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -668,7 +668,9 @@ async function executeTool(
       const collection = args.collection as string | undefined;
 
       const { semanticArtworkSearch } = await import('@/lib/semantic-search');
-      const artworks = await semanticArtworkSearch(query, 8, { genre, period, culture, collection });
+      const { filterVisibleArtworks } = await import('@/lib/artwork-visibility');
+      const rawArtworks = await semanticArtworkSearch(query, 8, { genre, period, culture, collection });
+      const artworks = await filterVisibleArtworks(await getDb(), rawArtworks);
 
       let context = '';
       if (artworks.length > 0) {


### PR DESCRIPTION
## Problem
`match_artworks_semantic` (Supabase RPC) has **no visibility filter**, and **7,484 of 22,200 `artwork_embeddings` rows (33.7%) are for artworks now hidden in Mongo**. The backfill only embeds `visible: true` artworks, but `--incremental` never removes rows for artworks hidden *after* embedding.

Three callers consume RPC rows **directly** (title/thumbnail/id) without re-resolving against Mongo, so hidden artworks could surface:
- `src/lib/embassy/librarian.ts` — `search_artworks` tool
- `src/app/api/search/unified/route.ts` — artwork lane
- `src/app/api/identify/route.ts`

`/api/artwork/search` and `/api/gallery` already re-resolve `visible:true` and were safe — that's the fix pattern reused here.

## Fix — defense in depth
**Layer 1 (RPC/data):** add a `visible` column to `artwork_embeddings`, filter `visible IS NOT FALSE` (fail-safe for partial backfill / new NULL inserts). `add-artwork-visible-filter.mjs` adds+indexes the column, backfills from Mongo (UPDATE-only, **no re-embed, no Gemini cost**), and swaps the RPC. `add-artwork-visible-filter.sql` is a paste-ready equivalent for the dashboard. Insert path in `backfill-artwork-embeddings.mjs` now stamps `visible=true`.

**Layer 2 (app):** `filterVisibleArtworks()` drops hidden rows against **live Mongo** in the three direct-consuming callers — guards against a stale `visible` column and **closes the leak independent of Layer 1**.

## Rollout
- **Layer 2 ships with this PR** and closes the leak on deploy (filters against live Mongo, never stale).
- **Layer 1 DDL** needs `SUPABASE_DB_URL` (not in local env) or the Supabase SQL editor. Hardening + protects future callers; not required to close the leak.

## Scope
- In: the semantic-leak fix (code + migration).
- Out: `artwork_embeddings` metadata staleness (separate), retina-card / illustration-panel issues, the 1 mislabeled book (separate data edit, already applied).

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)