### PR TITLE
fix(gallery): 600px card variant for sharp retina cards (#2401)

### DIFF
--- a/scripts/maintenance/backfill-card-thumbs.mjs
+++ b/scripts/maintenance/backfill-card-thumbs.mjs
@@ -10,7 +10,11 @@
  *
  * Usage:
  *   set -a; source .env.production.local; set +a
- *   node scripts/maintenance/backfill-card-thumbs.mjs [--dry-run] [--limit=N] [--book-id=ID] [--concurrency=8]
+ *   node scripts/maintenance/backfill-card-thumbs.mjs [--dry-run] [--limit=N] [--book-id=ID] [--concurrency=8] [--featured]
+ *
+ * --featured: scope to the high-visibility card surfaces only — visible books,
+ * top-ranked plates (book_rank <= 4). Covers collection-grid leads, the homepage
+ * strip, and lead gallery cards (~16K) without paying for the deep-scroll tail.
  */
 import { MongoClient } from 'mongodb';
 import sharp from 'sharp';
@@ -20,6 +24,7 @@ const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = Number((process.argv.find(a => a.startsWith('--limit=')) || '').split('=')[1]) || 0;
 const BOOK_ID = (process.argv.find(a => a.startsWith('--book-id=')) || '').split('=')[1] || null;
 const CONCURRENCY = Number((process.argv.find(a => a.startsWith('--concurrency=')) || '').split('=')[1]) || 8;
+const FEATURED = process.argv.includes('--featured');
 
 const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
 const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary';
@@ -83,6 +88,7 @@ async function main() {
     $or: [{ card_url: { $exists: false } }, { card_url: null }],
   };
   if (BOOK_ID) filter.book_id = BOOK_ID;
+  if (FEATURED) { filter.book_visible = true; filter.book_rank = { $lte: 4 }; }
 
   const total = await galleryCol.countDocuments(filter);
   console.log(`gallery_images needing a card variant: ${total}${LIMIT ? ` (processing ${LIMIT})` : ''}`);
@@ -100,13 +106,19 @@ async function main() {
     const card = await sharp(src).resize(600, null, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 72 }).toBuffer();
     const cardUrl = (await putR2(key, card)) + `?v=${startTime}`;
 
+    // gallery_images is the render-facing view + the idempotency key, so write
+    // it first and let it govern success. (The frontend derives -card.jpg from
+    // the thumb URL, so the R2 file above is what actually renders; these fields
+    // are bookkeeping.)
     await galleryCol.updateOne({ id: g.id }, { $set: { card_url: cardUrl, updated_at: new Date() } });
-    // Mirror onto the source-of-truth detected_images entry.
+    // Mirror onto the source-of-truth detected_images entry. Non-fatal: some
+    // pages carry a null detected_images[idx] slot ($set can't descend into
+    // null), and the R2 file + gallery_images row already cover rendering.
     if (g.page_id != null && g.detection_index != null) {
       await pagesCol.updateOne(
         { id: g.page_id },
         { $set: { [`detected_images.${g.detection_index}.card_url`]: cardUrl } },
-      );
+      ).catch(() => {});
     }
   });
 

--- a/scripts/maintenance/backfill-card-thumbs.mjs
+++ b/scripts/maintenance/backfill-card-thumbs.mjs
@@ -1,0 +1,119 @@
+/**
+ * Backfill the 600px gallery `-card.jpg` variant (#2401) for crops that were
+ * materialized before generate-thumbnails.mjs emitted it.
+ *
+ * Gallery/collection cards render in 324–443px slots (~650–880px at 2× DPR); the
+ * existing 300px `-thumb.jpg` blurs there. This generates a 600px `-card.jpg`
+ * sibling from the ALREADY-ARCHIVED extracted crop on R2 — it never touches the
+ * original page/IIIF source, so no link-rot or 403 risk and no Gemini cost.
+ * Idempotent: skips crops that already have `card_url`.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/backfill-card-thumbs.mjs [--dry-run] [--limit=N] [--book-id=ID] [--concurrency=8]
+ */
+import { MongoClient } from 'mongodb';
+import sharp from 'sharp';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const LIMIT = Number((process.argv.find(a => a.startsWith('--limit=')) || '').split('=')[1]) || 0;
+const BOOK_ID = (process.argv.find(a => a.startsWith('--book-id=')) || '').split('=')[1] || null;
+const CONCURRENCY = Number((process.argv.find(a => a.startsWith('--concurrency=')) || '').split('=')[1]) || 8;
+
+const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary';
+const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY } = process.env;
+if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY) {
+  console.error('R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY must be set'); process.exit(1);
+}
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+});
+
+async function fetchBuffer(url) {
+  const resp = await fetch(url, { signal: AbortSignal.timeout(30000) });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
+async function putR2(key, body) {
+  await s3.send(new PutObjectCommand({
+    Bucket: R2_BUCKET, Key: key, Body: body, ContentType: 'image/jpeg',
+    CacheControl: 'public, max-age=86400, s-maxage=86400',
+  }));
+  return `${R2_PUBLIC_URL}/${key}`;
+}
+
+// Turn an extracted/thumb URL into the R2 object key for its `-card.jpg` sibling.
+// gallery URLs look like `${R2_PUBLIC_URL}/gallery/{book}/{page}-{idx}[-thumb].jpg?v=...`
+function cardKeyFrom(url) {
+  const noQuery = url.split('?')[0];
+  const path = noQuery.replace(`${R2_PUBLIC_URL}/`, '');
+  if (!path.startsWith('gallery/')) return null;
+  return path.replace(/(-thumb)?\.jpg$/, '-card.jpg');
+}
+
+async function processPool(items, concurrency, fn) {
+  let idx = 0, done = 0, failed = 0;
+  const errors = [];
+  async function worker() {
+    while (idx < items.length) {
+      const i = idx++;
+      try { await fn(items[i]); done++; }
+      catch (e) { failed++; if (errors.length < 20) errors.push({ id: items[i].id, error: e.message }); }
+      if ((done + failed) % 100 === 0) console.log(`  [${done + failed}/${items.length}] ok=${done} fail=${failed}`);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return { done, failed, errors };
+}
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const galleryCol = db.collection('gallery_images');
+  const pagesCol = db.collection('pages');
+
+  const filter = {
+    extracted_url: { $ne: null },
+    $or: [{ card_url: { $exists: false } }, { card_url: null }],
+  };
+  if (BOOK_ID) filter.book_id = BOOK_ID;
+
+  const total = await galleryCol.countDocuments(filter);
+  console.log(`gallery_images needing a card variant: ${total}${LIMIT ? ` (processing ${LIMIT})` : ''}`);
+  if (DRY_RUN) { console.log('DRY RUN — no writes.'); await client.close(); return; }
+
+  const cursor = galleryCol.find(filter, { projection: { _id: 0, id: 1, book_id: 1, page_id: 1, detection_index: 1, extracted_url: 1 } });
+  if (LIMIT) cursor.limit(LIMIT);
+  const items = await cursor.toArray();
+
+  const startTime = Date.now();
+  const { done, failed, errors } = await processPool(items, CONCURRENCY, async (g) => {
+    const key = cardKeyFrom(g.extracted_url);
+    if (!key) throw new Error(`unmappable url: ${g.extracted_url?.slice(0, 60)}`);
+    const src = await fetchBuffer(g.extracted_url);
+    const card = await sharp(src).resize(600, null, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 72 }).toBuffer();
+    const cardUrl = (await putR2(key, card)) + `?v=${startTime}`;
+
+    await galleryCol.updateOne({ id: g.id }, { $set: { card_url: cardUrl, updated_at: new Date() } });
+    // Mirror onto the source-of-truth detected_images entry.
+    if (g.page_id != null && g.detection_index != null) {
+      await pagesCol.updateOne(
+        { id: g.page_id },
+        { $set: { [`detected_images.${g.detection_index}.card_url`]: cardUrl } },
+      );
+    }
+  });
+
+  const mins = ((Date.now() - startTime) / 60000).toFixed(1);
+  console.log(`\nDone in ${mins}m — generated ${done}, failed ${failed}.`);
+  if (errors.length) console.log('Sample errors:', JSON.stringify(errors.slice(0, 10), null, 2));
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/backfill-card-thumbs.mjs
+++ b/scripts/maintenance/backfill-card-thumbs.mjs
@@ -52,6 +52,14 @@ async function putR2(key, body) {
   return `${R2_PUBLIC_URL}/${key}`;
 }
 
+// Some stored URLs carry a literal newline from a past run where R2_PUBLIC_URL
+// had a trailing \n (see lesson_env_newline_phantom_sync_success). Strip all
+// whitespace so the fetch + key derivation see a clean URL. Empty → null.
+function cleanUrl(url) {
+  const u = (url || '').replace(/\s+/g, '').trim();
+  return u || null;
+}
+
 // Turn an extracted/thumb URL into the R2 object key for its `-card.jpg` sibling.
 // gallery URLs look like `${R2_PUBLIC_URL}/gallery/{book}/{page}-{idx}[-thumb].jpg?v=...`
 function cardKeyFrom(url) {
@@ -100,9 +108,11 @@ async function main() {
 
   const startTime = Date.now();
   const { done, failed, errors } = await processPool(items, CONCURRENCY, async (g) => {
-    const key = cardKeyFrom(g.extracted_url);
-    if (!key) throw new Error(`unmappable url: ${g.extracted_url?.slice(0, 60)}`);
-    const src = await fetchBuffer(g.extracted_url);
+    const srcUrl = cleanUrl(g.extracted_url);
+    if (!srcUrl) throw new Error('empty extracted_url (no crop to downscale)');
+    const key = cardKeyFrom(srcUrl);
+    if (!key) throw new Error(`unmappable url: ${srcUrl.slice(0, 60)}`);
+    const src = await fetchBuffer(srcUrl);
     const card = await sharp(src).resize(600, null, { fit: 'inside', withoutEnlargement: true }).jpeg({ quality: 72 }).toBuffer();
     const cardUrl = (await putR2(key, card)) + `?v=${startTime}`;
 

--- a/scripts/workers/generate-thumbnails.mjs
+++ b/scripts/workers/generate-thumbnails.mjs
@@ -129,11 +129,18 @@ async function generateThumbnails(sourceUrl, bbox, rotation, bookId, pageId, det
     pipeline = pipeline.rotate(rotation);
   }
 
-  // Generate full-size + thumbnail
+  // Generate full-size + thumbnail + card variant.
+  //   -thumb.jpg (300px) — dense/low-priority contexts
+  //   -card.jpg  (600px) — grid card slots (324–443px CSS → ~650–880px @2x
+  //                        DPR); 300px can't fill those sharply (#2401)
   const extractedBuffer = await pipeline.jpeg({ quality: 85, progressive: true }).toBuffer();
   const thumbnailBuffer = await sharp(extractedBuffer)
     .resize(300, null, { fit: 'inside', withoutEnlargement: true })
     .jpeg({ quality: 70 })
+    .toBuffer();
+  const cardBuffer = await sharp(extractedBuffer)
+    .resize(600, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: 72 })
     .toBuffer();
 
   // Compute dhash on the cropped image — same buffer the dedup logic will
@@ -142,15 +149,17 @@ async function generateThumbnails(sourceUrl, bbox, rotation, bookId, pageId, det
 
   // Upload to R2
   const blobPrefix = `gallery/${bookId}/${pageId}-${detectionIndex}`;
-  const [extractedBlob, thumbnailBlob] = await Promise.all([
+  const [extractedBlob, thumbnailBlob, cardBlob] = await Promise.all([
     storagePut(`${blobPrefix}.jpg`, extractedBuffer, 'image/jpeg'),
     storagePut(`${blobPrefix}-thumb.jpg`, thumbnailBuffer, 'image/jpeg'),
+    storagePut(`${blobPrefix}-card.jpg`, cardBuffer, 'image/jpeg'),
   ]);
 
   const cacheBust = `?v=${Date.now()}`;
   return {
     extractedUrl: extractedBlob.url + cacheBust,
     thumbnailUrl: thumbnailBlob.url + cacheBust,
+    cardUrl: cardBlob.url + cacheBust,
     dhash,
   };
 }
@@ -322,6 +331,7 @@ async function main() {
         $set: {
           [`detected_images.${detectionIndex}.extracted_url`]: urls.extractedUrl,
           [`detected_images.${detectionIndex}.thumbnail_url`]: urls.thumbnailUrl,
+          [`detected_images.${detectionIndex}.card_url`]: urls.cardUrl,
           [`detected_images.${detectionIndex}.dhash`]: urls.dhash,
         },
       }
@@ -335,6 +345,7 @@ async function main() {
         $set: {
           extracted_url: urls.extractedUrl,
           thumbnail_url: urls.thumbnailUrl,
+          card_url: urls.cardUrl,
           dhash: urls.dhash,
           updated_at: new Date(),
         },

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { headers } from 'next/headers';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { sortCollections, sanitizeThumbnail, collectionCountLabel, coverOverride } from '@/lib/collections-utils';
+import { toGalleryCardUrl } from '@/lib/utils';
 import EraTimeline, { type DecadeBucket } from '@/components/collections/EraTimeline';
 import ShowMorePathways from '@/components/collections/ShowMorePathways';
 import CollectionCardImage from '@/components/collections/CollectionCardImage';
@@ -187,6 +188,9 @@ function cardImageCandidates(images: FeaturedImage[] | undefined, override?: str
   if (!images?.length) return urls;
   for (const img of images) {
     if (typeof img === 'string') { add(img); continue; }
+    // Prefer the 600px gallery `-card.jpg` (sharp on retina); fall back to the
+    // 300px thumb for crops whose card variant isn't backfilled yet (#2401).
+    add(toGalleryCardUrl(img.thumbnail_url));
     add(img.thumbnail_url);
     add(img.extracted_url);
     add(img.image_url);

--- a/src/components/collections/CollectionCardImage.tsx
+++ b/src/components/collections/CollectionCardImage.tsx
@@ -33,6 +33,10 @@ export default function CollectionCardImage({
       alt={alt}
       fill
       sizes={sizes}
+      // Serve the sized R2 variant directly — the metered /_next/image optimizer
+      // under-picks small srcset candidates (135px into a 324px slot) and blurs
+      // the cards (#2401, CLAUDE.md). The candidate chain is pre-sized on R2.
+      unoptimized
       className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
       priority={priority}
       loading={priority ? 'eager' : 'lazy'}

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -13,7 +13,7 @@ import { useIdentity } from '@/hooks/useIdentity';
 import { BookLoader } from '@/components/ui/BookLoader';
 import FeaturedCollections from '@/components/gallery/FeaturedCollections';
 import IconclassFilter from '@/components/gallery/IconclassFilter';
-import { formatAuthor } from '@/lib/utils';
+import { formatAuthor, toGalleryCardUrl } from '@/lib/utils';
 import AuthorName from '@/components/AuthorName';
 import { LIBRARY_PARTNERS, getPartnerByProvider } from '@/lib/library-partners';
 import {
@@ -775,6 +775,7 @@ function GalleryMasonry({ items, hasMore, tenantPrefix, collectionScope }: { ite
 function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScope }: { item: GalleryItem; priority?: boolean; tenantPrefix?: string; collectionScope?: string }) {
   const [imageError, setImageError] = useState(false);
   const [useCropFallback, setUseCropFallback] = useState(false);
+  const [cardFailed, setCardFailed] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const reservedAspect = item.aspect && item.aspect > 0 ? item.aspect : 0.75;
 
@@ -782,8 +783,12 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
   // not the gallery image viewer.
   const isArtwork = item.source === 'artwork';
   const cropUrl = !isArtwork && item.bbox ? getCroppedImageUrl(item.imageUrl, item.bbox) : null;
-  // Prefer thumbnail for grid cards — extracted images are ~2MB vs ~38KB thumbnails
-  const blobUrl = item.thumbnailUrl || item.extractedUrl;
+  // Prefer the 600px gallery `-card.jpg` for grid cards (sharp on retina; #2401),
+  // falling back to the 300px thumb if its card variant isn't backfilled yet.
+  // Extracted images (~2MB) are the last resort. Artwork thumbs are already
+  // 600px, so toGalleryCardUrl returns null for them and blobUrl stays the thumb.
+  const cardUrl = !cardFailed ? toGalleryCardUrl(item.thumbnailUrl) : null;
+  const blobUrl = cardUrl || item.thumbnailUrl || item.extractedUrl;
 
   const displayUrl = useCropFallback
     ? (cropUrl || toThumbnailUrl(item.imageUrl))
@@ -818,7 +823,9 @@ function GalleryCard({ item, priority = false, tenantPrefix = '', collectionScop
               }
             }}
             onError={() => {
-              if (!useCropFallback && cropUrl) setUseCropFallback(true);
+              // Card variant missing (not yet backfilled) → retry with the thumb.
+              if (cardUrl) setCardFailed(true);
+              else if (!useCropFallback && cropUrl) setUseCropFallback(true);
               else setImageError(true);
             }}
           />

--- a/src/components/prototype/FromTheCollection.tsx
+++ b/src/components/prototype/FromTheCollection.tsx
@@ -1,6 +1,7 @@
-import Image from 'next/image';
 import Link from 'next/link';
 import { bookUrl, galleryImageUrl } from '@/lib/slugify';
+import { toGalleryCardUrl } from '@/lib/utils';
+import CollectionCardImage from '@/components/collections/CollectionCardImage';
 
 interface ShowcaseItem {
   // Gallery image fields
@@ -52,12 +53,13 @@ export default function FromTheCollection({ items }: FromTheCollectionProps) {
                 {/* Image */}
                 <Link href={imageHref}>
                   <div className="relative aspect-[3/4] bg-cream rounded-lg overflow-hidden border border-border-light group-hover:shadow-lg transition-all">
-                    <Image
-                      src={item.thumbnail_url || item.extracted_url || ''}
+                    <CollectionCardImage
+                      candidates={[
+                        toGalleryCardUrl(item.thumbnail_url),
+                        item.thumbnail_url,
+                        item.extracted_url,
+                      ].filter((u): u is string => !!u)}
                       alt={item.museum_description || 'Gallery image'}
-                      fill
-                      quality={85}
-                      className="object-cover group-hover:scale-105 transition-transform duration-500"
                       sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
                     />
                     {item.type && (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -149,6 +149,28 @@ export function isArchiveFailed(photo: string | undefined | null): boolean {
 }
 
 /**
+ * Gallery crops are materialized on R2 at deterministic sibling paths:
+ *   gallery/{book}/{page}-{idx}-thumb.jpg  (300px)
+ *   gallery/{book}/{page}-{idx}-card.jpg   (600px — #2401)
+ *   gallery/{book}/{page}-{idx}.jpg        (full extracted crop, ~2MB)
+ *
+ * The 300px thumb is too small for the 324–443px card slots in gallery /
+ * collection grids, so it blurs at ≥2× DPR. Derive the 600px `-card.jpg`
+ * sibling by convention so cards can prefer it with no API/type change; callers
+ * keep the original thumb as an onError fallback for crops whose card variant
+ * hasn't been backfilled yet (scripts/maintenance/backfill-card-thumbs.mjs).
+ *
+ * Returns null when the url isn't a gallery `-thumb.jpg` (artwork thumbs are
+ * already 600px; IIIF/other URLs have no card sibling) so we never point at a
+ * variant that can't exist.
+ */
+export function toGalleryCardUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  if (!/\/gallery\/.*-thumb\.jpg(\?|$)/.test(url)) return null;
+  return url.replace('-thumb.jpg', '-card.jpg');
+}
+
+/**
  * Get the best available image URL for a page.
  *
  * Priority: cropped_photo > archived_photo > photo_original > photo


### PR DESCRIPTION
Closes #2401.

## Problem
Gallery/collection cards render the 300px gallery `-thumb.jpg` in card slots that are **324–443px CSS wide** (~650–880px at 2× DPR). A 300px source can't fill that sharply, so the cards look soft on retina. Two compounding causes (per #2401's measurements): the source is too small, and several cards route through the metered `/_next/image` optimizer, which under-picks srcset candidates (135px into a 324px slot).

## Fix
- **600px `-card.jpg` variant.** `generate-thumbnails.mjs` now emits a 600px `-card.jpg` alongside the 300px `-thumb.jpg`, stored as `card_url` on `detected_images` + `gallery_images`. 600px covers a ~300px slot at 2× DPR.
- **Backfill for existing crops** (`scripts/maintenance/backfill-card-thumbs.mjs`): downscales from the **already-archived R2 extract** — never the original page/IIIF source, so no link-rot / 403 risk and no Gemini cost. Idempotent (skips crops with `card_url` set).
- **Drop the metered optimizer.** `CollectionCardImage` now uses `unoptimized` and serves the sized R2 variant directly (CLAUDE.md convention). `GalleryCard` already used a plain `<img>`.
- **Prefer the card variant by convention.** `toGalleryCardUrl()` derives the `-card.jpg` sibling from the thumb URL (returns null for non-gallery / artwork URLs, which are already 600px), with the 300px thumb kept as an `onError` fallback for crops not yet backfilled. No API/type change. Wired into `GalleryCard`, the `/collections` grid, and `FromTheCollection`.

## Rollout
1. Merge → the code is safe before the backfill runs (card URL derived, thumb fallback on 404).
2. Run `backfill-card-thumbs.mjs` over the gallery corpus (R2-only, cheap).
3. `generate-thumbnails.mjs` emits the variant for all future crops automatically.

## Scope
- In: gallery/collection card sharpness.
- Out: books whose **source scan** is genuinely low-res (can't sharpen in code); the illustration-panel backfill (#2092).

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)