### PR TITLE
artwork dedup toolkit: detect, CLIP-confirm, and gated purge (#2209)

### DIFF
--- a/scripts/analysis/artwork-dedup-clip-confirm.mjs
+++ b/scripts/analysis/artwork-dedup-clip-confirm.mjs
@@ -1,0 +1,101 @@
+/**
+ * READ-ONLY: confirm the LOW-tier (title+author+year) artwork duplicate
+ * candidates from artwork-exact-duplicates.mjs using CLIP visual similarity.
+ *
+ * The LOW tier is title-only, so it conflates same-subject with same-object
+ * (distinct emblems, common religious subjects). CLIP embeddings settle it: a
+ * pair that is ALSO visually near-identical is a real duplicate; a pair that
+ * shares a title but looks different is a distinct work. This does NOT do a
+ * 26K² self-join — it only fetches CLIP vectors for the candidate members
+ * already grouped by title, and scores intra-group pairs. Deletes nothing.
+ *
+ * Thresholds (CLIP cosine): >=0.97 confirmed near-identical; 0.90–0.97 likely
+ * (visual sibling — reused block / same object different scan, review); <0.90
+ * distinct (title collision, NOT a dup).
+ *
+ * Usage:
+ *   export SUPABASE_DB_URL=$(secret-lover get SUPABASE_DB_URL | tail -1)
+ *   node scripts/analysis/artwork-dedup-clip-confirm.mjs \
+ *     [--in=scripts/output/artwork-exact-duplicates.json] \
+ *     [--tiers=low,review] [--out=scripts/output/artwork-dedup-clip-confirmed.json]
+ */
+import pg from 'pg';
+import { readFileSync, writeFileSync } from 'fs';
+
+const IN = (process.argv.find(a => a.startsWith('--in=')) || '').split('=')[1]
+  || 'scripts/output/artwork-exact-duplicates.json';
+const OUT = (process.argv.find(a => a.startsWith('--out=')) || '').split('=')[1]
+  || 'scripts/output/artwork-dedup-clip-confirmed.json';
+const TIERS = ((process.argv.find(a => a.startsWith('--tiers=')) || '--tiers=low,review')
+  .split('=')[1]).split(',');
+
+const CONFIRM = 0.97, LIKELY = 0.90;
+
+function cosine(a, b) {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb) || 1);
+}
+
+async function main() {
+  const report = JSON.parse(readFileSync(IN, 'utf8'));
+  const groups = report.groups.filter(g => TIERS.includes(g.tier));
+  console.log(`Confirming ${groups.length} groups in tiers [${TIERS.join(',')}] via CLIP...`);
+
+  // Collect every member id across the candidate groups.
+  const ids = new Set();
+  for (const g of groups) { ids.add(g.keeper.id); for (const r of g.remove) ids.add(r.id); }
+  const idList = [...ids];
+
+  const c = new pg.Client({ connectionString: process.env.SUPABASE_DB_URL, ssl: { rejectUnauthorized: false } });
+  await c.connect();
+
+  // Fetch CLIP vectors for just those ids (batched).
+  const vecById = new Map();
+  for (let i = 0; i < idList.length; i += 1000) {
+    const chunk = idList.slice(i, i + 1000);
+    const { rows } = await c.query(
+      `SELECT book_id, embedding::text AS e FROM clip_embeddings WHERE source_type='artwork' AND book_id = ANY($1)`,
+      [chunk],
+    );
+    for (const r of rows) vecById.set(r.book_id, JSON.parse(r.e));
+  }
+  await c.end();
+  console.log(`Fetched CLIP vectors for ${vecById.size}/${idList.length} candidate records.`);
+
+  let confirmed = 0, likely = 0, distinct = 0, noVec = 0;
+  const out = [];
+  for (const g of groups) {
+    const members = [g.keeper.id, ...g.remove.map(r => r.id)];
+    const keeperVec = vecById.get(g.keeper.id);
+    const pairs = [];
+    for (const rid of g.remove.map(r => r.id)) {
+      const a = keeperVec, b = vecById.get(rid);
+      if (!a || !b) { pairs.push({ id: rid, verdict: 'no_vector' }); noVec++; continue; }
+      const sim = cosine(a, b);
+      const verdict = sim >= CONFIRM ? 'confirmed' : sim >= LIKELY ? 'likely' : 'distinct';
+      if (verdict === 'confirmed') confirmed++; else if (verdict === 'likely') likely++; else distinct++;
+      pairs.push({ id: rid, similarity: Math.round(sim * 1000) / 1000, verdict });
+    }
+    out.push({ tier: g.tier, key: g.key, keeper: g.keeper.id, title: g.keeper.title, pairs });
+  }
+
+  const result = {
+    generated_for: 'issue #2209 — CLIP confirmation of LOW-tier artwork dup candidates (READ-ONLY)',
+    thresholds: { confirmed: CONFIRM, likely: LIKELY },
+    tiers_checked: TIERS,
+    pair_counts: { confirmed, likely, distinct, no_vector: noVec },
+    groups: out,
+  };
+  writeFileSync(OUT, JSON.stringify(result, null, 2));
+
+  console.log(`\n── CLIP confirmation ──────────────────────────────`);
+  console.log(`Pairs checked:  ${confirmed + likely + distinct + noVec}`);
+  console.log(`  confirmed (>=${CONFIRM}):  ${confirmed}   real duplicates`);
+  console.log(`  likely (>=${LIKELY}):    ${likely}   visual sibling — review`);
+  console.log(`  distinct (<${LIKELY}):   ${distinct}   title collision, NOT a dup`);
+  console.log(`  no CLIP vector:      ${noVec}`);
+  console.log(`\nReport → ${OUT}`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/analysis/artwork-exact-duplicates.mjs
+++ b/scripts/analysis/artwork-exact-duplicates.mjs
@@ -1,0 +1,205 @@
+/**
+ * READ-ONLY detector for duplicate artwork RECORDS (#2209).
+ *
+ * Finds artwork docs (content_type:'artwork') that are the same object imported
+ * more than once — the Met/Rijks/Commons/e-manuscripta overlap. Groups by three
+ * exact-identity keys (strongest first) and, within each group, nominates a
+ * keeper by an evidence heuristic. Writes a review report; deletes NOTHING.
+ * Deletion of the non-keepers is a separate, sign-off-gated step (Data
+ * Protection CRITICAL: never batch-delete artworks without explicit approval).
+ *
+ * Identity keys (a group forms when ≥2 records share a value), tiered by trust:
+ *   1. commons_sha1 (HIGH) — Wikimedia file SHA-1. Identical = byte-identical
+ *                     file imported twice. Unambiguous; the actionable dedup list.
+ *   2. source_url (REVIEW) — image_source.source_url, the ORIGINAL record URL.
+ *                     A shared value usually means ONE museum object exploded
+ *                     into many child-image records (albums / multi-view: Met
+ *                     handscrolls, shunga pages) — NOT a dup import. Routes to
+ *                     convert-to-book (#2428) or manual review, not auto-delete.
+ *   3. title_author_year (LOW) — normalized title+author+year. Conflates
+ *                     same-SUBJECT with same-OBJECT (many "Adoration of the Magi";
+ *                     one "Atalanta Fugiens" per emblem). UNVERIFIED — needs CLIP
+ *                     visual confirmation, never a bulk-delete key.
+ * Keys are applied in priority order; a record already grouped by a
+ * higher-priority key is not re-grouped by a lower one (no double-counting).
+ * (commons_page_title was tried and dropped — it normalizes malformed values
+ * like "File:.jpg" to a shared junk key that groups unrelated works.)
+ *
+ * Keeper heuristic (first differentiator wins): visible > has enrichment >
+ * has collections > archived to R2 (image_display on images.sourcelibrary) >
+ * more populated fields > lexicographically smallest id (stable tiebreak).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/analysis/artwork-exact-duplicates.mjs [--json] [--out=path]
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync } from 'fs';
+
+const JSON_OUT = process.argv.includes('--json');
+const OUT = (process.argv.find(a => a.startsWith('--out=')) || '').split('=')[1]
+  || 'scripts/output/artwork-exact-duplicates.json';
+
+function norm(s) {
+  return (s || '').toString().toLowerCase().normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')       // strip diacritics
+    .replace(/[^a-z0-9]+/g, ' ').trim();   // collapse punctuation
+}
+
+// Normalize a source URL to its identity: strip protocol, trailing slash, query.
+function normUrl(u) {
+  if (!u) return '';
+  return u.toString().toLowerCase()
+    .replace(/^https?:\/\//, '').replace(/\/+$/, '').replace(/\?.*$/, '').trim();
+}
+
+function fieldScore(d) {
+  // Rough "how complete is this record" score for the keeper tiebreak.
+  let n = 0;
+  for (const k of ['title', 'author', 'published', 'summary', 'medium',
+    'current_location', 'commons_description', 'iconclass']) {
+    if (d[k] != null && d[k] !== '') n++;
+  }
+  if (Array.isArray(d.collections)) n += d.collections.length;
+  return n;
+}
+
+// Return the keeper (index into group) by the evidence heuristic.
+function pickKeeper(group) {
+  const scored = group.map(d => ({
+    d,
+    visible: d.visible === true ? 1 : 0,
+    enriched: d.enrichment && Object.keys(d.enrichment).length > 0 ? 1 : 0,
+    hasColl: Array.isArray(d.collections) && d.collections.length > 0 ? 1 : 0,
+    archived: /images\.sourcelibrary\.org/.test(d.image_display || d.image_full || '') ? 1 : 0,
+    fields: fieldScore(d),
+    id: d.id,
+  }));
+  scored.sort((a, b) =>
+    b.visible - a.visible || b.enriched - a.enriched || b.hasColl - a.hasColl ||
+    b.archived - a.archived || b.fields - a.fields || (a.id < b.id ? -1 : 1));
+  return scored[0].d;
+}
+
+async function main() {
+  const mc = new MongoClient(process.env.MONGODB_URI);
+  await mc.connect();
+  const db = mc.db('bookstore');
+
+  const docs = await db.collection('books').find(
+    { content_type: 'artwork' },
+    { projection: {
+      _id: 0, id: 1, title: 1, display_title: 1, author: 1, published: 1,
+      visible: 1, collections: 1, enrichment: 1, medium: 1, summary: 1,
+      current_location: 1, commons_description: 1, iconclass: 1,
+      commons_sha1: 1, image_display: 1, image_full: 1,
+      'image_source.source_url': 1, 'image_source.provider': 1,
+    }},
+  ).toArray();
+  console.log(`Scanning ${docs.length} artwork records...`);
+
+  const assigned = new Set(); // ids already placed in a group (higher-priority key wins)
+  const groups = [];          // { key, keyType, keeper, dupes:[...] }
+
+  // Confidence tiers. source_url / commons_title share the ORIGINAL identity, so
+  // a match is the same object (HIGH). title+author+year is only corroborating —
+  // it conflates same-subject with same-object (many "Adoration of the Magi",
+  // one "Atalanta Fugiens" per emblem), so it's LOW and never an auto-action key.
+  const keyPasses = [
+    { type: 'commons_sha1', tier: 'high', of: d => (d.commons_sha1 || '').trim() },
+    { type: 'source_url', tier: 'review', of: d => normUrl(d.image_source?.source_url) },
+    { type: 'title_author_year', tier: 'low', of: d => {
+        const t = norm(d.display_title || d.title);
+        const a = norm(d.author);
+        const y = norm(d.published);
+        // Require a real author AND year to even guess — kills cross-century
+        // same-subject collisions. Still LOW: same title+author+year can be
+        // distinct emblems/plates of one work. Needs visual (CLIP) confirmation.
+        return (t.length >= 6 && a && y) ? `${t}|${a}|${y}` : '';
+      } },
+  ];
+
+  for (const pass of keyPasses) {
+    const buckets = new Map();
+    for (const d of docs) {
+      if (assigned.has(d.id)) continue;
+      const k = pass.of(d);
+      if (!k) continue;
+      if (!buckets.has(k)) buckets.set(k, []);
+      buckets.get(k).push(d);
+    }
+    for (const [k, members] of buckets) {
+      if (members.length < 2) continue;
+      members.forEach(m => assigned.add(m.id));
+      const keeper = pickKeeper(members);
+      // Album fragments: many records sharing ONE original URL whose titles are
+      // sequential pages of one album (Met shunga, #2428). Not dup imports —
+      // they route to convert-to-book, so tag them out of the dedup count.
+      const titles = members.map(m => (m.display_title || m.title || ''));
+      const pageish = titles.filter(t =>
+        /\b(page|plate|fol\.?|leaf|scene|view|panel|p\.)\s*\d+/i.test(t) ||
+        /\d+\s*of\s*\d+/i.test(t) ||
+        /\b(cover|colophon|frontispiece|recto|verso)\b/i.test(t)).length;
+      const isAlbum = pass.type === 'source_url' && members.length >= 3 && pageish >= members.length * 0.5;
+      groups.push({
+        keyType: pass.type,
+        tier: isAlbum ? 'album_fragment' : pass.tier,
+        key: k.slice(0, 120),
+        size: members.length,
+        keeper: { id: keeper.id, title: keeper.display_title || keeper.title, visible: keeper.visible },
+        remove: members.filter(m => m.id !== keeper.id).map(m => ({
+          id: m.id, title: m.display_title || m.title, visible: m.visible,
+          provider: m.image_source?.provider,
+        })),
+      });
+    }
+  }
+
+  groups.sort((a, b) => b.size - a.size);
+  const tally = (tier) => {
+    const gs = groups.filter(g => g.tier === tier);
+    const recs = gs.reduce((n, g) => n + g.remove.length, 0);
+    const vis = gs.reduce((n, g) => n + g.remove.filter(r => r.visible).length, 0);
+    return { groups: gs.length, records: recs, visible: vis };
+  };
+  const tiers = {
+    high: tally('high'),                     // commons_sha1 — byte-identical, actionable dedup
+    review: tally('review'),                 // shared source_url, non-album — same original, review
+    low: tally('low'),                       // title+author+year — UNVERIFIED, over-reports
+    album_fragment: tally('album_fragment'), // pages of one album — route to #2428, NOT dedup
+  };
+
+  const report = {
+    generated_for: 'issue #2209 — artwork record dedup (READ-ONLY, no deletions)',
+    caveat: 'HIGH = commons_sha1 identical (byte-identical file, true dup import) — the '
+      + 'actionable dedup list. REVIEW = shared source_url (same original record, often '
+      + 'multi-view) — manual. LOW = title+author+year only; conflates same-subject with '
+      + 'same-object (distinct emblems, common religious subjects) — needs CLIP visual '
+      + 'confirmation, do NOT bulk-delete. album_fragment = per-page album records → #2428.',
+    scanned: docs.length,
+    tiers,
+    groups,
+  };
+
+  writeFileSync(OUT, JSON.stringify(report, null, 2));
+
+  if (JSON_OUT) { console.log(JSON.stringify(report, null, 2)); }
+  else {
+    console.log(`\n── Artwork duplicate report (tiered) ──────────────────────`);
+    console.log(`Scanned: ${docs.length}`);
+    console.log(`HIGH   (commons_sha1 byte-identical):  ${tiers.high.groups} groups, ${tiers.high.records} removable (${tiers.high.visible} visible)`);
+    console.log(`REVIEW (shared source_url, non-album):  ${tiers.review.groups} groups, ${tiers.review.records} records — manual`);
+    console.log(`LOW    (title-only — UNVERIFIED):       ${tiers.low.groups} groups, ${tiers.low.records} records — needs CLIP, do not bulk-delete`);
+    console.log(`ALBUM  (pages of one album → #2428):    ${tiers.album_fragment.groups} groups, ${tiers.album_fragment.records} fragments`);
+    console.log(`\nTop HIGH-tier groups (byte-identical dup imports):`);
+    for (const g of groups.filter(g => g.tier === 'high').slice(0, 12)) {
+      console.log(`  x${g.size}  keep=${g.keeper.id}  "${(g.keeper.title || '').slice(0, 48)}"`);
+    }
+    console.log(`\nFull report → ${OUT}`);
+    console.log(`NB: read-only. Any deletion needs explicit sign-off (Data Protection CRITICAL).`);
+  }
+
+  await mc.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/purge-artwork-duplicates.mjs
+++ b/scripts/maintenance/purge-artwork-duplicates.mjs
@@ -1,0 +1,141 @@
+/**
+ * Sign-off-gated purge of duplicate artwork records (#2209).
+ *
+ * SOFT-DELETES (recoverable) the non-keeper of each confirmed duplicate pair,
+ * mirroring the canonical delete path in src/app/api/books/[id]/route.ts:
+ * archive the full doc + any pages to `deleted_books`, then remove from the live
+ * collections. Every removed record is restorable via POST /api/books/restore/{id}.
+ *
+ * Input: the two READ-ONLY reports from the dedup detectors —
+ *   scripts/output/artwork-exact-duplicates.json        (HIGH: commons_sha1)
+ *   scripts/output/artwork-dedup-clip-confirmed.json     (CLIP verdict=confirmed)
+ *
+ * SAFETY (Data Protection CRITICAL — artworks are never batch-deleted casually):
+ *   • DRY-RUN by default. Nothing is deleted without --apply.
+ *   • HIDDEN-ONLY by default. Visible dups (the 2 public pairs) are skipped
+ *     unless --include-visible is passed, and are always listed individually.
+ *   • Keeper is NEVER deleted, and re-verified to still exist at apply-time.
+ *   • Each removable id is RE-VERIFIED live before deletion:
+ *       - still exists, is content_type:'artwork', and (unless --include-visible)
+ *         still visible:false;
+ *       - for the sha1 tier, still shares commons_sha1 with its keeper (guards a
+ *         stale report — the identity is re-confirmed against current data);
+ *       - keeper still present. Any failure → skip that record, don't delete.
+ *   • Prints BOTH the candidate count and the post-verify actual count.
+ *   • Writes a manifest of everything deleted (id, keeper, reason) before acting.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/purge-artwork-duplicates.mjs            # dry-run, both tiers, hidden-only
+ *   node scripts/maintenance/purge-artwork-duplicates.mjs --sha1-only
+ *   node scripts/maintenance/purge-artwork-duplicates.mjs --clip-only
+ *   node scripts/maintenance/purge-artwork-duplicates.mjs --apply    # DELETE (soft, recoverable)
+ *   node scripts/maintenance/purge-artwork-duplicates.mjs --apply --include-visible --limit=2
+ */
+import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync } from 'fs';
+
+const APPLY = process.argv.includes('--apply');
+const SHA1_ONLY = process.argv.includes('--sha1-only');
+const CLIP_ONLY = process.argv.includes('--clip-only');
+const INCLUDE_VISIBLE = process.argv.includes('--include-visible');
+const LIMIT = Number((process.argv.find(a => a.startsWith('--limit=')) || '').split('=')[1]) || 0;
+
+const SHA1_REPORT = 'scripts/output/artwork-exact-duplicates.json';
+const CLIP_REPORT = 'scripts/output/artwork-dedup-clip-confirmed.json';
+const MANIFEST = 'scripts/output/artwork-purge-manifest.json';
+
+function loadCandidates() {
+  const cands = new Map(); // removableId -> { id, keeper, reason, tier }
+  if (!CLIP_ONLY) {
+    const rep = JSON.parse(readFileSync(SHA1_REPORT, 'utf8'));
+    for (const g of rep.groups.filter(g => g.tier === 'high')) {
+      for (const r of g.remove) {
+        cands.set(r.id, { id: r.id, keeper: g.keeper.id, reason: 'commons_sha1 byte-identical', tier: 'sha1' });
+      }
+    }
+  }
+  if (!SHA1_ONLY) {
+    const rep = JSON.parse(readFileSync(CLIP_REPORT, 'utf8'));
+    for (const g of rep.groups) {
+      for (const p of g.pairs) {
+        if (p.verdict !== 'confirmed') continue;
+        // sha1 wins if a record is somehow in both — don't downgrade the reason.
+        if (!cands.has(p.id)) {
+          cands.set(p.id, { id: p.id, keeper: g.keeper, reason: `CLIP confirmed (${p.similarity})`, tier: 'clip' });
+        }
+      }
+    }
+  }
+  return [...cands.values()];
+}
+
+async function main() {
+  const candidates = loadCandidates();
+  console.log(`Candidates loaded: ${candidates.length} (sha1${CLIP_ONLY ? ' skipped' : ''}, clip${SHA1_ONLY ? ' skipped' : ''})`);
+
+  const mc = new MongoClient(process.env.MONGODB_URI);
+  await mc.connect();
+  const db = mc.db('bookstore');
+  const books = db.collection('books');
+
+  // Re-verify each candidate live.
+  const toDelete = [];
+  const skipped = { missing: 0, keeper_missing: 0, visible: 0, not_artwork: 0, sha1_mismatch: 0, self: 0 };
+  for (const c of candidates) {
+    if (c.id === c.keeper) { skipped.self++; continue; }
+    const dup = await books.findOne({ id: c.id }, { projection: { _id: 1, id: 1, title: 1, visible: 1, content_type: 1, commons_sha1: 1 } });
+    if (!dup) { skipped.missing++; continue; }
+    if (dup.content_type !== 'artwork') { skipped.not_artwork++; continue; }
+    if (!INCLUDE_VISIBLE && dup.visible === true) { skipped.visible++; continue; }
+    const keeper = await books.findOne({ id: c.keeper }, { projection: { _id: 1, id: 1, commons_sha1: 1, visible: 1 } });
+    if (!keeper) { skipped.keeper_missing++; continue; } // never orphan a pair by deleting the only copy
+    if (c.tier === 'sha1') {
+      if (!dup.commons_sha1 || dup.commons_sha1 !== keeper.commons_sha1) { skipped.sha1_mismatch++; continue; }
+    }
+    toDelete.push({ ...c, _id: dup._id, title: dup.title, visible: dup.visible === true });
+  }
+
+  const finalList = LIMIT ? toDelete.slice(0, LIMIT) : toDelete;
+  const visibleCount = finalList.filter(d => d.visible).length;
+
+  console.log(`\n── Purge plan (${APPLY ? 'APPLY' : 'DRY-RUN'}) ─────────────────────`);
+  console.log(`Candidates:           ${candidates.length}`);
+  console.log(`Skipped on re-verify: ${JSON.stringify(skipped)}`);
+  console.log(`Will soft-delete:     ${finalList.length}  (${visibleCount} currently visible)`);
+  if (visibleCount) console.log(`  visible dups: ${finalList.filter(d => d.visible).map(d => d.id).join(', ')}`);
+
+  // Always write the manifest (what would/did happen) before touching data.
+  writeFileSync(MANIFEST, JSON.stringify({
+    apply: APPLY, generated: 'purge-artwork-duplicates', include_visible: INCLUDE_VISIBLE,
+    count: finalList.length, visible_count: visibleCount,
+    records: finalList.map(d => ({ id: d.id, title: d.title, keeper: d.keeper, reason: d.reason, tier: d.tier, was_visible: d.visible })),
+  }, null, 2));
+  console.log(`Manifest → ${MANIFEST}`);
+
+  if (!APPLY) {
+    console.log(`\nDRY-RUN — no deletions. Re-run with --apply to soft-delete (recoverable via /api/books/restore/{id}).`);
+    await mc.close();
+    return;
+  }
+
+  // Soft-delete: archive to deleted_books (with any pages), then remove.
+  let done = 0;
+  for (const d of finalList) {
+    const book = await books.findOne({ _id: d._id });
+    if (!book) continue;
+    const pages = await db.collection('pages').find({ book_id: book.id }).maxTimeMS(30000).toArray();
+    await db.collection('deleted_books').insertOne({
+      ...book, pages, deleted_at: new Date(), original_id: book._id,
+      deleted_reason: `artwork dedup (#2209): ${d.reason}; keeper ${d.keeper}`,
+    });
+    if (pages.length) await db.collection('pages').deleteMany({ book_id: book.id });
+    await books.deleteOne({ _id: book._id });
+    done++;
+    if (done % 100 === 0) console.log(`  soft-deleted ${done}/${finalList.length}`);
+  }
+  console.log(`\nDone. Soft-deleted ${done} duplicate artworks (recoverable). Manifest at ${MANIFEST}.`);
+  await mc.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
The full artwork-record dedup workstream for #2209 — three scripts. The first two are read-only; the third deletes only behind `--apply` + sign-off.

## 1. `scripts/analysis/artwork-exact-duplicates.mjs` (read-only)
Tiered exact-duplicate detector. Live run over 26,392 artworks:
| Tier | Key | Removable | Confidence |
|---|---|---|---|
| HIGH | `commons_sha1` byte-identical | 1,372 (0 visible) | Unambiguous |
| REVIEW | shared `source_url`, non-album | 2 | Manual |
| LOW | title+author+year | 601 | Unverified → CLIP |
| album | per-page album records | 91 | → #2428 |

## 2. `scripts/analysis/artwork-dedup-clip-confirm.mjs` (read-only)
Resolves the LOW tier with CLIP visual similarity (no 26K² self-join — scores only the title-grouped pairs). Of 601: **111 confirmed** (≥0.97, only 2 visible), 185 likely, **307 distinct (not dupes)**.

## 3. `scripts/maintenance/purge-artwork-duplicates.mjs` (gated delete)
Soft-deletes the non-keeper of each confirmed pair, mirroring the canonical `deleted_books` archive path (recoverable via `/api/books/restore/{id}`). **DRY-RUN by default; HIDDEN-ONLY by default** (the 2 visible pairs held back unless `--include-visible`). Re-verifies every id live before deleting (exists, artwork, still hidden, sha1 still matches keeper) so a stale report can't misfire. Dry-run: **1,481 hidden dups queued, 2 visible held back, 0 mismatches.**

## Findings / net state
- Public gallery has **2 actual visible duplicate pairs**; ~1,481 removable are hidden dead-weight.
- Naive title-clustering over-reports ~half (307/601 distinct) — the tiering + CLIP catches it.

## Not in this PR
No deletions performed. `--apply` awaits sign-off. Findings posted to #2209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)