### PR TITLE
feat(collections): inline markdown deep-links in collection descriptions

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -125,7 +125,49 @@ interface CuratedHighlight {
 
 /** Auto-link book titles found in description text to their book pages.
  *  Explicit mentions (from collection.mentioned_books) take priority over auto-detection. */
+// Inline markdown links [anchor](/path) authored in a collection description.
+// Only INTERNAL hrefs (starting with "/") are honored — this both matches the
+// intended use (deep links to /book/<id>/page/<pageId>) and blocks javascript:
+// or off-site hrefs from admin-authored prose. Everything outside a markdown
+// link is still run through the book-title / author auto-linker.
+const MD_LINK_RE = /\[([^\]\n]+)\]\((\/[^)\s]+)\)/g;
+
 function linkBookTitles(
+  text: string,
+  allBooks: BookItem[],
+  explicitMentions?: { text: string; book_id: string }[],
+  tenantSlug?: string | null,
+  authorLinks: { name: string; href: string; canonical?: string; count?: number }[] = [],
+): React.ReactNode {
+  MD_LINK_RE.lastIndex = 0;
+  if (!MD_LINK_RE.test(text)) {
+    return autoLinkPlain(text, allBooks, explicitMentions, tenantSlug, authorLinks);
+  }
+  MD_LINK_RE.lastIndex = 0;
+  const out: React.ReactNode[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let k = 0;
+  while ((m = MD_LINK_RE.exec(text)) !== null) {
+    if (m.index > last) {
+      out.push(autoLinkPlain(text.slice(last, m.index), allBooks, explicitMentions, tenantSlug, authorLinks));
+    }
+    const anchor = m[1];
+    const href = m[2];
+    out.push(
+      <Link key={`md-${k++}-${m.index}`} href={href} className="text-accent-rust hover:underline italic">
+        {anchor}
+      </Link>
+    );
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) {
+    out.push(autoLinkPlain(text.slice(last), allBooks, explicitMentions, tenantSlug, authorLinks));
+  }
+  return <>{out}</>;
+}
+
+function autoLinkPlain(
   text: string,
   allBooks: BookItem[],
   explicitMentions?: { text: string; book_id: string }[],


### PR DESCRIPTION
## What

Adds support for inline `[anchor](/path)` markdown links inside collection `expanded_description` prose. Renders them as real `<Link>` elements, running alongside the existing book-title / author auto-linker (which only ever produced book-*landing* links).

This unblocks threading **deep links to specific interior pages** (`/book/<slug>/page/<pageId>`) into collection descriptions — the same pattern the blog essays already use — so a description can point at a specific plate or passage, not just the book.

## Scope / safety

- Only **internal** hrefs (starting with `/`) are honored — blocks `javascript:` / off-site hrefs from admin-authored prose.
- **No behavior change** for existing descriptions: with no markdown links present, `linkBookTitles` falls straight through to the old `autoLinkPlain` path.
- Inert until content uses it. This should ship to prod **before** any markdown-link description is written to Mongo, or those pages would render raw `[text](url)` for up to 24h (CDN HTML cache).

## Out of scope

The actual de-telled + deep-linked descriptions (issue #3038) are a separate content change, written only after this is live. Deep links are constrained to books with `pages_count > 0` (facsimiles have no reader pages); every link is body-validated before write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)