### PR TITLE
fix(text-role): explicit is_translation hint + preserve human QA

### DIFF
--- a/scripts/maintenance/classify-text-role.mjs
+++ b/scripts/maintenance/classify-text-role.mjs
@@ -60,6 +60,15 @@ function coerceYear(...vals) {
 }
 
 function classify(book) {
+  // Explicit translation hint wins over the language proxy below (which assumes
+  // every non-English scan is an original). Mirrors classifyTextRole() in
+  // src/lib/text-role.ts — keep in sync. #2395.
+  if (book.is_translation === true) {
+    const yr = coerceYear(book.year, book.published, book.original_work_year);
+    const role = yr && yr > 0 && yr < 1700 ? 'period-translation' : 'modern-translation';
+    return { role, loeb: false };
+  }
+
   // Non-English scan → it's an original-language source.
   if (!enLike(book.language)) return { role: 'original', loeb: false };
 
@@ -104,7 +113,7 @@ async function main() {
     : { visible: true };
   const cursor = col.find(
     query,
-    { projection: { _id: 0, id: 1, title: 1, author: 1, year: 1, published: 1, original_work_year: 1, language: 1, original_language: 1, read_count: 1 } },
+    { projection: { _id: 0, id: 1, title: 1, author: 1, year: 1, published: 1, original_work_year: 1, language: 1, original_language: 1, is_translation: 1, text_role_source: 1, read_count: 1 } },
   );
 
   const dist = { original: 0, 'period-translation': 0, 'modern-translation': 0 };
@@ -112,9 +121,13 @@ async function main() {
   const samples = { 'period-translation': [], 'modern-translation': [] };
   const ops = [];
 
+  let skippedManual = 0;
   for await (const b of cursor) {
     if (limit && processed >= limit) break;
     processed++;
+    // Never clobber a human-QA'd label — the heuristic can't see what a person
+    // verified (e.g. an English-only translation the title didn't flag).
+    if (b.text_role_source === 'manual-qa') { skippedManual++; continue; }
     const { role, loeb } = classify(b);
     dist[role]++;
     if (loeb) loebCount++;
@@ -134,6 +147,7 @@ async function main() {
   console.log(`  original:            ${dist.original}`);
   console.log(`  period-translation:  ${dist['period-translation']}`);
   console.log(`  modern-translation:  ${dist['modern-translation']} (incl. ${loebCount} Loeb/SBE)`);
+  console.log(`  skipped (manual-qa): ${skippedManual}`);
   if (!dryRun) console.log(`  modifiedCount:       ${written}`);
   console.log('\nperiod-translation samples:'); samples['period-translation'].forEach(s => console.log('  ', s));
   console.log('\nmodern-translation samples:'); samples['modern-translation'].forEach(s => console.log('  ', s));

--- a/src/lib/text-role.ts
+++ b/src/lib/text-role.ts
@@ -52,6 +52,13 @@ export interface ClassifiableBook {
   year?: number | string | null;
   published?: string | null;
   original_work_year?: number | string | null;
+  /**
+   * Explicit "this scan is a translation" hint from the import driver. The ONLY
+   * reliable signal for a non-English *translation* (Chaignet's French
+   * Damascius, Charles's English John of Nikiu) — the language proxy below
+   * assumes every non-English scan is an original and would mislabel these.
+   */
+  is_translation?: boolean | null;
 }
 
 /** First 4-digit year found in the given values, or NaN. */
@@ -66,6 +73,15 @@ function coerceYear(...vals: Array<number | string | null | undefined>): number 
 }
 
 export function classifyTextRole(book: ClassifiableBook): { text_role: TextRole; original_in_scan: boolean } {
+  // Explicit translation hint wins over the language proxy below (which would
+  // otherwise force any non-English scan to 'original'). Split by era so a
+  // pre-1700 rendering still reads as a period-translation artifact. #2395.
+  if (book.is_translation === true) {
+    const yr = coerceYear(book.year, book.published, book.original_work_year);
+    const role: TextRole = yr && yr > 0 && yr < 1700 ? 'period-translation' : 'modern-translation';
+    return { text_role: role, original_in_scan: false };
+  }
+
   // Non-English scan → original-language source.
   if (!enLike(book.language)) return { text_role: 'original', original_in_scan: false };
 
@@ -95,6 +111,13 @@ export function classifyTextRole(book: ClassifiableBook): { text_role: TextRole;
  * trusts it. Call right before `insertOne`.
  */
 export function applyTextRole(bookDoc: Record<string, unknown>): void {
+  // A caller that already knows the role (explicit import metadata, or a human
+  // QA value) wins — only auto-derive when text_role is absent. This lets an
+  // import driver hard-set `text_role` for editions the heuristic can't read.
+  if (typeof bookDoc.text_role === 'string' && bookDoc.text_role) {
+    if (!bookDoc.text_role_source) bookDoc.text_role_source = 'import-explicit';
+    return;
+  }
   const { text_role, original_in_scan } = classifyTextRole(bookDoc as ClassifiableBook);
   bookDoc.text_role = text_role;
   bookDoc.text_role_source = 'import-heuristic-v1';

--- a/tests/unit/text-role.test.ts
+++ b/tests/unit/text-role.test.ts
@@ -45,6 +45,24 @@ describe('classifyTextRole', () => {
     expect(classifyTextRole({ language: 'English', title: 'Englished out of the Greek', author: 'Anon', published: 'London, 1899' }).text_role)
       .toBe('modern-translation');
   });
+
+  it('explicit is_translation hint overrides the language proxy for non-English translations', () => {
+    // Charles's 1916 English translation of John of Nikiu — no title/author
+    // translation signal, so the heuristic alone reads it as English-native.
+    expect(classifyTextRole({ language: 'English', title: 'John Of Nikiu Chronicle 1916', author: 'John of Nikiu', year: 1916, is_translation: true }).text_role)
+      .toBe('modern-translation');
+    // Chaignet's French Damascius — non-English, so the proxy would force 'original'.
+    expect(classifyTextRole({ language: 'French', title: 'Vie de Porphyre', author: 'Bidez', year: 1913, is_translation: true }).text_role)
+      .toBe('modern-translation');
+    // A pre-1700 rendering with the hint is still a period-translation.
+    expect(classifyTextRole({ language: 'German', title: 'Ein Alt Werk', author: 'Anon', year: 1580, is_translation: true }).text_role)
+      .toBe('period-translation');
+  });
+
+  it('is_translation false / absent falls through to the normal heuristic', () => {
+    expect(classifyTextRole({ language: 'German', title: 'Aurora', author: 'Böhme', is_translation: false }).text_role)
+      .toBe('original');
+  });
 });
 
 describe('applyTextRole', () => {
@@ -63,6 +81,20 @@ describe('applyTextRole', () => {
     const plain: Record<string, unknown> = { language: 'German', title: 'Aurora', author: 'Böhme' };
     applyTextRole(plain);
     expect(plain.original_in_scan).toBeUndefined();
+  });
+
+  it('respects an explicit pre-set text_role instead of re-deriving', () => {
+    // A driver hard-sets the role for an edition the heuristic would misread.
+    const doc: Record<string, unknown> = { language: 'French', title: 'Vie de Porphyre', author: 'Bidez', text_role: 'modern-translation' };
+    applyTextRole(doc);
+    expect(doc.text_role).toBe('modern-translation');
+    expect(doc.text_role_source).toBe('import-explicit');
+  });
+
+  it('honours an is_translation hint passed through the doc', () => {
+    const doc: Record<string, unknown> = { language: 'English', title: 'John Of Nikiu Chronicle 1916', author: 'John of Nikiu', year: 1916, is_translation: true };
+    applyTextRole(doc);
+    expect(doc.text_role).toBe('modern-translation');
   });
 });
 


### PR DESCRIPTION
## Problem
`classifyTextRole()` (src/lib/text-role.ts) and its offline twin `classify()` (scripts/maintenance/classify-text-role.mjs) both force **any non-English scan to `text_role: 'original'`**. That mislabels translations as source-language originals — a false "we hold the original" claim:

- **Charles's 1916 English *John of Nikiu*** — English, no `transl`/`tr.` signal in title or author, so it read as an English-native original.
- **Chaignet's French Damascius / non-English translations** — non-English, so the language proxy short-circuits to `original` before any signal is checked.

Surfaced during the SHWEP acquisition QA (see handoff `2026-06-27-shwep-fix-acquire-and-search.md`, thread #4). Umbrella #2395.

## Fix (in scope)
- **Explicit `is_translation: true` hint** from the import driver now wins over the language proxy in both `classifyTextRole()` and `classify()` (kept in sync), era-split so a pre-1700 rendering stays `period-translation`.
- **`applyTextRole()`** respects a pre-set `text_role` (or `is_translation` on the doc) instead of unconditionally re-deriving — lets a driver hard-set the role for editions the heuristic can't read; marks provenance `import-explicit`.
- **Offline sweep** skips `text_role_source: 'manual-qa'` records, so a human QA fix (e.g. the John of Nikiu record, already corrected in the DB) survives the next full re-classify instead of being clobbered back to `heuristic-v1`.

## Out of scope
- Import drivers don't yet *pass* `is_translation` for known-translation editions — this PR makes the hint **honoured**; wiring specific drivers to emit it is follow-up.
- Chaignet's visible copy is a `French/Greek` facing-text edition (contains the Greek fragments), so it's left as `original` — not a clear mislabel. Only the unambiguous English-only translation (John of Nikiu) was corrected in data.

## Tests
`tests/unit/text-role.test.ts` — added hint-override, pass-through, false/absent fall-through, and pre-set-role cases. 14 pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)