### PR TITLE
fix(image-extraction): de-tell the museum_description prompt

### DIFF
--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -209,7 +209,7 @@ For each significant illustration return:
     "style": "Northern European Renaissance",
     "technique": "woodcut"
   },
-  "museum_description": "A compelling allegorical scene depicting... This exemplifies early modern alchemical imagery..."
+  "museum_description": "A robed figure holds a serpent that bites its own tail while standing over a lit furnace. The ouroboros and the athanor identify the scene as one of alchemical transmutation."
 }
 
 GALLERY QUALITY (0.0-1.0):
@@ -218,7 +218,7 @@ GALLERY QUALITY (0.0-1.0):
 - 0.6-0.8: Good illustrations without people
 - 0.4-0.6: Musical scores, alchemical symbols
 
-MUSEUM DESCRIPTION: Write 2-3 sentences for a museum label - what the viewer sees and its significance.
+MUSEUM DESCRIPTION: Write 2-3 plain sentences for a museum label: first what the viewer sees, then what it depicts or means. Name concrete things. Do NOT use promotional or filler language. Avoid the words "serves as", "stands as", "a testament to", "renowned", "profound", "delve", "intricate", "vibrant", "compelling", "exemplifies", "masterful", and the construction "not only X but also Y". State what is shown, not how significant it is.
 
 ────────────────────────────────────────────────────────────────────────────────
 PAGE-LEVEL SCAN QUALITY (technical, not curatorial)

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2016,7 +2016,7 @@ For each significant illustration return:
     "style": "Northern European Renaissance",
     "technique": "woodcut"
   },
-  "museum_description": "A compelling allegorical scene depicting... This exemplifies early modern alchemical imagery..."
+  "museum_description": "A robed figure holds a serpent that bites its own tail while standing over a lit furnace. The ouroboros and the athanor identify the scene as one of alchemical transmutation."
 }
 
 GALLERY QUALITY (0.0-1.0):
@@ -2025,7 +2025,7 @@ GALLERY QUALITY (0.0-1.0):
 - 0.6-0.8: Good illustrations without people
 - 0.4-0.6: Musical scores, alchemical symbols
 
-MUSEUM DESCRIPTION: Write 2-3 sentences for a museum label - what the viewer sees and its significance.
+MUSEUM DESCRIPTION: Write 2-3 plain sentences for a museum label: first what the viewer sees, then what it depicts or means. Name concrete things. Do NOT use promotional or filler language. Avoid the words "serves as", "stands as", "a testament to", "renowned", "profound", "delve", "intricate", "vibrant", "compelling", "exemplifies", "masterful", and the construction "not only X but also Y". State what is shown, not how significant it is.
 
 Return ONLY a valid JSON array. If no significant illustrations, return: []`;
 

--- a/src/lib/image-extraction.ts
+++ b/src/lib/image-extraction.ts
@@ -48,7 +48,7 @@ For each significant illustration return:
     "technique": "woodcut",
     "iconclass": ["49E39", "25FF41"]
   },
-  "museum_description": "A compelling allegorical scene depicting... This exemplifies early modern alchemical imagery..."
+  "museum_description": "A robed figure holds a serpent that bites its own tail while standing over a lit furnace. The ouroboros and the athanor identify the scene as one of alchemical transmutation."
 }
 
 GALLERY QUALITY (0.0-1.0):
@@ -57,7 +57,7 @@ GALLERY QUALITY (0.0-1.0):
 - 0.6-0.8: Good illustrations without people
 - 0.4-0.6: Musical scores, alchemical symbols
 
-MUSEUM DESCRIPTION: Write 2-3 sentences for a museum label - what the viewer sees and its significance.
+MUSEUM DESCRIPTION: Write 2-3 plain sentences for a museum label: first what the viewer sees, then what it depicts or means. Name concrete things. Do NOT use promotional or filler language. Avoid the words "serves as", "stands as", "a testament to", "renowned", "profound", "delve", "intricate", "vibrant", "compelling", "exemplifies", "masterful", and the construction "not only X but also Y". State what is shown, not how significant it is.
 
 ICONCLASS: Assign 2-5 Iconclass codes (iconclass.org) in metadata.iconclass. Use the most specific code that applies. Example: "49E39" for alchemy, "25F23(LION)" for a lion, "98C231" for Claudia Quinta. Parenthetical qualifiers add specificity. See the classification context appended below (if present) for guidance.
 


### PR DESCRIPTION
## What

The image-extraction prompt (in `src/lib/image-extraction.ts` and its two worker copies — `image-extract-worker.mjs`, `pipeline-orchestrator.mjs`) generated the `museum_description` for detected illustrations and artworks. Its instruction ("what the viewer sees and its significance") plus a worked example that itself modelled puffery ("A **compelling** allegorical scene... This **exemplifies**...") produced AI museum-speak.

An AI-tell audit found the artwork descriptions (18K `content_type:'artwork'` records) leaned on "serves as" (×221 / 5K sampled), "renowned" (×170), "stands as" (×64), "profound" (×106), "delve" (×56).

## Change

- Replaced the example with a concrete, de-telled one.
- Added explicit negative guidance to the instruction: name concrete things; no promotional/filler vocabulary (serves as / stands as / a testament to / renowned / profound / delve / intricate / vibrant / compelling / exemplifies / masterful); no "not only X but also Y".
- Applied identically to all three copies (rubric-drift watch per CLAUDE.md).

## Scope

Forward-looking only — fixes future extractions. Re-running over the ~18K existing artwork descriptions is a **separate, paid** Gemini batch and needs sign-off (issue #3039). No behavior change beyond the generated text style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)