### PR TITLE
fix(ft): add volume/container guard to Tier-0 catalog matcher (#3044)

### DIFF
--- a/scripts/eval/ft-catalog-match.mjs
+++ b/scripts/eval/ft-catalog-match.mjs
@@ -47,6 +47,9 @@
  *       does NOT defeat a Greek→En first)      only defeat Latin-source books
  *   (d) person-disambiguated, not a namesake  (NAMESAKE guard) — surname match
  *                                             alone is low-confidence
+ *   (e) not a single-volume-vs-whole match    (VOLUME guard, #3044) — a numbered
+ *                                             volume of a set is not the same work
+ *                                             as the whole "Opera omnia" container
  * Anything failing a guard → "needs_review", never an auto-demote candidate.
  *
  * Usage:
@@ -125,6 +128,63 @@ function bookTitleCoverage(bookTitle, priorTitle) {
   if (bookToks.length === 0) return 0;
   const found = bookToks.filter((t) => priorToks.has(t));
   return found.length / bookToks.length;
+}
+
+// ── Volume / part enumeration (mirrors scripts/iiif-discovery/dedupe-candidates.mjs
+//    and src/lib/ft-prior-guard.ts checkVolume) ──────────────────────────────────
+// A single numbered volume/part of a set is NOT the same work as the whole
+// container. "Opera Omnia Vol. 1" ⇔ catalog "Opera omnia" (whole) was the shared
+// signature of all 6 false merges in the #2885(b) alignment gold (#3044). Extract
+// an explicit enumeration so the guard can reject one-vs-whole and vol-1-vs-vol-2.
+
+// Tibetan pecha volumes are labelled by the consonant order (ka, kha, ga …), so a
+// letter token after a volume marker is a real enumeration too.
+const TIBETAN_VOLUME_LETTERS = [
+  'ka', 'kha', 'ga', 'nga', 'ca', 'cha', 'ja', 'nya', 'ta', 'tha', 'da', 'na',
+  'pa', 'pha', 'ba', 'ma', 'tsa', 'tsha', 'dza', 'wa', 'zha', 'za', 'ya', 'ra',
+  'la', 'sha', 'sa', 'ha', 'a',
+];
+const VOLUME_RE_WESTERN = new RegExp(
+  '\\b(?:vol(?:ume|umen|s)?|tom(?:e|us|o|i)?|band|bd|teil|th(?:eil)?|part(?:e|s)?|pt|pars|deel|abteilung|fasc(?:icule|iculus)?)\\b\\.?\\s*'
+  + `([0-9]+|[ivxlcdm]+|${TIBETAN_VOLUME_LETTERS.join('|')})\\b`,
+  'i',
+);
+const VOLUME_RE_CJK = /第?([0-9〇一二三四五六七八九十百千]+)\s*[卷冊册巻号輯辑編编集]/;
+const ROMAN = { i: 1, v: 5, x: 10, l: 50, c: 100, d: 500, m: 1000 };
+function romanToInt(s) {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) {
+    const v = ROMAN[s[i]], next = ROMAN[s[i + 1]] || 0;
+    n += v < next ? -v : v;
+  }
+  return n;
+}
+const CJK_DIGITS = { '〇': 0, '一': 1, '二': 2, '三': 3, '四': 4, '五': 5, '六': 6, '七': 7, '八': 8, '九': 9 };
+function cjkNumeral(s) {
+  if (/^[0-9]+$/.test(s)) return parseInt(s, 10);
+  let total = 0, current = 0;
+  for (const ch of s) {
+    if (ch in CJK_DIGITS) current = CJK_DIGITS[ch];
+    else if (ch === '十') { total += (current || 1) * 10; current = 0; }
+    else if (ch === '百') { total += (current || 1) * 100; current = 0; }
+    else if (ch === '千') { total += (current || 1) * 1000; current = 0; }
+  }
+  return total + current;
+}
+
+/** Extract a normalized volume/part key from a title, or null if none. */
+function volumeKey(title) {
+  if (!title) return null;
+  const w = title.toLowerCase().match(VOLUME_RE_WESTERN);
+  if (w) {
+    const raw = w[1];
+    if (/^[0-9]+$/.test(raw)) return `w${parseInt(raw, 10)}`;
+    if (/^[ivxlcdm]+$/.test(raw)) return `w${romanToInt(raw)}`;
+    return `t${raw}`; // Tibetan volume letter
+  }
+  const c = title.match(VOLUME_RE_CJK);
+  if (c) return `c${cjkNumeral(c[1])}`;
+  return null;
 }
 
 // Generic / collective "authors" whose surname is a meaningless join key — a
@@ -245,6 +305,27 @@ function guardSourceLang(book, row) {
   return { pass: false, reason: `source-language mismatch: book=${bookIso} ("${book.language}") vs catalog=${catIso}` };
 }
 
+/**
+ * (e) Volume/container guard (#3044). Pass = the pair is NOT a single-volume-
+ * vs-whole (or different-volume) mismatch. Fires when exactly one side carries
+ * an explicit volume/part enumeration (a single volume of a set matched against
+ * the whole opera, or vice-versa), or when both carry enumerations that differ.
+ * A single numbered volume of a collected-works set is not the same work as the
+ * whole container — auto-demoting on such a match was the shared signature of
+ * all 6 false merges in the #2885(b) alignment gold.
+ */
+function guardVolume(book, row) {
+  const bookVol = volumeKey(book.title);
+  const priorVol = volumeKey(row.english_title || '') || volumeKey(row.canonical_work || '');
+  if (!bookVol && !priorVol) return { pass: true, reason: 'no volume/part enumeration on either side' };
+  if (bookVol && priorVol) {
+    if (bookVol === priorVol) return { pass: true, reason: `same volume enumeration (${bookVol})` };
+    return { pass: false, reason: `different volume enumerations: book=${bookVol} vs catalog=${priorVol}` };
+  }
+  if (bookVol) return { pass: false, reason: `book is a single volume/part (${bookVol}) but the catalog prior is the whole work/container` };
+  return { pass: false, reason: `catalog prior is a single volume/part (${priorVol}) but the book is the whole work/container` };
+}
+
 /** (d) Namesake / person-disambiguation guard. Pass = strong author signal. */
 function guardNamesake(book, row, authorJaccard) {
   // A bare surname collision is the classic namesake trap. Require either a
@@ -329,14 +410,16 @@ export function matchBookToCatalog(book, bySurname) {
     const gComp = guardComplete(row);
     const gLang = guardSourceLang(book, row);
     const gName = guardNamesake(book, row, aJac);
+    const gVol = guardVolume(book, row);
 
     const guards = {
       ANTHOLOGY: gAnth,
       COMPLETENESS: gComp,
       SOURCE_LANG: gLang,
       NAMESAKE: gName,
+      VOLUME: gVol,
     };
-    const allPass = gAnth.pass && gComp.pass && gLang.pass && gName.pass;
+    const allPass = gAnth.pass && gComp.pass && gLang.pass && gName.pass && gVol.pass;
     const failed = Object.entries(guards).filter(([, g]) => !g.pass).map(([k]) => k);
 
     matches.push({
@@ -358,6 +441,7 @@ export function matchBookToCatalog(book, bySurname) {
         COMPLETENESS: gComp,
         SOURCE_LANG: gLang,
         NAMESAKE: gName,
+        VOLUME: gVol,
       },
       all_guards_pass: allPass,
       failed_guards: failed,
@@ -368,8 +452,8 @@ export function matchBookToCatalog(book, bySurname) {
 
   // Best match = most guards passed, then highest combined signal.
   matches.sort((a, b) => {
-    const ap = 4 - a.failed_guards.length;
-    const bp = 4 - b.failed_guards.length;
+    const ap = 5 - a.failed_guards.length;
+    const bp = 5 - b.failed_guards.length;
     if (ap !== bp) return bp - ap;
     return (b.author_overlap + b.title_coverage) - (a.author_overlap + a.title_coverage);
   });
@@ -666,7 +750,8 @@ function renderMarkdown(summary, demote, review) {
 export {
   normalise, sigTokens, tokenOverlap, bookTitleCoverage,
   isGenericAuthor, extractSurname, bookSourceIso,
-  guardAnthology, guardComplete, guardSourceLang, guardNamesake,
+  guardAnthology, guardComplete, guardSourceLang, guardNamesake, guardVolume,
+  volumeKey,
   authorOverlap, titleSignal,
   MIN_TITLE_COVERAGE, MIN_AUTHOR_JACCARD_FOR_MATCH,
 };

--- a/src/lib/ft-prior-guard.ts
+++ b/src/lib/ft-prior-guard.ts
@@ -7,8 +7,10 @@
  * 1. SELF_MATCH     — the cited prior IS the book's own catalog record
  * 2. ANTHOLOGY      — the cited prior is an anthology/collected-works, not a
  *                     translation of this specific work
- * 3. PARTIAL        — the cited prior is partial/excerpts (doesn't defeat "first complete")
- * 4. LOW_CONFIDENCE — source-language mismatch or namesake heuristics (low confidence only)
+ * 3. VOLUME         — the book is a single numbered volume/part of a set and the
+ *                     cited prior is the whole container (or a different volume)
+ * 4. PARTIAL        — the cited prior is partial/excerpts (doesn't defeat "first complete")
+ * 5. LOW_CONFIDENCE — source-language mismatch or namesake heuristics (low confidence only)
  *
  * Guards see only the *cited evidence* — passing all guards does NOT prove
  * the book IS a first translation, only that the cited evidence doesn't justify
@@ -40,6 +42,7 @@ export interface CitedPriorInput {
 export type GuardId =
   | 'SELF_MATCH'
   | 'ANTHOLOGY'
+  | 'VOLUME'
   | 'PARTIAL'
   | 'LOW_CONFIDENCE';
 
@@ -268,7 +271,87 @@ function checkAnthology(
   };
 }
 
-// ── Guard 3: Partial completeness ─────────────────────────────────────────────
+// ── Guard 3: Volume / container mismatch (#3044) ──────────────────────────────
+
+/**
+ * A single numbered volume/part of a collected-works set is NOT the same work as
+ * the whole container. "Opera Omnia Vol. 1" ⇔ a cited whole "Opera omnia" was the
+ * shared signature of all 6 false merges in the #2885(b) alignment gold. Extract
+ * an explicit volume/part enumeration so the guard can reject one-vs-whole and
+ * vol-1-vs-vol-2. Mirrors volumeKey() in scripts/eval/ft-catalog-match.mjs and
+ * scripts/iiif-discovery/dedupe-candidates.mjs.
+ */
+// Tibetan pecha volumes are labelled by the consonant order (ka, kha, ga …).
+const TIBETAN_VOLUME_LETTERS = [
+  'ka', 'kha', 'ga', 'nga', 'ca', 'cha', 'ja', 'nya', 'ta', 'tha', 'da', 'na',
+  'pa', 'pha', 'ba', 'ma', 'tsa', 'tsha', 'dza', 'wa', 'zha', 'za', 'ya', 'ra',
+  'la', 'sha', 'sa', 'ha', 'a',
+];
+const VOLUME_RE_WESTERN = new RegExp(
+  '\\b(?:vol(?:ume|umen|s)?|tom(?:e|us|o|i)?|band|bd|teil|th(?:eil)?|part(?:e|s)?|pt|pars|deel|abteilung|fasc(?:icule|iculus)?)\\b\\.?\\s*'
+  + `([0-9]+|[ivxlcdm]+|${TIBETAN_VOLUME_LETTERS.join('|')})\\b`,
+  'i',
+);
+const VOLUME_RE_CJK = /第?([0-9〇一二三四五六七八九十百千]+)\s*[卷冊册巻号輯辑編编集]/;
+const ROMAN: Record<string, number> = { i: 1, v: 5, x: 10, l: 50, c: 100, d: 500, m: 1000 };
+function romanToInt(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) {
+    const v = ROMAN[s[i]] ?? 0, next = ROMAN[s[i + 1]] ?? 0;
+    n += v < next ? -v : v;
+  }
+  return n;
+}
+const CJK_DIGITS: Record<string, number> = { '〇': 0, '一': 1, '二': 2, '三': 3, '四': 4, '五': 5, '六': 6, '七': 7, '八': 8, '九': 9 };
+function cjkNumeral(s: string): number {
+  if (/^[0-9]+$/.test(s)) return parseInt(s, 10);
+  let total = 0, current = 0;
+  for (const ch of s) {
+    if (ch in CJK_DIGITS) current = CJK_DIGITS[ch];
+    else if (ch === '十') { total += (current || 1) * 10; current = 0; }
+    else if (ch === '百') { total += (current || 1) * 100; current = 0; }
+    else if (ch === '千') { total += (current || 1) * 1000; current = 0; }
+  }
+  return total + current;
+}
+
+/** Extract a normalized volume/part key from a title, or null if none. */
+function volumeKey(title: string | undefined): string | null {
+  if (!title) return null;
+  const w = title.toLowerCase().match(VOLUME_RE_WESTERN);
+  if (w) {
+    const raw = w[1];
+    if (/^[0-9]+$/.test(raw)) return `w${parseInt(raw, 10)}`;
+    if (/^[ivxlcdm]+$/.test(raw)) return `w${romanToInt(raw)}`;
+    return `t${raw}`; // Tibetan volume letter
+  }
+  const c = title.match(VOLUME_RE_CJK);
+  if (c) return `c${cjkNumeral(c[1])}`;
+  return null;
+}
+
+/**
+ * Fires when exactly one side carries an explicit volume/part enumeration (a
+ * single volume matched against the whole container, or vice-versa), or when
+ * both sides carry enumerations that differ. A single numbered volume of a set
+ * is not the same work as the whole "Opera omnia".
+ */
+function checkVolume(
+  book: BookInput,
+  prior: CitedPriorInput,
+): { fired: boolean; reason: string } {
+  const bookVol = volumeKey(book.title);
+  const priorVol = volumeKey(prior.english_title) || volumeKey(prior.series);
+  if (!bookVol && !priorVol) return { fired: false, reason: 'no volume/part enumeration on either side' };
+  if (bookVol && priorVol) {
+    if (bookVol === priorVol) return { fired: false, reason: `same volume enumeration (${bookVol})` };
+    return { fired: true, reason: `different volume enumerations: book=${bookVol} vs cited prior=${priorVol}` };
+  }
+  if (bookVol) return { fired: true, reason: `book is a single volume/part (${bookVol}) but the cited prior is the whole work/container` };
+  return { fired: true, reason: `cited prior is a single volume/part (${priorVol}) but the book is the whole work/container` };
+}
+
+// ── Guard 4: Partial completeness ─────────────────────────────────────────────
 
 /**
  * Fires when the cited prior is explicitly partial, excerpts, or an annotated
@@ -301,7 +384,7 @@ function checkPartial(
   return { fired: false, reason: `completeness=${completeness ?? 'not set'}` };
 }
 
-// ── Guard 4: Low-confidence heuristics ───────────────────────────────────────
+// ── Guard 5: Low-confidence heuristics ───────────────────────────────────────
 
 /**
  * Heuristic guard (low confidence): fires when there are weak signals that the
@@ -351,12 +434,14 @@ export function evaluatePrior(
 ): GuardResult {
   const selfMatch = checkSelfMatch(book, citedPrior);
   const anthology = checkAnthology(book, citedPrior);
+  const volume = checkVolume(book, citedPrior);
   const partial = checkPartial(book, citedPrior);
   const lowConf = checkLowConfidence(book, citedPrior);
 
   const detail: GuardResult['detail'] = {
     SELF_MATCH: { fired: selfMatch.fired, reason: selfMatch.reason },
     ANTHOLOGY:  { fired: anthology.fired, reason: anthology.reason },
+    VOLUME:     { fired: volume.fired, reason: volume.reason },
     PARTIAL:    { fired: partial.fired, reason: partial.reason },
     LOW_CONFIDENCE: { fired: lowConf.fired, reason: lowConf.reason },
   };
@@ -365,6 +450,7 @@ export function evaluatePrior(
   const definitiveGuards: GuardId[] = [];
   if (selfMatch.fired) definitiveGuards.push('SELF_MATCH');
   if (anthology.fired) definitiveGuards.push('ANTHOLOGY');
+  if (volume.fired) definitiveGuards.push('VOLUME');
   if (partial.fired) definitiveGuards.push('PARTIAL');
 
   // Heuristic guard (low confidence)

--- a/tests/unit/ft-prior-guard.test.ts
+++ b/tests/unit/ft-prior-guard.test.ts
@@ -307,6 +307,63 @@ describe('Erasmus Paraphrases (id=69b2ffe2e5d6d64d8e1979e7) — all guards pass 
   });
 });
 
+// ── Case 7: single volume of a set vs whole opera → VOLUME guard (#3044) ─────
+
+describe('Opera Omnia single-volume vs whole (#3044) — volume guard', () => {
+  /**
+   * The #2885(b) alignment gold measured Tier-0 acted-on link precision at 72.7%,
+   * and all 6 false merges shared one signature: a single numbered volume of a
+   * collected-works set matched (and would auto-demote) against a whole-corpus
+   * catalog row. A single volume is not the same work as the whole container →
+   * these must route to needs_review, never demote.
+   */
+  it('Augustine "Opera Omnia Vol. 1" vs cited whole "Opera omnia" fires VOLUME', () => {
+    const book: BookInput = { title: 'Opera Omnia Vol. 1', author: 'Augustine', language: 'Latin' };
+    const prior: CitedPriorInput = {
+      english_title: 'The Complete Works of Saint Augustine',
+      translator: 'Various',
+      completeness: 'complete',
+    };
+    const result = evaluatePrior(book, prior);
+    expectGuardFired(result, 'VOLUME');
+  });
+
+  it('Pico "Opera Omnia (vol. 2)" vs cited whole "Opera omnia (1557-1573)" fires VOLUME', () => {
+    const book: BookInput = { title: 'Opera Omnia (vol. 2)', author: 'Pico della Mirandola', language: 'Latin' };
+    const prior: CitedPriorInput = {
+      english_title: 'Opera omnia (1557-1573)',
+      completeness: 'complete',
+    };
+    const result = evaluatePrior(book, prior);
+    expectGuardFired(result, 'VOLUME');
+  });
+
+  it('different numbered volumes (book Vol. 1 vs prior Vol. 2) fires VOLUME', () => {
+    const book: BookInput = { title: 'Collected Works, Vol. 1', author: 'Someone', language: 'Latin' };
+    const prior: CitedPriorInput = { english_title: 'Collected Works, Volume II', completeness: 'complete' };
+    const result = evaluatePrior(book, prior);
+    expectGuardFired(result, 'VOLUME');
+  });
+
+  it('same volume on both sides (Vol. 2 ↔ vol II) does NOT fire VOLUME', () => {
+    const book: BookInput = { title: 'The Works, Vol. 2', author: 'Someone', language: 'Latin' };
+    const prior: CitedPriorInput = { english_title: 'The Works, vol. II', completeness: 'complete' };
+    const result = evaluatePrior(book, prior);
+    expect(result.failedGuards).not.toContain('VOLUME');
+  });
+
+  it('no volume markers on either side does NOT fire VOLUME (Erasmus case)', () => {
+    const book: BookInput = { title: 'Paraphrases on the New Testament', author: 'Erasmus', language: 'Latin' };
+    const prior: CitedPriorInput = {
+      english_title: 'Paraphrases of Erasmus on the New Testament',
+      translator: 'Nicholas Udall (editor)',
+      completeness: 'complete',
+    };
+    const result = evaluatePrior(book, prior);
+    expect(result.failedGuards).not.toContain('VOLUME');
+  });
+});
+
 // ── Edge cases ────────────────────────────────────────────────────────────────
 
 describe('Edge cases', () => {


### PR DESCRIPTION
Closes #3044.

## Problem
The #2885(b) alignment gold (PR #3043) measured Tier-0 **acted-on link precision at 72.7% (16/22)**, and **all 6 false merges shared one signature**: a single numbered volume of a collected-works set matched — and would be auto-demoted — against a whole-corpus catalog row:
- Augustine "Opera Omnia Vol. 1/2/3/4/5" ⇔ catalog "Opera omnia" (whole)
- Pico della Mirandola "Opera Omnia (vol. 2)" ⇔ catalog "Opera omnia (1557-1573)" (whole)

A single volume/part of a set is not the same work as the whole container, so Tier-0 was not safe to auto-short-circuit (demote) on these matches.

## Fix
Adds a **VOLUME guard** to both matcher layers:

- **`scripts/eval/ft-catalog-match.mjs`** — `guardVolume()` as guard **(e)**, wired into `matchBookToCatalog` (the *same* guarded logic the alignment-gold harness reuses via `ft-alignment-gold-draw.mjs`, not a re-implementation). A failing volume guard routes the pair to `needs_review` instead of `demote_candidate`. Exports `guardVolume`/`volumeKey` for harness parity.
- **`src/lib/ft-prior-guard.ts`** — `checkVolume()` as a definitive guard in `evaluatePrior` (new `VOLUME` GuardId); a volume/whole mismatch makes the cited prior `trustworthy: false`.

The guard extracts an explicit volume/part enumeration via `volumeKey()` (mirroring the proven `scripts/iiif-discovery/dedupe-candidates.mjs` implementation), covering Western markers (`Vol.`/`Tomus`/`Band`/`Part`/`Teil`/roman numerals), Tibetan pecha volume letters (`ka`, `kha`, …), and CJK (`卷`/`冊`). It fires when **exactly one side** carries an enumeration (single volume vs whole), or **both differ** (Vol. 1 vs Vol. 2). Same-volume (`Vol. 2` ↔ `vol. II`) and no-marker pairs pass unchanged.

## Verification
- All 6 gold false-merge signatures now **fire** → route to `needs_review` (verified against the real exported `guardVolume`).
- 5 new unit tests in `tests/unit/ft-prior-guard.test.ts` (Augustine, Pico, different-volume, same-volume-no-fire, Erasmus no-marker control) — **all 29 tests pass**.
- `node --check` clean on the matcher and both harness importers; TS typecheck clean.

## Out of scope
Re-running the full alignment-gold harness on production (`ft-alignment-gold-runbook.md` / `scripts/eval/results/`) to re-measure demote-census precision — those live in the ops/main checkout. The guard is wired into the exact `matchBookToCatalog` the harness calls, so a re-run will pick it up automatically.

Refs: #2885, PR #3043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)