### PR TITLE
fix(collections): strip markdown links from JSON-LD description

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -83,6 +83,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 // ---------- Helpers ----------
 
+/** Flatten inline markdown links `[text](/href)` to their anchor text.
+ *  The rendered page body parses these into <Link>s, but plain-text consumers
+ *  (schema.org JSON-LD `description`) must not carry raw markdown syntax. */
+function stripMarkdownLinks(text: string | null | undefined): string {
+  return (text || '').replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+}
+
 interface BookItem {
   id: string;
   slug?: string;
@@ -889,7 +896,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
       <CollectionSchema
         slug={id}
         name={collection.name}
-        description={collection.expanded_description || collection.description}
+        description={stripMarkdownLinks(collection.expanded_description || collection.description)}
         bookCount={total}
         parentCollection={parentCollection}
         books={books.map(b => ({


### PR DESCRIPTION
## What

Since #3040, collection `expanded_description` carries inline markdown deep-links `[text](/book/.../page/...)`. The page body parses them into `<Link>`s, but `CollectionSchema` (schema.org JSON-LD) was handed the raw `expanded_description`, so crawlers saw literal `[anchor](/book/x/page/y)` markdown in the structured-data `description`. ~19 collections (those with a link in the first paragraph) were affected.

## Fix

Add `stripMarkdownLinks()` (flattens `[text](url)` → `text`) and apply it to the description passed to `CollectionSchema`. No change to the visible body (still renders links) or the meta/OG description (built from the short intro, which has no links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)