### PR TITLE
feat(feedback): issue↔feedback reconciler to stop re-triaging fixed items

### DIFF
--- a/.claude/skills/feedback/SKILL.md
+++ b/.claude/skills/feedback/SKILL.md
@@ -49,6 +49,22 @@ Propose a disposition per item: `already-fixed (link PR/page)` · `real, route i
 - **feature-request** → issue or note; ack the submitter.
 - **praise** → mark addressed; reply with thanks if email present (many are Spanish — reply in kind).
 
+**When you file a GitHub issue from a feedback item, LINK it back** so the loop
+closes itself. Put a marker line anywhere in the issue body:
+
+```
+Feedback-ID: <mongo _id>            # e.g. Feedback-ID: 6a473930a5f38bf2d79673bf
+```
+
+One issue can carry several ids (comma/space separated, or repeat the line).
+Then when that issue **closes** (a merged `Fixes #N` PR closes it automatically),
+`feedback-reconcile-issues.mjs` (Step 5) marks the linked feedback `addressed`
+with a link to the issue — no manual re-triage. **Only `Fixes #N` an issue when
+the PR resolves the WHOLE issue.** Partial fixes → reference it (`Refs #N`) and
+leave it open, or split the issue, or the reconciler will prematurely resolve
+feedback that isn't actually done (this bit us on #3051 — artwork half shipped,
+thumbnail half didn't, and `Fixes #3051` closed the lot).
+
 ## Step 4 — resolve
 
 **Anonymous / no-email items (the bulk):** mark directly — no email is sent.
@@ -65,6 +81,26 @@ reply email fires. Script-marking sets state but does NOT email — the script
 warns when a marked id has an email. **Sending an email is outward-facing and
 unsendable: draft it, show Derek, and only resolve-with-reply on his explicit
 approval.** Per-item, not blanket.
+
+## Step 5 — reconcile issue-linked feedback (stops the re-triage churn)
+
+The main backlog source is feedback that was **fixed but never marked** — often
+via an issue+PR in another session. Rather than re-verify by hand every time (a
+naive keyword→PR-title matcher is useless — measured 99/104 open items falsely
+"matched" on common words), close the loop off explicit `Feedback-ID:` links
+(Step 3):
+
+```bash
+node scripts/analytics/feedback-reconcile-issues.mjs            # dry-run
+node scripts/analytics/feedback-reconcile-issues.mjs --apply    # mark linked feedback for CLOSED issues
+node scripts/analytics/feedback-reconcile-issues.mjs --state all # also list open-issue links (informational)
+```
+
+It scans `user-feedback` issues, reads their `Feedback-ID:` markers, and marks
+the linked feedback `addressed` **only when the issue is closed** (idempotent —
+skips already-addressed rows; writes Mongo state only, never emails; warns on
+rows with an email so a human can send the reply). Run it at the top of every
+triage pass so resolved items drop off before you look at the queue.
 
 ## Guardrails
 - **Never blanket-resolve.** Mark by explicit `_id` list, after classifying. A wrong "addressed" can fire a wrong email.

--- a/scripts/analytics/feedback-reconcile-issues.mjs
+++ b/scripts/analytics/feedback-reconcile-issues.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Feedback ↔ issue reconciler — close the loop so fixed feedback stops
+// re-surfacing in triage.
+//
+// The problem this solves: feedback items get fixed (often via a GitHub issue +
+// PR, frequently in a different session), but the originating `feedback` row is
+// never marked `addressed`. So `feedback-triage.mjs` keeps re-listing them and
+// we waste time re-verifying work that's already done. A naive keyword→PR-title
+// matcher is far too noisy to trust (measured: 99/104 open items "matched" on
+// common words like "translation"/"pages"). The reliable signal is EXPLICIT
+// linkage, not guessing.
+//
+// The convention (one line, anywhere in the issue body):
+//   Feedback-ID: <mongo _id>            e.g.  Feedback-ID: 6a473930a5f38bf2d79673bf
+// or the HTML-comment form if you'd rather not show it:
+//   <!-- feedback-id: 6a473930a5f38bf2d79673bf -->
+// Multiple ids (one issue covering several reports) are fine — comma/space
+// separated, or repeat the line.
+//
+// This script reads CLOSED issues carrying that marker and marks their linked
+// feedback rows `addressed`, with a link back to the issue. It writes Mongo
+// state ONLY — like feedback-triage.mjs, it never sends the submitter email
+// (that fires solely from PATCH /api/feedback/[id]); it warns when a resolved
+// row has an email so a human can send the reply via /admin/feedback.
+//
+// Run (dry-run):  set -a; source .env.production.local; set +a; node scripts/analytics/feedback-reconcile-issues.mjs
+// Apply:          ... feedback-reconcile-issues.mjs --apply
+// Options:        --repo <owner/name>  (default: gh's current repo)
+//                 --state closed|all   (default: closed — only resolved issues mark feedback done)
+//
+// Requires: `gh` authenticated. Safe to run repeatedly (idempotent — skips rows
+// already addressed).
+
+import { withMongo } from '../lib/mongo.mjs';
+import { ObjectId } from 'mongodb';
+import { execSync } from 'child_process';
+
+const arg = (k) => { const i = process.argv.indexOf(k); return i > -1 ? process.argv[i + 1] : null; };
+const has = (k) => process.argv.includes(k);
+const APPLY = has('--apply');
+const STATE = arg('--state') || 'closed';
+const REPO = arg('--repo');
+
+// Pull the feedback ids out of an issue body. Accepts:
+//   Feedback-ID: <id>[, <id> ...]
+//   <!-- feedback-id: <id> -->
+const ID_LINE_RE = /(?:feedback[-\s]?id)\s*[:=]\s*([0-9a-f, \n]+?)(?:-->|$)/gim;
+function extractFeedbackIds(body) {
+  const ids = new Set();
+  let m;
+  while ((m = ID_LINE_RE.exec(body || '')) !== null) {
+    for (const tok of m[1].split(/[,\s]+/)) {
+      const t = tok.trim();
+      if (ObjectId.isValid(t)) ids.add(t);
+    }
+  }
+  return [...ids];
+}
+
+function ghIssues() {
+  const repoFlag = REPO ? `--repo ${REPO}` : '';
+  // gh caps --limit; 1000 is plenty for a feedback-linked issue set.
+  const raw = execSync(
+    `gh issue list ${repoFlag} --label user-feedback --state ${STATE} --limit 1000 --json number,title,body,state,url,closedAt`,
+    { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }
+  );
+  return JSON.parse(raw);
+}
+
+await withMongo(async (db) => {
+  const fb = db.collection('feedback');
+
+  let issues;
+  try {
+    issues = ghIssues();
+  } catch (e) {
+    console.error('Failed to list issues via gh — is gh authenticated?\n', e.message);
+    process.exitCode = 1;
+    return;
+  }
+
+  const linked = [];
+  for (const iss of issues) {
+    for (const fid of extractFeedbackIds(iss.body)) {
+      linked.push({ fid, issue: iss });
+    }
+  }
+
+  console.log('# Feedback ↔ issue reconciler');
+  console.log(`Scanned ${issues.length} ${STATE} user-feedback issue(s); found ${linked.length} feedback link(s).\n`);
+  if (!linked.length) {
+    console.log('No linked feedback ids found. Tag issues with a "Feedback-ID: <id>" line to enable auto-resolution.');
+    return;
+  }
+
+  const toMark = [];
+  const emailWarn = [];
+  for (const { fid, issue } of linked) {
+    const row = await fb.findOne({ _id: new ObjectId(fid) });
+    if (!row) { console.log(`  #${issue.number}  ↳ ${fid}  — no such feedback row (skip)`); continue; }
+    if (row.addressed) { console.log(`  #${issue.number}  ↳ ${fid}  — already addressed (skip)`); continue; }
+    // Only closed issues resolve feedback. An open issue linked here (with --state all)
+    // is informational — the work isn't done yet.
+    if (issue.state.toLowerCase() !== 'closed') {
+      console.log(`  #${issue.number}  ↳ ${fid}  — issue still OPEN, leaving feedback open`);
+      continue;
+    }
+    toMark.push({ fid, issue, row });
+    if ((row.email || '').includes('@')) emailWarn.push({ fid, email: row.email });
+    console.log(`  #${issue.number} (${issue.title.slice(0, 60)})  ↳ ${fid}  — WILL MARK addressed`);
+  }
+
+  console.log(`\n${APPLY ? 'APPLYING' : 'DRY-RUN'}: ${toMark.length} feedback row(s) to mark addressed.`);
+  if (emailWarn.length) {
+    console.log(`⚠ ${emailWarn.length} have an email — script-marking does NOT send the reply. Resolve in /admin/feedback to email the submitter:`);
+    for (const e of emailWarn) console.log(`    ${e.fid}  ${e.email}`);
+  }
+  if (!APPLY) { console.log('(add --apply to write)'); return; }
+
+  let modified = 0;
+  for (const { fid, issue } of toMark) {
+    const res = await fb.updateOne(
+      { _id: new ObjectId(fid), addressed: { $ne: true } },
+      { $set: {
+          read: true, read_at: new Date(),
+          addressed: true, addressed_at: new Date(),
+          addressed_by: 'feedback-issue-reconciler',
+          addressed_action: `Resolved by closed issue #${issue.number}: ${issue.title}`.slice(0, 1000),
+          addressed_link: issue.url,
+          updated_at: new Date(),
+        } }
+    );
+    modified += res.modifiedCount;
+  }
+  console.log(`modified ${modified}`);
+}, { timeoutMs: 120000 });


### PR DESCRIPTION
## Why
You flagged it directly: we keep re-surfacing feedback that's **already done** because the fix landed (issue+PR, often another session) but the `feedback` row was never marked `addressed`. So triage re-lists it and we re-verify done work.

I tried the obvious auto-detector (match feedback keywords against merged PR titles) and **it's unusable** — 99 of 104 open items falsely "matched" on common words like "translation" / "pages" / "notes". Auto-marking off that would be worse than the disease. The reliable signal is **explicit linkage**, not guessing.

## What
- **Convention:** an issue filed from feedback carries a marker line — `Feedback-ID: <mongo _id>` (one issue can list several).
- **`scripts/analytics/feedback-reconcile-issues.mjs`:** scans `user-feedback` issues, reads the markers, and marks linked feedback `addressed` **only when the issue is closed** (a merged `Fixes #N` PR closes it automatically). Idempotent, dry-run by default, writes Mongo state only — never emails (warns on rows with an email so a human sends the reply via `/admin/feedback`).
- **/feedback skill** documents the convention + a new Step 5 (run the reconciler at the top of each triage pass so resolved items drop off before you look).

## Guardrail this surfaced
Only `Fixes #N` an issue when the PR resolves the **whole** issue. #3054 fixed only the artwork-routing half of #3051 but `Fixes #3051` closed the lot — the reconciler then wanted to resolve the still-open thumbnail feedback. Caught in dry-run; #3051 reopened + re-scoped. The skill now warns against partial `Fixes`.

## Retro-linked this session
Issues #3048–#3053 tagged with their `Feedback-ID`s. Dry-run now correctly resolves nothing (all either already-addressed or issue-still-open) and will auto-close the loop when #3049/#3050/#3051 are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)