### PR TITLE
fix(collections): art collections default to image grid, not list (#3057)

### DIFF
--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -106,7 +106,11 @@ export default function CollectionAllBooks({
 }: CollectionAllBooksProps) {
   const isArt = collectionType === 'visual_art';
   const itemLabel = isArt ? 'works' : 'books';
-  const sizeDefault: ViewMode = total > 200 ? 'list' : 'grid';
+  // Art collections always lead with the image grid — the pictures ARE the
+  // point. The list default (below) is a readability aid for long *book*
+  // catalogues only; on a visual-art collection it renders as a text list and
+  // reads as "a catalogue, not pictures" (user feedback on ficinos-florence).
+  const sizeDefault: ViewMode = isArt ? 'grid' : (total > 200 ? 'list' : 'grid');
 
   const [expanded, setExpanded] = useState(false);
   const [allBooks, setAllBooks] = useState<BookItem[]>([]);


### PR DESCRIPTION
## Problem
Footer feedback (Derek, `/collections/ficinos-florence`): "clicking into art, I'd expect to see pictures, instead it is a catalogue."

## Root cause
`CollectionAllBooks.tsx`: `sizeDefault = total > 200 ? 'list' : 'grid'` keyed only on item count. Ficino's Florence is a `visual_art` collection with 747 artworks → tripped the >200 threshold → defaulted to the **list** view, which renders artworks as a text catalogue. Same hits `kabbalah-sacred-geometry` (537) and any large visual-art collection.

## Fix
`sizeDefault = isArt ? 'grid' : (total > 200 ? 'list' : 'grid')` — visual-art collections lead with the image grid; the size heuristic still applies to book collections. Users can still toggle to list (the toggle + `localStorage` persistence are untouched).

Fixes #3057

🤖 Generated with [Claude Code](https://claude.com/claude-code)