### PR TITLE
fix(first-translation): quarantine ft_verification_discovery priors (#3045)

### DIFF
--- a/scripts/maintenance/quarantine-ft-discovery-catalogs.mjs
+++ b/scripts/maintenance/quarantine-ft-discovery-catalogs.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Quarantine the `source: ft_verification_discovery` rows out of
+ * `translation_catalogs` (#3045).
+ *
+ * These ~302 rows are unverified Gemini discovery-pass output — all url-less,
+ * often fabricated (the "Madame Dupin" translation of Reuchlin's *De Verbo
+ * Mirifico* that nearly triggered a false demote; a 1969 Latin facsimile of
+ * Pico's *Opera Omnia* masquerading as a complete English prior). Treating a
+ * `found_refs` pointer into one of these as a trustworthy prior produces FALSE
+ * DEMOTES of genuine first-translation badges.
+ *
+ * The read-path matchers already exclude them (`ft-catalog-match.mjs`,
+ * `ft-prior-adjudicate.mjs` filter `source != 'ft_verification_discovery'`) and
+ * the derive path no longer blanket-trusts `found_refs` (needs a resolvable
+ * source_url — the discovery rows have none). This pass removes the rows from
+ * the collection entirely so no future writer can accidentally re-surface them.
+ *
+ * SAFETY: nothing is destroyed. Rows are backed up to a timestamped JSON file
+ * AND copied into the `translation_catalogs_quarantine` collection before being
+ * removed from `translation_catalogs`. `--unapply` moves them straight back.
+ * Dry-run by default — lists the rows and never writes.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/quarantine-ft-discovery-catalogs.mjs            # dry-run (list only)
+ *   node scripts/maintenance/quarantine-ft-discovery-catalogs.mjs --apply    # back up + move to quarantine collection
+ *   node scripts/maintenance/quarantine-ft-discovery-catalogs.mjs --unapply  # restore from quarantine collection
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getScriptClient } from '../lib/mongo.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const UNAPPLY = process.argv.includes('--unapply');
+
+const SOURCE = 'ft_verification_discovery';
+const LIVE = 'translation_catalogs';
+const QUARANTINE = 'translation_catalogs_quarantine';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_DIR = join(__dirname, '..', 'output');
+
+/** A row is "locatable" (curated-shaped) if it carries an http(s) link. */
+function hasUrl(r) {
+  const u = r.url || r.source_url;
+  return typeof u === 'string' && /^https?:\/\/\S/i.test(u.trim());
+}
+
+const { client, db } = await getScriptClient();
+const live = db.collection(LIVE);
+const quarantine = db.collection(QUARANTINE);
+
+try {
+  if (UNAPPLY) {
+    const rows = await quarantine.find({ source: SOURCE }).toArray();
+    if (rows.length === 0) {
+      console.log(`Nothing to restore — ${QUARANTINE} holds 0 ${SOURCE} rows.`);
+    } else {
+      await live.insertMany(rows, { ordered: false });
+      const r = await quarantine.deleteMany({ source: SOURCE });
+      console.log(`RESTORED ${rows.length} rows back into ${LIVE}; removed ${r.deletedCount} from ${QUARANTINE}.`);
+    }
+    process.exit(0);
+  }
+
+  const rows = await live.find({ source: SOURCE }).toArray();
+  const withUrl = rows.filter(hasUrl);
+
+  console.log(`${LIVE}: ${await live.estimatedDocumentCount()} docs total`);
+  console.log(`Rows with source='${SOURCE}': ${rows.length}`);
+  console.log(`  ↳ of those carrying a resolvable url: ${withUrl.length} (expected ~0 — these rows are url-less)\n`);
+
+  const sample = rows.slice(0, 25);
+  for (const r of sample) {
+    const who = r.canonical_author || r.author || r.author_surname || '—';
+    const what = r.english_title || r.canonical_work || '—';
+    console.log(`   ${hasUrl(r) ? '[url]' : '[   ]'} ${String(who).slice(0, 30).padEnd(30)}  ${String(what).slice(0, 60)}`);
+  }
+  if (rows.length > sample.length) console.log(`   … +${rows.length - sample.length} more`);
+  console.log('');
+
+  if (!APPLY) {
+    console.log('DRY-RUN. Re-run with --apply to back up + move these rows to the quarantine collection.');
+    process.exit(0);
+  }
+
+  if (rows.length === 0) {
+    console.log('No rows to quarantine.');
+    process.exit(0);
+  }
+
+  // 1) Back up to a timestamped JSON file (Date.now avoided — use ISO from Date via env-safe path).
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = join(OUTPUT_DIR, `translation-catalogs-ft-discovery-backup-${stamp}.json`);
+  writeFileSync(backupPath, JSON.stringify(rows, null, 2));
+  console.log(`Backed up ${rows.length} rows → ${backupPath}`);
+
+  // 2) Copy into the quarantine collection (idempotent on _id), then remove from live.
+  await quarantine.bulkWrite(
+    rows.map((r) => ({ replaceOne: { filter: { _id: r._id }, replacement: r, upsert: true } })),
+    { ordered: false },
+  );
+  const del = await live.deleteMany({ source: SOURCE });
+  console.log(`APPLIED: moved ${rows.length} rows to ${QUARANTINE}; deleted ${del.deletedCount} from ${LIVE}.`);
+  console.log(`Reverse with:  node scripts/maintenance/quarantine-ft-discovery-catalogs.mjs --unapply`);
+} finally {
+  await client.close();
+}

--- a/src/lib/first-translation/derive-from-evidence.ts
+++ b/src/lib/first-translation/derive-from-evidence.ts
@@ -129,16 +129,36 @@ function hasSearchCoverage(a: FirstTranslationAttempt): boolean {
   return (a.sources_checked?.length ?? 0) > 0 || (a.queries?.length ?? 0) > 0;
 }
 
+/** A prior is *locatable* when it carries a resolvable http(s) grounding link. */
+function hasResolvableUrl(p: NonNullable<FirstTranslationAttempt['priors']>[number]): boolean {
+  const u = p.source_url;
+  return typeof u === 'string' && /^https?:\/\/\S/i.test(u.trim());
+}
+
 /**
  * A found prior counts as a real defeat only when it is a TRUSTWORTHY sighting:
- * non-weak evidence AND (a concrete registry id OR a prior that survives the
- * evidence-quality guard). This is what excludes the legacy study/guess rows.
+ * non-weak evidence AND a corroborated prior.
+ *
+ * The `found_refs` pointer is NOT trusted on its own (#3045). It points into
+ * `translation_catalogs`, which contained ~302 `source: ft_verification_discovery`
+ * rows — unverified, url-less Gemini discovery-pass output, often fabricated (the
+ * "Madame Dupin" translation of Reuchlin that nearly triggered a false demote).
+ * A bare `found_refs` id is exactly as trustworthy as the row it points at, which
+ * a pure function can't resolve — so a `found_refs`-backed defeat requires the
+ * attempt to have copied a RESOLVABLE `source_url` off the referenced row (the
+ * fabricated discovery rows are url-less, so this excludes them). An agent/human
+ * that cited a structured prior directly (no `found_refs`) is trusted the old way:
+ * a prior that survives the evidence-quality guard. Legacy study/guess rows are
+ * `weak` and excluded upstream either way.
  */
 function isTrustworthyFound(a: FirstTranslationAttempt, bi: BookInput): boolean {
   if (a.result !== 'found') return false;
   if (a.evidence_strength === 'weak') return false;
-  if (a.found_refs && a.found_refs.length > 0) return true;
-  return (a.priors ?? []).some((p) => evaluatePrior(bi, toCited(p)).trustworthy);
+  const priors = a.priors ?? [];
+  if (a.found_refs && a.found_refs.length > 0) {
+    return priors.some(hasResolvableUrl);
+  }
+  return priors.some((p) => evaluatePrior(bi, toCited(p)).trustworthy);
 }
 
 /**

--- a/tests/unit/first-translation-derive-from-evidence.test.ts
+++ b/tests/unit/first-translation-derive-from-evidence.test.ts
@@ -145,7 +145,7 @@ describe('deriveVerdictFromAttempts — hardened against the real ledger', () =>
   it('tier2 refute over a catalog-only found → needs_review, never not_first (Arithmologia case)', () => {
     const ft = deriveVerdictFromAttempts([
       at({ method: 'tier1_catalog', result: 'found', evidence_strength: 'moderate', found_refs: ['cat:1'],
-        priors: [{ english_title: 'Claimed prior', completeness: 'complete', pub_year: '1959' }] }),
+        priors: [{ english_title: 'Claimed prior', completeness: 'complete', pub_year: '1959', source_url: 'https://archive.org/claimed' }] }),
       at({ method: 'tier2_agent', result: 'none', evidence_strength: 'strong',
         queries: ['searched for the claimed prior'], notes: 'could not confirm the cited prior exists' }),
     ], BOOK);
@@ -157,7 +157,7 @@ describe('deriveVerdictFromAttempts — hardened against the real ledger', () =>
   it('tier2 found stands even when a catalog absence exists → not_first', () => {
     const ft = deriveVerdictFromAttempts([
       at({ method: 'tier2_agent', result: 'found', evidence_strength: 'strong', found_refs: ['cat:2'],
-        priors: [{ english_title: 'Real prior', completeness: 'complete', pub_year: '1986' }] }),
+        priors: [{ english_title: 'Real prior', completeness: 'complete', pub_year: '1986', source_url: 'https://archive.org/real' }] }),
       at({ method: 'tier1_catalog', result: 'none' }),
     ], BOOK);
     expect(ft?.verdict).toBe('not_first');
@@ -184,11 +184,32 @@ describe('deriveVerdictFromAttempts — hardened against the real ledger', () =>
     expect(ft?.verdict).toBe('not_first');
   });
 
-  it('registry found_refs (year unknown) still → not_first', () => {
+  // #3045: a found_refs pointer into translation_catalogs is only trustworthy when
+  // the referenced row is locatable (a resolvable source_url was copied off it).
+  // The ~302 ft_verification_discovery rows are url-less fabrications.
+  it('found_refs with a resolvable source_url → not_first', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'tier1_catalog', result: 'found', evidence_strength: 'moderate', found_refs: ['cat:9'],
+        priors: [{ english_title: 'A real translation', source_url: 'https://archive.org/z' }] }),
+    ], BOOK);
+    expect(ft?.verdict).toBe('not_first');
+    expect(ft?.prior_refs).toEqual(['cat:9']);
+  });
+
+  it('bare found_refs (no prior at all) does NOT demote → null (defer)', () => {
     const ft = deriveVerdictFromAttempts([
       at({ method: 'tier1_catalog', result: 'found', evidence_strength: 'moderate', found_refs: ['cat:9'] }),
     ], BOOK);
-    expect(ft?.verdict).toBe('not_first');
+    expect(ft).toBeNull();
+  });
+
+  it('found_refs pointing at a url-less (contaminated) row does NOT demote → null (Madame Dupin case)', () => {
+    const ft = deriveVerdictFromAttempts([
+      at({ method: 'tier1_catalog', result: 'found', evidence_strength: 'moderate', found_refs: ['cat:discovery'],
+        priors: [{ english_title: 'De Verbo Mirifico', translator: 'Madame Dupin' /* no source_url */ }],
+        notes: '[ft_verification_discovery] unverified Gemini discovery-pass output' }),
+    ], BOOK);
+    expect(ft).toBeNull();
   });
 
   it('not_applicable rows are excluded from the absence family count', () => {


### PR DESCRIPTION
Closes #3045.

## What
Two coordinated changes that close the false-demote path from the ~302 `source: ft_verification_discovery` rows in `translation_catalogs` (unverified, url-less Gemini discovery-pass output — the "Madame Dupin" fabrication class).

### 1. Close the `found_refs` unconditional-trust path (in scope: the code fix)
`src/lib/first-translation/derive-from-evidence.ts` — `isTrustworthyFound` previously returned `true` for **any** non-empty `found_refs`, so a `found_refs` pointer defeated a first-translation badge regardless of what it pointed at. This module is pure (no DB), so it can't resolve the referenced catalog row — instead, a `found_refs`-backed defeat now requires the attempt to carry a **resolvable http(s) `source_url`** copied off that row. The discovery rows are url-less, so they no longer demote. Agent/human-cited priors (no `found_refs`) keep the existing evidence-quality-guard trust.

### 2. Quarantine the rows (script; **not yet run** against prod)
`scripts/maintenance/quarantine-ft-discovery-catalogs.mjs` — dry-run by default (lists the rows); `--apply` backs up to a timestamped JSON **and** copies into a `translation_catalogs_quarantine` collection before deleting from `translation_catalogs`; `--unapply` reverses. Dry-run confirms **302 rows, 0 with a resolvable url**, matching the issue.

## Out of scope / deliberately deferred
- **Running the quarantine `--apply`** against production — that's a data mutation and, per the repo's Data-Protection rules, needs explicit human approval. The script is dry-run-safe and reversible; run it after review.
- The 3 Pico "Opera Omnia" non-translation-reprint mismatches noted in the issue are a separate catalog-quality problem (the #3044 VOLUME guard already addresses the vol-vs-whole shape) — not touched here.

## Verification
- `npx vitest run tests/unit/first-translation-*.test.ts tests/unit/ft-prior-guard.test.ts` → 119 passed
- `npx tsc --noEmit` → clean
- Read-path exclusion (`ft-catalog-match.mjs`, `ft-prior-adjudicate.mjs` filtering `source != 'ft_verification_discovery'`) was already live; this closes the remaining derive-path hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)