### PR TITLE
Fix "Request translation" button shown even on translated pages.

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -50,6 +50,7 @@ import { AuthCheck } from '../auth/AuthCheck';
 import TranslationFeedbackPrompt from '@/components/feedback/TranslationFeedbackPrompt';
 import PageComments from '@/components/book/PageComments';
 import { useIsEmbedded } from '@/hooks/useEmbedContext';
+import { shouldShowTranslationRequestCta } from '@/lib/translation-request-cta';
 
 // Languages that use non-Latin scripts and benefit from transliteration
 const NON_LATIN_LANGUAGES = new Set([
@@ -734,6 +735,15 @@ export default function TranslationEditor({
   const isNonLatin = hasNonLatinScript(book.language);
   const hasTransliteration = !!(page.transliteration?.data || transliterationText);
   const hasGermanSource = !!page.translation?.german_source;
+  const shouldShowRequestTranslation = shouldShowTranslationRequestCta({
+    ocrText,
+    translationText,
+    translationData: page.translation?.data,
+    translationUpdatedAt: page.translation?.updated_at,
+    modernizedText,
+    bookPagesTranslated: book.pages_translated,
+    bookPagesCount: book.pages_count,
+  });
   useEffect(() => {
     if (!showTransliterationPanel || !isNonLatin || !page.ocr?.data) return;
     // Check for cached transliteration first
@@ -1896,16 +1906,18 @@ export default function TranslationEditor({
                             so every request is identifiable, not an anonymous click. */}
                         <AuthCheck role="inner_circle" fallback={
                           <AuthCheck fallback={
-                            <a
-                              href={`/auth/signin?callbackUrl=${encodeURIComponent(pathname || `/book/${book.id}/page/${page.id}`)}&reason=translation-request`}
-                              className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90"
-                              style={{ background: 'var(--bg-warm)', color: 'var(--text-secondary)' }}
-                            >
-                              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-                              </svg>
-                              Sign in to request a translation
-                            </a>
+                            shouldShowRequestTranslation ? (
+                              <a
+                                href={`/auth/signin?callbackUrl=${encodeURIComponent(pathname || `/book/${book.id}/page/${page.id}`)}&reason=translation-request`}
+                                className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90"
+                                style={{ background: 'var(--bg-warm)', color: 'var(--text-secondary)' }}
+                              >
+                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                                </svg>
+                                Sign in to request a translation
+                              </a>
+                            ) : null
                           }>
                             {translationRequested ? (
                               <p className="text-sm font-medium" style={{ color: 'var(--accent-sage-dark)' }}>
@@ -1913,7 +1925,7 @@ export default function TranslationEditor({
                                   ? "Thanks! We'll email you when this page is translated."
                                   : "Thanks! We'll prioritize this book."}
                               </p>
-                            ) : (
+                            ) : shouldShowRequestTranslation ? (
                               <button
                                 onClick={async () => {
                                   try {
@@ -1937,7 +1949,7 @@ export default function TranslationEditor({
                                 </svg>
                                 Request translation
                               </button>
-                            )}
+                            ) : null}
                           </AuthCheck>
                         }>
                           <button

--- a/src/lib/translation-request-cta.ts
+++ b/src/lib/translation-request-cta.ts
@@ -1,0 +1,52 @@
+function isNonEmptyText(value?: string | null) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function hasExistingTranslationContent({
+  translationText,
+  translationData,
+  translationUpdatedAt,
+  modernizedText,
+}: {
+  translationText?: string | null;
+  translationData?: string | null;
+  translationUpdatedAt?: string | Date | null;
+  modernizedText?: string | null;
+}) {
+  return (
+    isNonEmptyText(translationText) ||
+    isNonEmptyText(translationData) ||
+    isNonEmptyText(modernizedText) ||
+    Boolean(translationUpdatedAt)
+  );
+}
+
+export function shouldShowTranslationRequestCta({
+  ocrText,
+  translationText,
+  translationData,
+  translationUpdatedAt,
+  modernizedText,
+  bookPagesTranslated,
+  bookPagesCount,
+}: {
+  ocrText?: string | null;
+  translationText?: string | null;
+  translationData?: string | null;
+  translationUpdatedAt?: string | Date | null;
+  modernizedText?: string | null;
+  bookPagesTranslated?: number | null;
+  bookPagesCount?: number | null;
+}) {
+  if (!isNonEmptyText(ocrText)) return false;
+  if (hasExistingTranslationContent({ translationText, translationData, translationUpdatedAt, modernizedText })) {
+    return false;
+  }
+
+  const translatedPages = Number(bookPagesTranslated ?? 0);
+  const totalPages = Number(bookPagesCount ?? 0);
+  if (totalPages > 0 && translatedPages >= totalPages) return false;
+  if (totalPages > 0 && translatedPages / totalPages >= 0.9) return false;
+
+  return true;
+}

--- a/tests/unit/translation-request-cta.test.ts
+++ b/tests/unit/translation-request-cta.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasExistingTranslationContent } from '@/lib/translation-request-cta';
+
+describe('hasExistingTranslationContent', () => {
+  it('returns true when the page already has translation text', () => {
+    expect(hasExistingTranslationContent({ translationText: 'Existing translation' })).toBe(true);
+  });
+
+  it('returns true when the page has translation metadata but no visible text yet', () => {
+    expect(hasExistingTranslationContent({ translationUpdatedAt: '2026-07-01T00:00:00.000Z' })).toBe(true);
+  });
+
+  it('returns false when there is no translation content or metadata', () => {
+    expect(hasExistingTranslationContent({ translationText: '', translationData: '', translationUpdatedAt: null })).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3032 by hiding the “Request translation” CTA whenever the current page already has translation content or the book is already heavily translated.

- Added a shared guard for translation-request visibility in `translation-request-cta.ts`
- Applied that guard in `TranslationEditor.tsx` so readers no longer see the CTA on already-translated pages
- Added regression coverage in `translation-request-cta.test.ts`