### PR TITLE
feat(presence): live "N people are reading right now" (#3059)

### DIFF
--- a/src/app/api/presence/count/route.ts
+++ b/src/app/api/presence/count/route.ts
@@ -1,0 +1,34 @@
+/**
+ * Live reader count — GET /api/presence/count
+ *
+ * Returns the aggregate presence snapshot for the "N people are reading right
+ * now" line (issue #3059):
+ *   { count: number, titles: string[] }
+ *
+ * `count` is distinct anonymous visitors active in the last ~2 min. `titles`
+ * is a small sample of visible-book titles open right now (empty below a
+ * small floor so a lone reader isn't singled out). Never exposes who.
+ *
+ * Cached briefly so it doesn't hammer Mongo — the number only needs to feel
+ * live, not tick every request.
+ */
+
+import { NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { getPresenceSnapshot } from '@/lib/presence';
+
+export async function GET() {
+  try {
+    const db = await getDb();
+    const snapshot = await getPresenceSnapshot(db);
+    return NextResponse.json(snapshot, {
+      headers: { 'Cache-Control': 'public, max-age=15, stale-while-revalidate=45' },
+    });
+  } catch {
+    // A count failure should degrade to "hidden", never error the page.
+    return NextResponse.json(
+      { count: 0, titles: [] },
+      { headers: { 'Cache-Control': 'public, max-age=15' } }
+    );
+  }
+}

--- a/src/app/api/presence/route.ts
+++ b/src/app/api/presence/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Presence heartbeat — POST /api/presence
+ *
+ * A tiny anonymous ping the reader page (and the global footer chip) sends
+ * every ~50s while open. Powers the "N people are reading right now" line
+ * (issue #3059). One self-expiring doc per browser, keyed on an anonymous
+ * localStorage UUID. No IP, no login, no PII is stored — the visitor_id is
+ * random and is never returned to anyone.
+ *
+ * See src/lib/presence.ts for the aggregate read path and design invariants.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { classifyTraffic } from '@/lib/traffic-classification';
+import {
+  PRESENCE_COLLECTION,
+  TTL_MS,
+  VISITOR_ID_RE,
+  BOOK_KEY_RE,
+  ensurePresenceIndex,
+} from '@/lib/presence';
+
+// Presence is non-critical — never hold a serverless slot on a slow DB.
+const DB_TIMEOUT_MS = 2000;
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const visitorId = typeof body.visitor_id === 'string' ? body.visitor_id : '';
+    // `book` is the slug-or-id from the reader URL; absent on non-book pages.
+    const book = typeof body.book === 'string' && BOOK_KEY_RE.test(body.book) ? body.book : null;
+
+    if (!VISITOR_ID_RE.test(visitorId)) {
+      // Malformed/absent id — accept quietly, record nothing.
+      return NextResponse.json({ ok: true });
+    }
+
+    // Bot filter — same Cloudflare signals as /api/views. Scrapers must not
+    // inflate the live count.
+    const ua = request.headers.get('user-agent') || '';
+    const cfVerifiedBot = request.headers.get('cf-verified-bot') === 'true';
+    const cfThreat = parseInt(request.headers.get('cf-threat-score') || '', 10);
+    const cls = classifyTraffic(ua, {
+      verifiedBot: cfVerifiedBot,
+      threatScore: Number.isFinite(cfThreat) ? cfThreat : undefined,
+    });
+    if (cls !== 'human') {
+      return NextResponse.json({ ok: true });
+    }
+
+    const now = new Date();
+    const dbWrite = (async () => {
+      const db = await getDb();
+      await ensurePresenceIndex(db);
+      await db.collection(PRESENCE_COLLECTION).updateOne(
+        { visitor_id: visitorId }, // one doc per browser; unique index enforces it
+        {
+          $set: { book, updated_at: now, expireAt: new Date(now.getTime() + TTL_MS) },
+          $setOnInsert: { created_at: now },
+        },
+        { upsert: true }
+      );
+    })();
+    const timeout = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), DB_TIMEOUT_MS)
+    );
+    await Promise.race([dbWrite, timeout]);
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    // Presence must never error to the client.
+    return NextResponse.json({ ok: true });
+  }
+}

--- a/src/components/layout/GlobalFooter.tsx
+++ b/src/components/layout/GlobalFooter.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 import FeedbackCallout from '@/components/feedback/FeedbackCallout';
+import ReaderPresence from '@/components/presence/ReaderPresence';
 import { clearConsent } from '@/lib/consent';
 import { useLocale, FOOTER_STRINGS, type FooterStrings } from '@/lib/i18n';
 
@@ -107,6 +108,9 @@ export default function GlobalFooter() {
               unoptimized
             />
           </Link>
+          {/* Live reader presence — quiet, aggregate, self-hides when nobody's
+              here or on tenant subdomains (#3059). */}
+          <ReaderPresence variant="chip" />
           <Link href="/in-memoriam" className="font-serif italic text-white/50 text-lg hover:text-white/70 transition-colors" title="In memoriam: Joost R. Ritman">
             ad fontes
           </Link>

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -8,6 +8,7 @@ import { useStableSession } from '@/hooks/useStableSession';
 import { recordLoadingMetric } from '@/lib/analytics';
 import UnifiedSearch from '@/components/search/UnifiedSearch';
 import SiteHeader from '@/components/layout/SiteHeader';
+import ReaderPresence from '@/components/presence/ReaderPresence';
 import { HOME_STRINGS, type HomeLang, type HomeStrings } from '@/lib/home-i18n';
 
 function HeroSignUp({ t }: { t: HomeStrings }) {
@@ -199,6 +200,12 @@ export default function HeroSection({ lang = 'en' }: { lang?: HomeLang }) {
           <p className="text-xl md:text-2xl lg:text-3xl font-light text-white/90 leading-relaxed max-w-2xl mb-8">
             {t.heroSubtitleLine1}<br /> {t.heroSubtitleLine2}
           </p>
+
+          {/* Live "N people are reading right now" line (#3059). Reserve
+              height so the sign-up block below doesn't shift when it fades in. */}
+          <div className="min-h-[28px] mb-6 animate-fade-in">
+            <ReaderPresence variant="hero" />
+          </div>
 
           {/* Reserve min-height to prevent layout shift while session loads */}
           <div className="min-h-[120px]">

--- a/src/components/presence/ReaderPresence.tsx
+++ b/src/components/presence/ReaderPresence.tsx
@@ -1,0 +1,188 @@
+/**
+ * ReaderPresence — the quiet "N people are reading right now" live line
+ * (issue #3059). Inspired by TownSquare's felt-presence, kept dignified for a
+ * reading room: a soft pulse dot, a warm sentence, and an ambient sample of
+ * which books are open right now.
+ *
+ * Two variants:
+ *   - "hero"  display-only line under the homepage tagline (light-on-dark).
+ *   - "chip"  compact line in the global footer; ALSO sends the heartbeat.
+ *             The footer renders on every global page, so mounting the
+ *             heartbeat here covers the whole site with one beat per browser.
+ *
+ * Privacy / scope invariants (see src/lib/presence.ts):
+ *   - Anonymous random visitor id in localStorage; never tied to a login,
+ *     never displayed, never sent anywhere but our own heartbeat.
+ *   - Aggregate counts only. Book titles are resolved SERVER-SIDE from
+ *     visible books — the client only sends a slug/id, never a title.
+ *   - Nothing renders and no heartbeat fires on tenant subdomains / embeds
+ *     (BPH/EFM stay closed systems) — gated via useEmbedContext.
+ */
+
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { useEmbedContext, isTenantSubdomain } from '@/hooks/useEmbedContext';
+import { HEARTBEAT_MS, VISITOR_ID_RE, type PresenceSnapshot } from '@/lib/presence';
+
+const PRESENCE_ID_KEY = 'sl-presence-id';
+const COUNT_POLL_MS = 30_000;
+// Don't show a lonely "1 reading" — that's just you (or nobody yet).
+const DISPLAY_FLOOR = 2;
+const MAX_TITLES_SHOWN = 4;
+
+function uuid(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+function getOrCreatePresenceId(): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    const existing = window.localStorage.getItem(PRESENCE_ID_KEY);
+    if (existing && VISITOR_ID_RE.test(existing)) return existing;
+    const id = uuid();
+    window.localStorage.setItem(PRESENCE_ID_KEY, id);
+    return id;
+  } catch {
+    // Private-mode / blocked storage — fall back to an ephemeral id so the
+    // heartbeat still works for this page load.
+    return uuid();
+  }
+}
+
+/**
+ * Synchronous embed/tenant check for the heartbeat. useEmbedContext's
+ * `isEmbedded` only upgrades to true in a post-mount effect, so on a tenant
+ * subdomain the very first render reads false — we must NOT send even one beat
+ * from bph.sourcelibrary.org. This mirrors useEmbedContext's own signals and
+ * settles synchronously so no beat leaks in that first-render gap.
+ */
+function isEmbeddedNow(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    if (window.self !== window.top) return true;
+    if (window.location.pathname.startsWith('/embed/')) return true;
+    return isTenantSubdomain(window.location.host);
+  } catch {
+    return false;
+  }
+}
+
+/** Pull the slug-or-id out of a `/book/<seg>` reader URL, if we're on one. */
+function bookKeyFromPath(pathname: string | null): string | null {
+  if (!pathname) return null;
+  const m = pathname.match(/^\/book\/([^/]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+function formatTitleList(titles: string[]): string {
+  const shown = titles.slice(0, MAX_TITLES_SHOWN);
+  if (shown.length === 0) return '';
+  if (typeof Intl !== 'undefined' && 'ListFormat' in Intl) {
+    return new Intl.ListFormat('en', { style: 'long', type: 'conjunction' }).format(shown);
+  }
+  return shown.join(', ');
+}
+
+export default function ReaderPresence({ variant }: { variant: 'hero' | 'chip' }) {
+  const { isEmbedded } = useEmbedContext();
+  const pathname = usePathname();
+  const [snapshot, setSnapshot] = useState<PresenceSnapshot | null>(null);
+  const pathRef = useRef(pathname);
+  pathRef.current = pathname;
+
+  const isChip = variant === 'chip';
+
+  // Heartbeat — only the chip variant beats (it's in the footer, on every
+  // page), so we never double-count from the homepage's hero + footer.
+  useEffect(() => {
+    if (isEmbedded || !isChip) return;
+    const visitorId = getOrCreatePresenceId();
+    if (!visitorId) return;
+
+    const beat = () => {
+      // Never beat from a tenant subdomain / embed, even in the first-render
+      // gap before useEmbedContext settles (see isEmbeddedNow).
+      if (isEmbeddedNow()) return;
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+      const payload = JSON.stringify({ visitor_id: visitorId, book: bookKeyFromPath(pathRef.current) });
+      try {
+        if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+          navigator.sendBeacon('/api/presence', new Blob([payload], { type: 'application/json' }));
+        } else {
+          fetch('/api/presence', { method: 'POST', body: payload, keepalive: true, headers: { 'Content-Type': 'application/json' } }).catch(() => {});
+        }
+      } catch { /* presence is best-effort */ }
+    };
+
+    beat();
+    const interval = setInterval(beat, HEARTBEAT_MS);
+    const onVisible = () => { if (document.visibilityState === 'visible') beat(); };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [isEmbedded, isChip]);
+
+  // Count — both variants poll so each shows the live number.
+  useEffect(() => {
+    if (isEmbedded) return;
+    let alive = true;
+    const load = async () => {
+      try {
+        const res = await fetch('/api/presence/count');
+        if (!res.ok) return;
+        const data = (await res.json()) as PresenceSnapshot;
+        if (alive && typeof data?.count === 'number') {
+          setSnapshot({ count: data.count, titles: Array.isArray(data.titles) ? data.titles : [] });
+        }
+      } catch { /* leave last known snapshot */ }
+    };
+    load();
+    const interval = setInterval(load, COUNT_POLL_MS);
+    const onVisible = () => { if (document.visibilityState === 'visible') load(); };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      alive = false;
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [isEmbedded]);
+
+  // Nothing to show: embedded, not loaded yet, or below the display floor
+  // (deterministic null on SSR + first render → no hydration mismatch).
+  if (isEmbedded || !snapshot || snapshot.count < DISPLAY_FLOOR) return null;
+
+  const { count, titles } = snapshot;
+  const titleList = formatTitleList(titles);
+
+  const dotColor = isChip ? 'bg-emerald-500' : 'bg-emerald-400';
+  const wrapClass = isChip
+    ? 'inline-flex items-center gap-2 text-sm text-white/50'
+    : 'inline-flex items-center gap-2.5 text-base md:text-lg text-white/80';
+
+  return (
+    <div className={wrapClass} aria-label={`${count} people are reading right now`}>
+      <span className="relative flex h-2 w-2 shrink-0" aria-hidden="true">
+        <span className={`motion-safe:animate-ping absolute inline-flex h-full w-full rounded-full ${dotColor} opacity-60`} />
+        <span className={`relative inline-flex h-2 w-2 rounded-full ${dotColor}`} />
+      </span>
+      <span className="leading-snug">
+        <span className="tabular-nums font-medium">{count.toLocaleString()}</span>{' '}
+        {isChip ? 'reading now' : 'people are reading right now'}
+        {!isChip && titleList && (
+          <span className="text-white/60">
+            {' '}— including <span className="italic">{titleList}</span>
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/src/hooks/useEmbedContext.ts
+++ b/src/hooks/useEmbedContext.ts
@@ -14,7 +14,7 @@ import { useEffect, useState } from 'react';
  * Matches tenant subdomain hosts like `bph.sourcelibrary.org`. Excludes
  * `www.` and the bare apex — those are the canonical global site.
  */
-function isTenantSubdomain(host: string): boolean {
+export function isTenantSubdomain(host: string): boolean {
   const h = host.toLowerCase();
   if (h.startsWith('www.')) return false;
   if (!/\.sourcelibrary\.(org|com|net)$/.test(h)) return false;

--- a/src/lib/presence.ts
+++ b/src/lib/presence.ts
@@ -1,0 +1,145 @@
+/**
+ * Live reader presence — shared constants + helpers for the "N people are
+ * reading right now" feature (issue #3059).
+ *
+ * Design invariants (read before touching):
+ *  - AGGREGATE ONLY. We store one anonymous, self-expiring doc per browser
+ *    (`visitor_id`, a random localStorage UUID never tied to a login). We
+ *    never expose who is reading — only how many, and a sample of *which
+ *    books* are open right now.
+ *  - Titles shown next to the count are looked up SERVER-SIDE from the
+ *    `books` collection (visible:true only). The client sends a book
+ *    slug/id, never a title — otherwise a crafted heartbeat could inject
+ *    arbitrary or hidden-book text onto the homepage.
+ *  - The `presence` collection is the sanctioned exception to the no-TTL
+ *    policy (see feedback_no_automated_data_retention): heartbeats self-prune
+ *    via a TTL index on `expireAt`.
+ *  - No presence UI or heartbeat runs on tenant subdomains (BPH/EFM stay
+ *    closed systems) — that gate lives in the client component.
+ */
+
+import type { Db } from 'mongodb';
+
+export const PRESENCE_COLLECTION = 'presence';
+
+/** Client heartbeat cadence. Exported so the component and the windows agree. */
+export const HEARTBEAT_MS = 50_000;
+
+/**
+ * A visitor counts as "reading now" if we've heard from them within this
+ * window — ~2.5 missed heartbeats of tolerance so a brief network blip or a
+ * backgrounded tab doesn't drop them.
+ */
+export const ACTIVE_WINDOW_MS = 130_000;
+
+/**
+ * TTL horizon written to each doc's `expireAt`. Strictly LONGER than
+ * ACTIVE_WINDOW_MS (plus Mongo's ~60s TTL sweep lag) so a doc that's still
+ * inside the active window is never pruned out from under the count.
+ */
+export const TTL_MS = 180_000;
+
+/**
+ * Below this many concurrent readers we don't surface any book titles — a
+ * lone reader on a rare book shouldn't be singled out. The count itself is
+ * always aggregate; the client softens tiny counts in copy.
+ */
+export const TITLES_FLOOR = 3;
+
+/** Most titles to sample for the "…including X, Y, and N others" line. */
+export const TITLES_MAX = 6;
+
+/** Anonymous visitor id shape (UUID). */
+export const VISITOR_ID_RE = /^[0-9a-f-]{36}$/i;
+
+/** Book slug/id shape — same safe charset the views API uses for target ids. */
+export const BOOK_KEY_RE = /^[\w:.-]{1,128}$/;
+
+// TTL index is created lazily and memoized (repo convention — see
+// src/lib/rate-limit.ts). A rejected promise is not cached, so a transient
+// failure can be retried on the next call.
+let presenceIndexReady: Promise<void> | null = null;
+export async function ensurePresenceIndex(db: Db): Promise<void> {
+  if (!presenceIndexReady) {
+    presenceIndexReady = (async () => {
+      const coll = db.collection(PRESENCE_COLLECTION);
+      // One doc per browser — upserts key on visitor_id.
+      await coll.createIndex({ visitor_id: 1 }, { unique: true });
+      // Self-pruning heartbeats (sanctioned no-TTL exception, #3059).
+      await coll.createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 });
+      // Supports the active-window count/title queries.
+      await coll.createIndex({ updated_at: 1 });
+    })().catch((e) => {
+      presenceIndexReady = null;
+      throw e;
+    });
+  }
+  return presenceIndexReady;
+}
+
+export interface PresenceSnapshot {
+  /** Distinct humans active within ACTIVE_WINDOW_MS. */
+  count: number;
+  /** Sample of visible-book titles open right now (empty below the floor). */
+  titles: string[];
+}
+
+/**
+ * Read the current aggregate presence: how many distinct visitors are active,
+ * and a sample of which visible books they're reading. All filtering happens
+ * here so both the read path and any test share one source of truth.
+ */
+export async function getPresenceSnapshot(db: Db): Promise<PresenceSnapshot> {
+  const activeSince = new Date(Date.now() - ACTIVE_WINDOW_MS);
+  const coll = db.collection(PRESENCE_COLLECTION);
+
+  const count = await coll.countDocuments({ updated_at: { $gt: activeSince } });
+
+  if (count < TITLES_FLOOR) {
+    return { count, titles: [] };
+  }
+
+  // Distinct book keys currently open, most-read first.
+  const grouped = await coll
+    .aggregate<{ _id: string; readers: number }>([
+      { $match: { updated_at: { $gt: activeSince }, book: { $type: 'string' } } },
+      { $group: { _id: '$book', readers: { $sum: 1 } } },
+      { $sort: { readers: -1 } },
+      { $limit: TITLES_MAX * 3 }, // over-fetch; some keys may be hidden/stale
+    ])
+    .toArray();
+
+  const keys = grouped.map((g) => g._id).filter((k) => BOOK_KEY_RE.test(k));
+  if (keys.length === 0) return { count, titles: [] };
+
+  // Resolve titles server-side, visible books only. Never trust a client title.
+  const books = await db
+    .collection('books')
+    .find(
+      { $or: [{ slug: { $in: keys } }, { id: { $in: keys } }], visible: true },
+      { projection: { _id: 0, id: 1, slug: 1, title: 1 } }
+    )
+    .toArray();
+
+  // Map every resolvable key → title, then walk `grouped` to keep read-order.
+  const titleByKey = new Map<string, string>();
+  for (const b of books) {
+    const title = typeof b.title === 'string' ? b.title.trim() : '';
+    if (!title) continue;
+    if (typeof b.slug === 'string') titleByKey.set(b.slug, title);
+    if (typeof b.id === 'string') titleByKey.set(b.id, title);
+  }
+
+  const seen = new Set<string>();
+  const titles: string[] = [];
+  for (const g of grouped) {
+    const title = titleByKey.get(g._id);
+    if (title && !seen.has(title)) {
+      seen.add(title);
+      titles.push(title);
+      if (titles.length >= TITLES_MAX) break;
+    }
+  }
+
+  return { count, titles };
+}


### PR DESCRIPTION
Closes #3059.

## What
A lightweight, aggregate **live reader count** — "N people are reading Source Library right now" — with an ambient sample of which books are open. Inspiration from [TownSquare](https://townsquare.cauenapier.com/) is the *felt presence*, not avatars/chat; the visual is a quiet live line with a soft pulse dot, tuned for a reading room.

Design was agreed with Derek on the issue: **site-wide total** (not per-book), **quiet live line** visual, **homepage hero + persistent global chip**, titles but never a specific person↔book link.

## How it works
- **`POST /api/presence`** — anonymous heartbeat (~50s) keyed on a random localStorage UUID. Bot-filtered via `classifyTraffic` (same Cloudflare signals as `/api/views`). One self-expiring doc per browser. **No IP, no login, no PII** stored or returned.
- **`GET /api/presence/count`** — distinct visitors active in the last ~2 min + a sample of **visible-book** titles resolved **server-side** (the client only ever sends a slug/id — a crafted heartbeat can't inject a fake or hidden-book title onto the homepage). Cached ~15s.
- **`presence` collection** — TTL index on `expireAt`, the sanctioned exception to the no-TTL policy (heartbeats self-prune).
- **`ReaderPresence`** — hero variant under the homepage tagline (with titles); compact chip in the global footer (persistent, every global page) which carries the single heartbeat.

## Guardrails
- **Tenant lockdown:** no UI and no heartbeat on tenant subdomains / embeds (BPH/EFM stay closed systems). Gated via `useEmbedContext` **and** a synchronous `isEmbeddedNow()` check so not even one beat leaks in the first-render window before the hook settles.
- **Aggregate only, never who.** Random visitor id, never displayed.
- **Low-traffic honesty:** hides below 2 concurrent readers (no lonely "1 reading"); titles hidden below 3.
- Bots excluded so the number reflects humans.

## Out of scope (deliberate)
- Not on reader pages beyond the footer chip (Derek chose homepage + persistent site-wide, not a reader-page line).
- Per-title reader-count floor (currently a single reader's book *can* appear in the sample once total ≥3) is left as a tunable knob, not implemented — flagging for review.

## Verification
- `npx tsc --noEmit` clean.
- Endpoints + tenant-exclusion verified against the Vercel preview (see comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)