### PR TITLE
feat(home): make the librarian the hero's front door

### DIFF
--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -2,107 +2,54 @@
 
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { signIn } from 'next-auth/react';
-import { isInAppBrowser } from '@/lib/in-app-browser';
+import { useRouter } from 'next/navigation';
 import { useStableSession } from '@/hooks/useStableSession';
 import { recordLoadingMetric } from '@/lib/analytics';
-import UnifiedSearch from '@/components/search/UnifiedSearch';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { HOME_STRINGS, type HomeLang, type HomeStrings } from '@/lib/home-i18n';
 
-function HeroSignUp({ t }: { t: HomeStrings }) {
-  const [email, setEmail] = useState('');
-  const [sent, setSent] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(false);
-  // Google OAuth is blocked inside Instagram/Facebook/LinkedIn webviews
-  // (disallowed_useragent), so the button silently fails there. Detect it and
-  // steer the visitor to the email magic link, which always works.
-  const [inApp, setInApp] = useState(false);
-  useEffect(() => { setInApp(isInAppBrowser(navigator.userAgent)); }, []);
+/**
+ * The hero's primary front door: a prompt that hands the visitor's question
+ * straight to the librarian (which auto-runs a ?q= seed — see
+ * LibrarianClient's initial-query effect). Surfaces the most distinctive part
+ * of the product the instant you land, instead of leaving it buried in the
+ * nav. Label is intentionally a single i18n string so it's trivial to swap
+ * (e.g. Derek's "Talk to the source" — parked for now).
+ */
+function HeroLibrarianPrompt({ t }: { t: HomeStrings }) {
+  const router = useRouter();
+  const [q, setQ] = useState('');
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const go = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email) return;
-    setLoading(true);
-    setError(false);
-    try {
-      // Provider id is 'nodemailer' (next-auth v5 renamed Email→Nodemailer);
-      // the old 'email' id silently no-ops and faked a "check your email".
-      const result = await signIn('nodemailer', { email, callbackUrl: '/', redirect: false });
-      if (result?.error) setError(true);
-      else setSent(true);
-    } catch {
-      setError(true);
-    } finally {
-      setLoading(false);
-    }
+    const query = q.trim();
+    router.push(query ? `/librarian?q=${encodeURIComponent(query)}` : '/librarian');
   };
 
-  if (sent) {
-    return (
-      <div className="max-w-xl">
-        <p className="text-white text-lg">
-          {t.checkEmail} <strong>{email}</strong>
-        </p>
-        <button
-          onClick={() => setSent(false)}
-          className="mt-3 text-sm text-white/60 hover:text-white/90 transition-colors underline"
-        >
-          {t.differentEmail}
-        </button>
-      </div>
-    );
-  }
-
   return (
-    <div className="max-w-xl">
-      <form onSubmit={handleSubmit} className="flex gap-2">
+    <div className="max-w-2xl">
+      <form onSubmit={go} className="flex gap-2">
         <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder={t.emailPlaceholder}
-          required
-          className="flex-1 px-5 py-3.5 rounded-lg bg-white text-stone-900 placeholder-stone-400 text-base outline-none border border-white focus:ring-2 focus:ring-white/50 transition-colors"
+          type="text"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder={t.librarianPlaceholder}
+          aria-label={t.librarianPlaceholder}
+          className="flex-1 px-5 py-3.5 rounded-lg bg-white/95 text-stone-900 placeholder-stone-400 text-base outline-none border border-white focus:ring-2 focus:ring-white/50 transition-colors shadow-lg"
         />
         <button
           type="submit"
-          disabled={loading || !email}
-          className="px-7 py-3.5 rounded-lg text-base font-medium transition-all hover:brightness-110 disabled:opacity-50 shrink-0"
+          aria-label={t.librarianAsk}
+          className="px-7 py-3.5 rounded-lg text-base font-medium transition-all hover:brightness-110 shrink-0 inline-flex items-center gap-1.5"
           style={{ background: 'var(--accent-rust)', color: '#fff' }}
         >
-          {loading ? t.sending : t.join}
+          {t.librarianAsk}
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+          </svg>
         </button>
       </form>
-      {error && (
-        <p className="mt-2 text-sm text-red-200">{t.emailError}</p>
-      )}
-      <div className="flex items-center gap-4 mt-4">
-        <button
-          onClick={() => signIn('google', { callbackUrl: '/' })}
-          style={{ opacity: inApp ? 0.5 : 1 }}
-          className="inline-flex items-center gap-2 text-sm text-white/60 hover:text-white/90 transition-colors"
-        >
-          <svg className="w-4 h-4" viewBox="0 0 24 24">
-            <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
-            <path fill="currentColor" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-            <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-            <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-          </svg>
-          {t.google}
-        </button>
-        <span className="text-white/30">|</span>
-        <Link
-          href="/auth/signin"
-          className="text-sm text-white/60 hover:text-white/90 transition-colors"
-        >
-          {t.haveAccount}
-        </Link>
-      </div>
-      {inApp && (
-        <p className="mt-2 max-w-md text-xs text-white/50">{t.googleBlockedNote}</p>
-      )}
+      <p className="mt-2 text-sm text-white/60">{t.librarianHint}</p>
     </div>
   );
 }
@@ -200,19 +147,29 @@ export default function HeroSection({ lang = 'en' }: { lang?: HomeLang }) {
             {t.heroSubtitleLine1}<br /> {t.heroSubtitleLine2}
           </p>
 
-          {/* Reserve min-height to prevent layout shift while session loads */}
-          <div className="min-h-[120px]">
-            {/* Show the sign-up immediately on load (also during session
-                'loading') so it fades in with the hero instead of waiting for
-                the session round-trip. Authenticated visitors swap to search. */}
+          {/* Primary front door: ask the librarian. The secondary line adapts
+              to auth state — sign-up for guests, search for members — and both
+              are the same height so the min-h reservation prevents layout shift
+              while the session resolves. */}
+          <div className="min-h-[120px] animate-fade-in">
+            <HeroLibrarianPrompt t={t} />
             {status === 'authenticated' ? (
-              <div className="max-w-xl animate-fade-in">
-                <UnifiedSearch />
-              </div>
+              <Link
+                href="/search"
+                className="inline-block mt-3 text-sm text-white/60 hover:text-white/90 transition-colors"
+              >
+                {t.heroSearchInstead}
+              </Link>
             ) : (
-              <div className="animate-fade-in">
-                <HeroSignUp t={t} />
-              </div>
+              <p className="mt-3 text-sm text-white/60">
+                {t.heroSignupLead}{' '}
+                <Link
+                  href="/auth/signin"
+                  className="text-white/85 underline underline-offset-2 hover:text-white transition-colors"
+                >
+                  {t.heroSignupCta}
+                </Link>
+              </p>
             )}
           </div>
 

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -35,6 +35,13 @@ export interface HomeStrings {
   // Banner shown on `/` to es-locale visitors, linking to `/es`
   suggestSpanish: string;
   dismiss: string;
+  // Librarian hero prompt — primary front-door action (#3059 follow-on)
+  librarianPlaceholder: string;
+  librarianHint: string;
+  librarianAsk: string;
+  heroSignupLead: string;
+  heroSignupCta: string;
+  heroSearchInstead: string;
 
   // Collections section
   collectionsHeading: string;
@@ -127,6 +134,12 @@ const en: HomeStrings = {
   langSpanish: 'Español',
   suggestSpanish: 'Ver esta página en español',
   dismiss: 'Dismiss',
+  librarianPlaceholder: 'Ask the librarian anything…',
+  librarianHint: 'e.g. “What did Newton write about prophecy?”',
+  librarianAsk: 'Ask',
+  heroSignupLead: 'New here?',
+  heroSignupCta: 'Sign up to save your reading →',
+  heroSearchInstead: 'Or search the collection →',
 
   collectionsHeading: 'Collections',
   translationsLabel: 'translations',
@@ -219,6 +232,12 @@ const es: HomeStrings = {
   langSpanish: 'Español',
   suggestSpanish: 'View this page in English',
   dismiss: 'Cerrar',
+  librarianPlaceholder: 'Pregúntale al bibliotecario lo que quieras…',
+  librarianHint: 'p. ej. «¿Qué escribió Newton sobre la profecía?»',
+  librarianAsk: 'Preguntar',
+  heroSignupLead: '¿Primera vez aquí?',
+  heroSignupCta: 'Regístrate para guardar tu lectura →',
+  heroSearchInstead: 'O busca en la colección →',
 
   collectionsHeading: 'Colecciones',
   translationsLabel: 'traducciones',


### PR DESCRIPTION
Follow-on to the presence work (#3059) — a second homepage change Derek asked for: the AI librarian is hard to find today.

## Why
`/librarian` is a genuinely rich feature (chat, voice, rooms, threads) but its **only** entry point is one nav link (`SiteHeader.tsx:34`) — it's absent from the homepage entirely. The product's most distinctive capability is also its best-hidden one. This makes it the hero's primary action.

Pairs naturally with the presence line from #3067: "N people are reading right now" (alive) → "ask the librarian anything" (dive in).

## What
- The hero's central input becomes an **"Ask the librarian anything…"** prompt. On submit it opens `/librarian?q=<question>` — which **already auto-fills and auto-runs** the seeded question (`LibrarianClient` initial-query effect at :562, whose comment literally anticipates an "Ask the Librarian" link). Seamless handoff, **zero librarian-side changes**.
- Works for everyone (anonymous librarian access is already gated at "5 free/hour" via `anon-gate`).
- Sign-up **demotes to a secondary link** to `/auth/signin`; authenticated visitors get an "or search the collection →" link.
- New localized strings (EN + ES).

## For review — two calls
1. **Funnel change (please weigh):** this removes the hero's **inline email/Google capture** in favor of a link to `/auth/signin`. That matches the design option chosen, but inline capture generally converts better than a click-through. Trivial to restore the inline form beneath the prompt if signup metrics dip — say the word.
2. **Label is parked:** shipping with "Ask the librarian anything…". Derek floated **"Talk to the source"** (nice double meaning) — it's a one-line i18n swap (`librarianPlaceholder`) whenever you decide.

## Scope
- Separate PR from #3067 (presence) on purpose — different concern, and this one touches the signup funnel. Both edit `HeroSection.tsx`; expect a trivial merge resolution when the second one lands.

## Verification
- `npx tsc --noEmit` clean.
- Prompt → seeded librarian flow verified on the preview (see comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)