### PR TITLE
feat(home): hero→sign-up, "Ask the source" own band, presence→footer bottom

### DIFF
--- a/src/components/home/AskTheSourceBand.tsx
+++ b/src/components/home/AskTheSourceBand.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * "Ask the source" — the librarian's front door on the homepage, given its own
+ * section just below the hero so it doesn't compete with the hero's sign-up box
+ * (#3059 follow-on). The prompt hands the visitor's question straight to the
+ * librarian via /librarian?q=…, which already auto-fills AND auto-runs the seed
+ * (LibrarianClient initial-query effect) — a seamless handoff.
+ *
+ * Framed as "Ask the source" (ad fontes): you question the primary sources
+ * directly and the answer comes back citing them, not a help-desk persona.
+ */
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { HOME_STRINGS, type HomeLang } from '@/lib/home-i18n';
+
+export default function AskTheSourceBand({ lang = 'en' }: { lang?: HomeLang }) {
+  const t = HOME_STRINGS[lang];
+  const router = useRouter();
+  const [q, setQ] = useState('');
+
+  const go = (e: React.FormEvent) => {
+    e.preventDefault();
+    const query = q.trim();
+    router.push(query ? `/librarian?q=${encodeURIComponent(query)}` : '/librarian');
+  };
+
+  return (
+    <section className="py-16 md:py-24" style={{ background: 'var(--bg-dark)' }}>
+      <div className="px-6 md:px-12 max-w-3xl mx-auto text-center">
+        <p className="text-sm uppercase tracking-[0.2em] mb-4" style={{ color: 'var(--accent-gold)' }}>
+          {t.askSourceEyebrow}
+        </p>
+        <h2 className="text-3xl md:text-4xl lg:text-5xl font-display mb-4 leading-tight" style={{ color: '#f5f0e8' }}>
+          {t.askSourceHeading}
+        </h2>
+        <p className="text-base md:text-lg leading-relaxed mb-8 max-w-2xl mx-auto" style={{ color: '#b8b2a8' }}>
+          {t.askSourceSubtitle}
+        </p>
+
+        <form onSubmit={go} className="flex gap-2 max-w-2xl mx-auto">
+          <input
+            type="text"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder={t.librarianPlaceholder}
+            aria-label={t.librarianPlaceholder}
+            className="flex-1 px-5 py-3.5 rounded-lg bg-white text-stone-900 placeholder-stone-400 text-base outline-none border border-white focus:ring-2 focus:ring-white/40 transition-colors shadow-lg"
+          />
+          <button
+            type="submit"
+            aria-label={t.librarianAsk}
+            className="px-7 py-3.5 rounded-lg text-base font-medium transition-all hover:brightness-110 shrink-0 inline-flex items-center gap-1.5"
+            style={{ background: 'var(--accent-rust)', color: '#fff' }}
+          >
+            {t.librarianAsk}
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+            </svg>
+          </button>
+        </form>
+        <p className="mt-3 text-sm" style={{ color: '#8a8480' }}>{t.librarianHint}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import HeroSection from '@/components/layout/HeroSection';
+import AskTheSourceBand from '@/components/home/AskTheSourceBand';
 import HomePageSchema from '@/components/seo/HomePageSchema';
 import EditorialSpread from '@/components/prototype/EditorialSpread';
 import FromTheCollection from '@/components/prototype/FromTheCollection';
@@ -24,6 +25,10 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
 
       {/* Video Hero */}
       <HeroSection lang={lang} />
+
+      {/* Ask the source — the librarian's front door, its own section right
+          below the hero so it doesn't compete with the hero sign-up box. */}
+      <AskTheSourceBand lang={lang} />
 
       {/* Spanish podcast feature — the first real Spanish content a /es visitor
           meets. Only rendered on /es, so the English homepage is unchanged. */}

--- a/src/components/layout/GlobalFooter.tsx
+++ b/src/components/layout/GlobalFooter.tsx
@@ -108,9 +108,6 @@ export default function GlobalFooter() {
               unoptimized
             />
           </Link>
-          {/* Live reader presence — quiet, aggregate, self-hides when nobody's
-              here or on tenant subdomains (#3059). */}
-          <ReaderPresence variant="chip" />
           <Link href="/in-memoriam" className="font-serif italic text-white/50 text-lg hover:text-white/70 transition-colors" title="In memoriam: Joost R. Ritman">
             ad fontes
           </Link>
@@ -199,10 +196,17 @@ export default function GlobalFooter() {
         </div>
 
         {/* Zone 4: License line */}
-        <div className="pb-6 -mt-2 text-center">
+        <div className="pb-4 -mt-2 text-center">
           <Link href="/licensing" className="text-xs text-white/35 hover:text-white/60 transition-colors">
             {t.licenseLine}
           </Link>
+        </div>
+
+        {/* Zone 5: Live reader presence — the very bottom line, on every page
+            (#3059). The wrapper collapses (empty:hidden) when the chip renders
+            nothing (below the display floor, or on tenant subdomains). */}
+        <div className="flex justify-center pb-6 empty:hidden">
+          <ReaderPresence variant="chip" />
         </div>
       </div>
     </footer>

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -2,65 +2,19 @@
 
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import { isInAppBrowser } from '@/lib/in-app-browser';
 import { useStableSession } from '@/hooks/useStableSession';
 import { recordLoadingMetric } from '@/lib/analytics';
+import UnifiedSearch from '@/components/search/UnifiedSearch';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { HOME_STRINGS, type HomeLang, type HomeStrings } from '@/lib/home-i18n';
 
 /**
- * The hero's primary front door: a prompt that hands the visitor's question
- * straight to the librarian (which auto-runs a ?q= seed — see
- * LibrarianClient's initial-query effect). Surfaces the most distinctive part
- * of the product the instant you land, instead of leaving it buried in the
- * nav. Framed as "Ask the source" (ad fontes) rather than "ask a librarian":
- * you're questioning the primary sources directly, and the answer comes back
- * with citations to them. Label is a single i18n string, trivial to re-tune.
- */
-function HeroLibrarianPrompt({ t }: { t: HomeStrings }) {
-  const router = useRouter();
-  const [q, setQ] = useState('');
-
-  const go = (e: React.FormEvent) => {
-    e.preventDefault();
-    const query = q.trim();
-    router.push(query ? `/librarian?q=${encodeURIComponent(query)}` : '/librarian');
-  };
-
-  return (
-    <div className="max-w-2xl">
-      <form onSubmit={go} className="flex gap-2">
-        <input
-          type="text"
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          placeholder={t.librarianPlaceholder}
-          aria-label={t.librarianPlaceholder}
-          className="flex-1 px-5 py-3.5 rounded-lg bg-white/95 text-stone-900 placeholder-stone-400 text-base outline-none border border-white focus:ring-2 focus:ring-white/50 transition-colors shadow-lg"
-        />
-        <button
-          type="submit"
-          aria-label={t.librarianAsk}
-          className="px-7 py-3.5 rounded-lg text-base font-medium transition-all hover:brightness-110 shrink-0 inline-flex items-center gap-1.5"
-          style={{ background: 'var(--accent-rust)', color: '#fff' }}
-        >
-          {t.librarianAsk}
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-          </svg>
-        </button>
-      </form>
-      <p className="mt-2 text-sm text-white/60">{t.librarianHint}</p>
-    </div>
-  );
-}
-
-/**
- * Inline email/Google sign-up — kept in the hero as a secondary action beneath
- * the "Ask the source" prompt. The hero email field is a primary signup source,
- * so we capture it here rather than punting to a linked page.
+ * Inline email/Google sign-up — the hero's primary action. The hero is the
+ * visitor-capture front door (email ≈44% of signups, Google ≈56%), so we
+ * capture inline rather than punting to a linked page. The "Ask the source"
+ * librarian invitation lives in its own section below (AskTheSourceBand).
  */
 function HeroSignUp({ t }: { t: HomeStrings }) {
   const [email, setEmail] = useState('');
@@ -252,27 +206,21 @@ export default function HeroSection({ lang = 'en' }: { lang?: HomeLang }) {
             {t.heroSubtitleLine1}<br /> {t.heroSubtitleLine2}
           </p>
 
-          {/* Primary front door: ask the source. Sign-up stays inline beneath
-              it for guests (the hero email field is a real signup source);
-              members get a search link instead. The min-h reservation keeps
-              the content below from shifting while the session resolves. */}
-          <div className="animate-fade-in">
-            <HeroLibrarianPrompt t={t} />
-            <div className="min-h-[128px] mt-6">
-              {status === 'authenticated' ? (
-                <Link
-                  href="/search"
-                  className="inline-block text-sm text-white/60 hover:text-white/90 transition-colors"
-                >
-                  {t.heroSearchInstead}
-                </Link>
-              ) : (
-                <>
-                  <p className="text-sm text-white/70 mb-2">{t.heroSignupLead}</p>
-                  <HeroSignUp t={t} />
-                </>
-              )}
-            </div>
+          {/* The hero's job is sign-up — the visitor-capture front door (email
+              ≈44% of signups, Google ≈56%). The "Ask the source" librarian
+              invitation lives in its own section just below (AskTheSourceBand),
+              so the two never compete for the same box. Reserve min-height so
+              the content below doesn't shift while the session resolves. */}
+          <div className="min-h-[120px]">
+            {status === 'authenticated' ? (
+              <div className="max-w-xl animate-fade-in">
+                <UnifiedSearch />
+              </div>
+            ) : (
+              <div className="animate-fade-in">
+                <HeroSignUp t={t} />
+              </div>
+            )}
           </div>
 
           {/* Language switch lives in the site header now (top-right EN · ES),

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -42,6 +42,10 @@ export interface HomeStrings {
   heroSignupLead: string;
   heroSignupCta: string;
   heroSearchInstead: string;
+  // "Ask the source" librarian band (below the hero)
+  askSourceEyebrow: string;
+  askSourceHeading: string;
+  askSourceSubtitle: string;
 
   // Collections section
   collectionsHeading: string;
@@ -140,6 +144,9 @@ const en: HomeStrings = {
   heroSignupLead: 'New here? Sign up to save your reading.',
   heroSignupCta: 'Sign up to save your reading →',
   heroSearchInstead: 'Or search the collection →',
+  askSourceEyebrow: 'The Librarian',
+  askSourceHeading: 'Ask the source',
+  askSourceSubtitle: 'Put a question to thousands of primary sources and get an answer — with citations to the originals you can read for yourself.',
 
   collectionsHeading: 'Collections',
   translationsLabel: 'translations',
@@ -238,6 +245,9 @@ const es: HomeStrings = {
   heroSignupLead: '¿Primera vez aquí? Regístrate para guardar tu lectura.',
   heroSignupCta: 'Regístrate para guardar tu lectura →',
   heroSearchInstead: 'O busca en la colección →',
+  askSourceEyebrow: 'El Bibliotecario',
+  askSourceHeading: 'Pregúntale a la fuente',
+  askSourceSubtitle: 'Haz una pregunta a miles de fuentes primarias y recibe una respuesta, con citas a los originales que puedes leer por ti mismo.',
 
   collectionsHeading: 'Colecciones',
   translationsLabel: 'traducciones',


### PR DESCRIPTION
Per Derek's review of the crowded hero (two big boxes stacked + scroll indicator collision) and a data question about signups.

## Signup analysis (answered Derek's "how many sign up on the hero?")
3,010 users, measured from the DB: **~56% Google / ~44% email magic-link** — neither dominates, so the **hero email box stays** (it's a real capture surface). Caveat: there's **no per-surface attribution** today (no `source` field; `analytics_events.type` is null), so a hero-specific number isn't measurable without adding instrumentation or digging in PostHog. Also surfaced a real bug for later: `AuthPrompt.tsx` calls `signIn('email')` — the retired provider id that silently no-ops.

## Changes
1. **Hero → sign-up.** Reverts the hero to its front-door job: email + Google for guests, `UnifiedSearch` for members. Removes the "Ask the source" prompt from the hero — which fixes the collision (the restored inline signup had pushed hero content into the scroll indicator).
2. **"Ask the source" → its own band.** New `AskTheSourceBand`, a dedicated section right below the hero (dark, centered, "The Librarian / Ask the source" + prompt). Still routes to `/librarian?q=…` (auto-runs the seed). The librarian gets real estate instead of a cramped second box.
3. **Presence → very bottom of footer.** The "N reading now" chip moves from the footer brand row to the footer's final row, so it reads as the closing line and shows on **every page including /librarian** (footer renders site-wide via root layout; wrapper uses `empty:hidden` so it collapses cleanly below the display floor / on tenant subdomains).

## Verification
- `npx tsc --noEmit` clean.
- Preview: hero shows signup, "Ask the source" band renders below it, footer presence at bottom, /librarian shows the footer chip (see comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)