### PR TITLE
feat(home): move "Ask the source" band to after the collections grid

### DIFF
--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -26,10 +26,6 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
       {/* Video Hero */}
       <HeroSection lang={lang} />
 
-      {/* Ask the source — the librarian's front door, its own section right
-          below the hero so it doesn't compete with the hero sign-up box. */}
-      <AskTheSourceBand lang={lang} />
-
       {/* Spanish podcast feature — the first real Spanish content a /es visitor
           meets. Only rendered on /es, so the English homepage is unchanged. */}
       {lang === 'es' && spanishPodcast && (
@@ -201,6 +197,12 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
           </div>
         </div>
       </section>
+
+      {/* Ask the source — the librarian's front door. Placed after the
+          collections grid so the invitation lands once the visitor has seen
+          the breadth of the library, and so it doesn't stack a second input
+          box right under the hero sign-up. */}
+      <AskTheSourceBand lang={lang} />
 
       {/* Featured Collection — editorial spread */}
       {featuredItems.length > 0 && (


### PR DESCRIPTION
Placement tweak per Derek — the "Ask the source" librarian band moves from directly-below-hero to just after the collections grid, so the invitation lands after the visitor has seen the librarys breadth and two input boxes dont stack near the top. One-line move in HomeView. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)