### PR TITLE
feat(analytics): attribute signups by source + fix dead AuthPrompt signin

### DIFF
--- a/src/app/api/analytics/event/route.ts
+++ b/src/app/api/analytics/event/route.ts
@@ -16,11 +16,14 @@ import { anonymizeIp } from '@/lib/anonymize-ip';
 
 const ALLOWED_EVENTS = new Set([
   'cite', 'share', 'quote_copy', 'doi_view', 'download', 'signin_view',
+  // signup_start: fired when a visitor initiates sign-up from a surface, so we
+  // can attribute signups by `source` (hero / signin_page / …) and `method`.
+  'signup_start',
 ]);
 
 // Only these prop keys are persisted; everything else is dropped.
 const ALLOWED_PROPS = new Set([
-  'bookId', 'format', 'channel', 'page', 'title', 'url', 'hasDoi', 'edition', 'source', 'reason',
+  'bookId', 'format', 'channel', 'page', 'title', 'url', 'hasDoi', 'edition', 'source', 'reason', 'method',
 ]);
 
 const DB_TIMEOUT_MS = 3000;

--- a/src/components/auth/AuthPrompt.tsx
+++ b/src/components/auth/AuthPrompt.tsx
@@ -2,6 +2,7 @@
 
 import { signIn } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
+import { trackEvent } from '@/lib/track-event';
 
 interface AuthPromptProps {
   message?: string;
@@ -38,7 +39,13 @@ export default function AuthPrompt({
 
       <div className="space-y-2">
         <button
-          onClick={() => signIn('email', { callbackUrl })}
+          onClick={() => {
+            trackEvent('signup_start', { source: 'auth_prompt', method: 'email' });
+            // 'nodemailer' is the live provider id (v5 renamed Email→Nodemailer);
+            // the old 'email' id silently no-ops. With no email field here, this
+            // routes to /auth/signin to collect it.
+            signIn('nodemailer', { callbackUrl });
+          }}
           className="w-full px-3 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90"
           style={{
             background: 'var(--text-primary, #1c1917)',

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -143,6 +143,7 @@ function SignInContent({ locale }: { locale: Locale }) {
     }
     setLoading(true);
     setEmailError('');
+    trackEvent('signup_start', { source: 'signin_page', method: 'email' });
     try {
       const result = await signIn('nodemailer', {
         email,
@@ -277,6 +278,7 @@ function SignInContent({ locale }: { locale: Locale }) {
             onClick={async () => {
               setGoogleLoading(true);
               setEmailError('');
+              trackEvent('signup_start', { source: 'signin_page', method: 'google' });
               try {
                 await signIn('google', { callbackUrl });
               } catch {

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -6,6 +6,7 @@ import { signIn } from 'next-auth/react';
 import { isInAppBrowser } from '@/lib/in-app-browser';
 import { useStableSession } from '@/hooks/useStableSession';
 import { recordLoadingMetric } from '@/lib/analytics';
+import { trackEvent } from '@/lib/track-event';
 import UnifiedSearch from '@/components/search/UnifiedSearch';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { HOME_STRINGS, type HomeLang, type HomeStrings } from '@/lib/home-i18n';
@@ -32,6 +33,7 @@ function HeroSignUp({ t }: { t: HomeStrings }) {
     if (!email) return;
     setLoading(true);
     setError(false);
+    trackEvent('signup_start', { source: 'hero', method: 'email' });
     try {
       // Provider id is 'nodemailer' (next-auth v5 renamed Email→Nodemailer);
       // the old 'email' id silently no-ops and faked a "check your email".
@@ -86,7 +88,10 @@ function HeroSignUp({ t }: { t: HomeStrings }) {
       )}
       <div className="flex items-center gap-4 mt-4">
         <button
-          onClick={() => signIn('google', { callbackUrl: '/' })}
+          onClick={() => {
+            trackEvent('signup_start', { source: 'hero', method: 'google' });
+            signIn('google', { callbackUrl: '/' });
+          }}
           style={{ opacity: inApp ? 0.5 : 1 }}
           className="inline-flex items-center gap-2 text-sm text-white/60 hover:text-white/90 transition-colors"
         >

--- a/src/lib/track-event.ts
+++ b/src/lib/track-event.ts
@@ -5,7 +5,7 @@
  * keepalive fetch. Never throws — analytics must not break an interaction.
  */
 export function trackEvent(
-  event: 'cite' | 'share' | 'quote_copy' | 'doi_view' | 'download' | 'signin_view',
+  event: 'cite' | 'share' | 'quote_copy' | 'doi_view' | 'download' | 'signin_view' | 'signup_start',
   props?: Record<string, string | number | boolean | undefined>,
 ): void {
   if (typeof window === 'undefined') return;


### PR DESCRIPTION
The two open items from the hero work.

## 1. Signup-source attribution
Answers Derek's "how many sign up from the hero?" — which the DB genuinely couldn't (no per-surface attribution; users have no `source` field). Fires a `signup_start` event via the **existing** `trackEvent` → `/api/analytics/event` → `analytics_events` sink (added `signup_start` to the event allowlist + `method` to the prop allowlist), tagged with:
- `source`: `hero` | `signin_page` | `auth_prompt`
- `method`: `email` | `google`

Wired at every entry point: hero (email + Google), `/auth/signin` (email + Google), `AuthPrompt` (email). Measures **intent** (button click) from here forward — query `analytics_events` by `{event:'signup_start'}` grouped by `source`/`method`. (Completion attribution for magic-link would need more; intent-by-surface is the honest, low-risk signal and directly answers the hero question.)

## 2. Fix dead AuthPrompt sign-in
`AuthPrompt.tsx` called `signIn('email', …)` — the retired v5 provider id that silently no-ops — so its "Sign in with email" button did nothing. Now `signIn('nodemailer', …)` (routes to `/auth/signin` to collect the address, since the compact prompt has no email field).

## Verification
- `npx tsc --noEmit` clean.
- Post-deploy: `db.analytics_events.aggregate([{$match:{event:'signup_start'}},{$group:{_id:{source:'$source',method:'$method'},n:{$sum:1}}}])` will show the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)