### PR TITLE
fix(errors): library pagination 500 + timeline→encyclopedia 404s

### DIFF
--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -26,9 +26,16 @@ export interface SharedConnection {
 export const getSharedBooks = cache(async (name: string): Promise<SharedConnection[] | null> => {
   try {
     const db = await getReadDb();
-    // Try exact match first (uses index, 2ms) before falling back to case-insensitive regex (20s full scan)
+    // Try exact match first (uses index, 2ms), then the aliases array (the timeline
+    // links figures by their canonical Wikidata name, e.g. "Apuleius", while the
+    // entity is stored under a surface name, e.g. "Apuleius of Madaura" — both share
+    // the same aliases[]), then case-insensitive regex on name (20s full scan) as a
+    // last resort.
     const entity = await db.collection('entities').findOne(
       { name },
+      { sort: { book_count: -1 } }
+    ) ?? await db.collection('entities').findOne(
+      { aliases: name },
       { sort: { book_count: -1 } }
     ) ?? await db.collection('entities').findOne(
       { name: { $regex: `^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' } },
@@ -78,9 +85,16 @@ export const getSharedBooks = cache(async (name: string): Promise<SharedConnecti
 export const getEntity = cache(async (name: string) => {
   try {
     const db = await getReadDb();
-    // Try exact match first (uses index, 2ms) before falling back to case-insensitive regex (20s full scan)
+    // Try exact match first (uses index, 2ms), then the aliases array (the timeline
+    // links figures by their canonical Wikidata name, e.g. "Apuleius", while the
+    // entity is stored under a surface name, e.g. "Apuleius of Madaura" — both share
+    // the same aliases[]), then case-insensitive regex on name (20s full scan) as a
+    // last resort. Without the aliases fallback ~0.4% of timeline figures 404.
     const entity = await db.collection('entities').findOne(
       { name },
+      { sort: { book_count: -1 } }
+    ) ?? await db.collection('entities').findOne(
+      { aliases: name },
       { sort: { book_count: -1 } }
     ) ?? await db.collection('entities').findOne(
       { name: { $regex: `^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' } },

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -157,7 +157,18 @@ export async function browseBooks(opts: {
   query = query.range(offset, offset + limit - 1);
 
   const { data, count, error } = await query;
-  if (error) throw new Error(`books_catalog query failed: ${error.message}`);
+  if (error) {
+    // PostgREST returns 416 "Requested range not satisfiable" (PGRST103) when the
+    // requested offset is past the end of the result set — e.g. a bot or a stale
+    // pagination link hitting /libraries/[slug]?offset=60 on a provider with <60
+    // visible books. That's an empty page, not a server error, so don't throw
+    // (it was 500-ing library pages). The 416 response still carries the total in
+    // the Content-Range header, which supabase-js surfaces as `count`.
+    if (error.code === 'PGRST103' || /range not satisfiable/i.test(error.message)) {
+      return { books: [], total: count || 0 };
+    }
+    throw new Error(`books_catalog query failed: ${error.message}`);
+  }
 
   return { books: (data || []) as CatalogBook[], total: count || 0 };
 }


### PR DESCRIPTION
Two production errors caught while triaging `application_errors`.

## 1. `/libraries/[slug]` 500 on pagination past the end
`books_catalog query failed: Requested range not satisfiable` — 39× in 48h. `getCatalogBooks()` asks Supabase for a row range (`?offset=60`) beyond the number of visible books for that provider; PostgREST returns **416 (PGRST103)**, which we threw → **500** on the library page (also hit by crawlers following stale pagination links). Now treated as an empty page — the 416 response still carries the total in `Content-Range`, which supabase-js surfaces as `count`, so pagination counts stay correct. Other errors still throw.

## 2. Timeline figures 404 into the encyclopedia
User feedback: *"Things shouldn't show up in the timeline if the 404."* `/explore/timeline` links every figure to `/encyclopedia/<canonical Wikidata name>`, but `getEntity()` resolved the legacy `entities` collection by **surface name only**. **26 of 6,291 dated figures (0.4%)** 404'd on pure name-variant mismatch — e.g. the timeline's `Apuleius` vs the stored `Apuleius of Madaura` (1,047 books), `Gerolamo Cardano`, `Judah Leon Abravanel`. Both docs share `aliases[]`/`wikidata_id`. Added an indexed `{ aliases: name }` fallback (`entities_aliases_idx`, IXSCAN ~27ms) ahead of the regex full-scan in `getEntity()` and `getSharedBooks()`.

## Scope / out of scope
- Client-side `parentNode`/React #418 crashes on collection pages and the `miniProgram`/`keplr`/`webkit.messageHandlers` errors are browser-extension/streaming-Suspense noise — **not our code, left alone.**
- `/embed/bhutan` Mongo timeout (215×/48h) is a real perf issue but needs its own query work — **separate issue, not this PR.**

## Test
`npx tsc --noEmit` clean. Alias lookup verified against prod: `{aliases:"Apuleius"}` → `Apuleius of Madaura` in 27ms via IXSCAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)