### PR TITLE
fix(bph): re-crop gutter-clipped split halves; audit cohort (#2898)

### DIFF
--- a/scripts/maintenance/audit-bph-gutter-clip.mjs
+++ b/scripts/maintenance/audit-bph-gutter-clip.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Audit which BPH old-era crop books ACTUALLY clip text at the gutter (issue #2898).
+ *
+ * The zero-overlap crop is a LATENT defect across the whole ~1,230-book cohort,
+ * but it only causes VISIBLE harm where content actually reaches the gutter
+ * (right-margin numeral columns, catchwords, long line-ends). This audit finds
+ * the subset with real clipping so the re-crop sweep (recrop-bph-gutter.mjs) can
+ * target them instead of blanket-reprocessing every book.
+ *
+ * Method (reuses the ink-density primitive from scripts/lib/gutter-detect.mjs /
+ * batch-split-bph.mjs): for each sampled half, resize the FULL spread to 1000px
+ * wide (so column index == per-mille), and for each column count the fraction of
+ * central-band rows (y 25%–75%, skips header/footer) where min(R,G,B) < 120 (ink,
+ * incl. colored rubrication). Then measure ink in the band JUST OUTSIDE the
+ * current cut — the region a widen of `--overlap` would recover:
+ *   left half  (xStart 0, cut c=xEnd):   band [c, c+overlap]
+ *   right half (xEnd 1000, cut c=xStart): band [c-overlap, c]
+ * If that band carries ink, we're clipping text. Per-page severity = max column
+ * ink density in the band; "reach" = furthest per-mille past the cut with ink.
+ *
+ * Read-only. Iterates the cohort PER BOOK (the global unindexed `crop` scan times
+ * out). Anchor: held_by:'bph' ∩ per-book pages with crop + cropped_photo + not
+ * split_from_spread.
+ *
+ * Run:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/audit-bph-gutter-clip.mjs --limit 50 --html /tmp/gutter-clip.html
+ *   node scripts/maintenance/audit-bph-gutter-clip.mjs --out /tmp/gutter-clip.json
+ *   node scripts/maintenance/audit-bph-gutter-clip.mjs --ids-file /tmp/ids.json
+ *
+ * Options:
+ *   --ids-file PATH   Audit only these book ids (JSON array). Default: full BPH cohort.
+ *   --samples N       Pages sampled per book (default 8)
+ *   --overlap N       Per-mille recover band width to test (default 35, matches the fix)
+ *   --ink-thresh F    Column ink-density flag threshold (default 0.04 = 4% of rows)
+ *   --clip-frac F     Book flagged when this fraction of sampled pages clip (default 0.15)
+ *   --limit N         Audit at most N books
+ *   --out PATH        Write ranked JSON (default /tmp/gutter-clip.json)
+ *   --html PATH       Also write a visual HTML gallery (optional)
+ *   --concurrency N   Books processed in parallel (default 4)
+ */
+
+import { MongoClient } from 'mongodb';
+import sharp from 'sharp';
+import { writeFileSync, readFileSync } from 'fs';
+
+const argVal = (flag, def) => {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : def;
+};
+const IDS_FILE = argVal('--ids-file', null);
+const SAMPLES = parseInt(argVal('--samples', '8'), 10);
+const OVERLAP = parseInt(argVal('--overlap', '35'), 10);
+const INK_THRESH = parseFloat(argVal('--ink-thresh', '0.04'));
+const CLIP_FRAC = parseFloat(argVal('--clip-frac', '0.15'));
+const LIMIT = parseInt(argVal('--limit', '0'), 10);
+const OUT = argVal('--out', '/tmp/gutter-clip.json');
+const HTML = argVal('--html', null);
+const CONCURRENCY = parseInt(argVal('--concurrency', '4'), 10);
+
+const CROP_FILTER = {
+  'crop.xStart': { $exists: true },
+  cropped_photo: { $exists: true, $ne: null },
+  split_from_spread: { $ne: true },
+};
+
+async function fetchImage(url) {
+  const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return Buffer.from(await res.arrayBuffer());
+}
+
+function fullSpreadSource(page) {
+  const a = page.archived_photo;
+  if (typeof a === 'string' && a.startsWith('http')) return a;
+  const o = page.photo_original;
+  if (typeof o === 'string' && o.startsWith('http')) return o;
+  return null;
+}
+
+// Per-mille ink density: resize spread to width 1000 so column x === per-mille.
+async function inkPerMille(buf) {
+  const W = 1000;
+  const meta = await sharp(buf).metadata();
+  const H = Math.round((meta.height || 1) * (W / (meta.width || 1)));
+  const raw = await sharp(buf).resize(W, H, { fit: 'fill' }).removeAlpha().toColourspace('srgb').raw().toBuffer();
+  const y0 = Math.round(H * 0.25), y1 = Math.round(H * 0.75);
+  const rows = y1 - y0;
+  const ink = new Float32Array(W);
+  for (let x = 0; x < W; x++) {
+    let d = 0;
+    for (let y = y0; y < y1; y++) {
+      const i = (y * W + x) * 3;
+      if (Math.min(raw[i], raw[i + 1], raw[i + 2]) < 120) d++;
+    }
+    ink[x] = d / rows;
+  }
+  return ink;
+}
+
+// Measure the recover-band just outside the cut. Returns severity (max col ink),
+// mean ink, and reach (furthest per-mille past the cut with ink >= thresh).
+function measureBand(ink, crop) {
+  let lo, hi; // inclusive per-mille range of the recover band
+  if (crop.xStart === 0 && crop.xEnd < 1000) { lo = crop.xEnd; hi = Math.min(999, crop.xEnd + OVERLAP); }
+  else if (crop.xEnd === 1000 && crop.xStart > 0) { lo = Math.max(0, crop.xStart - OVERLAP); hi = crop.xStart; }
+  else return null; // undetermined side
+  const cut = crop.xStart === 0 ? crop.xEnd : crop.xStart;
+  let max = 0, sum = 0, n = 0, reach = 0;
+  for (let x = lo; x <= hi; x++) {
+    const v = ink[x] || 0;
+    max = Math.max(max, v); sum += v; n++;
+    if (v >= INK_THRESH) reach = Math.max(reach, Math.abs(x - cut));
+  }
+  return { max, mean: n ? sum / n : 0, reach, band: [lo, hi], cut, side: crop.xStart === 0 ? 'L' : 'R' };
+}
+
+async function auditBook(db, book) {
+  const pages = await db.collection('pages').find(
+    { book_id: book.id, ...CROP_FILTER },
+    { projection: { id: 1, page_number: 1, crop: 1, archived_photo: 1, photo_original: 1 } },
+  ).sort({ page_number: 1 }).toArray();
+  if (pages.length === 0) return null;
+
+  // Evenly spaced sample across the book.
+  const k = Math.min(SAMPLES, pages.length);
+  const idxs = [...new Set(Array.from({ length: k }, (_, i) => Math.floor(((i + 1) / (k + 1)) * pages.length)))];
+
+  const perPage = [];
+  for (const idx of idxs) {
+    const p = pages[idx];
+    const src = fullSpreadSource(p);
+    if (!src) continue;
+    try {
+      const ink = await inkPerMille(await fetchImage(src));
+      const m = measureBand(ink, p.crop);
+      if (m) perPage.push({ page_number: p.page_number, page_id: p.id, crop: p.crop, ...m, clipped: m.max >= INK_THRESH });
+    } catch { /* skip unfetchable sample */ }
+  }
+  if (perPage.length === 0) return null;
+
+  const clipped = perPage.filter(s => s.clipped);
+  const clipFrac = clipped.length / perPage.length;
+  // Severity: fraction clipped × mean ink of clipped pages × max reach — a book
+  // that clips most pages, with dense ink, far past the cut ranks highest.
+  const meanClipInk = clipped.length ? clipped.reduce((a, s) => a + s.max, 0) / clipped.length : 0;
+  const maxReach = perPage.reduce((a, s) => Math.max(a, s.reach), 0);
+  const severity = +(clipFrac * meanClipInk * (1 + maxReach / OVERLAP)).toFixed(4);
+
+  return {
+    book_id: book.id, slug: book.slug, title: book.title,
+    totalCropPages: pages.length, sampled: perPage.length,
+    clippedPages: clipped.length, clipFrac: +clipFrac.toFixed(3),
+    meanClipInk: +meanClipInk.toFixed(3), maxReach, severity,
+    flagged: clipFrac >= CLIP_FRAC,
+    samples: perPage,
+  };
+}
+
+async function parallelMap(items, fn, concurrency) {
+  const out = []; let i = 0;
+  const worker = async () => { while (i < items.length) { const idx = i++; out[idx] = await fn(items[idx], idx); } };
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return out;
+}
+
+async function main() {
+  const client = await MongoClient.connect(process.env.MONGODB_URI);
+  const db = client.db('bookstore');
+
+  let books;
+  if (IDS_FILE) {
+    const ids = JSON.parse(readFileSync(IDS_FILE, 'utf8'));
+    books = await db.collection('books').find({ id: { $in: ids } }, { projection: { id: 1, slug: 1, title: 1 } }).toArray();
+  } else {
+    // Full BPH cohort. Per-book crop-page check happens in auditBook (indexed by book_id).
+    books = await db.collection('books').find(
+      { held_by: 'bph' },
+      { projection: { id: 1, slug: 1, title: 1 } },
+    ).toArray();
+  }
+  if (LIMIT > 0) books = books.slice(0, LIMIT);
+  console.error(`Auditing ${books.length} books (samples ${SAMPLES}, overlap ${OVERLAP}‰, ink-thresh ${INK_THRESH}, clip-frac ${CLIP_FRAC})`);
+
+  let done = 0;
+  const results = (await parallelMap(books, async (book) => {
+    const r = await auditBook(db, book).catch(e => ({ book_id: book.id, error: e.message }));
+    if (++done % 25 === 0) console.error(`  ${done}/${books.length}`);
+    return r;
+  }, CONCURRENCY)).filter(Boolean);
+
+  const audited = results.filter(r => !r.error && r.sampled);
+  audited.sort((a, b) => b.severity - a.severity);
+  const flagged = audited.filter(r => r.flagged);
+
+  writeFileSync(OUT, JSON.stringify({
+    generated_for: 'issue-2898', overlap: OVERLAP, ink_thresh: INK_THRESH, clip_frac: CLIP_FRAC,
+    booksAudited: audited.length, booksWithCropPages: audited.length, flaggedCount: flagged.length,
+    flaggedBookIds: flagged.map(r => r.book_id),
+    results: audited,
+  }, null, 2));
+  console.error(`\nAudited ${audited.length} cohort books · ${flagged.length} flagged (clipFrac ≥ ${CLIP_FRAC}) · wrote ${OUT}`);
+  console.error(`Top flagged:`);
+  for (const r of flagged.slice(0, 15)) {
+    console.error(`  sev ${r.severity}  clip ${r.clippedPages}/${r.sampled} (${(r.clipFrac * 100).toFixed(0)}%)  reach ${r.maxReach}‰  ${r.book_id}  ${(r.title || '').slice(0, 45)}`);
+  }
+
+  if (HTML) writeFileSync(HTML, renderHtml(audited, flagged));
+  await client.close();
+}
+
+function esc(s) { return String(s || '').replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+function renderHtml(audited, flagged) {
+  const row = (r) => `<tr class="${r.flagged ? 'flag' : ''}">
+    <td>${r.severity}</td><td>${r.clippedPages}/${r.sampled} (${(r.clipFrac * 100).toFixed(0)}%)</td>
+    <td>${r.maxReach}‰</td><td>${r.meanClipInk}</td><td>${r.totalCropPages}</td>
+    <td><a href="https://sourcelibrary.org/book/${esc(r.slug || r.book_id)}" target="_blank">${esc((r.title || '').slice(0, 60))}</a></td>
+    <td class="mono">${esc(r.book_id)}</td></tr>`;
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>BPH gutter-clip audit (#2898)</title><style>
+    body{font-family:system-ui;background:#1a1a1a;color:#ddd;padding:20px;max-width:1400px;margin:0 auto}
+    h1{color:#e8c87a} table{border-collapse:collapse;width:100%;font-size:13px} th,td{padding:5px 9px;border-bottom:1px solid #333;text-align:left}
+    th{color:#e8c87a} tr.flag{background:#2a2318} a{color:#7ab6e8} .mono{font-family:ui-monospace;color:#888;font-size:11px}
+  </style></head><body>
+  <h1>BPH gutter-clip audit — #2898</h1>
+  <p>${audited.length} cohort books audited · <b>${flagged.length} flagged</b> (clipFrac ≥ ${CLIP_FRAC}). Severity = clipFrac × meanClipInk × (1 + reach/overlap). Higher = worse.</p>
+  <table><thead><tr><th>severity</th><th>clipped</th><th>reach</th><th>meanInk</th><th>cropPages</th><th>title</th><th>book_id</th></tr></thead>
+  <tbody>${audited.map(row).join('')}</tbody></table></body></html>`;
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/audit-bph-gutter-clip.mjs
+++ b/scripts/maintenance/audit-bph-gutter-clip.mjs
@@ -23,6 +23,23 @@
  * out). Anchor: held_by:'bph' ∩ per-book pages with crop + cropped_photo + not
  * split_from_spread.
  *
+ * ⚠ KNOWN LIMITATION — over-flags, do NOT drive a blanket sweep off this alone.
+ * The raw ink metric (min(R,G,B)<120) cannot tell CLIPPED TEXT apart from two
+ * other things that also darken the recover band: (1) the BINDING SHADOW of a
+ * tight-bound book (saturates to ~1.0 ink — distinct from text, which tops out
+ * ~0.6 because line spacing leaves white rows), and (2) FACING-PAGE bleed when
+ * the two text blocks sit close and the band crosses the gutter. Measured on the
+ * real BPH cohort (2026-07-08) this flags ~97% of books, and the HIGHEST-severity
+ * entries are tight pamphlets whose "clipping" is actually binding shadow — a
+ * naive +overlap re-crop there would pull in shadow + facing page, not recover
+ * content. So: verified-safe re-crops need WIDE-GUTTER books (like Artis
+ * auriferae). A trustworthy audit must be GUTTER-AWARE — locate the gutter
+ * (deepest/widest ink-free run, or the saturated dark run) and count only
+ * text-like ink BETWEEN the cut and the gutter (left-page content), excluding
+ * saturation and anything past the gutter. That is the hard, iteratively-tuned
+ * problem #1491 documents; treat this script as a first-pass triage + eye-check
+ * aid (the HTML gallery), NOT an auto-sweep driver.
+ *
  * Run:
  *   set -a; source .env.production.local; set +a
  *   node scripts/maintenance/audit-bph-gutter-clip.mjs --limit 50 --html /tmp/gutter-clip.html

--- a/scripts/maintenance/recrop-bph-gutter.mjs
+++ b/scripts/maintenance/recrop-bph-gutter.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Re-crop old-era BPH split halves with gutter overlap (issue #2898).
+ *
+ * The old crop-coord BPH splitter cut each spread into two halves at a single
+ * shared gutter line with ZERO overlap (`left.xEnd == right.xStart`), shaving
+ * off content that reaches the gutter (right-margin numeral columns, catchwords,
+ * long line-ends). This re-crops each half from the PRESERVED full spread
+ * (`archived_photo`/`photo_original`, immutable) with ~3.5% overlap on the
+ * gutter side, keeping page IDs / links / OCR intact.
+ *
+ * These pages carry a MATERIALIZED `cropped_photo` (and `photo`/`image_thumb`/
+ * `thumbnail` point at it). At read time getPageSource() returns cropped_photo
+ * and cropRegion() returns undefined (src/lib/page-image-url.ts), so the display
+ * serves the pre-cut file — updating `crop` coords alone changes nothing. We must
+ * regenerate the cropped half image.
+ *
+ * NEW R2 PATHS, not overwrite (issue #2898 decision; #1491 lesson #5):
+ * every display/thumb/hires request for these pages goes through the /api/image
+ * proxy keyed on the cropped_photo URL. Writing to a new key
+ * (`cropped/{bookId}/{pageId}-rc{overlap}.jpg`) and repointing the DB fields
+ * changes that key → the fix is live instantly with no CDN purge. Overwriting
+ * the same key would serve the old clipped crop for up to a week.
+ *
+ * Non-destructive + idempotent: nothing is deleted; each page is re-cropped from
+ * the immutable spread and the ORIGINAL crop is stashed in `recrop_2898.prev_crop`
+ * so re-runs never double-widen. Reversible via the stashed provenance.
+ *
+ * Re-cropping fixes PIXELS, not the stored OCR/translation (text cut at the
+ * gutter is missing from OCR that ran on the clipped crop). Re-OCR is a separate,
+ * paid, deferred decision (#2898 Phase 4).
+ *
+ * Run (on Hetzner or any box with R2 + Mongo creds):
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/recrop-bph-gutter.mjs --book-id 69751588a88d83c830d99e16 --dry-run
+ *   node scripts/maintenance/recrop-bph-gutter.mjs --book-id 69751588a88d83c830d99e16
+ *   node scripts/maintenance/recrop-bph-gutter.mjs --ids-file /tmp/clip-ids.json
+ *
+ * Options:
+ *   --book-id ID       Process a single book
+ *   --ids-file PATH    JSON array of book ids to process
+ *   --overlap N        Per-mille (0-1000) added to the gutter side (default 35 = 3.5%)
+ *   --concurrency N    Pages processed in parallel per book (default 5)
+ *   --limit N          Process at most N books (from --ids-file)
+ *   --dry-run          Print old→new bounds, write nothing
+ */
+
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+import { readFileSync } from 'fs';
+
+// --- Args ---
+const argVal = (flag, def) => {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : def;
+};
+const BOOK_ID = argVal('--book-id', null);
+const IDS_FILE = argVal('--ids-file', null);
+const OVERLAP = parseInt(argVal('--overlap', '35'), 10); // per-mille added to gutter side
+const CONCURRENCY = parseInt(argVal('--concurrency', '5'), 10);
+const LIMIT = parseInt(argVal('--limit', '0'), 10);
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// --- Config ---
+const CROPPED_MAX_WIDTH = 2000; // matches the modern splitter; improves the magnifier vs the old 1200px
+const CROPPED_QUALITY = 90;
+const HIGH_FAIL_FRAC = 0.2; // warn (do NOT abort — re-crop is non-destructive and per-page)
+
+// --- R2 (ALL env values are sanitized. Some .env files store R2_PUBLIC_URL /
+// R2_ACCOUNT_ID with a trailing "\n" — as a real newline (dotenv expands it) or
+// a LITERAL backslash-n (bash `source` keeps it verbatim). Either corrupts the
+// endpoint hostname (the URL parser turns "\" into "/" and truncates the host) →
+// DNS failure. Strip both defensively.) ---
+const env = (k, def) => (process.env[k] || def || '').trim().replace(/\\n$/, '').trim();
+const R2_BUCKET = env('R2_BUCKET_NAME', 'sourcelibrary');
+const R2_PUBLIC = env('R2_PUBLIC_URL', 'https://images.sourcelibrary.org');
+function getR2() {
+  const accountId = env('R2_ACCOUNT_ID');
+  const accessKeyId = env('R2_ACCESS_KEY_ID');
+  const secretAccessKey = env('R2_SECRET_ACCESS_KEY');
+  if (!accountId || !accessKeyId || !secretAccessKey) {
+    throw new Error('Missing R2 credentials (R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY)');
+  }
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId, secretAccessKey },
+  });
+}
+async function uploadToR2(r2, key, buffer) {
+  await r2.send(new PutObjectCommand({
+    Bucket: R2_BUCKET,
+    Key: key,
+    Body: buffer,
+    ContentType: 'image/jpeg',
+    // Content-addressed by overlap in the key → safe to cache long.
+    CacheControl: 'public, max-age=31536000, immutable',
+  }));
+  return `${R2_PUBLIC}/${key}`;
+}
+
+async function fetchImage(url) {
+  const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  if (!res.ok) throw new Error(`Fetch ${res.status}: ${url}`);
+  return Buffer.from(await res.arrayBuffer());
+}
+
+// The UNCROPPED full spread — never cropped_photo/photo (those are the half).
+function fullSpreadSource(page) {
+  const a = page.archived_photo;
+  if (typeof a === 'string' && a.startsWith('http')) return a;
+  const o = page.photo_original;
+  if (typeof o === 'string' && o.startsWith('http')) return o;
+  return null;
+}
+
+// Widen the gutter side of a crop by OVERLAP per-mille. Returns null if the
+// side can't be determined (not a clean left/right half).
+function widenCrop(base) {
+  if (base.xStart === 0 && base.xEnd < 1000) {
+    return { xStart: 0, xEnd: Math.min(1000, base.xEnd + OVERLAP) }; // left half
+  }
+  if (base.xEnd === 1000 && base.xStart > 0) {
+    return { xStart: Math.max(0, base.xStart - OVERLAP), xEnd: 1000 }; // right half
+  }
+  return null;
+}
+
+// --- Concurrency limiter ---
+async function parallelMap(items, fn, concurrency) {
+  const results = [];
+  let i = 0;
+  async function worker() {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await fn(items[idx], idx);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return results;
+}
+
+async function processPage(r2, db, page) {
+  // Idempotent base: always widen from the ORIGINAL crop, never a prior re-crop.
+  const base = page.recrop_2898?.prev_crop || page.crop;
+  const prevCropped = page.recrop_2898?.prev_cropped_photo || page.cropped_photo;
+  const newCrop = widenCrop(base);
+  if (!newCrop) return { status: 'skip', reason: `undetermined side ${JSON.stringify(base)}` };
+
+  const src = fullSpreadSource(page);
+  if (!src) return { status: 'skip', reason: 'no full-spread source' };
+
+  if (DRY_RUN) {
+    return { status: 'dry', side: base.xStart === 0 ? 'L' : 'R', from: base, to: newCrop };
+  }
+
+  const buf = await fetchImage(src);
+  const meta = await sharp(buf).metadata();
+  const W = meta.width || 1000;
+  const H = meta.height || 1000;
+  const left = Math.round((newCrop.xStart / 1000) * W);
+  const width = Math.round(((newCrop.xEnd - newCrop.xStart) / 1000) * W);
+
+  const outBuf = await sharp(buf)
+    .extract({ left, top: 0, width: Math.min(width, W - left), height: H })
+    .resize(CROPPED_MAX_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: CROPPED_QUALITY, progressive: true })
+    .toBuffer();
+
+  // New unique key → fresh /api/image cache key, no CDN purge needed.
+  const key = `cropped/${page.book_id}/${page.id}-rc${OVERLAP}.jpg`;
+  const newUrl = await uploadToR2(r2, key, outBuf);
+
+  await db.collection('pages').updateOne(
+    { id: page.id },
+    {
+      $set: {
+        cropped_photo: newUrl,
+        photo: newUrl,
+        image_thumb: newUrl,
+        thumbnail: newUrl,
+        crop: newCrop,
+        recrop_2898: {
+          at: new Date(),
+          overlap: OVERLAP,
+          prev_crop: base,
+          prev_cropped_photo: prevCropped,
+        },
+        updated_at: new Date(),
+      },
+    },
+  );
+  return { status: 'ok', url: newUrl };
+}
+
+async function processBook(r2, db, bookId) {
+  const book = await db.collection('books').findOne(
+    { $or: [{ id: bookId }, { slug: bookId }] },
+    { projection: { id: 1, title: 1 } },
+  );
+  if (!book) { console.log(`  ${bookId}: book not found`); return { notFound: true }; }
+
+  // Old-era crop halves: crop present, materialized cropped_photo, NOT split_from_spread.
+  const pages = await db.collection('pages').find(
+    {
+      book_id: book.id,
+      'crop.xStart': { $exists: true },
+      cropped_photo: { $exists: true, $ne: null },
+      split_from_spread: { $ne: true },
+    },
+    { projection: {
+      id: 1, book_id: 1, page_number: 1, crop: 1,
+      archived_photo: 1, photo_original: 1, cropped_photo: 1, recrop_2898: 1,
+    } },
+  ).sort({ page_number: 1 }).toArray();
+
+  if (pages.length === 0) { console.log(`  ${book.id}: no old-era crop pages`); return { empty: true }; }
+
+  let ok = 0, skip = 0, err = 0;
+  const results = await parallelMap(pages, async (page) => {
+    try { return await processPage(r2, db, page); }
+    catch (e) { return { status: 'error', msg: e.message, page: page.page_number }; }
+  }, CONCURRENCY);
+
+  for (const r of results) {
+    if (r.status === 'ok') ok++;
+    else if (r.status === 'dry') ok++;
+    else if (r.status === 'skip') skip++;
+    else { err++; if (err <= 5) console.error(`    FAIL p${r.page}: ${r.msg}`); }
+  }
+
+  if (DRY_RUN) {
+    const sample = results.filter(r => r.status === 'dry').slice(0, 4);
+    for (const s of sample) console.log(`    [${s.side}] ${JSON.stringify(s.from)} → ${JSON.stringify(s.to)}`);
+  }
+
+  const failFrac = pages.length ? err / pages.length : 0;
+  const flag = failFrac > HIGH_FAIL_FRAC ? '  ⚠ HIGH FAILURE RATE' : '';
+  console.log(`  ${book.id} "${(book.title || '').slice(0, 50)}": ${pages.length} pages → ok ${ok}, skip ${skip}, err ${err}${flag}`);
+  return { pages: pages.length, ok, skip, err };
+}
+
+async function main() {
+  let bookIds = [];
+  if (BOOK_ID) bookIds = [BOOK_ID];
+  else if (IDS_FILE) bookIds = JSON.parse(readFileSync(IDS_FILE, 'utf8'));
+  else { console.error('Provide --book-id or --ids-file'); process.exit(1); }
+  if (LIMIT > 0) bookIds = bookIds.slice(0, LIMIT);
+
+  console.log(`Re-crop BPH gutter (issue #2898)`);
+  console.log(`Books: ${bookIds.length}, overlap: ${OVERLAP}‰, concurrency: ${CONCURRENCY}, dry-run: ${DRY_RUN}\n`);
+
+  const r2 = getR2();
+  const client = await MongoClient.connect(process.env.MONGODB_URI);
+  const db = client.db('bookstore');
+
+  const totals = { books: 0, pages: 0, ok: 0, skip: 0, err: 0 };
+  const startedAt = Date.now();
+  for (let i = 0; i < bookIds.length; i++) {
+    console.log(`[${i + 1}/${bookIds.length}]`);
+    const res = await processBook(r2, db, bookIds[i]);
+    if (res.pages) {
+      totals.books++;
+      totals.pages += res.pages; totals.ok += res.ok; totals.skip += res.skip; totals.err += res.err;
+    }
+  }
+
+  const mins = ((Date.now() - startedAt) / 60000).toFixed(1);
+  console.log(`\nDone in ${mins} min. Books: ${totals.books}, pages: ${totals.pages}, ok: ${totals.ok}, skip: ${totals.skip}, err: ${totals.err}`);
+  if (!DRY_RUN && totals.ok > 0) {
+    console.log(`\nNext: revalidate ISR for each book (tenant + non-tenant) so readers see the re-cropped halves.`);
+  }
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Closes #2898 (reported book fixed) and ships the cohort audit. The blanket cohort sweep is intentionally **deferred** — tracked in #3088 (see Findings).

## Problem
Old-era BPH crop-coord splits cut each spread at a single shared gutter line with **zero overlap** (`left.xEnd == right.xStart`), shaving off content that reaches the gutter — right-margin numeral columns, catchwords, long line-ends. Reported on **Artis auriferae** p386 (`69751588a88d83c830d99e16`).

**Decisive data point:** these pages carry a *materialized* `cropped_photo` (and `photo`/`image_thumb`/`thumbnail` point at it), so `getPageSource()` serves the pre-cut file and `cropRegion()` returns `undefined` ([src/lib/page-image-url.ts](../blob/main/src/lib/page-image-url.ts)). **Updating `crop` coords alone does nothing** — the fix must regenerate the cropped half image from the preserved full spread (`archived_photo`, immutable).

## What's in scope
- **`scripts/maintenance/recrop-bph-gutter.mjs`** — in-place re-crop keeping page IDs. Re-cuts each half from the full spread with ~3.5% (35‰) overlap on the gutter side. Writes to **new R2 paths** (`cropped/{bookId}/{pageId}-rc{overlap}.jpg`) so the `/api/image` cache key changes and the fix is live with no CDN purge (#1491 lesson #5 — never reuse R2 paths). Non-destructive + idempotent (widens from the original crop stashed in `recrop_2898.prev_crop`), reversible, upgrades halves 1200px→2000px. Sanitizes R2 env values (some `.env` carry a literal trailing `\n` that corrupts the endpoint host → DNS failure).
- **`scripts/maintenance/audit-bph-gutter-clip.mjs`** — content-level triage: per-column ink density (`min(R,G,B)<120`, incl. rubrication) in the band just outside each half's cut, ranked by severity, with an HTML eye-check gallery.

## Done & verified
**Target book re-cropped** (1,250 halves) and verified end-to-end against the **live R2 image** — every clipped line-end and the full `I, II, III, IIII, V, VI, Ex` numeral column recovered, with no bleed from the facing page. `crop` updated 505→540‰; all four image fields repointed; provenance + prior crop stashed for reversibility.

## Findings — why the cohort sweep is deferred
- Cohort: **1,208 BPH books / ~410k crop pages**, all zero-overlap (matches the issue's ~1,230).
- The audit's raw ink metric **over-flags ~97%**: it can't distinguish clipped text from (a) **binding shadow** on tight-bound pamphlets (saturates ~1.0 ink; the highest-"severity" flags are actually shadow) and (b) **facing-page bleed** when text blocks sit close. Verified on the top-flagged pamphlet — its "clipping" is the dark binding shadow, and a naive +35‰ re-crop there would pull in shadow + the facing page rather than recover content.
- So the verified +35‰ fix is safe for **wide-gutter** books (Artis auriferae), **not** for the tight-gutter majority. A trustworthy audit must be **gutter-aware** (locate the gutter; count only text-like ink between the cut and the gutter) — the hard, iteratively-tuned problem #1491 documents.

Per this, a blanket sweep of ~400k pages with a naive overlap is **unsafe** (would degrade partner-facing BPH books). Documented as a limitation in the audit script header and left as a follow-up.

## Out of scope / follow-ups
- **Cohort sweep** (tracked in #3088) — needs the gutter-aware audit refinement above, then a targeted re-crop (per-page overlap cut to the detected gutter, not a blind +35‰). The `recrop-bph-gutter.mjs` `--ids-file` engine is ready to drive it once a trustworthy subset exists.
- **Re-OCR** of cut text (#2898 Phase 4) — separate, paid, pipeline paused.
- **Reader visibility** — book pages are ISR `revalidate=86400`; readers pick up the new (already-fresh) image URLs within 24h, or trigger `/api/admin/revalidate-book/{id}` for immediacy.

## Test plan
- `node scripts/maintenance/recrop-bph-gutter.mjs --book-id 69751588a88d83c830d99e16 --dry-run` → 1,250 pages, left `xEnd +35`, right `xStart −35`, 0 skip/err.
- Live image `cropped/.../{pageId}-rc35.jpg` recovers the numeral column with no facing-page bleed (verified visually).
- `npx tsc --noEmit` passes (scripts are `.mjs`, no dep changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)