### PR TITLE
fix(errors): library 500, timeline/gallery 404s, tiny thumbnails, broken PDF-cover srcSet, PDF-import 501

### DIFF
--- a/src/app/api/import/pdf/route.ts
+++ b/src/app/api/import/pdf/route.ts
@@ -8,13 +8,29 @@ import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { execFileSync } from 'child_process';
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { storagePut } from '@/lib/storage';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
 
 export const maxDuration = 300;
+
+/**
+ * `pdftoppm` (poppler-utils) is NOT present in the Vercel serverless runtime, so
+ * this route can only extract pages where the binary exists (local dev / Hetzner).
+ * Probe once so we can return an honest 501 with the supported workaround instead
+ * of downloading the whole PDF and then dying on a cryptic `spawnSync ENOENT`
+ * 500 (#2526). The interim/native path is `scripts/import/pdf-direct.ts`.
+ */
+function pdftoppmAvailable(): boolean {
+  try {
+    execFileSync('pdftoppm', ['-v'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Import a book from a PDF URL
@@ -70,6 +86,18 @@ export const POST = withCuratorAuth(async (request) => {
       return NextResponse.json(
         { error: 'Missing required fields: pdf_url, title, provider, provider_name' },
         { status: 400 },
+      );
+    }
+
+    // Bail early on serverless (Vercel) where poppler is absent — before the
+    // multi-minute PDF download — with an actionable message instead of a 500.
+    if (!pdftoppmAvailable()) {
+      return NextResponse.json(
+        {
+          error: 'PDF import is unavailable in this runtime: pdftoppm (poppler-utils) is not installed on Vercel serverless.',
+          workaround: 'Run scripts/import/pdf-direct.ts locally or on Hetzner, where poppler is present. It uses the same download → pdftoppm → R2 → insert-hidden flow.',
+        },
+        { status: 501 },
       );
     }
 
@@ -138,7 +166,7 @@ export const POST = withCuratorAuth(async (request) => {
 
     // 2. Extract pages with pdftoppm
     const pagesDir = join(tmpDir, 'pages');
-    execFileSync('mkdir', ['-p', pagesDir]);
+    mkdirSync(pagesDir, { recursive: true });
 
     try {
       execFileSync('pdftoppm', [

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -26,9 +26,16 @@ export interface SharedConnection {
 export const getSharedBooks = cache(async (name: string): Promise<SharedConnection[] | null> => {
   try {
     const db = await getReadDb();
-    // Try exact match first (uses index, 2ms) before falling back to case-insensitive regex (20s full scan)
+    // Try exact match first (uses index, 2ms), then the aliases array (the timeline
+    // links figures by their canonical Wikidata name, e.g. "Apuleius", while the
+    // entity is stored under a surface name, e.g. "Apuleius of Madaura" — both share
+    // the same aliases[]), then case-insensitive regex on name (20s full scan) as a
+    // last resort.
     const entity = await db.collection('entities').findOne(
       { name },
+      { sort: { book_count: -1 } }
+    ) ?? await db.collection('entities').findOne(
+      { aliases: name },
       { sort: { book_count: -1 } }
     ) ?? await db.collection('entities').findOne(
       { name: { $regex: `^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' } },
@@ -78,9 +85,16 @@ export const getSharedBooks = cache(async (name: string): Promise<SharedConnecti
 export const getEntity = cache(async (name: string) => {
   try {
     const db = await getReadDb();
-    // Try exact match first (uses index, 2ms) before falling back to case-insensitive regex (20s full scan)
+    // Try exact match first (uses index, 2ms), then the aliases array (the timeline
+    // links figures by their canonical Wikidata name, e.g. "Apuleius", while the
+    // entity is stored under a surface name, e.g. "Apuleius of Madaura" — both share
+    // the same aliases[]), then case-insensitive regex on name (20s full scan) as a
+    // last resort. Without the aliases fallback ~0.4% of timeline figures 404.
     const entity = await db.collection('entities').findOne(
       { name },
+      { sort: { book_count: -1 } }
+    ) ?? await db.collection('entities').findOne(
+      { aliases: name },
       { sort: { book_count: -1 } }
     ) ?? await db.collection('entities').findOne(
       { name: { $regex: `^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' } },

--- a/src/app/explore/timeline/page.tsx
+++ b/src/app/explore/timeline/page.tsx
@@ -112,10 +112,6 @@ async function fetchTimelineDataCanonical() {
     return best;
   }
 
-  const byCentury: Record<string, number> = {};
-  let minYear = Infinity;
-  let maxYear = -Infinity;
-
   const mapped = entities
     .map((e) => {
       const birthStr = e.wikidata_birth_date as string | undefined;
@@ -132,23 +128,9 @@ async function fetchTimelineDataCanonical() {
       // Filter out Anno Mundi / mythological dates (Eve, Noah, Cain, etc.)
       if ((bY && Math.abs(bY) > 2026) || (dY && Math.abs(dY) > 2026)) return null;
 
-      // Track year range
-      if (bY && bY < minYear) minYear = bY;
-      if (dY && dY > maxYear) maxYear = dY;
-      if (bY && bY > maxYear) maxYear = bY;
-      if (dY && dY < minYear) minYear = dY;
-
-      // Century stats — use absolute value for bucketing
-      const refYear = bY || dY!;
-      const absYear = Math.abs(refYear);
-      const century = refYear < 0
-        ? -Math.floor((absYear - 1) / 100) - 1
-        : Math.floor((absYear - 1) / 100) + 1;
-      byCentury[String(century)] = (byCentury[String(century)] || 0) + 1;
-
       return {
         name: e.name as string,
-        type: (e.type as string) === 'person' ? 'person' : 'concept',
+        type: ((e.type as string) === 'person' ? 'person' : 'concept') as 'person' | 'concept',
         birth_year: bY,
         death_year: dY,
         book_count: (e.book_count as number) || 0,
@@ -162,22 +144,40 @@ async function fetchTimelineDataCanonical() {
         occupations: (e.occupation_groups as string[] | undefined) ?? [],
       };
     })
-    .filter(Boolean) as {
-    name: string;
-    type: 'person' | 'concept';
-    birth_year: number | null;
-    death_year: number | null;
-    book_count: number;
-    total_mentions: number;
-    description?: string;
-    tradition: string;
-    occupations: string[];
-  }[];
+    .filter((e): e is NonNullable<typeof e> => e !== null);
+
+  // #3050: every timeline dot links to /encyclopedia/<name>, which resolves
+  // against the legacy `entities` collection (exact name → aliases[] → regex).
+  // A canonical_entities row whose name has no resolvable `entities` doc 404s
+  // the reader. Drop those here so the timeline never links to a dead page.
+  // Two indexed batch reads at ISR-rebuild time (every 6h) — not per request;
+  // resolution mirrors getEntity() in encyclopedia/[name]/layout.tsx exactly.
+  const visible = await filterResolvableEntities(db, mapped);
+
+  const byCentury: Record<string, number> = {};
+  let minYear = Infinity;
+  let maxYear = -Infinity;
+  for (const e of visible) {
+    const bY = e.birth_year;
+    const dY = e.death_year;
+    if (bY && bY < minYear) minYear = bY;
+    if (dY && dY > maxYear) maxYear = dY;
+    if (bY && bY > maxYear) maxYear = bY;
+    if (dY && dY < minYear) minYear = dY;
+
+    // Century stats — use absolute value for bucketing
+    const refYear = bY || dY!;
+    const absYear = Math.abs(refYear);
+    const century = refYear < 0
+      ? -Math.floor((absYear - 1) / 100) - 1
+      : Math.floor((absYear - 1) / 100) + 1;
+    byCentury[String(century)] = (byCentury[String(century)] || 0) + 1;
+  }
 
   return {
-    entities: mapped,
+    entities: visible,
     stats: {
-      total: mapped.length,
+      total: visible.length,
       year_range: [
         minYear === Infinity ? -500 : minYear,
         maxYear === -Infinity ? 2000 : maxYear,
@@ -185,6 +185,46 @@ async function fetchTimelineDataCanonical() {
       by_century: byCentury,
     },
   };
+}
+
+/**
+ * Keep only entities whose name resolves to an `entities` doc the same way the
+ * encyclopedia page does — exact `name`, then `aliases[]`. (The encyclopedia's
+ * third fallback is a case-insensitive regex full-scan; we deliberately skip
+ * that here — it is a 20s last-resort, and matching it would mean a full-name
+ * fetch of the ~1M-doc collection at every rebuild. The tiny case-only-mismatch
+ * tail it would rescue is acceptable to drop from the timeline.) Two `$in`
+ * reads over the name/aliases indexes; #3050.
+ */
+async function filterResolvableEntities<T extends { name: string }>(
+  db: Awaited<ReturnType<typeof getReadDb>>,
+  entities: T[],
+): Promise<T[]> {
+  const names = [...new Set(entities.map((e) => e.name))];
+  if (names.length === 0) return entities;
+
+  const resolvable = new Set<string>();
+
+  const byName = await db
+    .collection('entities')
+    .find({ name: { $in: names } }, { projection: { _id: 0, name: 1 }, maxTimeMS: 15000 })
+    .toArray();
+  for (const d of byName) resolvable.add(d.name as string);
+
+  const unresolved = names.filter((n) => !resolvable.has(n));
+  if (unresolved.length > 0) {
+    const byAlias = await db
+      .collection('entities')
+      .find({ aliases: { $in: unresolved } }, { projection: { _id: 0, aliases: 1 }, maxTimeMS: 15000 })
+      .toArray();
+    const aliasSet = new Set<string>();
+    for (const d of byAlias) {
+      for (const a of (d.aliases as string[] | undefined) ?? []) aliasSet.add(a);
+    }
+    for (const n of unresolved) if (aliasSet.has(n)) resolvable.add(n);
+  }
+
+  return entities.filter((e) => resolvable.has(e.name));
 }
 
 async function fetchTimelineData() {

--- a/src/app/gallery/image/[id]/layout.tsx
+++ b/src/app/gallery/image/[id]/layout.tsx
@@ -8,12 +8,65 @@
 
 import { cache } from 'react';
 import { Metadata } from 'next';
-import { permanentRedirect } from 'next/navigation';
+import { notFound, permanentRedirect } from 'next/navigation';
+import { ObjectId } from 'mongodb';
 import { getReadDb } from '@/lib/mongodb';
 import GalleryImageSchema from '@/components/seo/GalleryImageSchema';
 
+/** True if `books` has a doc for this id (string `id` field or Mongo `_id`). */
+const bookExists = cache(async (bookId: string): Promise<boolean> => {
+  try {
+    const db = await getReadDb();
+    const or: Record<string, unknown>[] = [{ id: bookId }];
+    if (/^[a-f0-9]{24}$/i.test(bookId)) or.push({ _id: new ObjectId(bookId) });
+    const doc = await db.collection('books').findOne({ $or: or }, { projection: { _id: 1 } });
+    return !!doc;
+  } catch {
+    // Fail open on a transient DB error — never turn one into a 404.
+    return true;
+  }
+});
+
 /**
- * Rescue non-viewer ids that leaked into /gallery/image/ links.
+ * True if the bare viewer id `<pageId>-<n>` resolves to an image the API would
+ * actually serve — a live page detection OR a `gallery_images` fallback row
+ * (orphaned page / stale index), excluding hidden books. Mirrors
+ * /api/gallery/image/[id] so the 404 gate matches exactly what the client can
+ * render; without the gallery_images leg we would wrongly 404 orphaned-page
+ * images that resolve only through it (#3049).
+ */
+const imageResolves = cache(async (id: string): Promise<boolean> => {
+  try {
+    const decodedId = decodeURIComponent(id);
+    const match = decodedId.match(/^(.+)[:\-](\d+)$/);
+    if (!match) return false;
+    const [, pageId, indexStr] = match;
+    const index = parseInt(indexStr, 10);
+    const db = await getReadDb();
+
+    const pages = await db.collection('pages').aggregate([
+      { $match: { id: pageId } },
+      { $lookup: { from: 'books', localField: 'book_id', foreignField: 'id', as: 'book' } },
+      { $unwind: { path: '$book', preserveNullAndEmptyArrays: true } },
+    ]).toArray();
+
+    if (pages.length) {
+      const p = pages[0] as { book?: { hidden?: boolean }; detected_images?: unknown[] };
+      if (p.book?.hidden === true) return false;
+      const detections = p.detected_images || [];
+      if (index >= 0 && index < detections.length && detections[index]) return true;
+    }
+
+    const galleryDoc = await db.collection('gallery_images').findOne({ id: `${pageId}-${index}` });
+    return !!galleryDoc;
+  } catch {
+    // Fail open — a transient DB error must not render as a 404.
+    return true;
+  }
+});
+
+/**
+ * Rescue (or reject) non-viewer ids that leaked into /gallery/image/ links.
  *
  * Several producers (clip_embeddings rows, the merged gallery browse) use
  * prefixed id namespaces that are NOT viewer ids:
@@ -21,20 +74,25 @@ import GalleryImageSchema from '@/components/seo/GalleryImageSchema';
  *   - cover-<bookId>[-<n>]    — book cover clip row
  *   - gallery-<pageId>-<n>    — clip row for a real gallery image
  * The viewer only resolves bare `<pageId>-<n>`, so these all soft-404.
- * Redirect them to where the content actually lives instead.
+ * Redirect them to where the content actually lives — but only if it exists.
+ * An artwork/cover id whose book has been deleted (or never existed) must NOT
+ * be redirected into another dead `/book/<id>` page; render a clean 404 (#3049).
  */
-function redirectLeakedId(id: string): void {
+async function resolveLeakedId(id: string): Promise<void> {
   const decoded = decodeURIComponent(id);
   const prefixed = decoded.match(/^(artwork|cover|gallery)-(.+)$/);
   if (!prefixed) return;
   const [, prefix, rest] = prefixed;
   if (prefix === 'gallery') {
+    // Canonicalize to the bare viewer id; that page's own gate 404s if it too
+    // resolves to nothing.
     permanentRedirect(`/gallery/image/${rest}`);
   }
   // artwork/cover: the payload is a book id, sometimes with a synthetic
   // detection-index suffix (`artwork-<bookId>-0` from the merged browse).
   const bookId = rest.replace(/-\d+$/, '');
-  permanentRedirect(`/book/${bookId}`);
+  if (await bookExists(bookId)) permanentRedirect(`/book/${bookId}`);
+  notFound();
 }
 
 interface PageWithBook {
@@ -130,7 +188,7 @@ export async function generateMetadata({
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {
   const { id } = await params;
-  redirectLeakedId(id);
+  await resolveLeakedId(id);
   let data;
   try {
     data = await getImageData(id);
@@ -200,11 +258,17 @@ export default async function ImageLayout({
   children: React.ReactNode;
 }) {
   const { id } = await params;
-  redirectLeakedId(id);
+  await resolveLeakedId(id);
   const data = await getImageData(id);
   const urlSafeId = decodeURIComponent(id).replace(/:(\d+)$/, '-$1');
 
-  if (!data) return <div className="min-h-screen bg-black">{children}</div>;
+  if (!data) {
+    // getImageData only checks page detections; the API also serves orphaned
+    // images from gallery_images. 404 only when neither resolves — otherwise
+    // render the shell so the client can fetch the gallery_images fallback.
+    if (!(await imageResolves(id))) notFound();
+    return <div className="min-h-screen bg-black">{children}</div>;
+  }
 
   const { page, detection } = data;
   const imageUrl = (page as any).enhanced_photo || page.cropped_photo || page.archived_photo || page.photo;

--- a/src/lib/book-cover-loader.ts
+++ b/src/lib/book-cover-loader.ts
@@ -41,6 +41,16 @@
 const SOURCELIBRARY_HOST = 'images.sourcelibrary.org';
 const THUMB_WIDTH_THRESHOLD = 500;
 
+// Only these R2 path families actually materialize a `-thumb.jpg` sibling
+// (page scans, gallery crops, cropped covers, artworks). Other single-variant
+// uploads — notably PDF-import blobs at `/books/{bookId}/pages/NNNN.jpg` and
+// raw `/archived/{id}/N.jpg` — have ONLY the bare `.jpg`, so rewriting them to
+// `-thumb.jpg` 404s the small-viewport srcSet candidates and renders a broken
+// cover (homepage smoke-test failure, 2026-07-08). Anchor each prefix to the
+// host so the PDF-blob `/books/.../pages/` path is NOT matched by `/pages/`.
+const THUMB_VARIANT_PREFIXES = ['/pages/', '/gallery/', '/cropped/', '/artwork/']
+  .map(p => `${SOURCELIBRARY_HOST}${p}`);
+
 export function bookCoverResponsiveLoader({
   src,
   width,
@@ -52,9 +62,12 @@ export function bookCoverResponsiveLoader({
   if (width > THUMB_WIDTH_THRESHOLD) return src;
   if (!src.includes(SOURCELIBRARY_HOST)) return src;
 
-  // Standard pages URL: `.../pages/{book_id}/{page}.jpg` → swap to `-thumb.jpg`.
-  // Already-thumb URLs are kept; full-resolution suffix gets normalised.
+  // Already-thumb URLs are kept regardless of path.
   if (src.endsWith('-thumb.jpg')) return src;
+
+  // Only swap to the 150px thumb for paths that actually have that variant.
+  if (!THUMB_VARIANT_PREFIXES.some(p => src.includes(p))) return src;
+
   if (src.endsWith('-full.jpg')) return src.replace(/-full\.jpg$/, '-thumb.jpg');
   if (src.endsWith('.jpg')) return src.replace(/\.jpg$/, '-thumb.jpg');
 

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -157,7 +157,18 @@ export async function browseBooks(opts: {
   query = query.range(offset, offset + limit - 1);
 
   const { data, count, error } = await query;
-  if (error) throw new Error(`books_catalog query failed: ${error.message}`);
+  if (error) {
+    // PostgREST returns 416 "Requested range not satisfiable" (PGRST103) when the
+    // requested offset is past the end of the result set — e.g. a bot or a stale
+    // pagination link hitting /libraries/[slug]?offset=60 on a provider with <60
+    // visible books. That's an empty page, not a server error, so don't throw
+    // (it was 500-ing library pages). The 416 response still carries the total in
+    // the Content-Range header, which supabase-js surfaces as `count`.
+    if (error.code === 'PGRST103' || /range not satisfiable/i.test(error.message)) {
+      return { books: [], total: count || 0 };
+    }
+    throw new Error(`books_catalog query failed: ${error.message}`);
+  }
 
   return { books: (data || []) as CatalogBook[], total: count || 0 };
 }

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -7,6 +7,7 @@ import { logAiUsage } from '@/lib/log-ai-usage';
 import { supabase } from '@/lib/supabase';
 import { ObjectId, type Document, type WithId } from 'mongodb';
 import { stripAnnotations } from '@/lib/semantic-alignment';
+import { getBookThumbnailUrl } from '@/lib/utils';
 import { CLIP_URL } from '@/lib/clip';
 
 /**
@@ -669,14 +670,36 @@ async function executeTool(
 
       const { semanticArtworkSearch } = await import('@/lib/semantic-search');
       const { filterVisibleArtworks } = await import('@/lib/artwork-visibility');
+      const artworkDb = await getDb();
       const rawArtworks = await semanticArtworkSearch(query, 8, { genre, period, culture, collection });
-      const artworks = await filterVisibleArtworks(await getDb(), rawArtworks);
+      const artworks = await filterVisibleArtworks(artworkDb, rawArtworks);
+
+      // The Supabase `thumbnail_url` is a stale 150px `book-thumbnails/{id}-thumb.jpg`
+      // snapshot — too small to embed in a chat answer (reported on /librarian,
+      // #3051), and the real high-res lives at a different path we can't derive
+      // from that string. Resolve each artwork's live display image (2000px
+      // /artwork, Wikimedia CDN, or IIIF) from Mongo via getBookThumbnailUrl.
+      const displayImageById = new Map<string, string>();
+      if (artworks.length > 0) {
+        const artBooks = await artworkDb.collection('books')
+          .find(
+            { id: { $in: artworks.map(a => a.book_id) } },
+            { projection: { _id: 0, id: 1, image_display: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1 }, maxTimeMS: 3000 },
+          )
+          .toArray()
+          .catch(() => [] as Array<Record<string, unknown>>);
+        for (const b of artBooks) {
+          const url = getBookThumbnailUrl(b as Parameters<typeof getBookThumbnailUrl>[0], 'display');
+          if (url && b.id) displayImageById.set(b.id as string, url);
+        }
+      }
+      const imageFor = (a: (typeof artworks)[number]): string | null =>
+        displayImageById.get(a.book_id) || a.thumbnail_url;
 
       let context = '';
       if (artworks.length > 0) {
         context = 'Artworks found:\n';
         for (const a of artworks) {
-          const slug = a.book_id; // artwork slug lookup would need DB, use book_id for now
           context += `\n- **${a.display_title || a.title}** by ${a.author || 'Unknown artist'}`;
           if (a.period) context += ` (${a.period})`;
           if (a.technique) context += ` — ${a.technique}`;
@@ -694,14 +717,15 @@ async function executeTool(
             );
             context += `  ${descLines.slice(1, 3).join(' ').trim().slice(0, 250)}\n`;
           }
-          if (a.thumbnail_url) context += `  Image: ${a.thumbnail_url}\n`;
+          const img = imageFor(a);
+          if (img) context += `  Image: ${img}\n`;
         }
       } else {
         context = 'No matching artworks found.';
       }
 
       return {
-        result: { found: artworks.length, context, artworks: artworks.slice(0, 6).map(a => ({ title: a.display_title || a.title, author: a.author, thumbnail: a.thumbnail_url, period: a.period, genre: a.genre })) },
+        result: { found: artworks.length, context, artworks: artworks.slice(0, 6).map(a => ({ title: a.display_title || a.title, author: a.author, thumbnail: imageFor(a), period: a.period, genre: a.genre })) },
         step: { type: 'tool_result', name: 'search_artworks', query, found: artworks.length,
           summary: artworks.length > 0 ? `Found ${artworks.length} artworks` : 'No artworks found' },
       };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -127,8 +127,12 @@ export function getBookThumbnailUrl(
     return `https://images.sourcelibrary.org/pages/${bookId}/${padded}${suffix}`;
   }
 
-  // Standard /pages/ URLs — rewrite suffix to requested variant
-  if (!raw.includes('/pages/')) return raw;
+  // Standard /pages/ URLs — rewrite suffix to requested variant. Anchor to the
+  // canonical `images.sourcelibrary.org/pages/{id}/` scan path so the PDF-import
+  // blob path `/books/{bookId}/pages/NNNN.jpg` (which merely CONTAINS `/pages/`
+  // and has ONLY the bare `.jpg`, no -thumb/-full siblings) is left untouched —
+  // otherwise 'thumb' size returns a 404ing `-thumb.jpg` (cf. book-cover-loader).
+  if (!raw.includes('images.sourcelibrary.org/pages/')) return raw;
 
   if (size === 'display') {
     // Rewrite -thumb.jpg or -full.jpg → .jpg (1200px display variant)

--- a/tests/unit/book-cover-loader.test.ts
+++ b/tests/unit/book-cover-loader.test.ts
@@ -52,4 +52,26 @@ describe('bookCoverResponsiveLoader', () => {
       expect(bookCoverResponsiveLoader({ src: external, width: 1200 })).toBe(external);
     });
   });
+
+  // Single-variant R2 paths have ONLY the bare `.jpg` — rewriting them to
+  // `-thumb.jpg` 404s the small-viewport candidate (homepage broken cover,
+  // 2026-07-08). They must pass through unchanged even at mobile widths.
+  describe('single-variant paths (no -thumb sibling): pass through unchanged', () => {
+    // PDF-import blob path — note it CONTAINS `/pages/` but is NOT the
+    // canonical `.../pages/{id}/...` scan path, so must not be swapped.
+    const pdfBlob = 'https://images.sourcelibrary.org/books/69c1bdc0b82ba5d5bed96a69/pages/0000.jpg';
+    const archivedRaw = 'https://images.sourcelibrary.org/archived/6992c88d4f3a879124230200/346.jpg';
+
+    it('PDF-import /books/{id}/pages/ blob untouched at w=150', () => {
+      expect(bookCoverResponsiveLoader({ src: pdfBlob, width: 150 })).toBe(pdfBlob);
+    });
+
+    it('PDF-import blob untouched at w=400', () => {
+      expect(bookCoverResponsiveLoader({ src: pdfBlob, width: 400 })).toBe(pdfBlob);
+    });
+
+    it('raw /archived/ upload untouched at w=150', () => {
+      expect(bookCoverResponsiveLoader({ src: archivedRaw, width: 150 })).toBe(archivedRaw);
+    });
+  });
 });


### PR DESCRIPTION
Cleans up a cluster of production errors, 404s, and degraded-image bugs from `application_errors`, footer feedback, and E2E.

## In scope
1. **Library pagination 500** (`Requested range not satisfiable`, 39×/48h). `/libraries/[slug]?offset=N` past the visible-book count made PostgREST return 416 → we threw → 500. Treat range-past-end as an empty page. *(books-catalog.ts)*

2. **Timeline → encyclopedia 404s (#3050).** Indexed `aliases` fallback in `getEntity()`/`getSharedBooks()`, **plus** a build-time filter that drops any timeline figure whose `/encyclopedia/<name>` link wouldn't resolve. Measured against prod: 0 figures dropped today — a guard against future drift.

3. **Gallery orphan-id dead-ends (#3049).** `artwork-`/`cover-<bookId>` ids verify the book exists before redirecting to `/book/<bookId>`; a bare `<pageId>-<n>` id renders a clean 404 only when it resolves in neither page detections nor `gallery_images` (mirrors the API's fallback). Fail-open on transient DB errors.

4. **Librarian tiny-thumbnail (#3051).** `search_artworks` embedded the stale 150px Supabase `thumbnail_url`; now resolves each visible artwork's live display image from Mongo via `getBookThumbnailUrl(book, 'display')`.

5. **Broken PDF-import cover srcSet (#2952 — the real E2E smoke failure).** PDF-imported books store covers at the single-variant blob path `/books/<id>/pages/NNNN.jpg` (no `-thumb`/`-full`). `book-cover-loader.ts` and `getBookThumbnailUrl('thumb')` both assumed a `-thumb` sibling and 404'd small-viewport srcSet candidates. Both now gate the thumb swap on an allowlist of variant-bearing path families, anchored to the host so `/books/.../pages/` is excluded. + loader regression tests.

6. **PDF import route honest 501 (#2526).** `/api/import/pdf` shells to `pdftoppm`, absent on Vercel serverless — it downloaded the whole PDF then died on a cryptic `spawnSync ENOENT` 500. Now probes up front and returns a 501 pointing to the supported `scripts/import/pdf-direct.ts`; also drops a needless shelled `mkdir`.

## Out of scope
- Serverless PDF rasterization (WASM) — the direct script remains the supported path (#2526).
- Producer-side audit to stop emitting orphan gallery ids (#3049).
- `/api/search/unified` + `/api/identify` share the stale artwork thumbnail (#3051) — same helper applies; librarian-only here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)