### PR TITLE
fix(bph): gutter-aware clip audit + per-page gutter-relative re-crop (#3088)

### DIFF
--- a/.claude/docs/bph-gutter-clip-audit-and-sweep.md
+++ b/.claude/docs/bph-gutter-clip-audit-and-sweep.md
@@ -1,0 +1,113 @@
+# BPH gutter-clip: gutter-aware audit + targeted re-crop sweep (#3088)
+
+Follow-up to #2898 (which fixed one book — *Artis auriferae*, `69751588a88d83c830d99e16` — and
+shipped the first tooling in PR #3082). This is the **cohort remediation** that was
+deferred: find the BPH books that *actually* clip text at the gutter, and re-crop only
+those, per-page, to the detected gutter.
+
+## The defect
+Old-era BPH splits stored each half as a per-mille crop against the full spread with
+**zero overlap** — `left = {0, c}`, `right = {c, 1000}`, the two facing pages sharing
+the cut line `c`. Where the old splitter put `c` short of the true binding gutter
+(classically it snapped to an **inter-column valley** — the gap between the body text
+and a right-aligned numeral/catchword column — instead of the binding), left-page
+content between the cut and the gutter is shaved off.
+
+These pages carry a **materialized `cropped_photo`**, so the reader serves the pre-cut
+file (`getPageSource()` returns `cropped_photo`, `cropRegion()` returns undefined —
+`src/lib/page-image-url.ts`). Editing `crop` coords alone changes nothing; the half
+image must be regenerated from the immutable full spread and written to a new R2 key.
+
+**Cohort:** ~**1,208 BPH books / ~410k crop pages** (`held_by:'bph'` ∩ pages with
+`crop.xStart` + materialized `cropped_photo` + not `split_from_spread`), all but *Artis*
+still zero-overlap.
+
+## Why the first-pass audit was untrustworthy (and how this fixes it)
+The v1 audit measured raw ink (`min(R,G,B)<120`) in a fixed band just past the cut and
+flagged anything dark. It **over-flagged ~97%** because raw ink can't tell clipped text
+from (a) the **binding shadow** of a tight book (saturates ~1.0; text tops ~0.6 because
+line leading leaves white rows) or (b) **facing-page bleed** past the gutter.
+
+The v2 audit is **gutter-aware** (`scripts/lib/gutter-clip.mjs`, shared with the recrop):
+
+1. Resize the full spread to width 1000 (column x === per-mille); compute per-column ink
+   and luminance over the central band (y 25–75%).
+2. **Locate the true gutter** in a window around the cut: the **widest** bright ink-free
+   run (picking the widest is what beats the ToC case — the inter-column valley is
+   narrower than the binding), or, on a tight binding with no bright gap, the saturated
+   dark shadow column.
+3. Count recoverable content **only between the cut and the gutter, on the correct side**
+   (sign of `gutter − cut` distinguishes a real clip from a cut that's already at/past the
+   gutter, i.e. harmless over-inclusion of facing page).
+4. Count only **text-like** columns (`TEXT_LO ≤ ink ≤ TEXT_HI`), and drop any column
+   within `SAT_ADJ‰` of a **saturation peak** (`ink ≥ SAT_PEAK`) — that kills the
+   binding-shadow *ramp*, which climbs through text-like values before it saturates (the
+   p197 false positive).
+
+Result on a 21-book sample: **~10% flagged** (vs 97%), every flag text-driven
+(`shadowFrac 0`), spot-checked against overlaid spreads. Real clips are **modest** —
+trailing line-end punctuation (`/`, `:`, `&`), marginal numerals, catchwords — which is
+consistent with #2898's finding that the harm is localized, not wholesale.
+
+## Acceptance-criteria status
+- [x] Gutter-aware audit, eye-checked (see PR: overlay renders of true clip p50, shadow
+      FP p197 now excluded, flagged books *Eine kurtze…* / *L'Elixir…* confirmed).
+- [ ] Dry-run counts reviewed before any write — **do this on Hetzner** (below).
+- [ ] Targeted sweep of confirmed-clipping books only, on Hetzner, batched with logs.
+- [ ] Revalidate affected pages (tenant + non-tenant) after each batch.
+- [ ] Re-OCR decision recorded (below).
+
+## Run plan (on Hetzner — image-heavy, multi-hour; belongs on the pipeline box)
+
+```bash
+set -a; source .env.production.local; set +a
+
+# 1. Full gutter-aware audit → ranked JSON + eye-check gallery.
+node scripts/maintenance/audit-bph-gutter-clip.mjs \
+  --out /tmp/gutter-clip.json --html /tmp/gutter-clip.html --concurrency 6
+#    Open /tmp/gutter-clip.html: red=cut, green=detected gutter, yellow band=recover.
+#    Spot-check flagged vs not-flagged. A flag is real when the band covers page text,
+#    not binding shadow or the facing page. Tune --clip-frac / --min-recover if needed.
+
+# 2. Extract the flagged ids and DRY-RUN the recrop (per-page gutter-relative widen).
+node -e 'console.log(JSON.stringify(require("/tmp/gutter-clip.json").flaggedBookIds))' > /tmp/clip-ids.json
+node scripts/maintenance/recrop-bph-gutter.mjs --ids-file /tmp/clip-ids.json --to-gutter --dry-run
+#    Review the "would re-crop N/total" lines. In --to-gutter, pages whose cut is already
+#    at/past the gutter are SKIPPED (healthy) — only clipping pages are touched.
+
+# 3. Real sweep, in batches with per-batch logs (idempotent + reversible).
+node scripts/maintenance/recrop-bph-gutter.mjs --ids-file /tmp/clip-ids.json --to-gutter \
+  --limit 25 2>&1 | tee /tmp/recrop-batch1.log
+#    Repeat with growing offsets (split clip-ids.json into batches), watching the logs.
+
+# 4. Revalidate a few affected books, tenant + non-tenant:
+#    https://sourcelibrary.org/book/<slug>  and  https://bph.sourcelibrary.org/... (embed)
+#    Confirm the re-cropped half shows the recovered edge and no facing-page bleed.
+```
+
+**Why `--to-gutter`, not blind `--overlap 35`:** the blind widen is safe only for
+wide-gutter books (*Artis*); on tight bindings it drags in the shadow + facing page.
+`--to-gutter` moves the cut to the *detected* gutter centre per page — recovering exactly
+the clipped content — and self-limits (a non-clipping page is left untouched).
+
+**Safety:** non-destructive, idempotent, reversible. Each page is re-cropped from the
+immutable spread to a **new** R2 key (fresh `/api/image` cache, no CDN purge); the
+original crop + cropped_photo are stashed in `recrop_2898.{prev_crop, prev_cropped_photo}`
+so re-runs never double-widen and the change is one-command reversible.
+
+## Re-OCR decision (was #2898 Task 4)
+Re-cropping fixes **pixels, not stored text**. OCR/translation ran on the clipped crop,
+so gutter-side content is missing from `pages.{ocr,translation}`. To re-OCR a swept book,
+clear its `ocr` and let the orchestrator re-run at `pipeline_auto.status='archive_complete'`.
+
+This is **separate, paid (Gemini), and the pipeline is currently paused** — decide *after*
+the sweep, and only for books where the recovered content is substantive (the audit's
+`meanRecoverInk` / `maxReach` per book are the signal). For the sample cohort the recovered
+content is mostly line-end punctuation and marginal marks, so re-OCR is **low-yield** there;
+prioritize any book whose flagged pages show a full recovered text column (e.g. a clipped
+numeral/marginal-gloss column), not just trailing glyphs. Record the final call here when made.
+
+## Files
+- `scripts/lib/gutter-clip.mjs` — shared gutter-aware primitive (profile, findGutter, measureClip).
+- `scripts/maintenance/audit-bph-gutter-clip.mjs` — audit; `--profile <id>` dumps per-page geometry; `--html` writes the eye-check gallery.
+- `scripts/maintenance/recrop-bph-gutter.mjs` — `--to-gutter` (per-page, recommended) or blind `--overlap`.

--- a/scripts/lib/gutter-clip.mjs
+++ b/scripts/lib/gutter-clip.mjs
@@ -1,0 +1,232 @@
+/**
+ * Gutter-AWARE clip detection for old-era BPH crop-coord split halves (issue #3088,
+ * follow-up to #2898). Shared by the audit (audit-bph-gutter-clip.mjs) and the
+ * gutter-relative re-crop (recrop-bph-gutter.mjs) so both reason about the SAME
+ * geometry — never two drifting copies (code-quality lesson).
+ *
+ * WHY a new primitive. The first-pass audit measured raw ink (`min(R,G,B)<120`)
+ * in a fixed band just past the cut and flagged anything dark. On the real BPH
+ * cohort that over-flagged ~97%, because raw ink cannot tell CLIPPED LEFT-PAGE
+ * TEXT apart from:
+ *   (a) the BINDING SHADOW of a tight-bound book — a saturated dark run that pins
+ *       ink toward ~1.0 (text tops out lower: line leading leaves white rows), and
+ *   (b) FACING-PAGE bleed — ink that lives PAST the gutter, on the other page
+ *       (a cut placed at/past the true gutter over-includes the facing page).
+ *
+ * The fix is to locate the TRUE gutter per page and count only text-like ink
+ * BETWEEN the cut and the gutter (the content a widen would actually recover),
+ * excluding saturation and everything past the gutter.
+ *
+ * Geometry. `crop` is per-mille [0,1000] of the full spread width. A zero-overlap
+ * old-era split stores each half as {xStart:0, xEnd:c} (left) or {xStart:c,
+ * xEnd:1000} (right), the two facing pages sharing the cut line c. Clipping
+ * happens when the splitter put c short of the true gutter g (classic case: it
+ * snapped to an INTER-COLUMN valley — the gap between the body text and a
+ * right-aligned numeral/catchword column — instead of the binding, see Artis
+ * p386), leaving recoverable content in [c, g] (left page) / [g, c] (right page).
+ *
+ * Method. Resize the FULL spread to width 1000 (column x === per-mille). Over the
+ * central band (y 25%-75%, skips running heads/footers) compute per column:
+ *   ink[x] = fraction of rows with min(R,G,B) < 120  (colored rubrication counts)
+ *   lum[x] = mean luminance                          (for the dark-shadow gutter)
+ * Light ±2px smoothing bridges inter-character slivers without erasing a 1-2px
+ * bright gutter.
+ *
+ * Then, per page, LOCATE THE TRUE GUTTER independently of the cut, in a window
+ * [cut-WIN, cut+WIN] (the old splitter aimed AT the gutter, so it sits near the
+ * cut):
+ *   - the WIDEST bright ink-free run (ink < BRIGHT_GAP) — the binding gap; picking
+ *     the *widest* is what beats the ToC case (Artis p386), where a narrower
+ *     INTER-COLUMN valley sits between the body text and a right-aligned numeral
+ *     column and the true, wider binding gutter is just beyond it, OR
+ *   - if there is no bright gap (tight binding), the saturated dark SHADOW column
+ *     (ink > SHADOW_INK AND lum < SHADOW_LUM).
+ * Compare gutter g to the cut c using the SIGN, which disambiguates clip from
+ * bleed:
+ *   left half  {0,c}:    clip only if g is to the RIGHT of c → recover text in [c, g)
+ *   right half {c,1000}: clip only if g is to the LEFT  of c → recover text in (g, c]
+ * A cut that sits AT or PAST the gutter clips nothing on its own page (it merely
+ * over-includes some facing page) → NOT flagged; this is exactly what the naive
+ * "ink just past the cut" metric got wrong. In the recover interval we count only
+ * text-like columns (TEXT_LO ≤ ink ≤ TEXT_HI); saturation and the bright gap
+ * contribute nothing. If no gutter is found in the window the page is reported
+ * low-confidence (`gutterKind:'none'`) and NOT flagged.
+ *
+ * One more shadow trap (the p197 false positive): a wide-margin book can show BOTH
+ * a bright inner-margin gap AND a narrow binding SHADOW just past it. The shadow's
+ * ramp climbs through text-like ink (0.1→0.8) before it saturates, so its slope
+ * would be miscounted as recovered text. We therefore drop any candidate column
+ * within SAT_ADJ‰ of a saturation peak (ink ≥ SAT_PEAK): real marginal text (~0.24)
+ * has no such peak, a shadow ramp always does.
+ */
+
+import sharp from 'sharp';
+
+// ── Tunables (per-mille unless noted). Defaults chosen against the real cohort;
+// override via the audit CLI for tuning. Kept in one place so audit + recrop agree.
+export const DEFAULTS = {
+  BAND_TOP: 0.25,      // central-band vertical window (skip head/footer)
+  BAND_BOT: 0.75,
+  DARK: 120,           // min(R,G,B) < DARK counts as ink
+  SMOOTH: 2,           // ±px smoothing radius
+  GUTTER_WIN: 60,      // ‰ each side of the cut to search for the true gutter
+  BRIGHT_GAP: 0.045,   // ink below this = a bright gap column
+  GAP_RUN: 2,          // consecutive bright columns needed to call it a gap
+  SHADOW_INK: 0.88,    // ink above this = saturated binding shadow (a gutter, NOT text)
+  SHADOW_LUM: 90,      // AND luminance below this — shadow is dark (a dense figure may be dark too)
+  TEXT_LO: 0.06,       // text-like ink floor
+  TEXT_HI: 0.62,       // text-like ink ceiling — line text tops ~0.6 (leading leaves white rows)
+  SAT_PEAK: 0.82,      // a column this dark is a saturation peak (binding shadow / dense figure)
+  SAT_ADJ: 8,          // ‰: a text column within this of a SAT_PEAK is a shadow RAMP, not text
+  MIN_RECOVER: 4,      // ≥ this many text ‰ between cut and gutter → the page clips
+};
+
+/**
+ * Compute per-mille ink + luminance profiles of a full spread.
+ * @returns {Promise<{ink:Float32Array, lum:Float32Array, W:number}>}
+ */
+export async function spreadProfile(buf, opts = {}) {
+  const o = { ...DEFAULTS, ...opts };
+  const W = 1000;
+  const meta = await sharp(buf).metadata();
+  const H = Math.max(1, Math.round((meta.height || 1) * (W / (meta.width || 1))));
+  const raw = await sharp(buf).resize(W, H, { fit: 'fill' }).removeAlpha().toColourspace('srgb').raw().toBuffer();
+  const y0 = Math.round(H * o.BAND_TOP), y1 = Math.round(H * o.BAND_BOT);
+  const rows = Math.max(1, y1 - y0);
+  const inkRaw = new Float32Array(W);
+  const lumRaw = new Float32Array(W);
+  for (let x = 0; x < W; x++) {
+    let d = 0, lum = 0;
+    for (let y = y0; y < y1; y++) {
+      const i = (y * W + x) * 3;
+      const r = raw[i], g = raw[i + 1], b = raw[i + 2];
+      if (Math.min(r, g, b) < o.DARK) d++;
+      lum += (r + g + b) / 3;
+    }
+    inkRaw[x] = d / rows;
+    lumRaw[x] = lum / rows;
+  }
+  return { ink: smooth(inkRaw, o.SMOOTH), lum: smooth(lumRaw, o.SMOOTH), W };
+}
+
+function smooth(src, radius) {
+  const W = src.length;
+  const out = new Float32Array(W);
+  for (let x = 0; x < W; x++) {
+    const lo = Math.max(0, x - radius), hi = Math.min(W - 1, x + radius);
+    let s = 0;
+    for (let i = lo; i <= hi; i++) s += src[i];
+    out[x] = s / (hi - lo + 1);
+  }
+  return out;
+}
+
+/** Which half is this crop, and where is the cut (per-mille)? null if indeterminate. */
+export function cropSide(crop) {
+  if (!crop || typeof crop.xStart !== 'number' || typeof crop.xEnd !== 'number') return null;
+  if (crop.xStart === 0 && crop.xEnd < 1000) return { side: 'L', cut: crop.xEnd };
+  if (crop.xEnd === 1000 && crop.xStart > 0) return { side: 'R', cut: crop.xStart };
+  return null;
+}
+
+/**
+ * Locate the true gutter in a window around the cut.
+ * @returns {{ kind:'bright'|'shadow'|'none', start:number, end:number, mid:number }}
+ *   For 'bright': [start,end] is the ink-free run (inclusive). For 'shadow': the
+ *   darkest saturated column (start==end). 'none' when neither is present.
+ */
+export function findGutter(profile, cut, opts = {}) {
+  const o = { ...DEFAULTS, ...opts };
+  const { ink, lum, W } = profile;
+  const lo = Math.max(0, cut - o.GUTTER_WIN);
+  const hi = Math.min(W - 1, cut + o.GUTTER_WIN);
+
+  // Widest bright ink-free run in the window.
+  let bestS = -1, bestE = -1, bestLen = 0;
+  let curS = -1;
+  for (let x = lo; x <= hi; x++) {
+    if (ink[x] < o.BRIGHT_GAP) {
+      if (curS < 0) curS = x;
+      const len = x - curS + 1;
+      if (len > bestLen) { bestLen = len; bestS = curS; bestE = x; }
+    } else {
+      curS = -1;
+    }
+  }
+  if (bestLen >= o.GAP_RUN) {
+    return { kind: 'bright', start: bestS, end: bestE, mid: Math.round((bestS + bestE) / 2) };
+  }
+
+  // No bright gap → tight binding: the darkest saturated column in the window.
+  let sx = -1, sLum = Infinity;
+  for (let x = lo; x <= hi; x++) {
+    if (ink[x] > o.SHADOW_INK && lum[x] < o.SHADOW_LUM && lum[x] < sLum) { sLum = lum[x]; sx = x; }
+  }
+  if (sx >= 0) return { kind: 'shadow', start: sx, end: sx, mid: sx };
+
+  return { kind: 'none', start: -1, end: -1, mid: -1 };
+}
+
+/**
+ * Measure gutter clipping for one page's crop against its spread profile.
+ * Returns null when the side is indeterminate.
+ *
+ * @returns {{
+ *   side:'L'|'R', cut:number,
+ *   gutter:number|null,        // per-mille cut-to line (gap near-edge / shadow col), null if none
+ *   gutterKind:'bright'|'shadow'|'none',
+ *   recoverWidth:number,       // count of text-like ‰ between cut and gutter
+ *   recoverInkMax:number,      // densest text column found (0 if none)
+ *   reach:number,              // furthest ‰ from cut with text before the gutter
+ *   clipped:boolean,
+ * }|null}
+ */
+export function measureClip(profile, crop, opts = {}) {
+  const o = { ...DEFAULTS, ...opts };
+  const sc = cropSide(crop);
+  if (!sc) return null;
+  const { side, cut } = sc;
+  const { ink } = profile;
+  const g = findGutter(profile, cut, o);
+
+  const base = { side, cut, gutter: null, gutterKind: g.kind, recoverWidth: 0, recoverInkMax: 0, reach: 0, clipped: false };
+  if (g.kind === 'none') return base;
+
+  // Recover interval: text between the cut and the gutter, on the correct side.
+  // The near edge of the gutter (toward the cut) is the boundary — the gap/shadow
+  // itself is never counted as recoverable text.
+  let a, b, boundary;
+  if (side === 'L') {
+    boundary = g.start;                                 // run start = near edge for a left page
+    if (boundary <= cut) return { ...base, gutter: boundary }; // cut at/past gutter → no left clip (bleed)
+    a = cut + 1; b = boundary - 1;
+  } else {
+    boundary = g.end;                                   // run end = near edge for a right page
+    if (boundary >= cut) return { ...base, gutter: boundary }; // cut at/past gutter → no right clip (bleed)
+    a = boundary + 1; b = cut - 1;
+  }
+
+  // A saturation peak anywhere near the recover interval means we're looking at a
+  // binding shadow (or a dense figure/initial), whose RAMP passes through text-like
+  // ink values on the way up — the p197 false-positive. Exclude any candidate column
+  // that sits within SAT_ADJ‰ of such a peak.
+  const nearSat = (x) => {
+    for (let d = -o.SAT_ADJ; d <= o.SAT_ADJ; d++) {
+      const xx = x + d;
+      if (xx >= 0 && xx < ink.length && ink[xx] >= o.SAT_PEAK) return true;
+    }
+    return false;
+  };
+
+  let width = 0, inkMax = 0, reach = 0;
+  for (let x = a; x <= b; x++) {
+    const v = ink[x];
+    if (v >= o.TEXT_LO && v <= o.TEXT_HI && !nearSat(x)) {
+      width++;
+      inkMax = Math.max(inkMax, v);
+      reach = Math.max(reach, Math.abs(x - cut));
+    }
+  }
+  const clipped = width >= o.MIN_RECOVER && inkMax >= o.TEXT_LO;
+  return { side, cut, gutter: boundary, gutterKind: g.kind, recoverWidth: width, recoverInkMax: +inkMax.toFixed(3), reach, clipped };
+}

--- a/scripts/maintenance/audit-bph-gutter-clip.mjs
+++ b/scripts/maintenance/audit-bph-gutter-clip.mjs
@@ -1,66 +1,51 @@
 #!/usr/bin/env node
 /**
- * Audit which BPH old-era crop books ACTUALLY clip text at the gutter (issue #2898).
+ * GUTTER-AWARE audit of which BPH old-era crop books ACTUALLY clip text at the
+ * gutter (issue #3088, follow-up to #2898).
  *
- * The zero-overlap crop is a LATENT defect across the whole ~1,230-book cohort,
- * but it only causes VISIBLE harm where content actually reaches the gutter
- * (right-margin numeral columns, catchwords, long line-ends). This audit finds
- * the subset with real clipping so the re-crop sweep (recrop-bph-gutter.mjs) can
- * target them instead of blanket-reprocessing every book.
+ * The zero-overlap crop is a LATENT defect across the whole ~1,200-book cohort,
+ * but it only causes VISIBLE harm where left-page content actually reaches past
+ * the cut toward the binding (right-margin numeral columns, catchwords, long
+ * line-ends). This audit finds that subset so the re-crop sweep
+ * (recrop-bph-gutter.mjs) targets confirmed clipping instead of blanket-widening
+ * every book (which would pull binding shadow + the facing page into tight books).
  *
- * Method (reuses the ink-density primitive from scripts/lib/gutter-detect.mjs /
- * batch-split-bph.mjs): for each sampled half, resize the FULL spread to 1000px
- * wide (so column index == per-mille), and for each column count the fraction of
- * central-band rows (y 25%–75%, skips header/footer) where min(R,G,B) < 120 (ink,
- * incl. colored rubrication). Then measure ink in the band JUST OUTSIDE the
- * current cut — the region a widen of `--overlap` would recover:
- *   left half  (xStart 0, cut c=xEnd):   band [c, c+overlap]
- *   right half (xEnd 1000, cut c=xStart): band [c-overlap, c]
- * If that band carries ink, we're clipping text. Per-page severity = max column
- * ink density in the band; "reach" = furthest per-mille past the cut with ink.
+ * ── Why the old audit was untrustworthy (superseded) ──
+ * v1 measured raw ink (min(R,G,B)<120) in a fixed band just past the cut and
+ * flagged anything dark → over-flagged ~97% of the cohort, because raw ink can't
+ * tell CLIPPED TEXT from (a) the BINDING SHADOW of a tight book (saturates ~1.0;
+ * text tops out lower because line leading leaves white rows) or (b) FACING-PAGE
+ * bleed past the gutter. This version is gutter-aware: it locates the true gutter
+ * per page and counts only text-like ink BETWEEN the cut and the gutter. See
+ * scripts/lib/gutter-clip.mjs for the geometry + tunables (shared with the recrop).
  *
  * Read-only. Iterates the cohort PER BOOK (the global unindexed `crop` scan times
  * out). Anchor: held_by:'bph' ∩ per-book pages with crop + cropped_photo + not
  * split_from_spread.
  *
- * ⚠ KNOWN LIMITATION — over-flags, do NOT drive a blanket sweep off this alone.
- * The raw ink metric (min(R,G,B)<120) cannot tell CLIPPED TEXT apart from two
- * other things that also darken the recover band: (1) the BINDING SHADOW of a
- * tight-bound book (saturates to ~1.0 ink — distinct from text, which tops out
- * ~0.6 because line spacing leaves white rows), and (2) FACING-PAGE bleed when
- * the two text blocks sit close and the band crosses the gutter. Measured on the
- * real BPH cohort (2026-07-08) this flags ~97% of books, and the HIGHEST-severity
- * entries are tight pamphlets whose "clipping" is actually binding shadow — a
- * naive +overlap re-crop there would pull in shadow + facing page, not recover
- * content. So: verified-safe re-crops need WIDE-GUTTER books (like Artis
- * auriferae). A trustworthy audit must be GUTTER-AWARE — locate the gutter
- * (deepest/widest ink-free run, or the saturated dark run) and count only
- * text-like ink BETWEEN the cut and the gutter (left-page content), excluding
- * saturation and anything past the gutter. That is the hard, iteratively-tuned
- * problem #1491 documents; treat this script as a first-pass triage + eye-check
- * aid (the HTML gallery), NOT an auto-sweep driver.
- *
  * Run:
- *   set -a; source .env.production.local; set +a
+ *   set -a; source .env.production.local; set +a   # or .env.local for a local read-only run
  *   node scripts/maintenance/audit-bph-gutter-clip.mjs --limit 50 --html /tmp/gutter-clip.html
  *   node scripts/maintenance/audit-bph-gutter-clip.mjs --out /tmp/gutter-clip.json
  *   node scripts/maintenance/audit-bph-gutter-clip.mjs --ids-file /tmp/ids.json
+ *   node scripts/maintenance/audit-bph-gutter-clip.mjs --profile <bookId>   # per-page geometry dump (tuning)
  *
  * Options:
  *   --ids-file PATH   Audit only these book ids (JSON array). Default: full BPH cohort.
  *   --samples N       Pages sampled per book (default 8)
- *   --overlap N       Per-mille recover band width to test (default 35, matches the fix)
- *   --ink-thresh F    Column ink-density flag threshold (default 0.04 = 4% of rows)
  *   --clip-frac F     Book flagged when this fraction of sampled pages clip (default 0.15)
  *   --limit N         Audit at most N books
  *   --out PATH        Write ranked JSON (default /tmp/gutter-clip.json)
- *   --html PATH       Also write a visual HTML gallery (optional)
+ *   --html PATH       Also write a visual eye-check HTML gallery (optional)
  *   --concurrency N   Books processed in parallel (default 4)
+ *   --profile BOOKID  Debug: dump per-page cut/gutter/recover profile for one book, exit
+ *   --min-recover N   Override text-‰ needed before the gutter to count a page (default 3)
+ *   --gutter-win N    Override ‰ each side of the cut searched for the gutter (default 60)
  */
 
 import { MongoClient } from 'mongodb';
-import sharp from 'sharp';
 import { writeFileSync, readFileSync } from 'fs';
+import { spreadProfile, measureClip, cropSide, DEFAULTS } from '../lib/gutter-clip.mjs';
 
 const argVal = (flag, def) => {
   const i = process.argv.indexOf(flag);
@@ -68,13 +53,17 @@ const argVal = (flag, def) => {
 };
 const IDS_FILE = argVal('--ids-file', null);
 const SAMPLES = parseInt(argVal('--samples', '8'), 10);
-const OVERLAP = parseInt(argVal('--overlap', '35'), 10);
-const INK_THRESH = parseFloat(argVal('--ink-thresh', '0.04'));
 const CLIP_FRAC = parseFloat(argVal('--clip-frac', '0.15'));
 const LIMIT = parseInt(argVal('--limit', '0'), 10);
 const OUT = argVal('--out', '/tmp/gutter-clip.json');
 const HTML = argVal('--html', null);
 const CONCURRENCY = parseInt(argVal('--concurrency', '4'), 10);
+const PROFILE = argVal('--profile', null);
+
+const CLIP_OPTS = {
+  MIN_RECOVER: parseInt(argVal('--min-recover', String(DEFAULTS.MIN_RECOVER)), 10),
+  GUTTER_WIN: parseInt(argVal('--gutter-win', String(DEFAULTS.GUTTER_WIN)), 10),
+};
 
 const CROP_FILTER = {
   'crop.xStart': { $exists: true },
@@ -88,6 +77,7 @@ async function fetchImage(url) {
   return Buffer.from(await res.arrayBuffer());
 }
 
+// The UNCROPPED full spread — never cropped_photo/photo (those are the half).
 function fullSpreadSource(page) {
   const a = page.archived_photo;
   if (typeof a === 'string' && a.startsWith('http')) return a;
@@ -96,48 +86,16 @@ function fullSpreadSource(page) {
   return null;
 }
 
-// Per-mille ink density: resize spread to width 1000 so column x === per-mille.
-async function inkPerMille(buf) {
-  const W = 1000;
-  const meta = await sharp(buf).metadata();
-  const H = Math.round((meta.height || 1) * (W / (meta.width || 1)));
-  const raw = await sharp(buf).resize(W, H, { fit: 'fill' }).removeAlpha().toColourspace('srgb').raw().toBuffer();
-  const y0 = Math.round(H * 0.25), y1 = Math.round(H * 0.75);
-  const rows = y1 - y0;
-  const ink = new Float32Array(W);
-  for (let x = 0; x < W; x++) {
-    let d = 0;
-    for (let y = y0; y < y1; y++) {
-      const i = (y * W + x) * 3;
-      if (Math.min(raw[i], raw[i + 1], raw[i + 2]) < 120) d++;
-    }
-    ink[x] = d / rows;
-  }
-  return ink;
-}
-
-// Measure the recover-band just outside the cut. Returns severity (max col ink),
-// mean ink, and reach (furthest per-mille past the cut with ink >= thresh).
-function measureBand(ink, crop) {
-  let lo, hi; // inclusive per-mille range of the recover band
-  if (crop.xStart === 0 && crop.xEnd < 1000) { lo = crop.xEnd; hi = Math.min(999, crop.xEnd + OVERLAP); }
-  else if (crop.xEnd === 1000 && crop.xStart > 0) { lo = Math.max(0, crop.xStart - OVERLAP); hi = crop.xStart; }
-  else return null; // undetermined side
-  const cut = crop.xStart === 0 ? crop.xEnd : crop.xStart;
-  let max = 0, sum = 0, n = 0, reach = 0;
-  for (let x = lo; x <= hi; x++) {
-    const v = ink[x] || 0;
-    max = Math.max(max, v); sum += v; n++;
-    if (v >= INK_THRESH) reach = Math.max(reach, Math.abs(x - cut));
-  }
-  return { max, mean: n ? sum / n : 0, reach, band: [lo, hi], cut, side: crop.xStart === 0 ? 'L' : 'R' };
-}
-
-async function auditBook(db, book) {
+async function samplePages(db, book) {
   const pages = await db.collection('pages').find(
     { book_id: book.id, ...CROP_FILTER },
     { projection: { id: 1, page_number: 1, crop: 1, archived_photo: 1, photo_original: 1 } },
   ).sort({ page_number: 1 }).toArray();
+  return pages;
+}
+
+async function auditBook(db, book) {
+  const pages = await samplePages(db, book);
   if (pages.length === 0) return null;
 
   // Evenly spaced sample across the book.
@@ -147,29 +105,34 @@ async function auditBook(db, book) {
   const perPage = [];
   for (const idx of idxs) {
     const p = pages[idx];
+    if (!cropSide(p.crop)) continue; // indeterminate side — skip
     const src = fullSpreadSource(p);
     if (!src) continue;
     try {
-      const ink = await inkPerMille(await fetchImage(src));
-      const m = measureBand(ink, p.crop);
-      if (m) perPage.push({ page_number: p.page_number, page_id: p.id, crop: p.crop, ...m, clipped: m.max >= INK_THRESH });
+      const prof = await spreadProfile(await fetchImage(src));
+      const m = measureClip(prof, p.crop, CLIP_OPTS);
+      if (m) perPage.push({ page_number: p.page_number, page_id: p.id, crop: p.crop, spread: HTML ? src : undefined, ...m });
     } catch { /* skip unfetchable sample */ }
   }
   if (perPage.length === 0) return null;
 
   const clipped = perPage.filter(s => s.clipped);
   const clipFrac = clipped.length / perPage.length;
-  // Severity: fraction clipped × mean ink of clipped pages × max reach — a book
-  // that clips most pages, with dense ink, far past the cut ranks highest.
-  const meanClipInk = clipped.length ? clipped.reduce((a, s) => a + s.max, 0) / clipped.length : 0;
+  const meanRecoverInk = clipped.length ? clipped.reduce((a, s) => a + s.recoverInkMax, 0) / clipped.length : 0;
   const maxReach = perPage.reduce((a, s) => Math.max(a, s.reach), 0);
-  const severity = +(clipFrac * meanClipInk * (1 + maxReach / OVERLAP)).toFixed(4);
+  const shadowPages = perPage.filter(s => s.gutterKind === 'shadow').length;
+  const noGutterPages = perPage.filter(s => s.gutterKind === 'none').length;
+  // Severity: fraction clipped × mean recoverable ink × (1 + reach depth). A book
+  // that clips most pages, with dense text, far past the cut, ranks highest.
+  const severity = +(clipFrac * meanRecoverInk * (1 + maxReach / CLIP_OPTS.GUTTER_WIN)).toFixed(4);
 
   return {
     book_id: book.id, slug: book.slug, title: book.title,
     totalCropPages: pages.length, sampled: perPage.length,
     clippedPages: clipped.length, clipFrac: +clipFrac.toFixed(3),
-    meanClipInk: +meanClipInk.toFixed(3), maxReach, severity,
+    meanRecoverInk: +meanRecoverInk.toFixed(3), maxReach, severity,
+    shadowFrac: +(shadowPages / perPage.length).toFixed(2),
+    noGutterFrac: +(noGutterPages / perPage.length).toFixed(2),
     flagged: clipFrac >= CLIP_FRAC,
     samples: perPage,
   };
@@ -182,23 +145,57 @@ async function parallelMap(items, fn, concurrency) {
   return out;
 }
 
+// ── Debug: dump per-page geometry for one book so thresholds can be eye-tuned ──
+async function profileBook(db, bookId) {
+  const book = await db.collection('books').findOne(
+    { $or: [{ id: bookId }, { slug: bookId }] }, { projection: { id: 1, slug: 1, title: 1 } });
+  if (!book) { console.error(`book ${bookId} not found`); return; }
+  const pages = await samplePages(db, book);
+  console.log(`# ${book.id} "${(book.title || '').slice(0, 60)}" — ${pages.length} crop pages`);
+  console.log(`# gutter-win ${CLIP_OPTS.GUTTER_WIN}‰  min-recover ${CLIP_OPTS.MIN_RECOVER}‰`);
+  const k = Math.min(SAMPLES, pages.length);
+  const idxs = [...new Set(Array.from({ length: k }, (_, i) => Math.floor(((i + 1) / (k + 1)) * pages.length)))];
+  for (const idx of idxs) {
+    const p = pages[idx];
+    const sc = cropSide(p.crop);
+    if (!sc) { console.log(`p${p.page_number}: crop ${JSON.stringify(p.crop)} — indeterminate side`); continue; }
+    const src = fullSpreadSource(p);
+    if (!src) { console.log(`p${p.page_number}: no full spread`); continue; }
+    try {
+      const prof = await spreadProfile(await fetchImage(src));
+      const m = measureClip(prof, p.crop, CLIP_OPTS);
+      // Print the ink profile in the walk window for eyeballing.
+      const dir = m.side === 'L' ? 1 : -1;
+      const strip = [];
+      for (let s = 0; s <= Math.min(CLIP_OPTS.GUTTER_WIN, 40); s += 2) {
+        const x = m.cut + dir * s;
+        if (x < 0 || x >= prof.W) break;
+        strip.push(prof.ink[x].toFixed(2));
+      }
+      console.log(
+        `p${p.page_number} [${m.side}] cut ${m.cut} gutter ${m.gutter}(${m.gutterKind}) ` +
+        `recover ${m.recoverWidth}‰ ink ${m.recoverInkMax} reach ${m.reach}‰ ` +
+        `${m.clipped ? 'CLIP' : '·'}  ink→ ${strip.join(' ')}`);
+    } catch (e) { console.log(`p${p.page_number}: err ${e.message}`); }
+  }
+}
+
 async function main() {
   const client = await MongoClient.connect(process.env.MONGODB_URI);
   const db = client.db('bookstore');
+
+  if (PROFILE) { await profileBook(db, PROFILE); await client.close(); return; }
 
   let books;
   if (IDS_FILE) {
     const ids = JSON.parse(readFileSync(IDS_FILE, 'utf8'));
     books = await db.collection('books').find({ id: { $in: ids } }, { projection: { id: 1, slug: 1, title: 1 } }).toArray();
   } else {
-    // Full BPH cohort. Per-book crop-page check happens in auditBook (indexed by book_id).
     books = await db.collection('books').find(
-      { held_by: 'bph' },
-      { projection: { id: 1, slug: 1, title: 1 } },
-    ).toArray();
+      { held_by: 'bph' }, { projection: { id: 1, slug: 1, title: 1 } }).toArray();
   }
   if (LIMIT > 0) books = books.slice(0, LIMIT);
-  console.error(`Auditing ${books.length} books (samples ${SAMPLES}, overlap ${OVERLAP}‰, ink-thresh ${INK_THRESH}, clip-frac ${CLIP_FRAC})`);
+  console.error(`Auditing ${books.length} books (samples ${SAMPLES}, gutter-win ${CLIP_OPTS.GUTTER_WIN}‰, min-recover ${CLIP_OPTS.MIN_RECOVER}‰, clip-frac ${CLIP_FRAC})`);
 
   let done = 0;
   const results = (await parallelMap(books, async (book) => {
@@ -212,15 +209,16 @@ async function main() {
   const flagged = audited.filter(r => r.flagged);
 
   writeFileSync(OUT, JSON.stringify({
-    generated_for: 'issue-2898', overlap: OVERLAP, ink_thresh: INK_THRESH, clip_frac: CLIP_FRAC,
-    booksAudited: audited.length, booksWithCropPages: audited.length, flaggedCount: flagged.length,
+    generated_for: 'issue-3088', method: 'gutter-aware', clip_frac: CLIP_FRAC,
+    gutter_win: CLIP_OPTS.GUTTER_WIN, min_recover: CLIP_OPTS.MIN_RECOVER,
+    booksAudited: audited.length, flaggedCount: flagged.length,
     flaggedBookIds: flagged.map(r => r.book_id),
     results: audited,
   }, null, 2));
   console.error(`\nAudited ${audited.length} cohort books · ${flagged.length} flagged (clipFrac ≥ ${CLIP_FRAC}) · wrote ${OUT}`);
   console.error(`Top flagged:`);
   for (const r of flagged.slice(0, 15)) {
-    console.error(`  sev ${r.severity}  clip ${r.clippedPages}/${r.sampled} (${(r.clipFrac * 100).toFixed(0)}%)  reach ${r.maxReach}‰  ${r.book_id}  ${(r.title || '').slice(0, 45)}`);
+    console.error(`  sev ${r.severity}  clip ${r.clippedPages}/${r.sampled} (${(r.clipFrac * 100).toFixed(0)}%)  reach ${r.maxReach}‰  shadow ${r.shadowFrac}  ${r.book_id}  ${(r.title || '').slice(0, 42)}`);
   }
 
   if (HTML) writeFileSync(HTML, renderHtml(audited, flagged));
@@ -228,20 +226,63 @@ async function main() {
 }
 
 function esc(s) { return String(s || '').replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+
+// Embed the full spread with the cut (red) and detected gutter (green) drawn as
+// absolutely-positioned lines at their per-mille % — a true visual eye-check with
+// no server-side compositing. The recover band (cut↔gutter) is tinted so a human
+// can confirm the flagged content is real page text, not shadow or the facing page.
+function spreadFig(s) {
+  if (!s.spread) return '';
+  const cutPct = (s.cut / 10).toFixed(1);
+  const gutPct = s.gutter != null ? (s.gutter / 10).toFixed(1) : null;
+  const bandLeft = Math.min(s.cut, s.gutter ?? s.cut) / 10;
+  const bandW = Math.abs((s.gutter ?? s.cut) - s.cut) / 10;
+  const band = gutPct != null && bandW > 0
+    ? `<span class="band" style="left:${bandLeft}%;width:${bandW}%"></span>` : '';
+  const gut = gutPct != null ? `<span class="gut" style="left:${gutPct}%" title="gutter ${s.gutter} (${s.gutterKind})"></span>` : '';
+  return `<figure class="${s.clipped ? 'clip' : ''}">
+    <div class="img"><img loading="lazy" src="${esc(s.spread)}">${band}
+      <span class="cut" style="left:${cutPct}%" title="cut ${s.cut}"></span>${gut}</div>
+    <figcaption>p${s.page_number} <b>${s.side}</b> cut ${s.cut}→gut ${s.gutter ?? '—'}(${s.gutterKind})
+      ${s.clipped ? `<b class="y">+${s.recoverWidth}‰ @${s.recoverInkMax}</b>` : `<span class="n">·</span>`}</figcaption>
+  </figure>`;
+}
+
 function renderHtml(audited, flagged) {
+  // For flagged books, render every sampled spread (clipped first) with overlays.
+  const bookBlock = (r) => {
+    const samps = [...(r.samples || [])].sort((a, b) => (b.clipped - a.clipped) || (b.recoverWidth - a.recoverWidth));
+    return `<section class="book">
+      <h2><a href="https://sourcelibrary.org/book/${esc(r.slug || r.book_id)}" target="_blank">${esc((r.title || '').slice(0, 70))}</a></h2>
+      <div class="meta">sev ${r.severity} · clip ${r.clippedPages}/${r.sampled} (${(r.clipFrac * 100).toFixed(0)}%) · reach ${r.maxReach}‰ · recoverInk ${r.meanRecoverInk} · shadow ${r.shadowFrac} · noGut ${r.noGutterFrac} · <span class="mono">${esc(r.book_id)}</span></div>
+      <div class="grid">${samps.map(spreadFig).join('')}</div>
+    </section>`;
+  };
   const row = (r) => `<tr class="${r.flagged ? 'flag' : ''}">
     <td>${r.severity}</td><td>${r.clippedPages}/${r.sampled} (${(r.clipFrac * 100).toFixed(0)}%)</td>
-    <td>${r.maxReach}‰</td><td>${r.meanClipInk}</td><td>${r.totalCropPages}</td>
-    <td><a href="https://sourcelibrary.org/book/${esc(r.slug || r.book_id)}" target="_blank">${esc((r.title || '').slice(0, 60))}</a></td>
-    <td class="mono">${esc(r.book_id)}</td></tr>`;
-  return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>BPH gutter-clip audit (#2898)</title><style>
-    body{font-family:system-ui;background:#1a1a1a;color:#ddd;padding:20px;max-width:1400px;margin:0 auto}
-    h1{color:#e8c87a} table{border-collapse:collapse;width:100%;font-size:13px} th,td{padding:5px 9px;border-bottom:1px solid #333;text-align:left}
+    <td>${r.maxReach}‰</td><td>${r.meanRecoverInk}</td><td>${r.shadowFrac}</td><td>${r.noGutterFrac}</td><td>${r.totalCropPages}</td>
+    <td>${esc((r.title || '').slice(0, 55))}</td><td class="mono">${esc(r.book_id)}</td></tr>`;
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>BPH gutter-clip audit (#3088)</title><style>
+    body{font-family:system-ui;background:#1a1a1a;color:#ddd;padding:20px;max-width:1500px;margin:0 auto}
+    h1,h2{color:#e8c87a} h2{font-size:16px;margin:0 0 3px} table{border-collapse:collapse;width:100%;font-size:13px} th,td{padding:5px 9px;border-bottom:1px solid #333;text-align:left;vertical-align:top}
     th{color:#e8c87a} tr.flag{background:#2a2318} a{color:#7ab6e8} .mono{font-family:ui-monospace;color:#888;font-size:11px}
+    .book{margin:26px 0;padding-top:14px;border-top:2px solid #333} .meta{font-size:12px;color:#aaa;margin-bottom:8px}
+    .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));gap:12px}
+    figure{margin:0;background:#111;border:1px solid #333;border-radius:5px;overflow:hidden} figure.clip{border-color:#7a5}
+    .img{position:relative;line-height:0} .img img{width:100%;display:block}
+    .cut{position:absolute;top:0;bottom:0;width:2px;background:#e44;box-shadow:0 0 3px #e44}
+    .gut{position:absolute;top:0;bottom:0;width:2px;background:#4d4;box-shadow:0 0 3px #4d4}
+    .band{position:absolute;top:0;bottom:0;background:rgba(230,200,60,.28)}
+    figcaption{font-size:11px;padding:4px 6px;color:#ccc} .y{color:#9d6} .n{color:#666}
   </style></head><body>
-  <h1>BPH gutter-clip audit — #2898</h1>
-  <p>${audited.length} cohort books audited · <b>${flagged.length} flagged</b> (clipFrac ≥ ${CLIP_FRAC}). Severity = clipFrac × meanClipInk × (1 + reach/overlap). Higher = worse.</p>
-  <table><thead><tr><th>severity</th><th>clipped</th><th>reach</th><th>meanInk</th><th>cropPages</th><th>title</th><th>book_id</th></tr></thead>
+  <h1>BPH gutter-clip audit — #3088 (gutter-aware)</h1>
+  <p>${audited.length} cohort books audited · <b>${flagged.length} flagged</b> (clipFrac ≥ ${CLIP_FRAC}).
+  Overlays: <b style="color:#e44">red</b> = current cut, <b style="color:#4d4">green</b> = detected gutter,
+  <b style="color:#e6c83c">yellow band</b> = recoverable content between them. A flag is real when the band covers page text — not binding shadow or the facing page.</p>
+  <h2>Flagged books — visual eye-check</h2>
+  ${flagged.map(bookBlock).join('')}
+  <h2 style="margin-top:40px">All audited (ranked)</h2>
+  <table><thead><tr><th>severity</th><th>clipped</th><th>reach</th><th>recoverInk</th><th>shadow%</th><th>noGut%</th><th>cropPages</th><th>title</th><th>book_id</th></tr></thead>
   <tbody>${audited.map(row).join('')}</tbody></table></body></html>`;
 }
 

--- a/scripts/maintenance/recrop-bph-gutter.mjs
+++ b/scripts/maintenance/recrop-bph-gutter.mjs
@@ -36,10 +36,25 @@
  *   node scripts/maintenance/recrop-bph-gutter.mjs --book-id 69751588a88d83c830d99e16
  *   node scripts/maintenance/recrop-bph-gutter.mjs --ids-file /tmp/clip-ids.json
  *
+ * TWO widen modes:
+ *   • BLIND (default) — add a fixed `--overlap` per-mille to the gutter side. Safe
+ *     for WIDE-gutter books (Artis auriferae): it recovers clipped content and only
+ *     over-includes a sliver of blank gutter. On TIGHT bindings it drags in the
+ *     shadow + the facing page, so don't blanket it across the cohort (issue #3088).
+ *   • --to-gutter — per-page, DETECT the true gutter (shared scripts/lib/gutter-clip.mjs,
+ *     same geometry the audit uses) and set the cut to the gutter centre. This
+ *     recovers exactly the content between the old cut and the binding without
+ *     guessing an overlap, and self-limits: a page whose cut is already at/past the
+ *     gutter is left untouched (no needless reprocess, no facing-page pull-in). This
+ *     is the mode for the targeted cohort sweep. Pages where no gutter is found are
+ *     skipped (we won't widen blindly into the unknown).
+ *
  * Options:
  *   --book-id ID       Process a single book
  *   --ids-file PATH    JSON array of book ids to process
- *   --overlap N        Per-mille (0-1000) added to the gutter side (default 35 = 3.5%)
+ *   --overlap N        BLIND mode: per-mille (0-1000) added to gutter side (default 35 = 3.5%)
+ *   --to-gutter        Per-page gutter-relative widen (recommended for the sweep)
+ *   --gutter-margin N  --to-gutter: per-mille past the gutter centre to keep (default 0)
  *   --concurrency N    Pages processed in parallel per book (default 5)
  *   --limit N          Process at most N books (from --ids-file)
  *   --dry-run          Print old→new bounds, write nothing
@@ -49,6 +64,7 @@ import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import sharp from 'sharp';
 import { readFileSync } from 'fs';
+import { spreadProfile, findGutter, measureClip, cropSide } from '../lib/gutter-clip.mjs';
 
 // --- Args ---
 const argVal = (flag, def) => {
@@ -57,7 +73,9 @@ const argVal = (flag, def) => {
 };
 const BOOK_ID = argVal('--book-id', null);
 const IDS_FILE = argVal('--ids-file', null);
-const OVERLAP = parseInt(argVal('--overlap', '35'), 10); // per-mille added to gutter side
+const OVERLAP = parseInt(argVal('--overlap', '35'), 10); // per-mille added to gutter side (blind mode)
+const TO_GUTTER = process.argv.includes('--to-gutter');
+const GUTTER_MARGIN = parseInt(argVal('--gutter-margin', '0'), 10); // ‰ past gutter centre (to-gutter mode)
 const CONCURRENCY = parseInt(argVal('--concurrency', '5'), 10);
 const LIMIT = parseInt(argVal('--limit', '0'), 10);
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -115,9 +133,9 @@ function fullSpreadSource(page) {
   return null;
 }
 
-// Widen the gutter side of a crop by OVERLAP per-mille. Returns null if the
-// side can't be determined (not a clean left/right half).
-function widenCrop(base) {
+// BLIND widen: add OVERLAP per-mille to the gutter side. Returns null if the side
+// can't be determined (not a clean left/right half).
+function blindWiden(base) {
   if (base.xStart === 0 && base.xEnd < 1000) {
     return { xStart: 0, xEnd: Math.min(1000, base.xEnd + OVERLAP) }; // left half
   }
@@ -125,6 +143,22 @@ function widenCrop(base) {
     return { xStart: Math.max(0, base.xStart - OVERLAP), xEnd: 1000 }; // right half
   }
   return null;
+}
+
+// GUTTER-RELATIVE widen: move the cut to the detected gutter centre so all content
+// between the old cut and the binding is recovered — no overlap guess. Only touches
+// pages the AUDIT would flag as clipping (same measureClip, so recrop ⇔ audit agree):
+// binding shadow / facing-page bleed / a cut already at-or-past the gutter all yield a
+// {status:'skip'} sentinel — the page is left untouched (no needless reprocess).
+function gutterWiden(base, profile) {
+  const sc = cropSide(base);
+  if (!sc) return { status: 'skip', reason: `undetermined side ${JSON.stringify(base)}` };
+  const m = measureClip(profile, base);
+  if (!m || !m.clipped) return { status: 'skip', reason: `no clip (${m?.gutterKind ?? 'na'}, recover ${m?.recoverWidth ?? 0}‰)` };
+  const g = findGutter(profile, sc.cut);
+  const target = Math.round(g.mid);
+  if (sc.side === 'L') return { crop: { xStart: 0, xEnd: Math.min(1000, target + GUTTER_MARGIN) }, gutter: g };
+  return { crop: { xStart: Math.max(0, target - GUTTER_MARGIN), xEnd: 1000 }, gutter: g };
 }
 
 // --- Concurrency limiter ---
@@ -145,17 +179,31 @@ async function processPage(r2, db, page) {
   // Idempotent base: always widen from the ORIGINAL crop, never a prior re-crop.
   const base = page.recrop_2898?.prev_crop || page.crop;
   const prevCropped = page.recrop_2898?.prev_cropped_photo || page.cropped_photo;
-  const newCrop = widenCrop(base);
-  if (!newCrop) return { status: 'skip', reason: `undetermined side ${JSON.stringify(base)}` };
 
   const src = fullSpreadSource(page);
   if (!src) return { status: 'skip', reason: 'no full-spread source' };
 
-  if (DRY_RUN) {
-    return { status: 'dry', side: base.xStart === 0 ? 'L' : 'R', from: base, to: newCrop };
+  // Compute the new crop. --to-gutter detects the gutter per page (needs the
+  // spread buffer up front, even for a dry-run); BLIND mode is pure arithmetic.
+  let newCrop, buf = null, gutter = null, keyTag;
+  if (TO_GUTTER) {
+    buf = await fetchImage(src);
+    const profile = await spreadProfile(buf);
+    const w = gutterWiden(base, profile);
+    if (w.status === 'skip') return w;
+    newCrop = w.crop; gutter = w.gutter;
+    keyTag = `g${gutter.kind[0]}${base.xStart === 0 ? newCrop.xEnd : newCrop.xStart}`;
+  } else {
+    newCrop = blindWiden(base);
+    if (!newCrop) return { status: 'skip', reason: `undetermined side ${JSON.stringify(base)}` };
+    keyTag = `rc${OVERLAP}`;
   }
 
-  const buf = await fetchImage(src);
+  if (DRY_RUN) {
+    return { status: 'dry', side: base.xStart === 0 ? 'L' : 'R', from: base, to: newCrop, gutter: gutter && { kind: gutter.kind, mid: gutter.mid } };
+  }
+
+  if (!buf) buf = await fetchImage(src);
   const meta = await sharp(buf).metadata();
   const W = meta.width || 1000;
   const H = meta.height || 1000;
@@ -168,8 +216,9 @@ async function processPage(r2, db, page) {
     .jpeg({ quality: CROPPED_QUALITY, progressive: true })
     .toBuffer();
 
-  // New unique key → fresh /api/image cache key, no CDN purge needed.
-  const key = `cropped/${page.book_id}/${page.id}-rc${OVERLAP}.jpg`;
+  // New unique key → fresh /api/image cache key, no CDN purge needed. The key
+  // encodes the new bound so a re-run with the same detection reuses it (idempotent).
+  const key = `cropped/${page.book_id}/${page.id}-${keyTag}.jpg`;
   const newUrl = await uploadToR2(r2, key, outBuf);
 
   await db.collection('pages').updateOne(
@@ -183,7 +232,9 @@ async function processPage(r2, db, page) {
         crop: newCrop,
         recrop_2898: {
           at: new Date(),
-          overlap: OVERLAP,
+          mode: TO_GUTTER ? 'to-gutter' : 'blind',
+          overlap: TO_GUTTER ? null : OVERLAP,
+          gutter: gutter ? { kind: gutter.kind, mid: gutter.mid } : null,
           prev_crop: base,
           prev_cropped_photo: prevCropped,
         },
@@ -231,8 +282,14 @@ async function processBook(r2, db, bookId) {
   }
 
   if (DRY_RUN) {
-    const sample = results.filter(r => r.status === 'dry').slice(0, 4);
-    for (const s of sample) console.log(`    [${s.side}] ${JSON.stringify(s.from)} → ${JSON.stringify(s.to)}`);
+    const sample = results.filter(r => r.status === 'dry').slice(0, 5);
+    for (const s of sample) {
+      const g = s.gutter ? `  gutter ${s.gutter.mid}(${s.gutter.kind})` : '';
+      console.log(`    [${s.side}] ${JSON.stringify(s.from)} → ${JSON.stringify(s.to)}${g}`);
+    }
+    // In to-gutter mode a "skip" means the page doesn't clip (cut already at/past
+    // the gutter) — that's expected and healthy, so report how many were touched.
+    console.log(`    would re-crop ${ok}/${pages.length} pages (${skip} left as-is)`);
   }
 
   const failFrac = pages.length ? err / pages.length : 0;
@@ -248,8 +305,9 @@ async function main() {
   else { console.error('Provide --book-id or --ids-file'); process.exit(1); }
   if (LIMIT > 0) bookIds = bookIds.slice(0, LIMIT);
 
-  console.log(`Re-crop BPH gutter (issue #2898)`);
-  console.log(`Books: ${bookIds.length}, overlap: ${OVERLAP}‰, concurrency: ${CONCURRENCY}, dry-run: ${DRY_RUN}\n`);
+  console.log(`Re-crop BPH gutter (issue #2898/#3088)`);
+  const modeStr = TO_GUTTER ? `to-gutter (margin ${GUTTER_MARGIN}‰)` : `blind +${OVERLAP}‰`;
+  console.log(`Books: ${bookIds.length}, mode: ${modeStr}, concurrency: ${CONCURRENCY}, dry-run: ${DRY_RUN}\n`);
 
   const r2 = getR2();
   const client = await MongoClient.connect(process.env.MONGODB_URI);


### PR DESCRIPTION
Closes the audit + tooling half of #3088 (follow-up to #2898 / PR #3082). The
cohort **sweep + re-OCR run itself is deferred to Hetzner** (documented), since
it's an image-heavy multi-hour job on the pipeline box.

## Problem
Old-era BPH splits cut spreads at a shared gutter line with **zero overlap**,
clipping left-page content that reaches the binding. The v1 audit measured raw
ink just past the cut and **over-flagged ~97%** of the ~1,208-book / ~410k-page
cohort — it couldn't distinguish clipped text from **binding shadow** (saturates
~1.0; text tops ~0.6 because line leading leaves white rows) or **facing-page
bleed** past the gutter.

## What's here
- **`scripts/lib/gutter-clip.mjs`** — shared gutter-aware primitive (used by both
  audit and recrop so they never drift):
  - locate the **true gutter** in a window around the cut — the *widest* bright
    ink-free run (picking widest beats the ToC inter-column-valley trap, Artis
    p386) or the saturated dark shadow on tight bindings;
  - count recoverable content **only between cut and gutter, on the correct side**
    (sign of `gutter − cut` rejects a cut already at/past the gutter = over-cut/bleed);
  - count only text-like columns and **drop any within `SAT_ADJ‰` of a saturation
    peak** — this kills the binding-shadow *ramp* (the p197 false positive).
- **`audit-bph-gutter-clip.mjs`** rewritten on that primitive. On a 21-book
  sample: **~10% flagged** (vs 97%), every flag text-driven (`shadowFrac 0`).
  Adds `--profile <id>` (per-page geometry dump) and an **HTML eye-check gallery**
  that overlays cut (red) / gutter (green) / recover band on the real spread.
- **`recrop-bph-gutter.mjs`** gains **`--to-gutter`**: per-page, move the cut to
  the *detected* gutter centre — recovers exactly the clipped content with no blind
  overlap guess, and is **clip-gated by the same `measureClip`** so recrop ⇔ audit
  agree (non-clipping pages left untouched). Blind `--overlap` mode kept for
  wide-gutter books. Still non-destructive / idempotent / reversible.
- **`.claude/docs/bph-gutter-clip-audit-and-sweep.md`** — Hetzner run plan +
  re-OCR decision guidance.

## Validation (spot-checked against composited overlays)
- `40 questions… p50` — real left-page clip (text bump ink 0.24 before a wide
  blank gutter) → **flagged** ✅
- `40 questions… p197` — binding shadow (ink peaks 0.88, right-page text starts at
  the cut) → **not flagged** after the shadow-ramp fix ✅
- `Eine kurtze…` / `L'Elixir…` — trailing line-end punctuation / marginalia past
  the cut → **flagged** (modest, low severity) ✅
- `--to-gutter --dry-run` on the top flagged book: **36/244 pages** touched, cut
  moved to each detected gutter; rest left as-is.

## Out of scope (deliberately deferred, per issue)
- Running the full audit + sweep on Hetzner (multi-hour, image-heavy).
- Re-OCR of swept pages — separate, paid (Gemini), pipeline paused; low-yield on
  the sampled cohort (mostly trailing glyphs). Decision guidance in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)