### PR TITLE
fix(reader): drop produced-by footer line, show nav hint only for first visits

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -484,6 +484,20 @@ export default function TranslationEditor({
   });
   const [modernizedText, setModernizedText] = useState<string | null>(page.modernized?.data || null);
 
+  // Navigation hint: shown for the reader's first few page views ever, then retired
+  const [showNavHint, setShowNavHint] = useState(false);
+  useEffect(() => {
+    const NAV_HINT_KEY = 'sl_nav_hint_views';
+    const NAV_HINT_MAX_VIEWS = 5;
+    const views = Number(localStorage.getItem(NAV_HINT_KEY) || '0');
+    if (views < NAV_HINT_MAX_VIEWS) {
+      setShowNavHint(true);
+      localStorage.setItem(NAV_HINT_KEY, String(views + 1));
+    } else {
+      setShowNavHint(false);
+    }
+  }, [page.id]);
+
   // Translation request (guest users)
   const [translationRequested, setTranslationRequested] = useState(false);
 
@@ -2028,12 +2042,12 @@ export default function TranslationEditor({
               </>
             )}
           </div>
-          <div className="px-4 py-1 flex items-center justify-center gap-4 text-xs flex-wrap">
-            <span className="hidden lg:inline">Use ← → arrow keys to navigate</span>
-            <span className="lg:hidden">Swipe left/right to navigate</span>
-            <span>·</span>
-            <span>Produced by <a href="https://sourcelibrary.org" className="hover:underline" style={{ color: 'var(--text-muted)' }}>SourceLibrary.org</a> in Amsterdam, 2026</span>
-          </div>
+          {showNavHint && (
+            <div className="px-4 py-1 flex items-center justify-center gap-4 text-xs flex-wrap">
+              <span className="hidden lg:inline">Use ← → arrow keys to navigate</span>
+              <span className="lg:hidden">Swipe left/right to navigate</span>
+            </div>
+          )}
           <div className="px-4 py-1.5" style={{ borderTop: '1px solid var(--border-light)' }}>
             <BookSearchBar bookId={book.id} tenantPrefix={tenantPrefix} />
           </div>


### PR DESCRIPTION
## What

Slims the mobile reader footer from three text rows to one:

- **Removes the "Produced by SourceLibrary.org in Amsterdam, 2026" line.** Besides costing a row on every page, it was an absolute `sourcelibrary.org` link **not** gated by `isEmbedded` (unlike the comments block above it), so it leaked off tenant subdomains — tenant-lockdown invariant 5.
- **Navigation hint ("Swipe left/right" / "arrow keys") now shows only for a reader's first 5 page views ever**, tracked via a `sl_nav_hint_views` localStorage counter, then the row disappears permanently. Same pattern as the existing `sl_reader_mode` persistence.

## What's deliberately kept (out of scope)

- **Like button** — real usage: 673 likes in the last 30 days from 243 distinct visitors.
- **Leave comment** — the `annotations` collection has zero documents ever, but Derek wants to keep it another week before deciding. Revisit ~2026-07-15.

## Verification

- `npx tsc --noEmit` passes.
- `grep -n 'Produced by' src/components/pipeline/TranslationEditor.tsx` → no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)