### PR TITLE
Focused reading: focus mode + reading themes/measure (#3092)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -286,6 +286,8 @@ h1, h2, h3, h4 {
 [data-reader-theme='night'] .text-stone-400 { color: #857c70; }
 [data-reader-theme='night'] .text-stone-500 { color: #a49b8f; }
 [data-reader-theme='night'] .text-stone-600 { color: #b5ac9f; }
+[data-reader-theme='night'] .text-primary { color: #ece7df; }
+[data-reader-theme='night'] .hover\:text-secondary:hover { color: #cfc8bd; }
 [data-reader-theme='night'] .text-stone-700 { color: #cfc8bd; }
 [data-reader-theme='night'] .hover\:text-stone-700:hover { color: #ece7df; }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -298,6 +298,21 @@ body.reader-focus [data-reader-chrome] {
   display: none;
 }
 
+/* Mobile focus mode = just the text. Panels stack vertically below lg, so a
+   reader in focus mode would scroll past the facsimile on every page turn.
+   Hide the image panel — but only when a text panel is up, so an image-only
+   view (all text panels toggled off) still shows the facsimile. */
+@media (max-width: 1023.98px) {
+  body.reader-focus
+    [data-reader-panels-container]:has(
+      [data-reader-section='ocr'],
+      [data-reader-section='translation']
+    )
+    [data-reader-section='image'] {
+    display: none;
+  }
+}
+
 /* Prose styling for content/document pages */
 .prose-content {
   font-family: 'Newsreader', Georgia, serif;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,6 +228,74 @@ h1, h2, h3, h4 {
   margin-bottom: 1.5em;
 }
 
+/* ---------------------------------------------------------------------------
+   Reader: reading measure, themes, and focus mode
+   (book reader at /book/[slug]/page/[pageId] — TranslationEditor read mode)
+--------------------------------------------------------------------------- */
+
+/* Cap the text measure inside reader text panels. Long lines on wide screens
+   are the single biggest readability cost; ~70ch is the classic upper bound.
+   Scoped to reader panels so prose-manuscript elsewhere is untouched. */
+[data-reader-panel] .prose-manuscript {
+  max-width: 70ch;
+  margin-inline: auto;
+}
+/* Nested NotesRenderer inside an already-capped wrapper: don't re-center */
+[data-reader-panel] .prose-manuscript .prose-manuscript {
+  max-width: none;
+  margin-inline: 0;
+}
+
+/* Reader themes: components inside the reader style themselves with the CSS
+   variables below, so re-declaring the variables on the themed root re-skins
+   the whole surface. Values composed from the existing palette (no new
+   design primitives): sepia warms the paper tokens, night inverts around
+   --bg-dark (#1a1612). */
+[data-reader-theme='sepia'] {
+  --bg-cream: #f6eeda;
+  --bg-white: #fbf4e4;
+  --bg-warm: #efe4cb;
+  --border-light: #e3d6ba;
+  --border-medium: #d1c1a0;
+}
+
+[data-reader-theme='night'] {
+  --bg-cream: #1a1612;
+  --bg-white: #211c17;
+  --bg-warm: #2a241d;
+  --text-primary: #ece7df;
+  --text-secondary: #cfc8bd;
+  --text-muted: #a49b8f;
+  --text-faint: #7d766c;
+  --border-light: #3a332b;
+  --border-medium: #4a4238;
+  /* "dark" accent variants exist for text on light backgrounds — lighten them */
+  --accent-sage-dark: #a8b898;
+  --accent-gold-dark: #d4b072;
+}
+
+/* Night-mode compatibility for hardcoded light-utility classes used inside the
+   reader (buttons, chips, the settings popover). Scoped to the themed root. */
+[data-reader-theme='night'] .bg-white { background-color: #211c17; }
+[data-reader-theme='night'] .bg-stone-100 { background-color: #2f2921; }
+[data-reader-theme='night'] .bg-stone-200 { background-color: #3d352a; }
+[data-reader-theme='night'] .hover\:bg-stone-100:hover { background-color: #373026; }
+[data-reader-theme='night'] .hover\:bg-stone-200:hover { background-color: #453c30; }
+[data-reader-theme='night'] .active\:bg-stone-300:active { background-color: #4d4436; }
+[data-reader-theme='night'] .hover\:bg-black\/5:hover { background-color: rgba(255, 255, 255, 0.08); }
+[data-reader-theme='night'] .text-stone-400 { color: #857c70; }
+[data-reader-theme='night'] .text-stone-500 { color: #a49b8f; }
+[data-reader-theme='night'] .text-stone-600 { color: #b5ac9f; }
+[data-reader-theme='night'] .text-stone-700 { color: #cfc8bd; }
+[data-reader-theme='night'] .hover\:text-stone-700:hover { color: #ece7df; }
+
+/* Focus mode: hide every piece of reader chrome. ReaderFocusMode toggles
+   .reader-focus on <body>; TranslationEditor marks its chrome elements with
+   data-reader-chrome. The floating focus bar replaces them until exit. */
+body.reader-focus [data-reader-chrome] {
+  display: none;
+}
+
 /* Prose styling for content/document pages */
 .prose-content {
   font-family: 'Newsreader', Georgia, serif;

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -2039,7 +2039,7 @@ export default function TranslationEditor({
         })()}
 
         {/* Footer: like + nav hint + search */}
-        <div style={{ background: 'var(--bg-warm)', color: 'var(--text-muted)', borderTop: '1px solid var(--border-light)' }}>
+        <div data-reader-chrome style={{ background: 'var(--bg-warm)', color: 'var(--text-muted)', borderTop: '1px solid var(--border-light)' }}>
           <div className="px-4 pt-2 pb-1 flex items-center justify-center gap-3 flex-wrap text-xs">
             <LikeButton
               key={`footer-${page.id}`}

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -27,7 +27,8 @@ import {
   Save,
   AlertCircle,
 } from 'lucide-react';
-import { useReaderPreferences } from '@/hooks/useReaderPreferences';
+import { useReaderPreferences, type ReaderTheme } from '@/hooks/useReaderPreferences';
+import ReaderFocusMode from '@/components/reader/ReaderFocusMode';
 import NotesRenderer from '@/components/reader/NotesRenderer';
 import AiBadge from '@/components/ui/AiBadge';
 import { MANUSCRIPT_OCR_FLAG } from '@/lib/marcianus-overlay.shared';
@@ -475,7 +476,7 @@ export default function TranslationEditor({
     translation: page.translation?.data || '',
     summary: page.summary?.data || '',
   });
-  const { fontSize, lineHeight, increaseFontSize, decreaseFontSize, resetFontSize, isMinSize, isMaxSize, isDefaultSize } = useReaderPreferences();
+  const { fontSize, lineHeight, increaseFontSize, decreaseFontSize, resetFontSize, isMinSize, isMaxSize, isDefaultSize, theme, setTheme } = useReaderPreferences();
 
   // Modernized text toggle
   const [modernizedMode, setModernizedMode] = useState(() => {
@@ -1041,9 +1042,9 @@ export default function TranslationEditor({
     const isFullyTranslated = ocrText && translationText;
 
     return (
-      <div className="h-screen flex flex-col" style={{ background: 'var(--bg-cream)' }}>
+      <div className="h-screen flex flex-col" data-reader-theme={theme} style={{ background: 'var(--bg-cream)' }}>
         {/* Header - Two rows on mobile, one row on desktop */}
-        <header className="px-3 sm:px-4 py-2 sm:py-3" style={{ background: 'var(--bg-white)', borderBottom: '1px solid var(--border-light)' }}>
+        <header data-reader-chrome className="px-3 sm:px-4 py-2 sm:py-3" style={{ background: 'var(--bg-white)', borderBottom: '1px solid var(--border-light)' }}>
           {/* Row 1: Back + Title ... Chapter Nav ... Page Navigator */}
           <div className="flex items-center justify-between gap-2 relative">
             <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
@@ -1214,20 +1215,29 @@ export default function TranslationEditor({
 
             {/* Right side: Mode toggle + Like + extras on desktop */}
             <div className="flex items-center gap-1 sm:gap-2">
-              {/* Desktop extras: Font size */}
-              <div className="hidden sm:flex items-center p-1 rounded-lg" style={{ background: 'var(--bg-warm)' }}>
+              {/* Reading tools: focus mode + reading settings */}
+              <div className="flex items-center p-1 rounded-lg" style={{ background: 'var(--bg-warm)' }}>
+                <ReaderFocusMode
+                  bookTitle={book.display_title || book.title}
+                  bookHref={`${tenantPrefix}/book/${book.id}`}
+                  pageLabel={`${currentIndex + 1} / ${pages.length}`}
+                  hasPrev={!!previousPage}
+                  hasNext={!!nextPage}
+                  onPrev={() => previousPage && onNavigate(previousPage.id)}
+                  onNext={() => nextPage && onNavigate(nextPage.id)}
+                />
                 <div className="relative" ref={fontControlsRef}>
                   <button
                     onClick={() => setShowFontControls(prev => !prev)}
                     className={`flex items-center gap-0.5 p-1.5 rounded-md text-xs font-medium transition-all hover:bg-stone-100 ${showFontControls ? 'bg-stone-200' : ''}`}
                     style={{ color: showFontControls ? 'var(--text-primary)' : 'var(--text-muted)' }}
-                    aria-label="Font size"
-                    title="Font size"
+                    aria-label="Reading settings"
+                    title="Reading settings"
                   >
                     <span className="text-xs">A</span><span className="text-base font-semibold leading-none">A</span>
                   </button>
                   {showFontControls && (
-                    <div className="absolute right-0 top-full mt-2 z-50 bg-white rounded-xl shadow-lg border p-4" style={{ borderColor: 'var(--border-light)', minWidth: '200px' }}>
+                    <div className="absolute right-0 top-full mt-2 z-50 bg-white rounded-xl shadow-lg border p-4" style={{ borderColor: 'var(--border-light)', minWidth: '220px' }}>
                       <div className="text-[10px] uppercase tracking-widest text-center mb-3" style={{ color: 'var(--text-muted)' }}>Font Size</div>
                       <div className="flex items-center justify-between gap-4">
                         <button
@@ -1257,6 +1267,30 @@ export default function TranslationEditor({
                         >
                           A
                         </button>
+                      </div>
+                      <div className="text-[10px] uppercase tracking-widest text-center mt-4 mb-3" style={{ color: 'var(--text-muted)' }}>Theme</div>
+                      <div className="flex items-center justify-between gap-2">
+                        {([
+                          ['paper', 'Paper', '#fdfcf9', '#1a1612'],
+                          ['sepia', 'Sepia', '#f6eeda', '#1a1612'],
+                          ['night', 'Night', '#1a1612', '#ece7df'],
+                        ] as [ReaderTheme, string, string, string][]).map(([key, label, bg, fg]) => (
+                          <button
+                            key={key}
+                            onClick={() => setTheme(key)}
+                            className="flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-all focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
+                            style={{
+                              background: bg,
+                              color: fg,
+                              borderColor: theme === key ? 'var(--accent-rust)' : 'var(--border-light)',
+                            }}
+                            aria-pressed={theme === key}
+                            title={`${label} theme`}
+                          >
+                            <span className="text-sm font-serif leading-none">Aa</span>
+                            <span className="text-[10px]">{label}</span>
+                          </button>
+                        ))}
                       </div>
                     </div>
                   )}
@@ -1366,7 +1400,7 @@ export default function TranslationEditor({
 
         {/* Rashi script quality warning */}
         {hasRashiScript && (
-          <div className="px-4 py-2 bg-amber-50 border-b border-amber-200 text-sm text-amber-800 flex items-center gap-2">
+          <div data-reader-chrome className="px-4 py-2 bg-amber-50 border-b border-amber-200 text-sm text-amber-800 flex items-center gap-2">
             <span className="font-bold flex-shrink-0">⚠</span>
             <span><span className="font-medium">Rashi script</span> — current AI models struggle with this typeface. OCR and translation quality is low.</span>
           </div>
@@ -1376,7 +1410,7 @@ export default function TranslationEditor({
             disruptive line. Berthelot's text fills the Original/Translation
             columns below; the manuscript's own OCR is demoted inside them. */}
         {paired && (
-          <div className="px-4 py-2 bg-accent-gold/10 border-b border-accent-gold/20 text-xs flex items-center gap-2" style={{ color: 'var(--accent-gold-dark)' }}>
+          <div data-reader-chrome className="px-4 py-2 bg-accent-gold/10 border-b border-accent-gold/20 text-xs flex items-center gap-2" style={{ color: 'var(--accent-gold-dark)' }}>
             <BookOpen className="w-3.5 h-3.5 flex-shrink-0" />
             <span>
               <span className="font-medium">Reading text from the critical edition</span> — Berthelot &amp; Ruelle 1887–88, folio {paired.folio}. The manuscript&rsquo;s own AI transcription is unverified; verify any quotation against the edition or the facsimile.
@@ -1409,7 +1443,7 @@ export default function TranslationEditor({
               {/* Source Image Panel */}
               {showImagePanel && (
                 <div data-reader-section="image" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1 relative`} style={{ background: 'var(--bg-warm)', borderRight: '1px solid var(--border-light)' }}>
-                  <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
+                  <div data-reader-chrome className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
                       {!pageDisplayUrl && hasWitnessPhotos ? 'Tablet Photo' : 'Source Image'}
                     </span>
@@ -1552,7 +1586,7 @@ export default function TranslationEditor({
               {/* OCR Panel */}
               {showOcrPanel && (
                 <div id="reader-text" data-reader-section="ocr" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-cream)', borderRight: '1px solid var(--border-light)' }}>
-                  <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
+                  <div data-reader-chrome className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
                         {paired ? 'Greek · Berthelot' : ocrText ? (isEnglishBook ? 'Original Text' : (book.language || 'Original')) : 'Step 1: Transcribe'}
@@ -1644,7 +1678,7 @@ export default function TranslationEditor({
               {/* Transliteration Panel (non-Latin scripts only) */}
               {showTransliterationPanel && hasTransliteration && (
                 <div className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-white)', borderLeft: '1px solid var(--border-light)' }}>
-                  <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
+                  <div data-reader-chrome className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
                         Romanized {book.language || ''}
@@ -1714,7 +1748,7 @@ export default function TranslationEditor({
               {/* German Source Panel (ORAEC Egyptian texts) */}
               {showGermanSourcePanel && hasGermanSource && (
                 <div className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-white)', borderRight: '1px solid var(--border-light)' }}>
-                  <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
+                  <div data-reader-chrome className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
                       Deutsch <span className="normal-case font-normal">(ORAEC)</span>
                     </span>
@@ -1738,7 +1772,7 @@ export default function TranslationEditor({
               {/* Translation Panel — suppressed for modern-print English books (OCR is the reading view) */}
               {showTranslationPanel && !englishOcrIsReadingView && (
                 <div id={showOcrPanel ? undefined : 'reader-text'} data-reader-section="translation" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-white)' }}>
-                  <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
+                  <div data-reader-chrome className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
                         {paired ? 'English · Berthelot' : translationText ? translationLangLabel : 'Step 2: Translate'}

--- a/src/components/reader/ReaderFocusMode.tsx
+++ b/src/components/reader/ReaderFocusMode.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight, Maximize2, Minimize2 } from 'lucide-react';
+
+interface ReaderFocusModeProps {
+  bookTitle: string;
+  bookHref: string; // tenant-relative, e.g. `/book/<slug>` — never an absolute sourcelibrary.org URL
+  pageLabel: string; // e.g. "12 / 340"
+  hasPrev: boolean;
+  hasNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+// Distraction-free reading mode. Self-contained on purpose: it owns its own
+// state and applies focus mode by toggling a class on <body> (CSS in
+// globals.css hides every [data-reader-chrome] element under .reader-focus).
+// Do NOT move this state into TranslationEditor — inline interactive state
+// there has silently failed before (see memory/ui-navigation.md, 2026-06-08).
+export default function ReaderFocusMode({
+  bookTitle,
+  bookHref,
+  pageLabel,
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+}: ReaderFocusModeProps) {
+  const [active, setActive] = useState(false);
+  const [barVisible, setBarVisible] = useState(false);
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearHideTimer = () => {
+    if (hideTimer.current) {
+      clearTimeout(hideTimer.current);
+      hideTimer.current = null;
+    }
+  };
+
+  const showBarTemporarily = useCallback((ms = 2500) => {
+    clearHideTimer();
+    setBarVisible(true);
+    hideTimer.current = setTimeout(() => setBarVisible(false), ms);
+  }, []);
+
+  const enter = useCallback(() => {
+    setActive(true);
+    showBarTemporarily(2500);
+  }, [showBarTemporarily]);
+
+  const exit = useCallback(() => {
+    clearHideTimer();
+    setActive(false);
+    setBarVisible(false);
+  }, []);
+
+  // Apply/remove the body class that hides reader chrome
+  useEffect(() => {
+    if (!active) return;
+    document.body.classList.add('reader-focus');
+    return () => document.body.classList.remove('reader-focus');
+  }, [active]);
+
+  // Keyboard: `f` toggles, Escape exits
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLInputElement) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === 'f' || e.key === 'F') {
+        e.preventDefault();
+        if (active) exit();
+        else enter();
+      } else if (e.key === 'Escape' && active) {
+        exit();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [active, enter, exit]);
+
+  // Desktop: reveal the bar when the pointer nears the top edge
+  useEffect(() => {
+    if (!active) return;
+    const handleMove = (e: MouseEvent) => {
+      if (e.clientY < 64) {
+        clearHideTimer();
+        setBarVisible(true);
+      } else if (e.clientY > 180) {
+        setBarVisible(false);
+      }
+    };
+    window.addEventListener('mousemove', handleMove);
+    return () => window.removeEventListener('mousemove', handleMove);
+  }, [active]);
+
+  // Mobile (and desktop): tapping non-interactive content toggles the bar.
+  // Skip taps on links/buttons/inputs and skip when the reader is selecting
+  // text (HighlightSelection fires a click at the end of a selection).
+  useEffect(() => {
+    if (!active) return;
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('a, button, input, textarea, select, summary, [role="button"], [data-reader-focus-bar]')) return;
+      if (window.getSelection()?.toString()) return;
+      setBarVisible(prev => {
+        clearHideTimer();
+        return !prev;
+      });
+    };
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [active]);
+
+  // Never leave a stray timer behind
+  useEffect(() => clearHideTimer, []);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => (active ? exit() : enter())}
+        className="p-1.5 rounded-md text-xs font-medium transition-all hover:bg-stone-100 focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
+        style={{ color: 'var(--text-muted)' }}
+        aria-label={active ? 'Exit focus mode' : 'Enter focus mode'}
+        aria-pressed={active}
+        title="Focus mode (f)"
+      >
+        <Maximize2 className="w-4 h-4" aria-hidden="true" />
+      </button>
+
+      {active && (
+        <div
+          data-reader-focus-bar
+          className={`fixed top-0 inset-x-0 z-50 transition-transform duration-200 motion-reduce:transition-none ${barVisible ? 'translate-y-0' : '-translate-y-full'}`}
+          style={{
+            background: 'var(--bg-white)',
+            borderBottom: '1px solid var(--border-light)',
+            boxShadow: '0 2px 12px rgba(0,0,0,0.08)',
+          }}
+          onMouseEnter={clearHideTimer}
+          aria-hidden={!barVisible}
+        >
+          <div className="flex items-center justify-between gap-3 px-3 sm:px-4 py-2">
+            <a href={bookHref} className="min-w-0 flex-1 hover:opacity-70 transition-opacity">
+              <span className="block text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                {bookTitle}
+              </span>
+            </a>
+            <div className="flex items-center gap-1 shrink-0 rounded-lg p-1" style={{ background: 'var(--bg-warm)' }}>
+              <button
+                type="button"
+                onClick={onPrev}
+                disabled={!hasPrev}
+                className="p-1.5 rounded-md transition-all disabled:opacity-30 focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
+                style={{ color: 'var(--text-secondary)' }}
+                aria-label="Previous page"
+              >
+                <ChevronLeft className="w-4 h-4" aria-hidden="true" />
+              </button>
+              <span className="px-1 text-sm font-medium tabular-nums" style={{ color: 'var(--text-muted)' }}>
+                {pageLabel}
+              </span>
+              <button
+                type="button"
+                onClick={onNext}
+                disabled={!hasNext}
+                className="p-1.5 rounded-md transition-all disabled:opacity-30 focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
+                style={{ color: 'var(--text-secondary)' }}
+                aria-label="Next page"
+              >
+                <ChevronRight className="w-4 h-4" aria-hidden="true" />
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={exit}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium shrink-0 transition-all hover:bg-stone-100 focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
+              style={{ color: 'var(--text-secondary)' }}
+              title="Exit focus mode (Esc)"
+            >
+              <Minimize2 className="w-3.5 h-3.5" aria-hidden="true" />
+              <span className="hidden sm:inline">Exit focus</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/reader/ReaderFocusMode.tsx
+++ b/src/components/reader/ReaderFocusMode.tsx
@@ -104,10 +104,8 @@ export default function ReaderFocusMode({
       if (!target) return;
       if (target.closest('a, button, input, textarea, select, summary, [role="button"], [data-reader-focus-bar]')) return;
       if (window.getSelection()?.toString()) return;
-      setBarVisible(prev => {
-        clearHideTimer();
-        return !prev;
-      });
+      clearHideTimer();
+      setBarVisible(prev => !prev);
     };
     document.addEventListener('click', handleClick);
     return () => document.removeEventListener('click', handleClick);

--- a/src/components/reader/ReaderFocusMode.tsx
+++ b/src/components/reader/ReaderFocusMode.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronLeft, ChevronRight, Maximize2, Minimize2 } from 'lucide-react';
+import { useReaderPreferences } from '@/hooks/useReaderPreferences';
 
 interface ReaderFocusModeProps {
   bookTitle: string;
@@ -30,6 +32,9 @@ export default function ReaderFocusMode({
   const [active, setActive] = useState(false);
   const [barVisible, setBarVisible] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The bar is portaled to <body>, outside the reader's themed root — read the
+  // theme here so the bar can carry its own data-reader-theme.
+  const { theme } = useReaderPreferences();
 
   const clearHideTimer = () => {
     if (hideTimer.current) {
@@ -128,9 +133,12 @@ export default function ReaderFocusMode({
         <Maximize2 className="w-4 h-4" aria-hidden="true" />
       </button>
 
-      {active && (
+      {/* The toggle button lives inside the (hidden-in-focus) toolbar, so the
+          floating bar must escape that subtree — portal it to <body>. */}
+      {active && createPortal(
         <div
           data-reader-focus-bar
+          data-reader-theme={theme}
           className={`fixed top-0 inset-x-0 z-50 transition-transform duration-200 motion-reduce:transition-none ${barVisible ? 'translate-y-0' : '-translate-y-full'}`}
           style={{
             background: 'var(--bg-white)',
@@ -182,7 +190,8 @@ export default function ReaderFocusMode({
               <span className="hidden sm:inline">Exit focus</span>
             </button>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </>
   );

--- a/src/hooks/useReaderPreferences.ts
+++ b/src/hooks/useReaderPreferences.ts
@@ -8,6 +8,10 @@ const MAX_SIZE = 32;
 const STEP = 2;
 const DEFAULT_SIZE = 18;
 
+export type ReaderTheme = 'paper' | 'sepia' | 'night';
+const THEMES: ReaderTheme[] = ['paper', 'sepia', 'night'];
+const DEFAULT_THEME: ReaderTheme = 'paper';
+
 function computeLineHeight(fontSize: number): number {
   // 1.6 at 14px, 1.8 at 18px, 2.0 at 24px
   return 1.6 + (fontSize - MIN_SIZE) * 0.04;
@@ -15,20 +19,23 @@ function computeLineHeight(fontSize: number): number {
 
 interface ReaderPrefs {
   fontSize: number;
+  theme: ReaderTheme;
 }
 
 function loadPrefs(): ReaderPrefs {
-  if (typeof window === 'undefined') return { fontSize: DEFAULT_SIZE };
+  const defaults: ReaderPrefs = { fontSize: DEFAULT_SIZE, theme: DEFAULT_THEME };
+  if (typeof window === 'undefined') return defaults;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       const parsed = JSON.parse(raw);
-      if (parsed.fontSize >= MIN_SIZE && parsed.fontSize <= MAX_SIZE) {
-        return { fontSize: parsed.fontSize };
-      }
+      return {
+        fontSize: parsed.fontSize >= MIN_SIZE && parsed.fontSize <= MAX_SIZE ? parsed.fontSize : DEFAULT_SIZE,
+        theme: THEMES.includes(parsed.theme) ? parsed.theme : DEFAULT_THEME,
+      };
     }
   } catch { /* ignore */ }
-  return { fontSize: DEFAULT_SIZE };
+  return defaults;
 }
 
 function savePrefs(prefs: ReaderPrefs) {
@@ -39,15 +46,18 @@ function savePrefs(prefs: ReaderPrefs) {
 
 export function useReaderPreferences() {
   const [fontSize, setFontSize] = useState(DEFAULT_SIZE);
+  const [theme, setThemeState] = useState<ReaderTheme>(DEFAULT_THEME);
 
   useEffect(() => {
-    setFontSize(loadPrefs().fontSize);
+    const prefs = loadPrefs();
+    setFontSize(prefs.fontSize);
+    setThemeState(prefs.theme);
   }, []);
 
   const increaseFontSize = useCallback(() => {
     setFontSize(prev => {
       const next = Math.min(prev + STEP, MAX_SIZE);
-      savePrefs({ fontSize: next });
+      savePrefs({ ...loadPrefs(), fontSize: next });
       return next;
     });
   }, []);
@@ -55,14 +65,19 @@ export function useReaderPreferences() {
   const decreaseFontSize = useCallback(() => {
     setFontSize(prev => {
       const next = Math.max(prev - STEP, MIN_SIZE);
-      savePrefs({ fontSize: next });
+      savePrefs({ ...loadPrefs(), fontSize: next });
       return next;
     });
   }, []);
 
   const resetFontSize = useCallback(() => {
     setFontSize(DEFAULT_SIZE);
-    savePrefs({ fontSize: DEFAULT_SIZE });
+    savePrefs({ ...loadPrefs(), fontSize: DEFAULT_SIZE });
+  }, []);
+
+  const setTheme = useCallback((next: ReaderTheme) => {
+    setThemeState(next);
+    savePrefs({ ...loadPrefs(), theme: next });
   }, []);
 
   return {
@@ -74,5 +89,7 @@ export function useReaderPreferences() {
     isMinSize: fontSize <= MIN_SIZE,
     isMaxSize: fontSize >= MAX_SIZE,
     isDefaultSize: fontSize === DEFAULT_SIZE,
+    theme,
+    setTheme,
   };
 }


### PR DESCRIPTION
## What

Implements #3092 (scope agreed: distraction-free mode + typography & comfort).

- **Focus mode** — toolbar button, `f` to toggle, `Esc` to exit. Hides all reader chrome (header, toolbar, panel strips) via `body.reader-focus` + `data-reader-chrome` markers. A slim floating bar (title link, prev/next + page counter, exit) appears on entry, top-edge hover, or center tap, then auto-hides. Arrow-key nav, swipe nav, and font shortcuts keep working. State is session-scoped.
- **Reading themes** — Paper / Sepia / Night in the (renamed) Reading Settings popover, persisted in `sl_reader_prefs`. Implemented as CSS-variable overrides on the reader root (`data-reader-theme`), composed from existing palette tokens — no new design primitives. Night mode ships compat overrides for the hardcoded `bg-white`/`bg-stone-*` utilities inside the reader.
- **Reading measure** — text panels capped at 70ch, centered (scoped to `[data-reader-panel] .prose-manuscript`, so prose elsewhere is untouched).
- Reading Settings (font size + theme) now visible on mobile, not just `sm:`+.

## Why the shape it has

Focus-mode state lives in a self-contained `ReaderFocusMode` component, NOT inline in `TranslationEditor` — inline interactive state there has silently failed before (2026-06-08 lesson, memory/ui-navigation.md). Chrome elements only carry passive `data-reader-chrome` attributes.

## Out of scope (deliberately)

Continuous cross-page text flow and facsimile-first immersion — possible follow-ups per #3092. Edit mode untouched.

## Testing

- `npx tsc --noEmit` clean; import check clean.
- Browser verification on the Vercel preview (see comments below).

Closes #3092

🤖 Generated with [Claude Code](https://claude.com/claude-code)