### PR TITLE
Reader trace mode: click a phrase in the translation, see it in the original (#3091)

### DIFF
--- a/src/app/api/books/[id]/pages/[pageId]/alignment/route.ts
+++ b/src/app/api/books/[id]/pages/[pageId]/alignment/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/mongodb';
+import { isBookReadable } from '@/lib/book-access';
+import { anonActionGate } from '@/lib/anon-gate';
+import { getOrCreateWordAlignment } from '@/lib/word-alignment';
+import type { Book } from '@/lib/types';
+
+/**
+ * GET /api/books/[id]/pages/[pageId]/alignment — span-level OCR↔translation
+ * alignment for the reader's trace mode (issue #3091).
+ *
+ * Serves the cached `pages.word_alignment` when its text hashes still match;
+ * otherwise generates it with one flash-lite call and caches it on the page.
+ * Cached serves are free and ungated; generation (a paid Gemini call) is
+ * rate-limited per IP for anonymous visitors via anonActionGate.
+ */
+
+export const dynamic = 'force-dynamic';
+
+interface RouteContext {
+  params: Promise<{ id: string; pageId: string }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const { id: bookIdParam, pageId } = await context.params;
+    const db = await getDb();
+
+    // Same id → slug → ObjectId fallback chain as the quote route.
+    let book = await db.collection('books').findOne({ id: bookIdParam }) as unknown as Book | null;
+    if (!book) {
+      book = await db.collection('books').findOne({ slug: bookIdParam }) as unknown as Book | null;
+    }
+    if (!book && ObjectId.isValid(bookIdParam)) {
+      book = await db.collection('books').findOne({ _id: new ObjectId(bookIdParam) }) as unknown as Book | null;
+    }
+    if (!book || !(await isBookReadable(book, request))) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+
+    const page = await db.collection('pages').findOne(
+      { id: pageId, book_id: book.id },
+      { projection: { id: 1, 'ocr.data': 1, 'translation.data': 1, word_alignment: 1 } },
+    );
+    if (!page) {
+      return NextResponse.json({ error: 'Page not found' }, { status: 404 });
+    }
+
+    // First pass without generation: a cache hit costs nothing and needs no gate.
+    let result = await getOrCreateWordAlignment(db, page as never, book.language || 'the original language', {
+      allowGenerate: false,
+    });
+
+    if (result.status === 'unavailable') {
+      // Cache miss — generation is a paid Gemini call, so gate anonymous volume.
+      const gate = await anonActionGate(request, { name: 'word-alignment', limit: 60 });
+      if (!gate.allowed) {
+        return NextResponse.json(
+          { status: 'rate_limited', retry_after: gate.retryAfter },
+          { status: 429, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : undefined },
+        );
+      }
+      result = await getOrCreateWordAlignment(db, page as never, book.language || 'the original language', {
+        allowGenerate: true,
+      });
+    }
+
+    if (result.status !== 'ready') {
+      return NextResponse.json({ status: result.status }, {
+        headers: { 'Cache-Control': 'no-store' },
+      });
+    }
+
+    return NextResponse.json(
+      {
+        status: 'ready',
+        version: result.alignment.version,
+        model: result.alignment.model,
+        pairs: result.alignment.pairs,
+      },
+      // Immutable per text revision (hash-keyed), so let the browser hold it.
+      { headers: { 'Cache-Control': 'private, max-age=3600' } },
+    );
+  } catch (error) {
+    console.error('Error serving word alignment:', error);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -26,9 +26,11 @@ import {
   BookOpen,
   Save,
   AlertCircle,
+  Crosshair,
 } from 'lucide-react';
 import { useReaderPreferences } from '@/hooks/useReaderPreferences';
 import NotesRenderer from '@/components/reader/NotesRenderer';
+import TraceAlignment, { type TraceStatus } from '@/components/reader/TraceAlignment';
 import AiBadge from '@/components/ui/AiBadge';
 import { MANUSCRIPT_OCR_FLAG } from '@/lib/marcianus-overlay.shared';
 import { usePairedEdition } from '@/hooks/usePairedEdition';
@@ -591,6 +593,27 @@ export default function TranslationEditor({
   // no separate band. See .claude/docs/edition-facsimile-pairing.md.
   const paired = usePairedEdition(book.id, page.id, page.page_number);
   const [pageInputValue, setPageInputValue] = useState('');
+
+  // Trace mode (#3091): click a phrase in the translation, see the aligned
+  // span highlighted in the original-language OCR (and vice versa). Only
+  // meaningful when a genuine cross-language pair is on screen — hidden for
+  // English books, the Spanish edition view, modernized mode, paired critical
+  // editions, and edit mode (offsets are computed against the canonical
+  // English translation + OCR).
+  const [traceMode, setTraceMode] = useState(false);
+  const [traceStatus, setTraceStatus] = useState<TraceStatus>('idle');
+  const isSpanishView = translationLang.startsWith('es') || translationLang.includes('span');
+  const traceEligible = !paired && !isEnglishBook && !isSpanishView && !modernizedMode
+    && mode === 'read' && !!ocrText && !!translationText && showTranslationPanel;
+
+  useEffect(() => {
+    if (!traceMode) return;
+    if (traceStatus === 'unavailable') {
+      toast.info("Tracing isn't available for this page.");
+    } else if (traceStatus === 'rate_limited') {
+      toast.info('Tracing limit reached — sign in (free) to keep going.');
+    }
+  }, [traceStatus, traceMode]);
 
   const previousPage = currentIndex > 0 ? pages[currentIndex - 1] : null;
   const nextPage = currentIndex < pages.length - 1 ? pages[currentIndex + 1] : null;
@@ -1789,6 +1812,26 @@ export default function TranslationEditor({
                     </div>
                     {translationText && (
                       <div className="flex items-center gap-2">
+                        {traceEligible && (
+                          <button
+                            onClick={() => {
+                              const next = !traceMode;
+                              setTraceMode(next);
+                              // Tracing needs both panes on screen.
+                              if (next && !showOcrPanel) setShowOcrPanel(true);
+                            }}
+                            className={`flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors ${traceMode
+                              ? 'bg-accent-gold/15 text-accent-gold-dark hover:bg-accent-gold/25'
+                              : 'bg-stone-100 text-stone-400 hover:bg-stone-200'
+                              }`}
+                            title={traceMode
+                              ? 'Turn off tracing'
+                              : `Trace: click any phrase to see it in the ${book.language || 'original'}`}
+                          >
+                            <Crosshair className={`w-3 h-3 ${traceMode && traceStatus === 'loading' ? 'animate-pulse' : ''}`} />
+                            Trace
+                          </button>
+                        )}
                         <button
                           onClick={() => setShowNotes(prev => !prev)}
                           className={`flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors ${showNotes
@@ -2048,7 +2091,13 @@ export default function TranslationEditor({
           />
         )}
 
-
+        {/* Trace mode: OCR↔translation span highlighting (#3091) */}
+        <TraceAlignment
+          bookId={book.id}
+          pageId={page.id}
+          active={traceMode && traceEligible}
+          onStatusChange={setTraceStatus}
+        />
       </div>
     );
   }
@@ -2630,6 +2679,7 @@ export default function TranslationEditor({
           onClose={() => setShowPageMetadata(false)}
         />
       )}
+
     </div>
   );
 }

--- a/src/components/reader/TraceAlignment.tsx
+++ b/src/components/reader/TraceAlignment.tsx
@@ -1,0 +1,401 @@
+'use client';
+
+/**
+ * Reader trace mode (issue #3091): with trace on, clicking a phrase in the
+ * translation pane highlights the span of the original-language OCR that
+ * produced it (and vice versa). Alignment pairs come from
+ * /api/books/[id]/pages/[pageId]/alignment — one cached flash-lite call per
+ * page, span strings verbatim from the wrapper-stripped page text.
+ *
+ * Highlighting uses the CSS Custom Highlight API so we never mutate the DOM
+ * that React (NotesRenderer) owns. Spans are located in the rendered DOM by
+ * whitespace-normalized text search (src/lib/align-text.ts) — the same code
+ * path the server used to verify the spans, so anything stored is findable
+ * unless the renderer transformed it (tables, hidden notes), in which case a
+ * click is a graceful no-op.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import { normalizeForSearch, locateSpan, type NormalizedText } from '@/lib/align-text';
+import type { AlignmentPair } from '@/lib/word-alignment';
+
+interface TraceAlignmentProps {
+  bookId: string;
+  pageId: string;
+  active: boolean;
+  /** Reported so the toggle can show loading / explain unavailability. */
+  onStatusChange?: (status: TraceStatus) => void;
+}
+
+export type TraceStatus = 'idle' | 'loading' | 'ready' | 'unavailable' | 'rate_limited';
+
+type Side = 'ocr' | 'translation';
+
+interface PaneMap {
+  /** Concatenated text of all text nodes in the pane. */
+  text: string;
+  norm: NormalizedText;
+  /** Text nodes with their cumulative start offsets into `text`. */
+  nodes: Array<{ node: Text; start: number }>;
+}
+
+const HIGHLIGHT_PRIMARY = 'sl-trace-primary';
+const HIGHLIGHT_COUNTERPART = 'sl-trace-counterpart';
+
+function highlightsSupported(): boolean {
+  return typeof window !== 'undefined'
+    && typeof (window as unknown as { Highlight?: unknown }).Highlight === 'function'
+    && !!(CSS as unknown as { highlights?: unknown }).highlights;
+}
+
+function getPaneEl(side: Side): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    `[data-reader-section="${side}"] [data-reader-panel]`,
+  );
+}
+
+function buildPaneMap(pane: HTMLElement): PaneMap {
+  const walker = document.createTreeWalker(pane, NodeFilter.SHOW_TEXT);
+  const nodes: Array<{ node: Text; start: number }> = [];
+  let text = '';
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    nodes.push({ node: n as Text, start: text.length });
+    text += (n as Text).data;
+  }
+  return { text, norm: normalizeForSearch(text), nodes };
+}
+
+/** Map a raw offset in the pane's concatenated text to a DOM point. */
+function offsetToPoint(map: PaneMap, offset: number): { node: Text; offset: number } | null {
+  let lo = 0, hi = map.nodes.length - 1, best = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (map.nodes[mid].start <= offset) { best = mid; lo = mid + 1; } else { hi = mid - 1; }
+  }
+  if (best === -1) return null;
+  const entry = map.nodes[best];
+  return { node: entry.node, offset: Math.min(offset - entry.start, entry.node.data.length) };
+}
+
+function rangeFromOffsets(map: PaneMap, start: number, end: number): Range | null {
+  const a = offsetToPoint(map, start);
+  const b = offsetToPoint(map, Math.max(start, end - 1));
+  if (!a || !b) return null;
+  const range = document.createRange();
+  range.setStart(a.node, a.offset);
+  range.setEnd(b.node, Math.min(b.offset + 1, b.node.data.length));
+  return range;
+}
+
+/** Raw offset in the concatenated pane text of a (textNode, offset) DOM point. */
+function pointToOffset(map: PaneMap, node: Node, offset: number): number | null {
+  const entry = map.nodes.find((e) => e.node === node);
+  if (!entry) return null;
+  return entry.start + offset;
+}
+
+/** Raw offset → offset in the normalized string (largest normIdx whose rawIdx ≤ raw). */
+function rawToNorm(norm: NormalizedText, raw: number): number {
+  let lo = 0, hi = norm.rawIdx.length - 1, best = 0;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (norm.rawIdx[mid] <= raw) { best = mid; lo = mid + 1; } else { hi = mid - 1; }
+  }
+  return best;
+}
+
+interface PairInterval {
+  pairIndex: number;
+  start: number;      // raw offsets in pane text
+  end: number;
+  normStart: number;
+}
+
+/**
+ * Locate every pair's span on one side of the rendered DOM, walking in
+ * stored-offset order with a moving cursor so repeated phrases bind to
+ * successive occurrences (mirrors resolveAlignmentPairs on the server).
+ */
+function locatePairIntervals(map: PaneMap, pairs: AlignmentPair[], side: Side): PairInterval[] {
+  const order = pairs
+    .map((_, i) => i)
+    .sort((a, b) => (side === 'ocr' ? pairs[a].so - pairs[b].so : pairs[a].to - pairs[b].to));
+  const out: PairInterval[] = [];
+  let cursor = 0;
+  for (const i of order) {
+    const span = side === 'ocr' ? pairs[i].s : pairs[i].t;
+    const hit = locateSpan(map.norm, span, cursor);
+    if (!hit) continue;
+    cursor = hit.normStart + 1;
+    out.push({ pairIndex: i, start: hit.start, end: hit.end, normStart: hit.normStart });
+  }
+  return out;
+}
+
+function caretFromPoint(x: number, y: number): { node: Node; offset: number } | null {
+  const doc = document as Document & {
+    caretRangeFromPoint?: (x: number, y: number) => Range | null;
+    caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+  };
+  if (doc.caretRangeFromPoint) {
+    const r = doc.caretRangeFromPoint(x, y);
+    return r ? { node: r.startContainer, offset: r.startOffset } : null;
+  }
+  if (doc.caretPositionFromPoint) {
+    const p = doc.caretPositionFromPoint(x, y);
+    return p ? { node: p.offsetNode, offset: p.offset } : null;
+  }
+  return null;
+}
+
+function setHighlight(name: string, range: Range | null) {
+  if (!highlightsSupported()) return;
+  const registry = (CSS as unknown as { highlights: Map<string, unknown> }).highlights;
+  if (range) {
+    const HighlightCtor = (window as unknown as { Highlight: new (...r: Range[]) => unknown }).Highlight;
+    registry.set(name, new HighlightCtor(range));
+  } else {
+    registry.delete(name);
+  }
+}
+
+function clearHighlights() {
+  setHighlight(HIGHLIGHT_PRIMARY, null);
+  setHighlight(HIGHLIGHT_COUNTERPART, null);
+}
+
+/** Scroll a range to the vertical center of its pane's scroll container. */
+function scrollRangeIntoPane(pane: HTMLElement, range: Range) {
+  const rect = range.getBoundingClientRect();
+  const paneRect = pane.getBoundingClientRect();
+  // Desktop panes are their own scroll containers; on mobile the window
+  // scrolls. Handle both by adjusting whichever actually overflows.
+  if (pane.scrollHeight > pane.clientHeight + 4) {
+    pane.scrollTo({
+      top: pane.scrollTop + (rect.top - paneRect.top) - pane.clientHeight / 2 + rect.height / 2,
+      behavior: 'smooth',
+    });
+  } else {
+    window.scrollTo({
+      top: window.scrollY + rect.top - window.innerHeight / 2 + rect.height / 2,
+      behavior: 'smooth',
+    });
+  }
+}
+
+interface SheetState {
+  /** The counterpart snippet to show (original text when English clicked, and vice versa). */
+  snippet: string;
+  counterpartSide: Side;
+  scrollTo: () => void;
+}
+
+export default function TraceAlignment({ bookId, pageId, active, onStatusChange }: TraceAlignmentProps) {
+  const [pairs, setPairs] = useState<AlignmentPair[] | null>(null);
+  const [status, setStatusRaw] = useState<TraceStatus>('idle');
+  const [sheet, setSheet] = useState<SheetState | null>(null);
+  const statusRef = useRef<TraceStatus>('idle');
+  const pairsRef = useRef<AlignmentPair[] | null>(null);
+
+  const setStatus = useCallback((s: TraceStatus) => {
+    statusRef.current = s;
+    setStatusRaw(s);
+    onStatusChange?.(s);
+  }, [onStatusChange]);
+
+  // Fetch alignment when trace turns on or the page changes.
+  useEffect(() => {
+    setPairs(null);
+    pairsRef.current = null;
+    setSheet(null);
+    clearHighlights();
+    if (!active) {
+      setStatus('idle');
+      return;
+    }
+    const controller = new AbortController();
+    setStatus('loading');
+    fetch(`/api/books/${bookId}/pages/${pageId}/alignment`, { signal: controller.signal })
+      .then((res) => (res.status === 429 ? { status: 'rate_limited' } : res.json()))
+      .then((data: { status: string; pairs?: AlignmentPair[] }) => {
+        if (data.status === 'ready' && data.pairs && data.pairs.length > 0) {
+          setPairs(data.pairs);
+          pairsRef.current = data.pairs;
+          setStatus('ready');
+        } else if (data.status === 'rate_limited') {
+          setStatus('rate_limited');
+        } else {
+          setStatus('unavailable');
+        }
+      })
+      .catch((e) => {
+        if (e?.name !== 'AbortError') setStatus('unavailable');
+      });
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, bookId, pageId]);
+
+  // Click handling: one document-level listener, resilient to pane re-renders.
+  useEffect(() => {
+    if (!active) return;
+
+    const handleClick = (e: MouseEvent) => {
+      if (statusRef.current !== 'ready' || !pairsRef.current) return;
+      // Never fight a real text selection (quote/share flows).
+      const sel = window.getSelection();
+      if (sel && !sel.isCollapsed) return;
+
+      const target = e.target as HTMLElement | null;
+      const panel = target?.closest?.('[data-reader-panel]');
+      const section = target?.closest?.('[data-reader-section]') as HTMLElement | null;
+      const side = section?.dataset.readerSection as Side | undefined;
+      if (!panel || !side || (side !== 'ocr' && side !== 'translation')) return;
+      // Ignore clicks on interactive elements inside the panes.
+      if (target?.closest('a, button, summary, input, textarea')) return;
+
+      const clickedPane = getPaneEl(side);
+      const otherSide: Side = side === 'ocr' ? 'translation' : 'ocr';
+      const otherPane = getPaneEl(otherSide);
+      if (!clickedPane) return;
+
+      const caret = caretFromPoint(e.clientX, e.clientY);
+      if (!caret) return;
+
+      const clickedMap = buildPaneMap(clickedPane);
+      const rawOffset = pointToOffset(clickedMap, caret.node, caret.offset);
+      if (rawOffset == null) return;
+
+      const currentPairs = pairsRef.current;
+      const intervals = locatePairIntervals(clickedMap, currentPairs, side);
+      const normOffset = rawToNorm(clickedMap.norm, rawOffset);
+
+      // Prefer the SHORTEST interval containing the click (most specific
+      // phrase); fall back to the nearest interval within ~60 chars.
+      let hit: PairInterval | null = null;
+      for (const iv of intervals) {
+        const normEnd = iv.normStart + (iv.end - iv.start); // approximate but adequate
+        if (normOffset >= iv.normStart && normOffset <= normEnd) {
+          if (!hit || iv.end - iv.start < hit.end - hit.start) hit = iv;
+        }
+      }
+      if (!hit) {
+        let bestDist = 60;
+        for (const iv of intervals) {
+          const dist = normOffset < iv.normStart
+            ? iv.normStart - normOffset
+            : normOffset - (iv.normStart + (iv.end - iv.start));
+          if (dist < bestDist) { bestDist = dist; hit = iv; }
+        }
+      }
+      if (!hit) {
+        clearHighlights();
+        setSheet(null);
+        return;
+      }
+
+      const pair = currentPairs[hit.pairIndex];
+      const primaryRange = rangeFromOffsets(clickedMap, hit.start, hit.end);
+      setHighlight(HIGHLIGHT_PRIMARY, primaryRange);
+
+      // Locate the counterpart span in the other pane (may be hidden on
+      // mobile-collapsed layouts or missing — then we still show the sheet).
+      let counterRange: Range | null = null;
+      let counterPaneEl: HTMLElement | null = null;
+      if (otherPane) {
+        const otherMap = buildPaneMap(otherPane);
+        const otherIntervals = locatePairIntervals(otherMap, currentPairs, otherSide);
+        const counter = otherIntervals.find((iv) => iv.pairIndex === hit!.pairIndex);
+        if (counter) {
+          counterRange = rangeFromOffsets(otherMap, counter.start, counter.end);
+          counterPaneEl = otherPane;
+        }
+      }
+      setHighlight(HIGHLIGHT_COUNTERPART, counterRange);
+
+      const counterpartText = side === 'translation' ? pair.s : pair.t;
+      const isDesktop = window.matchMedia('(min-width: 1024px)').matches;
+      const doScroll = () => {
+        if (counterRange && counterPaneEl) scrollRangeIntoPane(counterPaneEl, counterRange);
+      };
+
+      if (isDesktop && counterRange && highlightsSupported()) {
+        setSheet(null);
+        doScroll();
+      } else {
+        // Mobile (stacked panes — don't yank the reader away), or no
+        // highlight support: show the counterpart in a bottom sheet.
+        setSheet({ snippet: counterpartText, counterpartSide: otherSide, scrollTo: doScroll });
+      }
+    };
+
+    document.addEventListener('click', handleClick);
+    return () => {
+      document.removeEventListener('click', handleClick);
+      clearHighlights();
+      setSheet(null);
+    };
+  }, [active, pageId]);
+
+  if (!active) return null;
+
+  return (
+    <>
+      {/* ::highlight() rules live here (not globals.css): Next's CSS processor
+          rejects the Custom Highlight API pseudo-element. Gold family from the
+          /blog/word-alignment demo; primary = clicked span, counterpart = the
+          aligned span in the other pane. */}
+      <style>{`
+        ::highlight(${HIGHLIGHT_PRIMARY}) {
+          background-color: rgba(160, 120, 40, 0.22);
+        }
+        ::highlight(${HIGHLIGHT_COUNTERPART}) {
+          background-color: rgba(160, 120, 40, 0.38);
+          text-decoration: underline;
+          text-decoration-color: rgba(160, 120, 40, 0.85);
+          text-decoration-thickness: 2px;
+        }
+      `}</style>
+      {sheet && (
+    <div
+      className="fixed inset-x-0 bottom-0 z-50 px-3 pb-3 lg:left-auto lg:right-6 lg:max-w-md"
+      role="dialog"
+      aria-label={sheet.counterpartSide === 'ocr' ? 'Original text' : 'Translation'}
+    >
+      <div
+        className="rounded-xl border shadow-lg p-4"
+        style={{ background: 'var(--bg-white)', borderColor: 'var(--border-light)' }}
+      >
+        <div className="flex items-start justify-between gap-3 mb-2">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.15em]" style={{ color: 'var(--text-muted)' }}>
+            {sheet.counterpartSide === 'ocr' ? 'In the original' : 'In the translation'}
+          </span>
+          <button
+            onClick={() => { setSheet(null); clearHighlights(); }}
+            className="p-1 rounded hover:bg-stone-100"
+            style={{ color: 'var(--text-muted)' }}
+            aria-label="Dismiss"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        <p className="font-serif text-[15px] leading-relaxed" style={{ color: 'var(--text-primary)' }}>
+          {sheet.snippet}
+        </p>
+        <button
+          onClick={() => {
+            const sectionEl = document.querySelector(`[data-reader-section="${sheet.counterpartSide}"]`);
+            sectionEl?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            sheet.scrollTo();
+          }}
+          className="mt-3 text-xs font-medium hover:underline"
+          style={{ color: 'var(--accent-gold-dark, #a07828)' }}
+        >
+          Show in place →
+        </button>
+      </div>
+    </div>
+      )}
+    </>
+  );
+}

--- a/src/lib/align-text.ts
+++ b/src/lib/align-text.ts
@@ -1,0 +1,148 @@
+/**
+ * Pure text utilities for word-level alignment (issue #3091).
+ *
+ * Shared by the server-side span resolver (src/lib/word-alignment.ts) and the
+ * client-side trace layer (src/components/reader/TraceAlignment.tsx), which
+ * both need to answer the same question: "where does this quoted span sit in
+ * this larger text?" — robustly against the ways an LLM (or a renderer)
+ * lawfully differs from the stored page text.
+ *
+ * The folds are SYMMETRIC (applied to both haystack and needle), so they can
+ * be aggressive without breaking genuine usage: measured on real pages, the
+ * model quoting early-modern Latin routinely
+ *   - expands scribal abbreviations (nõ → non, Creatorẽ → Creatorem),
+ *   - normalizes long ſ to s (or misreads it as f),
+ *   - joins end-of-line hyphenations (reſurrectio-\nnem → reſurrectionem),
+ *   - drops accents (cùm → cum),
+ * each of which broke exact matching for ~half of all pairs.
+ *
+ * Kept dependency-free so it is safe to import from client bundles.
+ */
+
+export interface NormalizedText {
+  /** Folded, whitespace-collapsed text used for searching. */
+  norm: string;
+  /** rawIdx[i] = offset in the ORIGINAL string of the char behind norm[i]. */
+  rawIdx: number[];
+}
+
+/** Early-modern nasal abbreviations: tilde vowel = vowel + n. */
+const TILDE_VOWELS: Record<string, string> = {
+  'ã': 'an', 'ẽ': 'en', 'ĩ': 'in', 'õ': 'on', 'ũ': 'un',
+};
+
+/** Single-char ligatures NFD won't decompose. */
+const LIGATURES: Record<string, string> = {
+  'æ': 'ae', 'œ': 'oe', 'ﬀ': 'ff', 'ﬁ': 'fi', 'ﬂ': 'fl', 'ﬃ': 'ffi', 'ﬄ': 'ffl', 'ß': 'ss',
+};
+
+/**
+ * Fold one char to its normalized form (possibly several chars).
+ * Order matters: tilde-vowel expansion must run before diacritic stripping,
+ * or `õ` would collapse to plain `o` and lose its `n`.
+ */
+function foldChar(ch: string): string {
+  const lower = ch.toLowerCase();
+  const base = lower.length === 1 ? lower : ch;
+  if (TILDE_VOWELS[base]) return TILDE_VOWELS[base];
+  if (LIGATURES[base]) return LIGATURES[base];
+  if (base === 'ſ') return 's';
+  // Strip combining diacritics (cùm → cum). Multi-char decompositions of a
+  // genuinely different letter (rare) fall back to the original char.
+  const stripped = base.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  return stripped.length >= 1 ? stripped : base;
+}
+
+const WS = /\s/;
+
+/**
+ * Normalize a string for alignment search, keeping a map from each folded
+ * char back to its raw offset:
+ * - whitespace runs collapse to a single space,
+ * - end-of-line hyphenations disappear (`letter-` + whitespace → joined),
+ * - chars fold per foldChar (case, ligatures, abbreviations, diacritics).
+ */
+export function normalizeForSearch(raw: string): NormalizedText {
+  const chars: string[] = [];
+  const rawIdx: number[] = [];
+  let inWs = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (WS.test(ch)) {
+      if (!inWs && chars.length > 0) {
+        chars.push(' ');
+        rawIdx.push(i);
+      }
+      inWs = true;
+      continue;
+    }
+    // Dehyphenation: a hyphen glued to a word end and followed by whitespace
+    // is a line-break artifact — drop it AND the whitespace so the two halves
+    // join ("reſurrectio-\nnem" → "reſurrectionem"). A spaced dash (" - ")
+    // survives because the preceding char is whitespace.
+    if ((ch === '-' || ch === '\u00AD') && i + 1 < raw.length && WS.test(raw[i + 1]) && i > 0 && !WS.test(raw[i - 1])) {
+      while (i + 1 < raw.length && WS.test(raw[i + 1])) i++;
+      inWs = false;
+      continue;
+    }
+    const folded = foldChar(ch);
+    for (const f of folded) {
+      chars.push(f);
+      rawIdx.push(i);
+    }
+    inWs = false;
+  }
+  // Trim a trailing collapsed space so spans never end on padding.
+  if (chars[chars.length - 1] === ' ') {
+    chars.pop();
+    rawIdx.pop();
+  }
+  return { norm: chars.join(''), rawIdx };
+}
+
+/** Normalize a needle the same way normalizeForSearch treats the haystack. */
+export function normalizeNeedle(span: string): string {
+  const n = normalizeForSearch(span);
+  return n.norm.trim();
+}
+
+export interface LocatedSpan {
+  /** Raw-offset range [start, end) in the original string. */
+  start: number;
+  end: number;
+  /** Where the match begins in the normalized string (for cursor movement). */
+  normStart: number;
+}
+
+function indexWithFallback(norm: string, needle: string, fromNorm: number): number {
+  let at = norm.indexOf(needle, Math.max(0, fromNorm));
+  if (at === -1 && fromNorm > 0) at = norm.indexOf(needle);
+  return at;
+}
+
+/**
+ * Find `span` inside a normalized haystack, preferring the first occurrence
+ * at/after `fromNorm` (occurrence disambiguation for repeated phrases) and
+ * falling back to a global search. Returns raw offsets into the original
+ * string, or null when the span cannot be found.
+ *
+ * Second chance: models misread long ſ as `f` ("aduerſus" quoted as
+ * "aduerfus"). On a miss, retry with the needle's f folded to s — safe
+ * because the rest of the phrase still has to anchor the match exactly.
+ */
+export function locateSpan(
+  hay: NormalizedText,
+  span: string,
+  fromNorm = 0,
+): LocatedSpan | null {
+  const needle = normalizeNeedle(span);
+  if (!needle || needle.length < 2) return null;
+  let at = indexWithFallback(hay.norm, needle, fromNorm);
+  if (at === -1 && needle.includes('f')) {
+    at = indexWithFallback(hay.norm, needle.replace(/f/g, 's'), fromNorm);
+  }
+  if (at === -1) return null;
+  const start = hay.rawIdx[at];
+  const end = hay.rawIdx[at + needle.length - 1] + 1;
+  return { start, end, normStart: at };
+}

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -42,6 +42,11 @@ export interface Page {
     scored_at: Date;
   };
 
+  // Span-level OCR↔translation alignment for reader trace mode (#3091).
+  // Cached lazily; hash-invalidated when either text changes.
+  // Canonical type: WordAlignmentData in src/lib/word-alignment.ts.
+  word_alignment?: import('@/lib/word-alignment').WordAlignmentData;
+
   // Page classification from OCR (title-page, frontispiece, toc, etc.)
   page_type?: string;
 

--- a/src/lib/word-alignment.ts
+++ b/src/lib/word-alignment.ts
@@ -1,0 +1,261 @@
+/**
+ * Word/phrase-level OCR↔translation alignment (issue #3091).
+ *
+ * Powers the reader's "trace" mode: click a phrase in the English translation
+ * and the corresponding span lights up in the original-language OCR (and vice
+ * versa). One cheap flash-lite call per page, generated lazily the first time
+ * any reader asks, then cached forever on the page document as
+ * `pages.word_alignment`.
+ *
+ * Distinct from src/lib/semantic-alignment.ts, which scores whole-page
+ * OCR↔translation similarity for QA — this module produces the span-level
+ * pairs a reader can interact with.
+ *
+ * Invariants:
+ * - Both texts are passed through stripEditorialWrappers() BEFORE alignment,
+ *   so a pair can never map into <meta>/<summary> editorial prose (the #2232
+ *   misquote family). Span strings stored here are verbatim slices of the
+ *   STRIPPED text.
+ * - `ocr_hash`/`translation_hash` are sha256 of the stripped texts; a page
+ *   edit or re-OCR self-invalidates the cache on the next read (same pattern
+ *   as TransliterationData.source_ocr_hash).
+ */
+
+import { createHash } from 'crypto';
+import type { Db } from 'mongodb';
+import { GoogleGenerativeAI, SchemaType } from '@google/generative-ai';
+import { stripEditorialWrappers } from './strip-editorial-wrappers';
+import { normalizeForSearch, locateSpan } from './align-text';
+import { logGeminiCall } from './gemini-logger';
+
+export const WORD_ALIGNMENT_VERSION = 1;
+const ALIGNMENT_MODEL = 'gemini-3.1-flash-lite';
+// A page of early-modern print is ~2-4K chars; anything past this is an
+// outlier (indexes, dense tables) where alignment adds little. Truncating
+// bounds cost and keeps the model focused.
+const MAX_TEXT_CHARS = 20000;
+
+export interface AlignmentPair {
+  /** Verbatim span of the stripped SOURCE (OCR) text. */
+  s: string;
+  /** Verbatim span of the stripped TRANSLATION text. */
+  t: string;
+  /** Char offset of `s` in the stripped source (occurrence disambiguation). */
+  so: number;
+  /** Char offset of `t` in the stripped translation. */
+  to: number;
+}
+
+export interface WordAlignmentData {
+  version: number;
+  model: string;
+  created_at: Date;
+  /** sha256 of the STRIPPED ocr text this alignment was computed from. */
+  ocr_hash: string;
+  /** sha256 of the STRIPPED translation text. */
+  translation_hash: string;
+  pairs: AlignmentPair[];
+}
+
+export type AlignmentResult =
+  | { status: 'ready'; alignment: WordAlignmentData }
+  | { status: 'missing_text' }   // page lacks OCR or translation
+  | { status: 'unavailable' };   // generation not allowed/failed this request
+
+export function hashAlignmentText(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+interface PageLike {
+  id: string;
+  ocr?: { data?: string };
+  translation?: { data?: string };
+  word_alignment?: WordAlignmentData;
+}
+
+/**
+ * Resolve the model's quoted span pairs to verified offsets in the stripped
+ * texts. Pairs whose spans can't be found (hallucinated or mangled quotes)
+ * are dropped — every stored pair is guaranteed to be locatable text.
+ * Exported for unit tests.
+ */
+export function resolveAlignmentPairs(
+  rawPairs: Array<{ src?: string; en?: string }>,
+  sourceText: string,
+  translationText: string,
+): AlignmentPair[] {
+  const srcNorm = normalizeForSearch(sourceText);
+  const trNorm = normalizeForSearch(translationText);
+  const out: AlignmentPair[] = [];
+  let srcCursor = 0;
+  let trCursor = 0;
+  for (const p of rawPairs) {
+    if (!p?.src || !p?.en) continue;
+    const s = locateSpan(srcNorm, p.src, srcCursor);
+    if (!s) continue;
+    const t = locateSpan(trNorm, p.en, trCursor);
+    if (!t) continue;
+    // Advance cursors past the START (not end) of each match so overlapping
+    // or nested spans from the model still resolve, while repeated phrases
+    // bind to successive occurrences.
+    srcCursor = s.normStart + 1;
+    trCursor = t.normStart + 1;
+    out.push({
+      s: sourceText.slice(s.start, s.end),
+      t: translationText.slice(t.start, t.end),
+      so: s.start,
+      to: t.start,
+    });
+  }
+  return out;
+}
+
+async function generatePairs(
+  sourceText: string,
+  translationText: string,
+  language: string,
+): Promise<Array<{ src: string; en: string }>> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error('No GEMINI_API_KEY configured');
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({
+    model: ALIGNMENT_MODEL,
+    generationConfig: {
+      temperature: 0,
+      responseMimeType: 'application/json',
+      responseSchema: {
+        type: SchemaType.OBJECT,
+        properties: {
+          pairs: {
+            type: SchemaType.ARRAY,
+            items: {
+              type: SchemaType.OBJECT,
+              properties: {
+                src: { type: SchemaType.STRING },
+                en: { type: SchemaType.STRING },
+              },
+              required: ['src', 'en'],
+            },
+          },
+        },
+        required: ['pairs'],
+      },
+    },
+  });
+
+  const prompt = `You are aligning a page of a historical ${language} text with its English translation.
+
+SOURCE (${language}):
+<<<
+${sourceText}
+>>>
+
+TRANSLATION (English):
+<<<
+${translationText}
+>>>
+
+Produce phrase-level alignment pairs mapping spans of the SOURCE to the spans of the TRANSLATION that render them.
+
+Rules:
+- "src" must be copied EXACTLY, character for character, from SOURCE (including line breaks, ligatures, and archaic spellings such as long s). "en" must be copied EXACTLY from TRANSLATION. Never translate, correct, or paraphrase — only copy.
+- Be EXHAUSTIVE: work through the SOURCE from its first word to its last, and cover every sentence with pairs. Do not stop early and do not skip sentences.
+- Prefer short spans: a clause, a noun phrase, or a key term (roughly 1-8 words). Break every sentence into several small pairs rather than one big pair.
+- Skip only page numbers, catchwords, signature marks, and text with no counterpart in the other text.`;
+
+  const result = await model.generateContent(prompt);
+  const parsed = JSON.parse(result.response.text()) as {
+    pairs?: Array<{ src: string; en: string }>;
+  };
+  return Array.isArray(parsed.pairs) ? parsed.pairs : [];
+}
+
+/**
+ * Return the cached alignment for a page, or (when `allowGenerate`) create,
+ * store, and return it. An empty `pairs` array is a valid cached result —
+ * "we tried, nothing aligned" — so a hopeless page is only ever paid for once
+ * per text revision.
+ */
+export async function getOrCreateWordAlignment(
+  db: Db,
+  page: PageLike,
+  language: string,
+  opts: { allowGenerate: boolean },
+): Promise<AlignmentResult> {
+  const ocrRaw = page.ocr?.data || '';
+  const translationRaw = page.translation?.data || '';
+  if (!ocrRaw.trim() || !translationRaw.trim()) return { status: 'missing_text' };
+
+  const sourceText = stripEditorialWrappers(ocrRaw).slice(0, MAX_TEXT_CHARS);
+  const translationText = stripEditorialWrappers(translationRaw).slice(0, MAX_TEXT_CHARS);
+  if (!sourceText.trim() || !translationText.trim()) return { status: 'missing_text' };
+
+  const ocrHash = hashAlignmentText(sourceText);
+  const translationHash = hashAlignmentText(translationText);
+
+  const stored = page.word_alignment;
+  if (
+    stored &&
+    stored.version === WORD_ALIGNMENT_VERSION &&
+    stored.ocr_hash === ocrHash &&
+    stored.translation_hash === translationHash
+  ) {
+    return { status: 'ready', alignment: stored };
+  }
+
+  if (!opts.allowGenerate || process.env.WORD_ALIGNMENT_ENABLED === '0') {
+    return { status: 'unavailable' };
+  }
+
+  const startTime = Date.now();
+  let rawPairs: Array<{ src: string; en: string }>;
+  try {
+    rawPairs = await generatePairs(sourceText, translationText, language);
+  } catch (e) {
+    await logGeminiCall({
+      type: 'other',
+      mode: 'realtime',
+      model: ALIGNMENT_MODEL,
+      input_tokens: 0,
+      output_tokens: 0,
+      status: 'failed',
+      duration_ms: Date.now() - startTime,
+      prompt_version: `word-alignment-v${WORD_ALIGNMENT_VERSION}`,
+      endpoint: 'word-alignment',
+      error_message: e instanceof Error ? e.message : String(e),
+    }).catch(() => {});
+    return { status: 'unavailable' };
+  }
+
+  const pairs = resolveAlignmentPairs(rawPairs, sourceText, translationText);
+  // One line per page EVER (results are cached) — kept as a resolution-rate
+  // canary: a big raw→resolved drop means the model is misquoting spans.
+  console.log(`word-alignment: page ${page.id} raw=${rawPairs.length} resolved=${pairs.length}`);
+  const alignment: WordAlignmentData = {
+    version: WORD_ALIGNMENT_VERSION,
+    model: ALIGNMENT_MODEL,
+    created_at: new Date(),
+    ocr_hash: ocrHash,
+    translation_hash: translationHash,
+    pairs,
+  };
+
+  await db.collection('pages').updateOne(
+    { id: page.id },
+    { $set: { word_alignment: alignment } },
+  );
+
+  await logGeminiCall({
+    type: 'other',
+    mode: 'realtime',
+    model: ALIGNMENT_MODEL,
+    input_tokens: Math.round((sourceText.length + translationText.length) / 4),
+    output_tokens: Math.round(JSON.stringify(rawPairs).length / 4),
+    status: 'success',
+    duration_ms: Date.now() - startTime,
+    prompt_version: `word-alignment-v${WORD_ALIGNMENT_VERSION}`,
+    endpoint: 'word-alignment',
+  }).catch(() => {});
+
+  return { status: 'ready', alignment };
+}

--- a/tests/unit/word-alignment-resolve.test.ts
+++ b/tests/unit/word-alignment-resolve.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeForSearch, normalizeNeedle, locateSpan } from '@/lib/align-text';
+import { resolveAlignmentPairs } from '@/lib/word-alignment';
+
+// Trace mode (#3091) stores span strings + offsets resolved against the
+// wrapper-stripped page text. Every stored pair must be locatable text —
+// hallucinated or mangled model quotes are dropped, repeated phrases bind to
+// successive occurrences, and whitespace/case differences never break a match.
+
+describe('normalizeForSearch', () => {
+  it('collapses whitespace runs and maps back to raw offsets', () => {
+    const raw = 'PLATO  igitur,\n\nut ab eorum';
+    const n = normalizeForSearch(raw);
+    expect(n.norm).toBe('plato igitur, ut ab eorum');
+    // 'ut' begins at norm index 14 → raw offset of 'u'
+    const utNorm = n.norm.indexOf('ut ab');
+    expect(raw.slice(n.rawIdx[utNorm], n.rawIdx[utNorm] + 2)).toBe('ut');
+  });
+
+  it('never changes length on case folding of special chars', () => {
+    const raw = 'İstanbul VOLUPTAS';
+    const n = normalizeForSearch(raw);
+    expect(n.rawIdx.length).toBe(n.norm.length);
+  });
+
+  // The symmetric folds below were each measured breaking real pairs on a
+  // real page (Drebbel, Tractatus duo): before them, 10 of 19 model pairs
+  // failed to resolve; after, 19 of 19.
+  it('folds long ſ, ligatures, and accents', () => {
+    const n = normalizeForSearch('reſurrectiõem, Animæ, cùm cœleſti');
+    expect(n.norm).toBe('resurrectionem, animae, cum coelesti');
+  });
+
+  it('expands tilde-vowel abbreviations symmetrically', () => {
+    const hay = normalizeForSearch('nõ ſecus ac cœlum');
+    expect(locateSpan(hay, 'non secus ac coelum')).not.toBeNull();
+    expect(locateSpan(hay, 'nõ ſecus ac cœlum')).not.toBeNull();
+  });
+
+  it('joins end-of-line hyphenations but keeps spaced dashes', () => {
+    const hay = normalizeForSearch('reſurrectio-\nnem atque — vitam - I mean');
+    expect(hay.norm).toContain('resurrectionem');
+    expect(locateSpan(hay, 'reſurrectionem atque')).not.toBeNull();
+    // The spaced hyphen in "vitam - I" is a real dash, not a line break.
+    expect(hay.norm).toContain('vitam - i');
+  });
+});
+
+describe('locateSpan', () => {
+  const hay = normalizeForSearch('the spirit moves; the spirit rests; the spirit sleeps');
+
+  it('finds successive occurrences with a moving cursor', () => {
+    const first = locateSpan(hay, 'the spirit');
+    expect(first).not.toBeNull();
+    const second = locateSpan(hay, 'the spirit', first!.normStart + 1);
+    expect(second!.start).toBeGreaterThan(first!.start);
+  });
+
+  it('falls back to a global search when the cursor overshoots', () => {
+    const hit = locateSpan(hay, 'the spirit moves', 40);
+    expect(hit).not.toBeNull();
+    expect(hit!.start).toBe(0);
+  });
+
+  it('matches across case and whitespace differences', () => {
+    const h = normalizeForSearch('MENTI laeticiam &\ngaudium attribuit');
+    expect(locateSpan(h, 'menti laeticiam & gaudium')).not.toBeNull();
+  });
+
+  it('returns null for absent spans', () => {
+    expect(locateSpan(hay, 'voluptatem')).toBeNull();
+  });
+
+  it('retries with f→s for long-ſ misreads', () => {
+    const h = normalizeForSearch('Spiritûs militatem aduerſus Corpus');
+    const hit = locateSpan(h, 'militatem aduerfus Corpus');
+    expect(hit).not.toBeNull();
+  });
+});
+
+describe('normalizeNeedle', () => {
+  it('collapses internal whitespace and trims', () => {
+    expect(normalizeNeedle('  menti\n laeticiam ')).toBe('menti laeticiam');
+  });
+});
+
+describe('resolveAlignmentPairs', () => {
+  const source =
+    'PLATO igitur, cum animum in duas partes distribuisset, ' +
+    'menti laeticiam & gaudium attribuit, sensibus voluptatem.';
+  const translation =
+    'Plato, therefore, when he had divided the soul into two parts, ' +
+    'attributed gladness and joy to the mind, pleasure to the senses.';
+
+  it('resolves verbatim spans to raw slices with offsets', () => {
+    const pairs = resolveAlignmentPairs(
+      [
+        { src: 'PLATO igitur', en: 'Plato, therefore' },
+        { src: 'sensibus voluptatem', en: 'pleasure to the senses' },
+      ],
+      source,
+      translation,
+    );
+    expect(pairs).toHaveLength(2);
+    expect(pairs[0].s).toBe('PLATO igitur');
+    expect(source.slice(pairs[1].so, pairs[1].so + pairs[1].s.length)).toBe(pairs[1].s);
+    expect(translation.slice(pairs[1].to, pairs[1].to + pairs[1].t.length)).toBe(pairs[1].t);
+  });
+
+  it('drops pairs whose spans cannot be found on either side', () => {
+    const pairs = resolveAlignmentPairs(
+      [
+        { src: 'not in the source at all', en: 'Plato, therefore' },
+        { src: 'PLATO igitur', en: 'not in the translation' },
+        { src: 'menti', en: 'to the mind' },
+      ],
+      source,
+      translation,
+    );
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].s).toBe('menti');
+  });
+
+  it('binds repeated phrases to successive occurrences', () => {
+    const src = 'aqua vitae prima. aqua vitae secunda.';
+    const tr = 'the first water of life. the second water of life.';
+    const pairs = resolveAlignmentPairs(
+      [
+        { src: 'aqua vitae', en: 'water of life' },
+        { src: 'aqua vitae', en: 'water of life' },
+      ],
+      src,
+      tr,
+    );
+    expect(pairs).toHaveLength(2);
+    expect(pairs[1].so).toBeGreaterThan(pairs[0].so);
+    expect(pairs[1].to).toBeGreaterThan(pairs[0].to);
+  });
+
+  it('survives model quotes with mangled whitespace', () => {
+    const pairs = resolveAlignmentPairs(
+      [{ src: 'menti  laeticiam &\ngaudium', en: 'gladness  and joy' }],
+      source,
+      translation,
+    );
+    expect(pairs).toHaveLength(1);
+    // Stored span is the RAW slice from the text, not the model's string.
+    expect(pairs[0].s).toBe('menti laeticiam & gaudium');
+    expect(pairs[0].t).toBe('gladness and joy');
+  });
+});


### PR DESCRIPTION
Implements v1 of #3091.

## What this does

The reader's translation panel gets a **Trace** toggle. With it on, clicking any phrase in the English translation highlights the span of the original-language OCR that produced it — and vice versa (click the Latin, the English lights up). The counterpart pane auto-scrolls the span into view; on mobile and browsers without the CSS Custom Highlight API, a bottom sheet shows the counterpart snippet instead of yanking the reader away.

https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/3091

## How it works

- **One cheap LLM call per page, ever.** `GET /api/books/[id]/pages/[pageId]/alignment` serves `pages.word_alignment` when its hashes match; on first request it generates phrase pairs with `gemini-3.1-flash-lite` (~$0.0003/page), verifies every quoted span against the stored text, and caches the result. An edit or re-OCR self-invalidates via the stored sha256 hashes (same pattern as `TransliterationData.source_ocr_hash`).
- **Quote integrity:** both texts pass through `stripEditorialWrappers()` before alignment, and only verified, locatable spans are stored — a click can never land in `<meta>`/`<summary>` editorial prose (#2232 family).
- **Span matching (`src/lib/align-text.ts`)** uses symmetric folds measured on a real page (Drebbel, *Tractatus duo*): long ſ, ligatures (æ/œ), tilde abbreviations (nõ→non), accents, end-of-line dehyphenation, and an f/ſ-misread retry. Before these folds 9/19 model pairs resolved; after, 19/19. Unit tests pin each fold (`tests/unit/word-alignment-resolve.test.ts`, 15 tests).
- **Highlighting** uses the CSS Custom Highlight API — no mutation of the DOM React owns. The trace layer locates spans in the rendered panes by normalized text search, so it tolerates NotesRenderer's markdown/tag rendering; anything it can't find is a graceful no-op.
- **Access control:** route enforces `isBookReadable`; cached serves are ungated; generation is rate-limited for anonymous visitors via `anonActionGate` (60/hr/IP; signed-in exempt). Kill switch: `WORD_ALIGNMENT_ENABLED=0`.

## Verified

- End-to-end on localhost against production data: generation ~5s first call, ~170ms cached; both trace directions confirmed visually (English↔Latin, including a span bridging a hyphenated line break).
- `npx tsc --noEmit` clean; full unit suite 569/569 passing.
- Trace is gated to read mode with a real cross-language pair on screen: hidden for English books, Spanish edition view, modernized mode, and paired critical editions.

## Out of scope (per #3091)

- Facsimile-image highlighting (needs a bbox pass — v2)
- Pipeline-wide precompute/backfill
- Glossary popovers (v3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)