### PR TITLE
fix(dev): next dev broken locally — PostHog wrapper requires env vars that only exist on Vercel

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -394,12 +394,22 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withBotId(withPostHogConfig(nextConfig, {
-  personalApiKey: process.env.POSTHOG_API_KEY!,
-  projectId: process.env.POSTHOG_PROJECT_ID,
-  host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  sourcemaps: {
-    enabled: true,
-    deleteAfterUpload: true,
-  },
-}));
+// PostHog's config wrapper hard-requires projectId once sourcemaps are
+// enabled, and those env vars only exist on Vercel — with the wrapper applied
+// unconditionally, `next dev` throws "projectId is required when sourcemaps
+// are enabled" on every local checkout. Sourcemap upload is a build/deploy
+// concern, so only wrap when the PostHog credentials are actually present.
+const withAnalytics = (config: typeof nextConfig) =>
+  process.env.POSTHOG_API_KEY && process.env.POSTHOG_PROJECT_ID
+    ? withPostHogConfig(config, {
+        personalApiKey: process.env.POSTHOG_API_KEY,
+        projectId: process.env.POSTHOG_PROJECT_ID,
+        host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+        sourcemaps: {
+          enabled: true,
+          deleteAfterUpload: true,
+        },
+      })
+    : config;
+
+export default withBotId(withAnalytics(nextConfig));


### PR DESCRIPTION
## Problem

`next dev` fails on every local checkout:

```
⨯ Failed to load next.config.ts
Error: projectId is required when sourcemaps are enabled (envId is deprecated)
```

`withPostHogConfig` is applied unconditionally with `sourcemaps.enabled: true`, and the plugin hard-requires `projectId` in that mode. `POSTHOG_API_KEY` / `POSTHOG_PROJECT_ID` exist only in Vercel's environment — no local env file has them — so the config throws before the dev server can start. (Found while verifying #3096 locally; presumably unnoticed because we test via Vercel previews.)

## Fix

Apply the wrapper only when both credentials are present. On Vercel nothing changes — sourcemap upload behaves exactly as before. Locally, dev runs without PostHog credentials.

## Verified

- Fresh checkout of this branch, no PostHog env vars: `next dev` boots, `GET / → 200`.
- With the vars set, the wrapper code path is unchanged (same options object).

## Out of scope

Documenting local PostHog setup for anyone who *wants* sourcemap upload locally — the conditional makes it opt-in by setting the two vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)