### PR TITLE
fix(reader): magnifier lens zooms to full native detail on high-res scans

### DIFF
--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -90,7 +90,21 @@ export default function ImageWithMagnifier({
   const lensH = Math.round(magnifierSize * 0.85);
 
   const MIN_ZOOM = 1.5;
-  const MAX_ZOOM = 12;
+  // Absolute sanity bound only — the real ceiling is the scan's native pixel
+  // ratio (below), so a high-res master zooms deeper than a low-res one.
+  const MAX_ZOOM = 32;
+
+  // Native pixel ratio of the full image vs its displayed size — the deepest
+  // zoom that still shows real detail. Kept in a ref so the wheel handler
+  // (bound once) can clamp to it; render clamps effectiveZoom with the same
+  // numbers. 0 until the full image has loaded.
+  const nativeZoomRef = useRef(0);
+  useEffect(() => {
+    nativeZoomRef.current =
+      fullImageDimensions.width && imageDimensions.width
+        ? Math.max(fullImageDimensions.width / imageDimensions.width, MIN_ZOOM)
+        : 0;
+  }, [fullImageDimensions, imageDimensions, MIN_ZOOM]);
 
   // Scroll-to-zoom needs a native non-passive wheel listener (React attaches
   // wheel handlers passively, so preventDefault would be ignored). Only
@@ -101,7 +115,10 @@ export default function ImageWithMagnifier({
     const onWheel = (e: WheelEvent) => {
       if (!showMagnifierRef.current) return;
       e.preventDefault();
-      setUserZoom((z) => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, z * Math.exp(-e.deltaY * 0.002))));
+      // Clamp the stored zoom to the native ceiling too — otherwise scrolling
+      // "past" the ceiling banks invisible zoom the user must scroll back out of.
+      const cap = nativeZoomRef.current > 0 ? Math.min(nativeZoomRef.current, MAX_ZOOM) : MAX_ZOOM;
+      setUserZoom((z) => Math.min(cap, Math.max(MIN_ZOOM, z * Math.exp(-e.deltaY * 0.002))));
     };
     el.addEventListener('wheel', onWheel, { passive: false });
     return () => el.removeEventListener('wheel', onWheel);


### PR DESCRIPTION
## What

Removes the fixed `MAX_ZOOM = 12` as the working ceiling on the reading-lens scroll-zoom. The ceiling is now the scan's **native pixel ratio** (one lens pixel = one scan pixel), with 32× kept only as an absolute sanity bound.

## Why

The lens already samples the pristine archival master (`archived_photo`, per #2651) and #2941 correctly made native resolution the ceiling — but the hard 12× clamp sat *below* that ceiling for very high-res masters (6,000–8,000px scans displayed in a ~500px reader column). On exactly the books where deep zoom is most rewarding, the clamp — not the scan — was the limit.

Also clamps the *stored* zoom value to the same ceiling inside the wheel handler (kept in a ref, since the listener binds once), so scrolling past the ceiling no longer banks invisible zoom the user has to scroll back out of before the lens visibly responds.

Low-res scans are unchanged: their native ratio was already the binding cap.

## Out of scope

True beyond-native inspection (tiled deep zoom on all pages) — separate discussion; the lens deliberately never upscales past real detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)