### PR TITLE
Remove CMC Kloss Collection references + close tenant OAI visibility leak

### DIFF
--- a/src/app/about/sources/page.tsx
+++ b/src/app/about/sources/page.tsx
@@ -258,16 +258,6 @@ const sources: SourceLibrary[] = [
     highlights: 'Core collection. Bibliotheca Philosophica Hermetica: Hermetica, alchemy, Kabbalah, Rosicrucianism.',
   },
   {
-    name: 'CMC Prins Frederik — Kloss Collection',
-    country: 'Netherlands',
-    url: 'https://www.cmcdenhaag.nl',
-    route: '/api/import/pdf',
-    iiif: 'PDF',
-    status: 'live',
-    holdings: '1,530 MSS catalogued',
-    highlights: 'Bibliotheca Klossiana: Masonic, Rosicrucian, esoteric manuscripts. Georg Kloss (1787–1854) collection. 1,019 imported.',
-  },
-  {
     name: 'John Rylands Library, Manchester',
     country: 'UK',
     url: 'https://www.digitalcollections.manchester.ac.uk',

--- a/src/app/api/oai/route.ts
+++ b/src/app/api/oai/route.ts
@@ -351,10 +351,12 @@ ${bookToRecord(book)}
 
 export async function GET(request: NextRequest) {
   // Scope: a tenant subdomain harvests its own subset; the main domain (no tenant)
-  // harvests the GLOBAL public catalog. `visible: true` keeps hidden / in-copyright
-  // books out of the harvest, matching every other public surface.
+  // harvests the GLOBAL public catalog. `visible: true` applies in BOTH scopes —
+  // hidden / in-copyright / taken-down books must not be harvestable anywhere
+  // (the tenant branch missing it is how hidden Kloss books stayed exposed on
+  // the kloss subdomain's OAI endpoint, 2026-07-08).
   const { id: tenantId } = getTenantContextFromRequest(request);
-  const baseFilter: Document = tenantId ? { tenantId } : { visible: true };
+  const baseFilter: Document = tenantId ? { tenantId, visible: true } : { visible: true };
 
   const { searchParams } = new URL(request.url);
   const verb = searchParams.get('verb');

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -117,7 +117,6 @@ const CURATED_PATHWAYS = [
   'great-manuscripts',
   'herbalism',
   'jungs-library',
-  'kloss-collection',
 ];
 
 async function fetchCuratedPathways(tenantId: string | null): Promise<CollectionDoc[]> {

--- a/src/app/for-libraries/page.tsx
+++ b/src/app/for-libraries/page.tsx
@@ -149,15 +149,14 @@ export default function ForLibrariesPage() {
 
       {/* Live demos */}
       <section className="mb-16">
-        <h2 className="text-2xl md:text-3xl text-primary mb-3">Two libraries, one platform</h2>
+        <h2 className="text-2xl md:text-3xl text-primary mb-3">A live partner library</h2>
         <p className="text-secondary mb-8 max-w-2xl">
-          Both collections below are live, embedded right here using the same one-line script
-          shown above. Different institutions, different subject focus, different audiences
-          &mdash; same underlying platform.
+          The collection below is live, embedded right here using the same one-line script
+          shown above &mdash; a complete reading room running on the platform.
         </p>
 
         {/* BPH demo */}
-        <div className="bg-white rounded-xl border border-border-light overflow-hidden shadow-sm mb-8">
+        <div className="bg-white rounded-xl border border-border-light overflow-hidden shadow-sm">
           <div className="bg-stone-100 px-4 py-2.5 border-b border-border-light flex items-center justify-between">
             <div>
               <span className="text-sm font-medium text-stone-700">
@@ -179,35 +178,6 @@ export default function ForLibrariesPage() {
           <iframe
             src="https://bph.sourcelibrary.org"
             title="Bibliotheca Philosophica Hermetica live embed"
-            className="w-full"
-            style={{ height: '640px', border: 0 }}
-            loading="lazy"
-          />
-        </div>
-
-        {/* Kloss demo */}
-        <div className="bg-white rounded-xl border border-border-light overflow-hidden shadow-sm">
-          <div className="bg-stone-100 px-4 py-2.5 border-b border-border-light flex items-center justify-between">
-            <div>
-              <span className="text-sm font-medium text-stone-700">
-                Bibliotheca Klossiana &mdash; CMC Prins Frederik, The Hague
-              </span>
-              <span className="hidden md:inline text-xs text-muted ml-2">
-                Masonic, Rosicrucian &amp; esoteric collection of Georg Kloss (1787&ndash;1854)
-              </span>
-            </div>
-            <a
-              href="https://kloss.sourcelibrary.org"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-accent-rust hover:underline whitespace-nowrap"
-            >
-              Open in new tab &rarr;
-            </a>
-          </div>
-          <iframe
-            src="https://kloss.sourcelibrary.org"
-            title="Bibliotheca Klossiana live embed"
             className="w-full"
             style={{ height: '640px', border: 0 }}
             loading="lazy"

--- a/src/lib/library-partners.ts
+++ b/src/lib/library-partners.ts
@@ -238,17 +238,10 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
 
   // --- Other partners ---
 
-  'kloss-collection': {
-    slug: 'kloss-collection',
-    name: 'Kloss Collection (CMC)',
-    shortName: 'Kloss',
-    providerKey: 'cmc_kloss',
-    url: 'https://cmcdenhaag.nl',
-    description: 'The Bibliotheca Klossiana at CMC Prins Frederik in The Hague preserves the collection of Georg Kloss (1787–1854), one of the most important Masonic, Rosicrucian, and esoteric manuscript collections in Europe.',
-    color: 'gold',
-    heroImageOverride: 'https://images.sourcelibrary.org/pages/69c1d094b82ba5d5bed99883/0355.jpg',
-    hasUnifiedCatalogue: true,
-  },
+  // 'kloss-collection' (CMC Prins Frederik / Museum of Freemasonry) removed
+  // 2026-07-08 at the museum's request, pending a partnership agreement.
+  // All cmc_kloss books are hidden (hidden_reason: kloss_manuscripts_removed_2026-07-08)
+  // and the kloss tenant is soft-disabled (tenants.status: 'deleted').
   'library-of-congress': {
     slug: 'library-of-congress',
     name: 'Library of Congress',

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -191,7 +191,9 @@ function logBotAccess(request: NextRequest, action: string) {
 // Adding a new tenant: insert a row here and create the DNS record.
 const TENANT_SUBDOMAINS: Record<string, string> = {
   'bph.sourcelibrary.org': 'bph',
-  'kloss.sourcelibrary.org': 'kloss-collection',
+  // 'kloss.sourcelibrary.org' removed 2026-07-08 — CMC/Museum of Freemasonry
+  // takedown request; tenant soft-disabled (status: 'deleted'), re-add both
+  // together if the partnership is formalized.
   'bhutan.sourcelibrary.org': 'bhutan',
   // 'ritman.sourcelibrary.org': 'ritman',
 };


### PR DESCRIPTION
## Why
The Museum of Freemasonry (CMC Prins Frederik, The Hague) has formally asked us to remove the Kloss Collection material and all references to their institution, pending a proper partnership agreement. The 1,517 `cmc_kloss` books were already hidden data-side (reversible, `hidden_reason: kloss_manuscripts_removed_2026-07-08`); this PR removes the remaining public *references* in code.

## In scope
- **`src/lib/library-partners.ts`** — remove the `kloss-collection` entry → `/libraries/kloss-collection` and its listing on `/libraries` go away.
- **`/for-libraries`** — remove the Bibliotheca Klossiana live-demo iframe (it embedded kloss.sourcelibrary.org); section reworded for a single demo.
- **`/about/sources`** — remove the "CMC Prins Frederik — Kloss Collection" row.
- **`/collections`** — drop `kloss-collection` from the curated pathways list.
- **`src/proxy.ts`** — remove the `kloss.sourcelibrary.org` subdomain mapping (the tenant doc is also soft-disabled: `status: 'deleted'`, reversible).
- **`/api/oai`** — real leak found during the takedown audit: the tenant-scoped harvest filtered only by `tenantId`, so *hidden* books stayed harvestable on tenant subdomains (verified live on kloss before the tenant was disabled). Tenant harvests now also require `visible: true`, matching the global scope. This protects every tenant, not just Kloss.

## Out of scope (deliberate)
- Internal provider-label maps (`cmc_kloss: 'CMC (Kloss collection)'`), admin system-map text, import scripts, and `TENANT_ROOT_PATHS` — kept so a restore is one revert + status flip if the partnership is formalized. None of them render publicly while the books are hidden and the tenant is disabled.
- The hidden book/page/image data itself stays archived (nothing deleted).

## Verification
- `npx tsc --noEmit` clean; `provider-prefix-redirect` + `robots-content-signals` guard tests pass.
- Data-side state verified: 0 visible cmc_kloss books (Mongo + Supabase books_catalog), 0 kloss gallery images with `book_visible: true`, 13 kloss-* collection docs hidden, tenant status `deleted`.

After merge this needs a prod deploy (`npm run deploy:prod`) to take effect on sourcelibrary.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)