### PR TITLE
Hidden collections must not render on public collection pages

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -51,7 +51,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       getReadDb(),
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 15000)),
     ]);
-    const collection = await db.collection('collections').findOne({ slug: id });
+    const collection = await db.collection('collections').findOne({ slug: id, visible: { $ne: false } });
 
     if (!collection) {
       return { title: 'Collection Not Found - Source Library' };
@@ -340,17 +340,20 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
   const db = await withTimeout(getReadDb(), 10000, null as unknown as Awaited<ReturnType<typeof getReadDb>>);
   if (!db) throw new Error('DB connection timeout');
 
+  // Only explicit visible:false hides a collection (takedowns, prelaunch);
+  // missing/undefined stays public — same convention as books.
   const collection = await withTimeout(
     db.collection('collections').findOne(
       tenantId
         ? {
           slug: id,
+          visible: { $ne: false },
           $or: [
             { tenantId },
             { tenantId: { $exists: false } },
           ],
         }
-        : { slug: id }
+        : { slug: id, visible: { $ne: false } }
     ),
     8000, null,
   );

--- a/src/app/collections/all/page.tsx
+++ b/src/app/collections/all/page.tsx
@@ -57,9 +57,12 @@ async function fetchWings(): Promise<Wing[]> {
     visible: true,
   }).project({ slug: 1, tenantId: 1, name: 1, book_count: 1, artwork_count: 1, hero_image: 1, featured_images: { $slice: 1 }, _id: 0 }).sort({ name: 1 }).toArray();
 
-  // Get all subcollections with their first featured image
+  // Get all subcollections with their first featured image. Only explicit
+  // visible:false is excluded — hidden collections (e.g. takedowns) must not
+  // be listed at all, even dimmed; missing/undefined stays public.
   const subs = await db.collection('collections').find({
     parent: { $exists: true },
+    visible: { $ne: false },
   }).project({
     slug: 1, tenantId: 1, name: 1, book_count: 1, artwork_count: 1, parent: 1, visible: 1, type: 1,
     hero_image: 1, featured_images: { $slice: 1 }, _id: 0,

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -121,7 +121,7 @@ const CURATED_PATHWAYS = [
 
 async function fetchCuratedPathways(tenantId: string | null): Promise<CollectionDoc[]> {
   const db = await getReadDb();
-  const query: Record<string, unknown> = { slug: { $in: CURATED_PATHWAYS } };
+  const query: Record<string, unknown> = { slug: { $in: CURATED_PATHWAYS }, visible: { $ne: false } };
   if (tenantId) query.tenantId = tenantId;
 
   const docs = await db.collection('collections').find(query).toArray();


### PR DESCRIPTION
Follow-up to #3099 (Kloss/CMC takedown). A `collections` doc with `visible: false` was still fully served on three public surfaces:

- `/collections/[id]` — rendered the full page (the hidden Bibliotheca Klossiana page stayed live after the takedown)
- `/collections/all` — listed it as a dimmed but clickable, named card
- `/collections` — the curated-pathways grid would show it if its slug were in the list

All three reads now gate on `visible: { $ne: false }` — only an explicit `false` hides; missing/undefined stays public, matching the books convention (`book-access.ts`).

Out of scope: tenant-scoped collection surfaces and the Supabase-served grids (already scoped by book visibility).

Verification: `npx tsc --noEmit` clean; after deploy, https://sourcelibrary.org/collections/kloss-collection should 404 and no Kloss card should appear under Secret Societies on /collections/all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)