### PR TITLE
fix(search): drop hidden books from unified image search lanes

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -185,7 +185,7 @@ export async function GET(request: NextRequest) {
         emptyIndex, 'index',
       ),
       withTimeout(searchGallery(db, matchQuery, queryRegex, galleryLimit, tenantContext.id || undefined), emptyGallery, 'gallery'),
-      withTimeout(searchVisual(matchQuery, galleryLimit), emptyGallery, 'visual', 5000),
+      withTimeout(searchVisual(db, matchQuery, galleryLimit), emptyGallery, 'visual', 5000),
       // Semantic search: book-level discovery via book_embeddings (HNSW, ~17K rows)
       withTimeout(
         semanticBookSearch(matchQuery, 12, { tenantId: tenantContext.id || undefined })
@@ -709,6 +709,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
           {
             ...(tenantId ? { tenantId } : {}),
             gallery_quality: { $gte: 0.5 },
+            book_visible: { $ne: false },
             extracted_url: { $ne: null },
             $or: [
               { description: queryRegex },
@@ -728,8 +729,13 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
     // Filter out images without any thumbnail/extracted URL (detection without extraction)
     const withImages = images.filter((img: any) => img.thumbnail_url || img.extracted_url);
 
+    // Drop images from hidden/removed books (takedowns, dedup hides). The
+    // Atlas Search branch can't filter on book_visible, and the gallery_images
+    // mirror can drift — check books.visible in Mongo, same as the artwork lanes.
+    const visibleImages = await filterVisibleArtworks(db, withImages as Array<{ book_id: string }>);
+
     return {
-      results: withImages.slice(0, limit).map((img: any) => ({
+      results: visibleImages.slice(0, limit).map((img: any) => ({
         id: `${img.page_id}-${img.detection_index}`,
         imageUrl: img.thumbnail_url || img.extracted_url || '',
         description: img.description || '',
@@ -737,7 +743,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
         bookTitle: img.book_title || '',
         bookId: img.book_id || '',
       })),
-      total: withImages.length,
+      total: visibleImages.length,
     };
   } catch (err) {
     console.error('Gallery search error:', err);
@@ -749,7 +755,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
  * CLIP visual search: encode text query via CLIP, search against image embeddings.
  * Finds images by what they look like, not just their metadata.
  */
-async function searchVisual(query: string, limit: number): Promise<{ results: GalleryResult[]; total: number }> {
+async function searchVisual(db: any, query: string, limit: number): Promise<{ results: GalleryResult[]; total: number }> {
   try {
     // Encode text via CLIP text encoder
     const clipResp = await fetch(`${CLIP_URL}/embed-text`, {
@@ -778,7 +784,7 @@ async function searchVisual(query: string, limit: number): Promise<{ results: Ga
     // (artwork semantic+lexical, book search), so dropping them loses nothing.
     // Deduplicate by book (max 2 per book).
     const byBook = new Map<string, number>();
-    const deduped = (data as Array<{
+    const matches = (data as Array<{
       id: string; source_type: string; book_id: string; image_url: string; thumbnail_url: string;
       title: string; author: string; resource_type: string; similarity: number;
     }>).filter(m => {
@@ -787,7 +793,11 @@ async function searchVisual(query: string, limit: number): Promise<{ results: Ga
       if (count >= 2) return false;
       byBook.set(m.book_id, count + 1);
       return true;
-    }).slice(0, limit);
+    });
+
+    // clip_embeddings is a snapshot with no visibility column — drop rows whose
+    // book is hidden/removed in Mongo (takedowns), same as the other image lanes.
+    const deduped = (await filterVisibleArtworks(db, matches)).slice(0, limit);
 
     return {
       results: deduped.map(m => ({

--- a/src/lib/artwork-visibility.ts
+++ b/src/lib/artwork-visibility.ts
@@ -11,6 +11,10 @@ import type { Db } from 'mongodb';
  * /api/gallery do — run their results through this to drop anything not currently
  * visible in Mongo. Defense in depth for the books visible/hidden invariant.
  *
+ * Despite the name it is generic over any `{ book_id }` row: the unified-search
+ * gallery lane (gallery_images, whose book_visible mirror can drift) and CLIP
+ * visual lane (clip_embeddings, no visibility column at all) run through it too.
+ *
  * Returns the input rows minus any whose book is not `visible: true` in Mongo.
  */
 export async function filterVisibleArtworks<T extends { book_id: string }>(


### PR DESCRIPTION
## What

Images from hidden books (e.g. the 2026-07-08 Kloss/CMC takedown set, 1,187 gallery rows) surfaced in `/search` image results and 404'd on click. Reported via footer feedback on /search.

Two lanes in `/api/search/unified` had no visibility filtering:
- **Gallery lane** (`searchGallery`): Atlas Search + regex fallback over `gallery_images` filtered on quality/tenant only, never `book_visible`.
- **CLIP visual lane** (`searchVisual`): `clip_embeddings` is a snapshot with no visibility column.

## Fix

Route both lanes through the existing `filterVisibleArtworks()` Mongo-backed check (already used by the artwork semantic lane), and add `book_visible: { $ne: false }` to the regex fallback query. Extended the helper's doc comment to note it's generic over `{ book_id }` rows.

## Out of scope

- `/api/gallery` already filters `book_visible: true` — untouched.
- Purging hidden rows from the Supabase clip/artwork embedding snapshots (data-side hygiene; the app-layer filter makes it non-urgent).

Feedback-ID: 6a4f42138fd883b3e56a226e

🤖 Generated with [Claude Code](https://claude.com/claude-code)