### PR TITLE
feat(catalog): surface Memorix 'Internal remarks' to BPH editors only

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -77,6 +77,9 @@ interface BphWorkRow {
   volume_title: string | null;
   bibliography: string | null;
   remarks: string | null;
+  // Memorix "Internal remarks" — cataloguers' working notes. Rendered ONLY
+  // for editor+ roles; must never appear on the public page (José B., #3105).
+  internal_remarks: string | null;
   number_of_copies: number | null;
   object_size_cm: string | null;
   bibliographic_format: string | null;
@@ -135,7 +138,7 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
       place, printer, publisher, variant_printer, variant_publisher,
       year, shelf_mark, state_shelf_mark, present_location,
       keywords, language, series_title, volume_title,
-      bibliography, remarks, number_of_copies, object_size_cm, bibliographic_format,
+      bibliography, remarks, internal_remarks, number_of_copies, object_size_cm, bibliographic_format,
       binding, bound_with,
       provenance, collection, impressum_original, contributors,
       ia_identifier, ustc_sn, sl_book_id, sl_book_slug,
@@ -146,6 +149,7 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
   // then external-link columns, then author-authority columns. Each migration
   // runs independently per environment — the page renders if any are missing.
   const fallbackSelect = select
+    .replace('remarks, internal_remarks,', 'remarks,')
     .replace('provenance, collection, impressum_original, contributors,', 'provenance,')
     .replace(
       'sl_external_book_id, sl_external_slug, sl_external_source,\n      ',
@@ -748,6 +752,12 @@ export default async function CatalogEntryPage({ params }: Props) {
         <Section title="Notes">
           <Field label="Bibliography" value={work.bibliography} />
           <Field label="Remarks" value={work.remarks} />
+          {/* Staff-only working notes — never rendered for public visitors.
+              Safe to role-gate here: this page is fully dynamic (private,
+              no-store), so an editor's render is never cached for others. */}
+          {ROLE_LEVEL[role] >= ROLE_LEVEL['editor'] && (
+            <Field label="Internal remarks (staff only)" value={work.internal_remarks} />
+          )}
         </Section>
 
         <Section title="Identifiers">

--- a/src/components/catalog/BphWorkEditForm.tsx
+++ b/src/components/catalog/BphWorkEditForm.tsx
@@ -45,7 +45,7 @@ interface Props {
 // can map their mental model 1:1.
 const SECTIONS: Array<{
   title: string;
-  fields: Array<{ name: string; label: string; type?: 'text' | 'number' | 'textarea'; hidden?: boolean }>;
+  fields: Array<{ name: string; label: string; type?: 'text' | 'number' | 'textarea'; hidden?: boolean; editorOnly?: boolean }>;
 }> = [
   {
     title: 'Title',
@@ -122,6 +122,9 @@ const SECTIONS: Array<{
     fields: [
       { name: 'bibliography', label: 'Bibliography', type: 'textarea' },
       { name: 'remarks', label: 'Remarks', type: 'textarea' },
+      // Memorix "Internal remarks" — staff working notes (José B.). Shown to
+      // editors only; the public catalog page never renders this field.
+      { name: 'internal_remarks', label: 'Internal remarks (staff only, never public)', type: 'textarea', editorOnly: true },
     ],
   },
   {
@@ -481,7 +484,7 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
                 />
               </div>
             )}
-            {section.fields.filter((f) => !f.hidden).map((field) => {
+            {section.fields.filter((f) => !f.hidden && !(f.editorOnly && mode === 'contributor')).map((field) => {
               const provenance =
                 (initial.field_provenance as Record<string, { source?: string; edited_by?: string; edited_at?: string }> | null)?.[field.name];
               const isChanged = changedFields.includes(field.name);

--- a/src/lib/bph-catalog.ts
+++ b/src/lib/bph-catalog.ts
@@ -88,6 +88,9 @@ export const EDITABLE_BPH_FIELDS = [
   // Notes
   'bibliography',
   'remarks',
+  // Memorix "Internal remarks" — staff working notes. Editable/visible for
+  // editor+ only; the public catalog entry page must never render it.
+  'internal_remarks',
   // Provenance (ownership history) + collection (named collection the copy
   // belongs to) — kept as two distinct fields per Paul D. (2026-06-24).
   'provenance',


### PR DESCRIPTION
## What

José Bouman (EFM) reported via footer feedback that the Memorix field **Internal Remarks** is missing from the BPH catalogue: *"Contains important info for the librarian, but should not be visible on the website."*

The data has been sitting in `bph_works.internal_remarks` since the schema expansion (populated — e.g. UBN 14143 carries copy-state notes) but nothing read it.

## Changes

- **Catalog entry page** (`/embed/[tenant]/catalog/[ubn]`): renders an *Internal remarks (staff only)* field in Notes, gated on editor+ role. Safe to role-gate: the page is fully dynamic (`cache-control: private, no-store` verified on prod), so an editor render can't be cached and served publicly.
- **Edit form**: editable textarea in the Notes section; new `editorOnly` field flag hides it in contributor mode.
- **`EDITABLE_BPH_FIELDS`**: added `internal_remarks` — this drives both the edit page's column select and the save allowlist, so it flows through with no further wiring.

## Verified not public

`/api/catalog/bph` uses explicit column lists without the field; `/api/embed/bph/stats` is count-only; entry page renders it only for editor+.

Feedback-ID: 6a4e68949e6965dadc9dd437

🤖 Generated with [Claude Code](https://claude.com/claude-code)