### PR TITLE
feat(home): homepage_exclude flag opts collections out of the editorial spread

### DIFF
--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -57,9 +57,12 @@ export interface FeaturedItem {
 async function getFeaturedCollections(): Promise<FeaturedItem[]> {
   const db = await getReadDb();
 
-  // Pick 1 random collection with enough books for the editorial spread
+  // Pick 1 random collection with enough books for the editorial spread.
+  // homepage_exclude opts a collection out of this random rotation without
+  // hiding its /collections page — set on sensitive collections (e.g. erotica)
+  // that shouldn't front the site.
   const collections = await db.collection('collections').aggregate([
-    { $match: { book_count: { $gte: 10 }, parent: { $exists: false }, type: { $ne: 'curated' }, collection_type: { $ne: 'visual_art' }, visible: true } },
+    { $match: { book_count: { $gte: 10 }, parent: { $exists: false }, type: { $ne: 'curated' }, collection_type: { $ne: 'visual_art' }, visible: true, homepage_exclude: { $ne: true } } },
     { $sample: { size: 1 } },
   ]).toArray();
 


### PR DESCRIPTION
## What

Derek (footer feedback): *"I would not have erotic lit as a featured collection"* — seen on the homepage. The editorial spread samples 1 random collection matching `book_count ≥ 10, no parent, type ≠ curated, collection_type ≠ visual_art, visible`; **Erotic Literature** (57 books) and **Eros & the Esoteric** (31) both qualify.

## Change

Add `homepage_exclude: { $ne: true }` to the spread's $match. The flag removes a collection from homepage rotation without touching its `/collections` page visibility. Data side (done separately in Mongo): `homepage_exclude: true` set on `erotic-literature` and `eros-esoteric`.

## Out of scope

The discover-books strip samples random *books* and could still surface an erotic title; flagging book-level sensitivity is a different mechanism — left for a follow-up if wanted.

Feedback-ID: 6a4e81d1f034713e13a60210

🤖 Generated with [Claude Code](https://claude.com/claude-code)