### PR TITLE
fix(routing): 308 phantom /default/* URLs to their global equivalents

### DIFF
--- a/src/lib/provider-prefix.ts
+++ b/src/lib/provider-prefix.ts
@@ -38,6 +38,14 @@ export function getProviderPrefixRedirect(pathname: string): string | null {
   const match = pathname.match(/^\/([a-z0-9-]+)(\/.*)?$/);
   if (!match) return null;
   const [, firstSegment, rest] = match;
+  // '/default/book/foo' → '/book/foo'. The `tenants` collection has a
+  // kind:'default' row whose slug leaked into externally-built links
+  // (~390 not_found_reports/3d as of 2026-07-09). No book carries
+  // tenantId 'default', so the whole prefix is safe to strip; the bare
+  // root goes home rather than to a (nonexistent) credit page.
+  if (firstSegment === 'default') {
+    return rest && rest !== '/' ? rest : '/';
+  }
   if (!PROVIDER_PREFIX_SLUGS.has(firstSegment)) return null;
   return rest && rest !== '/' ? rest : `/libraries/${firstSegment}`;
 }

--- a/tests/unit/provider-prefix-redirect.test.ts
+++ b/tests/unit/provider-prefix-redirect.test.ts
@@ -39,6 +39,15 @@ describe('getProviderPrefixRedirect', () => {
     }
   });
 
+  it('strips the phantom default-tenant prefix', () => {
+    expect(getProviderPrefixRedirect('/default/book/foo')).toBe('/book/foo');
+    expect(getProviderPrefixRedirect('/default/book/foo/page/abc123')).toBe(
+      '/book/foo/page/abc123'
+    );
+    expect(getProviderPrefixRedirect('/default')).toBe('/');
+    expect(getProviderPrefixRedirect('/default/')).toBe('/');
+  });
+
   it('ignores non-provider paths', () => {
     expect(getProviderPrefixRedirect('/book/foo')).toBeNull();
     expect(getProviderPrefixRedirect('/author/marsilio-ficino')).toBeNull();


### PR DESCRIPTION
## What

A general 404 sweep (footer-feedback follow-up) found ~390 `/default/book/...` 404s in the last 3 days, 1,165 all-time. The `tenants` collection has an active `kind: 'default'` / slug `default` row ("Default Library") whose slug has leaked into externally-built links (AI-agent citations and scrapers construct `/default/book/<id>`). Zero books carry `tenantId: 'default'`, and `findTenantBookByIdOrSlug` already special-cases the slug — the page URLs just 404.

## Change

`getProviderPrefixRedirect()` now strips a leading `/default` the same way it strips provider prefixes (PR #2505's safety net): `/default/book/foo` → 308 → `/book/foo`; bare `/default` → `/` (there's no /libraries credit page for it). Guard test extended.

## Context from the same sweep (no action in this PR)

- 2,519 distinct `/artwork/*` 404s in 3d are scrapers replaying URLs of artworks hidden by the dedup sweep (#3037) — expected decay, same pattern as the earlier hidden-book 404 wave; sitemaps verified to filter `visible: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)