### PR TITLE
fix(reader): float the magnifier toggle, hide the lens over it

### DIFF
--- a/src/components/reader/PageDeepZoomButton.tsx
+++ b/src/components/reader/PageDeepZoomButton.tsx
@@ -16,9 +16,10 @@
  * see memory: inline state there silently failed (reactCompiler + IIFE layout).
  */
 
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import { Search, X, Maximize2 } from 'lucide-react';
 import type { DeepZoomManifest } from '@/lib/types/book';
+import { useFloatingOverlayTop, LENS_AVOID_ATTR } from '@/hooks/useFloatingOverlayTop';
 
 const DeepZoomInline = lazy(() => import('./DeepZoomInline'));
 const DeepZoomOverlay = lazy(() => import('@/components/artwork/DeepZoomOverlay'));
@@ -33,6 +34,9 @@ export default function PageDeepZoomButton({
   const [inline, setInline] = useState(false);
   const [overlay, setOverlay] = useState(false);
   const [isDesktop, setIsDesktop] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  // Follows the scroll so it stays reachable partway down a tall page scan.
+  const buttonTop = useFloatingOverlayTop(buttonRef, !inline);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -53,8 +57,11 @@ export default function PageDeepZoomButton({
     <>
       {!inline && (
         <button
+          ref={buttonRef}
+          {...{ [LENS_AVOID_ATTR]: '' }}
           onClick={() => (isDesktop ? setInline(true) : setOverlay(true))}
-          className="absolute top-2 right-2 z-10 flex items-center gap-1.5 px-2.5 py-1.5 bg-black/55 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-colors"
+          style={{ top: buttonTop, zIndex: 110 }}
+          className="absolute right-2 flex items-center gap-1.5 px-2.5 py-1.5 bg-black/55 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-colors"
           title="Open deep zoom — stream this page at full resolution"
         >
           <Search className="w-3.5 h-3.5" />

--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -3,14 +3,15 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { ZoomIn } from 'lucide-react';
 import FullscreenImageViewer from '@/components/reader/FullscreenImageViewer';
+import {
+  useFloatingOverlayTop,
+  FLOATING_OVERLAY_MARGIN,
+  LENS_AVOID_ATTR,
+} from '@/hooks/useFloatingOverlayTop';
 
 // Readers can switch the hover lens off (it captures scroll-to-zoom, which makes
 // scrolling past a tall facsimile awkward). Remembered across pages and sessions.
 const LENS_PREF_KEY = 'sl-magnifier-lens';
-
-// Lens toggle geometry — the button is h-8/w-8, inset 8px from the image edge.
-const TOGGLE_SIZE = 32;
-const TOGGLE_MARGIN = 8;
 
 interface ImageWithMagnifierProps {
   src: string;
@@ -66,14 +67,16 @@ export default function ImageWithMagnifier({
   // Lens on/off toggle. Defaults on; hydrated from localStorage after mount
   // (SSR-safe) so the choice sticks across pages and sessions.
   const [lensEnabled, setLensEnabled] = useState(true);
-  // Distance of the lens toggle from the top of the image. Follows the scroll
-  // position so the button stays on screen over a tall facsimile (see effect below).
-  const [toggleTop, setToggleTop] = useState(TOGGLE_MARGIN);
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
   const showMagnifierRef = useRef(false);
   showMagnifierRef.current = showMagnifier;
+
+  // The toggle floats: over a tall facsimile it tracks the top of the visible
+  // slice rather than scrolling out of reach — which is exactly when a reader
+  // wants it, since the lens captures the wheel for zoom.
+  const toggleTop = useFloatingOverlayTop(toggleRef, !isTouchDevice && isLoaded);
 
   useEffect(() => {
     try {
@@ -113,63 +116,6 @@ export default function ImageWithMagnifier({
         ? Math.max(fullImageDimensions.width / imageDimensions.width, MIN_ZOOM)
         : 0;
   }, [fullImageDimensions, imageDimensions, MIN_ZOOM]);
-
-  // The lens toggle floats: as the reader scrolls down a tall facsimile it tracks
-  // the top of the still-visible slice of the image rather than scrolling away.
-  // CSS `position: sticky` can't do this — callers wrap the image in a
-  // `rounded-lg overflow-hidden` box, which becomes sticky's scroll container
-  // and never scrolls, so the button would simply sit still. Instead we measure
-  // the nearest genuinely scrollable ancestor (the reader panel, else the page)
-  // and offset the button from the container's own top edge.
-  useEffect(() => {
-    if (isTouchDevice || !isLoaded) return;
-    const el = containerRef.current;
-    if (!el) return;
-
-    let scroller: HTMLElement | null = el.parentElement;
-    while (scroller) {
-      const overflowY = window.getComputedStyle(scroller).overflowY;
-      if (overflowY === 'auto' || overflowY === 'scroll') break;
-      scroller = scroller.parentElement;
-    }
-
-    // Page-scrolled callers (artwork hero) have no scrollable ancestor — the
-    // top of their "viewport" is whatever the sticky site header leaves free.
-    const viewportTop = () => {
-      if (scroller) return scroller.getBoundingClientRect().top;
-      const header = document.querySelector<HTMLElement>('[data-site-header]');
-      if (!header) return 0;
-      const position = window.getComputedStyle(header).position;
-      if (position !== 'sticky' && position !== 'fixed') return 0;
-      return Math.max(0, header.getBoundingClientRect().bottom);
-    };
-
-    let frame = 0;
-    const update = () => {
-      frame = 0;
-      const rect = el.getBoundingClientRect();
-      const viewTop = viewportTop();
-      // Never push the button below the image's bottom edge.
-      const maxTop = Math.max(TOGGLE_MARGIN, rect.height - TOGGLE_SIZE - TOGGLE_MARGIN);
-      const wanted = viewTop - rect.top + TOGGLE_MARGIN;
-      setToggleTop(Math.min(maxTop, Math.max(TOGGLE_MARGIN, wanted)));
-    };
-    const schedule = () => {
-      if (!frame) frame = requestAnimationFrame(update);
-    };
-
-    update();
-    // Scroll events don't bubble, so listen in the capture phase to catch them
-    // from whichever ancestor is actually scrolling.
-    const capture = { capture: true, passive: true } as const;
-    window.addEventListener('scroll', schedule, capture);
-    window.addEventListener('resize', schedule);
-    return () => {
-      if (frame) cancelAnimationFrame(frame);
-      window.removeEventListener('scroll', schedule, capture);
-      window.removeEventListener('resize', schedule);
-    };
-  }, [isTouchDevice, isLoaded]);
 
   // Scroll-to-zoom needs a native non-passive wheel listener (React attaches
   // wheel handlers passively, so preventDefault would be ignored). Only
@@ -321,22 +267,34 @@ export default function ImageWithMagnifier({
     img.src = magnifierSrc;
   }, [magnifierSrc, hasHovered]);
 
+  // Is the cursor on (or just beside) a control the lens must not cover? Searches
+  // from the positioning wrapper, so it finds sibling controls drawn over the
+  // same image as well as our own toggle.
+  const isOverLensAvoidControl = (clientX: number, clientY: number) => {
+    const scope = containerRef.current?.parentElement ?? containerRef.current;
+    if (!scope) return false;
+    return [...scope.querySelectorAll<HTMLElement>(`[${LENS_AVOID_ATTR}]`)].some((control) => {
+      const box = control.getBoundingClientRect();
+      return (
+        clientX >= box.left - FLOATING_OVERLAY_MARGIN &&
+        clientX <= box.right + FLOATING_OVERLAY_MARGIN &&
+        clientY >= box.top - FLOATING_OVERLAY_MARGIN &&
+        clientY <= box.bottom + FLOATING_OVERLAY_MARGIN
+      );
+    });
+  };
+
   // Desktop: mouse move for magnifier
   const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     // Skip magnifier on touch devices or when the reader switched the lens off
     // (also skips the full-res prefetch — it only serves the lens)
     if (isTouchDevice || !lensEnabled) return;
 
-    // Get out of the toggle's way — the lens is centred on the cursor, so it would
-    // otherwise cover the very button the reader is reaching for.
-    const toggleRect = toggleRef.current?.getBoundingClientRect();
-    if (
-      toggleRect &&
-      e.clientX >= toggleRect.left - TOGGLE_MARGIN &&
-      e.clientX <= toggleRect.right + TOGGLE_MARGIN &&
-      e.clientY >= toggleRect.top - TOGGLE_MARGIN &&
-      e.clientY <= toggleRect.bottom + TOGGLE_MARGIN
-    ) {
+    // Get out of the controls' way — the lens is centred on the cursor, so it
+    // would otherwise cover the very button the reader is reaching for. Covers
+    // our own toggle plus any sibling control that opts in (the deep-zoom
+    // button, which lives outside this component but over the same image).
+    if (isOverLensAvoidControl(e.clientX, e.clientY)) {
       setShowMagnifier(false);
       return;
     }
@@ -461,6 +419,7 @@ export default function ImageWithMagnifier({
           <button
             ref={toggleRef}
             type="button"
+            {...{ [LENS_AVOID_ATTR]: '' }}
             onClick={(e) => {
               e.stopPropagation();
               toggleLens();

--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -8,6 +8,10 @@ import FullscreenImageViewer from '@/components/reader/FullscreenImageViewer';
 // scrolling past a tall facsimile awkward). Remembered across pages and sessions.
 const LENS_PREF_KEY = 'sl-magnifier-lens';
 
+// Lens toggle geometry — the button is h-8/w-8, inset 8px from the image edge.
+const TOGGLE_SIZE = 32;
+const TOGGLE_MARGIN = 8;
+
 interface ImageWithMagnifierProps {
   src: string;
   thumbnail?: string;
@@ -62,8 +66,12 @@ export default function ImageWithMagnifier({
   // Lens on/off toggle. Defaults on; hydrated from localStorage after mount
   // (SSR-safe) so the choice sticks across pages and sessions.
   const [lensEnabled, setLensEnabled] = useState(true);
+  // Distance of the lens toggle from the top of the image. Follows the scroll
+  // position so the button stays on screen over a tall facsimile (see effect below).
+  const [toggleTop, setToggleTop] = useState(TOGGLE_MARGIN);
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
   const showMagnifierRef = useRef(false);
   showMagnifierRef.current = showMagnifier;
 
@@ -105,6 +113,63 @@ export default function ImageWithMagnifier({
         ? Math.max(fullImageDimensions.width / imageDimensions.width, MIN_ZOOM)
         : 0;
   }, [fullImageDimensions, imageDimensions, MIN_ZOOM]);
+
+  // The lens toggle floats: as the reader scrolls down a tall facsimile it tracks
+  // the top of the still-visible slice of the image rather than scrolling away.
+  // CSS `position: sticky` can't do this — callers wrap the image in a
+  // `rounded-lg overflow-hidden` box, which becomes sticky's scroll container
+  // and never scrolls, so the button would simply sit still. Instead we measure
+  // the nearest genuinely scrollable ancestor (the reader panel, else the page)
+  // and offset the button from the container's own top edge.
+  useEffect(() => {
+    if (isTouchDevice || !isLoaded) return;
+    const el = containerRef.current;
+    if (!el) return;
+
+    let scroller: HTMLElement | null = el.parentElement;
+    while (scroller) {
+      const overflowY = window.getComputedStyle(scroller).overflowY;
+      if (overflowY === 'auto' || overflowY === 'scroll') break;
+      scroller = scroller.parentElement;
+    }
+
+    // Page-scrolled callers (artwork hero) have no scrollable ancestor — the
+    // top of their "viewport" is whatever the sticky site header leaves free.
+    const viewportTop = () => {
+      if (scroller) return scroller.getBoundingClientRect().top;
+      const header = document.querySelector<HTMLElement>('[data-site-header]');
+      if (!header) return 0;
+      const position = window.getComputedStyle(header).position;
+      if (position !== 'sticky' && position !== 'fixed') return 0;
+      return Math.max(0, header.getBoundingClientRect().bottom);
+    };
+
+    let frame = 0;
+    const update = () => {
+      frame = 0;
+      const rect = el.getBoundingClientRect();
+      const viewTop = viewportTop();
+      // Never push the button below the image's bottom edge.
+      const maxTop = Math.max(TOGGLE_MARGIN, rect.height - TOGGLE_SIZE - TOGGLE_MARGIN);
+      const wanted = viewTop - rect.top + TOGGLE_MARGIN;
+      setToggleTop(Math.min(maxTop, Math.max(TOGGLE_MARGIN, wanted)));
+    };
+    const schedule = () => {
+      if (!frame) frame = requestAnimationFrame(update);
+    };
+
+    update();
+    // Scroll events don't bubble, so listen in the capture phase to catch them
+    // from whichever ancestor is actually scrolling.
+    const capture = { capture: true, passive: true } as const;
+    window.addEventListener('scroll', schedule, capture);
+    window.addEventListener('resize', schedule);
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', schedule, capture);
+      window.removeEventListener('resize', schedule);
+    };
+  }, [isTouchDevice, isLoaded]);
 
   // Scroll-to-zoom needs a native non-passive wheel listener (React attaches
   // wheel handlers passively, so preventDefault would be ignored). Only
@@ -262,6 +327,20 @@ export default function ImageWithMagnifier({
     // (also skips the full-res prefetch — it only serves the lens)
     if (isTouchDevice || !lensEnabled) return;
 
+    // Get out of the toggle's way — the lens is centred on the cursor, so it would
+    // otherwise cover the very button the reader is reaching for.
+    const toggleRect = toggleRef.current?.getBoundingClientRect();
+    if (
+      toggleRect &&
+      e.clientX >= toggleRect.left - TOGGLE_MARGIN &&
+      e.clientX <= toggleRect.right + TOGGLE_MARGIN &&
+      e.clientY >= toggleRect.top - TOGGLE_MARGIN &&
+      e.clientY <= toggleRect.bottom + TOGGLE_MARGIN
+    ) {
+      setShowMagnifier(false);
+      return;
+    }
+
     // Start loading full image on first hover
     if (!hasHovered) setHasHovered(true);
     if (!containerRef.current || !imgRef.current || !fullImageLoaded) return;
@@ -376,9 +455,11 @@ export default function ImageWithMagnifier({
 
         {/* Desktop: lens on/off toggle — top-left (deep-zoom button owns top-right).
             While the lens is up it captures scroll for zoom, so readers who want
-            to wheel past a tall facsimile can switch it off. */}
+            to wheel past a tall facsimile can switch it off. Floats with the
+            scroll position, and sits above the lens so it's never painted over. */}
         {!isTouchDevice && isLoaded && (
           <button
+            ref={toggleRef}
             type="button"
             onClick={(e) => {
               e.stopPropagation();
@@ -387,7 +468,8 @@ export default function ImageWithMagnifier({
             title={lensEnabled ? 'Magnifier on — click to turn off (restores normal scrolling)' : 'Turn on magnifier'}
             aria-label={lensEnabled ? 'Turn off magnifier' : 'Turn on magnifier'}
             aria-pressed={lensEnabled}
-            className={`absolute top-2 left-2 z-10 flex h-8 w-8 items-center justify-center rounded-lg backdrop-blur-sm transition-colors ${
+            style={{ top: toggleTop, zIndex: 110 }}
+            className={`absolute left-2 flex h-8 w-8 items-center justify-center rounded-lg backdrop-blur-sm transition-colors ${
               lensEnabled
                 ? 'bg-black/55 text-white hover:bg-black/80'
                 : 'bg-black/30 text-white/60 hover:bg-black/55 hover:text-white'

--- a/src/hooks/useFloatingOverlayTop.ts
+++ b/src/hooks/useFloatingOverlayTop.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useState, type RefObject } from 'react';
+
+/** Gap between a floating control and the top of the visible area, in px. */
+export const FLOATING_OVERLAY_MARGIN = 8;
+
+/**
+ * Marks a control the magnifier lens must not cover. `ImageWithMagnifier` hides
+ * the lens while the cursor is on (or just beside) any element carrying this
+ * attribute, so a reader can always see the button they're reaching for.
+ */
+export const LENS_AVOID_ATTR = 'data-lens-avoid';
+
+/**
+ * Keeps an absolutely-positioned control (the magnifier toggle, the deep-zoom
+ * button) on screen while the image beneath it scrolls past. Returns the `top`
+ * offset to apply, measured from the control's positioning container.
+ *
+ * `position: sticky` cannot do this. The reader wraps each page scan in an
+ * `overflow-hidden` box, which becomes sticky's scroll container — and that box
+ * never scrolls, so a sticky control would simply sit still. Instead we find the
+ * nearest ancestor that genuinely scrolls (the reader panel) and offset the
+ * control from its own container's top edge, clamped so it never runs past the
+ * bottom of the image.
+ *
+ * Page-scrolled callers have no scrollable ancestor; there the ceiling is the
+ * bottom of the sticky site header, or the viewport top when it doesn't stick.
+ *
+ * @param ref     the control itself — its `offsetParent` is the container it floats within
+ * @param enabled false while the control is unmounted or irrelevant (no listeners bound)
+ */
+export function useFloatingOverlayTop(
+  ref: RefObject<HTMLElement | null>,
+  enabled: boolean = true
+): number {
+  const [top, setTop] = useState(FLOATING_OVERLAY_MARGIN);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const el = ref.current;
+    const container = el?.offsetParent as HTMLElement | null;
+    if (!el || !container) return;
+
+    let scroller: HTMLElement | null = container.parentElement;
+    while (scroller) {
+      const overflowY = window.getComputedStyle(scroller).overflowY;
+      if (overflowY === 'auto' || overflowY === 'scroll') break;
+      scroller = scroller.parentElement;
+    }
+
+    const viewportTop = () => {
+      if (scroller) return scroller.getBoundingClientRect().top;
+      const header = document.querySelector<HTMLElement>('[data-site-header]');
+      if (!header) return 0;
+      const position = window.getComputedStyle(header).position;
+      if (position !== 'sticky' && position !== 'fixed') return 0;
+      return Math.max(0, header.getBoundingClientRect().bottom);
+    };
+
+    let frame = 0;
+    const update = () => {
+      frame = 0;
+      const box = container.getBoundingClientRect();
+      const height = el.offsetHeight;
+      const maxTop = Math.max(
+        FLOATING_OVERLAY_MARGIN,
+        box.height - height - FLOATING_OVERLAY_MARGIN
+      );
+      const wanted = viewportTop() - box.top + FLOATING_OVERLAY_MARGIN;
+      setTop(Math.min(maxTop, Math.max(FLOATING_OVERLAY_MARGIN, wanted)));
+    };
+    const schedule = () => {
+      if (!frame) frame = requestAnimationFrame(update);
+    };
+
+    update();
+    // `scroll` doesn't bubble, so listen in the capture phase to catch it from
+    // whichever ancestor is actually scrolling.
+    const capture = { capture: true, passive: true } as const;
+    window.addEventListener('scroll', schedule, capture);
+    window.addEventListener('resize', schedule);
+    // The image often loads after mount, growing the container under the control.
+    const observer = new ResizeObserver(schedule);
+    observer.observe(container);
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', schedule, capture);
+      window.removeEventListener('resize', schedule);
+      observer.disconnect();
+    };
+  }, [enabled, ref]);
+
+  return top;
+}


### PR DESCRIPTION
Follow-up to #3095 (magnifier lens on/off toggle).

Two problems with the toggle as shipped:

1. **It scrolled away.** The button was `absolute top-2 left-2` on the image, so once you scrolled down a tall facsimile it was gone — exactly when you want it, since the lens captures the wheel for zoom. It now floats, tracking the top of the visible slice of the image.
2. **The lens covered it.** The lens is centred on the cursor, so as you reached for the button the lens sat on top of it. Hovering the toggle (within 8px) now hides the lens, and the button paints above the lens (`z-index: 110` vs the lens's `100`) so it stays visible when the lens is merely nearby.

## Why not `position: sticky`

Every caller wraps the image in a `rounded-lg overflow-hidden` box. That box becomes sticky's scroll container, and it never scrolls — so a sticky button would simply sit still. Instead the effect walks up to the nearest ancestor whose `overflow-y` is `auto`/`scroll` (the reader panel, `[data-reader-panel]`) and offsets the button from the container's own top edge, clamped so it never runs past the image's bottom. Updates are rAF-throttled and bound in the capture phase, since `scroll` doesn't bubble.

Page-scrolled callers (`ArtworkHero` with `fitWidth`) have no scrollable ancestor; there the ceiling is the bottom of the sticky site header (`[data-site-header]`), or 0 when the header is static.

## Verified

Driven in Chrome against the reader (`/book/four-books-on-human-proportion-durer/page/…`, a 315-page Dürer facsimile):
- scrolled the image panel to its bottom → button pinned 8px below the panel's top edge (`style.top` 8px → 340px), still on screen
- scrolled back to top → button returns to the image corner
- hovered mid-image → lens appears, and renders *under* the button
- hovered the button → lens disappears

`npx tsc --noEmit` clean.

## Out of scope

The deep-zoom button (top-right, `PageDeepZoomButton`) still scrolls with the image. Same treatment would apply, but it's a separate component and this PR stays on the magnifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)