### PR TITLE
Reader comfort: themes (Paper/Sepia/Night), 70ch measure, settings on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,6 +228,69 @@ h1, h2, h3, h4 {
   margin-bottom: 1.5em;
 }
 
+/* ---------------------------------------------------------------------------
+   Reader: reading measure and themes
+   (book reader at /book/[slug]/page/[pageId] — TranslationEditor read mode)
+--------------------------------------------------------------------------- */
+
+/* Cap the text measure inside reader text panels. Long lines on wide screens
+   are the single biggest readability cost; ~70ch is the classic upper bound.
+   Scoped to reader panels so prose-manuscript elsewhere is untouched. */
+[data-reader-panel] .prose-manuscript {
+  max-width: 70ch;
+  margin-inline: auto;
+}
+/* Nested NotesRenderer inside an already-capped wrapper: don't re-center */
+[data-reader-panel] .prose-manuscript .prose-manuscript {
+  max-width: none;
+  margin-inline: 0;
+}
+
+/* Reader themes: components inside the reader style themselves with the CSS
+   variables below, so re-declaring the variables on the themed root re-skins
+   the whole surface. Values composed from the existing palette (no new
+   design primitives): sepia warms the paper tokens, night inverts around
+   --bg-dark (#1a1612). */
+[data-reader-theme='sepia'] {
+  --bg-cream: #f6eeda;
+  --bg-white: #fbf4e4;
+  --bg-warm: #efe4cb;
+  --border-light: #e3d6ba;
+  --border-medium: #d1c1a0;
+}
+
+[data-reader-theme='night'] {
+  --bg-cream: #1a1612;
+  --bg-white: #211c17;
+  --bg-warm: #2a241d;
+  --text-primary: #ece7df;
+  --text-secondary: #cfc8bd;
+  --text-muted: #a49b8f;
+  --text-faint: #7d766c;
+  --border-light: #3a332b;
+  --border-medium: #4a4238;
+  /* "dark" accent variants exist for text on light backgrounds — lighten them */
+  --accent-sage-dark: #a8b898;
+  --accent-gold-dark: #d4b072;
+}
+
+/* Night-mode compatibility for hardcoded light-utility classes used inside the
+   reader (buttons, chips, the settings popover). Scoped to the themed root. */
+[data-reader-theme='night'] .bg-white { background-color: #211c17; }
+[data-reader-theme='night'] .bg-stone-100 { background-color: #2f2921; }
+[data-reader-theme='night'] .bg-stone-200 { background-color: #3d352a; }
+[data-reader-theme='night'] .hover\:bg-stone-100:hover { background-color: #373026; }
+[data-reader-theme='night'] .hover\:bg-stone-200:hover { background-color: #453c30; }
+[data-reader-theme='night'] .active\:bg-stone-300:active { background-color: #4d4436; }
+[data-reader-theme='night'] .hover\:bg-black\/5:hover { background-color: rgba(255, 255, 255, 0.08); }
+[data-reader-theme='night'] .text-stone-400 { color: #857c70; }
+[data-reader-theme='night'] .text-stone-500 { color: #a49b8f; }
+[data-reader-theme='night'] .text-stone-600 { color: #b5ac9f; }
+[data-reader-theme='night'] .text-primary { color: #ece7df; }
+[data-reader-theme='night'] .hover\:text-secondary:hover { color: #cfc8bd; }
+[data-reader-theme='night'] .text-stone-700 { color: #cfc8bd; }
+[data-reader-theme='night'] .hover\:text-stone-700:hover { color: #ece7df; }
+
 /* Prose styling for content/document pages */
 .prose-content {
   font-family: 'Newsreader', Georgia, serif;

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -28,7 +28,7 @@ import {
   AlertCircle,
   Crosshair,
 } from 'lucide-react';
-import { useReaderPreferences } from '@/hooks/useReaderPreferences';
+import { useReaderPreferences, type ReaderTheme } from '@/hooks/useReaderPreferences';
 import NotesRenderer from '@/components/reader/NotesRenderer';
 import TraceAlignment, { type TraceStatus } from '@/components/reader/TraceAlignment';
 import AiBadge from '@/components/ui/AiBadge';
@@ -477,7 +477,7 @@ export default function TranslationEditor({
     translation: page.translation?.data || '',
     summary: page.summary?.data || '',
   });
-  const { fontSize, lineHeight, increaseFontSize, decreaseFontSize, resetFontSize, isMinSize, isMaxSize, isDefaultSize } = useReaderPreferences();
+  const { fontSize, lineHeight, increaseFontSize, decreaseFontSize, resetFontSize, isMinSize, isMaxSize, isDefaultSize, theme, setTheme } = useReaderPreferences();
 
   // Modernized text toggle
   const [modernizedMode, setModernizedMode] = useState(() => {
@@ -1078,7 +1078,7 @@ export default function TranslationEditor({
     const isFullyTranslated = ocrText && translationText;
 
     return (
-      <div className="h-screen flex flex-col" style={{ background: 'var(--bg-cream)' }}>
+      <div className="h-screen flex flex-col" data-reader-theme={theme} style={{ background: 'var(--bg-cream)' }}>
         {/* Header - Two rows on mobile, one row on desktop */}
         <header className="px-3 sm:px-4 py-2 sm:py-3" style={{ background: 'var(--bg-white)', borderBottom: '1px solid var(--border-light)' }}>
           {/* Row 1: Back + Title ... Chapter Nav ... Page Navigator */}
@@ -1251,20 +1251,20 @@ export default function TranslationEditor({
 
             {/* Right side: Mode toggle + Like + extras on desktop */}
             <div className="flex items-center gap-1 sm:gap-2">
-              {/* Desktop extras: Font size */}
-              <div className="hidden sm:flex items-center p-1 rounded-lg" style={{ background: 'var(--bg-warm)' }}>
+              {/* Reading settings: font size + theme */}
+              <div className="flex items-center p-1 rounded-lg" style={{ background: 'var(--bg-warm)' }}>
                 <div className="relative" ref={fontControlsRef}>
                   <button
                     onClick={() => setShowFontControls(prev => !prev)}
                     className={`flex items-center gap-0.5 p-1.5 rounded-md text-xs font-medium transition-all hover:bg-stone-100 ${showFontControls ? 'bg-stone-200' : ''}`}
                     style={{ color: showFontControls ? 'var(--text-primary)' : 'var(--text-muted)' }}
-                    aria-label="Font size"
-                    title="Font size"
+                    aria-label="Reading settings"
+                    title="Reading settings"
                   >
                     <span className="text-xs">A</span><span className="text-base font-semibold leading-none">A</span>
                   </button>
                   {showFontControls && (
-                    <div className="absolute right-0 top-full mt-2 z-50 bg-white rounded-xl shadow-lg border p-4" style={{ borderColor: 'var(--border-light)', minWidth: '200px' }}>
+                    <div className="absolute right-0 top-full mt-2 z-50 bg-white rounded-xl shadow-lg border p-4" style={{ borderColor: 'var(--border-light)', minWidth: '220px' }}>
                       <div className="text-[10px] uppercase tracking-widest text-center mb-3" style={{ color: 'var(--text-muted)' }}>Font Size</div>
                       <div className="flex items-center justify-between gap-4">
                         <button
@@ -1294,6 +1294,30 @@ export default function TranslationEditor({
                         >
                           A
                         </button>
+                      </div>
+                      <div className="text-[10px] uppercase tracking-widest text-center mt-4 mb-3" style={{ color: 'var(--text-muted)' }}>Theme</div>
+                      <div className="flex items-center justify-between gap-2">
+                        {([
+                          ['paper', 'Paper', '#fdfcf9', '#1a1612'],
+                          ['sepia', 'Sepia', '#f6eeda', '#1a1612'],
+                          ['night', 'Night', '#1a1612', '#ece7df'],
+                        ] as [ReaderTheme, string, string, string][]).map(([key, label, bg, fg]) => (
+                          <button
+                            key={key}
+                            onClick={() => setTheme(key)}
+                            className="flex-1 flex flex-col items-center gap-1 py-2 rounded-lg border-2 transition-all focus-visible:ring-2 focus-visible:ring-accent-rust focus-visible:outline-none"
+                            style={{
+                              background: bg,
+                              color: fg,
+                              borderColor: theme === key ? 'var(--accent-rust)' : 'var(--border-light)',
+                            }}
+                            aria-pressed={theme === key}
+                            title={`${label} theme`}
+                          >
+                            <span className="text-sm font-serif leading-none">Aa</span>
+                            <span className="text-[10px]">{label}</span>
+                          </button>
+                        ))}
                       </div>
                     </div>
                   )}

--- a/src/hooks/useReaderPreferences.ts
+++ b/src/hooks/useReaderPreferences.ts
@@ -8,6 +8,10 @@ const MAX_SIZE = 32;
 const STEP = 2;
 const DEFAULT_SIZE = 18;
 
+export type ReaderTheme = 'paper' | 'sepia' | 'night';
+const THEMES: ReaderTheme[] = ['paper', 'sepia', 'night'];
+const DEFAULT_THEME: ReaderTheme = 'paper';
+
 function computeLineHeight(fontSize: number): number {
   // 1.6 at 14px, 1.8 at 18px, 2.0 at 24px
   return 1.6 + (fontSize - MIN_SIZE) * 0.04;
@@ -15,20 +19,23 @@ function computeLineHeight(fontSize: number): number {
 
 interface ReaderPrefs {
   fontSize: number;
+  theme: ReaderTheme;
 }
 
 function loadPrefs(): ReaderPrefs {
-  if (typeof window === 'undefined') return { fontSize: DEFAULT_SIZE };
+  const defaults: ReaderPrefs = { fontSize: DEFAULT_SIZE, theme: DEFAULT_THEME };
+  if (typeof window === 'undefined') return defaults;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       const parsed = JSON.parse(raw);
-      if (parsed.fontSize >= MIN_SIZE && parsed.fontSize <= MAX_SIZE) {
-        return { fontSize: parsed.fontSize };
-      }
+      return {
+        fontSize: parsed.fontSize >= MIN_SIZE && parsed.fontSize <= MAX_SIZE ? parsed.fontSize : DEFAULT_SIZE,
+        theme: THEMES.includes(parsed.theme) ? parsed.theme : DEFAULT_THEME,
+      };
     }
   } catch { /* ignore */ }
-  return { fontSize: DEFAULT_SIZE };
+  return defaults;
 }
 
 function savePrefs(prefs: ReaderPrefs) {
@@ -39,15 +46,18 @@ function savePrefs(prefs: ReaderPrefs) {
 
 export function useReaderPreferences() {
   const [fontSize, setFontSize] = useState(DEFAULT_SIZE);
+  const [theme, setThemeState] = useState<ReaderTheme>(DEFAULT_THEME);
 
   useEffect(() => {
-    setFontSize(loadPrefs().fontSize);
+    const prefs = loadPrefs();
+    setFontSize(prefs.fontSize);
+    setThemeState(prefs.theme);
   }, []);
 
   const increaseFontSize = useCallback(() => {
     setFontSize(prev => {
       const next = Math.min(prev + STEP, MAX_SIZE);
-      savePrefs({ fontSize: next });
+      savePrefs({ ...loadPrefs(), fontSize: next });
       return next;
     });
   }, []);
@@ -55,14 +65,19 @@ export function useReaderPreferences() {
   const decreaseFontSize = useCallback(() => {
     setFontSize(prev => {
       const next = Math.max(prev - STEP, MIN_SIZE);
-      savePrefs({ fontSize: next });
+      savePrefs({ ...loadPrefs(), fontSize: next });
       return next;
     });
   }, []);
 
   const resetFontSize = useCallback(() => {
     setFontSize(DEFAULT_SIZE);
-    savePrefs({ fontSize: DEFAULT_SIZE });
+    savePrefs({ ...loadPrefs(), fontSize: DEFAULT_SIZE });
+  }, []);
+
+  const setTheme = useCallback((next: ReaderTheme) => {
+    setThemeState(next);
+    savePrefs({ ...loadPrefs(), theme: next });
   }, []);
 
   return {
@@ -74,5 +89,7 @@ export function useReaderPreferences() {
     isMinSize: fontSize <= MIN_SIZE,
     isMaxSize: fontSize >= MAX_SIZE,
     isDefaultSize: fontSize === DEFAULT_SIZE,
+    theme,
+    setTheme,
   };
 }


### PR DESCRIPTION
## What
Re-lands the reading-comfort subset of the reverted #3094 (revert: #3101). Derek's verdict was: focus mode not good, comfort features good.

**In scope**
- **Reader themes** — Paper / Sepia / Night picker in the reader's settings popover, persisted alongside font size in the existing `reader-prefs` localStorage key. Implemented by re-declaring the palette CSS variables on the read-mode root via `data-reader-theme`; sepia warms the paper tokens, night inverts around `--bg-dark`. No new design primitives.
- **Measure cap** — reader text panels cap prose at 70ch and center it (`[data-reader-panel] .prose-manuscript`), with an opt-out for nested NotesRenderer wrappers.
- **Settings on mobile** — the font-size control (now "Reading settings") loses its `hidden sm:` gate so phone readers can set size and theme.

**Out of scope (deliberately not re-landed)**
- `ReaderFocusMode` component, `data-reader-chrome` hiding machinery, mobile image-panel suppression — the parts Derek rejected. The full version survives on `feat/focused-reading` if ever reworked.

## Verification
- `npx tsc --noEmit` clean.
- `data-reader-panel` attributes already exist on main (they predate #3094's revert), so the measure CSS binds without component changes.
- Theme prefs round-trip: unknown stored theme falls back to `paper`; font-size bounds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)