### PR TITLE
fix(gallery): restore the magnifier near the caption; keep floating controls under overlays

### DIFF
--- a/src/app/gallery/image/[id]/page.tsx
+++ b/src/app/gallery/image/[id]/page.tsx
@@ -853,9 +853,9 @@ export default function ImageDetailPage({
             </div>
           </div>
 
-          {/* Type badge */}
+          {/* Type badge — left-12 clears the magnifier's lens toggle, which owns top-left */}
           {data.type && (
-            <span className="absolute top-3 left-3 px-2.5 py-0.5 rounded-full text-xs bg-accent-rust/90 text-white capitalize z-10">
+            <span className="absolute top-3 left-12 px-2.5 py-0.5 rounded-full text-xs bg-accent-rust/90 text-white capitalize z-10">
               {data.type}
             </span>
           )}
@@ -913,8 +913,12 @@ export default function ImageDetailPage({
             </button>
           )}
 
-          {/* Title + attribution overlay at bottom of image */}
-          <div className="absolute bottom-0 left-0 right-0 z-20 px-5 pb-5 pt-24 bg-gradient-to-t from-black/70 via-black/40 to-transparent">
+          {/* Title + attribution overlay at bottom of image.
+              pointer-events-none: this band (plus its 96px of gradient padding)
+              lies over the bottom of the image, and swallowing the pointer there
+              killed the magnifier lens across the lower fifth of every plate.
+              The same title and caption are selectable in the details section below. */}
+          <div className="pointer-events-none absolute bottom-0 left-0 right-0 z-20 px-5 pb-5 pt-24 bg-gradient-to-t from-black/70 via-black/40 to-transparent">
             <h1 className="text-xl sm:text-2xl md:text-3xl font-serif text-white leading-snug line-clamp-2">{data.description}</h1>
             <p className="text-base sm:text-lg text-white/60 mt-1.5">
               {data.book.title}{data.book.author && data.book.author !== 'Various' ? ` \u2014 ${data.book.author}` : ''}{data.book.year ? ` (${data.book.year})` : ''}, p.{data.pageNumber}

--- a/src/components/reader/PageDeepZoomButton.tsx
+++ b/src/components/reader/PageDeepZoomButton.tsx
@@ -19,7 +19,11 @@
 import { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import { Search, X, Maximize2 } from 'lucide-react';
 import type { DeepZoomManifest } from '@/lib/types/book';
-import { useFloatingOverlayTop, LENS_AVOID_ATTR } from '@/hooks/useFloatingOverlayTop';
+import {
+  useFloatingOverlayTop,
+  LENS_AVOID_ATTR,
+  OVERLAY_CONTROL_Z,
+} from '@/hooks/useFloatingOverlayTop';
 
 const DeepZoomInline = lazy(() => import('./DeepZoomInline'));
 const DeepZoomOverlay = lazy(() => import('@/components/artwork/DeepZoomOverlay'));
@@ -60,7 +64,7 @@ export default function PageDeepZoomButton({
           ref={buttonRef}
           {...{ [LENS_AVOID_ATTR]: '' }}
           onClick={() => (isDesktop ? setInline(true) : setOverlay(true))}
-          style={{ top: buttonTop, zIndex: 110 }}
+          style={{ top: buttonTop, zIndex: OVERLAY_CONTROL_Z }}
           className="absolute right-2 flex items-center gap-1.5 px-2.5 py-1.5 bg-black/55 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-colors"
           title="Open deep zoom — stream this page at full resolution"
         >

--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -7,6 +7,8 @@ import {
   useFloatingOverlayTop,
   FLOATING_OVERLAY_MARGIN,
   LENS_AVOID_ATTR,
+  LENS_Z,
+  OVERLAY_CONTROL_Z,
 } from '@/hooks/useFloatingOverlayTop';
 
 // Readers can switch the hover lens off (it captures scroll-to-zoom, which makes
@@ -427,7 +429,7 @@ export default function ImageWithMagnifier({
             title={lensEnabled ? 'Magnifier on — click to turn off (restores normal scrolling)' : 'Turn on magnifier'}
             aria-label={lensEnabled ? 'Turn off magnifier' : 'Turn on magnifier'}
             aria-pressed={lensEnabled}
-            style={{ top: toggleTop, zIndex: 110 }}
+            style={{ top: toggleTop, zIndex: OVERLAY_CONTROL_Z }}
             className={`absolute left-2 flex h-8 w-8 items-center justify-center rounded-lg backdrop-blur-sm transition-colors ${
               lensEnabled
                 ? 'bg-black/55 text-white hover:bg-black/80'
@@ -465,7 +467,7 @@ export default function ImageWithMagnifier({
                 backgroundPosition: `${-(magnifierPosition.x / 100) * bgW + lensW / 2}px ${-(magnifierPosition.y / 100) * bgH + lensH / 2}px`,
                 backgroundRepeat: 'no-repeat',
                 backgroundColor: 'white',
-                zIndex: 100,
+                zIndex: LENS_Z,
               }}
             >
               <span

--- a/src/hooks/useFloatingOverlayTop.ts
+++ b/src/hooks/useFloatingOverlayTop.ts
@@ -6,6 +6,15 @@ import { useEffect, useState, type RefObject } from 'react';
 export const FLOATING_OVERLAY_MARGIN = 8;
 
 /**
+ * Stacking tiers *within* an image area. Both must stay below the full-screen
+ * overlays that cover the image entirely — `DeepZoomOverlay` (z-60) and
+ * `FullscreenImageViewer` (z-100) — or a control paints on top of the very
+ * viewer it opened.
+ */
+export const LENS_Z = 30; // above the page's own image chrome (badges, arrows, captions)
+export const OVERLAY_CONTROL_Z = 40; // above the lens, so the lens never hides a button
+
+/**
  * Marks a control the magnifier lens must not cover. `ImageWithMagnifier` hides
  * the lens while the cursor is on (or just beside) any element carrying this
  * attribute, so a reader can always see the button they're reaching for.


### PR DESCRIPTION
Two bugs Derek hit on `/gallery/image`, both on [the same plate](https://sourcelibrary.org/gallery/image/69b6be2d8566c83814642ec1-0).

### 1. The lens died across the bottom fifth of every image

The title/attribution overlay is a **sibling** of the image container (`absolute bottom-0 … z-20 pt-24`). Those 96px of gradient padding sit over the bottom of the image, and because the band accepted the pointer, moving into it fired `mouseleave` on the container and dismissed the lens. So you could never magnify the lower part of a plate — exactly where the engraver's caption and `fig.` labels live.

It holds an `<h1>` and a `<p>` and nothing interactive, so it now gets `pointer-events-none`. The same title and caption remain selectable in the details section below the fold.

### 2. The floating controls painted over the full-screen viewers (regression from #3111)

I gave them `z-index: 110`. That outranks `FullscreenImageViewer` (`z-[100]`) and `DeepZoomOverlay` (`z-[60]`), so the lens toggle and the deep-zoom button rendered **on top of the very viewer they had just opened**.

Fixed by scoping the numbers to a tier that lives entirely under the full-screen overlays, exported from the shared hook so the relationship is stated once:

- `LENS_Z = 30` — above the page's own image chrome (type badge, nav arrows, caption)
- `OVERLAY_CONTROL_Z = 40` — above the lens, so the lens never hides a button

Raising the two overlays instead would have worked, but the invariant belongs with the controls: anything drawn *inside* an image area must stay below anything that *covers* it.

### 3. Drive-by

The gallery type badge (`top-3 left-3`) collided with the lens toggle (`top-2 left-2`). Moved to `left-12`.

## Verified

In Chrome against the plate above: hovering the caption band now magnifies (lens paints above the caption); clicking opens the fullscreen viewer with no controls bleeding through (`toggle z=40` vs `viewer z=100`); badge and toggle no longer overlap. Re-checked the reader (`/book/…/page/…`) — lens `z=30`, both controls `z=40`, floating and lens-avoidance from #3111 still behave.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)