### PR TITLE
chore(worktrees): reap by occupancy, not session count; add /gnite

### DIFF
--- a/.claude/commands/gnite.md
+++ b/.claude/commands/gnite.md
@@ -1,0 +1,53 @@
+Wrap up the session: commit, push, reap, hand off.
+
+"gnite" means **this window is closing** — not that every window is. Other Claude
+sessions are usually still running, and that's fine: every step below is safe to run
+concurrently with them. No new work, no questions, no strategic advice.
+
+## 1. Commit and push whatever is here
+
+- `git status` — if there are uncommitted changes, commit them with a clear message
+  and `Signed-off-by: JDerekLomas <j.d.lomas@tudelft.nl>` (the DCO bot blocks PRs without it).
+- Push. If this is a worktree with a feature branch and the work is complete,
+  open a PR (`gh pr create --base main`).
+- **Never leave uncommitted work in a worktree** — it's invisible to every other session,
+  and the reaper will keep the worktree around rather than touch it.
+
+## 2. Reap dead worktrees
+
+Run from the main checkout:
+
+```
+node scripts/maintenance/reap-worktrees.mjs --apply --merged-only --prune-branches
+```
+
+This is safe with other windows open. The reaper decides by **occupancy**, not by
+counting sessions: a worktree is kept if a live process has its cwd inside it, if its
+git lock names a running pid, or if it holds real uncommitted work. Everything else is
+an orphan whose session ended — which is exactly what accumulates, because a worktree
+can't be removed while its PR is open, and the PR merges after the session is gone.
+
+So each `gnite` cleans up after the *dead*, not after the living. One window at a time
+is the intended cadence. `--merged-only` additionally keeps any worktree whose PR is
+still open, so in-flight work survives even if its session ended.
+
+Show the user what was removed, and surface anything kept for stranded uncommitted
+work so they can deal with it. Don't pass `--force` — it exists only for the case
+where `lsof` is unavailable and occupancy can't be determined.
+
+## 3. Hand off if the session was complex
+
+Write `.claude/handoffs/YYYY-MM-DD-topic.md` covering: files modified, task state,
+test/deploy outcomes, what was agreed. Skip for short or routine sessions.
+
+**This repo is public (AGPL).** Operational and business material — fundraising,
+contacts, outreach, budgets, donors, sponsors — goes in the private
+`sourcelibrary-ops` repo (`~/sourcelibrary-ops`), never here.
+
+Then ask the handoff question: **does `CLAUDE.md` need a new invariant?** If this
+session hit a non-obvious failure that would bite the next person, PR the doc change
+now. Otherwise the lesson lives only in the handoff and decays.
+
+## 4. Say goodnight
+
+A short summary of where we left off and what's next. That's all.

--- a/.claude/commands/reap-worktrees.md
+++ b/.claude/commands/reap-worktrees.md
@@ -2,8 +2,27 @@ Clean up finished git worktrees safely.
 
 Run `node scripts/maintenance/reap-worktrees.mjs $ARGUMENTS` from the main checkout.
 
-- With no arguments it's a **dry-run**: it lists which worktrees would be removed and flags any with real uncommitted work (those are kept). Show the user that output.
-- If the user wants to actually remove them, run with `--apply`. Add `--merged-only` to keep worktrees whose PR is still open, or `--prune-branches` to also delete the local branches.
-- The script removes only worktrees with no real uncommitted work and preserves all branches/commits (a removed worktree is just re-checkout-able). It refuses `--apply` while other claude sessions look active — best run when sessions are closed.
+- With no arguments it's a **dry-run**: it lists what would be removed and what it's
+  keeping (in-use, stranded work, open PR). Show the user that output.
+- To actually remove them, run with `--apply`. Add `--merged-only` to keep worktrees
+  whose PR is still open, and `--prune-branches` to also delete the local branches.
+- The script preserves all branches and commits — a removed worktree is just
+  re-checkout-able. Only the working directory goes.
 
-After it runs, briefly summarize what was removed and surface any worktrees it kept for having stranded uncommitted work, so the user can deal with them.
+**It is safe to run while other Claude sessions are open.** The reaper decides by
+occupancy, not by counting sessions: a worktree is kept if a live process has its cwd
+inside it, if its git lock names a running pid, or if it holds real uncommitted work.
+Everything else is an orphan whose session already ended. This is why `/gnite` can reap
+one window at a time — each pass cleans up after the dead, never the living.
+
+Don't reach for `--force`. It only exists for the case where `lsof` is unavailable and
+occupancy can't be determined, at which point the script falls back to a conservative
+"any other session ⇒ refuse" check. Forcing past a *live* occupancy result would yank a
+working directory out from under a running session.
+
+Stale locks (lock pid is dead) are unlocked and reaped automatically. Live locks are
+kept — `git worktree remove --force` refuses a locked worktree anyway (git wants
+`-f -f`), so unlocking is a deliberate, checked step rather than a flag.
+
+After it runs, briefly summarize what was removed and surface any worktree it kept for
+stranded uncommitted work, so the user can deal with it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,9 @@ Derek runs ~10 Claude Code terminals simultaneously, all sharing the main workin
 - Active worktrees: `git worktree list`
 - Worktrees live in `.claude/worktrees/`
 - **Fresh worktrees fail the pre-commit `check-imports` hook** because `src/lib/vendor/lamejs-bundle.js` is gitignored and absent from a new checkout. Before your first commit, copy it from the main checkout: `cp <main-dir>/src/lib/vendor/lamejs-bundle.js src/lib/vendor/`.
+- **Worktrees accumulate structurally, not from sloppiness.** A worktree can't be removed while its PR is open, and the PR merges *after* the creating session ends — so nothing is left to reap it. Per-session `ExitWorktree` discipline cannot fix this. `/gnite` runs the reaper, and `/reap-worktrees` runs it on demand.
+- **Judge a worktree by occupancy, never by a global session count.** `reap-worktrees.mjs` keeps a worktree iff a live process has its cwd inside it (`lsof -d cwd`), its git lock names a running pid, or it holds real uncommitted work. Everything else is an orphan. Asked per worktree the question is exact, so reaping is safe with other sessions open — which is what lets `/gnite` reap one window at a time. The old `ps | grep -i claude` count reported **34 sessions on a machine running 3** (it matched the desktop app, the dashboard, and MCP helpers), so `--apply` always refused and the habit became `--force` — the one genuinely dangerous flag. A noisy safety check doesn't fail closed; it trains people to bypass it.
+- **`git worktree remove --force` refuses a *locked* worktree** — git wants `-f -f`. Don't force twice. `EnterWorktree` writes its session pid into the lock reason, so a dead pid means a stale lock (unlock, then reap) and a live pid means someone is working (keep). Locking is a deliberate "don't touch" signal; the reaper honors it.
 
 ## Data Protection — CRITICAL
 - **NEVER** delete books, pages, or source material without explicit confirmation

--- a/scripts/maintenance/reap-worktrees.mjs
+++ b/scripts/maintenance/reap-worktrees.mjs
@@ -5,9 +5,13 @@
  * Worktrees accumulate because one can't be removed while its PR is still open,
  * and the PR usually merges AFTER the session that created it has ended — so
  * nothing is left around to remove the now-done worktree. This is the reaper:
- * run it when sessions are idle and it removes the clutter SAFELY.
+ * it removes whatever no living process owns.
  *
  * Safety model (no committed work is ever lost):
+ *   - OCCUPANCY, not session-counting. A worktree is "in use" iff some live
+ *     process has its cwd inside it, or its git lock names a still-running pid.
+ *     Asked per worktree, this is exact — so the reaper can run safely while
+ *     other sessions are open, which is what makes a per-window /gnite reap work.
  *   - Removes only worktrees with NO real uncommitted work. Per-machine config
  *     and scratch outputs (.claude/, settings.local.json, scripts/output, _tmp*,
  *     vendor/lamejs-bundle) are treated as benign — not work.
@@ -15,12 +19,15 @@
  *     work surfaces for a deliberate commit-or-discard.
  *   - `git worktree remove` leaves the BRANCH intact — commits survive; a removed
  *     worktree is just re-checkout-able. Only the working directory goes.
- *   - --apply refuses to run while OTHER claude sessions look active (could yank a
- *     live cwd). Override with --force. Dry-run is always safe.
+ *   - Stale locks (lock pid is dead) are unlocked and reaped. Live locks are kept.
+ *     `git worktree remove --force` REFUSES a locked worktree (git wants -f -f);
+ *     unlocking first is deliberate, so a live lock can never be forced away.
+ *   - If occupancy can't be determined (no lsof), falls back to the old
+ *     conservative "any other claude session ⇒ refuse" check. --force overrides.
  *
  * Usage:
  *   node scripts/maintenance/reap-worktrees.mjs                 # dry-run (default)
- *   node scripts/maintenance/reap-worktrees.mjs --apply         # remove clean/benign worktrees
+ *   node scripts/maintenance/reap-worktrees.mjs --apply         # remove unoccupied, clean worktrees
  *   node scripts/maintenance/reap-worktrees.mjs --apply --merged-only   # only those whose PR is merged/closed (keeps open-PR checkouts; needs gh)
  *   node scripts/maintenance/reap-worktrees.mjs --apply --prune-branches # also delete local branches whose worktree was reaped
  */
@@ -39,31 +46,73 @@ const BENIGN = [/(^|\/)\.claude\//, /(^|\/)settings\.local\.json$/, /(^|\/)node_
 const isBenign = (f) => BENIGN.some((re) => re.test(f));
 
 const here = process.cwd();
+const alive = (pid) => { try { process.kill(pid, 0); return true; } catch (e) { return e.code === 'EPERM'; } };
 
-// Best-effort: how many claude CLI sessions look active (excluding this script)?
+/**
+ * Every live process's cwd, in one call (~0.2s system-wide). Returns null if
+ * lsof is unavailable, which the caller treats as "occupancy unknown".
+ *
+ * Over-inclusion is harmless here: a process whose cwd is not inside a worktree
+ * blocks nothing. That's why this replaced counting `ps | grep -i claude` hits —
+ * that count reached 34 on a machine with 3 real sessions (it matched the desktop
+ * app, the dashboard, and MCP helpers), so --apply always refused and the habit
+ * became --force, which is the actually dangerous flag.
+ */
+function liveCwds() {
+  const out = sh('lsof -d cwd -Fpn 2>/dev/null');
+  if (!out.trim()) return null;
+  const cwds = [];
+  let pid = null;
+  for (const line of out.split('\n')) {
+    if (line[0] === 'p') pid = Number(line.slice(1));
+    else if (line[0] === 'n' && pid !== process.pid) cwds.push(line.slice(1));
+  }
+  return cwds;
+}
+
+// Fallback only: how many claude CLI sessions look active (excluding this script)?
 function activeSessions() {
   const ps = sh('ps -eo command');
   const hits = ps.split('\n').filter((l) => /\bclaude\b/i.test(l) && !/reap-worktrees/.test(l) && !/\bgrep\b/.test(l));
-  // a single session may spawn helper processes; treat ">1 distinct hit" as "others active"
   return Math.max(0, hits.length - 1);
 }
 
-// Parse `git worktree list --porcelain` into {path, branch}. The FIRST entry is
-// always the primary checkout (the main working tree) — never reap it. (Don't use
-// `git rev-parse --show-toplevel`: from inside a worktree it returns that worktree.)
-const allWts = sh('git worktree list --porcelain').trim().split('\n\n').map((b) => ({
-  path: (b.match(/^worktree (.+)$/m) || [])[1],
-  branch: (b.match(/^branch refs\/heads\/(.+)$/m) || [])[1],
-  bare: /^bare$/m.test(b),
-}));
+// A worktree is occupied if a live cwd is at or beneath its path.
+const cwds = liveCwds();
+const occupiedBy = (p) => cwds && cwds.some((c) => c === p || c.startsWith(p + '/'));
+
+// Parse `git worktree list --porcelain` into {path, branch, locked, lockPid}. The
+// FIRST entry is always the primary checkout (the main working tree) — never reap
+// it. (Don't use `git rev-parse --show-toplevel`: from inside a worktree it
+// returns that worktree.) EnterWorktree writes its session pid into the lock
+// reason, so a dead pid means the owning session ended and the lock is stale.
+sh('git worktree prune');
+const allWts = sh('git worktree list --porcelain').trim().split('\n\n').map((b) => {
+  const lock = b.match(/^locked ?(.*)$/m);
+  const lockPid = lock ? Number((lock[1].match(/pid (\d+)/) || [])[1]) : NaN;
+  return {
+    path: (b.match(/^worktree (.+)$/m) || [])[1],
+    branch: (b.match(/^branch refs\/heads\/(.+)$/m) || [])[1],
+    bare: /^bare$/m.test(b),
+    locked: !!lock,
+    lockReason: lock ? lock[1].trim() : '',
+    lockPid: Number.isFinite(lockPid) ? lockPid : null,
+  };
+});
 const main = allWts[0]?.path;
 const wts = allWts.filter((w) => w.path && w.path !== main && !w.bare);
 
+const keepInUse = [];     // a live process owns it — never touch
 const keepReal = [];      // real uncommitted work — never auto-remove
 const keepOpenPr = [];    // clean but PR still open (only when --merged-only)
 let removable = [];
 
 for (const w of wts) {
+  const liveLock = w.locked && w.lockPid && alive(w.lockPid);
+  if (w.path === here || occupiedBy(w.path) || liveLock) {
+    keepInUse.push({ ...w, why: w.path === here ? 'current dir' : liveLock ? `lock held by live pid ${w.lockPid}` : 'live process cwd inside' });
+    continue;
+  }
   const st = sh('git status --porcelain', w.path).trim();
   const files = st ? st.split('\n').map((l) => l.slice(3)) : [];
   const real = files.filter((f) => !isBenign(f));
@@ -74,6 +123,9 @@ for (const w of wts) {
 if (MERGED_ONLY) {
   const next = [];
   for (const w of removable) {
+    // A detached worktree has no branch to look a PR up by — `gh pr list --head ""`
+    // would match every open PR. Never infer "merged" from that; keep it.
+    if (!w.branch) { keepOpenPr.push({ ...w, state: 'detached' }); continue; }
     const state = sh(`gh pr list --head "${w.branch}" --state all --json state --jq '.[0].state // "NONE"'`).trim();
     if (state === 'MERGED' || state === 'CLOSED') next.push(w);
     else keepOpenPr.push({ ...w, state });
@@ -82,43 +134,69 @@ if (MERGED_ONLY) {
 }
 
 const name = (p) => p.split('/').pop();
-console.log(`worktrees: ${wts.length}  |  removable: ${removable.length}  |  keep(real work): ${keepReal.length}${MERGED_ONLY ? `  |  keep(open/no PR): ${keepOpenPr.length}` : ''}`);
+const ref = (w) => w.branch || 'detached';   // --detach worktrees have no branch
+const staleLocked = removable.filter((w) => w.locked).length;
+console.log(`worktrees: ${wts.length}  |  removable: ${removable.length}${staleLocked ? ` (${staleLocked} stale-locked)` : ''}  |  keep(in use): ${keepInUse.length}  |  keep(real work): ${keepReal.length}${MERGED_ONLY ? `  |  keep(open/no PR): ${keepOpenPr.length}` : ''}`);
 
+if (cwds === null) console.log('\n· lsof unavailable — occupancy unknown, falling back to session-count check.');
+
+if (keepInUse.length) {
+  console.log('\n· KEEP — in use by a live process:');
+  for (const k of keepInUse) console.log(`  ${name(k.path)} [${ref(k)}] (${k.why})`);
+}
 if (keepReal.length) {
   console.log('\n⚠ KEEP — real uncommitted work (commit/push or discard before reaping):');
   for (const k of keepReal.sort((a, b) => b.real.length - a.real.length))
-    console.log(`  ${name(k.path)} [${k.branch}] → ${k.real.slice(0, 4).join(', ')}${k.real.length > 4 ? ` +${k.real.length - 4} more` : ''}`);
+    console.log(`  ${name(k.path)} [${ref(k)}] → ${k.real.slice(0, 4).join(', ')}${k.real.length > 4 ? ` +${k.real.length - 4} more` : ''}`);
 }
 if (keepOpenPr.length) {
   console.log('\n· KEEP — clean but PR still open / none (left for iteration):');
-  for (const k of keepOpenPr) console.log(`  ${name(k.path)} [${k.branch}] (${k.state})`);
+  for (const k of keepOpenPr) console.log(`  ${name(k.path)} [${ref(k)}] (${k.state})`);
 }
 
 if (!APPLY) {
-  console.log(`\nDRY-RUN — would remove ${removable.length} worktree(s) (branches preserved):`);
-  for (const w of removable) console.log(`  ${name(w.path)} [${w.branch}]`);
-  const act = activeSessions();
-  console.log(`\n${act > 0 ? `⚠ ${act} other claude session(s) appear active — reap when idle. ` : ''}Re-run with --apply to remove.`);
+  console.log(`\nDRY-RUN — would remove ${removable.length} worktree(s) (branches ${PRUNE_BRANCHES ? 'deleted' : 'preserved'}):`);
+  for (const w of removable) console.log(`  ${name(w.path)} [${ref(w)}]${w.locked ? ' (stale lock — will unlock)' : ''}`);
+  console.log('\nRe-run with --apply to remove.');
   process.exit(0);
 }
 
-const active = activeSessions();
-if (active > 0 && !FORCE) {
-  console.error(`\n✋ ${active} other claude session(s) appear active — refusing to reap (could yank a live working dir). Run when sessions are closed, or pass --force.`);
-  process.exit(1);
+// Occupancy is exact, so it stands on its own. Only the no-lsof fallback needs
+// the old blunt refusal.
+if (cwds === null) {
+  const active = activeSessions();
+  if (active > 0 && !FORCE) {
+    console.error(`\n✋ occupancy unknown and ${active} other claude session(s) appear active — refusing to reap (could yank a live working dir). Run when sessions are closed, or pass --force.`);
+    process.exit(1);
+  }
 }
 
 let removed = 0;
+const keptBranches = [];
 for (const w of removable) {
-  if (w.path === here) { console.log(`  skip (current dir): ${name(w.path)}`); continue; }
+  // git refuses to remove a locked worktree even with --force (it wants -f -f).
+  // Unlock explicitly — only stale locks reach here, live ones were kept above.
+  if (w.locked) sh(`git worktree unlock "${w.path}"`);
   sh(`git worktree remove --force "${w.path}"`);
   if (!sh('git worktree list --porcelain').includes(w.path)) {
     removed++;
     console.log(`  removed ${name(w.path)}`);
-    if (PRUNE_BRANCHES && w.branch) sh(`git branch -D "${w.branch}"`);
+    if (PRUNE_BRANCHES && w.branch) {
+      // -D only where `gh` confirmed the PR merged/closed: squash-merges leave the
+      // branch tip unreachable from main, so a plain -d would refuse them. Without
+      // that confirmation, -d is the only safe delete — it declines unmerged work.
+      const flag = MERGED_ONLY ? '-D' : '-d';
+      sh(`git branch ${flag} "${w.branch}"`);
+      if (sh(`git branch --list "${w.branch}"`).trim()) keptBranches.push(w.branch);
+    }
   } else {
     console.log(`  FAILED  ${name(w.path)} (still present)`);
   }
 }
 sh('git worktree prune');
-console.log(`\nReaped ${removed} worktree(s). Branches ${PRUNE_BRANCHES ? 'deleted' : 'preserved (re-checkout any time)'}. Stale metadata pruned.`);
+console.log(`\nReaped ${removed} worktree(s). Branches ${PRUNE_BRANCHES ? 'deleted where safe' : 'preserved (re-checkout any time)'}. Stale metadata pruned.`);
+if (keptBranches.length) {
+  console.log(`\n· ${keptBranches.length} branch(es) kept — not merged into main, so -d declined them:`);
+  for (const b of keptBranches) console.log(`  ${b}`);
+  console.log('  Re-run with --merged-only to delete the ones whose PR is merged, or delete by hand.');
+}


### PR DESCRIPTION
## Why

44 worktrees had accumulated, consuming 14 GB. `/reap-worktrees` existed and was never successfully run — because `--apply` refuses whenever another Claude session looks active, and its detector counted `ps | grep -i claude` hits: **34 "sessions" on a machine running 3**. It was matching Claude.app, the menubar dashboard, MCP helpers, and shell snapshots. The documented workaround was `--force`, which is the one flag that can yank a live working directory out from under a running session.

A safety check that noisy doesn't fail closed. It trains you to bypass it.

## What changed

**Occupancy replaces session-counting.** A worktree is in use iff a live process has its cwd inside it, or its git lock names a running pid. One `lsof -d cwd` dump answers this for every process on the system in ~0.2s. Over-counting candidate processes is now *harmless* — a process whose cwd is elsewhere blocks nothing — which is what lets the check be both precise and cheap.

Because the question is asked **per worktree**, reaping is safe while other sessions are open. That's the point: each pass cleans up after the sessions that ended, never the ones still running.

**New `/gnite` command.** Worktrees accumulate structurally, not from sloppiness — a worktree can't be removed while its PR is open, and the PR merges *after* the creating session ends, so nothing is left to reap it. Per-session `ExitWorktree` discipline cannot fix that. Wrap-up is the right hook. `/gnite` commits, pushes, reaps (`--apply --merged-only --prune-branches`), and asks the CLAUDE.md-invariant question. One window at a time, as intended.

### Bugs found and fixed along the way

- **Locked worktrees could never be reaped.** `git worktree remove --force` *refuses* a locked worktree — git wants `-f -f`. The script would loop forever printing `FAILED (still present)` with no explanation. All 6 locks on this machine turned out to be **stale**: `EnterWorktree` writes its session pid into the lock reason, and every one of those pids was dead. Now: dead pid → unlock and reap; live pid → keep. We do *not* force twice; locking is a deliberate "don't touch" signal.
- **`--prune-branches` force-deleted unmerged branches** via unconditional `git branch -D`. Now `-D` only where `gh` confirmed the PR merged/closed (squash merges leave the branch tip unreachable from main, so a plain `-d` would decline them); otherwise `-d`, with skipped branches reported.
- **`--merged-only` on a detached worktree** ran `gh pr list --head ""`, which matches every open PR — it could have classified a detached checkout as "merged." Guarded.

## Verification

Not just typecheck — I drove each safety property against the live repo:

- Parked a `sleep` with its cwd inside a scratch worktree → classified `in use`, kept. Killed it → became removable. (The load-bearing claim.)
- Locked a scratch worktree with a dead pid → reported `stale lock — will unlock`; `unlock` + `remove --force` cleared it.
- Confirmed single `--force` fails on a locked worktree (`fatal: cannot remove a locked working tree; use 'remove -f -f'`), git 2.39.3.
- Dry-run on the real 43: `removable: 42 (6 stale-locked) | keep(in use): 1` — the one kept being this session's own worktree. With `--merged-only`: 32 removable, 10 held back for open PRs.

## Scope

In scope: reaper safety model, lock handling, branch-delete safety, the `/gnite` command, and the CLAUDE.md invariant (per the repo's own "every lesson lands in CLAUDE.md" rule).

Out of scope, deliberately: **actually reaping the 42**, which is a local disk operation needing no PR and which I'll run after this merges. Also out of scope — the 46 orphaned docs, 66 gone-upstream branches, and 8 untracked acquisition scripts found in the same audit. Those are separate concerns and get their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)