### PR TITLE
chore(scripts): commit the acquisition scripts behind two live collections

### DIFF
--- a/scripts/import/early-america-direct.mjs
+++ b/scripts/import/early-america-direct.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Direct import (residential → Atlas) of the American founding intellectual arc:
+ * document gaps, founding fathers' works, early American philosophy, and the
+ * influences the founders drew on. Bypasses /api/import/ia (Vercel→Atlas
+ * timeouts, 2026-07-05). Same doc shape as founding-docs-direct.mjs / the route.
+ * All items are original-language works → text_role:'original'. Lands HIDDEN.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/early-america-direct.mjs --dry-run | --commit
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+const COMMIT = process.argv.includes('--commit');
+
+const BOOKS = [
+  // --- Document gaps ---
+  { ia: 'declarationofind00unit_2', title: 'The Declaration of Independence, and the Constitution of the United States of America', author: 'United States', language: 'English', published: '1796' },
+  { ia: 'constitutionfran00fran', title: "Constitution française présentée au roi par l'Assemblée nationale (avec la Déclaration des droits de l'homme et du citoyen, 1789)", author: 'Assemblée nationale constituante', language: 'French', published: '1791' },
+  // --- Founding fathers: standalone works ---
+  { ia: 'lifeofbenjaminfr00franiala', title: 'The Autobiography of Benjamin Franklin', author: 'Benjamin Franklin', language: 'English', published: '1840' },
+  { ia: 'defenceofconstit00adam_0', title: 'A Defence of the Constitutions of Government of the United States of America, Vol. 1', author: 'John Adams', language: 'English', published: '1787' },
+  { ia: 'defenceofconstit02adam', title: 'A Defence of the Constitutions of Government of the United States of America, Vol. 2', author: 'John Adams', language: 'English', published: '1787' },
+  { ia: 'defenceofconstit003adam', title: 'A Defence of the Constitutions of Government of the United States of America, Vol. 3', author: 'John Adams', language: 'English', published: '1787' },
+  { ia: 'washingtonsfarew01wash', title: "Washington's Farewell Address to the People of the United States", author: 'George Washington', language: 'English', published: '1810' },
+  { ia: 'lettersfromfarme00dick_1', title: 'Letters from a Farmer in Pennsylvania to the Inhabitants of the British Colonies', author: 'John Dickinson', language: 'English', published: '1768' },
+  { ia: 'rightsofbritishc00otis', title: 'The Rights of the British Colonies Asserted and Proved', author: 'James Otis', language: 'English', published: '1764' },
+  { ia: 'bim_eighteenth-century_rights-of-man-part-the-_paine-thomas_1792', title: 'Rights of Man, Part the Second: Combining Principle and Practice', author: 'Thomas Paine', language: 'English', published: '1792' },
+  // --- Early American philosophy ---
+  { ia: 'carefulstrictinq1804edwa', title: 'A Careful and Strict Inquiry into the Modern Prevailing Notions of the Freedom of the Will', author: 'Jonathan Edwards', language: 'English', published: '1804' },
+  { ia: 'treatiseconcerni1746edwa', title: 'A Treatise Concerning Religious Affections', author: 'Jonathan Edwards', language: 'English', published: '1746' },
+  { ia: 'bloudytenentofpe00will_0', title: 'The Bloudy Tenent of Persecution, for Cause of Conscience', author: 'Roger Williams', language: 'English', published: '1644' },
+  { ia: 'journaloflifegos00wooliala', title: 'A Journal of the Life, Gospel Labours, and Christian Experiences of John Woolman', author: 'John Woolman', language: 'English', published: '1774' },
+  { ia: 'bim_eighteenth-century_the-principles-of-action_colden-cadwallader_1751', title: 'The Principles of Action in Matter', author: 'Cadwallader Colden', language: 'English', published: '1751' },
+  { ia: 'christianphiloso00math', title: 'The Christian Philosopher: A Collection of the Best Discoveries in Nature', author: 'Cotton Mather', language: 'English', published: '1721' },
+  // --- Influences on the founders ---
+  { ia: 'twotreatisesofgo00lock_1', title: 'Two Treatises of Government', author: 'John Locke', language: 'English', published: '1690' },
+  { ia: 'essayconcerningh01lock_2', title: 'An Essay Concerning Human Understanding, Vol. 1', author: 'John Locke', language: 'English', published: '1710' },
+  { ia: 'essayconcerningh02lock_0', title: 'An Essay Concerning Human Understanding, Vol. 2', author: 'John Locke', language: 'English', published: '1710' },
+  { ia: 'nby_540263', title: 'A Letter Concerning Toleration', author: 'John Locke', language: 'English', published: '1689' },
+  { ia: 'lawsofenglandc01blacuoft', title: 'Commentaries on the Laws of England, Vol. 1', author: 'William Blackstone', language: 'English', published: '1765' },
+  { ia: 'lawsofenglandc02blacuoft', title: 'Commentaries on the Laws of England, Vol. 2', author: 'William Blackstone', language: 'English', published: '1766' },
+  { ia: 'lawsofenglandc03blacuoft', title: 'Commentaries on the Laws of England, Vol. 3', author: 'William Blackstone', language: 'English', published: '1768' },
+  { ia: 'lawsofenglandc04blacuoft', title: 'Commentaries on the Laws of England, Vol. 4', author: 'William Blackstone', language: 'English', published: '1769' },
+  { ia: 'discoursesconcer00sidnuoft', title: 'Discourses Concerning Government', author: 'Algernon Sidney', language: 'English', published: '1704' },
+  { ia: 'commonwealthof00harr', title: 'The Commonwealth of Oceana', author: 'James Harrington', language: 'English', published: '1656' },
+  { ia: 'bim_eighteenth-century_catos-letters-_trenchard-john_1723_1', title: 'Cato\'s Letters, or Essays on Liberty, Civil and Religious, Vol. 1', author: 'John Trenchard & Thomas Gordon', language: 'English', published: '1723' },
+  { ia: 'bim_eighteenth-century_catos-letters-_trenchard-john_1723_2', title: 'Cato\'s Letters, or Essays on Liberty, Civil and Religious, Vol. 2', author: 'John Trenchard & Thomas Gordon', language: 'English', published: '1723' },
+  { ia: 'bim_eighteenth-century_catos-letters-_trenchard-john_1723_3', title: 'Cato\'s Letters, or Essays on Liberty, Civil and Religious, Vol. 3', author: 'John Trenchard & Thomas Gordon', language: 'English', published: '1723' },
+  { ia: 'bim_eighteenth-century_catos-letters-_trenchard-john_1723_4', title: 'Cato\'s Letters, or Essays on Liberty, Civil and Religious, Vol. 4', author: 'John Trenchard & Thomas Gordon', language: 'English', published: '1723' },
+  { ia: 'leviathanormatte00hobb_3', title: 'Leviathan, or the Matter, Forme, and Power of a Common-Wealth Ecclesiasticall and Civil', author: 'Thomas Hobbes', language: 'English', published: '1651' },
+  { ia: 'oflawofnaturenat00pufe', title: 'Of the Law of Nature and Nations, Eight Books', author: 'Samuel von Pufendorf', language: 'English', published: '1729' },
+];
+
+function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
+function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/\b(born|died|fl\.?|circa|ca?\.?)\s*\d{3,4}\b/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
+function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
+async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}
+async function pageCountFor(ia,metadata){
+  try{const r=await fetch(`https://iiif.archive.org/iiif/${ia}/manifest.json`,{signal:AbortSignal.timeout(20000)});if(r.ok){const m=await r.json();if(Array.isArray(m.items))return{n:m.items.length,src:'iiif_v3'};if(m.sequences?.[0]?.canvases)return{n:m.sequences[0].canvases.length,src:'iiif_v2'};}}catch{}
+  const meta=metadata.metadata||{};if(meta.imagecount)return{n:parseInt(meta.imagecount,10),src:'imagecount'};
+  const jp2=(metadata.files||[]).filter(f=>f.name.endsWith('.jp2')&&!f.name.includes('thumb'));if(jp2.length>1)return{n:jp2.length,src:'jp2_files'};return{n:0,src:'none'};
+}
+async function main(){
+  if(!process.env.MONGODB_URI){console.error('MONGODB_URI missing');process.exit(1);}
+  const client=new MongoClient(process.env.MONGODB_URI,{maxPoolSize:3});await client.connect();const db=client.db('bookstore');
+  let imported=0,skipped=0,failed=0;const fails=[];
+  for(const b of BOOKS){
+    const fp=`ia:${b.ia}`;
+    const existing=await db.collection('books').findOne({$or:[{ia_identifier:b.ia},{source_fingerprint:fp}]},{projection:{_id:1,slug:1}});
+    if(existing){console.log(`SKIP  ${b.ia} — present (${existing.slug})`);skipped++;continue;}
+    let metadata;
+    try{const mr=await fetch(`https://archive.org/metadata/${b.ia}`,{signal:AbortSignal.timeout(20000)});if(!mr.ok){console.log(`FAIL  ${b.ia} — metadata ${mr.status}`);failed++;fails.push(b.ia);continue;}metadata=await mr.json();}
+    catch(e){console.log(`FAIL  ${b.ia} — metadata ${e}`);failed++;fails.push(b.ia);continue;}
+    const meta=metadata.metadata||{};
+    const restricted=meta['access-restricted-item']==='true'||meta['access-restricted-item']===true;
+    const {n:pageCount,src:pageCountSource}=await pageCountFor(b.ia,metadata);
+    if(!pageCount){console.log(`FAIL  ${b.ia} — no page count`);failed++;fails.push(b.ia);continue;}
+    const stripText=s=>String(s).replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim();
+    const firstOf=v=>{const raw=Array.isArray(v)?(typeof v[0]==='string'?v[0]:null):(typeof v==='string'?v:null);return raw?stripText(raw)||null:null;};
+    const arrOf=v=>{const raw=Array.isArray(v)?v.filter(x=>typeof x==='string'):(typeof v==='string'?[v]:[]);return raw.map(stripText).filter(Boolean);};
+    const iaCatalog={source:'internet_archive',identifier:b.ia,ark:meta['identifier-ark']||null,mediatype:meta.mediatype||null,collections:arrOf(meta.collection),access_restricted:restricted,publisher:firstOf(meta.publisher),place:firstOf(meta.publishplace)||firstOf(meta.place),creator:firstOf(meta.creator),description:firstOf(meta.description),subjects:arrOf(meta.subject),oclc_id:firstOf(meta['oclc-id']),lccn:firstOf(meta.lccn),date_iso:firstOf(meta.date),scan_date:firstOf(meta.scandate),scanning_center:firstOf(meta.scanningcenter),scraped_at:new Date().toISOString()};
+    for(const k of Object.keys(iaCatalog)){const v=iaCatalog[k];if(v===null||v===undefined||(Array.isArray(v)&&v.length===0))delete iaCatalog[k];}
+    const licenseUrl=meta.licenseurl||meta.license||null,rights=meta.rights||meta.possible_copyright_status||null;
+    const contributor=typeof meta.contributor==='string'?stripText(meta.contributor):null,sponsor=typeof meta.sponsor==='string'?stripText(meta.sponsor):null;
+    const bookId=new ObjectId(),bookIdStr=bookId.toHexString();
+    const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
+    const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
+    const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
+    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+      dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
+      catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
+      image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+    if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title.slice(0,50)}" (${pageCount}pp,${pageCountSource})`);imported++;continue;}
+    await db.collection('books').insertOne(bookDoc);
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    console.log(`OK    ${b.ia} → ${bookIdStr} "${b.title.slice(0,46)}" (${pageCount}pp)`);imported++;
+  }
+  await client.close();
+  console.log(`\n=== ${COMMIT?'COMMITTED':'DRY-RUN'} — imported:${imported} skipped:${skipped} failed:${failed} ${fails.length?'['+fails.join(', ')+']':''} ===`);
+}
+main().catch(e=>{console.error(e);process.exit(1);});

--- a/scripts/import/founders-collected-direct.mjs
+++ b/scripts/import/founders-collected-direct.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Direct import (residential → Atlas) of the founding fathers' COLLECTED
+ * multivolume works — the public-domain scholarly editions. Bypasses
+ * /api/import/ia (Vercel→Atlas timeouts, 2026-07-05). Same doc shape as
+ * founding-docs-direct.mjs. All original-language works → text_role:'original'.
+ * Lands HIDDEN. Volume numbers are by id-sequence (approx where IA lacks a
+ * volume field); refine later if needed. Washington uses Sparks (12v, v2 not
+ * cleanly scanned in this edition); the complete Fitzpatrick set is 39v.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/founders-collected-direct.mjs --dry-run | --commit
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+const COMMIT = process.argv.includes('--commit');
+
+const SETS = [
+  { author: 'John Adams', work: 'The Works of John Adams', pub: '1850', lang: 'English',
+    ids: ['worksofjohnadams01adam','worksofjohnadams02adam','worksofjohnadams0003char','worksofjohnadams04adam','worksofjohnadams05adam','worksofjohnadams06adam','worksofjohnadams0007char','worksofjohnadams0008char','worksofjohnadams09adam','worksofjohnadams10adam'] },
+  { author: 'Benjamin Franklin', work: 'The Writings of Benjamin Franklin (Smyth ed.)', pub: '1905', lang: 'English',
+    ids: ['writingsofbenjam01franuoft','writingsofbenjam02franuoft','writingsofbenjam03franuoft','writingsofbenjam04franuoft','writingsofbenjam05franuoft','writingsofbenjam06franuoft','writingsofbenjam07franuoft','writingsofbenjam08franuoft','writingsofbenjam09franuoft','writingsofbenjam10franuoft'] },
+  { author: 'Alexander Hamilton', work: 'The Works of Alexander Hamilton', pub: '1850', lang: 'English',
+    ids: ['worksofalexander01hamirich','worksofalexander02hamirich','worksofalexander03hamirich','worksofalexander04hamirich','worksofalexander05hamirich','worksofalexander06hamirich','worksofalexander07hamirich'] },
+  { author: 'Thomas Jefferson', work: 'The Works of Thomas Jefferson (Federal Edition, Ford)', pub: '1904', lang: 'English',
+    ids: ['cu31924092892011','cu31924092892037','cu31924092892045','cu31924092892052','cu31924092892060','cu31924092892078','cu31924092892086','cu31924092892094','cu31924092892102'] },
+  { author: 'James Madison', work: 'Letters and Other Writings of James Madison', pub: '1865', lang: 'English',
+    ids: ['lettersandotherw01madiiala','lettersandotherw02madiiala','lettersandotherw03madiiala','lettersandotherw04madiiala'] },
+  { author: 'George Washington', work: 'The Writings of George Washington (Sparks ed.)', pub: '1834', lang: 'English',
+    ids: ['writingsofgeorge01wash','writingsofgeorge03wash','writingsofgeorge04wash','writingsofgeorge05wash','writingsofgeorge06wash','writingsofgeorge07wash','writingsofgeorgew08wash','writingsofgeorge09wash','writingsofgeorge10wash','writingsofgeorge11wash','writingsofgeorge12wash'] },
+  { author: 'John Jay', work: 'The Life of John Jay, with Selections from his Correspondence and Miscellaneous Papers', pub: '1833', lang: 'English',
+    ids: ['lifeofjohnjaywit01jaywuoft','lifeofjohnjaywit02jaywuoft'] },
+  { author: 'Jonathan Edwards', work: 'The Works of President Edwards', pub: '1808', lang: 'English',
+    ids: ['worksofpresident01edwa','worksofpresident02edwa','worksofpresident03edwa','worksofpresident04edwa','worksofpresident05edwa','worksofpresident06edwa','worksofpresident07edwa','worksofpresident08edwa'] },
+];
+
+const BOOKS = SETS.flatMap(s => s.ids.map((ia, i) => ({
+  ia, title: `${s.work}, Vol. ${i + 1}`, author: s.author, language: s.lang, published: s.pub,
+})));
+
+function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
+function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
+function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
+async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}
+async function pageCountFor(ia,metadata){
+  try{const r=await fetch(`https://iiif.archive.org/iiif/${ia}/manifest.json`,{signal:AbortSignal.timeout(20000)});if(r.ok){const m=await r.json();if(Array.isArray(m.items))return{n:m.items.length,src:'iiif_v3'};if(m.sequences?.[0]?.canvases)return{n:m.sequences[0].canvases.length,src:'iiif_v2'};}}catch{}
+  const meta=metadata.metadata||{};if(meta.imagecount)return{n:parseInt(meta.imagecount,10),src:'imagecount'};
+  const jp2=(metadata.files||[]).filter(f=>f.name.endsWith('.jp2')&&!f.name.includes('thumb'));if(jp2.length>1)return{n:jp2.length,src:'jp2_files'};return{n:0,src:'none'};
+}
+async function main(){
+  if(!process.env.MONGODB_URI){console.error('MONGODB_URI missing');process.exit(1);}
+  const client=new MongoClient(process.env.MONGODB_URI,{maxPoolSize:3});await client.connect();const db=client.db('bookstore');
+  let imported=0,skipped=0,failed=0;const fails=[];
+  for(const b of BOOKS){
+    const fp=`ia:${b.ia}`;
+    const existing=await db.collection('books').findOne({$or:[{ia_identifier:b.ia},{source_fingerprint:fp}]},{projection:{_id:1,slug:1}});
+    if(existing){console.log(`SKIP  ${b.ia}`);skipped++;continue;}
+    let metadata;
+    try{const mr=await fetch(`https://archive.org/metadata/${b.ia}`,{signal:AbortSignal.timeout(20000)});if(!mr.ok){console.log(`FAIL  ${b.ia} — metadata ${mr.status}`);failed++;fails.push(b.ia);continue;}metadata=await mr.json();}
+    catch(e){console.log(`FAIL  ${b.ia} — ${e}`);failed++;fails.push(b.ia);continue;}
+    const meta=metadata.metadata||{};
+    const restricted=meta['access-restricted-item']==='true'||meta['access-restricted-item']===true;
+    const {n:pageCount,src:pageCountSource}=await pageCountFor(b.ia,metadata);
+    if(!pageCount){console.log(`FAIL  ${b.ia} — no page count`);failed++;fails.push(b.ia);continue;}
+    const stripText=s=>String(s).replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim();
+    const firstOf=v=>{const raw=Array.isArray(v)?(typeof v[0]==='string'?v[0]:null):(typeof v==='string'?v:null);return raw?stripText(raw)||null:null;};
+    const arrOf=v=>{const raw=Array.isArray(v)?v.filter(x=>typeof x==='string'):(typeof v==='string'?[v]:[]);return raw.map(stripText).filter(Boolean);};
+    const iaCatalog={source:'internet_archive',identifier:b.ia,ark:meta['identifier-ark']||null,mediatype:meta.mediatype||null,collections:arrOf(meta.collection),access_restricted:restricted,publisher:firstOf(meta.publisher),place:firstOf(meta.publishplace)||firstOf(meta.place),creator:firstOf(meta.creator),description:firstOf(meta.description),subjects:arrOf(meta.subject),oclc_id:firstOf(meta['oclc-id']),lccn:firstOf(meta.lccn),date_iso:firstOf(meta.date),scan_date:firstOf(meta.scandate),scraped_at:new Date().toISOString()};
+    for(const k of Object.keys(iaCatalog)){const v=iaCatalog[k];if(v===null||v===undefined||(Array.isArray(v)&&v.length===0))delete iaCatalog[k];}
+    const licenseUrl=meta.licenseurl||meta.license||null,rights=meta.rights||meta.possible_copyright_status||null;
+    const contributor=typeof meta.contributor==='string'?stripText(meta.contributor):null,sponsor=typeof meta.sponsor==='string'?stripText(meta.sponsor):null;
+    const bookId=new ObjectId(),bookIdStr=bookId.toHexString();
+    const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
+    const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
+    const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
+    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+      dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
+      catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
+      image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+    if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp)`);imported++;continue;}
+    await db.collection('books').insertOne(bookDoc);
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp)`);imported++;
+  }
+  await client.close();
+  console.log(`\n=== ${COMMIT?'COMMITTED':'DRY-RUN'} — imported:${imported} skipped:${skipped} failed:${failed} ${fails.length?'['+fails.join(', ')+']':''} ===`);
+}
+main().catch(e=>{console.error(e);process.exit(1);});

--- a/scripts/import/founding-chase.mjs
+++ b/scripts/import/founding-chase.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Chase the 3 founding-batch imports that failed on "no page count" (their
+ * first-choice IA scans lacked IIIF/imagecount/jp2). Substitutes ECCO/EEBO
+ * editions that carry an imagecount. Same doc shape / HIDDEN as the sibling
+ * direct-insert scripts. (The 4th failure — a standalone Declaration of
+ * Independence — is intentionally skipped: its text is already held inside
+ * declarationofind00unit_2 (1796) and the 1781 Constitutions compendium.)
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/founding-chase.mjs --commit
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+const COMMIT = process.argv.includes('--commit');
+const BOOKS = [
+  { ia: 'bim_early-english-books-1641-1700_a-letter-concerning-tole_locke-john_1689', title: 'A Letter Concerning Toleration', author: 'John Locke', language: 'English', published: '1689' },
+  { ia: 'bim_eighteenth-century_commentaries-on-the-laws_blackstone-william-sir_1765_2', title: 'Commentaries on the Laws of England, Vol. 2', author: 'William Blackstone', language: 'English', published: '1766' },
+  { ia: 'bim_eighteenth-century_commentaries-on-the-laws_blackstone-william-sir_1765_3', title: 'Commentaries on the Laws of England, Vol. 3', author: 'William Blackstone', language: 'English', published: '1768' },
+];
+function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
+function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
+function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
+async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}
+async function pageCountFor(ia,metadata){
+  try{const r=await fetch(`https://iiif.archive.org/iiif/${ia}/manifest.json`,{signal:AbortSignal.timeout(20000)});if(r.ok){const m=await r.json();if(Array.isArray(m.items))return{n:m.items.length,src:'iiif_v3'};if(m.sequences?.[0]?.canvases)return{n:m.sequences[0].canvases.length,src:'iiif_v2'};}}catch{}
+  const meta=metadata.metadata||{};if(meta.imagecount)return{n:parseInt(meta.imagecount,10),src:'imagecount'};
+  const jp2=(metadata.files||[]).filter(f=>f.name.endsWith('.jp2')&&!f.name.includes('thumb'));if(jp2.length>1)return{n:jp2.length,src:'jp2_files'};return{n:0,src:'none'};
+}
+async function main(){
+  const client=new MongoClient(process.env.MONGODB_URI,{maxPoolSize:3});await client.connect();const db=client.db('bookstore');
+  let imported=0,skipped=0,failed=0;
+  for(const b of BOOKS){
+    const fp=`ia:${b.ia}`;
+    if(await db.collection('books').findOne({$or:[{ia_identifier:b.ia},{source_fingerprint:fp}]},{projection:{_id:1}})){console.log(`SKIP ${b.ia}`);skipped++;continue;}
+    let metadata;try{const mr=await fetch(`https://archive.org/metadata/${b.ia}`,{signal:AbortSignal.timeout(20000)});if(!mr.ok){console.log(`FAIL ${b.ia} meta ${mr.status}`);failed++;continue;}metadata=await mr.json();}catch(e){console.log(`FAIL ${b.ia} ${e}`);failed++;continue;}
+    const meta=metadata.metadata||{};const {n:pageCount,src:pageCountSource}=await pageCountFor(b.ia,metadata);
+    if(!pageCount){console.log(`FAIL ${b.ia} no page count`);failed++;continue;}
+    const stripText=s=>String(s).replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim();
+    const firstOf=v=>{const raw=Array.isArray(v)?(typeof v[0]==='string'?v[0]:null):(typeof v==='string'?v:null);return raw?stripText(raw)||null:null;};
+    const arrOf=v=>{const raw=Array.isArray(v)?v.filter(x=>typeof x==='string'):(typeof v==='string'?[v]:[]);return raw.map(stripText).filter(Boolean);};
+    const iaCatalog={source:'internet_archive',identifier:b.ia,ark:meta['identifier-ark']||null,mediatype:meta.mediatype||null,collections:arrOf(meta.collection),publisher:firstOf(meta.publisher),place:firstOf(meta.publishplace)||firstOf(meta.place),description:firstOf(meta.description),subjects:arrOf(meta.subject),date_iso:firstOf(meta.date),scraped_at:new Date().toISOString()};
+    for(const k of Object.keys(iaCatalog)){const v=iaCatalog[k];if(v==null||(Array.isArray(v)&&!v.length))delete iaCatalog[k];}
+    const licenseUrl=meta.licenseurl||meta.license||null,rights=meta.rights||meta.possible_copyright_status||null;
+    const contributor=typeof meta.contributor==='string'?stripText(meta.contributor):null;
+    const bookId=new ObjectId(),bookIdStr=bookId.toHexString();const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
+    const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`,thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
+    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+      dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
+      catalog_metadata:iaCatalog,image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),access_date:now},
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+    if(!COMMIT){console.log(`DRY  ${b.ia} "${b.title}" (${pageCount}pp)`);imported++;continue;}
+    await db.collection('books').insertOne(bookDoc);
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    console.log(`OK   ${b.ia} "${b.title}" (${pageCount}pp)`);imported++;
+  }
+  await client.close();console.log(`\n=== ${COMMIT?'COMMITTED':'DRY'} — imported:${imported} skipped:${skipped} failed:${failed} ===`);
+}
+main().catch(e=>{console.error(e);process.exit(1);});

--- a/scripts/import/founding-docs-direct.mjs
+++ b/scripts/import/founding-docs-direct.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Direct import of earliest-edition founding documents (American + French
+ * Revolution) straight into Atlas, bypassing /api/import/ia.
+ *
+ * WHY direct: on 2026-07-05 the server-side IA import route reliably 500'd with
+ * `MongoNetworkTimeoutError` (Vercel serverless → Atlas connection timeout),
+ * while a residential (local) connection to the same Atlas cluster is healthy.
+ * Same residential-direct-insert pattern as harvard-wuzhen-direct.mjs — mirrors
+ * the route's book/page doc shape (source_fingerprint `ia:<id>`, normalized
+ * title/author, catalog_metadata, image_source, text_role) so a later
+ * /api/import/ia run correctly 409s these instead of duplicating them.
+ *
+ * All items are original-language first works → text_role: 'original'.
+ * Lands HIDDEN (visible:false, hidden:true) per the import invariant.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/founding-docs-direct.mjs --dry-run
+ *   node scripts/import/founding-docs-direct.mjs --commit
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+
+const COMMIT = process.argv.includes('--commit');
+
+const BOOKS = [
+  // --- American Revolution ---
+  { ia: 'commonsenseaddre00pain_7', title: 'Common Sense: Addressed to the Inhabitants of America', author: 'Thomas Paine', language: 'English', published: '1776' },
+  { ia: 'rightsofmanbeing1791pain', title: "Rights of Man: Being an Answer to Mr. Burke's Attack on the French Revolution", author: 'Thomas Paine', language: 'English', published: '1791' },
+  { ia: 'bim_eighteenth-century_the-american-crisis_paine-thomas-political_1777', title: 'The American Crisis', author: 'Thomas Paine', language: 'English', published: '1777' },
+  { ia: 'summaryviewofrig00jeff_0', title: 'A Summary View of the Rights of British America', author: 'Thomas Jefferson', language: 'English', published: '1774' },
+  { ia: 'bim_eighteenth-century_the-constitutions-of-the_1781', title: 'The Constitutions of the Several Independent States of America; the Declaration of Independence; the Articles of Confederation', author: 'United States', language: 'English', published: '1781' },
+  { ia: 'bim_eighteenth-century_the-fderal-constitution_united-states_1795', title: 'The Fœderal Constitution of the United States of America', author: 'United States', language: 'English', published: '1795' },
+  { ia: 'ageofreasonbeing0000pain_h5s9', title: 'The Age of Reason', author: 'Thomas Paine', language: 'English', published: '1794' },
+  { ia: 'service-rbc-rbc0001-2004-2004pe76546-2004pe76546_202505', title: 'The Declaration of Independence', author: 'Continental Congress', language: 'English', published: '1776' },
+  // --- French Revolution ---
+  { ia: 'questcequeletier00siey_0', title: "Qu'est-ce que le Tiers-État?", author: 'Emmanuel Joseph Sieyès', language: 'French', published: '1789' },
+  { ia: 'bub_gb_smqivFwgTLcC', title: "Préliminaire de la Constitution: Reconnaissance et exposition raisonnée des droits de l'homme et du citoyen", author: 'Emmanuel Joseph Sieyès', language: 'French', published: '1789' },
+  { ia: 'bub_gb_r-v5wN6ChUAC', title: 'Reflections on the Revolution in France', author: 'Edmund Burke', language: 'English', published: '1790' },
+  { ia: 'vindicationofrig00woll_4', title: 'A Vindication of the Rights of Men', author: 'Mary Wollstonecraft', language: 'English', published: '1790' },
+  { ia: 'vindicationofrig00wol', title: 'A Vindication of the Rights of Woman', author: 'Mary Wollstonecraft', language: 'English', published: '1792' },
+  { ia: 'lesdroitsdelafem00goug', title: 'Les Droits de la femme (Déclaration des droits de la femme et de la citoyenne)', author: 'Olympe de Gouges', language: 'French', published: '1791' },
+  { ia: 'discoursdemaximi00robe', title: "Discours de Maximilien Robespierre à l'Assemblée nationale", author: 'Maximilien Robespierre', language: 'French', published: '1790' },
+];
+
+const COLLECTIONS_TAG = []; // collection pages not built yet; leave untagged for now
+
+function normalizeTitle(title) {
+  return title.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i, '')
+    .replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i, '')
+    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+}
+function normalizeAuthor(author) {
+  const cleaned = author.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase()
+    .replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g, '')
+    .replace(/\s*\([\d\s\-–,?.]+\)\s*/g, '').replace(/,\s*[\d\s\-–?.]+$/, '')
+    .replace(/[\[\]]/g, '').replace(/\b(born|died|fl\.?|circa|ca?\.?)\s*\d{3,4}\b/g, '')
+    .replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+  return cleaned.split(' ').filter(w => w.length > 0).sort().join(' ');
+}
+function slugify(text, maxLen = 70) {
+  return text.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-')
+    .replace(/^-|-$/g, '').substring(0, maxLen).replace(/-$/, '');
+}
+async function uniqueSlug(db, base) {
+  let slug = base, i = 2;
+  while (await db.collection('books').findOne({ slug }, { projection: { _id: 1 } })) slug = `${base}-${i++}`;
+  return slug;
+}
+
+async function pageCountFor(ia, metadata) {
+  // 1. IIIF manifest (most reliable)
+  try {
+    const r = await fetch(`https://iiif.archive.org/iiif/${ia}/manifest.json`, { signal: AbortSignal.timeout(20000) });
+    if (r.ok) {
+      const m = await r.json();
+      if (Array.isArray(m.items)) return { n: m.items.length, src: 'iiif_v3' };
+      if (m.sequences?.[0]?.canvases) return { n: m.sequences[0].canvases.length, src: 'iiif_v2' };
+    }
+  } catch { /* fall through */ }
+  const meta = metadata.metadata || {};
+  if (meta.imagecount) return { n: parseInt(meta.imagecount, 10), src: 'imagecount' };
+  const jp2 = (metadata.files || []).filter(f => f.name.endsWith('.jp2') && !f.name.includes('thumb'));
+  if (jp2.length > 1) return { n: jp2.length, src: 'jp2_files' };
+  return { n: 0, src: 'none' };
+}
+
+async function main() {
+  if (!process.env.MONGODB_URI) { console.error('MONGODB_URI missing (source .env.production.local)'); process.exit(1); }
+  const client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 3 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  let imported = 0, skipped = 0, failed = 0;
+  for (const b of BOOKS) {
+    const fp = `ia:${b.ia}`;
+    const existing = await db.collection('books').findOne(
+      { $or: [{ ia_identifier: b.ia }, { source_fingerprint: fp }] }, { projection: { _id: 1, slug: 1 } });
+    if (existing) { console.log(`SKIP  ${b.ia} — already present (${existing.slug})`); skipped++; continue; }
+
+    let metadata;
+    try {
+      const mr = await fetch(`https://archive.org/metadata/${b.ia}`, { signal: AbortSignal.timeout(20000) });
+      if (!mr.ok) { console.log(`FAIL  ${b.ia} — metadata ${mr.status}`); failed++; continue; }
+      metadata = await mr.json();
+    } catch (e) { console.log(`FAIL  ${b.ia} — metadata fetch ${e}`); failed++; continue; }
+
+    const meta = metadata.metadata || {};
+    const restricted = meta['access-restricted-item'] === 'true' || meta['access-restricted-item'] === true;
+    const { n: pageCount, src: pageCountSource } = await pageCountFor(b.ia, metadata);
+    if (!pageCount) { console.log(`FAIL  ${b.ia} — could not determine page count`); failed++; continue; }
+    if (restricted) console.log(`WARN  ${b.ia} — access-restricted-item flagged (importing anyway, facsimile may gate)`);
+
+    const stripText = s => String(s).replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+    const firstOf = v => { const raw = Array.isArray(v) ? (typeof v[0] === 'string' ? v[0] : null) : (typeof v === 'string' ? v : null); return raw ? stripText(raw) || null : null; };
+    const arrOf = v => { const raw = Array.isArray(v) ? v.filter(x => typeof x === 'string') : (typeof v === 'string' ? [v] : []); return raw.map(stripText).filter(Boolean); };
+
+    const iaCatalog = {
+      source: 'internet_archive', identifier: b.ia,
+      ark: meta['identifier-ark'] || null, mediatype: meta.mediatype || null,
+      collections: arrOf(meta.collection), access_restricted: restricted,
+      publisher: firstOf(meta.publisher), place: firstOf(meta.publishplace) || firstOf(meta.place),
+      creator: firstOf(meta.creator), description: firstOf(meta.description),
+      subjects: arrOf(meta.subject), oclc_id: firstOf(meta['oclc-id']), lccn: firstOf(meta.lccn),
+      date_iso: firstOf(meta.date), scan_date: firstOf(meta.scandate),
+      scanning_center: firstOf(meta.scanningcenter), scraped_at: new Date().toISOString(),
+    };
+    for (const k of Object.keys(iaCatalog)) { const v = iaCatalog[k]; if (v === null || v === undefined || (Array.isArray(v) && v.length === 0)) delete iaCatalog[k]; }
+
+    const licenseUrl = meta.licenseurl || meta.license || null;
+    const rights = meta.rights || meta.possible_copyright_status || null;
+    const contributor = typeof meta.contributor === 'string' ? stripText(meta.contributor) : null;
+    const sponsor = typeof meta.sponsor === 'string' ? stripText(meta.sponsor) : null;
+
+    const bookId = new ObjectId();
+    const bookIdStr = bookId.toHexString();
+    const slug = await uniqueSlug(db, slugify(`${b.title} ${b.author}`));
+    const now = new Date();
+    const photo = i => `https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
+    const thumb = i => `https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
+
+    const bookDoc = {
+      _id: bookId, id: bookIdStr, slug,
+      title: b.title, display_title: null, author: b.author,
+      language: b.language, published: b.published,
+      field_provenance: { language: 'caller' },
+      categories: ['History', 'Political Philosophy'],
+      ...(COLLECTIONS_TAG.length ? { collections: COLLECTIONS_TAG } : {}),
+      ia_identifier: b.ia,
+      thumbnail: thumb(0),
+      pages_count: pageCount, pages_ocr: 0, pages_translated: 0,
+      content_type: 'book',
+      text_role: 'original',
+      dublin_core: {
+        dc_identifier: [`IA:${b.ia}`, ...(iaCatalog.ark ? [String(iaCatalog.ark)] : []),
+          ...(iaCatalog.oclc_id ? [`OCLC:${iaCatalog.oclc_id}`] : []), ...(iaCatalog.lccn ? [`LCCN:${iaCatalog.lccn}`] : [])],
+        dc_source: `https://archive.org/details/${b.ia}`,
+        ...(iaCatalog.publisher ? { dc_publisher: iaCatalog.publisher } : {}),
+        ...(iaCatalog.description ? { dc_description: iaCatalog.description } : {}),
+        ...(iaCatalog.subjects?.length ? { dc_subject: iaCatalog.subjects } : {}),
+      },
+      catalog_metadata: iaCatalog,
+      ...(iaCatalog.place ? { place_published: String(iaCatalog.place) } : {}),
+      ...(iaCatalog.publisher ? { publisher: String(iaCatalog.publisher) } : {}),
+      image_source: {
+        provider: 'internet_archive', provider_name: 'Internet Archive',
+        source_url: `https://archive.org/details/${b.ia}`, identifier: b.ia,
+        license: licenseUrl || 'publicdomain', license_url: licenseUrl, rights,
+        ...(contributor ? { contributing_library: contributor } : {}),
+        ...(sponsor ? { sponsor } : {}), access_date: now,
+      },
+      page_count_source: pageCountSource,
+      status: 'draft', hidden: true, visible: false,
+      source_fingerprint: fp,
+      normalized_title: normalizeTitle(b.title), normalized_author: normalizeAuthor(b.author),
+      created_at: now, updated_at: now,
+    };
+
+    if (!COMMIT) { console.log(`DRY   ${b.ia} — would insert "${b.title}" (${pageCount}pp, ${pageCountSource}) slug=${slug}`); imported++; continue; }
+
+    await db.collection('books').insertOne(bookDoc);
+    const CHUNK = 500;
+    for (let s = 0; s < pageCount; s += CHUNK) {
+      const docs = [];
+      for (let k = 0; k < CHUNK && s + k < pageCount; k++) {
+        const i = s + k; const pid = new ObjectId();
+        docs.push({ _id: pid, id: pid.toHexString(), book_id: bookIdStr, page_number: i + 1,
+          photo: photo(i), thumbnail: thumb(i), photo_original: photo(i), created_at: now, updated_at: now });
+      }
+      await db.collection('pages').insertMany(docs, { ordered: false });
+    }
+    console.log(`OK    ${b.ia} → ${bookIdStr} "${b.title}" (${pageCount}pp) slug=${slug}`);
+    imported++;
+  }
+
+  await client.close();
+  console.log(`\n=== ${COMMIT ? 'COMMITTED' : 'DRY-RUN'} — imported:${imported} skipped:${skipped} failed:${failed} ===`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/import/founding-enrich-direct.mjs
+++ b/scripts/import/founding-enrich-direct.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Direct import (residential → Atlas) of "american-founding" collection
+ * ENRICHMENT — contemporary political influences (commonwealthmen/radical-
+ * Whig, American pamphlets/sermons, Continental sources) plus original-
+ * language editions of works we hold only in English translation (Vattel FR,
+ * Burlamaqui FR, Pufendorf LA). Bypasses /api/import/ia (Vercel→Atlas
+ * timeouts, 2026-07-05). Same doc shape as founders-collected-direct.mjs /
+ * founding-influences2-direct.mjs. Lands HIDDEN, zero Gemini.
+ *
+ * text_role is set PER BOOK (not blanket 'original' — that was a prior bug):
+ *   - English-native works (British/American authors writing in English) → 'original'
+ *   - Non-English originals (French/Latin/Greek) → 'original'
+ *   - English translations of a foreign work → 'modern-translation' (or
+ *     'period-translation' if the TRANSLATED EDITION itself is pre-1700),
+ *     with original_language + is_translation:true set.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/founding-enrich-direct.mjs --dry-run | --commit
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+const COMMIT = process.argv.includes('--commit');
+const COLLECTION_TAG = 'american-founding';
+
+// Multi-volume sets — auto "Vol. N" titles.
+const SETS = [
+  { author: 'James Burgh', work: 'Political Disquisitions: or, An Enquiry into Public Errors, Defects, and Abuses', pub: '1774', lang: 'English', role: 'original',
+    ids: ['politicaldisquis01burg', 'politicaldisquis02burg', 'politicaldisquis03burg'] },
+  { author: 'Catharine Macaulay', work: 'The History of England from the Accession of James I to the Elevation of the House of Hanover', pub: '1769', lang: 'English', role: 'original',
+    ids: ['historyofengland001maca', 'historyofengland002maca'] },
+  { author: 'John Trenchard & Thomas Gordon', work: 'The Independent Whig', pub: '1732', lang: 'English', role: 'original',
+    ids: ['independentwhigo01tren', 'independentwhigo02tren'] },
+  { author: 'Abbé Raynal (tr. J. Justamond)', work: 'A Philosophical and Political History of the Settlements and Trade of the Europeans in the East and West Indies', pub: '1777', lang: 'English', role: 'modern-translation', originalLanguage: 'French', isTranslation: true,
+    ids: ['philosophicalpol01rayn_1', 'philosophicalpol02rayniala', 'philosophicalpol03rayn_1'] },
+  // Carnegie Endowment "Classics of International Law" facsimile (1916): Vols 1-2
+  // are photoreproductions of Books I-IV of the actual 1758 French edition (Vol 3,
+  // the Fenwick English translation, is skipped — we already hold an English
+  // translation of this work). This is the ORIGINAL-LANGUAGE acquisition (Part B).
+  { author: 'Emer de Vattel', work: 'Le Droit des gens, ou Principes de la loi naturelle (facsimile reproduction of the 1758 edition)', pub: '1758', lang: 'French', role: 'original',
+    ids: ['ledroitdesgensou01vattuoft', 'ledroitdesgensou02vattuoft'] },
+];
+
+// Single-item, single-title docs.
+const SINGLES = [
+  { ia: 'observationsonn00pricgoog', author: 'Richard Price',
+    title: 'Observations on the Nature of Civil Liberty, the Principles of Government, and the Justice and Policy of the War with America',
+    lang: 'English', pub: '1776', role: 'original' },
+  { ia: 'adiscourseonlov00pricgoog', author: 'Richard Price',
+    title: 'A Discourse on the Love of Our Country',
+    lang: 'English', pub: '1790', role: 'original' },
+  { ia: 'observationsonre00macauoft', author: 'Catharine Macaulay',
+    title: "Observations on the Reflections of the Right Hon. Edmund Burke on the Revolution in France",
+    lang: 'English', pub: '1791', role: 'original' },
+  { ia: 'bim_eighteenth-century_the-excellencie-of-a-fre_nedham-marchamont_1767', author: 'Marchamont Nedham',
+    title: 'The Excellencie of a Free State',
+    lang: 'English', pub: '1767', role: 'original' },
+  { ia: 'bim_early-english-books-1641-1700_an-account-of-denmark-_molesworth-robert-moles_1694', author: 'Robert Molesworth',
+    title: 'An Account of Denmark, as It Was in the Year 1692',
+    lang: 'English', pub: '1694', role: 'original' },
+  { ia: 'politicalworksa00fletgoog', author: 'Andrew Fletcher of Saltoun',
+    title: 'The Political Works of Andrew Fletcher, Esq. of Saltoun',
+    lang: 'English', pub: '1732', role: 'original' },
+  { ia: 'discourseconcer00mayh', author: 'Jonathan Mayhew',
+    title: 'A Discourse Concerning Unlimited Submission and Non-Resistance to the Higher Powers',
+    lang: 'English', pub: '1750', role: 'original' },
+  { ia: 'bim_eighteenth-century_a-vindication-of-the-gov_wise-john-pastor-to-a-_1772', author: 'John Wise',
+    title: 'A Vindication of the Government of New-England Churches',
+    lang: 'English', pub: '1772', role: 'original' },
+  { ia: 'considerationso00dulagoog', author: 'Daniel Dulany',
+    title: 'Considerations on the Propriety of Imposing Taxes in the British Colonies, for the Purpose of Raising a Revenue, by Act of Parliament',
+    lang: 'English', pub: '1765', role: 'original' },
+  { ia: 'inquirytotherights00blanrich', author: 'Richard Bland',
+    title: 'An Inquiry into the Rights of the British Colonies',
+    lang: 'English', pub: '1766', role: 'original' },
+  { ia: 'bim_eighteenth-century_considerations-on-the-na_wilson-james_1774', author: 'James Wilson',
+    title: 'Considerations on the Nature and the Extent of the Legislative Authority of the British Parliament',
+    lang: 'English', pub: '1774', role: 'original' },
+  { ia: 'bim_eighteenth-century_sketches-of-american-pol_webster-noah-lld_1785', author: 'Noah Webster',
+    title: 'Sketches of American Policy',
+    lang: 'English', pub: '1785', role: 'original' },
+  { ia: 'advicetoprivileg00barl_0', author: 'Joel Barlow',
+    title: 'Advice to the Privileged Orders in the Several States of Europe, Part I',
+    lang: 'English', pub: '1792', role: 'original' },
+  { ia: 'bim_eighteenth-century_observations-on-the-gove_mably-abb-de_1784', author: 'Abbé de Mably (tr.)',
+    title: 'Observations on the Government and Laws of the United States of America',
+    lang: 'English', pub: '1784', role: 'modern-translation', originalLanguage: 'French', isTranslation: true },
+  { ia: 'bim_early-english-books-1641-1700_patriarcha-or-the-natu_filmer-sir-robert_1680', author: 'Robert Filmer',
+    title: 'Patriarcha: or, the Natural Power of Kings',
+    lang: 'English', pub: '1680', role: 'original' },
+  { ia: 'worksofthatlearn03hook', author: 'Richard Hooker',
+    title: "The Works of That Learned and Judicious Divine Mr. Richard Hooker, Containing Eight Books of the Laws of Ecclesiastical Polity, and Several Other Treatises",
+    lang: 'English', pub: '1793', role: 'original' },
+  // --- Part B: original-language editions of works held only in English translation ---
+  { ia: 'principesdudroit01burluoft', author: 'Jean-Jacques Burlamaqui',
+    title: 'Principes du droit naturel et politique',
+    lang: 'French', pub: '1764', role: 'original' },
+  { ia: 'samuelispufendor1672pufe', author: 'Samuel von Pufendorf',
+    title: 'Samuelis Pufendorfii De Jure Naturae et Gentium Libri Octo',
+    lang: 'Latin', pub: '1672', role: 'original' },
+];
+
+const BOOKS = [
+  ...SETS.flatMap(s => s.ids.map((ia, i) => ({
+    ia, title: `${s.work}, Vol. ${i + 1}`, author: s.author, language: s.lang,
+    published: s.pub, role: s.role, originalLanguage: s.originalLanguage, isTranslation: s.isTranslation,
+  }))),
+  ...SINGLES.map(s => ({
+    ia: s.ia, title: s.title, author: s.author, language: s.lang,
+    published: s.pub, role: s.role, originalLanguage: s.originalLanguage, isTranslation: s.isTranslation,
+  })),
+];
+
+function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
+function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
+function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
+async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}
+async function pageCountFor(ia,metadata){
+  try{const r=await fetch(`https://iiif.archive.org/iiif/${ia}/manifest.json`,{signal:AbortSignal.timeout(20000)});if(r.ok){const m=await r.json();if(Array.isArray(m.items))return{n:m.items.length,src:'iiif_v3'};if(m.sequences?.[0]?.canvases)return{n:m.sequences[0].canvases.length,src:'iiif_v2'};}}catch{}
+  const meta=metadata.metadata||{};if(meta.imagecount)return{n:parseInt(meta.imagecount,10),src:'imagecount'};
+  const jp2=(metadata.files||[]).filter(f=>f.name.endsWith('.jp2')&&!f.name.includes('thumb'));if(jp2.length>1)return{n:jp2.length,src:'jp2_files'};return{n:0,src:'none'};
+}
+async function main(){
+  if(!process.env.MONGODB_URI){console.error('MONGODB_URI missing');process.exit(1);}
+  const client=new MongoClient(process.env.MONGODB_URI,{maxPoolSize:3});await client.connect();const db=client.db('bookstore');
+  let imported=0,skipped=0,failed=0;const fails=[];
+  for(const b of BOOKS){
+    const fp=`ia:${b.ia}`;
+    const existing=await db.collection('books').findOne({$or:[{ia_identifier:b.ia},{source_fingerprint:fp}]},{projection:{_id:1,slug:1}});
+    if(existing){console.log(`SKIP  ${b.ia} — "${b.title}" (already held)`);skipped++;continue;}
+    let metadata;
+    try{const mr=await fetch(`https://archive.org/metadata/${b.ia}`,{signal:AbortSignal.timeout(20000)});if(!mr.ok){console.log(`FAIL  ${b.ia} — metadata ${mr.status}`);failed++;fails.push(b.ia);continue;}metadata=await mr.json();}
+    catch(e){console.log(`FAIL  ${b.ia} — ${e}`);failed++;fails.push(b.ia);continue;}
+    const meta=metadata.metadata||{};
+    const restricted=meta['access-restricted-item']==='true'||meta['access-restricted-item']===true;
+    const {n:pageCount,src:pageCountSource}=await pageCountFor(b.ia,metadata);
+    if(!pageCount){console.log(`FAIL  ${b.ia} — no page count`);failed++;fails.push(b.ia);continue;}
+    const stripText=s=>String(s).replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim();
+    const firstOf=v=>{const raw=Array.isArray(v)?(typeof v[0]==='string'?v[0]:null):(typeof v==='string'?v:null);return raw?stripText(raw)||null:null;};
+    const arrOf=v=>{const raw=Array.isArray(v)?v.filter(x=>typeof x==='string'):(typeof v==='string'?[v]:[]);return raw.map(stripText).filter(Boolean);};
+    const iaCatalog={source:'internet_archive',identifier:b.ia,ark:meta['identifier-ark']||null,mediatype:meta.mediatype||null,collections:arrOf(meta.collection),access_restricted:restricted,publisher:firstOf(meta.publisher),place:firstOf(meta.publishplace)||firstOf(meta.place),creator:firstOf(meta.creator),description:firstOf(meta.description),subjects:arrOf(meta.subject),oclc_id:firstOf(meta['oclc-id']),lccn:firstOf(meta.lccn),date_iso:firstOf(meta.date),scan_date:firstOf(meta.scandate),scraped_at:new Date().toISOString()};
+    for(const k of Object.keys(iaCatalog)){const v=iaCatalog[k];if(v===null||v===undefined||(Array.isArray(v)&&v.length===0))delete iaCatalog[k];}
+    const licenseUrl=meta.licenseurl||meta.license||null,rights=meta.rights||meta.possible_copyright_status||null;
+    const contributor=typeof meta.contributor==='string'?stripText(meta.contributor):null,sponsor=typeof meta.sponsor==='string'?stripText(meta.sponsor):null;
+    const bookId=new ObjectId(),bookIdStr=bookId.toHexString();
+    const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
+    const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
+    const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
+    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:b.role,
+      ...(b.isTranslation?{is_translation:true,original_language:b.originalLanguage}:{}),
+      collections:[COLLECTION_TAG],
+      dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
+      catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
+      image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+    if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp, ${pageCountSource}, role:${b.role}${b.isTranslation?'→'+b.originalLanguage:''})`);imported++;continue;}
+    await db.collection('books').insertOne(bookDoc);
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp, role:${b.role})`);imported++;
+  }
+  await client.close();
+  console.log(`\n=== ${COMMIT?'COMMITTED':'DRY-RUN'} — imported:${imported} skipped:${skipped} failed:${failed} ${fails.length?'['+fails.join(', ')+']':''} ===`);
+}
+main().catch(e=>{console.error(e);process.exit(1);});

--- a/scripts/import/founding-influences2-direct.mjs
+++ b/scripts/import/founding-influences2-direct.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Direct import (residential → Atlas) of "influences on the American
+ * founders" texts — the intellectual sources the founders read and cited
+ * (Vattel, Burlamaqui, Hume's political essays, Milton's prose, Bolingbroke,
+ * Plutarch's Lives, Hutcheson Vol II, Polybius in English) plus a second
+ * batch of Lutz citation-ranking influences (De Lolme, Robertson) and two
+ * founders' library catalogs (Jefferson, Washington) as primary reference
+ * documents. Bypasses /api/import/ia (Vercel→Atlas timeouts, 2026-07-05).
+ * Same doc shape as founders-collected-direct.mjs / founding-tail-direct.mjs.
+ * All English editions → text_role:'original'. Lands HIDDEN.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/founding-influences2-direct.mjs --dry-run | --commit
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+const COMMIT = process.argv.includes('--commit');
+
+const SETS = [
+  { author: 'Emer de Vattel', work: 'The Law of Nations (Le Droit des gens)', pub: '1787', lang: 'English',
+    ids: ['bim_eighteenth-century_the-law-of-nations-or-_vattel-emer-de_1787'] },
+  { author: 'Jean-Jacques Burlamaqui', work: 'The Principles of Natural and Politic Law', pub: '1763', lang: 'English',
+    ids: ['principlesofnatu01burl','principlesofnatu02burl'] },
+  { author: 'David Hume', work: 'Political Discourses', pub: '1752', lang: 'English',
+    ids: ['bim_eighteenth-century_political-discourses-by_hume-david_1752'] },
+  { author: 'John Milton', work: 'Areopagitica', pub: '1644', lang: 'English',
+    ids: ['miltonareopagitica'] },
+  { author: 'John Milton', work: 'The Tenure of Kings and Magistrates', pub: '1649', lang: 'English',
+    ids: ['bim_early-english-books-1641-1700_the-tenure-of-kings-and-_milton-john_1649'] },
+  { author: 'Henry St. John, Viscount Bolingbroke', work: 'The Idea of a Patriot King', pub: '1740', lang: 'English',
+    ids: ['bim_eighteenth-century_the-idea-of-a-patriot-ki_bolingbroke-henry-st-j_1740'] },
+  { author: 'Plutarch', work: "Plutarch's Lives (tr. from the Greek)", pub: '1769', lang: 'English',
+    ids: ['plutarchslivesin01plutiala','plutarchslivesin02plutiala','plutarchslivesin03plutiala','plutarchslivesin04plutiala','plutarchslivesin05plutiala','plutarchslivesin06plutiala'] },
+  { author: 'Francis Hutcheson', work: 'A System of Moral Philosophy, Vol. II', pub: '1755', lang: 'English',
+    ids: ['bim_eighteenth-century_a-system-of-moral-philos_hutcheson-francis_1755_2'] },
+  { author: 'Polybius', work: 'The History of Polybius, the Megalopolitan (tr. Sheeres/Dryden)', pub: '1698', lang: 'English',
+    ids: ['historyofpolybiu01poly','historyofpolybiu02poly'] },
+  // --- Lutz citation-ranking influences + founders' library catalogs (added post-review) ---
+  { author: 'Jean Louis De Lolme', work: 'The Constitution of England', pub: '1775', lang: 'English',
+    ids: ['constitutioneng07lolmgoog'] },
+  { author: 'William Robertson', work: 'The History of America', pub: '1777', lang: 'English',
+    ids: ['bim_eighteenth-century_the-history-of-america-_robertson-william_1777_1','bim_eighteenth-century_the-history-of-america-_robertson-william_1777_2'] },
+  { author: 'William Robertson', work: 'The History of the Reign of the Emperor Charles V', pub: '1762', lang: 'English',
+    ids: ['bim_eighteenth-century_the-history-of-the-reign_robertson-william_1762_1','bim_eighteenth-century_the-history-of-the-reign_robertson-william_1762_2'] },
+];
+
+// Single-item, single-title docs (no "Vol." suffix, no volume enumeration).
+const SINGLES = [
+  { ia: 'cataloguelibrar01goog', author: 'Thomas Jefferson',
+    title: "Catalogue of the Library of the United States (Thomas Jefferson's Library, sold to Congress 1815)",
+    lang: 'English', pub: '1815' },
+  { ia: 'catalogueofwashi00bostuoft', author: 'Appleton P. C. Griffin (Boston Athenaeum)',
+    title: 'A Catalogue of the Washington Collection in the Boston Athenaeum',
+    lang: 'English', pub: '1897' },
+];
+
+const BOOKS = [
+  ...SETS.flatMap(s => s.ids.length > 1
+    ? s.ids.map((ia, i) => ({ ia, title: `${s.work}, Vol. ${i + 1}`, author: s.author, language: s.lang, published: s.pub }))
+    : s.ids.map(ia => ({ ia, title: s.work, author: s.author, language: s.lang, published: s.pub }))),
+  ...SINGLES.map(s => ({ ia: s.ia, title: s.title, author: s.author, language: s.lang, published: s.pub })),
+];
+
+function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
+function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
+function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
+async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}
+async function pageCountFor(ia,metadata){
+  try{const r=await fetch(`https://iiif.archive.org/iiif/${ia}/manifest.json`,{signal:AbortSignal.timeout(20000)});if(r.ok){const m=await r.json();if(Array.isArray(m.items))return{n:m.items.length,src:'iiif_v3'};if(m.sequences?.[0]?.canvases)return{n:m.sequences[0].canvases.length,src:'iiif_v2'};}}catch{}
+  const meta=metadata.metadata||{};if(meta.imagecount)return{n:parseInt(meta.imagecount,10),src:'imagecount'};
+  const jp2=(metadata.files||[]).filter(f=>f.name.endsWith('.jp2')&&!f.name.includes('thumb'));if(jp2.length>1)return{n:jp2.length,src:'jp2_files'};return{n:0,src:'none'};
+}
+async function main(){
+  if(!process.env.MONGODB_URI){console.error('MONGODB_URI missing');process.exit(1);}
+  const client=new MongoClient(process.env.MONGODB_URI,{maxPoolSize:3});await client.connect();const db=client.db('bookstore');
+  let imported=0,skipped=0,failed=0;const fails=[];
+  for(const b of BOOKS){
+    const fp=`ia:${b.ia}`;
+    const existing=await db.collection('books').findOne({$or:[{ia_identifier:b.ia},{source_fingerprint:fp}]},{projection:{_id:1,slug:1}});
+    if(existing){console.log(`SKIP  ${b.ia}`);skipped++;continue;}
+    let metadata;
+    try{const mr=await fetch(`https://archive.org/metadata/${b.ia}`,{signal:AbortSignal.timeout(20000)});if(!mr.ok){console.log(`FAIL  ${b.ia} — metadata ${mr.status}`);failed++;fails.push(b.ia);continue;}metadata=await mr.json();}
+    catch(e){console.log(`FAIL  ${b.ia} — ${e}`);failed++;fails.push(b.ia);continue;}
+    const meta=metadata.metadata||{};
+    const restricted=meta['access-restricted-item']==='true'||meta['access-restricted-item']===true;
+    const {n:pageCount,src:pageCountSource}=await pageCountFor(b.ia,metadata);
+    if(!pageCount){console.log(`FAIL  ${b.ia} — no page count`);failed++;fails.push(b.ia);continue;}
+    const stripText=s=>String(s).replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim();
+    const firstOf=v=>{const raw=Array.isArray(v)?(typeof v[0]==='string'?v[0]:null):(typeof v==='string'?v:null);return raw?stripText(raw)||null:null;};
+    const arrOf=v=>{const raw=Array.isArray(v)?v.filter(x=>typeof x==='string'):(typeof v==='string'?[v]:[]);return raw.map(stripText).filter(Boolean);};
+    const iaCatalog={source:'internet_archive',identifier:b.ia,ark:meta['identifier-ark']||null,mediatype:meta.mediatype||null,collections:arrOf(meta.collection),access_restricted:restricted,publisher:firstOf(meta.publisher),place:firstOf(meta.publishplace)||firstOf(meta.place),creator:firstOf(meta.creator),description:firstOf(meta.description),subjects:arrOf(meta.subject),oclc_id:firstOf(meta['oclc-id']),lccn:firstOf(meta.lccn),date_iso:firstOf(meta.date),scan_date:firstOf(meta.scandate),scraped_at:new Date().toISOString()};
+    for(const k of Object.keys(iaCatalog)){const v=iaCatalog[k];if(v===null||v===undefined||(Array.isArray(v)&&v.length===0))delete iaCatalog[k];}
+    const licenseUrl=meta.licenseurl||meta.license||null,rights=meta.rights||meta.possible_copyright_status||null;
+    const contributor=typeof meta.contributor==='string'?stripText(meta.contributor):null,sponsor=typeof meta.sponsor==='string'?stripText(meta.sponsor):null;
+    const bookId=new ObjectId(),bookIdStr=bookId.toHexString();
+    const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
+    const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
+    const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
+    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+      dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
+      catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
+      image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+    if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp)`);imported++;continue;}
+    await db.collection('books').insertOne(bookDoc);
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp)`);imported++;
+  }
+  await client.close();
+  console.log(`\n=== ${COMMIT?'COMMITTED':'DRY-RUN'} — imported:${imported} skipped:${skipped} failed:${failed} ${fails.length?'['+fails.join(', ')+']':''} ===`);
+}
+main().catch(e=>{console.error(e);process.exit(1)});

--- a/scripts/import/founding-tail-direct.mjs
+++ b/scripts/import/founding-tail-direct.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Direct import (residential → Atlas) of the remaining "American founding"
+ * TAIL items — Washington's complete Fitzpatrick edition, the missing
+ * Jefferson Federal Edition volumes, Anti-Federalist source collections, and
+ * Elliot's Debates. Bypasses /api/import/ia (Vercel→Atlas timeouts,
+ * 2026-07-05). Same doc shape as founders-collected-direct.mjs. All original-
+ * language works → text_role:'original'. Lands HIDDEN.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/founding-tail-direct.mjs --dry-run | --commit
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+const COMMIT = process.argv.includes('--commit');
+
+const SETS = [
+  { author: 'George Washington', work: 'The Writings of George Washington (Fitzpatrick ed.)', pub: '1931', lang: 'English',
+    ids: ['writingsofgeorge001wash','writingsofgeorge002wash','writingsofgeorge003wash','writingsofgeorge004wash','writingsofgeorge005wash','writingsofgeorge006wash','writingsofgeorge007wash','writingsofgeorge008wash','writingsofgeorge009wash','writingsofgeorge010wash','writingsofgeorge011wash','writingsofgeorge012wash','writingsofgeorge13wash','writingsofgeorge14wash','writingsofgeorge15wash','writingsofgeorge16wash','writingsofgeorge17wash','writingsofgeorge18wash','writingsofgeorge19wash','writingsofgeorge20wash','writingsofgeorge21wash','writingsofgeorge22wash','writingsofgeorge23wash','writingsofgeorge24wash','writingsofgeorge25wash','writingsofgeorge26wash','writingsofgeorge27wash','writingsofgeorge28wash','writingsofgeorge29wash','writingsofgeorge30wash','writingsofgeorge31wash','writingsofgeorge32wash','writingsofgeorge33wash','writingsofgeorge34wash','writingsofgeorge35wash','writingsofgeorge36wash','writingsofgeorge37wash','writingsofgeorge38wash','writingsofgeorge39wash'] },
+  { author: 'Thomas Jefferson', work: 'The Works of Thomas Jefferson (Federal Edition, Ford)', pub: '1905', lang: 'English',
+    ids: ['worksthomasjeff07fordgoog','worksthomasjeff00fordgoog','worksthomasjeff02fordgoog'],
+    titles: ['The Works of Thomas Jefferson (Federal Edition, Ford), Vol. 10','The Works of Thomas Jefferson (Federal Edition, Ford), Vol. 11','The Works of Thomas Jefferson (Federal Edition, Ford), Vol. 12'] },
+  { author: 'Jonathan Elliot (ed.)', work: 'The Debates in the Several State Conventions on the Adoption of the Federal Constitution', pub: '1888', lang: 'English',
+    ids: ['debatesinseveral01elli','debatesinseveral02elli','debatesinseveral03elli','debatesinseveral04elli','debatesinseveral05elli'] },
+  { author: 'Various (ed. Paul Leicester Ford)', work: 'Pamphlets on the Constitution of the United States', pub: '1888', lang: 'English',
+    ids: ['pamphletsonconst00forduoft'], titles: ['Pamphlets on the Constitution of the United States, Published During Its Discussion by the People, 1787-1788'] },
+  { author: 'Various (ed. Paul Leicester Ford)', work: 'Essays on the Constitution of the United States', pub: '1892', lang: 'English',
+    ids: ['essaysonconstitu00forduoft'], titles: ['Essays on the Constitution of the United States, Published During Its Discussion by the People, 1787-1788'] },
+  { author: 'Samuel Johnson', work: 'Early American Philosophy — Samuel Johnson', pub: 'various', lang: 'English',
+    ids: ['elementaphiloso00johngoog','bim_eighteenth-century_ethices-elementa_johnson-samuel-dd-_1746','elementsofphilos00john'],
+    titles: [
+      'Elementa Philosophica: Containing Chiefly Noetica, or Things Relating to the Mind or Understanding; and Ethica, or Things Relating to the Moral Behaviour',
+      'Ethices Elementa, or the First Principles of Moral Philosophy',
+      'The Elements of Philosophy',
+    ],
+    published: ['1752','1746','1754'] },
+];
+
+const BOOKS = SETS.flatMap(s => s.ids.map((ia, i) => ({
+  ia, title: s.titles ? s.titles[i] : `${s.work}, Vol. ${i + 1}`, author: s.author, language: s.lang,
+  published: Array.isArray(s.published) ? s.published[i] : s.pub,
+})));
+
+function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
+function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
+function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
+async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}
+async function pageCountFor(ia,metadata){
+  try{const r=await fetch(`https://iiif.archive.org/iiif/${ia}/manifest.json`,{signal:AbortSignal.timeout(20000)});if(r.ok){const m=await r.json();if(Array.isArray(m.items))return{n:m.items.length,src:'iiif_v3'};if(m.sequences?.[0]?.canvases)return{n:m.sequences[0].canvases.length,src:'iiif_v2'};}}catch{}
+  const meta=metadata.metadata||{};if(meta.imagecount)return{n:parseInt(meta.imagecount,10),src:'imagecount'};
+  const jp2=(metadata.files||[]).filter(f=>f.name.endsWith('.jp2')&&!f.name.includes('thumb'));if(jp2.length>1)return{n:jp2.length,src:'jp2_files'};return{n:0,src:'none'};
+}
+async function main(){
+  if(!process.env.MONGODB_URI){console.error('MONGODB_URI missing');process.exit(1);}
+  const client=new MongoClient(process.env.MONGODB_URI,{maxPoolSize:3});await client.connect();const db=client.db('bookstore');
+  let imported=0,skipped=0,failed=0;const fails=[];
+  // Prefetch already-held ids in ONE batch pass (ia_identifier is unindexed; a
+  // per-item $or does a full collection scan each ~27s). One $in scan instead.
+  const allIas=BOOKS.map(b=>b.ia);const allFps=allIas.map(ia=>`ia:${ia}`);
+  const held=new Set();
+  for(const d of await db.collection('books').find({$or:[{ia_identifier:{$in:allIas}},{source_fingerprint:{$in:allFps}}]},{projection:{ia_identifier:1,source_fingerprint:1}}).toArray()){
+    if(d.ia_identifier)held.add(d.ia_identifier);if(d.source_fingerprint)held.add(d.source_fingerprint);
+  }
+  for(const b of BOOKS){
+    const fp=`ia:${b.ia}`;
+    if(held.has(b.ia)||held.has(fp)){console.log(`SKIP  ${b.ia}`);skipped++;continue;}
+    let metadata;
+    try{const mr=await fetch(`https://archive.org/metadata/${b.ia}`,{signal:AbortSignal.timeout(20000)});if(!mr.ok){console.log(`FAIL  ${b.ia} — metadata ${mr.status}`);failed++;fails.push(b.ia);continue;}metadata=await mr.json();}
+    catch(e){console.log(`FAIL  ${b.ia} — ${e}`);failed++;fails.push(b.ia);continue;}
+    const meta=metadata.metadata||{};
+    const restricted=meta['access-restricted-item']==='true'||meta['access-restricted-item']===true;
+    const {n:pageCount,src:pageCountSource}=await pageCountFor(b.ia,metadata);
+    if(!pageCount){console.log(`FAIL  ${b.ia} — no page count`);failed++;fails.push(b.ia);continue;}
+    const stripText=s=>String(s).replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim();
+    const firstOf=v=>{const raw=Array.isArray(v)?(typeof v[0]==='string'?v[0]:null):(typeof v==='string'?v:null);return raw?stripText(raw)||null:null;};
+    const arrOf=v=>{const raw=Array.isArray(v)?v.filter(x=>typeof x==='string'):(typeof v==='string'?[v]:[]);return raw.map(stripText).filter(Boolean);};
+    const iaCatalog={source:'internet_archive',identifier:b.ia,ark:meta['identifier-ark']||null,mediatype:meta.mediatype||null,collections:arrOf(meta.collection),access_restricted:restricted,publisher:firstOf(meta.publisher),place:firstOf(meta.publishplace)||firstOf(meta.place),creator:firstOf(meta.creator),description:firstOf(meta.description),subjects:arrOf(meta.subject),oclc_id:firstOf(meta['oclc-id']),lccn:firstOf(meta.lccn),date_iso:firstOf(meta.date),scan_date:firstOf(meta.scandate),scraped_at:new Date().toISOString()};
+    for(const k of Object.keys(iaCatalog)){const v=iaCatalog[k];if(v===null||v===undefined||(Array.isArray(v)&&v.length===0))delete iaCatalog[k];}
+    const licenseUrl=meta.licenseurl||meta.license||null,rights=meta.rights||meta.possible_copyright_status||null;
+    const contributor=typeof meta.contributor==='string'?stripText(meta.contributor):null,sponsor=typeof meta.sponsor==='string'?stripText(meta.sponsor):null;
+    const bookId=new ObjectId(),bookIdStr=bookId.toHexString();
+    const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
+    const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
+    const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
+    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+      dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
+      catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
+      image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+    if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp)`);imported++;continue;}
+    await db.collection('books').insertOne(bookDoc);
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp)`);imported++;
+  }
+  await client.close();
+  console.log(`\n=== ${COMMIT?'COMMITTED':'DRY-RUN'} — imported:${imported} skipped:${skipped} failed:${failed} ${fails.length?'['+fails.join(', ')+']':''} ===`);
+}
+main().catch(e=>{console.error(e);process.exit(1);});

--- a/scripts/import/jefferson-canon-direct.mjs
+++ b/scripts/import/jefferson-canon-direct.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Direct import (residential → Atlas) of Thomas Jefferson canon acquisitions —
+ * on-mission titles from Jefferson's 1771 Skipwith recommended-library list
+ * (TASK 1) and his actual 1815 library sold to the Library of Congress
+ * (TASK 2 backfill). Bypasses /api/import/ia (Vercel→Atlas timeouts,
+ * 2026-07-05). Same doc shape as founders-collected-direct.mjs. All
+ * original-language works → text_role:'original'. Lands HIDDEN.
+ * Off-mission Skipwith categories (practical agriculture/husbandry, cookery,
+ * dictionaries/grammars, travel guides, medical recipe books, most Fine
+ * Arts novels/poems/plays) were deliberately excluded — see report.
+ * Multi-volume sets marked "partial" in comments are missing volumes IA
+ * never scanned separately (noted honestly in the final report, not hidden).
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/jefferson-canon-direct.mjs --dry-run | --commit
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+const COMMIT = process.argv.includes('--commit');
+
+// ===== TASK 1: Skipwith 1771 list — on-mission gaps =====
+const SETS = [
+  { author: 'Henry Home, Lord Kames', work: 'Elements of Criticism', pub: '1869', lang: 'English',
+    ids: ['elementscritici00boydgoog'] },
+  { author: 'William Hogarth', work: 'The Analysis of Beauty', pub: '1753', lang: 'English',
+    ids: ['bim_eighteenth-century_the-analysis-of-beauty-_hogarth-william_1753'] },
+  { author: 'Montesquieu', work: "Considérations sur les causes de la grandeur des Romains et de leur décadence", pub: '1761', lang: 'French',
+    ids: ['considerationss00montgoog'] },
+  { author: 'Sir James Steuart', work: 'An Inquiry into the Principles of Political Oeconomy', pub: '1767', lang: 'English',
+    ids: ['bim_eighteenth-century_an-inquiry-into-the-prin_steuart-james-sir_1767_1','bim_eighteenth-century_an-inquiry-into-the-prin_steuart-james-sir_1767_2'] },
+  { author: 'Henry St. John, Viscount Bolingbroke', work: 'The Philosophical Works', pub: '1754', lang: 'English',
+    ids: ['philosophicalwo00boligoog','philosophicalwo01boligoog','philosophicalwo02boligoog','philosophicalwo03boligoog','philosophicalwo04boligoog'] },
+  { author: 'David Hume', work: 'Essays, Moral, Political, and Literary', pub: '1898', lang: 'English',
+    ids: ['essaysmoral01humeuoft'] },
+  { author: 'Henry Home, Lord Kames', work: 'Principles of Equity', pub: '1767', lang: 'English',
+    ids: ['bim_eighteenth-century_principles-of-equity_kames-henry-home-lord_1767'] },
+  { author: 'Laurence Sterne', work: 'The Sermons of Mr. Yorick', pub: '1760', lang: 'English',
+    ids: ['sternesermons01'] },
+  { author: 'William Sherlock', work: 'A Practical Discourse Concerning Death', pub: '1767', lang: 'English',
+    ids: ['bim_eighteenth-century_a-practical-discourse-co_sherlock-william_1767'] },
+  { author: 'William Sherlock', work: 'A Practical Discourse Concerning a Future Judgment', pub: '1749', lang: 'English',
+    ids: ['practicaldiscour00sheruoft'] },
+  // Rollin, Ancient History — partial: 3 of 10 vols (consistent scan set)
+  { author: 'Charles Rollin', work: 'The Ancient History of the Egyptians, Carthaginians, Assyrians, Babylonians, Medes and Persians, Grecians and Macedonians', pub: '1795', lang: 'English',
+    ids: ['ancienthistoryof01roll_0','ancienthistoryof02roll_0','ancienthistoryof03roll_0'] },
+  { author: 'Temple Stanyan', work: 'The Grecian History', pub: '1774', lang: 'English',
+    ids: ['bim_eighteenth-century_the-grecian-history-fro_stanyan-temple_1774_1','bim_eighteenth-century_the-grecian-history-fro_stanyan-temple_1774_2'] },
+  { author: 'Abbé de Vertot', work: 'The History of the Revolutions that Happened in the Government of the Roman Republic', pub: '1721', lang: 'English',
+    ids: ['bim_eighteenth-century_histoire-des-revolution_vertot-abbe-de_1721_1','bim_eighteenth-century_histoire-des-revolution_vertot-abbe-de_1721_2'] },
+  // Bayle, Dictionary — partial: 2 of 10 vols
+  { author: 'Pierre Bayle', work: 'A General Dictionary, Historical and Critical', pub: '1741', lang: 'English',
+    ids: ['bim_eighteenth-century_a-general-dictionary-hi_bayle-pierre_1741_1','bim_eighteenth-century_a-general-dictionary-hi_bayle-pierre_1741_2'] },
+  { author: 'Jacques-Bénigne Bossuet', work: "Discours sur l'histoire universelle", pub: '1771', lang: 'French',
+    ids: ['discourssurlhis01boss'] },
+  { author: 'Arrigo Caterino Davila', work: 'The History of the Civil Wars of France', pub: '1758', lang: 'English',
+    ids: ['bim_eighteenth-century_the-history-of-the-civil_davila-arrigo-caterino_1758_1','bim_eighteenth-century_the-history-of-the-civil_davila-arrigo-caterino_1758_2'] },
+  // Hume, History of England — partial: 7 of 8 vols (vol 1 not separately scanned in this ed.)
+  { author: 'David Hume', work: 'The History of England, from the Invasion of Julius Caesar to the Revolution in 1688', pub: '1791', lang: 'English',
+    ids: ['bim_eighteenth-century_the-history-of-england-_hume-david-the-histori_1791_2','bim_eighteenth-century_the-history-of-england-_hume-david-the-histori_1791_3','bim_eighteenth-century_the-history-of-england-_hume-david-the-histori_1791_4','bim_eighteenth-century_the-history-of-england-_hume-david-the-histori_1791_5','bim_eighteenth-century_the-history-of-england-_hume-david-the-histori_1791_6','bim_eighteenth-century_the-history-of-england-_hume-david-the-histori_1791_7','bim_eighteenth-century_the-history-of-england-_hume-david-the-histori_1791_8'] },
+  // Clarendon — partial: 6 of 8 vols (vols 2, 6 not separately scanned in this ed.)
+  { author: 'Edward Hyde, Earl of Clarendon', work: 'The History of the Rebellion and Civil Wars in England', pub: '1826', lang: 'English',
+    ids: ['civilwarengland01claruoft','civilwarengland03claruoft','civilwarengland04claruoft','civilwarengland05claruoft','civilwarengland07claruoft','civilwarengland08claruoft'] },
+  { author: 'William Robertson', work: 'The History of Scotland', pub: '1759', lang: 'English',
+    ids: ['bim_eighteenth-century_the-history-of-scotland-_robertson-william_1759_1','bim_eighteenth-century_the-history-of-scotland-_robertson-william_1759_2'] },
+  { author: 'Sir William Keith', work: 'The History of the British Plantations in America (Virginia)', pub: '1738', lang: 'English',
+    ids: ['bim_eighteenth-century_the-history-of-the-briti_keith-sir-william-bart_1738'] },
+  { author: 'William Stith', work: 'The History of the First Discovery and Settlement of Virginia', pub: '1747', lang: 'English',
+    ids: ['bim_eighteenth-century_the-history-of-the-first_stith-william_1747'] },
+  // Buffon, Natural History — partial: 2 of 9 vols
+  { author: 'Georges-Louis Leclerc, Comte de Buffon', work: 'Natural History, General and Particular', pub: '1791', lang: 'English',
+    ids: ['naturalhistoryg00smelgoog','bim_eighteenth-century_histoire-naturelle-eng_buffon-georges-louis-le_1791_5'] },
+  { author: 'George Lyttelton', work: 'Dialogues of the Dead', pub: '1768', lang: 'English',
+    ids: ['bim_eighteenth-century_dialogues-of-the-dead_lyttelton-george-lyttel_1768'] },
+  { author: 'François Fénelon', work: 'Dialogues des morts anciens et modernes', pub: '1809', lang: 'French',
+    ids: ['dialoguesdesmor00unkngoog'] },
+  { author: 'John Locke', work: 'Some Thoughts Concerning Education', pub: '1712', lang: 'English',
+    ids: ['somethoughtscon01lockgoog'] },
+  { author: 'John Locke', work: 'A Treatise on the Conduct of the Understanding', pub: '1851', lang: 'English',
+    ids: ['treatiseonconduc00loc'] },
+
+  // ===== TASK 2: 1815 library (Sowerby catalog) — on-mission backfill, capped ~50 =====
+  // Gibbon — partial: 3 of ~12 vols (this 1821 scan set only has vols 4, 5, 7)
+  { author: 'Edward Gibbon', work: 'The History of the Decline and Fall of the Roman Empire', pub: '1821', lang: 'English',
+    ids: ['historyofthedecl04gibbiala','historyofthedecl05gibbiala','historyofthedecl07gibbiala'] },
+  { author: 'Johann Lorenz von Mosheim', work: 'An Ecclesiastical History, Ancient and Modern', pub: '1819', lang: 'English',
+    ids: ['mosheimsecclesia01moshuoft','mosheimsecclesia02moshuoft','mosheimsecclesia03moshuoft','mosheimsecclesia04moshuoft','mosheimsecclesia05moshuoft','mosheimsecclesia06moshuoft'] },
+  { author: 'Thomas Rutherforth', work: 'Institutes of Natural Law', pub: '1779', lang: 'English',
+    ids: ['bim_eighteenth-century_institutes-of-natural-la_rutherforth-t-thomas_1779_1','bim_eighteenth-century_institutes-of-natural-la_rutherforth-t-thomas_1779_2'] },
+  { author: 'Johann Gottlieb Heineccius', work: 'A Methodical System of Universal Law', pub: '1763', lang: 'English',
+    ids: ['bim_eighteenth-century_a-methodical-system-of-u_heineccius-johann-gottl_1763_1','bim_eighteenth-century_a-methodical-system-of-u_heineccius-johann-gottl_1763_2'] },
+  { author: 'Robert Beverley', work: 'The History and Present State of Virginia', pub: '1705', lang: 'English',
+    ids: ['bim_eighteenth-century_the-history-and-present-_beverley-robert_1705'] },
+  { author: 'John Millar', work: 'An Historical View of the English Government', pub: '1790', lang: 'English',
+    ids: ['viewofenglishgov00mill'] },
+  { author: 'Gaetano Filangieri', work: 'The Science of Legislation', pub: '1791', lang: 'English',
+    ids: ['bim_eighteenth-century_the-science-of-legislati_filangieri-gaetano_1791'] },
+  { author: 'William Enfield', work: 'The History of Philosophy, from the Earliest Times to the Beginning of the Present Century', pub: '1791', lang: 'English',
+    ids: ['b28771734_0001','b28771734_0002'] },
+  { author: 'Joseph Priestley', work: 'An History of the Corruptions of Christianity', pub: '1838', lang: 'English',
+    ids: ['historyofcorrupt00prie'] },
+  { author: 'Joseph Priestley', work: 'An Essay on the First Principles of Government', pub: '1771', lang: 'English',
+    ids: ['essayonfirstprin00prie'] },
+  { author: 'Conyers Middleton', work: 'The History of the Life of Marcus Tullius Cicero', pub: '1741', lang: 'English',
+    ids: ['bim_eighteenth-century_the-history-of-the-life-_middleton-conyers_1741_1','bim_eighteenth-century_the-history-of-the-life-_middleton-conyers_1741_2'] },
+  { author: 'William Paley', work: 'The Principles of Moral and Political Philosophy', pub: '1786', lang: 'English',
+    ids: ['bim_eighteenth-century_the-principles-of-moral-_paley-william_1786'] },
+];
+
+const BOOKS = SETS.flatMap(s => s.ids.map((ia, i) => ({
+  ia, title: s.ids.length > 1 ? `${s.work}, Vol. ${i + 1}` : s.work, author: s.author, language: s.lang, published: s.pub,
+})));
+
+function normalizeTitle(t){return t.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las)\s+/i,'').replace(/\s*[\(\[:]?\s*(vol\.?\s*\d+|tomus?\s*\d+|part\.?\s*\d+|band\s*\d+|tome?\s*\d+)[\)\]]?\s*$/i,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();}
+function normalizeAuthor(a){const c=a.normalize('NFD').replace(/[̀-ͯ]/g,'').toLowerCase().replace(/\b(dr|prof|rev|saint|st|sir|fr|bp)\b\.?\s*/g,'').replace(/\s*\([\d\s\-–,?.]+\)\s*/g,'').replace(/,\s*[\d\s\-–?.]+$/,'').replace(/[\[\]]/g,'').replace(/[^\w\s]/g,'').replace(/\s+/g,' ').trim();return c.split(' ').filter(w=>w.length>0).sort().join(' ');}
+function slugify(t,m=70){return t.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g,'').replace(/[^a-z0-9\s-]/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'').substring(0,m).replace(/-$/,'');}
+async function uniqueSlug(db,base){let s=base,i=2;while(await db.collection('books').findOne({slug:s},{projection:{_id:1}}))s=`${base}-${i++}`;return s;}
+async function pageCountFor(ia,metadata){
+  try{const r=await fetch(`https://iiif.archive.org/iiif/${ia}/manifest.json`,{signal:AbortSignal.timeout(20000)});if(r.ok){const m=await r.json();if(Array.isArray(m.items))return{n:m.items.length,src:'iiif_v3'};if(m.sequences?.[0]?.canvases)return{n:m.sequences[0].canvases.length,src:'iiif_v2'};}}catch{}
+  const meta=metadata.metadata||{};if(meta.imagecount)return{n:parseInt(meta.imagecount,10),src:'imagecount'};
+  const jp2=(metadata.files||[]).filter(f=>f.name.endsWith('.jp2')&&!f.name.includes('thumb'));if(jp2.length>1)return{n:jp2.length,src:'jp2_files'};return{n:0,src:'none'};
+}
+async function main(){
+  if(!process.env.MONGODB_URI){console.error('MONGODB_URI missing');process.exit(1);}
+  const client=new MongoClient(process.env.MONGODB_URI,{maxPoolSize:3});await client.connect();const db=client.db('bookstore');
+  let imported=0,skipped=0,failed=0;const fails=[];
+  for(const b of BOOKS){
+    const fp=`ia:${b.ia}`;
+    const existing=await db.collection('books').findOne({$or:[{ia_identifier:b.ia},{source_fingerprint:fp}]},{projection:{_id:1,slug:1}});
+    if(existing){console.log(`SKIP  ${b.ia}`);skipped++;continue;}
+    let metadata;
+    try{const mr=await fetch(`https://archive.org/metadata/${b.ia}`,{signal:AbortSignal.timeout(20000)});if(!mr.ok){console.log(`FAIL  ${b.ia} — metadata ${mr.status}`);failed++;fails.push(b.ia);continue;}metadata=await mr.json();}
+    catch(e){console.log(`FAIL  ${b.ia} — ${e}`);failed++;fails.push(b.ia);continue;}
+    const meta=metadata.metadata||{};
+    const restricted=meta['access-restricted-item']==='true'||meta['access-restricted-item']===true;
+    const {n:pageCount,src:pageCountSource}=await pageCountFor(b.ia,metadata);
+    if(!pageCount){console.log(`FAIL  ${b.ia} — no page count`);failed++;fails.push(b.ia);continue;}
+    const stripText=s=>String(s).replace(/<[^>]*>/g,'').replace(/\s+/g,' ').trim();
+    const firstOf=v=>{const raw=Array.isArray(v)?(typeof v[0]==='string'?v[0]:null):(typeof v==='string'?v:null);return raw?stripText(raw)||null:null;};
+    const arrOf=v=>{const raw=Array.isArray(v)?v.filter(x=>typeof x==='string'):(typeof v==='string'?[v]:[]);return raw.map(stripText).filter(Boolean);};
+    const iaCatalog={source:'internet_archive',identifier:b.ia,ark:meta['identifier-ark']||null,mediatype:meta.mediatype||null,collections:arrOf(meta.collection),access_restricted:restricted,publisher:firstOf(meta.publisher),place:firstOf(meta.publishplace)||firstOf(meta.place),creator:firstOf(meta.creator),description:firstOf(meta.description),subjects:arrOf(meta.subject),oclc_id:firstOf(meta['oclc-id']),lccn:firstOf(meta.lccn),date_iso:firstOf(meta.date),scan_date:firstOf(meta.scandate),scraped_at:new Date().toISOString()};
+    for(const k of Object.keys(iaCatalog)){const v=iaCatalog[k];if(v===null||v===undefined||(Array.isArray(v)&&v.length===0))delete iaCatalog[k];}
+    const licenseUrl=meta.licenseurl||meta.license||null,rights=meta.rights||meta.possible_copyright_status||null;
+    const contributor=typeof meta.contributor==='string'?stripText(meta.contributor):null,sponsor=typeof meta.sponsor==='string'?stripText(meta.sponsor):null;
+    const bookId=new ObjectId(),bookIdStr=bookId.toHexString();
+    const slug=await uniqueSlug(db,slugify(`${b.title} ${b.author}`));const now=new Date();
+    const photo=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/full/0/default.jpg`;
+    const thumb=i=>`https://archive.org/download/${b.ia}/page/n${i}/full/pct:15/0/default.jpg`;
+    const bookDoc={_id:bookId,id:bookIdStr,slug,title:b.title,display_title:null,author:b.author,language:b.language,published:b.published,field_provenance:{language:'caller'},categories:['History','Political Philosophy'],ia_identifier:b.ia,thumbnail:thumb(0),pages_count:pageCount,pages_ocr:0,pages_translated:0,content_type:'book',text_role:'original',
+      dublin_core:{dc_identifier:[`IA:${b.ia}`,...(iaCatalog.ark?[String(iaCatalog.ark)]:[]),...(iaCatalog.oclc_id?[`OCLC:${iaCatalog.oclc_id}`]:[]),...(iaCatalog.lccn?[`LCCN:${iaCatalog.lccn}`]:[])],dc_source:`https://archive.org/details/${b.ia}`,...(iaCatalog.publisher?{dc_publisher:iaCatalog.publisher}:{}),...(iaCatalog.description?{dc_description:iaCatalog.description}:{}),...(iaCatalog.subjects?.length?{dc_subject:iaCatalog.subjects}:{})},
+      catalog_metadata:iaCatalog,...(iaCatalog.place?{place_published:String(iaCatalog.place)}:{}),...(iaCatalog.publisher?{publisher:String(iaCatalog.publisher)}:{}),
+      image_source:{provider:'internet_archive',provider_name:'Internet Archive',source_url:`https://archive.org/details/${b.ia}`,identifier:b.ia,license:licenseUrl||'publicdomain',license_url:licenseUrl,rights,...(contributor?{contributing_library:contributor}:{}),...(sponsor?{sponsor}:{}),access_date:now},
+      page_count_source:pageCountSource,status:'draft',hidden:true,visible:false,source_fingerprint:fp,normalized_title:normalizeTitle(b.title),normalized_author:normalizeAuthor(b.author),created_at:now,updated_at:now};
+    if(!COMMIT){console.log(`DRY   ${b.ia} — "${b.title}" (${pageCount}pp)`);imported++;continue;}
+    await db.collection('books').insertOne(bookDoc);
+    const CHUNK=500;for(let s=0;s<pageCount;s+=CHUNK){const docs=[];for(let k=0;k<CHUNK&&s+k<pageCount;k++){const i=s+k,pid=new ObjectId();docs.push({_id:pid,id:pid.toHexString(),book_id:bookIdStr,page_number:i+1,photo:photo(i),thumbnail:thumb(i),photo_original:photo(i),created_at:now,updated_at:now});}await db.collection('pages').insertMany(docs,{ordered:false});}
+    console.log(`OK    ${b.ia} → "${b.title}" (${pageCount}pp)`);imported++;
+  }
+  await client.close();
+  console.log(`\n=== ${COMMIT?'COMMITTED':'DRY-RUN'} — imported:${imported} skipped:${skipped} failed:${failed} ${fails.length?'['+fails.join(', ')+']':''} ===`);
+}
+main().catch(e=>{console.error(e);process.exit(1);});

--- a/scripts/maintenance/expand-cannabis-collection.mjs
+++ b/scripts/maintenance/expand-cannabis-collection.mjs
@@ -1,0 +1,71 @@
+// Expands the cannabis collection: globalizes the framing (now includes the
+// Chinese & Indian classics), tags the newly-acquired Western works and the
+// already-held Eastern materia medica.
+import { MongoClient, ObjectId } from 'mongodb';
+const uri = process.env.MONGODB_URI || process.env.MONGO_URI || process.env.DATABASE_URL;
+if (!uri) { console.error('No MONGODB_URI'); process.exit(1); }
+const SLUG = 'cannabis-western-record';
+
+const NEW_META = {
+  subtitle: "Cannabis in the world's written record — from the Chinese and Indian classics to Hooke's Royal Society and the Decadents",
+  description:
+    "Cannabis enters the written record on three continents. In China the <em>Shennong Bencao Jing</em> warns that eating its flowers \"makes people see ghosts and run wildly\"; in India the Ayurvedic and tantric pharmacologists knew it as <em>bhaṅgā</em> and <em>vijayā</em>, \"the victorious.\" In Europe it was first the fiber-crop <em>kannabis</em> of Dioscorides, then the \"bangue\" the Portuguese met in the Indies — until Robert Hooke read <em>An Account of the Plant, call'd Bangue</em> to the Royal Society in 1689 and named it \"Indian hemp.\" This collection follows the plant across the world's traditions and across the two centuries after Hooke: the Chinese herbals, the Ayurvedic classics, the Orientalists who recovered the legend of the Assassins, the alienists — O'Shaughnessy and Moreau de Tours — who carried it into modern medicine and psychiatry, the Decadent literature of Baudelaire and Ludlow, and the fin-de-siècle occultists for whom Indian hemp was the sorcerer's key. One plant, read in turn as medicine, menace, muse, and mystery.",
+};
+
+// Newly acquired Western works (this session)
+const NEW_WESTERN = [
+  '6a356ea287fae58c35bbca59', // O'Shaughnessy, Bengal Dispensatory (1841)
+  '6a356eac87fae58c35bbcacc', // Moreau de Tours, Du hachisch (1845)
+  '6a356eb487fae58c35bbcc94', // Ludlow, The Hasheesh Eater (1857)
+  '6a356ebb87fae58c35bbce11', // Bayard Taylor, Lands of the Saracen (1856)
+  '6a356ec887fae58c35bbcfe8', // Indian Hemp Drugs Commission Report (1894)
+  '6a356ecfea27ed96662d77a0', // Hammer-Purgstall, Geschichte der Assassinen (1818)
+  '6a356ee2ea27ed96662d790c', // Garcia de Orta, Coloquios (Portuguese, 1563/1891)
+];
+
+// Already-held Eastern texts with CONFIRMED cannabis content
+const EASTERN_CONFIRMED = [
+  '69ee19caa478f461b9eb6357', // Shennong Bencao Jing (Divine Farmer's) — mafen
+  '6992cd5a43713c66ea635f8d', // Li Shizhen, Compendium of Materia Medica (1596)
+  '69e788094a6785cfd60ceb41', // Bencao Gangmu, Vol. 10 (1888)
+  '6992cefbf7519cdd65044ae0', // Wu Qijun, Zhiwu Mingshi Tukao, Vol. 1 (1848) — 大麻
+  '69d006973b94fe3961729712', // Rasa-Jala-Nidhi (bhang/ganja preparations)
+];
+
+const ADD = [...NEW_WESTERN, ...EASTERN_CONFIRMED];
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const books = db.collection('books');
+const colls = db.collection('collections');
+
+await colls.updateOne({ slug: SLUG }, { $set: { ...NEW_META, updated_at: new Date() } });
+console.log('Updated collection framing → global');
+
+let tagged = 0, missed = [];
+for (const bid of ADD) {
+  const q = { $or: [{ id: bid }] };
+  try { q.$or.push({ _id: new ObjectId(bid) }); } catch {}
+  const r = await books.updateOne(q, { $addToSet: { collections: SLUG }, $set: { updated_at: new Date() } });
+  if (r.matchedCount === 1) tagged++; else missed.push(bid);
+}
+// Seven Sisters of Sleep already existed — tag by title match
+const ss = await books.updateOne(
+  { title: /seven sisters of sleep/i },
+  { $addToSet: { collections: SLUG }, $set: { updated_at: new Date() } }
+);
+console.log(`Tagged ${tagged}/${ADD.length} by id; Seven Sisters matched=${ss.matchedCount}`);
+if (missed.length) console.log('MISSED:', missed);
+
+const taggedDocs = await books.find({ collections: SLUG }, { projection: { language: 1, visible: 1, pages_count: 1, title: 1, published: 1 } }).toArray();
+const live = taggedDocs.filter(b => b.visible !== false && (b.pages_count || 0) > 0);
+const langMap = {};
+for (const b of live) { const l = b.language || 'Unknown'; langMap[l] = (langMap[l] || 0) + 1; }
+const languages = Object.entries(langMap).map(([lang, count]) => ({ lang, count })).sort((a, b) => b.count - a.count);
+await colls.updateOne({ slug: SLUG }, { $set: { book_count: live.length, languages, updated_at: new Date() } });
+console.log(`\nbook_count=${live.length} (of ${taggedDocs.length} tagged) | languages:`, JSON.stringify(languages));
+console.log('\nFull collection roster:');
+for (const b of taggedDocs.sort((a,b)=>String(a.published).localeCompare(String(b.published))))
+  console.log(`  ${String(b.published||'?').padStart(5)}  ${b.title}`);
+await client.close();

--- a/scripts/maintenance/finish-cannabis-acq.mjs
+++ b/scripts/maintenance/finish-cannabis-acq.mjs
@@ -1,0 +1,64 @@
+// Finish the cannabis acquisition: import remaining titles, fix a language,
+// batch-OCR every new book (+ the one that missed), tag all into the collection.
+import { MongoClient, ObjectId } from 'mongodb';
+const SECRET = process.env.CRON_SECRET;
+const uri = process.env.MONGODB_URI;
+const SLUG = 'cannabis-western-record';
+const BASE = 'https://sourcelibrary.org';
+
+const remaining = [
+  ['rajanighantuanddhanvantarinighantuvaidyanarayanasarmapurandareanandashram331896_936_v','Rāja Nighaṇṭu & Dhanvantari Nighaṇṭu','Narahari Paṇḍita','1896','Sanskrit'],
+  ['pharmacographia00dymogoog','Pharmacographia Indica, Vol. 1','Dymock, Warden & Hooper','1890','English'],
+  ['encyclopdiem01lama','Encyclopédie méthodique: Botanique, Tome 1','Jean-Baptiste Lamarck','1785','French'],
+  ['2752373R.nlm.nih.gov','Den groten herbarius met al den figueren der cruyden','Unknown','1532','Dutch'],
+  ['denederlandtseh00nyla','De Nederlandtse herbarius of Kruydt-boeck','Petrus Nylandt','1670','Dutch'],
+];
+
+async function post(path, body){
+  const r = await fetch(BASE+path,{method:'POST',headers:{'Authorization':'Bearer '+SECRET,'Content-Type':'application/json'},body:JSON.stringify(body||{})});
+  const t = await r.text(); let j; try{j=JSON.parse(t)}catch{j={raw:t.slice(0,140),status:r.status}}; return j;
+}
+
+const newIds = [
+  '6a35798c82bf3ff3f867b045', // Seidenschnur (already imported)
+  '6a3579a482bf3ff3f867b074', // O'Shaughnessy 1843
+  '6a3579b882bf3ff3f867b0a1', // Sharngadhara
+];
+
+console.log('== import remaining ==');
+for(const [iaid,title,author,published,language] of remaining){
+  const d = await post('/api/import/ia',{ia_identifier:iaid,title,author,published,language});
+  if(d.bookId){ newIds.push(d.bookId); console.log(`  ${iaid.slice(0,24)} -> ${d.bookId} (${d.pagesCreated}pp)`); }
+  else console.log(`  ${iaid.slice(0,24)} -> ${JSON.stringify(d).slice(0,120)}`);
+}
+
+const client = new MongoClient(uri); await client.connect();
+const db = client.db('bookstore'); const books=db.collection('books'); const colls=db.collection('collections');
+// fix Sharngadhara language Marathi->Sanskrit
+await books.updateOne({_id:new ObjectId('6a3579b882bf3ff3f867b0a1')},{$set:{language:'Sanskrit',updated_at:new Date()}});
+
+// batch OCR: all new books + the Hemp Commission that missed
+const ocrTargets = [...newIds, '6a356ec887fae58c35bbcfe8'];
+console.log('\n== batch OCR submit ==');
+for(const id of ocrTargets){
+  // skip if already has an ocr batch job
+  const has = await db.collection('batch_jobs').countDocuments({book_id:id, type:/ocr/i});
+  if(has){ console.log(`  ${id} already has ${has} ocr jobs, skip`); continue; }
+  const d = await post(`/api/books/${id}/batch-ocr-async`,{});
+  console.log(`  ${id} -> ${d.success?('pages='+d.pagesSubmitted+' batches='+d.batchCount):JSON.stringify(d).slice(0,120)}`);
+}
+
+// tag all new books + Rumphius vol 4 into collection
+const tag = [...newIds, '6958eacd538549809db83318'];
+let tagged=0;
+for(const id of tag){ const q={$or:[{id}]}; try{q.$or.push({_id:new ObjectId(id)})}catch{} ; const r=await books.updateOne(q,{$addToSet:{collections:SLUG},$set:{updated_at:new Date()}}); if(r.matchedCount)tagged++; }
+console.log(`\ntagged ${tagged}/${tag.length}`);
+
+const docs=await books.find({collections:SLUG},{projection:{language:1,visible:1,pages_count:1}}).toArray();
+const live=docs.filter(b=>b.visible!==false&&(b.pages_count||0)>0);
+const lm={}; for(const b of live){const l=b.language||'Unknown'; lm[l]=(lm[l]||0)+1;}
+const languages=Object.entries(lm).map(([lang,count])=>({lang,count})).sort((a,b)=>b.count-a.count);
+await colls.updateOne({slug:SLUG},{$set:{book_count:live.length,languages,updated_at:new Date()}});
+console.log(`collection: tagged=${docs.length} live=${live.length}`);
+console.log('languages:',JSON.stringify(languages));
+await client.close();

--- a/scripts/maintenance/setup-cannabis-collection.mjs
+++ b/scripts/maintenance/setup-cannabis-collection.mjs
@@ -1,0 +1,107 @@
+// Creates the "An Account of the Plant: Cannabis in the Western Record" collection
+// and tags its books. Curation by topic; books are existing public-domain library titles.
+import { MongoClient, ObjectId } from 'mongodb';
+
+const uri = process.env.MONGODB_URI || process.env.MONGO_URI || process.env.DATABASE_URL;
+if (!uri) { console.error('No MONGODB_URI in env'); process.exit(1); }
+
+const SLUG = 'cannabis-western-record';
+
+const COLLECTION = {
+  slug: SLUG,
+  name: 'An Account of the Plant',
+  subtitle: "Cannabis in the Western record, from the Renaissance herbals to the Decadents",
+  description:
+    "In December 1689 Robert Hooke read to the Royal Society <em>An Account of the Plant, call'd Bangue</em> — the first detailed English scientific notice of cannabis, which he proposed calling \"Indian hemp.\" But the plant had been entering the European record for a century before him, through the herbals of Fuchs and the Indies pharmacologists Garcia de Orta, Monardes, and Cristóvão da Costa, who all wrote of \"bangue.\" This collection follows that thread across two centuries after Hooke: the Orientalist scholars who recovered the legend of the Assassins and the hashish-eaters of the <em>Thousand Nights</em>; the alienists — Moreau de Tours and his heirs — who used hashish to model madness and the unconscious; the Decadent literature of Baudelaire's <em>Paradis Artificiels</em>; and the fin-de-siècle occultists for whom Indian hemp was the sorcerer's key. A single plant, read in turn as medicine, as menace, as muse, and as mystery.",
+  color: '#5a7d4f',
+  order: 30,
+  type: 'category',
+  book_count: 0,
+  languages: [],
+  featured_images: [],
+  visible: true,
+  hidden: false,
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+// Confirmed cannabis/hashish-discussing titles (book ids), chronological-ish by theme.
+const BOOK_IDS = [
+  // Ancient root + Renaissance / Indies herbals (prologue)
+  '69c83f236c6f3cc53c850396', // Dioscorides, De medicinali materia (1552)
+  '69b1deeaca46fa60ea1ee933', // Dioscorides, On Medical Matters (Greek, 1906)
+  '69a5d8114d84314297c08924', // Fuchs, De historia stirpium (1542)
+  '69dbca381040d1d5e20aa246', // Latin Herbal (1484)
+  '69dbca3d1040d1d5e20aa644', // Latin Herbal w/ German synonyms (1486)
+  '69dc558ecb6f7429748b8ec8', // Herbarius latinus w/ Dutch synonyms (1486)
+  '69ef285385daccce30f2c71d', // Garcia de Orta / Clusius, Aromatum (1567)
+  '6958e0a9d34d35c8156625ba', // Monardes, De simplicibus ex Occidentali India (1574)
+  '69ef286185daccce30f2ca01', // Cristovao da Costa, Tractado de las Drogas (1578)
+  // The hinge
+  '695595e67bd6d2cd1d620227', // Hooke, Philosophical Experiments and Observations (1726)
+  // Orientalism & the Assassins legend
+  '69907936b621b177c1af59d3', // Lane, Manners and Customs of the Modern Egyptians
+  '699079eadb8b55d19ec685b8', // Lane, Arabian Society in the Middle Ages (1883)
+  '69e53443d48480a3869658be', // Burton, Supplemental Nights, Vol. 5 (1886)
+  '69a557200904636c44e54662', // Burton, Thousand Nights and a Night, Vol. 6 (1888)
+  '69ef2f7f72c1376fdf2af6e2', // Leclerc, Histoire de la medecine arabe, Vol. 2 (1876)
+  '69e9618b2beefe2f6f72bcd1', // Odoric of Pordenone, Les Voyages en Asie (1891)
+  '6991bd4f70254d38471e438c', // Colquhoun, History of Magic, Witchcraft & Animal Magnetism (1851)
+  '6953c85b77f38f6761bdc00b', // Spence, Encyclopaedia of Occultism (1920) [Assassins]
+  // Medicine & experimental psychology (the Moreau lineage)
+  '69ef2191b3e2d3a0927f3a9d', // von Bibra, Die narkotischen Genussmittel und der Mensch (1855)
+  '69905cd7aaa7f10ed4cfcfc5', // du Prel, Die Philosophie der Mystik (1884)
+  '6990541c38e1fdee57b36c1a', // Janet, L'automatisme psychologique (1903)
+  '6a15b94f070b5a08e3b8eb63', // N. C. Paul, A Treatise on the Yoga Philosophy (1851)
+  // Literature
+  '6a08a2b743d85a6ece189325', // Baudelaire, Les Paradis Artificiels (1860)
+  // Fin-de-siecle occultism
+  '69593291b91a6184ea943bbe', // Eliphas Levi, Histoire de la magie (1860)
+  '69c89a626c6f3cc53c85d135', // Guaita, Le Temple de Satan (1891)
+  '695932b8b91a6184ea943faf', // Papus, Traite elementaire de magie pratique
+  '6953e3c677f38f6761bee1fb', // Crowley, Diary of a Drug Fiend (1925)
+];
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const books = db.collection('books');
+const colls = db.collection('collections');
+
+// upsert the collection doc (don't clobber if re-run)
+const existing = await colls.findOne({ slug: SLUG });
+if (existing) {
+  await colls.updateOne({ slug: SLUG }, { $set: { ...COLLECTION, created_at: existing.created_at, updated_at: new Date() } });
+  console.log('Updated existing collection', SLUG);
+} else {
+  await colls.insertOne(COLLECTION);
+  console.log('Created collection', SLUG);
+}
+
+// tag each book; report match per id so we catch any id-space misses
+let tagged = 0, missed = [];
+for (const bid of BOOK_IDS) {
+  const q = { $or: [{ id: bid }] };
+  try { q.$or.push({ _id: new ObjectId(bid) }); } catch {}
+  const r = await books.updateOne(q, { $addToSet: { collections: SLUG }, $set: { updated_at: new Date() } });
+  if (r.matchedCount === 1) tagged++; else missed.push(bid);
+}
+console.log(`Tagged ${tagged}/${BOOK_IDS.length} books`);
+if (missed.length) console.log('MISSED ids:', missed);
+
+// compute book_count + language breakdown over visible, processed books
+const taggedDocs = await books.find({ collections: SLUG }, { projection: { language: 1, visible: 1, pages_count: 1, title: 1, published: 1 } }).toArray();
+const live = taggedDocs.filter(b => b.visible !== false && (b.pages_count || 0) > 0);
+const langMap = {};
+for (const b of live) { const l = b.language || 'Unknown'; langMap[l] = (langMap[l] || 0) + 1; }
+const languages = Object.entries(langMap).map(([lang, count]) => ({ lang, count })).sort((a, b) => b.count - a.count);
+await colls.updateOne({ slug: SLUG }, { $set: { book_count: live.length, languages, updated_at: new Date() } });
+
+console.log(`\nbook_count (visible, processed): ${live.length} of ${taggedDocs.length} tagged`);
+console.log('languages:', JSON.stringify(languages));
+console.log('\nTagged titles:');
+for (const b of taggedDocs.sort((a,b)=>String(a.published).localeCompare(String(b.published)))) {
+  console.log(`  ${b.published || '?'}  ${(b.visible===false?'[hidden] ':'')}${b.title}`);
+}
+
+await client.close();


### PR DESCRIPTION
## Why

Eleven scripts were sitting untracked in the main checkout. They produced **public, shipped collections** — [/collections/american-founding](https://sourcelibrary.org/collections/american-founding) (280 books, 136.8K pages) and the cannabis collection behind [/blog/cannabis-bangue](https://sourcelibrary.org/blog/cannabis-bangue).

So the corpus is public and permanent, while the code that acquired it lived on exactly one laptop. The imports are unreproducible, unreviewable, and one `rm` from gone. Provenance is a core promise of this project; the acquisition path is part of it.

## What's here

| | |
|---|---|
| `scripts/import/*-direct.mjs` (8) | Residential direct-insert imports for sources that 429 datacenter IPs, per `.claude/docs/import-workflow.md` |
| `scripts/maintenance/*cannabis*` (3) | Collection setup, expansion, acquisition finish |

No behavior change — nothing here is wired into a cron or the pipeline. This is purely getting existing, already-run tooling under version control.

## Security

All eleven read config from `process.env` with no literal fallbacks. Scanned for connection strings, API keys, JWTs, and `password/secret/token = "…"` assignments before committing, per the CLAUDE.md rule ("Review scripts for hardcoded credentials before committing"). None found.

## Out of scope — untracked, deliberately left alone

- **`scripts/maintenance/r2-reclaim/`** — I checked, and this is the working copy of **open PR #3013**. Committing it here would duplicate that PR.
- **`scripts/maintenance/auth-monitor-run.sh`** + `monitor-auth-verification.mjs` — a per-machine launchd wrapper with `/Users/dereklomas` hardcoded and a personal plist name. Not repo tooling until the path is parameterized.

Both are worth a follow-up; neither belongs in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)