### PR TITLE
docs: make the monthly staleness audit real; record its provenance

### DIFF
--- a/.claude/docs/archive/doc-reference-audit-2026-07-09.md
+++ b/.claude/docs/archive/doc-reference-audit-2026-07-09.md
@@ -1,0 +1,104 @@
+# Doc reference & staleness audit — 2026-07-09
+
+Snapshot. Records what the knowledge layer looked like the day the archive convention
+was written (PR #3119, commit `7fa84cda`) and the day the staleness check was built
+(this PR). Do not cite as current — re-run the check instead:
+
+    node scripts/audit/doc-staleness.mjs
+
+## Why this file exists
+
+PR #3119 folded the audit's *conclusions* into `.claude/docs/knowledge-layer.md` but
+never wrote down the audit itself. The conclusions therefore cited numbers — "39 of 115
+living docs with zero inbound references" — with no provenance and no way to reproduce
+them. This file supplies the provenance, and the script supplies the reproduction.
+
+Re-derived on 2026-07-09 against `7fa84cda` with an explicit definition, the count comes
+out at **40 of 115**, not 39. The difference is not worth reconciling: the original was
+taken mid-sweep, while docs were being archived and untracked drafts were being added.
+That it lands within one is the point. What matters is the shape, and the shape held.
+
+## Definitions used
+
+- **Living doc** — a tracked `.md` under `.claude/docs/`, excluding `archive/`.
+- **Inbound reference** — the doc's *basename* appears in any tracked file other than
+  itself, excluding `archive/`. A citation from an archived snapshot does not keep a
+  living doc alive.
+- **Counted with `git grep`, never `grep -r`.** See the trap below.
+
+## Findings
+
+**40 of 115 living docs have zero inbound references.** They fall into two kinds that
+were sitting undifferentiated in the same directory: dated one-off audits whose work is
+finished, and live drafts nobody had linked yet (essay drafts, a conference abstract, an
+annotator brief, a census). Mixing them is what made the directory hard to reason about
+— you could not tell the finished from the merely unlinked. Zero inbound references is
+**not** a delete signal. It is a question: would the next session find this when they
+need it?
+
+**5 dated docs still sit outside `archive/`, and all five are referenced by code.**
+This is the load-bearing finding, and it is why archiving is a deletion-class action:
+
+| Doc | Inbound | Nature of the reference |
+|---|---|---|
+| `bph-author-extraction-2026-05-11.md` | 2 | **write target** of `scripts/enrichment/extract-author-from-ocr.mjs` |
+| `bph-cover-audit-2026-05-11.md` | 2 | **write target** of `scripts/audit/bph-cover-quality.mjs` |
+| `bph-memorix-alignment-2026-05-19.md` | 3 | cited by `bph-memorix-final-sync.mjs` + `.sql` |
+| `jung-bph-alignment-2026-05-22.md` | 1 | linked from `collections/jung-resonances/page.tsx` |
+| `tenant-architecture-audit-2026-05-23.md` | 3 | cited by two migrations + `src/lib/embassy/librarian.ts` |
+
+Two are *write targets*: a script opens the file and rewrites it. Moving them to
+`archive/` breaks a script silently — the doc has a date in its name and looks exactly
+like a finished snapshot. **A date in the filename makes a doc a candidate for
+archiving, never an automatic one.** Read the inbound lines; a reference from a script is
+a dependency, not a citation.
+
+**3 stale statistics were being read into every session as current.** These are lines in
+the auto-loaded files (`CLAUDE.md`, `memory/`) that pair a date with a measurement and
+assert it in the present tense. The worst was `CLAUDE.md`'s corpus line, dated
+2026-05-26 and quoted as fact for six weeks. Re-measured against Atlas on 2026-07-09:
+
+| Claim (as of 2026-05-26) | Actual (2026-07-09) | Drift |
+|---|---|---|
+| ~46K total docs | 99,700 | 2.2× |
+| ~29K `visible: true` | 32,028 | 1.1× |
+| ~15K `pages_count > 0` ("actually processed") | 74,717 | **5.0×** |
+| ~14K with any OCR | 48,322 | 3.5× |
+
+Fixed in this PR. The other two — `memory/mcp-server.md:34` (~32K bot hits, as of
+2026-05) and `memory/pipeline-ops.md:5` (snapshot 2026-05) — are left open deliberately.
+They need a live analytics query to re-measure, and leaving them lets the first scheduled
+run of the check prove it surfaces real work rather than reporting clean.
+
+## The trap that nearly deleted five live docs
+
+Reference counts decided a destructive action, and the count could not be trusted.
+
+`grep -r` over `.claude/` descends into the dozens of full repo checkouts under
+`.claude/worktrees/`. Patching that with `--exclude-dir` does not work either, because
+`grep` on this machine may be **ugrep**, not GNU grep, and the two disagree about
+`--exclude-dir` semantics. During the #3119 audit the same query returned **134 hits,
+then 0, then 2**, depending on which binary ran and whether a file path was mixed in with
+the directory arguments. The "0" nearly archived five live docs — including the two write
+targets above.
+
+**Use `git grep`.** It searches tracked files only, never enters a worktree, and is fast.
+When a count decides a destructive action, read the matching *lines*, not the count.
+
+## What was built in response
+
+- `scripts/audit/doc-staleness.mjs` — the three checks above, reproducible, `--json`.
+- `.github/workflows/doc-staleness.yml` — runs monthly, opens/updates a tracking issue.
+- `CLAUDE.md` corpus stat — re-measured and re-dated.
+- `.claude/docs/knowledge-layer.md` — the claim "there is a monthly staleness audit" was
+  aspirational when written. It now names the script that makes it true.
+
+## Known limits of the check
+
+The stale-stat check finds measurements that **date themselves** ("as of 2026-05-26:
+~46K"). An undated stat is invisible to it — there is nothing to compare against. If you
+write a number into an auto-loaded file, date it, or the check cannot defend it.
+
+Orphan detection matches on basename. A doc referred to only by prose description
+("the author identity doc") reads as an orphan. That is arguably correct: if the next
+session cannot grep its way to the file, it may as well not be linked.

--- a/.claude/docs/knowledge-layer.md
+++ b/.claude/docs/knowledge-layer.md
@@ -66,8 +66,12 @@ the handoff, where nobody will look, and it decays. Both of the large CRITICAL s
 in `CLAUDE.md` were written this way. The `/lesson` skill runs this loop.
 
 The reverse also has to happen. A doc that no longer describes reality is worse than no
-doc, because it is trusted. There is a monthly `CLAUDE.md` staleness audit; stats older
-than 14 days are to be verified before use, not quoted.
+doc, because it is trusted. Stats older than 14 days are to be verified before use, not
+quoted — `scripts/audit/doc-staleness.mjs` finds the ones that date themselves, and
+`.github/workflows/doc-staleness.yml` runs it monthly into a tracking issue. Its first
+run caught `CLAUDE.md`'s corpus counts six weeks stale, with "actually processed" off by
+5×. Undated stats are invisible to it: if you write a number into an auto-loaded file,
+date it, or nothing can defend it.
 
 ## Two rules that are load-bearing
 
@@ -92,10 +96,12 @@ didn't read the prose.
 
 ## Doc lifecycle — the archive convention
 
-Reference docs accrete. A 2026-07 audit found **39 of 115 living docs with zero inbound
-references** from anywhere in the tracked tree. Two different kinds were mixed together:
-dated one-off audits, and live drafts nobody had linked yet. `.claude/docs/archive/`
-already existed for the first kind — it just wasn't being fed.
+Reference docs accrete. A 2026-07 audit found **40 of 115 living docs with zero inbound
+references** from anywhere in the tracked tree (full writeup, definitions, and the
+re-measured numbers: `.claude/docs/archive/doc-reference-audit-2026-07-09.md`). Two
+different kinds were mixed together: dated one-off audits, and live drafts nobody had
+linked yet. `.claude/docs/archive/` already existed for the first kind — it just wasn't
+being fed.
 
 The convention that separates them:
 

--- a/.github/workflows/doc-staleness.yml
+++ b/.github/workflows/doc-staleness.yml
@@ -1,0 +1,61 @@
+name: Doc staleness audit
+
+# `.claude/docs/knowledge-layer.md` says a doc that no longer describes reality is
+# worse than no doc, because it is trusted. This is the check that makes that
+# statement enforceable rather than aspirational: every month it re-counts orphaned
+# docs, dated docs still outside archive/, and stale statistics in the auto-loaded
+# files (CLAUDE.md, memory/), and files the result as a tracking issue.
+#
+# It NEVER moves or deletes a file. Archiving is a deletion-class action — of the
+# five dated docs the first run found outside archive/, all five were referenced by
+# code and two were script WRITE TARGETS. The report is a candidate list for a human,
+# never an instruction. See .claude/docs/archive/doc-reference-audit-2026-07-09.md.
+#
+# Runs on a schedule and on demand. Not a PR check: the findings are judgment calls,
+# and failing a contributor's PR because an unrelated doc went unreferenced would
+# train people to ignore it.
+
+on:
+  schedule:
+    # 09:00 UTC on the 1st of each month
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # git grep only searches tracked files, but it needs the full tree.
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run the audit
+        id: audit
+        run: |
+          node scripts/audit/doc-staleness.mjs > report.txt
+          cat report.txt
+
+      - name: File or update the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Doc staleness audit — $(date -u +'%Y-%m')"
+          BODY=$(printf '%s\n\n```\n%s\n```\n' \
+            "Monthly run of \`scripts/audit/doc-staleness.mjs\`. Findings are candidates, not instructions — archiving is deletion-class, so read the inbound lines before moving anything." \
+            "$(cat report.txt)")
+
+          EXISTING=$(gh issue list --search "$TITLE in:title" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label documentation
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ The policy across the whole site (open-access posture since 2026-07-05, #2963): 
 
 ## Stack
 - Next.js 16, MongoDB Atlas, Gemini AI, Vercel deployment
-- Production database: `bookstore`, NOT `sourcelibrary_research`. As of 2026-05-26: ~46K total docs, ~29K `visible: true` (publicly shown), ~15K with `pages_count > 0` (actually processed), ~14K with any OCR. The `tier` field is legacy (only used by `src/app/page.tsx` homepage ranking via `highlighted_books` collection entries); current canonical "live" filter across all public APIs is `visible: true && pages_count > 0` (see `/api/books/library`).
+- Production database: `bookstore`, NOT `sourcelibrary_research`. As of 2026-07-09: ~99.7K total docs, ~32K `visible: true` (publicly shown), ~74.7K with `pages_count > 0` (actually processed), ~48.3K with any OCR. Re-measure before quoting — the previous figures here were 2026-05-26 vintage and had drifted by up to 5× (`pages_count > 0` read ~15K against a true 74.7K). The `tier` field is legacy (only used by `src/app/page.tsx` homepage ranking via `highlighted_books` collection entries); current canonical "live" filter across all public APIs is `visible: true && pages_count > 0` (see `/api/books/library`).
 
 ## AI Models — IMPORTANT
 - Summary/Index generation: enrich-worker uses `gemini-3.1-flash-lite` for all phases — summary+index (Phase 6), chapters (Phase 7), quality scoring (Phase 7.5), collection assignment (Phase 7.6). NEVER use models older than v3.

--- a/scripts/audit/doc-staleness.mjs
+++ b/scripts/audit/doc-staleness.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * Doc staleness audit.
+ *
+ * `.claude/docs/knowledge-layer.md` states the rules this script checks:
+ *
+ *   - A date in the filename means snapshot, not doctrine — dated docs belong in
+ *     `.claude/docs/archive/` once their work is done.
+ *   - Undated docs are living: they must describe how the system works *now*.
+ *   - Stats older than 14 days are to be verified before use, not quoted.
+ *
+ * Prose invariants get violated by whoever didn't read the prose, so this is the
+ * machine check. It reports three things:
+ *
+ *   1. ORPHANS      — living docs with zero inbound references from tracked files.
+ *   2. ARCHIVE      — dated docs still sitting outside archive/, with their inbound
+ *      CANDIDATES     references listed so you can see what would break.
+ *   3. STALE STATS  — lines in the auto-loaded files (CLAUDE.md, memory/) that pair
+ *                     an old date with a quantity. These are load-bearing because
+ *                     they're read into every session's context as if current.
+ *
+ * ARCHIVING IS A DELETION-CLASS ACTION. This script never moves or deletes a file.
+ * An orphan or an archive candidate is a *candidate*, never an instruction: of the
+ * eleven dated audits that motivated the convention, five were still referenced by
+ * code, and `.claude/docs/bph-cover-audit-2026-05-11.md` is a WRITE TARGET of
+ * `scripts/audit/bph-cover-quality.mjs`, not merely a citation. Read the matching
+ * lines before you move anything.
+ *
+ * Reference counting uses `git grep`, never `grep -r`. A plain `grep -r` over
+ * `.claude/` descends into the dozens of full repo checkouts under
+ * `.claude/worktrees/`, and `grep` on a contributor's machine may be ugrep, whose
+ * `--exclude-dir` semantics differ from GNU grep's. The same query returned 134
+ * hits, then 0, then 2, during the audit that wrote this convention — and the "0"
+ * nearly archived five live docs.
+ *
+ *   node scripts/audit/doc-staleness.mjs              # human-readable report
+ *   node scripts/audit/doc-staleness.mjs --json       # machine-readable
+ *   node scripts/audit/doc-staleness.mjs --stat-age 30
+ *   node scripts/audit/doc-staleness.mjs --fail-on-findings   # exit 1 if anything found
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const failOnFindings = args.includes('--fail-on-findings');
+const statAgeDays = Number(
+  args.includes('--stat-age') ? args[args.indexOf('--stat-age') + 1] : 14,
+);
+
+/** Files whose content is read into every session, so stale stats there mislead by default. */
+const AUTO_LOADED = ['CLAUDE.md', 'memory'];
+const DOCS_DIR = '.claude/docs';
+const ARCHIVE_DIR = '.claude/docs/archive';
+
+/** A date anywhere in the filename: 2026-05-12, 2026-05, or 2026-04. */
+const DATED_FILENAME = /\d{4}-\d{2}(-\d{2})?/;
+
+function git(...argv) {
+  try {
+    return execFileSync('git', argv, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  } catch (err) {
+    // git grep exits 1 on "no matches" — that is a result, not a failure.
+    if (err.status === 1) return '';
+    throw err;
+  }
+}
+
+const lines = (s) => s.split('\n').filter(Boolean);
+
+/**
+ * Inbound references to a doc, by basename, across tracked files.
+ *
+ * Excludes the doc itself and the archive: a citation from an archived snapshot
+ * does not keep a living doc alive. Returns `file:line:text` so a human can judge
+ * whether the reference is a citation or a code dependency.
+ */
+function inboundRefs(path) {
+  const name = basename(path);
+  const out = git(
+    'grep',
+    '-nF',
+    name,
+    '--',
+    ':!' + path,
+    ':!' + ARCHIVE_DIR,
+  );
+  return lines(out);
+}
+
+function livingDocs() {
+  return lines(git('ls-files', DOCS_DIR + '/*.md')).filter(
+    (p) => !p.startsWith(ARCHIVE_DIR + '/'),
+  );
+}
+
+/**
+ * Lines pairing a date older than the threshold with a quantity.
+ *
+ * A bare date is usually an incident date and stays true forever ("fixed on
+ * 2026-05-24"). A date next to a *number* is a measurement, and measurements rot:
+ * "~46K total docs, ~29K visible (2026-05-26)" is quoted into every session as
+ * though someone re-counted this morning.
+ */
+function staleStats(cutoff) {
+  const paths = lines(git('ls-files', ...AUTO_LOADED));
+  const hasQuantity = /(\d[\d,.]*\s*[%KMB]\b)|(~\s*\d)|(\b\d{3,}\b)/;
+  const findings = [];
+
+  // Three things look like quantities and never rot: PR/issue refs (#1980), the
+  // dates themselves, and digits inside a path (…-2026-05-25-pr1980-split.md).
+  // Left in, they bury the ~12 real measurements under ~50 citations, and a report
+  // that cries wolf gets muted — which is how the stat went stale in the first place.
+  const notAQuantity = [
+    /\bPRs?\s*#[\d/#\s]+/gi,
+    /\bissues?\s*#[\d/#\s]+/gi,
+    /#\d+/g,
+    /`[^`]*`/g, // inline code: filenames, field names, commit hashes
+    /\[[^\]]*\]\([^)]*\)/g, // markdown links
+    /\S*\.(md|json|mjs|ts|tsx|sql|sh|yml)\b/g,
+    /\b\d{4}-\d{2}(-\d{2})?\b/g,
+  ];
+
+  // A dated past-tense lesson ("Lambda timeout (2026-03-13): books >500 pages
+  // exceed the 15min limit") is provenance and stays true. What rots is a line
+  // asserting a CURRENT measurement — it is quoted as though someone re-counted
+  // this morning. The cue is an as-of marker, so require one.
+  const assertsCurrent = /\b(as of|snapshot|currently|at present|today|live count|last (measured|counted|checked))\b/i;
+
+  for (const path of paths) {
+    if (!path.endsWith('.md')) continue;
+    // Read the WORKING TREE, not HEAD. `git grep` above resolves tracked paths against
+    // the working tree, and a check that can't see the fix you just made is a check
+    // people stop running.
+    const content = readFileSync(path, 'utf8');
+    content.split('\n').forEach((text, i) => {
+      const dates = text.match(/\b\d{4}-\d{2}(-\d{2})?\b/g);
+      if (!dates || !assertsCurrent.test(text)) return;
+      const stripped = notAQuantity.reduce((s, re) => s.replace(re, ' '), text);
+      if (!hasQuantity.test(stripped)) return;
+      // Judge a line by its NEWEST date: "changed in 2026-03, re-measured 2026-07"
+      // is current, and flagging it would train people to ignore the report.
+      const newest = dates
+        .map((d) => new Date(d.length === 7 ? `${d}-01` : d))
+        .sort((a, b) => b - a)[0];
+      if (Number.isNaN(newest.getTime()) || newest >= cutoff) return;
+      findings.push({
+        path,
+        line: i + 1,
+        date: newest.toISOString().slice(0, 10),
+        text: text.trim().slice(0, 160),
+      });
+    });
+  }
+  return findings;
+}
+
+function main() {
+  const cutoff = new Date(Date.now() - statAgeDays * 86400_000);
+
+  const docs = livingDocs();
+  const orphans = [];
+  const archiveCandidates = [];
+
+  for (const path of docs) {
+    const refs = inboundRefs(path);
+    if (refs.length === 0) orphans.push({ path, refs });
+    if (DATED_FILENAME.test(basename(path))) {
+      archiveCandidates.push({ path, refs });
+    }
+  }
+
+  const stats = staleStats(cutoff);
+  const report = {
+    generated_from_commit: git('rev-parse', '--short', 'HEAD').trim(),
+    living_docs: docs.length,
+    archived_docs: lines(git('ls-files', ARCHIVE_DIR + '/*.md')).length,
+    stat_age_days: statAgeDays,
+    orphans,
+    archive_candidates: archiveCandidates,
+    stale_stats: stats,
+  };
+
+  if (asJson) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    const { living_docs, archived_docs } = report;
+    console.log(`\nDoc staleness audit — ${report.generated_from_commit}`);
+    console.log(`${living_docs} living docs, ${archived_docs} archived\n`);
+
+    console.log(`ORPHANS — ${orphans.length}/${living_docs} living docs with zero inbound refs`);
+    console.log('  Not a delete list. A doc can be young, or linked only from prose a');
+    console.log('  human reads. Ask: would the next session find this when they need it?\n');
+    for (const { path } of orphans) console.log(`    ${path}`);
+
+    console.log(`\nARCHIVE CANDIDATES — ${archiveCandidates.length} dated docs outside archive/`);
+    console.log('  DELETION-CLASS. Read the inbound lines: a reference from a *script* is a');
+    console.log('  dependency, not a citation. Moving that file breaks the script.\n');
+    for (const { path, refs } of archiveCandidates) {
+      console.log(`    ${path}  (${refs.length} inbound)`);
+      for (const r of refs.slice(0, 6)) console.log(`        ${r.slice(0, 150)}`);
+      if (refs.length > 6) console.log(`        … ${refs.length - 6} more`);
+    }
+
+    console.log(`\nSTALE STATS — ${stats.length} lines older than ${statAgeDays}d pairing a date with a number`);
+    console.log('  These are read into every session as if current. Re-measure or re-date.\n');
+    for (const s of stats) console.log(`    ${s.path}:${s.line}  [${s.date}]  ${s.text}`);
+    console.log('');
+  }
+
+  const total = orphans.length + archiveCandidates.length + stats.length;
+  if (failOnFindings && total > 0) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Why

`.claude/docs/knowledge-layer.md` asserted "There is a monthly `CLAUDE.md` staleness audit." There wasn't one — no script, no workflow, no cron, no prior report. The line shipped yesterday in #3119, so nobody had been skipping a ritual; the ritual was never built. By the doc's own rule — *a doc that no longer describes reality is worse than no doc, because it is trusted* — that line was the exact failure mode it warns about.

Derek asked for two things: write the July audit up so its numbers have provenance, and build the check.

## What's in scope

**`scripts/audit/doc-staleness.mjs`** — three checks, reproducible, `--json` / `--fail-on-findings`:
1. **Orphans** — living docs with zero inbound references.
2. **Archive candidates** — dated docs still outside `archive/`, *with their inbound lines printed* so you can see what would break.
3. **Stale stats** — lines in the auto-loaded files (`CLAUDE.md`, `memory/`) pairing an old date with a measurement asserted in the present tense.

Counts references with `git grep`, never `grep -r`. It **never moves or deletes a file**.

**`.github/workflows/doc-staleness.yml`** — runs it monthly into a tracking issue.

**`.claude/docs/archive/doc-reference-audit-2026-07-09.md`** — the writeup #3119 never wrote. Re-derived against `7fa84cda` with an explicit definition: **40 of 115**, not 39. The original was taken mid-sweep; landing within one is the point.

## The check earned its keep on the first run

`CLAUDE.md`'s corpus stat was six weeks stale and read into every session as current:

| Claim (as of 2026-05-26) | Actual (2026-07-09) | Drift |
|---|---|---|
| ~46K total docs | 99,700 | 2.2× |
| ~29K `visible: true` | 32,028 | 1.1× |
| ~15K `pages_count > 0` ("actually processed") | 74,717 | **5.0×** |
| ~14K with any OCR | 48,322 | 3.5× |

Re-measured against Atlas, re-dated.

It also confirmed the finding that makes archiving deletion-class: **all five** dated docs outside `archive/` are referenced by code, and two (`bph-cover-audit-2026-05-11.md`, `bph-author-extraction-2026-05-11.md`) are script **write targets**, not citations. Moving them breaks a script silently.

## Deliberately out of scope

- **Two stale stats left unfixed** (`memory/mcp-server.md:34`, `memory/pipeline-ops.md:5`). They need a live analytics query to re-measure. Leaving them lets the first scheduled run prove the check surfaces real work rather than reporting clean.
- **No docs archived.** The 40 orphans and 5 candidates are a candidate list for a human. Archiving is deletion-class; that's a separate PR with separate judgment.
- **Not wired as a PR check.** Findings are judgment calls, and failing a contributor's PR over an unrelated unreferenced doc trains people to ignore the report.

## Known limit (documented in the script and the audit)

The stale-stat check finds measurements that **date themselves**. An undated number is invisible to it. If you write a number into an auto-loaded file, date it, or nothing can defend it.

## Verification

- `node scripts/audit/doc-staleness.mjs` → 40 orphans / 5 candidates / 2 stale stats
- `--json` parses; `--fail-on-findings` exits 1, bare run exits 0
- Workflow YAML parses (js-yaml + python yaml)
- Corpus counts re-measured directly against Atlas `bookstore.books`
- Caught and fixed a bug in my own script mid-review: `staleStats` read `git show HEAD:<path>` and so couldn't see an uncommitted fix. Now reads the working tree, matching `git grep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)