### PR TITLE
fix(revalidate): layout-invalidate every book path key, not just the slug

### DIFF
--- a/src/app/api/admin/revalidate-book/[id]/route.ts
+++ b/src/app/api/admin/revalidate-book/[id]/route.ts
@@ -35,8 +35,15 @@ export async function POST(
   // Also revalidate by ID in case both are cached
   revalidatePath(`/book/${id}`);
 
-  // Revalidate individual page routes via layout invalidation
-  revalidatePath(`/book/${slug}`, 'layout');
+  // Revalidate individual page routes (/book/<x>/page/<pageId>) via layout
+  // invalidation. Layout invalidation is keyed on the literal /book/<x> prefix,
+  // so it must run for every identifier a reader can arrive under — slug, the
+  // route param, and the canonical book id. Doing it for the slug alone left
+  // id-form page URLs serving a stale render for the full 24h ISR window.
+  const bookPathKeys = new Set([slug, id, book.id as string].filter(Boolean));
+  for (const key of bookPathKeys) {
+    revalidatePath(`/book/${key}`, 'layout');
+  }
 
   const revalidated = [`/book/${slug}`, `/book/${id}`];
 
@@ -54,14 +61,16 @@ export async function POST(
     // Regular tenant route
     revalidatePath(`/${tenantSlug}/book/${slug}`);
     revalidatePath(`/${tenantSlug}/book/${slug}/search`);
-    revalidatePath(`/${tenantSlug}/book/${slug}`, 'layout');
     revalidatePath(`/${tenantSlug}/book/${id}`);
     // Tenant subdomains route to /embed/[tenant]/book/[slug] via proxy.ts.
     // Without this, Vercel's edge cache happily keeps serving the stale 404
     // after a visibility flip — that's how the Bhutan promotion bit us.
     revalidatePath(`/embed/${tenantSlug}/book/${slug}`);
-    revalidatePath(`/embed/${tenantSlug}/book/${slug}`, 'layout');
     revalidatePath(`/embed/${tenantSlug}/book/${id}`);
+    for (const key of bookPathKeys) {
+      revalidatePath(`/${tenantSlug}/book/${key}`, 'layout');
+      revalidatePath(`/embed/${tenantSlug}/book/${key}`, 'layout');
+    }
     revalidated.push(
       `/${tenantSlug}/book/${slug}`,
       `/${tenantSlug}/book/${id}`,


### PR DESCRIPTION
## What

`/api/admin/revalidate-book/[id]` called `revalidatePath(path, 'layout')` for the slug form only. Next's layout invalidation is keyed on the literal `/book/<x>` prefix, so the id-form page routes (`/book/<bookId>/page/<pageId>`) were never invalidated and kept serving their stale ISR render for the full 24h window.

Found while enabling romanization on the Armenian *Patmutʻiwn Hayotsʻ* (Buzand). After writing `pages.transliteration.data` for all 311 pages and calling revalidate + a Cloudflare `purge_everything`, the "Romanized" toggle appeared under `/book/patmut-iwn-hayots-.../page/<id>` but not under `/book/69a5ead1d507939f0352ced7/page/<id>` — same page, same data. A cache-busted query string rendered it fine, confirming the ISR entry, not the data, was stale.

## Change

Collect `slug`, the route param, and the canonical `book.id` into one set, and layout-invalidate each — on the global path and both tenant path shapes (`/<tenant>/book/...`, `/embed/<tenant>/book/...`), which had the same gap.

## Out of scope

- The Cloudflare edge purge already covers its half; this is purely the Vercel ISR side.
- No change to which paths get the non-layout `revalidatePath` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)