### PR TITLE
fix(security): rate-limit the two endpoints that email arbitrary addresses

### DIFF
--- a/src/app/api/beta/subscribe/route.ts
+++ b/src/app/api/beta/subscribe/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { checkRateLimitShared, getClientIp } from '@/lib/rate-limit';
+
+// Every new address here triggers a welcome email to that address. Uncapped,
+// that is a spam relay: a script can make sourcelibrary.org mail strangers,
+// and the resulting Resend suspension would also kill the health-check alerts.
+const RATE_LIMIT = { name: 'beta-subscribe', limit: 3, windowSeconds: 3600 };
 
 const WELCOME_HTML = `
 <div style="font-family: Georgia, 'Times New Roman', serif; max-width: 520px; margin: 0 auto; padding: 40px 24px; color: #1a1612;">
@@ -121,6 +127,17 @@ export async function POST(request: NextRequest) {
         );
       }
       return NextResponse.json({ message: 'Already subscribed!', alreadySubscribed: true });
+    }
+
+    // Gate only the path that actually sends mail. A returning subscriber hits
+    // the early return above without spending budget; a script walking a list of
+    // fresh addresses spends it on every request, which is the case we care about.
+    const limit = await checkRateLimitShared(RATE_LIMIT, getClientIp(request));
+    if (!limit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many subscription attempts. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(limit.retryAfter) } },
+      );
     }
 
     // Get IP and country from headers (Cloudflare / Vercel)

--- a/src/app/api/donate/route.ts
+++ b/src/app/api/donate/route.ts
@@ -1,9 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabase';
 import { Resend } from 'resend';
+import { checkRateLimitShared, getClientIp } from '@/lib/rate-limit';
 
 const VALID_ROUTES = ['naf', 'efm', 'undecided'] as const;
 const VALID_AMOUNTS = ['under-1000', '1000-5000', '5000-10000', '10000-25000', '25000-50000', '50000-plus', ''] as const;
+
+// This route emails the submitted address. Uncapped, that is a spam relay:
+// anyone can make sourcelibrary.org mail a stranger. A donor submits once.
+const RATE_LIMIT = { name: 'donate', limit: 3, windowSeconds: 3600 };
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
 
 interface DonationIntention {
   name: string;
@@ -34,7 +47,7 @@ function buildDonorEmail(firstName: string, route: string): string {
       </div>
 
       <div style="line-height: 1.8; font-size: 15px; color: #1a1612;">
-        <p>Dear ${firstName},</p>
+        <p>Dear ${escapeHtml(firstName)},</p>
         <p>
           Thank you for your interest in supporting Source Library. Every contribution
           moves us closer to making these extraordinary texts freely available to the world.
@@ -86,15 +99,15 @@ function buildNotificationEmail(intention: DonationIntention): string {
     <div style="font-family: -apple-system, sans-serif; max-width: 520px; margin: 0 auto; padding: 24px; color: #1a1612;">
       <h2 style="font-size: 18px; margin: 0 0 16px;">New Donation Interest</h2>
       <table style="width: 100%; border-collapse: collapse; font-size: 14px;">
-        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600; width: 120px;">Name</td><td style="padding: 8px 12px;">${intention.name}</td></tr>
-        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Email</td><td style="padding: 8px 12px;"><a href="mailto:${intention.email}">${intention.email}</a></td></tr>
+        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600; width: 120px;">Name</td><td style="padding: 8px 12px;">${escapeHtml(intention.name)}</td></tr>
+        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Email</td><td style="padding: 8px 12px;"><a href="mailto:${escapeHtml(intention.email)}">${escapeHtml(intention.email)}</a></td></tr>
         <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Route</td><td style="padding: 8px 12px;">${routeLabel}</td></tr>
-        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Amount</td><td style="padding: 8px 12px;">${amountLabel}</td></tr>
-        ${intention.message ? `<tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600; vertical-align: top;">Message</td><td style="padding: 8px 12px;">${intention.message}</td></tr>` : ''}
-        ${intention.referrer ? `<tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Referrer</td><td style="padding: 8px 12px;">${intention.referrer}</td></tr>` : ''}
+        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Amount</td><td style="padding: 8px 12px;">${escapeHtml(amountLabel)}</td></tr>
+        ${intention.message ? `<tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600; vertical-align: top;">Message</td><td style="padding: 8px 12px;">${escapeHtml(intention.message)}</td></tr>` : ''}
+        ${intention.referrer ? `<tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Referrer</td><td style="padding: 8px 12px;">${escapeHtml(intention.referrer)}</td></tr>` : ''}
       </table>
       <p style="margin-top: 16px; font-size: 13px; color: #8a8480;">
-        Reply directly to this email to reach the donor at ${intention.email}.
+        Reply directly to this email to reach the donor at ${escapeHtml(intention.email)}.
       </p>
     </div>
   `;
@@ -102,6 +115,14 @@ function buildNotificationEmail(intention: DonationIntention): string {
 
 export async function POST(request: NextRequest) {
   try {
+    const limit = await checkRateLimitShared(RATE_LIMIT, getClientIp(request));
+    if (!limit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many submissions. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(limit.retryAfter) } },
+      );
+    }
+
     const body = await request.json();
     const { name, email, route, amount_range, message, referrer } = body;
 


### PR DESCRIPTION
## Why

`/api/donate` and `/api/beta/subscribe` are unauthenticated and both send email **to the address supplied in the request body**. Neither had a rate limit, captcha, honeypot, or origin check. Either is an open spam relay — a script can make `sourcelibrary.org` email a list of strangers, from our own sending domain.

The blast radius includes our own alerting. Welcome/donor mail and the `health-check` alert share one Resend account, so an abuser who gets that account throttled or suspended **also silently disables the only channel that would tell us anything is wrong.** The attack disables the detector.

`donation_intentions` holds 3 real rows and `beta_subscribers` 13, newest from March — these are low-traffic endpoints where any burst is unambiguous abuse.

## What changed

- Both routes now call `checkRateLimitShared` — the Mongo-backed **global** limiter already used by the magic-link send — at **3/hour per IP**. (Not the in-memory `checkRateLimit`, which is per-serverless-instance and trivially exceeded by fan-out.)
- On `/api/beta/subscribe` the gate sits **after** the existing-subscriber check. A returning subscriber still gets `Already subscribed` without spending budget; only the path that actually sends mail is metered. A script walking fresh addresses spends budget on every request, which is the case we care about.
- `/api/donate` escapes the submitted `name`, `email`, `message`, and `referrer` before interpolating them into the notification email. They were being injected as raw HTML into Derek's inbox.

## Verification

Ran a dev server with `RESEND_API_KEY` blanked so nothing could send, and drove the real routes:

- `/api/donate` — 3× `200`, then `429` with `Retry-After: 614`. A different IP still gets `200`, so the bucket is per-IP and not a global lock.
- `/api/beta/subscribe` — 3 fresh addresses `200`, 4th `429`; a **returning** subscriber from the same now-blocked IP still gets `200 {"alreadySubscribed":true}`.

Test rows were written to production and then removed: 5 from `beta_subscribers` (back to 13), 4 from `donation_intentions` (back to 3, all real). No mail was sent. `npx tsc --noEmit` clean.

## Out of scope (deliberately)

- **Turnstile.** `src/lib/turnstile.ts` and `TurnstileWidget.tsx` are already written and wired into the sign-in form, but `turnstileEnabled()` requires `NEXT_PUBLIC_TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY`, and neither exists in any env file — so `verifyTurnstile` is a no-op in production today. Turning it on is an env-var change plus extending the widget to these two forms. Separate PR.
- **Per-IP is not per-attacker.** A distributed caller with many IPs still gets 3/hour each. A global outbound-email ceiling is the real backstop, and belongs with the observability work below.
- **Recording the denials.** `src/lib/rate-limit.ts` has no insert and no log line — a 429 goes out and the event evaporates. So these limits now *stop* the attack but still leave no trace that it happened. Filed separately.
- No change to `/api/feedback`, `/api/volunteer`, or `/api/share-findings` — they accept an email but only write to the DB, so they're a spam-content problem, not a spam-relay one.

## Note for reviewers

While testing I tripped an *existing* limiter I hadn't noticed: `src/proxy.ts:803` rate-limits anything `looksLikeBot()` to 10 req/60s. Worth knowing that it resolves the client IP as `x-forwarded-for → x-real-ip → cf-connecting-ip`, while `src/lib/rate-limit.ts` uses `cf-connecting-ip → x-forwarded-for → x-real-ip`. The two layers can key the same request to different buckets. Behind Cloudflare + Vercel both headers are set at the edge so this is almost certainly benign, but the divergence is unintentional and worth reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)