### PR TITLE
feat(trace): light the romanized pane; stop snapping clicks to distant spans

### DIFF
--- a/src/app/api/books/[id]/pages/[pageId]/alignment/route.ts
+++ b/src/app/api/books/[id]/pages/[pageId]/alignment/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     const page = await db.collection('pages').findOne(
       { id: pageId, book_id: book.id },
-      { projection: { id: 1, 'ocr.data': 1, 'translation.data': 1, word_alignment: 1 } },
+      { projection: { id: 1, 'ocr.data': 1, 'translation.data': 1, 'transliteration.data': 1, word_alignment: 1 } },
     );
     if (!page) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -1702,9 +1702,11 @@ export default function TranslationEditor({
                 </div>
               )}
 
-              {/* Transliteration Panel (non-Latin scripts only) */}
+              {/* Transliteration Panel (non-Latin scripts only). data-reader-section
+                  opts it into trace mode: clicking a phrase in any pane lights the
+                  romanized span too (TraceAlignment). */}
               {showTransliterationPanel && hasTransliteration && (
-                <div className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-white)', borderLeft: '1px solid var(--border-light)' }}>
+                <div data-reader-section="transliteration" className={`w-full ${panelWidth} flex flex-col min-h-[50vh] shrink-0 lg:min-h-0 lg:shrink lg:flex-1`} style={{ background: 'var(--bg-white)', borderLeft: '1px solid var(--border-light)' }}>
                   <div className="px-4 py-2 flex items-center justify-between flex-shrink-0" style={{ borderBottom: '1px solid var(--border-light)' }}>
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>

--- a/src/components/reader/TraceAlignment.tsx
+++ b/src/components/reader/TraceAlignment.tsx
@@ -30,7 +30,26 @@ interface TraceAlignmentProps {
 
 export type TraceStatus = 'idle' | 'loading' | 'ready' | 'unavailable' | 'rate_limited';
 
-type Side = 'ocr' | 'translation';
+type Side = 'ocr' | 'translation' | 'transliteration';
+
+const SIDES: Side[] = ['ocr', 'translation', 'transliteration'];
+
+/** The pair field holding this side's span, and the field holding its offset. */
+function spanFor(pair: AlignmentPair, side: Side): string | undefined {
+  return side === 'ocr' ? pair.s : side === 'translation' ? pair.t : pair.r;
+}
+function offsetFor(pair: AlignmentPair, side: Side): number | undefined {
+  return side === 'ocr' ? pair.so : side === 'translation' ? pair.to : pair.ro;
+}
+
+/**
+ * How far (in normalized chars) a click may sit outside a span and still snap
+ * to it. Generous enough to absorb a click on trailing punctuation or the space
+ * after a phrase; too small to reach the next phrase. It used to be 60 — about
+ * ten words — which meant that clicking anywhere in the ~33% of a page the
+ * model leaves unaligned confidently highlighted an unrelated phrase.
+ */
+const SNAP_TOLERANCE = 12;
 
 interface PaneMap {
   /** Concatenated text of all text nodes in the pane. */
@@ -42,6 +61,8 @@ interface PaneMap {
 
 const HIGHLIGHT_PRIMARY = 'sl-trace-primary';
 const HIGHLIGHT_COUNTERPART = 'sl-trace-counterpart';
+/** Second counterpart, so a click lights all three panes at once. */
+const HIGHLIGHT_COUNTERPART_2 = 'sl-trace-counterpart-2';
 
 function highlightsSupported(): boolean {
   return typeof window !== 'undefined'
@@ -110,25 +131,28 @@ interface PairInterval {
   start: number;      // raw offsets in pane text
   end: number;
   normStart: number;
+  normEnd: number;    // offsets in the NORMALIZED pane text
 }
 
 /**
  * Locate every pair's span on one side of the rendered DOM, walking in
  * stored-offset order with a moving cursor so repeated phrases bind to
  * successive occurrences (mirrors resolveAlignmentPairs on the server).
+ * Pairs with no span on this side (a romanized span that never resolved) are
+ * simply absent — clicking their words highlights nothing rather than guessing.
  */
 function locatePairIntervals(map: PaneMap, pairs: AlignmentPair[], side: Side): PairInterval[] {
   const order = pairs
     .map((_, i) => i)
-    .sort((a, b) => (side === 'ocr' ? pairs[a].so - pairs[b].so : pairs[a].to - pairs[b].to));
+    .filter((i) => spanFor(pairs[i], side) !== undefined)
+    .sort((a, b) => (offsetFor(pairs[a], side)! - offsetFor(pairs[b], side)!));
   const out: PairInterval[] = [];
   let cursor = 0;
   for (const i of order) {
-    const span = side === 'ocr' ? pairs[i].s : pairs[i].t;
-    const hit = locateSpan(map.norm, span, cursor);
+    const hit = locateSpan(map.norm, spanFor(pairs[i], side)!, cursor);
     if (!hit) continue;
     cursor = hit.normStart + 1;
-    out.push({ pairIndex: i, start: hit.start, end: hit.end, normStart: hit.normStart });
+    out.push({ pairIndex: i, start: hit.start, end: hit.end, normStart: hit.normStart, normEnd: hit.normEnd });
   }
   return out;
 }
@@ -163,6 +187,7 @@ function setHighlight(name: string, range: Range | null) {
 function clearHighlights() {
   setHighlight(HIGHLIGHT_PRIMARY, null);
   setHighlight(HIGHLIGHT_COUNTERPART, null);
+  setHighlight(HIGHLIGHT_COUNTERPART_2, null);
 }
 
 /** Scroll a range to the vertical center of its pane's scroll container. */
@@ -250,13 +275,11 @@ export default function TraceAlignment({ bookId, pageId, active, onStatusChange 
       const panel = target?.closest?.('[data-reader-panel]');
       const section = target?.closest?.('[data-reader-section]') as HTMLElement | null;
       const side = section?.dataset.readerSection as Side | undefined;
-      if (!panel || !side || (side !== 'ocr' && side !== 'translation')) return;
+      if (!panel || !side || !SIDES.includes(side)) return;
       // Ignore clicks on interactive elements inside the panes.
       if (target?.closest('a, button, summary, input, textarea')) return;
 
       const clickedPane = getPaneEl(side);
-      const otherSide: Side = side === 'ocr' ? 'translation' : 'ocr';
-      const otherPane = getPaneEl(otherSide);
       if (!clickedPane) return;
 
       const caret = caretFromPoint(e.clientX, e.clientY);
@@ -271,24 +294,23 @@ export default function TraceAlignment({ bookId, pageId, active, onStatusChange 
       const normOffset = rawToNorm(clickedMap.norm, rawOffset);
 
       // Prefer the SHORTEST interval containing the click (most specific
-      // phrase); fall back to the nearest interval within ~60 chars.
+      // phrase); otherwise snap only to a span the click all but touches.
       let hit: PairInterval | null = null;
       for (const iv of intervals) {
-        const normEnd = iv.normStart + (iv.end - iv.start); // approximate but adequate
-        if (normOffset >= iv.normStart && normOffset <= normEnd) {
-          if (!hit || iv.end - iv.start < hit.end - hit.start) hit = iv;
+        if (normOffset >= iv.normStart && normOffset <= iv.normEnd) {
+          if (!hit || iv.normEnd - iv.normStart < hit.normEnd - hit.normStart) hit = iv;
         }
       }
       if (!hit) {
-        let bestDist = 60;
+        let bestDist = SNAP_TOLERANCE;
         for (const iv of intervals) {
-          const dist = normOffset < iv.normStart
-            ? iv.normStart - normOffset
-            : normOffset - (iv.normStart + (iv.end - iv.start));
+          const dist = normOffset < iv.normStart ? iv.normStart - normOffset : normOffset - iv.normEnd;
           if (dist < bestDist) { bestDist = dist; hit = iv; }
         }
       }
       if (!hit) {
+        // The click landed on text the model never aligned. Say nothing rather
+        // than highlighting a phrase that merely happens to be nearby.
         clearHighlights();
         setSheet(null);
         return;
@@ -298,34 +320,50 @@ export default function TraceAlignment({ bookId, pageId, active, onStatusChange 
       const primaryRange = rangeFromOffsets(clickedMap, hit.start, hit.end);
       setHighlight(HIGHLIGHT_PRIMARY, primaryRange);
 
-      // Locate the counterpart span in the other pane (may be hidden on
-      // mobile-collapsed layouts or missing — then we still show the sheet).
-      let counterRange: Range | null = null;
-      let counterPaneEl: HTMLElement | null = null;
-      if (otherPane) {
+      // Light up the pair in every other pane that is on screen and has a span
+      // for it. The romanized pane only participates when its span resolved.
+      const counterparts: Array<{ side: Side; range: Range; pane: HTMLElement }> = [];
+      for (const otherSide of SIDES) {
+        if (otherSide === side) continue;
+        const otherPane = getPaneEl(otherSide);
+        if (!otherPane || spanFor(pair, otherSide) === undefined) continue;
         const otherMap = buildPaneMap(otherPane);
-        const otherIntervals = locatePairIntervals(otherMap, currentPairs, otherSide);
-        const counter = otherIntervals.find((iv) => iv.pairIndex === hit!.pairIndex);
-        if (counter) {
-          counterRange = rangeFromOffsets(otherMap, counter.start, counter.end);
-          counterPaneEl = otherPane;
-        }
+        const counter = locatePairIntervals(otherMap, currentPairs, otherSide)
+          .find((iv) => iv.pairIndex === hit!.pairIndex);
+        if (!counter) continue;
+        const range = rangeFromOffsets(otherMap, counter.start, counter.end);
+        if (range) counterparts.push({ side: otherSide, range, pane: otherPane });
       }
-      setHighlight(HIGHLIGHT_COUNTERPART, counterRange);
 
-      const counterpartText = side === 'translation' ? pair.s : pair.t;
+      // The sheet (mobile / no-highlight fallback) shows the reader's opposite
+      // text, so a romanized click reads back as the translation.
+      const sheetSide: Side = side === 'translation' ? 'ocr' : 'translation';
+      const scrollTarget = counterparts.find((c) => c.side === sheetSide) ?? counterparts[0];
+
+      setHighlight(HIGHLIGHT_COUNTERPART, scrollTarget?.range ?? null);
+      setHighlight(
+        HIGHLIGHT_COUNTERPART_2,
+        counterparts.find((c) => c !== scrollTarget)?.range ?? null,
+      );
+
       const isDesktop = window.matchMedia('(min-width: 1024px)').matches;
       const doScroll = () => {
-        if (counterRange && counterPaneEl) scrollRangeIntoPane(counterPaneEl, counterRange);
+        if (scrollTarget) scrollRangeIntoPane(scrollTarget.pane, scrollTarget.range);
       };
 
-      if (isDesktop && counterRange && highlightsSupported()) {
+      if (isDesktop && counterparts.length && highlightsSupported()) {
         setSheet(null);
         doScroll();
       } else {
         // Mobile (stacked panes — don't yank the reader away), or no
-        // highlight support: show the counterpart in a bottom sheet.
-        setSheet({ snippet: counterpartText, counterpartSide: otherSide, scrollTo: doScroll });
+        // highlight support: show the counterpart in a bottom sheet. The
+        // snippet is always the sheet's labelled side, never whichever pane
+        // happened to scroll.
+        setSheet({
+          snippet: spanFor(pair, sheetSide) ?? '',
+          counterpartSide: sheetSide,
+          scrollTo: doScroll,
+        });
       }
     };
 
@@ -343,13 +381,14 @@ export default function TraceAlignment({ bookId, pageId, active, onStatusChange 
     <>
       {/* ::highlight() rules live here (not globals.css): Next's CSS processor
           rejects the Custom Highlight API pseudo-element. Gold family from the
-          /blog/word-alignment demo; primary = clicked span, counterpart = the
-          aligned span in the other pane. */}
+          /blog/word-alignment demo; primary = clicked span, counterparts = the
+          aligned span in each other pane. */}
       <style>{`
         ::highlight(${HIGHLIGHT_PRIMARY}) {
           background-color: rgba(160, 120, 40, 0.22);
         }
-        ::highlight(${HIGHLIGHT_COUNTERPART}) {
+        ::highlight(${HIGHLIGHT_COUNTERPART}),
+        ::highlight(${HIGHLIGHT_COUNTERPART_2}) {
           background-color: rgba(160, 120, 40, 0.38);
           text-decoration: underline;
           text-decoration-color: rgba(160, 120, 40, 0.85);

--- a/src/lib/align-text.ts
+++ b/src/lib/align-text.ts
@@ -112,6 +112,14 @@ export interface LocatedSpan {
   end: number;
   /** Where the match begins in the normalized string (for cursor movement). */
   normStart: number;
+  /**
+   * Where the match ends in the normalized string (exclusive). NOT derivable
+   * from `end - start`: folding changes length in both directions (`æ`→`ae`
+   * grows, dehyphenation and diacritic stripping shrink), so a raw length is
+   * not a normalized length. Callers testing "is this normalized offset inside
+   * the span?" must use this.
+   */
+  normEnd: number;
 }
 
 function indexWithFallback(norm: string, needle: string, fromNorm: number): number {
@@ -144,5 +152,5 @@ export function locateSpan(
   if (at === -1) return null;
   const start = hay.rawIdx[at];
   const end = hay.rawIdx[at + needle.length - 1] + 1;
-  return { start, end, normStart: at };
+  return { start, end, normStart: at, normEnd: at + needle.length };
 }

--- a/src/lib/word-alignment.ts
+++ b/src/lib/word-alignment.ts
@@ -44,6 +44,10 @@ export interface AlignmentPair {
   so: number;
   /** Char offset of `t` in the stripped translation. */
   to: number;
+  /** Verbatim span of the stripped TRANSLITERATION, when one was resolved. */
+  r?: string;
+  /** Char offset of `r` in the stripped transliteration. */
+  ro?: number;
 }
 
 export interface WordAlignmentData {
@@ -54,6 +58,12 @@ export interface WordAlignmentData {
   ocr_hash: string;
   /** sha256 of the STRIPPED translation text. */
   translation_hash: string;
+  /**
+   * sha256 of the STRIPPED transliteration the `r` spans were resolved against.
+   * Absent when the page has no transliteration, or when the romanized pass has
+   * not run yet — both are normal states, and trace works without it.
+   */
+  translit_hash?: string;
   pairs: AlignmentPair[];
 }
 
@@ -70,6 +80,7 @@ interface PageLike {
   id: string;
   ocr?: { data?: string };
   translation?: { data?: string };
+  transliteration?: { data?: string };
   word_alignment?: WordAlignmentData;
 }
 
@@ -108,6 +119,103 @@ export function resolveAlignmentPairs(
     });
   }
   return out;
+}
+
+/**
+ * Attach romanized spans to already-resolved pairs.
+ *
+ * Deliberately a SECOND call rather than a third field on the alignment prompt:
+ * measured on 12 pages, folding a `rom` field into the pair prompt dragged mean
+ * source coverage from 74% to 67% and collapsed one page from 97% to 24%. That
+ * prompt is load-bearing and stays byte-identical; the romanized mapping is
+ * additive and may fail without costing trace anything.
+ *
+ * Every returned span is verified against the transliteration with locateSpan
+ * and must advance monotonically (the romanization has the same words in the
+ * same order as the source), so a hallucinated or out-of-order span is dropped
+ * rather than highlighting the wrong words. Exported for unit tests.
+ */
+export function resolveRomanSpans(
+  pairs: AlignmentPair[],
+  rawSpans: Array<{ i?: number; rom?: string }>,
+  translitText: string,
+): AlignmentPair[] {
+  const romNorm = normalizeForSearch(translitText);
+  const byIndex = new Map<number, string>();
+  for (const e of rawSpans) {
+    if (typeof e?.i === 'number' && e.rom) byIndex.set(e.i, e.rom);
+  }
+  let cursor = 0;
+  let lastStart = -1;
+  return pairs.map((pair, i) => {
+    const rom = byIndex.get(i);
+    if (!rom) return pair;
+    const hit = locateSpan(romNorm, rom, cursor);
+    // Monotonicity: source order is romanization order, so each pair's match
+    // must start strictly after the previous one's. Without this, locateSpan's
+    // global fallback lets a mis-quoted span bind to an EARLIER occurrence and
+    // highlight the wrong words. Drop it; the pair stays usable without `r`.
+    if (!hit || hit.start <= lastStart) return pair;
+    cursor = hit.normStart + 1;
+    lastStart = hit.start;
+    return { ...pair, r: translitText.slice(hit.start, hit.end), ro: hit.start };
+  });
+}
+
+async function generateRomanSpans(
+  pairs: AlignmentPair[],
+  translitText: string,
+  language: string,
+): Promise<Array<{ i: number; rom: string }>> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error('No GEMINI_API_KEY configured');
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({
+    model: ALIGNMENT_MODEL,
+    generationConfig: {
+      temperature: 0,
+      responseMimeType: 'application/json',
+      responseSchema: {
+        type: SchemaType.OBJECT,
+        properties: {
+          spans: {
+            type: SchemaType.ARRAY,
+            items: {
+              type: SchemaType.OBJECT,
+              properties: {
+                i: { type: SchemaType.INTEGER },
+                rom: { type: SchemaType.STRING },
+              },
+              required: ['i', 'rom'],
+            },
+          },
+        },
+        required: ['spans'],
+      },
+    },
+  });
+
+  const prompt = `The text below is a page of ${language} transliterated into Latin script. It contains the same words, in the same order, as the ${language} original.
+
+ROMANIZATION:
+<<<
+${translitText}
+>>>
+
+Below are numbered spans of the ${language} original, in reading order. For each, return the span of ROMANIZATION that transliterates it.
+
+${pairs.map((p, i) => `[${i}] ${JSON.stringify(p.s)}`).join('\n')}
+
+Rules:
+- "rom" must be copied EXACTLY, character for character, from ROMANIZATION above — including its diacritics and punctuation. Never transliterate the span yourself; only copy from ROMANIZATION.
+- The spans are in reading order, so their romanized counterparts appear in the same order in ROMANIZATION.
+- If a span's counterpart is not present verbatim in ROMANIZATION, omit that entry entirely rather than guessing.`;
+
+  const result = await model.generateContent(prompt);
+  const parsed = JSON.parse(result.response.text()) as {
+    spans?: Array<{ i: number; rom: string }>;
+  };
+  return Array.isArray(parsed.spans) ? parsed.spans : [];
 }
 
 async function generatePairs(
@@ -175,6 +283,10 @@ Rules:
  * store, and return it. An empty `pairs` array is a valid cached result —
  * "we tried, nothing aligned" — so a hopeless page is only ever paid for once
  * per text revision.
+ *
+ * Romanized spans are a separate, cheaper stage: a page whose alignment is
+ * already cached but which has since gained a transliteration pays only for the
+ * romanized pass, never for a re-alignment.
  */
 export async function getOrCreateWordAlignment(
   db: Db,
@@ -190,20 +302,49 @@ export async function getOrCreateWordAlignment(
   const translationText = stripEditorialWrappers(translationRaw).slice(0, MAX_TEXT_CHARS);
   if (!sourceText.trim() || !translationText.trim()) return { status: 'missing_text' };
 
+  const translitRaw = page.transliteration?.data || '';
+  const translitText = translitRaw.trim()
+    ? stripEditorialWrappers(translitRaw).slice(0, MAX_TEXT_CHARS)
+    : '';
+  const translitHash = translitText.trim() ? hashAlignmentText(translitText) : undefined;
+
   const ocrHash = hashAlignmentText(sourceText);
   const translationHash = hashAlignmentText(translationText);
 
   const stored = page.word_alignment;
-  if (
-    stored &&
+  const baseFresh =
+    !!stored &&
     stored.version === WORD_ALIGNMENT_VERSION &&
     stored.ocr_hash === ocrHash &&
-    stored.translation_hash === translationHash
-  ) {
-    return { status: 'ready', alignment: stored };
+    stored.translation_hash === translationHash;
+  // A page with no transliteration is never "stale" for want of romanized spans.
+  const romFresh = !translitHash || stored?.translit_hash === translitHash;
+
+  if (baseFresh && romFresh) {
+    return { status: 'ready', alignment: stored! };
   }
 
-  if (!opts.allowGenerate || process.env.WORD_ALIGNMENT_ENABLED === '0') {
+  if (process.env.WORD_ALIGNMENT_ENABLED === '0') return { status: 'unavailable' };
+
+  // Base alignment is good; only the romanized spans are missing. Pay for the
+  // cheap pass alone, and serve the base pairs if even that fails.
+  if (baseFresh && !romFresh && translitText) {
+    if (!opts.allowGenerate) return { status: 'unavailable' };
+    try {
+      const rawSpans = await generateRomanSpans(stored!.pairs, translitText, language);
+      const pairs = resolveRomanSpans(stored!.pairs, rawSpans, translitText);
+      const alignment: WordAlignmentData = { ...stored!, pairs, translit_hash: translitHash };
+      await db.collection('pages').updateOne(
+        { id: page.id },
+        { $set: { 'word_alignment.pairs': pairs, 'word_alignment.translit_hash': translitHash } },
+      );
+      return { status: 'ready', alignment };
+    } catch {
+      return { status: 'ready', alignment: stored! };
+    }
+  }
+
+  if (!opts.allowGenerate) {
     return { status: 'unavailable' };
   }
 
@@ -227,16 +368,29 @@ export async function getOrCreateWordAlignment(
     return { status: 'unavailable' };
   }
 
-  const pairs = resolveAlignmentPairs(rawPairs, sourceText, translationText);
+  let pairs = resolveAlignmentPairs(rawPairs, sourceText, translationText);
   // One line per page EVER (results are cached) — kept as a resolution-rate
   // canary: a big raw→resolved drop means the model is misquoting spans.
   console.log(`word-alignment: page ${page.id} raw=${rawPairs.length} resolved=${pairs.length}`);
+
+  // Romanized spans: best-effort. A failure here must not lose the pairs above.
+  let romHash: string | undefined;
+  if (translitText && pairs.length) {
+    try {
+      pairs = resolveRomanSpans(pairs, await generateRomanSpans(pairs, translitText, language), translitText);
+      romHash = translitHash;
+    } catch (e) {
+      console.log(`word-alignment: page ${page.id} romanized pass failed: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+
   const alignment: WordAlignmentData = {
     version: WORD_ALIGNMENT_VERSION,
     model: ALIGNMENT_MODEL,
     created_at: new Date(),
     ocr_hash: ocrHash,
     translation_hash: translationHash,
+    ...(romHash ? { translit_hash: romHash } : {}),
     pairs,
   };
 

--- a/tests/unit/word-alignment-resolve.test.ts
+++ b/tests/unit/word-alignment-resolve.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { normalizeForSearch, normalizeNeedle, locateSpan } from '@/lib/align-text';
-import { resolveAlignmentPairs } from '@/lib/word-alignment';
+import { resolveAlignmentPairs, resolveRomanSpans, type AlignmentPair } from '@/lib/word-alignment';
 
 // Trace mode (#3091) stores span strings + offsets resolved against the
 // wrapper-stripped page text. Every stored pair must be locatable text —
@@ -76,6 +76,35 @@ describe('locateSpan', () => {
     const hit = locateSpan(h, 'militatem aduerfus Corpus');
     expect(hit).not.toBeNull();
   });
+
+  // The reader's trace layer asks "is this normalized click offset inside the
+  // span?" It must use normEnd. A raw length is not a normalized length: folds
+  // grow (æ→ae) and shrink (dehyphenation, diacritic stripping) the string.
+  describe('normEnd is a normalized offset, not a raw length', () => {
+    it('reports normEnd larger than the raw span when folding expands', () => {
+      const h = normalizeForSearch('cœleſti Animæ gaudium');
+      const hit = locateSpan(h, 'Animæ')!;
+      expect(h.norm.slice(hit.normStart, hit.normEnd)).toBe('animae');
+      // raw 'Animæ' is 5 chars; normalized 'animae' is 6.
+      expect(hit.end - hit.start).toBe(5);
+      expect(hit.normEnd - hit.normStart).toBe(6);
+    });
+
+    it('reports normEnd smaller than the raw span when dehyphenation shrinks', () => {
+      const h = normalizeForSearch('reſurrectio-\nnem atque');
+      const hit = locateSpan(h, 'reſurrectionem')!;
+      expect(h.norm.slice(hit.normStart, hit.normEnd)).toBe('resurrectionem');
+      expect(hit.normEnd - hit.normStart).toBe(14);
+      // The raw slice still spans the hyphen and the newline.
+      expect(hit.end - hit.start).toBe(16);
+    });
+
+    it('always delimits the matched text in the normalized string', () => {
+      const h = normalizeForSearch('MENTI laeticiam &\ngaudium attribuit');
+      const hit = locateSpan(h, 'laeticiam & gaudium')!;
+      expect(h.norm.slice(hit.normStart, hit.normEnd)).toBe('laeticiam & gaudium');
+    });
+  });
 });
 
 describe('normalizeNeedle', () => {
@@ -147,5 +176,58 @@ describe('resolveAlignmentPairs', () => {
     // Stored span is the RAW slice from the text, not the model's string.
     expect(pairs[0].s).toBe('menti laeticiam & gaudium');
     expect(pairs[0].t).toBe('gladness and joy');
+  });
+});
+
+// The romanized pane joins trace via a second, additive pass: source spans in,
+// verified spans of the transliteration out. A pair that fails verification
+// keeps working for OCR↔translation and simply gains no romanized highlight.
+describe('resolveRomanSpans', () => {
+  // Greek source, its romanization, and pairs as the aligner would store them.
+  const translit = 'ta men homos polees te kai allydis alloi iontes ouranoi helkontai';
+  const pairs: AlignmentPair[] = [
+    { s: 'τὰ μὲν ὁμῶς', t: 'these alike', so: 0, to: 0 },
+    { s: 'πολέες τε', t: 'many and', so: 12, to: 12 },
+    { s: 'οὐρανῷ ἕλκονται', t: 'are drawn through heaven', so: 30, to: 30 },
+  ];
+
+  it('attaches verified spans and leaves the base pair intact', () => {
+    const out = resolveRomanSpans(pairs, [
+      { i: 0, rom: 'ta men homos' },
+      { i: 2, rom: 'ouranoi helkontai' },
+    ], translit);
+    expect(out[0].r).toBe('ta men homos');
+    expect(translit.slice(out[0].ro!, out[0].ro! + out[0].r!.length)).toBe(out[0].r);
+    expect(out[1].r).toBeUndefined();          // no span offered → untouched
+    expect(out[2].r).toBe('ouranoi helkontai');
+    // Base fields survive untouched.
+    expect(out.map((p) => p.s)).toEqual(pairs.map((p) => p.s));
+    expect(out.map((p) => p.t)).toEqual(pairs.map((p) => p.t));
+  });
+
+  it('drops a hallucinated span rather than highlighting the wrong words', () => {
+    const out = resolveRomanSpans(pairs, [{ i: 1, rom: 'this text is nowhere on the page' }], translit);
+    expect(out[1].r).toBeUndefined();
+  });
+
+  it('drops a span that runs backwards through the romanization', () => {
+    // The romanization has the same words in the same order as the source, so a
+    // later pair whose span sits EARLIER in the text is a mis-quote. locateSpan
+    // would happily find it via its global fallback; the guard must not.
+    const out = resolveRomanSpans(pairs, [
+      { i: 1, rom: 'ouranoi helkontai' },  // pair 1 grabs pair 2's words (offset 48)
+      { i: 2, rom: 'ta men' },             // pair 2 then resolves back at offset 0
+    ], translit);
+    expect(out[1].r).toBe('ouranoi helkontai');
+    expect(out[2].r).toBeUndefined();
+  });
+
+  it('ignores entries whose index is out of range or empty', () => {
+    const out = resolveRomanSpans(pairs, [{ i: 99, rom: 'ta men' }, { i: 0, rom: '' }], translit);
+    expect(out.every((p) => p.r === undefined)).toBe(true);
+  });
+
+  it('is a no-op when the model returns nothing', () => {
+    expect(resolveRomanSpans(pairs, [], translit)).toEqual(pairs);
   });
 });


### PR DESCRIPTION
Trace now works across all three reader panes. Clicking a phrase in the translation, the original, or the romanized text highlights the aligned span in the other two.

Try it on the Armenian Buzand (romanized this morning): https://sourcelibrary.org/book/69a5ead1d507939f0352ced7/page/69a5ead1d507939f0352cef2 — open **Romanized**, turn on **Trace**, click an English phrase.

## How the romanized spans are produced

A **second, additive Gemini call**: it takes the already-resolved source spans and asks only for their counterparts in the transliteration.

I first tried the obvious thing — a third text block and a `rom` field on the existing pair prompt. Measured on 12 pages it **degraded the pairs it was supposed to extend**: mean source coverage 74% → 67%, and one page collapsed from 97% to 24%. That prompt is load-bearing, so it stays byte-identical. The separate call resolves a romanized span for **94% of pairs** (131/139 over 9 pages), 100% of them monotone.

A page that already has a cached alignment but later gains a transliteration pays only for the cheap pass, never a re-alignment. Verified end-to-end against prod data: source↔translation pairs come back byte-identical, 22/22 romanized spans reattach, cache hit is 1ms.

Every romanized span is verified with `locateSpan` against the transliteration and must start strictly after the previous pair's — otherwise `locateSpan`'s global fallback would let a mis-quoted span bind to an earlier occurrence and highlight the wrong words. Unresolved spans are simply absent; the pair still traces OCR↔translation.

## Two defects found while spot-checking trace quality

**`normEnd`.** `locateSpan` returned only raw offsets, and the click handler derived a *normalized* span end from a *raw* length (`iv.normStart + (iv.end - iv.start)`, commented "approximate but adequate"). Folding changes length in both directions — `æ`→`ae` grows, dehyphenation and diacritic stripping shrink — so the containment test was systematically wrong on exactly the early-modern pages trace was built for. `locateSpan` now returns `normEnd`; three tests pin it.

**The 60-char snap.** On a click outside every span, the handler snapped to the nearest span within 60 normalized chars — about ten words. The aligner leaves roughly a third of a page uncovered (mean source coverage **67%** across 14 pages spanning Latin, Greek, Armenian), so clicking unaligned text confidently highlighted an unrelated phrase. That is the "trace doesn't always work well" symptom. Tolerance is now 12 chars — enough to absorb a click on trailing punctuation — and beyond that trace says nothing rather than guessing.

## What I measured but did not ship

- **Prompt rewrite for coverage.** A coverage-oriented rewrite of the pair prompt was *worse* on average (61% vs 67%) and higher-variance. Not shipped.
- **Second pass over uncovered regions.** Re-asking the model to align only the gaps lifts mean source coverage 67% → 74% for one extra cached call on low-coverage pages. Real but modest, and it doubles first-open latency on those pages. Left out of this PR — worth its own issue, with the caveat that dense scholia pages stay low because the translation genuinely does not render every clause.
- The unresolved 16% of raw pairs are mostly the model quoting a famous line **from memory** rather than from the page (an Aratus verse that isn't in the scholion), or paraphrasing the translation. The resolver already drops these, which is correct behavior — it is coverage loss, not a misquote risk.

## Out of scope

- The romanized pane does not auto-open when trace turns on; opening a third pane unbidden felt intrusive. Trace still forces the OCR pane open, as before.
- No change to alignment cache versioning: `translit_hash` gates only the romanized spans, so existing cached alignments stay valid and are never regenerated.

## Verification

- `npx tsc --noEmit` clean; 510 unit tests pass, including 8 new ones (`normEnd` in both fold directions, romanized span verification, hallucination and backwards-binding rejection).
- End-to-end run of `getOrCreateWordAlignment` against prod data on Buzand p27: 22/22 romanized spans, all verbatim at their stored offsets, zero out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)