### PR TITLE
feat(home): pointer cursor on account avatar + "Recently looked at" slider

### DIFF
--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -237,7 +237,7 @@ export default function EmbedUserMenu() {
       )}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-center w-9 h-9 rounded-full bg-white/90 backdrop-blur-sm border border-border-light shadow-sm hover:bg-white transition-colors"
+        className="flex items-center justify-center w-9 h-9 rounded-full bg-white/90 backdrop-blur-sm border border-border-light shadow-sm cursor-pointer hover:bg-white transition-colors"
         aria-label={session ? 'Account & view options' : 'View options'}
       >
         {session ? (

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -6,6 +6,7 @@ import HomePageSchema from '@/components/seo/HomePageSchema';
 import EditorialSpread from '@/components/prototype/EditorialSpread';
 import FromTheCollection from '@/components/prototype/FromTheCollection';
 import CollectionBookCard, { type CollectionBook } from '@/components/CollectionBookCard';
+import RecentlyRead from '@/components/home/RecentlyRead';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { type HomeData } from '@/lib/home-data';
 import { HOME_STRINGS, type HomeLang, collectionName } from '@/lib/home-i18n';
@@ -197,6 +198,11 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
           </div>
         </div>
       </section>
+
+      {/* Recently looked at — personalized slider from the signed-in reader's
+          history, tucked right under the collections grid. Self-hides for
+          anonymous visitors and readers with no history. */}
+      <RecentlyRead />
 
       {/* Ask the source — the librarian's front door. Placed after the
           collections grid so the invitation lands once the visitor has seen

--- a/src/components/home/RecentlyRead.tsx
+++ b/src/components/home/RecentlyRead.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useRef, useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { ChevronLeft, ChevronRight, Clock, ArrowRight, BookOpen } from 'lucide-react';
+import { useStableSession } from '@/hooks/useStableSession';
+import { readingHistory, type ReadingHistoryEntry } from '@/lib/api-client';
+import { bookUrl } from '@/lib/slugify';
+import { getBookThumbnailUrl } from '@/lib/utils';
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+}
+
+/**
+ * "Recently looked at" — a personalized horizontal slider drawn from the
+ * signed-in reader's reading history, shown just under the collections grid on
+ * the homepage. Each card links straight back to the last page they read so
+ * they can pick up where they left off.
+ *
+ * Renders nothing for anonymous users or when there's no history yet, so the
+ * homepage is unchanged for logged-out visitors. Slider mechanics mirror the
+ * collection-page first-translations slider (arrows step one card, scroll-snap
+ * on mobile).
+ */
+export default function RecentlyRead() {
+  const { data: session, status } = useStableSession();
+  const [entries, setEntries] = useState<ReadingHistoryEntry[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (status !== 'authenticated') return;
+    let cancelled = false;
+    readingHistory
+      .list({ limit: 15 })
+      .then((res) => {
+        if (!cancelled) setEntries(res.entries);
+      })
+      .catch(() => { /* silent — the widget just stays hidden */ })
+      .finally(() => { if (!cancelled) setLoaded(true); });
+    return () => { cancelled = true; };
+  }, [status]);
+
+  // Hidden entirely for anonymous users and until we have something to show.
+  if (!session || !loaded || entries.length === 0) return null;
+
+  return <RecentlyReadSlider entries={entries} />;
+}
+
+/**
+ * Presentational slider — pure function of `entries`. Split out from the
+ * data/auth wrapper so it can be rendered in isolation (and previewed with
+ * sample data) without a live session.
+ */
+export function RecentlyReadSlider({ entries }: { entries: ReadingHistoryEntry[] }) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [atStart, setAtStart] = useState(true);
+  const [atEnd, setAtEnd] = useState(false);
+
+  const updateArrows = useCallback(() => {
+    const track = trackRef.current;
+    if (!track) return;
+    setAtStart(track.scrollLeft <= 1);
+    setAtEnd(track.scrollLeft + track.clientWidth >= track.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    if (entries.length) updateArrows();
+  }, [entries, updateArrows]);
+
+  const step = useCallback((dir: -1 | 1) => {
+    const track = trackRef.current;
+    if (!track) return;
+    const card = track.querySelector<HTMLElement>('[data-card]');
+    const gap = parseFloat(getComputedStyle(track).columnGap || '16') || 16;
+    const delta = ((card?.offsetWidth || 160) + gap) * dir;
+    track.scrollBy({ left: delta, behavior: 'smooth' });
+  }, []);
+
+  return (
+    <section className="bg-[#f3ede6] pb-16 md:pb-24 -mt-4">
+      <div className="px-6 md:px-12 max-w-[1500px] mx-auto">
+        <div className="flex items-baseline justify-between mb-6">
+          <div>
+            <h2 className="text-2xl md:text-3xl text-primary font-display">Recently looked at</h2>
+            <p className="text-muted mt-1 text-sm">Pick up where you left off.</p>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="hidden sm:flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => step(-1)}
+                disabled={atStart}
+                aria-label="Previous"
+                className="w-9 h-9 inline-flex items-center justify-center rounded-full border border-border-medium bg-white text-primary shadow-sm cursor-pointer hover:border-accent-rust hover:text-accent-rust disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => step(1)}
+                disabled={atEnd}
+                aria-label="Next"
+                className="w-9 h-9 inline-flex items-center justify-center rounded-full border border-border-medium bg-white text-primary shadow-sm cursor-pointer hover:border-accent-rust hover:text-accent-rust disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+            <Link
+              href="/reading-history"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-accent-rust hover:text-accent-rust/80 transition-colors"
+            >
+              See all
+              <ArrowRight className="w-3.5 h-3.5" />
+            </Link>
+          </div>
+        </div>
+
+        <div
+          ref={trackRef}
+          onScroll={updateArrows}
+          className="flex gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden -mx-1 px-1"
+        >
+          {entries.map((entry, i) => (
+            <RecentCard key={`${entry.book_id}-${entry.started_at}-${i}`} entry={entry} priority={i < 6} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function RecentCard({ entry, priority }: { entry: ReadingHistoryEntry; priority: boolean }) {
+  const [imageError, setImageError] = useState(false);
+  const book = entry.book;
+  const title = book.display_title || book.title;
+  const url = bookUrl({ slug: book.slug, id: book.id });
+  const pageUrl = `${url}/page/${entry.last_page_id}`;
+  const thumb = getBookThumbnailUrl(book, 'thumb');
+  const progress = book.pages_count
+    ? Math.min(100, Math.round((entry.last_page_number / book.pages_count) * 100))
+    : 0;
+
+  return (
+    <Link
+      href={pageUrl}
+      data-card
+      className="group snap-start shrink-0 basis-[42%] sm:basis-[calc((100%-3rem)/4)] lg:basis-[calc((100%-5rem)/6)] flex flex-col border border-border-light bg-white hover:border-accent-rust/40 hover:shadow-md transition-[border-color,box-shadow]"
+    >
+      {/* Cover */}
+      <div className="relative aspect-[3/4] bg-warm overflow-hidden">
+        {thumb && !imageError ? (
+          <Image
+            src={thumb}
+            alt={title}
+            fill
+            className="object-cover group-hover:scale-105 transition-transform duration-300"
+            sizes="(max-width: 640px) 42vw, (max-width: 1024px) 25vw, 16vw"
+            onError={() => setImageError(true)}
+            loading={priority ? 'eager' : 'lazy'}
+            unoptimized
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-border-medium">
+            <BookOpen className="w-6 h-6" />
+          </div>
+        )}
+        {/* Progress bar pinned to the bottom of the cover */}
+        {book.pages_count ? (
+          <div className="absolute bottom-0 left-0 right-0 h-1 bg-black/20">
+            <div className="h-full bg-accent-gold" style={{ width: `${progress}%` }} />
+          </div>
+        ) : null}
+      </div>
+
+      {/* Info */}
+      <div className="flex flex-col flex-1 p-3">
+        <h3 className="text-sm font-semibold text-primary group-hover:text-accent-rust transition-colors line-clamp-2 leading-snug" style={{ fontFamily: 'var(--font-body)' }}>
+          {title}
+        </h3>
+        {book.author && <p className="text-xs text-muted mt-0.5 line-clamp-1">{book.author}</p>}
+        <div className="flex items-center justify-between gap-2 mt-auto pt-3 text-[11px] text-faint">
+          <span className="inline-flex items-center gap-1">
+            <Clock className="w-3 h-3" />
+            {timeAgo(entry.updated_at)}
+          </span>
+          {book.pages_count ? <span>p. {entry.last_page_number}</span> : null}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -69,7 +69,8 @@ export default function UserMenu({ variant = 'default' }: UserMenuProps) {
     <div ref={menuRef} className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 focus:outline-none"
+        aria-label="Account menu"
+        className="flex items-center gap-2 cursor-pointer focus:outline-none"
       >
         {session.user?.image && !imgError ? (
           // eslint-disable-next-line @next/next/no-img-element


### PR DESCRIPTION
## What

Two small account / reading-history improvements.

### 1. Pointer cursor on the account avatar
Tailwind's preflight resets `<button>` to the default arrow cursor, so the signed-in avatar (initials or photo) didn't visually read as clickable. Added `cursor-pointer` to the `UserMenu` avatar button (and the `EmbedUserMenu` button on tenant subdomains for consistency), plus an `aria-label` on the main avatar button.

### 2. "Recently looked at" slider on the homepage
A personalized horizontal slider, tucked **right under the collections grid**, for signed-in readers:

- Draws the 15 most-recent entries from the reader's `reading_history` (`GET /api/reading-history`).
- Each card links back to the **last page read** (`/book/<slug>/page/<pageId>`) so you can pick up where you left off.
- Shows a gold progress bar (last page / page count), title (2-line clamp), author, time-ago, and page number.
- A **See all →** link goes to the full `/reading-history` page.
- **Self-hides entirely** for anonymous visitors and readers with no history — the logged-out homepage is byte-for-byte unchanged.

Slider mechanics (arrow stepping, mobile scroll-snap, hidden scrollbar) mirror the existing collection-page first-translations slider (`MycoSlider`). The component is split into a data/auth wrapper (`RecentlyRead`) and a pure presentational `RecentlyReadSlider(entries)` so it can be rendered/tested without a live session.

## Out of scope
No new reading-history API or data changes — this reads the existing endpoint and reuses `bookUrl` / `getBookThumbnailUrl` exactly as the `/reading-history` page does.

## Verification
- `npx tsc --noEmit` clean; ESLint clean on the changed files (two pre-existing lint errors in `UserMenu`/`EmbedUserMenu` are on untouched lines).
- Anonymous homepage: HTTP 200, collections intact, slider correctly absent, no new console errors.
- Slider rendered with sample data on a throwaway preview route (since local dev has no auth): heading, arrows (dim at ends, step one card), progress bars, title clamp, and placeholder-cover fallback all verified, then the preview route was removed.
- **Not yet verified live while signed in** (local dev has no auth secret) — best checked on this branch's Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)