### PR TITLE
feat(cta): default the Join-the-project section background to the Flamsteed plate

### DIFF
--- a/src/components/auth/SignUpCTA.tsx
+++ b/src/components/auth/SignUpCTA.tsx
@@ -13,7 +13,20 @@ interface SignUpCTAProps {
   bgAttribution?: { text: string; href: string };
 }
 
-export default function SignUpCTA({ variant = 'section', bgImageUrl, bgAttribution }: SignUpCTAProps) {
+// Default background for the shared "Join the project" section: the Flamsteed
+// celestial allegory. Any page that passes its own bgImageUrl (e.g. a collection
+// with a themed plate, like mycology) overrides it.
+const DEFAULT_BG_IMAGE_URL = '/api/gallery-crop/6955d43628a09ca65928002a-0';
+const DEFAULT_BG_ATTRIBUTION = {
+  text: 'Image: Flamsteed, Historia Coelestis Britannica, Vol. 3, 1725.',
+  href: '/gallery/image/6955d43628a09ca65928002a-0',
+};
+
+export default function SignUpCTA({
+  variant = 'section',
+  bgImageUrl = DEFAULT_BG_IMAGE_URL,
+  bgAttribution = DEFAULT_BG_ATTRIBUTION,
+}: SignUpCTAProps) {
   const { status } = useStableSession();
   const isEmbedded = useIsEmbedded();
 


### PR DESCRIPTION
## What
Make the Flamsteed celestial allegory (`/api/gallery-crop/6955d43628a09ca65928002a-0`) the **default** background for the shared `SignUpCTA` "Join the project" section.

`SignUpCTA` already supported `bgImageUrl`/`bgAttribution`, but only the mycology collection page passed them. This defaults both, so every bare `<SignUpCTA />` inherits the plate:
- gallery, curated, sacred-texts, generic `collections/[id]`, encyclopedia, and book pages

## Override behavior (unchanged)
- **mycology** passes its own `bgImageUrl` (the same Flamsteed plate) → still overrides, visually identical.
- **inline** variant (homepage footer CTA) renders no background → unaffected.
- book pages only render it when `!isEmbedded` → no change on tenant subdomains.

## Safety
- Image URL and attribution `href` are **relative** (`/api/gallery-crop/...`, `/gallery/image/...`) — respects the tenant-subdomain no-absolute-URL invariant.

## Verified
Ran locally against prod DB — the gallery "Join the project" section renders the engraving with the correct copy and "Image: Flamsteed, Historia Coelestis Britannica, Vol. 3, 1725." credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)