### PR TITLE
fix(quotes): strip <image-desc> AI plate descriptions from quotable text

### DIFF
--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -31,9 +31,15 @@
  */
 
 // Translation-side page-description blocks ∪ OCR-side page-level metadata
-// envelope. All *describe* the page; none are verbatim source text.
+// envelope ∪ AI image descriptions. All *describe* the page; none are verbatim
+// source text. `image-desc` is an AI-written account of a plate/diagram (e.g.
+// "a complex nine-pointed star (enneagram)…" on Morestel p.39) — quoting it
+// fabricates a citation to words that aren't in the source. The reader keeps
+// these as captions via NotesRenderer's own <image-desc> handling; only the
+// quote/search/text/IIIF surfaces route through here, so stripping it here does
+// not touch the reader.
 const EDITORIAL_WRAPPERS =
-  'meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning';
+  'meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning|image-desc';
 
 /**
  * Flatten GFM markdown tables to plain text.

--- a/tests/unit/strip-editorial-wrappers.test.ts
+++ b/tests/unit/strip-editorial-wrappers.test.ts
@@ -61,6 +61,18 @@ describe('stripEditorialWrappers', () => {
     expect(out).toContain('<insert>OLIN BM 175</insert>');
   });
 
+  it('drops an <image-desc> AI plate description content-and-all', () => {
+    // Real leak: get_quote on Morestel 1621 p.39 served this AI description of a
+    // woodcut as quotable translation text. The word "enneagram" is the model's,
+    // not the author's — quoting it fabricates a citation. Strip content and tag.
+    const t = `The third section encompasses the relative predicates, the sign of which is T.\n\n<image-desc>A circular diagram... a complex nine-pointed star (enneagram) is formed by lines connecting each of the nine points.</image-desc>`;
+    const out = stripEditorialWrappers(t);
+    expect(out).not.toMatch(/enneagram/i);
+    expect(out).not.toMatch(/nine-pointed/i);
+    expect(out).not.toContain('<image-desc>');
+    expect(out).toContain('relative predicates'); // real translated body survives
+  });
+
   it('strips inline <language> switch markers without eating the body', () => {
     const t = `Lorem ipsum <language>Latin</language> dolor sit amet`;
     const out = stripEditorialWrappers(t).replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
## What

`get_quote` and the other snippet surfaces were serving the AI-written `<image-desc>` block — a description of a plate/diagram, not source text — as verbatim quotable text.

Found it live: `get_quote` on Morestel's *Academy of the Kabbalistic Art* (1621), p.39, returned *"a complex nine-pointed star (enneagram) is formed by lines connecting each of the nine points"* as translation text. The word "enneagram" is the model's description of a woodcut; Morestel never wrote it. Quoting it produces a fabricated citation with a real-looking shortlink — the exact failure mode of the #2232 page-89 misquote.

Root cause: `image-desc` was simply missing from `EDITORIAL_WRAPPERS` in `strip-editorial-wrappers.ts`. A bounded DB sample hit its 200-page cap across 14 distinct books, so it's not a one-off.

## Scope

- **In scope:** add `image-desc` to the wrapper list (strips content-and-tag) + a regression test using the real leaked string.
- **Deliberately out of scope:** the stored artifacts. Like the #2232 leak, `<image-desc>` text is baked into `page_translations`/embeddings written by the old cleaner; this read-time strip fixes every live surface but a snippet-column backfill (`backfill-clean-snippets.mjs`) is a separate, unpaid follow-up if we want the semantic-search column re-derived.

## Why the reader is unaffected

`stripEditorialWrappers` is the quote/search/text/IIIF + SEO-JSON-LD path only. The reader renders `<image-desc>` as a caption through `NotesRenderer.tsx`'s own handling (`showNotes`), which this change does not touch. Verified both reader imports of the helper are for structured-data metadata, not the body render.

## Test

`tests/unit/strip-editorial-wrappers.test.ts` — 38 pass, including the new `image-desc` case asserting "enneagram"/"nine-pointed" are gone while the real translated body survives. `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)