### PR TITLE
feat(admin): record rate-limit denials + surface bot/abuse activity

### DIFF
--- a/src/app/admin/AdminNav.tsx
+++ b/src/app/admin/AdminNav.tsx
@@ -34,6 +34,7 @@ const adminLinks: NavItem[] = [
   { href: '/admin/members', label: 'Members' },
   { href: '/admin/api-keys', label: 'API Keys' },
   { href: '/analytics', label: 'Analytics' },
+  { href: '/admin/bots', label: 'Bots' },
   { href: '/admin/errors', label: 'Errors' },
   { href: '/admin/system-map', label: 'System Map' },
 ];

--- a/src/app/admin/bots/page.tsx
+++ b/src/app/admin/bots/page.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { RefreshCw, Bot, ShieldBan, Gauge, Users } from 'lucide-react';
+import { BookLoader } from '@/components/ui/BookLoader';
+
+interface ByBot {
+  bot: string;
+  hits: number;
+  unique_ips: number;
+  paths: string[];
+  last_seen: string;
+}
+interface Counted { _id: string; hits: number; bots?: string[] }
+interface BotStats {
+  period: { since: string; days: number };
+  total_hits: number;
+  total_unique_ips: number;
+  by_bot: ByBot[];
+  by_day: Counted[];
+  by_path: Counted[];
+  by_action: Counted[];
+}
+
+const ACTION_LABEL: Record<string, string> = {
+  blocked: 'Hard-blocked (proxy 403)',
+  'rate-limited': 'Rate-limited (429)',
+  'api-bot': 'Bot request (allowed / gated)',
+  request: 'Request',
+};
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+export default function AdminBotsPage() {
+  const [data, setData] = useState<BotStats | null>(null);
+  const [days, setDays] = useState(7);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/analytics/bots?days=${days}`);
+      if (res.ok) setData(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const action = (k: string) => data?.by_action.find(a => a._id === k)?.hits ?? 0;
+  const maxBotHits = Math.max(1, ...(data?.by_bot ?? []).map(b => b.hits));
+
+  return (
+    <div style={{ maxWidth: 1000, margin: '0 auto', padding: '24px 20px', color: '#c9d1d9' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <Bot className="w-5 h-5" />
+          <h1 style={{ fontSize: 20, fontWeight: 600, color: '#f0f6fc', margin: 0 }}>Bots &amp; Abuse</h1>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {[1, 7, 30].map(d => (
+            <button
+              key={d}
+              onClick={() => setDays(d)}
+              style={{
+                padding: '4px 12px', borderRadius: 6, fontSize: 13, cursor: 'pointer',
+                border: '1px solid #30363d',
+                background: days === d ? '#1f6feb' : 'transparent',
+                color: days === d ? '#fff' : '#8b949e',
+              }}
+            >{d}d</button>
+          ))}
+          <button onClick={load} style={{ padding: 6, borderRadius: 6, border: '1px solid #30363d', background: 'transparent', color: '#8b949e', cursor: 'pointer' }}>
+            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+      </div>
+
+      {loading && !data ? (
+        <BookLoader />
+      ) : !data ? (
+        <p style={{ color: '#8b949e' }}>No data.</p>
+      ) : (
+        <>
+          {/* Summary cards */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12, marginBottom: 24 }}>
+            <Card icon={<Bot className="w-4 h-4" />} label="Bot hits" value={fmt(data.total_hits)} />
+            <Card icon={<Users className="w-4 h-4" />} label="Unique IPs" value={fmt(data.total_unique_ips)} />
+            <Card icon={<ShieldBan className="w-4 h-4" />} label="Hard-blocked" value={fmt(action('blocked'))} tone="#f85149" />
+            <Card icon={<Gauge className="w-4 h-4" />} label="Rate-limited" value={fmt(action('rate-limited'))} tone="#d29922" />
+          </div>
+
+          {/* By action */}
+          <Section title="By outcome">
+            {data.by_action.map(a => (
+              <Row key={a._id} label={ACTION_LABEL[a._id] || a._id} value={fmt(a.hits)} />
+            ))}
+          </Section>
+
+          {/* By bot */}
+          <Section title={`Top bots (${data.period.days}d, since ${data.period.since})`}>
+            {data.by_bot.slice(0, 20).map(b => (
+              <div key={b.bot} style={{ marginBottom: 8 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 3 }}>
+                  <span style={{ color: b.bot === 'ratelimit' ? '#d29922' : '#c9d1d9' }}>{b.bot}</span>
+                  <span style={{ color: '#8b949e' }}>{fmt(b.hits)} hits · {fmt(b.unique_ips)} IPs</span>
+                </div>
+                <div style={{ height: 4, background: '#161b22', borderRadius: 2 }}>
+                  <div style={{ height: 4, width: `${(b.hits / maxBotHits) * 100}%`, background: b.bot === 'ratelimit' ? '#d29922' : '#1f6feb', borderRadius: 2 }} />
+                </div>
+              </div>
+            ))}
+          </Section>
+
+          {/* By path */}
+          <Section title="Top targets">
+            {data.by_path.slice(0, 15).map(p => (
+              <Row key={p._id} label={p._id || '(root)'} value={fmt(p.hits)} />
+            ))}
+          </Section>
+
+          {/* By day */}
+          <Section title="By day">
+            {data.by_day.map(d => (
+              <Row key={d._id} label={d._id} value={fmt(d.hits)} sub={`${d.bots?.length ?? 0} bot types`} />
+            ))}
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Card({ icon, label, value, tone }: { icon: React.ReactNode; label: string; value: string; tone?: string }) {
+  return (
+    <div style={{ background: '#0d1117', border: '1px solid #30363d', borderRadius: 8, padding: '12px 14px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#8b949e', fontSize: 12, marginBottom: 6 }}>
+        {icon}{label}
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 700, color: tone || '#f0f6fc' }}>{value}</div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ background: '#0d1117', border: '1px solid #30363d', borderRadius: 8, padding: 16, marginBottom: 16 }}>
+      <h2 style={{ fontSize: 13, fontWeight: 600, color: '#8b949e', textTransform: 'uppercase', letterSpacing: '0.04em', margin: '0 0 12px' }}>{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+function Row({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', padding: '5px 0', borderBottom: '1px solid #161b22', fontSize: 13 }}>
+      <span style={{ color: '#c9d1d9', wordBreak: 'break-all' }}>{label}</span>
+      <span style={{ color: '#8b949e', whiteSpace: 'nowrap', marginLeft: 12 }}>{value}{sub ? ` · ${sub}` : ''}</span>
+    </div>
+  );
+}

--- a/src/lib/abuse-log.ts
+++ b/src/lib/abuse-log.ts
@@ -1,0 +1,70 @@
+/**
+ * Durable, fire-and-forget recording of rate-limit denials.
+ *
+ * The proxy layer already logs bot blocks to `analytics_bot_access` (via
+ * POST /api/analytics/bots), and that collection is what the admin bot view
+ * reads. But denials from `src/lib/rate-limit.ts` — the magic-link send, the
+ * Librarian/voice caps, and the donate/subscribe email limiters added in
+ * #3123 — were dropped on the floor: a 429 went out and the event evaporated.
+ *
+ * This writes those denials into the SAME `analytics_bot_access` collection so
+ * they surface in the existing GET /api/analytics/bots aggregation with no
+ * endpoint change. We store them under a synthetic bot name `ratelimit`, keyed
+ * by limiter name in `path_prefix` (e.g. `limiter:donate`), with the action
+ * `rate-limited` — matching the shape the proxy's own logger uses.
+ *
+ * Contract: never throws, never blocks the caller, bounded latency. IPs are
+ * truncated (not personal data under GDPR) via anonymizeIp, consistent with
+ * the rest of that collection.
+ */
+import { anonymizeIp } from '@/lib/anonymize-ip';
+
+const COLLECTION = 'analytics_bot_access';
+const DB_TIMEOUT_MS = 1500;
+
+let indexEnsured = false;
+
+async function write(limiterName: string, ip: string): Promise<void> {
+  const { getDb } = await import('@/lib/mongodb');
+  const db = await getDb();
+  const col = db.collection(COLLECTION);
+
+  if (!indexEnsured) {
+    // Same index the POST /api/analytics/bots writer ensures — idempotent.
+    col.createIndex(
+      { bot: 1, path_prefix: 1, date: 1 },
+      { name: 'bot_daily_idx', background: true },
+    ).catch(() => {});
+    indexEnsured = true;
+  }
+
+  const anonIp = anonymizeIp(ip);
+  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+  await col.updateOne(
+    { bot: 'ratelimit', path_prefix: `limiter:${limiterName}`, date },
+    {
+      $inc: { hits: 1 },
+      $set: { last_ip: anonIp },
+      $addToSet: { actions: 'rate-limited', ips: anonIp },
+      $setOnInsert: { created_at: new Date() },
+    },
+    { upsert: true },
+  );
+}
+
+/**
+ * Record a single rate-limit denial. Fire-and-forget: returns immediately, the
+ * write happens in the background, and any failure (including a slow Mongo) is
+ * swallowed so it can never affect the request that was being limited.
+ */
+export function recordRateLimitDenial(limiterName: string, ip: string): void {
+  void (async () => {
+    try {
+      const timeout = new Promise<void>((resolve) => setTimeout(resolve, DB_TIMEOUT_MS));
+      await Promise.race([write(limiterName, ip), timeout]);
+    } catch {
+      // never surfaces to the caller
+    }
+  })();
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -8,6 +8,8 @@
  * Counters are pruned on access to prevent memory leaks.
  */
 
+import { recordRateLimitDenial } from '@/lib/abuse-log';
+
 interface RateLimitEntry {
   count: number;
   resetAt: number;
@@ -55,6 +57,7 @@ export function checkRateLimit(
   entry.count++;
   if (entry.count > config.limit) {
     const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+    recordRateLimitDenial(config.name, ip);
     return { allowed: false, retryAfter };
   }
 
@@ -156,7 +159,11 @@ export async function checkRateLimitShared(
     // adding a multi-second tax to every gated request.
     const timeout = new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 1500));
     const result = await Promise.race([run(), timeout]);
+    // On timeout the in-memory fallback records the denial itself; on the Mongo
+    // path we record here. Logging lives OUTSIDE run() so a slow request whose
+    // run() resolves after the timeout can't also log — one denial, one event.
     if (result === 'timeout') return checkRateLimit(config, ip);
+    if (!result.allowed) recordRateLimitDenial(config.name, ip);
     return result;
   } catch {
     // A limiter outage must never wall a user — degrade to the in-memory cap.


### PR DESCRIPTION
## Why

While reviewing our bot protection I found we **collect** a lot of abuse telemetry but **surface** almost none of it — and one signal was being dropped entirely.

- The proxy layer already logs bot blocks and soft rate-limits to `analytics_bot_access` (182k+ docs, actively written), and there's an authed `GET /api/analytics/bots` aggregation over it — but **no admin page reads it**. The data goes in and nobody looks.
- Denials from `src/lib/rate-limit.ts` — the magic-link send, the Librarian/voice caps, and the `donate`/`subscribe` email limiters from #3123 — were **dropped on the floor**: a 429 went out and the event evaporated. `rate-limit.ts` had no insert and no log line.

So today we *stop* abuse but can't *measure* it. This closes both gaps.

## What changed

**1. Record the denials** — `src/lib/abuse-log.ts` adds `recordRateLimitDenial(name, ip)`: a durable, fire-and-forget, timeout-bounded write into the **same** `analytics_bot_access` collection the dashboard already reads, so denials surface with no endpoint change. Stored under a synthetic bot `ratelimit`, keyed by limiter name in `path_prefix` (e.g. `limiter:donate`), action `rate-limited`, IP truncated via `anonymizeIp` (consistent with that collection). Never throws, never blocks the request.

**2. Wire it into the limiter** — `rate-limit.ts` calls it from both denial paths (in-memory `checkRateLimit` and Mongo-backed `checkRateLimitShared`). Logging lives **outside** the Mongo `run()` closure and **after** the timeout race, so a slow request whose `run()` resolves after the 1.5s fallback can't also log — one denial, one event. (First cut double-counted on the timeout-fallback path; caught and fixed during testing.)

**3. Surface it** — `/admin/bots`: an admin page rendering the existing GET aggregation — totals, hard-blocked vs rate-limited, top bots (`ratelimit` highlighted), top targets, by-day. Added to `AdminNav` next to Errors. Read-only; no new endpoint.

## Verification

On a dev server (Resend blanked): drove the `donate` limiter — 3 allowed (400 on empty payload, no data written) then 429s — and confirmed **exactly 4 recorded hits for 4 denials** with the right truncated IP and `rate-limited` action (was 6-for-3 before the double-count fix). `GET /api/analytics/bots` returns **401** unauthenticated; `/admin/bots` **307**-redirects unauthenticated; no server errors. All test docs removed from `analytics_bot_access` afterward. `npx tsc --noEmit` clean.

## Scope / follow-ups

Deliberately out of scope, tracked in #3124:
- **Alerting** on denial/block spikes via the `health-check` cron (it already owns the scheduler + Resend + cooldown).
- Folding the **app-layer `api_usage.blocked`** counts (content-API budget denials, 4.87M rows) into the same view — right now `/admin/bots` shows the proxy + limiter layers, not the app budget layer.

No change to enforcement — this is pure observability. Correction to an earlier claim of mine: the proxy layer was **already** recording blocks durably; the genuine gap was the `rate-limit.ts` layer and the missing UI, both addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)