### PR TITLE
feat(admin): break down the opaque bot buckets by raw user-agent

### DIFF
--- a/src/app/admin/bots/page.tsx
+++ b/src/app/admin/bots/page.tsx
@@ -12,6 +12,14 @@ interface ByBot {
   last_seen: string;
 }
 interface Counted { _id: string; hits: number; bots?: string[] }
+interface UnknownAgent {
+  ua: string;
+  hits: number;
+  buckets: string[];
+  countries: string[];
+  paths: string[];
+  last_seen: string;
+}
 interface BotStats {
   period: { since: string; days: number };
   total_hits: number;
@@ -20,6 +28,7 @@ interface BotStats {
   by_day: Counted[];
   by_path: Counted[];
   by_action: Counted[];
+  unknown_agents?: UnknownAgent[];
 }
 
 const ACTION_LABEL: Record<string, string> = {
@@ -114,6 +123,28 @@ export default function AdminBotsPage() {
               </div>
             ))}
           </Section>
+
+          {/* Unknown user-agents — what the opaque buckets actually are */}
+          {data.unknown_agents && data.unknown_agents.length > 0 && (
+            <Section title="Unknown / unnamed bot user-agents">
+              <p style={{ color: '#6e7681', fontSize: 12, margin: '0 0 12px' }}>
+                Raw UA strings behind the <code>unknown-bot</code> / <code>other-bot</code> / <code>script</code> buckets. A flood of single-hit UAs = a UA-randomizing scraper.
+              </p>
+              {data.unknown_agents.map((u, i) => (
+                <div key={i} style={{ padding: '7px 0', borderBottom: '1px solid #161b22' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12 }}>
+                    <code style={{ fontSize: 12, color: '#c9d1d9', wordBreak: 'break-all' }}>{u.ua || '(empty UA)'}</code>
+                    <span style={{ color: '#8b949e', fontSize: 12, whiteSpace: 'nowrap' }}>{fmt(u.hits)} hits</span>
+                  </div>
+                  <div style={{ color: '#6e7681', fontSize: 11, marginTop: 2 }}>
+                    {u.buckets.join(', ')}
+                    {u.countries.length > 0 && ` · ${u.countries.slice(0, 8).join(' ')}`}
+                    {u.paths.length > 0 && ` · ${u.paths.slice(0, 4).join(' ')}`}
+                  </div>
+                </div>
+              ))}
+            </Section>
+          )}
 
           {/* By path */}
           <Section title="Top targets">

--- a/src/app/api/analytics/bots/route.ts
+++ b/src/app/api/analytics/bots/route.ts
@@ -4,8 +4,14 @@ import { withAuth } from '@/lib/auth-helpers';
 import { anonymizeIp } from '@/lib/anonymize-ip';
 
 const COLLECTION = 'analytics_bot_access';
+// Per-raw-UA samples for the opaque buckets (unknown-bot / other-bot / script),
+// so the 90%-of-volume "unknown" pile can be broken down by actual user-agent.
+const UNKNOWN_COLLECTION = 'bot_unknown_agents';
+// classifyBot categories that tell us nothing on their own — worth sampling.
+const OPAQUE_BUCKETS = new Set(['unknown-bot', 'other-bot', 'script']);
 const DB_TIMEOUT_MS = 3000;
 let indexEnsured = false;
+let unknownIndexEnsured = false;
 
 /**
  * POST /api/analytics/bots — fire-and-forget bot access logging
@@ -16,7 +22,7 @@ export async function POST(request: NextRequest) {
   try {
     // Only accept internal calls (no auth header needed, but check origin)
     const body = await request.json();
-    const { userAgent, path, action, ip: rawIp } = body;
+    const { userAgent, path, action, ip: rawIp, country } = body;
 
     if (!userAgent || !path) {
       return NextResponse.json({ success: true });
@@ -26,6 +32,7 @@ export async function POST(request: NextRequest) {
     const botName = classifyBot(userAgent);
     const pathPrefix = extractPathPrefix(path);
     const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    const geo = typeof country === 'string' && country ? country.slice(0, 2).toUpperCase() : null;
 
     const dbWrite = (async () => {
       const db = await getDb();
@@ -51,6 +58,31 @@ export async function POST(request: NextRequest) {
         },
         { upsert: true }
       );
+
+      // For the opaque buckets, also record a per-raw-UA daily sample so the
+      // "unknown" pile can be identified. Keyed by the (truncated) UA string;
+      // a flood of singleton UAs is itself the signal (UA-randomizing scraper).
+      if (OPAQUE_BUCKETS.has(botName)) {
+        const ucol = db.collection(UNKNOWN_COLLECTION);
+        if (!unknownIndexEnsured) {
+          ucol.createIndex({ ua: 1, date: 1 }, { name: 'ua_daily_idx', background: true }).catch(() => {});
+          ucol.createIndex({ date: 1, hits: -1 }, { name: 'date_hits_idx', background: true }).catch(() => {});
+          unknownIndexEnsured = true;
+        }
+        await ucol.updateOne(
+          { ua: userAgent.substring(0, 200), date: today },
+          {
+            $inc: { hits: 1 },
+            $set: { bucket: botName, last_ip: ip },
+            $addToSet: {
+              paths: pathPrefix,
+              ...(geo ? { countries: geo } : {}),
+            },
+            $setOnInsert: { created_at: new Date() },
+          },
+          { upsert: true }
+        );
+      }
     })();
 
     const timeout = new Promise<'timeout'>((resolve) =>
@@ -149,6 +181,31 @@ export const GET = withAuth(async (request: NextRequest) => {
 
     const total = result?.total?.[0] || { hits: 0, unique_ips: [[]] };
 
+    // Break down the opaque buckets by actual user-agent.
+    const rawUnknown = await db.collection(UNKNOWN_COLLECTION).aggregate([
+      { $match: { date: { $gte: since } } },
+      {
+        $group: {
+          _id: '$ua',
+          hits: { $sum: '$hits' },
+          buckets: { $addToSet: '$bucket' },
+          countries: { $addToSet: '$countries' },
+          paths: { $addToSet: '$paths' },
+          last_seen: { $max: '$date' },
+        },
+      },
+      { $sort: { hits: -1 } },
+      { $limit: 40 },
+    ]).toArray();
+    const unknown_agents = rawUnknown.map((u: Record<string, unknown>) => ({
+      ua: u._id,
+      hits: u.hits,
+      buckets: u.buckets,
+      countries: [...new Set((u.countries as string[][] || []).flat())].filter(Boolean),
+      paths: [...new Set((u.paths as string[][] || []).flat())].filter(Boolean).slice(0, 8),
+      last_seen: u.last_seen,
+    }));
+
     return NextResponse.json({
       period: { since, days },
       total_hits: total.hits || 0,
@@ -157,6 +214,7 @@ export const GET = withAuth(async (request: NextRequest) => {
       by_day: result?.byDay || [],
       by_path: result?.byPath || [],
       by_action: result?.byAction || [],
+      unknown_agents,
     });
   } catch (error) {
     return NextResponse.json(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -176,10 +176,17 @@ function logBotAccess(request: NextRequest, action: string) {
     const path = request.nextUrl.pathname;
     if (path.startsWith('/api/analytics') || path.startsWith('/api/cron')) return;
 
+    // Forward the edge-provided country so the unknown-bot sampler can cluster
+    // opaque bots by origin (a coarse residential-vs-datacenter proxy until we
+    // have real ASN enrichment).
+    const country = request.headers.get('cf-ipcountry')
+      || request.headers.get('x-vercel-ip-country')
+      || '';
+
     fetch(`${origin}/api/analytics/bots`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userAgent: ua, path, action, ip }),
+      body: JSON.stringify({ userAgent: ua, path, action, ip, country }),
     }).catch(() => {}); // swallow errors
   } catch {
     // never throw from logging


### PR DESCRIPTION
## Why

Once #3138 gave us `/admin/bots`, the data showed the real gap: **~90% of logged bot volume classifies as `unknown-bot` / `other-bot` / `script`** — an opaque pile we can't make any policy on. `classifyBot` collapses everything unmatched into those three names, and the raw UA was only kept as an overwritten `last_ua`, so we couldn't tell whether that bucket is one aggressive scraper, a botnet, or benign monitoring.

Last 7 days for context — the named crawlers are tiny and behaving (Googlebot 2 hits, Bingbot 8, Anthropic 4,151, all on the API, none page-scraping); the entire question is *what is the unknown 231k?* This makes that answerable. It's the prerequisite for every downstream decision (block harder, rate-limit for real, or leave it alone).

## What changed

- **`POST /api/analytics/bots`** now also upserts a per-`(raw UA, day)` counter into a new `bot_unknown_agents` collection — but **only for the three opaque buckets** (named bots are already known, so they aren't sampled). Each doc records hits, which bucket it fell into, the target path prefixes, and country. Keyed by the truncated UA string, so a flood of singleton UAs is itself the signal: a UA-randomizing scraper.
- **`src/proxy.ts`** forwards the edge country (`cf-ipcountry` / `x-vercel-ip-country`) in the log payload — a coarse residential-vs-datacenter proxy. (True **ASN** isn't in standard Vercel/CF headers; capturing it needs an IP→ASN dataset or a CF-enterprise field — noted as a follow-up in #3124, not in this PR.)
- **`GET /api/analytics/bots`** returns `unknown_agents` (top 40 raw UAs over the window) and **`/admin/bots`** renders them in a new section, with a note that many single-hit UAs = a randomizer.

No enforcement change — pure visibility, building directly on #3138.

## Verification

On a dev server: sent a `MysteryHarvester/9.9` UA (recorded under `other-bot`, country SG) and bare `curl/8.4.0` (under `script`, country US), both with target paths and countries captured correctly. `GET /api/analytics/bots` 401s unauthenticated; no server errors; `npx tsc --noEmit` clean. The new collection held only the 2 test rows (it's brand new) — both deleted afterward, so it ships empty and populates from real traffic post-deploy.

## Follow-ups (tracked in #3124)

- Real **ASN** enrichment (IP→ASN dataset) to firmly separate datacenter from residential.
- A **prune path** for `bot_unknown_agents` if UA-randomizers inflate cardinality (no TTL per the #2976 decision — manual prune, like the other telemetry collections).
- Once we can see the bucket: decide whether the shared/loggable rate-limiter should replace the proxy's leaky per-instance soft limiter for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)