### PR TITLE
feat(admin): Reading Register — external-only readers/agents/search insight

### DIFF
--- a/scripts/analytics/snapshot-reading-register.mjs
+++ b/scripts/analytics/snapshot-reading-register.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// Reading Register snapshot writer.
+//
+// Computes an EXTERNAL-ONLY view of who reads and consults the library: which
+// specific books people open, which books external AI agents fetch, what gets
+// searched (and what search fails to surface), and which agents call the MCP
+// endpoint. Writes ONE document to system_config.reading_register. The protected
+// admin page at /platform/(protected)/admin/reading-register reads it and renders
+// instantly — it never runs these aggregations on page load.
+//
+// "External-only" is the point: our own dev CLIs, edge functions, audit probes,
+// and `test` queries are filtered out (INTERNAL_RE) so the numbers reflect real
+// outside readers and agents, not us. Purely read-only against Mongo `bookstore`.
+//
+// Run:  set -a; source .env.production.local; set +a; \
+//       node scripts/analytics/snapshot-reading-register.mjs [--days N]
+//
+// Cron (Hetzner, daily): see scripts/workers/crontab.production.
+
+import { withMongo } from '../lib/mongo.mjs';
+
+const DAYS = (() => { const i = process.argv.indexOf('--days'); return i > -1 ? Number(process.argv[i + 1]) : 30; })();
+
+// Our own traffic — dev CLIs, edge runtime, audit/probe scripts. Excluded everywhere.
+const INTERNAL_RE = /claude-code|Deno|SupabaseEdgeRuntime|SaSame-MCP-Audit|Codex local catalog|metadata check|^node$|python-httpx|^curl/i;
+// Non-content / noise queries never counted as real search intent.
+const NOISE_Q = new Set(['test', '', ' ', 'it', 'wrap', 'ja', 'bvva']);
+
+const PROVIDER_PREFIXES = new Set([
+  'internet-archive', 'gallica', 'bavarian-state-library', 'e-codices', 'bodleian',
+  'manchester', 'laurenziana', 'e-rara', 'library-of-congress', 'vatican-library',
+  'wellcome-collection', 'bdrc', 'kloss-collection', 'allard-pierson', 'cambridge',
+  'leiden', 'google-books', 'qatar-digital-library', 'oraec',
+  'bibliotheca-philosophica-hermetica', 'tu-delft', 'kyoto', 'british-library',
+]);
+
+// Collapse a raw pageview path to a canonical book slug (mirrors snapshot-metrics.mjs).
+function bookSlug(raw) {
+  if (!raw) return '';
+  const parts = raw.split('?')[0].split('/').filter(Boolean);
+  if (parts.length && PROVIDER_PREFIXES.has(parts[0])) parts.shift();
+  if (parts[0] === 'embed' && parts.length > 2) return parts[2] === 'book' ? (parts[3] || '') : '';
+  if (parts[0] === 'book' && parts.length === 2) return parts[1] || ''; // /book/<slug> only, not /page/...
+  return '';
+}
+
+await withMongo(async (db) => {
+  const now = Date.now();
+  const SINCE = new Date(now - DAYS * 864e5);
+  const books = db.collection('books');
+  const pv = db.collection('analytics_pageviews');
+  const mc = db.collection('mcp_tool_calls');
+  const sq = db.collection('search_queries');
+
+  // Resolve a set of book _id/id/slug values → display titles.
+  async function titlesByIdOrSlug(vals, key) {
+    const clean = [...new Set(vals)].filter(Boolean);
+    if (!clean.length) return {};
+    const q = key === 'slug'
+      ? { slug: { $in: clean } }
+      : { $or: [{ _id: { $in: clean } }, { id: { $in: clean } }] };
+    const bs = await books.find(q, { projection: { title: 1, author: 1, id: 1, slug: 1 } }).toArray();
+    const m = {};
+    for (const b of bs) {
+      const rec = { title: b.title || '', author: b.author || '', slug: b.slug || '' };
+      if (key === 'slug') { if (b.slug) m[b.slug] = rec; }
+      else { m[String(b._id)] = rec; if (b.id) m[b.id] = rec; }
+    }
+    return m;
+  }
+
+  // ---- data span ----
+  const [mcMin] = await mc.find({}).sort({ ts: 1 }).limit(1).project({ ts: 1 }).toArray();
+  const logsSince = mcMin?.ts ? new Date(mcMin.ts).toISOString().slice(0, 10) : null;
+
+  // ---- readers: specific books opened (human page views) ----
+  // Group by path in Mongo (fast, indexed prefix) rather than streaming ~400K
+  // docs into Node. Counts landing views on /book/<slug> (not /page/ subpaths),
+  // matching the artifact semantics; provider/embed book URLs are a small tail
+  // folded elsewhere (top-books here is the canonical-URL ranking).
+  const readerAgg = await pv.aggregate([
+    { $match: { timestamp: { $gte: SINCE }, path: { $regex: '^/book/[^/]+$' } } },
+    { $group: { _id: '$path', n: { $sum: 1 } } },
+    { $sort: { n: -1 } }, { $limit: 20 },
+  ]).toArray();
+  const readerTop = readerAgg.map((r) => [bookSlug(r._id), r.n]).filter(([s]) => s);
+  const rMap = await titlesByIdOrSlug(readerTop.map(([s]) => s), 'slug');
+  const readerBooks = readerTop.map(([slug, hits]) => ({
+    slug, hits, title: rMap[slug]?.title || slug, author: rMap[slug]?.author || '',
+  }));
+
+  // ---- agents: specific books consulted (external MCP) ----
+  const agentBookAgg = await mc.aggregate([
+    { $match: { ts: { $gte: SINCE }, 'args.book_id': { $exists: true }, user_agent: { $not: INTERNAL_RE } } },
+    { $group: { _id: '$args.book_id', n: { $sum: 1 } } },
+    { $sort: { n: -1 } }, { $limit: 15 },
+  ]).toArray();
+  const aMap = await titlesByIdOrSlug(agentBookAgg.map((r) => r._id), 'id');
+  const agentBooks = agentBookAgg.map((r) => ({
+    n: r.n, title: aMap[r._id]?.title || String(r._id), author: aMap[r._id]?.author || '',
+  }));
+
+  // ---- external MCP: totals, clients, breakdown ----
+  const mcpTotal = await mc.countDocuments({ ts: { $gte: SINCE } });
+  const mcpExternal = await mc.countDocuments({ ts: { $gte: SINCE }, user_agent: { $not: INTERNAL_RE } });
+  const mcpInternal = mcpTotal - mcpExternal;
+  const extClients = (await mc.distinct('ip_hash', { ts: { $gte: SINCE }, user_agent: { $not: INTERNAL_RE } })).length;
+  const claudeUser = await mc.countDocuments({ ts: { $gte: SINCE }, user_agent: /Claude-User/i });
+  const byUAraw = await mc.aggregate([
+    { $match: { ts: { $gte: SINCE }, user_agent: { $not: INTERNAL_RE } } },
+    { $group: { _id: '$user_agent', n: { $sum: 1 } } }, { $sort: { n: -1 } }, { $limit: 30 },
+  ]).toArray();
+  // fold near-identical browser UAs into one bucket
+  let browserBucket = 0;
+  const clientRows = [];
+  for (const r of byUAraw) {
+    const ua = r._id || '';
+    if (/^Mozilla/.test(ua)) { browserBucket += r.n; continue; }
+    clientRows.push({ client: ua.slice(0, 48), n: r.n });
+  }
+  if (browserBucket) clientRows.push({ client: 'browser-based agents · misc', n: browserBucket });
+  clientRows.sort((a, b) => b.n - a.n);
+
+  // ---- external MCP queries ----
+  const extQ = await mc.aggregate([
+    { $match: { ts: { $gte: SINCE }, 'args.query': { $exists: true }, user_agent: { $not: INTERNAL_RE } } },
+    { $group: { _id: '$args.query', n: { $sum: 1 }, tools: { $addToSet: '$tool' } } },
+    { $sort: { n: -1 } }, { $limit: 30 },
+  ]).toArray();
+  const agentQueries = extQ
+    .filter((r) => r._id && !NOISE_Q.has(String(r._id).toLowerCase()))
+    .map((r) => ({ query: String(r._id).slice(0, 80), n: r.n, tools: r.tools }))
+    .slice(0, 18);
+
+  // ---- human web search ----
+  const humanSearchers = (await sq.distinct('ip_hash', { ts: { $gte: SINCE }, user_agent: /^Mozilla/ })).length;
+  const humanSearches = await sq.countDocuments({ ts: { $gte: SINCE }, user_agent: /^Mozilla/, query: { $nin: [...NOISE_Q] } });
+  const topQ = await sq.aggregate([
+    { $match: { ts: { $gte: SINCE }, user_agent: /^Mozilla/, query: { $nin: [...NOISE_Q] } } },
+    { $group: { _id: { $toLower: '$query' }, n: { $sum: 1 }, avg: { $avg: '$total' } } },
+    { $sort: { n: -1 } }, { $limit: 15 },
+  ]).toArray();
+  const topQueries = topQ.filter((r) => r._id).map((r) => ({ query: r._id, n: r.n, avgResults: Math.round(r.avg || 0) }));
+  const zeroQ = await sq.aggregate([
+    { $match: { ts: { $gte: SINCE }, total: 0, query: { $nin: [...NOISE_Q] } } },
+    { $group: { _id: { $toLower: '$query' }, n: { $sum: 1 } } },
+    { $sort: { n: -1 } }, { $limit: 15 },
+  ]).toArray();
+  // annotate zero-result queries with whether we actually hold matches (recall-bug vs true gap)
+  const zeroQueries = [];
+  for (const r of zeroQ) {
+    const q = String(r._id || '').trim();
+    if (!q || q.length < 4) continue; // skip typeahead fragments
+    const rx = new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    const held = await books.countDocuments({ $or: [{ title: rx }, { author: rx }] });
+    const visible = held ? await books.countDocuments({ $or: [{ title: rx }, { author: rx }], visible: true }) : 0;
+    zeroQueries.push({ query: q, n: r.n, held, visible });
+  }
+
+  const snapshot = {
+    _id: 'reading_register',
+    schemaVersion: 1,
+    generatedAt: new Date(),
+    windowDays: DAYS,
+    since: SINCE,
+    logsSince,
+    headline: {
+      readerViews: 0, // set below
+      humanSearchers,
+      humanSearches,
+      mcpExternal,
+      mcpInternal,
+      extClients,
+      claudeUser,
+    },
+    readerBooks,
+    agentBooks,
+    mcp: { total: mcpTotal, external: mcpExternal, internal: mcpInternal, clients: extClients, claudeUser, clientRows: clientRows.slice(0, 8) },
+    agentQueries,
+    search: { humanSearchers, humanSearches, topQueries, zeroQueries },
+  };
+
+  // total reader views over the window (all book page views, for the headline)
+  snapshot.headline.readerViews = await pv.countDocuments({ timestamp: { $gte: SINCE }, path: /^\/(book|embed)\// });
+
+  const res = await db.collection('system_config').updateOne(
+    { _id: 'reading_register' },
+    { $set: snapshot },
+    { upsert: true },
+  );
+  console.log(`reading_register written (matched=${res.matchedCount} upserted=${res.upsertedCount ? 1 : 0}). generatedAt=${snapshot.generatedAt.toISOString()} window=${DAYS}d`);
+  console.log(`  readers: ${snapshot.headline.readerViews.toLocaleString()} views · agents: ${mcpExternal} external calls / ${extClients} clients (${mcpInternal} internal excluded) · searchers: ${humanSearchers}`);
+});

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -113,6 +113,8 @@
 30 5 * * * cd /root/sourcelibrary && [ -f scripts/enrichment/backfill-thesaurus-author-locations.mjs ] && flock -n /tmp/sl-thesaurus-loc.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/backfill-thesaurus-author-locations.mjs --write-books" >> /var/log/sourcelibrary/geocode-locations.log 2>&1
 0 9 * * * cd /root/sourcelibrary && flock -n /tmp/sl-newsletter-refresh.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/refresh-newsletter-audience.mjs" >> /var/log/sourcelibrary/newsletter-refresh.log 2>&1
 45 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-metrics-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analytics/snapshot-metrics.mjs" >> /var/log/sourcelibrary/metrics-snapshot.log 2>&1
+# Reading Register (external-only readers/agents/search) -> system_config.reading_register, read by /platform/admin/reading-register
+50 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-reading-register.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analytics/snapshot-reading-register.mjs" >> /var/log/sourcelibrary/reading-register.log 2>&1
 # On-mission acquisition: daily bounded batch (USTC gap -> IA/e-rara -> verify -> import hidden)
 # e-rara IIIF catalog refresh: weekly
 0 2 * * 0 cd /root/sourcelibrary && flock -n /tmp/sl-erara.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/harvest-erara-catalog.mjs" >> /var/log/sourcelibrary/erara-harvest.log 2>&1

--- a/src/app/platform/(protected)/admin/reading-register/page.tsx
+++ b/src/app/platform/(protected)/admin/reading-register/page.tsx
@@ -1,0 +1,226 @@
+/**
+ * Reading Register — an EXTERNAL-ONLY view of who reads and consults the library.
+ *
+ * Reads the daily snapshot from system_config.reading_register (written by
+ * scripts/analytics/snapshot-reading-register.mjs on a Hetzner cron) and renders
+ * it. Never runs the aggregations on page load. Gated by the protected layout
+ * (requireSuperAdmin) — this view carries pseudonymous identifiers and
+ * un-thresholded specifics, so it is INTERNAL ONLY, never public.
+ *
+ * "External-only" is the whole point: our own dev CLIs, edge functions, audit
+ * probes, and `test` queries are filtered out at snapshot time, so the numbers
+ * reflect real outside readers and agents. Keep the snapshot shape in sync with
+ * snapshot-reading-register.mjs.
+ */
+import { getDb } from '@/lib/mongodb';
+
+export const dynamic = 'force-dynamic';
+
+interface BookRow { slug?: string; title: string; author?: string; hits?: number; n?: number }
+interface QueryRow { query: string; n: number; avgResults?: number; tools?: string[] }
+interface ZeroRow { query: string; n: number; held: number; visible: number }
+interface ClientRow { client: string; n: number }
+interface ReadingRegister {
+  generatedAt?: Date | string;
+  windowDays?: number;
+  since?: Date | string;
+  logsSince?: string | null;
+  headline?: { readerViews?: number; humanSearchers?: number; humanSearches?: number; mcpExternal?: number; mcpInternal?: number; extClients?: number; claudeUser?: number };
+  readerBooks?: BookRow[];
+  agentBooks?: BookRow[];
+  mcp?: { total?: number; external?: number; internal?: number; clients?: number; claudeUser?: number; clientRows?: ClientRow[] };
+  agentQueries?: QueryRow[];
+  search?: { humanSearchers?: number; humanSearches?: number; topQueries?: QueryRow[]; zeroQueries?: ZeroRow[] };
+}
+
+const num = (n: number | null | undefined) => (n ?? 0).toLocaleString('en-US');
+
+const C = {
+  card: { background: '#161b22', border: '1px solid #30363d', borderRadius: 8, padding: '16px 18px' } as const,
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 12 } as const,
+  big: { fontSize: 30, fontWeight: 700, color: '#e6edf3', lineHeight: 1.1 } as const,
+  label: { fontSize: 12, color: '#8b949e', marginTop: 4, textTransform: 'uppercase', letterSpacing: 0.4 } as const,
+  sub: { fontSize: 12, color: '#6e7681', marginTop: 2 } as const,
+  h2: { fontSize: 16, fontWeight: 600, color: '#e6edf3', margin: '30px 0 4px' } as const,
+  h2sub: { fontSize: 12, color: '#6e7681', margin: '0 0 12px' } as const,
+  th: { textAlign: 'left' as const, fontSize: 11, color: '#8b949e', textTransform: 'uppercase' as const, letterSpacing: 0.4, padding: '6px 10px', borderBottom: '1px solid #30363d' },
+  td: { fontSize: 13, color: '#c9d1d9', padding: '6px 10px', borderBottom: '1px solid #21262d' },
+  mono: { fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' } as const,
+};
+
+function Stat({ value, label, sub, accent }: { value: string; label: string; sub?: string; accent?: string }) {
+  return (
+    <div style={C.card}>
+      <div style={{ ...C.big, color: accent || '#e6edf3' }}>{value}</div>
+      <div style={C.label}>{label}</div>
+      {sub ? <div style={C.sub}>{sub}</div> : null}
+    </div>
+  );
+}
+
+function SectionHead({ title, sub }: { title: string; sub?: string }) {
+  return (<><h2 style={C.h2}>{title}</h2>{sub ? <p style={C.h2sub}>{sub}</p> : null}</>);
+}
+
+// Horizontal-bar rank list for specific books / clients.
+function RankBars({ rows, color }: { rows: { label: React.ReactNode; value: number }[]; color: string }) {
+  if (!rows?.length) return <p style={{ color: '#6e7681', fontSize: 13 }}>No data.</p>;
+  const max = Math.max(...rows.map((r) => r.value), 1);
+  return (
+    <div style={{ ...C.card, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {rows.map((r, i) => (
+        <div key={i} style={{ display: 'grid', gridTemplateColumns: '1fr 90px 40px', gap: 10, alignItems: 'center' }}>
+          <div style={{ fontSize: 13, color: '#c9d1d9', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.label}</div>
+          <div style={{ height: 7, background: '#21262d', borderRadius: 4, overflow: 'hidden' }}>
+            <div style={{ width: `${(r.value / max) * 100}%`, height: '100%', background: color, minWidth: 2 }} />
+          </div>
+          <div style={{ ...C.mono, fontSize: 12, color: '#8b949e', textAlign: 'right' }}>{num(r.value)}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Table({ headers, rows }: { headers: string[]; rows: React.ReactNode[][] }) {
+  if (!rows?.length) return <p style={{ color: '#6e7681', fontSize: 13 }}>No data.</p>;
+  return (
+    <div style={{ ...C.card, padding: 0, overflow: 'hidden' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead><tr>{headers.map((h, i) => <th key={i} style={{ ...C.th, textAlign: i === headers.length - 1 ? 'right' : 'left' }}>{h}</th>)}</tr></thead>
+        <tbody>
+          {rows.map((r, ri) => (
+            <tr key={ri}>{r.map((c, ci) => <td key={ci} style={{ ...C.td, textAlign: ci === r.length - 1 ? 'right' : 'left', color: ci === 0 ? '#c9d1d9' : '#8b949e' }}>{c}</td>)}</tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const SCHEMA: { name: string; fields: string[]; note: string }[] = [
+  { name: 'mcp_tool_calls', fields: ['tool', 'args', 'ms', 'ok', 'error', 'ip_hash', 'user_agent', 'ts'], note: 'One row per agent tool-call. args holds the payload — the exact query, or a book_id + page. That is where intent lives.' },
+  { name: 'search_queries', fields: ['query', 'total', 'route', 'ms', 'ok', 'identity_kind', 'filters', 'stage_ms', 'ip_hash', 'user_agent'], note: 'One row per search (web + MCP). total is the result count (0 flags a possible miss); filters records language + ranking; stage_ms times each lane.' },
+];
+
+const METHODOLOGY: [string, string][] = [
+  ['External-only', 'Our own dev CLIs (claude-code), edge functions (Deno/Supabase), audit probes, and test queries are filtered out at snapshot time. What remains is outside readers and agents. In the last window that removed ~72% of raw MCP calls — do not compare these numbers to the raw logs.'],
+  ['Snapshot, not live', 'Precomputed daily by scripts/analytics/snapshot-reading-register.mjs and read from system_config.reading_register. The header shows when it was generated; older than ~30h turns amber.'],
+  ['Zero-result ≠ missing book', 'Each zero-result query is checked against holdings. "held" / "visible" columns > 0 mean we HAVE the book and search failed to surface it (a recall bug), not that we lack it. Only held=0 is a genuine acquisition signal.'],
+  ['Readers vs agents are different shelves', 'Human page views and agent tool-calls rank different books — readers spread across the whole collection; agents cluster hard on the Hermetic core. Neither is "the" popularity.'],
+  ['Identifiers are pseudonymous', 'ip_hash is a salted hash, never a raw IP — but it is still pseudonymous, not anonymous, so this page stays internal. Recommended hygiene: age operational logs out at 30–90 days, keep only anonymised aggregates beyond that.'],
+];
+
+export default async function ReadingRegisterPage() {
+  const db = await getDb();
+  const s = (await db.collection('system_config').findOne({ _id: 'reading_register' } as never)) as ReadingRegister | null;
+
+  if (!s) {
+    return (
+      <div>
+        <h1 style={{ fontSize: 22, fontWeight: 700, color: '#e6edf3' }}>Reading Register</h1>
+        <p style={{ color: '#8b949e', marginTop: 12 }}>
+          No snapshot yet. Run <code style={{ color: '#e6edf3' }}>node scripts/analytics/snapshot-reading-register.mjs</code> to populate it
+          (it also runs daily on the Hetzner cron).
+        </p>
+      </div>
+    );
+  }
+
+  const h = s.headline || {};
+  const win = s.windowDays || 30;
+  const gen = s.generatedAt ? new Date(s.generatedAt) : null;
+  const ageH = gen ? Math.round((Date.now() - gen.getTime()) / 36e5) : null;
+  const sr = s.search || {};
+
+  const bookLabel = (b: BookRow) =>
+    b.slug ? <a href={`https://sourcelibrary.org/book/${b.slug}`} style={{ color: '#c9d1d9' }} target="_blank" rel="noopener noreferrer">{b.title}{b.author ? <span style={{ color: '#6e7681' }}> · {b.author}</span> : null}</a>
+      : <span>{b.title}{b.author ? <span style={{ color: '#6e7681' }}> · {b.author}</span> : null}</span>;
+
+  return (
+    <div style={{ maxWidth: 1100 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', flexWrap: 'wrap', gap: 8 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, color: '#e6edf3', margin: 0 }}>Reading Register</h1>
+        <span style={{ fontSize: 12, color: ageH !== null && ageH > 30 ? '#d29922' : '#6e7681' }}>
+          snapshot {gen ? gen.toISOString().slice(0, 16).replace('T', ' ') + ' UTC' : 'unknown'}
+          {ageH !== null ? ` · ${ageH}h ago` : ''} · {win}-day window{s.logsSince ? ` · logs since ${s.logsSince}` : ''}
+        </span>
+      </div>
+      <p style={{ fontSize: 12, color: '#6e7681', margin: '6px 0 0' }}>
+        External readers &amp; agents only — our own dev, testing, and infrastructure traffic is filtered out. Internal view; never publish as-is.
+      </p>
+
+      <SectionHead title="Headline" sub={`Trailing ${win} days. Reader views are human page views; agent calls exclude our own clients.`} />
+      <div style={C.grid}>
+        <Stat value={num(h.readerViews)} label="Reader views" accent="#d4837a" />
+        <Stat value={num(h.humanSearchers)} label="Human searchers" accent="#d4837a" sub={`${num(h.humanSearches)} searches`} />
+        <Stat value={num(h.mcpExternal)} label="External agent calls" accent="#d3aa57" sub={`${num(h.mcpInternal)} internal excluded`} />
+        <Stat value={num(h.extClients)} label="External agents" accent="#d3aa57" />
+        <Stat value={num(h.claudeUser)} label="Via Claude (people)" accent="#d3aa57" />
+      </div>
+
+      <SectionHead title="What we capture" sub="The full field set of each log. ip_hash + user_agent are the identifying fields that keep this internal." />
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+        {SCHEMA.map((sc) => (
+          <div key={sc.name} style={C.card}>
+            <div style={{ ...C.mono, fontSize: 13, color: '#e6edf3', marginBottom: 10 }}>{sc.name}</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 10 }}>
+              {sc.fields.map((f) => {
+                const pii = f === 'ip_hash' || f === 'user_agent';
+                const key = f === 'tool' || f === 'args' || f === 'query' || f === 'total';
+                return <span key={f} style={{ ...C.mono, fontSize: 11.5, padding: '3px 8px', borderRadius: 3, background: '#0d1117', border: `1px solid ${pii ? '#5c2e2b' : key ? '#2a4d3a' : '#30363d'}`, color: pii ? '#d4837a' : key ? '#7ee2a8' : '#8b949e' }}>{f}</span>;
+              })}
+            </div>
+            <div style={{ fontSize: 12.5, color: '#8b949e', lineHeight: 1.5 }}>{sc.note}</div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+        <div>
+          <SectionHead title="What people opened" sub="Specific books, by human page views." />
+          <RankBars color="#d4837a" rows={(s.readerBooks || []).slice(0, 12).map((b) => ({ label: bookLabel(b), value: b.hits || 0 }))} />
+        </div>
+        <div>
+          <SectionHead title="What agents chose" sub="External MCP get_book / get_quote." />
+          <RankBars color="#d3aa57" rows={(s.agentBooks || []).slice(0, 12).map((b) => ({ label: bookLabel(b), value: b.n || 0 }))} />
+        </div>
+      </div>
+
+      <SectionHead title="Search, and what it can't find" sub="Top human searches resolve well. Zero-result queries are checked against holdings — held/visible > 0 means a recall bug, not a gap." />
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+        <div>
+          <SectionHead title="Top queries" sub="avg results" />
+          <Table headers={['query', 'count', 'avg']} rows={(sr.topQueries || []).map((q) => [q.query, num(q.n), `~${q.avgResults}`])} />
+        </div>
+        <div>
+          <SectionHead title="Zero results" sub="held / visible in catalogue" />
+          <Table headers={['query', 'count', 'held·vis']} rows={(sr.zeroQueries || []).map((q) => [
+            <span key="q">{q.query}{q.held === 0 ? <span style={{ color: '#d29922' }}> · possible gap</span> : q.visible > 0 ? <span style={{ color: '#6e7681' }}> · held, not surfaced</span> : <span style={{ color: '#6e7681' }}> · held, hidden</span>}</span>,
+            num(q.n),
+            `${q.held}·${q.visible}`,
+          ])} />
+        </div>
+      </div>
+
+      {s.agentQueries?.length ? (
+        <>
+          <SectionHead title="What agents searched for" sub="External concept / library / image queries — the research campaigns passing through." />
+          <Table headers={['query', 'tools', 'count']} rows={s.agentQueries.map((q) => [q.query, (q.tools || []).join(', '), num(q.n)])} />
+        </>
+      ) : null}
+
+      <SectionHead title="Who is calling — external agents only" sub={`${num(s.mcp?.clients)} clients · ${num(s.mcp?.external)} calls. Internal (${num(s.mcp?.internal)}) excluded.`} />
+      <RankBars color="#3fb950" rows={(s.mcp?.clientRows || []).map((c) => ({ label: <span style={C.mono}>{c.client}</span>, value: c.n }))} />
+
+      <SectionHead title="Methodology & caveats" sub="What these numbers mean — and what they do not." />
+      <div style={{ ...C.card, display: 'grid', gap: 14 }}>
+        {METHODOLOGY.map(([title, body]) => (
+          <div key={title}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#c9d1d9' }}>{title}</div>
+            <div style={{ fontSize: 12.5, color: '#8b949e', marginTop: 3, lineHeight: 1.5 }}>{body}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/platform/PlatformNav.tsx
+++ b/src/app/platform/PlatformNav.tsx
@@ -8,6 +8,7 @@ import { useSession, signOut } from 'next-auth/react';
 const navLinks = [
   { href: '/platform/dashboard', label: 'Dashboard' },
   { href: '/platform/admin/metrics', label: 'Metrics' },
+  { href: '/platform/admin/reading-register', label: 'Reading Register' },
   { href: '/platform/admin/translation-failures', label: 'Translation Failures' },
   { href: '/platform/tenants/new', label: 'New Library' },
 ];


### PR DESCRIPTION
## What
A new internal super-admin page at **`/platform/admin/reading-register`** that shows who actually reads and consults the library — **with our own dev/testing/infra traffic filtered out** (it was ~72% of raw MCP calls).

Grew out of a traffic-analysis session. The public-safe aggregate version lives separately as an artifact; this is the internal instrument.

### Sections
- **Specific books** people open (human page views) vs. books **external agents** fetch (MCP) — different shelves, both linked to the book pages.
- **What agents search for**, and **what human search can't find**. Zero-result queries are auto-checked against holdings each night: `held/visible > 0` = a recall miss (e.g. `hartmann` → we hold 80, 17 visible), `held = 0` = a possible acquisition gap.
- **Who calls the MCP endpoint** (external clients only; internal calls counted and excluded).
- **"What we capture"** — documents the `mcp_tool_calls` / `search_queries` field sets, flagging the pseudonymous `ip_hash` / `user_agent` that keep this view internal.

## How
- `scripts/analytics/snapshot-reading-register.mjs` computes an external-only snapshot → `system_config.reading_register`. Same **read-a-precomputed-doc** pattern as the existing metrics page; the page never runs aggregations on load.
- Grouping is done in Mongo (not by streaming ~400K pageview docs into Node) — snapshot runs in ~90s. Verified it writes and reads back with all sections populated.
- Wired into the Hetzner cron at **05:50 UTC** (right after the metrics snapshot).
- Gated by the existing `(protected)` `requireSuperAdmin` layout; added a nav link.

## Scope / out of scope
- **In:** the snapshot script, the admin page, the nav link, the cron line.
- **Out:** the search-recall bug this surfaced (`hartmann` → 0 despite holdings) is filed separately as #3141. Un-hiding the stranded Guaman Poma / 2026-04-21 import batch is a separate visibility decision, not touched here.

## Verification
- `npx tsc --noEmit` clean.
- Snapshot test-run wrote real data: 469,808 reader views · 985 external agent calls / 23 clients (2,553 internal excluded) · 1,243 human searchers.
- Titles resolve from the DB (e.g. correctly shows *Kitab al-Bulhan*, *Sefer ha-Zohar Mantua 1558*).

Note: no Vercel prod deploy yet — merging this does not ship it; the admin page goes live on the next `npm run deploy:prod`. The cron/script change auto-deploys via the Hetzner pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)