### PR TITLE
fix(ft-verify): capture prior years so first_modern doesn't collapse to not_first

### DIFF
--- a/.claude/skills/ft-verify/SKILL.md
+++ b/.claude/skills/ft-verify/SKILL.md
@@ -56,7 +56,18 @@ A set of flips, each with: `book_id`, `work` (title), `author`, `lang`, and a **
 - **demote** survives (the demote is valid) only if `result == confirmed_complete` with a real URL.
   `confirmed_partial` / `not_found` → the badge was right; KEEP it.
 - **promote** survives (the first stands) if `result == none_found` or `only_partial_exists`.
-  `complete_prior_found` → a prior exists; do NOT promote.
+  `complete_prior_found` → a prior exists; do NOT promote as a plain "first". **BUT see first_modern.**
+
+### first_modern — a complete prior can still be a badgeable first (don't collapse it)
+A complete prior does NOT always defeat the claim. The graded model (`src/lib/first-translation/types.ts`)
+has a `first_modern` verdict: **if the ONLY complete prior(s) are pre-1900, the text grades `first_modern`
+(a first-family badge, "First Modern Translation"), not `not_first`.** A 480-year-old Tudor crib is not a
+readable modern English translation. `derive-from-evidence.ts` makes this call automatically — but ONLY if
+the prior's **year is a structured `pub_year` field** in the registry row. So the one thing that CANNOT be
+dropped is the year: every found prior MUST carry `pub_year`. Do not bury "translator, 1547, title" in a
+single string — the grader can't parse it and a genuine first-modern collapses to not_first (this is exactly
+how Whittington 1547 mis-graded De remediis fortuitorum, 2026-07-13). Always emit `registry_rows[]` with a
+real `pub_year` for every confirmed prior, whatever the `result` value.
 
 ## Subagent prompt — DEMOTE (verify a claimed prior is real)
 > You are verifying a "first English translation" claim for a library audit. Stage 1 says a PRIOR
@@ -65,8 +76,9 @@ A set of flips, each with: `book_id`, `work` (title), `author`, `lang`, and a **
 > Do REAL web research (WebSearch/WebFetch): WorldCat, archive.org, Google Books, HathiTrust, the
 > publisher, tradition-appropriate catalogues, scholarship. Confirm whether THIS specific translation
 > actually exists, and whether it is COMPLETE or only partial/excerpt. Disambiguate same-named works
-> and authors. Return ONLY JSON:
-> `{"result":"confirmed_complete|confirmed_partial|not_found|uncertain","prior":"<translator,year,title or empty>","evidence_url":"<real url or empty>","queries_run":["every search you ran, verbatim"],"sources_consulted":[{"url":"...","found":"<one line: what it showed>"}],"reasoning":"<2-3 sentences>"}`
+> and authors. **Record the YEAR of every prior you find** — a pre-1900-only prior means the text is a
+> "first MODERN translation", so the year decides the grade. Return ONLY JSON:
+> `{"result":"confirmed_complete|confirmed_partial|not_found|uncertain","priors":[{"translator":"","year":0,"english_title":"","completeness":"complete|partial|excerpt","source_url":""}],"prior":"<translator, year, title — human-readable summary of the strongest prior, or empty>","evidence_url":"<real url or empty>","queries_run":["every search you ran, verbatim"],"sources_consulted":[{"url":"...","found":"<one line: what it showed>"}],"reasoning":"<2-3 sentences>"}`
 
 ## Subagent prompt — PROMOTE (try to refute "it's a first")
 > You are verifying a "first English translation" claim. We are about to claim "<work>" by <author>
@@ -75,8 +87,10 @@ A set of flips, each with: `book_id`, `work` (title), `author`, `lang`, and a **
 > that. Do REAL web research (WorldCat, archive.org, Google Books, HathiTrust, publisher,
 > tradition-appropriate sources for <lang>, scholarship). Separate THIS work from related works /
 > other editions; flag if it's a multi-work container/anthology/manuscript-miscellany (the claim is
-> then ill-posed). Return ONLY JSON:
-> `{"result":"complete_prior_found|only_partial_exists|none_found|uncertain","prior":"<translator,year,title or empty>","evidence_url":"<real url or empty>","queries_run":["every search, verbatim"],"sources_consulted":[{"url":"...","found":"<one line>"}],"reasoning":"<2-3 sentences>"}`
+> then ill-posed). If you DO find a complete prior, **record its YEAR** — a prior that is only pre-1900
+> does not defeat the claim outright, it grades the text a "first MODERN translation", so the year is
+> load-bearing. Return ONLY JSON:
+> `{"result":"complete_prior_found|only_partial_exists|none_found|uncertain","priors":[{"translator":"","year":0,"english_title":"","completeness":"complete|partial|excerpt","source_url":""}],"prior":"<translator, year, title — human-readable summary of the strongest prior, or empty>","evidence_url":"<real url or empty>","queries_run":["every search, verbatim"],"sources_consulted":[{"url":"...","found":"<one line>"}],"reasoning":"<2-3 sentences>"}`
 
 ## Notes
 - Quality observed (2026-06-21): Claude subagents disambiguated authors (Johann vs Georgius

--- a/scripts/maintenance/ingest-ft-verify-results.mjs
+++ b/scripts/maintenance/ingest-ft-verify-results.mjs
@@ -24,7 +24,14 @@
  *   only_partial_exists|complete_prior_found), survivor (bool), bucket,
  *   prior (string), evidence_url, queries_run[], sources_consulted[{url,found}],
  *   reasoning, registry_rows?[{author, english_title, translator, pub_year,
- *   publisher?, original_title?, source_language?, completeness, source_url?, notes?}]
+ *   publisher?, original_title?, source_language?, completeness, source_url?, notes?}],
+ *   priors?[{translator, year, english_title, completeness, source_url}]
+ *
+ * The attempt's structured `priors[]` are built from `registry_rows` (or the
+ * `priors` array), NOT the free `prior` string — so every prior carries a
+ * `pub_year`. The derive step needs that year to grade `first_modern` (a prior
+ * that is only pre-1900 is a badgeable "First Modern Translation", not not_first);
+ * a year lost inside a string collapses a genuine first-modern to not_first.
  *
  * Usage:
  *   set -a; source .env.production.local; set +a
@@ -56,6 +63,53 @@ const registry = db.collection('translation_catalogs');
 const FOUND = new Set(['confirmed_complete', 'confirmed_partial', 'complete_prior_found', 'only_partial_exists']);
 let aIns = 0, aSkip = 0, cIns = 0, cSkip = 0, badRows = 0;
 
+const completenessFor = (result) =>
+  result === 'confirmed_complete' || result === 'complete_prior_found' ? 'complete'
+  : result === 'confirmed_partial' || result === 'only_partial_exists' ? 'partial'
+  : 'unknown';
+
+/**
+ * Build the attempt's structured `priors[]`.
+ *
+ * CRITICAL: prefer `registry_rows` (they carry `pub_year`, `translator`,
+ * `english_title` as separate fields) over the free `prior` string. The derive
+ * step grades `first_modern` (a badgeable first) vs `not_first` by whether the
+ * priors are ALL pre-1900 — but it can only read the year if `pub_year` is a
+ * structured field. Cramming "translator, 1547, title" into `english_title`
+ * (the old behaviour) hides the year, so a genuine first-modern collapses to
+ * not_first. This is exactly how De remediis fortuitorum (Whittington 1547) was
+ * mis-graded before the fix.
+ */
+function buildPriors(r) {
+  // 1. registry_rows — the canonical structured source (pub_year, translator).
+  const rows = Array.isArray(r.registry_rows) ? r.registry_rows.filter((t) => t.english_title) : [];
+  if (rows.length) {
+    return rows.map((t) => ({
+      english_title: t.english_title,
+      translator: t.translator || undefined,
+      pub_year: t.pub_year != null ? String(t.pub_year) : undefined,
+      completeness: t.completeness || completenessFor(r.result),
+      source_url: t.source_url || r.evidence_url || undefined,
+    }));
+  }
+  // 2. priors[] — the subagent's structured array (year as a number field).
+  const sub = Array.isArray(r.priors) ? r.priors.filter((t) => t.english_title) : [];
+  if (sub.length) {
+    return sub.map((t) => ({
+      english_title: t.english_title,
+      translator: t.translator || undefined,
+      pub_year: t.year != null && t.year !== 0 ? String(t.year) : (t.pub_year != null ? String(t.pub_year) : undefined),
+      completeness: t.completeness || completenessFor(r.result),
+      source_url: t.source_url || r.evidence_url || undefined,
+    }));
+  }
+  // 3. Fallback: only a free `prior` string is available (no structured row).
+  //    The year is unparseable here — the derive step cannot grade first_modern.
+  return r.prior
+    ? [{ english_title: r.prior, completeness: completenessFor(r.result), source_url: r.evidence_url || undefined }]
+    : [];
+}
+
 for (const r of rows) {
   if (!r.book_id || !r.result || !Array.isArray(r.queries_run)) { badRows++; continue; }
 
@@ -77,17 +131,7 @@ for (const r of rows) {
         sources_detail: r.sources_consulted ?? [],
         result: FOUND.has(r.result) ? 'found' : 'none',
         verdict: r.result,
-        priors: r.prior
-          ? [{
-              english_title: r.prior,
-              completeness: r.result === 'confirmed_complete' || r.result === 'complete_prior_found'
-                ? 'complete'
-                : r.result === 'confirmed_partial' || r.result === 'only_partial_exists'
-                  ? 'partial'
-                  : 'unknown',
-              source_url: r.evidence_url || undefined,
-            }]
-          : [],
+        priors: buildPriors(r),
         evidence_strength: 'strong',
         independence_score: 1,
         notes: `[ft-verify-${runDate} ${r.direction ?? 'demote'}-check bucket=${r.bucket ?? 'unbucketed'}] ${r.reasoning ?? ''}`,


### PR DESCRIPTION
## Why
An ft-verify run on the Stoic collection surfaced a real gap: **a pre-1900 prior translation silently collapsed a genuine "first modern translation" into `not_first`.**

*De remediis fortuitorum* (pseudo-Seneca) has exactly one English translation ever — Robert Whittington's **1547** Tudor grammar-school crib, nothing since. Under the graded model that's `first_modern` (a badgeable "First Modern Translation"), and `derive-from-evidence.ts` already knows the rule ("all priors pre-1900 → first_modern"). But it never fired, because the ingest dropped the year.

## Root cause
`ingest-ft-verify-results.mjs` built the attempt's structured `priors[]` from the free **`prior` string** (`english_title = "Whittington, 1547, title"`), with no `pub_year` — even though `registry_rows` already carried the year as a structured field. The derive step parses `pub_year` to grade first_modern vs not_first; a year buried in a string is unparseable, so it defaulted to `not_first`.

## Fix
- **`ingest-ft-verify-results.mjs`** — build `priors[]` from `registry_rows` (or the subagent's structured `priors[]`), preserving `pub_year`. The free string is a last-resort fallback only.
- **`ft-verify/SKILL.md`** — both subagent prompts now require each prior's **year**, and a new *first_modern* section explains that a pre-1900-only prior is a first-family badge, not a defeat, so the year is load-bearing.

## Test
`buildPriors` unit check:
```
registry_rows → pub_year:"1547"   ✓
priors[]       → pub_year:"1614"   ✓
free string    → (no year — fallback only)
```
End-to-end already validated on the live book: with the year structured, `derive` graded `first_modern` and the reader page now renders the "First Modern Translation" badge with the Whittington 1547 prior shown.

## Out of scope (already done on the DB)
The five verified Stoic books' badges (3 firsts, 1 first-modern, 1 existing-translations) were set out-of-band with sign-off. No UI change was needed — the `first_modern` badge/label/verdict already existed in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)