### PR TITLE
fix(reader): reset zoom on page nav + magnifier lens on by default

### DIFF
--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -12,8 +12,11 @@ import {
 } from '@/hooks/useFloatingOverlayTop';
 
 // Readers can switch the hover lens off entirely (some prefer no lens at all).
-// Remembered across pages and sessions.
-const LENS_PREF_KEY = 'sl-magnifier-lens';
+// Remembered across pages and sessions. The key is versioned: the lens is on
+// by default, and bumping the suffix forgets stale "off" preferences so the
+// default takes effect again — done when the lens stopped capturing scroll
+// (#3137), which removed the main reason anyone had turned it off.
+const LENS_PREF_KEY = 'sl-magnifier-lens-v2';
 
 interface ImageWithMagnifierProps {
   src: string;
@@ -302,6 +305,15 @@ export default function ImageWithMagnifier({
     setFullImageDimensions({ width: 0, height: 0 });
     setUseFallback(false);
     setHiResDisplayReady(false);
+
+    // Page navigation drops out of inline zoom back to the reading view of the
+    // NEW page. Without this the next page opens stuck at the previous page's
+    // zoom/pan (the reading <img> is unmounted in zoom mode, so it never shows
+    // the new scan) — "next page doesn't reset / move to the next image".
+    zoomModeRef.current = false;
+    panZoomRef.current = { scale: 1, x: 0, y: 0 };
+    setZoomMode(false);
+    setPanZoom({ scale: 1, x: 0, y: 0 });
 
     // Check if image is already cached/loaded (fixes race condition on initial render)
     // Use a small timeout to let the img element mount first


### PR DESCRIPTION
Follow-ups to the magnifier work (#3137/#3140/#3144), from reader feedback.

## 1. Inline zoom didn't reset when you change pages

**Bug:** In pan/zoom mode, navigating to the next page left the pane stuck — the image didn't reset or advance to the new scan.

**Cause:** the `src`-change effect reset loading state but never touched `zoomMode`/`panZoom`. Since the reading `<img>` is unmounted while zoomed, the new page's scan was never rendered, and the stale pan/zoom transform stayed.

**Fix:** on page navigation (src change), drop back to the reading view of the new page and clear pan/zoom.

## 2. Magnifier lens on by default

The lens already defaults on (`useState(true)`), but the saved preference is sticky — anyone who once turned it off stayed off. The reason to disable it (it used to capture scroll) went away in #3137, so bump the `localStorage` key (`sl-magnifier-lens` -> `-v2`) to forget stale "off" preferences. The toggle still works and persists to the new key.

## Scope
One file, `ImageWithMagnifier.tsx`. `tsc` clean. The `set-state-in-effect` lint note on the new reset lines is the same class already present in this file on `main` and is non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)