### PR TITLE
fix(proxy): stop the soft bot-limiter clamping real readers to ~2 pages

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -111,7 +111,16 @@ We respond within 24 hours. Let's build something remarkable.
  * Real browsers send Accept-Language and Sec-Fetch-Mode headers.
  * Missing both is a strong signal of automated traffic.
  */
-function looksLikeBot(request: NextRequest): boolean {
+// Read-only content APIs the reader fans out to as a human turns pages
+// (BookPagesSection's "load more", per-page trace alignment, etc.). These are
+// already protected at the app layer — the anti-bulk budget (api-budget.ts) and
+// the bot page-gate (bot-gate.ts, 20% cap) — so the crude header heuristic below
+// only ever produced false positives here.
+function isContentReadPath(pathname: string): boolean {
+  return pathname.startsWith('/api/books/') || pathname.startsWith('/api/pages/');
+}
+
+export function looksLikeBot(request: NextRequest): boolean {
   const ua = request.headers.get('user-agent') || '';
 
   // No UA at all — definitely not a browser
@@ -123,7 +132,16 @@ function looksLikeBot(request: NextRequest): boolean {
   // Explicit bot/crawler/spider UA strings
   if (/bot|crawl|spider|scrape|fetch|http|wget|curl|python|java\/|php\//i.test(ua)) return true;
 
-  // Missing both Accept-Language and Sec-Fetch-Mode — no browser omits both
+  // Missing both Accept-Language and Sec-Fetch-Mode — a decent bot signal, but
+  // privacy browsers, in-app webviews, and some corporate proxies strip these
+  // from real people too. On read-only content GETs that heuristic clamped real
+  // readers to ~2 pages (the reader's per-page /api fan-out trips the 10-req/60s
+  // soft limiter below), so skip it there — those paths are already app-layer
+  // protected. Keep it for writes and every other endpoint.
+  const isContentRead =
+    request.method === 'GET' && isContentReadPath(request.nextUrl.pathname);
+  if (isContentRead) return false;
+
   const hasAcceptLang = !!request.headers.get('accept-language');
   const hasSecFetch = !!request.headers.get('sec-fetch-mode');
   if (!hasAcceptLang && !hasSecFetch) return true;

--- a/tests/unit/proxy-bot-limiter-content-reads.test.ts
+++ b/tests/unit/proxy-bot-limiter-content-reads.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { looksLikeBot } from '@/proxy';
+
+// Regression guard for the "can't read more than 2 pages" report.
+//
+// The soft bot rate-limiter (src/proxy.ts) 429s any request looksLikeBot()
+// flags on /api/*. One of its signals is "missing BOTH accept-language AND
+// sec-fetch-mode" — a decent bot tell, but privacy browsers, in-app webviews,
+// and some corporate proxies strip those from real people too. The reader fans
+// out to /api/books/* per page, so a misclassified human hit the 10-req/60s cap
+// after ~2 pages. Content-read GETs are already protected at the app layer
+// (api-budget + bot page-gate), so that header heuristic is now skipped there.
+//
+// These assertions pin the fix: real readers pass on content GETs, while
+// obvious bots and any non-content / write traffic stay classified.
+
+function req(
+  pathname: string,
+  { method = 'GET', ua = 'Mozilla/5.0 (X11; Linux) Gecko/20100101 Firefox/128.0', headers = {} as Record<string, string> } = {},
+): NextRequest {
+  return new NextRequest(`https://sourcelibrary.org${pathname}`, {
+    method,
+    headers: { 'user-agent': ua, ...headers },
+  });
+}
+
+describe('looksLikeBot — content-read exemption', () => {
+  it('does NOT flag a header-stripped real browser on a content-read GET', () => {
+    // No accept-language, no sec-fetch-mode, but a normal browser UA.
+    expect(looksLikeBot(req('/api/books/abc123'))).toBe(false);
+    expect(looksLikeBot(req('/api/pages/xyz/revisions'))).toBe(false);
+  });
+
+  it('still flags header-stripped traffic on non-content paths', () => {
+    expect(looksLikeBot(req('/api/search'))).toBe(true);
+    expect(looksLikeBot(req('/api/collections'))).toBe(true);
+  });
+
+  it('still flags writes to content paths (exemption is GET-only)', () => {
+    expect(looksLikeBot(req('/api/books/abc123/dedicate', { method: 'POST' }))).toBe(true);
+  });
+
+  it('still flags an obvious bot UA even on a content-read GET', () => {
+    expect(looksLikeBot(req('/api/books/abc123', { ua: 'curl/8.4.0' }))).toBe(true);
+    expect(looksLikeBot(req('/api/books/abc123', { ua: 'python-requests/2.31' }))).toBe(true);
+    expect(looksLikeBot(req('/api/books/abc123', { ua: 'GPTBot/1.0' }))).toBe(true);
+  });
+
+  it('does not flag a normal browser with full headers anywhere', () => {
+    const full = { 'accept-language': 'en-US,en;q=0.9', 'sec-fetch-mode': 'navigate' };
+    expect(looksLikeBot(req('/api/search', { headers: full }))).toBe(false);
+    expect(looksLikeBot(req('/api/books/abc123', { headers: full }))).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3147

## Problem
A reader reported being unable to read past ~2 pages on any book (*"no puedo leer más de 2 páginas sin importar el libro"*). It's not a paywall — the book was fully processed and reading works at scale. The cause is the soft bot rate-limiter in `src/proxy.ts`: `looksLikeBot()` flags any request missing **both** `accept-language` and `sec-fetch-mode`, which privacy browsers / in-app webviews / corporate proxies strip from real people. The reader fans out to `/api/books/*` per page, so a misclassified human trips the 10-req/60s cap after ~2 pages.

## Change
- Skip the header-absence heuristic for **read-only content GETs** (`/api/books/*`, `/api/pages/*`). Those are already protected at the app layer — the anti-bulk budget (`api-budget.ts`) and the bot page-gate (`bot-gate.ts`, 20% cap) — so the crude proxy heuristic only ever false-positived there.
- Obvious bot UAs (`curl`/`python`/`GPTBot`…) and **all writes / non-content endpoints** stay classified and rate-limited exactly as before.
- Export `looksLikeBot` and add `tests/unit/proxy-bot-limiter-content-reads.test.ts` (5 behavioral assertions, all passing).

## Scope / out of scope
- Touches only the soft in-memory limiter's classification. Does **not** change `BLOCKED_BOT_RE` (the hard edge 403), the app-layer bot-gate, or the Cloudflare layer — the other two crawler-gate layers are unchanged.
- No tenant-routing paths touched.

## Verification
- `npx tsc --noEmit` — clean.
- `npx vitest run tests/unit/proxy-bot-limiter-content-reads.test.ts` — 5/5 pass: header-stripped browser passes on content GETs; still flagged on `/api/search`, on POSTs, and for bot UAs; full-header browser passes everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)