### PR TITLE
fix(blog): post hero images on social share cards (og:image + twitter:image)

### DIFF
--- a/src/app/blog/10000-books/page.tsx
+++ b/src/app/blog/10000-books/page.tsx
@@ -22,6 +22,10 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6909aba7cf28baa1b4caef69/5.jpg' }],
+  },
   alternates: {
     canonical: '/blog/10000-books',
   },

--- a/src/app/blog/2000-first-translations/page.tsx
+++ b/src/app/blog/2000-first-translations/page.tsx
@@ -21,6 +21,10 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://sourcelibrary.org/og-image.png' }],
+  },
 };
 
 // --- Static data from MongoDB aggregation (March 2026) ---

--- a/src/app/blog/astrological-diagrams/page.tsx
+++ b/src/app/blog/astrological-diagrams/page.tsx
@@ -12,6 +12,10 @@ export const metadata: Metadata = {
     description: 'A visual tour from the 10th-century Dunhuang Star Chart to Kepler\'s cosmic harmonics — the original diagrams that mapped humanity\'s relationship to the heavens.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6952dac677f38f6761bc683a/13.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6952dac677f38f6761bc683a/13.jpg' }],
+  },
   alternates: {
     canonical: '/blog/astrological-diagrams',
   },

--- a/src/app/blog/autonomous-agents/page.tsx
+++ b/src/app/blog/autonomous-agents/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'A human curator and three autonomous AI agents working in parallel imported 950 books in a single weekend. The architecture and the lessons.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/695230c6ab34727b1f044784/9.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/695230c6ab34727b1f044784/9.jpg' }],
+  },
   alternates: {
     canonical: '/blog/autonomous-agents',
   },

--- a/src/app/blog/cannabis-bangue/page.tsx
+++ b/src/app/blog/cannabis-bangue/page.tsx
@@ -8,9 +8,14 @@ export const metadata: Metadata = {
   description:
     'In 1689 a sea-captain set a sample of "bangue" on Robert Hooke\'s coffeehouse table, and the Royal Society met cannabis. But the plant had two lives, and the West had been forgetting one of them for two thousand years. A tour through sixty books in twelve languages.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/69ef286185daccce30f2ca01/390.jpg', alt: 'Botanical woodcut of the cannabis plant labelled \'Bangue\' in Cristóvão da Costa\'s Tractado de las Drogas y Medicinas de las Indias Orientales, 1578' }],
     title: 'Theire Soe Admirable Herbe: How the West Forgot, and Remembered, Cannabis',
     description:
       'A sea-captain, a coffeehouse, and the Royal Society\'s first account of cannabis — and the two-thousand-year history it forgot. Sixty books, twelve languages.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/69ef286185daccce30f2ca01/390.jpg', alt: 'Botanical woodcut of the cannabis plant labelled \'Bangue\' in Cristóvão da Costa\'s Tractado de las Drogas y Medicinas de las Indias Orientales, 1578' }],
   },
   alternates: {
     canonical: '/blog/cannabis-bangue',

--- a/src/app/blog/carbon-ledger/page.tsx
+++ b/src/app/blog/carbon-ledger/page.tsx
@@ -26,10 +26,15 @@ export const metadata: Metadata = {
   description:
     "Source Library has OCR'd 4.1 million pages and translated almost all of them into English using AI. We logged every API call. This is what it cost — in dollars, tokens, and carbon.",
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/gallery/a5d0c381-d4ea-42cd-8864-44457e7fda33/69500509f426a210d109c5bd-0.jpg', alt: 'Allegorical frontispiece of Athanasius Kircher\'s Ars Magna Lucis et Umbrae (1671)' }],
     title: 'The Carbon Ledger of a Digital Library',
     description:
       "4.1 million pages, OCR'd and translated by AI. We logged every API call. This is what it cost — in dollars, tokens, and carbon.",
     type: 'article',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/gallery/a5d0c381-d4ea-42cd-8864-44457e7fda33/69500509f426a210d109c5bd-0.jpg', alt: 'Allegorical frontispiece of Athanasius Kircher\'s Ars Magna Lucis et Umbrae (1671)' }],
   },
   alternates: { canonical: '/blog/carbon-ledger' },
 };

--- a/src/app/blog/cellulae/page.tsx
+++ b/src/app/blog/cellulae/page.tsx
@@ -8,8 +8,13 @@ export const metadata: Metadata = {
   description:
     'A word on page 32 of a medieval manuscript launched modern biology. The argument on page 33 helped criminalize rape victims for eight centuries. They were written by the same man.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/695677fdbe7c607c5f03b2d9/717.jpg', alt: 'Scientific plate from Philosophical Transactions of the Royal Society, 1694' }],
     title: 'Cellulae: Biology, Law, and the Dangers of Careful Reasoning',
     description: 'A word on page 32 launched modern biology. The argument on page 33 helped criminalize rape victims for eight centuries. Written by the same man, in the same manuscript.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/695677fdbe7c607c5f03b2d9/717.jpg', alt: 'Scientific plate from Philosophical Transactions of the Royal Society, 1694' }],
   },
   alternates: {
     canonical: '/blog/cellulae',

--- a/src/app/blog/chakra-tradition/page.tsx
+++ b/src/app/blog/chakra-tradition/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'Digitizing and translating the primary tantric sources on chakras, nadis, and kundalini — many for the first time in any Western language.',
     images: [{ url: 'https://iiif.wellcomecollection.org/image/b33599051_0001.jp2/full/1000,/0/default.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://iiif.wellcomecollection.org/image/b33599051_0001.jp2/full/1000,/0/default.jpg' }],
+  },
   alternates: {
     canonical: '/blog/chakra-tradition',
   },

--- a/src/app/blog/clustering/page.tsx
+++ b/src/app/blog/clustering/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'What Does a Library of 3,400 Rare Books Look Like? - Research Notes - Source Library',
   description: 'We embedded 3,400 historical book summaries, clustered them with UMAP and HDBSCAN, and discovered 34 curated groupings spanning seven intellectual traditions — from early modern alchemy to Sanskrit astronomy to Chinese military encyclopedias.',
   openGraph: {
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6952dac677f38f6761bc683a/13.jpg', alt: 'Integra Naturae Speculum by Robert Fludd, 1617' }],
     title: 'What Does a Library of 3,400 Rare Books Look Like?',
     description: 'Embedding-based clustering reveals 34 curated groupings across seven intellectual traditions in one of the largest digitized rare book collections.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6952dac677f38f6761bc683a/13.jpg', alt: 'Integra Naturae Speculum by Robert Fludd, 1617' }],
   },
   alternates: {
     canonical: '/blog/clustering',

--- a/src/app/blog/confident-hallucinator/page.tsx
+++ b/src/app/blog/confident-hallucinator/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'The Confident Hallucinator - Research Notes - Source Library',
   description: 'AI OCR evaluation across five scripts and three Gemini model tiers. A model can be perfectly consistent and completely wrong. Thinking mode fixes what model size cannot.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6956eaf4f23ebf30578dba35/221.jpg', alt: 'Comparative table of five scripts from Agrippa\'s Occult Philosophy, 1531' }],
     title: 'The Confident Hallucinator',
     description: 'AI OCR evaluation across Latin, Tibetan, Arabic, Hebrew, and Sanskrit reveals that consistency alone is a dangerous quality signal — and thinking mode is the cure.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6956eaf4f23ebf30578dba35/221.jpg', alt: 'Comparative table of five scripts from Agrippa\'s Occult Philosophy, 1531' }],
   },
   alternates: {
     canonical: '/blog/confident-hallucinator',

--- a/src/app/blog/counting-first-translations/page.tsx
+++ b/src/app/blog/counting-first-translations/page.tsx
@@ -13,6 +13,10 @@ export const metadata: Metadata = {
       'A two-sided census of Source Library\'s first-translation claim: measuring both false positives and missed firsts with stratified sampling and per-book AI adjudication.',
     images: [{ url: 'https://images.sourcelibrary.org/archived/69af0a0a4c57359b8d2d0f49/1.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/69af0a0a4c57359b8d2d0f49/1.jpg' }],
+  },
   alternates: {
     canonical: '/blog/counting-first-translations',
   },

--- a/src/app/blog/counting-the-gap/page.tsx
+++ b/src/app/blog/counting-the-gap/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'We Spent a Day Counting What Hasn\'t Been Translated - Research Notes - Source Library',
   description: 'We downloaded the entire Library of Congress catalog, scraped a Renaissance bibliography, and matched it all against 1.6 million early modern editions. Here\'s what happened.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/pages/697c8e0fbaa544415f85b6c6/0132-full.jpg', alt: 'Tree of Knowledge of Good and Evil from Secret Symbols of the Rosicrucians, 1785' }],
     title: 'We Spent a Day Counting What Hasn\'t Been Translated',
     description: 'We downloaded the entire Library of Congress catalog, scraped a Renaissance bibliography, and matched it all against 1.6 million early modern editions.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/pages/697c8e0fbaa544415f85b6c6/0132-full.jpg', alt: 'Tree of Knowledge of Good and Evil from Secret Symbols of the Rosicrucians, 1785' }],
   },
   alternates: {
     canonical: '/blog/counting-the-gap',

--- a/src/app/blog/cuneiform-ocr/page.tsx
+++ b/src/app/blog/cuneiform-ocr/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'Eight experiments testing Gemini and Claude on cuneiform tablets — the oldest writing system on Earth. Claude Opus breaks through the 15% accuracy ceiling.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/blog/cuneiform/P464358_d-sBPv8Z5dT88Vwi9ZcuAMnSz4nYflrw.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/blog/cuneiform/P464358_d-sBPv8Z5dT88Vwi9ZcuAMnSz4nYflrw.jpg' }],
+  },
   alternates: {
     canonical: '/blog/cuneiform-ocr',
   },

--- a/src/app/blog/demonology/page.tsx
+++ b/src/app/blog/demonology/page.tsx
@@ -12,6 +12,10 @@ export const metadata: Metadata = {
     description: 'The Hermetic daemon is your cosmic guardian; the Christian demon is a fallen angel. Source Library holds the texts that document this extraordinary reversal.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6953b56577f38f6761bd979d/62.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6953b56577f38f6761bd979d/62.jpg' }],
+  },
   alternates: {
     canonical: '/blog/demonology',
   },

--- a/src/app/blog/did-an-ai-write-the-encyclical/page.tsx
+++ b/src/app/blog/did-an-ai-write-the-encyclical/page.tsx
@@ -8,9 +8,14 @@ export const metadata: Metadata = {
   description:
     "Detectors flagged Magnifica Humanitas as 46% AI-written; the headline was 127 em-dashes vs zero in a comparison encyclical. We re-ran the test locally against eight human encyclicals. The smoking gun is a baseline-selection artifact.",
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6990505e7d19f3f2aac1e2b7/5.jpg', alt: 'Frontispiece of Athanasius Kircher\'s Turris Babel (1679): a draftsman sketches the half-built Tower of Babel on a tablet while a sage and a general look on, beneath a radiant divine eye — the encyclical\'s own central image.' }],
     title: "Did an AI Write the Pope's AI Encyclical?",
     description:
       'Detectors flagged Magnifica Humanitas as 46% AI-written. We re-ran the test against eight human encyclicals — and the evidence dissolves. A note on why baselines decide everything.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6990505e7d19f3f2aac1e2b7/5.jpg', alt: 'Frontispiece of Athanasius Kircher\'s Turris Babel (1679): a draftsman sketches the half-built Tower of Babel on a tablet while a sage and a general look on, beneath a radiant divine eye — the encyclical\'s own central image.' }],
   },
   alternates: {
     canonical: '/blog/did-an-ai-write-the-encyclical',

--- a/src/app/blog/did-the-ai-read-this/page.tsx
+++ b/src/app/blog/did-the-ai-read-this/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'Did the AI Read This? - Research Notes - Source Library',
   description: 'A Bayesian survey of which books in our 16,871-volume OCR\'d corpus are already in frontier-model training data. About 43% are confidently new to AI; about 21% are confidently in training.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/9cafe1ee-dd5a-4dcf-ac9a-803ca75f5bb4/12.jpg', alt: 'Title page of Cornelius Drebbel\'s Tractatus duo de Natura Elementorum (Hamburg, 1621)' }],
     title: 'Did the AI Read This?',
     description: 'Mapping which books in the library are in frontier-model training data, with a Bayesian fusion of bibliographic priors and behavioural probes.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/9cafe1ee-dd5a-4dcf-ac9a-803ca75f5bb4/12.jpg', alt: 'Title page of Cornelius Drebbel\'s Tractatus duo de Natura Elementorum (Hamburg, 1621)' }],
   },
   alternates: {
     canonical: '/blog/did-the-ai-read-this',

--- a/src/app/blog/does-ai-get-religion/page.tsx
+++ b/src/app/blog/does-ai-get-religion/page.tsx
@@ -8,9 +8,14 @@ export const metadata: Metadata = {
   description:
     "The longest page in our library is one leaf of a Javanese Old Testament that the AI translated into 491,418 characters of 'generations of generations of generations.' It does this only with scripture.",
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Does the AI Get Religion?',
     description:
       "An AI translation model that picked up a book of sacred genealogies and could not stop generating generations. It only happens with scripture.",
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
   },
   alternates: {
     canonical: '/blog/does-ai-get-religion',

--- a/src/app/blog/fechner-bohme/page.tsx
+++ b/src/app/blog/fechner-bohme/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'Gustav Fechner founded experimental psychology — but his real goal was proving the universe has a soul. His untranslated German works reveal the mysticism behind the Weber-Fechner law.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6867c580aadfee9e955eca92/4.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6867c580aadfee9e955eca92/4.jpg' }],
+  },
   alternates: {
     canonical: '/blog/fechner-bohme',
   },

--- a/src/app/blog/fire-horse/page.tsx
+++ b/src/app/blog/fire-horse/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'Double yang fire, a 17th-century arsonist, and the original texts behind Chinese astrology — from the sexagenary cycle to the I Ching.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6992cac0d4d545ae73feea71/6.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6992cac0d4d545ae73feea71/6.jpg' }],
+  },
   alternates: {
     canonical: '/blog/fire-horse',
   },

--- a/src/app/blog/first-translation-methodology/page.tsx
+++ b/src/app/blog/first-translation-methodology/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'The methodology behind Source Library\'s first-translation classification: AI enrichment, bibliographic heuristics, and human review.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6952587bab34727b1f045546/3.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/6952587bab34727b1f045546/3.jpg' }],
+  },
   alternates: {
     canonical: '/blog/first-translation-methodology',
   },

--- a/src/app/blog/first-translations/page.tsx
+++ b/src/app/blog/first-translations/page.tsx
@@ -12,6 +12,10 @@ export const metadata: Metadata = {
     description: 'Alchemical lab manuals, radical theology, women alchemists, Sanskrit astrology manuscripts, and founding texts of biblical criticism — over 900 now fully translated into English for the first time.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/4d4089b9-9227-4cc5-b0a2-9b06ee731061/2.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/4d4089b9-9227-4cc5-b0a2-9b06ee731061/2.jpg' }],
+  },
   alternates: {
     canonical: '/blog/first-translations',
   },

--- a/src/app/blog/fish-voiced-priest/page.tsx
+++ b/src/app/blog/fish-voiced-priest/page.tsx
@@ -19,6 +19,10 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/manuscripts/marciana-gr-299/208.jpg' }],
+  },
   alternates: {
     canonical: '/blog/fish-voiced-priest',
   },

--- a/src/app/blog/hidden-engineers/page.tsx
+++ b/src/app/blog/hidden-engineers/page.tsx
@@ -12,6 +12,10 @@ export const metadata: Metadata = {
     description: 'Before engineering was a discipline, its knowledge lived inside alchemy, natural magic, and mystical philosophy. The primary sources tell a stranger story than the textbooks.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/695230c6ab34727b1f044784/9.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/695230c6ab34727b1f044784/9.jpg' }],
+  },
   alternates: {
     canonical: '/blog/hidden-engineers',
   },

--- a/src/app/blog/hieroglyph-ocr/page.tsx
+++ b/src/app/blog/hieroglyph-ocr/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'Four approaches to AI hieroglyphic OCR. Four failures. What the results reveal about the limits of visual language models.',
     images: [{ url: 'https://iiif.archive.org/iiif/egyptianreadingb00budguoft$80/full/1000,/0/default.jpg', width: 1000, height: 1400 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://iiif.archive.org/iiif/egyptianreadingb00budguoft$80/full/1000,/0/default.jpg' }],
+  },
   alternates: {
     canonical: '/blog/hieroglyph-ocr',
   },

--- a/src/app/blog/history-of-astrology/page.tsx
+++ b/src/app/blog/history-of-astrology/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'From Babylonian omen texts to Kepler\'s geometrical cosmos — pursued independently across Greek, Indian, Arabic, Chinese, and European traditions.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/699068948034a3640265b709/311.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/699068948034a3640265b709/311.jpg' }],
+  },
   alternates: {
     canonical: '/blog/history-of-astrology',
   },

--- a/src/app/blog/history-of-classification/page.tsx
+++ b/src/app/blog/history-of-classification/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'Ten Thousand Years of Tagging: A History of How Humans Organize Knowledge - Research Notes - Source Library',
   description: 'From Callimachus at Alexandria to LLM-assigned faceted tags, the history of classification runs through books we actually have. Aristotle, Porphyry, Llull, Leibniz, Linnaeus, Ranganathan, and the system we built from all of them.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/pages/69773e18094afd77cbd39c0a/0021-full.jpg', alt: 'Minerva in a library with putti studying a globe, from Chemical Library, 1727' }],
     title: 'Ten Thousand Years of Tagging',
     description: 'The history of knowledge classification, told through the books that invented it — most of which are in our collection.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/pages/69773e18094afd77cbd39c0a/0021-full.jpg', alt: 'Minerva in a library with putti studying a globe, from Chemical Library, 1727' }],
   },
   alternates: {
     canonical: '/blog/history-of-classification',

--- a/src/app/blog/hogwarts-library/page.tsx
+++ b/src/app/blog/hogwarts-library/page.tsx
@@ -13,6 +13,10 @@ export const metadata: Metadata = {
       'Nicolas Flamel was real. So was Cornelius Agrippa. So was Paracelsus. The books behind the wizarding world — bestiaries, alchemy, grimoires, Kabbalah — read in modern English.',
     images: [{ url: 'https://upload.wikimedia.org/wikipedia/commons/9/9c/Joseph_Wright_of_Derby_The_Alchemist.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://upload.wikimedia.org/wikipedia/commons/9/9c/Joseph_Wright_of_Derby_The_Alchemist.jpg' }],
+  },
   alternates: {
     canonical: '/blog/hogwarts-library',
   },

--- a/src/app/blog/how-big-is-the-library/page.tsx
+++ b/src/app/blog/how-big-is-the-library/page.tsx
@@ -22,6 +22,10 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/gallery/a5d0c381-d4ea-42cd-8864-44457e7fda33/69500509f426a210d109c5bd-0.jpg' }],
+  },
   alternates: {
     canonical: '/blog/how-big-is-the-library',
   },

--- a/src/app/blog/how-long-to-translate/page.tsx
+++ b/src/app/blog/how-long-to-translate/page.tsx
@@ -8,9 +8,14 @@ export const metadata: Metadata = {
   description:
     'We measured the rate of new Latin translations and counted what is left. At the current pace, finishing the Latin Renaissance alone would take roughly ten thousand years.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'How Long Would It Take to Translate the Renaissance?',
     description:
       'We did the division. At the current rate of scholarly translation, the Latin Renaissance alone would take about ten thousand years to finish.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
   },
   alternates: {
     canonical: '/blog/how-long-to-translate',

--- a/src/app/blog/iiif/page.tsx
+++ b/src/app/blog/iiif/page.tsx
@@ -19,6 +19,10 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/pages/69bd9e336120d54bd037bf37/0010.jpg' }],
+  },
   alternates: {
     canonical: '/blog/iiif',
   },

--- a/src/app/blog/incunabula-knowledge-graph/page.tsx
+++ b/src/app/blog/incunabula-knowledge-graph/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'Mapping the Incunabula: A Knowledge Graph of the First Printed Books - Research Notes - Source Library',
   description: 'An interactive force-directed graph connecting nearly 1,000 incunabula by author, printer, place, and subject — revealing the networks behind the printing revolution.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6909d654cf28baa1b4cb0269/4.jpg', alt: 'Allegorical printing press vignette from Zimmermann, 1751' }],
     title: 'Mapping the Incunabula: A Knowledge Graph of the First Printed Books',
     description: 'An interactive force-directed graph connecting nearly 1,000 incunabula by author, printer, place, and subject.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6909d654cf28baa1b4cb0269/4.jpg', alt: 'Allegorical printing press vignette from Zimmermann, 1751' }],
   },
   alternates: {
     canonical: '/blog/incunabula-knowledge-graph',

--- a/src/app/blog/indigenous-traditions/page.tsx
+++ b/src/app/blog/indigenous-traditions/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: '90+ volumes documenting indigenous spiritual traditions from every inhabited continent — Navajo ceremonies, Yoruba cosmology, Celtic place-lore, Norse Eddas.',
     images: [{ url: 'https://archive.org/download/gri_33125009545621/page/n23/full/pct:50/0/default.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://archive.org/download/gri_33125009545621/page/n23/full/pct:50/0/default.jpg' }],
+  },
   alternates: {
     canonical: '/blog/indigenous-traditions',
   },

--- a/src/app/blog/invisible-hand/page.tsx
+++ b/src/app/blog/invisible-hand/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'Before Adam Smith, Florentine merchants, Salamanca theologians, and Cambridge Platonists built the intellectual foundations of market theory.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/69520c46ab34727b1f044141/7.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/69520c46ab34727b1f044141/7.jpg' }],
+  },
   alternates: {
     canonical: '/blog/invisible-hand',
   },

--- a/src/app/blog/man-his-own-maker/page.tsx
+++ b/src/app/blog/man-his-own-maker/page.tsx
@@ -13,6 +13,10 @@ export const metadata: Metadata = {
       'A long read on Leo XIV&rsquo;s AI encyclical Magnifica Humanitas, Pico della Mirandola&rsquo;s banned Oration on the Dignity of Man, and what artificial intelligence forces us to decide about the soul.',
     images: [{ url: 'https://images.sourcelibrary.org/archived/adad5f6d-4f68-4009-9406-d0e083cf0acc/3.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/adad5f6d-4f68-4009-9406-d0e083cf0acc/3.jpg' }],
+  },
   alternates: {
     canonical: '/blog/man-his-own-maker',
   },

--- a/src/app/blog/mcp-server/page.tsx
+++ b/src/app/blog/mcp-server/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'An MCP server that gives Claude direct access to Source Library — thousands of historical texts with translations, a cross-book entity graph, and 90,000+ illustrations.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/699065973dc2ed39a49f1e71/4.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/699065973dc2ed39a49f1e71/4.jpg' }],
+  },
   alternates: {
     canonical: '/blog/mcp-server',
   },

--- a/src/app/blog/naked-philosophers/page.tsx
+++ b/src/app/blog/naked-philosophers/page.tsx
@@ -8,9 +8,14 @@ export const metadata: Metadata = {
   description:
     'In 327 BCE Alexander’s fleet-captain was sent to sit before fifteen naked, motionless sages who would not come when the king summoned them. Nineteen centuries later a Rosicrucian alchemist enrolled those same "gymnosophists" as ancestors of his Brotherhood. A story told through eight books in the library.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/gallery/69c1bd308522835be8468096/69c1bd308522835be8468180-0.jpg', alt: 'Alexander the Great, crowned and haloed, gesturing toward three naked bearded philosophers among flowering plants — labelled in the manuscript\'s Armenian as \'the Brahmans who speak.\' A 1544 Armenian Romance of Alexander miniature' }],
     title: 'The Naked Philosophers: How Alexander’s India Became the Rosicrucians’ Ancestor',
     description:
       'Power summons wisdom, and wisdom declines to come. The gymnosophists from Strabo and the Aldine Philostratus to Michael Maier’s College of the Rosy Cross.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/gallery/69c1bd308522835be8468096/69c1bd308522835be8468180-0.jpg', alt: 'Alexander the Great, crowned and haloed, gesturing toward three naked bearded philosophers among flowering plants — labelled in the manuscript\'s Armenian as \'the Brahmans who speak.\' A 1544 Armenian Romance of Alexander miniature' }],
   },
   alternates: {
     canonical: '/blog/naked-philosophers',

--- a/src/app/blog/ocr-consistency/page.tsx
+++ b/src/app/blog/ocr-consistency/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: '1,448 duplicate scans of the same physical pages, OCR\'d independently. The results quantify something nobody has measured before.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/uploads/697b079ac66889d6835b576a/697b09f386b3d3c458a4c04c.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/uploads/697b079ac66889d6835b576a/697b09f386b3d3c458a4c04c.jpg' }],
+  },
   alternates: {
     canonical: '/blog/ocr-consistency',
   },

--- a/src/app/blog/origin-story/page.tsx
+++ b/src/app/blog/origin-story/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'Where Source Library Came From - Research Notes - Source Library',
   description: 'From a single untranslated Ficino manuscript at the Embassy of the Free Mind to 5,000+ books and 2,000 first English translations — the origin story of Source Library.',
   openGraph: {
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/blog/ficino-bust-laptop.jpg', alt: 'Bronze bust of Marsilio Ficino with a laptop at the Embassy of the Free Mind' }],
     title: 'Where Source Library Came From',
     description: 'From a single untranslated Ficino manuscript to 5,000+ books — the origin story of Source Library.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/blog/ficino-bust-laptop.jpg', alt: 'Bronze bust of Marsilio Ficino with a laptop at the Embassy of the Free Mind' }],
   },
   alternates: {
     canonical: '/blog/origin-story',

--- a/src/app/blog/philosophers-stone/page.tsx
+++ b/src/app/blog/philosophers-stone/page.tsx
@@ -12,6 +12,10 @@ export const metadata: Metadata = {
     description: 'An allegorical emblem sequence, a universal salt, a red powder found in a bishop\'s tomb — eight primary sources, eight different answers.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/uploads/69804b952c52aad359879321/69804ceaefc8a337f6e2717b.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/uploads/69804b952c52aad359879321/69804ceaefc8a337f6e2717b.jpg' }],
+  },
   alternates: {
     canonical: '/blog/philosophers-stone',
   },

--- a/src/app/blog/progress-studies/page.tsx
+++ b/src/app/blog/progress-studies/page.tsx
@@ -12,6 +12,10 @@ export const metadata: Metadata = {
     description: 'Mokyr\'s "useful knowledge," Howes\'s "improving mentality," and Crawford\'s techno-humanism all predicted what 2,500 newly translated pre-industrial books confirm: innovation has deeper roots than anyone could read.',
     images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/695230c6ab34727b1f044784/9.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/695230c6ab34727b1f044784/9.jpg' }],
+  },
   alternates: {
     canonical: '/blog/progress-studies',
   },

--- a/src/app/blog/rashi-ocr/page.tsx
+++ b/src/app/blog/rashi-ocr/page.tsx
@@ -12,6 +12,10 @@ export const metadata: Metadata = {
     description: 'AI reads Arabic and Sanskrit fine. On Rashi script it hallucinates — and our quality metrics gave it a passing grade.',
     images: [{ url: 'https://images.sourcelibrary.org/archived/6990630be7b7642c081de08b/8.jpg', width: 1200, height: 1600 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6990630be7b7642c081de08b/8.jpg' }],
+  },
   alternates: {
     canonical: '/blog/rashi-ocr',
   },

--- a/src/app/blog/reading-classical-chinese/page.tsx
+++ b/src/app/blog/reading-classical-chinese/page.tsx
@@ -14,6 +14,10 @@ export const metadata: Metadata = {
     description: 'Measuring AI OCR and translation on the Chinese classics — against ctext.org for the characters, and against James Legge for the English.',
     images: [{ url: HERO, width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: HERO }],
+  },
   alternates: { canonical: '/blog/reading-classical-chinese' },
 };
 

--- a/src/app/blog/rithmomachia/page.tsx
+++ b/src/app/blog/rithmomachia/page.tsx
@@ -17,6 +17,10 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/699fcd499ff0f1d2c4518062/498.jpg' }],
+  },
   alternates: {
     canonical: '/blog/rithmomachia',
   },

--- a/src/app/blog/singularity-1486/page.tsx
+++ b/src/app/blog/singularity-1486/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'Pico della Mirandola, Gustav Fechner, and Johannes Kepler wrote the source code for transhumanism, panpsychism, and the cosmic mind. The original texts, newly translated.',
     images: [{ url: 'https://images.sourcelibrary.org/archived/6fc11c7d-782a-47c3-a855-f3b4415e797b/10.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6fc11c7d-782a-47c3-a855-f3b4415e797b/10.jpg' }],
+  },
   alternates: {
     canonical: '/blog/singularity-1486',
   },

--- a/src/app/blog/the-deletion/page.tsx
+++ b/src/app/blog/the-deletion/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'The Deletion: How Claude Code accidentally deleted 4,758 books — Research Notes — Source Library',
   description: 'A postmortem of the afternoon a Claude Code session in one of my ten open terminals hard-deleted nearly 5,000 books from production. With primary sources — the actual prompts and the actual postmortem.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'The Deletion: How Claude Code accidentally deleted 4,758 books',
     description: 'A postmortem of the afternoon a Claude Code session in one of my ten open terminals hard-deleted nearly 5,000 books from production.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
   },
   alternates: {
     canonical: '/blog/the-deletion',

--- a/src/app/blog/the-giants-werent-translated/page.tsx
+++ b/src/app/blog/the-giants-werent-translated/page.tsx
@@ -8,9 +8,14 @@ export const metadata: Metadata = {
   description:
     'The most-read book on Source Library, Robert Fludd&rsquo;s Utriusque Cosmi Historia, has never been translated into English in full. Neither have the major works of Kircher, and Ficino only reached English this century. Why "first full translation" is still meaningful.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6952dac677f38f6761bc683a/13.jpg', alt: 'Robert Fludd&rsquo;s Integra Naturae, from Utriusque Cosmi Historia, 1617' }],
     title: 'The Giants Were Never Fully Translated',
     description:
       'The most-read book on Source Library has no complete English translation. Neither do the works of the men who made the canon.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6952dac677f38f6761bc683a/13.jpg', alt: 'Robert Fludd&rsquo;s Integra Naturae, from Utriusque Cosmi Historia, 1617' }],
   },
   alternates: {
     canonical: '/blog/the-giants-werent-translated',

--- a/src/app/blog/tibetan-ocr/page.tsx
+++ b/src/app/blog/tibetan-ocr/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'Testing Claude and Gemini on handwritten Tibetan from five Bhutanese monasteries. Modal Consistency Rate, cross-model agreement, and comparison to human translation.',
     images: [{ url: 'https://images.eap.bl.uk/EAP039/EAP039_1_4_277/10.jp2/full/1200,/0/default.jpg', width: 1200, height: 630 }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.eap.bl.uk/EAP039/EAP039_1_4_277/10.jp2/full/1200,/0/default.jpg' }],
+  },
   alternates: {
     canonical: '/blog/tibetan-ocr',
   },

--- a/src/app/blog/translation-collapse/page.tsx
+++ b/src/app/blog/translation-collapse/page.tsx
@@ -8,9 +8,14 @@ export const metadata: Metadata = {
   description:
     'How we found, measured, and repaired "translation collapse" — pages where the AI returns a fragment instead of a translation — and the two times our measurement was wrong before the model was.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/69b2f434f9f1ad2b3b15154a/9.jpg', alt: 'A page from Henri Estienne\'s 1589 edition of the fragments of Dicaearchus' }],
     title: 'Quality Control on Four Million Machine-Translated Pages',
     description:
       'Detecting and repairing translation collapse across a 4.25-million-page corpus, and what it takes to check a generative system at scale.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/69b2f434f9f1ad2b3b15154a/9.jpg', alt: 'A page from Henri Estienne\'s 1589 edition of the fragments of Dicaearchus' }],
   },
   alternates: {
     canonical: '/blog/translation-collapse',

--- a/src/app/blog/translation-rate/page.tsx
+++ b/src/app/blog/translation-rate/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'How Many Renaissance Books Get Translated Each Year? - Research Notes - Source Library',
   description: 'We queried 23,700+ records from the UNESCO Index Translationum, Library of Congress, and 20+ other translation catalogs to measure the annual rate of new English translations of early modern texts. The answer is smaller than anyone guesses.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/69528b19ab34727b1f04f2fe/8.jpg', alt: 'Arts and Crafts frontispiece from the Book of Divine Consolation of Angela of Foligno, 1909' }],
     title: 'How Many Renaissance Books Get Translated Each Year?',
     description: 'We queried 13,862 records from the UNESCO Index Translationum and 11 other translation catalogs. The answer is smaller than anyone guesses.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/69528b19ab34727b1f04f2fe/8.jpg', alt: 'Arts and Crafts frontispiece from the Book of Divine Consolation of Angela of Foligno, 1909' }],
   },
   alternates: {
     canonical: '/blog/translation-rate',

--- a/src/app/blog/translations-across-civilizations/page.tsx
+++ b/src/app/blog/translations-across-civilizations/page.tsx
@@ -20,6 +20,10 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/69938e765d28b693146d0f99/19.jpg' }],
+  },
   alternates: {
     canonical: '/blog/translations-across-civilizations',
   },

--- a/src/app/blog/untranslated-renaissance/page.tsx
+++ b/src/app/blog/untranslated-renaissance/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'How Much of the Renaissance Has Been Translated? We Tried to Count. - Research Notes - Source Library',
   description: 'We built the first draft of a translation census — matching 1.4 million early modern editions against every English translation catalog we could find. The results are provisional, incomplete, and worse than we expected.',
   openGraph: {
+    images: [{ url: 'https://api.digitale-sammlungen.de/iiif/image/v2/bsb11057772_00219/full/full/0/default.jpg', alt: 'Human head as microcosm mapping mental faculties, from Fludd\'s History of the Microcosm, 1619' }],
     title: 'How Much of the Renaissance Has Been Translated? We Tried to Count.',
     description: 'We matched 1.4 million early modern editions against every English translation catalog we could find. The results are provisional, incomplete, and worse than we expected.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://api.digitale-sammlungen.de/iiif/image/v2/bsb11057772_00219/full/full/0/default.jpg', alt: 'Human head as microcosm mapping mental faculties, from Fludd\'s History of the Microcosm, 1619' }],
   },
   alternates: {
     canonical: '/blog/untranslated-renaissance',

--- a/src/app/blog/visualizing-classification/page.tsx
+++ b/src/app/blog/visualizing-classification/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'Visualizing 20,000 Books Across Six Dimensions - Source Library',
   description: 'Interactive visualizations of Source Library\'s faceted classification: scatter plot, heatmap, Sankey flow, and chord diagram — showing how 17 traditions flow into 15 domains across 11 cultural spheres.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6990601f8cbcc9a4dba2c624/7.jpg', alt: 'Jyotisha classification tree in Sanskrit from the Celestial Tree of Natal Astrology' }],
     title: 'Visualizing 20,000 Books Across Six Dimensions',
     description: 'Four interactive D3 visualizations of a faceted library classification system.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6990601f8cbcc9a4dba2c624/7.jpg', alt: 'Jyotisha classification tree in Sanskrit from the Celestial Tree of Natal Astrology' }],
   },
   alternates: {
     canonical: '/blog/visualizing-classification',

--- a/src/app/blog/what-makes-a-good-scan/page.tsx
+++ b/src/app/blog/what-makes-a-good-scan/page.tsx
@@ -7,8 +7,13 @@ export const metadata: Metadata = {
   title: 'What Makes a Good Scan? - Research Notes - Source Library',
   description: 'Pixel statistics, AI judgment, and the moment a model rated a blank page 95/100. Designing a per-illustration quality system for 100,000 rare-book images.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/695592c47bd6d2cd1d61b10b/209.jpg', alt: 'Woodcut of Ramon Llull and disciples, with the alphabetum operis consequentis table beneath. Ars Inventiva Veritatis, 1515.' }],
     title: 'What Makes a Good Scan?',
     description: 'Pixel statistics, AI judgment, and the moment a model rated a blank page 95/100. Designing a per-illustration quality system for 100,000 rare-book images.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/695592c47bd6d2cd1d61b10b/209.jpg', alt: 'Woodcut of Ramon Llull and disciples, with the alphabetum operis consequentis table beneath. Ars Inventiva Veritatis, 1515.' }],
   },
   alternates: {
     canonical: '/blog/what-makes-a-good-scan',

--- a/src/app/blog/why-terminals-cant-edit/page.tsx
+++ b/src/app/blog/why-terminals-cant-edit/page.tsx
@@ -8,8 +8,13 @@ export const metadata: Metadata = {
   description:
     'Terminal emulators don\'t know what\'s on screen. They draw characters on a grid and forward keystrokes. That architectural decision from 1978 is why basic text editing feels broken in 2026.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Why You Can\'t Click to Place Your Cursor in a Terminal',
     description: 'The 1978 architecture decision that still shapes how 50 million developers work.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
   },
   alternates: {
     canonical: '/blog/why-terminals-cant-edit',

--- a/src/app/blog/word-alignment/page.tsx
+++ b/src/app/blog/word-alignment/page.tsx
@@ -8,9 +8,14 @@ export const metadata: Metadata = {
   description:
     'Click any English word to see the original that produced it. On-demand cross-lingual alignment powered by Gemini embeddings.',
   openGraph: {
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6953cc3677f38f6761be156e/383.jpg', alt: 'Fragment of Greek papyrus from Herculaneum, 1885' }],
     title: 'Reading Through the Translation',
     description:
       'Click any English word to see the original that produced it.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://images.sourcelibrary.org/archived/6953cc3677f38f6761be156e/383.jpg', alt: 'Fragment of Greek papyrus from Herculaneum, 1885' }],
   },
   alternates: {
     canonical: '/blog/word-alignment',

--- a/src/app/blog/worlds-largest-collection/page.tsx
+++ b/src/app/blog/worlds-largest-collection/page.tsx
@@ -20,6 +20,10 @@ export const metadata: Metadata = {
       },
     ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: 'https://sourcelibrary.org/og-image.png' }],
+  },
   alternates: {
     canonical: '/blog/worlds-largest-collection',
   },


### PR DESCRIPTION
## What

Sharing a blog post today gives a broken or generic social card. Two bugs, both in metadata merge behavior:

1. **24 posts had no `og:image` at all.** They define an `openGraph` block with only title/description — and Next.js metadata merge replaces the root layout's `openGraph` object wholesale, silently dropping the default image. Verified live on `/blog/cannabis-bangue`: no `og:image` tag → blank cards on Facebook/LinkedIn/Slack/iMessage.
2. **Every post showed the generic logo on X**, even the 34 that do set `openGraph.images`, because the root layout's `twitter.images` (the generic `/og-image.jpg`) wins the merge over per-post og images. Verified live on `/blog/fire-horse`: `og:image` = hero, `twitter:image` = generic logo.

## Change

- Add `openGraph.images` (the post's own `ContentHeader` hero + its alt text) to the posts missing it. Five posts with no hero image get the site default explicitly so the card is never image-less; `interlinear-experiment`'s card uses its in-body CDLI tablet photo.
- Add a `twitter` block mirroring the og image to **every** post, so X shows the hero too.

Applied via codemod for consistency; `reading-classical-chinese` (uses a `HERO` const) adjusted by hand.

## Out of scope

- **Root layout untouched.** Removing `twitter.images` from the root layout would fix X site-wide via og fallback, but ~40 non-blog surfaces define `openGraph` without images and would degrade from logo-card to image-less on X. Blog-local twitter blocks have zero blast radius.
- Book/author/category pages already generate cards via the `opengraph-image` file convention — untouched and verified working.
- No share-button UI; separate concern if wanted.

## Verify

After preview deploy, per post: `og:image` + `twitter:image` should both be the post hero (or explicit site default). Will curl-verify on the Vercel preview before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)