### PR TITLE
fix(search): lexical fallback for bare-surname / single-token semantic queries (#3141)

### DIFF
--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { semanticBookSearch, semanticPageSearchGlobal } from '@/lib/semantic-search';
+import { searchBooksCatalog } from '@/lib/books-catalog';
 import { getDb } from '@/lib/mongodb';
 import { logSearchQuery } from '@/lib/search-log';
 
@@ -150,16 +151,59 @@ export async function GET(request: NextRequest) {
         slug: thumbnailMap[b.book_id]?.slug || b.book_id,
       }));
 
+    // Lexical fallback for named-entity / single-token queries (#3141).
+    // Pure vector search returns nothing for a bare surname, proper noun, or
+    // title fragment ("hartmann", "Voynich", "fludd") — the embedding of a name
+    // has no conceptual neighbours above the floor, so this endpoint reported 0
+    // results despite us holding many editions (31 daily-agent "hartmann" hits,
+    // all zero). When semantic recall is empty, fall back to lexical trigram
+    // search on title/author/display_title so these queries surface the held
+    // editions. searchBooksCatalog already gates on visible:true && pages_count>0,
+    // so the hidden-book concern the semantic lane guards against doesn't apply.
+    let results: typeof enriched = enriched;
+    let mode: 'semantic' | 'lexical' = 'semantic';
+    if (enriched.length === 0) {
+      try {
+        const lexical = await searchBooksCatalog(searchQuery, { limit, language });
+        const filtered = lexical.filter(b => {
+          const y = typeof b.year === 'number' ? b.year : undefined;
+          if (yearMin !== undefined && (y === undefined || y < yearMin)) return false;
+          if (yearMax !== undefined && (y === undefined || y > yearMax)) return false;
+          return true;
+        });
+        if (filtered.length > 0) {
+          mode = 'lexical';
+          results = filtered.map(b => ({
+            book_id: b.id,
+            title: b.title,
+            author: b.author,
+            year: typeof b.year === 'number' ? b.year : null,
+            language: b.language,
+            summary_text: b.summary_text,
+            metadata: undefined,
+            // Exact lexical match on title/author — rank as high confidence so
+            // callers that sort by similarity keep these at the top.
+            similarity: 1,
+            thumbnail: b.thumbnail || null,
+            thumbnail_blob: b.thumbnail_blob || null,
+            slug: b.slug || b.id,
+          })) as unknown as typeof enriched;
+        }
+      } catch (e) {
+        console.warn('[semantic-search] lexical fallback failed:', e instanceof Error ? e.message : String(e));
+      }
+    }
+
     logSearchQuery({
       request, route: 'search.semantic.book', query: query!,
-      total: enriched.length, ms: Date.now() - _searchStart, ok: true,
-      filters: { language, year_min: yearMin, year_max: yearMax },
+      total: results.length, ms: Date.now() - _searchStart, ok: true,
+      filters: { language, year_min: yearMin, year_max: yearMax, mode },
     });
     return NextResponse.json({
-      results: enriched,
+      results,
       query,
-      total: enriched.length,
-      mode: 'semantic',
+      total: results.length,
+      mode,
     }, {
       headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
     });


### PR DESCRIPTION
## Problem
`hartmann` was the single highest-frequency zero-result query in the 30-day Reading Register window (31×) despite the catalogue holding ~16 visible Hartmann editions. Fixes issue #3141.

## Root cause
The zeros came from **`/api/search/semantic`** (route `search.semantic.book`), a pure pgvector endpoint — not from the site's user-facing search. Confirmed in `search_queries`:

- A daily external agent (HeadlessChrome) hit `search.semantic.book?q=Hartmann` once/day, `total=0` every time.
- Meanwhile `/api/search` (RRF/ladder) returned 12–26 and the site's `/api/search/unified` returned 8 — both fine.

A bare surname / proper noun / title fragment has no conceptual neighbours above the 0.55 similarity floor, so the embedding lane finds nothing. The zero-result tail is dominated by exactly this class: `Voynich`, `fludd`, `Paracelsus`, `Enoch`, `Augustine`, `Kybalion`, …

## Fix
When the semantic book lane returns 0 results above the floor, fall back to **lexical trigram search** (`searchBooksCatalog`) on title/author/display_title, honoring the `language` and `year_min`/`year_max` filters. `searchBooksCatalog` already gates on `visible:true && pages_count>0`, so the hidden-book concern the semantic lane guards against doesn't apply. The response reports `mode: 'lexical'` when the fallback fires.

The `/search` UI consumes this endpoint as a supplemental "related / conceptual" lane, deduped against keyword results — so the fallback can only add recall, never regress the primary results.

## Verification
- `npx tsc --noEmit` clean.
- Replicated the fallback query against Supabase: `Hartmann`→16, `Voynich`→1, `fludd`→20, `Augustine`→20 held editions returned.
- Confirmed via `search_queries` that these queries return 0 from the semantic lane today (so the fallback triggers).

## Out of scope
- Page-level semantic (`level=page`) — the zero-result data is entirely book-level; passage-concept search is a different use case, left untouched.
- Broader zero-result sweep / acquisition sizing (issue scope item 3) — this PR closes the recall failure; the sweep can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)