### PR TITLE
fix(seo): social-card images for collections, libraries, and hub pages

### DIFF
--- a/src/app/artist/[name]/page.tsx
+++ b/src/app/artist/[name]/page.tsx
@@ -163,6 +163,7 @@ export async function generateMetadata({ params }: ArtistPageProps): Promise<Met
     description: `Visual works by ${artistName} in Source Library's collection of rare historical prints, paintings, and drawings, digitized and catalogued with AI.`,
     alternates: { canonical: `/artist/${name}` },
     openGraph: {
+      images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
       title: `${artistName} — Artist — Source Library`,
       description: `Visual works by ${artistName} in Source Library`,
     },

--- a/src/app/beta/layout.tsx
+++ b/src/app/beta/layout.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: 'Source Library — Early Access',
   description: 'Sign up for early access to Source Library. 1,200+ rare Hermetic, alchemical, and esoteric texts digitized and translated into modern English.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Source Library — Early Access',
     description: 'Sign up for early access to Source Library. Rare Hermetic & Renaissance texts digitized and translated with AI.',
   },

--- a/src/app/categories/layout.tsx
+++ b/src/app/categories/layout.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
     canonical: '/categories',
   },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Categories - Source Library',
     description: 'Browse books by category: alchemy, astrology, Hermetica, Kabbalah, natural philosophy, and more.',
     type: 'website',

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
   description: 'Explore rare esoteric, alchemical, and philosophical texts organized by tradition: alchemy, Hermeticism, Kabbalah, Neoplatonism, Rosicrucianism, astrology, and more.',
   alternates: { canonical: '/categories' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Browse by Category — Source Library',
     description: 'Explore rare esoteric texts organized by tradition and subject.',
   },

--- a/src/app/collection-areas/[id]/page.tsx
+++ b/src/app/collection-areas/[id]/page.tsx
@@ -68,6 +68,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         description: `Browse ${area.description.toLowerCase()} in Source Library's collection of rare historical texts.`,
         alternates: { canonical: `/collection-areas/${id}` },
         openGraph: {
+            images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
             title: `${area.name} — Source Library`,
             description: area.description,
         },

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -61,6 +61,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       ? String(collection.description).slice(0, 200)
       : `Browse the ${collection.name} collection on Source Library.`;
 
+    // Social-card image: the curated hero plate, falling back to the site
+    // default. Without an explicit entry this page ships no og:image at all —
+    // defining `openGraph` replaces the root layout's block, images included.
+    const cardImage = typeof collection.hero_image === 'string' && collection.hero_image
+      ? collection.hero_image
+      : 'https://sourcelibrary.org/og-image.jpg';
+
     return {
       title: `${collection.name} - Source Library`,
       description,
@@ -69,11 +76,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         title: `${collection.name} - Source Library`,
         description,
         type: 'website',
+        images: [{ url: cardImage, alt: `${collection.name} — Source Library collection` }],
       },
       twitter: {
         card: 'summary_large_image',
         title: `${collection.name} - Source Library`,
         description,
+        images: [{ url: cardImage, alt: `${collection.name} — Source Library collection` }],
       },
     };
   } catch {

--- a/src/app/collections/sacred-texts/page.tsx
+++ b/src/app/collections/sacred-texts/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
   description:
     'The foundational scriptures of the world\'s spiritual traditions, from the Vedas and Upanishads to the Bible and Quran, from Sumerian hymns to Buddhist sutras and Zoroastrian texts.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Sacred Texts - Source Library',
     description:
       'The foundational scriptures of the world\'s spiritual traditions, from Sumerian hymns to the Vedas, Bible, Quran, and beyond.',

--- a/src/app/contribute/wikipedia/page.tsx
+++ b/src/app/contribute/wikipedia/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     canonical: '/contribute/wikipedia',
   },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Help Bring Historical Texts to Wikipedia',
     description: 'Copy-paste Talk page posts to help Wikipedia readers discover thousands of translated primary sources — Copernicus, Galileo, Kepler, and more.',
   },

--- a/src/app/curated/page.tsx
+++ b/src/app/curated/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     'Thematic exhibitions across the library, stories that cut across traditions and centuries.',
   alternates: { canonical: '/curated' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Curated Collections | Source Library',
     description:
       'Thematic exhibitions across the library, stories that cut across traditions and centuries.',

--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     'Live data on the Source Library collection: books, languages, centuries, topics, and source institutions.',
   alternates: { canonical: '/data' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'The Collection — Source Library',
     description:
       'Live data on the Source Library collection: books, languages, centuries, topics, and source institutions.',

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
     'Structured parallel-text training data from 10,000+ historical texts in 90+ languages. Page-aligned OCR, English translations, and scholarly metadata.',
   alternates: { canonical: '/dataset' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Dataset — Source Library',
     description:
       'The only structured parallel-text dataset for historical languages. Page-aligned original text, English translation, and metadata.',

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -180,6 +180,7 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
       canonical: `/encyclopedia/${encodeURIComponent(decodedName)}`,
     },
     openGraph: {
+      images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
       title: decodedName,
       description,
       type: 'article',

--- a/src/app/encyclopedia/layout.tsx
+++ b/src/app/encyclopedia/layout.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
     canonical: '/encyclopedia',
   },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Encyclopedia - Source Library',
     description: 'Explore people, places, and concepts from historical texts. Discover connections between alchemists, philosophers, and esoteric ideas across the collection.',
     type: 'website',

--- a/src/app/es/page.tsx
+++ b/src/app/es/page.tsx
@@ -20,6 +20,7 @@ export const metadata: Metadata = {
     },
   },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Source Library — Fuentes antiguas traducidas con IA',
     description:
       'La mayor biblioteca de acceso abierto de fuentes primarias traducidas. Alquimia, hermética, filosofía y ciencia, accesibles para todos.',

--- a/src/app/explore/constellation/page.tsx
+++ b/src/app/explore/constellation/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
   description:
     'Interactive semantic map of 33,000+ books and artworks. Explore how texts cluster by meaning, discover edition families, and navigate the knowledge landscape.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Constellation — Explore — Source Library',
     description:
       'A UMAP projection of the entire Source Library — 33,000 books plotted by semantic similarity.',

--- a/src/app/explore/layout.tsx
+++ b/src/app/explore/layout.tsx
@@ -5,6 +5,7 @@ export const metadata: Metadata = {
   description:
     'Explore 12,500+ entities across the Western esoteric tradition — interactive map, timeline, and knowledge network built from AI-indexed historical texts and Wikidata.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Explore — Source Library',
     description:
       'Interactive visualizations of people, places, and concepts from 1,200+ digitized historical texts.',

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
   description: 'Interactive visualizations of 12,500+ people, places, and concepts from the Western esoteric tradition. Century heatmaps, era highlights, and data source breakdowns.',
   alternates: { canonical: '/explore' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Explore — Source Library',
     description: 'Interactive visualizations of the Western esoteric tradition, enriched with Wikidata.',
   },

--- a/src/app/explore/timeline/page.tsx
+++ b/src/app/explore/timeline/page.tsx
@@ -17,6 +17,7 @@ export const metadata: Metadata = {
   description:
     'Interactive timeline of 2,900+ historical figures from the Western esoteric tradition, plotted by birth and death dates from Wikidata.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Timeline — Explore — Source Library',
     description:
       'Lifespans of historical figures — who was alive when, and how intellectual movements clustered.',

--- a/src/app/ficino-society/layout.tsx
+++ b/src/app/ficino-society/layout.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: 'The Ficino Society',
   description: 'A circle of scholars and readers translating the Western esoteric tradition. Join the community — free and open to everyone.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'The Ficino Society',
     description: 'A circle of scholars and readers translating the Western esoteric tradition.',
     siteName: 'The Ficino Society',

--- a/src/app/gallery/collections/[slug]/page.tsx
+++ b/src/app/gallery/collections/[slug]/page.tsx
@@ -48,6 +48,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     description: data.description,
     alternates: { canonical: `/gallery/collections/${slug}` },
     openGraph: {
+      images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
       title: `${data.title} | Source Library Gallery`,
       description: data.description,
     },

--- a/src/app/gallery/collections/page.tsx
+++ b/src/app/gallery/collections/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
   title: 'Curated Collections | Gallery | Source Library',
   description: 'Thematic collections of illustrations from rare alchemical, Hermetic, and philosophical manuscripts: woodcuts, engravings, emblems, and diagrams spanning five centuries.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Curated Image Collections | Source Library',
     description: 'Thematic collections of illustrations from rare historical manuscripts.',
   },

--- a/src/app/gallery/layout.tsx
+++ b/src/app/gallery/layout.tsx
@@ -18,6 +18,7 @@ export const metadata: Metadata = {
     },
   },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: galleryTitle,
     description: galleryDescription,
   },

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -45,6 +45,7 @@ export const metadata: Metadata = {
     canonical: '/gallery',
   },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: GALLERY_TITLE,
     description: GALLERY_DESCRIPTION,
     type: 'website',

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -87,6 +87,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description,
     alternates: { canonical: `/languages/${code}` },
     openGraph: {
+      images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
       title: `${langName} Texts | Source Library`,
       description,
       type: 'website',

--- a/src/app/languages/page.tsx
+++ b/src/app/languages/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
   description: 'Browse Source Library by language — Latin, German, French, Greek, Hebrew, Arabic, and 30+ more languages spanning 5,000 years of human thought.',
   alternates: { canonical: '/languages' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Languages | Source Library',
     description: 'Browse Source Library by language — Latin, German, French, Greek, Hebrew, Arabic, and 30+ more languages spanning 5,000 years of human thought.',
     type: 'website',

--- a/src/app/librarian/layout.tsx
+++ b/src/app/librarian/layout.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: 'The Librarian — Source Library',
   description: 'Ask the Librarian about any text in the collection. Alchemy, Hermetica, Kabbalah, astrology, natural philosophy — thousands of rare books, many translated into English for the first time.',
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'The Librarian — Source Library',
     description: 'Ask the Librarian about any text in the collection.',
     siteName: 'Source Library',

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -82,6 +82,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         alt: `${partner.name} — Source Library`,
       }],
     },
+    twitter: {
+      card: 'summary_large_image',
+      images: [{
+        url: partner.heroImageOverride || 'https://sourcelibrary.org/og-image.jpg',
+        alt: `${partner.name} — Source Library`,
+      }],
+    },
   };
 }
 

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -75,6 +75,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `${partner.name} - Source Library`,
       description,
       type: 'website',
+      // Defining openGraph replaces the root layout's block wholesale, so an
+      // explicit image is required or the page ships no og:image at all.
+      images: [{
+        url: partner.heroImageOverride || 'https://sourcelibrary.org/og-image.jpg',
+        alt: `${partner.name} — Source Library`,
+      }],
     },
   };
 }

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
   description: 'Browse books by digital source and contributing institution — Bibliotheca Philosophica Hermetica, Internet Archive, Gallica, Bodleian Library, and more.',
   alternates: { canonical: '/libraries' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Libraries | Source Library',
     description: 'Browse books by digital source and contributing institution — Bibliotheca Philosophica Hermetica, Internet Archive, Gallica, Bodleian Library, and more.',
     type: 'website',

--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     'Browse AI-assisted curator research sessions — conversations discovering, evaluating, and importing historical texts across alchemy, Hermetica, Kabbalah, and 30+ traditions.',
   alternates: { canonical: '/research' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Research Sessions - Source Library',
     description:
       'Browse AI-assisted curator research sessions — conversations discovering, evaluating, and importing historical texts.',

--- a/src/app/research/translation-gap/page.tsx
+++ b/src/app/research/translation-gap/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     'Of ~1.4 million early-modern works in the Universal Short Title Catalogue, how many have a known modern translation? A federated, authority-reconciled census. About one in a hundred.',
   alternates: { canonical: '/research/translation-gap' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'The Translation Gap',
     description:
       'Of ~1.4 million early-modern works, roughly 1% have a known modern translation. A federated census against the Universal Short Title Catalogue.',

--- a/src/app/research/translation-registry/page.tsx
+++ b/src/app/research/translation-registry/page.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
     'Which early-modern Latin works have already been translated into English — and who translated them? A work-level registry that credits the translators and links to the translations, the companion to the Translation Gap.',
   alternates: { canonical: '/research/translation-registry' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'The Translation Registry',
     description:
       'The early-modern Latin works that have been Englished, and the translators who did it. The companion to the Translation Gap.',

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
     canonical: '/search',
   },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'Search - Source Library',
     description: 'Search over 10,000 translated primary sources — alchemy, Hermetica, Kabbalah, natural philosophy, Sanskrit, Chinese classics, Arabic philosophy, and more.',
     type: 'website',

--- a/src/app/shwep/[number]/page.tsx
+++ b/src/app/shwep/[number]/page.tsx
@@ -25,6 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: ep.description || `Primary sources discussed in SHWEP episode ${ep.number}.`,
     alternates: { canonical: `/shwep/${ep.number}` },
     openGraph: {
+      images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
       title: `${ep.title} - SHWEP Reading Room`,
       description: ep.description || `Primary sources discussed in SHWEP episode ${ep.number}.`,
       url: `https://sourcelibrary.org/shwep/${ep.number}`,

--- a/src/app/shwep/page.tsx
+++ b/src/app/shwep/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
   description: 'Read the primary sources discussed on the Secret History of Western Esotericism Podcast. Browse episodes and access original texts in Latin, Greek, and other languages.',
   alternates: { canonical: '/shwep' },
   openGraph: {
+    images: [{ url: 'https://sourcelibrary.org/og-image.jpg', alt: 'Source Library — Digitizing and translating ancient texts' }],
     title: 'SHWEP Reading Room - Source Library',
     description: 'Read the primary sources discussed on the Secret History of Western Esotericism Podcast.',
     url: 'https://sourcelibrary.org/shwep',


### PR DESCRIPTION
## What

Follow-up to #3149, same bug class on non-blog surfaces: ~35 pages define an `openGraph` block without `images`, and Next.js metadata merge replaces the root layout's openGraph wholesale — so these pages ship **no `og:image` at all** (verified live on `/collections/hermetica`, `/explore`, `/languages`, `/libraries`, `/gallery/collections`).

## Change

- **`/collections/[id]`** — card image is the collection's curated `hero_image` (322/330 visible collections have one; checked in prod Mongo), site default otherwise. Mirrored into the page's existing `twitter` block so X shows it too.
- **`/libraries/[slug]`** — card image is the partner's `heroImageOverride` from `LIBRARY_PARTNERS`, site default otherwise.
- **33 hub/listing pages** (explore ×3, gallery ×4, languages ×2, libraries index, categories, collection-areas, research ×3, shwep ×2, artist, encyclopedia ×2, search, librarian, es, curated, data, dataset, sacred-texts, contribute/wikipedia, beta, ficino-society) — explicit site-default og image, applied by codemod.

## Out of scope

- Book / author / category-detail / reader / gallery-image pages — already covered by file-convention `opengraph-image` (verified live).
- Tenant + embed routes — closed reading rooms; card images there must be tenant-scoped, separate concern.
- Per-artist / per-language bespoke card images — default for now; easy later upgrade.
- `/brand` has no openGraph block (inherits the root default correctly) — untouched.

## Verify

After preview deploy: `og:image` on `/collections/hermetica` = its hero plate; `/explore`, `/languages` = site default. Will curl-verify before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)