### PR TITLE
feat(blog): floating share button on blog posts

### DIFF
--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,10 +1,12 @@
 import BlogTableOfContents from '@/components/blog/BlogTableOfContents';
+import BlogShareButton from '@/components/blog/BlogShareButton';
 
 export default function BlogLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
       {children}
       <BlogTableOfContents />
+      <BlogShareButton />
     </>
   );
 }

--- a/src/components/blog/BlogShareButton.tsx
+++ b/src/components/blog/BlogShareButton.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import ShareButton from '@/components/ui/ShareButton';
+
+/**
+ * Floating share control for blog posts.
+ *
+ * Rendered once from the blog layout so every post gets it without per-post
+ * edits. Sits bottom-right, above the table-of-contents mobile button (which
+ * occupies bottom-6). Hidden on the /blog index — there's no single post to
+ * share there.
+ *
+ * Sharing itself is handled by the site-wide ShareButton (X, Bluesky,
+ * WhatsApp, Pinterest, copy link — with share tracking); this component only
+ * places it. `dropUp` opens the desktop menu above the button so it doesn't
+ * fall off the bottom of the viewport.
+ */
+export default function BlogShareButton() {
+  const pathname = usePathname();
+  if (!pathname || pathname === '/blog' || pathname === '/blog/') return null;
+
+  return (
+    <div className="fixed bottom-20 right-6 z-40 print:hidden">
+      <ShareButton
+        variant="icon"
+        dropUp
+        className="!w-12 !h-12 !rounded-full justify-center bg-white/95 backdrop-blur-sm border border-border-light shadow-lg hover:!bg-stone-50"
+      />
+    </div>
+  );
+}

--- a/src/components/ui/ShareButton.tsx
+++ b/src/components/ui/ShareButton.tsx
@@ -51,6 +51,7 @@ interface ShareButtonProps {
   variant?: 'icon' | 'button' | 'menu';
   label?: string;          // Optional text label next to icon (icon variant only)
   className?: string;
+  dropUp?: boolean;        // Open the desktop menu above the button (for bottom-anchored placements)
 }
 
 export default function ShareButton({
@@ -64,6 +65,7 @@ export default function ShareButton({
   variant = 'icon',
   label,
   className = '',
+  dropUp = false,
 }: ShareButtonProps) {
   const [showMenu, setShowMenu] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -186,8 +188,8 @@ export default function ShareButton({
               className="fixed inset-0 z-[9998] sm:bg-transparent bg-black/30"
               onClick={() => setShowMenu(false)}
             />
-            {/* Desktop: absolute dropdown. Mobile: fixed bottom sheet */}
-            <div className="fixed inset-x-0 bottom-0 sm:absolute sm:inset-auto sm:right-0 sm:top-full sm:mt-1 z-[9999] bg-white sm:rounded-lg rounded-t-xl shadow-lg border border-stone-200 py-1 sm:min-w-[160px] !text-stone-900">
+            {/* Desktop: absolute dropdown (below the button, or above with dropUp). Mobile: fixed bottom sheet */}
+            <div className={`fixed inset-x-0 bottom-0 sm:absolute sm:inset-auto sm:right-0 ${dropUp ? 'sm:bottom-full sm:mb-1' : 'sm:top-full sm:mt-1'} z-[9999] bg-white sm:rounded-lg rounded-t-xl shadow-lg border border-stone-200 py-1 sm:min-w-[160px] !text-stone-900`}>
               <div className="sm:hidden w-10 h-1 bg-stone-300 rounded-full mx-auto my-2" />
               <button
                 onClick={shareToTwitter}


### PR DESCRIPTION
## What

Blog posts have no share affordance — readers share from the URL bar or not at all. This adds a floating share control to every post, rendered once from the blog layout (zero per-post edits). Hidden on the `/blog` index.

## How

- Reuses the existing site-wide `ShareButton` (X, Bluesky, WhatsApp, Pinterest, copy link — with the existing `share` event tracking), placed bottom-right at `bottom-20` so it stacks above the TOC's mobile button at `bottom-6`.
- New additive `dropUp` prop on `ShareButton` opens the desktop dropdown above the button instead of below, so a bottom-anchored placement doesn't push the menu off-screen. Default is unchanged — existing usages (ArtworkInfo, TranslationEditor) are unaffected.

## Out of scope

- Social-card metadata — shipped separately in #3149 (blog) and #3151 (collections/hub pages).
- Read counts — deliberately not shown publicly.

## Verify

On the preview: open any blog post, share button appears bottom-right; menu opens upward on desktop, bottom sheet on mobile; copy-link works; `/blog` index shows no button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)