### PR TITLE
fix(index): stop large-book summaries silently coming up empty

### DIFF
--- a/src/app/api/books/[id]/index/route.ts
+++ b/src/app/api/books/[id]/index/route.ts
@@ -653,17 +653,22 @@ async function generateBookSummary(
     };
   }
 
-  // Compile all extracted information
-  const allThemes = [...new Set(batchExtractions.flatMap(b => b.themes))];
+  // Compile all extracted information. Cap the lists: on very large books
+  // (900+ pages → ~90 batches) the deduped entity sets and batch summaries can
+  // balloon the synthesis prompt/response past the model's limits, truncating
+  // the JSON and (previously) throwing → an empty summary. enrich-worker caps
+  // its equivalent inputs for the same reason; mirror that here.
+  const allThemes = [...new Set(batchExtractions.flatMap(b => b.themes))].slice(0, 30);
   const allQuotes = batchExtractions.flatMap(b => b.quotes);
-  const allPeople = [...new Set(batchExtractions.flatMap(b => b.people))];
-  const allPlaces = [...new Set(batchExtractions.flatMap(b => b.places))];
-  const allConcepts = [...new Set(batchExtractions.flatMap(b => b.concepts))];
+  const allPeople = [...new Set(batchExtractions.flatMap(b => b.people))].slice(0, 40);
+  const allPlaces = [...new Set(batchExtractions.flatMap(b => b.places))].slice(0, 30);
+  const allConcepts = [...new Set(batchExtractions.flatMap(b => b.concepts))].slice(0, 40);
 
-  // Build batch summaries section
+  // Build batch summaries section (bounded so the prompt stays within limits).
   const batchSummariesText = batchExtractions
     .map(b => `Pages ${b.pageRange.start}-${b.pageRange.end}: ${b.summary}`)
-    .join('\n');
+    .join('\n')
+    .slice(0, 16000);
 
   // Build quotes section (limit to best 15)
   const quotesText = allQuotes.slice(0, 15)
@@ -777,13 +782,35 @@ IMPORTANT: Use the actual quotes provided above. Don't invent new ones.`;
     triggered_by: triggeredBy,
   }).catch(console.error); // Non-blocking
 
-  // Parse JSON from response
-  const jsonMatch = responseText.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) {
-    throw new Error('Failed to parse book summary JSON');
-  }
+  // Parse JSON from response — resilient to truncation. On large books the
+  // model can hit its output-token limit mid-JSON (the `sections` array cuts
+  // off), which used to throw and leave the whole summary empty. If the full
+  // object won't parse, salvage the top-level brief/abstract/detailed strings
+  // (they come first in the response) so the About summary still populates,
+  // dropping only the truncated sections.
+  const salvageField = (name: string): string => {
+    const m = responseText.match(new RegExp(`"${name}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"`));
+    if (!m) return '';
+    try { return JSON.parse(`"${m[1]}"`); } catch { return m[1]; }
+  };
 
-  const parsed = JSON.parse(jsonMatch[0]);
+  let parsed: { brief?: unknown; abstract?: unknown; detailed?: unknown; sections?: unknown };
+  const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+  try {
+    if (!jsonMatch) throw new Error('no JSON object in response');
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch {
+    parsed = {
+      brief: salvageField('brief'),
+      abstract: salvageField('abstract'),
+      detailed: salvageField('detailed'),
+      sections: [],
+    };
+    if (!parsed.brief && !parsed.abstract && !parsed.detailed) {
+      throw new Error('Failed to parse book summary JSON (nothing salvageable)');
+    }
+    console.warn(`generateBookSummary: response JSON was truncated/invalid for ${bookId}; salvaged scalar summary fields, dropped sections.`);
+  }
 
   // Ensure all fields are strings
   const ensureString = (val: unknown): string => {


### PR DESCRIPTION
## Problem
The 904-page Heimskringla (and other large books) show no "About This Book" summary even after full OCR/translation. `generateBookSummary` in `/api/books/[id]/index` builds one synthesis prompt from ~90 batch summaries plus all deduped people/places/concepts, then `JSON.parse`s the model output. At that size the response truncates at the output-token limit mid-JSON, the parse throws, and the caller's `try/catch` **silently swallows it** — leaving `brief/abstract/detailed` empty while the concept index still populates. Result: the About card silently never renders.

`enrich-worker` (the pipeline path) already caps its equivalent inputs to avoid this; the on-demand API route didn't.

## Fix
- **Cap the synthesis inputs**: themes/people/places/concepts lists and the batch-summaries text, so the prompt stays bounded on large books.
- **Resilient parse**: if the JSON object is truncated/invalid, salvage the top-level `brief`/`abstract`/`detailed` strings (they precede the `sections` array) so the summary still populates — dropping only the cut-off sections. Only throw if nothing is salvageable.

## Scope
- Fixes summary generation for all large books, not just this one.
- No change to small-book behavior (they parse fine and hit neither the caps nor the salvage path).

## Verify
Typechecks clean. After deploy I'll clear + regenerate the Heimskringla index and confirm a non-empty About summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)