### PR TITLE
fix(index): clear book_indexes on force-regenerate

### DIFF
--- a/src/app/api/books/[id]/index/route.ts
+++ b/src/app/api/books/[id]/index/route.ts
@@ -1373,7 +1373,12 @@ export const POST = withAuth(async (request, session, context) => {
     // them via /admin/book-revisions even after the cache is cleared.
     await createBookRevisions(id, ['index', 'summary', 'reading_summary']);
 
-    // Clear cached index and summary
+    // Clear cached index and summary. There are TWO stores: the dedicated
+    // `book_indexes` collection (what getBookIndex reads FIRST) and the legacy
+    // inline `book.index`. Clearing only the inline field left a stale
+    // `book_indexes` doc in place, so GET kept returning the old cached index
+    // and never regenerated. Clear both.
+    await db.collection('book_indexes').deleteOne({ book_id: id });
     await db.collection('books').updateOne(
       { id },
       { $unset: { index: '', summary: '', reading_summary: '' } }


### PR DESCRIPTION
## Problem
Book summaries ("About This Book") can't be regenerated on demand. `getBookIndex` reads the dedicated **`book_indexes`** collection first, falling back to the legacy inline `book.index`. But the POST "regenerate" route only unset the inline `book.index` — so a stale `book_indexes` doc survived and GET kept returning the old cached index and never regenerated. Books were stuck with an old/empty summary (found on the 904-page Heimskringla, frozen since 2026-05-26).

## Fix
POST also `deleteOne({ book_id: id })` on `book_indexes`, so a subsequent GET actually regenerates.

## Follow-on
Pairs with #3154 (which hardened the generator so large-book summaries don't silently come up empty). Together they let a large book's About summary be regenerated and populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)