### PR TITLE
feat(blog): pitch-class circle visual for the comma station

### DIFF
--- a/src/components/blog/lab/CommaSpiralDemo.tsx
+++ b/src/components/blog/lab/CommaSpiralDemo.tsx
@@ -28,16 +28,20 @@ function CommaCircle({ n, fifth, temper }: { n: number; fifth: number; temper: '
     return { x: C + r * Math.sin(theta), y: C - r * Math.cos(theta), cents, r };
   };
   const points = Array.from({ length: n + 1 }, (_, i) => pt(i));
-  const gapDeg = n === 12 && temper === 'just' ? (points[12].cents / 1200) * 360 : 0;
 
-  // Arc marking the comma gap, drawn just outside the final landing.
-  const gapArc = () => {
-    const r = points[12].r + 9;
-    const a = (2 * Math.PI * points[12].cents) / 1200;
-    const x1 = C + r * Math.sin(a);
-    const y1 = C - r * Math.cos(a);
-    return `M ${C} ${C - r} A ${r} ${r} 0 0 1 ${x1} ${y1}`;
-  };
+  // Comma-gap annotation, fully precomputed: no array indexing may sit inside
+  // conditional JSX — the React Compiler can hoist member accesses above the
+  // guard (same failure mode as the TranslationEditor inline-conditional bug).
+  const last = points[points.length - 1];
+  const showGap = n === 12 && temper === 'just';
+  let gapPath = '';
+  let gapTextY = 0;
+  if (showGap) {
+    const r = last.r + 9;
+    const a = (2 * Math.PI * last.cents) / 1200;
+    gapPath = `M ${C} ${C - r} A ${r} ${r} 0 0 1 ${C + r * Math.sin(a)} ${C - r * Math.cos(a)}`;
+    gapTextY = C - last.r - 14;
+  }
 
   return (
     <svg viewBox="0 0 280 280" className="w-full max-w-[280px] mx-auto block" role="img"
@@ -85,10 +89,10 @@ function CommaCircle({ n, fifth, temper }: { n: number; fifth: number; temper: '
       })}
 
       {/* the comma gap */}
-      {gapDeg > 0 && (
+      {showGap && (
         <g>
-          <path d={gapArc()} fill="none" stroke="#a8503c" strokeWidth={2.5} strokeLinecap="round" />
-          <text x={C + 8} y={C - points[12].r - 14} fontSize={10} fill="#a8503c">
+          <path d={gapPath} fill="none" stroke="#a8503c" strokeWidth={2.5} strokeLinecap="round" />
+          <text x={C + 8} y={gapTextY} fontSize={10} fill="#a8503c">
             +23.5 ¢ — the comma
           </text>
         </g>

--- a/src/components/blog/lab/CommaSpiralDemo.tsx
+++ b/src/components/blog/lab/CommaSpiralDemo.tsx
@@ -8,6 +8,95 @@ const ROOT = 220;
 const JUST_FIFTH = 1200 * Math.log2(3 / 2); // 701.955 ¢
 const EQUAL_FIFTH = 700;
 
+// Pitch-class letters reached from A by successive fifths.
+const FIFTH_NAMES = ['A', 'E', 'B', 'F♯', 'C♯', 'G♯', 'D♯', 'A♯', 'F', 'C', 'G', 'D'];
+
+/**
+ * The circle the fifths actually draw. Angle is honest pitch space — cents
+ * around the octave, root at twelve o'clock — so successive fifths hop
+ * ~210° and trace the {12/7} star. The radius creeps outward one notch per
+ * step, making the walk legible and letting the twelfth landing sit right
+ * next to the root: dead aligned under Zhu Zaiyu's fifths, visibly rotated
+ * past it by the comma under pure 3:2.
+ */
+function CommaCircle({ n, fifth, temper }: { n: number; fifth: number; temper: 'just' | 'equal' }) {
+  const C = 140;
+  const pt = (step: number) => {
+    const cents = ((step * fifth) % 1200 + 1200) % 1200;
+    const theta = (2 * Math.PI * cents) / 1200;
+    const r = 76 + step * 3.2;
+    return { x: C + r * Math.sin(theta), y: C - r * Math.cos(theta), cents, r };
+  };
+  const points = Array.from({ length: n + 1 }, (_, i) => pt(i));
+  const gapDeg = n === 12 && temper === 'just' ? (points[12].cents / 1200) * 360 : 0;
+
+  // Arc marking the comma gap, drawn just outside the final landing.
+  const gapArc = () => {
+    const r = points[12].r + 9;
+    const a = (2 * Math.PI * points[12].cents) / 1200;
+    const x1 = C + r * Math.sin(a);
+    const y1 = C - r * Math.cos(a);
+    return `M ${C} ${C - r} A ${r} ${r} 0 0 1 ${x1} ${y1}`;
+  };
+
+  return (
+    <svg viewBox="0 0 280 280" className="w-full max-w-[280px] mx-auto block" role="img"
+      aria-label={`Circle of fifths after ${n} steps: ${temper === 'just' ? 'pure fifths spiral past the root by the comma' : 'equal fifths close the circle'}`}>
+      {/* pitch-class ring + semitone ticks */}
+      <circle cx={C} cy={C} r={76} fill="none" stroke="#d6d3d1" strokeWidth={1} />
+      {Array.from({ length: 12 }, (_, i) => {
+        const a = (2 * Math.PI * i) / 12;
+        return (
+          <line key={i}
+            x1={C + 72 * Math.sin(a)} y1={C - 72 * Math.cos(a)}
+            x2={C + 76 * Math.sin(a)} y2={C - 76 * Math.cos(a)}
+            stroke="#d6d3d1" strokeWidth={1}
+          />
+        );
+      })}
+
+      {/* the walk */}
+      {points.length > 1 && (
+        <polyline
+          points={points.map((p) => `${p.x},${p.y}`).join(' ')}
+          fill="none" stroke="#a8503c" strokeOpacity={0.35} strokeWidth={1.5}
+        />
+      )}
+
+      {/* landings */}
+      {points.map((p, i) => {
+        const isRoot = i === 0;
+        const isLast = i === n && n > 0;
+        const label = i === 12 ? (temper === 'just' ? 'A′' : 'A') : FIFTH_NAMES[i % 12];
+        const lr = p.r + 13;
+        const a = (2 * Math.PI * p.cents) / 1200;
+        return (
+          <g key={i}>
+            <circle cx={p.x} cy={p.y} r={isLast ? 5 : 3.5}
+              fill={isRoot ? 'white' : isLast ? '#a8503c' : '#78716c'}
+              stroke={isRoot ? '#a8503c' : 'none'} strokeWidth={1.5}
+            />
+            <text x={C + lr * Math.sin(a)} y={C - lr * Math.cos(a) + 3}
+              textAnchor="middle" fontSize={9} fill={isRoot || isLast ? '#a8503c' : '#a8a29e'}>
+              {label}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* the comma gap */}
+      {gapDeg > 0 && (
+        <g>
+          <path d={gapArc()} fill="none" stroke="#a8503c" strokeWidth={2.5} strokeLinecap="round" />
+          <text x={C + 8} y={C - points[12].r - 14} fontSize={10} fill="#a8503c">
+            +23.5 ¢ — the comma
+          </text>
+        </g>
+      )}
+    </svg>
+  );
+}
+
 /**
  * Station II — the circle that won't close.
  *
@@ -78,6 +167,10 @@ export default function CommaSpiralDemo() {
         >
           Reset
         </button>
+      </div>
+
+      <div className="mb-4">
+        <CommaCircle n={n} fifth={fifth} temper={temper} />
       </div>
 
       <div className="grid grid-cols-3 gap-3">


### PR DESCRIPTION
Derek: "circle of fifths could use visual..." — Station II of the Sound Laboratory (#3160) now draws the circle the fifths actually make.

- SVG pitch-class circle, angle = true cents around the octave (root at 12 o'clock). Each stacked fifth drops a labelled dot (A → E → B → F♯ … all twelve letters), hopping ~210° per step — the walk traces the {12/7} star of the circle of fifths.
- Radius creeps outward per step so the path reads as a journey and the twelfth landing sits beside the root: **aligned** under Zhu Zaiyu's ¹²√2 fifths, **rotated past it** under pure 3:2, with a red arc + "+23.5 ¢ — the comma" annotation on the gap.
- Angles are honest — no exaggeration; the comma looks small because it is (7° of arc). The annotation carries it.
- Pure SVG in the existing client component, no dependencies; aria-label describes the state.

Side note for reviewers: local tsc in fresh worktrees was failing on `abcjs` (new dep from #3163, the Shaker hymn player) because the shared main checkout hadn't pulled + installed it — fixed by pulling main and `npm install` there; nothing in this diff relates.

Will screenshot-verify the four states (0 / 6 / 12-just / 12-equal) on the preview before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)