### PR TITLE
Reader: edition bibliographic info + Source Library link in the Info panel

### DIFF
--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -116,6 +116,7 @@ interface BibliographicInfoProps {
   children?: React.ReactNode;
   showTranslationMethodologyLink?: boolean;
   showExternalLinks?: boolean;
+  defaultExpanded?: boolean;
 }
 
 export default function BibliographicInfo({
@@ -125,9 +126,10 @@ export default function BibliographicInfo({
   children,
   showTranslationMethodologyLink = true,
   showExternalLinks = true,
+  defaultExpanded = false,
 }: BibliographicInfoProps) {
   const router = useRouter();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const [copied, setCopied] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [provenanceExpanded, setProvenanceExpanded] = useState(false);

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -582,6 +582,23 @@ export default function TranslationEditor({
   const [transliterationLoading, setTransliterationLoading] = useState(false);
   const [showPageMetadata, setShowPageMetadata] = useState(false); // Toggle for page metadata panel
   const [showFontControls, setShowFontControls] = useState(false);
+  // Full book doc for the edition-info section of the metadata panel. The reader
+  // route only ships a slim book projection, so the bibliographic fields are
+  // fetched on demand — once per book, the first time the panel opens.
+  const [editionBook, setEditionBook] = useState<Book | null>(null);
+  const [editionError, setEditionError] = useState(false);
+  const editionFetchStartedRef = useRef(false);
+  useEffect(() => {
+    if (!showPageMetadata || editionFetchStartedRef.current) return;
+    editionFetchStartedRef.current = true;
+    fetch(`/api/books/${book.id}?pageLimit=1`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((data) => {
+        const { pages: _pages, ...fullBook } = data;
+        setEditionBook(fullBook as Book);
+      })
+      .catch(() => setEditionError(true));
+  }, [showPageMetadata, book.id]);
   const fontControlsRef = useRef<HTMLDivElement>(null);
 
   // Highlights and Annotations panels
@@ -2116,6 +2133,10 @@ export default function TranslationEditor({
           <PageMetadataPanel
             page={page}
             onClose={() => setShowPageMetadata(false)}
+            editionBook={editionBook}
+            editionError={editionError}
+            bookHref={`${tenantPrefix}/book/${book.id}`}
+            isEmbedded={isEmbedded}
           />
         )}
 
@@ -2705,6 +2726,10 @@ export default function TranslationEditor({
         <PageMetadataPanel
           page={page}
           onClose={() => setShowPageMetadata(false)}
+          editionBook={editionBook}
+          editionError={editionError}
+          bookHref={`${tenantPrefix}/book/${book.id}`}
+          isEmbedded={isEmbedded}
         />
       )}
 

--- a/src/components/reader/PageMetadataPanel.tsx
+++ b/src/components/reader/PageMetadataPanel.tsx
@@ -1,12 +1,19 @@
 'use client';
 
 import { useState } from 'react';
-import { X, FileText, Languages, Clock, User, Cpu, Tag, BookOpen, ChevronDown, ChevronRight } from 'lucide-react';
-import { Page } from '@/lib/types';
+import { X, FileText, Languages, Clock, User, Cpu, Tag, BookOpen, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
+import { Page, Book } from '@/lib/types';
+import BibliographicInfo from '@/components/book/BibliographicInfo';
 
 interface PageMetadataPanelProps {
   page: Page;
   onClose: () => void;
+  // Edition context (lazy-fetched by the caller when the panel opens).
+  // editionBook === undefined means still loading; editionError flags a failed fetch.
+  editionBook?: Book | null;
+  editionError?: boolean;
+  bookHref?: string;
+  isEmbedded?: boolean;
 }
 
 // Extract metadata tags from text (supports both XML and bracket syntax)
@@ -182,9 +189,17 @@ function TagList({ tags, color = 'stone' }: { tags: string[]; color?: 'stone' | 
   );
 }
 
-export default function PageMetadataPanel({ page, onClose }: PageMetadataPanelProps) {
+export default function PageMetadataPanel({
+  page,
+  onClose,
+  editionBook,
+  editionError,
+  bookHref,
+  isEmbedded,
+}: PageMetadataPanelProps) {
   const ocrMeta = extractMetadataFromText(page.ocr?.data || '');
   const translationMeta = extractMetadataFromText(page.translation?.data || '');
+  const hasEditionContext = !!bookHref;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -193,7 +208,7 @@ export default function PageMetadataPanel({ page, onClose }: PageMetadataPanelPr
         <div className="flex items-center justify-between px-4 py-3 border-b border-stone-200 bg-stone-50">
           <h2 className="font-semibold text-stone-900 flex items-center gap-2">
             <FileText className="w-5 h-5 text-stone-500" />
-            Page {page.page_number} Metadata
+            {hasEditionContext ? `Edition & Page Info` : `Page ${page.page_number} Metadata`}
           </h2>
           <button
             onClick={onClose}
@@ -218,6 +233,39 @@ export default function PageMetadataPanel({ page, onClose }: PageMetadataPanelPr
             <div className="mx-4 mt-4 p-3 bg-accent-gold/8 border border-accent-gold/20 rounded-lg text-sm text-accent-gold-dark">
               <strong>Summary:</strong> {translationMeta.summary}
             </div>
+          )}
+
+          {/* Edition Section — book-level bibliographic info, lazy-fetched by the caller */}
+          {hasEditionContext && (
+            <MetadataSection title="This Edition" icon={BookOpen}>
+              {editionBook ? (
+                // BibliographicInfo is styled for a dark background (book-page hero),
+                // so it sits inside its native dark container here.
+                <div className="bg-stone-900 rounded-lg px-4 pb-4 pt-1">
+                  <BibliographicInfo
+                    book={editionBook}
+                    pagesCount={editionBook.pages_count ?? 0}
+                    hasTranslations={(editionBook.pages_translated ?? 0) > 0}
+                    showExternalLinks={!isEmbedded}
+                    showTranslationMethodologyLink={!isEmbedded}
+                    defaultExpanded
+                  />
+                </div>
+              ) : editionError ? (
+                <p className="text-sm text-stone-400 italic">
+                  Couldn&apos;t load edition info.
+                </p>
+              ) : (
+                <p className="text-sm text-stone-400 italic">Loading edition info…</p>
+              )}
+              <a
+                href={bookHref}
+                className="inline-flex items-center gap-1.5 text-sm text-accent-gold-dark hover:underline mt-1"
+              >
+                <ExternalLink className="w-3.5 h-3.5" />
+                {isEmbedded ? 'View book details' : 'View on Source Library'}
+              </a>
+            </MetadataSection>
           )}
 
           {/* OCR Section */}


### PR DESCRIPTION
Closes #3170.

## What

The reader's existing **Info** button now also shows the book's full bibliographic record, so a reader who lands on any page view can see (and cite) exactly what edition they're reading without leaving the page.

- **`PageMetadataPanel`**: new optional edition props; renders a "This Edition" section above the page metadata containing `BibliographicInfo` (in its native dark container) + a "View on Source Library" link to the canonical book page.
- **`TranslationEditor`**: lazy-fetches the full book doc from `GET /api/books/[id]?pageLimit=1` the first time the panel opens — once per book per session, cached in state. Graceful degradation: fetch failure shows a quiet "couldn't load" line; page metadata always renders.
- **`BibliographicInfo`**: new `defaultExpanded` prop (panel opens it pre-expanded; book detail page behavior unchanged).

## Why lazy-fetch instead of widening the reader projection

Reader pages are the hottest, most heavily CDN-cached routes. Widening `BOOK_NAV_PROJECTION` would serialize the same bibliographic blob into every cached render of every page (500-page book = 500 copies across the edge cache) for a panel most readers never open. The on-demand fetch (~145 KB, verified against prod — the doc carries index/chapters) is paid only by readers who ask for it. Details + the rejected alternative are in #3170.

## Tenant lockdown

Embed/tenant readers share these components. `showExternalLinks={!isEmbedded}` suppresses VIAF/Wikidata/USTC/IIIF/source_url outbound links in embed mode; the book link is relative (`${tenantPrefix}/book/<id>`) so it resolves on-host, and the link label drops the "Source Library" name when embedded.

## Out of scope (per issue)

Light-theme restyle of `BibliographicInfo`; `field_provenance` in the reader.

## Verification

- `npx tsc --noEmit` clean.
- `GET /api/books/[id]?pageLimit=1` verified against prod: full book doc (publisher/place/image_source present) + exactly 1 page row.
- Visual check on the Vercel preview (screenshots in comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
