### PR TITLE
Sound Laboratory: stations VI–X + Descartes' circles (#3160)

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -29,9 +29,9 @@ export const posts: BlogPost[] = [
     slug: 'sound-laboratory',
     title: 'The Sound Laboratory',
     subtitle:
-      'Five interactive stations that put twenty-five centuries of claims about harmony to the test with your own ears — the smith\'s hammers weighed, the comma that won\'t close, Bharata\'s two vīṇās, Salmon\'s Royal Society trial, and Tartini\'s ghost tone. Headphones recommended.',
+      'Ten interactive stations that put twenty-five centuries of claims about harmony to the test with your own ears — the smith\'s hammers weighed, the comma that won\'t close, Bharata\'s two vīṇās, Kepler\'s planets auditioned against modern orbits, Kircher\'s sympathetic strings, and Euler\'s formula for sweetness, graded by you. Headphones recommended.',
     date: '16 July 2026',
-    readTime: '5 experiments',
+    readTime: '10 experiments',
     tag: 'Interactive',
     tagColor: 'bg-stone-100 text-stone-600',
     image: 'https://images.sourcelibrary.org/artwork/art-sadeler-fabel-van-de-smid-en-de-hond.jpg',

--- a/src/app/blog/sound-laboratory/page.tsx
+++ b/src/app/blog/sound-laboratory/page.tsx
@@ -6,13 +6,18 @@ import CommaSpiralDemo from '@/components/blog/lab/CommaSpiralDemo';
 import ShrutiTestDemo from '@/components/blog/lab/ShrutiTestDemo';
 import SalmonTrialDemo from '@/components/blog/lab/SalmonTrialDemo';
 import TartiniDemo from '@/components/blog/lab/TartiniDemo';
+import GalileoRhythmDemo from '@/components/blog/lab/GalileoRhythmDemo';
+import KeplerPlanetsDemo from '@/components/blog/lab/KeplerPlanetsDemo';
+import KircherResonanceDemo from '@/components/blog/lab/KircherResonanceDemo';
+import YueJiAffectDemo from '@/components/blog/lab/YueJiAffectDemo';
+import EulerGradusDemo from '@/components/blog/lab/EulerGradusDemo';
 
 const HERO = 'https://images.sourcelibrary.org/artwork/art-sadeler-fabel-van-de-smid-en-de-hond.jpg';
 
 export const metadata: Metadata = {
   title: 'The Sound Laboratory - Source Library',
   description:
-    'Five interactive stations that put twenty-five centuries of claims about harmony to the test — the smith\'s hammers, the Pythagorean comma, Bharata\'s two vīṇās, Salmon\'s Royal Society trial, and Tartini\'s third tone. Bring headphones.',
+    'Ten interactive stations that put twenty-five centuries of claims about harmony to the test — the smith\'s hammers, the Pythagorean comma, Bharata\'s two vīṇās, Salmon\'s Royal Society trial, Tartini\'s third tone, Galileo\'s rhythm-into-pitch continuum, Kepler\'s planet-songs, Kircher\'s sympathetic strings, the Record of Music\'s six sounds, and Euler\'s formula for sweetness. Bring headphones.',
   alternates: {
     canonical: '/blog/sound-laboratory',
   },
@@ -38,7 +43,7 @@ export default function SoundLaboratoryPage() {
           image={HERO}
           imageAlt="A smith at his anvil, hammer raised — Aegidius Sadeler's engraving of the smith and the dog, 1608"
         >
-          <p className="text-stone-400 text-sm mt-4">16 July 2026 &middot; 5 experiments &middot; headphones recommended</p>
+          <p className="text-stone-400 text-sm mt-4">16 July 2026 &middot; 10 experiments &middot; headphones recommended</p>
         </ContentHeader>
       }
       bg="bg-cream"
@@ -137,18 +142,85 @@ export default function SoundLaboratoryPage() {
         </p>
         <TartiniDemo />
 
+        <h2 className="font-serif text-3xl text-primary mb-6 mt-12">VI. Rhythm, sped up</h2>
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          If Tartini&apos;s ear manufactures tones, what is a tone to begin with? In the{' '}
+          <Link href="/book/discorsi-e-dimostrazioni-matematiche-intorno-a-due-nuove-galilei" className="text-accent-rust hover:text-accent-rust underline"><em>Discorsi</em></Link>{' '}
+          (1638), Galileo grounded consonance in coincidence: strings sound sweet together when
+          their pulses strike the ear in step, harsh when the pattern never settles. Taken
+          seriously, that claim dissolves the boundary between two things we experience as utterly
+          different — rhythm and pitch. A two-against-three drum pattern and a perfect fifth are
+          the same object at different speeds. That is a claim a slider can test: nothing changes
+          below but the rate.
+        </p>
+        <GalileoRhythmDemo />
+
+        <h2 className="font-serif text-3xl text-primary mb-6 mt-12">VII. The planets, auditioned</h2>
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          The grandest claim in the whole literature is Kepler&apos;s: that the heavens are a
+          polyphonic choir, each planet singing a glissando between its slowest motion at aphelion
+          and its fastest at perihelion. His{' '}
+          <Link href="/book/the-harmony-of-the-world-kepler?page=325" className="text-accent-rust hover:text-accent-rust underline"><em>Harmonices Mundi</em></Link>{' '}
+          (1619) tabulates the extremes planet by planet and assigns each its interval — Saturn a
+          major third, Mars a fifth, Earth a bare semitone. A margin note beside the Earth&apos;s
+          entry may be the darkest joke in the history of astronomy:{' '}
+          <Link href="/book/the-harmony-of-the-world-kepler?page=336" className="text-accent-rust hover:text-accent-rust underline">&ldquo;The Earth sings MI FA MI, so that we may observe from the symbol that even in our own home we obtain Misery and Famine.&rdquo;</Link>{' '}
+          Kepler&apos;s numbers, unlike the smith&apos;s hammers, were real measurements — which
+          means we can grade them. Four centuries of refined orbital elements are the answer key.
+        </p>
+        <KeplerPlanetsDemo />
+
+        <h2 className="font-serif text-3xl text-primary mb-6 mt-12">VIII. The string that answers</h2>
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          For Athanasius Kircher, the deepest evidence that harmony was woven into nature was
+          sympathy: pluck a string, and an untouched string tuned in unison answers across the
+          room, while its mistuned neighbours keep silent. His{' '}
+          <Link href="/book/kircher-musurgia-universalis-vol-ii-1650-kircher" className="text-accent-rust hover:text-accent-rust underline"><em>Musurgia Universalis</em></Link>{' '}
+          (1650) treats the effect as natural magic — consonance acting at a distance. The modern
+          name for his magic is resonance, and the demonstration works exactly as he describes: the
+          answer comes only when the tuning matches.
+        </p>
+        <KircherResonanceDemo />
+
+        <h2 className="font-serif text-3xl text-primary mb-6 mt-12">IX. The sound of a state of mind</h2>
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          The oldest empirical claim about music and emotion we hold is Chinese. The{' '}
+          <Link href="/book/the-sacred-books-of-china-li-ki-part-2-sbe-vol-28-trans?page=107" className="text-accent-rust hover:text-accent-rust underline"><em>Record of Music</em></Link>{' '}
+          opens by listing six states of mind and the sound each one stamps on the voice:{' '}
+          <Link href="/book/the-sacred-books-of-china-li-ki-part-2-sbe-vol-28-trans?page=107" className="text-accent-rust hover:text-accent-rust underline">&ldquo;When the mind is moved to sorrow, the sound is sharp and fading away&rdquo;</Link>
+          ; anger is coarse and fierce, reverence straightforward and humble, and{' '}
+          <Link href="/book/the-sacred-books-of-china-li-ki-part-2-sbe-vol-28-trans?page=107" className="text-accent-rust hover:text-accent-rust underline">&ldquo;when it is moved to love, the sound is harmonious and soft.&rdquo;</Link>{' '}
+          For the Record this is statecraft, not aesthetics — the same passage reads the music of an
+          age as a diagnostic of its government. But underneath sits a testable psychological claim:
+          that the six signatures are legible. If they are, you should be able to hear a phrase
+          built to one description and name the state of mind blind.
+        </p>
+        <YueJiAffectDemo />
+
+        <h2 className="font-serif text-3xl text-primary mb-6 mt-12">X. Grade the formula</h2>
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          Salmon&apos;s 1705 trial (Station IV) put temperaments to an audience; a generation later{' '}
+          <Link href="/book/tentamen-novae-theoriae-musicae-euler" className="text-accent-rust hover:text-accent-rust underline">Leonhard Euler</Link>{' '}
+          removed the audience altogether. His <em>Tentamen novae theoriae musicae</em> (1739)
+          assigns every interval a <em>gradus suavitatis</em> — a degree of agreeableness computed
+          from the prime factors of its ratio. It is the boldest reduction in this whole story:
+          taste itself, made arithmetic. Two and a half centuries before anyone said
+          &ldquo;empirical aesthetics,&rdquo; the formula was on the table; what was missing was
+          the panel of listeners. That&apos;s you.
+        </p>
+        <EulerGradusDemo />
+
         <hr className="border-border-light my-12" />
 
         <h2 className="font-serif text-3xl text-primary mb-6 mt-12">The bench stays open</h2>
         <p className="text-secondary leading-relaxed mb-8 font-body">
-          Five stations in, the old quarrel looks different: the ancients were not just theorizing
-          about harmony, they were <em>experimenting</em> — Bharata with his vīṇās, Galilei with his
-          weights, Salmon with his viols — and their claims are still runnable. More stations are
-          planned:{' '}
-          <Link href="/book/the-harmony-of-the-world-kepler" className="text-accent-rust hover:text-accent-rust underline">Kepler&apos;s planetary intervals</Link>{' '}
-          checked against modern orbits, Kircher&apos;s sympathetic strings, and the{' '}
-          <Link href="/book/the-sacred-books-of-china-li-ki-part-2-sbe-vol-28-trans?page=106" className="text-accent-rust hover:text-accent-rust underline"><em>Record of Music</em></Link>&apos;s
-          claim that modes carry moral weather. If a station misbehaves, or you know a claim from the
+          Ten stations in, a shape emerges: this is the history of empirical aesthetics, run in
+          miniature — Bharata detuning his vīṇās, Galilei hanging his weights, Salmon staging his
+          viols before the Royal Society, Euler writing taste as a formula, and now a reader with
+          headphones adjudicating all of them at a desk. Some claims survived their audit (Kircher&apos;s
+          strings answer; the Earth really does sing a semitone), some died gloriously (weigh the
+          hammers), and the deepest — that what pleases the ear can be computed — is still an open
+          question you just generated data on. If a station misbehaves, or you know a claim from the
           old books that belongs on this bench, use the suggest-an-edit link below — this note is a
           living instrument, and corrections are the point.
         </p>

--- a/src/app/blog/sound-laboratory/page.tsx
+++ b/src/app/blog/sound-laboratory/page.tsx
@@ -95,8 +95,12 @@ export default function SoundLaboratoryPage() {
           The cleanest solution came from a Ming prince:{' '}
           <Link href="/book/complete-works-on-music-and-tuning-vol-1" className="text-accent-rust hover:text-accent-rust underline">Zhu Zaiyu</Link>{' '}
           (1584) made every fifth equal to the twelfth root of two — shaving each one by two cents,
-          less than most ears can find — and the circle closed for the first time. Stack the fifths
-          yourself and listen to the comma churn against the root; then let the prince fix it.
+          less than most ears can find — and the circle closed for the first time. Even drawing
+          pitch as a circle had to be invented: the earliest circular pitch diagrams we hold are in{' '}
+          <Link href="/book/musicae-compendium-descartes" className="text-accent-rust hover:text-accent-rust underline">Descartes&apos;s first book</Link>,
+          the <em>Compendium Musicae</em> of 1618, and two of his folios are tucked into the station
+          below. Stack the fifths yourself and listen to the comma churn against the root; then let
+          the prince fix it.
         </p>
         <CommaSpiralDemo />
 

--- a/src/components/blog/lab/CommaSpiralDemo.tsx
+++ b/src/components/blog/lab/CommaSpiralDemo.tsx
@@ -1,12 +1,37 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
 import { ToneEngine } from './audio';
 import { LabCard, PlayToggle, Readout, Chip } from './LabCard';
 
 const ROOT = 220;
 const JUST_FIFTH = 1200 * Math.log2(3 / 2); // 701.955 ¢
 const EQUAL_FIFTH = 700;
+
+/**
+ * The circle-as-pitch-space convention this station draws is itself a
+ * historical artifact we hold: Descartes' Compendium Musicae — his first
+ * book, written 1618 (ours is the 1656 printing) — renders the octave as
+ * nested circles, intervals as arcs. `focus` is the CSS object-position
+ * that centers each plate's circle in the square thumbnail crop.
+ */
+const DESCARTES_PLATES = [
+  {
+    src: 'https://images.sourcelibrary.org/archived/69b1cafca282e3475aab4148/23.jpg',
+    href: '/book/musicae-compendium-descartes?page=23',
+    label: 'The consonances as nested arcs',
+    detail: 'Diapason, diapente, diatessaron — every consonance drawn as an arc of the same circle, so that adding a full turn adds an octave.',
+    focus: '50% 52%',
+  },
+  {
+    src: 'https://images.sourcelibrary.org/archived/69b1cafca282e3475aab4148/33.jpg',
+    href: '/book/musicae-compendium-descartes?page=33',
+    label: 'The octave ring, with string numbers',
+    detail: 'The solmization syllables around concentric rings, each note pinned to a string number (C.360, D.320/324, A.432…) — the same angle-is-pitch convention as the diagram above, three centuries early.',
+    focus: '50% 38%',
+  },
+];
 
 // Pitch-class letters reached from A by successive fifths.
 const FIFTH_NAMES = ['A', 'E', 'B', 'F♯', 'C♯', 'G♯', 'D♯', 'A♯', 'F', 'C', 'G', 'D'];
@@ -113,6 +138,10 @@ export default function CommaSpiralDemo() {
   const [playing, setPlaying] = useState(false);
   const [n, setN] = useState(0);
   const [temper, setTemper] = useState<'just' | 'equal'>('just');
+  const [plate, setPlate] = useState<number | null>(null);
+  // Precomputed: no indexing inside conditional JSX — the React Compiler can
+  // hoist member access above the null guard (see CommaCircle note below).
+  const activePlate = plate === null ? null : DESCARTES_PLATES[plate];
 
   const engineRef = useRef<ToneEngine | null>(null);
 
@@ -196,6 +225,57 @@ export default function CommaSpiralDemo() {
           3¹²/2¹⁹ = 531441/524288 ≈ 1.01364 — twelve pure fifths overshoot seven octaves by 23.46 ¢
         </p>
       )}
+
+      <div className="mt-5 pt-4 border-t border-border-light">
+        <p className="text-[11px] uppercase tracking-wider text-muted mb-2">
+          Where the circle comes from — Descartes, age 22
+        </p>
+        <p className="text-xs text-secondary mb-3">
+          Drawing pitch as a circle — one octave per turn, intervals as arcs — was itself an
+          invention. The earliest circular pitch diagrams we hold are in{' '}
+          <Link href="/book/musicae-compendium-descartes" className="text-accent-rust underline">
+            Descartes&apos; <em>Compendium Musicae</em>
+          </Link>
+          , his first book, written in 1618. Click a folio:
+        </p>
+        <div className="flex gap-2 mb-3">
+          {DESCARTES_PLATES.map((p, i) => (
+            <button
+              key={p.src}
+              onClick={() => setPlate((v) => (v === i ? null : i))}
+              className={`w-20 h-20 rounded overflow-hidden border transition-colors ${
+                plate === i ? 'border-accent-rust' : 'border-border-light hover:border-stone-300'
+              }`}
+              aria-label={`${plate === i ? 'Hide' : 'Show'} plate: ${p.label}`}
+              aria-expanded={plate === i}
+            >
+              <img
+                src={p.src}
+                alt={p.label}
+                className="w-full h-full object-cover"
+                style={{ objectPosition: p.focus, transform: 'scale(2.4)', transformOrigin: p.focus }}
+                loading="lazy"
+              />
+            </button>
+          ))}
+        </div>
+        {activePlate && (
+          <figure className="m-0">
+            <img
+              src={activePlate.src}
+              alt={activePlate.label}
+              className="w-full rounded border border-border-light"
+              loading="lazy"
+            />
+            <figcaption className="text-xs text-muted mt-2">
+              {activePlate.detail}{' '}
+              <Link href={activePlate.href} className="text-accent-rust underline">
+                Read this page
+              </Link>
+            </figcaption>
+          </figure>
+        )}
+      </div>
     </LabCard>
   );
 }

--- a/src/components/blog/lab/EulerGradusDemo.tsx
+++ b/src/components/blog/lab/EulerGradusDemo.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ToneEngine } from './audio';
+import { LabCard, Readout } from './LabCard';
+
+/**
+ * Euler's gradus suavitatis (Tentamen, 1739, ch. II): for a just interval
+ * p:q in lowest terms, factor p·q into primes and the degree is
+ * 1 + Σ (each prime − 1). Low degree = sweet. Computed here from the
+ * ratios, not hardcoded — the formula IS the exhibit.
+ */
+function gradus(p: number, q: number): number {
+  let n = p * q;
+  let g = 1;
+  for (let d = 2; d <= n; d++) {
+    while (n % d === 0) { g += d - 1; n /= d; }
+  }
+  return g;
+}
+
+const ROOT = 262;
+
+const DYADS = [
+  { name: 'Octave', p: 1, q: 2 },
+  { name: 'Perfect fifth', p: 2, q: 3 },
+  { name: 'Perfect fourth', p: 3, q: 4 },
+  { name: 'Major sixth', p: 3, q: 5 },
+  { name: 'Major third', p: 4, q: 5 },
+  { name: 'Minor third', p: 5, q: 6 },
+  { name: 'Minor seventh', p: 9, q: 16 },
+  { name: 'Semitone', p: 15, q: 16 },
+].map((d) => ({ ...d, gradus: gradus(d.p, d.q) }));
+
+const shuffle = <T,>(xs: T[]): T[] => {
+  const a = [...xs];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+};
+
+/** Average ranks (ties averaged), ascending. */
+function ranks(xs: number[]): number[] {
+  const idx = xs.map((v, i) => [v, i] as const).sort((a, b) => a[0] - b[0]);
+  const r = new Array<number>(xs.length).fill(0);
+  let i = 0;
+  while (i < idx.length) {
+    let j = i;
+    while (j + 1 < idx.length && idx[j + 1][0] === idx[i][0]) j++;
+    const avg = (i + j) / 2 + 1;
+    for (let k = i; k <= j; k++) r[idx[k][1]] = avg;
+    i = j + 1;
+  }
+  return r;
+}
+
+/** Spearman rank correlation. */
+function spearman(a: number[], b: number[]): number {
+  const ra = ranks(a);
+  const rb = ranks(b);
+  const n = a.length;
+  const ma = ra.reduce((s, v) => s + v, 0) / n;
+  const mb = rb.reduce((s, v) => s + v, 0) / n;
+  let num = 0, da = 0, db = 0;
+  for (let i = 0; i < n; i++) {
+    num += (ra[i] - ma) * (rb[i] - mb);
+    da += (ra[i] - ma) ** 2;
+    db += (rb[i] - mb) ** 2;
+  }
+  return da && db ? num / Math.sqrt(da * db) : 0;
+}
+
+/**
+ * Station X — Euler's formula, against your ear.
+ *
+ * The Tentamen assigns every just interval a computable "degree of
+ * agreeableness". If the formula is a law of taste, listeners' rankings
+ * should reproduce its ordering. Rate eight dyads blind; the station
+ * computes the rank agreement between you and the mathematics.
+ */
+export default function EulerGradusDemo() {
+  const [order, setOrder] = useState<number[] | null>(null);
+  const [i, setI] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [played, setPlayed] = useState(false);
+  const [ratings, setRatings] = useState<number[]>([]); // indexed like DYADS
+
+  const engineRef = useRef<ToneEngine | null>(null);
+  useEffect(() => () => { engineRef.current?.dispose(); }, []);
+
+  const start = () => {
+    if (!engineRef.current) engineRef.current = new ToneEngine();
+    engineRef.current.ensure();
+    setOrder(shuffle(DYADS.map((_, idx) => idx)));
+    setRatings(new Array(DYADS.length).fill(0));
+    setPlayed(false);
+    setI(0);
+  };
+
+  const play = async () => {
+    if (order === null || busy) return;
+    const e = engineRef.current;
+    if (!e) return;
+    setBusy(true);
+    const d = DYADS[order[i]];
+    await e.playTones([ROOT, (ROOT * d.q) / d.p], 1600, 'rich', 0.6);
+    setBusy(false);
+    setPlayed(true);
+  };
+
+  const rate = (r: number) => {
+    if (order === null || busy || !played) return;
+    setRatings((rs) => {
+      const next = [...rs];
+      next[order[i]] = r;
+      return next;
+    });
+    setPlayed(false);
+    setI((v) => v + 1);
+  };
+
+  const done = order !== null && i >= DYADS.length;
+  // Sweetness should fall as the degree rises, so agreement = −ρ(rating, gradus).
+  const agreement = done ? -spearman(ratings, DYADS.map((d) => d.gradus)) : 0;
+  const sorted = [...DYADS.keys()].sort((a, b) => DYADS[a].gradus - DYADS[b].gradus);
+
+  return (
+    <LabCard
+      title="Station X — Grade the formula"
+      headerRight={
+        <button
+          onClick={start}
+          className="shrink-0 px-4 py-2 rounded-full text-sm font-medium bg-accent-rust text-white hover:opacity-90"
+        >
+          {order === null ? 'Begin rating' : 'Restart'}
+        </button>
+      }
+      caption="Eight intervals in random order. Play each and rate its sweetness from 1 (grating) to 7 (sweet). At the end, your ranking is set against Euler's computed degrees of agreeableness — a formula from 1739, graded by your ear."
+      sourceHref="/book/tentamen-novae-theoriae-musicae-euler"
+      sourceLabel="Euler, Tentamen novae theoriae musicae (1739)"
+    >
+      {order === null && (
+        <p className="text-sm text-secondary">
+          Euler&apos;s rule: reduce the interval to lowest terms, factor the product into primes, add
+          (prime − 1) for each factor, plus one. The octave scores <span className="font-mono">2</span>,
+          the fifth <span className="font-mono">4</span>, the semitone <span className="font-mono">11</span>.
+          Lower is sweeter — says the mathematics. You be the judge.
+        </p>
+      )}
+
+      {order !== null && !done && (
+        <div>
+          <p className="text-sm text-muted mb-3">Interval {i + 1} of {DYADS.length}</p>
+          <button
+            onClick={play}
+            disabled={busy}
+            className="w-full py-2.5 rounded bg-stone-900 text-white text-sm hover:bg-stone-700 disabled:opacity-40 mb-3"
+          >
+            {busy ? 'Playing…' : played ? 'Play again' : 'Play the interval'}
+          </button>
+          <div className="flex gap-1.5 justify-between">
+            {[1, 2, 3, 4, 5, 6, 7].map((r) => (
+              <button
+                key={r}
+                onClick={() => rate(r)}
+                disabled={busy || !played}
+                className="flex-1 py-2 rounded border border-border-light text-sm text-secondary hover:bg-stone-50 disabled:opacity-40"
+                aria-label={`Rate ${r} of 7`}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
+          <div className="flex justify-between text-[10px] text-muted mt-1">
+            <span>grating</span>
+            <span>sweet</span>
+          </div>
+        </div>
+      )}
+
+      {done && (
+        <div>
+          <div className="grid grid-cols-2 gap-3 mb-4">
+            <Readout
+              label="Agreement with Euler"
+              value={`ρ = ${agreement.toFixed(2)}`}
+              note={agreement >= 0.7 ? 'the formula holds for you' : agreement >= 0.3 ? 'partial credit' : 'your ear dissents'}
+            />
+            <Readout label="Euler's claim" value="ρ = 1.00" note="taste, computable" />
+          </div>
+          <table className="w-full text-xs text-secondary">
+            <thead>
+              <tr className="text-muted uppercase tracking-wider text-[10px]">
+                <th className="text-left py-1 font-medium">Interval</th>
+                <th className="text-left py-1 font-medium">Ratio</th>
+                <th className="text-left py-1 font-medium">Euler&apos;s degree</th>
+                <th className="text-left py-1 font-medium">Your rating</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((idx) => (
+                <tr key={idx} className="border-t border-border-light">
+                  <td className="py-1">{DYADS[idx].name}</td>
+                  <td className="py-1 font-mono">{DYADS[idx].p}:{DYADS[idx].q}</td>
+                  <td className="py-1 font-mono">{DYADS[idx].gradus}</td>
+                  <td className="py-1 font-mono">{ratings[idx]} / 7</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </LabCard>
+  );
+}

--- a/src/components/blog/lab/GalileoRhythmDemo.tsx
+++ b/src/components/blog/lab/GalileoRhythmDemo.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ToneEngine } from './audio';
+import { LabCard, PlayToggle, Readout, Chip } from './LabCard';
+
+const RATIOS = [
+  { a: 1, b: 2, name: 'an octave' },
+  { a: 2, b: 3, name: 'a perfect fifth' },
+  { a: 3, b: 4, name: 'a perfect fourth' },
+  { a: 4, b: 5, name: 'a major third' },
+];
+
+/**
+ * Station VI — Galileo's continuum: rhythm sped up until it is pitch.
+ *
+ * The Discorsi (First Day) grounds consonance in coincidence: two strings
+ * are concordant when their pulses strike the ear in a commensurable
+ * pattern. If that is true, a consonance is nothing but a rhythm too fast
+ * to count — so one tempo knob should carry a 2-against-3 drum pattern all
+ * the way up into a sounding fifth. It does. Both voices here are the SAME
+ * oscillator patch (a click train) from 2 clicks per second to 300.
+ */
+export default function GalileoRhythmDemo() {
+  const [playing, setPlaying] = useState(false);
+  const [ratioIdx, setRatioIdx] = useState(1);
+  const [speed, setSpeed] = useState(0); // 0..1 → base rate 1..100 /s (log)
+
+  const engineRef = useRef<ToneEngine | null>(null);
+
+  const ratio = RATIOS[ratioIdx];
+  const base = Math.pow(10, 2 * speed); // 1..100
+  const rateA = ratio.a * base;
+  const rateB = ratio.b * base;
+  const regime = base < 8 ? 'rhythm' : base < 30 ? 'flutter' : 'tone';
+
+  useEffect(() => {
+    const e = engineRef.current;
+    if (!e || !playing) return;
+    e.setVoice('trainA', rateA, 0.5, 'pulse');
+    e.setVoice('trainB', rateB, 0.5, 'pulse');
+  }, [playing, rateA, rateB]);
+
+  useEffect(() => () => { engineRef.current?.dispose(); }, []);
+
+  const toggle = () => {
+    if (playing) {
+      engineRef.current?.stopAllVoices();
+      engineRef.current?.suspend();
+      setPlaying(false);
+      return;
+    }
+    if (!engineRef.current) engineRef.current = new ToneEngine();
+    engineRef.current.ensure();
+    setPlaying(true);
+  };
+
+  return (
+    <LabCard
+      title="Station VI — Speed up the rhythm"
+      headerRight={<PlayToggle playing={playing} onClick={toggle} label="Play both pulses" />}
+      caption="Two click trains in a fixed whole-number ratio, one speed knob. Start slow enough to count the cross-rhythm, then drag right: nothing changes but the rate, and the pattern becomes an interval. Both voices are one and the same instrument throughout."
+      sourceHref="/book/discorsi-e-dimostrazioni-matematiche-intorno-a-due-nuove-galilei"
+      sourceLabel="Galileo, Discorsi e dimostrazioni matematiche intorno a due nuove scienze (1638)"
+    >
+      <div className="flex gap-1.5 mb-4 flex-wrap">
+        {RATIOS.map((r, i) => (
+          <Chip key={r.name} active={ratioIdx === i} onClick={() => setRatioIdx(i)}>
+            {r.a}:{r.b} — {r.name}
+          </Chip>
+        ))}
+      </div>
+
+      <div className="mb-4">
+        <label className="text-[11px] uppercase tracking-wider text-muted block mb-1">
+          Speed — the only thing this slider changes
+        </label>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.001}
+          value={speed}
+          onChange={(ev) => setSpeed(Number(ev.target.value))}
+          className="w-full accent-accent-rust"
+          aria-label="Pulse speed"
+        />
+        <div className="flex justify-between text-[10px] text-muted">
+          <span>countable</span>
+          <span>too fast to count</span>
+          <span>a chord</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        <Readout label="Lower voice" value={`${rateA.toFixed(rateA < 10 ? 1 : 0)} /s`} note={regime === 'tone' ? `= ${rateA.toFixed(0)} Hz` : 'pulses per second'} />
+        <Readout label="Upper voice" value={`${rateB.toFixed(rateB < 10 ? 1 : 0)} /s`} note={regime === 'tone' ? `= ${rateB.toFixed(0)} Hz` : 'pulses per second'} />
+        <Readout
+          label="Your ear hears"
+          value={regime === 'rhythm' ? `${ratio.a} against ${ratio.b}` : regime === 'flutter' ? 'a flutter' : ratio.name}
+          note={regime === 'rhythm' ? 'count it' : regime === 'flutter' ? 'the seam between senses' : 'rhythm, too fast to count'}
+        />
+      </div>
+    </LabCard>
+  );
+}

--- a/src/components/blog/lab/KeplerPlanetsDemo.tsx
+++ b/src/components/blog/lab/KeplerPlanetsDemo.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ToneEngine, centsBetween } from './audio';
+import { LabCard, PlayToggle, Readout, Chip } from './LabCard';
+
+/**
+ * Kepler's own table (Harmonices Mundi V.4, p. 325 of our copy): extreme
+ * apparent daily motions seen from the Sun, and the harmony he assigned to
+ * each planet. `e` is the modern (J2000) orbital eccentricity; conservation
+ * of angular momentum makes the true aphelion:perihelion angular-velocity
+ * ratio ((1+e)/(1-e))² — Kepler states the squaring himself on the facing
+ * page ("the proportion of the apparent motions is the double of the
+ * proportion of the eccentric").
+ */
+interface Planet {
+  name: string;
+  arcs: string; // Kepler's measured extremes, min′ sec″ per day
+  ratio: [number, number];
+  interval: string;
+  e: number;
+  base: number; // audible root for the siren, Hz
+  period: number; // siren sweep period, s — slower for the slow planets
+}
+
+const PLANETS: Planet[] = [
+  { name: 'Mercury', arcs: '164′0″ – 384′0″', ratio: [5, 12], interval: 'octave + minor third', e: 0.2056, base: 294, period: 1.6 },
+  { name: 'Venus', arcs: '94′50″ – 97′37″', ratio: [24, 25], interval: 'diesis', e: 0.0068, base: 262, period: 2.2 },
+  { name: 'Earth', arcs: '57′3″ – 61′18″', ratio: [15, 16], interval: 'semitone', e: 0.0167, base: 220, period: 2.8 },
+  { name: 'Mars', arcs: '26′14″ – 38′1″', ratio: [2, 3], interval: 'perfect fifth', e: 0.0934, base: 175, period: 3.4 },
+  { name: 'Jupiter', arcs: '4′30″ – 5′30″', ratio: [5, 6], interval: 'minor third', e: 0.0489, base: 110, period: 4.2 },
+  { name: 'Saturn', arcs: '1′46″ – 2′15″', ratio: [4, 5], interval: 'major third', e: 0.0565, base: 82, period: 5.2 },
+];
+
+const modernRatio = (e: number) => Math.pow((1 + e) / (1 - e), 2);
+const keplerCents = (p: Planet) => centsBetween(p.ratio[0], p.ratio[1]);
+const modernCents = (p: Planet) => centsBetween(1, modernRatio(p.e));
+
+function verdict(dev: number): string {
+  if (dev < 8) return 'nearly exact';
+  if (dev < 30) return 'off by about a comma';
+  if (dev < 60) return 'off by a quarter tone';
+  return 'off by more than a semitone';
+}
+
+/**
+ * Station VII — Kepler's planet-songs, scored against modern orbits.
+ *
+ * Each planet "sings" a glissando between its slowest (aphelion) and
+ * fastest (perihelion) apparent motion. Kepler heard the consonances in
+ * his table of extremes; modern eccentricities let us check him planet by
+ * planet.
+ */
+export default function KeplerPlanetsDemo() {
+  const [playing, setPlaying] = useState(false);
+  const [sel, setSel] = useState(2); // Earth
+  const [mode, setMode] = useState<'kepler' | 'modern'>('kepler');
+
+  const engineRef = useRef<ToneEngine | null>(null);
+
+  const p = PLANETS[sel];
+  const kc = keplerCents(p);
+  const mc = modernCents(p);
+  const dev = Math.abs(kc - mc);
+  const spanCents = mode === 'kepler' ? kc : mc;
+  const fHigh = p.base * Math.pow(2, spanCents / 1200);
+
+  useEffect(() => {
+    const e = engineRef.current;
+    if (!e || !playing) return;
+    e.setSiren('planet', p.base, fHigh, p.period, 0.5, 'sine');
+  }, [playing, p, fHigh]);
+
+  useEffect(() => () => { engineRef.current?.dispose(); }, []);
+
+  const toggle = () => {
+    if (playing) {
+      engineRef.current?.stopAllVoices();
+      engineRef.current?.suspend();
+      setPlaying(false);
+      return;
+    }
+    if (!engineRef.current) engineRef.current = new ToneEngine();
+    engineRef.current.ensure();
+    setPlaying(true);
+  };
+
+  return (
+    <LabCard
+      title="Station VII — The planets, auditioned"
+      headerRight={<PlayToggle playing={playing} onClick={toggle} label="Hear the planet" />}
+      caption="Pick a planet and hear it swing between its slowest and fastest motion, as Kepler notated — a continuous glissando, transposed into hearing range. Switch to the modern orbit to hear how far his harmony was from the measured sky."
+      sourceHref="/book/the-harmony-of-the-world-kepler?page=325"
+      sourceLabel="Kepler, Harmonices Mundi, Book V, ch. 4 (1619) — the table of extreme motions"
+    >
+      <div className="flex gap-1.5 mb-3 flex-wrap">
+        {PLANETS.map((pl, i) => (
+          <Chip key={pl.name} active={sel === i} onClick={() => setSel(i)}>{pl.name}</Chip>
+        ))}
+      </div>
+      <div className="flex gap-1.5 mb-4">
+        <Chip active={mode === 'kepler'} onClick={() => setMode('kepler')}>Kepler&apos;s harmony</Chip>
+        <Chip active={mode === 'modern'} onClick={() => setMode('modern')}>Modern orbit</Chip>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 mb-4">
+        <Readout label="Kepler assigned" value={`${p.ratio[0]}:${p.ratio[1]}`} note={`${p.interval} — ${Math.round(kc)} ¢`} />
+        <Readout label="Modern orbit gives" value={`${Math.round(mc)} ¢`} note={`from e = ${p.e}`} />
+        <Readout label="Kepler's error" value={`${dev.toFixed(1)} ¢`} note={verdict(dev)} />
+      </div>
+
+      <table className="w-full text-xs text-secondary">
+        <thead>
+          <tr className="text-muted uppercase tracking-wider text-[10px]">
+            <th className="text-left py-1 font-medium">Planet</th>
+            <th className="text-left py-1 font-medium">His 1619 extremes</th>
+            <th className="text-left py-1 font-medium">His harmony</th>
+            <th className="text-left py-1 font-medium">Modern</th>
+            <th className="text-left py-1 font-medium">Error</th>
+          </tr>
+        </thead>
+        <tbody>
+          {PLANETS.map((pl, i) => {
+            const k = keplerCents(pl);
+            const m = modernCents(pl);
+            return (
+              <tr
+                key={pl.name}
+                className={`border-t border-border-light cursor-pointer ${sel === i ? 'bg-accent-rust/5' : 'hover:bg-stone-50'}`}
+                onClick={() => setSel(i)}
+              >
+                <td className="py-1">{pl.name}</td>
+                <td className="py-1 font-mono">{pl.arcs}</td>
+                <td className="py-1">{pl.ratio[0]}:{pl.ratio[1]} <span className="text-muted">({Math.round(k)} ¢)</span></td>
+                <td className="py-1 font-mono">{Math.round(m)} ¢</td>
+                <td className="py-1 font-mono">{Math.abs(k - m).toFixed(0)} ¢</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </LabCard>
+  );
+}

--- a/src/components/blog/lab/KircherResonanceDemo.tsx
+++ b/src/components/blog/lab/KircherResonanceDemo.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ToneEngine } from './audio';
+import { LabCard, Chip } from './LabCard';
+
+/** The five tuned strings of the bank. Spaced whole steps apart or more, so resonance is selective. */
+const STRINGS = [
+  { note: 'G', freq: 196.0 },
+  { note: 'A', freq: 220.0 },
+  { note: 'B', freq: 246.94 },
+  { note: 'D', freq: 293.66 },
+  { note: 'E', freq: 329.63 },
+];
+
+const STRIKES = [
+  ...STRINGS.map((s) => ({ label: `Strike ${s.note}`, freq: s.freq })),
+  { label: 'Strike between A and B', freq: 233.08 },
+];
+
+const Q = 55;
+
+/** Amplitude response of a bandpass resonator at driving frequency f — the physics of the sympathetic answer. */
+function response(f: number, f0: number): number {
+  const x = f / f0 - f0 / f;
+  return 1 / Math.sqrt(1 + Q * Q * x * x);
+}
+
+/**
+ * Station VIII — Kircher's sympathetic strings.
+ *
+ * Musurgia Universalis: pluck a string and an untouched string tuned in
+ * unison answers, while its mistuned neighbours stay silent. Kircher read
+ * this as the natural magic of consonance; the modern reading is resonance.
+ * Here the untouched strings are resonators (narrow bandpass filters, the
+ * physicist's model of a sympathetic string): the struck tone is fed
+ * through all five at once, and only the one whose tuning matches rings —
+ * and keeps ringing after the strike dies.
+ */
+export default function KircherResonanceDemo() {
+  const [amps, setAmps] = useState<number[]>(STRINGS.map(() => 0));
+  const [lastStrike, setLastStrike] = useState<number | null>(null);
+
+  const engineRef = useRef<ToneEngine | null>(null);
+  const bankRef = useRef<BiquadFilterNode[] | null>(null);
+  const decayRef = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (decayRef.current !== null) window.clearTimeout(decayRef.current);
+    engineRef.current?.dispose();
+  }, []);
+
+  const ensureBank = () => {
+    if (!engineRef.current) engineRef.current = new ToneEngine();
+    const ctx = engineRef.current.ensure();
+    const out = engineRef.current.output;
+    if (!ctx || !out) return null;
+    if (!bankRef.current) {
+      bankRef.current = STRINGS.map((s) => {
+        const bp = ctx.createBiquadFilter();
+        bp.type = 'bandpass';
+        bp.frequency.value = s.freq;
+        bp.Q.value = Q;
+        const g = ctx.createGain();
+        g.gain.value = 3.5; // a narrow bandpass attenuates heavily; make the answer audible
+        bp.connect(g);
+        g.connect(out);
+        return bp;
+      });
+    }
+    return ctx;
+  };
+
+  const strike = (freq: number) => {
+    const ctx = ensureBank();
+    const e = engineRef.current;
+    const out = e?.output;
+    if (!ctx || !e || !out || !bankRef.current) return;
+
+    // The struck string: a plucked tone that decays in ~1.8 s.
+    const t0 = ctx.currentTime;
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.value = freq;
+    const env = ctx.createGain();
+    env.gain.setValueAtTime(0, t0);
+    env.gain.linearRampToValueAtTime(0.9, t0 + 0.015);
+    env.gain.exponentialRampToValueAtTime(0.001, t0 + 1.8);
+    osc.connect(env);
+    // Dry path (the strike itself, quiet) + the resonator bank (the answer).
+    const dry = ctx.createGain();
+    dry.gain.value = 0.15;
+    env.connect(dry);
+    dry.connect(out);
+    for (const bp of bankRef.current) env.connect(bp);
+    osc.start(t0);
+    osc.stop(t0 + 2.0);
+
+    setLastStrike(freq);
+    setAmps(STRINGS.map((s) => response(freq, s.freq)));
+    if (decayRef.current !== null) window.clearTimeout(decayRef.current);
+    decayRef.current = window.setTimeout(() => setAmps(STRINGS.map(() => 0)), 2600);
+  };
+
+  return (
+    <LabCard
+      title="Station VIII — The string that answers"
+      headerRight={null}
+      caption="Five tuned strings, none of them touched. Strike a tone: the string in unison with it swells and keeps singing after the strike fades; its neighbours, a tone away, barely stir. Then strike between two tunings and hear the answer refuse to come."
+      sourceHref="/book/kircher-musurgia-universalis-vol-ii-1650-kircher"
+      sourceLabel="Kircher, Musurgia Universalis, Vol. II (1650)"
+    >
+      <div className="flex gap-1.5 mb-5 flex-wrap">
+        {STRIKES.map((s) => (
+          <Chip key={s.label} active={lastStrike === s.freq} onClick={() => strike(s.freq)}>
+            {s.label}
+          </Chip>
+        ))}
+      </div>
+
+      <svg viewBox="0 0 300 110" className="w-full max-w-[340px] mx-auto block mb-4" role="img"
+        aria-label="Five vertical strings; the one tuned to the struck pitch vibrates most">
+        {STRINGS.map((s, i) => {
+          const x = 40 + i * 55;
+          const a = amps[i] * 16;
+          const ringing = a > 1.5;
+          return (
+            <g key={s.note}>
+              <path
+                d={`M ${x} 8 Q ${x + a} 55 ${x} 102`}
+                fill="none"
+                stroke={ringing ? '#a8503c' : '#78716c'}
+                strokeWidth={ringing ? 2 : 1.2}
+                style={{ transition: 'all 2.2s ease-out' }}
+              />
+              <path
+                d={`M ${x} 8 Q ${x - a} 55 ${x} 102`}
+                fill="none"
+                stroke={ringing ? '#a8503c' : '#78716c'}
+                strokeOpacity={0.45}
+                strokeWidth={1}
+                style={{ transition: 'all 2.2s ease-out' }}
+              />
+              <text x={x} y={109} textAnchor="middle" fontSize={8} fill={ringing ? '#a8503c' : '#a8a29e'}>
+                {s.note} · {Math.round(s.freq)} Hz
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      <div className="grid grid-cols-5 gap-2">
+        {STRINGS.map((s, i) => (
+          <div key={s.note} className="rounded border border-border-light bg-cream px-1 py-1.5 text-center">
+            <p className="text-[10px] uppercase tracking-wider text-muted">{s.note} answers</p>
+            <p className="font-mono text-xs text-primary">{Math.round(amps[i] * 100)}%</p>
+          </div>
+        ))}
+      </div>
+    </LabCard>
+  );
+}

--- a/src/components/blog/lab/YueJiAffectDemo.tsx
+++ b/src/components/blog/lab/YueJiAffectDemo.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ToneEngine, Timbre } from './audio';
+import { LabCard, Readout } from './LabCard';
+
+// Pentatonic (gong scale on C) — the note-material of the Record's world.
+const N = {
+  C3: 130.81, D3: 146.83, E3: 164.81, G3: 196.0, A3: 220.0,
+  C4: 261.63, D4: 293.66, E4: 329.63, G4: 392.0, A4: 440.0,
+  C5: 523.25, D5: 587.33, E5: 659.26, G5: 783.99, A5: 880.0,
+};
+
+interface Step { freqs: number[]; ms: number; gap: number; level: number; timbre: Timbre }
+
+/**
+ * Each phrase is engineered to ONE of the Yo Kî's six sound-descriptions
+ * (Li Ki, Book XVII, opening section) — register, tempo, articulation and
+ * timbre follow the text's adjectives, nothing else. The reader's job is
+ * to hear which is which.
+ */
+const AFFECTS: Array<{ affect: string; descriptor: string; steps: Step[] }> = [
+  {
+    affect: 'sorrow',
+    descriptor: 'sharp and fading away',
+    steps: [N.A5, N.G5, N.E5, N.D5, N.C5].map((f, i) => ({
+      freqs: [f], ms: 300, gap: 240, level: 0.55 - i * 0.08, timbre: 'sine' as Timbre,
+    })),
+  },
+  {
+    affect: 'pleasure',
+    descriptor: 'slow and gentle',
+    steps: [N.C4, N.D4, N.E4, N.G4, N.E4, N.D4, N.C4].map((f) => ({
+      freqs: [f], ms: 650, gap: 70, level: 0.32, timbre: 'sine' as Timbre,
+    })),
+  },
+  {
+    affect: 'joy',
+    descriptor: 'exclamatory and soon disappears',
+    steps: [
+      { freqs: [N.C4], ms: 160, gap: 20, level: 0.6, timbre: 'rich' as Timbre },
+      { freqs: [N.G4], ms: 160, gap: 20, level: 0.62, timbre: 'rich' as Timbre },
+      { freqs: [N.C5], ms: 220, gap: 380, level: 0.65, timbre: 'rich' as Timbre },
+      { freqs: [N.E4], ms: 160, gap: 20, level: 0.6, timbre: 'rich' as Timbre },
+      { freqs: [N.A4], ms: 160, gap: 20, level: 0.62, timbre: 'rich' as Timbre },
+      { freqs: [N.E5], ms: 220, gap: 0, level: 0.65, timbre: 'rich' as Timbre },
+    ],
+  },
+  {
+    affect: 'anger',
+    descriptor: 'coarse and fierce',
+    steps: [N.C3, N.G3, N.C3, N.A3, N.D3, N.G3].map((f) => ({
+      freqs: [f], ms: 140, gap: 35, level: 0.8, timbre: 'rich' as Timbre,
+    })),
+  },
+  {
+    affect: 'reverence',
+    descriptor: 'straightforward, with an indication of humility',
+    steps: [N.G3, N.G3, N.G3, N.A3, N.G3, N.E3].map((f) => ({
+      freqs: [f], ms: 550, gap: 260, level: 0.4, timbre: 'sine' as Timbre,
+    })),
+  },
+  {
+    affect: 'love',
+    descriptor: 'harmonious and soft',
+    steps: [
+      { freqs: [N.C4, N.E4], ms: 700, gap: 90, level: 0.42, timbre: 'sine' as Timbre },
+      { freqs: [N.G3, N.D4], ms: 700, gap: 90, level: 0.42, timbre: 'sine' as Timbre },
+      { freqs: [N.A3, N.E4], ms: 700, gap: 90, level: 0.42, timbre: 'sine' as Timbre },
+      { freqs: [N.C4, N.E4, N.G4], ms: 950, gap: 0, level: 0.48, timbre: 'sine' as Timbre },
+    ],
+  },
+];
+
+const sleep = (ms: number) => new Promise<void>((r) => window.setTimeout(r, ms));
+const shuffle = <T,>(xs: T[]): T[] => {
+  const a = [...xs];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+};
+
+/**
+ * Station IX — the Record of Music's six sounds, blind.
+ *
+ * The Yo Kî claims each state of mind stamps a recognizably different
+ * character on sound — and describes all six. If the claim is right, the
+ * descriptions should be legible in reverse: hear a phrase built to one
+ * description, name the state. Six rounds, one per affect, order random.
+ */
+export default function YueJiAffectDemo() {
+  const [order, setOrder] = useState<number[] | null>(null);
+  const [i, setI] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [picks, setPicks] = useState<number[]>([]);
+
+  const engineRef = useRef<ToneEngine | null>(null);
+  useEffect(() => () => { engineRef.current?.dispose(); }, []);
+
+  const start = () => {
+    if (!engineRef.current) engineRef.current = new ToneEngine();
+    engineRef.current.ensure();
+    setOrder(shuffle(AFFECTS.map((_, idx) => idx)));
+    setPicks([]);
+    setI(0);
+  };
+
+  const play = async () => {
+    if (order === null || busy) return;
+    const e = engineRef.current;
+    if (!e) return;
+    setBusy(true);
+    for (const s of AFFECTS[order[i]].steps) {
+      await e.playTones(s.freqs, s.ms, s.timbre, s.level);
+      if (s.gap) await sleep(s.gap);
+    }
+    setBusy(false);
+  };
+
+  const pick = (affectIdx: number) => {
+    if (busy) return;
+    setPicks((p) => [...p, affectIdx]);
+    setI((v) => v + 1);
+  };
+
+  const done = order !== null && i >= AFFECTS.length;
+  const score = done ? picks.filter((p, idx) => p === order[idx]).length : 0;
+
+  return (
+    <LabCard
+      title="Station IX — Name the state of mind"
+      headerRight={
+        <button
+          onClick={start}
+          className="shrink-0 px-4 py-2 rounded-full text-sm font-medium bg-accent-rust text-white hover:opacity-90"
+        >
+          {order === null ? 'Begin' : 'Restart'}
+        </button>
+      }
+      caption="Six phrases, each built strictly to one of the Record of Music's six descriptions — register, pace and touch follow the text's adjectives and nothing else. Hear each one blind and name the state of mind. Chance is one in six."
+      sourceHref="/book/the-sacred-books-of-china-li-ki-part-2-sbe-vol-28-trans?page=107"
+      sourceLabel="Record of Music (Yo Kî), in Legge's Li Ki (1885)"
+    >
+      {order === null && (
+        <p className="text-sm text-secondary">
+          The Record lists six: sorrow, pleasure, joy, anger, reverence, love — each with its own
+          sound-signature, and none of them, it insists, natural: they are the mark of what has
+          moved the mind.
+        </p>
+      )}
+
+      {order !== null && !done && (
+        <div>
+          <p className="text-sm text-muted mb-3">Round {i + 1} of {AFFECTS.length}</p>
+          <button
+            onClick={play}
+            disabled={busy}
+            className="w-full py-2.5 rounded bg-stone-900 text-white text-sm hover:bg-stone-700 disabled:opacity-40 mb-3"
+          >
+            {busy ? 'Playing…' : 'Play the phrase'}
+          </button>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+            {AFFECTS.map((a, idx) => (
+              <button
+                key={a.affect}
+                onClick={() => pick(idx)}
+                disabled={busy}
+                className="py-2 rounded border border-border-light text-sm text-secondary hover:bg-stone-50 disabled:opacity-40 capitalize"
+              >
+                {a.affect}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {done && (
+        <div>
+          <div className="grid grid-cols-2 gap-3 mb-4">
+            <Readout label="Your score" value={`${score} of ${AFFECTS.length}`} note={score >= 4 ? 'the Record holds up' : score >= 2 ? 'partly legible' : 'chance is 1 in 6'} />
+            <Readout label="The Record's claim" value="6 of 6" note="each state has its sound" />
+          </div>
+          <table className="w-full text-xs text-secondary">
+            <thead>
+              <tr className="text-muted uppercase tracking-wider text-[10px]">
+                <th className="text-left py-1 font-medium">The sound was…</th>
+                <th className="text-left py-1 font-medium">The Record says</th>
+                <th className="text-left py-1 font-medium">You said</th>
+              </tr>
+            </thead>
+            <tbody>
+              {order.map((affectIdx, round) => (
+                <tr key={round} className="border-t border-border-light">
+                  <td className="py-1 italic">&ldquo;{AFFECTS[affectIdx].descriptor}&rdquo;</td>
+                  <td className="py-1 capitalize">{AFFECTS[affectIdx].affect}</td>
+                  <td className={`py-1 capitalize ${picks[round] === affectIdx ? 'text-primary' : 'text-muted line-through'}`}>
+                    {AFFECTS[picks[round]].affect}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </LabCard>
+  );
+}

--- a/src/components/blog/lab/audio.ts
+++ b/src/components/blog/lab/audio.ts
@@ -7,22 +7,27 @@
  * - All level changes ramp via setTargetAtTime — no clicks.
  * - Callers own teardown: suspend() on pause, dispose() on unmount.
  *
- * Two timbres: 'sine' (pure tone — psychoacoustics stations) and 'rich'
+ * Three timbres: 'sine' (pure tone — psychoacoustics stations), 'rich'
  * (six harmonics at 1/n^1.5 — tuning-preference stations, where beating
- * between upper partials is the audible difference between temperaments).
+ * between upper partials is the audible difference between temperaments),
+ * and 'pulse' (a click train: hundreds of near-equal harmonics, so the same
+ * oscillator is countable ticks at 2 Hz and a buzzy pitch at 200 Hz — the
+ * Galileo rhythm-becomes-pitch continuum needs one mechanism across both).
  */
 
-export type Timbre = 'sine' | 'rich';
+export type Timbre = 'sine' | 'rich' | 'pulse';
 
 interface Voice {
   osc: OscillatorNode;
   gain: GainNode;
+  lfo?: OscillatorNode;
 }
 
 export class ToneEngine {
   private ctx: AudioContext | null = null;
   private master: GainNode | null = null;
   private richWave: PeriodicWave | null = null;
+  private pulseWave: PeriodicWave | null = null;
   private voices = new Map<string, Voice>();
 
   /** Create (or resume) the context. Call only from a user-gesture handler. */
@@ -45,6 +50,13 @@ export class ToneEngine {
     const imag = new Float32Array(n + 1);
     for (let i = 1; i <= n; i++) imag[i] = 1 / Math.pow(i, 1.5);
     this.richWave = ctx.createPeriodicWave(real, imag, { disableNormalization: false });
+    // Click train: near-flat spectrum. WebAudio band-limits PeriodicWave per
+    // octave, so the same wave is safe from 2 Hz (ticks) to 300 Hz (a tone).
+    const pn = 1024;
+    const preal = new Float32Array(pn + 1);
+    const pimag = new Float32Array(pn + 1);
+    for (let i = 1; i <= pn; i++) pimag[i] = 1 / Math.pow(i, 0.2);
+    this.pulseWave = ctx.createPeriodicWave(preal, pimag, { disableNormalization: false });
     this.ctx = ctx;
     this.master = master;
     return ctx;
@@ -52,6 +64,17 @@ export class ToneEngine {
 
   get context(): AudioContext | null {
     return this.ctx;
+  }
+
+  /** Master bus, for stations that build their own node graphs (resonator banks). */
+  get output(): GainNode | null {
+    return this.master;
+  }
+
+  private applyTimbre(osc: OscillatorNode, timbre: Timbre) {
+    if (timbre === 'rich' && this.richWave) osc.setPeriodicWave(this.richWave);
+    else if (timbre === 'pulse' && this.pulseWave) osc.setPeriodicWave(this.pulseWave);
+    else osc.type = 'sine';
   }
 
   /** Create or retune a sustained voice. Level is per-voice (0..1). */
@@ -66,8 +89,7 @@ export class ToneEngine {
       return;
     }
     const osc = ctx.createOscillator();
-    if (timbre === 'rich' && this.richWave) osc.setPeriodicWave(this.richWave);
-    else osc.type = 'sine';
+    this.applyTimbre(osc, timbre);
     osc.frequency.value = freq;
     const gain = ctx.createGain();
     gain.gain.value = 0;
@@ -78,14 +100,45 @@ export class ToneEngine {
     this.voices.set(id, { osc, gain });
   }
 
+  /**
+   * A sustained voice that glides continuously between two frequencies —
+   * Kepler's planet-song, "a continuous series of intermediate notes"
+   * (Harmonices Mundi V.6). Sine-shaped sweep, one full cycle per `periodS`.
+   */
+  setSiren(id: string, fLow: number, fHigh: number, periodS: number, level: number, timbre: Timbre = 'sine') {
+    const ctx = this.ctx;
+    if (!ctx || !this.master) return;
+    this.removeVoice(id);
+    const t = ctx.currentTime;
+    const osc = ctx.createOscillator();
+    this.applyTimbre(osc, timbre);
+    osc.frequency.value = (fLow + fHigh) / 2;
+    const lfo = ctx.createOscillator();
+    lfo.type = 'sine';
+    lfo.frequency.value = 1 / periodS;
+    const depth = ctx.createGain();
+    depth.gain.value = (fHigh - fLow) / 2;
+    lfo.connect(depth);
+    depth.connect(osc.frequency);
+    const gain = ctx.createGain();
+    gain.gain.value = 0;
+    osc.connect(gain);
+    gain.connect(this.master);
+    osc.start();
+    lfo.start();
+    gain.gain.setTargetAtTime(level, t, 0.03);
+    this.voices.set(id, { osc, gain, lfo });
+  }
+
   removeVoice(id: string) {
     const ctx = this.ctx;
     const v = this.voices.get(id);
     if (!ctx || !v) return;
     v.gain.gain.setTargetAtTime(0, ctx.currentTime, 0.03);
     const osc = v.osc;
+    const lfo = v.lfo;
     window.setTimeout(() => {
-      try { osc.stop(); } catch { /* stopped */ }
+      try { osc.stop(); lfo?.stop(); } catch { /* stopped */ }
     }, 150);
     this.voices.delete(id);
   }
@@ -112,8 +165,7 @@ export class ToneEngine {
     const per = level / Math.max(1, freqs.length);
     for (const f of freqs) {
       const osc = ctx.createOscillator();
-      if (timbre === 'rich' && this.richWave) osc.setPeriodicWave(this.richWave);
-      else osc.type = 'sine';
+      this.applyTimbre(osc, timbre);
       osc.frequency.value = f;
       const g = ctx.createGain();
       g.gain.setValueAtTime(0, t0);
@@ -130,13 +182,14 @@ export class ToneEngine {
 
   dispose() {
     try {
-      for (const v of this.voices.values()) v.osc.stop();
+      for (const v of this.voices.values()) { v.osc.stop(); v.lfo?.stop(); }
       void this.ctx?.close();
     } catch { /* already closed */ }
     this.voices.clear();
     this.ctx = null;
     this.master = null;
     this.richWave = null;
+    this.pulseWave = null;
   }
 }
 


### PR DESCRIPTION
Closes nothing — tracks #3160 (reopened for follow-on stations).

## What's in scope

Five new stations for [/blog/sound-laboratory](https://sourcelibrary.org/blog/sound-laboratory), following the conventions set in #3162 (ToneEngine, LabCard, `sourceHref` required, results local-only):

- **VI. Galileo — rhythm sped up into pitch.** New `pulse` click-train timbre in the shared engine; one speed slider carries a 2:3 (or 1:2 / 3:4 / 4:5) pattern from countable rhythm through flutter into a sounding interval. Anchored to the *Discorsi* (held).
- **VII. Kepler — the planets, auditioned.** New `setSiren` glissando voice. Kepler's own extreme-motion table (*Harmonices Mundi* V.4, our p.325) per planet, scored in cents against modern (J2000) eccentricities via ((1+e)/(1−e))² — the squaring Kepler himself states on the facing page. Earth's error: 3.9 ¢; Mercury's: 71 ¢. The MI FA MI 'Misery and Famine' margin quote verified at p.336.
- **VIII. Kircher — sympathetic strings.** Bandpass resonator bank (Q=55) fed by a plucked tone through the engine's new master-bus tap; only the string in unison answers (measured 100% vs 8% for neighbours a tone away; a strike between two tunings gets ~16%/16%). *Musurgia Universalis* Vol. II (held).
- **IX. Yue Ji — name the state of mind.** The Record of Music's six sound-descriptors as a blind attribution test; phrases engineered strictly to the text's adjectives. Both quotes verified verbatim against Legge's Li Ki p.107 (our copy).
- **X. Euler — grade the formula.** *Gradus suavitatis* computed live from prime factorization (not hardcoded); reader rates eight dyads blind, gets Spearman rank agreement with the 1739 ordering.

Plus, per Derek's request: **Descartes' circular pitch diagrams in Station II** — an interactive folio strip (zoomed thumbnails → inline expansion → reader links) of the two circle plates from the *Compendium Musicae* (his first book, written 1618; our 1656 KB Den Haag copy, pp. 23/33 of the scan).

## Verification

- `npx tsc --noEmit` clean; pre-commit import check clean.
- All ten stations exercised in a real browser (dev server + DevTools MCP): headings, hydration, audio start/stop, Galileo slider end-to-end (2/s ticks → 200 Hz fifth), Kepler planet/mode switching + table, Kircher strike responses, Yue Ji trial flow, Descartes plate expand/collapse.
- Reader links soft-404-checked (grep for 'page not found', not status codes).
- Kepler and Yue Ji quotes verified against page text; station sources link to held books only.

## Out of scope

- Salmon-passage-in-three-temperaments (a richer v2 of Station IV) and any aggregate results collection — per the issue, reader scores stay local.
- Gallery extraction repair for the Descartes book (only 1 of its ~15 diagrams was extracted — worth a separate sweep; noting in #3160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)