### PR TITLE
feat(collections): show total book count on collection cards

### DIFF
--- a/scripts/maintenance/backfill-total-book-count.mjs
+++ b/scripts/maintenance/backfill-total-book-count.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Backfill collections.total_book_count = ALL visible member books (regardless
+ * of translation), so cards can show total holdings rather than the
+ * translated-only `book_count` (which syncCollectionCounts caches with a
+ * pages_translated>0 filter). Artworks are excluded (counted as artwork_count).
+ *   node scripts/maintenance/backfill-total-book-count.mjs [--apply]
+ */
+import { MongoClient } from 'mongodb';
+const APPLY = process.argv.includes('--apply');
+const c = new MongoClient(process.env.MONGODB_URI); await c.connect();
+const db = c.db('bookstore');
+
+const rows = await db.collection('books').aggregate([
+  { $match: { status: { $ne: 'deleted' }, visible: true, resource_type: { $exists: false } } },
+  { $unwind: '$collections' },
+  { $group: { _id: '$collections', n: { $sum: 1 } } },
+], { allowDiskUse: true }).toArray();
+const totalMap = new Map(rows.map(r => [r._id, r.n]));
+
+const cols = await db.collection('collections')
+  .find({}, { projection: { _id:1, slug:1, name:1, book_count:1, total_book_count:1, parent:1 } }).toArray();
+
+const ops = []; let changed = 0;
+const sample = [];
+for (const col of cols) {
+  const total = totalMap.get(col.slug) || 0;
+  if ((col.total_book_count || 0) !== total) {
+    changed++;
+    ops.push({ updateOne: { filter: { _id: col._id }, update: { $set: { total_book_count: total, updated_at: new Date() } } } });
+  }
+  if (!col.parent && total !== (col.book_count||0)) sample.push({ slug: col.slug, translated: col.book_count||0, total });
+}
+sample.sort((a,b)=>b.total-a.total);
+console.log('Top-level cards where total > translated (sample):');
+for (const s of sample.slice(0,20)) console.log(`  ${s.translated} -> ${s.total}\t ${s.slug}`);
+console.log(`\n${changed} collections need total_book_count set.`);
+if (APPLY && ops.length) { const r = await db.collection('collections').bulkWrite(ops); console.log('modified:', r.modifiedCount); }
+else console.log('DRY RUN — pass --apply to write.');
+await c.close();

--- a/scripts/workers/sync-worker.mjs
+++ b/scripts/workers/sync-worker.mjs
@@ -200,7 +200,11 @@ async function syncCollectionCounts(db) {
   // One pass over books per counter, instead of 2 countDocuments per collection.
   // book_count uses the canonical "readable book" filter from the archived cron;
   // artwork_count counts resource_type-bearing entries regardless of visibility.
-  const [bookCounts, artworkCounts] = await Promise.all([
+  // total_book_count = ALL visible member books (any translation state), so
+  // collection cards can show total holdings rather than the readable-only
+  // book_count. Artworks (resource_type present) stay excluded — they have
+  // their own artwork_count.
+  const [bookCounts, artworkCounts, totalBookCounts] = await Promise.all([
     db.collection('books').aggregate([
       { $match: { status: { $ne: 'deleted' }, visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 }, resource_type: { $exists: false } } },
       { $unwind: '$collections' },
@@ -211,12 +215,18 @@ async function syncCollectionCounts(db) {
       { $unwind: '$collections' },
       { $group: { _id: '$collections', n: { $sum: 1 } } },
     ]).toArray(),
+    db.collection('books').aggregate([
+      { $match: { status: { $ne: 'deleted' }, visible: true, resource_type: { $exists: false } } },
+      { $unwind: '$collections' },
+      { $group: { _id: '$collections', n: { $sum: 1 } } },
+    ], { allowDiskUse: true }).toArray(),
   ]);
   const bookMap = new Map(bookCounts.map(r => [r._id, r.n]));
   const artMap = new Map(artworkCounts.map(r => [r._id, r.n]));
+  const totalMap = new Map(totalBookCounts.map(r => [r._id, r.n]));
 
   const collections = await db.collection('collections')
-    .find({}, { projection: { _id: 1, slug: 1, book_count: 1, artwork_count: 1 } })
+    .find({}, { projection: { _id: 1, slug: 1, book_count: 1, artwork_count: 1, total_book_count: 1 } })
     .toArray();
 
   const ops = [];
@@ -224,13 +234,14 @@ async function syncCollectionCounts(db) {
   for (const col of collections) {
     const liveBookCount = bookMap.get(col.slug) || 0;
     const liveArtworkCount = artMap.get(col.slug) || 0;
-    if ((col.book_count || 0) !== liveBookCount || (col.artwork_count || 0) !== liveArtworkCount) {
+    const liveTotalBookCount = totalMap.get(col.slug) || 0;
+    if ((col.book_count || 0) !== liveBookCount || (col.artwork_count || 0) !== liveArtworkCount || (col.total_book_count || 0) !== liveTotalBookCount) {
       mismatchCount++;
       if (!DRY_RUN) {
         ops.push({
           updateOne: {
             filter: { _id: col._id },
-            update: { $set: { book_count: liveBookCount, artwork_count: liveArtworkCount, updated_at: new Date() } },
+            update: { $set: { book_count: liveBookCount, artwork_count: liveArtworkCount, total_book_count: liveTotalBookCount, updated_at: new Date() } },
           },
         });
       }

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -634,7 +634,7 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     db.collection('collections')
       .find({ parent: id, visible: true, ...(tenantId ? { tenantId } : {}) })
       .sort({ book_count: -1 })
-      .project({ slug: 1, name: 1, subtitle: 1, book_count: 1, featured_images: 1 })
+      .project({ slug: 1, name: 1, subtitle: 1, book_count: 1, total_book_count: 1, featured_images: 1 })
       .toArray(),
     8000, [],
   );
@@ -750,7 +750,7 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
     galleryTotalCount,
     exhibition: curationDraft?.curation ? JSON.parse(JSON.stringify(curationDraft.curation)) : null,
     exhibitionBooks,
-    childCollections: childCollections.map(({ _id, ...rest }) => rest) as { slug: string; name: string; subtitle?: string; book_count?: number; featured_images?: ({ extracted_url?: string; image_url?: string; thumbnail_url?: string } | string)[] }[],
+    childCollections: childCollections.map(({ _id, ...rest }) => rest) as { slug: string; name: string; subtitle?: string; book_count?: number; total_book_count?: number; featured_images?: ({ extracted_url?: string; image_url?: string; thumbnail_url?: string } | string)[] }[],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     artworks: artworks as any[],
   };
@@ -1038,9 +1038,9 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                     )}
                     <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
                     <div className="absolute inset-0 flex flex-col justify-end p-3 sm:p-4">
-                      {child.book_count ? (
+                      {(child.total_book_count ?? child.book_count) ? (
                         <p className="text-white/50 text-xs mb-1 hidden sm:block">
-                          {child.book_count.toLocaleString('en-US')} {itemLabel}
+                          {(child.total_book_count ?? child.book_count)!.toLocaleString('en-US')} {itemLabel}
                         </p>
                       ) : null}
                       <h3 className="font-serif text-sm sm:text-base lg:text-lg text-white font-semibold leading-tight line-clamp-2 group-hover:text-accent-gold transition-colors">

--- a/src/app/collections/all/page.tsx
+++ b/src/app/collections/all/page.tsx
@@ -24,6 +24,7 @@ interface SubCollection {
   tenant_slug?: string | null;
   name: string;
   book_count: number;
+  total_book_count?: number;
   artwork_count?: number;
   visible: boolean;
   type?: string;
@@ -35,6 +36,7 @@ interface Wing {
   tenant_slug?: string | null;
   name: string;
   book_count: number;
+  total_book_count?: number;
   artwork_count?: number;
   image?: string;
   children: SubCollection[];
@@ -55,7 +57,7 @@ async function fetchWings(): Promise<Wing[]> {
     type: { $ne: 'curated' },
     collection_type: { $ne: 'visual_art' },
     visible: true,
-  }).project({ slug: 1, tenantId: 1, name: 1, book_count: 1, artwork_count: 1, hero_image: 1, featured_images: { $slice: 1 }, _id: 0 }).sort({ name: 1 }).toArray();
+  }).project({ slug: 1, tenantId: 1, name: 1, book_count: 1, total_book_count: 1, artwork_count: 1, hero_image: 1, featured_images: { $slice: 1 }, _id: 0 }).sort({ name: 1 }).toArray();
 
   // Get all subcollections with their first featured image. Only explicit
   // visible:false is excluded — hidden collections (e.g. takedowns) must not
@@ -64,7 +66,7 @@ async function fetchWings(): Promise<Wing[]> {
     parent: { $exists: true },
     visible: { $ne: false },
   }).project({
-    slug: 1, tenantId: 1, name: 1, book_count: 1, artwork_count: 1, parent: 1, visible: 1, type: 1,
+    slug: 1, tenantId: 1, name: 1, book_count: 1, total_book_count: 1, artwork_count: 1, parent: 1, visible: 1, type: 1,
     hero_image: 1, featured_images: { $slice: 1 }, _id: 0,
   }).toArray();
 
@@ -91,6 +93,7 @@ async function fetchWings(): Promise<Wing[]> {
         tenant_slug: sub.tenantId ? tenantSlugById.get(sub.tenantId) || null : null,
         name: sub.name || sub.slug,
         book_count: sub.book_count || 0,
+        total_book_count: sub.total_book_count,
         artwork_count: sub.artwork_count || 0,
         visible: sub.visible !== false,
         type: sub.type,
@@ -109,6 +112,7 @@ async function fetchWings(): Promise<Wing[]> {
     tenant_slug: w.tenantId ? tenantSlugById.get(w.tenantId) || null : null,
     name: w.name,
     book_count: w.book_count || 0,
+    total_book_count: w.total_book_count,
     artwork_count: w.artwork_count || 0,
     image: coverOverride(w.slug) || w.hero_image || pickImage(w.featured_images),
     children: childMap.get(w.slug) || [],
@@ -137,7 +141,7 @@ function CollectionCard({ col }: { col: SubCollection }) {
       <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
       <div className="absolute inset-0 flex flex-col justify-end p-3">
         <p className="text-white/50 text-[10px] mb-0.5">
-          {collectionCountLabel(col.book_count, col.artwork_count) || 'Empty'}
+          {collectionCountLabel(col.total_book_count ?? col.book_count, col.artwork_count) || 'Empty'}
         </p>
         <h3 className="font-serif text-xs sm:text-sm text-white font-semibold leading-tight line-clamp-2 group-hover:text-accent-gold transition-colors">
           {col.name}
@@ -197,7 +201,7 @@ export default async function AllCollectionsPage() {
                   {wing.name}
                 </h2>
                 <p className="text-white/50 text-sm mt-1">
-                  {collectionCountLabel(wing.book_count, wing.artwork_count)} · {wing.children.length} sub-collections
+                  {collectionCountLabel(wing.total_book_count ?? wing.book_count, wing.artwork_count)} · {wing.children.length} sub-collections
                 </p>
               </div>
             </Link>

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -38,6 +38,7 @@ interface CollectionDoc {
   color: string;
   order: number;
   book_count: number;
+  total_book_count?: number;
   artwork_count?: number;
   type?: 'category' | 'curated';
   published?: boolean;
@@ -213,7 +214,7 @@ function CollectionCard({ col, tenantSlug, priority = false }: { col: Collection
       <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
       <div className="absolute inset-0 flex flex-col justify-end p-3 sm:p-4">
         <p className="text-white/50 text-[11px] mb-1 hidden sm:block">
-          {collectionCountLabel(col.book_count, col.artwork_count)}
+          {collectionCountLabel(col.total_book_count ?? col.book_count, col.artwork_count)}
           {col.children_count ? ` · ${col.children_count} sub-collections` : ''}
         </p>
         <h2 className="font-serif text-sm sm:text-base lg:text-lg text-white font-semibold leading-tight line-clamp-2 group-hover:text-accent-gold transition-colors">

--- a/src/components/book/BookLibrary.tsx
+++ b/src/components/book/BookLibrary.tsx
@@ -30,6 +30,7 @@ export interface CollectionForGrid {
   subtitle: string;
   description: string;
   book_count: number;
+  total_book_count?: number;
   artwork_count?: number;
   hero_image: string | null;
   languages?: string[];
@@ -471,7 +472,7 @@ export default function BookLibrary({ initialBooks, totalBooks, languages, colle
                       <div className="absolute inset-0 flex flex-col justify-end p-5 sm:p-6">
                         <div className="flex items-center gap-2 mb-2">
                           <span className="px-2.5 py-0.5 text-xs text-white/80 bg-white/15 backdrop-blur-sm rounded-full">
-                            {collectionCountLabel(col.book_count, col.artwork_count)}
+                            {collectionCountLabel(col.total_book_count ?? col.book_count, col.artwork_count)}
                           </span>
                           {topLangs && (
                             <span className="text-xs text-white/50">{topLangs}</span>

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -217,6 +217,7 @@ async function getRemainingCollections(): Promise<CollectionForGrid[]> {
       subtitle: rest.subtitle || '',
       description: rest.description || '',
       book_count: rest.book_count || 0,
+      total_book_count: rest.total_book_count,
       artwork_count: rest.artwork_count || 0,
       hero_image: heroUrl as string | null,
       languages,


### PR DESCRIPTION
## What
Collection cards showed `book_count`, which `syncCollectionCounts` caches with a `pages_translated > 0` filter — translated/readable books only. That undercounted total holdings on the card "X texts" label (South Asia 526 vs **602** held, Alchemy 1222 vs **1249**, SHWEP 1909 vs **2109**, etc.).

Adds a `total_book_count` field = all visible member books regardless of translation state (**artworks stay excluded** — they keep their own `artwork_count`), and switches the card count label to it.

## Surfaces updated
- `/collections` grid (the primary surface)
- `/collections/all`
- Sub-collection child cards on `/collections/[id]`
- Homepage library grid (`BookLibrary` via `home-data`)

All use `total_book_count ?? book_count`, so any collection missing the field still renders.

## Data / maintenance
- `syncCollectionCounts` (Hetzner, every 2h) now computes and stores `total_book_count` alongside `book_count`/`artwork_count`.
- One-time backfill already run on prod: `scripts/maintenance/backfill-total-book-count.mjs` (346 collections set).

## Out of scope
- Homepage grid gate still uses `book_count >= 10` (readable-content threshold) — deliberately unchanged.
- `/collections/[id]` hero pagination `total` unchanged (drives the readable listing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)