### PR TITLE
fix(collections): artwork_count must count visible artworks only

### DIFF
--- a/scripts/maintenance/backfill-artwork-count-visible.mjs
+++ b/scripts/maintenance/backfill-artwork-count-visible.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Fix collections.artwork_count to count only VISIBLE artworks, matching what the
+ * public /collections/[id] page shows (src/app/collections/[id]/page.tsx artFilter).
+ *
+ * The bug: syncCollectionCounts counted `{ resource_type: { $exists: true } }` with
+ * NO visibility filter, so hidden artworks inflated the card "· N artworks" label
+ * (~14.6K phantom counts across the library; natural-philosophy read 1697 vs a true
+ * 800, and six collections advertised artworks they had 0 of publicly). This applies
+ * the corrected filter as a one-time backfill; sync-worker.mjs is fixed to match.
+ *
+ *   node scripts/maintenance/backfill-artwork-count-visible.mjs [--apply]
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync } from 'fs';
+
+const APPLY = process.argv.includes('--apply');
+// Kept in sync with ART_EXCLUDED_RESOURCE_TYPES (src/lib/collections-utils.ts).
+const ART_EXCLUDED_RESOURCE_TYPES = ['photograph', 'object', 'sculpture', 'architectural', 'decorative', 'ritual-object'];
+
+const c = new MongoClient(process.env.MONGODB_URI); await c.connect();
+const db = c.db('bookstore');
+const Books = db.collection('books');
+const Cols = db.collection('collections');
+
+const rows = await Books.aggregate([
+  { $match: { resource_type: { $exists: true, $nin: ART_EXCLUDED_RESOURCE_TYPES }, visible: true, status: { $ne: 'deleted' } } },
+  { $unwind: '$collections' },
+  { $group: { _id: '$collections', n: { $sum: 1 } } },
+], { allowDiskUse: true }).toArray();
+const correctMap = new Map(rows.map(r => [r._id, r.n]));
+
+const cols = await Cols.find({}).project({ _id: 1, slug: 1, artwork_count: 1, parent: 1 }).toArray();
+const before = cols.filter(c => (c.artwork_count || 0) !== (correctMap.get(c.slug) || 0))
+  .map(c => ({ slug: c.slug, from: c.artwork_count || 0, to: correctMap.get(c.slug) || 0 }));
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+writeFileSync(`scripts/output/artwork-count-backfill-${stamp}.json`, JSON.stringify(before, null, 2));
+
+const ops = [];
+for (const col of cols) {
+  const correct = correctMap.get(col.slug) || 0;
+  if ((col.artwork_count || 0) !== correct) {
+    ops.push({ updateOne: { filter: { _id: col._id }, update: { $set: { artwork_count: correct, updated_at: new Date() } } } });
+  }
+}
+console.log(`${ops.length} collections need artwork_count corrected (backup: scripts/output/artwork-count-backfill-${stamp}.json)`);
+for (const b of before.filter(b => Math.abs(b.from - b.to) >= 30).sort((a, b) => (b.from - b.to) - (a.from - a.to)).slice(0, 15)) {
+  console.log(`   ${String(b.from).padStart(4)} -> ${String(b.to).padStart(4)}   ${b.slug}`);
+}
+if (APPLY && ops.length) { const r = await Cols.bulkWrite(ops); console.log('modified:', r.modifiedCount); }
+else console.log('DRY RUN — pass --apply to write.');
+await c.close();

--- a/scripts/workers/sync-worker.mjs
+++ b/scripts/workers/sync-worker.mjs
@@ -197,9 +197,16 @@ async function syncCollectionCounts(db) {
   console.log('\n--- Sync Collection Counts ---');
   const start = Date.now();
 
+  // Resource types the art surfaces treat as non-artwork (documentary/photographic
+  // records). Kept in sync with ART_EXCLUDED_RESOURCE_TYPES in src/lib/collections-utils.ts
+  // (source of truth for the /collections/[id] artwork query) — change both together.
+  const ART_EXCLUDED_RESOURCE_TYPES = ['photograph', 'object', 'sculpture', 'architectural', 'decorative', 'ritual-object'];
+
   // One pass over books per counter, instead of 2 countDocuments per collection.
   // book_count uses the canonical "readable book" filter from the archived cron;
-  // artwork_count counts resource_type-bearing entries regardless of visibility.
+  // artwork_count must match what the public /collections/[id] page shows — VISIBLE
+  // artworks only, excluding the documentary resource types (was counting hidden
+  // artworks too, overstating card counts by ~14.6K — e.g. natural-philosophy 800 vs 1697).
   // total_book_count = ALL visible member books (any translation state), so
   // collection cards can show total holdings rather than the readable-only
   // book_count. Artworks (resource_type present) stay excluded — they have
@@ -211,7 +218,7 @@ async function syncCollectionCounts(db) {
       { $group: { _id: '$collections', n: { $sum: 1 } } },
     ]).toArray(),
     db.collection('books').aggregate([
-      { $match: { resource_type: { $exists: true } } },
+      { $match: { status: { $ne: 'deleted' }, visible: true, resource_type: { $exists: true, $nin: ART_EXCLUDED_RESOURCE_TYPES } } },
       { $unwind: '$collections' },
       { $group: { _id: '$collections', n: { $sum: 1 } } },
     ]).toArray(),


### PR DESCRIPTION
## Bug
`syncCollectionCounts` computed `artwork_count` from `{ resource_type: { $exists: true } }` with **no visibility filter**, so hidden artworks inflated the public collection-card "· N artworks" label. This diverged from what `/collections/[id]` actually renders (`artFilter`: `visible:true` + `resource_type $nin ART_EXCLUDED_RESOURCE_TYPES`).

## Impact
~**14,590** phantom artwork counts across the library:
| collection | showed | true |
|---|---|---|
| Natural Philosophy | 1,697 | 800 |
| Astrology | 989 | 422 |
| Art & Illustrated | 783 | 566 |
| Alchemy | 499 | 319 |

And six collections advertised artworks they have **0** of publicly: renaissance-philosophy (75→0), classical-philosophy (65→0), demonology (55→0), theosophy (57→0), secret-societies (33→0), sacred-texts (33→0).

## Fix
Sync-worker artwork aggregation now matches the detail-page filter (`visible:true`, `status != deleted`, `resource_type $nin` the documentary types). Plus a one-time backfill (`scripts/maintenance/backfill-artwork-count-visible.mjs`). Consistent with the **Visibility & Stats Invariants** in CLAUDE.md (public counts filter `visible:true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)