### PR TITLE
Render the site header on all public pages (#3179)

### DIFF
--- a/scripts/audit/headerless-pages.mjs
+++ b/scripts/audit/headerless-pages.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Report public routes whose page renders no site header.
+ *
+ * A page "has a header" if page.tsx — or anything it imports, two levels
+ * deep — references SiteHeader, ContentPageLayout, or ContentHeader.
+ * Routes on the KNOWN_MINIMAL list are deliberately chromeless (immersive
+ * readers, auth flows, bespoke-identity pages, internal tools) and are not
+ * reported. Everything else without a header is a leak: a visitor landing
+ * there (usually from a shared link) gets no nav, no search, no sign-in.
+ *
+ * Usage: node scripts/audit/headerless-pages.mjs [--strict]
+ *   --strict  exit 1 if any unexpected headerless route is found (CI use)
+ *
+ * Context: issue #3179.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const HDR = /SiteHeader|ContentPageLayout|ContentHeader/;
+
+// Deliberately minimal routes (prefix match). Add here ONLY with a reason.
+const KNOWN_MINIMAL = [
+  '/[tenant]', // tenant surfaces have their own header policy
+  '/adopt/certificate', // printable certificate
+  '/auth', '/es/auth', '/login', '/unauthorized', // auth flows
+  '/beta', // conversion landing page — chromeless by design
+  '/book/[id]/page/[pageId]', // immersive reader
+  '/book/[id]/capture', '/book/[id]/edition', '/book/[id]/guide',
+  '/book/[id]/overview', '/book/[id]/pipeline', '/book/[id]/qa',
+  '/book/[id]/search', '/book/[id]/split', '/book/[id]/summary', // internal book tools
+  '/brand', '/design-options', '/prototype', // design sandboxes
+  '/collections/jung-resonances', // BPH-tenant-gated (tenant lockdown)
+  '/experiments', '/research', '/review', '/qa', '/scan',
+  '/processing', '/traffic', '/taxonomy', '/fulldata', '/analytics',
+  '/feedback', '/jobs', // internal/admin tools
+  '/ficino-society', // bespoke standalone identity (own chrome)
+  '/gallery/curate', '/gallery/review', // curation tools
+  '/gallery/image/[id]', // immersive image viewer
+  '/hieroglyphs', '/tablets', // data-less demos (corpus files absent)
+  '/librarian/voice', // full-screen voice UI
+  '/press-release', // redirect
+  '/status', // bare terminal-style status page (statuspage convention)
+];
+
+const pages = [];
+(function walk(d) {
+  for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+    const p = path.join(d, e.name);
+    if (e.isDirectory()) {
+      if (/_archived|\/embed$|\/platform$|\/admin$|\/api$/.test(p)) continue;
+      walk(p);
+    } else if (e.name === 'page.tsx') pages.push(p);
+  }
+})('src/app');
+
+function resolve(spec, fromFile) {
+  const base = spec.startsWith('@/')
+    ? path.join('src', spec.slice(2))
+    : spec.startsWith('.')
+      ? path.join(path.dirname(fromFile), spec)
+      : null;
+  if (!base) return null;
+  for (const c of [base + '.tsx', base + '.ts', path.join(base, 'index.tsx')]) {
+    if (fs.existsSync(c) && fs.statSync(c).isFile()) return c;
+  }
+  return null;
+}
+
+function hasHeader(file, depth, seen) {
+  if (depth > 2 || seen.has(file)) return false;
+  seen.add(file);
+  let src;
+  try { src = fs.readFileSync(file, 'utf8'); } catch { return false; }
+  if (HDR.test(src)) return true;
+  for (const m of src.matchAll(/from ["']([^"']+)["']/g)) {
+    const f = resolve(m[1], file);
+    if (f && hasHeader(f, depth + 1, seen)) return true;
+  }
+  return false;
+}
+
+// Redirect-only pages (e.g. /browse/artists → /browse/artists/A) never render.
+function isRedirectOnly(file) {
+  const src = fs.readFileSync(file, 'utf8');
+  return /\bredirect\(/.test(src) && !/return\s*\(/.test(src);
+}
+
+const missing = pages
+  .map((p) => ({ p, route: p.replace(/^src\/app/, '').replace(/\/page\.tsx$/, '') || '/' }))
+  .filter(({ p }) => !isRedirectOnly(p) && !hasHeader(p, 0, new Set()))
+  .filter(({ route }) => !KNOWN_MINIMAL.some((k) => route === k || route.startsWith(k + '/')));
+
+if (missing.length === 0) {
+  console.log('All public routes render a site header (or are on the known-minimal list).');
+} else {
+  console.log(`${missing.length} public route(s) with NO site header:\n`);
+  for (const { route } of missing) console.log('  ' + route);
+  console.log('\nAdd <SiteHeader /> (or ContentHeader), or add to KNOWN_MINIMAL with a reason.');
+  if (process.argv.includes('--strict')) process.exit(1);
+}

--- a/src/app/account/AccountClient.tsx
+++ b/src/app/account/AccountClient.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { BookOpen, Heart, LogOut, Crown, Users } from 'lucide-react';
 import { toast } from 'sonner';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 interface AccountClientProps {
   user: {
@@ -75,6 +76,7 @@ export default function AccountClient({ user }: AccountClientProps) {
 
   return (
     <div className="min-h-screen" style={{ background: 'var(--bg-cream)' }}>
+      <SiteHeader variant="light" />
       <div className="max-w-xl mx-auto px-4 py-16">
         <h1 className="text-2xl font-serif font-medium mb-8" style={{ color: 'var(--text-primary)' }}>
           Account

--- a/src/app/collections/contemplative-traditions/page.tsx
+++ b/src/app/collections/contemplative-traditions/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ArrowLeft, BookOpen } from 'lucide-react';
+import { BookOpen } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getReadDb } from '@/lib/mongodb';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
@@ -220,18 +221,7 @@ export default async function ContemplativeTraditionsPage() {
 
   return (
     <div className="min-h-screen bg-stone-50">
-      {/* Nav */}
-      <header className="bg-gradient-to-r from-stone-800 via-stone-900 to-stone-800 border-b border-accent-gold-dark/30">
-        <div className="max-w-[1500px] mx-auto px-6 py-4">
-          <Link
-            href="/collections"
-            className="inline-flex items-center gap-2 text-accent-gold hover:text-accent-gold transition-colors text-sm"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Collections
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="dark" breadcrumbs={[{ label: 'Collections', href: '/collections' }]} />
 
       {/* Hero */}
       <div className="relative bg-gradient-to-br from-stone-800 via-stone-900 to-stone-800 text-white overflow-hidden">

--- a/src/app/collections/sacred-texts/page.tsx
+++ b/src/app/collections/sacred-texts/page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Metadata } from 'next';
-import { ArrowLeft } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getReadDb } from '@/lib/mongodb';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
@@ -165,15 +165,8 @@ export default async function SacredTextsPortal() {
     <div className="min-h-screen bg-cream">
       {/* Hero */}
       <div className="bg-dark">
+        <SiteHeader variant="dark" />
         <div className="max-w-[1500px] mx-auto px-6 pt-8 pb-14 sm:pb-16">
-          <Link
-            href="/#library"
-            className="inline-flex items-center gap-2 text-sm text-white/50 hover:text-white/80 transition-colors mb-10"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Library
-          </Link>
-
           <h1 className="text-4xl sm:text-5xl md:text-6xl text-white font-semibold leading-tight mb-4 font-display">
             Sacred Texts
           </h1>

--- a/src/app/explore/timeline/page.tsx
+++ b/src/app/explore/timeline/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 import TimelineLoader from '@/components/explore/TimelineLoader';
+import SiteHeader from '@/components/layout/SiteHeader';
 import {
   CANONICAL_ENTITIES_COLLECTION,
   canonicalEntitiesReadpathEnabled,
@@ -377,5 +378,10 @@ export default async function TimelinePage() {
   const data = canonicalEntitiesReadpathEnabled()
     ? await fetchTimelineDataCanonical()
     : await fetchTimelineData();
-  return <TimelineLoader entities={data.entities} stats={data.stats} />;
+  return (
+    <>
+      <SiteHeader variant="light" />
+      <TimelineLoader entities={data.entities} stats={data.stats} />
+    </>
+  );
 }

--- a/src/app/identify/page.tsx
+++ b/src/app/identify/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useRef, useCallback } from 'react';
 import Link from 'next/link';
-import { Camera, Upload, Loader2, ArrowLeft, ExternalLink } from 'lucide-react';
+import { Camera, Upload, Loader2, ExternalLink } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { bookUrl } from '@/lib/slugify';
 
 interface Match {
@@ -143,11 +144,8 @@ export default function IdentifyPage() {
     <div className="min-h-screen bg-cream">
       {/* Header */}
       <div className="bg-dark text-white">
+        <SiteHeader variant="dark" />
         <div className="max-w-2xl mx-auto px-4 py-6">
-          <Link href="/" className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors mb-4">
-            <ArrowLeft className="w-4 h-4" />
-            Library
-          </Link>
           <h1 className="text-2xl sm:text-3xl font-display font-semibold">Identify</h1>
           <p className="text-white/60 mt-1 text-sm">Photograph an artwork or book to find it in Source Library</p>
         </div>

--- a/src/app/ngrams/page.tsx
+++ b/src/app/ngrams/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { Suspense } from 'react';
 import NgramViewer from '@/components/ngrams/NgramViewer';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 const TITLE = 'Ngram Viewer — Source Library';
 const DESCRIPTION =
@@ -30,7 +31,9 @@ export const metadata: Metadata = {
 
 export default function NgramsPage() {
   return (
-    <div className="max-w-5xl mx-auto px-4 py-8">
+    <>
+      <SiteHeader variant="light" />
+      <div className="max-w-5xl mx-auto px-4 py-8">
       <h1 className="font-serif text-3xl mb-2">Ngram Viewer</h1>
       <p className="text-[var(--text-secondary)] mb-6 max-w-3xl">
         How often does a word or phrase appear across the library, year by year?
@@ -59,6 +62,7 @@ export default function NgramsPage() {
           Latin, German, French, and Greek sources at once.
         </p>
       </div>
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/app/podcast/[threadId]/page.tsx
+++ b/src/app/podcast/[threadId]/page.tsx
@@ -3,6 +3,7 @@ import { ObjectId } from 'mongodb';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import TranscriptToggle from '../TranscriptToggle';
+import SiteHeader from '@/components/layout/SiteHeader';
 import EpisodePlayer from '../EpisodePlayer';
 
 export const revalidate = 3600;
@@ -273,15 +274,7 @@ export default async function EpisodePage({ params }: Props) {
 
   return (
     <div className="min-h-screen bg-[#fdfcf9]">
-      <header className="bg-[#fdfcf9] border-b border-[#e8e4dc] py-3">
-        <div className="flex items-center gap-2 px-6 max-w-[960px] mx-auto text-[13px] font-sans text-[#8a8480]">
-          <Link href="/" className="text-[#1a1612] hover:text-[#9e4a3a] transition-colors font-medium tracking-wide">
-            <span className="font-semibold">Source</span><span className="font-light">Library</span>
-          </Link>
-          <span>/</span>
-          <Link href="/podcast" className="hover:text-[#1a1612] transition-colors">Podcast</Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" breadcrumbs={[{ label: 'Podcast', href: '/podcast' }]} />
 
       {/* Hero image */}
       {episode.heroImage && (

--- a/src/app/read/gilgamesh/page.tsx
+++ b/src/app/read/gilgamesh/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import { tokenizeAtfLine, type AtfToken } from '@/lib/cuneiform-signs';
+import SiteHeader from '@/components/layout/SiteHeader';
 import gilgameshData from '../../../../scripts/output/gilgamesh-tablets.json';
 
 export const metadata: Metadata = {
@@ -243,6 +244,7 @@ function TabletSection({ tablet }: { tablet: TabletEntry }) {
 export default function GilgameshReaderPage() {
   return (
     <div className="min-h-screen" style={{ backgroundColor: 'var(--bg-cream)' }}>
+      <SiteHeader variant="light" />
       {/* Header */}
       <header className="border-b py-10 px-6" style={{ borderColor: 'var(--border-light)' }}>
         <div className="max-w-6xl mx-auto">

--- a/src/app/rithmomachia/guide/page.tsx
+++ b/src/app/rithmomachia/guide/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import MiniBoard, { MiniBoardPiece } from '@/components/rithmomachia/MiniBoard';
 import { Position } from '@/lib/rithmomachia/types';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 export const metadata: Metadata = {
   title: 'Rithmomachia Visual Guide | Source Library',
@@ -91,7 +92,15 @@ function GuideSection({
 
 export default function RithmomachiaGuidePage() {
   return (
-    <div className="max-w-2xl mx-auto px-4 py-8">
+    <>
+      <SiteHeader
+        variant="light"
+        breadcrumbs={[
+          { label: 'Rithmomachia', href: '/rithmomachia' },
+          { label: 'Visual Guide', href: '/rithmomachia/guide' },
+        ]}
+      />
+      <div className="max-w-2xl mx-auto px-4 py-8">
       {/* Header */}
       <div className="mb-8">
         <Link href="/rithmomachia" className="text-sm text-accent-rust hover:underline">
@@ -317,6 +326,7 @@ export default function RithmomachiaGuidePage() {
           Full rules with primary sources &rarr;
         </Link>
       </div>
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/app/rithmomachia/page.tsx
+++ b/src/app/rithmomachia/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import RithmomachiaGame from '@/components/rithmomachia/RithmomachiaGame';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 export const metadata: Metadata = {
   title: 'Rithmomachia — Play the Battle of Numbers - Source Library',
@@ -24,19 +25,8 @@ export const metadata: Metadata = {
 export default function RithmomachiaPage() {
   return (
     <main className="min-h-screen bg-cream">
+      <SiteHeader variant="light" breadcrumbs={[{ label: 'Rithmomachia', href: '/rithmomachia' }]} />
       <div className="max-w-[1500px] mx-auto px-4 py-8 md:py-12">
-        {/* Breadcrumb */}
-        <nav className="mb-8">
-          <Link
-            href="/"
-            className="text-sm text-muted hover:text-secondary transition-colors"
-          >
-            Source Library
-          </Link>
-          <span className="text-muted mx-2">/</span>
-          <span className="text-sm text-secondary">Rithmomachia</span>
-        </nav>
-
         <RithmomachiaGame />
 
         {/* Footer links */}

--- a/src/app/rithmomachia/scenarios/page.tsx
+++ b/src/app/rithmomachia/scenarios/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import ScenarioSelector from '@/components/rithmomachia/ScenarioSelector';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 export const metadata: Metadata = {
   title: 'Rithmomachia Strategy Scenarios | Source Library',
@@ -13,26 +14,14 @@ export const metadata: Metadata = {
 export default function ScenariosPage() {
   return (
     <main className="min-h-screen bg-cream">
+      <SiteHeader
+        variant="light"
+        breadcrumbs={[
+          { label: 'Rithmomachia', href: '/rithmomachia' },
+          { label: 'Strategy Scenarios', href: '/rithmomachia/scenarios' },
+        ]}
+      />
       <div className="max-w-5xl mx-auto px-4 py-8 md:py-12">
-        {/* Breadcrumb */}
-        <nav className="mb-8">
-          <Link
-            href="/"
-            className="text-sm text-muted hover:text-secondary transition-colors"
-          >
-            Source Library
-          </Link>
-          <span className="text-muted mx-2">/</span>
-          <Link
-            href="/rithmomachia"
-            className="text-sm text-muted hover:text-secondary transition-colors"
-          >
-            Rithmomachia
-          </Link>
-          <span className="text-muted mx-2">/</span>
-          <span className="text-sm text-secondary">Strategy Scenarios</span>
-        </nav>
-
         <ScenarioSelector />
 
         {/* Footer */}

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ArrowLeft, ExternalLink, BookOpen, Scroll, Compass, FlaskConical, Calculator, Star } from 'lucide-react';
 import { BookLoader } from '@/components/ui/BookLoader';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { books } from '@/lib/api-client';
 
 interface RoadmapBook {
@@ -133,18 +134,7 @@ export default function RoadmapPage() {
 
   return (
     <div className="min-h-screen bg-stone-50">
-      {/* Header */}
-      <header className="bg-white border-b border-stone-200">
-        <div className="max-w-5xl mx-auto px-4 py-4">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-2 text-stone-600 hover:text-stone-900"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Back to Library
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       {/* Hero */}
       <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white">

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -100,8 +100,11 @@ export default function RoadmapPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-stone-50 flex items-center justify-center">
-        <BookLoader />
+      <div className="min-h-screen bg-stone-50">
+        <SiteHeader variant="light" />
+        <div className="flex items-center justify-center py-40">
+          <BookLoader />
+        </div>
       </div>
     );
   }

--- a/src/app/search/visual/page.tsx
+++ b/src/app/search/visual/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useCallback, useRef } from 'react';
 import Link from 'next/link';
-import { Search, ArrowLeft, Loader2 } from 'lucide-react';
+import { Search, Loader2 } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { bookUrl } from '@/lib/slugify';
 
 interface VisualResult {
@@ -70,11 +71,8 @@ export default function VisualSearchPage() {
     <div className="min-h-screen bg-cream">
       {/* Header */}
       <div className="bg-dark text-white">
+        <SiteHeader variant="dark" breadcrumbs={[{ label: 'Gallery', href: '/gallery' }]} />
         <div className="max-w-6xl mx-auto px-4 py-6">
-          <Link href="/gallery" className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors mb-4">
-            <ArrowLeft className="w-4 h-4" />
-            Gallery
-          </Link>
           <h1 className="text-2xl sm:text-3xl font-display font-semibold">Visual Search</h1>
           <p className="text-white/60 mt-1 text-sm">
             Search images by what they look like, not just their descriptions

--- a/src/app/shwep/[number]/page.tsx
+++ b/src/app/shwep/[number]/page.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { getEpisodeData, getAllEpisodeNumbers } from '../shwep-data';
 import type { MatchedBook } from '../shwep-data';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 // Must be a finite number — `false` would cache a bad-render fallback forever
 // (e.g. the noindex metadata below) until the next deploy.
@@ -52,22 +53,7 @@ export default async function EpisodePage({ params }: Props) {
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
       {/* Header */}
-      <header className="bg-white border-b border-stone-200">
-        <div className="max-w-5xl mx-auto px-6 py-4 flex items-center gap-4">
-          <Link href="/" className="flex items-center gap-2 text-stone-500 hover:text-stone-800 transition-colors">
-            <svg className="w-8 h-8" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="1" />
-              <circle cx="12" cy="12" r="7" stroke="currentColor" strokeWidth="1" />
-              <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1" />
-            </svg>
-            <span className="font-medium">Source Library</span>
-          </Link>
-          <span className="text-stone-300">/</span>
-          <Link href="/shwep" className="text-stone-500 hover:text-stone-800 transition-colors text-sm">
-            SHWEP Reading Room
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" breadcrumbs={[{ label: 'SHWEP Reading Room', href: '/shwep' }]} />
 
       {/* Caveat */}
       <div className="bg-stone-100 border-b border-stone-200">

--- a/src/app/shwep/page.tsx
+++ b/src/app/shwep/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { getShwepIndexData } from './shwep-data';
 import ShwepClient from './ShwepClient';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 // Must be a finite number — `false` would cache a bad-render fallback forever.
@@ -28,6 +29,7 @@ export default async function ShwepPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
+      <SiteHeader variant="light" />
       <ShwepClient data={data} />
     </div>
   );

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -18,6 +18,7 @@ import {
   Camera,
 } from 'lucide-react';
 import { IMAGE_LICENSES, type ImageSourceProvider } from '@/lib/types';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { books, catalog } from '@/lib/api-client';
 import type { CatalogResult } from '@/lib/api-client';
 import { create } from 'domain';
@@ -206,15 +207,7 @@ export default function UploadPage() {
 
   return (
     <div className="min-h-screen bg-stone-50">
-      {/* Header */}
-      <header className="bg-white border-b border-stone-200">
-        <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <Link href="/" className="inline-flex items-center gap-2 text-stone-600 hover:text-stone-900">
-            <ArrowLeft className="w-4 h-4" />
-            Back to Library
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       <main className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Progress Steps */}

--- a/src/app/volunteers/page.tsx
+++ b/src/app/volunteers/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import ReviewStats from '@/components/review/ReviewStats';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 /**
  * Orphan welcome page for invited volunteers.
@@ -46,6 +47,8 @@ const QUEUES = [
 
 export default function VolunteersWelcomePage() {
   return (
+    <>
+    <SiteHeader variant="light" />
     <main className="max-w-3xl mx-auto px-6 py-14">
       <div className="text-sm font-medium text-accent-rust mb-3 tracking-wide uppercase">You're one of the first</div>
       <h1 className="text-4xl font-serif font-bold text-stone-900 mb-4 leading-tight">
@@ -104,5 +107,6 @@ export default function VolunteersWelcomePage() {
         </p>
       </div>
     </main>
+    </>
   );
 }


### PR DESCRIPTION
Closes #3179.

## What
Every public page now renders `SiteHeader` (logo, nav, search, EN/ES toggle, and the signed-in user menu). Previously a visitor landing on these pages — usually from a shared link — had no navigation and no sign-in/account access:

- `/account` (a signed-in page with no site nav at all)
- `/ngrams`, `/explore/timeline` (Timeline's container was already sized `calc(100vh-64px)` — built for a header that wasn't there)
- Podcast episode pages (`/podcast/[threadId]`)
- `/shwep` + episode pages, `/read/gilgamesh`
- `/rithmomachia`, `/rithmomachia/guide`, `/rithmomachia/scenarios`
- `/roadmap`, `/upload`, `/volunteers`, `/identify`, `/search/visual`
- Collection portals `/collections/sacred-texts`, `/collections/contemplative-traditions`

Where a page had a hand-rolled mini-header ("Source Library / Podcast" style breadcrumb bars), it's **replaced** by SiteHeader's `breadcrumbs` prop, not stacked under it. Dark hero pages use `variant="dark"`/`transparent` to match.

## Deliberately left minimal (with reasons, encoded in the new audit script)
- Immersive reader (`/book/[id]/page/[pageId]`), `/gallery/image/[id]` viewer
- Auth flows, `/beta` conversion landing, `/status` (bare terminal-style status page)
- **Ficino Society** — has its own bespoke chrome (ficinosociety.org identity incl. Sign In/Account links); adding the global header would collide with its absolute-positioned header
- **`/collections/jung-resonances`** — BPH-tenant-gated (tenant lockdown)
- Internal tools (`/experiments`, `/research`, `/review`, `/jobs`, `/scan`, …) and data-less demos (`/tablets`, `/hieroglyphs`)

## Guard
`scripts/audit/headerless-pages.mjs` — walks every `page.tsx` (following imports two levels) and reports public routes with no `SiteHeader`/`ContentHeader`; the known-minimal list above lives there with per-route reasons. `--strict` exits 1 for CI use (not wired up in this PR).

## Out of scope
Header redesign; tenant/embed surfaces; the responsive breakpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)