### PR TITLE
fix(rearchive): tile-stitch capped IIIF servers + regenerate display variants

### DIFF
--- a/scripts/maintenance/rearchive-iiif-fullres.mjs
+++ b/scripts/maintenance/rearchive-iiif-fullres.mjs
@@ -6,7 +6,12 @@
  * only archives pages with NO `archived_photo`), this script targets
  * pages whose `archived_photo` IS set but where the source was imported
  * at a downsized IIIF resolution (e.g. `/full/1000,/`). It refetches at
- * `/full/full/` and overwrites the existing R2 archive.
+ * `/full/full/` and overwrites the existing R2 archive. When the server
+ * caps single-request output below the master size (e.g. Cambridge:
+ * maxWidth 2000 vs a 9718px master), it tile-stitches region requests to
+ * recover native resolution (via fetchIiifNativeRes). It also regenerates
+ * the pre-sized display/thumb R2 variants the reader serves directly —
+ * without that, the reader keeps showing the old low-res derivative.
  *
  * Three modes:
  *
@@ -61,7 +66,8 @@ import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 
-import { upgradeToFullRes, rateLimitedFetch, fetchIiifInfo, isIiifUrl, getIiifSizeCap } from '../lib/iiif-utils.mjs';
+import { upgradeToFullRes, rateLimitedFetch, fetchIiifInfo, isIiifUrl, getIiifSizeCap, fetchIiifNativeRes, shouldTileStitch } from '../lib/iiif-utils.mjs';
+import { generateDisplayVariants } from '../workers/lib/display-image.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: resolve(__dirname, '../../.env.production.local') });
@@ -147,7 +153,16 @@ async function fetchUpgraded(url) {
   if (upgraded === url) return { skipped: 'no-upgrade-pattern', url };
   let raw;
   try {
-    raw = await rateLimitedFetch(upgraded, { timeout: 60_000 });
+    // Servers like Cambridge (maxWidth/maxHeight 2000) silently downscale
+    // /full/full/ below the master size — the only path to native pixels is
+    // region tiles. Per-page info.json: dimensions vary page to page.
+    const pageInfo = await fetchIiifInfo(url);
+    if (pageInfo && shouldTileStitch(pageInfo, url)) {
+      const maxChunk = Math.min(pageInfo.maxWidth || 2000, pageInfo.maxHeight || 2000, 2000);
+      ({ buffer: raw } = await fetchIiifNativeRes(url, { info: pageInfo, maxChunk, timeout: 60_000 }));
+    } else {
+      raw = await rateLimitedFetch(upgraded, { timeout: 60_000 });
+    }
   } catch (e) {
     return { skipped: 'fetch-fail', url: upgraded, error: e.message };
   }
@@ -230,12 +245,30 @@ async function audit() {
   }
 }
 
+/**
+ * Regenerate the pre-sized R2 display/thumb variants (the files the reader
+ * serves directly) from an upgraded master buffer, overwriting the SAME R2
+ * keys so no DB pointer changes. No-op for pages without R2-hosted variants.
+ */
+async function regenerateVariants(page, masterBuffer) {
+  const toKey = (url) =>
+    typeof url === 'string' && url.startsWith(`${R2_PUBLIC_URL}/`)
+      ? url.slice(R2_PUBLIC_URL.length + 1)
+      : null;
+  const displayKey = toKey(page.display_photo);
+  const thumbKey = toKey(page.image_thumb) || toKey(page.thumbnail_blob);
+  if (!displayKey && !thumbKey) return;
+  const { display, thumb } = await generateDisplayVariants(masterBuffer);
+  if (displayKey) await r2Put(displayKey, display);
+  if (thumbKey) await r2Put(thumbKey, thumb);
+}
+
 // ── Refetch mode (un-split books) ──
 
 async function refetchOne(book) {
   const pages = await db.collection('pages').find(
     { book_id: book.id },
-    { projection: { id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, split_side: 1 } },
+    { projection: { id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, split_side: 1, display_photo: 1, image_thumb: 1, thumbnail_blob: 1 } },
   ).sort({ page_number: 1 }).toArray();
 
   if (!pages.length) return { skipped: 'no-pages' };
@@ -268,6 +301,10 @@ async function refetchOne(book) {
     }
     try {
       const newUrl = await r2Put(key, result.processed);
+      // Pre-sized R2 variants (display_photo / image_thumb) are what the reader
+      // actually serves — regenerate them from the upgraded master onto the SAME
+      // keys, else the reader keeps showing the old low-res derivative.
+      await regenerateVariants(page, result.processed);
       await db.collection('pages').updateOne(
         { _id: page._id || new ObjectId(page.id) },
         { $set: {


### PR DESCRIPTION
## Why

Derek flagged that the Paramesvaratantra reader page (https://sourcelibrary.org/book/6991d8a08c1030b12444c14c/page/6991d8a18c1030b12444c152) shows a much-too-small image. Root cause: the book was imported from Cambridge Digital Library at `/full/1000,/` — 1000×225 px for a palm-leaf strip whose master is **9718×2185**. Every downstream surface (display_photo, thumb, hires zoom) derives from that 1000px archive.

## What

Two gaps in `scripts/maintenance/rearchive-iiif-fullres.mjs`:

1. **Tile-stitching for capped servers.** The script upgraded URLs to `/full/full/`, but Cambridge caps any single response at maxWidth/maxHeight 2000 — so the "full-res" refetch would still lose 4.4× linear resolution. Now it checks per-page `info.json` with `shouldTileStitch()` and reconstructs the native master from region tiles via the existing `fetchIiifNativeRes()` (verified seam-free on the palm-leaf ms).

2. **Display-variant regeneration.** The reader serves the pre-sized R2 variants (`display_photo` / `image_thumb`) directly; the script never regenerated them, so an archive upgrade would never reach the screen. Now regenerates both onto the same R2 keys (no DB pointer churn) via the shared `generateDisplayVariants()` (provenance marks included).

## Scope

- In scope: the `--refetch` path. Run for the Paramesvaratantra as pilot.
- Out of scope: the remaining 65 Cambridge books (22.4K pages, all `image_source.provider: "cambridge"`) — same treatment works via `--provider cambridge`, but that's a ~220K-request job worth a deliberate go.
- Out of scope: `--recover-split` path (split books re-generate variants downstream of the splitter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)