### PR TITLE
fix(collections): homepage hero_image consistency, sub-collection ordering, FT badge gate

### DIFF
--- a/src/components/catalog/ScholarCatalog.tsx
+++ b/src/components/catalog/ScholarCatalog.tsx
@@ -7,6 +7,7 @@ import {
   ArrowUpDown, ArrowUp, ArrowDown, FileText, ChevronDown,
 } from 'lucide-react';
 import AuthorName from '@/components/AuthorName';
+import { isPublishedFirstTranslation } from '@/lib/book';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import CatalogPagination from '@/components/collections/CatalogPagination';
 
@@ -627,7 +628,7 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
                               {book.display_title || book.title}
                             </span>
                           </Link>
-                          {book.is_first_translation && (
+                          {isPublishedFirstTranslation(book) && (
                             <span className="shrink-0 inline-block bg-accent-gold/15 text-accent-gold-dark text-[10px] px-1.5 py-0.5 rounded-full font-medium">
                               {firstTranslationBadge(book.ft_disposition, book.language ?? undefined)}
                             </span>

--- a/src/lib/collections-utils.ts
+++ b/src/lib/collections-utils.ts
@@ -39,16 +39,25 @@ export const PINNED_COLLECTION_SLUGS = [
 ];
 
 /** Pin specific collections first, shuffle the rest. */
-export function sortCollections<T extends { slug: string }>(collections: T[]): T[] {
+export function sortCollections<T extends { slug: string; children_count?: number }>(collections: T[]): T[] {
   const pinned = PINNED_COLLECTION_SLUGS
     .map(s => collections.find(c => c.slug === s))
     .filter(Boolean) as T[];
   const rest = collections.filter(c => !PINNED_COLLECTION_SLUGS.includes(c.slug));
-  for (let i = rest.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [rest[i], rest[j]] = [rest[j], rest[i]];
-  }
-  return [...pinned, ...rest];
+  const shuffle = (arr: T[]) => {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  };
+  // Collections with sub-collections are richer entry points — lift them ahead of
+  // the thin single-topic collections in the (otherwise randomised) tail. Pinned
+  // curation still leads. When children_count is absent (e.g. homepage grid) this
+  // is a no-op and the tail is simply shuffled.
+  const withSubs = shuffle(rest.filter(c => (c.children_count ?? 0) > 0));
+  const withoutSubs = shuffle(rest.filter(c => !(c.children_count ?? 0)));
+  return [...pinned, ...withSubs, ...withoutSubs];
 }
 
 // ---------- Thumbnail sanitization ----------

--- a/src/lib/home-data.ts
+++ b/src/lib/home-data.ts
@@ -2,7 +2,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import { Book } from '@/lib/types';
 import { type CollectionForGrid } from '@/components/book/BookLibrary';
-import { sortCollections, withTimeout } from '@/lib/collections-utils';
+import { sortCollections, withTimeout, coverOverride } from '@/lib/collections-utils';
 import { browseBooks, type CatalogBook } from '@/lib/books-catalog';
 import { toGalleryCardUrl } from '@/lib/utils';
 import { type Plate } from '@/components/GalleryMasonry';
@@ -196,7 +196,12 @@ async function getRemainingCollections(): Promise<CollectionForGrid[]> {
       (img: unknown) => typeof img === 'string' || (img && typeof img === 'object' && ((img as Record<string, unknown>).thumbnail_url || (img as Record<string, unknown>).extracted_url || (img as Record<string, unknown>).image_url))
     );
     // Prefer thumbnail for card grids — extracted images are ~2MB vs ~38KB thumbnails
-    const heroUrl = typeof hero === 'string' ? hero : ((hero as Record<string, unknown>)?.thumbnail_url || (hero as Record<string, unknown>)?.extracted_url || (hero as Record<string, unknown>)?.image_url || null) as string | null;
+    const featuredUrl = typeof hero === 'string' ? hero : ((hero as Record<string, unknown>)?.thumbnail_url || (hero as Record<string, unknown>)?.extracted_url || (hero as Record<string, unknown>)?.image_url || null) as string | null;
+    // Honour the curated cover with the SAME precedence as the /collections card
+    // helper (cardImageCandidates): coverOverride → hero_image → featured_images.
+    // Without this the homepage grid ignored `hero_image` and showed a different
+    // image than /collections for every collection with a curated cover.
+    const heroUrl = coverOverride(rest.slug) || (rest.hero_image as string | undefined) || featuredUrl;
     const languageValues = Array.isArray(rest.languages)
       ? rest.languages
       : [];


### PR DESCRIPTION
Three display-correctness fixes from the collections-grid audit.

### 1. Homepage grid ignored curated `hero_image`
`home-data.ts` resolved covers from `featured_images` only; `/collections` uses `coverOverride → hero_image → featured_images` (`cardImageCandidates`). Result: every collection with a curated cover showed a **different image on the homepage vs /collections** — Sacred Texts rendered the Egyptian papyrus on `/collections` but a Shiva chakra diagram on the homepage. Also meant all recently-set covers (dragon, Ganesha, Book of Kells…) weren't reflected on the homepage. Now uses the same precedence.

### 2. Sub-collection-having collections rise in the grid
`sortCollections` now lifts collections with `children_count > 0` ahead of thin single-topic ones in the (still-randomised) tail. Pinned curation still leads; no-op when `children_count` is absent.

### 3. False "First Translation" badge in the Scholar Catalog
`ScholarCatalog.tsx` rendered the badge on the raw `is_first_translation` flag, skipping the `pages_translated > 0` guard every other surface applies (`isPublishedFirstTranslation`). 111 flagged-but-untranslated originals (Erasmus *Opera*, *Corpus Reformatorum*) showed a false badge. Fixed.

### Out of scope
- The homepage **featured editorial spread** (`getFeaturedCollections`) still resolves from `curated_gallery` (deliberate multi-image editorial curation) — left as-is.
- The 111 `is_first_translation` flags on original-language editions are a data question for the FT sign-off process, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)