### PR TITLE
feat(mcp): propose_collection — let anyone propose a collection, review → approve

### DIFF
--- a/src/app/admin/AdminNav.tsx
+++ b/src/app/admin/AdminNav.tsx
@@ -17,6 +17,7 @@ const adminLinks: NavItem[] = [
   { href: '/admin/processing', label: 'Processing' },
   { href: '/admin/realtime', label: 'Realtime' },
   { href: '/admin/collections', label: 'Collections' },
+  { href: '/admin/collection-proposals', label: 'Proposals' },
   { href: '/admin/duplicates', label: 'Duplicates' },
   { href: '/admin/catalog-coverage', label: 'Catalogue' },
   { href: '/admin/r2-coverage', label: 'R2 Storage' },

--- a/src/app/admin/collection-proposals/page.tsx
+++ b/src/app/admin/collection-proposals/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+interface ProposalItem {
+  _id: string;
+  title: string;
+  rationale: string;
+  suggested_slug: string | null;
+  book_ids: string[];
+  proposer_name: string | null;
+  proposer_email: string | null;
+  created_at: string;
+  status: 'pending' | 'approved' | 'rejected';
+  reviewed_by?: string | null;
+  reviewed_at?: string | null;
+  review_note?: string | null;
+  created_collection_slug?: string | null;
+}
+
+type Tab = 'pending' | 'approved' | 'rejected';
+
+function formatDate(s: string) {
+  const d = new Date(s);
+  return d.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+export default function AdminCollectionProposalsPage() {
+  const [tab, setTab] = useState<Tab>('pending');
+  const [items, setItems] = useState<ProposalItem[]>([]);
+  const [counts, setCounts] = useState<{ pending: number; approved: number; rejected: number }>({ pending: 0, approved: 0, rejected: 0 });
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/collection-proposals?status=${tab}&limit=200`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setItems(data.proposals || []);
+      setCounts(data.counts || { pending: 0, approved: 0, rejected: 0 });
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [tab]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function act(item: ProposalItem, action: 'approve' | 'reject') {
+    const slug = action === 'approve'
+      ? (prompt('Slug for the new collection (blank = derive from title):', item.suggested_slug || '') ?? undefined)
+      : undefined;
+    if (action === 'approve' && slug === undefined) return; // cancelled
+    const note = action === 'reject' ? (prompt('Reason for rejecting (optional):', '') ?? undefined) : undefined;
+    if (action === 'reject' && note === undefined) return; // cancelled
+
+    setBusy(item._id);
+    try {
+      const res = await fetch(`/api/collection-proposals/${item._id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, slug: slug || undefined, note: note || undefined }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        alert(`${action} failed: ${data.error || res.status}`);
+        return;
+      }
+      if (action === 'approve') {
+        alert(`Created hidden draft collection "${data.collection_slug}" (${data.books_tagged} books tagged). Review & flip visible in the book-collections admin.`);
+      }
+      load();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-6 py-10">
+      <h1 className="text-2xl font-semibold mb-2">Collection proposals</h1>
+      <p className="text-sm text-stone-500 mb-6">Themed-collection proposals submitted via the <code>propose_collection</code> MCP tool / <code>/api/collection-proposals</code>. Untrusted input — review the rationale and books before approving. <strong>Approve</strong> mints a <em>hidden draft</em> collection (books tagged, <code>visible:false</code>); flip it public in the book-collections admin after review.</p>
+
+      <div className="flex gap-2 mb-6 border-b border-stone-200">
+        {(['pending', 'approved', 'rejected'] as Tab[]).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${tab === t ? 'border-accent-rust text-accent-rust' : 'border-transparent text-stone-500 hover:text-stone-800'}`}
+          >
+            {t.charAt(0).toUpperCase() + t.slice(1)} <span className="ml-1 text-xs text-stone-400">({counts[t]})</span>
+          </button>
+        ))}
+      </div>
+
+      {loading && <p className="text-sm text-stone-500">Loading…</p>}
+      {!loading && items.length === 0 && (
+        <p className="text-sm text-stone-500">No <em>{tab}</em> proposals.</p>
+      )}
+
+      <div className="space-y-4">
+        {items.map(item => (
+          <article key={item._id} className="border border-stone-200 rounded-lg p-4 bg-white">
+            <header className="flex items-baseline justify-between gap-4 mb-2">
+              <h2 className="text-base font-semibold text-stone-800">
+                {item.title}
+                {item.suggested_slug && <span className="ml-2 text-xs font-mono text-stone-400">/{item.suggested_slug}</span>}
+              </h2>
+              <div className="text-xs text-stone-500 whitespace-nowrap">
+                {formatDate(item.created_at)}
+                {item.proposer_name && <span> · <span className="text-stone-700">{item.proposer_name}</span></span>}
+                {item.proposer_email && <span className="text-stone-400"> &lt;{item.proposer_email}&gt;</span>}
+              </div>
+            </header>
+
+            <p className="text-sm whitespace-pre-wrap text-stone-700 leading-relaxed mb-3">{item.rationale}</p>
+
+            <div className="text-xs text-stone-500 mb-3">
+              <span className="font-medium text-stone-600">{item.book_ids.length} books:</span>{' '}
+              {item.book_ids.map((id, i) => (
+                <span key={id}>
+                  {i > 0 && ', '}
+                  <a
+                    href={`https://sourcelibrary.org/book/${id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent-rust hover:underline font-mono"
+                  >
+                    {id}
+                  </a>
+                </span>
+              ))}
+            </div>
+
+            {item.status === 'pending' ? (
+              <div className="flex gap-2">
+                <button
+                  disabled={busy === item._id}
+                  onClick={() => act(item, 'approve')}
+                  className="text-xs px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white rounded transition-colors disabled:opacity-50"
+                >
+                  Approve → draft collection
+                </button>
+                <button
+                  disabled={busy === item._id}
+                  onClick={() => act(item, 'reject')}
+                  className="text-xs px-3 py-1.5 bg-stone-100 hover:bg-stone-200 text-stone-700 rounded transition-colors disabled:opacity-50"
+                >
+                  Reject
+                </button>
+              </div>
+            ) : (
+              <div className="text-xs text-stone-500">
+                {item.status === 'approved' && item.created_collection_slug && (
+                  <span>Approved → <a href={`/collections/${item.created_collection_slug}`} className="text-accent-rust hover:underline">/collections/{item.created_collection_slug}</a> (draft)</span>
+                )}
+                {item.status === 'rejected' && <span>Rejected{item.review_note ? ` — ${item.review_note}` : ''}</span>}
+                {item.reviewed_by && <span className="text-stone-400"> · by {item.reviewed_by}</span>}
+              </div>
+            )}
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/collection-proposals/[id]/route.ts
+++ b/src/app/api/collection-proposals/[id]/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { ObjectId } from 'mongodb';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { createCollection } from '@/lib/create-collection';
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 100);
+}
+
+/**
+ * POST /api/collection-proposals/[id] — admin action on a proposal (#3185).
+ *
+ * body.action = 'approve' | 'reject'
+ *   approve: mints a HIDDEN draft collection (visible:false) from the proposal,
+ *            tagging the proposed books, then marks the proposal approved.
+ *            Optional overrides: title, slug, description.
+ *   reject:  marks the proposal rejected with an optional note. No collection.
+ *
+ * A proposal can only be acted on while `pending`. Approve is idempotency-guarded
+ * by the collections slug-uniqueness check (returns 409 on a taken slug).
+ */
+export const POST = withAdminAuth(async (
+  request: NextRequest,
+  session,
+  context?: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await context!.params;
+    if (!ObjectId.isValid(id)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const action = body?.action;
+    if (action !== 'approve' && action !== 'reject') {
+      return NextResponse.json({ error: "action must be 'approve' or 'reject'" }, { status: 400 });
+    }
+
+    const db = await getDb();
+    const proposal = await db.collection('collection_proposals').findOne({ _id: new ObjectId(id) });
+    if (!proposal) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    if (proposal.status !== 'pending') {
+      return NextResponse.json(
+        { error: `Proposal already ${proposal.status}` },
+        { status: 409 },
+      );
+    }
+
+    const reviewer = (session?.user as { email?: string } | undefined)?.email || null;
+    const now = new Date();
+    const note = typeof body?.note === 'string' ? body.note.trim().slice(0, 2000) || null : null;
+
+    if (action === 'reject') {
+      await db.collection('collection_proposals').updateOne(
+        { _id: new ObjectId(id) },
+        { $set: { status: 'rejected', reviewed_by: reviewer, reviewed_at: now, review_note: note } },
+      );
+      return NextResponse.json({ ok: true, status: 'rejected' });
+    }
+
+    // approve — allow admin overrides, else fall back to the proposal's own values.
+    const title =
+      typeof body?.title === 'string' && body.title.trim() ? body.title.trim() : (proposal.title as string);
+    const description =
+      typeof body?.description === 'string' && body.description.trim()
+        ? body.description.trim()
+        : (proposal.rationale as string);
+    const slug =
+      (typeof body?.slug === 'string' && body.slug.trim() && slugify(body.slug)) ||
+      (proposal.suggested_slug as string | null) ||
+      slugify(title);
+
+    if (!slug) {
+      return NextResponse.json({ error: 'Could not derive a slug — provide one' }, { status: 400 });
+    }
+
+    let result;
+    try {
+      result = await createCollection({
+        slug,
+        name: title,
+        description,
+        bookIds: (proposal.book_ids as string[]) || [],
+        draft: true,
+        createdBy: (proposal.proposer_email as string | null) || reviewer,
+      });
+    } catch (err) {
+      const code = (err as { code?: string })?.code;
+      if (code === 'exists') {
+        return NextResponse.json({ error: (err as Error).message, code: 'slug_taken' }, { status: 409 });
+      }
+      throw err;
+    }
+
+    await db.collection('collection_proposals').updateOne(
+      { _id: new ObjectId(id) },
+      {
+        $set: {
+          status: 'approved',
+          reviewed_by: reviewer,
+          reviewed_at: now,
+          review_note: note,
+          created_collection_slug: slug,
+        },
+      },
+    );
+
+    return NextResponse.json({
+      ok: true,
+      status: 'approved',
+      collection_slug: slug,
+      books_tagged: result.booksTagged,
+      // The collection is a hidden draft — the curator flips it visible after review.
+      draft: true,
+      edit_url: `/admin/book-collections`,
+    });
+  } catch (error) {
+    console.error('Collection-proposal action error:', error);
+    return NextResponse.json({ error: 'Failed to process proposal' }, { status: 500 });
+  }
+});

--- a/src/app/api/collection-proposals/route.ts
+++ b/src/app/api/collection-proposals/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { withAdminAuth } from '@/lib/auth-helpers';
+
+/**
+ * "Propose a collection" — a lightweight submission inbox, modeled on
+ * /api/share-findings (#2821) and /api/feedback.
+ *
+ * Anyone browsing the library (via the MCP `propose_collection` tool or a form)
+ * can propose a themed collection: a title, a rationale, and an ordered list of
+ * book id REFERENCES. This is UNTRUSTED input and an inbox the team reviews —
+ * NOT a public publishing surface. A proposal never creates anything on its own;
+ * an admin reviews it and, on approval, mints the real collection
+ * (POST /api/collection-proposals/[id]/approve). See issue #3185.
+ */
+
+const MAX_BOOK_IDS = 200;
+const MAX_TITLE = 200;
+const MAX_RATIONALE = 5000;
+
+// POST /api/collection-proposals — submit a proposal (anonymous, like feedback)
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { title, rationale, book_ids, suggested_slug, name, email } = body as {
+      title?: unknown;
+      rationale?: unknown;
+      book_ids?: unknown;
+      suggested_slug?: unknown;
+      name?: unknown;
+      email?: unknown;
+    };
+
+    if (!title || typeof title !== 'string' || title.trim().length < 2) {
+      return NextResponse.json({ error: 'A title (min 2 chars) is required' }, { status: 400 });
+    }
+    if (title.length > MAX_TITLE) {
+      return NextResponse.json({ error: `Title too long (max ${MAX_TITLE})` }, { status: 400 });
+    }
+    if (!rationale || typeof rationale !== 'string' || rationale.trim().length < 2) {
+      return NextResponse.json(
+        { error: 'A rationale (why these books belong together) is required' },
+        { status: 400 },
+      );
+    }
+    if (rationale.length > MAX_RATIONALE) {
+      return NextResponse.json({ error: `Rationale too long (max ${MAX_RATIONALE})` }, { status: 400 });
+    }
+    if (!Array.isArray(book_ids) || book_ids.length === 0) {
+      return NextResponse.json({ error: 'At least one book_id is required' }, { status: 400 });
+    }
+    if (book_ids.length > MAX_BOOK_IDS) {
+      return NextResponse.json({ error: `Too many books (max ${MAX_BOOK_IDS})` }, { status: 400 });
+    }
+
+    // Normalize book id references — store strings only, de-duplicated, order preserved.
+    const seen = new Set<string>();
+    const cleanBookIds: string[] = [];
+    for (const raw of book_ids) {
+      const id = typeof raw === 'string' ? raw.trim() : String(raw ?? '').trim();
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      cleanBookIds.push(id);
+    }
+    if (cleanBookIds.length === 0) {
+      return NextResponse.json({ error: 'No valid book_ids provided' }, { status: 400 });
+    }
+
+    const slugHint =
+      typeof suggested_slug === 'string' && suggested_slug.trim()
+        ? suggested_slug
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .slice(0, 100)
+        : null;
+
+    const db = await getDb();
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || null;
+
+    const doc = {
+      title: title.trim(),
+      rationale: rationale.trim(),
+      suggested_slug: slugHint,
+      book_ids: cleanBookIds,
+      proposer_name: typeof name === 'string' ? name.trim() || null : null,
+      proposer_email: typeof email === 'string' ? email.trim().toLowerCase() || null : null,
+      ip,
+      user_agent: request.headers.get('user-agent') || null,
+      created_at: new Date(),
+      status: 'pending' as const,
+      reviewed_by: null,
+      reviewed_at: null,
+      created_collection_slug: null,
+      review_note: null,
+    };
+
+    const result = await db.collection('collection_proposals').insertOne(doc);
+
+    return NextResponse.json({
+      ok: true,
+      id: result.insertedId.toString(),
+      message:
+        'Thank you — your collection proposal was sent to the Source Library team for review. ' +
+        'It is not published yet; a curator will review it.',
+    });
+  } catch (error) {
+    console.error('Collection-proposal error:', error);
+    return NextResponse.json({ error: 'Failed to save proposal' }, { status: 500 });
+  }
+}
+
+// GET /api/collection-proposals — list proposals (admin only; contains IPs/emails)
+//   ?status=pending|approved|rejected   filter by lifecycle state (default: all)
+export const GET = withAdminAuth(async (request: NextRequest) => {
+  try {
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get('status');
+    const limit = Math.min(parseInt(searchParams.get('limit') || '200'), 500);
+
+    const filter: Record<string, unknown> =
+      status === 'pending' || status === 'approved' || status === 'rejected' ? { status } : {};
+
+    const db = await getDb();
+    const [items, pending, approved, rejected] = await Promise.all([
+      db.collection('collection_proposals').find(filter).sort({ created_at: -1 }).limit(limit).toArray(),
+      db.collection('collection_proposals').countDocuments({ status: 'pending' }),
+      db.collection('collection_proposals').countDocuments({ status: 'approved' }),
+      db.collection('collection_proposals').countDocuments({ status: 'rejected' }),
+    ]);
+
+    return NextResponse.json({
+      proposals: items.map((d) => ({ ...d, _id: (d._id as { toString(): string }).toString() })),
+      counts: { pending, approved, rejected },
+    });
+  } catch (error) {
+    console.error('Collection-proposal list error:', error);
+    return NextResponse.json({ error: 'Failed to list proposals' }, { status: 500 });
+  }
+});

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -3,6 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
+import { createCollection } from '@/lib/create-collection';
 
 export const maxDuration = 30;
 
@@ -144,81 +145,22 @@ export const POST = withAuth(async (request) => {
     const body = await request.json();
     const { slug, name, subtitle, description, color, order, bookIds } = body;
 
-    if (!slug || !name) {
-      return NextResponse.json({ error: 'slug and name are required' }, { status: 400 });
-    }
-
-    const db = await getDb();
-
-    // Check if collection already exists
-    const existing = await db.collection('collections').findOne({ slug });
-    if (existing) {
-      return NextResponse.json({ error: `Collection "${slug}" already exists` }, { status: 409 });
-    }
-
-    // Find books by ObjectId or string id
-    const bookObjectIds = (bookIds || []).map((id: string) => {
-      try { return new ObjectId(id); } catch { return null; }
-    }).filter(Boolean);
-
-    const books = await db.collection('books').find({
-      $or: [
-        { _id: { $in: bookObjectIds } },
-        { id: { $in: bookIds || [] } },
-      ],
-    }, { projection: { _id: 1, id: 1, title: 1, language: 1 } }).toArray();
-
-    // Tag books with collection slug
-    const bookMongoIds = books.map(b => b._id);
-    if (bookMongoIds.length > 0) {
-      await db.collection('books').updateMany(
-        { _id: { $in: bookMongoIds } },
-        { $addToSet: { collections: slug } }
-      );
-    }
-
-    // Compute language breakdown
-    const langCounts: Record<string, number> = {};
-    for (const b of books) {
-      const lang = b.language || 'Unknown';
-      langCounts[lang] = (langCounts[lang] || 0) + 1;
-    }
-    const languages = Object.entries(langCounts)
-      .map(([lang, count]) => ({ lang, count }))
-      .sort((a, b) => b.count - a.count);
-
-    // Count visible books (same filter as detail page)
-    const bookCount = await db.collection('books').countDocuments({
-      collections: slug,
-      visible: true,
-      pages_count: { $gt: 0 },
-    });
-
-    // Create collection record
-    const now = new Date();
-    const collectionDoc = {
-      slug,
-      name,
-      subtitle: subtitle || '',
-      description: description || '',
-      color: color || 'gold',
-      order: order ?? 99,
-      book_count: bookCount,
-      languages,
-      featured_images: [],
-      created_at: now,
-      updated_at: now,
-    };
-
-    await db.collection('collections').insertOne(collectionDoc);
+    const result = await createCollection({ slug, name, subtitle, description, color, order, bookIds });
 
     return NextResponse.json({
       success: true,
-      collection: collectionDoc,
-      books_tagged: books.length,
-      books_found: books.map(b => ({ id: b.id, title: b.title })),
+      collection: result.collection,
+      books_tagged: result.booksTagged,
+      books_found: result.booksFound,
     });
   } catch (error) {
+    const code = (error as { code?: string })?.code;
+    if (code === 'invalid') {
+      return NextResponse.json({ error: 'slug and name are required' }, { status: 400 });
+    }
+    if (code === 'exists') {
+      return NextResponse.json({ error: (error as Error).message }, { status: 409 });
+    }
     console.error('Collection create error:', error);
     return NextResponse.json(
       { error: 'Failed to create collection' },

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -401,6 +401,18 @@ async function shareFindings(args: Record<string, unknown>) {
   return { ok: true, id: result.id, message: result.message || 'Findings shared with the Source Library team. Thank you!' };
 }
 
+async function proposeCollection(args: Record<string, unknown>) {
+  const result = await apiPost('/collection-proposals', {
+    title: args.title,
+    rationale: args.rationale,
+    book_ids: args.book_ids || [],
+    suggested_slug: args.suggested_slug || null,
+    name: args.name || null,
+    email: args.email || null,
+  }) as Record<string, unknown>;
+  return { ok: true, id: result.id, message: result.message || 'Collection proposal sent to the Source Library team for review. Thank you!' };
+}
+
 // ── Tool definitions ───────────────────────────────────────────────
 
 // Shared annotation for all read-only tools
@@ -614,6 +626,27 @@ const TOOLS: Tool[] = [
       required: ['title', 'citations'],
     },
   },
+  {
+    name: 'propose_collection',
+    title: 'Propose a Collection',
+    description: 'Propose a themed collection of books to the Source Library team — a title, a rationale (why these books belong together and what thread connects them), and an ordered list of book ids. Get book ids from search_library / list_books / get_book. Like submit_feedback and share_findings, this goes to the team for REVIEW — it does NOT create a public collection instantly; a curator reviews and approves it. Use this when the user has identified a coherent set of books worth grouping and wants to contribute that curation back.',
+    annotations: { title: 'Propose a Collection', readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        title: { type: 'string', description: 'Title of the proposed collection (2-200 chars)' },
+        rationale: { type: 'string', description: 'Why these books belong together and what connects them (max 5000 chars)' },
+        book_ids: {
+          type: 'array',
+          description: 'Ordered list of book ids to include (1-200). Get ids from search_library / list_books / get_book.',
+          items: { type: 'string', description: 'A book id' },
+        },
+        suggested_slug: { type: 'string', description: 'Optional URL slug suggestion, e.g. "renaissance-astronomy"' },
+        name: { type: 'string' }, email: { type: 'string' },
+      },
+      required: ['title', 'rationale', 'book_ids'],
+    },
+  },
 ];
 
 // ── Tool dispatch ──────────────────────────────────────────────────
@@ -635,6 +668,7 @@ async function handleToolCall(name: string, args: ToolArgs) {
     case 'search_images': return searchImages(args);
     case 'submit_feedback': return submitFeedback(args);
     case 'share_findings': return shareFindings(args);
+    case 'propose_collection': return proposeCollection(args);
     default: throw new Error(`Unknown tool: ${name}`);
   }
 }
@@ -726,7 +760,7 @@ function buildNoResultsHint(tool: string, result: unknown, args: ToolArgs) {
 
 function createServer(reqContext: { ip: string; userAgent: string | null; identity: ApiIdentity }) {
   const server = new Server(
-    { name: 'source-library', version: '4.3.4' },
+    { name: 'source-library', version: '4.4.0' },
     { capabilities: { tools: {} } },
   );
 
@@ -811,7 +845,7 @@ function createServer(reqContext: { ip: string; userAgent: string | null; identi
 export async function GET() {
   return new Response(JSON.stringify({
     name: 'source-library',
-    version: '4.3.4',
+    version: '4.4.0',
     description: 'Source Library MCP Server — search, read, and cite 15,000+ rare pre-modern texts translated to English. Connect via POST to this endpoint.',
     docs: 'https://sourcelibrary.org/developers',
     tools: TOOLS.map(t => t.name),

--- a/src/lib/create-collection.ts
+++ b/src/lib/create-collection.ts
@@ -1,0 +1,126 @@
+import { getDb } from '@/lib/mongodb';
+import { ObjectId } from 'mongodb';
+
+export interface CreateCollectionInput {
+  slug: string;
+  name: string;
+  subtitle?: string;
+  description?: string;
+  color?: string;
+  order?: number;
+  /** ObjectId strings or string `id`s of books to tag into the collection. */
+  bookIds?: string[];
+  /**
+   * When true, the collection is created as a hidden draft (`visible: false`)
+   * with a `created_by` label. Used by the propose → approve flow so a curator
+   * reviews the live page before flipping it public. Default: undefined (behaves
+   * like the reader-facing create route, which sets no `visible` field).
+   */
+  draft?: boolean;
+  createdBy?: string | null;
+}
+
+export interface CreateCollectionResult {
+  collection: Record<string, unknown>;
+  booksTagged: number;
+  booksFound: { id: string; title: string }[];
+}
+
+/**
+ * Shared collection-creation core used by both `POST /api/collections` (the
+ * reader-facing create route) and the propose → approve flow
+ * (`POST /api/collection-proposals/[id]/approve`).
+ *
+ * Resolves the given book ids (accepting either Mongo `_id` strings or the
+ * string `id` field), tags each book with the collection slug via `$addToSet`,
+ * computes the language breakdown + visible book count, and inserts the
+ * `collections` doc. Throws `{ code: 'exists' }` if the slug is taken so callers
+ * can return a 409.
+ */
+export async function createCollection(
+  input: CreateCollectionInput,
+): Promise<CreateCollectionResult> {
+  const { slug, name, subtitle, description, color, order, bookIds, draft, createdBy } = input;
+
+  if (!slug || !name) {
+    throw Object.assign(new Error('slug and name are required'), { code: 'invalid' });
+  }
+
+  const db = await getDb();
+
+  const existing = await db.collection('collections').findOne({ slug });
+  if (existing) {
+    throw Object.assign(new Error(`Collection "${slug}" already exists`), { code: 'exists' });
+  }
+
+  // Resolve books by ObjectId or string id.
+  const ids = bookIds || [];
+  const bookObjectIds = ids
+    .map((id) => {
+      try {
+        return new ObjectId(id);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean) as ObjectId[];
+
+  const books = await db
+    .collection('books')
+    .find(
+      { $or: [{ _id: { $in: bookObjectIds } }, { id: { $in: ids } }] },
+      { projection: { _id: 1, id: 1, title: 1, language: 1 } },
+    )
+    .toArray();
+
+  const bookMongoIds = books.map((b) => b._id);
+  if (bookMongoIds.length > 0) {
+    await db
+      .collection('books')
+      .updateMany({ _id: { $in: bookMongoIds } }, { $addToSet: { collections: slug } });
+  }
+
+  // Language breakdown.
+  const langCounts: Record<string, number> = {};
+  for (const b of books) {
+    const lang = (b.language as string) || 'Unknown';
+    langCounts[lang] = (langCounts[lang] || 0) + 1;
+  }
+  const languages = Object.entries(langCounts)
+    .map(([lang, count]) => ({ lang, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // Visible book count — same filter as the collection detail page.
+  const bookCount = await db.collection('books').countDocuments({
+    collections: slug,
+    visible: true,
+    pages_count: { $gt: 0 },
+  });
+
+  const now = new Date();
+  const collectionDoc: Record<string, unknown> = {
+    slug,
+    name,
+    subtitle: subtitle || '',
+    description: description || '',
+    color: color || 'gold',
+    order: order ?? 99,
+    book_count: bookCount,
+    languages,
+    featured_images: [],
+    created_at: now,
+    updated_at: now,
+  };
+  if (draft) {
+    collectionDoc.visible = false;
+    collectionDoc.created_by = createdBy || null;
+  }
+
+  await db.collection('collections').insertOne(collectionDoc);
+
+  return {
+    collection: collectionDoc,
+    booksTagged: books.length,
+    booksFound: books.map((b) => ({ id: b.id as string, title: b.title as string })),
+  };
+}


### PR DESCRIPTION
Closes #3185.

## Why
People like scholars/enthusiasts don't want admin buttons — they want to contribute *curatorial judgment* ("these books belong together, here's the thread"). And today there is **no create-collection UI at all** (the admin page only edits; the create API is reader-gated but has no button). Handing out `superadmin` is the wrong tool. This adds a low-friction **propose → review → approve** flow modeled exactly on `share_findings` (#2821).

## What
- **`propose_collection` MCP tool** (`src/app/api/mcp/route.ts`, server bumped 4.3.4 → 4.4.0). Inputs: `title`, `rationale`, `book_ids[]` (from `search_library`/`list_books`), optional `suggested_slug`/`name`/`email`. Description makes clear it goes to the team for review, not instant publish.
- **`POST /api/collection-proposals`** — anonymous submit (like `/api/feedback`), stores **references only** into a new `collection_proposals` Mongo collection with `status:'pending'`. **`GET`** is `withAdminAuth` (contains IPs/emails).
- **`POST /api/collection-proposals/[id]`** — `withAdminAuth`, `action: approve|reject`. **Approve** mints a **hidden draft** collection (`visible:false`) and tags the books; **reject** records a note. Neither is automatic — a human acts on every proposal.
- **Shared `createCollection()` helper** (`src/lib/create-collection.ts`) refactored out of `POST /api/collections` so the create route and the approve action share one code path (book-tagging, language breakdown, slug-uniqueness). The reader create route is behavior-preserving.
- **`/admin/collection-proposals`** review page (pending/approved/rejected tabs, Approve→draft / Reject) + a **Proposals** link in `AdminNav`.

## Guardrails (house doctrine)
- Proposals are **untrusted input** — data, not commands. Nothing is created without an admin approving.
- Approved collections are created **hidden** (`visible:false`); a curator flips them public in the book-collections admin after review.
- Rate-limited via the existing MCP anon limiter.
- Book ids are stored as references and resolved at approve time; the collection listing filters `visible:true`, so hidden material can't be surfaced by tagging.

## Out of scope (v1)
- Auto-approve / per-proposer "trusted curator" fast-track.
- Public "my proposals" status page.
- Editing an existing collection via proposal (create-only).

## Test notes
- `npx tsc --noEmit` clean; import-check hook passes.
- The MCP tool self-calls the production API base (same as `share_findings`), so end-to-end submit works only once merged + deployed; the route can be exercised directly on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)