### PR TITLE
feat(ux): mobile catalog, total-books stat, Core/Pathways separation

### DIFF
--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -3,7 +3,7 @@ import { getReadDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import { headers } from 'next/headers';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
-import { sortCollections, sanitizeThumbnail, collectionCountLabel, coverOverride } from '@/lib/collections-utils';
+import { sortCollections, sanitizeThumbnail, collectionCountLabel, coverOverride, PINNED_COLLECTION_SLUGS } from '@/lib/collections-utils';
 import { toGalleryCardUrl } from '@/lib/utils';
 import EraTimeline, { type DecadeBucket } from '@/components/collections/EraTimeline';
 import ShowMorePathways from '@/components/collections/ShowMorePathways';
@@ -113,8 +113,9 @@ const CURATED_PATHWAYS = [
   'kepler-fludd-debate',
   'neoplatonism',
   'the-cosmos',
-  'indic-traditions',
-  'chinese-classics',
+  // 'indic-traditions' / 'chinese-classics' removed — their parent wings
+  // (South Asia / East Asia) are now Core Collections, so they're reachable as
+  // sub-collections there rather than duplicated as loose top-level pathways.
   'great-manuscripts',
   'herbalism',
   'jungs-library',
@@ -282,15 +283,16 @@ export default async function CollectionsPage() {
         />
       }
     >
-      {/* Each section streams on its own so the fast Curated Pathways query
-          isn't blocked behind the heavy timeline aggregation over all books. */}
-      <Suspense fallback={<SectionSkeleton heading="Curated Pathways" sub="Thematic journeys through the collection" />}>
-        <CuratedPathwaysSection />
+      {/* Core Collections (the major subject wings) lead; Curated Pathways
+          (narrower thematic journeys + special collections) follow. Each
+          section streams on its own. */}
+      <Suspense fallback={<SectionSkeleton heading="Core Collections" sub="The major subject wings of the library" />}>
+        <CoreCollectionsSection />
       </Suspense>
 
       <div className="mt-12">
-        <Suspense fallback={<SectionSkeleton heading="Core Collections" sub="The main wings of the library" />}>
-          <CoreCollectionsSection />
+        <Suspense fallback={<SectionSkeleton heading="Curated Pathways" sub="Thematic journeys and special collections" />}>
+          <CuratedPathwaysSection />
         </Suspense>
       </div>
 
@@ -302,41 +304,54 @@ export default async function CollectionsPage() {
   );
 }
 
-async function CuratedPathwaysSection() {
-  const { id: tenantId, slug: tenantSlug } = getTenantContextFromRequest(await headers());
-  const pathways = await fetchCuratedPathways(tenantId);
-  if (pathways.length === 0) return null;
-
-  return (
-    <div>
-      <div className="mb-4">
-        <h2 className="font-display text-2xl text-primary">Curated Pathways</h2>
-        <p className="text-stone-500 mt-1 text-sm">Thematic journeys through the collection</p>
-      </div>
-      <ShowMorePathways initialCount={INITIAL_PATHWAYS} totalCount={pathways.length}>
-        {pathways.map((col, i) => (
-          <CuratedCard key={col.slug} col={col} tenantSlug={tenantSlug} priority={i < 4} />
-        ))}
-      </ShowMorePathways>
-    </div>
-  );
-}
-
 async function CoreCollectionsSection() {
   const { id: tenantId, slug: tenantSlug } = getTenantContextFromRequest(await headers());
-  const categories = await fetchCollections(tenantId);
+  const all = await fetchCollections(tenantId);
+  // Core = the major subject wings only (PINNED). sortCollections already puts
+  // the pinned wings first and in curated order.
+  const wings = all.filter((col) => PINNED_COLLECTION_SLUGS.includes(col.slug));
 
   return (
     <div>
       <div className="mb-4">
         <h2 className="font-display text-2xl text-primary">Core Collections</h2>
-        <p className="text-stone-500 mt-1 text-sm">The main wings of the library</p>
+        <p className="text-stone-500 mt-1 text-sm">The major subject wings of the library</p>
       </div>
       <div className="grid gap-3 sm:gap-4 grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-        {categories.map((col) => (
+        {wings.map((col) => (
           <CollectionCard key={col.slug} col={col} tenantSlug={tenantSlug} />
         ))}
       </div>
+    </div>
+  );
+}
+
+async function CuratedPathwaysSection() {
+  const { id: tenantId, slug: tenantSlug } = getTenantContextFromRequest(await headers());
+  const [pathways, all] = await Promise.all([
+    fetchCuratedPathways(tenantId),
+    fetchCollections(tenantId),
+  ]);
+  // Pathways = the hand-picked thematic journeys (sub-collections), then the
+  // remaining top-level collections that aren't Core wings (special/niche
+  // collections like The Sibyls, Dissenters & Prophets, An Account of the Plant).
+  // Nothing top-level is orphaned: every collection is either a wing or here.
+  const seen = new Set(pathways.map((p) => p.slug));
+  const specials = all.filter((col) => !PINNED_COLLECTION_SLUGS.includes(col.slug) && !seen.has(col.slug));
+  const items = [...pathways, ...specials];
+  if (items.length === 0) return null;
+
+  return (
+    <div>
+      <div className="mb-4">
+        <h2 className="font-display text-2xl text-primary">Curated Pathways</h2>
+        <p className="text-stone-500 mt-1 text-sm">Thematic journeys and special collections</p>
+      </div>
+      <ShowMorePathways initialCount={INITIAL_PATHWAYS} totalCount={items.length}>
+        {items.map((col, i) => (
+          <CuratedCard key={col.slug} col={col} tenantSlug={tenantSlug} priority={i < 4} />
+        ))}
+      </ShowMorePathways>
     </div>
   );
 }

--- a/src/components/catalog/ScholarCatalog.tsx
+++ b/src/components/catalog/ScholarCatalog.tsx
@@ -593,7 +593,57 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
         {books.length === 0 && !loading ? (
           <div className="py-20 text-center text-muted">No books match your filters.</div>
         ) : (
-          <div className="overflow-x-auto">
+          <>
+          {/* Mobile (<md): stacked list + a sort control, since a table reads
+              cramped on a phone. Desktop keeps the sortable table below. */}
+          <div className="md:hidden">
+            <div className="mb-3 flex items-center gap-2">
+              <label htmlFor="mobile-sort" className="text-xs text-muted uppercase tracking-wide">Sort</label>
+              <select
+                id="mobile-sort"
+                value={sort}
+                onChange={(e) => handleSort(e.target.value)}
+                className="text-sm border border-border-medium rounded px-2 py-1 bg-white text-primary"
+              >
+                <option value="title">Title</option>
+                <option value="year_asc">Year (oldest first)</option>
+                <option value="year_desc">Year (newest first)</option>
+                <option value="author">Author</option>
+                <option value="popular">Most read</option>
+                <option value="recent">Recently added</option>
+              </select>
+            </div>
+            <ul className="divide-y divide-border-light">
+              {books.map((book) => {
+                const href = `/book/${book.slug || book.id}`;
+                return (
+                  <li key={book.id}>
+                    <Link href={href} className="block py-3 active:bg-warm/50 transition-colors">
+                      <div className="flex items-start gap-2">
+                        <span className="text-sm font-medium text-primary line-clamp-2 flex-1" style={{ fontFamily: 'var(--font-serif)' }}>
+                          {book.display_title || book.title}
+                        </span>
+                        {isPublishedFirstTranslation(book) && (
+                          <span className="shrink-0 inline-block bg-accent-gold/15 text-accent-gold-dark text-[10px] px-1.5 py-0.5 rounded-full font-medium">
+                            {firstTranslationBadge(book.ft_disposition, book.language ?? undefined)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xs text-muted mt-1 flex flex-wrap items-center gap-x-1.5">
+                        <AuthorName author={book.author} fallback="—" />
+                        <span aria-hidden>·</span>
+                        <span className="tabular-nums">{displayYear(book)}</span>
+                        {book.language && (<><span aria-hidden>·</span><span>{book.language}</span></>)}
+                        {book.pages_count ? (<><span aria-hidden>·</span><span className="tabular-nums">{book.pages_count} pp</span></>) : null}
+                      </div>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+          {/* Desktop (md+): sortable table */}
+          <div className="hidden md:block overflow-x-auto">
             <table className="w-full text-left">
               <thead>
                 <tr className="border-b border-border-medium text-xs text-muted uppercase tracking-wide">
@@ -664,6 +714,7 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
               </tbody>
             </table>
           </div>
+          </>
         )}
       </div>
 

--- a/src/components/home/HomeView.tsx
+++ b/src/components/home/HomeView.tsx
@@ -109,6 +109,8 @@ export default function HomeView({ data, lang }: { data: HomeData; lang: HomeLan
                 {t.collectionsHeading}
               </h2>
               <p className="text-muted mt-2">
+                <Link href="/catalog" className="hover:text-accent-rust transition-colors">{nf(counts.totalBooks)} {t.booksLabel}</Link>
+                {' '}&middot;{' '}
                 <Link href="/search?has_translation=true" className="hover:text-accent-rust transition-colors">{nf(counts.translatedToEnglish)} {t.translationsLabel}</Link>
                 {' '}&middot;{' '}
                 <Link href="/search?first_translation=true" className="hover:text-accent-rust transition-colors">{nf(counts.firstTranslationCount)} {t.firstTimeLabel}</Link>

--- a/src/lib/collections-utils.ts
+++ b/src/lib/collections-utils.ts
@@ -36,6 +36,9 @@ export const PINNED_COLLECTION_SLUGS = [
   // Row 5 — remaining
   'psychology',
   'history-political-thought',
+  // Row 6 — regional wings (major domains, promoted out of the misc top-level bucket)
+  'east-asia',
+  'south-asia',
 ];
 
 /** Pin specific collections first, shuffle the rest. */


### PR DESCRIPTION
Three collections/catalog UX fixes (from live review with Derek).

### 1. Browse catalog is cramped on mobile
`/catalog/scholar` was an HTML `<table>` — on a phone: Title at 45% width, a far-right Year column, and a big empty gap. Now renders a **stacked list + sort dropdown on mobile (<md)**; the sortable table stays on **desktop (md+)**.

### 2. Homepage stat line never stated the total book count
It led with "17,429 translations · 5,842 for the first time · …" but never the total holdings. Now leads with **19,414 books ·** … (links to /catalog).

### 3. Core Collections and Curated Pathways were mixed
- "Core" was *every* top-level collection — mixing 1,700-book wings with 10-book niche ones (Sibyls, Druids).
- "Pathways" held sub-collections **bigger than some wings** (Chinese Classics 614 > Kabbalah 388).

Now:
- **Core Collections = the major subject wings only** (promoted **East Asia** + **South Asia** into the pinned wings).
- **Curated Pathways = the hand-picked journeys + the remaining niche/special top-levels** (Sibyls, Dissenters & Prophets, An Account of the Plant, …).
- **Core leads, Pathways follow.** Chinese Classics / Indic Traditions dropped from Pathways (now reachable inside their wing parents). Guaranteed no top-level collection is orphaned (`specials = all top-level − wings − pathways`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)