### PR TITLE
fix(strip): bound emphasis regex interiors — ReDoS on junk pages

### DIFF
--- a/scripts/analytics/build-ngrams.mjs
+++ b/scripts/analytics/build-ngrams.mjs
@@ -61,6 +61,9 @@ const TRUNCATE = has('--truncate'); // wipe both tables before a fresh load — 
 // replacing a run built with different thresholds/filters, or stale rows from the
 // old run survive the upsert (only matching keys get overwritten)
 const MAX_PAGE_TOKENS = 15_000; // corpus-size.mjs found ~50k-word junk pages (whole-book dumps); skip them
+const MAX_PAGE_CHARS = 200_000; // and skip them BEFORE the wrapper strip: a real dense page is <20K
+// chars, and running the cleanup regexes over a 400KB junk dump is what turned
+// into a 2h regex spin on 2026-07-18 (regexes now bounded too — defense in depth)
 
 if (!['all', 'emit', 'load'].includes(PHASE)) { console.error(`Unknown --phase ${PHASE}`); process.exit(1); }
 
@@ -144,8 +147,13 @@ async function emit() {
     .toArray();
 
   let nextPages = workList.length ? fetchPages(workList[0].id) : null;
+  const statusPath = path.join(DIR, 'current-book.txt');
   for (let b = 0; b < workList.length; b++) {
     const book = workList[b];
+    // Breadcrumb for stall diagnosis: if the process ever wedges (e.g. a
+    // pathological page), this names the book it wedged on.
+    fs.writeFileSync(statusPath, `${b} ${book.id} year=${book.year} lang=${book.language || '?'}\n`);
+    const bookStart = Date.now();
     const pages = await nextPages;
     if (b + 1 < workList.length) nextPages = fetchPages(workList[b + 1].id);
 
@@ -162,6 +170,7 @@ async function emit() {
 
     const ingest = (raw, corpus) => {
       if (!raw || !corpus) return;
+      if (raw.length > MAX_PAGE_CHARS) { nSkippedJunk++; return; }
       const tokens = tokenize(stripApparatusTags(stripEditorialWrappers(raw)), corpus);
       if (!tokens.length) return;
       if (tokens.length > MAX_PAGE_TOKENS) { nSkippedJunk++; return; }
@@ -199,6 +208,8 @@ async function emit() {
     for (const [s, buf] of buffers) await writeShard(s, buf.join(''));
 
     nBooks++;
+    const bookSecs = (Date.now() - bookStart) / 1000;
+    if (bookSecs > 30) console.log(`[emit] slow book ${book.id} (${pages.length} pages) took ${bookSecs.toFixed(0)}s`);
     if (nBooks % 200 === 0 || nBooks === workList.length) {
       const rate = nBooks / ((Date.now() - t0) / 60000);
       const eta = ((workList.length - nBooks) / rate).toFixed(0);

--- a/scripts/lib/strip-editorial-wrappers.mjs
+++ b/scripts/lib/strip-editorial-wrappers.mjs
@@ -23,13 +23,16 @@ function flattenMarkdownTables(text) {
 }
 
 function stripMarkdownMarkers(text) {
+  // Interiors are BOUNDED (300 chars, no newlines) — the lazy-unbounded
+  // originals went quadratic on junk pages with thousands of stray asterisks
+  // (2h regex spin in the ngram build, 2026-07-18). See the TS twin's comment.
   return text
     .replace(/^[ \t]*#{1,6}[ \t]+/gm, '')
     .replace(/^[ \t]*(?:-{3,}|\*{3,})[ \t]*$/gm, '')
-    .replace(/->\s*(.+?)\s*<-/g, '$1')
-    .replace(/\*\*\*(\S(?:[^*]*?\S)?)\*\*\*/g, '$1')
-    .replace(/\*\*(\S(?:[^*]*?\S)?)\*\*/g, '$1')
-    .replace(/\*(\S(?:[^*]*?\S)?)\*/g, '$1')
+    .replace(/->[ \t]*(\S(?:[^\n]{0,300}?\S)?)[ \t]*<-/g, '$1')
+    .replace(/\*\*\*(\S(?:[^*\n]{0,300}?\S)?)\*\*\*/g, '$1')
+    .replace(/\*\*(\S(?:[^*\n]{0,300}?\S)?)\*\*/g, '$1')
+    .replace(/\*(\S(?:[^*\n]{0,300}?\S)?)\*/g, '$1')
     .replace(/\n[ \t]*\n[ \t]*\n+/g, '\n\n');
 }
 

--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -75,6 +75,16 @@ function flattenMarkdownTables(text: string): string {
  * Deliberately conservative: emphasis must hug non-whitespace (real markdown
  * rule) so spaced-out literal asterisks survive, and underscore emphasis is left
  * alone — "_" appears too often as a literal in OCR/transliteration to strip safely.
+ *
+ * BOUNDED interiors, not lazy-unbounded (2026-07-18): the emphasis/centered
+ * patterns originally used `[^*]*?` / `.+?` interiors. On junk pages (the
+ * ~50k-word single-page ingest dumps, which can also carry thousands of stray
+ * asterisks) every unpaired `*` triggered an O(line)-scan and the whole call
+ * went quadratic — the ngram batch build sat 2h at 111% CPU inside this
+ * function on one page, and the same text served through a reader/quote route
+ * would spin that request. Real emphasis and ->centered<- spans are short and
+ * never cross a line, so interiors are capped at 300 chars and excluded from
+ * matching newlines; longer spans keep their literal markers (harmless).
  */
 function stripMarkdownMarkers(text: string): string {
   return text
@@ -84,11 +94,11 @@ function stripMarkdownMarkers(text: string): string {
     // are left alone to honour the "never touch _" guarantee below.
     .replace(/^[ \t]*(?:-{3,}|\*{3,})[ \t]*$/gm, '')
     // ->centered<- markers (content kept).
-    .replace(/->\s*(.+?)\s*<-/g, '$1')
+    .replace(/->[ \t]*(\S(?:[^\n]{0,300}?\S)?)[ \t]*<-/g, '$1')
     // Paired bold/italic asterisks (content must start & end non-space).
-    .replace(/\*\*\*(\S(?:[^*]*?\S)?)\*\*\*/g, '$1')
-    .replace(/\*\*(\S(?:[^*]*?\S)?)\*\*/g, '$1')
-    .replace(/\*(\S(?:[^*]*?\S)?)\*/g, '$1')
+    .replace(/\*\*\*(\S(?:[^*\n]{0,300}?\S)?)\*\*\*/g, '$1')
+    .replace(/\*\*(\S(?:[^*\n]{0,300}?\S)?)\*\*/g, '$1')
+    .replace(/\*(\S(?:[^*\n]{0,300}?\S)?)\*/g, '$1')
     // Collapse blank lines left by removed headings/rules.
     .replace(/\n[ \t]*\n[ \t]*\n+/g, '\n\n');
 }

--- a/tests/unit/strip-editorial-wrappers.test.ts
+++ b/tests/unit/strip-editorial-wrappers.test.ts
@@ -252,3 +252,31 @@ describe('stripLeadingAiPreamble (via cleanOcrArtifacts)', () => {
     expect(cleanOcrArtifacts(refusal)).toBe('');
   });
 });
+
+// ReDoS guard (2026-07-18): the emphasis/centered-marker regexes originally
+// used unbounded lazy interiors; on a junk page with thousands of stray
+// asterisks each unpaired `*` scanned to end-of-line and the whole call went
+// quadratic (a 400KB page held the ngram build at 111% CPU for 2h; the same
+// text through a reader/quote route would spin that request). Interiors are
+// now capped at 300 chars and single-line. These tests pin both the bound and
+// the preserved behavior.
+describe('stripMarkdownMarkers ReDoS bound', () => {
+  it('survives a 400KB junk page riddled with unpaired asterisks', () => {
+    const junk = ('lorem ipsum * dolor ** sit -> amet '.repeat(20) + '\n').repeat(600);
+    expect(junk.length).toBeGreaterThan(400_000);
+    const t0 = Date.now();
+    stripEditorialWrappers(junk);
+    // Unbounded interiors take minutes-to-hours here; bounded takes ~tens of ms.
+    expect(Date.now() - t0).toBeLessThan(5_000);
+  });
+
+  it('still strips normal emphasis and centered markers', () => {
+    expect(stripEditorialWrappers('**B** and *italic* and ***both***')).toBe('B and italic and both');
+    expect(stripEditorialWrappers('->THE END.<-')).toBe('THE END.');
+  });
+
+  it('leaves markers literal on over-long spans instead of scanning', () => {
+    const long = '**' + 'a'.repeat(400) + '**';
+    expect(stripEditorialWrappers(long)).toBe(long);
+  });
+});


### PR DESCRIPTION
The paired-emphasis and ->centered<- patterns in `stripMarkdownMarkers` used unbounded lazy interiors (`[^*]*?`, `.+?`). On the known ~50K-word junk pages (single-page whole-book ingest dumps, often riddled with stray asterisks) every unpaired `*` triggered an O(line) scan → quadratic total. Caught tonight when the ngram batch build (#3177) wedged for 2h at 111% CPU inside `stripMarkdownMarkers` (confirmed via CDP pause on the live process). The same text served through any reader/quote/search route would spin that request — so this is also request-path hardening.

**Fix:** interiors bounded to 300 chars and single-line in BOTH twins (src/lib TS + scripts/lib mjs, changed identically; the parity test still pins them). Spans longer than the bound keep their literal markers — harmless, and real emphasis never gets near 300 chars. `build-ngrams.mjs` additionally skips >200KB raw pages *before* the strip (the token-based junk guard ran after — too late) and writes a `current-book.txt` breadcrumb so any future stall names its book instantly.

**Tests:** new ReDoS regression block (400KB pathological page must complete <5s; normal emphasis still strips; over-long spans stay literal). Stripper + ngram suites: 56/56. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)