### PR TITLE
docs+indexes: register book_events collection

### DIFF
--- a/.claude/docs/system-map.md
+++ b/.claude/docs/system-map.md
@@ -169,7 +169,8 @@ Routes: `/artwork/[slug]`, `/artist/[name]`, `/api/artwork/`. Collections suppor
 | `analytics_events`, `analytics_pageviews` | User behavior (migrating to Supabase) |
 | `pipeline_snapshots`, `pipeline_health_daily` | Pipeline metrics (mirrored to Supabase) |
 | `cron_runs` | Cron execution logs (mirrored to Supabase) |
-| `audit_log` | Admin action trail |
+| `audit_log` | Admin action trail (prunable telemetry — in prune-telemetry.mjs scope) |
+| `book_events` | PERMANENT per-book history (e.g. `image_resolution_upgrade` with OCR-input provenance, #3191/#3186) — never prune. Books flagged for re-OCR carry `books.reocr_candidate` |
 | `application_errors` | Error logging |
 
 ### Research & Experiments

--- a/scripts/maintenance/ensure-indexes.mjs
+++ b/scripts/maintenance/ensure-indexes.mjs
@@ -87,6 +87,8 @@ export const INDEXES = [
   { collection: 'api_usage', key: { 'ip_hash': 1, 'ts': -1 }, options: { 'name': 'ip_hash_1_ts_-1' }, why: 'Per-client analysis, hashed IP for PII-light logging. src/lib/api-usage.ts.' },
   // ── audit_log ─────────────────────────────────────────────────
   { collection: 'audit_log', key: { 'book_id': 1 }, options: { 'name': 'audit_log_book_idx', 'background': true }, why: 'Lookup by book_id. Archived ensure-indexes route.' },
+  // ── book_events ───────────────────────────────────────────────
+  { collection: 'book_events', key: { 'book_id': 1, 'type': 1 }, options: { 'name': 'book_events_book_type_idx', 'background': true }, why: 'Per-book durable history lookups (image_resolution_upgrade etc.). Unlike audit_log this collection is PERMANENT — never add it to prune-telemetry. rearchive-iiif-fullres.mjs, backfill-resolution-upgrade-events.mjs (#3191).' },
   // ── authors ───────────────────────────────────────────────────
   { collection: 'authors', key: { 'slug': 1 }, options: { 'name': 'slug_1', 'unique': true }, why: 'Canonical slug lookup, the primary key for the author thesaurus. scripts/maintenance/build-authors-collection.mjs.' },
   { collection: 'authors', key: { 'variant_slugs': 1 }, options: { 'name': 'variant_slugs_1' }, why: 'Redirect-map lookup: any variant slug resolves to the canonical author. build-authors-collection.mjs.' },


### PR DESCRIPTION
Housekeeping for #3191: adds the {book_id, type} index for `book_events` to ensure-indexes.mjs and documents the collection in the system map — explicitly contrasted with the prunable `audit_log` so permanent provenance never lands in a prune list. In scope: index def + doc rows. Out of scope: any UI surfacing of book history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)