### PR TITLE
fix(librarian): align mic button with Send button

### DIFF
--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -1108,7 +1108,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                         aria-label={listening ? 'Stop voice input' : 'Start voice input'}
                         aria-pressed={listening}
                         title={listening ? 'Stop voice input' : 'Speak your question'}
-                        className={`flex-shrink-0 p-2.5 rounded-lg border transition-colors ${listening
+                        className={`flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-lg border transition-colors ${listening
                           ? 'border-[#9e4a3a] bg-[#9e4a3a] text-white animate-pulse'
                           : 'border-[#e8e4dc] text-[#8a8480] hover:text-[#1a1612] hover:border-[#c9a86c]'
                           }`}


### PR DESCRIPTION
One-line CSS fix for the mic button shipped in #3194: the inline SVG's baseline alignment added phantom descender space below the icon, making the button taller than Send and vertically misaligned. Now a flex-centered fixed 40px square (`h-10 w-10`), exactly matching Send's height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)