### PR TITLE
feat(overview): chapter-grouped Contents view, wall becomes a toggle

### DIFF
--- a/src/app/book/[id]/overview/page.tsx
+++ b/src/app/book/[id]/overview/page.tsx
@@ -3,7 +3,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { getTenantContext } from '@/lib/tenant-context';
 import type { Metadata } from 'next';
-import BookOverview from '@/components/reader/BookOverview';
+import BookOverviewShell from '@/components/reader/BookOverviewShell';
 export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
 export async function generateStaticParams() {
@@ -25,6 +25,7 @@ const BOOK_PROJECTION = {
   display_title: 1,
   author: 1,
   pages_count: 1,
+  chapters: 1,
 };
 
 const PAGE_PROJECTION = {
@@ -41,6 +42,9 @@ const PAGE_PROJECTION = {
   split_from_spread: 1,
   crop: 1,
   page_type: 1,
+  // First gallery-worthy illustration only (>=0.5 = gallery materialization
+  // threshold) — mapped to a has_illustration boolean before serialization.
+  detected_images: { $elemMatch: { gallery_quality: { $gte: 0.5 } } },
 };
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -100,16 +104,27 @@ export default async function BookOverviewPage({ params }: PageProps) {
     display_photo: p.display_photo as string | undefined,
     split_from_spread: p.split_from_spread as boolean | undefined,
     crop: p.crop as { xStart?: number; xEnd?: number } | undefined,
+    has_illustration: Array.isArray(p.detected_images) && p.detected_images.length > 0 ? true : undefined,
   }));
 
   if (pages.length === 0) notFound();
 
+  const chapters = (Array.isArray(book.chapters) ? book.chapters : [])
+    .filter(c => typeof c?.pageNumber === 'number' && c.confidence !== 'low')
+    .map(c => ({
+      title: c.title as string,
+      titleEn: c.titleEn as string | undefined,
+      pageNumber: c.pageNumber as number,
+      level: (c.level as number) || 1,
+    }));
+
   return (
-    <BookOverview
+    <BookOverviewShell
       bookId={bookId}
       bookSlug={book.slug}
       bookTitle={book.display_title || book.title}
       pages={pages}
+      chapters={chapters}
     />
   );
 }

--- a/src/components/reader/BookOverview.tsx
+++ b/src/components/reader/BookOverview.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 
-interface OverviewPage {
+export interface OverviewPage {
   id: string;
   page_number: number;
   photo?: string;
@@ -15,6 +15,7 @@ interface OverviewPage {
   split_from_spread?: boolean;
   crop?: { xStart?: number; xEnd?: number };
   display_photo?: string;
+  has_illustration?: boolean;
 }
 
 interface BookOverviewProps {
@@ -22,6 +23,8 @@ interface BookOverviewProps {
   bookSlug?: string;
   bookTitle?: string;
   pages: OverviewPage[];
+  /** When provided, renders a "Contents" button that switches back to the grid view */
+  onShowContents?: () => void;
 }
 
 // Two-tier image URLs: fast thumbnail for overview, mid-res for zoom.
@@ -29,7 +32,7 @@ interface BookOverviewProps {
 // both point at the full uncropped spread for split pages, so falling
 // through to them renders the wrong image. cropped_photo is the half-page
 // crop and is the canonical source for split pages.
-function getThumbUrl(page: OverviewPage): string | null {
+export function getThumbUrl(page: OverviewPage): string | null {
   if (page.split_from_spread || page.crop) {
     return page.thumbnail_blob || page.cropped_photo || null;
   }
@@ -69,7 +72,7 @@ const HIRES_MIN_CELL_PX = 350; // on-screen cell width before hi-res is worth fe
 const HIRES_SETTLE_MS = 150; // camera must be still this long before hi-res loads start
 const HIRES_CONCURRENCY = 3;
 
-export default function BookOverview({ bookId, bookSlug, bookTitle, pages }: BookOverviewProps) {
+export default function BookOverview({ bookId, bookSlug, bookTitle, pages, onShowContents }: BookOverviewProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
@@ -626,8 +629,23 @@ export default function BookOverview({ bookId, bookSlug, bookTitle, pages }: Boo
         </div>
       )}
 
-      {/* Zoom controls — bottom-right pill */}
-      <div className="absolute bottom-6 right-6 z-20 flex items-center gap-1
+      {/* Bottom-right controls */}
+      <div className="absolute bottom-6 right-6 z-20 flex items-center gap-2">
+      {onShowContents && (
+        <button
+          onClick={onShowContents}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-full
+            bg-black/60 backdrop-blur-md border border-white/10
+            text-white/70 hover:text-white text-sm transition-colors shadow-lg"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path d="M2 3.5h10M2 7h10M2 10.5h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+          Contents
+        </button>
+      )}
+      {/* Zoom controls pill */}
+      <div className="flex items-center gap-1
         bg-black/60 backdrop-blur-md border border-white/10 rounded-full
         px-1 py-1 shadow-lg">
         <button
@@ -669,6 +687,7 @@ export default function BookOverview({ bookId, bookSlug, bookTitle, pages }: Boo
             <path d="M5 5h6v6H5z" stroke="currentColor" strokeWidth="1" strokeDasharray="2 1" />
           </svg>
         </button>
+      </div>
       </div>
 
       {/* Back link — bottom-left */}

--- a/src/components/reader/BookOverviewShell.tsx
+++ b/src/components/reader/BookOverviewShell.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import BookOverview, { getThumbUrl, type OverviewPage } from './BookOverview';
+
+interface OverviewChapter {
+  title: string;
+  titleEn?: string;
+  pageNumber: number;
+  level: number;
+}
+
+interface BookOverviewShellProps {
+  bookId: string;
+  bookSlug?: string;
+  bookTitle?: string;
+  pages: OverviewPage[];
+  chapters: OverviewChapter[];
+}
+
+interface Section {
+  /** Anchor id — start page number, or 'front' for pages before the first chapter */
+  anchor: string;
+  /** Chapter headings starting at this page (level 1 before level 2), empty for front matter */
+  headings: OverviewChapter[];
+  pages: OverviewPage[];
+}
+
+// Group pages into sections at chapter start pages. Several headings can share
+// a start page (e.g. "Tractatus I" and its "Quaestio I") — they render stacked.
+function buildSections(pages: OverviewPage[], chapters: OverviewChapter[]): Section[] {
+  const chs = [...chapters].sort((a, b) => a.pageNumber - b.pageNumber || a.level - b.level);
+  if (chs.length === 0) return [{ anchor: 'front', headings: [], pages }];
+
+  const starts = [...new Set(chs.map(c => c.pageNumber))];
+  const sections: Section[] = [];
+
+  const front = pages.filter(p => p.page_number < starts[0]);
+  if (front.length > 0) sections.push({ anchor: 'front', headings: [], pages: front });
+
+  starts.forEach((start, i) => {
+    const end = i + 1 < starts.length ? starts[i + 1] : Infinity;
+    const sectionPages = pages.filter(p => p.page_number >= start && p.page_number < end);
+    if (sectionPages.length === 0) return;
+    sections.push({
+      anchor: String(start),
+      headings: chs.filter(c => c.pageNumber === start),
+      pages: sectionPages,
+    });
+  });
+
+  return sections;
+}
+
+export default function BookOverviewShell({ bookId, bookSlug, bookTitle, pages, chapters }: BookOverviewShellProps) {
+  const [view, setView] = useState<'contents' | 'wall'>('contents');
+  const sections = useMemo(() => buildSections(pages, chapters), [pages, chapters]);
+  const bookPath = `/book/${bookSlug || bookId}`;
+  const hasChapters = sections.some(s => s.headings.length > 0);
+
+  if (view === 'wall') {
+    return (
+      <BookOverview
+        bookId={bookId}
+        bookSlug={bookSlug}
+        bookTitle={bookTitle}
+        pages={pages}
+        onShowContents={() => setView('contents')}
+      />
+    );
+  }
+
+  const jumpTo = (anchor: string) => {
+    document.getElementById(`section-${anchor}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <div className="min-h-dvh bg-[#0a0a0a] text-white">
+      {/* Sticky header: back link, title, chapter jump, view toggle */}
+      <header className="sticky top-0 z-30 bg-[#0a0a0a]/90 backdrop-blur-md border-b border-white/10">
+        <div className="max-w-[1500px] mx-auto px-4 sm:px-6 py-3 flex items-center gap-3">
+          <Link
+            href={bookPath}
+            className="shrink-0 flex items-center gap-1.5 text-white/60 hover:text-white text-sm transition-colors"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path d="M9 3L5 7l4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            <span className="hidden sm:inline">Back to book</span>
+          </Link>
+
+          <h1 className="flex-1 min-w-0 truncate text-sm sm:text-base text-white/80">
+            {bookTitle}
+            <span className="ml-2 text-white/40 text-xs sm:text-sm">{pages.length} pages</span>
+          </h1>
+
+          {hasChapters && (
+            <select
+              onChange={e => { if (e.target.value) jumpTo(e.target.value); }}
+              defaultValue=""
+              aria-label="Jump to chapter"
+              className="shrink-0 max-w-[40vw] sm:max-w-xs bg-white/5 border border-white/15 rounded-md
+                text-sm text-white/80 px-2 py-1.5 focus:outline-none focus:border-white/40"
+            >
+              <option value="" disabled>Jump to chapter…</option>
+              {sections.filter(s => s.headings.length > 0).map(s => {
+                const top = s.headings[0];
+                return (
+                  <option key={s.anchor} value={s.anchor}>
+                    {top.level > 1 ? '  ' : ''}{top.titleEn || top.title}
+                  </option>
+                );
+              })}
+            </select>
+          )}
+
+          <button
+            onClick={() => setView('wall')}
+            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full
+              border border-white/15 text-white/70 hover:text-white hover:border-white/40
+              text-sm transition-colors"
+            title="Zoomable wall of all pages"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <rect x="1.5" y="1.5" width="4.5" height="4.5" stroke="currentColor" strokeWidth="1.2" />
+              <rect x="8" y="1.5" width="4.5" height="4.5" stroke="currentColor" strokeWidth="1.2" />
+              <rect x="1.5" y="8" width="4.5" height="4.5" stroke="currentColor" strokeWidth="1.2" />
+              <rect x="8" y="8" width="4.5" height="4.5" stroke="currentColor" strokeWidth="1.2" />
+            </svg>
+            <span className="hidden sm:inline">Wall view</span>
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-[1500px] mx-auto px-4 sm:px-6 pb-16">
+        {sections.map(section => (
+          <section
+            key={section.anchor}
+            id={`section-${section.anchor}`}
+            className="scroll-mt-16"
+            // Off-screen sections skip layout/paint; the estimate keeps the
+            // scrollbar stable for long books (up to the 2000-page fetch cap).
+            style={{ contentVisibility: 'auto', containIntrinsicSize: `auto ${Math.ceil(section.pages.length / 6) * 220 + 80}px` }}
+          >
+            {section.headings.length > 0 ? (
+              <div className="pt-8 pb-4">
+                {section.headings.map((h, i) => (
+                  <div key={i}>
+                    {h.titleEn && h.titleEn !== h.title ? (
+                      <>
+                        <span className={h.level <= 1 ? 'block text-lg sm:text-xl text-white/90' : 'block text-base text-white/80'}>
+                          {h.titleEn}
+                        </span>
+                        <span className="block text-sm text-white/40 italic">{h.title}</span>
+                      </>
+                    ) : (
+                      <span className={h.level <= 1 ? 'block text-lg sm:text-xl text-white/90' : 'block text-base text-white/80'}>
+                        {h.title}
+                      </span>
+                    )}
+                  </div>
+                ))}
+                <div className="mt-1 text-xs text-white/35 tabular-nums">
+                  Pages {section.pages[0].page_number}–{section.pages[section.pages.length - 1].page_number}
+                </div>
+              </div>
+            ) : (
+              <div className="pt-8 pb-4">
+                {hasChapters && <span className="block text-lg text-white/50">Front matter</span>}
+              </div>
+            )}
+
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] sm:grid-cols-[repeat(auto-fill,minmax(128px,1fr))] gap-3">
+              {section.pages.map(page => {
+                const thumb = getThumbUrl(page);
+                return (
+                  <Link
+                    key={page.id}
+                    href={`${bookPath}/page/${page.id}`}
+                    className="group block"
+                  >
+                    <div className="relative aspect-[3/4] bg-[#1a1a1a] border border-white/10
+                      group-hover:border-white/40 transition-colors overflow-hidden">
+                      {thumb && (
+                        // eslint-disable-next-line @next/next/no-img-element -- pre-sized R2 thumbs; the optimizer would re-proxy them at cost
+                        <img
+                          src={thumb}
+                          alt={`Page ${page.page_number}`}
+                          loading="lazy"
+                          decoding="async"
+                          className="w-full h-full object-contain"
+                        />
+                      )}
+                      {page.has_illustration && (
+                        <span
+                          className="absolute top-1 right-1 w-5 h-5 flex items-center justify-center
+                            rounded-full bg-black/70 text-white/80"
+                          title="Contains an illustration"
+                        >
+                          <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+                            <rect x="1" y="1" width="10" height="10" rx="1" stroke="currentColor" strokeWidth="1.2" />
+                            <circle cx="4.2" cy="4.2" r="1.1" fill="currentColor" />
+                            <path d="M2 9l2.5-2.5L7 9l2-2 1 1" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-1 text-center text-[11px] text-white/40 group-hover:text-white/70
+                      tabular-nums transition-colors">
+                      {page.page_number}
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </main>
+    </div>
+  );
+}

--- a/src/components/reader/BookOverviewShell.tsx
+++ b/src/components/reader/BookOverviewShell.tsx
@@ -54,7 +54,13 @@ function buildSections(pages: OverviewPage[], chapters: OverviewChapter[]): Sect
 }
 
 export default function BookOverviewShell({ bookId, bookSlug, bookTitle, pages, chapters }: BookOverviewShellProps) {
-  const [view, setView] = useState<'contents' | 'wall'>('contents');
+  const [view, setViewState] = useState<'contents' | 'wall'>('contents');
+  // Body scroll persists across the swap — a wall opened mid-scroll would show
+  // the site footer instead of the canvas.
+  const setView = (v: 'contents' | 'wall') => {
+    window.scrollTo(0, 0);
+    setViewState(v);
+  };
   const sections = useMemo(() => buildSections(pages, chapters), [pages, chapters]);
   const bookPath = `/book/${bookSlug || bookId}`;
   const hasChapters = sections.some(s => s.headings.length > 0);


### PR DESCRIPTION
## What

`/book/<slug>/overview` now defaults to a **Contents view**: a scrollable HTML grid of page thumbnails grouped by the book's extracted chapters, with the zoomable canvas wall (fixed in #3199) kept one click away as "Wall view". Closes #3197.

- **Sections from `book.chapters`** (low-confidence entries filtered): English title with the original beneath, stacked when several headings share a start page (Grillandus' "Treatise I" + "Question I"), page-range line, "Front matter" for pages before the first chapter. Books without chapters render one flat numbered grid.
- **Sticky header**: back-to-book, title + page count, jump-to-chapter `<select>` (hidden when no chapters), Wall-view toggle.
- **Thumbnails** lazy-load (`loading=lazy`) from the same `getThumbUrl` resolver the wall uses (split-page `cropped_photo` invariant preserved); page-number captions; sections use `content-visibility:auto` so long books skip off-screen layout/paint (page fetch already caps at 2000).
- **Illustration badge** on pages whose `detected_images` clear the 0.5 gallery threshold — computed server-side via an `$elemMatch` projection so the array never ships to the client.
- **Wall view** gains a "Contents" button beside the zoom controls; toggling either way resets scroll (body scroll otherwise persists and shows the site footer instead of the h-dvh canvas).

## Verification (preview deploy, Playwright)

- Grillandus (348 pp, 19 chapters, text-only): sections render with EN+Latin headings and ranges; jump select works.
- *De Fransche Neptunus* (atlas): illustration badges show; stacked same-page headings render.
- Shaker memoir (no chapters): flat grid, chapter select correctly absent.
- Mobile 390px: truncating title, icon-only toggle, 3-col grid.
- Wall toggle round-trip after mid-page scroll: canvas visible, return lands at top (`scrollY === 0` asserted).
- `npx tsc --noEmit` + eslint clean.

## Out of scope

Site header on this route (stays deliberately headerless per #3180 — the view has its own sticky chrome); tenant embed exposure (overview link remains hidden in embed mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)