### PR TITLE
Ngram viewer: cross-language overlays, 1930 default, modern-translation exclusion

### DIFF
--- a/scripts/analytics/build-ngrams.mjs
+++ b/scripts/analytics/build-ngrams.mjs
@@ -120,6 +120,13 @@ async function emit() {
     visible: true,
     pages_count: { $gt: 0 },
     year: { $gte: MIN_YEAR, $lte: MAX_YEAR, $type: 'number' },
+    // Modern-translation editions are excluded (620 books, ~3.4%): their year
+    // is the modern translation's publication date, so a 1911 Jowett Plato
+    // would inject a translator's 1911 English at year=1911 — semantically
+    // different from every other book, where year = the period edition and our
+    // own translation is pinned to it. period-translation stays: a 1650
+    // English rendering IS 1650 voice.
+    text_role: { $ne: 'modern-translation' },
     ...(LANGUAGE ? { language: LANGUAGE } : {}),
   };
   const books = await db.collection('books')

--- a/src/app/api/ngrams/route.ts
+++ b/src/app/api/ngrams/route.ts
@@ -1,29 +1,38 @@
 /**
  * GET /api/ngrams — term-frequency series for the ngram viewer (issue #3175).
  *
- * ?q=philosophers+stone,alkahest   1–6 comma-separated terms (≤3 words each)
- * &corpus=en                       corpus id (see NGRAM_CORPORA)
- * &smoothing=3                     ±years moving average, 0–10
- * &from=1450&to=1900               year range
+ * ?q=philosophers+stone,mercurius:la   1–6 comma-separated terms (≤3 words
+ *                                      each); a `:corpus` suffix charts that
+ *                                      term against a specific corpus, enabling
+ *                                      cross-language overlays (mercury vs
+ *                                      mercurius:la on one chart)
+ * &corpus=en                           default corpus for untagged terms
+ * &smoothing=3                         ±years moving average, 0–10
+ * &from=1450&to=1930                   year range (1930 default: later years
+ *                                      are thin and skew toward reprint noise)
  *
  * Reads the precomputed ngram_series / ngram_totals tables in Supabase
  * (written by scripts/analytics/build-ngrams.mjs). Query terms are normalized
  * with the same tokenizer the build used — parity is pinned by
- * tests/unit/ngram-normalize.test.ts. Anonymous, read-only, aggressively
- * CDN-cached: the data only changes when the batch build is re-run.
+ * tests/unit/ngram-normalize.test.ts. Per-million normalization is against
+ * each term's OWN corpus totals, which is what makes cross-corpus curves
+ * comparable on one axis. Anonymous, read-only, aggressively CDN-cached.
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabase';
 import { NGRAM_CORPORA, normalizePhrase, MAX_NGRAM_N } from '@/lib/ngram-normalize';
-import { buildSeries, MIN_YEAR_TOKENS, type NgramPoint } from '@/lib/ngram-series';
+import { buildSeries, parseTermSpec, MIN_YEAR_TOKENS, type NgramPoint } from '@/lib/ngram-series';
 
 const MAX_TERMS = 6;
 const YEAR_FLOOR = 800;
 const YEAR_CEIL = 2030;
 
 interface SeriesOut {
-  /** The term as the user typed it. */
+  /** The term as the user typed it (without any corpus tag). */
   term: string;
+  /** Corpus this term was charted against. */
+  corpus: string;
+  corpusLabel: string;
   /** The normalized ngram key actually looked up ('' if nothing tokenizable). */
   ngram: string;
   /** false = not in the table (below build threshold, or truly absent). */
@@ -38,9 +47,9 @@ interface SeriesOut {
 export async function GET(request: NextRequest) {
   const sp = request.nextUrl.searchParams;
 
-  const corpus = sp.get('corpus') || 'en';
-  if (!NGRAM_CORPORA.some(c => c.id === corpus)) {
-    return NextResponse.json({ error: `Unknown corpus "${corpus}"` }, { status: 400 });
+  const defaultCorpus = sp.get('corpus') || 'en';
+  if (!NGRAM_CORPORA.some(c => c.id === defaultCorpus)) {
+    return NextResponse.json({ error: `Unknown corpus "${defaultCorpus}"` }, { status: 400 });
   }
 
   const rawTerms = (sp.get('q') || '')
@@ -55,47 +64,67 @@ export async function GET(request: NextRequest) {
   const clamp = (v: number, lo: number, hi: number, def: number) =>
     Number.isFinite(v) ? Math.min(hi, Math.max(lo, v)) : def;
   const from = clamp(Number(sp.get('from')), YEAR_FLOOR, YEAR_CEIL, 1450);
-  let to = clamp(Number(sp.get('to')), YEAR_FLOOR, YEAR_CEIL, 1950);
+  let to = clamp(Number(sp.get('to')), YEAR_FLOOR, YEAR_CEIL, 1930);
   if (to < from) to = Math.min(YEAR_CEIL, from + 50);
   const smoothing = clamp(Number(sp.get('smoothing')), 0, 10, 3);
 
-  const terms = rawTerms.map(term => {
-    const ngram = normalizePhrase(term, corpus);
-    return { term, ngram, tooLong: ngram.split(' ').length > MAX_NGRAM_N };
+  const terms = rawTerms.map(raw => {
+    const spec = parseTermSpec(raw, defaultCorpus);
+    const ngram = normalizePhrase(spec.term, spec.corpus);
+    return { ...spec, ngram, tooLong: ngram.split(' ').length > MAX_NGRAM_N };
   });
-  const lookup = [...new Set(terms.filter(t => t.ngram && !t.tooLong).map(t => t.ngram))];
 
-  const [totalsRes, seriesRes] = await Promise.all([
-    supabase.from('ngram_totals').select('year, tokens').eq('corpus', corpus),
-    lookup.length
-      ? supabase.from('ngram_series')
-          .select('ngram, counts, total_count, book_count')
-          .eq('corpus', corpus)
-          .in('ngram', lookup)
-      : Promise.resolve({ data: [], error: null }),
+  // One series lookup per distinct corpus; totals for every corpus involved
+  // (each term normalizes against its own corpus) plus the default corpus
+  // (whose totals draw the backdrop even if every term is tagged elsewhere).
+  const lookupByCorpus = new Map<string, string[]>();
+  for (const t of terms) {
+    if (!t.ngram || t.tooLong) continue;
+    const list = lookupByCorpus.get(t.corpus) ?? [];
+    if (!list.includes(t.ngram)) list.push(t.ngram);
+    lookupByCorpus.set(t.corpus, list);
+  }
+  const totalsCorpora = [...new Set([defaultCorpus, ...lookupByCorpus.keys()])];
+
+  const [totalsRes, ...seriesRes] = await Promise.all([
+    supabase.from('ngram_totals').select('corpus, year, tokens').in('corpus', totalsCorpora),
+    ...[...lookupByCorpus.entries()].map(([corpus, ngrams]) =>
+      supabase.from('ngram_series')
+        .select('corpus, ngram, counts, total_count, book_count')
+        .eq('corpus', corpus)
+        .in('ngram', ngrams),
+    ),
   ]);
-  if (totalsRes.error || seriesRes.error) {
-    console.error('[ngrams] supabase error:', totalsRes.error || seriesRes.error);
+  const firstError = totalsRes.error || seriesRes.find(r => r.error)?.error;
+  if (firstError) {
+    console.error('[ngrams] supabase error:', firstError);
     return NextResponse.json({ error: 'Lookup failed' }, { status: 500 });
   }
-  if (!totalsRes.data?.length) {
+
+  const totalsByCorpus = new Map<string, Map<number, number>>();
+  for (const r of totalsRes.data || []) {
+    let m = totalsByCorpus.get(r.corpus);
+    if (!m) { m = new Map(); totalsByCorpus.set(r.corpus, m); }
+    m.set(Number(r.year), Number(r.tokens));
+  }
+  if (!totalsByCorpus.get(defaultCorpus)?.size) {
     return NextResponse.json(
-      { error: `Corpus "${corpus}" has no data yet` },
+      { error: `Corpus "${defaultCorpus}" has no data yet` },
       { status: 404 },
     );
   }
 
-  const totals = new Map<number, number>(
-    totalsRes.data.map(r => [Number(r.year), Number(r.tokens)]),
+  const rowByKey = new Map(
+    seriesRes.flatMap(r => (r.data || []).map(row => [`${row.corpus}${row.ngram}`, row])),
   );
-  const byNgram = new Map(
-    (seriesRes.data || []).map(r => [r.ngram as string, r]),
-  );
+  const labelOf = (id: string) => NGRAM_CORPORA.find(c => c.id === id)?.label || id;
 
-  const series: SeriesOut[] = terms.map(({ term, ngram, tooLong }) => {
-    const row = ngram && !tooLong ? byNgram.get(ngram) : undefined;
+  const series: SeriesOut[] = terms.map(({ term, corpus, ngram, tooLong }) => {
+    const row = ngram && !tooLong ? rowByKey.get(`${corpus}${ngram}`) : undefined;
     return {
       term,
+      corpus,
+      corpusLabel: labelOf(corpus),
       ngram,
       found: Boolean(row),
       tooLong,
@@ -103,18 +132,23 @@ export async function GET(request: NextRequest) {
       bookCount: row ? Number(row.book_count) : 0,
       points: buildSeries(
         (row?.counts as Record<string, number>) || {},
-        totals, from, to, smoothing,
+        totalsByCorpus.get(corpus) || new Map(),
+        from, to, smoothing,
       ),
     };
   });
 
-  const totalsOut = [...totals.entries()]
+  const defaultTotals = totalsByCorpus.get(defaultCorpus)!;
+  const totalsOut = [...defaultTotals.entries()]
     .filter(([year]) => year >= from && year <= to)
     .sort((a, b) => a[0] - b[0])
     .map(([year, tokens]) => ({ year, tokens }));
 
   return NextResponse.json(
-    { corpus, from, to, smoothing, minYearTokens: MIN_YEAR_TOKENS, totals: totalsOut, series },
+    {
+      corpus: defaultCorpus, from, to, smoothing,
+      minYearTokens: MIN_YEAR_TOKENS, totals: totalsOut, series,
+    },
     {
       headers: {
         'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',

--- a/src/components/ngrams/NgramViewer.tsx
+++ b/src/components/ngrams/NgramViewer.tsx
@@ -13,10 +13,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { linearScale, linePath, areaPath, niceTicks, compactNumber } from '@/components/analytics/charts/chart-utils';
 import { NGRAM_CORPORA, ORIGINAL_LANGUAGE_CORPUS } from '@/lib/ngram-normalize';
+import { findTermFamily } from '@/lib/ngram-lexicon';
 
 interface Point { year: number; count: number; perMillion: number; smoothed: number }
 interface Series {
-  term: string; ngram: string; found: boolean; tooLong: boolean;
+  term: string; corpus: string; corpusLabel: string;
+  ngram: string; found: boolean; tooLong: boolean;
   totalCount: number; bookCount: number; points: Point[];
 }
 interface ApiResponse {
@@ -40,6 +42,7 @@ const EXAMPLES: Array<{ label: string; q: string; corpus: string }> = [
   { label: "philosopher's stone vs elixir", q: "philosopher's stone,elixir", corpus: 'en' },
   { label: 'kabbalah vs hieroglyphics', q: 'kabbalah,hieroglyphics', corpus: 'en' },
   { label: 'lapis philosophorum (Latin)', q: 'lapis philosophorum,quinta essentia', corpus: 'la' },
+  { label: 'mercury across languages', q: 'mercury,mercurius:la,quecksilber:de,mercure:fr', corpus: 'en' },
 ];
 
 // corpus id → books.language value, for the /search click-through filter.
@@ -59,7 +62,8 @@ export default function NgramViewer() {
   const [corpus, setCorpus] = useState(searchParams.get('corpus') || 'en');
   const [smoothing, setSmoothing] = useState(Number(searchParams.get('smoothing') ?? 3));
   const [from, setFrom] = useState(Number(searchParams.get('from') ?? 1450));
-  const [to, setTo] = useState(Number(searchParams.get('to') ?? 1950));
+  // 1930 default: later years are thin and dominated by reprint/edition noise.
+  const [to, setTo] = useState(Number(searchParams.get('to') ?? 1930));
   const [committed, setCommitted] = useState(query);
   const [data, setData] = useState<ApiResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -147,16 +151,60 @@ export default function NgramViewer() {
 
   const handleClick = useCallback(() => {
     if (!hover || !shown[hover.seriesIdx]) return;
-    const term = shown[hover.seriesIdx].term;
+    const s = shown[hover.seriesIdx];
     const params = new URLSearchParams({
-      q: term,
+      q: s.term,
       date_from: String(Math.max(from, hover.year - 5)),
       date_to: String(Math.min(to, hover.year + 5)),
     });
-    const lang = CORPUS_SEARCH_LANGUAGE[corpus];
+    // Scope the search to the series' own corpus language (a tagged term like
+    // mercurius:la searches Latin books even when the default corpus is en).
+    const lang = CORPUS_SEARCH_LANGUAGE[s.corpus];
     if (lang) params.set('language', lang);
     window.open(`/search?${params.toString()}`, '_blank');
-  }, [hover, shown, corpus, from, to]);
+  }, [hover, shown, from, to]);
+
+  // Short language name for legend/chips: "Latin (originals)" → "Latin".
+  const shortLabel = (label: string) => label.split(/[—(]/)[0].trim();
+
+  // Cross-language suggestions: for every charted term that belongs to a
+  // lexicon family, offer the other languages' equivalents not already charted.
+  const chartedKeys = useMemo(
+    () => new Set((data?.series || []).map(s => `${s.corpus}:${s.term.toLowerCase()}`)),
+    [data],
+  );
+  const suggestions = useMemo(() => {
+    if (!data) return [];
+    const out: Array<{ display: string; append: string; language: string }> = [];
+    const seen = new Set<string>();
+    for (const s of data.series) {
+      const fam = findTermFamily(s.term);
+      if (!fam) continue;
+      for (const [corpusId, forms] of Object.entries(fam.forms)) {
+        const form = forms[0];
+        const key = `${corpusId}:${form.toLowerCase()}`;
+        if (seen.has(key) || chartedKeys.has(key)) continue;
+        if (corpusId === s.corpus && form.toLowerCase() === s.term.toLowerCase()) continue;
+        const label = NGRAM_CORPORA.find(c => c.id === corpusId)?.label;
+        if (!label) continue;
+        seen.add(key);
+        out.push({ display: form, append: `${form}:${corpusId}`, language: shortLabel(label) });
+      }
+      // The English headword itself, when a foreign form is charted.
+      const enKey = `en:${fam.en}`;
+      if (!seen.has(enKey) && !chartedKeys.has(enKey) && s.term.toLowerCase() !== fam.en) {
+        seen.add(enKey);
+        out.push({ display: fam.en, append: fam.en, language: 'English' });
+      }
+    }
+    return out.slice(0, 8);
+  }, [data, chartedKeys]);
+
+  const addTerm = useCallback((append: string) => {
+    const next = query.trim() ? `${query.replace(/,\s*$/, '')},${append}` : append;
+    setQuery(next);
+    setCommitted(next);
+  }, [query]);
 
   const hoverInfo = hover && shown[hover.seriesIdx]
     ? { series: shown[hover.seriesIdx], point: shown[hover.seriesIdx].points.find(p => p.year === hover.year) }
@@ -167,7 +215,7 @@ export default function NgramViewer() {
       {/* Controls */}
       <div className="flex flex-wrap items-end gap-3 mb-3">
         <label className="flex-1 min-w-[260px]">
-          <span className="block text-xs text-[var(--text-muted)] mb-1">Terms (comma-separated, up to 6, max 3 words each)</span>
+          <span className="block text-xs text-[var(--text-muted)] mb-1">Terms (comma-separated, up to 6, max 3 words · tag a language with :la, :de, :fr…)</span>
           <input
             type="text"
             value={query}
@@ -232,12 +280,17 @@ export default function NgramViewer() {
       {data && (
         <div className="flex flex-wrap gap-x-4 gap-y-1 mb-2 text-sm">
           {data.series.map((s, i) => (
-            <span key={s.term} className="inline-flex items-center gap-1.5">
+            <span key={`${s.corpus}:${s.term}`} className="inline-flex items-center gap-1.5">
               <span
                 className="inline-block w-3 h-[3px] rounded"
                 style={{ backgroundColor: SERIES_COLORS[i % SERIES_COLORS.length], opacity: s.found ? 1 : 0.3 }}
               />
               <span className={s.found ? '' : 'text-[var(--text-faint)] line-through'}>{s.term}</span>
+              {s.corpus !== data.corpus && (
+                <span className="text-xs px-1 rounded bg-[var(--bg-warm,#f5f0e8)] text-[var(--text-muted)]">
+                  {shortLabel(s.corpusLabel)}
+                </span>
+              )}
               {s.found && (
                 <span className="text-xs text-[var(--text-muted)]">
                   {compactNumber(s.totalCount)}× in {compactNumber(s.bookCount)} books
@@ -249,6 +302,23 @@ export default function NgramViewer() {
                 </span>
               )}
             </span>
+          ))}
+        </div>
+      )}
+
+      {/* Cross-language comparison chips */}
+      {suggestions.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5 mb-2 text-xs text-[var(--text-muted)]">
+          <span>Compare across languages:</span>
+          {suggestions.map(s => (
+            <button
+              key={s.append}
+              onClick={() => addTerm(s.append)}
+              className="px-2 py-0.5 rounded-full border border-[var(--border-medium)] text-[var(--text-secondary)] hover:border-[var(--accent-rust)] hover:text-[var(--accent-rust)] transition-colors"
+              title={`Add ${s.display} (${s.language} corpus) to the chart`}
+            >
+              {s.display} <span className="text-[var(--text-faint)]">· {s.language}</span>
+            </button>
           ))}
         </div>
       )}

--- a/src/lib/ngram-lexicon.ts
+++ b/src/lib/ngram-lexicon.ts
@@ -1,0 +1,71 @@
+/**
+ * Cross-language term families for the ngram viewer (issue #3175 follow-up).
+ * When a charted term matches a family, the UI offers the other languages'
+ * equivalents as one-click comparison chips (`mercurius:la` syntax).
+ *
+ * Curated by hand, deliberately small: only equivalents that are unambiguous
+ * in early-modern usage belong here. Known exclusions: French "or" (gold) is
+ * drowned by the conjunction; Greek forms are included only where the everyday
+ * word and the technical term coincide. Forms are written in display spelling —
+ * the normalizer folds orthography (u/v, ligatures, diacritics) at query time,
+ * so "cœlum" and "caelum" are listed separately only when they normalize
+ * differently (coelum vs caelum are genuinely distinct spellings).
+ */
+
+export interface TermFamily {
+  /** English headword — also the `en`-corpus form. */
+  en: string;
+  /** corpus id → equivalent forms in that corpus. */
+  forms: Record<string, string[]>;
+}
+
+export const NGRAM_LEXICON: TermFamily[] = [
+  { en: 'mercury', forms: { la: ['mercurius'], de: ['quecksilber'], fr: ['mercure'], it: ['mercurio'], es: ['mercurio'] } },
+  { en: 'sulphur', forms: { la: ['sulphur'], de: ['schwefel'], fr: ['soufre'], it: ['zolfo'] } },
+  { en: 'salt', forms: { la: ['sal'], de: ['salz'], fr: ['sel'], it: ['sale'] } },
+  { en: 'gold', forms: { la: ['aurum'], de: ['gold'], it: ['oro'] } },
+  { en: 'silver', forms: { la: ['argentum'], de: ['silber'], fr: ['argent'] } },
+  { en: "philosopher's stone", forms: { la: ['lapis philosophorum'], de: ['stein der weisen'], fr: ['pierre philosophale'], it: ['pietra filosofale'] } },
+  { en: 'elixir', forms: { la: ['elixir'], fr: ['élixir'] } },
+  { en: 'quintessence', forms: { la: ['quinta essentia'], fr: ['quintessence'] } },
+  { en: 'tincture', forms: { la: ['tinctura'], de: ['tinktur'], fr: ['teinture'] } },
+  { en: 'transmutation', forms: { la: ['transmutatio'], fr: ['transmutation'] } },
+  { en: 'antimony', forms: { la: ['antimonium'], de: ['antimon'], fr: ['antimoine'] } },
+  { en: 'vitriol', forms: { la: ['vitriolum'], de: ['vitriol'] } },
+  { en: 'alchemy', forms: { la: ['alchimia', 'alchemia'], de: ['alchemie', 'alchimie'], fr: ['alchimie'], it: ['alchimia'] } },
+  { en: 'magic', forms: { la: ['magia'], de: ['magie'], fr: ['magie'], el: ['μαγεια'] } },
+  { en: 'kabbalah', forms: { la: ['cabala'], de: ['kabbala'], fr: ['cabale'] } },
+  { en: 'spirit', forms: { la: ['spiritus'], de: ['geist'], fr: ['esprit'], el: ['πνευμα'] } },
+  { en: 'soul', forms: { la: ['anima'], de: ['seele'], fr: ['âme'], el: ['ψυχη'] } },
+  { en: 'nature', forms: { la: ['natura'], de: ['natur'], fr: ['nature'], el: ['φυσις'] } },
+  { en: 'god', forms: { la: ['deus'], de: ['gott'], fr: ['dieu'], el: ['θεος'] } },
+  { en: 'wisdom', forms: { la: ['sapientia'], de: ['weisheit'], fr: ['sagesse'], el: ['σοφια'] } },
+  { en: 'light', forms: { la: ['lux'], de: ['licht'], fr: ['lumière'], el: ['φως'] } },
+  { en: 'fire', forms: { la: ['ignis'], de: ['feuer'], fr: ['feu'], el: ['πυρ'] } },
+  { en: 'water', forms: { la: ['aqua'], de: ['wasser'], fr: ['eau'], el: ['υδωρ'] } },
+  { en: 'earth', forms: { la: ['terra'], de: ['erde'], fr: ['terre'], el: ['γη'] } },
+  { en: 'air', forms: { la: ['aer'], de: ['luft'], fr: ['air'], el: ['αηρ'] } },
+  { en: 'world', forms: { la: ['mundus'], de: ['welt'], fr: ['monde'], el: ['κοσμος'] } },
+  { en: 'heaven', forms: { la: ['caelum', 'coelum'], de: ['himmel'], fr: ['ciel'], el: ['ουρανος'] } },
+  { en: 'sun', forms: { la: ['sol'], de: ['sonne'], fr: ['soleil'], el: ['ηλιος'] } },
+  { en: 'moon', forms: { la: ['luna'], de: ['mond'], fr: ['lune'], el: ['σεληνη'] } },
+  { en: 'death', forms: { la: ['mors'], de: ['tod'], fr: ['mort'], el: ['θανατος'] } },
+  { en: 'medicine', forms: { la: ['medicina'], de: ['medizin'], fr: ['médecine'] } },
+  { en: 'microcosm', forms: { la: ['microcosmus'], fr: ['microcosme'] } },
+];
+
+/**
+ * Find the family a (normalized-ish) term belongs to — matches the English
+ * headword or any listed form, case-insensitively. Returns null if none.
+ */
+export function findTermFamily(term: string): TermFamily | null {
+  const t = term.trim().toLowerCase();
+  if (!t) return null;
+  for (const fam of NGRAM_LEXICON) {
+    if (fam.en === t) return fam;
+    for (const forms of Object.values(fam.forms)) {
+      if (forms.some(f => f.toLowerCase() === t)) return fam;
+    }
+  }
+  return null;
+}

--- a/src/lib/ngram-series.ts
+++ b/src/lib/ngram-series.ts
@@ -1,8 +1,37 @@
 /**
- * Series math for the ngram viewer — shared by /api/ngrams and unit tests.
- * App-side only (the batch build stores raw counts; frequency and smoothing are
- * derived at read time so they can be re-parameterized per request).
+ * Series math + term-spec parsing for the ngram viewer — shared by /api/ngrams,
+ * the viewer UI, and unit tests. App-side only (the batch build stores raw
+ * counts; frequency and smoothing are derived at read time so they can be
+ * re-parameterized per request).
  */
+
+import { NGRAM_CORPORA } from './ngram-normalize';
+
+export interface TermSpec {
+  /** The term text without any corpus tag. */
+  term: string;
+  /** Resolved corpus id for this term. */
+  corpus: string;
+  /** True if the corpus came from an explicit `term:corpus` tag. */
+  tagged: boolean;
+}
+
+/**
+ * Parse one query term with optional `:corpus` suffix — `mercurius:la` charts
+ * mercurius against the Latin corpus regardless of the page's default corpus.
+ * An unknown suffix is NOT treated as a tag (the colon is just text and the
+ * tokenizer will drop it), so "12:30" or a stray colon can't break a query.
+ */
+export function parseTermSpec(raw: string, defaultCorpus: string): TermSpec {
+  const idx = raw.lastIndexOf(':');
+  if (idx > 0) {
+    const suffix = raw.slice(idx + 1).trim().toLowerCase();
+    if (NGRAM_CORPORA.some(c => c.id === suffix)) {
+      return { term: raw.slice(0, idx).trim(), corpus: suffix, tagged: true };
+    }
+  }
+  return { term: raw.trim(), corpus: defaultCorpus, tagged: false };
+}
 
 export interface NgramPoint {
   year: number;

--- a/tests/unit/ngram-normalize.test.ts
+++ b/tests/unit/ngram-normalize.test.ts
@@ -141,3 +141,34 @@ describe('series math', () => {
     expect(series[0].smoothed).toBeCloseTo((10 + 0) / 2);
   });
 });
+
+describe('cross-language term specs + lexicon', () => {
+  it('parses a :corpus suffix into a tagged spec', async () => {
+    const { parseTermSpec } = await import('../../src/lib/ngram-series');
+    expect(parseTermSpec('mercurius:la', 'en')).toEqual({ term: 'mercurius', corpus: 'la', tagged: true });
+    expect(parseTermSpec('stein der weisen:de', 'en')).toEqual({ term: 'stein der weisen', corpus: 'de', tagged: true });
+  });
+
+  it('treats unknown suffixes and bare colons as text, not tags', async () => {
+    const { parseTermSpec } = await import('../../src/lib/ngram-series');
+    expect(parseTermSpec('12:30', 'en')).toEqual({ term: '12:30', corpus: 'en', tagged: false });
+    expect(parseTermSpec('mercury:xx', 'en')).toEqual({ term: 'mercury:xx', corpus: 'en', tagged: false });
+    expect(parseTermSpec(':la', 'en')).toEqual({ term: ':la', corpus: 'en', tagged: false });
+  });
+
+  it('lexicon corpus ids are all real corpora and forms normalize non-empty', async () => {
+    const { NGRAM_LEXICON, findTermFamily } = await import('../../src/lib/ngram-lexicon');
+    const ids = new Set(ts.NGRAM_CORPORA.map(c => c.id));
+    for (const fam of NGRAM_LEXICON) {
+      expect(ts.normalizePhrase(fam.en, 'en')).not.toBe('');
+      for (const [corpus, forms] of Object.entries(fam.forms)) {
+        expect(ids.has(corpus)).toBe(true);
+        for (const form of forms) {
+          expect(ts.normalizePhrase(form, corpus)).not.toBe('');
+        }
+      }
+    }
+    expect(findTermFamily('Mercurius')?.en).toBe('mercury');
+    expect(findTermFamily('unknownword')).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-ups to #3177 from tonight's review of the live viewer.

## Cross-language term comparison
- **`term:corpus` syntax**: `?q=mercury,mercurius:la,quecksilber:de` charts each term against its own corpus on one axis. Per-million normalization is per-corpus, which is exactly what makes the curves comparable. Parser (`parseTermSpec`) is conservative — unknown suffixes stay literal text, so `12:30` can't break a query.
- **Curated lexicon** (`src/lib/ngram-lexicon.ts`, ~30 early-modern term families, hand-checked): when a charted term matches a family, 'Compare across languages' chips appear under the chart and one click adds the tagged equivalent. Deliberately excludes ambiguous equivalents (e.g. French *or* = the conjunction).
- Legend tags series charted against a non-default corpus; peak click-through searches the series' own corpus language.

## Data honesty
- **Default range now 1450–1930** (was –1950): the later tail is thin and dominated by modern-edition noise. Extendable manually.
- **`text_role: 'modern-translation'` excluded from the build** (620 books, 3.4%): their year is the modern translation's publication date — a 1911 Jowett Plato injected translator-voice English at 1911, semantically unlike every other book where year = period edition. `period-translation` (21 books) stays: a 1650 English rendering is 1650 voice.

## Tests
18/18 in the ngram suite (spec parser, lexicon integrity vs corpus list + normalizer, prior parity/series tests). tsc clean. The corpus change requires a rebuild — the currently-running full build will be re-run with the exclusion once it completes (thresholds and filters apply cleanly via --truncate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)