### PR TITLE
Sound Laboratory: source-accuracy corrections (six hammers, Kircher reattribution, Tartini softening) + essay cross-link

### DIFF
--- a/src/app/blog/nature-of-harmony/page.tsx
+++ b/src/app/blog/nature-of-harmony/page.tsx
@@ -308,6 +308,12 @@ export default function NatureOfHarmonyPage() {
           sourceLabel="Galileo, Discorsi (1638)"
         />
 
+        <p className="text-muted text-sm mb-8 font-body italic">
+          This bench has nine siblings — the smith&apos;s hammers weighed, Kepler&apos;s planets
+          auditioned, Tartini&apos;s ghost tone summoned — in{' '}
+          <Link href="/blog/sound-laboratory" className="text-accent-rust hover:text-accent-rust underline not-italic">The Sound Laboratory</Link>.
+        </p>
+
         <p className="text-secondary leading-relaxed mb-8 font-body">
           The word Descartes reaches for is the hinge of the whole story: <em>resonare</em>. By 1650 sympathetic resonance was
           no longer a metaphor at all — it was a repeatable experiment. Athanasius Kircher, in his vast{' '}

--- a/src/app/blog/sound-laboratory/page.tsx
+++ b/src/app/blog/sound-laboratory/page.tsx
@@ -218,8 +218,8 @@ export default function SoundLaboratoryPage() {
         <FolioPair>
           <FolioFigure
             src="https://images.sourcelibrary.org/gallery/695592747bd6d2cd1d61a5c3/695592757bd6d2cd1d61a741-0.jpg?v=17718766663"
-            alt="A personified breath projects rays onto a string marked with the letters A through F, mapping the consonant divisions"
-            caption={<>A breath strikes a string at its consonant divisions — and the surrounding text promises that the fifth <em>will necessarily sound</em>.</>}
+            alt="A personified wind head blows rays onto a string marked A through F, showing how pressing it at different division points yields different notes"
+            caption={<>Wind as plectrum, from the wind-harp chapter: press the string at a division point and the remainder sounds the octave, the fifth (<em>necessariò quintam sonabit</em>), the fifteenth — one string, many voices, by pure arithmetic.</>}
             href="/book/kircher-musurgia-universalis-vol-ii-1650-kircher?page=382"
             sourceLabel="Musurgia Universalis II, p382"
           />

--- a/src/components/blog/lab/HammerStringDemo.tsx
+++ b/src/components/blog/lab/HammerStringDemo.tsx
@@ -9,11 +9,14 @@ const BASE = 220;
 
 /**
  * The hammer weights as Gaffurius printed them (Theorica Musicae, 1492, p46
- * of our copy): IIII, VI, VIII, XII, XVI. The marginal annotations in our
- * copy work through the pairs — "ex XVI ad VIII dupla proportio: diapason."
+ * of our copy): IIII, VI, VIII, VIIII, XII, XVI — six hammers, per the
+ * page's own pairing table ("Ex xvi ad viij dupla proportione diapason
+ * creabatur"; the OCR of p46 lists all six weights). The 9-pound hammer is
+ * the fun one: 9:4 is a perfect square, so it is the ONE pair that still
+ * sounds its promised interval (a fifth) under real sqrt-tension physics.
  */
-const HAMMERS = [4, 6, 8, 12, 16] as const;
-const ROMAN: Record<number, string> = { 4: 'IIII', 6: 'VI', 8: 'VIII', 12: 'XII', 16: 'XVI' };
+const HAMMERS = [4, 6, 8, 9, 12, 16] as const;
+const ROMAN: Record<number, string> = { 4: 'IIII', 6: 'VI', 8: 'VIII', 9: 'VIIII', 12: 'XII', 16: 'XVI' };
 
 const GAFFURIUS_PLATE =
   'https://images.sourcelibrary.org/gallery/695688febe7c607c5f03c1da/69569e3b1479a63c110927ca-0.jpg?v=17805160105';
@@ -39,7 +42,7 @@ function intervalName(cents: number): string {
  * octave needs 4:1 — and the legend's 2:1 lands on a tritone. String LENGTH,
  * by contrast, really does behave as the legend claims.
  *
- * Two benches: the single-pair lab (sliders), and the whole smithy — all five
+ * Two benches: the single-pair lab (sliders), and the whole smithy — all six
  * of Gaffurius's hammers at once, under the legend's law and under Galilei's.
  */
 export default function HammerStringDemo() {
@@ -196,17 +199,18 @@ export default function HammerStringDemo() {
           >
             <img
               src={GAFFURIUS_PLATE}
-              alt="Gaffurius's 1492 woodcut of the smithy legend: men strike an anvil with hammers marked IIII, VI, VIII, XII and XVI"
+              alt="Gaffurius's 1492 woodcut of the smithy legend: six men strike an anvil with hammers marked IIII, VI, VIII, VIIII, XII and XVI"
               className="w-full h-auto"
               loading="lazy"
             />
           </Link>
           <div className="mt-3 md:mt-0 min-w-0">
             <p className="text-xs text-secondary mb-2">
-              Gaffurius&apos;s woodcut numbers the hammers — IIII, VI, VIII, XII, XVI — and a
-              15th-century reader has inked the promised proportions into the margins of{' '}
-              <Link href="/book/theorica-musicae-gaffurius?page=46" className="text-accent-rust underline">our copy</Link>.
-              Tap two hammers to hang exactly that weight ratio:
+              Gaffurius&apos;s woodcut numbers six hammers — IIII, VI, VIII, VIIII, XII, XVI — and
+              the page itself works through every pairing (an early reader re-inks them in the margins of{' '}
+              <Link href="/book/theorica-musicae-gaffurius?page=46" className="text-accent-rust underline">our copy</Link>).
+              Tap two hammers to hang exactly that weight ratio — and try VIIII : IIII, the one
+              pair that keeps its promise even under the real law:
             </p>
             <div className="flex flex-wrap gap-1.5 mb-2">
               {HAMMERS.map((w) => (
@@ -219,7 +223,7 @@ export default function HammerStringDemo() {
               </p>
             )}
             <p className="text-xs text-secondary mb-2">
-              And the legend&apos;s real claim is the whole smithy ringing in concord. Hear all five
+              And the legend&apos;s real claim is the whole smithy ringing in concord. Hear all six
               hammers under each law:
             </p>
             <div className="flex flex-wrap items-center gap-1.5">
@@ -229,7 +233,7 @@ export default function HammerStringDemo() {
             </div>
             <p className="text-xs text-muted mt-2">
               {law === 'legend'
-                ? 'Ratios straight through: 4 : 6 : 8 : 12 : 16 rings as octaves, fifths and fourths — the miracle as told.'
+                ? 'Ratios straight through: 4 : 6 : 8 : 9 : 12 : 16 rings as octaves, fifths, fourths and a tone — the miracle as told.'
                 : 'Frequency follows √weight: the same numbers smear into a cluster nothing in music theory can name.'}
             </p>
           </div>

--- a/src/components/blog/lab/KircherResonanceDemo.tsx
+++ b/src/components/blog/lab/KircherResonanceDemo.tsx
@@ -19,11 +19,11 @@ function response(f: number, f0: number): number {
 
 /**
  * The full sympathetic response: every partial of the plucked string (h)
- * against every mode of the untouched string (m). This is what Kircher's
- * text beside the p382 diagram asserts — pluck a string and its fifth
- * "necessario quintam sonabit": the untouched string tuned a fifth up
- * answers through the SHARED partial (3 × 220 = 2 × 330). A pure-sine
- * model would falsify him; a string with overtones proves him right.
+ * against every mode of the untouched string (m). The fifth-answers
+ * prediction is the MODERN shared-partials reading (3 × 220 = 2 × 330),
+ * not a sentence of Kircher's — his "necessariò quintam sonabit" (p382)
+ * is about wind dividing ONE string, though it runs on the same
+ * arithmetic. A pure-sine model can't show either; real overtones can.
  */
 function stringResponse(tune: number): { r: number; h: number; m: number } {
   let best = { r: 0, h: 1, m: 1 };
@@ -41,7 +41,7 @@ const PRESETS = [
   { label: 'G · 196 Hz', freq: 196 },
   { label: 'A · 220 Hz — unison', freq: 220 },
   { label: 'B · 247 Hz', freq: 247 },
-  { label: 'E · 330 Hz — the fifth he promised', freq: 330 },
+  { label: 'E · 330 Hz — the fifth', freq: 330 },
   { label: 'A · 440 Hz — octave', freq: 440 },
 ];
 
@@ -57,10 +57,11 @@ function verdict(r: number, h: number, m: number): string {
 /**
  * Station VIII — Kircher's sympathetic strings, as he staged it: TWO
  * strings. One is plucked; the other is never touched. Tuned in unison the
- * untouched string sings back; tuned to the FIFTH it still answers, in a
- * whisper, through the partial the two strings share — the stronger,
- * stranger half of Kircher's claim. The untouched string is modeled as a
- * bank of mode resonators fed by a pluck with real overtones.
+ * untouched string sings back — his natural magic of consonance. Tuned to
+ * the FIFTH it still answers, in a whisper, through the partial the two
+ * strings share — the modern physics extending his division arithmetic.
+ * The untouched string is a bank of mode resonators fed by a pluck with
+ * real overtones.
  */
 export default function KircherResonanceDemo() {
   const [tune, setTune] = useState(247); // start mistuned: the first pluck fails
@@ -156,9 +157,9 @@ export default function KircherResonanceDemo() {
           Pluck the left string
         </button>
       }
-      caption="Two strings. The left is plucked, always at A · 220 Hz; the right is never touched. At unison the silent string sings back. But Kircher promises more: tuned a fifth up it must still answer — through the one partial the two strings share. Find both answers."
-      sourceHref="/book/kircher-musurgia-universalis-vol-ii-1650-kircher?page=382"
-      sourceLabel="Kircher, Musurgia Universalis, Vol. II (1650), p382"
+      caption="Two strings. The left is plucked, always at A · 220 Hz; the right is never touched. At unison the silent string sings back — the effect Kircher read as natural magic. And the physics of shared partials adds a prediction he would have relished: tuned a fifth up, it still answers, faintly. Find both."
+      sourceHref="/book/kircher-musurgia-universalis-vol-ii-1650-kircher"
+      sourceLabel="Kircher, Musurgia Universalis, Vol. II (1650)"
     >
       <div className="mb-4">
         <label className="text-[11px] uppercase tracking-wider text-muted block mb-1">
@@ -230,8 +231,10 @@ export default function KircherResonanceDemo() {
       <p className="mt-3 text-xs text-muted">
         The plucked string carries overtones at 440, 660 and 880 Hz; the untouched string listens
         with modes of its own. Tuned to E · 330, its second mode sits at 660 — exactly the pluck&apos;s
-        third partial — and the text beside Kircher&apos;s diagram says it plainly: it{' '}
-        <em>necessario quintam sonabit</em>, will of necessity sound the fifth.
+        third partial — so it answers without being touched. Kircher never wrote that sentence;
+        his wind-harp chapter derives the fifth from the same string-divisions (<em>necessariò
+        quintam sonabit</em> — the plate above), and the shared-partial answer is where his
+        arithmetic leads once a string is allowed its overtones.
       </p>
     </LabCard>
   );

--- a/src/components/blog/lab/TartiniDemo.tsx
+++ b/src/components/blog/lab/TartiniDemo.tsx
@@ -11,8 +11,9 @@ const TARTINI_PLATE =
   'https://images.sourcelibrary.org/gallery/6990585617295890441358e0/699058571729589044135991-0.jpg?v=17816616026';
 
 /**
- * The dyads Tartini works through in the Trattato's terzo-suono figures —
- * simple ratios against the fixed 660 Hz voice. For any m:n dyad built on a
+ * Simple consonances against the fixed 660 Hz voice. (Not a transcription
+ * of the p177 examples — those work through major/minor-tone cases; these
+ * are the textbook dyads of the same phenomenon.) For any m:n dyad on a
  * common fundamental g (f1 = m·g, f2 = n·g with m = n+1), the difference
  * tone IS g: the bass the consonance implies. That is his whole theory.
  */
@@ -141,7 +142,7 @@ export default function TartiniDemo() {
 
       <div className="mt-5 pt-4 border-t border-border-light">
         <p className="text-[11px] uppercase tracking-wider text-muted mb-2">
-          His figures, playable
+          The phenomenon he engraved, playable
         </p>
         <div className="md:flex md:gap-4">
           <Link
@@ -158,7 +159,8 @@ export default function TartiniDemo() {
           <div className="mt-3 md:mt-0">
             <p className="text-xs text-secondary mb-2">
               Tartini engraves the ghost as a real note — <em>terzo suono</em> written under each
-              worked dyad. Set the slider to a figure and hear the bass he notated:
+              worked dyad on this page. These presets put the slider on simple consonances so you
+              can hear the bass his theory predicts:
             </p>
             <div className="flex flex-wrap gap-1.5">
               {FIGURES.map((fig) => (


### PR DESCRIPTION
Follow-up to #3189, fixing three source-accuracy issues found by verifying the quoted pages against their OCR/translations, plus one open item from the 2026-07-16 handoff.

- **Station I — six hammers, not five.** The p46 OCR lists IIII, VI, VIII, VIIII, XII, XVI and the full pairing table ("Ex viij ad viiii sesquioctava proportione tonus nascebatur"). Added the 9-pound hammer to the tap row and ensemble. Delightful side effect now surfaced in copy: 9:4 is a perfect square, so VIIII:IIII is the one pair whose promised interval (a fifth) survives √tension physics.
- **Station VIII — honest attribution.** "Necessariò quintam sonabit" (p382) is from the aeolian-harp chapter: wind pressing ONE string at a division point makes the remainder sound the fifth. It is not a promise about a second string tuned a fifth up. The demo's shared-partials physics stands, but captions now attribute the fifth-answers prediction to the physics, with Kircher's division arithmetic as the period grounding. Plate caption rewritten; demo sourceHref reverted to book level; preset relabeled.
- **Station V — no overclaim.** Presets are textbook consonances demonstrating the terzo suono, not transcriptions of the p177 figures (which work major/minor-tone cases). Copy adjusted.
- **nature-of-harmony → Sound Laboratory link** after the DissonanceDemo (open item from the 7/16 handoff).

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)