### PR TITLE
fix(ngrams): default-param collapse (Number(null)=0) + totals-first load order

### DIFF
--- a/scripts/analytics/build-ngrams.mjs
+++ b/scripts/analytics/build-ngrams.mjs
@@ -294,6 +294,13 @@ async function load() {
   const shardFiles = fs.readdirSync(DIR).filter(f => /^shard-\d+\.tsv\.gz$/.test(f)).sort();
   if (!shardFiles.length) { console.error(`[load] no shard files in ${DIR} — run emit first`); process.exit(1); }
 
+  // Totals load FIRST: they're tiny, already final at emit time, and the API
+  // 404s the whole corpus without them. Loading them last meant /api/ngrams
+  // was dead for the entire multi-hour shard stream after a --truncate
+  // (observed live 2026-07-18). With totals in, the viewer works progressively
+  // as shards land.
+  await loadTotals(pgc);
+
   let totalRows = 0, totalDropped = 0;
   for (const file of shardFiles) {
     if (loaded.has(file)) continue;
@@ -351,6 +358,11 @@ async function load() {
     console.log(`[load] ${file}: ${rows.length.toLocaleString()} rows kept (${loaded.size}/${shardFiles.length} shards, ${totalRows.toLocaleString()} rows total, ${elapsed()})`);
   }
 
+  console.log(`[load] done: ${totalRows.toLocaleString()} series rows (${totalDropped.toLocaleString()} below threshold), ${elapsed()}`);
+  await pgc.end();
+}
+
+async function loadTotals(pgc) {
   const totals = JSON.parse(fs.readFileSync(path.join(DIR, 'totals.json'), 'utf8'));
   let totalRowCount = 0;
   for (const [corpus, years] of Object.entries(totals)) {
@@ -373,8 +385,7 @@ async function load() {
       totalRowCount += chunk.length;
     }
   }
-  console.log(`[load] done: ${totalRows.toLocaleString()} series rows (${totalDropped.toLocaleString()} below threshold), ${totalRowCount} totals rows, ${elapsed()}`);
-  await pgc.end();
+  console.log(`[load] ${totalRowCount} totals rows loaded (up-front)`);
 }
 
 // ------------------------------------------------------------------- driver

--- a/src/app/api/ngrams/route.ts
+++ b/src/app/api/ngrams/route.ts
@@ -61,12 +61,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Provide 1-6 comma-separated terms via ?q=' }, { status: 400 });
   }
 
-  const clamp = (v: number, lo: number, hi: number, def: number) =>
-    Number.isFinite(v) ? Math.min(hi, Math.max(lo, v)) : def;
-  const from = clamp(Number(sp.get('from')), YEAR_FLOOR, YEAR_CEIL, 1450);
-  let to = clamp(Number(sp.get('to')), YEAR_FLOOR, YEAR_CEIL, 1930);
+  // Note: Number(null) is 0, not NaN — an absent param must fall to the
+  // default BEFORE numeric coercion or every default collapses to the floor.
+  const clamp = (raw: string | null, lo: number, hi: number, def: number) => {
+    if (raw === null || raw.trim() === '') return def;
+    const v = Number(raw);
+    return Number.isFinite(v) ? Math.min(hi, Math.max(lo, v)) : def;
+  };
+  const from = clamp(sp.get('from'), YEAR_FLOOR, YEAR_CEIL, 1450);
+  let to = clamp(sp.get('to'), YEAR_FLOOR, YEAR_CEIL, 1930);
   if (to < from) to = Math.min(YEAR_CEIL, from + 50);
-  const smoothing = clamp(Number(sp.get('smoothing')), 0, 10, 3);
+  const smoothing = clamp(sp.get('smoothing'), 0, 10, 3);
 
   const terms = rawTerms.map(raw => {
     const spec = parseTermSpec(raw, defaultCorpus);


### PR DESCRIPTION
Two live catches after deploying #3203:

1. **Absent params collapsed to the floor.** `Number(null)` is `0` (not NaN), so a bare `/api/ngrams?q=term` got `from=to=800, smoothing=0` — one degenerate data point. The UI always sends explicit params, which masked it. Defaults now apply before numeric coercion.
2. **Totals now load before the shard stream.** The loader wrote `ngram_totals` last, so after a `--truncate` the API returned 404 'no data yet' for the entire multi-hour load (observed on prod today during the v1 reload). Totals are tiny and final at emit time; loading them up-front makes the viewer work progressively as shards land. (Prod was unblocked immediately via a one-off totals upsert from the emit's totals.json.)

Tests 18/18, node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)