### PR TITLE
Two-stage visual identification: union retrieval + Gemini visual rerank (#3193)

### DIFF
--- a/scripts/backfill-clip-embeddings.mjs
+++ b/scripts/backfill-clip-embeddings.mjs
@@ -12,6 +12,10 @@
  *   --artworks-only    Only embed artworks (resource_type exists)
  *   --covers-only      Only embed book covers
  *   --gallery-only     Only embed gallery images from image extraction
+ *   --fix-gallery-crops  Re-embed gallery rows whose stored image is not the
+ *                        illustration crop (extracted_url). Historical rows were
+ *                        embedded from the FULL PAGE scan, which buries the artwork
+ *                        in page text and breaks photo->image matching (#3193).
  *   --limit N          Process at most N items
  *   --dry-run          Count what would be embedded, don't embed
  *   --clip-url URL     CLIP server URL (default: http://localhost:3457)
@@ -26,6 +30,7 @@ const CLIP_URL = process.env.CLIP_URL || process.argv.find(a => a.startsWith('--
 const ARTWORKS_ONLY = process.argv.includes('--artworks-only');
 const COVERS_ONLY = process.argv.includes('--covers-only');
 const GALLERY_ONLY = process.argv.includes('--gallery-only');
+const FIX_GALLERY_CROPS = process.argv.includes('--fix-gallery-crops');
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = parseInt(process.argv.find(a => a.startsWith('--limit='))?.split('=')[1] || '0') || 0;
 
@@ -72,9 +77,10 @@ async function main() {
   await pgClient.connect();
   await pgClient.query('SET ROLE postgres');
 
-  // Get existing embeddings to skip
-  const { rows: existing } = await pgClient.query('SELECT id FROM clip_embeddings');
-  const existingIds = new Set(existing.map(r => r.id));
+  // Get existing embeddings to skip (id -> embedded image_url, for crop-fix detection)
+  const { rows: existing } = await pgClient.query('SELECT id, image_url FROM clip_embeddings');
+  const existingUrl = new Map(existing.map(r => [r.id, r.image_url]));
+  const existingIds = new Set(existingUrl.keys());
   console.log(`Existing embeddings: ${existingIds.size}`);
 
   // Collect items to embed
@@ -159,7 +165,7 @@ async function main() {
       });
     }
     console.log(`Book covers to embed: ${coverItems.length}`);
-    items.push(...coverItems);
+    for (const it of coverItems) items.push(it);
   }
 
   // Phase 3: Gallery images from image extraction pipeline
@@ -169,7 +175,7 @@ async function main() {
       {
         projection: {
           id: 1, book_id: 1, book_title: 1, book_author: 1,
-          image_url: 1, type: 1, description: 1,
+          image_url: 1, extracted_url: 1, thumbnail_url: 1, type: 1, description: 1,
         },
       },
     ).toArray();
@@ -177,22 +183,29 @@ async function main() {
     const galleryItems = [];
     for (const g of galleryImages) {
       const id = `gallery-${g.id}`;
-      if (existingIds.has(id)) continue;
-      if (!g.image_url) continue;
+      // Embed the illustration CROP, never the full page scan — a full-page
+      // embedding is dominated by the surrounding text and can't match a
+      // photo of the artwork alone (#3193).
+      const embedUrl = g.extracted_url || g.image_url;
+      if (!embedUrl) continue;
+      if (existingIds.has(id)) {
+        // Skip unless we're repairing rows embedded from the wrong (full-page) URL
+        if (!FIX_GALLERY_CROPS || existingUrl.get(id) === embedUrl) continue;
+      }
 
       galleryItems.push({
         id,
         source_type: 'gallery_image',
         book_id: g.book_id,
-        image_url: g.image_url,
+        image_url: embedUrl,
         title: g.description || g.book_title,
         author: g.book_author,
         resource_type: g.type || null,
-        thumbnail_url: g.image_url,
+        thumbnail_url: g.thumbnail_url || embedUrl,
       });
     }
     console.log(`Gallery images to embed: ${galleryItems.length}`);
-    items.push(...galleryItems);
+    for (const it of galleryItems) items.push(it);
   }
 
   const total = LIMIT > 0 ? Math.min(items.length, LIMIT) : items.length;

--- a/scripts/eval/identify-bench.mjs
+++ b/scripts/eval/identify-bench.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Identify benchmark (#3193): measures "photo of an artwork -> the right library
+ * image" retrieval quality. Regression-test this whenever /api/identify, the CLIP
+ * index, or the gallery text embeddings change.
+ *
+ * Method: sample N indexed gallery images, distort each into a simulated "wall
+ * photo" (downscale, rotate, wall-colored padding, JPEG q65), then rank the true
+ * image against a pool of distractor images through each retrieval path:
+ *   B      CLIP on illustration crops (what clip_embeddings holds after the
+ *          --fix-gallery-crops re-embed)
+ *   C1     Gemini describe -> text-embed query = title+author+desc+terms
+ *   C2     query = catalog_description only (hallucinated titles poison C1)
+ *   C3     confidence-gated: title/author included only when confidence=high
+ *   C4     C3 described by gemini-3-flash-preview instead of flash-lite
+ *   Rtext  Gemini visual rerank of C3 top-20 (photo vs candidate thumbnails)
+ *   Rclip  Gemini visual rerank of B top-20
+ *   Runion rerank of union(B top-10, C3 top-10)  <- the production design
+ *
+ * Baseline 2026-07-18 (n=24, pool=400): B 17/24 top-1, C2 20/24,
+ * Rtext 24/24, Runion 23/24. Full history in issue #3193.
+ *
+ * Usage (macOS only — image distortion shells out to `sips`):
+ *   set -a; source .env.production.local; set +a; \
+ *     node scripts/eval/identify-bench.mjs [--pool=400] [--targets=24] [--skip-rerank]
+ *
+ * Cost: ~$0.02-0.10 in Gemini calls per run. Writes results + wall photos to
+ * scripts/output/identify-bench/ (gitignored).
+ */
+
+import { MongoClient } from 'mongodb';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DIR = path.join(REPO, 'scripts', 'output', 'identify-bench');
+const IMG_DIR = path.join(DIR, 'wall-photos');
+fs.mkdirSync(IMG_DIR, { recursive: true });
+
+const CLIP = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
+const GK = process.env.GEMINI_API_KEY;
+if (!GK || !process.env.MONGODB_URI) { console.error('missing GEMINI_API_KEY or MONGODB_URI'); process.exit(1); }
+
+const arg = (name, dflt) => parseInt(process.argv.find(a => a.startsWith(`--${name}=`))?.split('=')[1] || '') || dflt;
+const POOL_SIZE = arg('pool', 400), N_TARGETS = arg('targets', 24);
+const SKIP_RERANK = process.argv.includes('--skip-rerank');
+const log = (...a) => console.log(new Date().toISOString().slice(11, 19), ...a);
+function cos(a, b) { let s = 0, na = 0, nb = 0; for (let i = 0; i < a.length; i++) { s += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; } return s / (Math.sqrt(na) * Math.sqrt(nb)); }
+
+async function fetchJson(url, opts = {}, retries = 3) {
+  for (let i = 0; ; i++) {
+    try {
+      const r = await fetch(url, opts);
+      if (!r.ok) throw new Error(`${r.status} ${await r.text().then(t => t.slice(0, 150))}`);
+      return await r.json();
+    } catch (e) { if (i >= retries) throw e; await new Promise(r => setTimeout(r, 2500 * (i + 1))); }
+  }
+}
+async function gemini(model, parts, retries = 3) {
+  const d = await fetchJson(`https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${GK}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contents: [{ parts }], generationConfig: { temperature: 0.1 } }),
+  }, retries);
+  const txt = (d.candidates?.[0]?.content?.parts || []).map(p => p.text || '').join('');
+  const m = txt.match(/```(?:json)?\s*([\s\S]*?)```/);
+  return JSON.parse((m?.[1] || txt).trim());
+}
+async function runPool(jobs, width) {
+  const q = [...jobs];
+  await Promise.all(Array.from({ length: width }, async () => { while (q.length) await q.shift()(); }));
+}
+
+// ---- 1. Sample ----
+const mc = await MongoClient.connect(process.env.MONGODB_URI);
+const gi = mc.db('bookstore').collection('gallery_images');
+const sample = await gi.aggregate([
+  { $match: { extracted_url: { $ne: null }, thumbnail_url: { $ne: null }, description: { $type: 'string', $ne: '' }, book_visible: true, gallery_quality: { $gte: 0.5 } } },
+  { $sample: { size: 900 } },
+  { $project: { id: 1, book_id: 1, book_title: 1, book_author: 1, extracted_url: 1, thumbnail_url: 1, description: 1, type: 1, gallery_quality: 1 } },
+]).toArray();
+await mc.close();
+const seen = new Set(); const pool = [];
+for (const g of sample) { if (seen.has(g.book_id)) continue; seen.add(g.book_id); pool.push(g); if (pool.length >= POOL_SIZE) break; }
+const hi = pool.filter(p => p.gallery_quality >= 0.8), lo = pool.filter(p => p.gallery_quality < 0.8);
+const targets = [...hi.slice(0, N_TARGETS / 2), ...lo.slice(0, N_TARGETS / 2)];
+log(`pool=${pool.length} targets=${targets.length}`);
+
+// ---- 2. Wall photos ----
+for (let i = 0; i < targets.length; i++) {
+  const t = targets[i];
+  const clean = path.join(IMG_DIR, `t${i}-clean.jpg`), wall = path.join(IMG_DIR, `t${i}-wall.jpg`);
+  if (!fs.existsSync(wall)) {
+    fs.writeFileSync(clean, Buffer.from(await (await fetch(t.extracted_url)).arrayBuffer()));
+    const deg = 3 + (i % 4);
+    execSync(`sips -Z 900 "${clean}" --out "${wall}" >/dev/null 2>&1 && sips -r ${deg} --padColor B0A898 "${wall}" >/dev/null 2>&1 && sips -p 1300 1050 --padColor A29988 "${wall}" >/dev/null 2>&1 && sips -s format jpeg -s formatOptions 65 "${wall}" >/dev/null 2>&1`, { shell: '/bin/zsh' });
+  }
+  t.wallFile = wall;
+  t.wallB64 = fs.readFileSync(wall).toString('base64');
+}
+log('wall photos ready');
+
+// ---- 3. CLIP pool + queries (for B and Rclip/Runion) ----
+const poolClip = new Map();
+for (let i = 0; i < pool.length; i += 25) {
+  const batch = pool.slice(i, i + 25);
+  const resp = await fetchJson(`${CLIP}/embed-images`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ urls: batch.map(b => b.extracted_url) }) });
+  resp.results.forEach((r, j) => { if (r.embedding) poolClip.set(batch[j].id, r.embedding); });
+}
+log(`clip pool: ${poolClip.size}`);
+for (const t of targets) {
+  const r = await fetchJson(`${CLIP}/embed-image`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ base64: t.wallB64, mime_type: 'image/jpeg' }) });
+  t.wallClip = r.embedding;
+}
+log('clip queries done');
+
+function rankList(queryEmb, embMap) {
+  const scored = [];
+  for (const [id, emb] of embMap) scored.push([id, cos(queryEmb, emb)]);
+  scored.sort((x, y) => y[1] - x[1]);
+  return scored;
+}
+for (const t of targets) {
+  t.clipRanked = rankList(t.wallClip, poolClip);
+  t.B = t.clipRanked.findIndex(s => s[0] === t.id) + 1 || null;
+}
+
+// ---- 4. Describe with both models ----
+const DP = `You are an art historian identifying a photographed print, engraving, or book illustration. Return JSON only:
+{
+ "title": "best guess at the title of this specific work OR the book it appears in; null if not reasonably sure",
+ "author": "best guess at artist/author; null if not reasonably sure",
+ "confidence": "high | medium | low — high ONLY if you recognize this specific work or can read text that names it",
+ "visible_text": "transcription of any legible text/captions/inscriptions in the image, null if none",
+ "catalog_description": "one-to-three sentence museum-catalog description of what is depicted: scene, figures, objects, style, technique",
+ "search_terms": ["3-5 search terms"]
+}`;
+await runPool(targets.map((t, i) => async () => {
+  try { t.lite = await gemini('gemini-3.1-flash-lite', [{ text: DP }, { inline_data: { mime_type: 'image/jpeg', data: t.wallB64 } }]); } catch (e) { t.lite = null; log(`lite ${i} FAIL ${e.message.slice(0, 80)}`); }
+  try { t.flash = await gemini('gemini-3-flash-preview', [{ text: DP }, { inline_data: { mime_type: 'image/jpeg', data: t.wallB64 } }]); } catch (e) { t.flash = null; log(`flash ${i} FAIL ${e.message.slice(0, 80)}`); }
+  log(`describe ${i}: lite=${t.lite?.confidence} "${(t.lite?.title || '').slice(0, 35)}" | flash=${t.flash?.confidence} "${(t.flash?.title || '').slice(0, 35)}"`);
+}), 4);
+
+// ---- 5. Text embeddings ----
+async function embedTexts(texts, taskType) {
+  const out = [];
+  for (let i = 0; i < texts.length; i += 90) {
+    const chunk = texts.slice(i, i + 90);
+    const d = await fetchJson(`https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents?key=${GK}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requests: chunk.map(text => ({ model: 'models/gemini-embedding-001', content: { parts: [{ text: text || ' ' }] }, taskType, outputDimensionality: 768 })) }),
+    });
+    out.push(...d.embeddings.map(e => e.values));
+  }
+  return out;
+}
+const poolTextEmb = await embedTexts(pool.map(p => `${p.description}${p.type ? '. Type: ' + p.type : ''}`), 'RETRIEVAL_DOCUMENT');
+const poolText = new Map(pool.map((p, i) => [p.id, poolTextEmb[i]]));
+log('pool text embedded');
+
+const qBuilders = {
+  C1: g => g ? [g.title, g.author, g.catalog_description, ...(g.search_terms || [])].filter(Boolean).join('. ') : '',
+  C2: g => g?.catalog_description || '',
+  C3: g => g ? (g.confidence === 'high'
+    ? [g.title, g.author, g.catalog_description, ...(g.search_terms || [])].filter(Boolean).join('. ')
+    : [g.catalog_description, ...(g.search_terms || [])].filter(Boolean).join('. ')) : '',
+};
+const variants = [['C1', 'lite', 'C1'], ['C2', 'lite', 'C2'], ['C3', 'lite', 'C3'], ['C4', 'flash', 'C3']];
+for (const [name, src, builder] of variants) {
+  const queries = targets.map(t => qBuilders[builder](t[src]));
+  const qEmb = await embedTexts(queries, 'RETRIEVAL_QUERY');
+  targets.forEach((t, i) => {
+    const ranked = rankList(qEmb[i], poolText);
+    t[name] = ranked.findIndex(s => s[0] === t.id) + 1 || null;
+    if (name === 'C3') t.c3Ranked = ranked;
+  });
+  log(`${name} done`);
+}
+
+// ---- 6. Visual rerank ----
+const thumbCache = new Map();
+async function thumbB64(p) {
+  if (thumbCache.has(p.id)) return thumbCache.get(p.id);
+  try {
+    const buf = Buffer.from(await (await fetch(p.thumbnail_url)).arrayBuffer());
+    const v = buf.toString('base64');
+    thumbCache.set(p.id, v);
+    return v;
+  } catch { thumbCache.set(p.id, null); return null; }
+}
+const poolById = new Map(pool.map(p => [p.id, p]));
+async function rerank(t, candidateIds, label) {
+  const cands = candidateIds.map(id => poolById.get(id)).filter(Boolean);
+  const parts = [{ text: `The FIRST image is a visitor's photograph of an artwork or book illustration. The following ${cands.length} numbered images are candidate matches from a library catalog. Identify which candidate shows THE SAME work (same plate/engraving/illustration, allowing for photo distortion, framing, and print-state differences). Return JSON only: {"best": <candidate number 1-${cands.length}, or null if none is the same work>, "sure": true|false}` },
+  { inline_data: { mime_type: 'image/jpeg', data: t.wallB64 } }];
+  const kept = [];
+  for (const c of cands) {
+    const b = await thumbB64(c);
+    if (!b) continue;
+    kept.push(c);
+    parts.push({ text: `Candidate ${kept.length}:` }, { inline_data: { mime_type: 'image/jpeg', data: b } });
+  }
+  try {
+    const r = await gemini('gemini-3-flash-preview', parts);
+    const pick = r.best != null ? kept[r.best - 1] : null;
+    return { hit: pick?.id === t.id, picked: pick?.id || null, sure: !!r.sure, inSet: kept.some(c => c.id === t.id) };
+  } catch (e) { return { hit: false, picked: null, err: e.message.slice(0, 80), inSet: kept.some(c => c.id === t.id) }; }
+}
+if (SKIP_RERANK) {
+  for (const t of targets) { t.Rclip = { hit: false, inSet: false }; t.Rtext = { hit: false, inSet: false }; t.Runion = { hit: false, inSet: false }; }
+} else {
+  await runPool(targets.map((t, i) => async () => {
+    const clipTop = t.clipRanked.slice(0, 20).map(s => s[0]);
+    const textTop = t.c3Ranked.slice(0, 20).map(s => s[0]);
+    const union = [...new Set([...t.clipRanked.slice(0, 10).map(s => s[0]), ...t.c3Ranked.slice(0, 10).map(s => s[0])])];
+    t.Rclip = await rerank(t, clipTop, 'Rclip');
+    t.Rtext = await rerank(t, textTop, 'Rtext');
+    t.Runion = await rerank(t, union, 'Runion');
+    log(`rerank ${i}: clip=${t.Rclip.hit} text=${t.Rtext.hit} union=${t.Runion.hit} (inSet: ${t.Rclip.inSet}/${t.Rtext.inSet}/${t.Runion.inSet})`);
+  }), 3);
+}
+
+// ---- 7. Report ----
+function stats(ranks) {
+  const valid = ranks.filter(r => r != null);
+  return { top1: valid.filter(r => r === 1).length, top5: valid.filter(r => r <= 5).length, top20: valid.filter(r => r <= 20).length, mrr: +(ranks.reduce((s, r) => s + (r ? 1 / r : 0), 0) / ranks.length).toFixed(3) };
+}
+const report = {
+  poolSize: poolClip.size,
+  B_clip_crop: stats(targets.map(t => t.B)),
+  C1_baseline_concat: stats(targets.map(t => t.C1)),
+  C2_desc_only: stats(targets.map(t => t.C2)),
+  C3_confidence_gated: stats(targets.map(t => t.C3)),
+  C4_flash_model: stats(targets.map(t => t.C4)),
+  Rclip_rerank_top1: targets.filter(t => t.Rclip.hit).length,
+  Rtext_rerank_top1: targets.filter(t => t.Rtext.hit).length,
+  Runion_rerank_top1: targets.filter(t => t.Runion.hit).length,
+  Runion_candidate_recall: targets.filter(t => t.Runion.inSet).length,
+  perTarget: targets.map((t, i) => ({
+    i, q: t.gallery_quality, book: (t.book_title || '').slice(0, 40), desc: (t.description || '').slice(0, 50),
+    B: t.B, C1: t.C1, C2: t.C2, C3: t.C3, C4: t.C4,
+    Rclip: t.Rclip.hit, Rtext: t.Rtext.hit, Runion: t.Runion.hit, unionHadIt: t.Runion.inSet,
+    lite_conf: t.lite?.confidence, lite_title: t.lite?.title?.slice(0, 40), flash_conf: t.flash?.confidence, flash_title: t.flash?.title?.slice(0, 40),
+    visible_text: (t.lite?.visible_text || '').slice(0, 60),
+  })),
+};
+report.poolIds = pool.map(p => p.id);
+report.targetIds = targets.map(t => t.id);
+const outFile = path.join(DIR, `results-${new Date().toISOString().slice(0, 10)}.json`);
+fs.writeFileSync(outFile, JSON.stringify(report, null, 1));
+console.log(`\nresults -> ${outFile}`);
+console.log('==== SUMMARY (n=' + targets.length + ', pool=' + poolClip.size + ') ====');
+for (const k of ['B_clip_crop', 'C1_baseline_concat', 'C2_desc_only', 'C3_confidence_gated', 'C4_flash_model']) {
+  const s = report[k];
+  console.log(`${k}: top1=${s.top1} top5=${s.top5} top20=${s.top20} mrr=${s.mrr}`);
+}
+if (!SKIP_RERANK) {
+  console.log(`Rerank top-1 accuracy: Rclip=${report.Rclip_rerank_top1}/${targets.length} Rtext=${report.Rtext_rerank_top1}/${targets.length} Runion=${report.Runion_rerank_top1}/${targets.length} (union recall ${report.Runion_candidate_recall}/${targets.length})`);
+}

--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -5,8 +5,15 @@ import { supabase } from '@/lib/supabase';
 import { semanticArtworkSearch, type SemanticArtworkResult } from '@/lib/semantic-search';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { CLIP_URL } from '@/lib/clip';
+import {
+  getGalleryCandidatesByText,
+  hydrateCandidates,
+  rerankByVisualComparison,
+  type IdentifyCandidate,
+  type ConfirmedMatch,
+} from '@/lib/identify-rerank';
 
-export const maxDuration = 30;
+export const maxDuration = 60;
 export const dynamic = 'force-dynamic';
 
 // Max image size: 4MB (Vercel serverless body limit is 4.5MB)
@@ -215,6 +222,82 @@ export async function POST(request: NextRequest) {
     const semanticArtworkPromise: Promise<SemanticArtworkResult[]> = artworkSearchQuery
       ? semanticArtworkSearch(artworkSearchQuery, 10, { threshold: 0.4 }).catch(() => [])
       : Promise.resolve([]);
+
+    // Promise 3b: two-stage visual confirmation (#3193). Candidates come from
+    // the CLIP index and a description-text match; one Gemini vision call then
+    // compares the photo against candidate thumbnails and confirms or declines.
+    // Runs concurrently with the Mongo strategies and web verification below.
+    const rerankPromise = (async () => {
+      try {
+        const db = await getDb();
+        // Description-only query — benchmarks showed hallucinated titles poison
+        // retrieval, while the visual description alone ranks best.
+        const textQuery = [identification.subject, ...(identification.search_terms || []).slice(0, 3)]
+          .filter(Boolean).join('. ');
+        const textCands = await getGalleryCandidatesByText(textQuery, 10);
+
+        const clipCands: IdentifyCandidate[] = clipMatches.slice(0, 10).map(cm => ({
+          id: cm.id,
+          source: 'clip' as const,
+          sourceType: (cm.source_type as IdentifyCandidate['sourceType']) || 'gallery_image',
+          bookId: cm.book_id,
+          galleryId: cm.source_type === 'gallery_image' && cm.id.startsWith('gallery-') ? cm.id.slice('gallery-'.length) : undefined,
+          thumbnailUrl: cm.thumbnail_url || cm.image_url,
+          similarity: cm.similarity,
+          title: cm.title,
+          author: cm.author,
+        }));
+
+        // Union, CLIP first (dedupe by id), capped to keep the rerank call small
+        const byId = new Map<string, IdentifyCandidate>();
+        for (const c of [...clipCands, ...textCands]) if (!byId.has(c.id)) byId.set(c.id, c);
+        let candidates = [...byId.values()].slice(0, 16);
+
+        const hydration = await hydrateCandidates(db, candidates);
+        candidates = candidates
+          .map(c => {
+            const h = c.galleryId ? hydration.get(c.galleryId) : undefined;
+            return {
+              ...c,
+              thumbnailUrl: c.thumbnailUrl || h?.thumbnail_url || '',
+              title: c.title || h?.book_title,
+              author: c.author || h?.book_author,
+              _hydrated: h,
+            };
+          })
+          .filter(c => c.thumbnailUrl && (!c.galleryId || c._hydrated?.book_visible !== false));
+
+        const verdict = await rerankByVisualComparison(base64, mimeType, candidates);
+        if (!verdict?.picked) return { confirmed: null as ConfirmedMatch | null, candidateCount: candidates.length, ran: candidates.length > 0 };
+
+        const picked = verdict.picked as IdentifyCandidate & { _hydrated?: { page_id?: string; page_number?: number; description?: string; book_title?: string; book_author?: string } };
+        const book = await db.collection('books').findOne(
+          { id: picked.bookId },
+          { projection: { _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, visible: 1 } },
+        );
+        if (book && book.visible === false) return { confirmed: null, candidateCount: candidates.length, ran: true };
+        const slugOrId = (book?.slug as string) || picked.bookId;
+        const h = picked._hydrated;
+        const confirmed: ConfirmedMatch = {
+          book_id: picked.bookId,
+          book_slug: book?.slug as string | undefined,
+          book_title: (book?.display_title || book?.title || picked.title) as string | undefined,
+          book_author: (book?.author || picked.author) as string | undefined,
+          gallery_image_id: picked.galleryId,
+          page_id: h?.page_id,
+          page_number: h?.page_number,
+          description: h?.description,
+          image_url: picked.thumbnailUrl,
+          read_url: h?.page_id ? `/book/${slugOrId}/page/${h.page_id}` : `/book/${slugOrId}`,
+          gallery_url: picked.galleryId ? `/gallery/image/${picked.galleryId}` : undefined,
+          source_type: picked.sourceType,
+        };
+        return { confirmed, candidateCount: candidates.length, ran: true, sure: verdict.sure };
+      } catch (e) {
+        console.warn('[identify] rerank pipeline failed:', e instanceof Error ? e.message : String(e));
+        return { confirmed: null as ConfirmedMatch | null, candidateCount: 0, ran: false };
+      }
+    })();
 
     // Promise 4: Google Search verification (runs after initial ID, in parallel with DB search)
     // Uses grounding to verify/correct the identification against museum catalogs
@@ -666,6 +749,31 @@ Return JSON only:
     // The artwork image fields are already in the match object from Strategy 1 query
     // (commons_full_url, archived_full_url were projected but not shown — now we surface them)
 
+    // Await visual confirmation (started right after identification)
+    const rerank = await rerankPromise;
+    const confirmed = rerank.confirmed;
+
+    if (confirmed) {
+      // The visually confirmed book is the answer — put it first.
+      const idx = matches.findIndex(m => m.id === confirmed.book_id);
+      if (idx >= 0) {
+        const [hit] = matches.splice(idx, 1);
+        hit._score = Math.max(hit._score ?? 0, 100);
+        hit._match_source = 'visual_confirmed';
+        matches.unshift(hit);
+      } else {
+        matches.unshift({
+          id: confirmed.book_id,
+          slug: confirmed.book_slug,
+          title: confirmed.book_title,
+          author: confirmed.book_author,
+          thumbnail: confirmed.image_url,
+          _score: 100,
+          _match_source: 'visual_confirmed',
+        });
+      }
+    }
+
     // Await Google Search verification (started earlier, should be done by now)
     const verification = await verifyPromise;
 
@@ -712,11 +820,17 @@ Return JSON only:
       visual_search: clipMatches.length > 0,
       semantic_artwork_search: semanticArtworks.length > 0,
       verified: !!verification,
-      page: bestPage ? {
-        book_id: bestPage.bookId,
-        page_number: bestPage.pageNumber,
-        score: bestPage.score,
-      } : null,
+      confirmed,
+      // A visually confirmed match supersedes the text-heuristic page guess —
+      // an unconfirmed guess pointing at a different book misleads (see #3193
+      // benchmark: the heuristic picked the wrong book on degraded photos).
+      page: confirmed
+        ? (confirmed.page_number != null ? { book_id: confirmed.book_id, page_number: confirmed.page_number, score: 100 } : null)
+        : bestPage ? {
+          book_id: bestPage.bookId,
+          page_number: bestPage.pageNumber,
+          score: bestPage.score,
+        } : null,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/src/app/identify/page.tsx
+++ b/src/app/identify/page.tsx
@@ -50,11 +50,27 @@ interface Identification {
   web_sources?: { title: string; url: string }[];
 }
 
+interface ConfirmedMatch {
+  book_id: string;
+  book_slug?: string;
+  book_title?: string;
+  book_author?: string;
+  gallery_image_id?: string;
+  page_id?: string;
+  page_number?: number;
+  description?: string;
+  image_url: string;
+  read_url: string;
+  gallery_url?: string;
+  source_type: string;
+}
+
 interface Result {
   identification: Identification;
   matches: Match[];
   visual_search?: boolean;
   verified?: boolean;
+  confirmed?: ConfirmedMatch | null;
   page?: { book_id: string; page_number: number; score: number } | null;
 }
 
@@ -237,6 +253,52 @@ export default function IdentifyPage() {
         {/* Results */}
         {result && (
           <div className="space-y-6">
+            {/* Visually confirmed match — the answer, front and center */}
+            {result.confirmed && (
+              <div className="rounded-xl overflow-hidden bg-white border-2 border-accent-rust/40 shadow-sm">
+                <div className="flex items-center gap-2 px-5 py-3 bg-accent-rust/5 border-b border-accent-rust/20">
+                  <span className="text-xs font-semibold uppercase tracking-wider text-accent-rust">Found in the library</span>
+                  <span className="text-[10px] text-green-700 bg-green-50 rounded px-1.5 py-0.5">confirmed by visual comparison</span>
+                </div>
+                <div className="flex gap-4 p-5">
+                  <div className="w-24 sm:w-32 flex-shrink-0 rounded overflow-hidden bg-stone-100">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img src={result.confirmed.image_url} alt="" className="w-full h-auto object-contain" />
+                  </div>
+                  <div className="flex-1 min-w-0 space-y-1.5">
+                    {result.confirmed.description && (
+                      <p className="text-sm text-secondary line-clamp-3">{result.confirmed.description}</p>
+                    )}
+                    <p className="font-display font-semibold text-primary">
+                      {result.confirmed.book_title}
+                      {result.confirmed.page_number != null && (
+                        <span className="text-sm font-normal text-muted ml-2">page {result.confirmed.page_number}</span>
+                      )}
+                    </p>
+                    {result.confirmed.book_author && (
+                      <p className="text-sm text-secondary">{result.confirmed.book_author}</p>
+                    )}
+                    <div className="flex flex-wrap gap-2 pt-2">
+                      <Link
+                        href={result.confirmed.read_url}
+                        className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-accent-rust text-white text-sm font-medium hover:bg-accent-rust/85 transition-colors"
+                      >
+                        Read this book
+                      </Link>
+                      {result.confirmed.gallery_url && (
+                        <Link
+                          href={result.confirmed.gallery_url}
+                          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-border-light text-sm text-secondary hover:border-accent-rust/30 transition-colors"
+                        >
+                          View in gallery
+                        </Link>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* What Gemini saw */}
             <div className="card p-5 space-y-3">
               <div className="flex items-center justify-between">
@@ -379,14 +441,16 @@ export default function IdentifyPage() {
               <div>
                 <div className="flex items-center gap-2 mb-3">
                   <h2 className="text-lg font-display font-semibold text-primary">
-                    {result.matches.length === 1 ? 'Match Found' : `${result.matches.length} Possible Matches`}
+                    {result.confirmed
+                      ? 'Related results'
+                      : result.matches.length === 1 ? 'Closest Match' : `${result.matches.length} Possible Matches`}
                   </h2>
                   {result.visual_search && (
                     <span className="text-[10px] text-blue-600 bg-blue-50 rounded px-1.5 py-0.5">visual search</span>
                   )}
                 </div>
                 <div className="space-y-2">
-                  {result.matches.map((match, i) => {
+                  {result.matches.filter(m => !result.confirmed || m.id !== result.confirmed.book_id).map((match, i) => {
                     const pageUrl = match.page_number
                       ? `${bookUrl({ slug: match.slug, id: match.id })}/page-number/${match.page_number}`
                       : bookUrl({ slug: match.slug, id: match.id });
@@ -408,7 +472,7 @@ export default function IdentifyPage() {
                       )}
                       <div className="flex-1 min-w-0">
                         <p className="font-medium text-primary group-hover:text-accent-rust transition-colors line-clamp-1">
-                          {i === 0 && result.matches.length > 1 && (
+                          {i === 0 && !result.confirmed && result.matches.length > 1 && (
                             <span className="text-xs bg-accent-rust/10 text-accent-rust rounded px-1.5 py-0.5 mr-2">Best match</span>
                           )}
                           {match.display_title || match.title}

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -3,11 +3,11 @@ import { getGeminiClient, reportRateLimitError } from './gemini-client';
 import { TaskType } from '@google/generative-ai';
 import { supabase } from './supabase';
 
-// text-embedding-004 was deprecated April 2026. Gallery text embeddings (87K rows)
-// were generated with this model and are NOT compatible with gemini-embedding-001.
-// Semantic gallery search is disabled until embeddings are re-generated.
-// Book/artwork embeddings use gemini-embedding-2-preview (separate pipeline).
-const EMBEDDING_MODEL = 'gemini-embedding-001';
+// The gallery_text_embeddings table (~203K rows, verified 2026-07-18) is fully
+// on gemini-embedding-2-preview — the model here MUST match or every similarity
+// lookup returns noise (query with gemini-embedding-001 self-matched at 0.148;
+// with -2-preview at 0.970). See issue #3193.
+const EMBEDDING_MODEL = 'gemini-embedding-2-preview';
 const EMBEDDING_DIMENSIONS = 768;
 
 export interface ImageEmbeddingInput {

--- a/src/lib/identify-rerank.ts
+++ b/src/lib/identify-rerank.ts
@@ -1,0 +1,172 @@
+import { Db } from 'mongodb';
+import { supabase } from './supabase';
+import { getQueryEmbedding } from './semantic-search';
+import { getNextApiKey } from './gemini-client';
+
+// Two-stage identification (issue #3193): cheap retrieval channels propose
+// candidates (CLIP crop-index + gallery-description text match), then a single
+// multimodal Gemini call compares the visitor's photo against the candidate
+// thumbnails and either confirms one match or honestly declines. Benchmarked
+// 2026-07-18: rerank over the union of both channels resolved 23-24/24
+// simulated wall photos vs 14-17/24 for any single retrieval path.
+
+export interface IdentifyCandidate {
+  /** clip_embeddings id ('gallery-<pageId>-<idx>', 'artwork-<bookId>', 'cover-<bookId>') or raw gallery id */
+  id: string;
+  source: 'clip' | 'text';
+  sourceType: 'gallery_image' | 'artwork' | 'book_cover';
+  bookId: string;
+  galleryId?: string; // '<pageId>-<detectionIndex>' when sourceType is gallery_image
+  thumbnailUrl: string;
+  similarity: number;
+  title?: string;
+  author?: string;
+}
+
+export interface ConfirmedMatch {
+  book_id: string;
+  book_slug?: string;
+  book_title?: string;
+  book_author?: string;
+  gallery_image_id?: string;
+  page_id?: string;
+  page_number?: number;
+  description?: string;
+  image_url: string;
+  read_url: string;
+  gallery_url?: string;
+  source_type: string;
+}
+
+interface GalleryTextMatch {
+  id: string;
+  page_id: string;
+  book_id: string;
+  detection_index: number;
+  similarity: number;
+}
+
+/**
+ * Text-retrieval channel: embed a visual description of the photo and match it
+ * against the museum descriptions in gallery_text_embeddings.
+ */
+export async function getGalleryCandidatesByText(queryText: string, limit = 10): Promise<IdentifyCandidate[]> {
+  if (!queryText.trim()) return [];
+  const embedding = await getQueryEmbedding(queryText);
+  if (!embedding) return [];
+
+  const { data, error } = await supabase.rpc('match_gallery_text', {
+    query_embedding: JSON.stringify(embedding),
+    match_threshold: 0.2,
+    match_count: limit,
+  });
+  if (error || !data) return [];
+
+  return (data as GalleryTextMatch[]).map(m => ({
+    id: `gallery-${m.id}`,
+    source: 'text' as const,
+    sourceType: 'gallery_image' as const,
+    bookId: m.book_id,
+    galleryId: m.id,
+    thumbnailUrl: '', // filled from gallery_images by hydrateCandidates
+    similarity: m.similarity,
+  }));
+}
+
+/**
+ * Fill thumbnails + provenance from gallery_images for gallery candidates and
+ * drop candidates whose book is not publicly visible.
+ */
+export async function hydrateCandidates(db: Db, candidates: IdentifyCandidate[]): Promise<Map<string, {
+  thumbnail_url?: string; page_id?: string; page_number?: number; description?: string;
+  book_title?: string; book_author?: string; book_visible?: boolean;
+}>> {
+  const galleryIds = [...new Set(candidates.filter(c => c.galleryId).map(c => c.galleryId as string))];
+  const docs = galleryIds.length
+    ? await db.collection('gallery_images')
+      .find(
+        { id: { $in: galleryIds } },
+        { projection: { id: 1, thumbnail_url: 1, extracted_url: 1, image_url: 1, page_id: 1, page_number: 1, description: 1, book_title: 1, book_author: 1, book_visible: 1 }, maxTimeMS: 5000 },
+      )
+      .toArray()
+      .catch(() => [])
+    : [];
+  const map = new Map<string, { thumbnail_url?: string; page_id?: string; page_number?: number; description?: string; book_title?: string; book_author?: string; book_visible?: boolean }>();
+  for (const d of docs) {
+    map.set(d.id as string, {
+      thumbnail_url: (d.thumbnail_url || d.extracted_url || d.image_url) as string | undefined,
+      page_id: d.page_id as string | undefined,
+      page_number: d.page_number as number | undefined,
+      description: d.description as string | undefined,
+      book_title: d.book_title as string | undefined,
+      book_author: d.book_author as string | undefined,
+      book_visible: d.book_visible as boolean | undefined,
+    });
+  }
+  return map;
+}
+
+/**
+ * Visual verification: one Gemini call comparing the visitor photo against
+ * candidate thumbnails. Returns the confirmed candidate, or null when no
+ * candidate is the same work (the model is instructed to decline rather than
+ * guess — critical for museum use, where a confident wrong answer is worse
+ * than none).
+ */
+export async function rerankByVisualComparison(
+  photoBase64: string,
+  photoMime: string,
+  candidates: IdentifyCandidate[],
+): Promise<{ picked: IdentifyCandidate | null; sure: boolean } | null> {
+  if (candidates.length === 0) return { picked: null, sure: false };
+
+  // Fetch candidate thumbnails in parallel; skip any that fail.
+  const thumbs = await Promise.all(candidates.map(async c => {
+    if (!c.thumbnailUrl) return null;
+    try {
+      const res = await fetch(c.thumbnailUrl, { signal: AbortSignal.timeout(6000) });
+      if (!res.ok) return null;
+      const buf = Buffer.from(await res.arrayBuffer());
+      if (buf.length > 3 * 1024 * 1024) return null; // keep the rerank request small
+      return { candidate: c, base64: buf.toString('base64'), mime: res.headers.get('content-type') || 'image/jpeg' };
+    } catch {
+      return null;
+    }
+  }));
+  const kept = thumbs.filter((t): t is NonNullable<typeof t> => t !== null);
+  if (kept.length === 0) return { picked: null, sure: false };
+
+  const parts: Array<{ text: string } | { inline_data: { mime_type: string; data: string } }> = [
+    {
+      text: `The FIRST image is a visitor's photograph of an artwork, print, or book illustration (possibly on a wall, framed, at an angle, or a page in a physical book). The following ${kept.length} numbered images are candidate matches from a library catalog. Identify which candidate shows THE SAME work — the same plate, engraving, painting, or illustration — allowing for photo distortion, framing, cropping, and differences between print states or copies. A candidate that merely depicts a similar subject is NOT the same work. Return JSON only: {"best": <candidate number 1-${kept.length}, or null if no candidate is the same work>, "sure": true|false}`,
+    },
+    { inline_data: { mime_type: photoMime, data: photoBase64 } },
+  ];
+  kept.forEach((t, i) => {
+    parts.push({ text: `Candidate ${i + 1}:` }, { inline_data: { mime_type: t.mime, data: t.base64 } });
+  });
+
+  try {
+    const apiKey = getNextApiKey();
+    const resp = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contents: [{ parts }], generationConfig: { temperature: 0.1 } }),
+        signal: AbortSignal.timeout(20000),
+      },
+    );
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    const text = (data.candidates?.[0]?.content?.parts || []).map((p: { text?: string }) => p.text || '').join('');
+    const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+    const parsed = JSON.parse((jsonMatch?.[1] || text).trim());
+    const idx = typeof parsed.best === 'number' ? parsed.best - 1 : -1;
+    const picked = idx >= 0 && idx < kept.length ? kept[idx].candidate : null;
+    return { picked, sure: !!parsed.sure };
+  } catch (e) {
+    console.warn('[identify] rerank failed:', e instanceof Error ? e.message : String(e));
+    return null;
+  }
+}


### PR DESCRIPTION
## Why
Point your phone at an engraving on the Embassy wall and land on that image in Source Library. The existing /identify pipeline identified well but retrieved terribly: 3/24 top-1 on simulated wall photos (benchmark in #3193).

## What
- **CLIP backfill fix**: gallery rows embedded the FULL PAGE scan instead of the illustration crop, burying the artwork in page text. Now embeds `extracted_url`; new `--fix-gallery-crops` mode repairs the 181,462 stale rows (dry-run verified on Hetzner). Also fixes a max-call-stack crash on large item sets.
- **/api/identify two-stage**: candidate retrieval (CLIP index ∪ gallery-description text match) → one gemini-3-flash-preview call compares the photo against candidate thumbnails → confirmed match or honest decline. Confirmed match leads the response and supersedes the text-heuristic page guess (which picked the wrong book on degraded photos). New `src/lib/identify-rerank.ts`.
- **Bonus bug fix**: `src/lib/embeddings.ts` embedded queries with `gemini-embedding-001` against a `gallery_text_embeddings` table fully on `gemini-embedding-2-preview` — every gallery semantic-similarity lookup returned noise (self-match sim 0.148; correct model 0.970, rank 1). One-line model fix.
- **/identify UI**: confirmed-match hero card ("Found in the library", visual-comparison badge, reader deep link via `/book/<slug>/page/<pageId>`, gallery link).
- **Benchmark**: committed as `scripts/eval/identify-bench.mjs` (macOS, ~$0.05/run) with the 2026-07-18 baselines in the header.

## Benchmarks (24 simulated wall photos, 400-book pool)
| Path | Top-1 |
|---|---|
| CLIP as deployed (full-page index) | 3/24 |
| CLIP crop index | 17/24 |
| Gemini describe→text match | 20/24 |
| **Rerank union (this PR's design)** | **23/24** (candidate recall 24/24) |

## Out of scope (deliberately)
- The Hetzner re-embed run itself (operational; kicked off after merge — CLIP channel improves as it progresses, rerank works regardless)
- Query-side bbox cropping of the visitor photo (bench ceiling suggests it helps; separate PR if rerank misses in practice)
- Exhibit mode / tenant-scoped identify for bph subdomain (#3193 Phase 3)
- Rate-limit rework for shared museum wifi (#3193 Phase 3)

Tracks #3193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)