### PR TITLE
fix(identify): timeout guards so no stage can hang the request

### DIFF
--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -138,6 +138,9 @@ export async function POST(request: NextRequest) {
           }],
           generationConfig: { temperature: 0.1 },
         }),
+        // Without a timeout a stalled Gemini connection holds the whole
+        // request to maxDuration and the client sees a hang (2026-07-18).
+        signal: AbortSignal.timeout(25000),
       },
     );
 
@@ -171,7 +174,7 @@ export async function POST(request: NextRequest) {
           query_embedding: embedding,
           match_threshold: 0.25,
           match_count: 20,
-        });
+        }).abortSignal(AbortSignal.timeout(8000));
         if (error) {
           console.error('[identify] CLIP search error:', error.message);
           return [];
@@ -749,8 +752,15 @@ Return JSON only:
     // The artwork image fields are already in the match object from Strategy 1 query
     // (commons_full_url, archived_full_url were projected but not shown — now we surface them)
 
-    // Await visual confirmation (started right after identification)
-    const rerank = await rerankPromise;
+    // Await visual confirmation (started right after identification), but never
+    // let it hold the response — a stalled dependency degrades to "no
+    // confirmation" instead of a hung request.
+    const rerank = await Promise.race([
+      rerankPromise,
+      new Promise<{ confirmed: ConfirmedMatch | null; candidateCount: number; ran: boolean }>(
+        resolve => setTimeout(() => resolve({ confirmed: null, candidateCount: 0, ran: false }), 25000),
+      ),
+    ]);
     const confirmed = rerank.confirmed;
 
     if (confirmed) {

--- a/src/lib/identify-rerank.ts
+++ b/src/lib/identify-rerank.ts
@@ -59,7 +59,7 @@ export async function getGalleryCandidatesByText(queryText: string, limit = 10):
     query_embedding: JSON.stringify(embedding),
     match_threshold: 0.2,
     match_count: limit,
-  });
+  }).abortSignal(AbortSignal.timeout(8000));
   if (error || !data) return [];
 
   return (data as GalleryTextMatch[]).map(m => ({


### PR DESCRIPTION
Follow-up to #3207. Prod /api/identify intermittently hung to maxDuration (observed 900s client waits, no response). Root exposure: the main Gemini vision fetch had no AbortSignal, and the Supabase RPC calls had no timeout — either could hold the request indefinitely. The rerank stage is now also awaited through a 25s Promise.race that degrades to 'no confirmation' rather than a hang. All other stages already had timeouts (thumbnails 6s, rerank call 20s, query embed 5s, web verify 20s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)