### PR TITLE
feat(identify): rerank telemetry in response

### DIFF
--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -270,8 +270,17 @@ export async function POST(request: NextRequest) {
           })
           .filter(c => c.thumbnailUrl && (!c.galleryId || c._hydrated?.book_visible !== false));
 
+        const t0 = Date.now();
         const verdict = await rerankByVisualComparison(base64, mimeType, candidates);
-        if (!verdict?.picked) return { confirmed: null as ConfirmedMatch | null, candidateCount: candidates.length, ran: candidates.length > 0 };
+        if (!verdict?.picked) {
+          return {
+            confirmed: null as ConfirmedMatch | null,
+            candidateCount: candidates.length,
+            ran: candidates.length > 0,
+            ms: Date.now() - t0,
+            error: verdict?.error,
+          };
+        }
 
         const picked = verdict.picked as IdentifyCandidate & { _hydrated?: { page_id?: string; page_number?: number; description?: string; book_title?: string; book_author?: string } };
         const book = await db.collection('books').findOne(
@@ -295,10 +304,11 @@ export async function POST(request: NextRequest) {
           gallery_url: picked.galleryId ? `/gallery/image/${picked.galleryId}` : undefined,
           source_type: picked.sourceType,
         };
-        return { confirmed, candidateCount: candidates.length, ran: true, sure: verdict.sure };
+        return { confirmed, candidateCount: candidates.length, ran: true, sure: verdict.sure, ms: Date.now() - t0 };
       } catch (e) {
-        console.warn('[identify] rerank pipeline failed:', e instanceof Error ? e.message : String(e));
-        return { confirmed: null as ConfirmedMatch | null, candidateCount: 0, ran: false };
+        const msg = e instanceof Error ? e.message : String(e);
+        console.warn('[identify] rerank pipeline failed:', msg);
+        return { confirmed: null as ConfirmedMatch | null, candidateCount: 0, ran: false, error: `pipeline:${msg.slice(0, 120)}` };
       }
     })();
 
@@ -757,8 +767,8 @@ Return JSON only:
     // confirmation" instead of a hung request.
     const rerank = await Promise.race([
       rerankPromise,
-      new Promise<{ confirmed: ConfirmedMatch | null; candidateCount: number; ran: boolean }>(
-        resolve => setTimeout(() => resolve({ confirmed: null, candidateCount: 0, ran: false }), 25000),
+      new Promise<{ confirmed: ConfirmedMatch | null; candidateCount: number; ran: boolean; error?: string }>(
+        resolve => setTimeout(() => resolve({ confirmed: null, candidateCount: 0, ran: false, error: 'race_timeout_25s' }), 25000),
       ),
     ]);
     const confirmed = rerank.confirmed;
@@ -831,6 +841,13 @@ Return JSON only:
       semantic_artwork_search: semanticArtworks.length > 0,
       verified: !!verification,
       confirmed,
+      rerank: {
+        ran: rerank.ran,
+        candidates: rerank.candidateCount,
+        sure: (rerank as { sure?: boolean }).sure ?? false,
+        ms: (rerank as { ms?: number }).ms,
+        error: (rerank as { error?: string }).error,
+      },
       // A visually confirmed match supersedes the text-heuristic page guess —
       // an unconfirmed guess pointing at a different book misleads (see #3193
       // benchmark: the heuristic picked the wrong book on degraded photos).

--- a/src/lib/identify-rerank.ts
+++ b/src/lib/identify-rerank.ts
@@ -117,8 +117,8 @@ export async function rerankByVisualComparison(
   photoBase64: string,
   photoMime: string,
   candidates: IdentifyCandidate[],
-): Promise<{ picked: IdentifyCandidate | null; sure: boolean } | null> {
-  if (candidates.length === 0) return { picked: null, sure: false };
+): Promise<{ picked: IdentifyCandidate | null; sure: boolean; error?: string; thumbsFetched?: number } | null> {
+  if (candidates.length === 0) return { picked: null, sure: false, error: 'no_candidates' };
 
   // Fetch candidate thumbnails in parallel; skip any that fail.
   const thumbs = await Promise.all(candidates.map(async c => {
@@ -134,7 +134,7 @@ export async function rerankByVisualComparison(
     }
   }));
   const kept = thumbs.filter((t): t is NonNullable<typeof t> => t !== null);
-  if (kept.length === 0) return { picked: null, sure: false };
+  if (kept.length === 0) return { picked: null, sure: false, error: 'no_thumbnails_fetched' };
 
   const parts: Array<{ text: string } | { inline_data: { mime_type: string; data: string } }> = [
     {
@@ -157,16 +157,20 @@ export async function rerankByVisualComparison(
         signal: AbortSignal.timeout(20000),
       },
     );
-    if (!resp.ok) return null;
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      return { picked: null, sure: false, thumbsFetched: kept.length, error: `gemini_${resp.status}:${body.slice(0, 120)}` };
+    }
     const data = await resp.json();
     const text = (data.candidates?.[0]?.content?.parts || []).map((p: { text?: string }) => p.text || '').join('');
     const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
     const parsed = JSON.parse((jsonMatch?.[1] || text).trim());
     const idx = typeof parsed.best === 'number' ? parsed.best - 1 : -1;
     const picked = idx >= 0 && idx < kept.length ? kept[idx].candidate : null;
-    return { picked, sure: !!parsed.sure };
+    return { picked, sure: !!parsed.sure, thumbsFetched: kept.length };
   } catch (e) {
-    console.warn('[identify] rerank failed:', e instanceof Error ? e.message : String(e));
-    return null;
+    const msg = e instanceof Error ? e.message : String(e);
+    console.warn('[identify] rerank failed:', msg);
+    return { picked: null, sure: false, thumbsFetched: kept.length, error: `rerank_call:${msg.slice(0, 120)}` };
   }
 }


### PR DESCRIPTION
Surfaces {ran, candidates, sure, ms, error} from the identify rerank stage in the API response — needed to diagnose why prod declines matches that preview confirms (Vercel log streaming truncates function output). Also useful product telemetry for the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)