### PR TITLE
fix(routing): route Malay to full flash — Jawi manuscripts garble on flash-lite

### DIFF
--- a/src/lib/types/ai-models.ts
+++ b/src/lib/types/ai-models.ts
@@ -63,9 +63,12 @@ const LATIN_SCRIPT_LANGUAGES: ReadonlySet<string> = new Set([
   'albanian', 'sq', 'sqi', 'alb',
   'turkish', 'tr', 'tur',
   // Latinized Asian
+  // NOTE: Malay is deliberately absent. Our Malay holdings are mostly Jawi
+  // (Arabic-script) manuscripts from Leiden — flash-lite garbles them into
+  // confident nonsense (2026-07-18 Hikayat Tanah Hitu pilot, same failure
+  // mode as the Tibetan case above). Malay must route to full flash.
   'indonesian', 'id', 'ind',
   'vietnamese', 'vi', 'vie',
-  'malay', 'ms', 'msa',
   'tagalog', 'tl', 'tgl', 'filipino',
   // African (Latin-script)
   'swahili', 'sw', 'swa',


### PR DESCRIPTION
## What
Removes `malay`/`ms`/`msa` from the `LATIN_SCRIPT_LANGUAGES` allowlist in `src/lib/types/ai-models.ts`, so Malay-tagged books route to `gemini-3-flash-preview` instead of flash-lite.

## Why
Our 29 Malay-tagged books are mostly **Jawi (Arabic-script) manuscripts** from the Leiden Or. collection — the language tag says Malay, but the script is the exact case the allowlist exists to protect against.

Pilot evidence (2026-07-18, Hikayat Tanah Hitu, Or. 5448, scored against the published Manusama romanization):
- **flash-lite**: ~55% word accuracy; garbled every proper name (`perdana Mulai` → "fer dan mulai"), produced Rumi word salad, and appended **fabricated scholarly footnotes** explaining its own gibberish as "archaic Ambon-Malay dialect." Same prior-over-ink failure mode as the documented Tibetan case in this file's comment.
- **full flash**: ~72–85% word accuracy, genuinely readable draft transcription + usable translation.

## Out of scope
- `indonesian` stays on the allowlist for now — most Indonesian-tagged holdings are romanized. If we import Pegon-script books tagged Indonesian, the same treatment applies; flagging for awareness.
- Actual processing of the 25 Jawi manuscripts (pipeline is paused; separate cost decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)