### PR TITLE
feat(ngrams): make per-year book counts visible

### DIFF
--- a/src/app/api/ngrams/route.ts
+++ b/src/app/api/ngrams/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: NextRequest) {
   // under the cap.
   const [totalsResList, seriesRes] = await Promise.all([
     Promise.all(totalsCorpora.map(corpus =>
-      supabase.from('ngram_totals').select('corpus, year, tokens').eq('corpus', corpus),
+      supabase.from('ngram_totals').select('corpus, year, tokens, books').eq('corpus', corpus),
     )),
     Promise.all([...lookupByCorpus.entries()].map(([corpus, ngrams]) =>
       supabase.from('ngram_series')
@@ -115,11 +115,13 @@ export async function GET(request: NextRequest) {
   }
 
   const totalsByCorpus = new Map<string, Map<number, number>>();
+  const booksByYear = new Map<number, number>(); // default corpus only — drives the UI's per-year "N books"
   for (const res of totalsResList) {
     for (const r of res.data || []) {
       let m = totalsByCorpus.get(r.corpus);
       if (!m) { m = new Map(); totalsByCorpus.set(r.corpus, m); }
       m.set(Number(r.year), Number(r.tokens));
+      if (r.corpus === defaultCorpus) booksByYear.set(Number(r.year), Number(r.books));
     }
   }
   if (!totalsByCorpus.get(defaultCorpus)?.size) {
@@ -157,7 +159,7 @@ export async function GET(request: NextRequest) {
   const totalsOut = [...defaultTotals.entries()]
     .filter(([year]) => year >= from && year <= to)
     .sort((a, b) => a[0] - b[0])
-    .map(([year, tokens]) => ({ year, tokens }));
+    .map(([year, tokens]) => ({ year, tokens, books: booksByYear.get(year) ?? 0 }));
 
   return NextResponse.json(
     {

--- a/src/components/ngrams/NgramViewer.tsx
+++ b/src/components/ngrams/NgramViewer.tsx
@@ -23,7 +23,7 @@ interface Series {
 }
 interface ApiResponse {
   corpus: string; from: number; to: number; smoothing: number;
-  totals: Array<{ year: number; tokens: number }>;
+  totals: Array<{ year: number; tokens: number; books: number }>;
   series: Series[];
   error?: string;
 }
@@ -209,6 +209,12 @@ export default function NgramViewer() {
   const hoverInfo = hover && shown[hover.seriesIdx]
     ? { series: shown[hover.seriesIdx], point: shown[hover.seriesIdx].points.find(p => p.year === hover.year) }
     : null;
+
+  const totalsByYear = useMemo(
+    () => new Map((data?.totals || []).map(t => [t.year, t])),
+    [data],
+  );
+  const hoverVolume = hover ? totalsByYear.get(hover.year) : null;
 
   return (
     <div>
@@ -415,10 +421,22 @@ export default function NgramViewer() {
             <div className="text-[var(--text-muted)]">
               {hoverInfo.point.count.toLocaleString()} raw hits that year
             </div>
+            {hoverVolume && (
+              <div className="text-[var(--text-faint)] mt-0.5 pt-0.5 border-t border-[var(--border-light)]">
+                corpus in {hover!.year}: {hoverVolume.books.toLocaleString()} books · {compactNumber(hoverVolume.tokens)} tokens
+              </div>
+            )}
             <div className="mt-1 text-[var(--accent-rust)]">Click to read these passages →</div>
           </div>
         )}
       </div>
+
+      {data && (
+        <p className="mt-1.5 text-xs text-[var(--text-faint)]">
+          Gray backdrop: how much text each year contributes ({compactNumber(data.totals.reduce((s, t) => s + t.books, 0))} books
+          across this range). Hover any point for that year&apos;s exact book and token counts.
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Derek: 'the total number of books for the year should be easier to see.' The data was already in `ngram_totals.books` — this surfaces it: the API's totals now carry `books`, the hover tooltip gains a 'corpus in 1617: 42 books · 1.2M tokens' line, and a one-line caption under the chart explains the gray volume backdrop with the total book count in range. No schema or rebuild needed. tsc + ngram suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)