### PR TITLE
fix(ngrams): coverage panel — per-language USTC facet, binned held-share, darker bars

### DIFF
--- a/scripts/analytics/ustc-year-counts.mjs
+++ b/scripts/analytics/ustc-year-counts.mjs
@@ -54,6 +54,25 @@ const { rows } = await pgc.query(`
   GROUP BY year
   ORDER BY year
 `);
+
+// Per-language subsets keyed by NGRAM corpus id, so the panel can compare an
+// original-language corpus against USTC's same-language editions (apples to
+// apples). The `en` corpus (translations of EVERYTHING) deliberately has no
+// subset — it reads against all of European print.
+const USTC_LANG_TO_CORPUS = {
+  Latin: 'la', German: 'de', French: 'fr', English: 'en-orig', Dutch: 'nl',
+  Italian: 'it', Spanish: 'es', Greek: 'el', Portuguese: 'pt', Hebrew: 'he',
+};
+const { rows: langRows } = await pgc.query(`
+  SELECT language_1 AS lang, year,
+         count(*)::int AS editions,
+         count(*) FILTER (WHERE in_source_library)::int AS matched
+  FROM ustc_editions
+  WHERE year IS NOT NULL AND language_1 = ANY($1)
+  GROUP BY language_1, year
+  ORDER BY language_1, year
+`, [Object.keys(USTC_LANG_TO_CORPUS)]);
+
 const { rows: [{ coverage_built_at }] } = await pgc.query(
   'SELECT max(coverage_built_at) AS coverage_built_at FROM ustc_editions',
 );
@@ -65,6 +84,15 @@ const years = rows
   .map(r => ({ ...r, year: Number(r.year) }))
   .filter(r => Number.isInteger(r.year) && r.year >= YEAR_MIN && r.year <= YEAR_MAX)
   .map(({ year, editions, matched, scanned, translated }) => ({ year, editions, matched, scanned, translated }));
+
+const languages = {};
+for (const r of langRows) {
+  const year = Number(r.year);
+  if (!Number.isInteger(year) || year < YEAR_MIN || year > YEAR_MAX) continue;
+  const corpusId = USTC_LANG_TO_CORPUS[r.lang];
+  const entry = (languages[corpusId] ??= { label: r.lang, years: [] });
+  entry.years.push({ year, editions: r.editions, matched: r.matched });
+}
 
 const sum = (k) => years.reduce((s, r) => s + r[k], 0);
 const out = {
@@ -79,6 +107,7 @@ const out = {
   total_scanned: sum('scanned'),
   total_translated: sum('translated'),
   years,
+  languages,
 };
 
 fs.writeFileSync(OUT, JSON.stringify(out, null, 1) + '\n');

--- a/src/components/ngrams/NgramViewer.tsx
+++ b/src/components/ngrams/NgramViewer.tsx
@@ -478,6 +478,7 @@ export default function NgramViewer() {
           totals={data.totals}
           from={from}
           to={to}
+          corpus={data.corpus}
           corpusLabel={shortLabel(NGRAM_CORPORA.find(c => c.id === data.corpus)?.label || data.corpus)}
         />
       )}

--- a/src/components/ngrams/UstcCoveragePanel.tsx
+++ b/src/components/ngrams/UstcCoveragePanel.tsx
@@ -6,10 +6,19 @@
  * The curves above describe OUR collection, not print culture at large. This
  * panel quantifies that: it charts the USTC's universe of European print
  * (~1.6M dated editions, 1450-1700 authoritative) against what this corpus
- * contributes per year, plus the honest headline — the share of each year's
- * known editions we actually hold (`in_source_library` matches computed by the
- * catalog-coverage build). It measures bias; it deliberately does NOT reweight
- * the curves (that's a separate research question — see #3214).
+ * contributes per year, plus the honest headline — the share of known editions
+ * we actually hold (`in_source_library` matches from the catalog-coverage
+ * build). It measures bias; it deliberately does NOT reweight the curves.
+ *
+ * Original-language corpora facet to USTC's same-language editions (the `la`
+ * corpus reads against USTC's Latin subset — apples to apples). The `en`
+ * corpus is translations of EVERYTHING, so it reads against all of European
+ * print, and the copy says so.
+ *
+ * The held-share strip uses 5-year bins: single years early in the window can
+ * have a handful of editions, and 1 match in 2 editions would spike to 500‰
+ * and flatten every real year to the baseline (shipped that way, caught by
+ * Derek within the hour).
  *
  * Data: src/generated/ustc-year-counts.json (static, checked in — regenerate
  * with scripts/analytics/ustc-year-counts.mjs after a coverage rebuild).
@@ -24,19 +33,23 @@ import { linePath, linearScale, niceTicks, compactNumber } from '@/components/an
 // the catalogue's scope, so the panel clamps to it.
 const USTC_FROM = 1450;
 const USTC_TO = 1700;
+const RATIO_BIN = 5; // years per held-share bin
 
-interface YearRow { year: number; editions: number; matched: number; scanned: number; translated: number }
+interface YearRow { year: number; editions: number; matched: number }
+interface LangEntry { label: string; years: YearRow[] }
 
 interface Props {
   /** Per-year totals for the active corpus, from the /api/ngrams response. */
   totals: Array<{ year: number; tokens: number; books: number }>;
   from: number;
   to: number;
+  /** Active corpus id ("en", "la", …) — picks the USTC language facet. */
+  corpus: string;
   /** Short label of the active corpus ("English", "Latin", …). */
   corpusLabel: string;
 }
 
-export default function UstcCoveragePanel({ totals, from, to, corpusLabel }: Props) {
+export default function UstcCoveragePanel({ totals, from, to, corpus, corpusLabel }: Props) {
   const [open, setOpen] = useState(false);
   const [hoverYear, setHoverYear] = useState<number | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -45,35 +58,54 @@ export default function UstcCoveragePanel({ totals, from, to, corpusLabel }: Pro
   const winTo = Math.min(to, USTC_TO);
   const hasWindow = winFrom <= winTo;
 
+  // Facet: original-language corpora read against USTC's same-language subset.
+  // `en` (translations of everything) and unmapped corpora read against all.
+  const facet = (ustc.languages as Record<string, LangEntry | undefined>)[corpus];
+  const universeLabel = facet ? `USTC ${facet.label} editions` : 'USTC editions (all languages)';
+
   const rows = useMemo(
-    () => (ustc.years as YearRow[]).filter(r => r.year >= winFrom && r.year <= winTo),
-    [winFrom, winTo],
+    () => ((facet?.years ?? ustc.years) as YearRow[]).filter(r => r.year >= winFrom && r.year <= winTo),
+    [facet, winFrom, winTo],
   );
   const booksByYear = useMemo(() => new Map(totals.map(t => [t.year, t.books])), [totals]);
 
   const windowStats = useMemo(() => {
     const editions = rows.reduce((s, r) => s + r.editions, 0);
     const matched = rows.reduce((s, r) => s + r.matched, 0);
-    const scanned = rows.reduce((s, r) => s + r.scanned, 0);
-    const translated = rows.reduce((s, r) => s + r.translated, 0);
     let ourBooks = 0;
     for (const [year, books] of booksByYear) {
       if (year >= winFrom && year <= winTo) ourBooks += books;
     }
-    return { editions, matched, scanned, translated, ourBooks };
+    return { editions, matched, ourBooks };
   }, [rows, booksByYear, winFrom, winTo]);
 
-  // ---- geometry: main chart (bars + line) over a per-mille ratio strip ----
+  // Held-share bins: sum matched / sum editions per RATIO_BIN years. Per-year
+  // ratios are meaningless when a year has a handful of editions.
+  const ratioBins = useMemo(() => {
+    const bins: Array<{ year: number; editions: number; matched: number; perMille: number }> = [];
+    for (let start = winFrom; start <= winTo; start += RATIO_BIN) {
+      const end = Math.min(start + RATIO_BIN - 1, winTo);
+      let editions = 0, matched = 0;
+      for (const r of rows) {
+        if (r.year >= start && r.year <= end) { editions += r.editions; matched += r.matched; }
+      }
+      if (editions === 0) continue;
+      bins.push({ year: (start + end) / 2, editions, matched, perMille: (matched / editions) * 1000 });
+    }
+    return bins;
+  }, [rows, winFrom, winTo]);
+
+  // ---- geometry: main chart (bars + line) over the held-share strip ----
   const width = 900;
-  const mainH = 170;
-  const stripH = 56;
-  const gap = 26; // room for the strip's own title
+  const mainH = 260;
+  const stripH = 64;
+  const gap = 28; // room for the strip's own title
   const margin = { top: 8, right: 24, bottom: 24, left: 56 };
   const plotW = width - margin.left - margin.right;
   const height = margin.top + mainH + gap + stripH + margin.bottom;
 
   const xScale = useMemo(() => linearScale(winFrom, winTo, 0, plotW), [winFrom, winTo, plotW]);
-  const barW = Math.max(0.6, plotW / Math.max(1, winTo - winFrom + 1) - 0.4);
+  const barW = Math.max(0.8, plotW / Math.max(1, winTo - winFrom + 1) - 0.3);
 
   const editionsMax = useMemo(() => Math.max(1, ...rows.map(r => r.editions)), [rows]);
   const editionsScale = useMemo(() => linearScale(0, editionsMax * 1.05, mainH, 0), [editionsMax]);
@@ -84,12 +116,8 @@ export default function UstcCoveragePanel({ totals, from, to, corpusLabel }: Pro
   }, [rows, booksByYear]);
   const ourScale = useMemo(() => linearScale(0, ourMax * 1.05, mainH, 0), [ourMax]);
 
-  const perMille = useCallback(
-    (r: YearRow) => (r.editions > 0 ? (r.matched / r.editions) * 1000 : 0),
-    [],
-  );
-  const ratioMax = useMemo(() => Math.max(0.1, ...rows.map(perMille)), [rows, perMille]);
-  const ratioScale = useMemo(() => linearScale(0, ratioMax * 1.1, stripH, 0), [ratioMax, stripH]);
+  const ratioMax = useMemo(() => Math.max(0.1, ...ratioBins.map(b => b.perMille)), [ratioBins]);
+  const ratioScale = useMemo(() => linearScale(0, ratioMax * 1.15, stripH, 0), [ratioMax, stripH]);
   const stripTop = mainH + gap;
 
   const xTicks = useMemo(() => niceTicks(winFrom, winTo, 8), [winFrom, winTo]);
@@ -104,6 +132,9 @@ export default function UstcCoveragePanel({ totals, from, to, corpusLabel }: Pro
   }, [rows.length, plotW, winFrom, winTo, margin.left]);
 
   const hoverRow = hoverYear !== null ? rows.find(r => r.year === hoverYear) : undefined;
+  const hoverBin = hoverYear !== null
+    ? ratioBins.find(b => Math.abs(b.year - hoverYear) <= RATIO_BIN / 2)
+    : undefined;
 
   const pm = (windowStats.matched / Math.max(1, windowStats.editions)) * 1000;
   const builtAt = ustc.coverage_built_at ? new Date(ustc.coverage_built_at) : null;
@@ -134,10 +165,18 @@ export default function UstcCoveragePanel({ totals, from, to, corpusLabel }: Pro
             <>
               <p className="text-sm text-[var(--text-secondary)] mb-2">
                 In {winFrom}–{winTo} the USTC records{' '}
-                <strong>{windowStats.editions.toLocaleString()}</strong> European printed editions.
+                <strong>{windowStats.editions.toLocaleString()}</strong>{' '}
+                {facet ? `${facet.label}-language ` : ''}European printed editions.
                 Source Library holds <strong>{windowStats.matched.toLocaleString()}</strong> of them
                 ({pm.toFixed(1)}‰), and the {corpusLabel} corpus charted above draws on{' '}
                 <strong>{windowStats.ourBooks.toLocaleString()}</strong> books in this window.
+                {!facet && corpus === 'en' && (
+                  <span className="text-[var(--text-muted)]">
+                    {' '}(The English corpus is our translations of works in every language, so it
+                    reads against all of European print; pick an original-language corpus for a
+                    same-language comparison.)
+                  </span>
+                )}
               </p>
 
               <div className="relative">
@@ -157,8 +196,8 @@ export default function UstcCoveragePanel({ totals, from, to, corpusLabel }: Pro
                         y={editionsScale(r.editions)}
                         width={barW}
                         height={mainH - editionsScale(r.editions)}
-                        fill="var(--text-faint)"
-                        opacity={hoverYear === r.year ? 0.55 : 0.3}
+                        fill="var(--text-muted)"
+                        opacity={hoverYear === r.year ? 0.9 : 0.55}
                       />
                     ))}
 
@@ -178,19 +217,19 @@ export default function UstcCoveragePanel({ totals, from, to, corpusLabel }: Pro
                     ))}
                     <text x={-44} y={mainH / 2} fontSize={10} fill="var(--text-secondary)"
                       textAnchor="middle" transform={`rotate(-90, -44, ${mainH / 2})`}>
-                      USTC editions
+                      {universeLabel}
                     </text>
 
-                    {/* Ratio strip: share of each year's known print we hold */}
+                    {/* Held-share strip: matched ‰ of known print, RATIO_BIN-year bins */}
                     <g transform={`translate(0,${stripTop})`}>
                       <text x={0} y={-8} fontSize={10} fill="var(--text-secondary)">
-                        Held here, as ‰ of that year&apos;s known European print
+                        Held here, as ‰ of known {facet ? `${facet.label} ` : ''}print ({RATIO_BIN}-year bins)
                       </text>
                       <path
-                        d={linePath(rows.map(r => ({ x: xScale(r.year), y: ratioScale(perMille(r)) })))}
+                        d={linePath(ratioBins.map(b => ({ x: xScale(b.year), y: ratioScale(b.perMille) })))}
                         fill="none"
                         stroke="var(--accent-sage-dark)"
-                        strokeWidth={1.5}
+                        strokeWidth={1.75}
                       />
                       <line x1={0} y1={stripH} x2={plotW} y2={stripH} stroke="var(--border-medium)" />
                       <text x={-8} y={ratioScale(ratioMax) + 4} fontSize={10} fill="var(--text-muted)" textAnchor="end">
@@ -214,22 +253,27 @@ export default function UstcCoveragePanel({ totals, from, to, corpusLabel }: Pro
                 {hoverRow && (
                   <div className="absolute top-0 right-0 bg-white/95 border border-[var(--border-light)] rounded px-2 py-1 text-xs text-[var(--text-secondary)] pointer-events-none">
                     <span className="font-medium">{hoverRow.year}</span>
-                    {' · '}USTC: {hoverRow.editions.toLocaleString()} editions
-                    {' · '}held here: {hoverRow.matched.toLocaleString()} ({perMille(hoverRow).toFixed(1)}‰)
+                    {' · '}{facet ? `USTC ${facet.label}` : 'USTC'}: {hoverRow.editions.toLocaleString()} editions
                     {' · '}{corpusLabel} corpus: {(booksByYear.get(hoverRow.year) ?? 0).toLocaleString()} books
+                    {hoverBin && (
+                      <>
+                        {' · '}held {hoverBin.matched.toLocaleString()} of {hoverBin.editions.toLocaleString()}
+                        {' '}({hoverBin.perMille.toFixed(1)}‰, {RATIO_BIN}y bin)
+                      </>
+                    )}
                   </div>
                 )}
               </div>
 
               <ul className="mt-2 text-xs text-[var(--text-faint)] space-y-0.5 list-disc pl-4">
                 <li>
-                  Gray bars: editions per year in the{' '}
+                  Gray bars: {facet ? `${facet.label}-language editions` : 'editions'} per year in the{' '}
                   <a href="https://www.ustc.ac.uk" target="_blank" rel="noopener noreferrer" className="underline hover:text-[var(--accent-rust)]">
                     Universal Short Title Catalogue
                   </a>{' '}
                   — European <em>printed</em> output only, including broadsheets and ephemera. The rust
                   line is this corpus&apos;s books per year (its own scale); the green strip is the share
-                  of each year&apos;s known editions positively matched to a Source Library copy.
+                  of known editions positively matched to a Source Library copy, in {RATIO_BIN}-year bins.
                 </li>
                 <li>
                   The match is conservative, and most of Source Library lies outside USTC&apos;s scope

--- a/src/generated/ustc-year-counts.json
+++ b/src/generated/ustc-year-counts.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-18T23:48:36.733Z",
+ "generated_at": "2026-07-19T00:57:52.311Z",
  "coverage_built_at": "2026-04-10T07:06:35.389Z",
  "year_min": 1450,
  "year_max": 1744,
@@ -1828,5 +1828,11567 @@
    "scanned": 0,
    "translated": 0
   }
- ]
+ ],
+ "languages": {
+  "nl": {
+   "label": "Dutch",
+   "years": [
+    {
+     "year": 1465,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1471,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1477,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1478,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1479,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1480,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1481,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1482,
+     "editions": 19,
+     "matched": 0
+    },
+    {
+     "year": 1483,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1484,
+     "editions": 31,
+     "matched": 0
+    },
+    {
+     "year": 1485,
+     "editions": 19,
+     "matched": 0
+    },
+    {
+     "year": 1486,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1487,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1488,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1489,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1490,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1491,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1492,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1493,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1494,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1495,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1496,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1497,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1498,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1499,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1500,
+     "editions": 53,
+     "matched": 0
+    },
+    {
+     "year": 1501,
+     "editions": 85,
+     "matched": 0
+    },
+    {
+     "year": 1502,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1503,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1504,
+     "editions": 48,
+     "matched": 0
+    },
+    {
+     "year": 1505,
+     "editions": 41,
+     "matched": 0
+    },
+    {
+     "year": 1506,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1507,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1508,
+     "editions": 20,
+     "matched": 0
+    },
+    {
+     "year": 1509,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1510,
+     "editions": 59,
+     "matched": 0
+    },
+    {
+     "year": 1511,
+     "editions": 20,
+     "matched": 0
+    },
+    {
+     "year": 1512,
+     "editions": 35,
+     "matched": 0
+    },
+    {
+     "year": 1513,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1514,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1515,
+     "editions": 43,
+     "matched": 0
+    },
+    {
+     "year": 1516,
+     "editions": 43,
+     "matched": 0
+    },
+    {
+     "year": 1517,
+     "editions": 36,
+     "matched": 0
+    },
+    {
+     "year": 1518,
+     "editions": 56,
+     "matched": 0
+    },
+    {
+     "year": 1519,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1520,
+     "editions": 85,
+     "matched": 0
+    },
+    {
+     "year": 1521,
+     "editions": 43,
+     "matched": 0
+    },
+    {
+     "year": 1522,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1523,
+     "editions": 31,
+     "matched": 0
+    },
+    {
+     "year": 1524,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1525,
+     "editions": 48,
+     "matched": 0
+    },
+    {
+     "year": 1526,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1527,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1528,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1529,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1530,
+     "editions": 87,
+     "matched": 0
+    },
+    {
+     "year": 1531,
+     "editions": 62,
+     "matched": 0
+    },
+    {
+     "year": 1532,
+     "editions": 48,
+     "matched": 0
+    },
+    {
+     "year": 1533,
+     "editions": 36,
+     "matched": 0
+    },
+    {
+     "year": 1534,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1535,
+     "editions": 62,
+     "matched": 0
+    },
+    {
+     "year": 1536,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1537,
+     "editions": 35,
+     "matched": 0
+    },
+    {
+     "year": 1538,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1539,
+     "editions": 45,
+     "matched": 0
+    },
+    {
+     "year": 1540,
+     "editions": 210,
+     "matched": 0
+    },
+    {
+     "year": 1541,
+     "editions": 60,
+     "matched": 1
+    },
+    {
+     "year": 1542,
+     "editions": 92,
+     "matched": 0
+    },
+    {
+     "year": 1543,
+     "editions": 90,
+     "matched": 0
+    },
+    {
+     "year": 1544,
+     "editions": 83,
+     "matched": 0
+    },
+    {
+     "year": 1545,
+     "editions": 56,
+     "matched": 0
+    },
+    {
+     "year": 1546,
+     "editions": 71,
+     "matched": 0
+    },
+    {
+     "year": 1547,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1548,
+     "editions": 51,
+     "matched": 0
+    },
+    {
+     "year": 1549,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1550,
+     "editions": 172,
+     "matched": 0
+    },
+    {
+     "year": 1551,
+     "editions": 123,
+     "matched": 0
+    },
+    {
+     "year": 1552,
+     "editions": 85,
+     "matched": 0
+    },
+    {
+     "year": 1553,
+     "editions": 80,
+     "matched": 0
+    },
+    {
+     "year": 1554,
+     "editions": 100,
+     "matched": 0
+    },
+    {
+     "year": 1555,
+     "editions": 125,
+     "matched": 0
+    },
+    {
+     "year": 1556,
+     "editions": 114,
+     "matched": 0
+    },
+    {
+     "year": 1557,
+     "editions": 88,
+     "matched": 0
+    },
+    {
+     "year": 1558,
+     "editions": 95,
+     "matched": 0
+    },
+    {
+     "year": 1559,
+     "editions": 75,
+     "matched": 0
+    },
+    {
+     "year": 1560,
+     "editions": 138,
+     "matched": 0
+    },
+    {
+     "year": 1561,
+     "editions": 166,
+     "matched": 0
+    },
+    {
+     "year": 1562,
+     "editions": 102,
+     "matched": 0
+    },
+    {
+     "year": 1563,
+     "editions": 147,
+     "matched": 0
+    },
+    {
+     "year": 1564,
+     "editions": 132,
+     "matched": 1
+    },
+    {
+     "year": 1565,
+     "editions": 148,
+     "matched": 0
+    },
+    {
+     "year": 1566,
+     "editions": 235,
+     "matched": 1
+    },
+    {
+     "year": 1567,
+     "editions": 236,
+     "matched": 0
+    },
+    {
+     "year": 1568,
+     "editions": 172,
+     "matched": 0
+    },
+    {
+     "year": 1569,
+     "editions": 108,
+     "matched": 0
+    },
+    {
+     "year": 1570,
+     "editions": 105,
+     "matched": 0
+    },
+    {
+     "year": 1571,
+     "editions": 119,
+     "matched": 0
+    },
+    {
+     "year": 1572,
+     "editions": 96,
+     "matched": 0
+    },
+    {
+     "year": 1573,
+     "editions": 95,
+     "matched": 0
+    },
+    {
+     "year": 1574,
+     "editions": 111,
+     "matched": 0
+    },
+    {
+     "year": 1575,
+     "editions": 124,
+     "matched": 0
+    },
+    {
+     "year": 1576,
+     "editions": 185,
+     "matched": 0
+    },
+    {
+     "year": 1577,
+     "editions": 214,
+     "matched": 0
+    },
+    {
+     "year": 1578,
+     "editions": 250,
+     "matched": 1
+    },
+    {
+     "year": 1579,
+     "editions": 317,
+     "matched": 0
+    },
+    {
+     "year": 1580,
+     "editions": 330,
+     "matched": 2
+    },
+    {
+     "year": 1581,
+     "editions": 282,
+     "matched": 0
+    },
+    {
+     "year": 1582,
+     "editions": 332,
+     "matched": 0
+    },
+    {
+     "year": 1583,
+     "editions": 292,
+     "matched": 2
+    },
+    {
+     "year": 1584,
+     "editions": 310,
+     "matched": 0
+    },
+    {
+     "year": 1585,
+     "editions": 300,
+     "matched": 0
+    },
+    {
+     "year": 1586,
+     "editions": 313,
+     "matched": 2
+    },
+    {
+     "year": 1587,
+     "editions": 278,
+     "matched": 0
+    },
+    {
+     "year": 1588,
+     "editions": 228,
+     "matched": 0
+    },
+    {
+     "year": 1589,
+     "editions": 197,
+     "matched": 0
+    },
+    {
+     "year": 1590,
+     "editions": 259,
+     "matched": 1
+    },
+    {
+     "year": 1591,
+     "editions": 225,
+     "matched": 0
+    },
+    {
+     "year": 1592,
+     "editions": 196,
+     "matched": 0
+    },
+    {
+     "year": 1593,
+     "editions": 189,
+     "matched": 0
+    },
+    {
+     "year": 1594,
+     "editions": 232,
+     "matched": 1
+    },
+    {
+     "year": 1595,
+     "editions": 245,
+     "matched": 2
+    },
+    {
+     "year": 1596,
+     "editions": 296,
+     "matched": 2
+    },
+    {
+     "year": 1597,
+     "editions": 352,
+     "matched": 1
+    },
+    {
+     "year": 1598,
+     "editions": 333,
+     "matched": 3
+    },
+    {
+     "year": 1599,
+     "editions": 353,
+     "matched": 1
+    },
+    {
+     "year": 1600,
+     "editions": 453,
+     "matched": 0
+    },
+    {
+     "year": 1601,
+     "editions": 747,
+     "matched": 0
+    },
+    {
+     "year": 1602,
+     "editions": 218,
+     "matched": 1
+    },
+    {
+     "year": 1603,
+     "editions": 260,
+     "matched": 3
+    },
+    {
+     "year": 1604,
+     "editions": 227,
+     "matched": 1
+    },
+    {
+     "year": 1605,
+     "editions": 251,
+     "matched": 0
+    },
+    {
+     "year": 1606,
+     "editions": 242,
+     "matched": 0
+    },
+    {
+     "year": 1607,
+     "editions": 328,
+     "matched": 0
+    },
+    {
+     "year": 1608,
+     "editions": 401,
+     "matched": 1
+    },
+    {
+     "year": 1609,
+     "editions": 443,
+     "matched": 1
+    },
+    {
+     "year": 1610,
+     "editions": 461,
+     "matched": 0
+    },
+    {
+     "year": 1611,
+     "editions": 435,
+     "matched": 0
+    },
+    {
+     "year": 1612,
+     "editions": 440,
+     "matched": 0
+    },
+    {
+     "year": 1613,
+     "editions": 349,
+     "matched": 2
+    },
+    {
+     "year": 1614,
+     "editions": 402,
+     "matched": 4
+    },
+    {
+     "year": 1615,
+     "editions": 401,
+     "matched": 1
+    },
+    {
+     "year": 1616,
+     "editions": 486,
+     "matched": 0
+    },
+    {
+     "year": 1617,
+     "editions": 590,
+     "matched": 2
+    },
+    {
+     "year": 1618,
+     "editions": 776,
+     "matched": 0
+    },
+    {
+     "year": 1619,
+     "editions": 630,
+     "matched": 0
+    },
+    {
+     "year": 1620,
+     "editions": 650,
+     "matched": 1
+    },
+    {
+     "year": 1621,
+     "editions": 841,
+     "matched": 4
+    },
+    {
+     "year": 1622,
+     "editions": 840,
+     "matched": 2
+    },
+    {
+     "year": 1623,
+     "editions": 795,
+     "matched": 5
+    },
+    {
+     "year": 1624,
+     "editions": 678,
+     "matched": 5
+    },
+    {
+     "year": 1625,
+     "editions": 635,
+     "matched": 1
+    },
+    {
+     "year": 1626,
+     "editions": 689,
+     "matched": 2
+    },
+    {
+     "year": 1627,
+     "editions": 600,
+     "matched": 6
+    },
+    {
+     "year": 1628,
+     "editions": 743,
+     "matched": 0
+    },
+    {
+     "year": 1629,
+     "editions": 779,
+     "matched": 2
+    },
+    {
+     "year": 1630,
+     "editions": 950,
+     "matched": 1
+    },
+    {
+     "year": 1631,
+     "editions": 752,
+     "matched": 0
+    },
+    {
+     "year": 1632,
+     "editions": 671,
+     "matched": 2
+    },
+    {
+     "year": 1633,
+     "editions": 592,
+     "matched": 5
+    },
+    {
+     "year": 1634,
+     "editions": 576,
+     "matched": 2
+    },
+    {
+     "year": 1635,
+     "editions": 662,
+     "matched": 2
+    },
+    {
+     "year": 1636,
+     "editions": 602,
+     "matched": 1
+    },
+    {
+     "year": 1637,
+     "editions": 618,
+     "matched": 2
+    },
+    {
+     "year": 1638,
+     "editions": 583,
+     "matched": 1
+    },
+    {
+     "year": 1639,
+     "editions": 709,
+     "matched": 2
+    },
+    {
+     "year": 1640,
+     "editions": 780,
+     "matched": 3
+    },
+    {
+     "year": 1641,
+     "editions": 737,
+     "matched": 0
+    },
+    {
+     "year": 1642,
+     "editions": 983,
+     "matched": 3
+    },
+    {
+     "year": 1643,
+     "editions": 1155,
+     "matched": 3
+    },
+    {
+     "year": 1644,
+     "editions": 1340,
+     "matched": 10
+    },
+    {
+     "year": 1645,
+     "editions": 1228,
+     "matched": 1
+    },
+    {
+     "year": 1646,
+     "editions": 1152,
+     "matched": 0
+    },
+    {
+     "year": 1647,
+     "editions": 946,
+     "matched": 1
+    },
+    {
+     "year": 1648,
+     "editions": 1157,
+     "matched": 3
+    },
+    {
+     "year": 1649,
+     "editions": 1104,
+     "matched": 2
+    },
+    {
+     "year": 1650,
+     "editions": 1338,
+     "matched": 3
+    },
+    {
+     "year": 1651,
+     "editions": 1271,
+     "matched": 5
+    },
+    {
+     "year": 1652,
+     "editions": 1128,
+     "matched": 2
+    },
+    {
+     "year": 1653,
+     "editions": 931,
+     "matched": 2
+    },
+    {
+     "year": 1654,
+     "editions": 874,
+     "matched": 1
+    },
+    {
+     "year": 1655,
+     "editions": 988,
+     "matched": 8
+    },
+    {
+     "year": 1656,
+     "editions": 1055,
+     "matched": 3
+    },
+    {
+     "year": 1657,
+     "editions": 1195,
+     "matched": 3
+    },
+    {
+     "year": 1658,
+     "editions": 1300,
+     "matched": 3
+    },
+    {
+     "year": 1659,
+     "editions": 1321,
+     "matched": 11
+    },
+    {
+     "year": 1660,
+     "editions": 1393,
+     "matched": 6
+    },
+    {
+     "year": 1661,
+     "editions": 1299,
+     "matched": 8
+    },
+    {
+     "year": 1662,
+     "editions": 1194,
+     "matched": 9
+    },
+    {
+     "year": 1663,
+     "editions": 1165,
+     "matched": 7
+    },
+    {
+     "year": 1664,
+     "editions": 1399,
+     "matched": 9
+    },
+    {
+     "year": 1665,
+     "editions": 1399,
+     "matched": 2
+    },
+    {
+     "year": 1666,
+     "editions": 1584,
+     "matched": 4
+    },
+    {
+     "year": 1667,
+     "editions": 1413,
+     "matched": 8
+    },
+    {
+     "year": 1668,
+     "editions": 1278,
+     "matched": 4
+    },
+    {
+     "year": 1669,
+     "editions": 1223,
+     "matched": 8
+    },
+    {
+     "year": 1670,
+     "editions": 1099,
+     "matched": 2
+    },
+    {
+     "year": 1671,
+     "editions": 1177,
+     "matched": 6
+    },
+    {
+     "year": 1672,
+     "editions": 2064,
+     "matched": 2
+    },
+    {
+     "year": 1673,
+     "editions": 1621,
+     "matched": 5
+    },
+    {
+     "year": 1674,
+     "editions": 1577,
+     "matched": 5
+    },
+    {
+     "year": 1675,
+     "editions": 1704,
+     "matched": 1
+    },
+    {
+     "year": 1676,
+     "editions": 1242,
+     "matched": 2
+    },
+    {
+     "year": 1677,
+     "editions": 1249,
+     "matched": 3
+    },
+    {
+     "year": 1678,
+     "editions": 1205,
+     "matched": 0
+    },
+    {
+     "year": 1679,
+     "editions": 1294,
+     "matched": 0
+    },
+    {
+     "year": 1680,
+     "editions": 1454,
+     "matched": 1
+    },
+    {
+     "year": 1681,
+     "editions": 1099,
+     "matched": 2
+    },
+    {
+     "year": 1682,
+     "editions": 1129,
+     "matched": 0
+    },
+    {
+     "year": 1683,
+     "editions": 1314,
+     "matched": 2
+    },
+    {
+     "year": 1684,
+     "editions": 1743,
+     "matched": 0
+    },
+    {
+     "year": 1685,
+     "editions": 1365,
+     "matched": 4
+    },
+    {
+     "year": 1686,
+     "editions": 1344,
+     "matched": 5
+    },
+    {
+     "year": 1687,
+     "editions": 1375,
+     "matched": 2
+    },
+    {
+     "year": 1688,
+     "editions": 1742,
+     "matched": 1
+    },
+    {
+     "year": 1689,
+     "editions": 1393,
+     "matched": 0
+    },
+    {
+     "year": 1690,
+     "editions": 1423,
+     "matched": 8
+    },
+    {
+     "year": 1691,
+     "editions": 1491,
+     "matched": 17
+    },
+    {
+     "year": 1692,
+     "editions": 1398,
+     "matched": 6
+    },
+    {
+     "year": 1693,
+     "editions": 1381,
+     "matched": 15
+    },
+    {
+     "year": 1694,
+     "editions": 1176,
+     "matched": 5
+    },
+    {
+     "year": 1695,
+     "editions": 1492,
+     "matched": 3
+    },
+    {
+     "year": 1696,
+     "editions": 1281,
+     "matched": 1
+    },
+    {
+     "year": 1697,
+     "editions": 1403,
+     "matched": 0
+    },
+    {
+     "year": 1698,
+     "editions": 1271,
+     "matched": 4
+    },
+    {
+     "year": 1699,
+     "editions": 1297,
+     "matched": 1
+    },
+    {
+     "year": 1700,
+     "editions": 1448,
+     "matched": 3
+    }
+   ]
+  },
+  "en-orig": {
+   "label": "English",
+   "years": [
+    {
+     "year": 1455,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1460,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1461,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1462,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1465,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1468,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1469,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1473,
+     "editions": 1,
+     "matched": 1
+    },
+    {
+     "year": 1474,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1476,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1477,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1478,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1479,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1480,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1481,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1482,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1483,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1484,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1485,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1486,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1487,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1489,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1490,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1491,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1492,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1493,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1494,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1495,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1496,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1497,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1498,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1499,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1500,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1501,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1502,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1503,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1504,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1505,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1506,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1507,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1508,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1509,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1510,
+     "editions": 57,
+     "matched": 0
+    },
+    {
+     "year": 1511,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1512,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1513,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1514,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1515,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1516,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1517,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1518,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1519,
+     "editions": 19,
+     "matched": 0
+    },
+    {
+     "year": 1520,
+     "editions": 58,
+     "matched": 0
+    },
+    {
+     "year": 1521,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1522,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1523,
+     "editions": 20,
+     "matched": 0
+    },
+    {
+     "year": 1524,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1525,
+     "editions": 57,
+     "matched": 0
+    },
+    {
+     "year": 1526,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1527,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1528,
+     "editions": 61,
+     "matched": 0
+    },
+    {
+     "year": 1529,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1530,
+     "editions": 99,
+     "matched": 0
+    },
+    {
+     "year": 1531,
+     "editions": 62,
+     "matched": 0
+    },
+    {
+     "year": 1532,
+     "editions": 64,
+     "matched": 0
+    },
+    {
+     "year": 1533,
+     "editions": 72,
+     "matched": 0
+    },
+    {
+     "year": 1534,
+     "editions": 88,
+     "matched": 0
+    },
+    {
+     "year": 1535,
+     "editions": 89,
+     "matched": 0
+    },
+    {
+     "year": 1536,
+     "editions": 78,
+     "matched": 0
+    },
+    {
+     "year": 1537,
+     "editions": 64,
+     "matched": 0
+    },
+    {
+     "year": 1538,
+     "editions": 105,
+     "matched": 0
+    },
+    {
+     "year": 1539,
+     "editions": 68,
+     "matched": 0
+    },
+    {
+     "year": 1540,
+     "editions": 97,
+     "matched": 0
+    },
+    {
+     "year": 1541,
+     "editions": 57,
+     "matched": 0
+    },
+    {
+     "year": 1542,
+     "editions": 81,
+     "matched": 0
+    },
+    {
+     "year": 1543,
+     "editions": 97,
+     "matched": 0
+    },
+    {
+     "year": 1544,
+     "editions": 89,
+     "matched": 0
+    },
+    {
+     "year": 1545,
+     "editions": 114,
+     "matched": 0
+    },
+    {
+     "year": 1546,
+     "editions": 100,
+     "matched": 0
+    },
+    {
+     "year": 1547,
+     "editions": 132,
+     "matched": 0
+    },
+    {
+     "year": 1548,
+     "editions": 251,
+     "matched": 0
+    },
+    {
+     "year": 1549,
+     "editions": 173,
+     "matched": 0
+    },
+    {
+     "year": 1550,
+     "editions": 245,
+     "matched": 0
+    },
+    {
+     "year": 1551,
+     "editions": 120,
+     "matched": 0
+    },
+    {
+     "year": 1552,
+     "editions": 125,
+     "matched": 0
+    },
+    {
+     "year": 1553,
+     "editions": 147,
+     "matched": 0
+    },
+    {
+     "year": 1554,
+     "editions": 109,
+     "matched": 0
+    },
+    {
+     "year": 1555,
+     "editions": 160,
+     "matched": 0
+    },
+    {
+     "year": 1556,
+     "editions": 167,
+     "matched": 0
+    },
+    {
+     "year": 1557,
+     "editions": 154,
+     "matched": 0
+    },
+    {
+     "year": 1558,
+     "editions": 124,
+     "matched": 0
+    },
+    {
+     "year": 1559,
+     "editions": 124,
+     "matched": 0
+    },
+    {
+     "year": 1560,
+     "editions": 206,
+     "matched": 0
+    },
+    {
+     "year": 1561,
+     "editions": 208,
+     "matched": 0
+    },
+    {
+     "year": 1562,
+     "editions": 270,
+     "matched": 0
+    },
+    {
+     "year": 1563,
+     "editions": 202,
+     "matched": 0
+    },
+    {
+     "year": 1564,
+     "editions": 151,
+     "matched": 0
+    },
+    {
+     "year": 1565,
+     "editions": 421,
+     "matched": 0
+    },
+    {
+     "year": 1566,
+     "editions": 172,
+     "matched": 1
+    },
+    {
+     "year": 1567,
+     "editions": 219,
+     "matched": 0
+    },
+    {
+     "year": 1568,
+     "editions": 184,
+     "matched": 0
+    },
+    {
+     "year": 1569,
+     "editions": 280,
+     "matched": 0
+    },
+    {
+     "year": 1570,
+     "editions": 287,
+     "matched": 0
+    },
+    {
+     "year": 1571,
+     "editions": 128,
+     "matched": 0
+    },
+    {
+     "year": 1572,
+     "editions": 149,
+     "matched": 0
+    },
+    {
+     "year": 1573,
+     "editions": 134,
+     "matched": 0
+    },
+    {
+     "year": 1574,
+     "editions": 147,
+     "matched": 0
+    },
+    {
+     "year": 1575,
+     "editions": 202,
+     "matched": 1
+    },
+    {
+     "year": 1576,
+     "editions": 166,
+     "matched": 0
+    },
+    {
+     "year": 1577,
+     "editions": 223,
+     "matched": 0
+    },
+    {
+     "year": 1578,
+     "editions": 275,
+     "matched": 1
+    },
+    {
+     "year": 1579,
+     "editions": 337,
+     "matched": 0
+    },
+    {
+     "year": 1580,
+     "editions": 387,
+     "matched": 2
+    },
+    {
+     "year": 1581,
+     "editions": 319,
+     "matched": 1
+    },
+    {
+     "year": 1582,
+     "editions": 245,
+     "matched": 0
+    },
+    {
+     "year": 1583,
+     "editions": 281,
+     "matched": 0
+    },
+    {
+     "year": 1584,
+     "editions": 253,
+     "matched": 1
+    },
+    {
+     "year": 1585,
+     "editions": 270,
+     "matched": 0
+    },
+    {
+     "year": 1586,
+     "editions": 324,
+     "matched": 2
+    },
+    {
+     "year": 1587,
+     "editions": 271,
+     "matched": 1
+    },
+    {
+     "year": 1588,
+     "editions": 334,
+     "matched": 0
+    },
+    {
+     "year": 1589,
+     "editions": 311,
+     "matched": 0
+    },
+    {
+     "year": 1590,
+     "editions": 383,
+     "matched": 0
+    },
+    {
+     "year": 1591,
+     "editions": 341,
+     "matched": 0
+    },
+    {
+     "year": 1592,
+     "editions": 305,
+     "matched": 0
+    },
+    {
+     "year": 1593,
+     "editions": 252,
+     "matched": 1
+    },
+    {
+     "year": 1594,
+     "editions": 334,
+     "matched": 0
+    },
+    {
+     "year": 1595,
+     "editions": 371,
+     "matched": 0
+    },
+    {
+     "year": 1596,
+     "editions": 316,
+     "matched": 0
+    },
+    {
+     "year": 1597,
+     "editions": 294,
+     "matched": 3
+    },
+    {
+     "year": 1598,
+     "editions": 350,
+     "matched": 1
+    },
+    {
+     "year": 1599,
+     "editions": 348,
+     "matched": 0
+    },
+    {
+     "year": 1600,
+     "editions": 441,
+     "matched": 6
+    },
+    {
+     "year": 1601,
+     "editions": 286,
+     "matched": 2
+    },
+    {
+     "year": 1602,
+     "editions": 385,
+     "matched": 1
+    },
+    {
+     "year": 1603,
+     "editions": 477,
+     "matched": 1
+    },
+    {
+     "year": 1604,
+     "editions": 465,
+     "matched": 2
+    },
+    {
+     "year": 1605,
+     "editions": 430,
+     "matched": 5
+    },
+    {
+     "year": 1606,
+     "editions": 452,
+     "matched": 0
+    },
+    {
+     "year": 1607,
+     "editions": 467,
+     "matched": 0
+    },
+    {
+     "year": 1608,
+     "editions": 471,
+     "matched": 1
+    },
+    {
+     "year": 1609,
+     "editions": 496,
+     "matched": 0
+    },
+    {
+     "year": 1610,
+     "editions": 435,
+     "matched": 0
+    },
+    {
+     "year": 1611,
+     "editions": 435,
+     "matched": 2
+    },
+    {
+     "year": 1612,
+     "editions": 519,
+     "matched": 1
+    },
+    {
+     "year": 1613,
+     "editions": 541,
+     "matched": 1
+    },
+    {
+     "year": 1614,
+     "editions": 506,
+     "matched": 0
+    },
+    {
+     "year": 1615,
+     "editions": 562,
+     "matched": 2
+    },
+    {
+     "year": 1616,
+     "editions": 486,
+     "matched": 2
+    },
+    {
+     "year": 1617,
+     "editions": 487,
+     "matched": 0
+    },
+    {
+     "year": 1618,
+     "editions": 586,
+     "matched": 0
+    },
+    {
+     "year": 1619,
+     "editions": 490,
+     "matched": 0
+    },
+    {
+     "year": 1620,
+     "editions": 617,
+     "matched": 0
+    },
+    {
+     "year": 1621,
+     "editions": 655,
+     "matched": 2
+    },
+    {
+     "year": 1622,
+     "editions": 684,
+     "matched": 1
+    },
+    {
+     "year": 1623,
+     "editions": 619,
+     "matched": 1
+    },
+    {
+     "year": 1624,
+     "editions": 602,
+     "matched": 3
+    },
+    {
+     "year": 1625,
+     "editions": 690,
+     "matched": 3
+    },
+    {
+     "year": 1626,
+     "editions": 454,
+     "matched": 0
+    },
+    {
+     "year": 1627,
+     "editions": 496,
+     "matched": 1
+    },
+    {
+     "year": 1628,
+     "editions": 547,
+     "matched": 1
+    },
+    {
+     "year": 1629,
+     "editions": 526,
+     "matched": 2
+    },
+    {
+     "year": 1630,
+     "editions": 740,
+     "matched": 2
+    },
+    {
+     "year": 1631,
+     "editions": 674,
+     "matched": 4
+    },
+    {
+     "year": 1632,
+     "editions": 612,
+     "matched": 0
+    },
+    {
+     "year": 1633,
+     "editions": 704,
+     "matched": 2
+    },
+    {
+     "year": 1634,
+     "editions": 610,
+     "matched": 1
+    },
+    {
+     "year": 1635,
+     "editions": 730,
+     "matched": 2
+    },
+    {
+     "year": 1636,
+     "editions": 572,
+     "matched": 1
+    },
+    {
+     "year": 1637,
+     "editions": 602,
+     "matched": 1
+    },
+    {
+     "year": 1638,
+     "editions": 800,
+     "matched": 5
+    },
+    {
+     "year": 1639,
+     "editions": 723,
+     "matched": 2
+    },
+    {
+     "year": 1640,
+     "editions": 1042,
+     "matched": 2
+    },
+    {
+     "year": 1641,
+     "editions": 2495,
+     "matched": 0
+    },
+    {
+     "year": 1642,
+     "editions": 4395,
+     "matched": 3
+    },
+    {
+     "year": 1643,
+     "editions": 2545,
+     "matched": 2
+    },
+    {
+     "year": 1644,
+     "editions": 2021,
+     "matched": 0
+    },
+    {
+     "year": 1645,
+     "editions": 1967,
+     "matched": 3
+    },
+    {
+     "year": 1646,
+     "editions": 1770,
+     "matched": 1
+    },
+    {
+     "year": 1647,
+     "editions": 2317,
+     "matched": 3
+    },
+    {
+     "year": 1648,
+     "editions": 3169,
+     "matched": 4
+    },
+    {
+     "year": 1649,
+     "editions": 2392,
+     "matched": 4
+    },
+    {
+     "year": 1650,
+     "editions": 2421,
+     "matched": 5
+    },
+    {
+     "year": 1651,
+     "editions": 975,
+     "matched": 2
+    },
+    {
+     "year": 1652,
+     "editions": 1314,
+     "matched": 1
+    },
+    {
+     "year": 1653,
+     "editions": 2691,
+     "matched": 3
+    },
+    {
+     "year": 1654,
+     "editions": 1980,
+     "matched": 0
+    },
+    {
+     "year": 1655,
+     "editions": 1530,
+     "matched": 8
+    },
+    {
+     "year": 1656,
+     "editions": 1217,
+     "matched": 9
+    },
+    {
+     "year": 1657,
+     "editions": 1233,
+     "matched": 7
+    },
+    {
+     "year": 1658,
+     "editions": 1203,
+     "matched": 13
+    },
+    {
+     "year": 1659,
+     "editions": 2156,
+     "matched": 12
+    },
+    {
+     "year": 1660,
+     "editions": 3205,
+     "matched": 4
+    },
+    {
+     "year": 1661,
+     "editions": 1851,
+     "matched": 4
+    },
+    {
+     "year": 1662,
+     "editions": 1422,
+     "matched": 6
+    },
+    {
+     "year": 1663,
+     "editions": 1342,
+     "matched": 2
+    },
+    {
+     "year": 1664,
+     "editions": 1025,
+     "matched": 6
+    },
+    {
+     "year": 1665,
+     "editions": 1026,
+     "matched": 5
+    },
+    {
+     "year": 1666,
+     "editions": 846,
+     "matched": 5
+    },
+    {
+     "year": 1667,
+     "editions": 904,
+     "matched": 2
+    },
+    {
+     "year": 1668,
+     "editions": 839,
+     "matched": 4
+    },
+    {
+     "year": 1669,
+     "editions": 973,
+     "matched": 7
+    },
+    {
+     "year": 1670,
+     "editions": 1378,
+     "matched": 1
+    },
+    {
+     "year": 1671,
+     "editions": 1081,
+     "matched": 3
+    },
+    {
+     "year": 1672,
+     "editions": 1277,
+     "matched": 3
+    },
+    {
+     "year": 1673,
+     "editions": 1208,
+     "matched": 4
+    },
+    {
+     "year": 1674,
+     "editions": 1419,
+     "matched": 3
+    },
+    {
+     "year": 1675,
+     "editions": 1493,
+     "matched": 3
+    },
+    {
+     "year": 1676,
+     "editions": 1235,
+     "matched": 3
+    },
+    {
+     "year": 1677,
+     "editions": 1265,
+     "matched": 8
+    },
+    {
+     "year": 1678,
+     "editions": 1452,
+     "matched": 4
+    },
+    {
+     "year": 1679,
+     "editions": 2030,
+     "matched": 2
+    },
+    {
+     "year": 1680,
+     "editions": 5226,
+     "matched": 5
+    },
+    {
+     "year": 1681,
+     "editions": 2945,
+     "matched": 3
+    },
+    {
+     "year": 1682,
+     "editions": 2732,
+     "matched": 6
+    },
+    {
+     "year": 1683,
+     "editions": 2261,
+     "matched": 7
+    },
+    {
+     "year": 1684,
+     "editions": 2165,
+     "matched": 4
+    },
+    {
+     "year": 1685,
+     "editions": 2565,
+     "matched": 5
+    },
+    {
+     "year": 1686,
+     "editions": 1447,
+     "matched": 0
+    },
+    {
+     "year": 1687,
+     "editions": 1560,
+     "matched": 3
+    },
+    {
+     "year": 1688,
+     "editions": 2321,
+     "matched": 6
+    },
+    {
+     "year": 1689,
+     "editions": 3232,
+     "matched": 2
+    },
+    {
+     "year": 1690,
+     "editions": 3115,
+     "matched": 4
+    },
+    {
+     "year": 1691,
+     "editions": 2382,
+     "matched": 6
+    },
+    {
+     "year": 1692,
+     "editions": 2415,
+     "matched": 6
+    },
+    {
+     "year": 1693,
+     "editions": 2235,
+     "matched": 5
+    },
+    {
+     "year": 1694,
+     "editions": 2083,
+     "matched": 6
+    },
+    {
+     "year": 1695,
+     "editions": 3370,
+     "matched": 4
+    },
+    {
+     "year": 1696,
+     "editions": 3542,
+     "matched": 9
+    },
+    {
+     "year": 1697,
+     "editions": 2988,
+     "matched": 6
+    },
+    {
+     "year": 1698,
+     "editions": 3295,
+     "matched": 2
+    },
+    {
+     "year": 1699,
+     "editions": 3096,
+     "matched": 2
+    },
+    {
+     "year": 1700,
+     "editions": 3964,
+     "matched": 2
+    },
+    {
+     "year": 1703,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1711,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1712,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1719,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1730,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1735,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1744,
+     "editions": 1,
+     "matched": 0
+    }
+   ]
+  },
+  "fr": {
+   "label": "French",
+   "years": [
+    {
+     "year": 1465,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1472,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1473,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1474,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1475,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1476,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1477,
+     "editions": 48,
+     "matched": 0
+    },
+    {
+     "year": 1478,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1479,
+     "editions": 50,
+     "matched": 0
+    },
+    {
+     "year": 1480,
+     "editions": 63,
+     "matched": 0
+    },
+    {
+     "year": 1481,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1482,
+     "editions": 51,
+     "matched": 0
+    },
+    {
+     "year": 1483,
+     "editions": 66,
+     "matched": 0
+    },
+    {
+     "year": 1484,
+     "editions": 61,
+     "matched": 0
+    },
+    {
+     "year": 1485,
+     "editions": 101,
+     "matched": 0
+    },
+    {
+     "year": 1486,
+     "editions": 75,
+     "matched": 0
+    },
+    {
+     "year": 1487,
+     "editions": 73,
+     "matched": 0
+    },
+    {
+     "year": 1488,
+     "editions": 170,
+     "matched": 0
+    },
+    {
+     "year": 1489,
+     "editions": 89,
+     "matched": 0
+    },
+    {
+     "year": 1490,
+     "editions": 185,
+     "matched": 0
+    },
+    {
+     "year": 1491,
+     "editions": 138,
+     "matched": 0
+    },
+    {
+     "year": 1492,
+     "editions": 168,
+     "matched": 0
+    },
+    {
+     "year": 1493,
+     "editions": 189,
+     "matched": 2
+    },
+    {
+     "year": 1494,
+     "editions": 136,
+     "matched": 0
+    },
+    {
+     "year": 1495,
+     "editions": 274,
+     "matched": 1
+    },
+    {
+     "year": 1496,
+     "editions": 74,
+     "matched": 0
+    },
+    {
+     "year": 1497,
+     "editions": 139,
+     "matched": 0
+    },
+    {
+     "year": 1498,
+     "editions": 200,
+     "matched": 0
+    },
+    {
+     "year": 1499,
+     "editions": 203,
+     "matched": 0
+    },
+    {
+     "year": 1500,
+     "editions": 373,
+     "matched": 0
+    },
+    {
+     "year": 1501,
+     "editions": 116,
+     "matched": 0
+    },
+    {
+     "year": 1502,
+     "editions": 99,
+     "matched": 0
+    },
+    {
+     "year": 1503,
+     "editions": 115,
+     "matched": 0
+    },
+    {
+     "year": 1504,
+     "editions": 79,
+     "matched": 0
+    },
+    {
+     "year": 1505,
+     "editions": 208,
+     "matched": 0
+    },
+    {
+     "year": 1506,
+     "editions": 127,
+     "matched": 0
+    },
+    {
+     "year": 1507,
+     "editions": 144,
+     "matched": 0
+    },
+    {
+     "year": 1508,
+     "editions": 118,
+     "matched": 0
+    },
+    {
+     "year": 1509,
+     "editions": 135,
+     "matched": 0
+    },
+    {
+     "year": 1510,
+     "editions": 183,
+     "matched": 0
+    },
+    {
+     "year": 1511,
+     "editions": 79,
+     "matched": 0
+    },
+    {
+     "year": 1512,
+     "editions": 126,
+     "matched": 0
+    },
+    {
+     "year": 1513,
+     "editions": 104,
+     "matched": 0
+    },
+    {
+     "year": 1514,
+     "editions": 113,
+     "matched": 0
+    },
+    {
+     "year": 1515,
+     "editions": 201,
+     "matched": 0
+    },
+    {
+     "year": 1516,
+     "editions": 139,
+     "matched": 0
+    },
+    {
+     "year": 1517,
+     "editions": 105,
+     "matched": 0
+    },
+    {
+     "year": 1518,
+     "editions": 105,
+     "matched": 0
+    },
+    {
+     "year": 1519,
+     "editions": 102,
+     "matched": 0
+    },
+    {
+     "year": 1520,
+     "editions": 309,
+     "matched": 0
+    },
+    {
+     "year": 1521,
+     "editions": 146,
+     "matched": 2
+    },
+    {
+     "year": 1522,
+     "editions": 108,
+     "matched": 0
+    },
+    {
+     "year": 1523,
+     "editions": 83,
+     "matched": 1
+    },
+    {
+     "year": 1524,
+     "editions": 96,
+     "matched": 0
+    },
+    {
+     "year": 1525,
+     "editions": 199,
+     "matched": 0
+    },
+    {
+     "year": 1526,
+     "editions": 88,
+     "matched": 3
+    },
+    {
+     "year": 1527,
+     "editions": 162,
+     "matched": 0
+    },
+    {
+     "year": 1528,
+     "editions": 184,
+     "matched": 1
+    },
+    {
+     "year": 1529,
+     "editions": 284,
+     "matched": 1
+    },
+    {
+     "year": 1530,
+     "editions": 463,
+     "matched": 0
+    },
+    {
+     "year": 1531,
+     "editions": 233,
+     "matched": 1
+    },
+    {
+     "year": 1532,
+     "editions": 231,
+     "matched": 0
+    },
+    {
+     "year": 1533,
+     "editions": 213,
+     "matched": 0
+    },
+    {
+     "year": 1534,
+     "editions": 204,
+     "matched": 1
+    },
+    {
+     "year": 1535,
+     "editions": 230,
+     "matched": 0
+    },
+    {
+     "year": 1536,
+     "editions": 263,
+     "matched": 0
+    },
+    {
+     "year": 1537,
+     "editions": 281,
+     "matched": 0
+    },
+    {
+     "year": 1538,
+     "editions": 323,
+     "matched": 0
+    },
+    {
+     "year": 1539,
+     "editions": 395,
+     "matched": 0
+    },
+    {
+     "year": 1540,
+     "editions": 511,
+     "matched": 0
+    },
+    {
+     "year": 1541,
+     "editions": 299,
+     "matched": 0
+    },
+    {
+     "year": 1542,
+     "editions": 362,
+     "matched": 0
+    },
+    {
+     "year": 1543,
+     "editions": 415,
+     "matched": 4
+    },
+    {
+     "year": 1544,
+     "editions": 450,
+     "matched": 2
+    },
+    {
+     "year": 1545,
+     "editions": 356,
+     "matched": 1
+    },
+    {
+     "year": 1546,
+     "editions": 299,
+     "matched": 2
+    },
+    {
+     "year": 1547,
+     "editions": 378,
+     "matched": 1
+    },
+    {
+     "year": 1548,
+     "editions": 365,
+     "matched": 0
+    },
+    {
+     "year": 1549,
+     "editions": 405,
+     "matched": 5
+    },
+    {
+     "year": 1550,
+     "editions": 523,
+     "matched": 0
+    },
+    {
+     "year": 1551,
+     "editions": 446,
+     "matched": 2
+    },
+    {
+     "year": 1552,
+     "editions": 490,
+     "matched": 2
+    },
+    {
+     "year": 1553,
+     "editions": 456,
+     "matched": 1
+    },
+    {
+     "year": 1554,
+     "editions": 444,
+     "matched": 1
+    },
+    {
+     "year": 1555,
+     "editions": 589,
+     "matched": 3
+    },
+    {
+     "year": 1556,
+     "editions": 594,
+     "matched": 1
+    },
+    {
+     "year": 1557,
+     "editions": 510,
+     "matched": 4
+    },
+    {
+     "year": 1558,
+     "editions": 604,
+     "matched": 3
+    },
+    {
+     "year": 1559,
+     "editions": 682,
+     "matched": 1
+    },
+    {
+     "year": 1560,
+     "editions": 760,
+     "matched": 2
+    },
+    {
+     "year": 1561,
+     "editions": 1018,
+     "matched": 4
+    },
+    {
+     "year": 1562,
+     "editions": 816,
+     "matched": 0
+    },
+    {
+     "year": 1563,
+     "editions": 831,
+     "matched": 1
+    },
+    {
+     "year": 1564,
+     "editions": 796,
+     "matched": 1
+    },
+    {
+     "year": 1565,
+     "editions": 734,
+     "matched": 1
+    },
+    {
+     "year": 1566,
+     "editions": 650,
+     "matched": 3
+    },
+    {
+     "year": 1567,
+     "editions": 802,
+     "matched": 0
+    },
+    {
+     "year": 1568,
+     "editions": 766,
+     "matched": 0
+    },
+    {
+     "year": 1569,
+     "editions": 574,
+     "matched": 7
+    },
+    {
+     "year": 1570,
+     "editions": 577,
+     "matched": 0
+    },
+    {
+     "year": 1571,
+     "editions": 526,
+     "matched": 1
+    },
+    {
+     "year": 1572,
+     "editions": 755,
+     "matched": 1
+    },
+    {
+     "year": 1573,
+     "editions": 734,
+     "matched": 1
+    },
+    {
+     "year": 1574,
+     "editions": 791,
+     "matched": 1
+    },
+    {
+     "year": 1575,
+     "editions": 624,
+     "matched": 0
+    },
+    {
+     "year": 1576,
+     "editions": 576,
+     "matched": 1
+    },
+    {
+     "year": 1577,
+     "editions": 706,
+     "matched": 0
+    },
+    {
+     "year": 1578,
+     "editions": 862,
+     "matched": 0
+    },
+    {
+     "year": 1579,
+     "editions": 806,
+     "matched": 2
+    },
+    {
+     "year": 1580,
+     "editions": 720,
+     "matched": 1
+    },
+    {
+     "year": 1581,
+     "editions": 617,
+     "matched": 0
+    },
+    {
+     "year": 1582,
+     "editions": 780,
+     "matched": 4
+    },
+    {
+     "year": 1583,
+     "editions": 809,
+     "matched": 1
+    },
+    {
+     "year": 1584,
+     "editions": 592,
+     "matched": 0
+    },
+    {
+     "year": 1585,
+     "editions": 845,
+     "matched": 2
+    },
+    {
+     "year": 1586,
+     "editions": 820,
+     "matched": 0
+    },
+    {
+     "year": 1587,
+     "editions": 979,
+     "matched": 0
+    },
+    {
+     "year": 1588,
+     "editions": 1402,
+     "matched": 1
+    },
+    {
+     "year": 1589,
+     "editions": 1583,
+     "matched": 0
+    },
+    {
+     "year": 1590,
+     "editions": 802,
+     "matched": 0
+    },
+    {
+     "year": 1591,
+     "editions": 533,
+     "matched": 0
+    },
+    {
+     "year": 1592,
+     "editions": 391,
+     "matched": 0
+    },
+    {
+     "year": 1593,
+     "editions": 598,
+     "matched": 1
+    },
+    {
+     "year": 1594,
+     "editions": 954,
+     "matched": 1
+    },
+    {
+     "year": 1595,
+     "editions": 963,
+     "matched": 3
+    },
+    {
+     "year": 1596,
+     "editions": 898,
+     "matched": 4
+    },
+    {
+     "year": 1597,
+     "editions": 860,
+     "matched": 3
+    },
+    {
+     "year": 1598,
+     "editions": 870,
+     "matched": 2
+    },
+    {
+     "year": 1599,
+     "editions": 760,
+     "matched": 0
+    },
+    {
+     "year": 1600,
+     "editions": 1164,
+     "matched": 4
+    },
+    {
+     "year": 1601,
+     "editions": 639,
+     "matched": 0
+    },
+    {
+     "year": 1602,
+     "editions": 631,
+     "matched": 1
+    },
+    {
+     "year": 1603,
+     "editions": 610,
+     "matched": 2
+    },
+    {
+     "year": 1604,
+     "editions": 646,
+     "matched": 5
+    },
+    {
+     "year": 1605,
+     "editions": 554,
+     "matched": 5
+    },
+    {
+     "year": 1606,
+     "editions": 738,
+     "matched": 1
+    },
+    {
+     "year": 1607,
+     "editions": 599,
+     "matched": 0
+    },
+    {
+     "year": 1608,
+     "editions": 810,
+     "matched": 9
+    },
+    {
+     "year": 1609,
+     "editions": 863,
+     "matched": 1
+    },
+    {
+     "year": 1610,
+     "editions": 1289,
+     "matched": 0
+    },
+    {
+     "year": 1611,
+     "editions": 856,
+     "matched": 1
+    },
+    {
+     "year": 1612,
+     "editions": 819,
+     "matched": 3
+    },
+    {
+     "year": 1613,
+     "editions": 756,
+     "matched": 3
+    },
+    {
+     "year": 1614,
+     "editions": 1171,
+     "matched": 2
+    },
+    {
+     "year": 1615,
+     "editions": 1576,
+     "matched": 5
+    },
+    {
+     "year": 1616,
+     "editions": 1062,
+     "matched": 0
+    },
+    {
+     "year": 1617,
+     "editions": 1331,
+     "matched": 0
+    },
+    {
+     "year": 1618,
+     "editions": 1005,
+     "matched": 6
+    },
+    {
+     "year": 1619,
+     "editions": 1085,
+     "matched": 1
+    },
+    {
+     "year": 1620,
+     "editions": 1545,
+     "matched": 0
+    },
+    {
+     "year": 1621,
+     "editions": 1503,
+     "matched": 0
+    },
+    {
+     "year": 1622,
+     "editions": 1644,
+     "matched": 1
+    },
+    {
+     "year": 1623,
+     "editions": 1143,
+     "matched": 1
+    },
+    {
+     "year": 1624,
+     "editions": 1080,
+     "matched": 1
+    },
+    {
+     "year": 1625,
+     "editions": 1310,
+     "matched": 2
+    },
+    {
+     "year": 1626,
+     "editions": 1227,
+     "matched": 0
+    },
+    {
+     "year": 1627,
+     "editions": 1184,
+     "matched": 3
+    },
+    {
+     "year": 1628,
+     "editions": 1180,
+     "matched": 3
+    },
+    {
+     "year": 1629,
+     "editions": 1022,
+     "matched": 1
+    },
+    {
+     "year": 1630,
+     "editions": 885,
+     "matched": 0
+    },
+    {
+     "year": 1631,
+     "editions": 1084,
+     "matched": 0
+    },
+    {
+     "year": 1632,
+     "editions": 1127,
+     "matched": 3
+    },
+    {
+     "year": 1633,
+     "editions": 1242,
+     "matched": 2
+    },
+    {
+     "year": 1634,
+     "editions": 1337,
+     "matched": 3
+    },
+    {
+     "year": 1635,
+     "editions": 1407,
+     "matched": 2
+    },
+    {
+     "year": 1636,
+     "editions": 1221,
+     "matched": 3
+    },
+    {
+     "year": 1637,
+     "editions": 1196,
+     "matched": 7
+    },
+    {
+     "year": 1638,
+     "editions": 1076,
+     "matched": 0
+    },
+    {
+     "year": 1639,
+     "editions": 1189,
+     "matched": 2
+    },
+    {
+     "year": 1640,
+     "editions": 1305,
+     "matched": 3
+    },
+    {
+     "year": 1641,
+     "editions": 1182,
+     "matched": 3
+    },
+    {
+     "year": 1642,
+     "editions": 1228,
+     "matched": 4
+    },
+    {
+     "year": 1643,
+     "editions": 1543,
+     "matched": 1
+    },
+    {
+     "year": 1644,
+     "editions": 1439,
+     "matched": 1
+    },
+    {
+     "year": 1645,
+     "editions": 1345,
+     "matched": 2
+    },
+    {
+     "year": 1646,
+     "editions": 1310,
+     "matched": 4
+    },
+    {
+     "year": 1647,
+     "editions": 1517,
+     "matched": 1
+    },
+    {
+     "year": 1648,
+     "editions": 1583,
+     "matched": 5
+    },
+    {
+     "year": 1649,
+     "editions": 2616,
+     "matched": 2
+    },
+    {
+     "year": 1650,
+     "editions": 1681,
+     "matched": 3
+    },
+    {
+     "year": 1651,
+     "editions": 2718,
+     "matched": 2
+    },
+    {
+     "year": 1652,
+     "editions": 3191,
+     "matched": 1
+    },
+    {
+     "year": 1653,
+     "editions": 1660,
+     "matched": 0
+    },
+    {
+     "year": 1654,
+     "editions": 1739,
+     "matched": 0
+    },
+    {
+     "year": 1655,
+     "editions": 1828,
+     "matched": 0
+    },
+    {
+     "year": 1656,
+     "editions": 1755,
+     "matched": 6
+    },
+    {
+     "year": 1657,
+     "editions": 1832,
+     "matched": 4
+    },
+    {
+     "year": 1658,
+     "editions": 1878,
+     "matched": 7
+    },
+    {
+     "year": 1659,
+     "editions": 1914,
+     "matched": 11
+    },
+    {
+     "year": 1660,
+     "editions": 2159,
+     "matched": 1
+    },
+    {
+     "year": 1661,
+     "editions": 2517,
+     "matched": 0
+    },
+    {
+     "year": 1662,
+     "editions": 1974,
+     "matched": 0
+    },
+    {
+     "year": 1663,
+     "editions": 2075,
+     "matched": 0
+    },
+    {
+     "year": 1664,
+     "editions": 2276,
+     "matched": 0
+    },
+    {
+     "year": 1665,
+     "editions": 2353,
+     "matched": 1
+    },
+    {
+     "year": 1666,
+     "editions": 2478,
+     "matched": 3
+    },
+    {
+     "year": 1667,
+     "editions": 2452,
+     "matched": 3
+    },
+    {
+     "year": 1668,
+     "editions": 2663,
+     "matched": 1
+    },
+    {
+     "year": 1669,
+     "editions": 2555,
+     "matched": 1
+    },
+    {
+     "year": 1670,
+     "editions": 2337,
+     "matched": 2
+    },
+    {
+     "year": 1671,
+     "editions": 2453,
+     "matched": 0
+    },
+    {
+     "year": 1672,
+     "editions": 2453,
+     "matched": 0
+    },
+    {
+     "year": 1673,
+     "editions": 2366,
+     "matched": 3
+    },
+    {
+     "year": 1674,
+     "editions": 2166,
+     "matched": 0
+    },
+    {
+     "year": 1675,
+     "editions": 2218,
+     "matched": 0
+    },
+    {
+     "year": 1676,
+     "editions": 2180,
+     "matched": 0
+    },
+    {
+     "year": 1677,
+     "editions": 2611,
+     "matched": 0
+    },
+    {
+     "year": 1678,
+     "editions": 2270,
+     "matched": 0
+    },
+    {
+     "year": 1679,
+     "editions": 2206,
+     "matched": 4
+    },
+    {
+     "year": 1680,
+     "editions": 2399,
+     "matched": 1
+    },
+    {
+     "year": 1681,
+     "editions": 2249,
+     "matched": 3
+    },
+    {
+     "year": 1682,
+     "editions": 2529,
+     "matched": 5
+    },
+    {
+     "year": 1683,
+     "editions": 2592,
+     "matched": 4
+    },
+    {
+     "year": 1684,
+     "editions": 2357,
+     "matched": 15
+    },
+    {
+     "year": 1685,
+     "editions": 2642,
+     "matched": 5
+    },
+    {
+     "year": 1686,
+     "editions": 2535,
+     "matched": 2
+    },
+    {
+     "year": 1687,
+     "editions": 2460,
+     "matched": 2
+    },
+    {
+     "year": 1688,
+     "editions": 2828,
+     "matched": 4
+    },
+    {
+     "year": 1689,
+     "editions": 2714,
+     "matched": 5
+    },
+    {
+     "year": 1690,
+     "editions": 2996,
+     "matched": 1
+    },
+    {
+     "year": 1691,
+     "editions": 2777,
+     "matched": 1
+    },
+    {
+     "year": 1692,
+     "editions": 2846,
+     "matched": 2
+    },
+    {
+     "year": 1693,
+     "editions": 3229,
+     "matched": 0
+    },
+    {
+     "year": 1694,
+     "editions": 2864,
+     "matched": 5
+    },
+    {
+     "year": 1695,
+     "editions": 2820,
+     "matched": 6
+    },
+    {
+     "year": 1696,
+     "editions": 3226,
+     "matched": 0
+    },
+    {
+     "year": 1697,
+     "editions": 3310,
+     "matched": 2
+    },
+    {
+     "year": 1698,
+     "editions": 3207,
+     "matched": 0
+    },
+    {
+     "year": 1699,
+     "editions": 3411,
+     "matched": 2
+    },
+    {
+     "year": 1700,
+     "editions": 2136,
+     "matched": 2
+    }
+   ]
+  },
+  "de": {
+   "label": "German",
+   "years": [
+    {
+     "year": 1450,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1454,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1456,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1457,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1458,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1461,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1462,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1463,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1464,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1466,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1467,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1469,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1470,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1471,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1472,
+     "editions": 19,
+     "matched": 0
+    },
+    {
+     "year": 1473,
+     "editions": 37,
+     "matched": 1
+    },
+    {
+     "year": 1474,
+     "editions": 41,
+     "matched": 1
+    },
+    {
+     "year": 1475,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1476,
+     "editions": 53,
+     "matched": 0
+    },
+    {
+     "year": 1477,
+     "editions": 63,
+     "matched": 0
+    },
+    {
+     "year": 1478,
+     "editions": 63,
+     "matched": 0
+    },
+    {
+     "year": 1479,
+     "editions": 72,
+     "matched": 1
+    },
+    {
+     "year": 1480,
+     "editions": 97,
+     "matched": 0
+    },
+    {
+     "year": 1481,
+     "editions": 78,
+     "matched": 0
+    },
+    {
+     "year": 1482,
+     "editions": 134,
+     "matched": 1
+    },
+    {
+     "year": 1483,
+     "editions": 130,
+     "matched": 0
+    },
+    {
+     "year": 1484,
+     "editions": 71,
+     "matched": 0
+    },
+    {
+     "year": 1485,
+     "editions": 137,
+     "matched": 0
+    },
+    {
+     "year": 1486,
+     "editions": 98,
+     "matched": 0
+    },
+    {
+     "year": 1487,
+     "editions": 92,
+     "matched": 0
+    },
+    {
+     "year": 1488,
+     "editions": 140,
+     "matched": 3
+    },
+    {
+     "year": 1489,
+     "editions": 105,
+     "matched": 2
+    },
+    {
+     "year": 1490,
+     "editions": 152,
+     "matched": 0
+    },
+    {
+     "year": 1491,
+     "editions": 115,
+     "matched": 0
+    },
+    {
+     "year": 1492,
+     "editions": 152,
+     "matched": 0
+    },
+    {
+     "year": 1493,
+     "editions": 147,
+     "matched": 1
+    },
+    {
+     "year": 1494,
+     "editions": 108,
+     "matched": 0
+    },
+    {
+     "year": 1495,
+     "editions": 210,
+     "matched": 0
+    },
+    {
+     "year": 1496,
+     "editions": 152,
+     "matched": 0
+    },
+    {
+     "year": 1497,
+     "editions": 132,
+     "matched": 0
+    },
+    {
+     "year": 1498,
+     "editions": 127,
+     "matched": 0
+    },
+    {
+     "year": 1499,
+     "editions": 138,
+     "matched": 0
+    },
+    {
+     "year": 1500,
+     "editions": 324,
+     "matched": 1
+    },
+    {
+     "year": 1501,
+     "editions": 119,
+     "matched": 0
+    },
+    {
+     "year": 1502,
+     "editions": 78,
+     "matched": 0
+    },
+    {
+     "year": 1503,
+     "editions": 68,
+     "matched": 0
+    },
+    {
+     "year": 1504,
+     "editions": 79,
+     "matched": 0
+    },
+    {
+     "year": 1505,
+     "editions": 101,
+     "matched": 0
+    },
+    {
+     "year": 1506,
+     "editions": 78,
+     "matched": 0
+    },
+    {
+     "year": 1507,
+     "editions": 107,
+     "matched": 0
+    },
+    {
+     "year": 1508,
+     "editions": 114,
+     "matched": 0
+    },
+    {
+     "year": 1509,
+     "editions": 148,
+     "matched": 0
+    },
+    {
+     "year": 1510,
+     "editions": 222,
+     "matched": 0
+    },
+    {
+     "year": 1511,
+     "editions": 91,
+     "matched": 3
+    },
+    {
+     "year": 1512,
+     "editions": 191,
+     "matched": 1
+    },
+    {
+     "year": 1513,
+     "editions": 141,
+     "matched": 0
+    },
+    {
+     "year": 1514,
+     "editions": 166,
+     "matched": 0
+    },
+    {
+     "year": 1515,
+     "editions": 224,
+     "matched": 0
+    },
+    {
+     "year": 1516,
+     "editions": 153,
+     "matched": 0
+    },
+    {
+     "year": 1517,
+     "editions": 131,
+     "matched": 1
+    },
+    {
+     "year": 1518,
+     "editions": 212,
+     "matched": 1
+    },
+    {
+     "year": 1519,
+     "editions": 339,
+     "matched": 0
+    },
+    {
+     "year": 1520,
+     "editions": 648,
+     "matched": 2
+    },
+    {
+     "year": 1521,
+     "editions": 717,
+     "matched": 0
+    },
+    {
+     "year": 1522,
+     "editions": 878,
+     "matched": 0
+    },
+    {
+     "year": 1523,
+     "editions": 1185,
+     "matched": 1
+    },
+    {
+     "year": 1524,
+     "editions": 1205,
+     "matched": 0
+    },
+    {
+     "year": 1525,
+     "editions": 1136,
+     "matched": 2
+    },
+    {
+     "year": 1526,
+     "editions": 790,
+     "matched": 1
+    },
+    {
+     "year": 1527,
+     "editions": 510,
+     "matched": 3
+    },
+    {
+     "year": 1528,
+     "editions": 597,
+     "matched": 2
+    },
+    {
+     "year": 1529,
+     "editions": 677,
+     "matched": 0
+    },
+    {
+     "year": 1530,
+     "editions": 926,
+     "matched": 5
+    },
+    {
+     "year": 1531,
+     "editions": 548,
+     "matched": 0
+    },
+    {
+     "year": 1532,
+     "editions": 439,
+     "matched": 0
+    },
+    {
+     "year": 1533,
+     "editions": 396,
+     "matched": 1
+    },
+    {
+     "year": 1534,
+     "editions": 372,
+     "matched": 2
+    },
+    {
+     "year": 1535,
+     "editions": 687,
+     "matched": 0
+    },
+    {
+     "year": 1536,
+     "editions": 414,
+     "matched": 1
+    },
+    {
+     "year": 1537,
+     "editions": 410,
+     "matched": 3
+    },
+    {
+     "year": 1538,
+     "editions": 375,
+     "matched": 3
+    },
+    {
+     "year": 1539,
+     "editions": 409,
+     "matched": 1
+    },
+    {
+     "year": 1540,
+     "editions": 627,
+     "matched": 1
+    },
+    {
+     "year": 1541,
+     "editions": 395,
+     "matched": 0
+    },
+    {
+     "year": 1542,
+     "editions": 517,
+     "matched": 0
+    },
+    {
+     "year": 1543,
+     "editions": 477,
+     "matched": 0
+    },
+    {
+     "year": 1544,
+     "editions": 402,
+     "matched": 0
+    },
+    {
+     "year": 1545,
+     "editions": 669,
+     "matched": 0
+    },
+    {
+     "year": 1546,
+     "editions": 879,
+     "matched": 1
+    },
+    {
+     "year": 1547,
+     "editions": 384,
+     "matched": 1
+    },
+    {
+     "year": 1548,
+     "editions": 455,
+     "matched": 0
+    },
+    {
+     "year": 1549,
+     "editions": 396,
+     "matched": 3
+    },
+    {
+     "year": 1550,
+     "editions": 790,
+     "matched": 1
+    },
+    {
+     "year": 1551,
+     "editions": 475,
+     "matched": 1
+    },
+    {
+     "year": 1552,
+     "editions": 484,
+     "matched": 1
+    },
+    {
+     "year": 1553,
+     "editions": 493,
+     "matched": 0
+    },
+    {
+     "year": 1554,
+     "editions": 438,
+     "matched": 1
+    },
+    {
+     "year": 1555,
+     "editions": 699,
+     "matched": 1
+    },
+    {
+     "year": 1556,
+     "editions": 536,
+     "matched": 1
+    },
+    {
+     "year": 1557,
+     "editions": 522,
+     "matched": 0
+    },
+    {
+     "year": 1558,
+     "editions": 522,
+     "matched": 4
+    },
+    {
+     "year": 1559,
+     "editions": 544,
+     "matched": 1
+    },
+    {
+     "year": 1560,
+     "editions": 1146,
+     "matched": 7
+    },
+    {
+     "year": 1561,
+     "editions": 564,
+     "matched": 8
+    },
+    {
+     "year": 1562,
+     "editions": 669,
+     "matched": 13
+    },
+    {
+     "year": 1563,
+     "editions": 662,
+     "matched": 4
+    },
+    {
+     "year": 1564,
+     "editions": 592,
+     "matched": 3
+    },
+    {
+     "year": 1565,
+     "editions": 673,
+     "matched": 8
+    },
+    {
+     "year": 1566,
+     "editions": 692,
+     "matched": 7
+    },
+    {
+     "year": 1567,
+     "editions": 586,
+     "matched": 3
+    },
+    {
+     "year": 1568,
+     "editions": 612,
+     "matched": 1
+    },
+    {
+     "year": 1569,
+     "editions": 533,
+     "matched": 2
+    },
+    {
+     "year": 1570,
+     "editions": 836,
+     "matched": 3
+    },
+    {
+     "year": 1571,
+     "editions": 628,
+     "matched": 1
+    },
+    {
+     "year": 1572,
+     "editions": 559,
+     "matched": 1
+    },
+    {
+     "year": 1573,
+     "editions": 527,
+     "matched": 1
+    },
+    {
+     "year": 1574,
+     "editions": 503,
+     "matched": 3
+    },
+    {
+     "year": 1575,
+     "editions": 567,
+     "matched": 1
+    },
+    {
+     "year": 1576,
+     "editions": 511,
+     "matched": 0
+    },
+    {
+     "year": 1577,
+     "editions": 536,
+     "matched": 1
+    },
+    {
+     "year": 1578,
+     "editions": 619,
+     "matched": 0
+    },
+    {
+     "year": 1579,
+     "editions": 562,
+     "matched": 1
+    },
+    {
+     "year": 1580,
+     "editions": 777,
+     "matched": 0
+    },
+    {
+     "year": 1581,
+     "editions": 597,
+     "matched": 2
+    },
+    {
+     "year": 1582,
+     "editions": 612,
+     "matched": 1
+    },
+    {
+     "year": 1583,
+     "editions": 670,
+     "matched": 0
+    },
+    {
+     "year": 1584,
+     "editions": 649,
+     "matched": 1
+    },
+    {
+     "year": 1585,
+     "editions": 652,
+     "matched": 2
+    },
+    {
+     "year": 1586,
+     "editions": 703,
+     "matched": 2
+    },
+    {
+     "year": 1587,
+     "editions": 614,
+     "matched": 1
+    },
+    {
+     "year": 1588,
+     "editions": 747,
+     "matched": 1
+    },
+    {
+     "year": 1589,
+     "editions": 762,
+     "matched": 1
+    },
+    {
+     "year": 1590,
+     "editions": 933,
+     "matched": 3
+    },
+    {
+     "year": 1591,
+     "editions": 675,
+     "matched": 3
+    },
+    {
+     "year": 1592,
+     "editions": 896,
+     "matched": 0
+    },
+    {
+     "year": 1593,
+     "editions": 831,
+     "matched": 0
+    },
+    {
+     "year": 1594,
+     "editions": 744,
+     "matched": 0
+    },
+    {
+     "year": 1595,
+     "editions": 923,
+     "matched": 0
+    },
+    {
+     "year": 1596,
+     "editions": 844,
+     "matched": 9
+    },
+    {
+     "year": 1597,
+     "editions": 831,
+     "matched": 4
+    },
+    {
+     "year": 1598,
+     "editions": 808,
+     "matched": 1
+    },
+    {
+     "year": 1599,
+     "editions": 750,
+     "matched": 4
+    },
+    {
+     "year": 1600,
+     "editions": 809,
+     "matched": 0
+    },
+    {
+     "year": 1601,
+     "editions": 1020,
+     "matched": 0
+    },
+    {
+     "year": 1602,
+     "editions": 1024,
+     "matched": 0
+    },
+    {
+     "year": 1603,
+     "editions": 992,
+     "matched": 3
+    },
+    {
+     "year": 1604,
+     "editions": 838,
+     "matched": 5
+    },
+    {
+     "year": 1605,
+     "editions": 898,
+     "matched": 1
+    },
+    {
+     "year": 1606,
+     "editions": 942,
+     "matched": 1
+    },
+    {
+     "year": 1607,
+     "editions": 972,
+     "matched": 1
+    },
+    {
+     "year": 1608,
+     "editions": 936,
+     "matched": 9
+    },
+    {
+     "year": 1609,
+     "editions": 1165,
+     "matched": 0
+    },
+    {
+     "year": 1610,
+     "editions": 1372,
+     "matched": 8
+    },
+    {
+     "year": 1611,
+     "editions": 1217,
+     "matched": 9
+    },
+    {
+     "year": 1612,
+     "editions": 1311,
+     "matched": 5
+    },
+    {
+     "year": 1613,
+     "editions": 1175,
+     "matched": 1
+    },
+    {
+     "year": 1614,
+     "editions": 1262,
+     "matched": 19
+    },
+    {
+     "year": 1615,
+     "editions": 1378,
+     "matched": 6
+    },
+    {
+     "year": 1616,
+     "editions": 1451,
+     "matched": 17
+    },
+    {
+     "year": 1617,
+     "editions": 1562,
+     "matched": 10
+    },
+    {
+     "year": 1618,
+     "editions": 1755,
+     "matched": 17
+    },
+    {
+     "year": 1619,
+     "editions": 2319,
+     "matched": 19
+    },
+    {
+     "year": 1620,
+     "editions": 3238,
+     "matched": 10
+    },
+    {
+     "year": 1621,
+     "editions": 2426,
+     "matched": 3
+    },
+    {
+     "year": 1622,
+     "editions": 1964,
+     "matched": 7
+    },
+    {
+     "year": 1623,
+     "editions": 1783,
+     "matched": 2
+    },
+    {
+     "year": 1624,
+     "editions": 1566,
+     "matched": 2
+    },
+    {
+     "year": 1625,
+     "editions": 1969,
+     "matched": 6
+    },
+    {
+     "year": 1626,
+     "editions": 1627,
+     "matched": 0
+    },
+    {
+     "year": 1627,
+     "editions": 1554,
+     "matched": 0
+    },
+    {
+     "year": 1628,
+     "editions": 1595,
+     "matched": 5
+    },
+    {
+     "year": 1629,
+     "editions": 1795,
+     "matched": 0
+    },
+    {
+     "year": 1630,
+     "editions": 2328,
+     "matched": 1
+    },
+    {
+     "year": 1631,
+     "editions": 2839,
+     "matched": 2
+    },
+    {
+     "year": 1632,
+     "editions": 2622,
+     "matched": 0
+    },
+    {
+     "year": 1633,
+     "editions": 2281,
+     "matched": 1
+    },
+    {
+     "year": 1634,
+     "editions": 2137,
+     "matched": 1
+    },
+    {
+     "year": 1635,
+     "editions": 1998,
+     "matched": 2
+    },
+    {
+     "year": 1636,
+     "editions": 2156,
+     "matched": 1
+    },
+    {
+     "year": 1637,
+     "editions": 1886,
+     "matched": 0
+    },
+    {
+     "year": 1638,
+     "editions": 1825,
+     "matched": 2
+    },
+    {
+     "year": 1639,
+     "editions": 1460,
+     "matched": 1
+    },
+    {
+     "year": 1640,
+     "editions": 1765,
+     "matched": 3
+    },
+    {
+     "year": 1641,
+     "editions": 1493,
+     "matched": 3
+    },
+    {
+     "year": 1642,
+     "editions": 1611,
+     "matched": 0
+    },
+    {
+     "year": 1643,
+     "editions": 1967,
+     "matched": 1
+    },
+    {
+     "year": 1644,
+     "editions": 2062,
+     "matched": 1
+    },
+    {
+     "year": 1645,
+     "editions": 2146,
+     "matched": 2
+    },
+    {
+     "year": 1646,
+     "editions": 2435,
+     "matched": 0
+    },
+    {
+     "year": 1647,
+     "editions": 2333,
+     "matched": 2
+    },
+    {
+     "year": 1648,
+     "editions": 2515,
+     "matched": 1
+    },
+    {
+     "year": 1649,
+     "editions": 2194,
+     "matched": 0
+    },
+    {
+     "year": 1650,
+     "editions": 3045,
+     "matched": 7
+    },
+    {
+     "year": 1651,
+     "editions": 1869,
+     "matched": 4
+    },
+    {
+     "year": 1652,
+     "editions": 2174,
+     "matched": 7
+    },
+    {
+     "year": 1653,
+     "editions": 2035,
+     "matched": 0
+    },
+    {
+     "year": 1654,
+     "editions": 1845,
+     "matched": 1
+    },
+    {
+     "year": 1655,
+     "editions": 2223,
+     "matched": 2
+    },
+    {
+     "year": 1656,
+     "editions": 2175,
+     "matched": 3
+    },
+    {
+     "year": 1657,
+     "editions": 2547,
+     "matched": 6
+    },
+    {
+     "year": 1658,
+     "editions": 2937,
+     "matched": 8
+    },
+    {
+     "year": 1659,
+     "editions": 3002,
+     "matched": 5
+    },
+    {
+     "year": 1660,
+     "editions": 3004,
+     "matched": 9
+    },
+    {
+     "year": 1661,
+     "editions": 2336,
+     "matched": 4
+    },
+    {
+     "year": 1662,
+     "editions": 2332,
+     "matched": 2
+    },
+    {
+     "year": 1663,
+     "editions": 3112,
+     "matched": 5
+    },
+    {
+     "year": 1664,
+     "editions": 3253,
+     "matched": 5
+    },
+    {
+     "year": 1665,
+     "editions": 4134,
+     "matched": 1
+    },
+    {
+     "year": 1666,
+     "editions": 3604,
+     "matched": 4
+    },
+    {
+     "year": 1667,
+     "editions": 3396,
+     "matched": 2
+    },
+    {
+     "year": 1668,
+     "editions": 3856,
+     "matched": 1
+    },
+    {
+     "year": 1669,
+     "editions": 3690,
+     "matched": 2
+    },
+    {
+     "year": 1670,
+     "editions": 3526,
+     "matched": 1
+    },
+    {
+     "year": 1671,
+     "editions": 3469,
+     "matched": 0
+    },
+    {
+     "year": 1672,
+     "editions": 3867,
+     "matched": 1
+    },
+    {
+     "year": 1673,
+     "editions": 4693,
+     "matched": 1
+    },
+    {
+     "year": 1674,
+     "editions": 4256,
+     "matched": 0
+    },
+    {
+     "year": 1675,
+     "editions": 4473,
+     "matched": 3
+    },
+    {
+     "year": 1676,
+     "editions": 4593,
+     "matched": 5
+    },
+    {
+     "year": 1677,
+     "editions": 4575,
+     "matched": 1
+    },
+    {
+     "year": 1678,
+     "editions": 4035,
+     "matched": 0
+    },
+    {
+     "year": 1679,
+     "editions": 3959,
+     "matched": 1
+    },
+    {
+     "year": 1680,
+     "editions": 4173,
+     "matched": 1
+    },
+    {
+     "year": 1681,
+     "editions": 3792,
+     "matched": 7
+    },
+    {
+     "year": 1682,
+     "editions": 3468,
+     "matched": 10
+    },
+    {
+     "year": 1683,
+     "editions": 4488,
+     "matched": 0
+    },
+    {
+     "year": 1684,
+     "editions": 4857,
+     "matched": 4
+    },
+    {
+     "year": 1685,
+     "editions": 4890,
+     "matched": 3
+    },
+    {
+     "year": 1686,
+     "editions": 5007,
+     "matched": 3
+    },
+    {
+     "year": 1687,
+     "editions": 4908,
+     "matched": 2
+    },
+    {
+     "year": 1688,
+     "editions": 5052,
+     "matched": 0
+    },
+    {
+     "year": 1689,
+     "editions": 5258,
+     "matched": 0
+    },
+    {
+     "year": 1690,
+     "editions": 5305,
+     "matched": 4
+    },
+    {
+     "year": 1691,
+     "editions": 5081,
+     "matched": 4
+    },
+    {
+     "year": 1692,
+     "editions": 5004,
+     "matched": 2
+    },
+    {
+     "year": 1693,
+     "editions": 5243,
+     "matched": 3
+    },
+    {
+     "year": 1694,
+     "editions": 4622,
+     "matched": 1
+    },
+    {
+     "year": 1695,
+     "editions": 4432,
+     "matched": 1
+    },
+    {
+     "year": 1696,
+     "editions": 4482,
+     "matched": 2
+    },
+    {
+     "year": 1697,
+     "editions": 5274,
+     "matched": 0
+    },
+    {
+     "year": 1698,
+     "editions": 4823,
+     "matched": 4
+    },
+    {
+     "year": 1699,
+     "editions": 4967,
+     "matched": 3
+    },
+    {
+     "year": 1700,
+     "editions": 3440,
+     "matched": 6
+    },
+    {
+     "year": 1708,
+     "editions": 1,
+     "matched": 0
+    }
+   ]
+  },
+  "el": {
+   "label": "Greek",
+   "years": [
+    {
+     "year": 1471,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1475,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1478,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1480,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1481,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1483,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1484,
+     "editions": 1,
+     "matched": 1
+    },
+    {
+     "year": 1485,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1486,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1487,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1488,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1489,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1490,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1492,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1493,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1494,
+     "editions": 2,
+     "matched": 1
+    },
+    {
+     "year": 1495,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1496,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1497,
+     "editions": 4,
+     "matched": 2
+    },
+    {
+     "year": 1498,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1499,
+     "editions": 4,
+     "matched": 2
+    },
+    {
+     "year": 1500,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1501,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1502,
+     "editions": 10,
+     "matched": 1
+    },
+    {
+     "year": 1503,
+     "editions": 8,
+     "matched": 1
+    },
+    {
+     "year": 1504,
+     "editions": 5,
+     "matched": 1
+    },
+    {
+     "year": 1505,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1506,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1507,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1508,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1509,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1510,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1511,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1512,
+     "editions": 22,
+     "matched": 1
+    },
+    {
+     "year": 1513,
+     "editions": 17,
+     "matched": 1
+    },
+    {
+     "year": 1514,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1515,
+     "editions": 25,
+     "matched": 1
+    },
+    {
+     "year": 1516,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1517,
+     "editions": 31,
+     "matched": 1
+    },
+    {
+     "year": 1518,
+     "editions": 29,
+     "matched": 2
+    },
+    {
+     "year": 1519,
+     "editions": 26,
+     "matched": 3
+    },
+    {
+     "year": 1520,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1521,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1522,
+     "editions": 35,
+     "matched": 0
+    },
+    {
+     "year": 1523,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1524,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1525,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1526,
+     "editions": 28,
+     "matched": 1
+    },
+    {
+     "year": 1527,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1528,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1529,
+     "editions": 50,
+     "matched": 0
+    },
+    {
+     "year": 1530,
+     "editions": 79,
+     "matched": 0
+    },
+    {
+     "year": 1531,
+     "editions": 56,
+     "matched": 1
+    },
+    {
+     "year": 1532,
+     "editions": 51,
+     "matched": 4
+    },
+    {
+     "year": 1533,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1534,
+     "editions": 46,
+     "matched": 1
+    },
+    {
+     "year": 1535,
+     "editions": 50,
+     "matched": 3
+    },
+    {
+     "year": 1536,
+     "editions": 69,
+     "matched": 1
+    },
+    {
+     "year": 1537,
+     "editions": 52,
+     "matched": 2
+    },
+    {
+     "year": 1538,
+     "editions": 70,
+     "matched": 1
+    },
+    {
+     "year": 1539,
+     "editions": 64,
+     "matched": 3
+    },
+    {
+     "year": 1540,
+     "editions": 86,
+     "matched": 4
+    },
+    {
+     "year": 1541,
+     "editions": 60,
+     "matched": 0
+    },
+    {
+     "year": 1542,
+     "editions": 70,
+     "matched": 2
+    },
+    {
+     "year": 1543,
+     "editions": 88,
+     "matched": 0
+    },
+    {
+     "year": 1544,
+     "editions": 83,
+     "matched": 2
+    },
+    {
+     "year": 1545,
+     "editions": 77,
+     "matched": 0
+    },
+    {
+     "year": 1546,
+     "editions": 73,
+     "matched": 2
+    },
+    {
+     "year": 1547,
+     "editions": 63,
+     "matched": 1
+    },
+    {
+     "year": 1548,
+     "editions": 64,
+     "matched": 1
+    },
+    {
+     "year": 1549,
+     "editions": 83,
+     "matched": 0
+    },
+    {
+     "year": 1550,
+     "editions": 86,
+     "matched": 0
+    },
+    {
+     "year": 1551,
+     "editions": 70,
+     "matched": 2
+    },
+    {
+     "year": 1552,
+     "editions": 71,
+     "matched": 1
+    },
+    {
+     "year": 1553,
+     "editions": 60,
+     "matched": 1
+    },
+    {
+     "year": 1554,
+     "editions": 60,
+     "matched": 1
+    },
+    {
+     "year": 1555,
+     "editions": 86,
+     "matched": 0
+    },
+    {
+     "year": 1556,
+     "editions": 62,
+     "matched": 0
+    },
+    {
+     "year": 1557,
+     "editions": 70,
+     "matched": 0
+    },
+    {
+     "year": 1558,
+     "editions": 68,
+     "matched": 0
+    },
+    {
+     "year": 1559,
+     "editions": 56,
+     "matched": 0
+    },
+    {
+     "year": 1560,
+     "editions": 52,
+     "matched": 1
+    },
+    {
+     "year": 1561,
+     "editions": 52,
+     "matched": 0
+    },
+    {
+     "year": 1562,
+     "editions": 60,
+     "matched": 1
+    },
+    {
+     "year": 1563,
+     "editions": 61,
+     "matched": 1
+    },
+    {
+     "year": 1564,
+     "editions": 53,
+     "matched": 0
+    },
+    {
+     "year": 1565,
+     "editions": 43,
+     "matched": 3
+    },
+    {
+     "year": 1566,
+     "editions": 66,
+     "matched": 1
+    },
+    {
+     "year": 1567,
+     "editions": 62,
+     "matched": 0
+    },
+    {
+     "year": 1568,
+     "editions": 61,
+     "matched": 1
+    },
+    {
+     "year": 1569,
+     "editions": 54,
+     "matched": 0
+    },
+    {
+     "year": 1570,
+     "editions": 77,
+     "matched": 2
+    },
+    {
+     "year": 1571,
+     "editions": 51,
+     "matched": 0
+    },
+    {
+     "year": 1572,
+     "editions": 55,
+     "matched": 0
+    },
+    {
+     "year": 1573,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1574,
+     "editions": 48,
+     "matched": 1
+    },
+    {
+     "year": 1575,
+     "editions": 59,
+     "matched": 0
+    },
+    {
+     "year": 1576,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1577,
+     "editions": 44,
+     "matched": 0
+    },
+    {
+     "year": 1578,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1579,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1580,
+     "editions": 76,
+     "matched": 0
+    },
+    {
+     "year": 1581,
+     "editions": 60,
+     "matched": 1
+    },
+    {
+     "year": 1582,
+     "editions": 65,
+     "matched": 0
+    },
+    {
+     "year": 1583,
+     "editions": 49,
+     "matched": 1
+    },
+    {
+     "year": 1584,
+     "editions": 63,
+     "matched": 0
+    },
+    {
+     "year": 1585,
+     "editions": 52,
+     "matched": 0
+    },
+    {
+     "year": 1586,
+     "editions": 60,
+     "matched": 0
+    },
+    {
+     "year": 1587,
+     "editions": 79,
+     "matched": 0
+    },
+    {
+     "year": 1588,
+     "editions": 85,
+     "matched": 0
+    },
+    {
+     "year": 1589,
+     "editions": 65,
+     "matched": 1
+    },
+    {
+     "year": 1590,
+     "editions": 54,
+     "matched": 1
+    },
+    {
+     "year": 1591,
+     "editions": 67,
+     "matched": 0
+    },
+    {
+     "year": 1592,
+     "editions": 67,
+     "matched": 1
+    },
+    {
+     "year": 1593,
+     "editions": 78,
+     "matched": 1
+    },
+    {
+     "year": 1594,
+     "editions": 68,
+     "matched": 0
+    },
+    {
+     "year": 1595,
+     "editions": 63,
+     "matched": 0
+    },
+    {
+     "year": 1596,
+     "editions": 57,
+     "matched": 0
+    },
+    {
+     "year": 1597,
+     "editions": 48,
+     "matched": 0
+    },
+    {
+     "year": 1598,
+     "editions": 78,
+     "matched": 0
+    },
+    {
+     "year": 1599,
+     "editions": 69,
+     "matched": 0
+    },
+    {
+     "year": 1600,
+     "editions": 88,
+     "matched": 0
+    },
+    {
+     "year": 1601,
+     "editions": 88,
+     "matched": 1
+    },
+    {
+     "year": 1602,
+     "editions": 91,
+     "matched": 0
+    },
+    {
+     "year": 1603,
+     "editions": 78,
+     "matched": 0
+    },
+    {
+     "year": 1604,
+     "editions": 108,
+     "matched": 0
+    },
+    {
+     "year": 1605,
+     "editions": 79,
+     "matched": 2
+    },
+    {
+     "year": 1606,
+     "editions": 91,
+     "matched": 0
+    },
+    {
+     "year": 1607,
+     "editions": 67,
+     "matched": 0
+    },
+    {
+     "year": 1608,
+     "editions": 69,
+     "matched": 0
+    },
+    {
+     "year": 1609,
+     "editions": 92,
+     "matched": 1
+    },
+    {
+     "year": 1610,
+     "editions": 88,
+     "matched": 1
+    },
+    {
+     "year": 1611,
+     "editions": 86,
+     "matched": 0
+    },
+    {
+     "year": 1612,
+     "editions": 98,
+     "matched": 0
+    },
+    {
+     "year": 1613,
+     "editions": 88,
+     "matched": 1
+    },
+    {
+     "year": 1614,
+     "editions": 92,
+     "matched": 2
+    },
+    {
+     "year": 1615,
+     "editions": 80,
+     "matched": 0
+    },
+    {
+     "year": 1616,
+     "editions": 68,
+     "matched": 2
+    },
+    {
+     "year": 1617,
+     "editions": 51,
+     "matched": 0
+    },
+    {
+     "year": 1618,
+     "editions": 105,
+     "matched": 0
+    },
+    {
+     "year": 1619,
+     "editions": 87,
+     "matched": 0
+    },
+    {
+     "year": 1620,
+     "editions": 89,
+     "matched": 0
+    },
+    {
+     "year": 1621,
+     "editions": 56,
+     "matched": 0
+    },
+    {
+     "year": 1622,
+     "editions": 60,
+     "matched": 0
+    },
+    {
+     "year": 1623,
+     "editions": 64,
+     "matched": 0
+    },
+    {
+     "year": 1624,
+     "editions": 66,
+     "matched": 0
+    },
+    {
+     "year": 1625,
+     "editions": 60,
+     "matched": 0
+    },
+    {
+     "year": 1626,
+     "editions": 54,
+     "matched": 0
+    },
+    {
+     "year": 1627,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1628,
+     "editions": 51,
+     "matched": 0
+    },
+    {
+     "year": 1629,
+     "editions": 52,
+     "matched": 0
+    },
+    {
+     "year": 1630,
+     "editions": 69,
+     "matched": 0
+    },
+    {
+     "year": 1631,
+     "editions": 48,
+     "matched": 0
+    },
+    {
+     "year": 1632,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1633,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1634,
+     "editions": 36,
+     "matched": 0
+    },
+    {
+     "year": 1635,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1636,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1637,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1638,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1639,
+     "editions": 45,
+     "matched": 0
+    },
+    {
+     "year": 1640,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1641,
+     "editions": 36,
+     "matched": 0
+    },
+    {
+     "year": 1642,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1643,
+     "editions": 52,
+     "matched": 0
+    },
+    {
+     "year": 1644,
+     "editions": 56,
+     "matched": 0
+    },
+    {
+     "year": 1645,
+     "editions": 53,
+     "matched": 0
+    },
+    {
+     "year": 1646,
+     "editions": 50,
+     "matched": 1
+    },
+    {
+     "year": 1647,
+     "editions": 56,
+     "matched": 0
+    },
+    {
+     "year": 1648,
+     "editions": 53,
+     "matched": 0
+    },
+    {
+     "year": 1649,
+     "editions": 72,
+     "matched": 0
+    },
+    {
+     "year": 1650,
+     "editions": 54,
+     "matched": 0
+    },
+    {
+     "year": 1651,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1652,
+     "editions": 39,
+     "matched": 1
+    },
+    {
+     "year": 1653,
+     "editions": 60,
+     "matched": 0
+    },
+    {
+     "year": 1654,
+     "editions": 43,
+     "matched": 1
+    },
+    {
+     "year": 1655,
+     "editions": 45,
+     "matched": 0
+    },
+    {
+     "year": 1656,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1657,
+     "editions": 61,
+     "matched": 0
+    },
+    {
+     "year": 1658,
+     "editions": 52,
+     "matched": 0
+    },
+    {
+     "year": 1659,
+     "editions": 52,
+     "matched": 0
+    },
+    {
+     "year": 1660,
+     "editions": 48,
+     "matched": 1
+    },
+    {
+     "year": 1661,
+     "editions": 44,
+     "matched": 0
+    },
+    {
+     "year": 1662,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1663,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1664,
+     "editions": 41,
+     "matched": 1
+    },
+    {
+     "year": 1665,
+     "editions": 44,
+     "matched": 2
+    },
+    {
+     "year": 1666,
+     "editions": 50,
+     "matched": 2
+    },
+    {
+     "year": 1667,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1668,
+     "editions": 63,
+     "matched": 0
+    },
+    {
+     "year": 1669,
+     "editions": 38,
+     "matched": 2
+    },
+    {
+     "year": 1670,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1671,
+     "editions": 36,
+     "matched": 0
+    },
+    {
+     "year": 1672,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1673,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1674,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1675,
+     "editions": 41,
+     "matched": 0
+    },
+    {
+     "year": 1676,
+     "editions": 41,
+     "matched": 0
+    },
+    {
+     "year": 1677,
+     "editions": 43,
+     "matched": 0
+    },
+    {
+     "year": 1678,
+     "editions": 43,
+     "matched": 1
+    },
+    {
+     "year": 1679,
+     "editions": 63,
+     "matched": 0
+    },
+    {
+     "year": 1680,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1681,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1682,
+     "editions": 52,
+     "matched": 0
+    },
+    {
+     "year": 1683,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1684,
+     "editions": 41,
+     "matched": 0
+    },
+    {
+     "year": 1685,
+     "editions": 76,
+     "matched": 0
+    },
+    {
+     "year": 1686,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1687,
+     "editions": 45,
+     "matched": 0
+    },
+    {
+     "year": 1688,
+     "editions": 50,
+     "matched": 1
+    },
+    {
+     "year": 1689,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1690,
+     "editions": 36,
+     "matched": 0
+    },
+    {
+     "year": 1691,
+     "editions": 35,
+     "matched": 0
+    },
+    {
+     "year": 1692,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1693,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1694,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1695,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1696,
+     "editions": 43,
+     "matched": 0
+    },
+    {
+     "year": 1697,
+     "editions": 56,
+     "matched": 0
+    },
+    {
+     "year": 1698,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1699,
+     "editions": 36,
+     "matched": 0
+    },
+    {
+     "year": 1700,
+     "editions": 31,
+     "matched": 0
+    }
+   ]
+  },
+  "he": {
+   "label": "Hebrew",
+   "years": [
+    {
+     "year": 1469,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1475,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1476,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1477,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1480,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1481,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1482,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1484,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1485,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1486,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1487,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1488,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1489,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1490,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1491,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1492,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1493,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1494,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1495,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1496,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1497,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1500,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1501,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1503,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1505,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1506,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1507,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1508,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1509,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1510,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1511,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1512,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1513,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1514,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1515,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1516,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1517,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1518,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1519,
+     "editions": 20,
+     "matched": 0
+    },
+    {
+     "year": 1520,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1521,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1522,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1523,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1524,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1525,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1526,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1527,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1528,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1529,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1530,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1531,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1532,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1533,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1534,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1535,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1536,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1537,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1538,
+     "editions": 17,
+     "matched": 0
+    },
+    {
+     "year": 1539,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1540,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1541,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1542,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1543,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1544,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1545,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1546,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1547,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1548,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1549,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1550,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1551,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1552,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1553,
+     "editions": 17,
+     "matched": 0
+    },
+    {
+     "year": 1554,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1555,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1556,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1557,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1558,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1559,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1560,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1561,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1562,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1563,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1564,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1565,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1566,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1567,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1568,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1569,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1570,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1571,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1572,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1573,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1574,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1575,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1576,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1577,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1578,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1579,
+     "editions": 31,
+     "matched": 0
+    },
+    {
+     "year": 1580,
+     "editions": 49,
+     "matched": 0
+    },
+    {
+     "year": 1581,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1582,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1583,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1584,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1585,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1586,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1587,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1588,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1589,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1590,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1591,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1592,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1593,
+     "editions": 31,
+     "matched": 0
+    },
+    {
+     "year": 1594,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1595,
+     "editions": 36,
+     "matched": 0
+    },
+    {
+     "year": 1596,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1597,
+     "editions": 49,
+     "matched": 0
+    },
+    {
+     "year": 1598,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1599,
+     "editions": 43,
+     "matched": 0
+    },
+    {
+     "year": 1600,
+     "editions": 45,
+     "matched": 0
+    },
+    {
+     "year": 1601,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1602,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1603,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1604,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1605,
+     "editions": 43,
+     "matched": 0
+    },
+    {
+     "year": 1606,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1607,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1608,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1609,
+     "editions": 50,
+     "matched": 0
+    },
+    {
+     "year": 1610,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1611,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1612,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1613,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1614,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1615,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1616,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1617,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1618,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1619,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1620,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1621,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1622,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1623,
+     "editions": 31,
+     "matched": 0
+    },
+    {
+     "year": 1624,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1625,
+     "editions": 19,
+     "matched": 0
+    },
+    {
+     "year": 1626,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1627,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1628,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1629,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1630,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1631,
+     "editions": 17,
+     "matched": 0
+    },
+    {
+     "year": 1632,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1633,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1634,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1635,
+     "editions": 17,
+     "matched": 0
+    },
+    {
+     "year": 1636,
+     "editions": 20,
+     "matched": 0
+    },
+    {
+     "year": 1637,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1638,
+     "editions": 20,
+     "matched": 0
+    },
+    {
+     "year": 1639,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1640,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1641,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1642,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1643,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1644,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1645,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1646,
+     "editions": 31,
+     "matched": 0
+    },
+    {
+     "year": 1647,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1648,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1649,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1650,
+     "editions": 72,
+     "matched": 0
+    },
+    {
+     "year": 1651,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1652,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1653,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1654,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1655,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1656,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1657,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1658,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1659,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1660,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1661,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1662,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1663,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1664,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1665,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1666,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1667,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1668,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1669,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1670,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1671,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1672,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1673,
+     "editions": 20,
+     "matched": 0
+    },
+    {
+     "year": 1674,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1675,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1676,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1677,
+     "editions": 19,
+     "matched": 0
+    },
+    {
+     "year": 1678,
+     "editions": 17,
+     "matched": 0
+    },
+    {
+     "year": 1679,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1680,
+     "editions": 19,
+     "matched": 0
+    },
+    {
+     "year": 1681,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1682,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1683,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1684,
+     "editions": 19,
+     "matched": 0
+    },
+    {
+     "year": 1685,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1686,
+     "editions": 20,
+     "matched": 0
+    },
+    {
+     "year": 1687,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1688,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1689,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1690,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1691,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1692,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1693,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1694,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1695,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1696,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1697,
+     "editions": 51,
+     "matched": 0
+    },
+    {
+     "year": 1698,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1699,
+     "editions": 59,
+     "matched": 0
+    },
+    {
+     "year": 1700,
+     "editions": 27,
+     "matched": 0
+    }
+   ]
+  },
+  "it": {
+   "label": "Italian",
+   "years": [
+    {
+     "year": 1455,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1469,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1470,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1471,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1472,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1473,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1474,
+     "editions": 23,
+     "matched": 1
+    },
+    {
+     "year": 1475,
+     "editions": 64,
+     "matched": 0
+    },
+    {
+     "year": 1476,
+     "editions": 32,
+     "matched": 1
+    },
+    {
+     "year": 1477,
+     "editions": 59,
+     "matched": 0
+    },
+    {
+     "year": 1478,
+     "editions": 50,
+     "matched": 0
+    },
+    {
+     "year": 1479,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1480,
+     "editions": 67,
+     "matched": 0
+    },
+    {
+     "year": 1481,
+     "editions": 65,
+     "matched": 1
+    },
+    {
+     "year": 1482,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1483,
+     "editions": 44,
+     "matched": 0
+    },
+    {
+     "year": 1484,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1485,
+     "editions": 58,
+     "matched": 0
+    },
+    {
+     "year": 1486,
+     "editions": 31,
+     "matched": 0
+    },
+    {
+     "year": 1487,
+     "editions": 69,
+     "matched": 0
+    },
+    {
+     "year": 1488,
+     "editions": 48,
+     "matched": 0
+    },
+    {
+     "year": 1489,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1490,
+     "editions": 153,
+     "matched": 0
+    },
+    {
+     "year": 1491,
+     "editions": 80,
+     "matched": 0
+    },
+    {
+     "year": 1492,
+     "editions": 119,
+     "matched": 0
+    },
+    {
+     "year": 1493,
+     "editions": 87,
+     "matched": 1
+    },
+    {
+     "year": 1494,
+     "editions": 93,
+     "matched": 3
+    },
+    {
+     "year": 1495,
+     "editions": 167,
+     "matched": 6
+    },
+    {
+     "year": 1496,
+     "editions": 95,
+     "matched": 2
+    },
+    {
+     "year": 1497,
+     "editions": 108,
+     "matched": 0
+    },
+    {
+     "year": 1498,
+     "editions": 67,
+     "matched": 0
+    },
+    {
+     "year": 1499,
+     "editions": 56,
+     "matched": 1
+    },
+    {
+     "year": 1500,
+     "editions": 321,
+     "matched": 0
+    },
+    {
+     "year": 1501,
+     "editions": 111,
+     "matched": 0
+    },
+    {
+     "year": 1502,
+     "editions": 66,
+     "matched": 2
+    },
+    {
+     "year": 1503,
+     "editions": 103,
+     "matched": 1
+    },
+    {
+     "year": 1504,
+     "editions": 71,
+     "matched": 0
+    },
+    {
+     "year": 1505,
+     "editions": 143,
+     "matched": 2
+    },
+    {
+     "year": 1506,
+     "editions": 63,
+     "matched": 1
+    },
+    {
+     "year": 1507,
+     "editions": 82,
+     "matched": 0
+    },
+    {
+     "year": 1508,
+     "editions": 97,
+     "matched": 0
+    },
+    {
+     "year": 1509,
+     "editions": 81,
+     "matched": 0
+    },
+    {
+     "year": 1510,
+     "editions": 182,
+     "matched": 0
+    },
+    {
+     "year": 1511,
+     "editions": 107,
+     "matched": 1
+    },
+    {
+     "year": 1512,
+     "editions": 105,
+     "matched": 1
+    },
+    {
+     "year": 1513,
+     "editions": 111,
+     "matched": 0
+    },
+    {
+     "year": 1514,
+     "editions": 120,
+     "matched": 2
+    },
+    {
+     "year": 1515,
+     "editions": 284,
+     "matched": 8
+    },
+    {
+     "year": 1516,
+     "editions": 124,
+     "matched": 3
+    },
+    {
+     "year": 1517,
+     "editions": 129,
+     "matched": 5
+    },
+    {
+     "year": 1518,
+     "editions": 182,
+     "matched": 2
+    },
+    {
+     "year": 1519,
+     "editions": 146,
+     "matched": 3
+    },
+    {
+     "year": 1520,
+     "editions": 267,
+     "matched": 0
+    },
+    {
+     "year": 1521,
+     "editions": 129,
+     "matched": 1
+    },
+    {
+     "year": 1522,
+     "editions": 128,
+     "matched": 1
+    },
+    {
+     "year": 1523,
+     "editions": 125,
+     "matched": 0
+    },
+    {
+     "year": 1524,
+     "editions": 168,
+     "matched": 1
+    },
+    {
+     "year": 1525,
+     "editions": 211,
+     "matched": 2
+    },
+    {
+     "year": 1526,
+     "editions": 166,
+     "matched": 0
+    },
+    {
+     "year": 1527,
+     "editions": 105,
+     "matched": 1
+    },
+    {
+     "year": 1528,
+     "editions": 97,
+     "matched": 3
+    },
+    {
+     "year": 1529,
+     "editions": 98,
+     "matched": 2
+    },
+    {
+     "year": 1530,
+     "editions": 231,
+     "matched": 0
+    },
+    {
+     "year": 1531,
+     "editions": 138,
+     "matched": 0
+    },
+    {
+     "year": 1532,
+     "editions": 142,
+     "matched": 1
+    },
+    {
+     "year": 1533,
+     "editions": 144,
+     "matched": 0
+    },
+    {
+     "year": 1534,
+     "editions": 154,
+     "matched": 0
+    },
+    {
+     "year": 1535,
+     "editions": 244,
+     "matched": 1
+    },
+    {
+     "year": 1536,
+     "editions": 183,
+     "matched": 0
+    },
+    {
+     "year": 1537,
+     "editions": 197,
+     "matched": 2
+    },
+    {
+     "year": 1538,
+     "editions": 228,
+     "matched": 0
+    },
+    {
+     "year": 1539,
+     "editions": 245,
+     "matched": 0
+    },
+    {
+     "year": 1540,
+     "editions": 277,
+     "matched": 0
+    },
+    {
+     "year": 1541,
+     "editions": 165,
+     "matched": 1
+    },
+    {
+     "year": 1542,
+     "editions": 209,
+     "matched": 0
+    },
+    {
+     "year": 1543,
+     "editions": 245,
+     "matched": 0
+    },
+    {
+     "year": 1544,
+     "editions": 295,
+     "matched": 4
+    },
+    {
+     "year": 1545,
+     "editions": 301,
+     "matched": 0
+    },
+    {
+     "year": 1546,
+     "editions": 263,
+     "matched": 0
+    },
+    {
+     "year": 1547,
+     "editions": 315,
+     "matched": 0
+    },
+    {
+     "year": 1548,
+     "editions": 280,
+     "matched": 0
+    },
+    {
+     "year": 1549,
+     "editions": 320,
+     "matched": 1
+    },
+    {
+     "year": 1550,
+     "editions": 684,
+     "matched": 4
+    },
+    {
+     "year": 1551,
+     "editions": 295,
+     "matched": 4
+    },
+    {
+     "year": 1552,
+     "editions": 295,
+     "matched": 2
+    },
+    {
+     "year": 1553,
+     "editions": 315,
+     "matched": 1
+    },
+    {
+     "year": 1554,
+     "editions": 383,
+     "matched": 2
+    },
+    {
+     "year": 1555,
+     "editions": 377,
+     "matched": 1
+    },
+    {
+     "year": 1556,
+     "editions": 340,
+     "matched": 1
+    },
+    {
+     "year": 1557,
+     "editions": 357,
+     "matched": 1
+    },
+    {
+     "year": 1558,
+     "editions": 446,
+     "matched": 2
+    },
+    {
+     "year": 1559,
+     "editions": 382,
+     "matched": 2
+    },
+    {
+     "year": 1560,
+     "editions": 547,
+     "matched": 0
+    },
+    {
+     "year": 1561,
+     "editions": 419,
+     "matched": 1
+    },
+    {
+     "year": 1562,
+     "editions": 484,
+     "matched": 1
+    },
+    {
+     "year": 1563,
+     "editions": 420,
+     "matched": 0
+    },
+    {
+     "year": 1564,
+     "editions": 480,
+     "matched": 0
+    },
+    {
+     "year": 1565,
+     "editions": 503,
+     "matched": 1
+    },
+    {
+     "year": 1566,
+     "editions": 566,
+     "matched": 0
+    },
+    {
+     "year": 1567,
+     "editions": 485,
+     "matched": 0
+    },
+    {
+     "year": 1568,
+     "editions": 535,
+     "matched": 1
+    },
+    {
+     "year": 1569,
+     "editions": 473,
+     "matched": 0
+    },
+    {
+     "year": 1570,
+     "editions": 533,
+     "matched": 4
+    },
+    {
+     "year": 1571,
+     "editions": 669,
+     "matched": 1
+    },
+    {
+     "year": 1572,
+     "editions": 602,
+     "matched": 2
+    },
+    {
+     "year": 1573,
+     "editions": 473,
+     "matched": 2
+    },
+    {
+     "year": 1574,
+     "editions": 608,
+     "matched": 0
+    },
+    {
+     "year": 1575,
+     "editions": 708,
+     "matched": 0
+    },
+    {
+     "year": 1576,
+     "editions": 690,
+     "matched": 1
+    },
+    {
+     "year": 1577,
+     "editions": 561,
+     "matched": 0
+    },
+    {
+     "year": 1578,
+     "editions": 599,
+     "matched": 1
+    },
+    {
+     "year": 1579,
+     "editions": 511,
+     "matched": 1
+    },
+    {
+     "year": 1580,
+     "editions": 656,
+     "matched": 1
+    },
+    {
+     "year": 1581,
+     "editions": 584,
+     "matched": 5
+    },
+    {
+     "year": 1582,
+     "editions": 608,
+     "matched": 2
+    },
+    {
+     "year": 1583,
+     "editions": 645,
+     "matched": 2
+    },
+    {
+     "year": 1584,
+     "editions": 752,
+     "matched": 8
+    },
+    {
+     "year": 1585,
+     "editions": 868,
+     "matched": 4
+    },
+    {
+     "year": 1586,
+     "editions": 842,
+     "matched": 1
+    },
+    {
+     "year": 1587,
+     "editions": 887,
+     "matched": 0
+    },
+    {
+     "year": 1588,
+     "editions": 991,
+     "matched": 2
+    },
+    {
+     "year": 1589,
+     "editions": 904,
+     "matched": 3
+    },
+    {
+     "year": 1590,
+     "editions": 932,
+     "matched": 4
+    },
+    {
+     "year": 1591,
+     "editions": 767,
+     "matched": 0
+    },
+    {
+     "year": 1592,
+     "editions": 749,
+     "matched": 0
+    },
+    {
+     "year": 1593,
+     "editions": 718,
+     "matched": 1
+    },
+    {
+     "year": 1594,
+     "editions": 704,
+     "matched": 0
+    },
+    {
+     "year": 1595,
+     "editions": 756,
+     "matched": 0
+    },
+    {
+     "year": 1596,
+     "editions": 744,
+     "matched": 2
+    },
+    {
+     "year": 1597,
+     "editions": 768,
+     "matched": 0
+    },
+    {
+     "year": 1598,
+     "editions": 898,
+     "matched": 5
+    },
+    {
+     "year": 1599,
+     "editions": 860,
+     "matched": 0
+    },
+    {
+     "year": 1600,
+     "editions": 895,
+     "matched": 0
+    },
+    {
+     "year": 1601,
+     "editions": 596,
+     "matched": 0
+    },
+    {
+     "year": 1602,
+     "editions": 577,
+     "matched": 1
+    },
+    {
+     "year": 1603,
+     "editions": 548,
+     "matched": 1
+    },
+    {
+     "year": 1604,
+     "editions": 567,
+     "matched": 0
+    },
+    {
+     "year": 1605,
+     "editions": 610,
+     "matched": 1
+    },
+    {
+     "year": 1606,
+     "editions": 815,
+     "matched": 1
+    },
+    {
+     "year": 1607,
+     "editions": 699,
+     "matched": 1
+    },
+    {
+     "year": 1608,
+     "editions": 659,
+     "matched": 0
+    },
+    {
+     "year": 1609,
+     "editions": 645,
+     "matched": 2
+    },
+    {
+     "year": 1610,
+     "editions": 746,
+     "matched": 0
+    },
+    {
+     "year": 1611,
+     "editions": 585,
+     "matched": 0
+    },
+    {
+     "year": 1612,
+     "editions": 581,
+     "matched": 4
+    },
+    {
+     "year": 1613,
+     "editions": 649,
+     "matched": 5
+    },
+    {
+     "year": 1614,
+     "editions": 642,
+     "matched": 3
+    },
+    {
+     "year": 1615,
+     "editions": 669,
+     "matched": 2
+    },
+    {
+     "year": 1616,
+     "editions": 628,
+     "matched": 1
+    },
+    {
+     "year": 1617,
+     "editions": 620,
+     "matched": 2
+    },
+    {
+     "year": 1618,
+     "editions": 617,
+     "matched": 6
+    },
+    {
+     "year": 1619,
+     "editions": 667,
+     "matched": 2
+    },
+    {
+     "year": 1620,
+     "editions": 777,
+     "matched": 0
+    },
+    {
+     "year": 1621,
+     "editions": 750,
+     "matched": 0
+    },
+    {
+     "year": 1622,
+     "editions": 712,
+     "matched": 2
+    },
+    {
+     "year": 1623,
+     "editions": 610,
+     "matched": 1
+    },
+    {
+     "year": 1624,
+     "editions": 592,
+     "matched": 1
+    },
+    {
+     "year": 1625,
+     "editions": 702,
+     "matched": 0
+    },
+    {
+     "year": 1626,
+     "editions": 602,
+     "matched": 0
+    },
+    {
+     "year": 1627,
+     "editions": 718,
+     "matched": 0
+    },
+    {
+     "year": 1628,
+     "editions": 810,
+     "matched": 1
+    },
+    {
+     "year": 1629,
+     "editions": 719,
+     "matched": 5
+    },
+    {
+     "year": 1630,
+     "editions": 621,
+     "matched": 0
+    },
+    {
+     "year": 1631,
+     "editions": 382,
+     "matched": 0
+    },
+    {
+     "year": 1632,
+     "editions": 535,
+     "matched": 1
+    },
+    {
+     "year": 1633,
+     "editions": 461,
+     "matched": 0
+    },
+    {
+     "year": 1634,
+     "editions": 508,
+     "matched": 0
+    },
+    {
+     "year": 1635,
+     "editions": 511,
+     "matched": 0
+    },
+    {
+     "year": 1636,
+     "editions": 503,
+     "matched": 0
+    },
+    {
+     "year": 1637,
+     "editions": 518,
+     "matched": 0
+    },
+    {
+     "year": 1638,
+     "editions": 553,
+     "matched": 1
+    },
+    {
+     "year": 1639,
+     "editions": 505,
+     "matched": 0
+    },
+    {
+     "year": 1640,
+     "editions": 608,
+     "matched": 1
+    },
+    {
+     "year": 1641,
+     "editions": 516,
+     "matched": 0
+    },
+    {
+     "year": 1642,
+     "editions": 524,
+     "matched": 0
+    },
+    {
+     "year": 1643,
+     "editions": 486,
+     "matched": 1
+    },
+    {
+     "year": 1644,
+     "editions": 578,
+     "matched": 2
+    },
+    {
+     "year": 1645,
+     "editions": 580,
+     "matched": 0
+    },
+    {
+     "year": 1646,
+     "editions": 548,
+     "matched": 0
+    },
+    {
+     "year": 1647,
+     "editions": 594,
+     "matched": 1
+    },
+    {
+     "year": 1648,
+     "editions": 587,
+     "matched": 0
+    },
+    {
+     "year": 1649,
+     "editions": 461,
+     "matched": 1
+    },
+    {
+     "year": 1650,
+     "editions": 586,
+     "matched": 0
+    },
+    {
+     "year": 1651,
+     "editions": 695,
+     "matched": 0
+    },
+    {
+     "year": 1652,
+     "editions": 595,
+     "matched": 0
+    },
+    {
+     "year": 1653,
+     "editions": 576,
+     "matched": 0
+    },
+    {
+     "year": 1654,
+     "editions": 566,
+     "matched": 0
+    },
+    {
+     "year": 1655,
+     "editions": 636,
+     "matched": 0
+    },
+    {
+     "year": 1656,
+     "editions": 756,
+     "matched": 0
+    },
+    {
+     "year": 1657,
+     "editions": 571,
+     "matched": 0
+    },
+    {
+     "year": 1658,
+     "editions": 553,
+     "matched": 0
+    },
+    {
+     "year": 1659,
+     "editions": 492,
+     "matched": 0
+    },
+    {
+     "year": 1660,
+     "editions": 582,
+     "matched": 0
+    },
+    {
+     "year": 1661,
+     "editions": 580,
+     "matched": 1
+    },
+    {
+     "year": 1662,
+     "editions": 578,
+     "matched": 0
+    },
+    {
+     "year": 1663,
+     "editions": 582,
+     "matched": 0
+    },
+    {
+     "year": 1664,
+     "editions": 728,
+     "matched": 2
+    },
+    {
+     "year": 1665,
+     "editions": 636,
+     "matched": 0
+    },
+    {
+     "year": 1666,
+     "editions": 784,
+     "matched": 1
+    },
+    {
+     "year": 1667,
+     "editions": 790,
+     "matched": 2
+    },
+    {
+     "year": 1668,
+     "editions": 839,
+     "matched": 3
+    },
+    {
+     "year": 1669,
+     "editions": 872,
+     "matched": 0
+    },
+    {
+     "year": 1670,
+     "editions": 884,
+     "matched": 0
+    },
+    {
+     "year": 1671,
+     "editions": 900,
+     "matched": 1
+    },
+    {
+     "year": 1672,
+     "editions": 784,
+     "matched": 0
+    },
+    {
+     "year": 1673,
+     "editions": 817,
+     "matched": 0
+    },
+    {
+     "year": 1674,
+     "editions": 818,
+     "matched": 2
+    },
+    {
+     "year": 1675,
+     "editions": 971,
+     "matched": 0
+    },
+    {
+     "year": 1676,
+     "editions": 808,
+     "matched": 0
+    },
+    {
+     "year": 1677,
+     "editions": 839,
+     "matched": 0
+    },
+    {
+     "year": 1678,
+     "editions": 910,
+     "matched": 0
+    },
+    {
+     "year": 1679,
+     "editions": 806,
+     "matched": 1
+    },
+    {
+     "year": 1680,
+     "editions": 869,
+     "matched": 0
+    },
+    {
+     "year": 1681,
+     "editions": 776,
+     "matched": 0
+    },
+    {
+     "year": 1682,
+     "editions": 758,
+     "matched": 0
+    },
+    {
+     "year": 1683,
+     "editions": 822,
+     "matched": 2
+    },
+    {
+     "year": 1684,
+     "editions": 891,
+     "matched": 0
+    },
+    {
+     "year": 1685,
+     "editions": 836,
+     "matched": 2
+    },
+    {
+     "year": 1686,
+     "editions": 921,
+     "matched": 0
+    },
+    {
+     "year": 1687,
+     "editions": 866,
+     "matched": 0
+    },
+    {
+     "year": 1688,
+     "editions": 902,
+     "matched": 0
+    },
+    {
+     "year": 1689,
+     "editions": 778,
+     "matched": 0
+    },
+    {
+     "year": 1690,
+     "editions": 980,
+     "matched": 0
+    },
+    {
+     "year": 1691,
+     "editions": 816,
+     "matched": 0
+    },
+    {
+     "year": 1692,
+     "editions": 766,
+     "matched": 0
+    },
+    {
+     "year": 1693,
+     "editions": 823,
+     "matched": 0
+    },
+    {
+     "year": 1694,
+     "editions": 736,
+     "matched": 0
+    },
+    {
+     "year": 1695,
+     "editions": 766,
+     "matched": 0
+    },
+    {
+     "year": 1696,
+     "editions": 763,
+     "matched": 0
+    },
+    {
+     "year": 1697,
+     "editions": 861,
+     "matched": 0
+    },
+    {
+     "year": 1698,
+     "editions": 901,
+     "matched": 2
+    },
+    {
+     "year": 1699,
+     "editions": 822,
+     "matched": 0
+    },
+    {
+     "year": 1700,
+     "editions": 605,
+     "matched": 0
+    },
+    {
+     "year": 1702,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1703,
+     "editions": 1,
+     "matched": 0
+    }
+   ]
+  },
+  "la": {
+   "label": "Latin",
+   "years": [
+    {
+     "year": 1453,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1454,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1455,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1456,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1457,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1458,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1459,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1460,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1461,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1462,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1463,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1464,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1465,
+     "editions": 201,
+     "matched": 0
+    },
+    {
+     "year": 1466,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1467,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1468,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1469,
+     "editions": 48,
+     "matched": 1
+    },
+    {
+     "year": 1470,
+     "editions": 198,
+     "matched": 0
+    },
+    {
+     "year": 1471,
+     "editions": 248,
+     "matched": 3
+    },
+    {
+     "year": 1472,
+     "editions": 342,
+     "matched": 2
+    },
+    {
+     "year": 1473,
+     "editions": 377,
+     "matched": 6
+    },
+    {
+     "year": 1474,
+     "editions": 439,
+     "matched": 3
+    },
+    {
+     "year": 1475,
+     "editions": 645,
+     "matched": 3
+    },
+    {
+     "year": 1476,
+     "editions": 424,
+     "matched": 5
+    },
+    {
+     "year": 1477,
+     "editions": 433,
+     "matched": 3
+    },
+    {
+     "year": 1478,
+     "editions": 487,
+     "matched": 6
+    },
+    {
+     "year": 1479,
+     "editions": 379,
+     "matched": 0
+    },
+    {
+     "year": 1480,
+     "editions": 675,
+     "matched": 1
+    },
+    {
+     "year": 1481,
+     "editions": 592,
+     "matched": 1
+    },
+    {
+     "year": 1482,
+     "editions": 545,
+     "matched": 6
+    },
+    {
+     "year": 1483,
+     "editions": 592,
+     "matched": 2
+    },
+    {
+     "year": 1484,
+     "editions": 464,
+     "matched": 1
+    },
+    {
+     "year": 1485,
+     "editions": 724,
+     "matched": 4
+    },
+    {
+     "year": 1486,
+     "editions": 595,
+     "matched": 5
+    },
+    {
+     "year": 1487,
+     "editions": 626,
+     "matched": 3
+    },
+    {
+     "year": 1488,
+     "editions": 779,
+     "matched": 3
+    },
+    {
+     "year": 1489,
+     "editions": 723,
+     "matched": 7
+    },
+    {
+     "year": 1490,
+     "editions": 1039,
+     "matched": 5
+    },
+    {
+     "year": 1491,
+     "editions": 667,
+     "matched": 4
+    },
+    {
+     "year": 1492,
+     "editions": 819,
+     "matched": 4
+    },
+    {
+     "year": 1493,
+     "editions": 775,
+     "matched": 6
+    },
+    {
+     "year": 1494,
+     "editions": 822,
+     "matched": 4
+    },
+    {
+     "year": 1495,
+     "editions": 1140,
+     "matched": 3
+    },
+    {
+     "year": 1496,
+     "editions": 816,
+     "matched": 7
+    },
+    {
+     "year": 1497,
+     "editions": 905,
+     "matched": 5
+    },
+    {
+     "year": 1498,
+     "editions": 924,
+     "matched": 3
+    },
+    {
+     "year": 1499,
+     "editions": 905,
+     "matched": 5
+    },
+    {
+     "year": 1500,
+     "editions": 1754,
+     "matched": 5
+    },
+    {
+     "year": 1501,
+     "editions": 972,
+     "matched": 2
+    },
+    {
+     "year": 1502,
+     "editions": 919,
+     "matched": 7
+    },
+    {
+     "year": 1503,
+     "editions": 912,
+     "matched": 9
+    },
+    {
+     "year": 1504,
+     "editions": 790,
+     "matched": 9
+    },
+    {
+     "year": 1505,
+     "editions": 1239,
+     "matched": 3
+    },
+    {
+     "year": 1506,
+     "editions": 975,
+     "matched": 7
+    },
+    {
+     "year": 1507,
+     "editions": 959,
+     "matched": 10
+    },
+    {
+     "year": 1508,
+     "editions": 1075,
+     "matched": 6
+    },
+    {
+     "year": 1509,
+     "editions": 1036,
+     "matched": 6
+    },
+    {
+     "year": 1510,
+     "editions": 1418,
+     "matched": 10
+    },
+    {
+     "year": 1511,
+     "editions": 1044,
+     "matched": 8
+    },
+    {
+     "year": 1512,
+     "editions": 1223,
+     "matched": 17
+    },
+    {
+     "year": 1513,
+     "editions": 1214,
+     "matched": 19
+    },
+    {
+     "year": 1514,
+     "editions": 1197,
+     "matched": 18
+    },
+    {
+     "year": 1515,
+     "editions": 1472,
+     "matched": 20
+    },
+    {
+     "year": 1516,
+     "editions": 1220,
+     "matched": 14
+    },
+    {
+     "year": 1517,
+     "editions": 1168,
+     "matched": 21
+    },
+    {
+     "year": 1518,
+     "editions": 1389,
+     "matched": 21
+    },
+    {
+     "year": 1519,
+     "editions": 1379,
+     "matched": 30
+    },
+    {
+     "year": 1520,
+     "editions": 1694,
+     "matched": 10
+    },
+    {
+     "year": 1521,
+     "editions": 1361,
+     "matched": 5
+    },
+    {
+     "year": 1522,
+     "editions": 1074,
+     "matched": 10
+    },
+    {
+     "year": 1523,
+     "editions": 1013,
+     "matched": 2
+    },
+    {
+     "year": 1524,
+     "editions": 1020,
+     "matched": 9
+    },
+    {
+     "year": 1525,
+     "editions": 973,
+     "matched": 5
+    },
+    {
+     "year": 1526,
+     "editions": 983,
+     "matched": 3
+    },
+    {
+     "year": 1527,
+     "editions": 960,
+     "matched": 14
+    },
+    {
+     "year": 1528,
+     "editions": 860,
+     "matched": 11
+    },
+    {
+     "year": 1529,
+     "editions": 987,
+     "matched": 13
+    },
+    {
+     "year": 1530,
+     "editions": 1123,
+     "matched": 14
+    },
+    {
+     "year": 1531,
+     "editions": 969,
+     "matched": 19
+    },
+    {
+     "year": 1532,
+     "editions": 939,
+     "matched": 16
+    },
+    {
+     "year": 1533,
+     "editions": 969,
+     "matched": 31
+    },
+    {
+     "year": 1534,
+     "editions": 1157,
+     "matched": 20
+    },
+    {
+     "year": 1535,
+     "editions": 1158,
+     "matched": 15
+    },
+    {
+     "year": 1536,
+     "editions": 1236,
+     "matched": 10
+    },
+    {
+     "year": 1537,
+     "editions": 1173,
+     "matched": 9
+    },
+    {
+     "year": 1538,
+     "editions": 1427,
+     "matched": 10
+    },
+    {
+     "year": 1539,
+     "editions": 1308,
+     "matched": 18
+    },
+    {
+     "year": 1540,
+     "editions": 1442,
+     "matched": 16
+    },
+    {
+     "year": 1541,
+     "editions": 1313,
+     "matched": 11
+    },
+    {
+     "year": 1542,
+     "editions": 1470,
+     "matched": 16
+    },
+    {
+     "year": 1543,
+     "editions": 1476,
+     "matched": 21
+    },
+    {
+     "year": 1544,
+     "editions": 1291,
+     "matched": 15
+    },
+    {
+     "year": 1545,
+     "editions": 1502,
+     "matched": 12
+    },
+    {
+     "year": 1546,
+     "editions": 1328,
+     "matched": 19
+    },
+    {
+     "year": 1547,
+     "editions": 1112,
+     "matched": 15
+    },
+    {
+     "year": 1548,
+     "editions": 1290,
+     "matched": 13
+    },
+    {
+     "year": 1549,
+     "editions": 1313,
+     "matched": 9
+    },
+    {
+     "year": 1550,
+     "editions": 1756,
+     "matched": 14
+    },
+    {
+     "year": 1551,
+     "editions": 1502,
+     "matched": 13
+    },
+    {
+     "year": 1552,
+     "editions": 1296,
+     "matched": 11
+    },
+    {
+     "year": 1553,
+     "editions": 1418,
+     "matched": 6
+    },
+    {
+     "year": 1554,
+     "editions": 1613,
+     "matched": 18
+    },
+    {
+     "year": 1555,
+     "editions": 1696,
+     "matched": 9
+    },
+    {
+     "year": 1556,
+     "editions": 1657,
+     "matched": 7
+    },
+    {
+     "year": 1557,
+     "editions": 1400,
+     "matched": 12
+    },
+    {
+     "year": 1558,
+     "editions": 1559,
+     "matched": 20
+    },
+    {
+     "year": 1559,
+     "editions": 1464,
+     "matched": 13
+    },
+    {
+     "year": 1560,
+     "editions": 1812,
+     "matched": 9
+    },
+    {
+     "year": 1561,
+     "editions": 1580,
+     "matched": 9
+    },
+    {
+     "year": 1562,
+     "editions": 1674,
+     "matched": 7
+    },
+    {
+     "year": 1563,
+     "editions": 1528,
+     "matched": 7
+    },
+    {
+     "year": 1564,
+     "editions": 1640,
+     "matched": 13
+    },
+    {
+     "year": 1565,
+     "editions": 1509,
+     "matched": 2
+    },
+    {
+     "year": 1566,
+     "editions": 1653,
+     "matched": 11
+    },
+    {
+     "year": 1567,
+     "editions": 1545,
+     "matched": 8
+    },
+    {
+     "year": 1568,
+     "editions": 1497,
+     "matched": 10
+    },
+    {
+     "year": 1569,
+     "editions": 1473,
+     "matched": 12
+    },
+    {
+     "year": 1570,
+     "editions": 1702,
+     "matched": 10
+    },
+    {
+     "year": 1571,
+     "editions": 1530,
+     "matched": 11
+    },
+    {
+     "year": 1572,
+     "editions": 1660,
+     "matched": 5
+    },
+    {
+     "year": 1573,
+     "editions": 1698,
+     "matched": 4
+    },
+    {
+     "year": 1574,
+     "editions": 1617,
+     "matched": 5
+    },
+    {
+     "year": 1575,
+     "editions": 1791,
+     "matched": 12
+    },
+    {
+     "year": 1576,
+     "editions": 1545,
+     "matched": 2
+    },
+    {
+     "year": 1577,
+     "editions": 1478,
+     "matched": 9
+    },
+    {
+     "year": 1578,
+     "editions": 1587,
+     "matched": 12
+    },
+    {
+     "year": 1579,
+     "editions": 1595,
+     "matched": 4
+    },
+    {
+     "year": 1580,
+     "editions": 1985,
+     "matched": 16
+    },
+    {
+     "year": 1581,
+     "editions": 1827,
+     "matched": 9
+    },
+    {
+     "year": 1582,
+     "editions": 1772,
+     "matched": 15
+    },
+    {
+     "year": 1583,
+     "editions": 1849,
+     "matched": 14
+    },
+    {
+     "year": 1584,
+     "editions": 2024,
+     "matched": 11
+    },
+    {
+     "year": 1585,
+     "editions": 2179,
+     "matched": 10
+    },
+    {
+     "year": 1586,
+     "editions": 2228,
+     "matched": 6
+    },
+    {
+     "year": 1587,
+     "editions": 2312,
+     "matched": 6
+    },
+    {
+     "year": 1588,
+     "editions": 2422,
+     "matched": 4
+    },
+    {
+     "year": 1589,
+     "editions": 2307,
+     "matched": 5
+    },
+    {
+     "year": 1590,
+     "editions": 2379,
+     "matched": 8
+    },
+    {
+     "year": 1591,
+     "editions": 2231,
+     "matched": 10
+    },
+    {
+     "year": 1592,
+     "editions": 2262,
+     "matched": 1
+    },
+    {
+     "year": 1593,
+     "editions": 2591,
+     "matched": 8
+    },
+    {
+     "year": 1594,
+     "editions": 2447,
+     "matched": 7
+    },
+    {
+     "year": 1595,
+     "editions": 2404,
+     "matched": 5
+    },
+    {
+     "year": 1596,
+     "editions": 2700,
+     "matched": 7
+    },
+    {
+     "year": 1597,
+     "editions": 2516,
+     "matched": 6
+    },
+    {
+     "year": 1598,
+     "editions": 2628,
+     "matched": 8
+    },
+    {
+     "year": 1599,
+     "editions": 2672,
+     "matched": 8
+    },
+    {
+     "year": 1600,
+     "editions": 3084,
+     "matched": 12
+    },
+    {
+     "year": 1601,
+     "editions": 3324,
+     "matched": 15
+    },
+    {
+     "year": 1602,
+     "editions": 2979,
+     "matched": 8
+    },
+    {
+     "year": 1603,
+     "editions": 2890,
+     "matched": 9
+    },
+    {
+     "year": 1604,
+     "editions": 2941,
+     "matched": 4
+    },
+    {
+     "year": 1605,
+     "editions": 2823,
+     "matched": 7
+    },
+    {
+     "year": 1606,
+     "editions": 3102,
+     "matched": 14
+    },
+    {
+     "year": 1607,
+     "editions": 3092,
+     "matched": 8
+    },
+    {
+     "year": 1608,
+     "editions": 3269,
+     "matched": 9
+    },
+    {
+     "year": 1609,
+     "editions": 3434,
+     "matched": 11
+    },
+    {
+     "year": 1610,
+     "editions": 3527,
+     "matched": 19
+    },
+    {
+     "year": 1611,
+     "editions": 3109,
+     "matched": 12
+    },
+    {
+     "year": 1612,
+     "editions": 3487,
+     "matched": 6
+    },
+    {
+     "year": 1613,
+     "editions": 3196,
+     "matched": 14
+    },
+    {
+     "year": 1614,
+     "editions": 3269,
+     "matched": 25
+    },
+    {
+     "year": 1615,
+     "editions": 3381,
+     "matched": 17
+    },
+    {
+     "year": 1616,
+     "editions": 3309,
+     "matched": 20
+    },
+    {
+     "year": 1617,
+     "editions": 3529,
+     "matched": 23
+    },
+    {
+     "year": 1618,
+     "editions": 3698,
+     "matched": 32
+    },
+    {
+     "year": 1619,
+     "editions": 3785,
+     "matched": 14
+    },
+    {
+     "year": 1620,
+     "editions": 3907,
+     "matched": 15
+    },
+    {
+     "year": 1621,
+     "editions": 3373,
+     "matched": 14
+    },
+    {
+     "year": 1622,
+     "editions": 3373,
+     "matched": 13
+    },
+    {
+     "year": 1623,
+     "editions": 3049,
+     "matched": 10
+    },
+    {
+     "year": 1624,
+     "editions": 3142,
+     "matched": 14
+    },
+    {
+     "year": 1625,
+     "editions": 3097,
+     "matched": 11
+    },
+    {
+     "year": 1626,
+     "editions": 2694,
+     "matched": 11
+    },
+    {
+     "year": 1627,
+     "editions": 2510,
+     "matched": 7
+    },
+    {
+     "year": 1628,
+     "editions": 2819,
+     "matched": 9
+    },
+    {
+     "year": 1629,
+     "editions": 2899,
+     "matched": 15
+    },
+    {
+     "year": 1630,
+     "editions": 2967,
+     "matched": 10
+    },
+    {
+     "year": 1631,
+     "editions": 2588,
+     "matched": 13
+    },
+    {
+     "year": 1632,
+     "editions": 2165,
+     "matched": 24
+    },
+    {
+     "year": 1633,
+     "editions": 2370,
+     "matched": 7
+    },
+    {
+     "year": 1634,
+     "editions": 2407,
+     "matched": 17
+    },
+    {
+     "year": 1635,
+     "editions": 2519,
+     "matched": 10
+    },
+    {
+     "year": 1636,
+     "editions": 2474,
+     "matched": 11
+    },
+    {
+     "year": 1637,
+     "editions": 2409,
+     "matched": 3
+    },
+    {
+     "year": 1638,
+     "editions": 2503,
+     "matched": 13
+    },
+    {
+     "year": 1639,
+     "editions": 2310,
+     "matched": 6
+    },
+    {
+     "year": 1640,
+     "editions": 2692,
+     "matched": 14
+    },
+    {
+     "year": 1641,
+     "editions": 2743,
+     "matched": 13
+    },
+    {
+     "year": 1642,
+     "editions": 2655,
+     "matched": 14
+    },
+    {
+     "year": 1643,
+     "editions": 2989,
+     "matched": 8
+    },
+    {
+     "year": 1644,
+     "editions": 3027,
+     "matched": 23
+    },
+    {
+     "year": 1645,
+     "editions": 3082,
+     "matched": 10
+    },
+    {
+     "year": 1646,
+     "editions": 3024,
+     "matched": 6
+    },
+    {
+     "year": 1647,
+     "editions": 3197,
+     "matched": 15
+    },
+    {
+     "year": 1648,
+     "editions": 3513,
+     "matched": 18
+    },
+    {
+     "year": 1649,
+     "editions": 3222,
+     "matched": 8
+    },
+    {
+     "year": 1650,
+     "editions": 3777,
+     "matched": 11
+    },
+    {
+     "year": 1651,
+     "editions": 3506,
+     "matched": 28
+    },
+    {
+     "year": 1652,
+     "editions": 3304,
+     "matched": 16
+    },
+    {
+     "year": 1653,
+     "editions": 3424,
+     "matched": 12
+    },
+    {
+     "year": 1654,
+     "editions": 3209,
+     "matched": 17
+    },
+    {
+     "year": 1655,
+     "editions": 3385,
+     "matched": 12
+    },
+    {
+     "year": 1656,
+     "editions": 3347,
+     "matched": 16
+    },
+    {
+     "year": 1657,
+     "editions": 3178,
+     "matched": 9
+    },
+    {
+     "year": 1658,
+     "editions": 3543,
+     "matched": 18
+    },
+    {
+     "year": 1659,
+     "editions": 3425,
+     "matched": 8
+    },
+    {
+     "year": 1660,
+     "editions": 3784,
+     "matched": 11
+    },
+    {
+     "year": 1661,
+     "editions": 3666,
+     "matched": 14
+    },
+    {
+     "year": 1662,
+     "editions": 3475,
+     "matched": 11
+    },
+    {
+     "year": 1663,
+     "editions": 3675,
+     "matched": 10
+    },
+    {
+     "year": 1664,
+     "editions": 3703,
+     "matched": 13
+    },
+    {
+     "year": 1665,
+     "editions": 3793,
+     "matched": 11
+    },
+    {
+     "year": 1666,
+     "editions": 3588,
+     "matched": 12
+    },
+    {
+     "year": 1667,
+     "editions": 3675,
+     "matched": 11
+    },
+    {
+     "year": 1668,
+     "editions": 3989,
+     "matched": 10
+    },
+    {
+     "year": 1669,
+     "editions": 3898,
+     "matched": 15
+    },
+    {
+     "year": 1670,
+     "editions": 4150,
+     "matched": 18
+    },
+    {
+     "year": 1671,
+     "editions": 3774,
+     "matched": 15
+    },
+    {
+     "year": 1672,
+     "editions": 3697,
+     "matched": 14
+    },
+    {
+     "year": 1673,
+     "editions": 3357,
+     "matched": 12
+    },
+    {
+     "year": 1674,
+     "editions": 3574,
+     "matched": 10
+    },
+    {
+     "year": 1675,
+     "editions": 3878,
+     "matched": 17
+    },
+    {
+     "year": 1676,
+     "editions": 3683,
+     "matched": 19
+    },
+    {
+     "year": 1677,
+     "editions": 3487,
+     "matched": 12
+    },
+    {
+     "year": 1678,
+     "editions": 3416,
+     "matched": 16
+    },
+    {
+     "year": 1679,
+     "editions": 3451,
+     "matched": 7
+    },
+    {
+     "year": 1680,
+     "editions": 3607,
+     "matched": 24
+    },
+    {
+     "year": 1681,
+     "editions": 3150,
+     "matched": 4
+    },
+    {
+     "year": 1682,
+     "editions": 3235,
+     "matched": 4
+    },
+    {
+     "year": 1683,
+     "editions": 3270,
+     "matched": 5
+    },
+    {
+     "year": 1684,
+     "editions": 3539,
+     "matched": 6
+    },
+    {
+     "year": 1685,
+     "editions": 3638,
+     "matched": 10
+    },
+    {
+     "year": 1686,
+     "editions": 3207,
+     "matched": 6
+    },
+    {
+     "year": 1687,
+     "editions": 3121,
+     "matched": 9
+    },
+    {
+     "year": 1688,
+     "editions": 3381,
+     "matched": 3
+    },
+    {
+     "year": 1689,
+     "editions": 3164,
+     "matched": 4
+    },
+    {
+     "year": 1690,
+     "editions": 3441,
+     "matched": 8
+    },
+    {
+     "year": 1691,
+     "editions": 3054,
+     "matched": 4
+    },
+    {
+     "year": 1692,
+     "editions": 3223,
+     "matched": 5
+    },
+    {
+     "year": 1693,
+     "editions": 3336,
+     "matched": 6
+    },
+    {
+     "year": 1694,
+     "editions": 3158,
+     "matched": 5
+    },
+    {
+     "year": 1695,
+     "editions": 3343,
+     "matched": 4
+    },
+    {
+     "year": 1696,
+     "editions": 3212,
+     "matched": 10
+    },
+    {
+     "year": 1697,
+     "editions": 3351,
+     "matched": 5
+    },
+    {
+     "year": 1698,
+     "editions": 3471,
+     "matched": 4
+    },
+    {
+     "year": 1699,
+     "editions": 3492,
+     "matched": 4
+    },
+    {
+     "year": 1700,
+     "editions": 2477,
+     "matched": 2
+    },
+    {
+     "year": 1701,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1702,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1703,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1727,
+     "editions": 1,
+     "matched": 0
+    }
+   ]
+  },
+  "pt": {
+   "label": "Portuguese",
+   "years": [
+    {
+     "year": 1486,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1488,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1489,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1492,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1494,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1495,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1496,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1497,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1498,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1500,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1501,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1502,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1503,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1504,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1505,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1506,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1509,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1512,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1513,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1514,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1515,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1516,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1518,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1520,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1521,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1522,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1523,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1524,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1525,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1526,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1527,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1528,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1529,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1530,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1531,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1532,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1533,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1534,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1535,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1536,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1537,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1538,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1539,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1540,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1541,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1542,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1543,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1544,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1545,
+     "editions": 5,
+     "matched": 0
+    },
+    {
+     "year": 1546,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1547,
+     "editions": 4,
+     "matched": 0
+    },
+    {
+     "year": 1548,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1549,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1550,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1551,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1552,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1553,
+     "editions": 7,
+     "matched": 0
+    },
+    {
+     "year": 1554,
+     "editions": 18,
+     "matched": 0
+    },
+    {
+     "year": 1555,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1556,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1557,
+     "editions": 45,
+     "matched": 0
+    },
+    {
+     "year": 1558,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1559,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1560,
+     "editions": 24,
+     "matched": 1
+    },
+    {
+     "year": 1561,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1562,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1563,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1564,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1565,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1566,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1567,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1568,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1569,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1570,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1571,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1572,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1573,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1574,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1575,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1576,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1577,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1578,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1579,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1580,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1581,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1582,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1583,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1584,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1585,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1586,
+     "editions": 8,
+     "matched": 0
+    },
+    {
+     "year": 1587,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1588,
+     "editions": 13,
+     "matched": 0
+    },
+    {
+     "year": 1589,
+     "editions": 12,
+     "matched": 0
+    },
+    {
+     "year": 1590,
+     "editions": 21,
+     "matched": 0
+    },
+    {
+     "year": 1591,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1592,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1593,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1594,
+     "editions": 17,
+     "matched": 0
+    },
+    {
+     "year": 1595,
+     "editions": 9,
+     "matched": 0
+    },
+    {
+     "year": 1596,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1597,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1598,
+     "editions": 15,
+     "matched": 0
+    },
+    {
+     "year": 1599,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1600,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1601,
+     "editions": 17,
+     "matched": 0
+    },
+    {
+     "year": 1602,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1603,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1604,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1605,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1606,
+     "editions": 16,
+     "matched": 0
+    },
+    {
+     "year": 1607,
+     "editions": 29,
+     "matched": 0
+    },
+    {
+     "year": 1608,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1609,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1610,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1611,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1612,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1613,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1614,
+     "editions": 31,
+     "matched": 0
+    },
+    {
+     "year": 1615,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1616,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1617,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1618,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1619,
+     "editions": 45,
+     "matched": 0
+    },
+    {
+     "year": 1620,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1621,
+     "editions": 52,
+     "matched": 0
+    },
+    {
+     "year": 1622,
+     "editions": 41,
+     "matched": 0
+    },
+    {
+     "year": 1623,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1624,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1625,
+     "editions": 62,
+     "matched": 0
+    },
+    {
+     "year": 1626,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1627,
+     "editions": 47,
+     "matched": 1
+    },
+    {
+     "year": 1628,
+     "editions": 41,
+     "matched": 0
+    },
+    {
+     "year": 1629,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1630,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1631,
+     "editions": 44,
+     "matched": 0
+    },
+    {
+     "year": 1632,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1633,
+     "editions": 39,
+     "matched": 0
+    },
+    {
+     "year": 1634,
+     "editions": 23,
+     "matched": 0
+    },
+    {
+     "year": 1635,
+     "editions": 32,
+     "matched": 0
+    },
+    {
+     "year": 1636,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1637,
+     "editions": 17,
+     "matched": 0
+    },
+    {
+     "year": 1638,
+     "editions": 31,
+     "matched": 0
+    },
+    {
+     "year": 1639,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1640,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1641,
+     "editions": 195,
+     "matched": 0
+    },
+    {
+     "year": 1642,
+     "editions": 210,
+     "matched": 0
+    },
+    {
+     "year": 1643,
+     "editions": 142,
+     "matched": 0
+    },
+    {
+     "year": 1644,
+     "editions": 111,
+     "matched": 0
+    },
+    {
+     "year": 1645,
+     "editions": 94,
+     "matched": 0
+    },
+    {
+     "year": 1646,
+     "editions": 71,
+     "matched": 0
+    },
+    {
+     "year": 1647,
+     "editions": 64,
+     "matched": 0
+    },
+    {
+     "year": 1648,
+     "editions": 63,
+     "matched": 0
+    },
+    {
+     "year": 1649,
+     "editions": 103,
+     "matched": 0
+    },
+    {
+     "year": 1650,
+     "editions": 73,
+     "matched": 0
+    },
+    {
+     "year": 1651,
+     "editions": 67,
+     "matched": 0
+    },
+    {
+     "year": 1652,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1653,
+     "editions": 80,
+     "matched": 0
+    },
+    {
+     "year": 1654,
+     "editions": 57,
+     "matched": 0
+    },
+    {
+     "year": 1655,
+     "editions": 70,
+     "matched": 0
+    },
+    {
+     "year": 1656,
+     "editions": 58,
+     "matched": 0
+    },
+    {
+     "year": 1657,
+     "editions": 43,
+     "matched": 0
+    },
+    {
+     "year": 1658,
+     "editions": 56,
+     "matched": 0
+    },
+    {
+     "year": 1659,
+     "editions": 60,
+     "matched": 0
+    },
+    {
+     "year": 1660,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1661,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1662,
+     "editions": 45,
+     "matched": 0
+    },
+    {
+     "year": 1663,
+     "editions": 66,
+     "matched": 0
+    },
+    {
+     "year": 1664,
+     "editions": 74,
+     "matched": 0
+    },
+    {
+     "year": 1665,
+     "editions": 84,
+     "matched": 0
+    },
+    {
+     "year": 1666,
+     "editions": 57,
+     "matched": 0
+    },
+    {
+     "year": 1667,
+     "editions": 41,
+     "matched": 0
+    },
+    {
+     "year": 1668,
+     "editions": 68,
+     "matched": 0
+    },
+    {
+     "year": 1669,
+     "editions": 71,
+     "matched": 0
+    },
+    {
+     "year": 1670,
+     "editions": 77,
+     "matched": 0
+    },
+    {
+     "year": 1671,
+     "editions": 106,
+     "matched": 0
+    },
+    {
+     "year": 1672,
+     "editions": 128,
+     "matched": 0
+    },
+    {
+     "year": 1673,
+     "editions": 112,
+     "matched": 0
+    },
+    {
+     "year": 1674,
+     "editions": 110,
+     "matched": 0
+    },
+    {
+     "year": 1675,
+     "editions": 93,
+     "matched": 0
+    },
+    {
+     "year": 1676,
+     "editions": 79,
+     "matched": 0
+    },
+    {
+     "year": 1677,
+     "editions": 58,
+     "matched": 0
+    },
+    {
+     "year": 1678,
+     "editions": 63,
+     "matched": 0
+    },
+    {
+     "year": 1679,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1680,
+     "editions": 54,
+     "matched": 0
+    },
+    {
+     "year": 1681,
+     "editions": 56,
+     "matched": 0
+    },
+    {
+     "year": 1682,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1683,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1684,
+     "editions": 57,
+     "matched": 0
+    },
+    {
+     "year": 1685,
+     "editions": 96,
+     "matched": 0
+    },
+    {
+     "year": 1686,
+     "editions": 128,
+     "matched": 0
+    },
+    {
+     "year": 1687,
+     "editions": 88,
+     "matched": 0
+    },
+    {
+     "year": 1688,
+     "editions": 147,
+     "matched": 0
+    },
+    {
+     "year": 1689,
+     "editions": 96,
+     "matched": 0
+    },
+    {
+     "year": 1690,
+     "editions": 60,
+     "matched": 0
+    },
+    {
+     "year": 1691,
+     "editions": 57,
+     "matched": 0
+    },
+    {
+     "year": 1692,
+     "editions": 65,
+     "matched": 0
+    },
+    {
+     "year": 1693,
+     "editions": 53,
+     "matched": 0
+    },
+    {
+     "year": 1694,
+     "editions": 48,
+     "matched": 0
+    },
+    {
+     "year": 1695,
+     "editions": 59,
+     "matched": 0
+    },
+    {
+     "year": 1696,
+     "editions": 64,
+     "matched": 0
+    },
+    {
+     "year": 1697,
+     "editions": 53,
+     "matched": 1
+    },
+    {
+     "year": 1698,
+     "editions": 86,
+     "matched": 0
+    },
+    {
+     "year": 1699,
+     "editions": 81,
+     "matched": 0
+    },
+    {
+     "year": 1700,
+     "editions": 84,
+     "matched": 0
+    }
+   ]
+  },
+  "es": {
+   "label": "Spanish",
+   "years": [
+    {
+     "year": 1472,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1473,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1474,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1475,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1476,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1477,
+     "editions": 2,
+     "matched": 0
+    },
+    {
+     "year": 1478,
+     "editions": 1,
+     "matched": 0
+    },
+    {
+     "year": 1479,
+     "editions": 3,
+     "matched": 0
+    },
+    {
+     "year": 1480,
+     "editions": 6,
+     "matched": 0
+    },
+    {
+     "year": 1481,
+     "editions": 11,
+     "matched": 0
+    },
+    {
+     "year": 1482,
+     "editions": 22,
+     "matched": 0
+    },
+    {
+     "year": 1483,
+     "editions": 14,
+     "matched": 0
+    },
+    {
+     "year": 1484,
+     "editions": 10,
+     "matched": 0
+    },
+    {
+     "year": 1485,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1486,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1487,
+     "editions": 28,
+     "matched": 0
+    },
+    {
+     "year": 1488,
+     "editions": 27,
+     "matched": 0
+    },
+    {
+     "year": 1489,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1490,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1491,
+     "editions": 37,
+     "matched": 0
+    },
+    {
+     "year": 1492,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1493,
+     "editions": 59,
+     "matched": 0
+    },
+    {
+     "year": 1494,
+     "editions": 44,
+     "matched": 0
+    },
+    {
+     "year": 1495,
+     "editions": 75,
+     "matched": 0
+    },
+    {
+     "year": 1496,
+     "editions": 53,
+     "matched": 0
+    },
+    {
+     "year": 1497,
+     "editions": 55,
+     "matched": 0
+    },
+    {
+     "year": 1498,
+     "editions": 59,
+     "matched": 1
+    },
+    {
+     "year": 1499,
+     "editions": 92,
+     "matched": 0
+    },
+    {
+     "year": 1500,
+     "editions": 111,
+     "matched": 0
+    },
+    {
+     "year": 1501,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1502,
+     "editions": 41,
+     "matched": 0
+    },
+    {
+     "year": 1503,
+     "editions": 35,
+     "matched": 0
+    },
+    {
+     "year": 1504,
+     "editions": 19,
+     "matched": 0
+    },
+    {
+     "year": 1505,
+     "editions": 30,
+     "matched": 0
+    },
+    {
+     "year": 1506,
+     "editions": 25,
+     "matched": 0
+    },
+    {
+     "year": 1507,
+     "editions": 26,
+     "matched": 0
+    },
+    {
+     "year": 1508,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1509,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1510,
+     "editions": 46,
+     "matched": 0
+    },
+    {
+     "year": 1511,
+     "editions": 81,
+     "matched": 0
+    },
+    {
+     "year": 1512,
+     "editions": 50,
+     "matched": 0
+    },
+    {
+     "year": 1513,
+     "editions": 40,
+     "matched": 0
+    },
+    {
+     "year": 1514,
+     "editions": 38,
+     "matched": 0
+    },
+    {
+     "year": 1515,
+     "editions": 60,
+     "matched": 1
+    },
+    {
+     "year": 1516,
+     "editions": 59,
+     "matched": 0
+    },
+    {
+     "year": 1517,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1518,
+     "editions": 33,
+     "matched": 0
+    },
+    {
+     "year": 1519,
+     "editions": 42,
+     "matched": 0
+    },
+    {
+     "year": 1520,
+     "editions": 82,
+     "matched": 0
+    },
+    {
+     "year": 1521,
+     "editions": 43,
+     "matched": 0
+    },
+    {
+     "year": 1522,
+     "editions": 24,
+     "matched": 0
+    },
+    {
+     "year": 1523,
+     "editions": 34,
+     "matched": 0
+    },
+    {
+     "year": 1524,
+     "editions": 48,
+     "matched": 0
+    },
+    {
+     "year": 1525,
+     "editions": 64,
+     "matched": 0
+    },
+    {
+     "year": 1526,
+     "editions": 93,
+     "matched": 1
+    },
+    {
+     "year": 1527,
+     "editions": 70,
+     "matched": 0
+    },
+    {
+     "year": 1528,
+     "editions": 82,
+     "matched": 0
+    },
+    {
+     "year": 1529,
+     "editions": 70,
+     "matched": 0
+    },
+    {
+     "year": 1530,
+     "editions": 72,
+     "matched": 0
+    },
+    {
+     "year": 1531,
+     "editions": 47,
+     "matched": 0
+    },
+    {
+     "year": 1532,
+     "editions": 45,
+     "matched": 0
+    },
+    {
+     "year": 1533,
+     "editions": 68,
+     "matched": 0
+    },
+    {
+     "year": 1534,
+     "editions": 79,
+     "matched": 0
+    },
+    {
+     "year": 1535,
+     "editions": 77,
+     "matched": 0
+    },
+    {
+     "year": 1536,
+     "editions": 59,
+     "matched": 0
+    },
+    {
+     "year": 1537,
+     "editions": 57,
+     "matched": 0
+    },
+    {
+     "year": 1538,
+     "editions": 55,
+     "matched": 0
+    },
+    {
+     "year": 1539,
+     "editions": 83,
+     "matched": 0
+    },
+    {
+     "year": 1540,
+     "editions": 89,
+     "matched": 0
+    },
+    {
+     "year": 1541,
+     "editions": 84,
+     "matched": 0
+    },
+    {
+     "year": 1542,
+     "editions": 107,
+     "matched": 0
+    },
+    {
+     "year": 1543,
+     "editions": 118,
+     "matched": 0
+    },
+    {
+     "year": 1544,
+     "editions": 99,
+     "matched": 0
+    },
+    {
+     "year": 1545,
+     "editions": 126,
+     "matched": 0
+    },
+    {
+     "year": 1546,
+     "editions": 135,
+     "matched": 0
+    },
+    {
+     "year": 1547,
+     "editions": 117,
+     "matched": 0
+    },
+    {
+     "year": 1548,
+     "editions": 124,
+     "matched": 0
+    },
+    {
+     "year": 1549,
+     "editions": 105,
+     "matched": 0
+    },
+    {
+     "year": 1550,
+     "editions": 193,
+     "matched": 0
+    },
+    {
+     "year": 1551,
+     "editions": 166,
+     "matched": 0
+    },
+    {
+     "year": 1552,
+     "editions": 181,
+     "matched": 0
+    },
+    {
+     "year": 1553,
+     "editions": 138,
+     "matched": 0
+    },
+    {
+     "year": 1554,
+     "editions": 155,
+     "matched": 0
+    },
+    {
+     "year": 1555,
+     "editions": 141,
+     "matched": 1
+    },
+    {
+     "year": 1556,
+     "editions": 120,
+     "matched": 1
+    },
+    {
+     "year": 1557,
+     "editions": 88,
+     "matched": 0
+    },
+    {
+     "year": 1558,
+     "editions": 87,
+     "matched": 0
+    },
+    {
+     "year": 1559,
+     "editions": 60,
+     "matched": 0
+    },
+    {
+     "year": 1560,
+     "editions": 86,
+     "matched": 0
+    },
+    {
+     "year": 1561,
+     "editions": 77,
+     "matched": 0
+    },
+    {
+     "year": 1562,
+     "editions": 99,
+     "matched": 0
+    },
+    {
+     "year": 1563,
+     "editions": 105,
+     "matched": 0
+    },
+    {
+     "year": 1564,
+     "editions": 112,
+     "matched": 0
+    },
+    {
+     "year": 1565,
+     "editions": 114,
+     "matched": 2
+    },
+    {
+     "year": 1566,
+     "editions": 128,
+     "matched": 0
+    },
+    {
+     "year": 1567,
+     "editions": 105,
+     "matched": 1
+    },
+    {
+     "year": 1568,
+     "editions": 131,
+     "matched": 2
+    },
+    {
+     "year": 1569,
+     "editions": 127,
+     "matched": 2
+    },
+    {
+     "year": 1570,
+     "editions": 140,
+     "matched": 0
+    },
+    {
+     "year": 1571,
+     "editions": 114,
+     "matched": 2
+    },
+    {
+     "year": 1572,
+     "editions": 142,
+     "matched": 0
+    },
+    {
+     "year": 1573,
+     "editions": 109,
+     "matched": 0
+    },
+    {
+     "year": 1574,
+     "editions": 127,
+     "matched": 0
+    },
+    {
+     "year": 1575,
+     "editions": 141,
+     "matched": 0
+    },
+    {
+     "year": 1576,
+     "editions": 136,
+     "matched": 0
+    },
+    {
+     "year": 1577,
+     "editions": 107,
+     "matched": 0
+    },
+    {
+     "year": 1578,
+     "editions": 140,
+     "matched": 0
+    },
+    {
+     "year": 1579,
+     "editions": 110,
+     "matched": 0
+    },
+    {
+     "year": 1580,
+     "editions": 170,
+     "matched": 0
+    },
+    {
+     "year": 1581,
+     "editions": 115,
+     "matched": 0
+    },
+    {
+     "year": 1582,
+     "editions": 138,
+     "matched": 0
+    },
+    {
+     "year": 1583,
+     "editions": 163,
+     "matched": 0
+    },
+    {
+     "year": 1584,
+     "editions": 150,
+     "matched": 0
+    },
+    {
+     "year": 1585,
+     "editions": 165,
+     "matched": 0
+    },
+    {
+     "year": 1586,
+     "editions": 190,
+     "matched": 0
+    },
+    {
+     "year": 1587,
+     "editions": 198,
+     "matched": 0
+    },
+    {
+     "year": 1588,
+     "editions": 239,
+     "matched": 0
+    },
+    {
+     "year": 1589,
+     "editions": 198,
+     "matched": 0
+    },
+    {
+     "year": 1590,
+     "editions": 209,
+     "matched": 0
+    },
+    {
+     "year": 1591,
+     "editions": 167,
+     "matched": 1
+    },
+    {
+     "year": 1592,
+     "editions": 166,
+     "matched": 0
+    },
+    {
+     "year": 1593,
+     "editions": 162,
+     "matched": 0
+    },
+    {
+     "year": 1594,
+     "editions": 233,
+     "matched": 0
+    },
+    {
+     "year": 1595,
+     "editions": 226,
+     "matched": 0
+    },
+    {
+     "year": 1596,
+     "editions": 218,
+     "matched": 0
+    },
+    {
+     "year": 1597,
+     "editions": 234,
+     "matched": 0
+    },
+    {
+     "year": 1598,
+     "editions": 301,
+     "matched": 0
+    },
+    {
+     "year": 1599,
+     "editions": 305,
+     "matched": 0
+    },
+    {
+     "year": 1600,
+     "editions": 318,
+     "matched": 0
+    },
+    {
+     "year": 1601,
+     "editions": 644,
+     "matched": 1
+    },
+    {
+     "year": 1602,
+     "editions": 333,
+     "matched": 0
+    },
+    {
+     "year": 1603,
+     "editions": 500,
+     "matched": 0
+    },
+    {
+     "year": 1604,
+     "editions": 426,
+     "matched": 0
+    },
+    {
+     "year": 1605,
+     "editions": 387,
+     "matched": 0
+    },
+    {
+     "year": 1606,
+     "editions": 340,
+     "matched": 0
+    },
+    {
+     "year": 1607,
+     "editions": 376,
+     "matched": 0
+    },
+    {
+     "year": 1608,
+     "editions": 451,
+     "matched": 2
+    },
+    {
+     "year": 1609,
+     "editions": 470,
+     "matched": 0
+    },
+    {
+     "year": 1610,
+     "editions": 523,
+     "matched": 0
+    },
+    {
+     "year": 1611,
+     "editions": 440,
+     "matched": 0
+    },
+    {
+     "year": 1612,
+     "editions": 528,
+     "matched": 0
+    },
+    {
+     "year": 1613,
+     "editions": 459,
+     "matched": 1
+    },
+    {
+     "year": 1614,
+     "editions": 519,
+     "matched": 0
+    },
+    {
+     "year": 1615,
+     "editions": 617,
+     "matched": 0
+    },
+    {
+     "year": 1616,
+     "editions": 579,
+     "matched": 0
+    },
+    {
+     "year": 1617,
+     "editions": 590,
+     "matched": 0
+    },
+    {
+     "year": 1618,
+     "editions": 547,
+     "matched": 0
+    },
+    {
+     "year": 1619,
+     "editions": 609,
+     "matched": 1
+    },
+    {
+     "year": 1620,
+     "editions": 618,
+     "matched": 0
+    },
+    {
+     "year": 1621,
+     "editions": 800,
+     "matched": 0
+    },
+    {
+     "year": 1622,
+     "editions": 805,
+     "matched": 0
+    },
+    {
+     "year": 1623,
+     "editions": 845,
+     "matched": 1
+    },
+    {
+     "year": 1624,
+     "editions": 816,
+     "matched": 0
+    },
+    {
+     "year": 1625,
+     "editions": 899,
+     "matched": 1
+    },
+    {
+     "year": 1626,
+     "editions": 885,
+     "matched": 0
+    },
+    {
+     "year": 1627,
+     "editions": 687,
+     "matched": 1
+    },
+    {
+     "year": 1628,
+     "editions": 718,
+     "matched": 0
+    },
+    {
+     "year": 1629,
+     "editions": 709,
+     "matched": 0
+    },
+    {
+     "year": 1630,
+     "editions": 808,
+     "matched": 0
+    },
+    {
+     "year": 1631,
+     "editions": 595,
+     "matched": 0
+    },
+    {
+     "year": 1632,
+     "editions": 600,
+     "matched": 1
+    },
+    {
+     "year": 1633,
+     "editions": 650,
+     "matched": 0
+    },
+    {
+     "year": 1634,
+     "editions": 765,
+     "matched": 0
+    },
+    {
+     "year": 1635,
+     "editions": 730,
+     "matched": 0
+    },
+    {
+     "year": 1636,
+     "editions": 609,
+     "matched": 0
+    },
+    {
+     "year": 1637,
+     "editions": 532,
+     "matched": 0
+    },
+    {
+     "year": 1638,
+     "editions": 716,
+     "matched": 0
+    },
+    {
+     "year": 1639,
+     "editions": 689,
+     "matched": 0
+    },
+    {
+     "year": 1640,
+     "editions": 831,
+     "matched": 2
+    },
+    {
+     "year": 1641,
+     "editions": 661,
+     "matched": 0
+    },
+    {
+     "year": 1642,
+     "editions": 730,
+     "matched": 0
+    },
+    {
+     "year": 1643,
+     "editions": 546,
+     "matched": 0
+    },
+    {
+     "year": 1644,
+     "editions": 625,
+     "matched": 0
+    },
+    {
+     "year": 1645,
+     "editions": 649,
+     "matched": 0
+    },
+    {
+     "year": 1646,
+     "editions": 677,
+     "matched": 0
+    },
+    {
+     "year": 1647,
+     "editions": 563,
+     "matched": 0
+    },
+    {
+     "year": 1648,
+     "editions": 597,
+     "matched": 0
+    },
+    {
+     "year": 1649,
+     "editions": 577,
+     "matched": 0
+    },
+    {
+     "year": 1650,
+     "editions": 1069,
+     "matched": 0
+    },
+    {
+     "year": 1651,
+     "editions": 660,
+     "matched": 0
+    },
+    {
+     "year": 1652,
+     "editions": 747,
+     "matched": 0
+    },
+    {
+     "year": 1653,
+     "editions": 744,
+     "matched": 0
+    },
+    {
+     "year": 1654,
+     "editions": 672,
+     "matched": 0
+    },
+    {
+     "year": 1655,
+     "editions": 737,
+     "matched": 0
+    },
+    {
+     "year": 1656,
+     "editions": 669,
+     "matched": 0
+    },
+    {
+     "year": 1657,
+     "editions": 644,
+     "matched": 0
+    },
+    {
+     "year": 1658,
+     "editions": 669,
+     "matched": 0
+    },
+    {
+     "year": 1659,
+     "editions": 682,
+     "matched": 0
+    },
+    {
+     "year": 1660,
+     "editions": 872,
+     "matched": 0
+    },
+    {
+     "year": 1661,
+     "editions": 680,
+     "matched": 0
+    },
+    {
+     "year": 1662,
+     "editions": 824,
+     "matched": 0
+    },
+    {
+     "year": 1663,
+     "editions": 703,
+     "matched": 0
+    },
+    {
+     "year": 1664,
+     "editions": 669,
+     "matched": 1
+    },
+    {
+     "year": 1665,
+     "editions": 857,
+     "matched": 0
+    },
+    {
+     "year": 1666,
+     "editions": 731,
+     "matched": 0
+    },
+    {
+     "year": 1667,
+     "editions": 700,
+     "matched": 0
+    },
+    {
+     "year": 1668,
+     "editions": 723,
+     "matched": 0
+    },
+    {
+     "year": 1669,
+     "editions": 682,
+     "matched": 0
+    },
+    {
+     "year": 1670,
+     "editions": 915,
+     "matched": 0
+    },
+    {
+     "year": 1671,
+     "editions": 822,
+     "matched": 0
+    },
+    {
+     "year": 1672,
+     "editions": 772,
+     "matched": 0
+    },
+    {
+     "year": 1673,
+     "editions": 720,
+     "matched": 0
+    },
+    {
+     "year": 1674,
+     "editions": 774,
+     "matched": 0
+    },
+    {
+     "year": 1675,
+     "editions": 789,
+     "matched": 0
+    },
+    {
+     "year": 1676,
+     "editions": 662,
+     "matched": 0
+    },
+    {
+     "year": 1677,
+     "editions": 781,
+     "matched": 0
+    },
+    {
+     "year": 1678,
+     "editions": 751,
+     "matched": 0
+    },
+    {
+     "year": 1679,
+     "editions": 863,
+     "matched": 1
+    },
+    {
+     "year": 1680,
+     "editions": 1224,
+     "matched": 0
+    },
+    {
+     "year": 1681,
+     "editions": 685,
+     "matched": 0
+    },
+    {
+     "year": 1682,
+     "editions": 699,
+     "matched": 0
+    },
+    {
+     "year": 1683,
+     "editions": 849,
+     "matched": 0
+    },
+    {
+     "year": 1684,
+     "editions": 894,
+     "matched": 0
+    },
+    {
+     "year": 1685,
+     "editions": 751,
+     "matched": 0
+    },
+    {
+     "year": 1686,
+     "editions": 798,
+     "matched": 0
+    },
+    {
+     "year": 1687,
+     "editions": 817,
+     "matched": 0
+    },
+    {
+     "year": 1688,
+     "editions": 840,
+     "matched": 0
+    },
+    {
+     "year": 1689,
+     "editions": 970,
+     "matched": 0
+    },
+    {
+     "year": 1690,
+     "editions": 1036,
+     "matched": 0
+    },
+    {
+     "year": 1691,
+     "editions": 760,
+     "matched": 0
+    },
+    {
+     "year": 1692,
+     "editions": 735,
+     "matched": 0
+    },
+    {
+     "year": 1693,
+     "editions": 726,
+     "matched": 0
+    },
+    {
+     "year": 1694,
+     "editions": 638,
+     "matched": 0
+    },
+    {
+     "year": 1695,
+     "editions": 795,
+     "matched": 0
+    },
+    {
+     "year": 1696,
+     "editions": 777,
+     "matched": 0
+    },
+    {
+     "year": 1697,
+     "editions": 711,
+     "matched": 0
+    },
+    {
+     "year": 1698,
+     "editions": 625,
+     "matched": 0
+    },
+    {
+     "year": 1699,
+     "editions": 1347,
+     "matched": 0
+    },
+    {
+     "year": 1700,
+     "editions": 2020,
+     "matched": 0
+    }
+   ]
+  }
+ }
 }


### PR DESCRIPTION
Follow-ups to #3219 from Derek's first look:

- **Per-language facet:** choosing the Latin corpus now compares against USTC's **Latin** editions (503K editions, 2,371 matched) instead of all of European print — same for de/fr/it/nl/es/el/en-orig/pt/he. The `en` corpus (translations of everything) deliberately keeps the all-languages universe, with a line of copy explaining that and pointing at the original-language corpora for same-language comparisons. The generator now emits a `languages{}` block keyed by corpus id.
- **Held-share strip fixed:** it was computing per-year ratios, and early years with a handful of editions (1450 has 1) spiked to hundreds of ‰, flattening every real year to the baseline — it read as broken. Now 5-year bins (sum matched / sum editions), with the bin's raw counts in the hover readout ('held 14 of 1,756').
- **Histogram visibility:** bars darkened (text-muted at 0.55 vs text-faint at 0.3) and the main chart grown 170→260px.

Verified: tsc clean (exit code checked directly, not through a pipe), regenerated JSON sanity-checked (Latin 1550: 1,756 editions / 14 matched ≈ 8‰).

🤖 Generated with [Claude Code](https://claude.com/claude-code)