### PR TITLE
fix(seo): book pages served skeleton HTML to crawlers — Suspense-wrap useSearchParams in EmbedNavigationReporter

### DIFF
--- a/src/components/embed/EmbedNavigationReporter.tsx
+++ b/src/components/embed/EmbedNavigationReporter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 
 interface Props {
@@ -24,8 +24,23 @@ const INTERNAL_PARAMS = new Set(['host_path', '_r']);
  * view, display, c-prefixed catalogue filters, language, offset, ...).
  *
  * Only fires when inside an iframe — no-ops when loaded directly.
+ *
+ * useSearchParams() must stay inside this component's own Suspense boundary:
+ * on statically prerendered routes (the book page is ISR) an unwrapped call
+ * throws a CSR bailout that gets caught by the *page's* outer Suspense,
+ * replacing the entire server-rendered body with its skeleton fallback in the
+ * served HTML — invisible to users (the client re-renders), but crawlers see
+ * a content-free page (issue #2266).
  */
-export default function EmbedNavigationReporter({ book = null, page = null }: Props) {
+export default function EmbedNavigationReporter(props: Props) {
+  return (
+    <Suspense fallback={null}>
+      <EmbedNavigationReporterInner {...props} />
+    </Suspense>
+  );
+}
+
+function EmbedNavigationReporterInner({ book = null, page = null }: Props) {
   const searchParams = useSearchParams();
   // searchParams identity can change between renders without contents changing;
   // depend on the string form so the effect re-fires exactly when the iframe


### PR DESCRIPTION
## What
One-component fix for the root cause behind #2266's orphaned-pages problem: `EmbedNavigationReporter` called `useSearchParams()` with no Suspense boundary of its own. On the statically prerendered book route (ISR, `revalidate = 86400` — the one content route that never reads `headers()`), that throws a CSR bailout at prerender time, caught by the page's **outer** Suspense boundary — so the served HTML for every `/book/<slug>` page was the loading skeleton: zero page-grid anchors, no Read CTA, no RelatedBooks, no overview link. Browsers recover via client render (users never saw it); crawlers see a content-free dead end.

Verified live before the fix: `/book/platonis-opera-plato` fresh origin render (cf-cache-status MISS) = 0 `<h1>`, 0 `/book/` links, 0 `/author/` links, `BAILOUT_TO_CLIENT_SIDE_RENDERING` template in HTML. Control: `/collections/hermetica` = 24 book links (dynamic route, unaffected).

## How
Standard pattern (same as `SearchHighlighter` in `PageEditorClient.tsx`): the `useSearchParams` consumer moves to an inner component; the default export wraps it in `<Suspense fallback={null}>`. Fixes all five call sites at once (book, collections, tenant, embed, reader routes). No behavior change for the embed postMessage contract.

## Scope
In scope: the P0 regression fix only — smallest possible diff, cleanly bisectable.
Out of scope (deliberate, per the plan on #2266): reader prev/next anchors (P1), server nav block on reader pages (P2), `/browse` SSR, `related_books` backfill, sitemap count fix #2386 — follow-up PRs.

## Verification plan
After merge + deploy: purge Cloudflare (skeleton HTML is CDN-cached 24h), then curl book pages as a browser UA and assert ≥20 `/page/` anchors + the overview link in server HTML. Full rollout/measurement plan: https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2266#issuecomment-5013645284

Refs #2266

🤖 Generated with [Claude Code](https://claude.com/claude-code)