### PR TITLE
The Playable Page — manuscript diagrams replicated and strung (harmony post 4, first slice of #3224)

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -26,6 +26,19 @@ export interface BlogPost {
 // Exported so the RSS feed (/api/feed/blog) reads the same list — single source of truth.
 export const posts: BlogPost[] = [
   {
+    slug: 'playable-page',
+    title: 'The Playable Page',
+    subtitle:
+      'Old treatises are full of instruments diagrammed and silenced — monochord divisions, tetrachord arcs, string tables worked out to the integer. Three of them, replicated and strung: Galilei\'s two-string bench with its weight pan, the Lyre of Mercury\'s disputed numbers read as three different laws, and the full two-octave system of ancient music from a Boethius manuscript, playable in all three genera.',
+    date: '19 July 2026',
+    readTime: '3 instruments',
+    tag: 'Interactive',
+    tagColor: 'bg-stone-100 text-stone-600',
+    image: 'https://images.sourcelibrary.org/archived/6955739df63a7571091720cf/80.jpg',
+    imageAlt:
+      'A page of the Boethius manuscript: nested red arcs mapping the chromatic and enharmonic tetrachords, with string names and monochord numbers.',
+  },
+  {
     slug: 'ngram-viewer',
     title: 'Chart a Word, Then Read the Page',
     subtitle:

--- a/src/app/blog/playable-page/page.tsx
+++ b/src/app/blog/playable-page/page.tsx
@@ -1,0 +1,179 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import GalileiStringsDemo from '@/components/blog/lab/GalileiStringsDemo';
+import LyreReadingsDemo from '@/components/blog/lab/LyreReadingsDemo';
+import BoethiusLadderDemo from '@/components/blog/lab/BoethiusLadderDemo';
+import { FolioFigure, FolioPair } from '@/components/blog/lab/FolioFigure';
+
+const HERO = 'https://images.sourcelibrary.org/archived/6955739df63a7571091720cf/80.jpg';
+const HERO_ALT =
+  'A page of the Boethius manuscript: two large hand-drawn diagrams of nested red arcs mapping the chromatic and enharmonic tetrachords, with string names and monochord numbers.';
+
+export const metadata: Metadata = {
+  title: 'The Playable Page - Source Library',
+  description:
+    'Old books are full of instruments diagrammed and silenced: monochord divisions, tetrachord arcs, interval tables. This note replicates three of them and strings them — Galilei\'s two-string bench, the Lyre of Mercury\'s disputed numbers, and the full two-octave system of ancient music from a Boethius manuscript, playable in all three genera.',
+  alternates: {
+    canonical: '/blog/playable-page',
+  },
+  openGraph: {
+    title: 'The Playable Page',
+    description:
+      'Manuscript diagrams, replicated and strung: Galilei\'s two-string bench, the Lyre of Mercury read three ways, and Boethius\'s two-octave system playable in all three genera.',
+    images: [{ url: HERO, alt: HERO_ALT }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    images: [{ url: HERO, alt: HERO_ALT }],
+  },
+};
+
+export default function PlayablePagePage() {
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="The Playable Page"
+          subtitle="Manuscript diagrams are instruments with the sound left out. Put it back."
+          image={HERO}
+          imageAlt={HERO_ALT}
+        >
+          <p className="text-stone-400 text-sm mt-4">19 July 2026 &middot; 3 instruments &middot; headphones recommended</p>
+        </ContentHeader>
+      }
+      bg="bg-cream"
+    >
+      <div className="mb-8">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-secondary transition-colors text-sm"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          All notes
+        </Link>
+      </div>
+
+      <article className="prose-content max-w-none">
+        <p className="text-xl text-secondary leading-relaxed mb-8 font-body">
+          <Link href="/blog/nature-of-harmony" className="text-accent-rust hover:text-accent-rust underline">The Nature of Harmony</Link>{' '}
+          told the story,{' '}
+          <Link href="/blog/show-me-the-number" className="text-accent-rust hover:text-accent-rust underline">Show Me the Number</Link>{' '}
+          made the argument, and{' '}
+          <Link href="/blog/sound-laboratory" className="text-accent-rust hover:text-accent-rust underline">the Sound Laboratory</Link>{' '}
+          built the bench. This note goes one step further into the books themselves. The old
+          treatises are full of instruments that were diagrammed and then silenced — monochord
+          divisions, tetrachord arcs, string tables with every pitch worked out to the integer —
+          waiting five centuries for a reader who could hear them. Below, three of those diagrams
+          are replicated and strung. Nothing is a recording; every sound is synthesized live from
+          the numbers on the page.
+        </p>
+
+        <h2 className="font-serif text-3xl text-primary mb-6 mt-12">I. The falsifier&apos;s own apparatus</h2>
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          The Sound Laboratory&apos;s{' '}
+          <Link href="/blog/sound-laboratory" className="text-accent-rust hover:text-accent-rust underline">first station</Link>{' '}
+          weighs the smith&apos;s hammers and watches the legend break. What we did not notice until
+          we read further into{' '}
+          <Link href="/book/dialogo-della-musica-antica-et-della-moderna-galilei" className="text-accent-rust hover:text-accent-rust underline">Vincenzo Galilei&apos;s <em>Dialogo</em></Link>{' '}
+          is that the falsifier left build instructions. On p.&thinsp;145 he describes the exact
+          bench: &ldquo;if one takes two strings of the same length, thickness, and quality; if
+          these are stretched to unison over a flat surface, and one of them is deprived of half
+          its length by means of a bridge, fret, or even the fingers of the hand, one will hear
+          (as has been said before) the Diapason consonance every time they are struck together or
+          one after the other&rdquo; &mdash; and, a line later, &ldquo;From these observations, the
+          use of the Monochord easily took its origin&rdquo;{' '}
+          (<a href="https://sourcelibrary.org/q/BeoftnrTNYqCao3dYsz" className="text-accent-rust hover:text-accent-rust underline">verified verbatim</a>).
+          The presets below are his sentence, word for word. The weight pan is the half of the
+          story he put on trial: a string answers weight only by its square root, so the
+          legend&apos;s two-to-one lands on the tritone, and an octave costs fourfold.
+        </p>
+        <GalileiStringsDemo />
+        <FolioFigure
+          src="https://images.sourcelibrary.org/gallery/69ac83c55d2908b26341c442/69ac83c55d2908b26341c4c4-0.jpg"
+          alt="Woodcut monochord division from Zarlino's Le istitutioni harmoniche: a long ruled diagram dividing a string into tetrachords with numerical ratios."
+          caption={<>The instrument as the orthodoxy drew it: a monochord division from Gioseffo Zarlino&apos;s <em>Le istitutioni harmoniche</em> (1558). Zarlino was Galilei&apos;s teacher — and the <em>Dialogo</em>&apos;s chief target.</>}
+          href="/book/69ac83c55d2908b26341c442?page=130"
+          sourceLabel="Zarlino, Le istitutioni harmoniche (1558)"
+        />
+
+        <h2 className="font-serif text-3xl text-primary mb-6 mt-12">II. Four numbers, three laws</h2>
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          Boethius gives Mercury&apos;s lyre four strings in the proportions
+          6&thinsp;&middot;&thinsp;8&thinsp;&middot;&thinsp;9&thinsp;&middot;&thinsp;12 — the same
+          numbers as the hammers. But the authorities could not agree which <em>end</em> was low.
+          Galilei lays out the dispute on p.&thinsp;144: Plutarch&apos;s camp &ldquo;applied the
+          number six to the first, eight to the second, nine to the third, and twelve to the fourth
+          and last named&rdquo; — six on the lowest string — while the Zarlino camp assigns the
+          numbers &ldquo;exactly the opposite&rdquo; way{' '}
+          (<a href="https://sourcelibrary.org/q/BeoftnrTNYqCao3dYsy" className="text-accent-rust hover:text-accent-rust underline">verified verbatim</a>).
+          His diagnosis, same page: Plutarch&apos;s numbers cannot be monochord divisions — they
+          only make sense as <em>weights</em>, while the reversed order reads them as measures of
+          length. The direction of a scale is the fossil of a physical hypothesis. And a hypothesis
+          about sound is audible: each reading is a different law, so the same four numbers sing
+          three different chords. That is how you know for sure — authority picks a direction; the
+          bench picks the law.
+        </p>
+        <LyreReadingsDemo />
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          Two honest footnotes. The struck-hammer reading is the one a browser cannot fully settle:
+          our tone follows the cube-root scaling of similar solid bodies, but in a real smithy the
+          <em> anvil</em> sings its own note almost regardless of the hammer — and Galilei himself
+          guessed that direction wrong, writing that the twelve-pound hammer &ldquo;made the high
+          sound.&rdquo; To know that for sure you need iron, not a web page. And the legend never
+          agreed with itself about its own data: in Boethius&apos;s telling there are five hammers
+          and Pythagoras rejects one as dissonant —{' '}
+          <a href="https://sourcelibrary.org/q/BeoftnrTNYqCao3dYt3" className="text-accent-rust hover:text-accent-rust underline">Galilei replays that arithmetic</a>{' '}
+          — while Gaffurius&apos;s woodcut draws six.
+        </p>
+
+        <h2 className="font-serif text-3xl text-primary mb-6 mt-12">III. The page that begs to be played</h2>
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          In our fifteenth-century{' '}
+          <Link href="/book/de-institutione-musica-15th-c-ms-boethius" className="text-accent-rust hover:text-accent-rust underline">Boethius manuscript</Link>,
+          the whole two-octave system of ancient music is drawn as nested arcs in red ink — string
+          names, interval spans, and the monochord number of every string, in ladders for the
+          chromatic and enharmonic genera. Below, the same ladder is replicated and strung. The
+          drawn length of each string is true to its number on the 9,216 ruler, and the diatonic
+          division reproduces the manuscript tradition&apos;s canonical integers exactly: 9216,
+          8192, 7776&hellip;down to 2304, two octaves up. Switch the genus and the brass strings
+          — the movable notes — re-divide, just as the facing diagrams on the page do; the
+          chromatic pulls Lichanos up to an F&#9839;, and the enharmonic lands on genuine
+          quarter-tones, notes that fall between the frets of every modern instrument.
+        </p>
+        <FolioPair>
+          <FolioFigure
+            src={HERO}
+            alt={HERO_ALT}
+            caption={<>The original: chromatic and enharmonic wing-diagrams, hand-drawn c.&thinsp;1490, with the string numbers written along the arcs.</>}
+            href="/book/de-institutione-musica-15th-c-ms-boethius?page=80"
+            sourceLabel="Boethius, De institutione musica"
+          />
+          <FolioFigure
+            src="https://images.sourcelibrary.org/gallery/695688febe7c607c5f03c1da/69569e3b1479a63c110927ca-0.jpg"
+            alt="Gaffurius's 1492 woodcut of the smithy legend: six men strike an anvil with hammers marked IIII, VI, VIII, VIIII, XII and XVI, with a reader's handwriting in the margins."
+            caption={<>Where the numbers entered legend: Gaffurius&apos;s smithy, with an early reader re-inking the hammer arithmetic in the margins. The playable version lives at Station I of the Sound Laboratory.</>}
+            href="/book/theorica-musicae-gaffurius?page=46"
+            sourceLabel="Gaffurio, Theorica musicae (1492)"
+          />
+        </FolioPair>
+        <BoethiusLadderDemo />
+
+        <hr className="border-border-light my-12" />
+
+        <h2 className="font-serif text-3xl text-primary mb-6 mt-12">Every diagram is a score</h2>
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          A monochord division is not an illustration <em>about</em> music; it is music, stored in
+          the only medium its author had. The three instruments on this page took an afternoon to
+          string because the hard work was done centuries ago — the numbers are on the pages,
+          worked out to the integer. The library holds many more: division tables in Zarlino and
+          Salinas, interval ladders in Gaffurius, circle diagrams in Descartes, tuning grids from
+          Ming China. We intend to keep stringing them. If there is a page you want to hear, tell
+          us with the suggest-an-edit link below.
+        </p>
+      </article>
+    </ContentPageLayout>
+  );
+}

--- a/src/components/blog/lab/BoethiusLadderDemo.tsx
+++ b/src/components/blog/lab/BoethiusLadderDemo.tsx
@@ -137,7 +137,7 @@ export default function BoethiusLadderDemo() {
                 className="cursor-pointer hover:stroke-[var(--accent-rust,#a8503c)]"
                 onClick={() => playArc(a.lo, a.hi, a.label)}
               >
-                <title>{a.label} — play both strings</title>
+                <title>{`${a.label} — play both strings`}</title>
               </path>
               {a.big && (
                 <text

--- a/src/components/blog/lab/BoethiusLadderDemo.tsx
+++ b/src/components/blog/lab/BoethiusLadderDemo.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ToneEngine } from './audio';
+import { LabCard, Chip } from './LabCard';
+import { Genus, GPS_MOVABLE, GPS_NAMES, GPS_RULER, gpsRatios, noteName } from './pythagorean';
+
+const BASE = 110; // Proslambanomenos; Nete hyperboleon lands on A4 = 440
+const RUST = 'var(--accent-rust, #a8503c)';
+const BRASS = '#a16207';
+
+const rowY = (i: number) => 404 - i * 27;
+
+/** Arcs between the FIXED strings — these hold in every genus. */
+const ARCS: { lo: number; hi: number; label: string; big: boolean }[] = [
+  { lo: 0, hi: 7, label: 'diapason — the octave', big: true },
+  { lo: 7, hi: 14, label: 'diapason — the octave', big: true },
+  { lo: 4, hi: 8, label: 'diapente — the fifth', big: false },
+  { lo: 7, hi: 11, label: 'diapente — the fifth', big: false },
+  { lo: 1, hi: 4, label: 'diatessaron — the fourth', big: false },
+  { lo: 4, hi: 7, label: 'diatessaron — the fourth', big: false },
+  { lo: 8, hi: 11, label: 'diatessaron — the fourth', big: false },
+  { lo: 11, hi: 14, label: 'diatessaron — the fourth', big: false },
+  { lo: 0, hi: 1, label: 'tonus — the tone', big: false },
+  { lo: 7, hi: 8, label: 'tonus — the disjunction tone', big: false },
+];
+
+const GENUS_LABEL: Record<Genus, string> = { dia: 'Diatonic', chr: 'Chromatic', enh: 'Enharmonic' };
+
+/**
+ * The Greater Perfect System of our Boethius manuscript (De institutione
+ * musica, the wing-diagram pages of Book IV), replicated and strung: fifteen
+ * strings whose drawn lengths are true to the monochord numbers (f ∝ 1/N on
+ * the 9,216 ruler), arcs that play their dyads, and the three genera the
+ * manuscript itself draws. The diatonic ladder reproduces the manuscript
+ * tradition's canonical integers — 9216, 8192, 7776 … 2304 — exactly.
+ */
+export default function BoethiusLadderDemo() {
+  const [genus, setGenus] = useState<Genus>('dia');
+  const [ringing, setRinging] = useState<number[]>([]);
+  const [now, setNow] = useState('');
+  const engineRef = useRef<ToneEngine | null>(null);
+
+  useEffect(() => () => { engineRef.current?.dispose(); }, []);
+
+  const engine = () => {
+    if (!engineRef.current) engineRef.current = new ToneEngine();
+    return engineRef.current;
+  };
+
+  // Precompute every row's geometry and labels as plain scalars.
+  const ratios = gpsRatios(genus);
+  const rows = GPS_NAMES.map((name, i) => {
+    const ratio = ratios[i];
+    const N = GPS_RULER / ratio;
+    const freq = BASE * ratio;
+    return {
+      i,
+      name,
+      y: rowY(i),
+      x2: 150 + 320 * (N / GPS_RULER),
+      num: Math.round(N),
+      note: noteName(freq),
+      freq,
+      movable: GPS_MOVABLE.has(i),
+      rings: ringing.includes(i),
+    };
+  });
+
+  const ring = (i: number) => {
+    setRinging((prev) => [...prev, i]);
+    window.setTimeout(() => setRinging((prev) => prev.filter((x) => x !== i)), 480);
+  };
+  const announce = (i: number, rs: number[]) => {
+    setNow(`${GPS_NAMES[i]} · ${(BASE * rs[i]).toFixed(1)} Hz · ${noteName(BASE * rs[i])} · number ${Math.round(GPS_RULER / rs[i])}`);
+  };
+
+  const pluckRow = (i: number) => {
+    engine().pluck(BASE * ratios[i], 0, 0.9);
+    ring(i);
+    announce(i, ratios);
+  };
+
+  const playArc = (lo: number, hi: number, label: string) => {
+    const e = engine();
+    e.pluck(BASE * ratios[lo], 0, 0.9);
+    e.pluck(BASE * ratios[hi], 0, 0.9);
+    ring(lo); ring(hi);
+    setNow(`${label}: ${GPS_NAMES[lo]} + ${GPS_NAMES[hi]} · ${noteName(BASE * ratios[lo])} + ${noteName(BASE * ratios[hi])}`);
+  };
+
+  const selectGenus = (g: Genus) => {
+    setGenus(g);
+    const rs = gpsRatios(g);
+    const e = engine();
+    // Sound the genus: the meson tetrachord ascending, slow enough to follow.
+    [4, 5, 6, 7].forEach((r, k) => {
+      e.pluck(BASE * rs[r], k * 0.42, 0.9);
+      window.setTimeout(() => { ring(r); announce(r, rs); }, 60 + k * 420);
+    });
+  };
+
+  const runLadder = () => {
+    const e = engine();
+    for (let i = 0; i < 15; i++) {
+      e.pluck(BASE * ratios[i], i * 0.22, 0.8);
+      window.setTimeout(() => { ring(i); announce(i, ratios); }, 50 + i * 220);
+    }
+  };
+
+  return (
+    <LabCard
+      title="The Greater Perfect System, strung"
+      caption="The fifteen strings of ancient music as our manuscript diagrams them, with each string's monochord number on the 9,216 ruler. Tap strings, tap arcs, switch the genus — the brass strings are the movable notes, and their numbers re-divide as the manuscript's own diagrams show. Replicated from"
+      sourceHref="/book/de-institutione-musica-15th-c-ms-boethius?page=80"
+      sourceLabel="Boethius, De institutione musica (15th-c. MS)"
+    >
+      <div className="flex flex-wrap gap-1.5 mb-4">
+        {(['dia', 'chr', 'enh'] as Genus[]).map((g) => (
+          <Chip key={g} active={genus === g} onClick={() => selectGenus(g)}>{GENUS_LABEL[g]}</Chip>
+        ))}
+        <Chip onClick={runLadder}>▶ Run the ladder</Chip>
+      </div>
+
+      <svg viewBox="0 0 720 420" className="w-full h-auto" role="img"
+        aria-label="The fifteen strings of the Greater Perfect System drawn as a ladder, each labeled with its Greek name, modern note, and monochord number; arcs on the left connect the fixed strings by fourths, fifths, octaves and tones. Every string and arc is playable.">
+        {ARCS.map((a, k) => {
+          const y1 = rowY(a.lo);
+          const y2 = rowY(a.hi);
+          const depth = 16 + Math.abs(a.lo - a.hi) * 9;
+          const mid = (y1 + y2) / 2;
+          return (
+            <g key={k}>
+              <path
+                d={`M 146 ${y1} Q ${146 - depth} ${mid} 146 ${y2}`}
+                fill="none" stroke="#a8a29e" strokeWidth="1.2"
+                className="cursor-pointer hover:stroke-[var(--accent-rust,#a8503c)]"
+                onClick={() => playArc(a.lo, a.hi, a.label)}
+              >
+                <title>{a.label} — play both strings</title>
+              </path>
+              {a.big && (
+                <text
+                  x={146 - depth - 8} y={mid + 3} fontSize="9.5" fontFamily="monospace"
+                  fill="#a8a29e" textAnchor="middle" pointerEvents="none"
+                  transform={`rotate(-90 ${146 - depth - 8} ${mid})`}
+                >DIAPASON</text>
+              )}
+            </g>
+          );
+        })}
+        {rows.map((r) => (
+          <g key={r.i}>
+            <line
+              x1={150} y1={r.y} x2={r.x2} y2={r.y}
+              stroke={r.rings ? RUST : r.movable ? BRASS : '#44403c'}
+              strokeWidth={r.rings ? 2.6 : 2}
+              className="cursor-pointer" onClick={() => pluckRow(r.i)}
+            >
+              <title>{`${r.name} — ${r.freq.toFixed(1)} Hz, number ${r.num}`}</title>
+            </line>
+            <text x={478} y={r.y + 3.5} fontSize="10.5" fontFamily="monospace"
+              fill={r.rings ? RUST : '#78716c'}>{r.name}</text>
+            <text x={600} y={r.y + 3.5} fontSize="10.5" fontFamily="monospace"
+              fill={r.rings ? RUST : '#44403c'}>{r.note}</text>
+            <text x={716} y={r.y + 3.5} fontSize="10.5" fontFamily="monospace"
+              fill={r.rings ? RUST : BRASS} textAnchor="end">{r.num}</text>
+          </g>
+        ))}
+      </svg>
+
+      <p className="font-mono text-xs text-muted mt-3 min-h-[1.2em]" aria-live="polite">{now || ' '}</p>
+      <p className="text-xs text-muted mt-2">
+        The middle column gives each string&apos;s nearest modern note with its deviation in cents.
+        Even the diatonic sits a few cents off a modern tuner — pure 9:8 tones against equal
+        temperament — while the enharmonic&apos;s quarter-tones land ~50¢ between any modern frets.
+        The dieses here split the semitone equally; Boethius divides the ruler arithmetically, a
+        hair&apos;s difference the ear forgives.
+      </p>
+    </LabCard>
+  );
+}

--- a/src/components/blog/lab/GalileiStringsDemo.tsx
+++ b/src/components/blog/lab/GalileiStringsDemo.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ToneEngine } from './audio';
+import { LabCard, Readout, Chip } from './LabCard';
+import { outcomeName } from './pythagorean';
+
+const BASE = 220;
+const RUST = 'var(--accent-rust, #a8503c)';
+const BRASS = '#a16207';
+
+/**
+ * Galilei's two strings (Dialogo 1581, p. 145 of our copy): "two strings of
+ * the same length, thickness, and quality … stretched to unison over a flat
+ * surface", one of them shortened by a movable bridge — AND, the half he put
+ * on trial, loaded by a weight hung over the tail pulley. f = f0 · (1/L) · √W.
+ * Verified verbatim: sourcelibrary.org/q/BeoftnrTNYqCao3dYsz
+ */
+export default function GalileiStringsDemo() {
+  const [len, setLen] = useState(1); // sounding length of string II, 0.5–1
+  const [wgt, setWgt] = useState(1); // weight multiple on string II, 1–5
+  const [ringI, setRingI] = useState(false);
+  const [ringII, setRingII] = useState(false);
+  const engineRef = useRef<ToneEngine | null>(null);
+
+  useEffect(() => () => { engineRef.current?.dispose(); }, []);
+
+  const engine = () => {
+    if (!engineRef.current) engineRef.current = new ToneEngine();
+    return engineRef.current;
+  };
+
+  // Precomputed scalars only past this point (React Compiler hoist rule).
+  const freq = (BASE / len) * Math.sqrt(wgt);
+  const centsUp = Math.round(1200 * Math.log2(freq / BASE));
+  const verdict = outcomeName(centsUp);
+  const bridgeX = 74 + len * 700;
+  const panH = Math.round(16 + wgt * 9);
+  const panLabelY = 264 + panH + 17;
+  const lenPct = Math.round(len * 100);
+  const wgtLabel = wgt.toFixed(2);
+
+  const flash = (which: 'I' | 'II' | 'both') => {
+    if (which !== 'II') { setRingI(true); window.setTimeout(() => setRingI(false), 600); }
+    if (which !== 'I') { setRingII(true); window.setTimeout(() => setRingII(false), 600); }
+  };
+
+  const playI = () => { engine().pluck(BASE); flash('I'); };
+  const playII = () => { engine().pluck(freq); flash('II'); };
+  const playBoth = () => {
+    const e = engine();
+    e.pluck(BASE);
+    e.pluck(freq);
+    flash('both');
+  };
+
+  const preset = (l: number, w: number) => {
+    setLen(l);
+    setWgt(w);
+    const e = engine();
+    e.pluck(BASE);
+    e.pluck((BASE / l) * Math.sqrt(w));
+    flash('both');
+  };
+
+  return (
+    <LabCard
+      title="Galilei’s two strings"
+      caption="Two strings tuned in unison at 220 Hz. Shorten string II with the bridge, or load its pan over the tail pulley — and hear which handle keeps the legend's promises. Built to the apparatus Galilei describes on p. 145 —"
+      sourceHref="/book/dialogo-della-musica-antica-et-della-moderna-galilei?page=145"
+      sourceLabel="Vincenzo Galilei, Dialogo (1581)"
+    >
+      <svg viewBox="0 0 900 340" className="w-full h-auto" role="img"
+        aria-label="Two monochord strings over a soundbox: string one is a fixed reference, string two has a movable bridge and a weight hanging over a pulley at its tail.">
+        <rect x="40" y="46" width="800" height="210" rx="6" fill="none" stroke="#78716c" strokeWidth="1.5" />
+        <circle cx="330" cy="152" r="24" fill="none" stroke="#a8a29e" strokeWidth="0.8" />
+        <circle cx="330" cy="152" r="15" fill="none" stroke="#a8a29e" strokeWidth="0.8" />
+        <rect x="66" y="80" width="8" height="30" fill={BRASS} />
+        <rect x="66" y="190" width="8" height="30" fill={BRASS} />
+        <rect x="806" y="80" width="8" height="30" fill={BRASS} />
+        <line
+          x1="74" y1="95" x2="806" y2="95"
+          stroke={ringI ? RUST : '#44403c'} strokeWidth={ringI ? 2.6 : 2}
+          className="cursor-pointer" onClick={playI}
+        >
+          <title>Pluck string I — the whole string, 220 Hz</title>
+        </line>
+        <text x="74" y="78" fontSize="12" fill="#78716c" fontFamily="monospace">I · THE WHOLE STRING · 220 HZ</text>
+        <line
+          x1="74" y1="205" x2={bridgeX} y2="205"
+          stroke={ringII ? RUST : '#44403c'} strokeWidth={ringII ? 2.6 : 2}
+          className="cursor-pointer" onClick={playII}
+        >
+          <title>Pluck string II</title>
+        </line>
+        <line x1={bridgeX} y1="205" x2="806" y2="205" stroke="#a8a29e" strokeWidth="1.2" strokeDasharray="4 5" />
+        <polygon points={`${bridgeX},200 ${bridgeX - 10},220 ${bridgeX + 10},220`} fill={BRASS} />
+        <text x="74" y="188" fontSize="12" fill="#78716c" fontFamily="monospace">II · BRIDGE + WEIGHT</text>
+        <circle cx="850" cy="205" r="13" fill="none" stroke="#44403c" strokeWidth="1.5" />
+        <line x1="806" y1="205" x2="850" y2="192" stroke="#44403c" strokeWidth="1.1" />
+        <line x1="863" y1="205" x2="863" y2="264" stroke="#44403c" strokeWidth="1.1" />
+        <rect x="845" y="264" width="36" height={panH} fill="none" stroke={RUST} strokeWidth="1.5" />
+        <text x="864" y={panLabelY} fontSize="13" fill={RUST} fontFamily="monospace" textAnchor="middle">{wgtLabel}×</text>
+      </svg>
+
+      <div className="grid md:grid-cols-2 gap-x-7 gap-y-4 mt-4">
+        <label className="block">
+          <span className="flex items-baseline justify-between text-sm text-secondary mb-1">
+            <span>The bridge — sounding length of string II</span>
+            <span className="font-mono text-primary">{lenPct}%</span>
+          </span>
+          <input
+            type="range" min={0.5} max={1} step={0.001} value={len}
+            onChange={(e) => setLen(Number(e.target.value))}
+            className="w-full accent-[var(--accent-rust,#a8503c)]"
+            aria-label="Sounding length of string II as a fraction of string I"
+          />
+        </label>
+        <label className="block">
+          <span className="flex items-baseline justify-between text-sm text-secondary mb-1">
+            <span>The pan — weight hung on string II</span>
+            <span className="font-mono text-primary">{wgtLabel}×</span>
+          </span>
+          <input
+            type="range" min={1} max={5} step={0.01} value={wgt}
+            onChange={(e) => setWgt(Number(e.target.value))}
+            className="w-full accent-[var(--accent-rust,#a8503c)]"
+            aria-label="Weight hung on string II as a multiple of string I's tension"
+          />
+        </label>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        <Chip onClick={playI}>▶ String I</Chip>
+        <Chip onClick={playII}>▶ String II</Chip>
+        <Chip onClick={playBoth}>▶ Both together</Chip>
+      </div>
+
+      <p className="text-xs text-muted mt-4 mb-1.5">His presets, in his words — deprive string II of:</p>
+      <div className="flex flex-wrap gap-1.5">
+        <Chip onClick={() => preset(0.5, 1)}>“half” — the Diapason</Chip>
+        <Chip onClick={() => preset(2 / 3, 1)}>“a third part” — the Diapente</Chip>
+        <Chip onClick={() => preset(0.75, 1)}>“a fourth” — the Diatessaron</Chip>
+        <Chip onClick={() => preset(8 / 9, 1)}>“a ninth” — the Tone</Chip>
+      </div>
+      <p className="text-xs text-muted mt-3 mb-1.5">…or leave the bridge alone and load the pan instead:</p>
+      <div className="flex flex-wrap gap-1.5">
+        <Chip onClick={() => preset(1, 2)}>the legend’s octave — 2× weight</Chip>
+        <Chip onClick={() => preset(1, 4)}>the octave the bench demands — 4× weight</Chip>
+        <Chip onClick={() => preset(1, 2.25)}>9 : 4 in the pan — a pure fifth</Chip>
+      </div>
+
+      <div className="mt-4 grid grid-cols-3 gap-3">
+        <Readout label="String II" value={`${freq.toFixed(1)} Hz`} note="string I stays 220.0 Hz" />
+        <Readout label="Interval" value={`${centsUp} ¢`} note={verdict.pure ? `✓ ${verdict.label}` : verdict.label} />
+        <Readout label="The law" value="f ∝ (1/L)·√W" note={`L ${len.toFixed(2)} · W ${wgtLabel}`} />
+      </div>
+    </LabCard>
+  );
+}

--- a/src/components/blog/lab/LyreReadingsDemo.tsx
+++ b/src/components/blog/lab/LyreReadingsDemo.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ToneEngine } from './audio';
+import { LabCard, Chip } from './LabCard';
+
+const RUST = 'var(--accent-rust, #a8503c)';
+const NUMBERS = [6, 8, 9, 12];
+const XS = [150, 370, 590, 810];
+
+type Reading = 'len' | 'wgt' | 'ham';
+
+/**
+ * The Lyre of Mercury's four numbers — 6 · 8 · 9 · 12 — read three ways.
+ * Galilei records the fight over which end is low (Dialogo p. 144: Plutarch
+ * puts 6 on the lowest string, the Zarlino camp 12 — "exactly the opposite")
+ * and diagnoses it: one camp read the numbers as weights, the other as
+ * measures. Each reading is a different physical law, so each sings a
+ * different chord. Verified verbatim: sourcelibrary.org/q/BeoftnrTNYqCao3dYsy
+ */
+const READINGS: Record<Reading, {
+  button: string;
+  freqs: number[];
+  pure: boolean;
+  verdict: string;
+  direction: string;
+}> = {
+  len: {
+    button: 'As lengths — Zarlino’s direction',
+    freqs: NUMBERS.map((n) => 1760 / n),
+    pure: true,
+    verdict:
+      '12:6 sounds the octave; 12:8 and 9:6 pure fifths; 12:9 and 8:6 pure fourths; 9:8 the tone. The Greatest Harmony, exactly as promised — the long string lies low, just as Zarlino’s direction says.',
+    direction: 'sounding low → high: 12 · 9 · 8 · 6 — bigger number, deeper voice.',
+  },
+  wgt: {
+    button: 'As hung weights — Plutarch’s direction',
+    freqs: NUMBERS.map((n) => 165 * Math.sqrt(n / 6)),
+    pure: false,
+    verdict:
+      'Every span halves: 12 against 6 sounds 600¢ — the tritone — the “fifths” sound 351¢, the “fourths” 249¢. No names in the scale. But notice the direction: the heaviest weight sings highest, exactly as Plutarch’s ordering implies. Right direction, wrong intervals.',
+    direction: 'sounding low → high: 6 · 8 · 9 · 12 — bigger weight, higher voice.',
+  },
+  ham: {
+    button: 'As struck hammers — scale model',
+    freqs: NUMBERS.map((n) => 260 * Math.cbrt(6 / n)),
+    pure: false,
+    verdict:
+      'Solid bodies scale by the cube root: 12 against 6 rings only ~400¢ apart and the whole chord crushes into a cluster — with the heavy hammer sunk low, against both the legend and Galilei’s own guess. And in a real forge the anvil sings one note regardless of the hammer.',
+    direction: 'sounding low → high: 12 · 9 · 8 · 6 — but squeezed to a third of the promised spans.',
+  },
+};
+
+export default function LyreReadingsDemo() {
+  const [reading, setReading] = useState<Reading>('len');
+  const [ringing, setRinging] = useState<number[]>([]);
+  const engineRef = useRef<ToneEngine | null>(null);
+
+  useEffect(() => () => { engineRef.current?.dispose(); }, []);
+
+  const R = READINGS[reading];
+
+  const play = (r: Reading) => {
+    setReading(r);
+    if (!engineRef.current) engineRef.current = new ToneEngine();
+    const e = engineRef.current;
+    const cfg = READINGS[r];
+    const order = cfg.freqs
+      .map((f, i) => ({ f, i }))
+      .sort((a, b) => a.f - b.f);
+    order.forEach(({ f, i }, k) => {
+      e.pluck(f, k * 0.32, 0.9);
+      window.setTimeout(() => {
+        setRinging((prev) => [...prev, i]);
+        window.setTimeout(() => setRinging((prev) => prev.filter((x) => x !== i)), 480);
+      }, 60 + k * 320);
+    });
+    cfg.freqs.forEach((f) => e.pluck(f, 4 * 0.32 + 0.5, 0.6));
+  };
+
+  // Precomputed geometry per station (React Compiler hoist rule).
+  const stations = NUMBERS.map((n, i) => {
+    const x = XS[i];
+    const rings = ringing.includes(i);
+    const stringLen = n * 17;
+    const panSide = 14 + n * 3.2;
+    const hamW = 26 + n * 5.5;
+    const hamH = 16 + n * 3;
+    const labelY =
+      reading === 'len' ? 34 + stringLen + 32 :
+      reading === 'wgt' ? 152 + panSide + 26 :
+      72 + hamH + 30;
+    return { n, x, rings, stringLen, panSide, hamW, hamH, labelY, freq: R.freqs[i] };
+  });
+
+  return (
+    <LabCard
+      title="The Lyre of Mercury — but which way up?"
+      caption="Boethius gives Mercury's lyre four strings in the proportions 6 · 8 · 9 · 12 — the hammer numbers. Plutarch's camp put 6 on the lowest string; Zarlino's put 12 there, and Galilei saw why: one camp read the numbers as weights, the other as lengths. Each reading is a law; each law is a chord. Choose one and listen —"
+      sourceHref="/book/dialogo-della-musica-antica-et-della-moderna-galilei?page=144"
+      sourceLabel="Vincenzo Galilei, Dialogo (1581), p. 144"
+    >
+      <div className="flex flex-wrap gap-1.5 mb-4">
+        {(Object.keys(READINGS) as Reading[]).map((r) => (
+          <Chip key={r} active={reading === r} onClick={() => play(r)}>
+            ▶ {READINGS[r].button}
+          </Chip>
+        ))}
+      </div>
+
+      <svg viewBox="0 0 900 300" className="w-full h-auto" role="img"
+        aria-label="Four strings, weights, or hammers labeled 6, 8, 9 and 12, drawn according to the selected physical reading of the numbers.">
+        <line x1="60" y1="34" x2="840" y2="34" stroke="#44403c" strokeWidth="2" />
+        {stations.map((s) => (
+          <g key={s.n}>
+            {reading !== 'ham' && (
+              <line
+                x1={s.x} y1={34} x2={s.x}
+                y2={reading === 'len' ? 34 + s.stringLen : 144}
+                stroke={s.rings ? RUST : '#44403c'} strokeWidth={s.rings ? 2.6 : 2}
+              />
+            )}
+            {reading === 'len' && (
+              <rect x={s.x - 11} y={34 + s.stringLen} width={22} height={7} fill="#a16207" />
+            )}
+            {reading === 'wgt' && (
+              <g>
+                <line x1={s.x} y1={144} x2={s.x} y2={152} stroke="#44403c" strokeWidth="1.1" />
+                <rect
+                  x={s.x - s.panSide / 2} y={152} width={s.panSide} height={s.panSide}
+                  fill="none" stroke={s.rings ? RUST : '#a8503c'} strokeWidth={s.rings ? 2.4 : 1.5}
+                />
+              </g>
+            )}
+            {reading === 'ham' && (
+              <g>
+                <line x1={s.x} y1={34} x2={s.x} y2={72} stroke="#44403c" strokeWidth="1.1" />
+                <rect
+                  x={s.x - s.hamW / 2} y={72} width={s.hamW} height={s.hamH}
+                  fill="none" stroke={s.rings ? RUST : '#44403c'} strokeWidth={s.rings ? 2.4 : 1.8}
+                />
+              </g>
+            )}
+            <text x={s.x} y={s.labelY} fontSize="22" fontFamily="serif" fontWeight="700"
+              fill={s.rings ? RUST : '#a16207'} textAnchor="middle">{s.n}</text>
+            <text x={s.x} y={s.labelY + 18} fontSize="11" fontFamily="monospace"
+              fill="#78716c" textAnchor="middle">{s.freq.toFixed(1)} HZ</text>
+          </g>
+        ))}
+      </svg>
+
+      <div className={`mt-3 px-3 py-2.5 text-sm border-l-[3px] bg-cream ${R.pure ? 'border-emerald-700' : 'border-[var(--accent-rust,#a8503c)]'}`}>
+        {R.verdict}
+      </div>
+      <p className="text-xs text-muted italic mt-2">{R.direction}</p>
+    </LabCard>
+  );
+}

--- a/src/components/blog/lab/audio.ts
+++ b/src/components/blog/lab/audio.ts
@@ -180,6 +180,33 @@ export class ToneEngine {
     return new Promise((resolve) => window.setTimeout(resolve, ms + 40));
   }
 
+  /**
+   * One plucked-string note: eight partials at 1/n^1.1, higher partials
+   * decaying faster (τ = 0.55/n^0.75 s) — the playable-facsimile demos'
+   * voice (#3224). `at` is seconds from now (for arpeggios); level 1 peaks
+   * around −14 dBFS after the master bus.
+   */
+  pluck(freq: number, at = 0, level = 1) {
+    const ctx = this.ensure();
+    if (!ctx || !this.master) return;
+    const t0 = ctx.currentTime + 0.02 + Math.max(0, at);
+    for (let h = 1; h <= 8; h++) {
+      const osc = ctx.createOscillator();
+      osc.type = 'sine';
+      osc.frequency.value = freq * h;
+      const g = ctx.createGain();
+      const a = (1.27 * level) / Math.pow(h, 1.1);
+      const tau = 0.55 / Math.pow(h, 0.75);
+      g.gain.setValueAtTime(0.0001, t0);
+      g.gain.linearRampToValueAtTime(a, t0 + 0.01);
+      g.gain.setTargetAtTime(0.0001, t0 + 0.015, tau);
+      osc.connect(g);
+      g.connect(this.master);
+      osc.start(t0);
+      osc.stop(t0 + 2.6);
+    }
+  }
+
   dispose() {
     try {
       for (const v of this.voices.values()) { v.osc.stop(); v.lfo?.stop(); }

--- a/src/components/blog/lab/pythagorean.ts
+++ b/src/components/blog/lab/pythagorean.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared Pythagorean interval arithmetic for the playable-facsimile demos
+ * (/blog/playable-page, issue #3224). Everything is computed from exact
+ * ratios (9:8 tone, 256:243 limma, 2187:2048 apotome), never from rounded
+ * cents — that is what lets the Boethius ladder reproduce the manuscript's
+ * canonical monochord integers (9216, 8192 … 2304) on the nose.
+ */
+
+export const LIMMA = 256 / 243;
+export const APOTOME = 2187 / 2048;
+
+export const cents = (ratio: number) => 1200 * Math.log2(ratio);
+
+/** Just-interval names within the tolerance the demos display. */
+const JUST_TABLE: [number, string][] = [
+  [0, 'a unison'],
+  [204, 'a whole tone'],
+  [498, 'a pure fourth'],
+  [702, 'a pure fifth'],
+  [996, 'a minor seventh — two fourths'],
+  [1200, 'the octave'],
+  [1404, 'an octave and a tone — two fifths'],
+  [1698, 'an octave and a fourth'],
+  [1902, 'an octave and a fifth'],
+  [2400, 'a double octave'],
+];
+
+export function justName(c: number): string | null {
+  for (const [jc, name] of JUST_TABLE) {
+    if (Math.abs(jc - c) <= 6) return name;
+  }
+  return null;
+}
+
+/** Display name for a bench outcome: just name, tritone, or honest nothing. */
+export function outcomeName(c: number): { label: string; pure: boolean } {
+  const name = justName(c);
+  if (name) return { label: name, pure: true };
+  if (Math.abs(c - 600) <= 6) return { label: 'the tritone — √2', pure: false };
+  return { label: 'no name in the scale', pure: false };
+}
+
+const NOTE_NAMES = ['C', 'C♯', 'D', 'D♯', 'E', 'F', 'F♯', 'G', 'G♯', 'A', 'A♯', 'B'];
+
+/** Nearest modern (12-TET, A440) note name with signed cent deviation ≥3¢. */
+export function noteName(f: number): string {
+  const midiF = 69 + 12 * Math.log2(f / 440);
+  const midi = Math.round(midiF);
+  const off = Math.round((midiF - midi) * 100);
+  const label = NOTE_NAMES[((midi % 12) + 12) % 12] + (Math.floor(midi / 12) - 1);
+  return Math.abs(off) < 3 ? label : `${label} ${off > 0 ? '+' : '−'}${Math.abs(off)}¢`;
+}
+
+/**
+ * The Greater Perfect System: fifteen strings, Proslambanomenos → Nete
+ * hyperboleon. Fixed strings carry exact ratios vs Proslambanomenos; movable
+ * strings are genus offsets from their tetrachord's lowest fixed string.
+ */
+export const GPS_NAMES = [
+  'Proslambanomenos', 'Hypate hypaton', 'Parhypate hypaton', 'Lichanos hypaton',
+  'Hypate meson', 'Parhypate meson', 'Lichanos meson', 'Mese', 'Paramese',
+  'Trite diezeugmenon', 'Paranete diezeug.', 'Nete diezeugmenon',
+  'Trite hyperboleon', 'Paranete hyperb.', 'Nete hyperboleon',
+];
+
+const GPS_FIXED: Record<number, number> = { 0: 1, 1: 9 / 8, 4: 3 / 2, 7: 2, 8: 9 / 4, 11: 3, 14: 4 };
+const GPS_TETRA: Record<number, [number, number]> = {
+  2: [1, 0], 3: [1, 1], 5: [4, 0], 6: [4, 1],
+  9: [8, 0], 10: [8, 1], 12: [11, 0], 13: [11, 1],
+};
+
+export type Genus = 'dia' | 'chr' | 'enh';
+
+/**
+ * Inner-note offsets per genus (ratio above the tetrachord base). The
+ * enharmonic dieses are equal halves of the limma in log-pitch; Boethius
+ * divides the ruler arithmetically — a hair's difference, noted in the copy.
+ */
+const GENUS_STEPS: Record<Genus, [number, number]> = {
+  dia: [LIMMA, LIMMA * (9 / 8)],
+  chr: [LIMMA, LIMMA * APOTOME],
+  enh: [Math.sqrt(LIMMA), LIMMA],
+};
+
+export const GPS_RULER = 9216;
+
+export function gpsRatios(genus: Genus): number[] {
+  const steps = GENUS_STEPS[genus];
+  const out: number[] = [];
+  for (let i = 0; i < 15; i++) {
+    const fixed = GPS_FIXED[i];
+    if (fixed !== undefined) {
+      out.push(fixed);
+    } else {
+      const [base, step] = GPS_TETRA[i];
+      out.push(GPS_FIXED[base] * steps[step]);
+    }
+  }
+  return out;
+}
+
+export const GPS_MOVABLE = new Set(Object.keys(GPS_TETRA).map(Number));


### PR DESCRIPTION
## What

Fourth post in the harmony set (`/blog/playable-page`) + the first three **playable facsimiles** per #3224: manuscript diagrams replicated as sounding lab components.

- **`GalileiStringsDemo`** — the two-string bench Galilei describes on p. 145 of the *Dialogo* (bridge + weight pan over a tail pulley, f = f₀·(1/L)·√W). Presets are his sentence verbatim ("half — the Diapason", "a third part — the Diapente"…) plus the weight trio (2× = the legend's octave → tritone; 4× = the real octave; 9:4 → a pure fifth).
- **`LyreReadingsDemo`** — the Lyre of Mercury's 6·8·9·12 read three ways (lengths / hung weights / struck hammers), dramatizing the p. 144 ordering dispute Galilei diagnoses: the direction of the scale is the fossil of the physical hypothesis. Each reading draws differently AND sounds differently.
- **`BoethiusLadderDemo`** — the Greater Perfect System from our Boethius MS wing-diagram page, 15 strings with drawn length ∝ monochord number. Exact ratio arithmetic reproduces the canonical integers (9216, 8192, 7776 … 2304). Genus toggle (diatonic/chromatic/enharmonic — the two the page draws) re-divides the movable strings; every string shows its modern note + cents deviation; arcs play dyads; live now-sounding readout.

Shared additions: `pythagorean.ts` (exact ratio arithmetic, GPS data, note naming) and a `pluck()` voice on `ToneEngine` (8 partials, per-partial decay). The engine change is purely additive — no existing station's API touched.

## Source integrity

All quoted period words verified via get_quote before shipping: [q/BeoftnrTNYqCao3dYsz](https://sourcelibrary.org/q/BeoftnrTNYqCao3dYsz) (p145 apparatus + monochord origin), [q/BeoftnrTNYqCao3dYsy](https://sourcelibrary.org/q/BeoftnrTNYqCao3dYsy) (p144 lyre orderings + hammer direction), [q/BeoftnrTNYqCao3dYt3](https://sourcelibrary.org/q/BeoftnrTNYqCao3dYt3) (p149 five-hammers arithmetic). Every demo and folio carries `sourceHref` (?page=N form). Honesty notes in copy: enharmonic dieses drawn as equal limma halves vs Boethius' arithmetic division; struck-hammer case not settleable in a browser.

## Conventions honored

- Metadata: explicit `openGraph.images` + mirrored `twitter` block (social-card invariant).
- Blog index entry added to `posts[]` (single source of truth, feeds RSS).
- React Compiler rule: all geometry precomputed as plain scalars; conditional JSX renders scalars only.
- AudioContext on gesture only; engines disposed on unmount; trial-free page (no data collected).

## Out of scope (deliberate)

- Station I v2 upgrade on /blog/sound-laboratory (this post links to it instead; upgrading the station is a separate PR against the #3160 v2 briefs).
- The #3224 per-page registry — worth adding when a second batch of pages lands; three components don't yet earn the abstraction.

Refs #3224, #3160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)