### PR TITLE
Route untranslated editions to their translated work_id sibling (#3033)

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -25,6 +25,7 @@ import DownloadButton from '@/components/ui/DownloadButton';
 import BibliographicInfo from '@/components/book/BibliographicInfo';
 import BphCatalogueRecord from '@/components/book/BphCatalogueRecord';
 import OriginalEditionNotice from '@/components/book/OriginalEditionNotice';
+import TranslatedSiblingNotice from '@/components/book/TranslatedSiblingNotice';
 import RelatedEditions from '@/components/book/RelatedEditions';
 import IndexCatalogChip from '@/components/book/IndexCatalogChip';
 import RelatedBooks from '@/components/book/RelatedBooks';
@@ -916,6 +917,25 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, previewProposed
                   />
                 </Suspense>
               )}
+
+              {/* Sibling-edition routing (#3033) — an effectively-untranslated
+                  edition of a work we hold translated should point the reader
+                  at the translated sibling, not read as a dead end. Skipped for
+                  books that are themselves English translations (they're
+                  already readable). Tenant-gated like RelatedEditions. */}
+              {embedPolicy.showRelatedEditions &&
+                (book as any).work_id &&
+                totalPages > 0 &&
+                translatedCount / totalPages < 0.05 &&
+                !['modern-translation', 'period-translation'].includes((book as any).text_role) && (
+                  <Suspense fallback={null}>
+                    <TranslatedSiblingNotice
+                      bookId={book.id}
+                      workId={(book as any).work_id}
+                      showCrossLink={embedPolicy.showRelatedEditions}
+                    />
+                  </Suspense>
+                )}
 
               {/* Read This Book — first chapter > endpaper-skip fallback */}
               {embedPolicy.showBookReadCta && (() => {

--- a/src/components/book/TranslatedSiblingNotice.tsx
+++ b/src/components/book/TranslatedSiblingNotice.tsx
@@ -1,0 +1,78 @@
+import { getReadDb } from '@/lib/mongodb';
+import Link from 'next/link';
+import { Languages } from 'lucide-react';
+
+/**
+ * Reader-routing notice for effectively-untranslated books: when a sibling
+ * edition of the same work (shared books.work_id) is substantially translated,
+ * point the reader at it instead of letting a translated work look like a
+ * dead end. See issue #3033 (a reader requested a translation of a 0/64 Monas
+ * hieroglyphica edition while four fully-translated sibling editions existed).
+ *
+ * The page only renders this when the current book is effectively untranslated;
+ * this component finds the best translated sibling (highest translated
+ * fraction) and returns null when there is none.
+ *
+ * `showCrossLink` must be embedPolicy.showRelatedEditions: sibling editions are
+ * a whole-library query by work_id, gated on tenant subdomains exactly like
+ * RelatedEditions (tenant lockdown).
+ */
+
+interface TranslatedSiblingNoticeProps {
+  bookId: string;
+  workId: string;
+  showCrossLink: boolean;
+}
+
+interface SiblingEdition {
+  id?: string;
+  slug?: string;
+  title?: string;
+  year?: number;
+  language?: string;
+  pages_count?: number;
+  pages_translated?: number;
+}
+
+export default async function TranslatedSiblingNotice({
+  bookId,
+  workId,
+  showCrossLink,
+}: TranslatedSiblingNoticeProps) {
+  if (!showCrossLink || !workId) return null;
+
+  const db = await getReadDb();
+  const siblings = (await db.collection('books').find(
+    { work_id: workId, id: { $ne: bookId }, visible: true, pages_translated: { $gt: 0 } },
+    {
+      projection: { _id: 0, id: 1, slug: 1, title: 1, year: 1, language: 1, pages_count: 1, pages_translated: 1 },
+      limit: 20,
+      maxTimeMS: 3000,
+    },
+  ).toArray().catch(() => [])) as SiblingEdition[];
+
+  // Best sibling = highest translated fraction; only offer editions that are
+  // actually readable in English (>=50%, the page's own hasTranslations bar).
+  const ratio = (b: SiblingEdition) => (b.pages_translated ?? 0) / Math.max(1, b.pages_count ?? 0);
+  const best = siblings
+    .filter((b) => ratio(b) >= 0.5)
+    .sort((a, b) => ratio(b) - ratio(a))[0];
+  if (!best) return null;
+
+  return (
+    <div className="mt-3 flex items-start gap-2.5 p-3 bg-stone-800/50 rounded-lg border border-stone-700/50 text-sm">
+      <Languages className="w-4 h-4 mt-0.5 text-accent-gold flex-shrink-0" />
+      <div className="text-stone-300">
+        This edition is not yet translated, but the library holds this work in English —{' '}
+        <Link
+          href={`/book/${encodeURIComponent(best.slug || best.id || '')}`}
+          className="text-accent-gold hover:text-accent-gold/80 underline underline-offset-2"
+        >
+          {best.title}
+          {best.year ? ` (${best.year})` : ''}
+        </Link>
+        .
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why
A reader requested a translation of a 0/64-translated Monas hieroglyphica edition while four fully-translated sibling editions existed (#3033). Nothing routed them from the dead-end edition to the readable one — the reader-facing gap in the work-identity layer.

## What
- New `TranslatedSiblingNotice` server component (modeled on `OriginalEditionNotice`): finds visible siblings sharing `books.work_id` with `pages_translated > 0`, picks the highest translated fraction, offers it only when that fraction is ≥50% (the page's own `hasTranslations` bar).
- Rendered in the book page hero band (next to the historical-translation notice, above the Read CTA) only when the current book is effectively untranslated (<5% of pages) and is not itself an English translation.
- **Tenant lockdown:** whole-library `work_id` query, so it's gated by `embedPolicy.showRelatedEditions` exactly like `RelatedEditions` — never renders in embed/tenant mode.

## Verification
- `npx tsc --noEmit` clean.
- Query verified against prod: the #3033 Pymander case (0/472) resolves to `reg-lat-1352-trismegistus` (432/432) as best sibling; 14 translated siblings found, ratio filter behaves.
- Reach measured 2026-07-19: **157 visible dead-end books across 117 works** will show the link.

## Out of scope
- The `/work/[id]` aggregation page already lists editions; this PR only adds the routing notice on the dead-end book page.
- Sibling routing for partially-translated books (5–50%) — deliberate, to keep the notice truthful ("not yet translated").

🤖 Generated with [Claude Code](https://claude.com/claude-code)