### PR TITLE
Retain superseded OCR/translation on re-runs (#3240)

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -8,6 +8,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { saveRevisionsBeforeOverwrite } from '../lib/page-revisions.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
@@ -273,6 +274,14 @@ async function processOneJob(db, job) {
     }
 
     if (bulkOps.length > 0) {
+      // Retain any existing content as a revision before overwriting (#3240).
+      // No-op for pages getting their first OCR/translation.
+      await saveRevisionsBeforeOverwrite(
+        db,
+        bulkOps.map(op => op.updateOne.filter.id),
+        job.type === 'ocr' ? 'ocr' : 'translation',
+        { jobId: jobIdStr, reason: job.type === 'ocr' ? 'reocr_batch' : 'retranslate_batch' }
+      );
       const bulkResult = await db.collection('pages').bulkWrite(bulkOps, { ordered: false });
       successCount = bulkResult.matchedCount;
       failCount += (bulkOps.length - bulkResult.matchedCount);

--- a/scripts/batch/collect-multipage-ocr.mjs
+++ b/scripts/batch/collect-multipage-ocr.mjs
@@ -7,6 +7,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -206,6 +207,9 @@ async function main() {
           { id: pageId, ocr: null },
           { $set: { ocr: {} } }
         );
+
+        // Retain existing OCR as a revision before overwriting (#3240); no-op on first write
+        await saveRevisionBeforeOverwrite(db, pageId, 'ocr', { jobId: String(job._id), reason: 'reocr_batch' });
 
         const updateResult = await db.collection('pages').updateOne(
           { id: pageId },

--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -24,6 +24,7 @@
 
 import { MongoClient } from 'mongodb';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
+import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -252,6 +253,10 @@ async function processPage(page, promptText, db) {
     const pageType = extractPageType(result.text);
     const columns = extractColumns(result.text);
     const detectedImages = parseDetectedImages(result.text);
+
+    // Retain existing OCR as a revision before overwriting (#3240) —
+    // no-op in 'no-ocr' mode, fires in 'old-ocr'/'all' modes.
+    await saveRevisionBeforeOverwrite(db, page.id, 'ocr', { reason: 'reocr_realtime' });
 
     await db.collection('pages').updateOne(
       { id: page.id },

--- a/scripts/batch/realtime-reocr-efm.mjs
+++ b/scripts/batch/realtime-reocr-efm.mjs
@@ -18,6 +18,7 @@
 
 import { MongoClient } from 'mongodb';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
+import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -201,6 +202,9 @@ async function processPage(page, promptText, db) {
     const pageType = extractPageType(result.text);
     const columns = extractColumns(result.text);
     const detectedImages = parseDetectedImages(result.text);
+
+    // Retain existing OCR as a revision before overwriting (#3240)
+    await saveRevisionBeforeOverwrite(db, page.id, 'ocr', { reason: 'reocr_realtime' });
 
     // Save to MongoDB
     await db.collection('pages').updateOne(

--- a/scripts/batch/realtime-translate.mjs
+++ b/scripts/batch/realtime-translate.mjs
@@ -25,6 +25,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -225,6 +226,10 @@ async function processBook(book, pages, basePrompt, db, globalStats) {
       }
 
       const translationMeta = extractTranslationMetadata(result.text);
+
+      // Retain existing translation as a revision before overwriting (#3240) —
+      // no-op on first translation, fires in --stale mode re-translations.
+      await saveRevisionBeforeOverwrite(db, page.id, 'translation', { reason: 'retranslate_stale' });
 
       await db.collection('pages').updateOne(
         { id: page.id },

--- a/scripts/lib/page-revisions.mjs
+++ b/scripts/lib/page-revisions.mjs
@@ -1,0 +1,74 @@
+import { randomBytes } from 'crypto';
+
+/**
+ * Scripts-side twin of src/lib/page-revisions.ts createRevision().
+ *
+ * Doctrine (system map): every write to pages.ocr.data or pages.translation.data
+ * must save the existing content to `page_revisions` FIRST. A code path that
+ * skips this destroys a before/after pair that can never be backfilled (#3240).
+ *
+ * Both helpers are no-ops when the page has no existing content for the field,
+ * so callers can invoke them unconditionally — first writes cost one read and
+ * store nothing. Failures never throw: losing a revision must not block the
+ * content write itself.
+ *
+ * `reason` records why the content was superseded. Recommended values:
+ *   'reocr_batch' | 'reocr_realtime' | 'retranslate_batch' | 'retranslate_stale' |
+ *   'recitation_retry' | 'spread_split' | 'manual'
+ */
+
+// Placeholder texts that carry no content — not worth a revision document.
+const MARKER_TEXTS = new Set(['[RECITATION_BLOCKED]']);
+
+/**
+ * Bulk variant: one find + one insertMany for a batch of page ids.
+ * Returns the number of revisions written.
+ */
+export async function saveRevisionsBeforeOverwrite(db, pageIds, field, opts = {}) {
+  const { jobId, reason } = opts;
+  if (!pageIds || pageIds.length === 0) return 0;
+  try {
+    const pages = await db.collection('pages')
+      .find({ id: { $in: pageIds } }, { projection: { id: 1, book_id: 1, [field]: 1 } })
+      .toArray();
+
+    const now = new Date();
+    const docs = [];
+    for (const page of pages) {
+      const fieldData = page[field];
+      if (!fieldData?.data) continue; // first write — nothing to retain
+      if (MARKER_TEXTS.has(fieldData.data)) continue;
+      docs.push({
+        id: randomBytes(6).toString('hex'),
+        page_id: page.id,
+        book_id: page.book_id,
+        field,
+        data: fieldData.data,
+        source: fieldData.source || 'ai',
+        model: fieldData.model,
+        language: field === 'ocr' ? fieldData.language : (fieldData.source_language || fieldData.language),
+        prompt_version: fieldData.prompt_version,
+        edited_by: fieldData.edited_by,
+        job_id: fieldData.batch_job_id || jobId,
+        ...(reason ? { reason } : {}),
+        original_date: fieldData.updated_at || fieldData.edited_at,
+        created_at: now,
+      });
+    }
+    if (docs.length > 0) {
+      await db.collection('page_revisions').insertMany(docs, { ordered: false });
+    }
+    return docs.length;
+  } catch (e) {
+    console.error(`[page-revisions] Failed to save revisions (${field}, ${pageIds.length} pages): ${e.message?.slice(0, 80)}`);
+    return 0;
+  }
+}
+
+/**
+ * Single-page variant. Returns true if a revision was written.
+ */
+export async function saveRevisionBeforeOverwrite(db, pageId, field, opts = {}) {
+  const n = await saveRevisionsBeforeOverwrite(db, [pageId], field, opts);
+  return n > 0;
+}

--- a/tests/unit/page-revisions-scripts.test.ts
+++ b/tests/unit/page-revisions-scripts.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Guard for scripts/lib/page-revisions.mjs (#3240) — the scripts-side twin of
+ * src/lib/page-revisions.ts createRevision(). Every batch/realtime writer that
+ * overwrites pages.ocr.data or pages.translation.data must retain the prior
+ * content in page_revisions first. Pins:
+ *  1. Existing content → one revision doc with the superseded text + provenance.
+ *  2. First writes (no existing data) → no revision.
+ *  3. '[RECITATION_BLOCKED]' markers → no revision (placeholder, not content).
+ *  4. reason/jobId land on the doc; translation uses source_language.
+ *  5. DB failures are swallowed (never block the content write).
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  saveRevisionBeforeOverwrite,
+  saveRevisionsBeforeOverwrite,
+} from '../../scripts/lib/page-revisions.mjs';
+
+type AnyDoc = Record<string, unknown>;
+
+function fakeDb(pages: AnyDoc[]) {
+  const inserted: AnyDoc[] = [];
+  const db = {
+    collection(name: string) {
+      if (name === 'pages') {
+        return {
+          find(filter: { id: { $in: string[] } }) {
+            const ids = new Set(filter.id.$in);
+            return {
+              toArray: async () => pages.filter(p => ids.has(p.id as string)),
+            };
+          },
+        };
+      }
+      if (name === 'page_revisions') {
+        return {
+          insertMany: async (docs: AnyDoc[]) => {
+            inserted.push(...docs);
+            return { insertedCount: docs.length };
+          },
+        };
+      }
+      throw new Error(`unexpected collection ${name}`);
+    },
+  };
+  return { db, inserted };
+}
+
+describe('saveRevisionsBeforeOverwrite', () => {
+  it('retains existing OCR with provenance, reason, and jobId', async () => {
+    const { db, inserted } = fakeDb([
+      {
+        id: 'p1',
+        book_id: 'b1',
+        ocr: {
+          data: 'old text',
+          model: 'gemini-2.0-flash',
+          language: 'Latin',
+          source: 'batch_api',
+          prompt_version: 'v10',
+          batch_job_id: 'job-orig',
+          updated_at: new Date('2026-01-01'),
+        },
+      },
+    ]);
+    const n = await saveRevisionsBeforeOverwrite(db, ['p1'], 'ocr', {
+      jobId: 'job-new',
+      reason: 'reocr_batch',
+    });
+    expect(n).toBe(1);
+    expect(inserted).toHaveLength(1);
+    const doc = inserted[0];
+    expect(doc.page_id).toBe('p1');
+    expect(doc.book_id).toBe('b1');
+    expect(doc.field).toBe('ocr');
+    expect(doc.data).toBe('old text');
+    expect(doc.model).toBe('gemini-2.0-flash');
+    expect(doc.language).toBe('Latin');
+    expect(doc.prompt_version).toBe('v10');
+    expect(doc.reason).toBe('reocr_batch');
+    // batch_job_id on the superseded content wins over the incoming jobId
+    expect(doc.job_id).toBe('job-orig');
+    expect(doc.original_date).toEqual(new Date('2026-01-01'));
+  });
+
+  it('is a no-op for first writes and missing pages', async () => {
+    const { db, inserted } = fakeDb([
+      { id: 'p1', book_id: 'b1' }, // no ocr at all
+      { id: 'p2', book_id: 'b1', ocr: { data: '' } }, // empty
+    ]);
+    const n = await saveRevisionsBeforeOverwrite(db, ['p1', 'p2', 'p-missing'], 'ocr', {
+      reason: 'reocr_batch',
+    });
+    expect(n).toBe(0);
+    expect(inserted).toHaveLength(0);
+  });
+
+  it('skips [RECITATION_BLOCKED] markers', async () => {
+    const { db, inserted } = fakeDb([
+      { id: 'p1', book_id: 'b1', ocr: { data: '[RECITATION_BLOCKED]' } },
+    ]);
+    const n = await saveRevisionsBeforeOverwrite(db, ['p1'], 'ocr', { reason: 'recitation_retry' });
+    expect(n).toBe(0);
+    expect(inserted).toHaveLength(0);
+  });
+
+  it('uses source_language for translation revisions', async () => {
+    const { db, inserted } = fakeDb([
+      {
+        id: 'p1',
+        book_id: 'b1',
+        translation: { data: 'old translation', source_language: 'German', source: 'ai' },
+      },
+    ]);
+    const n = await saveRevisionsBeforeOverwrite(db, ['p1'], 'translation', {
+      reason: 'retranslate_stale',
+    });
+    expect(n).toBe(1);
+    expect(inserted[0].language).toBe('German');
+    expect(inserted[0].field).toBe('translation');
+  });
+
+  it('swallows DB errors instead of throwing', async () => {
+    const db = {
+      collection() {
+        throw new Error('connection lost');
+      },
+    };
+    const n = await saveRevisionsBeforeOverwrite(db, ['p1'], 'ocr', { reason: 'reocr_batch' });
+    expect(n).toBe(0);
+  });
+});
+
+describe('saveRevisionBeforeOverwrite', () => {
+  it('returns true when a revision was written, false otherwise', async () => {
+    const { db } = fakeDb([{ id: 'p1', book_id: 'b1', ocr: { data: 'x' } }]);
+    expect(await saveRevisionBeforeOverwrite(db, 'p1', 'ocr', { reason: 'manual' })).toBe(true);
+    expect(await saveRevisionBeforeOverwrite(db, 'p-missing', 'ocr')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3240.

## What
Wires the five batch/realtime scripts that overwrote `pages.ocr.data` / `pages.translation.data` without saving a revision through a new shared helper, `scripts/lib/page-revisions.mjs` (scripts-side twin of `src/lib/page-revisions.ts createRevision()`):

- `scripts/batch/collect-batch-results.mjs` — the local collector that lands bulk re-OCR batch results (bulk variant: one find + one insertMany per job)
- `scripts/batch/collect-multipage-ocr.mjs`
- `scripts/batch/realtime-ocr.mjs` — fires only in `old-ocr`/`all` modes
- `scripts/batch/realtime-reocr-efm.mjs`
- `scripts/batch/realtime-translate.mjs` — fires only in `--stale` re-translations

The helper adds a `reason` field on revision docs (`reocr_batch | reocr_realtime | retranslate_batch | retranslate_stale | recitation_retry | spread_split | manual`), skips `[RECITATION_BLOCKED]` placeholder markers, no-ops on first writes, and swallows failures so a lost revision never blocks the content write. `page_revisions` indexes already exist in `ensure-indexes.mjs`.

## Key finding vs the issue text
#3240 proposed a new `ocr_history` array / `ocr_supersessions` collection. That store already exists: `page_revisions` + `createRevision()`, with system-map doctrine that skipping it is a bug. The Hetzner workers (`batch-collector.mjs`, `pipeline-orchestrator.mjs`, `translate-worker.mjs`), the Vercel write-processor, and the editor/batch-save routes all already call it — the recitation-retry path named in the issue turned out to be covered (`pipeline-orchestrator.mjs:3303`). This PR closes the actual bypasses instead of adding a second store.

## Audited and found NOT to be gaps
- `split-book.mjs` — archives old spreads in place (negative `page_number`, `archived-spread`), so spread OCR survives splits; also writes a pre-split snapshot
- `bulk-reocr-local.mjs` / `bulk-reocr-opened-books.mjs` / `retranslate-stale.mjs` / `queue-*` — submit batch jobs only; the collectors write
- `retranslate-pages.mjs`, `fix-unclosed-note-tags.mjs` — already save revisions inline
- `batch-split-bph.mjs` — touches image fields and page numbers, not text
- `tmp-recitation-retry.mjs` — only overwrites `[RECITATION_BLOCKED]` markers (no content destroyed)

## Out of scope
- Consolidating the three existing inline `saveRevisionBeforeOverwrite` copies in the Hetzner workers onto the shared lib — identical behavior, but touching live workers is a separate low-risk cleanup
- Eval-side ingestion of revisions into the observations dataset (#3235)
- Editor/reader correction diffs (#3241, next PR)

## Testing
`tests/unit/page-revisions-scripts.test.ts` (6 tests) pins: revision content + provenance + reason, no-op on first write/missing page, marker skip, translation `source_language`, error swallowing. Scripts-only change — no Vercel deploy needed; Hetzner auto-pulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)