### PR TITLE
Capture editor correction diffs as labeled OCR/translation errors (#3241)

### DIFF
--- a/scripts/maintenance/ensure-indexes.mjs
+++ b/scripts/maintenance/ensure-indexes.mjs
@@ -265,6 +265,9 @@ export const INDEXES = [
   { collection: 'mcp_tool_calls', key: { 'ip_hash': 1, 'ts': -1 }, options: { 'name': 'ip_hash_1_ts_-1' }, why: 'Per-client analysis for the MCP tool-call log. src/lib/mcp-usage.ts.' },
   { collection: 'mcp_tool_calls', key: { 'tool': 1, 'ts': -1 }, options: { 'name': 'tool_1_ts_-1' }, why: '\'How is tool X doing\' queries. src/lib/mcp-usage.ts.' },
   { collection: 'mcp_tool_calls', key: { 'ts': 1 }, options: { 'name': 'ts_1' }, why: 'Plain ts range index — retention is manual per #2976 decision 2026-07-05; TTL removed (was 90d). src/lib/mcp-usage.ts ensureIndexes(), created lazily; live TTL swapped to plain by scripts/maintenance/swap-ttl-to-plain-indexes.mjs post-deploy.' },
+  // ── correction_events ─────────────────────────────────────────
+  { collection: 'correction_events', key: { 'page_id': 1, 'created_at': -1 }, options: { 'name': 'correction_events_page_idx', 'background': true }, why: 'Corrections for a page, newest first. src/lib/correction-events.ts (#3241).' },
+  { collection: 'correction_events', key: { 'field': 1, 'created_at': -1 }, options: { 'name': 'correction_events_field_idx', 'background': true }, why: 'Eval-side mining: all OCR (or translation) corrections in time order (#3241).' },
   // ── page_revisions ────────────────────────────────────────────
   { collection: 'page_revisions', key: { 'page_id': 1, 'field': 1, 'created_at': -1 }, options: { 'name': 'page_revisions_page_field_idx', 'background': true }, why: 'Lookup by page + field, newest first (revision history). Archived ensure-indexes route.' },
   { collection: 'page_revisions', key: { 'id': 1 }, options: { 'name': 'page_revisions_id_idx', 'background': true, 'unique': true }, why: 'Unique id lookup. Archived ensure-indexes route.' },

--- a/src/app/api/[tenant]/pages/[id]/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/route.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withAuth } from '@/lib/auth-helpers';
 import { createRevision } from '@/lib/page-revisions';
+import { recordCorrectionEvent } from '@/lib/correction-events';
 import { contentHash } from '@/lib/steganographia';
 
 export const preferredRegion = 'fra1';
@@ -117,13 +118,10 @@ export const PATCH = withAuth(async (request, session, context) => {
     const now = new Date();
     const editedBy = body.edited_by || 'Unknown';
 
-    // Create revisions of existing content before manual overwrite
-    if (body.ocr) {
-      await createRevision(id, 'ocr');
-    }
-    if (body.translation) {
-      await createRevision(id, 'translation');
-    }
+    // Create revisions of existing content before manual overwrite.
+    // The returned revision carries the before-text for the correction event below.
+    const ocrRevision = body.ocr ? await createRevision(id, 'ocr') : undefined;
+    const translationRevision = body.translation ? await createRevision(id, 'translation') : undefined;
 
     // Update OCR if provided - mark as manual edit
     if (body.ocr) {
@@ -171,6 +169,21 @@ export const PATCH = withAuth(async (request, session, context) => {
 
     if (!updatedPage) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
+    }
+
+    // Capture the correction as a labeled model error (#3241) — fire and forget
+    const sessionEmail = session.user?.email;
+    if (body.ocr) {
+      recordCorrectionEvent({
+        revision: ocrRevision, after: body.ocr.data,
+        editorRole: 'editor', editedBy: editedBy, sessionEmail, tenantId,
+      }).catch(() => {});
+    }
+    if (body.translation) {
+      recordCorrectionEvent({
+        revision: translationRevision, after: body.translation.data,
+        editorRole: 'editor', editedBy: editedBy, sessionEmail, tenantId,
+      }).catch(() => {});
     }
 
     // Track edit for the book (fire and forget - don't block response)

--- a/src/app/api/pages/[id]/route.ts
+++ b/src/app/api/pages/[id]/route.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withAuth, withAdminAuth } from '@/lib/auth-helpers';
 import { createRevision } from '@/lib/page-revisions';
+import { recordCorrectionEvent } from '@/lib/correction-events';
 import { contentHash } from '@/lib/steganographia';
 
 export const preferredRegion = 'fra1';
@@ -113,13 +114,10 @@ export const PATCH = withAuth(async (request, session, context) => {
     const now = new Date();
     const editedBy = body.edited_by || 'Unknown';
 
-    // Create revisions of existing content before manual overwrite
-    if (body.ocr) {
-      await createRevision(id, 'ocr');
-    }
-    if (body.translation) {
-      await createRevision(id, 'translation');
-    }
+    // Create revisions of existing content before manual overwrite.
+    // The returned revision carries the before-text for the correction event below.
+    const ocrRevision = body.ocr ? await createRevision(id, 'ocr') : undefined;
+    const translationRevision = body.translation ? await createRevision(id, 'translation') : undefined;
 
     // Update OCR if provided - mark as manual edit
     if (body.ocr) {
@@ -167,6 +165,21 @@ export const PATCH = withAuth(async (request, session, context) => {
 
     if (!updatedPage) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
+    }
+
+    // Capture the correction as a labeled model error (#3241) — fire and forget
+    const sessionEmail = session.user?.email;
+    if (body.ocr) {
+      recordCorrectionEvent({
+        revision: ocrRevision, after: body.ocr.data,
+        editorRole: 'editor', editedBy: editedBy, sessionEmail, tenantId,
+      }).catch(() => {});
+    }
+    if (body.translation) {
+      recordCorrectionEvent({
+        revision: translationRevision, after: body.translation.data,
+        editorRole: 'editor', editedBy: editedBy, sessionEmail, tenantId,
+      }).catch(() => {});
     }
 
     // Track edit for the book (fire and forget - don't block response)

--- a/src/lib/correction-events.ts
+++ b/src/lib/correction-events.ts
@@ -1,0 +1,96 @@
+import { getDb } from './mongodb';
+import { nanoid } from 'nanoid';
+import type { PageRevision } from './page-revisions';
+
+/**
+ * Correction events (#3241) — human corrections captured as labeled model errors.
+ *
+ * Every manual edit of OCR or translation text is the highest-value quality
+ * signal we have: a person looked at the page image and fixed what the model
+ * got wrong. `page_revisions` retains the before-text for recovery; this
+ * collection additionally stores the immutable before/after PAIR with who
+ * corrected it, so eval tooling can mine error taxonomies per script/source
+ * without reconstructing pairs from revision history.
+ *
+ * Write-path hook only — no UI. Failures are swallowed: losing an event must
+ * never block the edit itself.
+ */
+
+export interface CorrectionEvent {
+  id: string;
+  page_id: string;
+  book_id: string;
+  field: 'ocr' | 'translation';
+  before: string;
+  after: string;
+  /** Provenance of the corrected (before) text — which model made the error. */
+  before_model?: string;
+  before_source?: string;
+  before_prompt_version?: string;
+  /** Link to the page_revisions doc holding the same before-text. */
+  revision_id?: string;
+  editor_role: 'editor' | 'reader';
+  /** Display name supplied by the editor UI. */
+  edited_by?: string;
+  /** Authenticated identity from the session. */
+  session_email?: string;
+  tenant_id?: string;
+  created_at: Date;
+}
+
+export interface CorrectionEventInput {
+  revision: PageRevision | undefined;
+  after: string;
+  editorRole: 'editor' | 'reader';
+  editedBy?: string;
+  sessionEmail?: string | null;
+  tenantId?: string;
+}
+
+/**
+ * Build the correction-event document from a manual edit. Returns null when
+ * there was no prior content (first write — nothing was corrected) or when
+ * the text is unchanged. Pure — no DB access.
+ */
+export function buildCorrectionEvent(opts: CorrectionEventInput): CorrectionEvent | null {
+  const { revision, after, editorRole, editedBy, sessionEmail, tenantId } = opts;
+  if (!revision?.data) return null; // first write — not a correction
+  if (revision.data === after) return null; // no-change save
+
+  const event: CorrectionEvent = {
+    id: nanoid(12),
+    page_id: revision.page_id,
+    book_id: revision.book_id,
+    field: revision.field,
+    before: revision.data,
+    after,
+    before_model: revision.model,
+    before_source: revision.source,
+    before_prompt_version: revision.prompt_version,
+    revision_id: revision.id,
+    editor_role: editorRole,
+    edited_by: editedBy,
+    session_email: sessionEmail || undefined,
+    tenant_id: tenantId,
+    created_at: new Date(),
+  };
+  return event;
+}
+
+/**
+ * Build and persist a correction event. Call with the revision returned by
+ * createRevision() — it already carries the before-text and its provenance.
+ */
+export async function recordCorrectionEvent(opts: CorrectionEventInput): Promise<CorrectionEvent | null> {
+  const event = buildCorrectionEvent(opts);
+  if (!event) return null;
+
+  try {
+    const db = await getDb();
+    await db.collection('correction_events').insertOne(event as unknown as Record<string, unknown>);
+    return event;
+  } catch (error) {
+    console.error(`[correction-events] Failed to record event for page ${event.page_id}:`, error);
+    return null;
+  }
+}

--- a/tests/unit/correction-events.test.ts
+++ b/tests/unit/correction-events.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Guard for src/lib/correction-events.ts (#3241) — human corrections captured
+ * as labeled model errors. Pins the pure builder:
+ *  1. A real edit → event with before/after pair + provenance of the corrected text.
+ *  2. First write (no revision) → null: nothing was corrected.
+ *  3. No-change save → null: not a correction.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { buildCorrectionEvent } from '../../src/lib/correction-events';
+import type { PageRevision } from '../../src/lib/page-revisions';
+
+const revision: PageRevision = {
+  id: 'rev1',
+  page_id: 'p1',
+  book_id: 'b1',
+  field: 'ocr',
+  data: 'the qvick brown fox',
+  source: 'batch_api',
+  model: 'gemini-3.1-flash-lite',
+  language: 'Latin',
+  prompt_version: 'v15',
+  created_at: new Date('2026-07-01'),
+};
+
+describe('buildCorrectionEvent', () => {
+  it('captures the before/after pair with provenance', () => {
+    const event = buildCorrectionEvent({
+      revision,
+      after: 'the quick brown fox',
+      editorRole: 'editor',
+      editedBy: 'Derek',
+      sessionEmail: 'derek@example.com',
+      tenantId: 'default',
+    });
+    expect(event).not.toBeNull();
+    expect(event!.page_id).toBe('p1');
+    expect(event!.book_id).toBe('b1');
+    expect(event!.field).toBe('ocr');
+    expect(event!.before).toBe('the qvick brown fox');
+    expect(event!.after).toBe('the quick brown fox');
+    expect(event!.before_model).toBe('gemini-3.1-flash-lite');
+    expect(event!.before_source).toBe('batch_api');
+    expect(event!.before_prompt_version).toBe('v15');
+    expect(event!.revision_id).toBe('rev1');
+    expect(event!.editor_role).toBe('editor');
+    expect(event!.edited_by).toBe('Derek');
+    expect(event!.session_email).toBe('derek@example.com');
+    expect(event!.tenant_id).toBe('default');
+  });
+
+  it('returns null on first write (no prior content)', () => {
+    expect(
+      buildCorrectionEvent({ revision: undefined, after: 'new text', editorRole: 'editor' })
+    ).toBeNull();
+  });
+
+  it('returns null on a no-change save', () => {
+    expect(
+      buildCorrectionEvent({ revision, after: revision.data, editorRole: 'editor' })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #3241.

## What
On save of an edited OCR or translation, store an immutable before/after diff record in a new `correction_events` collection — each one a labeled model error on a specific page.

- **`src/lib/correction-events.ts`** — `buildCorrectionEvent` (pure, unit-tested) + `recordCorrectionEvent`. Doc shape: `{page_id, book_id, field, before, after, before_model, before_source, before_prompt_version, revision_id, editor_role, edited_by, session_email, tenant_id, created_at}`.
- **Wired into both manual-edit PATCH routes** (`/api/pages/[id]` and `/api/[tenant]/pages/[id]`). Traced the actual save path: TranslationEditor → PageEditorClient → `pagesApi.update` → the **tenant** route, so both twins are covered. The routes already call `createRevision()` before overwriting; the event reuses the returned revision (before-text + provenance of the model that made the error) — no extra page fetch.
- **Fire-and-forget** — a lost event never blocks the edit. No-op on first writes (nothing was corrected) and no-change saves.
- **Indexes** added to `ensure-indexes.mjs` (`page_id+created_at`, `field+created_at`) — run it once after merge, or let the collection build them lazily on first eval query.

## Scope notes
- `editor_role` is always `'editor'` here — these routes are auth-gated. `'reader'` is reserved for a future flow that applies feedback-submitted corrections through review (per the feedback-as-untrusted-input doctrine, reader corrections are data applied only via existing review flows — they reach this route as an editor's save today).
- Full before/after texts stored (max 500KB each per the route's zod cap); trimming to changed regions deferred until size is actually a concern.
- Downstream eval-side mining (error taxonomy per script/source) is separate, per the issue.

## Testing
- `tests/unit/correction-events.test.ts` — 3 tests pin the pair capture + provenance, first-write null, no-change null.
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)