### PR TITLE
fix(search): honour the date range in unified (All) search

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -96,6 +96,15 @@ export async function GET(request: NextRequest) {
     const firstTranslation = searchParams.get('first_translation') === 'true';
     const hasTranslation = searchParams.get('has_translation') === 'true';
     const library = searchParams.get('library') || undefined;
+    // Publication-year range. The search page shows these inputs on every tab
+    // (and the ngram viewer deep-links into /search with a ±5y window), so a
+    // range that isn't honoured here reads as "filter set, results ignore it".
+    const parseYear = (v: string | null): number | undefined => {
+      const n = parseInt(v || '', 10);
+      return Number.isFinite(n) ? n : undefined;
+    };
+    const yearFrom = parseYear(searchParams.get('date_from'));
+    const yearTo = parseYear(searchParams.get('date_to'));
 
     if (!query || query.length < 2) {
       return NextResponse.json({
@@ -128,6 +137,8 @@ export async function GET(request: NextRequest) {
     if (category) searchFilters.category = category;
     if (firstTranslation) searchFilters.isFirstTranslation = true;
     if (hasTranslation) searchFilters.hasTranslation = true;
+    if (yearFrom !== undefined) searchFilters.yearFrom = yearFrom;
+    if (yearTo !== undefined) searchFilters.yearTo = yearTo;
     if (tenantContext.id) searchFilters.tenantId = tenantContext.id;
 
     // Run book, index, gallery, and visual search in parallel.
@@ -304,7 +315,19 @@ export async function GET(request: NextRequest) {
 
     // Dedup semantic results: remove books already in keyword results
     const keywordBookIds = new Set(booksResult.results.map((b: any) => b.id));
-    const dedupedSemantic = semanticResultRaw.results.filter(s => !keywordBookIds.has(s.book_id));
+    // Semantic search has no year predicate (vector index) — post-filter it so
+    // the semantic lane obeys the same range as the keyword lane. A book with an
+    // unknown year is dropped only when a range is actually set.
+    const inYearRange = (year: number | null | undefined) => {
+      if (yearFrom === undefined && yearTo === undefined) return true;
+      if (typeof year !== 'number') return false;
+      if (yearFrom !== undefined && year < yearFrom) return false;
+      if (yearTo !== undefined && year > yearTo) return false;
+      return true;
+    };
+    const dedupedSemantic = semanticResultRaw.results
+      .filter(s => !keywordBookIds.has(s.book_id))
+      .filter(s => inYearRange(s.year));
     const semanticResult = { results: dedupedSemantic.slice(0, 6), total: dedupedSemantic.length };
 
     // Apply similarity floor to visual/semantic/artwork lanes.

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -397,7 +397,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
     try {
       if (mode === 'unified') {
         // Check client-side cache first
-        const cacheKey = `unified:${q}:${language}:${category}:${hasTranslation}:${firstTranslation}:${library}`;
+        const cacheKey = `unified:${q}:${language}:${category}:${hasTranslation}:${firstTranslation}:${library}:${dateFrom}:${dateTo}`;
         const cached = searchCache.current.get(cacheKey);
         if (cached && Date.now() - cached.ts < CACHE_TTL) {
           setBookResults(cached.books);
@@ -418,6 +418,8 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             has_translation: hasTranslation ? 'true' : undefined,
             first_translation: firstTranslation ? 'true' : undefined,
             library: library || undefined,
+            date_from: dateFrom || undefined,
+            date_to: dateTo || undefined,
           };
           const data = await searchApi.unified(q, {
             limit: PREVIEW_BOOKS,

--- a/src/lib/api-client/search.ts
+++ b/src/lib/api-client/search.ts
@@ -50,6 +50,8 @@ export const search = {
     if (options?.filters?.has_translation) params.append('has_translation', options.filters.has_translation);
     if (options?.filters?.first_translation) params.append('first_translation', options.filters.first_translation);
     if (options?.filters?.library) params.append('library', options.filters.library);
+    if (options?.filters?.date_from) params.append('date_from', options.filters.date_from);
+    if (options?.filters?.date_to) params.append('date_to', options.filters.date_to);
 
     return await apiClient.get(`/api/search/unified?${params}`);
   },


### PR DESCRIPTION
The **Published after / Published before** filters are displayed on every search tab, and the ngram viewer deep-links into `/search` with a ±5-year window around a clicked point. But the default **All** (unified) view dropped them end to end:

- `src/app/search/page.tsx` — the `filters` object passed to `searchApi.unified()` omitted `date_from`/`date_to`
- `src/lib/api-client/search.ts` — `unified()` never appended them
- `src/app/api/search/unified/route.ts` — never read them

So a range like 1822–1832 rendered as an active filter (dot + Clear all) while a 1559 book sat at the top of the results. Only the **Books** tab applied the range; the page's semantic sidecar applied it too, so the same screen showed a year-filtered semantic column beside unfiltered keyword results.

## Changes
- Plumb `date_from`/`date_to` through page → api-client → unified route.
- Map to `BookSearchFilters.yearFrom`/`yearTo` — `buildBookSearchStage` already emits the `range` predicate on `year`, so no new search-index work.
- Post-filter the semantic lane by year (the vector index has no year predicate). Books with no year are dropped only when a range is actually set.
- Add the dates to the client-side unified cache key — previously, editing a date re-ran the effect but hit the same 60s cache entry and returned identical results.

## Out of scope
- The **Index** and **Images** lanes still ignore the date range. Flagged, not fixed.
- Filters remain sticky across a newly typed query. That's intended; it only *looked* like a leak because the range wasn't applied.

Verified with `npx tsc --noEmit` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)