### PR TITLE
fix(search): apply the publication-year range in every search lane

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -65,6 +65,37 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
     const year = searchParams.get('year'); // Exact year filter
     const yearFrom = searchParams.get('year_from'); // Year range start
     const yearTo = searchParams.get('year_to'); // Year range end
+    // date_from/date_to are publication-year bounds (the search UI's "Published
+    // after/before"). They used to be applied as a STRING comparison on
+    // `published` — a free-text field ("circa 1600", "[1620]", "n.d.") — where
+    // the comparison silently misfires. Normalize to the numeric `year` field,
+    // which is what every other surface filters on, and share one range between
+    // the book lane, the page lane, and the semantic lanes.
+    const parseYear = (v: string | null): number | undefined => {
+      const n = parseInt(v || '', 10);
+      return Number.isFinite(n) ? n : undefined;
+    };
+    const exactYear = parseYear(year);
+    const yearMin = parseYear(yearFrom) ?? parseYear(dateFrom);
+    const yearMax = parseYear(yearTo) ?? parseYear(dateTo);
+    const hasYearRange = exactYear !== undefined || yearMin !== undefined || yearMax !== undefined;
+    /** True when a book's year satisfies the requested range. Undated books drop out of a bounded range. */
+    const yearInRange = (y: number | null | undefined): boolean => {
+      if (!hasYearRange) return true;
+      if (typeof y !== 'number') return false;
+      if (exactYear !== undefined) return y === exactYear;
+      if (yearMin !== undefined && y < yearMin) return false;
+      if (yearMax !== undefined && y > yearMax) return false;
+      return true;
+    };
+    /** Attach the year predicate to a MongoDB book-level filter object. */
+    const applyYearFilter = (target: Record<string, unknown>) => {
+      if (exactYear !== undefined) { target.year = exactYear; return; }
+      const range: Record<string, number> = {};
+      if (yearMin !== undefined) range.$gte = yearMin;
+      if (yearMax !== undefined) range.$lte = yearMax;
+      if (Object.keys(range).length > 0) target.year = range;
+    };
     const hasDoi = searchParams.get('has_doi');
     const hasTranslation = searchParams.get('has_translation');
     const firstTranslation = searchParams.get('first_translation');
@@ -141,28 +172,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       else if (excludeLanguages.length > 0) filters.language = { $nin: excludeLanguages };
       else if (language) filters.language = language;
       if (category) filters.categories = category;
-      if (dateFrom || dateTo) {
-        filters.published = {};
-        if (dateFrom) (filters.published as Record<string, string>).$gte = dateFrom;
-        if (dateTo) (filters.published as Record<string, string>).$lte = dateTo;
-      }
-      if (year || yearFrom || yearTo) {
-        const yearFilter: Record<string, number> = {};
-        if (year) {
-          const yearNum = parseInt(year);
-          if (!isNaN(yearNum)) filters.year = yearNum;
-        } else {
-          if (yearFrom) {
-            const yearNum = parseInt(yearFrom);
-            if (!isNaN(yearNum)) yearFilter.$gte = yearNum;
-          }
-          if (yearTo) {
-            const yearNum = parseInt(yearTo);
-            if (!isNaN(yearNum)) yearFilter.$lte = yearNum;
-          }
-          if (Object.keys(yearFilter).length > 0) filters.year = yearFilter;
-        }
-      }
+      applyYearFilter(filters);
       if (hasDoi === 'true') filters.doi = { $exists: true, $ne: null };
       if (hasTranslation === 'true') filters.pages_translated = { $gt: 0 };
       if (firstTranslation === 'true') filters.is_first_translation = true;
@@ -297,11 +307,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
             else if (excludeLanguages.length > 0) bookIdFilter.language = { $nin: excludeLanguages };
             else if (language) bookIdFilter.language = language;
             if (category) bookIdFilter.categories = category;
-            if (dateFrom || dateTo) {
-              bookIdFilter.published = {};
-              if (dateFrom) (bookIdFilter.published as Record<string, string>).$gte = dateFrom;
-              if (dateTo) (bookIdFilter.published as Record<string, string>).$lte = dateTo;
-            }
+            applyYearFilter(bookIdFilter);
             if (hasDoi === 'true') bookIdFilter.doi = { $exists: true, $ne: null };
 
             const filteredBooks = await db.collection('books')
@@ -367,7 +373,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
             language: language || undefined,
             tenantId: tenantId || undefined,
           });
-          return books.map(b => ({
+          return books.filter(b => yearInRange(b.year)).map(b => ({
             page_id: '',
             book_id: b.book_id,
             page_number: 0,
@@ -403,7 +409,10 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
               .filter(d => (NON_CONTENT_PAGE_TYPES as readonly string[]).includes(d.page_type as string))
               .map(d => d.id as string),
           );
-          return pages.filter(p => !badIds.has(p.page_id));
+          // Year range applies to the semantic page lane too — its hits are
+          // rendered as book-attributed passages, so an out-of-range book
+          // arriving here reads exactly like an unfiltered result.
+          return pages.filter(p => !badIds.has(p.page_id) && yearInRange(p.book_year));
         } catch {
           degradedLanes.push('semantic_page'); // BUG 2: lane dropped out — total is now incomplete.
           return [];

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -96,6 +96,15 @@ export async function GET(request: NextRequest) {
     const firstTranslation = searchParams.get('first_translation') === 'true';
     const hasTranslation = searchParams.get('has_translation') === 'true';
     const library = searchParams.get('library') || undefined;
+    // Publication-year range. The search page shows these inputs on every tab
+    // (and the ngram viewer deep-links into /search with a ±5y window), so a
+    // range that isn't honoured here reads as "filter set, results ignore it".
+    const parseYear = (v: string | null): number | undefined => {
+      const n = parseInt(v || '', 10);
+      return Number.isFinite(n) ? n : undefined;
+    };
+    const yearFrom = parseYear(searchParams.get('date_from'));
+    const yearTo = parseYear(searchParams.get('date_to'));
 
     if (!query || query.length < 2) {
       return NextResponse.json({
@@ -128,6 +137,8 @@ export async function GET(request: NextRequest) {
     if (category) searchFilters.category = category;
     if (firstTranslation) searchFilters.isFirstTranslation = true;
     if (hasTranslation) searchFilters.hasTranslation = true;
+    if (yearFrom !== undefined) searchFilters.yearFrom = yearFrom;
+    if (yearTo !== undefined) searchFilters.yearTo = yearTo;
     if (tenantContext.id) searchFilters.tenantId = tenantContext.id;
 
     // Run book, index, gallery, and visual search in parallel.
@@ -304,7 +315,19 @@ export async function GET(request: NextRequest) {
 
     // Dedup semantic results: remove books already in keyword results
     const keywordBookIds = new Set(booksResult.results.map((b: any) => b.id));
-    const dedupedSemantic = semanticResultRaw.results.filter(s => !keywordBookIds.has(s.book_id));
+    // Semantic search has no year predicate (vector index) — post-filter it so
+    // the semantic lane obeys the same range as the keyword lane. A book with an
+    // unknown year is dropped only when a range is actually set.
+    const inYearRange = (year: number | null | undefined) => {
+      if (yearFrom === undefined && yearTo === undefined) return true;
+      if (typeof year !== 'number') return false;
+      if (yearFrom !== undefined && year < yearFrom) return false;
+      if (yearTo !== undefined && year > yearTo) return false;
+      return true;
+    };
+    const dedupedSemantic = semanticResultRaw.results
+      .filter(s => !keywordBookIds.has(s.book_id))
+      .filter(s => inYearRange(s.year));
     const semanticResult = { results: dedupedSemantic.slice(0, 6), total: dedupedSemantic.length };
 
     // Apply similarity floor to visual/semantic/artwork lanes.

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -490,6 +490,8 @@ async function searchBooks(
     firstTranslation: searchFilters.isFirstTranslation,
     hasTranslation: searchFilters.hasTranslation,
     library,
+    yearMin: searchFilters.yearFrom,
+    yearMax: searchFilters.yearTo,
   });
 
   // Canon-weighted reranking: older editions first, original language preferred

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -397,7 +397,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
     try {
       if (mode === 'unified') {
         // Check client-side cache first
-        const cacheKey = `unified:${q}:${language}:${category}:${hasTranslation}:${firstTranslation}:${library}`;
+        const cacheKey = `unified:${q}:${language}:${category}:${hasTranslation}:${firstTranslation}:${library}:${dateFrom}:${dateTo}`;
         const cached = searchCache.current.get(cacheKey);
         if (cached && Date.now() - cached.ts < CACHE_TTL) {
           setBookResults(cached.books);
@@ -418,6 +418,8 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             has_translation: hasTranslation ? 'true' : undefined,
             first_translation: firstTranslation ? 'true' : undefined,
             library: library || undefined,
+            date_from: dateFrom || undefined,
+            date_to: dateTo || undefined,
           };
           const data = await searchApi.unified(q, {
             limit: PREVIEW_BOOKS,

--- a/src/lib/api-client/search.ts
+++ b/src/lib/api-client/search.ts
@@ -50,6 +50,8 @@ export const search = {
     if (options?.filters?.has_translation) params.append('has_translation', options.filters.has_translation);
     if (options?.filters?.first_translation) params.append('first_translation', options.filters.first_translation);
     if (options?.filters?.library) params.append('library', options.filters.library);
+    if (options?.filters?.date_from) params.append('date_from', options.filters.date_from);
+    if (options?.filters?.date_to) params.append('date_to', options.filters.date_to);
 
     return await apiClient.get(`/api/search/unified?${params}`);
   },

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -402,6 +402,8 @@ export async function searchBooksCatalog(
     firstTranslation?: boolean;
     hasTranslation?: boolean;
     library?: string;
+    yearMin?: number;
+    yearMax?: number;
   }
 ): Promise<CatalogBookDetail[]> {
   const limit = opts?.limit || 20;
@@ -470,6 +472,10 @@ export async function searchBooksCatalog(
   if (opts?.category) query = query.contains('categories', [canonicalizeCategory(opts.category)]);
   if (opts?.firstTranslation) query = query.eq('is_first_translation', true);
   if (opts?.hasTranslation) query = query.gt('pages_translated', 0);
+  // Publication-year range. Rows with a null year drop out of a bounded range,
+  // same as listBooksCatalog — an undated edition can't satisfy "after 1600".
+  if (opts?.yearMin != null) query = query.gte('year', opts.yearMin);
+  if (opts?.yearMax != null) query = query.lte('year', opts.yearMax);
   if (opts?.library === 'bhutan') query = query.ilike('source_url', '%eap.bl.uk%');
   else if (opts?.library) query = query.eq('image_source_provider', opts.library);
 


### PR DESCRIPTION
Follow-up to #3267, which fixed the plumbing but not the actual filtering. Verified against production after #3267 shipped: `date_from=1600&date_to=1700` still returned a 1559 book on **both** the All tab and the Books tab.

Three separate lanes were dropping the range:

1. **Unified book lane never used Atlas Search.** `searchBooks()` in the unified route calls `searchBooksCatalog()` (Supabase `books_catalog`), so the `BookSearchFilters.yearFrom/yearTo` mapping added in #3267 was dead code for that lane. Fixed by giving `searchBooksCatalog()` `yearMin`/`yearMax` options that filter on the numeric `year` column — the same predicate `listBooksCatalog()` already uses — and wiring the route through them.

2. **`/api/search` compared strings against `published`.** `published` is free text (`circa 1600`, `[1620]`, `n.d.`, roman numerals), so `$gte: "1600"` is not a year comparison. Replaced with a normalized numeric range over the `year` field, shared by the book lane and the page lane's book-id prefilter. `date_from`/`date_to`/`year`/`year_from`/`year_to` now collapse into one range instead of two competing predicates.

3. **The two semantic lanes ignored the range entirely.** `semanticBookSearch` and `semanticPageSearchGlobal` results merge into the response as book/passage results, and neither had a year predicate (vector indexes don't carry one). Both are now post-filtered. This was the actual reason a 1559 book survived "Published after 1600" on the Books tab.

Undated books (null `year`) drop out of a bounded range, consistently across all lanes — an undated edition can't satisfy "after 1600".

`npx tsc --noEmit` clean; 563 unit tests pass. Will re-verify the same curl matrix against production after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
