### PR TITLE
fix(search,gallery): year range on every tab + revive /gallery's dead year filter

### DIFF
--- a/src/app/api/search/index/route.ts
+++ b/src/app/api/search/index/route.ts
@@ -25,6 +25,19 @@ export async function GET(request: NextRequest) {
     const query = searchParams.get('q') || '';
     const type = searchParams.get('type'); // Filter by type: keyword, concept, person, place, vocabulary, quote
     const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200);
+    // Publication-year range ("Published after/before" in the search UI).
+    // Index hits are entity→book pairs: the entity has no year, but the book it
+    // points at does, so the range is expressible as a book-id gate.
+    const parseYear = (v: string | null): number | undefined => {
+      const n = parseInt(v || '', 10);
+      return Number.isFinite(n) ? n : undefined;
+    };
+    const yearMin = parseYear(searchParams.get('date_from'));
+    const yearMax = parseYear(searchParams.get('date_to'));
+    const hasYearRange = yearMin !== undefined || yearMax !== undefined;
+    // Over-fetch when filtering: the lanes cap their own candidate sets, so a
+    // narrow range applied after the cap would starve the result list.
+    const candidateLimit = hasYearRange ? Math.min(limit * 4, 400) : limit;
 
     if (!query || query.length < 2) {
       return NextResponse.json({
@@ -43,11 +56,27 @@ export async function GET(request: NextRequest) {
 
     // Run entity search + quote search in parallel
     const [termResults, quoteResults] = await Promise.all([
-      wantTerms ? searchEntities(db, query, queryRegex, type, limit) : Promise.resolve([]),
-      wantQuotes ? searchQuotes(db, queryRegex, limit) : Promise.resolve([]),
+      wantTerms ? searchEntities(db, query, queryRegex, type, candidateLimit) : Promise.resolve([]),
+      wantQuotes ? searchQuotes(db, queryRegex, candidateLimit) : Promise.resolve([]),
     ]);
 
-    const results = [...termResults, ...quoteResults].slice(0, limit);
+    let merged = [...termResults, ...quoteResults];
+
+    // One books lookup gates every lane at once — cheaper than a per-lane join,
+    // and it can't be forgotten when a new lane is added below.
+    if (hasYearRange && merged.length > 0) {
+      const bookIds = [...new Set(merged.map(r => r.book_id).filter(Boolean))];
+      const yearFilter: Record<string, number> = {};
+      if (yearMin !== undefined) yearFilter.$gte = yearMin;
+      if (yearMax !== undefined) yearFilter.$lte = yearMax;
+      const inRange = await db.collection('books')
+        .find({ id: { $in: bookIds }, year: yearFilter }, { projection: { id: 1 }, maxTimeMS: 5000 })
+        .toArray();
+      const allowed = new Set<string>(inRange.map(b => b.id as string));
+      merged = merged.filter(r => allowed.has(r.book_id));
+    }
+
+    const results = merged.slice(0, limit);
 
     // Group results by type for summary
     const byType: Record<string, number> = {

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -105,6 +105,12 @@ export async function GET(request: NextRequest) {
     };
     const yearFrom = parseYear(searchParams.get('date_from'));
     const yearTo = parseYear(searchParams.get('date_to'));
+    // Shared by every lane. Index/gallery/CLIP/artwork rows carry no year of
+    // their own, but each is attributed to a book that does — so the range is
+    // expressible everywhere, via a book-id gate or the denormalized book_year.
+    const yearRange = (yearFrom !== undefined || yearTo !== undefined)
+      ? { min: yearFrom, max: yearTo }
+      : undefined;
 
     if (!query || query.length < 2) {
       return NextResponse.json({
@@ -189,14 +195,14 @@ export async function GET(request: NextRequest) {
       withTimeout(searchBooks(query, limit, searchFilters, library), emptyBooks, 'books'),
       // Skip index/entity search for quoted phrases — autocomplete returns loose single-word noise
       isPhrase ? Promise.resolve(emptyIndex) : withTimeout(
-        searchIndex(db, matchQuery, limit, tenantContext.id || undefined).catch((err) => {
+        searchIndex(db, matchQuery, limit, tenantContext.id || undefined, yearRange).catch((err) => {
           console.error('Index search error:', err);
           return emptyIndex;
         }),
         emptyIndex, 'index',
       ),
-      withTimeout(searchGallery(db, matchQuery, queryRegex, galleryLimit, tenantContext.id || undefined), emptyGallery, 'gallery'),
-      withTimeout(searchVisual(db, matchQuery, galleryLimit), emptyGallery, 'visual', 5000),
+      withTimeout(searchGallery(db, matchQuery, queryRegex, galleryLimit, tenantContext.id || undefined, yearRange), emptyGallery, 'gallery'),
+      withTimeout(searchVisual(db, matchQuery, galleryLimit, yearRange), emptyGallery, 'visual', 5000),
       // Semantic search: book-level discovery via book_embeddings (HNSW, ~17K rows)
       withTimeout(
         semanticBookSearch(matchQuery, 12, { tenantId: tenantContext.id || undefined })
@@ -240,7 +246,7 @@ export async function GET(request: NextRequest) {
         semanticArtworkSearch(matchQuery, 4)
           // Drop hidden artworks — these RPC rows are returned to the client
           // directly (title/thumbnail), not re-resolved against Mongo below.
-          .then(raw => filterVisibleArtworks(db, raw))
+          .then(raw => filterVisibleArtworks(db, raw, yearRange))
           .then(artworks => ({
             results: artworks.map(a => ({
               book_id: a.book_id,
@@ -263,7 +269,7 @@ export async function GET(request: NextRequest) {
       // cards exist but vector search surfaced 4. This lane fuses in every artwork
       // that literally contains the term (#2735).
       withTimeout(
-        lexicalArtworkSearch(db, queryRegex, 24, tenantContext.id || undefined)
+        lexicalArtworkSearch(db, queryRegex, 24, tenantContext.id || undefined, yearRange)
           .catch(() => emptyLexicalArtworks),
         emptyLexicalArtworks, 'artworks-lexical', 3000,
       ),
@@ -562,7 +568,7 @@ async function searchBooks(
   };
 }
 
-async function searchIndex(db: any, query: string, limit: number, tenantId?: string) {
+async function searchIndex(db: any, query: string, limit: number, tenantId?: string, yearRange?: { min?: number; max?: number }) {
   // Skip index search for very short queries — autocomplete + fuzzy on 1-2 chars is too loose
   if (query.length < 3) return { results: [] as IndexResult[], total: 0, hasMore: false };
   const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -605,15 +611,27 @@ async function searchIndex(db: any, query: string, limit: number, tenantId?: str
       .toArray();
   }
 
-  // Expand each entity into per-book results (matching the IndexResult shape)
+  // Expand each entity into per-book results (matching the IndexResult shape).
+  // An index hit is an entity→book pair: the entity carries no year, but the
+  // book does, so the publication range rides the same book-id gate the tenant
+  // scoping already uses — one lookup covers both.
+  const yearMatch: Record<string, number> = {};
+  if (yearRange?.min !== undefined) yearMatch.$gte = yearRange.min;
+  if (yearRange?.max !== undefined) yearMatch.$lte = yearRange.max;
+  const hasYearRange = Object.keys(yearMatch).length > 0;
+
   let allowedBookIds: Set<string> | null = null;
-  if (tenantId) {
+  if (tenantId || hasYearRange) {
     const entityBookIds = [...new Set(
       entities.flatMap((e: any) => (e.books || []).map((b: any) => b.book_id).filter(Boolean)),
     )];
     if (entityBookIds.length > 0) {
       const allowedBooks = await db.collection('books')
-        .find({ id: { $in: entityBookIds }, tenantId }, { projection: { id: 1 } })
+        .find({
+          id: { $in: entityBookIds },
+          ...(tenantId ? { tenantId } : {}),
+          ...(hasYearRange ? { year: yearMatch } : {}),
+        }, { projection: { id: 1 } })
         .toArray();
       allowedBookIds = new Set(allowedBooks.map((b: any) => b.id));
     } else {
@@ -646,6 +664,7 @@ async function searchIndex(db: any, query: string, limit: number, tenantId?: str
       'index.generatedAt': { $exists: true },
       visible: true,
       ...(tenantId ? { tenantId } : {}),
+      ...(hasYearRange ? { year: yearMatch } : {}),
       $or: [
         { 'index.concepts.term': queryRegex },
         { 'index.people.term': queryRegex },
@@ -700,8 +719,16 @@ async function searchIndex(db: any, query: string, limit: number, tenantId?: str
   return { results, total: results.length, hasMore: results.length >= limit };
 }
 
-async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: number, tenantId?: string): Promise<{ results: GalleryResult[]; total: number }> {
+async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: number, tenantId?: string, yearRange?: { min?: number; max?: number }): Promise<{ results: GalleryResult[]; total: number }> {
   try {
+    // gallery_images denormalizes the owning book's year (book_year, present on
+    // ~83% of rows), so the range needs no join. It is NOT in the Atlas Search
+    // index mapping, so it can't ride in the compound filter — it goes in a
+    // $match placed BEFORE $limit so a narrow range doesn't starve the page.
+    const yearMatch: Record<string, number> = {};
+    if (yearRange?.min !== undefined) yearMatch.$gte = yearRange.min;
+    if (yearRange?.max !== undefined) yearMatch.$lte = yearRange.max;
+    const hasYearRange = Object.keys(yearMatch).length > 0;
     let images;
     try {
       // Use Atlas Search with autocomplete on description + fuzzy text on other fields
@@ -724,6 +751,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
             },
           },
         },
+        ...(hasYearRange ? [{ $match: { book_year: yearMatch } }] : []),
         { $limit: limit * 2 },
         { $project: { page_id: 1, detection_index: 1, description: 1, type: 1, thumbnail_url: 1, extracted_url: 1, book_id: 1, book_title: 1, gallery_quality: 1 } },
       ], { maxTimeMS: 5000 }).toArray();
@@ -733,6 +761,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
         .find(
           {
             ...(tenantId ? { tenantId } : {}),
+            ...(hasYearRange ? { book_year: yearMatch } : {}),
             gallery_quality: { $gte: 0.5 },
             book_visible: { $ne: false },
             extracted_url: { $ne: null },
@@ -757,7 +786,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
     // Drop images from hidden/removed books (takedowns, dedup hides). The
     // Atlas Search branch can't filter on book_visible, and the gallery_images
     // mirror can drift — check books.visible in Mongo, same as the artwork lanes.
-    const visibleImages = await filterVisibleArtworks(db, withImages as Array<{ book_id: string }>);
+    const visibleImages = await filterVisibleArtworks(db, withImages as Array<{ book_id: string }>, yearRange);
 
     return {
       results: visibleImages.slice(0, limit).map((img: any) => ({
@@ -780,7 +809,7 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
  * CLIP visual search: encode text query via CLIP, search against image embeddings.
  * Finds images by what they look like, not just their metadata.
  */
-async function searchVisual(db: any, query: string, limit: number): Promise<{ results: GalleryResult[]; total: number }> {
+async function searchVisual(db: any, query: string, limit: number, yearRange?: { min?: number; max?: number }): Promise<{ results: GalleryResult[]; total: number }> {
   try {
     // Encode text via CLIP text encoder
     const clipResp = await fetch(`${CLIP_URL}/embed-text`, {
@@ -822,7 +851,7 @@ async function searchVisual(db: any, query: string, limit: number): Promise<{ re
 
     // clip_embeddings is a snapshot with no visibility column — drop rows whose
     // book is hidden/removed in Mongo (takedowns), same as the other image lanes.
-    const deduped = (await filterVisibleArtworks(db, matches)).slice(0, limit);
+    const deduped = (await filterVisibleArtworks(db, matches, yearRange)).slice(0, limit);
 
     return {
       results: deduped.map(m => ({
@@ -854,6 +883,7 @@ async function lexicalArtworkSearch(
   queryRegex: RegExp,
   limit: number,
   tenantId?: string,
+  yearRange?: { min?: number; max?: number },
 ): Promise<Array<{
   book_id: string;
   title: string;
@@ -870,6 +900,9 @@ async function lexicalArtworkSearch(
       content_type: 'artwork',
       visible: true,
       ...(tenantId ? { tenantId } : {}),
+      ...(yearRange && (yearRange.min !== undefined || yearRange.max !== undefined)
+        ? { year: { ...(yearRange.min !== undefined ? { $gte: yearRange.min } : {}), ...(yearRange.max !== undefined ? { $lte: yearRange.max } : {}) } }
+        : {}),
       $or: [
         { display_title: queryRegex },
         { title: queryRegex },

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -638,11 +638,21 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         setBookTotal(data.total || 0);
         clickCtx.current = { query: q, ranking: (data as any).ranking || null, results: data.results || [], view: 'books', total: data.total || 0 };
       } else if (mode === 'index') {
-        const data = await searchApi.index(q, { type: indexType || undefined });
+        const data = await searchApi.index(q, {
+          type: indexType || undefined,
+          dateFrom: dateFrom || undefined,
+          dateTo: dateTo || undefined,
+        });
         setIndexResults(data.results || []);
         setIndexTotal(data.total || 0);
       } else if (mode === 'images') {
-        const data = await galleryApi.list({ query: q, limit: resultsPerPage, offset: pageOffset });
+        const data = await galleryApi.list({
+          query: q,
+          limit: resultsPerPage,
+          offset: pageOffset,
+          yearFrom: dateFrom ? parseInt(dateFrom, 10) || undefined : undefined,
+          yearTo: dateTo ? parseInt(dateTo, 10) || undefined : undefined,
+        });
         const items = data.items || [];
         // Merge any AI-supplemented images that arrived before gallery API responded
         const pending = pendingAiImages.current;

--- a/src/lib/api-client/gallery.ts
+++ b/src/lib/api-client/gallery.ts
@@ -30,8 +30,12 @@ export const gallery = {
     if (params?.subject) queryParams.append('subject', params.subject);
     if (params?.figure) queryParams.append('figure', params.figure);
     if (params?.symbol) queryParams.append('symbol', params.symbol);
-    if (params?.yearFrom) queryParams.append('yearFrom', params.yearFrom.toString());
-    if (params?.yearTo) queryParams.append('yearTo', params.yearTo.toString());
+    // /api/gallery reads these as yearStart/yearEnd. Sending yearFrom/yearTo
+    // (the option names here) was silently ignored, which left the year filter
+    // on /gallery inert — the page rendered the range while the API served the
+    // whole corpus. Keep the option names, fix the wire names.
+    if (params?.yearFrom) queryParams.append('yearStart', params.yearFrom.toString());
+    if (params?.yearTo) queryParams.append('yearEnd', params.yearTo.toString());
     if (params?.limit) queryParams.append('limit', params.limit.toString());
     if (params?.offset) queryParams.append('offset', params.offset.toString());
     if (params?.minQuality) queryParams.append('minQuality', params.minQuality.toString());

--- a/src/lib/api-client/search.ts
+++ b/src/lib/api-client/search.ts
@@ -30,10 +30,12 @@ export const search = {
   /**
    * Search book indexes (keywords, concepts, people, places, quotes)
    */
-  index: async (query: string, options?: { type?: string; bookId?: string }): Promise<IndexSearchResponse> => {
+  index: async (query: string, options?: { type?: string; bookId?: string; dateFrom?: string; dateTo?: string }): Promise<IndexSearchResponse> => {
     const params = new URLSearchParams({ q: query });
     if (options?.type) params.append('type', options.type);
     if (options?.bookId) params.append('book_id', options.bookId);
+    if (options?.dateFrom) params.append('date_from', options.dateFrom);
+    if (options?.dateTo) params.append('date_to', options.dateTo);
 
     return await apiClient.get(`/api/search/index?${params}`);
   },

--- a/src/lib/artwork-visibility.ts
+++ b/src/lib/artwork-visibility.ts
@@ -16,13 +16,40 @@ import type { Db } from 'mongodb';
  * visual lane (clip_embeddings, no visibility column at all) run through it too.
  *
  * Returns the input rows minus any whose book is not `visible: true` in Mongo.
+ *
+ * Optionally also enforces a publication-year range. Image rows (gallery, CLIP,
+ * artwork) carry no year of their own, but they're all attributed to a book that
+ * has one — and this helper is already doing the books lookup, so the range
+ * rides along in the same query instead of costing a second round-trip. Books
+ * with no `year` drop out of a bounded range, matching the book lanes.
  */
 export async function filterVisibleArtworks<T extends { book_id: string }>(
   db: Db,
   rows: T[],
+  yearRange?: { min?: number; max?: number },
 ): Promise<T[]> {
   if (rows.length === 0) return rows;
   const ids = rows.map(r => r.book_id);
+
+  const yearFilter: Record<string, number> = {};
+  if (yearRange?.min !== undefined) yearFilter.$gte = yearRange.min;
+  if (yearRange?.max !== undefined) yearFilter.$lte = yearRange.max;
+
+  // With a year range the predicate stops being a pure negation, so query for
+  // the rows we KEEP. Without one, keep the cheaper hidden-only lookup.
+  if (Object.keys(yearFilter).length > 0) {
+    const allowedDocs = await db.collection('books')
+      .find({ id: { $in: ids }, visible: true, year: yearFilter }, { projection: { _id: 0, id: 1 }, maxTimeMS: 3000 })
+      .toArray()
+      .catch(() => null);
+    // A failed lookup must not silently drop every result — fall through to the
+    // visibility-only path rather than returning an empty set.
+    if (allowedDocs) {
+      const allowed = new Set(allowedDocs.map(d => d.id));
+      return rows.filter(r => allowed.has(r.book_id));
+    }
+  }
+
   const hiddenDocs = await db.collection('books')
     .find({ id: { $in: ids }, visible: { $ne: true } }, { projection: { _id: 0, id: 1 }, maxTimeMS: 3000 })
     .toArray()

--- a/tests/unit/search-filter-wire-names.test.ts
+++ b/tests/unit/search-filter-wire-names.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// A filter is only real if the name the client puts on the wire is the name the
+// route reads. Three separate filters were inert in production because those two
+// names disagreed (or because nothing was sent at all):
+//
+//   - /search's date range never reached /api/search/unified   (#3267)
+//   - /gallery's year range was sent as yearFrom/yearTo while
+//     /api/gallery reads yearStart/yearEnd — the page rendered the
+//     range while the API served the whole corpus                (#3269)
+//
+// Each of these looked fine in a browser: results appeared, the filter chip was
+// lit, and only a curl comparing filtered vs unfiltered output revealed that
+// nothing had been constrained. These tests pin the wire names so the failure
+// mode can't return silently.
+
+const captured: string[] = [];
+
+vi.mock('@/lib/api-client/client', () => ({
+  apiClient: {
+    get: vi.fn(async (url: string) => {
+      captured.push(url);
+      return {};
+    }),
+  },
+}));
+
+beforeEach(() => { captured.length = 0; });
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('gallery api-client year range', () => {
+  it('sends yearStart/yearEnd — the names /api/gallery actually reads', async () => {
+    const { gallery } = await import('@/lib/api-client/gallery');
+    await gallery.list({ query: 'alchemy', yearFrom: 1600, yearTo: 1700 });
+
+    const url = captured[0];
+    expect(url).toContain('yearStart=1600');
+    expect(url).toContain('yearEnd=1700');
+    // The old (ignored) spelling must not be what goes on the wire.
+    expect(url).not.toContain('yearFrom=');
+    expect(url).not.toContain('yearTo=');
+  });
+
+  it('omits the range entirely when unset', async () => {
+    const { gallery } = await import('@/lib/api-client/gallery');
+    await gallery.list({ query: 'alchemy' });
+
+    expect(captured[0]).not.toContain('yearStart');
+    expect(captured[0]).not.toContain('yearEnd');
+  });
+});
+
+describe('search api-client date range', () => {
+  it('forwards date_from/date_to to unified search', async () => {
+    const { search } = await import('@/lib/api-client/search');
+    await search.unified('philosopher\'s stone', {
+      filters: { date_from: '1600', date_to: '1700' },
+    });
+
+    const url = captured[0];
+    expect(url).toContain('/api/search/unified');
+    expect(url).toContain('date_from=1600');
+    expect(url).toContain('date_to=1700');
+  });
+
+  it('forwards date_from/date_to to index search', async () => {
+    const { search } = await import('@/lib/api-client/search');
+    await search.index('mercury', { dateFrom: '1600', dateTo: '1700' });
+
+    const url = captured[0];
+    expect(url).toContain('/api/search/index');
+    expect(url).toContain('date_from=1600');
+    expect(url).toContain('date_to=1700');
+  });
+
+  it('forwards date_from/date_to to keyword search', async () => {
+    const { search } = await import('@/lib/api-client/search');
+    await search.search('mercury', { date_from: '1600', date_to: '1700' });
+
+    const url = captured[0];
+    expect(url).toContain('date_from=1600');
+    expect(url).toContain('date_to=1700');
+  });
+});


### PR DESCRIPTION
Follow-up to #3267/#3268. I had written off the Index and Images tabs as having "no year to filter on." That was wrong, and one query would have told me:

- **Index** hits are entity→book pairs. The entity carries no year, but the book it points at does — and the lane already builds an allowed-book-id set for tenant scoping, so the range rides the same lookup.
- **Gallery** images already denormalize the owning book's year: `gallery_images.book_year` is populated on **171,728 of ~206,390** rows (~83%). No join needed at all.

So instead of hiding the inputs on those tabs, they now work.

## Changes
- `/api/search/index`: accepts `date_from`/`date_to`; one books lookup (by id + year) gates every lane at once, so a new lane can't silently skip it. Over-fetches candidates when a range is set, so a narrow range doesn't starve the result list.
- Unified **index** lane: range folded into the existing tenant book-id gate.
- Unified **gallery** lane: `$match` on `book_year`, placed *before* `$limit`. (`book_year` is not in the `gallery_search` index mapping — I checked — so it can't ride in the compound filter.)
- `filterVisibleArtworks()`: optional year range folded into the books lookup it already performs, covering the gallery, CLIP-visual, and artwork lanes in one change. A failed lookup falls through to the visibility-only path rather than returning an empty set.
- Lexical artwork lane: year predicate on its books query.
- Search page: Index and Images tabs pass the range.

## Separate live bug found along the way
**`/gallery`'s year filter has been inert in production.** `galleryApi.list()` sent `yearFrom`/`yearTo`; `/api/gallery` reads `yearStart`/`yearEnd`. Verified against prod:

```
/api/gallery?limit=8&yearFrom=1900&yearTo=1950   → [1400, 1400, 1400, null, ...]
/api/gallery?limit=8&yearStart=1900&yearEnd=1950 → [1900, 1901, 1901, 1900, ...]
```

`GalleryClient.tsx` is the caller, so the year range on the public gallery page was decorative. Fixed the wire names (option names unchanged).

## Guard test
`tests/unit/search-filter-wire-names.test.ts` pins the wire name for every date/year filter. All three bugs in this series were the same shape — a client and a route disagreeing about a parameter name (or sending nothing) while the UI showed the filter as active. Verified the test actually fails when the gallery fix is reverted.

`npx tsc --noEmit` clean; 568 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
