### PR TITLE
docs: search filters must be enforced in every lane

### DIFF
--- a/.claude/handoffs/2026-07-19-search-filter-lanes.md
+++ b/.claude/handoffs/2026-07-19-search-filter-lanes.md
@@ -1,0 +1,101 @@
+# Search filters were displayed but not enforced — 2026-07-19
+
+Purely technical postmortem. No PII, secrets, or business material.
+
+## Trigger
+
+A screenshot of `/search?q=philosopher's+stone` with **Published after 1822 /
+Published before 1832** set, the "active filters" dot lit — and a **1559** book
+at the top of the results. Reported as "seems like dates leak?"
+
+## What it actually was
+
+Nothing leaked. The dates arrived legitimately: `NgramViewer.tsx:163` opens
+`/search` with a ±5-year window around a clicked chart point, and the search page
+keeps filters in state + URL across a newly typed query (intended). The bug was
+that the range was **rendered as active but never enforced** — in four places,
+found one at a time, each hiding behind the previous.
+
+1. **Never sent.** The page's `filters` object, `searchApi.unified()`, and
+   `/api/search/unified` all omitted `date_from`/`date_to`. (#3267)
+2. **Sent, still ignored.** The unified book lane doesn't use Atlas Search — it
+   queries Supabase `books_catalog` via `searchBooksCatalog()`. The
+   `BookSearchFilters.yearFrom/yearTo` mapping added in #3267 was dead code for
+   the lane that actually renders All-tab results. (#3268)
+3. **Wrong field type.** `/api/search` applied `date_from` as a **string**
+   comparison against `published`, which is free text (`circa 1600`, `[1620]`,
+   `n.d.`, roman numerals). Never a year comparison. Now normalized to numeric
+   `year`. (#3268)
+4. **Lanes with no predicate.** `semanticBookSearch` and
+   `semanticPageSearchGlobal` merge in as book/passage results and carry no
+   metadata predicate (vector indexes don't have one). They ignored every filter
+   until post-filtered. This was the specific reason a 1559 book survived
+   "after 1600" on the Books tab. (#3268)
+
+## The wrong claim, and what checking it turned up
+
+I reported that the Index and Images tabs "have no year to filter on" and
+proposed hiding the inputs. Derek asked why not. Both were wrong:
+
+- Index hits are entity→book pairs. The entity has no year; the book does — and
+  the lane already builds an allowed-book-id set for tenant scoping, so the
+  range rides the same lookup.
+- `gallery_images` denormalizes `book_year`: **171,728 of ~206,390** rows (83%).
+  A `$match` away. (Not in the `gallery_search` Atlas index mapping, so it can't
+  ride in the compound filter — `$match` before `$limit`.)
+
+So the inputs now work on all four tabs instead of being hidden. (#3269)
+
+**And checking surfaced an unrelated live bug:** `/gallery`'s year filter had
+been inert in production. `galleryApi.list()` sent `yearFrom`/`yearTo`;
+`/api/gallery` reads `yearStart`/`yearEnd`. Verified against prod before
+touching anything — `yearFrom=1900&yearTo=1950` returned 1400s. `GalleryClient.tsx`
+is the caller, so the public gallery's year range was decorative. (#3269)
+
+## Files changed
+
+- `src/app/search/page.tsx` — pass dates to unified/index/images; dates in the
+  client-side unified cache key (editing a date previously hit the same 60s
+  cache entry and returned identical results)
+- `src/app/api/search/unified/route.ts` — year range threaded to every lane
+- `src/app/api/search/route.ts` — one numeric year range for
+  `date_from`/`date_to`/`year`/`year_from`/`year_to`; both semantic lanes
+  post-filtered
+- `src/app/api/search/index/route.ts` — accepts `date_from`/`date_to`; single
+  books lookup gates all lanes
+- `src/lib/books-catalog.ts` — `searchBooksCatalog()` takes `yearMin`/`yearMax`
+- `src/lib/artwork-visibility.ts` — optional year range folded into the books
+  lookup it already performs (covers gallery + CLIP-visual + artwork lanes)
+- `src/lib/api-client/{search,gallery}.ts` — wire names
+- `tests/unit/search-filter-wire-names.test.ts` — new guard
+
+## State
+
+PRs #3267, #3268, #3269 merged. Three prod deploys via `npm run deploy:prod`
+(deploy → purge → warm), all verified live:
+
+- `/gallery` 1900–1950 → 1900, 1901, 1901, 1900, 1901, 1902, 1913, 1900
+- Index 1600–1700 → in-range books; 1990–1995 → 0
+- All tab 1600–1700 → books 1601–1634; all 6 gallery images resolve to books
+  dated 1606–1678
+- Books tab 1600–1700 → 1620–1700, no 1559
+
+`tsc --noEmit` clean, 568 unit tests pass. Guard test verified to fail when the
+gallery fix is reverted (not a vacuous pass).
+
+## Open
+
+- **`search-eval` flakiness.** The `stukeley` test intermittently reports 0 book
+  results. It runs against **production**, not the PR — and it failed on #3267
+  before any of this code was in prod, then passed on #3268's run. Prod answers
+  correctly on demand (3 books, three consecutive runs). It's the fail-soft book
+  lane dropping out, most likely the Supabase trigram call from the CI runner.
+  Same bug class as this session: a lane returning empty without saying so.
+- Collections lane in unified search takes no year range — deliberate,
+  collections aren't dated objects.
+
+## CLAUDE.md
+
+Added a "Search filters must be enforced in every lane" invariant. Three
+independent instances in one session justified doctrine rather than a handoff
+note.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,48 @@ A famous Kircher diagram has `gallery_quality: 0.9` whether the scan is pristine
 
 **Record images: use the accessor, never raw fields — book vs artwork store images differently.** The `books` collection mixes content types with *different* image-field conventions: book **covers** live in `thumbnail` / `thumbnail_blob`; **page scans** in `pages.display_photo` / `archived_photo` / `photo`; and **artworks** (`content_type:'artwork'` — single-image gallery items like the Tarot cards) in `image_display` / `image_full` / `image_thumb` / `archived_full_url`. Checking the *wrong* family makes an artwork look imageless when it isn't (a real footgun — it produced a false "94% of artworks have no image" during a 2026-06 audit; the images were all present in the `image_*` fields). **Always resolve a record's display image via `getBookThumbnailUrl()` / `getCoverImageCandidates()` (`src/lib/utils.ts`)** — they already handle every convention (incl. Wikimedia CDN URLs and the artwork 600px/2000px/full thumb variants). Don't hand-check `photo` / `display_photo` on an artwork record. Likewise, **artworks legitimately have `pages_count: 0`** — they're single images, not paginated books, so a `visible:true, pages_count:0` record is usually fine art, not a broken "stub."
 
+## Search filters must be enforced in every lane
+Lessons from PRs #3267/#3268/#3269 (the "dates leak" report, 2026-07-19 — three
+independent instances of one shape in a single session).
+
+Search fans out into **independent lanes whose results are merged into one list**.
+A filter is only as strong as its weakest lane, and the UI's "active filter"
+indicator reads page state, not what the query path received — so an unenforced
+filter renders as *on* while out-of-range results sit at the top.
+
+- **`/api/search/unified` (All tab):** the book lane is **Supabase
+  `books_catalog`** via `searchBooksCatalog()` — NOT Atlas Search. Adding a
+  predicate to `BookSearchFilters` (`src/lib/atlas-search.ts`) does nothing for
+  it. Other lanes: index, gallery, CLIP-visual, semantic, artwork (semantic +
+  lexical), collections.
+- **`/api/search` (Books tab):** four lanes — Supabase trigram books, Atlas
+  pages, `semanticBookSearch`, `semanticPageSearchGlobal`.
+- **Vector lanes carry no metadata predicate** and their hits merge in as
+  book/passage results. They must be post-filtered in JS or they leak past every
+  filter. This is the one people miss.
+- **`books.published` is FREE TEXT** (`circa 1600`, `[1620]`, `n.d.`, roman
+  numerals). Never range-compare it as a string — `$gte: "1600"` is not a year
+  comparison. The numeric `year` field is the filterable one, in both Mongo and
+  `books_catalog`.
+- **"That source has no year/metadata to filter on" is usually false — check the
+  data before asserting it.** Index hits are entity→book pairs whose book has a
+  year (and the lane already does a books lookup for tenant scoping);
+  `gallery_images` denormalizes `book_year` (83% of rows). Both were filterable
+  all along. `filterVisibleArtworks()` takes an optional year range folded into
+  the books lookup it already performs — one helper covers the gallery,
+  CLIP-visual, and artwork lanes.
+- **Wire-name mismatches are the recurring failure mode.** `/gallery`'s year
+  filter was inert in production because the api-client sent `yearFrom`/`yearTo`
+  while `/api/gallery` reads `yearStart`/`yearEnd`. Pinned by
+  `tests/unit/search-filter-wire-names.test.ts` — add a case there for any new
+  filter.
+
+**Verifying:** a browser always looks fine — results appear and the filter chip
+lights up. Proof is a **curl matrix against a deployed preview**: unfiltered vs
+filtered vs an impossible range (which must return 0). Check every lane in the
+response body, not just the first list. Same discipline as the three-layer
+crawler gate above: changing one layer alone is silently defeated by the others.
+
 ## Quote & snippet integrity — CRITICAL
 Lessons from PRs #2232/#2233 (the "mercury on page 89" misquote — Nirmal, 2026-05-30).
 


### PR DESCRIPTION
Doc-only follow-up to #3267 / #3268 / #3269.

Today's "dates leak?" report turned out to be three independent instances of one shape, found one behind the other: a filter **rendered as active while the lane that produced the results never received it**. The last one (`/gallery`'s year filter sending `yearFrom`/`yearTo` at a route reading `yearStart`/`yearEnd`) had been inert in production and was unrelated to the original report — it only surfaced because a wrong assumption got challenged.

That's doctrine-worthy rather than handoff-worthy, so this adds a **"Search filters must be enforced in every lane"** section to `CLAUDE.md` covering:

- the lane inventory for both `/api/search/unified` and `/api/search` — including that the unified book lane is Supabase `books_catalog`, *not* Atlas Search, so `BookSearchFilters` predicates don't reach it
- vector lanes carry no metadata predicate and must be post-filtered (the one people miss)
- `books.published` is free text — never range-compare it as a string; use numeric `year`
- "that source has no year to filter on" is usually false — check the data first
- wire-name mismatches as the recurring failure mode, pinned by `tests/unit/search-filter-wire-names.test.ts`
- how to verify: a curl matrix against a deployed preview (unfiltered / filtered / impossible range → 0), because a browser always looks fine

Also adds `.claude/handoffs/2026-07-19-search-filter-lanes.md` via deliberate `git add -f` — a purely technical postmortem with no PII, secrets, or business material, which is the documented bar for a handoff living in this public repo.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
