### PR TITLE
fix(reader,gallery): swipe scroll-to-top, mobile logo, gallery search count (#3085)

### DIFF
--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -238,55 +238,77 @@ export async function GET(request: NextRequest) {
       : Promise.resolve(new Map<string, number>());
 
     let textItems: any[] = [];
+    // Accurate total for the Atlas Search path. The old estimate
+    // (offset + items.length + 1) grew with every page — "ship" reported
+    // "Found 41", then "Found 61", and "Page X of X+1" forever, so a reader
+    // never saw the true page count (#3085). Run a parallel $count that mirrors
+    // the same $search + $match so pagination bounds are real.
+    let atlasSearchCount: Promise<number | null> | null = null;
 
     if (searchQuery) {
       // Primary: Atlas Search (gallery_search index) — searches description,
       // museum_description, subjects, figures. Same index used by unified search.
+      // Shared $search + $match stages so the count pipeline can't drift from
+      // the results pipeline.
+      const searchStage = {
+        $search: {
+          index: 'gallery_search',
+          compound: {
+            should: [
+              { autocomplete: { query: searchQuery, path: 'description', score: { boost: { value: 3 } }, fuzzy: { maxEdits: 1, prefixLength: 2 } } },
+              { text: { query: searchQuery, path: 'museum_description', score: { boost: { value: 2 } }, fuzzy: { maxEdits: 1, prefixLength: 2 } } },
+              { text: { query: searchQuery, path: 'metadata.subjects', fuzzy: { maxEdits: 1, prefixLength: 2 } } },
+              { text: { query: searchQuery, path: 'metadata.figures', fuzzy: { maxEdits: 1, prefixLength: 2 } } },
+            ],
+            minimumShouldMatch: 1,
+            filter: [
+              { range: { path: 'gallery_quality', gte: minQuality } },
+            ],
+          },
+        },
+      };
+      const matchStage = {
+        $match: {
+          book_visible: true,
+          extracted_url: { $ne: null },
+          image_url: { $ne: null },
+          ...(!bookId && maxPerBook < 100 ? { book_rank: { $lte: maxPerBook } } : {}),
+          ...(bookId ? { book_id: bookId } : {}),
+          ...(collectionBookIds && libraryBookIds
+            ? { book_id: { $in: collectionBookIds.filter(id => libraryBookIds!.includes(id)) } }
+            : collectionBookIds ? { book_id: { $in: collectionBookIds } }
+            : libraryBookIds ? { book_id: { $in: libraryBookIds } }
+            : {}),
+          ...(imageType ? { type: imageType } : {}),
+          ...(subjectFilter ? { 'metadata.subjects': subjectFilter } : {}),
+          ...(figureFilter ? { 'metadata.figures': figureFilter } : {}),
+          ...(symbolFilter ? { 'metadata.symbols': symbolFilter } : {}),
+          ...(yearStart !== null || yearEnd !== null ? {
+            book_year: {
+              ...(yearStart !== null ? { $gte: yearStart } : {}),
+              ...(yearEnd !== null ? { $lte: yearEnd } : {}),
+            },
+          } : {}),
+        },
+      };
       try {
         textItems = await db.collection('gallery_images').aggregate([
-          {
-            $search: {
-              index: 'gallery_search',
-              compound: {
-                should: [
-                  { autocomplete: { query: searchQuery, path: 'description', score: { boost: { value: 3 } }, fuzzy: { maxEdits: 1, prefixLength: 2 } } },
-                  { text: { query: searchQuery, path: 'museum_description', score: { boost: { value: 2 } }, fuzzy: { maxEdits: 1, prefixLength: 2 } } },
-                  { text: { query: searchQuery, path: 'metadata.subjects', fuzzy: { maxEdits: 1, prefixLength: 2 } } },
-                  { text: { query: searchQuery, path: 'metadata.figures', fuzzy: { maxEdits: 1, prefixLength: 2 } } },
-                ],
-                minimumShouldMatch: 1,
-                filter: [
-                  { range: { path: 'gallery_quality', gte: minQuality } },
-                ],
-              },
-            },
-          },
-          { $match: {
-            book_visible: true,
-            extracted_url: { $ne: null },
-            image_url: { $ne: null },
-            ...(!bookId && maxPerBook < 100 ? { book_rank: { $lte: maxPerBook } } : {}),
-            ...(bookId ? { book_id: bookId } : {}),
-            ...(collectionBookIds && libraryBookIds
-              ? { book_id: { $in: collectionBookIds.filter(id => libraryBookIds!.includes(id)) } }
-              : collectionBookIds ? { book_id: { $in: collectionBookIds } }
-              : libraryBookIds ? { book_id: { $in: libraryBookIds } }
-              : {}),
-            ...(imageType ? { type: imageType } : {}),
-            ...(subjectFilter ? { 'metadata.subjects': subjectFilter } : {}),
-            ...(figureFilter ? { 'metadata.figures': figureFilter } : {}),
-            ...(symbolFilter ? { 'metadata.symbols': symbolFilter } : {}),
-            ...(yearStart !== null || yearEnd !== null ? {
-              book_year: {
-                ...(yearStart !== null ? { $gte: yearStart } : {}),
-                ...(yearEnd !== null ? { $lte: yearEnd } : {}),
-              },
-            } : {}),
-          }},
+          searchStage,
+          matchStage,
           { $project: { _id: 0 } },
           { $skip: offset },
           { $limit: limit + 1 },
         ], { maxTimeMS: 8000 }).toArray();
+        // Kick off the count in parallel (only meaningful when Atlas Search ran,
+        // not the $text fallback). Guarded so a slow/failed count degrades to the
+        // old estimate rather than breaking the request.
+        atlasSearchCount = db.collection('gallery_images').aggregate([
+          searchStage,
+          matchStage,
+          { $count: 'total' },
+        ], { maxTimeMS: 8000 }).toArray()
+          .then(r => (r[0]?.total as number | undefined) ?? null)
+          .catch(() => null);
       } catch {
         // Atlas Search index not ready — fall back to $text
       }
@@ -397,8 +419,12 @@ export async function GET(request: NextRequest) {
       // Filtered query — for Atlas Search queries, countDocuments can't replicate the
       // search pipeline, so estimate from result count. For $text queries, use countDocuments.
       if (searchQuery && !filter.$text) {
-        // Atlas Search was used — estimate total from what we have
-        total = offset + items.length + (hasMore ? 1 : 0);
+        // Atlas Search was used — prefer the accurate parallel $count; fall back
+        // to the (page-growing) estimate only if it failed/timed out.
+        const counted = atlasSearchCount ? await atlasSearchCount : null;
+        total = (counted != null && counted >= offset + items.length)
+          ? counted
+          : offset + items.length + (hasMore ? 1 : 0);
       } else {
         total = await db.collection('gallery_images').countDocuments(filter, { maxTimeMS: 10000 }).catch(() => offset + items.length + 1);
       }

--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -241,15 +241,18 @@ export default function PageEditorClient({
   }, [book.id, currentPageId, currentPage?.page_number]);
 
   // Client-side navigation - update URL and current page
-  const handleNavigate = useCallback((newPageId: string) => {
+  const handleNavigate = useCallback((newPageId: string, opts?: { toTop?: boolean }) => {
     // On mobile the panels stack vertically (image, then OCR, then translation).
     // Flipping a page used to dump the reader back to the top of the page even
     // when they were mid-way through the translation. Capture which panel is
     // currently filling the viewport *before* the swap, so we can land on the
     // same panel of the new page. (Reader feedback: "going to the next page from
     // the OCR or translation should take you to the same part of the next page.")
+    // Exception: a swipe passes { toTop: true } — readers expect a swipe to land
+    // at the top of the new page, and section-preserving read as "lands mid-page"
+    // there (#3085).
     const isMobile = window.innerWidth < 1024;
-    const activeSection = isMobile ? (getActiveReaderSection() || 'image') : null;
+    const activeSection = isMobile && !opts?.toTop ? (getActiveReaderSection() || 'image') : null;
 
     setCurrentPageId(newPageId);
     // Build URL with supported query params (version pinning)
@@ -258,7 +261,7 @@ export default function PageEditorClient({
     const suffix = newParams.toString() ? `?${newParams.toString()}` : '';
     window.history.pushState(null, '', `${tenantPrefix}/book/${book.id}/page/${newPageId}${suffix}`);
 
-    if (isMobile) {
+    if (isMobile && activeSection) {
       // Land on the same section the reader was in (image / OCR / translation),
       // at its top. The section <div>s persist across the page swap (only their
       // content changes), so the same selector resolves on the new page. Two rAFs
@@ -267,6 +270,12 @@ export default function PageEditorClient({
         const el = document.querySelector(`[data-reader-section="${activeSection}"]`);
         if (el) el.scrollIntoView({ behavior: 'instant', block: 'start' });
         else window.scrollTo({ top: 0, behavior: 'instant' });
+      }));
+    } else if (isMobile) {
+      // Swipe (opts.toTop): always land at the very top of the new page. Wait two
+      // rAFs so the page swap has committed before scrolling.
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        window.scrollTo({ top: 0, behavior: 'instant' });
       }));
     } else {
       // Desktop: go to the top.

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -24,6 +24,15 @@ export default function Logo({ white, compact, mini }: LogoProps) {
       ? 'text-lg'
       : 'text-base md:text-[1.2rem]';
 
+  // When to reveal the "Source Library" wordmark. The reader header (mini) is
+  // dense on mobile — logo, a long title, the chapter dropdown and the page
+  // navigator all share one row — so the wordmark stays hidden until `lg`
+  // (the same width at which the site nav stops collapsing to a hamburger),
+  // leaving just the three rings on phones/tablets. Reader feedback: the logo
+  // read as "smooshed" and "should collapse to just the circles" (#3085).
+  // The marketing/site header keeps its wordmark from `sm` up.
+  const wordmarkVisibility = mini ? 'hidden lg:inline' : 'hidden sm:inline';
+
   return (
     <Link
       href="/"
@@ -46,7 +55,7 @@ export default function Logo({ white, compact, mini }: LogoProps) {
         <circle cx="12" cy="12" r="4" stroke={strokeColor} strokeWidth="1" />
       </svg>
       <span
-        className={`${textSize} uppercase tracking-wider hidden sm:inline`}
+        className={`${textSize} uppercase tracking-wider ${wordmarkVisibility}`}
       >
         <span className="font-semibold">Source</span>
         <span className="font-light">Library</span>

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -180,7 +180,7 @@ interface TranslationEditorProps {
   page: Page;
   pages: Page[];
   currentIndex: number;
-  onNavigate: (pageId: string) => void;
+  onNavigate: (pageId: string, opts?: { toTop?: boolean }) => void;
   onSave: (data: { ocr?: string; translation?: string; summary?: string }) => Promise<void>;
   onRefresh?: () => Promise<void>;
 }
@@ -934,10 +934,13 @@ export default function TranslationEditor({
     const deltaX = swipeOffset * 2; // Reverse the 0.5 multiplier
 
     if (!hasSelection && Math.abs(deltaX) > SWIPE_THRESHOLD) {
+      // A swipe always lands at the top of the new page. The section-preserving
+      // scroll (keep the reader in the OCR/translation panel across a flip) is
+      // for button/keyboard nav; on a swipe it read as "lands mid-page" (#3085).
       if (deltaX > 0 && previousPage) {
-        onNavigate(previousPage.id);
+        onNavigate(previousPage.id, { toTop: true });
       } else if (deltaX < 0 && nextPage) {
-        onNavigate(nextPage.id);
+        onNavigate(nextPage.id, { toTop: true });
       }
     }
 


### PR DESCRIPTION
Addresses fixable items from the #3085 reader/UI feedback checklist. Each was reproduced/verified before changing code.

## In scope (code fixes)

**#12 — Mobile swipe should land at top of page.** Swipe now passes `{ toTop: true }` through `onNavigate`; the reader keeps its section-preserving scroll (stay in the OCR/translation panel) for button/keyboard nav, where earlier feedback asked for it, but a swipe goes to the top of the new page. (`TranslationEditor.tsx`, `PageEditorClient.tsx`)

**#5 — Mobile logo "smooshed", should collapse to just the rings.** The dense reader header (`<Logo mini />`) now hides the "Source Library" wordmark until `lg` — the same width at which the site nav stops collapsing to a hamburger — so phones/tablets show only the three rings. The marketing/site header keeps its wordmark from `sm` up. (`Logo.tsx`)

**#6 — Gallery search: counts change per page.** `/api/gallery` estimated the total as `offset + items.length + 1` for Atlas Search queries, so it grew each page ("Found 41" → "Found 61", "Page X of X+1" forever) and a reader never saw the true page count. Now runs a parallel `$count` mirroring the same `$search + $match` for an accurate, offset-independent total, falling back to the old estimate only if the count fails/times out. (`api/gallery/route.ts`)

## Verified, no code change

- **#8** `/book/69b43d…` (Plotinus, Ficino translation): all page scans return HTTP 200; `gallery_images = 0` — a text-only philosophy translation with genuinely **no illustrations**, so "no illustrations shown" is correct.
- **#1/#2/#3/#4/#7/#13**: not reproducible on manual testing (magic link arrives; notes toggle keeps body text; likes persist across page nav; Android shows the native copy/share menu; gallery image loads; collection opens at top).

## Confirmed real, but data-repair (out of scope here)

- **#14** `/book/69aec4…/page/…36` (The Federalist): the displayed scan (`/pages/0013.jpg`) is the **Contents page (folio vi)**, but the stored OCR for that page is the **"THE FEDERALIST" title page** — a front-matter off-by-one between the OCR stream and the image stream. Confirmed by viewing the scan against the OCR.
- **#15** `/book/69e636…/page/…56` (The Shipwrecked Sailor): same class — the hieroglyphic transliteration doesn't correspond to the papyrus image shown.

Both are OCR↔image alignment defects in stored `pages` docs, not rendering bugs. Per the Data-Protection rules they need a careful per-book re-alignment/re-OCR pass with explicit confirmation, so they're left for a follow-up rather than auto-shifted here.

## Out of scope — insufficient info
- **#9/#10/#11**: full paths not included in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)