### PR TITLE
fix(data): recount page counters on visible pages only (12 false 'not yet translated' banners)

### DIFF
--- a/scripts/maintenance/recount-page-stats.mjs
+++ b/scripts/maintenance/recount-page-stats.mjs
@@ -13,9 +13,19 @@
  * said "This edition is not yet translated" (gate: translated/pages < 5%) while
  * the reader below it served English on 581 of its pages — the counter said 20.
  *
- * Counting rules mirror collect-batch-results.mjs exactly (all pages, including
- * negative page_number soft-hidden ones) so this script can never disagree with
- * the pipeline's own writer.
+ * Counting rule: VISIBLE pages only — `page_number > 0`. A negative page_number
+ * is a deliberate soft-hide (dropped duplicate spreads, junk scans), those pages
+ * never render in the reader, and `books.pages_count` is what the book page
+ * prints as "N scans" and divides by for every ratio it shows. Counting hidden
+ * pages inflates the scan count and depresses the translated fraction.
+ *
+ * This is the corpus's dominant convention but NOT a universal one: sampling 400
+ * visible books that have hidden pages, 387 store the positive-only count and 13
+ * store the all-pages count. `collect-batch-results.mjs` (and the sibling writers
+ * that copied it) count all pages — that writer is the source of the minority,
+ * and of the bug above: it is what left Histoire de la magie claiming 929 scans
+ * for 620 readable pages. Fixing those writers is issue-worthy follow-up; until
+ * then this script is the corrective, so do not "align" it back to them.
  *
  * Usage:
  *   node scripts/maintenance/recount-page-stats.mjs --slug <slug> [...]
@@ -38,7 +48,7 @@ if (!STALE && slugs.length === 0) {
 }
 
 const COUNT_PIPELINE = (bookId) => [
-  { $match: { book_id: bookId } },
+  { $match: { book_id: bookId, page_number: { $gt: 0 } } },
   {
     $group: {
       _id: null,

--- a/scripts/maintenance/recount-page-stats.mjs
+++ b/scripts/maintenance/recount-page-stats.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Recount books.pages_count / pages_ocr / pages_translated from the `pages`
+ * collection.
+ *
+ * Why this exists: those three fields are denormalised counters, written by
+ * whichever worker last touched the book (collect-batch-results, batch-collector,
+ * realtime-translate, batch-split-bph…). Any translation path that finishes
+ * without running the recount leaves the counter frozen at its old value, and
+ * every read-path gate that divides by it then misreads the book. The
+ * user-visible symptom that surfaced this (2026-07-20): the sibling-edition
+ * notice on /book/histoire-de-la-magie-avec-une-exposition-claire-et-precise-constant
+ * said "This edition is not yet translated" (gate: translated/pages < 5%) while
+ * the reader below it served English on 581 of its pages — the counter said 20.
+ *
+ * Counting rules mirror collect-batch-results.mjs exactly (all pages, including
+ * negative page_number soft-hidden ones) so this script can never disagree with
+ * the pipeline's own writer.
+ *
+ * Usage:
+ *   node scripts/maintenance/recount-page-stats.mjs --slug <slug> [...]
+ *   node scripts/maintenance/recount-page-stats.mjs --stale      # scan all visible books
+ *   node scripts/maintenance/recount-page-stats.mjs --stale --apply
+ *
+ * Dry-run by default; --apply writes.
+ */
+
+import { MongoClient } from 'mongodb';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const STALE = args.includes('--stale');
+const slugs = args.filter((a, i) => args[i - 1] === '--slug');
+
+if (!STALE && slugs.length === 0) {
+  console.error('Usage: --slug <slug> [--slug <slug>...] | --stale   [--apply]');
+  process.exit(1);
+}
+
+const COUNT_PIPELINE = (bookId) => [
+  { $match: { book_id: bookId } },
+  {
+    $group: {
+      _id: null,
+      total: { $sum: 1 },
+      with_ocr: {
+        $sum: {
+          $cond: [
+            {
+              $and: [
+                { $ne: ['$ocr.data', null] },
+                { $ne: ['$ocr.data', ''] },
+                { $ifNull: ['$ocr.data', false] },
+              ],
+            },
+            1,
+            0,
+          ],
+        },
+      },
+      with_translation: {
+        $sum: {
+          $cond: [
+            {
+              $and: [
+                { $ne: ['$translation.data', null] },
+                { $ne: ['$translation.data', ''] },
+                { $ifNull: ['$translation.data', false] },
+              ],
+            },
+            1,
+            0,
+          ],
+        },
+      },
+    },
+  },
+];
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+const books = db.collection('books');
+const pages = db.collection('pages');
+
+const query = STALE
+  ? { visible: true, pages_count: { $gt: 0 } }
+  : { slug: { $in: slugs } };
+
+const candidates = await books
+  .find(query)
+  .project({ _id: 1, id: 1, slug: 1, title: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1 })
+  .toArray();
+
+console.log(`Scanning ${candidates.length} book(s)…`);
+
+let drifted = 0;
+let written = 0;
+
+for (const book of candidates) {
+  const bookId = book.id || String(book._id);
+  const [counts] = await pages.aggregate(COUNT_PIPELINE(bookId)).toArray();
+  if (!counts) continue;
+
+  const same =
+    (book.pages_count ?? 0) === counts.total &&
+    (book.pages_ocr ?? 0) === counts.with_ocr &&
+    (book.pages_translated ?? 0) === counts.with_translation;
+  if (same) continue;
+
+  drifted++;
+  console.log(
+    `${book.slug}\n  pages       ${book.pages_count ?? 0} → ${counts.total}` +
+      `\n  ocr         ${book.pages_ocr ?? 0} → ${counts.with_ocr}` +
+      `\n  translated  ${book.pages_translated ?? 0} → ${counts.with_translation}`,
+  );
+
+  if (APPLY) {
+    const res = await books.updateOne(
+      { _id: book._id },
+      {
+        $set: {
+          pages_count: counts.total,
+          pages_ocr: counts.with_ocr,
+          pages_translated: counts.with_translation,
+          updated_at: new Date(),
+        },
+      },
+    );
+    written += res.modifiedCount;
+  }
+}
+
+console.log(`\nDrifted: ${drifted}${APPLY ? ` · written: ${written}` : ' (dry run — pass --apply to write)'}`);
+if (APPLY && written > 0) {
+  console.log(
+    'Next: re-sync the Supabase catalog (scripts/maintenance/sync-books-catalog.mjs), ' +
+      'revalidate the affected /book pages, and purge Cloudflare.',
+  );
+}
+
+await client.close();


### PR DESCRIPTION
Fixes the book Derek reported (2026-07-20) and the 11 others like it. Root cause filed as #3293.

## The report

[/book/histoire-de-la-magie-...-constant](https://sourcelibrary.org/book/histoire-de-la-magie-avec-une-exposition-claire-et-precise-constant) showed *"This edition is not yet translated, but the library holds this work in English"* while the reader below it served English. Stored `pages_translated: 20`; the true visible count is 581 of 620.

## Root cause (#3293)

Two conflicting conventions for `books.pages_count`. The read path assumes **visible pages only** (`page_number > 0`) — it prints `pages_count` as "N scans" and divides by it for the `TranslatedSiblingNotice` <5% gate, `hasTranslations`, and the ≥90%-readable filter. The pipeline's counter writers (`collect-batch-results`, `batch-collector`, `collect-multipage-ocr`, `batch-split-bph`, `realtime-translate`) count **all** pages, including negative-`page_number` soft-hidden ones. 387 of 400 sampled books use visible-only, so the writers are the minority — but a book they touch after a split/hide flips to the wrong convention.

## This PR

`scripts/maintenance/recount-page-stats.mjs` — recomputes the three counters on visible pages only. Dry-run by default; `--slug` for targeted repair, `--stale` to scan, `--apply` to write. The header comment explains why it must NOT be realigned to the pipeline writers.

## Already applied to prod

12 books had a genuinely false banner. All repaired, revalidated, catalog re-synced, Cloudflare purged. A re-scan of all 1,918 gate-tripping books now returns **0** false banners. Histoire de la magie reads 620 scans against 620 readable pages.

Net genuine recovery: 3,858 translated pages. Largest cases: *De re metallica* 592/600 (stored 0), Agrippa 617/624, Pymander 465/472, Suetonius 683/695, Celsus 609/615.

## A wrong turn worth recording

My first pass copied the counting rule from `collect-batch-results.mjs` and wrote it to 88 books — adding 13,274 phantom scans and 12,852 translated pages that exist only on hidden pages, making 66 books whose banner was *correct* look translated. Live ~30 minutes, fully reversed. The tell I skipped: in 12 of 12 sampled books the `pages_count` "drift" equalled the hidden-page count exactly, which is a definitional difference, not staleness. **Anyone sweeping this should verify a few "recovered" pages actually render before trusting an aggregate.**

## Out of scope

- **Fixing the five pipeline writers** — #3293. Without that, counters keep flipping convention.
- **The corpus-wide sweep.** Residual drift is **unmeasured**: a full `pages` aggregation was killed mid-run three times in my session. `--stale` does it once it can complete.
- No frontend change — `TranslatedSiblingNotice` behaved correctly on the data it was given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)