### PR TITLE
fix(scholarly-pdf): robust Typst generation for DOI batch minting

### DIFF
--- a/scripts/lib/scholarly-typst.mjs
+++ b/scripts/lib/scholarly-typst.mjs
@@ -103,10 +103,12 @@ function translationToTypst(text) {
   // Now escape Typst special chars (but not our %%FN%% placeholders)
   out = escapeTypst(out);
 
-  // Convert footnote placeholders to Typst footnotes
+  // Convert footnote placeholders to Typst footnotes. The trailing semicolon
+  // explicitly ends the code expression — without it, adjacent text like
+  // "#footnote[...].Feverish" parses as a field access and fails to compile
   for (let i = 0; i < footnotes.length; i++) {
     const escaped = escapeTypst(footnotes[i]);
-    out = out.replace(`%%FN${i}%%`, `#footnote[${escaped}]`);
+    out = out.replace(`%%FN${i}%%`, `#footnote[${escaped}];`);
   }
 
   // Remove markdown table rows (they don't render well — keep content)

--- a/scripts/lib/scholarly-typst.mjs
+++ b/scripts/lib/scholarly-typst.mjs
@@ -456,7 +456,9 @@ export async function generateScholarlyPdf(book, pages, options = {}) {
 
   try {
     execSync(`typst compile "${typFile}" "${pdfFile}"`, {
-      timeout: 60000,
+      // Large books legitimately take minutes, and a loaded machine (this box
+      // often runs concurrent pipeline jobs) stretches that further
+      timeout: 300000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 

--- a/scripts/lib/scholarly-typst.mjs
+++ b/scripts/lib/scholarly-typst.mjs
@@ -125,7 +125,8 @@ function translationToTypst(text) {
 
 function escapeTypst(text) {
   // Escape characters special in Typst content mode
-  return text
+  // Coerce non-strings: fields like ustc_id are stored as numbers on some books
+  return String(text ?? '')
     .replace(/\\/g, '\\\\')
     .replace(/#/g, '\\#')
     .replace(/\$/g, '\\$')
@@ -136,7 +137,13 @@ function escapeTypst(text) {
     .replace(/\[/g, '\\[')
     .replace(/\]/g, '\\]')
     .replace(/_/g, '\\_')
-    .replace(/\*/g, '\\*');
+    .replace(/\*/g, '\\*')
+    // // and /* open Typst comments even in content mode: // silently eats
+    // the rest of the line (and any closing ] of an enclosing #footnote)
+    .replace(/\/\//g, '\\/\\/')
+    .replace(/\/\*/g, '\\/\\*')
+    // backtick opens a Typst raw block and swallows everything to the next one
+    .replace(/`/g, '\\`');
 }
 
 function markdownToTypst(md) {
@@ -146,6 +153,10 @@ function markdownToTypst(md) {
   // ## Heading → = Heading (Typst level 2 since we use = for title)
   out = out.replace(/^### (.+)$/gm, '=== $1');
   out = out.replace(/^## (.+)$/gm, '== $1');
+
+  // Markdown `*` bullets → `-` bullets BEFORE emphasis conversion,
+  // so a bullet asterisk can't pair with an italic asterisk on the same line
+  out = out.replace(/^(\s*)\*\s+/gm, '$1- ');
 
   // **bold** → *bold*
   out = out.replace(/\*\*(.+?)\*\*/g, '*$1*');
@@ -164,6 +175,20 @@ function markdownToTypst(md) {
   out = out.replace(/@/g, '\\@');
   out = out.replace(/(?<!\\)<(?![a-z])/g, '\\<');
   out = out.replace(/(?<![a-z])>(?!])/g, '\\>');
+
+  // Typst comment-openers in prose (e.g. https:// URLs) silently eat the
+  // rest of the line — escape them
+  out = out.replace(/\/\//g, '\\/\\/');
+  out = out.replace(/\/\*/g, '\\/\\*');
+
+  // Unclosed-delimiter guard: any line left with an odd number of * or _
+  // (AI markdown variance) would make Typst fail to compile — escape them
+  out = out.split('\n').map(line => {
+    if (((line.match(/(?<!\\)\*/g) || []).length) % 2 === 1) line = line.replace(/(?<!\\)\*/g, '\\*');
+    if (((line.match(/(?<!\\)_/g) || []).length) % 2 === 1) line = line.replace(/(?<!\\)_/g, '\\_');
+    if (((line.match(/(?<!\\)`/g) || []).length) % 2 === 1) line = line.replace(/(?<!\\)`/g, '\\`');
+    return line;
+  }).join('\n');
 
   return out;
 }


### PR DESCRIPTION
Found while minting DOIs for the top-viewed translated books (5 of the first ~14 books failed PDF generation, three distinct root causes).

**In scope:**
- `escapeTypst` coerces input to string — `ustc_id` is stored as a number on printed books and threw `text.replace is not a function`.
- `escapeTypst` escapes `//`, `/*`, and backticks — Typst treats these as comment/raw openers even in content mode. `///` inside a marginal-note footnote swallowed the closing `]` (compile error), and a bare `https://` URL in prose would silently comment out the rest of its line (text loss).
- `markdownToTypst` converts markdown `*` bullets to `-` **before** emphasis conversion (Gemini mixes `*` bullets with italics, corrupting the line), escapes comment-openers, and escapes any line left with an odd count of `*`/`_`/backtick so AI markdown variance can never produce an unclosed delimiter.

**Out of scope:** the DOI batch run itself (data-side); orphaned Zenodo draft cleanup.

Verified per-book: Atalanta Fugiens (3.6MB), 2,087-page Huser Paracelsus (28.4MB), Agrippa De Occulta Philosophia (9.1MB), Michael Scot Liber Introductorius (6.7MB) all compile after the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)