### PR TITLE
Download gating: free text formats with sign-in, premium formats paid, daily cap

### DIFF
--- a/src/app/api/[tenant]/books/[id]/download/route.ts
+++ b/src/app/api/[tenant]/books/[id]/download/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
-import { canDownload, classifyImageAccess, PRICES } from '@/lib/purchases';
+import { canDownload, classifyImageAccess, hasPurchased, PRICES } from '@/lib/purchases';
 import { isBookReadable } from '@/lib/book-access';
+import { isInnerCircle } from '@/lib/auth-helpers';
+import { isPremiumFormat, isValidDownloadFormat } from '@/lib/download-formats';
+import { checkAndRecordDownload } from '@/lib/download-cap';
 import type { Book, Page, TranslationEdition } from '@/lib/types';
 import epub from 'epub-gen-memory';
 import archiver from 'archiver';
@@ -2498,9 +2501,10 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 
-    // Valid formats: TXT, EPUB, and ZIP
-    const validFormats = ['translation', 'ocr', 'both', 'epub-translation', 'epub-ocr', 'epub-both', 'epub-parallel', 'epub-facsimile', 'epub-images', 'epub-scholarly', 'epub-bilingual', 'images-zip', 'pdf-translation', 'pdf-facsimile'];
-    if (!validFormats.includes(format)) {
+    // Valid formats: TXT, EPUB, ZIP, and PDF — tier membership (free text vs.
+    // premium) lives in src/lib/download-formats.ts, the single source of
+    // truth shared with the global route and DownloadButton.tsx.
+    if (!isValidDownloadFormat(format)) {
       return NextResponse.json(
         { error: 'Invalid format' },
         { status: 400 }
@@ -2554,15 +2558,39 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Member-or-purchased gate for paid formats. NC-free image formats bypass
-    // this (charging for an NC scan would cross the commercial line).
-    if (process.env.STRIPE_SECRET_KEY && imageAccess !== 'nc-free') {
+    // Member-or-purchased gate applies ONLY to premium formats (#3290). NC-free
+    // image formats bypass this too (charging for an NC scan would cross the
+    // commercial line).
+    if (isPremiumFormat(format) && process.env.STRIPE_SECRET_KEY && imageAccess !== 'nc-free') {
       const allowed = await canDownload(userId, 'book', id);
       if (!allowed) {
         return NextResponse.json(
           { error: 'Purchase required', price: PRICES.book.label, type: 'book', itemId: id },
           { status: 402 },
         );
+      }
+    }
+
+    // Daily free-tier cap (#3290): free text formats are ungated by price but
+    // capped at 20 distinct books/24h per account, to keep the free tier from
+    // becoming a bulk-export path. Members, per-book purchasers, and
+    // editor/admin sessions are exempt. Runs after the sign-in/402/403 gates
+    // and before any expensive generation work below.
+    if (!isPremiumFormat(format)) {
+      const isMember = (session?.user as { membership?: unknown } | undefined)?.membership != null;
+      const isExemptEditor = await isInnerCircle();
+      const isPurchased = isMember || isExemptEditor ? false : await hasPurchased(userId, 'book', id);
+      if (!isMember && !isExemptEditor && !isPurchased) {
+        const cap = await checkAndRecordDownload(userId, id);
+        if (!cap.allowed) {
+          return NextResponse.json(
+            {
+              error: 'Daily download limit reached (20 books/24h). For bulk or programmatic access, see https://sourcelibrary.org/licensing',
+              limit_reached: true,
+            },
+            { status: 429 },
+          );
+        }
       }
     }
 

--- a/src/app/api/books/[id]/download/route.ts
+++ b/src/app/api/books/[id]/download/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
-import { canDownload, classifyImageAccess, PRICES } from '@/lib/purchases';
+import { canDownload, classifyImageAccess, hasPurchased, PRICES } from '@/lib/purchases';
 import { isBookReadable } from '@/lib/book-access';
+import { isInnerCircle } from '@/lib/auth-helpers';
+import { isPremiumFormat, isValidDownloadFormat } from '@/lib/download-formats';
+import { checkAndRecordDownload } from '@/lib/download-cap';
 import type { Book, Page, TranslationEdition } from '@/lib/types';
 import epub from 'epub-gen-memory';
 import archiver from 'archiver';
@@ -2510,9 +2513,10 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const { searchParams } = new URL(request.url);
     const format = searchParams.get('format') || 'translation';
 
-    // Valid formats: TXT, EPUB, ZIP, and PDF
-    const validFormats = ['translation', 'ocr', 'both', 'epub-translation', 'epub-ocr', 'epub-both', 'epub-parallel', 'epub-facsimile', 'epub-images', 'epub-scholarly', 'epub-bilingual', 'images-zip', 'pdf-translation', 'pdf-facsimile'];
-    if (!validFormats.includes(format)) {
+    // Valid formats: TXT, EPUB, ZIP, and PDF — tier membership (free text vs.
+    // premium) lives in src/lib/download-formats.ts, the single source of
+    // truth shared with the tenant route and DownloadButton.tsx.
+    if (!isValidDownloadFormat(format)) {
       return NextResponse.json(
         { error: 'Invalid format' },
         { status: 400 }
@@ -2560,14 +2564,39 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // NC-free image formats skip the paid gate (charging would cross the NC line).
-    if (process.env.STRIPE_SECRET_KEY && imageAccess !== 'nc-free') {
+    // Paid gate applies ONLY to premium formats (#3290) — free text formats
+    // never hit this. NC-free image formats skip it too (charging would
+    // cross the NC line).
+    if (isPremiumFormat(format) && process.env.STRIPE_SECRET_KEY && imageAccess !== 'nc-free') {
       const allowed = await canDownload(userId, 'book', id);
       if (!allowed) {
         return NextResponse.json(
           { error: 'Purchase required', price: PRICES.book.label, type: 'book', itemId: id },
           { status: 402 },
         );
+      }
+    }
+
+    // Daily free-tier cap (#3290): free text formats are ungated by price but
+    // capped at 20 distinct books/24h per account, to keep the free tier from
+    // becoming a bulk-export path. Members, per-book purchasers, and
+    // editor/admin sessions are exempt. Runs after the sign-in/402/403 gates
+    // and before any expensive generation work below.
+    if (!isPremiumFormat(format)) {
+      const isMember = (session?.user as { membership?: unknown } | undefined)?.membership != null;
+      const isExemptEditor = await isInnerCircle();
+      const isPurchased = isMember || isExemptEditor ? false : await hasPurchased(userId, 'book', id);
+      if (!isMember && !isExemptEditor && !isPurchased) {
+        const cap = await checkAndRecordDownload(userId, id);
+        if (!cap.allowed) {
+          return NextResponse.json(
+            {
+              error: 'Daily download limit reached (20 books/24h). For bulk or programmatic access, see https://sourcelibrary.org/licensing',
+              limit_reached: true,
+            },
+            { status: 429 },
+          );
+        }
       }
     }
 

--- a/src/components/ui/DownloadButton.tsx
+++ b/src/components/ui/DownloadButton.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { trackEvent } from '@/lib/track-event';
 import { Download, ChevronDown, FileText, Languages, Layers, BookOpen, Columns, Image, GraduationCap, FileType } from 'lucide-react';
 import { BookDownloadFormats, books } from '@/lib/api-client';
+import { isImageFormat, isPremiumFormat } from '@/lib/download-formats';
 
 type ImageAccess = 'open' | 'nc-free' | 'blocked';
 
@@ -64,8 +65,6 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const isImageFormat = (f: BookDownloadFormats) =>
-    f === 'images-zip' || f === 'epub-images' || f === 'epub-facsimile' || f === 'pdf-facsimile';
   const isNcFreeFormat = (f: BookDownloadFormats) =>
     imageAccess === 'nc-free' && isImageFormat(f);
 
@@ -80,15 +79,16 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
     // at the moment of the click and lets them choose to continue.
     if (!session?.user) {
       toast('Sign in to download', {
-        description: 'Members download every format. Sign in to get started.',
+        description: 'Text formats are free once you sign in. Premium formats (facsimiles, parallel text, scholarly editions) need purchase or membership.',
         action: { label: 'Sign in', onClick: goToSignIn },
       });
       return;
     }
 
-    // Signed-in but no purchase: NC-free image formats are free; everything
-    // else still routes through the paid flow.
-    if (accessChecked && !hasAccess && !isNcFreeFormat(format)) {
+    // Text formats are free for any signed-in user (subject to a daily cap
+    // enforced server-side). Only premium formats route through the paid
+    // flow — and NC-free image formats are exempt even there.
+    if (isPremiumFormat(format) && accessChecked && !hasAccess && !isNcFreeFormat(format)) {
       handlePurchase();
       return;
     }
@@ -105,6 +105,18 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
       if (response.status === 402) {
         setDownloading(null);
         handlePurchase();
+        return;
+      }
+      if (response.status === 429) {
+        setDownloading(null);
+        let message = 'Daily download limit reached (20 books/24h). For bulk or programmatic access, see /licensing.';
+        try {
+          const data = await response.json();
+          if (data?.error) message = data.error;
+        } catch {
+          // Fall back to the generic message above.
+        }
+        toast.error(message);
         return;
       }
       // Any other failure (500, gateway 504/524, …) must NOT be saved as the
@@ -212,12 +224,14 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
                 Sign in to download
               </button>
               <p className="mt-2 text-xs text-stone-400 text-center">
-                {ncImagesFree ? 'Page scans are free; other formats may require a member account.' : 'Free for members.'}
+                {ncImagesFree ? 'Text formats and page scans are free once you sign in.' : 'Text formats are free once you sign in — premium formats (facsimiles, parallel text, scholarly editions) need a member account.'}
               </p>
             </div>
           )}
 
-          {/* Quiet purchase prompt for signed-in non-members */}
+          {/* Quiet purchase prompt for signed-in non-members — text formats
+              below are already free and download directly; this only unlocks
+              the premium (image/apparatus) formats. */}
           {needsPurchase && (
             <div className="px-3 py-3 border-b border-stone-100">
               <button
@@ -225,16 +239,17 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
                 disabled={purchasing}
                 className="w-full py-2.5 bg-stone-900 hover:bg-stone-800 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
               >
-                {purchasing ? 'Redirecting...' : 'Download this book ($5)'}
+                {purchasing ? 'Redirecting...' : 'Unlock premium formats ($5)'}
               </button>
               <p className="mt-2 text-xs text-stone-400 text-center">
-                {ncImagesFree ? 'Page scans are free; other formats included with purchase.' : 'All formats included'}
+                {ncImagesFree ? 'Page scans are free; parallel-text and scholarly editions included with purchase.' : 'Text formats below are already free — this unlocks facsimiles, parallel text, and scholarly editions.'}
               </p>
             </div>
           )}
 
-          <div className="px-3 py-2 text-xs font-medium text-stone-500 uppercase tracking-wide border-b border-stone-100">
-            TXT
+          <div className="px-3 py-2 flex items-center justify-between border-b border-stone-100">
+            <span className="text-xs font-medium text-stone-500 uppercase tracking-wide">TXT</span>
+            <span className="text-[10px] font-medium text-emerald-700 uppercase tracking-wide">Free with sign-in</span>
           </div>
 
           {hasTranslations && (

--- a/src/lib/download-cap.ts
+++ b/src/lib/download-cap.ts
@@ -1,0 +1,60 @@
+import { getDb } from './mongodb';
+
+/**
+ * Daily free-tier download cap (#3290).
+ *
+ * The paid tier protects bulk export (the AI-licensing rate card's asset).
+ * The free tier — text formats, free with sign-in — needed a cap of its own
+ * so it can't be scripted into a corpus-exfiltration path: max 20 DISTINCT
+ * books per rolling 24h per account, counted only across free-tier
+ * downloads. Downloading the same book twice (or in several free formats)
+ * counts once. Members, per-book purchasers, and editor/admin sessions are
+ * exempt — the caller (the download routes) checks those and only calls
+ * this helper for accounts that aren't.
+ *
+ * Storage: `download_events` collection in the `bookstore` db, one doc per
+ * (user_id, book_id) download event with a `ts` Date. No TTL index — repo
+ * policy (#2976) forbids automated retention; prune manually if the
+ * collection ever needs pruning. At scale a compound index on
+ * `{ user_id: 1, ts: -1 }` would speed the rolling-window query below; not
+ * created here — this repo does index/schema changes as explicit ops, not
+ * inline in application code.
+ */
+
+const CAP_WINDOW_MS = 24 * 60 * 60 * 1000;
+export const DAILY_FREE_BOOK_CAP = 20;
+
+export interface DownloadCapResult {
+  allowed: boolean;
+  remaining: number;
+}
+
+/**
+ * Checks the caller's rolling-24h distinct-book count against the daily free
+ * cap. If under the cap (or the book is already counted in the window), the
+ * download is allowed and this download event is recorded. If at the cap AND
+ * this is a new book, the download is rejected and nothing is recorded.
+ */
+export async function checkAndRecordDownload(
+  userId: string,
+  bookId: string,
+): Promise<DownloadCapResult> {
+  const db = await getDb();
+  const events = db.collection('download_events');
+  const since = new Date(Date.now() - CAP_WINDOW_MS);
+
+  const distinctBooks = await events.distinct('book_id', {
+    user_id: userId,
+    ts: { $gte: since },
+  });
+  const alreadyCounted = distinctBooks.includes(bookId);
+
+  if (!alreadyCounted && distinctBooks.length >= DAILY_FREE_BOOK_CAP) {
+    return { allowed: false, remaining: 0 };
+  }
+
+  await events.insertOne({ user_id: userId, book_id: bookId, ts: new Date() });
+
+  const newCount = alreadyCounted ? distinctBooks.length : distinctBooks.length + 1;
+  return { allowed: true, remaining: Math.max(0, DAILY_FREE_BOOK_CAP - newCount) };
+}

--- a/src/lib/download-formats.ts
+++ b/src/lib/download-formats.ts
@@ -1,0 +1,86 @@
+/**
+ * Single source of truth for download format tier membership (#3290).
+ *
+ * Three-tier model:
+ *  1. Free with sign-in — text formats (translation/OCR/EPUB/PDF-translation).
+ *     Subject only to the daily download cap (src/lib/download-cap.ts).
+ *  2. Paid ($5/book or membership) — image-bearing facsimiles, the parallel-
+ *     text edition, and the scholarly/bilingual apparatus editions. Gated by
+ *     canDownload() (src/lib/purchases.ts).
+ *  3. License-driven (unchanged) — NC-free scans stay free with sign-in;
+ *     image-restricted books keep image formats blocked (403). See
+ *     classifyImageAccess() in src/lib/purchases.ts.
+ *
+ * Imported by BOTH download routes (global + tenant twin) AND
+ * DownloadButton.tsx — this module must stay safe to import from a client
+ * component: no `mongodb`, no `next/server`, no Node built-ins.
+ *
+ * A pin test (tests/unit/download-format-tiers.test.ts) locks the exact
+ * membership of each tier so an accidental edit here fails loudly instead of
+ * silently moving a format between free and paid.
+ */
+import type { BookDownloadFormats } from '@/lib/api-client/types/books';
+
+/** Text formats: free for any signed-in user, capped at 20 distinct books/24h. */
+export const FREE_TEXT_FORMATS = [
+  'translation',
+  'ocr',
+  'both',
+  'epub-translation',
+  'epub-ocr',
+  'epub-both',
+  'pdf-translation',
+] as const satisfies readonly BookDownloadFormats[];
+
+/** Premium formats: require membership or a per-book purchase. */
+export const PREMIUM_FORMATS = [
+  'pdf-facsimile',
+  'epub-parallel',
+  'epub-scholarly',
+  'epub-bilingual',
+  'epub-facsimile',
+  'epub-images',
+  'images-zip',
+] as const satisfies readonly BookDownloadFormats[];
+
+export const ALL_DOWNLOAD_FORMATS = [
+  ...FREE_TEXT_FORMATS,
+  ...PREMIUM_FORMATS,
+] as const satisfies readonly BookDownloadFormats[];
+
+type FreeTextFormat = (typeof FREE_TEXT_FORMATS)[number];
+type PremiumFormat = (typeof PREMIUM_FORMATS)[number];
+
+const PREMIUM_SET = new Set<string>(PREMIUM_FORMATS);
+const ALL_FORMATS_SET = new Set<string>(ALL_DOWNLOAD_FORMATS);
+
+// Image-bearing formats: fetch + embed page scans, so they're subject to
+// classifyImageAccess() (blocked/nc-free license classification) in addition
+// to the paid-format gate. Every one of these is also a PREMIUM_FORMATS
+// member — image formats are always premium, but not every premium format is
+// an image format (epub-parallel/epub-scholarly/epub-bilingual are text-only
+// but still paid). Semantics kept identical to DownloadButton.tsx's
+// pre-#3290 `isImageFormat`.
+const IMAGE_FORMAT_SET = new Set<string>([
+  'pdf-facsimile',
+  'epub-facsimile',
+  'epub-images',
+  'images-zip',
+]);
+
+/** True for any format recognized by the download pipeline (free or premium). */
+export function isValidDownloadFormat(format: string): format is BookDownloadFormats {
+  return ALL_FORMATS_SET.has(format);
+}
+
+/** True for formats that require membership or a per-book purchase. */
+export function isPremiumFormat(format: string): format is PremiumFormat {
+  return PREMIUM_SET.has(format);
+}
+
+/** True for formats that embed page scans and are subject to image-license classification. */
+export function isImageFormat(format: string): boolean {
+  return IMAGE_FORMAT_SET.has(format);
+}
+
+export type { FreeTextFormat, PremiumFormat };

--- a/tests/unit/download-format-tiers.test.ts
+++ b/tests/unit/download-format-tiers.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALL_DOWNLOAD_FORMATS,
+  FREE_TEXT_FORMATS,
+  PREMIUM_FORMATS,
+  isImageFormat,
+  isPremiumFormat,
+  isValidDownloadFormat,
+} from '@/lib/download-formats';
+import type { BookDownloadFormats } from '@/lib/api-client/types/books';
+
+// download-formats.ts is the single source of truth for which download
+// formats are free-with-sign-in vs. paid (#3290), imported by both download
+// routes (global + tenant) AND DownloadButton.tsx. A format silently moving
+// between tiers here — or a format existing in BookDownloadFormats but
+// missing from both lists — would either open a paid format for free or
+// charge for a format that should be free. This test hard-codes the expected
+// membership of each tier so any edit fails loudly, in the same spirit as
+// tests/unit/search-filter-wire-names.test.ts.
+
+const EXPECTED_FREE_TEXT_FORMATS: BookDownloadFormats[] = [
+  'translation',
+  'ocr',
+  'both',
+  'epub-translation',
+  'epub-ocr',
+  'epub-both',
+  'pdf-translation',
+];
+
+const EXPECTED_PREMIUM_FORMATS: BookDownloadFormats[] = [
+  'pdf-facsimile',
+  'epub-parallel',
+  'epub-scholarly',
+  'epub-bilingual',
+  'epub-facsimile',
+  'epub-images',
+  'images-zip',
+];
+
+// The full BookDownloadFormats union, listed explicitly so a new format added
+// to the type but forgotten here fails this test rather than silently landing
+// in neither tier list.
+const ALL_KNOWN_FORMATS: BookDownloadFormats[] = [
+  ...EXPECTED_FREE_TEXT_FORMATS,
+  ...EXPECTED_PREMIUM_FORMATS,
+];
+
+describe('download format tiers (#3290)', () => {
+  it('FREE_TEXT_FORMATS matches the approved free tier exactly', () => {
+    expect([...FREE_TEXT_FORMATS].sort()).toEqual([...EXPECTED_FREE_TEXT_FORMATS].sort());
+  });
+
+  it('PREMIUM_FORMATS matches the approved paid tier exactly', () => {
+    expect([...PREMIUM_FORMATS].sort()).toEqual([...EXPECTED_PREMIUM_FORMATS].sort());
+  });
+
+  it('every format belongs to exactly one tier — no overlap, no gaps', () => {
+    const free = new Set<string>(FREE_TEXT_FORMATS);
+    const premium = new Set<string>(PREMIUM_FORMATS);
+
+    // No overlap.
+    for (const f of free) {
+      expect(premium.has(f)).toBe(false);
+    }
+
+    // No gaps against the full known-format universe.
+    for (const f of ALL_KNOWN_FORMATS) {
+      const inFree = free.has(f);
+      const inPremium = premium.has(f);
+      expect(inFree || inPremium).toBe(true);
+      expect(inFree && inPremium).toBe(false);
+    }
+  });
+
+  it('ALL_DOWNLOAD_FORMATS is the union of both tiers, matching the full type', () => {
+    expect([...ALL_DOWNLOAD_FORMATS].sort()).toEqual([...ALL_KNOWN_FORMATS].sort());
+  });
+
+  it('isValidDownloadFormat accepts every known format and rejects junk', () => {
+    for (const f of ALL_KNOWN_FORMATS) {
+      expect(isValidDownloadFormat(f)).toBe(true);
+    }
+    expect(isValidDownloadFormat('not-a-real-format')).toBe(false);
+    expect(isValidDownloadFormat('')).toBe(false);
+  });
+
+  it('isPremiumFormat agrees with PREMIUM_FORMATS membership', () => {
+    for (const f of EXPECTED_FREE_TEXT_FORMATS) {
+      expect(isPremiumFormat(f)).toBe(false);
+    }
+    for (const f of EXPECTED_PREMIUM_FORMATS) {
+      expect(isPremiumFormat(f)).toBe(true);
+    }
+  });
+
+  it('isImageFormat matches the historical DownloadButton definition exactly', () => {
+    const expectedImageFormats: BookDownloadFormats[] = [
+      'pdf-facsimile',
+      'epub-facsimile',
+      'epub-images',
+      'images-zip',
+    ];
+    for (const f of ALL_KNOWN_FORMATS) {
+      expect(isImageFormat(f)).toBe(expectedImageFormats.includes(f));
+    }
+    // Image formats are always premium, but not every premium format is an
+    // image format (the text-only apparatus editions are paid too).
+    expect(isPremiumFormat('epub-parallel')).toBe(true);
+    expect(isImageFormat('epub-parallel')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Restructures download gating from "everything paid except NC scans" to the three-tier model approved in #3290:

1. **Free with sign-in** — text formats: `translation`, `ocr`, `both`, `epub-translation`, `epub-ocr`, `epub-both`, `pdf-translation`. No purchase gate, subject only to the new daily cap.
2. **Paid ($5/book or membership)** — premium formats: `pdf-facsimile`, `epub-parallel`, `epub-scholarly`, `epub-bilingual`, `epub-facsimile`, `epub-images`, `images-zip`. Unchanged `canDownload()` gate, now scoped to premium formats only.
3. **License-driven (unchanged)** — NC-free scans stay free with sign-in via `classifyImageAccess()`; image-restricted books keep image formats blocked (403).

New daily cap prevents the free tier from becoming a bulk-export path: max 20 distinct books per rolling 24h per account, counted only across free-tier downloads (same book twice, or in several formats, counts once). Members, per-book purchasers, and editor/admin sessions are exempt. Over the cap returns 429 with a message pointing at `/licensing` for bulk/programmatic access.

### Changes

- **`src/lib/download-formats.ts`** (new) — single source of truth for tier membership (`FREE_TEXT_FORMATS`, `PREMIUM_FORMATS`, `ALL_DOWNLOAD_FORMATS`, `isPremiumFormat`, `isImageFormat`, `isValidDownloadFormat`). Client-safe (no server-only imports) so it's shared by both download routes and `DownloadButton.tsx`.
- **`src/lib/download-cap.ts`** (new) — `checkAndRecordDownload(userId, bookId)`, backed by a new `download_events` Mongo collection (one doc per download event with a `ts` Date; distinct `book_id` count over the last 24h). No TTL index — repo policy (#2976) forbids automated retention; manual prune only if ever needed.
- **`src/app/api/books/[id]/download/route.ts`** + **`src/app/api/[tenant]/books/[id]/download/route.ts`** — format validation now goes through `isValidDownloadFormat`; the paid gate (`canDownload`) now only runs for `isPremiumFormat(format)`; free-tier formats run the new cap check (with member/purchaser/editor exemptions) after the sign-in/402/403 gates and before any generation work.
- **`src/components/ui/DownloadButton.tsx`** — text formats download immediately for any signed-in user; the purchase prompt only fires for premium formats; copy updated to explain the split ("Unlock premium formats ($5)" / "Free with sign-in" tag on the TXT section); new 429 handling toasts the server's limit message instead of a generic failure.
- **`tests/unit/download-format-tiers.test.ts`** (new) — pins the exact tier membership so an accidental edit fails loudly (every `BookDownloadFormats` member is in exactly one tier list, matches a hard-coded expectation).

### Out of scope

- Anonymous downloads — sign-in stays universal for all formats (unchanged).
- Changes to reading/API budgets (`api-budget.ts`) — this is a download-specific cap, separate mechanism.
- EPUB overlap bug #3284 — not touched here.

Closes #3290. Related: #3283 (PDF formats, shipped in #3285).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 678/678 tests pass (53 files), including the new pin test
- [x] `npx eslint` on all changed/new files — no new errors (the two touched routes + `DownloadButton.tsx` carry pre-existing `no-explicit-any` errors unrelated to this change, confirmed identical via `git stash` against the base branch)
- [x] Grep-verified both routes: `isValidDownloadFormat` rejects anything not in `ALL_DOWNLOAD_FORMATS` before any generation branch runs, and `ALL_DOWNLOAD_FORMATS` is exactly `FREE_TEXT_FORMATS ∪ PREMIUM_FORMATS` with no gaps (pinned by the test) — so no format can reach generation without passing through either the premium-purchase gate or the free-tier cap gate.
- [ ] Manual click-through on a deployed preview (signed-in non-member: free TXT/EPUB-text downloads directly, premium formats prompt purchase; hit the 20-book cap) — not run in this session, recommend before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)