### PR TITLE
fix(e2e): refresh stale crawl sample slugs (#3109)

### DIFF
--- a/e2e/crawl-all-pages.spec.ts
+++ b/e2e/crawl-all-pages.spec.ts
@@ -128,20 +128,24 @@ const STATIC_PAGES = [
 
 // Dynamic pages with known-good sample slugs — cover every dynamic route template
 const DYNAMIC_PAGES = [
-  // /book/[id] — multiple books to catch template bugs
+  // /book/[id] — multiple books to catch template bugs.
+  // NOTE: these are exact current slugs; books get re-slugged by dedup/merge,
+  // so if one starts 404ing it's stale test data, not a broken reader — refresh
+  // the slug (search the API, follow the /book/<id> 301) rather than "restoring"
+  // content. (Two slugs replaced 2026-07-21 for exactly this reason, #3109.)
   '/book/the-hermetic-museum-various-sendivogius',
-  '/book/theatrum-chemicum-zetzner',
-  '/book/de-occulta-philosophia-agrippa',
+  '/book/theatrum-chemicum-vol-vi-ed',
+  '/book/three-books-of-occult-philosophy-nettesheim-2',
 
   // /collections/[id] — broad sample across collection types
   '/collections/alchemy',
   '/collections/classical-philosophy',
   '/collections/hermetica',
   '/collections/kabbalah',
-  '/collections/rosicrucianism',
+  '/collections/secret-societies',
   '/collections/astrology',
   '/collections/natural-philosophy',
-  '/collections/theurgy',
+  '/collections/mysticism',
 
   // /browse/authors/[letter]
   '/browse/authors/A',


### PR DESCRIPTION
## What

The daily E2E `Full site crawl` fails intermittently on four hardcoded sample URLs in `e2e/crawl-all-pages.spec.ts` that no longer resolve (tracked by the auto-created issue #3109):

| Old URL | Reason it 404s | Replacement |
|---|---|---|
| `/collections/rosicrucianism` | No such collection — Rosicrucian content lives under `secret-societies` | `/collections/secret-societies` |
| `/collections/theurgy` | No such collection (48 exist; not one) | `/collections/mysticism` |
| `/book/de-occulta-philosophia-agrippa` | Book re-slugged by dedup/merge (5+ Agrippa copies held) | `/book/three-books-of-occult-philosophy-nettesheim-2` |
| `/book/theatrum-chemicum-zetzner` | Book re-slugged (multiple *Theatrum Chemicum* vols held) | `/book/theatrum-chemicum-vol-vi-ed` |

**No reader-facing content regressed** — I verified all four works/themes are still in the library under current slugs. This was purely stale test data: the crawl pins exact slugs, and slugs drift as books are deduped/merged.

## Scope

- **In scope:** replace the four stale sample URLs; add a comment explaining that a 404 here means stale test data (refresh the slug), not a broken reader.
- **Out of scope:** making the sample list fully dynamic (derive from sitemap/API). Considered it, but it trades slug-drift for a network dependency and potential flakiness in the crawl itself; kept the curated-static design and just fixed the drift. Worth revisiting if this recurs often.

## Verification

`BASE_URL=https://sourcelibrary.org npx playwright test crawl-all-pages` — both `Full site crawl` (155 pages) and `Link follower` (376 links) pass with **0 broken**.

Closes #3109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)