### PR TITLE
fix(pages): count visible pages only in every page-count writer (#3293)

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -9,6 +9,7 @@
 
 import { MongoClient } from 'mongodb';
 import { saveRevisionsBeforeOverwrite } from '../lib/page-revisions.mjs';
+import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
@@ -483,39 +484,10 @@ async function updateParentJobProgress(db, parentJobId) {
 }
 
 async function updateBookCounts(db, bookId) {
-  const [counts] = await db.collection('pages').aggregate([
-    { $match: { book_id: bookId } },
-    {
-      $group: {
-        _id: null,
-        total: { $sum: 1 },
-        with_ocr: {
-          $sum: {
-            $cond: [
-              { $and: [
-                { $ne: ['$ocr.data', null] },
-                { $ne: ['$ocr.data', ''] },
-                { $ifNull: ['$ocr.data', false] }
-              ]},
-              1, 0
-            ]
-          }
-        },
-        with_translation: {
-          $sum: {
-            $cond: [
-              { $and: [
-                { $ne: ['$translation.data', null] },
-                { $ne: ['$translation.data', ''] },
-                { $ifNull: ['$translation.data', false] }
-              ]},
-              1, 0
-            ]
-          }
-        },
-      },
-    },
-  ]).toArray();
+  // Count VISIBLE pages only (page_number > 0) — see scripts/lib/page-counts.mjs
+  // and issue #3293. Soft-hidden pages never render and must not inflate counts.
+  const [counts] = await db.collection('pages')
+    .aggregate(buildVisiblePageCountPipeline(bookId)).toArray();
 
   if (counts) {
     await db.collection('books').updateOne(

--- a/scripts/batch/collect-multipage-ocr.mjs
+++ b/scripts/batch/collect-multipage-ocr.mjs
@@ -8,6 +8,7 @@
 
 import { MongoClient } from 'mongodb';
 import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
+import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
 
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -263,22 +264,11 @@ async function main() {
       }
     );
 
-    // Update book page counts
-    const [counts] = await db.collection('pages').aggregate([
-      { $match: { book_id: job.book_id } },
-      {
-        $group: {
-          _id: null,
-          total: { $sum: 1 },
-          with_ocr: {
-            $sum: { $cond: [{ $and: [{ $ne: ['$ocr.data', null] }, { $ne: ['$ocr.data', ''] }, { $ifNull: ['$ocr.data', false] }] }, 1, 0] }
-          },
-          with_translation: {
-            $sum: { $cond: [{ $and: [{ $ne: ['$translation.data', null] }, { $ne: ['$translation.data', ''] }, { $ifNull: ['$translation.data', false] }] }, 1, 0] }
-          },
-        },
-      },
-    ]).toArray();
+    // Update book page counts — VISIBLE pages only (page_number > 0). See
+    // scripts/lib/page-counts.mjs and issue #3293. Soft-hidden pages never
+    // render and must not inflate counts.
+    const [counts] = await db.collection('pages')
+      .aggregate(buildVisiblePageCountPipeline(job.book_id)).toArray();
 
     if (counts) {
       await db.collection('books').updateOne(

--- a/scripts/batch/realtime-translate.mjs
+++ b/scripts/batch/realtime-translate.mjs
@@ -26,6 +26,7 @@
 
 import { MongoClient } from 'mongodb';
 import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
+import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
 
 // --- Config ---
 const TARGET_MODEL = 'gemini-3-flash-preview';
@@ -305,8 +306,10 @@ async function processBook(book, pages, basePrompt, db, globalStats) {
   // Update book translation count
   if (bookCompleted > 0) {
     try {
+      // VISIBLE pages only (page_number > 0). Soft-hidden pages never render, so
+      // counting them corrupts the visible-only read-path convention (issue #3293).
       const translatedCount = await db.collection('pages').countDocuments({
-        book_id: book.id, 'translation.data': { $exists: true, $ne: '' }
+        book_id: book.id, ...VISIBLE_PAGE_MATCH, 'translation.data': { $exists: true, $ne: '' }
       });
       await db.collection('books').updateOne(
         { id: book.id },

--- a/scripts/lib/page-counts.mjs
+++ b/scripts/lib/page-counts.mjs
@@ -1,0 +1,89 @@
+/**
+ * Canonical page-count convention (issue #3293).
+ *
+ * `books.pages_count` / `pages_ocr` / `pages_translated` are VISIBLE-only:
+ * they count pages with `page_number > 0`. Pages with `page_number <= 0`
+ * are a deliberate soft-hide — they never render in the reader — so counting
+ * them corrupts the read path, which prints `pages_count` as "N scans" and
+ * divides by it for `hasTranslations`, the ≥90%-readable filter, and the
+ * `TranslatedSiblingNotice` <5% gate.
+ *
+ * Every writer that recomputes these counters (batch collectors, the split
+ * worker, realtime translate) must count visible pages only. This module is
+ * the single source of that rule so the convention can't drift per-writer
+ * again. Pinned by tests/unit/page-counts.test.ts.
+ */
+
+/** Match fragment selecting only visible (renderable) pages. */
+export const VISIBLE_PAGE_MATCH = { page_number: { $gt: 0 } };
+
+/** True iff a page renders in the reader (soft-hidden pages have page_number <= 0). */
+export function isVisiblePage(page) {
+  return (page?.page_number ?? 0) > 0;
+}
+
+/** True iff a page carries non-empty OCR text. */
+export function hasOcr(page) {
+  const data = page?.ocr?.data;
+  return typeof data === 'string' && data !== '';
+}
+
+/** True iff a page carries non-empty translation text. */
+export function hasTranslation(page) {
+  const data = page?.translation?.data;
+  return typeof data === 'string' && data !== '';
+}
+
+/**
+ * Aggregation pipeline that returns { total, with_ocr, with_translation }
+ * for the VISIBLE pages of one book. Used by the batch collectors.
+ */
+export function buildVisiblePageCountPipeline(bookId) {
+  return [
+    { $match: { book_id: bookId, ...VISIBLE_PAGE_MATCH } },
+    {
+      $group: {
+        _id: null,
+        total: { $sum: 1 },
+        with_ocr: {
+          $sum: {
+            $cond: [
+              { $and: [
+                { $ne: ['$ocr.data', null] },
+                { $ne: ['$ocr.data', ''] },
+                { $ifNull: ['$ocr.data', false] },
+              ] },
+              1, 0,
+            ],
+          },
+        },
+        with_translation: {
+          $sum: {
+            $cond: [
+              { $and: [
+                { $ne: ['$translation.data', null] },
+                { $ne: ['$translation.data', ''] },
+                { $ifNull: ['$translation.data', false] },
+              ] },
+              1, 0,
+            ],
+          },
+        },
+      },
+    },
+  ];
+}
+
+/**
+ * Pure JS twin of the pipeline: count visible-page stats from an in-memory
+ * page array. Same convention as buildVisiblePageCountPipeline; used where a
+ * writer already holds the pages, and by the test that pins the rule.
+ */
+export function countVisiblePageStats(pages) {
+  const visible = (pages ?? []).filter(isVisiblePage);
+  return {
+    total: visible.length,
+    with_ocr: visible.filter(hasOcr).length,
+    with_translation: visible.filter(hasTranslation).length,
+  };
+}

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -23,6 +23,7 @@ import { logUsageAsync } from './lib/supabase-usage-logger.mjs';
 import { syncPageBatch } from './lib/supabase-page-writer.mjs';
 import { hasScope } from './lib/selective-unpause.mjs';
 import { buildGalleryDoc } from '../lib/gallery-doc.mjs';
+import { buildVisiblePageCountPipeline } from '../lib/page-counts.mjs';
 
 /**
  * Save current page content as a revision before overwriting.
@@ -742,39 +743,10 @@ async function processOneJob(db, job) {
 // ── Post-processing ──
 
 async function updateBookCounts(db, bookId) {
-  const [counts] = await db.collection('pages').aggregate([
-    { $match: { book_id: bookId } },
-    {
-      $group: {
-        _id: null,
-        total: { $sum: 1 },
-        with_ocr: {
-          $sum: {
-            $cond: [
-              { $and: [
-                { $ne: ['$ocr.data', null] },
-                { $ne: ['$ocr.data', ''] },
-                { $ifNull: ['$ocr.data', false] },
-              ]},
-              1, 0,
-            ],
-          },
-        },
-        with_translation: {
-          $sum: {
-            $cond: [
-              { $and: [
-                { $ne: ['$translation.data', null] },
-                { $ne: ['$translation.data', ''] },
-                { $ifNull: ['$translation.data', false] },
-              ]},
-              1, 0,
-            ],
-          },
-        },
-      },
-    },
-  ]).toArray();
+  // Count VISIBLE pages only (page_number > 0) — see scripts/lib/page-counts.mjs
+  // and issue #3293. Soft-hidden pages never render and must not inflate counts.
+  const [counts] = await db.collection('pages')
+    .aggregate(buildVisiblePageCountPipeline(bookId)).toArray();
 
   if (counts) {
     await db.collection('books').updateOne(

--- a/scripts/workers/batch-split-bph.mjs
+++ b/scripts/workers/batch-split-bph.mjs
@@ -30,6 +30,7 @@ import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { MongoClient, ObjectId } from 'mongodb';
 import sharp from 'sharp';
 import { parseArgs } from 'util';
+import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
 
 // --- Config ---
 const ASPECT_RATIO_THRESHOLD = 1.2; // w/h > 1.2 = spread
@@ -455,13 +456,19 @@ async function processBook(r2, db, book) {
     await pagesCol.bulkWrite(renumberOps);
   }
 
-  // Update book
+  // Update book — count VISIBLE pages only (page_number > 0). Soft-hidden pages
+  // never render, so counting them corrupts the visible-only read-path convention
+  // (issue #3293). The renumber above reassigns every page to a positive number,
+  // so allPages.length is already the visible count; the countDocuments filters
+  // keep the convention correct regardless.
   const ocrCount = await pagesCol.countDocuments({
     book_id: book.id,
+    ...VISIBLE_PAGE_MATCH,
     'ocr.data': { $exists: true, $ne: '' },
   });
   const translateCount = await pagesCol.countDocuments({
     book_id: book.id,
+    ...VISIBLE_PAGE_MATCH,
     'translation.data': { $exists: true, $ne: '' },
   });
 

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -25,6 +25,7 @@ import { MongoClient, ObjectId } from 'mongodb';
 import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { buildPageGrounding } from '../lib/page-grounding.mjs';
+import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { GoogleGenAI } from '@google/genai';
@@ -3334,9 +3335,11 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
             await sleep(200);
           }
 
-          // Update book: mark preview done, sync OCR count
+          // Update book: mark preview done, sync OCR count. VISIBLE pages only
+          // (page_number > 0) — see scripts/lib/page-counts.mjs and issue #3293.
           const ocrCount = await db.collection('pages').countDocuments({
             book_id: book.id,
+            ...VISIBLE_PAGE_MATCH,
             'ocr.data': { $exists: true, $ne: '', $not: { $eq: null } },
           });
           await db.collection('books').updateOne(

--- a/tests/unit/page-counts.test.ts
+++ b/tests/unit/page-counts.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Page-count convention guard (issue #3293).
+ *
+ * `books.pages_count` / `pages_ocr` / `pages_translated` are VISIBLE-only —
+ * they count pages with `page_number > 0`. Pages with `page_number <= 0` are
+ * a deliberate soft-hide and never render, so "N scans", the ≥90%-readable
+ * filter, and the <5% "not yet translated" gate all assume the counters
+ * exclude them. Every counter writer (batch collectors, split worker,
+ * realtime translate) routes through scripts/lib/page-counts.mjs so the
+ * convention can't drift per-writer again.
+ *
+ * The damage this pins against: histoire-de-la-magie-...-constant stored
+ * pages_translated: 20 (all-pages counter with hidden pages) while 581 of 620
+ * visible pages were translated, wrongly banner-ing "not yet translated".
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  VISIBLE_PAGE_MATCH,
+  isVisiblePage,
+  hasOcr,
+  hasTranslation,
+  buildVisiblePageCountPipeline,
+  countVisiblePageStats,
+} from '../../scripts/lib/page-counts.mjs';
+
+describe('page-counts convention (#3293)', () => {
+  it('VISIBLE_PAGE_MATCH selects only page_number > 0', () => {
+    expect(VISIBLE_PAGE_MATCH).toEqual({ page_number: { $gt: 0 } });
+  });
+
+  it('isVisiblePage treats page_number <= 0 as hidden', () => {
+    expect(isVisiblePage({ page_number: 1 })).toBe(true);
+    expect(isVisiblePage({ page_number: 0 })).toBe(false);
+    expect(isVisiblePage({ page_number: -3 })).toBe(false);
+    expect(isVisiblePage({})).toBe(false);
+    expect(isVisiblePage(null)).toBe(false);
+  });
+
+  it('hasOcr / hasTranslation require non-empty string data', () => {
+    expect(hasOcr({ ocr: { data: 'text' } })).toBe(true);
+    expect(hasOcr({ ocr: { data: '' } })).toBe(false);
+    expect(hasOcr({ ocr: {} })).toBe(false);
+    expect(hasOcr({})).toBe(false);
+    expect(hasTranslation({ translation: { data: 'x' } })).toBe(true);
+    expect(hasTranslation({ translation: { data: '' } })).toBe(false);
+    expect(hasTranslation({})).toBe(false);
+  });
+
+  it('buildVisiblePageCountPipeline scopes the $match to book + visible pages', () => {
+    const pipeline = buildVisiblePageCountPipeline('book-123');
+    expect(pipeline[0]).toEqual({
+      $match: { book_id: 'book-123', page_number: { $gt: 0 } },
+    });
+    // and it aggregates the three counters
+    const group = pipeline[1].$group;
+    expect(group.total).toEqual({ $sum: 1 });
+    expect(group).toHaveProperty('with_ocr');
+    expect(group).toHaveProperty('with_translation');
+  });
+
+  it('countVisiblePageStats excludes soft-hidden pages from every counter', () => {
+    const pages = [
+      { page_number: 1, ocr: { data: 'a' }, translation: { data: 'A' } },
+      { page_number: 2, ocr: { data: 'b' }, translation: { data: 'B' } },
+      { page_number: 3, ocr: { data: 'c' } }, // ocr but no translation
+      // soft-hidden pages: fully processed, but must NOT be counted
+      { page_number: -1, ocr: { data: 'z' }, translation: { data: 'Z' } },
+      { page_number: 0, ocr: { data: 'y' }, translation: { data: 'Y' } },
+    ];
+    expect(countVisiblePageStats(pages)).toEqual({
+      total: 3,
+      with_ocr: 3,
+      with_translation: 2,
+    });
+  });
+
+  it('regression: hidden translated pages do not fabricate a low translated count', () => {
+    // Mirrors histoire-de-la-magie: many visible translated pages, plus hidden
+    // pages. The all-pages counter would have produced the wrong totals; the
+    // visible-only counter must report the visible truth.
+    const pages = [];
+    for (let n = 1; n <= 581; n++) {
+      pages.push({ page_number: n, ocr: { data: 'o' }, translation: { data: 't' } });
+    }
+    for (let n = 582; n <= 620; n++) {
+      pages.push({ page_number: n, ocr: { data: 'o' } }); // visible, untranslated
+    }
+    // soft-hidden trailing pages (front/back matter removed from the reader)
+    for (let i = 1; i <= 309; i++) {
+      pages.push({ page_number: -i, ocr: { data: 'o' }, translation: { data: 't' } });
+    }
+    const stats = countVisiblePageStats(pages);
+    expect(stats.total).toBe(620); // "N scans" — visible only, not 929
+    expect(stats.with_ocr).toBe(620);
+    expect(stats.with_translation).toBe(581); // not 20, not 890
+    // >90%-readable and >5% gates both see the visible truth
+    expect(stats.with_translation / stats.total).toBeGreaterThan(0.9);
+  });
+});


### PR DESCRIPTION
Fixes #3293.

## The bug
`books.pages_count` / `pages_ocr` / `pages_translated` had two conflicting conventions depending on which writer last touched the book. The read path (`src/app/book/[id]/page.tsx`) assumes **visible-only** — it prints `pages_count` as "N scans" and divides by it for `hasTranslations`, the ≥90%-readable filter, and the `TranslatedSiblingNotice` <5% gate. Soft-hidden pages (`page_number <= 0`) never render. But the pipeline's counter writers filtered on `book_id` only, computing the **all-pages** count, so any book they touched after a split/hide flipped to the wrong convention.

Observed damage (issue #3293): *histoire-de-la-magie* showed "not yet translated" (stored `pages_translated: 20`) while 581 of 620 visible pages were translated, and "929 scans" for 620 readable pages.

## What's in scope
1. **New `scripts/lib/page-counts.mjs`** — single source of the visible-only rule (`VISIBLE_PAGE_MATCH`, `buildVisiblePageCountPipeline`, plus pure predicates + `countVisiblePageStats` for testing). Prevents per-writer drift recurring.
2. **All writers from the issue routed through it:**
   - `collect-batch-results.mjs`, `batch-collector.mjs`, `collect-multipage-ocr.mjs` → `buildVisiblePageCountPipeline()` (the `$match` now scopes `page_number > 0`)
   - `realtime-translate.mjs`, `batch-split-bph.mjs` → `VISIBLE_PAGE_MATCH` on the `countDocuments` filters
3. **Plus `pipeline-orchestrator.mjs`** — its preview-OCR `pages_ocr` sync was the same shape and unlisted; fixed to avoid re-introducing drift on every run.
4. **`tests/unit/page-counts.test.ts`** — pins the convention (item 2 of the issue: "N scans" excludes soft-hidden pages), including the *histoire-de-la-magie* regression (620 scans / 581 translated, not 929 / 20). All 677 unit tests pass.

## What's out of scope
- **The corpus sweep (item 3)** — books already stored on the wrong convention are repaired by `scripts/maintenance/recount-page-stats.mjs --stale`, which ships in the separate open PR #3288. Not duplicated here; this PR stops the *bleeding* (writers producing the bad convention), #3288 repairs the residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)