### PR TITLE
fix(reader): note highlights survive multi-paragraph, nested, and unbalanced annotation spans

### DIFF
--- a/src/components/reader/NotesRenderer.tsx
+++ b/src/components/reader/NotesRenderer.tsx
@@ -9,6 +9,7 @@ import { ChevronDown, ChevronRight, Info } from 'lucide-react';
 import { isRTLLanguage } from '@/lib/types';
 import { NOTE_TAG_STYLES } from '@/lib/style-constants';
 import { cleanOcrArtifacts } from '@/lib/strip-editorial-wrappers';
+import { normalizeAnnotationSpans } from '@/lib/normalize-annotation-spans';
 
 // Page types where the entire "translation" is AI-generated description (no original text)
 const DESCRIPTION_ONLY_PAGE_TYPES = new Set(['blank', 'frontispiece', 'illustration', 'cover', 'map', 'diagram', 'musical-score', 'table']);
@@ -802,23 +803,30 @@ function ColumnMarkdown({ text, showNotes, withNotes }: {
 export default function NotesRenderer({ text, className = '', showMetadata = true, showNotes = true, language, columns, pageType }: NotesRendererProps) {
   const { cleanText, metadata } = useMemo(() => extractMetadata(text), [text]);
 
-  // For non-text page types (frontispiece, illustration, etc.), all content is AI description.
-  // Check the prop and the model's own <page-type> tag (captured into metadata) — but only
-  // treat the page as description-only when no genuine transcribed text survives outside the
-  // annotation tags (title pages keep their real title/author/imprint text). See #feedback.
-  const isDescriptionOnly =
-    (DESCRIPTION_ONLY_PAGE_TYPES.has(pageType ?? '') ||
-      DESCRIPTION_ONLY_PAGE_TYPES.has(metadata.pageType ?? '')) &&
-    !hasBodyTextOutsideNotes(cleanText);
-
   // Read-time OCR safety net (#2764): collapse runaway dot/dash/underscore
   // lacuna walls to […] and convert leaked LaTeX (\frac, \sqrt, operators) to
   // readable text BEFORE any markdown/annotation preprocessing. Superscript
   // spans ($^{n}$) are left for preprocessLatexSuperscripts below.
   const withArtifacts = useMemo(() => cleanOcrArtifacts(cleanText), [cleanText]);
   const withBracketTags = useMemo(() => preprocessBracketTags(withArtifacts, showNotes), [withArtifacts, showNotes]);
+  // Rewrite annotation spans into balanced, non-nested, single-paragraph tag
+  // pairs (#2709). Multi-paragraph <note> blocks otherwise lose their highlight
+  // at the first blank line (CommonMark ends raw-HTML blocks there), and nested
+  // notes break every lazy pairing regex below — AI description then renders
+  // indistinguishable from the book's own text. Must run before any helper that
+  // pairs tags with `<note>[\s\S]*?<\/note>`-style regexes.
+  const withNormalizedSpans = useMemo(() => normalizeAnnotationSpans(withBracketTags), [withBracketTags]);
+  // For non-text page types (frontispiece, illustration, etc.), all content is AI description.
+  // Check the prop and the model's own <page-type> tag (captured into metadata) — but only
+  // treat the page as description-only when no genuine transcribed text survives outside the
+  // annotation tags (title pages keep their real title/author/imprint text). Runs on the
+  // NORMALIZED spans so multi-paragraph/nested note content isn't miscounted as body text.
+  const isDescriptionOnly =
+    (DESCRIPTION_ONLY_PAGE_TYPES.has(pageType ?? '') ||
+      DESCRIPTION_ONLY_PAGE_TYPES.has(metadata.pageType ?? '')) &&
+    !hasBodyTextOutsideNotes(withNormalizedSpans);
   // Drop dangling vocabulary chips when notes are off (see preprocessTerms).
-  const withTerms = useMemo(() => preprocessTerms(withBracketTags, showNotes), [withBracketTags, showNotes]);
+  const withTerms = useMemo(() => preprocessTerms(withNormalizedSpans, showNotes), [withNormalizedSpans, showNotes]);
   // On description-only pages, render the whole AI description uniformly (no half-highlighting).
   const withDescription = useMemo(
     () => (isDescriptionOnly && showNotes ? unwrapDescriptionNotes(withTerms) : withTerms),

--- a/src/lib/normalize-annotation-spans.ts
+++ b/src/lib/normalize-annotation-spans.ts
@@ -1,0 +1,117 @@
+/**
+ * Normalize AI annotation spans (<note>/<margin>/<gloss>/<insert>/<unclear>/
+ * <image-desc>) so the reader's markdown pipeline can render them reliably.
+ *
+ * The translation model emits three structural shapes the render path cannot
+ * represent (issue #2709; reader report 2026-07-13):
+ *
+ *  1. MULTI-PARAGRAPH spans — CommonMark ends a raw-HTML block at the first
+ *     blank line, so paragraphs 2+ of a long <note> silently lose their
+ *     highlight and read as the book's own text. On the de Caus title page the
+ *     AI's engraving description flickers in and out of yellow mid-sentence.
+ *  2. NESTED spans (<note> inside <note>) — the lazy pairing regexes downstream
+ *     (`<note>[\s\S]*?<\/note>`) match the outer open to the INNER close,
+ *     stranding the tail of the outer note as body text.
+ *  3. UNBALANCED tags — a stray close renders as junk; an unclosed open swallows
+ *     unpredictable amounts of the page depending on parser fallback.
+ *
+ * This pass rewrites every annotation span into the one shape the whole
+ * pipeline handles correctly: balanced, non-nested, and confined to a single
+ * paragraph (one open/close pair PER paragraph of content). Run it before any
+ * of the lazy-regex preprocessors so they only ever see well-formed spans.
+ *
+ * Provenance rule: content is never dropped or reordered — only the tag
+ * structure changes. Non-family inline tags (<term>, <sup>, …) inside a span
+ * pass through untouched. Nested family tags are flattened into the outer span
+ * (a note inside a note is just more note). A stray close tag is removed; an
+ * unclosed open is closed at the end of its own paragraph — the conservative
+ * choice, since swallowing subsequent real body text into a highlight would
+ * misattribute source text to the AI.
+ */
+
+const FAMILY = 'note|margin|gloss|insert|unclear|image-desc';
+
+// Open or close tag of the family, with optional attributes on the open tag
+// (the OCR side emits e.g. <image-desc size="large" type="engraving">).
+const TAG_RE = new RegExp(`<(\\/?)(${FAMILY})((?:\\s[^>]*)?)>`, 'gi');
+
+const PARAGRAPH_BREAK = /\n[ \t]*\n+/;
+
+// Markdown list/heading marker at line start. Lines like "- To the left: …"
+// inside a <note> must keep the marker OUTSIDE the tag — a line starting with
+// "-" interrupts the paragraph and becomes a list item, which would strand the
+// note content outside the span again. "marker + <note>text</note>" renders as
+// a real list item whose text is highlighted.
+const MARKER_LINE = /^([ \t]*(?:[-*+]|\d+[.)]|#{1,6})[ \t]+)(.*)$/;
+
+/** Wrap one blank-line-free chunk, handling markdown marker lines line-wise. */
+function emitChunk(tagName: string, attrs: string, chunk: string): string {
+  const lines = chunk.split('\n');
+  if (!lines.some(l => MARKER_LINE.test(l))) {
+    return `<${tagName}${attrs}>${chunk}</${tagName}>`;
+  }
+  return lines
+    .map(line => {
+      const m = line.match(MARKER_LINE);
+      if (m) return m[2].trim() ? `${m[1]}<${tagName}${attrs}>${m[2]}</${tagName}>` : line;
+      return line.trim() ? `<${tagName}${attrs}>${line.trim()}</${tagName}>` : line;
+    })
+    .join('\n');
+}
+
+/** Wrap each blank-line-separated paragraph of `content` in its own tag pair. */
+function emitSpan(tagName: string, attrs: string, content: string): string {
+  const chunks = content
+    .split(PARAGRAPH_BREAK)
+    .map(c => c.trim())
+    .filter(Boolean);
+  if (chunks.length === 0) return '';
+  return chunks.map(c => emitChunk(tagName, attrs, c)).join('\n\n');
+}
+
+export function normalizeAnnotationSpans(text: string): string {
+  if (!text || text.indexOf('<') === -1) return text;
+
+  let out = '';
+  let depth = 0;
+  let outerTag = '';
+  let outerAttrs = '';
+  let content = ''; // accumulated span content, family tags excluded
+  let cursor = 0;
+
+  TAG_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TAG_RE.exec(text)) !== null) {
+    const [token, slash, rawName, attrs] = m;
+    const name = rawName.toLowerCase();
+    const between = text.slice(cursor, m.index);
+    cursor = m.index + token.length;
+
+    if (depth === 0) {
+      out += between;
+      if (slash) continue; // stray close tag: drop it
+      depth = 1;
+      outerTag = name;
+      outerAttrs = attrs || '';
+      content = '';
+    } else {
+      content += between;
+      if (slash) {
+        depth--;
+        if (depth === 0) out += emitSpan(outerTag, outerAttrs, content);
+      } else {
+        depth++; // nested family tag: flatten (keep its content, drop the tag)
+      }
+    }
+  }
+
+  const tail = text.slice(cursor);
+  if (depth === 0) return out + tail;
+
+  // Unclosed open: close the span at the end of its own paragraph and emit
+  // everything after that blank line as ordinary text.
+  const all = content + tail;
+  const breakAt = all.search(PARAGRAPH_BREAK);
+  if (breakAt === -1) return out + emitSpan(outerTag, outerAttrs, all);
+  return out + emitSpan(outerTag, outerAttrs, all.slice(0, breakAt)) + '\n\n' + all.slice(breakAt).replace(/^\s+/, '');
+}

--- a/tests/unit/normalize-annotation-spans.test.ts
+++ b/tests/unit/normalize-annotation-spans.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAnnotationSpans } from '../../src/lib/normalize-annotation-spans';
+
+describe('normalizeAnnotationSpans', () => {
+  it('leaves text without annotation tags untouched', () => {
+    const t = 'Plain body text.\n\nAnother paragraph with <term>chesed</term> inline.';
+    expect(normalizeAnnotationSpans(t)).toBe(t);
+  });
+
+  it('leaves a balanced single-paragraph note untouched in shape', () => {
+    const t = 'Before <note>a short gloss</note> after.';
+    expect(normalizeAnnotationSpans(t)).toBe(t);
+  });
+
+  it('splits a multi-paragraph note into one balanced pair per paragraph', () => {
+    const t = '<note>First paragraph of description.\n\nSecond paragraph of description.</note>';
+    expect(normalizeAnnotationSpans(t)).toBe(
+      '<note>First paragraph of description.</note>\n\n<note>Second paragraph of description.</note>'
+    );
+  });
+
+  it('flattens a nested note into the outer span', () => {
+    const t = '<note>Archimedes <note>the mathematician</note> sits with a compass.</note>';
+    expect(normalizeAnnotationSpans(t)).toBe(
+      '<note>Archimedes the mathematician sits with a compass.</note>'
+    );
+  });
+
+  it('flattens nested family tags of a different name too', () => {
+    const t = '<note>text <margin>marginal</margin> more</note>';
+    expect(normalizeAnnotationSpans(t)).toBe('<note>text marginal more</note>');
+  });
+
+  it('preserves non-family inline tags inside a span', () => {
+    const t = '<note>an armillary sphere <term>a model of the heavens</term> rests on a plinth</note>';
+    expect(normalizeAnnotationSpans(t)).toBe(t);
+  });
+
+  it('keeps list markers outside the tag so lists still render', () => {
+    const t = '<note>Two niches:\n- To the left: Mercury.\n- To the right: Nature.</note>';
+    expect(normalizeAnnotationSpans(t)).toBe(
+      '<note>Two niches:</note>\n- <note>To the left: Mercury.</note>\n- <note>To the right: Nature.</note>'
+    );
+  });
+
+  it('drops a stray close tag', () => {
+    const t = 'Real body text.</note> More body.';
+    expect(normalizeAnnotationSpans(t)).toBe('Real body text. More body.');
+  });
+
+  it('closes an unclosed open at the end of its own paragraph', () => {
+    const t = 'Body.\n\n<note>Dangling description here\n\nReal transcribed text continues.';
+    expect(normalizeAnnotationSpans(t)).toBe(
+      'Body.\n\n<note>Dangling description here</note>\n\nReal transcribed text continues.'
+    );
+  });
+
+  it('wraps a fully unclosed trailing note without swallowing structure', () => {
+    const t = '<note>only a caption';
+    expect(normalizeAnnotationSpans(t)).toBe('<note>only a caption</note>');
+  });
+
+  it('preserves attributes on every emitted chunk', () => {
+    const t = '<image-desc size="large" type="engraving">One.\n\nTwo.</image-desc>';
+    expect(normalizeAnnotationSpans(t)).toBe(
+      '<image-desc size="large" type="engraving">One.</image-desc>\n\n<image-desc size="large" type="engraving">Two.</image-desc>'
+    );
+  });
+
+  it('handles the de Caus shape: multi-paragraph + nested + lists in one span', () => {
+    const t = [
+      '<note>An ornate title page.',
+      '',
+      'Flanking the scene are two niches:',
+      '- On the left: Archimedes <note>the mathematician</note> sits.',
+      '- On the right: Hero points.</note>',
+      '',
+      '# THE REASONS',
+    ].join('\n');
+    const out = normalizeAnnotationSpans(t);
+    // No text between spans escapes the note family…
+    expect(out).toContain('<note>An ornate title page.</note>');
+    expect(out).toContain('- <note>On the left: Archimedes the mathematician sits.</note>');
+    expect(out).toContain('- <note>On the right: Hero points.</note>');
+    // …and the real body text stays outside.
+    expect(out).toMatch(/# THE REASONS\s*$/);
+    expect(out).not.toMatch(/<note>[^<]*# THE REASONS/);
+  });
+
+  it('every emitted span is balanced, non-nested, and blank-line-free', () => {
+    const messy =
+      '<note>a\n\nb <note>c</note> d\n\ne</note> body </note> <margin>m1\n\nm2</margin> tail <note>open';
+    const out = normalizeAnnotationSpans(messy);
+    const re = /<(\/?)(note|margin|gloss|insert|unclear|image-desc)(\s[^>]*)?>/g;
+    let depth = 0;
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(out)) !== null) {
+      if (m[1]) {
+        expect(depth).toBe(1); // every close matches an open (no strays)
+        // span content contains no blank line
+        expect(/\n[ \t]*\n/.test(out.slice(last, m.index))).toBe(false);
+        depth--;
+      } else {
+        expect(depth).toBe(0); // never nested
+        depth++;
+        last = re.lastIndex;
+      }
+    }
+    expect(depth).toBe(0); // balanced overall
+  });
+});


### PR DESCRIPTION
## Problem

AI editorial annotations (`<note>`, image descriptions) render **indistinguishably from the book's own text** whenever the span structure exceeds what the markdown pipeline can represent (#2709; reader feedback 2026-07-13 on [*The Reasons of Motive Forces* p.9](https://sourcelibrary.org/book/69a5b99dd76b98f272fcec6d/page/69a5b99dd76b98f272fcec76)):

1. **Multi-paragraph notes** — CommonMark ends a raw-HTML block at the first blank line, so paragraphs 2+ of a long `<note>` silently lose their highlight and read as transcribed source. On the de Caus title page the AI's engraving description flickers in and out of yellow mid-sentence.
2. **Nested notes** (`<note>` inside `<note>`) — every lazy pairing regex in `NotesRenderer` (`<note>[\s\S]*?<\/note>`) pairs the outer open with the *inner* close, stranding the outer note's tail as body text.
3. **Unbalanced tags** — stray closes / unclosed opens (3.7% of note-bearing pages, dominated by doubled `</margin>` closes).

Measured on a 3,000-page sample of note-bearing pages: 0.4% multi-paragraph, 0.8% nested, 3.7% unbalanced. Low rates, but each affected page is severely confusing — and this is the reading-view face of the quote-integrity doctrine: AI prose presenting as the book's words.

## Fix

New `src/lib/normalize-annotation-spans.ts`, run once at the top of the reader preprocessing chain, rewrites every note-family span (`note|margin|gloss|insert|unclear|image-desc`) into the one shape the entire pipeline handles correctly — **balanced, non-nested, confined to a single paragraph**:

- one open/close pair **per paragraph** of span content (a highlight can no longer die at a blank line, because no span crosses one)
- markdown list/heading markers stay **outside** the tag (`- <note>item</note>`) so lists still render as lists with highlighted text
- nested family tags flatten into the outer span; non-family inline tags (`<term>`, `<sup>`) pass through untouched
- stray closes dropped; an unclosed open closes at the end of its own paragraph (conservative: never swallows subsequent real body text into a highlight)
- content is never dropped or reordered — only tag structure changes

Downstream, all the lazy-regex helpers (`preprocessTerms`, `unwrapDescriptionNotes`, `hasBodyTextOutsideNotes`, `preprocessAnnotationInlineMarkdown`) now only ever see well-formed spans. `isDescriptionOnly` moved onto the normalized text so multi-paragraph note content isn't miscounted as body text.

Display-side only — repairs rendering for all frozen data, zero re-translation cost.

## Verification

- 13 new unit tests incl. a structural invariant (every emitted span balanced, non-nested, blank-line-free) and the full de Caus shape; all 597 unit tests pass; `tsc --noEmit` clean.
- Parse-level simulation (remark → rehype-raw, same as the reader) on the real de Caus page: before, the AI description oscillated NOTE→BODY→NOTE 6 times; after, it is one contiguous NOTE run while the motto, title, and imprint remain body text.

## Out of scope

- Reader *styling* of the three annotation categories (#2709's main proposal).
- Prompt-side contract forbidding nested/multi-paragraph notes at write time (#2393).
- Quote/search/embedding provenance of `<note>` content — separate workstream.

Refs #2709, #2393

🤖 Generated with [Claude Code](https://claude.com/claude-code)