### PR TITLE
fix(scholarly-pdf): escape line-initial slashes (Typst term-list syntax)

### DIFF
--- a/scripts/lib/scholarly-typst.mjs
+++ b/scripts/lib/scholarly-typst.mjs
@@ -127,6 +127,11 @@ function translationToTypst(text) {
   // Clean up excessive blank lines
   out = out.replace(/\n{4,}/g, '\n\n\n');
 
+  // A line-initial "/ " is Typst term-list syntax and errors without a colon.
+  // Must run LAST: table-row flattening above can create new line-initial
+  // slashes by joining cells
+  out = out.replace(/^([ \t]*)\/(?!\/)/gm, '$1\\/');
+
   return out.trim();
 }
 


### PR DESCRIPTION
Found during the tranche-2 DOI batch: a line-initial `/ ` parses as a Typst term list and errors without a colon. Hit by slash-prefixed numbered lines and — more subtly — by markdown-table flattening joining cells into a new line starting with `/`. The escape now runs last, after all line-restructuring transforms. Verified on both failing books (14.7MB and 0.4MB PDFs compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)