### PR TITLE
fix(auth): make magic-link signup failures visible and preventable

### DIFF
--- a/src/app/api/analytics/event/route.ts
+++ b/src/app/api/analytics/event/route.ts
@@ -19,11 +19,19 @@ const ALLOWED_EVENTS = new Set([
   // signup_start: fired when a visitor initiates sign-up from a surface, so we
   // can attribute signups by `source` (hero / signin_page / …) and `method`.
   'signup_start',
+  // confirm_view / confirm_click: the two halves of the magic-link interstitial
+  // at /auth/confirm. views-minus-clicks is the drop-off introduced by the
+  // prefetch-safe second click; without them an unconsumed verification token
+  // is indistinguishable from mail that was never opened at all.
+  'confirm_view', 'confirm_click',
 ]);
 
 // Only these prop keys are persisted; everything else is dropped.
 const ALLOWED_PROPS = new Set([
   'bookId', 'format', 'channel', 'page', 'title', 'url', 'hasDoi', 'edition', 'source', 'reason', 'method',
+  // safe: on confirm_view/confirm_click, whether the `next` callback parameter
+  // survived transit — separates "changed their mind" from "the link broke".
+  'safe',
 ]);
 
 const DB_TIMEOUT_MS = 3000;

--- a/src/app/auth/confirm/ConfirmTracker.tsx
+++ b/src/app/auth/confirm/ConfirmTracker.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { trackEvent } from '@/lib/track-event';
+
+/**
+ * Instrumentation for the magic-link interstitial.
+ *
+ * The interstitial (see ../page.tsx) exists so mail-client prefetchers cannot
+ * burn a single-use token before the human clicks. It works — but it also means
+ * signing in now costs TWO clicks, and we had no way to see what that costs us.
+ * An unconsumed `verification_tokens` row is silent about which step was missed:
+ * never-opened mail, abandoned interstitial, and a link mangled by a corporate
+ * URL-rewriter all leave exactly the same trace.
+ *
+ * `confirm_view` on mount and `confirm_click` on the button close that gap:
+ * views tell us the mail arrived and was opened, and views-minus-clicks is the
+ * interstitial's true drop-off. `safe` records whether the `next` parameter
+ * survived transit, which separates "changed their mind" from "the link broke".
+ *
+ * Renders nothing. Tracking must never be able to block a sign-in, so this is a
+ * sibling of the button rather than a wrapper around it.
+ */
+export function ConfirmTracker({ safe }: { safe: boolean }) {
+  const logged = useRef(false);
+
+  useEffect(() => {
+    if (logged.current) return; // StrictMode double-invokes effects in dev
+    logged.current = true;
+    trackEvent('confirm_view', { safe });
+  }, [safe]);
+
+  useEffect(() => {
+    const btn = document.getElementById('confirm-signin');
+    if (!btn) return;
+    const onClick = () => trackEvent('confirm_click', { safe });
+    btn.addEventListener('click', onClick);
+    return () => btn.removeEventListener('click', onClick);
+  }, [safe]);
+
+  return null;
+}

--- a/src/app/auth/confirm/page.tsx
+++ b/src/app/auth/confirm/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { headers } from 'next/headers';
+import { ConfirmTracker } from './ConfirmTracker';
 
 /**
  * Prefetch-safe magic-link interstitial.
@@ -56,6 +57,7 @@ export default async function ConfirmSignInPage({
       <div className="absolute inset-0 bg-black/50" />
 
       <div className="relative z-10 w-full max-w-md p-8 rounded-2xl text-center bg-white/95 backdrop-blur-sm border border-white/20 mx-4">
+        <ConfirmTracker safe={safe} />
         <svg className="w-12 h-12 mx-auto mb-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="var(--text-primary)" strokeWidth="1" />
           <circle cx="12" cy="12" r="7" stroke="var(--text-primary)" strokeWidth="1" />
@@ -73,6 +75,7 @@ export default async function ConfirmSignInPage({
             {/* Plain <a> (not next/link) to the absolute callback URL so Next.js
                 never prefetches it — only a human click consumes the token. */}
             <a
+              id="confirm-signin"
               href={next}
               rel="nofollow"
               className="inline-block w-full px-4 py-3 rounded-lg text-base font-medium transition-all hover:brightness-110"

--- a/src/app/login/TenantSignIn.tsx
+++ b/src/app/login/TenantSignIn.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import { TurnstileWidget, turnstileConfigured } from '@/components/auth/TurnstileWidget';
 
 interface TenantSignInProps {
   tenantSlug: string;
@@ -25,6 +26,10 @@ export function TenantSignIn({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [inviteRequired, setInviteRequired] = useState(false);
+  // Same latent tripwire as the homepage hero: this form POSTs straight to
+  // /api/auth/signin/nodemailer, so without a Turnstile token every tenant
+  // sign-in would 403 the moment Turnstile is enabled. It is off today.
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const router = useRouter();
 
   // Check if email has a pending invitation (only matters if allowSignup is false)
@@ -63,12 +68,21 @@ export function TenantSignIn({
       const res = await fetch('/api/auth/signin/nodemailer', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({ email, csrfToken, callbackUrl }),
+        body: new URLSearchParams({
+          email,
+          csrfToken,
+          callbackUrl,
+          'cf-turnstile-response': turnstileToken ?? '',
+        }),
         redirect: 'follow',
       });
 
       if (res.ok || res.redirected) {
         setEmailSent(true);
+      } else if (res.status === 429) {
+        setError(
+          'Too many sign-in requests from your network in the last hour. Wait a little and try again — this limit is shared by everyone on the same connection.',
+        );
       } else {
         setError('Could not send sign-in link. Please try again.');
       }
@@ -215,9 +229,11 @@ export function TenantSignIn({
             style={inputStyle}
             disabled={loading}
           />
+          {/* Renders only when NEXT_PUBLIC_TURNSTILE_SITE_KEY is set. */}
+          <TurnstileWidget onVerify={setTurnstileToken} />
           <button
             type="submit"
-            disabled={loading || !email}
+            disabled={loading || !email || (turnstileConfigured && !turnstileToken)}
             style={{ ...submitButtonStyle, opacity: loading || !email ? 0.5 : 1 }}
           >
             {loading ? 'Sending…' : 'Continue with Email'}

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -8,6 +8,7 @@ import { BookLoader } from '@/components/ui/BookLoader';
 import { isInAppBrowser, preferredBrowser, inAppBrowserName } from '@/lib/in-app-browser';
 import { trackEvent } from '@/lib/track-event';
 import { TurnstileWidget, turnstileConfigured } from '@/components/auth/TurnstileWidget';
+import { suggestEmailFix } from '@/lib/email-typo';
 import type { Locale } from '@/lib/i18n';
 
 // Page-specific copy. Funnel pages (sign-in, support) get native Spanish so the
@@ -26,6 +27,8 @@ interface SignInStrings {
   errEmailSignin: string;
   errGeneric: string;
   errSendLink: string;
+  errRateLimited: string;
+  didYouMean: (suggestion: string) => string;
   errVerify: string;
   errGoogle: string;
   emailLabel: string;
@@ -55,6 +58,8 @@ const STRINGS: Record<Locale, SignInStrings> = {
     errEmailSignin: 'Could not send sign-in email. Please try again.',
     errGeneric: 'An error occurred during sign in. Please try again.',
     errSendLink: 'Could not send sign-in link. Please try again.',
+    errRateLimited: 'Too many sign-in requests from your network in the last hour. Wait a little and try again — this limit is shared by everyone on the same connection.',
+    didYouMean: (suggestion) => `Did you mean ${suggestion}?`,
     errVerify: 'Please complete the verification below.',
     errGoogle: 'Could not connect to Google. Please try again.',
     emailLabel: 'Email address',
@@ -82,6 +87,8 @@ const STRINGS: Record<Locale, SignInStrings> = {
     errEmailSignin: 'No se pudo enviar el correo de acceso. Inténtalo de nuevo.',
     errGeneric: 'Ocurrió un error al iniciar sesión. Inténtalo de nuevo.',
     errSendLink: 'No se pudo enviar el enlace de acceso. Inténtalo de nuevo.',
+    errRateLimited: 'Demasiadas solicitudes de acceso desde tu red en la última hora. Espera un poco e inténtalo de nuevo — este límite se comparte con todos los que usan la misma conexión.',
+    didYouMean: (suggestion) => `¿Quisiste decir ${suggestion}?`,
     errVerify: 'Por favor completa la verificación abajo.',
     errGoogle: 'No se pudo conectar con Google. Inténtalo de nuevo.',
     emailLabel: 'Correo electrónico',
@@ -110,6 +117,9 @@ function SignInContent({ locale }: { locale: Locale }) {
   const [emailSent, setEmailSent] = useState(false);
   const [loading, setLoading] = useState(false);
   const [emailError, setEmailError] = useState('');
+  // Non-blocking domain-typo hint. A mistyped domain mints a token, bounces at
+  // Resend, and the person never learns why nothing arrived — see src/lib/email-typo.ts.
+  const [suggestion, setSuggestion] = useState<string | null>(null);
   const [googleLoading, setGoogleLoading] = useState(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
 
@@ -152,7 +162,10 @@ function SignInContent({ locale }: { locale: Locale }) {
         'cf-turnstile-response': turnstileToken ?? '',
       });
       if (result?.error) {
-        setEmailError(s.errSendLink);
+        // 429 comes from our own magic-link guard (5/hour per IP, shared across
+        // everyone behind one NAT). Saying so beats a generic failure the user
+        // can only respond to by retrying into the same wall.
+        setEmailError(result.status === 429 ? s.errRateLimited : s.errSendLink);
       } else {
         setEmailSent(true);
       }
@@ -245,7 +258,11 @@ function SignInContent({ locale }: { locale: Locale }) {
             id="email"
             type="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              if (suggestion) setSuggestion(null);
+            }}
+            onBlur={(e) => setSuggestion(suggestEmailFix(e.target.value))}
             placeholder="you@example.com"
             required
             className="w-full px-4 py-3 rounded-lg text-base outline-none transition-all"
@@ -255,6 +272,22 @@ function SignInContent({ locale }: { locale: Locale }) {
               border: '1px solid var(--border-medium)',
             }}
           />
+          {/* A hint, never a block: plenty of valid addresses live on domains no
+              list will contain, and this audience uses hotmail.es / yahoo.com.ar
+              heavily. One tap accepts it; typing dismisses it. */}
+          {suggestion && (
+            <button
+              type="button"
+              onClick={() => {
+                setEmail(suggestion);
+                setSuggestion(null);
+              }}
+              className="mt-1.5 text-sm underline text-left"
+              style={{ color: 'var(--accent-rust)' }}
+            >
+              {s.didYouMean(suggestion)}
+            </button>
+          )}
           {/* Renders only when NEXT_PUBLIC_TURNSTILE_SITE_KEY is set. */}
           <TurnstileWidget onVerify={setTurnstileToken} />
           <button

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -7,6 +7,8 @@ import { isInAppBrowser } from '@/lib/in-app-browser';
 import { useStableSession } from '@/hooks/useStableSession';
 import { recordLoadingMetric } from '@/lib/analytics';
 import { trackEvent } from '@/lib/track-event';
+import { suggestEmailFix } from '@/lib/email-typo';
+import { TurnstileWidget, turnstileConfigured } from '@/components/auth/TurnstileWidget';
 import UnifiedSearch from '@/components/search/UnifiedSearch';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { HOME_STRINGS, type HomeLang, type HomeStrings } from '@/lib/home-i18n';
@@ -22,6 +24,12 @@ function HeroSignUp({ t }: { t: HomeStrings }) {
   const [sent, setSent] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
+  const [suggestion, setSuggestion] = useState<string | null>(null);
+  // The hero mints magic links exactly like the sign-in page does, so it needs
+  // the same Turnstile token. Without this the widget is absent here and every
+  // hero signup would 403 the moment Turnstile is switched on in production —
+  // a latent tripwire, since turnstileEnabled() is false today.
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   // Google OAuth is blocked inside Instagram/Facebook/LinkedIn webviews
   // (disallowed_useragent), so the button silently fails there. Detect it and
   // steer the visitor to the email magic link, which always works.
@@ -37,7 +45,12 @@ function HeroSignUp({ t }: { t: HomeStrings }) {
     try {
       // Provider id is 'nodemailer' (next-auth v5 renamed Email→Nodemailer);
       // the old 'email' id silently no-ops and faked a "check your email".
-      const result = await signIn('nodemailer', { email, callbackUrl: '/', redirect: false });
+      const result = await signIn('nodemailer', {
+        email,
+        callbackUrl: '/',
+        redirect: false,
+        'cf-turnstile-response': turnstileToken ?? '',
+      });
       if (result?.error) setError(true);
       else setSent(true);
     } catch {
@@ -70,19 +83,31 @@ function HeroSignUp({ t }: { t: HomeStrings }) {
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
+          onBlur={(e) => setSuggestion(suggestEmailFix(e.target.value))}
           placeholder={t.emailPlaceholder}
           required
           className="flex-1 px-5 py-3.5 rounded-lg bg-white text-stone-900 placeholder-stone-400 text-base outline-none border border-white focus:ring-2 focus:ring-white/50 transition-colors"
         />
         <button
           type="submit"
-          disabled={loading || !email}
+          disabled={loading || !email || (turnstileConfigured && !turnstileToken)}
           className="px-7 py-3.5 rounded-lg text-base font-medium transition-all hover:brightness-110 disabled:opacity-50 shrink-0"
           style={{ background: 'var(--accent-rust)', color: '#fff' }}
         >
           {loading ? t.sending : t.join}
         </button>
       </form>
+      {/* Renders only when NEXT_PUBLIC_TURNSTILE_SITE_KEY is set. */}
+      <TurnstileWidget onVerify={setTurnstileToken} />
+      {suggestion && (
+        <button
+          type="button"
+          onClick={() => { setEmail(suggestion); setSuggestion(null); }}
+          className="mt-2 text-sm text-white/90 underline text-left"
+        >
+          {t.didYouMean(suggestion)}
+        </button>
+      )}
       {error && (
         <p className="mt-2 text-sm text-red-200">{t.emailError}</p>
       )}

--- a/src/lib/email-typo.ts
+++ b/src/lib/email-typo.ts
@@ -1,0 +1,118 @@
+/**
+ * Mail-domain typo suggestions for the sign-in / sign-up email field.
+ *
+ * Why this exists: a magic-link signup only becomes an account when the person
+ * clicks the link in the email. A mistyped domain mints a `verification_tokens`
+ * row, hard-bounces at Resend, and leaves an orphan forever — the person simply
+ * never hears from us and has no idea why. Measured on 2026-07-21, 14 of the 357
+ * organic signups that failed to complete in the previous 30 days were plain
+ * domain typos: `gamil.com`, `gmail.con`, `gmailcom`, `gmailo.com`, `yahoo.cok`,
+ * `hotmail.com1`, `gmail` (no TLD at all), and friends.
+ *
+ * Design rules, both learned from the same failing set:
+ *
+ * 1. SUGGEST, NEVER BLOCK. Valid addresses live on domains no list will ever
+ *    contain. Our audience is heavily Spanish-speaking (Argentina is the #2
+ *    country), so `hotmail.es`, `yahoo.com.ar`, `hotmail.com.ar` and
+ *    `yahoo.com.mx` are all real and common here. Rejecting "unknown" domains
+ *    would break more signups than typos do.
+ * 2. REGIONAL VARIANTS MUST NOT TRIGGER A SUGGESTION. `hotmail.co.uk` is 3 edits
+ *    from `hotmail.com`, so the distance-2 cutoff already spares it — but the
+ *    KNOWN list below carries the common regional forms explicitly so they exit
+ *    early and can never be "corrected" into the wrong country.
+ */
+
+/**
+ * Domains we treat as certainly-correct. Anything here exits early with no
+ * suggestion. Includes regional variants precisely so they are never "fixed".
+ */
+const KNOWN = new Set([
+  'gmail.com', 'googlemail.com',
+  'hotmail.com', 'hotmail.es', 'hotmail.co.uk', 'hotmail.fr', 'hotmail.it',
+  'hotmail.com.ar', 'hotmail.com.mx', 'hotmail.de', 'hotmail.nl',
+  'outlook.com', 'outlook.es', 'outlook.fr', 'outlook.de', 'outlook.com.br',
+  'yahoo.com', 'yahoo.es', 'yahoo.co.uk', 'yahoo.com.ar', 'yahoo.com.mx',
+  'yahoo.com.br', 'yahoo.fr', 'yahoo.de', 'yahoo.co.jp', 'yahoo.co.in',
+  'icloud.com', 'me.com', 'mac.com',
+  'proton.me', 'protonmail.com', 'pm.me',
+  'live.com', 'live.nl', 'live.com.ar', 'live.co.uk',
+  'aol.com', 'msn.com', 'gmx.de', 'gmx.net', 'web.de', 't-online.de',
+  'yandex.ru', 'mail.ru', 'qq.com', '163.com', '126.com', 'naver.com',
+  'zoho.com', 'fastmail.com', 'hey.com', 'tutanota.com',
+  'orange.fr', 'free.fr', 'wanadoo.fr', 'libero.it', 'terra.com.br', 'uol.com.br',
+]);
+
+/**
+ * The subset we will actively correct *towards*. Deliberately small: only the
+ * giants, where a near-miss is overwhelmingly likely to be a typo rather than a
+ * genuine small provider that merely resembles one.
+ */
+const CORRECT_TO = [
+  'gmail.com',
+  'hotmail.com',
+  'outlook.com',
+  'yahoo.com',
+  'icloud.com',
+  'proton.me',
+  'live.com',
+  'aol.com',
+];
+
+/** Levenshtein distance, bailing out as soon as it exceeds `max`. */
+function distance(a: string, b: string, max: number): number {
+  if (Math.abs(a.length - b.length) > max) return max + 1;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i];
+    let best = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const v = Math.min(row[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+      row.push(v);
+      if (v < best) best = v;
+    }
+    if (best > max) return max + 1; // whole row already too far — stop
+    prev = row;
+  }
+  return prev[b.length];
+}
+
+/**
+ * Suggest a corrected address, or null when the input looks fine (or is too
+ * far gone to guess at). Never throws; safe to call on every keystroke.
+ *
+ * @example suggestEmailFix('ada@gamil.com') === 'ada@gmail.com'
+ * @example suggestEmailFix('ada@hotmail.es') === null  // real domain, left alone
+ */
+export function suggestEmailFix(email: string): string | null {
+  const trimmed = (email || '').trim().toLowerCase();
+  const at = trimmed.lastIndexOf('@');
+  if (at < 1 || at === trimmed.length - 1) return null;
+
+  const local = trimmed.slice(0, at);
+  const domain = trimmed.slice(at + 1);
+  if (!local || !domain) return null;
+  if (KNOWN.has(domain)) return null;
+
+  // A bare provider name with no TLD ("gmail", "hotmail") is unambiguous.
+  // Note the fall-through: "gmailcom" has no dot either, but it is a dropped-dot
+  // typo rather than a bare name, so it must reach the distance check below.
+  if (!domain.includes('.')) {
+    const hit = CORRECT_TO.find((d) => d.startsWith(`${domain}.`));
+    if (hit) return `${local}@${hit}`;
+  }
+
+  // Too short to judge: "a.co" is 2 edits from half the list.
+  if (domain.length < 5) return null;
+
+  let best: string | null = null;
+  let bestDist = 3; // strictly less than 3 → at most 2 edits
+  for (const candidate of CORRECT_TO) {
+    const d = distance(domain, candidate, 2);
+    if (d < bestDist) {
+      bestDist = d;
+      best = candidate;
+    }
+  }
+  return best ? `${local}@${best}` : null;
+}

--- a/src/lib/home-i18n.ts
+++ b/src/lib/home-i18n.ts
@@ -28,6 +28,7 @@ export interface HomeStrings {
   google: string;
   googleBlockedNote: string;
   emailError: string;
+  didYouMean: (suggestion: string) => string;
   haveAccount: string;
   explore: string;
   langEnglish: string;
@@ -141,6 +142,7 @@ const en: HomeStrings = {
   google: 'Or continue with Google',
   googleBlockedNote: 'Google sign-in is usually blocked in in-app browsers — use email above, or open this page in Safari/Chrome.',
   emailError: 'Could not send the sign-in link. Please try again.',
+  didYouMean: (suggestion) => `Did you mean ${suggestion}?`,
   haveAccount: 'Already have an account?',
   explore: 'Explore the collection',
   langEnglish: 'English',
@@ -247,6 +249,7 @@ const es: HomeStrings = {
   google: 'O continúa con Google',
   googleBlockedNote: 'El acceso con Google suele estar bloqueado en navegadores internos — usa el correo de arriba, o abre esta página en Safari/Chrome.',
   emailError: 'No se pudo enviar el enlace de acceso. Inténtalo de nuevo.',
+  didYouMean: (suggestion) => `¿Quisiste decir ${suggestion}?`,
   haveAccount: '¿Ya tienes una cuenta?',
   explore: 'Explora la colección',
   langEnglish: 'English',

--- a/src/lib/track-event.ts
+++ b/src/lib/track-event.ts
@@ -5,7 +5,22 @@
  * keepalive fetch. Never throws — analytics must not break an interaction.
  */
 export function trackEvent(
-  event: 'cite' | 'share' | 'quote_copy' | 'doi_view' | 'download' | 'signin_view' | 'signup_start',
+  event:
+    | 'cite'
+    | 'share'
+    | 'quote_copy'
+    | 'doi_view'
+    | 'download'
+    | 'signin_view'
+    | 'signup_start'
+    // Magic-link interstitial (/auth/confirm). `confirm_view` fires when someone
+    // opens the link from their email, `confirm_click` when they press through to
+    // the callback. The gap between them is the cost of the prefetch-safe second
+    // click, and until these existed it was pure guesswork — a token that is
+    // never consumed looks identical whether the mail was never opened, the
+    // interstitial was abandoned, or the link was mangled in transit.
+    | 'confirm_view'
+    | 'confirm_click',
   props?: Record<string, string | number | boolean | undefined>,
 ): void {
   if (typeof window === 'undefined') return;

--- a/tests/unit/email-typo.test.ts
+++ b/tests/unit/email-typo.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Mail-domain typo suggestions (src/lib/email-typo.ts).
+ *
+ * The cases below are not invented: the "must correct" list is every genuine
+ * domain typo found in the `verification_tokens` rows that never became accounts
+ * in the 30 days to 2026-07-21, and the "must leave alone" list is drawn from
+ * the same set — real regional domains that a naive matcher would happily
+ * "correct" into the wrong country. That second list is the load-bearing one:
+ * a false positive here nags a person whose address was right all along, and on
+ * this audience (Argentina is the #2 country) those are common.
+ */
+import { describe, it, expect } from 'vitest';
+import { suggestEmailFix } from '@/lib/email-typo';
+
+describe('suggestEmailFix', () => {
+  it('corrects the domain typos actually observed in failed signups', () => {
+    const cases: Array<[string, string]> = [
+      ['reader@gamil.com', 'reader@gmail.com'],
+      ['reader@gmail.con', 'reader@gmail.com'],
+      ['reader@gmailcom', 'reader@gmail.com'],
+      ['reader@gmailo.com', 'reader@gmail.com'],
+      ['reader@gmaill.com', 'reader@gmail.com'],
+      ['reader@gmai.com', 'reader@gmail.com'],
+      ['reader@gmail.co', 'reader@gmail.com'],
+      ['reader@yahoo.con', 'reader@yahoo.com'],
+      ['reader@yahoo.cok', 'reader@yahoo.com'],
+      ['reader@hotmail.com1', 'reader@hotmail.com'],
+      ['reader@gmail', 'reader@gmail.com'],
+    ];
+    for (const [input, expected] of cases) {
+      expect(suggestEmailFix(input), input).toBe(expected);
+    }
+  });
+
+  it('leaves real regional domains alone', () => {
+    const real = [
+      'lector@hotmail.es',
+      'lector@yahoo.com.ar',
+      'lector@hotmail.com.ar',
+      'leitor@yahoo.com.br',
+      'lector@yahoo.com.mx',
+      'reader@hotmail.co.uk',
+      'reader@yahoo.co.uk',
+      'lecteur@orange.fr',
+      'leser@web.de',
+    ];
+    for (const email of real) {
+      expect(suggestEmailFix(email), email).toBeNull();
+    }
+  });
+
+  it('leaves the big providers and unknown-but-plausible domains alone', () => {
+    const fine = [
+      'reader@gmail.com',
+      'reader@proton.me',
+      'reader@icloud.com',
+      'scholar@ox.ac.uk',
+      'curator@embassyofthefreemind.com',
+      'someone@a-small-isp.coop',
+      'me@tudelft.nl',
+    ];
+    for (const email of fine) {
+      expect(suggestEmailFix(email), email).toBeNull();
+    }
+  });
+
+  it('never throws and returns null on junk', () => {
+    for (const junk of ['', '   ', 'no-at-sign', '@nolocal.com', 'trailing@', 'a@b']) {
+      expect(() => suggestEmailFix(junk)).not.toThrow();
+      expect(suggestEmailFix(junk)).toBeNull();
+    }
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(suggestEmailFix('  Reader@GAMIL.com ')).toBe('reader@gmail.com');
+  });
+});


### PR DESCRIPTION
**357 organic signups in the 30 days to 2026-07-21 minted a verification token and never became accounts**, against 1,804 that completed — a 16.5% loss. An unconsumed token is silent about *which* step was missed, so this is half prevention, half making the rest measurable.

## Measuring it first — and two readings that were wrong

- Deduplicating tokens by newest-per-address hid every older row, which made the pile look like a rolling 30-day window. It isn't; orphans go back to April.
- **426 of the orphans were minted by our own campaign scripts.** `_tmp_signin_nudge.mjs` and siblings write one `verification_tokens` row per recipient, aimed at people selected *precisely because* they have no account. They show up as three tight bursts (06-21 12:00Z, 06-26 11:00Z and 12:00Z) matching the June nudge. Excluding them gives 16.5%, not the 24% a naive count reports.

**What the corrected set shows:** 247 of the 357 are ordinary `gmail.com` addresses. Deliverable. So the dominant loss is *not* bad addresses — it's people not clicking. The pile starts at 16455743 (2026-06-21), which added the prefetch-safe `/auth/confirm` interstitial. **That fix is correct and stays** — it stopped mail scanners burning single-use tokens, which was the previous dominant failure. But it made signing in cost two clicks, and nothing prunes an unclicked token, so they now accumulate where they used to be consumed.

## Changes

| | |
|---|---|
| **Instrument the interstitial** | `confirm_view` / `confirm_click`, plus `safe` (did the callback param survive transit). views−clicks is the real cost of the second click. Both events *and* the prop had to be added to the allowlists in `/api/analytics/event` — otherwise they 400 and the drop-off reads as zero. |
| **Domain-typo suggestions** | `src/lib/email-typo.ts`, wired into all three email entry points. **Suggest, never block.** 14 of the 357 are typos (`gamil.com`, `gmail.con`, `gmailcom`, `yahoo.cok`, a bare `gmail`) — but this audience is heavily Spanish-speaking and `hotmail.es` / `yahoo.com.ar` are real addresses. Pinned by a test built from the actual failing set, with the real regional domains as negative cases. |
| **Surface the 429** | The magic-link cap is 5/hour **per IP**, shared by everyone behind one corporate or carrier NAT. "Could not send sign-in link. Please try again." invites a retry straight into the same wall. |
| **Mount Turnstile on two forms that lacked it** | The homepage hero and the tenant login both mint magic links but forwarded no token — enabling Turnstile would have 403'd every signup from the site's main front door. Off today, so this is a tripwire, not a live bug. |

## Out of scope, deliberately

- **No TTL on `verification_tokens`.** Orphan rows live forever and it's untidy, but automated retention was removed wholesale in #2976 and I'm not quietly reintroducing it.
- **The interstitial itself is unchanged.** Removing the second click would undo the prefetch fix. The right move is to measure the drop-off first — which is what this PR makes possible — and only then decide whether it's worth trading against.
- **Tenant callback lands on the apex.** `AUTH_URL` forces every magic link to `sourcelibrary.org`, so a visitor who starts on `bph.sourcelibrary.org` signs in fine but is dropped on the apex homepage instead of back where they started. Real UX defect, produces a valid account, unrelated to orphan tokens. Separate PR.

## Verification

`npx tsc --noEmit` clean · 702 unit tests pass · new test covers all 11 observed typo domains and 9 real regional domains as negative cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)