### PR TITLE
fix(ngrams): readable corpus backdrop + browser-cache stale-data trap

### DIFF
--- a/src/app/api/ngrams/route.ts
+++ b/src/app/api/ngrams/route.ts
@@ -199,7 +199,13 @@ export async function GET(request: NextRequest) {
     },
     {
       headers: {
-        'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+        // max-age=0 is load-bearing: without it a browser applies HEURISTIC
+        // freshness and honours the 7-day stale-while-revalidate, so a response
+        // captured mid-backfill (docs mode reports found:false until
+        // books_by_year lands) kept rendering "no data" in an already-open tab
+        // for days after the data was live and the CDN had been purged.
+        // The CDN keeps its own 24h window via s-maxage.
+        'Cache-Control': 'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800',
         'CDN-Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
       },
     },

--- a/src/components/ngrams/NgramViewer.tsx
+++ b/src/components/ngrams/NgramViewer.tsx
@@ -407,14 +407,19 @@ export default function NgramViewer() {
                 fill="var(--text-faint)"
                 opacity={0.16}
               />
-              {/* Band ceiling — gives the grey a number so it isn't a scaleless smear */}
+              {/* Band ceiling — gives the grey a number so it isn't a scaleless
+                  smear. Long dashes so it doesn't read as one of the y-gridlines
+                  (which are 2,4); the label carries a surface-colored halo so it
+                  stays legible where a curve crosses this height. */}
               <line
                 x1={0} y1={plotH * BACKDROP_TOP} x2={plotW} y2={plotH * BACKDROP_TOP}
-                stroke="var(--text-faint)" strokeDasharray="2,5" opacity={0.4}
+                stroke="var(--text-faint)" strokeDasharray="7,5" opacity={0.45}
               />
               <text
-                x={plotW - 2} y={plotH * BACKDROP_TOP - 4}
+                x={plotW - 2} y={plotH * BACKDROP_TOP - 5}
                 fontSize={10} fill="var(--text-faint)" textAnchor="end"
+                stroke="var(--surface-primary, #fdfcf8)" strokeWidth={3}
+                paintOrder="stroke"
               >
                 {compactNumber(tokenBand.top)} tokens/yr
                 {tokenBand.clipped > 0 && ' (peaks clipped)'}

--- a/src/components/ngrams/NgramViewer.tsx
+++ b/src/components/ngrams/NgramViewer.tsx
@@ -59,6 +59,10 @@ const CORPUS_SEARCH_LANGUAGE: Record<string, string> = Object.fromEntries(
 
 const DEFAULT_Q = "philosopher's stone,elixir";
 
+/** Fraction of the plot height where the corpus-volume backdrop tops out
+ *  (0 = top of plot, 1 = baseline). It occupies the bottom 40%. */
+const BACKDROP_TOP = 0.6;
+
 export default function NgramViewer() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -121,12 +125,28 @@ export default function NgramViewer() {
     for (const s of shown) for (const p of s.points) m = Math.max(m, p.smoothed);
     return m || 1;
   }, [shown]);
-  const tokensMax = useMemo(() => Math.max(1, ...(data?.totals || []).map(t => t.tokens)), [data]);
+  // Backdrop scale: the corpus is dominated by a handful of freak years (1700
+  // alone holds 104M tokens — 8x the 99th percentile — because round years are
+  // the fallback for undated editions). Scaling the backdrop to the true max
+  // flattened every other year into an invisible smear at ~3% of a quarter-
+  // height band. Scale to the 98th percentile instead and let the outliers clip
+  // flat against the band top, so the shape of the ordinary years is readable.
+  const tokenBand = useMemo(() => {
+    const vals = (data?.totals || []).map(t => t.tokens).sort((a, b) => a - b);
+    if (!vals.length) return { top: 1, clipped: 0 };
+    const top = Math.max(1, vals[Math.min(vals.length - 1, Math.floor(vals.length * 0.98))]);
+    return { top, clipped: vals.filter(v => v > top).length };
+  }, [data]);
 
   const xScale = useMemo(() => linearScale(from, to, 0, plotW), [from, to, plotW]);
   const yScale = useMemo(() => linearScale(0, yMax * 1.05, plotH, 0), [yMax, plotH]);
-  // Token backdrop rides in the bottom quarter of the plot on its own scale.
-  const tokenScale = useMemo(() => linearScale(0, tokensMax, plotH, plotH * 0.75), [tokensMax, plotH]);
+  // Backdrop rides in the bottom ~40% of the plot on its OWN scale — it shares
+  // the x-axis with the curves but nothing else. The y-axis labels describe the
+  // curves only; the band's own ceiling is labelled at its top edge.
+  const tokenScale = useMemo(
+    () => linearScale(0, tokenBand.top, plotH, plotH * BACKDROP_TOP),
+    [tokenBand, plotH],
+  );
 
   const xTicks = useMemo(() => niceTicks(from, to, 8), [from, to]);
   const yTicks = useMemo(() => niceTicks(0, yMax * 1.05, 5), [yMax]);
@@ -374,12 +394,31 @@ export default function NgramViewer() {
             onClick={handleClick}
           >
             <g transform={`translate(${margin.left},${margin.top})`}>
-              {/* Token-volume backdrop — the honesty layer: how much corpus is under each year */}
+              {/* Token-volume backdrop — the honesty layer: how much corpus is
+                  under each year. Own scale, clipped at the 98th percentile. */}
               <path
-                d={areaPath(data.totals.map(t => ({ x: xScale(t.year), y: tokenScale(t.tokens) })), plotH)}
+                d={areaPath(
+                  data.totals.map(t => ({
+                    x: xScale(t.year),
+                    y: tokenScale(Math.min(t.tokens, tokenBand.top)),
+                  })),
+                  plotH,
+                )}
                 fill="var(--text-faint)"
-                opacity={0.12}
+                opacity={0.16}
               />
+              {/* Band ceiling — gives the grey a number so it isn't a scaleless smear */}
+              <line
+                x1={0} y1={plotH * BACKDROP_TOP} x2={plotW} y2={plotH * BACKDROP_TOP}
+                stroke="var(--text-faint)" strokeDasharray="2,5" opacity={0.4}
+              />
+              <text
+                x={plotW - 2} y={plotH * BACKDROP_TOP - 4}
+                fontSize={10} fill="var(--text-faint)" textAnchor="end"
+              >
+                {compactNumber(tokenBand.top)} tokens/yr
+                {tokenBand.clipped > 0 && ' (peaks clipped)'}
+              </text>
 
               {/* Grid */}
               {yTicks.map(t => (
@@ -468,7 +507,11 @@ export default function NgramViewer() {
       {data && (
         <p className="mt-1.5 text-xs text-[var(--text-faint)]">
           Gray backdrop: how much text each year contributes ({compactNumber(data.totals.reduce((s, t) => s + t.books, 0))} books
-          across this range). Hover any point for that year&apos;s exact book and token counts.
+          across this range). It has its own scale — the dashed line marks{' '}
+          {compactNumber(tokenBand.top)} tokens in a year
+          {tokenBand.clipped > 0 && `, and ${tokenBand.clipped} outlier ${tokenBand.clipped === 1 ? 'year runs' : 'years run'} off the top of it`}
+          {' '}— so it says nothing about the y-axis on the left, which belongs to the curves.
+          Hover any point for that year&apos;s exact book and token counts.
         </p>
       )}
 


### PR DESCRIPTION
Two fixes to `/ngrams`, both surfaced by one report ("the % of books mode shows no data, and the grey backdrop is a flat smear").

## The gray backdrop was unreadable — and unlabelled

It was scaled linearly to the true maximum year. **1700 alone holds 104M tokens — 8x the 99th percentile**, because a round year is the fallback for undated editions. Every ordinary year therefore rendered at ~3% of a band that was itself only a quarter of the plot height: ~0.8% of the chart. The result read as a featureless grey smear with a single spike at 1700.

- Scale the band to the **98th percentile** and clip outlier years flat against its top, so the shape of the ordinary years is visible.
- Give it the bottom **40%** of the plot instead of 25%.
- **Label the ceiling.** The backdrop shares only the x-axis with the curves; its vertical extent was on a private, unlabelled scale, so "how high is the grey?" had no answer. It now has a dashed ceiling line labelled with its actual value (`10.7M tokens/yr`, plus `(peaks clipped)` when outliers run past it), and the caption states outright that the left y-axis belongs to the curves, not to the grey.

## `no data` in an already-open tab, days after the data went live

Not a logic bug. `?mode=docs` (#3217) deliberately reports `found: false` rather than charting zeros until the `books_by_year` backfill reaches a row. That backfill (`chain-v4` on Hetzner) finished 2026-07-19 17:48 UTC and purged Cloudflare — the API has returned real curves since.

But `/api/ngrams` sent `Cache-Control: public, s-maxage=86400, stale-while-revalidate=604800` with **no `max-age`**. Absent one, a browser applies heuristic freshness and honours that 7-day `stale-while-revalidate`, so a response captured mid-backfill kept rendering "no data" client-side for days after the CDN was purged and the origin was correct. Adding `max-age=0` makes the browser revalidate; the CDN keeps its own 24h window via `s-maxage`.

## Out of scope

- **The 1700 bucket itself.** 1,523 books landing on a round year is a metadata artifact worth investigating, but it's a data question, not a chart one — the backdrop now shows the corpus honestly either way (the year is clipped, not hidden, and its exact token count is still in the hover tooltip).
- Backdrop still plots tokens, not books. Tokens is what `MIN_YEAR_TOKENS` gates year eligibility on, so it's the quantity that explains why a year is present or elided.

## Verification

`npx tsc --noEmit` clean; `tests/unit/ngram-normalize.test.ts` 19/19. Preview checked against `?mode=docs` and `?mode=tokens` across the 1450-1930 default range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)