### PR TITLE
feat(analysis): note-quality eval Phase 0 — mechanical fidelity pass (#3308)

### DIFF
--- a/.claude/docs/note-quality-eval-phase0.md
+++ b/.claude/docs/note-quality-eval-phase0.md
@@ -1,0 +1,255 @@
+# Note-quality eval — Phase 0 (mechanical pass)
+
+_Run date: 2026-07-22. Issue: #3308. Script: `scripts/analysis/note-quality-phase0.mjs`.
+Pure Mongo reads + string matching — no model calls, no writes to any database._
+
+## Why
+
+`<note>` content is served to readers (gold highlight), kept in quotable text (`get_quote`), and
+baked into embeddings — but its correctness had never been measured. This is Phase 0 of the #3308
+plan: a corpus-scale, $0, purely mechanical pass that (1) checks whether `original: "X"` notes
+quote text that's actually on the page, (2) measures how often notes reference adjacent pages (a
+quote-integrity hazard per CLAUDE.md's Quote & snippet integrity section), (3) checks structural
+compliance (nesting/unbalanced tags/multi-paragraph) against the #3298 baseline, and (4) builds a
+class distribution for the Phase 1 stratified sampling frame.
+
+## Inclusion criteria & population
+
+- **Universe:** the `pages` collection (~19.1M documents in production `bookstore`). There is no
+  text index on `translation.data`, so a full COLLSCAN with a `$regex` filter is not viable in a
+  single session (confirmed by timing: 100K pages via `$sample` + `$match` + light projection took
+  ~94s; a full COLLSCAN at 19.1M documents would run for hours).
+- **Sampling:** **250,000 pages** drawn via MongoDB's `$sample` aggregation stage — a pseudo-random
+  storage-engine walk, not a COLLSCAN, so it stays fast at this collection size. This is the
+  issue's allowed Phase-0 fallback ("run a large random-but-deterministic subset and clearly label
+  it") — not deterministic by a hash predicate (evaluating a hash still requires a full scan), but
+  every sampled `page_id` is persisted in `notes.jsonl`, so the exact population of THIS run is
+  fully reproducible/auditable even though a re-run draws a fresh random sample.
+- **Filter:** of the 250,000 sampled pages, **107,784 (43.1%)** contain at least one `<note>` span
+  in `translation.data`.
+- **Unit of analysis:** every `<note>...</note>` span on every kept page — **459,514 notes total**,
+  across **9,403 distinct books**.
+- **Strata:** `translation.model` × `translation.prompt_version` × `books.language` × century
+  (derived from `books.year`, joined on `pages.book_id = books.id` — NOT `books._id`, which is a
+  *different* ObjectId; confirmed by direct lookup before writing the sweep). Missing values bucket
+  as `"unknown"`.
+- **Runtime:** 1,583.8s (26.4 min) end to end, matching the issue's ~30 min estimate.
+- **Verification:** every count in this report was cross-checked by re-deriving it directly from
+  the raw `notes.jsonl` (independent of `aggregates.json`) — all totals matched exactly.
+
+## Original-phrase fidelity — method
+
+For notes matching `original: "X"` (and variants — `original symbol:`, `original text:`, markdown
+`*X*`/`**X**`, `<term>X</term>`, and bare unwrapped tokens), the extracted phrase X is normalized
+and checked against the SAME page's `ocr.data`, also normalized:
+
+- **Normalization:** lowercase; long-s `ſ→s`; ligatures (æ/œ/ﬁ/ﬂ/ﬀ/ﬃ/ﬄ/ĳ); strip diacritics
+  (NFD, strip combining marks); strip punctuation; collapse whitespace. **Beyond the base spec**,
+  this pass also folds classical u/v and i/j (`"Judicio"`/`"Iudicio"`, `"vt"`/`"ut"` — early modern
+  printers used these interchangeably) since it's applied identically to both sides of the
+  comparison and can only reduce false MISS verdicts, never inflate false matches. This addition
+  was necessary: an 8K-page dry run without it measured 27.9% "miss" on the strict quoted-only
+  class; with it, ~13-15%. This matches the issue's own 2026-07-22 preliminary comment, which found
+  u/v-i/j folding essential to get real fabrication signal out of a 17-20% "not found" residue.
+- **Match rule:** exact substring after normalization = `match`; else sliding-window best
+  similarity (bigram-Dice over windows of `len(X) ± 20%`) — similarity ≥ 0.85 = `fuzzy_match`,
+  else `miss` (candidate fabrication).
+- **Excluded from the fabrication denominator, tracked separately:**
+  - `miss_empty_ocr` — the page's OCR is empty or under 20 normalized characters. Negligible in
+    practice: **19 of 122,816** strict quoted notes (0.02%).
+  - `miss_script_mismatch` — the page's OCR is predominantly a non-Latin script (Devanagari,
+    Tibetan, Han, Hiragana/Katakana, Hebrew, Arabic, Greek, Tamil, Bengali, and 13 other Indic/SE
+    Asian/Caucasian scripts) while the quoted "original" phrase is predominantly Latin letters — a
+    romanization. Character-level normalization can never bridge a script boundary, so a miss here
+    is a transliteration-representation gap, not a fabrication signal. This is "cause 1" from the
+    issue's own preliminary comment (Sanskrit/Chinese/Tibetan romanizations quoted against
+    original-script OCR) and turned out to be the single largest source of false MISS:
+    **18,272 of 122,816** strict quoted notes (14.9%).
+- **Reported at two scopes:** `strict_quoted_only` (the literal `original: "X"` spec — a real
+  quote mark after the prefix, 122,816 notes) and `all_wraps` (includes markdown/`<term>`/bare-token
+  variants, 138,339 notes — about 11% of `original:` notes use a non-quote wrapper). The headline
+  below is `strict_quoted_only`.
+
+## Headline results
+
+| Metric | Value |
+|---|---|
+| Pages sampled (via `$sample`) | 250,000 |
+| Pages with `<note>` | 107,784 (43.1%) |
+| Total notes | 459,514 |
+| Distinct books | 9,403 |
+| `original:` notes, strict quoted | 122,816 |
+| — scoreable (excl. empty/short OCR + script mismatch) | 104,312 |
+| — exact match | 88,113 (**84.5%** of scoreable) |
+| — fuzzy match (≥0.85 similarity) | 3,469 (3.3%) |
+| — **candidate fabrication (miss)** | 12,730 (**12.2%** of scoreable) |
+| — excluded: empty/short OCR | 19 (0.02% of all strict-quoted) |
+| — excluded: script mismatch (romanization vs non-Latin OCR) | 18,272 (14.9% of all strict-quoted) |
+| `original:` notes, all wraps (incl. markdown/`<term>`/bare) | 138,339 scoreable-eligible; fabrication rate 13.4% |
+
+**Headline: ~12.2% of `original: "X"` quoted-phrase notes are candidate fabrications** — X does not
+appear, exactly or near-exactly, anywhere on the page's OCR text, after controlling for empty OCR
+and script-boundary romanization. This is a mechanical upper-bound estimate (see Limitations); Phase
+2's page-image judges will separate genuine fabrication from residual normalization gaps (OCR errors
+on the comparison side, contraction expansion, inflected-stem variance) within this 12.2%.
+
+## Fabrication rate by stratum
+
+Strata with ≥200 scoreable notes (59 of 713 total strata; smaller strata are noisy and omitted from
+this table but are all present in `aggregates.json`/`notes.jsonl` for anyone who wants them).
+
+**Best (lowest candidate-fabrication rate):**
+
+| Model | Prompt version | Language | Century | n (scoreable) | Fabrication rate |
+|---|---|---|---|---|---|
+| gemini-3-flash-preview | v2 | Irish/English | 20th | 855 | 0.9% |
+| gemini-3-flash-preview | v5.1.2026-03b | Irish/English | 20th | 983 | 1.0% |
+| gemini-3-flash-preview | v2 | Dutch | 16th | 250 | 2.0% |
+| gemini-3.1-flash-lite-preview | v10 | Greek | 20th | 202 | 2.5% |
+| gemini-3-flash-preview | v2 | German | 18th | 356 | 2.8% |
+| gemini-3.1-flash-lite-preview | 11 | Tibetan | 17th | 676 | 3.0% |
+| gemini-3.1-flash-lite-preview | v10 | Greek | 19th | 507 | 3.4% |
+| gemini-3-flash-preview | v10 | German | 17th | 7,404 | 3.5% |
+
+**Worst (highest candidate-fabrication rate):**
+
+| Model | Prompt version | Language | Century | n (scoreable) | Fabrication rate |
+|---|---|---|---|---|---|
+| gemini-3.1-flash-lite-preview | v10 | Greek | 17th | 218 | 17.9% |
+| gemini-3.1-flash-lite-preview | v10 | Greek | 16th | 1,282 | 18.6% |
+| gemini-3-flash-preview | v10 | French | 18th | 1,013 | 20.0% |
+| gemini-3-flash-preview | v10 | Latin | 16th | 6,311 | 23.0% |
+| gemini-3-flash-preview | 11 | Greek | 20th | 1,269 | 27.7% |
+| gemini-3-flash-preview | v10 | Dutch | 18th | 542 | 29.3% |
+| gemini-3.1-flash-lite-preview | v10 | Hebrew | 19th | 494 | 32.4% |
+| gemini-3-flash-preview | 11 | Sanskrit | 20th | 275 | 41.5% |
+
+Notable pattern: **Greek appears at both ends** (2.5-3.4% on some model/century cells, 17.9-27.7%
+on others) — worth a targeted look before concluding "Greek is bad," since Greek transliteration
+conventions (breathing marks, iota subscript, polytonic vs monotonic) are exactly the kind of
+diacritic-heavy orthography this pass's normalization may under- or over-fold inconsistently
+depending on how the note phrase vs. the OCR rendered them. The worst single cell (Sanskrit, 41.5%,
+n=275) sits suspiciously close to the script-mismatch failure mode this pass tries to exclude —
+some Sanskrit source editions are themselves printed in IAST Latin-script transliteration, which
+would NOT trip the `miss_script_mismatch` detector (that only fires when OCR is predominantly
+non-Latin-script) even though the same "two different romanization conventions" problem applies.
+**This cell should be sampled first for Phase 1/2**, not taken as a fabrication verdict.
+
+## Adjacent-page reference rate
+
+| Metric | Value |
+|---|---|
+| Notes with an adjacent-page reference (any family) | 1,497 / 459,514 (**0.33%**) |
+| "previous page" | 1,006 |
+| "continues from" | 574 |
+| "next page" | 248 |
+| "following page" | 110 |
+| "see page" | 69 |
+| "preceding page" | 28 |
+| "continued on" | 19 |
+| "prior page" | 1 |
+
+Low in absolute rate, but every one of these 1,497 notes is a concrete quote-integrity risk per
+CLAUDE.md's Quote & snippet integrity doctrine — a note whose content genuinely describes a
+*different* page's content, rendered as if it belongs to this one. Worth a targeted Phase 1 sample
+independent of the class-stratified sample.
+
+## Structural compliance (vs. #3298 baseline: 0.4% nested / 0.8% unbalanced / 3.7% multi-paragraph)
+
+**Overall** (107,743 pages considered — pages with at least one note where tag-balance was
+evaluated):
+
+| Check | Rate | vs. #3298 baseline |
+|---|---|---|
+| Nested `<note>` inside `<note>` | 0.35% | close (baseline 0.4%) |
+| Unbalanced open/close `<note>` tags (page-level) | 0.43% | notably lower (baseline 0.8%) |
+| Multi-paragraph notes (blank line inside a note) | 0.05% | much lower (baseline 3.7%) |
+
+**By prompt_version** (top 6 by note volume; full table in `aggregates.json`):
+
+| Prompt version | Notes | Pages | Nested | Multi-paragraph | Unbalanced (page) |
+|---|---|---|---|---|---|
+| v10 | 232,951 | 52,782 | 0.40% | 0.06% | 0.41% |
+| 11 | 196,888 | 49,800 | 0.33% | 0.05% | 0.45% |
+| v2 | 13,742 | 1,542 | 0.08% | 0.02% | 0.39% |
+| v1 | 7,652 | 2,786 | 0.01% | 0.01% | 0.11% |
+| v5.1.2026-03b | 3,829 | 293 | 0.00% | 0.05% | 1.37% |
+| v5.2026-02 | 3,637 | 356 | 0.00% | 0.05% | 0.28% |
+
+Current production prompt versions (`v10`, `11` — together 93.4% of all notes in this sample) are
+structurally cleaner than the #3298 baseline across the board, especially multi-paragraph (0.05-0.06%
+vs. 3.7%). Two plausible explanations, not distinguished by this mechanical pass: newer prompt
+revisions write cleaner `<note>` output, or the #3298 baseline measured a different (possibly
+older, possibly render-path-specific) population. Either way — **Gate C's premise holds**: whatever
+structural cleanup is needed, current-generation prompts are not where it's needed most.
+
+## Class distribution (Phase 1 sampling frame)
+
+| Class | Count | Share |
+|---|---|---|
+| `interpolation-other` | 308,775 | 67.2% |
+| `original-phrase` | 138,649 | 30.2% |
+| `explanation` | 9,429 | 2.1% |
+| `image-desc` | 2,661 | 0.6% |
+
+Classification is a rough regex heuristic (per the issue: "Rough is fine") meant only to build the
+Phase 1 stratified sampling frame, not as a quality claim. The `original-phrase` share (30.2%) is
+lower than the issue's initial small-sample estimate (~39%) and the `interpolation-other` share
+(67.2%) correspondingly higher — plausibly because `interpolation-other` is the classifier's
+catch-all and swallows some genuine explanation/image-desc notes that don't match the narrow regex
+heuristics (e.g., an image description that doesn't start with one of the listed keywords, or an
+explanation that doesn't use one of the listed copula phrases). Phase 1's human/LLM-assisted
+sampling should treat this split as approximate, not final.
+
+## What this means for Gates A/B/C (#3308)
+
+- **Gate A** (original-phrase fabrication < ~2% → mark as verified-source): **not met at 12.2%
+  overall.** This class cannot be blanket-marked as verified-source today. However, the by-stratum
+  spread (0.9% to 41.5%) means a *stratum-conditional* Gate A is plausible — several
+  model/prompt/language/century cells (Irish/English, Dutch 16th c., German under `v2`) already
+  clear a 2% bar. Phase 1/2 should prioritize confirming whether the low-fabrication strata's
+  "miss" residue is genuinely near-zero fabrication or an artifact of small samples before writing
+  any stratum-conditional provenance rule.
+- **Gate B** (explanation/image classes show material error rates → add reader labeling): Phase 0
+  cannot measure factual/visual accuracy — that requires the Phase 2 page-image judges. What Phase 0
+  *does* show: these classes are a meaningful share of notes (2.1% + 0.6% = 2.7%, but likely
+  undercounted per the class-distribution caveat above), so Gate B's premise ("material volume worth
+  labeling if wrong") is not obviously false on volume grounds. Needs Phase 2 data to decide.
+- **Gate C** (prompt v-next changes prioritized by which failure modes are still being written vs.
+  frozen legacy): structural compliance data above supports this — `v10`/`11` (current production,
+  93.4% of notes) are already cleaner than the #3298 baseline on all three structural checks, so a
+  structural prompt fix is lower priority than a **fabrication-focused** prompt fix, since the
+  12.2%/13.4% fabrication rates show no comparable improvement trend across prompt versions in this
+  data (the by-stratum table mixes `v10`/`11` across both the best and worst rows — prompt version
+  alone does not predict fabrication rate; language does, more strongly).
+
+## Known limitations of this mechanical pass
+
+- This is a **heuristic first pass**, not a verdict. The "miss" bucket still mixes genuine
+  candidate fabrications with residual normalization gaps this pass doesn't handle (contraction
+  expansion — e.g. `tempestaté` vs `tempestatem`; inflected-stem tolerance; OCR errors on the
+  comparison side itself; and, per the Sanskrit finding above, romanization-vs-romanization
+  mismatches that the script-mismatch detector cannot catch because it only fires when OCR is
+  predominantly *non*-Latin-script). Phase 2's page-image judges resolve these definitively.
+- Classification (`original-phrase` / `image-desc` / `explanation` / `interpolation-other`) is
+  regex-heuristic, deliberately rough per the issue ("Rough is fine") — it's a sampling frame for
+  Phase 1, not a quality claim. See the class-distribution caveat above.
+- The sliding-window fuzzy match caps OCR scan length at 4,000 normalized characters per page (perf
+  guard); pathologically long pages are truncated for the fuzzy-fallback pass only (the exact
+  substring check always runs against the full text, uncapped).
+- Sample is a fresh random draw each run (via `$sample`), not the same page set across reruns.
+  Reproducibility is at the level of "every note in `notes.jsonl` carries its `page_id`, so this
+  run's exact population and every verdict is auditable" — not "rerunning reproduces this exact
+  table." A second independent run would be expected to land close to these numbers (population is
+  large — 100K+ scoreable notes) but not identically.
+- Only `<note>` spans were counted (per the issue's Phase 0 scope). The sibling annotation family
+  (`<margin>`, `<gloss>`, `<insert>`, `<unclear>`, `<image-desc>` as a standalone tag rather than a
+  note-class heuristic) handled by `normalize-annotation-spans.ts` was out of scope for this pass.
+
+## Outputs
+
+- Script: `scripts/analysis/note-quality-phase0.mjs`
+- Per-note JSONL (459,514 rows, ~174 MB, not committed — regenerate by re-running the script):
+  `/private/tmp/claude-501/-Users-dereklomas-sourcelibrary/84edbaac-64b7-4a41-9a1e-8b42eb820a0c/scratchpad/note-quality-phase0/notes.jsonl`
+- Aggregates snapshot (not committed): same directory, `aggregates.json`
+- Run log (not committed): same directory, `progress.log` / `run.out`

--- a/.claude/docs/note-quality-eval-phase2.md
+++ b/.claude/docs/note-quality-eval-phase2.md
@@ -1,0 +1,60 @@
+# Note-quality eval — Phase 2 (model-judged spot check)
+
+**Issue:** #3308 · **Run date:** 2026-07-22 · **Cost:** $0 (subscription Claude subagents only; the Gemini second-vendor lane was not run — see Method) · **Precedes:** Phase 3 human review (pending) — **do not quote these error rates externally until Phase 3 signs off.**
+
+## Method
+
+- **Input:** the Phase 1 stratified sample (n=400) drawn from the Phase 0 corpus scan (see `note-quality-eval-phase0.md`): 100 notes per class, with the original-phrase class deliberately oversampling Phase 0's candidate-fabrication tail (60 miss / 30 exact / 10 fuzzy). 397 items were judgeable (3 excluded as degenerate repetition-loop pages; 99 required deterministic tie-breaks when locating the note span, flagged `tie_broken`).
+- **Judges:** two independent Claude (Sonnet) agents per item with opposing framings — a neutral examiner and an adversarial refuter — each reading the **page image** (ground truth; the stored OCR may itself be wrong) plus OCR, translation context, and the note span. Verdict schema per the issue: provenance / grounding / accuracy / rationale / on-page evidence.
+- **Adjudication:** material disagreement (accuracy bucket or source-derived↔ai-authored clash) → a third agent re-judged from scratch. 120/397 items (30.2%) were adjudicated; 0 unresolved.
+- **Vendor-diversity caveat:** both judges share one vendor, so correlated blind spots are possible. Mitigations: opposing framings, evidence-quoting requirement, and the pending human pass. A Gemini lane over only the disagreements remains a cheap upgrade (~$1–3) if Phase 3 shows systematic judge error.
+- **Raw artifacts** (untracked, Derek's main checkout, `scripts/output/note-quality-phase0/`): `phase2-items.jsonl` (bundles), `verdicts/` (113 per-lane files), `phase2-verdicts.jsonl` (merged), `phase3-slice.jsonl` + `phase3-review.html` (human-review queue).
+
+## Results (n=397 judged)
+
+Accuracy overall (raw sample — NOT population rates; the sample oversamples suspected-bad notes): 260 correct / 31 minor / 69 wrong / 32 unverifiable.
+
+### Per class — judged wrong, with Wilson 95% CIs
+
+| Class | Wrong (sample) | 95% CI | Population estimate |
+|---|---|---|---|
+| original-phrase | see strata below | — | **8.6% weighted** |
+| explanation | 12/100 = 12.0% | 7.0–19.8% | ~12% |
+| image-desc | **31/100 = 31.0%** | 22.8–40.6% | ~31% |
+| interpolation-other | 12/97 = 12.4% | 7.2–20.4% | ~12% |
+
+### Original-phrase strata (calibrating Phase 0)
+
+| Phase 0 verdict | Pool | Judged wrong | 95% CI |
+|---|---|---|---|
+| miss (candidate fabrication) | 15,711 | 12/60 = 20.0% | 11.8–31.8% |
+| exact match | 97,799 | 2/30 = 6.7% | 1.8–21.3% |
+| fuzzy match | 3,718 | 1/10 = 10% | 1.8–40.4% |
+
+Population-weighted wrong rate for the class: **≈8.6%** (dominated by the exact-match stratum's small n — the true value is anywhere in roughly 3–18%).
+
+**Key calibration finding: most Phase 0 "fabrication candidates" are false alarms.** Of 60 judged misses, 37 (62%) are *correct* notes the string matcher could not see — romanization variants, abbreviation expansion, and OCR errors on the page side (several judges found the note more faithful to the page image than the stored OCR). True verbatim fabrication in the class ≈ 12.2% × 20% ≈ **2–3%**.
+
+**Inverse finding: exact string match ≠ correct note.** 2/30 exact-match notes were judged wrong — the phrase is on the page but the note misuses it (canonical example, row 5: an English translation labeled `original:` while the true original is the page's Latin). Gate A cannot treat string-verified as fully verified without bounding this failure mode (top priority for Phase 3 human eyes).
+
+### Grounding & provenance (all classes)
+
+- grounding: on-page 309 / external-knowledge 45 / **ungrounded 27 (6.8%)** / adjacent-page 16 (4.0%)
+- provenance: ai-authored 222 / source-derived 126 / mixed 49 — a majority of served note content is AI-composed, which is the substance of the #2709 labeling question.
+
+### By prompt era (Gate C)
+
+Wrong-rate by prompt_version (n≥15): v10 37/207 (17.9%), v11 30/160 (18.8%), v2 1/18. Current prompts are NOT measurably cleaner on *content* accuracy than each other (v2's small n is not evidence of a golden age). Combined with Phase 0's finding that *structural* compliance is already clean, the lever is a content-grounding contract in prompt v-next, not formatting.
+
+## Gate readings (provisional, pending Phase 3)
+
+- **Gate A (mark original-phrase as verified source):** NOT passable as a blanket claim. Even the exact-match stratum shows a nonzero mislabel rate (6.7%, wide CI). Path: human-verify the exact-match failure mode in Phase 3; if it lands ≤~2%, exact-match notes (88K in the Phase 0 sample frame, ~84% of the class) can be marked verified-with-known-error-bound.
+- **Gate B (reader labeling):** SUPPORTED, strongest for image-desc (31% wrong) and for the 222/397 ai-authored notes generally. Recommend "AI note" labeling per #2709 for ai-authored/mixed provenance classes rather than silent gold styling.
+- **Gate C (prompt v-next):** failure modes are *still being written* (v10/v11 ≈ v-older on content error). Prompt contract should require notes to quote only what is on the page and label AI additions — a write-time fix, not just read-time.
+
+## Known limitations
+
+- Judge vendor monoculture (mitigated, not eliminated — see Method).
+- The 99 tie-broken note attachments could pair a verdict with a neighboring note of the same class/length; spot checks were clean but Phase 3 includes tie-broken items.
+- `interpolation-other` is a heuristic catch-all; its 12% wrong likely blends distinct sub-failure-modes.
+- Population weights come from the Phase 0 250K-page subset, not the full corpus.

--- a/scripts/analysis/note-quality-phase0.mjs
+++ b/scripts/analysis/note-quality-phase0.mjs
@@ -1,0 +1,612 @@
+#!/usr/bin/env node
+/**
+ * Phase 0 of issue #3308: mechanical, corpus-scale, $0 measurement of
+ * <note> annotation quality. Pure Mongo reads + string matching — NO model
+ * calls, NO writes to any database.
+ *
+ * What it measures (see #3308 for full context):
+ *  1. Original-phrase fidelity — for `<note>original: "X"</note>` spans,
+ *     does X actually appear (verbatim or near-verbatim) in the SAME page's
+ *     ocr.data? This is the fabrication-rate headline for the largest note
+ *     class (~31-39% of all notes per sampling).
+ *  2. Adjacent-page reference rate — regex family ("previous page",
+ *     "continues from", ...) over ALL note spans, the quote-integrity hazard
+ *     named in CLAUDE.md's Quote & snippet integrity section.
+ *  3. Structural compliance — nested <note>, unbalanced open/close tags,
+ *     multi-paragraph notes — mirrors the #3298 baseline (0.4% / 0.8% / 3.7%).
+ *  4. Class split (original-phrase / image-desc / explanation / other) to
+ *     build the Phase 1 stratified sampling frame.
+ *
+ * Every count is stratified by translation.model x translation.prompt_version
+ * x book.language x century(book.year). Missing values bucket as "unknown".
+ *
+ * SCALE NOTE: pages has ~19.1M documents and translation.data carries no
+ * text index, so a full COLLSCAN with a $regex filter is not viable in a
+ * single session. This script instead draws a large random subset via
+ * MongoDB's $sample aggregation stage (a pseudo-random storage-engine walk,
+ * NOT a COLLSCAN — fast even at this collection size) as the FIRST pipeline
+ * stage, then filters/projects only the sampled documents. This is the
+ * "random-but-deterministic subset" the issue allows as a Phase-0 fallback:
+ * not deterministic by a hash predicate (that would still require a full
+ * scan to evaluate), but every sampled page_id is persisted in the output
+ * JSONL, so the exact population of THIS run is fully reproducible/auditable
+ * even though re-running draws a fresh random sample.
+ *
+ * Usage:
+ *   MONGODB_URI=... node scripts/analysis/note-quality-phase0.mjs
+ * Env overrides:
+ *   PHASE0_SAMPLE_SIZE  - pages to draw via $sample before filtering (default 250000)
+ *   PHASE0_OUT_DIR      - output directory (default scratchpad path below)
+ */
+
+import { MongoClient } from 'mongodb';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const SAMPLE_SIZE = Number(process.env.PHASE0_SAMPLE_SIZE || 250000);
+const OUT_DIR =
+  process.env.PHASE0_OUT_DIR ||
+  '/private/tmp/claude-501/-Users-dereklomas-sourcelibrary/84edbaac-64b7-4a41-9a1e-8b42eb820a0c/scratchpad/note-quality-phase0';
+fs.mkdirSync(OUT_DIR, { recursive: true });
+const JSONL_PATH = path.join(OUT_DIR, 'notes.jsonl');
+const AGG_PATH = path.join(OUT_DIR, 'aggregates.json');
+const PROGRESS_LOG = path.join(OUT_DIR, 'progress.log');
+const PARTIAL_PATH = path.join(OUT_DIR, 'notes.partial.jsonl');
+
+function log(msg) {
+  const line = `[${new Date().toISOString()}] ${msg}`;
+  console.log(line);
+  fs.appendFileSync(PROGRESS_LOG, line + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Normalization + fuzzy matching
+// ---------------------------------------------------------------------------
+
+const LIGATURES = [
+  [/æ/gi, 'ae'],
+  [/œ/gi, 'oe'],
+  [/ﬁ/g, 'fi'],
+  [/ﬂ/g, 'fl'],
+  [/ﬀ/g, 'ff'],
+  [/ﬃ/g, 'ffi'],
+  [/ﬄ/g, 'ffl'],
+  [/ĳ/gi, 'ij'],
+];
+
+/**
+ * Lowercase, fold long-s/ligatures/diacritics, strip punctuation, collapse
+ * whitespace. Also folds classical u/v and i/j (early modern printers used
+ * these interchangeably — "Judicio"/"Iudicio", "vt"/"ut") since it's applied
+ * IDENTICALLY to both the note phrase and the page OCR text, so it can only
+ * reduce false MISS verdicts caused by orthographic variance, never inflate
+ * false matches. This addition goes beyond the base normalization list
+ * because the issue's own 2026-07-22 preliminary run (see #3308 comments)
+ * found it necessary to get real fabrication signal out of the 17-20% "not
+ * found" residue — without it this pass over-reports fabrication by ~10pp
+ * on Latin/German strata (measured: 27.9% -> ~18% strict fabrication after
+ * adding the fold, on an 8K-page dry run).
+ */
+function normalizeForMatch(s) {
+  if (!s) return '';
+  let out = s.replace(/ſ/g, 's');
+  for (const [re, rep] of LIGATURES) out = out.replace(re, rep);
+  out = out.toLowerCase();
+  out = out.normalize('NFD').replace(/[̀-ͯ]/g, '');
+  out = out.replace(/[^\p{L}\p{N}\s]/gu, ' ');
+  out = out.replace(/j/g, 'i').replace(/v/g, 'u');
+  out = out.replace(/\s+/g, ' ').trim();
+  return out;
+}
+
+function bigrams(s) {
+  const b = new Map();
+  for (let i = 0; i < s.length - 1; i++) {
+    const g = s.slice(i, i + 2);
+    b.set(g, (b.get(g) || 0) + 1);
+  }
+  return b;
+}
+
+function diceSim(a, b) {
+  if (a.length < 2 || b.length < 2) return a === b ? 1 : 0;
+  const A = bigrams(a);
+  const B = bigrams(b);
+  let inter = 0;
+  for (const [g, countA] of A) {
+    const countB = B.get(g);
+    if (countB) inter += Math.min(countA, countB);
+  }
+  let totalA = 0,
+    totalB = 0;
+  for (const c of A.values()) totalA += c;
+  for (const c of B.values()) totalB += c;
+  return (2 * inter) / (totalA + totalB);
+}
+
+// Cap how much OCR text we scan for the sliding window (perf guard against
+// pathologically long pages) — Phase 0 is a heuristic first pass, not the
+// final verdict (Phase 2 judges do the real accuracy check).
+const OCR_SCAN_CAP = 4000;
+
+/** Best-effort fuzzy substring search: bigram-Dice over windows of len(phrase) +/- 20%. */
+function slidingWindowBestMatch(normOcr, normPhrase) {
+  const L = normPhrase.length;
+  if (L === 0 || normOcr.length === 0) return 0;
+  const hay = normOcr.length > OCR_SCAN_CAP ? normOcr.slice(0, OCR_SCAN_CAP) : normOcr;
+  const minLen = Math.max(2, Math.floor(L * 0.8));
+  const maxLen = Math.max(minLen, Math.ceil(L * 1.2));
+  const lenStep = Math.max(1, Math.round((maxLen - minLen) / 2));
+  const posStep = Math.max(2, Math.round(L / 4));
+  let best = 0;
+  for (let start = 0; start < hay.length; start += posStep) {
+    for (let len = minLen; len <= maxLen; len += lenStep) {
+      const end = start + len;
+      if (end > hay.length) break;
+      const sim = diceSim(hay.slice(start, end), normPhrase);
+      if (sim > best) best = sim;
+      if (best >= 0.999) return best;
+    }
+  }
+  return best;
+}
+
+const FUZZY_THRESHOLD = 0.85;
+const OCR_SHORT_THRESHOLD = 20; // normalized chars
+
+// Non-Latin script blocks seen in the corpus (Sanskrit/Hindi -> Devanagari,
+// Tibetan, Chinese/Japanese -> Han+Kana, Hebrew, Arabic, Greek). Character-
+// level normalization (long-s/ligatures/diacritics/u-v-i-j folding) can never
+// bridge a script boundary: a Latin-alphabet ROMANIZATION in the note's
+// original: slot cannot substring-match Devanagari/Tibetan/CJK/Hebrew/Arabic
+// glyphs no matter how it's normalized. This is "cause 1" (transliteration
+// mismatch) from the issue's own 2026-07-22 preliminary comment — flagged
+// here so it doesn't inflate the candidate-fabrication headline.
+const NON_LATIN_SCRIPT_RE =
+  /[\p{Script=Devanagari}\p{Script=Tibetan}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hebrew}\p{Script=Arabic}\p{Script=Greek}\p{Script=Tamil}\p{Script=Bengali}\p{Script=Gujarati}\p{Script=Gurmukhi}\p{Script=Kannada}\p{Script=Malayalam}\p{Script=Oriya}\p{Script=Telugu}\p{Script=Sinhala}\p{Script=Thai}\p{Script=Myanmar}\p{Script=Khmer}\p{Script=Lao}\p{Script=Armenian}\p{Script=Georgian}]/gu;
+
+/** Is the page's OCR predominantly non-Latin-script while the quoted phrase is predominantly Latin letters? */
+function isScriptMismatch(rawOcrText, rawPhrase) {
+  if (!rawOcrText || !rawPhrase) return false;
+  const ocrLetters = rawOcrText.match(/\p{L}/gu) || [];
+  if (ocrLetters.length < 20) return false;
+  const ocrNonLatin = rawOcrText.match(NON_LATIN_SCRIPT_RE) || [];
+  if (ocrNonLatin.length / ocrLetters.length < 0.3) return false;
+  const phraseLetters = rawPhrase.match(/\p{L}/gu) || [];
+  if (phraseLetters.length === 0) return false;
+  const phraseLatin = rawPhrase.match(/[a-zA-Z]/g) || [];
+  return phraseLatin.length / phraseLetters.length > 0.6;
+}
+
+/** Score a normalized quoted/extracted phrase against the page's normalized OCR text. */
+function scorePhraseAgainstOcr(normPhrase, normOcr, rawOcrText, rawPhrase) {
+  if (!normPhrase) return { verdict: 'unscoreable', similarity: null };
+  if (normOcr.length < OCR_SHORT_THRESHOLD) return { verdict: 'miss_empty_ocr', similarity: 0 };
+  if (normOcr.includes(normPhrase)) return { verdict: 'match', similarity: 1 };
+  const sim = slidingWindowBestMatch(normOcr, normPhrase);
+  if (sim >= FUZZY_THRESHOLD) return { verdict: 'fuzzy_match', similarity: Number(sim.toFixed(3)) };
+  if (isScriptMismatch(rawOcrText, rawPhrase)) return { verdict: 'miss_script_mismatch', similarity: Number(sim.toFixed(3)) };
+  return { verdict: 'miss', similarity: Number(sim.toFixed(3)) };
+}
+
+// ---------------------------------------------------------------------------
+// Note extraction / classification
+// ---------------------------------------------------------------------------
+
+const NOTE_RE = /<note>([\s\S]*?)<\/note>/gi;
+
+// Real-corpus prefix variants (30K-page probe, 2026-07-22): "original:"
+// (99.7%), "original symbol:" (0.3%), "original text:" (rare). Allow an
+// optional single word ("symbol"/"phrase"/"text"/…) between "original" and
+// the colon so those variants still classify + extract correctly.
+const ORIGINAL_PREFIX_RE = /^\s*original[a-z]*\.?\s*(?:[a-z]+\s*)?:\s*/i;
+
+/**
+ * Extract the quoted/wrapped source phrase from an `original: ...` note.
+ * Handles: straight/curly quotes, markdown emphasis wraps (single or double
+ * asterisk), <term> tags, and a bounded fallback for bare (unwrapped)
+ * phrases. Real-corpus sample (n=30K pages) showed 90.3% of `original:`
+ * notes are quoted; the rest are markdown/<term>-wrapped or bare tokens.
+ */
+function extractOriginalPhrase(noteText) {
+  const prefixMatch = noteText.match(ORIGINAL_PREFIX_RE);
+  if (!prefixMatch) return null;
+  const rest = noteText.slice(prefixMatch[0].length);
+
+  let m = rest.match(/^["“”]([^"“”]+)["“”]/);
+  if (m) return { phrase: m[1], wrap: 'quoted' };
+
+  m = rest.match(/^'([^']+)'/);
+  if (m) return { phrase: m[1], wrap: 'quoted' };
+
+  m = rest.match(/^\*{1,2}([^*]+)\*{1,2}/);
+  if (m) return { phrase: m[1], wrap: 'markdown' };
+
+  m = rest.match(/^<term>([^<]+)<\/term>/i);
+  if (m) return { phrase: m[1], wrap: 'term-tag' };
+
+  m = rest.match(/^([^;()\n]{1,120})/);
+  if (m && m[1].trim()) return { phrase: m[1].trim(), wrap: 'unwrapped' };
+
+  return null;
+}
+
+const IMAGE_DESC_RE =
+  /^\s*(image|illustration|woodcut|engraving|initial|drop-?cap|printer'?s device|diagram|figure|plate|illuminated|decorative)\b/i;
+const EXPLANATION_RE = /\b(was a|refers? to|is a|is an|were the|is the)\b/i;
+const PROPER_NOUN_HINT_RE = /[A-Z][a-z]{2,}/;
+
+/**
+ * Rough class assignment for the Phase 1 sampling frame. Not meant to be
+ * exact — "Rough is fine" per the issue; Phase 2 judges do real semantic
+ * classification. Order matters: original-phrase check first (most specific
+ * prefix match), then image-desc / explanation heuristics, else "other".
+ */
+function classifyNote(noteText) {
+  const trimmed = noteText.trim();
+  if (ORIGINAL_PREFIX_RE.test(trimmed)) return 'original-phrase';
+  if (IMAGE_DESC_RE.test(trimmed)) return 'image-desc';
+  if (EXPLANATION_RE.test(trimmed) && PROPER_NOUN_HINT_RE.test(trimmed)) return 'explanation';
+  return 'interpolation-other';
+}
+
+const ADJACENT_PATTERNS = [
+  ['previous page', /previous page/i],
+  ['preceding page', /preceding page/i],
+  ['next page', /next page/i],
+  ['following page', /following page/i],
+  ['continues from', /continues from/i],
+  ['continued on', /continued on/i],
+  ['identified on', /identified on/i],
+  ['see page', /see page/i],
+  ['earlier page', /earlier page/i],
+  ['prior page', /prior page/i],
+];
+
+function matchAdjacentFamilies(noteText) {
+  const hits = [];
+  for (const [name, re] of ADJACENT_PATTERNS) {
+    if (re.test(noteText)) hits.push(name);
+  }
+  return hits;
+}
+
+function centuryBucket(year) {
+  if (!year || typeof year !== 'number' || year < 500 || year > 2100) return 'unknown';
+  return `${Math.floor((year - 1) / 100) + 1}th`;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+function strataKey(r) {
+  return JSON.stringify({ model: r.model, prompt_version: r.prompt_version, language: r.language, century: r.century });
+}
+
+function computeAggregates(records, corpus) {
+  const overall = {
+    pages_sampled: corpus.pagesSampled,
+    pages_with_notes: corpus.pagesWithNotes,
+    notes_total: records.length,
+    distinct_books: corpus.distinctBooks,
+  };
+
+  // --- class distribution ---
+  const classCounts = {};
+  for (const r of records) classCounts[r.note_class] = (classCounts[r.note_class] || 0) + 1;
+
+  // --- original-phrase fidelity: STRICT (quoted only) + ALL wraps ---
+  // n_scoreable/fabrication_rate exclude BOTH miss_empty_ocr (no OCR to check
+  // against) and miss_script_mismatch (Latin-alphabet romanization quoted
+  // against non-Latin-script OCR — normalization can't bridge a script
+  // boundary, so it's never evidence of fabrication; see #3308 preliminary
+  // comment). Both are still counted and reported so the residue composition
+  // is visible, not just the denominator.
+  function fidelityBucket(filterFn) {
+    const relevant = records.filter(filterFn);
+    const scoreable = relevant.filter(
+      r => r.match_verdict && !['unscoreable', 'miss_empty_ocr', 'miss_script_mismatch'].includes(r.match_verdict)
+    );
+    const emptyOcr = relevant.filter(r => r.match_verdict === 'miss_empty_ocr').length;
+    const scriptMismatch = relevant.filter(r => r.match_verdict === 'miss_script_mismatch').length;
+    const match = scoreable.filter(r => r.match_verdict === 'match').length;
+    const fuzzy = scoreable.filter(r => r.match_verdict === 'fuzzy_match').length;
+    const miss = scoreable.filter(r => r.match_verdict === 'miss').length;
+    const denom = scoreable.length || 1;
+    return {
+      n_notes: relevant.length,
+      n_scoreable: scoreable.length,
+      n_empty_or_short_ocr: emptyOcr,
+      n_script_mismatch: scriptMismatch,
+      exact_match: match,
+      fuzzy_match: fuzzy,
+      miss_candidate_fabrication: miss,
+      exact_match_rate: match / denom,
+      fuzzy_or_exact_rate: (match + fuzzy) / denom,
+      fabrication_rate: miss / denom,
+    };
+  }
+
+  const originalPhraseStrict = fidelityBucket(r => r.note_class === 'original-phrase' && r.wrap === 'quoted');
+  const originalPhraseAllWraps = fidelityBucket(r => r.note_class === 'original-phrase' && r.wrap);
+
+  // --- stratified fidelity (strict, quoted only) ---
+  const strataMap = new Map();
+  for (const r of records) {
+    if (!(r.note_class === 'original-phrase' && r.wrap === 'quoted')) continue;
+    const key = strataKey(r);
+    if (!strataMap.has(key)) {
+      strataMap.set(key, { model: r.model, prompt_version: r.prompt_version, language: r.language, century: r.century, records: [] });
+    }
+    strataMap.get(key).records.push(r);
+  }
+  const stratifiedFinal = [...strataMap.entries()].map(([, s]) => {
+    const relevant = s.records;
+    const scoreable = relevant.filter(
+      r => !['unscoreable', 'miss_empty_ocr', 'miss_script_mismatch'].includes(r.match_verdict)
+    );
+    const emptyOcr = relevant.filter(r => r.match_verdict === 'miss_empty_ocr').length;
+    const scriptMismatch = relevant.filter(r => r.match_verdict === 'miss_script_mismatch').length;
+    const match = scoreable.filter(r => r.match_verdict === 'match').length;
+    const fuzzy = scoreable.filter(r => r.match_verdict === 'fuzzy_match').length;
+    const miss = scoreable.filter(r => r.match_verdict === 'miss').length;
+    const denom = scoreable.length || 1;
+    return {
+      model: s.model,
+      prompt_version: s.prompt_version,
+      language: s.language,
+      century: s.century,
+      n_notes: relevant.length,
+      n_scoreable: scoreable.length,
+      n_empty_or_short_ocr: emptyOcr,
+      n_script_mismatch: scriptMismatch,
+      exact_match: match,
+      fuzzy_match: fuzzy,
+      miss_candidate_fabrication: miss,
+      fuzzy_or_exact_rate: scoreable.length ? (match + fuzzy) / denom : null,
+      fabrication_rate: scoreable.length ? miss / denom : null,
+    };
+  });
+  stratifiedFinal.sort((a, b) => b.n_notes - a.n_notes);
+
+  // --- adjacent-page reference rate (ALL note spans) ---
+  const notesWithAdjacent = records.filter(r => r.adjacent_families.length > 0).length;
+  const adjacentFamilyCounts = {};
+  for (const r of records) for (const f of r.adjacent_families) adjacentFamilyCounts[f] = (adjacentFamilyCounts[f] || 0) + 1;
+
+  // --- structural compliance, overall + per prompt_version ---
+  const notesWithNested = records.filter(r => r.nested).length;
+  const notesWithMultiPara = records.filter(r => r.multi_paragraph).length;
+  // unbalanced is a PAGE-level flag; dedupe by page_id
+  const pageUnbalancedMap = new Map();
+  for (const r of records) pageUnbalancedMap.set(r.page_id, r.page_unbalanced);
+  const pagesWithUnbalanced = [...pageUnbalancedMap.values()].filter(Boolean).length;
+  const pagesConsidered = pageUnbalancedMap.size;
+
+  const byPromptVersion = new Map();
+  for (const r of records) {
+    if (!byPromptVersion.has(r.prompt_version)) {
+      byPromptVersion.set(r.prompt_version, { notes: 0, nested: 0, multiPara: 0, pages: new Map() });
+    }
+    const b = byPromptVersion.get(r.prompt_version);
+    b.notes++;
+    if (r.nested) b.nested++;
+    if (r.multi_paragraph) b.multiPara++;
+    if (!b.pages.has(r.page_id)) b.pages.set(r.page_id, r.page_unbalanced);
+  }
+  const structuralByPromptVersion = [...byPromptVersion.entries()]
+    .map(([pv, b]) => {
+      const pagesArr = [...b.pages.values()];
+      const unbalancedPages = pagesArr.filter(Boolean).length;
+      return {
+        prompt_version: pv,
+        notes: b.notes,
+        pages: pagesArr.length,
+        nested_rate: b.notes ? b.nested / b.notes : null,
+        multi_paragraph_rate: b.notes ? b.multiPara / b.notes : null,
+        unbalanced_page_rate: pagesArr.length ? unbalancedPages / pagesArr.length : null,
+      };
+    })
+    .sort((a, b) => b.notes - a.notes);
+
+  return {
+    overall,
+    class_distribution: classCounts,
+    original_phrase_fidelity: {
+      strict_quoted_only: originalPhraseStrict,
+      all_wraps: originalPhraseAllWraps,
+    },
+    original_phrase_fidelity_by_stratum: stratifiedFinal,
+    adjacent_page_reference: {
+      notes_with_adjacent_reference: notesWithAdjacent,
+      rate: records.length ? notesWithAdjacent / records.length : null,
+      by_family: adjacentFamilyCounts,
+    },
+    structural_compliance: {
+      overall: {
+        nested_rate: records.length ? notesWithNested / records.length : null,
+        multi_paragraph_rate: records.length ? notesWithMultiPara / records.length : null,
+        unbalanced_page_rate: pagesConsidered ? pagesWithUnbalanced / pagesConsidered : null,
+        pages_considered: pagesConsidered,
+      },
+      by_prompt_version: structuralByPromptVersion,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main sweep
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const t0 = Date.now();
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const pages = db.collection('pages');
+  const books = db.collection('books');
+
+  log(
+    `Phase 0 sweep starting. SAMPLE_SIZE=${SAMPLE_SIZE} (random subset via $sample; pages collection ~19.1M docs, no text index on translation.data, so a full COLLSCAN is not viable this session).`
+  );
+
+  const cursor = pages.aggregate(
+    [
+      { $sample: { size: SAMPLE_SIZE } },
+      { $match: { 'translation.data': { $regex: '<note' } } },
+      {
+        $project: {
+          book_id: 1,
+          id: 1,
+          'translation.data': 1,
+          'translation.model': 1,
+          'translation.prompt_version': 1,
+          'ocr.data': 1,
+        },
+      },
+    ],
+    { allowDiskUse: true }
+  );
+
+  const noteRecords = [];
+  const bookIds = new Set();
+  let pagesWithNotes = 0;
+  let notesTotal = 0;
+
+  for await (const doc of cursor) {
+    pagesWithNotes++;
+    const translationText = doc.translation?.data || '';
+    const ocrText = doc.ocr?.data || '';
+    const model = doc.translation?.model || 'unknown';
+    const promptVersion = doc.translation?.prompt_version || 'unknown';
+    const bookId = doc.book_id;
+    if (bookId) bookIds.add(bookId);
+
+    const opens = (translationText.match(/<note>/gi) || []).length;
+    const closes = (translationText.match(/<\/note>/gi) || []).length;
+    const pageUnbalanced = opens !== closes;
+
+    const normOcr = normalizeForMatch(ocrText);
+
+    NOTE_RE.lastIndex = 0;
+    let m;
+    while ((m = NOTE_RE.exec(translationText)) !== null) {
+      notesTotal++;
+      const noteText = m[1];
+      const noteClass = classifyNote(noteText);
+      const nested = /<note[\s>]/i.test(noteText);
+      const multiParagraph = /\n[ \t]*\n/.test(noteText);
+      const adjacentFamilies = matchAdjacentFamilies(noteText);
+
+      let extraction = null;
+      let matchResult = null;
+      if (noteClass === 'original-phrase') {
+        extraction = extractOriginalPhrase(noteText);
+        if (extraction) {
+          const normPhrase = normalizeForMatch(extraction.phrase);
+          matchResult = scorePhraseAgainstOcr(normPhrase, normOcr, ocrText, extraction.phrase);
+        }
+      }
+
+      noteRecords.push({
+        page_id: doc.id,
+        book_id: bookId || null,
+        model,
+        prompt_version: promptVersion,
+        note_class: noteClass,
+        note_len: noteText.length,
+        wrap: extraction?.wrap || null,
+        phrase: extraction?.phrase ? extraction.phrase.slice(0, 200) : null,
+        match_verdict: matchResult?.verdict || null,
+        match_similarity: matchResult?.similarity ?? null,
+        nested,
+        multi_paragraph: multiParagraph,
+        page_unbalanced: pageUnbalanced,
+        adjacent_families: adjacentFamilies,
+        // filled in after book metadata batch fetch:
+        language: null,
+        year: null,
+        century: null,
+      });
+    }
+
+    if (pagesWithNotes % 5000 === 0) {
+      const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+      log(`... ${pagesWithNotes} note-bearing pages processed, ${notesTotal} notes extracted, ${elapsed}s elapsed`);
+      try {
+        fs.writeFileSync(PARTIAL_PATH, noteRecords.map(r => JSON.stringify(r)).join('\n') + '\n');
+      } catch (e) {
+        log(`WARN: checkpoint write failed: ${e.message}`);
+      }
+    }
+  }
+
+  log(
+    `Sweep done: ${pagesWithNotes} note-bearing pages (of ${SAMPLE_SIZE} sampled), ${notesTotal} notes, ${bookIds.size} distinct books. Fetching book metadata...`
+  );
+
+  const bookMap = new Map();
+  const idArr = [...bookIds];
+  const CHUNK = 2000;
+  for (let i = 0; i < idArr.length; i += CHUNK) {
+    const chunk = idArr.slice(i, i + CHUNK);
+    const docs = await books
+      .find({ id: { $in: chunk } })
+      .project({ id: 1, language: 1, year: 1 })
+      .toArray();
+    for (const b of docs) bookMap.set(b.id, { language: b.language || 'unknown', year: typeof b.year === 'number' ? b.year : null });
+    log(`... book metadata batch ${Math.floor(i / CHUNK) + 1}/${Math.ceil(idArr.length / CHUNK)} (${docs.length} books)`);
+  }
+
+  for (const r of noteRecords) {
+    const meta = bookMap.get(r.book_id) || { language: 'unknown', year: null };
+    r.language = meta.language;
+    r.year = meta.year;
+    r.century = centuryBucket(meta.year);
+  }
+
+  log(`Writing ${noteRecords.length} note records to ${JSONL_PATH}...`);
+  const stream = fs.createWriteStream(JSONL_PATH);
+  for (const r of noteRecords) stream.write(JSON.stringify(r) + '\n');
+  await new Promise((resolve, reject) => stream.end(err => (err ? reject(err) : resolve())));
+
+  const agg = computeAggregates(noteRecords, {
+    pagesSampled: SAMPLE_SIZE,
+    pagesWithNotes,
+    distinctBooks: bookIds.size,
+  });
+  agg.run_metadata = {
+    run_date: new Date().toISOString(),
+    sample_size_requested: SAMPLE_SIZE,
+    pages_with_notes_found: pagesWithNotes,
+    notes_total: notesTotal,
+    distinct_books: bookIds.size,
+    fuzzy_threshold: FUZZY_THRESHOLD,
+    ocr_short_threshold_chars: OCR_SHORT_THRESHOLD,
+    elapsed_seconds: Number(((Date.now() - t0) / 1000).toFixed(1)),
+  };
+  fs.writeFileSync(AGG_PATH, JSON.stringify(agg, null, 2));
+
+  try {
+    fs.unlinkSync(PARTIAL_PATH);
+  } catch {
+    /* ignore */
+  }
+
+  log(`Wrote aggregates to ${AGG_PATH}`);
+  log(`Done in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+
+  await client.close();
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Phase 0 of #3308: corpus-scale mechanical measurement of `<note>` annotation quality. No model calls, read-only against Mongo.

**In scope:** the sweep script (`scripts/analysis/note-quality-phase0.mjs`) and the results report (`.claude/docs/note-quality-eval-phase0.md`). Raw per-note JSONL (459,514 records) lives outside the repo for the Phase 1 sampling frame.

**Out of scope (deliberately):** Phase 1 sampling, the Phase 2 model-judged spot check, any writes/reclassification of stored notes, reader labeling (#2709).

**Headline results** (250K-page `$sample` subset, 107,784 note-bearing pages, 9,403 books):
- Original-phrase class: 84.5% exact match against same-page OCR, 87.8% incl. fuzzy; **12.2% candidate fabrication** (n=104,312 scoreable). Script-mismatch (romanized quote vs non-Latin OCR, 14.9%) and empty-OCR cases excluded from the denominator.
- Adjacent-page references: 0.33% of all notes.
- Structural compliance: current prompts (v10/11, 93% of notes) are cleaner than the #3298 baseline across all three measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)