### PR TITLE
fix(downloads): stop bundling pdfkit so PDF exports work in production

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,14 +10,23 @@ const nextConfig: NextConfig = {
   experimental: {
     proxyClientMaxBodySize: 50 * 1024 * 1024, // 50MB // TODO: Remove if frontend logic changes to smaller uploads at a time.
   },
+  // pdfkit must stay an unbundled runtime require: bundling it rewrites
+  // __dirname to a literal /ROOT/... path, so its constructor's
+  // readFileSync(__dirname + '/data/Helvetica.afm') throws ENOENT in
+  // production and every pdf-* download 500s ("Download failed", feedback
+  // 2026-07-21). Externalizing keeps the real node_modules/pdfkit on disk,
+  // .afm metrics and all. Local dev never catches this — node_modules is
+  // present there — so verify PDF downloads on a deploy after touching this.
+  serverExternalPackages: ['pdfkit'],
   // Belt-and-suspenders for the pdf-translation/pdf-facsimile download formats
   // (issue #3283): src/lib/pdf-fonts.ts reads the bundled Noto Serif TTFs via
   // a static `path.join(process.cwd(), 'src/assets/fonts/…')`, which Vercel's
   // build-time file tracer should already pick up automatically — this pins
-  // it explicitly in case static analysis ever misses it.
+  // it explicitly in case static analysis ever misses it. The pdfkit data pin
+  // is the same insurance for the externalized package's font metrics.
   outputFileTracingIncludes: {
-    '/api/books/[id]/download': ['./src/assets/fonts/**'],
-    '/api/[tenant]/books/[id]/download': ['./src/assets/fonts/**'],
+    '/api/books/[id]/download': ['./src/assets/fonts/**', './node_modules/pdfkit/js/data/**'],
+    '/api/[tenant]/books/[id]/download': ['./src/assets/fonts/**', './node_modules/pdfkit/js/data/**'],
   },
   images: {
     formats: ['image/avif', 'image/webp'],


### PR DESCRIPTION
## What

Every `pdf-translation` / `pdf-facsimile` download 500s on production with the generic "Download failed" toast — reported by the same reader whose feedback drove #3285, in a follow-up feedback item (`6a5f889370d2b7e1c209050f`, 2026-07-21).

## Root cause (verified in prod runtime logs)

```
Download error: Error: ENOENT: no such file or directory,
open '/ROOT/node_modules/pdfkit/js/data/Helvetica.afm'
    at hI.initFonts → new PDFDocument
```

Turbopack bundles pdfkit into the function chunk and rewrites `__dirname` to a literal `/ROOT/...` path. `new PDFDocument()` loads its default Helvetica `.afm` metrics from `__dirname + '/data/...'` in the constructor — before our registered Noto TTFs are ever touched — so the route's outer catch turns it into a 500 for every book, every time. Local runs (and the pre-merge testing on #3285) never hit it because `node_modules` is physically present there.

## Fix

- `serverExternalPackages: ['pdfkit']` — keeps pdfkit a real runtime require from `node_modules`; Vercel's file tracer ships the package whole, `.afm` data included, and `__dirname` resolves to a real directory.
- Pin `./node_modules/pdfkit/js/data/**` in `outputFileTracingIncludes` for both download routes as belt-and-suspenders.

## Out of scope

The DownloadButton client copy (a 500 could name-check 'try a different format') and the pdf-ocr/pdf-both Phase 2 work in #3283.

## Verification plan

Reproduced the 500 against prod with a signed-in session before the fix; after merge + `npm run deploy:prod`, re-run the same signed-in fetch and confirm a PDF blob comes back, then reply to the feedback submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)