### PR TITLE
feat(seo): machine-readable license on book/gallery JSON-LD + IIIF rights default

### DIFF
--- a/src/app/api/iiif/[id]/manifest/route.ts
+++ b/src/app/api/iiif/[id]/manifest/route.ts
@@ -389,9 +389,15 @@ export async function GET(
       book.reading_summary?.overview ||
       book.index?.bookSummary?.brief;
 
-    // Rights
+    // Rights. Books without a stored license value default to the Public
+    // Domain Mark: everything served here is a publicly readable facsimile of
+    // a pre-1900 original (copyright-held books are hidden and 404 above).
+    // The CC BY-SA claim on our OCR/translation layer lives in the License
+    // metadata row — IIIF `rights` takes exactly one URI, and the facsimile
+    // images are the manifest's primary content.
     const license = book.image_source?.license || book.license;
-    const rightsUri = resolveRights(license);
+    const rightsUri =
+      resolveRights(license) || 'http://creativecommons.org/publicdomain/mark/1.0/';
 
     // Attribution — always credit the digitizing institution. Prefer an explicit
     // attribution string when stored; otherwise build one from the institution

--- a/src/components/seo/GalleryImageSchema.tsx
+++ b/src/components/seo/GalleryImageSchema.tsx
@@ -1,4 +1,4 @@
-import { BASE_URL, getLicenseUrl } from './schema-utils';
+import { BASE_URL, PUBLIC_DOMAIN_MARK_URL, getLicenseUrl } from './schema-utils';
 import { formatAuthor } from '@/lib/utils';
 
 interface GalleryImageSchemaProps {
@@ -82,7 +82,8 @@ export default function GalleryImageSchema({
       creator: { '@type': 'Person', name: formatAuthor(book.author).name || book.author },
     }),
     ...(book?.published && { dateCreated: book.published }),
-    ...(license && { license: getLicenseUrl(license) }),
+    license: license ? getLicenseUrl(license) : PUBLIC_DOMAIN_MARK_URL,
+    usageInfo: `${BASE_URL}/licensing`,
     creditText: book?.image_source?.attribution || `Digitized by ${book?.image_source?.provider || 'Internet Archive'}`,
     copyrightNotice: `Public domain. Original published ${book?.published || 'before 1900'}.`,
     acquireLicensePage: book ? `${BASE_URL}/book/${book.slug || book.id}` : undefined,

--- a/src/components/seo/SchemaOrgMetadata.tsx
+++ b/src/components/seo/SchemaOrgMetadata.tsx
@@ -1,5 +1,6 @@
 import { Book, TranslationEdition } from '@/lib/types';
-import { BASE_URL, getLicenseUrl } from './schema-utils';
+import { CONTENT_LICENSE } from '@/lib/license-info';
+import { BASE_URL, PUBLIC_DOMAIN_MARK_URL, getLicenseUrl } from './schema-utils';
 import { formatAuthor } from '@/lib/utils';
 
 interface SchemaOrgMetadataProps {
@@ -81,6 +82,8 @@ export default function SchemaOrgMetadata({
       about: book.categories.map(c => ({ '@type': 'Thing', name: c })),
     }),
     copyrightNotice: `Public domain. Original published ${book.published || 'before 1900'}.`,
+    license: PUBLIC_DOMAIN_MARK_URL,
+    usageInfo: `${baseUrl}/licensing`,
     acquireLicensePage: `${baseUrl}/book/${bookPath}`,
     creditText: book.image_source?.attribution || `Digitized by ${book.image_source?.provider_name || 'Internet Archive'}`,
   };
@@ -111,7 +114,6 @@ export default function SchemaOrgMetadata({
       datePublished: currentEdition.published_at
         ? new Date(currentEdition.published_at).toISOString().split('T')[0]
         : undefined,
-      license: getLicenseUrl(currentEdition.license),
       ...(currentEdition.doi && {
         identifier: {
           '@type': 'PropertyValue',
@@ -132,6 +134,12 @@ export default function SchemaOrgMetadata({
         }),
       })),
     }),
+    // Translations/OCR default to the site-wide CC BY-SA license; a published
+    // edition's own license (which may differ, e.g. CC0 on Zenodo) wins.
+    license:
+      (currentEdition?.license && getLicenseUrl(currentEdition.license)) ||
+      CONTENT_LICENSE.url,
+    usageInfo: `${baseUrl}/licensing`,
     provider: {
       '@type': 'Organization',
       name: 'Source Library',

--- a/src/components/seo/schema-utils.ts
+++ b/src/components/seo/schema-utils.ts
@@ -1,5 +1,11 @@
 export const BASE_URL = 'https://sourcelibrary.org';
 
+/**
+ * Creative Commons Public Domain Mark — the default `license` for facsimiles
+ * of our pre-1900 originals. A stored per-book/per-edition license overrides.
+ */
+export const PUBLIC_DOMAIN_MARK_URL = 'https://creativecommons.org/publicdomain/mark/1.0/';
+
 export function getLicenseUrl(license: string): string {
   const licenseUrls: Record<string, string> = {
     'publicdomain': 'https://creativecommons.org/publicdomain/mark/1.0/',


### PR DESCRIPTION
## What

Closes the last gap in the machine-readable licensing layer. An audit today confirmed robots.txt Content-Signals, /.well-known/tdmrep.json, TDM-Reservation headers + meta tags, llms.txt, and the API `CONTENT_LICENSE` block are all live and consistent on prod — but schema.org JSON-LD carried no license at all, and IIIF manifests almost never emitted a `rights` URI.

- **Book-page JSON-LD**: the original-work `Book` node now declares `license` = CC Public Domain Mark + `usageInfo` = /licensing; the translation `CreativeWork` node defaults `license` to CC BY-SA 4.0 (sourced from `CONTENT_LICENSE` so there's one source of truth) with a published edition's own license still winning, plus `usageInfo` = /licensing (schema.org's designated property for TDM/AI-training terms).
- **Gallery image JSON-LD**: same PDM default + usageInfo on the `VisualArtwork` node (previously license only appeared for the rare book with a stored license value).
- **IIIF manifests**: `rights` now defaults to the Public Domain Mark when no license value is stored. Stored values still override (incl. in-copyright → rightsstatements.org). Safe because the route 404s hidden/copyright-held books before this point. The CC BY-SA claim on the OCR/translation layer stays in the manifest's License metadata row, since IIIF `rights` takes exactly one URI and the facsimile images are the primary content.

## Out of scope

- Collection/author/category schema components — they describe listings, not licensable content.
- Any change to the enforcement layers (Cloudflare / proxy / bot-gate) — declaration only.

## Verification

- `npx tsc --noEmit` clean; `gallery-doc-schema` unit tests pass.
- After deploy: book-page `@graph` nodes should show `license`/`usageInfo`, and any `/api/iiif/<id>/manifest` should show `rights`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)