### PR TITLE
fix(health+analytics): resolve the three weekly-digest false flags

### DIFF
--- a/scripts/analytics/snapshot-metrics.mjs
+++ b/scripts/analytics/snapshot-metrics.mjs
@@ -196,19 +196,30 @@ await withMongo(async (db) => {
   const pvLast7 = dailyPageviews.filter((r) => r.date >= day(7)).reduce((s, r) => s + r.hits, 0);
   const pvPrev7 = dailyPageviews.filter((r) => r.date >= day(14) && r.date < day(7)).reduce((s, r) => s + r.hits, 0);
 
-  // Resolve top book slugs/ids to titles.
-  const topBookKeys = topN(bookHits, 15);
+  // Resolve top book slugs/ids to titles. Pageview keys are whatever the URL
+  // path used: slug, Mongo _id hex, or the string `id` field — which is a
+  // DIFFERENT 24-hex value than _id, so hex keys need both lookups. Then merge
+  // rows that resolve to the same underlying book (one book viewed via both
+  // its slug and an id otherwise appears twice with its hits split).
+  const topBookKeys = topN(bookHits, 30);
   const { ObjectId } = await import('mongodb');
-  const slugLike = [], idLike = [];
-  for (const [s] of topBookKeys) { if (/^[a-f0-9]{24}$/i.test(s)) { try { idLike.push(new ObjectId(s)); } catch {} } else slugLike.push(s); }
-  const proj = { projection: { slug: 1, title: 1, author: 1, language: 1 } };
+  const slugLike = [], hexLike = [];
+  for (const [s] of topBookKeys) { if (/^[a-f0-9]{24}$/i.test(s)) hexLike.push(s); else slugLike.push(s); }
+  const oidLike = hexLike.map((s) => { try { return new ObjectId(s); } catch { return null; } }).filter(Boolean);
+  const proj = { projection: { slug: 1, id: 1, title: 1, author: 1, language: 1 } };
   const bMeta = new Map();
   for (const b of slugLike.length ? await db.collection('books').find({ slug: { $in: slugLike } }, proj).toArray() : []) bMeta.set(b.slug, b);
-  for (const b of idLike.length ? await db.collection('books').find({ _id: { $in: idLike } }, proj).toArray() : []) bMeta.set(b._id.toString(), b);
-  const topBooks = topBookKeys.map(([key, hits]) => {
-    const m = bMeta.get(key) || {};
-    return { key, hits, title: (m.title || key).slice(0, 70), author: (Array.isArray(m.author) ? m.author[0] : m.author || '') || '', language: m.language || '' };
-  });
+  for (const b of oidLike.length ? await db.collection('books').find({ _id: { $in: oidLike } }, proj).toArray() : []) bMeta.set(b._id.toString(), b);
+  for (const b of hexLike.length ? await db.collection('books').find({ id: { $in: hexLike } }, proj).toArray() : []) { if (b.id) bMeta.set(b.id, b); }
+  const mergedBooks = new Map(); // canonical _id (or unresolved raw key) -> row
+  for (const [key, hits] of topBookKeys) {
+    const m = bMeta.get(key);
+    const canon = m ? m._id.toString() : key;
+    const row = mergedBooks.get(canon);
+    if (row) { row.hits += hits; continue; }
+    mergedBooks.set(canon, { key: m?.slug || key, hits, title: (m?.title || key).slice(0, 70), author: (Array.isArray(m?.author) ? m.author[0] : m?.author || '') || '', language: m?.language || '' });
+  }
+  const topBooks = [...mergedBooks.values()].sort((a, b) => b.hits - a.hits).slice(0, 15);
   const topCollections = topN(collectionHits, 10).map(([slug, hits]) => ({ slug, hits }));
   const topReferrers = topN(referrers, 12).map(([referrer, hits]) => ({ referrer, hits }));
   const topCountries = topN(countries, 12).map(([country, hits]) => ({ country, hits }));

--- a/scripts/analytics/usage-deepdive.mjs
+++ b/scripts/analytics/usage-deepdive.mjs
@@ -191,27 +191,33 @@ async function main() {
 
   print(`### Top 30 books visited`);
   const topBookSlugs = topN(bookHits, 30);
-  // URLs may use either slug or 24-char hex ObjectId — look up by both.
+  // URLs may use a slug, a 24-char hex Mongo _id, or the string `id` field
+  // (a DIFFERENT 24-hex value than _id) — look up hex keys by both.
   const { ObjectId } = await import('mongodb');
   const slugLike = [];
-  const idLike = [];
+  const hexLike = [];
   for (const [s] of topBookSlugs) {
     if (/^[a-f0-9]{24}$/i.test(s)) {
-      try { idLike.push(new ObjectId(s)); } catch {}
+      hexLike.push(s);
     } else {
       slugLike.push(s);
     }
   }
-  const proj = { projection: { slug: 1, title: 1, author: 1, language: 1, year_published: 1 } };
+  const idLike = hexLike.map((s) => { try { return new ObjectId(s); } catch { return null; } }).filter(Boolean);
+  const proj = { projection: { slug: 1, id: 1, title: 1, author: 1, language: 1, year_published: 1 } };
   const bySlug = slugLike.length
     ? await db.collection('books').find({ slug: { $in: slugLike } }, proj).toArray()
     : [];
   const byId = idLike.length
     ? await db.collection('books').find({ _id: { $in: idLike } }, proj).toArray()
     : [];
+  const byIdField = hexLike.length
+    ? await db.collection('books').find({ id: { $in: hexLike } }, proj).toArray()
+    : [];
   const bookMeta = new Map();
   for (const b of bySlug) bookMeta.set(b.slug, b);
   for (const b of byId) bookMeta.set(b._id.toString(), b);
+  for (const b of byIdField) { if (b.id) bookMeta.set(b.id, b); }
   print(table(
     topBookSlugs.map(([key, hits]) => {
       const m = bookMeta.get(key) || {};

--- a/src/app/api/admin/health/route.ts
+++ b/src/app/api/admin/health/route.ts
@@ -81,12 +81,17 @@ export const GET = withAdminAuth(async () => {
   const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
   const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
 
+  // Fetched ahead of the parallel batch: the supabase-sync check needs the
+  // pause flag to avoid alarming on gemini_usage lag while the pipeline is
+  // deliberately paused (nothing writes the table then).
+  const systemConfig = await db.collection('system_config')
+    .findOne({ _id: 'processing_control' as any });
+
   const [
     activeJobs,
     activeBatchJobs,
     errorRate,
     stalledBooks,
-    systemConfig,
     sqsDepths,
     recentCronRuns,
     supabaseSync,
@@ -148,9 +153,6 @@ export const GET = withAdminAuth(async () => {
       { $group: { _id: '$pipeline_auto.status', count: { $sum: 1 } } },
     ]).toArray(),
 
-    // System config (pause flag)
-    db.collection('system_config').findOne({ _id: 'processing_control' as any }),
-
     // SQS queue depths (all queues in parallel)
     getQueueDepths(),
 
@@ -165,8 +167,8 @@ export const GET = withAdminAuth(async () => {
       }},
     ]).toArray(),
 
-    // Supabase sync health
-    getSupabaseSyncHealth().catch(() => null),
+    // Supabase sync health (pause-aware — see supabase-health.ts)
+    getSupabaseSyncHealth({ pipelinePaused: systemConfig?.paused === true }).catch(() => null),
 
     // 404 reports: last 24h vs previous 24h, plus top URL buckets.
     // not_found_reports is otherwise write-only — the provider-prefix strip
@@ -205,7 +207,11 @@ export const GET = withAdminAuth(async () => {
     // write-only until 2026-06-10.
     db.collection('embassy_errors').aggregate([
       { $match: { createdAt: { $gte: oneDayAgo } } },
-      { $group: { _id: '$kind', count: { $sum: 1 } } },
+      { $group: {
+        _id: '$kind',
+        count: { $sum: 1 },
+        unrepaired: { $sum: { $size: { $ifNull: ['$unrepaired', []] } } },
+      } },
     ], { maxTimeMS: 10000 }).toArray().catch(() => null),
 
     // Librarian turns + token usage (last 24h) — usage is persisted per AI
@@ -346,8 +352,10 @@ export const GET = withAdminAuth(async () => {
   // --- 11. Librarian (embassy chat) errors + usage (last 24h) ---
   {
     const errByKind: Record<string, number> = {};
-    for (const e of (librarianErrors || []) as Array<{ _id: string; count: number }>) {
+    let unrepairedCitations = 0;
+    for (const e of (librarianErrors || []) as Array<{ _id: string; count: number; unrepaired?: number }>) {
       errByKind[e._id || 'unknown'] = e.count;
+      if (e._id === 'broken_citation') unrepairedCitations = e.unrepaired || 0;
     }
     const totalLibErrors = Object.values(errByKind).reduce((a, b) => a + b, 0);
     const turns = (librarianTurns?.[0] || null) as {
@@ -355,12 +363,18 @@ export const GET = withAdminAuth(async () => {
       cachedTokens: number; turnsWithUsage: number;
     } | null;
     const turnCount = turns?.turns || 0;
+    // broken_citation rows are the citation guard CATCHING (and usually
+    // repairing) fabricated links (#3114) — the guard working, not a
+    // reader-facing failure. Only unrepaired links (the reader gets a
+    // dead-link disclaimer) count toward status; catches stay visible as info.
+    const effectiveErrors = (totalLibErrors - (errByKind['broken_citation'] || 0)) + unrepairedCitations;
     checks.librarian = {
       // Errors on a meaningful share of turns = something is broken for
       // real readers, not a one-off.
-      status: totalLibErrors > Math.max(5, turnCount * 0.2) ? 'warning' : 'ok',
+      status: effectiveErrors > Math.max(5, turnCount * 0.2) ? 'warning' : 'ok',
       errors_24h: totalLibErrors,
       errors_by_kind: errByKind,
+      citation_unrepaired_24h: unrepairedCitations,
       turns_24h: turnCount,
       ...(turns && turns.turnsWithUsage > 0 ? {
         avg_prompt_tokens: Math.round(turns.promptTokens / turns.turnsWithUsage),

--- a/src/lib/supabase-health.ts
+++ b/src/lib/supabase-health.ts
@@ -7,7 +7,13 @@
  * doesn't exist yet.
  */
 
-import { supabase } from './supabase';
+import { supabase, supabaseAdmin } from './supabase';
+
+// The anon key cannot execute sync_health() — Postgres returns 42501
+// (permission denied for table gemini_usage), which silently forced the
+// fallback path (and its hardcoded 'warning') on every health check until
+// 2026-07-23. Server-side health checks must use the service-role client.
+const client = supabaseAdmin ?? supabase;
 
 interface SyncHealthResult {
   status: 'ok' | 'warning' | 'critical';
@@ -17,11 +23,14 @@ interface SyncHealthResult {
   lag_minutes?: Record<string, number | null>;
   checked_at?: string;
   error?: string;
+  note?: string;
 }
 
-export async function getSupabaseSyncHealth(): Promise<SyncHealthResult> {
+export async function getSupabaseSyncHealth(
+  opts: { pipelinePaused?: boolean } = {},
+): Promise<SyncHealthResult> {
   // Try the RPC function first (instant, uses pg_class)
-  const { data, error } = await supabase.rpc('sync_health');
+  const { data, error } = await client.rpc('sync_health');
 
   if (error) {
     // RPC doesn't exist yet — fall back to lightweight individual queries
@@ -57,7 +66,12 @@ export async function getSupabaseSyncHealth(): Promise<SyncHealthResult> {
   //     by design between hand-runs of sync-entities.mjs.
   // Both are still reported in `lag_minutes` for visibility but don't drive status.
   const liveLag = lag.gemini_usage ?? 0;
-  const status = liveLag > 360 ? 'critical'
+  // While the pipeline is deliberately paused, nothing writes gemini_usage —
+  // its lag measures the pause, not a sync outage. A paused system reporting
+  // stale gemini_usage is normal, not an incident.
+  const paused = opts.pipelinePaused === true;
+  const status = paused ? 'ok'
+    : liveLag > 360 ? 'critical'
     : liveLag > 60 ? 'warning'
     : 'ok';
 
@@ -68,6 +82,9 @@ export async function getSupabaseSyncHealth(): Promise<SyncHealthResult> {
     gemini_usage: result.gemini_usage,
     lag_minutes: lag,
     checked_at: result.checked_at,
+    ...(paused && liveLag > 60
+      ? { note: 'gemini_usage lag not escalated: pipeline is deliberately paused, so the source table is not being written' }
+      : {}),
   };
 }
 
@@ -77,7 +94,7 @@ async function getFallbackHealth(): Promise<SyncHealthResult> {
   const lag: Record<string, number | null> = {};
 
   // Entities — has an index on updated_at, should be fast
-  const { data: entityRow } = await supabase
+  const { data: entityRow } = await client
     .from('entities')
     .select('updated_at')
     .order('updated_at', { ascending: false })
@@ -92,7 +109,7 @@ async function getFallbackHealth(): Promise<SyncHealthResult> {
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 3000);
-    const { data: pageRow } = await supabase
+    const { data: pageRow } = await client
       .from('pages')
       .select('updated_at')
       .order('updated_at', { ascending: false })


### PR DESCRIPTION
Fixes the three findings the first weekly digest (2026-07-23) surfaced — two turned out to be monitoring bugs, one a data-resolution bug.

## 1. Top-books raw IDs (analytics)
Pageview keys can be a slug, a Mongo `_id` hex, or the string `id` field — a **different** 24-hex value. Both analytics scripts only resolved `_id`, so three of the top-15 books rendered as raw hex. Now hex keys are looked up by both, and `snapshot-metrics.mjs` merges rows resolving to the same book (Fludd Vol. 1 appeared twice — slug + id — with split hits). Verified against prod: all 15 rows resolve, Fludd merged 1,779+765→2,504, and the top mystery book is *Cours du livre de Thot* (Etteilla) at #2.

## 2. supabase_sync permanent cosmetic warning
The anon key can't execute `sync_health()` (42501 permission denied on `gemini_usage`), which silently forced the fallback path — and the fallback hardcodes `warning`. Every health payload has carried this warning with only the by-design entities/pages lags. Fix: use the service-role client. **Trap avoided:** that alone would flip the check to a false CRITICAL, because `gemini_usage` lag (~20h) is a pause artifact — nothing writes the table while the pipeline is deliberately paused. The checker is now pause-aware (same class as PR #2556); the route fetches the pause flag before the parallel check batch and passes it in.

## 3. Librarian broken_citation
These rows are the #3114 citation guard **catching and usually repairing** fabricated links — the guard working, not a reader-facing failure (verified by sampling 30 recent rows: varied books, most repaired to a valid slug). Status now keys on **unrepaired** links + non-citation errors; catches remain visible, with a new `citation_unrepaired_24h` field.

## Out of scope
- The genuine engagement-decline flag from the digest (real, needs product attention, not a code fix).
- Entities/pages manual-sync cadence (documented gap D).

Deploy note: scripts/** goes live via Hetzner auto-pull; the health route + supabase-health need a prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)