### PR TITLE
feat(export): editorial apparatus as labeled annotation fields (#3327)

### DIFF
--- a/scripts/export/build-corpus-snapshot.mjs
+++ b/scripts/export/build-corpus-snapshot.mjs
@@ -90,6 +90,23 @@ function qualityFlags(text) {
   return { flags, words: words.length };
 }
 
+// Editorial apparatus, exported as labeled annotation fields (issue #3327):
+// the same wrapper blocks that must NEVER ship inline as source text are
+// themselves licensable data when clearly labeled. Extracted from the RAW
+// text before stripping. Tag content gets any nested tags flattened.
+const TRANSLATION_ANNOTATION_TAGS = ['meta', 'summary', 'keywords', 'vocab'];
+const OCR_ANNOTATION_TAGS = ['language', 'script', 'page-type', 'columns', 'scan-quality', 'warning'];
+function extractAnnotations(raw, tags) {
+  const out = {};
+  for (const tag of tags) {
+    const m = raw.match(new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`, 'i'));
+    if (!m) continue;
+    const content = m[1].replace(/<[^>]{1,60}>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (content) out[tag.replace(/-/g, '_')] = content;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
 const ZWC_RE = /[​‌‍⁠﻿]/;
 const WRAPPER_TAG_RE = /<\/?(?:meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning|image-desc)>/i;
 
@@ -149,6 +166,7 @@ async function build() {
       published: 1, language: 1, text_role: 1, work_id: 1,
       is_first_translation: 1, pages_translated: 1, ia_identifier: 1,
       'image_source.provider': 1, 'image_source.source_url': 1, doi: 1,
+      summary: 1, chapters: 1,
     })
     .sort({ language: 1, id: 1 })
     .toArray();
@@ -190,6 +208,14 @@ async function build() {
     const outPages = [];
     for (const page of pages) {
       const rec = { id: page.id, n: page.page_number };
+      if (page.translation?.data) {
+        const a = extractAnnotations(page.translation.data, TRANSLATION_ANNOTATION_TAGS);
+        if (a) rec.annotations = a;
+      }
+      if (page.ocr?.data) {
+        const s = extractAnnotations(page.ocr.data, OCR_ANNOTATION_TAGS);
+        if (s) rec.scan = s;
+      }
       for (const [key, raw] of [['ocr', page.ocr?.data], ['translation', page.translation?.data]]) {
         if (!raw) continue;
         const text = stripEditorialWrappers(raw).trim();
@@ -227,6 +253,11 @@ async function build() {
         source_url: book.image_source?.source_url ?? null,
       },
       license: CONTENT_LICENSE.spdx,
+      // Book-level editorial apparatus (AI-generated; labeled, never inline)
+      summary: typeof book.summary === 'string' ? book.summary : null,
+      chapters: Array.isArray(book.chapters)
+        ? book.chapters.map(c => ({ page: c.pageNumber ?? c.page ?? null, title: c.title ?? null }))
+        : null,
       pages: outPages,
     };
     if (!shard.gz.write(JSON.stringify(record) + '\n')) await once(shard.gz, 'drain');

--- a/scripts/maintenance/clear-stale-hidden-reason.mjs
+++ b/scripts/maintenance/clear-stale-hidden-reason.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// One-time cleanup for issue #3334: unset stale `hidden_reason` on VISIBLE
+// books. ~6.3K visible books carry residue (`launch_curation` 5,752,
+// `unprocessed` 437, `unarchived` 64, …) from batch sweeps that flipped
+// `visible: true` before the writers learned to $unset the reason — every
+// current writer now clears it (set-launch-books.mjs, pipeline-orchestrator
+// unhide paths, the visibility route), so this residue is purely historical.
+// It misleads any consumer that reads the field as a state signal (the corpus
+// exporter dropped 6,289 books this way, #3332).
+//
+// Touches ONLY the reason field on already-visible books — no visibility
+// flips, so the takedown-sweep rule (never bulk-unhide by reason) is not in
+// play. Rights-class reasons (copyright/takedown/dmca) are never unset, even
+// on visible books: they're reported loudly for manual review instead.
+//
+// Usage:
+//   set -a; source .env.production.local; set +a
+//   node scripts/maintenance/clear-stale-hidden-reason.mjs             # dry-run
+//   node scripts/maintenance/clear-stale-hidden-reason.mjs --apply \
+//     --backup ~/sourcelibrary-ops/docs/backups/hidden-reason-backup.json
+//
+// Verify after: db.books.countDocuments({visible:true, hidden_reason:{$exists:true}}) → 0
+// (modulo any rights-class rows, which are reported and kept).
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { withMongo } from '../lib/mongo.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const argOf = (flag) => { const i = process.argv.indexOf(flag); return i > -1 ? process.argv[i + 1] : null; };
+const BACKUP = argOf('--backup');
+
+const RIGHTS_REASON_RE = /copyright|takedown|dmca|rights/i;
+
+if (APPLY && !BACKUP) {
+  console.error('--apply requires --backup <path> (id → reason provenance file)');
+  process.exit(1);
+}
+
+await withMongo(async (db) => {
+  const books = db.collection('books');
+  const query = { visible: true, hidden_reason: { $exists: true } };
+
+  const rows = await books.find(query)
+    .project({ _id: 0, id: 1, slug: 1, hidden_reason: 1 })
+    .toArray();
+
+  const rights = rows.filter(r => RIGHTS_REASON_RE.test(String(r.hidden_reason)));
+  const stale = rows.filter(r => !RIGHTS_REASON_RE.test(String(r.hidden_reason)));
+
+  const byReason = {};
+  for (const r of stale) byReason[r.hidden_reason] = (byReason[r.hidden_reason] || 0) + 1;
+  console.log(`visible books with hidden_reason: ${rows.length}`);
+  console.log(`stale (will unset): ${stale.length}`);
+  for (const [reason, n] of Object.entries(byReason).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${n}\t${reason}`);
+  }
+  if (rights.length) {
+    console.log(`\nRIGHTS-CLASS reasons on VISIBLE books — NOT touched, review manually:`);
+    for (const r of rights) console.log(`  ${r.id}\t${r.slug}\t${r.hidden_reason}`);
+  }
+
+  if (!APPLY) {
+    console.log('\nDry-run (default). Re-run with --apply --backup <path> to unset.');
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(path.resolve(BACKUP)), { recursive: true });
+  fs.writeFileSync(BACKUP, JSON.stringify({ cleared_at: new Date().toISOString(), issue: 3334, rows: stale }, null, 1));
+  console.log(`\nBackup written: ${BACKUP} (${stale.length} rows)`);
+
+  const res = await books.updateMany(
+    { visible: true, hidden_reason: { $exists: true, $not: RIGHTS_REASON_RE } },
+    { $unset: { hidden_reason: '' } },
+  );
+  console.log(`Unset hidden_reason on ${res.modifiedCount} books (matched ${res.matchedCount}).`);
+
+  const remaining = await books.countDocuments(query);
+  console.log(`Remaining visible-with-reason after cleanup: ${remaining} (expected ${rights.length})`);
+});


### PR DESCRIPTION
The wrapper blocks that must never ship inline as source text are themselves licensable data when clearly labeled (layer 2 of the value stack). Extracts per-page `annotations` (meta/summary/keywords/vocab from the translation layer) and `scan` (language/script/page-type/columns/scan-quality/warning from the OCR envelope) from raw text before stripping, plus book-level `summary` and `chapters`. Quote-integrity invariant untouched — text fields still wrapper-stripped, verify phase still asserts zero tags/ZWC in sampled output.

Validated on 8 Latin books: 414/414 Cardano pages with annotations, 21 chapters, verify pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)