### PR TITLE
feat(licensing): grounding/RAG tier + clean-data & living-corpus statements (#3327 Phase 3)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -47,6 +47,8 @@ Original texts are public domain. AI-generated translations and editorial conten
 
 **Cooperative partners can license at lower rates through Dataset subscriptions** — scoped corpora delivered via the streaming JSONL API: single language $4,990/yr, one scholarly domain $14,990/yr, full collection $49,990/yr, with a free evaluation tier (100 pages/day). Details and quickstart: https://sourcelibrary.org/dataset. The standard rate card above is the default term for training use outside a subscription and the invoicing basis for unlicensed use.
 
+**Grounding / RAG at scale (ai-input=yes): permitted with attribution; a Grounding API subscription buys delivery** — an API key with no daily page budget: $499/mo (unlimited retrieval, attribution + link-back required in your product), $1,999/mo with SLA, support, and re-translation webhooks. Licensed exports and API responses are clean — none of the provenance marks embedded in public serve surfaces — and the corpus is living: texts are continuously re-read by newer models and revised by scholars, so subscriptions track the best current text.
+
 We genuinely want these texts in the models that shape how people learn — please license through the API or MCP server rather than scraping, and reach out. Full terms: https://sourcelibrary.org/licensing — contact derek@sourcelibrary.org ("AI Licensing Inquiry").
 
 ## MCP Server (Recommended)

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -219,7 +219,7 @@ export default async function DatasetPage() {
             { name: 'Single Language', price: '$4,990/yr', scope: 'One language corpus, unlimited', note: 'or $499/mo' },
             { name: 'Domain', price: '$14,990/yr', scope: 'One scholarly domain, unlimited', note: 'or $1,499/mo' },
             { name: 'Full Collection', price: '$49,990/yr', scope: 'All languages, all domains', note: 'or $4,999/mo' },
-            { name: 'Enterprise', price: 'Custom', scope: 'Parquet exports, exclusivity, SLA', note: null },
+            { name: 'Enterprise', price: 'Custom', scope: 'Parquet exports, custom scopes, SLA', note: null },
           ].map((tier) => (
             <div key={tier.name} className="flex items-baseline justify-between gap-4 px-5 py-4 bg-white">
               <div className="flex-1">
@@ -247,6 +247,16 @@ export default async function DatasetPage() {
             AI &amp; Data-Mining Licensing
           </Link>{' '}
           for the full policy.
+        </p>
+
+        <p className="text-[#666] text-[15px] leading-[1.75] mt-4 max-w-2xl">
+          Building a retrieval or RAG product rather than training? Grounding
+          with attribution is permitted under our content signals; a{' '}
+          <Link href="/licensing" className="text-[#1a1a18] underline hover:no-underline">
+            Grounding API subscription
+          </Link>{' '}
+          ($499/mo, or $1,999/mo with SLA) removes the daily page budgets for
+          retrieval at scale.
         </p>
 
         <div className="flex flex-wrap gap-4 mt-8">

--- a/src/app/licensing/page.tsx
+++ b/src/app/licensing/page.tsx
@@ -120,6 +120,35 @@ export default function LicensingPage() {
           </p>
         </section>
 
+        {/* ── Grounding / RAG tier ── */}
+        <section className="bg-white rounded-xl p-8 border border-border-light">
+          <h2 className="text-2xl text-primary mb-4">Grounding &amp; retrieval (RAG) access</h2>
+          <p className="text-secondary leading-relaxed mb-4">
+            Our content signals declare <code>ai-input=yes</code>: using our pages to
+            ground AI answers at inference time, with attribution, is permitted.
+            What a grounding subscription buys is <em>delivery</em> — an API key with
+            no daily page budget, support, and change notifications — for products
+            that retrieve and cite our pages at scale:
+          </p>
+          <ul className="space-y-2 text-secondary leading-relaxed list-disc pl-5">
+            <li>
+              <strong>Grounding API:</strong> <strong>$499 per month</strong> —
+              unlimited retrieval, attribution with a link back to the source page
+              required in your product&rsquo;s interface.
+            </li>
+            <li>
+              <strong>Grounding API with SLA:</strong> <strong>$1,999 per month</strong> —
+              adds an uptime commitment, support, and webhook notification of
+              re-translated or newly added texts.
+            </li>
+          </ul>
+          <p className="text-secondary leading-relaxed mt-4">
+            Grounding access does not include training rights — those are licensed
+            separately below. The free budgets on the public API remain available
+            for evaluation.
+          </p>
+        </section>
+
         {/* ── Rate card ── */}
         <section className="bg-white rounded-xl p-8 border border-border-light">
           <h2 className="text-2xl text-primary mb-4">Standard training license — rate card</h2>
@@ -156,6 +185,17 @@ export default function LicensingPage() {
             Common Crawl. Corpus partners additionally receive priority input on what
             gets translated next through our{' '}
             <a href="mailto:derek@sourcelibrary.org?subject=AI%20Partnership" className="text-accent-rust hover:underline">sponsorship program</a>.
+          </p>
+          <p className="text-secondary leading-relaxed mb-4">
+            Two properties of licensed data worth knowing. <strong>It&rsquo;s
+            clean:</strong> licensed exports and API responses carry none of the
+            provenance marks embedded in our public serve surfaces — you receive
+            unmarked, checksummed text, and the marks in publicly scraped copies
+            are how unlicensed use is identified. <strong>It&rsquo;s alive:</strong>{' '}
+            these texts are continuously improved — re-read by newer models, revised
+            by human scholars, extended by new acquisitions — so a license with
+            refresh tracks the best current text while a one-time scrape only
+            depreciates.
           </p>
           <p className="text-secondary leading-relaxed">
             <strong>Unlicensed training use is unauthorized.</strong> Where we identify


### PR DESCRIPTION
**DRAFT — publishes new prices; Derek approves by marking ready + merging.**

Adds the missing rung of the licensing ladder and two product-property statements, consistent across /licensing, /dataset, and llms.txt:

- **Grounding & retrieval (RAG) tier** — $499/mo (unlimited retrieval API key, attribution + link-back required), $1,999/mo with SLA/support/re-translation webhooks. Rationale: our Content-Signal already declares `ai-input=yes`, so grounding is permitted by policy — this tier sells *delivery* (budget removal, SLA), exactly the Wikimedia Enterprise model ($500/$2,500 per month comps). Converts Perplexity-shaped and Elicit-shaped buyers without touching training rights.
- **Clean data statement** — licensed exports/API responses carry no provenance marks (marks are serve-time only, verified by the exporter); marked public copies are how unlicensed use is identified.
- **Living corpus statement** — texts continuously improved (new models, human revision, acquisitions); subscriptions track the best current text, scrapes depreciate.
- **/dataset Enterprise row: "exclusivity" → "custom scopes"** — flagging this change explicitly: offering exclusivity contradicts the non-exclusive-only position stated on /licensing and the strategic decision to keep corpus rights (ops doc). If exclusivity was intentional, drop this hunk.

Declaration-only change: no crawler-gate layer (Cloudflare/proxy/app) is touched; enforcement semantics unchanged. Prices appear on /licensing, /dataset, llms.txt — the same three surfaces #3324 reconciled.

No new API product is wired up — the $499 tier is fulfilled today by issuing an API key (unlimited tier already exists in api-budget.ts); billing is manual/invoice, consistent with contact-based deals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)