### PR TITLE
fix(export): verify flags ZWC runs, not single chars (ZWNJ is a Persian letter)

### DIFF
--- a/scripts/export/build-corpus-snapshot.mjs
+++ b/scripts/export/build-corpus-snapshot.mjs
@@ -128,7 +128,11 @@ async function* shardLines(p) {
   for await (const line of rl) if (line) yield line;
 }
 
-const ZWC_RE = /[​‌‍⁠﻿]/;
+// A provenance mark is a structured RUN of zero-width chars (≥9 consecutive
+// per payload byte — see src/lib/steganographia.ts). Isolated ZWNJ/ZWJ are
+// legitimate letters in Persian/Indic scripts (Rumi's Masnavi false-positived
+// the first full verify with 8 linguistic ZWNJs), so flag runs only.
+const ZWC_RE = /[​‌‍⁠﻿]{8,}/;
 const WRAPPER_TAG_RE = /<\/?(?:meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning|image-desc)>/i;
 
 const RIGHTS_REASON_RE = /copyright|takedown|dmca|rights/i;


### PR DESCRIPTION
First full-corpus verify (18,479 books / 3.93B words — the manifest itself is good) failed on one sampled page: Rumi's Masnavi, Persian, 8 isolated U+200C ZWNJ — which is *orthography* in Persian (می‌روم), not a provenance mark. A genuine steganographia payload is ≥9 consecutive ZWCs per byte (see src/lib/steganographia.ts framing), so the verifier now flags runs of ≥8 consecutive zero-width chars instead of any single occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)