### PR TITLE
fix(cache): add max-age=0 so CDN purges reach browser caches (#3309)

### DIFF
--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -13,6 +13,18 @@
 # skip the purge entirely. This wrapper closes that gap: deploy, then purge +
 # warm, every time.
 #
+# Caching caveat (#3309): a Cloudflare purge clears the shared CDN edge, NOT
+# browsers' private HTTP caches. An API response sent as `public, s-maxage=<n>`
+# with no `max-age` is cached by the browser under RFC 9111 heuristic freshness
+# and served with zero network requests — so a data correction (backfill,
+# visibility flip, re-sync) can stay invisible in an already-open tab for days
+# even after this purge runs. Content-derived API routes therefore ship
+# `max-age=0` (browser revalidates; s-maxage still feeds the CDN). If a
+# correction must be visible immediately to existing sessions, the response
+# needs `max-age=0` BEFORE the stale copies are minted — purging afterwards is
+# too late for copies already in browsers. Invariant pinned by
+# tests/unit/api-cache-max-age.test.ts.
+#
 # Usage:  npm run deploy:prod   (or)   ./scripts/deploy-prod.sh
 #
 # Requires CLOUDFLARE_API_TOKEN, CLOUDFLARE_ZONE_ID, CRON_SECRET in

--- a/src/app/api/[tenant]/pages/batch/route.ts
+++ b/src/app/api/[tenant]/pages/batch/route.ts
@@ -52,7 +52,7 @@ export async function POST(
     const cleaned = pages.map(({ _id, ...rest }) => rest);
 
     return NextResponse.json({ pages: cleaned }, {
-      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300' },
+      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=300' },
     });
   } catch (error) {
     console.error('Batch pages error:', error);

--- a/src/app/api/admin/processing-overview/route.ts
+++ b/src/app/api/admin/processing-overview/route.ts
@@ -31,7 +31,7 @@ export const GET = withAdminAuth(async (request, session) => {
       searchBookIds = matchingBooks.map((b: any) => b.id);
       if (searchBookIds.length === 0) {
         return NextResponse.json({ rows: [], total: 0, summary: { total_steps: 0, total_cost: 0, books_processed: 0, pages_processed: 0 } }, {
-          headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120' },
+          headers: { 'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=120' },
         });
       }
     }
@@ -74,7 +74,7 @@ export const GET = withAdminAuth(async (request, session) => {
     const rows = allRows.slice(offset, offset + limit);
 
     return NextResponse.json({ rows, total, summary }, {
-      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120' },
+      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=120' },
     });
   } catch (error) {
     console.error('Processing overview error:', error);

--- a/src/app/api/books/browse/route.ts
+++ b/src/app/api/books/browse/route.ts
@@ -127,7 +127,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(
       { books: booksWithTenantSlug, total: count || 0, skip, limit },
-      { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300' } }
+      { headers: { 'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=300' } }
     );
   } catch (error) {
     console.error('[books/browse] Error:', error);

--- a/src/app/api/books/library/route.ts
+++ b/src/app/api/books/library/route.ts
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest) {
         return new NextResponse(cached.data, {
           headers: {
             'Content-Type': 'application/json',
-            'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+            'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=300',
           },
         });
       }

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
     if (tenantContext.slug && !tenantContext.id) {
       return NextResponse.json([], {
         headers: {
-          'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120',
+          'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=120',
         },
       });
     }
@@ -81,7 +81,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(booksWithTenantSlug, {
       headers: {
-        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+        'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=600',
       },
     });
   } catch (error) {

--- a/src/app/api/books/search/route.ts
+++ b/src/app/api/books/search/route.ts
@@ -70,7 +70,7 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300');
+    response.headers.set('Cache-Control', 'public, max-age=0, s-maxage=60, stale-while-revalidate=300');
     return response;
   } catch (error) {
     console.error('Search error:', error instanceof Error ? error.message : error);

--- a/src/app/api/books/timeline/route.ts
+++ b/src/app/api/books/timeline/route.ts
@@ -95,7 +95,7 @@ export async function GET(request: NextRequest) {
         }));
 
         return NextResponse.json({ decade: decadeNum, art: mapped, total, offset, mode: 'art' }, {
-          headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+          headers: { 'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=600' },
         });
       }
 
@@ -136,7 +136,7 @@ export async function GET(request: NextRequest) {
       }));
 
       return NextResponse.json({ decade: decadeNum, books: mapped, total, offset }, {
-        headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+        headers: { 'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=600' },
       });
     }
 
@@ -148,7 +148,7 @@ export async function GET(request: NextRequest) {
 
     if (cached?.data) {
       return NextResponse.json(cached.data, {
-        headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+        headers: { 'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=600' },
       });
     }
 

--- a/src/app/api/catalog/browse/route.ts
+++ b/src/app/api/catalog/browse/route.ts
@@ -47,7 +47,7 @@ export async function GET(request: Request) {
 
     return NextResponse.json(
       { books: result.books, total: result.total, ...(languages ? { languages } : {}) },
-      { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30' } },
+      { headers: { 'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=30' } },
     );
   } catch (err) {
     console.error('Catalog browse error:', err);

--- a/src/app/api/catalog/coverage/route.ts
+++ b/src/app/api/catalog/coverage/route.ts
@@ -212,7 +212,7 @@ async function handleTimeline(db: any, params: URLSearchParams) {
     // so repeat traffic doesn't re-trigger the scan. Only set on success;
     // the 503 timeout path above is explicitly no-store.
     headers: {
-      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400',
       'CDN-Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
     },
   });

--- a/src/app/api/catalog/csv/route.ts
+++ b/src/app/api/catalog/csv/route.ts
@@ -111,7 +111,7 @@ export async function GET(request: NextRequest) {
       headers: {
         'Content-Type': 'text/csv; charset=utf-8',
         'Content-Disposition': `attachment; filename="sourcelibrary-catalog-${date}.csv"`,
-        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
+        'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=7200',
       },
     });
   } catch (error) {

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -196,7 +196,7 @@ let cachedResult: { data: unknown; timestamp: number } | null = null;
 
 // GET /api/categories — powered by Supabase books_catalog (or MongoDB for tenant-scoped)
 export async function GET(request: NextRequest) {
-  const headers = { 'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600' };
+  const headers = { 'Cache-Control': 'public, max-age=0, s-maxage=1800, stale-while-revalidate=3600' };
 
   try {
     // Tenant-scoped: bypass Supabase (no tenant_id column) and aggregate from MongoDB

--- a/src/app/api/dataset/v1/stats/route.ts
+++ b/src/app/api/dataset/v1/stats/route.ts
@@ -130,7 +130,7 @@ export async function GET() {
     // the edge so repeat/bot traffic doesn't re-run these 4 scans. Mirrors
     // the CDN-Cache-Control convention in next.config.ts / api/image.
     headers: {
-      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400',
       'CDN-Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
     },
   });

--- a/src/app/api/embed/bph/stats/route.ts
+++ b/src/app/api/embed/bph/stats/route.ts
@@ -18,7 +18,7 @@ const CORS_HEADERS = {
 // the next request.
 const CACHE_HEADERS = {
   ...CORS_HEADERS,
-  'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+  'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400',
 };
 
 export async function OPTIONS() {

--- a/src/app/api/explore/map/route.ts
+++ b/src/app/api/explore/map/route.ts
@@ -164,7 +164,7 @@ export async function GET() {
       },
     }, {
       headers: {
-        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
+        'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=7200',
       },
     });
   } catch (error) {

--- a/src/app/api/explore/stats/route.ts
+++ b/src/app/api/explore/stats/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
   try {
     if (cachedResult && Date.now() - cachedResult.timestamp < CACHE_TTL_MS) {
       return NextResponse.json(cachedResult.data, {
-        headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
+        headers: { 'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=7200' },
       });
     }
 
@@ -84,7 +84,7 @@ export async function GET() {
 
       cachedResult = { data, timestamp: Date.now() };
       return NextResponse.json(data, {
-        headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
+        headers: { 'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=7200' },
       });
     }
 
@@ -97,12 +97,12 @@ export async function GET() {
     const data = snapshot?.data ?? EMPTY_RESPONSE;
     cachedResult = { data, timestamp: Date.now() };
     return NextResponse.json(data, {
-      headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
+      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=7200' },
     });
   } catch (error) {
     console.error('Error fetching explore stats:', error);
     return NextResponse.json(EMPTY_RESPONSE, {
-      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30' },
+      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=30' },
     });
   }
 }

--- a/src/app/api/gallery/similar/route.ts
+++ b/src/app/api/gallery/similar/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
       );
       if (resolved.length >= 3) {
         const response = NextResponse.json({ items: resolved, total: resolved.length, method: 'clip' });
-        response.headers.set('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=3600');
+        response.headers.set('Cache-Control', 'public, max-age=0, s-maxage=86400, stale-while-revalidate=3600');
         return response;
       }
     }
@@ -77,7 +77,7 @@ export async function GET(request: NextRequest) {
     });
 
     // Cache 24 hours
-    response.headers.set('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=3600');
+    response.headers.set('Cache-Control', 'public, max-age=0, s-maxage=86400, stale-while-revalidate=3600');
 
     return response;
   } catch (error) {

--- a/src/app/api/languages/route.ts
+++ b/src/app/api/languages/route.ts
@@ -81,7 +81,7 @@ export async function GET(request: NextRequest) {
     const total_books = languages.reduce((sum, l) => sum + l.book_count, 0);
 
     return NextResponse.json({ languages, total_books }, {
-      headers: { 'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1800' },
+      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=600, stale-while-revalidate=1800' },
     });
   } catch (error) {
     console.error('Error fetching languages:', error);

--- a/src/app/api/nde/dataset/route.ts
+++ b/src/app/api/nde/dataset/route.ts
@@ -148,7 +148,7 @@ export async function GET() {
     headers: {
       'Content-Type': 'application/ld+json; charset=utf-8',
       'Access-Control-Allow-Origin': '*',
-      'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=3600',
+      'Cache-Control': 'public, max-age=0, s-maxage=86400, stale-while-revalidate=3600',
     },
   });
 }

--- a/src/app/api/pages/batch/route.ts
+++ b/src/app/api/pages/batch/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
     const cleaned = pages.map(({ _id, ...rest }) => rest);
 
     return NextResponse.json({ pages: cleaned }, {
-      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300' },
+      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=300' },
     });
   } catch (error) {
     console.error('Batch pages error:', error);

--- a/src/app/api/search/index/route.ts
+++ b/src/app/api/search/index/route.ts
@@ -101,7 +101,7 @@ export async function GET(request: NextRequest) {
     }).catch(() => {});
 
     const response = NextResponse.json({ query, total: results.length, byType, results });
-    response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300');
+    response.headers.set('Cache-Control', 'public, max-age=0, s-maxage=60, stale-while-revalidate=300');
     return response;
   } catch (error) {
     console.error('Index search error:', error);

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -904,7 +904,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       },
     }, {
       headers: {
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+        'Cache-Control': 'public, max-age=0, s-maxage=60, stale-while-revalidate=300',
       },
     });
   } catch (error) {
@@ -920,7 +920,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
     }, {
       status: 500,
       headers: {
-        'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30',
+        'Cache-Control': 'public, max-age=0, s-maxage=10, stale-while-revalidate=30',
       },
     });
   }

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -89,7 +89,7 @@ export async function GET(request: NextRequest) {
         mode: 'semantic',
         level: 'page',
       }, {
-        headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+        headers: { 'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=600' },
       });
     } catch (error) {
       console.error('[semantic-search] page-level error:', error);
@@ -205,7 +205,7 @@ export async function GET(request: NextRequest) {
       total: results.length,
       mode,
     }, {
-      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=600' },
     });
   } catch (error) {
     console.error('[semantic-search] Error:', error);

--- a/src/app/api/search/visual/route.ts
+++ b/src/app/api/search/visual/route.ts
@@ -136,7 +136,7 @@ export async function GET(request: NextRequest) {
       offset,
       mode: 'visual',
     }, {
-      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+      headers: { 'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=600' },
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/src/app/api/search/vocabulary/route.ts
+++ b/src/app/api/search/vocabulary/route.ts
@@ -39,7 +39,7 @@ export async function GET() {
 
   return NextResponse.json(cachedVocabulary, {
     headers: {
-      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400',
     },
   });
 }

--- a/tests/unit/api-cache-max-age.test.ts
+++ b/tests/unit/api-cache-max-age.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Guards issue #3309: an API response sent as `public, s-maxage=<n>` with NO
+ * `max-age` is cached by the *browser* (RFC 9111 heuristic freshness) and then
+ * served with zero network requests — unreachable by a Cloudflare purge. A tab
+ * open during a backfill keeps rendering the stale body for days.
+ *
+ * The fix is `max-age=0` on every content-derived route (browser revalidates;
+ * `s-maxage` still governs the shared CDN edge, so load is absorbed there).
+ * This test pins the invariant across ALL route files so it cannot drift back
+ * in one route at a time.
+ *
+ * Allowlisted: routes whose body is genuinely static config, deliberately
+ * CDN-only, and NOT corrected out-of-band by a purge/backfill. Add here ONLY
+ * with a reason.
+ */
+const ALLOWLIST = new Set<string>([
+  // Static app config — deliberately CDN-only, not purge-driven (#3309 scope note).
+  'src/app/api/config/route.ts',
+]);
+
+const API_DIR = join(process.cwd(), 'src', 'app', 'api');
+
+function routeFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...routeFiles(full));
+    else if (entry.name === 'route.ts') out.push(full);
+  }
+  return out;
+}
+
+// Matches a Cache-Control string literal that sets s-maxage, capturing the value.
+const CACHE_CONTROL_RE = /['"]([^'"]*\bs-maxage=[^'"]*)['"]/gi;
+
+describe('API Cache-Control: s-maxage always pairs with max-age (#3309)', () => {
+  it('every s-maxage response header also sets max-age (browser-cache reachable by purge)', () => {
+    const offenders: string[] = [];
+
+    for (const file of routeFiles(API_DIR)) {
+      const rel = file.slice(file.indexOf('src/'));
+      if (ALLOWLIST.has(rel)) continue;
+      const src = readFileSync(file, 'utf8');
+      for (const m of src.matchAll(CACHE_CONTROL_RE)) {
+        const header = m[1];
+        if (!/\bmax-age=/i.test(header)) {
+          offenders.push(`${rel}: "${header}"`);
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `These API responses set s-maxage without max-age, so browsers cache them ` +
+        `invisibly to a Cloudflare purge (#3309). Add max-age=0 (keep s-maxage for the CDN):\n` +
+        offenders.join('\n'),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #3309.

## Problem
An API response sent as `Cache-Control: public, s-maxage=<n>` with **no `max-age`** is cached by the *browser* (RFC 9111 heuristic freshness), which then serves it with **zero network requests**. A Cloudflare `purge_everything` clears the shared edge but **cannot reach the browser's private cache** — so a tab open during a backfill / visibility-flip / re-sync keeps rendering the stale body for up to the `stale-while-revalidate` window (7 days on the worst route), long after the data is live and the CDN was purged. This is exactly how `/api/ngrams` docs-mode kept reporting `found:false` after `books_by_year` landed (fixed for that one route in #3306).

Measured on prod before this PR:
- `/api/dataset/v1/stats` → `public, s-maxage=3600, stale-while-revalidate=86400` (no `max-age`) — second fetch of the same URL returns **0 bytes** from the browser cache.
- `/api/ngrams?mode=docs` → `public, max-age=0, must-revalidate` (already fixed) — second fetch hits the network.

## Fix — targeted, not a blanket sweep
Adds `max-age=0` to the **34 content-derived** API cache headers (browser revalidates; **`s-maxage` unchanged**, so the CDN still absorbs load). Scope follows the issue: routes whose data is corrected out-of-band and where a purge is expected to make the fix visible — `/api/books|catalog|explore|search|dataset|gallery|languages|categories|nde|pages|admin` + the bph stats route.

**Left alone (deliberately):**
- `/api/config` — static app config, deliberately CDN-only.
- Every route already carrying an explicit `max-age`: RSS/podcast feeds, IIIF manifests/canvases, `authority/author/search`, `explore/map/city`.

## Guard against drift
`tests/unit/api-cache-max-age.test.ts` scans **all** `src/app/api/**/route.ts` and asserts any `Cache-Control` with `s-maxage` also sets `max-age`, with a documented allowlist for `/api/config`. This is the anti-drift mechanism (same spirit as the existing `robots-content-signals` / `search-filter-wire-names` guard tests) — it prevents the bug reappearing one route at a time. Negative-control verified: emptying the allowlist correctly fails on `config`.

`scripts/deploy-prod.sh` now documents the caveat in its header: a purge clears the CDN edge, not browsers' private caches, so the header must land **before** stale copies are minted.

## Out of scope
Considered the shared `cacheHeaders()` helper (issue point 3) but kept this PR to the mechanical header fix + guard test — matches the #3306 precedent, keeps the diff a pure header change, and the guard test already enforces the invariant. A helper (and optionally routing `CDN-Cache-Control` separately) can follow.

## Verification
- `npx tsc --noEmit` — clean.
- `npx vitest run tests/unit/api-cache-max-age.test.ts` — passes; negative control fails as expected.
- Note (from the issue): this only stops *new* stale copies. Responses already in existing browsers age out on their own — no purge can clear them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)