### PR TITLE
feat(eval): Hugging Face dataset package + CHR 2027 venue decision

### DIFF
--- a/.claude/docs/ocr-memorization-paper.md
+++ b/.claude/docs/ocr-memorization-paper.md
@@ -682,9 +682,22 @@ Earlier planned experiments (status as of 2026-07-23):
   type with long-s and ligatures. A baseline arm must be scoped to material the
   baseline can actually read, or its collapse is misread as model advantage.
 
-## Venue / form
+## Venue / form — DECIDED 2026-07-24
 
-Candidates: (a) blog-post research note first (house pattern, citable, fast) →
-(b) workshop/conference paper (NLP4DH / LM4DH / DH venue; or an eval-focused ML
-venue). Dataset DOI via Zenodo at submission time. Both pending Derek's call on
-naming and hosting.
+- **Venue: CHR 2027** (Computational Humanities Research, Manchester, 5–8 Jan 2027).
+  **Submission deadline: 2026-08-14 AoE** — three weeks from decision date; the
+  deadline is the schedule. Rationale: exact audience (computational methods for
+  cultural heritage / the people running digitization pipelines), archival
+  proceedings, and the only strong venue whose window lands inside the scoop
+  horizon (NLP4DH 2026 already ran in July; its next deadline is ~Mar 2027).
+- **At submission time**: arXiv preprint + blog research note (house pattern) go up
+  the same week for dated priority.
+- **Title: keep "Reading or Reciting?"** as the deliberate, cited echo of
+  "Reading or Guessing?" (2605.27750) — recitation vs guessing IS the distinction
+  between the papers; say so in the related-work paragraph.
+- **Dataset: Hugging Face** (Derek, 2026-07-24), named
+  **`sourcelibrary/reading-or-reciting`** (namespace verified unclaimed
+  2026-07-24). Card + publish script: `scripts/eval/dataset/hf/` — one-time HF
+  org/token setup is Derek's, then `publish.sh v0.3`. Zenodo remains available
+  later if a DOI is wanted for the paper's camera-ready; HF revision tags carry
+  versioning until then.

--- a/scripts/eval/dataset/hf/README.md
+++ b/scripts/eval/dataset/hf/README.md
@@ -1,0 +1,127 @@
+---
+license: other
+license_name: mixed-per-file
+license_link: "https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/blob/main/scripts/eval/dataset/v0.3/README.md"
+pretty_name: "Reading or Reciting? — Source Library OCR-Eval"
+task_categories:
+  - image-to-text
+language:
+  - la
+  - el
+  - hy
+  - he
+  - de
+  - en
+  - zh
+tags:
+  - ocr
+  - historical-documents
+  - benchmark-contamination
+  - memorization
+  - digital-humanities
+  - vision-language-models
+  - cultural-heritage
+configs:
+  - config_name: pages
+    data_files: pages.jsonl
+  - config_name: references
+    data_files: references.jsonl
+  - config_name: runs
+    data_files: runs.jsonl
+---
+
+# Reading or Reciting? — Source Library OCR-Eval (v0.3)
+
+Reference-scored OCR observations on historical printed and manuscript pages, with a
+**memorization control**: every reference passage is labeled canonical (texts frontier
+models have plausibly memorized) or non-canonical (editor prefaces, biographical front
+matter, mid-text passages of rarely digitized works). The canonical-vs-non-canonical
+score gap on matched pages estimates the **memorization subsidy** — how much better a
+vision-language model scores on text it can recite than on text it can only read.
+
+OCR benchmarks for historical documents are built almost entirely on canonical texts,
+because those are the texts with published transcriptions to score against — and those
+are precisely the texts models have memorized. **The ground-truth supply and the
+contamination are the same variable.** This dataset exists to measure that.
+
+Produced by [Source Library](https://sourcelibrary.org/research), a project of
+Wisdom Frontiers. Companion working paper: *Reading or Reciting? Measuring the
+Memorization Subsidy in Vision-Language-Model OCR of Historical Documents*
+(in preparation, targeted at CHR 2027; the running draft is
+[maintained in the open](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/blob/main/.claude/docs/ocr-memorization-paper.md)).
+
+## What's in it
+
+- **`pages.jsonl`** — 44 pinned pages from held early-modern editions and manuscripts
+  (Armenian, Greek, Latin, Hebrew, German, Chinese; print, manuscript, woodblock).
+  Book metadata, Source Library URLs, visually audited `page_class` covariates
+  (layout, density, type size, `canonical_text`, `memorization_risk`,
+  `canonicity_grade`), measured image resolution (0.64–17.4 MP), and
+  `same_work_contrast` links: four **within-work pairs** pin a hyper-canonical and a
+  low-canonicity passage of the SAME work in the SAME scan (Vulgate Genesis 1 ↔ 5;
+  Aeneid I ↔ X; Iliad I ↔ XIII on a 1555 manuscript; Zohrab John 1 ↔ 1 Chronicles 1),
+  holding edition, typeface, and scan constant by construction.
+- **`references.jsonl`** — 44 reference passages from published scholarly
+  transcriptions (TITUS, First1KGreek, DTA, Wikisource, ctext), with provenance and
+  license status. **Passage text is included only where the source license permits
+  redistribution** (~half); the rest ship as sha256 pointers + retrieval
+  instructions, so every score remains verifiable without violating any source's
+  terms.
+- **`runs.jsonl`** — 1,737 raw model outputs across ~15 model×provider arms
+  (Gemini 3.x/3.5/3.6 families, Claude Sonnet, Mistral-OCR, Qwen3-VL, DeepSeek-OCR,
+  Gemma 3/4 across three serving providers, and the Source Library production
+  pipeline), including resolution-ablation (`@wN`), prompt-ablation (`@annotated`),
+  and occlusion/blur arms. Raw text is retained so everything can be re-scored under
+  different metrics.
+- **`checksums.txt`** — sha256 of every file plus the withheld reference texts.
+
+## Headline findings (details and paired statistics in the working paper)
+
+- Same-scan, same-work canonical passages read up to 9pp better than non-canonical
+  ones for the same model — and on a 1555 Greek manuscript, three models read the
+  canonical opening at a recitation-flag 100.0%.
+- Under occlusion, models silently emit text for masked pixels on canonical pages
+  (up to +37pp of reference coverage beyond what is visible) while behaving as
+  readers on non-canonical controls; under blur, canonical accuracy is degradation-
+  robust while non-canonical accuracy collapses.
+- Alignment-conditioned accuracy inverts model rankings versus unconditional
+  accuracy; consensus methods fail on canonical text because reciting models agree.
+
+## Uses and caveats
+
+Use this dataset to: measure the memorization subsidy for a new model; test
+contamination-robust scoring; calibrate agreement→accuracy on the non-canonical
+rows; or as a small, adversarially audited historical-OCR eval whose canonicity
+labels you can regress against.
+
+Nine documented caveats travel with the data (canonical rows are memory-assisted
+upper bounds; pooled canonical-vs-non-canonical statistics are confounded by page
+mix; serving provider is part of the system under test; full list in the
+[versioned release notes](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/tree/main/scripts/eval/dataset)).
+
+## Provenance and reproduction
+
+Every page comes from a scan Source Library holds and serves publicly; every row is
+reproducible from the build tooling in
+[`scripts/eval/`](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/tree/main/scripts/eval)
+(AGPL). Scores are re-derived from raw outputs at build time with a
+`scoring_version`, so a different metric is one script away.
+
+## License
+
+The compilation, page metadata, and model outputs: **CC BY 4.0**. Reference texts
+retain their source licenses (First1KGreek and Wikisource CC BY-SA 4.0; DTA public
+domain; TITUS and ctext **not redistributed** — sha256 pointers only). Per-row
+license fields are in `references.jsonl`.
+
+## Citation
+
+```bibtex
+@dataset{sourcelibrary_reading_or_reciting_2026,
+  title   = {Reading or Reciting? — Source Library OCR-Eval (v0.3)},
+  author  = {{Source Library}},
+  year    = {2026},
+  url     = {https://huggingface.co/datasets/sourcelibrary/reading-or-reciting},
+  note    = {A project of Wisdom Frontiers. https://sourcelibrary.org/research}
+}
+```

--- a/scripts/eval/dataset/hf/publish.sh
+++ b/scripts/eval/dataset/hf/publish.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Publish the OCR-Eval dataset to Hugging Face as sourcelibrary/reading-or-reciting.
+#
+# Prereqs (one-time, interactive — Derek):
+#   1. huggingface.co account; create the org "sourcelibrary" (Settings → Organizations → New).
+#   2. Access token with WRITE scope for that org (Settings → Access Tokens).
+#   3. `hf auth login` and paste the token.
+#
+# Then: ./scripts/eval/dataset/hf/publish.sh [version-dir]   (default v0.3)
+#
+# Layout on HF: latest version's files at the repo root (feeds the dataset viewer
+# via the card's `configs`), original per-version README preserved as
+# RELEASE_NOTES_<version>.md. Re-running for a new version overwrites root files;
+# HF keeps full git history, so old versions stay addressable by revision.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+VERSION="${1:-v0.3}"
+REPO=sourcelibrary/reading-or-reciting
+SRC="../$VERSION"
+
+[ -d "$SRC" ] || { echo "No such version dir: $SRC"; exit 1; }
+hf auth whoami >/dev/null 2>&1 || { echo "Not logged in — run: hf auth login"; exit 1; }
+
+hf repo create "$REPO" --repo-type dataset 2>/dev/null || true
+
+hf upload "$REPO" README.md README.md --repo-type dataset --commit-message "dataset card"
+for f in pages.jsonl references.jsonl runs.jsonl checksums.txt; do
+  hf upload "$REPO" "$SRC/$f" "$f" --repo-type dataset --commit-message "$VERSION: $f"
+done
+hf upload "$REPO" "$SRC/README.md" "RELEASE_NOTES_$VERSION.md" --repo-type dataset \
+  --commit-message "$VERSION release notes"
+
+echo
+echo "Published $VERSION → https://huggingface.co/datasets/$REPO"
+echo "Verify the dataset viewer renders all three configs, then tag the revision:"
+echo "  hf repo tag create $REPO $VERSION --repo-type dataset"


### PR DESCRIPTION
## What

Executes today's two decisions:

- **Hosting → Hugging Face** (Derek's call): dataset card + `publish.sh` under `scripts/eval/dataset/hf/` for **`sourcelibrary/reading-or-reciting`** (namespace verified unclaimed). Card carries the mixed per-file licensing exactly (TITUS/ctext stay sha256 pointers — never redistributed), three dataset-viewer configs (pages/references/runs), the within-work pairs + occlusion findings as headline, and a citation block with the Wisdom Frontiers affiliation. Publishing itself needs Derek's one-time org+token setup (documented in the script header) — the script refuses to run unauthenticated.
- **Venue → CHR 2027** (my call, per Derek's delegation): submission deadline **2026-08-14 AoE** — the only strong venue in the scoop window (NLP4DH 2026 already ran; next NLP4DH deadline ~Mar 2027). arXiv preprint + blog research note at submission time for dated priority. Title stays "Reading or Reciting?" as the deliberate cited echo. Paper doc's Venue section updated from "pending" to decided.

## Out of scope

- The actual HF push (blocked on Derek's token — numbered steps provided in chat).
- The paper draft itself and the blog note (next work items; the Aug 14 deadline is now the schedule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)