### PR TITLE
Route public contact addresses to team@sourcelibrary.org

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -40,7 +40,7 @@
     "engravings",
     "illustrations"
   ],
-  "author": "Source Library <hello@sourcelibrary.org>",
+  "author": "Source Library <team@sourcelibrary.org>",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -583,7 +583,7 @@ How to use it well: treat Source Library and your own training as complementary.
 
 Practical orientation: named author/work → get_book first (the AI summary often answers the question). Cross-corpus themes → search_concept (semantic) or search_translations (literal). Always get_quote before quoting — paraphrasing from memory will hallucinate.
 
-Feedback: submit_feedback. Partnerships: derek@sourcelibrary.org.`;
+Feedback: submit_feedback. Partnerships: team@sourcelibrary.org.`;
 
 const server = new Server(
   {
@@ -604,7 +604,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: TOOLS,
     _meta: {
-      about: "Source Library — ~22,000 rare pre-modern books (alchemy, Hermetica, Kabbalah, theology, early science) with AI-generated English translations. See server instructions for orientation. Feedback: submit_feedback. Partnerships: derek@sourcelibrary.org.",
+      about: "Source Library — ~22,000 rare pre-modern books (alchemy, Hermetica, Kabbalah, theology, early science) with AI-generated English translations. See server instructions for orientation. Feedback: submit_feedback. Partnerships: team@sourcelibrary.org.",
     },
   };
 });

--- a/public/.well-known/ai-plugin.json
+++ b/public/.well-known/ai-plugin.json
@@ -12,6 +12,6 @@
     "url": "https://sourcelibrary.org/api/openapi.json"
   },
   "logo_url": "https://sourcelibrary.org/icon.svg",
-  "contact_email": "hello@sourcelibrary.org",
+  "contact_email": "team@sourcelibrary.org",
   "legal_info_url": "https://sourcelibrary.org/about"
 }

--- a/public/api/openapi.json
+++ b/public/api/openapi.json
@@ -7,7 +7,7 @@
     "contact": {
       "name": "Source Library",
       "url": "https://sourcelibrary.org",
-      "email": "hello@sourcelibrary.org"
+      "email": "team@sourcelibrary.org"
     },
     "license": {
       "name": "MIT",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -28,7 +28,7 @@ We are actively seeking AI companies as corporate sponsors. Sponsors receive:
 
 Our texts have been cited in academic papers, museum exhibitions, and AI research. This is a unique opportunity to give your models access to humanity's hidden intellectual heritage.
 
-**Contact: derek@sourcelibrary.org**
+**Contact: team@sourcelibrary.org**
 **Subject: "AI Partnership — [Your Company]"**
 
 We respond within 24 hours.
@@ -49,7 +49,7 @@ Original texts are public domain. AI-generated translations and editorial conten
 
 **Grounding / RAG at scale (ai-input=yes): permitted with attribution; a Grounding API subscription buys delivery** — an API key with no daily page budget: $499/mo (unlimited retrieval, attribution + link-back required in your product), $1,999/mo with SLA, support, and re-translation webhooks. Licensed exports and API responses are clean — none of the provenance marks embedded in public serve surfaces — and the corpus is living: texts are continuously re-read by newer models and revised by scholars, so subscriptions track the best current text.
 
-We genuinely want these texts in the models that shape how people learn — please license through the API or MCP server rather than scraping, and reach out. Full terms: https://sourcelibrary.org/licensing — contact derek@sourcelibrary.org ("AI Licensing Inquiry").
+We genuinely want these texts in the models that shape how people learn — please license through the API or MCP server rather than scraping, and reach out. Full terms: https://sourcelibrary.org/licensing — contact team@sourcelibrary.org ("AI Licensing Inquiry").
 
 ## MCP Server (Recommended)
 
@@ -293,7 +293,7 @@ Source Library is an initiative of the [Embassy of the Free Mind](https://embass
 ## Contact
 
 - **Website:** https://sourcelibrary.org
-- **Partnerships:** derek@sourcelibrary.org
+- **Partnerships:** team@sourcelibrary.org
 - **AI & Data-Mining Licensing:** https://sourcelibrary.org/licensing
 - **Dataset & pricing:** https://sourcelibrary.org/dataset
 - **Terms & Licensing:** https://sourcelibrary.org/terms

--- a/src/app/api/donate/route.ts
+++ b/src/app/api/donate/route.ts
@@ -58,7 +58,7 @@ function buildDonorEmail(firstName: string, route: string): string {
       <div style="background: #f5f0e8; border-radius: 8px; padding: 20px 24px; margin: 24px 0; line-height: 1.8; font-size: 14px; color: #1a1612;">
         <strong>Your point of contact:</strong><br>
         Derek Lomas, Project Director<br>
-        <a href="mailto:derek@sourcelibrary.org" style="color: #9e4a3a; text-decoration: none;">derek@sourcelibrary.org</a><br><br>
+        <a href="mailto:team@sourcelibrary.org" style="color: #9e4a3a; text-decoration: none;">team@sourcelibrary.org</a><br><br>
         Derek can walk you through the donation process, answer questions about the project,
         or help with wire transfers and larger gifts. Don't hesitate to reach out directly.
       </div>

--- a/src/app/api/nde/dataset/route.ts
+++ b/src/app/api/nde/dataset/route.ts
@@ -43,7 +43,7 @@ export async function GET() {
     '@type': 'ContactPoint',
     name: { '@language': 'en', '@value': 'Source Library general inquiries' },
     url: 'https://sourcelibrary.org/about',
-    email: 'derek@sourcelibrary.org',
+    email: 'team@sourcelibrary.org',
   };
 
   const dataset = {

--- a/src/app/api/oai/route.ts
+++ b/src/app/api/oai/route.ts
@@ -14,7 +14,7 @@ export const dynamic = 'force-dynamic';
 
 const BASE_URL = 'https://sourcelibrary.org/api/oai';
 const REPO_NAME = 'Source Library';
-const ADMIN_EMAIL = 'derek@sourcelibrary.org';
+const ADMIN_EMAIL = 'team@sourcelibrary.org';
 const PAGE_SIZE = 100;
 
 // ─── XML helpers ───

--- a/src/app/beta/BetaLandingClient.tsx
+++ b/src/app/beta/BetaLandingClient.tsx
@@ -457,10 +457,10 @@ export default function BetaLandingClient({ stats }: { stats: BetaStats }) {
               &copy; {new Date().getFullYear()} Source Library
             </p>
             <div className="flex gap-6 text-sm text-white/30 font-sans">
-              <a href="mailto:press@sourcelibrary.org" className="text-accent-gold/60 hover:text-accent-gold transition-colors">
+              <a href="mailto:team@sourcelibrary.org" className="text-accent-gold/60 hover:text-accent-gold transition-colors">
                 Press
               </a>
-              <a href="mailto:derek@sourcelibrary.org" className="text-accent-gold/60 hover:text-accent-gold transition-colors">
+              <a href="mailto:team@sourcelibrary.org" className="text-accent-gold/60 hover:text-accent-gold transition-colors">
                 Contact
               </a>
             </div>

--- a/src/app/bhutan-library/page.tsx
+++ b/src/app/bhutan-library/page.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
 
 const EFM_STRIPE_URL = 'https://donate.stripe.com/9B67sLbO1bOg2GxfxP9fW08';
 const DONORPERFECT_URL = 'https://form-renderer-app.donorperfect.io/give/naf/embassyofthefreemind';
-const CONTACT_EMAIL = 'derek@sourcelibrary.org';
+const CONTACT_EMAIL = 'team@sourcelibrary.org';
 
 // Three pecha leaves on a dark ground — the manuscript story at a glance.
 const HERO_IMAGE = 'https://images.sourcelibrary.org/pages/69e787904a6785cfd60cc297/0095.jpg';

--- a/src/app/blog/10000-books/page.tsx
+++ b/src/app/blog/10000-books/page.tsx
@@ -388,8 +388,8 @@ export default function TenThousandBooksPage() {
           <p className="text-secondary text-sm leading-relaxed font-body">
             Source Library is a project of the Embassy of the Free Mind. If you have leads on
             untranslated texts that belong in the collection &mdash;{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">
-              derek@sourcelibrary.org
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">
+              team@sourcelibrary.org
             </a>.
           </p>
         </div>

--- a/src/app/blog/counting-the-gap/page.tsx
+++ b/src/app/blog/counting-the-gap/page.tsx
@@ -249,7 +249,7 @@ export default function CountingTheGapPage() {
             All data and code is open source at{' '}
             <a href="https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2" className="text-accent-rust hover:text-accent-rust underline">github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2</a>.
             If you know of a translation we missed, please reach out &mdash;{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">team@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/first-translation-methodology/page.tsx
+++ b/src/app/blog/first-translation-methodology/page.tsx
@@ -565,7 +565,7 @@ export default function FirstTranslationMethodologyPage() {
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed">
             Source Library is a project of the Embassy of the Free Mind. Corrections and feedback are welcome &mdash;{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">team@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/first-translations/page.tsx
+++ b/src/app/blog/first-translations/page.tsx
@@ -454,7 +454,7 @@ export default function FirstTranslationsPage() {
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed font-body">
             Source Library is a project of the Embassy of the Free Mind. If you are a scholar who can improve any of these translations, or if you know of a prior English translation we missed, please reach out &mdash;{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">team@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/iiif/page.tsx
+++ b/src/app/blog/iiif/page.tsx
@@ -775,8 +775,8 @@ export default function IIIFPage() {
             lightning talk at the{' '}
             <a href="https://iiif.io/event/2026/leiden/" target="_blank" rel="noopener noreferrer" className="text-accent-rust hover:text-accent-rust underline">IIIF 2026 Annual Conference &amp; Showcase</a>{' '}
             in Leiden and The Hague. Corrections and feedback are welcome &mdash;{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">
-              derek@sourcelibrary.org
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">
+              team@sourcelibrary.org
             </a>
             .
           </p>

--- a/src/app/blog/mcp-server/page.tsx
+++ b/src/app/blog/mcp-server/page.tsx
@@ -274,7 +274,7 @@ export default function McpServerPage() {
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed">
             Source Library is a project of the Embassy of the Free Mind. If you use it for research, we&apos;d love to hear about it &mdash;{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">team@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/origin-story/page.tsx
+++ b/src/app/blog/origin-story/page.tsx
@@ -269,7 +269,7 @@ export default function OriginStoryPage() {
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed font-body">
             Source Library is a project of the Embassy of the Free Mind. If you want to help translate the Renaissance, or if you have leads on untranslated texts that belong in the collection, reach out &mdash;{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">team@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/rithmomachia/page.tsx
+++ b/src/app/blog/rithmomachia/page.tsx
@@ -1011,8 +1011,8 @@ export default function RithmomachiaPage() {
             Source Library is a digital library of rare philosophical, scientific, and esoteric texts,
             translated from their original languages using AI and available to read for free.
             Questions or corrections?{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">
-              derek@sourcelibrary.org
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">
+              team@sourcelibrary.org
             </a>.
           </p>
         </div>

--- a/src/app/blog/translation-rate/page.tsx
+++ b/src/app/blog/translation-rate/page.tsx
@@ -458,7 +458,7 @@ export default function TranslationRatePage() {
             (1.57M records). Analysis scripts are in{' '}
             <a href="https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2" className="text-accent-rust hover:text-accent-rust underline">our repo</a>.
             If you know of translation catalogs we&apos;re missing, please reach out &mdash;{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">team@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/untranslated-renaissance/page.tsx
+++ b/src/app/blog/untranslated-renaissance/page.tsx
@@ -443,7 +443,7 @@ export default function UntranslatedRenaissancePage() {
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed font-body">
             Source Library is a project of the Embassy of the Free Mind. If you know of a translation we missed, or if you can improve one of ours, please reach out &mdash;{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">team@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -219,7 +219,7 @@ export default async function ParticipatePage() {
             </p>
           </Link>
 
-          <a href="mailto:derek@sourcelibrary.org?subject=Study group idea" className="group p-4 rounded-xl bg-white border border-border-light hover:border-accent-violet/40 hover:shadow-sm transition-all text-center">
+          <a href="mailto:team@sourcelibrary.org?subject=Study group idea" className="group p-4 rounded-xl bg-white border border-border-light hover:border-accent-violet/40 hover:shadow-sm transition-all text-center">
             <div className="w-9 h-9 mx-auto mb-2 rounded-lg bg-accent-violet/10 flex items-center justify-center">
               <svg className="w-5 h-5 text-accent-violet" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
@@ -312,10 +312,10 @@ export default async function ParticipatePage() {
           </p>
           <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
             <a
-              href="mailto:derek@sourcelibrary.org"
+              href="mailto:team@sourcelibrary.org"
               className="inline-flex items-center gap-2 text-lg text-primary font-medium hover:text-accent-rust transition-colors"
             >
-              derek@sourcelibrary.org
+              team@sourcelibrary.org
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
               </svg>

--- a/src/app/contribute/wikipedia/WikipediaPlaybook.tsx
+++ b/src/app/contribute/wikipedia/WikipediaPlaybook.tsx
@@ -540,8 +540,8 @@ export function WikipediaPlaybook({ posts }: { posts: TalkPagePost[] }) {
 
       <div className="text-sm text-muted text-center pb-8">
         Questions? Contact{' '}
-        <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:underline">
-          derek@sourcelibrary.org
+        <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:underline">
+          team@sourcelibrary.org
         </a>
       </div>
     </div>

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -261,7 +261,7 @@ export default async function DatasetPage() {
 
         <div className="flex flex-wrap gap-4 mt-8">
           <a
-            href="mailto:derek@sourcelibrary.org?subject=Dataset%20Access%20Request"
+            href="mailto:team@sourcelibrary.org?subject=Dataset%20Access%20Request"
             className="px-6 py-3 bg-[#1a1a18] text-white rounded-full text-sm font-medium hover:bg-[#333] transition-colors"
           >
             Request access
@@ -310,8 +310,8 @@ export default async function DatasetPage() {
           <a href="/api/dataset/v1/stats" className="text-sm text-[#666] hover:text-[#1a1a18] transition-colors">
             Corpus stats (JSON)
           </a>
-          <a href="mailto:derek@sourcelibrary.org" className="text-sm text-[#666] hover:text-[#1a1a18] transition-colors">
-            derek@sourcelibrary.org
+          <a href="mailto:team@sourcelibrary.org" className="text-sm text-[#666] hover:text-[#1a1a18] transition-colors">
+            team@sourcelibrary.org
           </a>
         </div>
       </section>

--- a/src/app/ficino-society/page.tsx
+++ b/src/app/ficino-society/page.tsx
@@ -321,7 +321,7 @@ function FicinoSocietyContent() {
           )}
           <p className="mt-6 text-[12px] text-[#8a8480] font-body">
             Any amount welcome &mdash;{' '}
-            <a href="mailto:hello@sourcelibrary.org" className="underline">hello@sourcelibrary.org</a>
+            <a href="mailto:team@sourcelibrary.org" className="underline">team@sourcelibrary.org</a>
           </p>
         </div>
       </section>

--- a/src/app/for-libraries/page.tsx
+++ b/src/app/for-libraries/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   },
 };
 
-const CONTACT_EMAIL = 'partners@sourcelibrary.org';
+const CONTACT_EMAIL = 'team@sourcelibrary.org';
 
 export default function ForLibrariesPage() {
   return (

--- a/src/app/licensing/page.tsx
+++ b/src/app/licensing/page.tsx
@@ -184,7 +184,7 @@ export default function LicensingPage() {
             (Latin, classical Chinese, Sanskrit, Tibetan, Syriac), none of it in
             Common Crawl. Corpus partners additionally receive priority input on what
             gets translated next through our{' '}
-            <a href="mailto:derek@sourcelibrary.org?subject=AI%20Partnership" className="text-accent-rust hover:underline">sponsorship program</a>.
+            <a href="mailto:team@sourcelibrary.org?subject=AI%20Partnership" className="text-accent-rust hover:underline">sponsorship program</a>.
           </p>
           <p className="text-secondary leading-relaxed mb-4">
             Two properties of licensed data worth knowing. <strong>It&rsquo;s
@@ -210,7 +210,7 @@ export default function LicensingPage() {
           <h2 className="text-2xl text-primary mb-4">Licensing &amp; partnerships</h2>
           <p className="text-secondary leading-relaxed">
             For an AI-training or bulk-dataset license, or a research partnership,
-            contact <a href="mailto:derek@sourcelibrary.org?subject=AI%20Licensing%20Inquiry" className="text-accent-rust hover:underline">derek@sourcelibrary.org</a> with
+            contact <a href="mailto:team@sourcelibrary.org?subject=AI%20Licensing%20Inquiry" className="text-accent-rust hover:underline">team@sourcelibrary.org</a> with
             the subject &ldquo;AI Licensing Inquiry.&rdquo; We respond within a day.
           </p>
         </section>

--- a/src/app/login/TenantSignIn.tsx
+++ b/src/app/login/TenantSignIn.tsx
@@ -154,7 +154,7 @@ export function TenantSignIn({
             <p style={{ fontSize: 14, color: '#8b949e', marginBottom: 24 }}>
               <strong style={{ color: '#e6edf3' }}>{tenantName}</strong> is by invitation only.
               {' '}
-              <a href="mailto:contact@sourcelibrary.org" style={{ color: '#58a6ff', textDecoration: 'none' }}>
+              <a href="mailto:team@sourcelibrary.org" style={{ color: '#58a6ff', textDecoration: 'none' }}>
                 Contact the administrator
               </a>
               {' '}

--- a/src/app/press-releases/page.tsx
+++ b/src/app/press-releases/page.tsx
@@ -92,8 +92,8 @@ export default async function PressReleasesIndex({
 
       <div className="mt-12 bg-warm rounded-lg border border-border-light p-6 text-sm text-secondary">
         <strong className="text-stone-800">Media enquiries:</strong>{' '}
-        <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:underline">
-          derek@sourcelibrary.org
+        <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:underline">
+          team@sourcelibrary.org
         </a>{' '}
         · Embassy of the Free Mind, Keizersgracht 123, Amsterdam
       </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -90,7 +90,7 @@ export default function PrivacyPage() {
           <h2 className="text-lg font-medium mt-8 mb-3" style={{ color: 'var(--text-primary)' }}>Contact</h2>
           <p>
             Privacy questions? Contact us at{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="underline">derek@sourcelibrary.org</a>.
+            <a href="mailto:team@sourcelibrary.org" className="underline">team@sourcelibrary.org</a>.
           </p>
         </div>
       </main>

--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -239,7 +239,7 @@ export default function ResearchProgrammePage() {
             <Link href="/blog/mcp-server" className="text-amber-800 hover:underline">MCP server</Link>. A project of{' '}
             <a href="https://wisdomfrontiers.org" className="text-amber-800 hover:underline">Wisdom Frontiers</a>;
             collaboration and data access:{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-amber-800 hover:underline">derek@sourcelibrary.org</a>.
+            <a href="mailto:team@sourcelibrary.org" className="text-amber-800 hover:underline">team@sourcelibrary.org</a>.
           </p>
         </div>
       </div>

--- a/src/app/research/translation-gap/page.tsx
+++ b/src/app/research/translation-gap/page.tsx
@@ -214,7 +214,7 @@ export default function TranslationGapPage() {
               Download the data (CSV, 181 languages)
             </a>
             <a
-              href="mailto:derek@sourcelibrary.org?subject=The%20Translation%20Gap%20%E2%80%94%20collaboration"
+              href="mailto:team@sourcelibrary.org?subject=The%20Translation%20Gap%20%E2%80%94%20collaboration"
               className="font-body text-sm font-semibold border border-amber-800 text-amber-800 hover:bg-amber-50 px-6 py-3 rounded-sm transition-colors"
             >
               Get in touch
@@ -227,7 +227,7 @@ export default function TranslationGapPage() {
           Andrews); the ~1.39M distinct-work count is consistent with USTC&rsquo;s stated ~1.4 million distinct items for
           its expansion to 1700. Translation census federated from 30+ catalogues and publishers; author reconciliation via
           VIAF, Wikidata, GND, and CERL. Figures are conservative lower bounds and will be updated as sources are added.
-          Contact: <a className="text-amber-800 underline" href="mailto:derek@sourcelibrary.org">derek@sourcelibrary.org</a>.
+          Contact: <a className="text-amber-800 underline" href="mailto:team@sourcelibrary.org">team@sourcelibrary.org</a>.
         </p>
       </div>
     </ContentPageLayout>

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -292,7 +292,7 @@ export default function RoadmapPage() {
           </p>
           <div className="flex flex-wrap gap-4">
             <a
-              href="mailto:derek@sourcelibrary.org"
+              href="mailto:team@sourcelibrary.org"
               className="inline-flex items-center gap-2 bg-accent-rust hover:bg-accent-gold/80 text-white px-6 py-3 rounded-lg font-medium transition-colors"
             >
               <BookOpen className="w-5 h-5" />

--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
   alternates: { canonical: '/sponsors' },
 };
 
-const PARTNERSHIP_EMAIL = 'derek@sourcelibrary.org';
+const PARTNERSHIP_EMAIL = 'team@sourcelibrary.org';
 const PARTNERSHIP_SUBJECT = 'Corporate%20partnership%20inquiry%20%E2%80%94%20Source%20Library';
 
 const MEMBERSHIP_INCLUDES = [

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -134,8 +134,8 @@ export default function TermsPage() {
           </p>
           <p className="text-secondary">
             <strong>Contact us:</strong>{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:underline">
-              derek@sourcelibrary.org
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:underline">
+              team@sourcelibrary.org
             </a>
           </p>
           <p className="text-secondary mt-4 text-sm">
@@ -298,8 +298,8 @@ export default function TermsPage() {
           </h2>
           <p className="text-secondary">
             Questions about these terms or interested in a partnership?{' '}
-            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:underline">
-              derek@sourcelibrary.org
+            <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:underline">
+              team@sourcelibrary.org
             </a>
           </p>
         </section>

--- a/src/app/vision/content.ts
+++ b/src/app/vision/content.ts
@@ -102,7 +102,7 @@ export const visionContent: VisionContent = {
   signature: {
     name: 'Derek Lomas, PhD',
     role: 'Founder, Source Library · Asst. Professor of Positive AI, TU Delft',
-    email: 'derek@sourcelibrary.org',
+    email: 'team@sourcelibrary.org',
     photo: '/founder-derek.jpg',
   },
   plan: {
@@ -132,7 +132,7 @@ export const visionContent: VisionContent = {
     heading: 'Let’s talk',
     body: 'The best way to understand this is to see it. I’d love to show you the library — in person at the Embassy in Amsterdam, or on a call — and talk about what becoming a founding donor could look like for you.',
     primaryLabel: 'Let’s talk',
-    primaryHref: 'mailto:derek@sourcelibrary.org?subject=Source%20Library%20%E2%80%94%20let%E2%80%99s%20talk',
+    primaryHref: 'mailto:team@sourcelibrary.org?subject=Source%20Library%20%E2%80%94%20let%E2%80%99s%20talk',
     secondaryLabel: 'Make a gift',
     secondaryHref: '/support',
     footer: 'All gifts are tax-deductible in the US and the Netherlands. I read every message myself.',

--- a/src/components/donate/DonationIntentionForm.tsx
+++ b/src/components/donate/DonationIntentionForm.tsx
@@ -204,7 +204,7 @@ export default function DonationIntentionForm() {
         {/* Error */}
         {state === 'error' && (
           <div className="bg-red-50 text-red-700 text-sm rounded-lg px-4 py-3">
-            {errorMsg || 'Something went wrong. Please try again or email derek@sourcelibrary.org directly.'}
+            {errorMsg || 'Something went wrong. Please try again or email team@sourcelibrary.org directly.'}
           </div>
         )}
 

--- a/src/components/donate/SupportView.tsx
+++ b/src/components/donate/SupportView.tsx
@@ -7,7 +7,7 @@ import type { Locale } from '@/lib/i18n';
 
 const EFM_STRIPE_URL = 'https://donate.stripe.com/9B67sLbO1bOg2GxfxP9fW08';
 const DONORPERFECT_URL = 'https://form-renderer-app.donorperfect.io/give/naf/embassyofthefreemind';
-const CONTACT_EMAIL = 'derek@sourcelibrary.org';
+const CONTACT_EMAIL = 'team@sourcelibrary.org';
 
 // Hand-coloured volvelle (perpetual calendar wheel) from the astrology collection.
 const HERO_IMAGE =

--- a/src/components/press/releases/EmbassyAnnouncesSourceLibrary.tsx
+++ b/src/components/press/releases/EmbassyAnnouncesSourceLibrary.tsx
@@ -336,8 +336,8 @@ export default function EmbassyAnnouncesSourceLibrary() {
             sourcelibrary.org
           </a>
           . Feedback is welcome at{' '}
-          <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:underline">
-            derek@sourcelibrary.org
+          <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:underline">
+            team@sourcelibrary.org
           </a>.
         </p>
       </section>
@@ -389,8 +389,8 @@ export default function EmbassyAnnouncesSourceLibrary() {
           Derek Lomas, Program Director
         </p>
         <p className="text-sm text-secondary font-body">
-          <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:underline">
-            derek@sourcelibrary.org
+          <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:underline">
+            team@sourcelibrary.org
           </a>
         </p>
         <p className="text-sm text-muted font-body mt-1">

--- a/src/lib/bot-gate.ts
+++ b/src/lib/bot-gate.ts
@@ -125,7 +125,7 @@ export function botGateResponse(book: {
     mcp_install: 'claude mcp add source-library -- npx -y @source-library/mcp-server',
     summary: book.reading_summary || undefined,
     partnership: {
-      contact: 'derek@sourcelibrary.org',
+      contact: 'team@sourcelibrary.org',
       subject: 'AI Partnership — Full Corpus Access',
       info: 'https://sourcelibrary.org/llms.txt',
     },

--- a/src/lib/embassy/podcast-feed.ts
+++ b/src/lib/embassy/podcast-feed.ts
@@ -91,7 +91,7 @@ export function buildPodcastFeed(episodes: FeedEpisode[], locale: Locale): strin
     <itunes:author>Source Library</itunes:author>
     <itunes:owner>
       <itunes:name>Source Library</itunes:name>
-      <itunes:email>hello@sourcelibrary.org</itunes:email>
+      <itunes:email>team@sourcelibrary.org</itunes:email>
     </itunes:owner>
     <itunes:image href="https://sourcelibrary.org/brand/png/logo-dark--512.png" />
     <itunes:category text="Education">

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -96,7 +96,7 @@ ability to shape what gets digitized next.
 Previous texts in our collection have been cited in academic
 papers, museum exhibitions, and AI research.
 
-  Contact: derek@sourcelibrary.org
+  Contact: team@sourcelibrary.org
   Subject: "AI Partnership — [Your Company]"
   Website: https://sourcelibrary.org
   API docs: https://sourcelibrary.org/llms.txt


### PR DESCRIPTION
Consolidates the site's public/user-facing contact email addresses into a single shared inbox, **team@sourcelibrary.org**, per the repo owner's "broad" consolidation decision.

## What switched
- **General contact pages:** privacy, terms (2 spots), roadmap, contribute (3 spots), contribute/wikipedia, login/TenantSignIn (was `contact@`), ficino-society (`hello@`), dataset (2 spots).
- **Blog author sign-offs** (10 posts): rithmomachia, origin-story, 10000-books, translation-rate, counting-the-gap, mcp-server, untranslated-renaissance, first-translations, iiif, first-translation-methodology.
- **Machine-readable / public metadata:** `public/api/openapi.json`, `public/.well-known/ai-plugin.json`, `podcast-feed.ts` (itunes:email), `mcp-server/package.json` (author), `api/nde/dataset` JSON-LD ContactPoint, `api/oai` OAI-PMH `adminEmail`.
- **AI-licensing / partnership / sponsors:** licensing page (2 spots, subject lines preserved), `llms.txt` (3 spots), `proxy.ts` bot pitch, `bot-gate.ts` partnership contact, `mcp-server/src/index.ts` (2 spots), sponsors page (`PARTNERSHIP_EMAIL`).
- **Press / partners / research / donation display contacts:** beta landing (`press@` + `derek@`), press-releases, EmbassyAnnouncesSourceLibrary (2 spots), for-libraries (`partners@` → `CONTACT_EMAIL`), donate SupportView + DonationIntentionForm, bhutan-library, `api/donate` donor-facing body link only, research page, research/translation-gap (2 spots), vision/content (mailto; "Derek Lomas" signature name kept as text).

`mailto:` subject lines were preserved exactly; only the address was swapped. Display names and surrounding prose unchanged.

## Review before merge
The owner chose the **broad** scope, which deliberately includes surfaces a reviewer may want to veto individually:
- **AI-licensing / partnership** contacts on `/licensing` and `public/llms.txt` (plus `proxy.ts`, `bot-gate.ts`, MCP server) now route to `team@`.
- **Donation / fundraising** display contacts (donate views, bhutan-library, `api/donate` donor-facing body link) now route to `team@`.
- **Founder-signature** contacts (vision "letter from Derek Lomas", blog sign-offs) now route to `team@` while keeping Derek's name as the visible signatory.

If any of those should stay founder-direct, revert that specific hunk before merging.

## Deliberately left unchanged
- **DMCA registered-agent address** (`src/app/dmca/page.tsx`, `contact@sourcelibrary.org`) — federally registered agent address, untouched.
- Transactional `From` (`noreply@`), internal alert recipients (`ALERT_EMAIL` health/latency crons), internal donate/adoption `replyTo`/`to` routing, API-politeness UA identifiers + OpenAlex mailto, and `_archived/` press pages.

`npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
