### PR TITLE
fix(encyclopedia): verify entity page attributions instead of smearing batch ranges (#3361)

### DIFF
--- a/scripts/batch/batch-generate-indexes.mjs
+++ b/scripts/batch/batch-generate-indexes.mjs
@@ -20,6 +20,7 @@
 import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
+import { buildPageTexts, attributeEntityPages, entityCounters } from '../lib/entity-page-match.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -324,23 +325,43 @@ function buildConceptIndex(batches, pages) {
   const placesMap = new Map();
   const conceptsMap = new Map();
 
+  // Twin of buildConceptIndexFromBatches in scripts/workers/enrich-worker.mjs —
+  // keep both sides in step. Gemini names the entities in a ~50k-char batch but
+  // is never asked which page each sits on, so we verify against page text
+  // instead of crediting the whole batch range (#3361).
+  const pagesByNumber = new Map(pages.map(p => [p.page_number, p]));
+
+  const accumulate = (map, term, batchPageTexts) => {
+    if (!term) return;
+    const attribution = attributeEntityPages(term, batchPageTexts);
+    const prev = map.get(term);
+    if (!prev) {
+      map.set(term, attribution);
+      return;
+    }
+    const merged_pages = [...new Set([...prev.pages, ...attribution.pages])].sort((a, b) => a - b);
+    const ranges = [prev.page_range, attribution.page_range].filter(Boolean);
+    const merged = { pages: merged_pages, page_precision: merged_pages.length > 0 ? 'page' : 'section' };
+    if (merged.page_precision === 'section' && ranges.length > 0) {
+      merged.page_range = {
+        start: Math.min(...ranges.map(r => r.start)),
+        end: Math.max(...ranges.map(r => r.end)),
+      };
+    }
+    map.set(term, merged);
+  };
+
   for (const batch of batches) {
-    const pageNumbers = Array.from(
-      { length: batch.pageRange.end - batch.pageRange.start + 1 },
-      (_, i) => batch.pageRange.start + i
-    );
-    for (const person of batch.people) {
-      if (!peopleMap.has(person)) peopleMap.set(person, []);
-      peopleMap.get(person).push(...pageNumbers);
+    const batchPages = [];
+    for (let n = batch.pageRange.start; n <= batch.pageRange.end; n++) {
+      const p = pagesByNumber.get(n);
+      if (p) batchPages.push(p);
     }
-    for (const place of batch.places) {
-      if (!placesMap.has(place)) placesMap.set(place, []);
-      placesMap.get(place).push(...pageNumbers);
-    }
-    for (const concept of batch.concepts) {
-      if (!conceptsMap.has(concept)) conceptsMap.set(concept, []);
-      conceptsMap.get(concept).push(...pageNumbers);
-    }
+    const batchPageTexts = buildPageTexts(batchPages);
+
+    for (const person of batch.people) accumulate(peopleMap, person, batchPageTexts);
+    for (const place of batch.places) accumulate(placesMap, place, batchPageTexts);
+    for (const concept of batch.concepts) accumulate(conceptsMap, concept, batchPageTexts);
   }
 
   // Extract vocabulary/keywords from page tags
@@ -361,17 +382,24 @@ function buildConceptIndex(batches, pages) {
     }
   }
 
+  // vocabulary/keywords are extracted from per-page tags, so they were always
+  // page-exact.
   const mapToEntries = (map) =>
     Array.from(map.entries())
-      .map(([term, pgs]) => ({ term, pages: [...new Set(pgs)].sort((a, b) => a - b) }))
+      .map(([term, pgs]) => ({ term, pages: [...new Set(pgs)].sort((a, b) => a - b), page_precision: 'page' }))
+      .sort((a, b) => b.pages.length - a.pages.length);
+
+  const attributionToEntries = (map) =>
+    Array.from(map.entries())
+      .map(([term, attribution]) => ({ term, ...attribution }))
       .sort((a, b) => b.pages.length - a.pages.length);
 
   return {
     vocabulary: mapToEntries(vocabMap),
     keywords: mapToEntries(keywordMap),
-    people: mapToEntries(peopleMap),
-    places: mapToEntries(placesMap),
-    concepts: mapToEntries(conceptsMap),
+    people: attributionToEntries(peopleMap),
+    places: attributionToEntries(placesMap),
+    concepts: attributionToEntries(conceptsMap),
   };
 }
 
@@ -381,21 +409,30 @@ async function syncBookEntities(db, bookId, bookTitle, bookAuthor, conceptIndex)
   const now = new Date();
   const promises = [];
 
-  const syncEntity = async (term, type, pages) => {
+  const syncEntity = async (term, type, entry) => {
+    if (!term) return;
+    const bookEntry = {
+      book_id: bookId,
+      book_title: bookTitle,
+      book_author: bookAuthor,
+      pages: entry.pages || [],
+      page_precision: entry.page_precision || 'section',
+      ...(entry.page_range ? { page_range: entry.page_range } : {}),
+    };
+    // Replace this book's entry, don't append another. See the same fix in
+    // enrich-worker.mjs — `$addToSet` on a whole subdocument duplicated books.
     await db.collection('entities').updateOne(
       { name: term, type },
-      {
-        $set: { updated_at: now },
-        $setOnInsert: { name: term, type, created_at: now },
-        $addToSet: { books: { book_id: bookId, book_title: bookTitle, book_author: bookAuthor, pages } },
-      },
+      { $set: { updated_at: now }, $setOnInsert: { name: term, type, created_at: now } },
       { upsert: true }
     );
+    await db.collection('entities').updateOne({ name: term, type }, { $pull: { books: { book_id: bookId } } });
+    await db.collection('entities').updateOne({ name: term, type }, { $push: { books: bookEntry } });
   };
 
-  for (const p of conceptIndex.people) promises.push(syncEntity(p.term, 'person', p.pages));
-  for (const p of conceptIndex.places) promises.push(syncEntity(p.term, 'place', p.pages));
-  for (const c of conceptIndex.concepts) promises.push(syncEntity(c.term, 'concept', c.pages));
+  for (const p of conceptIndex.people) promises.push(syncEntity(p.term, 'person', p));
+  for (const p of conceptIndex.places) promises.push(syncEntity(p.term, 'place', p));
+  for (const c of conceptIndex.concepts) promises.push(syncEntity(c.term, 'concept', c));
 
   await Promise.all(promises);
 
@@ -406,11 +443,9 @@ async function syncBookEntities(db, bookId, bookTitle, bookAuthor, conceptIndex)
     ...conceptIndex.concepts.map(p => ({ name: p.term, type: 'concept' })),
   ];
   for (const { name, type } of allTerms) {
-    const entity = await db.collection('entities').findOne({ name, type });
+    const entity = await db.collection('entities').findOne({ name, type }, { projection: { books: 1 } });
     if (entity) {
-      const bookCount = entity.books?.length || 0;
-      const totalMentions = (entity.books || []).reduce((sum, b) => sum + (b.pages?.length || 0), 0);
-      await db.collection('entities').updateOne({ name, type }, { $set: { book_count: bookCount, total_mentions: totalMentions } });
+      await db.collection('entities').updateOne({ name, type }, { $set: entityCounters(entity.books) });
     }
   }
 }

--- a/scripts/lib/entity-page-match.mjs
+++ b/scripts/lib/entity-page-match.mjs
@@ -1,0 +1,227 @@
+/**
+ * Entity → page attribution.
+ *
+ * The index extractor (enrich-worker Phase 6, batch-generate-indexes) asks
+ * Gemini "who/what appears in these pages" over a ~50k-char BATCH and gets back
+ * bare name lists — no page numbers. Quotes carry a `page`; people/places/
+ * concepts never did. The old code filled that hole by crediting EVERY page in
+ * the batch's range with EVERY entity in the batch, and `/encyclopedia/[name]`
+ * rendered those inferred numbers as exact `p. N` citations. Measured on 30
+ * sampled entity-book pairs, only ~22% of claimed pages actually contained the
+ * name — i.e. most page citations on that surface were fabricated (#3361).
+ *
+ * So: we verify. The batch tells us WHICH entities are in a section; the page
+ * text tells us WHERE. An entity is attributed to a page only if that page's
+ * OCR or translation text actually names it. When no page in the batch matches
+ * (divergent spelling, entity named only in paraphrase, OCR too rough), we fall
+ * back to SECTION precision — `pages: []` plus a `page_range` — rather than
+ * guessing. A coarse true claim beats a precise false one.
+ *
+ * Matching is deliberately tolerant of how early-modern print actually reads:
+ * diacritics are stripped, Latin j/v are folded to i/u (Iohannes/Johannes,
+ * Vrbs/Urbs), and a token matches on its stem so case endings inflect freely
+ * (Matthiolus / Matthioli / Matthiolum). Tolerance costs recall in the safe
+ * direction only — a miss becomes section precision, never a false page cite.
+ */
+
+/** Longest trailing inflection we'll trim off a token to form its stem. */
+const MAX_TRIM = 2;
+/** Shortest stem we'll ever search for. */
+const STEM_MIN_LEN = 5;
+/**
+ * A token must be at least this long to be matched as a SUBSTRING (stemmed).
+ * Shorter tokens match only on word boundaries: measured on live data, stemming
+ * a 5-char token attributed "James Smart" to a page reading "smartly vibrated"
+ * and "Marcus Aurelius Antoninus" to a page naming his mother Aurelia.
+ */
+const SUBSTRING_MIN_LEN = 7;
+/** Tokens shorter than this are ignored entirely (too noisy as needles). */
+const MIN_TOKEN_LEN = 4;
+
+/**
+ * Honorifics, epithets and role words. These appear in entity names but carry
+ * no identity — matching on them attributed "Saint Perpetua" to every page of a
+ * liturgical calendar that mentioned any saint.
+ */
+const GENERIC_NAME_TOKENS = new Set([
+  'saint', 'sainte', 'santo', 'santa', 'abba', 'pope', 'papa', 'king', 'queen',
+  'emperor', 'empress', 'prince', 'princess', 'duke', 'duchess', 'count',
+  'countess', 'earl', 'lord', 'lady', 'father', 'mother', 'brother', 'sister',
+  'master', 'doctor', 'rabbi', 'imam', 'sheikh', 'bishop', 'archbishop',
+  'cardinal', 'priest', 'monk', 'friar', 'abbot', 'prophet', 'apostle',
+  'euangelist', 'evangelist', 'martyr', 'confessor', 'philosopher', 'philosophus',
+  'author', 'anonymous', 'unknown', 'elder', 'younger', 'junior', 'senior',
+  'blessed', 'venerable', 'sir', 'dame', 'madame', 'monsieur', 'herr',
+  'the', 'and', 'von', 'van', 'der', 'den', 'del', 'della', 'di', 'da', 'de',
+]);
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Fold text into the space where matches are compared: no diacritics, no case,
+ * Latin j→i and v→u. Applied identically to needle and haystack.
+ */
+export function normalizeForMatch(text) {
+  return String(text || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/j/g, 'i')
+    .replace(/v/g, 'u');
+}
+
+/**
+ * Build the needle set for an entity name. Returns { stems, patterns } — a page
+ * matches if ANY needle hits.
+ *
+ * Only the single most distinctive token of the name becomes a needle. Matching
+ * on every token is what produced the false positives above: a name's common
+ * parts ("Marcus", "James", "Saint") fire on unrelated text, and one bad needle
+ * is enough to fabricate a citation. The distinctive token is the longest one
+ * after stoplisting, breaking ties toward the last — Western surnames trail, and
+ * single-name figures have only one token anyway.
+ *
+ * Aliases are deliberately NOT used. The `entity_aliases` table carries generic
+ * epithets ("the philosopher", "Confessor") that match half the corpus. Losing
+ * an alias spelling costs recall, which degrades to section precision — safe.
+ */
+export function buildEntityMatcher(name) {
+  const stems = new Set();
+  const patterns = [];
+  const seenPatterns = new Set();
+
+  const addPattern = (phrase) => {
+    if (phrase.length < 2 || seenPatterns.has(phrase)) return;
+    seenPatterns.add(phrase);
+    patterns.push(new RegExp(`\\b${escapeRe(phrase)}\\b`));
+  };
+
+  const raw = Array.isArray(name) ? name[0] : name;
+  if (!raw || typeof raw !== 'string') return { stems: [], patterns: [] };
+
+  const norm = normalizeForMatch(raw);
+  const tokens = norm
+    .split(/[^a-z0-9]+/)
+    .filter(t => t.length >= MIN_TOKEN_LEN && !GENERIC_NAME_TOKENS.has(t));
+
+  if (tokens.length === 0) {
+    // Nothing distinctive to stem ("Job", "Ur", "Li Bo", "The Master") — only an
+    // exact whole-word hit on the full name counts.
+    addPattern(norm.replace(/[^a-z0-9]+/g, ' ').trim());
+    return { stems: [], patterns };
+  }
+
+  let anchor = tokens[0];
+  for (const token of tokens) {
+    if (token.length >= anchor.length) anchor = token;
+  }
+
+  if (anchor.length >= SUBSTRING_MIN_LEN) {
+    // Long enough that a prefix stem stays distinctive, so Latin case endings
+    // don't hide a real mention (Matthiolus / Matthioli / Matthiolum).
+    stems.add(anchor.slice(0, Math.max(STEM_MIN_LEN, anchor.length - MAX_TRIM)));
+  } else {
+    addPattern(anchor);
+  }
+
+  return { stems: [...stems], patterns };
+}
+
+/** Does this already-normalized page text name the entity? */
+export function pageMatchesEntity(matcher, normalizedPageText) {
+  for (const stem of matcher.stems) {
+    if (normalizedPageText.includes(stem)) return true;
+  }
+  for (const re of matcher.patterns) {
+    if (re.test(normalizedPageText)) return true;
+  }
+  return false;
+}
+
+/**
+ * Normalize a book's pages once, for reuse across every entity in the book.
+ * Both OCR and translation count as evidence: a Latin page names "Matthiolus"
+ * in the OCR, an English-only reader finds him in the translation.
+ */
+export function buildPageTexts(pages) {
+  return pages.map(p => ({
+    page_number: p.page_number,
+    norm: normalizeForMatch(`${p.ocr?.data || ''} ${p.translation?.data || ''}`),
+  }));
+}
+
+/**
+ * Attribute one entity to the pages that actually name it.
+ *
+ * `candidatePages` is the batch's own page set — the entity is known to be
+ * somewhere in there, so we never search the whole book and never invent a
+ * location outside the section Gemini actually read.
+ *
+ * Returns page precision with verified page numbers, or section precision with
+ * the range and no page numbers at all. Callers must not synthesize pages from
+ * a section range — that reintroduces #3361.
+ */
+export function attributeEntityPages(name, candidatePages) {
+  const matcher = buildEntityMatcher(name);
+  const matched = [];
+  for (const page of candidatePages) {
+    if (pageMatchesEntity(matcher, page.norm)) matched.push(page.page_number);
+  }
+
+  if (matched.length > 0) {
+    return { pages: matched.sort((a, b) => a - b), page_precision: 'page' };
+  }
+
+  const nums = candidatePages.map(p => p.page_number).filter(n => Number.isFinite(n));
+  if (nums.length === 0) return { pages: [], page_precision: 'section' };
+  return {
+    pages: [],
+    page_precision: 'section',
+    page_range: { start: Math.min(...nums), end: Math.max(...nums) },
+  };
+}
+
+/**
+ * Collapse an entity's per-book entries into the shape the read path trusts:
+ * one entry per book_id (the writer used to `$addToSet` whole subdocuments, so
+ * a re-run appended a second entry for the same book — Matthiolus carried 162
+ * entries for 117 distinct books, which is why the hero count and the "Appears
+ * in N Books" heading disagreed).
+ */
+export function dedupeEntityBooks(books) {
+  const byBook = new Map();
+  for (const entry of books || []) {
+    if (!entry?.book_id) continue;
+    const prev = byBook.get(entry.book_id);
+    if (!prev) {
+      byBook.set(entry.book_id, { ...entry, pages: [...(entry.pages || [])] });
+      continue;
+    }
+    // Merge: verified pages win over a section range, and page precision is
+    // sticky once any entry has it.
+    const pages = [...new Set([...(prev.pages || []), ...(entry.pages || [])])].sort((a, b) => a - b);
+    const precision = prev.page_precision === 'page' || entry.page_precision === 'page' || pages.length > 0
+      ? 'page'
+      : 'section';
+    const merged = { ...prev, ...entry, pages, page_precision: precision };
+    if (precision === 'page') delete merged.page_range;
+    else merged.page_range = prev.page_range || entry.page_range;
+    byBook.set(entry.book_id, merged);
+  }
+  return [...byBook.values()];
+}
+
+/**
+ * Canonical counters for an entity. `total_mentions` counts VERIFIED page
+ * references only — it used to be the sum of smeared page-array lengths, which
+ * is how Matthiolus came to advertise "10,700 total mentions".
+ */
+export function entityCounters(books) {
+  const deduped = dedupeEntityBooks(books);
+  return {
+    book_count: deduped.length,
+    total_mentions: deduped.reduce((sum, b) => sum + (b.pages?.length || 0), 0),
+  };
+}

--- a/scripts/maintenance/repair-entity-page-attribution.mjs
+++ b/scripts/maintenance/repair-entity-page-attribution.mjs
@@ -72,7 +72,33 @@ const client = new MongoClient(process.env.MONGODB_URI);
 await client.connect();
 const db = client.db('bookstore');
 
+/**
+ * Retry a Mongo op through transient network faults. A multi-hour sweep against
+ * Atlas will hit `read ECONNRESET` sooner or later — the first full run died on
+ * one after 250 books, losing nothing but needing a manual resume. Only retries
+ * transient transport errors; a genuine write error still throws.
+ */
+async function withRetry(label, fn, attempts = 5) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const msg = String(err?.message || err);
+      const transient = /ECONNRESET|ETIMEDOUT|EPIPE|socket hang up|connection .* closed|MongoNetworkError|not primary|PoolClearedError/i.test(msg);
+      if (!transient || i === attempts - 1) throw err;
+      const backoffMs = 1000 * 2 ** i;
+      console.warn(`  transient error on ${label} (attempt ${i + 1}/${attempts}): ${msg.slice(0, 120)} — retrying in ${backoffMs}ms`);
+      stats.transientRetries++;
+      await new Promise(r => setTimeout(r, backoffMs));
+    }
+  }
+  throw lastErr;
+}
+
 const stats = {
+  transientRetries: 0,
   booksScanned: 0,
   booksWithNoPages: 0,
   entityEntriesExamined: 0,
@@ -115,7 +141,7 @@ for await (const book of bookCursor) {
   // hundreds of book entries, so `projection: { books: 1 }` ships megabytes per
   // book and pins the sweep at 0.3% CPU waiting on the wire — measured at under
   // one book per minute before this change.
-  const entities = await db.collection('entities').aggregate([
+  const entities = await withRetry(`read entities for ${book.id}`, () => db.collection('entities').aggregate([
     { $match: { 'books.book_id': book.id } },
     {
       $project: {
@@ -129,12 +155,12 @@ for await (const book of bookCursor) {
         },
       },
     },
-  ]).toArray();
+  ]).toArray());
   if (entities.length === 0) continue;
 
-  const pages = await db.collection('pages')
+  const pages = await withRetry(`read pages for ${book.id}`, () => db.collection('pages')
     .find({ book_id: book.id }, { projection: { page_number: 1, 'ocr.data': 1, 'translation.data': 1 } })
-    .toArray();
+    .toArray());
 
   if (pages.length === 0) {
     stats.booksWithNoPages++;
@@ -237,8 +263,11 @@ for await (const book of bookCursor) {
 
   if (ops.length > 0) {
     // One self-contained op per entity, so order doesn't matter and the server
-    // is free to parallelize.
-    await db.collection('entities').bulkWrite(ops, { ordered: false });
+    // is free to parallelize. Each op is idempotent, so a retry after a partial
+    // failure re-applies safely.
+    await withRetry(`bulkWrite for ${book.id}`, () =>
+      db.collection('entities').bulkWrite(ops, { ordered: false })
+    );
   }
 
   logProgress({ book_id: book.id, entities: entities.length, ops: ops.length, at: new Date().toISOString() });
@@ -326,6 +355,7 @@ if (stats.pagesClaimedBefore > 0) {
   console.log(`unverifiable citations dropped: ${removed} (${(100 * removed / stats.pagesClaimedBefore).toFixed(1)}%)`);
 }
 console.log(`distinct entities touched:   ${stats.entitiesTouched.size}`);
+console.log(`transient errors retried:    ${stats.transientRetries}`);
 if (!DRY_RUN) console.log(`progress log: ${PROGRESS_FILE}`);
 
 await client.close();

--- a/scripts/maintenance/repair-entity-page-attribution.mjs
+++ b/scripts/maintenance/repair-entity-page-attribution.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Repair fabricated entity page citations (#3361).
+ *
+ * The index extractor credited every page in a ~50k-char batch range with every
+ * entity found anywhere in that batch, and `/encyclopedia/[name]` rendered those
+ * inferred numbers as exact `p. N` citations. Measured on live data, only
+ * ~14-22% of claimed pages actually contained the entity name.
+ *
+ * This sweep re-derives `entities.books[].pages` from the page text that is
+ * already stored — no Gemini calls, no cost. For each book it loads the page
+ * text once, then for every entity referencing that book keeps only the pages
+ * that actually name the entity. Where nothing matches, the entry drops to
+ * section precision (`pages: []` + `page_range`) instead of guessing.
+ *
+ * It also fixes two things that travelled with the same writer:
+ *   - duplicate `books[]` entries for one book (the writer `$addToSet`-ed whole
+ *     subdocuments, so re-runs appended instead of replacing)
+ *   - `book_count` / `total_mentions` computed from those duplicates and smeared
+ *     page arrays (one entity advertised "10,700 total mentions")
+ *
+ * RE-RUNNABLE BY DESIGN. Page numbering changes under us: a book re-split after
+ * indexing doubles its `page_number`s, so an entry correct today can be stale
+ * tomorrow. Nothing here depends on a previous run's state — it always recomputes
+ * from current page text — so re-running after a split sweep is the fix.
+ *
+ * SCOPE LIMIT — this removes fabrications, it does not build a complete
+ * concordance. Verification happens only within the pages the old entry already
+ * claimed (the batch range Gemini actually read), so a real mention elsewhere in
+ * the book stays unlisted: Matthiolus is named on pp. 44 and 100 of "Raphael
+ * Explaining the Art of Medicine" and this sweep restores p. 44 alone. Two
+ * reasons to keep it narrow. It stays inside the section a model actually
+ * assessed, so the model's judgment about WHICH "Paul" or "Faber" is meant still
+ * counts for something — a whole-book string sweep would replace that with bare
+ * lexical matching and cheerfully merge homonyms. And missing a page is a
+ * recall gap, whereas asserting one is a false citation; only the latter is a
+ * correctness bug. Building the fuller index is separate work.
+ *
+ * Usage:
+ *   node scripts/maintenance/repair-entity-page-attribution.mjs --dry-run
+ *   node scripts/maintenance/repair-entity-page-attribution.mjs --apply
+ *   node scripts/maintenance/repair-entity-page-attribution.mjs --apply --book-id <id>
+ *   node scripts/maintenance/repair-entity-page-attribution.mjs --apply --limit 500
+ *   node scripts/maintenance/repair-entity-page-attribution.mjs --apply --resume-from <bookId>
+ */
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+import {
+  buildPageTexts,
+  attributeEntityPages,
+  entityCounters,
+} from '../lib/entity-page-match.mjs';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const DRY_RUN = !APPLY;
+const getArg = (flag) => {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : null;
+};
+const ONLY_BOOK = getArg('--book-id');
+const LIMIT = Number(getArg('--limit') || 0);
+const RESUME_FROM = getArg('--resume-from');
+const PROGRESS_FILE = getArg('--progress-file')
+  || 'scripts/output/repair-entity-page-attribution-progress.jsonl';
+
+if (!process.env.MONGODB_URI) {
+  console.error('MONGODB_URI not set. Run with: set -a; source .env.production.local; set +a; node ...');
+  process.exit(1);
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+const stats = {
+  booksScanned: 0,
+  booksWithNoPages: 0,
+  entityEntriesExamined: 0,
+  entriesNowPagePrecision: 0,
+  entriesNowSection: 0,
+  entriesUnchanged: 0,
+  duplicateEntriesCollapsed: 0,
+  pagesClaimedBefore: 0,
+  pagesClaimedAfter: 0,
+  entitiesTouched: new Set(),
+};
+
+// Append-only progress log, so a killed run can resume without redoing work and
+// a stray `git reset` in a worktree can't silently erase what was done.
+fs.mkdirSync(PROGRESS_FILE.replace(/\/[^/]+$/, ''), { recursive: true });
+const logProgress = (row) => {
+  if (DRY_RUN) return;
+  fs.appendFileSync(PROGRESS_FILE, JSON.stringify(row) + '\n');
+};
+
+const bookFilter = ONLY_BOOK
+  ? { id: ONLY_BOOK }
+  : { index: { $exists: true }, ...(RESUME_FROM ? { id: { $gt: RESUME_FROM } } : {}) };
+
+const bookCursor = db.collection('books')
+  .find(bookFilter, { projection: { id: 1, title: 1, display_title: 1 } })
+  .sort({ id: 1 });
+
+let processed = 0;
+for await (const book of bookCursor) {
+  if (LIMIT && processed >= LIMIT) break;
+  processed++;
+  stats.booksScanned++;
+
+  // Every entity that claims this book. If none, there is nothing to repair.
+  const entities = await db.collection('entities')
+    .find({ 'books.book_id': book.id }, { projection: { name: 1, type: 1, books: 1 } })
+    .toArray();
+  if (entities.length === 0) continue;
+
+  const pages = await db.collection('pages')
+    .find({ book_id: book.id }, { projection: { page_number: 1, 'ocr.data': 1, 'translation.data': 1 } })
+    .toArray();
+
+  if (pages.length === 0) {
+    stats.booksWithNoPages++;
+    // No text to verify against. Leave the entries alone rather than deleting
+    // evidence — a book can be mid-reprocess. Read path already demotes
+    // unmarked entries to section precision.
+    continue;
+  }
+
+  const pageTexts = buildPageTexts(pages);
+  const pageTextsByNumber = new Map(pageTexts.map(p => [p.page_number, p]));
+  const ops = [];
+
+  for (const entity of entities) {
+    const ownEntries = (entity.books || []).filter(b => b.book_id === book.id);
+    if (ownEntries.length === 0) continue;
+    if (ownEntries.length > 1) stats.duplicateEntriesCollapsed += ownEntries.length - 1;
+    stats.entityEntriesExamined++;
+
+    // Candidate window = the union of pages the old entry claimed, which is the
+    // batch range Gemini actually read. Staying inside it means we never invent
+    // a location in a section the model never saw. Fall back to the whole book
+    // only when the claim is empty (nothing to narrow from).
+    const claimed = [...new Set(ownEntries.flatMap(e => e.pages || []))].sort((a, b) => a - b);
+    stats.pagesClaimedBefore += claimed.length;
+
+    const candidates = claimed.length > 0
+      ? claimed.map(n => pageTextsByNumber.get(n)).filter(Boolean)
+      : pageTexts;
+
+    // If the claimed pages no longer exist (book re-split/renumbered), we cannot
+    // verify anything — mark section over the claimed span and move on.
+    if (candidates.length === 0) {
+      stats.entriesNowSection++;
+      const base = ownEntries[0];
+      const repaired = {
+        book_id: book.id,
+        book_title: base.book_title,
+        book_author: base.book_author,
+        ...(base.book_year ? { book_year: base.book_year } : {}),
+        pages: [],
+        page_precision: 'section',
+        ...(claimed.length > 0
+          ? { page_range: { start: claimed[0], end: claimed[claimed.length - 1] } }
+          : {}),
+      };
+      queueEntry(ops, entity, book.id, repaired);
+      continue;
+    }
+
+    const attribution = attributeEntityPages(entity.name, candidates);
+    const base = ownEntries[0];
+    const repaired = {
+      book_id: book.id,
+      book_title: base.book_title,
+      book_author: base.book_author,
+      ...(base.book_year ? { book_year: base.book_year } : {}),
+      pages: attribution.pages,
+      page_precision: attribution.page_precision,
+      ...(attribution.page_range ? { page_range: attribution.page_range } : {}),
+    };
+
+    stats.pagesClaimedAfter += repaired.pages.length;
+    if (repaired.page_precision === 'page') stats.entriesNowPagePrecision++;
+    else stats.entriesNowSection++;
+
+    const sameShape =
+      ownEntries.length === 1 &&
+      base.page_precision === repaired.page_precision &&
+      JSON.stringify(base.pages || []) === JSON.stringify(repaired.pages);
+    if (sameShape) {
+      stats.entriesUnchanged++;
+      continue;
+    }
+
+    queueEntry(ops, entity, book.id, repaired);
+  }
+
+  if (ops.length > 0) {
+    // Ordered: each entity's $pull must land before its $push.
+    await db.collection('entities').bulkWrite(ops, { ordered: true });
+  }
+
+  logProgress({ book_id: book.id, entities: entities.length, ops: ops.length, at: new Date().toISOString() });
+
+  if (stats.booksScanned % 250 === 0) {
+    console.log(
+      `[${stats.booksScanned} books] entries: ${stats.entityEntriesExamined} ` +
+      `| page-precision ${stats.entriesNowPagePrecision} | section ${stats.entriesNowSection} ` +
+      `| page claims ${stats.pagesClaimedBefore} → ${stats.pagesClaimedAfter}`
+    );
+  }
+}
+
+/**
+ * Queue the replacement of one entity's entry for one book. Ops are collected
+ * per book and flushed as a single bulkWrite — three round trips per entity
+ * (pull, push, recount) put the full 19.6K-book sweep in the multi-day range.
+ *
+ * Uses $pull + $push rather than $set-ing the whole `books` array, so a
+ * concurrent writer touching a DIFFERENT book on the same entity isn't
+ * clobbered. Counters are computed from the known post-state, which is exact
+ * while the enrich pipeline is paused and self-corrects on the next re-run
+ * otherwise.
+ */
+function queueEntry(ops, entity, bookId, repaired) {
+  stats.entitiesTouched.add(entity._id.toString());
+  if (DRY_RUN) return;
+
+  const postState = [
+    ...(entity.books || []).filter(b => b.book_id !== bookId),
+    repaired,
+  ];
+
+  ops.push({
+    updateOne: {
+      filter: { _id: entity._id },
+      update: { $pull: { books: { book_id: bookId } } },
+    },
+  });
+  ops.push({
+    updateOne: {
+      filter: { _id: entity._id },
+      update: {
+        $push: { books: repaired },
+        $set: { ...entityCounters(postState), updated_at: new Date() },
+      },
+    },
+  });
+}
+
+console.log('\n=== repair-entity-page-attribution ===');
+console.log(DRY_RUN ? 'MODE: dry run (no writes)' : 'MODE: APPLIED');
+console.log(`books scanned:               ${stats.booksScanned}`);
+console.log(`books with no page text:     ${stats.booksWithNoPages}`);
+console.log(`entity-book entries:         ${stats.entityEntriesExamined}`);
+console.log(`  → page precision:          ${stats.entriesNowPagePrecision}`);
+console.log(`  → section precision:       ${stats.entriesNowSection}`);
+console.log(`  → unchanged:               ${stats.entriesUnchanged}`);
+console.log(`duplicate entries collapsed: ${stats.duplicateEntriesCollapsed}`);
+console.log(`page citations claimed:      ${stats.pagesClaimedBefore} → ${stats.pagesClaimedAfter}`);
+const removed = stats.pagesClaimedBefore - stats.pagesClaimedAfter;
+if (stats.pagesClaimedBefore > 0) {
+  console.log(`unverifiable citations dropped: ${removed} (${(100 * removed / stats.pagesClaimedBefore).toFixed(1)}%)`);
+}
+console.log(`distinct entities touched:   ${stats.entitiesTouched.size}`);
+if (!DRY_RUN) console.log(`progress log: ${PROGRESS_FILE}`);
+
+await client.close();

--- a/scripts/maintenance/repair-entity-page-attribution.mjs
+++ b/scripts/maintenance/repair-entity-page-attribution.mjs
@@ -48,7 +48,6 @@ import fs from 'fs';
 import {
   buildPageTexts,
   attributeEntityPages,
-  entityCounters,
 } from '../lib/entity-page-match.mjs';
 
 const args = process.argv.slice(2);
@@ -80,6 +79,7 @@ const stats = {
   entriesNowPagePrecision: 0,
   entriesNowSection: 0,
   entriesUnchanged: 0,
+  entriesNoWindow: 0,
   duplicateEntriesCollapsed: 0,
   pagesClaimedBefore: 0,
   pagesClaimedAfter: 0,
@@ -109,9 +109,27 @@ for await (const book of bookCursor) {
   stats.booksScanned++;
 
   // Every entity that claims this book. If none, there is nothing to repair.
-  const entities = await db.collection('entities')
-    .find({ 'books.book_id': book.id }, { projection: { name: 1, type: 1, books: 1 } })
-    .toArray();
+  //
+  // Project ONLY this book's entries via $filter, never the whole `books` array.
+  // A popular book is referenced by ~900 entities, and a common concept carries
+  // hundreds of book entries, so `projection: { books: 1 }` ships megabytes per
+  // book and pins the sweep at 0.3% CPU waiting on the wire — measured at under
+  // one book per minute before this change.
+  const entities = await db.collection('entities').aggregate([
+    { $match: { 'books.book_id': book.id } },
+    {
+      $project: {
+        name: 1,
+        type: 1,
+        books: {
+          $filter: {
+            input: { $ifNull: ['$books', []] },
+            cond: { $eq: ['$$this.book_id', book.id] },
+          },
+        },
+      },
+    },
+  ]).toArray();
   if (entities.length === 0) continue;
 
   const pages = await db.collection('pages')
@@ -136,16 +154,38 @@ for await (const book of bookCursor) {
     if (ownEntries.length > 1) stats.duplicateEntriesCollapsed += ownEntries.length - 1;
     stats.entityEntriesExamined++;
 
-    // Candidate window = the union of pages the old entry claimed, which is the
+    // Candidate window = the pages this entry already points at, which is the
     // batch range Gemini actually read. Staying inside it means we never invent
-    // a location in a section the model never saw. Fall back to the whole book
-    // only when the claim is empty (nothing to narrow from).
+    // a location in a section the model never saw.
+    //
+    // A section-precision entry has an EMPTY `pages` array, so its window has to
+    // come from `page_range`. Falling back to the whole book here is what made
+    // the first version non-idempotent: on a second pass, every section entry
+    // got re-scanned across all pages and converted back to page precision with
+    // matches the model never saw — a re-run that ADDED 8% more citations. If
+    // there is no window at all, leave the entry alone.
     const claimed = [...new Set(ownEntries.flatMap(e => e.pages || []))].sort((a, b) => a - b);
     stats.pagesClaimedBefore += claimed.length;
 
-    const candidates = claimed.length > 0
-      ? claimed.map(n => pageTextsByNumber.get(n)).filter(Boolean)
-      : pageTexts;
+    let window = claimed;
+    if (window.length === 0) {
+      const ranges = ownEntries.map(e => e.page_range).filter(Boolean);
+      if (ranges.length > 0) {
+        const start = Math.min(...ranges.map(r => r.start));
+        const end = Math.max(...ranges.map(r => r.end));
+        window = [];
+        for (let n = start; n <= end; n++) window.push(n);
+      }
+    }
+
+    if (window.length === 0) {
+      // Nothing claimed and no range — no evidence to re-verify against.
+      stats.entriesNoWindow++;
+      stats.entriesUnchanged++;
+      continue;
+    }
+
+    const candidates = window.map(n => pageTextsByNumber.get(n)).filter(Boolean);
 
     // If the claimed pages no longer exist (book re-split/renumbered), we cannot
     // verify anything — mark section over the claimed span and move on.
@@ -159,9 +199,9 @@ for await (const book of bookCursor) {
         ...(base.book_year ? { book_year: base.book_year } : {}),
         pages: [],
         page_precision: 'section',
-        ...(claimed.length > 0
-          ? { page_range: { start: claimed[0], end: claimed[claimed.length - 1] } }
-          : {}),
+        // Keep the span from the window (claimed pages, or an existing
+        // page_range) so a re-run still has something to narrow from.
+        page_range: { start: window[0], end: window[window.length - 1] },
       };
       queueEntry(ops, entity, book.id, repaired);
       continue;
@@ -196,8 +236,9 @@ for await (const book of bookCursor) {
   }
 
   if (ops.length > 0) {
-    // Ordered: each entity's $pull must land before its $push.
-    await db.collection('entities').bulkWrite(ops, { ordered: true });
+    // One self-contained op per entity, so order doesn't matter and the server
+    // is free to parallelize.
+    await db.collection('entities').bulkWrite(ops, { ordered: false });
   }
 
   logProgress({ book_id: book.id, entities: entities.length, ops: ops.length, at: new Date().toISOString() });
@@ -213,37 +254,59 @@ for await (const book of bookCursor) {
 
 /**
  * Queue the replacement of one entity's entry for one book. Ops are collected
- * per book and flushed as a single bulkWrite — three round trips per entity
- * (pull, push, recount) put the full 19.6K-book sweep in the multi-day range.
+ * per book and flushed as a single bulkWrite.
  *
- * Uses $pull + $push rather than $set-ing the whole `books` array, so a
- * concurrent writer touching a DIFFERENT book on the same entity isn't
- * clobbered. Counters are computed from the known post-state, which is exact
- * while the enrich pipeline is paused and self-corrects on the next re-run
- * otherwise.
+ * Expressed as an aggregation-pipeline update so the whole operation runs
+ * server-side and the `books` array never crosses the wire in either direction:
+ * drop every entry for this book (collapsing duplicates), append the repaired
+ * one, then recount from the result. Shipping the array back to recompute
+ * counters in JS is what made the first attempt I/O-bound.
+ *
+ * Rebuilding `books` in one pipeline also means a concurrent writer touching a
+ * DIFFERENT book on the same entity is preserved — $filter keeps every entry
+ * whose book_id isn't ours, whatever it looks like.
  */
 function queueEntry(ops, entity, bookId, repaired) {
   stats.entitiesTouched.add(entity._id.toString());
   if (DRY_RUN) return;
 
-  const postState = [
-    ...(entity.books || []).filter(b => b.book_id !== bookId),
-    repaired,
-  ];
-
   ops.push({
     updateOne: {
       filter: { _id: entity._id },
-      update: { $pull: { books: { book_id: bookId } } },
-    },
-  });
-  ops.push({
-    updateOne: {
-      filter: { _id: entity._id },
-      update: {
-        $push: { books: repaired },
-        $set: { ...entityCounters(postState), updated_at: new Date() },
-      },
+      update: [
+        {
+          $set: {
+            books: {
+              $concatArrays: [
+                {
+                  $filter: {
+                    input: { $ifNull: ['$books', []] },
+                    cond: { $ne: ['$$this.book_id', bookId] },
+                  },
+                },
+                [repaired],
+              ],
+            },
+          },
+        },
+        {
+          $set: {
+            // Mirrors entityCounters() in scripts/lib/entity-page-match.mjs:
+            // distinct books (one entry each after the rebuild above) and
+            // VERIFIED page references only.
+            book_count: { $size: '$books' },
+            total_mentions: {
+              $sum: {
+                $map: {
+                  input: '$books',
+                  in: { $size: { $ifNull: ['$$this.pages', []] } },
+                },
+              },
+            },
+            updated_at: new Date(),
+          },
+        },
+      ],
     },
   });
 }

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -41,6 +41,7 @@ import { createBookRevisions } from './lib/book-revisions.mjs';
 import { buildSummaryPrompt, SUMMARY_GEN_CONFIG } from './lib/summary-prompt.mjs';
 import { createClient } from '@supabase/supabase-js';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
+import { buildPageTexts, attributeEntityPages, entityCounters } from '../lib/entity-page-match.mjs';
 
 // Selective-unpause scope confinement, set in main() after the pause check.
 // Empty {} in normal operation so the full enrich queue is unaffected.
@@ -538,23 +539,47 @@ function buildConceptIndexFromBatches(batches, pages) {
   const placesMap = new Map();
   const conceptsMap = new Map();
 
+  // Gemini returns bare name lists per batch — it is never asked WHERE in the
+  // batch each name occurs (only `quotes` carry a page). So the batch tells us
+  // which entities are in a section, and the page text tells us where. Crediting
+  // the whole batch range to every entity — the old behavior — fabricated page
+  // citations on /encyclopedia/[name] (#3361). Attribute per verified page, and
+  // fall back to a section range with NO page numbers when nothing matches.
+  const pagesByNumber = new Map(pages.map(p => [p.page_number, p]));
+
+  const accumulate = (map, term, batchPageTexts) => {
+    if (!term) return;
+    const attribution = attributeEntityPages(term, batchPageTexts);
+    const prev = map.get(term);
+    if (!prev) {
+      map.set(term, attribution);
+      return;
+    }
+    // Same entity in more than one batch: union verified pages; a section-only
+    // batch never contributes page numbers, but widens the fallback range.
+    const pages_ = [...new Set([...prev.pages, ...attribution.pages])].sort((a, b) => a - b);
+    const ranges = [prev.page_range, attribution.page_range].filter(Boolean);
+    const merged = { pages: pages_, page_precision: pages_.length > 0 ? 'page' : 'section' };
+    if (merged.page_precision === 'section' && ranges.length > 0) {
+      merged.page_range = {
+        start: Math.min(...ranges.map(r => r.start)),
+        end: Math.max(...ranges.map(r => r.end)),
+      };
+    }
+    map.set(term, merged);
+  };
+
   for (const batch of batches) {
-    const pageNumbers = Array.from(
-      { length: batch.pageRange.end - batch.pageRange.start + 1 },
-      (_, i) => batch.pageRange.start + i
-    );
-    for (const person of batch.people) {
-      if (!peopleMap.has(person)) peopleMap.set(person, []);
-      peopleMap.get(person).push(...pageNumbers);
+    const batchPages = [];
+    for (let n = batch.pageRange.start; n <= batch.pageRange.end; n++) {
+      const p = pagesByNumber.get(n);
+      if (p) batchPages.push(p);
     }
-    for (const place of batch.places) {
-      if (!placesMap.has(place)) placesMap.set(place, []);
-      placesMap.get(place).push(...pageNumbers);
-    }
-    for (const concept of batch.concepts) {
-      if (!conceptsMap.has(concept)) conceptsMap.set(concept, []);
-      conceptsMap.get(concept).push(...pageNumbers);
-    }
+    const batchPageTexts = buildPageTexts(batchPages);
+
+    for (const person of batch.people) accumulate(peopleMap, person, batchPageTexts);
+    for (const place of batch.places) accumulate(placesMap, place, batchPageTexts);
+    for (const concept of batch.concepts) accumulate(conceptsMap, concept, batchPageTexts);
   }
 
   // Vocabulary + keywords from page tags
@@ -576,17 +601,25 @@ function buildConceptIndexFromBatches(batches, pages) {
     }
   }
 
+  // vocabulary/keywords come straight from per-page tags, so their page numbers
+  // were always page-exact — no verification needed.
   const mapToEntries = (map) =>
     Array.from(map.entries())
-      .map(([term, pgs]) => ({ term, pages: [...new Set(pgs)].sort((a, b) => a - b) }))
+      .map(([term, pgs]) => ({ term, pages: [...new Set(pgs)].sort((a, b) => a - b), page_precision: 'page' }))
+      .sort((a, b) => b.pages.length - a.pages.length);
+
+  // people/places/concepts carry a verified attribution object.
+  const attributionToEntries = (map) =>
+    Array.from(map.entries())
+      .map(([term, attribution]) => ({ term, ...attribution }))
       .sort((a, b) => b.pages.length - a.pages.length);
 
   return {
     vocabulary: mapToEntries(vocabMap),
     keywords: mapToEntries(keywordMap),
-    people: mapToEntries(peopleMap),
-    places: mapToEntries(placesMap),
-    concepts: mapToEntries(conceptsMap),
+    people: attributionToEntries(peopleMap),
+    places: attributionToEntries(placesMap),
+    concepts: attributionToEntries(conceptsMap),
   };
 }
 
@@ -877,39 +910,54 @@ async function syncBookEntities(db, bookId, bookTitle, bookAuthor, conceptIndex,
 
   const now = new Date();
 
-  async function syncEntity(term, type, pages) {
+  async function syncEntity(term, type, entry) {
     const canonicalName = resolve(term, type);
-    const update = {
-      $set: { updated_at: now },
-      $setOnInsert: { name: canonicalName, type, created_at: now },
-      $addToSet: {
-        books: {
-          book_id: bookId,
-          book_title: bookTitle,
-          book_author: bookAuthor,
-          ...(bookYear ? { book_year: bookYear } : {}),
-          pages,
-        },
-      },
+    const bookEntry = {
+      book_id: bookId,
+      book_title: bookTitle,
+      book_author: bookAuthor,
+      ...(bookYear ? { book_year: bookYear } : {}),
+      pages: entry.pages || [],
+      page_precision: entry.page_precision || 'section',
+      ...(entry.page_range ? { page_range: entry.page_range } : {}),
     };
-    if (term !== canonicalName) {
-      update.$addToSet.aliases = term;
-    }
-    await db.collection('entities').updateOne({ name: canonicalName, type }, update, { upsert: true });
+
+    // Replace this book's entry rather than adding one. `$addToSet` compares
+    // whole subdocuments, so re-running the index with a different page list
+    // appended a SECOND entry for the same book — Matthiolus accumulated 162
+    // entries for 117 distinct books, and the page's hero count (books.length)
+    // disagreed with its own deduped "Appears in N Books" heading (#3361).
+    await db.collection('entities').updateOne(
+      { name: canonicalName, type },
+      {
+        $set: { updated_at: now },
+        $setOnInsert: { name: canonicalName, type, created_at: now },
+        ...(term !== canonicalName ? { $addToSet: { aliases: term } } : {}),
+      },
+      { upsert: true }
+    );
+    await db.collection('entities').updateOne(
+      { name: canonicalName, type },
+      { $pull: { books: { book_id: bookId } } }
+    );
+    await db.collection('entities').updateOne(
+      { name: canonicalName, type },
+      { $push: { books: bookEntry } }
+    );
   }
 
   const promises = [];
   for (const person of conceptIndex.people) {
     if (!person.term) continue;
-    promises.push(syncEntity(person.term, 'person', person.pages));
+    promises.push(syncEntity(person.term, 'person', person));
   }
   for (const place of conceptIndex.places) {
     if (!place.term) continue;
-    promises.push(syncEntity(place.term, 'place', place.pages));
+    promises.push(syncEntity(place.term, 'place', place));
   }
   for (const concept of conceptIndex.concepts) {
     if (!concept.term) continue;
-    promises.push(syncEntity(concept.term, 'concept', concept.pages));
+    promises.push(syncEntity(concept.term, 'concept', concept));
   }
   await Promise.all(promises);
 
@@ -922,11 +970,15 @@ async function syncBookEntities(db, bookId, bookTitle, bookAuthor, conceptIndex,
   const uniqueTerms = [...new Map(allTerms.map(t => [`${t.type}:${t.name}`, t])).values()];
 
   for (const { name, type } of uniqueTerms) {
-    const entity = await db.collection('entities').findOne({ name, type });
+    const entity = await db.collection('entities').findOne({ name, type }, { projection: { books: 1 } });
     if (entity) {
-      const bookCount = entity.books?.length || 0;
-      const totalMentions = (entity.books || []).reduce((sum, b) => sum + (b.pages?.length || 0), 0);
-      await db.collection('entities').updateOne({ name, type }, { $set: { book_count: bookCount, total_mentions: totalMentions } });
+      // book_count counts DISTINCT books and total_mentions counts VERIFIED page
+      // references. Summing raw page-array lengths is how Matthiolus came to
+      // advertise "10,700 total mentions" of smeared page slots (#3361).
+      await db.collection('entities').updateOne(
+        { name, type },
+        { $set: entityCounters(entity.books) }
+      );
     }
   }
 

--- a/src/app/api/entities/route.ts
+++ b/src/app/api/entities/route.ts
@@ -4,6 +4,13 @@ import { supabase } from '@/lib/supabase';
 import { withAuth } from '@/lib/auth-helpers';
 import { loadAliasResolver } from '@/lib/entity-aliases';
 import { buildEntityListJsonLd } from '@/lib/jsonld';
+import {
+  dedupeEntityBooks,
+  entityCounters,
+  normalizeEntityBook,
+  type EntityBookRef,
+  type EntityPagePrecision,
+} from '@/lib/entity-books';
 
 export interface Entity {
   _id?: string;
@@ -12,12 +19,7 @@ export interface Entity {
   aliases?: string[];
   description?: string;
   wikipedia_url?: string;
-  books: Array<{
-    book_id: string;
-    book_title: string;
-    book_author: string;
-    pages: number[];
-  }>;
+  books: EntityBookRef[];
   total_mentions: number;
   book_count: number;
   created_at: Date;
@@ -166,7 +168,7 @@ export const POST = withAuth(async (request, session) => {
       name: string;
       type: Entity['type'];
       variantNames: Set<string>;
-      books: Map<string, { book_id: string; book_title: string; book_author: string; pages: number[] }>;
+      books: Map<string, EntityBookRef>;
     }>();
 
     const addToEntityMap = (
@@ -175,7 +177,12 @@ export const POST = withAuth(async (request, session) => {
       bookId: string,
       bookTitle: string,
       bookAuthor: string,
-      pages: number[]
+      pages: number[],
+      // Carried through from the book's index. An index entry written before
+      // #3361 has no marker and an unverified (batch-smeared) page array —
+      // normalizeEntityBook demotes those to section precision rather than
+      // letting this route launder them back into page citations.
+      indexEntry?: { page_precision?: EntityPagePrecision; page_range?: { start: number; end: number } }
     ) => {
       // Resolve alias to canonical name
       const canonicalName = aliasResolver.resolve(term, type);
@@ -195,13 +202,19 @@ export const POST = withAuth(async (request, session) => {
         entity.variantNames.add(term);
       }
       // Merge book data — combine pages if same book appears via different variants
+      const incoming = normalizeEntityBook({
+        book_id: bookId,
+        book_title: bookTitle,
+        book_author: bookAuthor,
+        pages,
+        page_precision: indexEntry?.page_precision,
+        page_range: indexEntry?.page_range,
+      });
       const existing = entity.books.get(bookId);
-      if (existing) {
-        const allPages = [...new Set([...existing.pages, ...pages])].sort((a, b) => a - b);
-        entity.books.set(bookId, { ...existing, pages: allPages });
-      } else {
-        entity.books.set(bookId, { book_id: bookId, book_title: bookTitle, book_author: bookAuthor, pages });
-      }
+      entity.books.set(
+        bookId,
+        existing ? dedupeEntityBooks([existing, incoming])[0] : incoming
+      );
     };
 
     for (const book of books) {
@@ -211,17 +224,17 @@ export const POST = withAuth(async (request, session) => {
 
       for (const person of (book.index?.people || [])) {
         if (!person.term) continue;
-        addToEntityMap(person.term, 'person', bookId, bookTitle, bookAuthor, person.pages || []);
+        addToEntityMap(person.term, 'person', bookId, bookTitle, bookAuthor, person.pages || [], person);
       }
 
       for (const place of (book.index?.places || [])) {
         if (!place.term) continue;
-        addToEntityMap(place.term, 'place', bookId, bookTitle, bookAuthor, place.pages || []);
+        addToEntityMap(place.term, 'place', bookId, bookTitle, bookAuthor, place.pages || [], place);
       }
 
       for (const concept of (book.index?.concepts || [])) {
         if (!concept.term) continue;
-        addToEntityMap(concept.term, 'concept', bookId, bookTitle, bookAuthor, concept.pages || []);
+        addToEntityMap(concept.term, 'concept', bookId, bookTitle, bookAuthor, concept.pages || [], concept);
       }
     }
 
@@ -233,15 +246,13 @@ export const POST = withAuth(async (request, session) => {
     let merged = 0;
     for (const [key, data] of entityMap) {
       const booksArray = Array.from(data.books.values());
-      const totalMentions = booksArray.reduce((sum, b) => sum + b.pages.length, 0);
 
       // Build update — merge variant names into aliases without overwriting manual aliases
       const updateSet: Record<string, unknown> = {
         name: data.name,
         type: data.type,
         books: booksArray,
-        total_mentions: totalMentions,
-        book_count: booksArray.length,
+        ...entityCounters(booksArray),
         updated_at: now,
       };
 

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -445,11 +445,15 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
               </Link>
             )}
             {encyclopediaEntity && (
+              // Says where it goes. This page lists what the author WROTE; the
+              // encyclopedia entry lists books that mention them — a different
+              // frame, and "Encyclopedia entry" sitting beside "Artist page" read
+              // as more of the same, so readers clicked expecting works (#3361).
               <Link
                 href={`/encyclopedia/${encodeURIComponent(encyclopediaEntity.name)}`}
                 className="inline-block px-3 py-1.5 text-sm bg-accent-rust/20 text-accent-gold hover:bg-accent-rust/30 rounded-full transition-colors"
               >
-                Encyclopedia entry
+                Mentions in other books
               </Link>
             )}
             {wikipediaUrl && (

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -3,6 +3,12 @@ import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import EntitySchema from '@/components/seo/EntitySchema';
+import {
+  dedupeEntityBooks,
+  entityCounters,
+  normalizeEntityBook,
+  type EntityBookRef,
+} from '@/lib/entity-books';
 
 // ISR: 24h background revalidation
 export const revalidate = 86400;
@@ -107,6 +113,10 @@ export const getEntity = cache(async (name: string) => {
     const birthDate = entity.wikidata_birth_date as string | undefined;
     const deathDate = entity.wikidata_death_date as string | undefined;
 
+    const books = dedupeEntityBooks(
+      ((entity.books || []) as EntityBookRef[]).map(normalizeEntityBook)
+    );
+
     // Fetch related entities (same books)
     const bookIds = entity.books?.map((b: { book_id: string }) => b.book_id) || [];
     const related = bookIds.length > 0
@@ -132,9 +142,13 @@ export const getEntity = cache(async (name: string) => {
       wikidata_birth_date: birthDate,
       wikidata_death_date: deathDate,
       wikidata_coordinates: entity.wikidata_coordinates as { lat: number; lng: number } | undefined,
-      books: (entity.books || []) as Array<{ book_id: string; book_title: string; book_author: string; pages: number[] }>,
-      total_mentions: (entity.total_mentions || 0) as number,
-      book_count: (entity.book_count || 0) as number,
+      // Dedupe + normalize on read. Legacy rows have duplicate entries per book
+      // and an unverified `pages` array (the old smeared batch range), so both
+      // the list and the counters are derived here rather than trusted from the
+      // stored fields — otherwise the hero count contradicts the body heading
+      // and the page renders fabricated `p. N` citations (#3361).
+      books,
+      ...entityCounters(books),
       related: related.map(r => ({
         _id: (r._id as ObjectId).toString(),
         name: r.name as string,

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -87,6 +87,104 @@ export const getSharedBooks = cache(async (name: string): Promise<SharedConnecti
   }
 });
 
+export interface AuthoredWork {
+  id: string;
+  slug?: string;
+  title: string;
+  display_title?: string;
+  author?: string;
+  year?: number;
+  published?: string;
+  language?: string;
+  pages_count?: number;
+  thumbnail?: string | null;
+  thumbnail_blob?: string | null;
+  image_display?: string | null;
+  image_thumb?: string | null;
+}
+
+/**
+ * Books this person WROTE that the library holds — distinct from the books that
+ * merely mention them, which is what the rest of this page is about.
+ *
+ * The page previously showed "Appears in 117 Books" for Matthiolus and none of
+ * the 4 editions of his own Dioscorides commentary that we hold, with no link to
+ * his author page. A reader arriving on a famous author's entry expects his
+ * works first (#3361).
+ *
+ * Resolution is by FOREIGN KEY only — `books.author_id` → `authors._id` (the
+ * canonical thesaurus, see CLAUDE.md) and the transitional
+ * `books.author_entity_id`. Deliberately NOT by name or alias: books store
+ * "Pietro Andrea Mattioli" while the entity is named "Matthiolus", so a name
+ * match returns nothing here, and matching the alias list would attach wrong
+ * books to an author — the same false-claim shape as a fabricated page cite,
+ * since `entity_aliases` carries generic epithets.
+ */
+export const getAuthoredWorks = cache(async (
+  entityId: string,
+  wikidataId?: string,
+  entityName?: string
+): Promise<{ works: AuthoredWork[]; total: number; authorSlug: string | null }> => {
+  try {
+    const db = await getReadDb();
+
+    const orClauses: Record<string, unknown>[] = [{ author_entity_id: entityId }];
+
+    // Canonical authors layer: match on a shared authority id, never on a name.
+    // `authors._id` is the canonical author SLUG (a string), not an ObjectId.
+    const authorDoc = await db.collection<{ _id: string; wikidata_id?: string }>('authors').findOne(
+      {
+        $or: [
+          ...(wikidataId ? [{ wikidata_id: wikidataId }] : []),
+          ...(entityName ? [{ _id: entityName.toLowerCase().replace(/\s+/g, '-') }] : []),
+        ],
+      },
+      { projection: { _id: 1 } }
+    );
+    // `authors._id` IS the canonical author slug, so it's the safe link target —
+    // deriving one from the entity name can point at a 404 (books here are filed
+    // under "Pietro Andrea Mattioli", the entity is "Matthiolus").
+    const authorSlug: string | null = typeof authorDoc?._id === 'string' ? authorDoc._id : null;
+    if (authorDoc?._id) orClauses.push({ author_id: authorDoc._id });
+
+    // Canonical "live" filter — same as every public surface.
+    const query = { $or: orClauses, visible: true, pages_count: { $gt: 0 } };
+
+    // Count separately from the capped fetch: the heading must state the real
+    // holding, not the size of the page's grid. Aristotle has more than the 24
+    // we render, and "24 works in the library" would be a made-up total.
+    const total = await db.collection('books').countDocuments(query);
+
+    const works = await db.collection('books')
+      .find(
+        query,
+        {
+          projection: {
+            id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1,
+            published: 1, language: 1, pages_count: 1,
+            thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1,
+          },
+        }
+      )
+      .sort({ year: 1 })
+      .limit(24)
+      .toArray();
+
+    // One book can match on both keys; dedupe on the public id.
+    const seen = new Set<string>();
+    const unique: AuthoredWork[] = [];
+    for (const w of works) {
+      const id = w.id as string;
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      unique.push(w as unknown as AuthoredWork);
+    }
+    return { works: unique, total, authorSlug };
+  } catch {
+    return { works: [], total: 0, authorSlug: null };
+  }
+});
+
 // Shared cached fetch — used by both layout (metadata/schema) and page (rendering)
 export const getEntity = cache(async (name: string) => {
   try {

--- a/src/app/encyclopedia/[name]/page.tsx
+++ b/src/app/encyclopedia/[name]/page.tsx
@@ -1,10 +1,13 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import Image from 'next/image';
 import { User, MapPin, Lightbulb, ExternalLink } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { ENTITY_TYPE_STYLES, ENTITY_TYPE_LABELS, type EntityType } from '@/lib/style-constants';
 import SignUpCTA from '@/components/auth/SignUpCTA';
-import { getEntity, getSharedBooks } from './layout';
+import { bookUrl } from '@/lib/slugify';
+import { getBookThumbnailUrl } from '@/lib/utils';
+import { getEntity, getSharedBooks, getAuthoredWorks } from './layout';
 
 const TYPE_ICONS = {
   person: User,
@@ -52,6 +55,16 @@ export default async function EntityDetailPage({
 
   const Icon = TYPE_ICONS[entity.type];
   const connections = await getSharedBooks(decodedName);
+
+  // Books this person WROTE (vs the books that mention them, below). Only people
+  // can have authored works, so don't spend a query on places and concepts.
+  const {
+    works: authoredWorks,
+    total: authoredTotal,
+    authorSlug: canonicalAuthorSlug,
+  } = entity.type === 'person'
+    ? await getAuthoredWorks(entity._id, entity.wikidata_id, entity.name)
+    : { works: [], total: 0, authorSlug: null };
 
   return (
     <div className="min-h-screen bg-stone-50">
@@ -106,6 +119,68 @@ export default async function EntityDetailPage({
       </div>
 
       <main className="max-w-5xl mx-auto px-4 py-8 space-y-8">
+        {/*
+          Works BY this person come first. Everything below is about books that
+          mention them — for an author we actually hold, that was a confusing
+          lead (#3361).
+        */}
+        {authoredWorks.length > 0 && (
+          <div className="bg-white rounded-lg border border-stone-200 p-6">
+            <div className="flex items-baseline justify-between gap-4 mb-4">
+              <div>
+                <h2 className="text-lg font-semibold text-stone-900">
+                  {authoredTotal === 1
+                    ? `1 work by ${entity.name} in the library`
+                    : `${authoredTotal} works by ${entity.name} in the library`}
+                </h2>
+                {authoredTotal > authoredWorks.length && (
+                  <p className="text-sm text-stone-500 mt-0.5">
+                    Showing {authoredWorks.length} — see the author page for all {authoredTotal}.
+                  </p>
+                )}
+              </div>
+              {canonicalAuthorSlug && (
+                <Link
+                  href={`/author/${canonicalAuthorSlug}`}
+                  className="shrink-0 text-sm text-accent-rust hover:text-accent-gold-dark"
+                >
+                  Author page →
+                </Link>
+              )}
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+              {authoredWorks.map((work) => {
+                const thumb = getBookThumbnailUrl(work);
+                return (
+                  <Link key={work.id} href={bookUrl(work)} className="group block">
+                    <div className="relative w-full aspect-[3/4] rounded overflow-hidden bg-stone-100 border border-stone-200">
+                      {thumb ? (
+                        <Image
+                          src={thumb}
+                          alt={work.display_title || work.title}
+                          fill
+                          className="object-cover group-hover:scale-105 transition-transform duration-300"
+                          sizes="(max-width: 640px) 45vw, (max-width: 768px) 30vw, 22vw"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center p-2 text-center text-[10px] text-stone-400">
+                          {work.display_title || work.title}
+                        </div>
+                      )}
+                    </div>
+                    <p className="mt-2 text-sm font-medium text-stone-900 line-clamp-2 group-hover:text-accent-rust transition-colors">
+                      {work.display_title || work.title}
+                    </p>
+                    <p className="text-xs text-stone-500 mt-0.5">
+                      {[work.year || work.published, work.language].filter(Boolean).join(' · ')}
+                    </p>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
         {/* Description */}
         {(entity.description || (entity.type === 'place' && entity.wikidata_coordinates)) && (
           <div className="bg-white rounded-lg border border-stone-200 p-6">

--- a/src/app/encyclopedia/[name]/page.tsx
+++ b/src/app/encyclopedia/[name]/page.tsx
@@ -47,19 +47,8 @@ export default async function EntityDetailPage({
     notFound();
   }
 
-  // Deduplicate books by book_id and merge page arrays
-  const booksMap = new Map<string, typeof entity.books[0]>();
-  for (const book of entity.books) {
-    if (booksMap.has(book.book_id)) {
-      const existing = booksMap.get(book.book_id)!;
-      // Merge page arrays (deduplicate page numbers too)
-      const mergedPages = Array.from(new Set([...existing.pages, ...book.pages])).sort((a, b) => a - b);
-      booksMap.set(book.book_id, { ...existing, pages: mergedPages });
-    } else {
-      booksMap.set(book.book_id, book);
-    }
-  }
-  const deduplicatedBooks = Array.from(booksMap.values());
+  // Already deduped and normalized in getEntity (src/lib/entity-books.ts).
+  const deduplicatedBooks = entity.books;
 
   const Icon = TYPE_ICONS[entity.type];
   const connections = await getSharedBooks(decodedName);
@@ -92,10 +81,24 @@ export default async function EntityDetailPage({
                   {formatLifespan(entity.wikidata_birth_date, entity.wikidata_death_date)}
                 </p>
               )}
+              {/*
+                Counts come from the deduped book list, so this row can't
+                contradict the "Appears in N Books" heading below. "Total
+                mentions" used to sum the smeared page arrays, which is how this
+                page came to advertise five-figure mention counts (#3361) — it
+                now counts page references we actually verified, and is omitted
+                when there are none rather than reading as a hard zero.
+              */}
               <div className="flex items-center gap-4 mt-4 text-sm text-stone-400">
                 <span>{entity.book_count} book{entity.book_count !== 1 ? 's' : ''}</span>
-                <span>&middot;</span>
-                <span>{entity.total_mentions} total mention{entity.total_mentions !== 1 ? 's' : ''}</span>
+                {entity.total_mentions > 0 && (
+                  <>
+                    <span>&middot;</span>
+                    <span>
+                      {entity.total_mentions} verified page reference{entity.total_mentions !== 1 ? 's' : ''}
+                    </span>
+                  </>
+                )}
               </div>
             </div>
           </div>
@@ -214,22 +217,40 @@ export default async function EntityDetailPage({
                   {book.book_title}
                 </Link>
                 <p className="text-sm text-stone-500 mt-0.5">{book.book_author}</p>
-                <div className="mt-2 flex flex-wrap gap-1">
-                  {book.pages.slice(0, 10).map((page) => (
+                {/*
+                  Page pills are citations, so only verified pages get one. A
+                  'section' entry means we know which stretch of the book
+                  discusses this entity but not the page — it links to the start
+                  of the range and says so, rather than minting a pill per page
+                  in the range (which is what made these pages ~78% wrong, #3361).
+                */}
+                {book.page_precision === 'page' && book.pages.length > 0 ? (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {book.pages.slice(0, 10).map((page) => (
+                      <Link
+                        key={page}
+                        href={`/book/${book.book_id}/page-number/${page}`}
+                        className="inline-block px-2 py-0.5 bg-stone-100 text-stone-600 text-xs rounded hover:bg-accent-gold/15 hover:text-accent-rust transition-colors"
+                      >
+                        p. {page}
+                      </Link>
+                    ))}
+                    {book.pages.length > 10 && (
+                      <span className="inline-block px-2 py-0.5 text-stone-400 text-xs">
+                        +{book.pages.length - 10} more pages
+                      </span>
+                    )}
+                  </div>
+                ) : book.page_range ? (
+                  <div className="mt-2">
                     <Link
-                      key={page}
-                      href={`/book/${book.book_id}/page-number/${page}`}
-                      className="inline-block px-2 py-0.5 bg-stone-100 text-stone-600 text-xs rounded hover:bg-accent-gold/15 hover:text-accent-rust transition-colors"
+                      href={`/book/${book.book_id}/page-number/${book.page_range.start}`}
+                      className="inline-block px-2 py-0.5 bg-stone-100 text-stone-500 text-xs rounded hover:bg-accent-gold/15 hover:text-accent-rust transition-colors"
                     >
-                      p. {page}
+                      discussed in pp. {book.page_range.start}–{book.page_range.end}
                     </Link>
-                  ))}
-                  {book.pages.length > 10 && (
-                    <span className="inline-block px-2 py-0.5 text-stone-400 text-xs">
-                      +{book.pages.length - 10} more pages
-                    </span>
-                  )}
-                </div>
+                  </div>
+                ) : null}
               </div>
             ))}
           </div>

--- a/src/lib/entity-books.ts
+++ b/src/lib/entity-books.ts
@@ -1,0 +1,84 @@
+/**
+ * Read-side twin of the entity-book helpers in
+ * `scripts/lib/entity-page-match.mjs` (the writer side). Parity is pinned by
+ * `tests/unit/entity-page-attribution.test.ts` — change both together.
+ *
+ * Why the read path needs them at all: `entities.books[]` accumulated duplicate
+ * entries per book for years (the writer used `$addToSet` on a whole
+ * subdocument, so a re-run appended rather than replaced), and the stored
+ * `book_count` / `total_mentions` were computed from those duplicates plus
+ * smeared page arrays. Deriving both from the deduped array on render means the
+ * page is self-consistent even where the repair sweep hasn't reached yet (#3361).
+ */
+
+export type EntityPagePrecision = 'page' | 'section';
+
+export interface EntityBookRef {
+  book_id: string;
+  book_title: string;
+  book_author: string;
+  book_year?: number;
+  pages: number[];
+  /**
+   * 'page' — every number in `pages` was verified against that page's text.
+   * 'section' — we know only which stretch of the book discusses the entity;
+   * `pages` is empty and `page_range` carries the span. Never synthesize page
+   * numbers from a range: that is exactly the bug this field exists to prevent.
+   */
+  page_precision?: EntityPagePrecision;
+  page_range?: { start: number; end: number };
+}
+
+/** One entry per book, with page lists merged. */
+export function dedupeEntityBooks(books: EntityBookRef[]): EntityBookRef[] {
+  const byBook = new Map<string, EntityBookRef>();
+  for (const entry of books || []) {
+    if (!entry?.book_id) continue;
+    const prev = byBook.get(entry.book_id);
+    if (!prev) {
+      byBook.set(entry.book_id, { ...entry, pages: [...(entry.pages || [])] });
+      continue;
+    }
+    const pages = [...new Set([...(prev.pages || []), ...(entry.pages || [])])].sort((a, b) => a - b);
+    const precision: EntityPagePrecision =
+      prev.page_precision === 'page' || entry.page_precision === 'page' || pages.length > 0
+        ? 'page'
+        : 'section';
+    const merged: EntityBookRef = { ...prev, ...entry, pages, page_precision: precision };
+    if (precision === 'page') delete merged.page_range;
+    else merged.page_range = prev.page_range || entry.page_range;
+    byBook.set(entry.book_id, merged);
+  }
+  return [...byBook.values()];
+}
+
+/**
+ * Distinct books, and VERIFIED page references only. A section-precision entry
+ * contributes a book but no page references — which is honest: we have not
+ * established a single page for it.
+ */
+export function entityCounters(books: EntityBookRef[]): { book_count: number; total_mentions: number } {
+  const deduped = dedupeEntityBooks(books);
+  return {
+    book_count: deduped.length,
+    total_mentions: deduped.reduce((sum, b) => sum + (b.pages?.length || 0), 0),
+  };
+}
+
+/**
+ * Legacy rows carry neither `page_precision` nor a verified page list — their
+ * `pages` array is the old smeared batch range. Treat anything unmarked as
+ * section precision so the UI stops rendering those numbers as page citations,
+ * and derive the span from the array we no longer trust page-by-page.
+ */
+export function normalizeEntityBook(entry: EntityBookRef): EntityBookRef {
+  if (entry.page_precision) return entry;
+  const pages = entry.pages || [];
+  if (pages.length === 0) return { ...entry, page_precision: 'section' };
+  return {
+    ...entry,
+    pages: [],
+    page_precision: 'section',
+    page_range: { start: Math.min(...pages), end: Math.max(...pages) },
+  };
+}

--- a/tests/unit/entity-page-attribution.test.ts
+++ b/tests/unit/entity-page-attribution.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Entity → page attribution guards (issue #3361).
+ *
+ * The bug: the index extractor gets bare entity name lists back from Gemini for
+ * a ~50k-char BATCH (no page numbers — only `quotes` carry a page), and the old
+ * code credited every page in the batch's range with every entity in it.
+ * `/encyclopedia/[name]` then rendered those inferred numbers as exact `p. N`
+ * citations. Measured on live data, ~14-22% of claimed pages actually contained
+ * the name.
+ *
+ * The invariant these tests pin is STRUCTURAL, not statistical: a page number is
+ * only ever attributed to an entity if that page's text names the entity. When
+ * nothing matches we fall back to section precision with NO page numbers — a
+ * coarse true claim instead of a precise false one. Any change that lets
+ * `pages` be populated without a text hit reintroduces fabricated citations.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  normalizeForMatch,
+  buildEntityMatcher,
+  pageMatchesEntity,
+  buildPageTexts,
+  attributeEntityPages,
+  dedupeEntityBooks,
+  entityCounters,
+} from '../../scripts/lib/entity-page-match.mjs';
+import {
+  dedupeEntityBooks as dedupeTs,
+  entityCounters as countersTs,
+  normalizeEntityBook,
+  type EntityBookRef,
+} from '../../src/lib/entity-books';
+
+const page = (page_number: number, ocr: string, translation = '') => ({
+  page_number,
+  ocr: { data: ocr },
+  translation: { data: translation },
+});
+
+describe('normalizeForMatch', () => {
+  it('folds diacritics, case, and Latin j/v so early-modern print matches', () => {
+    expect(normalizeForMatch('Gérard')).toBe('gerard');
+    expect(normalizeForMatch('Johannes')).toBe('iohannes');
+    expect(normalizeForMatch('VRBS')).toBe('urbs');
+    expect(normalizeForMatch('Jovis')).toBe('iouis');
+  });
+});
+
+describe('buildEntityMatcher', () => {
+  it('stems long names so Latin case endings still match', () => {
+    const m = buildEntityMatcher('Matthiolus');
+    expect(pageMatchesEntity(m, normalizeForMatch('cuius explanator est Matthioli'))).toBe(true);
+    expect(pageMatchesEntity(m, normalizeForMatch('Matthiolum sequitur'))).toBe(true);
+  });
+
+  it('ignores honorifics — "Saint Perpetua" must not match every saint', () => {
+    const m = buildEntityMatcher('Saint Perpetua');
+    expect(pageMatchesEntity(m, normalizeForMatch('octaue of saint stephen'))).toBe(false);
+    expect(pageMatchesEntity(m, normalizeForMatch('the passion of Perpetua'))).toBe(true);
+  });
+
+  it('requires a word boundary for short anchors (no smart/smartly)', () => {
+    const m = buildEntityMatcher('James Smart');
+    expect(pageMatchesEntity(m, normalizeForMatch('are smartly vibrated against the medium'))).toBe(false);
+    expect(pageMatchesEntity(m, normalizeForMatch('as Smart observes'))).toBe(true);
+  });
+
+  it('does not fire on a near-miss stem of a different person', () => {
+    // Live false positive: "Marcus Aurelius Antoninus" hit a page naming his
+    // mother Aurelia, because every token was a needle and "aureli" is a prefix
+    // of "aurelia". Only the distinctive token counts now.
+    const m = buildEntityMatcher('Marcus Aurelius Antoninus');
+    expect(pageMatchesEntity(m, normalizeForMatch('nato duno lucio cesare & di aurelia romani'))).toBe(false);
+    expect(pageMatchesEntity(m, normalizeForMatch('Antonini imperatoris'))).toBe(true);
+  });
+
+  it('falls back to whole-name word match when no token is distinctive', () => {
+    const m = buildEntityMatcher('Job');
+    expect(pageMatchesEntity(m, normalizeForMatch('the book of Job'))).toBe(true);
+    expect(pageMatchesEntity(m, normalizeForMatch('jobbing work'))).toBe(false);
+  });
+});
+
+describe('attributeEntityPages', () => {
+  const pages = buildPageTexts([
+    page(47, 'de arte medica nihil'),
+    page(48, 'cuius exactissimus explanator est Matthiolus'),
+    page(49, 'sequitur Fuchsius'),
+    page(50, 'Matthioli sententia de iunipero'),
+  ]);
+
+  it('attributes only the pages whose text names the entity', () => {
+    const res = attributeEntityPages('Matthiolus', pages);
+    expect(res.page_precision).toBe('page');
+    expect(res.pages).toEqual([48, 50]);
+  });
+
+  it('NEVER returns page numbers it could not verify (the #3361 invariant)', () => {
+    const res = attributeEntityPages('Paracelsus', pages);
+    expect(res.page_precision).toBe('section');
+    expect(res.pages).toEqual([]);
+    expect(res.page_range).toEqual({ start: 47, end: 50 });
+  });
+
+  it('keeps a section range that spans the batch, not a fabricated page list', () => {
+    const res = attributeEntityPages('Paracelsus', pages);
+    // The old bug: pages would have been [47,48,49,50]. If this ever holds
+    // again, encyclopedia pages are citing pages that do not mention the entity.
+    expect(res.pages.length).toBe(0);
+  });
+
+  it('handles a batch with no usable page numbers', () => {
+    const res = attributeEntityPages('Anyone', buildPageTexts([]));
+    expect(res.page_precision).toBe('section');
+    expect(res.pages).toEqual([]);
+    expect(res.page_range).toBeUndefined();
+  });
+
+  it('reads both OCR and translation as evidence', () => {
+    const p = buildPageTexts([page(5, 'lorem ipsum', 'Mattioli writes that juniper lasts a hundred years')]);
+    // "Mattioli" (translation spelling) stems to the same needle as "Matthiolus".
+    expect(attributeEntityPages('Mattioli', p).pages).toEqual([5]);
+  });
+});
+
+describe('dedupeEntityBooks', () => {
+  it('collapses repeat entries for one book and merges their pages', () => {
+    // The writer used $addToSet on the whole subdocument, so a re-run appended a
+    // second entry for the same book: Matthiolus carried 162 entries for 117
+    // distinct books, which is why the hero count and the "Appears in N Books"
+    // heading disagreed on the live page.
+    const out = dedupeEntityBooks([
+      { book_id: 'b1', book_title: 'T', pages: [4, 5], page_precision: 'page' },
+      { book_id: 'b1', book_title: 'T', pages: [5, 9], page_precision: 'page' },
+      { book_id: 'b2', book_title: 'U', pages: [], page_precision: 'section', page_range: { start: 1, end: 9 } },
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0].pages).toEqual([4, 5, 9]);
+    expect(out[1].page_precision).toBe('section');
+  });
+
+  it('lets verified pages win over a section range for the same book', () => {
+    const out = dedupeEntityBooks([
+      { book_id: 'b1', pages: [], page_precision: 'section', page_range: { start: 1, end: 9 } },
+      { book_id: 'b1', pages: [7], page_precision: 'page' },
+    ]);
+    expect(out[0].page_precision).toBe('page');
+    expect(out[0].pages).toEqual([7]);
+    expect(out[0].page_range).toBeUndefined();
+  });
+
+  it('drops entries with no book_id', () => {
+    expect(dedupeEntityBooks([{ pages: [1] }, { book_id: 'b', pages: [2] }])).toHaveLength(1);
+  });
+});
+
+describe('entityCounters', () => {
+  it('counts distinct books and VERIFIED page references only', () => {
+    const books = [
+      { book_id: 'b1', pages: [4, 5], page_precision: 'page' },
+      { book_id: 'b1', pages: [4, 5], page_precision: 'page' },
+      { book_id: 'b2', pages: [], page_precision: 'section', page_range: { start: 1, end: 30 } },
+    ];
+    // Old behavior: book_count 3, total_mentions 4+2+30. Matthiolus advertised
+    // "10,700 total mentions" this way.
+    expect(entityCounters(books)).toEqual({ book_count: 2, total_mentions: 2 });
+  });
+});
+
+describe('normalizeEntityBook (read-side legacy demotion)', () => {
+  it('demotes an unmarked legacy entry to section precision', () => {
+    // The 1M pre-existing entity rows carry no page_precision and a smeared
+    // page array. Until the repair sweep reaches them the read path must not
+    // render those numbers as citations — it keeps the span, drops the pages.
+    const out = normalizeEntityBook({
+      book_id: 'b1', book_title: 'T', book_author: 'A', pages: [47, 48, 49, 50],
+    } as EntityBookRef);
+    expect(out.page_precision).toBe('section');
+    expect(out.pages).toEqual([]);
+    expect(out.page_range).toEqual({ start: 47, end: 50 });
+  });
+
+  it('leaves an already-marked entry untouched', () => {
+    const entry = {
+      book_id: 'b1', book_title: 'T', book_author: 'A', pages: [48], page_precision: 'page',
+    } as EntityBookRef;
+    expect(normalizeEntityBook(entry)).toBe(entry);
+  });
+
+  it('handles a legacy entry with an empty page array', () => {
+    const out = normalizeEntityBook({
+      book_id: 'b1', book_title: 'T', book_author: 'A', pages: [],
+    } as EntityBookRef);
+    expect(out.page_precision).toBe('section');
+    expect(out.page_range).toBeUndefined();
+  });
+});
+
+describe('PARITY: scripts/lib/entity-page-match.mjs vs src/lib/entity-books.ts', () => {
+  // The writer (.mjs) and the read path (.ts) must agree on dedupe and counting,
+  // or the stored counters and the rendered list drift apart again.
+  const FIXTURES: EntityBookRef[][] = [
+    [],
+    [{ book_id: 'b1', book_title: 'T', book_author: 'A', pages: [4, 5], page_precision: 'page' }],
+    [
+      { book_id: 'b1', book_title: 'T', book_author: 'A', pages: [4, 5], page_precision: 'page' },
+      { book_id: 'b1', book_title: 'T', book_author: 'A', pages: [5, 9], page_precision: 'page' },
+    ],
+    [
+      { book_id: 'b1', book_title: 'T', book_author: 'A', pages: [], page_precision: 'section', page_range: { start: 1, end: 9 } },
+      { book_id: 'b1', book_title: 'T', book_author: 'A', pages: [7], page_precision: 'page' },
+      { book_id: 'b2', book_title: 'U', book_author: 'B', pages: [], page_precision: 'section', page_range: { start: 3, end: 8 } },
+    ],
+  ];
+
+  it.each(FIXTURES.map((f, i) => [i, f] as const))('fixture %i dedupes identically', (_i, fixture) => {
+    expect(dedupeTs(fixture)).toEqual(dedupeEntityBooks(fixture));
+  });
+
+  it.each(FIXTURES.map((f, i) => [i, f] as const))('fixture %i counts identically', (_i, fixture) => {
+    expect(countersTs(fixture)).toEqual(entityCounters(fixture));
+  });
+});


### PR DESCRIPTION
Fixes #3361. Reported via footer feedback (`6a6553991bea89b3a6e94279`, on `/encyclopedia/Matthiolus`): *"What is this page about? Real?"*

Answer: not real, at page granularity.

## The bug

The index extractor asks Gemini which people/places/concepts appear in a ~50k-char batch and gets back **bare name lists** — only `quotes` come back with a `page`. The code filled that hole by crediting every page in the batch's range with every entity in it, and `/encyclopedia/[name]` rendered those inferred numbers as exact `p. N` citation pills.

Measured on 30 sampled entity-book pairs: **91 of 415 claimed page attributions (21.9%)** actually contained the entity name, and the deliberately loose stems used for that check make it an upper bound. `Matthiolus` claimed pp. 47-58 of *Raphael Explaining the Art of Medicine*; he is named on pp. 44 and 100. All twelve links went to pages that never mention him.

That is a fabricated citation on a public surface — same family as the #2232 misquote, which is why this is a bug and not an enhancement.

## The fix

Precision is now **structural, not statistical**: a page number can only exist where that page's OCR or translation text matched. No match anywhere in the batch → the entry drops to **section precision** (`pages: []` + `page_range`) and the UI reads "discussed in pp. 47–58" instead of minting twelve pills.

| | before | after |
|---|---|---|
| page attributions | every page in the batch range | only pages whose text names the entity |
| no match found | all pages claimed anyway | section range, zero page numbers |
| `total_mentions` | sum of smeared arrays (one entity: 10,700) | verified page references |
| `book_count` | `books.length` incl. duplicates (162) | distinct books (117) |

## What's in it

- **`scripts/lib/entity-page-match.mjs`** — shared matcher. Folds diacritics and Latin j/v (`Iohannes`/`Johannes`), stems the most distinctive token so case endings inflect (`Matthiolus`/`Matthioli`/`Matthiolum`). Two rules exist because live data broke the naive version: matching *every* token fired `saint` on every saint in a liturgical calendar and `smart` on "smartly vibrated"; using `entity_aliases` fired `philosopher` and `Confessor` on half the corpus. So only the stoplisted-longest token counts, and aliases are excluded — recall loss degrades to section precision, which is safe.
- **Both writers** (`enrich-worker.mjs` Phase 6 and its `batch-generate-indexes.mjs` twin) verify per page, and replace a book's entry with `$pull`/`$push` instead of `$addToSet` on a whole subdocument — that appended a *second* entry on every re-run, which is why the hero count (162) contradicted the page's own "Appears in 117 Books" heading.
- **`src/app/api/entities/route.ts`** — third writer, rebuilds entities from `book.index`; now carries the precision marker through instead of laundering unmarked legacy pages back into citations.
- **`src/lib/entity-books.ts`** — read-side twin, parity-pinned by the test. `normalizeEntityBook` demotes any row without a `page_precision` marker to section precision, so the ~1M un-swept entities stop showing fabricated citations **at deploy time, not sweep time**.
- **Author page** — "Encyclopedia entry" → **"Mentions in other books"**. Sitting beside "Artist page" it read as more works, so readers clicked expecting books. That was the other half of the report.
- **`scripts/maintenance/repair-entity-page-attribution.mjs`** — re-runnable repair sweep. Pure string matching over stored text, **no Gemini cost**.

## Verification

- 26 new unit tests; full suite 633 passing; `npx tsc --noEmit` clean.
- The central test asserts the invariant directly: an unmatched entity must return `pages: []`. If that ever holds page numbers again, citations are being fabricated.
- Sweep dry run over 60 books: 6,644 → 1,471 claimed citations, **77.9% dropped as unverifiable** — independently reproducing the 22% precision figure.
- Applied to the reported book: the `Matthiolus` entry is now `pages: [44], page_precision: 'page'` — p. 44 being one of the two pages verified by hand.
- Full sweep (19,581 indexed books, ~3.3h) running now; safe to merge before it finishes, since the read path demotes un-swept rows on its own.

## Out of scope

- **Building a fuller concordance.** The sweep verifies only within the pages an entry already claimed — the window Gemini actually read. So `Matthiolus` p. 100 stays unlisted. Deliberate: it keeps the model's judgment about *which* "Paul" or "Faber" is meant, where a whole-book string sweep would merge homonyms. A missing page is a recall gap; an asserted one is a false citation, and only the latter is a correctness bug.
- **Asking the model for page numbers directly.** The real repair for recall is putting `page` in the people/places/concepts contract the way `quotes` already has it. That costs a re-extraction pass, so it's separate.
- **`books.index.vocabulary`** — a different derivation, also wrong for the sampled book (it claimed pp. 23, 51). Not what `/encyclopedia` renders; needs its own look.
- **Page renumbering.** Books re-split after indexing have stale numbers (the vocabulary path's 23/51 vs the real 44/100 looks like a post-index doubling). The sweep is re-runnable precisely so this is a re-run, not a migration.
- Splitting `entities` into canonical vs per-book mentions (#2979, closed) — storage shape, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)