### PR TITLE
fix(tenant): 404 corpus-wide surfaces on partner subdomains (#3364)

### DIFF
--- a/scripts/audit-bph-leaks.mjs
+++ b/scripts/audit-bph-leaks.mjs
@@ -25,10 +25,13 @@
  *     decided to render the not-found UI. From outside, it looks like a
  *     working page; the only signal is the marker baked into the HTML.
  *
- * Out of scope (manual audit needed): verifying that every book.id rendered
- * on a page belongs to the tenant. Doable by parsing /book/<id> links and
- * checking each book's tenantId via the API; not implemented here to keep
- * the script offline-friendly.
+ *   - A /book/<id> link that stays ON the subdomain but points at a book the
+ *     tenant does not hold. This was the "out of scope" item in earlier
+ *     versions of this script, and skipping it is what let #3364 sit: the
+ *     encyclopedia linked 102 non-BPH books from bph.sourcelibrary.org using
+ *     RELATIVE hrefs, so every hostname check passed while the page listed
+ *     other libraries' holdings. Requires MONGODB_URI; when it is absent the
+ *     check is reported as NOT RUN rather than silently passing.
  */
 
 const TARGET = (process.argv[2] || 'https://bph.sourcelibrary.org').replace(/\/+$/, '');
@@ -80,6 +83,18 @@ function classifyHref(href, fromUrl) {
 
 const ANCHOR_RE = /<a\b[^>]*\bhref\s*=\s*("([^"]*)"|'([^']*)')/gi;
 
+// Book identifiers referenced anywhere in the HTML — anchors, but also flight
+// data and embedded JSON, since a client-rendered list still tells the reader
+// which books exist. Trailing segments (/page/x, /overview) are dropped.
+const BOOK_REF_RE = /\/book\/([A-Za-z0-9][A-Za-z0-9-]{5,})/g;
+
+function extractBookRefs(html) {
+  if (!html) return [];
+  const out = new Set();
+  for (const m of html.matchAll(BOOK_REF_RE)) out.add(m[1]);
+  return [...out];
+}
+
 function extractHrefs(html) {
   const out = [];
   let m;
@@ -94,6 +109,8 @@ const queue = [];
 const leaks = [];        // { fromUrl, href, resolved }
 const redirectLeaks = []; // { fromUrl, redirectedTo }
 const silentNotFounds = []; // { url } — 200 response carrying notFound() fallback
+const bookRefs = new Map(); // book id-or-slug → first page that linked it
+let unresolvedBookRefs = 0;
 let pagesFetched = 0;
 
 // Next.js stamps this digest into the streamed HTML when a server component
@@ -117,6 +134,17 @@ const SEED_PATHS = [
   '/browse',
   '/explore',
   '/artwork',
+  // Corpus-wide surfaces the proxy now 404s on tenant hosts (#3364). Nothing
+  // links to them from the tenant UI, so only an explicit seed exercises them.
+  // While the block holds these return 404 and contribute nothing; if it is
+  // ever removed they immediately re-expose other libraries' books and the
+  // foreign-book check below fires.
+  '/encyclopedia',
+  '/encyclopedia/Matthiolus',
+  '/explore/timeline',
+  '/explore/map',
+  '/ngrams',
+  '/libraries',
 ];
 for (const p of SEED_PATHS) queue.push({ url: TARGET + p, depth: 0 });
 
@@ -166,6 +194,13 @@ while (queue.length > 0 && pagesFetched < MAX_PAGES) {
     silentNotFounds.push({ url: page.finalUrl || url });
   }
 
+  // Content-level leak: a book link that stays on-subdomain but points at a
+  // book the tenant doesn't hold. Collected here, resolved against the DB after
+  // the crawl (see below) so the link walk stays offline-friendly.
+  for (const ref of extractBookRefs(page.html)) {
+    if (!bookRefs.has(ref)) bookRefs.set(ref, url);
+  }
+
   const hrefs = extractHrefs(page.html);
   for (const href of hrefs) {
     const classified = classifyHref(href, page.finalUrl);
@@ -179,14 +214,73 @@ while (queue.length > 0 && pagesFetched < MAX_PAGES) {
   }
 }
 
+// --- Foreign-book check (needs MONGODB_URI) ---
+//
+// The hostname checks above cannot see this class of leak. `/encyclopedia/X`
+// linked 102 non-BPH books from the BPH subdomain using RELATIVE hrefs, so every
+// link resolved to bph.sourcelibrary.org and the audit passed clean (#3364).
+// A tenant page is only sealed if the books it links to are the tenant's own.
+const foreignBooks = [];
+let bookCheckSkipped = null;
+
+if (bookRefs.size === 0) {
+  bookCheckSkipped = 'no /book/ links found in the crawled HTML';
+} else if (!process.env.MONGODB_URI) {
+  // Never let an unrun check read as a pass.
+  bookCheckSkipped = `MONGODB_URI not set — ${bookRefs.size} book link(s) left unverified`;
+} else {
+  try {
+    const { MongoClient } = await import('mongodb');
+    const client = new MongoClient(process.env.MONGODB_URI);
+    await client.connect();
+    const db = client.db('bookstore');
+
+    const tenantSlug = TENANT_HOST.split('.')[0];
+    const tenantDoc = await db.collection('tenants').findOne(
+      { slug: tenantSlug, status: { $ne: 'deleted' } },
+      { projection: { id: 1, slug: 1 } }
+    );
+
+    if (!tenantDoc?.id) {
+      bookCheckSkipped = `no active tenant found for slug "${tenantSlug}"`;
+    } else {
+      const refs = [...bookRefs.keys()];
+      const books = await db.collection('books')
+        .find({ $or: [{ id: { $in: refs } }, { slug: { $in: refs } }] },
+              { projection: { id: 1, slug: 1, title: 1, display_title: 1, tenantId: 1 } })
+        .toArray();
+
+      for (const b of books) {
+        if (b.tenantId === tenantDoc.id) continue;
+        const ref = bookRefs.has(b.id) ? b.id : b.slug;
+        foreignBooks.push({
+          ref,
+          title: b.display_title || b.title || '(untitled)',
+          fromUrl: bookRefs.get(ref) || '(unknown page)',
+        });
+      }
+      unresolvedBookRefs = refs.length - books.length;
+    }
+    await client.close();
+  } catch (err) {
+    bookCheckSkipped = `lookup failed — ${err?.message || err}`;
+  }
+}
+
 const totalLeaks = leaks.length + redirectLeaks.length;
-const totalIssues = totalLeaks + silentNotFounds.length;
+const totalIssues = totalLeaks + silentNotFounds.length + foreignBooks.length;
 process.stdout.write(`\nBPH lockdown audit\n`);
 process.stdout.write(`  base:           ${TARGET}\n`);
 process.stdout.write(`  pages:          ${pagesFetched} (visited)\n`);
 process.stdout.write(`  depth:          ${MAX_DEPTH}\n`);
 process.stdout.write(`  leaks:          ${totalLeaks}\n`);
 process.stdout.write(`  silent 404s:    ${silentNotFounds.length}\n`);
+process.stdout.write(`  book links:     ${bookRefs.size} seen`);
+process.stdout.write(
+  bookCheckSkipped
+    ? ` — NOT CHECKED (${bookCheckSkipped})\n`
+    : `, ${foreignBooks.length} not held by this tenant${unresolvedBookRefs ? `, ${unresolvedBookRefs} unresolved` : ''}\n`
+);
 
 if (redirectLeaks.length > 0) {
   process.stdout.write(`\nRedirect leaks (${redirectLeaks.length}):\n`);
@@ -225,8 +319,27 @@ if (silentNotFounds.length > 0) {
   }
 }
 
+if (foreignBooks.length > 0) {
+  process.stdout.write(`\nForeign books linked (${foreignBooks.length}):\n`);
+  process.stdout.write(`  Links that stay on ${TENANT_HOST} but point at books this tenant does not hold.\n`);
+  process.stdout.write(`  Hostname checks cannot see these — the hrefs are relative (#3364).\n`);
+  for (const f of foreignBooks.slice(0, 25)) {
+    process.stdout.write(`  /book/${f.ref}  "${f.title.slice(0, 60)}"\n    linked from ${f.fromUrl}\n`);
+  }
+  if (foreignBooks.length > 25) {
+    process.stdout.write(`  … and ${foreignBooks.length - 25} more\n`);
+  }
+}
+
 if (totalIssues === 0) {
-  process.stdout.write(`\nNo issues detected. The subdomain stays inside ${TENANT_HOST}.\n`);
+  if (bookCheckSkipped) {
+    // A skipped check is not a clean bill of health. Say so, and don't claim
+    // the subdomain is sealed on evidence we didn't gather.
+    process.stdout.write(`\nNo link or redirect leaks found, but the book-ownership check did not run (${bookCheckSkipped}).\n`);
+    process.stdout.write(`Re-run with MONGODB_URI set for a complete audit.\n`);
+    process.exit(0);
+  }
+  process.stdout.write(`\nNo issues detected. The subdomain stays inside ${TENANT_HOST}, and every linked book belongs to it.\n`);
   process.exit(0);
 } else {
   process.stdout.write(`\nIssues detected. Patch each before shipping.\n`);

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -7,6 +7,7 @@ import Logo from './Logo';
 import UserMenu from './UserMenu';
 import { Search, ChevronDown } from 'lucide-react';
 import { useLocale, localeHref, hasLocalizedTwin, NAV_STRINGS, type NavStrings, type Locale } from '@/lib/i18n';
+import { isGlobalOnlyNavHref } from '@/lib/tenant-global-paths';
 
 interface NavLink {
   label: string;
@@ -34,6 +35,25 @@ function buildNavLinks(t: NavStrings): NavLink[] {
     { label: t.librarian, href: '/librarian' },
     { label: t.podcast, href: '/podcast' },
   ];
+}
+
+/**
+ * True when rendering on a partner subdomain (bph.sourcelibrary.org, …) or
+ * inside an /embed/* view. Deliberately host-shaped rather than an allow-list of
+ * tenant slugs, so a new tenant subdomain is covered the day its DNS record
+ * exists. `false` during SSR and on the first client render, so the global
+ * site's static HTML is untouched.
+ */
+function useIsTenantHost(): boolean {
+  const [isTenant, setIsTenant] = useState(false);
+  useEffect(() => {
+    const h = window.location.hostname;
+    const parts = h.split('.');
+    const isSubdomain =
+      h.endsWith('.sourcelibrary.org') && parts.length > 2 && parts[0] !== 'www';
+    setIsTenant(isSubdomain || window.location.pathname.startsWith('/embed/'));
+  }, []);
+  return isTenant;
 }
 
 interface Breadcrumb {
@@ -73,7 +93,21 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
   // derived one (null during static prerender).
   const locale = homeLocale ?? pathnameLocale;
   const t = NAV_STRINGS[locale];
-  const NAV_LINKS = buildNavLinks(t);
+  // Corpus-wide surfaces 404 on partner subdomains (see GLOBAL_ONLY_TENANT_BLOCKED
+  // in src/proxy.ts, issue #3364), so the nav must not point at them there — "Map"
+  // would otherwise be a dead link in the tenant's own header.
+  //
+  // Detected from the hostname rather than passed down: this is a client
+  // component rendered by ~every page, so a prop would mean threading tenant
+  // context through all of them, and reading headers() server-side to provide it
+  // would force the ISR routes dynamic. Resolved after mount, so the static HTML
+  // (which the global site shares) is unchanged and only a tenant visitor sees
+  // the item drop — acceptable for a nav link, and it never removes anything on
+  // sourcelibrary.org itself.
+  const isTenantHost = useIsTenantHost();
+  const NAV_LINKS = buildNavLinks(t).filter(
+    link => !(isTenantHost && isGlobalOnlyNavHref(link.href))
+  );
   // The EN/ES toggle shows only where a real Spanish twin exists (home, sign-in,
   // support) — the thin-i18n bargain (#2763). On deep English-only pages the
   // toggle is hidden, so clicking ES never bounces the reader to the `/es`

--- a/src/lib/tenant-global-paths.ts
+++ b/src/lib/tenant-global-paths.ts
@@ -1,0 +1,67 @@
+/**
+ * Surfaces that exist only on the global library, never inside a partner
+ * reading room (issue #3364).
+ *
+ * After the tenant-as-filter migration, every path on a tenant subdomain flows
+ * through to its global counterpart and the route is expected to honor the
+ * `x-tenant-*` headers the proxy stamps. These routes don't: they render
+ * corpus-wide aggregations that have no tenant-scoped meaning, so on
+ * bph.sourcelibrary.org they served the whole global library. Measured before
+ * the fix, `/encyclopedia/Matthiolus` on the BPH host linked 121 books of which
+ * 102 were NOT BPH holdings, and `/api/entities` returned byte-identical global
+ * results on both hosts.
+ *
+ * Blocking rather than scoping is deliberate. The entity index is built across
+ * the whole corpus (`entities.books[]`), the timeline and map plot global
+ * entities, ngrams are corpus-wide frequency data by construction, and
+ * `/libraries` credits every contributing institution. A tenant-scoped version
+ * of each would be a different feature, not a filter — and until one exists a
+ * partner reading room should say "not here" rather than show someone else's
+ * holdings.
+ *
+ * NOT listed, because they already scope correctly (verified by diffing tenant
+ * vs global responses): `/search` and `/api/search/unified`, `/gallery`,
+ * `/collections`, `/browse` (see src/lib/tenant-browse.ts).
+ *
+ * This is one list so the proxy block and the site nav can never disagree —
+ * the nav must not link to a path the proxy 404s.
+ */
+
+/** Page routes. Also used to filter the site nav on tenant hosts. */
+export const GLOBAL_ONLY_TENANT_PAGE_PATHS = [
+  '/encyclopedia',
+  '/explore',
+  '/ngrams',
+  '/libraries',
+] as const;
+
+/**
+ * API routes backing those pages. Listed separately because these surfaces
+ * render client-side: blocking only the page would leave the unscoped data
+ * reachable, since the browser fetches it from the tenant host.
+ */
+export const GLOBAL_ONLY_TENANT_API_PATHS = [
+  '/api/entities',
+  '/api/explore',
+  '/api/ngrams',
+] as const;
+
+const ALL_GLOBAL_ONLY_PATHS: readonly string[] = [
+  ...GLOBAL_ONLY_TENANT_PAGE_PATHS,
+  ...GLOBAL_ONLY_TENANT_API_PATHS,
+];
+
+/** Exact match or a path segment beneath it — `/explore` and `/explore/map`,
+ *  but never `/exploration`. */
+export function isGlobalOnlyTenantPath(pathname: string): boolean {
+  return ALL_GLOBAL_ONLY_PATHS.some(
+    p => pathname === p || pathname.startsWith(`${p}/`)
+  );
+}
+
+/** True for a nav href that the proxy would 404 on a tenant host. */
+export function isGlobalOnlyNavHref(href: string): boolean {
+  return GLOBAL_ONLY_TENANT_PAGE_PATHS.some(
+    p => href === p || href.startsWith(`${p}/`)
+  );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,6 +2,7 @@ import { NextResponse, NextRequest } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import authorCanonicalRedirects from '@/lib/author-canonical-redirects.json';
 import { getProviderPrefixRedirect, TENANT_ROOT_PATHS } from '@/lib/provider-prefix';
+import { isGlobalOnlyTenantPath } from '@/lib/tenant-global-paths';
 
 // Precomputed variant-slug → canonical-slug map for /author URL dedup (#2250).
 // Bundled because the proxy runs at the edge with no DB access; regenerate with
@@ -222,6 +223,12 @@ const TENANT_SUBDOMAINS: Record<string, string> = {
   'bhutan.sourcelibrary.org': 'bhutan',
   // 'ritman.sourcelibrary.org': 'ritman',
 };
+
+// Global-only surfaces (the list, and why, live in src/lib/tenant-global-paths.ts).
+// Enforced here rather than in the pages because those routes are ISR
+// (`revalidate = 86400`); reading headers() in them to detect the host would
+// force dynamic rendering and drop the cache — same reasoning as the book-page
+// redirects further down.
 
 // --- Tenant resolution helpers (module-level) ---
 // Pulled out of proxy() so they can be reused by resolveTenantFromRequest and
@@ -676,6 +683,23 @@ export async function proxy(request: NextRequest) {
   // tenant context travels via the x-tenant-* headers stamped by the
   // resolution block lower in this file.
   const tenant = TENANT_SUBDOMAINS[host.toLowerCase()];
+
+  // Corpus-wide surfaces don't exist inside a partner reading room (#3364).
+  // Checked before the rewrite block, which skips /api/* — the listed API twins
+  // are the unscoped data sources behind these pages and must be refused too.
+  if (tenant && isGlobalOnlyTenantPath(pathname)) {
+    return new NextResponse(
+      'Not found on this collection. This page indexes the whole Source Library; a partner reading room only serves its own holdings.',
+      {
+        status: 404,
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'X-Robots-Tag': 'noindex, nofollow',
+        },
+      }
+    );
+  }
+
   if (tenant && !pathname.startsWith('/embed/') && !pathname.startsWith('/_next/') && !pathname.startsWith('/api/')) {
     const url = request.nextUrl.clone();
     let needsRewrite = false;

--- a/tests/unit/tenant-global-paths.test.ts
+++ b/tests/unit/tenant-global-paths.test.ts
@@ -18,6 +18,9 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import path from 'path';
+import { NextRequest } from 'next/server';
+
+import { proxy } from '@/proxy';
 
 import {
   GLOBAL_ONLY_TENANT_PAGE_PATHS,
@@ -92,17 +95,62 @@ describe('isGlobalOnlyNavHref', () => {
   });
 });
 
+/**
+ * Behavioral tests against the real proxy.
+ *
+ * These exist because the obvious end-to-end check does NOT work: curling a
+ * Vercel PREVIEW url with `Host: bph.sourcelibrary.org` does not exercise the
+ * preview build at all — Vercel's router resolves the Host to the PRODUCTION
+ * deployment for that domain and serves it. During review that produced a
+ * convincing false negative (every blocked path answered 200, including a real
+ * BPH landing page at `/`) which looked exactly like a broken fix. Calling
+ * proxy() directly is the only deterministic check short of deploying.
+ */
+describe('proxy behavior', () => {
+  const req = (url: string, host: string) =>
+    new NextRequest(url, {
+      headers: {
+        host,
+        'user-agent': 'Mozilla/5.0 Chrome/124',
+        'accept-language': 'en',
+        'sec-fetch-mode': 'navigate',
+      },
+    });
+
+  it.each([
+    '/encyclopedia',
+    '/encyclopedia/Matthiolus',
+    '/explore/timeline',
+    '/explore/map',
+    '/ngrams',
+    '/libraries',
+    '/libraries/internet-archive',
+    '/api/entities',
+  ])('404s %s on a tenant subdomain', async (p) => {
+    const res = await proxy(req(`https://bph.sourcelibrary.org${p}`, 'bph.sourcelibrary.org'));
+    expect(res?.status).toBe(404);
+  });
+
+  it.each(['/collections', '/gallery', '/browse', '/search'])(
+    'leaves the correctly-scoped route %s reachable on a tenant subdomain',
+    async (p) => {
+      const res = await proxy(req(`https://bph.sourcelibrary.org${p}`, 'bph.sourcelibrary.org'));
+      expect(res?.status).not.toBe(404);
+    }
+  );
+
+  it.each(['/encyclopedia', '/encyclopedia/Matthiolus', '/explore/map', '/ngrams', '/libraries'])(
+    'leaves %s untouched on the global host',
+    async (p) => {
+      const res = await proxy(req(`https://sourcelibrary.org${p}`, 'sourcelibrary.org'));
+      expect(res?.status).not.toBe(404);
+    }
+  );
+});
+
 describe('wiring', () => {
-  it('proxy.ts blocks global-only paths on tenant subdomains with a 404', () => {
+  it('blocks before the tenant rewrite, or the page would be served first', () => {
     const src = read('src/proxy.ts');
-    expect(src, 'proxy must import the shared predicate').toContain(
-      "from '@/lib/tenant-global-paths'"
-    );
-    expect(src, 'proxy must gate on tenant + the predicate').toMatch(
-      /if\s*\(\s*tenant\s*&&\s*isGlobalOnlyTenantPath\(pathname\)\s*\)/
-    );
-    // The block must precede the subdomain rewrite, or /encyclopedia would be
-    // rewritten and served before it is ever refused.
     const blockAt = src.indexOf('isGlobalOnlyTenantPath(pathname)');
     const rewriteAt = src.indexOf("!pathname.startsWith('/embed/')");
     expect(blockAt).toBeGreaterThan(-1);

--- a/tests/unit/tenant-global-paths.test.ts
+++ b/tests/unit/tenant-global-paths.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tenant lockdown: corpus-wide surfaces must not answer on a partner subdomain
+ * (issue #3364).
+ *
+ * Measured on production before the fix: `/encyclopedia/Matthiolus` served from
+ * bph.sourcelibrary.org linked 121 books, 102 of which were NOT BPH holdings,
+ * and `/api/entities` returned byte-identical global results on both hosts. The
+ * existing crawler audit (`scripts/audit-bph-leaks.mjs`) could not catch it —
+ * it asserts that links don't resolve OFF the subdomain, and these links are
+ * relative, so they stay on-host while pointing at other libraries' books.
+ *
+ * These tests pin three things:
+ *  1. the path predicate (prefix matching, no false positives)
+ *  2. that routes verified as correctly tenant-scoped are NOT blocked
+ *  3. that the proxy and the site nav read the SAME list, so the nav can never
+ *     link to a path the proxy 404s
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import {
+  GLOBAL_ONLY_TENANT_PAGE_PATHS,
+  GLOBAL_ONLY_TENANT_API_PATHS,
+  isGlobalOnlyTenantPath,
+  isGlobalOnlyNavHref,
+} from '@/lib/tenant-global-paths';
+
+const repoRoot = path.resolve(__dirname, '../..');
+const read = (p: string) => readFileSync(path.join(repoRoot, p), 'utf8');
+
+describe('isGlobalOnlyTenantPath', () => {
+  it('blocks the corpus-wide pages and their children', () => {
+    expect(isGlobalOnlyTenantPath('/encyclopedia')).toBe(true);
+    expect(isGlobalOnlyTenantPath('/encyclopedia/Matthiolus')).toBe(true);
+    expect(isGlobalOnlyTenantPath('/explore')).toBe(true);
+    expect(isGlobalOnlyTenantPath('/explore/timeline')).toBe(true);
+    expect(isGlobalOnlyTenantPath('/explore/map')).toBe(true);
+    expect(isGlobalOnlyTenantPath('/ngrams')).toBe(true);
+    expect(isGlobalOnlyTenantPath('/libraries')).toBe(true);
+    expect(isGlobalOnlyTenantPath('/libraries/internet-archive')).toBe(true);
+  });
+
+  it('blocks the unscoped APIs behind them — the pages render client-side', () => {
+    expect(isGlobalOnlyTenantPath('/api/entities')).toBe(true);
+    expect(isGlobalOnlyTenantPath('/api/entities?limit=5')).toBe(false); // query string is not part of pathname
+    expect(isGlobalOnlyTenantPath('/api/explore/map')).toBe(true);
+    expect(isGlobalOnlyTenantPath('/api/ngrams')).toBe(true);
+  });
+
+  it('leaves correctly tenant-scoped routes alone', () => {
+    // Verified against production by diffing tenant vs global responses:
+    // /api/search/unified returns different results per host, /gallery and
+    // /collections render smaller tenant-filtered pages, /browse has
+    // src/lib/tenant-browse.ts.
+    for (const p of [
+      '/search',
+      '/api/search/unified',
+      '/gallery',
+      '/gallery/image/abc-0',
+      '/collections',
+      '/collections/alchemy',
+      '/browse',
+      '/browse/titles/A',
+      '/book/some-slug',
+      '/author/marsilio-ficino',
+      '/',
+    ]) {
+      expect(isGlobalOnlyTenantPath(p), `${p} must stay reachable`).toBe(false);
+    }
+  });
+
+  it('matches on path segments, not string prefixes', () => {
+    expect(isGlobalOnlyTenantPath('/exploration')).toBe(false);
+    expect(isGlobalOnlyTenantPath('/librariesXYZ')).toBe(false);
+    expect(isGlobalOnlyTenantPath('/encyclopedias')).toBe(false);
+  });
+});
+
+describe('isGlobalOnlyNavHref', () => {
+  it('flags nav hrefs that the proxy would 404 on a tenant host', () => {
+    // The site header links "Map" → /explore/map. Blocking the route without
+    // dropping the link would leave a dead entry in the tenant's own nav.
+    expect(isGlobalOnlyNavHref('/explore/map')).toBe(true);
+    expect(isGlobalOnlyNavHref('/collections')).toBe(false);
+    expect(isGlobalOnlyNavHref('/gallery')).toBe(false);
+    expect(isGlobalOnlyNavHref('/browse')).toBe(false);
+  });
+
+  it('does not flag API paths — those are never nav targets', () => {
+    expect(isGlobalOnlyNavHref('/api/entities')).toBe(false);
+  });
+});
+
+describe('wiring', () => {
+  it('proxy.ts blocks global-only paths on tenant subdomains with a 404', () => {
+    const src = read('src/proxy.ts');
+    expect(src, 'proxy must import the shared predicate').toContain(
+      "from '@/lib/tenant-global-paths'"
+    );
+    expect(src, 'proxy must gate on tenant + the predicate').toMatch(
+      /if\s*\(\s*tenant\s*&&\s*isGlobalOnlyTenantPath\(pathname\)\s*\)/
+    );
+    // The block must precede the subdomain rewrite, or /encyclopedia would be
+    // rewritten and served before it is ever refused.
+    const blockAt = src.indexOf('isGlobalOnlyTenantPath(pathname)');
+    const rewriteAt = src.indexOf("!pathname.startsWith('/embed/')");
+    expect(blockAt).toBeGreaterThan(-1);
+    expect(rewriteAt).toBeGreaterThan(-1);
+    expect(blockAt, 'block must come before the tenant rewrite').toBeLessThan(rewriteAt);
+  });
+
+  it('the site nav filters on the same list the proxy enforces', () => {
+    const src = read('src/components/layout/SiteHeader.tsx');
+    expect(src, 'header must import the shared predicate').toContain(
+      "from '@/lib/tenant-global-paths'"
+    );
+    expect(src).toContain('isGlobalOnlyNavHref');
+  });
+
+  it('every blocked page path is a real route in the app tree', () => {
+    // A typo here would silently block nothing. Each entry must correspond to a
+    // directory under src/app.
+    for (const p of GLOBAL_ONLY_TENANT_PAGE_PATHS) {
+      const dir = path.join(repoRoot, 'src/app', p.replace(/^\//, ''));
+      expect(() => readFileSync(path.join(dir, 'page.tsx')), `${p} should exist`).not.toThrow();
+    }
+  });
+
+  it('every blocked API path is a real route handler', () => {
+    for (const p of GLOBAL_ONLY_TENANT_API_PATHS) {
+      const dir = path.join(repoRoot, 'src/app', p.replace(/^\//, ''));
+      let found = true;
+      try {
+        readFileSync(path.join(dir, 'route.ts'));
+      } catch {
+        // /api/explore is a parent segment whose children hold the handlers.
+        try {
+          readFileSync(path.join(dir, 'map', 'route.ts'));
+        } catch {
+          found = false;
+        }
+      }
+      expect(found, `${p} should resolve to a route handler`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3364.

## The leak

`bph.sourcelibrary.org` served `/encyclopedia`, `/explore/*`, `/ngrams` and `/libraries` as the **full global page**. Measured on production:

- `/encyclopedia/Matthiolus` on the BPH host linked **121 books, 102 of them not BPH holdings**
- `/api/entities` returned **byte-identical** results on both hosts

Two invariants from the CLAUDE.md tenant-lockdown section: every server query touching a tenant page must filter by tenant, and corpus-wide pre-computed cross-references must not render in embed mode. EFM uses this subdomain as their public face.

Pre-existing — found while checking whether a new query in #3361 needed tenant scoping, not introduced by it.

## Why block instead of scope

The entity index is built across the whole corpus (`entities.books[]`), the timeline and map plot global entities, ngrams are corpus-wide frequency data by construction, and `/libraries` credits every contributing institution. A tenant-scoped version of each would be a **different feature, not a filter**. Until one exists, a partner reading room should say "not here" rather than show another library's holdings.

**Verified as correctly scoped and deliberately left alone:** `/search` + `/api/search/unified` (different results per host), `/gallery`, `/collections`, `/browse` (`src/lib/tenant-browse.ts`).

## Where it's enforced, and why there

In the **proxy**, not the pages. These routes are ISR (`revalidate = 86400`); reading `headers()` in them to detect the host would force dynamic rendering and drop the cache. That's the same reasoning already recorded for the book-page redirects handled in `proxy.ts`.

The backing APIs are blocked too — these pages render client-side, so blocking only the page would leave the unscoped data reachable from the tenant host.

## The nav had to move with it

The site header links "Map" → `/explore/map`. Blocking the route alone would leave a **dead link in the tenant's own nav**, so the header filters on the *same* list (`src/lib/tenant-global-paths.ts` — one source of truth, so proxy and nav can't drift).

Tenant detection there is a post-mount hostname check. `SiteHeader` is a client component rendered by nearly every page: a prop would mean threading tenant context through all of them, and reading `headers()` server-side to supply it would force the ISR routes dynamic. Resolved after mount, so the global site's static HTML is byte-unchanged and only a tenant visitor sees the item drop.

## Closing the audit gap that let this sit

`scripts/audit-bph-leaks.mjs` listed *"verifying that every book.id rendered on a page belongs to the tenant"* as out of scope. Its hostname checks **structurally cannot** catch this class: the encyclopedia's hrefs are relative, so they resolve to `bph.sourcelibrary.org` and the audit passed clean while the page listed 102 other libraries' books.

It now:
- resolves every `/book/<id>` reference against `books.tenantId` and fails on any foreign book
- **seeds the blocked paths**, so if the block is ever removed they immediately re-expose foreign books and the audit fires
- reports **NOT RUN** when `MONGODB_URI` is absent — a skipped check never reads as a pass

Run against **unfixed** production it reproduces the finding exactly:

```
book links:     121 seen, 102 not held by this tenant
Foreign books linked (102):
  Links that stay on bph.sourcelibrary.org but point at books this tenant does not hold.
```

## Verification

- 10 new unit tests; full suite 643 passing; `npx tsc --noEmit` exit 0.
- Tests pin the predicate, the correctly-scoped routes staying reachable, segment-not-prefix matching (`/exploration` must not match `/explore`), that the block precedes the tenant rewrite in `proxy.ts`, that nav and proxy read the same list, and that every listed path resolves to a real route (a typo would silently block nothing).
- Negative control above: the extended audit detects the leak on current production.

## Out of scope

- Building tenant-scoped versions of these surfaces — that's new product, not a filter.
- The pre-existing silent 404 the audit reports on `/gallery/image/anything`; it comes from a deliberately bogus seed id and predates this work.
- Whether `/encyclopedia` deserves investment at all (#89 called it a data dump) — worth deciding before anyone builds a tenant-scoped twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)