### PR TITLE
fix(tenant): 404 Source Library's institutional pages on partner subdomains (#3370)

### DIFF
--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -8,6 +8,7 @@ import UserMenu from './UserMenu';
 import { Search, ChevronDown } from 'lucide-react';
 import { useLocale, localeHref, hasLocalizedTwin, NAV_STRINGS, type NavStrings, type Locale } from '@/lib/i18n';
 import { isGlobalOnlyNavHref } from '@/lib/tenant-global-paths';
+import { useIsEmbedded } from '@/hooks/useEmbedContext';
 
 interface NavLink {
   label: string;
@@ -35,25 +36,6 @@ function buildNavLinks(t: NavStrings): NavLink[] {
     { label: t.librarian, href: '/librarian' },
     { label: t.podcast, href: '/podcast' },
   ];
-}
-
-/**
- * True when rendering on a partner subdomain (bph.sourcelibrary.org, …) or
- * inside an /embed/* view. Deliberately host-shaped rather than an allow-list of
- * tenant slugs, so a new tenant subdomain is covered the day its DNS record
- * exists. `false` during SSR and on the first client render, so the global
- * site's static HTML is untouched.
- */
-function useIsTenantHost(): boolean {
-  const [isTenant, setIsTenant] = useState(false);
-  useEffect(() => {
-    const h = window.location.hostname;
-    const parts = h.split('.');
-    const isSubdomain =
-      h.endsWith('.sourcelibrary.org') && parts.length > 2 && parts[0] !== 'www';
-    setIsTenant(isSubdomain || window.location.pathname.startsWith('/embed/'));
-  }, []);
-  return isTenant;
 }
 
 interface Breadcrumb {
@@ -93,18 +75,22 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
   // derived one (null during static prerender).
   const locale = homeLocale ?? pathnameLocale;
   const t = NAV_STRINGS[locale];
-  // Corpus-wide surfaces 404 on partner subdomains (see GLOBAL_ONLY_TENANT_BLOCKED
-  // in src/proxy.ts, issue #3364), so the nav must not point at them there — "Map"
-  // would otherwise be a dead link in the tenant's own header.
+  // Global-only surfaces 404 on partner subdomains (the list and rationale live
+  // in src/lib/tenant-global-paths.ts — #3364, #3370), so the nav must not point
+  // at them there: "Map" → /explore/map would be a dead link in the tenant's own
+  // header.
   //
-  // Detected from the hostname rather than passed down: this is a client
-  // component rendered by ~every page, so a prop would mean threading tenant
-  // context through all of them, and reading headers() server-side to provide it
-  // would force the ISR routes dynamic. Resolved after mount, so the static HTML
-  // (which the global site shares) is unchanged and only a tenant visitor sees
-  // the item drop — acceptable for a nav link, and it never removes anything on
-  // sourcelibrary.org itself.
-  const isTenantHost = useIsTenantHost();
+  // Reuses the shared `useEmbedContext` signal (tenant subdomain, /embed/ route,
+  // or iframe) rather than a bespoke hostname check — #3367 added a second,
+  // narrower copy of this detection, which is exactly the drift the shared hook
+  // exists to prevent. Resolved after mount, so the static HTML the global site
+  // shares is unchanged and only a tenant visitor sees the item drop.
+  //
+  // Note most pages wrap this in ConditionalSiteHeader, which removes the whole
+  // header on a tenant host post-hydration. This filter is what protects the
+  // pages that render SiteHeader directly and stay reachable there (e.g.
+  // /author/[name]).
+  const isTenantHost = useIsEmbedded();
   const NAV_LINKS = buildNavLinks(t).filter(
     link => !(isTenantHost && isGlobalOnlyNavHref(link.href))
   );

--- a/src/lib/tenant-global-paths.ts
+++ b/src/lib/tenant-global-paths.ts
@@ -29,10 +29,49 @@
 
 /** Page routes. Also used to filter the site nav on tenant hosts. */
 export const GLOBAL_ONLY_TENANT_PAGE_PATHS = [
+  // Corpus-wide aggregations (#3364).
   '/encyclopedia',
   '/explore',
   '/ngrams',
   '/libraries',
+  // Source Library's own institutional pages (#3370). A partner reading room is
+  // not the place to tell Source Library's story, and these pages carry
+  // hardcoded links into the wider corpus: /about alone embeds a figure linking
+  // Michael Maier's Atalanta Fugiens plus four /q/ shortlinks to non-tenant
+  // books, which was the last foreign-book link the leak audit could find on
+  // bph.sourcelibrary.org. `/about` covers `/about/progress` by prefix.
+  '/about',
+  '/vision',
+  '/census',
+  '/research',
+  '/blog',
+  '/contribute',
+  '/support',
+  '/sponsors',
+] as const;
+
+/**
+ * Institutional pages that stay reachable on tenant hosts, deliberately.
+ *
+ * `/terms`, `/privacy`, `/dmca` and `/licensing` are legal and rights notices —
+ * a public site must serve them on whatever host it answers, and the first three
+ * plus `/developers` sit in the crawler-readable allow-lists that the
+ * three-layer AI-access gate depends on (`BOT_READABLE_PATHS` in src/proxy.ts,
+ * the path-scoped Cloudflare skip rule, and robots.txt DOCS_ONLY). Blocking them
+ * per-host would make the policy layer inconsistent for anything crawling a
+ * subdomain. `/in-memoriam` honours Joost Ritman, whose library IS the BPH
+ * collection — more apt on that subdomain than on the global site.
+ *
+ * Not enforced in code; recorded so the next person adding to the block list
+ * above knows these were considered and kept.
+ */
+export const TENANT_REACHABLE_INSTITUTIONAL_PATHS = [
+  '/terms',
+  '/privacy',
+  '/dmca',
+  '/licensing',
+  '/developers',
+  '/in-memoriam',
 ] as const;
 
 /**

--- a/tests/unit/tenant-global-paths.test.ts
+++ b/tests/unit/tenant-global-paths.test.ts
@@ -27,6 +27,7 @@ import {
   GLOBAL_ONLY_TENANT_API_PATHS,
   isGlobalOnlyTenantPath,
   isGlobalOnlyNavHref,
+  TENANT_REACHABLE_INSTITUTIONAL_PATHS,
 } from '@/lib/tenant-global-paths';
 
 const repoRoot = path.resolve(__dirname, '../..');
@@ -118,6 +119,7 @@ describe('proxy behavior', () => {
     });
 
   it.each([
+    // corpus-wide aggregations (#3364)
     '/encyclopedia',
     '/encyclopedia/Matthiolus',
     '/explore/timeline',
@@ -126,10 +128,32 @@ describe('proxy behavior', () => {
     '/libraries',
     '/libraries/internet-archive',
     '/api/entities',
+    // Source Library's own institutional pages (#3370)
+    '/about',
+    '/about/progress',
+    '/vision',
+    '/census',
+    '/research',
+    '/blog',
+    '/contribute',
+    '/support',
+    '/sponsors',
   ])('404s %s on a tenant subdomain', async (p) => {
     const res = await proxy(req(`https://bph.sourcelibrary.org${p}`, 'bph.sourcelibrary.org'));
     expect(res?.status).toBe(404);
   });
+
+  it.each(TENANT_REACHABLE_INSTITUTIONAL_PATHS)(
+    'keeps the legal/policy page %s reachable on a tenant subdomain',
+    async (p) => {
+      // Rights notices must be served on whatever host answers, and
+      // /terms, /privacy, /dmca, /licensing and /developers sit in the
+      // crawler-readable allow-lists the three-layer AI-access gate depends on.
+      // /in-memoriam honours Joost Ritman, whose library IS the BPH collection.
+      const res = await proxy(req(`https://bph.sourcelibrary.org${p}`, 'bph.sourcelibrary.org'));
+      expect(res?.status).not.toBe(404);
+    }
+  );
 
   it.each(['/collections', '/gallery', '/browse', '/search'])(
     'leaves the correctly-scoped route %s reachable on a tenant subdomain',
@@ -146,6 +170,17 @@ describe('proxy behavior', () => {
       expect(res?.status).not.toBe(404);
     }
   );
+});
+
+describe('the block list and the carve-out cannot overlap', () => {
+  it('no institutional path is both blocked and declared reachable', () => {
+    for (const keep of TENANT_REACHABLE_INSTITUTIONAL_PATHS) {
+      expect(
+        isGlobalOnlyTenantPath(keep),
+        `${keep} is declared tenant-reachable but the proxy blocks it`
+      ).toBe(false);
+    }
+  });
 });
 
 describe('wiring', () => {


### PR DESCRIPTION
Fixes #3370. Your call on option (1).

## What's blocked

`/about` (covers `/about/progress`), `/vision`, `/census`, `/research`, `/blog`, `/contribute`, `/support`, `/sponsors` — 404 on tenant hosts, added to the same `src/lib/tenant-global-paths.ts` list as the corpus-wide surfaces from #3364.

This closes the last foreign-book link the leak audit could find on `bph.sourcelibrary.org`: `/about` hardcodes a figure linking Michael Maier's *Atalanta Fugiens* — not a BPH holding — plus four `/q/` shortlinks to non-tenant books.

## What stays reachable, and why

Recorded in `TENANT_REACHABLE_INSTITUTIONAL_PATHS` so the next person adding to the block list knows these were considered:

- **`/terms`, `/privacy`, `/dmca`, `/licensing`** — rights notices. A public site must serve them on whatever host it answers.
- Those plus **`/developers`** sit in the crawler-readable allow-lists that the **three-layer AI-access gate** depends on (`BOT_READABLE_PATHS` in `src/proxy.ts`, the path-scoped Cloudflare skip rule, `robots.txt` DOCS_ONLY). Blocking them per-host would make the policy layer inconsistent for anything crawling a subdomain — and CLAUDE.md is explicit that changing one layer alone gets silently defeated by the others.
- **`/in-memoriam`** honours Joost Ritman, whose library *is* the BPH collection. More apt on that subdomain than on the global site.

A test asserts the two lists can never overlap.

## Correcting my own framing from #3367

I told you twice this needed a tenant-aware footer. **It doesn't.** `ConditionalFooter` and `ConditionalSiteHeader` already remove the global chrome post-hydration on tenant hosts, so real visitors never see those links — `/explore` and `/libraries` have in fact been linked-but-404 in the server HTML since #3367 with no user-visible effect.

What remains is that the links persist in *prerendered* HTML, because making the footer host-aware would mean reading `headers()` and forcing the ISR routes dynamic. So crawlers see hrefs that now 404. No non-tenant content is served, which is the part that matters; a dead href is a weaker problem than a page listing another library's books.

## Cleanup

Removes the bespoke hostname hook #3367 added to `SiteHeader` in favour of the existing shared `useEmbedContext`. A second, narrower copy of tenant detection is exactly the drift that hook exists to prevent — my own duplication, caught while reading the footer.

## Verification

- 711 tests pass; `npx tsc --noEmit` exit 0.
- **Negative control:** removing the eight new entries fails exactly 9 tests (the 8 paths plus the app-tree existence check) and nothing else.
- Behavioural tests call `proxy()` directly — a `Host` header cannot test a Vercel preview (it routes to production; see #3372).
- An existing test asserts every blocked path resolves to a real route under `src/app`, so a typo can't silently block nothing.
- Post-deploy: `node scripts/audit-bph-leaks.mjs` with `MONGODB_URI` should reach **0 foreign books** for the first time.

## Judgment call to flag

**`/blog` is the most debatable entry.** It's editorial rather than institutional, and its posts quote books across the corpus — which is exactly why I blocked it. If you'd rather partners see the writing, it's a one-line removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)