### PR TITLE
fix(e2e): locate Librarian suggestion chips structurally, not by wording (#3358)

### DIFF
--- a/e2e/embassy.spec.ts
+++ b/e2e/embassy.spec.ts
@@ -23,29 +23,37 @@ test.describe('Librarian', () => {
     await expect(page.getByText('The Librarian searches the collection')).toBeVisible();
   });
 
+  // The suggestion chips are NOT stable content. LibrarianClient redraws the
+  // set twice after first paint (`pickSuggestions`): once on mount, and again
+  // when the public-threads fetch resolves and blends in real visitor
+  // questions. So neither the wording of a chip nor its presence in the set
+  // survives long enough to assert on — both produced the #3358 flake:
+  //
+  //   1. locating chips by keyword (/Agrippa|Kabbalah|.../) — the redraw picks
+  //      4 of ~30 suggestions at random, so a keyword can vanish entirely and
+  //      the click times out;
+  //   2. capturing a chip's text and asserting the textarea matches THAT text
+  //      — the redraw can swap the chip between the read and the click.
+  //
+  // Both are fixed by locating chips structurally and asserting the behaviour.
+  const chips = (page: import('@playwright/test').Page) =>
+    page.getByTestId('suggestion-chip');
+
   test('shows suggestion chips', async ({ page }) => {
-    // Suggestions may vary — just verify at least 2 are visible
-    const suggestions = page.locator('button', {
-      hasText: /world soul|philosopher|Agrippa|Kabbalah|Emerald|Ficino|alchemist/i,
-    });
-    await expect(suggestions.first()).toBeVisible();
-    expect(await suggestions.count()).toBeGreaterThanOrEqual(1);
+    await expect(chips(page).first()).toBeVisible();
+    expect(await chips(page).count()).toBeGreaterThanOrEqual(1);
   });
 
   test('clicking suggestion populates input', async ({ page }) => {
-    // Click whichever suggestion is visible
-    const suggestions = page.locator('button', {
-      hasText: /world soul|philosopher|Agrippa|Kabbalah|Emerald|Ficino|alchemist/i,
-    });
-    await expect(suggestions.first()).toBeVisible();
-    const text = await suggestions.first().textContent();
-    await suggestions.first().click();
+    await expect(chips(page).first()).toBeVisible();
+
     const textarea = page.locator('textarea');
-    // After clicking, the textarea should contain part of the suggestion text
-    if (text) {
-      const keyword = text.split(/\s+/).find(w => w.length > 4) || text.slice(0, 10);
-      await expect(textarea).toHaveValue(new RegExp(keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
-    }
+    await expect(textarea).toHaveValue('');
+    await chips(page).first().click();
+
+    // Empty → a whole question (4+ words). WHICH question is deliberately not
+    // asserted; see the note above.
+    await expect(textarea).toHaveValue(/\S+(\s+\S+){3,}/);
   });
 
   test('anonymous visitors can use the Librarian input', async ({ page }) => {

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -933,6 +933,10 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                         {suggestions.map((suggestion) => (
                           <button
                             key={suggestion}
+                            // Stable hook for e2e: the chip SET is redrawn twice
+                            // after first paint (see pickSuggestions), so tests
+                            // cannot locate a chip by its wording (#3358).
+                            data-testid="suggestion-chip"
                             onClick={() => { setInput(suggestion); inputRef.current?.focus(); }}
                             className="px-3 py-1.5 text-xs text-[#6b6560] border border-[#e8e4dc] rounded-full hover:bg-[#f5f0e8] hover:text-[#444] transition-colors font-sans"
                           >


### PR DESCRIPTION
Fixes #3358.

## What actually failed

`Librarian › clicking suggestion populates input` failed 3 retries deep on the 2026-07-26 scheduled run ([30194810316](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/actions/runs/30194810316)) and is still reported as **"1 flaky"** on the green 2026-07-27 run. The other failures in that run — the `bph-iframe` strict-mode violations — did not recur and are not touched here.

**The app is correct. The test assumed the chips hold still; they don't.**

`LibrarianClient.pickSuggestions` redraws the suggestion set **twice** after first paint:

1. on mount — the initial set is seeded deterministically on purpose (a random one hydration-mismatches, React #418), so the shuffle is deferred to a `useEffect`;
2. again when the public-threads fetch resolves and blends up to two real visitor questions into the set.

That gave the spec two independent ways to fail, and it hit both:

| # | Assumption | How the redraw breaks it |
|---|---|---|
| 1 | chips are locatable by keyword (`/world soul\|Agrippa\|Kabbalah\|…/`) | the redraw picks 4 of ~30 suggestions at random, so every keyword in the alternation can be absent — the click times out |
| 2 | `first().textContent()` still describes the chip you're about to click | the redraw can swap the chip between the read and the click — this is the reported symptom, `unexpected value "Tell me about the Emerald Tablet"` |

## Fix

- `data-testid="suggestion-chip"` on the chip button — a stable hook, since the wording provably isn't one.
- The spec locates on that testid and asserts the **behaviour**: textarea goes from empty to a whole 4+ word question. *Which* question is deliberately not asserted, with a comment saying why so nobody "tightens" it back into a flake.

## Verification — forced the race instead of waiting for it

Re-running the old test 8× locally passed **8/8**, which is exactly why this read as noise for weeks. So I built a probe that delays `/api/embassy/threads` by 2.5s, putting the redraw *after* the read — the slow-network timing CI hits:

| | old assertion | new assertion |
|---|---|---|
| under forced redraw | **failed 3/3** | passes |
| plain repeat run (no delay) | 8/8 pass | 4/4 pass |

The probe also caught failure mode #1 independently: the old keyword locator timed out on `.click()` when no drawn chip matched the alternation. The probe was throwaway and is not committed.

`npx tsc --noEmit` clean.

## Note for the reviewer

The one app-side change is a `data-testid` attribute — no behaviour, no styling. The e2e suite runs against a **deployed** base URL, so this test only goes green once the attribute ships; expect the scheduled run to still report the old flake until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)