### PR TITLE
fix(tenant): restore Account / Sign out on partner subdomains (#2150)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import AnalyticsScripts from "@/components/providers/AnalyticsScripts";
 import EmbedLinkInterceptor from "@/components/embed/EmbedLinkInterceptor";
 import EmbedHostNavigationListener from "@/components/embed/EmbedHostNavigationListener";
 import EmbedHistoryPatch from "@/components/embed/EmbedHistoryPatch";
+import TenantAccountMenu from "@/components/embed/TenantAccountMenu";
 import ScrollReveal from "@/components/layout/ScrollReveal";
 
 
@@ -162,6 +163,12 @@ export default async function RootLayout({
           <EmbedLinkInterceptor />
           <EmbedHostNavigationListener />
           <EmbedHistoryPatch />
+          {/* Tenant subdomains serve the global routes with the SiteHeader
+              stripped, which left signed-in readers with no way to reach their
+              account or sign out (#2150). Must sit inside <Providers> for the
+              session, and stays client-gated so the root layout never reads
+              headers() and the book page keeps its ISR cache. */}
+          <TenantAccountMenu />
           <div id="main-content" className="flex-1">
             {children}
           </div>

--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -101,7 +101,28 @@ function writeCookie(name: string, on: boolean) {
   document.cookie = `${name}=${on ? '1' : '0'}; path=/; max-age=${COOKIE_MAX_AGE}; samesite=lax`;
 }
 
-export default function EmbedUserMenu() {
+export interface EmbedUserMenuProps {
+  /**
+   * `full` (default) — the partner landing/catalogue surface under
+   * `/embed/<tenant>/*`: view-options toggles, BPH catalogue search, and auth.
+   * Rendered to everyone, signed in or not.
+   *
+   * `account-only` — the global routes a tenant subdomain serves directly
+   * (`/book/*`, `/collections/*`, …). Renders NOTHING for anonymous visitors
+   * and only the auth affordance for signed-in ones (#2150).
+   *
+   * The split exists because those pages strip the SiteHeader entirely on a
+   * tenant host, which left signed-in visitors with no Account or Sign-out
+   * control anywhere on the subdomain. Restoring auth there is a bug fix;
+   * putting the view-options toggles back is a separate product decision
+   * (2026-05-28: BPH is deliberately "hidden, no toggle"), so this variant
+   * deliberately does not reopen it.
+   */
+  variant?: 'full' | 'account-only';
+}
+
+export default function EmbedUserMenu({ variant = 'full' }: EmbedUserMenuProps = {}) {
+  const accountOnly = variant === 'account-only';
   const { data: session, status } = useStableSession();
   const [isOpen, setIsOpen] = useState(false);
   const [imgError, setImgError] = useState(false);
@@ -127,8 +148,8 @@ export default function EmbedUserMenu() {
   useEffect(() => {
     setHideAi(readHideAi());
     setHideGuide(readCookie(COOKIE_HIDE_GUIDE));
-    setShowSearch(isBphSurface());
-  }, []);
+    setShowSearch(!accountOnly && isBphSurface());
+  }, [accountOnly]);
 
   // Focus the field as it expands.
   useEffect(() => {
@@ -146,6 +167,11 @@ export default function EmbedUserMenu() {
   }, []);
 
   if (status === 'loading') return null;
+  // On a tenant subdomain's global routes the menu exists only to give a
+  // signed-in reader their Account / Sign out back. An anonymous visitor there
+  // gets no floating control at all — the partner reading room stays a
+  // sign-in-free surface and its pages look exactly as they do today.
+  if (accountOnly && !session) return null;
 
   // CSS-driven hiding: the inline script in embed/layout.tsx sets data
   // attributes on <html> at page-load time; the toggle handlers update them
@@ -263,27 +289,29 @@ export default function EmbedUserMenu() {
 
       {isOpen && (
         <div className="absolute right-0 mt-2 w-64 rounded-md bg-white border border-border-light shadow-lg overflow-hidden">
-          <div className="px-3 py-2 border-b border-border-light/60">
-            <div className="text-xs text-muted mb-1.5">View</div>
-            <label className="flex items-start gap-2 py-1 cursor-pointer text-sm text-secondary hover:text-primary">
-              <input
-                type="checkbox"
-                checked={hideAi}
-                onChange={toggleHideAi}
-                className="mt-0.5"
-              />
-              <span>Hide AI introductions &amp; summaries</span>
-            </label>
-            <label className="flex items-start gap-2 py-1 cursor-pointer text-sm text-secondary hover:text-primary">
-              <input
-                type="checkbox"
-                checked={hideGuide}
-                onChange={toggleHideGuide}
-                className="mt-0.5"
-              />
-              <span>Hide reading guide &amp; pedagogical helpers</span>
-            </label>
-          </div>
+          {!accountOnly && (
+            <div className="px-3 py-2 border-b border-border-light/60">
+              <div className="text-xs text-muted mb-1.5">View</div>
+              <label className="flex items-start gap-2 py-1 cursor-pointer text-sm text-secondary hover:text-primary">
+                <input
+                  type="checkbox"
+                  checked={hideAi}
+                  onChange={toggleHideAi}
+                  className="mt-0.5"
+                />
+                <span>Hide AI introductions &amp; summaries</span>
+              </label>
+              <label className="flex items-start gap-2 py-1 cursor-pointer text-sm text-secondary hover:text-primary">
+                <input
+                  type="checkbox"
+                  checked={hideGuide}
+                  onChange={toggleHideGuide}
+                  className="mt-0.5"
+                />
+                <span>Hide reading guide &amp; pedagogical helpers</span>
+              </label>
+            </div>
+          )}
 
           {/* Signed-in users keep Account + Sign out. Anonymous visitors are
               shown no sign-in affordance in the embed — the menu is just the

--- a/src/components/embed/TenantAccountMenu.tsx
+++ b/src/components/embed/TenantAccountMenu.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+/**
+ * Restores the Account / Sign-out control on tenant subdomains (#2150).
+ *
+ * After the tenant-as-filter migration, a partner subdomain serves the GLOBAL
+ * routes directly — `bph.sourcelibrary.org/book/<slug>` renders
+ * `src/app/book/[id]/page.tsx`, not an `/embed/*` route. Two things follow:
+ *
+ *   1. `src/app/embed/layout.tsx` never runs there, so `EmbedUserMenu` — which
+ *      it is the only mount point for — is absent;
+ *   2. `ConditionalSiteHeader` removes the whole SiteHeader on a tenant host
+ *      post-hydration, so the header's account control is gone too.
+ *
+ * Net effect, verified live on 2026-07-27 against the hydrated DOM of
+ * bph.sourcelibrary.org/book/…: zero auth affordances on the page. A signed-in
+ * reader on a partner subdomain could not reach their account or sign out.
+ *
+ * Mounted from the ROOT layout and gated client-side on purpose. The root
+ * layout must not read `headers()` — that would force dynamic rendering and
+ * break ISR on the book page (`revalidate = 86400`), which is the same
+ * constraint that made site-mode detection client-side in the first place.
+ * `useEmbedContext` resolves its host signal in a post-mount effect, so the
+ * server HTML is identical for every host and stays cacheable.
+ */
+
+import { usePathname } from 'next/navigation';
+import { useEmbedContext } from '@/hooks/useEmbedContext';
+import EmbedUserMenu from './EmbedUserMenu';
+
+export default function TenantAccountMenu() {
+  const { isEmbedded } = useEmbedContext();
+  const pathname = usePathname();
+
+  // `/embed/*` already mounts the full menu from its own layout — mounting a
+  // second instance here would stack two floating controls in the same corner.
+  if (pathname?.startsWith('/embed/')) return null;
+  if (!isEmbedded) return null;
+
+  // `account-only`: nothing renders for anonymous visitors, and the
+  // view-options toggles stay off. Restoring those is a product decision
+  // (2026-05-28 — BPH is deliberately "hidden, no toggle"), not part of this
+  // fix; see EmbedUserMenuProps.
+  return <EmbedUserMenu variant="account-only" />;
+}

--- a/tests/unit/tenant-account-menu.test.ts
+++ b/tests/unit/tenant-account-menu.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+// A signed-in reader on a partner subdomain must always have a way to reach
+// their account and sign out (#2150).
+//
+// The failure this pins is structural, not visual, which is why it went
+// unnoticed for two months: on a tenant host the global routes render with
+// `ConditionalSiteHeader` removing the SiteHeader post-hydration, and
+// `EmbedUserMenu` — the "only sign-out affordance" on embed surfaces — was
+// mounted solely by `src/app/embed/layout.tsx`, which those routes never hit.
+// The result was a page with zero auth affordances, verified live against the
+// hydrated DOM of bph.sourcelibrary.org/book/… on 2026-07-27.
+//
+// Each assertion below is one link in the chain that keeps that from
+// reoccurring. Removing any single one restores the bug silently.
+const repoRoot = path.resolve(__dirname, '..', '..');
+const read = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf8');
+
+describe('tenant subdomain account menu (#2150)', () => {
+  const layout = read('src/app/layout.tsx');
+  const menu = read('src/components/embed/TenantAccountMenu.tsx');
+  const embedMenu = read('src/components/embed/EmbedUserMenu.tsx');
+
+  it('is mounted from the ROOT layout, not only from embed/layout.tsx', () => {
+    // embed/layout.tsx does not run on a tenant subdomain's global routes.
+    expect(layout).toMatch(/import TenantAccountMenu from/);
+    expect(layout).toMatch(/<TenantAccountMenu\s*\/>/);
+  });
+
+  it('is mounted inside <Providers> so the session is available', () => {
+    const open = layout.indexOf('<Providers>');
+    const close = layout.indexOf('</Providers>');
+    const mount = layout.indexOf('<TenantAccountMenu />');
+    expect(open).toBeGreaterThan(-1);
+    expect(mount).toBeGreaterThan(open);
+    expect(mount).toBeLessThan(close);
+  });
+
+  it('keeps the root layout free of headers() — ISR on the book page depends on it', () => {
+    // Detecting the tenant host server-side here would force dynamic rendering
+    // and blank the ISR cache the book page relies on (revalidate = 86400).
+    expect(layout).not.toMatch(/from ['"]next\/headers['"]/);
+    expect(menu).toMatch(/useEmbedContext/);
+  });
+
+  it('does not double-mount on /embed/* routes', () => {
+    // embed/layout.tsx renders the full menu there; a second floating control
+    // would stack in the same corner.
+    expect(menu).toMatch(/pathname\?\.startsWith\('\/embed\/'\)/);
+  });
+
+  it('renders nothing for anonymous visitors in account-only mode', () => {
+    // A partner reading room stays a sign-in-free surface: this fix must not
+    // add a floating control to pages anonymous readers see.
+    expect(embedMenu).toMatch(/if \(accountOnly && !session\) return null;/);
+  });
+
+  it('keeps the view-options toggles out of account-only mode', () => {
+    // Re-enabling those on tenant pages is a product decision (2026-05-28:
+    // BPH is deliberately "hidden, no toggle"), not part of the bug fix.
+    expect(embedMenu).toMatch(/\{!accountOnly && \(/);
+    expect(menu).toMatch(/variant="account-only"/);
+  });
+
+  it('still offers Account and Sign out to signed-in users', () => {
+    expect(embedMenu).toMatch(/Sign out/);
+    expect(embedMenu).toMatch(/navigateToAccount/);
+  });
+});


### PR DESCRIPTION
Fixes #2150 — the half the issue flagged as *"higher-priority"* and *"should be confirmed"*. Now confirmed, and fixed.

## Confirmed live

The issue asked whether signed-in users on a tenant subdomain have any account control. They do not. Checked 2026-07-27 against the **hydrated** DOM of `bph.sourcelibrary.org/book/aurora-consurgens-…`, in a browser holding a **valid session** (`/api/auth/session` → `dereklomas@gmail.com`):

```
headerPresent:     false
navHrefs:          null
embedUserMenu:     false
authAffordances:   []      ← zero sign-in/out/account controls anywhere on the page
```

A signed-in reader on a partner subdomain is stranded: no Account, no Sign out, on any page.

## Why it hid for two months

Two individually-correct behaviours compose into the gap, and **`curl` cannot see it** — the server HTML still contains a header, which is removed only after hydration.

After the tenant-as-filter migration a partner subdomain serves the **global** routes directly (`src/proxy.ts` rewrites only `/`, `/catalogue*`, `/catalog/*`). So on `/book/<slug>`:

1. `src/app/embed/layout.tsx` never runs — and it is the **only** mount point for `EmbedUserMenu`, which its own header comment calls *"the only sign-out affordance"* for surfaces where the SiteHeader is stripped;
2. `ConditionalSiteHeader` then strips the SiteHeader post-hydration on a tenant host, taking the header's account control with it.

## The fix

Mount the menu from the **root layout**, client-gated, in a new `account-only` variant.

- **Root layout, not a tenant layout.** Reading `headers()` there would force dynamic rendering and blank the book page's ISR cache (`revalidate = 86400`) — the same constraint that already makes site-mode detection client-side. `useEmbedContext` resolves the host in a post-mount effect, so server HTML stays host-agnostic and cacheable.
- **`account-only` renders nothing for anonymous visitors**, and omits the view-options toggles and BPH catalogue search. Anonymous BPH pages are byte-identical to today. Restoring auth is a bug fix; putting the toggles back is a **separate product decision** (2026-05-28: BPH is deliberately "hidden, no toggle"), so this deliberately does not reopen it — the plumbing is there to flip later.
- **`/embed/*` untouched** — it still mounts the full menu from its own layout, and `TenantAccountMenu` returns `null` there so the two never stack.

## Guard

`tests/unit/tenant-account-menu.test.ts` pins each link in the chain: root-layout mount, inside `<Providers>`, no `next/headers` in the root layout, no double-mount on `/embed/*`, anonymous renders nothing, toggles stay out, Account + Sign out still present. Removing any one restores the bug silently.

725 unit tests pass; `npx tsc --noEmit` clean.

## Verification — read this before approving

**A Vercel preview cannot verify this.** Two independent reasons:

1. CLAUDE.md's known trap — curling a preview with `Host: bph.sourcelibrary.org` makes Vercel's router serve the **production** deployment for that domain, producing a convincing false result.
2. The gate is `isTenantSubdomain(window.location.host)`, and a preview host is `sourcelibrary-v2-git-….vercel.app` — not a `.sourcelibrary.org` subdomain, so the menu correctly does not mount there regardless.

What the preview **can** confirm, and what I'll check on it: `/embed/bph/*` still shows exactly one floating menu, and the apex site is unchanged.

The tenant path must be verified **after deploy, on the real subdomain, while signed in** — same method as the confirmation above. I can run that check once it ships.

## Out of scope

- The view-options toggles on tenant pages (product decision above).
- `EmbedUserMenu`'s `navigateToAccount` comment is now stale — it says the proxy rewrites *every* non-`/embed/` path, which stopped being true. Its behaviour (routing `/account` to the apex, where the shared `.sourcelibrary.org` cookie carries the session) is still correct, so I left it alone rather than widen the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)