### PR TITLE
fix(seo): real 404 for unknown reader page ids (#3376 follow-up)

### DIFF
--- a/src/app/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/book/[id]/page/[pageId]/layout.tsx
@@ -1,4 +1,6 @@
+import { cache } from 'react';
 import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { getTenantContext } from '@/lib/tenant-context';
@@ -21,7 +23,9 @@ const PAGE_META_PROJECTION = {
   'translation.data': 1, 'ocr.data': 1, seo_indexable: 1,
 };
 
-async function getPageData(bookId: string, pageId: string, tenantId?: string): Promise<{ book: Book | null; page: Page | null }> {
+// `cache()`d because both generateMetadata and the layout shell below read it;
+// without it a reader page would issue this book+page lookup twice per request.
+const getPageData = cache(async function getPageData(bookId: string, pageId: string, tenantId?: string): Promise<{ book: Book | null; page: Page | null }> {
   try {
     const db = await getReadDb();
     const [bookResult, page] = await Promise.all([
@@ -44,7 +48,7 @@ async function getPageData(bookId: string, pageId: string, tenantId?: string): P
   } catch {
     return { book: null, page: null };
   }
-}
+});
 
 export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
   const { id, pageId } = await params;
@@ -116,6 +120,30 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
   };
 }
 
-export default async function PageLayout({ children }: LayoutProps) {
+export default async function PageLayout({ children, params }: LayoutProps) {
+  // Resolve existence HERE, in the shell, rather than leaving it to page.tsx.
+  //
+  // This segment has a loading.tsx and deliberately keeps it — the reader is
+  // the one route where the skeleton earns its place, on every page turn. But
+  // a loading.tsx wraps its page.tsx in an automatic <Suspense>, so Next.js
+  // flushes the 200 shell the moment the page's data fetch suspends, before
+  // page.tsx's notFound() runs. The status is committed by then and notFound()
+  // can only swap the body — the soft-404 documented in CLAUDE.md and fixed on
+  // sibling routes in #3277 and #3376.
+  //
+  // A layout sits ABOVE that boundary, so awaiting here still sets a real 404
+  // and the skeleton is untouched.
+  //
+  // The condition is deliberately a strict SUBSET of page.tsx's four notFound()
+  // cases: missing page, missing book, and (inside getPageData) a page whose
+  // book_id doesn't match the book in the URL. The hidden-book gate stays in
+  // page.tsx alone — `findBookByIdOrSlug` does not filter on visibility, so the
+  // editor preview route (page/[pageId]/preview, allowHidden) still renders
+  // hidden books through this layout exactly as before.
+  const { id, pageId } = await params;
+  const ctx = await getTenantContext();
+  const { book, page } = await getPageData(id, pageId, ctx?.id ?? undefined);
+  if (!book || !page) notFound();
+
   return children;
 }

--- a/tests/unit/soft-404-loading-guard.test.ts
+++ b/tests/unit/soft-404-loading-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 
 // Unknown detail-page slugs must return a REAL 404 status, not a soft-404
@@ -57,4 +57,38 @@ describe('soft-404 guard: no loading.tsx above a route existence check (#3232, #
       expect(existsSync(path.join(repoRoot, rel))).toBe(false);
     });
   }
+});
+
+// The reader takes the OTHER solution to the same problem, and needs its own
+// guard because "the loading.tsx is absent" cannot express it.
+//
+// `/book/[id]/page/[pageId]` is the one route where the skeleton genuinely
+// earns its keep — it shows on every page turn — so deleting its loading.tsx
+// would trade a status code for a visible regression. Instead the existence
+// check moved UP into the segment's layout.tsx, which renders above the
+// automatic <Suspense> that loading.tsx creates. Keep both halves: the layout
+// gate is what sets the status, the loading.tsx is what the reader sees.
+describe('soft-404 guard: the reader gates in its layout, above the boundary (#3376)', () => {
+  const readerDir = 'src/app/book/[id]/page/[pageId]';
+  const layout = readFileSync(path.join(repoRoot, readerDir, 'layout.tsx'), 'utf8');
+
+  it('keeps its loading.tsx — the skeleton is load-bearing on page turns', () => {
+    expect(existsSync(path.join(repoRoot, readerDir, 'loading.tsx'))).toBe(true);
+  });
+
+  it('calls notFound() from the layout shell, not only from page.tsx', () => {
+    expect(layout).toMatch(/from ['"]next\/navigation['"]/);
+    expect(layout).toMatch(/if \(!book \|\| !page\) notFound\(\);/);
+  });
+
+  it('dedupes the lookup so the gate costs no extra query', () => {
+    // generateMetadata and the layout shell both read it.
+    expect(layout).toMatch(/const getPageData = cache\(/);
+  });
+
+  it('does not gate on visibility — that would 404 the editor preview route', () => {
+    // page/[pageId]/preview renders hidden books for editors through this same
+    // layout (allowHidden). The hidden-book 404 belongs in page.tsx alone.
+    expect(layout).not.toMatch(/isHiddenBook/);
+  });
 });


### PR DESCRIPTION
Closes the soft-404 family opened by #3232 and continued in #3376. Follow-up to #3381.

## The last one

Measured on production today:

```
/book/platonis-opera-plato/page/definitely-not-a-real-page-id   200
/book/platonis-opera-plato/page/abc123def456abc123def456        200
/book/curious-physics-hellwig/page/zzzzzzzz                     200
```

All three serve the "Page Not Found" body with the `NEXT_HTTP_ERROR_FALLBACK;404` digest baked in. Purely **numeric** page numbers are already caught by `proxy.ts` and 302 — this is the non-numeric id case that slips past it, and it's the one CLAUDE.md warns about under quote-and-link validation (*"`curl -w '%{http_code}'` returns 200 for these soft-404s"*).

## The fix is deliberately NOT the sibling fix

Same mechanism as #3277 / #3376 — `loading.tsx` wraps `page.tsx` in an automatic `<Suspense>`, the 200 shell flushes when the data fetch suspends, and `notFound()` arrives after the status is committed.

But #3277 **deliberately left this segment's `loading.tsx` alone**, and that was the right call: the reader is the one route where the skeleton earns its keep, because it shows on *every page turn*. Deleting it would trade a status code for a visible regression on the highest-traffic URL set in the site.

So instead the existence check moves **up into the segment's own `layout.tsx`**, which renders above the boundary `loading.tsx` creates.

The layout already had `getPageData()` for `generateMetadata`, and already **knew** about this case — it returns `title: 'Page Not Found - Source Library'` for it. It just never acted on it. Now it does, and the lookup is wrapped in `cache()` so the gate costs no extra query.

## Why this can't over-404

The layout's condition is a strict **subset** of `page.tsx`'s four `notFound()` cases:

| case | page.tsx | layout (this PR) |
|---|---|---|
| page id doesn't exist | 404 | 404 |
| book id/slug doesn't resolve | 404 | 404 |
| page.book_id ≠ book in URL | 404 | 404 (inside `getPageData`) |
| **book is hidden** | 404 (unless `allowHidden`) | **not checked — deliberate** |

The hidden-book gate stays in `page.tsx` alone. `findBookByIdOrSlug` does not filter on visibility, so the editor preview route (`page/[pageId]/preview`, which passes `allowHidden`) still renders hidden books through this same layout exactly as before. Gating on visibility here would have broken it.

No ISR concern: this route already reads `headers()` via `getTenantContext()` and is dynamic.

## Guard

The existing `tests/unit/soft-404-loading-guard.test.ts` gains a second `describe` block, because *"the loading.tsx is absent"* — the assertion shape used for every other route — **cannot express this fix**. The new block pins the opposite: the `loading.tsx` is still **present** (the skeleton is load-bearing), the layout calls `notFound()`, the lookup is `cache()`d, and the layout does **not** reference `isHiddenBook`.

722 unit tests pass; `npx tsc --noEmit` clean.

## Verification

Curl matrix against the preview once it builds — the three ids above must return **404**, and a real page (`/book/<slug>/page/<real-id>`) must still 200 and render with its skeleton intact. Status and body checked together, since status alone was 200 for all of these before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)