### PR TITLE
feat(ocr): grounded Gemini correction — standard repair lane for RECITATION-blocked books

### DIFF
--- a/scripts/lib/early-modern-text.mjs
+++ b/scripts/lib/early-modern-text.mjs
@@ -1,0 +1,86 @@
+/**
+ * Early-modern typography helpers for OCR correction.
+ *
+ * WHY: layout OCR engines (MinerU) do not understand pre-1820 typography. The
+ * dominant artefact is the long s (ſ) being read as "f" — "firft finne" for
+ * "first sinne", "Herefy and Atheifme" for "Heresy and Atheisme". The MinerU
+ * worker's quality gate screens for run-together text and short output; it does
+ * NOT catch letter substitution, so mangled pre-1820 pages pass it silently and
+ * reach readers looking like confident OCR.
+ *
+ * These helpers give the correction lane a deterministic normalisation step and
+ * a detector that can refuse to write text still carrying the artefact — never
+ * trust the model to have followed the instruction (measured: it normalised on
+ * two pages of a three-page sample and emitted raw ſ on the third).
+ */
+
+/** Long s and its ligatures → modern equivalents. Deterministic, lossless for reading. */
+export function normalizeLongS(text) {
+  if (typeof text !== 'string') return text;
+  return text
+    .replace(/ſ/g, 's')   // ſ LATIN SMALL LETTER LONG S
+    .replace(/ﬅ/g, 'st')  // ﬅ LONG S T ligature
+    .replace(/ﬆ/g, 'st'); // ﬆ ST ligature
+}
+
+/**
+ * Words that are only plausible as long-s misreads. Deliberately conservative:
+ * every entry is a real early-modern word whose "f" spelling is not an English
+ * word, so a hit is evidence of the artefact rather than of period spelling.
+ *
+ * NOT included: "fame" (a real word — "the fame time" is a misread but "fame"
+ * alone is legitimate), "fo", "fon". Those need context, and a noisy detector
+ * gets bypassed.
+ */
+const LONG_S_ARTEFACTS = [
+  'firft', 'moft', 'muft', 'juft', 'laft', 'beft', 'worft',
+  'fhall', 'fhould', 'fhe', 'fuch', 'fome', 'felf', 'fince',
+  'thefe', 'thofe', 'whofe', 'houfe', 'caufe', 'becaufe', 'ufe',
+  'confecration', 'diftribution', 'afpiring', 'herefy', 'atheifme',
+  'philofopher', 'philofophy', 'majefty', 'perfon', 'prefent', 'poffeft',
+  'obfervance', 'facrifices', 'bufineffe',
+  'expreffe', 'invefted', 'afcribed', 'prieft', 'pofterity',
+];
+// Deliberately absent, and they must stay absent — each is an ordinary English
+// word, so listing it turns a correct page into a rejected one:
+//   infinite, anxiety, fire, reft ("reft" is archaic English for "bereft").
+// A gate that rejects good pages gets bypassed, which is worse than no gate.
+const ARTEFACT_RE = new RegExp(`\\b(${LONG_S_ARTEFACTS.join('|')})\\b`, 'gi');
+
+/**
+ * Count long-s artefacts remaining in a text.
+ * Returns { count, samples } — samples for the operator to eyeball.
+ */
+export function detectLongSArtefacts(text) {
+  if (typeof text !== 'string' || !text) return { count: 0, samples: [] };
+  const raw = (text.match(/ſ/g) || []).length;      // literal ſ still present
+  const subs = text.match(ARTEFACT_RE) || [];
+  const samples = [...new Set(subs.map(s => s.toLowerCase()))].slice(0, 8);
+  return { count: raw + subs.length, samples, rawLongS: raw, substitutions: subs.length };
+}
+
+/**
+ * Is this text acceptable to write as corrected OCR?
+ * Rejects when the "correction" still carries the artefact it was meant to fix.
+ *
+ * @param {string} corrected
+ * @param {string} original - the pre-correction text, for a relative check
+ */
+export function isCorrectionAcceptable(corrected, original) {
+  if (typeof corrected !== 'string' || corrected.trim().length === 0) {
+    return { ok: false, reason: 'empty output' };
+  }
+  const after = detectLongSArtefacts(corrected);
+  if (after.count === 0) return { ok: true, reason: 'clean' };
+
+  const before = detectLongSArtefacts(original || '');
+  // Allow a residue only if it is a large improvement AND small in absolute terms;
+  // otherwise the model did not do the job and we must not overwrite.
+  if (before.count > 0 && after.count <= Math.min(2, before.count * 0.1)) {
+    return { ok: true, reason: `residual ${after.count} (from ${before.count})` };
+  }
+  return {
+    ok: false,
+    reason: `long-s artefacts remain: ${after.count} (was ${before.count}) e.g. ${after.samples.join(', ')}`,
+  };
+}

--- a/scripts/workers/ocr-correct-grounded.mjs
+++ b/scripts/workers/ocr-correct-grounded.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * ocr-correct-grounded.mjs — second pass over MinerU OCR: correct it against the
+ * page image with Gemini.
+ *
+ * THE LANE THIS COMPLETES
+ * -----------------------
+ * Gemini's RECITATION filter refuses to transcribe ubiquitous canonical texts
+ * (NT/Galatians, Talmud, Migne, Hamlet), so those books stall. MinerU has no such
+ * filter and is free — but it only reads modern print well. On pre-1820 typography
+ * it produces three failure classes:
+ *
+ *   1. long s read as "f"      "firft finne"  ->  "first sinne"
+ *   2. words run together       "knowledgeinclines"
+ *   3. display type as soup     "qnore or0 FnT H Esi),bnim ymomu aor"
+ *
+ * Classes 1-2 are text-fixable. Class 3 is NOT — the characters were never read,
+ * so a text-only "correction" would invent plausible words. That is why this pass
+ * sends the PAGE IMAGE alongside the text: the model corrects against the scan and
+ * genuinely re-reads what MinerU garbled. Verified on Bacon's *Advancement of
+ * Learning* (1763) p119: MinerU's soup became "OF THE / DIGNITY AND ADVANCEMENT /
+ * OF LEARNING.", matching the plate exactly.
+ *
+ * So the standard repair lane for a RECITATION-blocked book is:
+ *     mineru-ocr-worker.mjs   (free, no filter, reads the page)
+ *  -> ocr-correct-grounded.mjs (this: corrects against the image)
+ *
+ * SAFETY
+ * ------
+ *  - Dry-run by default; --apply to write.
+ *  - Snapshots existing OCR to page_revisions before overwriting (reason
+ *    'grounded_correction') — never silently replaces text.
+ *  - Deterministic ſ->s normalisation AFTER the model, because the model does not
+ *    reliably follow that instruction (2 of 3 pages in the pilot).
+ *  - Refuses to write a "correction" that still carries long-s artefacts. A pass
+ *    that quietly writes unimproved text is worse than no pass.
+ *  - Only touches pages whose ocr.source is MinerU. Never overwrites Gemini OCR.
+ *
+ * USAGE
+ *   node scripts/workers/ocr-correct-grounded.mjs --book <id>            # dry-run
+ *   node scripts/workers/ocr-correct-grounded.mjs --book <id> --apply
+ *   node scripts/workers/ocr-correct-grounded.mjs --pre-1820 --limit 5 --apply
+ */
+import { MongoClient } from 'mongodb';
+import { GoogleGenAI } from '@google/genai';
+import { getPageSource } from '../lib/page-image-url.mjs';
+import { saveRevisionsBeforeOverwrite } from '../lib/page-revisions.mjs';
+import { normalizeLongS, isCorrectionAcceptable, detectLongSArtefacts } from '../lib/early-modern-text.mjs';
+
+const argv = process.argv.slice(2);
+const flag = k => argv.includes(k);
+const opt = (k, d) => { const i = argv.indexOf(k); return i >= 0 ? argv[i + 1] : d; };
+
+const APPLY = flag('--apply');
+const ONE_BOOK = opt('--book', null);
+const PRE1820 = flag('--pre-1820');
+const LIMIT = parseInt(opt('--limit', '1'), 10);
+const PAGE_LIMIT = parseInt(opt('--page-limit', '0'), 10);
+const MODEL = opt('--model', 'gemini-3.1-flash-lite');
+const CONCURRENCY = parseInt(opt('--concurrency', '4'), 10);
+
+const PROMPT = `You are correcting an existing OCR transcription of a printed page, using the page image as the authority.
+
+The transcription came from a layout OCR engine that does not understand early-modern typography. Its known failure modes:
+- the long s (ſ) is read as "f"  ("firft" for "first", "Herefy" for "Heresy")
+- words run together ("knowledgeinclines", "OFLEARNING")
+- decorative / display type on title pages comes out as garbage character soup
+
+Your job:
+1. Read the page image.
+2. Return the page's text, using the supplied transcription as a starting point but CORRECTING it against what the image actually shows.
+3. Where the supplied transcription is garbage, transcribe from the image instead.
+4. Preserve the original spelling and punctuation EXACTLY as printed, with one exception: write the long s as a normal "s". Keep period spellings ("Consecration", "shewed", "Atheisme", "businesse", "individuall") — do NOT modernise them.
+5. Preserve the printed line and paragraph structure, running heads, folio numbers, catchwords and signature marks.
+6. If a passage is genuinely illegible in the image, output <unclear/> rather than guessing. Never invent text that you cannot see.
+
+Output ONLY the corrected page text. No commentary, no code fences.
+
+--- EXISTING TRANSCRIPTION ---
+`;
+
+const key = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY_2 || process.env.GEMINI_API_KEY;
+if (!key) { console.error('No Gemini API key in env'); process.exit(1); }
+const ai = new GoogleGenAI({ apiKey: key });
+
+const client = new MongoClient(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 30000, socketTimeoutMS: 300000 });
+await client.connect();
+const db = client.db('bookstore');
+
+let books;
+if (ONE_BOOK) {
+  books = await db.collection('books').find({ $or: [{ id: ONE_BOOK }, { _id: ONE_BOOK }] },
+    { projection: { id: 1, _id: 1, title: 1, year: 1, visible: 1 } }).toArray();
+} else {
+  const bookIds = await db.collection('pages').distinct('book_id', { 'ocr.source': 'mineru' });
+  const q = { id: { $in: bookIds }, ...(PRE1820 ? { year: { $lt: 1820 } } : {}) };
+  books = await db.collection('books').find(q, { projection: { id: 1, title: 1, year: 1, visible: 1 } })
+    .limit(LIMIT).toArray();
+}
+if (!books.length) { console.log('no matching books'); await client.close(); process.exit(0); }
+console.log(`${APPLY ? 'APPLY' : 'DRY-RUN'} | model ${MODEL} | ${books.length} book(s)\n`);
+
+async function correctPage(page) {
+  const url = getPageSource(page);
+  if (!url) return { skip: 'no image' };
+  const resp = await fetch(url, { signal: AbortSignal.timeout(60000) });
+  if (!resp.ok) return { skip: `image ${resp.status}` };
+  const b64 = Buffer.from(await resp.arrayBuffer()).toString('base64');
+  const before = page.ocr.data;
+
+  const r = await ai.models.generateContent({
+    model: MODEL,
+    contents: [{ role: 'user', parts: [
+      { text: PROMPT + before.replace(/<[^>]+>/g, '').trim() + '\n--- END TRANSCRIPTION ---' },
+      { inlineData: { mimeType: 'image/jpeg', data: b64 } },
+    ]}],
+    config: { temperature: 0.1, maxOutputTokens: 16384, thinkingConfig: { thinkingBudget: 0 } },
+  });
+
+  const finish = r.candidates?.[0]?.finishReason;
+  let text = (r.text || '').trim();
+  if (!text) return { skip: `empty output (${finish})`, finish };
+  // The model does not reliably honour the ſ instruction — normalise deterministically.
+  text = normalizeLongS(text);
+  const verdict = isCorrectionAcceptable(text, before);
+  return { text, verdict, finish, before };
+}
+
+let totals = { pages: 0, written: 0, rejected: 0, skipped: 0 };
+for (const book of books) {
+  const bid = book.id || String(book._id);
+  const q = { book_id: bid, 'ocr.source': 'mineru', 'ocr.data': { $exists: true, $ne: '' } };
+  let cur = db.collection('pages').find(q, { projection: {
+    id: 1, page_number: 1, 'ocr.data': 1, cropped_photo: 1, archived_photo: 1,
+    photo_original: 1, photo: 1, enhanced_photo: 1, split_from_spread: 1, crop: 1,
+  }}).sort({ page_number: 1 });
+  if (PAGE_LIMIT) cur = cur.limit(PAGE_LIMIT);
+  const pages = await cur.toArray();
+  if (!pages.length) { console.log(`  ${book.title?.slice(0, 50)} — no MinerU pages`); continue; }
+
+  console.log(`[${book.year || '?'}] ${(book.title || '?').slice(0, 56)} — ${pages.length} MinerU pages ${book.visible ? '(VISIBLE)' : ''}`);
+  let written = 0, rejected = 0, skipped = 0;
+
+  for (let i = 0; i < pages.length; i += CONCURRENCY) {
+    const chunk = pages.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(chunk.map(p => correctPage(p)));
+    for (let j = 0; j < chunk.length; j++) {
+      const p = chunk[j], res = results[j];
+      totals.pages++;
+      if (res.status === 'rejected') { skipped++; totals.skipped++; console.log(`    p${p.page_number}: ERROR ${res.reason?.message?.slice(0, 70)}`); continue; }
+      const v = res.value;
+      if (v.skip) { skipped++; totals.skipped++; console.log(`    p${p.page_number}: skip — ${v.skip}`); continue; }
+      if (!v.verdict.ok) {
+        rejected++; totals.rejected++;
+        console.log(`    p${p.page_number}: REJECTED — ${v.verdict.reason}`);
+        continue;
+      }
+      if (APPLY) {
+        await saveRevisionsBeforeOverwrite(db, [p.id], 'ocr', { reason: 'grounded_correction' });
+        await db.collection('pages').updateOne({ id: p.id }, { $set: {
+          'ocr.data': v.text,
+          'ocr.source': 'mineru+gemini-grounded',
+          'ocr.model': MODEL,
+          'ocr.corrected_from': 'mineru',
+          'ocr.updated_at': new Date(),
+        }});
+      }
+      written++; totals.written++;
+      if (written <= 2) {
+        const b = detectLongSArtefacts(v.before), a = detectLongSArtefacts(v.text);
+        console.log(`    p${p.page_number}: ok — long-s artefacts ${b.count} -> ${a.count}${APPLY ? '' : ' (dry-run)'}`);
+      }
+    }
+  }
+  console.log(`  => ${written} corrected, ${rejected} rejected, ${skipped} skipped\n`);
+}
+
+console.log(`TOTAL: ${totals.pages} pages | ${totals.written} ${APPLY ? 'written' : 'would write'} | ${totals.rejected} rejected | ${totals.skipped} skipped`);
+if (!APPLY) console.log('(dry-run — re-run with --apply to write)');
+await client.close();

--- a/tests/unit/early-modern-text.test.ts
+++ b/tests/unit/early-modern-text.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs module, no types
+import { normalizeLongS, detectLongSArtefacts, isCorrectionAcceptable } from '../../scripts/lib/early-modern-text.mjs';
+
+describe('normalizeLongS', () => {
+  it('normalises the long s and its ligatures', () => {
+    expect(normalizeLongS('ſtands inveſted')).toBe('stands invested');
+    expect(normalizeLongS('Triſmegiſtus')).toBe('Trismegistus');
+    expect(normalizeLongS('ﬅate')).toBe('state');
+  });
+
+  it('leaves modern text untouched', () => {
+    expect(normalizeLongS('stands invested')).toBe('stands invested');
+    expect(normalizeLongS('')).toBe('');
+  });
+});
+
+describe('detectLongSArtefacts', () => {
+  // The real MinerU output that shipped to a visible page (Bacon 1763, p119).
+  const MANGLED = 'The Confecration of this work untothe mot learned of PRINces. ' +
+    'That the afpiring unto knowledge was the firft finne. ' +
+    'That knowledgeinclines the Mind to Herefy and Atheifme.';
+
+  it('flags f-for-long-s substitutions', () => {
+    const r = detectLongSArtefacts(MANGLED);
+    expect(r.count).toBeGreaterThan(3);
+    expect(r.samples).toEqual(expect.arrayContaining(['confecration', 'afpiring', 'firft']));
+  });
+
+  it('flags residual literal long-s characters', () => {
+    // The model emitted raw ſ instead of normalising on 1 of 3 pilot pages.
+    const r = detectLongSArtefacts('ſtands inveſted with that triplicity');
+    expect(r.rawLongS).toBe(2);
+    expect(r.count).toBe(2);
+  });
+
+  it('does not fire on clean corrected text', () => {
+    const clean = 'The Consecration of this work unto the most learned of PRINCES. ' +
+      'That the aspiring unto knowledge was the first sinne.';
+    expect(detectLongSArtefacts(clean).count).toBe(0);
+  });
+
+  it('does not fire on legitimate period spellings', () => {
+    // These must survive: they are how the page is actually printed.
+    const period = 'businesse individuall Vertue Atheisme shewed Originall Guilt';
+    expect(detectLongSArtefacts(period).count).toBe(0);
+  });
+
+  // Regression: the first artefact list wrongly contained ordinary English words,
+  // which rejected two correctly-corrected Bacon pages in the pilot dry-run.
+  it('does not fire on ordinary English words', () => {
+    const ordinary = 'That Learning is a thing infinite, and full of anxiety. ' +
+      'The fire was lit. Nothing was reft from him.';
+    expect(detectLongSArtefacts(ordinary).count).toBe(0);
+  });
+});
+
+describe('isCorrectionAcceptable', () => {
+  const MANGLED = 'the firft finne, Herefy and Atheifme, the Confecration, moft juft, thefe philofophers';
+
+  it('accepts a clean correction', () => {
+    const fixed = 'the first sinne, Heresy and Atheisme, the Consecration, most just, these philosophers';
+    expect(isCorrectionAcceptable(fixed, MANGLED).ok).toBe(true);
+  });
+
+  // The load-bearing case: a pass that writes unimproved text is worse than no pass.
+  it('REJECTS output that still carries the artefact', () => {
+    const notFixed = 'the firft finne, Herefy and Atheifme, the Confecration';
+    const v = isCorrectionAcceptable(notFixed, MANGLED);
+    expect(v.ok).toBe(false);
+    expect(v.reason).toMatch(/long-s artefacts remain/);
+  });
+
+  it('REJECTS output that merely swapped f for a literal long s', () => {
+    const v = isCorrectionAcceptable('the firſt ſinne, Hereſy and Atheiſme, the Conſecration', MANGLED);
+    expect(v.ok).toBe(false);
+  });
+
+  it('rejects empty output', () => {
+    expect(isCorrectionAcceptable('', MANGLED).ok).toBe(false);
+    expect(isCorrectionAcceptable('   ', MANGLED).ok).toBe(false);
+  });
+
+  it('tolerates a tiny residue on a large improvement', () => {
+    const many = Array(40).fill('firft moft juft thefe').join(' ');
+    const almost = Array(40).fill('first most just these').join(' ') + ' firft';
+    expect(isCorrectionAcceptable(almost, many).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Gemini's RECITATION filter refuses to transcribe ubiquitous canonical texts, so those books stall permanently. MinerU has no filter and is free — but it only reads modern print well. On pre-1820 typography it fails three ways:

| class | example | text-fixable? |
|---|---|---|
| long s read as "f" | `firft finne` → `first sinne` | yes |
| words run together | `knowledgeinclines` | yes |
| display type as soup | `qnore or0 FnT H Esi),bnim ymomu aor` | **no** |

Class 3 is the reason this pass sends the **page image** alongside the text. Those characters were never read, so a text-only correction would invent plausible words — fluent, wrong, unverifiable. That is the one failure mode this corpus cannot tolerate.

**Verified**: Bacon's *Advancement of Learning* (1763) p119. MinerU produced `SALBAN` and the soup above. The grounded pass returned `VICOVNT St ALBAN,` / `OF THE / DIGNITY AND ADVANCEMENT / OF LEARNING.` — checked against the plate, character for character. Re-read, not guessed.

## The lane

```
mineru-ocr-worker.mjs       free, no RECITATION filter, reads the page
  └─> ocr-correct-grounded.mjs   corrects against the page image
```

This is not hypothetical cleanup: **9 pre-1820 books / 471 pages already carry raw MinerU text, and 4 are VISIBLE** (Bacon 1763, a 1694 Journal, a 1660 law tract, 1813 *Popular Antiquities*). The MinerU gate screens for run-together text and short output — **not letter substitution** — so mangled pre-1820 pages pass it silently and reach readers looking like confident OCR.

## Safety — each item learned from the pilot, not assumed

- **Deterministic ſ→s normalisation after the model call.** The model does not reliably honour the instruction: it normalised 2 of 3 pilot pages and emitted raw `ſ` on the third.
- **A gate that refuses to write a correction still carrying the artefact.** A pass that quietly writes unimproved text is worse than no pass.
- **A deliberately conservative artefact list** — only f-spellings that aren't themselves English words. My first draft included `infinite`, `anxiety`, `fire`; the live dry-run rejected two *correctly corrected* pages because of it. A gate that rejects good pages gets bypassed — same lesson as the worktree reaper.
- Snapshots to `page_revisions` before overwrite (`reason: 'grounded_correction'`).
- Only touches `ocr.source='mineru'`. **Never overwrites Gemini OCR.** Dry-run by default.

## Verification

- 12 unit tests: normaliser, both artefact classes (f-substitution and residual literal `ſ`), period spellings that must survive (`businesse`, `individuall`, `Atheisme`), and the ordinary-English-word regression.
- Full suite 734 passed, `tsc --noEmit` clean.
- Live dry-run on 6 Bacon pages: 6 corrected, 0 rejected, artefacts 11→0 and 14→0.

Cost is negligible — `gemini-3.1-flash-lite`, well under a dollar for all 471 pre-1820 MinerU pages.

## Out of scope

- **Running the lane over the 9 existing books** — wants a per-book spot-check against page images, not a batch.
- **Wiring into the orchestrator's recitation escalation** — the escalation tiers (2.5-flash → 3.1-flash-lite) should still be tried first for books that are merely *hard*; this lane is for books Gemini refuses outright.
- Note the year constraint cuts both ways: MinerU is the good lane for **1820+**, so pre-1820 books should reach it only when Gemini has actually refused them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)