### PR TITLE
fix(ocr): remove gemini-2.5-flash from the RECITATION ladder

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -102,7 +102,7 @@ const MODEL_PRICING = {
 const BATCH_DISCOUNT = 0.5;
 
 function calculateCost(model, inputTokens, outputTokens) {
-  const pricing = MODEL_PRICING[model] || MODEL_PRICING['gemini-2.5-flash'];
+  const pricing = MODEL_PRICING[model] || MODEL_PRICING['gemini-3-flash-preview'];
   const inputCost = (inputTokens / 1_000_000) * pricing.input * BATCH_DISCOUNT;
   const outputCost = (outputTokens / 1_000_000) * pricing.output * BATCH_DISCOUNT;
   return Math.round((inputCost + outputCost) * 1_000_000) / 1_000_000;
@@ -1229,12 +1229,15 @@ async function run() {
   }
 
   // RECITATION recovery: mark affected books for retry with a different model.
-  // The batch API with gemini-3-flash-preview triggers RECITATION on some historical
-  // texts. Three-tier escalation before a permanent block:
-  //   1. First failure  -> recitation_retry      -> orchestrator retries with gemini-2.5-flash.
-  //   2. Second failure -> recitation_retry_lite -> orchestrator retries with gemini-3.1-flash-lite
-  //                        (proven to bypass RECITATION on famous texts where 2.5-flash also fails).
-  //   3. Third failure  -> recitation_blocked    -> permanently skip (all 3 models failed).
+  // The batch API triggers RECITATION on ubiquitous canonical texts. Escalation
+  // before a permanent block (never any model below v3 — see CLAUDE.md):
+  //   1. First failure  -> recitation_retry      -> orchestrator retries with gemini-3.1-flash-lite.
+  //   2. Second failure -> recitation_retry_lite -> orchestrator retries with gemini-3-flash-preview.
+  //   3. Third failure  -> recitation_blocked    -> both Gemini tiers refuse.
+  //      Such a book is NOT hopeless: route it to the MinerU + grounded-correction
+  //      lane (mineru-ocr-worker.mjs, then ocr-correct-grounded.mjs — #3389), which
+  //      reads with an engine that has no recitation filter and then corrects the
+  //      result against the page image.
   if (recitationBooks.size > 0) {
     console.log(`\nRECITATION recovery: flagging ${recitationBooks.size} books for retry`);
     for (const bookId of recitationBooks) {
@@ -1261,9 +1264,9 @@ async function run() {
               $unset: { 'pipeline_auto.recitation_retry_lite': '' },
             }
           );
-          console.log(`  RECITATION permanently blocked ${bookId} -> needs_attention (all 3 models failed)`);
+          console.log(`  RECITATION blocked on both Gemini tiers ${bookId} -> needs_attention (route to MinerU + grounded correction, #3389)`);
         } else if (retriedFallback) {
-          // Second RECITATION failure: gemini-2.5-flash also blocked. Escalate to gemini-3.1-flash-lite.
+          // Second RECITATION failure: gemini-3.1-flash-lite also blocked. Escalate to gemini-3-flash-preview.
           await db.collection('books').updateOne(
             { id: bookId, 'pipeline_auto.status': { $in: ['ocr_submitted', 'ocr_complete'] } },
             {

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -4074,7 +4074,7 @@ Rules:
             $or: [
               { pages_ocr: { $gt: 0 } }, // Already has some OCR (preview pass done)
               { 'pipeline_auto.recitation_retry': true }, // All pages were RECITATION-blocked — retry with fallback model regardless of pages_ocr
-              { 'pipeline_auto.recitation_retry_lite': true }, // 2.5-flash also RECITATION-blocked — retry with gemini-3.1-flash-lite regardless of pages_ocr
+              { 'pipeline_auto.recitation_retry_lite': true }, // tier 1 also RECITATION-blocked — retry with gemini-3-flash-preview regardless of pages_ocr
             ],
           }},
           { $addFields: {
@@ -4117,19 +4117,27 @@ Rules:
             continue;
           }
 
-          // Direct OCR submission — downloads images on Hetzner, submits to Gemini Batch API
-          // Use a fallback model for RECITATION retries (gemini-3-flash-preview triggers it).
-          // 3-tier escalation: recitation_retry -> gemini-2.5-flash; recitation_retry_lite ->
-          // gemini-3.1-flash-lite (proven to bypass RECITATION where 2.5-flash also fails).
+          // Direct OCR submission — downloads images on Hetzner, submits to Gemini Batch API.
+          //
+          // RECITATION escalation ladder (models below v3 are never used — see CLAUDE.md):
+          //   tier 1  recitation_retry       -> gemini-3.1-flash-lite
+          //   tier 2  recitation_retry_lite  -> gemini-3-flash-preview
+          //   tier 3  still blocked          -> MinerU + grounded correction
+          //                                     (mineru-ocr-worker.mjs, then
+          //                                      ocr-correct-grounded.mjs — #3389)
+          // The flag NAMES are historical; what matters is the order. Tier 3 is not
+          // a Gemini model: once both Gemini tiers refuse, no prompt or model change
+          // gets the text out, so the page has to be read by an engine without a
+          // recitation filter and then corrected against its own image.
           const isLiteRetry = book.pipeline_auto?.recitation_retry_lite === true;
           const isRecitationRetry = book.pipeline_auto?.recitation_retry === true;
           const ocrOpts = isLiteRetry
-            ? { modelOverride: OCR_MODEL_LITE }
+            ? { modelOverride: OCR_MODEL_FLASH }
             : isRecitationRetry
-              ? { modelOverride: 'gemini-2.5-flash' }
+              ? { modelOverride: OCR_MODEL_LITE }
               : {};
-          if (isLiteRetry) console.log(`  RECITATION retry with ${OCR_MODEL_LITE}: ${label}`);
-          else if (isRecitationRetry) console.log(`  RECITATION retry with gemini-2.5-flash: ${label}`);
+          if (isLiteRetry) console.log(`  RECITATION retry (tier 2) with ${OCR_MODEL_FLASH}: ${label}`);
+          else if (isRecitationRetry) console.log(`  RECITATION retry (tier 1) with ${OCR_MODEL_LITE}: ${label}`);
           else console.log(`  Submitting OCR: ${label}...`);
           const result = await submitOcrDirectly(db, book, ocrOpts);
 


### PR DESCRIPTION
## Why

The RECITATION escalation retried with **gemini-2.5-flash** as tier 1. That contradicts the standing rule in CLAUDE.md ("NEVER use models older than v3"), and it was stale on its own terms: 3.1-flash-lite has since been observed to bypass RECITATION where 2.5 also failed, so the ladder had the *weaker* model first.

## New order

| tier | flag | model |
|---|---|---|
| 1 | `recitation_retry` | `gemini-3.1-flash-lite` |
| 2 | `recitation_retry_lite` | `gemini-3-flash-preview` |
| 3 | both Gemini tiers refuse | **MinerU + grounded correction** (#3389) |

No pre-v3 model remains anywhere in the OCR path.

## Tier 3 is a change in posture, not just a model swap

Previously a third failure meant *"permanently blocked, all 3 models failed"* and the book was abandoned. But once both Gemini tiers refuse, no further model or prompt change gets the text out — the page has to be read by an engine with **no recitation filter**, then corrected against its own image. That lane landed in #3389, so the terminal state is now a routing decision rather than a dead end. Log line and comments say so.

## Deliberately untouched

- **`pipeline_auto` flag names.** They're historical labels, written by `batch-collector` and read by the orchestrator. Renaming them would strand books already carrying the old flags mid-escalation. What matters is the order they map to.
- **The 2.5 entries in `MODEL_PRICING`** — historical jobs still need to price correctly. Only the *default* for an unrecognised model moves to `gemini-3-flash-preview`, so a new model no longer prices against a retired one.
- **`podcast/ask`** — `gemini-2.5-flash-preview-tts`, no v3 TTS equivalent.
- **`identify/route.ts`** — pins 2.5-flash because `google_search` grounding isn't supported on v3 yet. A capability constraint, not a choice. Worth revisiting when grounding lands on v3.

## Verification

739 unit tests pass. Comment-and-constant change; no behavioural test exists for the ladder because it only fires on live RECITATION responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)