### PR TITLE
Book page: faster mosaic load + fade-in + section reveals

### DIFF
--- a/src/app/api/books/[id]/hero-mosaic/route.ts
+++ b/src/app/api/books/[id]/hero-mosaic/route.ts
@@ -8,6 +8,7 @@ import { getDb } from '@/lib/mongodb';
 import { storagePut } from '@/lib/storage';
 import { images } from '@/lib/api-client/images';
 import { type PageImageFields } from '@/lib/page-image-url';
+import { HERO_MOSAIC_VERSION } from '@/lib/hero-mosaic-version';
 
 /**
  * GET /api/books/[id]/hero-mosaic
@@ -21,7 +22,7 @@ import { type PageImageFields } from '@/lib/page-image-url';
  * dark panel instead of a wall of identical tiles.
  */
 
-const MOSAIC_VERSION = 23; // bump to force-regenerate cached mosaics
+const MOSAIC_VERSION = HERO_MOSAIC_VERSION; // shared with the book page (cache-buster)
 const MAX_ROWS = 4; // the hero crop (desktop rows 2-4, mobile rows 1-3) never shows a 5th row
 const MAX_TILES = 10 * MAX_ROWS; // 10 cols × 4 rows = 40 — the most that can ever be seen
 const MIN_TILES = 4; // below this we can't make a grid that fills without stretching

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -50,6 +50,7 @@ import { authorUrl } from '@/lib/slugify';
 import FirstTranslationEvidence from '@/components/book/FirstTranslationEvidence';
 import GalleryMasonry, { type Plate } from '@/components/GalleryMasonry';
 import HeroVariants from '@/components/book/HeroVariants';
+import { HERO_MOSAIC_VERSION } from '@/lib/hero-mosaic-version';
 import AboutVariants from '@/components/book/AboutVariants';
 import BookBiblioPanel from '@/components/book/BookBiblioPanel';
 import PlusToggle from '@/components/book/PlusToggle';
@@ -1130,7 +1131,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     const readingDropdowns = (
       <>
         {hasReadingGuide && (
-          <AISection kind="reading-guide" className="card">
+          <AISection kind="reading-guide" className="card reveal-in">
             <details className="group sl-collapse">
               <summary className="p-4 md:p-6 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex items-center justify-between gap-3 md:gap-4">
                 <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>Reading guide</h3>
@@ -1144,7 +1145,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         )}
         {/* Book's own contents — only when there's a TOC scan or chapters */}
         {(!!book.chapters?.length || !!tocPage) && (
-        <details id="contents" className="card group scroll-mt-24 sl-collapse">
+        <details id="contents" className="card group scroll-mt-24 sl-collapse reveal-in">
           <summary className="p-4 md:p-6 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex items-center justify-between gap-3 md:gap-4">
             <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>Contents</h3>
             <PlusToggle />
@@ -1199,7 +1200,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         })()}
 
         {/* Bibliographic information — the source's own record only. */}
-        <details className="card group sl-collapse">
+        <details className="card group sl-collapse reveal-in">
           <summary className="p-4 md:p-6 cursor-pointer list-none [&::-webkit-details-marker]:hidden flex items-center justify-between gap-3 md:gap-4">
             <h3 className="font-display font-medium text-[17px] md:text-[22px]" style={{ color: '#2b2620' }}>Bibliographic information</h3>
             <PlusToggle />
@@ -1220,11 +1221,11 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             (editions + prior translations appear as timeline entries) and nests
             the staff processing log + editions tooling under "Added to Source
             Library". */}
-        <BookTimeline events={timelineEvents} />
+        <div className="reveal-in"><BookTimeline events={timelineEvents} /></div>
 
         {/* Search this book — styled like a dropdown card but always open; the
             card grows to show results (max-height + scroll) as you type. */}
-        <div className="card p-4 md:p-6">
+        <div className="card p-4 md:p-6 reveal-in">
           <h3 className="font-display font-medium text-[17px] md:text-[22px] mb-4" style={{ color: '#2b2620' }}>Search this book</h3>
           <SearchPanel bookId={book.id} inline theme="light" placeholder="Find a word, name, or phrase…" />
         </div>
@@ -1256,7 +1257,16 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         {/* ===================== HERO ===================== */}
         <HeroVariants
           pageThumbs={heroPageThumbs}
-          mosaicUrl={`/api/books/${book.id}/hero-mosaic`}
+          /* Warmed books point straight at the cached R2 URL (fast CDN hit).
+             Only un-warmed books go through the API route, which lazily
+             composites + caches on first view. This skips a Vercel-function +
+             Mongo + 302 hop on every load of a popular book. */
+          mosaicUrl={
+            (book as unknown as { hero_mosaic_url?: string; hero_mosaic_version?: number }).hero_mosaic_url &&
+            (book as unknown as { hero_mosaic_version?: number }).hero_mosaic_version === HERO_MOSAIC_VERSION
+              ? (book as unknown as { hero_mosaic_url?: string }).hero_mosaic_url
+              : `/api/books/${book.id}/hero-mosaic`
+          }
           actions={(
             /* Mobile-only: pinned to the foot of the hero (desktop keeps these
                inline in the meta below). Read sits under the text; the icon bar
@@ -1405,16 +1415,18 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         {/* ===================== ABOUT · READING GUIDE · CONTENTS ===================== */}
         {/* Always render the two-column About section: prose (when present) + the
             dropdowns on the left, an interesting non-cover plate on the right. */}
-        <AboutVariants
-          content={hasSummary ? linkEntities(summaryText!, summaryEntities) : null}
-          visual={sideVisual}
-          tags={hasSummary ? subjectTags : []}
-          belowContent={readingDropdowns}
-        />
+        <div className="reveal-in">
+          <AboutVariants
+            content={hasSummary ? linkEntities(summaryText!, summaryEntities) : null}
+            visual={sideVisual}
+            tags={hasSummary ? subjectTags : []}
+            belowContent={readingDropdowns}
+          />
+        </div>
 
         {/* ===================== PAGES ===================== */}
         <section id="pages" style={{ background: 'linear-gradient(180deg, #fdfcf9 0%, #f8f2ea 100%)' }} className="pt-14 pb-16 scroll-mt-4">
-          <main className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12">
+          <main className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 reveal-in">
             {(() => {
               const digitizer = book.image_source?.digitized_by || book.image_source?.contributing_library || book.image_source?.provider_name;
               const pagesSubtitle = digitizer
@@ -1433,7 +1445,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         {/* ===================== ILLUSTRATIONS (masonry) ===================== */}
         {galleryPlates.length > 0 && (
           <section id="illustrations" style={{ background: 'linear-gradient(180deg, #fdfcf9 0%, #f8f2ea 100%)' }} className="border-t border-[#e6e0d3] py-14 scroll-mt-4">
-            <div className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12">
+            <div className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 reveal-in">
               <h2 className="font-display font-medium text-2xl md:text-[28px] mb-1" style={{ color: '#2b2620' }}>Illustrations</h2>
               <p className="text-sm md:text-[15px] mb-6" style={{ color: '#8a8170' }}>Plates, diagrams, and figures detected in the scanned pages.</p>
               <GalleryMasonry plates={galleryPlates} />
@@ -1451,12 +1463,12 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
 
 
         {/* ===================== PART OF THE COLLECTION (library/source) ===================== */}
-        {librarySection && <BookLibrarySection data={librarySection} />}
+        {librarySection && <div className="reveal-in"><BookLibrarySection data={librarySection} /></div>}
 
         {/* ===================== RELATED BOOKS ===================== */}
         {hasRelated && (
           <section id="related" style={{ background: 'linear-gradient(180deg, #fdfcf9 0%, #f8f2ea 100%)' }} className="py-14 border-t border-[#e6e0d3] scroll-mt-4">
-            <div className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12">
+            <div className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 reveal-in">
               <h2 className="font-display font-medium text-2xl md:text-[28px] mb-1" style={{ color: '#2b2620' }}>Related books</h2>
               <p className="text-sm md:text-[15px] mb-5" style={{ color: '#8a8170' }}>Other volumes close to this one by author, subject, place, and period.</p>
               <BookSlider books={tagRelated as unknown as MiniBook[]} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -823,3 +823,23 @@ html[data-sl-hide-ai="1"] [data-view-section="ai-summary-catalog"] {
 .hymn-now * {
   fill: var(--accent-rust) !important;
 }
+
+/* ── Section reveal-in (book page) ────────────────────────────────────────────
+   Sections fade + rise as they scroll into view. Pure CSS via a scroll-driven
+   view() timeline — no JS, no IntersectionObserver, no hydration flash.
+   Guarded by @supports so browsers without scroll-driven animations (and users
+   who prefer reduced motion) simply see the content in place, never hidden.
+   Content already in view on load resolves to the animation's end state. */
+@media (prefers-reduced-motion: no-preference) {
+  @supports (animation-timeline: view()) {
+    .reveal-in {
+      animation: reveal-in-kf linear both;
+      animation-timeline: view();
+      animation-range: entry 2% entry 36%;
+    }
+  }
+}
+@keyframes reveal-in-kf {
+  from { opacity: 0; transform: translateY(24px); }
+  to   { opacity: 1; transform: translateY(0); }
+}

--- a/src/components/book/HeroVariants.tsx
+++ b/src/components/book/HeroVariants.tsx
@@ -38,6 +38,13 @@ export default function HeroVariants({
   // page scan covering the background.
   const onBgError = () => { if (single && bgSrc !== single) setBgSrc(single); };
 
+  // Fade + sharpen the background in once it decodes, so the load reads as
+  // deliberate rather than a hard pop. `loaded` is shared by the desktop and
+  // mobile <img>s (only one is visible per breakpoint); the ref callback also
+  // catches the already-cached case where onLoad may not fire.
+  const [loaded, setLoaded] = useState(false);
+  const markLoaded = () => setLoaded(true);
+
   // Subtle scroll parallax — the bg + tint drift slower than the page.
   const sectionRef = useRef<HTMLElement>(null);
   const [parallax, setParallax] = useState(0);
@@ -62,7 +69,17 @@ export default function HeroVariants({
   const Bg = () =>
     bgSrc ? (
       /* eslint-disable-next-line @next/next/no-img-element */
-      <img src={bgSrc} alt="" onError={onBgError} className="absolute inset-0 w-full h-full object-cover" loading="eager" />
+      <img
+        ref={(el) => { if (el?.complete) setLoaded(true); }}
+        src={bgSrc}
+        alt=""
+        onLoad={markLoaded}
+        onError={onBgError}
+        loading="eager"
+        className={`absolute inset-0 w-full h-full object-cover transition-[opacity,filter,transform] duration-[1100ms] ease-out will-change-[opacity,filter,transform] ${
+          loaded ? 'opacity-100 blur-0 scale-100' : 'opacity-0 blur-[14px] scale-[1.06]'
+        }`}
+      />
     ) : null;
 
   return (

--- a/src/components/book/HeroVariants.tsx
+++ b/src/components/book/HeroVariants.tsx
@@ -38,12 +38,16 @@ export default function HeroVariants({
   // page scan covering the background.
   const onBgError = () => { if (single && bgSrc !== single) setBgSrc(single); };
 
-  // Fade + sharpen the background in once it decodes, so the load reads as
-  // deliberate rather than a hard pop. `loaded` is shared by the desktop and
-  // mobile <img>s (only one is visible per breakpoint); the ref callback also
-  // catches the already-cached case where onLoad may not fire.
-  const [loaded, setLoaded] = useState(false);
-  const markLoaded = () => setLoaded(true);
+  // Fade + focus the background in once it decodes, so the load reads as
+  // deliberate rather than a hard pop. Because warmed books load the mosaic
+  // straight from R2 (often instantly / from cache), we must PAINT the blurred
+  // state for a couple frames first — otherwise React flips to the sharp state
+  // in the same tick and the transition never plays. Two rAFs guarantee at
+  // least one painted frame in the blurred state before we resolve.
+  const [revealed, setRevealed] = useState(false);
+  const reveal = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => setRevealed(true)));
+  };
 
   // Subtle scroll parallax — the bg + tint drift slower than the page.
   const sectionRef = useRef<HTMLElement>(null);
@@ -70,14 +74,14 @@ export default function HeroVariants({
     bgSrc ? (
       /* eslint-disable-next-line @next/next/no-img-element */
       <img
-        ref={(el) => { if (el?.complete) setLoaded(true); }}
+        ref={(el) => { if (el?.complete) reveal(); }}
         src={bgSrc}
         alt=""
-        onLoad={markLoaded}
+        onLoad={reveal}
         onError={onBgError}
         loading="eager"
-        className={`absolute inset-0 w-full h-full object-cover transition-[opacity,filter,transform] duration-[1100ms] ease-out will-change-[opacity,filter,transform] ${
-          loaded ? 'opacity-100 blur-0 scale-100' : 'opacity-0 blur-[14px] scale-[1.06]'
+        className={`absolute inset-0 w-full h-full object-cover transition-[opacity,filter,transform] duration-[1600ms] delay-150 ease-out will-change-[opacity,filter,transform] ${
+          revealed ? 'opacity-100 blur-0 scale-100' : 'opacity-0 blur-[26px] scale-[1.10]'
         }`}
       />
     ) : null;

--- a/src/lib/hero-mosaic-version.ts
+++ b/src/lib/hero-mosaic-version.ts
@@ -1,0 +1,9 @@
+/**
+ * The current hero-mosaic cache version. Bumping it invalidates every cached
+ * mosaic (forces a full regen), so treat it as a deliberate cache-buster.
+ *
+ * Lives in its own tiny module (no heavy deps) so the book page — a server
+ * component — can import it to decide whether a book's cached mosaic is
+ * current, WITHOUT pulling in the mosaic route's sharp/image toolchain.
+ */
+export const HERO_MOSAIC_VERSION = 23;


### PR DESCRIPTION
## Book page: faster mosaic load + fade-in + section reveals

Follow-up polish to the book-page redesign (#3378).

### What & why
- **Faster hero mosaic** — the bg `<img>` for a warmed book now points **straight at its cached R2 URL** (`book.hero_mosaic_url`) instead of `/api/books/[id]/hero-mosaic`. The route did a Vercel-function + Mongo lookup + 302 redirect on *every* load (even popular books) before the browser ever reached the image; now that hop is gone. Un-warmed books still use the route (which lazily composites + caches on first view). New shared `HERO_MOSAIC_VERSION` constant so the page can tell "warmed" without importing the route's sharp toolchain.
- **Mosaic fade/blur-in** — the mosaic fades + sharpens in once it decodes (blur-up), so the load reads as deliberate rather than a hard pop. Handles the already-cached case (ref `.complete`) so it doesn't stay hidden.
- **Section reveal-in** — cards and content sections fade + rise as they scroll into view. Pure CSS via a scroll-driven `view()` timeline — **no JS, no IntersectionObserver, no hydration flash**. `@supports` + `prefers-reduced-motion` guarded, so browsers without scroll-driven animations (and reduced-motion users) just see the content in place, never hidden. Applied to: reading guide, contents, bibliographic, book history, search, about, pages, illustrations, collection, related.

### Notes
- `MOSAIC_VERSION` stays 23 (no mosaic regeneration).
- Content is always in the DOM (reveal only affects opacity/transform), so SEO/crawlers and no-JS users are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
