### PR TITLE
fix(analytics): stop PostHog counting a headless fleet as users (#3400)

### DIFF
--- a/src/components/providers/AnalyticsScripts.tsx
+++ b/src/components/providers/AnalyticsScripts.tsx
@@ -129,7 +129,30 @@ export default function AnalyticsScripts() {
           // and hand every cached visitor the same decision. Analytics events
           // are unaffected; only the replay recording is gated.
           var _slRecordSession = Math.random() < 0.3;
-          posthog.init('${POSTHOG_KEY}', {
+          // Automated-browser gate (#3400). A headless fleet executing our
+          // reader was producing ~35K "users"/day of one-hit sessions — enough
+          // to make PostHog report traffic TRIPLING over a month in which real
+          // human traffic actually fell 4x. Server-side filtering can't help
+          // here: these loads never reach /api/track, and their user-agents are
+          // spoofed desktop Chrome (an impossible 50/50 Windows/Mac split), so
+          // UA matching won't catch them either.
+          //
+          // navigator.webdriver is the W3C-standard flag set by every
+          // automation driver (Puppeteer/Playwright/Selenium) and is never true
+          // in an ordinary browser, so it cannot false-positive a real reader.
+          // Empty navigator.languages is a second headless tell.
+          //
+          // We skip posthog.init OUTRIGHT rather than passing a config option:
+          // an unsupported option would be ignored silently and ship as a
+          // no-op, which is the exact failure class this fix exists to correct.
+          var _slAutomated = (function () {
+            try {
+              if (navigator.webdriver === true) return true;
+              if (!navigator.languages || navigator.languages.length === 0) return true;
+              return false;
+            } catch (e) { return false; }
+          })();
+          if (!_slAutomated) posthog.init('${POSTHOG_KEY}', {
             api_host: '${POSTHOG_HOST}',
             person_profiles: 'identified_only',
             capture_pageview: true,

--- a/tests/unit/posthog-bot-gate.test.ts
+++ b/tests/unit/posthog-bot-gate.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import vm from 'vm';
+
+/**
+ * Pins the automated-browser gate in the inline `posthog-init` script
+ * (src/components/providers/AnalyticsScripts.tsx).
+ *
+ * A headless fleet executing our reader was producing ~35K "users"/day of
+ * one-hit sessions — enough that PostHog reported traffic TRIPLING over a month
+ * in which real human traffic actually fell 4x (#3400). Server-side filtering
+ * cannot reach it: those loads never hit /api/track, and the fleet spoofs
+ * desktop Chrome, so user-agent matching is useless too.
+ *
+ * The gate keys on navigator.webdriver, the W3C flag every automation driver
+ * sets and no ordinary browser sets. There is no DOM in the unit environment,
+ * so this evaluates the REAL script (extracted from source) inside a vm against
+ * minimal stubs, and asserts on whether posthog.init was actually reached.
+ *
+ * Deleting the gate makes the first test fail; making the gate too aggressive
+ * makes the "ordinary browser" tests fail.
+ */
+
+const SRC = join(process.cwd(), 'src/components/providers/AnalyticsScripts.tsx');
+
+function extractPosthogInit(): string {
+  const src = readFileSync(SRC, 'utf8');
+  const start = src.indexOf('<Script id="posthog-init"');
+  if (start === -1) throw new Error('posthog-init Script block not found');
+  const open = src.indexOf('{`', start);
+  const close = src.indexOf('`}', open);
+  if (open === -1 || close === -1) throw new Error('posthog-init template literal not found');
+  return src
+    .slice(open + 2, close)
+    .replace(/\$\{POSTHOG_KEY\}/g, 'phc_test')
+    .replace(/\$\{POSTHOG_HOST\}/g, 'https://eu.i.posthog.com');
+}
+
+/** Run the real init script with a stubbed navigator; report whether posthog.init was reached. */
+function runInit(navigatorStub: Record<string, unknown>): { initCalls: number } {
+  const scriptEl: Record<string, unknown> = {};
+  const firstScript = { parentNode: { insertBefore: () => {} } };
+
+  const documentStub = {
+    createElement: () => scriptEl,
+    getElementsByTagName: () => [firstScript],
+  };
+
+  const sandbox: Record<string, unknown> = {
+    navigator: navigatorStub,
+    document: documentStub,
+    Math,
+  };
+  vm.createContext(sandbox);
+  // In a browser `window` IS the global object, so the loader's
+  // `window.posthog = e` also defines a bare global `posthog`. Model that
+  // exactly — a plain {} stub here would make the script throw on a code path
+  // that works fine in production.
+  sandbox.window = sandbox;
+
+  vm.runInContext(extractPosthogInit(), sandbox);
+
+  const ph = (sandbox as { posthog?: { _i?: unknown[] } }).posthog;
+  return { initCalls: ph?._i?.length ?? 0 };
+}
+
+const ORDINARY = { webdriver: false, languages: ['en-GB', 'en'] };
+
+describe('posthog-init automated-browser gate', () => {
+  it('does NOT initialise PostHog when navigator.webdriver is true', () => {
+    expect(runInit({ ...ORDINARY, webdriver: true }).initCalls).toBe(0);
+  });
+
+  it('does NOT initialise PostHog when navigator.languages is empty (headless tell)', () => {
+    expect(runInit({ ...ORDINARY, languages: [] }).initCalls).toBe(0);
+  });
+
+  it('DOES initialise PostHog for an ordinary browser', () => {
+    expect(runInit(ORDINARY).initCalls).toBe(1);
+  });
+
+  it('DOES initialise when navigator.webdriver is undefined (older browsers)', () => {
+    expect(runInit({ languages: ['fr'] }).initCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #3400.

PostHog has been reporting daily pageviews climbing **11K → 35K** over the last 30 days. Mongo's bot-filtered `analytics_pageviews` reports human traffic **falling** over the same window, ~23K/day → ~5.7K/day.

PostHog is the wrong one. A reviewer reading that dashboard today would conclude traffic tripled; it fell 4×.

## Evidence that the tail is automated

| signature | measurement |
|---|---|
| one-hit sessions | **204,270** distinct_ids made exactly one pageview in 7 days; only ~3,150 made two or more |
| impossible OS split | Chrome/Windows **102,497** users vs Chrome/Mac **99,373** — near-perfect 50/50, almost no mobile |
| referrer | ~100% `$direct` (206,250 of ~206,000 users) |

Strip that tail and **the two systems agree**: PostHog's multi-pageview users over 7 days (~3,200) closely matches Mongo's multi-pageview sessions (4,108). The real engaged audience is a few thousand people a week and always was. Only the tail is contaminated.

The responsible fleet is characterised in the private ops repo — ~80 sequential IPs, 126K page-reads in a single day, driving `/api/image` at ~6K hits/day. It also explains the reading-depth artifact in #3405.

## Why this can't be fixed server-side

- **These loads never reach `/api/track`**, which is why `analytics_traffic_class` records only ~58–114 `other_bot` hits/day while PostHog books 35,000. There is nothing there to filter.
- **The user-agents are spoofed desktop Chrome.** UA matching — including PostHog's own built-in bot list — cannot see them.

The only place with enough signal is the browser itself.

## The gate

`navigator.webdriver` is the W3C-standard flag set by every automation driver (Puppeteer, Playwright, Selenium) and set by no ordinary browser, so it **cannot false-positive a real reader**. Empty `navigator.languages` is a second headless tell.

**It skips `posthog.init` outright rather than passing a config option.** That is deliberate: an unsupported config option would be ignored silently and ship as a no-op — the exact failure class this PR exists to correct. Not initialising is guaranteed to work regardless of the CDN build's version.

Consent behaviour is unchanged. The existing opt-in/opt-out effect no-ops safely against the uninitialised loader stub.

## Guard

`tests/unit/posthog-bot-gate.test.ts` extracts the **real inline script** from source, evaluates it in a `vm` against minimal stubs, and asserts whether `posthog.init` was actually reached — the same approach as the existing `translation-dom-guard.test.ts`. Four cases: webdriver true and empty languages must *not* initialise; an ordinary browser and an older browser with `webdriver` undefined *must*.

Negative control run — removing the gate **fails 2 of 4**.

(While writing it the harness initially failed on a correct build, because a plain `{}` window stub doesn't reproduce browser semantics where `window` *is* the global and `window.posthog = e` therefore defines a bare global. Fixed by making the sandbox self-referential. Worth noting given CLAUDE.md's warning about harnesses that prove nothing — here it failed loudly rather than passing falsely, but the same class of error could have gone the other way.)

## Out of scope

The **null `$exception_type` / `$exception_message`** on 15,611 events from 1,502 users is a separate defect, filed as #3409. Fixing the bot contamination may reduce that count — a headless fleet throws exceptions of its own — but the null properties would remain.

## Verifying after deploy

The honest check is that PostHog's daily user count **drops sharply** and then tracks Mongo's shape rather than inverting it. If it doesn't drop, the fleet is masking `navigator.webdriver` and this needs a different signal — say so rather than assuming the fix worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
