### PR TITLE
feat(provenance): canary + attribution on bulk text egress

### DIFF
--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -8,6 +8,8 @@ import { checkPageBudget, bulkBudgetExceededBody } from '@/lib/api-budget';
 import { isBookReadable } from '@/lib/book-access';
 import { CONTENT_LICENSE } from '@/lib/license-info';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { markForExport } from '@/lib/provenance';
+import { attributionBlock, attributionMeta, clientKeyFor, extractionRef } from '@/lib/bot-attribution';
 
 // This route serves quotable page text (get_book_text tells agents to "copy
 // verbatim from the translation field"), so it MUST strip the AI editorial
@@ -99,6 +101,25 @@ export const GET = withApiAuth(async (
     const isBotRequest = isBot(request) && !(await isTrustedBot(request));
     const botPageLimit = isBotRequest ? botMaxPage(book.pages_count || 0) : undefined;
 
+    // Provenance. Two layers, deliberately different in reach:
+    //   - the INVISIBLE imprimatur goes on every page of every response (this
+    //     route is the highest-volume text egress we have and carried no mark
+    //     at all before), so any passage that later surfaces elsewhere is
+    //     attributable;
+    //   - the VISIBLE notice is added only for bot-classified, untrusted
+    //     callers. Verified search crawlers, user-initiated assistant fetches,
+    //     signed-in readers and key holders never see it, so indexing and
+    //     ordinary reading are untouched.
+    // The ref ties a recovered passage to an extraction campaign; it is
+    // pseudonymous and recomputable from api_usage (see bot-attribution.ts).
+    const ref = isBotRequest ? extractionRef(clientKeyFor(request), new Date()) : undefined;
+    const mark = (text: string) => (text ? markForExport(text, resolvedBookId, { ref }) : text);
+    const bookSubject = {
+      title: book.display_title || book.title,
+      author: book.author,
+      url: `https://sourcelibrary.org/book/${resolvedBookId}`,
+    };
+
     // Per-request page cap. The daily budget check above only sees the PRIOR 24h
     // total, so a single large from/to range (or an unbounded request) could serve
     // far past the cap in ONE call. Clamp this request to the remaining budget for
@@ -162,13 +183,14 @@ export const GET = withApiAuth(async (
           `# Pages ${ct.pageStart}–${ct.pageEnd}`,
           `# Source: https://sourcelibrary.org/book/${resolvedBookId}`,
           '',
-          cleanText(content === 'ocr' ? (ct.ocr_text || ct.text) : ct.text),
+          ...(ref ? [attributionBlock(ref, bookSubject)] : []),
+          mark(cleanText(content === 'ocr' ? (ct.ocr_text || ct.text) : ct.text)),
         ].join('\n');
 
         return new Response(header, {
           headers: {
             'Content-Type': 'text/plain; charset=utf-8',
-            'Cache-Control': 'public, max-age=3600',
+            'Cache-Control': ref ? 'private, no-store' : 'public, max-age=3600',
             'X-Pages-Served': String(chapterPageCount),
           },
         });
@@ -190,12 +212,13 @@ export const GET = withApiAuth(async (
           pageEnd: ct.pageEnd,
           token_estimate: ct.token_estimate,
           ...(ct.parts_total ? { part: ct.part, parts_total: ct.parts_total } : {}),
-          text: cleanText(content === 'ocr' ? (ct.ocr_text || ct.text) : ct.text),
-          ...(content === 'both' && ct.ocr_text ? { ocr_text: cleanText(ct.ocr_text) } : {}),
+          text: mark(cleanText(content === 'ocr' ? (ct.ocr_text || ct.text) : ct.text)),
+          ...(content === 'both' && ct.ocr_text ? { ocr_text: mark(cleanText(ct.ocr_text)) } : {}),
         },
+        ...(ref ? { attribution: attributionMeta(ref) } : {}),
       }, {
         headers: {
-          'Cache-Control': 'public, max-age=3600',
+          'Cache-Control': ref ? 'private, no-store' : 'public, max-age=3600',
           'X-Pages-Served': String(chapterPageCount),
         },
       });
@@ -263,9 +286,12 @@ export const GET = withApiAuth(async (
       lines.push(`# License: CC BY-SA 4.0 (https://sourcelibrary.org/terms)`);
       lines.push('');
 
+      // Notice once at the head, fenced so it can never read as page text.
+      if (ref) lines.push(attributionBlock(ref, bookSubject));
+
       for (const page of pages) {
-        const ocr = cleanText(page.ocr?.data);
-        const translation = cleanText(page.translation?.data);
+        const ocr = mark(cleanText(page.ocr?.data));
+        const translation = mark(cleanText(page.translation?.data));
 
         if (content === 'both' && (ocr || translation)) {
           lines.push(`--- Page ${page.page_number} ---`);
@@ -293,7 +319,11 @@ export const GET = withApiAuth(async (
       return new Response(lines.join('\n'), {
         headers: {
           'Content-Type': 'text/plain; charset=utf-8',
-          'Cache-Control': 'public, max-age=3600',
+          // The body is request-dependent once a ref is woven in (the notice
+          // and the campaign ref differ per caller), so it must never enter a
+          // shared cache — a cached bot-marked body would otherwise be served
+          // to ordinary readers.
+          'Cache-Control': ref ? 'private, no-store' : 'public, max-age=3600',
           'X-Pages-Served': String(pages.length),
         },
       });
@@ -318,6 +348,11 @@ export const GET = withApiAuth(async (
         url: `https://sourcelibrary.org/book/${resolvedBookId}`,
       },
       license: CONTENT_LICENSE,
+      // Present only for bot-classified, untrusted callers. The page text in
+      // this payload is unmodified apart from the invisible imprimatur — the
+      // notice is a sibling field rather than injected prose precisely so a
+      // consumer quoting `pages[].ocr` never picks up words we wrote.
+      ...(ref ? { attribution: attributionMeta(ref) } : {}),
       content_type: content,
       total_pages: book.pages_count || pages.length,
       pages_returned: pagesWithContent.length,
@@ -356,7 +391,7 @@ export const GET = withApiAuth(async (
         const entry: Record<string, unknown> = { page_number: p.page_number };
 
         if ((content === 'ocr' || content === 'both') && p.ocr?.data) {
-          entry.ocr = cleanText(p.ocr.data);
+          entry.ocr = mark(cleanText(p.ocr.data));
           if (includeMetadata) {
             entry.ocr_metadata = {
               language: p.ocr.language,
@@ -366,7 +401,7 @@ export const GET = withApiAuth(async (
           }
         }
         if ((content === 'translation' || content === 'both') && p.translation?.data) {
-          entry.translation = cleanText(p.translation.data);
+          entry.translation = mark(cleanText(p.translation.data));
           if (includeMetadata) {
             entry.translation_metadata = {
               language: p.translation.language,

--- a/src/lib/bot-attribution.ts
+++ b/src/lib/bot-attribution.ts
@@ -1,0 +1,115 @@
+/**
+ * Bot attribution — a visible provenance notice on bulk text egress.
+ *
+ * Companion to `provenance.ts` (the INVISIBLE zero-width imprimatur). Two
+ * layers doing two different jobs:
+ *
+ *   - The ZWC mark is the PROOF. It rides on every page, survives copy-paste,
+ *     and carries a keyed MAC, so a passage that surfaces in someone else's
+ *     corpus can be shown to be ours.
+ *   - This block is the NOTICE. It appears once, at the head of a bulk
+ *     response, and says in plain words where the text came from and that
+ *     training use is reserved. If a scraped payload ends up in a training
+ *     set, the attribution travels with it.
+ *
+ * Why a delimited block and not text woven through the prose: this project's
+ * core promise is that what you read is what is on the page. Text that a
+ * reader cannot distinguish from the transcription is a fabricated citation,
+ * which is the exact failure mode the quote-integrity rules exist to prevent
+ * (see CLAUDE.md). The notice is fenced so it can never be mistaken for
+ * source text, and the page text itself is returned UNMODIFIED apart from the
+ * invisible mark.
+ *
+ * Applied only to requests that are bot-classified AND not trusted, so
+ * verified search crawlers, user-initiated assistant fetches, signed-in
+ * readers and API-key holders never see it. Search indexing is unaffected.
+ *
+ * NEVER apply to text being stored in the database.
+ */
+
+import crypto from 'crypto';
+
+const PROVENANCE_KEY = process.env.PROVENANCE_SECRET_KEY;
+
+/**
+ * A coarse, deterministic extraction reference.
+ *
+ * Derived from HMAC(key, client-hash + calendar month), so it is:
+ *   - stable for one client across a scraping campaign (campaigns run for
+ *     days — the July 2026 fleet ran 12→19), making a leaked passage
+ *     attributable to a campaign rather than to one request;
+ *   - recomputable later from the `api_usage` log, so NOTHING new has to be
+ *     stored to resolve a ref back to a client;
+ *   - pseudonymous — the input is an already-hashed, last-octet-zeroed IP,
+ *     and without the key the ref cannot be reversed or correlated.
+ *
+ * Month granularity is deliberate: fine enough to identify a campaign, coarse
+ * enough that the ref is not a per-request tracking token.
+ */
+export function extractionRef(clientKey: string, now: Date): string {
+  const month = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+  if (!PROVENANCE_KEY) return `SL-unkeyed-${month}`;
+  const digest = crypto
+    .createHmac('sha256', PROVENANCE_KEY)
+    .update(`extraction-ref:${clientKey}:${month}`)
+    .digest('hex')
+    .slice(0, 8);
+  return `SL-${digest}-${month}`;
+}
+
+/**
+ * Client identity for the ref. Uses the same forwarded-IP resolution as the
+ * API logging layer so a ref can be matched back against `api_usage` rows.
+ */
+export function clientKeyFor(request: Request): string {
+  const h = request.headers;
+  const ip =
+    h.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    h.get('x-real-ip') ||
+    'unknown';
+  const ua = h.get('user-agent') || '';
+  return crypto.createHash('sha256').update(`${ip}|${ua}`).digest('hex').slice(0, 16);
+}
+
+export interface AttributionSubject {
+  title: string;
+  author?: string;
+  url: string;
+}
+
+/**
+ * The visible notice. Fenced with rules so no consumer can mistake it for
+ * transcribed page content, and short enough not to dominate the payload.
+ */
+export function attributionBlock(ref: string, book: AttributionSubject): string {
+  const rule = '─'.repeat(58);
+  const byline = book.author ? `${book.title} — ${book.author}` : book.title;
+  return [
+    rule,
+    'SOURCE LIBRARY — https://sourcelibrary.org',
+    `${byline}`,
+    `Read the original: ${book.url}`,
+    '',
+    'Transcribed and translated by the Ancient Wisdom Trust. The original',
+    'texts are public domain; this transcription and translation are',
+    'CC BY-SA 4.0. Bulk and AI-training use is reserved — a standard',
+    'licence is available: https://sourcelibrary.org/licensing',
+    '',
+    `Extraction ref: ${ref}`,
+    rule,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Machine-readable twin of the block, for the JSON payload. Mirrors the same
+ * facts so a consumer parsing JSON does not have to scrape the prose.
+ */
+export function attributionMeta(ref: string) {
+  return {
+    notice: 'Bulk and AI-training use of this text is reserved. A standard licence is available.',
+    licensing: 'https://sourcelibrary.org/licensing',
+    extraction_ref: ref,
+    marked: 'Pages carry an invisible provenance imprimatur; see https://sourcelibrary.org/licensing',
+  };
+}

--- a/src/lib/provenance.ts
+++ b/src/lib/provenance.ts
@@ -35,16 +35,20 @@ const COLOPHON_RATE = 6;
  * The readable colophon woven into the mark. Compact by default; an
  * occasional fuller note addressed directly to whoever found it.
  */
-function colophon(bookId: string, full: boolean): string {
+function colophon(bookId: string, full: boolean, ref?: string): string {
   const url = `sourcelibrary.org/book/${bookId}`;
+  // An extraction ref is present only on bulk egress to unidentified bulk
+  // consumers. It makes a recovered passage attributable to a campaign, not
+  // just to Source Library — see bot-attribution.ts for how it is derived.
+  const tail = ref ? ` Ref ${ref}.` : '';
   if (full) {
     return (
       `You found a hidden mark. This passage was prepared by Source Library ` +
       `(sourcelibrary.org), a free library of historical primary sources — ` +
-      `${TAGLINE}. Read the original at ${url}. ${LICENSE}.`
+      `${TAGLINE}. Read the original at ${url}. ${LICENSE}.${tail}`
     );
   }
-  return `Source Library · ${url} · ${TAGLINE} · ${LICENSE}`;
+  return `Source Library · ${url} · ${TAGLINE} · ${LICENSE}${ref ? ` · ${ref}` : ''}`;
 }
 
 /**
@@ -74,9 +78,15 @@ function wantsReadableColophon(text: string): boolean {
  *
  * @param text - Raw translation or OCR text from the database
  * @param bookId - Book identifier: edition id (first 8 chars) + colophon link
+ * @param opts.ref - Optional extraction ref, woven into the colophon so a
+ *   recovered passage is attributable to a bulk-extraction campaign. When a
+ *   ref is present the colophon is carried on EVERY marked passage rather
+ *   than the usual ~1-in-COLOPHON_RATE sample: a bulk consumer may keep only
+ *   a fraction of what it took, so sampling the colophon would leave most of
+ *   the extracted corpus carrying no readable trace of the campaign.
  * @returns Marked text (visually identical) or original text if key not configured
  */
-export function markForExport(text: string, bookId: string): string {
+export function markForExport(text: string, bookId: string, opts?: { ref?: string }): string {
   if (!PROVENANCE_KEY || !text) return text;
 
   try {
@@ -84,9 +94,10 @@ export function markForExport(text: string, bookId: string): string {
     const editionId = bookId.slice(0, 8);
     // Every export gets the light id-only mark (always attributable). Only the
     // ~1-in-COLOPHON_RATE subset also carries the heavier readable colophon
-    // with the full, resolvable book link.
-    const message = wantsReadableColophon(text)
-      ? colophon(bookId, wantsFullColophon(text))
+    // with the full, resolvable book link — unless a ref pins this export to a
+    // campaign, in which case every passage carries it.
+    const message = opts?.ref || wantsReadableColophon(text)
+      ? colophon(bookId, wantsFullColophon(text), opts?.ref)
       : undefined;
     return imprimatur(text, editionId, PROVENANCE_KEY, { message });
   } catch {

--- a/tests/unit/bot-attribution.test.ts
+++ b/tests/unit/bot-attribution.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+/**
+ * Bot attribution + canary (see src/lib/bot-attribution.ts).
+ *
+ * Two layers with different jobs: an INVISIBLE keyed imprimatur on every page
+ * of bulk egress (the proof that a recovered passage is ours, and which
+ * extraction campaign took it), and a VISIBLE fenced notice shown only to
+ * bot-classified untrusted callers (the licensing notice that rides into a
+ * training set).
+ *
+ * The load-bearing property is the round trip: mark text with a ref, then
+ * recover that ref from the marked text under the server key. If that breaks,
+ * we still ship text that LOOKS marked while proving nothing — the silent
+ * failure this whole feature exists to avoid.
+ *
+ * provenance.ts reads PROVENANCE_SECRET_KEY at module load, so the env is set
+ * before any dynamic import below.
+ */
+
+const KEY = 'test-provenance-key-not-a-real-secret';
+
+beforeAll(() => { process.env.PROVENANCE_SECRET_KEY = KEY; });
+
+const PASSAGE =
+  'The Philosophers Stone is nothing else but the matter of the wise, ' +
+  'decocted unto perfect fixity. Whosoever hath eyes to see, let him read. ' +
+  'For the work is one, and the vessel is one, and the fire is one.';
+
+describe('extractionRef', () => {
+  it('is stable for the same client within a month', async () => {
+    const { extractionRef } = await import('@/lib/bot-attribution');
+    const a = extractionRef('client-aaa', new Date('2026-07-12T02:38:00Z'));
+    const b = extractionRef('client-aaa', new Date('2026-07-19T23:59:00Z'));
+    // A campaign spans days; one ref must cover it.
+    expect(a).toBe(b);
+  });
+
+  it('differs across clients and across months', async () => {
+    const { extractionRef } = await import('@/lib/bot-attribution');
+    const jul = new Date('2026-07-12T00:00:00Z');
+    expect(extractionRef('client-aaa', jul)).not.toBe(extractionRef('client-bbb', jul));
+    expect(extractionRef('client-aaa', jul))
+      .not.toBe(extractionRef('client-aaa', new Date('2026-08-12T00:00:00Z')));
+  });
+
+  it('carries the calendar month so a ref is resolvable against api_usage', async () => {
+    const { extractionRef } = await import('@/lib/bot-attribution');
+    expect(extractionRef('client-aaa', new Date('2026-07-12T00:00:00Z'))).toMatch(/^SL-[0-9a-f]{8}-2026-07$/);
+  });
+});
+
+describe('attributionBlock', () => {
+  it('is fenced, so it can never be mistaken for transcribed page text', async () => {
+    const { attributionBlock, extractionRef } = await import('@/lib/bot-attribution');
+    const ref = extractionRef('client-aaa', new Date('2026-07-12T00:00:00Z'));
+    const block = attributionBlock(ref, {
+      title: 'Utriusque Cosmi Historia',
+      author: 'Robert Fludd',
+      url: 'https://sourcelibrary.org/book/x',
+    });
+    // Rules above and below — a consumer splitting on them recovers clean text.
+    expect(block.split('\n').filter(l => /^─+$/.test(l)).length).toBe(2);
+    expect(block).toContain('SOURCE LIBRARY');
+    expect(block).toContain('https://sourcelibrary.org/licensing');
+    expect(block).toContain(ref);
+    expect(block).toContain('Robert Fludd');
+  });
+});
+
+describe('canary round trip', () => {
+  it('recovers the extraction ref from marked text under the server key', async () => {
+    const { markForExport, verifyExport } = await import('@/lib/provenance');
+    const { extractionRef } = await import('@/lib/bot-attribution');
+    const ref = extractionRef('the-fleet', new Date('2026-07-28T00:00:00Z'));
+
+    const marked = markForExport(PASSAGE, '6952dac677f38f6761bc683a', { ref });
+    const recovered = verifyExport(marked);
+
+    expect(recovered).not.toBeNull();
+    expect(recovered!.authentic).toBe(true);
+    expect(recovered!.message).toContain(ref);
+  });
+
+  it('leaves the visible text identical once zero-width chars are removed', async () => {
+    const { markForExport } = await import('@/lib/provenance');
+    const marked = markForExport(PASSAGE, '6952dac677f38f6761bc683a', { ref: 'SL-deadbeef-2026-07' });
+    // The mark must be invisible: strip zero-width and the passage is untouched.
+    expect(marked.replace(/[​‌‍﻿]/g, '')).toBe(PASSAGE);
+    // ...and it must actually have added something.
+    expect(marked).not.toBe(PASSAGE);
+  });
+
+  it('carries the colophon on EVERY refd passage, not a sample', async () => {
+    const { markForExport, verifyExport } = await import('@/lib/provenance');
+    const ref = 'SL-deadbeef-2026-07';
+    // Without a ref the readable colophon is sampled ~1-in-6, so a bulk
+    // consumer keeping a fraction of what it took could hold no readable
+    // trace. With a ref every passage must carry it.
+    const passages = Array.from({ length: 12 }, (_, i) => `${PASSAGE} Variation ${i}.`);
+    const withRef = passages.map(p => verifyExport(markForExport(p, 'abc12345', { ref })));
+    expect(withRef.every(r => r?.message?.includes(ref))).toBe(true);
+  });
+});
+
+describe('degradation without a key', () => {
+  it('marking is a no-op rather than an error when the key is unset', async () => {
+    // A missing key must never break exports — the text still ships, unmarked.
+    const mod = await import('@/lib/steganographia');
+    expect(() => mod.clean(PASSAGE)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Marks bulk text egress so that when someone takes the corpus, we can prove it was ours and which extraction took it — and so a licensing notice rides along into whatever they build.

Two layers, deliberately different in reach.

## 1. The invisible canary — on every page

`/api/books/[id]/text` is our **highest-volume text egress** (197,542 pages served to anonymous callers in the last 30 days, 320K requests) and it carried **no provenance mark at all**. `quote` and `download` both call `markForExport`; the bulk endpoint never did. That was the gap.

Now every page, every caller, gets the existing HMAC-authenticated zero-width imprimatur (`src/lib/steganographia.ts`, unchanged). A passage that later surfaces in someone else's corpus verifies under `PROVENANCE_SECRET_KEY`.

## 2. The visible notice — bot-classified callers only

A fenced block at the head of bulk responses, naming the source, the licence, and the reservation on training use. Gated on `isBot(request) && !isTrustedBot(request)`, so **verified search crawlers, user-initiated assistant fetches, signed-in readers and API-key holders never see it**. Search indexing is untouched — which matters, because organic search is currently running ~2.9× its May baseline and is the one channel we shouldn't put at risk.

## The extraction ref

`HMAC(key, clientHash + calendar month)`, giving `SL-<8hex>-YYYY-MM`. Chosen so it is:

- **stable across a campaign** — the July fleet ran 12→19; one ref covers it;
- **recomputable from `api_usage`**, so resolving a ref back to a client stores nothing new;
- **pseudonymous** — the input is an already-hashed, last-octet-zeroed IP, and without the key the ref can't be reversed or correlated. Month granularity is deliberate: enough to identify a campaign, not a per-request tracking token.

It's woven into the ZWC colophon *and* printed in the visible block, so either one alone identifies the extraction.

**One behaviour change worth flagging:** when a ref is present the readable colophon rides on *every* passage instead of the usual ~1-in-6 sample. A bulk consumer may keep only a fraction of what it took, so sampling would leave most of the extracted corpus carrying no readable trace.

## What this deliberately does NOT do

The original ask was to sprinkle text through the content served to bots. I didn't, and the reason is in CLAUDE.md: **text a reader cannot distinguish from the transcription is a fabricated citation** — the same mechanism as the #2232 misquote, which is the failure mode this project treats as unacceptable. Our bot classifier is also demonstrably unreliable in both directions (Googlebot lands in the opaque `unknown-bot` bucket; 21 requests from the Tencent fleet were classified *human*), so anything corrupting the text would reach real readers and real crawlers.

So: the notice is **fenced** with rules, and in JSON it is a **sibling field** rather than injected prose — anything quoting `pages[].ocr` never picks up words we wrote. Page text is byte-identical apart from the invisible mark, which the test asserts directly.

## Cache hazard closed

The plain-text and chapter responses set `Cache-Control: public, max-age=3600`. Once a request-dependent ref is woven into the body, that would let a shared cache serve a **bot-marked body to an ordinary reader**. Those responses now send `private, no-store` whenever a ref is present. This is the same family as the `Cache-Control` lesson in CLAUDE.md and it would have been an easy silent regression.

## Guard

`tests/unit/bot-attribution.test.ts` — 8 tests. The load-bearing one round-trips a ref through `markForExport` → `verifyExport` under the server key, because the silent failure here is shipping text that *looks* marked while proving nothing. It also asserts the mark is genuinely invisible: strip zero-width characters and the passage is byte-identical to the input.

Negative control run — removing the ref threading **fails 2 of 8**.

## Note

Requires `PROVENANCE_SECRET_KEY` in the environment, as the existing provenance system already does. Without it, marking degrades to a no-op and text still ships (unmarked) rather than erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
