### PR TITLE
fix(metrics): exclude fleet IPs from reading depth (follow-up to #3405)

### DIFF
--- a/scripts/analytics/engagement-metrics.mjs
+++ b/scripts/analytics/engagement-metrics.mjs
@@ -17,6 +17,7 @@
 //   7. Pipeline cost            (gemini_usage_daily)
 
 import { withMongo } from '../lib/mongo.mjs';
+import { computeReadingDepth } from '../lib/reading-depth.mjs';
 
 const DAYS = (() => { const i = process.argv.indexOf('--days'); return i > -1 ? Number(process.argv[i + 1]) : 30; })();
 const now = Date.now();
@@ -79,20 +80,16 @@ await withMongo(async (db) => {
 
   // ---- 2. READING DEPTH ----
   await section('2. Reading depth (page_read events, last 7d)', async () => {
-    // HUMAN EVENTS ONLY. Until #3405 this section matched every page_read, and
-    // page_read was written without any bot filter or user-agent — so the
-    // histogram was describing a headless fleet walking one page per book
-    // (839,701 events against 24,577 human book-page views in the same week).
-    // Events written before the fix have no traffic_class and CANNOT be
-    // classified retroactively; they are counted as unclassified, never as
-    // human. If most of the window is unclassified the honest output is "not
-    // measurable yet", not a plausible-looking histogram.
-    const total = await ev.countDocuments({ event: 'page_read', timestamp: { $gt: D7 } });
-    const classified = await ev.countDocuments({ event: 'page_read', timestamp: { $gt: D7 }, traffic_class: { $exists: true } });
-    if (total > 0 && classified / total < 0.5) {
-      console.log(`page_read events (7d)         ${total}`);
-      console.log(`  classified (post-#3405)     ${classified}  (${pct(classified, total)})`);
-      console.log(`NOT REPORTED: ${total - classified} of these events predate write-time bot`);
+    // Implementation lives in scripts/lib/reading-depth.mjs and is shared with
+    // snapshot-metrics.mjs — see the header there for both contaminations this
+    // has to survive (unclassifiable pre-#3405 rows, and a fleet that passes
+    // UA classification as human).
+    const d = await computeReadingDepth(db, D7);
+
+    if (d.contaminated) {
+      console.log(`page_read events (7d)         ${d.total}`);
+      console.log(`  classified (post-#3405)     ${d.classified}  (${pct(d.classified, d.total)})`);
+      console.log(`NOT REPORTED: ${d.unclassified} of these events predate write-time bot`);
       console.log(`classification and cannot be attributed to humans or crawlers. Reading`);
       console.log(`depth is unmeasurable over this window — do not quote a number for it.`);
       console.log(`Re-run once a full 7d window sits after the #3405 deploy.`);
@@ -100,25 +97,23 @@ await withMongo(async (db) => {
       console.log(`book opens, human-only (7d)   ${opens}`);
       return;
     }
-    // distinct pages read per (reader ip, book) — proxy for how far into a book a reader gets.
-    const depth = await ev.aggregate([
-      { $match: { event: 'page_read', timestamp: { $gt: D7 }, book_id: { $ne: null }, traffic_class: 'human' } },
-      { $group: { _id: { ip: '$ip', b: '$book_id' }, pages: { $addToSet: '$page_id' } } },
-      { $project: { n: { $size: '$pages' } } },
-      { $group: { _id: '$n', sessions: { $sum: 1 } } }, { $sort: { _id: 1 } },
-    ], { allowDiskUse: true }).toArray();
-    const all = []; for (const d of depth) for (let i = 0; i < d.sessions; i++) all.push(d._id);
-    all.sort((a, b) => a - b);
-    const n = all.length, med = all[Math.floor(n / 2)] || 0, p90 = all[Math.floor(n * 0.9)] || 0;
-    const oneOnly = depth.find((d) => d._id === 1)?.sessions || 0;
-    const deep = depth.filter((d) => d._id >= 10).reduce((s, d) => s + d.sessions, 0);
-    console.log(`reader-book pairs (7d)        ${n}`);
-    console.log(`pages read / pair  median=${med}  p90=${p90}`);
-    console.log(`read only 1 page              ${oneOnly}  (${pct(oneOnly, n)})`);
-    console.log(`read 10+ pages (deep read)    ${deep}  (${pct(deep, n)})`);
-    const opens = await ev.countDocuments({ event: 'book_read', timestamp: { $gt: D7 }, traffic_class: 'human' });
-    console.log(`book opens (book_read, 7d)    ${opens}`);
-    console.log(`(human-classified events only; ${total - classified} unclassified pre-#3405 events excluded)`);
+
+    console.log(`reader-book pairs (7d)        ${d.pairs}`);
+    console.log(`pages read / pair  median=${d.median}  p90=${d.p90}`);
+    console.log(`read only 1 page              ${d.oneOnly}  (${pct(d.oneOnly, d.pairs)})`);
+    console.log(`read 10+ pages (deep read)    ${d.deep}  (${pct(d.deep, d.pairs)})`);
+    console.log(`book opens (book_read, 7d)    ${d.opens}`);
+    console.log(`\nbasis — read these before quoting anything above:`);
+    console.log(`  unclassified events dropped  ${d.unclassified}  (pre-#3405, unattributable)`);
+    console.log(`  heavy IPs excluded           ${d.excludedIps}  (>${d.threshold} events/7d from one /24)`);
+    console.log(`  their events                 ${d.excludedEvents}`);
+    for (const h of d.excludedTopIps) console.log(`      ${h.ip}  ${h.events}`);
+    if (d.excludedIps) {
+      console.log(`  WITHOUT that exclusion:      pairs=${d.unfiltered.pairs} median=${d.unfiltered.median} 1-page=${pct(d.unfiltered.oneOnly, d.unfiltered.pairs)}`);
+      console.log(`  If those two rows disagree, the headline is a product of the heuristic,`);
+      console.log(`  not of the data. The /24 anonymization means a large NAT can be excluded`);
+      console.log(`  as a fleet — check the addresses above before trusting either figure.`);
+    }
   });
 
   // ---- 3. MISSION ACTIONS ----

--- a/scripts/analytics/snapshot-metrics.mjs
+++ b/scripts/analytics/snapshot-metrics.mjs
@@ -17,6 +17,7 @@
 // Cron (Hetzner, daily): see scripts/workers/crontab.production.
 
 import { withMongo } from '../lib/mongo.mjs';
+import { computeReadingDepth } from '../lib/reading-depth.mjs';
 
 const DAYS = (() => { const i = process.argv.indexOf('--days'); return i > -1 ? Number(process.argv[i + 1]) : 30; })();
 const norm = (e) => (e || '').trim().toLowerCase();
@@ -141,39 +142,14 @@ await withMongo(async (db) => {
   const multiDay = byDays.filter((x) => x._id > 1).reduce((s, x) => s + x.n, 0);
 
   // ─── READING DEPTH (page_read events, 7d) ─────────────────────────────────
+  // Shared with engagement-metrics.mjs via scripts/lib/reading-depth.mjs so a
+  // correction can't land in one and miss the other. This snapshot feeds
+  // /platform/admin/metrics AND the weekly digest, so a wrong number here is a
+  // number that gets emailed.
   const ev = db.collection('analytics_events');
   let reading = null;
   try {
-    // Human-classified events only (#3405). page_read had no bot filter and
-    // stored no user-agent, so the depth histogram this feeds — rendered on
-    // /platform/admin/metrics and carried in the weekly digest — was describing
-    // crawler traffic. Pre-fix events can never be classified, so a window
-    // dominated by them reports `contaminated` and the surfaces suppress the
-    // number rather than showing a confident wrong one.
-    const total = await ev.countDocuments({ event: 'page_read', timestamp: { $gt: d7 } });
-    const classified = await ev.countDocuments({ event: 'page_read', timestamp: { $gt: d7 }, traffic_class: { $exists: true } });
-    if (total > 0 && classified / total < 0.5) {
-      reading = { contaminated: true, unclassified: total - classified, total };
-    } else {
-    const depth = await ev.aggregate([
-      { $match: { event: 'page_read', timestamp: { $gt: d7 }, book_id: { $ne: null }, traffic_class: 'human' } },
-      { $group: { _id: { ip: '$ip', b: '$book_id' }, pages: { $addToSet: '$page_id' } } },
-      { $project: { n: { $size: '$pages' } } },
-      { $group: { _id: '$n', sessions: { $sum: 1 } } }, { $sort: { _id: 1 } },
-    ], { allowDiskUse: true }).toArray();
-    const flat = []; for (const d of depth) for (let i = 0; i < d.sessions; i++) flat.push(d._id);
-    flat.sort((a, b) => a - b);
-    const rn = flat.length;
-    reading = {
-      pairs: rn,
-      median: flat[Math.floor(rn / 2)] || 0,
-      p90: flat[Math.floor(rn * 0.9)] || 0,
-      oneOnly: depth.find((d) => d._id === 1)?.sessions || 0,
-      deep: depth.filter((d) => d._id >= 10).reduce((s, d) => s + d.sessions, 0),
-      opens: await ev.countDocuments({ event: 'book_read', timestamp: { $gt: d7 }, traffic_class: 'human' }),
-      unclassified: total - classified,
-    };
-    }
+    reading = await computeReadingDepth(db, d7);
   } catch { /* events collection may be sparse */ }
 
   // ─── MISSION ACTIONS ──────────────────────────────────────────────────────

--- a/scripts/lib/reading-depth.mjs
+++ b/scripts/lib/reading-depth.mjs
@@ -1,0 +1,126 @@
+/**
+ * Reading depth — the one product question that matters most ("do people who
+ * open a book actually read it?") and the one we have repeatedly got wrong.
+ *
+ * Shared by scripts/analytics/engagement-metrics.mjs (the human-readable
+ * report) and scripts/analytics/snapshot-metrics.mjs (which feeds
+ * /platform/admin/metrics AND the weekly digest email). They had near-identical
+ * copies of this aggregation; a correction applied to one and not the other is
+ * how a bad number survives a fix, so there is exactly one implementation now.
+ *
+ * Two independent contaminations have to be handled, and the second is the
+ * subtle one:
+ *
+ *  1. UNCLASSIFIED events. Before #3405 `page_read` was written with no bot
+ *     filter and no user-agent, so those rows can never be attributed. They are
+ *     counted, never included, and if they dominate the window the answer is
+ *     "not measurable" rather than a plausible histogram.
+ *
+ *  2. Events classified 'human' that are not. Verified in production minutes
+ *     after the #3405 deploy: the headless fleet in 43.172/43.173 presents a
+ *     plain "Windows NT 10.0 … Chrome" user-agent, so UA matching correctly
+ *     finds nothing wrong with it, and the per-IP cap is per serverless
+ *     instance so it does not bind across a fleet. 353 of 1,528 events in a
+ *     12-minute window (23%) were stored as human from those two /16s alone.
+ *     Write-time classification cannot see this — only an aggregate over the
+ *     whole window can.
+ *
+ * So depth excludes IPs whose volume is impossible for a person, and REPORTS
+ * what it excluded. Never a silent cap: the caller prints both the excluded and
+ * unexcluded figures, because the exclusion has a real false-positive mode
+ * (`ip` is anonymized to a /24, so a large NAT or CGNAT range is many readers
+ * sharing one key). Seeing both is what tells you whether the headline depends
+ * on the heuristic.
+ */
+
+// Distinct page_read events from one anonymized /24 over the window, above
+// which the source cannot be a person. 1,500 over 7 days is ~214 pages/day
+// sustained, every day, with no gap — well beyond a devoted reader, and far
+// below the fleet's observed ~1,575/day per address.
+export const HEAVY_IP_EVENT_THRESHOLD = 1500;
+
+// Below this share of classified events, the window is mostly pre-#3405 rows
+// and no depth figure should be produced at all.
+const MIN_CLASSIFIED_SHARE = 0.5;
+
+/**
+ * @param {import('mongodb').Db} db
+ * @param {Date} since  start of the window (typically 7 days ago)
+ * @param {{ threshold?: number }} [opts]  threshold is per-window, so a caller
+ *   measuring a shorter span must scale it down — the default is sized for 7d.
+ * @returns {Promise<object>} depth stats, or { contaminated: true, … }
+ */
+export async function computeReadingDepth(db, since, opts = {}) {
+  const threshold = opts.threshold ?? HEAVY_IP_EVENT_THRESHOLD;
+  const ev = db.collection('analytics_events');
+  const base = { event: 'page_read', timestamp: { $gt: since } };
+
+  const total = await ev.countDocuments(base);
+  const classified = await ev.countDocuments({ ...base, traffic_class: { $exists: true } });
+
+  if (total > 0 && classified / total < MIN_CLASSIFIED_SHARE) {
+    return { contaminated: true, total, classified, unclassified: total - classified };
+  }
+
+  const human = { ...base, traffic_class: 'human', book_id: { $ne: null } };
+
+  // Which anonymized /24s emit more than a person could?
+  const heavy = await ev.aggregate([
+    { $match: human },
+    { $group: { _id: '$ip', n: { $sum: 1 } } },
+    { $match: { n: { $gt: threshold } } },
+    { $sort: { n: -1 } },
+  ], { allowDiskUse: true }).toArray();
+
+  const heavyIps = heavy.map((h) => h._id);
+  const heavyEvents = heavy.reduce((s, h) => s + h.n, 0);
+
+  const histogram = async (match) => {
+    const rows = await ev.aggregate([
+      { $match: match },
+      { $group: { _id: { ip: '$ip', b: '$book_id' }, pages: { $addToSet: '$page_id' } } },
+      { $project: { n: { $size: '$pages' } } },
+      { $group: { _id: '$n', sessions: { $sum: 1 } } },
+      { $sort: { _id: 1 } },
+    ], { allowDiskUse: true }).toArray();
+
+    const flat = [];
+    for (const r of rows) for (let i = 0; i < r.sessions; i++) flat.push(r._id);
+    flat.sort((a, b) => a - b);
+    const n = flat.length;
+    return {
+      pairs: n,
+      median: flat[Math.floor(n / 2)] || 0,
+      p90: flat[Math.floor(n * 0.9)] || 0,
+      oneOnly: rows.find((r) => r._id === 1)?.sessions || 0,
+      deep: rows.filter((r) => r._id >= 10).reduce((s, r) => s + r.sessions, 0),
+    };
+  };
+
+  const filtered = await histogram(
+    heavyIps.length ? { ...human, ip: { $nin: heavyIps } } : human
+  );
+  // The same statistic without the heuristic. If the two disagree sharply, the
+  // headline is a product of the exclusion rule and must be quoted as such.
+  const unfiltered = heavyIps.length ? await histogram(human) : filtered;
+
+  return {
+    ...filtered,
+    opens: await ev.countDocuments({
+      event: 'book_read',
+      timestamp: { $gt: since },
+      traffic_class: 'human',
+      ...(heavyIps.length ? { ip: { $nin: heavyIps } } : {}),
+    }),
+    // Clamped: the two counts are taken a moment apart against a live stream,
+    // so on a busy window `classified` can exceed the `total` read just before
+    // it. A negative "unclassified" in a report is a bug that reads as a data
+    // anomaly, which is the last thing this section needs.
+    unclassified: Math.max(0, total - classified),
+    excludedIps: heavyIps.length,
+    excludedEvents: heavyEvents,
+    excludedTopIps: heavy.slice(0, 5).map((h) => ({ ip: h._id, events: h.n })),
+    threshold,
+    unfiltered,
+  };
+}

--- a/tests/integration/reading-depth.test.ts
+++ b/tests/integration/reading-depth.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTestDb, cleanDb } from '../setup';
+// @ts-expect-error — plain .mjs analytics lib, no types
+import { computeReadingDepth } from '../../scripts/lib/reading-depth.mjs';
+
+/**
+ * Reading depth has been wrong twice in two different ways (#3405 and the
+ * fleet-passes-as-human finding that followed the fix). These assertions pin
+ * both behaviours against seeded data rather than asserting the source shape:
+ * each one fails if the filter, the exclusion, or the honesty reporting is
+ * removed.
+ */
+
+const HOUR = 3600_000;
+
+function pageReads(opts: {
+  ip: string; book: string; pages: number; traffic_class?: string | null;
+}) {
+  const now = Date.now();
+  return Array.from({ length: opts.pages }, (_, i) => ({
+    event: 'page_read',
+    book_id: opts.book,
+    page_id: `${opts.book}-p${i}`,
+    ip: opts.ip,
+    timestamp: new Date(now - HOUR),
+    created_at: new Date(now - HOUR),
+    ...(opts.traffic_class === null ? {} : { traffic_class: opts.traffic_class ?? 'human' }),
+  }));
+}
+
+async function seed(docs: object[]) {
+  await getTestDb().collection('analytics_events').insertMany(docs as never[]);
+}
+
+const since = () => new Date(Date.now() - 24 * HOUR);
+
+describe('computeReadingDepth', () => {
+  beforeEach(cleanDb);
+
+  it('refuses to report when the window is mostly unclassifiable pre-#3405 events', async () => {
+    await seed([
+      ...pageReads({ ip: '10.0.0.0', book: 'b1', pages: 60, traffic_class: null }),
+      ...pageReads({ ip: '10.0.1.0', book: 'b2', pages: 10 }),
+    ]);
+
+    const d = await computeReadingDepth(getTestDb(), since());
+
+    expect(d.contaminated).toBe(true);
+    expect(d.unclassified).toBe(60);
+    // No histogram fields at all — a caller cannot accidentally render a number.
+    expect(d.median).toBeUndefined();
+    expect(d.pairs).toBeUndefined();
+  });
+
+  it('counts only human-classified events', async () => {
+    await seed([
+      ...pageReads({ ip: '10.0.0.0', book: 'b1', pages: 12 }),
+      ...pageReads({ ip: '10.0.9.0', book: 'b2', pages: 40, traffic_class: 'ai_trainer' }),
+      ...pageReads({ ip: '10.0.8.0', book: 'b3', pages: 40, traffic_class: 'search_crawler' }),
+    ]);
+
+    const d = await computeReadingDepth(getTestDb(), since());
+
+    expect(d.contaminated).toBeUndefined();
+    expect(d.pairs).toBe(1);        // only the human reader-book pair
+    expect(d.median).toBe(12);
+    expect(d.deep).toBe(1);
+  });
+
+  it('excludes a fleet that passes UA classification as human, and says so', async () => {
+    // Ten addresses, each walking one page of many books — the observed fleet
+    // signature, and the shape that produced "81% read a single page".
+    const fleet = Array.from({ length: 10 }, (_, i) =>
+      Array.from({ length: 200 }, (_, b) =>
+        pageReads({ ip: `43.173.${i}.0`, book: `fleet-b${b}`, pages: 1 })
+      ).flat()
+    ).flat();
+    // Two genuine readers who read deeply.
+    const readers = [
+      ...pageReads({ ip: '10.0.0.0', book: 'real-1', pages: 30 }),
+      ...pageReads({ ip: '10.0.1.0', book: 'real-2', pages: 25 }),
+    ];
+    await seed([...fleet, ...readers]);
+
+    const d = await computeReadingDepth(getTestDb(), since(), { threshold: 150 });
+
+    expect(d.excludedIps).toBe(10);
+    expect(d.excludedEvents).toBe(2000);
+    expect(d.excludedTopIps[0].ip).toMatch(/^43\.173\./);
+
+    // Without the exclusion the fleet buries the readers: 2,002 pairs, median 1.
+    expect(d.unfiltered.pairs).toBe(2002);
+    expect(d.unfiltered.median).toBe(1);
+    expect(d.unfiltered.oneOnly).toBe(2000);
+
+    // With it, the two real readers are the whole population.
+    expect(d.pairs).toBe(2);
+    expect(d.median).toBeGreaterThanOrEqual(25);
+    expect(d.oneOnly).toBe(0);
+  });
+
+  it('reports the unexcluded figures even when nothing is excluded', async () => {
+    await seed(pageReads({ ip: '10.0.0.0', book: 'b1', pages: 5 }));
+
+    const d = await computeReadingDepth(getTestDb(), since());
+
+    expect(d.excludedIps).toBe(0);
+    // The caller always has both numbers to compare, so "no exclusion applied"
+    // is visible rather than implied by a missing field.
+    expect(d.unfiltered.pairs).toBe(d.pairs);
+  });
+});


### PR DESCRIPTION
Follow-up to #3414. Re-opens the substance of #3405: **write-time classification alone does not fix the reading-depth metric.**

## What production showed after the deploy

I verified the #3405 fix end-to-end (bot POST → `{"dropped":true}`, zero leaked rows, real traffic carrying `traffic_class`), then checked *which* traffic was landing in the human bucket:

```
stored events by class + IP prefix, 12min window
   238  human   43.173.   Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/5…
   115  human   43.172.   Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/5…
    60  human   172.71.   Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWe…
```

The fleet from ops #5 sends a plain Windows Chrome user-agent. `classifyTraffic` correctly finds nothing wrong with it, and the per-IP cap is per serverless instance so it never binds across ~80 addresses. 353 of 1,528 events in that window — 23% — were stored as **human** from those two /16s alone.

The PR description for #3414 hedged this correctly ("does not catch a distributed fleet — that's ops #5"). The practical consequence is sharper than the hedge: left alone, depth would have come back *confidently wrong* the moment a clean 7-day window existed. A metric that is honestly "not measurable" for a week and then silently wrong afterwards is worse than one that stays broken loudly.

## The fix

Write-time classification cannot see cross-instance volume; only an aggregate over the window can. So depth excludes anonymized /24s emitting more than a person could (default 1,500 events/7d ≈ 214/day sustained) — and **reports every exclusion**.

Measured on 7 minutes of real post-deploy traffic with the threshold scaled to the span:

| | pairs | median | read 1 page only |
|---|---:|---:|---:|
| with exclusion | 879 | 1 | 840 |
| without | 2,200 | 1 | 2,003 |

15 addresses, 1,507 events, every one of the top five in `43.172.*`/`43.173.*`. **The fleet was ~60% of the "human" reader-book denominator.**

### Never a silent cap

`ip` is anonymized to a /24, so a university NAT or CGNAT range is many readers behind one key — this heuristic has a real false-positive mode. Callers therefore print the excluded count, the top addresses, and the same statistic *without* the heuristic, with a note that disagreement between the two means the headline is a product of the rule rather than the data. Deciding from one number without the other is how we got here.

### One implementation

`engagement-metrics.mjs` and `snapshot-metrics.mjs` had near-identical copies of this aggregation. They now share `scripts/lib/reading-depth.mjs`. `snapshot-metrics` is the one that feeds `/platform/admin/metrics` **and the weekly digest**, so a correction landing in only the report script would have left the emailed number wrong.

## Testing

`tests/integration/reading-depth.test.ts` seeds a synthetic fleet (10 addresses × 200 books × 1 page — the observed signature, and the shape that produced "81% read a single page") alongside two deep readers, and asserts the unfiltered view buries them (2,002 pairs, median 1) while the filtered view recovers them (2 pairs, median ≥25). Also pins the refuse-to-report branch and that `unfiltered` is always populated.

4 tests, plus 909 unit / 30 integration green, `tsc` clean.

## Note

The live snapshot currently reads `{"contaminated": true, "unclassified": 852407}` — correct, and the admin page renders the explanation card shipped in #3414. It resolves on its own once a 7-day window sits entirely after the deploy (~2026-08-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
