### PR TITLE
Redirect /call to the Source Library booking page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -326,6 +326,16 @@ const nextConfig: NextConfig = {
         destination: '/support',
         permanent: false,
       },
+      // Fundraising outreach links to sourcelibrary.org/call so the emails carry
+      // an on-domain URL rather than a raw calendar.app.google one. Points at the
+      // 15-minute Google Calendar appointment schedule (the 30-minute page is
+      // linked directly from the few drafts that ask for longer). Temporary: the
+      // schedule can be rebuilt, which mints a new booking URL.
+      {
+        source: '/call',
+        destination: 'https://calendar.app.google/rh2H63a7JxPkcgR87',
+        permanent: false,
+      },
       // SHWEP reading room taken down (collection hidden). Keep inbound podcast
       // links off a 404 — temporary so it can be restored.
       {


### PR DESCRIPTION
`sourcelibrary.org/call` 404s today. The fundraising outreach drafts ask for 15 minutes and need an on-domain link to hand over, rather than pasting a raw `calendar.app.google` URL into donor emails.

Adds one redirect: `/call` → the 15-minute Google Calendar appointment schedule.

- **307, not 308.** The appointment schedule can be rebuilt, and rebuilding mints a new booking URL — a permanent redirect would get cached against a dead target.
- No existing `/call` route to collide with, and no other `source: '/call'` entry in the config.
- `npx tsc --noEmit` clean.

The 30-minute schedule is deliberately not routed here; the few drafts that ask for 20–30 minutes link it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)