### PR TITLE
fix: stop the browser-translation crash on collection pages and /search (#3409)

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -34,6 +34,7 @@ import { LIBRARY_PARTNERS } from '@/lib/library-partners';
 import CollectionBookCard, { type CollectionBook } from '@/components/CollectionBookCard';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { getEffectiveByline } from '@/lib/byline';
+import TranslationSafe from '@/components/layout/TranslationSafe';
 
 // How many results to show in unified view per section
 const PREVIEW_BOOKS = 5;
@@ -1181,6 +1182,12 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
 
       {/* Results */}
       <main className="max-w-[var(--container-wide)] mx-auto px-6 md:px-12 py-8">
+        {/* With a browser translator active React cannot reconcile these
+            result lists — the translator has replaced every text node — so we
+            remount them instead. Wraps only the results, never the search box
+            or filter state, which live above and must survive. See
+            TranslationSafe and #3314. */}
+        <TranslationSafe identity={`${query}|${viewMode}|${language}|${category}|${offset}|${resultsPerPage}`}>
         {/* Anonymous free-search wall — shown after 5 searches/hour */}
         {signInRequired && (
           <div className="text-center py-16 max-w-lg mx-auto">
@@ -1785,6 +1792,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             </div>
           </section>
         )}
+      </TranslationSafe>
       </main>
 
     </div>

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -8,6 +8,7 @@ import CollectionListView from '@/components/collections/CollectionListView';
 import CatalogPagination from '@/components/collections/CatalogPagination';
 import { bookTitle } from '@/lib/collections-utils';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import TranslationSafe from '@/components/layout/TranslationSafe';
 
 const PER_PAGE = 60;
 
@@ -357,7 +358,14 @@ export default function CollectionAllBooks({
         )}
       </div>
 
-      {/* Books — Grid or List */}
+      {/* Books — Grid or List.
+          Wrapped in TranslationSafe: with a browser translator active, React
+          cannot reconcile this list (the translator has replaced every text
+          node), so it remounts instead. Identity covers everything that
+          changes the rendered set. The wrapper sits BELOW the controls on
+          purpose — sort/filter/query state lives in this component, above the
+          key, so remounting the list never resets them. */}
+      <TranslationSafe identity={`${viewMode}|${expanded}|${sort}|${language}|${query}|${safePage}`}>
       {viewMode === 'list' && expanded ? (
         <CollectionListView
           books={displayBooks}
@@ -504,6 +512,7 @@ export default function CollectionAllBooks({
           )}
         </div>
       )}
+      </TranslationSafe>
 
       {/* Pagination */}
       {expanded && (

--- a/src/components/layout/TranslationSafe.tsx
+++ b/src/components/layout/TranslationSafe.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Fragment, type ReactNode } from 'react';
+import { useBrowserTranslation } from '@/hooks/useBrowserTranslation';
+
+/**
+ * Remount a subtree instead of reconciling it, while a browser translator is
+ * rewriting the page.
+ *
+ * Chrome/Edge's translator replaces every text node with a nested
+ * <font style="vertical-align: inherit"> pair. React still holds the ORIGINAL
+ * text node, so its next commit patches nodes that have left the document. The
+ * inline guard in the root layout (TRANSLATION_DOM_GUARD_SCRIPT) stops the
+ * resulting throw, but it cannot make the update *arrive* — only a remount
+ * does that. Both halves shipped for the reader in #3314; this is the second
+ * half generalised, because every other list that re-renders needs it too.
+ *
+ * Measured before writing this (PostHog, 30d): the null-`parentNode` /
+ * `insertBefore` crash class runs at ~2,575 events on collection pages and 147
+ * on /search, and Spanish-locale visitors hit it ~16x more often than
+ * English-locale ones — the auto-translate signature. The reader, which has
+ * had the remount since #3314, sits at 333 events across 502K pageviews.
+ *
+ * `identity` must change whenever the subtree's *content* changes — sort,
+ * filter, query, page. That is what triggers the remount.
+ *
+ * Costs nothing when no translator is present: the key is `undefined`, so
+ * React reconciles exactly as before and untranslated readers are untouched.
+ *
+ * Wrap the CONTENT that re-renders, never a parent holding UI state — keying
+ * a subtree resets any state inside it. (The reader learned this: panel
+ * toggles and font size deliberately live above its key.)
+ */
+export default function TranslationSafe({
+  identity,
+  children,
+}: {
+  identity: string | number;
+  children: ReactNode;
+}) {
+  const translated = useBrowserTranslation();
+  return <Fragment key={translated ? `sl-t-${identity}` : undefined}>{children}</Fragment>;
+}

--- a/tests/unit/translation-safe.test.ts
+++ b/tests/unit/translation-safe.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement as h, Fragment } from 'react';
+import TranslationSafe from '@/components/layout/TranslationSafe';
+
+/**
+ * TranslationSafe wraps lists React cannot reconcile while a browser
+ * translator is rewriting the page (see the component, and #3314).
+ *
+ * SCOPE — read before trusting this file. The repo's vitest environment is
+ * `node` with no jsdom or testing-library, so the REMOUNT behaviour (which
+ * needs a DOM, an effect pass and a simulated translator) is NOT covered here;
+ * adding a DOM test runner is a tooling change that does not belong in a bug
+ * fix. What IS covered is the other half of the contract, equally easy to
+ * regress and silent when it breaks:
+ *
+ *   the wrapper must be TRANSPARENT — no extra element, no changed markup.
+ *
+ * Both call sites sit inside CSS grid/flex containers (CollectionAllBooks'
+ * results grid, /search's results main). Wrapping children in a <div> would
+ * not throw, would pass typecheck, and would quietly break both layouts.
+ * Changing Fragment to any host element fails these assertions.
+ *
+ * The remount half is verified post-deploy by the locale split — the es-ES
+ * crash rate falling toward the en-US rate. That is stated in the PR because
+ * it is the check that can actually fail.
+ *
+ * (No jsx here: the runner's include glob is tests/**\/*.test.ts.)
+ */
+
+describe('TranslationSafe', () => {
+  it('renders children with no wrapper element', () => {
+    const html = renderToStaticMarkup(
+      h(TranslationSafe, { identity: 'a' }, h('span', null, 'one'), h('span', null, 'two')),
+    );
+    expect(html).toBe('<span>one</span><span>two</span>');
+  });
+
+  it('is byte-identical to rendering the children directly', () => {
+    const kids = [h('li', { key: 1 }, 'Atalanta fugiens'), h('li', { key: 2 }, 'Utriusque Cosmi Historia')];
+    const wrapped = renderToStaticMarkup(h(TranslationSafe, { identity: 'x' }, ...kids));
+    const bare = renderToStaticMarkup(h(Fragment, null, ...kids));
+    expect(wrapped).toBe(bare);
+  });
+
+  it('never leaks identity into the markup', () => {
+    // Identity drives the remount key only. If it reached the DOM it would
+    // appear in server HTML and in crawler-visible markup.
+    const a = renderToStaticMarkup(h(TranslationSafe, { identity: 'sort=year' }, h('p', null, 'x')));
+    const b = renderToStaticMarkup(h(TranslationSafe, { identity: 'sort=title|page=7' }, h('p', null, 'x')));
+    expect(a).toBe(b);
+    expect(a).not.toContain('sort');
+  });
+});


### PR DESCRIPTION
Closes the collection-page and `/search` half of #3409.

## What was actually wrong

#3314 fixed this crash class for the reader with **two** parts:

1. `TRANSLATION_DOM_GUARD_SCRIPT` — an inline `<head>` script that stops the *throw*.
2. A **remount** while a translator is active — which is what makes React's updates actually *arrive*.

Only part 1 was global. Part 2 was wired into `TranslationEditor` alone. Every other list that re-renders has been running with the un-fixed half ever since.

## The measurement

Crashes (`Cannot read properties of null (reading 'parentNode')` + `insertBefore`) vs pageviews, by path shape, PostHog 30d:

| surface | crashes | pageviews | rate | users |
|---|---|---|---|---|
| **collection** | 2,575 | 2,693 | **~0.96 / pageview** | 46 |
| **search** | 147 | 447 | **0.33** | 41 |
| reader-page | 333 | 502,053 | 0.0007 | 305 |
| book-landing | 1 | 44,084 | ~0 | 1 |

The reader — the one surface with the remount — is two to three orders of magnitude cleaner. Note the collection users: **46 people generating 2,575 events**, ~56 each. That is a page crashing repeatedly for the same visitor, not an occasional blip.

**Grouping matters here and nearly fooled me.** Reader pathnames are unique per page (`/book/<slug>/page/<id>`), so grouping by exact `$pathname` scatters reader traffic across thousands of rows and buries it, while `/collections/psychology` aggregates into one. My first pass did exactly that. The table above groups by path *shape*.

## Locale confirms the cause

Affected users as a share of that locale's audience:

| locale | affected | total (7d) | rate |
|---|---|---|---|
| **es-ES** | 28 | 245 | **11.4%** |
| es-419 | 11 | 176 | 6.3% |
| en-US | 48 | 6,675 | 0.7% |

Spanish-locale visitors are **~16× more likely** to hit it. That is the auto-translate signature, and it is how #3314 was originally found — via an Italian reader whose screenshot showed the Chrome translate icon lit.

(zh-CN is excluded from that read: its denominator is the Tencent headless fleet, not people.)

## The change

`TranslationSafe` — remounts its subtree instead of reconciling it, while `useBrowserTranslation` reports an active translator. The key is `undefined` otherwise, so **untranslated readers are byte-for-byte unaffected**.

Applied to `CollectionAllBooks`'s results region and `/search`'s results `<main>`.

**Both wrappers sit below the controls, never around them.** Sort, filter, query and pagination state live above the key and must survive a remount — that is precisely the mistake the reader's own code comment warns about ("Never key the whole reader… panel toggles/font size live above the key").

## What I am NOT claiming

**I could not pinpoint the throwing frame.** PostHog stacks are minified with no source maps — every frame is `?`. I checked and ruled out three candidate call sites in our own code:

- `useSearchHighlight` — reads `el.parentNode`, but null-guarded and only runs with `?highlight=`;
- `ScrollReveal` — walks `parentElement`, null-guarded, and its MutationObserver watches `childList` only and is rAF-debounced, so it cannot self-trigger;
- the PostHog loader snippet — reads `.parentNode` but on a script element that always has one.

So this ships as **the remedy already proven for this crash class on this codebase, applied to the surfaces that measurably still have it** — not as a fix to an identified line. That distinction is real and I would rather state it than imply more certainty than I have.

**Recommended follow-up:** enable `productionBrowserSourceMaps` so the next occurrence names its function. That is what would close this conclusively, and it is a one-line config change I deliberately kept out of this PR (different concern, and it changes build output).

## Guard, and its honest limits

`tests/unit/translation-safe.test.ts` pins that the wrapper is **transparent** — no extra element, markup byte-identical to rendering the children directly, identity never leaking into the DOM. That matters because both call sites sit inside CSS grid/flex containers: an added `<div>` would break both layouts silently while passing typecheck. **Negative control run — `Fragment` → `div` fails 2 of 3.**

The **remount half is not unit-tested**. It needs a DOM, an effect pass and a simulated translator; the repo's vitest environment is `node` with no jsdom or testing-library, and adding a DOM test runner is a tooling change that does not belong in a bug fix (per the PR conventions on tooling additions).

**So verify by measurement after deploy:** the es-ES crash rate should fall toward the en-US rate. Watch the *locale split*, not the raw count — raw counts are contaminated by the bot fleet. If es-ES stays near 11%, this was the wrong remedy and the source maps become the priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
