### PR TITLE
fix: guard React's streaming-SSR inline helpers against translator DOM rewrites (#3409)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ const VIEW_MODE_INIT_SCRIPT = `(function(){var d=document,c=d.cookie,h=location.
 // React bundle has even parsed, so patching from a client component would be too
 // late for the hydration commit. `window.__slTranslateGuardHits` counts swallowed
 // calls for support triage.
-const TRANSLATION_DOM_GUARD_SCRIPT = `(function(){if(typeof Node!=='function'||!Node.prototype)return;window.__slTranslateGuardHits=0;var r=Node.prototype.removeChild;Node.prototype.removeChild=function(c){if(c&&c.parentNode!==this){window.__slTranslateGuardHits++;return c;}return r.apply(this,arguments);};var i=Node.prototype.insertBefore;Node.prototype.insertBefore=function(n,ref){if(ref&&ref.parentNode!==this){window.__slTranslateGuardHits++;return n;}return i.apply(this,arguments);};})();`;
+const TRANSLATION_DOM_GUARD_SCRIPT = `(function(){if(typeof Node!=='function'||!Node.prototype)return;window.__slTranslateGuardHits=0;var r=Node.prototype.removeChild;Node.prototype.removeChild=function(c){if(c&&c.parentNode!==this){window.__slTranslateGuardHits++;return c;}return r.apply(this,arguments);};var i=Node.prototype.insertBefore;Node.prototype.insertBefore=function(n,ref){if(ref&&ref.parentNode!==this){window.__slTranslateGuardHits++;return n;}return i.apply(this,arguments);};})();(function(){window.__slStreamGuardHits=0;var K=['$RS','$RC','$RM','$RX','$RB','$RT'];for(var j=0;j<K.length;j++){(function(k){var v;try{Object.defineProperty(window,k,{configurable:true,get:function(){return v;},set:function(f){v=(typeof f==='function')?function(){try{return f.apply(this,arguments);}catch(e){window.__slStreamGuardHits++;}}:f;}});}catch(e){}})(K[j]);}})();`;
 
 export const metadata: Metadata = {
   title: "Source Library — Ancient Texts Translated to English",

--- a/tests/unit/translation-stream-guard.test.ts
+++ b/tests/unit/translation-stream-guard.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import vm from 'vm';
+
+/**
+ * Pins the SECOND half of the inline guard in src/app/layout.tsx: the wrapper
+ * around React's streaming-SSR inline helpers ($RS, $RC, $RM, …).
+ *
+ * Diagnosed from production stacks, not guessed. Every one of 120 sampled
+ * `Cannot read properties of null (reading 'parentNode')` exceptions carried
+ * `$RS` in its frames, with `filename` pointing at the HTML DOCUMENT rather
+ * than a JS bundle — i.e. the throw is inside React's inline bootstrap, not
+ * in our client bundle.
+ *
+ * React's $RS replaces a streamed Suspense segment, roughly:
+ *
+ *     $RS = function (a, b) {
+ *       a = document.getElementById(a);
+ *       b = document.getElementById(b);
+ *       for (a.parentNode.removeChild(a); a.firstChild; ) b.parentNode.insertBefore(a.firstChild, b);
+ *       ...
+ *     }
+ *
+ * A browser translator rewrites the DOM while the response is still
+ * streaming, so the placeholder React is about to look up is gone,
+ * getElementById returns null, and `a.parentNode` throws — blanking the page
+ * at the nearest error boundary. Collection pages stream several Suspense
+ * boundaries each, which is why they crashed at roughly one per pageview
+ * while the reader did not.
+ *
+ * The DOM-guard half (removeChild/insertBefore) cannot help here: nothing is
+ * being called on a Node, a property is being read off null. Hence a separate
+ * mechanism, and a separate test.
+ *
+ * Evaluated against the REAL script extracted from layout.tsx.
+ */
+
+const LAYOUT = join(process.cwd(), 'src/app/layout.tsx');
+
+function extractGuardScript(): string {
+  const src = readFileSync(LAYOUT, 'utf8');
+  const m = src.match(/const TRANSLATION_DOM_GUARD_SCRIPT = `([^`]*)`/);
+  if (!m) throw new Error('TRANSLATION_DOM_GUARD_SCRIPT not found in src/app/layout.tsx');
+  return m[1];
+}
+
+/** Run the guard in a sandbox whose global doubles as `window`, as in a browser. */
+function runGuard(): Record<string, unknown> {
+  const sandbox: Record<string, unknown> = { Object, document: { getElementById: () => null } };
+  vm.createContext(sandbox);
+  sandbox.window = sandbox;
+  // Node.prototype patching is exercised by translation-dom-guard.test.ts; here
+  // the first IIFE simply returns early because there is no Node in scope.
+  vm.runInContext(extractGuardScript(), sandbox);
+  return sandbox;
+}
+
+describe('streaming-SSR guard ($RS and friends)', () => {
+  it('swallows the null-placeholder throw instead of letting it blank the page', () => {
+    const w = runGuard();
+    // Assign exactly what React's inline bootstrap assigns.
+    (w as { $RS: unknown }).$RS = function (a: string) {
+      const el = (w.document as { getElementById: (id: string) => null }).getElementById(a);
+      // Reproduces the production failure: getElementById returned null.
+      return (el as unknown as { parentNode: unknown }).parentNode;
+    };
+
+    const call = () => (w as { $RS: (a: string, b: string) => void }).$RS('S:0', 'P:0');
+    expect(call).not.toThrow();
+    expect(w.__slStreamGuardHits).toBe(1);
+  });
+
+  it('does not disturb a call that succeeds', () => {
+    const w = runGuard();
+    let ran = 0;
+    (w as { $RC: unknown }).$RC = function (a: number, b: number) { ran++; return a + b; };
+    const out = (w as { $RC: (a: number, b: number) => number }).$RC(2, 3);
+    expect(out).toBe(5);
+    expect(ran).toBe(1);
+    expect(w.__slStreamGuardHits).toBe(0);
+  });
+
+  it('wraps every helper React may define', () => {
+    const w = runGuard();
+    for (const k of ['$RS', '$RC', '$RM', '$RX', '$RB', '$RT']) {
+      (w as Record<string, unknown>)[k] = () => { throw new Error('boom'); };
+      expect(() => (w as Record<string, () => void>)[k]()).not.toThrow();
+    }
+    expect(w.__slStreamGuardHits).toBe(6);
+  });
+
+  it('leaves non-function assignments alone', () => {
+    const w = runGuard();
+    (w as Record<string, unknown>).$RM = 'not-a-function';
+    expect((w as Record<string, unknown>).$RM).toBe('not-a-function');
+  });
+});


### PR DESCRIPTION
Fixes the crash in #3409. **Supersedes #3418**, which I opened before finding the actual cause and which does not address it.

## Root cause — from production stacks, not inference

I said in #3418 that I could not pinpoint the throwing frame because the stacks looked empty. They were not empty; I had been reading the wrong part of the payload. The raw frames carry this:

```
function: "$RS"
filename: "https://sourcelibrary.org/book/<slug>/page/<id>"   ← the HTML DOCUMENT, not a bundle
lineno:   20
```

**All 120 sampled `Cannot read properties of null (reading 'parentNode')` exceptions contain `$RS`.**

`$RS` is React's *replace suspense segment* helper, injected inline as each streamed boundary flushes:

```js
$RS = function (a, b) {
  a = document.getElementById(a);
  b = document.getElementById(b);
  for (a.parentNode.removeChild(a); a.firstChild; ) b.parentNode.insertBefore(a.firstChild, b);
  ...
}
```

Chrome/Edge's translator rewrites the DOM **while the response is still streaming**. The placeholder React is about to look up is gone, `getElementById` returns `null`, and `a.parentNode` throws — blanking the page at the nearest error boundary.

## It explains the distribution exactly

`collections/[id]/page.tsx` renders several `Suspense` boundaries, so a translated visitor gets a `$RS` call **per boundary, per pageview**:

| surface | crashes | pageviews | rate |
|---|---|---|---|
| collection | 2,575 | 2,693 | **~0.96 / pageview** |
| search | 147 | 447 | 0.33 |
| reader-page | 333 | 502,053 | 0.0007 |

And by locale — es-ES **11.4%** of that audience affected vs en-US **0.7%**, the auto-translate signature.

## Why the existing guard could never catch it

`TRANSLATION_DOM_GUARD_SCRIPT` patches `Node.prototype.removeChild` / `insertBefore`, so it only fires when something is called **on** a Node. Here a property is **read off `null`** before any Node method is reached. Different failure, needs a different mechanism.

This adds one: an accessor on `window` that wraps `$RS`/`$RC`/`$RM`/`$RX`/`$RB`/`$RT` in try/catch **as React assigns them** (the head script runs before React's inline bootstrap, so the setter intercepts the assignment).

**Trade-off, stated plainly:** swallowing a failed segment placement can leave one Suspense boundary unresolved — some content may not appear for that visitor. The status quo is that the entire page blanks. That is a clear improvement, not a free win.

## Why #3418 should be closed

#3418 added a `TranslationSafe` remount to `CollectionAllBooks` and `/search`. That addresses client-side *reconciliation*, which is the second-order staleness problem from #3314 — real, but **not this crash**. The throw happens in React's inline bootstrap during streaming, before any client reconciliation. Shipping it would have been churn on two high-traffic files with no evidence it helps. I would rather close it than leave a plausible-looking non-fix in the tree; the component is easy to resurrect if staleness is ever measured on those surfaces.

## Guard

`tests/unit/translation-stream-guard.test.ts` evaluates the **real** script extracted from `layout.tsx` in a `vm`, assigns exactly what React assigns, and asserts:

- the null-placeholder call no longer throws, and increments `__slStreamGuardHits`;
- a call that succeeds is completely untouched (return value and side effects preserved);
- all six helpers are wrapped;
- non-function assignments pass through.

**Negative control run — removing the guard fails 3 of 4.** The existing `translation-dom-guard.test.ts` still passes.

## Follow-up filed separately

PostHog could not symbolicate **1,312 of 1,482** of these frames: `resolve_failure: HTTP 403 while fetching` — its symbolicator is being blocked by our own bot gate. That is why the stacks read as empty and why this sat unread. Worth allowing, since it turns future crashes into named functions instead of guesswork.

## Verifying after deploy

Watch the **locale split**, not the raw count (raw counts are contaminated by the headless fleet). The es-ES rate should fall toward the en-US rate. `window.__slStreamGuardHits` also becomes a direct measure — non-zero on a translated collection page means the guard is catching real calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
