### PR TITLE
feat(metrics): reading depth from reading_history — members do read

### DIFF
--- a/scripts/analytics/engagement-metrics.mjs
+++ b/scripts/analytics/engagement-metrics.mjs
@@ -17,7 +17,7 @@
 //   7. Pipeline cost            (gemini_usage_daily)
 
 import { withMongo } from '../lib/mongo.mjs';
-import { computeReadingDepth } from '../lib/reading-depth.mjs';
+import { computeReadingDepth, computeMemberReadingDepth } from '../lib/reading-depth.mjs';
 
 const DAYS = (() => { const i = process.argv.indexOf('--days'); return i > -1 ? Number(process.argv[i + 1]) : 30; })();
 const now = Date.now();
@@ -114,6 +114,27 @@ await withMongo(async (db) => {
       console.log(`  not of the data. The /24 anonymization means a large NAT can be excluded`);
       console.log(`  as a fleet — check the addresses above before trusting either figure.`);
     }
+  });
+
+  // ---- 2b. READING DEPTH, SIGNED-IN MEMBERS ----
+  await section(`2b. Reading depth — signed-in members (reading_history, last ${DAYS}d)`, async () => {
+    // The uncontaminated twin of section 2: written only behind a session, so no
+    // crawler can be in it, and keyed on user_id so a shared NAT stays several
+    // readers. Narrower population, much higher confidence.
+    const m = await computeMemberReadingDepth(db, SINCE);
+    if (!m) { console.log('no reading_history rows in window'); return; }
+    console.log(`reading sessions              ${m.sessions}   (one user+book sitting, 30min gap)`);
+    console.log(`distinct members / books      ${m.users} / ${m.books}`);
+    console.log(`pages read / session  median=${m.median}  p75=${m.p75}  p90=${m.p90}  p99=${m.p99}  max=${m.max}`);
+    console.log(`  1 page only                 ${m.oneOnly}  (${pct(m.oneOnly, m.sessions)})`);
+    console.log(`  2-4 pages                   ${m.shallow}  (${pct(m.shallow, m.sessions)})`);
+    console.log(`  5-9 pages                   ${m.middling}  (${pct(m.middling, m.sessions)})`);
+    console.log(`  10+ pages (deep read)       ${m.deep}  (${pct(m.deep, m.sessions)})`);
+    console.log(`  50+ pages                   ${m.veryDeep}  (${pct(m.veryDeep, m.sessions)})`);
+    console.log(`members with >1 session       ${m.returningUsers}  (${pct(m.returningUsers, m.users)})`);
+    console.log(`distinct pages read, total    ${m.totalPages}`);
+    console.log(`CEILING, not average: members are self-selected and more engaged than a`);
+    console.log(`passer-by. This answers "do our members read?", not "do visitors read?".`);
   });
 
   // ---- 3. MISSION ACTIONS ----

--- a/scripts/analytics/snapshot-metrics.mjs
+++ b/scripts/analytics/snapshot-metrics.mjs
@@ -17,7 +17,7 @@
 // Cron (Hetzner, daily): see scripts/workers/crontab.production.
 
 import { withMongo } from '../lib/mongo.mjs';
-import { computeReadingDepth } from '../lib/reading-depth.mjs';
+import { computeReadingDepth, computeMemberReadingDepth } from '../lib/reading-depth.mjs';
 
 const DAYS = (() => { const i = process.argv.indexOf('--days'); return i > -1 ? Number(process.argv[i + 1]) : 30; })();
 const norm = (e) => (e || '').trim().toLowerCase();
@@ -148,9 +148,15 @@ await withMongo(async (db) => {
   // number that gets emailed.
   const ev = db.collection('analytics_events');
   let reading = null;
+  let readingMembers = null;
   try {
     reading = await computeReadingDepth(db, d7);
   } catch { /* events collection may be sparse */ }
+  // Signed-in twin over the full window — no crawler can be in it, so this is
+  // reportable today rather than after the anonymous instrument's window fills.
+  try {
+    readingMembers = await computeMemberReadingDepth(db, SINCE);
+  } catch { /* reading_history may be absent */ }
 
   // ─── MISSION ACTIONS ──────────────────────────────────────────────────────
   let missionActions = {};
@@ -311,6 +317,7 @@ await withMongo(async (db) => {
       returningVisitors: multiDay, returningTotal: totalFp,
     },
     reading,
+    readingMembers,
     missionActions,
     traffic: { humanPvs, botPvs, dailyPageviews, topBooks, topCollections, topReferrers, topCountries },
     search,

--- a/scripts/lib/reading-depth.mjs
+++ b/scripts/lib/reading-depth.mjs
@@ -31,6 +31,24 @@
  * (`ip` is anonymized to a /24, so a large NAT or CGNAT range is many readers
  * sharing one key). Seeing both is what tells you whether the headline depends
  * on the heuristic.
+ *
+ * ── The second instrument: computeMemberReadingDepth ──────────────────────────
+ *
+ * `reading_history` answers the same question for signed-in readers and is
+ * **structurally immune to all of the above**: it is written only behind a
+ * session, so no crawler can appear in it, and it keys on `user_id` rather than
+ * an anonymized IP, so two readers behind one NAT stay two readers. It was
+ * sitting there, uncontaminated, the whole time the anonymous metric was being
+ * quoted — nobody thought to check it because the broken instrument answered
+ * confidently. When one instrument is compromised, look for a second one that
+ * measures the same thing by different means before declaring the question
+ * unanswerable.
+ *
+ * What it cannot do is speak for the whole audience: signed-in members are a
+ * self-selected minority (946 of 3,851 accounts active in a recent 30-day
+ * window) and are more engaged than a passer-by, so it is a CEILING, not an
+ * average. Both numbers are reported side by side, each labelled with its
+ * population, and neither is presented as "reading depth" unqualified.
  */
 
 // Distinct page_read events from one anonymized /24 over the window, above
@@ -122,5 +140,62 @@ export async function computeReadingDepth(db, since, opts = {}) {
     excludedTopIps: heavy.slice(0, 5).map((h) => ({ ip: h._id, events: h.n })),
     threshold,
     unfiltered,
+  };
+}
+
+/**
+ * Reading depth for SIGNED-IN members, from `reading_history`.
+ *
+ * One row is one reading session (the write path collapses activity on the same
+ * user+book within 30 minutes into a single row), and `pages_read` is an
+ * `$addToSet` of distinct pages — so its length is genuinely "how far into this
+ * book did this person get in this sitting", not a page-turn counter.
+ * `pages_viewed` counts every turn including re-reads, which is why the two are
+ * reported separately rather than averaged into one misleading figure.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {Date} since
+ * @returns {Promise<object|null>} null when the collection is empty/absent
+ */
+export async function computeMemberReadingDepth(db, since) {
+  const rows = await db.collection('reading_history').aggregate([
+    { $match: { updated_at: { $gte: since } } },
+    {
+      $project: {
+        user_id: 1,
+        book_id: 1,
+        viewed: { $ifNull: ['$pages_viewed', 0] },
+        distinct: { $size: { $ifNull: ['$pages_read', []] } },
+      },
+    },
+  ], { allowDiskUse: true }).toArray();
+
+  if (!rows.length) return null;
+
+  const depths = rows.map((r) => r.distinct).sort((a, b) => a - b);
+  const n = depths.length;
+  const q = (p) => depths[Math.floor(n * p)] || 0;
+  const count = (fn) => rows.filter(fn).length;
+
+  const sessionsByUser = new Map();
+  for (const r of rows) sessionsByUser.set(r.user_id, (sessionsByUser.get(r.user_id) || 0) + 1);
+  const returning = [...sessionsByUser.values()].filter((v) => v > 1).length;
+
+  return {
+    sessions: n,
+    users: sessionsByUser.size,
+    books: new Set(rows.map((r) => r.book_id)).size,
+    median: q(0.5),
+    p75: q(0.75),
+    p90: q(0.9),
+    p99: q(0.99),
+    max: depths[n - 1] || 0,
+    oneOnly: count((r) => r.distinct === 1),
+    shallow: count((r) => r.distinct >= 2 && r.distinct <= 4),
+    middling: count((r) => r.distinct >= 5 && r.distinct <= 9),
+    deep: count((r) => r.distinct >= 10),
+    veryDeep: count((r) => r.distinct >= 50),
+    returningUsers: returning,
+    totalPages: rows.reduce((s, r) => s + r.distinct, 0),
   };
 }

--- a/src/app/platform/(protected)/admin/metrics/page.tsx
+++ b/src/app/platform/(protected)/admin/metrics/page.tsx
@@ -42,6 +42,13 @@ interface MetricsSnapshot {
     // traffic_class and so can't be attributed to humans or crawlers.
     contaminated?: boolean; unclassified?: number; total?: number;
   } | null;
+  // From reading_history: signed-in members only, therefore crawler-free.
+  readingMembers?: {
+    sessions?: number; users?: number; books?: number;
+    median?: number; p75?: number; p90?: number; p99?: number; max?: number;
+    oneOnly?: number; shallow?: number; middling?: number; deep?: number; veryDeep?: number;
+    returningUsers?: number; totalPages?: number;
+  } | null;
   missionActions?: Record<string, number>;
   traffic?: {
     humanPvs?: number; botPvs?: number;
@@ -279,9 +286,37 @@ export default async function MetricsPage() {
         </>
       ) : null}
 
+      {s.readingMembers ? (
+        <>
+          <SectionHead
+            title="Reading depth — signed-in members"
+            sub={`${num(s.readingMembers.sessions)} sessions from ${num(s.readingMembers.users)} members across ${num(s.readingMembers.books)} books, last ${win} days. A session is one member on one book, activity within 30 minutes collapsed.`}
+          />
+          <div style={C.grid}>
+            <Stat value={String(s.readingMembers.median ?? 0)} label="Median pages / session"
+              sub={`p90 ${s.readingMembers.p90 ?? 0} · max ${num(s.readingMembers.max)}`}
+              def="Distinct pages a member reads in one sitting. Counted from reading_history, which is written only behind a session — no crawler can appear in it." />
+            <Stat value={pct(s.readingMembers.deep, s.readingMembers.sessions)} label="Deep read (10+ pages)"
+              sub={`${num(s.readingMembers.deep)} sessions · ${num(s.readingMembers.veryDeep)} read 50+`}
+              def="The engaged tail. This is the number the anonymous page_read metric got wrong by an order of magnitude before #3405." />
+            <Stat value={pct(s.readingMembers.oneOnly, s.readingMembers.sessions)} label="One page only"
+              def="Arrived from a search result or citation and left. Expected to be substantial for a reference library." />
+            <Stat value={pct(s.readingMembers.returningUsers, s.readingMembers.users)} label="Members who came back"
+              sub={`${num(s.readingMembers.returningUsers)} of ${num(s.readingMembers.users)} had >1 session`}
+              def="More than one reading session in the window — the closest thing we have to a retention signal for reading itself." />
+          </div>
+          <div style={{ ...C.card, marginBottom: 12, marginTop: 12, lineHeight: 1.5 }}>
+            <strong>A ceiling, not an average.</strong> Members are self-selected and read more than
+            a passer-by, so this answers &ldquo;do our members read?&rdquo; — not &ldquo;do visitors
+            read?&rdquo; The anonymous instrument below answers the second question, and only for
+            windows that sit entirely after the #3405 fix.
+          </div>
+        </>
+      ) : null}
+
       {s.reading?.contaminated ? (
         <>
-          <SectionHead title="Reading depth" sub="Not measurable for this window — see #3405." />
+          <SectionHead title="Reading depth — anonymous visitors" sub="Not measurable for this window — see #3405." />
           <div style={{ ...C.card, marginBottom: 12, lineHeight: 1.5 }}>
             {num(s.reading.unclassified)} of {num(s.reading.total)} page_read events in the last 7
             days were written before bot classification existed. They record no user-agent, so they
@@ -293,7 +328,7 @@ export default async function MetricsPage() {
         </>
       ) : s.reading ? (
         <>
-          <SectionHead title="Reading depth" sub="Human-classified page_read events, last 7 days. Median 1 page is normal for a reference library." />
+          <SectionHead title="Reading depth — anonymous visitors" sub="Human-classified page_read events, last 7 days. Keyed on a /24-truncated IP, so readers behind one NAT merge into one; treat it as coarser than the member figures above." />
           <div style={C.grid}>
             <Stat value={num(s.reading.opens)} label="Book opens" def="book_read events in the last 7 days." />
             <Stat value={String(s.reading.median ?? 0)} label="Median pages / book" sub={`p90 ${s.reading.p90 ?? 0}`}

--- a/tests/integration/reading-depth.test.ts
+++ b/tests/integration/reading-depth.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getTestDb, cleanDb } from '../setup';
 // @ts-expect-error — plain .mjs analytics lib, no types
-import { computeReadingDepth } from '../../scripts/lib/reading-depth.mjs';
+import { computeReadingDepth, computeMemberReadingDepth } from '../../scripts/lib/reading-depth.mjs';
 
 /**
  * Reading depth has been wrong twice in two different ways (#3405 and the
@@ -108,5 +108,65 @@ describe('computeReadingDepth', () => {
     // The caller always has both numbers to compare, so "no exclusion applied"
     // is visible rather than implied by a missing field.
     expect(d.unfiltered.pairs).toBe(d.pairs);
+  });
+});
+
+describe('computeMemberReadingDepth', () => {
+  beforeEach(cleanDb);
+
+  const session = (user: string, book: string, pages: number, viewed?: number) => ({
+    user_id: user,
+    book_id: book,
+    pages_viewed: viewed ?? pages,
+    pages_read: Array.from({ length: pages }, (_, i) => ({ page_id: `${book}-p${i}`, page_number: i + 1 })),
+    updated_at: new Date(Date.now() - HOUR),
+    started_at: new Date(Date.now() - HOUR),
+  });
+
+  it('returns null rather than a zeroed shape when there is nothing to report', async () => {
+    expect(await computeMemberReadingDepth(getTestDb(), since())).toBeNull();
+  });
+
+  it('measures distinct pages, not page turns', async () => {
+    // 40 turns across 4 distinct pages — someone flipping back and forth.
+    // Depth must be 4; counting pages_viewed would claim a deep read.
+    await getTestDb().collection('reading_history').insertOne(session('u1', 'b1', 4, 40) as never);
+
+    const m = await computeMemberReadingDepth(getTestDb(), since());
+
+    expect(m.median).toBe(4);
+    expect(m.deep).toBe(0);
+  });
+
+  it('counts sessions, members, books and returning members separately', async () => {
+    await getTestDb().collection('reading_history').insertMany([
+      session('u1', 'b1', 30),
+      session('u1', 'b2', 12),   // same member, second book -> returning
+      session('u2', 'b1', 1),    // same book, different member
+      session('u3', 'b3', 60),
+    ] as never[]);
+
+    const m = await computeMemberReadingDepth(getTestDb(), since());
+
+    expect(m.sessions).toBe(4);
+    expect(m.users).toBe(3);
+    expect(m.books).toBe(3);
+    expect(m.returningUsers).toBe(1);
+    expect(m.deep).toBe(3);       // 30, 12, 60
+    expect(m.veryDeep).toBe(1);   // 60
+    expect(m.oneOnly).toBe(1);
+    expect(m.totalPages).toBe(103);
+  });
+
+  it('ignores sessions outside the window', async () => {
+    await getTestDb().collection('reading_history').insertMany([
+      session('u1', 'b1', 20),
+      { ...session('u2', 'b2', 99), updated_at: new Date(Date.now() - 90 * 24 * HOUR) },
+    ] as never[]);
+
+    const m = await computeMemberReadingDepth(getTestDb(), since());
+
+    expect(m.sessions).toBe(1);
+    expect(m.max).toBe(20);
   });
 });


### PR DESCRIPTION
Answers the question #3405 was opened about, without waiting for the anonymous window to fill.

## There was a second instrument the whole time

`reading_history` measures the same thing by different means and is structurally immune to every problem #3405 was about:

- **Written only behind a session** — no crawler can appear in it.
- **Keyed on `user_id`**, not a /24-truncated IP — two readers behind one NAT stay two readers.
- **`pages_read` is an `$addToSet`** — its length is distinct pages reached, not page turns.

It was sitting there uncontaminated the entire time the broken number was being quoted. Nobody checked it because the broken instrument answered confidently. That's the transferable lesson, and it's in the module header: when one instrument is compromised, look for a second that measures the same thing by different means before declaring the question unanswerable.

## What it says (30 days, production)

4,194 sessions · 944 members · 1,759 books

| pages read in a session | sessions | share |
|---|---:|---:|
| 1 only | 1,825 | 43.5% |
| 2–4 | 646 | 15.4% |
| 5–9 | 617 | 14.7% |
| **10+** | **1,106** | **26.4%** |
| 50+ | 252 | 6.0% |

Median 3, p75 11, p90 31, p99 262, max 1,062. **62% of members had more than one reading session.**

The metric this replaces claimed *81% read a single page, 2% read ten or more*. The engaged tail is **thirteen times** what we believed. People read the books.

## Reported as a ceiling, never as "reading depth" unqualified

Members are self-selected and read more than a passer-by, so this answers "do our members read?" and not "do visitors read?". The card says so in those words. Both figures now sit side by side on `/platform/admin/metrics`, each labelled with its population, and the anonymous card is retitled "Reading depth — anonymous visitors" with a note that its /24 keying merges readers behind one NAT. Neither can be quoted as the whole audience by accident.

## Testing

4 new integration tests, including the one that matters: a session with **40 page turns across 4 distinct pages** must report depth 4 and not count as a deep read. Also that `null` is returned rather than a zeroed shape when there's nothing to report — a zeroed shape renders as "0% deep reads", which is a lie that looks like data.

8 tests in the file, 909 unit + 38 integration green, `tsc` clean.

## Deploy note

Frontend change — needs `npm run deploy:prod`. The snapshot has already been refreshed, so the section renders as soon as the deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
