### PR TITLE
fix(tenant): footer served ten 404 links on partner subdomains

### DIFF
--- a/src/components/layout/GlobalFooter.tsx
+++ b/src/components/layout/GlobalFooter.tsx
@@ -8,52 +8,9 @@ import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 import FeedbackCallout from '@/components/feedback/FeedbackCallout';
 import ReaderPresence from '@/components/presence/ReaderPresence';
 import { clearConsent } from '@/lib/consent';
-import { useLocale, FOOTER_STRINGS, type FooterStrings } from '@/lib/i18n';
-
-// Labels are resolved per-locale from FOOTER_STRINGS via `key`; hrefs are
-// constant and point at the English pages (deep pages have no `/es` route).
-type FooterLinkKey = Exclude<keyof FooterStrings, 'colLibrary' | 'colAbout' | 'colParticipate'>;
-
-const NAV_COLUMNS: ReadonlyArray<{
-  titleKey: keyof FooterStrings;
-  links: ReadonlyArray<{ key: FooterLinkKey; href: string }>;
-}> = [
-  {
-    titleKey: 'colLibrary',
-    links: [
-      { key: 'browseBooks', href: '/' },
-      { key: 'browseAZ', href: '/browse' },
-      { key: 'gallery', href: '/gallery' },
-      { key: 'collections', href: '/collections' },
-      { key: 'search', href: '/search' },
-    ],
-  },
-  {
-    titleKey: 'colAbout',
-    links: [
-      { key: 'about', href: '/about' },
-      { key: 'vision', href: '/vision' },
-      { key: 'census', href: '/census' },
-      { key: 'progress', href: '/about/progress' },
-      { key: 'research', href: '/research' },
-      { key: 'researchNotes', href: '/blog' },
-      { key: 'privacy', href: '/privacy' },
-      { key: 'cookieSettings', href: '#cookie-settings' },
-      { key: 'terms', href: '/terms' },
-      { key: 'copyright', href: '/dmca' },
-    ],
-  },
-  {
-    titleKey: 'colParticipate',
-    links: [
-      { key: 'libraries', href: '/libraries' },
-      { key: 'contribute', href: '/contribute' },
-      { key: 'support', href: '/support' },
-      { key: 'sponsorship', href: '/sponsors' },
-      { key: 'developers', href: '/developers' },
-    ],
-  },
-];
+import { useIsEmbedded } from '@/hooks/useEmbedContext';
+import { visibleFooterNavColumns } from '@/lib/footer-nav';
+import { useLocale, FOOTER_STRINGS } from '@/lib/i18n';
 
 type Partner = {
   name: string;
@@ -76,6 +33,19 @@ export default function GlobalFooter() {
   const pathname = usePathname();
   const t = FOOTER_STRINGS[useLocale()];
   const [hasFavorites, setHasFavorites] = useState(false);
+  // Global-only surfaces 404 on partner subdomains (the list and its rationale
+  // live in src/lib/tenant-global-paths.ts — #3364, #3370). SiteHeader has
+  // filtered on that list since #3364; the footer never did, so on
+  // bph.sourcelibrary.org it shipped ten links that all returned 404 —
+  // /about, /vision, /census, /research, /blog, /contribute, /support,
+  // /sponsors, /libraries and /about/progress. That is the failure the
+  // one-list rule exists to prevent: blocking a route the nav links to just
+  // moves the leak into a dead link.
+  //
+  // Same shared `useEmbedContext` signal the header uses, not a second
+  // hostname check (#3367). Resolved after mount, so the static HTML the
+  // global site serves is unchanged and only a tenant visitor sees links drop.
+  const navColumns = visibleFooterNavColumns(useIsEmbedded());
 
   useEffect(() => {
     try {
@@ -116,7 +86,7 @@ export default function GlobalFooter() {
         {/* Zone 2: Navigation Columns. Mobile: 2 columns — Library + Participate
             stacked on the left, About on the right. Desktop: the usual 3-up. */}
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-8 sm:gap-12 py-10 border-b border-white/[0.08]">
-          {NAV_COLUMNS.map((col) => (
+          {navColumns.map((col) => (
             <div
               key={col.titleKey}
               className={

--- a/src/lib/footer-nav.ts
+++ b/src/lib/footer-nav.ts
@@ -1,0 +1,76 @@
+import { isGlobalOnlyNavHref } from '@/lib/tenant-global-paths';
+import { type FooterStrings } from '@/lib/i18n';
+
+/**
+ * The global footer's navigation table, and the tenant filter applied to it.
+ *
+ * Lives outside the component so the filter is directly testable — the repo has
+ * no DOM test harness, and a test that only greps `GlobalFooter.tsx` for a
+ * string would catch deletion but never wrongness (see CLAUDE.md, "A test that
+ * greps source is not a guard").
+ *
+ * Labels are resolved per-locale from FOOTER_STRINGS via `key`; hrefs are
+ * constant and point at the English pages (deep pages have no `/es` route).
+ */
+
+export type FooterLinkKey = Exclude<keyof FooterStrings, 'colLibrary' | 'colAbout' | 'colParticipate'>;
+
+export type FooterNavColumn = {
+  titleKey: keyof FooterStrings;
+  links: ReadonlyArray<{ key: FooterLinkKey; href: string }>;
+};
+
+export const FOOTER_NAV_COLUMNS: ReadonlyArray<FooterNavColumn> = [
+  {
+    titleKey: 'colLibrary',
+    links: [
+      { key: 'browseBooks', href: '/' },
+      { key: 'browseAZ', href: '/browse' },
+      { key: 'gallery', href: '/gallery' },
+      { key: 'collections', href: '/collections' },
+      { key: 'search', href: '/search' },
+    ],
+  },
+  {
+    titleKey: 'colAbout',
+    links: [
+      { key: 'about', href: '/about' },
+      { key: 'vision', href: '/vision' },
+      { key: 'census', href: '/census' },
+      { key: 'progress', href: '/about/progress' },
+      { key: 'research', href: '/research' },
+      { key: 'researchNotes', href: '/blog' },
+      { key: 'privacy', href: '/privacy' },
+      { key: 'cookieSettings', href: '#cookie-settings' },
+      { key: 'terms', href: '/terms' },
+      { key: 'copyright', href: '/dmca' },
+    ],
+  },
+  {
+    titleKey: 'colParticipate',
+    links: [
+      { key: 'libraries', href: '/libraries' },
+      { key: 'contribute', href: '/contribute' },
+      { key: 'support', href: '/support' },
+      { key: 'sponsorship', href: '/sponsors' },
+      { key: 'developers', href: '/developers' },
+    ],
+  },
+];
+
+/**
+ * Drop links the proxy 404s on a partner subdomain, and any column that empties
+ * as a result. On the global site (`isTenantHost === false`) the table is
+ * returned unchanged.
+ *
+ * The blocked list is `GLOBAL_ONLY_TENANT_PAGE_PATHS` — one list, so the proxy
+ * block and the site nav can never disagree (#3364, #3370). SiteHeader has
+ * filtered on it since #3364; the footer did not, so bph.sourcelibrary.org
+ * served ten links that every one returned 404.
+ */
+export function visibleFooterNavColumns(isTenantHost: boolean): FooterNavColumn[] {
+  if (!isTenantHost) return [...FOOTER_NAV_COLUMNS];
+  return FOOTER_NAV_COLUMNS
+    .map(col => ({ ...col, links: col.links.filter(link => !isGlobalOnlyNavHref(link.href)) }))
+    .filter(col => col.links.length > 0);
+}

--- a/tests/unit/footer-tenant-nav.test.ts
+++ b/tests/unit/footer-tenant-nav.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { FOOTER_NAV_COLUMNS, visibleFooterNavColumns } from '@/lib/footer-nav';
+import { GLOBAL_ONLY_TENANT_PAGE_PATHS, isGlobalOnlyNavHref } from '@/lib/tenant-global-paths';
+
+/**
+ * The global footer must not link to a path the proxy 404s on a tenant host.
+ *
+ * CLAUDE.md states the rule as one list, "so the proxy block and the site nav
+ * can never disagree — the nav must not link to a path the proxy 404s."
+ * SiteHeader has honored it since #3364. GlobalFooter never did: measured on
+ * bph.sourcelibrary.org, the footer served /about, /about/progress, /vision,
+ * /census, /research, /blog, /contribute, /support, /sponsors, /libraries and
+ * /explore, and every one of them returned 404.
+ *
+ * These assertions call the filter rather than grepping the component, so they
+ * fail on a wrong filter, not only on a deleted one.
+ */
+
+const hrefsOf = (cols: ReadonlyArray<{ links: ReadonlyArray<{ href: string }> }>) =>
+  cols.flatMap(c => c.links.map(l => l.href));
+
+describe('GlobalFooter tenant nav', () => {
+  it('serves no global-only link on a tenant host', () => {
+    const offenders = hrefsOf(visibleFooterNavColumns(true)).filter(isGlobalOnlyNavHref);
+    expect(offenders, `footer links 404 on a partner subdomain: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('is unchanged on the global site', () => {
+    expect(hrefsOf(visibleFooterNavColumns(false))).toEqual(hrefsOf(FOOTER_NAV_COLUMNS));
+  });
+
+  it('still offers navigation on a tenant host', () => {
+    // Filtering must not empty the footer — the reading room keeps its own
+    // library links plus the legal/rights notices that stay reachable there.
+    const kept = hrefsOf(visibleFooterNavColumns(true));
+    expect(kept).toContain('/collections');
+    expect(kept).toContain('/gallery');
+    expect(kept).toContain('/terms');
+    expect(kept).toContain('/privacy');
+    expect(visibleFooterNavColumns(true).length).toBeGreaterThan(0);
+  });
+
+  it('drops no column to an empty heading', () => {
+    for (const col of visibleFooterNavColumns(true)) {
+      expect(col.links.length, `${col.titleKey} rendered with no links`).toBeGreaterThan(0);
+    }
+  });
+
+  it('negative control: the unfiltered table really does contain blocked paths', () => {
+    // If this ever passes trivially, the test above proves nothing — the fix
+    // would be verified against a table that had no offenders to begin with.
+    const blocked = hrefsOf(FOOTER_NAV_COLUMNS).filter(isGlobalOnlyNavHref);
+    expect(blocked.length).toBeGreaterThan(0);
+    expect(blocked).toContain('/about');
+  });
+
+  it('tracks the shared list, not a private copy', () => {
+    // A new entry in GLOBAL_ONLY_TENANT_PAGE_PATHS must take effect in the
+    // footer automatically; nothing here may hardcode its own block list.
+    for (const p of GLOBAL_ONLY_TENANT_PAGE_PATHS) {
+      expect(hrefsOf(visibleFooterNavColumns(true))).not.toContain(p);
+    }
+  });
+});


### PR DESCRIPTION
## The bug

On `bph.sourcelibrary.org` the global footer links to ten routes the proxy 404s. Verified live before the fix:

| link | tenant host |
|---|---|
| `/about`, `/about/progress`, `/vision`, `/census`, `/research`, `/blog` | 404 |
| `/contribute`, `/support`, `/sponsors`, `/libraries` | 404 |

EFM uses that subdomain as its public face. A partner's own footer is one of the most-clicked things on the page, and every institutional link in it was dead.

## Why it happened

`GLOBAL_ONLY_TENANT_PAGE_PATHS` exists as one list precisely so this can't happen — CLAUDE.md: *"the nav must not link to a path the proxy 404s."* `SiteHeader` was wired to it in #3364. `GlobalFooter` was not, and nothing noticed, because the tenant-leak audit checks where links **resolve** (all of these resolve on-host, correctly) rather than whether the destination exists.

## The fix

- `NAV_COLUMNS` + the filter move to `src/lib/footer-nav.ts` (`visibleFooterNavColumns`). Same shared `useEmbedContext` signal the header uses, not a second hostname check (#3367).
- Columns that empty out are dropped so no heading renders with zero links. None do today — the reading room keeps Browse A–Z / Gallery / Collections / Search, the legal notices (`/terms`, `/privacy`, `/dmca` stay reachable on tenant hosts by design), and `/developers`.
- **The global site is unchanged.** The filter is a pass-through off a tenant host, and resolves post-mount, so the static HTML is identical.

## Guard

`tests/unit/footer-tenant-nav.test.ts` **calls the filter** rather than grepping the component — the repo has no DOM harness, and per CLAUDE.md a source-shape test for behaviour "is documentation with a green checkmark". It also pins that the footer tracks the shared list rather than a private copy, so a future addition to `GLOBAL_ONLY_TENANT_PAGE_PATHS` takes effect here automatically.

**Negative control run:** reverting `visibleFooterNavColumns` to a pass-through fails 2 of 6 (`serves no global-only link on a tenant host`, `tracks the shared list, not a private copy`). Restored: 6/6.

`npx tsc --noEmit` clean · full suite 945/945.

## Out of scope

- `/explore` was removed from the footer outright in #3316 rather than filtered. Left as-is; the header still reaches `/explore/map` on the global site. Worth revisiting if the hub link is wanted back on the apex.
- **Verification note:** per CLAUDE.md a Vercel preview cannot verify this — a preview host is not a `.sourcelibrary.org` subdomain, so `useIsEmbedded()` is false there and the tenant branch never runs. Confirm on the real subdomain after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)