### PR TITLE
chore(ci): watch production dependencies — dependabot + a weekly audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+version: 2
+
+# Nothing watched our dependencies until 2026-07-29. The only reason 3 criticals
+# in production deps were ever noticed is that CLAUDE.md's /reap-prs section tells
+# a human to run `npm audit --omit=dev` by hand during a PR sweep — and the one PR
+# that did act on it (#2946) sat 25 days and was then closed unmerged by a
+# stale-PR sweep. See #3427.
+#
+# Grouped deliberately. Ungrouped npm updates open ~15 PRs a week here, and this
+# repo's failure mode is a stale PR tail, not a shortage of PRs — a flood would be
+# swept closed the same way #2946 was. One security PR and one routine PR a week
+# is a queue a person can actually read.
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '07:00'
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
+    groups:
+      # Security fixes travel alone so they are never held up by a routine bump
+      # that needs review.
+      security:
+        applies-to: security-updates
+        patterns: ['*']
+      production:
+        applies-to: version-updates
+        dependency-type: production
+        update-types: [minor, patch]
+      development:
+        applies-to: version-updates
+        dependency-type: development
+        update-types: [minor, patch]
+    ignore:
+      # Majors here are not mechanical — they touch image processing, CLIP
+      # embeddings and the auth surface, and each needs its own PR with real
+      # verification (see #3427). Dependabot proposing them weekly would train
+      # us to close them unread, which is how #2946 died.
+      - dependency-name: sharp
+        update-types: [version-update:semver-major]
+      - dependency-name: '@xenova/transformers'
+        update-types: [version-update:semver-major]
+      - dependency-name: next-auth
+        update-types: [version-update:semver-major]
+      # next-auth pins its own @auth/core; bumping it directly desynchronizes the
+      # pair and npm hoists whichever copy resolves first (this is exactly why the
+      # @auth/core critical survived a next-auth bump — see #3431).
+      - dependency-name: '@auth/core'
+      # next-auth's peer range caps nodemailer at ^8; a 9.x PR cannot be merged
+      # until that widens.
+      - dependency-name: nodemailer
+        update-types: [version-update:semver-major]

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,107 @@
+name: Production dependency audit
+
+# Counts vulnerabilities in PRODUCTION dependencies (`--omit=dev`) and keeps a
+# single tracking issue in sync with the result.
+#
+# Why an issue rather than a required PR check: on 2026-07-29 this repo carried 3
+# criticals in production deps — including an Auth.js advisory where "configuration
+# errors can cause existence-based auth checks to fail open" — and nothing was
+# watching. The gap was never that a gate was missing; it was that no artifact
+# survived a session. A red X on an unrelated contributor's PR is the alarm that
+# gets ignored (see doc-staleness.yml for the same reasoning, and CLAUDE.md's
+# "An alarm nobody reads is not an instrument").
+#
+# The job DOES fail on a critical, so the Actions run goes red and the weekly
+# digest has something to point at — but it is not wired as a required check, so
+# it can never block unrelated work.
+#
+# --omit=dev is the whole point. The full audit is dominated by build tooling that
+# never runs in production; including it is how a real critical hides in a count
+# of 200. See #3427.
+
+on:
+  schedule:
+    # 07:00 UTC Mondays — lands before the weekly digest reads the week.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Audit production dependencies
+        id: audit
+        run: |
+          # npm audit exits non-zero whenever anything is found, so capture and
+          # decide ourselves rather than letting `set -e` end the job here.
+          npm audit --omit=dev --json > audit.json || true
+          node -e '
+            const a = require("./audit.json");
+            const m = a.metadata.vulnerabilities;
+            const bad = Object.entries(a.vulnerabilities)
+              .filter(([, v]) => v.severity === "critical" || v.severity === "high")
+              .sort(([, x], [, y]) => (x.severity === "critical" ? -1 : 1) - (y.severity === "critical" ? -1 : 1));
+            const rows = bad.map(([name, v]) => {
+              const titles = v.via.filter(x => typeof x === "object").map(x => x.title);
+              const fix = v.fixAvailable === true ? "yes"
+                : v.fixAvailable ? `${v.fixAvailable.name}@${v.fixAvailable.version}${v.fixAvailable.isSemVerMajor ? " (major)" : ""}`
+                : "none";
+              return `| ${v.severity} | \`${name}\` | ${(titles[0] || "").slice(0, 90)} | ${fix} |`;
+            });
+            const body = [
+              `**${m.critical} critical · ${m.high} high · ${m.moderate} moderate · ${m.low} low** in production dependencies.`,
+              "",
+              rows.length ? "| severity | package | advisory | fix |\n|---|---|---|---|" : "_Nothing at critical or high._",
+              ...rows,
+              "",
+              "Reproduce: `npm audit --omit=dev`. A major-version fix needs its own PR with real verification — do not batch it with patches.",
+            ].join("\n");
+            require("fs").writeFileSync("report.md", body);
+            const fs = require("fs");
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `critical=${m.critical}\n`);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `high=${m.high}\n`);
+          '
+          cat report.md
+
+      - name: Sync the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CRITICAL: ${{ steps.audit.outputs.critical }}
+          HIGH: ${{ steps.audit.outputs.high }}
+        run: |
+          TITLE="Production dependency vulnerabilities"
+          EXISTING=$(gh issue list --search "$TITLE in:title" --state open --json number --jq '.[0].number')
+
+          if [ "$CRITICAL" -eq 0 ] && [ "$HIGH" -eq 0 ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --body "Production dependencies are clean at critical and high as of $(date -u +'%Y-%m-%d'). Closing."
+              gh issue close "$EXISTING"
+            fi
+            exit 0
+          fi
+
+          BODY=$(printf '%s\n\n_Updated by `.github/workflows/dependency-audit.yml` on %s._\n' \
+            "$(cat report.md)" "$(date -u +'%Y-%m-%d')")
+
+          if [ -n "$EXISTING" ]; then
+            # One issue, kept current — a new issue every week is a queue nobody reads.
+            gh issue edit "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label security
+          fi
+
+      - name: Fail on a critical
+        if: steps.audit.outputs.critical != '0'
+        run: |
+          echo "::error::${{ steps.audit.outputs.critical }} critical vulnerabilities in production dependencies"
+          exit 1


### PR DESCRIPTION
Item 4 of #3427. Companion to #3431 (which does the actual bumps).

Nothing watched our dependencies. `npm audit --omit=dev` reported **3 criticals in production deps** on 2026-07-29 — one an Auth.js advisory where *"configuration errors can cause existence-based auth checks to fail open."* The only reason anyone looked is that CLAUDE.md's `/reap-prs` section tells a human to run the command by hand during a PR sweep. The one PR that acted on it (#2946) sat 25 days and was then closed unmerged by a stale-PR sweep.

So the gap was never a missing gate — it was that **no artifact survived a session.** Both pieces here are shaped around that.

## `.github/dependabot.yml`

Grouped, weekly, 5 PRs max.

- **Ungrouped npm updates would open ~15 PRs a week here.** This repo's failure mode is a stale PR tail, not a shortage of PRs; a flood gets swept closed exactly the way #2946 was. One security PR and one routine PR a week is a queue a person can actually read.
- **Security updates are their own group**, so a fix is never held behind a routine bump awaiting review.
- **Majors that need real verification are ignored, not proposed.** `sharp` and `@xenova/transformers` touch image processing and CLIP embeddings; `next-auth` majors touch the auth surface. Proposing them weekly trains us to close them unread.
- **`@auth/core` is ignored outright** — next-auth pins its own copy, and bumping it directly desynchronizes the pair. That desync is precisely why the critical survived a next-auth bump (see #3431).

## `.github/workflows/dependency-audit.yml`

Weekly, keeps **one** tracking issue in sync — edits it in place, closes it when clean — rather than filing a new issue each week (a weekly issue *is* a queue nobody reads).

It fails the job on a critical so the Actions run goes red and the weekly digest has something to point at. It is deliberately **not** wired as a required PR check: failing a contributor's unrelated PR is the alarm people learn to ignore. `doc-staleness.yml` is already built around that exact reasoning, and CLAUDE.md states it directly — *"An alarm nobody reads is not an instrument."*

`--omit=dev` is load-bearing, not a convenience. The full audit is dominated by build tooling that never runs in production; including it is how a real critical hides inside a count of 200.

## Verification

Both YAML files parse (`yaml.safe_load`). The embedded report generator was dry-run against a live `npm audit --omit=dev` payload and renders the current findings correctly, including the major-fix annotation (`@xenova/transformers@1.4.2 (major)`) and packages whose `via` is purely transitive.

Not verified until it runs: the `gh issue` sync path. First scheduled run is the real test — if it misbehaves it files or edits an issue, which is recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)