### PR TITLE
fix(security): scope alias hosts to their own surface; refuse the fleet's network app-side

### DIFF
--- a/src/lib/alias-host-scope.ts
+++ b/src/lib/alias-host-scope.ts
@@ -1,0 +1,77 @@
+/**
+ * Scoping non-canonical hosts to the surface they exist for.
+ *
+ * `ficinosociety.org` is an alias on the same Vercel project. `SOCIETY_DOMAINS`
+ * in the proxy was written as an *additive* allowlist: it rewrites `/` →
+ * `/ficino-society` and lifts `/discussions` and `/members` onto the domain
+ * root. It never restricted anything, so every other route — `/book/*`,
+ * `/artwork/*`, `/collections/*`, the whole library — fell through and was
+ * served from that hostname too.
+ *
+ * That mattered more than duplicate content. `ficinosociety.org` resolves
+ * straight to Vercel (name.com nameservers, no `cf-ray` on any response), so
+ * the entire Cloudflare layer is absent there: the AS132203 blocks, the bot
+ * rules, the first layer of the three-layer crawler gate. Measured 2026-07-29,
+ * minutes after `host` was added to read events: **3,791 of ~6,276 `page_read`
+ * events came from the Tencent fleet via `ficinosociety.org`, and zero came
+ * from the fleet via `sourcelibrary.org`** — the edge block works, they were
+ * simply walking in through the unguarded door.
+ *
+ * So a request to a non-canonical host for something outside that host's own
+ * surface is answered with a 308 to the canonical domain, where every layer
+ * applies. Redirecting rather than blocking keeps shared links working and
+ * consolidates the duplicate content, and a crawler that follows the redirect
+ * arrives somewhere it can be governed.
+ *
+ * The allowlist is deliberately explicit. Anything the society pages genuinely
+ * need — their own routes, framework assets, auth, presence, telemetry — stays;
+ * everything else leaves. If a society feature breaks, the fix is to add its
+ * prefix here, never to widen this to a catch-all.
+ */
+
+export const CANONICAL_HOST = 'sourcelibrary.org';
+
+/** Prefixes that must keep working on an alias host. */
+const ALIAS_ALLOWED_PREFIXES = [
+  // The society surface itself, plus the two paths the proxy lifts to root.
+  '/ficino-society',
+  '/discussions',
+  '/members',
+  // Framework + static assets. Redirecting these would break the page that is
+  // legitimately served here.
+  '/_next',
+  '/static',
+  '/images',
+  '/fonts',
+  // Auth and the society's own APIs. A cross-origin redirect on a credentialed
+  // XHR fails, so these must be answered in place.
+  '/api/auth',
+  '/api/ficino',
+  '/api/presence',
+  '/api/me',
+  // Telemetry: keep it local so this host's traffic keeps being measurable —
+  // losing that visibility is how the bypass stayed invisible in the first place.
+  '/api/analytics',
+  '/api/track',
+  '/api/errors',
+  '/api/feedback',
+];
+
+/** Exact paths allowed on an alias host. */
+const ALIAS_ALLOWED_EXACT = new Set(['/', '/favicon.ico', '/manifest.json', '/opensearch.xml']);
+
+/**
+ * Should this path be redirected off an alias host to the canonical domain?
+ * Callers apply it only when the request is already known to be on an alias.
+ */
+export function shouldRedirectToCanonical(pathname: string): boolean {
+  if (ALIAS_ALLOWED_EXACT.has(pathname)) return false;
+  return !ALIAS_ALLOWED_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(p + '/')
+  );
+}
+
+/** The canonical URL a redirected alias request should land on. */
+export function canonicalUrl(pathname: string, search: string): string {
+  return `https://${CANONICAL_HOST}${pathname}${search || ''}`;
+}

--- a/src/lib/blocked-networks.ts
+++ b/src/lib/blocked-networks.ts
@@ -1,0 +1,45 @@
+/**
+ * Datacenter networks refused at the application layer, on every hostname.
+ *
+ * Cloudflare already blocks AS132203 on the reader and image paths, but a
+ * Cloudflare rule protects a *zone*, and this project answers on hostnames
+ * outside it (`ficinosociety.org`, `sourcelibrary-v2.vercel.app`). The fleet
+ * found that: on 2026-07-29, minutes after `host` was added to read events,
+ * 3,791 of ~6,276 `page_read` events were the fleet arriving via
+ * ficinosociety.org and **zero** were the fleet via sourcelibrary.org.
+ *
+ * This is the same lesson the crawler gate already records — a control applied
+ * at one layer is silently defeated by the others — so the durable version of
+ * the block lives here, where every host and every route passes through it.
+ *
+ * Scope is deliberately narrow: only ranges where sustained automated abuse has
+ * been measured and no plausible reader exists. 43.172.0.0/15 is Tencent Cloud
+ * Singapore (Aceville Pte Ltd, abuse@tencent.com), observed as 37 distinct /24s
+ * rotating 16 user-agents, 354,997 page-reads in 7 days across 8,047 books, and
+ * 57% of all 404s from enumerating guessed URLs. Alibaba (AS45102) was measured
+ * at 179/day and is deliberately NOT listed — it does not clear the bar.
+ *
+ * A person on a VPN does not browse from a Tencent Cloud VM at 1,575 pages a
+ * day. If that ever stops being true, this list is one line to change.
+ */
+
+/** CIDR-ish prefixes, matched on the leading octets of the client IP. */
+const BLOCKED_PREFIXES: string[] = [
+  // 43.172.0.0/15 — covers 43.172.x.x and 43.173.x.x
+  '43.172.',
+  '43.173.',
+];
+
+export const BLOCKED_NETWORK_RESPONSE =
+  'Automated bulk access from this network is not permitted. ' +
+  'Source Library is free to read and the full corpus is available under licence — see https://sourcelibrary.org/licensing.';
+
+/**
+ * Is this client IP inside a refused network?
+ * Takes the raw address; the caller extracts it from the proxy headers.
+ */
+export function isBlockedNetwork(ip: string | null | undefined): boolean {
+  if (!ip) return false;
+  const addr = ip.trim();
+  return BLOCKED_PREFIXES.some((prefix) => addr.startsWith(prefix));
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,8 @@ import authorCanonicalRedirects from '@/lib/author-canonical-redirects.json';
 import { getProviderPrefixRedirect, TENANT_ROOT_PATHS } from '@/lib/provider-prefix';
 import { isGlobalOnlyTenantPath } from '@/lib/tenant-global-paths';
 import { retiredCollectionMessage } from '@/lib/retired-collections';
+import { shouldRedirectToCanonical, canonicalUrl } from '@/lib/alias-host-scope';
+import { isBlockedNetwork, BLOCKED_NETWORK_RESPONSE } from '@/lib/blocked-networks';
 
 // Precomputed variant-slug → canonical-slug map for /author URL dedup (#2250).
 // Bundled because the proxy runs at the edge with no DB access; regenerate with
@@ -578,6 +580,21 @@ function pickOgVariantForToday(now: Date = new Date()): string {
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
+  // Refused datacenter networks, checked before anything else so it applies on
+  // every hostname and every route. Cloudflare blocks the same ASN, but a
+  // Cloudflare rule covers one zone and this project also answers on hosts
+  // outside it — which is exactly where the fleet was reading from.
+  // See src/lib/blocked-networks.ts.
+  if (isBlockedNetwork(getClientIp(request))) {
+    return new NextResponse(BLOCKED_NETWORK_RESPONSE, {
+      status: 403,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Robots-Tag': 'noindex, nofollow',
+      },
+    });
+  }
+
   // Rewrite /og-image.jpg → /og-image-{variant}.jpg based on day of year.
   // Must come before any DB work since this fires on every OG crawl.
   if (pathname === '/og-image.jpg') {
@@ -620,6 +637,24 @@ export async function proxy(request: NextRequest) {
     const url = request.nextUrl.clone();
     url.host = 'sourcelibrary.org';
     return NextResponse.redirect(url, 301);
+  }
+
+  // --- Alias-host scoping ---
+  // ficinosociety.org is an alias on this same project, and SOCIETY_DOMAINS
+  // below only ever ADDED routes to it (/ → /ficino-society, /discussions,
+  // /members). Everything else fell through, so the entire library was served
+  // from a hostname that resolves straight to Vercel with no Cloudflare in
+  // front — which is where the AS132203 fleet was actually reading (3,791 of
+  // ~6,276 page_read events, vs zero for the fleet on sourcelibrary.org).
+  //
+  // Runs BEFORE any library-specific routing, so an alias host is scoped once,
+  // up front, rather than after book/author/provider rules have had a go at it.
+  // See src/lib/alias-host-scope.ts.
+  if (
+    (host.includes('ficinosociety.org') || host.includes('ficino.sourcelibrary.org')) &&
+    shouldRedirectToCanonical(pathname)
+  ) {
+    return NextResponse.redirect(canonicalUrl(pathname, request.nextUrl.search), 308);
   }
 
   // --- Canonical author URL redirect (#2250) ---
@@ -906,6 +941,7 @@ export async function proxy(request: NextRequest) {
         return NextResponse.rewrite(url);
       }
     }
+
   }
 
   // --- Tenant slug resolution ---

--- a/tests/unit/alias-host-scope.test.ts
+++ b/tests/unit/alias-host-scope.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Alias hosts serve only their own surface; refused networks are refused on
+ * every host. Both exercised through `proxy()` itself — the point is the
+ * response a client receives, not the shape of the source.
+ *
+ * The bug being pinned: `ficinosociety.org` served the entire library because
+ * SOCIETY_DOMAINS was an additive allowlist, and that host sits outside the
+ * Cloudflare zone, so it was where the AS132203 fleet actually read.
+ */
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { proxy } from '@/proxy';
+import { shouldRedirectToCanonical } from '@/lib/alias-host-scope';
+import { isBlockedNetwork } from '@/lib/blocked-networks';
+
+// `host` must be set explicitly: undici treats it as a forbidden header, so a
+// Request built from a URL alone exposes no host to the proxy — and the proxy
+// routes on that header.
+const req = (url: string, headers: Record<string, string> = {}) =>
+  new NextRequest(new Request(url, { headers: { host: new URL(url).host, ...headers } }));
+
+describe('shouldRedirectToCanonical', () => {
+  it('redirects library surfaces off an alias host', () => {
+    for (const p of [
+      '/book/chymische-hochzeit-christiani-rosencreutz-andreae',
+      '/artwork/bembine-table-of-isis',
+      '/collections/hermetica',
+      '/gallery',
+      '/api/image',
+      '/api/books/abc/text',
+      '/search',
+    ]) {
+      expect(shouldRedirectToCanonical(p), p).toBe(true);
+    }
+  });
+
+  it('keeps the society surface and what it needs to run', () => {
+    for (const p of [
+      '/',
+      '/ficino-society',
+      '/discussions',
+      '/discussions/42',
+      '/members',
+      '/_next/static/chunk.js',
+      '/api/auth/session',
+      '/api/ficino/discussions',
+      '/api/presence',
+      // Telemetry stays local so this host's traffic remains measurable —
+      // losing that visibility is how the bypass went unnoticed.
+      '/api/analytics/track',
+      '/api/track',
+      '/favicon.ico',
+    ]) {
+      expect(shouldRedirectToCanonical(p), p).toBe(false);
+    }
+  });
+
+  it('does not let a prefix match a longer unrelated segment', () => {
+    // '/members' is allowed; '/membership-plans' is not the same surface.
+    expect(shouldRedirectToCanonical('/membership-plans')).toBe(true);
+    expect(shouldRedirectToCanonical('/discussions-archive')).toBe(true);
+  });
+});
+
+describe('proxy() on the ficinosociety alias', () => {
+  it('308s a book page to the canonical domain, preserving path and query', async () => {
+    const res = await proxy(req('https://ficinosociety.org/book/some-slug?utm=x'));
+    expect(res?.status).toBe(308);
+    expect(res?.headers.get('location')).toBe('https://sourcelibrary.org/book/some-slug?utm=x');
+  });
+
+  it('scopes the host BEFORE library-specific routing gets a turn', async () => {
+    // /book/<slug>?page=N is rewritten to the bare-page resolver early in the
+    // proxy. While the alias check sat after that, this shape stayed on the
+    // alias host for a hop; scoping now happens first, so it leaves immediately.
+    const res = await proxy(req('https://ficinosociety.org/book/some-slug?page=3'));
+    expect(res?.status).toBe(308);
+    expect(res?.headers.get('location')).toBe('https://sourcelibrary.org/book/some-slug?page=3');
+  });
+
+  it('still serves the society surface in place', async () => {
+    const res = await proxy(req('https://ficinosociety.org/discussions'));
+    expect(res?.status).not.toBe(308);
+  });
+
+  it('leaves the canonical host alone', async () => {
+    const res = await proxy(req('https://sourcelibrary.org/book/some-slug'));
+    expect(res?.status).not.toBe(308);
+  });
+});
+
+describe('isBlockedNetwork', () => {
+  it('covers 43.172.0.0/15, both halves', () => {
+    expect(isBlockedNetwork('43.172.195.14')).toBe(true);
+    expect(isBlockedNetwork('43.173.181.2')).toBe(true);
+  });
+
+  it('does not bleed into neighbouring space', () => {
+    // 43.171.x and 43.174.x are outside the measured range.
+    expect(isBlockedNetwork('43.171.195.14')).toBe(false);
+    expect(isBlockedNetwork('43.174.195.14')).toBe(false);
+    expect(isBlockedNetwork('143.172.195.14')).toBe(false);
+    expect(isBlockedNetwork(null)).toBe(false);
+    expect(isBlockedNetwork('')).toBe(false);
+  });
+});
+
+describe('proxy() refuses blocked networks on every host', () => {
+  it.each([
+    'https://sourcelibrary.org/book/some-slug',
+    'https://ficinosociety.org/book/some-slug',
+    'https://sourcelibrary-v2.vercel.app/book/some-slug',
+    'https://bph.sourcelibrary.org/book/some-slug',
+  ])('403s %s', async (url) => {
+    const res = await proxy(req(url, { 'x-forwarded-for': '43.173.181.5' }));
+    expect(res?.status).toBe(403);
+    expect(await res!.text()).toContain('licensing');
+  });
+
+  it('does not touch an ordinary visitor', async () => {
+    const res = await proxy(req('https://sourcelibrary.org/', { 'x-forwarded-for': '81.204.11.9' }));
+    expect(res?.status).not.toBe(403);
+  });
+});


### PR DESCRIPTION
Answers the question directly: **`ficinosociety.org` served the library because it was never told not to.**

`SOCIETY_DOMAINS` in `src/proxy.ts` is an *additive* allowlist. It rewrites `/` → `/ficino-society` and lifts `/discussions` and `/members` to the domain root. That's all it does. It scoped three paths **onto** the domain; it never scoped the domain. Every other route — `/book/*`, `/artwork/*`, `/collections/*`, `/gallery`, the APIs — fell straight through to the global app.

## Why that mattered more than duplicate content

`ficinosociety.org` is on name.com nameservers and resolves directly to Vercel (216.150.1.1). **No `cf-ray` on any response** — Cloudflare is not in that path at all. So every edge control is absent there: both AS132203 rules, the bot rules, and the entire first layer of the three-layer crawler gate documented in CLAUDE.md.

Measured minutes after `host` landed on read events (#3429):

| events | fleet? | host |
|---:|---|---|
| 3,791 | **YES** | ficinosociety.org |
| 1,444 | no | sourcelibrary.org |
| 1,084 | no | ficinosociety.org |
| 5 | no | sourcelibrary-v2.vercel.app |

**Zero fleet events on `sourcelibrary.org`.** Last night's rule reorder (moving the AS132203 block above the `managed_challenge` that had been shadowing it) *worked* — the fleet had simply been reading through the unguarded door the whole time. Without the `host` field this would still read as "the block doesn't work."

## The two changes, deliberately at different layers

**(3) Alias hosts 308 anything outside their own surface to the canonical domain.** Redirect rather than block: shared links keep working, duplicate content consolidates, and a crawler that follows the redirect arrives somewhere governed. The allowlist is explicit — society routes, framework assets, auth, presence, and **telemetry kept local** so this host's traffic stays measurable. Losing that visibility is precisely how the bypass went unnoticed.

Placed *before* any library-specific routing, after finding that `/book/<slug>?page=N` is rewritten early to the bare-page resolver and so lingered on the alias for a hop. Pinned by its own test.

**(2) `43.172.0.0/15` refused at the application layer, on every hostname and every route.** A Cloudflare rule protects a *zone*; this project answers on hostnames outside it. Same lesson the crawler gate already records — a control at one layer is silently defeated by the others — so the durable version lives where nothing can route around it.

Scope is narrow and evidence-based: Tencent Cloud Singapore only (Aceville Pte Ltd, `abuse@tencent.com`), 37 distinct /24s rotating 16 UAs, 354,997 page-reads in 7 days across 8,047 books, 57% of all 404s. **Alibaba (AS45102) measured 179/day and is deliberately absent** — it doesn't clear the bar. The 403 body points at `/licensing` rather than just refusing.

## Testing

14 new tests exercising `proxy()` itself on four hostnames including the tenant subdomain — not source-shape assertions. Includes negative cases: `/membership-plans` must not match the `/members` prefix, `43.171.*` and `43.174.*` must not be caught, an ordinary visitor must pass.

`scripts/audit-bph-leaks.mjs`: **0 leaks**. 972 unit + 38 integration green, `tsc` clean.

## Still needs you (step 1)

Putting `ficinosociety.org` behind Cloudflare can't be done from here — it's on name.com nameservers, so it isn't a zone in our Cloudflare account. This PR makes that non-urgent rather than unnecessary: the app layer now holds regardless of DNS.

## Noted, not fixed

`audit-bph-leaks.mjs` flags two pre-existing issues on deployed prod, unrelated to this change: `/developers` and `/librarian` each link a Fludd book the BPH tenant doesn't hold, and `/gallery/image/anything` is a silent 404 (200 with a not-found body). Both deserve their own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
