### PR TITLE
fix(auth): user _id lookups matched nothing — welcome gate and membership were dead

### DIFF
--- a/src/app/api/books/[id]/dedicate/route.ts
+++ b/src/app/api/books/[id]/dedicate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
+import { toUserId } from '@/lib/user-id';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -21,7 +22,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   // Must be a member
   const db = await getDb();
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { membership: 1, name: 1 } }
   );
 

--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -7,6 +7,7 @@ import { streamAgenticResponse, type LibrarianStep, type SourceCard } from '@/li
 import { applyCitationFixes, applyImageRemovals, type CitationFix } from '@/lib/embassy/citation-fixes';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 import { z } from 'zod';
+import { toUserId } from '@/lib/user-id';
 
 export const dynamic = 'force-dynamic';
 // 120s was killing real research turns mid-stream: the agentic loop routinely
@@ -115,7 +116,7 @@ export async function POST(request: NextRequest) {
   // Get user display name (anonymous visitors skip the lookup)
   const user = userId
     ? await db.collection('users').findOne(
-        { _id: userId as any },
+        { _id: toUserId(userId) as any },
         { projection: { name: 1, membership: 1 } },
       )
     : null;

--- a/src/app/api/embassy/rooms/[slug]/messages/route.ts
+++ b/src/app/api/embassy/rooms/[slug]/messages/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { z } from 'zod';
+import { toUserId } from '@/lib/user-id';
 
 const messageSchema = z.object({
   content: z.string().min(1, 'Message cannot be empty').max(5000, 'Message too long'),
@@ -82,7 +83,7 @@ export async function POST(
   }
 
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { name: 1, image: 1, membership: 1 } },
   );
   const displayName = user?.membership?.profile?.displayName || user?.name || 'A visitor';

--- a/src/app/api/ficino/discussions/[id]/replies/route.ts
+++ b/src/app/api/ficino/discussions/[id]/replies/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
+import { toUserId } from '@/lib/user-id';
 
 /**
  * POST /api/ficino/discussions/[id]/replies — reply to a discussion thread
@@ -17,7 +18,7 @@ export async function POST(
 
   const db = await getDb();
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { membership: 1, name: 1 } }
   );
 

--- a/src/app/api/ficino/discussions/[id]/route.ts
+++ b/src/app/api/ficino/discussions/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getReadDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
+import { toUserId } from '@/lib/user-id';
 
 /**
  * GET /api/ficino/discussions/[id] — get a thread and its replies
@@ -17,7 +18,7 @@ export async function GET(
 
   const db = await getReadDb();
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { membership: 1 } }
   );
 

--- a/src/app/api/ficino/discussions/route.ts
+++ b/src/app/api/ficino/discussions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
+import { toUserId } from '@/lib/user-id';
 
 /**
  * GET /api/ficino/discussions — list discussion threads (members only)
@@ -14,7 +15,7 @@ export async function GET() {
 
   const db = await getDb();
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { membership: 1 } }
   );
 
@@ -54,7 +55,7 @@ export async function POST(request: NextRequest) {
 
   const db = await getDb();
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { membership: 1, name: 1 } }
   );
 

--- a/src/app/api/ficino/join/route.ts
+++ b/src/app/api/ficino/join/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { sendSocietyWelcomeEmail } from '@/lib/membership-email';
+import { toUserId } from '@/lib/user-id';
 
 /**
  * POST /api/ficino/join — Join the Ficino Society (free)
@@ -19,7 +20,7 @@ export async function POST() {
 
   // Check if already joined
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { 'membership.joined': 1 } }
   );
 
@@ -28,7 +29,7 @@ export async function POST() {
   }
 
   await db.collection('users').updateOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     {
       $set: {
         'membership.joined': true,

--- a/src/app/api/membership/profile/route.ts
+++ b/src/app/api/membership/profile/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
+import { toUserId } from '@/lib/user-id';
 
 /**
  * GET: Fetch the current user's member profile.
@@ -14,7 +15,7 @@ export async function GET() {
 
   const db = await getDb();
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { 'membership.profile': 1 } }
   );
 
@@ -34,7 +35,7 @@ export async function PATCH(request: NextRequest) {
 
   const db = await getDb();
   await db.collection('users').updateOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     {
       $set: {
         'membership.profile': { displayName, bio, visible },

--- a/src/app/api/membership/route.ts
+++ b/src/app/api/membership/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getMembership } from '@/lib/membership';
 import { getReadDb } from '@/lib/mongodb';
+import { toUserId } from '@/lib/user-id';
 
 export async function GET() {
   const session = await auth();
@@ -16,7 +17,7 @@ export async function GET() {
 
   // Check if they've joined the Society (free) — separate from financial contribution
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { 'membership.joined': 1, 'membership.joinedAt': 1 } }
   );
 

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { stripe, MEMBERSHIP_PRICE, MEMBERSHIP_CURRENCY, MEMBERSHIP_NAME, MEMBERSHIP_DESCRIPTION } from '@/lib/stripe';
 import { getDb } from '@/lib/mongodb';
+import { toUserId } from '@/lib/user-id';
 
 export async function POST(request: NextRequest) {
   if (!stripe) {
@@ -31,7 +32,7 @@ export async function POST(request: NextRequest) {
     // Reuse existing Stripe customer if we have one, otherwise create
     const db = await getDb();
     const user = await db.collection('users').findOne(
-      { _id: session.user.id as any },
+      { _id: toUserId(session.user.id) as any },
       { projection: { 'membership.stripeCustomerId': 1 } }
     );
 
@@ -47,7 +48,7 @@ export async function POST(request: NextRequest) {
 
       // Store the customer ID even before checkout completes
       await db.collection('users').updateOne(
-        { _id: session.user.id as any },
+        { _id: toUserId(session.user.id) as any },
         { $set: { 'membership.stripeCustomerId': customerId } }
       );
     }

--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { stripe } from '@/lib/stripe';
 import { getDb } from '@/lib/mongodb';
+import { toUserId } from '@/lib/user-id';
 
 /**
  * Creates a Stripe Billing Portal session for the current user.
@@ -19,7 +20,7 @@ export async function POST() {
 
   const db = await getDb();
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { 'membership.stripeCustomerId': 1 } }
   );
 

--- a/src/app/api/stripe/purchase/route.ts
+++ b/src/app/api/stripe/purchase/route.ts
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth';
 import { stripe } from '@/lib/stripe';
 import { PRICES, PurchaseType } from '@/lib/purchases';
 import { getDb } from '@/lib/mongodb';
+import { toUserId } from '@/lib/user-id';
 
 /**
  * Create a Stripe Checkout session for a single-item purchase (book or image).
@@ -33,7 +34,7 @@ export async function POST(request: NextRequest) {
   // Reuse Stripe customer if we have one
   const db = await getDb();
   const user = await db.collection('users').findOne(
-    { _id: session.user.id as any },
+    { _id: toUserId(session.user.id) as any },
     { projection: { 'membership.stripeCustomerId': 1 } }
   );
   let customerId = user?.membership?.stripeCustomerId;
@@ -46,7 +47,7 @@ export async function POST(request: NextRequest) {
     });
     customerId = customer.id;
     await db.collection('users').updateOne(
-      { _id: session.user.id as any },
+      { _id: toUserId(session.user.id) as any },
       { $set: { 'membership.stripeCustomerId': customerId } }
     );
   }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import Google from 'next-auth/providers/google';
 import Email from 'next-auth/providers/nodemailer';
 import { MongoDBAdapter } from '@auth/mongodb-adapter';
+import { toUserId } from './user-id';
 import clientPromise from './mongodb-client';
 import { Resend } from 'resend';
 import { activatePendingMembership } from './memberships';
@@ -388,9 +389,14 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         try {
           const client = await clientPromise;
           const db = client.db(dbName);
+          // token.id is the adapter's string form of the user _id, but the
+          // MongoDBAdapter stores _id as an ObjectId — querying with the raw
+          // string silently matches nothing. That made needsWelcome and
+          // membership permanently falsy (see the empty catch below, which hid
+          // it): 3,850 of 3,854 users never saw the welcome interstitial.
           const dbUser = await db.collection('users').findOne(
-            { _id: token.id as any },
-            { projection: { 'membership.active': 1, 'membership.plan': 1, 'membership.joined': 1, welcomedAt: 1 } }
+            { _id: toUserId(token.id as string) as any },
+            { projection: { name: 1, 'membership.active': 1, 'membership.plan': 1, 'membership.joined': 1, welcomedAt: 1 } }
           );
           if (dbUser?.membership?.active) {
             token.membership = dbUser.membership.plan || 'ficino';
@@ -400,11 +406,18 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             token.membership = null;
           }
 
+          // Pick up a name saved after sign-in (magic-link users have none until
+          // they fill in /welcome) so the session greets them without a re-login.
+          if (dbUser?.name) token.name = dbUser.name;
+
           // needsWelcome is true only when welcomedAt is explicitly null (set on createUser).
           // Pre-feature users have no welcomedAt field at all — treat as already welcomed.
           (token as any).needsWelcome = dbUser && 'welcomedAt' in dbUser && dbUser.welcomedAt === null;
-        } catch {
-          // Don't block auth if membership check fails
+        } catch (error) {
+          // Don't block auth if the lookup fails — but never swallow it silently
+          // again; the previous bare catch is why the _id type mismatch above
+          // went unnoticed from the day it shipped.
+          console.error('[auth] User lookup failed (membership/needsWelcome):', error);
         }
       }
 

--- a/src/lib/membership.ts
+++ b/src/lib/membership.ts
@@ -1,4 +1,5 @@
 import { getDb } from './mongodb';
+import { toUserId } from './user-id';
 
 export interface MembershipInfo {
   active: boolean;
@@ -13,7 +14,7 @@ export interface MembershipInfo {
 export async function getMembership(userId: string): Promise<MembershipInfo> {
   const db = await getDb();
   const user = await db.collection('users').findOne(
-    { _id: userId as any },
+    { _id: toUserId(userId) as any },
     { projection: { membership: 1 } }
   );
 
@@ -26,7 +27,7 @@ export async function getMembership(userId: string): Promise<MembershipInfo> {
   // This is a safety net in case the cancellation webhook was missed.
   if (m.expiresAt && new Date(m.expiresAt) < new Date()) {
     await db.collection('users').updateOne(
-      { _id: userId as any },
+      { _id: toUserId(userId) as any },
       { $set: { 'membership.active': false } }
     );
     return { active: false, plan: m.plan, expiresAt: new Date(m.expiresAt), stripeCustomerId: m.stripeCustomerId };
@@ -53,7 +54,7 @@ export async function activateMembership(
   const db = await getDb();
 
   await db.collection('users').updateOne(
-    { _id: userId as any },
+    { _id: toUserId(userId) as any },
     {
       $set: {
         'membership.active': true,
@@ -77,7 +78,7 @@ export async function deactivateMembership(userId: string): Promise<void> {
   const db = await getDb();
 
   await db.collection('users').updateOne(
-    { _id: userId as any },
+    { _id: toUserId(userId) as any },
     {
       $set: {
         'membership.active': false,

--- a/src/lib/purchases.ts
+++ b/src/lib/purchases.ts
@@ -1,4 +1,5 @@
 import { getDb } from './mongodb';
+import { toUserId } from './user-id';
 
 export const PRICES = {
   book: { amount: 500, label: '$5' },   // cents
@@ -101,7 +102,7 @@ export async function canDownload(userId: string | null, type: PurchaseType, ite
 
   // Check membership first (fast path)
   const user = await db.collection('users').findOne(
-    { _id: userId as any },
+    { _id: toUserId(userId) as any },
     { projection: { 'membership.active': 1 } }
   );
   if (user?.membership?.active) return true;

--- a/src/lib/user-id.ts
+++ b/src/lib/user-id.ts
@@ -1,0 +1,23 @@
+import { ObjectId } from 'mongodb';
+
+/**
+ * Convert a session/JWT user id into the form the `users` collection is keyed by.
+ *
+ * The NextAuth MongoDBAdapter stores `users._id` as an ObjectId but hands the
+ * application the string form (`session.user.id`, `token.id`). Querying with the
+ * raw string matches nothing and — because Mongo returns null rather than an
+ * error — the failure is completely silent. That is exactly how the welcome
+ * interstitial and the membership check were both dead in production while
+ * looking fine in code review.
+ *
+ * Every read/write of a `users` document keyed by a session id must go through
+ * this helper. Falls back to the string for ids that aren't valid ObjectIds, so
+ * it stays correct if a non-adapter user doc is ever introduced.
+ */
+export function toUserId(id: string): ObjectId | string {
+  // Deliberately NOT ObjectId.isValid(): it also returns true for any
+  // 12-character string, and the modern driver then throws on the constructor
+  // ("input must be a 24 character hex string"). A strict 24-hex test is the
+  // only shape the adapter actually produces.
+  return /^[0-9a-fA-F]{24}$/.test(id) ? new ObjectId(id) : id;
+}

--- a/tests/unit/user-id-objectid.test.ts
+++ b/tests/unit/user-id-objectid.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import path from 'path';
+import { ObjectId } from 'mongodb';
+import { toUserId } from '../../src/lib/user-id';
+
+// The NextAuth MongoDBAdapter stores `users._id` as an ObjectId but hands the
+// application the STRING form via `session.user.id` / `token.id`. Querying the
+// users collection with that raw string matches nothing — and Mongo returns
+// null rather than raising, so the failure is completely silent.
+//
+// Measured on production 2026-07-29: all 3,854 user documents have an ObjectId
+// _id, and `findOne({ _id: "<the string form>" })` returned null for every one
+// of them. That single line in src/lib/auth.ts's jwt callback made
+// `needsWelcome` permanently false, so the /welcome interstitial never fired
+// for 3,850 users, and `token.membership` permanently null, which would have
+// denied the first paying member their member-only downloads.
+//
+// Two guards below: the helper's actual behaviour, and the absence of any
+// remaining raw-string user lookup (re-introduction is the failure mode here,
+// which is what makes a source-shape assertion the right tool — see the
+// "a test that greps source is not a guard" note in CLAUDE.md).
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+describe('toUserId', () => {
+  it('converts an adapter id string to the ObjectId the document is keyed by', () => {
+    const oid = new ObjectId('699508ede7f094a3786bed8e');
+    const converted = toUserId(oid.toString());
+
+    expect(converted).toBeInstanceOf(ObjectId);
+    // .equals is the check that matters: a same-typed but different-valued
+    // ObjectId would still satisfy an instanceof assertion.
+    expect((converted as ObjectId).equals(oid)).toBe(true);
+  });
+
+  it('round-trips every id shape the adapter can produce', () => {
+    for (const hex of ['000000000000000000000000', 'ffffffffffffffffffffffff', '69f8691d858d22fcff27ce34']) {
+      expect(toUserId(hex).toString()).toBe(hex);
+    }
+  });
+
+  it('passes through ids that are not valid ObjectIds instead of throwing', () => {
+    // A non-adapter user document (or a future auth backend) may key on a
+    // plain string. Converting must never be the thing that breaks sign-in.
+    for (const id of ['not-an-object-id', '', 'user_12345']) {
+      expect(toUserId(id)).toBe(id);
+    }
+  });
+
+  it('does not treat a 12-character string as an ObjectId', () => {
+    // ObjectId.isValid('123456789012') returns TRUE (Mongo's legacy 12-byte
+    // form), but the modern driver throws on that constructor input. Using
+    // isValid here would turn a harmless unknown id into a 500 at sign-in.
+    expect(() => toUserId('123456789012')).not.toThrow();
+    expect(toUserId('123456789012')).toBe('123456789012');
+  });
+});
+
+describe('no raw-string user _id lookups remain', () => {
+  it('every users-collection query keyed on a session id goes through toUserId', () => {
+    // git grep stays inside tracked files, so it never descends into the
+    // worktree checkouts under .claude/worktrees/ (CLAUDE.md).
+    let output = '';
+    try {
+      output = execFileSync(
+        'git',
+        ['grep', '-n', '-E', '_id: (session\\.user\\.id|token\\.id|userId) as any', '--', 'src', 'scripts'],
+        { cwd: repoRoot, encoding: 'utf8' }
+      );
+    } catch (err: any) {
+      // git grep exits 1 with no output when there are no matches — that is a pass.
+      if (err.status === 1 && !err.stdout) return;
+      throw err;
+    }
+
+    const offenders = output.split('\n').filter(Boolean);
+    expect(
+      offenders,
+      `These query users._id with the raw session string, which silently matches nothing. ` +
+        `Wrap the id in toUserId() from src/lib/user-id.ts:\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

`session.user.id` / `token.id` is the NextAuth adapter's **string** form of `users._id`, but the MongoDBAdapter keys the collection on an **ObjectId**. Querying with the raw string matches nothing, and Mongo returns `null` rather than raising — so every one of these failures was silent.

Verified against production on 2026-07-29: all 3,854 user documents have an ObjectId `_id`, and `findOne({ _id: '<string form>' })` returns `null` for every one of them.

## Blast radius found

| Site | Effect |
|---|---|
| `src/lib/auth.ts` jwt callback | `needsWelcome` permanently false → the `WelcomeGate` interstitial **never fired**. 3,850 of 3,854 users sit at `welcomedAt: null`. The 4 completed profiles came in via the feedback widget's direct link to `/welcome`. |
| same line | `token.membership` permanently null. Zero members today so no user is currently affected, but the first paying member would be denied member-only downloads (`api/[tenant]/books/[id]/download` reads `session.user.membership`). |
| `activateMembership()` | Called from the Stripe `invoice.paid` webhook — would have no-op'd, leaving a paid subscriber unactivated. |
| 13 more routes | checkout, portal, purchase, ficino join + discussions, embassy chat + rooms, book dedications, `lib/purchases` — all read a user doc and got null. |

The bare `catch {}` in the jwt callback is why this went unnoticed from the day it shipped. It now logs.

## The fix

All 17 sites go through `toUserId()` in the new `src/lib/user-id.ts`. It uses a strict 24-hex test rather than `ObjectId.isValid` — `isValid` also returns true for any 12-character string, and the modern driver's constructor *throws* on that input, which would turn an unknown id into a 500 at sign-in.

The jwt callback additionally picks up `users.name` on session update, so a name saved after sign-in is reflected without re-authenticating (groundwork for the follow-up PR).

## Testing

`tests/unit/user-id-objectid.test.ts` — four behavioural cases on the helper, plus an absence guard against re-introducing a raw-string lookup. The absence-guard shape is the legitimate one per CLAUDE.md ("re-introduction is the failure mode"), and it was **verified as a negative control**: restoring the old line in `api/membership/route.ts` fails the test with that file and line named.

`npx tsc --noEmit` clean.

## Deploy note

Merging this makes the welcome interstitial start firing for the 3,850 users with `welcomedAt: null` — i.e. essentially every existing signed-in reader sees `/welcome` once on their next visit. That is intended (Derek's call), and the form has a "Skip for now" that stamps `welcomedAt` so it never repeats. Flagging it because it is a visible behaviour change for existing users, not a silent bugfix.

## Out of scope

- The `/welcome` form itself (no name field, free-text only) — follow-up PR.
- `membership.ts`'s `$setOnInsert` without `upsert: true` is dead but harmless; left alone to keep this diff to one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)