### PR TITLE
feat(welcome): ask for a name on the welcome form

### DIFF
--- a/src/app/api/me/welcome/route.ts
+++ b/src/app/api/me/welcome/route.ts
@@ -1,13 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ObjectId } from 'mongodb';
-import { auth } from '@/lib/auth';
+import { Resend } from 'resend';
+import { auth, RESEND_AUDIENCE_ID } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
+import { toUserId } from '@/lib/user-id';
 
-// POST /api/me/welcome — captures the first-fill of the user profile (languages,
-// interests, how they'd like to help) and marks the welcome step done.
+// POST /api/me/welcome — captures the first-fill of the user profile (name, who
+// they are and what draws them here, how they'd like to help) and marks the
+// welcome step done.
 //
-// Body: { languages?: string[], interests?: string, help_description?: string, skip?: boolean }
+// Body: { name?: string, about_you?: string, help_description?: string, skip?: boolean }
 // Skipping still sets welcomedAt so the gate doesn't fire again.
+//
+// This is the ONLY place we ask for a name. Google sign-ins arrive with one from
+// the OAuth profile; magic-link sign-ins never do, which is why 46% of user docs
+// had users.name null when this was written.
 //
 // The profile is the durable record — saved to users.profile. A snapshot is also
 // upserted into the `volunteers` collection so we can scan and reach out without
@@ -30,13 +36,13 @@ export async function POST(request: NextRequest) {
       ? body.help_description.trim().slice(0, 2000)
       : '';
 
+    const name = typeof body?.name === 'string'
+      ? body.name.trim().replace(/\s+/g, ' ').slice(0, 100)
+      : '';
+
     const db = await getDb();
-    const userId = session.user.id;
     const email = session.user.email.toLowerCase();
     const now = new Date();
-
-    let userObjectId: ObjectId | string = userId;
-    try { userObjectId = new ObjectId(userId); } catch { /* keep string id */ }
 
     const userUpdate: Record<string, unknown> = {
       welcomedAt: now,
@@ -45,10 +51,13 @@ export async function POST(request: NextRequest) {
       userUpdate['profile.aboutYou'] = aboutYou;
       userUpdate['profile.helpDescription'] = helpDescription;
       userUpdate['profile.updatedAt'] = now;
+      // Only ever set a name, never clear one: a blank field here means "didn't
+      // answer", not "remove the name Google gave me".
+      if (name) userUpdate.name = name;
     }
 
     await db.collection('users').updateOne(
-      { _id: userObjectId as any },
+      { _id: toUserId(session.user.id) as any },
       { $set: userUpdate }
     );
 
@@ -60,7 +69,7 @@ export async function POST(request: NextRequest) {
         {
           $set: {
             email,
-            name: session.user.name || null,
+            name: name || session.user.name || null,
             about_you: aboutYou,
             help_description: helpDescription,
             updated_at: now,
@@ -79,6 +88,24 @@ export async function POST(request: NextRequest) {
         } as Record<string, unknown>,
         { upsert: true }
       );
+    }
+
+    // Backfill the Resend contact. It was created at sign-up (events.createUser
+    // in src/lib/auth.ts), when a magic-link user had no name to give it — this
+    // is the first moment we know one. Best-effort: the profile is already
+    // saved, so a mailing-list hiccup must not fail the request.
+    if (name && process.env.RESEND_API_KEY) {
+      try {
+        const parts = name.split(' ');
+        await new Resend(process.env.RESEND_API_KEY).contacts.update({
+          audienceId: RESEND_AUDIENCE_ID,
+          email,
+          firstName: parts[0],
+          lastName: parts.slice(1).join(' ') || null,
+        });
+      } catch (error) {
+        console.error('[welcome] Resend contact name sync failed:', error);
+      }
     }
 
     return NextResponse.json({ ok: true });

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -44,7 +44,7 @@ export default async function WelcomePage() {
         <p className="font-serif text-white text-xl md:text-2xl mb-4 px-2 drop-shadow-md">
           {firstName ? `Welcome, ${firstName}.` : 'Welcome.'}
         </p>
-        <WelcomeForm />
+        <WelcomeForm initialName={session.user.name || ''} />
       </div>
 
       {(hero.bookTitle || hero.bookYear) && (

--- a/src/components/welcome/WelcomeForm.tsx
+++ b/src/components/welcome/WelcomeForm.tsx
@@ -4,9 +4,12 @@ import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 
-export default function WelcomeForm() {
+export default function WelcomeForm({ initialName = '' }: { initialName?: string }) {
   const router = useRouter();
   const { update } = useSession();
+  // Google sign-ins arrive with a name; magic-link sign-ins never do, and this
+  // is the only place we ever ask. Prefill so Google users aren't retyping it.
+  const [name, setName] = useState(initialName);
   const [aboutYou, setAboutYou] = useState('');
   const [helpDescription, setHelpDescription] = useState('');
   const [status, setStatus] = useState<'idle' | 'submitting' | 'error'>('idle');
@@ -31,6 +34,7 @@ export default function WelcomeForm() {
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     send({
+      name: name.trim(),
       about_you: aboutYou.trim(),
       help_description: helpDescription.trim(),
     });
@@ -40,6 +44,23 @@ export default function WelcomeForm() {
 
   return (
     <form onSubmit={handleSubmit} className="bg-white/95 backdrop-blur-sm border border-stone-200 rounded-xl p-6 md:p-8 space-y-7 shadow-lg shadow-stone-900/5">
+      <div>
+        <label htmlFor="welcome-name" className="block font-serif text-xl text-stone-900 mb-1">
+          What should we call you?
+          <span className="font-sans font-normal text-base text-stone-500 ml-2">optional</span>
+        </label>
+        <input
+          id="welcome-name"
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          autoComplete="name"
+          maxLength={100}
+          placeholder="Your name"
+          className="w-full px-3 py-2.5 border border-stone-300 rounded-lg text-stone-900 text-base focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+        />
+      </div>
+
       <div>
         <label htmlFor="about-you" className="block font-serif text-xl text-stone-900 mb-1">
           Who are you, and what interests you about Source Library?

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,6 +9,11 @@ import { activatePendingMembership } from './memberships';
 
 const dbName = process.env.MONGODB_DB || 'bookstore';
 
+// The Resend audience every signed-up reader is added to. Exported so the
+// welcome form can backfill firstName/lastName on the same contact — magic-link
+// signups have no name at createUser time, which is when the contact is made.
+export const RESEND_AUDIENCE_ID = '62145526-c584-4230-81f1-a62387c49055';
+
 // --- Role system ---
 // Replaces the old admin | curator | inner_circle | reader system.
 // superadmin:  platform owner, cross-tenant (tenantId: null in memberships)
@@ -234,11 +239,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (user.email && process.env.RESEND_API_KEY) {
         try {
           const resend = new Resend(process.env.RESEND_API_KEY);
-          const AUDIENCE_ID = '62145526-c584-4230-81f1-a62387c49055';
 
           await Promise.allSettled([
             resend.contacts.create({
-              audienceId: AUDIENCE_ID,
+              audienceId: RESEND_AUDIENCE_ID,
               email: user.email,
               firstName: user.name?.split(' ')[0] || undefined,
               lastName: user.name?.split(' ').slice(1).join(' ') || undefined,

--- a/tests/unit/welcome-name-capture.test.ts
+++ b/tests/unit/welcome-name-capture.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// /welcome is the ONLY place Source Library ever asks for a name. Google
+// sign-ins arrive with one from the OAuth profile; magic-link sign-ins never do
+// — 1,762 of 3,854 user documents (46%) had users.name null when this shipped.
+//
+// These tests exercise the real route handler and assert on the update document
+// it actually writes. The cases that matter are the two asymmetries, both of
+// which are easy to "simplify" away later:
+//   1. a blank name must NOT clear an existing one (didn't answer ≠ delete it)
+//   2. skipping must still stamp welcomedAt, or the gate re-fires forever
+const userUpdates: { filter: unknown; update: Record<string, any> }[] = [];
+const volunteerUpdates: { filter: unknown; update: Record<string, any> }[] = [];
+
+let sessionUser: { id: string; email: string; name?: string | null } | null = null;
+
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(async () => (sessionUser ? { user: sessionUser } : null)),
+  RESEND_AUDIENCE_ID: 'test-audience',
+}));
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: (name: string) => ({
+      updateOne: async (filter: unknown, update: Record<string, any>) => {
+        (name === 'users' ? userUpdates : volunteerUpdates).push({ filter, update });
+        return { modifiedCount: 1 };
+      },
+    }),
+  })),
+}));
+
+function post(body: unknown) {
+  return new Request('https://sourcelibrary.org/api/me/welcome', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+}
+
+beforeEach(() => {
+  userUpdates.length = 0;
+  volunteerUpdates.length = 0;
+  sessionUser = { id: '699508ede7f094a3786bed8e', email: 'Reader@Example.com', name: null };
+  delete process.env.RESEND_API_KEY;
+});
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('/api/me/welcome name capture', () => {
+  it('saves a name given by a magic-link user who had none', async () => {
+    const { POST } = await import('@/app/api/me/welcome/route');
+    const res = await POST(post({ name: 'Derek Lomas', about_you: 'Here for the Hermetica.' }));
+
+    expect(res.status).toBe(200);
+    expect(userUpdates).toHaveLength(1);
+    expect(userUpdates[0].update.$set.name).toBe('Derek Lomas');
+    expect(userUpdates[0].update.$set['profile.aboutYou']).toBe('Here for the Hermetica.');
+    expect(userUpdates[0].update.$set.welcomedAt).toBeInstanceOf(Date);
+  });
+
+  it('does NOT clear an existing name when the field is left blank', async () => {
+    // A Google user's name is prefilled; if they clear the box, that is far more
+    // likely to be a stray keystroke than a request to become anonymous. Writing
+    // '' here would silently strip names from the very users who have them.
+    sessionUser = { id: '699508ede7f094a3786bed8e', email: 'reader@example.com', name: 'Existing Name' };
+    const { POST } = await import('@/app/api/me/welcome/route');
+    await POST(post({ name: '   ', about_you: 'Something.' }));
+
+    expect(userUpdates[0].update.$set).not.toHaveProperty('name');
+  });
+
+  it('normalises whitespace and caps length', async () => {
+    const { POST } = await import('@/app/api/me/welcome/route');
+    await POST(post({ name: '  Marsilio   Ficino  ', about_you: 'x' }));
+    expect(userUpdates[0].update.$set.name).toBe('Marsilio Ficino');
+
+    userUpdates.length = 0;
+    await POST(post({ name: 'a'.repeat(500), about_you: 'x' }));
+    expect((userUpdates[0].update.$set.name as string).length).toBe(100);
+  });
+
+  it('stamps welcomedAt on skip so the gate never fires again, without a profile', async () => {
+    const { POST } = await import('@/app/api/me/welcome/route');
+    await POST(post({ skip: true, name: 'Ignored On Skip' }));
+
+    const set = userUpdates[0].update.$set;
+    expect(set.welcomedAt).toBeInstanceOf(Date);
+    expect(set).not.toHaveProperty('name');
+    expect(set).not.toHaveProperty('profile.aboutYou');
+    expect(volunteerUpdates).toHaveLength(0);
+  });
+
+  it('keys the user update by ObjectId, not the raw session string', async () => {
+    // The whole reason this flow was unreachable for 3,850 users. See
+    // tests/unit/user-id-objectid.test.ts.
+    const { POST } = await import('@/app/api/me/welcome/route');
+    await POST(post({ name: 'X', about_you: 'y' }));
+
+    const filter = userUpdates[0].filter as { _id: unknown };
+    expect(typeof filter._id).not.toBe('string');
+    expect(String(filter._id)).toBe('699508ede7f094a3786bed8e');
+  });
+
+  it('carries the new name into the volunteers outreach mirror', async () => {
+    const { POST } = await import('@/app/api/me/welcome/route');
+    await POST(post({ name: 'New Name', about_you: 'a', help_description: 'b' }));
+
+    expect(volunteerUpdates).toHaveLength(1);
+    expect(volunteerUpdates[0].update.$set.name).toBe('New Name');
+    // email is lowercased for the outreach key
+    expect(volunteerUpdates[0].filter).toEqual({ email: 'reader@example.com' });
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    sessionUser = null;
+    const { POST } = await import('@/app/api/me/welcome/route');
+    const res = await POST(post({ name: 'Nobody' }));
+
+    expect(res.status).toBe(401);
+    expect(userUpdates).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Supersedes #3449, which GitHub auto-closed when its base branch was deleted on the merge of #3448. Same commit, rebased onto `main`; now correctly based on `main` so the `test` workflow runs (it only triggers on PRs targeting `main`).

## Why

`/welcome` is the only place Source Library ever asks for a name, and it never did. Google sign-ins arrive with one from the OAuth profile; magic-link sign-ins never do — **1,762 of 3,854 user documents (46%) have `users.name` null.** That is why the `/welcome` greeting falls back to a bare "Welcome." and why the Resend audience has no first name for nearly half the list.

Context: until #3448 this form was unreachable. The welcome interstitial never fired, so 3,850 of 3,854 users sat at `welcomedAt: null` and the form had captured 4 profiles ever.

## What

An optional name field above the existing questions. **The two free-text questions are unchanged, verbatim** — only a field was added.

Behaviour worth keeping (each is easy to "simplify" away later, which is what the tests are for):

- **A blank name never clears an existing one.** A Google user's name is prefilled; clearing the box is far more likely a stray keystroke than a request to become anonymous. Writing `''` would strip names from exactly the users who have one.
- Whitespace-normalised, capped at 100 chars.
- **Skip still stamps `welcomedAt` only** — no name, no profile, no volunteers row. If that regresses, the gate re-fires forever.
- The name flows into the `volunteers` outreach mirror, and backfills `firstName`/`lastName` on the **Resend contact**, which was created at sign-up when a magic-link user had no name to give it. Best-effort — the profile is already saved by then, so a mailing-list hiccup cannot fail the request.
- `RESEND_AUDIENCE_ID` moved out of the inline literal in `auth.ts` so both writers address the same audience.

## Testing

`tests/unit/welcome-name-capture.test.ts` — 7 cases against the **real route handler**, asserting on the update document it actually writes (mocking `getDb`/`auth`, following the pattern in `analytics-event-props.test.ts`). Covers the blank-name guard, skip, normalisation, the ObjectId key, the volunteers mirror, and the 401.

Verified as a negative control: dropping the `if (name)` guard fails the clearing test.

Full unit suite green after the rebase (897 tests / 78 files). `npx tsc --noEmit` clean.

## Deliberately not done

- **No structured interest checkboxes.** Considered a chip grid over `LIBRARY_CATEGORIES` (29 subjects) or the 20 pinned collections, which would give queryable segments and let us recommend collections. Derek chose free text — the four answers captured so far are genuinely richer than a checkbox set would be. Worth revisiting once there is volume.
- **The welcome email is untouched.** It is a static HTML constant (`WELCOME_HTML`, `src/lib/auth.ts`) with no personalisation, and it fires at `createUser` — *before* a magic-link user has given a name, so it could not greet them by name without being resequenced. That is a copy + flow change, not a drive-by.
- No name editing on `/account`. Today the only way to change a name is to have never set one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)