### PR TITLE
feat(auth): append-only auth event log — provider, outcome, classified at write time

### DIFF
--- a/scripts/analytics/auth-events-report.mjs
+++ b/scripts/analytics/auth-events-report.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Read the auth event log: sign-ins per day, split by provider, plus the
+ * magic-link send→sign-in gap.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/analytics/auth-events-report.mjs [--days=14]
+ *
+ * The magic-link section is the one worth reading after any auth dependency
+ * change: links sent with no sign-ins following them means the mail is going
+ * out and nobody can use it (or is not going out at all). That was the open
+ * question after #3431 and it previously took a human signing in to answer.
+ */
+
+import { MongoClient } from 'mongodb';
+
+const days = parseInt((process.argv.find(a => a.startsWith('--days=')) || '').split('=')[1] || '14', 10);
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const col = db.collection('auth_events');
+
+const total = await col.estimatedDocumentCount();
+if (total === 0) {
+  console.log('auth_events is empty.');
+  console.log('Expected until the first sign-in AFTER this shipped — the log is');
+  console.log('append-only and not backfilled (nothing to backfill from: users.lastLogin');
+  console.log('records no provider and keeps no history). Meanwhile:');
+  console.log('  db.users.find({lastLogin:{$exists:true}}).sort({lastLogin:-1}).limit(5)');
+  await client.close();
+  process.exit(0);
+}
+
+const since = new Date(Date.now() - days * 86400_000);
+
+const byDay = await col.aggregate([
+  { $match: { ts: { $gte: since } } },
+  { $group: { _id: { day: '$day', kind: '$kind', provider: '$provider' }, n: { $sum: 1 } } },
+  { $sort: { '_id.day': -1 } },
+]).toArray();
+
+console.log(`auth_events — last ${days} days (${total} rows total)\n`);
+
+const dayMap = new Map();
+for (const r of byDay) {
+  const d = dayMap.get(r._id.day) || {};
+  d[`${r._id.kind}:${r._id.provider}`] = r.n;
+  dayMap.set(r._id.day, d);
+}
+if (dayMap.size === 0) {
+  console.log(`(no events in the last ${days} days)`);
+} else {
+  for (const [day, counts] of [...dayMap.entries()].sort().reverse()) {
+    const parts = Object.entries(counts).map(([k, v]) => `${k}=${v}`).join('  ');
+    console.log(`  ${day}  ${parts}`);
+  }
+}
+
+// Magic-link health. Deliberately compares SENDS to SIGN-INS rather than
+// reporting a bare success rate: a rate needs both numbers to exist, and the
+// failure being watched for is one of them being zero.
+const sent = await col.countDocuments({ kind: 'magic_link_sent', ts: { $gte: since } });
+const usedIn = await col.countDocuments({ kind: 'signin', provider: 'nodemailer', ts: { $gte: since } });
+console.log(`\nmagic link: ${sent} sent -> ${usedIn} completed sign-ins`);
+if (sent === 0) {
+  console.log('  NOT MEASURABLE — no links requested in the window. Absence of');
+  console.log('  sends is not evidence the flow works.');
+} else if (usedIn === 0) {
+  console.log('  WARNING: links are being sent and none are completing. Check the');
+  console.log('  nodemailer/next-auth peer range and the Resend key before assuming');
+  console.log('  users simply ignored them.');
+}
+
+// Unclassified rows are reported, never silently folded into "human".
+const unclassified = await col.countDocuments({ traffic_class: null, ts: { $gte: since } });
+if (unclassified) console.log(`\nnote: ${unclassified} event(s) written with no request scope (traffic_class null).`);
+
+await client.close();

--- a/src/lib/analytics-ingest.ts
+++ b/src/lib/analytics-ingest.ts
@@ -24,7 +24,12 @@ const SITE_HOST = 'sourcelibrary.org';
 
 /** Normalize the request host into a tenant-identifying key. */
 export function resolveHost(request: NextRequest): string {
-  const raw = (request.headers.get('x-forwarded-host') || request.headers.get('host') || SITE_HOST)
+  return resolveHostFromHeaders(request.headers);
+}
+
+/** Host key from a bare Headers bag (server contexts without a NextRequest). */
+export function resolveHostFromHeaders(headers: Headers): string {
+  const raw = (headers.get('x-forwarded-host') || headers.get('host') || SITE_HOST)
     .split(',')[0]
     .trim()
     .toLowerCase();
@@ -33,8 +38,13 @@ export function resolveHost(request: NextRequest): string {
 
 /** Anonymized client IP (last octet zeroed) from the proxy headers. */
 export function clientIp(request: NextRequest): string {
-  const raw = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-    || request.headers.get('x-real-ip')
+  return clientIpFromHeaders(request.headers);
+}
+
+/** Anonymized client IP from a bare Headers bag. */
+export function clientIpFromHeaders(headers: Headers): string {
+  const raw = headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    || headers.get('x-real-ip')
     || 'unknown';
   return anonymizeIp(raw);
 }
@@ -76,17 +86,31 @@ export interface ClassifiedRequest {
  * signals are folded in the same way `/api/track` folds them.
  */
 export function classifyRequest(request: NextRequest): ClassifiedRequest {
-  const userAgent = (request.headers.get('user-agent') || '').slice(0, 200);
-  const ip = clientIp(request);
-  const cfThreat = parseInt(request.headers.get('cf-threat-score') || '', 10);
+  return classifyHeaders(request.headers);
+}
+
+/**
+ * Same classification from a bare `Headers` bag, for server contexts that never
+ * see a `NextRequest` — notably the NextAuth `events`/`sendVerificationRequest`
+ * hooks, which receive no request object and can only reach the inbound headers
+ * via `await headers()`.
+ *
+ * Deliberately the SAME function rather than a second implementation: the whole
+ * point of this module is that there is one classifier, so a new write path
+ * cannot be born contaminated (#3405).
+ */
+export function classifyHeaders(headers: Headers): ClassifiedRequest {
+  const userAgent = (headers.get('user-agent') || '').slice(0, 200);
+  const ip = clientIpFromHeaders(headers);
+  const cfThreat = parseInt(headers.get('cf-threat-score') || '', 10);
 
   const cls = classifyTraffic(userAgent, {
-    verifiedBot: request.headers.get('cf-verified-bot') === 'true',
+    verifiedBot: headers.get('cf-verified-bot') === 'true',
     threatScore: Number.isFinite(cfThreat) ? cfThreat : undefined,
     rateCapped: exceedsEventCap(ip),
   });
 
-  return { cls, isHuman: cls === 'human', userAgent, ip, host: resolveHost(request) };
+  return { cls, isHuman: cls === 'human', userAgent, ip, host: resolveHostFromHeaders(headers) };
 }
 
 /**

--- a/src/lib/auth-events.ts
+++ b/src/lib/auth-events.ts
@@ -1,0 +1,109 @@
+import type { Db } from 'mongodb';
+import { classifyHeaders } from '@/lib/analytics-ingest';
+
+/**
+ * Append-only log of authentication events.
+ *
+ * `users.lastLogin` / `loginCount` already record that a person signed in, but
+ * they are STATE, not history: `lastLogin` is overwritten on every sign-in and
+ * neither field records which provider was used. So the collection can answer
+ * "who signed in, and when last" and nothing else — not sign-ins per day, not
+ * Google vs magic link, not whether a requested magic link was ever used.
+ *
+ * That gap has a concrete cost. After the 2026-07-29 auth dependency bump
+ * (next-auth beta.32, #3431) the open question was specifically whether the
+ * magic-link path still sent mail — nodemailer stayed on 8.x because next-auth
+ * caps its peer at `^8.0.5`. `lastLogin` could not answer it: a successful
+ * sign-in looks identical whichever provider produced it, so the provider had
+ * to be inferred from the ABSENCE of a `verification_tokens` row. An inference
+ * from absence is exactly the reasoning CLAUDE.md warns about.
+ *
+ * Two events are recorded, and the pair is the point:
+ *   - `magic_link_sent` when a link is mailed
+ *   - `signin` when authentication actually completes
+ * A `magic_link_sent` with no matching `signin` is a broken magic-link flow —
+ * visible without anyone having to test sign-in by hand.
+ *
+ * Writes are best-effort and never block authentication: a logging failure must
+ * not stop someone signing in. Every call site wraps this, and it also swallows
+ * internally, because the failure mode of a telemetry write is silence, not a
+ * locked-out user.
+ */
+
+export type AuthEventKind = 'signin' | 'magic_link_sent';
+
+export interface AuthEventInput {
+  kind: AuthEventKind;
+  /** 'google' | 'nodemailer' | … — the NextAuth provider id. */
+  provider?: string | null;
+  email?: string | null;
+  /** True when this sign-in also created the account. */
+  isNewUser?: boolean;
+  /** Inbound request headers, when the calling context can reach them. */
+  headers?: Headers | null;
+}
+
+export interface AuthEventDoc {
+  kind: AuthEventKind;
+  provider: string;
+  email: string | null;
+  isNewUser: boolean;
+  ts: Date;
+  day: string;
+  /** Classified at WRITE time — see analytics-ingest.ts. Retroactive is impossible. */
+  traffic_class: string | null;
+  user_agent: string | null;
+  ip: string | null;
+  host: string | null;
+}
+
+/** Build the document. Pure, so the shape is testable without a database. */
+export function buildAuthEvent(input: AuthEventInput, now: Date): AuthEventDoc {
+  // Classification is best-effort: `headers()` throws outside a request scope
+  // (background jobs, tests), and a null class is honest where a fabricated
+  // 'human' would quietly contaminate every later count.
+  let cls: string | null = null;
+  let userAgent: string | null = null;
+  let ip: string | null = null;
+  let host: string | null = null;
+  if (input.headers) {
+    try {
+      const c = classifyHeaders(input.headers);
+      cls = c.cls;
+      userAgent = c.userAgent || null;
+      ip = c.ip;
+      host = c.host;
+    } catch { /* leave null — see above */ }
+  }
+
+  return {
+    kind: input.kind,
+    // NextAuth reports the email provider as 'nodemailer'; normalize absent to
+    // 'unknown' rather than dropping the key, so a provider breakdown never
+    // silently loses rows to a missing field.
+    provider: input.provider || 'unknown',
+    email: input.email ? input.email.toLowerCase() : null,
+    isNewUser: input.isNewUser === true,
+    ts: now,
+    day: now.toISOString().slice(0, 10),
+    traffic_class: cls,
+    user_agent: userAgent,
+    ip,
+    host,
+  };
+}
+
+/**
+ * Append one auth event. Never throws.
+ *
+ * No TTL index — this repo removed automated retention deliberately (#2976) and
+ * prunes by hand. Volume is negligible: ~3,100 users have ever signed in, and
+ * sign-ins run a few per day, so the collection grows by order kilobytes a year.
+ */
+export async function recordAuthEvent(db: Db, input: AuthEventInput): Promise<void> {
+  try {
+    await db.collection('auth_events').insertOne(buildAuthEvent(input, new Date()));
+  } catch (error) {
+    console.error('[auth-events] write failed:', error instanceof Error ? error.message : error);
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,8 +6,27 @@ import { toUserId } from './user-id';
 import clientPromise from './mongodb-client';
 import { Resend } from 'resend';
 import { activatePendingMembership } from './memberships';
+import { recordAuthEvent } from './auth-events';
 
 const dbName = process.env.MONGODB_DB || 'bookstore';
+
+/**
+ * Inbound request headers, or null when there is no request scope.
+ *
+ * The NextAuth `events` and `sendVerificationRequest` hooks receive no request
+ * object, so `next/headers` is the only way to classify the caller. It throws
+ * outside a request (background invocation, tests) — hence the dynamic import
+ * and the swallow. Returning null is deliberate: `buildAuthEvent` then stores a
+ * null traffic_class rather than inventing one.
+ */
+async function safeHeaders(): Promise<Headers | null> {
+  try {
+    const { headers } = await import('next/headers');
+    return await headers();
+  } catch {
+    return null;
+  }
+}
 
 // --- Role system ---
 // Replaces the old admin | curator | inner_circle | reader system.
@@ -156,6 +175,20 @@ if (process.env.RESEND_API_KEY) {
             </div>
           `,
         });
+        // Record the SEND, not just the eventual sign-in. A `magic_link_sent`
+        // with no matching `signin` is the signature of a broken magic-link
+        // flow (a bad provider peer range, a dead SMTP key, prefetch burning
+        // the token) — and it is visible without anyone signing in by hand to
+        // check. That is precisely the question left open by #3431.
+        try {
+          const client = await clientPromise;
+          await recordAuthEvent(client.db(dbName), {
+            kind: 'magic_link_sent',
+            provider: 'nodemailer',
+            email,
+            headers: await safeHeaders(),
+          });
+        } catch { /* never let telemetry break a sign-in */ }
       } catch (error) {
         console.error('[auth] Failed to send verification email:', error);
         throw new Error('Failed to send verification email');
@@ -259,7 +292,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     // not on every JWT validation / page load — so it measures returning
     // members who re-authenticate, e.g. after their session expires). Pairs
     // with createdAt so we can tell new sign-ups from returning ones.
-    async signIn({ user }) {
+    async signIn({ user, account, isNewUser }) {
       if (!user?.email) return;
       try {
         const client = await clientPromise;
@@ -268,6 +301,16 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           { email: user.email.toLowerCase() },
           { $set: { lastLogin: new Date() }, $inc: { loginCount: 1 } }
         );
+        // Append the event too. lastLogin is overwritten each time and records
+        // no provider, so it cannot answer "how many sign-ins today" or "did
+        // the magic-link path work" — see src/lib/auth-events.ts.
+        await recordAuthEvent(db, {
+          kind: 'signin',
+          provider: account?.provider,
+          email: user.email,
+          isNewUser,
+          headers: await safeHeaders(),
+        });
       } catch (error) {
         console.error('[auth] Failed to stamp lastLogin:', error);
       }

--- a/tests/unit/auth-events.test.ts
+++ b/tests/unit/auth-events.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { buildAuthEvent } from '@/lib/auth-events';
+
+/**
+ * These call `buildAuthEvent` rather than asserting on the source of auth.ts.
+ * A source-shape test here could only catch deletion, never a wrong field name
+ * — and a wrong field name is the exact defect this module exists to prevent
+ * (#3409: a metric reported as missing because it was queried under posthog's
+ * legacy singular property names).
+ */
+
+const NOW = new Date('2026-07-29T09:26:52.431Z');
+
+function headersWith(entries: Record<string, string>): Headers {
+  return new Headers(entries);
+}
+
+describe('buildAuthEvent', () => {
+  it('records the provider, which lastLogin cannot', () => {
+    const ev = buildAuthEvent({ kind: 'signin', provider: 'google', email: 'A@Example.com' }, NOW);
+    expect(ev.kind).toBe('signin');
+    expect(ev.provider).toBe('google');
+    // Lowercased so a provider/user breakdown doesn't split on casing.
+    expect(ev.email).toBe('a@example.com');
+    expect(ev.ts).toEqual(NOW);
+    expect(ev.day).toBe('2026-07-29');
+  });
+
+  it('never drops a row to a missing provider', () => {
+    // A missing key would silently vanish from a `group by provider`; 'unknown'
+    // stays countable.
+    expect(buildAuthEvent({ kind: 'signin' }, NOW).provider).toBe('unknown');
+  });
+
+  it('classifies at write time from the request headers', () => {
+    const ev = buildAuthEvent({
+      kind: 'signin',
+      provider: 'nodemailer',
+      headers: headersWith({
+        'user-agent': 'Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/126 Safari/537.36',
+        'x-forwarded-for': '203.0.113.44',
+        host: 'sourcelibrary.org',
+      }),
+    }, NOW);
+
+    expect(ev.traffic_class).toBe('human');
+    expect(ev.user_agent).toContain('Chrome');
+    expect(ev.host).toBe('sourcelibrary.org');
+    // Anonymized — last octet zeroed before storage.
+    expect(ev.ip).toBe('203.0.113.0');
+  });
+
+  it('classifies a bot as a bot rather than as a member', () => {
+    const ev = buildAuthEvent({
+      kind: 'signin',
+      headers: headersWith({ 'user-agent': 'Googlebot/2.1 (+http://www.google.com/bot.html)' }),
+    }, NOW);
+    expect(ev.traffic_class).not.toBe('human');
+  });
+
+  it('reports an unknown class as null rather than inventing one', () => {
+    // No request scope (background job, test). CLAUDE.md: when an instrument
+    // cannot measure, say so — a plausible wrong value is worse than none.
+    const ev = buildAuthEvent({ kind: 'signin', provider: 'google' }, NOW);
+    expect(ev.traffic_class).toBeNull();
+    expect(ev.user_agent).toBeNull();
+    expect(ev.ip).toBeNull();
+  });
+
+  it('distinguishes a link being sent from a sign-in completing', () => {
+    // The pair is the point: sent-without-signin is a broken magic-link flow.
+    const sent = buildAuthEvent({ kind: 'magic_link_sent', provider: 'nodemailer' }, NOW);
+    const done = buildAuthEvent({ kind: 'signin', provider: 'nodemailer' }, NOW);
+    expect(sent.kind).not.toBe(done.kind);
+    expect([sent.kind, done.kind]).toEqual(['magic_link_sent', 'signin']);
+  });
+
+  it('defaults isNewUser to false rather than undefined', () => {
+    // undefined would be indistinguishable from "not recorded" in a query.
+    expect(buildAuthEvent({ kind: 'signin' }, NOW).isNewUser).toBe(false);
+    expect(buildAuthEvent({ kind: 'signin', isNewUser: true }, NOW).isNewUser).toBe(true);
+  });
+
+  it('stores every field a later query will need', () => {
+    // Guards the #3405 failure directly: analytics_events stored no user-agent,
+    // so its contamination could never be cleaned retroactively.
+    const ev = buildAuthEvent({
+      kind: 'signin', provider: 'google', email: 'x@y.z',
+      headers: headersWith({ 'user-agent': 'Chrome', host: 'sourcelibrary.org' }),
+    }, NOW);
+    for (const key of ['kind','provider','email','isNewUser','ts','day','traffic_class','user_agent','ip','host']) {
+      expect(Object.hasOwn(ev, key), `missing ${key}`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Derek asked "shouldn't you see sign-ins?" after I twice failed to find his. The honest answer turned out to be: **sign-ins are recorded, my queries were wrong** — but the follow-up question exposed a real, narrower gap, which is what this fixes.

## The gap

`users.lastLogin` / `loginCount` are **state, not history**. `lastLogin` is overwritten on every sign-in, and neither field records the provider. So they answer *"who signed in, and when last"* — and nothing else:

- ❌ sign-ins per day (no history)
- ❌ Google vs magic link (no provider)
- ❌ whether a requested magic link was ever used

**This had a concrete cost today.** After the auth bump in #3431 the one open question was whether the magic-link path still sends mail — nodemailer stayed on 8.x because next-auth caps its peer at `^8.0.5`. `lastLogin` couldn't answer it: a successful sign-in looks identical whichever provider produced it. I had to infer the provider from the **absence** of a `verification_tokens` row, which is precisely the reasoning CLAUDE.md warns about.

## What's added

Two event kinds, and the **pair** is the point:

| event | written from |
|---|---|
| `magic_link_sent` | `sendVerificationRequest` |
| `signin` | the existing `events.signIn` hook |

A `magic_link_sent` with no `signin` following it is the signature of a broken magic-link flow — a bad peer range, a dead SMTP key, prefetch burning the token. **Visible without anyone signing in by hand to check.**

## Following the measurement doctrine, not adding a fourth set of habits

- **Classified at write time via the same classifier as every other sink.** `classifyRequest` is refactored into `classifyHeaders(Headers)`, and `classifyRequest` delegates — so the NextAuth hooks, which receive no `NextRequest`, share the one classifier instead of growing a second copy. No behavior change for existing callers.
- **Stores `traffic_class` AND `user_agent` AND `ip`**, so a future contamination is diagnosable from the data instead of by inference (#3405 could never be cleaned because the UA was never stored).
- **An unknown class is `null`, never `'human'`.** `headers()` throws outside a request scope; a fabricated class would quietly poison every later count.
- **No TTL** — automated retention was removed deliberately (#2976). Volume is a few rows a day against ~3,100 lifetime users.
- **Best-effort writes that swallow.** Telemetry must never block a sign-in.

## Verification

`tests/unit/auth-events.test.ts` calls `buildAuthEvent` rather than asserting on the source of `auth.ts` — a source-shape test could only catch deletion, and a *wrong field name* is the exact defect this guards against (#3409, and the same mistake I made twice this session).

**Negative control run:** bypassing the classifier (storing nulls, the #3405 shape) fails `classifies at write time from the request headers`. Restored: 8/8.

`scripts/analytics/auth-events-report.mjs` reads it. Dry-run against production returns the empty-state message correctly, and the magic-link section prints **NOT MEASURABLE** when no links were sent in the window rather than a rate computed from a zero denominator.

`npx tsc --noEmit` clean · full suite **998/998**.

## Scope

- **Not backfilled**, and can't be — `lastLogin` has no history and no provider to recover. The log starts at the first sign-in after deploy.
- **Failed sign-ins are out of scope.** NextAuth fires no event for them; they surface as redirects to `/auth/error`. Capturing those is a separate change, and worth doing if the send→signin gap ever shows a problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)