### PR TITLE
fix(welcome): 26 MB hero image, and instrument the onboarding form

### DIFF
--- a/src/app/api/analytics/event/route.ts
+++ b/src/app/api/analytics/event/route.ts
@@ -24,6 +24,13 @@ const ALLOWED_EVENTS = new Set([
   // prefetch-safe second click; without them an unconsumed verification token
   // is indistinguishable from mail that was never opened at all.
   'confirm_view', 'confirm_click',
+  // welcome_view / welcome_save / welcome_skip: the onboarding form at /welcome.
+  // It shipped with no instrumentation at all, which is how it went unnoticed
+  // that the interstitial never fired and the form had captured 4 profiles in
+  // its lifetime (#3448). Without the view event a low completion rate and an
+  // unreachable page look identical. `source` separates gate-redirected users
+  // from people who navigated to /welcome themselves.
+  'welcome_view', 'welcome_save', 'welcome_skip',
 ]);
 
 // Only these prop keys are persisted; everything else is dropped.
@@ -37,6 +44,12 @@ const ALLOWED_PROPS = new Set([
   // safe: on confirm_view/confirm_click, whether the `next` callback parameter
   // survived transit — separates "changed their mind" from "the link broke".
   'safe',
+  // hasName / hasAbout / hasHelp: on welcome_save, WHICH fields the reader
+  // actually filled — never their contents, which live in users.profile. A bare
+  // save count cannot tell "they answered everything" from "they typed a name
+  // and left the two essay boxes empty", and that distinction is the whole
+  // question about whether the form asks for the right things at the right time.
+  'hasName', 'hasAbout', 'hasHelp',
 ]);
 
 const DB_TIMEOUT_MS = 3000;

--- a/src/components/welcome/WelcomeForm.tsx
+++ b/src/components/welcome/WelcomeForm.tsx
@@ -1,8 +1,20 @@
 'use client';
 
-import { useState, FormEvent } from 'react';
+import { useState, useEffect, useRef, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
+import { trackEvent } from '@/lib/track-event';
+
+// Did the reader arrive because WelcomeGate redirected them (it appends ?from=),
+// or did they navigate to /welcome themselves? Those are different populations —
+// the ~3,850 backfilled users all arrive via the gate — and mixing them would
+// make the completion rate meaningless. Read from window.location rather than
+// useSearchParams: this component renders inside a page that already opts out of
+// static prerendering, but the hook would add a bailout boundary for no reason.
+function arrivalSource(): 'gate' | 'direct' {
+  if (typeof window === 'undefined') return 'direct';
+  return new URLSearchParams(window.location.search).has('from') ? 'gate' : 'direct';
+}
 
 export default function WelcomeForm({ initialName = '' }: { initialName?: string }) {
   const router = useRouter();
@@ -13,6 +25,16 @@ export default function WelcomeForm({ initialName = '' }: { initialName?: string
   const [aboutYou, setAboutYou] = useState('');
   const [helpDescription, setHelpDescription] = useState('');
   const [status, setStatus] = useState<'idle' | 'submitting' | 'error'>('idle');
+  const viewed = useRef(false);
+
+  // One view per mount. Without this the denominator does not exist, and a low
+  // completion rate reads identically to a page nobody can reach — the failure
+  // this form actually had.
+  useEffect(() => {
+    if (viewed.current) return;
+    viewed.current = true;
+    trackEvent('welcome_view', { source: arrivalSource() });
+  }, []);
 
   const send = async (payload: object) => {
     setStatus('submitting');
@@ -33,14 +55,26 @@ export default function WelcomeForm({ initialName = '' }: { initialName?: string
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
+    const trimmed = { name: name.trim(), about: aboutYou.trim(), help: helpDescription.trim() };
+    // Which boxes were filled, never their contents — the prose lives in
+    // users.profile, and an analytics row is the wrong place for it.
+    trackEvent('welcome_save', {
+      source: arrivalSource(),
+      hasName: Boolean(trimmed.name),
+      hasAbout: Boolean(trimmed.about),
+      hasHelp: Boolean(trimmed.help),
+    });
     send({
-      name: name.trim(),
-      about_you: aboutYou.trim(),
-      help_description: helpDescription.trim(),
+      name: trimmed.name,
+      about_you: trimmed.about,
+      help_description: trimmed.help,
     });
   };
 
-  const handleSkip = () => send({ skip: true });
+  const handleSkip = () => {
+    trackEvent('welcome_skip', { source: arrivalSource() });
+    send({ skip: true });
+  };
 
   return (
     <form onSubmit={handleSubmit} className="bg-white/95 backdrop-blur-sm border border-stone-200 rounded-xl p-6 md:p-8 space-y-7 shadow-lg shadow-stone-900/5">

--- a/src/lib/track-event.ts
+++ b/src/lib/track-event.ts
@@ -20,7 +20,14 @@ export function trackEvent(
     // never consumed looks identical whether the mail was never opened, the
     // interstitial was abandoned, or the link was mangled in transit.
     | 'confirm_view'
-    | 'confirm_click',
+    | 'confirm_click'
+    // Onboarding form (/welcome). `welcome_view` on mount, then exactly one of
+    // `welcome_save` / `welcome_skip`. The form shipped with no instrumentation,
+    // so a completion rate of 4-in-3,854 was indistinguishable from a page
+    // nobody could reach — which is exactly what it turned out to be (#3448).
+    | 'welcome_view'
+    | 'welcome_save'
+    | 'welcome_skip',
   props?: Record<string, string | number | boolean | undefined>,
 ): void {
   if (typeof window === 'undefined') return;

--- a/src/lib/welcome-hero.ts
+++ b/src/lib/welcome-hero.ts
@@ -11,6 +11,23 @@ export type WelcomeHero = {
 // from the gallery_images collection by URL so the attribution stays accurate.
 const HERO_IMAGE_URL = 'https://images.sourcelibrary.org/archived/69b525af95677df8153c6f62/66.jpg';
 
+// The archival original is a 26 MB full-resolution scan, and the welcome page
+// renders it full-bleed with `unoptimized` (the house convention — 27 other files
+// do the same, keeping R2 images off Vercel's image-optimization bill). So nothing
+// was resizing it: the browser pulled all 26 MB and the page sat as a bare dark
+// rectangle for ~10s on desktop ethernet, far worse on a phone. This is the first
+// screen 3,850 existing readers see exactly once, so it mattered more than usual.
+//
+// Route it through the house resizer instead — measured 626 KB at w=1920/q=80,
+// served in 1.8s. The raw URL stays the gallery_images lookup key; only the
+// rendered URL changes.
+const HERO_DISPLAY_WIDTH = 1920;
+const HERO_DISPLAY_QUALITY = 80;
+
+export function heroDisplayUrl(sourceUrl: string): string {
+  return `/api/image?url=${encodeURIComponent(sourceUrl)}&w=${HERO_DISPLAY_WIDTH}&q=${HERO_DISPLAY_QUALITY}`;
+}
+
 export async function getWelcomeHero(): Promise<WelcomeHero> {
   try {
     const db = await getReadDb();
@@ -19,12 +36,12 @@ export async function getWelcomeHero(): Promise<WelcomeHero> {
       { projection: { _id: 0, image_url: 1, book_title: 1, book_year: 1, description: 1 } }
     );
     return {
-      imageUrl: HERO_IMAGE_URL,
+      imageUrl: heroDisplayUrl(HERO_IMAGE_URL),
       bookTitle: doc?.book_title ? String(doc.book_title).trim() : null,
       bookYear: doc?.book_year ?? null,
       description: doc?.description ?? null,
     };
   } catch {
-    return { imageUrl: HERO_IMAGE_URL };
+    return { imageUrl: heroDisplayUrl(HERO_IMAGE_URL) };
   }
 }

--- a/tests/unit/welcome-instrumentation.test.ts
+++ b/tests/unit/welcome-instrumentation.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { heroDisplayUrl } from '../../src/lib/welcome-hero';
+
+// Two guards for the welcome page's instrumentation and its hero image.
+//
+// The analytics half matters because /api/analytics/event drops any prop key not
+// on its allowlist SILENTLY — the client fires, the request 200s, and the field
+// simply is not there when someone queries for it weeks later. Adding a prop
+// without allowlisting it reproduces that bug inside its own fix, which is why
+// these assert on the document the route actually writes rather than on the
+// contents of the allowlist.
+//
+// The hero half matters because the welcome page renders full-bleed with
+// `unoptimized`, so nothing resizes the source. Pointed at the raw archival URL
+// it shipped a 26 MB scan to every reader.
+const inserted: Record<string, unknown>[] = [];
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: () => ({
+      insertOne: async (doc: Record<string, unknown>) => {
+        inserted.push(doc);
+        return { insertedId: 'test' };
+      },
+    }),
+  })),
+}));
+
+function post(body: unknown) {
+  return new Request('https://sourcelibrary.org/api/analytics/event', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+}
+
+beforeEach(() => { inserted.length = 0; });
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('welcome analytics events', () => {
+  it('accepts all three welcome events', async () => {
+    const { POST } = await import('@/app/api/analytics/event/route');
+    for (const event of ['welcome_view', 'welcome_save', 'welcome_skip']) {
+      const res = await POST(post({ event, props: { source: 'gate' } }));
+      expect(res.status, `${event} was rejected`).toBe(200);
+    }
+    expect(inserted.map(d => d.event)).toEqual(['welcome_view', 'welcome_save', 'welcome_skip']);
+  });
+
+  it('persists which fields were filled on welcome_save', async () => {
+    const { POST } = await import('@/app/api/analytics/event/route');
+    await POST(post({
+      event: 'welcome_save',
+      props: { source: 'gate', hasName: true, hasAbout: true, hasHelp: false },
+    }));
+
+    expect(inserted).toHaveLength(1);
+    // Booleans specifically: sanitizeProps only passes string/number/boolean, and
+    // `false` must survive — it is the interesting half of the answer.
+    expect(inserted[0].hasName).toBe(true);
+    expect(inserted[0].hasAbout).toBe(true);
+    expect(inserted[0].hasHelp).toBe(false);
+  });
+
+  it('keeps `source` so gate arrivals are separable from direct ones', async () => {
+    // The ~3,850 backfilled users all arrive via the gate. Pooling them with
+    // people who navigated to /welcome themselves makes the completion rate
+    // describe no real population.
+    const { POST } = await import('@/app/api/analytics/event/route');
+    await POST(post({ event: 'welcome_view', props: { source: 'direct' } }));
+    expect(inserted[0].source).toBe('direct');
+  });
+
+  it('never persists the reader\'s actual answers', async () => {
+    // The prose belongs in users.profile. If someone later "improves" the event
+    // by sending the text along, the allowlist should drop it — assert that it
+    // does, rather than trusting the caller.
+    const { POST } = await import('@/app/api/analytics/event/route');
+    await POST(post({
+      event: 'welcome_save',
+      props: { source: 'gate', about_you: 'I am a lawyer and filmmaker.', name: 'Derek Lomas' },
+    }));
+
+    expect(inserted[0]).not.toHaveProperty('about_you');
+    expect(inserted[0]).not.toHaveProperty('name');
+  });
+});
+
+describe('welcome hero image', () => {
+  it('routes the archival scan through the resizer instead of serving it raw', async () => {
+    const raw = 'https://images.sourcelibrary.org/archived/69b525af95677df8153c6f62/66.jpg';
+    const url = heroDisplayUrl(raw);
+
+    // The raw URL is a 26 MB original; the page renders it with `unoptimized`,
+    // so if this ever returns the bare URL again nothing downstream resizes it.
+    expect(url).not.toBe(raw);
+    expect(url.startsWith('/api/image?')).toBe(true);
+
+    const params = new URLSearchParams(url.slice(url.indexOf('?') + 1));
+    expect(params.get('url')).toBe(raw);
+    expect(Number(params.get('w'))).toBeLessThanOrEqual(1920);
+    expect(Number(params.get('w'))).toBeGreaterThan(0);
+    expect(Number(params.get('q'))).toBeLessThanOrEqual(90);
+  });
+
+  it('encodes the source URL so its query string cannot leak into ours', () => {
+    const url = heroDisplayUrl('https://example.com/a.jpg?w=99999&evil=1');
+    const params = new URLSearchParams(url.slice(url.indexOf('?') + 1));
+    // If the source were interpolated unencoded, `w` would resolve to 99999.
+    expect(params.get('w')).toBe('1920');
+    expect(params.get('evil')).toBeNull();
+  });
+});


### PR DESCRIPTION
Two defects on `/welcome` — the page 3,850 existing readers now see exactly once, following #3448.

## The hero was a 26 MB JPEG

The page renders it full-bleed with `unoptimized`, which is the **house convention** (27 other files do the same, keeping R2 images off Vercel's image-optimization bill) — so nothing was resizing it. The browser pulled the full archival scan. Measured on desktop ethernet: the page painted as a bare dark rectangle for ~10 seconds before the engraving appeared. On a phone it is the whole experience.

Rather than break the convention, it now goes through the existing house resizer at `/api/image`:

| | bytes | time |
|---|---|---|
| raw archival URL | 26,234,457 | ~10s |
| `?w=1920&q=80` | 625,935 | 1.79s |

42× smaller. The raw URL stays the `gallery_images` lookup key — only the rendered URL changes.

## The form had no instrumentation

No view, save, or skip event. That is precisely how it went unnoticed that the interstitial never fired and the form had captured 4 profiles in its lifetime: **with no denominator, a low completion rate and an unreachable page are the same number.**

Adds `welcome_view` / `welcome_save` / `welcome_skip`, with:

- **`source`** — `gate` (WelcomeGate redirected them, which appends `?from=`) vs `direct`. The ~3,850 backfilled users are all `gate`; pooling them with people who navigated to `/welcome` themselves would produce a rate describing no real population.
- **`hasName` / `hasAbout` / `hasHelp`** on save — *which* boxes were filled, **never their contents** (the prose belongs in `users.profile`). A bare save count cannot tell "answered everything" from "typed a name and left both essay boxes empty", and that distinction is the entire open question about whether the form asks the right things at the right moment.

Both new props are registered in the `ALLOWED_PROPS` allowlist. Skipping that step drops them **silently on a 200 response** — reproducing #3399 inside its own fix.

## Testing

`tests/unit/welcome-instrumentation.test.ts` — 6 cases asserting on the document `/api/analytics/event` actually writes and on the rendered hero URL, including that `false` survives sanitisation (it is the interesting half of the answer) and that a caller who sends the reader's prose has it dropped.

Verified as negative controls:
- removing the three allowlist entries → **1 test fails**
- returning the raw hero URL → **2 tests fail**

Full unit suite green (919 tests / 81 files). `npx tsc --noEmit` clean.

## Out of scope

The question set itself is unchanged. Whether `/welcome` is the right moment to ask "who are you, and what interests you about Source Library?" — a question a brand-new reader has no answer to yet — is a product decision Derek is still weighing, and it should not ride along with a performance fix. These events are what will let that decision be made on evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)