### PR TITLE
fix(welcome): return the reader to where the gate interrupted them

### DIFF
--- a/src/components/welcome/WelcomeForm.tsx
+++ b/src/components/welcome/WelcomeForm.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { trackEvent } from '@/lib/track-event';
+import { returnDestination } from '@/lib/welcome-return';
 
 // Did the reader arrive because WelcomeGate redirected them (it appends ?from=),
 // or did they navigate to /welcome themselves? Those are different populations —
@@ -46,7 +47,11 @@ export default function WelcomeForm({ initialName = '' }: { initialName?: string
       });
       if (!res.ok) throw new Error();
       await update();
-      router.push('/');
+      // Back to whatever they were reading when the gate interrupted them.
+      const from = typeof window !== 'undefined'
+        ? new URLSearchParams(window.location.search).get('from')
+        : null;
+      router.push(returnDestination(from));
       router.refresh();
     } catch {
       setStatus('error');

--- a/src/lib/welcome-return.ts
+++ b/src/lib/welcome-return.ts
@@ -1,0 +1,36 @@
+/**
+ * Where to send a reader once they save or skip the /welcome form.
+ *
+ * WelcomeGate interrupts whatever they were doing and records the destination as
+ * `?from=`. That value used to be recorded and then discarded — everyone landed
+ * on '/'. Harmless for a fresh signup headed to the homepage anyway, and exactly
+ * wrong for the ~3,850 existing readers now meeting this gate mid-journey: click
+ * a link to a book, get pulled to /welcome, end up on the homepage with the book
+ * lost.
+ *
+ * `from` is user-controlled — anyone can hand out /welcome?from=<anything> — so
+ * it is validated as a same-origin path rather than trusted. Rejected:
+ *   - anything not starting with '/' (absolute URLs, javascript:, mailto:)
+ *   - protocol-relative '//host' and the '/\host' variant browsers also resolve
+ *     off-site, which are the classic open-redirect payloads
+ *   - /welcome itself, which would bounce the reader back into the form
+ */
+export function returnDestination(rawFrom: string | null | undefined): string {
+  if (!rawFrom) return '/';
+
+  let from: string;
+  try {
+    from = decodeURIComponent(rawFrom);
+  } catch {
+    return '/'; // malformed percent-encoding
+  }
+
+  from = from.trim();
+  if (!from.startsWith('/')) return '/';
+  // Backslashes are normalised to forward slashes by browsers in some contexts,
+  // so '/\evil.com' and '/\\evil.com' must be rejected alongside '//evil.com'.
+  if (from.startsWith('//') || from.startsWith('/\\')) return '/';
+  if (from === '/welcome' || from.startsWith('/welcome?') || from.startsWith('/welcome/')) return '/';
+
+  return from;
+}

--- a/tests/unit/welcome-return-destination.test.ts
+++ b/tests/unit/welcome-return-destination.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { returnDestination } from '../../src/lib/welcome-return';
+
+// WelcomeGate records where the reader was headed as ?from=, and the form used to
+// discard it and push everyone to '/'. For the ~3,850 existing readers now meeting
+// the gate mid-journey that means: click a link to a book, get pulled to /welcome,
+// land on the homepage with the book lost.
+//
+// The param is user-controlled, so the interesting half of these tests is the
+// rejection set — a naive `router.push(from)` is a textbook open redirect.
+
+describe('returnDestination — sends the reader back where they were going', () => {
+  it('restores a real destination', () => {
+    expect(returnDestination('/book/some-slug')).toBe('/book/some-slug');
+    expect(returnDestination('/book/some-slug/page/abc123')).toBe('/book/some-slug/page/abc123');
+    expect(returnDestination('/collections/alchemy')).toBe('/collections/alchemy');
+  });
+
+  it('decodes the value the gate encoded', () => {
+    // WelcomeGate builds the param with encodeURIComponent(pathname).
+    expect(returnDestination(encodeURIComponent('/gallery/image/x?q=1'))).toBe('/gallery/image/x?q=1');
+  });
+
+  it('falls back to the homepage when there is nothing to return to', () => {
+    expect(returnDestination(null)).toBe('/');
+    expect(returnDestination(undefined)).toBe('/');
+    expect(returnDestination('')).toBe('/');
+  });
+});
+
+describe('returnDestination — open-redirect rejections', () => {
+  it('rejects protocol-relative URLs', () => {
+    // The classic payload: browsers resolve //evil.com against the current scheme.
+    expect(returnDestination('//evil.com')).toBe('/');
+    expect(returnDestination('//evil.com/path')).toBe('/');
+    expect(returnDestination(encodeURIComponent('//evil.com'))).toBe('/');
+  });
+
+  it('rejects the backslash variant of a protocol-relative URL', () => {
+    // Several browsers normalise backslashes to forward slashes when resolving.
+    expect(returnDestination('/\\evil.com')).toBe('/');
+    expect(returnDestination('/\\\\evil.com')).toBe('/');
+  });
+
+  it('rejects absolute URLs and non-http schemes', () => {
+    expect(returnDestination('https://evil.com')).toBe('/');
+    expect(returnDestination('http://evil.com')).toBe('/');
+    expect(returnDestination('javascript:alert(1)')).toBe('/');
+    expect(returnDestination('mailto:someone@example.com')).toBe('/');
+    expect(returnDestination(encodeURIComponent('javascript:alert(1)'))).toBe('/');
+  });
+
+  it('rejects a destination that would bounce back into the form', () => {
+    // An infinite loop: save → /welcome → save → /welcome …
+    expect(returnDestination('/welcome')).toBe('/');
+    expect(returnDestination('/welcome?from=%2F')).toBe('/');
+    expect(returnDestination('/welcome/anything')).toBe('/');
+  });
+
+  it('survives malformed percent-encoding instead of throwing', () => {
+    // decodeURIComponent('%') throws URIError. An analytics-grade nicety would be
+    // to ignore it; here it would break the reader's exit from the form.
+    expect(() => returnDestination('%')).not.toThrow();
+    expect(returnDestination('%')).toBe('/');
+    expect(returnDestination('%E0%A4%A')).toBe('/');
+  });
+
+  it('does not treat leading whitespace as a way past the checks', () => {
+    expect(returnDestination('  //evil.com')).toBe('/');
+    expect(returnDestination('  https://evil.com')).toBe('/');
+  });
+});


### PR DESCRIPTION
## The bug

`WelcomeGate` carefully records the destination it pulled the reader away from:

    router.push(`/welcome?from=${encodeURIComponent(pathname)}`)

…and `WelcomeForm` then discarded it and pushed everyone to `/`. The param was captured but never read.

Harmless for a fresh signup who was headed to the homepage anyway. **Exactly wrong for the ~3,850 existing readers now meeting this gate mid-journey** — which is the population that started hitting it this week, following #3448. Click a link to a book, get pulled to `/welcome`, save or skip, land on the homepage with the book lost.

Found while confirming that the welcome form gates nothing (it doesn't — the only readers of `welcomedAt` are the gate itself and an admin listing; the account is fully created and usable before the screen ever appears).

## The fix

`returnDestination()` in the new `src/lib/welcome-return.ts`. Kept out of the component so it is pure and directly testable without mounting React.

`from` is **user-controlled** — anyone can hand out `/welcome?from=<anything>` — so it is validated as a same-origin path rather than trusted. A naive `router.push(from)` here is a textbook open redirect. Rejected:

- anything not starting with `/` (absolute URLs, `javascript:`, `mailto:`)
- protocol-relative `//host`, and the `/\host` variant browsers also resolve off-site
- `/welcome` itself, which would bounce the reader back into the form forever
- leading whitespace used to sneak past the above

Malformed percent-encoding returns `/` rather than throwing. `decodeURIComponent('%')` raises `URIError`, and here that would break the reader's only exit from the form.

## Testing

`tests/unit/welcome-return-destination.test.ts` — 9 cases, most of them the rejection set.

Verified as a negative control: replacing the body with a naive `return from` **fails 5 of the 9**.

Full unit suite green (928 tests / 82 files). `npx tsc --noEmit` clean.

## Out of scope

Still unchanged: the question set, and the fact that the gate re-fires on each fresh page load until the reader presses Save or Skip (closing the tab is not a dismissal). That second one is by design — it is how the form gets seen at all — but it is worth knowing that "voluntary" describes the *content*, not the *appearance*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)