### PR TITLE
fix(ft): resolve both sides of the SOURCE_LANG guard to an ISO bucket

### DIFF
--- a/scripts/eval/ft-catalog-match.mjs
+++ b/scripts/eval/ft-catalog-match.mjs
@@ -68,6 +68,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { withMongo } from '../lib/mongo.mjs';
 import { appendAttempt } from '../lib/ft-attempt-log.mjs';
+import { toSourceIso } from '../lib/translation-catalog-record.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(__dirname, '..', 'output');
@@ -217,50 +218,26 @@ function extractSurname(author) {
 // ── Source-language normalisation ──────────────────────────────────────────────
 // The catalog was originally entirely `source_language: 'la'`; #2899 adds
 // non-Latin catalogs (Hebrew/Aramaic via Sefaria, Sanskrit/Pali/etc. via Sacred
-// Books of the East, …). Map both the book's surface/original language AND any
-// ISO code that may already appear in the data to the same bucket so guard (c)
-// compares like with like. Keys are matched after `normalise()` (lowercased,
-// punctuation-stripped). Keep in sync with KNOWN_SOURCE_LANGUAGES in
-// scripts/lib/translation-catalog-record.mjs.
-
-const LANG_TO_ISO = {
-  // Latin
-  latin: 'la', 'latin-german': 'la', la: 'la',
-  // Greek
-  greek: 'grc', 'ancient greek': 'grc', 'classical greek': 'grc', grc: 'grc',
-  // modern European (parity with existing rows)
-  german: 'de', de: 'de', dutch: 'nl', nl: 'nl', french: 'fr', fr: 'fr',
-  italian: 'it', it: 'it', spanish: 'es', es: 'es',
-  // Hebrew / Aramaic
-  hebrew: 'he', 'biblical hebrew': 'he', 'mishnaic hebrew': 'he', he: 'he',
-  aramaic: 'arc', 'jewish aramaic': 'arc', 'imperial aramaic': 'arc', arc: 'arc',
-  // Arabic / Persian
-  arabic: 'ar', ar: 'ar', persian: 'fa', fa: 'fa', avestan: 'ave', ave: 'ave',
-  // South Asian
-  sanskrit: 'sa', sa: 'sa', san: 'sa', pali: 'pli', pli: 'pli', pi: 'pli', tamil: 'ta', ta: 'ta',
-  // Tibetan
-  tibetan: 'bo', bo: 'bo',
-  // Chinese (all classical/literary variants collapse to one bucket) + CJK
-  chinese: 'zh', 'classical chinese': 'zh', 'literary chinese': 'zh', 'old chinese': 'zh',
-  zh: 'zh', lzh: 'zh', zho: 'zh',
-  japanese: 'ja', ja: 'ja', korean: 'ko', ko: 'ko',
-  // Ancient Near East
-  syriac: 'syc', syc: 'syc', armenian: 'hy', hy: 'hy',
-  akkadian: 'akk', akk: 'akk', sumerian: 'sux', sux: 'sux', egyptian: 'egy', egy: 'egy',
-};
+// Books of the East, …). Guard (c) can only compare like with like if BOTH the
+// book's language and the catalog row's `source_language` are resolved to the
+// same ISO bucket.
+//
+// #3460: this file used to own a private LANG_TO_ISO table and apply it to the
+// BOOK side only, comparing the result against the raw catalog string. Any row
+// written with a display name ("Sanskrit", "Greek") therefore failed the guard
+// against every book — silently disabling all 305 hand-verified
+// `claude_subagent_verify` rows, which carry 213 of the catalogue's 385
+// `completeness: 'complete'` rows. The mapping now lives in
+// scripts/lib/translation-catalog-record.mjs as the single source of truth and
+// is applied to both sides.
 
 function bookSourceIso(book) {
   // prefer original_language when present; else the surface language
-  const ol = normalise(book.original_language || '');
-  const l = normalise(book.language || '');
-  for (const key of [ol, l]) {
-    if (!key) continue;
-    if (LANG_TO_ISO[key]) return LANG_TO_ISO[key];
-    // handle compound like "latin-german" → first segment
-    const first = key.split(/[-\/, ]/)[0];
-    if (LANG_TO_ISO[first]) return LANG_TO_ISO[first];
+  for (const raw of [book.original_language, book.language]) {
+    const iso = toSourceIso(raw);
+    if (iso) return iso;
   }
-  return l || ol || 'unknown';
+  return normalise(book.language || '') || normalise(book.original_language || '') || 'unknown';
 }
 
 // ── Guards ─────────────────────────────────────────────────────────────────────
@@ -298,7 +275,9 @@ function guardComplete(row) {
 /** (c) Source-language guard. Pass only when the catalog source matches the book's. */
 function guardSourceLang(book, row) {
   const bookIso = bookSourceIso(book);
-  const catIso = normalise(row.source_language || '');
+  // Resolve the catalog side through the SAME map as the book side. Comparing a
+  // resolved bucket against a raw display name is what made 305 rows inert.
+  const catIso = toSourceIso(row.source_language) || normalise(row.source_language || '');
   if (!catIso) return { pass: false, reason: 'catalog row has no source_language' };
   if (bookIso === 'unknown') return { pass: false, reason: `book source-language unknown (lang="${book.language}")` };
   if (bookIso === catIso) return { pass: true, reason: `source_language match (${catIso})` };

--- a/scripts/lib/translation-catalog-record.mjs
+++ b/scripts/lib/translation-catalog-record.mjs
@@ -85,7 +85,90 @@ export const KNOWN_SOURCE_LANGUAGES = new Set([
   'egy', // Egyptian
   'ta',  // Tamil
   'de', 'nl', 'fr', 'it', 'es', // modern European (parity with existing rows)
+  // Long-tail sources that appear in hand-verified rows. Added with #3460 so a
+  // real verified prior is never lost to an over-narrow whitelist — every one of
+  // these was observed in `source: 'claude_subagent_verify'` production rows.
+  'enm', // Middle English
+  'nah', // Nahuatl
+  'myz', // Mandaic
+  'cy',  // Welsh
+  'hai', // Haida
+  'en',  // English (a same-language "source" is a data smell, but keep it visible)
 ]);
+
+/**
+ * Canonical surface-form → ISO bucket map.
+ *
+ * SINGLE SOURCE OF TRUTH. `scripts/eval/ft-catalog-match.mjs` imports this for
+ * BOTH sides of its SOURCE_LANG guard. Before #3460 the matcher mapped only the
+ * *book* side through an equivalent private table and compared it against the
+ * raw catalog string, so any row whose `source_language` was a display name
+ * ("Sanskrit", "Greek") could never match a book whose language resolved to an
+ * ISO code ("sa", "grc"). That silently disabled all 305 hand-verified
+ * `claude_subagent_verify` rows — including 213 of the catalogue's 385
+ * `completeness: 'complete'` rows, i.e. 55% of the only rows strong enough to
+ * defeat a first-translation claim.
+ */
+const SOURCE_LANGUAGE_ALIASES = {
+  latin: 'la', la: 'la',
+  greek: 'grc', 'ancient greek': 'grc', 'classical greek': 'grc', grc: 'grc',
+  hebrew: 'he', 'biblical hebrew': 'he', 'mishnaic hebrew': 'he', he: 'he',
+  aramaic: 'arc', 'jewish aramaic': 'arc', 'imperial aramaic': 'arc', arc: 'arc',
+  arabic: 'ar', ar: 'ar',
+  sanskrit: 'sa', sa: 'sa', san: 'sa',
+  pali: 'pli', pli: 'pli', pi: 'pli',
+  tibetan: 'bo', bo: 'bo',
+  chinese: 'zh', 'classical chinese': 'zh', 'literary chinese': 'zh',
+  'old chinese': 'zh', zh: 'zh', lzh: 'zh', zho: 'zh',
+  syriac: 'syc', syc: 'syc',
+  armenian: 'hy', hy: 'hy',
+  akkadian: 'akk', akk: 'akk',
+  sumerian: 'sux', sux: 'sux',
+  japanese: 'ja', ja: 'ja',
+  korean: 'ko', ko: 'ko',
+  persian: 'fa', fa: 'fa',
+  avestan: 'ave', ave: 'ave',
+  egyptian: 'egy', egy: 'egy', demotic: 'egy',
+  tamil: 'ta', ta: 'ta',
+  german: 'de', de: 'de',
+  dutch: 'nl', nl: 'nl',
+  french: 'fr', fr: 'fr',
+  italian: 'it', it: 'it',
+  spanish: 'es', es: 'es',
+  'middle english': 'enm', enm: 'enm',
+  nahuatl: 'nah', nah: 'nah',
+  mandaic: 'myz', myz: 'myz',
+  welsh: 'cy', cy: 'cy',
+  haida: 'hai', hai: 'hai',
+  english: 'en', en: 'en',
+};
+
+/**
+ * Resolve any surface form of a source language to its ISO bucket.
+ *
+ * Handles the three shapes hand-written rows actually use:
+ *   "Sanskrit"                          → 'sa'
+ *   "Mandaic (via Lidzbarski's German)" → 'myz'   (parenthetical dropped)
+ *   "Latin/German", "Latin-Dutch"       → 'la'    (first segment wins)
+ *
+ * The first-segment rule matches the convention already used on the book side:
+ * for a bilingual text the leading language is the one being translated FROM.
+ * Callers that need the untruncated original should keep `source_language_raw`.
+ *
+ * @param {string} raw
+ * @returns {string|null} ISO bucket, or null when unmappable
+ */
+export function toSourceIso(raw) {
+  if (!raw) return null;
+  // Drop parentheticals ("Mandaic (via Lidzbarski's German)") and lowercase.
+  const base = String(raw).replace(/\([^)]*\)/g, ' ').toLowerCase().trim();
+  if (!base) return null;
+  if (SOURCE_LANGUAGE_ALIASES[base]) return SOURCE_LANGUAGE_ALIASES[base];
+  // Compound "A/B", "A-B", "A, B" → the leading segment is the source.
+  const first = base.split(/[\/,]|\s-\s|-/)[0].trim();
+  if (SOURCE_LANGUAGE_ALIASES[first]) return SOURCE_LANGUAGE_ALIASES[first];
+  return null;
+}
 
 /**
  * Build a single `translation_catalogs` document from a raw record.
@@ -110,11 +193,15 @@ export const KNOWN_SOURCE_LANGUAGES = new Set([
 export function buildCatalogDoc(rec) {
   const source = (rec.source || '').trim();
   if (!source) throw new Error('buildCatalogDoc: missing source');
-  const sourceLanguage = (rec.source_language || '').trim();
-  if (!KNOWN_SOURCE_LANGUAGES.has(sourceLanguage)) {
+  const sourceLanguageRaw = (rec.source_language || '').trim();
+  // Accept display names ("Sanskrit") as well as ISO codes, but STORE the ISO
+  // bucket — the SOURCE_LANG guard compares buckets, so a display name stored
+  // verbatim is a row that can never match (#3460).
+  const sourceLanguage = toSourceIso(sourceLanguageRaw);
+  if (!sourceLanguage || !KNOWN_SOURCE_LANGUAGES.has(sourceLanguage)) {
     throw new Error(
-      `buildCatalogDoc: invalid source_language "${sourceLanguage}" for "${rec.english_title || rec.author}" `
-      + `(must be one of ${[...KNOWN_SOURCE_LANGUAGES].join(',')})`,
+      `buildCatalogDoc: invalid source_language "${sourceLanguageRaw}" for "${rec.english_title || rec.author}" `
+      + `(must resolve to one of ${[...KNOWN_SOURCE_LANGUAGES].join(',')})`,
     );
   }
 
@@ -151,6 +238,10 @@ export function buildCatalogDoc(rec) {
     series: series || undefined,
     completeness,
     source_language: sourceLanguage,
+    // Keep the untruncated original so a compound ("Nahuatl/Latin") or a
+    // qualified form ("Mandaic (via Lidzbarski's German)") is never lost to the
+    // first-segment rule in toSourceIso().
+    source_language_raw: sourceLanguageRaw !== sourceLanguage ? sourceLanguageRaw : undefined,
     source_language_provenance: 'ingest_explicit',
     source_url: rec.source_url || undefined,
   };

--- a/scripts/maintenance/ingest-ft-verify-results.mjs
+++ b/scripts/maintenance/ingest-ft-verify-results.mjs
@@ -40,6 +40,7 @@
  */
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
+import { buildCatalogDoc } from '../lib/translation-catalog-record.mjs';
 
 const file = process.argv.slice(2).find((a) => a.endsWith('.json'));
 const APPLY = process.argv.includes('--apply');
@@ -59,9 +60,10 @@ await c.connect();
 const db = c.db('bookstore');
 const attempts = db.collection('first_translation_attempts');
 const registry = db.collection('translation_catalogs');
+const quarantine = db.collection('translation_catalogs_quarantine');
 
 const FOUND = new Set(['confirmed_complete', 'confirmed_partial', 'complete_prior_found', 'only_partial_exists']);
-let aIns = 0, aSkip = 0, cIns = 0, cSkip = 0, badRows = 0;
+let aIns = 0, aSkip = 0, cIns = 0, cSkip = 0, cQuar = 0, badRows = 0;
 
 const completenessFor = (result) =>
   result === 'confirmed_complete' || result === 'complete_prior_found' ? 'complete'
@@ -148,12 +150,39 @@ for (const r of rows) {
     if (t.translator) dupQuery.translator = t.translator;
     const dup = await registry.findOne(dupQuery);
     if (dup) { cSkip++; continue; }
-    if (APPLY) {
-      await registry.insertOne({
+
+    // #3460: build through the shared builder rather than spreading the raw
+    // subagent object. Spreading stored `source_language` verbatim as a display
+    // name ("Sanskrit") — the matcher's SOURCE_LANG guard compares ISO buckets,
+    // so every such row was inert. buildCatalogDoc also derives author_surname /
+    // english_title_normalized / pub_year_int, which the raw spread never set.
+    let doc;
+    try {
+      doc = buildCatalogDoc({
         ...t,
         pub_year: String(t.pub_year),
-        author_normalized: (t.author ?? '').toLowerCase(),
         source: 'claude_subagent_verify',
+      });
+    } catch (err) {
+      // An unmappable source_language is a real verified prior we must not drop.
+      // Quarantine keeps the record (and the reason) rather than throwing it away.
+      cQuar++;
+      if (APPLY) {
+        await quarantine.insertOne({
+          ...t,
+          pub_year: String(t.pub_year),
+          source: 'claude_subagent_verify',
+          quarantine_reason: err.message,
+          quarantined_at: new Date(),
+          source_language_provenance: `ft-verify-${runDate}`,
+        });
+      }
+      continue;
+    }
+
+    if (APPLY) {
+      await registry.insertOne({
+        ...doc,
         source_language_provenance: `ft-verify-${runDate}`,
         imported_at: new Date(),
       });
@@ -164,7 +193,7 @@ for (const r of rows) {
 
 console.log(`${APPLY ? 'APPLIED' : 'DRY-RUN'} — ${rows.length} results from ${file}`);
 console.log(`  Sink A (attempts ledger): +${aIns} inserted, ${aSkip} already present`);
-console.log(`  Sink C (translation_catalogs): +${cIns} inserted, ${cSkip} deduped`);
+console.log(`  Sink C (translation_catalogs): +${cIns} inserted, ${cSkip} deduped, ${cQuar} quarantined`);
 if (badRows) console.log(`  WARNING: ${badRows} malformed rows/registry entries skipped`);
 console.log('  Sink B (verdict) deliberately untouched — run derive-ft-verdict-from-attempts.ts; the public flag stays behind the reconcile.');
 await c.close();

--- a/scripts/maintenance/reproject-translation-catalogs.mjs
+++ b/scripts/maintenance/reproject-translation-catalogs.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * reproject-translation-catalogs.mjs — repair rows written without the shared
+ * builder, so the matcher can actually see them.  (#3460)
+ *
+ * WHY
+ * ---
+ * `scripts/maintenance/ingest-ft-verify-results.mjs` used to insert its Sink-C
+ * rows by spreading the raw ft-verify subagent object:
+ *
+ *     await registry.insertOne({ ...t, author_normalized: t.author.toLowerCase(), … })
+ *
+ * That bypassed `buildCatalogDoc()`, so those rows never got the derived fields
+ * the Tier-0 matcher relies on, and — the binding defect — kept
+ * `source_language` as a human display name ("Sanskrit", "Greek", "Latin")
+ * instead of the ISO bucket ("sa", "grc", "la").
+ *
+ * `scripts/eval/ft-catalog-match.mjs` resolves the BOOK's language to an ISO
+ * bucket and compares it against the catalog row's stored string, so a display
+ * name can never match. Every affected row failed the SOURCE_LANG guard against
+ * every book — measured 2026-07-29: 305 rows, ALL of `source:
+ * 'claude_subagent_verify'`, carrying 213 of the catalogue's 385
+ * `completeness: 'complete'` rows (55% of the only rows strong enough to defeat
+ * a first-translation claim).
+ *
+ * This sweep recomputes the derived fields from data already present on the row.
+ * It is a re-projection, not a re-fetch: no network, no LLM, no cost.
+ *
+ * SAFETY
+ * ------
+ *   - Dry-run by default; `--apply` required to write.
+ *   - Writes a full backup of every touched document BEFORE mutating.
+ *   - Never changes `completeness`, `english_title`, `translator`, `pub_year`,
+ *     or any human-entered judgement — only derived/normalised fields.
+ *   - A row whose `source_language` cannot be resolved is REPORTED, never
+ *     guessed and never deleted.
+ *   - Idempotent: a second run reports 0 to change.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/reproject-translation-catalogs.mjs           # dry-run
+ *   node scripts/maintenance/reproject-translation-catalogs.mjs --apply
+ *   node scripts/maintenance/reproject-translation-catalogs.mjs --source claude_subagent_verify
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+import {
+  normalize,
+  extractSurname,
+  toSourceIso,
+  KNOWN_SOURCE_LANGUAGES,
+} from '../lib/translation-catalog-record.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+const APPLY = process.argv.includes('--apply');
+const SOURCE_FILTER = (() => {
+  const i = process.argv.indexOf('--source');
+  return i === -1 ? null : process.argv[i + 1];
+})();
+
+/**
+ * Recompute the derived fields for one row.
+ *
+ * FILL-ONLY, deliberately. A derived field that is already populated is left
+ * alone even when recomputation would produce something different.
+ *
+ * Measured 2026-07-29: recomputing unconditionally would have MUTATED 2,961
+ * existing `author_surname` values, and the new value is frequently worse. The
+ * stored keys were derived from the `author` field, which is in reliable
+ * "Last, First" form; `buildCatalogDoc` prefers `canonical_author`, which is an
+ * English display name, and `extractSurname`'s last-word rule mangles those:
+ *
+ *     "Augustine of Hippo"           → "hippo"     (was "aurelius")
+ *     "Various Authors"              → "authors"
+ *     "Ioannes Paulus II"            → "ii"
+ *     "Various Early Church Fathers" → "fathers"
+ *
+ * Those are the matcher's candidate-lookup keys, so overwriting them silently
+ * re-buckets thousands of rows. That is a separate concern with its own
+ * evidence bar — this sweep exists to fix `source_language`, and it stays in
+ * that lane. The divergence is counted and reported so the follow-up is sized.
+ *
+ * Returns the fields that would change, the divergences observed but NOT
+ * applied, and any problem worth reporting.
+ */
+function reproject(row) {
+  const patch = {};
+  const problems = [];
+  const divergences = [];
+
+  /** Fill `field` only when it is currently empty; otherwise record divergence. */
+  const fill = (field, value) => {
+    if (!value) return;
+    const current = row[field];
+    if (current === value) return;
+    if (current === undefined || current === null || current === '') patch[field] = value;
+    else divergences.push({ field, was: current, would_be: value });
+  };
+
+  // ── source_language → ISO bucket ───────────────────────────────────────────
+  // The ONE field this sweep overwrites: a display name here is not a stylistic
+  // difference, it is a value the SOURCE_LANG guard can never match (#3460).
+  const rawLang = (row.source_language || '').trim();
+  const iso = toSourceIso(rawLang);
+  if (!rawLang) {
+    problems.push('no source_language');
+  } else if (!iso || !KNOWN_SOURCE_LANGUAGES.has(iso)) {
+    problems.push(`unmappable source_language "${rawLang}"`);
+  } else if (iso !== rawLang) {
+    patch.source_language = iso;
+    patch.source_language_raw = rawLang;
+  }
+
+  // ── derived match keys (fill-only) ─────────────────────────────────────────
+  const author = (row.author || '').trim();
+  const canonicalAuthor = (row.canonical_author || '').trim();
+  fill('author_surname', extractSurname(canonicalAuthor || author));
+  fill('author_normalized', normalize(author));
+  fill('english_title_normalized', normalize(row.english_title || ''));
+  if (row.canonical_work) fill('canonical_work_normalized', normalize(row.canonical_work));
+  if (row.original_title) fill('original_title_normalized', normalize(row.original_title));
+
+  const yearInt = parseInt(String(row.pub_year ?? '').trim(), 10);
+  if (Number.isFinite(yearInt)) fill('pub_year_int', yearInt);
+
+  return { patch, problems, divergences };
+}
+
+await withMongo(async (db) => {
+  const registry = db.collection('translation_catalogs');
+  const query = SOURCE_FILTER ? { source: SOURCE_FILTER } : {};
+  const rows = await registry.find(query).toArray();
+  console.log(`Scanning ${rows.length} rows${SOURCE_FILTER ? ` (source=${SOURCE_FILTER})` : ''}…\n`);
+
+  const toWrite = [];
+  const problemRows = [];
+  const fieldTally = {};
+  const sourceTally = {};
+  const divergenceTally = {};
+  const divergenceExamples = [];
+
+  for (const row of rows) {
+    const { patch, problems, divergences } = reproject(row);
+    if (problems.length) {
+      problemRows.push({ _id: String(row._id), source: row.source, title: row.english_title, problems });
+    }
+    for (const d of divergences) {
+      divergenceTally[d.field] = (divergenceTally[d.field] || 0) + 1;
+      if (d.field === 'author_surname' && divergenceExamples.length < 10) {
+        divergenceExamples.push({ src: row.source, author: row.author, canon: row.canonical_author, ...d });
+      }
+    }
+    if (Object.keys(patch).length === 0) continue;
+    toWrite.push({ row, patch });
+    for (const f of Object.keys(patch)) fieldTally[f] = (fieldTally[f] || 0) + 1;
+    sourceTally[row.source] = (sourceTally[row.source] || 0) + 1;
+  }
+
+  console.log(`Rows needing re-projection: ${toWrite.length}`);
+  console.log('  by field:', fieldTally);
+  console.log('  by source:', sourceTally);
+  console.log(`\nRows with unresolvable problems (reported, NOT changed): ${problemRows.length}`);
+  for (const p of problemRows.slice(0, 20)) {
+    console.log(`  - [${p.source}] ${String(p.title).slice(0, 60)} — ${p.problems.join('; ')}`);
+  }
+  if (problemRows.length > 20) console.log(`  … and ${problemRows.length - 20} more`);
+
+  console.log('\nDIVERGENCES observed but deliberately NOT applied (fill-only policy):');
+  console.log(' ', divergenceTally);
+  if (divergenceExamples.length) {
+    console.log('  sample author_surname divergences — note the recomputed value is often WORSE,');
+    console.log('  which is why this sweep does not overwrite populated keys:');
+    for (const e of divergenceExamples) {
+      console.log(`    [${e.src}] author="${e.author}" canon="${e.canon}" stored="${e.was}" recomputed="${e.would_be}"`);
+    }
+  }
+
+  // How many rows become guard-eligible as a result — the number that matters.
+  const nowComplete = toWrite.filter(
+    ({ row, patch }) => row.completeness === 'complete' && patch.source_language,
+  ).length;
+  console.log(`\n"complete" rows gaining an ISO source_language: ${nowComplete}`);
+
+  if (!APPLY) {
+    console.log('\nDRY-RUN — nothing written. Re-run with --apply.');
+    return;
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backupPath = path.join(OUT_DIR, `reproject-translation-catalogs-backup-${stamp}.json`);
+  fs.writeFileSync(backupPath, JSON.stringify(toWrite.map(({ row }) => row), null, 2));
+  console.log(`\nBacked up ${toWrite.length} original documents → ${backupPath}`);
+
+  let written = 0;
+  for (let i = 0; i < toWrite.length; i += 500) {
+    const chunk = toWrite.slice(i, i + 500);
+    const res = await registry.bulkWrite(
+      chunk.map(({ row, patch }) => ({
+        updateOne: {
+          filter: { _id: row._id },
+          update: { $set: { ...patch, reprojected_at: new Date() } },
+        },
+      })),
+    );
+    written += res.modifiedCount;
+  }
+  console.log(`APPLIED — modifiedCount=${written} (expected ${toWrite.length})`);
+  if (written !== toWrite.length) {
+    console.log('WARNING: modifiedCount does not match the planned count — investigate before trusting this run.');
+  }
+});

--- a/tests/unit/translation-catalog-source-language.test.ts
+++ b/tests/unit/translation-catalog-source-language.test.ts
@@ -1,0 +1,146 @@
+/**
+ * SOURCE_LANG guard: both sides must resolve to the same ISO bucket (#3460).
+ *
+ * The bug: `scripts/eval/ft-catalog-match.mjs` resolved the BOOK's language to
+ * an ISO code via a private table, then compared that against the catalog row's
+ * `source_language` string *as stored*. Rows written with a human display name
+ * ("Sanskrit", "Greek", "Latin") therefore failed the guard against every book
+ * in the corpus.
+ *
+ * Blast radius measured against production on 2026-07-29: 305 rows, all of
+ * `source: 'claude_subagent_verify'` — the hand-verified batch — carrying 213 of
+ * the catalogue's 385 `completeness: 'complete'` rows. Since COMPLETENESS is the
+ * guard that actually defeats a first-translation claim, 55% of the rows strong
+ * enough to demote a badge could never be reached. Running the real matcher
+ * before/after the fix moved the corpus-wide demote-candidate count from 0 to 2.
+ *
+ * These tests exercise the real exported matcher against real row shapes. They
+ * are deliberately NOT source-shape assertions: the failure mode here is a
+ * guard that returns the wrong answer, which a grep for a line of code cannot
+ * see (see "A test that greps source is not a guard" in CLAUDE.md).
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import { buildCatalogIndex, matchBookToCatalog } from '../../scripts/eval/ft-catalog-match.mjs';
+// @ts-expect-error — .mjs script module without type declarations
+import { toSourceIso, buildCatalogDoc } from '../../scripts/lib/translation-catalog-record.mjs';
+
+describe('toSourceIso', () => {
+  it('maps display names to ISO buckets', () => {
+    expect(toSourceIso('Sanskrit')).toBe('sa');
+    expect(toSourceIso('Greek')).toBe('grc');
+    expect(toSourceIso('Ancient Greek')).toBe('grc');
+    expect(toSourceIso('Latin')).toBe('la');
+    expect(toSourceIso('Classical Chinese')).toBe('zh');
+    expect(toSourceIso('Tibetan')).toBe('bo');
+  });
+
+  it('is idempotent on values already in ISO form', () => {
+    for (const iso of ['la', 'grc', 'sa', 'bo', 'zh', 'he', 'arc']) {
+      expect(toSourceIso(iso)).toBe(iso);
+    }
+  });
+
+  it('drops qualifying parentheticals', () => {
+    // Real production values from the claude_subagent_verify batch.
+    expect(toSourceIso("Mandaic (via Lidzbarski's German)")).toBe('myz');
+    expect(toSourceIso('Middle English (French-derived recension)')).toBe('enm');
+  });
+
+  it('takes the leading segment of a compound source', () => {
+    expect(toSourceIso('Latin/German')).toBe('la');
+    expect(toSourceIso('Latin-Dutch')).toBe('la');
+    expect(toSourceIso('Nahuatl/Latin')).toBe('nah');
+  });
+
+  it('returns null rather than guessing on an unmappable value', () => {
+    // Reported by the repair sweep, deliberately left unresolved.
+    expect(toSourceIso('Mixtec (pictographic; via Spanish)')).toBeNull();
+    expect(toSourceIso('')).toBeNull();
+    expect(toSourceIso(undefined)).toBeNull();
+  });
+});
+
+describe('buildCatalogDoc source_language', () => {
+  const base = {
+    source: 'test',
+    author: 'Patanjali',
+    english_title: 'The Yoga Sutras of Patanjali',
+    translator: 'Someone',
+    pub_year: '1914',
+  };
+
+  it('stores the ISO bucket even when handed a display name', () => {
+    // This is the regression: the ft-verify ingest fed display names straight
+    // through, so rows were born unmatchable.
+    const doc = buildCatalogDoc({ ...base, source_language: 'Sanskrit' });
+    expect(doc.source_language).toBe('sa');
+    expect(doc.source_language_raw).toBe('Sanskrit');
+  });
+
+  it('does not set source_language_raw when the input was already ISO', () => {
+    const doc = buildCatalogDoc({ ...base, source_language: 'sa' });
+    expect(doc.source_language).toBe('sa');
+    expect(doc.source_language_raw).toBeUndefined();
+  });
+
+  it('throws on a source_language it cannot resolve', () => {
+    expect(() => buildCatalogDoc({ ...base, source_language: 'Klingon' })).toThrow(/invalid source_language/);
+  });
+});
+
+describe('SOURCE_LANG guard via the real matcher', () => {
+  const book = {
+    id: 'bk-yoga',
+    title: 'Yoga Sutras',
+    author: 'Patanjali',
+    language: 'Sanskrit',
+    original_language: 'Sanskrit',
+  };
+
+  /** A complete prior translation that should defeat a first-translation claim. */
+  const row = (sourceLanguage: string) => ({
+    _id: 'row-1',
+    source: 'claude_subagent_verify',
+    author: 'Patanjali',
+    canonical_author: 'Patanjali',
+    author_surname: 'patanjali',
+    english_title: 'Yoga Sutras',
+    translator: 'Charles Johnston',
+    pub_year: '1912',
+    pub_year_int: 1912,
+    completeness: 'complete',
+    source_language: sourceLanguage,
+  });
+
+  it('passes when the row carries an ISO code', () => {
+    const result = matchBookToCatalog(book, buildCatalogIndex([row('sa')]));
+    expect(result).not.toBeNull();
+    expect(result.best_match.guards.SOURCE_LANG.pass).toBe(true);
+  });
+
+  it('ALSO passes when the row carries the display name — the #3460 regression', () => {
+    // Before the fix this compared 'sa' against 'sanskrit' and failed, taking
+    // the whole hand-verified batch out of play.
+    const result = matchBookToCatalog(book, buildCatalogIndex([row('Sanskrit')]));
+    expect(result).not.toBeNull();
+    expect(result.best_match.guards.SOURCE_LANG.pass).toBe(true);
+  });
+
+  it('still rejects a genuinely different source language', () => {
+    // The guard must keep doing its job: a Latin→English translation does not
+    // defeat a Sanskrit→English first claim.
+    const result = matchBookToCatalog(book, buildCatalogIndex([row('Latin')]));
+    expect(result).not.toBeNull();
+    expect(result.best_match.guards.SOURCE_LANG.pass).toBe(false);
+  });
+
+  it('a display-name row with completeness=complete becomes a demote candidate', () => {
+    // The end-to-end consequence: all five guards pass, so the row is finally
+    // able to surface an over-claim.
+    const result = matchBookToCatalog(book, buildCatalogIndex([row('Sanskrit')]));
+    expect(result.best_match.all_guards_pass).toBe(true);
+    expect(result.tier).toBe('demote_candidate');
+  });
+});


### PR DESCRIPTION
First step on `.claude/handoffs/2026-07-29-reference-set-implementation.md`. Found while measuring reference-set coverage per tradition (handoff §4 step 1) — this blocks that measurement, so it goes first.

## The bug

`scripts/eval/ft-catalog-match.mjs` resolved the **book's** language to an ISO bucket via a private `LANG_TO_ISO` table, then compared it against the catalog row's `source_language` **as stored**. Any row written with a human display name could never match any book:

```
book "Yoga Sutras" (Sanskrit) → 'sa'
row  source_language: "Sanskrit" → 'sanskrit'     ✗ mismatch, always
```

## Blast radius (measured against production, 2026-07-29)

| | |
|---|---|
| rows with a non-ISO `source_language` | **305** |
| ...all from one source | `claude_subagent_verify` — the hand-verified batch |
| ...carrying `completeness: 'complete'` | **213 of the catalogue's 385** |

`COMPLETENESS` is the guard that actually defeats a first-translation claim, so **55% of the rows strong enough to demote a badge were unreachable**. Running the real matcher before/after the fix moves the corpus-wide count from **0 → 2 demote candidates**.

Both surfaced candidates are real and queue for sign-off (no flag is flipped here):
- *Volumen Paramirum und Opus Paramirum* — prior: *Opus Paramirum* (in: Essential Theoretical Writings), `de`
- *Epictetus, Encheiridion and Aesop (MS)* — prior: *The Discourses of Epictetus; with the Encheiridion and Fragments*, `grc`

## Changes

- **`toSourceIso()`** in `scripts/lib/translation-catalog-record.mjs` is the single source of truth. Handles display names, qualifying parentheticals (`"Mandaic (via Lidzbarski's German)"`), and compounds (`"Latin/German"`). Returns `null` rather than guessing.
- **`buildCatalogDoc()`** accepts a display name but stores the ISO bucket, preserving the original in `source_language_raw`.
- **`ingest-ft-verify-results.mjs`** — the writer that produced these rows — now builds through `buildCatalogDoc` instead of spreading the raw subagent object, so the class cannot regress. An unresolvable language goes to `translation_catalogs_quarantine` **with its reason** rather than being dropped.
- **`reproject-translation-catalogs.mjs`** repairs rows already written. Applied: 429 modified, backup written, re-run reports 0.

## Deliberately out of scope

The sweep is **fill-only** on derived keys. Recomputing them unconditionally would have mutated **2,961** existing `author_surname` values, and the recomputed value is frequently *worse* — `extractSurname` prefers `canonical_author`, whose last-word rule mangles English display names:

```
"Augustine of Hippo"           → "hippo"    (stored: "aurelius")
"Various Authors"              → "authors"
"Ioannes Paulus II"            → "ii"
```

Those are the matcher's candidate-lookup keys. Re-bucketing thousands of rows is a separate concern with its own evidence bar; the divergence is counted and reported by the sweep so the follow-up is sized. **Not** fixed here.

Also out of scope: `completeness` is still `unknown` on 22,005 rows and remains the dominant guard failure (44 of 46 matches). That is what `bib_records` (#3455) addresses — next PR.

## Verification

- Tests exercise the **real exported matcher**, not source text (per the "a test that greps source is not a guard" rule).
- **Negative control run:** reverted the guard line and re-ran — exactly the 2 regression tests fail, the 10 pinning unchanged behaviour still pass. The harness bites.
- Sweep verified idempotent (second run: 0 rows).
- `npx tsc --noEmit` clean; full unit suite 1040/1040.

Refs #3459, #3455, #2567

🤖 Generated with [Claude Code](https://claude.com/claude-code)