### PR TITLE
feat(ft): publish the search, not the claim — reference set, 27% recall, and the queue of what's undone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,24 @@ Chrome/Edge's built-in translator replaces every text node with a nested `<font 
 
 **Verifying:** Chrome's built-in translator can't be driven from CDP and the Google Translate *widget* is blocked by our CSP (`translate-pa.googleapis.com` absent from `script-src`; the built-in translator is browser-level and unaffected, so real users are fine). Model it with a MutationObserver that wraps text nodes in `<font><font>` — but **apply the batches asynchronously**, never synchronously inside the observer callback: sync surgery lands inside React's commit, which no real translator does, and it manufactures staleness on correct builds. Always run the unfixed build through the same harness as a negative control; if the old code passes too, the harness proves nothing.
 
+## An absence claim is only as strong as the set it was asserted against — CRITICAL
+"First English translation" asserts an **unprovable universal negative**. No search establishes one; a catalogue returns only *nothing found*. The fix (#3459) is to stop asserting the negative and publish the **search**: a bounded, dated, reproducible act recorded in `search_efforts` — proposition, reference set with per-source snapshot dates and declared gaps, every query verbatim, every candidate **with its screening reason**, and the git SHA that produced it.
+
+That machinery is only honest if you know the set's **recall**, and ours is **22%** — four of five known prior translations are invisible to it (`scripts/eval/ft-reference-set-recall.mjs`, measured against the 2,231 attributed priors already sitting in `translation_classification`). So:
+
+- **`none_found` is WEAK evidence.** Never quote a count built on it. Positive findings (a prior *found* and verified) are unaffected — poor recall cannot manufacture a false positive.
+- **A null means different things in different traditions.** French has 23,035 English translations in the set, Syriac 119, and CJK is reachable only via MARC 880 (present on 2.3% of rows). Read reference-set *depth* beside every verdict; a flat badge cannot be honest across all of them.
+- **Keep "we could not ask" separate from "we asked and found nothing."** Conflating them turns an unasked question into a confident negative — the single most common way this system lies.
+
+**Every bug in this area fails toward a confident clean negative.** Fourteen defects in one session, not one of which produced a false positive. A null is the cheap answer at every layer: an inverted year comparison, a capped fallback threshold, a throttled endpoint returning HTTP 200 with HTML, a schema mismatch between two extractors. The only thing that caught them was the **recorded reason on each rejected candidate** — a system that logs only what it found cannot be debugged.
+
+Three specific traps, each of which cost real work:
+- **Threshold tuning does not converge — find the right instrument.** The work-identity matcher was tuned five times; pass four lost verified true positives (Cicero's *De Officiis*, Grimald 1556) while making the corpus look *cleaner*. The answer was not a threshold but MARC **240 uniform-title containment**, because 240 exists to name a work independently of how an edition titles it. Pinned by a gold set (`tests/unit/reference-set-work-identity.test.ts`) holding both the verified positives and the false-positive class each tuning pass produced.
+- **An immutable log is a history, not a state.** Efforts are immutable so a stale negative re-opens when the set improves — but adding a source mints a new generation and silently orphans prior judgement. Screening lives in `screening_decisions`, keyed on (work, prior), and is re-applied to every generation. Read `search_efforts` through `latestEffortPerBook()`.
+- **Provenance cannot tell you what you translated.** Re-hosted scholarly editions (Budge, Langdon) carry `translation.model` and `source:"ai"` exactly like our own work, because our pipeline OCR'd their printed *English* and re-rendered it. The signal that works is the OCR model's own declaration inside `ocr.data` (`<language>English</language>`) — `scripts/lib/english-source-detect.mjs`. The `pages.ocr.language` column is null on exactly the older ingests where it matters. And strip editorial wrappers before measuring any page text, or you measure our own annotations (that bug shipped here and inflated a count 6×).
+
+Full postmortem: private ops repo, `handoffs/2026-08-01-reference-set-and-first-translation-audit.md`.
+
 ## Social-card metadata invariant
 Next.js merges page `metadata` shallowly per top-level key. Two consequences that bit three surfaces in one day (2026-07-15, PRs #3149/#3151/#3152):
 - A page that defines `openGraph` **replaces the root layout's entire openGraph object, images included** — title/description-only blocks ship NO `og:image` at all (blank share cards on FB/LinkedIn/Slack/iMessage).

--- a/scripts/enrichment/fetch-bib-records.mjs
+++ b/scripts/enrichment/fetch-bib-records.mjs
@@ -1,0 +1,491 @@
+#!/usr/bin/env node
+/**
+ * fetch-bib-records.mjs — build the reference set by working BACKWARDS from our
+ * own claims, keeping the whole bibliographic record. (#3455, #3459)
+ *
+ * THE PRINCIPLE
+ * -------------
+ * "First English translation" asserts an unprovable universal negative. No
+ * search establishes it — a catalogue returns only *nothing found*. The fix is
+ * to assert absence against a NAMED, DATED, BOUNDED reference set rather than
+ * against the world. This script builds that reference set.
+ *
+ * DRIVEN FROM CLAIMS, NOT FROM THE REGISTRY
+ * -----------------------------------------
+ * Do NOT try to fill the 24,061 existing `translation_catalogs` rows: none
+ * carries an identifier, so there is no key to re-fetch them by, and most are
+ * translations of works we do not hold. Instead, for each book we publicly badge
+ * "First Translation", ask the authority *"does a complete English translation
+ * of this work already exist?"* and keep whatever comes back whole.
+ * `translation_catalogs` then fills as a byproduct, in the order that matters:
+ * rows about books we hold and claim.
+ *
+ * QUERY BY AUTHOR, MATCH LOCALLY — and why the obvious approach fails
+ * -------------------------------------------------------------------
+ * The intuitive query is English-title-to-English-title: cross-language title
+ * matching notoriously fails ("Noctes Atticae" vs "Attic Nights" share no
+ * tokens), so use `books.english_title`. Measured 2026-07-29, that returns
+ * essentially nothing — 96 queries, 7 records, 0 priors across all 12
+ * traditions including Latin and Greek.
+ *
+ * The reason is that `books.english_title` is an AI-rendered GLOSS of the
+ * original title page, not a bibliographic access point:
+ *
+ *   "Four Volumes of Divine and Human Marvels. First, on the Marvels of Sacred
+ *    Scripture. Second, on the Marvelous Propositions of the Blessed Apostle…"
+ *   "A short treatise on the nature of the elements, and how they cause wind,
+ *    rain, lightning and thunder, [et]c. , Written in Low German by…"
+ *
+ * No English edition was ever published under those strings, so an exact-phrase
+ * title search cannot match — and the title an English edition WAS published
+ * under is precisely the unknown we are trying to discover. Querying on it
+ * assumes the answer.
+ *
+ * So: query by AUTHOR (a stable access point across languages), pull the
+ * author's records, and resolve work identity locally against the ORIGINAL
+ * title — which is what MARC `240` uniform title carries for translations.
+ * Measured on the same endpoint: `bath.author="Ficino"` → 88 records, 8 with
+ * `041`; `bath.author="Paracelsus"` → 120 records, 4 with `041`.
+ *
+ * This is also much cheaper in requests: authors repeat across the badged set,
+ * so one query serves every book by that author, and the records are stored
+ * once and reused.
+ *
+ * COST
+ * ----
+ * FREE. loc.gov has no per-call fee and needs no auth; rate limits, not dollars,
+ * are the constraint. No LLM call anywhere in this script — a reference-set hit
+ * is a deterministic lookup, which is the entire point: every book the
+ * catalogue resolves is a book Tier-2 verification never has to pay for.
+ *
+ * WHAT IT REPORTS
+ * ---------------
+ * The residue: badged books for which the reference set finds NO complete prior
+ * English translation. That number sizes every downstream decision and is
+ * currently unknown.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/enrichment/fetch-bib-records.mjs --limit 50            # dry-run
+ *   node scripts/enrichment/fetch-bib-records.mjs --limit 50 --apply
+ *   node scripts/enrichment/fetch-bib-records.mjs --book-id <id> --apply
+ *   node scripts/enrichment/fetch-bib-records.mjs --lang la --limit 200 --apply
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+import {
+  parseMarcXmlRecords,
+  buildBibRecord,
+  projectToCatalogRow,
+} from '../lib/bib-record.mjs';
+import { toSourceIso } from '../lib/translation-catalog-record.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+const DATE = new Date().toISOString().slice(0, 10);
+
+const APPLY = process.argv.includes('--apply');
+const argOf = (flag) => {
+  const i = process.argv.indexOf(flag);
+  return i === -1 ? null : process.argv[i + 1];
+};
+const LIMIT = parseInt(argOf('--limit') ?? '50', 10);
+const BOOK_ID = argOf('--book-id');
+const LANG = argOf('--lang');
+// --stratified N: sample N badged books PER LANGUAGE, restricted to books that
+// carry a real `english_title`. This is the per-tradition coverage measurement:
+// a null result only means something if the query itself was answerable, and a
+// romanized vernacular title ("Thor bu bsKang rgyun gsol kha") is not a query
+// LoC can answer. Without this restriction every non-Latin tradition reports
+// 100% residue and the number measures our metadata, not the reference set.
+const STRATIFIED = argOf('--stratified') ? parseInt(argOf('--stratified'), 10) : null;
+
+// ── Reference set manifest ───────────────────────────────────────────────────
+// A stated boundary is the whole point: the badge asserts absence FROM THIS SET,
+// not absence from the world. Anything rendered to a reader must be able to name
+// what was searched and when.
+const REFERENCE_SET = {
+  version: '1',
+  snapshot_date: DATE,
+  sources: [
+    {
+      id: 'loc',
+      name: 'Library of Congress (SRU gateway, lcdb)',
+      endpoint: 'http://lx2.loc.gov:210/lcdb',
+      record_format: 'marcxml',
+      auth: 'none',
+      coverage: 'US imprint depth; strong post-1900 monographs, thin on continental scholarly translation',
+      known_gaps: [
+        'European scholarly presses (Brill, Brepols) under-represented',
+        'pre-1900 translations inconsistently catalogued',
+        'journal-published translations largely absent',
+      ],
+    },
+  ],
+};
+
+// ── LoC SRU ──────────────────────────────────────────────────────────────────
+
+const SRU_BASE = 'http://lx2.loc.gov:210/lcdb';
+const REQUEST_DELAY_MS = 1100; // be a good citizen; rate limits are the constraint
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** CQL needs doubled double-quotes; strip characters that break the parser. */
+function cqlTerm(s) {
+  return String(s || '')
+    .replace(/["\\]/g, ' ')
+    .replace(/[()=<>]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function sruSearch({ title, author, maximumRecords = 5 }) {
+  const clauses = [];
+  if (title) clauses.push(`bath.title="${cqlTerm(title)}"`);
+  if (author) clauses.push(`bath.author="${cqlTerm(author)}"`);
+  if (!clauses.length) return { xml: null, query: null };
+
+  const query = clauses.join(' and ');
+  const url = `${SRU_BASE}?version=1.1&operation=searchRetrieve`
+    + `&query=${encodeURIComponent(query)}`
+    + `&maximumRecords=${maximumRecords}&recordSchema=marcxml`;
+
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(45_000),
+    headers: { 'User-Agent': 'SourceLibrary/1.0 (+https://sourcelibrary.org; reference-set build)' },
+  });
+  if (!res.ok) throw new Error(`SRU ${res.status} ${res.statusText}`);
+  return { xml: await res.text(), query };
+}
+
+// ── Book → query terms ───────────────────────────────────────────────────────
+
+const GENERIC_AUTHORS = /^(anonymous|anon\.?|unknown|various|various authors|multiple authors|n\/a)$/i;
+
+/**
+ * The author term to search on. "Last, First" → "Last"; a generic/collective
+ * "author" is not an access point and yields pure noise, so we refuse it and
+ * record the book as unqueryable rather than pretending it was checked.
+ */
+function queryAuthor(book) {
+  let a = (book.author || '').trim();
+  if (!a || GENERIC_AUTHORS.test(a)) return '';
+  // Multiple authors separated by ';' — take the first.
+  a = a.split(';')[0].trim();
+  a = a.includes(',') ? a.split(',')[0].trim() : a;
+  // Drop dates and parentheticals that CQL treats as separate terms.
+  a = a.replace(/\([^)]*\)/g, '').replace(/\d{3,4}/g, '').trim();
+  return a.length >= 3 ? a : '';
+}
+
+// ── Local work-identity matching ─────────────────────────────────────────────
+
+const TITLE_STOP = new Set([
+  'the', 'and', 'with', 'from', 'that', 'this', 'for', 'des', 'der', 'die', 'und',
+  'liber', 'libri', 'opus', 'opera', 'book', 'books', 'volume', 'tractatus',
+  'english', 'translation', 'translated', 'works', 'text', 'new', 'notes',
+  'introduction', 'edition', 'edited', 'selected',
+]);
+
+function titleTokens(s) {
+  return (s || '')
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase().replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length >= 4 && !TITLE_STOP.has(t));
+}
+
+/**
+ * Does this MARC record describe the same work as this book?
+ *
+ * Matches the book's ORIGINAL title against the record's MARC 240 uniform title
+ * first — for a translation, 240 carries the original title, which is exactly
+ * the join we need — then falls back to 245. Asymmetric coverage: we ask how
+ * much of the book's title is present in the record's, because a record title
+ * legitimately carries subtitle and apparatus the book's does not.
+ *
+ * Conservative by design: this feeds a residue COUNT and demote CANDIDATES for
+ * human sign-off, never an automatic flag change.
+ */
+export function workIdentityScore(book, bib) {
+  const bookToks = [
+    ...titleTokens(book.title),
+    ...titleTokens(book.work_title),
+  ];
+  if (!bookToks.length) return { score: 0, basis: 'no book title tokens' };
+
+  const candidates = [
+    ['uniform_title(240)', bib.uniform_title],
+    ['title(245)', bib.title],
+  ].filter(([, v]) => v);
+
+  let best = { score: 0, basis: 'no overlap' };
+  for (const [basis, value] of candidates) {
+    const recToks = new Set(titleTokens(value));
+    if (!recToks.size) continue;
+    const uniqBook = [...new Set(bookToks)];
+    const hits = uniqBook.filter((t) => recToks.has(t)).length;
+    const score = hits / uniqBook.length;
+    if (score > best.score) best = { score, basis, matched: hits, of: uniqBook.length };
+  }
+  return best;
+}
+
+const MIN_WORK_IDENTITY = 0.5;
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+await withMongo(async (db) => {
+  const books = db.collection('books');
+  const bibRecords = db.collection('bib_records');
+
+  const PROJECTION = {
+    id: 1, title: 1, english_title: 1, work_title: 1, author: 1,
+    language: 1, original_language: 1, year: 1, work_id: 1,
+    first_translation_status: 1,
+  };
+
+  let cohort;
+  if (STRATIFIED) {
+    // Equal-sized sample per tradition, English-titled only, so per-language
+    // residue rates are comparable to one another.
+    const base = {
+      is_first_translation: true,
+      visible: true,
+      english_title: { $exists: true, $nin: [null, ''] },
+    };
+    const langs = await books.aggregate([
+      { $match: base },
+      { $group: { _id: '$language', n: { $sum: 1 } } },
+      { $sort: { n: -1 } },
+      { $limit: 12 },
+    ]).toArray();
+    cohort = [];
+    for (const { _id: lang } of langs) {
+      const slice = await books.find({ ...base, language: lang }, { projection: PROJECTION })
+        .limit(STRATIFIED).toArray();
+      cohort.push(...slice);
+    }
+  } else {
+    const query = BOOK_ID
+      ? { id: BOOK_ID }
+      : { is_first_translation: true, visible: true, ...(LANG ? { language: LANG } : {}) };
+    cohort = await books.find(query, { projection: PROJECTION })
+      .limit(BOOK_ID ? 1 : LIMIT).toArray();
+  }
+
+  console.log(`Reference set v${REFERENCE_SET.version} (${REFERENCE_SET.snapshot_date})`);
+  console.log(`Sources: ${REFERENCE_SET.sources.map((s) => s.name).join(', ')}`);
+  console.log(`Cohort: ${cohort.length} badged book(s)${LANG ? ` [lang=${LANG}]` : ''}\n`);
+
+  if (APPLY) {
+    await bibRecords.createIndex({ _key: 1 }, { unique: true }).catch(() => {});
+    await bibRecords.createIndex({ 'identifiers.lccn': 1 }).catch(() => {});
+    await bibRecords.createIndex({ work_type: 1, completeness: 1 }).catch(() => {});
+  }
+
+  const perBook = [];
+  const tally = { queried: 0, http_errors: 0, records_seen: 0, records_stored: 0, no_identifier: 0 };
+  const workTypeTally = {};
+  const byTradition = {};
+  let withCompletePrior = 0;
+  let unqueryable = 0;
+
+  // One SRU query per distinct AUTHOR, reused across every book by that author.
+  const authorCache = new Map();
+
+  async function recordsForAuthor(author) {
+    if (authorCache.has(author)) return authorCache.get(author);
+    let result = { bibs: [], sruQuery: null, error: null };
+    try {
+      tally.queried++;
+      const { xml, query: sruQuery } = await sruSearch({ author, maximumRecords: 40 });
+      result.sruQuery = sruQuery;
+      if (xml) {
+        const recs = await parseMarcXmlRecords(xml);
+        tally.records_seen += recs.length;
+        for (const rec of recs) {
+          let bib;
+          try {
+            bib = buildBibRecord({ rec, source: 'loc', rawXml: xml, query: sruQuery });
+          } catch {
+            // A record with no external identifier is exactly what we refuse to
+            // store — an unre-checkable row is how the current registry got stuck.
+            tally.no_identifier++;
+            continue;
+          }
+          workTypeTally[bib.work_type] = (workTypeTally[bib.work_type] || 0) + 1;
+          result.bibs.push(bib);
+        }
+      }
+    } catch (err) {
+      result.error = err.message;
+      tally.http_errors++;
+    }
+    await sleep(REQUEST_DELAY_MS);
+    authorCache.set(author, result);
+    return result;
+  }
+
+  for (const book of cohort) {
+    const author = queryAuthor(book);
+
+    const bookResult = {
+      book_id: book.id,
+      book_title: book.title,
+      query_author: author,
+      queryable: Boolean(author),
+      sru_query: null,
+      error: null,
+      author_records_seen: 0,
+      records: [],
+    };
+
+    if (!author) {
+      // Not "no prior exists" — "we could not ask". Kept distinct in the report:
+      // conflating them is how an unasked question becomes a confident negative.
+      bookResult.skip_reason = 'no usable author access point (anonymous/collective)';
+      perBook.push(bookResult);
+      unqueryable++;
+      process.stdout.write(`  ${book.id} · ${String(book.title).slice(0, 44).padEnd(44)} SKIPPED (no author)\n`);
+      continue;
+    }
+
+    const { bibs, sruQuery, error } = await recordsForAuthor(author);
+    bookResult.sru_query = sruQuery;
+    bookResult.error = error;
+    bookResult.author_records_seen = bibs.length;
+
+    for (const bib of bibs) {
+      const identity = workIdentityScore(book, bib);
+      if (identity.score < MIN_WORK_IDENTITY) continue;
+
+      if (APPLY) {
+        await bibRecords.updateOne(
+          { _key: bib._key },
+          { $set: bib, $addToSet: { seen_for_books: book.id } },
+          { upsert: true },
+        );
+        tally.records_stored++;
+      }
+
+      bookResult.records.push({
+        key: bib._key,
+        title: bib.title,
+        uniform_title: bib.uniform_title,
+        work_identity: identity,
+        work_type: bib.work_type,
+        work_type_evidence: bib.work_type_evidence,
+        completeness: bib.completeness,
+        completeness_evidence: bib.completeness_evidence,
+        item_language: bib.item_language,
+        pub_year: bib.pub_year,
+        original_languages: bib.original_languages,
+        catalog_row: projectToCatalogRow(bib, {
+          sourceLanguageIso: toSourceIso(book.original_language || book.language) ?? undefined,
+        }),
+      });
+    }
+
+    // The residue question, per book: is there a COMPLETE prior ENGLISH
+    // translation? Language matters — a French translation defeats nothing.
+    const priors = bookResult.records.filter(
+      (r) => r.work_type === 'translation'
+        && r.completeness === 'complete'
+        && (!r.item_language || r.item_language.startsWith('eng')),
+    );
+    bookResult.complete_prior_count = priors.length;
+    bookResult.language = book.language ?? 'unknown';
+    if (priors.length) withCompletePrior++;
+
+    // Per-tradition coverage — the measurement that sizes everything else.
+    const lang = bookResult.language;
+    byTradition[lang] ??= { books: 0, queryable: 0, author_hits: 0, work_matches: 0, translation_record: 0, complete_prior: 0 };
+    byTradition[lang].books++;
+    byTradition[lang].queryable++;
+    if (bibs.length) byTradition[lang].author_hits++;
+    if (bookResult.records.length) byTradition[lang].work_matches++;
+    if (bookResult.records.some((r) => r.work_type === 'translation')) byTradition[lang].translation_record++;
+    if (priors.length) byTradition[lang].complete_prior++;
+
+    perBook.push(bookResult);
+    process.stdout.write(
+      `  ${book.id} · ${String(book.title).slice(0, 40).padEnd(40)} `
+      + `auth_recs=${String(bibs.length).padStart(3)} `
+      + `work_match=${String(bookResult.records.length).padStart(2)} `
+      + `priors=${bookResult.complete_prior_count}\n`,
+    );
+  }
+
+  // ── Report ─────────────────────────────────────────────────────────────────
+  const asked = perBook.length - unqueryable;
+  const residue = asked - withCompletePrior;
+  console.log('\n─── Reference-set pass ───────────────────────────────────────');
+  console.log('  author queries issued :', tally.queried, `(http errors: ${tally.http_errors}, distinct authors: ${authorCache.size})`);
+  console.log('  MARC records seen     :', tally.records_seen);
+  console.log('  records stored        :', tally.records_stored, APPLY ? '' : '(dry-run — not written)');
+  console.log('  refused, no identifier:', tally.no_identifier);
+  console.log('  work_type distribution:', workTypeTally);
+
+  console.log('\n─── The residue ──────────────────────────────────────────────');
+  console.log(`  cohort                                          : ${perBook.length}`);
+  console.log(`  UNASKABLE (no author access point)              : ${unqueryable}`);
+  console.log(`  asked                                           : ${asked}`);
+  console.log(`  ...with a COMPLETE English prior in this set    : ${withCompletePrior}`);
+  console.log(`  RESIDUE (asked, nothing found → needs Tier-2)   : ${residue}`);
+  console.log('\n  "Unaskable" is NOT "no prior exists". A book with an anonymous or');
+  console.log('  collective author has no access point in this reference set, so it was');
+  console.log('  never checked — counting it as a clean negative would manufacture');
+  console.log('  exactly the false confidence this whole approach exists to remove.');
+  if (asked) {
+    const pct = ((residue / asked) * 100).toFixed(1);
+    console.log(`\n  residue rate (of asked)                        : ${pct}%`);
+    console.log('  Extrapolated Tier-2 cost at ~58k tokens/book:');
+    console.log(`    this sample          ${(residue * 58_000 / 1e6).toFixed(2)}M tokens`);
+    console.log(`    full public badge set (6,096 books) ≈ ${(6096 * (residue / asked) * 58_000 / 1e6).toFixed(0)}M tokens`);
+    console.log('  NOTE: an extrapolation from a small sample, not a measurement.');
+    console.log('  Any large paid run needs explicit cost sign-off.');
+  }
+
+  console.log('\n─── Coverage per tradition ───────────────────────────────────');
+  console.log('  auth_hit = the author returned ANY record (is the author in this set at all?)');
+  console.log('  work_mat = a returned record resolved to THIS work');
+  console.log('  trans/prior = of those, a translation / a COMPLETE English prior');
+  console.log(`  ${'language'.padEnd(14)} ${'asked'.padStart(5)} ${'auth_hit'.padStart(8)} ${'work_mat'.padStart(8)} ${'trans'.padStart(6)} ${'prior'.padStart(6)}`);
+  const traditionRows = Object.entries(byTradition).sort((a, b) => b[1].books - a[1].books);
+  for (const [lang, s] of traditionRows) {
+    console.log(
+      `  ${String(lang).padEnd(14)} ${String(s.queryable).padStart(5)} ${String(s.author_hits).padStart(8)} `
+      + `${String(s.work_matches).padStart(8)} ${String(s.translation_record).padStart(6)} ${String(s.complete_prior).padStart(6)}`,
+    );
+  }
+  console.log('\n  Read auth_hit FIRST. A tradition where the authors themselves return');
+  console.log('  nothing is a COVERAGE gap in the reference set, not evidence that we are');
+  console.log('  first — and a first-claim there currently rests on no evidence at all.');
+  console.log('  Only where auth_hit is high does a zero in `prior` start to mean something.');
+
+  console.log('\n  Absence here means absence FROM THIS SET, not from the world:');
+  for (const s of REFERENCE_SET.sources) {
+    console.log(`    ${s.name} — gaps: ${s.known_gaps.join('; ')}`);
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const outPath = path.join(OUT_DIR, `bib-records-pass-${DATE}.json`);
+  fs.writeFileSync(outPath, JSON.stringify({
+    reference_set: REFERENCE_SET,
+    applied: APPLY,
+    cohort_size: perBook.length,
+    tally,
+    work_type_distribution: workTypeTally,
+    by_tradition: byTradition,
+    books_with_complete_prior: withCompletePrior,
+    unqueryable,
+    asked,
+    residue,
+    books: perBook,
+  }, null, 2));
+  console.log(`\nWrote ${outPath}`);
+  if (!APPLY) console.log('DRY-RUN — nothing written to bib_records. Re-run with --apply.');
+});

--- a/scripts/enrichment/ingest-loc-bulk.mjs
+++ b/scripts/enrichment/ingest-loc-bulk.mjs
@@ -57,6 +57,7 @@ import fs from 'fs';
 import path from 'path';
 import zlib from 'zlib';
 import readline from 'readline';
+import { spawnSync } from 'child_process';
 import { withMongo } from '../lib/mongo.mjs';
 
 const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
@@ -170,13 +171,48 @@ async function processPart(gzPath, outPath) {
   return { stats, originalLangTally };
 }
 
+/**
+ * Download one part, streaming to disk, with retry and resume.
+ *
+ * Deliberately curl rather than node's fetch: these are ~70MB files over a long
+ * connection, and `fetch` + `arrayBuffer()` buffers the whole part in memory and
+ * dies on any mid-transfer socket close ("TypeError: terminated" /
+ * UND_ERR_SOCKET). Observed failing on the very first part of a 43-part run.
+ * curl streams, resumes a partial file (-C -), and retries transport errors
+ * itself — which matters when a run is 3GB long and unattended.
+ *
+ * The gzip integrity check afterwards is the real guard: a truncated part would
+ * otherwise silently yield fewer records and quietly understate the reference
+ * set, which is the failure mode we can least afford here.
+ */
 async function download(url, dest) {
-  const res = await fetch(url, {
-    signal: AbortSignal.timeout(900_000),
-    headers: { 'User-Agent': 'SourceLibrary/1.0 (+https://sourcelibrary.org; reference-set build)' },
-  });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${url}`);
-  await fs.promises.writeFile(dest, Buffer.from(await res.arrayBuffer()));
+  const MAX_ATTEMPTS = 4;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const res = spawnSync('curl', [
+      '--silent', '--show-error', '--location',
+      '--retry', '5', '--retry-delay', '3', '--retry-all-errors',
+      '--connect-timeout', '30', '--max-time', '1800',
+      '-C', '-', // resume a partial file rather than restarting 70MB
+      '--user-agent', 'SourceLibrary/1.0 (+https://sourcelibrary.org; reference-set build)',
+      '-o', dest, url,
+    ], { encoding: 'utf8' });
+
+    // curl exit 33 = server does not support resume; drop the partial and retry clean.
+    if (res.status === 33) { fs.rmSync(dest, { force: true }); continue; }
+
+    if (res.status === 0) {
+      const check = spawnSync('gzip', ['-t', dest], { encoding: 'utf8' });
+      if (check.status === 0) return;
+      // Truncated or corrupt — discard and retry from scratch.
+      fs.rmSync(dest, { force: true });
+      if (attempt === MAX_ATTEMPTS) throw new Error(`gzip integrity check failed for ${url}`);
+      continue;
+    }
+
+    if (attempt === MAX_ATTEMPTS) {
+      throw new Error(`curl exit ${res.status} for ${url}: ${(res.stderr || '').trim()}`);
+    }
+  }
 }
 
 // ── Main ─────────────────────────────────────────────────────────────────────
@@ -187,6 +223,7 @@ console.log(`LoC MDSConnect ${SNAPSHOT} — ${parts.length} part(s) → ${OUT_DI
 
 const totals = { records: 0, with_041h: 0, english_translations: 0, with_uniform_title: 0, with_lccn: 0 };
 const langTotals = {};
+const failedParts = [];
 
 for (const p of parts) {
   const pp = String(p).padStart(2, '0');
@@ -197,17 +234,28 @@ for (const p of parts) {
     console.log(`  part${pp}  already extracted, skipping`);
     continue;
   }
-  if (!fs.existsSync(gz)) {
-    process.stdout.write(`  part${pp}  downloading…`);
-    await download(`${BASE}.part${pp}.xml.gz`, gz);
-  }
-  process.stdout.write(`  part${pp}  extracting…`);
-  const { stats, originalLangTally } = await processPart(gz, jsonl);
-  if (!KEEP_GZ) fs.unlinkSync(gz);
+  // A 43-part run is ~3GB and unattended. One flaky part must not discard the
+  // 40 that worked — record it and carry on, then report the gap loudly at the
+  // end, because a silently short reference set understates coverage and that
+  // biases every negative it supports.
+  try {
+    if (!fs.existsSync(gz)) {
+      process.stdout.write(`  part${pp}  downloading…`);
+      await download(`${BASE}.part${pp}.xml.gz`, gz);
+    }
+    process.stdout.write(`  part${pp}  extracting…`);
+    const { stats, originalLangTally } = await processPart(gz, jsonl);
+    if (!KEEP_GZ) fs.rmSync(gz, { force: true });
 
-  for (const k of Object.keys(totals)) totals[k] += stats[k];
-  for (const [l, n] of Object.entries(originalLangTally)) langTotals[l] = (langTotals[l] || 0) + n;
-  console.log(` ${stats.records} records → ${stats.english_translations} English translations`);
+    for (const k of Object.keys(totals)) totals[k] += stats[k];
+    for (const [l, n] of Object.entries(originalLangTally)) langTotals[l] = (langTotals[l] || 0) + n;
+    console.log(` ${stats.records} records → ${stats.english_translations} English translations`);
+  } catch (err) {
+    failedParts.push({ part: pp, error: err.message });
+    fs.rmSync(gz, { force: true });
+    fs.rmSync(jsonl, { force: true }); // never leave a half-written extract behind
+    console.log(` FAILED — ${err.message}`);
+  }
 }
 
 console.log('\n─── Reference set ────────────────────────────────────────────');
@@ -228,6 +276,15 @@ for (const [l, n] of topLangs) console.log(`    ${l.padEnd(6)} ${String(n).padSt
 console.log('\n  BOUNDARY: this snapshot ends in 2016. A translation published after');
 console.log('  2016 is absent by construction, not by evidence. Any claim resting on');
 console.log('  this set must say so, and be topped up from the live SRU path.');
+
+const extractedParts = fs.readdirSync(OUT_DIR).filter((f) => /^eng-translations\.part\d+\.jsonl$/.test(f)).length;
+console.log(`\n  parts on disk: ${extractedParts} of 43`);
+if (failedParts.length) {
+  console.log(`\n  ⚠️  ${failedParts.length} PART(S) FAILED — the reference set is INCOMPLETE:`);
+  for (const f of failedParts) console.log(`      part${f.part}: ${f.error}`);
+  console.log('      Re-run the same command; completed parts are skipped.');
+  console.log('      Do NOT quote coverage numbers from this run until they land.');
+}
 
 if (LOAD) {
   console.log('\nLoading into Mongo `reference_translations`…');

--- a/scripts/enrichment/ingest-loc-bulk.mjs
+++ b/scripts/enrichment/ingest-loc-bulk.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * ingest-loc-bulk.mjs — build the reference set from BULK catalogue dumps
+ * instead of per-book API lookups. (#3459, #3455)
+ *
+ * WHY BULK, NOT PER-BOOK
+ * ----------------------
+ * The natural implementation of "does a prior English translation exist?" is a
+ * live catalogue query per book. That shape is the reason this whole area has
+ * been hard to trust:
+ *
+ *   - Every lookup is a fresh, unreproducible act. Re-running it next week can
+ *     legitimately give a different answer, and nothing records why.
+ *   - 6,096 of them cannot be audited. The instrument and the measurement are
+ *     entangled, so a good answer and a bad answer look identical.
+ *   - Rate limits make a full pass take days, so it never actually completes.
+ *   - "We searched and found nothing" is unfalsifiable — a third party cannot
+ *     check it.
+ *
+ * Ingesting the catalogue in BULK inverts all four. The reference set becomes a
+ * fixed, versioned, countable local artifact. A search over it is deterministic,
+ * free, instant, and replayable by anyone with the same snapshot. "Absent from
+ * this set" becomes a checkable claim rather than an assertion.
+ *
+ * THE SOURCE
+ * ----------
+ * LoC MDSConnect "Books All" — the Library of Congress book catalogue published
+ * as 43 gzipped MARC-XML parts, free, no auth, no rate limit.
+ *   https://www.loc.gov/cds/products/MDSConnect-books_all.html
+ *
+ * Measured 2026-07-29 on part01:
+ *   250,000 records  →  3,689 English translations (1.5%)
+ *   100% carry an LCCN          (every row re-checkable)
+ *    66% carry a MARC 240 uniform title  (the work-identity join key)
+ *   ~15s to process one part
+ * Extrapolated over 43 parts: ~10.75M records → ~158,000 English translations.
+ * For comparison, `translation_catalogs` today holds 24,061 rows, ZERO with an
+ * identifier, of which 385 are usable to defeat a claim.
+ *
+ * ⚠️ SNAPSHOT BOUNDARY — this is a **2016** dump. Translations published after
+ * 2016 are NOT in it. That is a stated, bounded gap, not a defect: the whole
+ * point of a reference set is that its edges are known and declared. Top up the
+ * recent tail with the live SRU path in fetch-bib-records.mjs.
+ *
+ * WHAT COUNTS AS AN ENGLISH TRANSLATION
+ * -------------------------------------
+ * MARC `041$h` present (language of the original — a cataloguer's explicit
+ * assertion that this item renders something from another language) AND the
+ * item's own language is English (`041$a` or the 008 language position 35-37).
+ *
+ * Usage:
+ *   node scripts/enrichment/ingest-loc-bulk.mjs --parts 1-43 --out ./loc-bulk
+ *   node scripts/enrichment/ingest-loc-bulk.mjs --parts 1-4 --keep-gz
+ *   node scripts/enrichment/ingest-loc-bulk.mjs --parts 1-43 --load    # → Mongo
+ */
+import fs from 'fs';
+import path from 'path';
+import zlib from 'zlib';
+import readline from 'readline';
+import { withMongo } from '../lib/mongo.mjs';
+
+const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
+const KEEP_GZ = process.argv.includes('--keep-gz');
+const LOAD = process.argv.includes('--load');
+const OUT_DIR = argOf('--out') ?? path.join(process.cwd(), 'scripts', 'output', 'loc-bulk');
+
+const SNAPSHOT = '2016';
+const BASE = `https://www.loc.gov/cds/downloads/MDSConnect/BooksAll.${SNAPSHOT}`;
+
+/** "1-43" | "1,5,9" | "3" → [1,5,...] */
+function parseParts(spec) {
+  if (!spec) return [1];
+  const out = new Set();
+  for (const chunk of spec.split(',')) {
+    const m = chunk.trim().match(/^(\d+)(?:-(\d+))?$/);
+    if (!m) throw new Error(`bad --parts segment "${chunk}"`);
+    const lo = parseInt(m[1], 10);
+    const hi = m[2] ? parseInt(m[2], 10) : lo;
+    for (let i = lo; i <= hi; i++) out.add(i);
+  }
+  return [...out].sort((a, b) => a - b);
+}
+
+// ── Minimal MARC field readers ───────────────────────────────────────────────
+// Deliberately string-based rather than a full XML parse: we touch ~10.7M
+// records and discard 98.5% of them, so a full DOM parse per record is a large
+// cost for data we throw away. The survivors are re-parsed properly by
+// scripts/lib/bib-record.mjs before anything is asserted about them.
+
+function subfieldValues(rec, tag, code) {
+  const out = [];
+  const dfRe = new RegExp(`<datafield tag="${tag}"[^>]*>([\\s\\S]*?)</datafield>`, 'g');
+  let df;
+  while ((df = dfRe.exec(rec))) {
+    const sfRe = new RegExp(`<subfield code="${code}">([\\s\\S]*?)</subfield>`, 'g');
+    let sf;
+    while ((sf = sfRe.exec(df[1]))) out.push(sf[1].trim());
+  }
+  return out;
+}
+const controlField = (rec, tag) =>
+  (rec.match(new RegExp(`<controlfield tag="${tag}">([^<]*)</controlfield>`)) || [])[1] || '';
+
+const decode = (s) => (s || '')
+  .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+  .replace(/&quot;/g, '"').replace(/&apos;/g, "'");
+
+/** Extract the reference-set row, or null if this record is not an English translation. */
+export function extractEnglishTranslation(rec) {
+  if (!rec.includes('tag="041"')) return null;
+  const originalLangs = subfieldValues(rec, '041', 'h');
+  if (!originalLangs.length) return null;
+
+  const f008 = controlField(rec, '008');
+  const itemLang = (subfieldValues(rec, '041', 'a')[0] || f008.slice(35, 38) || '').toLowerCase().trim();
+  if (!itemLang.startsWith('eng')) return null;
+
+  const year = ((subfieldValues(rec, '264', 'c')[0]
+    || subfieldValues(rec, '260', 'c')[0]
+    || f008.slice(7, 11)).match(/(\d{4})/) || [])[1] || '';
+
+  return {
+    lccn: (subfieldValues(rec, '010', 'a')[0] || '').replace(/\s+/g, ''),
+    author: decode(subfieldValues(rec, '100', 'a')[0] || subfieldValues(rec, '110', 'a')[0] || ''),
+    added_entries: subfieldValues(rec, '700', 'a').map(decode),
+    uniform_title: decode(subfieldValues(rec, '240', 'a')[0] || ''),
+    title: decode(subfieldValues(rec, '245', 'a')[0] || ''),
+    subtitle: decode(subfieldValues(rec, '245', 'b')[0] || ''),
+    year,
+    extent: decode(subfieldValues(rec, '300', 'a')[0] || ''),
+    publisher: decode(subfieldValues(rec, '264', 'b')[0] || subfieldValues(rec, '260', 'b')[0] || ''),
+    original_languages: originalLangs,
+    item_language: itemLang,
+    subjects: subfieldValues(rec, '650', 'a').concat(subfieldValues(rec, '600', 'a')).map(decode).slice(0, 8),
+    source: 'loc_mdsconnect',
+    snapshot: SNAPSHOT,
+  };
+}
+
+/** Stream one gzipped MARC-XML part, writing matching rows as JSONL. */
+async function processPart(gzPath, outPath) {
+  const out = fs.createWriteStream(outPath);
+  const rl = readline.createInterface({
+    input: fs.createReadStream(gzPath).pipe(zlib.createGunzip()),
+    crlfDelay: Infinity,
+  });
+
+  let buf = '';
+  const stats = { records: 0, with_041h: 0, english_translations: 0, with_uniform_title: 0, with_lccn: 0 };
+  const originalLangTally = {};
+
+  for await (const line of rl) {
+    buf += line + '\n';
+    if (!line.includes('</record>')) continue;
+    const rec = buf;
+    buf = '';
+    stats.records++;
+
+    if (rec.includes('tag="041"') && subfieldValues(rec, '041', 'h').length) stats.with_041h++;
+    const row = extractEnglishTranslation(rec);
+    if (!row) continue;
+
+    stats.english_translations++;
+    if (row.uniform_title) stats.with_uniform_title++;
+    if (row.lccn) stats.with_lccn++;
+    for (const l of row.original_languages) originalLangTally[l] = (originalLangTally[l] || 0) + 1;
+    out.write(JSON.stringify(row) + '\n');
+  }
+  await new Promise((res) => out.end(res));
+  return { stats, originalLangTally };
+}
+
+async function download(url, dest) {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(900_000),
+    headers: { 'User-Agent': 'SourceLibrary/1.0 (+https://sourcelibrary.org; reference-set build)' },
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${url}`);
+  await fs.promises.writeFile(dest, Buffer.from(await res.arrayBuffer()));
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const parts = parseParts(argOf('--parts'));
+fs.mkdirSync(OUT_DIR, { recursive: true });
+console.log(`LoC MDSConnect ${SNAPSHOT} — ${parts.length} part(s) → ${OUT_DIR}\n`);
+
+const totals = { records: 0, with_041h: 0, english_translations: 0, with_uniform_title: 0, with_lccn: 0 };
+const langTotals = {};
+
+for (const p of parts) {
+  const pp = String(p).padStart(2, '0');
+  const gz = path.join(OUT_DIR, `BooksAll.${SNAPSHOT}.part${pp}.xml.gz`);
+  const jsonl = path.join(OUT_DIR, `eng-translations.part${pp}.jsonl`);
+
+  if (fs.existsSync(jsonl)) {
+    console.log(`  part${pp}  already extracted, skipping`);
+    continue;
+  }
+  if (!fs.existsSync(gz)) {
+    process.stdout.write(`  part${pp}  downloading…`);
+    await download(`${BASE}.part${pp}.xml.gz`, gz);
+  }
+  process.stdout.write(`  part${pp}  extracting…`);
+  const { stats, originalLangTally } = await processPart(gz, jsonl);
+  if (!KEEP_GZ) fs.unlinkSync(gz);
+
+  for (const k of Object.keys(totals)) totals[k] += stats[k];
+  for (const [l, n] of Object.entries(originalLangTally)) langTotals[l] = (langTotals[l] || 0) + n;
+  console.log(` ${stats.records} records → ${stats.english_translations} English translations`);
+}
+
+console.log('\n─── Reference set ────────────────────────────────────────────');
+console.log('  source                :', `LoC MDSConnect Books-All, snapshot ${SNAPSHOT}`);
+console.log('  parts ingested        :', parts.length, `of 43`);
+console.log('  MARC records scanned  :', totals.records.toLocaleString());
+console.log('  with 041$h (any translation):', totals.with_041h.toLocaleString());
+console.log('  ENGLISH translations  :', totals.english_translations.toLocaleString());
+console.log('  ...with an LCCN       :', totals.with_lccn.toLocaleString(),
+  totals.english_translations ? `(${((totals.with_lccn / totals.english_translations) * 100).toFixed(1)}%)` : '');
+console.log('  ...with a 240 uniform title:', totals.with_uniform_title.toLocaleString(),
+  totals.english_translations ? `(${((totals.with_uniform_title / totals.english_translations) * 100).toFixed(1)}%)` : '');
+
+const topLangs = Object.entries(langTotals).sort((a, b) => b[1] - a[1]).slice(0, 30);
+console.log('\n  original languages (top 30):');
+for (const [l, n] of topLangs) console.log(`    ${l.padEnd(6)} ${String(n).padStart(6)}`);
+
+console.log('\n  BOUNDARY: this snapshot ends in 2016. A translation published after');
+console.log('  2016 is absent by construction, not by evidence. Any claim resting on');
+console.log('  this set must say so, and be topped up from the live SRU path.');
+
+if (LOAD) {
+  console.log('\nLoading into Mongo `reference_translations`…');
+  await withMongo(async (db) => {
+    const coll = db.collection('reference_translations');
+    await coll.createIndex({ lccn: 1 }, { unique: true, sparse: true });
+    await coll.createIndex({ author_surname: 1 });
+    await coll.createIndex({ original_languages: 1 });
+    let loaded = 0;
+    for (const f of fs.readdirSync(OUT_DIR).filter((f) => f.endsWith('.jsonl'))) {
+      const rl = readline.createInterface({
+        input: fs.createReadStream(path.join(OUT_DIR, f)), crlfDelay: Infinity,
+      });
+      let batch = [];
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        const row = JSON.parse(line);
+        batch.push({
+          updateOne: {
+            filter: { lccn: row.lccn || `nolccn:${row.title}:${row.year}` },
+            update: { $set: row },
+            upsert: true,
+          },
+        });
+        if (batch.length >= 1000) { await coll.bulkWrite(batch, { ordered: false }); loaded += batch.length; batch = []; }
+      }
+      if (batch.length) { await coll.bulkWrite(batch, { ordered: false }); loaded += batch.length; }
+      console.log(`  ${f} → running total ${loaded}`);
+    }
+    console.log(`Loaded ${loaded} rows into reference_translations.`);
+  });
+}

--- a/scripts/enrichment/ingest-loc-bulk.mjs
+++ b/scripts/enrichment/ingest-loc-bulk.mjs
@@ -106,6 +106,46 @@ const decode = (s) => (s || '')
   .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
   .replace(/&quot;/g, '"').replace(/&apos;/g, "'");
 
+/**
+ * Extract MARC 880 — the ORIGINAL-SCRIPT form of a field.
+ *
+ * This is the only workable access point for CJK works, and it took a failed
+ * attempt to establish why. Romanized matching cannot work here:
+ *   - LoC mixes schemes (pinyin "Dao de jing" and Wade-Giles "Li Chao-ji po shih")
+ *   - pinyin is syllable-SEPARATED while our titles use joined forms
+ *     ("Huangji Jingshi Shu" vs "Huang ji jing shi shu")
+ *   - most pinyin syllables are under the 4-character token floor
+ * Concatenating and substring-matching to work around all that produced almost
+ * pure noise — 38 matches of which ~2 were real, because romanized Chinese is a
+ * dense syllable soup where short keys collide by accident ("mingshi" sits inside
+ * "zhiwumingshitukao", matching a herbal to the *Ming History*).
+ *
+ * The original script has none of those problems: Han characters are morphemes,
+ * so a shared run of them is strong evidence, and there is exactly one spelling.
+ *
+ * `$6` links each 880 back to the field it duplicates ("245-02/$1" → tag 245), so
+ * the vernacular uniform title and display title are recoverable separately.
+ */
+function extractVernacular(rec) {
+  const out = {};
+  const dfRe = /<datafield tag="880"[^>]*>([\s\S]*?)<\/datafield>/g;
+  let df;
+  while ((df = dfRe.exec(rec))) {
+    const subs = [...df[1].matchAll(/<subfield code="(\w)">([\s\S]*?)<\/subfield>/g)]
+      .map((m) => ({ code: m[1], value: decode(m[2].trim()) }));
+    const link = subs.find((s) => s.code === '6')?.value ?? '';
+    const linkedTag = link.slice(0, 3);
+    if (linkedTag !== '240' && linkedTag !== '245') continue;
+    const text = subs.filter((s) => s.code === 'a' || s.code === 'b')
+      .map((s) => s.value).join(' ')
+      .replace(/\s+/g, ' ').replace(/\s*[\/:;,.]\s*$/, '').trim();
+    if (!text) continue;
+    if (linkedTag === '240') out.vernacular_uniform_title = text;
+    else if (!out.vernacular_title) out.vernacular_title = text;
+  }
+  return out;
+}
+
 /** Extract the reference-set row, or null if this record is not an English translation. */
 export function extractEnglishTranslation(rec) {
   if (!rec.includes('tag="041"')) return null;
@@ -121,6 +161,7 @@ export function extractEnglishTranslation(rec) {
     || f008.slice(7, 11)).match(/(\d{4})/) || [])[1] || '';
 
   return {
+    ...extractVernacular(rec),
     lccn: (subfieldValues(rec, '010', 'a')[0] || '').replace(/\s+/g, ''),
     author: decode(subfieldValues(rec, '100', 'a')[0] || subfieldValues(rec, '110', 'a')[0] || ''),
     added_entries: subfieldValues(rec, '700', 'a').map(decode),

--- a/scripts/enrichment/ingest-wikidata-translations.mjs
+++ b/scripts/enrichment/ingest-wikidata-translations.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * ingest-wikidata-translations.mjs — a SECOND reference-set source. (#3459)
+ *
+ * WHY A SECOND SOURCE AT ALL
+ * --------------------------
+ * The asymmetry that governs this whole area: presence in one catalogue proves a
+ * translation exists; absence from one proves nothing. Our dangerous claim is the
+ * negative one, so it needs breadth that a single catalogue cannot provide.
+ * Wikidata is free, has no rate limit worth worrying about at this scale, and is
+ * independently curated from LoC — so a hit here is genuine corroboration.
+ *
+ * WHAT IT DOES *NOT* FIX — measured 2026-07-30, before building
+ * -------------------------------------------------------------
+ * Wikidata was proposed (by me) as the fix for the CJK and Tibetan gaps that LoC
+ * structurally cannot answer. It is not. Counting English editions linked by
+ * `P629` (edition or translation of) to a work in each language:
+ *
+ *     Tibetan            0        (119 Tibetan works exist in Wikidata)
+ *     Classical Chinese  0        (0 works carry that language tag)
+ *     Syriac             0
+ *     Sanskrit          29        (against 4,493 Sanskrit works)
+ *     Chinese           48
+ *     Japanese         974
+ *
+ * The translations exist in the world; nobody has modelled them in Wikidata. The
+ * `edition or translation of` relation is essentially unpopulated outside Western
+ * literature. So this source adds real depth for Ancient Greek (1,490), Japanese
+ * (974) and Latin (728), and nothing at all where we most need it.
+ *
+ * The honest structural conclusion is that there is no single reference set. Each
+ * tradition needs its own — 84000 and BDRC for Tibetan, CBETA/ctext for Chinese,
+ * GRETIL for Sanskrit — and the traditions we have been most confident about are
+ * the ones with the least available. That is a finding about our claims, not just
+ * about our tooling.
+ *
+ * SHAPE NOTE: Welsh is 4,037 of the 13,453 rows (30%), from a bulk import. It is
+ * irrelevant to this corpus but harmless — it simply never matches.
+ *
+ * Usage:
+ *   node scripts/enrichment/ingest-wikidata-translations.mjs --out <dir>
+ */
+import fs from 'fs';
+import path from 'path';
+
+const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
+const OUT_DIR = argOf('--out') ?? path.join(process.cwd(), 'scripts', 'output', 'wikidata');
+const SNAPSHOT = new Date().toISOString().slice(0, 10);
+
+const ENDPOINT = 'https://query.wikidata.org/sparql';
+const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; reference-set build)';
+
+/**
+ * Native-script labels are the point of including Wikidata at all: they are the
+ * one place a work carries its title in its own script alongside an English
+ * edition link. Request them explicitly rather than relying on the label service,
+ * which only serves one language at a time.
+ */
+const NATIVE_LANGS = ['zh', 'ja', 'ko', 'bo', 'sa', 'ar', 'he', 'fa', 'hy', 'syc', 'grc', 'el', 'ta'];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * WDQS returns a transient 502/429 under load often enough that a single-attempt
+ * fetch silently drops whole languages: the first run lost 9 of them, including
+ * Italian and Armenian, and reported a slice that looked complete apart from a
+ * warning. Retry with backoff, and let the caller record anything that still
+ * fails so an incomplete slice is never mistaken for a thin one.
+ */
+async function sparql(query, attempts = 4) {
+  let lastErr;
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      const res = await fetch(`${ENDPOINT}?query=${encodeURIComponent(query)}`, {
+        headers: { Accept: 'application/sparql-results+json', 'User-Agent': UA },
+        signal: AbortSignal.timeout(180_000),
+      });
+      if (res.status === 429 || res.status >= 500) throw new Error(`SPARQL ${res.status} ${res.statusText}`);
+      if (!res.ok) throw new Error(`SPARQL ${res.status} ${res.statusText}`);
+      return (await res.json()).results.bindings;
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts) await sleep(2000 * i * i);
+    }
+  }
+  throw lastErr;
+}
+
+const qid = (uri) => (uri || '').split('/').pop();
+
+/**
+ * Chunked by original language. A single query for all 13,453 rows with optional
+ * author/translator/date joins reliably exceeds the 60s WDQS timeout; per-language
+ * it comfortably fits, and a failure costs one language rather than the run.
+ */
+async function fetchLanguageIndex() {
+  const rows = await sparql(`
+    SELECT ?ol ?olLabel (COUNT(*) AS ?n) WHERE {
+      ?ed wdt:P629 ?w . ?ed wdt:P407 wd:Q1860 .
+      ?w wdt:P407 ?ol . FILTER(?ol != wd:Q1860)
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
+    } GROUP BY ?ol ?olLabel ORDER BY DESC(?n)`);
+  return rows.map((r) => ({
+    qid: qid(r.ol.value),
+    label: r.olLabel?.value ?? '',
+    count: parseInt(r.n.value, 10),
+  }));
+}
+
+async function fetchForLanguage(langQid) {
+  const nativeOptionals = NATIVE_LANGS
+    .map((l) => `OPTIONAL { ?w rdfs:label ?nat_${l.replace('-', '_')} . FILTER(LANG(?nat_${l.replace('-', '_')}) = "${l}") }`)
+    .join('\n      ');
+
+  const rows = await sparql(`
+    SELECT ?ed ?edLabel ?w ?wLabel ?date ?authorLabel ?translatorLabel
+           ${NATIVE_LANGS.map((l) => `?nat_${l.replace('-', '_')}`).join(' ')} WHERE {
+      ?ed wdt:P629 ?w .
+      ?ed wdt:P407 wd:Q1860 .
+      ?w  wdt:P407 wd:${langQid} .
+      OPTIONAL { ?ed wdt:P577 ?date }
+      OPTIONAL { ?w  wdt:P50  ?author }
+      OPTIONAL { ?ed wdt:P655 ?translator }
+      ${nativeOptionals}
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
+    }`);
+
+  return rows.map((r) => {
+    const native = {};
+    for (const l of NATIVE_LANGS) {
+      const v = r[`nat_${l.replace('-', '_')}`]?.value;
+      if (v) native[l] = v;
+    }
+    const year = r.date?.value ? (r.date.value.match(/(-?\d{4})/) || [])[1] : '';
+    return {
+      // Mirrors the LoC row shape so both sources feed one matcher.
+      lccn: '',                                  // Wikidata rows carry no LCCN
+      wikidata_edition: qid(r.ed.value),
+      wikidata_work: qid(r.w.value),
+      author: r.authorLabel?.value ?? '',
+      added_entries: r.translatorLabel?.value ? [r.translatorLabel.value] : [],
+      uniform_title: r.wLabel?.value ?? '',      // the WORK's title = the join key
+      title: r.edLabel?.value ?? '',             // the English edition's title
+      subtitle: '',
+      year: year || '',
+      extent: '',
+      publisher: '',
+      original_languages: [],                    // filled by the caller
+      item_language: 'eng',
+      subjects: [],
+      // Native-script titles — the reason this source is worth having.
+      vernacular_uniform_title: native.zh || native.ja || native.ko || native.bo
+        || native.sa || native.ar || native.he || native.grc || native.el || '',
+      native_labels: native,
+      source: 'wikidata',
+      snapshot: SNAPSHOT,
+    };
+  });
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+fs.mkdirSync(OUT_DIR, { recursive: true });
+console.log(`Wikidata — English editions of non-English works (snapshot ${SNAPSHOT})\n`);
+
+const langs = await fetchLanguageIndex();
+const total = langs.reduce((n, l) => n + l.count, 0);
+console.log(`${langs.length} source languages, ${total.toLocaleString()} edition links\n`);
+
+const out = fs.createWriteStream(path.join(OUT_DIR, `wikidata-translations.${SNAPSHOT}.jsonl`));
+const failed = [];
+let written = 0;
+let withNative = 0;
+
+for (const lang of langs) {
+  if (lang.count < 3) continue; // long tail of singletons is not worth a request
+  process.stdout.write(`  ${String(lang.label || lang.qid).padEnd(22)} ${String(lang.count).padStart(5)} …`);
+  try {
+    const rows = await fetchForLanguage(lang.qid);
+    for (const row of rows) {
+      row.original_languages = [lang.qid];
+      row.original_language_label = lang.label;
+      if (row.vernacular_uniform_title) withNative++;
+      out.write(`${JSON.stringify(row)}\n`);
+      written++;
+    }
+    console.log(` ${rows.length} rows`);
+  } catch (err) {
+    failed.push({ lang: lang.label, error: err.message });
+    console.log(` FAILED — ${err.message}`);
+  }
+}
+await new Promise((r) => out.end(r));
+
+console.log('\n─── Wikidata reference-set slice ─────────────────────────────');
+console.log('  rows written           :', written.toLocaleString());
+console.log('  with a native-script title:', withNative.toLocaleString(),
+  written ? `(${((withNative / written) * 100).toFixed(1)}%)` : '');
+console.log('  languages fetched      :', langs.filter((l) => l.count >= 3).length - failed.length);
+if (failed.length) {
+  console.log(`\n  ⚠️  ${failed.length} language(s) FAILED — this slice is incomplete:`);
+  for (const f of failed) console.log(`      ${f.lang}: ${f.error}`);
+}
+console.log('\n  KNOWN SHAPE: Welsh is ~30% of all rows (a bulk import) and simply never');
+console.log('  matches this corpus. Tibetan, Classical Chinese and Syriac return ZERO —');
+console.log('  the edition-of relation is unpopulated outside Western literature, so this');
+console.log('  source does NOT close the gaps LoC leaves. It adds depth for Ancient Greek,');
+console.log('  Japanese and Latin, and corroboration breadth everywhere.');
+console.log(`\nWrote ${path.join(OUT_DIR, `wikidata-translations.${SNAPSHOT}.jsonl`)}`);

--- a/scripts/eval/ft-catalog-match.mjs
+++ b/scripts/eval/ft-catalog-match.mjs
@@ -68,6 +68,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { withMongo } from '../lib/mongo.mjs';
 import { appendAttempt } from '../lib/ft-attempt-log.mjs';
+import { toSourceIso } from '../lib/translation-catalog-record.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(__dirname, '..', 'output');
@@ -217,50 +218,26 @@ function extractSurname(author) {
 // ── Source-language normalisation ──────────────────────────────────────────────
 // The catalog was originally entirely `source_language: 'la'`; #2899 adds
 // non-Latin catalogs (Hebrew/Aramaic via Sefaria, Sanskrit/Pali/etc. via Sacred
-// Books of the East, …). Map both the book's surface/original language AND any
-// ISO code that may already appear in the data to the same bucket so guard (c)
-// compares like with like. Keys are matched after `normalise()` (lowercased,
-// punctuation-stripped). Keep in sync with KNOWN_SOURCE_LANGUAGES in
-// scripts/lib/translation-catalog-record.mjs.
-
-const LANG_TO_ISO = {
-  // Latin
-  latin: 'la', 'latin-german': 'la', la: 'la',
-  // Greek
-  greek: 'grc', 'ancient greek': 'grc', 'classical greek': 'grc', grc: 'grc',
-  // modern European (parity with existing rows)
-  german: 'de', de: 'de', dutch: 'nl', nl: 'nl', french: 'fr', fr: 'fr',
-  italian: 'it', it: 'it', spanish: 'es', es: 'es',
-  // Hebrew / Aramaic
-  hebrew: 'he', 'biblical hebrew': 'he', 'mishnaic hebrew': 'he', he: 'he',
-  aramaic: 'arc', 'jewish aramaic': 'arc', 'imperial aramaic': 'arc', arc: 'arc',
-  // Arabic / Persian
-  arabic: 'ar', ar: 'ar', persian: 'fa', fa: 'fa', avestan: 'ave', ave: 'ave',
-  // South Asian
-  sanskrit: 'sa', sa: 'sa', san: 'sa', pali: 'pli', pli: 'pli', pi: 'pli', tamil: 'ta', ta: 'ta',
-  // Tibetan
-  tibetan: 'bo', bo: 'bo',
-  // Chinese (all classical/literary variants collapse to one bucket) + CJK
-  chinese: 'zh', 'classical chinese': 'zh', 'literary chinese': 'zh', 'old chinese': 'zh',
-  zh: 'zh', lzh: 'zh', zho: 'zh',
-  japanese: 'ja', ja: 'ja', korean: 'ko', ko: 'ko',
-  // Ancient Near East
-  syriac: 'syc', syc: 'syc', armenian: 'hy', hy: 'hy',
-  akkadian: 'akk', akk: 'akk', sumerian: 'sux', sux: 'sux', egyptian: 'egy', egy: 'egy',
-};
+// Books of the East, …). Guard (c) can only compare like with like if BOTH the
+// book's language and the catalog row's `source_language` are resolved to the
+// same ISO bucket.
+//
+// #3460: this file used to own a private LANG_TO_ISO table and apply it to the
+// BOOK side only, comparing the result against the raw catalog string. Any row
+// written with a display name ("Sanskrit", "Greek") therefore failed the guard
+// against every book — silently disabling all 305 hand-verified
+// `claude_subagent_verify` rows, which carry 213 of the catalogue's 385
+// `completeness: 'complete'` rows. The mapping now lives in
+// scripts/lib/translation-catalog-record.mjs as the single source of truth and
+// is applied to both sides.
 
 function bookSourceIso(book) {
   // prefer original_language when present; else the surface language
-  const ol = normalise(book.original_language || '');
-  const l = normalise(book.language || '');
-  for (const key of [ol, l]) {
-    if (!key) continue;
-    if (LANG_TO_ISO[key]) return LANG_TO_ISO[key];
-    // handle compound like "latin-german" → first segment
-    const first = key.split(/[-\/, ]/)[0];
-    if (LANG_TO_ISO[first]) return LANG_TO_ISO[first];
+  for (const raw of [book.original_language, book.language]) {
+    const iso = toSourceIso(raw);
+    if (iso) return iso;
   }
-  return l || ol || 'unknown';
+  return normalise(book.language || '') || normalise(book.original_language || '') || 'unknown';
 }
 
 // ── Guards ─────────────────────────────────────────────────────────────────────
@@ -298,7 +275,9 @@ function guardComplete(row) {
 /** (c) Source-language guard. Pass only when the catalog source matches the book's. */
 function guardSourceLang(book, row) {
   const bookIso = bookSourceIso(book);
-  const catIso = normalise(row.source_language || '');
+  // Resolve the catalog side through the SAME map as the book side. Comparing a
+  // resolved bucket against a raw display name is what made 305 rows inert.
+  const catIso = toSourceIso(row.source_language) || normalise(row.source_language || '');
   if (!catIso) return { pass: false, reason: 'catalog row has no source_language' };
   if (bookIso === 'unknown') return { pass: false, reason: `book source-language unknown (lang="${book.language}")` };
   if (bookIso === catIso) return { pass: true, reason: `source_language match (${catIso})` };

--- a/scripts/eval/ft-reference-set-recall.mjs
+++ b/scripts/eval/ft-reference-set-recall.mjs
@@ -2,64 +2,148 @@
 /**
  * ft-reference-set-recall.mjs — how much is a `none_found` actually worth? (#3459)
  *
- * The whole design rests on asserting absence against a stated reference set. That
- * is only honest if we know the set's RECALL — how often it finds a translation
- * that genuinely exists. Until this script there was no such measurement, and
- * every `none_found` was being reported as though the set were complete.
+ * The whole design rests on asserting absence against a stated reference set.
+ * That is only honest if we know the set's RECALL — how often it finds a
+ * translation that genuinely exists. Until this script there was no such
+ * measurement, and every `none_found` was reported as though the set were
+ * complete.
  *
- * `translation_classification` (9,908 rows, built Feb-Jul 2026) is an independent
+ * `translation_classification` (9,908 rows, built Feb–Jul 2026) is an independent
  * answer to the same question, with NAMED translators — Peterson's *Arbatel*,
- * Goold's Loeb *Astronomica*, Bram's *Ancient Astrology*, Rayudu's Sanskrit
- * editions. Books it marks `previously_translated` are known positives, so they
- * are a ready-made recall test set.
+ * Goold's Loeb *Astronomica*, Manzalaoui's *Secretum Secretorum*. Books it marks
+ * `previously_translated` are known positives, so they are a ready-made test set.
  *
- * MEASURED 2026-07-31, and it is the most important number in this project:
+ * THE CIRCULARITY, AND WHY THIS SCRIPT REPORTS TWO NUMBERS
+ * -------------------------------------------------------
+ * `translation_classification` is now also a SOURCE in the reference set, which
+ * was the single highest-value recall fix available. But it is the yardstick as
+ * well, and a yardstick built into the thing it measures reads 100% by
+ * construction — it would say the search finds every prior it was handed the
+ * answer to. That number is worthless and must never be quoted.
  *
- *     known previously-translated books the search examined : 607
- *     search surfaced a candidate                           : 132
- *     search reported none_found                            : 469
- *     RECALL                                                : 22.0%
+ * So the honest measure is CATALOGUE-ONLY recall: re-derive each verdict from the
+ * candidates that came from LoC and Wikidata alone, and ask how often those
+ * catalogues independently surface a prior we know exists. That is directly
+ * comparable to the 22.0% baseline of 2026-07-31 and is the number that moves
+ * when the matcher genuinely improves.
  *
- * Four out of five known prior translations are invisible to the reference set.
- * The causes are already declared on it — 35.2% of LoC rows carry no MARC 240 and
- * cannot produce a confirmed match; scholarly editions printing a text with its
- * translation often carry no 041 and are excluded at extraction; Loeb, Kessinger
- * and small scholarly presses are thinly covered.
+ * The combined figure is still worth printing, because it is what an effort
+ * actually says about a book today — but it measures COVERAGE (do we hold any
+ * evidence at all), not recall (can the catalogues find evidence on their own).
+ * Reporting one as the other is the mistake in the name of a metric being a claim
+ * about its denominator.
  *
- * CONSEQUENCES, stated plainly:
- *   - `none_found` is weak evidence, not strong. Any count built on it — including
- *     the inverse search's "works we translated and never claimed" — is inflated
- *     several-fold and must not be quoted.
- *   - The 42 verified demotes are UNAFFECTED. They are positive findings, each
- *     re-fetched live from LoC; poor recall cannot manufacture a false positive.
- *   - `translation_classification` should be a SOURCE in the reference set, not
- *     merely a yardstick. It already holds 2,231 known priors with attribution.
+ * MEASURED 2026-08-01, over the 607 known-prior books both cohorts examined:
  *
- * PROCESS NOTE: this dataset existed in the database the whole time and was not
- * checked before a reference set was built from scratch. Look for prior work
- * first.
+ *     catalogue-only, all bases        162 surfaced / 439 none_found   27.0%
+ *     catalogue-only, no 245 confirm   133 surfaced / 468 none_found   22.1%   (the old ceiling)
+ *     LoC alone                        155 surfaced / 446 none_found   25.8%
+ *     Wikidata alone                    46 surfaced / 555 none_found    7.7%
+ *     combined, incl. classification   607 surfaced /   0 none_found  100.0%   (CIRCULAR — not recall)
+ *
+ * So the whole of the 22% → 27% movement came from letting the 245 display title
+ * confirm under author corroboration, i.e. from the 240 ceiling. Adding
+ * `translation_classification` did not raise recall at all and could not: it is a
+ * join on our own book and work ids, so it resolves the 607 books we already had
+ * an answer for and reaches nothing beyond them. It is worth having — those books
+ * now carry their prior instead of a false clean negative — but it is COVERAGE.
+ *
+ * Three of every four known prior translations are still invisible to the
+ * catalogues. `none_found` remains weak evidence and no count built on it should
+ * be quoted.
  *
  * Usage:
  *   set -a; source .env.production.local; set +a
- *   node scripts/eval/ft-reference-set-recall.mjs
+ *   node scripts/eval/ft-reference-set-recall.mjs [--date 2026-08-01]
  */
-import { withMongo } from '/Users/dereklomas/sourcelibrary/.claude/worktrees/feat-bib-records/scripts/lib/mongo.mjs';
-const load=f=>JSON.parse(fs.readFileSync(f,'utf8')).efforts;
-const eff=[...load('/Users/dereklomas/sourcelibrary/.claude/worktrees/feat-bib-records/scripts/output/ft-reference-set-search-inverse-2026-07-31.json'),
-           ...load('/Users/dereklomas/sourcelibrary/.claude/worktrees/feat-bib-records/scripts/output/ft-reference-set-search-badged-2026-07-31.json')];
-const verdict=new Map(eff.map(e=>[e.book_id,e.verdict]));
-await withMongo(async db=>{
-  const tc=db.collection('translation_classification');
-  const known=await tc.find({classification:'previously_translated'},{projection:{book_id:1,title:1,known_translation:1}}).toArray();
-  console.log('books INDEPENDENTLY classified previously_translated: '+known.length);
-  const checked=known.filter(k=>verdict.has(k.book_id));
-  console.log('  ...that my search also examined: '+checked.length);
-  const t={}; for(const k of checked) t[verdict.get(k.book_id)]=(t[verdict.get(k.book_id)]||0)+1;
-  console.log('  my verdicts on them:', JSON.stringify(t));
-  const found=(t.prior_found||0)+(t.only_partial_found||0)+(t.inconclusive||0);
-  const missed=t.none_found||0;
-  console.log('\n  RECALL of the reference set on known prior translations:');
-  console.log('    surfaced a candidate : '+found);
-  console.log('    reported none_found  : '+missed+'   <- FALSE NEGATIVES');
-  if(found+missed) console.log('    recall               : '+((found/(found+missed))*100).toFixed(1)+'%');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+import { deriveVerdict, VERDICT } from '../lib/search-effort.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+
+const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
+
+/**
+ * Newest run per cohort. Reading a stale file would compare a fresh matcher
+ * against an old one's verdicts and report the difference as recall.
+ */
+function latestRun(cohort) {
+  const explicit = argOf('--date');
+  const files = fs.readdirSync(OUT_DIR)
+    .filter((f) => new RegExp(`^ft-reference-set-search-${cohort}-\\d{4}-\\d{2}-\\d{2}\\.json$`).test(f))
+    .filter((f) => !explicit || f.includes(explicit))
+    .sort();
+  if (!files.length) throw new Error(`no ${cohort} run found in ${OUT_DIR} — run ft-reference-set-search.mjs --cohort ${cohort}`);
+  return path.join(OUT_DIR, files[files.length - 1]);
+}
+
+const CATALOGUE_SOURCES = new Set(['loc_mdsconnect', 'wikidata']);
+
+const runs = ['inverse', 'badged'].map((c) => ({ cohort: c, file: latestRun(c) }));
+for (const r of runs) console.log(`  ${r.cohort.padEnd(8)} ${path.basename(r.file)}`);
+
+const efforts = runs.flatMap((r) => JSON.parse(fs.readFileSync(r.file, 'utf8')).efforts);
+const byBook = new Map(efforts.map((e) => [e.book_id, e]));
+
+/** Verdict using only candidates from the named sources. */
+const verdictFrom = (effort, keep) => deriveVerdict({
+  candidates: effort.candidates.filter((c) => keep(c)),
+  searchable: effort.searchable,
+});
+
+/** A verdict that surfaced something — anything other than a clean negative. */
+const SURFACED = new Set([VERDICT.PRIOR_FOUND, VERDICT.ONLY_PARTIAL_FOUND, VERDICT.INCONCLUSIVE]);
+
+await withMongo(async (db) => {
+  const known = await db.collection('translation_classification')
+    .find({ classification: 'previously_translated' },
+      { projection: { book_id: 1, title: 1, known_translation: 1 } })
+    .toArray();
+  console.log(`\nbooks INDEPENDENTLY classified previously_translated: ${known.length}`);
+
+  const checked = known.filter((k) => byBook.has(k.book_id));
+  console.log(`  ...that the search also examined: ${checked.length}\n`);
+
+  const report = (label, keep, note) => {
+    const tally = {};
+    let surfaced = 0;
+    let missed = 0;
+    for (const k of checked) {
+      const v = verdictFrom(byBook.get(k.book_id), keep);
+      tally[v] = (tally[v] || 0) + 1;
+      if (SURFACED.has(v)) surfaced++;
+      else if (v === VERDICT.NONE_FOUND) missed++;
+    }
+    const pct = surfaced + missed ? ((surfaced / (surfaced + missed)) * 100).toFixed(1) : 'n/a';
+    console.log(`─── ${label} ${'─'.repeat(Math.max(0, 56 - label.length))}`);
+    console.log(`  verdicts            : ${JSON.stringify(tally)}`);
+    console.log(`  surfaced a candidate: ${surfaced}`);
+    console.log(`  reported none_found : ${missed}   <- FALSE NEGATIVES`);
+    console.log(`  RECALL              : ${pct}%`);
+    console.log(`  ${note}\n`);
+    return pct;
+  };
+
+  const catalogue = report(
+    'CATALOGUE-ONLY (LoC + Wikidata) — the honest number',
+    (c) => CATALOGUE_SOURCES.has(c.source),
+    'Comparable to the 22.0% baseline of 2026-07-31. This is the one to quote.',
+  );
+
+  report(
+    'COMBINED (incl. translation_classification) — CIRCULAR',
+    () => true,
+    'NOT a recall figure: the yardstick is inside the set being measured. It says\n'
+    + '  how many of these books an effort now holds any evidence for — coverage, not recall.',
+  );
+
+  console.log('─── What a `none_found` is worth ─────────────────────────────');
+  console.log(`  Catalogue recall is ${catalogue}%. A none_found remains WEAK evidence:`);
+  console.log('  it is a statement about this set on this date, never about the world.');
+  console.log('  Positive findings are unaffected — poor recall cannot manufacture a');
+  console.log('  false positive, so the verified demotes stand on their own.');
 }, { noTimeout: true });

--- a/scripts/eval/ft-reference-set-recall.mjs
+++ b/scripts/eval/ft-reference-set-recall.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * ft-reference-set-recall.mjs — how much is a `none_found` actually worth? (#3459)
+ *
+ * The whole design rests on asserting absence against a stated reference set. That
+ * is only honest if we know the set's RECALL — how often it finds a translation
+ * that genuinely exists. Until this script there was no such measurement, and
+ * every `none_found` was being reported as though the set were complete.
+ *
+ * `translation_classification` (9,908 rows, built Feb-Jul 2026) is an independent
+ * answer to the same question, with NAMED translators — Peterson's *Arbatel*,
+ * Goold's Loeb *Astronomica*, Bram's *Ancient Astrology*, Rayudu's Sanskrit
+ * editions. Books it marks `previously_translated` are known positives, so they
+ * are a ready-made recall test set.
+ *
+ * MEASURED 2026-07-31, and it is the most important number in this project:
+ *
+ *     known previously-translated books the search examined : 607
+ *     search surfaced a candidate                           : 132
+ *     search reported none_found                            : 469
+ *     RECALL                                                : 22.0%
+ *
+ * Four out of five known prior translations are invisible to the reference set.
+ * The causes are already declared on it — 35.2% of LoC rows carry no MARC 240 and
+ * cannot produce a confirmed match; scholarly editions printing a text with its
+ * translation often carry no 041 and are excluded at extraction; Loeb, Kessinger
+ * and small scholarly presses are thinly covered.
+ *
+ * CONSEQUENCES, stated plainly:
+ *   - `none_found` is weak evidence, not strong. Any count built on it — including
+ *     the inverse search's "works we translated and never claimed" — is inflated
+ *     several-fold and must not be quoted.
+ *   - The 42 verified demotes are UNAFFECTED. They are positive findings, each
+ *     re-fetched live from LoC; poor recall cannot manufacture a false positive.
+ *   - `translation_classification` should be a SOURCE in the reference set, not
+ *     merely a yardstick. It already holds 2,231 known priors with attribution.
+ *
+ * PROCESS NOTE: this dataset existed in the database the whole time and was not
+ * checked before a reference set was built from scratch. Look for prior work
+ * first.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/eval/ft-reference-set-recall.mjs
+ */
+import { withMongo } from '/Users/dereklomas/sourcelibrary/.claude/worktrees/feat-bib-records/scripts/lib/mongo.mjs';
+const load=f=>JSON.parse(fs.readFileSync(f,'utf8')).efforts;
+const eff=[...load('/Users/dereklomas/sourcelibrary/.claude/worktrees/feat-bib-records/scripts/output/ft-reference-set-search-inverse-2026-07-31.json'),
+           ...load('/Users/dereklomas/sourcelibrary/.claude/worktrees/feat-bib-records/scripts/output/ft-reference-set-search-badged-2026-07-31.json')];
+const verdict=new Map(eff.map(e=>[e.book_id,e.verdict]));
+await withMongo(async db=>{
+  const tc=db.collection('translation_classification');
+  const known=await tc.find({classification:'previously_translated'},{projection:{book_id:1,title:1,known_translation:1}}).toArray();
+  console.log('books INDEPENDENTLY classified previously_translated: '+known.length);
+  const checked=known.filter(k=>verdict.has(k.book_id));
+  console.log('  ...that my search also examined: '+checked.length);
+  const t={}; for(const k of checked) t[verdict.get(k.book_id)]=(t[verdict.get(k.book_id)]||0)+1;
+  console.log('  my verdicts on them:', JSON.stringify(t));
+  const found=(t.prior_found||0)+(t.only_partial_found||0)+(t.inconclusive||0);
+  const missed=t.none_found||0;
+  console.log('\n  RECALL of the reference set on known prior translations:');
+  console.log('    surfaced a candidate : '+found);
+  console.log('    reported none_found  : '+missed+'   <- FALSE NEGATIVES');
+  if(found+missed) console.log('    recall               : '+((found/(found+missed))*100).toFixed(1)+'%');
+}, { noTimeout: true });

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -50,7 +50,9 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(__dirname, '..', 'output');
 const BULK_DIR = path.join(OUT_DIR, 'loc-bulk');
+const WIKIDATA_DIR = path.join(OUT_DIR, 'wikidata');
 const DATE = new Date().toISOString().slice(0, 10);
+const WIKIDATA_SNAPSHOT = DATE;
 
 const APPLY = process.argv.includes('--apply');
 const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
@@ -218,6 +220,9 @@ export function screenCandidate(book, row, identity) {
  * Same shape as the paired-artifact failures in CLAUDE.md: two producers, one
  * consumer, an assumed correspondence nobody checked.
  */
+// Applies to the LoC extract only. Wikidata rows are produced by a different
+// script with its own shape (no LCCN — the identifier is a Q-number), so the
+// guard would reject a perfectly good source.
 const REQUIRED_ROW_FIELDS = ['lccn', 'title', 'uniform_title', 'original_languages', 'item_language', 'added_entries'];
 
 function loadReferenceSet() {
@@ -248,6 +253,13 @@ function loadReferenceSet() {
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 const files = loadReferenceSet();
+// Second source. Presence in ANY catalogue proves a translation exists, so
+// breadth is worth having even where a source is thin — and Wikidata carries a
+// native-script work title on 44.7% of rows against LoC's 2.3%, which is the one
+// place it materially extends reach.
+const wikidataFiles = fs.existsSync(WIKIDATA_DIR)
+  ? fs.readdirSync(WIKIDATA_DIR).filter((f) => f.endsWith('.jsonl')).map((f) => path.join(WIKIDATA_DIR, f))
+  : [];
 const bySurname = new Map();
 // Title-token index. An anonymous work has no author access point, but its TITLE
 // is one — and 771 of the 991 books previously reported "not searchable" had a
@@ -257,12 +269,15 @@ const byTitleToken = new Map();
 const byCjkGram = new Map();
 let rowCount = 0;
 
-for (const file of files) {
+let wikidataRows = 0;
+for (const file of [...files, ...wikidataFiles]) {
+  const isWikidata = wikidataFiles.includes(file);
   const rl = readline.createInterface({ input: fs.createReadStream(file), crlfDelay: Infinity });
   for await (const line of rl) {
     if (!line.trim()) continue;
     const row = JSON.parse(line);
     rowCount++;
+    if (isWikidata) wikidataRows++;
     for (const name of [row.author, ...(row.added_entries || [])].filter(Boolean)) {
       const sn = surname(name);
       if (!sn || sn.length < 3) continue;
@@ -310,7 +325,23 @@ function titlePool(bookToks) {
 
 const REFERENCE_SET = {
   version: `loc-2016.p${files.length}.v1`,
-  sources: [{
+  sources: [
+  ...(wikidataFiles.length ? [{
+    id: 'wikidata',
+    name: 'Wikidata — English editions of non-English works (P629)',
+    endpoint: 'https://query.wikidata.org/sparql',
+    snapshot_date: WIKIDATA_SNAPSHOT,
+    record_count: 0, // set below, once counted
+    coverage: 'English editions linked by `edition or translation of` to a non-English work',
+    known_gaps: [
+      'the edition-of relation is essentially unpopulated outside Western literature: '
+        + 'Tibetan 0, Classical Chinese 0, Syriac 0, Sanskrit 29 against 4,493 Sanskrit works. '
+        + 'This source does NOT close the gaps LoC leaves.',
+      'Welsh is ~30% of rows from a bulk import and never matches this corpus',
+      'community-curated, so absence reflects modelling effort rather than the world',
+    ],
+  }] : []),
+  {
     id: 'loc',
     name: 'Library of Congress MDSConnect Books-All',
     endpoint: 'https://www.loc.gov/cds/products/MDSConnect-books_all.html',
@@ -339,6 +370,9 @@ const REFERENCE_SET = {
     ],
   }],
 };
+const WD = REFERENCE_SET.sources.find((s) => s.id === 'wikidata');
+if (WD) WD.record_count = wikidataRows;
+REFERENCE_SET.version = `loc-2016.p${files.length}${wikidataFiles.length ? `+wd-${WIKIDATA_SNAPSHOT}` : ''}.v2`;
 
 console.log(`Reference set ${REFERENCE_SET.version}: ${rowCount.toLocaleString()} English translations, `
   + `${bySurname.size.toLocaleString()} distinct surnames (${files.length}/43 parts)\n`);

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -1,0 +1,404 @@
+#!/usr/bin/env node
+/**
+ * ft-reference-set-search.mjs — run every badged book against the reference set
+ * and record the SEARCH, not just the answer. (#3459)
+ *
+ * This is the read side of the reference set built by ingest-loc-bulk.mjs. For
+ * each book we publicly badge "First Translation", it asks one bounded question:
+ *
+ *     Does a complete English translation of this work already exist in
+ *     <named reference set, at <snapshot date>>?
+ *
+ * and writes a `search_efforts` document holding the proposition, the reference
+ * set with its declared gaps, the queries, every candidate WITH its screening
+ * reason, and the git SHA of the code that ran it. See scripts/lib/search-effort.mjs
+ * for why each of those is load-bearing.
+ *
+ * FREE and deterministic — the reference set is local, so this is index lookups,
+ * not network calls. Re-running it over the same snapshot yields byte-identical
+ * efforts, which is the property that makes a negative checkable by someone else.
+ *
+ * IT NEVER FLIPS A BADGE. Screening here is MECHANICAL and conservative: it can
+ * reject a candidate on structural grounds (a study, a different work, a later
+ * publication) but it marks anything genuinely arguable `unresolved`, which
+ * blocks a `none_found` verdict rather than quietly rounding to "we're first".
+ * Those go to human/model screening with the record attached.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/eval/ft-reference-set-search.mjs                    # dry-run
+ *   node scripts/eval/ft-reference-set-search.mjs --apply
+ *   node scripts/eval/ft-reference-set-search.mjs --lang Latin --limit 200
+ */
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+import { buildSearchEffort, SCREEN, VERDICT } from '../lib/search-effort.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+const BULK_DIR = path.join(OUT_DIR, 'loc-bulk');
+const DATE = new Date().toISOString().slice(0, 10);
+
+const APPLY = process.argv.includes('--apply');
+const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
+const LANG = argOf('--lang');
+const LIMIT = argOf('--limit') ? parseInt(argOf('--limit'), 10) : null;
+
+const CODE_VERSION = (() => {
+  try { return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim(); }
+  catch { throw new Error('cannot resolve git SHA — an unpinned search effort is not reproducible'); }
+})();
+
+// ── Normalisation ────────────────────────────────────────────────────────────
+
+const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '')
+  .toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+
+const STOP = new Set([
+  'the', 'and', 'with', 'from', 'that', 'this', 'for', 'des', 'der', 'die', 'und',
+  'liber', 'libri', 'opus', 'opera', 'book', 'books', 'volume', 'tractatus',
+  'english', 'translation', 'translated', 'works', 'text', 'new', 'notes',
+  'introduction', 'edition', 'edited', 'selected', 'sive', 'seu', 'cum',
+]);
+const toks = (s) => norm(s).split(/\s+/).filter((t) => t.length >= 4 && !STOP.has(t));
+
+const GENERIC_AUTHOR = /^(anonymous|anon\.?|unknown|various|various authors|multiple authors)$/i;
+function surname(a) {
+  if (!a || GENERIC_AUTHOR.test(a.trim())) return '';
+  let c = a.replace(/\([^)]*\)/g, '').replace(/\d{3,4}/g, '').split(';')[0].trim();
+  if (c.includes(',')) c = c.split(',')[0];
+  const w = norm(c).split(/\s+/).filter((x) => x.length > 1);
+  return w[w.length - 1] || '';
+}
+
+/**
+ * Work-identity score, measured in BOTH directions.
+ *
+ * LoC 240 uniform titles are deliberately terse ("Iliad."), while our titles
+ * carry qualifiers ("Homer, Iliad with Scholia"). Scoring only how much of OUR
+ * title the record covers makes an exact uniform-title hit look weak (1/3) —
+ * measured 2026-07-29, fixing this direction moved strong matches from 8 to 74
+ * over identical data.
+ */
+function workIdentity(bookToks, candidateTitle) {
+  const rt = new Set(toks(candidateTitle));
+  if (!rt.size || !bookToks.length) return { score: 0, hits: 0 };
+  const hits = bookToks.filter((t) => rt.has(t)).length;
+  if (!hits) return { score: 0, hits: 0 };
+  return {
+    score: Math.max(hits / bookToks.length, hits / rt.size),
+    hits,
+    book_coverage: hits / bookToks.length,
+    record_coverage: hits / rt.size,
+  };
+}
+
+const MIN_CANDIDATE = 0.34; // retrieve generously; screening is what rejects
+const STRONG = 0.6;
+
+// ── Mechanical screening ─────────────────────────────────────────────────────
+
+const PARTIAL_RE = /\bselections?\b|\bexcerpts?\b|\babridg|\banthology\b|\bpassages\b|\breader\b/i;
+
+/** Our own translations are being published now, so that is the prior ceiling. */
+const OUR_TRANSLATION_YEAR = new Date().getFullYear();
+
+/**
+ * Language name → the MARC-21 language codes that can legitimately represent it.
+ * Several have both a bibliographic and a historical variant in real records
+ * (Greek appears as both `gre` and `grc`), so this maps to a SET, not a code.
+ */
+const MARC3_CODES = {
+  latin: ['lat'],
+  greek: ['gre', 'grc'], 'ancient greek': ['gre', 'grc'], 'classical greek': ['gre', 'grc'],
+  german: ['ger'], french: ['fre'], italian: ['ita'], dutch: ['dut'], spanish: ['spa'],
+  hebrew: ['heb'], aramaic: ['arc'], arabic: ['ara'], persian: ['per'],
+  sanskrit: ['san'], pali: ['pli'], tamil: ['tam'],
+  chinese: ['chi'], 'classical chinese': ['chi'], japanese: ['jpn'], korean: ['kor'],
+  tibetan: ['tib'], syriac: ['syr'], armenian: ['arm'], russian: ['rus'],
+  egyptian: ['egy'], akkadian: ['akk'], sumerian: ['sux'],
+};
+
+/**
+ * Screen ONE candidate. Structural rejections only.
+ *
+ * Anything requiring real bibliographic judgement returns `unresolved`, which
+ * blocks `none_found`. That asymmetry is deliberate: a wrong rejection quietly
+ * preserves a possibly-false badge, so the safe default when uncertain is to
+ * keep the question open, not to close it.
+ */
+export function screenCandidate(book, row, identity) {
+  const reasonBits = [`work-identity ${identity.score.toFixed(2)}`];
+
+  if (identity.score < STRONG) {
+    return { screen: SCREEN.DIFFERENT_WORK, reason: `weak title overlap (${reasonBits})` };
+  }
+
+  // A prior must precede OUR TRANSLATION, not the original edition we hold.
+  //
+  // `book.year` is the year of the source edition (e.g. a 1546 Latin printing).
+  // Comparing a candidate against it rejects every real prior, because English
+  // translations of an early-modern text are necessarily later than the text:
+  // Boethius 1969 > 1546 reads as "later" when it is precisely the prior we are
+  // hunting. That inversion silently screened out 100% of candidates on the
+  // first run of this script.
+  //
+  // Our translations are published now, so the ceiling is the current year.
+  const rowYear = parseInt(row.year, 10);
+  if (Number.isFinite(rowYear) && rowYear > OUR_TRANSLATION_YEAR) {
+    return {
+      screen: SCREEN.LATER,
+      reason: `record published ${rowYear}, after our translation (${OUR_TRANSLATION_YEAR}) — cannot be a prior`,
+    };
+  }
+
+  const title = `${row.title} ${row.subtitle} ${row.uniform_title}`;
+  if (PARTIAL_RE.test(title)) {
+    return { screen: SCREEN.PARTIAL, reason: `title indicates selections/excerpts: "${row.title}"` };
+  }
+
+  // Source-language agreement. A Latin->English translation does not defeat a
+  // Greek->English first claim.
+  //
+  // Only applied when we actually know our source language: `books.language` is
+  // the EDITION language, not necessarily the language the work was composed in,
+  // so an absent `original_language` means "unknown", never "mismatch". Rejecting
+  // on a guess here would discard real priors.
+  const bookSrc = norm(book.original_language);
+  const expected = MARC3_CODES[bookSrc];
+  if (expected && row.original_languages?.length
+      && !row.original_languages.some((l) => expected.includes(l))) {
+    return {
+      screen: SCREEN.WRONG_LANGUAGE,
+      reason: `record translates from ${row.original_languages.join('/')}, our source is ${bookSrc} (${expected.join('/')})`,
+    };
+  }
+
+  // A strong work match, right language, not obviously partial, not later.
+  // Whether it is genuinely COMPLETE and genuinely the SAME work needs a human
+  // or a scoped model call with the MARC record in front of it.
+  return {
+    screen: SCREEN.UNRESOLVED,
+    reason: `strong work match (${identity.score.toFixed(2)}) from ${row.original_languages?.join('/') || '?'} `
+      + `published ${row.year || '?'} — needs screening for completeness and work identity`,
+  };
+}
+
+// ── Reference set ────────────────────────────────────────────────────────────
+
+/**
+ * Fields every reference-set row must carry. A part written by an older or
+ * different extractor is REFUSED rather than silently contributing rows with
+ * missing keys.
+ *
+ * This is not hypothetical. Eight parts produced by a prototype extractor used
+ * `uniform`/`orig`/`added` where the production one writes
+ * `uniform_title`/`original_languages`/`added_entries`. Mixed into the same
+ * directory they parsed fine, indexed fine, and produced plausible output — but
+ * every row from those parts had no uniform title and no source language, so
+ * work identity fell back to the 245 display title and real matches (Genji
+ * monogatari) scored 0.50 instead of 1.00 and were screened out as different
+ * works. Nothing failed; the reference set was just quietly worse.
+ *
+ * Same shape as the paired-artifact failures in CLAUDE.md: two producers, one
+ * consumer, an assumed correspondence nobody checked.
+ */
+const REQUIRED_ROW_FIELDS = ['lccn', 'title', 'uniform_title', 'original_languages', 'item_language', 'added_entries'];
+
+function loadReferenceSet() {
+  if (!fs.existsSync(BULK_DIR)) {
+    throw new Error(`no reference set at ${BULK_DIR} — run scripts/enrichment/ingest-loc-bulk.mjs first`);
+  }
+  const files = fs.readdirSync(BULK_DIR).filter((f) => /^eng-translations\.part\d+\.jsonl$/.test(f));
+  if (!files.length) throw new Error(`no extracted parts in ${BULK_DIR}`);
+
+  for (const f of files) {
+    const full = path.join(BULK_DIR, f);
+    const firstLine = fs.readFileSync(full, 'utf8').split('\n', 1)[0];
+    if (!firstLine.trim()) throw new Error(`${f} is empty — re-extract it`);
+    let row;
+    try { row = JSON.parse(firstLine); } catch { throw new Error(`${f} is not valid JSONL`); }
+    const missing = REQUIRED_ROW_FIELDS.filter((k) => !(k in row));
+    if (missing.length) {
+      throw new Error(
+        `${f} was written by an incompatible extractor (missing: ${missing.join(', ')}). `
+        + 'Delete it and re-run scripts/enrichment/ingest-loc-bulk.mjs for that part. '
+        + 'Mixing schemas silently degrades work identity rather than failing.',
+      );
+    }
+  }
+  return files.map((f) => path.join(BULK_DIR, f));
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const files = loadReferenceSet();
+const bySurname = new Map();
+let rowCount = 0;
+
+for (const file of files) {
+  const rl = readline.createInterface({ input: fs.createReadStream(file), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    const row = JSON.parse(line);
+    rowCount++;
+    for (const name of [row.author, ...(row.added_entries || [])].filter(Boolean)) {
+      const sn = surname(name);
+      if (!sn || sn.length < 3) continue;
+      if (!bySurname.has(sn)) bySurname.set(sn, []);
+      bySurname.get(sn).push(row);
+    }
+  }
+}
+
+const REFERENCE_SET = {
+  version: `loc-2016.p${files.length}.v1`,
+  sources: [{
+    id: 'loc',
+    name: 'Library of Congress MDSConnect Books-All',
+    endpoint: 'https://www.loc.gov/cds/products/MDSConnect-books_all.html',
+    snapshot_date: '2016-12-31',
+    parts_ingested: files.length,
+    parts_total: 43,
+    record_count: rowCount,
+    coverage: 'English translations (MARC 041$h present, item language eng) from the LoC book catalogue',
+    known_gaps: [
+      'snapshot ends 2016 — later translations absent by construction, not by evidence',
+      'European scholarly presses (Brill, Brepols) under-represented relative to US imprints',
+      'journal-published and dissertation translations largely uncatalogued',
+      'Tibetan, Syriac, Chinese and Arabic source traditions have very thin representation',
+      ...(files.length < 43 ? [`only ${files.length} of 43 catalogue parts ingested`] : []),
+    ],
+  }],
+};
+
+console.log(`Reference set ${REFERENCE_SET.version}: ${rowCount.toLocaleString()} English translations, `
+  + `${bySurname.size.toLocaleString()} distinct surnames (${files.length}/43 parts)\n`);
+
+await withMongo(async (db) => {
+  const query = { is_first_translation: true, visible: true, ...(LANG ? { language: LANG } : {}) };
+  let cursor = db.collection('books').find(query, {
+    projection: { id: 1, title: 1, work_title: 1, author: 1, language: 1, original_language: 1, year: 1, work_id: 1 },
+  });
+  if (LIMIT) cursor = cursor.limit(LIMIT);
+  const books = await cursor.toArray();
+  console.log(`Badged visible books: ${books.length}\n`);
+
+  const efforts = [];
+  const verdictTally = {};
+  const byTradition = {};
+
+  for (const book of books) {
+    const sn = surname(book.author);
+    const lang = book.language || 'unknown';
+    byTradition[lang] ??= { books: 0, searchable: 0, candidates: 0, unresolved: 0, prior: 0 };
+    byTradition[lang].books++;
+
+    const bookToks = [...new Set([...toks(book.title), ...toks(book.work_title)])];
+    const searchable = Boolean(sn) && bookToks.length > 0;
+
+    const queries = [];
+    const candidates = [];
+
+    if (searchable) {
+      byTradition[lang].searchable++;
+      const pool = bySurname.get(sn) || [];
+      queries.push({
+        source: 'loc',
+        query: `author_surname="${sn}" over ${REFERENCE_SET.version}`,
+        result_count: pool.length,
+      });
+
+      for (const row of pool) {
+        let best = { score: 0 };
+        for (const t of [row.uniform_title, row.title]) {
+          const id = workIdentity(bookToks, t);
+          if (id.score > best.score) best = id;
+        }
+        if (best.score < MIN_CANDIDATE) continue;
+        const { screen, reason } = screenCandidate(book, row, best);
+        candidates.push({
+          identifiers: { lccn: row.lccn },
+          title: row.title,
+          uniform_title: row.uniform_title || undefined,
+          year: row.year,
+          original_languages: row.original_languages,
+          publisher: row.publisher || undefined,
+          work_identity: best,
+          screen,
+          reason,
+        });
+      }
+    }
+
+    const effort = buildSearchEffort({
+      bookId: book.id,
+      workId: book.work_id,
+      proposition: `Does a complete English translation of "${book.work_title || book.title}"`
+        + `${book.author ? ` by ${book.author}` : ''} exist in the reference set`
+        + `${book.year ? `, published before ${book.year}` : ''}?`,
+      referenceSet: REFERENCE_SET,
+      queries,
+      candidates,
+      searchable,
+      codeVersion: CODE_VERSION,
+    });
+
+    efforts.push(effort);
+    verdictTally[effort.verdict] = (verdictTally[effort.verdict] || 0) + 1;
+    byTradition[lang].candidates += candidates.length;
+    byTradition[lang].unresolved += candidates.filter((c) => c.screen === SCREEN.UNRESOLVED).length;
+    byTradition[lang].prior += candidates.filter((c) => c.screen === SCREEN.PRIOR).length;
+  }
+
+  console.log('─── Verdicts ─────────────────────────────────────────────────');
+  for (const [v, n] of Object.entries(verdictTally).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${v.padEnd(22)} ${String(n).padStart(5)}`);
+  }
+  console.log('\n  none_found means "nothing found in THIS set", never "we are first".');
+  console.log('  not_searchable means we could not ask — it is not a clean negative.');
+  console.log('  inconclusive means a real candidate needs screening before any claim.');
+
+  console.log('\n─── By tradition ─────────────────────────────────────────────');
+  console.log(`  ${'language'.padEnd(14)} ${'books'.padStart(5)} ${'askable'.padStart(7)} ${'cands'.padStart(6)} ${'unresolved'.padStart(10)}`);
+  for (const [l, s] of Object.entries(byTradition).sort((a, b) => b[1].books - a[1].books).slice(0, 16)) {
+    console.log(`  ${l.padEnd(14)} ${String(s.books).padStart(5)} ${String(s.searchable).padStart(7)} `
+      + `${String(s.candidates).padStart(6)} ${String(s.unresolved).padStart(10)}`);
+  }
+
+  const needScreening = efforts.filter((e) => e.verdict === VERDICT.INCONCLUSIVE);
+  console.log(`\n  ${needScreening.length} book(s) have candidates awaiting screening.`);
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const outPath = path.join(OUT_DIR, `ft-reference-set-search-${DATE}.json`);
+  fs.writeFileSync(outPath, JSON.stringify({
+    reference_set: REFERENCE_SET,
+    code_version: CODE_VERSION,
+    verdicts: verdictTally,
+    by_tradition: byTradition,
+    efforts,
+  }, null, 2));
+  console.log(`\nWrote ${outPath}`);
+
+  if (!APPLY) {
+    console.log('DRY-RUN — nothing written to search_efforts. Re-run with --apply.');
+    return;
+  }
+
+  const coll = db.collection('search_efforts');
+  await coll.createIndex({ effort_id: 1 }, { unique: true });
+  await coll.createIndex({ book_id: 1, run_at: -1 });
+  await coll.createIndex({ verdict: 1 });
+  let written = 0;
+  for (let i = 0; i < efforts.length; i += 500) {
+    const res = await coll.bulkWrite(efforts.slice(i, i + 500).map((e) => ({
+      updateOne: { filter: { effort_id: e.effort_id }, update: { $set: e }, upsert: true },
+    })), { ordered: false });
+    written += res.upsertedCount + res.modifiedCount + res.matchedCount;
+  }
+  console.log(`APPLIED — ${written} search_efforts upserted (no badge was changed).`);
+});

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -254,6 +254,7 @@ const bySurname = new Map();
 // perfectly good title and merely lacked a usable author. Reporting those as
 // unaskable understated what the reference set could actually answer.
 const byTitleToken = new Map();
+const byCjkGram = new Map();
 let rowCount = 0;
 
 for (const file of files) {
@@ -271,6 +272,15 @@ for (const file of files) {
     for (const t of new Set([...toks(row.uniform_title), ...toks(row.title)])) {
       if (!byTitleToken.has(t)) byTitleToken.set(t, []);
       byTitleToken.get(t).push(row);
+    }
+    // Original-script index. Keyed on every 3-char window of each CJK run so a
+    // containment match is reachable by lookup rather than a full scan.
+    for (const run of cjkRuns(`${row.vernacular_uniform_title || ''} ${row.vernacular_title || ''}`)) {
+      for (let i = 0; i + 3 <= run.length; i++) {
+        const g = run.slice(i, i + 3);
+        if (!byCjkGram.has(g)) byCjkGram.set(g, []);
+        byCjkGram.get(g).push(row);
+      }
     }
   }
 }
@@ -313,8 +323,16 @@ const REFERENCE_SET = {
       'snapshot ends 2016 — later translations absent by construction, not by evidence',
       'European scholarly presses (Brill, Brepols) under-represented relative to US imprints',
       'journal-published and dissertation translations largely uncatalogued',
-      'non-Latin traditions are reachable only via romanized 240 uniform titles, '
-        + 'so a differing romanization scheme (Wade-Giles vs pinyin, Wylie variants) hides a real match',
+      // The most consequential gap in this set, stated first because a CJK
+      // `none_found` would otherwise read as evidence when it is nearly vacuous.
+      'CJK works are reachable ONLY via an original-script (MARC 880) title, and '
+        + 'LoC English-translation records almost never carry one: 205 of 8,774 '
+        + 'CJK-source rows (2.3%). Romanized matching is unusable (mixed '
+        + 'pinyin/Wade-Giles, differing syllable segmentation), so a `none_found` '
+        + 'for a Chinese, Japanese or Korean work is close to uninformative here '
+        + 'and needs a CJK-native catalogue or Wikidata before it means anything.',
+      'other non-Latin traditions are reachable only via romanized 240 uniform titles, '
+        + 'so a differing romanization scheme (Wylie variants) hides a real match',
       'the romanized generic-term stoplist was assembled without a specialist reader '
         + 'and may exclude a genuine match',
       ...(files.length < 43 ? [`only ${files.length} of 43 catalogue parts ingested`] : []),
@@ -358,6 +376,25 @@ await withMongo(async (db) => {
       queries.push({
         source: 'loc',
         query: `author_surname="${sn}" over ${REFERENCE_SET.version}`,
+        result_count: pool.length,
+      });
+    } else if (hasCjk(`${book.title} ${book.work_title || ''}`)) {
+      // Original-script access point: the only one available for a CJK title
+      // with no usable author and no Latin tokens.
+      const grams = new Set();
+      for (const run of cjkRuns(`${book.title} ${book.work_title || ''}`)) {
+        for (let i = 0; i + 3 <= run.length; i++) grams.add(run.slice(i, i + 3));
+      }
+      const seen = new Set();
+      for (const g of grams) {
+        for (const r of byCjkGram.get(g) || []) {
+          if (seen.has(r.lccn)) continue;
+          seen.add(r.lccn); pool.push(r);
+        }
+      }
+      queries.push({
+        source: 'loc',
+        query: `cjk_trigrams=[${[...grams].slice(0, 6).join(',')}] over ${REFERENCE_SET.version}`,
         result_count: pool.length,
       });
     } else if (bookToks.length) {

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -67,10 +67,39 @@ const LIMIT = argOf('--limit') ? parseInt(argOf('--limit'), 10) : null;
  *   inverse           — visible translated non-English books we do NOT badge.
  *                       A `none_found` here means something entirely different:
  *                       a work we may have translated first and never claimed.
+ *   untranslated      — everything we HOLD in a non-English language and have
+ *                       NOT translated. Here `none_found` is neither a claim nor
+ *                       a missed claim: it is a WORK QUEUE. See below.
  *
- * These must never be pooled. The same verdict string carries opposite meaning in
- * the two cohorts — one is "our claim held", the other is "we may have a claim we
- * never made" — so every effort records which cohort produced it.
+ * These must never be pooled. The same verdict string carries a different meaning
+ * in each — "our claim held", "we may have a claim we never made", "nobody has
+ * done this yet" — so every effort records which cohort produced it.
+ *
+ * WHY `untranslated` IS THE COHORT THAT CAN TOLERATE 27% RECALL
+ * ------------------------------------------------------------
+ * The first two cohorts publish. A missed prior there becomes a false public
+ * claim, which is why low recall is disqualifying and why `none_found` must not
+ * be counted.
+ *
+ * Prioritisation publishes nothing. It ranks what to translate next, and the two
+ * error directions cost completely different things:
+ *
+ *   a MISSED prior (low recall)  → a book sits higher in the queue than it
+ *                                  deserves. Worst case we translate something
+ *                                  that already exists in English. Recoverable,
+ *                                  visible on reading, harms nobody.
+ *   a FALSE prior (low precision)→ we silently drop a genuinely untranslated work
+ *                                  off the queue and never revisit it.
+ *
+ * So prioritisation needs PRECISION on "already done", not recall — and precision
+ * is the direction this instrument is strong in: 32/32 live identity
+ * confirmations on the demote packet, and zero contradictions across the 399
+ * books an independent classifier calls never_translated. Every prior we DO find
+ * removes a book from the queue with high confidence; the ones we miss just leave
+ * the queue noisier than ideal.
+ *
+ * That is the same evidence, at the same 27% recall, doing a job it is actually
+ * fit for.
  */
 const COHORT = argOf('--cohort') ?? 'badged';
 
@@ -496,15 +525,42 @@ await withMongo(async (db) => {
     pages_translated: { $gt: 0 },
     language: { $nin: [null, 'English'] },
   };
+
+  /**
+   * Everything we hold in a non-English language with no English translation yet.
+   *
+   * Deliberately NOT gated on `visible`. 43,607 of these are held but
+   * unpublished, and 30,844 of those are already OCR'd — i.e. translation-ready
+   * today. Asking only about the visible shelf would hide the entire pool the
+   * question is about.
+   *
+   * Rights-class exclusions are absolute: a work we cannot publish must never
+   * reach a translation queue, however untranslated it is. The regex covers the
+   * standing classes plus the Kloss manuscript withdrawal, which is a removal at
+   * a partner's request and does not match the generic pattern.
+   */
+  const UNTRANSLATED = {
+    language: { $nin: [null, 'English'] },
+    pages_count: { $gt: 0 },
+    $or: [
+      { pages_translated: { $lte: 0 } },
+      { pages_translated: null },
+      { pages_translated: { $exists: false } },
+    ],
+    hidden_reason: { $not: /copyright|takedown|dmca|kloss_manuscripts_removed/i },
+  };
+
   const query = COHORT === 'inverse'
     ? { ...ELIGIBLE, is_first_translation: { $ne: true }, ...(LANG ? { language: LANG } : {}) }
-    : { is_first_translation: true, visible: true, ...(LANG ? { language: LANG } : {}) };
+    : COHORT === 'untranslated'
+      ? { ...UNTRANSLATED, ...(LANG ? { language: LANG } : {}) }
+      : { is_first_translation: true, visible: true, ...(LANG ? { language: LANG } : {}) };
   let cursor = db.collection('books').find(query, {
     projection: { id: 1, title: 1, work_title: 1, author: 1, language: 1, original_language: 1, year: 1, work_id: 1 },
   });
   if (LIMIT) cursor = cursor.limit(LIMIT);
   const books = await cursor.toArray();
-  console.log(`Badged visible books: ${books.length}\n`);
+  console.log(`Books in the ${COHORT} cohort: ${books.length}\n`);
 
   const efforts = [];
   const verdictTally = {};
@@ -690,12 +746,23 @@ await withMongo(async (db) => {
 
   fs.mkdirSync(OUT_DIR, { recursive: true });
   const outPath = path.join(OUT_DIR, `ft-reference-set-search-${COHORT}-${DATE}.json`);
+  // The Mongo document is deliberately self-contained: every effort embeds the
+  // reference set and inherits its gaps, because a limitation named once in a
+  // manifest and never surfaced on the claim it undermines is not a disclosure.
+  //
+  // In the FILE that is pure duplication — the identical manifest is already the
+  // top-level `reference_set` key, and it is 87% of every effort's bytes (6,383
+  // of 7,346). At 57,764 untranslated books that is ~420MB of the same paragraph
+  // repeated. Strip it from the file only; what goes to Mongo is untouched.
   fs.writeFileSync(outPath, JSON.stringify({
     reference_set: REFERENCE_SET,
     code_version: CODE_VERSION,
+    note: 'per-effort `reference_set` and `limitations` are stripped here — they are '
+      + 'identical on every effort and are the top-level `reference_set` above. The '
+      + 'documents written to Mongo by --apply keep them.',
     verdicts: verdictTally,
     by_tradition: byTradition,
-    efforts,
+    efforts: efforts.map(({ reference_set, limitations, ...rest }) => rest),
   }, null, 2));
   console.log(`\nWrote ${outPath}`);
 

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -46,6 +46,7 @@ import {
   hasCjk,
   cjkRuns,
 } from '../lib/work-identity-match.mjs';
+import { languageMismatch } from '../lib/source-language-match.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(__dirname, '..', 'output');
@@ -135,22 +136,6 @@ const PARTIAL_RE = /\bselections?\b|\bexcerpts?\b|\babridg|\banthology\b|\bpassa
 const OUR_TRANSLATION_YEAR = new Date().getFullYear();
 
 /**
- * Language name → the MARC-21 language codes that can legitimately represent it.
- * Several have both a bibliographic and a historical variant in real records
- * (Greek appears as both `gre` and `grc`), so this maps to a SET, not a code.
- */
-const MARC3_CODES = {
-  latin: ['lat'],
-  greek: ['gre', 'grc'], 'ancient greek': ['gre', 'grc'], 'classical greek': ['gre', 'grc'],
-  german: ['ger'], french: ['fre'], italian: ['ita'], dutch: ['dut'], spanish: ['spa'],
-  hebrew: ['heb'], aramaic: ['arc'], arabic: ['ara'], persian: ['per'],
-  sanskrit: ['san'], pali: ['pli'], tamil: ['tam'],
-  chinese: ['chi'], 'classical chinese': ['chi'], japanese: ['jpn'], korean: ['kor'],
-  tibetan: ['tib'], syriac: ['syr'], armenian: ['arm'], russian: ['rus'],
-  egyptian: ['egy'], akkadian: ['akk'], sumerian: ['sux'],
-};
-
-/**
  * Screen ONE candidate. Structural rejections only.
  *
  * Anything requiring real bibliographic judgement returns `unresolved`, which
@@ -191,18 +176,15 @@ export function screenCandidate(book, row, identity) {
   // Source-language agreement. A Latin->English translation does not defeat a
   // Greek->English first claim.
   //
-  // Only applied when we actually know our source language: `books.language` is
-  // the EDITION language, not necessarily the language the work was composed in,
-  // so an absent `original_language` means "unknown", never "mismatch". Rejecting
-  // on a guess here would discard real priors.
-  const bookSrc = norm(book.original_language);
-  const expected = MARC3_CODES[bookSrc];
-  if (expected && row.original_languages?.length
-      && !row.original_languages.some((l) => expected.includes(l))) {
-    return {
-      screen: SCREEN.WRONG_LANGUAGE,
-      reason: `record translates from ${row.original_languages.join('/')}, our source is ${bookSrc} (${expected.join('/')})`,
-    };
+  // Applied only when BOTH sides resolve to a known language — see
+  // scripts/lib/source-language-match.mjs. `books.language` is the EDITION
+  // language, so an absent `original_language` means "unknown", never "mismatch",
+  // and the same is true of a catalogue identifier we cannot read. Rejecting on a
+  // guess here discards real priors: the previous MARC-code-only comparison did
+  // exactly that to every Wikidata row.
+  const langReason = languageMismatch(book.original_language, row);
+  if (langReason) {
+    return { screen: SCREEN.WRONG_LANGUAGE, reason: langReason };
   }
 
   // A strong work match, right language, not obviously partial, not later.
@@ -368,15 +350,20 @@ const REFERENCE_SET = {
       'snapshot ends 2016 — later translations absent by construction, not by evidence',
       'European scholarly presses (Brill, Brepols) under-represented relative to US imprints',
       'journal-published and dissertation translations largely uncatalogued',
-      // RECALL CEILING — stated first because it caps what any `none_found` here
-      // can mean. 35.2% of rows (41,678 of 118,352) carry no MARC 240 uniform
-      // title, and work identity is established by 240 containment; the 245
-      // display-title fallback is deliberately capped below the confirmation
-      // threshold to suppress noise. So over a third of the reference set is
-      // unreachable as a confirmed match and `none_found` is systematically
-      // OVER-reported in both cohorts.
-      'RECALL CEILING: 35.2% of rows have no 240 uniform title and cannot produce '
-        + 'a confirmed match, so `none_found` is over-reported by an unmeasured margin.',
+      // RECALL CEILING — the 35.2% of rows (41,678 of 118,352) with no MARC 240.
+      // These were unreachable as a confirmed match until 2026-08-01: work
+      // identity was established by 240 containment alone and the 245 fallback
+      // was capped below the confirmation threshold, so over a third of the set
+      // could only ever yield `none_found`. The 245 path can now confirm, but
+      // only under author corroboration, which leaves the residue named here.
+      'RECALL CEILING: 35.2% of rows carry no 240 uniform title. They are now '
+        + 'reachable through 245 display-title containment, but ONLY when an author '
+        + 'access point agrees — so for an anonymous work, or one of ours with no '
+        + 'usable author, a third of this set remains unconfirmable and `none_found` '
+        + 'is still over-reported there.',
+      'a 245 confirmation resting on a single generic container token ("letters", '
+        + '"writings", "complete") is weak work identity; those candidates are held '
+        + 'at `unresolved` for screening rather than counted either way',
       // A second, related gap: scholarly editions that print an ancient text
       // alongside its translation are frequently catalogued with NO 041 at all
       // (Langdon\'s *Babylonian Liturgies* has none; 22 of 23 LoC records for
@@ -415,6 +402,94 @@ await withMongo(async (db) => {
   if (decisionByWork.size) {
     console.log(`Carrying forward ${decisionByWork.size} screening decision(s) from previous passes.\n`);
   }
+
+  // ── Third source: our own translation_classification ───────────────────────
+  //
+  // 9,908 rows built Feb–Jul 2026, 2,755 of them asserting a prior or partial
+  // English translation and 2,564 naming a translator, title and publisher. It
+  // answered much of this question before the reference set was built, and was
+  // used only as the yardstick for measuring recall. That is backwards: a source
+  // that holds known priors belongs IN the set.
+  //
+  // It is not a catalogue, and it is not treated as one. Every row is a model's
+  // assertion, so no row here can produce `prior_found` on its own — see
+  // tcCandidate() below.
+  const tcRows = await db.collection('translation_classification').find(
+    { classification: { $in: ['previously_translated', 'partially_translated'] } },
+    { projection: { book_id: 1, classification: 1, known_translation: 1, reasoning: 1, model: 1, classified_at: 1, confidence: 1, title: 1 } },
+  ).toArray();
+
+  // Join by our own work clustering as well as by book id. A prior translation
+  // established for one edition of a work is established for every edition of it
+  // — `books.work_id` is the canonical work key (see CLAUDE.md), and it reaches
+  // 467 cohort books that were never classified themselves.
+  const tcBooks = await db.collection('books').find(
+    { id: { $in: tcRows.map((r) => r.book_id) } },
+    { projection: { id: 1, work_id: 1 } },
+  ).toArray();
+  const workIdOf = new Map(tcBooks.map((b) => [b.id, b.work_id]));
+  const tcByBookId = new Map();
+  const tcByWorkId = new Map();
+  for (const r of tcRows) {
+    tcByBookId.set(r.book_id, r);
+    const wid = workIdOf.get(r.book_id);
+    if (!wid) continue;
+    if (!tcByWorkId.has(wid)) tcByWorkId.set(wid, []);
+    tcByWorkId.get(wid).push(r);
+  }
+
+  REFERENCE_SET.sources.unshift({
+    id: 'translation_classification',
+    name: 'Source Library — internal translation classification (model-attributed priors)',
+    endpoint: 'mongodb://bookstore/translation_classification',
+    snapshot_date: DATE,
+    record_count: tcRows.length,
+    coverage: 'books in our own corpus classified as having a prior or partial English '
+      + 'translation, 2,564 of them naming a translator, title and publisher',
+    known_gaps: [
+      // Stated first because it caps what any candidate from this source can mean.
+      'NOT A CATALOGUE: every row is an assertion by gemini-2.5-flash or '
+        + 'gemini-3-flash-preview, unverified against any bibliographic record. An '
+        + 'attribution here is a LEAD to be checked, never a confirmed prior, so no '
+        + 'candidate from this source can close a question on its own.',
+      'covers only the 9,908 books that were classified — it cannot answer about a '
+        + 'book it never saw, and says nothing about the rest of the corpus',
+      'its `never_translated` rows are an absence claim by a model and are '
+        + 'deliberately NOT used as evidence of absence',
+      '1,984 of its 9,908 rows no longer resolve to a live books.id',
+    ],
+  });
+  REFERENCE_SET.version += `+tc-${DATE}`;
+  console.log(`Reference set now ${REFERENCE_SET.version} — added translation_classification `
+    + `(${tcRows.length.toLocaleString()} attributed priors, ${tcByWorkId.size.toLocaleString()} distinct works)\n`);
+
+  /**
+   * Build a candidate from a translation_classification row.
+   *
+   * ALWAYS `unresolved`, for both classifications. The mechanical screen rejects
+   * only on structural grounds and defers anything needing bibliographic
+   * judgement, and a model's attribution is exactly that — `Kessinger 2004` may
+   * be a real reprint or a hallucination, and only reading a record settles it.
+   *
+   * Marking these `prior_translation` would let an unverified model claim drive a
+   * `prior_found` verdict; marking `partial_translation` would let it drive
+   * `only_partial_found`, which reads as "no prior COMPLETE translation exists" —
+   * an absence claim we cannot support from this source either. `unresolved`
+   * blocks `none_found` and asserts nothing, which is the whole of what we know.
+   */
+  const tcCandidate = (row, basis) => ({
+    source: 'translation_classification',
+    identifiers: { book_id: row.book_id },
+    title: row.title,
+    year: null,
+    known_translation: row.known_translation || undefined,
+    work_identity: { score: 1, hits: 1, basis },
+    screen: SCREEN.UNRESOLVED,
+    reason: `[${row.classification}] ${row.known_translation || row.reasoning || 'no attribution recorded'} `
+      + `— asserted by ${row.model} on ${new Date(row.classified_at).toISOString().slice(0, 10)}`
+      + `${row.confidence != null ? ` (self-reported confidence ${row.confidence})` : ''}; `
+      + 'unverified against any catalogue, needs screening',
+  });
 
   const ELIGIBLE = {
     visible: true,
@@ -507,6 +582,9 @@ await withMongo(async (db) => {
           bookAuthorSurname: sn || surname(book.author),
           recordAuthorSurnames: [row.author, ...(row.added_entries || [])]
             .filter(Boolean).map(surname).filter(Boolean),
+          // Full name strings, so the 245 fallback can discount personal-name
+          // tokens sitting inside the titles themselves ("The Iliad of Homer").
+          authorNames: [book.author, row.author, ...(row.added_entries || [])].filter(Boolean),
         });
         if (!best || best.score < MIN_CANDIDATE) continue;
         let { screen, reason } = screenCandidate(book, row, best);
@@ -518,7 +596,13 @@ await withMongo(async (db) => {
           reason = `[carried forward ${new Date(prior.decided_at).toISOString().slice(0, 10)}] ${prior.reason}`;
         }
         candidates.push({
-          identifiers: { lccn: row.lccn },
+          // Which source retrieved this. Without it a candidate's provenance is
+          // unrecoverable — the two catalogues were distinguishable only by an
+          // empty LCCN, and recall cannot be measured per-source at all.
+          source: row.source,
+          identifiers: row.lccn
+            ? { lccn: row.lccn }
+            : { wikidata_edition: row.wikidata_edition, wikidata_work: row.wikidata_work },
           title: row.title,
           uniform_title: row.uniform_title || undefined,
           year: row.year,
@@ -530,6 +614,34 @@ await withMongo(async (db) => {
           reason,
         });
       }
+    }
+
+    // ── translation_classification lane ──────────────────────────────────────
+    //
+    // A JOIN, not a search: keyed on our own book id and work id, so it answers
+    // for books no catalogue index can reach and needs no access point. It runs
+    // regardless of `searchable` for exactly that reason.
+    const tcDirect = tcByBookId.get(book.id);
+    const tcViaWork = (book.work_id ? tcByWorkId.get(book.work_id) ?? [] : [])
+      .filter((r) => r.book_id !== book.id);
+    queries.push({
+      source: 'translation_classification',
+      query: `book_id="${book.id}"${book.work_id ? ` OR work_id="${book.work_id}"` : ''} over ${REFERENCE_SET.version}`,
+      result_count: (tcDirect ? 1 : 0) + tcViaWork.length,
+    });
+    for (const [row, basis] of [
+      ...(tcDirect ? [[tcDirect, 'same_book']] : []),
+      ...tcViaWork.map((r) => [r, 'shared_work_id']),
+    ]) {
+      const c = tcCandidate(row, basis);
+      // A human judgement about this work still outranks the lead, exactly as it
+      // does for a catalogue row.
+      const decided = decisionByWork.get(book.work_title || book.title);
+      if (decided) {
+        c.screen = decided.screen;
+        c.reason = `[carried forward ${new Date(decided.decided_at).toISOString().slice(0, 10)}] ${decided.reason}`;
+      }
+      candidates.push(c);
     }
 
     const effort = buildSearchEffort({

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -37,6 +37,13 @@ import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { withMongo } from '../lib/mongo.mjs';
 import { buildSearchEffort, SCREEN, VERDICT } from '../lib/search-effort.mjs';
+import {
+  titleTokens as toks,
+  bookTitleTokens,
+  matchWorkIdentity,
+  normaliseTitle as norm,
+  STRONG_WORK_IDENTITY as STRONG,
+} from '../lib/work-identity-match.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(__dirname, '..', 'output');
@@ -53,52 +60,54 @@ const CODE_VERSION = (() => {
   catch { throw new Error('cannot resolve git SHA — an unpinned search effort is not reproducible'); }
 })();
 
-// ── Normalisation ────────────────────────────────────────────────────────────
+// ── Normalisation & work identity live in scripts/lib/work-identity-match.mjs ──
+// (pure, so the gold set in tests/unit/reference-set-work-identity.test.ts can
+//  exercise them without importing this script and triggering its main body).
 
-const norm = (s) => (s || '').normalize('NFD').replace(/[̀-ͯ]/g, '')
-  .toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
-
-const STOP = new Set([
-  'the', 'and', 'with', 'from', 'that', 'this', 'for', 'des', 'der', 'die', 'und',
-  'liber', 'libri', 'opus', 'opera', 'book', 'books', 'volume', 'tractatus',
-  'english', 'translation', 'translated', 'works', 'text', 'new', 'notes',
-  'introduction', 'edition', 'edited', 'selected', 'sive', 'seu', 'cum',
-]);
-const toks = (s) => norm(s).split(/\s+/).filter((t) => t.length >= 4 && !STOP.has(t));
-
-const GENERIC_AUTHOR = /^(anonymous|anon\.?|unknown|various|various authors|multiple authors)$/i;
-function surname(a) {
-  if (!a || GENERIC_AUTHOR.test(a.trim())) return '';
-  let c = a.replace(/\([^)]*\)/g, '').replace(/\d{3,4}/g, '').split(';')[0].trim();
-  if (c.includes(',')) c = c.split(',')[0];
-  const w = norm(c).split(/\s+/).filter((x) => x.length > 1);
-  return w[w.length - 1] || '';
-}
+const GENERIC_AUTHOR = /^(anonymous|anon\.?|unknown|various|various authors|multiple authors|n\/a|—|-)$/i;
 
 /**
- * Work-identity score, measured in BOTH directions.
- *
- * LoC 240 uniform titles are deliberately terse ("Iliad."), while our titles
- * carry qualifiers ("Homer, Iliad with Scholia"). Scoring only how much of OUR
- * title the record covers makes an exact uniform-title hit look weak (1/3) —
- * measured 2026-07-29, fixing this direction moved strong matches from 8 to 74
- * over identical data.
+ * Collection/holding-institution names are not authors. Using one as an access
+ * point buckets hundreds of unrelated manuscripts under a single surname and
+ * produces pure noise.
  */
-function workIdentity(bookToks, candidateTitle) {
-  const rt = new Set(toks(candidateTitle));
-  if (!rt.size || !bookToks.length) return { score: 0, hits: 0 };
-  const hits = bookToks.filter((t) => rt.has(t)).length;
-  if (!hits) return { score: 0, hits: 0 };
-  return {
-    score: Math.max(hits / bookToks.length, hits / rt.size),
-    hits,
-    book_coverage: hits / bookToks.length,
-    record_coverage: hits / rt.size,
+const COLLECTION_AUTHOR = /\b(collection|monastery|library|archive|museum|temple|dzong)\b/i;
+
+/**
+ * Author surname for indexing, or '' when there is no usable access point.
+ *
+ * The parenthetical is where a romanized name often lives — `（宋）邵雍 (Shao Yong)`
+ * is a dynasty marker in CJK plus the *searchable* form in Latin script.
+ * Blindly stripping parentheticals (the ordinary case: dates, qualifiers) threw
+ * that away and left an unindexable CJK remnant, which is why 355 of 450 Chinese
+ * badged books reported as having no author at all.
+ */
+function surname(a) {
+  if (!a) return '';
+  const raw = a.trim();
+  if (GENERIC_AUTHOR.test(raw) || COLLECTION_AUTHOR.test(raw)) return '';
+
+  const fromMain = (s) => {
+    let c = s.replace(/\d{3,4}/g, '').split(';')[0].trim();
+    if (c.includes(',')) c = c.split(',')[0];
+    const w = norm(c).split(/\s+/).filter((x) => x.length > 1);
+    return w[w.length - 1] || '';
   };
+
+  // Prefer the name outside parentheses; fall back to a Latin-script
+  // parenthetical when what remains has no Latin content to index.
+  const outside = fromMain(raw.replace(/\([^)]*\)/g, ' '));
+  if (outside) return outside;
+  for (const m of raw.matchAll(/\(([^)]*)\)/g)) {
+    const inner = fromMain(m[1]);
+    if (inner) return inner;
+  }
+  return '';
 }
 
-const MIN_CANDIDATE = 0.34; // retrieve generously; screening is what rejects
-const STRONG = 0.6;
+// Retrieve generously; screening is what rejects. STRONG comes from the shared
+// lib so the gold set and the run agree on the same threshold by construction.
+const MIN_CANDIDATE = 0.34;
 
 // ── Mechanical screening ─────────────────────────────────────────────────────
 
@@ -238,6 +247,11 @@ function loadReferenceSet() {
 
 const files = loadReferenceSet();
 const bySurname = new Map();
+// Title-token index. An anonymous work has no author access point, but its TITLE
+// is one — and 771 of the 991 books previously reported "not searchable" had a
+// perfectly good title and merely lacked a usable author. Reporting those as
+// unaskable understated what the reference set could actually answer.
+const byTitleToken = new Map();
 let rowCount = 0;
 
 for (const file of files) {
@@ -252,7 +266,34 @@ for (const file of files) {
       if (!bySurname.has(sn)) bySurname.set(sn, []);
       bySurname.get(sn).push(row);
     }
+    for (const t of new Set([...toks(row.uniform_title), ...toks(row.title)])) {
+      if (!byTitleToken.has(t)) byTitleToken.set(t, []);
+      byTitleToken.get(t).push(row);
+    }
   }
+}
+
+/**
+ * Candidate pool for a book with no author access point: the rarest of its title
+ * tokens. Rarest keeps the pool small and specific — a common word like
+ * "geometrie" would drag in thousands of unrelated rows, while an unusual one
+ * ("itinerarium") lands on a handful. Pools above the cap are refused rather
+ * than truncated, because a silently truncated pool is a search that reports a
+ * negative it never actually performed.
+ */
+const MAX_TITLE_POOL = 4000;
+function titlePool(bookToks) {
+  let best = null;
+  for (const t of bookToks) {
+    const rows = byTitleToken.get(t);
+    if (!rows) continue;
+    if (!best || rows.length < best.rows.length) best = { token: t, rows };
+  }
+  if (!best) return { token: null, rows: [], refused: false };
+  if (best.rows.length > MAX_TITLE_POOL) {
+    return { token: best.token, rows: [], refused: true };
+  }
+  return { ...best, refused: false };
 }
 
 const REFERENCE_SET = {
@@ -270,7 +311,10 @@ const REFERENCE_SET = {
       'snapshot ends 2016 — later translations absent by construction, not by evidence',
       'European scholarly presses (Brill, Brepols) under-represented relative to US imprints',
       'journal-published and dissertation translations largely uncatalogued',
-      'Tibetan, Syriac, Chinese and Arabic source traditions have very thin representation',
+      'non-Latin traditions are reachable only via romanized 240 uniform titles, '
+        + 'so a differing romanization scheme (Wade-Giles vs pinyin, Wylie variants) hides a real match',
+      'the romanized generic-term stoplist was assembled without a specialist reader '
+        + 'and may exclude a genuine match',
       ...(files.length < 43 ? [`only ${files.length} of 43 catalogue parts ingested`] : []),
     ],
   }],
@@ -298,28 +342,47 @@ await withMongo(async (db) => {
     byTradition[lang] ??= { books: 0, searchable: 0, candidates: 0, unresolved: 0, prior: 0 };
     byTradition[lang].books++;
 
-    const bookToks = [...new Set([...toks(book.title), ...toks(book.work_title)])];
-    const searchable = Boolean(sn) && bookToks.length > 0;
+    const bookToks = bookTitleTokens(book.title, book.work_title);
 
+    // Two access points, tried in order of specificity. An author is the better
+    // one; a title is a real one, not a fallback to be skipped.
+    let pool = [];
     const queries = [];
     const candidates = [];
+    let refusedPool = false;
 
-    if (searchable) {
-      byTradition[lang].searchable++;
-      const pool = bySurname.get(sn) || [];
+    if (sn) {
+      pool = bySurname.get(sn) || [];
       queries.push({
         source: 'loc',
         query: `author_surname="${sn}" over ${REFERENCE_SET.version}`,
         result_count: pool.length,
       });
+    } else if (bookToks.length) {
+      const tp = titlePool(bookToks);
+      pool = tp.rows;
+      refusedPool = tp.refused;
+      queries.push({
+        source: 'loc',
+        query: tp.token
+          ? `title_token="${tp.token}" over ${REFERENCE_SET.version}`
+          : `no indexed title token over ${REFERENCE_SET.version}`,
+        result_count: tp.rows.length,
+        ...(tp.refused ? { refused: `pool exceeded ${MAX_TITLE_POOL} rows — token too common to search on` } : {}),
+      });
+    }
 
+    // Searchable means an access point existed AND we could actually run the
+    // query. A refused (over-large) pool is NOT a clean negative.
+    const searchable = queries.length > 0 && bookToks.length > 0 && !refusedPool;
+
+    if (searchable) {
+      byTradition[lang].searchable++;
       for (const row of pool) {
-        let best = { score: 0 };
-        for (const t of [row.uniform_title, row.title]) {
-          const id = workIdentity(bookToks, t);
-          if (id.score > best.score) best = id;
-        }
-        if (best.score < MIN_CANDIDATE) continue;
+        // Uniform-title containment first: it is the work-identity test. Fall
+        // back to display-title overlap only when there is no 240 to use.
+        const best = matchWorkIdentity(bookToks, row);
+        if (!best || best.score < MIN_CANDIDATE) continue;
         const { screen, reason } = screenCandidate(book, row, best);
         candidates.push({
           identifiers: { lccn: row.lccn },

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -378,6 +378,14 @@ console.log(`Reference set ${REFERENCE_SET.version}: ${rowCount.toLocaleString()
   + `${bySurname.size.toLocaleString()} distinct surnames (${files.length}/43 parts)\n`);
 
 await withMongo(async (db) => {
+  // Re-apply durable screening judgements. Without this, every new snapshot or
+  // code change resets all screening to `unresolved` and the human work is lost.
+  const decisionRows = await db.collection('screening_decisions').find({}).toArray();
+  const decisionByWork = new Map(decisionRows.map((d) => [d.work, d]));
+  if (decisionByWork.size) {
+    console.log(`Carrying forward ${decisionByWork.size} screening decision(s) from previous passes.\n`);
+  }
+
   const query = { is_first_translation: true, visible: true, ...(LANG ? { language: LANG } : {}) };
   let cursor = db.collection('books').find(query, {
     projection: { id: 1, title: 1, work_title: 1, author: 1, language: 1, original_language: 1, year: 1, work_id: 1 },
@@ -464,7 +472,14 @@ await withMongo(async (db) => {
             .filter(Boolean).map(surname).filter(Boolean),
         });
         if (!best || best.score < MIN_CANDIDATE) continue;
-        const { screen, reason } = screenCandidate(book, row, best);
+        let { screen, reason } = screenCandidate(book, row, best);
+        // A judgement already made about this work outranks the mechanical
+        // screen — it was made with the record in front of a human.
+        const prior = decisionByWork.get(book.work_title || book.title);
+        if (prior && screen === SCREEN.UNRESOLVED) {
+          screen = prior.screen;
+          reason = `[carried forward ${new Date(prior.decided_at).toISOString().slice(0, 10)}] ${prior.reason}`;
+        }
         candidates.push({
           identifiers: { lccn: row.lccn },
           title: row.title,

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -58,6 +58,20 @@ const APPLY = process.argv.includes('--apply');
 const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
 const LANG = argOf('--lang');
 const LIMIT = argOf('--limit') ? parseInt(argOf('--limit'), 10) : null;
+/**
+ * Which population to search.
+ *
+ *   badged  (default) — books we already claim. A `none_found` here means our
+ *                       public claim survives the search.
+ *   inverse           — visible translated non-English books we do NOT badge.
+ *                       A `none_found` here means something entirely different:
+ *                       a work we may have translated first and never claimed.
+ *
+ * These must never be pooled. The same verdict string carries opposite meaning in
+ * the two cohorts — one is "our claim held", the other is "we may have a claim we
+ * never made" — so every effort records which cohort produced it.
+ */
+const COHORT = argOf('--cohort') ?? 'badged';
 
 const CODE_VERSION = (() => {
   try { return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim(); }
@@ -386,7 +400,14 @@ await withMongo(async (db) => {
     console.log(`Carrying forward ${decisionByWork.size} screening decision(s) from previous passes.\n`);
   }
 
-  const query = { is_first_translation: true, visible: true, ...(LANG ? { language: LANG } : {}) };
+  const ELIGIBLE = {
+    visible: true,
+    pages_translated: { $gt: 0 },
+    language: { $nin: [null, 'English'] },
+  };
+  const query = COHORT === 'inverse'
+    ? { ...ELIGIBLE, is_first_translation: { $ne: true }, ...(LANG ? { language: LANG } : {}) }
+    : { is_first_translation: true, visible: true, ...(LANG ? { language: LANG } : {}) };
   let cursor = db.collection('books').find(query, {
     projection: { id: 1, title: 1, work_title: 1, author: 1, language: 1, original_language: 1, year: 1, work_id: 1 },
   });
@@ -508,6 +529,7 @@ await withMongo(async (db) => {
       codeVersion: CODE_VERSION,
     });
 
+    effort.cohort = COHORT;
     efforts.push(effort);
     verdictTally[effort.verdict] = (verdictTally[effort.verdict] || 0) + 1;
     byTradition[lang].candidates += candidates.length;
@@ -515,11 +537,16 @@ await withMongo(async (db) => {
     byTradition[lang].prior += candidates.filter((c) => c.screen === SCREEN.PRIOR).length;
   }
 
-  console.log('─── Verdicts ─────────────────────────────────────────────────');
+  console.log(`─── Verdicts (cohort: ${COHORT}) ──────────────────────────────`);
   for (const [v, n] of Object.entries(verdictTally).sort((a, b) => b[1] - a[1])) {
     console.log(`  ${v.padEnd(22)} ${String(n).padStart(5)}`);
   }
-  console.log('\n  none_found means "nothing found in THIS set", never "we are first".');
+  console.log(COHORT === 'inverse'
+    ? '\n  INVERSE COHORT — these books carry NO badge. Here `none_found` does not\n'
+      + '  confirm a claim, it SURFACES a possible one: a work with no English\n'
+      + '  translation in the reference set that we have translated and never claimed.\n'
+      + '  It is a candidate for the first-translation pipeline, not a verdict.'
+    : '\n  none_found means "nothing found in THIS set", never "we are first".');
   console.log('  not_searchable means we could not ask — it is not a clean negative.');
   console.log('  inconclusive means a real candidate needs screening before any claim.');
 
@@ -534,7 +561,7 @@ await withMongo(async (db) => {
   console.log(`\n  ${needScreening.length} book(s) have candidates awaiting screening.`);
 
   fs.mkdirSync(OUT_DIR, { recursive: true });
-  const outPath = path.join(OUT_DIR, `ft-reference-set-search-${DATE}.json`);
+  const outPath = path.join(OUT_DIR, `ft-reference-set-search-${COHORT}-${DATE}.json`);
   fs.writeFileSync(outPath, JSON.stringify({
     reference_set: REFERENCE_SET,
     code_version: CODE_VERSION,

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -43,6 +43,8 @@ import {
   matchWorkIdentity,
   normaliseTitle as norm,
   STRONG_WORK_IDENTITY as STRONG,
+  hasCjk,
+  cjkRuns,
 } from '../lib/work-identity-match.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -374,7 +376,10 @@ await withMongo(async (db) => {
 
     // Searchable means an access point existed AND we could actually run the
     // query. A refused (over-large) pool is NOT a clean negative.
-    const searchable = queries.length > 0 && bookToks.length > 0 && !refusedPool;
+    // A CJK title yields no Latin tokens but IS searchable via original script,
+    // so token emptiness alone must not mark a book unaskable.
+    const hasVernacular = [book.title, book.work_title].filter(Boolean).some(hasCjk);
+    const searchable = queries.length > 0 && (bookToks.length > 0 || hasVernacular) && !refusedPool;
 
     if (searchable) {
       byTradition[lang].searchable++;
@@ -382,6 +387,7 @@ await withMongo(async (db) => {
         // Uniform-title containment first: it is the work-identity test. Fall
         // back to display-title overlap only when there is no 240 to use.
         const best = matchWorkIdentity(bookToks, row, {
+          bookTitles: [book.title, book.work_title].filter(Boolean),
           bookAuthorSurname: sn || surname(book.author),
           recordAuthorSurnames: [row.author, ...(row.added_entries || [])]
             .filter(Boolean).map(surname).filter(Boolean),

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -381,7 +381,11 @@ await withMongo(async (db) => {
       for (const row of pool) {
         // Uniform-title containment first: it is the work-identity test. Fall
         // back to display-title overlap only when there is no 240 to use.
-        const best = matchWorkIdentity(bookToks, row);
+        const best = matchWorkIdentity(bookToks, row, {
+          bookAuthorSurname: sn || surname(book.author),
+          recordAuthorSurnames: [row.author, ...(row.added_entries || [])]
+            .filter(Boolean).map(surname).filter(Boolean),
+        });
         if (!best || best.score < MIN_CANDIDATE) continue;
         const { screen, reason } = screenCandidate(book, row, best);
         candidates.push({
@@ -391,6 +395,7 @@ await withMongo(async (db) => {
           year: row.year,
           original_languages: row.original_languages,
           publisher: row.publisher || undefined,
+          record_author: row.author || undefined,
           work_identity: best,
           screen,
           reason,

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -368,6 +368,22 @@ const REFERENCE_SET = {
       'snapshot ends 2016 — later translations absent by construction, not by evidence',
       'European scholarly presses (Brill, Brepols) under-represented relative to US imprints',
       'journal-published and dissertation translations largely uncatalogued',
+      // RECALL CEILING — stated first because it caps what any `none_found` here
+      // can mean. 35.2% of rows (41,678 of 118,352) carry no MARC 240 uniform
+      // title, and work identity is established by 240 containment; the 245
+      // display-title fallback is deliberately capped below the confirmation
+      // threshold to suppress noise. So over a third of the reference set is
+      // unreachable as a confirmed match and `none_found` is systematically
+      // OVER-reported in both cohorts.
+      'RECALL CEILING: 35.2% of rows have no 240 uniform title and cannot produce '
+        + 'a confirmed match, so `none_found` is over-reported by an unmeasured margin.',
+      // A second, related gap: scholarly editions that print an ancient text
+      // alongside its translation are frequently catalogued with NO 041 at all
+      // (Langdon\'s *Babylonian Liturgies* has none; 22 of 23 LoC records for
+      // Budge\'s *Book of the Dead* have none). The extraction filter requires
+      // 041$h, so that whole class is absent from the set by construction.
+      'scholarly editions printing a text WITH its translation often carry no 041 '
+        + 'and are therefore excluded from this set entirely',
       // The most consequential gap in this set, stated first because a CJK
       // `none_found` would otherwise read as evidence when it is nearly vacuous.
       'CJK works are reachable ONLY via an original-script (MARC 880) title, and '

--- a/scripts/eval/ft-screening-triage.mjs
+++ b/scripts/eval/ft-screening-triage.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * ft-screening-triage.mjs — the SCREENING judgements, recorded as code. (#3459)
+ *
+ * The reference-set search (ft-reference-set-search.mjs) retrieves candidates and
+ * refuses to decide the arguable ones: it marks them `unresolved`, which blocks a
+ * `none_found` verdict. This file is where that decision gets made, and it is
+ * checked in rather than done in a chat window for one reason — a screening
+ * judgement is a claim about a public badge, so it must be attributable,
+ * reviewable, and re-runnable.
+ *
+ * Each entry below is a judgement about ONE work, keyed on the work title as it
+ * appears in our catalogue, with the reason written out. Nothing here flips a
+ * badge; `--apply` writes the screening into `search_efforts` so the derived
+ * verdict updates, and the public flag still moves only through the
+ * sign-off-gated reconcile (#2933).
+ *
+ * THE CRITICAL DISTINCTION, and why so many entries are `first_complete`
+ * ---------------------------------------------------------------------
+ * A prior PARTIAL translation does not defeat "first COMPLETE English
+ * translation". Several candidates here are exactly that, and lumping them in
+ * with real priors would demote badges that are actually defensible:
+ *
+ *   - Flamsteed's *Historia Coelestis Britannica* — the catalogued English item
+ *     is "The preface to ...", a preface, not the work.
+ *   - Fludd's *Utriusque Cosmi Historia* — "The temple of music" is one section
+ *     of an enormous compendium.
+ *   - Servius on Virgil — "commentary on Book four" is one book of twelve.
+ *   - Bélidor's *Architecture hydraulique* — "The mills of Bélidor" is a selection.
+ *   - Avicenna's *Canon* — "The general principles" is Book I.
+ *   - Witelo's *Perspectiva* — "liber secundus et tertius" is books 2-3.
+ *
+ * And some are simply different works that share an author, which the retrieval
+ * layer cannot know: Euclid's *Optics* vs his *Phaenomena*; Jacopo Alighieri's
+ * metrical index vs illustrations for his father's Comedy.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/eval/ft-screening-triage.mjs            # report
+ *   node scripts/eval/ft-screening-triage.mjs --apply    # write screening
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+import { SCREEN, deriveVerdict, latestEffortPerBook } from '../lib/search-effort.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+const APPLY = process.argv.includes('--apply');
+const DATE = new Date().toISOString().slice(0, 10);
+
+/**
+ * PRIOR — a complete English translation of this work demonstrably predates
+ * ours. These badges are not defensible and are recommended for demotion.
+ */
+const PRIOR = [
+  ['De formula honestae vitae', 'pseudo-Seneca. Whittington\'s "A frutefull worke" (1546) is a complete rendering. 10 duplicate book records carry this badge.'],
+  ['De Officiis', 'Cicero. Nicholas Grimald, "Thre bokes of duties" (1556), complete; reprinted 1558.'],
+  ['Plutarchi Chaeronensis Moralia', 'Plutarch. 1561 "Three morall treatises" is partial, but Goodwin\'s "Plutarch\'s morals" (1870) is the complete Moralia.'],
+  ['Στοιχεῖα (Elements)', 'Euclid. Billingsley (1570) from the Latin; Heath (1908/1955) directly from the Greek — so even "first from the Greek" fails.'],
+  ['Complete Works of Euclid, Vol. 5 (Elements, Scholia)', 'Same as Στοιχεῖα — Heath covers the Elements complete from the Greek.'],
+  ['De consolatione philosophiae', 'Boethius. English since Alfred; "Fiue bookes of philosophicall comfort" (1609) is a complete early modern rendering.'],
+  ['The Iliad of Homer', 'Homer. Chapman\'s complete Iliad, 1609/1611.'],
+  ['The Iliad and Odyssey of Homer', 'Homer. Chapman: Iliad 1611, Odysses 1614 — both complete.'],
+  ['Magia Naturalis', 'Della Porta. "Natural magick" (1658) is the complete twenty books.'],
+  ['Della Porta Magia Naturalis (German 1713)', 'Same work as above; the 1658 English precedes this German edition regardless.'],
+  ['Tractatus theologico-politicus', 'Spinoza. "A treatise partly theological, and partly political" (1689), complete.'],
+  ['Epigrammata', 'Martial. "Epigrams of Martial, Englished" (1695); complete Bohn edition 1877.'],
+  ['Poetics', 'Aristotle. English since 1775; many complete translations follow.'],
+  ['Divina Commedia', 'Dante. English complete since Cary (1814); Longfellow 1867.'],
+  ['Gītagovinda', 'Jayadeva. Edwin Arnold, "The Indian Song of Songs" (1884); Barbara Stoler Miller (1977).'],
+  ['Epistulae morales ad Lucilium', 'Seneca. Gummere\'s complete Loeb (1917-25); "Seneca\'s letters to Lucilius" 1932.'],
+  ['Institutio Christianae religionis', 'Calvin. Norton\'s English Institutes 1561; Battles/McNeill 1960.'],
+  ['Ko-i Genji Monogatari (校異源氏物語), Vol. 1', 'Murasaki. Waley (1925-33) and Seidensticker (1976) are complete.'],
+  ['Genji Monogatari Ekotoba (源氏物語絵詞), Vol. 3', 'Same work as above.'],
+  ['Genji Monogatari Ekotoba (源氏物語絵詞), Vol. 1', 'Same work as above.'],
+  ['Works and Days with the Commentary of Proclus', 'Hesiod. The Works and Days has complete English translations well before 1959.'],
+  ['De architectura', 'Vitruvius. English complete since Newton (1771); Morgan 1914.'],
+  ['Nicomachean Ethics (with Averroes\' Commentary)', 'Aristotle. Complete English since the 17th c.; the Averroes commentary is the novel part, not the Ethics.'],
+  ['Epistolae', 'Ficino. The School of Economic Science translation of the Letters is complete and ongoing from 1975.'],
+  ['Platon : Gorgias', 'Plato. Complete English Gorgias since Jowett (1871).'],
+  ['Metaphysics and Ethics', 'Aristotle. Both texts have long-standing complete English translations.'],
+  ['The New Thoughts of Galileo', 'Galileo. "Dialogues concerning two new sciences" — Crew/de Salvio 1914, complete.'],
+  ['Institutio Theologica', 'Proclus. E. R. Dodds, "The Elements of Theology" (1933), complete with facing Greek.'],
+  ['Isagoge', 'Porphyry. Complete English translations well before 2003 (Warren 1975).'],
+  ['Mimiambi', 'Herodas. Complete English since Knox/Headlam (1922).'],
+  ['Geography', 'Strabo. Jones\'s complete Loeb Geography (1917-32).'],
+  ['De subtilitate', 'Cardano. The 2013 Forrester translation is complete — and predates ours.'],
+  ['Logical Works', 'Zabarella. "On methods" (2013) covers the logical works in English.'],
+  ['Timaeus, Asclepius, De deo Socratis, De mundo', 'Plato/Apuleius. Cornford\'s "Plato\'s cosmology" (1937) is a complete Timaeus; the Apuleius texts also have English versions.'],
+];
+
+/**
+ * FIRST_COMPLETE — the catalogued English item is genuinely PARTIAL, so a
+ * "first COMPLETE English translation" claim survives. These should be
+ * re-labelled rather than demoted, and the prior credited.
+ */
+const FIRST_COMPLETE = [
+  ['Historia Coelestis Britannica Vol. 1', 'The only English item is "The preface to Flamsteed\'s Historia" — a preface, not the work.'],
+  ['Historia Coelestis Britannica Vol. 2', 'As Vol. 1 — preface only.'],
+  ['Historia Coelestis Britannica Vol. 3', 'As Vol. 1 — preface only.'],
+  ['Utriusque Cosmi Historia', '"The temple of music" is one section of Fludd\'s compendium, not the whole.'],
+  ['Servius the Grammarian, Commentaries on the Poems of Virgil', '"Commentary on Book four" is one book of twelve.'],
+  ['Commentary on the Poems of Virgil, Vol. I', 'As above — Book four only.'],
+  ['In Vergilii carmina commentarii, Vol. II', 'As above — Book four only.'],
+  ['Hydraulic Architecture, Volume One, Part One', '"The mills of Bélidor" is a selection, not the complete Architecture hydraulique.'],
+  ['Hydraulic Architecture, Volume One, Part Two', 'As above — selection only.'],
+  ['Hydraulic Architecture, Volume Two, Part One', 'As above — selection only.'],
+  ['Hydraulic Architecture, Volume 2, Part 2', 'As above — selection only.'],
+  ['al-Qānūn fī al-Ṭibb', '"The general principles of Avicenna\'s Canon" is Book I of five.'],
+  ['Optics', 'Witelo. "Perspectivae liber secundus et tertius" is books 2-3 of ten.'],
+  ['Margarita philosophica', '"Natural philosophy epitomised" renders part of Reisch, not the whole Margarita.'],
+  ['Aristotle with John Philoponus Commentary on Prior Analytics', 'The Aristotle text is long translated; the Philoponus commentary is the untranslated part.'],
+  ['Complete Works of Euclid, Vol. 6 (Optics, Catoptrics)', 'The catalogued item is the ARABIC version of the Optics in English — a different transmission line.'],
+  ['A Little Book on Colors', 'Telesio. "On colours" (2002) — verify whether complete before finalising; provisionally partial.'],
+];
+
+/**
+ * NOT_A_PRIOR — retrieval was right about the author, wrong about the work.
+ * These are false positives and must not touch the badge.
+ */
+const NOT_A_PRIOR = [
+  ['Euclid\'s Optics', 'Matched "Euclid\'s Phaenomena" — a DIFFERENT work by Euclid.'],
+  ['Jacopo Dante, Metrical Index to his Father\'s Comedy', 'Matched "The illustrations for Dante\'s Divine comedy" — a different work entirely.'],
+  ['Carceri d\'Invenzione (Imaginary Prisons)', 'Piranesi\'s Carceri is a print series, not a text; there is nothing to translate.'],
+  ['Introduction à l\'Histoire du Buddhisme Indien', 'Matched "Legends of Indian Buddhism" — a different Burnouf work. (Buffetrille/Lopez translated the Introduction in 2010, so re-check separately.)'],
+  ['Adagiorum Desiderii Erasmi Roterodami epitome', 'Matched "The plea of reason, religion and humanity" (1813), which is not the Adagia. Erasmus\'s Adages DO exist in English (CWE 31-36) — re-screen against that, not this record.'],
+  ['Roger Bacon Alchemical Compendium', 'Matched a truncated "Bacon :" record with a French source language — not a reliable identification.'],
+  ['Unpublished Works of Roger Bacon (Opus Tertium)', 'As above — the "Bacon :" record is not identifiable as this work.'],
+  ['The Philosophy of Roger Bacon', 'As above.'],
+  ['Les  fables egyptiennes et grecques dévoilées', 'Matched "An alchemical treatise on the great art" — needs a positive identification before any claim; not established.'],
+];
+
+/** Everything else in the inconclusive set stays unresolved pending research. */
+const UNRESOLVED_NOTE = 'not screened in this pass — remains unresolved by design';
+
+const SCREEN_FOR = new Map();
+for (const [work, reason] of PRIOR) SCREEN_FOR.set(work, { screen: SCREEN.PRIOR, reason });
+for (const [work, reason] of FIRST_COMPLETE) SCREEN_FOR.set(work, { screen: SCREEN.PARTIAL, reason });
+for (const [work, reason] of NOT_A_PRIOR) SCREEN_FOR.set(work, { screen: SCREEN.DIFFERENT_WORK, reason });
+
+await withMongo(async (db) => {
+  const coll = db.collection('search_efforts');
+  const all = await coll.find({}, {
+    projection: { effort_id: 1, book_id: 1, run_at: 1, verdict: 1, proposition: 1, candidates: 1, searchable: 1 },
+  }).toArray();
+  const current = latestEffortPerBook(all);
+  const efforts = current.filter((e) => e.verdict === 'inconclusive');
+  console.log(`search_efforts rows: ${all.length} across all generations`);
+  console.log(`current generation (latest per book): ${current.length}`);
+  console.log(`...of which inconclusive: ${efforts.length}\n`);
+
+  const tally = { prior: 0, first_complete: 0, not_a_prior: 0, unscreened: 0 };
+  const updates = [];
+  const rows = [];
+
+  for (const e of efforts) {
+    const work = e.proposition.match(/of "([^"]+)"/)?.[1] ?? '';
+    const decision = SCREEN_FOR.get(work);
+    if (!decision) {
+      tally.unscreened++;
+      rows.push({ work, book_id: e.book_id, decision: 'unscreened', reason: UNRESOLVED_NOTE });
+      continue;
+    }
+
+    const candidates = e.candidates.map((c) => (
+      c.screen === SCREEN.UNRESOLVED
+        ? { ...c, screen: decision.screen, reason: `[screened ${DATE}] ${decision.reason}`, screened_at: new Date() }
+        : c
+    ));
+    const verdict = deriveVerdict({ candidates, searchable: e.searchable });
+
+    if (decision.screen === SCREEN.PRIOR) tally.prior++;
+    else if (decision.screen === SCREEN.PARTIAL) tally.first_complete++;
+    else tally.not_a_prior++;
+
+    rows.push({ work, book_id: e.book_id, decision: decision.screen, verdict, reason: decision.reason });
+    updates.push({
+      updateOne: {
+        filter: { effort_id: e.effort_id },
+        update: { $set: { candidates, verdict, screened_at: new Date(), screened_by: 'ft-screening-triage' } },
+      },
+    });
+  }
+
+  console.log('─── Screening outcome ────────────────────────────────────────');
+  console.log(`  PRIOR (badge not defensible — recommend demote) : ${tally.prior}`);
+  console.log(`  PARTIAL prior only (first_complete stands)      : ${tally.first_complete}`);
+  console.log(`  NOT a prior (retrieval false positive)          : ${tally.not_a_prior}`);
+  console.log(`  left unresolved on purpose                      : ${tally.unscreened}`);
+  console.log('\n  A partial prior does NOT defeat "first complete". Collapsing the');
+  console.log('  middle row into the first would demote defensible badges.');
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const out = path.join(OUT_DIR, `ft-screening-triage-${DATE}.json`);
+  fs.writeFileSync(out, JSON.stringify({ date: DATE, tally, rows }, null, 2));
+  console.log(`\nWrote ${out}`);
+
+  if (!APPLY) {
+    console.log('REPORT ONLY — no screening written. Re-run with --apply.');
+    return;
+  }
+  let n = 0;
+  for (let i = 0; i < updates.length; i += 500) {
+    const res = await coll.bulkWrite(updates.slice(i, i + 500), { ordered: false });
+    n += res.modifiedCount;
+  }
+  console.log(`APPLIED — ${n} efforts screened. NO badge was changed; demotes still need sign-off.`);
+});

--- a/scripts/eval/ft-screening-triage.mjs
+++ b/scripts/eval/ft-screening-triage.mjs
@@ -142,6 +142,16 @@ for (const [work, reason] of NOT_A_PRIOR) SCREEN_FOR.set(work, { screen: SCREEN.
 
 await withMongo(async (db) => {
   const coll = db.collection('search_efforts');
+  // Screening decisions are DURABLE, stored separately from the effort they were
+  // first applied to. An effort is immutable and a new reference-set snapshot or
+  // code version mints a new one — so attaching judgements only to an effort
+  // means every re-run silently discards them. Observed: adding Wikidata created
+  // a new generation and dropped all 45 demote decisions on the floor.
+  //
+  // A judgement is about a (work, prior record) pair, not about a run, so it is
+  // keyed that way and re-applied by the search on every subsequent generation.
+  // That is what makes this a living, correctable census rather than a snapshot.
+  const decisions = db.collection('screening_decisions');
   const all = await coll.find({}, {
     projection: { effort_id: 1, book_id: 1, run_at: 1, verdict: 1, proposition: 1, candidates: 1, searchable: 1 },
   }).toArray();
@@ -201,6 +211,27 @@ await withMongo(async (db) => {
     console.log('REPORT ONLY — no screening written. Re-run with --apply.');
     return;
   }
+  // Persist the judgements first, so they survive the next re-run regardless of
+  // what happens to this generation's efforts.
+  await decisions.createIndex({ work: 1 }, { unique: true });
+  const decisionDocs = [...SCREEN_FOR.entries()].map(([work, d]) => ({
+    updateOne: {
+      filter: { work },
+      update: {
+        $set: {
+          work,
+          screen: d.screen,
+          reason: d.reason,
+          decided_at: new Date(),
+          decided_by: 'ft-screening-triage',
+        },
+      },
+      upsert: true,
+    },
+  }));
+  await decisions.bulkWrite(decisionDocs, { ordered: false });
+  console.log(`Persisted ${decisionDocs.length} durable screening decisions.`);
+
   let n = 0;
   for (let i = 0; i < updates.length; i += 500) {
     const res = await coll.bulkWrite(updates.slice(i, i + 500), { ordered: false });

--- a/scripts/eval/ft-translation-queue.mjs
+++ b/scripts/eval/ft-translation-queue.mjs
@@ -39,6 +39,7 @@ import readline from 'readline';
 import { fileURLToPath } from 'url';
 import { withMongo } from '../lib/mongo.mjs';
 import { canonicalLanguage } from '../lib/source-language-match.mjs';
+import { classifySourceLanguage } from '../lib/english-source-detect.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(__dirname, '..', 'output');
@@ -52,6 +53,16 @@ const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null
  */
 const MIN_DEPTH = parseInt(argOf('--min-depth') ?? '500', 10);
 const TOP = parseInt(argOf('--top') ?? '40', 10);
+
+/**
+ * `--visible` restricts to the PUBLIC shelf: books a reader can already reach.
+ *
+ * A different question from the full queue, and usually the more actionable one.
+ * The unpublished holdings are the larger opportunity but every one of them
+ * needs a curation decision before a translation is worth anything; a visible
+ * book is one a reader can hit today and find untranslated.
+ */
+const VISIBLE_ONLY = process.argv.includes('--visible');
 
 /**
  * Languages where DEPTH DOES NOT IMPLY ANSWERABILITY.
@@ -148,6 +159,7 @@ await withMongo(async (db) => {
   for (const e of run.efforts) {
     const b = byId.get(e.book_id);
     if (!b) continue;
+    if (VISIBLE_ONLY && b.visible !== true) continue;
     const canon = canonicalLanguage(b.original_language) ?? canonicalLanguage(b.language);
     rows.push({
       ...b,
@@ -246,8 +258,50 @@ await withMongo(async (db) => {
     // an enumeration, so the shortest is closest to the work's own name.
     if ((r.title || '').length < (w.title || '').length) { w.title = r.title; w.slug = r.slug; w.id = r.id; }
   }
-  const head = [...works.values()]
+  let head = [...works.values()]
     .sort((a, b) => b.editions - a.editions || b.volumes - a.volumes || b.pages - a.pages);
+
+  // ── Source-language screen ────────────────────────────────────────────────
+  //
+  // `books.language` records the language of the WORK, not of the pages we hold.
+  // A re-hosted scholarly edition prints the ancient text with an English
+  // translation, and some of our records are the translation itself: Ganguli's
+  // *Mahābhārata* is catalogued Sanskrit, Avalon's *Serpent Power* is catalogued
+  // Sanskrit, Boehme's *Works* (1781) is catalogued Latin. Every one of them is
+  // already English and needs no translation at all.
+  //
+  // Nothing upstream catches this — it is invisible to the catalogue search,
+  // which is asking a question about the WORK. Read the OCR model's own declared
+  // page language (see english-source-detect.mjs for why provenance and
+  // `pages.ocr.language` both fail here).
+  if (!process.argv.includes('--no-source-screen')) {
+    const pages = db.collection('pages');
+    const kept = [];
+    const alreadyEnglish = [];
+    let undetermined = 0;
+    for (const w of head) {
+      // Sample from the MIDDLE of the book. Front matter (title page, preface,
+      // editor's introduction) is routinely English even in a Latin edition, so
+      // sampling from the start reports the apparatus rather than the text.
+      const skip = Math.max(2, Math.floor((w.pages || 0) * 0.3));
+      const sample = await pages.find(
+        { book_id: w.id, 'ocr.data': { $exists: true, $ne: null } },
+        { projection: { 'ocr.data': 1 }, sort: { page_number: 1 }, skip, limit: 8 },
+      ).toArray();
+      const verdict = classifySourceLanguage(sample.map((p) => p.ocr?.data).filter(Boolean));
+      w.source_language = verdict;
+      if (verdict.verdict === 'english_source') alreadyEnglish.push(w);
+      else { if (verdict.verdict === 'undetermined') undetermined++; kept.push(w); }
+    }
+    head = kept;
+    console.log(`\n─── Source-language screen: ${alreadyEnglish.length} work(s) are ALREADY ENGLISH ───`);
+    console.log('  Catalogued under a foreign language, but the pages we hold are an English');
+    console.log('  edition. They need no translation and are removed from the queue.');
+    for (const w of alreadyEnglish) {
+      console.log(`  ${String(w.canon).padEnd(10)}${String(w.pages).padStart(6)}pp  ${(w.title || '').slice(0, 52).padEnd(54)}${w.source_language.basis}`);
+    }
+    if (undetermined) console.log(`  (${undetermined} work(s) undetermined — too little legible text; kept, flagged in the JSON)`);
+  }
 
   console.log(`\n─── Head of the queue: OCR-ready, no prior found, answerable language ───`);
   console.log(`  ${eligible.length.toLocaleString()} books collapse to ${head.length.toLocaleString()} distinct works.`);
@@ -260,7 +314,18 @@ await withMongo(async (db) => {
       + `${(w.title || '').slice(0, 50).padEnd(52)}${w.visible ? '' : '[hidden] '}${w.year || ''}`);
   }
 
-  const out = path.join(OUT_DIR, `ft-translation-queue-${new Date().toISOString().slice(0, 10)}.json`);
+  // Blocked on OCR, not on evidence. Same finding, different next action: these
+  // need a pipeline run before a translator or a model can touch them, so they
+  // belong on a separate list rather than buried in the queue's tail.
+  const needsOcr = rows.filter((r) => r.verdict === 'none_found' && !r.ocrReady
+    && r.depth >= MIN_DEPTH && !SCRIPT_UNREACHABLE.has(r.canon));
+  console.log(`\n─── Blocked on OCR first: ${needsOcr.length} book(s), no prior found, answerable language ───`);
+  for (const r of needsOcr.slice(0, 12)) {
+    console.log(`  ${String(r.canon).padEnd(11)}${String(r.pages_count ?? 0).padStart(6)}pp  ${(r.title || '').slice(0, 54).padEnd(56)}${r.year || ''}`);
+  }
+
+  const out = path.join(OUT_DIR,
+    `ft-translation-queue${VISIBLE_ONLY ? '-visible' : ''}-${new Date().toISOString().slice(0, 10)}.json`);
   fs.writeFileSync(out, JSON.stringify({
     min_depth: MIN_DEPTH,
     reference_depth: Object.fromEntries([...depth].sort((a, b) => b[1] - a[1])),

--- a/scripts/eval/ft-translation-queue.mjs
+++ b/scripts/eval/ft-translation-queue.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * ft-translation-queue.mjs — what has nobody translated yet? (#3459)
+ *
+ * The reference set was built to defend claims we already make. That is the job
+ * it is WORST suited to, because defending a claim means asserting an absence and
+ * catalogue recall is 27%. This script points the same evidence at the job it is
+ * actually fit for: deciding what to translate next.
+ *
+ * The asymmetry is the whole argument. Prioritisation publishes nothing, so:
+ *   - a MISSED prior costs a wasted translation, caught the moment someone reads it
+ *   - a FALSE prior silently drops a genuinely untranslated work off the queue
+ * Precision on "already done" is what matters, and that is the strong direction
+ * of this instrument (32/32 live identity confirmations; zero contradictions
+ * against 399 independently-classified never_translated books). Every prior found
+ * removes a book with confidence; the 73% missed merely leave the queue noisy.
+ *
+ * THE ONE THING THIS SCRIPT REFUSES TO DO
+ * --------------------------------------
+ * Emit a single ranked list across languages. `none_found` for a French work is
+ * asserted against 23,035 English translations from French in the set; for a
+ * Syriac work it is asserted against 119, and for a Tibetan or Chinese work
+ * against a set that structurally cannot answer (MARC 880 on 2.3% of rows). Those
+ * are not the same finding and a shared sort order would silently equate them —
+ * the exact conflation of "we could not ask" with "we asked and found nothing"
+ * that this whole area exists to prevent.
+ *
+ * So the queue is FACETED by language, every language carries its own reference-
+ * set depth, and languages whose depth cannot support a negative are reported
+ * separately as UNANSWERABLE rather than ranked low.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/eval/ft-translation-queue.mjs [--min-depth 500] [--top 40]
+ */
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+import { canonicalLanguage } from '../lib/source-language-match.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
+
+/**
+ * Below this many English translations FROM a language in the reference set, a
+ * `none_found` is not evidence of absence and the books are reported as
+ * unanswerable rather than queued. 500 is a declared floor, not a tuned one —
+ * it is stated here so a reader can disagree with it and recompute.
+ */
+const MIN_DEPTH = parseInt(argOf('--min-depth') ?? '500', 10);
+const TOP = parseInt(argOf('--top') ?? '40', 10);
+
+/**
+ * Languages where DEPTH DOES NOT IMPLY ANSWERABILITY.
+ *
+ * The set holds 3,868 English translations from Chinese and 5,209 from Japanese,
+ * so a depth floor waves them straight through. But CJK works are reachable in
+ * this set only through an original-script (MARC 880) title, and LoC English-
+ * translation records carry one on 205 of 8,774 CJK-source rows — 2.3%. A
+ * romanized match is unusable (mixed pinyin/Wade-Giles, differing syllable
+ * segmentation). So a Chinese `none_found` is close to uninformative no matter
+ * how deep the set looks by row count.
+ *
+ * This matters more than any other caveat here: Chinese is the second-largest
+ * block in the queue (12,364 works with no prior found) and the least
+ * trustworthy. Ranking it on depth alone would put the least reliable evidence at
+ * the top of the list and say nothing about it.
+ */
+const SCRIPT_UNREACHABLE = new Map([
+  ['chinese', 'reachable only via MARC 880 original-script title, present on 2.3% of CJK rows'],
+  ['japanese', 'reachable only via MARC 880 original-script title, present on 2.3% of CJK rows'],
+  ['korean', 'reachable only via MARC 880 original-script title, present on 2.3% of CJK rows'],
+  ['tibetan', 'romanized Wylie only; the generic-term stoplist is unreviewed by a Tibetanist'],
+]);
+
+const latest = (cohort) => {
+  const f = fs.readdirSync(OUT_DIR)
+    .filter((x) => new RegExp(`^ft-reference-set-search-${cohort}-\\d{4}-\\d{2}-\\d{2}\\.json$`).test(x))
+    .sort().pop();
+  if (!f) throw new Error(`no ${cohort} run — node scripts/eval/ft-reference-set-search.mjs --cohort ${cohort}`);
+  return path.join(OUT_DIR, f);
+};
+
+// ── Reference-set depth, per source language ────────────────────────────────
+// How many English translations FROM this language does the set actually hold?
+// This is what bounds a null, and it is why a single ranked list would lie.
+async function referenceDepth() {
+  const depth = new Map();
+  const add = (lang, n = 1) => {
+    const c = canonicalLanguage(lang);
+    if (c) depth.set(c, (depth.get(c) ?? 0) + n);
+  };
+  for (const dir of ['loc-bulk', 'wikidata']) {
+    const full = path.join(OUT_DIR, dir);
+    if (!fs.existsSync(full)) continue;
+    for (const file of fs.readdirSync(full).filter((f) => f.endsWith('.jsonl'))) {
+      const rl = readline.createInterface({
+        input: fs.createReadStream(path.join(full, file)), crlfDelay: Infinity,
+      });
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        const row = JSON.parse(line);
+        if (row.original_language_label) add(row.original_language_label);
+        else for (const l of row.original_languages ?? []) add(l);
+      }
+    }
+  }
+  return depth;
+}
+
+const run = JSON.parse(fs.readFileSync(latest('untranslated'), 'utf8'));
+console.log(`Reading ${path.basename(latest('untranslated'))} — ${run.efforts.length.toLocaleString()} efforts\n`);
+
+const depth = await referenceDepth();
+
+await withMongo(async (db) => {
+  const books = await db.collection('books').find(
+    { id: { $in: run.efforts.map((e) => e.book_id) } },
+    { projection: { id: 1, slug: 1, title: 1, author: 1, language: 1, original_language: 1, year: 1, work_id: 1, pages_count: 1, pages_ocr: 1, visible: 1 } },
+  ).toArray();
+  const byId = new Map(books.map((b) => [b.id, b]));
+
+  // Books sharing a work_id, and how many DISTINCT years are among them.
+  //
+  // The obvious significance proxy — "how many copies of this work do we hold" —
+  // is wrong, and the first run of this script proved it: the entire head of the
+  // queue was 御定佩文韻府, a Qing rhyme dictionary held as 728 sequential
+  // 25-page VOLUME records under one work_id. That counted as 728 editions and
+  // buried everything else. Multi-volume serials are not popularity.
+  //
+  // Distinct publication years separate the two: genuine re-editions of a valued
+  // work differ in year, volumes of one set share it.
+  const worksBooks = new Map();
+  for (const b of books) {
+    const k = b.work_id || `book:${b.id}`;
+    if (!worksBooks.has(k)) worksBooks.set(k, []);
+    worksBooks.get(k).push(b);
+  }
+  const editionsOfWork = new Map();
+  for (const [k, list] of worksBooks) {
+    editionsOfWork.set(k, new Set(list.map((b) => b.year).filter(Boolean)).size || 1);
+  }
+
+  const rows = [];
+  for (const e of run.efforts) {
+    const b = byId.get(e.book_id);
+    if (!b) continue;
+    const canon = canonicalLanguage(b.original_language) ?? canonicalLanguage(b.language);
+    rows.push({
+      ...b,
+      verdict: e.verdict,
+      canon,
+      depth: canon ? (depth.get(canon) ?? 0) : 0,
+      ocrReady: (b.pages_ocr ?? 0) > 0,
+      workKey: b.work_id || `book:${b.id}`,
+      editions: editionsOfWork.get(b.work_id || `book:${b.id}`) ?? 1,
+    });
+  }
+
+  const tally = {};
+  for (const r of rows) tally[r.verdict] = (tally[r.verdict] || 0) + 1;
+  console.log('─── Verdicts over the untranslated holdings ──────────────────');
+  for (const [v, n] of Object.entries(tally).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${v.padEnd(22)} ${String(n).padStart(7)}`);
+  }
+  console.log('\n  none_found   = nobody in this reference set has done it. A LEAD, not a fact.');
+  console.log('  inconclusive = a candidate prior nobody has screened. Screen BEFORE spending.');
+  console.log('  prior_found  = English already exists. Drop it.');
+  console.log('');
+  console.log('  READ `prior_found` CAREFULLY — it is small for a mechanical reason, not');
+  console.log('  because the holdings are untranslated. The mechanical screen never asserts');
+  console.log('  PRIOR on its own; it defers anything needing bibliographic judgement to');
+  console.log('  `unresolved`. So `prior_found` here counts only works a human already ruled');
+  console.log('  on (60 durable decisions), and the real "already done" pile is the');
+  console.log('  `inconclusive` column. Screening that is what actually shortens this queue —');
+  console.log('  do not read a small prior_found as evidence the queue is clean.\n');
+
+  // ── Faceted by language ───────────────────────────────────────────────────
+  const byLang = new Map();
+  for (const r of rows) {
+    const k = r.canon ?? '(unresolved language)';
+    if (!byLang.has(k)) byLang.set(k, { lang: k, depth: r.depth, total: 0, none: 0, prior: 0, inconc: 0, ready: 0 });
+    const g = byLang.get(k);
+    g.total++;
+    if (r.verdict === 'none_found') { g.none++; if (r.ocrReady) g.ready++; }
+    if (r.verdict === 'prior_found') g.prior++;
+    if (r.verdict === 'inconclusive') g.inconc++;
+  }
+  const langs = [...byLang.values()].sort((a, b) => b.none - a.none);
+  for (const l of langs) l.unreachable = SCRIPT_UNREACHABLE.get(l.lang) ?? null;
+  const answerable = langs.filter((l) => l.depth >= MIN_DEPTH && !l.unreachable);
+  const unanswerable = langs.filter((l) => l.depth < MIN_DEPTH || l.unreachable);
+
+  console.log(`─── QUEUE — languages the reference set can actually answer (depth >= ${MIN_DEPTH}) ───`);
+  console.log(`  ${'language'.padEnd(18)}${'set depth'.padStart(10)}${'held'.padStart(8)}${'no prior'.padStart(10)}${'OCR-ready'.padStart(11)}${'prior'.padStart(8)}${'unscreened'.padStart(11)}`);
+  for (const l of answerable.slice(0, 20)) {
+    console.log(`  ${l.lang.padEnd(18)}${String(l.depth).padStart(10)}${String(l.total).padStart(8)}`
+      + `${String(l.none).padStart(10)}${String(l.ready).padStart(11)}${String(l.prior).padStart(8)}${String(l.inconc).padStart(11)}`);
+  }
+  const sum = (arr, k) => arr.reduce((n, x) => n + x[k], 0);
+  console.log(`  ${'TOTAL'.padEnd(18)}${''.padStart(10)}${String(sum(answerable, 'total')).padStart(8)}`
+    + `${String(sum(answerable, 'none')).padStart(10)}${String(sum(answerable, 'ready')).padStart(11)}`
+    + `${String(sum(answerable, 'prior')).padStart(8)}${String(sum(answerable, 'inconc')).padStart(11)}`);
+
+  console.log('\n─── NOT A QUEUE — the set cannot support a negative here ───');
+  console.log('  These are not low-priority. They are UNMEASURED: a null says nothing, and');
+  console.log('  answering them needs a tradition-native catalogue (84000/BDRC, CBETA/ctext).');
+  console.log(`  Either the set is too thin (depth < ${MIN_DEPTH}) or the work is unreachable by`);
+  console.log('  the only key the set indexes on — note that CJK fails on REACHABILITY while');
+  console.log('  looking perfectly deep by row count.\n');
+  for (const l of unanswerable.slice(0, 14)) {
+    console.log(`  ${l.lang.padEnd(14)}${String(l.depth).padStart(7)} depth  ${String(l.total).padStart(6)} held, ${String(l.none).padStart(6)} unmeasured`
+      + `${l.unreachable ? `\n      ^ ${l.unreachable}` : ''}`);
+  }
+  console.log(`  ${'TOTAL'.padEnd(18)}${''.padStart(10)}         ${String(sum(unanswerable, 'total')).padStart(6)} held, ${String(sum(unanswerable, 'none')).padStart(6)} unmeasured`);
+
+  // ── The actionable head of the queue ──────────────────────────────────────
+  //
+  // ONE ROW PER WORK, not per book. You decide to translate the *Peiwen Yunfu*,
+  // not volume 621 of it, and a per-book list makes a single 728-volume set look
+  // like 728 opportunities. Collapsing by work_id also turns the size of a
+  // multi-volume undertaking into visible information (18,200 pages) instead of
+  // hiding it as repetition.
+  // Must apply BOTH gates the language table applies — depth AND reachability.
+  // Filtering on depth alone left 11,033 Chinese books in the head of the queue
+  // while the table above reported them as unmeasured: the same run contradicting
+  // itself, with the unreliable evidence sitting at the top.
+  const eligible = rows.filter((r) => r.verdict === 'none_found' && r.ocrReady
+    && r.depth >= MIN_DEPTH && !SCRIPT_UNREACHABLE.has(r.canon));
+  const works = new Map();
+  for (const r of eligible) {
+    if (!works.has(r.workKey)) {
+      works.set(r.workKey, {
+        workKey: r.workKey, canon: r.canon, depth: r.depth, editions: r.editions,
+        volumes: 0, pages: 0, title: r.title, author: r.author, year: r.year,
+        slug: r.slug, id: r.id, visible: r.visible,
+      });
+    }
+    const w = works.get(r.workKey);
+    w.volumes++;
+    w.pages += r.pages_ocr ?? 0;
+    // Show the shortest title in the set — volume titles are the base title plus
+    // an enumeration, so the shortest is closest to the work's own name.
+    if ((r.title || '').length < (w.title || '').length) { w.title = r.title; w.slug = r.slug; w.id = r.id; }
+  }
+  const head = [...works.values()]
+    .sort((a, b) => b.editions - a.editions || b.volumes - a.volumes || b.pages - a.pages);
+
+  console.log(`\n─── Head of the queue: OCR-ready, no prior found, answerable language ───`);
+  console.log(`  ${eligible.length.toLocaleString()} books collapse to ${head.length.toLocaleString()} distinct works.`);
+  console.log('  Ordered by distinct editions held, then volumes, then length. Deliberately');
+  console.log('  NOT a score — no weights are invented, and the columns are shown so you can');
+  console.log('  disagree with the ordering rather than trust it.\n');
+  console.log(`  ${'lang'.padEnd(11)}${'ed'.padStart(3)}${'vol'.padStart(5)}${'pages'.padStart(8)}  title`);
+  for (const w of head.slice(0, TOP)) {
+    console.log(`  ${String(w.canon).padEnd(11)}${String(w.editions).padStart(3)}${String(w.volumes).padStart(5)}${String(w.pages).padStart(8)}  `
+      + `${(w.title || '').slice(0, 50).padEnd(52)}${w.visible ? '' : '[hidden] '}${w.year || ''}`);
+  }
+
+  const out = path.join(OUT_DIR, `ft-translation-queue-${new Date().toISOString().slice(0, 10)}.json`);
+  fs.writeFileSync(out, JSON.stringify({
+    min_depth: MIN_DEPTH,
+    reference_depth: Object.fromEntries([...depth].sort((a, b) => b[1] - a[1])),
+    verdicts: tally,
+    by_language: langs,
+    queue: head.map((w) => ({
+      work_key: w.workKey, id: w.id, slug: w.slug, title: w.title, author: w.author,
+      year: w.year, language: w.canon, reference_set_depth: w.depth,
+      distinct_editions_held: w.editions, volumes: w.volumes, ocr_pages: w.pages,
+      visible: w.visible,
+    })),
+  }, null, 2));
+  console.log(`\nWrote ${out}`);
+}, { noTimeout: true });

--- a/scripts/eval/ft-verify-demote-packet.mjs
+++ b/scripts/eval/ft-verify-demote-packet.mjs
@@ -199,4 +199,10 @@ await withMongo(async (db) => {
   const out = path.join(OUT_DIR, `ft-demote-packet-${DATE}.json`);
   fs.writeFileSync(out, JSON.stringify({ date: DATE, tally, rows }, null, 2));
   console.log(`\nWrote ${out}`);
-});
+// This run is dominated by DELIBERATELY PACED live LoC fetches — 33 works x up
+// to 4 records x 1.5s — so it necessarily outlives the default script timeout.
+// Without this it force-exited at 300s having completed 31 of 33 works and
+// written nothing at all: every fetch discarded, and a non-zero exit that reads
+// like a network failure rather than "you ran out of clock". The Mongo
+// connection is idle throughout; the wall time is the rate limit we chose.
+}, { noTimeout: true });

--- a/scripts/eval/ft-verify-demote-packet.mjs
+++ b/scripts/eval/ft-verify-demote-packet.mjs
@@ -71,8 +71,28 @@ async function fetchByLccn(lccn) {
 await withMongo(async (db) => {
   const all = await db.collection('search_efforts').find({}).toArray();
   const current = latestEffortPerBook(all);
-  const proposed = current.filter((e) => e.candidates?.some((c) => c.screen === SCREEN.PRIOR));
-  console.log(`Proposed demotes in the current generation: ${proposed.length}\n`);
+  const withPrior = current.filter((e) => e.candidates?.some((c) => c.screen === SCREEN.PRIOR));
+
+  // A DEMOTE presupposes a badge. `search_efforts` covers both cohorts, and the
+  // inverse cohort is by definition unbadged — finding a prior there is a normal,
+  // uninteresting result (we translated something that already existed in
+  // English), not a claim to retract. Unfiltered, 115 of 162 prior-bearing
+  // efforts were unbadged books, and because the packet groups by WORK and
+  // reports `books.size` as the number of badges affected, they inflated that
+  // count without changing the work list.
+  //
+  // Gate on `books.is_first_translation`, not on `effort.cohort`: the cohort is
+  // what the search believed when it ran, while the flag is the claim actually on
+  // the site right now. If a badge moved in between, the flag is right and the
+  // cohort is stale.
+  const badgedNow = new Set((await db.collection('books').find(
+    { id: { $in: withPrior.map((e) => e.book_id) }, is_first_translation: true },
+    { projection: { id: 1 } },
+  ).toArray()).map((b) => b.id));
+  const proposed = withPrior.filter((e) => badgedNow.has(e.book_id));
+  console.log(`Efforts with a screened prior: ${withPrior.length}`);
+  console.log(`  ...on a book that actually carries the badge: ${proposed.length}`);
+  console.log(`  ...unbadged, so nothing to demote: ${withPrior.length - proposed.length}\n`);
 
   // Group by WORK, not by record. The question is not "is this particular
   // edition complete" but "does at least one COMPLETE prior English rendering of

--- a/scripts/eval/ft-verify-demote-packet.mjs
+++ b/scripts/eval/ft-verify-demote-packet.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * ft-verify-demote-packet.mjs — the sign-off packet for proposed demotes. (#3459)
+ *
+ * Every screened `prior_translation` candidate is re-fetched LIVE from LoC by its
+ * LCCN and re-derived from that record, independently of the bulk extract the
+ * search ran against. A recommendation that survives being re-fetched from the
+ * authority is a different thing from one that survives my own snapshot.
+ *
+ * TWO EVIDENTIARY GRADES, KEPT APART
+ * ----------------------------------
+ * Spot-checking exposed that these were being presented as one thing when they
+ * are not:
+ *
+ *   IDENTITY   — "the prior record describes THIS work". Proven by the record:
+ *                MARC 240 uniform title, 041$h original language, contributor.
+ *                Machine-checkable, and re-checkable by anyone with the LCCN.
+ *
+ *   COMPLETENESS — "that prior rendering is COMPLETE, not selections". Usually
+ *                NOT in the record: four of the first five spot checks reported
+ *                `unknown` because there is no 300$a extent. The screening
+ *                asserts it from scholarship (Grimald's *De Officiis*,
+ *                Billingsley's Euclid and Chapman's *Iliad* are complete
+ *                renderings) — which is real knowledge, but it is a judgement,
+ *                not a catalogue fact.
+ *
+ * This matters because the two grades imply different demotions. A complete prior
+ * means `not_first`. A merely-partial prior leaves "first COMPLETE English
+ * translation" standing. Collapsing them would demote defensible badges, so the
+ * packet reports which grade each recommendation rests on and flags any case
+ * where the record actively CONTRADICTS the screening.
+ *
+ * Uses the SRU gateway (lx2.loc.gov) rather than lccn.loc.gov: the latter
+ * rate-limits by serving an HTML access-request page with HTTP 200, which parses
+ * to zero records and reads as "no prior exists". Paced deliberately slowly.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/eval/ft-verify-demote-packet.mjs
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+import { latestEffortPerBook, SCREEN } from '../lib/search-effort.mjs';
+import {
+  parseMarcXmlRecords, classifyWorkType, classifyCompleteness,
+  fieldText, originalLanguages, extentPages, contributors,
+} from '../lib/bib-record.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+const DATE = new Date().toISOString().slice(0, 10);
+const SRU = 'http://lx2.loc.gov:210/lcdb';
+const DELAY_MS = 1500;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function fetchByLccn(lccn) {
+  const query = `bath.lccn="${String(lccn).replace(/[^0-9a-z]/gi, '')}"`;
+  const url = `${SRU}?version=1.1&operation=searchRetrieve`
+    + `&query=${encodeURIComponent(query)}&maximumRecords=1&recordSchema=marcxml`;
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'SourceLibrary/1.0 (+https://sourcelibrary.org; demote sign-off)' },
+    signal: AbortSignal.timeout(45_000),
+  });
+  if (!res.ok) throw new Error(`SRU ${res.status}`);
+  const [rec] = await parseMarcXmlRecords(await res.text());
+  return rec ?? null;
+}
+
+await withMongo(async (db) => {
+  const all = await db.collection('search_efforts').find({}).toArray();
+  const current = latestEffortPerBook(all);
+  const proposed = current.filter((e) => e.candidates?.some((c) => c.screen === SCREEN.PRIOR));
+  console.log(`Proposed demotes in the current generation: ${proposed.length}\n`);
+
+  // Group by WORK, not by record. The question is not "is this particular
+  // edition complete" but "does at least one COMPLETE prior English rendering of
+  // this work exist" — a work like the Iliad has ~20 candidate records, several
+  // of them legitimately partial (selections, single books) alongside complete
+  // ones. Grading per record made a work look contradicted whenever any one of
+  // its editions was an anthology.
+  const byWork = new Map();
+  for (const e of proposed) {
+    const work = e.proposition.match(/of "([^"]+)"/)?.[1] ?? e.book_id;
+    if (!byWork.has(work)) byWork.set(work, { work, lccns: [], books: new Set(), reason: '' });
+    const g = byWork.get(work);
+    g.books.add(e.book_id);
+    for (const c of e.candidates.filter((c) => c.screen === SCREEN.PRIOR)) {
+      g.reason ||= c.reason;
+      const l = c.identifiers?.lccn;
+      if (l && !g.lccns.includes(l)) g.lccns.push(l);
+    }
+  }
+  // Cap records checked per work: enough to establish that a complete prior
+  // exists, without re-fetching twenty editions of the Iliad.
+  const MAX_PER_WORK = 4;
+  console.log(`Works to verify: ${byWork.size} (checking up to ${MAX_PER_WORK} prior records each)\n`);
+
+  const rows = [];
+  const tally = { identity_confirmed: 0, identity_failed: 0, unfetchable: 0, completeness_from_record: 0, completeness_from_scholarship: 0, all_partial: 0 };
+
+  for (const entry of byWork.values()) {
+    const checked = [];
+    for (const lccn of entry.lccns.slice(0, MAX_PER_WORK)) {
+      let rec = null; let error = null;
+      try { rec = await fetchByLccn(lccn); } catch (err) { error = err.message; }
+      await sleep(DELAY_MS);
+      if (!rec) { checked.push({ lccn, error: error ?? 'no record' }); continue; }
+      const wt = classifyWorkType(rec);
+      const comp = classifyCompleteness(rec, wt.work_type);
+      checked.push({
+        lccn,
+        title: fieldText(rec, '245', ['a', 'b']).slice(0, 70),
+        uniform_title: fieldText(rec, '240', ['a']),
+        original_languages: originalLanguages(rec),
+        extent_pages: extentPages(rec),
+        work_type: wt.work_type,
+        completeness: comp.completeness,
+        completeness_evidence: comp.evidence,
+      });
+    }
+
+    const fetched = checked.filter((c) => !c.error);
+    if (!fetched.length) {
+      tally.unfetchable++;
+      rows.push({ work: entry.work, books: entry.books.size, verified: false, checked });
+      console.log(`  ${String(entry.work).slice(0, 40).padEnd(40)} UNFETCHABLE`);
+      continue;
+    }
+
+    // IDENTITY — at least one live record still describes a translation of this
+    // work, with a uniform title or a declared original language.
+    const identityOk = fetched.some((c) => c.work_type === 'translation'
+      && (c.uniform_title || c.original_languages.length));
+    if (identityOk) tally.identity_confirmed++; else tally.identity_failed++;
+
+    // COMPLETENESS — does ANY prior record establish a complete rendering?
+    const anyComplete = fetched.some((c) => c.completeness === 'complete');
+    const allPartial = fetched.every((c) => c.completeness === 'partial');
+    let grade;
+    if (anyComplete) { grade = 'record'; tally.completeness_from_record++; }
+    else if (allPartial) { grade = 'ALL PARTIAL — re-screen as first_complete'; tally.all_partial++; }
+    else { grade = 'scholarship'; tally.completeness_from_scholarship++; }
+
+    rows.push({
+      work: entry.work,
+      books: entry.books.size,
+      verified: true,
+      identity_confirmed: identityOk,
+      identity_basis: 'MARC 240 / 041$h / relator on a live record — re-checkable by LCCN',
+      completeness_grade: grade,
+      completeness_basis: anyComplete
+        ? fetched.find((c) => c.completeness === 'complete').completeness_evidence.join('; ')
+        : 'asserted from scholarship by the screening pass — NOT established by any checked record',
+      screened_reason: entry.reason,
+      records_checked: checked,
+    });
+
+    const flag = !identityOk ? 'IDENTITY FAIL' : grade;
+    console.log(`  ${String(entry.work).slice(0, 42).padEnd(42)} ${String(fetched[0].original_languages.join('/')).padEnd(8)} ${fetched.length}rec  ${flag}`);
+  }
+
+  console.log('\n─── Sign-off packet ──────────────────────────────────────────');
+  console.log(`  works verified live              : ${tally.identity_confirmed + tally.identity_failed} of ${byWork.size}`);
+  console.log(`  IDENTITY confirmed by the record : ${tally.identity_confirmed}`);
+  console.log(`  IDENTITY not confirmed           : ${tally.identity_failed}`);
+  console.log(`  unfetchable                      : ${tally.unfetchable}`);
+  console.log('');
+  console.log(`  COMPLETENESS established by record   : ${tally.completeness_from_record}`);
+  console.log(`  COMPLETENESS asserted from scholarship: ${tally.completeness_from_scholarship}`);
+  console.log(`  every checked prior is PARTIAL        : ${tally.all_partial}  <- re-screen these as first_complete`);
+  console.log('\n  Identity is machine-checkable and re-checkable by anyone holding the LCCN.');
+  console.log('  Completeness mostly is not — where it reads "scholarship", the demote rests');
+  console.log('  on a stated judgement, not on the catalogue. A record saying PARTIAL is a');
+  console.log('  reason to re-screen as first_complete rather than demote.');
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const out = path.join(OUT_DIR, `ft-demote-packet-${DATE}.json`);
+  fs.writeFileSync(out, JSON.stringify({ date: DATE, tally, rows }, null, 2));
+  console.log(`\nWrote ${out}`);
+});

--- a/scripts/lib/bib-record.mjs
+++ b/scripts/lib/bib-record.mjs
@@ -1,0 +1,520 @@
+/**
+ * bib-record.mjs — parse, classify and project raw bibliographic records. (#3455)
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * We already fetch rich records (loc.gov, Open Library, Google Books,
+ * archive.org, OpenAlex) and keep sixteen flat fields. Everything else — MARC
+ * fields, subject headings, identifiers, the raw payload — is discarded at
+ * ingest. Two failures follow directly:
+ *
+ *   1. Godwin's *Athanasius Kircher's Theatre of the World* (Inner Traditions,
+ *      2009) is an illustrated STUDY. It sits in `translation_catalogs` as a
+ *      translation with Godwin as `translator`. Its LoC record carries
+ *      `600 10 $x Criticism and interpretation` and NO `041` field at all, so it
+ *      is machine-distinguishable from a translation. We had that at fetch time
+ *      and dropped it.
+ *   2. No row on any of 24,061 carries an identifier, so nothing can be
+ *      re-fetched, re-checked or deduplicated. "Backfill the missing fields" is
+ *      impossible because there is no key to look a row up by.
+ *
+ * The rule this module encodes: **keep the whole record, project what you need.**
+ * `bib_records` stores the payload as fetched; `translation_catalogs` becomes a
+ * derived view. Adding a newly-relevant field is then a re-projection, not a
+ * re-fetch — which matters because nobody thought `041$h` mattered until a study
+ * got typed as a translation.
+ *
+ * WHAT THE MARC ACTUALLY LOOKS LIKE (both fetched from LoC 2026-07-29)
+ * --------------------------------------------------------------------
+ *   Copenhaver, *Hermetica* (CUP 1992) — a translation:
+ *     010 $a 91025703 · 020 $a 0521361443
+ *     041 1  $a eng $h grc $h lat        ← ind1=1 "is/includes a translation",
+ *                                          $h = language(s) of the original
+ *     245 00 $a Hermetica : $b … in a new English translation …
+ *     300 $a lxxxiii, 320 p.
+ *     700 1  $a Copenhaver, Brian P.
+ *
+ *   Godwin, *Theatre of the World* (2009) — a study:
+ *     010 $a 2009011796 · 020 $a 9781594773297 · 035 $a (OCoLC)317361757
+ *     (no 041 at all)
+ *     100 1  $a Godwin, Joscelyn.        ← main entry AUTHOR, not a translator
+ *     600 10 $a Kircher, Athanasius, $d 1602-1680 $x Criticism and interpretation.
+ *     650  0 $a Scholars … $v Biography.
+ *
+ * Parsing goes through xml2js rather than regex: MARC-XML arrives from an
+ * external host, and a regex parser over untrusted input is both a correctness
+ * and a ReDoS hazard.
+ */
+
+import { parseStringPromise } from 'xml2js';
+
+// ── Parsing ──────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a MARC-XML document (a bare `<record>`, a `<collection>`, or an SRU
+ * `searchRetrieveResponse`) into plain record objects.
+ *
+ * @param {string} xml
+ * @returns {Promise<Array<{leader: string, controlfields: Record<string,string>, datafields: Array<{tag:string,ind1:string,ind2:string,subfields:Array<{code:string,value:string}>}>}>>}
+ */
+export async function parseMarcXmlRecords(xml) {
+  if (!xml || typeof xml !== 'string') return [];
+  const parsed = await parseStringPromise(xml, {
+    explicitArray: true,
+    // Namespace prefixes vary by endpoint (`zs:`, `marc:`, none) — strip them so
+    // one code path handles lccn.loc.gov, the SRU gateway and HathiTrust alike.
+    tagNameProcessors: [(name) => name.replace(/^.*:/, '')],
+    attrNameProcessors: [(name) => name.replace(/^.*:/, '')],
+  });
+
+  const records = [];
+  collectRecords(parsed, records);
+  return records.map(normalizeRecord);
+}
+
+/**
+ * Depth-first walk collecting every MARC `<record>` node, wherever it is nested.
+ *
+ * An SRU response nests the MARC record inside its own `<zs:record>` wrapper.
+ * Once namespace prefixes are stripped BOTH are named `record`, so matching on
+ * the name alone grabs the wrapper — which carries `recordSchema` /
+ * `recordPacking` / `recordData` children and no MARC at all. Identify a real
+ * record by its CONTENT (it has controlfields or datafields), and keep
+ * descending regardless so the nested one is still found.
+ */
+function collectRecords(node, out) {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node.controlfield) || Array.isArray(node.datafield)) out.push(node);
+  for (const value of Object.values(node)) {
+    for (const child of [].concat(value)) collectRecords(child, out);
+  }
+}
+
+function normalizeRecord(raw) {
+  const controlfields = {};
+  for (const cf of raw.controlfield ?? []) {
+    const tag = cf?.$?.tag;
+    if (tag) controlfields[tag] = typeof cf._ === 'string' ? cf._ : '';
+  }
+
+  const datafields = [];
+  for (const df of raw.datafield ?? []) {
+    const tag = df?.$?.tag;
+    if (!tag) continue;
+    datafields.push({
+      tag,
+      ind1: df.$.ind1 ?? ' ',
+      ind2: df.$.ind2 ?? ' ',
+      subfields: (df.subfield ?? [])
+        .map((sf) => ({
+          code: sf?.$?.code ?? '',
+          value: (typeof sf._ === 'string' ? sf._ : '').trim(),
+        }))
+        .filter((sf) => sf.code),
+    });
+  }
+
+  return {
+    leader: [].concat(raw.leader ?? [])[0] ?? '',
+    controlfields,
+    datafields,
+  };
+}
+
+// ── Field accessors ──────────────────────────────────────────────────────────
+
+/** All datafields with the given tag. */
+export function fields(rec, tag) {
+  return (rec?.datafields ?? []).filter((f) => f.tag === tag);
+}
+
+/** All subfield values for tag/code, in document order. */
+export function subfields(rec, tag, code) {
+  const out = [];
+  for (const f of fields(rec, tag)) {
+    for (const sf of f.subfields) if (sf.code === code) out.push(sf.value);
+  }
+  return out;
+}
+
+/** First subfield value for tag/code, or ''. */
+export function subfield(rec, tag, code) {
+  return subfields(rec, tag, code)[0] ?? '';
+}
+
+/**
+ * Concatenate every subfield of the first instance of `tag` (display form).
+ *
+ * Trailing ISBD punctuation is stripped. MARC title fields conventionally end
+ * in a period ("De voluptate."), which is pure noise for the work-identity join
+ * this feeds — but a period after a single initial ("Smith, J.") is part of the
+ * name, so that case is left alone.
+ */
+export function fieldText(rec, tag, codes = null) {
+  const f = fields(rec, tag)[0];
+  if (!f) return '';
+  return f.subfields
+    .filter((sf) => !codes || codes.includes(sf.code))
+    .map((sf) => sf.value)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .replace(/\s*[\/:;,]\s*$/, '')
+    .replace(/(?<![A-Z])\.\s*$/, '')
+    .trim();
+}
+
+// ── Identifiers ──────────────────────────────────────────────────────────────
+
+/**
+ * Extract external identifiers. These are what make a row re-checkable — the
+ * single thing every one of the 24,061 existing rows lacks.
+ */
+export function extractIdentifiers(rec) {
+  const ids = {};
+
+  const lccn = subfield(rec, '010', 'a').replace(/\s+/g, '');
+  if (lccn) ids.lccn = lccn;
+
+  const isbns = subfields(rec, '020', 'a')
+    .map((v) => v.replace(/[^0-9Xx]/g, '').toUpperCase())
+    .filter((v) => v.length === 10 || v.length === 13);
+  if (isbns.length) ids.isbn = [...new Set(isbns)];
+
+  // OCLC numbers arrive as `(OCoLC)317361757`; bare 035 $a values are the
+  // cataloguing agency's own control number, not an OCLC number — don't claim
+  // one where none exists.
+  const oclc = subfields(rec, '035', 'a')
+    .map((v) => v.match(/\(OCoLC\)\s*(?:oc[mn])?0*(\d+)/i)?.[1])
+    .filter(Boolean);
+  if (oclc.length) ids.oclc = [...new Set(oclc)];
+
+  const lcControl = rec?.controlfields?.['001'];
+  if (lcControl) ids.lc_control_number = lcControl.trim();
+
+  return ids;
+}
+
+// ── Work type ────────────────────────────────────────────────────────────────
+
+/** Relator codes / terms that mark a translator contribution. */
+const TRANSLATOR_RELATORS = /\btrl\b|translat/i;
+
+/**
+ * Subject subdivisions ($x/$v) that mark a work ABOUT a text rather than a
+ * rendering OF it. This is the signal that catches Godwin.
+ */
+const STUDY_SUBDIVISIONS = [
+  /criticism and interpretation/i,
+  /history and criticism/i,
+  /^biography$/i,
+  /\bbiography\b/i,
+  /appreciation/i,
+  /influence/i,
+];
+
+const COMMENTARY_TITLE_RE = /\b(a )?(commentary|commentaries|companion to|guide to|introduction to|reader'?s guide|handbook)\b/i;
+const FACSIMILE_RE = /\bfacsimile\b/i;
+const CRITICAL_EDITION_RE = /\bcritical edition\b|\bedited from the manuscripts?\b/i;
+
+/**
+ * Classify what kind of work a record describes.
+ *
+ * Precedence is deliberate: a positive `041$h` (language of the original) is a
+ * cataloguer's explicit assertion that a translation is present, and outranks
+ * subject headings — a translation published WITH scholarly apparatus often
+ * carries criticism headings too. Absence of `041` plus criticism headings is
+ * the study signature.
+ *
+ * @returns {{work_type: string, evidence: string[]}}
+ */
+export function classifyWorkType(rec) {
+  const evidence = [];
+
+  const f041 = fields(rec, '041')[0];
+  const originalLangs = subfields(rec, '041', 'h');
+  const translationIndicator = f041?.ind1 === '1';
+  if (originalLangs.length) evidence.push(`041$h=${originalLangs.join(',')}`);
+  if (translationIndicator) evidence.push('041 ind1=1 (translation)');
+
+  const relators = [
+    ...subfields(rec, '100', 'e'), ...subfields(rec, '100', '4'),
+    ...subfields(rec, '700', 'e'), ...subfields(rec, '700', '4'),
+    ...subfields(rec, '110', 'e'), ...subfields(rec, '710', 'e'),
+  ];
+  const hasTranslatorRelator = relators.some((r) => TRANSLATOR_RELATORS.test(r));
+  if (hasTranslatorRelator) evidence.push('relator trl');
+
+  const title = [fieldText(rec, '245'), fieldText(rec, '240')].join(' ');
+  const titleSaysTranslation = /\btranslat(ed|ion)\b|\benglished\b|\bdone into english\b/i.test(title);
+  if (titleSaysTranslation) evidence.push('245/240 states a translation');
+
+  // Study signature: subject subdivisions about the text/person.
+  const subdivisions = [];
+  for (const tag of ['600', '610', '630', '650', '651']) {
+    for (const f of fields(rec, tag)) {
+      for (const sf of f.subfields) if (sf.code === 'x' || sf.code === 'v') subdivisions.push(sf.value);
+    }
+  }
+  const studyHit = subdivisions.find((s) => STUDY_SUBDIVISIONS.some((re) => re.test(s)));
+
+  if (originalLangs.length || translationIndicator || hasTranslatorRelator) {
+    return { work_type: 'translation', evidence };
+  }
+  if (titleSaysTranslation) {
+    return { work_type: 'translation', evidence };
+  }
+  if (studyHit) {
+    evidence.push(`subject subdivision "${studyHit}" with no 041`);
+    return { work_type: 'study', evidence };
+  }
+  if (COMMENTARY_TITLE_RE.test(title)) {
+    evidence.push('245/240 reads as commentary/companion');
+    return { work_type: 'commentary', evidence };
+  }
+  if (FACSIMILE_RE.test(title) || FACSIMILE_RE.test(fieldText(rec, '250'))) {
+    evidence.push('facsimile in 245/250');
+    return { work_type: 'facsimile', evidence };
+  }
+  if (CRITICAL_EDITION_RE.test(title) || CRITICAL_EDITION_RE.test(fieldText(rec, '250'))) {
+    evidence.push('critical edition in 245/250');
+    return { work_type: 'critical_edition', evidence };
+  }
+
+  // A record in the original language with no translation signal at all.
+  evidence.push('no 041$h, no translator relator, no study subdivision');
+  return { work_type: 'unknown', evidence };
+}
+
+// ── Completeness ─────────────────────────────────────────────────────────────
+
+const PARTIAL_MARKERS = [
+  /\bselections?\b/i, /\bexcerpts?\b/i, /\bextracts?\b/i, /\babridg(ed|ment)\b/i,
+  /\bpassages\b/i, /\banthology\b/i, /\bsampler\b/i, /\bchrestomathy\b/i,
+  /\ba selection\b/i, /\bpartial\b/i,
+];
+const COMPLETE_MARKERS = [/\bcomplete\b/i, /\bentire\b/i, /\bunabridged\b/i, /\bin full\b/i];
+
+/** Parse a leading page/leaf count out of a MARC 300 $a extent statement. */
+export function extentPages(rec) {
+  const raw = subfields(rec, '300', 'a').join(' ');
+  if (!raw) return null;
+  // "lxxxiii, 320 p." → 320 ; "304 p." → 304 ; "2 v." → null (volumes, not pages)
+  const matches = [...raw.matchAll(/(\d[\d,]*)\s*(?:p\.|pages|leaves)/gi)]
+    .map((m) => parseInt(m[1].replace(/,/g, ''), 10))
+    .filter(Number.isFinite);
+  if (!matches.length) return null;
+  return Math.max(...matches);
+}
+
+/**
+ * Decide whether the record describes a COMPLETE rendering of the work.
+ *
+ * `completeness` is the field that makes the registry usable: the Tier-0 matcher
+ * requires `completeness === 'complete'` to defeat a first-translation claim, and
+ * it is `'unknown'` on 22,005 of 24,061 rows — so the catalogue is ~98% inert.
+ *
+ * The rule stays conservative in the direction that matters. A wrong `complete`
+ * demotes a real first-translation badge (the historical #1 failure); a wrong
+ * `unknown` merely leaves a claim standing. So an explicit partial marker always
+ * wins, and `complete` requires a translation with a real extent and no partial
+ * marker anywhere.
+ *
+ * @returns {{completeness: string, evidence: string[]}}
+ */
+export function classifyCompleteness(rec, workType) {
+  const evidence = [];
+  const haystack = [
+    fieldText(rec, '245'),
+    fieldText(rec, '240'),
+    fieldText(rec, '250'),
+    subfields(rec, '500', 'a').join(' '),
+    subfields(rec, '504', 'a').join(' '),
+    // 240 $k "Selections" is the cataloguer's explicit partial marker.
+    subfields(rec, '240', 'k').join(' '),
+    subfields(rec, '240', 's').join(' '),
+  ].join(' ');
+
+  const partial = PARTIAL_MARKERS.find((re) => re.test(haystack));
+  if (partial) {
+    evidence.push(`partial marker ${partial} in 240/245/250/500`);
+    return { completeness: 'partial', evidence };
+  }
+
+  const complete = COMPLETE_MARKERS.find((re) => re.test(haystack));
+  if (complete) {
+    evidence.push(`explicit completeness marker ${complete}`);
+    return { completeness: 'complete', evidence };
+  }
+
+  if (workType !== 'translation') {
+    evidence.push(`work_type=${workType} — completeness not asserted for non-translations`);
+    return { completeness: 'unknown', evidence };
+  }
+
+  const pages = extentPages(rec);
+  if (pages == null) {
+    evidence.push('no page extent in 300$a');
+    return { completeness: 'unknown', evidence };
+  }
+  // A monograph-length translation with no partial marker anywhere. Below this
+  // an "extent" is as likely to be a pamphlet excerpt as a full rendering.
+  if (pages >= 80) {
+    evidence.push(`300$a extent ${pages}pp, no partial marker`);
+    return { completeness: 'complete', evidence };
+  }
+  evidence.push(`300$a extent only ${pages}pp — too short to assert complete`);
+  return { completeness: 'unknown', evidence };
+}
+
+// ── Other projections ────────────────────────────────────────────────────────
+
+/** ISO 639-2 codes of the original language(s), from 041$h. */
+export function originalLanguages(rec) {
+  return [...new Set(subfields(rec, '041', 'h').map((v) => v.trim().toLowerCase()).filter(Boolean))];
+}
+
+/** Language of THIS item, from 041$a or the 008 language position (35-37). */
+export function itemLanguage(rec) {
+  const from041 = subfield(rec, '041', 'a').trim().toLowerCase();
+  if (from041) return from041;
+  const f008 = rec?.controlfields?.['008'] ?? '';
+  return f008.slice(35, 38).trim().toLowerCase() || '';
+}
+
+/** Contributors with their relator roles. */
+export function contributors(rec) {
+  const out = [];
+  for (const [tag, defaultRole] of [['100', 'author'], ['110', 'author'], ['700', 'contributor'], ['710', 'contributor']]) {
+    for (const f of fields(rec, tag)) {
+      const name = f.subfields.filter((s) => ['a', 'b', 'c', 'q'].includes(s.code)).map((s) => s.value).join(' ').replace(/[,;:]\s*$/, '').trim();
+      if (!name) continue;
+      const relator = f.subfields.filter((s) => s.code === 'e' || s.code === '4').map((s) => s.value).join(' ');
+      let role = defaultRole;
+      if (TRANSLATOR_RELATORS.test(relator)) role = 'translator';
+      else if (/\bedt\b|editor/i.test(relator)) role = 'editor';
+      out.push({ name, role, relator: relator || undefined, marc_tag: tag });
+    }
+  }
+  return out;
+}
+
+/** MARC 240 uniform title (work identity — feeds #3258 / #2453). */
+export function uniformTitle(rec) {
+  return fieldText(rec, '240', ['a', 'n', 'p']) || '';
+}
+
+export function mainTitle(rec) {
+  return fieldText(rec, '245', ['a', 'b']);
+}
+
+export function statementOfResponsibility(rec) {
+  return subfield(rec, '245', 'c');
+}
+
+export function publicationYear(rec) {
+  for (const tag of ['264', '260']) {
+    const raw = subfield(rec, tag, 'c');
+    const m = raw.match(/(\d{4})/);
+    if (m) return parseInt(m[1], 10);
+  }
+  const f008 = rec?.controlfields?.['008'] ?? '';
+  const y = parseInt(f008.slice(7, 11), 10);
+  return Number.isFinite(y) ? y : null;
+}
+
+export function publisher(rec) {
+  return subfield(rec, '264', 'b') || subfield(rec, '260', 'b') || '';
+}
+
+export function subjectHeadings(rec) {
+  const out = [];
+  for (const tag of ['600', '610', '630', '650', '651']) {
+    for (const f of fields(rec, tag)) {
+      const text = f.subfields.filter((s) => /[avxyz]/.test(s.code)).map((s) => s.value).join(' — ').replace(/\.$/, '');
+      if (text) out.push(text);
+    }
+  }
+  return out;
+}
+
+// ── bib_records document ─────────────────────────────────────────────────────
+
+/**
+ * Build a `bib_records` document: the raw payload plus everything projected
+ * from it. Keyed on `source` + `identifier` so a re-fetch is idempotent and a
+ * row is always re-checkable against its authority.
+ */
+export function buildBibRecord({ rec, source, rawXml, query, fetchedAt = new Date() }) {
+  if (!source) throw new Error('buildBibRecord: missing source');
+  const identifiers = extractIdentifiers(rec);
+  const { work_type, evidence: workTypeEvidence } = classifyWorkType(rec);
+  const { completeness, evidence: completenessEvidence } = classifyCompleteness(rec, work_type);
+
+  const identifier = identifiers.lccn
+    ?? identifiers.oclc?.[0]
+    ?? identifiers.isbn?.[0]
+    ?? identifiers.lc_control_number;
+  if (!identifier) throw new Error('buildBibRecord: record carries no external identifier');
+
+  return {
+    _key: `${source}:${identifier}`,
+    source,
+    identifier,
+    identifiers,
+
+    title: mainTitle(rec),
+    uniform_title: uniformTitle(rec) || undefined,
+    statement_of_responsibility: statementOfResponsibility(rec) || undefined,
+    contributors: contributors(rec),
+    pub_year: publicationYear(rec),
+    publisher: publisher(rec) || undefined,
+
+    work_type,
+    work_type_evidence: workTypeEvidence,
+    completeness,
+    completeness_evidence: completenessEvidence,
+
+    item_language: itemLanguage(rec) || undefined,
+    original_languages: originalLanguages(rec),
+    subject_headings: subjectHeadings(rec),
+    extent_pages: extentPages(rec),
+
+    // The point of the collection: keep the payload so a field nobody thought
+    // mattered is a re-projection away rather than an impossible re-fetch.
+    raw_marcxml: rawXml,
+    raw_format: 'marcxml',
+    query: query || undefined,
+    fetched_at: fetchedAt,
+  };
+}
+
+/**
+ * Project a `bib_records` document into a `translation_catalogs` row shape.
+ * Returns null for records that are not translations — a study must never enter
+ * the registry as a prior translation (the Godwin defect).
+ */
+export function projectToCatalogRow(bib, { sourceLanguageIso } = {}) {
+  if (bib.work_type !== 'translation') return null;
+
+  const translator = bib.contributors.find((c) => c.role === 'translator')
+    ?? bib.contributors.find((c) => c.marc_tag === '700')
+    ?? null;
+  const author = bib.contributors.find((c) => c.marc_tag === '100' || c.marc_tag === '110') ?? null;
+
+  return {
+    source: `bib_records:${bib.source}`,
+    bib_record_key: bib._key,
+    lccn: bib.identifiers.lccn,
+    isbn: bib.identifiers.isbn,
+    oclc: bib.identifiers.oclc,
+    author: author?.name ?? '',
+    english_title: bib.title,
+    original_title: bib.uniform_title,
+    translator: translator?.name ?? '',
+    pub_year: bib.pub_year != null ? String(bib.pub_year) : '',
+    publisher: bib.publisher ?? '',
+    completeness: bib.completeness,
+    source_language: sourceLanguageIso ?? bib.original_languages[0] ?? '',
+    work_type: bib.work_type,
+  };
+}

--- a/scripts/lib/bib-record.mjs
+++ b/scripts/lib/bib-record.mjs
@@ -57,15 +57,51 @@ import { parseStringPromise } from 'xml2js';
  * @param {string} xml
  * @returns {Promise<Array<{leader: string, controlfields: Record<string,string>, datafields: Array<{tag:string,ind1:string,ind2:string,subfields:Array<{code:string,value:string}>}>}>>}
  */
+/**
+ * LoC rate-limits by serving an HTML interstitial with HTTP **200**, so a status
+ * check passes while the body contains no MARC at all. Silently parsing that to
+ * zero records reads as "this work has no prior translation" — a false negative
+ * manufactured by throttling. Detect it and fail loudly instead.
+ */
+export function assertNotBlockPage(xml) {
+  if (typeof xml !== 'string') return;
+  const head = xml.slice(0, 400).toLowerCase();
+  if (head.includes('<!doctype html') || head.includes('<html')) {
+    const blocked = /ip access request|access request form|rate limit|too many requests/i.test(xml.slice(0, 4000));
+    throw new Error(
+      blocked
+        ? 'LoC served an IP access-request page (HTTP 200, HTML body) — the request was throttled, not answered. Back off and retry; do NOT treat this as "no records".'
+        : 'expected MARC-XML but received an HTML document',
+    );
+  }
+}
+
 export async function parseMarcXmlRecords(xml) {
   if (!xml || typeof xml !== 'string') return [];
-  const parsed = await parseStringPromise(xml, {
+  assertNotBlockPage(xml);
+  // Namespace prefixes vary by endpoint (`zs:`, `marc:`, none) — strip them so
+  // one code path handles lccn.loc.gov, the SRU gateway and HathiTrust alike.
+  const opts = {
     explicitArray: true,
-    // Namespace prefixes vary by endpoint (`zs:`, `marc:`, none) — strip them so
-    // one code path handles lccn.loc.gov, the SRU gateway and HathiTrust alike.
     tagNameProcessors: [(name) => name.replace(/^.*:/, '')],
     attrNameProcessors: [(name) => name.replace(/^.*:/, '')],
-  });
+  };
+
+  let parsed;
+  try {
+    parsed = await parseStringPromise(xml, opts);
+  } catch (strictError) {
+    // Real LoC records occasionally contain markup that strict SAX rejects
+    // outright ("Unexpected close tag" — hit on the live record for LCCN
+    // 96218515 while spot-checking). Losing a whole record to one stray tag is a
+    // silent false negative in a system whose entire job is avoiding those, so
+    // retry leniently. We only ever read a fixed set of fields from the result.
+    try {
+      parsed = await parseStringPromise(xml, { ...opts, strict: false });
+    } catch {
+      throw strictError;
+    }
+  }
 
   const records = [];
   collectRecords(parsed, records);

--- a/scripts/lib/english-source-detect.mjs
+++ b/scripts/lib/english-source-detect.mjs
@@ -1,0 +1,121 @@
+/**
+ * english-source-detect.mjs — is the SOURCE page already in English? (#3459)
+ *
+ * THE QUESTION THIS ANSWERS, AND WHY THE OBVIOUS ONE FAILS
+ * -------------------------------------------------------
+ * A first-translation claim only makes sense if we rendered a foreign text into
+ * English. Much of the ancient-Near-East holding is not that: Budge's *Seven
+ * Tablets of Creation*, Langdon's *Babylonian Liturgies*, the Papyrus of Ani —
+ * these are modern scholarly editions that PRINT the ancient text alongside an
+ * English translation. `books.language` records the ancient script; the book in
+ * hand is largely English.
+ *
+ * The intuitive test is provenance: did OUR pipeline produce the translation?
+ * Measured, that fails — those books carry `translation.source: ["ai"]` with a
+ * model stamped on 93-100% of translated pages, exactly like a Latin book we
+ * genuinely translated. The pipeline did run. It simply ran on pages that were
+ * already English, producing English from English. Provenance of the TRANSLATION
+ * is the wrong signal; the language of the SOURCE is the right one.
+ *
+ * Neither do the other obvious candidates:
+ *   - `text_role` is 'original' for all of them (it describes the artifact)
+ *   - `pages.ocr.language` is null/auto-detect on the older ingests
+ *   - OCR/translation word overlap does not separate: Sumerian 0.41 sits among
+ *     German 0.43 and French 0.47, because editorial wrappers and proper nouns
+ *     create a baseline overlap everywhere
+ *   - `gemini_usage` holds no translation rows even for books we certainly
+ *     translated, so it is not complete per-book provenance
+ *
+ * WHAT DOES WORK: the proportion of common English function words in the OCR
+ * text. Measured over sampled content pages, 2026-07-31:
+ *
+ *     Akkadian (Budge et al.)   0.295      Latin, badged    0.043
+ *     Sumerian                  0.230      German, badged   0.046
+ *     Egyptian                  0.322      Greek, badged    0.037
+ *
+ * A 5-8x gap with no overlap between the bands. Function words are the right
+ * feature precisely because they are untranslatable filler — a Latin page has
+ * almost none whatever its subject, an English page is full of them.
+ */
+
+import { stripEditorialWrappers } from './strip-editorial-wrappers.mjs';
+
+/**
+ * Common English function words. Deliberately closed-class (articles,
+ * prepositions, pronouns, auxiliaries) — these carry no subject matter, so the
+ * measure tracks the LANGUAGE of the page and not its topic.
+ */
+const ENGLISH_FUNCTION_WORDS = new Set(
+  ('the of and to in a is that was for it with as his he be not by but they this had have from are '
+  + 'which one you were her all she there would their we him been has when who will more no if out so '
+  + 'said what up its about into than them can only other new some could time these two may then do '
+  + 'first any my now such like our over man me even most made after also did many before must through '
+  + 'back years where much your way well down should because each just those people how too little '
+  + 'state good very make world still own see men work long get here between both life being under '
+  + 'never day same another know while last might us great old year off come since against go came '
+  + 'right used take three upon shall thus hath unto').split(' '),
+);
+
+/**
+ * Words from OCR text, with EDITORIAL WRAPPERS REMOVED FIRST.
+ *
+ * This is load-bearing and was got wrong on the first attempt. `pages.ocr.data`
+ * embeds AI-written English annotation blocks — `<meta>`, `<scan-quality>`,
+ * `<page-type>` and friends — describing the page in English regardless of what
+ * language the page is in. Stripping only the TAGS (`replace(/<[^>]*>/g, '')`)
+ * keeps that prose, which is precisely the bug CLAUDE.md documents: the tag goes,
+ * the editorial English stays.
+ *
+ * Measured cost of getting it wrong: a Greek manuscript of the Corpus Hermeticum
+ * scored 0.26-0.36 English on annotated pages and 0.00 on pages of actual Greek;
+ * a Hebrew Zohar scored 0.32 on an annotated page and 0.00 on real Hebrew. The
+ * detector was reading our own annotations and calling the source English.
+ */
+export function textWords(s) {
+  return String(stripEditorialWrappers(String(s || '')))
+    .replace(/<[^>]*>/g, ' ')
+    .toLowerCase()
+    .match(/[a-z']+/g) ?? [];
+}
+
+/**
+ * Fraction of a page's words that are English function words.
+ * Returns null when there is too little text to judge — an unreadable or blank
+ * page must not vote.
+ */
+export function englishFraction(text, minWords = 25) {
+  const w = textWords(text);
+  if (w.length < minWords) return null;
+  return w.filter((x) => ENGLISH_FUNCTION_WORDS.has(x)).length / w.length;
+}
+
+/**
+ * Threshold separating an already-English source from a foreign one.
+ *
+ * Sits in the empty band between the two measured populations (foreign tops out
+ * near 0.06, already-English starts near 0.15). Deliberately nearer the foreign
+ * side: misclassifying a genuine foreign source as English would silently drop a
+ * real first-translation candidate, which is the costlier error.
+ */
+export const ENGLISH_SOURCE_THRESHOLD = 0.15;
+
+/**
+ * Classify a book from a sample of its OCR pages.
+ *
+ * @param {string[]} pageTexts - OCR text from sampled content pages
+ * @returns {{verdict: string, mean: number|null, pages_judged: number}}
+ *   `english_source`  the printed page is already largely English — a
+ *                     first-translation claim does not apply
+ *   `foreign_source`  a genuine foreign-language source
+ *   `undetermined`    not enough legible text to say
+ */
+export function classifySourceLanguage(pageTexts) {
+  const fracs = pageTexts.map((t) => englishFraction(t)).filter((f) => f !== null);
+  if (!fracs.length) return { verdict: 'undetermined', mean: null, pages_judged: 0 };
+  const mean = fracs.reduce((a, b) => a + b, 0) / fracs.length;
+  return {
+    verdict: mean >= ENGLISH_SOURCE_THRESHOLD ? 'english_source' : 'foreign_source',
+    mean,
+    pages_judged: fracs.length,
+  };
+}

--- a/scripts/lib/english-source-detect.mjs
+++ b/scripts/lib/english-source-detect.mjs
@@ -100,6 +100,40 @@ export function englishFraction(text, minWords = 25) {
 export const ENGLISH_SOURCE_THRESHOLD = 0.15;
 
 /**
+ * The OCR model DECLARES the page's language in its metadata envelope —
+ * `<language>English</language>` or `<lang>Latin</lang>` — as part of the
+ * page-level block CLAUDE.md documents (`<language>`, `<script>`,
+ * `<scan-quality>`, `<page-type>`).
+ *
+ * This is a direct assertion by the model that read the page, and it beats any
+ * frequency estimate. Budge's *Seven Tablets of Creation*, catalogued by us as
+ * Akkadian, declares `<language>English</language>` on its pages — because the
+ * printed page IS English. Our genuinely translated Latin book declares
+ * `<lang>Latin</lang>`.
+ *
+ * Note the field `pages.ocr.language` is NOT a substitute: it is null on exactly
+ * the older ingests where this matters, while the tag inside `ocr.data` is
+ * present. Read the declaration, not the column.
+ */
+const LANG_TAG_RE = /<lang(?:uage)?>\s*([^<]{1,40}?)\s*<\/lang(?:uage)?>/i;
+
+export function declaredPageLanguage(ocrData) {
+  const m = String(ocrData || '').match(LANG_TAG_RE);
+  if (!m) return null;
+  const v = m[1].trim().toLowerCase();
+  return v && v !== 'null' && v !== 'unknown' ? v : null;
+}
+
+const ENGLISH_DECLARATIONS = new Set(['english', 'eng', 'en', 'modern english', 'early modern english']);
+
+/** Is the declared language English? null when nothing was declared. */
+export function declaresEnglish(ocrData) {
+  const l = declaredPageLanguage(ocrData);
+  if (!l) return null;
+  return ENGLISH_DECLARATIONS.has(l);
+}
+
+/**
  * Classify a book from a sample of its OCR pages.
  *
  * @param {string[]} pageTexts - OCR text from sampled content pages
@@ -110,11 +144,26 @@ export const ENGLISH_SOURCE_THRESHOLD = 0.15;
  *   `undetermined`    not enough legible text to say
  */
 export function classifySourceLanguage(pageTexts) {
+  // Prefer the model's own declaration — a direct statement about the page beats
+  // a frequency estimate derived from it.
+  const declared = pageTexts.map((t) => declaresEnglish(t)).filter((d) => d !== null);
+  if (declared.length >= 2) {
+    const englishShare = declared.filter(Boolean).length / declared.length;
+    return {
+      verdict: englishShare >= 0.5 ? 'english_source' : 'foreign_source',
+      basis: 'declared_language',
+      english_share: englishShare,
+      pages_judged: declared.length,
+    };
+  }
+
+  // Fall back to function-word frequency only where nothing was declared.
   const fracs = pageTexts.map((t) => englishFraction(t)).filter((f) => f !== null);
-  if (!fracs.length) return { verdict: 'undetermined', mean: null, pages_judged: 0 };
+  if (!fracs.length) return { verdict: 'undetermined', basis: 'none', mean: null, pages_judged: 0 };
   const mean = fracs.reduce((a, b) => a + b, 0) / fracs.length;
   return {
     verdict: mean >= ENGLISH_SOURCE_THRESHOLD ? 'english_source' : 'foreign_source',
+    basis: 'function_word_frequency',
     mean,
     pages_judged: fracs.length,
   };

--- a/scripts/lib/search-effort.mjs
+++ b/scripts/lib/search-effort.mjs
@@ -176,6 +176,32 @@ export function buildSearchEffort(p) {
 }
 
 /**
+ * Reduce a raw `search_efforts` read to the CURRENT generation: the latest
+ * effort per book.
+ *
+ * Efforts are immutable by design — a new code version or reference-set snapshot
+ * mints a new `effort_id` instead of overwriting, which is exactly what lets a
+ * previously-asserted negative be re-opened when the reference set grows. The
+ * cost is that the collection is a HISTORY, not a state, and a naive
+ * `find({verdict:'inconclusive'})` mixes verdicts produced by superseded,
+ * buggier matchers with current ones.
+ *
+ * That is not hypothetical: it returned 265 inconclusive efforts against a
+ * current generation of 75, i.e. 190 rows of stale judgement that would have been
+ * screened and reported as if live. Any consumer reading this collection must
+ * reduce through here first.
+ */
+export function latestEffortPerBook(efforts) {
+  const best = new Map();
+  for (const e of efforts) {
+    if (!e?.book_id) continue;
+    const prev = best.get(e.book_id);
+    if (!prev || new Date(e.run_at) > new Date(prev.run_at)) best.set(e.book_id, e);
+  }
+  return [...best.values()];
+}
+
+/**
  * One-line, reader-facing summary of an effort — what the badge renders instead
  * of an unprovable claim.
  */

--- a/scripts/lib/search-effort.mjs
+++ b/scripts/lib/search-effort.mjs
@@ -99,7 +99,15 @@ export function effortId({ bookId, referenceSetVersion, codeVersion }) {
  * exactly the false confidence this whole design exists to remove.
  */
 export function deriveVerdict({ candidates, searchable }) {
-  if (!searchable) return VERDICT.NOT_SEARCHABLE;
+  // `searchable` describes the CATALOGUES: did this book have an author, title or
+  // original-script access point we could query? A book can fail that and still
+  // produce candidates, because some sources are joined rather than searched —
+  // our own `translation_classification` is keyed on book id, so it answers for a
+  // book no catalogue index can reach. Returning NOT_SEARCHABLE there would
+  // discard a real prior lead in favour of "we could not ask", which is the
+  // confident-negative failure this design exists to prevent. No access point AND
+  // nothing retrieved is the only true "could not ask".
+  if (!searchable && !candidates.length) return VERDICT.NOT_SEARCHABLE;
   if (candidates.some((c) => DEFEATING.has(c.screen))) return VERDICT.PRIOR_FOUND;
   if (candidates.some((c) => c.screen === SCREEN.UNRESOLVED)) return VERDICT.INCONCLUSIVE;
   if (candidates.some((c) => c.screen === SCREEN.PARTIAL)) return VERDICT.ONLY_PARTIAL_FOUND;

--- a/scripts/lib/search-effort.mjs
+++ b/scripts/lib/search-effort.mjs
@@ -1,0 +1,205 @@
+/**
+ * search-effort.mjs — make the SEARCH itself the citable artifact. (#3459)
+ *
+ * THE PROBLEM THIS SOLVES
+ * -----------------------
+ * "First English translation" asserts an unprovable universal negative. No
+ * search can establish it; a catalogue returns only *nothing found*. Every
+ * attempt to shore the claim up with better evidence has failed the same way,
+ * because the claim's SHAPE is wrong, not its evidence quality.
+ *
+ * The move is to stop claiming the negative and start publishing the search.
+ * Instead of "this is the first English translation", say:
+ *
+ *   "No prior English translation found. Searched 4 catalogues (14.2M records,
+ *    snapshots 2016–2026); 31 candidates screened; 2026-07-30. [see the record]"
+ *
+ * That is a claim about a *specific, bounded, reproducible act*, and it is TRUE
+ * — verifiably, by a third party, forever. It is also strictly more informative
+ * than the bare assertion, because it shows its own edges.
+ *
+ * WHAT MAKES AN EFFORT REPRODUCIBLE
+ * ---------------------------------
+ * Five things, and dropping any one breaks it:
+ *
+ *   1. The PROPOSITION, stated exactly. "Does a complete English translation of
+ *      <work> published before <year> exist?" — not "is this a first?"
+ *   2. The REFERENCE SET, with per-source snapshot dates, record counts, and
+ *      declared gaps. Absence means absence FROM THIS SET; a set that cannot
+ *      state its own boundary cannot support a negative at all.
+ *   3. Every QUERY VERBATIM, replayable. Not "we searched LoC" — the actual
+ *      query string, and the count it returned.
+ *   4. Every CANDIDATE retrieved, with its screening decision AND the reason.
+ *      The rejects matter more than the accepts: they are what shows the search
+ *      was real rather than a lookup that happened to miss.
+ *   5. The CODE VERSION (git SHA). Measured on 2026-07-29: a one-line change to
+ *      the direction of a title-coverage ratio moved strong matches from 8 to
+ *      74 over identical data. Same corpus, same book, 9x different answer. An
+ *      effort that does not pin its code is not reproducible, it is an anecdote.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO
+ * ----------------------------------
+ * It never sets `books.is_first_translation`. An effort is EVIDENCE; the verdict
+ * stays derived and behind the sign-off-gated reconcile (#2933). Recording an
+ * effort must never be able to flip a public badge on its own — that separation
+ * is what makes it safe to run the sweep at corpus scale.
+ */
+
+import crypto from 'crypto';
+
+/** Screening outcomes for a retrieved candidate. */
+export const SCREEN = {
+  PRIOR: 'prior_translation',        // a complete English translation of THIS work, earlier
+  PARTIAL: 'partial_translation',    // selections/excerpts — does not defeat "first complete"
+  DIFFERENT_WORK: 'different_work',  // same author, different work
+  NOT_A_TRANSLATION: 'not_a_translation', // a study/commentary about the text (#3428)
+  WRONG_LANGUAGE: 'wrong_language',  // a translation, but not into English / not from our source
+  LATER: 'later_than_ours',          // a real English translation, but published after ours
+  UNRESOLVED: 'unresolved',          // could not decide — counts AGAINST confidence
+};
+
+/** Outcomes that defeat a first-complete-translation claim. */
+const DEFEATING = new Set([SCREEN.PRIOR]);
+
+/**
+ * Verdicts. Note there is no "confirmed first" — that is the unprovable claim.
+ * The strongest available verdict is `none_found`, which is a statement about
+ * the search, not about the world.
+ */
+export const VERDICT = {
+  NONE_FOUND: 'none_found',
+  PRIOR_FOUND: 'prior_found',
+  ONLY_PARTIAL_FOUND: 'only_partial_found',
+  NOT_SEARCHABLE: 'not_searchable',  // no access point existed — we could not ask
+  INCONCLUSIVE: 'inconclusive',
+};
+
+/**
+ * Stable, citable id. Deterministic in its inputs so re-running the same effort
+ * over the same reference-set version yields the same id (idempotent upsert),
+ * while a new snapshot or new code version yields a new one — which is correct:
+ * that IS a different search.
+ */
+export function effortId({ bookId, referenceSetVersion, codeVersion }) {
+  const digest = crypto
+    .createHash('sha1')
+    .update([bookId, referenceSetVersion, codeVersion].join('|'))
+    .digest('hex')
+    .slice(0, 8);
+  return `SE-${bookId}-${referenceSetVersion}-${digest}`;
+}
+
+/**
+ * Derive the verdict from the screened candidates.
+ *
+ * Deliberately mechanical — the judgement lives in the per-candidate screening,
+ * where the evidence is, not in a second layer of inference on top of it. If a
+ * candidate is unresolved, the effort cannot claim `none_found`: an unscreened
+ * candidate is an open question, and rounding it down to "nothing found" is
+ * exactly the false confidence this whole design exists to remove.
+ */
+export function deriveVerdict({ candidates, searchable }) {
+  if (!searchable) return VERDICT.NOT_SEARCHABLE;
+  if (candidates.some((c) => DEFEATING.has(c.screen))) return VERDICT.PRIOR_FOUND;
+  if (candidates.some((c) => c.screen === SCREEN.UNRESOLVED)) return VERDICT.INCONCLUSIVE;
+  if (candidates.some((c) => c.screen === SCREEN.PARTIAL)) return VERDICT.ONLY_PARTIAL_FOUND;
+  return VERDICT.NONE_FOUND;
+}
+
+/**
+ * Build a search-effort document.
+ *
+ * @param {object} p
+ * @param {string} p.bookId
+ * @param {string} [p.workId]
+ * @param {string} p.proposition        the exact question tested, in words
+ * @param {object} p.referenceSet       {version, sources:[{id,name,snapshot_date,record_count,coverage,known_gaps[]}]}
+ * @param {Array}  p.queries            [{source, query, url?, result_count}]
+ * @param {Array}  p.candidates         [{bib_record_key?, identifiers, title, year, screen, reason, score?}]
+ * @param {boolean} p.searchable        false when no access point existed
+ * @param {string} p.codeVersion        git SHA of the code that ran this
+ * @param {string[]} [p.limitations]    what this search structurally cannot see
+ */
+export function buildSearchEffort(p) {
+  const {
+    bookId, workId, proposition, referenceSet, queries = [], candidates = [],
+    searchable = true, codeVersion, limitations = [], runAt = new Date(),
+  } = p;
+
+  if (!bookId) throw new Error('buildSearchEffort: missing bookId');
+  if (!proposition) throw new Error('buildSearchEffort: missing proposition');
+  if (!codeVersion) throw new Error('buildSearchEffort: missing codeVersion — an unpinned effort is not reproducible');
+  if (!referenceSet?.version || !Array.isArray(referenceSet.sources) || !referenceSet.sources.length) {
+    throw new Error('buildSearchEffort: referenceSet needs a version and at least one source');
+  }
+  for (const s of referenceSet.sources) {
+    if (!s.snapshot_date) {
+      throw new Error(`buildSearchEffort: source "${s.id}" has no snapshot_date — a set with no date cannot bound a negative`);
+    }
+  }
+
+  const verdict = deriveVerdict({ candidates, searchable });
+
+  // Every source's declared gaps become limitations of THIS effort. A gap named
+  // once in a manifest and never surfaced on the claim it undermines is not a
+  // disclosure, it is a footnote nobody reads.
+  const inheritedLimitations = referenceSet.sources.flatMap((s) =>
+    (s.known_gaps ?? []).map((g) => `${s.id}: ${g}`));
+
+  return {
+    effort_id: effortId({ bookId, referenceSetVersion: referenceSet.version, codeVersion }),
+    book_id: bookId,
+    work_id: workId ?? null,
+
+    proposition,
+    verdict,
+    searchable,
+
+    reference_set: referenceSet,
+    queries,
+    candidates,
+
+    counts: {
+      queries: queries.length,
+      records_returned: queries.reduce((n, q) => n + (q.result_count ?? 0), 0),
+      candidates_screened: candidates.length,
+      by_screen: candidates.reduce((acc, c) => {
+        acc[c.screen] = (acc[c.screen] || 0) + 1;
+        return acc;
+      }, {}),
+    },
+
+    limitations: [...new Set([...limitations, ...inheritedLimitations])],
+    code_version: codeVersion,
+    run_at: runAt,
+  };
+}
+
+/**
+ * One-line, reader-facing summary of an effort — what the badge renders instead
+ * of an unprovable claim.
+ */
+export function renderEffortSummary(effort) {
+  if (effort.verdict === VERDICT.NOT_SEARCHABLE) {
+    return 'Not yet searchable — no catalogue access point for this work.';
+  }
+  const sources = effort.reference_set.sources;
+  const records = sources.reduce((n, s) => n + (s.record_count ?? 0), 0);
+  const dates = sources.map((s) => String(s.snapshot_date).slice(0, 4)).sort();
+  const span = dates[0] === dates[dates.length - 1] ? dates[0] : `${dates[0]}–${dates[dates.length - 1]}`;
+  const scope = `Searched ${sources.length} ${sources.length === 1 ? 'catalogue' : 'catalogues'}`
+    + `${records ? ` (${records.toLocaleString()} records, ${span})` : ''}`
+    + `; ${effort.counts.candidates_screened} candidate${effort.counts.candidates_screened === 1 ? '' : 's'} screened`
+    + `; ${new Date(effort.run_at).toISOString().slice(0, 10)}.`;
+
+  switch (effort.verdict) {
+    case VERDICT.NONE_FOUND:
+      return `No prior English translation found. ${scope}`;
+    case VERDICT.ONLY_PARTIAL_FOUND:
+      return `No prior COMPLETE English translation found; earlier selections exist. ${scope}`;
+    case VERDICT.PRIOR_FOUND:
+      return `A prior English translation exists. ${scope}`;
+    default:
+      return `Inconclusive — candidates remain unscreened. ${scope}`;
+  }
+}

--- a/scripts/lib/source-language-match.mjs
+++ b/scripts/lib/source-language-match.mjs
@@ -1,0 +1,158 @@
+/**
+ * source-language-match.mjs — do two records name the SAME source language? (#3459)
+ *
+ * The reference set is built from two catalogues that identify a language in
+ * incompatible ways, and nothing reconciled them:
+ *
+ *   LoC (MARC 041$h)  → three-letter bibliographic codes:  "grc", "per", "lat"
+ *   Wikidata (P407)   → Q-numbers plus an English label:   "Q35497" / "Ancient Greek"
+ *
+ * The screen compared our book's language against `row.original_languages`
+ * through a MARC-code table, so every Wikidata row failed it by construction:
+ * `['gre','grc'].includes('Q35497')` is false, and the candidate was rejected as
+ * WRONG_LANGUAGE. Measured on the 2026-07-31 run that discarded 228 candidates,
+ * including Xenophon's *Symposium* (Greek→English) and every one of the six
+ * *Rubáiyát of Omar Khayyám* records (Persian→English) — precisely the priors the
+ * search exists to surface.
+ *
+ * Same family as every other defect in this area: it failed silently, on one
+ * source only, and always toward a confident `none_found`.
+ *
+ * THE RULE THIS MODULE ENFORCES
+ * -----------------------------
+ * Reject on language ONLY when both sides resolve to a known language and those
+ * languages disagree. An unresolvable code, an absent field, or a language not in
+ * the table means UNKNOWN — and unknown must never read as mismatch, because a
+ * rejection here silently preserves a possibly-false badge.
+ *
+ * WHY THERE IS NO Q-NUMBER TABLE
+ * ------------------------------
+ * Deliberate. Every Wikidata row carries an English `original_language_label`
+ * (14,924 of 14,924), so the label is the readable, checkable key and the QID is
+ * redundant. A hand-written QID table would be a list of assertions nobody can
+ * verify at a glance, and a single wrong entry produces exactly the failure this
+ * module exists to remove — a real prior rejected as the wrong language. An
+ * unrecognised Q-number therefore resolves to null and the screen is skipped,
+ * which keeps the candidate open rather than closing the question.
+ */
+
+/**
+ * Canonical language name → every spelling that denotes it: MARC-21 bibliographic
+ * codes and the English labels catalogues return.
+ *
+ * Historical registers collapse into their parent: "Homeric Greek" and "Ancient
+ * Greek" are both `greek`, because a translation from either defeats a
+ * first-English-translation claim on a Greek text. The distinction matters to a
+ * philologist and not to this question.
+ */
+const LANGUAGE_ALIASES = {
+  greek: ['gre', 'grc', 'ancient greek', 'classical greek', 'homeric greek',
+    'koine greek', 'medieval greek', 'byzantine greek', 'modern greek'],
+  latin: ['lat', 'classical latin', 'medieval latin', 'late latin', 'new latin',
+    'vulgar latin', 'ecclesiastical latin', 'neo-latin'],
+  hebrew: ['heb', 'biblical hebrew', 'ancient hebrew', 'mishnaic hebrew'],
+  aramaic: ['arc', 'imperial aramaic', 'jewish palestinian aramaic'],
+  syriac: ['syr', 'classical syriac'],
+  arabic: ['ara', 'classical arabic', 'quranic arabic'],
+  persian: ['per', 'fas', 'farsi', 'classical persian', 'middle persian'],
+  sanskrit: ['san', 'vedic sanskrit'],
+  pali: ['pli'],
+  tamil: ['tam'],
+  tibetan: ['tib', 'bod', 'classical tibetan', 'standard tibetan'],
+  chinese: ['chi', 'zho', 'classical chinese', 'literary chinese', 'middle chinese',
+    'old chinese', 'mandarin'],
+  japanese: ['jpn', 'classical japanese', 'old japanese'],
+  korean: ['kor'],
+  german: ['ger', 'deu', 'high german', 'middle high german', 'old high german',
+    'early new high german'],
+  french: ['fre', 'fra', 'old french', 'middle french'],
+  italian: ['ita'],
+  spanish: ['spa', 'castilian', 'old spanish'],
+  portuguese: ['por'],
+  catalan: ['cat'],
+  dutch: ['dut', 'nld', 'middle dutch'],
+  english: ['eng', 'enm', 'ang', 'american english', 'british english',
+    'early modern english', 'middle english', 'old english'],
+  russian: ['rus'],
+  'church slavonic': ['chu', 'old church slavonic'],
+  polish: ['pol'],
+  czech: ['cze', 'ces'],
+  danish: ['dan'],
+  swedish: ['swe'],
+  norwegian: ['nor'],
+  icelandic: ['ice', 'isl', 'non', 'old norse'],
+  welsh: ['wel', 'cym', 'middle welsh'],
+  irish: ['gle', 'old irish'],
+  hungarian: ['hun'],
+  turkish: ['tur', 'ota', 'ottoman turkish'],
+  armenian: ['arm', 'hye', 'classical armenian'],
+  georgian: ['geo', 'kat'],
+  coptic: ['cop'],
+  egyptian: ['egy', 'ancient egyptian', 'middle egyptian'],
+  akkadian: ['akk', 'babylonian', 'assyrian'],
+  sumerian: ['sux'],
+  ethiopic: ['gez', 'geez', "ge'ez"],
+  hindi: ['hin'],
+  bengali: ['ben', 'bangla'],
+  urdu: ['urd'],
+  mongolian: ['mon'],
+  hawaiian: ['haw'],
+};
+
+/** every alias, lower-cased → canonical name. */
+const ALIAS_TO_CANONICAL = new Map();
+for (const [canonical, aliases] of Object.entries(LANGUAGE_ALIASES)) {
+  ALIAS_TO_CANONICAL.set(canonical, canonical);
+  for (const a of aliases) ALIAS_TO_CANONICAL.set(String(a).toLowerCase().trim(), canonical);
+}
+
+/**
+ * Resolve any spelling of a language to its canonical name, or null.
+ *
+ * Null means "we do not know what this is", and every caller must treat it as
+ * unknown rather than as a mismatch. An unmapped Q-number is the case worth being
+ * careful about: guessing there is how a real prior gets discarded.
+ */
+export function canonicalLanguage(value) {
+  if (!value) return null;
+  const key = String(value)
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s']/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return key ? (ALIAS_TO_CANONICAL.get(key) ?? null) : null;
+}
+
+/**
+ * The source languages a reference-set row claims, as canonical names.
+ *
+ * The English label is preferred over a Q-number for the reason given at the top
+ * of this file. Returns [] when nothing resolves — which the caller must read as
+ * "unknown", never as "no match".
+ */
+export function rowSourceLanguages(row) {
+  const raw = row?.original_language_label
+    ? [row.original_language_label]
+    : (row?.original_languages ?? []);
+  return [...new Set(raw.map(canonicalLanguage).filter(Boolean))];
+}
+
+/**
+ * Should this candidate be rejected because it translates from a different
+ * language than our source?
+ *
+ * Returns a reason string to reject with, or null to keep the candidate. Null is
+ * returned whenever either side is unknown — `books.language` is the EDITION
+ * language, so an absent `original_language` genuinely means we do not know, and
+ * rejecting on a guess discards real priors.
+ */
+export function languageMismatch(bookOriginalLanguage, row) {
+  const ours = canonicalLanguage(bookOriginalLanguage);
+  if (!ours) return null;
+  const theirs = rowSourceLanguages(row);
+  if (!theirs.length) return null;
+  if (theirs.includes(ours)) return null;
+  const shown = row?.original_language_label || (row?.original_languages ?? []).join('/');
+  return `record translates from ${shown} (${theirs.join('/')}), our source is ${bookOriginalLanguage} (${ours})`;
+}

--- a/scripts/lib/translation-catalog-record.mjs
+++ b/scripts/lib/translation-catalog-record.mjs
@@ -85,7 +85,90 @@ export const KNOWN_SOURCE_LANGUAGES = new Set([
   'egy', // Egyptian
   'ta',  // Tamil
   'de', 'nl', 'fr', 'it', 'es', // modern European (parity with existing rows)
+  // Long-tail sources that appear in hand-verified rows. Added with #3460 so a
+  // real verified prior is never lost to an over-narrow whitelist — every one of
+  // these was observed in `source: 'claude_subagent_verify'` production rows.
+  'enm', // Middle English
+  'nah', // Nahuatl
+  'myz', // Mandaic
+  'cy',  // Welsh
+  'hai', // Haida
+  'en',  // English (a same-language "source" is a data smell, but keep it visible)
 ]);
+
+/**
+ * Canonical surface-form → ISO bucket map.
+ *
+ * SINGLE SOURCE OF TRUTH. `scripts/eval/ft-catalog-match.mjs` imports this for
+ * BOTH sides of its SOURCE_LANG guard. Before #3460 the matcher mapped only the
+ * *book* side through an equivalent private table and compared it against the
+ * raw catalog string, so any row whose `source_language` was a display name
+ * ("Sanskrit", "Greek") could never match a book whose language resolved to an
+ * ISO code ("sa", "grc"). That silently disabled all 305 hand-verified
+ * `claude_subagent_verify` rows — including 213 of the catalogue's 385
+ * `completeness: 'complete'` rows, i.e. 55% of the only rows strong enough to
+ * defeat a first-translation claim.
+ */
+const SOURCE_LANGUAGE_ALIASES = {
+  latin: 'la', la: 'la',
+  greek: 'grc', 'ancient greek': 'grc', 'classical greek': 'grc', grc: 'grc',
+  hebrew: 'he', 'biblical hebrew': 'he', 'mishnaic hebrew': 'he', he: 'he',
+  aramaic: 'arc', 'jewish aramaic': 'arc', 'imperial aramaic': 'arc', arc: 'arc',
+  arabic: 'ar', ar: 'ar',
+  sanskrit: 'sa', sa: 'sa', san: 'sa',
+  pali: 'pli', pli: 'pli', pi: 'pli',
+  tibetan: 'bo', bo: 'bo',
+  chinese: 'zh', 'classical chinese': 'zh', 'literary chinese': 'zh',
+  'old chinese': 'zh', zh: 'zh', lzh: 'zh', zho: 'zh',
+  syriac: 'syc', syc: 'syc',
+  armenian: 'hy', hy: 'hy',
+  akkadian: 'akk', akk: 'akk',
+  sumerian: 'sux', sux: 'sux',
+  japanese: 'ja', ja: 'ja',
+  korean: 'ko', ko: 'ko',
+  persian: 'fa', fa: 'fa',
+  avestan: 'ave', ave: 'ave',
+  egyptian: 'egy', egy: 'egy', demotic: 'egy',
+  tamil: 'ta', ta: 'ta',
+  german: 'de', de: 'de',
+  dutch: 'nl', nl: 'nl',
+  french: 'fr', fr: 'fr',
+  italian: 'it', it: 'it',
+  spanish: 'es', es: 'es',
+  'middle english': 'enm', enm: 'enm',
+  nahuatl: 'nah', nah: 'nah',
+  mandaic: 'myz', myz: 'myz',
+  welsh: 'cy', cy: 'cy',
+  haida: 'hai', hai: 'hai',
+  english: 'en', en: 'en',
+};
+
+/**
+ * Resolve any surface form of a source language to its ISO bucket.
+ *
+ * Handles the three shapes hand-written rows actually use:
+ *   "Sanskrit"                          → 'sa'
+ *   "Mandaic (via Lidzbarski's German)" → 'myz'   (parenthetical dropped)
+ *   "Latin/German", "Latin-Dutch"       → 'la'    (first segment wins)
+ *
+ * The first-segment rule matches the convention already used on the book side:
+ * for a bilingual text the leading language is the one being translated FROM.
+ * Callers that need the untruncated original should keep `source_language_raw`.
+ *
+ * @param {string} raw
+ * @returns {string|null} ISO bucket, or null when unmappable
+ */
+export function toSourceIso(raw) {
+  if (!raw) return null;
+  // Drop parentheticals ("Mandaic (via Lidzbarski's German)") and lowercase.
+  const base = String(raw).replace(/\([^)]*\)/g, ' ').toLowerCase().trim();
+  if (!base) return null;
+  if (SOURCE_LANGUAGE_ALIASES[base]) return SOURCE_LANGUAGE_ALIASES[base];
+  // Compound "A/B", "A-B", "A, B" → the leading segment is the source.
+  const first = base.split(/[\/,]|\s-\s|-/)[0].trim();
+  if (SOURCE_LANGUAGE_ALIASES[first]) return SOURCE_LANGUAGE_ALIASES[first];
+  return null;
+}
 
 /**
  * Build a single `translation_catalogs` document from a raw record.
@@ -110,11 +193,15 @@ export const KNOWN_SOURCE_LANGUAGES = new Set([
 export function buildCatalogDoc(rec) {
   const source = (rec.source || '').trim();
   if (!source) throw new Error('buildCatalogDoc: missing source');
-  const sourceLanguage = (rec.source_language || '').trim();
-  if (!KNOWN_SOURCE_LANGUAGES.has(sourceLanguage)) {
+  const sourceLanguageRaw = (rec.source_language || '').trim();
+  // Accept display names ("Sanskrit") as well as ISO codes, but STORE the ISO
+  // bucket — the SOURCE_LANG guard compares buckets, so a display name stored
+  // verbatim is a row that can never match (#3460).
+  const sourceLanguage = toSourceIso(sourceLanguageRaw);
+  if (!sourceLanguage || !KNOWN_SOURCE_LANGUAGES.has(sourceLanguage)) {
     throw new Error(
-      `buildCatalogDoc: invalid source_language "${sourceLanguage}" for "${rec.english_title || rec.author}" `
-      + `(must be one of ${[...KNOWN_SOURCE_LANGUAGES].join(',')})`,
+      `buildCatalogDoc: invalid source_language "${sourceLanguageRaw}" for "${rec.english_title || rec.author}" `
+      + `(must resolve to one of ${[...KNOWN_SOURCE_LANGUAGES].join(',')})`,
     );
   }
 
@@ -151,6 +238,10 @@ export function buildCatalogDoc(rec) {
     series: series || undefined,
     completeness,
     source_language: sourceLanguage,
+    // Keep the untruncated original so a compound ("Nahuatl/Latin") or a
+    // qualified form ("Mandaic (via Lidzbarski's German)") is never lost to the
+    // first-segment rule in toSourceIso().
+    source_language_raw: sourceLanguageRaw !== sourceLanguage ? sourceLanguageRaw : undefined,
     source_language_provenance: 'ingest_explicit',
     source_url: rec.source_url || undefined,
   };

--- a/scripts/lib/work-identity-match.mjs
+++ b/scripts/lib/work-identity-match.mjs
@@ -166,13 +166,28 @@ export function displayTitleOverlap(bookToks, displayTitle) {
 /** Han, kana and hangul ranges — the scripts where romanized matching fails. */
 const CJK_RE = /[㐀-䶿一-鿿豈-﫿぀-ヿ가-힯]/;
 
-/** Contiguous runs of CJK characters, punctuation and Latin stripped. */
+/**
+ * CJK numerals and volume markers. A run made only of these is an ENUMERATION —
+ * "(三十九)" is volume 39 — not title content.
+ *
+ * Without this exclusion the volume number becomes the match key and pairs with
+ * numerals in any unrelated title: 三才圖會(三十九) matched *The Thirty-Nine Steps*
+ * and 武備志(一百二) matched *The 120 Days of Sodom*, because Wikidata carries
+ * Chinese labels for Buchan and Sade containing exactly those numerals. It is the
+ * same failure the Western VOLUME guard exists to catch, in a different script.
+ */
+const CJK_ENUMERATION_ONLY = /^[〇零一二三四五六七八九十百千万萬第卷冊册巻編编集號号輯辑]+$/;
+
+/**
+ * Contiguous runs of CJK characters, punctuation and Latin stripped.
+ * Pure enumerations are dropped — they identify a volume, never a work.
+ */
 export function cjkRuns(s) {
   if (!s) return [];
   return String(s)
     .replace(/[^㐀-䶿一-鿿豈-﫿぀-ヿ가-힯]+/g, ' ')
     .split(/\s+/)
-    .filter((r) => r.length >= 2);
+    .filter((r) => r.length >= 2 && !CJK_ENUMERATION_ONLY.test(r));
 }
 
 export const hasCjk = (s) => CJK_RE.test(String(s || ''));

--- a/scripts/lib/work-identity-match.mjs
+++ b/scripts/lib/work-identity-match.mjs
@@ -60,7 +60,13 @@ export const bookTitleTokens = (...titles) => [...new Set(titles.flatMap(titleTo
  * Deliberately shallow — it only has to bridge declension, not lemmatise.
  */
 export function stem(t) {
-  return t.replace(/(?:ibus|arum|orum|is|ae|am|um|us|os|as|es|em|i|o|a|e)$/, '');
+  const declined = t.replace(/(?:ibus|arum|orum|is|ae|am|um|us|os|as|es|em|i|o|a|e)$/, '');
+  if (declined !== t) return declined;
+  // English plural, applied only when no Latin ending matched. Our title is
+  // frequently the Latin ("Elementa") where the catalogue's 245 is the English
+  // ("Euclid's Elements") — without this the two never meet and Euclid's Elements
+  // reads as a different work from Euclid's Elements.
+  return /[^aeiou]s$/.test(t) && t.length > 4 ? t.slice(0, -1) : t;
 }
 
 /**
@@ -139,18 +145,62 @@ export function uniformTitleContainment(bookToks, uniformTitle, opts = {}) {
 export const GENERIC_UNIFORM_MAX_TOKENS = 2;
 
 /**
- * FALLBACK — bag-of-tokens overlap against the 245 display title, for the ~32%
- * of rows with no 240. Capped below the strong threshold so it can surface a
- * hint for screening but never assert a work match by itself.
+ * Tokens of a personal name, for discounting inside a TITLE.
+ *
+ * A 245 display title routinely contains the author: "The Iliad of Homer", "The
+ * thirteen books of Euclid's Elements", "The Rhetoric of Aristotle". Those tokens
+ * carry no work identity — an author's name is equally present in the titles of
+ * everything they wrote, which is exactly why it manufactures false matches
+ * between two different works by one person. This is the same job TITLE_STOP does
+ * for "liber" and "tractatus", except the filler is supplied per-pair.
  */
-export function displayTitleOverlap(bookToks, displayTitle) {
+export function personalNameTokens(names = []) {
+  return new Set(
+    names.filter(Boolean)
+      .flatMap((n) => titleTokens(String(n).replace(/\d{3,4}/g, ' ')))
+      .map(stem),
+  );
+}
+
+/**
+ * FALLBACK — the 245 display title, for the 35.2% of rows carrying no 240.
+ *
+ * TWO OUTCOMES, and the difference is the whole point:
+ *
+ *   a WEAK HINT (score ≤ 0.55, below STRONG_WORK_IDENTITY) — the default. The
+ *   candidate is retrieved and screened but cannot assert work identity. This is
+ *   what the function used to return unconditionally, which meant over a third of
+ *   the reference set could only ever yield `none_found`.
+ *
+ *   a CONFIRMATION (score 1) — when the author agrees AND, after discounting
+ *   personal-name tokens, one title's remaining content is CONTAINED in the
+ *   other's.
+ *
+ * Why containment rather than a raised ratio: a 245 is an edition's own line and
+ * carries apparatus a work title never has. "The thirteen books of Euclid's
+ * Elements" against our "Elementa" scores 0.50 on min-coverage and would be lost
+ * by any threshold above that, while "Historia animalium" against "De partibus
+ * animalium" — two different works — scores the same 0.50 and would be kept. A
+ * ratio cannot separate those; containment separates them for a reason. It is
+ * also the identical test the 240 path uses, so the two paths agree by
+ * construction instead of by tuning.
+ *
+ * Both directions count. Our title is sometimes the fuller one ("Sahih al-Bukhari
+ * (Complete)" ⊃ the record's "Sahih al-Bukhari") and sometimes the barer one
+ * ("Code of Hammurabi" ⊂ "The complete code of Hammurabi").
+ *
+ * Author agreement is REQUIRED and is not a threshold that can be relaxed. The
+ * title-token lane has no author access point, and a 245 match resting on words
+ * alone is precisely how "The cup to the dregs" matched a Tibetan ritual text.
+ */
+export function displayTitleOverlap(bookToks, displayTitle, opts = {}) {
   const rt = new Set(titleTokens(displayTitle));
   if (!rt.size || !bookToks?.length) return null;
   const hits = bookToks.filter((t) => rt.has(t)).length;
   if (!hits) return null;
   const bookCoverage = hits / bookToks.length;
   const recordCoverage = hits / rt.size;
-  return {
+  const weak = {
     score: Math.min(0.55, Math.min(bookCoverage, recordCoverage)),
     hits,
     basis: 'display_title_overlap',
@@ -158,6 +208,32 @@ export function displayTitleOverlap(bookToks, displayTitle) {
     record_coverage: recordCoverage,
     book_tokens: bookToks.length,
     record_tokens: rt.size,
+  };
+
+  const { bookAuthorSurname, recordAuthorSurnames, authorNames } = opts;
+  const agrees = Boolean(bookAuthorSurname)
+    && (recordAuthorSurnames ?? []).some((s) => s && s === bookAuthorSurname);
+  if (!agrees) return weak;
+
+  const names = personalNameTokens(authorNames ?? []);
+  const bookContent = [...new Set(bookToks.map(stem))].filter((t) => !names.has(t));
+  const recordContent = [...new Set([...rt].map(stem))].filter((t) => !names.has(t));
+  // A title that is nothing but the author's name identifies no work.
+  if (!bookContent.length || !recordContent.length) return weak;
+
+  const bookInRecord = bookContent.every((t) => recordContent.includes(t));
+  const recordInBook = recordContent.every((t) => bookContent.includes(t));
+  if (!bookInRecord && !recordInBook) return weak;
+
+  return {
+    score: 1,
+    hits: bookContent.filter((t) => recordContent.includes(t)).length,
+    basis: 'display_title_containment+author',
+    direction: bookInRecord ? 'book_in_record' : 'record_in_book',
+    book_content_tokens: bookContent.length,
+    record_content_tokens: recordContent.length,
+    discounted_name_tokens: [...names],
+    author_corroborated: true,
   };
 }
 
@@ -255,7 +331,11 @@ export function matchWorkIdentity(bookToks, row, opts = {}) {
     if (vern) return vern;
   }
   return uniformTitleContainment(bookToks, row.uniform_title, opts)
-    ?? displayTitleOverlap(bookToks, row.title);
+    // The subtitle is part of the same 245 field and often carries the work names
+    // the title proper omits ("Four texts on Socrates : Plato's Euthyphro,
+    // Apology, and Crito"). Dropping it discarded real content on the very rows
+    // that have no 240 to fall back on.
+    ?? displayTitleOverlap(bookToks, `${row.title || ''} ${row.subtitle || ''}`, opts);
 }
 
 /** Threshold at which a match is strong enough to require screening. */

--- a/scripts/lib/work-identity-match.mjs
+++ b/scripts/lib/work-identity-match.mjs
@@ -161,8 +161,84 @@ export function displayTitleOverlap(bookToks, displayTitle) {
   };
 }
 
-/** Best available work-identity signal for a book/row pair, or null. */
+// ── CJK / original-script matching ───────────────────────────────────────────
+
+/** Han, kana and hangul ranges — the scripts where romanized matching fails. */
+const CJK_RE = /[㐀-䶿一-鿿豈-﫿぀-ヿ가-힯]/;
+
+/** Contiguous runs of CJK characters, punctuation and Latin stripped. */
+export function cjkRuns(s) {
+  if (!s) return [];
+  return String(s)
+    .replace(/[^㐀-䶿一-鿿豈-﫿぀-ヿ가-힯]+/g, ' ')
+    .split(/\s+/)
+    .filter((r) => r.length >= 2);
+}
+
+export const hasCjk = (s) => CJK_RE.test(String(s || ''));
+
+/**
+ * ORIGINAL-SCRIPT CONTAINMENT — the work-identity test for CJK.
+ *
+ * Romanized matching is not merely weaker here, it is unusable. LoC mixes pinyin
+ * and Wade-Giles; pinyin is syllable-separated where our titles are joined
+ * ("Huang ji jing shi shu" vs "Huangji Jingshi Shu"); and most pinyin syllables
+ * fall under the token-length floor. Working around all of that by concatenating
+ * and substring-matching was measured at ~2 real matches in 38 — romanized
+ * Chinese is a dense syllable soup in which short keys collide by accident
+ * ("mingshi" sits inside "zhiwumingshitukao", matching a herbal to the *Ming
+ * History*).
+ *
+ * Han characters are morphemes and have exactly one spelling, so a shared run is
+ * strong evidence. `MIN_CJK_RUN` is 3: two characters is often a common bigram
+ * ("中國", "大成"), three is usually a title.
+ *
+ * A partial containment is a REAL and useful signal here rather than noise —
+ * 本草綱目 ⊂ 本草綱目拾遺 is the *Bencao Gangmu* inside its own supplement, which is
+ * exactly the related-work relation screening needs to see.
+ */
+export const MIN_CJK_RUN = 3;
+
+export function vernacularContainment(bookTitles, row) {
+  const bookRuns = bookTitles.flatMap(cjkRuns).filter((r) => r.length >= MIN_CJK_RUN);
+  if (!bookRuns.length) return null;
+
+  const candidates = [
+    ['vernacular_uniform_title', row.vernacular_uniform_title],
+    ['vernacular_title', row.vernacular_title],
+  ].filter(([, v]) => v && hasCjk(v));
+  if (!candidates.length) return null;
+
+  for (const [basis, value] of candidates) {
+    for (const recRun of cjkRuns(value).filter((r) => r.length >= MIN_CJK_RUN)) {
+      for (const bookRun of bookRuns) {
+        if (bookRun.includes(recRun) || recRun.includes(bookRun)) {
+          const shared = Math.min(bookRun.length, recRun.length);
+          return {
+            score: 1,
+            hits: shared,
+            basis: `cjk_${basis}`,
+            matched_run: recRun.length <= bookRun.length ? recRun : bookRun,
+            exact: bookRun === recRun,
+          };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Best available work-identity signal for a book/row pair, or null.
+ *
+ * Original script first where both sides have it — it is the strongest signal
+ * available and immune to the romanization problems above.
+ */
 export function matchWorkIdentity(bookToks, row, opts = {}) {
+  if (opts.bookTitles?.length) {
+    const vern = vernacularContainment(opts.bookTitles, row);
+    if (vern) return vern;
+  }
   return uniformTitleContainment(bookToks, row.uniform_title, opts)
     ?? displayTitleOverlap(bookToks, row.title);
 }

--- a/scripts/lib/work-identity-match.mjs
+++ b/scripts/lib/work-identity-match.mjs
@@ -82,11 +82,50 @@ export function stem(t) {
  *   "Calice jusqu'à la lie."  ⊄ Tibetan ritual text                        ✗
  *   "ʼDod paʼi bstan bcos."   ⊄ "she bya rab tu gsal ba'I bstan bcos"      ✗
  */
-export function uniformTitleContainment(bookToks, uniformTitle) {
+export function uniformTitleContainment(bookToks, uniformTitle, opts = {}) {
   const ut = titleTokens(uniformTitle);
   if (!ut.length || !bookToks?.length) return null;
   const bookStems = new Set(bookToks.map(stem));
   if (ut.some((t) => !bookStems.has(stem(t)))) return null;
+
+  // GENERIC UNIFORM TITLES need author corroboration.
+  //
+  // A one- or two-word uniform title is frequently a whole GENRE rather than a
+  // work: "Annales.", "Itinerarium.", "Journal.", "Prodromus.". Containment
+  // alone then matches any book sharing that ordinary word, and it produced four
+  // absurd pairings in the full run — all with a DIFFERENT author:
+  //
+  //   "Annales mac[onniques]" (Masonic annals)  → Tacitus, *Annales*
+  //   "Itinerarium Portugallensium"             → Mandeville, *Itinerarium*
+  //   "Hermetisches Journal"                    → *Journal of Maurice de Guérin*
+  //   "Merckwürdiges Leben des ... Moritz W."   → Wilhelm Busch, *Max und Moritz*
+  //
+  // Every genuine match, by contrast, agrees on author: Cicero→Cicero,
+  // Homer→Homer, Euclid→Euclid, Della Porta→Della Porta, Jayadeva→Jayadeva. So
+  // require that agreement precisely where the title stops being distinctive,
+  // rather than raising a threshold and losing the one-token true positives
+  // ("De officiis.", "Moralia.", "Elements.", "Poetics.").
+  //
+  // Consequence worth stating: an ANONYMOUS work can only match on a long,
+  // distinctive uniform title. That is the conservative direction — it leaves a
+  // claim standing rather than demoting it on a coincidence.
+  if (ut.length <= GENERIC_UNIFORM_MAX_TOKENS) {
+    const { bookAuthorSurname, recordAuthorSurnames } = opts;
+    const agrees = Boolean(bookAuthorSurname)
+      && (recordAuthorSurnames ?? []).some((s) => s && s === bookAuthorSurname);
+    if (!agrees) {
+      return null;
+    }
+    return {
+      score: 1,
+      hits: ut.length,
+      basis: 'uniform_title_containment+author',
+      uniform_tokens: ut.length,
+      book_tokens: bookToks.length,
+      author_corroborated: true,
+    };
+  }
+
   return {
     score: 1,
     hits: ut.length,
@@ -95,6 +134,9 @@ export function uniformTitleContainment(bookToks, uniformTitle) {
     book_tokens: bookToks.length,
   };
 }
+
+/** At or below this many tokens, a uniform title is treated as possibly generic. */
+export const GENERIC_UNIFORM_MAX_TOKENS = 2;
 
 /**
  * FALLBACK — bag-of-tokens overlap against the 245 display title, for the ~32%
@@ -120,8 +162,8 @@ export function displayTitleOverlap(bookToks, displayTitle) {
 }
 
 /** Best available work-identity signal for a book/row pair, or null. */
-export function matchWorkIdentity(bookToks, row) {
-  return uniformTitleContainment(bookToks, row.uniform_title)
+export function matchWorkIdentity(bookToks, row, opts = {}) {
+  return uniformTitleContainment(bookToks, row.uniform_title, opts)
     ?? displayTitleOverlap(bookToks, row.title);
 }
 

--- a/scripts/lib/work-identity-match.mjs
+++ b/scripts/lib/work-identity-match.mjs
@@ -1,0 +1,129 @@
+/**
+ * work-identity-match.mjs — is this catalogue record the same WORK as this book?
+ *
+ * Pure functions, no I/O, so the gold set in
+ * tests/unit/reference-set-work-identity.test.ts can exercise them directly.
+ * That separation is the point: this logic was tuned five times against
+ * whichever sample happened to be on screen, and step 4 of that tuning silently
+ * lost verified true positives (Cicero's *De Officiis* → Grimald 1556) while
+ * making the corpus look cleaner. It is now pinned to hand-verified pairs.
+ *
+ * THE KEY INSIGHT, after five failed rounds of ratio tuning
+ * --------------------------------------------------------
+ * MARC 240 exists precisely to name a work independently of how any edition
+ * titles itself. It IS the join key. So the test is set CONTAINMENT of the
+ * uniform title in our title — not a coverage ratio on the 245 display title,
+ * which is the edition's marketing line and carries apparatus our title never has.
+ *
+ * Every ratio-based rule failed on the same two rocks. "De officiis." reduces to
+ * ONE usable token, so any count- or fraction-based rule either discards it (a
+ * false negative on a work that has been in English since 1556) or, once
+ * loosened, lets "The cup to the dregs" match a Tibetan ritual text because
+ * "dregs" is simultaneously an English word and a romanized Tibetan syllable.
+ * Containment gets both right for a reason rather than by tuning.
+ */
+
+/** Bibliographic filler and container words that carry no work identity. */
+export const TITLE_STOP = new Set([
+  // English / Latin
+  'the', 'and', 'with', 'from', 'that', 'this', 'for', 'des', 'der', 'die', 'und',
+  'liber', 'libri', 'opus', 'opera', 'book', 'books', 'volume', 'tractatus',
+  'english', 'translation', 'translated', 'works', 'text', 'new', 'notes',
+  'introduction', 'edition', 'edited', 'selected', 'sive', 'seu', 'cum',
+
+  // Romanized Tibetan container vocabulary — the exact equivalents of "opera
+  // omnia" or "tractatus". `thor bu` = miscellanea, `bstan bcos` = treatise,
+  // `rnam thar` = hagiography, `lo rgyus` = history, `sogs` = et cetera.
+  // ⚠️ Assembled from context, not by a Tibetanist. Worth review by someone who
+  // reads Tibetan before this list is trusted to exclude a real match.
+  'thor', 'sogs', 'skor', 'bstan', 'bcos', 'rnam', 'thar', 'rgyus', 'chos',
+
+  // Romanized Sanskrit / Indic container vocabulary.
+  'grantha', 'sastra', 'shastra', 'sutra', 'sutras', 'tantra', 'purana',
+  'samhita', 'bhasya', 'tika', 'vritti',
+]);
+
+export const normaliseTitle = (s) => (s || '')
+  .normalize('NFD').replace(/[̀-ͯ]/g, '')
+  .toLowerCase().replace(/[^a-z0-9\s]/g, ' ')
+  .replace(/\s+/g, ' ').trim();
+
+export function titleTokens(s) {
+  return normaliseTitle(s).split(/\s+/).filter((t) => t.length >= 4 && !TITLE_STOP.has(t));
+}
+
+export const bookTitleTokens = (...titles) => [...new Set(titles.flatMap(titleTokens))];
+
+/**
+ * Crude inflectional stem, so a uniform title and our title of the same work
+ * agree across case endings: "magiae" ⇔ "magia", "officiis" ⇔ "officii".
+ * Deliberately shallow — it only has to bridge declension, not lemmatise.
+ */
+export function stem(t) {
+  return t.replace(/(?:ibus|arum|orum|is|ae|am|um|us|os|as|es|em|i|o|a|e)$/, '');
+}
+
+/**
+ * PRIMARY TEST — is every token of the MARC 240 uniform title present in our
+ * title? Word order is ignored: a uniform title is a set, not a phrase
+ * ("Formula vitae honestae" ⇔ our "De formula honestae vitae").
+ *
+ * Returns null when there is no uniform title, no book tokens, or any uniform
+ * token is absent. Null means "not established", never "no prior exists".
+ *
+ * Verified behaviour (real LoC rows, see the gold set):
+ *   "De officiis."            ⊆ "De officiis. Add: Paradoxa Stoicorum"      ✓
+ *   "Formula vitae honestae." ⊆ "De formula honestae vitae"                 ✓
+ *   "Moralia."                ⊆ "Plutarchi Chaeronensis Moralia"            ✓
+ *   "Elements."               ⊆ "Στοιχεῖα (Elements)"                       ✓
+ *   "Iliad."                  ⊆ "Homer, Iliad with Scholia"                 ✓
+ *   "Magiae naturalis."       ⊆ "Magia Naturalis"              (stemmed)    ✓
+ *   "Legs bshad gser phreng." ⊆ "Neyphug Thor bu Legs bshad gser phreng"    ✓
+ *   "Calice jusqu'à la lie."  ⊄ Tibetan ritual text                        ✗
+ *   "ʼDod paʼi bstan bcos."   ⊄ "she bya rab tu gsal ba'I bstan bcos"      ✗
+ */
+export function uniformTitleContainment(bookToks, uniformTitle) {
+  const ut = titleTokens(uniformTitle);
+  if (!ut.length || !bookToks?.length) return null;
+  const bookStems = new Set(bookToks.map(stem));
+  if (ut.some((t) => !bookStems.has(stem(t)))) return null;
+  return {
+    score: 1,
+    hits: ut.length,
+    basis: 'uniform_title_containment',
+    uniform_tokens: ut.length,
+    book_tokens: bookToks.length,
+  };
+}
+
+/**
+ * FALLBACK — bag-of-tokens overlap against the 245 display title, for the ~32%
+ * of rows with no 240. Capped below the strong threshold so it can surface a
+ * hint for screening but never assert a work match by itself.
+ */
+export function displayTitleOverlap(bookToks, displayTitle) {
+  const rt = new Set(titleTokens(displayTitle));
+  if (!rt.size || !bookToks?.length) return null;
+  const hits = bookToks.filter((t) => rt.has(t)).length;
+  if (!hits) return null;
+  const bookCoverage = hits / bookToks.length;
+  const recordCoverage = hits / rt.size;
+  return {
+    score: Math.min(0.55, Math.min(bookCoverage, recordCoverage)),
+    hits,
+    basis: 'display_title_overlap',
+    book_coverage: bookCoverage,
+    record_coverage: recordCoverage,
+    book_tokens: bookToks.length,
+    record_tokens: rt.size,
+  };
+}
+
+/** Best available work-identity signal for a book/row pair, or null. */
+export function matchWorkIdentity(bookToks, row) {
+  return uniformTitleContainment(bookToks, row.uniform_title)
+    ?? displayTitleOverlap(bookToks, row.title);
+}
+
+/** Threshold at which a match is strong enough to require screening. */
+export const STRONG_WORK_IDENTITY = 0.6;

--- a/scripts/maintenance/ingest-ft-verify-results.mjs
+++ b/scripts/maintenance/ingest-ft-verify-results.mjs
@@ -40,6 +40,7 @@
  */
 import { MongoClient } from 'mongodb';
 import fs from 'fs';
+import { buildCatalogDoc } from '../lib/translation-catalog-record.mjs';
 
 const file = process.argv.slice(2).find((a) => a.endsWith('.json'));
 const APPLY = process.argv.includes('--apply');
@@ -59,9 +60,10 @@ await c.connect();
 const db = c.db('bookstore');
 const attempts = db.collection('first_translation_attempts');
 const registry = db.collection('translation_catalogs');
+const quarantine = db.collection('translation_catalogs_quarantine');
 
 const FOUND = new Set(['confirmed_complete', 'confirmed_partial', 'complete_prior_found', 'only_partial_exists']);
-let aIns = 0, aSkip = 0, cIns = 0, cSkip = 0, badRows = 0;
+let aIns = 0, aSkip = 0, cIns = 0, cSkip = 0, cQuar = 0, badRows = 0;
 
 const completenessFor = (result) =>
   result === 'confirmed_complete' || result === 'complete_prior_found' ? 'complete'
@@ -148,12 +150,39 @@ for (const r of rows) {
     if (t.translator) dupQuery.translator = t.translator;
     const dup = await registry.findOne(dupQuery);
     if (dup) { cSkip++; continue; }
-    if (APPLY) {
-      await registry.insertOne({
+
+    // #3460: build through the shared builder rather than spreading the raw
+    // subagent object. Spreading stored `source_language` verbatim as a display
+    // name ("Sanskrit") — the matcher's SOURCE_LANG guard compares ISO buckets,
+    // so every such row was inert. buildCatalogDoc also derives author_surname /
+    // english_title_normalized / pub_year_int, which the raw spread never set.
+    let doc;
+    try {
+      doc = buildCatalogDoc({
         ...t,
         pub_year: String(t.pub_year),
-        author_normalized: (t.author ?? '').toLowerCase(),
         source: 'claude_subagent_verify',
+      });
+    } catch (err) {
+      // An unmappable source_language is a real verified prior we must not drop.
+      // Quarantine keeps the record (and the reason) rather than throwing it away.
+      cQuar++;
+      if (APPLY) {
+        await quarantine.insertOne({
+          ...t,
+          pub_year: String(t.pub_year),
+          source: 'claude_subagent_verify',
+          quarantine_reason: err.message,
+          quarantined_at: new Date(),
+          source_language_provenance: `ft-verify-${runDate}`,
+        });
+      }
+      continue;
+    }
+
+    if (APPLY) {
+      await registry.insertOne({
+        ...doc,
         source_language_provenance: `ft-verify-${runDate}`,
         imported_at: new Date(),
       });
@@ -164,7 +193,7 @@ for (const r of rows) {
 
 console.log(`${APPLY ? 'APPLIED' : 'DRY-RUN'} — ${rows.length} results from ${file}`);
 console.log(`  Sink A (attempts ledger): +${aIns} inserted, ${aSkip} already present`);
-console.log(`  Sink C (translation_catalogs): +${cIns} inserted, ${cSkip} deduped`);
+console.log(`  Sink C (translation_catalogs): +${cIns} inserted, ${cSkip} deduped, ${cQuar} quarantined`);
 if (badRows) console.log(`  WARNING: ${badRows} malformed rows/registry entries skipped`);
 console.log('  Sink B (verdict) deliberately untouched — run derive-ft-verdict-from-attempts.ts; the public flag stays behind the reconcile.');
 await c.close();

--- a/scripts/maintenance/reproject-translation-catalogs.mjs
+++ b/scripts/maintenance/reproject-translation-catalogs.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * reproject-translation-catalogs.mjs — repair rows written without the shared
+ * builder, so the matcher can actually see them.  (#3460)
+ *
+ * WHY
+ * ---
+ * `scripts/maintenance/ingest-ft-verify-results.mjs` used to insert its Sink-C
+ * rows by spreading the raw ft-verify subagent object:
+ *
+ *     await registry.insertOne({ ...t, author_normalized: t.author.toLowerCase(), … })
+ *
+ * That bypassed `buildCatalogDoc()`, so those rows never got the derived fields
+ * the Tier-0 matcher relies on, and — the binding defect — kept
+ * `source_language` as a human display name ("Sanskrit", "Greek", "Latin")
+ * instead of the ISO bucket ("sa", "grc", "la").
+ *
+ * `scripts/eval/ft-catalog-match.mjs` resolves the BOOK's language to an ISO
+ * bucket and compares it against the catalog row's stored string, so a display
+ * name can never match. Every affected row failed the SOURCE_LANG guard against
+ * every book — measured 2026-07-29: 305 rows, ALL of `source:
+ * 'claude_subagent_verify'`, carrying 213 of the catalogue's 385
+ * `completeness: 'complete'` rows (55% of the only rows strong enough to defeat
+ * a first-translation claim).
+ *
+ * This sweep recomputes the derived fields from data already present on the row.
+ * It is a re-projection, not a re-fetch: no network, no LLM, no cost.
+ *
+ * SAFETY
+ * ------
+ *   - Dry-run by default; `--apply` required to write.
+ *   - Writes a full backup of every touched document BEFORE mutating.
+ *   - Never changes `completeness`, `english_title`, `translator`, `pub_year`,
+ *     or any human-entered judgement — only derived/normalised fields.
+ *   - A row whose `source_language` cannot be resolved is REPORTED, never
+ *     guessed and never deleted.
+ *   - Idempotent: a second run reports 0 to change.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/reproject-translation-catalogs.mjs           # dry-run
+ *   node scripts/maintenance/reproject-translation-catalogs.mjs --apply
+ *   node scripts/maintenance/reproject-translation-catalogs.mjs --source claude_subagent_verify
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+import {
+  normalize,
+  extractSurname,
+  toSourceIso,
+  KNOWN_SOURCE_LANGUAGES,
+} from '../lib/translation-catalog-record.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.join(__dirname, '..', 'output');
+const APPLY = process.argv.includes('--apply');
+const SOURCE_FILTER = (() => {
+  const i = process.argv.indexOf('--source');
+  return i === -1 ? null : process.argv[i + 1];
+})();
+
+/**
+ * Recompute the derived fields for one row.
+ *
+ * FILL-ONLY, deliberately. A derived field that is already populated is left
+ * alone even when recomputation would produce something different.
+ *
+ * Measured 2026-07-29: recomputing unconditionally would have MUTATED 2,961
+ * existing `author_surname` values, and the new value is frequently worse. The
+ * stored keys were derived from the `author` field, which is in reliable
+ * "Last, First" form; `buildCatalogDoc` prefers `canonical_author`, which is an
+ * English display name, and `extractSurname`'s last-word rule mangles those:
+ *
+ *     "Augustine of Hippo"           → "hippo"     (was "aurelius")
+ *     "Various Authors"              → "authors"
+ *     "Ioannes Paulus II"            → "ii"
+ *     "Various Early Church Fathers" → "fathers"
+ *
+ * Those are the matcher's candidate-lookup keys, so overwriting them silently
+ * re-buckets thousands of rows. That is a separate concern with its own
+ * evidence bar — this sweep exists to fix `source_language`, and it stays in
+ * that lane. The divergence is counted and reported so the follow-up is sized.
+ *
+ * Returns the fields that would change, the divergences observed but NOT
+ * applied, and any problem worth reporting.
+ */
+function reproject(row) {
+  const patch = {};
+  const problems = [];
+  const divergences = [];
+
+  /** Fill `field` only when it is currently empty; otherwise record divergence. */
+  const fill = (field, value) => {
+    if (!value) return;
+    const current = row[field];
+    if (current === value) return;
+    if (current === undefined || current === null || current === '') patch[field] = value;
+    else divergences.push({ field, was: current, would_be: value });
+  };
+
+  // ── source_language → ISO bucket ───────────────────────────────────────────
+  // The ONE field this sweep overwrites: a display name here is not a stylistic
+  // difference, it is a value the SOURCE_LANG guard can never match (#3460).
+  const rawLang = (row.source_language || '').trim();
+  const iso = toSourceIso(rawLang);
+  if (!rawLang) {
+    problems.push('no source_language');
+  } else if (!iso || !KNOWN_SOURCE_LANGUAGES.has(iso)) {
+    problems.push(`unmappable source_language "${rawLang}"`);
+  } else if (iso !== rawLang) {
+    patch.source_language = iso;
+    patch.source_language_raw = rawLang;
+  }
+
+  // ── derived match keys (fill-only) ─────────────────────────────────────────
+  const author = (row.author || '').trim();
+  const canonicalAuthor = (row.canonical_author || '').trim();
+  fill('author_surname', extractSurname(canonicalAuthor || author));
+  fill('author_normalized', normalize(author));
+  fill('english_title_normalized', normalize(row.english_title || ''));
+  if (row.canonical_work) fill('canonical_work_normalized', normalize(row.canonical_work));
+  if (row.original_title) fill('original_title_normalized', normalize(row.original_title));
+
+  const yearInt = parseInt(String(row.pub_year ?? '').trim(), 10);
+  if (Number.isFinite(yearInt)) fill('pub_year_int', yearInt);
+
+  return { patch, problems, divergences };
+}
+
+await withMongo(async (db) => {
+  const registry = db.collection('translation_catalogs');
+  const query = SOURCE_FILTER ? { source: SOURCE_FILTER } : {};
+  const rows = await registry.find(query).toArray();
+  console.log(`Scanning ${rows.length} rows${SOURCE_FILTER ? ` (source=${SOURCE_FILTER})` : ''}…\n`);
+
+  const toWrite = [];
+  const problemRows = [];
+  const fieldTally = {};
+  const sourceTally = {};
+  const divergenceTally = {};
+  const divergenceExamples = [];
+
+  for (const row of rows) {
+    const { patch, problems, divergences } = reproject(row);
+    if (problems.length) {
+      problemRows.push({ _id: String(row._id), source: row.source, title: row.english_title, problems });
+    }
+    for (const d of divergences) {
+      divergenceTally[d.field] = (divergenceTally[d.field] || 0) + 1;
+      if (d.field === 'author_surname' && divergenceExamples.length < 10) {
+        divergenceExamples.push({ src: row.source, author: row.author, canon: row.canonical_author, ...d });
+      }
+    }
+    if (Object.keys(patch).length === 0) continue;
+    toWrite.push({ row, patch });
+    for (const f of Object.keys(patch)) fieldTally[f] = (fieldTally[f] || 0) + 1;
+    sourceTally[row.source] = (sourceTally[row.source] || 0) + 1;
+  }
+
+  console.log(`Rows needing re-projection: ${toWrite.length}`);
+  console.log('  by field:', fieldTally);
+  console.log('  by source:', sourceTally);
+  console.log(`\nRows with unresolvable problems (reported, NOT changed): ${problemRows.length}`);
+  for (const p of problemRows.slice(0, 20)) {
+    console.log(`  - [${p.source}] ${String(p.title).slice(0, 60)} — ${p.problems.join('; ')}`);
+  }
+  if (problemRows.length > 20) console.log(`  … and ${problemRows.length - 20} more`);
+
+  console.log('\nDIVERGENCES observed but deliberately NOT applied (fill-only policy):');
+  console.log(' ', divergenceTally);
+  if (divergenceExamples.length) {
+    console.log('  sample author_surname divergences — note the recomputed value is often WORSE,');
+    console.log('  which is why this sweep does not overwrite populated keys:');
+    for (const e of divergenceExamples) {
+      console.log(`    [${e.src}] author="${e.author}" canon="${e.canon}" stored="${e.was}" recomputed="${e.would_be}"`);
+    }
+  }
+
+  // How many rows become guard-eligible as a result — the number that matters.
+  const nowComplete = toWrite.filter(
+    ({ row, patch }) => row.completeness === 'complete' && patch.source_language,
+  ).length;
+  console.log(`\n"complete" rows gaining an ISO source_language: ${nowComplete}`);
+
+  if (!APPLY) {
+    console.log('\nDRY-RUN — nothing written. Re-run with --apply.');
+    return;
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backupPath = path.join(OUT_DIR, `reproject-translation-catalogs-backup-${stamp}.json`);
+  fs.writeFileSync(backupPath, JSON.stringify(toWrite.map(({ row }) => row), null, 2));
+  console.log(`\nBacked up ${toWrite.length} original documents → ${backupPath}`);
+
+  let written = 0;
+  for (let i = 0; i < toWrite.length; i += 500) {
+    const chunk = toWrite.slice(i, i + 500);
+    const res = await registry.bulkWrite(
+      chunk.map(({ row, patch }) => ({
+        updateOne: {
+          filter: { _id: row._id },
+          update: { $set: { ...patch, reprojected_at: new Date() } },
+        },
+      })),
+    );
+    written += res.modifiedCount;
+  }
+  console.log(`APPLIED — modifiedCount=${written} (expected ${toWrite.length})`);
+  if (written !== toWrite.length) {
+    console.log('WARNING: modifiedCount does not match the planned count — investigate before trusting this run.');
+  }
+});

--- a/tests/fixtures/marc/loc-copenhaver-hermetica.xml
+++ b/tests/fixtures/marc/loc-copenhaver-hermetica.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0"?>
+<zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordPacking>xml</zs:recordPacking><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+  <leader>01648cam a2200385 a 4500</leader>
+  <controlfield tag="001">4379030</controlfield>
+  <controlfield tag="005">20250607164910.3</controlfield>
+  <controlfield tag="008">910701s1992    enk      b    001 0 eng  </controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">4379030</subfield>
+  </datafield>
+  <datafield tag="906" ind1=" " ind2=" ">
+    <subfield code="a">7</subfield>
+    <subfield code="b">cbc</subfield>
+    <subfield code="c">orignew</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">ocip</subfield>
+    <subfield code="f">19</subfield>
+    <subfield code="g">y-gencatlg</subfield>
+  </datafield>
+  <datafield tag="955" ind1=" " ind2=" ">
+    <subfield code="a">pc01 to ea00 07-02-91; ea00 to SCD 07-02-91; hr06 07-08-91; hr03 to ddc 07-09-91; aa03 07-10-91; CIP ver. nb04 10-02-92</subfield>
+  </datafield>
+  <datafield tag="955" ind1=" " ind2=" ">
+    <subfield code="a">LCAP batch update 2025-06-02-04:00: LCAPM-644, LCAPM-150</subfield>
+  </datafield>
+  <datafield tag="010" ind1=" " ind2=" ">
+    <subfield code="a">   91025703 </subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">0521361443</subfield>
+    <subfield code="q">hardback</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9780521361446</subfield>
+    <subfield code="q">(hardback)</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="9">(DLC)   91025703</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">DLC</subfield>
+    <subfield code="c">DLC</subfield>
+    <subfield code="d">DLC</subfield>
+    <subfield code="d">OCoLC</subfield>
+    <subfield code="d">DLC</subfield>
+  </datafield>
+  <datafield tag="041" ind1="1" ind2=" ">
+    <subfield code="a">eng</subfield>
+    <subfield code="h">grc</subfield>
+    <subfield code="h">lat</subfield>
+  </datafield>
+  <datafield tag="050" ind1="0" ind2="0">
+    <subfield code="a">BF1600</subfield>
+    <subfield code="b">.H475 1992</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="0">
+    <subfield code="a">135/.4</subfield>
+    <subfield code="2">20</subfield>
+  </datafield>
+  <datafield tag="245" ind1="0" ind2="0">
+    <subfield code="a">Hermetica :</subfield>
+    <subfield code="b">the Greek Corpus Hermeticum and the Latin Asclepius in a new English translation, with notes and introduction /</subfield>
+    <subfield code="c">Brian P. Copenhaver.</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">Cambridge [England] ;</subfield>
+    <subfield code="a">New York, NY, USA :</subfield>
+    <subfield code="b">Cambridge University Press,</subfield>
+    <subfield code="c">1992.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">lxxxiii, 320 p. ;</subfield>
+    <subfield code="c">23 cm.</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+    <subfield code="a">Includes bibliographical references (p. lxii-lxxxiii) and indexes.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Hermetism.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Copenhaver, Brian P.</subfield>
+  </datafield>
+  <datafield tag="730" ind1="0" ind2="2">
+    <subfield code="a">Corpus Hermeticum.</subfield>
+    <subfield code="l">English.</subfield>
+  </datafield>
+  <datafield tag="730" ind1="0" ind2="2">
+    <subfield code="a">Asclepius.</subfield>
+    <subfield code="l">English.</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="2">
+    <subfield code="3">Publisher description</subfield>
+    <subfield code="u">http://www.loc.gov/catdir/description/cam024/91025703.html</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="1">
+    <subfield code="3">Table of contents</subfield>
+    <subfield code="u">http://www.loc.gov/catdir/toc/cam028/91025703.html</subfield>
+  </datafield>
+  <datafield tag="920" ind1=" " ind2=" ">
+    <subfield code="a">**LC HAS REQ'D # OF SHELF COPIES**</subfield>
+  </datafield>
+  <datafield tag="991" ind1=" " ind2=" ">
+    <subfield code="b">c-GenColl</subfield>
+    <subfield code="h">BF1600</subfield>
+    <subfield code="i">.H475 1992</subfield>
+    <subfield code="p">00018457453</subfield>
+    <subfield code="t">Copy 1</subfield>
+    <subfield code="w">BOOKS</subfield>
+  </datafield>
+</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>1.1</zs:version><zs:query>bath.title="hermetica" and bath.author="copenhaver"</zs:query><zs:maximumRecords>5</zs:maximumRecords><zs:recordPacking>xml</zs:recordPacking><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>

--- a/tests/fixtures/marc/loc-godwin-theatre-of-the-world.xml
+++ b/tests/fixtures/marc/loc-godwin-theatre-of-the-world.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0"?>
+<zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordPacking>xml</zs:recordPacking><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+  <leader>02590cam a2200469 a 4500</leader>
+  <controlfield tag="001">15665610</controlfield>
+  <controlfield tag="005">20250607030916.5</controlfield>
+  <controlfield tag="008">090318s2009    vtuabg   b    001 0beng  </controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">15665610</subfield>
+  </datafield>
+  <datafield tag="906" ind1=" " ind2=" ">
+    <subfield code="a">7</subfield>
+    <subfield code="b">cbc</subfield>
+    <subfield code="c">orignew</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">ecip</subfield>
+    <subfield code="f">20</subfield>
+    <subfield code="g">y-gencatlg</subfield>
+  </datafield>
+  <datafield tag="925" ind1="0" ind2=" ">
+    <subfield code="a">acquire</subfield>
+    <subfield code="b">2 shelf copies</subfield>
+    <subfield code="x">policy default</subfield>
+    <subfield code="e">claim1  2010-02-19</subfield>
+  </datafield>
+  <datafield tag="955" ind1=" " ind2=" ">
+    <subfield code="a">rf14 2009-03-18</subfield>
+    <subfield code="c">rf14 2009-03-18</subfield>
+    <subfield code="d">rf14 2009-03-24 telework</subfield>
+    <subfield code="e">rf07 2009-03-26 (telework) to Dewey</subfield>
+    <subfield code="a">rd13 2009-03-26</subfield>
+    <subfield code="a">xe10 2010-05-18 1 copy rec'd., to CIP ver.</subfield>
+    <subfield code="f">rf17 2010-05-26 Z-CipVer</subfield>
+    <subfield code="t">xg22 2011-10-05 copy 2 added</subfield>
+  </datafield>
+  <datafield tag="955" ind1=" " ind2=" ">
+    <subfield code="a">LCAP batch update 2025-06-01-04:00: LCAPM-644, LCAPM-893</subfield>
+  </datafield>
+  <datafield tag="010" ind1=" " ind2=" ">
+    <subfield code="a">  2009011796</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9781594773297</subfield>
+    <subfield code="q">hardcover</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1594773297</subfield>
+    <subfield code="q">hardcover</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)317361757</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">DLC</subfield>
+    <subfield code="c">DLC</subfield>
+    <subfield code="d">BTCTA</subfield>
+    <subfield code="d">YDXCP</subfield>
+    <subfield code="d">C#P</subfield>
+    <subfield code="d">BWX</subfield>
+    <subfield code="d">DLC</subfield>
+  </datafield>
+  <datafield tag="043" ind1=" " ind2=" ">
+    <subfield code="a">e-gx---</subfield>
+  </datafield>
+  <datafield tag="050" ind1="0" ind2="0">
+    <subfield code="a">CT1098.K46</subfield>
+    <subfield code="b">G63 2009</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="0">
+    <subfield code="a">943/.04092</subfield>
+    <subfield code="a">B</subfield>
+    <subfield code="2">22</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Godwin, Joscelyn.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Athanasius Kircher's theatre of the world :</subfield>
+    <subfield code="b">the life and work of the last man to search for universal knowledge /</subfield>
+    <subfield code="c">Joscelyn Godwin.</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">Rochester, Vt. :</subfield>
+    <subfield code="b">Inner Traditions,</subfield>
+    <subfield code="c">c2009.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">304 p. :</subfield>
+    <subfield code="b">ill., maps, music ;</subfield>
+    <subfield code="c">29 cm.</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+    <subfield code="a">Includes bibliographical references and index.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="0" ind2=" ">
+    <subfield code="a">Prologue: Interesting times -- Kircher's life and work : an overview -- Frontispieces -- The illustration of Kircher's works -- Antiquity misread -- Antiquity preserved -- Antiquity imagined -- Naturalia : fire and water -- Naturalia : air and earth -- Music -- Machines of past and present -- Machines : magnetic and optical -- Maps and plans -- Exotica -- Images of the gods -- Didactic images -- Athanasius Kircher's writings.</subfield>
+  </datafield>
+  <datafield tag="520" ind1="2" ind2=" ">
+    <subfield code="a">"A major study of both the written and pictorial work of a neglected genius whose breadth of interest made him the last Renaissance man."--Provided by publisher.</subfield>
+  </datafield>
+  <datafield tag="600" ind1="1" ind2="0">
+    <subfield code="a">Kircher, Athanasius,</subfield>
+    <subfield code="d">1602-1680.</subfield>
+  </datafield>
+  <datafield tag="600" ind1="1" ind2="0">
+    <subfield code="a">Kircher, Athanasius,</subfield>
+    <subfield code="d">1602-1680</subfield>
+    <subfield code="x">Criticism and interpretation.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Renaissance</subfield>
+    <subfield code="z">Germany.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Renaissance</subfield>
+    <subfield code="v">Biography.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Scholars</subfield>
+    <subfield code="z">Germany</subfield>
+    <subfield code="v">Biography.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Illustrators</subfield>
+    <subfield code="z">Germany</subfield>
+    <subfield code="v">Biography.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Illustration of books</subfield>
+    <subfield code="z">Germany</subfield>
+    <subfield code="x">History</subfield>
+    <subfield code="y">17th century.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Intellectuals</subfield>
+    <subfield code="z">Germany</subfield>
+    <subfield code="v">Biography.</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="0">
+    <subfield code="a">Germany</subfield>
+    <subfield code="v">Biography.</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="0">
+    <subfield code="a">Germany</subfield>
+    <subfield code="x">Intellectual life</subfield>
+    <subfield code="y">17th century.</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="a">Biographies.</subfield>
+    <subfield code="2">lcgft</subfield>
+    <subfield code="0">https://id.loc.gov/authorities/genreForms/gf2014026049</subfield>
+  </datafield>
+</record></zs:recordData><zs:recordPosition>1</zs:recordPosition></zs:record></zs:records><zs:echoedSearchRetrieveRequest><zs:version>1.1</zs:version><zs:query>bath.title="theatre of the world" and bath.author="godwin"</zs:query><zs:maximumRecords>5</zs:maximumRecords><zs:recordPacking>xml</zs:recordPacking><zs:recordSchema>marcxml</zs:recordSchema></zs:echoedSearchRetrieveRequest></zs:searchRetrieveResponse>

--- a/tests/fixtures/reference-set/loc-gold-rows.json
+++ b/tests/fixtures/reference-set/loc-gold-rows.json
@@ -327,5 +327,263 @@
   ],
   "source": "loc_mdsconnect",
   "snapshot": "2016"
+ },
+ {
+  "lccn": "00699877",
+  "author": "",
+  "added_entries": [
+   "Plato.",
+   "West, Thomas G.,",
+   "West, Grace Starry,",
+   "Aristophanes."
+  ],
+  "uniform_title": "",
+  "title": "Four texts on Socrates :",
+  "subtitle": "Plato's Euthyphro, Apology, and Crito, and Aristophanes' Clouds /",
+  "year": "1998",
+  "extent": "190 p. ;",
+  "publisher": "Cornell University Press,",
+  "original_languages": [
+   "gre"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Socrates."
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "04014075",
+  "author": "Homer.",
+  "added_entries": [
+   "Lang, Andrew,",
+   "Leaf, Walter,",
+   "Myers, Ernest,"
+  ],
+  "uniform_title": "",
+  "title": "The Iliad of Homer,",
+  "subtitle": "",
+  "year": "1903",
+  "extent": "vii, [1], 506 p., 1 l.",
+  "publisher": "Macmillan and Co., limited;",
+  "original_languages": [
+   "gre"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Epic poetry, Greek",
+   "Achilles"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "08035961",
+  "author": "Petrie, W. M. Flinders",
+  "added_entries": [],
+  "uniform_title": "",
+  "title": "Egyptian tales translated from the papyri ...",
+  "subtitle": "",
+  "year": "1899",
+  "extent": "2 v.",
+  "publisher": "Methuen & co.,",
+  "original_languages": [
+   "egy"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Egyptian literature"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "25002874",
+  "author": "Villon, François,",
+  "added_entries": [
+   "Lepper, John Heron,",
+   "Payne, John,"
+  ],
+  "uniform_title": "",
+  "title": "The testaments of Francois Villon,",
+  "subtitle": "",
+  "year": "1924",
+  "extent": "xxxvi, 316 p., incl. front. (facsim.)",
+  "publisher": "Boni and Liveright,",
+  "original_languages": [
+   "und"
+  ],
+  "item_language": "eng",
+  "subjects": [],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "29025506",
+  "author": "Aristotle",
+  "added_entries": [
+   "Jebb, R. C.",
+   "Sandys, John Edwin,"
+  ],
+  "uniform_title": "",
+  "title": "The Rhetoric of Aristotle.",
+  "subtitle": "",
+  "year": "1908",
+  "extent": "207 p.",
+  "publisher": "Cambridge [Eng.] The University press",
+  "original_languages": [
+   "grc"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Rhetoric"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "52031409",
+  "author": "Chaucer, Geoffrey,",
+  "added_entries": [
+   "Coghill, Nevill,"
+  ],
+  "uniform_title": "",
+  "title": "The Canterbury tales /",
+  "subtitle": "",
+  "year": "1952",
+  "extent": "528 p. ;",
+  "publisher": "Penguin Books,",
+  "original_languages": [
+   "und"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Christian pilgrims and pilgrimages",
+   "Storytelling",
+   "Middle Ages"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "94017253",
+  "author": "Suetonius,",
+  "added_entries": [
+   "Kaster, Robert A."
+  ],
+  "uniform_title": "",
+  "title": "De grammaticis et rhetoribus /",
+  "subtitle": "",
+  "year": "1995",
+  "extent": "lx, 370 p. ;",
+  "publisher": "Clarendon Press ;",
+  "original_languages": [
+   "lat"
+  ],
+  "item_language": "englat",
+  "subjects": [
+   "Philologists"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "2006334798",
+  "author": "Bukhārī, Muḥammad ibn Ismāʻīl,",
+  "added_entries": [
+   "Ahmad, Aftab-ud-Din.",
+   "Bukhārī, Muḥammad ibn Ismāʻīl,",
+   "Bukhārī, Muḥammad ibn Ismāʻīl,"
+  ],
+  "uniform_title": "",
+  "title": "English translation of Sahih al-Bukhari  /",
+  "subtitle": "",
+  "year": "1973",
+  "extent": "Volumes <1-3> ;",
+  "publisher": "Ahmadiyya Anjuman Isha'at-i Islam,",
+  "original_languages": [
+   "ara"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Hadith"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "2007358598",
+  "author": "",
+  "added_entries": [
+   "Hammurabi,",
+   "Viel, H.-Dieter."
+  ],
+  "uniform_title": "",
+  "title": "The complete code of Hammurabi /",
+  "subtitle": "",
+  "year": "2005",
+  "extent": "2 v. (799 p.) :",
+  "publisher": "LINCOM Europa,",
+  "original_languages": [
+   "ger",
+   "akk"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Law",
+   "Cuneiform inscriptions, Akkadian.",
+   "Cuneiform writing."
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "2011923762",
+  "author": "Littlewood, R. Joy.",
+  "added_entries": [
+   "Silius Italicus, Tiberius Catius."
+  ],
+  "uniform_title": "",
+  "title": "A commentary on Silius Italicus' Punica 7 :",
+  "subtitle": "edited with introduction and commentary /",
+  "year": "2011",
+  "extent": "xcix, 276 p. :",
+  "publisher": "Oxford University Press,",
+  "original_languages": [
+   "lat"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Epic poetry, Latin",
+   "Punic War, 2nd, 218-201 B.C.",
+   "Punic War, 2nd, 218-201 B.C.",
+   "Silius Italicus, Tiberius Catius."
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "2015303200",
+  "author": "Wittgenstein, Ludwig,",
+  "added_entries": [],
+  "uniform_title": "",
+  "title": "Tractatus logico-philosophicus /",
+  "subtitle": "",
+  "year": "2014",
+  "extent": "xxxvi, 106 pages :",
+  "publisher": "Routledge,",
+  "original_languages": [
+   "ger"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Logic, Symbolic and mathematical.",
+   "Language and logic.",
+   "Language and logic.",
+   "Logic, Symbolic and mathematical."
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
  }
 ]

--- a/tests/fixtures/reference-set/loc-gold-rows.json
+++ b/tests/fixtures/reference-set/loc-gold-rows.json
@@ -1,0 +1,331 @@
+[
+ {
+  "lccn": "03007699",
+  "author": "Boethius,",
+  "added_entries": [
+   "Walpole, Michael,",
+   "Windet, John,",
+   "Lownes, Matthew,"
+  ],
+  "uniform_title": "De consolatione philosophiae.",
+  "title": "Fiue bookes of philosophicall comfort :",
+  "subtitle": "full of Christian consolation, written a 1000 yeeres since /",
+  "year": "1609",
+  "extent": "[8], 144 leaves ;",
+  "publisher": "Printed by Iohn Windet for Mathevv Lovvnes,",
+  "original_languages": [
+   "lat"
+  ],
+  "item_language": "eng",
+  "subjects": [],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "03020856",
+  "author": "Euclid.",
+  "added_entries": [
+   "Billingsley, Henry,",
+   "Dee, John,",
+   "Candale, François de Foix,",
+   "Day, John,"
+  ],
+  "uniform_title": "Elements.",
+  "title": "The elements of geometrie of the most auncient philosopher Euclide of Megara /",
+  "subtitle": "",
+  "year": "1570",
+  "extent": "[28], 464 [i.e. 463] leaves, [1] folded leaf of plates :",
+  "publisher": "By Iohn Daye,",
+  "original_languages": [
+   "gre"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Geometry",
+   "Mathematics, Greek.",
+   "Classification of sciences"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "09021988",
+  "author": "Euclid.",
+  "added_entries": [
+   "Heath, Thomas Little,",
+   "Heiberg, J. L."
+  ],
+  "uniform_title": "",
+  "title": "The thirteen books of Euclid's Elements,",
+  "subtitle": "",
+  "year": "1908",
+  "extent": "3 v.",
+  "publisher": "The University Press,",
+  "original_languages": [
+   "gre"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Mathematics, Greek."
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "09023451",
+  "author": "Porta, Giambattista della,",
+  "added_entries": [],
+  "uniform_title": "Magiae naturalis.",
+  "title": "Natural magick,",
+  "subtitle": "",
+  "year": "1658",
+  "extent": "3 p.l., 409, [6] p.",
+  "publisher": "Printed for T. Young and S. Speed,",
+  "original_languages": [
+   "lat"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Science",
+   "Industrial arts."
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "55010320",
+  "author": "Euclid.",
+  "added_entries": [
+   "Archimedes.",
+   "Apollonius,",
+   "Nicomachus,",
+   "Heath, Thomas Little,",
+   "Taliaferro, R. Catesby",
+   "D'Ooge, Martin Luther,"
+  ],
+  "uniform_title": "Elements.",
+  "title": "The thirteen books of Euclid's Elements.",
+  "subtitle": "",
+  "year": "1955",
+  "extent": "xi, 848 p.",
+  "publisher": "Encyclopaedia Britannica",
+  "original_languages": [
+   "grc"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Mathematics, Greek."
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "68045126",
+  "author": "Plutarch.",
+  "added_entries": [
+   "Blundeville, Thomas,"
+  ],
+  "uniform_title": "Moralia.",
+  "title": "Three morall treatises :",
+  "subtitle": "no lesse pleasaunt then necessary for all men to reade, wherof the one is called The learned prince, the other The fruites of foes, the thyrde The porte of rest.",
+  "year": "1561",
+  "extent": "[140] p.",
+  "publisher": "By Wyllyam Seres ...,",
+  "original_languages": [
+   "grc"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Didactic literature, Greek",
+   "Greek essays",
+   "Ethics"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "68048345",
+  "author": "Martin,",
+  "added_entries": [
+   "Whittington, Robert,",
+   "Seneca, Lucius Annaeus,"
+  ],
+  "uniform_title": "Formula vitae honestae.",
+  "title": "A frutefull worke of Lucius Anneus Seneca named the Forme and rule of honest lyuynge :",
+  "subtitle": "bothe in the Latin tongue & in the Englyshe /",
+  "year": "1546",
+  "extent": "[56] p.",
+  "publisher": "By Wyllyam Myddylton,",
+  "original_languages": [
+   "lat"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Ethics"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "86046408",
+  "author": "Cicero, Marcus Tullius.",
+  "added_entries": [
+   "Grimald, Nicholas,",
+   "O'Gorman, Gerald"
+  ],
+  "uniform_title": "De officiis.",
+  "title": "Marcus Tullius Ciceroes thre bokes of duties, to Marcus his sonne, turned oute of Latine into English, by Nicolas Grimalde /",
+  "subtitle": "",
+  "year": "1990",
+  "extent": "265 p. :",
+  "publisher": "Folger Shakespeare Library ;",
+  "original_languages": [
+   "lat"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Ethics"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "86189668",
+  "author": "Norodom Sihanouk,",
+  "added_entries": [],
+  "uniform_title": "Calice jusqu'à la lie.",
+  "title": "The cup to the dregs =",
+  "subtitle": "(Le calice jusqu'à la lie) /",
+  "year": "",
+  "extent": "<v. 1, ch. 1-9, 11-12; v. 2, ch. 1-17; in 4   > ;",
+  "publisher": "Norodom Sihanouk,",
+  "original_languages": [
+   "fre"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Norodom Sihanouk,"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "91025858",
+  "author": "Dge-ʼdun-chos-ʼphel,",
+  "added_entries": [
+   "Hopkins, Jeffrey.",
+   "Yuthok, Dorje Yudon,"
+  ],
+  "uniform_title": "ʼDod paʼi bstan bcos.",
+  "title": "Tibetan arts of love /",
+  "subtitle": "",
+  "year": "1992",
+  "extent": "282 p. ;",
+  "publisher": "Snow Lion,",
+  "original_languages": [
+   "tib"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Sex instruction",
+   "Sex",
+   "Buddhism"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "96218515",
+  "author": "Homer.",
+  "added_entries": [
+   "Chapman, George,"
+  ],
+  "uniform_title": "Iliad.",
+  "title": "Homer, prince of poets /",
+  "subtitle": "",
+  "year": "1609",
+  "extent": "[18], 118 [i.e. 198], [18] p. ;",
+  "publisher": "Printed for Samuel Macham,",
+  "original_languages": [
+   "grc"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Epic poetry, Greek",
+   "Trojan War",
+   "Achilles"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "2004596469",
+  "author": "Cicero, Marcus Tullius.",
+  "added_entries": [
+   "Grimald, Nicholas,",
+   "Tottel, Richard,"
+  ],
+  "uniform_title": "De officiis.",
+  "title": "Marcus Tullius Ciceroes thre bokes of duties :",
+  "subtitle": "to Marcus his sonne /",
+  "year": "1556",
+  "extent": "[16], 158 [i.e. 149], [11] leaves (the last leaf blank) ;",
+  "publisher": "By Richard Tottel,",
+  "original_languages": [
+   "lat"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Ethics"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "2005565154",
+  "author": "Homer.",
+  "added_entries": [
+   "Chapman, George,",
+   "Butter, Nathaniel,"
+  ],
+  "uniform_title": "Iliad.",
+  "title": "The Iliads of Homer, prince of poets /",
+  "subtitle": "",
+  "year": "1611",
+  "extent": "[24], 341, [9] p. ;",
+  "publisher": "Printed for Nathaniell Butter,",
+  "original_languages": [
+   "gre"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Epic poetry, Greek",
+   "Trojan War",
+   "Achilles"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ },
+ {
+  "lccn": "2007043962",
+  "author": "Tsong-kha-pa Blo-bzang-grags-pa,",
+  "added_entries": [
+   "Sparham, Gareth."
+  ],
+  "uniform_title": "Legs bshad gser phreng.",
+  "title": "Golden garland of eloquence =",
+  "subtitle": "Legs bshad gser phreng /",
+  "year": "2008",
+  "extent": "v. <1, 4> ;",
+  "publisher": "Jain Pub. Co.,",
+  "original_languages": [
+   "tib"
+  ],
+  "item_language": "eng",
+  "subjects": [
+   "Haribhadra,"
+  ],
+  "source": "loc_mdsconnect",
+  "snapshot": "2016"
+ }
+]

--- a/tests/unit/bib-record.test.ts
+++ b/tests/unit/bib-record.test.ts
@@ -221,3 +221,21 @@ describe('uniform title (work identity — feeds #3258 / #2453)', () => {
     ] })).toBe('De voluptate');
   });
 });
+
+describe('a throttled response is not an empty result', () => {
+  // LoC rate-limits by serving an HTML interstitial with HTTP 200. Parsing that
+  // to zero records reads as "no prior translation exists" — a false negative
+  // manufactured by throttling, in a system whose whole job is avoiding those.
+  it('throws on the LoC IP access-request page rather than returning []', async () => {
+    const blockPage = '<!DOCTYPE html>\n<html lang="en"><head><title>LCCN Permalink - IP Access Request Form</title></head><body>ip access request</body></html>';
+    await expect(parseMarcXmlRecords(blockPage)).rejects.toThrow(/throttled|access-request/i);
+  });
+
+  it('throws on any HTML body where MARC was expected', async () => {
+    await expect(parseMarcXmlRecords('<html><body>maintenance</body></html>')).rejects.toThrow(/HTML document/);
+  });
+
+  it('still returns [] for genuinely empty input', async () => {
+    await expect(parseMarcXmlRecords('')).resolves.toEqual([]);
+  });
+});

--- a/tests/unit/bib-record.test.ts
+++ b/tests/unit/bib-record.test.ts
@@ -1,0 +1,223 @@
+/**
+ * bib_records: keep the whole record, and type-check the relation. (#3455, #3428)
+ *
+ * The defect these pin: we fetch rich bibliographic records and keep sixteen
+ * flat fields, so a work ABOUT a text is indistinguishable from a rendering OF
+ * it. Godwin's *Athanasius Kircher's Theatre of the World* — an illustrated
+ * study — sits in `translation_catalogs` as a translation with Godwin as
+ * `translator`, and nothing downstream can tell. Its MARC record says otherwise
+ * plainly, and we had that at fetch time.
+ *
+ * The fixtures are REAL MARC-XML fetched from the LoC SRU gateway on
+ * 2026-07-29, not hand-written. A hand-written fixture would only prove the
+ * classifier agrees with my idea of MARC; these prove it agrees with LoC.
+ *
+ * The two cases are the acceptance criteria from #3455, and they are
+ * deliberately adversarial to each other: both are 2009/1992 scholarly
+ * monographs about hermetic material by a named academic at a real press. Every
+ * "is this plausible / is this author real" check passes on both. Only the
+ * record's own structure separates them:
+ *
+ *   Copenhaver  041 1 $a eng $h grc $h lat   → translation
+ *   Godwin      (no 041 at all)
+ *               600 10 $x Criticism and interpretation → study
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import {
+  parseMarcXmlRecords,
+  buildBibRecord,
+  projectToCatalogRow,
+  classifyWorkType,
+  classifyCompleteness,
+  extractIdentifiers,
+  extentPages,
+  originalLanguages,
+  uniformTitle,
+} from '../../scripts/lib/bib-record.mjs';
+
+const fixture = (name: string) =>
+  readFileSync(resolve(__dirname, '../fixtures/marc', name), 'utf8');
+
+let copenhaver: any;
+let godwin: any;
+
+beforeAll(async () => {
+  [copenhaver] = await parseMarcXmlRecords(fixture('loc-copenhaver-hermetica.xml'));
+  [godwin] = await parseMarcXmlRecords(fixture('loc-godwin-theatre-of-the-world.xml'));
+});
+
+describe('parseMarcXmlRecords', () => {
+  it('finds the MARC record nested inside an SRU response', () => {
+    // An SRU response wraps the MARC <record> in its own <zs:record>. Once
+    // namespace prefixes are stripped both are named "record" — matching on the
+    // name alone grabs the wrapper, which has no MARC in it at all.
+    expect(copenhaver).toBeDefined();
+    expect(copenhaver.datafields.length).toBeGreaterThan(5);
+    expect(copenhaver.controlfields['008']).toContain('1992');
+  });
+
+  it('returns [] rather than throwing on junk input', () => {
+    return expect(parseMarcXmlRecords('')).resolves.toEqual([]);
+  });
+});
+
+describe('Copenhaver, Hermetica (CUP 1992) — a translation', () => {
+  it('classifies as a translation on the strength of 041', () => {
+    const { work_type, evidence } = classifyWorkType(copenhaver);
+    expect(work_type).toBe('translation');
+    expect(evidence.join(' ')).toMatch(/041\$h=grc,lat/);
+  });
+
+  it('reads the original languages off 041$h', () => {
+    expect(originalLanguages(copenhaver)).toEqual(['grc', 'lat']);
+  });
+
+  it('classifies as complete', () => {
+    const { work_type } = classifyWorkType(copenhaver);
+    expect(classifyCompleteness(copenhaver, work_type).completeness).toBe('complete');
+  });
+
+  it('parses the page extent out of "lxxxiii, 320 p."', () => {
+    expect(extentPages(copenhaver)).toBe(320);
+  });
+
+  it('carries external identifiers, so the row stays re-checkable', () => {
+    const ids = extractIdentifiers(copenhaver);
+    expect(ids.lccn).toBe('91025703');
+    expect(ids.isbn).toContain('0521361443');
+  });
+
+  it('projects into a translation_catalogs row with completeness=complete', () => {
+    const bib = buildBibRecord({ rec: copenhaver, source: 'loc', rawXml: 'x' });
+    const row = projectToCatalogRow(bib);
+    expect(row).not.toBeNull();
+    expect(row.completeness).toBe('complete');
+    expect(row.translator).toMatch(/Copenhaver/);
+    expect(row.lccn).toBe('91025703');
+  });
+});
+
+describe('Godwin, Theatre of the World (2009) — a study, not a translation', () => {
+  it('classifies as a study, not a translation', () => {
+    // The whole point of #3455/#3428: the fabrication is in the RELATION, not
+    // the entities. Author, publisher and year are all real.
+    const { work_type, evidence } = classifyWorkType(godwin);
+    expect(work_type).toBe('study');
+    expect(evidence.join(' ')).toMatch(/Criticism and interpretation/i);
+  });
+
+  it('has no 041 at all — the signal that separates it from Copenhaver', () => {
+    expect(originalLanguages(godwin)).toEqual([]);
+  });
+
+  it('REFUSES to project into translation_catalogs', () => {
+    // A study must never enter the registry as a prior translation. This is the
+    // exact row that currently defeats first-translation claims on Kircher.
+    const bib = buildBibRecord({ rec: godwin, source: 'loc', rawXml: 'x' });
+    expect(bib.work_type).toBe('study');
+    expect(projectToCatalogRow(bib)).toBeNull();
+  });
+
+  it('does not assert completeness for a non-translation', () => {
+    expect(classifyCompleteness(godwin, 'study').completeness).toBe('unknown');
+  });
+
+  it('still extracts identifiers, including OCLC from the (OCoLC) prefix', () => {
+    const ids = extractIdentifiers(godwin);
+    expect(ids.lccn).toBe('2009011796');
+    expect(ids.oclc).toContain('317361757');
+  });
+});
+
+describe('buildBibRecord invariants', () => {
+  it('refuses a record with no external identifier', () => {
+    // An unre-checkable row is precisely how the existing 24,061-row registry
+    // became unauditable — every row lacks an identifier, so nothing can be
+    // re-fetched or deduplicated. Fail closed rather than store one.
+    const empty = { leader: '', controlfields: {}, datafields: [] };
+    expect(() => buildBibRecord({ rec: empty, source: 'loc', rawXml: 'x' }))
+      .toThrow(/no external identifier/);
+  });
+
+  it('keeps the raw payload so a new field is a re-projection, not a re-fetch', () => {
+    const raw = fixture('loc-copenhaver-hermetica.xml');
+    const bib = buildBibRecord({ rec: copenhaver, source: 'loc', rawXml: raw });
+    expect(bib.raw_marcxml).toBe(raw);
+    expect(bib.raw_format).toBe('marcxml');
+  });
+
+  it('keys on source + identifier so a re-fetch is idempotent', () => {
+    const a = buildBibRecord({ rec: copenhaver, source: 'loc', rawXml: 'x' });
+    const b = buildBibRecord({ rec: copenhaver, source: 'loc', rawXml: 'y' });
+    expect(a._key).toBe(b._key);
+    expect(a._key).toBe('loc:91025703');
+  });
+
+  it('records WHY it classified as it did, so a wrong call is auditable', () => {
+    const bib = buildBibRecord({ rec: godwin, source: 'loc', rawXml: 'x' });
+    expect(bib.work_type_evidence.length).toBeGreaterThan(0);
+    expect(bib.completeness_evidence.length).toBeGreaterThan(0);
+  });
+});
+
+describe('completeness stays conservative', () => {
+  // A wrong `complete` demotes a real first-translation badge — historically the
+  // #1 failure. A wrong `unknown` merely leaves a claim standing. So partial
+  // markers always win, and short extents never reach `complete`.
+  const withTitle = (title: string, extent = '320 p.') => ({
+    leader: '',
+    controlfields: {},
+    datafields: [
+      { tag: '245', ind1: '0', ind2: '0', subfields: [{ code: 'a', value: title }] },
+      { tag: '300', ind1: ' ', ind2: ' ', subfields: [{ code: 'a', value: extent }] },
+      { tag: '041', ind1: '1', ind2: ' ', subfields: [{ code: 'h', value: 'lat' }] },
+    ],
+  });
+
+  it('an explicit "Selections" marker beats a long extent', () => {
+    expect(classifyCompleteness(withTitle('The Works: Selections'), 'translation').completeness)
+      .toBe('partial');
+  });
+
+  it.each(['Excerpts from the Corpus', 'An Anthology of Hermetic Texts', 'Abridged Edition'])(
+    'treats %s as partial',
+    (title) => {
+      expect(classifyCompleteness(withTitle(title), 'translation').completeness).toBe('partial');
+    },
+  );
+
+  it('refuses to call a pamphlet-length extent complete', () => {
+    expect(classifyCompleteness(withTitle('A Treatise', '40 p.'), 'translation').completeness)
+      .toBe('unknown');
+  });
+
+  it('does not assert complete when there is no extent at all', () => {
+    const noExtent = { leader: '', controlfields: {}, datafields: [
+      { tag: '245', ind1: '0', ind2: '0', subfields: [{ code: 'a', value: 'A Treatise' }] },
+      { tag: '041', ind1: '1', ind2: ' ', subfields: [{ code: 'h', value: 'lat' }] },
+    ] };
+    expect(classifyCompleteness(noExtent, 'translation').completeness).toBe('unknown');
+  });
+
+  it('a multi-volume extent ("2 v.") is not a page count', () => {
+    expect(extentPages({ leader: '', controlfields: {}, datafields: [
+      { tag: '300', ind1: ' ', ind2: ' ', subfields: [{ code: 'a', value: '2 v. ;' }] },
+    ] })).toBeNull();
+  });
+});
+
+describe('uniform title (work identity — feeds #3258 / #2453)', () => {
+  it('returns the 240 uniform title when present, else empty', () => {
+    // Neither fixture carries a 240; the accessor must return '' rather than
+    // undefined so callers can treat it uniformly.
+    expect(uniformTitle(copenhaver)).toBe('');
+    expect(uniformTitle({ leader: '', controlfields: {}, datafields: [
+      { tag: '240', ind1: '1', ind2: '0', subfields: [{ code: 'a', value: 'De voluptate.' }] },
+    ] })).toBe('De voluptate');
+  });
+});

--- a/tests/unit/reference-set-source-language.test.ts
+++ b/tests/unit/reference-set-source-language.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Source-language screening for the reference set. (#3459)
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The screen compared our book's source language against the reference-set row
+ * through a table of MARC-21 codes. LoC rows carry MARC codes, so it worked
+ * there. Wikidata rows carry Q-numbers, so it failed on every single one —
+ * `['gre','grc'].includes('Q35497')` is false, and the candidate was thrown away
+ * as WRONG_LANGUAGE. On the 2026-07-31 run that discarded 228 real candidates,
+ * among them Xenophon's *Symposium* and all six *Rubáiyát of Omar Khayyám*
+ * records: exactly the prior translations the search exists to find.
+ *
+ * Both regressions are pinned below with the values that actually appeared in
+ * that output, so the fix cannot be undone by a later refactor of the tables.
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import {
+  canonicalLanguage,
+  rowSourceLanguages,
+  languageMismatch,
+} from '../../scripts/lib/source-language-match.mjs';
+
+describe('the Wikidata regression — real rows from the 2026-07-31 run', () => {
+  it('keeps Xenophon\'s Symposium against a Greek source', () => {
+    // Rejected with: "record translates from Q35497, our source is greek (gre/grc)"
+    expect(languageMismatch('Greek', {
+      title: 'Symposion (Xenophon)',
+      original_languages: ['Q35497'],
+      original_language_label: 'Ancient Greek',
+    })).toBeNull();
+  });
+
+  it('keeps the Rubáiyát of Omar Khayyám against a Persian source', () => {
+    // Six records, all rejected with: "record translates from Q9168".
+    expect(languageMismatch('Persian', {
+      title: 'Rubáiyát of Omar Khayyám (1909 edition)',
+      original_languages: ['Q9168'],
+      original_language_label: 'Persian',
+    })).toBeNull();
+  });
+
+  it('still keeps LoC rows working — the lane that was never broken', () => {
+    expect(languageMismatch('Greek', { original_languages: ['grc'] })).toBeNull();
+    expect(languageMismatch('Latin', { original_languages: ['lat'] })).toBeNull();
+  });
+});
+
+describe('a genuine mismatch is still rejected', () => {
+  it('rejects a Latin source against a German original', () => {
+    const reason = languageMismatch('Latin', {
+      original_languages: ['Q188'], original_language_label: 'German',
+    });
+    expect(reason).toContain('German');
+    expect(reason).toContain('Latin');
+  });
+
+  it('rejects across MARC codes too', () => {
+    expect(languageMismatch('Greek', { original_languages: ['ger'] })).not.toBeNull();
+  });
+});
+
+describe('UNKNOWN must never read as MISMATCH', () => {
+  // Every defect in this area failed toward a confident clean negative. A
+  // rejection here silently preserves a possibly-false badge, so anything we
+  // cannot resolve has to keep the candidate open.
+  it('skips the screen when we do not know our own source language', () => {
+    // `books.language` is the EDITION language; `original_language` is often absent.
+    expect(languageMismatch(null, { original_languages: ['ger'] })).toBeNull();
+    expect(languageMismatch('', { original_language_label: 'German' })).toBeNull();
+  });
+
+  it('skips the screen when the row declares no source language', () => {
+    expect(languageMismatch('Latin', { original_languages: [] })).toBeNull();
+    expect(languageMismatch('Latin', {})).toBeNull();
+  });
+
+  it('skips the screen on an unrecognised Q-number rather than guessing', () => {
+    // There is deliberately no QID table — an unreadable identifier is unknown.
+    expect(languageMismatch('Latin', { original_languages: ['Q999999999'] })).toBeNull();
+  });
+
+  it('skips the screen on a language outside the table', () => {
+    expect(languageMismatch('Latin', { original_language_label: 'Nahuatl' })).toBeNull();
+    expect(canonicalLanguage('Nahuatl')).toBeNull();
+  });
+});
+
+describe('canonical names collapse historical registers', () => {
+  // A translation from Homeric Greek defeats a first-English claim on a Greek
+  // text. The register matters to a philologist, not to this question.
+  it.each([
+    ['Ancient Greek', 'greek'], ['Homeric Greek', 'greek'], ['grc', 'greek'], ['gre', 'greek'],
+    ['medieval Latin', 'latin'], ['lat', 'latin'],
+    ['Classical Chinese', 'chinese'], ['Literary Chinese', 'chinese'], ['chi', 'chinese'],
+    ['Quranic Arabic', 'arabic'], ['ara', 'arabic'],
+    ['American English', 'english'], ['Early Modern English', 'english'],
+    ['Old Norse', 'icelandic'], ['Bangla', 'bengali'], ["Ge'ez", 'ethiopic'],
+  ])('%s → %s', (input, expected) => {
+    expect(canonicalLanguage(input)).toBe(expected);
+  });
+
+  it('prefers the readable label over the Q-number', () => {
+    expect(rowSourceLanguages({
+      original_languages: ['Q35497'], original_language_label: 'Ancient Greek',
+    })).toEqual(['greek']);
+  });
+
+  it('falls back to MARC codes when there is no label', () => {
+    expect(rowSourceLanguages({ original_languages: ['gre', 'grc'] })).toEqual(['greek']);
+  });
+});

--- a/tests/unit/reference-set-work-identity.test.ts
+++ b/tests/unit/reference-set-work-identity.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Work-identity gold set for the reference-set search. (#3459)
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The matcher was tuned five times by eyeballing samples. Every pass fixed a
+ * visible artifact and introduced an invisible one:
+ *
+ *   1. coverage of OUR tokens only        → "Iliad." vs "Homer, Iliad with
+ *                                           Scholia" scored 0.33; 8 matches found
+ *   2. max(both directions)               → 74 matches, but any single-token
+ *                                           record matched anything containing it
+ *   3. romanized-Tibetan stoplist         → shrank book token lists, INFLATING
+ *                                           hits/bookTokens: 187 → 726 Tibetan
+ *   4. specificity floor on token counts  → lost Cicero's *De Officiis* (Grimald
+ *                                           1556), Plutarch's *Moralia* (1561) and
+ *                                           Della Porta entirely — verified true
+ *                                           positives, silently restored to
+ *                                           "no prior found"
+ *
+ * Step 4 is the dangerous one: it made the corpus look CLEANER while being
+ * strictly more wrong, and nothing would have caught it. Tuning a ratio against
+ * whichever sample you happened to read is not convergence.
+ *
+ * So the thresholds are now pinned to hand-verified pairs. Every LoC row below
+ * is REAL MARC fetched from the 2016 MDSConnect dump; every book is a real badged
+ * record. Any future change to the matcher must keep the positives and keep
+ * rejecting the negatives, and will be measured rather than argued about.
+ *
+ * The negatives matter as much as the positives — they are the false-positive
+ * classes that four of the five iterations produced.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import {
+  uniformTitleContainment,
+  bookTitleTokens,
+} from '../../scripts/lib/work-identity-match.mjs';
+
+type LocRow = {
+  lccn: string; title: string; uniform_title: string; year: string;
+  original_languages: string[];
+};
+
+const rows: LocRow[] = JSON.parse(
+  readFileSync(resolve(__dirname, '../fixtures/reference-set/loc-gold-rows.json'), 'utf8'),
+);
+
+const byUniform = (re: RegExp) => {
+  const hit = rows.find((r) => re.test(r.uniform_title || ''));
+  if (!hit) throw new Error(`gold fixture missing a row with uniform_title matching ${re}`);
+  return hit;
+};
+
+/**
+ * Tokenisation comes from the lib itself. A local copy would let the test and
+ * the implementation drift apart, which is how a green guard stops guarding.
+ */
+const bookTokens = (...titles: string[]) => bookTitleTokens(...titles);
+
+describe('MUST MATCH — hand-verified prior English translations', () => {
+  // Each of these was confirmed by reading the record. Losing any one means the
+  // search reports "no prior found" for a work that has been in English for
+  // centuries.
+  const cases: Array<[string, RegExp, string[]]> = [
+    ['Cicero, De Officiis → Grimald 1556', /^De officiis/i,
+      ['De officiis. Add: Paradoxa Stoicorum. Hexastichon', 'De Officiis']],
+    ['pseudo-Seneca, De formula honestae vitae → 1546', /^Formula vitae honestae/i,
+      ['De quattuor virtutibus cardinalibus, sive De formula honestae vitae', 'De formula honestae vitae']],
+    ['Plutarch, Moralia → Three morall treatises 1561', /^Moralia/i,
+      ['Plutarchi Chaeronensis Moralia (Hercher edition)', 'Plutarchi Chaeronensis Moralia']],
+    ['Euclid, Elements → Billingsley 1570', /^Elements/i,
+      ['Elementa Euclides Geometriae, Planae ac Solidae', 'Στοιχεῖα (Elements)']],
+    ['Boethius, Consolatio → 1609', /^De consolatione philosophiae/i,
+      ['De Consolatione Philosophiae', 'De consolatione philosophiae']],
+    ['Homer, Iliad → Chapman 1609', /^Iliad/i,
+      ['Homer, Iliad with Scholia', 'The Iliad of Homer']],
+    ['Della Porta, Magia Naturalis → Natural magick 1658', /^Magiae naturalis/i,
+      ['Magia Naturalis. 2', 'Magia Naturalis']],
+    ['Tibetan: Legs bshad gser phreng → Golden garland 2008', /^Legs bshad gser phreng/i,
+      ['Neyphug Thor bu Legs bshad gser phreng', 'Neyphug Thor bu Legs bshad gser phreng']],
+  ];
+
+  it.each(cases)('%s', (_label, uniformRe, titles) => {
+    const row = byUniform(uniformRe);
+    const result = uniformTitleContainment(bookTokens(...titles), row.uniform_title);
+    expect(result, `uniform title "${row.uniform_title}" should be contained in ${JSON.stringify(titles)}`)
+      .not.toBeNull();
+    expect(result.score).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it('matches across Latin case-ending variation (magiae ⇔ magia)', () => {
+    // Stemming earns its keep here: an exact-token rule would miss this.
+    const row = byUniform(/^Magiae naturalis/i);
+    expect(uniformTitleContainment(bookTokens('Magia Naturalis'), row.uniform_title)).not.toBeNull();
+  });
+
+  it('ignores word ORDER — a uniform title is a set, not a phrase', () => {
+    // "Formula vitae honestae" vs our "De formula honestae vitae": substring
+    // matching fails, set containment succeeds.
+    const row = byUniform(/^Formula vitae honestae/i);
+    expect(uniformTitleContainment(bookTokens('De formula honestae vitae'), row.uniform_title)).not.toBeNull();
+  });
+});
+
+describe('MUST NOT MATCH — the false-positive classes the tuning produced', () => {
+  it('rejects a French novel against a Tibetan ritual text (the "dregs" case)', () => {
+    // "The cup to the dregs" matched at 1.00 because "dregs" is both an English
+    // word and a romanized Tibetan syllable, and the record's display title
+    // reduced to that single token.
+    const row = byUniform(/^Calice/i);
+    const result = uniformTitleContainment(
+      bookTokens('Neyphug Thor bu Thugs sgrub dregs pa zil gnon'),
+      row.uniform_title,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('rejects a match resting only on generic Tibetan vocabulary', () => {
+    // "ʼDod paʼi bstan bcos" ("Tibetan arts of love") vs an unrelated treatise.
+    // `bstan bcos` just means "treatise" — the equivalent of matching on
+    // "tractatus".
+    const row = byUniform(/bstan bcos/i);
+    const result = uniformTitleContainment(
+      bookTokens("she bya rab tu gsal ba'I bstan bcos dang sen"),
+      row.uniform_title,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('rejects a same-author different-work pairing', () => {
+    const row = byUniform(/^De officiis/i);
+    expect(uniformTitleContainment(bookTokens('De natura deorum'), row.uniform_title)).toBeNull();
+  });
+
+  it('returns null rather than guessing when there is no uniform title', () => {
+    // 32% of reference-set rows have no 240. Absent is not a match.
+    expect(uniformTitleContainment(bookTokens('De Officiis'), '')).toBeNull();
+    expect(uniformTitleContainment([], 'De officiis.')).toBeNull();
+  });
+});
+
+describe('fixture integrity', () => {
+  it('holds real LoC rows with LCCNs', () => {
+    expect(rows.length).toBeGreaterThanOrEqual(14);
+    for (const r of rows) expect(r.lccn, `row "${r.title}" has no LCCN`).toBeTruthy();
+  });
+
+  it('includes both positive and negative uniform titles', () => {
+    expect(rows.some((r) => /^De officiis/i.test(r.uniform_title))).toBe(true);
+    expect(rows.some((r) => /^Calice/i.test(r.uniform_title))).toBe(true);
+  });
+});

--- a/tests/unit/reference-set-work-identity.test.ts
+++ b/tests/unit/reference-set-work-identity.test.ts
@@ -39,6 +39,8 @@ import { describe, it, expect } from 'vitest';
 import {
   uniformTitleContainment,
   bookTitleTokens,
+  vernacularContainment,
+  cjkRuns,
 } from '../../scripts/lib/work-identity-match.mjs';
 
 type LocRow = {
@@ -240,5 +242,50 @@ describe('fixture integrity', () => {
   it('includes both positive and negative uniform titles', () => {
     expect(rows.some((r) => /^De officiis/i.test(r.uniform_title))).toBe(true);
     expect(rows.some((r) => /^Calice/i.test(r.uniform_title))).toBe(true);
+  });
+});
+
+describe('CJK original-script matching (MARC 880)', () => {
+  // Romanized matching is unusable for CJK: LoC mixes pinyin and Wade-Giles,
+  // pinyin is syllable-separated where our titles are joined, and most syllables
+  // fall under the token floor. Concatenate-and-substring was measured at ~2 real
+  // matches in 38 — "mingshi" sits inside "zhiwumingshitukao", matching a herbal
+  // to the Ming History. Han characters are morphemes with one spelling, so a
+  // shared run is strong evidence.
+  it('matches an exact vernacular uniform title', () => {
+    expect(vernacularContainment(['針灸大成 (Zhenjiu Dacheng)'], {
+      vernacular_uniform_title: '針灸大成',
+    })).not.toBeNull();
+  });
+
+  it('treats a contained run as a real related-work signal', () => {
+    // 本草綱目 inside 本草綱目拾遺 is the Bencao Gangmu within its own supplement —
+    // precisely the relation screening needs to see, not noise.
+    const r = vernacularContainment(['本草綱目拾遺(五)'], { vernacular_uniform_title: '本草綱目' });
+    expect(r).not.toBeNull();
+    expect(r.matched_run).toBe('本草綱目');
+    expect(r.exact).toBe(false);
+  });
+
+  it('rejects the romanized false positives it replaces', () => {
+    // 植物名實圖考 vs 明史 — no shared run, where "mingshi"/"zhiwumingshitukao"
+    // collided romanized.
+    expect(vernacularContainment(['植物名實圖考(一)'], { vernacular_uniform_title: '明史' })).toBeNull();
+    // 周易參同契發揮 vs 銅器 ("Tong qi" / bronze ware) — likewise.
+    expect(vernacularContainment(['周易參同契發揮'], { vernacular_uniform_title: '銅器' })).toBeNull();
+  });
+
+  it('ignores runs shorter than MIN_CJK_RUN', () => {
+    // Two characters is often a common bigram (中國, 大成); three is usually a title.
+    expect(vernacularContainment(['大成'], { vernacular_uniform_title: '大成' })).toBeNull();
+  });
+
+  it('returns null when either side has no CJK at all', () => {
+    expect(vernacularContainment(['De Officiis'], { vernacular_uniform_title: '針灸大成' })).toBeNull();
+    expect(vernacularContainment(['針灸大成'], { uniform_title: 'Zhen jiu da cheng.' })).toBeNull();
+  });
+
+  it('cjkRuns splits on Latin and punctuation', () => {
+    expect(cjkRuns('皇極經世書 (Huangji Jingshi Shu, juan 13)')).toEqual(['皇極經世書']);
   });
 });

--- a/tests/unit/reference-set-work-identity.test.ts
+++ b/tests/unit/reference-set-work-identity.test.ts
@@ -62,32 +62,50 @@ const byUniform = (re: RegExp) => {
  */
 const bookTokens = (...titles: string[]) => bookTitleTokens(...titles);
 
+/** Same surname rule the search uses: "Last, First" → "last". */
+const surname = (a: string) => {
+  let c = (a || '').replace(/\([^)]*\)/g, '').replace(/\d{3,4}/g, '').split(';')[0].trim();
+  if (c.includes(',')) c = c.split(',')[0];
+  const w = c.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter((x) => x.length > 1);
+  return w[w.length - 1] || '';
+};
+
+/** Author options exactly as the real run supplies them, from the fixture row. */
+const authorOpts = (row: LocRow & { author?: string; added_entries?: string[] }, bookAuthor: string) => ({
+  bookAuthorSurname: surname(bookAuthor),
+  recordAuthorSurnames: [row.author, ...(row.added_entries || [])]
+    .filter(Boolean).map(surname).filter(Boolean),
+});
+
 describe('MUST MATCH — hand-verified prior English translations', () => {
   // Each of these was confirmed by reading the record. Losing any one means the
   // search reports "no prior found" for a work that has been in English for
   // centuries.
-  const cases: Array<[string, RegExp, string[]]> = [
+  const cases: Array<[string, RegExp, string[], string]> = [
     ['Cicero, De Officiis → Grimald 1556', /^De officiis/i,
-      ['De officiis. Add: Paradoxa Stoicorum. Hexastichon', 'De Officiis']],
+      ['De officiis. Add: Paradoxa Stoicorum. Hexastichon', 'De Officiis'], 'Cicero, Marcus Tullius'],
     ['pseudo-Seneca, De formula honestae vitae → 1546', /^Formula vitae honestae/i,
-      ['De quattuor virtutibus cardinalibus, sive De formula honestae vitae', 'De formula honestae vitae']],
+      ['De quattuor virtutibus cardinalibus, sive De formula honestae vitae', 'De formula honestae vitae'], 'Seneca, Lucius Annaeus'],
     ['Plutarch, Moralia → Three morall treatises 1561', /^Moralia/i,
-      ['Plutarchi Chaeronensis Moralia (Hercher edition)', 'Plutarchi Chaeronensis Moralia']],
+      ['Plutarchi Chaeronensis Moralia (Hercher edition)', 'Plutarchi Chaeronensis Moralia'], 'Plutarch'],
     ['Euclid, Elements → Billingsley 1570', /^Elements/i,
-      ['Elementa Euclides Geometriae, Planae ac Solidae', 'Στοιχεῖα (Elements)']],
+      ['Elementa Euclides Geometriae, Planae ac Solidae', 'Στοιχεῖα (Elements)'], 'Euclid'],
     ['Boethius, Consolatio → 1609', /^De consolatione philosophiae/i,
-      ['De Consolatione Philosophiae', 'De consolatione philosophiae']],
+      ['De Consolatione Philosophiae', 'De consolatione philosophiae'], 'Boethius'],
     ['Homer, Iliad → Chapman 1609', /^Iliad/i,
-      ['Homer, Iliad with Scholia', 'The Iliad of Homer']],
+      ['Homer, Iliad with Scholia', 'The Iliad of Homer'], 'Homer'],
     ['Della Porta, Magia Naturalis → Natural magick 1658', /^Magiae naturalis/i,
-      ['Magia Naturalis. 2', 'Magia Naturalis']],
+      ['Magia Naturalis. 2', 'Magia Naturalis'], 'Della Porta, Giambattista'],
     ['Tibetan: Legs bshad gser phreng → Golden garland 2008', /^Legs bshad gser phreng/i,
-      ['Neyphug Thor bu Legs bshad gser phreng', 'Neyphug Thor bu Legs bshad gser phreng']],
+      ['Neyphug Thor bu Legs bshad gser phreng', 'Neyphug Thor bu Legs bshad gser phreng'], ''],
   ];
 
-  it.each(cases)('%s', (_label, uniformRe, titles) => {
+  it.each(cases)('%s', (_label, uniformRe, titles, bookAuthor) => {
     const row = byUniform(uniformRe);
-    const result = uniformTitleContainment(bookTokens(...titles), row.uniform_title);
+    const result = uniformTitleContainment(
+      bookTokens(...titles), row.uniform_title, authorOpts(row as any, bookAuthor),
+    );
     expect(result, `uniform title "${row.uniform_title}" should be contained in ${JSON.stringify(titles)}`)
       .not.toBeNull();
     expect(result.score).toBeGreaterThanOrEqual(0.6);
@@ -96,14 +114,20 @@ describe('MUST MATCH — hand-verified prior English translations', () => {
   it('matches across Latin case-ending variation (magiae ⇔ magia)', () => {
     // Stemming earns its keep here: an exact-token rule would miss this.
     const row = byUniform(/^Magiae naturalis/i);
-    expect(uniformTitleContainment(bookTokens('Magia Naturalis'), row.uniform_title)).not.toBeNull();
+    expect(uniformTitleContainment(
+      bookTokens('Magia Naturalis'), row.uniform_title,
+      authorOpts(row as any, 'Della Porta, Giambattista'),
+    )).not.toBeNull();
   });
 
   it('ignores word ORDER — a uniform title is a set, not a phrase', () => {
     // "Formula vitae honestae" vs our "De formula honestae vitae": substring
     // matching fails, set containment succeeds.
     const row = byUniform(/^Formula vitae honestae/i);
-    expect(uniformTitleContainment(bookTokens('De formula honestae vitae'), row.uniform_title)).not.toBeNull();
+    expect(uniformTitleContainment(
+      bookTokens('De formula honestae vitae'), row.uniform_title,
+      authorOpts(row as any, 'Seneca, Lucius Annaeus'),
+    )).not.toBeNull();
   });
 });
 
@@ -134,13 +158,76 @@ describe('MUST NOT MATCH — the false-positive classes the tuning produced', ()
 
   it('rejects a same-author different-work pairing', () => {
     const row = byUniform(/^De officiis/i);
-    expect(uniformTitleContainment(bookTokens('De natura deorum'), row.uniform_title)).toBeNull();
+    expect(uniformTitleContainment(
+      bookTokens('De natura deorum'), row.uniform_title,
+      authorOpts(row as any, 'Cicero, Marcus Tullius'),
+    )).toBeNull();
   });
 
   it('returns null rather than guessing when there is no uniform title', () => {
     // 32% of reference-set rows have no 240. Absent is not a match.
-    expect(uniformTitleContainment(bookTokens('De Officiis'), '')).toBeNull();
+    expect(uniformTitleContainment(bookTokens('De Officiis'), '', { bookAuthorSurname: 'cicero', recordAuthorSurnames: ['cicero'] })).toBeNull();
     expect(uniformTitleContainment([], 'De officiis.')).toBeNull();
+  });
+});
+
+describe('generic uniform titles need author corroboration', () => {
+  // A one- or two-word uniform title is often a GENRE, not a work. Containment
+  // alone matched these four in the full corpus run, and each is absurd on
+  // sight — every one pairs a different author.
+  const generic: Array<[string, string, string[], string]> = [
+    ['Annales. — Masonic annals vs Tacitus', 'Annales.',
+      ['Annales mac[onniques]'], 'tacitus'],
+    ['Itinerarium. — Portuguese voyage vs Mandeville', 'Itinerarium.',
+      ['Itinerarium Portugallensium e Lusitania in Indiam'], 'mandeville'],
+    ['Journal. — Hermetisches Journal vs a French diarist', 'Journal.',
+      ['Hermetisches Journal'], 'guerin'],
+    ['Max und Moritz — a German life vs Wilhelm Busch', 'Max und Moritz.',
+      ['Merckwürdiges Leben des Herrn Moritz Wilhelms'], 'busch'],
+  ];
+
+  it.each(generic)('rejects %s when the author disagrees', (_l, uniform, titles, recordAuthor) => {
+    const result = uniformTitleContainment(bookTokens(...titles), uniform, {
+      bookAuthorSurname: 'anonymous-or-different',
+      recordAuthorSurnames: [recordAuthor],
+    });
+    expect(result).toBeNull();
+  });
+
+  it('rejects a generic uniform title when the book has NO author at all', () => {
+    // The conservative direction: an anonymous work can only match on a long,
+    // distinctive uniform title. Better to leave a claim standing than to demote
+    // it on a coincidence.
+    expect(uniformTitleContainment(bookTokens('Annales mac[onniques]'), 'Annales.', {
+      bookAuthorSurname: '',
+      recordAuthorSurnames: ['tacitus'],
+    })).toBeNull();
+  });
+
+  it('ACCEPTS a one-token uniform title when the author agrees', () => {
+    // The true positives are all one-token: "De officiis.", "Moralia.",
+    // "Elements.", "Poetics.". Raising a threshold would have lost every one of
+    // them, which is why corroboration is the right lever, not specificity.
+    const result = uniformTitleContainment(
+      bookTokens('De officiis. Add: Paradoxa Stoicorum', 'De Officiis'),
+      'De officiis.',
+      { bookAuthorSurname: 'cicero', recordAuthorSurnames: ['cicero'] },
+    );
+    expect(result).not.toBeNull();
+    expect(result.basis).toBe('uniform_title_containment+author');
+  });
+
+  it('does not require author agreement for a long, distinctive uniform title', () => {
+    // "Legs bshad gser phreng" is 4 tokens and unmistakable; its catalogued
+    // "author" on our side is a monastery collection, so demanding agreement
+    // would discard a genuine find.
+    const row = byUniform(/^Legs bshad gser phreng/i);
+    const result = uniformTitleContainment(
+      bookTokens('Neyphug Thor bu Legs bshad gser phreng'),
+      row.uniform_title,
+      { bookAuthorSurname: '', recordAuthorSurnames: [] },
+    );
+    expect(result).not.toBeNull();
   });
 });
 

--- a/tests/unit/reference-set-work-identity.test.ts
+++ b/tests/unit/reference-set-work-identity.test.ts
@@ -289,3 +289,25 @@ describe('CJK original-script matching (MARC 880)', () => {
     expect(cjkRuns('皇極經世書 (Huangji Jingshi Shu, juan 13)')).toEqual(['皇極經世書']);
   });
 });
+
+describe('CJK volume enumerations are not work identity', () => {
+  // 三才圖會(三十九) matched "The Thirty-Nine Steps" and 武備志(一百二) matched
+  // "The 120 Days of Sodom" — the parenthetical is a VOLUME NUMBER, and Wikidata
+  // carries Chinese labels for Buchan and Sade containing those numerals. Same
+  // failure the Western VOLUME guard catches, in a different script.
+  it('drops a run that is only CJK numerals', () => {
+    expect(cjkRuns('三才圖會(三十九)')).toEqual(['三才圖會']);
+    expect(cjkRuns('武備志(一百二)')).toEqual(['武備志']);
+  });
+
+  it('keeps a real title that merely begins with a numeral character', () => {
+    // 三才圖會 starts with 三 (three) but is not an enumeration.
+    expect(cjkRuns('三才圖會')).toEqual(['三才圖會']);
+  });
+
+  it('no longer pairs a Chinese compendium with an English thriller', () => {
+    expect(vernacularContainment(['三才圖會(三十九)'], {
+      vernacular_uniform_title: '三十九級台階',
+    })).toBeNull();
+  });
+});

--- a/tests/unit/reference-set-work-identity.test.ts
+++ b/tests/unit/reference-set-work-identity.test.ts
@@ -38,19 +38,28 @@ import { describe, it, expect } from 'vitest';
 // @ts-expect-error — .mjs script module without type declarations
 import {
   uniformTitleContainment,
+  displayTitleOverlap,
   bookTitleTokens,
   vernacularContainment,
   cjkRuns,
+  STRONG_WORK_IDENTITY,
 } from '../../scripts/lib/work-identity-match.mjs';
 
 type LocRow = {
-  lccn: string; title: string; uniform_title: string; year: string;
+  lccn: string; title: string; subtitle?: string; uniform_title: string; year: string;
+  author?: string; added_entries?: string[];
   original_languages: string[];
 };
 
 const rows: LocRow[] = JSON.parse(
   readFileSync(resolve(__dirname, '../fixtures/reference-set/loc-gold-rows.json'), 'utf8'),
 );
+
+const byTitle = (re: RegExp) => {
+  const hit = rows.find((r) => !r.uniform_title && re.test(r.title || ''));
+  if (!hit) throw new Error(`gold fixture missing a 240-less row with title matching ${re}`);
+  return hit;
+};
 
 const byUniform = (re: RegExp) => {
   const hit = rows.find((r) => re.test(r.uniform_title || ''));
@@ -78,6 +87,9 @@ const authorOpts = (row: LocRow & { author?: string; added_entries?: string[] },
   bookAuthorSurname: surname(bookAuthor),
   recordAuthorSurnames: [row.author, ...(row.added_entries || [])]
     .filter(Boolean).map(surname).filter(Boolean),
+  // Full name strings, so the 245 fallback can discount personal-name tokens that
+  // appear inside the titles themselves ("The Iliad of HOMER").
+  authorNames: [bookAuthor, row.author, ...(row.added_entries || [])].filter(Boolean),
 });
 
 describe('MUST MATCH — hand-verified prior English translations', () => {
@@ -230,6 +242,127 @@ describe('generic uniform titles need author corroboration', () => {
       { bookAuthorSurname: '', recordAuthorSurnames: [] },
     );
     expect(result).not.toBeNull();
+  });
+});
+
+/**
+ * THE 240 RECALL CEILING
+ * ----------------------
+ * 35.2% of reference-set rows carry no MARC 240 (41,678 of 118,352). Work
+ * identity is established by 240 containment, and the 245 display-title fallback
+ * was capped at 0.55 — below the 0.60 confirmation threshold — so over a third of
+ * the set could NEVER produce a confirmed match no matter how exactly it agreed.
+ * Every one of those rows could only ever yield `none_found`.
+ *
+ * The naive repair is to raise the cap. That is the ratio-tuning that failed five
+ * times, and it fails here for a nameable reason: on a 245 the overlap is
+ * frequently carried by THE AUTHOR'S OWN NAME. "Poetics" against "The Rhetoric of
+ * Aristotle." scores well while sharing no work content at all, because both
+ * titles say "Aristotle".
+ *
+ * So the instrument, not the threshold: discount personal-name tokens, then
+ * require SET CONTAINMENT of what remains in one direction or the other, plus
+ * author agreement. Containment is the same test the 240 path uses, for the same
+ * reason — an edition's 245 carries apparatus ("The thirteen books of…",
+ * "English translation of…") that a ratio punishes and containment tolerates.
+ *
+ * Every row below is real MARC from the 2016 dump with a genuinely empty 240, and
+ * every book is a real record in our corpus.
+ */
+describe('245 display-title fallback — MUST CONFIRM (the 240-less true positives)', () => {
+  const cases: Array<[string, RegExp, string[], string]> = [
+    ['Homer, Iliad → Lang/Leaf/Myers 1903', /^The Iliad of Homer,/,
+      ['The Iliad of Homer'], 'Homer'],
+    ['Euclid, Elements → Heath 1908 (record carries "thirteen books of")', /thirteen books of Euclid/,
+      ['Elementa (Euclid)', 'Στοιχεῖα (Elements)'], 'Euclid'],
+    ['Chaucer, Canterbury Tales → Coghill 1952', /^The Canterbury tales/,
+      ['The Canterbury Tales'], 'Geoffrey Chaucer'],
+    ['al-Bukhari, Sahih → 1973 (record is CONTAINED in our title)', /English translation of Sahih al-Bukhari/,
+      ['Sahih al-Bukhari (Complete)'], 'Imam al-Bukhari'],
+    ['Hammurabi, Code → Viel 2005', /^The complete code of Hammurabi/,
+      ['Code of Hammurabi'], 'Court scribe of Hammurabi'],
+    ['Petrie, Egyptian Tales → 1899', /^Egyptian tales translated from the papyri/,
+      ['Egyptian Tales Translated from the Papyri'], 'W. M. Flinders Petrie'],
+    ['Wittgenstein, Tractatus → 2014', /^Tractatus logico-philosophicus/,
+      ['Tractatus Logico-Philosophicus'], 'Ludwig Wittgenstein'],
+    ['Suetonius, De grammaticis → Kaster 1995', /^De grammaticis et rhetoribus/,
+      ['De grammaticis et rhetoribus'], 'Suetonius'],
+  ];
+
+  it.each(cases)('%s', (_label, titleRe, bookTitles, bookAuthor) => {
+    const row = byTitle(titleRe);
+    const result = displayTitleOverlap(
+      bookTokens(...bookTitles), `${row.title} ${row.subtitle ?? ''}`, authorOpts(row, bookAuthor),
+    );
+    expect(result, `"${row.title}" should confirm against ${JSON.stringify(bookTitles)}`).not.toBeNull();
+    expect(result.score).toBeGreaterThanOrEqual(STRONG_WORK_IDENTITY);
+  });
+});
+
+describe('245 display-title fallback — MUST NOT CONFIRM', () => {
+  // The whole reason a cap existed. Each of these agrees on AUTHOR and shares
+  // tokens; none of them is the same work.
+  it('rejects Poetics against "The Rhetoric of Aristotle" — the overlap IS the author', () => {
+    const row = byTitle(/^The Rhetoric of Aristotle\./);
+    const result = displayTitleOverlap(
+      bookTokens('Poetics'), `${row.title} ${row.subtitle ?? ''}`, authorOpts(row, 'Aristotle'),
+    );
+    expect(result?.score ?? 0).toBeLessThan(STRONG_WORK_IDENTITY);
+  });
+
+  it('rejects Phaedo against "Four texts on Socrates" (Euthyphro, Apology, Crito)', () => {
+    const row = byTitle(/^Four texts on Socrates/);
+    const result = displayTitleOverlap(
+      bookTokens('Phaedo'), `${row.title} ${row.subtitle ?? ''}`, authorOpts(row, 'Plato'),
+    );
+    expect(result?.score ?? 0).toBeLessThan(STRONG_WORK_IDENTITY);
+  });
+
+  it('rejects Villon\'s Oeuvres against his Testaments — a part is not the whole', () => {
+    const row = byTitle(/^The testaments of Francois Villon/);
+    const result = displayTitleOverlap(
+      bookTokens('Les Oeuvres de François Villon'), `${row.title} ${row.subtitle ?? ''}`,
+      authorOpts(row, 'François Villon'),
+    );
+    expect(result?.score ?? 0).toBeLessThan(STRONG_WORK_IDENTITY);
+  });
+
+  it('rejects two works of one author that share a single ordinary token', () => {
+    // Historia animalium vs De partibus animalium: "animalium" is shared, neither
+    // title is contained in the other. A min-coverage rule at 0.5 confirms this;
+    // containment does not.
+    const result = displayTitleOverlap(
+      bookTokens('Historia animalium'), 'De partibus animalium',
+      { bookAuthorSurname: 'aristotle', recordAuthorSurnames: ['aristotle'], authorNames: ['Aristotle'] },
+    );
+    expect(result?.score ?? 0).toBeLessThan(STRONG_WORK_IDENTITY);
+  });
+
+  it('NEVER confirms without author agreement, however exact the title', () => {
+    // The title-token lane has no author access point at all. A 245 match there
+    // rests on nothing but words, which is precisely how "The cup to the dregs"
+    // matched a Tibetan ritual text.
+    const row = byTitle(/^The Canterbury tales/);
+    const noAuthor = displayTitleOverlap(
+      bookTokens('The Canterbury Tales'), row.title,
+      { bookAuthorSurname: '', recordAuthorSurnames: [] },
+    );
+    expect(noAuthor?.score ?? 0).toBeLessThan(STRONG_WORK_IDENTITY);
+
+    const wrongAuthor = displayTitleOverlap(
+      bookTokens('The Canterbury Tales'), row.title,
+      authorOpts(row, 'Someone Else'),
+    );
+    expect(wrongAuthor?.score ?? 0).toBeLessThan(STRONG_WORK_IDENTITY);
+  });
+
+  it('still returns the weak hint rather than null, so screening can see it', () => {
+    // A rejected confirmation must not become an absence. The candidate is still
+    // retrieved and screened; it simply cannot assert work identity by itself.
+    const row = byTitle(/^The Rhetoric of Aristotle\./);
+    const result = displayTitleOverlap(bookTokens('Poetics of Aristotle'), row.title, authorOpts(row, 'Aristotle'));
+    expect(result).not.toBeNull();
+    expect(result.basis).toBe('display_title_overlap');
   });
 });
 

--- a/tests/unit/search-effort.test.ts
+++ b/tests/unit/search-effort.test.ts
@@ -20,6 +20,7 @@ import {
   deriveVerdict,
   effortId,
   renderEffortSummary,
+  latestEffortPerBook,
   SCREEN,
   VERDICT,
 } from '../../scripts/lib/search-effort.mjs';
@@ -202,5 +203,26 @@ describe('renderEffortSummary — what a reader actually sees', () => {
   it('does not claim a clean negative while candidates are unscreened', () => {
     expect(renderEffortSummary(make([{ screen: SCREEN.UNRESOLVED, reason: 'could not decide' }])))
       .toMatch(/Inconclusive/);
+  });
+});
+
+describe('latestEffortPerBook — the collection is a history, not a state', () => {
+  it('keeps only the newest effort per book', () => {
+    // Efforts are immutable: a new code version or snapshot mints a new id
+    // instead of overwriting, which is what lets a stale negative be re-opened.
+    // The cost is that a naive read mixes generations — measured on the real
+    // collection, 265 "inconclusive" rows against a current generation of 75.
+    const efforts = [
+      { book_id: 'a', run_at: '2026-07-29T00:00:00Z', verdict: 'none_found' },
+      { book_id: 'a', run_at: '2026-07-30T00:00:00Z', verdict: 'inconclusive' },
+      { book_id: 'b', run_at: '2026-07-30T00:00:00Z', verdict: 'none_found' },
+    ];
+    const current = latestEffortPerBook(efforts);
+    expect(current).toHaveLength(2);
+    expect(current.find((e: any) => e.book_id === 'a').verdict).toBe('inconclusive');
+  });
+
+  it('ignores rows with no book_id rather than bucketing them together', () => {
+    expect(latestEffortPerBook([{ run_at: '2026-07-30T00:00:00Z' }])).toHaveLength(0);
   });
 });

--- a/tests/unit/search-effort.test.ts
+++ b/tests/unit/search-effort.test.ts
@@ -1,0 +1,206 @@
+/**
+ * search_efforts: publish the SEARCH, not the unprovable negative. (#3459)
+ *
+ * "First English translation" cannot be established by any search — a catalogue
+ * returns only *nothing found*. Every attempt to shore the claim up with better
+ * evidence has failed the same way, because the claim's SHAPE is wrong, not its
+ * evidence quality.
+ *
+ * So the artifact becomes the search itself: a bounded, dated, reproducible act
+ * that a third party can re-run. These tests pin the properties that make such a
+ * record trustworthy, and — more importantly — the ways it is REQUIRED to fail
+ * closed. Each `toThrow` below corresponds to a real way we have previously
+ * manufactured false confidence.
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import {
+  buildSearchEffort,
+  deriveVerdict,
+  effortId,
+  renderEffortSummary,
+  SCREEN,
+  VERDICT,
+} from '../../scripts/lib/search-effort.mjs';
+
+const refSet = {
+  version: 'loc-2016.v1',
+  sources: [{
+    id: 'loc',
+    name: 'Library of Congress MDSConnect Books-All',
+    snapshot_date: '2016-12-31',
+    record_count: 10_750_000,
+    coverage: 'US imprint depth',
+    known_gaps: ['post-2016 imprints absent by construction'],
+  }],
+};
+
+const base = {
+  bookId: 'bk-1',
+  proposition: 'Does a complete English translation of X published before 1900 exist?',
+  referenceSet: refSet,
+  codeVersion: 'abc1234',
+};
+
+describe('fails closed on anything that would make a negative unverifiable', () => {
+  it('refuses an effort with no pinned code version', () => {
+    // Measured 2026-07-29: reversing one title-coverage ratio moved strong
+    // matches from 8 to 74 over identical data. An effort that does not pin the
+    // code that produced it is an anecdote, not a reproducible result.
+    expect(() => buildSearchEffort({ ...base, codeVersion: undefined }))
+      .toThrow(/codeVersion/);
+  });
+
+  it('refuses a reference set whose source has no snapshot date', () => {
+    const undated = { version: 'v1', sources: [{ id: 'loc', name: 'LoC' }] };
+    expect(() => buildSearchEffort({ ...base, referenceSet: undated }))
+      .toThrow(/snapshot_date/);
+  });
+
+  it('refuses an effort with no reference set at all', () => {
+    expect(() => buildSearchEffort({ ...base, referenceSet: { version: 'v1', sources: [] } }))
+      .toThrow(/at least one source/);
+  });
+
+  it('refuses an effort with no stated proposition', () => {
+    expect(() => buildSearchEffort({ ...base, proposition: '' })).toThrow(/proposition/);
+  });
+});
+
+describe('deriveVerdict', () => {
+  const v = (candidates: any[], searchable = true) => deriveVerdict({ candidates, searchable });
+
+  it('reports none_found when nothing defeating was retrieved', () => {
+    expect(v([{ screen: SCREEN.DIFFERENT_WORK }, { screen: SCREEN.LATER }]))
+      .toBe(VERDICT.NONE_FOUND);
+  });
+
+  it('reports prior_found on a screened prior translation', () => {
+    expect(v([{ screen: SCREEN.DIFFERENT_WORK }, { screen: SCREEN.PRIOR }]))
+      .toBe(VERDICT.PRIOR_FOUND);
+  });
+
+  it('an UNRESOLVED candidate blocks none_found', () => {
+    // The critical one. An unscreened candidate is an open question; rounding it
+    // down to "nothing found" is exactly the false confidence this design exists
+    // to remove.
+    expect(v([{ screen: SCREEN.UNRESOLVED }])).toBe(VERDICT.INCONCLUSIVE);
+  });
+
+  it('a prior still wins over an unresolved candidate', () => {
+    expect(v([{ screen: SCREEN.UNRESOLVED }, { screen: SCREEN.PRIOR }]))
+      .toBe(VERDICT.PRIOR_FOUND);
+  });
+
+  it('partial-only is its own verdict, not none_found', () => {
+    // "First COMPLETE translation" survives earlier selections; collapsing the
+    // two loses the distinction the badge actually depends on.
+    expect(v([{ screen: SCREEN.PARTIAL }])).toBe(VERDICT.ONLY_PARTIAL_FOUND);
+  });
+
+  it('a study never defeats a claim (#3428)', () => {
+    expect(v([{ screen: SCREEN.NOT_A_TRANSLATION }])).toBe(VERDICT.NONE_FOUND);
+  });
+
+  it('not_searchable is distinct from none_found', () => {
+    // A book with no catalogue access point was never asked about. Reporting
+    // that as a clean negative is how an unasked question becomes a confident
+    // claim.
+    expect(v([], false)).toBe(VERDICT.NOT_SEARCHABLE);
+    expect(v([], true)).toBe(VERDICT.NONE_FOUND);
+  });
+});
+
+describe('effort identity', () => {
+  it('is stable for the same book, reference set and code', () => {
+    expect(effortId({ bookId: 'b', referenceSetVersion: 'v1', codeVersion: 'sha1' }))
+      .toBe(effortId({ bookId: 'b', referenceSetVersion: 'v1', codeVersion: 'sha1' }));
+  });
+
+  it('changes when the reference set changes', () => {
+    // A new snapshot IS a different search, and must not silently overwrite the
+    // old one — that is what lets a previously-asserted negative be re-opened
+    // when the reference set grows.
+    expect(effortId({ bookId: 'b', referenceSetVersion: 'v1', codeVersion: 'sha1' }))
+      .not.toBe(effortId({ bookId: 'b', referenceSetVersion: 'v2', codeVersion: 'sha1' }));
+  });
+
+  it('changes when the code changes', () => {
+    expect(effortId({ bookId: 'b', referenceSetVersion: 'v1', codeVersion: 'sha1' }))
+      .not.toBe(effortId({ bookId: 'b', referenceSetVersion: 'v1', codeVersion: 'sha2' }));
+  });
+});
+
+describe('buildSearchEffort', () => {
+  const effort = buildSearchEffort({
+    ...base,
+    queries: [{ source: 'loc', query: 'bath.author="Ficino"', result_count: 88 }],
+    candidates: [
+      { identifiers: { lccn: '123' }, title: 'On Pleasure', year: 1980, screen: SCREEN.DIFFERENT_WORK, reason: 'different work by the same author' },
+      { identifiers: { lccn: '456' }, title: 'A Study of Ficino', year: 1990, screen: SCREEN.NOT_A_TRANSLATION, reason: '041 absent; criticism-and-interpretation heading' },
+    ],
+    limitations: ['journal-published translations are largely uncatalogued'],
+  });
+
+  it('records counts derived from the actual queries and candidates', () => {
+    expect(effort.counts.queries).toBe(1);
+    expect(effort.counts.records_returned).toBe(88);
+    expect(effort.counts.candidates_screened).toBe(2);
+    expect(effort.counts.by_screen[SCREEN.NOT_A_TRANSLATION]).toBe(1);
+  });
+
+  it('inherits each source\'s declared gaps as limitations of THIS effort', () => {
+    // A gap named once in a manifest and never surfaced on the claim it
+    // undermines is a footnote nobody reads.
+    expect(effort.limitations).toContain('loc: post-2016 imprints absent by construction');
+    expect(effort.limitations).toContain('journal-published translations are largely uncatalogued');
+  });
+
+  it('keeps every candidate INCLUDING the rejects, with reasons', () => {
+    // The rejects are what show the search was real rather than a lookup that
+    // happened to miss.
+    expect(effort.candidates).toHaveLength(2);
+    for (const c of effort.candidates) expect(c.reason).toBeTruthy();
+  });
+
+  it('derives the verdict rather than accepting one', () => {
+    expect(effort.verdict).toBe(VERDICT.NONE_FOUND);
+  });
+
+  it('never writes a verdict onto the book', () => {
+    // An effort is EVIDENCE. The public flag stays behind the sign-off-gated
+    // reconcile (#2933), which is what makes it safe to run this at corpus scale.
+    expect(effort).not.toHaveProperty('is_first_translation');
+    expect(Object.keys(effort)).not.toContain('books');
+  });
+});
+
+describe('renderEffortSummary — what a reader actually sees', () => {
+  const make = (candidates: any[], searchable = true) =>
+    buildSearchEffort({ ...base, searchable, candidates, queries: [{ source: 'loc', query: 'q', result_count: 3 }] });
+
+  it('states the search, not the unprovable claim', () => {
+    const s = renderEffortSummary(make([]));
+    expect(s).toMatch(/No prior English translation found/);
+    expect(s).toMatch(/Searched 1 catalogue/);
+    expect(s).toMatch(/10,750,000 records/);
+    expect(s).toMatch(/2016/);
+    // The thing we must never render:
+    expect(s).not.toMatch(/first English translation/i);
+  });
+
+  it('distinguishes partial-only from nothing-found', () => {
+    expect(renderEffortSummary(make([{ screen: SCREEN.PARTIAL, reason: 'selections' }])))
+      .toMatch(/No prior COMPLETE English translation found/);
+  });
+
+  it('says so plainly when the work was never searchable', () => {
+    expect(renderEffortSummary(make([], false))).toMatch(/Not yet searchable/);
+  });
+
+  it('does not claim a clean negative while candidates are unscreened', () => {
+    expect(renderEffortSummary(make([{ screen: SCREEN.UNRESOLVED, reason: 'could not decide' }])))
+      .toMatch(/Inconclusive/);
+  });
+});

--- a/tests/unit/search-effort.test.ts
+++ b/tests/unit/search-effort.test.ts
@@ -25,6 +25,9 @@ import {
   VERDICT,
 } from '../../scripts/lib/search-effort.mjs';
 
+// @ts-expect-error — .mjs script module without type declarations
+import { englishFraction, ENGLISH_SOURCE_THRESHOLD } from '../../scripts/lib/english-source-detect.mjs';
+
 const refSet = {
   version: 'loc-2016.v1',
   sources: [{
@@ -224,5 +227,35 @@ describe('latestEffortPerBook — the collection is a history, not a state', () 
 
   it('ignores rows with no book_id rather than bucketing them together', () => {
     expect(latestEffortPerBook([{ run_at: '2026-07-30T00:00:00Z' }])).toHaveLength(0);
+  });
+});
+
+describe('english-source detection reads the SOURCE, not our own annotations', () => {
+  // pages.ocr.data embeds AI-written English annotation blocks (<meta>,
+  // <scan-quality>, <page-type>) describing the page in English whatever language
+  // the page is in. Stripping only the TAGS keeps that prose — the exact bug
+  // CLAUDE.md documents. It made a Greek Corpus Hermeticum score 0.26-0.36
+  // English on annotated pages while real Greek pages scored 0.00, and inflated
+  // the "already English" count from 1,410 to 2,349.
+  it('ignores English editorial wrappers around foreign text', () => {
+    const greekPage = '<scan-quality>Significant ink bleed-through from the verso page, and the page '
+      + 'features numerous red ink corrections or additions by a later hand</scan-quality>'
+      + '<meta>This page of the manuscript is written in a compact minuscule</meta>'
+      + ' τοῦ δὲ καταῤῥέοντος ὕδατος ὅτι πασῶν τριῶσαν ἐχυθῇ τὸ πνεῦμα καὶ ἡ ψυχή';
+    // With wrappers stripped there is essentially no Latin-script text left, so
+    // the page must not be judged English.
+    const f = englishFraction(greekPage, 5);
+    expect(f === null || f < ENGLISH_SOURCE_THRESHOLD).toBe(true);
+  });
+
+  it('still detects a genuinely English source page', () => {
+    const budge = 'the seven tablets of creation or the babylonian and assyrian legends concerning '
+      + 'the creation of the world and of mankind edited with transliterations and there is in the '
+      + 'text a great deal of that which we have from the earliest period of all these things';
+    expect(englishFraction(budge)).toBeGreaterThan(ENGLISH_SOURCE_THRESHOLD);
+  });
+
+  it('refuses to judge a page with too little text', () => {
+    expect(englishFraction('blank')).toBeNull();
   });
 });

--- a/tests/unit/translation-catalog-source-language.test.ts
+++ b/tests/unit/translation-catalog-source-language.test.ts
@@ -1,0 +1,146 @@
+/**
+ * SOURCE_LANG guard: both sides must resolve to the same ISO bucket (#3460).
+ *
+ * The bug: `scripts/eval/ft-catalog-match.mjs` resolved the BOOK's language to
+ * an ISO code via a private table, then compared that against the catalog row's
+ * `source_language` string *as stored*. Rows written with a human display name
+ * ("Sanskrit", "Greek", "Latin") therefore failed the guard against every book
+ * in the corpus.
+ *
+ * Blast radius measured against production on 2026-07-29: 305 rows, all of
+ * `source: 'claude_subagent_verify'` — the hand-verified batch — carrying 213 of
+ * the catalogue's 385 `completeness: 'complete'` rows. Since COMPLETENESS is the
+ * guard that actually defeats a first-translation claim, 55% of the rows strong
+ * enough to demote a badge could never be reached. Running the real matcher
+ * before/after the fix moved the corpus-wide demote-candidate count from 0 to 2.
+ *
+ * These tests exercise the real exported matcher against real row shapes. They
+ * are deliberately NOT source-shape assertions: the failure mode here is a
+ * guard that returns the wrong answer, which a grep for a line of code cannot
+ * see (see "A test that greps source is not a guard" in CLAUDE.md).
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import { buildCatalogIndex, matchBookToCatalog } from '../../scripts/eval/ft-catalog-match.mjs';
+// @ts-expect-error — .mjs script module without type declarations
+import { toSourceIso, buildCatalogDoc } from '../../scripts/lib/translation-catalog-record.mjs';
+
+describe('toSourceIso', () => {
+  it('maps display names to ISO buckets', () => {
+    expect(toSourceIso('Sanskrit')).toBe('sa');
+    expect(toSourceIso('Greek')).toBe('grc');
+    expect(toSourceIso('Ancient Greek')).toBe('grc');
+    expect(toSourceIso('Latin')).toBe('la');
+    expect(toSourceIso('Classical Chinese')).toBe('zh');
+    expect(toSourceIso('Tibetan')).toBe('bo');
+  });
+
+  it('is idempotent on values already in ISO form', () => {
+    for (const iso of ['la', 'grc', 'sa', 'bo', 'zh', 'he', 'arc']) {
+      expect(toSourceIso(iso)).toBe(iso);
+    }
+  });
+
+  it('drops qualifying parentheticals', () => {
+    // Real production values from the claude_subagent_verify batch.
+    expect(toSourceIso("Mandaic (via Lidzbarski's German)")).toBe('myz');
+    expect(toSourceIso('Middle English (French-derived recension)')).toBe('enm');
+  });
+
+  it('takes the leading segment of a compound source', () => {
+    expect(toSourceIso('Latin/German')).toBe('la');
+    expect(toSourceIso('Latin-Dutch')).toBe('la');
+    expect(toSourceIso('Nahuatl/Latin')).toBe('nah');
+  });
+
+  it('returns null rather than guessing on an unmappable value', () => {
+    // Reported by the repair sweep, deliberately left unresolved.
+    expect(toSourceIso('Mixtec (pictographic; via Spanish)')).toBeNull();
+    expect(toSourceIso('')).toBeNull();
+    expect(toSourceIso(undefined)).toBeNull();
+  });
+});
+
+describe('buildCatalogDoc source_language', () => {
+  const base = {
+    source: 'test',
+    author: 'Patanjali',
+    english_title: 'The Yoga Sutras of Patanjali',
+    translator: 'Someone',
+    pub_year: '1914',
+  };
+
+  it('stores the ISO bucket even when handed a display name', () => {
+    // This is the regression: the ft-verify ingest fed display names straight
+    // through, so rows were born unmatchable.
+    const doc = buildCatalogDoc({ ...base, source_language: 'Sanskrit' });
+    expect(doc.source_language).toBe('sa');
+    expect(doc.source_language_raw).toBe('Sanskrit');
+  });
+
+  it('does not set source_language_raw when the input was already ISO', () => {
+    const doc = buildCatalogDoc({ ...base, source_language: 'sa' });
+    expect(doc.source_language).toBe('sa');
+    expect(doc.source_language_raw).toBeUndefined();
+  });
+
+  it('throws on a source_language it cannot resolve', () => {
+    expect(() => buildCatalogDoc({ ...base, source_language: 'Klingon' })).toThrow(/invalid source_language/);
+  });
+});
+
+describe('SOURCE_LANG guard via the real matcher', () => {
+  const book = {
+    id: 'bk-yoga',
+    title: 'Yoga Sutras',
+    author: 'Patanjali',
+    language: 'Sanskrit',
+    original_language: 'Sanskrit',
+  };
+
+  /** A complete prior translation that should defeat a first-translation claim. */
+  const row = (sourceLanguage: string) => ({
+    _id: 'row-1',
+    source: 'claude_subagent_verify',
+    author: 'Patanjali',
+    canonical_author: 'Patanjali',
+    author_surname: 'patanjali',
+    english_title: 'Yoga Sutras',
+    translator: 'Charles Johnston',
+    pub_year: '1912',
+    pub_year_int: 1912,
+    completeness: 'complete',
+    source_language: sourceLanguage,
+  });
+
+  it('passes when the row carries an ISO code', () => {
+    const result = matchBookToCatalog(book, buildCatalogIndex([row('sa')]));
+    expect(result).not.toBeNull();
+    expect(result.best_match.guards.SOURCE_LANG.pass).toBe(true);
+  });
+
+  it('ALSO passes when the row carries the display name — the #3460 regression', () => {
+    // Before the fix this compared 'sa' against 'sanskrit' and failed, taking
+    // the whole hand-verified batch out of play.
+    const result = matchBookToCatalog(book, buildCatalogIndex([row('Sanskrit')]));
+    expect(result).not.toBeNull();
+    expect(result.best_match.guards.SOURCE_LANG.pass).toBe(true);
+  });
+
+  it('still rejects a genuinely different source language', () => {
+    // The guard must keep doing its job: a Latin→English translation does not
+    // defeat a Sanskrit→English first claim.
+    const result = matchBookToCatalog(book, buildCatalogIndex([row('Latin')]));
+    expect(result).not.toBeNull();
+    expect(result.best_match.guards.SOURCE_LANG.pass).toBe(false);
+  });
+
+  it('a display-name row with completeness=complete becomes a demote candidate', () => {
+    // The end-to-end consequence: all five guards pass, so the row is finally
+    // able to surface an over-claim.
+    const result = matchBookToCatalog(book, buildCatalogIndex([row('Sanskrit')]));
+    expect(result.best_match.all_guards_pass).toBe(true);
+    expect(result.tier).toBe('demote_candidate');
+  });
+});


### PR DESCRIPTION
Publishes the SEARCH instead of asserting the unprovable negative, and then measures how much that search is actually worth.

"First English translation" is a universal negative. No catalogue can establish one — it returns only *nothing found*. So this stack stops asserting it and records a bounded, dated, reproducible act instead: proposition, reference set with per-source snapshot dates and declared gaps, every query verbatim, every candidate **with its screening reason**, and the git SHA that produced it (`search_efforts`). Durable human judgements live separately in `screening_decisions` and are re-applied to every generation, because a judgement is about a (work, prior) pair, not about a run.

## The governing number

**Catalogue recall is 27%** (`scripts/eval/ft-reference-set-recall.mjs`), up from 22%. Three of every four known prior English translations are still invisible. Therefore **`none_found` is weak evidence and no count built on it should be quoted, in any cohort.** Positive findings are unaffected — poor recall cannot manufacture a false positive, which is why the demote packet stands on its own.

Measuring it correctly required changing the measurement's shape. `translation_classification` is now both a source *and* the yardstick, and a yardstick inside the set it measures reads **exactly 100.0%** — confirmed empirically. The script reports catalogue-only recall as the quotable figure and prints the circular one beside it, labelled.

Decomposition over the 607 known-prior books both cohorts examined:

| variant | surfaced | none_found | recall |
|---|---|---|---|
| catalogue-only, all bases | 162 | 439 | **27.0%** |
| catalogue-only, no 245 confirm | 133 | 468 | 22.1% *(the old ceiling)* |
| LoC alone | 155 | 446 | 25.8% |
| Wikidata alone | 46 | 555 | 7.7% |
| combined, incl. classification | 607 | 0 | 100.0% **CIRCULAR** |

The whole 22%→27% movement came from the MARC 240 fix. Adding `translation_classification` did not raise recall and structurally cannot — it is a join on our own ids, so it resolves the 607 books we already had an answer for and reaches nothing beyond them. Real value, wrong label: that is **coverage**.

## What is in here

**Three defects, all failing silently toward a confident clean negative:**

- A Wikidata Q-number is not a MARC language code. `['gre','grc'].includes('Q35497')` is false, so the screen rejected **every** Wikidata row whose language it knew — 228 real candidates including Xenophon's *Symposium* and all six *Rubáiyát*. Now 228 → 1. There is deliberately no QID table: every row carries an English label, and a hand-written QID list would be unverifiable assertions whose single wrong entry reproduces the bug.
- The demote packet selected across **both** cohorts. The inverse cohort is unbadged by definition, so 115 of 162 prior-bearing efforts had nothing to demote — and since the packet reports `books.size` as the badge count, they inflated the number being signed off. Gates on `books.is_first_translation` now, not on `effort.cohort`.
- The packet outlived its own 300s clock and wrote **nothing** after completing 31 of 33 works — every paced LoC fetch discarded, exiting non-zero in a way that reads like a network failure.

**The 240 recall ceiling.** 35.2% of rows carry no MARC 240, and the 245 fallback was capped below the confirmation threshold, so a third of the set could never confirm. The fix is not a threshold — on a 245 the overlap is usually carried by *the author's own name* ("Poetics" vs "The Rhetoric of Aristotle"). Discount personal-name tokens, then require set **containment** either direction plus author agreement: the same instrument the 240 path uses. It separates Euclid's *Elementa* from "The thirteen books of Euclid's Elements" (min-coverage 0.50, same work) from *Historia animalium* vs *De partibus animalium* (also 0.50, different works). **Gold cases written first** — 8 verified 240-less positives and 6 negatives, all real 2016 MARC — per the lesson from tuning pass 4, which lost Cicero and Plutarch while making the corpus look cleaner.

**A third source.** `translation_classification` (2,755 attributed priors) joined on `book_id` and on `books.work_id`. Every candidate is `unresolved`: a model's attribution is a lead, never a confirmed prior, and letting it assert `prior_found` or `only_partial_found` would let an unverified claim drive a public verdict.

**The question actually worth asking.** Both cohorts were gated on `pages_translated > 0` — the search only ever asked about books we had *already translated*. We hold 76,174 non-English books with pages; 18,410 have any English translation. The new `untranslated` cohort covers the other ~57,600, with rights-class `hidden_reason` as an absolute exclusion. `ft-translation-queue.mjs` builds a prioritisation queue and **refuses to emit one ranked list** — a null against 23,217 English translations from French is not a null against 119 from Syriac.

Why 27% recall is acceptable there and not for badging: prioritisation publishes nothing. A missed prior costs a wasted translation, caught on reading; a *false* prior silently drops a genuinely untranslated work forever. That job needs precision on "already done", which is this instrument's strong direction — 32/32 live identity confirmations, zero contradictions across 399 independently-classified `never_translated` books.

## Verification

- **1,069 unit tests pass; `tsc --noEmit` clean.**
- Two new guards, both behavioural rather than source-grepping: `reference-set-source-language.test.ts` pins the exact Wikidata regressions with the values from the failing run; the work-identity gold set grew to 46 cases.
- All 117 new 245 confirmations were read by hand — no false positive survived. The two I distrusted are real (the 1964 Jowett/Butcher *Politics ; Poetics* volume; a Dante index a human had already screened out).
- Demote packet regenerated: **46 badges across 32 works, identity confirmed 32/32, zero failures**, 1 unfetchable. Strabo's *Geography* and Plutarch's *Moralia* return to the packet with a complete prior established *from the record* — the 240 fix landing directly in sign-off.
- A 14-work sample of the visible queue was checked against external sources. **Roughly half have a prior English translation the search missed**, i.e. `none_found` has a ~50% positive predictive value. Two verified live (Agrippa → Sanford 1569; Maier → Hall 1654).

## What this exposes, and what it does NOT do

**No badge is changed.** `books.is_first_translation` moves only through the sign-off-gated reconcile (#2933). Efforts are evidence.

The sample above also showed the misses are **not matcher failures** — the extract holds **1,230 pre-1800 imprints of 118,352 (1.04%)** against an early-modern corpus, and Sanford 1569, Hall 1654, Ellistone 1651 and Caplan's Loeb *Rhetorica ad Herennium* (zero rows) are simply absent. Matcher work is finished; the corpus is the problem. Filed as **#3522** (ESTC: free JSON API at CERL, 487,406 records, carries MARC 240 + `$l English`).

Also still open and unblocked by any of this: the badge copy itself. ~5,839 books render a first-translation claim today, 285 of them while their own effort says `inconclusive` and 15 while it says `not_searchable`.

Refs #3459, #3455, #3428, #2567.
