### PR TITLE
feat(welcome): tell readers they can edit their answers later, and build the place to do it

### DIFF
--- a/src/app/account/AccountClient.tsx
+++ b/src/app/account/AccountClient.tsx
@@ -16,10 +16,20 @@ interface AccountClientProps {
 }
 
 export default function AccountClient({ user }: AccountClientProps) {
-  const { data: session } = useSession();
+  const { data: session, update } = useSession();
   const isMember = (session?.user as any)?.membership != null;
   const [expiresAt, setExpiresAt] = useState<string | null>(null);
   const [managingBilling, setManagingBilling] = useState(false);
+
+  // Reader profile — the four things /welcome asks for. The welcome page tells
+  // readers they can change their answers here, so this editor is what makes
+  // that sentence true; don't remove one without the other.
+  const [readerName, setReaderName] = useState(user.name || '');
+  const [aboutYou, setAboutYou] = useState('');
+  const [preferredLanguage, setPreferredLanguage] = useState('');
+  const [helpDescription, setHelpDescription] = useState('');
+  const [readerLoaded, setReaderLoaded] = useState(false);
+  const [savingReader, setSavingReader] = useState(false);
 
   // Member profile editing
   const [displayName, setDisplayName] = useState('');
@@ -33,6 +43,43 @@ export default function AccountClient({ user }: AccountClientProps) {
       if (data.expiresAt) setExpiresAt(new Date(data.expiresAt).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }));
     });
   }, []);
+
+  useEffect(() => {
+    fetch('/api/me/welcome')
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (!data) return;
+        setReaderName(data.name || '');
+        setAboutYou(data.about_you || '');
+        setPreferredLanguage(data.preferred_language || '');
+        setHelpDescription(data.help_description || '');
+      })
+      .catch(() => {})
+      .finally(() => setReaderLoaded(true));
+  }, []);
+
+  const saveReaderProfile = async () => {
+    setSavingReader(true);
+    try {
+      const res = await fetch('/api/me/welcome', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: readerName.trim(),
+          about_you: aboutYou.trim(),
+          preferred_language: preferredLanguage.trim(),
+          help_description: helpDescription.trim(),
+        }),
+      });
+      if (!res.ok) throw new Error();
+      await update();
+      toast.success('Profile updated');
+    } catch {
+      toast.error('Failed to save');
+    } finally {
+      setSavingReader(false);
+    }
+  };
 
   // Load member profile
   useEffect(() => {
@@ -116,6 +163,102 @@ export default function AccountClient({ user }: AccountClientProps) {
               )}
             </div>
           </div>
+        </div>
+
+        {/* Reader profile — editable answers to the /welcome questions */}
+        <div
+          id="reader-profile"
+          className="rounded-xl p-6 mb-6 scroll-mt-24"
+          style={{ background: 'white', border: '1px solid var(--border-light)' }}
+        >
+          <h2 className="text-sm font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>
+            Reader profile
+          </h2>
+          <p className="text-sm mb-4" style={{ color: 'var(--text-muted)' }}>
+            What you told us when you joined. Change it whenever you like — every field is optional.
+          </p>
+
+          {!readerLoaded ? (
+            <p className="text-sm" style={{ color: 'var(--text-muted)' }}>Loading…</p>
+          ) : (
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="reader-name" className="block text-xs mb-1" style={{ color: 'var(--text-muted)' }}>
+                  Your name
+                </label>
+                <input
+                  id="reader-name"
+                  type="text"
+                  value={readerName}
+                  onChange={e => setReaderName(e.target.value)}
+                  autoComplete="name"
+                  maxLength={100}
+                  placeholder="Your name"
+                  className="w-full px-3 py-2 rounded-lg text-sm"
+                  style={{ background: 'var(--bg-cream)', border: '1px solid var(--border-light)', color: 'var(--text-primary)' }}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="reader-about" className="block text-xs mb-1" style={{ color: 'var(--text-muted)' }}>
+                  Who you are, and what interests you about Source Library
+                </label>
+                <textarea
+                  id="reader-about"
+                  rows={4}
+                  value={aboutYou}
+                  onChange={e => setAboutYou(e.target.value)}
+                  maxLength={4000}
+                  placeholder="Your background, the authors or traditions you're drawn to, questions you're chasing…"
+                  className="w-full px-3 py-2 rounded-lg text-sm resize-y"
+                  style={{ background: 'var(--bg-cream)', border: '1px solid var(--border-light)', color: 'var(--text-primary)' }}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="reader-language" className="block text-xs mb-1" style={{ color: 'var(--text-muted)' }}>
+                  The language you prefer to read in
+                </label>
+                <input
+                  id="reader-language"
+                  type="text"
+                  value={preferredLanguage}
+                  onChange={e => setPreferredLanguage(e.target.value)}
+                  maxLength={60}
+                  placeholder="e.g. English, Spanish, Portuguese, Chinese…"
+                  className="w-full px-3 py-2 rounded-lg text-sm"
+                  style={{ background: 'var(--bg-cream)', border: '1px solid var(--border-light)', color: 'var(--text-primary)' }}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="reader-help" className="block text-xs mb-1" style={{ color: 'var(--text-muted)' }}>
+                  How you&rsquo;d like to help, if at all
+                </label>
+                <textarea
+                  id="reader-help"
+                  rows={3}
+                  value={helpDescription}
+                  onChange={e => setHelpDescription(e.target.value)}
+                  maxLength={2000}
+                  placeholder="Reviewing translations, annotating texts, suggesting books, writing, coding, study groups — or just here to read."
+                  className="w-full px-3 py-2 rounded-lg text-sm resize-y"
+                  style={{ background: 'var(--bg-cream)', border: '1px solid var(--border-light)', color: 'var(--text-primary)' }}
+                />
+              </div>
+
+              <div className="flex justify-end">
+                <button
+                  onClick={saveReaderProfile}
+                  disabled={savingReader}
+                  className="px-4 py-1.5 rounded-lg text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
+                  style={{ background: 'var(--text-primary)', color: 'white' }}
+                >
+                  {savingReader ? 'Saving...' : 'Save'}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Membership */}

--- a/src/app/api/me/welcome/route.ts
+++ b/src/app/api/me/welcome/route.ts
@@ -4,9 +4,39 @@ import { auth, RESEND_AUDIENCE_ID } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { toUserId } from '@/lib/user-id';
 
+// GET /api/me/welcome — the same four fields back, so the reader profile editor
+// on /account can prefill them. The welcome page promises this information can be
+// changed later; without a read path that promise is only half true.
+export async function GET() {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const db = await getDb();
+    const user = await db.collection('users').findOne(
+      { _id: toUserId(session.user.id) as any },
+      { projection: { name: 1, profile: 1 } }
+    );
+
+    return NextResponse.json({
+      name: user?.name || '',
+      about_you: user?.profile?.aboutYou || '',
+      preferred_language: user?.profile?.preferredLanguage || '',
+      help_description: user?.profile?.helpDescription || '',
+    });
+  } catch (error) {
+    console.error('[welcome] read error:', error);
+    return NextResponse.json({ error: 'Failed to load' }, { status: 500 });
+  }
+}
+
 // POST /api/me/welcome — captures the first-fill of the user profile (name, who
 // they are and what draws them here, how they'd like to help) and marks the
-// welcome step done.
+// welcome step done. Also serves later edits from /account, where a field the
+// reader empties means "remove this", not "didn't answer" — which is why the
+// volunteers mirror below has to handle the all-blank case.
 //
 // Body: { name?: string, about_you?: string, help_description?: string, skip?: boolean }
 // Skipping still sets welcomedAt so the gate doesn't fire again.
@@ -98,6 +128,21 @@ export async function POST(request: NextRequest) {
           },
         } as Record<string, unknown>,
         { upsert: true }
+      );
+    } else if (!skip) {
+      // Everything cleared from the account editor. Don't create a row for a
+      // reader who never volunteered anything, but do clear one that exists —
+      // otherwise the outreach list keeps quoting prose they deleted.
+      await db.collection('volunteers').updateOne(
+        { email },
+        {
+          $set: {
+            about_you: '',
+            help_description: '',
+            preferred_language: '',
+            updated_at: now,
+          },
+        }
       );
     }
 

--- a/src/components/welcome/WelcomeForm.tsx
+++ b/src/components/welcome/WelcomeForm.tsx
@@ -19,7 +19,7 @@ function arrivalSource(): 'gate' | 'direct' {
 
 export default function WelcomeForm({ initialName = '' }: { initialName?: string }) {
   const router = useRouter();
-  const { update } = useSession();
+  const { data: session, update } = useSession();
   // Google sign-ins arrive with a name; magic-link sign-ins never do, and this
   // is the only place we ever ask. Prefill so Google users aren't retyping it.
   const [name, setName] = useState(initialName);
@@ -78,6 +78,17 @@ export default function WelcomeForm({ initialName = '' }: { initialName?: string
       help_description: trimmed.help,
     });
   };
+
+  // Mirrors UserMenu's avatar so the glyph in the pointer below matches the one
+  // the reader will actually look for. Derived from the live name field, so it
+  // tracks what they type.
+  const initials =
+    name
+      .split(' ')
+      .map(part => part[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2) || session?.user?.email?.[0]?.toUpperCase() || '?';
 
   const handleSkip = () => {
     trackEvent('welcome_skip', { source: arrivalSource() });
@@ -165,6 +176,24 @@ export default function WelcomeForm({ initialName = '' }: { initialName?: string
           className="w-full px-3 py-2.5 border border-stone-300 rounded-lg text-stone-900 text-base focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust resize-y"
         />
       </div>
+
+      {/* Nothing here is a one-shot. Skipping in particular reads as "this
+          question is now closed", which is why the pointer names the exact
+          control rather than just saying "later in your account" — the avatar
+          in the top right is on every page, including this one. Editor lives at
+          /account#reader-profile; if that card moves, fix this sentence too. */}
+      <p className="text-sm text-stone-500 border-t border-stone-200 pt-5 flex items-start gap-2">
+        <span
+          aria-hidden="true"
+          className="mt-0.5 shrink-0 w-5 h-5 rounded-full border-2 border-stone-300 bg-stone-100 flex items-center justify-center text-[9px] font-medium text-stone-500"
+        >
+          {initials}
+        </span>
+        <span>
+          You can add to or change all of this later on your reader profile — open this menu at the
+          top right of any page and choose <span className="text-stone-700 font-medium">Account</span>.
+        </span>
+      </p>
 
       <div className="flex items-center justify-between pt-1">
         <button


### PR DESCRIPTION
`/welcome?from=/book/...` asks four questions and then disappears. Nothing told the reader the answers were revisable — and they weren't: `/account` had no editor for name, about-you, preferred reading language, or how they'd like to help. Only *members* got a profile editor there, and it edits a different thing (the members-page display name and bio).

So this does both halves. Pointing at a control that doesn't exist would have been the worse failure.

**In scope**

- **`/account` — new "Reader profile" card**, above Membership, for every signed-in user. Prefilled with the four welcome answers, saveable, anchored at `#reader-profile`.
- **`GET /api/me/welcome`** so the card can prefill. The POST already handled writes and is reused unchanged for edits.
- **volunteers mirror clears on empty.** POST only mirrored into `volunteers` when at least one field was non-empty, which was right for a first fill and wrong for an edit — a reader who deleted their prose would still have it quoted in the outreach list. Now an all-blank save clears an existing row (no upsert, so a reader who never volunteered still doesn't get one).
- **Welcome form pointer**, above the buttons: a small circle glyph carrying the reader's initials — mirroring `UserMenu`'s avatar so they're looking for the right thing — then "You can add to or change all of this later on your reader profile — open this menu at the top right of any page and choose Account." Placed above the button row so it's read before *Skip for now*, which is the population that most needs to know the question stays open.

**Out of scope**

- The pointer is text, not a link. A link out of a half-filled form loses the input; the reader isn't going anywhere yet, they just need to know where it lives.
- Not merged with the members-page profile card. They edit different collections (`users.profile` vs the membership profile) and one is member-only. Unifying them is a real design question, not a side effect of this.

**Verification**

`npx tsc --noEmit` clean. The rest needs the preview: sign in, `/welcome` for the pointer, `/account#reader-profile` to load / edit / save, and a re-load to confirm the values persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)