### PR TITLE
fix(welcome): saving the welcome form left readers unable to leave /welcome

### DIFF
--- a/src/components/auth/WelcomeGate.tsx
+++ b/src/components/auth/WelcomeGate.tsx
@@ -3,16 +3,35 @@
 import { useEffect, useRef } from 'react';
 import { useSession } from 'next-auth/react';
 import { usePathname, useRouter } from 'next/navigation';
+import { shouldFireWelcomeGate } from '@/lib/welcome-gate';
 
-// Paths where the welcome gate should not fire (auth flow itself, the welcome page,
-// API routes, embed/tenant subdomains where we don't own the chrome).
-const SKIP_PATH_PREFIXES = [
-  '/welcome',
-  '/auth/',
-  '/api/',
-  '/admin',
-  '/embed/',
-];
+// The gate interrupts a reader once per tab and never again.
+//
+// Why that matters: `redirected` below only guards a single mount, which is no
+// guard at all, because every firing of the gate is a navigation and every
+// navigation remounts. So when the session's needsWelcome flag went stale-true
+// (see the update() note in WelcomeForm), saving the form returned the reader to
+// their page and the freshly-mounted gate sent them straight back to /welcome — on
+// every page, until the token expired 30 days later. 36 readers were locked out
+// that way on 2026-07-29/30. This flag is the structural fix: whatever else goes
+// wrong upstream, the reader loses one navigation, not the site.
+const GATE_FIRED_KEY = 'sl_welcome_gate_fired';
+
+function alreadyFired(): boolean {
+  try {
+    return window.sessionStorage.getItem(GATE_FIRED_KEY) === '1';
+  } catch {
+    return false; // Safari private mode and friends — degrade to the old behaviour
+  }
+}
+
+function markFired(): void {
+  try {
+    window.sessionStorage.setItem(GATE_FIRED_KEY, '1');
+  } catch {
+    /* non-fatal */
+  }
+}
 
 export default function WelcomeGate() {
   const { data: session, status } = useSession();
@@ -21,23 +40,21 @@ export default function WelcomeGate() {
   const redirected = useRef(false);
 
   useEffect(() => {
-    if (status !== 'authenticated') return;
     if (redirected.current) return;
-    if (!pathname) return;
-    const needs = (session?.user as { needsWelcome?: boolean } | undefined)?.needsWelcome === true;
-    if (!needs) return;
-    if (SKIP_PATH_PREFIXES.some(p => pathname.startsWith(p))) return;
+    if (typeof window === 'undefined') return;
 
-    // Only fire on apex/sourcelibrary host — tenant subdomains have their own chrome.
-    if (typeof window !== 'undefined') {
-      const host = window.location.hostname;
-      // Match sourcelibrary.org, www.sourcelibrary.org, localhost. Skip tenant subdomains.
-      const isApex = host === 'sourcelibrary.org' || host === 'www.sourcelibrary.org' || host.startsWith('localhost') || host.endsWith('.vercel.app');
-      if (!isApex) return;
-    }
+    const fire = shouldFireWelcomeGate({
+      status,
+      needsWelcome: (session?.user as { needsWelcome?: boolean } | undefined)?.needsWelcome === true,
+      pathname,
+      hostname: window.location.hostname,
+      alreadyFired: alreadyFired(),
+    });
+    if (!fire) return;
 
     redirected.current = true;
-    router.push(`/welcome?from=${encodeURIComponent(pathname)}`);
+    markFired();
+    router.push(`/welcome?from=${encodeURIComponent(pathname!)}`);
   }, [status, session, pathname, router]);
 
   return null;

--- a/src/components/welcome/WelcomeForm.tsx
+++ b/src/components/welcome/WelcomeForm.tsx
@@ -47,7 +47,14 @@ export default function WelcomeForm({ initialName = '' }: { initialName?: string
         body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error();
-      await update();
+      // MUST pass a payload. `update()` with no argument issues a GET to
+      // /api/auth/session (next-auth/react's update() only builds a body when
+      // called with data, and lib/client.js only sets method:'POST' when a body
+      // exists). A GET does not run the jwt callback with trigger:'update', so
+      // the token kept needsWelcome:true even though welcomedAt had just been
+      // written — and WelcomeGate bounced the reader straight back to this form,
+      // forever. 36 readers were locked out of the site that way on 2026-07-29/30.
+      await update({ welcomed: true });
       // Back to whatever they were reading when the gate interrupted them.
       const from = typeof window !== 'undefined'
         ? new URLSearchParams(window.location.search).get('from')

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -468,6 +468,15 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }
       }
 
+      // The welcome form has just saved and says so explicitly. The DB read
+      // above already reaches the same conclusion when it succeeds — this is the
+      // fallback for when it doesn't, because the cost of a stale true here is
+      // not a missing badge but a reader who cannot leave /welcome. Outside the
+      // try/catch on purpose: a failed lookup must not be able to re-trap them.
+      if (trigger === 'update' && (session as any)?.welcomed === true) {
+        (token as any).needsWelcome = false;
+      }
+
       // Phase 1: resolve tenant-scoped role when the client triggers a session update
       // with { _pendingTenantSlug }. Called from [tenant]/layout.tsx after sign-in.
       const pendingTenantSlug =

--- a/src/lib/welcome-gate.ts
+++ b/src/lib/welcome-gate.ts
@@ -1,0 +1,59 @@
+/**
+ * Should the welcome interstitial interrupt this page view?
+ *
+ * Extracted from WelcomeGate so the decision can be tested. The component around
+ * it is three hooks and a `router.push`; every rule that could lock a reader out
+ * of the site lives here, where a test can reach it.
+ */
+
+// Paths where the gate must not fire (the auth flow itself, the welcome page, API
+// routes, embed/tenant surfaces where we don't own the chrome).
+export const SKIP_PATH_PREFIXES = [
+  '/welcome',
+  '/auth/',
+  '/api/',
+  '/admin',
+  '/embed/',
+];
+
+// Only the apex site. Tenant subdomains render a partner's reading room and have
+// their own chrome — see the tenant lockdown rules in CLAUDE.md.
+export function isApexHost(hostname: string): boolean {
+  return (
+    hostname === 'sourcelibrary.org' ||
+    hostname === 'www.sourcelibrary.org' ||
+    hostname.startsWith('localhost') ||
+    hostname.endsWith('.vercel.app')
+  );
+}
+
+export interface WelcomeGateInput {
+  /** next-auth session status. */
+  status: string;
+  /** session.user.needsWelcome — may be STALE; see alreadyFired. */
+  needsWelcome: boolean;
+  pathname: string | null;
+  hostname: string;
+  /**
+   * Has the gate already interrupted this reader in this tab?
+   *
+   * This is the rule that turns a stale `needsWelcome` from a lockout into a
+   * single wasted navigation. It has to be here rather than in a mount-scoped
+   * ref, because every firing of the gate is a navigation and every navigation
+   * remounts the component.
+   */
+  alreadyFired: boolean;
+}
+
+export function shouldFireWelcomeGate(input: WelcomeGateInput): boolean {
+  const { status, needsWelcome, pathname, hostname, alreadyFired } = input;
+
+  if (status !== 'authenticated') return false;
+  if (!needsWelcome) return false;
+  if (!pathname) return false;
+  if (alreadyFired) return false;
+  if (SKIP_PATH_PREFIXES.some(p => pathname.startsWith(p))) return false;
+  if (!isApexHost(hostname)) return false;
+
+  return true;
+}

--- a/tests/unit/welcome-gate.test.ts
+++ b/tests/unit/welcome-gate.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { shouldFireWelcomeGate, isApexHost } from '../../src/lib/welcome-gate';
+
+const base = {
+  status: 'authenticated',
+  needsWelcome: true,
+  pathname: '/collections',
+  hostname: 'sourcelibrary.org',
+  alreadyFired: false,
+};
+
+describe('shouldFireWelcomeGate', () => {
+  it('interrupts a gated reader on an ordinary page', () => {
+    expect(shouldFireWelcomeGate(base)).toBe(true);
+  });
+
+  // The lockout. A reader saves the form, the session's needsWelcome flag stays
+  // stale-true, they land back on their page — and before this rule the gate sent
+  // them to /welcome again, forever, on every page.
+  it('never interrupts twice, even while needsWelcome is still true', () => {
+    expect(shouldFireWelcomeGate({ ...base, alreadyFired: true })).toBe(false);
+  });
+
+  it('does not interrupt a reader who has already been welcomed', () => {
+    expect(shouldFireWelcomeGate({ ...base, needsWelcome: false })).toBe(false);
+  });
+
+  it('does not interrupt an unauthenticated visitor', () => {
+    expect(shouldFireWelcomeGate({ ...base, status: 'loading' })).toBe(false);
+    expect(shouldFireWelcomeGate({ ...base, status: 'unauthenticated' })).toBe(false);
+  });
+
+  it('does not interrupt the welcome page itself (that would be its own loop)', () => {
+    expect(shouldFireWelcomeGate({ ...base, pathname: '/welcome' })).toBe(false);
+    expect(shouldFireWelcomeGate({ ...base, pathname: '/welcome?from=%2F' })).toBe(false);
+  });
+
+  it('stays out of the auth flow, the API, admin, and embed surfaces', () => {
+    for (const pathname of ['/auth/signin', '/api/me/welcome', '/admin/users', '/embed/bph']) {
+      expect(shouldFireWelcomeGate({ ...base, pathname })).toBe(false);
+    }
+  });
+
+  it('never fires on a tenant subdomain', () => {
+    expect(shouldFireWelcomeGate({ ...base, hostname: 'bph.sourcelibrary.org' })).toBe(false);
+    expect(isApexHost('bph.sourcelibrary.org')).toBe(false);
+    expect(isApexHost('sourcelibrary.org')).toBe(true);
+    expect(isApexHost('www.sourcelibrary.org')).toBe(true);
+  });
+
+  it('tolerates a null pathname', () => {
+    expect(shouldFireWelcomeGate({ ...base, pathname: null })).toBe(false);
+  });
+});
+
+describe('WelcomeForm session refresh', () => {
+  // A source assertion, deliberately, and only because deletion IS the failure
+  // mode here (see the "a test that greps source is not a guard" rule in
+  // CLAUDE.md). next-auth's update() sends a GET when called with no argument —
+  // lib/client.js only sets method:'POST' when a body is present — and a GET does
+  // not run the jwt callback with trigger:'update', so the token keeps
+  // needsWelcome:true and the reader is bounced back to the form. The behavioural
+  // consequence is covered above; this pins the one-character regression that
+  // reintroduces it, which no test in a node environment can otherwise reach.
+  it('calls update() with a payload so the token is actually re-minted', () => {
+    const src = readFileSync(
+      join(__dirname, '../../src/components/welcome/WelcomeForm.tsx'),
+      'utf8'
+    );
+    expect(src).toContain('update({ welcomed: true })');
+    // The prose above this call mentions `update()` by name, so match the call
+    // site rather than the bare token.
+    expect(src).not.toMatch(/await\s+update\(\s*\)/);
+  });
+});


### PR DESCRIPTION
Reported as "`/welcome` → 404 → infinite loop." Reproduced on production, signed in as a gated reader: `POST /api/me/welcome` returns **200**, `welcomedAt` is written, and the reader lands back on the welcome form. Every page they visit afterwards bounces there too.

**36 readers hit this on 2026-07-29 and 07-30** — every user who has saved since the gate started firing for real (#3448) — and **3,847** more are gated behind it. For those 36 the site is currently unusable: the gate fires on every path, so they cannot read anything.

## Root cause — one missing argument

`WelcomeForm` called `await update()`. In `next-auth/react`, `update(data)` only builds a request body when called *with* data, and `lib/client.js` only sets `method: 'POST'` when a body exists — so the call was a **GET**. A GET to `/api/auth/session` does not run the `jwt` callback with `trigger: 'update'`, and the callback's DB re-read is gated on `(user || trigger === 'update')`. The token therefore kept `needsWelcome: true` for its full 30-day life, no matter what the database said.

`WelcomeGate` then re-fired on the page the form returned them to, pushed them back to `/welcome`, and repeated.

Verified directly: `welcomedAt = 2026-07-30T08:30:32Z` in Mongo, while `/api/auth/session` still served `needsWelcome: true` forty minutes and several saves later.

## Fixes

1. **`WelcomeForm` passes a payload** — `update({ welcomed: true })` — which makes it a POST and re-mints the token.
2. **The `jwt` callback honours that payload**, placed *outside* the try/catch, so a failed user lookup cannot re-trap a reader who has just saved.
3. **`WelcomeGate` fires at most once per tab** (`sessionStorage`). Its old `redirected` ref was mount-scoped and therefore no guard at all — every firing of the gate is a navigation and every navigation remounts. This is the structural fix: a stale flag now costs one wasted navigation instead of the whole site, and it **self-heals the 36 readers whose tokens stay stale for up to 30 days**, which nothing server-side can force-refresh.

The gate decision moves into `src/lib/welcome-gate.ts` so it is reachable by a test; `tests/unit/welcome-gate.test.ts` asserts the lockout case (`needsWelcome` still true + already fired → does not fire) plus the skip-path and tenant-host rules. One source assertion pins the `update()` argument, with a comment explaining why deletion genuinely is the failure mode there.

## Not in scope

The 404 in the original report is a **separate** matter and not caused by the gate: `/book/6810f4e60b70c1a5b48ba3f8` is in neither `books` nor `deleted_books`, so that `?from=` target pointed at a book that does not exist. The gate faithfully returned the reader to a dead URL and the loop took over from the 404 page. Whether the gate should validate its return target is a real question, filed separately rather than bundled here.

## Verification

`npx tsc --noEmit` clean; 9/9 new tests pass. Needs a signed-in gated account on the preview to confirm end-to-end: save the form and land on the `?from=` page, then navigate freely without being pulled back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)