### PR TITLE
fix(tenant): give partner-subdomain visitors a way to sign in (#3468)

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import { BookMarked, ExternalLink, BookOpen, Pencil, Search } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { getReadDb, getDb } from '@/lib/mongodb';
@@ -6,6 +7,7 @@ import { getReadDb, getDb } from '@/lib/mongodb';
 import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
 import { isPublishedFirstTranslation } from '@/lib/book';
 import { getPartnerBySlug } from '@/lib/library-partners';
+import { buildSignInHref } from '@/lib/tenant-signin-url';
 import { auth } from '@/lib/auth';
 import { ROLE_LEVEL, type Role } from '@/lib/auth';
 import type { BphContributor } from '@/lib/bph-catalog';
@@ -382,6 +384,20 @@ export default async function CatalogEntryPage({ params }: Props) {
       />
     );
   }
+
+  // Sign-in link for signed-out visitors. Built from the REQUEST host, never
+  // from the public pathname: the proxy rewrites bph.sourcelibrary.org/catalog/X
+  // to /embed/bph/catalog/X internally, so the path we render under is not the
+  // one the visitor's browser shows. Sending them back to the internal path
+  // would strand them on a URL the tenant host doesn't serve. (Gating on
+  // usePathname() is the same mistake that broke #3383.)
+  const requestHeaders = await headers();
+  const requestHost = requestHeaders.get('host') || '';
+  const publicPath = `/catalog/${encodeURIComponent(work.ubn)}`;
+  const signInHref = buildSignInHref(
+    requestHost,
+    requestHost ? `https://${requestHost}${publicPath}` : publicPath
+  );
 
   const platformRole = normalizeRoleSafe((session?.user as { role?: unknown } | undefined)?.role);
   const role = await effectiveCatalogRole(session?.user?.email, platformRole, tenant);
@@ -790,6 +806,21 @@ export default async function CatalogEntryPage({ params }: Props) {
                 {ROLE_LEVEL[role] >= ROLE_LEVEL['editor'] ? 'Edit this entry' : 'Propose a change'}
               </a>
               .
+            </>
+          ) : null}
+          {/* Cataloguers arrive here signed out and, with the SiteHeader
+              stripped on tenant hosts, previously had nothing to click —
+              the record simply rendered read-only with no hint that editing
+              existed or that they needed a session (#3468). The gear menu
+              carries a Sign in item too, but nobody looking to catalogue
+              thinks to open a settings icon. */}
+          {!session ? (
+            <>
+              {' '}
+              <a href={signInHref} className="text-accent-rust hover:underline">
+                Sign in to edit
+              </a>
+              {' — for BPH cataloguers.'}
             </>
           ) : null}
         </p>

--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -3,7 +3,8 @@
 import { signOut } from 'next-auth/react';
 import { useStableSession } from '@/hooks/useStableSession';
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { Settings, Search, X } from 'lucide-react';
+import { Settings, Search, X, LogIn } from 'lucide-react';
+import { buildSignInHref, isTenantSubdomain } from '@/lib/tenant-signin-url';
 
 // On tenant subdomains, /auth/* and /account are caught by the proxy.ts
 // rewrite (it sends every non-/embed/, non-/api/, non-/_next/ path to
@@ -11,9 +12,6 @@ import { Settings, Search, X } from 'lucide-react';
 // from the user's POV "nothing happens". Route those off to the main
 // host instead. Cookies are shared on .sourcelibrary.org so the session
 // carries back (see CLAUDE.md "Authentication across subdomains").
-function isTenantSubdomain(host: string): boolean {
-  return host.endsWith('.sourcelibrary.org') && host !== 'sourcelibrary.org';
-}
 
 function navigateToAccount() {
   if (typeof window === 'undefined') return;
@@ -22,6 +20,18 @@ function navigateToAccount() {
   } else {
     window.location.assign('/account');
   }
+}
+
+// Sign-in has no route on a tenant host, so this crosses to the apex and
+// carries a callbackUrl back to the exact page the visitor was reading.
+// The return hop is only permitted because auth.ts allows cross-subdomain
+// redirects (src/lib/auth-redirect.ts) — without that half, NextAuth drops
+// them on the main site instead.
+function navigateToSignIn() {
+  if (typeof window === 'undefined') return;
+  window.location.assign(
+    buildSignInHref(window.location.hostname, window.location.href)
+  );
 }
 
 /**
@@ -34,12 +44,20 @@ function navigateToAccount() {
  *    (BPH) who finds the default presentation off-putting for scholarly use:
  *    "Default with bells and whistles, possible to chose without".
  *
- * 2. Auth — avatar + Account/Sign out for authenticated visitors. No sign-in
- *    affordance is shown to anonymous visitors in the embed (the partner
- *    reading room is a closed, sign-in-free surface). The main SiteHeader is
- *    stripped on embed routes so partner subdomains (bph.sourcelibrary.org, …)
- *    look like the partner's own site; this control is the only sign-out
- *    affordance for those already signed in.
+ * 2. Auth — avatar + Account/Sign out for authenticated visitors, and a
+ *    Sign in item for anonymous ones. The main SiteHeader is stripped on
+ *    embed routes so partner subdomains (bph.sourcelibrary.org, …) look like
+ *    the partner's own site; this control is therefore the ONLY way in or
+ *    out of a session on those hosts.
+ *
+ *    The reading room used to show anonymous visitors no sign-in affordance
+ *    at all, on the reasoning that a partner reading room is a closed,
+ *    sign-in-free surface. That is right for readers and wrong for the BPH's
+ *    cataloguers, whose whole job lives on that subdomain: with no entry
+ *    point they simply could not get in, and reported it as "I cannot find
+ *    where to sign in" (#3468). Sign-in lives inside the dropdown rather
+ *    than on the trigger button, so readers still see an unadorned reading
+ *    room and only someone looking for an account finds one.
  *
  * Cookies are scoped to the current host (no Domain attr) so each subdomain
  * keeps independent preferences — a scholar can run BPH in scholar mode
@@ -238,7 +256,7 @@ export default function EmbedUserMenu() {
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center justify-center w-9 h-9 rounded-full bg-white/90 backdrop-blur-sm border border-border-light shadow-sm cursor-pointer hover:bg-white transition-colors"
-        aria-label={session ? 'Account & view options' : 'View options'}
+        aria-label={session ? 'Account & view options' : 'Sign in & view options'}
       >
         {session ? (
           session.user?.image && !imgError ? (
@@ -285,9 +303,24 @@ export default function EmbedUserMenu() {
             </label>
           </div>
 
-          {/* Signed-in users keep Account + Sign out. Anonymous visitors are
-              shown no sign-in affordance in the embed — the menu is just the
-              view options for them. */}
+          {/* Anonymous visitors get a way in. This is the only one on a
+              partner subdomain — the SiteHeader is stripped there — so
+              removing it strands the BPH cataloguers (#3468). */}
+          {!session && (
+            <button
+              type="button"
+              onClick={() => {
+                setIsOpen(false);
+                navigateToSignIn();
+              }}
+              className="flex items-center gap-2 w-full text-left px-3 py-2 text-sm text-secondary hover:bg-cream/60"
+            >
+              <LogIn className="w-4 h-4 shrink-0" aria-hidden="true" />
+              Sign in
+            </button>
+          )}
+
+          {/* Signed-in users keep Account + Sign out. */}
           {session && (
             <>
               <div className="px-3 py-2 border-b border-border-light/60">

--- a/src/lib/auth-redirect.ts
+++ b/src/lib/auth-redirect.ts
@@ -1,0 +1,64 @@
+/**
+ * Post-sign-in redirect resolution for NextAuth.
+ *
+ * Sign-in lives only on the apex (`sourcelibrary.org/auth/signin`). Partner
+ * reading rooms — bph.sourcelibrary.org and the tenants that follow — have no
+ * sign-in page of their own, so a cataloguer signing in from a tenant
+ * subdomain has to be sent back across an origin boundary afterwards.
+ *
+ * NextAuth's default `redirect` callback allows only relative URLs and URLs
+ * whose origin equals `baseUrl`; anything else silently falls back to
+ * `baseUrl`. That drops BPH editors on the main site after sign-in with no
+ * explanation, which is indistinguishable from "signing in didn't work"
+ * (#3468 — it cost a BPH librarian an hour before she wrote in).
+ *
+ * The session cookie is already shared across `.sourcelibrary.org` (see the
+ * cookies block in `auth.ts`), so the session genuinely does carry to the
+ * subdomain. Only the redirect was blocking the return trip.
+ *
+ * This module is deliberately dependency-free so it can be unit-tested
+ * without pulling in the Mongo adapter that `auth.ts` imports.
+ */
+
+const APEX = 'sourcelibrary.org';
+
+/**
+ * Is this a Source Library host we're willing to hand a session back to?
+ *
+ * Exact-match the apex, or require a literal `.` before it, so lookalikes
+ * fail closed:
+ *   - `evilsourcelibrary.org`      → false (no dot separator)
+ *   - `sourcelibrary.org.evil.com` → false (doesn't end with the apex)
+ *   - `https://sourcelibrary.org@evil.com` → false (URL parses host as evil.com)
+ *
+ * HTTPS only: an http:// target would strip the `__Secure-` cookie's
+ * protection and is never a real destination in production.
+ */
+export function isSourceLibraryHost(url: URL): boolean {
+  if (url.protocol !== 'https:') return false;
+  return url.hostname === APEX || url.hostname.endsWith(`.${APEX}`);
+}
+
+/**
+ * Resolve where to send someone after they sign in.
+ *
+ * Order matters: relative paths resolve against `baseUrl` (NextAuth's own
+ * behaviour), then same-origin absolutes pass through, then — the part we
+ * add — any other `*.sourcelibrary.org` host. Everything else, including
+ * anything unparseable, falls back to `baseUrl` rather than throwing, so a
+ * malformed callbackUrl degrades to "you land on the homepage signed in"
+ * instead of a 500 on the auth callback.
+ */
+export function resolvePostSignInRedirect(url: string, baseUrl: string): string {
+  if (url.startsWith('/')) return `${baseUrl}${url}`;
+
+  try {
+    const target = new URL(url);
+    if (target.origin === baseUrl) return url;
+    if (isSourceLibraryHost(target)) return target.toString();
+  } catch {
+    // Not a URL at all — fall through.
+  }
+
+  return baseUrl;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,7 @@ import clientPromise from './mongodb-client';
 import { Resend } from 'resend';
 import { activatePendingMembership } from './memberships';
 import { recordAuthEvent } from './auth-events';
+import { resolvePostSignInRedirect } from './auth-redirect';
 
 const dbName = process.env.MONGODB_DB || 'bookstore';
 
@@ -321,6 +322,14 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
   },
   callbacks: {
+    // Send people back where they started, including across the subdomain
+    // boundary. Sign-in exists only on the apex, so a BPH cataloguer signing
+    // in from bph.sourcelibrary.org needs a cross-origin return trip that
+    // NextAuth's default callback refuses. Restricted to *.sourcelibrary.org
+    // over https — see src/lib/auth-redirect.ts for the allowlist rationale.
+    async redirect({ url, baseUrl }) {
+      return resolvePostSignInRedirect(url, baseUrl);
+    },
     // Enforce signup restrictions based on tenant allowSignup setting
     async signIn({ user, account }) {
       if (!user?.email) return true;

--- a/src/lib/tenant-signin-url.ts
+++ b/src/lib/tenant-signin-url.ts
@@ -1,0 +1,56 @@
+/**
+ * Where does a visitor on a partner subdomain go to sign in?
+ *
+ * Not to their own host. Tenant subdomains have no `/auth/*` routes of their
+ * own — `proxy.ts` rewrites every non-`/embed/`, non-`/api/`, non-`/_next/`
+ * path to `/embed/<tenant>`, so a relative `/auth/signin` link lands silently
+ * on the tenant homepage and reads as "nothing happened" (the same trap
+ * `navigateToAccount` was written for in #1953).
+ *
+ * So the link has to point at the apex, carrying a `callbackUrl` that brings
+ * the visitor back to the tenant page they started on. That return trip needs
+ * `resolvePostSignInRedirect` in `auth-redirect.ts` to permit it — NextAuth's
+ * default callback rejects cross-origin returns. Both halves are required;
+ * either one alone leaves the visitor on the wrong site (#3468).
+ *
+ * Shared by the client menu (`EmbedUserMenu`) and the server-rendered
+ * catalogue record page so the two can't drift apart.
+ */
+
+const APEX_ORIGIN = 'https://sourcelibrary.org';
+
+/**
+ * A tenant subdomain is any `*.sourcelibrary.org` host that isn't the apex.
+ * Vercel previews (`*.vercel.app`) and localhost are deliberately excluded —
+ * they're not tenant hosts, and there the relative link works fine.
+ */
+export function isTenantSubdomain(host: string): boolean {
+  return host.endsWith('.sourcelibrary.org') && host !== 'sourcelibrary.org';
+}
+
+/**
+ * Build the sign-in href for a visitor currently at `currentUrl` on `host`.
+ *
+ * On a tenant subdomain this is an absolute apex URL with an absolute
+ * callback. Anywhere else it stays relative, so previews and localhost keep
+ * working without a hardcoded production origin.
+ */
+export function buildSignInHref(host: string, currentUrl: string): string {
+  if (isTenantSubdomain(host)) {
+    return `${APEX_ORIGIN}/auth/signin?callbackUrl=${encodeURIComponent(currentUrl)}`;
+  }
+
+  // Relative callback for same-host sign-in: keep the path and query, drop
+  // the origin, so this behaves identically on preview and local hosts.
+  let relative = '/';
+  try {
+    const parsed = new URL(currentUrl);
+    relative = `${parsed.pathname}${parsed.search}`;
+  } catch {
+    // currentUrl wasn't absolute — treat it as already-relative if it looks
+    // like a path, otherwise fall back to the homepage.
+    if (currentUrl.startsWith('/')) relative = currentUrl;
+  }
+
+  return `/auth/signin?callbackUrl=${encodeURIComponent(relative)}`;
+}

--- a/tests/unit/tenant-signin.test.ts
+++ b/tests/unit/tenant-signin.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { buildSignInHref, isTenantSubdomain } from '@/lib/tenant-signin-url';
+import { resolvePostSignInRedirect, isSourceLibraryHost } from '@/lib/auth-redirect';
+
+/**
+ * Sign-in from a partner subdomain (#3468).
+ *
+ * These call the real functions rather than asserting that some string appears
+ * in a source file. Per CLAUDE.md ("A test that greps source is not a guard"),
+ * the question to ask of each case is: what code change makes it fail?
+ * Here, breaking either half of the round trip does — which is the point,
+ * because the two halves live in different files and each looks harmless to
+ * delete on its own.
+ */
+
+describe('isTenantSubdomain', () => {
+  it('recognises partner subdomains', () => {
+    expect(isTenantSubdomain('bph.sourcelibrary.org')).toBe(true);
+    expect(isTenantSubdomain('kloss-collection.sourcelibrary.org')).toBe(true);
+  });
+
+  it('excludes the apex, previews and localhost', () => {
+    expect(isTenantSubdomain('sourcelibrary.org')).toBe(false);
+    expect(isTenantSubdomain('sourcelibrary-v2-git-foo.vercel.app')).toBe(false);
+    expect(isTenantSubdomain('localhost:3000')).toBe(false);
+  });
+});
+
+describe('buildSignInHref', () => {
+  it('sends a BPH visitor to the apex and brings them back to the exact page', () => {
+    const href = buildSignInHref(
+      'bph.sourcelibrary.org',
+      'https://bph.sourcelibrary.org/catalog/BPH%20151'
+    );
+
+    const url = new URL(href);
+    expect(url.origin).toBe('https://sourcelibrary.org');
+    expect(url.pathname).toBe('/auth/signin');
+    // The whole point: the callback must return to the TENANT host, not the apex.
+    expect(url.searchParams.get('callbackUrl')).toBe(
+      'https://bph.sourcelibrary.org/catalog/BPH%20151'
+    );
+  });
+
+  it('never emits a relative sign-in link on a tenant host', () => {
+    // A relative /auth/signin is swallowed by the proxy rewrite and lands on
+    // the tenant homepage — "nothing happens", which is the original bug.
+    const href = buildSignInHref('bph.sourcelibrary.org', 'https://bph.sourcelibrary.org/');
+    expect(href.startsWith('https://sourcelibrary.org/')).toBe(true);
+  });
+
+  it('stays relative off-tenant so previews and localhost work', () => {
+    expect(
+      buildSignInHref('sourcelibrary.org', 'https://sourcelibrary.org/catalog/X?a=1')
+    ).toBe('/auth/signin?callbackUrl=%2Fcatalog%2FX%3Fa%3D1');
+
+    expect(
+      buildSignInHref('localhost:3000', 'http://localhost:3000/catalog/X')
+    ).toBe('/auth/signin?callbackUrl=%2Fcatalog%2FX');
+  });
+
+  it('degrades to the homepage rather than throwing on a junk current URL', () => {
+    expect(buildSignInHref('sourcelibrary.org', 'not a url')).toBe(
+      '/auth/signin?callbackUrl=%2F'
+    );
+  });
+});
+
+describe('resolvePostSignInRedirect', () => {
+  const baseUrl = 'https://sourcelibrary.org';
+
+  it('permits the return trip to a tenant subdomain', () => {
+    // Without this, NextAuth's default callback drops the cataloguer on the
+    // apex after sign-in and it reads as "signing in did not work".
+    expect(
+      resolvePostSignInRedirect('https://bph.sourcelibrary.org/catalog/BPH%20151', baseUrl)
+    ).toBe('https://bph.sourcelibrary.org/catalog/BPH%20151');
+  });
+
+  it('keeps NextAuth default behaviour for relative and same-origin URLs', () => {
+    expect(resolvePostSignInRedirect('/account', baseUrl)).toBe(
+      'https://sourcelibrary.org/account'
+    );
+    expect(resolvePostSignInRedirect('https://sourcelibrary.org/x', baseUrl)).toBe(
+      'https://sourcelibrary.org/x'
+    );
+  });
+
+  it('is not an open redirect', () => {
+    for (const hostile of [
+      'https://evil.com/phish',
+      'https://evilsourcelibrary.org/phish',        // no dot separator
+      'https://sourcelibrary.org.evil.com/phish',   // apex as a prefix
+      'https://bph.sourcelibrary.org.evil.com/x',   // subdomain as a prefix
+      'https://sourcelibrary.org@evil.com/phish',   // userinfo trick
+      'http://bph.sourcelibrary.org/x',             // downgraded to http
+      'javascript:alert(1)',
+      'garbage',
+    ]) {
+      expect(resolvePostSignInRedirect(hostile, baseUrl), hostile).toBe(baseUrl);
+    }
+  });
+});
+
+describe('isSourceLibraryHost', () => {
+  it('requires https and a real dot-separated subdomain', () => {
+    expect(isSourceLibraryHost(new URL('https://bph.sourcelibrary.org/'))).toBe(true);
+    expect(isSourceLibraryHost(new URL('https://sourcelibrary.org/'))).toBe(true);
+    expect(isSourceLibraryHost(new URL('http://bph.sourcelibrary.org/'))).toBe(false);
+    expect(isSourceLibraryHost(new URL('https://notsourcelibrary.org/'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3468.

A BPH librarian could not find where to sign in on `bph.sourcelibrary.org`, because there is nothing to find. `EmbedUserMenu` deliberately renders no sign-in affordance for anonymous visitors — the partner reading room was built as a closed, sign-in-free surface. That is right for readers and wrong for the BPH's three cataloguers, whose entire job lives on that subdomain.

## In scope

**Two halves, and either one alone leaves the visitor on the wrong site.**

1. **`src/lib/auth-redirect.ts` + a `redirect` callback in `auth.ts`.** NextAuth v5's default callback permits only relative and same-origin URLs; anything else silently falls back to `baseUrl`. So even a correct sign-in link would have returned the cataloguer to the apex, which is indistinguishable from "it didn't work". Allowlist is `https:` plus `sourcelibrary.org` and its subdomains, exact-or-dot-suffixed. The session cookie was already shared on `.sourcelibrary.org` — only the redirect was blocking.

2. **The affordances.** `EmbedUserMenu` gains a *Sign in* item for anonymous visitors, and the catalogue record page renders a visible "Sign in to edit — for BPH cataloguers" line where the Edit link sits for editors. Deliberately asymmetric: the menu item stays inside the dropdown so readers keep an unadorned reading room, while the catalogue line is visible because nobody looking to catalogue thinks to open a settings gear.

The sign-in URL is built from the **request host**, never the pathname. The proxy rewrites `bph.sourcelibrary.org/catalog/X` to `/embed/bph/catalog/X` internally, so the rendered path is not the one the browser shows; returning someone to the internal path would strand them on a URL the tenant host does not serve. Gating on the public path is precisely what broke #3383.

## Out of scope

- **Global routes under a tenant host** (`/book/<id>` on the subdomain) fall through the proxy rewrite and mount the root layout, not `EmbedLayout`, so `EmbedUserMenu` never renders there. Giving those pages an entry point is a separate change and a separate double-mount risk — the exact hazard that got #3383 reverted. Not touched here.
- **Sign-*out* callbackUrl** on tenant hosts (`signOut({ callbackUrl: '/' })` resolves against the apex) is pre-existing and unchanged.
- Reopening #2150's broader "restore the whole account menu on tenant subdomains" scope.

## Verification

- `npx vitest run tests/unit` — 951/951 pass, including 10 new cases.
- `npx tsc --noEmit` — clean.
- Tests call the real functions (both halves of the round trip, plus 8 open-redirect rejection cases: lookalike hosts, apex-as-prefix, userinfo trick, http downgrade, junk input). Per CLAUDE.md, a test that greps source is not a guard.
- **Negative control run:** the pre-change NextAuth default returns `https://sourcelibrary.org` where the test expects `https://bph.sourcelibrary.org/catalog/BPH%20151` — so these tests genuinely fail on the old code rather than passing vacuously.

**A Vercel preview cannot verify the subdomain behaviour** (host-gated code evaluates false on a preview host, and curling a preview with `Host: bph.sourcelibrary.org` resolves to the production deployment). Confirm on the real subdomain after deploy — signed out and signed in, on `/` and `/catalog/<ubn>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)