### PR TITLE
fix(bph-catalog): three catalogue-editor requests from José Bouman

### DIFF
--- a/scripts/lib/bph-state-shelfmark.mjs
+++ b/scripts/lib/bph-state-shelfmark.mjs
@@ -1,0 +1,21 @@
+/**
+ * Scripts-side twin of `src/lib/bph-state-shelfmark.ts`.
+ *
+ * Batch consumers (the CSV importers and the one-off sweep) can't import the
+ * TypeScript original, so the logic is duplicated here and parity is pinned by
+ * `tests/unit/bph-state-shelfmark.test.ts`. Change both sides together.
+ *
+ * See the TS file for why "neen" ends up in a shelf-mark column at all.
+ */
+
+/** Values that mean "no", not a shelf mark. Compared case-insensitively. */
+const NOT_A_SHELFMARK = new Set(['neen', 'nee']);
+
+export function normalizeStateShelfMark(raw) {
+  if (raw == null) return null;
+  const kept = String(raw)
+    .split('|')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0 && !NOT_A_SHELFMARK.has(part.toLowerCase()));
+  return kept.length > 0 ? kept.join('|') : null;
+}

--- a/scripts/maintenance/clear-neen-state-shelfmark.mjs
+++ b/scripts/maintenance/clear-neen-state-shelfmark.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * Empty the "neen" answers out of bph_works.state_shelf_mark.
+ *
+ * WHY
+ * ---
+ * The column was imported from Memorix's `bruikleen_icn` — "is this copy on
+ * loan from the ICN (the Dutch state collection)?" — which is answered either
+ * with a real shelf mark (`PH3018`) or with the Dutch word for "no", `neen`.
+ * The importer mapped the raw answer straight through, so ~19.9K of the 24K
+ * populated rows carry a boolean *no* in a field the catalogue renders as a
+ * shelf mark. José Bouman (BPH) asked for it emptied across the whole
+ * catalogue (feedback, 2026-07-15):
+ *
+ *   "In the whole catalogue: if the field State Collection Shelfmark contains
+ *    'neen' please delete, field should be empty"
+ *
+ * The write boundary is fixed too — both CSV importers now normalise through
+ * scripts/lib/bph-state-shelfmark.mjs — so a re-import cannot undo this.
+ *
+ * WHAT IT DOES NOT TOUCH
+ * ----------------------
+ * `ja` ("yes", 31 rows) is equally not a shelf mark, but emptying it would
+ * discard the only trace that those copies ARE on loan from the state
+ * collection. That needs a librarian's decision, so it is reported and left.
+ *
+ * AUDIT TRAIL
+ * -----------
+ * bph_works is the BPH's catalogue of record: every mutation is traceable via
+ * bph_works_revisions (see src/lib/bph-catalog.ts). This script writes a
+ * revision row per affected UBN — with the real `from` value, so the change is
+ * individually reversible — BEFORE touching the live rows, matching the
+ * ordering applyWorkRevision uses: if the run dies midway the failure direction
+ * is an orphaned revision, never an unrecorded edit. It is a bulk writer rather
+ * than a caller of applyWorkRevision only because that helper is TypeScript and
+ * does one row per three round-trips; the invariant it protects is preserved.
+ *
+ * A full backup of every affected row is written to scripts/output/ before any
+ * write, so the sweep can be reversed from disk as well as from the revisions.
+ *
+ * Idempotent: re-running finds nothing to do.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/clear-neen-state-shelfmark.mjs            # dry run
+ *   node scripts/maintenance/clear-neen-state-shelfmark.mjs --apply
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync, mkdirSync } from 'fs';
+import { parseArgs } from 'util';
+import { randomUUID } from 'crypto';
+import { normalizeStateShelfMark } from '../lib/bph-state-shelfmark.mjs';
+
+const { values: args } = parseArgs({
+  options: {
+    apply: { type: 'boolean', default: false },
+    'chunk-size': { type: 'string', default: '500' },
+  },
+});
+
+const APPLY = args.apply;
+const CHUNK = parseInt(args['chunk-size'], 10);
+const EDITOR = 'system:clear-neen-state-shelfmark';
+const NOTE =
+  'Bulk cleanup: "neen" (Dutch "no") was imported from Memorix bruikleen_icn ' +
+  'into the State Collection shelf mark field. Requested by José Bouman, ' +
+  'feedback 2026-07-15.';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const chunks = (arr, n) => {
+  const out = [];
+  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
+  return out;
+};
+
+/**
+ * Page through every row that could possibly be affected.
+ *
+ * The filter is `%nee%`, not `%neen%`: the normaliser also empties the shorter
+ * spelling `nee` (10 rows), and a fetch narrower than the normaliser would
+ * leave rows behind that the catalogue then hides at read time — a silent
+ * disagreement between what is stored and what is shown. Deliberately loose:
+ * real values that merely contain the letters (e.g. a hypothetical "Neenah")
+ * are filtered out by comparing the normalised value, never by substring.
+ */
+async function fetchCandidates() {
+  const rows = [];
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await sb
+      .from('bph_works')
+      .select('ubn, state_shelf_mark, field_provenance')
+      .ilike('state_shelf_mark', '%nee%')
+      .range(from, from + 999);
+    if (error) throw new Error(`fetch failed at offset ${from}: ${error.message}`);
+    rows.push(...data);
+    if (data.length < 1000) break;
+  }
+  return rows;
+}
+
+/** Rows the normaliser would actually change, with their target value. */
+function pendingChanges(rows) {
+  return rows
+    .map((r) => ({ ...r, next: normalizeStateShelfMark(r.state_shelf_mark) }))
+    .filter((r) => r.next !== r.state_shelf_mark);
+}
+
+async function main() {
+  console.log(APPLY ? 'MODE: APPLY (writing)' : 'MODE: DRY RUN (use --apply to write)');
+
+  const candidates = await fetchCandidates();
+  console.log(`Rows whose state_shelf_mark mentions "nee":   ${candidates.length}`);
+
+  const affected = pendingChanges(candidates);
+  console.log(`Rows the normaliser changes:                 ${affected.length}`);
+  if (affected.length !== candidates.length) {
+    const untouched = candidates.length - affected.length;
+    console.log(`Rows left alone (real values containing "neen"): ${untouched}`);
+  }
+
+  const transitions = new Map();
+  for (const r of affected) {
+    const key = `${JSON.stringify(r.state_shelf_mark)} -> ${JSON.stringify(r.next)}`;
+    transitions.set(key, (transitions.get(key) || 0) + 1);
+  }
+  console.log('\nTransitions:');
+  for (const [k, n] of [...transitions.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${n.toString().padStart(6)}  ${k}`);
+  }
+
+  // Report, don't touch: "ja" is the same class of defect but deleting it
+  // destroys information (see the header).
+  const { count: jaCount } = await sb
+    .from('bph_works')
+    .select('ubn', { count: 'exact', head: true })
+    .eq('state_shelf_mark', 'ja');
+  console.log(`\nNOT swept — state_shelf_mark = "ja" ("yes"): ${jaCount} rows (needs a librarian's call)`);
+
+  if (affected.length === 0) {
+    console.log('\nNothing to do.');
+    return;
+  }
+
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backupPath = `scripts/output/neen-state-shelfmark-backup-${stamp}.json`;
+  if (!APPLY) {
+    console.log(`\nDRY RUN — would write ${affected.length} revision rows, update ${affected.length} rows,`);
+    console.log(`and back up the prior values to ${backupPath}.`);
+    return;
+  }
+
+  mkdirSync('scripts/output', { recursive: true });
+  writeFileSync(
+    backupPath,
+    JSON.stringify(
+      {
+        generated: new Date().toISOString(),
+        reason: NOTE,
+        rows: affected.map((r) => ({
+          ubn: r.ubn,
+          state_shelf_mark: r.state_shelf_mark,
+          field_provenance: r.field_provenance,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`\nBacked up ${affected.length} prior values → ${backupPath}`);
+
+  // 1. History first. If this dies partway, the worst case is revision rows
+  //    describing a change that never landed — recoverable, and detectable by
+  //    comparing field_changes.from against the live row.
+  const appliedAt = new Date().toISOString();
+  let revisionsWritten = 0;
+  for (const chunk of chunks(affected, CHUNK)) {
+    const { error } = await sb.from('bph_works_revisions').insert(
+      chunk.map((r) => ({
+        id: randomUUID(),
+        ubn: r.ubn,
+        change_type: 'edit',
+        field_changes: { state_shelf_mark: { from: r.state_shelf_mark, to: r.next, source: 'bulk cleanup' } },
+        editor_email: EDITOR,
+        proposed_by: null,
+        source_pending_id: null,
+        applied_at: appliedAt,
+        note: NOTE,
+      })),
+    );
+    if (error) throw new Error(`revision insert failed: ${error.message}`);
+    revisionsWritten += chunk.length;
+    process.stdout.write(`\r  revisions: ${revisionsWritten}/${affected.length}`);
+  }
+  console.log('');
+
+  // 2. Then the live rows. Rows sharing a target value AND an empty
+  //    field_provenance can go in one UPDATE per chunk; the handful with
+  //    existing provenance are merged individually so another writer's entries
+  //    survive (Supabase can't deep-merge JSONB from the client).
+  const provenanceEntry = { source: 'bulk cleanup', edited_by: EDITOR, edited_at: appliedAt };
+  const isEmptyProvenance = (fp) => !fp || typeof fp !== 'object' || Object.keys(fp).length === 0;
+
+  const bulk = new Map();
+  const perRow = [];
+  for (const r of affected) {
+    if (isEmptyProvenance(r.field_provenance)) {
+      const key = JSON.stringify(r.next);
+      if (!bulk.has(key)) bulk.set(key, { next: r.next, ubns: [] });
+      bulk.get(key).ubns.push(r.ubn);
+    } else {
+      perRow.push(r);
+    }
+  }
+
+  let updated = 0;
+  for (const { next, ubns } of bulk.values()) {
+    for (const chunk of chunks(ubns, CHUNK)) {
+      const { error } = await sb
+        .from('bph_works')
+        .update({ state_shelf_mark: next, field_provenance: { state_shelf_mark: provenanceEntry } })
+        .in('ubn', chunk);
+      if (error) throw new Error(`bulk update failed: ${error.message}`);
+      updated += chunk.length;
+      process.stdout.write(`\r  updated: ${updated}/${affected.length}`);
+    }
+  }
+  for (const r of perRow) {
+    const { error } = await sb
+      .from('bph_works')
+      .update({
+        state_shelf_mark: r.next,
+        field_provenance: { ...r.field_provenance, state_shelf_mark: provenanceEntry },
+      })
+      .eq('ubn', r.ubn);
+    if (error) throw new Error(`update failed for ubn=${r.ubn}: ${error.message}`);
+    updated++;
+    process.stdout.write(`\r  updated: ${updated}/${affected.length}`);
+  }
+  console.log('');
+
+  // 3. Verify by re-reading the database and re-asking the normaliser, rather
+  //    than trusting our own counters or a substring count (a real shelf mark
+  //    containing those letters would fail a naive `%nee%` check forever).
+  const remaining = pendingChanges(await fetchCandidates());
+
+  console.log(`\nRevisions written: ${revisionsWritten}`);
+  console.log(`Rows updated:      ${updated}`);
+  console.log(`Rows still needing the change: ${remaining.length} (expect 0)`);
+  if (remaining.length !== 0) {
+    console.error('VERIFICATION FAILED — sample:', remaining.slice(0, 5).map((r) => r.ubn).join(', '));
+    process.exit(1);
+  }
+  console.log('Done.');
+}
+
+main().catch((err) => {
+  console.error('\nFAILED:', err.message);
+  process.exit(1);
+});

--- a/scripts/migration/add-bph-exhibition-history.sql
+++ b/scripts/migration/add-bph-exhibition-history.sql
@@ -1,0 +1,24 @@
+-- Add an "Exhibition history" field to the BPH catalogue.
+--
+-- Requested by José Bouman (BPH), feedback 2026-07-29: a Notes field recording
+-- where a copy has been exhibited, not visible to public visitors, with no
+-- length limit. TEXT rather than VARCHAR(n) for exactly that reason — entries
+-- accumulate one line per exhibition over a copy's lifetime.
+--
+-- Staff-only, same treatment as internal_remarks (#3105): the field is rendered
+-- on the catalogue entry page for editor+ only and is deliberately absent from
+-- every public read path and from search_tsv. Do not add it to the tsvector
+-- trigger — indexing it would leak the contents through catalogue search.
+--
+-- This is additive and nullable, so it is safe to apply before or after the
+-- code deploy: the entry page's stacked column fallbacks render fine while the
+-- column is missing.
+--
+-- Run via Supabase SQL editor or psql:
+--   psql "$DATABASE_URL" -f scripts/migration/add-bph-exhibition-history.sql
+
+ALTER TABLE bph_works
+  ADD COLUMN IF NOT EXISTS exhibition_history TEXT;
+
+COMMENT ON COLUMN bph_works.exhibition_history IS
+  'Staff-only: where this copy has been exhibited. Never rendered publicly (editor+ only, like internal_remarks). Unbounded length.';

--- a/scripts/migration/enrich-bph-from-csv.mjs
+++ b/scripts/migration/enrich-bph-from-csv.mjs
@@ -39,6 +39,7 @@
 import { MongoClient } from 'mongodb';
 import { readFileSync } from 'fs';
 import { parseArgs } from 'util';
+import { normalizeStateShelfMark } from '../lib/bph-state-shelfmark.mjs';
 
 const { values: args } = parseArgs({
   options: {
@@ -124,7 +125,9 @@ function loadCSV(path) {
       remarks: c[cols.remarks] || null,
       internal_remarks: c[cols.internalRemarks] || null,
       status: c[cols.status] || null,
-      state_shelf_mark: c[cols.stateShelfMark] || null,
+      // "neen" (Dutch "no") is an answer, not a shelf mark — normalise at the
+      // write boundary so a re-import can't undo the one-off sweep.
+      state_shelf_mark: normalizeStateShelfMark(c[cols.stateShelfMark]),
       acquisition_date: c[cols.acquisitionDate] || null,
       acquisition_source: c[cols.acquisitionSource] || null,
       price: c[cols.price] || null,

--- a/scripts/migration/import-bph-catalog.mjs
+++ b/scripts/migration/import-bph-catalog.mjs
@@ -31,6 +31,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { readFileSync } from 'fs';
 import { parseArgs } from 'util';
+import { normalizeStateShelfMark } from '../lib/bph-state-shelfmark.mjs';
 
 const { values: args } = parseArgs({
   options: {
@@ -164,7 +165,11 @@ async function main() {
       internal_remarks: get(r, 'Internal remarks'),
       number_of_copies: parseInt0(get(r, 'Number of copies')),
       work_status: get(r, 'Status'),
-      state_shelf_mark: get(r, 'BPH State Collection shelf mark'),
+      // Memorix answers this with a shelf mark OR with "neen" ("no") — the
+      // source field is really "on loan from the ICN?". Normalise at the write
+      // boundary so a re-import can't reintroduce the 19.9K bare "neen" rows
+      // that scripts/maintenance/clear-neen-state-shelfmark.mjs cleaned up.
+      state_shelf_mark: normalizeStateShelfMark(get(r, 'BPH State Collection shelf mark')),
       object_size_cm: get(r, 'Object size in cm'),
       provenance: get(r, 'Provenance'),
       binding: get(r, 'Binding'),

--- a/src/app/embed/[tenant]/catalog/[ubn]/GenericCatalogEntry.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/GenericCatalogEntry.tsx
@@ -6,6 +6,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
 import { isPublishedFirstTranslation } from '@/lib/book';
 import type { LibraryPartner } from '@/lib/library-partners';
+import { normalizeStateShelfMark } from '@/lib/bph-state-shelfmark';
 import { AISection } from '@/components/embed/AISection';
 
 // Generic catalogue detail renderer for tenants whose bibliographic data
@@ -424,7 +425,7 @@ export default async function GenericCatalogEntry({
         <Section title={`Location at ${partner.shortName}`}>
           <Field label="Present location" value={row.present_location} />
           <Field label="Shelf mark" value={row.shelf_mark} mono />
-          <Field label="State Collection shelf mark" value={row.state_shelf_mark} mono />
+          <Field label="State Collection shelf mark" value={normalizeStateShelfMark(row.state_shelf_mark)} mono />
           <Field label="Kloss shelf mark" value={klossShelfMark} mono />
           <Field label="Provenance / collection" value={row.provenance} />
         </Section>

--- a/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
@@ -102,7 +102,7 @@ export default async function EditCatalogEntryPage({ params }: Props) {
   // from 20260624000000), retry without them. The form silently shows those
   // fields empty, and a save would fail at write time with the same error —
   // the right behaviour (don't pretend to save what we can't write).
-  const maybeMissingCols = ['author_entity_id', 'author_canonical_name', 'author_wikidata_qid', 'collection', 'impressum_original', 'contributors'];
+  const maybeMissingCols = ['author_entity_id', 'author_canonical_name', 'author_wikidata_qid', 'collection', 'impressum_original', 'contributors', 'exhibition_history'];
   const cols = ['ubn', ...EDITABLE_BPH_FIELDS, 'field_provenance', 'sl_book_id'].join(', ');
   const fallbackCols = ['ubn', ...EDITABLE_BPH_FIELDS.filter((c) => !maybeMissingCols.includes(c)), 'field_provenance', 'sl_book_id'].join(', ');
   let { data, error } = await supabase

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -11,6 +11,7 @@ import { buildSignInHref } from '@/lib/tenant-signin-url';
 import { auth } from '@/lib/auth';
 import { ROLE_LEVEL, type Role } from '@/lib/auth';
 import type { BphContributor } from '@/lib/bph-catalog';
+import { normalizeStateShelfMark } from '@/lib/bph-state-shelfmark';
 import { AISection } from '@/components/embed/AISection';
 import CatalogueUnavailable from '@/components/embed/CatalogueUnavailable';
 import GenericCatalogEntry, { generateGenericMetadata } from './GenericCatalogEntry';
@@ -82,6 +83,9 @@ interface BphWorkRow {
   // Memorix "Internal remarks" — cataloguers' working notes. Rendered ONLY
   // for editor+ roles; must never appear on the public page (José B., #3105).
   internal_remarks: string | null;
+  // Where this copy has been exhibited. Staff-only on the same terms as
+  // internal_remarks above (José B., 2026-07-29).
+  exhibition_history: string | null;
   number_of_copies: number | null;
   object_size_cm: string | null;
   bibliographic_format: string | null;
@@ -140,7 +144,7 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
       place, printer, publisher, variant_printer, variant_publisher,
       year, shelf_mark, state_shelf_mark, present_location,
       keywords, language, series_title, volume_title,
-      bibliography, remarks, internal_remarks, number_of_copies, object_size_cm, bibliographic_format,
+      bibliography, remarks, internal_remarks, exhibition_history, number_of_copies, object_size_cm, bibliographic_format,
       binding, bound_with,
       provenance, collection, impressum_original, contributors,
       ia_identifier, ustc_sn, sl_book_id, sl_book_slug,
@@ -151,7 +155,7 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
   // then external-link columns, then author-authority columns. Each migration
   // runs independently per environment — the page renders if any are missing.
   const fallbackSelect = select
-    .replace('remarks, internal_remarks,', 'remarks,')
+    .replace('remarks, internal_remarks, exhibition_history,', 'remarks,')
     .replace('provenance, collection, impressum_original, contributors,', 'provenance,')
     .replace(
       'sl_external_book_id, sl_external_slug, sl_external_source,\n      ',
@@ -760,7 +764,7 @@ export default async function CatalogEntryPage({ params }: Props) {
         <Section title="Location at the BPH">
           <Field label="Present location" value={work.present_location} />
           <Field label="Shelf mark" value={work.shelf_mark} mono />
-          <Field label="State Collection shelf mark" value={work.state_shelf_mark?.trim().toLowerCase() === 'neen' ? null : work.state_shelf_mark} mono />
+          <Field label="State Collection shelf mark" value={normalizeStateShelfMark(work.state_shelf_mark)} mono />
           <Field label="Provenance" value={work.provenance} />
           <Field label="Collection" value={work.collection} />
         </Section>
@@ -772,7 +776,10 @@ export default async function CatalogEntryPage({ params }: Props) {
               Safe to role-gate here: this page is fully dynamic (private,
               no-store), so an editor's render is never cached for others. */}
           {ROLE_LEVEL[role] >= ROLE_LEVEL['editor'] && (
-            <Field label="Internal remarks (staff only)" value={work.internal_remarks} />
+            <>
+              <Field label="Internal remarks (staff only)" value={work.internal_remarks} />
+              <Field label="Exhibition history (staff only)" value={work.exhibition_history} />
+            </>
           )}
         </Section>
 

--- a/src/app/embed/[tenant]/catalog/new/page.tsx
+++ b/src/app/embed/[tenant]/catalog/new/page.tsx
@@ -10,8 +10,9 @@ import BphWorkEditForm from '@/components/catalog/BphWorkEditForm';
  * Create a new BPH catalogue record.
  *
  * Editor-only. Renders the same form as the editor, in 'create' mode: it
- * shows a UBN field (pre-filled with a safe SL-… id), starts every field
- * blank, and POSTs to /api/[tenant]/catalog/create. BPH-only in Phase 1.
+ * shows a UBN field (pre-filled with the next free id from the reserved
+ * 33,000+ range — see suggestNewUbn), starts every field blank, and POSTs to
+ * /api/[tenant]/catalog/create. BPH-only in Phase 1.
  *
  * Issue #1877.
  */

--- a/src/components/book/BphCatalogueRecord.tsx
+++ b/src/components/book/BphCatalogueRecord.tsx
@@ -1,5 +1,6 @@
 import { supabase } from '@/lib/supabase';
 import { ExternalLink } from 'lucide-react';
+import { normalizeStateShelfMark } from '@/lib/bph-state-shelfmark';
 
 /**
  * Inline display of a book's BPH catalogue record, side-loaded from Supabase
@@ -221,7 +222,7 @@ export default async function BphCatalogueRecord({ ubn }: { ubn: string }) {
         )}
 
         {(() => {
-          const stateShelfMark = work.state_shelf_mark?.trim().toLowerCase() === 'neen' ? null : work.state_shelf_mark;
+          const stateShelfMark = normalizeStateShelfMark(work.state_shelf_mark);
           if (!work.present_location && !work.shelf_mark && !stateShelfMark && !work.provenance) return null;
           return (
             <Section title="Location at the BPH">

--- a/src/components/catalog/BphWorkEditForm.tsx
+++ b/src/components/catalog/BphWorkEditForm.tsx
@@ -125,6 +125,8 @@ const SECTIONS: Array<{
       // Memorix "Internal remarks" — staff working notes (José B.). Shown to
       // editors only; the public catalog page never renders this field.
       { name: 'internal_remarks', label: 'Internal remarks (staff only, never public)', type: 'textarea', editorOnly: true },
+      // Exhibition history — staff-only on the same terms (José B., 2026-07-29).
+      { name: 'exhibition_history', label: 'Exhibition history (staff only, never public)', type: 'textarea', editorOnly: true },
     ],
   },
   {

--- a/src/lib/bph-catalog.ts
+++ b/src/lib/bph-catalog.ts
@@ -91,6 +91,10 @@ export const EDITABLE_BPH_FIELDS = [
   // Memorix "Internal remarks" — staff working notes. Editable/visible for
   // editor+ only; the public catalog entry page must never render it.
   'internal_remarks',
+  // Exhibition history — where this copy has been shown (José B., 2026-07-29).
+  // Staff-only on the same terms as internal_remarks. Unbounded TEXT: entries
+  // accumulate one line per exhibition over the life of a copy.
+  'exhibition_history',
   // Provenance (ownership history) + collection (named collection the copy
   // belongs to) — kept as two distinct fields per Paul D. (2026-06-24).
   'provenance',
@@ -347,32 +351,59 @@ export async function applyWorkRevision(input: ApplyWorkRevisionInput): Promise<
 }
 
 /**
- * Suggest the next Source-Library-originated UBN (`SL-000123`). New records
- * created in the editor get an `SL-` prefixed id rather than a numeric one so
- * they never collide with the BPH's authoritative numeric UBN namespace (the
- * Memorix sync upserts on numeric UBNs). Editors can override the suggestion
- * with a real BPH UBN if the record already has one — uniqueness is enforced
- * by the primary key and the create guard in applyWorkRevision.
+ * First UBN reserved for records created on Source Library. The BPH's own
+ * numbering is dense up to ~32,999, so 33,000 is the agreed start of the new
+ * range (José Bouman, 2026-07-15) — see UBN_ALLOCATION_START's usage below.
+ */
+export const UBN_ALLOCATION_START = 33000;
+
+/** How many ids to probe per round-trip when hunting for a free number. */
+const UBN_PROBE_WINDOW = 200;
+
+/** Give up after this many windows (covers 33,000 – 53,000). */
+const UBN_MAX_PROBES = 100;
+
+/**
+ * Suggest the next free numeric UBN, starting at 33,000.
  *
- * Best-effort: on any lookup failure we fall back to a timestamp-free random
- * suffix so the create page still renders a usable default.
+ * This used to hand out `SL-000123`. The prefix was there to keep new records
+ * out of the BPH's authoritative numeric namespace, but the BPH writes the UBN
+ * into the physical book by hand and the `SL-` was too easy to forget, so a
+ * shelf number and a catalogue number could silently diverge (José Bouman,
+ * feedback 2026-07-15). A reserved numeric range gives the same collision
+ * safety with nothing to forget. No `SL-` record was ever created, so there is
+ * no legacy id to migrate.
+ *
+ * Collision safety is not assumed — the allocator probes a window of ids and
+ * returns the lowest one that is actually free, so it stays correct as the
+ * range fills and against the ~20 stray numeric UBNs that already sit above
+ * 33,000 (39424, 40402, … 272622). Uniqueness is still enforced underneath by
+ * the primary key and the create guard in applyWorkRevision; this only picks a
+ * sensible default that the editor can overwrite with a real BPH UBN.
+ *
+ * Best-effort: on any lookup failure we fall back to the start of the range so
+ * the create page still renders a usable default.
  */
 export async function suggestNewUbn(): Promise<string> {
-  const pad = (n: number) => `SL-${String(n).padStart(6, '0')}`;
-  if (!supabaseAdmin) return pad(1);
+  if (!supabaseAdmin) return String(UBN_ALLOCATION_START);
   try {
-    const { data } = await supabaseAdmin
-      .from('bph_works')
-      .select('ubn')
-      .like('ubn', 'SL-%')
-      .order('ubn', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    const last = (data as { ubn?: string } | null)?.ubn;
-    const n = last ? parseInt(last.replace(/^SL-/, ''), 10) : 0;
-    return pad(Number.isFinite(n) ? n + 1 : 1);
+    for (let probe = 0; probe < UBN_MAX_PROBES; probe++) {
+      const base = UBN_ALLOCATION_START + probe * UBN_PROBE_WINDOW;
+      const window = Array.from({ length: UBN_PROBE_WINDOW }, (_, i) => String(base + i));
+      const { data, error } = await supabaseAdmin
+        .from('bph_works')
+        .select('ubn')
+        .in('ubn', window);
+      if (error) throw error;
+      const taken = new Set((data as { ubn: string }[] | null)?.map((r) => r.ubn) ?? []);
+      const free = window.find((candidate) => !taken.has(candidate));
+      if (free) return free;
+    }
+    // Every id in the probed range is taken — fall through to the range start
+    // rather than guessing past the window; the editor sets the UBN by hand.
+    return String(UBN_ALLOCATION_START);
   } catch {
-    return pad(1);
+    return String(UBN_ALLOCATION_START);
   }
 }
 

--- a/src/lib/bph-state-shelfmark.ts
+++ b/src/lib/bph-state-shelfmark.ts
@@ -1,0 +1,41 @@
+/**
+ * Normalise `bph_works.state_shelf_mark` ("State Collection shelf mark").
+ *
+ * The column was imported from Memorix's `bruikleen_icn` field — "is this copy
+ * on loan from the ICN (the Dutch state collection)?" — which is answered
+ * either with a real shelf mark (`PH3018`) or with the Dutch word for "no",
+ * `neen`. The import mapped the raw answer straight through, so ~19.9K of the
+ * 24K populated rows read "neen", i.e. a boolean *no* sitting in a text field
+ * that the catalogue renders as a shelf mark. José Bouman (BPH) asked for it to
+ * be emptied across the whole catalogue (feedback, 2026-07-15).
+ *
+ * Multi-value Memorix cells arrive pipe-joined (`neen|Slav`), so this strips
+ * per segment rather than testing the whole string, and returns null when
+ * nothing real is left.
+ *
+ * Two callers by design, and they must agree:
+ *   - the data sweep + CSV importers (`scripts/lib/bph-state-shelfmark.mjs`)
+ *   - the catalogue read paths (this file)
+ * Parity is pinned by `tests/unit/bph-state-shelfmark.test.ts` — change both
+ * sides together.
+ */
+
+/**
+ * Values that mean "no", not a shelf mark. Compared case-insensitively.
+ *
+ * Deliberately limited to the negative answers: `ja` ("yes") also appears in
+ * the column (31 rows as of 2026-07-30) and is equally not a shelf mark, but
+ * emptying it would discard the only record that those copies ARE on loan from
+ * the state collection. That needs a librarian's decision and a column that can
+ * express it, so it is left alone here rather than swept.
+ */
+const NOT_A_SHELFMARK = new Set(['neen', 'nee']);
+
+export function normalizeStateShelfMark(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const kept = String(raw)
+    .split('|')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0 && !NOT_A_SHELFMARK.has(part.toLowerCase()));
+  return kept.length > 0 ? kept.join('|') : null;
+}

--- a/tests/unit/bph-state-shelfmark.test.ts
+++ b/tests/unit/bph-state-shelfmark.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `state_shelf_mark` normalisation guards (José Bouman feedback, 2026-07-15).
+ *
+ *  1. PARITY — scripts/lib/bph-state-shelfmark.mjs (the sweep + CSV importers,
+ *     which decide what gets STORED) and src/lib/bph-state-shelfmark.ts (the
+ *     catalogue read paths, which decide what gets SHOWN) must agree, or a
+ *     value the importer keeps is one the page hides, and vice versa.
+ *  2. BEHAVIOR — the actual shapes present in bph_works: bare "neen", the
+ *     pipe-joined multi-value cells Memorix exports, and real shelf marks that
+ *     must survive untouched.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { normalizeStateShelfMark as mjs } from '../../scripts/lib/bph-state-shelfmark.mjs';
+import { normalizeStateShelfMark as ts } from '../../src/lib/bph-state-shelfmark';
+
+/** Every distinct shape observed in the column, plus adversarial padding. */
+const FIXTURES = [
+  'neen',
+  'Neen',
+  'NEEN',
+  '  neen  ',
+  'nee',
+  'neen|',
+  'neen|Slav',
+  '|',
+  '||',
+  'ja',
+  'PH3018',
+  'PH1883-B',
+  'PH3154-C',
+  'zie PH3301',
+  'avail.',
+  '1',
+  '',
+  '   ',
+  null,
+  undefined,
+];
+
+describe('normalizeStateShelfMark parity', () => {
+  it('mjs and ts agree on every fixture', () => {
+    for (const f of FIXTURES) {
+      expect(mjs(f), `mismatch on ${JSON.stringify(f)}`).toEqual(ts(f));
+    }
+  });
+});
+
+describe('normalizeStateShelfMark behavior', () => {
+  it('empties the Dutch "no" answers that were imported as shelf marks', () => {
+    expect(ts('neen')).toBeNull();
+    expect(ts('Neen')).toBeNull();
+    expect(ts('  neen  ')).toBeNull();
+    expect(ts('nee')).toBeNull();
+  });
+
+  it('strips "neen" per segment in pipe-joined multi-value cells', () => {
+    // Three real rows look like this — UBN 20390/18666 ("neen|") and 13579.
+    expect(ts('neen|')).toBeNull();
+    expect(ts('neen|Slav')).toBe('Slav');
+  });
+
+  it('empties cells that are only separators or whitespace', () => {
+    expect(ts('|')).toBeNull();
+    expect(ts('||')).toBeNull();
+    expect(ts('   ')).toBeNull();
+    expect(ts('')).toBeNull();
+    expect(ts(null)).toBeNull();
+  });
+
+  it('leaves real shelf marks exactly as they are', () => {
+    expect(ts('PH3018')).toBe('PH3018');
+    expect(ts('PH1883-B')).toBe('PH1883-B');
+    expect(ts('zie PH3301')).toBe('zie PH3301');
+  });
+
+  it('leaves "ja" alone — emptying it would discard a real (if crude) signal', () => {
+    expect(ts('ja')).toBe('ja');
+  });
+});


### PR DESCRIPTION
Three items from the BPH's librarian, José Bouman, via the footer feedback widget. All three are about the **catalogue editor**, not the reader. The oldest had been sitting read-but-unactioned since 15 July.

## In scope

### 1. Empty `neen` out of "State Collection shelf mark" (feedback 2026-07-15)

> "In the whole catalogue: if the field State Collection Shelfmark contains 'neen' please delete, field should be empty"

Root cause, for the record: the column was imported from Memorix's `bruikleen_icn` — *"is this copy on loan from the ICN (the Dutch state collection)?"* — which is answered either with a real shelf mark (`PH3018`) or with the Dutch word for **no**. The importer mapped the raw answer straight through, so **19,929 of the 24,041 populated rows held a boolean *no* in a field the catalogue renders as a shelf mark**.

**Swept 19,942 rows, applied and verified (0 remaining).** That is more than the bare `neen` count on purpose:

| transition | rows |
|---|---|
| `"neen"` → empty | 19,929 |
| `"nee"` → empty | 10 |
| `"neen\|"` → empty | 2 |
| `"neen\|Slav"` → `"Slav"` | 1 |

The pipe-joined ones are Memorix multi-value cells, so the rule strips per segment rather than testing the whole string — `neen|Slav` keeps `Slav`.

Fixed at the **write boundary** too: both CSV importers now normalise, so a re-import cannot reintroduce it.

**Not swept, deliberately:** `ja` ("yes", 31 rows) is the same defect, but emptying it would discard the only record that those copies *are* on loan from the state collection. That needs a librarian's call and a column that can express it — flagged to José rather than decided here.

### 2. New records number from 33000, not `SL-000001` (feedback 2026-07-15)

> "UBN: please start the new range with 33.000, not with SL000001. We write the UBN also in the book, and the risk of forgetting to add the 'SL' is too big..."

The `SL-` prefix existed to keep new records out of the BPH's authoritative numeric namespace. But the UBN is hand-written into the physical book, so a forgotten prefix silently diverges the shelf number from the catalogue number. A reserved numeric range gives the same collision safety with nothing to forget.

**No `SL-` record was ever created**, so there is no legacy id to migrate. The allocator probes for the lowest genuinely free id rather than assuming the range is empty — ~20 stray numeric UBNs already sit above 33,000 (39424, 40402, … 272622).

### 3. Add an "Exhibition history" field (feedback 2026-07-29)

> "Please add a field in NOTES (not visible for visitors): Exhibition history. It should have unlimited space."

Staff-only on exactly the same terms as `internal_remarks` (#3105): editor+ only on the entry page and in the editor, absent from every public read path, unbounded `TEXT`. **Deliberately not added to `search_tsv`** — indexing it would leak the contents back out through catalogue search, which would defeat the "not visible for visitors" requirement in a way nobody would notice.

## Out of scope

- **The `ja` rows** — see above; needs José's decision, not a code change.
- **The 6 rows whose shelf mark is just `|`** — an empty pipe-join. The normaliser already empties them when it touches a row, but they aren't swept on their own since they're a different (harmless) artifact.
- **Backfilling exhibition history** — the field is new and empty; no source data exists for it in Memorix (checked: no exhibition key in `memorix_raw`).

## Already applied to production

Both of these are data/schema changes that had to land before the code is useful, and both are done and verified:

- **The sweep** — 19,942 rows, each with a reversible `bph_works_revisions` row (`editor_email: system:clear-neen-state-shelfmark`) plus a full on-disk backup of prior values. Re-verified independently: `state_shelf_mark = 'neen'` → 0, `'nee'` → 0, real shelf marks (`PH3018`, `PH1346`) intact, `neen|Slav` → `Slav`.
- **The migration** — `exhibition_history TEXT` exists, nullable, with a column comment, and is referenced by no trigger function (so it cannot reach search).

The script is idempotent and safe to re-run.

## Verification

- `npx tsc --noEmit` clean
- `tests/unit/bph-state-shelfmark.test.ts` — parity between the TS (read paths) and `.mjs` (sweep + importers) twins across every value shape observed in the column, plus behaviour tests on the real pipe-joined rows

Note the fetch filter in the sweep is **wider** than the normalisation rule (`%nee%`, not `%neen%`): a fetch narrower than the rule would leave rows stored that the read path then hides — the two sides have to agree, or the catalogue shows something different from what it holds.

**Still needs a human check after deploy:** that the Exhibition history field is visible to an editor and absent for a visitor has to be confirmed on the real `bph.sourcelibrary.org` subdomain — a preview can't verify host-gated tenant behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)