### PR TITLE
feat(admin): Introductions — read what readers wrote on /welcome

### DIFF
--- a/src/app/admin/AdminNav.tsx
+++ b/src/app/admin/AdminNav.tsx
@@ -32,6 +32,7 @@ const adminLinks: NavItem[] = [
   },
   { href: '/admin/kdp', label: 'Publishing' },
   { href: '/admin/users', label: 'Users' },
+  { href: '/admin/introductions', label: 'Introductions' },
   { href: '/admin/members', label: 'Members' },
   { href: '/admin/api-keys', label: 'API Keys' },
   { href: '/analytics', label: 'Analytics' },

--- a/src/app/admin/introductions/page.tsx
+++ b/src/app/admin/introductions/page.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+interface Introduction {
+  id: string;
+  name: string | null;
+  email: string | null;
+  about: string;
+  help: string;
+  language: string;
+  language_key: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+interface Totals {
+  wrote: number;
+  welcomed: number;
+  skipped: number;
+  pending: number;
+  offered_help: number;
+  gave_language: number;
+  language_respondents: number;
+}
+
+interface Payload {
+  introductions: Introduction[];
+  totals: Totals;
+  language_tally: { language: string; count: number }[];
+  language_unmatched: string[];
+}
+
+type Filter = 'all' | 'help' | 'substantial';
+
+function fmtDate(s: string | null) {
+  if (!s) return '—';
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? '—' : d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function csvCell(v: unknown) {
+  if (v === null || v === undefined) return '';
+  const s = String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+export default function IntroductionsPage() {
+  const [data, setData] = useState<Payload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<Filter>('all');
+
+  useEffect(() => {
+    fetch('/api/admin/introductions')
+      .then(r => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then(setData)
+      .catch(e => setError(String(e.message || e)));
+  }, []);
+
+  const rows = useMemo(() => {
+    if (!data) return [];
+    const q = query.trim().toLowerCase();
+    return data.introductions.filter(i => {
+      if (filter === 'help' && !i.help.trim()) return false;
+      // "Substantial" = wrote more than a couple of words. Most introductions are
+      // one line ("leer"); the handful of long ones are where the offers and the
+      // corpus gaps actually are, and they get buried by volume otherwise.
+      if (filter === 'substantial' && i.about.trim().length < 120) return false;
+      if (!q) return true;
+      return [i.name, i.email, i.about, i.help, i.language]
+        .some(f => (f || '').toLowerCase().includes(q));
+    });
+  }, [data, query, filter]);
+
+  function exportCsv() {
+    if (!data) return;
+    const header = ['name', 'email', 'language', 'about', 'help', 'written'];
+    const lines = [header.join(',')];
+    for (const i of rows) {
+      lines.push([i.name, i.email, i.language, i.about, i.help, i.updated_at].map(csvCell).join(','));
+    }
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `introductions-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  if (error) {
+    return <div className="p-8 text-status-error">Could not load introductions: {error}</div>;
+  }
+  if (!data) {
+    return <div className="p-8 text-stone-500">Loading…</div>;
+  }
+
+  const t = data.totals;
+  const topLanguage = data.language_tally[0];
+
+  return (
+    <div className="p-6 md:p-8 max-w-6xl">
+      <header className="mb-6">
+        <h1 className="font-serif text-3xl text-stone-900 mb-1">Introductions</h1>
+        <p className="text-stone-500 text-sm">
+          What readers wrote about themselves on <code className="text-stone-600">/welcome</code>. Every field is optional.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+        {[
+          { label: 'Wrote something', value: t.wrote },
+          { label: 'Skipped', value: t.skipped },
+          { label: 'Offered to help', value: t.offered_help },
+          { label: 'Gave a language', value: t.gave_language },
+          { label: 'Not yet seen', value: t.pending },
+        ].map(s => (
+          <div key={s.label} className="border border-stone-200 rounded-lg p-3">
+            <div className="text-2xl font-serif text-stone-900">{s.value.toLocaleString()}</div>
+            <div className="text-xs text-stone-500">{s.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {data.language_tally.length > 0 && (
+        <section className="mb-6 border border-stone-200 rounded-lg p-4">
+          <h2 className="font-serif text-lg text-stone-900 mb-1">Languages readers want</h2>
+          <p className="text-xs text-stone-500 mb-3">
+            Free text, so one reader who names two languages counts for both.
+            {topLanguage && t.language_respondents > 0 && (
+              <>
+                {' '}
+                {topLanguage.language} leads at{' '}
+                {Math.round((100 * topLanguage.count) / t.language_respondents)}% of the{' '}
+                {t.language_respondents} who answered.
+              </>
+            )}
+          </p>
+          <div className="space-y-1.5">
+            {data.language_tally.map(l => (
+              <div key={l.language} className="flex items-center gap-3 text-sm">
+                <div className="w-24 text-stone-700">{l.language}</div>
+                <div className="flex-1 bg-stone-100 rounded h-4 overflow-hidden">
+                  <div
+                    className="bg-accent-rust/70 h-full"
+                    style={{ width: `${Math.round((100 * l.count) / Math.max(1, t.language_respondents))}%` }}
+                  />
+                </div>
+                <div className="w-10 text-right text-stone-500 tabular-nums">{l.count}</div>
+              </div>
+            ))}
+          </div>
+          {data.language_unmatched.length > 0 && (
+            <p className="text-xs text-stone-500 mt-3">
+              Not recognised: {data.language_unmatched.join(' · ')}
+            </p>
+          )}
+        </section>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        <input
+          type="search"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="Search name, email, or what they wrote…"
+          className="flex-1 min-w-[240px] px-3 py-2 border border-stone-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+        />
+        {([
+          ['all', 'All'],
+          ['help', 'Offered help'],
+          ['substantial', 'Wrote at length'],
+        ] as [Filter, string][]).map(([key, label]) => (
+          <button
+            key={key}
+            onClick={() => setFilter(key)}
+            className={`px-3 py-2 rounded-lg text-sm border transition-colors ${
+              filter === key
+                ? 'bg-stone-900 text-white border-stone-900'
+                : 'bg-white text-stone-600 border-stone-300 hover:border-stone-400'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+        <button
+          onClick={exportCsv}
+          className="px-3 py-2 rounded-lg text-sm border border-stone-300 text-stone-600 hover:border-stone-400"
+        >
+          CSV
+        </button>
+      </div>
+
+      <p className="text-xs text-stone-500 mb-3">
+        {rows.length === data.introductions.length
+          ? `${rows.length} introduction${rows.length === 1 ? '' : 's'}`
+          : `${rows.length} of ${data.introductions.length}`}
+      </p>
+
+      <div className="space-y-3">
+        {rows.map(i => (
+          <article key={i.id} className="border border-stone-200 rounded-lg p-4">
+            <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2">
+              <div>
+                <span className="font-medium text-stone-900">{i.name || '(no name given)'}</span>
+                {i.email && (
+                  <a
+                    href={`mailto:${i.email}`}
+                    className="ml-2 text-sm text-stone-500 hover:text-accent-rust break-all"
+                  >
+                    {i.email}
+                  </a>
+                )}
+              </div>
+              <span className="text-xs text-stone-400">{fmtDate(i.updated_at)}</span>
+            </div>
+
+            {i.language && (
+              <p className="text-sm text-stone-600 mb-2">
+                <span className="text-stone-400">Reads in </span>
+                {i.language}
+              </p>
+            )}
+            {i.about && (
+              <p className="text-stone-800 whitespace-pre-wrap text-[15px] leading-relaxed">{i.about}</p>
+            )}
+            {i.help && (
+              <p className="mt-2 pt-2 border-t border-stone-100 text-stone-700 whitespace-pre-wrap text-[15px] leading-relaxed">
+                <span className="text-stone-400">Would help by </span>
+                {i.help}
+              </p>
+            )}
+          </article>
+        ))}
+        {rows.length === 0 && (
+          <p className="text-stone-500 text-sm py-8 text-center">Nothing matches that filter.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/introductions/route.ts
+++ b/src/app/api/admin/introductions/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { getDb } from '@/lib/mongodb';
+
+/**
+ * GET /api/admin/introductions
+ *
+ * What readers wrote about themselves on /welcome — name, what draws them here,
+ * the language they'd rather read in, and whether they offered to help.
+ *
+ * The form has been collecting free text since 2026-07-29 and nothing in the
+ * product could read it: /admin/users shows *whether* someone was welcomed but
+ * not a word of what they said. Asking people to write to you and never opening
+ * the letters is the failure this route exists to prevent.
+ *
+ * users.profile is the durable record. The `volunteers` collection holds an
+ * outreach-shaped mirror, but it only receives a row when someone wrote
+ * something, and it is keyed by email rather than user — so it under-reports.
+ * Read the source of truth.
+ */
+export const GET = withAdminAuth(async () => {
+  const db = await getDb();
+  const users = db.collection('users');
+
+  const [rows, welcomedTotal, pending] = await Promise.all([
+    users
+      .find(
+        { 'profile.updatedAt': { $exists: true } },
+        {
+          projection: {
+            name: 1,
+            email: 1,
+            createdAt: 1,
+            'profile.aboutYou': 1,
+            'profile.helpDescription': 1,
+            'profile.preferredLanguage': 1,
+            'profile.preferredLanguageKey': 1,
+            'profile.updatedAt': 1,
+          },
+        },
+      )
+      .sort({ 'profile.updatedAt': -1 })
+      .toArray(),
+    users.countDocuments({ welcomedAt: { $ne: null, $exists: true } }),
+    users.countDocuments({ welcomedAt: null }),
+  ]);
+
+  const introductions = rows.map(u => {
+    const p = (u.profile || {}) as Record<string, unknown>;
+    return {
+      id: String(u._id),
+      name: (u.name as string) || null,
+      email: (u.email as string) || null,
+      about: (p.aboutYou as string) || '',
+      help: (p.helpDescription as string) || '',
+      language: (p.preferredLanguage as string) || '',
+      language_key: (p.preferredLanguageKey as string) || '',
+      created_at: u.createdAt ? new Date(u.createdAt as Date).toISOString() : null,
+      updated_at: p.updatedAt ? new Date(p.updatedAt as Date).toISOString() : null,
+    };
+  });
+
+  // Language tally. Readers type free text ("English and Spanish", "español",
+  // "Spanish-English"), deliberately — a dropdown can only offer the languages we
+  // already thought of. So count a mention rather than an exact match: one reader
+  // who reads two languages is evidence for both.
+  const LANGUAGES: Record<string, RegExp> = {
+    Spanish: /espa[nñ]ol|spanish|castellano/i,
+    English: /engl[ií]sh|ingl[eé]s/i,
+    Portuguese: /portugu[eê]s|portuguese/i,
+    French: /fran[cç]ais|french|franc[eé]s/i,
+    German: /deutsch|german|alem[aá]n/i,
+    Italian: /italian[oa]?|italien/i,
+    Latin: /\blat[ií]n\b|\blatin\b/i,
+    Dutch: /nederlands|dutch|holand[eé]s/i,
+    Chinese: /chinese|mandarin|chino|中文/i,
+    Arabic: /arabic|[aá]rabe/i,
+    Greek: /greek|griego|ελλην/i,
+    Russian: /russian|ruso|русск/i,
+  };
+
+  const languageTally: { language: string; count: number }[] = [];
+  const withLanguage = introductions.filter(i => i.language.trim());
+  for (const [label, re] of Object.entries(LANGUAGES)) {
+    const count = withLanguage.filter(i => re.test(i.language)).length;
+    if (count > 0) languageTally.push({ language: label, count });
+  }
+  languageTally.sort((a, b) => b.count - a.count);
+
+  // Anything nobody's regex matched — the whole point of free text is catching
+  // the languages we did not predict, so surface them rather than dropping them.
+  const unmatched = withLanguage
+    .filter(i => !Object.values(LANGUAGES).some(re => re.test(i.language)))
+    .map(i => i.language);
+
+  return NextResponse.json({
+    introductions,
+    totals: {
+      // Written a profile.
+      wrote: introductions.length,
+      // Pressed Save or Skip. wrote + skipped === welcomed.
+      welcomed: welcomedTotal,
+      skipped: Math.max(0, welcomedTotal - introductions.length),
+      // Never seen it, or seen it and walked away without pressing anything.
+      pending,
+      offered_help: introductions.filter(i => i.help.trim()).length,
+      gave_language: withLanguage.length,
+      language_respondents: withLanguage.length,
+    },
+    language_tally: languageTally,
+    language_unmatched: unmatched,
+  });
+});

--- a/tests/unit/admin-introductions.test.ts
+++ b/tests/unit/admin-introductions.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// /admin/introductions is the only place in the product that can read what
+// readers wrote about themselves on /welcome. The form has been collecting free
+// text since 2026-07-29 and nothing surfaced it — /admin/users shows *whether*
+// someone was welcomed, not a word of what they said.
+//
+// The load-bearing behaviour here is the language tally. Readers type free text
+// on purpose ("English and Spanish", "español", "Spanish-English", "I AM GOOD IN
+// ENGLISH, BUT SPANISH IS MY FIRST LANGUAGE") because a dropdown can only offer
+// the languages we already thought of. So the tally must count a *mention*, not
+// an exact match — and it must not silently drop answers it fails to recognise,
+// which would quietly defeat the entire reason the field is free text.
+let docs: Record<string, unknown>[] = [];
+let welcomedCount = 0;
+let pendingCount = 0;
+
+vi.mock('@/lib/auth-helpers', () => ({
+  // Auth is exercised by the shared withAuth tests; here it would only obscure
+  // the thing under test.
+  withAdminAuth: (h: (req: unknown, session: unknown) => Promise<Response>) =>
+    (req: unknown) => h(req, { user: { id: 'admin', role: 'superadmin' } }),
+}));
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: () => ({
+      find: () => ({
+        sort: () => ({ toArray: async () => docs }),
+      }),
+      countDocuments: async (q: Record<string, unknown>) =>
+        'welcomedAt' in q && q.welcomedAt === null ? pendingCount : welcomedCount,
+    }),
+  })),
+}));
+
+function intro(over: Record<string, unknown> = {}) {
+  return {
+    _id: 'u1',
+    name: 'A Reader',
+    email: 'reader@example.com',
+    createdAt: new Date('2026-07-29T10:00:00Z'),
+    profile: {
+      aboutYou: 'Here for the Hermetica.',
+      helpDescription: '',
+      preferredLanguage: 'English',
+      preferredLanguageKey: 'english',
+      updatedAt: new Date('2026-07-29T11:00:00Z'),
+    },
+    ...over,
+  };
+}
+
+async function call() {
+  const { GET } = await import('@/app/api/admin/introductions/route');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const res = await (GET as any)(new Request('https://sourcelibrary.org/api/admin/introductions'));
+  return res.json();
+}
+
+beforeEach(() => { docs = []; welcomedCount = 0; pendingCount = 0; });
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('/api/admin/introductions', () => {
+  it('returns what the reader actually wrote', async () => {
+    docs = [intro()];
+    welcomedCount = 1;
+    const body = await call();
+
+    expect(body.introductions).toHaveLength(1);
+    expect(body.introductions[0].about).toBe('Here for the Hermetica.');
+    expect(body.introductions[0].name).toBe('A Reader');
+    expect(body.introductions[0].email).toBe('reader@example.com');
+  });
+
+  it('counts skipped as welcomed-minus-wrote', async () => {
+    docs = [intro(), intro({ _id: 'u2' })];
+    welcomedCount = 5;
+    pendingCount = 3847;
+    const body = await call();
+
+    expect(body.totals.wrote).toBe(2);
+    expect(body.totals.welcomed).toBe(5);
+    expect(body.totals.skipped).toBe(3);
+    expect(body.totals.pending).toBe(3847);
+  });
+
+  it('never reports negative skips when the counts disagree', async () => {
+    // welcomedAt and profile.updatedAt are written by the same request, but a
+    // partial failure could leave more profiles than welcomes. A negative stat
+    // on an admin dashboard reads as a bug in the data, not in the arithmetic.
+    docs = [intro(), intro({ _id: 'u2' }), intro({ _id: 'u3' })];
+    welcomedCount = 1;
+    const body = await call();
+    expect(body.totals.skipped).toBe(0);
+  });
+});
+
+describe('language tally — counts mentions, not exact matches', () => {
+  const withLang = (lang: string, id: string) =>
+    intro({ _id: id, profile: { ...intro().profile, preferredLanguage: lang } });
+
+  it('counts a reader who names two languages for both', async () => {
+    docs = [withLang('English and Spanish', 'u1')];
+    const body = await call();
+    const tally = Object.fromEntries(body.language_tally.map((l: { language: string; count: number }) => [l.language, l.count]));
+
+    expect(tally.English).toBe(1);
+    expect(tally.Spanish).toBe(1);
+  });
+
+  it('recognises the language in the reader\'s own language', async () => {
+    // These are real answers from the first day of responses.
+    docs = [
+      withLang('español', 'u1'),
+      withLang('Español', 'u2'),
+      withLang('castellano', 'u3'),
+      withLang('Italiano', 'u4'),
+      withLang('inglés', 'u5'),
+    ];
+    const body = await call();
+    const tally = Object.fromEntries(body.language_tally.map((l: { language: string; count: number }) => [l.language, l.count]));
+
+    expect(tally.Spanish).toBe(3);
+    expect(tally.Italian).toBe(1);
+    expect(tally.English).toBe(1);
+  });
+
+  it('handles shouting, punctuation and full sentences', async () => {
+    docs = [
+      withLang('I AM GOOD IN ENGLISH, BUT SPANISH IS MY FIRST LANGUAGE', 'u1'),
+      withLang('Spanish-English', 'u2'),
+      withLang('English first, but I work directly in the German and Latin', 'u3'),
+    ];
+    const body = await call();
+    const tally = Object.fromEntries(body.language_tally.map((l: { language: string; count: number }) => [l.language, l.count]));
+
+    expect(tally.English).toBe(3);
+    expect(tally.Spanish).toBe(2);
+    expect(tally.German).toBe(1);
+    expect(tally.Latin).toBe(1);
+  });
+
+  it('surfaces answers it could not classify instead of dropping them', async () => {
+    // The whole point of a free-text field is catching what we did not predict.
+    // Silently discarding an unrecognised answer would defeat it — and would look
+    // identical to nobody having asked for that language.
+    docs = [withLang('Tagalog', 'u1'), withLang('Swahili', 'u2'), withLang('English', 'u3')];
+    const body = await call();
+
+    expect(body.language_unmatched).toContain('Tagalog');
+    expect(body.language_unmatched).toContain('Swahili');
+    expect(body.language_unmatched).not.toContain('English');
+  });
+
+  it('ignores blank answers rather than counting them as respondents', async () => {
+    docs = [withLang('', 'u1'), withLang('   ', 'u2'), withLang('English', 'u3')];
+    const body = await call();
+
+    expect(body.totals.gave_language).toBe(1);
+    expect(body.totals.language_respondents).toBe(1);
+  });
+
+  it('omits languages nobody named', async () => {
+    docs = [withLang('English', 'u1')];
+    const body = await call();
+    const names = body.language_tally.map((l: { language: string }) => l.language);
+
+    expect(names).toContain('English');
+    expect(names).not.toContain('Russian');
+  });
+});


### PR DESCRIPTION
## Why

The welcome form has been collecting free text since 2026-07-29 (#3448) and **nothing in the product could read it.** `/admin/users` shows *whether* someone was welcomed but not a word of what they said; the `volunteers` collection only receives a row when someone wrote something, so it under-reports. The only way to see the answers was a Mongo query.

Asking readers to write to you and never opening the letters is the failure this page prevents — the same shape as collecting a field nothing consumes.

There is real content in there. As of today, 32 introductions including an independent researcher on the Bavarian Illuminati offering a gap list for 1776–1800 literature and systematic OCR issue reports, and an offer to upload AI-translated books that needs a careful answer rather than a yes.

## What

`/admin/introductions`, in the superadmin nav next to Users.

- The introductions themselves, newest first, **rendered as prose rather than squeezed into table cells** — several run to hundreds of words and a table would truncate exactly the ones worth reading.
- Search across name, email, and text. Filters for *offered help* and *wrote at length* (the long answers carry the corpus gaps and the concrete offers; volume buries them).
- CSV export of the current filter.
- Counts: wrote / skipped / offered help / gave a language / not yet seen.

## The language tally is the load-bearing part

The field is deliberately free text so it can catch languages we did not think to offer. That has consequences the implementation has to respect:

- **Count a mention, not an exact match.** `English and Spanish` is evidence for both. So are `español`, `castellano`, `Spanish-English`, and `I AM GOOD IN ENGLISH, BUT SPANISH IS MY FIRST LANGUAGE` — all real answers from the first day.
- **Surface what no pattern matched, verbatim.** Silently dropping an unrecognised answer would defeat the entire reason the field is free text, and would look identical to nobody having asked for that language.

Early signal, for context on why this matters: ~77% of respondents so far name Spanish.

## Testing

`tests/unit/admin-introductions.test.ts` — 9 cases against the real route handler, using real answers from the first days of responses. Also covers the arithmetic guard that `skipped` can never render negative if `welcomedAt` and `profile.updatedAt` ever disagree (a negative stat on a dashboard reads as broken data, not broken arithmetic).

Verified as negative controls:
- dropping the unmatched-language list → **1 test fails**
- switching the tally to exact-match → **3 tests fail**

Full unit suite green (997 tests / 88 files). `npx tsc --noEmit` clean.

## Note on access

The route is `withAdminAuth`. The page shows real readers' names, email addresses, and personal statements — it is deliberately admin-only and there is no public surface for any of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)