### PR TITLE
fix(import): set the numeric `year` on every import route (#3267 follow-up)

### DIFF
--- a/src/app/api/import/e-rara/route.ts
+++ b/src/app/api/import/e-rara/route.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withCuratorAuth } from '@/lib/auth-helpers';
+import { publishedToYear } from '@/lib/resolve-language';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -177,6 +178,7 @@ export const POST = withCuratorAuth(async (request, session) => {
     const author = normalizeMarcAuthor(authorOverride) ?? normalizeMarcAuthor(metadata.creator);
     const authorForLookup = author ?? 'Unknown';
     const published = publishedOverride || metadata.date || 'Unknown';
+    const numericYear = publishedToYear(published);
     const language = languageOverride || metadata.language || 'Unknown';
 
     // Map language codes to full names
@@ -250,6 +252,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       author,
       language: languageFull,
       published,
+      ...(numericYear !== null ? { year: numericYear } : {}),
       categories: categories || [],
       ...(work_id ? { work_id } : {}),
       erara_id: numericId,

--- a/src/app/api/import/gallica/route.ts
+++ b/src/app/api/import/gallica/route.ts
@@ -8,7 +8,7 @@ import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
-import { resolveLanguage } from '@/lib/resolve-language';
+import { resolveLanguage, publishedToYear } from '@/lib/resolve-language';
 
 export const maxDuration = 300;
 
@@ -167,6 +167,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       ...(lang.original_language ? { original_language: lang.original_language } : {}),
       field_provenance: { language: lang.provenance },
       published: published || 'Unknown',
+      ...(publishedToYear(published) !== null ? { year: publishedToYear(published)! } : {}),
       categories: categories || [],
       ...(work_id ? { work_id } : {}),
       gallica_ark: ark,

--- a/src/app/api/import/google-books/route.ts
+++ b/src/app/api/import/google-books/route.ts
@@ -8,7 +8,7 @@ import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
-import { resolveLanguage, resolveDate, type LanguageSignal } from '@/lib/resolve-language';
+import { resolveLanguage, resolveDate, publishedToYear, type LanguageSignal } from '@/lib/resolve-language';
 
 export const maxDuration = 300;
 
@@ -187,6 +187,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       ...(lang.is_translation ? { is_translation: true } : {}),
       ...(lang.language_review ? { language_review: true } : {}),
       published: dateRes.published || 'Unknown',
+      ...(publishedToYear(dateRes.published) !== null ? { year: publishedToYear(dateRes.published)! } : {}),
       ...(dateRes.original_work_year ? { original_work_year: dateRes.original_work_year } : {}),
       field_provenance: { language: lang.provenance },
       categories: categories || [],

--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -8,7 +8,7 @@ import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
-import { resolveLanguage, resolveDate, type LanguageSignal } from '@/lib/resolve-language';
+import { resolveLanguage, resolveDate, publishedToYear, type LanguageSignal } from '@/lib/resolve-language';
 
 export const maxDuration = 300;
 
@@ -284,6 +284,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       ...(lang.is_translation ? { is_translation: true } : {}),
       ...(lang.language_review ? { language_review: true } : {}),
       published: dateRes.published || 'Unknown',
+      ...(publishedToYear(dateRes.published) !== null ? { year: publishedToYear(dateRes.published)! } : {}),
       ...(dateRes.original_work_year ? { original_work_year: dateRes.original_work_year } : {}),
       field_provenance: { language: lang.provenance },
       categories: categories || [],

--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -4,6 +4,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { withCuratorAuth } from '@/lib/auth-helpers';
+import { publishedToYear } from '@/lib/resolve-language';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -498,7 +499,9 @@ export const POST = withCuratorAuth(async (request, session) => {
       author,
       language: language || 'Unknown',
       published: published || 'Unknown',
-      ...(typeof year === 'number' ? { year } : /^\d{3,4}$/.test(String(published || '')) ? { year: parseInt(String(published), 10) } : {}),
+      ...(publishedToYear(typeof year === 'number' ? year : published) !== null
+        ? { year: publishedToYear(typeof year === 'number' ? year : published)! }
+        : {}),
       categories: categories || [],
       ...(requestCollections?.length ? { collections: requestCollections } : {}),
       ...(work_id ? { work_id } : {}),

--- a/src/app/api/import/loc/route.ts
+++ b/src/app/api/import/loc/route.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withCuratorAuth } from '@/lib/auth-helpers';
+import { publishedToYear } from '@/lib/resolve-language';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -243,6 +244,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       language: bookLanguage,
       published: bookPublished,
       categories: categories || [],
+      ...(publishedToYear(bookPublished) !== null ? { year: publishedToYear(bookPublished)! } : {}),
       ...(work_id ? { work_id } : {}),
       loc_lccn: lccn,
       thumbnail: selectedPages[0]?.thumbnail || '',

--- a/src/app/api/import/mdz/route.ts
+++ b/src/app/api/import/mdz/route.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withCuratorAuth } from '@/lib/auth-helpers';
+import { publishedToYear } from '@/lib/resolve-language';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -202,7 +203,7 @@ export const POST = withCuratorAuth(async (request, session) => {
       language: original_language || 'Unknown',
       original_language: original_language || 'Unknown',
       published: year ? String(year) : 'Unknown',
-      year: year || null,
+      ...(publishedToYear(year) !== null ? { year: publishedToYear(year)! } : {}),
       categories: categories || [],
       ...(work_id ? { work_id } : {}),
       mdz_id: normalizedId,

--- a/src/app/api/import/pdf/route.ts
+++ b/src/app/api/import/pdf/route.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withCuratorAuth } from '@/lib/auth-helpers';
+import { publishedToYear } from '@/lib/resolve-language';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { execFileSync } from 'child_process';
@@ -231,6 +232,7 @@ export const POST = withCuratorAuth(async (request) => {
       language,
       published,
       categories,
+      ...(publishedToYear(published) !== null ? { year: publishedToYear(published)! } : {}),
       thumbnail: blobUrls[0]?.photo || '',
       pages_count: pageCount,
       pages_ocr: 0,

--- a/src/app/api/import/wellcome/route.ts
+++ b/src/app/api/import/wellcome/route.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withCuratorAuth } from '@/lib/auth-helpers';
+import { publishedToYear } from '@/lib/resolve-language';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -251,7 +252,9 @@ export const POST = withCuratorAuth(async (request, session) => {
       language,
       published,
       categories: categories || work.subjects?.map(s => s.label) || [],
-      ...(typeof year === 'number' ? { year } : /^\d{3,4}$/.test(String(published || '')) ? { year: parseInt(String(published), 10) } : {}),
+      ...(publishedToYear(typeof year === 'number' ? year : published) !== null
+        ? { year: publishedToYear(typeof year === 'number' ? year : published)! }
+        : {}),
       ...(requestCollections?.length ? { collections: requestCollections } : {}),
       ...(work_id ? { work_id } : {}),
       wellcome_id: work_id,

--- a/src/lib/import-utils.ts
+++ b/src/lib/import-utils.ts
@@ -7,7 +7,7 @@ import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { computeProcessingPriority } from '@/lib/processing-priority';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
-import { resolveLanguage, resolveDate } from '@/lib/resolve-language';
+import { resolveLanguage, resolveDate, publishedToYear } from '@/lib/resolve-language';
 import { storeImportedManifest } from '@/lib/iiif-manifest-store';
 import { applyTextRole } from '@/lib/text-role';
 
@@ -381,6 +381,7 @@ export async function importBookFromIIIF(
     ...(lang.is_translation ? { is_translation: true } : {}),
     ...(lang.language_review ? { language_review: true } : {}),
     published: dateRes.published || 'Unknown',
+    ...(publishedToYear(dateRes.published) !== null ? { year: publishedToYear(dateRes.published)! } : {}),
     ...(dateRes.original_work_year ? { original_work_year: dateRes.original_work_year } : {}),
     field_provenance: { language: lang.provenance },
     categories: config.categories || [],

--- a/src/lib/resolve-language.ts
+++ b/src/lib/resolve-language.ts
@@ -184,3 +184,31 @@ function extractYear(s: string | null): string | null {
   const m = s.match(/-?\d{3,4}/);
   return m ? m[0] : null;
 }
+
+/**
+ * The numeric `year` that date range-filters read (#3267).
+ *
+ * `books.published` is FREE TEXT — `circa 1600`, `[1620]`, `1628.`, `n.d.`,
+ * roman numerals — so it can never be range-compared. `year` is the filterable
+ * twin, and a book without one is invisible to every date filter in search.
+ * Import routes must set it whenever `published` yields a plausible year.
+ *
+ * Returns null rather than guessing: no digits (`n.d.`, `MDCXXVIII`) or an
+ * implausible run (a shelfmark, a page count) leaves the field unset, which is
+ * honest — an absent `year` reads as "unknown", a wrong one silently misfiles
+ * the book into another century's results.
+ */
+export function publishedToYear(published?: string | number | null): number | null {
+  if (published == null) return null;
+  if (typeof published === 'number') return isPlausibleYear(published) ? published : null;
+  const raw = extractYear(clean(published));
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && isPlausibleYear(n) ? n : null;
+}
+
+function isPlausibleYear(n: number): boolean {
+  // Widest defensible window for a physical artefact we could hold: no future
+  // imprints, and a floor well below the oldest datable text in the corpus.
+  return n >= -3000 && n <= new Date().getFullYear() + 1;
+}

--- a/tests/unit/import-published-to-year.test.ts
+++ b/tests/unit/import-published-to-year.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `publishedToYear` — the numeric `year` that date range-filters read (#3267).
+ *
+ * `books.published` is free text, so it can never be range-compared; `year` is
+ * the filterable twin, and an import that omits it makes the book invisible to
+ * every date filter in search. Only 2 of 24 import routes set it before this
+ * change, and both used `/^\d{3,4}$/` against the whole string — which rejects
+ * every real-world early-modern imprint form below.
+ *
+ * These are BEHAVIOUR assertions: each case is an input the old expression got
+ * wrong (or a value we must refuse to invent). A source-shape test would have
+ * passed against the broken version.
+ */
+import { describe, it, expect } from 'vitest';
+import { publishedToYear } from '../../src/lib/resolve-language';
+
+describe('publishedToYear', () => {
+  it('reads a bare year', () => {
+    expect(publishedToYear('1628')).toBe(1628);
+  });
+
+  it('reads the free-text imprint forms the old regex rejected', () => {
+    // Every one of these returned null under /^\d{3,4}$/.test(published).
+    expect(publishedToYear('circa 1600')).toBe(1600);
+    expect(publishedToYear('[1620]')).toBe(1620);
+    expect(publishedToYear('1628.')).toBe(1628);
+    expect(publishedToYear('M.DC.XXVIII [1628]')).toBe(1628);
+    expect(publishedToYear('1628-1630')).toBe(1628);
+    expect(publishedToYear(' 1543 ')).toBe(1543);
+  });
+
+  it('accepts a caller-supplied number', () => {
+    expect(publishedToYear(1628)).toBe(1628);
+  });
+
+  it('handles three-digit and negative (BCE) years', () => {
+    expect(publishedToYear('987')).toBe(987);
+    expect(publishedToYear('-350')).toBe(-350);
+  });
+
+  it('refuses to invent a year rather than guessing wrong', () => {
+    // An absent year reads as "unknown"; a wrong one silently misfiles the book
+    // into another century's filter results.
+    expect(publishedToYear('n.d.')).toBeNull();
+    expect(publishedToYear('Unknown')).toBeNull();
+    expect(publishedToYear('unknown')).toBeNull();
+    expect(publishedToYear('MDCXXVIII')).toBeNull(); // roman only, no digits
+    expect(publishedToYear('')).toBeNull();
+    expect(publishedToYear(null)).toBeNull();
+    expect(publishedToYear(undefined)).toBeNull();
+  });
+
+  it('rejects implausible years', () => {
+    expect(publishedToYear('9999')).toBeNull();
+    expect(publishedToYear(String(new Date().getFullYear() + 5))).toBeNull();
+  });
+
+  it('never returns NaN — a NaN year would poison every range comparison', () => {
+    for (const v of ['n.d.', 'Unknown', '', 'MDCXXVIII', null, undefined]) {
+      const y = publishedToYear(v as string | null | undefined);
+      expect(y === null || Number.isFinite(y)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Why

`books.published` is **free text** — `circa 1600`, `[1620]`, `1628.`, `n.d.`, roman numerals — so it can never be range-compared. `year` is the filterable twin that every date filter in search actually reads (per the "Search filters must be enforced in every lane" section in CLAUDE.md).

**Only 2 of 24 import routes set it.** Both used `/^\d{3,4}$/.test(String(published))`, which rejects every real-world early-modern imprint form listed above.

Found while importing Thibault's *Académie de l'Espée* (Gallica, 1628): the book landed with no `year` at all, so it would not have appeared in any date-range filter.

## Measured impact

Books with no numeric `year`, by provider — `recoverable` = has a `published` string a year can be read from:

| provider | total | no year | recoverable |
|---|---|---|---|
| internet_archive | 29,149 | 20,503 | 8,111 |
| iiif | 16,988 | 12,780 | 189 |
| e-rara | 13,163 | 12,014 | 11,976 |
| bsb | 5,871 | 4,913 | 4,912 |
| gallica | 840 | 568 | 3 |

~55K books total carry no `year`; ~25K are trivially recoverable.

## What changed

- `publishedToYear()` added beside the existing private `extractYear()` in `src/lib/resolve-language.ts` — one definition, range-checked, returns `null` rather than inventing a year.
- Wired into `importBookFromIIIF` (covers the ~15 thin provider routes) plus the standalone `gallica` / `google-books` / `ia` / `loc` / `e-rara` / `pdf` / `mdz` paths.
- The two hand-rolled inline expressions (`iiif`, `wellcome`) now call the helper, so there is one definition instead of three.
- `mdz` no longer writes an explicit `year: null` — an unset field is what "unknown" should look like.

## Explicitly out of scope

**Backfilling the ~25K existing recoverable books.** That is a data sweep with its own review — which providers, what to do with `original_work_year`, whether Supabase `books_catalog` needs a resync afterwards — and should not ride along with a code change. Happy to do it as a follow-up.

## Testing

`tests/unit/import-published-to-year.test.ts` — **behavioural, not source-shape**. Every case is either an input the old expression got wrong (`circa 1600`, `[1620]`, `1628.`, `M.DC.XXVIII [1628]`) or a value we must refuse to invent (`n.d.`, `MDCXXVIII`, `9999`, `null`). A source-grep test would have passed against the broken version.

- `npx tsc --noEmit` — clean
- `npx vitest run` — 89 files / 1095 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)