### PR TITLE
fix(archive): stall timeout instead of a total-duration cap on image fetches

### DIFF
--- a/scripts/lib/fetch-stall-timeout.mjs
+++ b/scripts/lib/fetch-stall-timeout.mjs
@@ -1,0 +1,94 @@
+/**
+ * Fetch an image with a STALL timeout instead of a total-duration cap.
+ *
+ * Why this exists (measured on Thibault, *Académie de l'Espée*, Gallica
+ * bpt6k1912344f, 2026-07-31):
+ *
+ * The archivers aborted a fetch 60s after it *started*. That is a cap on file
+ * size wearing a clock's clothing — at Gallica's ~570 KB/s, 60s buys ~34 MB
+ * only if nothing else shares the pipe. The book's 45 double-page engravings
+ * are ~21.7 MB each (11,873 × 8,919 px) and take ~38s alone; with two workers
+ * sharing bandwidth they cross 60s and abort. Result: 42 of 45 plates failed
+ * while the ordinary 6 MB text pages sailed through.
+ *
+ * The failure therefore selects for the LARGEST page in a book — which is
+ * always the foldout, the map, the plate: the pages a reader actually came
+ * for. And it is invisible, because the book still reports hundreds of
+ * successfully archived pages.
+ *
+ * A stall timeout asks the right question — "is this connection still
+ * delivering?" — rather than "has this taken too long?", so a 200 MB plate on
+ * a slow link succeeds while a genuinely dead socket still fails fast. The
+ * absolute `maxMs` cap remains as a backstop against a connection that
+ * trickles forever.
+ *
+ * NOTE: do NOT "fix" a timeout of this kind by requesting a smaller IIIF size.
+ * Width caps on wide-format material are the #3186 mistake (~2.1M pages left
+ * 2-9× below their masters) and are doubly destructive on exactly the
+ * double-page plates this function exists to rescue.
+ */
+
+/**
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {number} [opts.stallMs=60000]  Abort if no bytes arrive for this long.
+ * @param {number} [opts.maxMs=900000]   Absolute backstop for a trickling connection.
+ * @param {Record<string,string>} [opts.headers]
+ * @returns {Promise<{ res: Response, buffer: Buffer }>}
+ */
+export async function fetchWithStallTimeout(url, opts = {}) {
+  const stallMs = opts.stallMs ?? 60_000;
+  const maxMs = opts.maxMs ?? 15 * 60_000;
+  const headers = opts.headers ?? {};
+
+  const controller = new AbortController();
+  let abortReason = null;
+  let stallTimer = null;
+
+  const armStall = () => {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => {
+      abortReason = `stalled — no data for ${Math.round(stallMs / 1000)}s`;
+      controller.abort();
+    }, stallMs);
+  };
+  const hardTimer = setTimeout(() => {
+    abortReason = `exceeded absolute cap of ${Math.round(maxMs / 1000)}s`;
+    controller.abort();
+  }, maxMs);
+
+  const cleanup = () => {
+    if (stallTimer) clearTimeout(stallTimer);
+    clearTimeout(hardTimer);
+  };
+
+  armStall();
+  try {
+    const res = await fetch(url, { signal: controller.signal, headers });
+
+    // Caller inspects status (429 handling, etc). Only drain the body on 2xx —
+    // reading a large error page would be pointless work.
+    if (!res.ok) {
+      cleanup();
+      return { res, buffer: Buffer.alloc(0) };
+    }
+
+    // Stream so the stall timer can be re-armed per chunk. `res.arrayBuffer()`
+    // gives no progress signal, which is what forced the total-duration cap.
+    const chunks = [];
+    if (res.body) {
+      for await (const chunk of res.body) {
+        chunks.push(Buffer.from(chunk));
+        armStall();
+      }
+    }
+    cleanup();
+    return { res, buffer: Buffer.concat(chunks) };
+  } catch (err) {
+    cleanup();
+    // Surface WHY it aborted. A bare "This operation was aborted" is what made
+    // the original failure read as rate-limiting for two debugging passes.
+    if (abortReason) throw new Error(`fetch aborted: ${abortReason} (${url})`);
+    throw err;
+  }
+}

--- a/scripts/workers/archive-gallica.mjs
+++ b/scripts/workers/archive-gallica.mjs
@@ -17,6 +17,7 @@ import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
+import { fetchWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -26,6 +27,10 @@ const PAGE_LIMIT = parseInt(getArg('limit') || '2000', 10);
 const CONCURRENCY = parseInt(getArg('concurrency') || '2', 10);
 const RATE_PER_SEC = parseFloat(getArg('rate') || '1');
 const DRY_RUN = hasFlag('dry-run');
+// Abort only when a connection goes QUIET for this long — never merely because
+// a file is big. Raising this does not slow healthy fetches; it only widens the
+// window a genuinely stalled socket gets before we give up on it.
+const FETCH_STALL_MS = parseInt(getArg('stall-timeout') || '60000', 10);
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID;
@@ -82,15 +87,16 @@ function upgradeToFullRes(url) {
 
 async function downloadImage(url, maxRetries = 4) {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 60_000);
     try {
-      const res = await fetch(url, {
-        signal: controller.signal,
+      // Stall timeout, not a total-duration cap: a 21 MB double-page plate is
+      // slow because it is large, not because the connection is broken. The
+      // old 60s wall-clock abort failed 42 of this book's 45 engravings while
+      // every 6 MB text page succeeded. See scripts/lib/fetch-stall-timeout.mjs.
+      const { res, buffer } = await fetchWithStallTimeout(url, {
+        stallMs: FETCH_STALL_MS,
         headers: { 'User-Agent': USER_AGENT },
       });
       if (res.status === 429) {
-        clearTimeout(timeout);
         // Exponential backoff: 5s, 10s, 20s, 40s
         const backoff = 5000 * Math.pow(2, attempt);
         if (attempt < maxRetries) {
@@ -100,10 +106,8 @@ async function downloadImage(url, maxRetries = 4) {
         throw new Error(`HTTP 429 after ${maxRetries + 1} attempts`);
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const buffer = Buffer.from(await res.arrayBuffer());
       return buffer;
     } catch (err) {
-      clearTimeout(timeout);
       if (attempt === maxRetries || !err.message?.includes('429')) throw err;
     }
   }

--- a/tests/unit/fetch-stall-timeout.test.ts
+++ b/tests/unit/fetch-stall-timeout.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `fetchWithStallTimeout` — a stall timeout, not a total-duration cap.
+ *
+ * The bug this replaces: archivers aborted 60s after a fetch STARTED, which is
+ * a size limit wearing a clock's clothing. Measured on Thibault's *Académie de
+ * l'Espée* (Gallica), the 21.7 MB double-page plates took ~38s alone and blew
+ * the cap under any concurrency — 42 of 45 engravings failed while every 6 MB
+ * text page succeeded.
+ *
+ * Each test drives a real HTTP server rather than asserting on source shape,
+ * and the first test includes a NEGATIVE CONTROL: the same slow-but-healthy
+ * response is shown to fail under the old total-duration cap. Without that,
+ * the test proves nothing about whether the fix was needed.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+// @ts-expect-error — plain .mjs helper, no types
+import { fetchWithStallTimeout } from '../../scripts/lib/fetch-stall-timeout.mjs';
+
+let server: http.Server | null = null;
+
+function listen(handler: http.RequestListener): Promise<string> {
+  return new Promise((resolve) => {
+    server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server!.address() as AddressInfo;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/** The old implementation: abort N ms after the fetch begins, regardless of progress. */
+async function fetchWithTotalCap(url: string, capMs: number): Promise<Buffer> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), capMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    return Buffer.from(await res.arrayBuffer());
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((r) => server!.close(() => r()));
+    server = null;
+  }
+});
+
+describe('fetchWithStallTimeout', () => {
+  it('completes a slow but steadily-progressing body that a total-duration cap would abort', async () => {
+    // 10 chunks, 60ms apart => ~600ms total, but never more than 60ms of silence.
+    // This is a large plate on a slow link, in miniature.
+    const url = await listen((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'image/jpeg' });
+      let n = 0;
+      const tick = setInterval(() => {
+        if (n++ >= 10) {
+          clearInterval(tick);
+          res.end();
+          return;
+        }
+        res.write(Buffer.alloc(1024, 1));
+      }, 60);
+    });
+
+    const { res, buffer } = await fetchWithStallTimeout(url, { stallMs: 300 });
+    expect(res.ok).toBe(true);
+    expect(buffer.length).toBe(10 * 1024);
+
+    // NEGATIVE CONTROL: the same healthy response under the old 300ms total cap.
+    // If this did NOT throw, the stall timeout would be solving nothing.
+    await expect(fetchWithTotalCap(url, 300)).rejects.toThrow();
+  });
+
+  it('aborts a connection that goes silent, and says why', async () => {
+    // Headers, one chunk, then nothing — a dead socket, which we must still catch.
+    const url = await listen((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'image/jpeg' });
+      res.write(Buffer.alloc(64, 1));
+      // deliberately never end
+    });
+
+    await expect(fetchWithStallTimeout(url, { stallMs: 150 })).rejects.toThrow(/stalled/);
+  });
+
+  it('names the reason rather than surfacing a bare "operation was aborted"', async () => {
+    // The opaque abort message is what made this read as rate-limiting for two
+    // debugging passes, so the reason text is part of the contract.
+    const url = await listen((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'image/jpeg' });
+      res.write(Buffer.alloc(8, 1));
+    });
+
+    await expect(fetchWithStallTimeout(url, { stallMs: 100 })).rejects.toThrow(/no data for/);
+  });
+
+  it('returns a non-ok response to the caller instead of throwing, so 429 handling still works', async () => {
+    const url = await listen((_req, res) => {
+      res.writeHead(429, { 'Content-Type': 'text/plain' });
+      res.end('slow down');
+    });
+
+    const { res } = await fetchWithStallTimeout(url, { stallMs: 500 });
+    expect(res.status).toBe(429);
+  });
+
+  it('enforces the absolute backstop against a connection that trickles forever', async () => {
+    // Chunks forever, each inside the stall window — healthy by the stall test,
+    // but it must not run unbounded.
+    const url = await listen((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'image/jpeg' });
+      const tick = setInterval(() => res.write(Buffer.alloc(8, 1)), 20);
+      res.on('close', () => clearInterval(tick));
+    });
+
+    await expect(
+      fetchWithStallTimeout(url, { stallMs: 5_000, maxMs: 300 })
+    ).rejects.toThrow(/absolute cap/);
+  });
+});


### PR DESCRIPTION
## The bug

A fetch aborted 60s after it **started** is a cap on *file size* wearing a clock's costume. At Gallica's ~570 KB/s, 60s buys ~34 MB — and only if nothing else shares the pipe. So the abort selects for the largest page in a book, which is always the foldout, the map, the plate.

Measured while acquiring Thibault's *Académie de l'Espée* (Gallica `bpt6k1912344f`):

| | size | time alone | outcome |
|---|---|---|---|
| ordinary text page | ~6 MB | ~13s | always succeeded |
| double-page engraving | **21.7 MB** (11,873 × 8,919) | **38s** | aborted under any concurrency |

**42 of the book's 45 engravings failed. Every text page succeeded.** The book still reported hundreds of pages archived, so nothing looked wrong from the outside — this is a silent, systematic loss of exactly the pages a reader came for.

It also misleads the person debugging it. The abort surfaces as `This operation was aborted`, which reads as rate-limiting; I slowed the request rate in response and made it strictly **worse**, because the constraint is per-request duration, not requests per second.

## The fix

`scripts/lib/fetch-stall-timeout.mjs` asks *"is this connection still delivering?"* instead of *"has this taken too long?"* — it streams the body and re-arms the timer on each chunk.

- A 200 MB plate on a slow link now succeeds.
- A dead socket still fails fast.
- An absolute `maxMs` backstop still bounds a connection that trickles forever.
- Abort errors now **name their reason** instead of the opaque bare abort.

Wired into `archive-gallica.mjs`, with `--stall-timeout` to tune.

## What I did NOT do

**Request a smaller IIIF size.** That's the easy way to beat a timeout and it's the #3186 mistake — a width cap on 12,000px double-page plates crushes precisely the detail worth keeping, and that recovery sweep (~2.1M pages, 2–9× below master) is still expensive.

**Blind-convert the other archivers.** The same total-duration pattern exists in `archive-ocr.mjs` (60s), `archive-harvard.mjs` (60s), `archive-eap.mjs` (30s), plus configurable-but-still-total caps in `archive-erara.mjs` and `archive-bulk.mjs`. `archive-ocr.mjs` is the most exposed — it's the other per-page IIIF full-res archiver and carries a `// 60s for full-res images` comment. I have a live reproduction and measurements only for Gallica, and I'd rather convert each with its own evidence than edit five workers on inference. Happy to follow up.

## Testing

`tests/unit/fetch-stall-timeout.test.ts` drives a **real HTTP server**, and the first test carries a **negative control**: the same slow-but-healthy response is shown to fail under the old total-duration cap. Without that control the test can't tell a fix from a no-op.

Covers: slow-but-progressing body succeeds; silent connection aborts; the abort names its reason; a 429 is returned to the caller rather than thrown (so existing backoff still works); the absolute backstop fires.

- `npx vitest run` — 90 files / 1102 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)