### PR TITLE
fix(health): confirm before paging "sign-in is broken"

### DIFF
--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -19,8 +19,6 @@
 15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-prewarm.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/prewarm-browse.mjs" >> /var/log/sourcelibrary/prewarm-browse.log 2>&1
 */2 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-scheduler.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/scheduler.mjs" >> /var/log/sourcelibrary/scheduler.log 2>&1
 30 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-entity-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-entities.mjs" >> /var/log/sourcelibrary/entity-sync.log 2>&1
-# canonical_entities read-model rebuild (#2979) — after 02:15 Vercel enrich-entities cron + 03:30 entity sync
-45 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-canonical-entities.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/build-canonical-entities.mjs --apply" >> /var/log/sourcelibrary/canonical-entities.log 2>&1
 #PAUSED-GEMINI 30 */4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-embed-gemini.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=\$GEMINI_API_KEY_TIER3 && node scripts/workers/embed-gemini.mjs --incremental" >> /var/log/sourcelibrary/embed-gemini.log 2>&1
 30 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/snapshot-stats.mjs" >> /var/log/sourcelibrary/snapshot.log 2>&1
 30 5 * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; curl -s -X POST https://sourcelibrary.org/api/admin/cache-probe -H "Authorization: Bearer $CRON_SECRET"" >> /var/log/sourcelibrary/cache-probe.log 2>&1
@@ -69,13 +67,16 @@
 # during the transition (they got removed from vercel.json in the same PR).
 
 # Auth provider health probe — Google OAuth, Resend, NextAuth session, DB
-*/10 * * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; node scripts/workers/cron-caller.mjs /api/health/auth" >> /var/log/sourcelibrary/cron-caller.log 2>&1
+# Offset to :03 (not :00): nine cron schedules converge at 00:00 UTC, and the
+# resulting pile of cold Vercel functions all dialling Atlas at once dropped a
+# TLS handshake on 2026-07-31, paging a false "sign-in is broken".
+3-59/10 * * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; node scripts/workers/cron-caller.mjs /api/health/auth" >> /var/log/sourcelibrary/cron-caller.log 2>&1
 
-# DB + zombie-job health check
-0 * * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; node scripts/workers/cron-caller.mjs health-check" >> /var/log/sourcelibrary/cron-caller.log 2>&1
+# DB + zombie-job health check (offset to :02, off the top-of-hour cron pile-up)
+2 * * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; node scripts/workers/cron-caller.mjs health-check" >> /var/log/sourcelibrary/cron-caller.log 2>&1
 
-# Latency trend (consumes cron_runs left by health-check; 5min offset gives it a head start)
-5 * * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; node scripts/workers/cron-caller.mjs latency-trend" >> /var/log/sourcelibrary/cron-caller.log 2>&1
+# Latency trend (consumes cron_runs left by health-check; still +5min after it, now :07)
+7 * * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; node scripts/workers/cron-caller.mjs latency-trend" >> /var/log/sourcelibrary/cron-caller.log 2>&1
 
 # Image-side embeddings — artwork_embeddings, gallery_text_embeddings, clip_embeddings (issue #2021)
 # These tables had no recurring writer; froze for 35+ days. Uses TIER3 paid key for data-rights.
@@ -92,10 +93,7 @@
 #RETIRED-2933 40 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-discover.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/discover-translations-estimate.mjs --save --limit 300 && node scripts/maintenance/apply-discovery-results.mjs --apply" >> /var/log/sourcelibrary/ft-discover.log 2>&1
 #RETIRED-2933 0 8 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-ground.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analysis/ft-ground-remediation.mjs --set unverified --limit 250" >> /var/log/sourcelibrary/ft-ground.log 2>&1
 
-# FT single-writer loop (#2933-C): derive graded verdicts from the evidence ledger
-# (free, non-public), then materialize ONLY agent/human-verified demotions.
-# Promotions and catalog-tier demotions stay sign-off-gated (census 2026-07-02:
-# ~46% of unverified Stage-1 'prior exists' claims were wrong).
+# FT single-writer loop (#2933-C): derive graded verdicts (free) then materialize ONLY agent/human-verified demotions
 30 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-ft-derive.lock bash -c "set -a; source .env.production.local; set +a; npx tsx scripts/maintenance/derive-ft-verdict-from-attempts.ts --apply && npx tsx scripts/maintenance/reconcile-first-translation-flag.ts --apply --only-demotions --verdict=not_first,not_applicable --resolver=tier2_agent,human" >> /var/log/sourcelibrary/ft-derive.log 2>&1
 
 # Crontab drift detector — logs if live crontab diverges from committed snapshot (#2332)
@@ -113,15 +111,21 @@
 30 5 * * * cd /root/sourcelibrary && [ -f scripts/enrichment/backfill-thesaurus-author-locations.mjs ] && flock -n /tmp/sl-thesaurus-loc.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/backfill-thesaurus-author-locations.mjs --write-books" >> /var/log/sourcelibrary/geocode-locations.log 2>&1
 0 9 * * * cd /root/sourcelibrary && flock -n /tmp/sl-newsletter-refresh.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/refresh-newsletter-audience.mjs" >> /var/log/sourcelibrary/newsletter-refresh.log 2>&1
 45 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-metrics-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analytics/snapshot-metrics.mjs" >> /var/log/sourcelibrary/metrics-snapshot.log 2>&1
-# Reading Register (external-only readers/agents/search) -> system_config.reading_register, read by /platform/admin/reading-register
-50 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-reading-register.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analytics/snapshot-reading-register.mjs" >> /var/log/sourcelibrary/reading-register.log 2>&1
 # On-mission acquisition: daily bounded batch (USTC gap -> IA/e-rara -> verify -> import hidden)
 # e-rara IIIF catalog refresh: weekly
 0 2 * * 0 cd /root/sourcelibrary && flock -n /tmp/sl-erara.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/harvest-erara-catalog.mjs" >> /var/log/sourcelibrary/erara-harvest.log 2>&1
 # On-mission acquisition: hourly bounded concurrent batch
-30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-acquire.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/acquire-gap-batch.mjs --batch 400 --concurrency 12" >> /var/log/sourcelibrary/acquire.log 2>&1
+30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-acquire.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/acquire-gap-batch.mjs --batch 400 --concurrency 10" >> /var/log/sourcelibrary/acquire.log 2>&1
 # Archive newly-acquired gap books to R2 (companion to acquisition)
-45 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-arch-acq.lock bash -c "set -a; source .env.production.local; set +a; npx tsx scripts/catalog-coverage/archive-acquired.ts --batch 120 --concurrency 6" >> /var/log/sourcelibrary/archive-acquired.log 2>&1
-# catchup-watchdog: keep the acquisition catch-up alive while pending work remains
+45 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-arch-acq.lock bash -c "set -a; source .env.production.local; set +a; npx tsx scripts/catalog-coverage/archive-acquired.ts --batch 240 --concurrency 10" >> /var/log/sourcelibrary/archive-acquired.log 2>&1
 */20 * * * * tmux has-session -t catchup 2>/dev/null || ( cd /root/sourcelibrary && P=$(bash -c "set -a; source .env.production.local; set +a; node -e \"const {MongoClient}=require(process.cwd()+\x27/node_modules/mongodb\x27);(async()=>{const c=new MongoClient(process.env.MONGODB_URI);await c.connect();console.log(await c.db(\x27bookstore\x27).collection(\x27acquisition_queue\x27).countDocuments({status:\x27pending\x27}));await c.close();})()\"" 2>/dev/null); [ "$P" -gt 500 ] 2>/dev/null && tmux new-session -d -s catchup "/tmp/acquire_catchup.sh" )
 30 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-supabase-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/supabase-sync.mjs" >> /var/log/sourcelibrary/supabase-sync.log 2>&1
+# catchup-watchdog: restart the acquisition catch-up if it died (loop self-exits when queue drains)
+*/15 * * * * ( [ -f /tmp/acquire_catchup.sh ] && tmux has-session -t catchup 2>/dev/null ) || ( [ -f /tmp/acquire_catchup.sh ] && tmux new-session -d -s catchup "/tmp/acquire_catchup.sh" )
+#TEMP-FT-CENSUS (#2933) — remove when ft-census-daily reports exhausted
+30 9 * * * flock -n /tmp/sl-ft-census.lock bash /root/sourcelibrary/scripts/eval/ft-census-daily.sh >> /var/log/sourcelibrary/ft-census.log 2>&1
+# canonical_entities read-model rebuild (#2979) — after 02:15 Vercel enrich-entities cron + 03:30 entity sync
+45 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-canonical-entities.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/build-canonical-entities.mjs --apply" >> /var/log/sourcelibrary/canonical-entities.log 2>&1
+0 5 * * * /root/restic-backup.sh
+# Traffic anomaly detector — pushes to ntfy on state change (#3446)
+17 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-traffic-anomaly.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/traffic-anomaly-alert.mjs" >> /var/log/sourcelibrary/traffic-anomaly.log 2>&1

--- a/src/app/api/cron/health-check/route.ts
+++ b/src/app/api/cron/health-check/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getDb, forceReconnect } from '@/lib/mongodb';
 import { verifyCronAuth } from '@/lib/cron-auth';
+import { retryWithBackoff } from '@/lib/health-alerting';
 
 export const maxDuration = 30;
 export const preferredRegion = 'fra1';
@@ -31,19 +32,31 @@ export async function GET(request: NextRequest) {
   const t0 = Date.now();
 
   // 1. DB connectivity + latency
+  //
+  // Retried with backoff and a forced reconnect. This probe runs only once an
+  // hour, so a streak gate (as on /api/health/auth) would delay a real
+  // DB-is-down page by an hour — too slow. Absorbing the blip inside the single
+  // request is the right guard here instead. On 2026-07-31 a dropped Atlas TLS
+  // handshake made this report `status: down` while the site served readers
+  // normally and accounts were being created; the connection was fine seconds
+  // later, so one retry with a real delay would have caught it.
   let db;
   try {
-    db = await getDb();
-    const t1 = Date.now();
-    await db.command({ ping: 1 });
-    const pingMs = Date.now() - t1;
+    let pingMs = 0;
+    db = await retryWithBackoff(async attempt => {
+      const handle = attempt === 0 ? await getDb() : await forceReconnect();
+      const t1 = Date.now();
+      await handle.command({ ping: 1 });
+      pingMs = Date.now() - t1;
+      return handle;
+    });
     latencies.db_ping = pingMs;
     if (pingMs > THRESHOLDS.ping) {
       issues.push({ check: 'ping', detail: `${pingMs}ms (threshold: ${THRESHOLDS.ping}ms)`, severity: 'critical' });
     }
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    issues.push({ check: 'db_connect', detail: msg, severity: 'critical' });
+    issues.push({ check: 'db_connect', detail: `${msg} (after retries)`, severity: 'critical' });
     // Can't do any more checks without DB
     await sendAlertIfNeeded(null, issues);
     return NextResponse.json({ status: 'down', issues, duration_ms: Date.now() - t0 }, { status: 503 });

--- a/src/app/api/health/auth/route.ts
+++ b/src/app/api/health/auth/route.ts
@@ -1,12 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb, forceReconnect } from '@/lib/mongodb';
 import { verifyCronAuth } from '@/lib/cron-auth';
+import { retryWithBackoff, recordFailureStreaks, clearFailureStreaks } from '@/lib/health-alerting';
 
 export const dynamic = 'force-dynamic';
-export const maxDuration = 15;
+// Raised from 15s to cover the in-probe retry backoff added below. A clean run
+// still finishes in ~1s; only a failing run spends the extra budget.
+export const maxDuration = 25;
 
 const ALERT_EMAIL = process.env.ALERT_EMAIL || 'derek@sourcelibrary.org';
 const COOLDOWN_MS = 60 * 60 * 1000; // 1 alert per hour max
+const ALERT_STATE_KEY = 'auth_alert_state';
+
+/**
+ * Consecutive failed probes required before paging. The probe runs every 10
+ * minutes, so a real outage is still reported within ~20 minutes, while a
+ * single transient fault (the 2026-07-31 Atlas TLS drop) stays silent.
+ */
+const CONSECUTIVE_FAILURES_TO_ALERT = 2;
 
 interface AuthCheck {
   provider: string;
@@ -47,15 +58,51 @@ export async function GET(request: NextRequest) {
   const failures = checks.filter(c => c.status === 'error');
   const status = failures.length === 0 ? 'healthy' : 'broken';
 
-  // Alert if any provider is broken
+  // A single failed probe is not evidence that users cannot sign in — it is far
+  // more often evidence that the probe's own connection blipped. Page only once
+  // the SAME provider has failed on consecutive probes.
+  let streak: Awaited<ReturnType<typeof recordFailureStreaks>> | null = null;
+  const streakDb = await getStreakDb();
+
   if (failures.length > 0) {
-    await sendAuthAlert(failures);
+    streak = await recordFailureStreaks(
+      streakDb,
+      ALERT_STATE_KEY,
+      failures.map(f => f.provider),
+      CONSECUTIVE_FAILURES_TO_ALERT
+    );
+    const confirmed = failures.filter(f => streak!.confirmed.includes(f.provider));
+    if (confirmed.length > 0) {
+      await sendAuthAlert(confirmed, streak);
+    }
+  } else {
+    await clearFailureStreaks(streakDb, ALERT_STATE_KEY);
   }
 
   return NextResponse.json(
-    { status, checks, timestamp: new Date().toISOString() },
+    {
+      status,
+      checks,
+      // Surfaced so the cron log distinguishes "first failure, watching" from
+      // "confirmed, paged" without opening the mailbox.
+      ...(streak ? { alerted: streak.confirmed.length > 0, streaks: streak.streaks } : {}),
+      timestamp: new Date().toISOString(),
+    },
     { status: failures.length > 0 ? 503 : 200 }
   );
+}
+
+/**
+ * Db handle for the streak store. Returns null when Atlas is genuinely
+ * unreachable, which `recordFailureStreaks` treats as "alert now" — a total DB
+ * outage is exactly the case that should page on the first probe.
+ */
+async function getStreakDb() {
+  try {
+    return await getDb();
+  } catch {
+    return null;
+  }
 }
 
 async function checkGoogleOAuth(): Promise<AuthCheck> {
@@ -114,62 +161,68 @@ async function checkEmailProvider(): Promise<AuthCheck> {
     return { provider: 'email', status: 'error', detail: 'RESEND_API_KEY missing' };
   }
 
-  // One retry on transient network errors: the api.resend.com probe occasionally
-  // exceeds the 5s budget even though real `resend.emails.send` calls during
-  // sign-in are unaffected. A single failed probe should not page Derek.
-  let lastErr: unknown;
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
+  // Retry transient network errors WITH BACKOFF: the api.resend.com probe
+  // occasionally exceeds the 5s budget even though real `resend.emails.send`
+  // calls during sign-in are unaffected. Back-to-back retries with no delay
+  // (the previous behaviour) are defeated by any fault lasting a second or two.
+  try {
+    return await retryWithBackoff(async () => {
       // Validate API key by fetching domains (lightweight, no side effects)
       const res = await fetch('https://api.resend.com/domains', {
         headers: { Authorization: `Bearer ${process.env.RESEND_API_KEY}` },
         signal: AbortSignal.timeout(5000),
       });
+      // A definitive answer from Resend is not worth retrying — return it as-is.
       if (res.status === 401 || res.status === 403) {
-        return { provider: 'email', status: 'error', detail: 'RESEND_API_KEY is invalid' };
+        return { provider: 'email', status: 'error', detail: 'RESEND_API_KEY is invalid' } as AuthCheck;
       }
       if (!res.ok) {
-        return { provider: 'email', status: 'error', detail: `Resend API returned ${res.status}` };
+        return { provider: 'email', status: 'error', detail: `Resend API returned ${res.status}` } as AuthCheck;
       }
-      return { provider: 'email', status: 'ok' };
-    } catch (e) {
-      lastErr = e;
-    }
+      return { provider: 'email', status: 'ok' } as AuthCheck;
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { provider: 'email', status: 'error', detail: `Resend check failed (after retries): ${msg}` };
   }
-  const msg = lastErr instanceof Error ? lastErr.message : String(lastErr);
-  return { provider: 'email', status: 'error', detail: `Resend check failed (after retry): ${msg}` };
 }
 
 async function checkMongoAdapter(): Promise<AuthCheck> {
-  // One retry with forced reconnect: Atlas TLS handshakes occasionally drop
-  // ("Client network socket disconnected before secure TLS connection was established").
-  // The MongoDB client recovers transparently for user requests, so a single failed
-  // probe should not page Derek.
-  let lastErr: unknown;
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const db = attempt === 0 ? await getDb() : await forceReconnect();
-      const count = await db.collection('users').estimatedDocumentCount({ maxTimeMS: 5000 } as any);
-      if (count === 0) {
-        return { provider: 'database', status: 'error', detail: 'Users collection is empty' };
+  // Retry with forced reconnect AND backoff: Atlas TLS handshakes occasionally
+  // drop ("Client network socket disconnected before secure TLS connection was
+  // established"), most often when a pile of cold functions dial out at once.
+  // The MongoDB client recovers transparently for user requests. The previous
+  // version retried immediately, which is why a single ~2s fault on 2026-07-31
+  // exhausted both attempts and paged a "sign-in is broken" email while users
+  // were signing in normally.
+  try {
+    const count = await retryWithBackoff(
+      async attempt => {
+        const db = attempt === 0 ? await getDb() : await forceReconnect();
+        return db.collection('users').estimatedDocumentCount({ maxTimeMS: 5000 } as any);
       }
-      return { provider: 'database', status: 'ok' };
-    } catch (e) {
-      lastErr = e;
+    );
+    if (count === 0) {
+      return { provider: 'database', status: 'error', detail: 'Users collection is empty' };
     }
+    return { provider: 'database', status: 'ok' };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { provider: 'database', status: 'error', detail: `MongoDB check failed (after retries): ${msg}` };
   }
-  const msg = lastErr instanceof Error ? lastErr.message : String(lastErr);
-  return { provider: 'database', status: 'error', detail: `MongoDB check failed (after retry): ${msg}` };
 }
 
-async function sendAuthAlert(failures: AuthCheck[]) {
+async function sendAuthAlert(
+  failures: AuthCheck[],
+  streak: Awaited<ReturnType<typeof recordFailureStreaks>>
+) {
   if (!process.env.RESEND_API_KEY) return;
 
   // Cooldown check
   try {
     const db = await getDb();
     const state = await db.collection('system_config').findOne(
-      { _id: 'auth_alert_state' as any },
+      { _id: ALERT_STATE_KEY as any },
       { maxTimeMS: 5000 } as any
     );
     if (state?.last_sent_at) {
@@ -181,19 +234,31 @@ async function sendAuthAlert(failures: AuthCheck[]) {
   }
 
   const failureRows = failures
-    .map(f => `<tr><td style="padding:8px;border:1px solid #ddd;font-weight:bold">${f.provider}</td><td style="padding:8px;border:1px solid #ddd;color:#c0392b">${f.detail}</td></tr>`)
+    .map(f => `<tr><td style="padding:8px;border:1px solid #ddd;font-weight:bold">${f.provider}</td><td style="padding:8px;border:1px solid #ddd;color:#c0392b">${f.detail}</td><td style="padding:8px;border:1px solid #ddd;text-align:center">${streak.streaks[f.provider] ?? 1}</td></tr>`)
     .join('\n');
+
+  // Say what was actually observed. The old copy asserted "Users cannot sign in"
+  // off a single probe; on 2026-07-31 that was false — accounts were being
+  // created while the email sat in the inbox.
+  const confidence = streak.storeUnavailable
+    ? 'The streak store was unreachable, so this fired on the first failed probe — Atlas itself is likely down.'
+    : `Failing on ${CONSECUTIVE_FAILURES_TO_ALERT}+ consecutive probes (10 min apart), so this is not a transient blip.`;
 
   const html = `
     <div style="font-family:-apple-system,sans-serif;max-width:560px;margin:0 auto;padding:24px">
-      <h2 style="color:#c0392b;margin:0 0 16px">Sign-in is broken</h2>
-      <p style="color:#333;margin:0 0 16px">
-        Users cannot sign in to Source Library. The following auth providers are failing:
+      <h2 style="color:#c0392b;margin:0 0 16px">Auth provider check is failing</h2>
+      <p style="color:#333;margin:0 0 8px">
+        Sign-in on Source Library may be affected. These providers failed their health probe:
       </p>
+      <p style="color:#666;font-size:13px;margin:0 0 16px">${confidence}</p>
       <table style="border-collapse:collapse;width:100%;margin:0 0 16px">
-        <tr style="background:#f5f5f5"><th style="padding:8px;border:1px solid #ddd;text-align:left">Provider</th><th style="padding:8px;border:1px solid #ddd;text-align:left">Error</th></tr>
+        <tr style="background:#f5f5f5"><th style="padding:8px;border:1px solid #ddd;text-align:left">Provider</th><th style="padding:8px;border:1px solid #ddd;text-align:left">Error</th><th style="padding:8px;border:1px solid #ddd">Probes</th></tr>
         ${failureRows}
       </table>
+      <p style="color:#666;font-size:13px">
+        Confirm real user impact before treating this as an outage — check for recent
+        account creations and sign-in links, not just this probe.
+      </p>
       <p style="color:#666;font-size:13px">
         Check: <a href="https://sourcelibrary.org/api/health/auth">health/auth endpoint</a> |
         <a href="https://console.cloud.google.com/apis/credentials">Google Cloud Console</a>
@@ -208,7 +273,7 @@ async function sendAuthAlert(failures: AuthCheck[]) {
     await resend.emails.send({
       from: 'Source Library <noreply@sourcelibrary.org>',
       to: ALERT_EMAIL,
-      subject: '[CRITICAL] Source Library sign-in is broken',
+      subject: `[CRITICAL] Source Library auth check failing: ${failures.map(f => f.provider).join(', ')}`,
       html,
     });
 
@@ -216,7 +281,7 @@ async function sendAuthAlert(failures: AuthCheck[]) {
     try {
       const db = await getDb();
       await db.collection('system_config').updateOne(
-        { _id: 'auth_alert_state' as any },
+        { _id: ALERT_STATE_KEY as any },
         { $set: { last_sent_at: new Date(), failures } },
         { upsert: true }
       );

--- a/src/lib/health-alerting.ts
+++ b/src/lib/health-alerting.ts
@@ -1,0 +1,141 @@
+import type { Db } from 'mongodb';
+
+/**
+ * Shared plumbing for the health probes that page Derek.
+ *
+ * Motivating incident (2026-07-31): a single dropped Atlas TLS handshake at
+ * 00:00:01 UTC made /api/health/auth report `database: error` and send a
+ * "[CRITICAL] Source Library sign-in is broken" email. Sign-in was never
+ * broken — a new user account was created two minutes later, and 2,013 of the
+ * preceding 2,016 probes were clean. Both DB-touching probes failed in the same
+ * second because nine Hetzner cron schedules converge at 00:00 UTC, so a pile of
+ * cold Vercel functions all opened fresh TLS connections to Atlas at once.
+ *
+ * Per CLAUDE.md ("a metric is a claim about an instrument before it is a claim
+ * about readers"), the defect is the alerting policy, not the connection. Two
+ * guards live here:
+ *
+ *   1. `retryWithBackoff` — absorb a blip WITHIN one probe. The old code retried
+ *      back-to-back with no delay, so a fault lasting a couple of seconds
+ *      defeated both attempts.
+ *   2. `recordFailureStreaks` — require N consecutive failed probes before
+ *      paging, tracked per failing check so unrelated one-off blips in
+ *      different providers never add up to a page.
+ */
+
+/** Default gap between attempts. Grows so a multi-second fault is still caught. */
+const DEFAULT_BACKOFF_MS = [300, 900];
+
+export interface RetryOptions {
+  /** Delay before each retry. Attempt count is `backoffMs.length + 1`. */
+  backoffMs?: number[];
+  /** Called before each retry — used to force a fresh connection. */
+  onRetry?: (attempt: number) => void | Promise<void>;
+  /** Injectable for tests so they don't sleep for real. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const realSleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * Run `fn`, retrying on throw with a growing delay between attempts.
+ * Rethrows the LAST error if every attempt fails.
+ */
+export async function retryWithBackoff<T>(
+  fn: (attempt: number) => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const backoff = options.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const sleep = options.sleep ?? realSleep;
+  let lastErr: unknown;
+
+  for (let attempt = 0; attempt <= backoff.length; attempt++) {
+    if (attempt > 0) {
+      await sleep(backoff[attempt - 1]);
+      await options.onRetry?.(attempt);
+    }
+    try {
+      return await fn(attempt);
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw lastErr;
+}
+
+export interface StreakDecision {
+  /** Checks whose consecutive-failure count has reached the threshold. */
+  confirmed: string[];
+  /** Consecutive-failure count per check, after this probe. */
+  streaks: Record<string, number>;
+  /**
+   * True when the streak could not be persisted. The store lives in Mongo, so
+   * this generally means Atlas is genuinely unreachable — exactly when a page
+   * IS warranted. Callers must treat it as "alert now" (fail open).
+   */
+  storeUnavailable: boolean;
+}
+
+/**
+ * Increment the consecutive-failure count for each failing check, reset every
+ * other known check to zero, and report which ones have reached `threshold`.
+ *
+ * Streaks are per-check on purpose. A database blip on one probe followed by an
+ * unrelated email blip on the next is two isolated faults, not a two-probe
+ * outage, and must not page.
+ */
+export async function recordFailureStreaks(
+  db: Db | null,
+  stateKey: string,
+  failingChecks: string[],
+  threshold: number
+): Promise<StreakDecision> {
+  const unavailable = (): StreakDecision => ({
+    confirmed: [...failingChecks],
+    streaks: Object.fromEntries(failingChecks.map(c => [c, 1])),
+    storeUnavailable: true,
+  });
+
+  if (!db) return unavailable();
+
+  try {
+    const doc = await db.collection('system_config').findOne(
+      { _id: stateKey as any },
+      { maxTimeMS: 5000 }
+    );
+    const previous: Record<string, number> = doc?.streaks ?? {};
+
+    // Reset everything we've seen before, then increment the current failures.
+    const streaks: Record<string, number> = {};
+    for (const check of Object.keys(previous)) streaks[check] = 0;
+    for (const check of failingChecks) streaks[check] = (previous[check] ?? 0) + 1;
+
+    await db.collection('system_config').updateOne(
+      { _id: stateKey as any },
+      { $set: { streaks, last_failure_at: new Date(), last_failing_checks: failingChecks } },
+      { upsert: true }
+    );
+
+    return {
+      confirmed: failingChecks.filter(c => streaks[c] >= threshold),
+      streaks,
+      storeUnavailable: false,
+    };
+  } catch {
+    // Can't reach the store to prove this is a repeat — assume the worst.
+    return unavailable();
+  }
+}
+
+/** Zero every streak after a clean probe. No-ops until the state doc exists. */
+export async function clearFailureStreaks(db: Db | null, stateKey: string): Promise<void> {
+  if (!db) return;
+  try {
+    await db.collection('system_config').updateOne(
+      { _id: stateKey as any, streaks: { $exists: true } },
+      { $set: { streaks: {}, last_clear_at: new Date() } }
+    );
+  } catch {
+    // Non-fatal: a stale streak costs at most one delayed page.
+  }
+}

--- a/tests/unit/health-alert-streak.test.ts
+++ b/tests/unit/health-alert-streak.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Health-probe alerting guards (2026-07-31 false "sign-in is broken" page).
+ *
+ * A single dropped Atlas TLS handshake at 00:00:01 UTC made /api/health/auth
+ * report `database: error` and email "[CRITICAL] Source Library sign-in is
+ * broken". Sign-in was fine — an account was created two minutes later, and
+ * 2,013 of the preceding 2,016 probes were clean. Two things had failed:
+ * the retry ran back-to-back with no delay, and one failed probe was treated as
+ * proof of an outage.
+ *
+ * These tests drive the real functions against a stubbed Db and assert on
+ * behaviour — what gets slept, what gets written, and whether a page is
+ * authorised. Reverting to instant retries, or to paging on the first failure,
+ * fails here.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { Db } from 'mongodb';
+import {
+  retryWithBackoff,
+  recordFailureStreaks,
+  clearFailureStreaks,
+} from '../../src/lib/health-alerting';
+
+/** Minimal in-memory stand-in for the one collection these helpers touch. */
+function stubDb(seed: Record<string, any> = {}) {
+  const docs = new Map<string, any>(Object.entries(seed));
+  const db = {
+    collection: (name: string) => {
+      if (name !== 'system_config') throw new Error(`unexpected collection ${name}`);
+      return {
+        findOne: async (filter: any) => docs.get(filter._id) ?? null,
+        updateOne: async (filter: any, update: any, options: any = {}) => {
+          const existing = docs.get(filter._id);
+          // Honour the `streaks: { $exists: true }` guard used by the clear path.
+          if (filter.streaks?.$exists && !existing?.streaks) return { matchedCount: 0 };
+          if (!existing && !options.upsert) return { matchedCount: 0 };
+          docs.set(filter._id, { ...(existing ?? { _id: filter._id }), ...update.$set });
+          return { matchedCount: 1 };
+        },
+      };
+    },
+  } as unknown as Db;
+  return { db, docs };
+}
+
+/** A Db whose every operation throws — stands in for "Atlas is unreachable". */
+function brokenDb() {
+  return {
+    collection: () => ({
+      findOne: async () => { throw new Error('Client network socket disconnected'); },
+      updateOne: async () => { throw new Error('Client network socket disconnected'); },
+    }),
+  } as unknown as Db;
+}
+
+describe('retryWithBackoff', () => {
+  it('waits between attempts instead of retrying instantly', async () => {
+    const slept: number[] = [];
+    const sleep = async (ms: number) => { slept.push(ms); };
+    let calls = 0;
+
+    const result = await retryWithBackoff(
+      async () => {
+        calls++;
+        if (calls < 3) throw new Error('Client network socket disconnected');
+        return 'recovered';
+      },
+      { sleep }
+    );
+
+    expect(result).toBe('recovered');
+    expect(calls).toBe(3);
+    // The whole point: real delays, and growing ones. A fault lasting a second
+    // or two defeated the old back-to-back retry.
+    expect(slept.length).toBe(2);
+    expect(slept.every(ms => ms > 0)).toBe(true);
+    expect(slept[1]).toBeGreaterThan(slept[0]);
+  });
+
+  it('forces a reconnect before each retry and reports the attempt number', async () => {
+    const attempts: number[] = [];
+    const reconnects: number[] = [];
+    await retryWithBackoff(
+      async attempt => {
+        attempts.push(attempt);
+        if (attempt === 0) throw new Error('boom');
+        return 'ok';
+      },
+      { sleep: async () => {}, onRetry: n => { reconnects.push(n); } }
+    );
+    expect(attempts).toEqual([0, 1]);
+    expect(reconnects).toEqual([1]);
+  });
+
+  it('rethrows the last error when every attempt fails', async () => {
+    await expect(
+      retryWithBackoff(
+        async attempt => { throw new Error(`fail-${attempt}`); },
+        { sleep: async () => {} }
+      )
+    ).rejects.toThrow('fail-2');
+  });
+});
+
+describe('recordFailureStreaks', () => {
+  it('does NOT authorise a page on the first failed probe', async () => {
+    const { db } = stubDb();
+    const decision = await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2);
+
+    // This is the 2026-07-31 incident: one blip, no email.
+    expect(decision.confirmed).toEqual([]);
+    expect(decision.streaks.database).toBe(1);
+    expect(decision.storeUnavailable).toBe(false);
+  });
+
+  it('authorises a page once the same check fails on consecutive probes', async () => {
+    const { db } = stubDb();
+    await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2);
+    const second = await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2);
+
+    expect(second.confirmed).toEqual(['database']);
+    expect(second.streaks.database).toBe(2);
+  });
+
+  it('never lets two UNRELATED single blips add up to a page', async () => {
+    const { db } = stubDb();
+    await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2);
+    const second = await recordFailureStreaks(db, 'auth_alert_state', ['email'], 2);
+
+    expect(second.confirmed).toEqual([]);
+    expect(second.streaks.email).toBe(1);
+    // The database recovered on this probe, so its streak must reset.
+    expect(second.streaks.database).toBe(0);
+  });
+
+  it('confirms only the checks that actually met the threshold', async () => {
+    const { db } = stubDb();
+    await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2);
+    const second = await recordFailureStreaks(db, 'auth_alert_state', ['database', 'email'], 2);
+
+    expect(second.confirmed).toEqual(['database']);
+    expect(second.streaks).toMatchObject({ database: 2, email: 1 });
+  });
+
+  it('fails OPEN when the streak store is unreachable — a real outage still pages', async () => {
+    for (const db of [null, brokenDb()]) {
+      const decision = await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2);
+      expect(decision.confirmed).toEqual(['database']);
+      expect(decision.storeUnavailable).toBe(true);
+    }
+  });
+
+  it('persists the streak so the next probe can read it', async () => {
+    const { db, docs } = stubDb();
+    await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2);
+    expect(docs.get('auth_alert_state').streaks).toEqual({ database: 1 });
+    expect(docs.get('auth_alert_state').last_failing_checks).toEqual(['database']);
+  });
+});
+
+describe('clearFailureStreaks', () => {
+  it('resets streaks after a clean probe, so a later blip starts from zero', async () => {
+    const { db, docs } = stubDb();
+    await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2);
+    await clearFailureStreaks(db, 'auth_alert_state');
+    expect(docs.get('auth_alert_state').streaks).toEqual({});
+
+    const afterRecovery = await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2);
+    expect(afterRecovery.confirmed).toEqual([]);
+    expect(afterRecovery.streaks.database).toBe(1);
+  });
+
+  it('is a no-op when no failure has ever been recorded', async () => {
+    const { db, docs } = stubDb();
+    await clearFailureStreaks(db, 'auth_alert_state');
+    expect(docs.has('auth_alert_state')).toBe(false);
+  });
+
+  it('swallows store errors rather than breaking a healthy probe', async () => {
+    await expect(clearFailureStreaks(brokenDb(), 'auth_alert_state')).resolves.toBeUndefined();
+  });
+});
+
+describe('alert threshold wiring', () => {
+  it('pages within ~20 minutes of a real outage at a 10-minute probe cadence', async () => {
+    // Guards the tradeoff itself: the threshold buys blip-immunity, but must not
+    // silence a genuine outage for long. Two probes 10 min apart = 20 min.
+    const { db } = stubDb();
+    const probeIntervalMin = 10;
+    let probes = 0;
+    let confirmed: string[] = [];
+    while (confirmed.length === 0 && probes < 10) {
+      probes++;
+      confirmed = (await recordFailureStreaks(db, 'auth_alert_state', ['database'], 2)).confirmed;
+    }
+    expect(probes * probeIntervalMin).toBeLessThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
## What happened

At **00:00:01 UTC on 2026-07-31** a single dropped Atlas TLS handshake made `/api/health/auth` report `database: error` and send a **"[CRITICAL] Source Library sign-in is broken"** email.

Sign-in was never broken:

- A sign-in link was issued at **23:27**, and a new account was created at **00:02:24** — two minutes *after* the alert.
- **2,013 of the preceding 2,016 probes** (14 days) were clean. The other two failures were Resend returning 500 on Jul 29 — an upstream email outage, not the DB. This was the first database-class failure in a fortnight.
- No auth or Mongo entries in `application_errors` during the window.

`/api/cron/health-check` failed in the same second with the identical error. Both are DB-touching probes that fire at `:00`, and **nine Hetzner cron schedules converge at 00:00 UTC** — a pile of cold Vercel functions all opening fresh TLS connections to Atlas at once.

Per CLAUDE.md — *"a metric is a claim about an instrument before it is a claim about readers"* — the defect is the alerting policy, not the connection. Two things had failed: the retry ran back-to-back with no delay, and one failed probe was treated as proof of an outage.

## Changes

**`src/lib/health-alerting.ts`** (new)
- `retryWithBackoff` — absorbs a blip *inside* one probe. The old code retried immediately, so a fault lasting a couple of seconds exhausted both attempts.
- `recordFailureStreaks` — requires N consecutive failed probes before paging, tracked **per check** so two unrelated single blips never add up to an alert. **Fails open** when the streak store is unreachable, so a genuine Atlas outage still pages on the first probe.

**`/api/health/auth`** (every 10 min) — retry with backoff **and** 2 consecutive probes before paging; a real outage is still reported within ~20 min. Email states what was observed instead of asserting users cannot sign in, and shows the per-provider probe count. `maxDuration` 15s → 25s to cover the backoff (a clean run still finishes in ~1s).

**`/api/cron/health-check`** (hourly) — retry with backoff only. A streak gate would delay a real DB-down page by a full hour, so at this cadence absorbing the blip inside the request is the right guard. Deliberate asymmetry with the auth probe.

**Live Hetzner crontab** — probes moved off the top of the hour: auth `*/10` → `3-59/10`, health-check `:00` → `:02`, latency-trend `:05` → `:07` (preserving its +5min ordering after health-check). Backed up to `/root/crontab-backups/` first; exactly 3 schedule lines + 3 comments changed, verified against `crontab -l`.

## Verification

- `npx tsc --noEmit` clean; **1110 unit tests across 90 files pass**.
- **Mutation-tested** (per CLAUDE.md "a test that greps source is not a guard"): reverting to paging on the first failure fails 4 cases; setting backoff to zero fails 1. The tests drive the real functions against a stubbed `Db` and assert on what gets slept, written, and authorised.
- Post-change probes against prod: all four providers `ok` on three consecutive calls.
- Crontab drift check after re-snapshot: clean.

## Out of scope

- **The wider midnight cron convergence is untouched.** Only the two probes were moved. Reshuffling the other ~8 jobs that fire at 00:00 is a bigger change with real blast radius, and the retry guard already makes the probes immune to it.
- **`scripts/workers/crontab.production` also picks up ~9 lines of pre-existing drift** (differing `--concurrency` values, catchup-watchdog, ft-census, restic-backup, traffic-anomaly). The snapshot can only be refreshed wholesale — `sync-crontab.sh` has been logging this drift and asking for exactly this re-snapshot. Called out so it isn't mistaken for part of the fix.
- No change to what the probes actually check, or to any auth code path. This touches alerting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)