### PR TITLE
fix(bph-catalog): make the catalogue search box cover every public field

### DIFF
--- a/scripts/migration/expand-bph-search-norm.sql
+++ b/scripts/migration/expand-bph-search-norm.sql
@@ -1,0 +1,122 @@
+-- Widen the BPH catalogue's general search box to cover every public field.
+--
+-- José Bouman (BPH) reported that searching by UBN returns nothing. That was the
+-- visible symptom of a narrower problem: `search_norm` -- the column the search
+-- box actually queries -- covered only 20 of the ~40 populated fields, so a
+-- librarian searching by anything outside the title/author/imprint block got
+-- silence rather than results. Populated but unsearchable before this change:
+--
+--   remarks 7,572 . present_location 7,194 . bibliography 5,110
+--   object_size_cm 4,417 . provenance 4,142 . ustc_sn 3,504
+--   picturae_barcode 3,066 . bound_with 2,838 . ia_identifier 853
+--   annotation 754 . full_title 663 . physical_description 199 . ...
+--
+-- UBN itself is deliberately NOT added here. `search_norm` is matched with
+-- ILIKE '%q%' and UBNs are 1-5 digit numbers, so folding them in would make
+-- every 4-digit year search also match the UBNs containing those digits
+-- (searching 1545 would drag in 15450-15459, 11545, 21545, 31545...). UBN gets a
+-- precise lane in the API instead: exact match for an all-digit query, ILIKE for
+-- the non-numeric ones ("BPH 131", "PH144"). See src/app/api/catalog/bph/route.ts.
+--
+-- DELIBERATELY EXCLUDED -- this column feeds a PUBLIC search box, so a match is
+-- itself a disclosure: anyone could probe for records containing a phrase.
+-- Do not add any of these:
+--   internal_remarks (1,705 rows)  -- staff working notes
+--   exhibition_history             -- staff-only, see add-bph-exhibition-history.sql
+--   price (38) / acquisition_source (308) / acquisition_date  -- commercial
+--   work_status / fully_approved / delivered_to_customer / publish_scan -- workflow
+--   modified_by_username / modified_by_email  -- personal data
+--   ia_match_validation_notes  -- internal QA notes
+--
+-- `contributors` (JSONB) is not included: it is an empty array on all 29,879
+-- rows today, and a generated column cannot contain the subquery needed to pull
+-- names out of it. Revisit if it is ever populated.
+--
+-- NOTE ON STYLE -- do not "tidy" this into concat_ws(). concat_ws is STABLE
+-- (it can invoke arbitrary type output functions), and Postgres refuses a
+-- non-immutable generation expression, so the whole migration fails with
+-- `42P17: generation expression is not immutable`. COALESCE + || is immutable.
+-- add-bph-diacritic-normalization.sql in this directory shows concat_ws and
+-- does NOT match what is deployed -- production was built with the || form and
+-- that file would fail if re-run. Verified against pg_get_expr, 2026-07-31.
+--
+-- A generated column's expression cannot be altered in place, so the column is
+-- dropped and recreated. That also drops idx_bph_search_norm_trgm, recreated
+-- below -- without it every search-box query becomes a seq scan. Both are in one
+-- transaction so search is never live without its index.
+--
+-- Run via Supabase SQL editor or psql:
+--   psql "$DATABASE_URL" -f scripts/migration/expand-bph-search-norm.sql
+
+BEGIN;
+
+ALTER TABLE bph_works DROP COLUMN IF EXISTS search_norm;
+
+ALTER TABLE bph_works
+  ADD COLUMN search_norm text GENERATED ALWAYS AS (
+    public.normalize_bph_text(
+      -- Title family
+      COALESCE(title, ''::text) || ' '::text ||
+      COALESCE(parallel_title, ''::text) || ' '::text ||
+      COALESCE(uniform_title, ''::text) || ' '::text ||
+      COALESCE(full_title, ''::text) || ' '::text ||
+      COALESCE(series_title, ''::text) || ' '::text ||
+      COALESCE(volume_title, ''::text) || ' '::text ||
+      COALESCE(journal_title, ''::text) || ' '::text ||
+      COALESCE(volume_number, ''::text) || ' '::text ||
+      -- Authorship
+      COALESCE(author, ''::text) || ' '::text ||
+      COALESCE(variant_author, ''::text) || ' '::text ||
+      COALESCE(pseudonym, ''::text) || ' '::text ||
+      COALESCE(author_canonical_name, ''::text) || ' '::text ||
+      COALESCE(editor, ''::text) || ' '::text ||
+      COALESCE(variant_editor, ''::text) || ' '::text ||
+      COALESCE(compiler, ''::text) || ' '::text ||
+      COALESCE(scribe, ''::text) || ' '::text ||
+      COALESCE(statement_of_responsibility, ''::text) || ' '::text ||
+      -- Imprint
+      COALESCE(place, ''::text) || ' '::text ||
+      COALESCE(printer, ''::text) || ' '::text ||
+      COALESCE(publisher, ''::text) || ' '::text ||
+      COALESCE(variant_printer, ''::text) || ' '::text ||
+      COALESCE(variant_publisher, ''::text) || ' '::text ||
+      COALESCE(impressum_original, ''::text) || ' '::text ||
+      COALESCE(edition_note, ''::text) || ' '::text ||
+      COALESCE(ms_date, ''::text) || ' '::text ||
+      COALESCE(origin, ''::text) || ' '::text ||
+      -- Location & ownership
+      COALESCE(shelf_mark, ''::text) || ' '::text ||
+      COALESCE(state_shelf_mark, ''::text) || ' '::text ||
+      COALESCE(present_location, ''::text) || ' '::text ||
+      COALESCE(provenance, ''::text) || ' '::text ||
+      COALESCE(collection, ''::text) || ' '::text ||
+      -- Subject & language
+      COALESCE(keywords, ''::text) || ' '::text ||
+      COALESCE(language, ''::text) || ' '::text ||
+      COALESCE(script, ''::text) || ' '::text ||
+      -- Physical description
+      COALESCE(binding, ''::text) || ' '::text ||
+      COALESCE(bound_with, ''::text) || ' '::text ||
+      COALESCE(physical_description, ''::text) || ' '::text ||
+      COALESCE(object_size_cm, ''::text) || ' '::text ||
+      COALESCE(pagination, ''::text) || ' '::text ||
+      COALESCE(characterization, ''::text) || ' '::text ||
+      COALESCE(iconography, ''::text) || ' '::text ||
+      COALESCE(illumination_illustration, ''::text) || ' '::text ||
+      -- Notes (public only)
+      COALESCE(bibliography, ''::text) || ' '::text ||
+      COALESCE(remarks, ''::text) || ' '::text ||
+      COALESCE(annotation, ''::text) || ' '::text ||
+      COALESCE(contents, ''::text) || ' '::text ||
+      -- Identifiers (UBN handled in the API)
+      COALESCE(ustc_sn::text, ''::text) || ' '::text ||
+      COALESCE(ia_identifier, ''::text) || ' '::text ||
+      COALESCE(picturae_barcode, ''::text) || ' '::text ||
+      COALESCE(icn_registration_number, ''::text)
+    )
+  ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_bph_search_norm_trgm
+  ON bph_works USING gin (search_norm gin_trgm_ops);
+
+COMMIT;

--- a/src/app/api/catalog/[tenant]/route.ts
+++ b/src/app/api/catalog/[tenant]/route.ts
@@ -75,17 +75,30 @@ export async function GET(req: NextRequest, { params }: RouteContext) {
 
   if (q.length >= 2) {
     const safe = sanitizeFilterValue(q);
-    query = query.or(
-      `title.ilike.%${safe}%,` +
-      `parallel_title.ilike.%${safe}%,` +
-      `uniform_title.ilike.%${safe}%,` +
-      `author.ilike.%${safe}%,` +
-      `variant_author.ilike.%${safe}%,` +
-      `pseudonym.ilike.%${safe}%,` +
-      `shelf_mark.ilike.%${safe}%,` +
-      `state_shelf_mark.ilike.%${safe}%,` +
-      `keywords.ilike.%${safe}%`,
-    );
+    // Every public field on the record, not just the title/author block. A
+    // librarian searching by catalogue number, shelf location or a phrase from
+    // the remarks got silence before — the same gap José Bouman hit on the BPH
+    // catalogue (see expand-bph-search-norm.sql for the equivalent there).
+    // `library_catalog_records` holds no staff-only columns, so "every field"
+    // is literally safe here; if one is ever added, it must NOT be listed.
+    // The table is ~1.6K rows, so the un-indexed ILIKE chain is cheap.
+    const searchCols = [
+      'catalog_id',
+      'title', 'parallel_title', 'uniform_title', 'series_title', 'volume_title',
+      'author', 'variant_author', 'pseudonym', 'editor', 'variant_editor',
+      'place', 'printer', 'publisher', 'variant_printer', 'variant_publisher',
+      'year_text',
+      'shelf_mark', 'state_shelf_mark', 'present_location', 'provenance',
+      'keywords', 'language',
+      'binding', 'bound_with', 'object_size_cm',
+      'bibliography', 'remarks',
+      'ia_identifier',
+    ];
+    const ors = searchCols.map((c) => `${c}.ilike.%${safe}%`);
+    // ustc_sn is an integer column — ILIKE would be a type error, so match it
+    // exactly and only when the query is all digits.
+    if (/^\d+$/.test(q)) ors.push(`ustc_sn.eq.${q}`);
+    query = query.or(ors.join(','));
   }
 
   const ilikeFilter = (val: string, columns: string[]) => {

--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -142,13 +142,26 @@ export async function GET(req: NextRequest) {
       // include the year, so "1545" otherwise returned nothing. Digits-only,
       // so it's safe to inline in an .or() string.
       const yearQ = /^\d{3,4}$/.test(q) ? q : null;
+      // UBN gets its own lane rather than living in `search_norm`. That column
+      // is matched with ILIKE '%q%' and UBNs are 1–5 digit numbers, so folding
+      // them in would make every year search also match the UBNs containing
+      // those digits (1545 would drag in 15450–15459, 11545, 21545, 31545…).
+      // Exact match for an all-digit query is what "search by UBN" means;
+      // non-numeric UBNs ("BPH 131", "PH144", "PH 2") still need a substring
+      // match. Reported by José Bouman (BPH) — searching a UBN returned nothing.
+      const digitsOnly = /^\d+$/.test(q);
+      const ubnLane = digitsOnly
+        ? `ubn.eq.${q}`
+        : `ubn.ilike.%${sanitizeFilterValue(q)}%`;
       if (mode === 'new' && hasNormalizedColumns !== false) {
         if (yearQ) {
-          query = query.or(`search_norm.ilike.%${yearQ}%,year.eq.${yearQ}`);
+          query = query.or(`search_norm.ilike.%${yearQ}%,year.eq.${yearQ},${ubnLane}`);
         } else {
           const normQ = sanitizeFilterValue(normalizeBphSearchText(q));
           if (normQ.length > 0) {
-            query = query.ilike('search_norm', `%${normQ}%`);
+            query = query.or(`search_norm.ilike.%${normQ}%,${ubnLane}`);
+          } else {
+            query = query.or(ubnLane);
           }
         }
       } else if (mode === 'new') {


### PR DESCRIPTION
José Bouman (BPH) tried to search the catalogue by UBN and got nothing back. Reproduced against production before touching anything: `q=13043` → **0 results**, `q=alchemia` → 16.

## What was actually wrong

UBN was the visible symptom of a wider gap. `search_norm` — the column the search box actually queries — covered 20 of the ~40 populated fields. Everything outside the title/author/imprint block was silently unsearchable:

| field | populated rows |
|---|---|
| `remarks` | 7,572 |
| `present_location` | 7,194 |
| `bibliography` | 5,110 |
| `object_size_cm` | 4,417 |
| `provenance` | 4,142 |
| `ustc_sn` | 3,504 |
| `picturae_barcode` | 3,066 |
| `bound_with` | 2,838 |
| `ia_identifier` | 853 |
| `annotation` | 754 |
| `full_title` | 663 |
| `physical_description` | 199 |

Plus the manuscript description block (`contents`, `origin`, `script`, `scribe`, `iconography`, `illumination_illustration`, …). A librarian searching a shelf location, a donor name, a USTC number or a phrase from the remarks got silence — indistinguishable from "we don't hold it".

## Changes

**1. `search_norm` now spans all 50 public fields** (`expand-bph-search-norm.sql`, already applied).

**Deliberately excluded, and the list is written into the migration header:** `internal_remarks` (1,705 rows), `exhibition_history`, `price`, `acquisition_source`/`acquisition_date`, the workflow flags, and `modified_by_username`/`modified_by_email`. This column feeds a **public** search box, so a match is itself a disclosure — anyone could probe for records containing a phrase. That is the same leak that keeping `exhibition_history` out of `search_tsv` was meant to prevent last week.

Verified after applying that the generation expression references no staff column. A substring probe flagged 6 rows where a staff note *appears* findable; all 6 are cases where the librarian typed the same text into a public field too (`shelf_mark`, `bound_with`, `title`, `provenance`, `bibliography`, `remarks`), which is their data-entry choice, not a leak — traced each one to its source column.

**2. UBN gets its own lane in the API**, rather than joining `search_norm`. That column is matched with `ILIKE '%q%'` and UBNs are 1–5 digit numbers, so folding them in would make every 4-digit year search also match the UBNs containing those digits — searching `1545` would drag in 15450–15459, 11545, 21545, 31545. The lane is an **exact** match for an all-digit query and `ILIKE` for the non-numeric UBNs (`BPH 131`, `PH144`, `PH 2`).

**3. The tenant catalogue got the same fix.** `/api/catalog/[tenant]` (table `library_catalog_records`, currently kloss-collection, 1,614 rows) had the identical defect — catalogue number, notes, location and provenance all unsearchable. That table holds no staff-only columns, so "every field" is literally safe there; there's a comment saying so in case one is ever added.

## Two things found on the way

Both recorded in the migration header so the next person doesn't rediscover them:

- **`concat_ws` is STABLE**, not immutable (it can invoke arbitrary type output functions), so Postgres refuses it in a generation expression with `42P17: generation expression is not immutable`. The immutable form is `COALESCE(col,'') || ' ' || …`.
- **`add-bph-diacritic-normalization.sql` does not match deployed reality.** It shows `concat_ws`; production was built with the `||` form. Re-running the committed file today would fail. Confirmed by reading `pg_get_expr` off the live column rather than trusting the file — which is how the first migration attempt got caught.

The failed first attempt was wrapped in `BEGIN`/`COMMIT`, so it rolled back cleanly; confirmed `search_norm` and its trigram index were intact before continuing.

## Out of scope

- **`contributors`** (JSONB) is not searchable. It is an empty array on all 29,879 rows today, and a generated column cannot hold the subquery needed to extract names. Worth revisiting if it is ever populated.
- **2,012 catalogue rows have no UBN at all** (959 photocopies, 812 manuscripts, 241 printed). Unrelated to search, but relevant to José since she navigates by UBN — flagged, not touched.
- **`search_tsv`** (the legacy fallback path) is unchanged. It is dormant while `search_norm` exists.

## Verification

`npx tsc --noEmit` clean; full unit suite green (1,110 tests).

The migration is already live, so the DB half is verifiable now:

- provenance search: 0 → working (`Erich Kaniok`, a donor, returns 1,442 records; `Westenberg` 91)
- `q=alchemia`: 16 → 20 results

UBN search needs this deploy; will confirm on the real subdomain afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)