### PR TITLE
fix(authors): catch names promoted from inside a book to its author (#3434)

### DIFF
--- a/scripts/audit/author-attribution.mjs
+++ b/scripts/audit/author-attribution.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * Standing audit: is `books.author` actually the person who wrote the book? (#3434)
+ *
+ * THE CLASS. A name that appears *inside* a book can be promoted to that book's
+ * author. The originating run is visible in the data: 1,353 BSB books created on
+ * 2026-03-14 whose `author` is not a name off the title page but the *search term*
+ * that found the book — which is why the values include things nobody would write
+ * as a name ("Albertus Secrets", "Fludd Medicina", "Iamblichus De Mysteriis") and
+ * why the matched books are overwhelmingly bookseller and library CATALOGUES: a
+ * full-text search for a title matches every catalogue that lists a copy of it.
+ * Same mechanism, three surface forms — hence the three checks below.
+ *
+ * WHY THE EXISTING DETECTORS MISS IT.
+ *   - `qa-author-date-anachronisms.mjs` tests the BIRTH side only (book predates
+ *     birth). This class is the death side: Khunrath died 1605, the catalogue is
+ *     1762. Invisible to a birth-only test by construction.
+ *   - `quarantine-non-person-authors.mjs` fixes the `authors` THESAURUS (flags
+ *     `is_person:false`) and never touches `books.author`, so a book keeps
+ *     rendering "by Theatrum Chemicum" after its author doc is quarantined. Its
+ *     safety interlock also, correctly, refuses to touch anchored real people —
+ *     so the Khunrath case can never be caught there: he is a real person with a
+ *     VIAF id who genuinely wrote other books we hold.
+ *
+ * Read-only. Prints a review queue; writes nothing. Exits 1 when anything is
+ * flagged so it can gate CI, 0 when clean.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/author-attribution.mjs
+ *   node scripts/audit/author-attribution.mjs --json        # machine-readable
+ *   node scripts/audit/author-attribution.mjs --margin=30   # death-window slack
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+import {
+  parseWikidataYear,
+  posthumousMisattributionLikely,
+  isReferenceGenreTitle,
+} from '../lib/author-date-window.mjs';
+
+const JSON_OUT = process.argv.includes('--json');
+const MARGIN = Number(
+  (process.argv.find((a) => a.startsWith('--margin=')) || '--margin=50').split('=')[1],
+);
+
+const log = (...a) => { if (!JSON_OUT) console.log(...a); };
+const findings = { posthumous_reference_genre: [], work_title_as_author: [], structural_garbage: [] };
+
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const db = mc.db('bookstore');
+const books = db.collection('books');
+const authors = db.collection('authors');
+const entities = db.collection('entities');
+
+// ───────────────────────────────────────────────────────────────────────────────
+// CHECK 1 — a reference-genre book attributed to someone long dead.
+// ───────────────────────────────────────────────────────────────────────────────
+log('══ 1. Reference-genre books attributed to a long-dead author ══\n');
+
+// Death years live on `entities`, reachable via authors.entity_ids. The `authors`
+// collection itself carries no life dates at all (0 of 4,825 as of 2026-07-31) —
+// only birth_place/death_place — so this join is the only route to a death year.
+const persons = await authors
+  .find({ is_person: { $ne: false }, 'entity_ids.0': { $exists: true } },
+        { projection: { slug: 1, canonical_name: 1, entity_ids: 1 } })
+  .toArray();
+const entIds = [...new Set(persons.flatMap((p) => p.entity_ids))]
+  .filter((s) => ObjectId.isValid(s))
+  .map((s) => new ObjectId(s));
+const entDocs = await entities
+  .find({ _id: { $in: entIds } }, { projection: { wikidata_death_date: 1 } })
+  .toArray();
+const deathByEnt = new Map(entDocs.map((e) => [String(e._id), parseWikidataYear(e.wikidata_death_date)]));
+
+const deathBySlug = new Map();
+const nameBySlug = new Map();
+for (const p of persons) {
+  nameBySlug.set(p.slug, p.canonical_name);
+  for (const e of p.entity_ids) {
+    const y = deathByEnt.get(String(e));
+    if (y != null) { deathBySlug.set(p.slug, y); break; }
+  }
+}
+log(`author docs with a resolvable death year: ${deathBySlug.size} / ${persons.length} with entity links`);
+
+const live = await books
+  .find({ visible: true, author_id: { $exists: true, $ne: null }, year: { $type: 'number' } },
+        { projection: { id: 1, title: 1, author: 1, author_id: 1, year: 1 } })
+  .toArray();
+log(`visible books with author_id + numeric year: ${live.length}`);
+
+for (const b of live) {
+  const deathYear = deathBySlug.get(b.author_id);
+  const verdict = posthumousMisattributionLikely({ bookYear: b.year, deathYear, title: b.title, margin: MARGIN });
+  if (verdict.suspect) {
+    findings.posthumous_reference_genre.push({
+      book_id: b.id, title: b.title, year: b.year,
+      author: b.author, author_id: b.author_id, death_year: deathYear, reason: verdict.reason,
+    });
+  }
+}
+findings.posthumous_reference_genre.sort((a, b) => a.author_id.localeCompare(b.author_id) || a.year - b.year);
+log(`\nFLAGGED: ${findings.posthumous_reference_genre.length} books (margin ${MARGIN}y)\n`);
+{
+  const byAuthor = new Map();
+  for (const f of findings.posthumous_reference_genre) {
+    if (!byAuthor.has(f.author_id)) byAuthor.set(f.author_id, []);
+    byAuthor.get(f.author_id).push(f);
+  }
+  for (const [slug, items] of [...byAuthor].sort((a, b) => b[1].length - a[1].length)) {
+    log(`  ${nameBySlug.get(slug) ?? slug} (d. ${items[0].death_year}) — ${items.length} book(s)`);
+    for (const f of items) log(`     ${f.book_id}  ${f.year}  ${String(f.title).slice(0, 66)}`);
+  }
+  log('\n  NOTE: a genuine posthumous collected edition can look like this');
+  log('  (Diodorus Siculus\' own Bibliotheca Historica; Bibliotheca Fratrum');
+  log('  Polonorum). Review each — do not auto-write from this list.');
+}
+
+// ───────────────────────────────────────────────────────────────────────────────
+// CHECK 2 — the author string is a work title, not a person.
+// ───────────────────────────────────────────────────────────────────────────────
+log('\n\n══ 2. Work titles sitting in books.author ══\n');
+
+// Signal: the author doc carries NO authority record (no VIAF, no Wikidata) AND
+// books whose *title* begins with that same string exist. A real person can share
+// a string with a title ("William Blake" names both a man and monographs about
+// him), but a real person of any note carries an authority id — so requiring the
+// absence of one is what keeps this from flagging every author in the corpus.
+const unanchored = await authors
+  .find({
+    $and: [
+      { $or: [{ viaf_id: { $in: [null, ''] } }, { viaf_id: { $exists: false } }] },
+      { $or: [{ wikidata_id: { $in: [null, ''] } }, { wikidata_id: { $exists: false } }] },
+    ],
+  }, { projection: { _id: 1, slug: 1, canonical_name: 1, is_person: 1, book_count: 1 } })
+  .toArray();
+
+const norm = (s) => String(s ?? '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+let skippedSelfTitled = 0;
+for (const a of unanchored) {
+  const name = a.canonical_name || a._id;
+  const n = norm(name);
+  if (n.split(' ').length < 2) continue;   // single tokens are too noisy to judge
+
+  // Books that CARRY this string as their author…
+  const carrying = await books
+    .find({ $or: [{ author: name }, { author_id: a._id }] },
+          { projection: { id: 1, title: 1, year: 1, visible: 1 } })
+    .toArray();
+  if (!carrying.length) continue;
+
+  // …versus books whose TITLE starts with it (evidence the string names a work).
+  const titlePrefix = new RegExp('^' + n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/ /g, '[^a-z0-9]+'));
+  const asTitle = await books.countDocuments({ normalized_title: titlePrefix });
+  if (asTitle === 0) continue;   // no evidence it names a work — nothing to say
+
+  // THE SIGNATURE. The string names a work in the corpus, but the books wearing
+  // it as their author are DIFFERENT works. That mismatch is what separates a
+  // misattribution from an author whose surname simply heads their own book.
+  //
+  // Without this test the check flags real people who legitimately compiled
+  // reference works — Guanzelli, who compiled the *Index librorum expurgandorum*;
+  // Bernardus de Lutzemburgo, who wrote *Catalogus haereticorum*. A person CAN be
+  // the author of a catalogue, so catalogue-genre alone proves nothing; it is only
+  // evidence when the author is also long dead, which is check 1's job.
+  const selfTitled = carrying.filter((b) => titlePrefix.test(norm(b.title))).length;
+  if (selfTitled >= carrying.length / 2) { skippedSelfTitled++; continue; }
+
+  findings.work_title_as_author.push({
+    author_slug: a._id,
+    author_name: name,
+    quarantined: a.is_person === false,
+    books_carrying: carrying.length,
+    books_visible: carrying.filter((b) => b.visible).length,
+    titles_starting_with_it: asTitle,
+    carrying_reference_genre: carrying.filter((b) => isReferenceGenreTitle(b.title)).length,
+    sample: carrying.slice(0, 4).map((b) => ({ id: b.id, year: b.year, title: b.title })),
+  });
+}
+findings.work_title_as_author.sort((a, b) => b.books_visible - a.books_visible);
+log(`FLAGGED: ${findings.work_title_as_author.length} author strings`);
+log(`(skipped ${skippedSelfTitled} where the carriers ARE the work the string names — an author heading their own book)\n`);
+for (const f of findings.work_title_as_author) {
+  log(`  "${f.author_name}"  [${f.quarantined ? 'thesaurus quarantined' : 'NOT QUARANTINED'}]`);
+  log(`     ${f.books_visible} visible / ${f.books_carrying} carrying · ${f.titles_starting_with_it} titles start with it · ${f.carrying_reference_genre} of the carriers are catalogues`);
+  for (const s of f.sample) log(`     e.g. ${s.id}  ${s.year ?? '----'}  ${String(s.title).slice(0, 62)}`);
+}
+
+// ───────────────────────────────────────────────────────────────────────────────
+// CHECK 3 — structural garbage: a value no writer should ever have stored.
+// ───────────────────────────────────────────────────────────────────────────────
+log('\n\n══ 3. Structurally invalid author values ══\n');
+const GARBAGE = [
+  { tag: 'object-stringified', filter: { author: '[object Object]' } },
+  { tag: 'concatenated-placeholder', filter: { author: /^(Anonymous|Unknown)(Unknown|Anonymous)/i } },
+  { tag: 'non-string', filter: { author: { $type: ['object', 'array'] } } },
+  { tag: 'model-reasoning', filter: { author: /\b(wait|I will use|must be exactly one)\b/i } },
+  { tag: 'over-long', filter: { $expr: { $gt: [{ $strLenCP: { $ifNull: ['$author', ''] } }, 200] } } },
+];
+for (const g of GARBAGE) {
+  const total = await books.countDocuments(g.filter);
+  if (!total) { log(`  ${g.tag}: clean`); continue; }
+  const visible = await books.countDocuments({ ...g.filter, visible: true });
+  const sample = await books
+    .find({ ...g.filter, visible: true }, { projection: { id: 1, author: 1, title: 1 } })
+    .limit(4).toArray();
+  findings.structural_garbage.push({ tag: g.tag, total, visible, sample: sample.map((s) => ({ id: s.id, author: String(s.author).slice(0, 80), title: s.title })) });
+  log(`  ${g.tag}: ${total} books (${visible} VISIBLE)`);
+  for (const s of sample) log(`     ${s.id}  author=${JSON.stringify(String(s.author).slice(0, 46))}  ${String(s.title).slice(0, 42)}`);
+}
+
+// ───────────────────────────────────────────────────────────────────────────────
+const totalFlagged =
+  findings.posthumous_reference_genre.length +
+  findings.work_title_as_author.length +
+  findings.structural_garbage.reduce((s, g) => s + g.visible, 0);
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({ margin: MARGIN, total_flagged: totalFlagged, findings }, null, 2));
+} else {
+  log('\n\n══ SUMMARY ══');
+  log(`  posthumous reference-genre attributions : ${findings.posthumous_reference_genre.length} books`);
+  log(`  work titles used as author              : ${findings.work_title_as_author.length} strings`);
+  log(`  structurally invalid author values      : ${findings.structural_garbage.reduce((s, g) => s + g.visible, 0)} visible books`);
+  log(`\n  ${totalFlagged === 0 ? 'CLEAN' : `${totalFlagged} findings — review before writing anything`}`);
+}
+
+await mc.close();
+process.exit(totalFlagged === 0 ? 0 : 1);

--- a/scripts/lib/author-date-window.mjs
+++ b/scripts/lib/author-date-window.mjs
@@ -40,3 +40,55 @@ export function authorshipPlausible({ bookYear, birthYear, deathYear, margin = 1
   void deathYear;
   return { plausible: true, reason: 'within or after life window' };
 }
+
+/**
+ * Titles of the genres where a personal name printed inside the book is evidence
+ * of MENTION, not authorship: bookseller/auction/library catalogues, banned-book
+ * lists, accession registers, bibliographic periodicals.
+ *
+ * Deliberately anchored at the start of the title — a catalogue announces itself
+ * in its first words ("Catalogus librorum…", "Verzeichniß von…"). A mid-title
+ * match would sweep in every work that merely cites a catalogue.
+ */
+export const REFERENCE_GENRE_TITLE_RE =
+  /^\s*[\[(]?\s*(catalog(ue|us|o|i)?\b|catalogv|index librorum\b|verzeichni|b(ü|u)cher-?verzeichni|katalog|nachrichten von\b|nachtrag zu dem catalog|supplementum ad catalog|allgemeiner anzeiger\b|bibliotheca(e)?\s+(heinsiana|nicolaiana|fratrum|samuelis|a\s|d[eu]\s))/i;
+
+/** Does this title announce itself as a catalogue / reference list? */
+export function isReferenceGenreTitle(title) {
+  return REFERENCE_GENRE_TITLE_RE.test(String(title ?? ''));
+}
+
+/**
+ * The #3434 class: a name that appears INSIDE a later book promoted to its author.
+ *
+ * `authorshipPlausible` above deliberately refuses to exclude on the death side,
+ * and that refusal is correct for editions — a 1925 Boethius is a reprint, not a
+ * misattribution, and Boethius alone carries 55 such books. But it is the wrong
+ * rule for a *catalogue*: a 1762 Habsburg banned-book list is not an edition of a
+ * Khunrath work, it is a list that happens to name him. So the death-side signal
+ * only becomes usable when combined with the genre of the containing book.
+ *
+ * Both conditions are required, and even then this is a REVIEW signal, not a
+ * verdict — a genuine posthumous collected edition can carry a catalogue-shaped
+ * title (Diodorus Siculus' own *Bibliotheca Historica*; the *Bibliotheca Fratrum
+ * Polonorum*). Callers must not auto-write from it.
+ *
+ * @param margin  years after death still treated as a plausible edition window.
+ *                Generous by design: precision here comes from the genre test,
+ *                not from shaving the margin.
+ * @returns {{ suspect: boolean, reason: string }}
+ */
+export function posthumousMisattributionLikely({ bookYear, deathYear, title, margin = 50 }) {
+  if (bookYear == null) return { suspect: false, reason: 'no book year' };
+  if (deathYear == null) return { suspect: false, reason: 'no author death year' };
+  if (bookYear <= deathYear + margin) {
+    return { suspect: false, reason: `book ${bookYear} within ${margin}y of death ${deathYear}` };
+  }
+  if (!isReferenceGenreTitle(title)) {
+    return { suspect: false, reason: 'postdates death but not a reference-genre title (likely a reprint)' };
+  }
+  return {
+    suspect: true,
+    reason: `reference-genre title published ${bookYear}, ${bookYear - deathYear}y after author death ${deathYear}`,
+  };
+}

--- a/scripts/maintenance/quarantine-non-person-authors.mjs
+++ b/scripts/maintenance/quarantine-non-person-authors.mjs
@@ -59,6 +59,15 @@ const TITLE_NOT_AUTHOR = new Set([
   'splendor solis', 'philosophia reformata', 'theatrum sympatheticum', 'theatrum chemicum',
   'porta magia naturalis', 'magia naturalis', 'aurora consurgens', 'turba philosophorum',
   'mutus liber', 'rosarium philosophorum', 'musaeum hermeticum', 'atalanta fugiens',
+  // ── added by #3434 ─────────────────────────────────────────────────────────
+  // Surfaced by scripts/audit/author-attribution.mjs. These are the *search
+  // queries* of the 2026-03-14 BSB import run, stamped into `books.author`: note
+  // the "<author surname> <work keyword>" shape, which is nobody's name. Each is
+  // a work (or a work-plus-author query), verified individually — never a person.
+  'museum hermeticum', 'tripus aureus', 'fama fraternitatis', 'confessio fraternitatis',
+  'iamblichus de mysteriis', 'albertus secrets', 'fludd medicina', 'kabbala denudata',
+  'chaldaean oracles', 'viridarium chymicum', 'john dee monas',
+  'kircher oedipus', 'kircher ars magna', 'kircher musurgia', 'kircher mundus',
 ].map((s) => s.toLowerCase()));
 
 function classify(doc) {

--- a/scripts/maintenance/repair-author-misattribution-3434.mjs
+++ b/scripts/maintenance/repair-author-misattribution-3434.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Repair the hand-verified author misattributions from #3434.
+ *
+ * SCOPE: exactly the 14 book ids listed below — reference-genre works (bookseller
+ * and auction catalogues, banned-book lists, accession registers, a bibliographic
+ * periodical) attributed to a person who died decades or centuries earlier. Each
+ * was checked individually against its title, imprint and publication year; the
+ * list is a literal, not a query, so this script cannot widen its own blast
+ * radius if the detector's precision changes.
+ *
+ * WHAT IT WRITES. `author` and its derived links are UNSET, not replaced. Most of
+ * these are corporate or anonymous imprints — a Frankfurt fair catalogue was
+ * compiled by the fair's booksellers, a Habsburg banned-book list by the Aulic
+ * Commission — so no personal name is the right answer, and inventing one would
+ * substitute a second fabrication for the first. An unset author renders as
+ * unattributed, which is what these records honestly are.
+ *
+ * Note these are real books worth holding: the *Catalogus Librorum a Commissione
+ * Aulica Prohibitorum* is a Habsburg censorship record and a primary source for
+ * the history of the book trade. Only the attribution is wrong.
+ *
+ * DELIBERATELY EXCLUDED. `69c774ad6a0f3d112faf9347` — *Bibliotheca Fratrum
+ * Polonorum* (1668), flagged by the audit against Faustus Socinus (d. 1604). That
+ * is a genuine posthumous collected edition of the Socinian corpus and Socinus is
+ * its principal author. The detector cannot tell that from a catalogue; a human
+ * can. This is why the audit is a review queue and never auto-writes.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/repair-author-misattribution-3434.mjs            # dry-run
+ *   node scripts/maintenance/repair-author-misattribution-3434.mjs --apply
+ *   node scripts/maintenance/repair-author-misattribution-3434.mjs --revert   # from backup
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const APPLY = process.argv.includes('--apply');
+const REVERT = process.argv.includes('--revert');
+const BACKUP = 'scripts/output/author-misattribution-3434-backup.json';
+
+// Hand-verified. Each entry: id, the wrong author, and why it is wrong.
+const MISATTRIBUTED = [
+  // ── Heinrich Khunrath (d. 1605) — 18th-c. censorship lists and catalogues ──
+  { id: '69b51df1efd8df28f2dadfad', wrong: 'Heinrich Khunrath', year: 1751, why: 'Halle library accession report; Khunrath d. 1605' },
+  { id: '69b51df5768235dc6598a621', wrong: 'Heinrich Khunrath', year: 1758, why: 'Habsburg Aulic Commission banned-book list' },
+  { id: '69b51df5261c58d63664d47a', wrong: 'Heinrich Khunrath', year: 1758, why: 'Habsburg Aulic Commission banned-book list' },
+  { id: '69b51df5cf111105c4294131', wrong: 'Heinrich Khunrath', year: 1762, why: 'Habsburg Aulic Commission banned-book list' },
+  { id: '69b51df647b06ecd58187baa', wrong: 'Heinrich Khunrath', year: 1763, why: 'bookseller index librorum' },
+  { id: '69b51df6768235dc6598a6e2', wrong: 'Heinrich Khunrath', year: 1765, why: 'Habsburg Aulic Commission banned-book list' },
+  { id: '69b51df7efd8df28f2dae884', wrong: 'Heinrich Khunrath', year: 1765, why: 'Habsburg Aulic Commission banned-book list' },
+  { id: '69b51df7cf111105c42942d9', wrong: 'Heinrich Khunrath', year: 1768, why: 'Habsburg Aulic Commission banned-book list' },
+  { id: '69b51dfd768235dc6598ae64', wrong: 'Heinrich Khunrath', year: 1791, why: 'chemical/alchemical book-sale Verzeichniß' },
+  { id: '69b51e06cf111105c4295209', wrong: 'Heinrich Khunrath', year: 1810, why: 'Allgemeiner Anzeiger der Deutschen, a periodical' },
+  // ── Gerhard Dorn (d. 1584) — late-18th-c. book auction catalogues ──
+  { id: '69b51dfecf111105c4294c34', wrong: 'Gerhard Dorn', year: 1797, why: 'estate book-auction Verzeichniß; Dorn d. 1584' },
+  { id: '69b51e05efd8df28f2daf369', wrong: 'Gerhard Dorn', year: 1806, why: 'chemical/alchemical book-sale Verzeichniß' },
+  // ── Elias Ashmole (d. 1692) ──
+  { id: '69b51e8f9a81ef7feb3d75e2', wrong: 'Elias Ashmole', year: 1809, why: "G. J. Manget's bookshop catalogue" },
+  // ── Robert Fludd (d. 1637) ──
+  { id: '69b51df6cf111105c4294244', wrong: 'Robert Fludd', year: 1765, why: 'book-auction catalogue of a rare-book collection' },
+];
+
+// Fields that carry or derive from the wrong attribution.
+const ATTRIBUTION_FIELDS = ['author', 'author_id', 'author_entity_id', 'normalized_author'];
+
+const mc = new MongoClient(process.env.MONGODB_URI);
+await mc.connect();
+const books = mc.db('bookstore').collection('books');
+
+// ── revert ───────────────────────────────────────────────────────────────────
+if (REVERT) {
+  if (!existsSync(BACKUP)) { console.error(`No backup at ${BACKUP} — nothing to revert.`); process.exit(1); }
+  const saved = JSON.parse(readFileSync(BACKUP, 'utf8'));
+  let n = 0;
+  for (const row of saved.records) {
+    const restore = {};
+    for (const f of ATTRIBUTION_FIELDS) if (row.before[f] !== undefined) restore[f] = row.before[f];
+    if (!Object.keys(restore).length) continue;
+    const r = await books.updateOne({ id: row.id }, { $set: restore });
+    n += r.modifiedCount;
+  }
+  console.log(`Reverted attribution fields on ${n} of ${saved.records.length} records from ${saved.created_at}.`);
+  await mc.close();
+  process.exit(0);
+}
+
+// ── read current state, verify each target still looks like what we verified ──
+const ids = MISATTRIBUTED.map((m) => m.id);
+const current = await books
+  .find({ id: { $in: ids } },
+        { projection: { id: 1, title: 1, author: 1, author_id: 1, author_entity_id: 1, normalized_author: 1, year: 1, visible: 1 } })
+  .toArray();
+const byId = new Map(current.map((b) => [b.id, b]));
+
+console.log(`Targets: ${MISATTRIBUTED.length}   found in DB: ${current.length}\n`);
+
+const actionable = [];
+const skipped = [];
+for (const m of MISATTRIBUTED) {
+  const b = byId.get(m.id);
+  if (!b) { skipped.push({ ...m, skip: 'not found in DB' }); continue; }
+  if (b.author == null || b.author === '') { skipped.push({ ...m, skip: 'author already unset' }); continue; }
+  // Guard: refuse to touch a record whose author is no longer the value we verified.
+  // Someone may have corrected it by hand since; a blind unset would destroy that.
+  if (String(b.author).trim() !== m.wrong) {
+    skipped.push({ ...m, skip: `author changed since verification (now "${b.author}") — re-verify before touching` });
+    continue;
+  }
+  actionable.push({ m, b });
+}
+
+for (const { m, b } of actionable) {
+  console.log(`  ${m.id}  ${b.year}  "${b.author}"  ->  (unset)`);
+  console.log(`      ${String(b.title).slice(0, 84)}`);
+  console.log(`      ${m.why}`);
+}
+if (skipped.length) {
+  console.log(`\nSkipped ${skipped.length}:`);
+  for (const s of skipped) console.log(`  ${s.id}  ${s.skip}`);
+}
+
+if (!APPLY) {
+  console.log(`\nDRY-RUN. ${actionable.length} records would have ${ATTRIBUTION_FIELDS.join(', ')} unset.`);
+  console.log('Re-run with --apply to write.');
+  await mc.close();
+  process.exit(0);
+}
+
+// ── back up BEFORE writing, then write ───────────────────────────────────────
+mkdirSync(dirname(BACKUP), { recursive: true });
+writeFileSync(BACKUP, JSON.stringify({
+  issue: 3434,
+  created_at: new Date().toISOString(),
+  note: 'Pre-repair attribution fields. Restore with --revert.',
+  records: actionable.map(({ m, b }) => ({
+    id: m.id,
+    title: b.title,
+    why: m.why,
+    before: Object.fromEntries(ATTRIBUTION_FIELDS.filter((f) => b[f] !== undefined).map((f) => [f, b[f]])),
+  })),
+}, null, 2));
+console.log(`\nBackup written: ${BACKUP}`);
+
+let modified = 0;
+for (const { m } of actionable) {
+  const r = await books.updateOne(
+    { id: m.id, author: m.wrong },   // re-assert the guard at write time
+    { $unset: Object.fromEntries(ATTRIBUTION_FIELDS.map((f) => [f, ''])),
+      $set: {
+        updated_at: new Date(),
+        'field_provenance.author': {
+          source: 'maintenance',
+          method: 'manual-verification',
+          script: 'repair-author-misattribution-3434.mjs',
+          issue: 3434,
+          date: new Date(),
+          action: 'cleared',
+          previous_value: m.wrong,
+          note: m.why,
+        },
+      } },
+  );
+  modified += r.modifiedCount;
+}
+console.log(`APPLIED: cleared attribution on ${modified} of ${actionable.length} records.`);
+if (modified !== actionable.length) {
+  console.error(`WARNING: ${actionable.length - modified} writes did not match — re-run the audit before assuming success.`);
+}
+
+console.log('\nNext: these are visible books, so refresh the Supabase catalogue mirror');
+console.log('and revalidate the affected /book and /author pages (see CLAUDE.md).');
+await mc.close();

--- a/tests/unit/author-date-window.test.ts
+++ b/tests/unit/author-date-window.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Author date-window guards (#2250, #2264, #3434).
+ *
+ * These are BEHAVIOUR tests: every case calls the real function and asserts the
+ * verdict it returns. Deleting the death-side logic, inverting a comparison, or
+ * loosening the genre regex all make cases here fail — which is the bar a guard
+ * has to clear (see "A test that greps source is not a guard" in CLAUDE.md).
+ *
+ * The invariant worth protecting is the ASYMMETRY between the two functions:
+ *
+ *   authorshipPlausible          excludes on the BIRTH side only. A book printed
+ *                                after an author's death is a reprint, not a
+ *                                misattribution — Boethius carries 55 of them.
+ *
+ *   posthumousMisattributionLikely  uses the death side, but ONLY together with
+ *                                the genre of the containing book. A catalogue is
+ *                                not an edition of anything, so a long-dead
+ *                                author on one is evidence of mention, not
+ *                                authorship (#3434: Khunrath d. 1605 on a 1762
+ *                                Habsburg banned-book list).
+ *
+ * Collapsing those two into one death-side rule would flag every legitimate
+ * reprint in the corpus. The `reprintsNeverFlagged` block below is what stops it.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  parseWikidataYear,
+  authorshipPlausible,
+  posthumousMisattributionLikely,
+  isReferenceGenreTitle,
+} from '../../scripts/lib/author-date-window.mjs';
+
+describe('parseWikidataYear', () => {
+  it('parses full dates, bare years, and zero-padded BCE years', () => {
+    expect(parseWikidataYear('1756-01-27')).toBe(1756);
+    expect(parseWikidataYear('1498')).toBe(1498);
+    expect(parseWikidataYear('-0427')).toBe(-427);
+    expect(parseWikidataYear('0080-01-01')).toBe(80);
+  });
+
+  it('returns null for missing or unparseable input rather than guessing', () => {
+    for (const bad of [null, undefined, '', '   ', 'n.d.', 'circa', '0000']) {
+      expect(parseWikidataYear(bad as string)).toBeNull();
+    }
+  });
+});
+
+describe('authorshipPlausible — excludes on the birth side only', () => {
+  it('rules out a book printed well before the author was born', () => {
+    const r = authorshipPlausible({ bookYear: 1500, birthYear: 1756, margin: 10 });
+    expect(r.plausible).toBe(false);
+    expect(r.reason).toMatch(/predates author birth/);
+  });
+
+  it('tolerates near-birth noise inside the margin', () => {
+    expect(authorshipPlausible({ bookYear: 1750, birthYear: 1756, margin: 10 }).plausible).toBe(true);
+    expect(authorshipPlausible({ bookYear: 1745, birthYear: 1756, margin: 10 }).plausible).toBe(false);
+  });
+
+  it('NEVER excludes on the death side — posthumous editions are normal', () => {
+    // A 1925 Boethius (d. 524) is a reprint. If this ever returns false, every
+    // reprint in the corpus becomes a false positive.
+    const r = authorshipPlausible({ bookYear: 1925, birthYear: 477, deathYear: 524, margin: 10 });
+    expect(r.plausible).toBe(true);
+  });
+
+  it('abstains when a required year is missing', () => {
+    expect(authorshipPlausible({ bookYear: null, birthYear: 1500 }).plausible).toBe(true);
+    expect(authorshipPlausible({ bookYear: 1500, birthYear: null }).plausible).toBe(true);
+  });
+});
+
+describe('isReferenceGenreTitle', () => {
+  const CATALOGUES = [
+    'Catalogus Librorum A Commissione Aulica Prohibitorum',
+    'Catalogus librorum per quinquennium a Commissione Aulica prohibitorum',
+    'Catalogue général des livres qui se trouvent chez G. J. Manget. 1809',
+    'Catalogo de\'libri che trovansi vendibili nel negozio di Carlo',
+    'Verzeichniß von chymischen, alchymischen, physikalischen Büchern',
+    'Verzeichniss einiger Rarer Bücher',
+    'Index librorum quorundam ex omni elegantiori litteratura',
+    'Nachrichten von einer hallischen Bibliothek. 7 = 37/42. Stück. 1751',
+    'Allgemeiner Anzeiger der Deutschen',
+    'Katalog einer auserlesenen Büchersammlung',
+    '[Catalogus librorum] Catalogvs librorvm in omni facultate',
+    'Nachtrag zu dem Catalogo Librorum A Commissione Aulica Prohibitorum. 7',
+    'Supplementum ad catalogum librorum a commissione aulica prohibitorum',
+    'Bibliotheca Heinsiana Sive Catalogus Librorum',
+  ];
+  it.each(CATALOGUES)('recognises %s', (t) => {
+    expect(isReferenceGenreTitle(t)).toBe(true);
+  });
+
+  // The regex is start-anchored so it cannot sweep in works that merely cite a
+  // catalogue, and must not fire on ordinary works that happen to contain a
+  // catalogue-ish word later on.
+  const NOT_CATALOGUES = [
+    'Amphitheatrum Sapientiae Aeternae',
+    'Theatrum Chemicum, Praecipuos Selectorum Auctorum Tractatus',
+    'Turba Philosophorum, Das ist, Das Buch von der güldenen Kunst',
+    'Vom Hylealischen, Das ist, Pri-materialischen Catholischen Oder Algemeinen',
+    'De Igne Magorum Philosophorumque secreto externo et visibili',
+    'A treatise on the catalogue of the stars',
+    'Aureum Vellus, oder Güldin Schatz und Kunstkammer',
+  ];
+  it.each(NOT_CATALOGUES)('does not fire on %s', (t) => {
+    expect(isReferenceGenreTitle(t)).toBe(false);
+  });
+
+  it('treats missing titles as not-a-catalogue rather than throwing', () => {
+    expect(isReferenceGenreTitle(null)).toBe(false);
+    expect(isReferenceGenreTitle(undefined)).toBe(false);
+    expect(isReferenceGenreTitle('')).toBe(false);
+  });
+});
+
+describe('posthumousMisattributionLikely — death side, gated on genre (#3434)', () => {
+  // The real records the issue was filed about.
+  const KHUNRATH_DEATH = 1605;
+  it.each([
+    [1751, 'Nachrichten von einer hallischen Bibliothek. 7 = 37/42. Stück. 1751'],
+    [1758, 'Catalogus Librorum per Quinquenium à Commissione aulica prohibitorum'],
+    [1762, 'Catalogus Librorum A Commissione Aulica Prohibitorum'],
+    [1810, 'Allgemeiner Anzeiger der Deutschen'],
+  ])('flags the %i catalogue attributed to Khunrath', (bookYear, title) => {
+    const r = posthumousMisattributionLikely({ bookYear, deathYear: KHUNRATH_DEATH, title });
+    expect(r.suspect).toBe(true);
+    expect(r.reason).toMatch(/after author death/);
+  });
+
+  it('flags the other verified cases (Dorn, Ashmole, Fludd)', () => {
+    expect(posthumousMisattributionLikely({
+      bookYear: 1797, deathYear: 1584, title: 'Verzeichniß des einen Theils der von dem verstorbenen Königl. Leibmedicus',
+    }).suspect).toBe(true);
+    expect(posthumousMisattributionLikely({
+      bookYear: 1809, deathYear: 1692, title: 'Catalogue général des livres qui se trouvent chez G. J. Manget',
+    }).suspect).toBe(true);
+    expect(posthumousMisattributionLikely({
+      bookYear: 1765, deathYear: 1637, title: "Catalogue D'Une Nombreuse Collection De Livres, En Tout Genre",
+    }).suspect).toBe(true);
+  });
+
+  describe('reprintsNeverFlagged', () => {
+    // BOTH conditions are required. Genre without the death gap, or the death gap
+    // without the genre, must stay silent — otherwise the corpus's reprints and
+    // its legitimate catalogue compilers both become false positives.
+    it('does not flag a posthumous reprint of the author\'s own work', () => {
+      const r = posthumousMisattributionLikely({
+        bookYear: 1925, deathYear: 524, title: 'De consolatione philosophiae',
+      });
+      expect(r.suspect).toBe(false);
+      expect(r.reason).toMatch(/not a reference-genre title/);
+    });
+
+    it('does not flag a catalogue compiled by its own living author', () => {
+      // Bernardus de Lutzemburgo (d. 1535) genuinely wrote Catalogus haereticorum.
+      const r = posthumousMisattributionLikely({
+        bookYear: 1529, deathYear: 1535, title: 'Catalogus haereticorum omnium pene qui ad haec usque tempora',
+      });
+      expect(r.suspect).toBe(false);
+      expect(r.reason).toMatch(/within/);
+    });
+
+    it('does not flag a 1653 edition of Khunrath\'s own Amphitheatrum', () => {
+      const r = posthumousMisattributionLikely({
+        bookYear: 1653, deathYear: KHUNRATH_DEATH, title: 'Amphitheatrvm Sapientiae Aeternae, Solius, Verae',
+      });
+      expect(r.suspect).toBe(false);
+    });
+  });
+
+  it('respects the margin boundary exactly', () => {
+    const title = 'Catalogus Librorum';
+    expect(posthumousMisattributionLikely({ bookYear: 1650, deathYear: 1600, title, margin: 50 }).suspect).toBe(false);
+    expect(posthumousMisattributionLikely({ bookYear: 1651, deathYear: 1600, title, margin: 50 }).suspect).toBe(true);
+  });
+
+  it('abstains when the death year is unknown', () => {
+    // Only 1,229 of 3,253 entity-linked author docs have a death year, so
+    // abstaining rather than guessing is the common path, not an edge case.
+    const r = posthumousMisattributionLikely({
+      bookYear: 1762, deathYear: null, title: 'Catalogus Librorum A Commissione Aulica Prohibitorum',
+    });
+    expect(r.suspect).toBe(false);
+    expect(r.reason).toMatch(/no author death year/);
+  });
+
+  it('abstains when the book year is unknown', () => {
+    expect(posthumousMisattributionLikely({
+      bookYear: null, deathYear: 1605, title: 'Catalogus Librorum',
+    }).suspect).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes the concrete asks in #3434 and corrects its diagnosis.

## The bug is narrower and more mechanical than "work titles in the author field"

The 2026-03-14 BSB import run (1,353 books) **stamped its search term into `books.author`.** The tell is in the values themselves:

`Albertus Secrets` · `Fludd Medicina` · `Kircher Oedipus` · `Kircher Ars Magna` · `Kircher Musurgia` · `John Dee Monas` · `Kabbala Denudata` · `Iamblichus De Mysteriis`

Nobody writes those as names — they are `<surname> <work keyword>` **queries**. And the books wearing them are overwhelmingly bookseller and library catalogues, because a full-text search for a title matches every catalogue that *lists* a copy of it. Catalogues are the highest-recall false positive for a title search.

That explains every symptom at once, including two the issue read as separate problems:

| author string | what it actually landed on |
|---|---|
| `Heinrich Khunrath` | 14 catalogues + periodicals, 1751–1810 (he died 1605) |
| `Iamblichus De Mysteriis` | 5 bookseller/library catalogues |
| `Kircher Oedipus` | German literary periodicals (*Der teutsche Merkur*, *Morgenblatt für gebildete Stände*) |
| `Confessio Fraternitatis` | 16 editions of the **Augsburg Confession** — keyword collision on "Confessio" |

`field_provenance` has **no `author` entry on any of these records**, so none of it was traceable from the data — the second-layer gap #3471 describes.

## Why neither existing detector could see it

- **`qa-author-date-anachronisms.mjs`** tests the **birth** side only (book predates birth). This class is the death side, so it is invisible there *by construction*.
- **`quarantine-non-person-authors.mjs`** fixes the `authors` **thesaurus** and never touches `books.author` — a book keeps rendering "by Theatrum Chemicum" after its author doc is quarantined. Its safety interlock also, correctly, refuses to touch anchored real people, so Khunrath could **never** be caught there: he is a real person with a VIAF id who genuinely wrote other books we hold.

## The asymmetry this preserves

`author-date-window.mjs` deliberately refuses to exclude on the death side, and that refusal is **right** for editions — a 1925 Boethius is a reprint, and Boethius alone carries 55 of them. It is the wrong rule for a catalogue, which is not an edition of anything.

So `posthumousMisattributionLikely()` uses the death side **only together with the genre** of the containing book. Both conditions are required. Collapsing them into one death-side rule would flag every legitimate reprint in the corpus; `tests/unit/author-date-window.test.ts` has a `reprintsNeverFlagged` block that fails if anyone does. I verified the test has teeth by removing the genre gate and watching it go red, not just green.

Genre alone proves nothing either — a person *can* compile a catalogue (Guanzelli compiled the *Index librorum expurgandorum*; Bernardus de Lutzemburgo wrote *Catalogus haereticorum*). An earlier draft of the audit flagged all three of them; the current signature does not.

## What's here

- **`scripts/audit/author-attribution.mjs`** — standing read-only audit. Three checks: posthumous reference-genre, work-title-as-author, structural garbage. Exits non-zero when anything is flagged. It is a **review queue and never writes**, because a genuine posthumous collected edition looks identical (Diodorus' own *Bibliotheca Historica*; *Bibliotheca Fratrum Polonorum*).
- **`repair-author-misattribution-3434.mjs`** — the 14 verified records as a **literal list**, so it cannot widen its own blast radius if detector precision changes. Backup + `--revert`, and it re-asserts the expected author at write time so a hand correction made since verification is never clobbered.
- **`posthumousMisattributionLikely()` + `isReferenceGenreTitle()`** in the existing helper; `authorshipPlausible` semantics untouched.
- 15 further hand-verified work titles added to the quarantine list.

**Unsets rather than replaces.** These are corporate and anonymous imprints — a Frankfurt fair catalogue was compiled by the fair's booksellers, a Habsburg banned-book list by the Aulic Commission. Inventing a name would swap one fabrication for another.

These are real books worth holding: the *Catalogus Librorum a Commissione Aulica Prohibitorum* is a Habsburg censorship record. Only the attribution was wrong, and all 14 remain visible.

## Applied to production

- 14 books cleared — verified 14/14, `field_provenance.author` stamped, all still visible
- `books_catalog` synced (14 synced, 0 errors); byline confirmed gone from the live page
- 9 further work-title author docs quarantined (`is_person:false`: 50 → 59)
- Audit check 1 now returns **1** finding: the *Bibliotheca Fratrum Polonorum*, deliberately excluded as a genuine posthumous collected edition

Found **4 misattributions the issue didn't know about**: Gerhard Dorn ×2, Elias Ashmole, Robert Fludd — all on later book-auction catalogues.

## Out of scope, deliberately

1. **All 14 slugs and all 14 `work_id`s still encode the wrong name** (`local:a:heinrich-khunrath:books-by-catalog-commission-court-prohibited`). The work-identity layer clustered these catalogues under Khunrath. Renaming public URLs and rewriting work-cluster keys each need their own review — noted on #3434.
2. **The 21 work-title-as-author strings** the audit flags need a per-string curatorial call (unset vs. correct to a person, e.g. `Iamblichus De Mysteriis` → Iamblichus).
3. **`is_person: false` is read by nothing in `src/`** — `/author/theatrum-chemicum` still returns HTTP 200 listing 4 books. 50 quarantine flags were inert before this PR and 59 are now. That is a reader-facing behaviour change with its own blast radius; filing separately rather than smuggling it in here.
4. `[object Object]` on 3,297 books (0 visible) — real, not reader-facing.

`npx tsc --noEmit` clean; 1,049 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)