### PR TITLE
feat(analytics): instrument the BPH catalogue search; one writer for all search events

### DIFF
--- a/src/app/api/[tenant]/books/[id]/search/route.ts
+++ b/src/app/api/[tenant]/books/[id]/search/route.ts
@@ -3,6 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { resolveTenantId } from '@/lib/tenant-context';
 import { isBookReadable } from '@/lib/book-access';
+import { logSearchEvent } from '@/lib/search-event-log';
 
 interface SearchMatch {
   field: 'ocr' | 'translation';
@@ -171,17 +172,12 @@ export async function GET(
       if (hasTranslation) translationPages++;
     }
 
-    // Log search query (fire-and-forget)
-    db.collection('analytics_events').insertOne({
-      event: 'search_query',
-      query: trimmedQuery,
-      results_count: results.length,
-      filters: { book_id: bookId, tenantId, source: 'book_search' },
+    // Log search query (fire-and-forget) — see src/lib/search-event-log.ts
+    logSearchEvent({
+      request, db, query: trimmedQuery, resultsCount: results.length, source: 'book_search',
       tenantId,
-      timestamp: new Date(),
-      ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
-      created_at: new Date(),
-    }).catch(() => {});
+      filters: { book_id: bookId },
+    });
 
     return NextResponse.json({
       query: trimmedQuery,

--- a/src/app/api/books/[id]/search/route.ts
+++ b/src/app/api/books/[id]/search/route.ts
@@ -5,6 +5,7 @@ import { semanticPageSearchScoped } from '@/lib/semantic-search';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { isBookReadable } from '@/lib/book-access';
+import { logSearchEvent } from '@/lib/search-event-log';
 
 interface SearchMatch {
   field: 'ocr' | 'translation';
@@ -251,16 +252,12 @@ export async function GET(
       if (result.matches.some(m => m.field === 'translation')) translationPages++;
     }
 
-    // Log search query (fire-and-forget)
-    db.collection('analytics_events').insertOne({
-      event: 'search_query',
-      query: trimmedQuery,
-      results_count: results.length,
-      filters: { book_id: bookId, source: 'book_search', tenantId: tenantContext.id || null },
-      timestamp: new Date(),
-      ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
-      created_at: new Date(),
-    }).catch(() => {});
+    // Log search query (fire-and-forget) — see src/lib/search-event-log.ts
+    logSearchEvent({
+      request, db, query: trimmedQuery, resultsCount: results.length, source: 'book_search',
+      tenantId: tenantContext.id || null,
+      filters: { book_id: bookId },
+    });
 
     return NextResponse.json({
       query: trimmedQuery,

--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -3,6 +3,8 @@ import { supabase, sanitizeFilterValue } from '@/lib/supabase';
 import { normalizeBphSearchText } from '@/lib/text-normalize';
 import { getReadDb } from '@/lib/mongodb';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import { logSearchEvent } from '@/lib/search-event-log';
+import { resolveTenantId } from '@/lib/tenant-context';
 
 export const dynamic = 'force-dynamic';
 
@@ -443,9 +445,54 @@ export async function GET(req: NextRequest) {
     }
   }
 
+  const total = isPinnedDigitizedView ? BPH_DIGITIZED_PINNED_TOTAL : (result.count || 0);
+
+  // Record the search. This route is the BPH reading room's front-page search
+  // box — the first thing a visitor sees — and until #3483 it logged nothing at
+  // all, which made "how much do readers search here?" unanswerable.
+  //
+  // Two deliberate exclusions, so the count means "searches" and not "requests":
+  //   - a request carrying no query and no advanced field is *browsing* the
+  //     catalogue (or paging through it), not searching;
+  //   - only `offset === 0` is logged, so paginating deeper into one result set
+  //     stays one search rather than N.
+  // Both matter because this number will be read as a rate against reading-room
+  // pageviews; inflating the numerator would repeat the error this fixes.
+  const advancedTerms = { author, title, place, printer, publisher, editor, keyword, shelfMark, provenance };
+  const hasSearchTerm = !!q || Object.values(advancedTerms).some(Boolean);
+  if (hasSearchTerm && offset === 0) {
+    // Resolved inside the fire-and-forget path so neither the tenant lookup
+    // (cached, but still async) nor the insert sits on the response path.
+    void resolveTenantId('bph')
+      .then((tenantId) => {
+        logSearchEvent({
+          request: req,
+          // The simple search box is `q`; an advanced-only search has no `q`,
+          // so fall back to the field that was actually filled in.
+          query: q || Object.values(advancedTerms).find(Boolean) || '',
+          resultsCount: total,
+          source: 'catalogue',
+          tenantId,
+          filters: {
+            ...Object.fromEntries(Object.entries(advancedTerms).filter(([, v]) => v)),
+            language: language || null,
+            yearFrom,
+            yearTo,
+            digitized,
+            first_translation: firstTranslation || null,
+            sort,
+            // Distinguishes "typed in the simple box" from "used the advanced
+            // form" — they are different behaviours and worth telling apart.
+            advanced: !q,
+          },
+        });
+      })
+      .catch(() => {});
+  }
+
   return NextResponse.json({
     works,
-    total: isPinnedDigitizedView ? BPH_DIGITIZED_PINNED_TOTAL : (result.count || 0),
+    total,
     offset,
     limit,
     schemaMode: schemaMode || 'unknown',

--- a/src/app/api/search/index/route.ts
+++ b/src/app/api/search/index/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { logSearchEvent } from '@/lib/search-event-log';
 
 const ENTITIES_SEARCH_INDEX = 'entities_search';
 
@@ -86,19 +87,11 @@ export async function GET(request: NextRequest) {
       byType[r.type] = (byType[r.type] || 0) + 1;
     }
 
-    // Log search query (fire-and-forget)
-    db.collection('analytics_events').insertOne({
-      event: 'search_query',
-      query,
-      results_count: results.length,
-      filters: { type, source: 'index' },
-      timestamp: new Date(),
-      ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
-      // Geo from the edge header (same source pageviews use) so search interests
-      // can be broken down by country. Forward-only — past searches have none.
-      country: request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || 'Unknown',
-      created_at: new Date(),
-    }).catch(() => {});
+    // Log search query (fire-and-forget) — see src/lib/search-event-log.ts
+    logSearchEvent({
+      request, db, query, resultsCount: results.length, source: 'index',
+      filters: { type },
+    });
 
     const response = NextResponse.json({ query, total: results.length, byType, results });
     response.headers.set('Cache-Control', 'public, max-age=0, s-maxage=60, stale-while-revalidate=300');

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -13,6 +13,7 @@ import { withApiAuth } from '@/lib/api-auth';
 import { expandLanguages } from '@/lib/language-utils';
 import { logSearchQuery } from '@/lib/search-log';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
+import { logSearchEvent } from '@/lib/search-event-log';
 
 export const preferredRegion = 'fra1';
 
@@ -847,20 +848,11 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
       }
     }
 
-    // Log search query (fire-and-forget)
-    db.collection('analytics_events').insertOne({
-      event: 'search_query',
-      query,
-      results_count: results.length,
-      semantic_count: semanticDocs.length,
-      filters: { language, category, year, bookId, library, source: 'global' },
-      timestamp: new Date(),
-      ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
-      // Geo from the edge header (same source pageviews use) so search interests
-      // can be broken down by country. Forward-only — past searches have none.
-      country: request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || 'Unknown',
-      created_at: new Date(),
-    }).catch(() => {});
+    // Log search query (fire-and-forget) — see src/lib/search-event-log.ts
+    logSearchEvent({
+      request, db, query, resultsCount: results.length, source: 'global',
+      filters: { language, category, year, bookId, library, semantic_count: semanticDocs.length },
+    });
 
     logSearchQuery({
       request, identity, route: 'search', query,

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -13,6 +13,7 @@ import { anonSearchGate, SIGNIN_URL } from '@/lib/anon-gate';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { CLIP_URL } from '@/lib/clip';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import { logSearchEvent } from '@/lib/search-event-log';
 
 const ENTITIES_SEARCH_INDEX = 'entities_search';
 const GALLERY_SEARCH_INDEX = 'gallery_search';
@@ -448,19 +449,13 @@ export async function GET(request: NextRequest) {
       filteredArtworks.total = filteredArtworks.results.length;
     }
 
-    // Log search query (fire-and-forget)
-    db.collection('analytics_events').insertOne({
-      event: 'search_query',
-      query,
-      results_count: scopedBooks.total + scopedIndex.total + scopedGallery.total + filteredVisual.total + scopedSemantic.total + filteredArtworks.total,
-      filters: { language, category, library, source: 'unified', tenantId: tenantContext.id || null },
-      timestamp: new Date(),
-      ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
-      // Geo from the edge header (same source pageviews use) so search interests
-      // can be broken down by country. Forward-only — past searches have none.
-      country: request.headers.get('x-vercel-ip-country') || request.headers.get('cf-ipcountry') || 'Unknown',
-      created_at: new Date(),
-    }).catch(() => {});
+    // Log search query (fire-and-forget) — see src/lib/search-event-log.ts
+    logSearchEvent({
+      request, db, query, source: 'unified',
+      resultsCount: scopedBooks.total + scopedIndex.total + scopedGallery.total + filteredVisual.total + scopedSemantic.total + filteredArtworks.total,
+      tenantId: tenantContext.id || null,
+      filters: { language, category, library },
+    });
 
     return NextResponse.json({
       query,

--- a/src/lib/search-event-log.ts
+++ b/src/lib/search-event-log.ts
@@ -1,0 +1,133 @@
+import type { NextRequest } from 'next/server';
+import type { Db } from 'mongodb';
+import { getDb } from '@/lib/mongodb';
+import { classifyRequest } from '@/lib/analytics-ingest';
+
+/**
+ * The single writer for `analytics_events` `search_query` documents.
+ *
+ * Why this file exists — two failures found together on 2026-07-31:
+ *
+ * 1. **A whole search box recorded nothing.** The BPH reading room's
+ *    front-page catalogue search (`BphCatalogBrowser` → `/api/catalog/bph`)
+ *    had no logging of any kind. It is the first thing a visitor to the
+ *    reading room sees, and over four months it produced zero rows. The only
+ *    BPH searches we could see were in-book search and the site's unified
+ *    search — 644 records that were then mistaken for the whole picture, and
+ *    briefly reported to the partner as "readers here don't search."
+ *
+ * 2. **Every writer was hand-rolled and they had drifted.** Five routes each
+ *    built their own `insertOne`, so the fields disagreed: `/api/search/unified`
+ *    stored `country`, the book-search routes did not; **none** stored `host`,
+ *    which is why all 94,442 stored events had `host: null` and reading-room
+ *    searches could not be separated from main-site searches at all. That is
+ *    the same shape as the five `entities.books[]` writers in CLAUDE.md.
+ *
+ * The rule this module enforces: **a search that a human can type is a search
+ * that gets logged, through here, with the request classified at write time.**
+ * `classifyRequest()` is the shared classifier from `analytics-ingest` — it
+ * yields `traffic_class`, `user_agent` and `host`, so a new search surface
+ * cannot be born contaminated or unattributable (see CLAUDE.md, "The
+ * measurement layer fails silently, and always toward good news").
+ *
+ * Fire-and-forget by design: logging must never fail or slow a search
+ * response. Callers do not await it.
+ */
+
+/** Where the search was typed. One value per distinct search box in the UI. */
+export type SearchSource =
+  /** Site-wide search on the main site (`/api/search`). */
+  | 'global'
+  /** The "All" tab / homepage search (`/api/search/unified`). */
+  | 'unified'
+  /** Search inside a single open book (`/api/books/[id]/search` + tenant twin). */
+  | 'book_search'
+  /** Entity/index search (`/api/search/index`). */
+  | 'index'
+  /** The BPH-style partner catalogue browser (`/api/catalog/bph`). */
+  | 'catalogue';
+
+export interface LogSearchEventInput {
+  request: NextRequest;
+  /** Raw user query. Trimmed and truncated before storage. */
+  query: string;
+  /** Number of results the caller returned. Use 0 for a genuine no-hit. */
+  resultsCount: number;
+  /** Which search box this came from. */
+  source: SearchSource;
+  /** Tenant the search was scoped to, when the surface is tenant-scoped. */
+  tenantId?: string | null;
+  /** Extra per-surface filter context (language, year range, book id, …). */
+  filters?: Record<string, unknown>;
+  /**
+   * Reuse an already-open handle instead of resolving a new one. Routes that
+   * already hold a `Db` should pass it; the write is on the response path.
+   */
+  db?: Db;
+}
+
+const MAX_QUERY_LEN = 300;
+const MAX_FILTER_STR = 100;
+
+/** Country from the edge headers — same source the pageview log uses. */
+function edgeCountry(request: NextRequest): string {
+  return (
+    request.headers.get('x-vercel-ip-country') ||
+    request.headers.get('cf-ipcountry') ||
+    'Unknown'
+  );
+}
+
+/** Coerce a free-form filter bag to primitives so one bad value can't bloat a doc. */
+function normalizeFilters(filters: Record<string, unknown> | undefined): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(filters || {})) {
+    if (v == null) continue;
+    if (typeof v === 'string') out[k] = v.slice(0, MAX_FILTER_STR);
+    else if (typeof v === 'number' || typeof v === 'boolean') out[k] = v;
+    else if (Array.isArray(v)) out[k] = v.slice(0, 10).map((x) => String(x).slice(0, MAX_FILTER_STR));
+  }
+  return out;
+}
+
+/**
+ * Record one search. Fire-and-forget — never throws, never awaited by callers.
+ *
+ * Empty and whitespace-only queries are dropped: they are typeahead noise, not
+ * searches, and they were a meaningful share of the old zero-result lists.
+ */
+export function logSearchEvent(input: LogSearchEventInput): void {
+  void writeSearchEvent(input).catch(() => {});
+}
+
+async function writeSearchEvent(input: LogSearchEventInput): Promise<void> {
+  const query = (input.query || '').trim();
+  if (!query) return;
+
+  const { cls, userAgent, ip, host } = classifyRequest(input.request);
+  const db = input.db ?? (await getDb());
+
+  await db.collection('analytics_events').insertOne({
+    event: 'search_query',
+    query: query.slice(0, MAX_QUERY_LEN),
+    results_count: input.resultsCount,
+    filters: {
+      ...normalizeFilters(input.filters),
+      source: input.source,
+      tenantId: input.tenantId ?? null,
+    },
+    // Promoted out of `filters` so a tenant breakdown is an indexable field
+    // rather than a nested path. `filters.tenantId` stays for back-compat
+    // with the existing four months of rows and the admin search dashboards.
+    tenantId: input.tenantId ?? null,
+    source: input.source,
+    // Stored at write time — the only moment the evidence exists.
+    traffic_class: cls,
+    user_agent: userAgent,
+    host,
+    ip,
+    country: edgeCountry(input.request),
+    timestamp: new Date(),
+    created_at: new Date(),
+  });
+}

--- a/tests/unit/search-event-instrumentation.test.ts
+++ b/tests/unit/search-event-instrumentation.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// A whole search box recorded nothing for four months.
+//
+// The BPH reading room's front-page catalogue search (`/api/catalog/bph`) had
+// no logging of any kind, while five *other* search routes each hand-rolled
+// their own `analytics_events` insert. The consequences were both directions of
+// wrong: reading-room searches were invisible, and the ones that were visible
+// stored no `host`, so all 94,442 events collapsed into a single unattributable
+// bucket. A usage report briefly told the partner "readers here don't search."
+//
+// Two kinds of test below, deliberately:
+//
+//   1. BEHAVIOUR — drive `logSearchEvent` and assert on the document it really
+//      writes. Breaking the classifier wiring, dropping `host`, or logging
+//      empty queries fails these.
+//   2. ABSENCE — assert no route hand-rolls a `search_query` insert, and that
+//      every known search route imports the shared writer. Here deletion *is*
+//      the failure mode (a new route that forgets to log looks identical to a
+//      route nobody searches), which is the one case CLAUDE.md allows a
+//      source-shape assertion — same rationale as the soft-404 loading guard.
+
+const inserted: Record<string, unknown>[] = [];
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: () => ({
+      insertOne: async (doc: Record<string, unknown>) => {
+        inserted.push(doc);
+        return { insertedId: 'test' };
+      },
+    }),
+  })),
+}));
+
+import { logSearchEvent } from '@/lib/search-event-log';
+
+function req(headers: Record<string, string> = {}) {
+  const h = new Headers({
+    'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) Safari/604.1',
+    host: 'bph.sourcelibrary.org',
+    'x-forwarded-for': '203.0.113.45',
+    'cf-ipcountry': 'NL',
+    ...headers,
+  });
+  return { headers: h } as unknown as Parameters<typeof logSearchEvent>[0]['request'];
+}
+
+/** logSearchEvent is fire-and-forget; let its microtask chain settle. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  inserted.length = 0;
+});
+
+describe('logSearchEvent — the document it writes', () => {
+  it('stores host, traffic class and user agent so a search can be attributed later', async () => {
+    logSearchEvent({
+      request: req(),
+      query: 'quicksilver',
+      resultsCount: 46,
+      source: 'catalogue',
+      tenantId: 'bce03f71-c18d-4460-b8ad-224c817f9aa0',
+    });
+    await settle();
+
+    expect(inserted).toHaveLength(1);
+    const doc = inserted[0];
+    // The three fields whose absence made the original data unusable.
+    expect(doc.host).toBe('bph.sourcelibrary.org');
+    expect(doc.traffic_class).toBe('human');
+    expect(doc.user_agent).toContain('iPhone');
+
+    expect(doc.event).toBe('search_query');
+    expect(doc.query).toBe('quicksilver');
+    expect(doc.results_count).toBe(46);
+    expect(doc.source).toBe('catalogue');
+    expect(doc.country).toBe('NL');
+  });
+
+  it('promotes tenantId to a top-level field and keeps it in filters for back-compat', async () => {
+    logSearchEvent({
+      request: req(), query: 'boehme', resultsCount: 23,
+      source: 'catalogue', tenantId: 'tenant-x',
+    });
+    await settle();
+
+    // Four months of existing rows carry tenant only at filters.tenantId; the
+    // admin search dashboards read that path. Both must be present.
+    expect(inserted[0].tenantId).toBe('tenant-x');
+    expect((inserted[0].filters as Record<string, unknown>).tenantId).toBe('tenant-x');
+  });
+
+  it('classifies a crawler as non-human instead of dropping it', async () => {
+    logSearchEvent({
+      request: req({ 'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' }),
+      query: 'alchemy', resultsCount: 9, source: 'unified',
+    });
+    await settle();
+
+    // Stored, not discarded — retroactive classification is impossible once the
+    // user-agent is gone, so the class is recorded and filtered at read time.
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].traffic_class).not.toBe('human');
+  });
+
+  it('does not write a row for an empty or whitespace-only query', async () => {
+    logSearchEvent({ request: req(), query: '', resultsCount: 0, source: 'catalogue' });
+    logSearchEvent({ request: req(), query: '   ', resultsCount: 0, source: 'catalogue' });
+    await settle();
+
+    // Typeahead noise, not searches — it inflated the old zero-result lists.
+    expect(inserted).toHaveLength(0);
+  });
+
+  it('records a genuine no-hit search', async () => {
+    logSearchEvent({ request: req(), query: 'tekhelet', resultsCount: 0, source: 'catalogue' });
+    await settle();
+
+    // A real search returning nothing is the most valuable row in the table —
+    // it is the collection-gap signal. Must not be confused with the empty case.
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].results_count).toBe(0);
+  });
+
+  it('truncates a very long query rather than storing it whole', async () => {
+    logSearchEvent({ request: req(), query: 'x'.repeat(5000), resultsCount: 1, source: 'global' });
+    await settle();
+    expect((inserted[0].query as string).length).toBeLessThanOrEqual(300);
+  });
+});
+
+// Every route that serves a search box a human can type into. Adding a search
+// surface means adding it here — otherwise this guard silently stops covering
+// the thing it exists to cover (the failure mode of the five `entities.books[]`
+// writers in CLAUDE.md, where a fix "landed everywhere" twice and did not).
+const SEARCH_ROUTES = [
+  'src/app/api/catalog/bph/route.ts',
+  'src/app/api/search/route.ts',
+  'src/app/api/search/unified/route.ts',
+  'src/app/api/search/index/route.ts',
+  'src/app/api/books/[id]/search/route.ts',
+  'src/app/api/[tenant]/books/[id]/search/route.ts',
+];
+
+const repoRoot = path.resolve(__dirname, '../..');
+const read = (p: string) => fs.readFileSync(path.join(repoRoot, p), 'utf8');
+
+describe('search instrumentation coverage', () => {
+  it.each(SEARCH_ROUTES)('%s logs through the shared writer', (route) => {
+    const src = read(route);
+    expect(src).toContain("from '@/lib/search-event-log'");
+    expect(src).toContain('logSearchEvent(');
+  });
+
+  it('no route hand-rolls its own search_query insert', () => {
+    // Five divergent copies is how `host` went missing from all of them.
+    const offenders = SEARCH_ROUTES.filter((r) => {
+      const src = read(r);
+      return /analytics_events'\)\s*\.insertOne\(\{[\s\S]{0,200}event:\s*'search_query'/.test(src);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('the BPH catalogue route only logs real searches, not catalogue browsing', () => {
+    const src = read('src/app/api/catalog/bph/route.ts');
+    // Guards the numerator: without this, every page of catalogue browsing and
+    // every pagination click counts as a search, and the resulting rate against
+    // reading-room pageviews is meaningless.
+    //
+    // Asserted as one composite string that must sit *before* the log call —
+    // `offset === 0` and `hasSearchTerm` each appear elsewhere in this file, so
+    // testing for them separately would pass even with the logging deleted.
+    const guard = src.indexOf('if (hasSearchTerm && offset === 0) {');
+    const call = src.indexOf('logSearchEvent({');
+    expect(guard).toBeGreaterThan(-1);
+    expect(call).toBeGreaterThan(guard);
+  });
+});


### PR DESCRIPTION
## The bug

The BPH reading room's front-page catalogue search — **the first thing a visitor to the reading room sees** — logged nothing at all. `/api/catalog/bph` had no analytics call of any kind. Four months, zero rows.

The gap was invisible because a *different* search box did log. The only BPH searches on record (644) came from in-book search and the site's unified search. Reporting usage to EFM, that was read as the whole picture and briefly stated as **"readers here don't search"** — which is not supported by anything. A field nothing writes looks identical to a field nothing needs.

## Why nobody noticed

Five routes each hand-rolled their own `analytics_events` insert, and they had drifted:

| | `country` | `host` | `traffic_class` |
|---|---|---|---|
| `/api/search/unified` | yes | **no** | no |
| `/api/search` | yes | **no** | no |
| `/api/search/index` | yes | **no** | no |
| `/api/books/[id]/search` | no | **no** | no |
| `/api/[tenant]/books/[id]/search` | no | **no** | no |
| `/api/catalog/bph` | *(no logging at all)* | | |

Because none stored `host`, **all 94,442 stored search events have `host: null`** — reading-room searches cannot be separated from main-site searches even retroactively. Same shape as the five `entities.books[]` writers in CLAUDE.md: N divergent copies of one write, and a fix that "landed everywhere" without landing everywhere.

## The change

- **`src/lib/search-event-log.ts`** — the single writer. Every event goes through `classifyRequest()` (the shared classifier in `analytics-ingest`), so `traffic_class` / `user_agent` / `host` are stored **at write time**, the only moment that evidence exists. Bots are classified and kept, never dropped.
- **`/api/catalog/bph` wired up**, with two deliberate exclusions so the count means *searches* and not *requests*:
  - no query and no advanced field = browsing the catalogue, not searching;
  - only `offset === 0`, so paging deeper into one result set stays one search.

  Both matter because this number will be read as a rate against reading-room pageviews — inflating the numerator would repeat the error this PR fixes.
- **Five existing writers routed through the helper.** `tenantId` is promoted to a top-level field *and* kept at `filters.tenantId`, which the admin search dashboards and four months of existing rows depend on.

## Scope

**In:** the missing instrumentation, and the writer consolidation that let it hide. These are one concern — search is either measured consistently or it isn't.

**Out, deliberately:**
- No backfill. The four months of `host: null` rows are unrecoverable by construction; they are left as-is rather than guessed at.
- `search_queries` (the separate `/api/search` + semantic log) is untouched. It answers a different question (latency, lanes, API identity) and has no tenant column; giving it one is its own change.
- No read-side dashboard work. Once data accumulates, the reading-room search list becomes reportable — that is a follow-up, not this PR.

## Verification

`npx tsc --noEmit` clean · **1124 unit tests pass** (91 files).

Tests are behavioural where behaviour is the risk (drive the writer, assert on the document it actually produces) and source-shape only for the coverage invariant, where deletion *is* the failure mode — a new search route that forgets to log looks exactly like a route nobody uses. That is the one case CLAUDE.md permits a shape assertion, same rationale as the soft-404 loading guard.

Both halves were checked against negative controls rather than assumed:

| Regression introduced | Result |
|---|---|
| catalogue instrumentation removed | **2 tests fail** |
| `host` dropped from the shared writer | **1 test fails** |
| restored | 14/14 pass |

The `hasSearchTerm` / `offset === 0` guard is asserted as a composite string positioned *before* the log call — each token appears elsewhere in that file, so asserting them separately would have passed with the logging deleted. That weaker version was written first and caught by the negative control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)