### PR TITLE
docs: pin the search-surface invariants, and flag a migration that lies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,35 @@ filtered vs an impossible range (which must return 0). Check every lane in the
 response body, not just the first list. Same discipline as the three-layer
 crawler gate above: changing one layer alone is silently defeated by the others.
 
+**A searchable field is a readable field — never index a staff-only column.**
+Being able to search a field is a way of reading it: an attacker (or a curious
+visitor) can binary-search for the phrase it contains, one query at a time, and
+a hit is itself the disclosure. So the public search columns —
+`bph_works.search_norm`, `bph_works.search_tsv`, and any successor — must
+exclude `internal_remarks`, `exhibition_history`, `price`,
+`acquisition_source`/`_date`, the workflow flags, and `modified_by_*` (personal
+data). The exclusion list with per-field reasons lives in
+`scripts/migration/expand-bph-search-norm.sql`; keep it there rather than
+rediscovering it. This is the same shape as the tenant-lockdown rule above — ask
+what a surface *renders*, not only where it *links* — applied to the query side.
+
+**The inverse failure is just as real: a field nobody indexed is a field nobody
+can find.** `search_norm` covered 20 of ~40 populated columns, so searching a
+shelf location, a donor, a USTC number or a phrase from the remarks returned
+nothing — indistinguishable from "we don't hold it", and it took a librarian
+telling us in person to surface it (#3481). When adding a column that a human
+will later search by, add it to the search column in the same PR, or state why
+it is excluded.
+
+**Careful with generated search columns.** They cannot be altered in place —
+drop + recreate, which **also drops their indexes** (rebuild
+`idx_bph_search_norm_trgm` or every query becomes a seq scan), so wrap the whole
+thing in a transaction. And the expression must be IMMUTABLE: `concat_ws` is
+STABLE and is rejected (`42P17`), which is why these use `COALESCE(x,'') || ' '`.
+`add-bph-diacritic-normalization.sql` shows `concat_ws` and **does not match
+deployed reality** — read `pg_get_expr` off the live column, not the migration
+file.
+
 ## Quote & snippet integrity — CRITICAL
 Lessons from PRs #2232/#2233 (the "mercury on page 89" misquote — Nirmal, 2026-05-30).
 

--- a/scripts/migration/add-bph-diacritic-normalization.sql
+++ b/scripts/migration/add-bph-diacritic-normalization.sql
@@ -1,5 +1,27 @@
 -- Diacritic-insensitive search for bph_works (issue #1680).
 --
+-- ⚠️ THIS FILE DOES NOT MATCH PRODUCTION. DO NOT RE-RUN IT.
+--
+-- The generated columns below are written with concat_ws(). concat_ws is
+-- STABLE, not IMMUTABLE (it can invoke arbitrary type output functions), and
+-- Postgres refuses a non-immutable generation expression — so this file as
+-- written fails with `42P17: generation expression is not immutable` and cannot
+-- have produced the live columns. Production was built with the equivalent
+-- immutable form, `COALESCE(col,'') || ' ' || …`, presumably hand-edited in the
+-- SQL editor at the time and never backported here. Verified against
+-- pg_get_expr on 2026-07-31 (PR #3481); note the same IMMUTABLE constraint is
+-- already called out for unaccent() twenty lines below.
+--
+-- Read the live definition before touching these columns — never this file:
+--   select a.attname, pg_get_expr(d.adbin, d.adrelid)
+--   from pg_attrdef d join pg_attribute a
+--     on a.attrelid = d.adrelid and a.attnum = d.adnum
+--   where d.adrelid = 'bph_works'::regclass;
+--
+-- `search_norm` in particular has since been widened to every public field;
+-- scripts/migration/expand-bph-search-norm.sql is its current definition and
+-- supersedes the one here.
+--
 -- Goal: searching "Boehme" finds "Böhme", "Goerlitz" finds "Görlitz", "Mueller"
 -- finds "Müller". Postgres `unaccent` handles the accent stripping; on top we
 -- collapse the standard German digraphs so the convention "ö ↔ oe" matches

--- a/src/generated/blog-revisions.json
+++ b/src/generated/blog-revisions.json
@@ -293,6 +293,12 @@
     "revised": "2026-07-16T01:06:36+02:00",
     "revisions": 4
   },
+  "reciting-not-reading": {
+    "path": "src/app/blog/reciting-not-reading/page.tsx",
+    "published": "2026-07-30T15:35:23+02:00",
+    "revised": "2026-07-30T15:35:23+02:00",
+    "revisions": 1
+  },
   "rithmomachia": {
     "path": "src/app/blog/rithmomachia/page.tsx",
     "published": "2026-03-02T11:34:13+04:00",


### PR DESCRIPTION
Housekeeping follow-up to #3472 / #3481. **No behaviour change** — one migration comment, one CLAUDE.md section, one regenerated artifact.

## 1. A migration file that cannot have produced the schema it claims

`scripts/migration/add-bph-diacritic-normalization.sql` defines the `bph_works` generated columns using `concat_ws()`. `concat_ws` is **STABLE**, not IMMUTABLE (it can invoke arbitrary type output functions), and Postgres refuses a non-immutable generation expression — so that file fails with `42P17` and **cannot** have created the columns that are live today. Production uses the equivalent immutable form, `COALESCE(col,'') || ' ' || …`, evidently hand-edited in the SQL editor at the time and never backported.

That drift cost real time in #3481: I copied the recipe from the file, and the migration failed. Nothing detects this, because migration files are essentially never re-run.

The file now carries a warning at the top pointing at `pg_get_expr` as the source of truth, and at `expand-bph-search-norm.sql` as `search_norm`'s current definition. Worth noting the file *already* called out the same IMMUTABLE constraint for `unaccent()` twenty lines below the new warning — the trap is easy to walk into twice, which is exactly why it's worth a comment rather than a memory note.

## 2. Three invariants in CLAUDE.md

Placed next to the existing "Search filters must be enforced in every lane" section, since they're the same surface:

- **A searchable field is a readable field.** Being able to search a column is a way of reading it — you can probe for a phrase one query at a time, and a hit is itself the disclosure. So the public search columns (`search_norm`, `search_tsv`, successors) must never index `internal_remarks`, `exhibition_history`, `price`, `acquisition_source`/`_date`, workflow flags, or `modified_by_*` (personal data). The per-field exclusion list lives in the migration; this points at it rather than duplicating it.
- **The inverse failure is equally real.** `search_norm` covered 20 of ~40 populated columns, so searching a shelf location, a donor name, a USTC number or a phrase from the remarks returned nothing — indistinguishable from "we don't hold it". It took a librarian saying so in person to surface it. New column a human will search by → add it to the search column in the same PR, or state why not.
- **Generated search columns can't be altered in place.** Drop + recreate also drops their indexes (rebuild `idx_bph_search_norm_trgm` or every query becomes a seq scan over ~30K rows), so wrap it in a transaction — that is what made the failed first attempt in #3481 harmless.

These are two failure directions of one decision — what goes in the search column — which is why they're written as a pair rather than as a single "don't leak" rule.

## 3. `src/generated/blog-revisions.json`

Regenerated by `deploy-prod.sh` during the #3481 production deploy; it picked up the new `reciting-not-reading` post. Committed so the working tree stops showing dirty. Derived from git history and regenerated on every deploy, so this is bookkeeping, not content.

## Verification

Unit suite green (1,010 tests). No source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)