### PR TITLE
fix(analytics): record the caller's IP, not Cloudflare's

### DIFF
--- a/scripts/workers/traffic-anomaly-alert.mjs
+++ b/scripts/workers/traffic-anomaly-alert.mjs
@@ -89,6 +89,52 @@ export const EXPECTED_HOSTS = new Set([
 // that is supposed to be working is not.
 export const SHOULD_BE_BLOCKED = [{ label: 'AS132203 Tencent Cloud (43.172.0.0/15)', re: /^43\.17[23]\./ }];
 
+// Cloudflare's published IPv4 egress ranges. Present because the concentration
+// check below is only meaningful if the stored address belongs to the CALLER.
+// Until the cf-connecting-ip fix, the analytics write paths read
+// `x-forwarded-for` — which Vercel sets to whatever connected to Vercel, i.e.
+// Cloudflare — so every front-door request was recorded against an edge node.
+// The check then flagged 14 "networks each reading >2,000 pages" that were all
+// Cloudflare, and told the reader to add them to blocked-networks.ts. Following
+// that advice would have taken the site down. An alarm whose remediation is
+// self-harm is worse than no alarm, which is the whole point of this file.
+// Source: https://www.cloudflare.com/ips-v4
+export const CDN_EGRESS_CIDRS = [
+  '173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22',
+  '141.101.64.0/18', '108.162.192.0/18', '190.93.240.0/20', '188.114.96.0/20',
+  '197.234.240.0/22', '198.41.128.0/17', '162.158.0.0/15', '104.16.0.0/13',
+  '104.24.0.0/14', '172.64.0.0/13', '131.0.72.0/22',
+];
+
+function ipv4ToInt(ip) {
+  const parts = String(ip).split('.');
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const p of parts) {
+    const o = Number(p);
+    if (!Number.isInteger(o) || o < 0 || o > 255) return null;
+    n = n * 256 + o;
+  }
+  return n;
+}
+
+const CDN_RANGES = CDN_EGRESS_CIDRS.map((cidr) => {
+  const [base, bits] = cidr.split('/');
+  const size = 2 ** (32 - Number(bits));
+  const start = ipv4ToInt(base);
+  return { start, end: start + size - 1 };
+});
+
+/**
+ * Is this address a CDN edge node rather than a caller? Anonymized IPs (last
+ * octet zeroed) still fall inside their own /24, so truncation is harmless.
+ */
+export function isCdnEgress(ip) {
+  const n = ipv4ToInt(ip);
+  if (n === null) return false;
+  return CDN_RANGES.some((r) => n >= r.start && n <= r.end);
+}
+
 /** A hostname serving reader traffic that we did not expect. */
 export function isUnexpectedHost(host) {
   return Boolean(host) && !EXPECTED_HOSTS.has(host);
@@ -134,13 +180,31 @@ async function run() {
     { $limit: 20 },
   ], { allowDiskUse: true }).toArray();
 
-  if (heavy.length) {
-    const worst = heavy[0];
-    const sum = heavy.reduce((s, h) => s + h.n, 0);
+  // A CDN edge node is not an actor. Split before alerting: a heavy hitter that
+  // is really Cloudflare says the WRITE PATH is broken, not that a fleet is
+  // reading — and those two findings need opposite responses.
+  const heavyReal = heavy.filter((h) => !isCdnEgress(h._id));
+  const heavyCdn = heavy.filter((h) => isCdnEgress(h._id));
+
+  if (heavyReal.length) {
+    const worst = heavyReal[0];
+    const sum = heavyReal.reduce((s, h) => s + h.n, 0);
     alerts.push({
       level: 'critical',
       check: 'traffic_concentration',
-      message: `${heavy.length} network(s) each read >${CONCENTRATION_THRESHOLD} pages in ${HOURS}h while classified HUMAN — ${sum.toLocaleString()} events total. Worst: ${worst._id} with ${worst.n.toLocaleString()} reads across ${worst.books.toLocaleString()} books via ${(worst.hosts || []).join(',') || '?'}. A person does not read at this rate; a UA-based classifier cannot see a distributed fleet. Confirm with: whois -h whois.cymru.com " -v ${String(worst._id).replace(/0$/, '1')}" — then consider a network block in src/lib/blocked-networks.ts. Networks: ${heavy.slice(0, 8).map(h => `${h._id}(${h.n})`).join(' ')}`,
+      message: `${heavyReal.length} network(s) each read >${CONCENTRATION_THRESHOLD} pages in ${HOURS}h while classified HUMAN — ${sum.toLocaleString()} events total. Worst: ${worst._id} with ${worst.n.toLocaleString()} reads across ${worst.books.toLocaleString()} books via ${(worst.hosts || []).join(',') || '?'}. A person does not read at this rate; a UA-based classifier cannot see a distributed fleet. Confirm with: whois -h whois.cymru.com " -v ${String(worst._id).replace(/0$/, '1')}" — then consider a network block in src/lib/blocked-networks.ts. Networks: ${heavyReal.slice(0, 8).map(h => `${h._id}(${h.n})`).join(' ')}`,
+    });
+  }
+
+  // The instrument, not the readers. Fires when the top talkers are the CDN,
+  // which means the caller's address was never written down and concentration
+  // cannot be measured at all for front-door traffic.
+  if (heavyCdn.length && !heavyReal.length) {
+    const sum = heavyCdn.reduce((s, h) => s + h.n, 0);
+    alerts.push({
+      level: 'critical',
+      check: 'client_ip_not_recorded',
+      message: `${heavyCdn.length} of the top-reading "networks" in ${HOURS}h are CLOUDFLARE EDGE NODES (${heavyCdn.slice(0, 4).map(h => `${h._id}(${h.n})`).join(' ')}, ${sum.toLocaleString()} events). That is our own CDN, not a caller — do NOT block these. It means an analytics write path recorded x-forwarded-for (which Vercel sets to the Cloudflare edge) instead of cf-connecting-ip, so no front-door traffic can be attributed to a network and the concentration check above is blind. Fix at the source: clientIpFromHeaders() in src/lib/analytics-ingest.ts must read cf-connecting-ip first, and every analytics writer must use it (src/app/api/track/route.ts was the second one). Compare with src/lib/rate-limit.ts, which has always had the order right.`,
     });
   }
 

--- a/src/app/api/[tenant]/analytics/loading/route.ts
+++ b/src/app/api/[tenant]/analytics/loading/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { LoadingMetric } from '@/lib/api-client';
 import { withAuth } from '@/lib/auth-helpers';
-import { anonymizeIp } from '@/lib/anonymize-ip';
+import { clientIpFromHeaders } from '@/lib/analytics-ingest';
 import { resolveTenantId } from '@/lib/tenant-context';
 
 interface AnalyticsPayload {
@@ -38,7 +38,7 @@ export async function POST(
       tenantId,
       received_at: new Date(),
       user_agent: request.headers.get('user-agent') || 'unknown',
-      ip: anonymizeIp(request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown'),
+      ip: clientIpFromHeaders(request.headers),
     }));
 
     const dbWrite = (async () => {

--- a/src/app/api/analytics/broken-image/route.ts
+++ b/src/app/api/analytics/broken-image/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { clientIpFromHeaders } from '@/lib/analytics-ingest';
 
 /**
  * Log broken-image reports from the client.
@@ -29,7 +30,7 @@ export async function POST(request: NextRequest) {
 
     // Cap at 20 per report to prevent abuse
     const capped = urls.slice(0, 20);
-    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const ip = clientIpFromHeaders(request.headers);
 
     const dbWork = (async () => {
       const db = await getDb();

--- a/src/app/api/analytics/loading/route.ts
+++ b/src/app/api/analytics/loading/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { LoadingMetric } from '@/lib/api-client';
 import { withAuth } from '@/lib/auth-helpers';
-import { anonymizeIp } from '@/lib/anonymize-ip';
+import { clientIpFromHeaders } from '@/lib/analytics-ingest';
 
 interface AnalyticsPayload {
   metrics: LoadingMetric[];
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
       ...metric,
       received_at: new Date(),
       user_agent: request.headers.get('user-agent') || 'unknown',
-      ip: anonymizeIp(request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown'),
+      ip: clientIpFromHeaders(request.headers),
     }));
 
     const dbWrite = (async () => {

--- a/src/app/api/analytics/not-found/route.ts
+++ b/src/app/api/analytics/not-found/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { clientIpFromHeaders } from '@/lib/analytics-ingest';
 
 /**
  * Auto-log 404 page hits.
@@ -17,7 +18,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true });
     }
 
-    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const ip = clientIpFromHeaders(request.headers);
     const ua = request.headers.get('user-agent') || '';
 
     const dbWork = (async () => {

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse, after } from 'next/server';
 import { getDb } from '@/lib/mongodb';
-import { anonymizeIp } from '@/lib/anonymize-ip';
+import { clientIpFromHeaders } from '@/lib/analytics-ingest';
 import { classifyTraffic, type TrafficClass } from '@/lib/traffic-classification';
 
 const SITE_HOST = 'sourcelibrary.org';
@@ -122,8 +122,11 @@ export async function POST(request: NextRequest) {
     const cfVerifiedBot = request.headers.get('cf-verified-bot') === 'true';
     const cfThreat = parseInt(request.headers.get('cf-threat-score') || '', 10);
 
-    const rawIp = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-    const ip = anonymizeIp(rawIp);
+    // Shared with /api/analytics/track so both pageview and event streams key
+    // on the same address. Reads cf-connecting-ip first — see the note on
+    // clientIpFromHeaders for why the previous header order recorded Cloudflare
+    // edge nodes instead of readers.
+    const ip = clientIpFromHeaders(request.headers);
 
     // Spoofed-UA scrapers that pass the UA check are caught by the per-IP cap.
     const rateCapped = exceedsIpCap(ip, effectiveUA || '');

--- a/src/app/api/views/route.ts
+++ b/src/app/api/views/route.ts
@@ -17,7 +17,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
-import { anonymizeIp } from '@/lib/anonymize-ip';
+import { clientIpFromHeaders } from '@/lib/analytics-ingest';
 import { classifyTraffic } from '@/lib/traffic-classification';
 
 const VALID_TYPES = ['image', 'page', 'book'] as const;
@@ -83,8 +83,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: true });
     }
 
-    const rawIp = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-    const ip = anonymizeIp(rawIp);
+    // Must be the CALLER, not the CDN: this address dedupes view increments,
+    // so a Cloudflare edge IP collapses every reader behind that node into one
+    // and silently suppresses real views. read_count also orders the paid
+    // re-OCR queues, so a wrong denominator here spends money in the wrong place.
+    const ip = clientIpFromHeaders(request.headers);
     if (isDuplicate(ip, `${target_type}:${target_id}`)) {
       return NextResponse.json({ success: true });
     }

--- a/src/lib/analytics-ingest.ts
+++ b/src/lib/analytics-ingest.ts
@@ -41,9 +41,32 @@ export function clientIp(request: NextRequest): string {
   return clientIpFromHeaders(request.headers);
 }
 
-/** Anonymized client IP from a bare Headers bag. */
+/**
+ * Anonymized client IP from a bare Headers bag.
+ *
+ * `cf-connecting-ip` FIRST, and this order is load-bearing. On the canonical
+ * host the chain is client → Cloudflare → Vercel, and Vercel rewrites
+ * `x-forwarded-for` with the address that connected to *it* — Cloudflare's
+ * edge node. Reading `x-forwarded-for` first therefore recorded a CDN address
+ * for every request that came through the front door: `analytics_pageviews`
+ * and `analytics_events` were full of 172.64.0.0/13, 104.16.0.0/13 and
+ * 162.158.0.0/15 rather than readers.
+ *
+ * The consequence was not cosmetic. Every IP-based defence downstream reads
+ * these fields, so a distributed fleet arriving via Cloudflare was invisible
+ * by construction — spread evenly across edge nodes, indistinguishable from
+ * organic traffic. The one fleet we ever caught (AS132203, nine weeks) was
+ * caught *because* it bypassed Cloudflare on an alias host, which is the only
+ * reason its real addresses were ever written down. The per-IP event cap below
+ * had the same blind spot: it was rate-limiting Cloudflare, not the caller.
+ *
+ * `src/lib/rate-limit.ts` has always had this order right; the analytics write
+ * paths did not. Keep the two in agreement.
+ */
 export function clientIpFromHeaders(headers: Headers): string {
-  const raw = headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+  const raw = headers.get('cf-connecting-ip')?.trim()
+    || headers.get('true-client-ip')?.trim()
+    || headers.get('x-forwarded-for')?.split(',')[0]?.trim()
     || headers.get('x-real-ip')
     || 'unknown';
   return anonymizeIp(raw);

--- a/tests/unit/analytics-client-ip.test.ts
+++ b/tests/unit/analytics-client-ip.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The analytics write paths must record the CALLER's address, not Cloudflare's.
+ *
+ * On the canonical host the chain is client → Cloudflare → Vercel, and Vercel
+ * rewrites `x-forwarded-for` with the address that connected to it — a
+ * Cloudflare edge node. `clientIpFromHeaders()` read `x-forwarded-for` first,
+ * so `analytics_pageviews` and `analytics_events` recorded 172.64.0.0/13,
+ * 104.16.0.0/13 and 162.158.0.0/15 for every front-door request.
+ *
+ * That made a distributed fleet arriving through Cloudflare invisible by
+ * construction: its reads spread evenly across edge nodes and looked organic.
+ * The one fleet ever caught (AS132203, nine weeks, 17,357 books) was caught
+ * only because it bypassed Cloudflare on an alias host, which is the sole
+ * reason its real addresses were written down at all.
+ *
+ * These tests exercise the functions rather than asserting on source text —
+ * with one deliberate exception at the bottom, where deletion IS the failure
+ * mode (see the comment there).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+import { clientIpFromHeaders } from '@/lib/analytics-ingest';
+import { isCdnEgress, CDN_EGRESS_CIDRS } from '../../scripts/workers/traffic-anomaly-alert.mjs';
+
+const repoRoot = path.resolve(__dirname, '../..');
+
+describe('clientIpFromHeaders', () => {
+  it('prefers cf-connecting-ip over the Vercel-rewritten x-forwarded-for', () => {
+    // The exact shape of a real front-door request: Cloudflare reports the
+    // caller, Vercel reports Cloudflare. Before the fix this returned the
+    // edge node — the negative control for this whole change.
+    const headers = new Headers({
+      'cf-connecting-ip': '203.0.113.44',
+      'x-forwarded-for': '172.70.248.13',
+    });
+    expect(clientIpFromHeaders(headers)).toBe('203.0.113.0');
+  });
+
+  it('anonymizes to a /24 whichever header it came from', () => {
+    expect(clientIpFromHeaders(new Headers({ 'cf-connecting-ip': '198.51.100.222' })))
+      .toBe('198.51.100.0');
+    expect(clientIpFromHeaders(new Headers({ 'x-forwarded-for': '198.51.100.222' })))
+      .toBe('198.51.100.0');
+  });
+
+  it('falls back through true-client-ip, x-forwarded-for, x-real-ip', () => {
+    expect(clientIpFromHeaders(new Headers({ 'true-client-ip': '203.0.113.7' })))
+      .toBe('203.0.113.0');
+    expect(clientIpFromHeaders(new Headers({ 'x-forwarded-for': '203.0.113.7, 172.70.1.1' })))
+      .toBe('203.0.113.0');
+    expect(clientIpFromHeaders(new Headers({ 'x-real-ip': '203.0.113.7' })))
+      .toBe('203.0.113.0');
+    expect(clientIpFromHeaders(new Headers())).toBe('unknown');
+  });
+
+  it('reports unknown rather than a CDN address when no client header is present', () => {
+    // A request that genuinely carries only the Vercel hop is unattributable.
+    // "unknown" is the honest answer; a Cloudflare /24 is a wrong one that
+    // would then be counted as a heavy reader.
+    const ip = clientIpFromHeaders(new Headers({ 'x-forwarded-for': '172.70.248.13' }));
+    expect(isCdnEgress(ip)).toBe(true); // still CDN — which is why the alarm below exists
+  });
+});
+
+describe('isCdnEgress', () => {
+  it('recognizes every edge range observed in production analytics', () => {
+    // These are the addresses the concentration check flagged as "networks
+    // each reading >2,000 pages" and told the operator to block.
+    for (const ip of [
+      '172.70.248.0', '172.70.242.0', '172.70.240.0', '172.70.250.0',
+      '172.71.148.0', '172.71.144.0', '172.71.164.0', '172.68.193.0',
+      '172.69.150.0', '104.22.123.0', '104.23.239.0', '162.158.110.0',
+    ]) {
+      expect(isCdnEgress(ip), `${ip} should be recognized as CDN egress`).toBe(true);
+    }
+  });
+
+  it('does not swallow real client networks', () => {
+    // AS132203 above all: if this ever reads as CDN the fleet check goes quiet.
+    for (const ip of ['43.172.0.0', '43.173.255.0', '203.0.113.0', '8.8.8.0', '198.51.100.0']) {
+      expect(isCdnEgress(ip), `${ip} must not be treated as CDN egress`).toBe(false);
+    }
+  });
+
+  it('handles anonymized and malformed input without throwing', () => {
+    expect(isCdnEgress('unknown')).toBe(false);
+    expect(isCdnEgress('')).toBe(false);
+    expect(isCdnEgress('2606:4700::0')).toBe(false); // IPv6 unsupported, must not crash
+    expect(isCdnEgress('999.1.1.1')).toBe(false);
+  });
+
+  it('keeps the published range list non-empty and well-formed', () => {
+    expect(CDN_EGRESS_CIDRS.length).toBeGreaterThan(10);
+    for (const cidr of CDN_EGRESS_CIDRS) {
+      expect(cidr).toMatch(/^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/);
+    }
+  });
+});
+
+describe('no analytics writer reads x-forwarded-for directly', () => {
+  /**
+   * An ABSENCE invariant, which is the one case where a source-shape assertion
+   * is a real guard (cf. tests/unit/soft-404-loading-guard.test.ts): the way
+   * this bug returns is a NEW analytics route reaching for `x-forwarded-for`
+   * on its own instead of calling the shared helper. Nothing about behaviour
+   * can catch a writer that does not exist yet.
+   *
+   * `src/lib/rate-limit.ts` and `src/lib/bot-attribution.ts` are deliberately
+   * out of scope — rate-limit already reads cf-connecting-ip first, and
+   * bot-attribution serves the edge-log path, not the analytics collections.
+   */
+  const analyticsRoutes = [
+    'src/app/api/track/route.ts',
+    'src/app/api/analytics/track/route.ts',
+    'src/app/api/analytics/event/route.ts',
+    'src/app/api/analytics/loading/route.ts',
+    'src/app/api/analytics/broken-image/route.ts',
+    'src/app/api/analytics/not-found/route.ts',
+    'src/app/api/[tenant]/analytics/loading/route.ts',
+  ].filter((p) => {
+    try { readFileSync(path.join(repoRoot, p)); return true; } catch { return false; }
+  });
+
+  it('finds every analytics write route it means to guard', () => {
+    // If a rename drops one silently the guard shrinks to nothing and still
+    // passes — so pin the count, not just "more than zero".
+    expect(analyticsRoutes.length).toBe(7);
+  });
+
+  it.each(analyticsRoutes)('%s does not read x-forwarded-for itself', (rel) => {
+    const src = readFileSync(path.join(repoRoot, rel), 'utf8');
+    expect(src).not.toMatch(/x-forwarded-for/i);
+  });
+
+  // Deliberately NOT asserted here: "cf-connecting-ip appears before
+  // x-forwarded-for in analytics-ingest.ts". That was written, and it passed
+  // with the header order reverted — the doc comment above the function
+  // mentions cf-connecting-ip first, so the assertion was measuring prose.
+  // The behavioural test at the top of this file is the real guard; it fails
+  // on the reverted order, which was verified by running it that way.
+
+  it('catches a NEW analytics route added later that reads the header itself', () => {
+    // Match on the repo-RELATIVE path. Matching the absolute path silently
+    // matched every route in the tree, because the worktree these run in is
+    // itself named `.claude/worktrees/fix+analytics-client-ip` — a check that
+    // always fires is as useless as one that never can.
+    const apiRoot = path.join(repoRoot, 'src/app/api');
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name === 'route.ts') {
+          const rel = path.relative(repoRoot, full);
+          if (!/(^|\/)(analytics|track)(\/|$)/.test(rel)) continue;
+          if (/x-forwarded-for/i.test(readFileSync(full, 'utf8'))) offenders.push(rel);
+        }
+      }
+    };
+    walk(apiRoot);
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The bug

The analytics write paths read `x-forwarded-for` first. On the canonical host the chain is client → Cloudflare → Vercel, and **Vercel rewrites that header with the address that connected to it** — a Cloudflare edge node. So every front-door request was recorded against the CDN. `analytics_pageviews` and `analytics_events` are full of `172.64.0.0/13`, `104.16.0.0/13` and `162.158.0.0/15`.

This is not cosmetic. Every IP-based check downstream reads those fields, so **a distributed fleet arriving through Cloudflare is invisible by construction** — spread evenly across edge nodes, indistinguishable from organic traffic. The one fleet we ever caught (AS132203, nine weeks, 17,357 books) was caught only because it *bypassed* Cloudflare on an alias host, which is the sole reason its real addresses were ever written down.

`src/lib/rate-limit.ts` has always read `cf-connecting-ip` first. The analytics writers did not.

## What changed

- **`clientIpFromHeaders()`** reads `cf-connecting-ip` → `true-client-ip` → `x-forwarded-for` → `x-real-ip`.
- **Every analytics writer routed through it.** `/api/analytics/{track,event}` already were, via `classifyRequest()`. `/api/track`, both `analytics/loading` routes, `analytics/broken-image` and `analytics/not-found` read the header themselves and now don't — fixing only the helper is how the R2-key bug shipped twice in one week.
- **`/api/views`** as well: it dedupes view increments on this address, so a CDN IP collapsed every reader behind one edge node into a single view. `books.read_count` orders the paid re-OCR queues, so a wrong denominator there spends money in the wrong place.
- **`traffic-anomaly-alert.mjs`** learns Cloudflare's published egress ranges. Its concentration check was flagging 14–15 "networks each reading >2,000 pages" that were **all our own CDN**, with remediation text telling the operator to add them to `blocked-networks.ts` — following that advice would have taken the site down. They now raise `client_ip_not_recorded`, which reports that the instrument is broken rather than inventing a fleet, and clears itself once this deploys and real addresses arrive.

## Verification

- Full unit suite green (1145 tests, 92 files); `npx tsc --noEmit` clean.
- **Negative control run:** reverting the header order fails `prefers cf-connecting-ip over the Vercel-rewritten x-forwarded-for`. A source-order assertion was written first and **dropped** — it passed on the reverted code because it was matching the doc comment above the function, not the code.
- The detector was run against production before and after. Before: `traffic_concentration` CRITICAL naming Cloudflare IPs. After: `client_ip_not_recorded` CRITICAL naming the defect.
- One test bug worth recording: the directory walk originally matched on the **absolute** path, which contains `.claude/worktrees/fix+analytics-client-ip` — so it matched every route in the tree and always fired. It matches the repo-relative path now.

## Out of scope (deliberate)

Eleven other routes read `x-forwarded-for` directly and have the same blind spot, but they are abuse/rate-limit and submission paths rather than analytics collections, and each needs its own thought about what a shared address means for its limiter: `annotations/[id]/upvote`, `authority/author/search`, `beta/subscribe`, `collection-proposals`, `dataset/v1/pages`, `errors`, `feedback`, `search/click`, `share-findings`, `volunteer`. Worth a follow-up; not bundled here.

`analytics/not-found` and `analytics/broken-image` previously stored the **full** IP and now store a /24, matching every other analytics writer. That is a deliberate narrowing, not an accident.

## What this does NOT do

It does not answer whether the 13,055 distinct books read in the last 48 hours are readers or a walker. It makes that answerable — roughly a day after deploy, once the concentration check is reading real client networks for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)