### PR TITLE
fix(analytics): make search logs attributable to a tenant

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -851,6 +851,11 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
     // Log search query (fire-and-forget) — see src/lib/search-event-log.ts
     logSearchEvent({
       request, db, query, resultsCount: results.length, source: 'global',
+      // `tenantId` is already resolved above for scoping the query itself.
+      // Omitting it here (as the first pass did) left every "global" search
+      // unattributable even though the value was sitting in scope — the same
+      // blind spot that made the pre-existing rows unsplittable.
+      tenantId,
       filters: { language, category, year, bookId, library, semantic_count: semanticDocs.length },
     });
 

--- a/src/lib/search-log.ts
+++ b/src/lib/search-log.ts
@@ -18,6 +18,8 @@ import type { NextRequest } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getClientIp } from '@/lib/rate-limit';
 import type { ApiIdentity } from '@/lib/api-auth';
+import { getTenantContextFromRequest } from '@/lib/tenant-context';
+import { resolveHostFromHeaders } from '@/lib/analytics-ingest';
 
 const COLLECTION = 'search_queries';
 const MAX_QUERY_LEN = 500;
@@ -91,6 +93,16 @@ async function writeEntry(input: LogSearchQueryInput) {
     else if (Array.isArray(v)) filters[k] = v.slice(0, 10).map(x => String(x).slice(0, 100));
   }
 
+  // Tenant + host are derived here rather than threaded through every caller.
+  // This log had NEITHER field, which made its four months of rows structurally
+  // unattributable: a partner subdomain's `/search?q=…` is rewritten by
+  // proxy.ts to `/embed/<tenant>/search`, which re-exports the main SearchPage
+  // and therefore lands in `/api/search` — indistinguishable from a main-site
+  // search. A usage report consequently labelled the whole table "main site
+  // only", which it never was. Deriving inside the writer means a new caller
+  // cannot forget it (see src/lib/search-event-log.ts for the sibling rule).
+  const tenant = getTenantContextFromRequest(input.request.headers);
+
   await db.collection(COLLECTION).insertOne({
     ts: new Date(),
     route: input.route,
@@ -101,6 +113,9 @@ async function writeEntry(input: LogSearchQueryInput) {
     identity_kind: input.identity?.kind || 'anon',
     user_id: input.identity?.userId || null,
     api_key_id: input.identity?.apiKeyId || null,
+    tenant_id: tenant?.id || null,
+    tenant_slug: tenant?.slug || null,
+    host: resolveHostFromHeaders(input.request.headers),
     ip_hash: hashIp(ip),
     user_agent: (input.request.headers.get('user-agent') || '').slice(0, 200),
     filters,

--- a/tests/unit/search-event-instrumentation.test.ts
+++ b/tests/unit/search-event-instrumentation.test.ts
@@ -164,6 +164,48 @@ describe('search instrumentation coverage', () => {
     expect(offenders).toEqual([]);
   });
 
+  it('every tenant-aware search route passes its tenant to the logger', () => {
+    // A route that resolves a tenant in order to *scope* its query, but does
+    // not pass it to the logger, produces rows that cannot be attributed later
+    // — which is exactly how `search_queries` ended up with four months of
+    // unsplittable rows, and how `/api/search` shipped in the first pass of
+    // #3484. If a route knows its tenant, the log must know it too.
+    // Comments are stripped before matching. The first version of this test
+    // did not strip them, so the explanatory comment sitting directly above
+    // `tenantId,` satisfied the assertion and the test passed with the actual
+    // argument deleted — a check that could not fail.
+    const stripComments = (s: string) => s.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+    for (const route of SEARCH_ROUTES) {
+      const src = read(route);
+      const resolvesTenant = /getTenantContextFromRequest|resolveTenantId|const tenantId/.test(src);
+      if (!resolvesTenant) continue;
+      const call = src.slice(src.indexOf('logSearchEvent({'));
+      const callBody = stripComments(call.slice(0, call.indexOf('});') + 3));
+      expect(callBody, `${route} resolves a tenant but does not pass it to logSearchEvent`)
+        .toMatch(/\btenantId\b/);
+    }
+  });
+
+  it('the semantic lane logs latency but does NOT emit a second search_query event', () => {
+    // /api/search/semantic is fired by the same page-load as /api/search for a
+    // single user query. Adding a search_query event here would double-count
+    // every search. It logs to `search_queries` (latency/lane telemetry) only —
+    // which is why it is deliberately absent from SEARCH_ROUTES above.
+    const src = read('src/app/api/search/semantic/route.ts');
+    expect(src).toContain('logSearchQuery(');
+    expect(src).not.toContain('logSearchEvent(');
+  });
+
+  it('search_queries rows carry tenant and host so the log can be split later', () => {
+    const src = read('src/lib/search-log.ts');
+    // Derived inside the writer, not threaded through callers — a new caller
+    // must not be able to omit them.
+    expect(src).toContain('tenant_id:');
+    expect(src).toContain('host:');
+    expect(src).toContain('getTenantContextFromRequest');
+  });
+
   it('the BPH catalogue route only logs real searches, not catalogue browsing', () => {
     const src = read('src/app/api/catalog/bph/route.ts');
     // Guards the numerator: without this, every page of catalogue browsing and


### PR DESCRIPTION
Follow-up to #3484, prompted by a question that PR could not answer: **"are those search terms from Source Library, or from BPH?"**

For `search_queries` the honest answer was **unknowable** — and I had labelled a 441-term list "main site only" anyway.

## Why it was unknowable

`search_queries` stored **neither host nor tenant**. And a partner subdomain's `/search?q=…` is rewritten by `proxy.ts` to `/embed/<tenant>/search`, which re-exports the main site's `SearchPage` → hits `/api/search` + `/api/search/semantic` → lands in that same log, indistinguishable from a main-site search. That route's own source comment cites `?q=boehme`, `?q=rosicrucian`, `?q=Hartmann` arriving exactly that way.

## Changes

- **`src/lib/search-log.ts`** records `tenant_id`, `tenant_slug`, `host` — derived **inside the writer** from request headers rather than threaded through callers, so a new caller cannot omit them.
- **`/api/search`** passes `tenantId` to `logSearchEvent`. It resolved that value at line 163 to scope its own query and then didn't log it: #3484 left every `global` search unattributable with the answer sitting in scope.

## On the guards

The tenant guard's **first version passed with the argument deleted** — the explanatory comment sitting above `tenantId,` satisfied the regex. It now strips comments before matching, and was re-verified against negative controls:

| Regression | Result |
|---|---|
| `tenantId` arg removed from `/api/search` | 1 test fails |
| `tenant_id` dropped from `search-log.ts` | 1 test fails |
| restored | 17/17 pass |

That is the second time in this line of work a source-shape assertion matched incidental text. Worth recording as the standing hazard of the form.

A second guard pins that `/api/search/semantic` keeps logging latency but does **not** emit a `search_query` event — it fires on the same page-load as `/api/search` for one user query, so "fixing" its apparent coverage gap would double-count every search on the site.

## Scope

**Out:** no backfill. Historical rows stay unattributable rather than guessed at — the fields were never captured.

`npx tsc --noEmit` clean · **1131 tests pass** (91 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)