### PR TITLE
feat(bph-catalog): build and drill the restore path; harden the backup

### DIFF
--- a/.claude/docs/bph-catalogue-disaster-recovery.md
+++ b/.claude/docs/bph-catalogue-disaster-recovery.md
@@ -1,0 +1,107 @@
+# BPH catalogue — protection and disaster recovery
+
+`bph_works` is the **system of record** for the Bibliotheca Philosophica Hermetica.
+Memorix is no longer the upstream (that sync ended 2026-05-25, see
+`bph-memorix-final-sync.mjs`), and BPH librarians now edit it directly on Source
+Library. So this table is not a cache of something else — if it is lost, the
+catalogue is lost. It holds 29,879 records.
+
+Verified end-to-end 2026-08-01, including a full restore drill.
+
+## The four layers
+
+| # | Layer | Covers | Where |
+|---|---|---|---|
+| 1 | `bph_works_revisions` | per-field logical rollback (from→to, editor, timestamp) | Supabase, append-only |
+| 2 | Supabase managed backups | whole-database physical restore | Supabase, daily, 8 retained |
+| 3 | Nightly JSON export | table-level restore, independent of Supabase | Hetzner `/root/backups/bph-catalog-*`, 04:00 daily + weekly kept |
+| 4 | restic → object storage | offsite, encrypted, versioned | Hetzner Object Storage nbg1, 05:00 daily, 7d/8w/12m |
+
+Layers 3 and 4 matter most: they are the only ones that survive losing the Supabase
+account itself. Layer 4 sweeps `/root/backups` wholesale — note its cron entry and
+snapshot tag both say `mongodump`, so **if anyone ever narrows that path, the BPH
+catalogue silently falls out of offsite backup.** It is included by breadth, not by
+design.
+
+**PITR is OFF** (`pitr_enabled: false`). Supabase's physical backups are daily
+snapshots, so the exposure on a bad write is up to ~24h, not seconds. Enabling PITR
+is a paid add-on and a deliberate cost decision — not enabled unilaterally.
+
+## Restoring
+
+`scripts/maintenance/restore-bph-catalog.mjs`. Dry-run by default; `--apply` to write;
+restoring over the live table additionally demands
+`--i-understand-this-overwrites-live-data`.
+
+```bash
+# 1. Fetch a snapshot (latest, or a dated weekly)
+scp -r root@46.224.122.120:/root/backups/bph-catalog-latest /tmp/
+#    older: /root/backups/bph-catalog-weekly/2026-07-26
+#    offsite: restic -r <repo> restore latest --target /tmp/restic-out
+
+# 2. Rehearse — reads the snapshot, writes nothing
+node scripts/maintenance/restore-bph-catalog.mjs --dir /tmp/bph-catalog-latest
+
+# 3. Restore into a scratch table and diff before committing to anything
+node scripts/maintenance/restore-bph-catalog.mjs --dir /tmp/bph-catalog-latest \
+  --table bph_works --into bph_works_restore_drill --apply
+
+# 4. Only then, if it is genuinely the right call:
+node scripts/maintenance/restore-bph-catalog.mjs --dir /tmp/bph-catalog-latest \
+  --table bph_works --apply --i-understand-this-overwrites-live-data
+```
+
+It upserts on `id` and **never deletes** — a row that is live but absent from the
+snapshot is reported, not removed, because "created after the backup" and "should not
+exist" are indistinguishable from inside the script.
+
+For a *logical* mistake (a bad sweep, a wrong bulk edit) prefer layer 1: replay the
+`from` values out of `bph_works_revisions` for the affected UBNs. That is surgical and
+loses no legitimate concurrent work. Reach for a full restore only for structural loss.
+
+## What the drill actually found
+
+A restore path that has never been run is a hypothesis. Running it on 2026-08-01
+against a scratch table surfaced three things, all now handled:
+
+1. **Eight generated columns** (`search_norm`, `title_norm`, `author_norm`,
+   `editor_norm`, `place_norm`, `printer_norm`, `publisher_norm`, `shelf_mark_norm`)
+   cannot be inserted into — Postgres rejects any INSERT naming them. A naive
+   "read the JSON and upsert it" loop dies on row one. They are dropped before
+   writing and the database recomputes them; verified all 29,879 restored rows had
+   `search_norm` rebuilt *identically to live*.
+2. **Schema discovery by sampling a row fails on an empty table** — which is exactly
+   the restore case. The first version of the script learned its column list by
+   reading one existing row, worked fine in rehearsal, and failed on the first real
+   drill. The column list is now static, with the write loop parsing Postgres's own
+   error to drop anything unexpected.
+3. **`CREATE TABLE … (LIKE … INCLUDING CONSTRAINTS)` does not copy the primary key** —
+   that needs `INCLUDING INDEXES` (or `INCLUDING ALL`). Without a PK there is nothing
+   for the upsert to conflict on and the restore cannot proceed. **If you ever
+   recreate `bph_works` from scratch, restore its indexes before restoring its rows.**
+
+Result: 29,879/29,879 rows restored in ~3m30s; a field-by-field comparison against
+live differed on exactly 7 rows, in `sl_book_id`/`sl_book_slug` only — written by the
+6-hourly `sync-bph-sl-book-ids` cron in the hours after the snapshot. Correct drift,
+not restore error.
+
+## Backup integrity
+
+`scripts/workers/backup-bph-catalog.sh` (04:00 daily, Hetzner cron):
+
+- Dumps to a **staging directory and swaps only on success.** It used to `rm -rf` the
+  latest snapshot *before* dumping, so a failure destroyed the last good local copy.
+- **Refuses to publish a collapsed snapshot** — under 1,000 rows, or a >10% drop
+  against the previous manifest. An export that "succeeds" with zero rows (revoked
+  key, silent API change) would otherwise overwrite the good copy with an empty one
+  and then propagate through the retention chain.
+- **Pushes to `ntfy.sh/sourcelibrary-uptime` on failure.** Previously it only wrote
+  `ERROR:` to a log file that nothing monitored, which is the failure mode described
+  in CLAUDE.md: an alarm nobody reads is not an instrument.
+
+## Re-drill periodically
+
+The point of a drill is that it decays. Re-run steps 1–3 above (scratch table, then
+drop it) after any schema change to `bph_works`, and at least a couple of times a
+year. It costs about five minutes and is the only thing that distinguishes a backup
+from a hope.

--- a/scripts/maintenance/restore-bph-catalog.mjs
+++ b/scripts/maintenance/restore-bph-catalog.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+/**
+ * Restore the BPH catalogue from a backup-bph-catalog.mjs snapshot.
+ *
+ * The missing half of the backup story. `backup-bph-catalog.mjs` has produced
+ * nightly gzipped JSON since May and its own docstring admitted the restore
+ * side was "not yet built" — which meant 30MB of snapshots nobody could put
+ * back without writing an upsert loop under pressure. A backup you have never
+ * restored is a hypothesis, not a backup.
+ *
+ * THE TRAP THIS EXISTS TO HANDLE: `bph_works` has eight GENERATED columns
+ * (search_norm, title_norm, author_norm, editor_norm, place_norm, printer_norm,
+ * publisher_norm, shelf_mark_norm). Postgres rejects any INSERT that names
+ * them, so the obvious "read the JSON, upsert it back" loop fails on row one.
+ * They are also pure functions of other columns, so dropping them loses
+ * nothing — the database recomputes them. PostgREST does not expose
+ * information_schema, so the list below is static; the write loop additionally
+ * parses Postgres's own error and drops any column it names, so a generated
+ * column added years from now degrades to a warning instead of a failed
+ * restore at the worst possible moment.
+ *
+ * SAFETY. Dry-run by default: it reads the snapshot, checks it against the
+ * live schema and reports what it would write, touching nothing. Writing
+ * requires --apply. Restoring over a live table additionally requires
+ * --i-understand-this-overwrites-live-data, because the sane emergency move is
+ * usually to restore into a scratch table first and diff.
+ *
+ * Usage:
+ *   # Rehearse (safe, no writes):
+ *   node scripts/maintenance/restore-bph-catalog.mjs --dir <backup-dir>
+ *
+ *   # Restore into a scratch table to inspect before committing to anything:
+ *   node scripts/maintenance/restore-bph-catalog.mjs --dir <d> --table bph_works \
+ *     --into bph_works_restore_drill --apply
+ *
+ *   # Real recovery, over the live table:
+ *   node scripts/maintenance/restore-bph-catalog.mjs --dir <d> --table bph_works \
+ *     --apply --i-understand-this-overwrites-live-data
+ *
+ * Upserts on the primary key (`id`), so it repairs a partially-damaged table
+ * without deleting rows that are fine. It never DELETEs: a row present live but
+ * absent from the snapshot is reported, never removed, because "created after
+ * the backup" and "should not exist" look identical from here and only a human
+ * can tell them apart.
+ *
+ * Backups live on the Hetzner box at /root/backups/bph-catalog-{latest,weekly/<date>}
+ * and are swept offsite nightly by restic (encrypted, 7 daily / 8 weekly / 12
+ * monthly). Fetch one with:
+ *   scp -r root@46.224.122.120:/root/backups/bph-catalog-latest /tmp/
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { gunzipSync } from 'node:zlib';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const { values: args } = parseArgs({
+  options: {
+    dir: { type: 'string' },
+    table: { type: 'string', default: 'bph_works' },
+    into: { type: 'string' },
+    apply: { type: 'boolean', default: false },
+    'i-understand-this-overwrites-live-data': { type: 'boolean', default: false },
+    'batch-size': { type: 'string', default: '500' },
+    limit: { type: 'string' },
+  },
+});
+
+const SOURCE_TABLE = args.table;
+const TARGET_TABLE = args.into || SOURCE_TABLE;
+const APPLY = args.apply;
+const OVERWRITE_OK = args['i-understand-this-overwrites-live-data'];
+const BATCH = parseInt(args['batch-size'], 10);
+const LIMIT = args.limit ? parseInt(args.limit, 10) : Infinity;
+
+if (!args.dir) {
+  console.error('Usage: node scripts/maintenance/restore-bph-catalog.mjs --dir <backup-dir> [--table T] [--into T2] [--apply]');
+  process.exit(1);
+}
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const chunks = (arr, n) => {
+  const out = [];
+  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
+  return out;
+};
+
+/**
+ * Columns `bph_works` will refuse on INSERT because Postgres computes them.
+ *
+ * Static by necessity: PostgREST exposes neither information_schema nor a
+ * column list for an EMPTY table, and an empty target is precisely the restore
+ * case (table dropped and recreated). An earlier version of this script learned
+ * the schema by reading one existing row, which worked in rehearsal and failed
+ * on the first real drill against an empty table — the one scenario it existed
+ * for. The write loop's adaptive retry is what actually keeps this honest;
+ * this list only saves it a round-trip.
+ */
+const KNOWN_GENERATED = new Set([
+  'search_norm', 'title_norm', 'author_norm', 'editor_norm',
+  'place_norm', 'printer_norm', 'publisher_norm', 'shelf_mark_norm',
+]);
+
+async function main() {
+  console.log(APPLY ? 'MODE: APPLY (writing)' : 'MODE: DRY RUN (use --apply to write)');
+  console.log(`snapshot dir : ${args.dir}`);
+  console.log(`source table : ${SOURCE_TABLE}`);
+  console.log(`target table : ${TARGET_TABLE}${TARGET_TABLE === SOURCE_TABLE ? '  ← LIVE TABLE' : '  (scratch)'}`);
+
+  if (APPLY && TARGET_TABLE === SOURCE_TABLE && !OVERWRITE_OK) {
+    console.error(
+      '\nREFUSING: --apply against the live table needs --i-understand-this-overwrites-live-data.\n' +
+      'Prefer restoring into a scratch table first (--into bph_works_restore_drill) and diffing.',
+    );
+    process.exit(1);
+  }
+
+  const path = join(args.dir, `${SOURCE_TABLE}.json.gz`);
+  if (!existsSync(path)) {
+    console.error(`\nNo snapshot for "${SOURCE_TABLE}" at ${path}`);
+    process.exit(1);
+  }
+
+  const manifestPath = join(args.dir, 'manifest.json');
+  if (existsSync(manifestPath)) {
+    const m = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    console.log(`snapshot taken: ${m.exported_at}`);
+    const expected = m.tables?.[SOURCE_TABLE]?.rows;
+    if (expected != null) console.log(`manifest says : ${expected} rows`);
+  }
+
+  const rows = JSON.parse(gunzipSync(readFileSync(path)).toString('utf8'));
+  if (!Array.isArray(rows)) throw new Error('snapshot is not a JSON array');
+  console.log(`rows in file  : ${rows.length}`);
+  if (rows.length === 0) {
+    console.log('\nNothing to restore.');
+    return;
+  }
+
+  // Generated columns must be stripped or every INSERT fails; the database
+  // recomputes them from the columns we do restore.
+  const snapshotCols = new Set(Object.keys(rows[0]));
+  const dropped = [...snapshotCols].filter((c) => KNOWN_GENERATED.has(c));
+  const keep = [...snapshotCols].filter((c) => !dropped.includes(c));
+  console.log(`columns       : ${keep.length} restored, ${dropped.length} dropped`);
+  if (dropped.length) console.log(`  dropped (generated / not on target): ${dropped.join(', ')}`);
+
+  const payload = rows.slice(0, LIMIT).map((r) => {
+    const o = {};
+    for (const c of keep) o[c] = r[c];
+    return o;
+  });
+
+  // Report rows that exist live but not in the snapshot. Never delete them —
+  // "created after the backup" and "should not exist" are indistinguishable here.
+  const { count: liveCount } = await sb
+    .from(TARGET_TABLE)
+    .select('id', { count: 'exact', head: true });
+  console.log(`rows live now : ${liveCount ?? 0} in ${TARGET_TABLE}`);
+  if (liveCount != null && liveCount > payload.length) {
+    console.log(
+      `NOTE: ${liveCount - payload.length} more rows live than in the snapshot. ` +
+      'They will be left alone (this script never deletes) — check whether they postdate the backup.',
+    );
+  }
+
+  if (!APPLY) {
+    console.log(`\nDRY RUN — would upsert ${payload.length} rows into ${TARGET_TABLE} on primary key "id".`);
+    console.log('Re-run with --apply to write.');
+    return;
+  }
+
+  // Adaptive write. The static list above is correct today, but a generated
+  // column added years from now would otherwise hard-fail a restore at exactly
+  // the moment nobody can afford to debug it. Postgres names the offending
+  // column in the error ("cannot insert a non-DEFAULT value into column X"),
+  // so drop it and retry rather than dying.
+  const runtimeDropped = [];
+  const stripColumn = (col) => {
+    runtimeDropped.push(col);
+    for (const row of payload) delete row[col];
+  };
+
+  let written = 0;
+  for (const chunk of chunks(payload, BATCH)) {
+    for (let attempt = 0; ; attempt++) {
+      const { error } = await sb.from(TARGET_TABLE).upsert(chunk, { onConflict: 'id' });
+      if (!error) break;
+      const namedCol = /column "?([A-Za-z0-9_]+)"?/.exec(error.message || '')?.[1];
+      // Two recoverable shapes: a column Postgres computes (generated), and a
+      // column the snapshot has but this target does not (schema drift since
+      // the backup). Both mean "drop it and carry on" — losing a column beats
+      // losing the restore.
+      const recoverable = /non-DEFAULT value|generated column|does not exist|could not find/i.test(error.message || '');
+      if (namedCol && recoverable && attempt < 40 && keep.includes(namedCol)) {
+        console.log(`\n  note: dropping "${namedCol}" (${error.message.slice(0, 80)}…) and retrying`);
+        stripColumn(namedCol);
+        continue;
+      }
+      throw new Error(`upsert failed at row ${written}: ${error.message}`);
+    }
+    written += chunk.length;
+    process.stdout.write(`\r  restored: ${written}/${payload.length}`);
+  }
+  console.log('');
+  if (runtimeDropped.length) {
+    console.log(`Columns dropped at runtime (update the known-generated list): ${runtimeDropped.join(', ')}`);
+  }
+
+  const { count: after } = await sb
+    .from(TARGET_TABLE)
+    .select('id', { count: 'exact', head: true });
+  console.log(`\nRows written  : ${written}`);
+  console.log(`Rows in table : ${after} (was ${liveCount ?? 0})`);
+  if (after < payload.length) {
+    console.error('VERIFICATION FAILED — fewer rows present than restored.');
+    process.exit(1);
+  }
+  console.log('Done.');
+}
+
+main().catch((err) => {
+  console.error('\nFAILED:', err.message);
+  process.exit(1);
+});

--- a/scripts/workers/backup-bph-catalog.sh
+++ b/scripts/workers/backup-bph-catalog.sh
@@ -31,15 +31,52 @@ set +a
 log "Starting BPH catalogue backup"
 
 LATEST_DIR="$BACKUP_DIR/bph-catalog-latest"
-rm -rf "$LATEST_DIR"
+STAGING_DIR="$BACKUP_DIR/.bph-catalog-staging"
+NTFY="https://ntfy.sh/sourcelibrary-uptime"
 
-if node "$REPO/scripts/maintenance/backup-bph-catalog.mjs" --out "$LATEST_DIR" >> "$LOG" 2>&1; then
-  SIZE=$(du -sh "$LATEST_DIR" | cut -f1)
-  log "BPH catalogue backup complete ($SIZE)"
-else
-  log "ERROR: backup-bph-catalog.mjs failed"
+# Alert loudly. A backup that fails silently is worse than no backup: it reads
+# as protection right up until the moment it is needed. The log alone was never
+# read by anyone (nothing monitored it — confirmed 2026-08-01).
+alert() {
+  log "ALERT: $1"
+  curl -s -m 10 -H "Title: BPH catalogue backup FAILED" -H "Priority: high" \
+       -d "$1" "$NTFY" > /dev/null 2>&1 || log "  (ntfy push failed too)"
+}
+
+# Build into staging and only swap on success. The previous version deleted
+# LATEST_DIR *before* dumping, so any failure destroyed the last good local
+# snapshot and left nothing behind — recoverable from the weeklies and restic,
+# but exactly backwards for the one directory meant to be the fast restore path.
+rm -rf "$STAGING_DIR"
+if ! node "$REPO/scripts/maintenance/backup-bph-catalog.mjs" --out "$STAGING_DIR" >> "$LOG" 2>&1; then
+  alert "backup-bph-catalog.mjs failed — previous snapshot at $LATEST_DIR left intact"
+  rm -rf "$STAGING_DIR"
   exit 1
 fi
+
+# Sanity-gate the snapshot before it replaces a known-good one. An export that
+# "succeeds" with zero or collapsed row counts (revoked key, silent API change)
+# is the failure mode that quietly overwrites the good copy with an empty one.
+NEW_ROWS=$(python3 -c "import json;print(json.load(open('$STAGING_DIR/manifest.json'))['tables']['bph_works']['rows'])" 2>/dev/null || echo 0)
+OLD_ROWS=$(python3 -c "import json;print(json.load(open('$LATEST_DIR/manifest.json'))['tables']['bph_works']['rows'])" 2>/dev/null || echo 0)
+
+if [ "$NEW_ROWS" -lt 1000 ]; then
+  alert "snapshot has only $NEW_ROWS bph_works rows (expected ~30k) — refusing to replace $LATEST_DIR"
+  rm -rf "$STAGING_DIR"
+  exit 1
+fi
+# The catalogue only grows or holds steady; a >10% drop means deletion or a
+# partial export, and either way a human should look before it becomes the
+# newest copy in the retention chain.
+if [ "$OLD_ROWS" -gt 0 ] && [ "$NEW_ROWS" -lt $((OLD_ROWS * 90 / 100)) ]; then
+  alert "snapshot row count dropped $OLD_ROWS → $NEW_ROWS (>10%) — refusing to replace $LATEST_DIR; inspect $STAGING_DIR"
+  exit 1
+fi
+
+rm -rf "$LATEST_DIR"
+mv "$STAGING_DIR" "$LATEST_DIR"
+SIZE=$(du -sh "$LATEST_DIR" | cut -f1)
+log "BPH catalogue backup complete ($SIZE, $NEW_ROWS rows)"
 
 # Weekly point-in-time snapshot on Sundays, kept forever.
 if [ "$DAY_OF_WEEK" -eq 7 ]; then


### PR DESCRIPTION
Derek asked how we protect the BPH catalogue from loss. This is the answer, plus the two gaps the question exposed.

`bph_works` is the BPH's **system of record** — Memorix stopped being upstream in May, and José and Paul edit it directly on Source Library. Losing it means losing the catalogue, not a cache. 29,879 records.

## The existing protection is genuinely good

Verified all four layers live before changing anything:

| # | Layer | Status |
|---|---|---|
| 1 | `bph_works_revisions` (per-field rollback) | ✅ 20,093 rows |
| 2 | Supabase managed physical backups | ✅ 8 retained, daily |
| 3 | Nightly JSON → Hetzner `/root/backups` | ✅ ran 07-31 04:00, 30MB, 6 weeklies back to Jun 21 |
| 4 | restic → Hetzner Object Storage (encrypted, versioned) | ✅ ran 07-31 05:00, 7d/8w/12m |

Two gaps, though.

## Gap 1 — there was no restore path, and it had never been tested

`backup-bph-catalog.mjs` has produced nightly snapshots since May. Its own docstring admitted the restore side was *"not yet built"*. So: 30MB of gzipped JSON that nobody could put back without writing an upsert loop under pressure at 2am.

Added `restore-bph-catalog.mjs` and **ran a real drill** against a scratch table. It found three things a paper review would not have:

1. **`bph_works` has 8 generated columns** (`search_norm`, `title_norm`, `author_norm`, `editor_norm`, `place_norm`, `printer_norm`, `publisher_norm`, `shelf_mark_norm`). Postgres rejects any INSERT naming them, so the obvious "read the JSON, upsert it back" loop dies on row one. They're dropped before writing — and all 29,879 restored rows had `search_norm` recomputed **identically to live**.
2. **Learning the column list by sampling a row fails on an empty table** — which is exactly the restore scenario. My first version did this, passed rehearsal, and failed on the first real drill. Now static, with the write loop parsing Postgres's own error to drop anything unexpected, so a generated column added in 2028 degrades to a warning instead of a failed restore.
3. **`CREATE TABLE (LIKE … INCLUDING CONSTRAINTS)` does not copy the primary key** — that needs `INCLUDING INDEXES`. Without a PK there's nothing for the upsert to conflict on. Worth knowing: **if `bph_works` is ever recreated, its indexes must be restored before its rows.**

**Drill result:** 29,879/29,879 rows in ~3m30s. Field-by-field comparison against live differed on exactly **7 rows**, in `sl_book_id`/`sl_book_slug` only — written by the 6-hourly `sync-bph-sl-book-ids` cron in the hours after the snapshot. Correct post-backup drift, not restore error.

Safety: dry-run by default, `--apply` to write, and restoring **over the live table** additionally demands `--i-understand-this-overwrites-live-data`. It upserts on `id` and never deletes — a row live but absent from the snapshot is reported, not removed, since "created after the backup" and "should not exist" are indistinguishable from inside the script.

## Gap 2 — nothing watched the backup

It logged `ERROR:` to a file nothing monitored. That's the exact shape CLAUDE.md warns about: an alarm nobody reads is not an instrument. Worse, reading the wrapper closely turned up a real bug — it ran `rm -rf "$LATEST_DIR"` **before** dumping, so any failure destroyed the last good local snapshot.

`backup-bph-catalog.sh` now:

- **dumps to staging and swaps only on success** (fixes the above);
- **refuses to publish a collapsed snapshot** — under 1,000 rows, or >10% below the previous manifest. An export that "succeeds" with zero rows (revoked key, silent API change) would otherwise overwrite the good copy with an empty one and propagate it through the whole retention chain;
- **pushes to `ntfy.sh/sourcelibrary-uptime` on failure**, the channel `traffic-anomaly-alert` already uses.

Gate logic exercised against 0 / 20,000 / 29,000 / 29,879 row counts.

## Runbook

`.claude/docs/bph-catalogue-disaster-recovery.md` — the four layers, copy-pasteable restore commands, what the drill found, and a note to re-drill after any `bph_works` schema change (a drill decays; that's the point of writing it down).

It also flags something worth knowing: **restic sweeps `/root/backups` wholesale, and both its cron entry and snapshot tag say `mongodump`.** The BPH catalogue is offsite by breadth, not by design — if anyone narrows that path, it silently falls out of offsite backup.

## Deliberately not done

**PITR is off** (`pitr_enabled: false`). Supabase's physical backups are daily snapshots, so exposure on a bad write is up to ~24h rather than seconds. That's a paid add-on and a cost decision for Derek — flagged, not enabled.

## No production data touched

The drill ran into `bph_works_restore_drill`, was verified, and dropped. `bph_works` still reads 29,879 rows. `npx tsc --noEmit` clean; unit suite green (1,028).

🤖 Generated with [Claude Code](https://claude.com/claude-code)