### PR TITLE
fix(edge): scope the bare Vercel alias, key edge limits on the caller

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,13 @@ on:
       base_url:
         description: 'Base URL to test against'
         required: false
-        default: 'https://sourcelibrary-v2.vercel.app'
+        # Was sourcelibrary-v2.vercel.app, whose reader surface now 308s to the
+        # canonical host (src/lib/alias-host-scope.ts). This job is also on a
+        # daily cron, so it needs a working default — and since that alias only
+        # ever mirrored production, pointing at production is what it has been
+        # testing all along, now through the CDN like a real visitor. For a
+        # branch, pass the preview deployment URL explicitly.
+        default: 'https://sourcelibrary.org'
 
 jobs:
   e2e:
@@ -34,7 +40,7 @@ jobs:
       - name: Run E2E tests
         run: npx playwright test
         env:
-          BASE_URL: ${{ inputs.base_url || 'https://sourcelibrary-v2.vercel.app' }}
+          BASE_URL: ${{ inputs.base_url || 'https://sourcelibrary.org' }}
 
       - name: Upload test report
         if: always()
@@ -89,7 +95,7 @@ jobs:
                 ``,
                 `**Date:** ${date}`,
                 `**Run:** ${runUrl}`,
-                `**Base URL:** ${process.env.BASE_URL || 'https://sourcelibrary-v2.vercel.app'}`,
+                `**Base URL:** ${process.env.BASE_URL || 'https://sourcelibrary.org'}`,
                 ``,
                 `Download the \`playwright-report\` artifact from the run for details.`,
                 ``,
@@ -99,4 +105,4 @@ jobs:
               labels: ['bug', 'e2e-tests'],
             });
         env:
-          BASE_URL: ${{ inputs.base_url || 'https://sourcelibrary-v2.vercel.app' }}
+          BASE_URL: ${{ inputs.base_url || 'https://sourcelibrary.org' }}

--- a/e2e/crawl-all-pages.spec.ts
+++ b/e2e/crawl-all-pages.spec.ts
@@ -403,7 +403,7 @@ test.describe('Link follower', () => {
 
     const baseUrl = (page as any)._browserContext._options?.baseURL
       || process.env.BASE_URL
-      || 'https://sourcelibrary-v2.vercel.app';
+      || '';
 
     const visited = new Set<string>();
     const discovered = new Set<string>();

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -31,7 +31,17 @@ const ROUTES = [
 ];
 
 export default async function globalSetup() {
-  const baseURL = process.env.BASE_URL || 'https://sourcelibrary-v2.vercel.app';
+  // No default. The reader surface on sourcelibrary-v2.vercel.app now 308s to
+  // production (src/lib/alias-host-scope.ts), so a fallback would quietly point
+  // this suite — crawl-all-pages.spec.ts above all — at the live site. Pass the
+  // branch's preview URL explicitly.
+  const baseURL = process.env.BASE_URL;
+  if (!baseURL) {
+    throw new Error(
+      'BASE_URL is required. Pass the preview deployment URL for the branch under test, '
+      + 'e.g. BASE_URL=https://sourcelibrary-v2-git-<branch>.vercel.app'
+    );
+  }
   const ctx = await request.newContext({
     baseURL,
     extraHTTPHeaders: { 'X-E2E-Test': 'sourcelibrary-warmup' },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   use: {
     // Use Vercel direct URL by default to avoid Cloudflare bot protection in CI.
     // Override with BASE_URL=https://sourcelibrary.org for local testing.
-    baseURL: process.env.BASE_URL || 'https://sourcelibrary-v2.vercel.app',
+    baseURL: process.env.BASE_URL,
     navigationTimeout: 20_000,
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',

--- a/src/lib/alias-host-scope.ts
+++ b/src/lib/alias-host-scope.ts
@@ -61,14 +61,70 @@ const ALIAS_ALLOWED_PREFIXES = [
 const ALIAS_ALLOWED_EXACT = new Set(['/', '/favicon.ico', '/manifest.json', '/opensearch.xml']);
 
 /**
+ * The project's bare Vercel production alias is the SAME shape of hole.
+ *
+ * `sourcelibrary-v2.vercel.app` resolves straight to Vercel — no `cf-ray`, so
+ * none of the edge layer applies — and it answers the entire library. The
+ * traffic detector has flagged reader traffic on it every run since #3446. It
+ * is the last known unguarded door of the kind the AS132203 fleet walked
+ * through, and nobody reads books there on purpose.
+ *
+ * It cannot simply 308 everything, which is the trap here: `scripts/uptime-
+ * monitor.mjs` probes it, and the Playwright suite defaults its `BASE_URL` to
+ * it — `e2e/crawl-all-pages.spec.ts` in particular. A catch-all redirect would
+ * not merely break those; it would silently repoint a page-crawler at
+ * production. So the allowlist keeps exactly the operational paths those two
+ * consumers use, and nothing that serves a book.
+ *
+ * Note the EXACT matches: `/api/books` is the monitor's listing probe, while
+ * `/api/books/<id>/text` and `/quote` — the bulk-read routes — are deliberately
+ * not covered by it. Same for the three `/embed/*` landing pages, whose reading
+ * rooms below them still redirect.
+ */
+const DEPLOYMENT_ALLOWED_PREFIXES = ['/_next', '/static', '/api/health'];
+const DEPLOYMENT_ALLOWED_EXACT = new Set([
+  '/',
+  '/favicon.ico',
+  '/api/books',
+  '/embed/bph',
+  '/embed/ficino',
+  '/embed/bhutan',
+]);
+
+/**
+ * Matched EXACTLY, never by substring. Preview deployments
+ * (`sourcelibrary-v2-git-*.vercel.app`, `*-dereklomas-projects.vercel.app`)
+ * must keep serving the whole site or branch review stops working — they are a
+ * known, accepted exposure, and a `host.includes('vercel.app')` test here would
+ * take them all out.
+ */
+export const DEPLOYMENT_ALIAS_HOSTS = new Set(['sourcelibrary-v2.vercel.app']);
+
+export type AliasPolicy = 'society' | 'deployment';
+
+/** Which scoping policy applies to this host, if any. Ports are ignored. */
+export function aliasPolicyForHost(host: string): AliasPolicy | null {
+  const bare = (host || '').split(',')[0].trim().toLowerCase().replace(/:\d+$/, '');
+  if (!bare) return null;
+  if (DEPLOYMENT_ALIAS_HOSTS.has(bare)) return 'deployment';
+  if (bare.includes('ficinosociety.org') || bare.includes('ficino.sourcelibrary.org')) {
+    return 'society';
+  }
+  return null;
+}
+
+/**
  * Should this path be redirected off an alias host to the canonical domain?
  * Callers apply it only when the request is already known to be on an alias.
  */
-export function shouldRedirectToCanonical(pathname: string): boolean {
-  if (ALIAS_ALLOWED_EXACT.has(pathname)) return false;
-  return !ALIAS_ALLOWED_PREFIXES.some(
-    (p) => pathname === p || pathname.startsWith(p + '/')
-  );
+export function shouldRedirectToCanonical(
+  pathname: string,
+  policy: AliasPolicy = 'society'
+): boolean {
+  const exact = policy === 'deployment' ? DEPLOYMENT_ALLOWED_EXACT : ALIAS_ALLOWED_EXACT;
+  const prefixes = policy === 'deployment' ? DEPLOYMENT_ALLOWED_PREFIXES : ALIAS_ALLOWED_PREFIXES;
+  if (exact.has(pathname)) return false;
+  return !prefixes.some((p) => pathname === p || pathname.startsWith(p + '/'));
 }
 
 /** The canonical URL a redirected alias request should land on. */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,7 +4,7 @@ import authorCanonicalRedirects from '@/lib/author-canonical-redirects.json';
 import { getProviderPrefixRedirect, TENANT_ROOT_PATHS } from '@/lib/provider-prefix';
 import { isGlobalOnlyTenantPath } from '@/lib/tenant-global-paths';
 import { retiredCollectionMessage } from '@/lib/retired-collections';
-import { shouldRedirectToCanonical, canonicalUrl } from '@/lib/alias-host-scope';
+import { shouldRedirectToCanonical, canonicalUrl, aliasPolicyForHost } from '@/lib/alias-host-scope';
 import { isBlockedNetwork, BLOCKED_NETWORK_RESPONSE } from '@/lib/blocked-networks';
 
 // Precomputed variant-slug → canonical-slug map for /author URL dedup (#2250).
@@ -157,10 +157,16 @@ export function looksLikeBot(request: NextRequest): boolean {
 const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
 
 function getClientIp(request: NextRequest): string {
+  // cf-connecting-ip FIRST. Vercel rewrites x-forwarded-for with whatever
+  // connected to Vercel, which behind the CDN is a Cloudflare edge node — so
+  // the old order keyed this limiter on ~15 shared addresses. Every bot behind
+  // one edge node drew from the same 10-req/60s bucket while a bot on a quiet
+  // node ran free: over-blocking and under-blocking at once, from one wrong
+  // header. Same defect as PR #3487, in the proxy's own limiter.
   return (
+    request.headers.get('cf-connecting-ip') ||
     (request.headers.get('x-forwarded-for') || '').split(',')[0].trim() ||
     request.headers.get('x-real-ip') ||
-    request.headers.get('cf-connecting-ip') ||
     'unknown'
   );
 }
@@ -650,10 +656,12 @@ export async function proxy(request: NextRequest) {
   // Runs BEFORE any library-specific routing, so an alias host is scoped once,
   // up front, rather than after book/author/provider rules have had a go at it.
   // See src/lib/alias-host-scope.ts.
-  if (
-    (host.includes('ficinosociety.org') || host.includes('ficino.sourcelibrary.org')) &&
-    shouldRedirectToCanonical(pathname)
-  ) {
+  //
+  // The bare Vercel production alias (`sourcelibrary-v2.vercel.app`) is the
+  // same hole and is scoped here too, with its own narrower allowlist — see
+  // alias-host-scope.ts for why it cannot just 308 everything.
+  const aliasPolicy = aliasPolicyForHost(host);
+  if (aliasPolicy && shouldRedirectToCanonical(pathname, aliasPolicy)) {
     return NextResponse.redirect(canonicalUrl(pathname, request.nextUrl.search), 308);
   }
 

--- a/tests/unit/alias-host-scope.test.ts
+++ b/tests/unit/alias-host-scope.test.ts
@@ -122,3 +122,72 @@ describe('proxy() refuses blocked networks on every host', () => {
     expect(res?.status).not.toBe(403);
   });
 });
+
+/**
+ * The bare Vercel production alias is the last unguarded door of the same kind.
+ * `sourcelibrary-v2.vercel.app` resolves straight to Vercel — no cf-ray, so no
+ * edge layer — and answered the whole library; the traffic detector has flagged
+ * reader traffic on it every run since #3446.
+ *
+ * It could not simply 308 everything: scripts/uptime-monitor.mjs probes it and
+ * the Playwright suite defaults BASE_URL to it, so a catch-all would have
+ * silently repointed a page-crawler at production. These pin both halves — the
+ * library leaves, the operational probes stay.
+ */
+describe('bare Vercel production alias', () => {
+  const DEPLOY_HOST = 'https://sourcelibrary-v2.vercel.app';
+
+  it.each([
+    '/book/chymische-hochzeit-christiani-rosencreutz-andreae',
+    '/book/some-slug/page/abc123',
+    '/collections/hermetica',
+    '/gallery',
+    '/gallery/image/xyz',
+    '/author/paracelsus',
+    '/artwork/bembine-table-of-isis',
+    '/encyclopedia/Matthiolus',
+    '/api/books/abc/text',
+    '/api/books/abc/quote',
+    '/api/image',
+    '/embed/bph/book/some-slug',
+  ])('308s the reader surface: %s', async (path) => {
+    const res = await proxy(req(`${DEPLOY_HOST}${path}`));
+    expect(res?.status).toBe(308);
+    expect(res?.headers.get('location')).toBe(`https://sourcelibrary.org${path}`);
+  });
+
+  it.each([
+    '/api/health',
+    '/api/books',
+    '/embed/bph',
+    '/embed/ficino',
+    '/embed/bhutan',
+    '/_next/static/chunks/main.js',
+  ])('leaves the operational probes in place: %s', async (path) => {
+    const res = await proxy(req(`${DEPLOY_HOST}${path}`));
+    expect(res?.status).not.toBe(308);
+  });
+
+  it('preserves the query string when redirecting', async () => {
+    const res = await proxy(req(`${DEPLOY_HOST}/search?q=alchemy&page=2`));
+    expect(res?.headers.get('location')).toBe('https://sourcelibrary.org/search?q=alchemy&page=2');
+  });
+
+  it('does NOT scope preview deployments', async () => {
+    // Branch review depends on these serving the whole site. A
+    // host.includes('vercel.app') test here would take every preview out —
+    // which is why the deployment alias is matched exactly.
+    for (const host of [
+      'https://sourcelibrary-v2-git-fix-something.vercel.app',
+      'https://sourcelibrary-v2-32g32u0ho-dereklomas-projects.vercel.app',
+    ]) {
+      const res = await proxy(req(`${host}/book/some-slug`));
+      expect(res?.status, host).not.toBe(308);
+    }
+  });
+
+  it('does not touch the canonical host', async () => {
+    const res = await proxy(req('https://sourcelibrary.org/book/some-slug'));
+    expect(res?.status).not.toBe(308);
+  });
+});


### PR DESCRIPTION
**Stacked on #3487** — base it to `main` once that merges.

## The exposure

`sourcelibrary-v2.vercel.app` resolves straight to Vercel. No `cf-ray` on any response, so the ASN blocks, the bot rules and the first layer of the three-layer crawler gate are all simply absent — and it answered **every route**, the whole library included. The traffic detector has flagged reader traffic on it every run since #3446.

This is the same shape as the `ficinosociety.org` hole the AS132203 fleet used for nine weeks. #3438 scoped that host **by name**; this closes the remaining one.

## Why it isn't a catch-all redirect

Finding this out was most of the work. Two consumers point at that host:

- `scripts/uptime-monitor.mjs` — probes `/api/health`, `/api/books?limit=1`, and three `/embed/*` landing pages
- the Playwright suite — `playwright.config.ts`, `e2e/global-setup.ts` and `e2e/crawl-all-pages.spec.ts` all default `BASE_URL` to it

A blanket 308 would not merely have broken them. It would have **silently repointed a page-crawler at production**. So the allowlist keeps exactly the operational paths and nothing that serves a book:

- `/api/books` is allowed as an **exact** match; `/api/books/<id>/text` and `/quote` — the bulk-read routes — are not
- `/embed/bph`, `/embed/ficino`, `/embed/bhutan` are exact; the reading rooms beneath them redirect
- `/_next`, `/static`, `/api/health` by prefix

**Preview deployments are matched out on purpose.** `DEPLOYMENT_ALIAS_HOSTS` is an exact-match set, because `host.includes('vercel.app')` would take every branch preview offline and end branch review. There's a test pinning that.

## The second half: the limiter couldn't see callers

`getClientIp()` in `src/proxy.ts` read `x-forwarded-for` first — which Vercel rewrites with the Cloudflare edge node that connected to it. So the 10-req/60s bot bucket was keyed on roughly **15 shared addresses**: bots behind a busy edge node all drew from one bucket while a bot on a quiet node ran free. Over-blocking and under-blocking at once, from one wrong header. Same defect as #3487, in the proxy's own limiter.

## e2e defaults

`playwright.config.ts`, `global-setup.ts` and `crawl-all-pages.spec.ts` no longer fall back to the alias — `global-setup` now throws with the preview-URL form. The daily workflow (it's on a 06:00 cron, not just dispatch) keeps a default, now the canonical host: that alias only ever mirrored production, so the scheduled crawl was already testing production and now does it through the CDN like a real visitor.

## Verification

- 1166 unit tests pass, `tsc --noEmit` clean, workflow YAML parses.
- **Negative control run:** reverting the proxy hunk fails 13 of the new assertions.
- Tests exercise `proxy()` directly rather than asserting on source, per the tenant-testing rule — a preview cannot verify host-gated behaviour, so this is the only place it can be checked before deploy.

## After merge

The `reader_traffic_on_unexpected_host` CRITICAL should clear on its own. If it doesn't, the traffic is arriving on a host nobody has enumerated yet, which is worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)