### PR TITLE
feat(bph-catalog): detect distortion, not just loss

### DIFF
--- a/.claude/docs/bph-catalogue-disaster-recovery.md
+++ b/.claude/docs/bph-catalogue-disaster-recovery.md
@@ -99,6 +99,46 @@ not restore error.
   `ERROR:` to a log file that nothing monitored, which is the failure mode described
   in CLAUDE.md: an alarm nobody reads is not an instrument.
 
+## Detecting distortion (not just loss)
+
+Backups answer "can we get it back". They do not answer **"would we know if
+something had been quietly altered?"** — the failure mode where nothing is
+missing, nothing errors, and the catalogue just says something slightly
+different than it did. Only the editor path writes `bph_works_revisions`; the
+sl_book_id sync, the NAS ingest, format derivation, dedupe and the backfills all
+write `bph_works` directly, and any of them could change a title or a shelf mark
+without leaving a trace.
+
+`scripts/workers/bph-integrity-check.mjs` (04:30 nightly, after the backup and
+before restic) fingerprints every record in five column groups — biblio,
+location, notes, identifiers, automation — and classifies every change:
+
+| Verdict | Meaning |
+|---|---|
+| `revision` | a matching `bph_works_revisions` row exists — accounted for |
+| `automation` | only automation-owned columns moved (sl_book_id sync, IA matching, Memorix bookkeeping) — expected churn |
+| `UNEXPLAINED` | anything else — pages a human via ntfy |
+
+Grouping is what makes this usable: a single whole-row hash would flag the
+6-hourly `sl_book_id` sync every night and train everyone to ignore it. The
+column→group mapping lives in `scripts/migration/add-bph-integrity-monitor.sql`
+— **a column not listed there defaults to `biblio`, so a new column fails loud
+(unexplained) rather than silently unwatched.**
+
+Every detection is appended to `bph_works_integrity_events` with a
+`reviewed_at`/`reviewed_by`/`note` workflow, so "we looked at it and here is why
+it was fine" is itself recorded. That table is the artifact to show anyone who
+asks how we would know if their work had been altered.
+
+**Verified by deliberate test, 2026-08-01.** A record's `remarks` was changed
+directly in the database, bypassing the editor path entirely; the next scan
+flagged it `changed / UNEXPLAINED / [notes]`. The revert was flagged too — any
+change is a change. Both events are in the table, marked reviewed. Re-run that
+test after changing the grouping.
+
+A scan that *fails to run* also alerts: a silent detector and an untouched
+catalogue look identical from outside.
+
 ## Re-drill periodically
 
 The point of a drill is that it decays. Re-run steps 1–3 above (scratch table, then

--- a/scripts/migration/add-bph-integrity-monitor.sql
+++ b/scripts/migration/add-bph-integrity-monitor.sql
@@ -1,0 +1,230 @@
+-- Change detection for the BPH catalogue: make "distorted" knowable.
+--
+-- WHY THIS EXISTS
+-- ---------------
+-- bph_works is the BPH's system of record. Backups protect against LOSS; the
+-- revision trail protects edits made through the editor. Neither protects
+-- against DISTORTION — a script, a stray credential, or a well-meaning bulk
+-- sweep silently changing thousands of rows. That is the failure mode you do
+-- not find out about, because nothing is missing and nothing errors.
+--
+-- Only the editor path (applyWorkRevision) writes bph_works_revisions. Plenty
+-- of other code writes bph_works directly — the sl_book_id sync cron, the NAS
+-- ingest, format derivation, dedupe, the various backfills — and any of them
+-- could change a title or a shelf mark without leaving a trace. Measured
+-- 2026-08-01: 20,093 revisions exist, of which 46 are human; the other ~29,800
+-- rows have been edited over eight years with no per-field history at all.
+--
+-- So this compares the catalogue against itself, nightly, and asks of every
+-- change: IS THIS EXPLAINED? A change with a matching revision row is
+-- accounted for. A change touching only automation-owned columns is expected.
+-- Anything else is unexplained and pages a human.
+--
+-- HOW IT WORKS
+-- ------------
+-- Per row we store five group hashes rather than one. A single whole-row hash
+-- would tell you *that* something changed but not *what kind* — and the
+-- 6-hourly sl_book_id sync would then make every night look like a change.
+-- Grouping lets the expected churn (automation) be distinguished from the
+-- things nobody should be touching unattended (bibliography, location, notes).
+--
+-- Deliberately NOT hashed: search_tsv and the *_norm generated columns (derived
+-- — they change when their sources do, which is already caught), and
+-- last-checked bookkeeping. field_provenance IS hashed: a writer that edits a
+-- record and forges its provenance should show up.
+--
+-- Run via Supabase SQL editor or psql:
+--   psql "$DATABASE_URL" -f scripts/migration/add-bph-integrity-monitor.sql
+
+BEGIN;
+
+-- Current fingerprint, one row per catalogue record.
+CREATE TABLE IF NOT EXISTS bph_works_integrity (
+  -- bph_works.id is TEXT, not uuid (bph_works_revisions.id IS uuid — don't
+  -- copy this type from there).
+  id                text PRIMARY KEY,
+  ubn               text,
+  hash_biblio       text NOT NULL,
+  hash_location     text NOT NULL,
+  hash_notes        text NOT NULL,
+  hash_identifiers  text NOT NULL,
+  hash_automation   text NOT NULL,
+  first_seen        timestamptz NOT NULL DEFAULT now(),
+  last_checked      timestamptz NOT NULL DEFAULT now(),
+  last_changed      timestamptz
+);
+
+-- Append-only log of every detected change. This is the artifact you show
+-- someone who asks "how would you know if my work had been altered?".
+CREATE TABLE IF NOT EXISTS bph_works_integrity_events (
+  id            bigserial PRIMARY KEY,
+  detected_at   timestamptz NOT NULL DEFAULT now(),
+  work_id       text,          -- bph_works.id (text)
+  ubn           text,
+  kind          text NOT NULL,          -- inserted | changed | deleted
+  groups_changed text[],                -- biblio | location | notes | identifiers | automation
+  explanation   text NOT NULL,          -- revision | automation | UNEXPLAINED
+  revision_id   uuid,                   -- matching bph_works_revisions.id when explanation='revision'
+  reviewed_at   timestamptz,            -- set by a human who has looked
+  reviewed_by   text,
+  note          text
+);
+
+CREATE INDEX IF NOT EXISTS idx_bph_integrity_events_detected
+  ON bph_works_integrity_events (detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_bph_integrity_events_unexplained
+  ON bph_works_integrity_events (explanation, detected_at DESC)
+  WHERE explanation = 'UNEXPLAINED';
+
+-- Column groups. Keeping these in one function makes the classification
+-- auditable in a single place: if you add a column to bph_works, decide here
+-- which group owns it. Anything unlisted lands in 'biblio' by default, which
+-- fails LOUD (an unexplained change) rather than silent — the safe direction.
+CREATE OR REPLACE FUNCTION public.bph_row_hashes(r bph_works)
+RETURNS TABLE (biblio text, location text, notes text, identifiers text, automation text)
+LANGUAGE sql IMMUTABLE AS $$
+  SELECT
+    md5(concat_ws('|',
+      r.title, r.parallel_title, r.uniform_title, r.full_title,
+      r.series_title, r.volume_title, r.journal_title, r.volume_number,
+      r.author, r.variant_author, r.pseudonym, r.author_canonical_name,
+      r.editor, r.variant_editor, r.compiler, r.scribe,
+      r.statement_of_responsibility, r.author_entity_id, r.author_viaf_id,
+      r.author_wikidata_qid, r.contributors::text,
+      r.place, r.printer, r.publisher, r.variant_printer, r.variant_publisher,
+      r.impressum_original, r.edition_note, r.ms_date, r.origin,
+      r.year, r.year_raw, r.language, r.detected_language, r.script,
+      r.keywords, r.record_type, r.object_size, r.object_size_cm,
+      r.bibliographic_format, r.binding, r.bound_with, r.physical_description,
+      r.pagination, r.characterization, r.iconography,
+      r.illumination_illustration, r.number_of_copies, r.thumbnail
+    )),
+    md5(concat_ws('|',
+      r.shelf_mark, r.state_shelf_mark, r.present_location, r.location,
+      r.provenance, r.collection, r.cross_listed_with_uuid
+    )),
+    md5(concat_ws('|',
+      r.bibliography, r.remarks, r.annotation, r.contents,
+      r.internal_remarks, r.exhibition_history, r.field_provenance::text
+    )),
+    md5(concat_ws('|',
+      r.ubn, r.ustc_sn::text, r.ia_identifier, r.ia_url, r.picturae_barcode,
+      r.icn_registration_number, r.uuid::text
+    )),
+    -- Columns owned by automation. Changes confined here are expected churn:
+    -- the 6-hourly sl_book_id sync, IA matching, first-translation derivation,
+    -- Memorix file bookkeeping, and the acquisition/workflow fields.
+    md5(concat_ws('|',
+      r.sl_book_id, r.sl_book_slug,
+      r.sl_external_book_id, r.sl_external_slug, r.sl_external_source,
+      r.is_first_translation::text,
+      r.ia_match_confidence::text, r.ia_match_method, r.ia_title_similarity::text,
+      r.ia_author_match::text, r.ia_year_match::text, r.ia_matched_at::text,
+      r.ia_match_validated::text, r.ia_match_is_same_work::text,
+      r.ia_match_is_same_edition::text, r.ia_match_validated_by,
+      r.ia_match_validation_notes, r.ia_match_validated_at::text,
+      r.memorix_file_count::text, r.memorix_files::text,
+      r.memorix_total_file_bytes::text, r.memorix_modified_time::text,
+      r.memorix_raw::text, r.file_count::text,
+      r.modified_time::text, r.modified_by_username, r.modified_by_email,
+      r.status, r.work_status, r.fully_approved, r.delivered_to_customer,
+      r.publish_scan, r.acquisition_date, r.acquisition_source, r.price,
+      r.created_at::text
+    ))
+$$;
+
+-- One pass: fingerprint every row, log what moved, update the baseline.
+-- Returns the events it just recorded so the caller can alert on them.
+CREATE OR REPLACE FUNCTION public.bph_integrity_scan()
+RETURNS TABLE (kind text, explanation text, ubn text, groups_changed text[])
+LANGUAGE plpgsql AS $$
+DECLARE
+  run_at timestamptz := now();
+BEGIN
+  CREATE TEMP TABLE _cur ON COMMIT DROP AS
+  SELECT w.id, w.ubn, h.biblio, h.location, h.notes, h.identifiers, h.automation
+  FROM bph_works w, LATERAL public.bph_row_hashes(w) h;
+
+  -- Rows that vanished. Never expected; a delete is always worth a human look.
+  INSERT INTO bph_works_integrity_events (detected_at, work_id, ubn, kind, groups_changed, explanation)
+  SELECT run_at, i.id, i.ubn, 'deleted', ARRAY[]::text[], 'UNEXPLAINED'
+  FROM bph_works_integrity i
+  WHERE NOT EXISTS (SELECT 1 FROM _cur c WHERE c.id = i.id);
+
+  DELETE FROM bph_works_integrity i
+  WHERE NOT EXISTS (SELECT 1 FROM _cur c WHERE c.id = i.id);
+
+  -- Changed rows, with their explanation resolved in one place.
+  INSERT INTO bph_works_integrity_events
+        (detected_at, work_id, ubn, kind, groups_changed, explanation, revision_id)
+  SELECT run_at, c.id, c.ubn, 'changed', g.groups,
+         CASE
+           WHEN rev.id IS NOT NULL THEN 'revision'
+           WHEN g.groups = ARRAY['automation']::text[] THEN 'automation'
+           ELSE 'UNEXPLAINED'
+         END,
+         rev.id
+  FROM _cur c
+  JOIN bph_works_integrity i ON i.id = c.id
+  CROSS JOIN LATERAL (
+    SELECT ARRAY_REMOVE(ARRAY[
+      CASE WHEN c.biblio      IS DISTINCT FROM i.hash_biblio      THEN 'biblio'      END,
+      CASE WHEN c.location    IS DISTINCT FROM i.hash_location    THEN 'location'    END,
+      CASE WHEN c.notes       IS DISTINCT FROM i.hash_notes       THEN 'notes'       END,
+      CASE WHEN c.identifiers IS DISTINCT FROM i.hash_identifiers THEN 'identifiers' END,
+      CASE WHEN c.automation  IS DISTINCT FROM i.hash_automation  THEN 'automation'  END
+    ], NULL) AS groups
+  ) g
+  LEFT JOIN LATERAL (
+    SELECT r.id FROM bph_works_revisions r
+    WHERE r.ubn = c.ubn AND r.applied_at > i.last_checked - interval '1 minute'
+    ORDER BY r.applied_at DESC LIMIT 1
+  ) rev ON true
+  WHERE array_length(g.groups, 1) > 0;
+
+  -- New rows. Explained if a 'create' revision exists, else worth a look —
+  -- rows appearing in a catalogue of record without provenance is its own problem.
+  INSERT INTO bph_works_integrity_events (detected_at, work_id, ubn, kind, groups_changed, explanation, revision_id)
+  SELECT run_at, c.id, c.ubn, 'inserted', ARRAY[]::text[],
+         CASE WHEN rev.id IS NOT NULL THEN 'revision' ELSE 'UNEXPLAINED' END, rev.id
+  FROM _cur c
+  LEFT JOIN bph_works_integrity i ON i.id = c.id
+  LEFT JOIN LATERAL (
+    SELECT r.id FROM bph_works_revisions r
+    WHERE r.ubn = c.ubn AND r.change_type = 'create'
+    ORDER BY r.applied_at DESC LIMIT 1
+  ) rev ON true
+  WHERE i.id IS NULL
+    -- First run establishes the baseline rather than reporting 29,879 inserts.
+    AND EXISTS (SELECT 1 FROM bph_works_integrity);
+
+  -- Roll the baseline forward.
+  INSERT INTO bph_works_integrity AS t
+        (id, ubn, hash_biblio, hash_location, hash_notes, hash_identifiers, hash_automation, last_checked)
+  SELECT c.id, c.ubn, c.biblio, c.location, c.notes, c.identifiers, c.automation, run_at
+  FROM _cur c
+  ON CONFLICT (id) DO UPDATE SET
+    ubn              = EXCLUDED.ubn,
+    hash_biblio      = EXCLUDED.hash_biblio,
+    hash_location    = EXCLUDED.hash_location,
+    hash_notes       = EXCLUDED.hash_notes,
+    hash_identifiers = EXCLUDED.hash_identifiers,
+    hash_automation  = EXCLUDED.hash_automation,
+    last_checked     = EXCLUDED.last_checked,
+    last_changed     = CASE
+      WHEN t.hash_biblio      IS DISTINCT FROM EXCLUDED.hash_biblio
+        OR t.hash_location    IS DISTINCT FROM EXCLUDED.hash_location
+        OR t.hash_notes       IS DISTINCT FROM EXCLUDED.hash_notes
+        OR t.hash_identifiers IS DISTINCT FROM EXCLUDED.hash_identifiers
+        OR t.hash_automation  IS DISTINCT FROM EXCLUDED.hash_automation
+      THEN run_at ELSE t.last_changed END;
+
+  RETURN QUERY
+    SELECT e.kind, e.explanation, e.ubn, e.groups_changed
+    FROM bph_works_integrity_events e
+    WHERE e.detected_at = run_at
+    ORDER BY (e.explanation = 'UNEXPLAINED') DESC, e.ubn;
+END;
+$$;
+
+COMMIT;

--- a/scripts/workers/bph-integrity-check.mjs
+++ b/scripts/workers/bph-integrity-check.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * BPH catalogue integrity check — makes "distorted" knowable.
+ *
+ * Backups protect against losing the catalogue. The revision trail records
+ * edits made through the editor. Neither notices a script, a stray credential,
+ * or a well-meaning bulk sweep silently rewriting thousands of rows — nothing
+ * is missing, nothing errors, and the catalogue simply says something slightly
+ * different than it used to. That is the failure this exists to catch.
+ *
+ * Each run fingerprints every record in five column groups and compares
+ * against the stored baseline, then classifies every change:
+ *
+ *   revision    — a matching bph_works_revisions row exists. Accounted for.
+ *   automation  — only automation-owned columns moved (sl_book_id sync, IA
+ *                 matching, Memorix file bookkeeping). Expected churn.
+ *   UNEXPLAINED — anything else. Someone should look.
+ *
+ * Only UNEXPLAINED pages a human, and only on the run that finds it — a
+ * detector that repeats itself nightly trains you to ignore it (the same
+ * reason traffic-anomaly-alert pushes on state change only).
+ *
+ * The heavy lifting is a Postgres function (bph_integrity_scan) so this is one
+ * round trip rather than 30K rows over the wire. See
+ * scripts/migration/add-bph-integrity-monitor.sql for the column grouping —
+ * that file is where you declare which group a new column belongs to.
+ *
+ * Cron: 30 4 * * *  (after the 04:00 backup, before restic at 05:00, so a
+ * flagged night is captured in that night's snapshot)
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/workers/bph-integrity-check.mjs [--no-push] [--json]
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const NO_PUSH = process.argv.includes('--no-push');
+const AS_JSON = process.argv.includes('--json');
+const NTFY_TOPIC = 'https://ntfy.sh/sourcelibrary-uptime';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('[bph-integrity] missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function push(title, body, priority = 'default') {
+  if (NO_PUSH) {
+    console.log(`[bph-integrity] --no-push: would send "${title}"`);
+    return;
+  }
+  try {
+    await fetch(NTFY_TOPIC, {
+      method: 'POST',
+      headers: { Title: title, Priority: priority },
+      body,
+      signal: AbortSignal.timeout(10_000),
+    });
+    console.log('[bph-integrity] ntfy push sent');
+  } catch (err) {
+    console.error(`[bph-integrity] ntfy push failed: ${err.message}`);
+  }
+}
+
+async function main() {
+  const { data, error } = await sb.rpc('bph_integrity_scan');
+
+  if (error) {
+    // A scan that cannot run is itself an alert: the detector going quiet and
+    // the catalogue being untouched look identical from the outside.
+    console.error(`[bph-integrity] scan failed: ${error.message}`);
+    await push(
+      'BPH integrity check FAILED to run',
+      `The catalogue integrity scan could not complete: ${error.message}\n\n` +
+        'Nothing is known about changes since the last successful run.',
+      'high',
+    );
+    process.exit(1);
+  }
+
+  const events = data || [];
+  const unexplained = events.filter((e) => e.explanation === 'UNEXPLAINED');
+  const byRevision = events.filter((e) => e.explanation === 'revision');
+  const byAutomation = events.filter((e) => e.explanation === 'automation');
+
+  if (AS_JSON) {
+    console.log(JSON.stringify({ total: events.length, unexplained, byRevision: byRevision.length, byAutomation: byAutomation.length }, null, 2));
+  } else {
+    console.log(`[bph-integrity] ${events.length} change(s) since last scan`);
+    console.log(`  explained by a revision : ${byRevision.length}`);
+    console.log(`  expected automation     : ${byAutomation.length}`);
+    console.log(`  UNEXPLAINED             : ${unexplained.length}`);
+  }
+
+  if (unexplained.length === 0) {
+    console.log('[bph-integrity] catalogue accounted for.');
+    return;
+  }
+
+  // Group for a readable alert: "17 records, bibliography + location" beats a
+  // wall of UBNs, and the UBNs are in the events table for whoever follows up.
+  const groups = new Map();
+  for (const e of unexplained) {
+    const key = (e.groups_changed || []).join('+') || e.kind;
+    groups.set(key, (groups.get(key) || 0) + 1);
+  }
+  const summary = [...groups.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([g, n]) => `  ${n} × ${g}`)
+    .join('\n');
+  const sample = unexplained.slice(0, 10).map((e) => e.ubn).join(', ');
+
+  const body =
+    `${unexplained.length} catalogue record(s) changed with no revision and outside automation:\n\n` +
+    `${summary}\n\n` +
+    `UBNs: ${sample}${unexplained.length > 10 ? ` … +${unexplained.length - 10} more` : ''}\n\n` +
+    'Review: select * from bph_works_integrity_events where explanation=\'UNEXPLAINED\' and reviewed_at is null;\n' +
+    'Prior values are in that night\'s backup (/root/backups/bph-catalog-latest) and, for editor changes, bph_works_revisions.';
+
+  console.error(`[bph-integrity] UNEXPLAINED changes:\n${body}`);
+  await push(`BPH catalogue: ${unexplained.length} unexplained change(s)`, body, 'high');
+}
+
+main().catch(async (err) => {
+  console.error(`[bph-integrity] fatal: ${err.message}`);
+  await push('BPH integrity check CRASHED', String(err.message), 'high');
+  process.exit(1);
+});

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -104,6 +104,10 @@
 50 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-classify-text-role.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/classify-text-role.mjs --only-missing" >> /var/log/sourcelibrary/classify-text-role.log 2>&1
 30 6 * * 0 cd /root/sourcelibrary && flock -n /tmp/sl-lang-audit.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/audit-language-mismatch.mjs --flag" >> /var/log/sourcelibrary/lang-audit.log 2>&1
 0 4 * * * /root/sourcelibrary/scripts/workers/backup-bph-catalog.sh
+# Catalogue integrity: fingerprint every record and flag changes that no revision
+# and no known automation explains. Runs after the 04:00 backup and before restic
+# at 05:00, so a flagged night is preserved in that night's snapshot.
+30 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-bph-integrity.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/bph-integrity-check.mjs" >> /var/log/sourcelibrary/bph-integrity.log 2>&1
 30 2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-work-id-mint.lock bash -c "set -a; source .env.production.local; set +a; node scripts/analysis/mint-local-work-ids.mjs --apply --include-anon --include-parts --include-hidden && node scripts/analysis/assign-work-slugs.mjs --apply" >> /var/log/sourcelibrary/work-id-mint.log 2>&1
 # Refresh book locations[] (publication/author/tradition) before the map-cache rebuild at 05:45
 15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-geocode.lock bash -c "set -a; source .env.production.local; set +a; node scripts/enrichment/geocode-publication-places.mjs && node scripts/enrichment/backfill-author-locations.mjs --write-books && node scripts/enrichment/geocode-origin-by-tradition.mjs" >> /var/log/sourcelibrary/geocode-locations.log 2>&1


### PR DESCRIPTION
Second half of the catalogue-protection work (after #3489, which covered loss). Derek's framing was **"lose or distort or disorganize"** — three different failure modes. This one is distortion, and it's the one backups cannot help with.

## The gap

Backups answer *"can we get it back."* They do not answer **"would we know if something had been quietly altered?"** — where nothing is missing, nothing errors, and the catalogue just says something slightly different than it used to.

Only the editor path (`applyWorkRevision`) writes `bph_works_revisions`. The `sl_book_id` sync cron, the NAS ingest, format derivation, dedupe and the various backfills all write `bph_works` **directly**. Any of them could change a title or a shelf mark without leaving a trace.

Measured while building this:

- **20,093 revisions exist — 46 of them human** (34 José, 6 Paul, 6 Derek). The rest are system writes, 19,942 of which are my own `neen` sweep from two days ago.
- The catalogue's real human labour is the **29,879 records themselves**: eight named cataloguers working from **February 2017 to June 2025**, with **no per-field history at all**. The revision trail only begins in May 2026.

So for the overwhelming majority of the catalogue, "has this been altered?" was unanswerable.

## What this adds

Nightly at 04:30 — after the backup, before restic, so a flagged night is preserved in that night's snapshot — every record is fingerprinted in five column groups and each change classified:

| Verdict | Meaning |
|---|---|
| `revision` | matching `bph_works_revisions` row — accounted for |
| `automation` | only automation-owned columns moved (sl_book_id sync, IA matching, Memorix bookkeeping) — expected churn |
| `UNEXPLAINED` | anything else — pages via ntfy |

**Grouping rather than one whole-row hash is the load-bearing decision.** A single hash would flag the 6-hourly `sl_book_id` sync every single night, and an alert that fires every night is one nobody reads — the exact trap CLAUDE.md documents. Grouping separates expected churn from the fields nobody should be touching unattended.

A column not listed in the grouping **defaults to `biblio`**, so a new column added years from now fails *loud* (unexplained) rather than sitting silently unwatched.

Detections append to `bph_works_integrity_events` with a `reviewed_at` / `reviewed_by` / `note` workflow, so "we looked at it and here's why it was fine" is recorded too. **That table is the artifact to show anyone who asks how we would know if their work had been altered.**

## Verified by deliberate test, not by construction

I changed a record's `remarks` directly in the database, bypassing the editor path entirely — simulating exactly the rogue-script scenario:

```
kind=changed  explanation=UNEXPLAINED  ubn=?  groups_changed=[notes]
```

The **revert was flagged too**, which is correct: any change is a change. The row was restored to its exact prior value (`NULL`), verified no residue remains, and both events are in the table marked reviewed with an explanatory note. Catalogue still reads 29,879 rows.

A scan that *fails to run* also alerts — a silent detector and an untouched catalogue look identical from the outside.

## Two type traps, recorded in the migration

- `bph_works.id` is **TEXT**, while `bph_works_revisions.id` is **uuid**. Copying the type across cost a failed apply.
- The grouping function must be `IMMUTABLE`.

## Verification

`npx tsc --noEmit` clean; unit suite green (1,031). Migration applied; baseline established at 29,879 fingerprints with 0 events on first run (it establishes a baseline rather than reporting 29,879 spurious inserts).

## Not in scope

- **Extending coverage backwards** — the 2017–2025 edits have no per-field history and never will; this establishes a baseline from today forward.
- **Making the other writers use `applyWorkRevision`** — the prevention side. Detection first, because it works regardless of which writer misbehaves, including one added next year.
- **Surfacing the cataloguers' names in the UI** — the 27,703 records carrying `modified_by_username` are currently invisible on the site. That's the "communicate it" half, and needs EFM's consent on naming staff publicly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)