### PR TITLE
fix(archive): stall timeout in archive-ocr.mjs (follow-up to #3477)

### DIFF
--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -12,6 +12,7 @@
 // Run: set -a; source .env.production.local; set +a; node scripts/workers/archive-ocr.mjs
 
 import { MongoClient } from 'mongodb';
+import { fetchWithStallTimeout } from '../lib/fetch-stall-timeout.mjs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
 import { upgradeToFullRes } from '../lib/iiif-utils.mjs';
@@ -108,17 +109,24 @@ const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary
 // UA the IA bulk archiver uses so per-provider policies are consistent.
 const USER_AGENT = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@ancientwisdomtrust.org)';
 
+// Abort only when a connection goes QUIET this long — never merely because a file
+// is big. Overridable per-run; raising it does not slow healthy fetches.
+const FETCH_STALL_MS = parseInt(process.env.ARCHIVE_STALL_TIMEOUT_MS || '60000', 10);
+
 async function downloadImage(url, retries = 2) {
   for (let attempt = 0; attempt <= retries; attempt++) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 60_000); // 60s for full-res images
     try {
-      const res = await fetch(url, {
-        signal: controller.signal,
+      // Stall timeout, not a total-duration cap. The old 60s wall-clock abort
+      // was a file-size limit in disguise: it fires on the LARGEST page in a
+      // book — the foldout, the map, the plate — while ordinary text pages
+      // sail through, and the book still reports hundreds of archived pages so
+      // nothing looks wrong. See scripts/lib/fetch-stall-timeout.mjs for the
+      // measured case (42 of 45 double-page engravings lost on one book).
+      const { res, buffer } = await fetchWithStallTimeout(url, {
+        stallMs: FETCH_STALL_MS,
         headers: { 'User-Agent': USER_AGENT, Accept: 'image/jpeg,image/png,image/*;q=0.9,*/*;q=0.1' },
       });
       if (res.status === 429 || res.status === 503) {
-        clearTimeout(timeout);
         if (attempt < retries) {
           const delay = (attempt + 1) * 3000; // 3s, 6s backoff
           await new Promise(r => setTimeout(r, delay));
@@ -126,19 +134,21 @@ async function downloadImage(url, retries = 2) {
         }
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const buffer = Buffer.from(await res.arrayBuffer());
       const mimeType = res.headers.get('content-type') || 'image/jpeg';
       return { buffer, mimeType };
     } catch (err) {
-      clearTimeout(timeout);
-      if (attempt < retries && (err.name === 'AbortError' || err.message?.includes('fetch failed'))) {
+      // A stalled fetch now reports "fetch aborted: stalled …" rather than a
+      // bare AbortError, so retry on that too — otherwise the rename silently
+      // removes a retry path that used to exist.
+      const retryable = err.name === 'AbortError'
+        || err.message?.includes('fetch failed')
+        || err.message?.includes('fetch aborted');
+      if (attempt < retries && retryable) {
         const delay = (attempt + 1) * 3000;
         await new Promise(r => setTimeout(r, delay));
         continue;
       }
       throw err;
-    } finally {
-      clearTimeout(timeout);
     }
   }
 }

--- a/tests/unit/fetch-stall-timeout.test.ts
+++ b/tests/unit/fetch-stall-timeout.test.ts
@@ -107,6 +107,19 @@ describe('fetchWithStallTimeout', () => {
     expect(res.status).toBe(429);
   });
 
+  it('prefixes abort errors with "fetch aborted" — archivers match on this to retry', async () => {
+    // archive-ocr.mjs previously retried on `err.name === 'AbortError'`. Routing
+    // through this helper replaces that with a thrown Error, so the message
+    // prefix IS the contract now: if it changes, that worker silently loses a
+    // retry path it used to have and stalls become hard failures.
+    const url = await listen((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'image/jpeg' });
+      res.write(Buffer.alloc(8, 1));
+    });
+
+    await expect(fetchWithStallTimeout(url, { stallMs: 100 })).rejects.toThrow(/^fetch aborted:/);
+  });
+
   it('enforces the absolute backstop against a connection that trickles forever', async () => {
     // Chunks forever, each inside the stall window — healthy by the stall test,
     // but it must not run unbounded.


### PR DESCRIPTION
## Why now

[#3477](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/pull/3477) converted `archive-gallica.mjs` and deliberately left the other archivers alone — I had a live reproduction only for Gallica and didn't want to blind-edit five workers. **The evidence for this one has arrived.**

Production scan of **visible** books with `pages_archived < pages_count`:

| provider | books | pages missing |
|---|---|---|
| **iiif** | **433** | **94,888** |
| gallica | 5 | 1,234 |
| leiden | 18 | 116 |
| e-rara | 21 | 79 |
| internet_archive | 6 | 41 |
| others | 4 | 24 |
| **total** | **487** | **96,382** |

98% of the gap sits on provider `iiif` — which is exactly what `archive-ocr.mjs` serves. It still carried the 60s total-duration cap, comment and all: `// 60s for full-res images`.

## The bug

A 60s abort measured from the *start* of a fetch is a file-size limit wearing a clock's costume. It fires on the largest page in a book — the foldout, the map, the plate — while ordinary text pages sail through. The book still reports hundreds of archived pages, so the loss is invisible from outside. On Thibault's *Académie de l'Espée* it cost **42 of 45 double-page engravings**.

## What this claims, and what it doesn't

The provider/gap correlation is **strong circumstantial evidence, not a demonstrated cause** for all 94,888 pages. Those pages have other plausible explanations — dead sources, 404s, provider blocks, books abandoned mid-archive. This PR removes one known, reproducible cause.

**It is not a backfill.** Nothing is re-archived by merging this; it only stops the bleeding for future runs. Re-archiving the existing gap is a separate, larger decision.

## Subtle detail worth reviewing

The old code retried on `err.name === 'AbortError'`. Routing through `fetchWithStallTimeout` throws a plain `Error` instead — so retrying on the name alone would have **silently dropped a retry path that used to exist**, turning a recoverable stall into a hard failure. The catch now also matches `fetch aborted`, and a new test pins that message prefix as the contract, since two workers depend on it.

`ARCHIVE_STALL_TIMEOUT_MS` overrides the stall window per run.

## Testing

- `npx vitest run` — 93 files / 1144 tests pass
- New case in `tests/unit/fetch-stall-timeout.test.ts` pinning the `fetch aborted:` prefix
- Existing negative control retained: the same slow-but-healthy response is shown to fail under the old total-duration cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)