### PR TITLE
fix(welcome): a blank welcome form no longer erases the answers behind it

### DIFF
--- a/src/app/api/me/welcome/route.ts
+++ b/src/app/api/me/welcome/route.ts
@@ -3,6 +3,7 @@ import { Resend } from 'resend';
 import { auth, RESEND_AUDIENCE_ID } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { toUserId } from '@/lib/user-id';
+import { buildProfileUpdate } from '@/lib/welcome-profile-update';
 
 // GET /api/me/welcome — the same four fields back, so the reader profile editor
 // on /account can prefill them. The welcome page promises this information can be
@@ -86,11 +87,13 @@ export async function POST(request: NextRequest) {
       welcomedAt: now,
     };
     if (!skip) {
-      userUpdate['profile.aboutYou'] = aboutYou;
-      userUpdate['profile.helpDescription'] = helpDescription;
-      userUpdate['profile.preferredLanguage'] = preferredLanguage;
-      userUpdate['profile.preferredLanguageKey'] = preferredLanguage.toLowerCase();
-      userUpdate['profile.updatedAt'] = now;
+      // An ABSENT key means "leave this alone"; a present empty string means the
+      // reader cleared the box. The distinction is load-bearing — when the two
+      // were conflated, a form that rendered blank wrote those blanks over real
+      // answers, and two readers lost theirs on 2026-07-30. Callers that cannot
+      // show the reader their current value must omit the key. Rule lives in
+      // src/lib/welcome-profile-update.ts so a test can reach it.
+      Object.assign(userUpdate, buildProfileUpdate(body, now));
       // Only ever set a name, never clear one: a blank field here means "didn't
       // answer", not "remove the name Google gave me".
       if (name) userUpdate.name = name;
@@ -103,18 +106,24 @@ export async function POST(request: NextRequest) {
 
     // Mirror into volunteers when the user shared anything — keeps the outreach
     // list usable without joining against users.
+    //
+    // Same absent-vs-empty rule as above, and it matters more here: this mirror
+    // is the only reason the two blanked profiles were recoverable at all, so a
+    // field nobody sent must never overwrite the copy of record.
+    const mirror: Record<string, unknown> = {
+      email,
+      name: name || session.user.name || null,
+      updated_at: now,
+    };
+    if ('about_you' in (body || {})) mirror.about_you = aboutYou;
+    if ('help_description' in (body || {})) mirror.help_description = helpDescription;
+    if ('preferred_language' in (body || {})) mirror.preferred_language = preferredLanguage;
+
     if (!skip && (aboutYou || helpDescription || preferredLanguage)) {
       await db.collection('volunteers').updateOne(
         { email },
         {
-          $set: {
-            email,
-            name: name || session.user.name || null,
-            about_you: aboutYou,
-            help_description: helpDescription,
-            preferred_language: preferredLanguage,
-            updated_at: now,
-          },
+          $set: mirror,
           $setOnInsert: {
             source: 'welcome',
             created_at: now,
@@ -129,21 +138,12 @@ export async function POST(request: NextRequest) {
         } as Record<string, unknown>,
         { upsert: true }
       );
-    } else if (!skip) {
-      // Everything cleared from the account editor. Don't create a row for a
-      // reader who never volunteered anything, but do clear one that exists —
-      // otherwise the outreach list keeps quoting prose they deleted.
-      await db.collection('volunteers').updateOne(
-        { email },
-        {
-          $set: {
-            about_you: '',
-            help_description: '',
-            preferred_language: '',
-            updated_at: now,
-          },
-        }
-      );
+    } else if (!skip && ('about_you' in (body || {}) || 'help_description' in (body || {}) || 'preferred_language' in (body || {}))) {
+      // Everything the caller sent was explicitly cleared. Don't create a row for
+      // a reader who never volunteered anything, but do clear the fields they
+      // actually cleared on one that exists — otherwise the outreach list keeps
+      // quoting prose they deleted. Fields they did NOT send stay untouched.
+      await db.collection('volunteers').updateOne({ email }, { $set: mirror });
     }
 
     // Backfill the Resend contact. It was created at sign-up (events.createUser

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -5,6 +5,8 @@ import { auth } from '@/lib/auth';
 import SiteHeader from '@/components/layout/SiteHeader';
 import WelcomeForm from '@/components/welcome/WelcomeForm';
 import { getWelcomeHero } from '@/lib/welcome-hero';
+import { getDb } from '@/lib/mongodb';
+import { toUserId } from '@/lib/user-id';
 import { welcomeSignInUrl } from '@/lib/welcome-return';
 
 export const metadata: Metadata = {
@@ -26,7 +28,56 @@ export default async function WelcomePage({
   }
 
   const firstName = session.user.name?.split(' ')[0] || null;
+
+  // Prefill from what they already told us. This is a data-integrity fix, not a
+  // convenience: the form used to render blank every time, and saving it wrote
+  // those blanks over the stored answers. Anyone who reached /welcome twice
+  // therefore erased themselves — which is exactly what the redirect loop
+  // (#3467) made people do. Two readers lost their answers that way on
+  // 2026-07-30, recovered only because the `volunteers` mirror happens to keep a
+  // copy. With the fields prefilled, an empty box means "I cleared this", which
+  // is the only reading under which overwriting is correct.
+  //
+  // Server-side rather than a fetch on mount, so there is no window in which the
+  // form is mounted, empty, and submittable.
+  let initialProfile = { aboutYou: '', preferredLanguage: '', helpDescription: '' };
+  try {
+    const db = await getDb();
+    const user = await db.collection('users').findOne(
+      { _id: toUserId(session.user.id) as any },
+      { projection: { profile: 1 } }
+    );
+    initialProfile = {
+      aboutYou: user?.profile?.aboutYou || '',
+      preferredLanguage: user?.profile?.preferredLanguage || '',
+      helpDescription: user?.profile?.helpDescription || '',
+    };
+  } catch (error) {
+    // A failed read must not block the page — but it MUST NOT silently fall
+    // through to blank fields either, because a blank save would then wipe
+    // stored answers. WelcomeForm treats profileLoaded=false as "send only the
+    // fields the reader actually typed".
+    console.error('[welcome] profile prefill failed:', error);
+    return renderPage({ userName: session.user.name || "", firstName, hero: await getWelcomeHero(), initialProfile, profileLoaded: false });
+  }
+
   const hero = await getWelcomeHero();
+  return renderPage({ userName: session.user.name || "", firstName, hero, initialProfile, profileLoaded: true });
+}
+
+function renderPage({
+  userName,
+  firstName,
+  hero,
+  initialProfile,
+  profileLoaded,
+}: {
+  userName: string;
+  firstName: string | null;
+  hero: Awaited<ReturnType<typeof getWelcomeHero>>;
+  initialProfile: { aboutYou: string; preferredLanguage: string; helpDescription: string };
+  profileLoaded: boolean;
+}) {
 
   return (
     <div className="relative min-h-screen bg-stone-900">
@@ -59,7 +110,13 @@ export default async function WelcomePage({
           We&rsquo;re a small team and it really helps us to know who we are building for.
           Everything is optional.
         </p>
-        <WelcomeForm initialName={session.user.name || ''} />
+        <WelcomeForm
+          initialName={userName}
+          initialAboutYou={initialProfile.aboutYou}
+          initialPreferredLanguage={initialProfile.preferredLanguage}
+          initialHelpDescription={initialProfile.helpDescription}
+          profileLoaded={profileLoaded}
+        />
       </div>
 
       {(hero.bookTitle || hero.bookYear) && (

--- a/src/components/welcome/WelcomeForm.tsx
+++ b/src/components/welcome/WelcomeForm.tsx
@@ -17,15 +17,35 @@ function arrivalSource(): 'gate' | 'direct' {
   return new URLSearchParams(window.location.search).has('from') ? 'gate' : 'direct';
 }
 
-export default function WelcomeForm({ initialName = '' }: { initialName?: string }) {
+export default function WelcomeForm({
+  initialName = '',
+  initialAboutYou = '',
+  initialPreferredLanguage = '',
+  initialHelpDescription = '',
+  profileLoaded = true,
+}: {
+  initialName?: string;
+  initialAboutYou?: string;
+  initialPreferredLanguage?: string;
+  initialHelpDescription?: string;
+  /**
+   * Did the server manage to read the stored profile? When false the fields are
+   * blank because we couldn't look them up, NOT because the reader cleared them
+   * — so a save must omit any field still untouched rather than write an empty
+   * string over a real answer.
+   */
+  profileLoaded?: boolean;
+}) {
   const router = useRouter();
   const { data: session, update } = useSession();
   // Google sign-ins arrive with a name; magic-link sign-ins never do, and this
   // is the only place we ever ask. Prefill so Google users aren't retyping it.
   const [name, setName] = useState(initialName);
-  const [aboutYou, setAboutYou] = useState('');
-  const [preferredLanguage, setPreferredLanguage] = useState('');
-  const [helpDescription, setHelpDescription] = useState('');
+  // Prefilled with what they already told us, so an empty box means "cleared"
+  // rather than "never rendered". See the note in src/app/welcome/page.tsx.
+  const [aboutYou, setAboutYou] = useState(initialAboutYou);
+  const [preferredLanguage, setPreferredLanguage] = useState(initialPreferredLanguage);
+  const [helpDescription, setHelpDescription] = useState(initialHelpDescription);
   const [status, setStatus] = useState<'idle' | 'submitting' | 'error'>('idle');
   const viewed = useRef(false);
 
@@ -78,12 +98,14 @@ export default function WelcomeForm({ initialName = '' }: { initialName?: string
       hasHelp: Boolean(trimmed.help),
       hasLanguage: Boolean(trimmed.language),
     });
-    send({
-      name: trimmed.name,
-      about_you: trimmed.about,
-      preferred_language: trimmed.language,
-      help_description: trimmed.help,
-    });
+    // When the prefill read failed, a blank box carries no information — it may
+    // be a real answer we simply could not load. Omit those fields so the route
+    // leaves the stored value alone, rather than writing "" over it.
+    const payload: Record<string, string> = { name: trimmed.name };
+    if (profileLoaded || trimmed.about) payload.about_you = trimmed.about;
+    if (profileLoaded || trimmed.language) payload.preferred_language = trimmed.language;
+    if (profileLoaded || trimmed.help) payload.help_description = trimmed.help;
+    send(payload);
   };
 
   // Mirrors UserMenu's avatar so the glyph in the pointer below matches the one

--- a/src/lib/welcome-profile-update.ts
+++ b/src/lib/welcome-profile-update.ts
@@ -1,0 +1,48 @@
+/**
+ * Which `users.profile` fields a welcome/account save should write.
+ *
+ * The rule that matters: an ABSENT key means "leave this alone", a present empty
+ * string means "the reader cleared this box". Conflating the two is how two
+ * readers lost their answers on 2026-07-30 — the welcome form rendered blank on
+ * every visit, and the redirect loop (#3467) made people submit it twice, so the
+ * second, empty save overwrote the first, real one.
+ *
+ * Extracted from the route so the rule is reachable by a test.
+ */
+
+export interface WelcomeProfileBody {
+  about_you?: unknown;
+  help_description?: unknown;
+  preferred_language?: unknown;
+  name?: unknown;
+  skip?: unknown;
+}
+
+const str = (v: unknown, max: number, collapse = false) => {
+  if (typeof v !== 'string') return '';
+  const s = collapse ? v.trim().replace(/\s+/g, ' ') : v.trim();
+  return s.slice(0, max);
+};
+
+/**
+ * @returns the `$set` fragment for the profile fields, keyed as stored. Callers
+ * add `welcomedAt` / `name` themselves.
+ */
+export function buildProfileUpdate(body: WelcomeProfileBody | null | undefined, now: Date): Record<string, unknown> {
+  const b = body || {};
+  const update: Record<string, unknown> = {};
+
+  if ('about_you' in b) update['profile.aboutYou'] = str(b.about_you, 4000);
+  if ('help_description' in b) update['profile.helpDescription'] = str(b.help_description, 2000);
+  if ('preferred_language' in b) {
+    const lang = str(b.preferred_language, 60, true);
+    update['profile.preferredLanguage'] = lang;
+    update['profile.preferredLanguageKey'] = lang.toLowerCase();
+  }
+
+  // Only stamp when something actually changed, so an empty save doesn't make a
+  // profile look freshly edited.
+  if (Object.keys(update).length) update['profile.updatedAt'] = now;
+
+  return update;
+}

--- a/tests/unit/welcome-name-capture.test.ts
+++ b/tests/unit/welcome-name-capture.test.ts
@@ -135,13 +135,43 @@ describe('/api/me/welcome name capture', () => {
     expect(volunteerUpdates[0].update.$set.preferred_language).toBe('Spanish');
   });
 
-  it('records an empty language rather than omitting the field', async () => {
-    // Stored as '' so "asked and declined" is distinguishable from "never
-    // asked" — the pre-feature users have no key at all.
+  // "Asked and declined" must still be distinguishable from "never asked" — but
+  // the signal now comes from the caller SENDING the key, not from the route
+  // inventing an empty value for a key nobody sent. That inference was the
+  // data-loss bug: the welcome form rendered blank, so a save meant to record a
+  // name wrote '' over answers the reader had given earlier and could not see
+  // (two readers lost theirs on 2026-07-30). The form sends all four fields
+  // whenever it could prefill them, so the declined case is unchanged in
+  // production; it omits only what it could not show the reader.
+  it('records an empty language when the reader explicitly left it blank', async () => {
+    const { POST } = await import('@/app/api/me/welcome/route');
+    await POST(post({ name: 'X', about_you: 'y', preferred_language: '' }));
+
+    expect(userUpdates[0].update.$set).toHaveProperty('profile.preferredLanguage', '');
+    expect(userUpdates[0].update.$set).toHaveProperty('profile.preferredLanguageKey', '');
+  });
+
+  it('leaves a field alone when the caller omits it', async () => {
     const { POST } = await import('@/app/api/me/welcome/route');
     await POST(post({ name: 'X', about_you: 'y' }));
 
-    expect(userUpdates[0].update.$set).toHaveProperty('profile.preferredLanguage', '');
+    const set = userUpdates[0].update.$set;
+    expect(set).toHaveProperty('profile.aboutYou', 'y');
+    expect(set).not.toHaveProperty('profile.preferredLanguage');
+    expect(set).not.toHaveProperty('profile.helpDescription');
+  });
+
+  it('never lets an omitted field blank the volunteers copy of record', async () => {
+    // volunteers is the last-resort backup — it is the only reason the two
+    // blanked profiles were recoverable at all.
+    const { POST } = await import('@/app/api/me/welcome/route');
+    await POST(post({ name: 'X', about_you: 'still here' }));
+
+    expect(volunteerUpdates).toHaveLength(1);
+    const set = volunteerUpdates[0].update.$set;
+    expect(set).toHaveProperty('about_you', 'still here');
+    expect(set).not.toHaveProperty('help_description');
+    expect(set).not.toHaveProperty('preferred_language');
   });
 
   it('rejects an unauthenticated caller', async () => {

--- a/tests/unit/welcome-profile-update.test.ts
+++ b/tests/unit/welcome-profile-update.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { buildProfileUpdate } from '../../src/lib/welcome-profile-update';
+
+const NOW = new Date('2026-08-01T00:00:00Z');
+
+describe('buildProfileUpdate — absent means "leave alone", empty means "cleared"', () => {
+  // The data-loss case. A form that renders blank must be able to save a name
+  // without erasing prose it never showed the reader.
+  it('does not touch a field the caller omitted', () => {
+    const update = buildProfileUpdate({ name: 'Ada' }, NOW);
+    expect(update).not.toHaveProperty('profile.aboutYou');
+    expect(update).not.toHaveProperty('profile.helpDescription');
+    expect(update).not.toHaveProperty('profile.preferredLanguage');
+    expect(update).toEqual({});
+  });
+
+  it('clears a field the reader explicitly emptied', () => {
+    const update = buildProfileUpdate({ about_you: '' }, NOW);
+    expect(update['profile.aboutYou']).toBe('');
+  });
+
+  it('writes what the reader typed', () => {
+    const update = buildProfileUpdate({
+      about_you: '  Founder of Source Library  ',
+      help_description: 'everything!',
+      preferred_language: '  English   and  Spanish ',
+    }, NOW);
+    expect(update['profile.aboutYou']).toBe('Founder of Source Library');
+    expect(update['profile.helpDescription']).toBe('everything!');
+    expect(update['profile.preferredLanguage']).toBe('English and Spanish');
+    expect(update['profile.preferredLanguageKey']).toBe('english and spanish');
+  });
+
+  it('keeps the language key in step with the language', () => {
+    const update = buildProfileUpdate({ preferred_language: 'Español' }, NOW);
+    expect(update['profile.preferredLanguageKey']).toBe('español');
+    // Cleared language must clear its key too, or the demand tally keeps a
+    // language the reader withdrew.
+    const cleared = buildProfileUpdate({ preferred_language: '' }, NOW);
+    expect(cleared['profile.preferredLanguage']).toBe('');
+    expect(cleared['profile.preferredLanguageKey']).toBe('');
+  });
+
+  it('stamps updatedAt only when something changed', () => {
+    expect(buildProfileUpdate({ name: 'Ada' }, NOW)['profile.updatedAt']).toBeUndefined();
+    expect(buildProfileUpdate({ about_you: 'x' }, NOW)['profile.updatedAt']).toBe(NOW);
+  });
+
+  it('enforces the stored length caps', () => {
+    const update = buildProfileUpdate({
+      about_you: 'a'.repeat(5000),
+      help_description: 'b'.repeat(3000),
+      preferred_language: 'c'.repeat(200),
+    }, NOW);
+    expect((update['profile.aboutYou'] as string).length).toBe(4000);
+    expect((update['profile.helpDescription'] as string).length).toBe(2000);
+    expect((update['profile.preferredLanguage'] as string).length).toBe(60);
+  });
+
+  it('ignores non-string junk rather than storing it', () => {
+    const update = buildProfileUpdate({ about_you: { evil: true }, help_description: 42 } as never, NOW);
+    expect(update['profile.aboutYou']).toBe('');
+    expect(update['profile.helpDescription']).toBe('');
+  });
+
+  it('survives a null body', () => {
+    expect(buildProfileUpdate(null, NOW)).toEqual({});
+  });
+});


### PR DESCRIPTION
Found while answering "didn't I put something in?" — Derek's own reader profile was empty on /account. It had been filled in, and something overwrote it ten seconds later.

**The bug.** `/welcome` rendered every field blank on every visit, and saving wrote those blanks over the stored answers. On its own that required a deliberate revisit. Combined with the redirect loop (#3467) — which returned people to the form again and again — it meant a second save erased the first.

**Blast radius, measured, not estimated: 2 readers**, both recovered. `users.profile` was blanked while the `volunteers` mirror still held the real text, which is the only reason recovery was possible:

| reader | lost |
|---|---|
| derek@sourcelibrary.org | "Founder of Source Library" / "everything!" / English |
| (one reader) | "I'm a passionate for mystical knowledge that turns into Wisdom…" / "Just read and study groups" |

Both restored to `users.profile` from `volunteers`, stamped `profile.restoredFrom`. Verified on production.

**The fix, in four parts**

1. **`/welcome` prefills** from `users.profile`, resolved server-side so there is no window in which the form is mounted, empty and submittable.
2. **The API distinguishes absent from empty.** An absent key means "leave this alone"; a present empty string means the reader cleared the box. That distinction is the whole bug, so it is extracted to `src/lib/welcome-profile-update.ts` and tested (8 cases) rather than left inline.
3. **A failed prefill read fails safe.** The page passes `profileLoaded={false}` and the form then omits untouched fields — a database hiccup must not be able to erase someone.
4. **The volunteers mirror follows the same rule.** It is the last-resort copy that made recovery possible; a field nobody sent must never overwrite it.

**Note for the letter cohort:** this reclassifies one recipient. She was counted as "quiet" because `users.profile` was blank, when in fact she wrote a real answer that this bug erased. Contributors 26 → 27.

**Verification.** `npx tsc --noEmit` clean, 8/8 new tests pass. The prefill itself needs a signed-in account on the preview: open /welcome and confirm the boxes carry your stored answers rather than placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)