### PR TITLE
feat(bph-catalog): a workspace for the librarians — their work, their worklist

### DIFF
--- a/scripts/migration/add-bph-worklist-rpc.sql
+++ b/scripts/migration/add-bph-worklist-rpc.sql
@@ -1,0 +1,128 @@
+-- The librarian's worklist: what in the catalogue actually needs a human.
+--
+-- Feeds /catalog/workspace. Computed live rather than stored, so it can never
+-- go stale, and kept in SQL rather than assembled from a dozen PostgREST calls
+-- so the *definitions* live in one auditable place.
+--
+-- THE POINT OF THIS FILE IS THE DEFINITIONS, NOT THE SQL. A worklist shown to
+-- someone who has catalogued this collection for eight years has to be right;
+-- a list of things that are not actually wrong reads as "this system does not
+-- understand my collection", and she will stop opening it. Two naive queries
+-- were measured and rejected on 2026-08-01:
+--
+--   "1,047 records have no title" — FALSE. 812 are manuscripts, and 663 of
+--   those carry full_title instead; manuscripts are described in a different
+--   field by design. Genuinely nameless: 320.
+--
+--   "2,260 duplicate shelf marks / 25,738 records" — FALSE. shelf_mark is a
+--   location and class code, not an identifier: 1,867 books legitimately share
+--   "M", 1,383 share "A". There are ZERO duplicate UBNs, which is the
+--   identifier that actually has to be unique.
+--
+-- So each category below is scoped to something a librarian would genuinely
+-- act on, and every one carries samples so the number is never just a number.
+--
+-- Run via Supabase SQL editor or psql:
+--   psql "$DATABASE_URL" -f scripts/migration/add-bph-worklist-rpc.sql
+
+BEGIN;
+
+-- Any of the four title columns counts as "described". Used by several
+-- categories, so it lives in one place.
+CREATE OR REPLACE FUNCTION public.bph_any_title(r bph_works)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT COALESCE(
+    NULLIF(TRIM(r.title), ''),
+    NULLIF(TRIM(r.full_title), ''),
+    NULLIF(TRIM(r.uniform_title), ''),
+    NULLIF(TRIM(r.parallel_title), '')
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION public.bph_catalogue_worklist()
+RETURNS TABLE (category text, label text, detail text, n bigint, samples jsonb)
+LANGUAGE sql STABLE AS $$
+  -- Real physical objects, on a shelf, with no name and no catalogue number.
+  -- The most interesting rows in the catalogue and currently invisible.
+  SELECT 'undescribed_manuscripts',
+         'Manuscripts on the shelf with no title and no UBN',
+         'Real objects we hold and can locate, but which the catalogue barely describes. Each needs a title and a number.',
+         count(*),
+         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'id', id, 'shelf_mark', shelf_mark, 'hint', present_location)
+                  ORDER BY shelf_mark) FILTER (WHERE rn <= 25), '[]'::jsonb)
+  FROM (
+    SELECT w.*, row_number() OVER (ORDER BY w.shelf_mark) rn
+    FROM bph_works w
+    WHERE w.record_type = 'manuscript'
+      AND public.bph_any_title(w) IS NULL
+      AND w.shelf_mark IS NOT NULL
+      AND w.ubn IS NULL
+  ) t
+
+  UNION ALL
+
+  -- Near-empty printed records: no title, no shelf mark, no number. Almost
+  -- certainly import residue rather than books — but only a librarian can say
+  -- whether they are deletable, so they are surfaced, never cleaned up.
+  SELECT 'empty_printed_stubs',
+         'Printed records with no title, shelf mark or UBN',
+         'Probably residue from an old import rather than real holdings. Needs a decision: complete them, or remove them.',
+         count(*),
+         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'id', id, 'shelf_mark', shelf_mark, 'hint', author)
+                  ORDER BY id) FILTER (WHERE rn <= 25), '[]'::jsonb)
+  FROM (
+    SELECT w.*, row_number() OVER (ORDER BY w.id) rn
+    FROM bph_works w
+    WHERE w.record_type = 'printed'
+      AND public.bph_any_title(w) IS NULL
+      AND w.shelf_mark IS NULL
+      AND w.ubn IS NULL
+  ) t
+
+  UNION ALL
+
+  -- No catalogue number at all. Findable by title, never by number — which is
+  -- how the BPH actually works day to day.
+  SELECT 'missing_ubn',
+         'Records with no UBN',
+         'These cannot be found by catalogue number, only by title. Mostly photocopies and manuscripts.',
+         count(*),
+         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'id', id, 'shelf_mark', shelf_mark, 'hint', any_title)
+                  ORDER BY id) FILTER (WHERE rn <= 25), '[]'::jsonb)
+  FROM (
+    SELECT w.*, public.bph_any_title(w) AS any_title, row_number() OVER (ORDER BY w.id) rn
+    FROM bph_works w WHERE w.ubn IS NULL
+  ) t
+
+  UNION ALL
+
+  -- The other half of the "neen" cleanup, deliberately left for a librarian:
+  -- emptying "ja" would destroy the only trace that these copies ARE on loan.
+  SELECT 'state_shelfmark_ja',
+         'State Collection shelf mark still reads "ja"',
+         'Same import fault as the "neen" values that were cleared on 30 July. Emptying these would lose the only record that the copy IS on loan from the State Collection, so it needs your decision.',
+         count(*),
+         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'id', id, 'shelf_mark', shelf_mark, 'hint', any_title)
+                  ORDER BY ubn) FILTER (WHERE rn <= 25), '[]'::jsonb)
+  FROM (
+    SELECT w.*, public.bph_any_title(w) AS any_title, row_number() OVER (ORDER BY w.ubn) rn
+    FROM bph_works w WHERE lower(trim(w.state_shelf_mark)) = 'ja'
+  ) t
+
+  UNION ALL
+
+  -- Contributor proposals waiting on an editor. Empty today; the queue exists
+  -- and someone has to be told when it is not.
+  SELECT 'pending_contributions',
+         'Suggested changes awaiting review',
+         'Corrections proposed by contributors that need an editor to accept or decline.',
+         count(*),
+         COALESCE(jsonb_agg(jsonb_build_object('ubn', ubn, 'id', id::text, 'shelf_mark', NULL, 'hint', proposer_email)
+                  ORDER BY created_at) FILTER (WHERE rn <= 25), '[]'::jsonb)
+  FROM (
+    SELECT p.*, row_number() OVER (ORDER BY p.created_at) rn
+    FROM bph_works_pending_changes p WHERE p.status = 'pending'
+  ) t
+$$;
+
+COMMIT;

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -454,6 +454,12 @@ export default async function CatalogEntryPage({ params }: Props) {
             {showReviewLink && (
               <>
                 <a
+                  href="/catalog/workspace"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
+                >
+                  My work
+                </a>
+                <a
                   href="/catalog/new"
                   className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
                 >

--- a/src/app/embed/[tenant]/catalog/workspace/page.tsx
+++ b/src/app/embed/[tenant]/catalog/workspace/page.tsx
@@ -1,0 +1,311 @@
+import { notFound, redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { auth } from '@/lib/auth';
+import { ROLE_LEVEL, type Role } from '@/lib/auth';
+import { getDb } from '@/lib/mongodb';
+import { supabaseAdmin } from '@/lib/supabase';
+import { memorixAliasesFor } from '@/lib/bph-cataloguer-identity';
+
+/**
+ * The librarian's workspace: your work, what needs attention, what changed.
+ *
+ * Built for the people who keep this catalogue rather than the people who read
+ * it, and it answers the three questions they actually have:
+ *
+ *   1. IS MY WORK HELD AND ATTRIBUTED? Eight cataloguers have been describing
+ *      this collection since 2017 and the site showed no sign any of them
+ *      existed. Nothing else here matters if that stays true.
+ *   2. WHAT NEEDS ME? A catalogue of 29,879 records has no natural surface for
+ *      "the 86 manuscripts on your shelves that nobody has ever titled".
+ *   3. WHAT HAS BEEN DONE TO IT? Automation edits this catalogue. A librarian
+ *      should be able to read what it did, in plain words, without asking.
+ *
+ * Editor-only and fully dynamic (reads the session), so nothing here is cached
+ * for anyone else.
+ */
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Catalogue workspace — BPH',
+  robots: { index: false, follow: false },
+};
+
+interface Props {
+  params: Promise<{ tenant: string }>;
+}
+
+function normalizeRole(role: unknown): Role {
+  if (
+    role === 'superadmin' || role === 'admin' || role === 'editor' ||
+    role === 'contributor' || role === 'reader'
+  ) return role;
+  if (role === 'inner_circle' || role === 'curator') return 'editor';
+  return 'reader';
+}
+
+async function effectiveTenantRole(email: string | null | undefined, tenantSlug: string): Promise<Role> {
+  if (!email) return 'reader';
+  try {
+    const db = await getDb();
+    const tenant = await db.collection('tenants').findOne({ slug: tenantSlug, status: { $ne: 'deleted' } });
+    if (!tenant) return 'reader';
+    const membership = await db.collection('memberships').findOne({
+      email: email.toLowerCase(), tenantId: tenant.id, status: 'active',
+    });
+    return normalizeRole(membership?.role);
+  } catch {
+    return 'reader';
+  }
+}
+
+interface WorklistRow {
+  category: string;
+  label: string;
+  detail: string;
+  n: number;
+  samples: Array<{ ubn: string | null; id: string; shelf_mark: string | null; hint: string | null }>;
+}
+
+interface RevisionRow {
+  id: string;
+  ubn: string;
+  change_type: string;
+  field_changes: Record<string, { from?: unknown; to?: unknown; source?: string }>;
+  editor_email: string;
+  applied_at: string;
+  note: string | null;
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  state_shelf_mark: 'State Collection shelf mark',
+  shelf_mark: 'Shelf mark',
+  present_location: 'Present location',
+  internal_remarks: 'Internal remarks',
+  exhibition_history: 'Exhibition history',
+  impressum_original: 'Original impressum',
+  bibliographic_format: 'Format',
+  number_of_copies: 'Copies held',
+  ustc_sn: 'USTC number',
+  ia_identifier: 'Internet Archive id',
+};
+const fieldLabel = (f: string) =>
+  FIELD_LABELS[f] || f.replace(/_/g, ' ').replace(/^./, (c) => c.toUpperCase());
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+/** "19,942" reads better than 19942 to someone counting their own records. */
+const n = (x: number | null | undefined) => (x ?? 0).toLocaleString('en-GB');
+
+export default async function CatalogueWorkspacePage({ params }: Props) {
+  const { tenant } = await params;
+  if (tenant !== 'bph') notFound();
+
+  const session = await auth();
+  if (!session?.user) redirect(`/${tenant}/login?callbackUrl=/catalog/workspace`);
+
+  const platformRole = normalizeRole((session.user as { role?: unknown }).role);
+  const tenantRole = await effectiveTenantRole(session.user.email, tenant);
+  const role = ROLE_LEVEL[platformRole] >= ROLE_LEVEL[tenantRole] ? platformRole : tenantRole;
+  if (ROLE_LEVEL[role] < ROLE_LEVEL['editor']) redirect('/catalog');
+
+  const email = (session.user.email || '').toLowerCase();
+  const aliases = memorixAliasesFor(email);
+
+  if (!supabaseAdmin) notFound();
+
+  // bph_works_revisions is RLS-protected; read with the service-role client
+  // (this page is already editor-gated above).
+  const [worklistRes, myRevisionsRes, recentRes, integrityRes, memorixRes] = await Promise.all([
+    supabaseAdmin.rpc('bph_catalogue_worklist'),
+    supabaseAdmin
+      .from('bph_works_revisions')
+      .select('id, ubn, change_type, field_changes, editor_email, applied_at, note')
+      .eq('editor_email', email)
+      .order('applied_at', { ascending: false })
+      .limit(40),
+    supabaseAdmin
+      .from('bph_works_revisions')
+      .select('id, ubn, change_type, field_changes, editor_email, applied_at, note')
+      .order('applied_at', { ascending: false })
+      .limit(25),
+    supabaseAdmin
+      .from('bph_works_integrity')
+      .select('last_checked')
+      .order('last_checked', { ascending: false })
+      .limit(1),
+    aliases.length
+      ? supabaseAdmin
+          .from('bph_works')
+          .select('modified_time', { count: 'exact' })
+          .in('modified_by_email', aliases)
+          .order('modified_time', { ascending: true })
+          .limit(1)
+      : Promise.resolve({ data: null, count: 0, error: null }),
+  ]);
+
+  const worklist = ((worklistRes.data as WorklistRow[] | null) || []).filter((w) => w.n > 0);
+  const myRevisions = (myRevisionsRes.data as RevisionRow[] | null) || [];
+  const recent = (recentRes.data as RevisionRow[] | null) || [];
+  const lastChecked = (integrityRes.data as { last_checked: string }[] | null)?.[0]?.last_checked || null;
+
+  const memorixCount = (memorixRes as { count?: number | null }).count || 0;
+  const memorixFirst = (memorixRes as { data?: { modified_time: string }[] | null }).data?.[0]?.modified_time || null;
+  let memorixLast: string | null = null;
+  if (memorixCount > 0 && aliases.length) {
+    const { data } = await supabaseAdmin
+      .from('bph_works')
+      .select('modified_time')
+      .in('modified_by_email', aliases)
+      .order('modified_time', { ascending: false })
+      .limit(1);
+    memorixLast = (data as { modified_time: string }[] | null)?.[0]?.modified_time || null;
+  }
+
+  const totalAttention = worklist.reduce((s, w) => s + Number(w.n), 0);
+
+  return (
+    <div className="bg-cream min-h-screen">
+      <div className="max-w-3xl mx-auto px-6 py-8">
+        <a href="/catalog" className="inline-flex items-center text-sm text-muted hover:text-primary mb-4 transition-colors">
+          ← Back to catalogue
+        </a>
+
+        <h1 className="text-2xl sm:text-3xl text-primary font-display leading-tight mb-1">
+          Catalogue workspace
+        </h1>
+        <p className="text-sm text-muted mb-8">
+          Signed in as {session.user.email}
+          {lastChecked && (
+            <>
+              {' · '}
+              <span title="Every record is fingerprinted nightly; changes that no revision or known automation explains raise an alert.">
+                all changes accounted for as of {formatDate(lastChecked)}
+              </span>
+            </>
+          )}
+        </p>
+
+        {/* 1. Your work — the reason this page exists. */}
+        <section className="mb-10">
+          <h2 className="text-lg text-primary font-display mb-3">Your work</h2>
+          <div className="border border-stone-200 bg-white p-5">
+            {memorixCount > 0 ? (
+              <p className="text-primary mb-3">
+                <strong>{n(memorixCount)} records</strong> in this catalogue were last catalogued by you
+                {memorixFirst && memorixLast && (
+                  <>, between {formatDate(memorixFirst)} and {formatDate(memorixLast)}</>
+                )}
+                .
+              </p>
+            ) : (
+              <p className="text-muted mb-3">
+                No earlier cataloguing is linked to this account. If you catalogued under a different
+                address, tell us and we can connect it.
+              </p>
+            )}
+            <p className="text-primary">
+              <strong>{n(myRevisions.length)}{myRevisions.length === 40 ? '+' : ''} changes</strong> made
+              here on Source Library, each kept with the source you cited. Nothing is ever overwritten:
+              corrections are recorded as new entries, so the whole history stays readable.
+            </p>
+
+            {myRevisions.length > 0 && (
+              <ul className="mt-4 divide-y divide-stone-100 border-t border-stone-100">
+                {myRevisions.slice(0, 10).map((r) => {
+                  const fields = Object.keys(r.field_changes || {});
+                  const source = Object.values(r.field_changes || {}).find((c) => c?.source)?.source;
+                  return (
+                    <li key={r.id} className="py-2.5 text-sm">
+                      <a href={`/catalog/${encodeURIComponent(r.ubn)}`} className="text-accent-rust hover:underline font-medium">
+                        {r.ubn}
+                      </a>
+                      <span className="text-muted"> · {formatDate(r.applied_at)}</span>
+                      <div className="text-primary">
+                        {r.change_type === 'create' ? 'Created this record' : fields.map(fieldLabel).join(', ')}
+                        {source && <span className="text-muted"> — cited: {source}</span>}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </section>
+
+        {/* 2. What needs a librarian. Every number links to the actual records. */}
+        <section className="mb-10">
+          <h2 className="text-lg text-primary font-display mb-1">Needs your attention</h2>
+          <p className="text-sm text-muted mb-3">
+            {totalAttention > 0
+              ? `${n(totalAttention)} records where only a librarian can decide what is right.`
+              : 'Nothing outstanding.'}
+          </p>
+
+          {worklist.map((w) => (
+            <div key={w.category} className="border border-stone-200 bg-white p-5 mb-3">
+              <div className="flex items-baseline justify-between gap-4">
+                <h3 className="text-primary font-medium">{w.label}</h3>
+                <span className="text-xl text-primary font-display shrink-0">{n(Number(w.n))}</span>
+              </div>
+              <p className="text-sm text-muted mt-1">{w.detail}</p>
+              {w.samples?.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-sm">
+                  {w.samples.slice(0, 12).map((s, i) => (
+                    <a
+                      key={`${w.category}-${s.id}-${i}`}
+                      href={`/catalog/${encodeURIComponent(s.ubn || s.id)}`}
+                      className="text-accent-rust hover:underline"
+                      title={s.hint || undefined}
+                    >
+                      {s.ubn || s.shelf_mark || s.id.slice(0, 8)}
+                    </a>
+                  ))}
+                  {Number(w.n) > 12 && <span className="text-muted">+{n(Number(w.n) - 12)} more</span>}
+                </div>
+              )}
+            </div>
+          ))}
+        </section>
+
+        {/* 3. What has been done to the catalogue, in plain words. */}
+        <section className="mb-10">
+          <h2 className="text-lg text-primary font-display mb-1">Recent changes</h2>
+          <p className="text-sm text-muted mb-3">
+            Every edit to this catalogue, by a person or by our software, with what changed and why.
+          </p>
+          <div className="border border-stone-200 bg-white divide-y divide-stone-100">
+            {recent.length === 0 && <p className="p-5 text-sm text-muted">No changes recorded yet.</p>}
+            {recent.map((r) => {
+              const fields = Object.keys(r.field_changes || {});
+              const isSystem = r.editor_email.startsWith('system:');
+              const who = isSystem ? 'Source Library (automatic)' : r.editor_email;
+              return (
+                <div key={r.id} className="p-4 text-sm">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <a href={`/catalog/${encodeURIComponent(r.ubn)}`} className="text-accent-rust hover:underline font-medium">
+                      {r.ubn}
+                    </a>
+                    <span className="text-muted shrink-0">{formatDate(r.applied_at)}</span>
+                  </div>
+                  <div className="text-primary mt-0.5">
+                    {r.change_type === 'create' ? 'Record created' : `Changed ${fields.map(fieldLabel).join(', ')}`}
+                    <span className="text-muted"> · {who}</span>
+                  </div>
+                  {r.note && <p className="text-muted mt-1">{r.note}</p>}
+                </div>
+              );
+            })}
+          </div>
+          <p className="text-xs text-muted mt-2">
+            Showing the {recent.length} most recent. Every record also has its own full history, linked
+            from the record itself.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/bph-cataloguer-identity.ts
+++ b/src/lib/bph-cataloguer-identity.ts
@@ -1,0 +1,52 @@
+/**
+ * Link a signed-in editor to the cataloguing they did before Source Library.
+ *
+ * 27,703 of the 29,879 BPH records carry `modified_by_email` /
+ * `modified_by_username` from Memorix — eight named cataloguers working from
+ * February 2017 to June 2025. That is the bulk of the human labour in the
+ * catalogue, and until now it was invisible: the columns are rendered nowhere.
+ *
+ * The catch is that the library changed domain. José's Memorix address is
+ * `jbouman@ritmanlibrary.nl`; she signs in as `jbouman@efm.amsterdam`. Same
+ * person, and nothing in the data says so. This maps between the two by local
+ * part across the library's known domains — deliberately narrow, because the
+ * consequence of a wrong match is attributing one person's work to another.
+ *
+ * Personal addresses (gmail and the like) are matched only to themselves.
+ */
+
+/** Domains the library has used for staff accounts, old and current. */
+const BPH_DOMAINS = ['efm.amsterdam', 'ritmanlibrary.nl'];
+
+/**
+ * Accounts shared by several people. Work done under these must never be
+ * attributed to whoever happens to be signed in — "BPH1" is a desk, not a
+ * person, and 7,449 records sit behind it.
+ */
+const SHARED_ACCOUNTS = new Set(['bph@ritmanlibrary.nl', 'memorix.servicedesk@vitecsoftware.com']);
+
+/** Usernames belonging to shared accounts, for the same reason. */
+export const SHARED_USERNAMES = new Set(['BPH1', 'BPH2', 'pictura']);
+
+/**
+ * Every Memorix address that plausibly belongs to this signed-in person.
+ * Empty when the account is shared — we would rather show nothing than credit
+ * one librarian with another's eight years of work.
+ */
+export function memorixAliasesFor(email: string | null | undefined): string[] {
+  if (!email) return [];
+  const normalized = email.trim().toLowerCase();
+  if (!normalized.includes('@') || SHARED_ACCOUNTS.has(normalized)) return [];
+
+  const [local, domain] = normalized.split('@');
+  if (!local || !domain) return [];
+
+  // Only bridge domains for library accounts. A personal address matches
+  // itself and nothing else: `jsmith@gmail.com` must not claim
+  // `jsmith@ritmanlibrary.nl`.
+  const aliases = BPH_DOMAINS.includes(domain)
+    ? BPH_DOMAINS.map((d) => `${local}@${d}`)
+    : [normalized];
+
+  return aliases.filter((a) => !SHARED_ACCOUNTS.has(a));
+}


### PR DESCRIPTION
The "communicate it" half of the catalogue-protection work (#3489 loss, #3492 distortion). Built for the people who *keep* this catalogue rather than the people who read it, and it answers the three questions they actually have — none of which the site could answer before.

## 1. Is my work held, and attributed to me?

**27,703 of 29,879 records carry the name of the person who catalogued them** — eight cataloguers, February 2017 to June 2025 — and those columns were rendered *nowhere*. Eight years of a team's working life sitting in the database as an unused column.

Signing in now shows: *"5,290 records in this catalogue were last catalogued by you, between 8 March 2017 and 12 June 2025"*, plus every change made here on Source Library with the source cited for each.

**The identity bridge is the delicate part.** The library changed domain: José's Memorix identity is `jbouman@ritmanlibrary.nl`, she signs in as `jbouman@efm.amsterdam`, and nothing in the data says they're the same person. `src/lib/bph-cataloguer-identity.ts` matches local parts across the library's known domains **only**:

- a personal address (`…@gmail.com`) matches itself and nothing else — `jsmith@gmail.com` must never claim `jsmith@ritmanlibrary.nl`;
- shared desks are excluded outright — `bph@ritmanlibrary.nl` (BPH1/BPH2, **7,449 records**) and `pictura` are desks, not people.

Crediting one librarian with another's eight years of work is the one failure mode worth being paranoid about here.

## 2. What needs me?

A worklist, computed live. **The definitions are the point, not the SQL.** A list of things that aren't actually wrong tells someone who has catalogued this collection for eight years that the system doesn't understand her collection — and she stops opening it. Two naive queries were measured and **rejected**:

| Naive claim | Reality |
|---|---|
| "1,047 records have no title" | **False.** 812 are manuscripts, 663 of those carry `full_title` — manuscripts are described in a different field by design. Genuinely nameless: **320**. |
| "2,260 duplicate shelf marks (25,738 records)" | **False.** `shelf_mark` is a location/class code — 1,867 books legitimately share "M", 1,383 share "A". Duplicate **UBNs**, the identifier that must be unique: **zero**. |

What survived the scrutiny:

| Category | n | Why it's real |
|---|---|---|
| Manuscripts on a shelf, no title, no UBN | **86** | Real objects we hold and can locate, barely described. The most interesting rows in the catalogue. |
| Near-empty printed stubs | **228** | Almost certainly import residue — but only a librarian can say if they're deletable, so they're surfaced, never cleaned up. |
| No UBN at all | **2,012** | Findable by title, never by number — which is how the BPH works day to day. |
| State Collection shelf mark still `"ja"` | **31** | Her pending decision from the `neen` sweep. |
| Contributor changes awaiting review | 0 | The queue exists; someone has to be told when it isn't empty. |

Every count carries sample records, so a number is never *just* a number.

## 3. What has been done to it?

Recent changes in plain words — person or software, what changed, and why — plus a header line: **"all changes accounted for as of 1 August"**, drawn from the nightly integrity scan. For someone afraid of losing this, a dated line saying nothing unexplained happened is worth more than any amount of prose about backups.

## Verification

Type-check clean; unit suite green (1,082). All three data paths exercised against **production** via PostgREST, not just reasoned about:

- worklist RPC returns all five categories with samples;
- the alias bridge resolves José → **5,290** records;
- her **34** revisions read back correctly.

Editor-gated, `force-dynamic`, reached via a "My work" link on any record alongside the existing New record / Review queue / Team buttons.

## Out of scope

- **Public attribution.** The cataloguers' names stay internal to signed-in editors until EFM consents to naming staff publicly. Nothing here is visible to visitors.
- **An entry point from the catalogue index.** Editor links currently only appear on individual records — the existing Review queue and Team links have the same limitation, so this is consistent rather than worse, but it's worth fixing for all of them together.
- **Per-field provenance for pre-May-2026 work.** Those eight years have no per-field history and never will; the workspace shows the record count, not a change history, for that period.

Tenant behaviour can't be verified on a Vercel preview (host-gated), so I'll confirm on `bph.sourcelibrary.org` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)