### PR TITLE
fix(archive): clear transient page-level failure markers so stranded pages can retry

### DIFF
--- a/scripts/lib/archive-failure-class.mjs
+++ b/scripts/lib/archive-failure-class.mjs
@@ -1,0 +1,77 @@
+/**
+ * Classify a page-level `archived_photo: "failed:…"` marker.
+ *
+ * Why this matters more than it looks:
+ *
+ * Every archiver selects work with `archived_photo` missing/null/empty. Writing
+ * a `failed:` STRING into that same field therefore makes the page invisible to
+ * every future run — the write erases its own repair path (CLAUDE.md, Data
+ * Protection). Nothing in the codebase clears these: `archive-auto-unblock.mjs`
+ * only unsets book-level `archive_metadata.*`, never the page field. So a page
+ * marked on a transient blip stays unarchived forever.
+ *
+ * Measured 2026-08-01: 14,123 pages carry a marker; a 3,000-page sample was
+ * 93.5% `HTTP 403` (provider blocking — emphatically not a statement that the
+ * page is absent), with a small genuinely-transient tail.
+ *
+ * The split below is the whole point of the module: clearing a PERMANENT marker
+ * just re-queues work that will fail again and re-mark, burning provider
+ * goodwill on a loop. Clearing a TRANSIENT one recovers a page that is still
+ * there. When a reason is unrecognised we return UNKNOWN and callers must leave
+ * it alone — an unclassified marker is not evidence of recoverability.
+ */
+
+/** Retryable: the source blocked, timed out, or the transfer broke mid-flight. */
+const TRANSIENT = [
+  /HTTP 403/i,          // provider block / rate limit — not "page absent"
+  /HTTP 429/i,
+  /HTTP 5\d\d/,         // any 5xx
+  /timeout/i,
+  /terminated/i,
+  /aborted/i,           // incl. "fetch aborted: stalled …" from the stall timeout
+  /fetch failed/i,
+  /ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang up/i,
+  /premature end of JPEG|VipsJpeg|Input buffer contains unsupported image format/i,
+];
+
+/** Permanent: the source is telling us this page does not exist. Never clear. */
+const PERMANENT = [
+  /HTTP 404/i,
+  /HTTP 410/i,
+  /source-not-found/i,
+  /HTTP 401/i,          // needs credentials we do not have; retrying changes nothing
+];
+
+export const FAILURE_CLASS = {
+  TRANSIENT: 'transient',
+  PERMANENT: 'permanent',
+  UNKNOWN: 'unknown',
+};
+
+/**
+ * @param {string|null|undefined} archivedPhoto the raw field value
+ * @returns {{ isMarker: boolean, class: string, reason: string|null }}
+ */
+export function classifyArchiveFailure(archivedPhoto) {
+  if (typeof archivedPhoto !== 'string' || !archivedPhoto.startsWith('failed:')) {
+    return { isMarker: false, class: null, reason: null };
+  }
+  const reason = archivedPhoto.slice('failed:'.length).trim();
+
+  // Permanent wins on a tie: a marker naming both a 404 and a timeout is a page
+  // we should not keep asking for.
+  if (PERMANENT.some(re => re.test(reason))) {
+    return { isMarker: true, class: FAILURE_CLASS.PERMANENT, reason };
+  }
+  if (TRANSIENT.some(re => re.test(reason))) {
+    return { isMarker: true, class: FAILURE_CLASS.TRANSIENT, reason };
+  }
+  return { isMarker: true, class: FAILURE_CLASS.UNKNOWN, reason };
+}
+
+/** Group key for reporting — digits collapsed so counts aggregate sensibly. */
+export function failureReasonKey(archivedPhoto) {
+  const { reason } = classifyArchiveFailure(archivedPhoto);
+  if (!reason) return null;
+  return reason.replace(/\d+/g, 'N').slice(0, 60);
+}

--- a/scripts/lib/archive-failure-class.mjs
+++ b/scripts/lib/archive-failure-class.mjs
@@ -69,9 +69,22 @@ export function classifyArchiveFailure(archivedPhoto) {
   return { isMarker: true, class: FAILURE_CLASS.UNKNOWN, reason };
 }
 
-/** Group key for reporting — digits collapsed so counts aggregate sensibly. */
+/**
+ * Group key for reporting — incidental digits collapsed so counts aggregate,
+ * but HTTP status codes PRESERVED.
+ *
+ * Collapsing every digit reported `2438  HTTP N`, merging 403 (retryable) with
+ * 404 (permanent) into one row — hiding the single distinction this whole
+ * module exists to make, in the very output an operator reads before running
+ * with --apply. Incidental counts ("gallica has only 45 pages") still collapse,
+ * because those genuinely are noise.
+ */
 export function failureReasonKey(archivedPhoto) {
   const { reason } = classifyArchiveFailure(archivedPhoto);
   if (!reason) return null;
-  return reason.replace(/\d+/g, 'N').slice(0, 60);
+  return reason
+    .split(/(HTTP \d{3})/)
+    .map(part => (/^HTTP \d{3}$/.test(part) ? part : part.replace(/\d+/g, 'N')))
+    .join('')
+    .slice(0, 60);
 }

--- a/scripts/maintenance/clear-transient-archive-failures.mjs
+++ b/scripts/maintenance/clear-transient-archive-failures.mjs
@@ -78,9 +78,21 @@ async function main() {
     .find(query, { projection: { _id: 1, book_id: 1, page_number: 1, archived_photo: 1 } })
     .batchSize(500);
 
+  // `archived_photo` is unindexed, so this is a collection scan over ~18.9M
+  // pages and a full pass takes many minutes. Without a heartbeat the run is
+  // silent the whole time and looks hung — two earlier runs were killed for
+  // exactly that reason before producing any output.
+  const t0 = Date.now();
+  let nextTick = 500;
+
   for await (const page of cursor) {
     scanned++;
     if (scanned > LIMIT) break;
+    if (scanned >= nextTick) {
+      nextTick += 500;
+      const secs = ((Date.now() - t0) / 1000).toFixed(0);
+      process.stdout.write(`  …scanned ${scanned} markers (${secs}s)\n`);
+    }
     const { class: cls } = classifyArchiveFailure(page.archived_photo);
     byClass[cls] = (byClass[cls] || 0) + 1;
     const key = failureReasonKey(page.archived_photo);

--- a/scripts/maintenance/clear-transient-archive-failures.mjs
+++ b/scripts/maintenance/clear-transient-archive-failures.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Clear page-level `archived_photo: "failed:…"` markers so transiently-failed
+ * pages become archivable again.
+ *
+ * THE PROBLEM
+ * Archivers select work with `archived_photo` missing/null/empty. Writing a
+ * `failed:` string into that field hides the page from every future run — the
+ * bad write erases its own repair path. Nothing clears these today:
+ * `archive-auto-unblock.mjs` unsets only book-level `archive_metadata.*`.
+ * Measured 2026-08-01: 14,123 pages stranded this way.
+ *
+ * WHAT THIS DOES NOT DO
+ * It does not archive anything. It only makes pages eligible again; the normal
+ * archivers pick them up on their next run. That separation is deliberate — it
+ * keeps this script cheap, idempotent and easy to reason about, and it means a
+ * mistake here costs a re-queue rather than a bad write.
+ *
+ * SAFETY
+ *  - Dry-run by DEFAULT. `--apply` is required to write.
+ *  - Only `transient` markers are cleared (see scripts/lib/archive-failure-class.mjs).
+ *    `404` / `source-not-found` are permanent and left alone; clearing those
+ *    would re-queue work that fails again and re-marks, on a loop.
+ *  - `unknown` reasons are LEFT ALONE and reported. An unrecognised marker is
+ *    not evidence of recoverability.
+ *  - `--max-per-provider` throttles how many pages one source gets re-queued at
+ *    once, because 93.5% of markers are HTTP 403 and dumping every one back
+ *    into the queue would hammer a provider that is already refusing us.
+ *
+ * USAGE
+ *   node scripts/maintenance/clear-transient-archive-failures.mjs            # dry run, full report
+ *   node scripts/maintenance/clear-transient-archive-failures.mjs --apply
+ *   node scripts/maintenance/clear-transient-archive-failures.mjs --apply --max-per-provider=500
+ *   node scripts/maintenance/clear-transient-archive-failures.mjs --book-id=<id> --apply
+ */
+import { MongoClient } from 'mongodb';
+import { classifyArchiveFailure, failureReasonKey, FAILURE_CLASS } from '../lib/archive-failure-class.mjs';
+
+const args = process.argv.slice(2);
+const getArg = (n) => args.find(a => a.startsWith(`--${n}=`))?.split('=')[1];
+const APPLY = args.includes('--apply');
+const BOOK_ID = getArg('book-id') || null;
+const MAX_PER_PROVIDER = parseInt(getArg('max-per-provider') || '0', 10) || Infinity;
+const LIMIT = parseInt(getArg('limit') || '0', 10) || Infinity;
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('Missing MONGODB_URI'); process.exit(1); }
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI, { serverSelectionTimeoutMS: 20000 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  const query = { archived_photo: { $regex: '^failed:' } };
+  if (BOOK_ID) query.book_id = BOOK_ID;
+
+  console.log(`[clear-failures] ${APPLY ? 'APPLY' : 'DRY RUN'}${BOOK_ID ? ` book=${BOOK_ID}` : ''}` +
+    `${MAX_PER_PROVIDER !== Infinity ? ` max-per-provider=${MAX_PER_PROVIDER}` : ''}`);
+
+  // Resolve provider per book so throttling is per-source, not global.
+  const providerByBook = new Map();
+  async function providerFor(bookId) {
+    if (providerByBook.has(bookId)) return providerByBook.get(bookId);
+    const b = await db.collection('books').findOne({ id: bookId }, { projection: { 'image_source.provider': 1 } });
+    const p = b?.image_source?.provider || 'unknown';
+    providerByBook.set(bookId, p);
+    return p;
+  }
+
+  const byClass = { transient: 0, permanent: 0, unknown: 0 };
+  const byReason = {};
+  const clearedByProvider = {};
+  const seenByProvider = {};
+  const toClear = [];
+  let scanned = 0;
+
+  const cursor = db.collection('pages')
+    .find(query, { projection: { _id: 1, book_id: 1, page_number: 1, archived_photo: 1 } })
+    .batchSize(500);
+
+  for await (const page of cursor) {
+    scanned++;
+    if (scanned > LIMIT) break;
+    const { class: cls } = classifyArchiveFailure(page.archived_photo);
+    byClass[cls] = (byClass[cls] || 0) + 1;
+    const key = failureReasonKey(page.archived_photo);
+    if (key) byReason[key] = (byReason[key] || 0) + 1;
+
+    if (cls !== FAILURE_CLASS.TRANSIENT) continue;
+
+    const prov = await providerFor(page.book_id);
+    seenByProvider[prov] = (seenByProvider[prov] || 0) + 1;
+    if ((clearedByProvider[prov] || 0) >= MAX_PER_PROVIDER) continue;
+    clearedByProvider[prov] = (clearedByProvider[prov] || 0) + 1;
+    toClear.push(page._id);
+  }
+
+  console.log(`\n  scanned: ${scanned} marker pages`);
+  console.log(`  transient: ${byClass.transient}  permanent: ${byClass.permanent}  unknown: ${byClass.unknown}`);
+  console.log('\n  by reason:');
+  Object.entries(byReason).sort((a, b) => b[1] - a[1]).slice(0, 15)
+    .forEach(([k, v]) => console.log(`    ${String(v).padStart(6)}  ${k}`));
+
+  console.log('\n  eligible to clear, by provider:');
+  Object.entries(clearedByProvider).sort((a, b) => b[1] - a[1])
+    .forEach(([p, v]) => {
+      const seen = seenByProvider[p] || v;
+      const held = seen - v;
+      console.log(`    ${String(v).padStart(6)}  ${p}${held > 0 ? `  (${held} held back by --max-per-provider)` : ''}`);
+    });
+
+  if (byClass.unknown > 0) {
+    console.log(`\n  NOTE: ${byClass.unknown} marker(s) have an unrecognised reason and were LEFT ALONE.`);
+    console.log('        Add a pattern to scripts/lib/archive-failure-class.mjs if they are recoverable.');
+  }
+
+  if (!APPLY) {
+    console.log(`\n  DRY RUN — would clear ${toClear.length} page(s). Re-run with --apply.`);
+    await client.close();
+    return;
+  }
+
+  let cleared = 0;
+  for (let i = 0; i < toClear.length; i += 500) {
+    const chunk = toClear.slice(i, i + 500);
+    const res = await db.collection('pages').updateMany(
+      // Re-assert the marker in the filter: if an archiver wrote a real URL
+      // between scan and write, we must not clobber it.
+      { _id: { $in: chunk }, archived_photo: { $regex: '^failed:' } },
+      { $unset: { archived_photo: '' }, $set: { updated_at: new Date() } }
+    );
+    cleared += res.modifiedCount;
+  }
+  console.log(`\n  CLEARED ${cleared} page(s) — now eligible for the normal archivers.`);
+  console.log('  Nothing was archived by this script; the archivers do that on their next run.');
+
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/tests/unit/archive-failure-class.test.ts
+++ b/tests/unit/archive-failure-class.test.ts
@@ -75,8 +75,25 @@ describe('classifyArchiveFailure', () => {
       .toBe(FAILURE_CLASS.PERMANENT);
   });
 
-  it('collapses digits in the reporting key so counts aggregate', () => {
+  it('collapses incidental digits in the reporting key so counts aggregate', () => {
     expect(failureReasonKey('failed:source-not-found (gallica has only 45 pages)'))
       .toBe(failureReasonKey('failed:source-not-found (gallica has only 912 pages)'));
+  });
+
+  it('does NOT collapse HTTP status codes — 403 vs 404 is the whole decision', () => {
+    // Collapsing every digit printed "2438  HTTP N" in the dry-run report,
+    // merging retryable 403s with permanent 404s in the exact output an
+    // operator reads before running --apply.
+    expect(failureReasonKey('failed:HTTP 403')).toBe('HTTP 403');
+    expect(failureReasonKey('failed:HTTP 404')).toBe('HTTP 404');
+    expect(failureReasonKey('failed:HTTP 403'))
+      .not.toBe(failureReasonKey('failed:HTTP 404'));
+  });
+
+  it('preserves the status code while still collapsing surrounding noise', () => {
+    expect(failureReasonKey('failed:HTTP 403 after 5 attempts on page 214'))
+      .toBe(failureReasonKey('failed:HTTP 403 after 9 attempts on page 7'));
+    expect(failureReasonKey('failed:HTTP 403 after 5 attempts on page 214'))
+      .toContain('HTTP 403');
   });
 });

--- a/tests/unit/archive-failure-class.test.ts
+++ b/tests/unit/archive-failure-class.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Classification of page-level `archived_photo: "failed:…"` markers.
+ *
+ * The stakes are asymmetric, and the tests are written around that:
+ *  - Clearing a PERMANENT marker (404 / source-not-found) re-queues work that
+ *    fails again and re-marks — a loop that burns provider goodwill.
+ *  - Leaving a TRANSIENT marker (403 / timeout / truncated transfer) strands a
+ *    page that is still there, forever, because every archiver selects on the
+ *    field being empty.
+ *  - An UNRECOGNISED reason must be left alone. Defaulting unknown→transient
+ *    would silently re-queue the next novel permanent failure en masse.
+ *
+ * These assert behaviour on real marker strings observed in production, not the
+ * shape of the source.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain .mjs helper, no types
+import { classifyArchiveFailure, failureReasonKey, FAILURE_CLASS } from '../../scripts/lib/archive-failure-class.mjs';
+
+describe('classifyArchiveFailure', () => {
+  it('ignores values that are not markers', () => {
+    for (const v of [
+      'https://images.sourcelibrary.org/archived/abc/1.jpg',
+      '', null, undefined, 42,
+    ]) {
+      expect(classifyArchiveFailure(v as string).isMarker).toBe(false);
+    }
+  });
+
+  it('treats a provider block as transient — 403 is not "page absent"', () => {
+    // 93.5% of the 14,123 production markers. Getting this wrong strands them all.
+    const r = classifyArchiveFailure('failed:HTTP 403');
+    expect(r.isMarker).toBe(true);
+    expect(r.class).toBe(FAILURE_CLASS.TRANSIENT);
+  });
+
+  it('treats broken transfers as transient', () => {
+    for (const s of [
+      'failed:timeout',
+      'failed:terminated',
+      'failed:This operation was aborted',
+      'failed:fetch aborted: stalled — no data for 60s (https://example/x.jpg)',
+      'failed:VipsJpeg: premature end of JPEG image',
+      'failed:fetch failed',
+      'failed:ECONNRESET',
+      'failed:HTTP 503',
+      'failed:HTTP 429',
+    ]) {
+      expect(classifyArchiveFailure(s).class, s).toBe(FAILURE_CLASS.TRANSIENT);
+    }
+  });
+
+  it('treats absence as permanent — these must never be cleared', () => {
+    for (const s of [
+      'failed:HTTP 404',
+      'failed:HTTP 410',
+      'failed:HTTP 401',
+      'failed:source-not-found (gallica has only 45 pages, DB stub claims 100)',
+    ]) {
+      expect(classifyArchiveFailure(s).class, s).toBe(FAILURE_CLASS.PERMANENT);
+    }
+  });
+
+  it('classifies an unrecognised reason as unknown, never transient', () => {
+    // The default must not be "recoverable" — that would mass-re-queue the next
+    // novel permanent failure the moment it appears.
+    const r = classifyArchiveFailure('failed:some brand new error nobody has seen');
+    expect(r.class).toBe(FAILURE_CLASS.UNKNOWN);
+    expect(r.class).not.toBe(FAILURE_CLASS.TRANSIENT);
+  });
+
+  it('lets permanent win when a reason names both', () => {
+    // "timed out waiting, then HTTP 404" must not be retried on the timeout.
+    expect(classifyArchiveFailure('failed:timeout then HTTP 404').class)
+      .toBe(FAILURE_CLASS.PERMANENT);
+  });
+
+  it('collapses digits in the reporting key so counts aggregate', () => {
+    expect(failureReasonKey('failed:source-not-found (gallica has only 45 pages)'))
+      .toBe(failureReasonKey('failed:source-not-found (gallica has only 912 pages)'));
+  });
+});


### PR DESCRIPTION
## The trap

Every archiver selects work with `archived_photo` missing/null/empty. Writing a `failed:` **string** into that same field hides the page from every future run — the bad write erases its own repair path. This is the class CLAUDE.md documents under Data Protection ("a bad write can erase its own repair path").

**Nothing clears these today.** `archive-auto-unblock.mjs` unsets only book-level `archive_metadata.*`; it never touches the page field. A page marked during a transient blip stays unarchived permanently.

Measured 2026-08-01: **14,123 pages** carry a marker. 3,000-page sample:

| count | reason | verdict |
|---|---|---|
| 2805 | `HTTP 403` | provider block — **retryable** |
| 133 | `HTTP 404` | absent — permanent |
| 55 | `source-not-found` | absent — permanent |
| 3 | `VipsJpeg: premature end of JPEG` | truncated transfer — retryable |
| 2 | `terminated` | retryable |
| 1 | `timeout` | retryable |
| 1 | `This operation was aborted` | retryable |

93.5% are 403 — a provider refusing us, which is **not** a statement that the page is absent.

## Why classification gets its own module and tests

The stakes are asymmetric in both directions:

- Clearing a **permanent** marker re-queues work that fails again and re-marks — a loop against a provider that already said no.
- Leaving a **transient** marker strands a page that is still there, forever.
- An **unrecognised** reason is left alone and reported. Defaulting unknown→transient would silently mass-re-queue the next novel permanent failure the moment it appears.

`classifyArchiveFailure()` also lets permanent win on a tie, so `"timeout then HTTP 404"` is not retried on the timeout.

## What the script does not do

**It does not archive anything.** It only makes pages eligible again; the normal archivers pick them up on their next run. That separation keeps it cheap and idempotent, and means a mistake costs a re-queue rather than a bad write.

Safety: dry-run by default (`--apply` required); `--max-per-provider` throttles so a 93.5%-403 population doesn't stampede a source already refusing us; the update re-asserts the marker in its filter so a concurrent archiver's real URL can never be clobbered; `--book-id` / `--limit` for scoped runs.

## Sequencing

Pairs with #3493. Clearing markers **without** the stall-timeout fix would just re-fail the largest pages and re-mark them — so #3493 should land first.

## Testing

`npx vitest run tests/unit/archive-failure-class.test.ts` — 7 behavioural cases over real production marker strings, including the unknown-is-not-transient default and the permanent-wins-a-tie rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)