### PR TITLE
fix(pipeline): stop gating stale-status recovery on the SPEND allowlist

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -264,6 +264,13 @@ const phaseIdx = args.indexOf('--phase');
 const ONLY_PHASE = phaseIdx >= 0 ? parseFloat(args[phaseIdx + 1]) : null;
 const bookArg = args.find(a => a.startsWith('--book='));
 const BOOK_OVERRIDE = bookArg ? bookArg.split('=')[1] : null;
+// Phase 8.5 is RECOVERY, not production: it only rolls a stuck status back to
+// the phase before it. It submits nothing and spends nothing. A run limited to
+// it is therefore safe under a global pause — and must be allowed, because the
+// pause is a SPEND control and gating bookkeeping on it is how six derived
+// outputs froze for seven weeks (CLAUDE.md).
+const RECOVERY_ONLY = ONLY_PHASE === 8.5;
+
 if (BOOK_OVERRIDE && ONLY_PHASE === null) {
   console.error('--book requires --phase to be specified');
   process.exit(1);
@@ -2549,7 +2556,10 @@ async function run() {
   // a single --book override (existing behavior) or a config-driven allowlist.
   const SCOPE_ACTIVE = !!BOOK_OVERRIDE || SCOPED_MODE;
 
-  if (!shouldBypassPause(control, { bookOverride: !!BOOK_OVERRIDE })) {
+  if (RECOVERY_ONLY && !shouldBypassPause(control, { bookOverride: !!BOOK_OVERRIDE })) {
+    console.log('[pipeline-orchestrator] PAUSED, but this is a recovery-only run (--phase 8.5): rolling back stuck statuses spends nothing, so it proceeds.');
+  }
+  if (!RECOVERY_ONLY && !shouldBypassPause(control, { bookOverride: !!BOOK_OVERRIDE })) {
     const pauseAgeMs = control.paused_at ? Date.now() - new Date(control.paused_at).getTime() : Infinity;
     console.log(`[pipeline-orchestrator] PAUSED (${Math.round(pauseAgeMs / 60000)}min ago by ${control.paused_by || 'unknown'}). Exiting.`);
     await db.collection('cron_runs').insertOne({
@@ -5289,7 +5299,14 @@ Rules:
         .project({ id: 1, title: 1, pipeline_auto: 1 })
         .limit(50)
         .toArray();
-      if (SCOPE_ACTIVE) staleBooks = await applyBookOverride(db, staleBooks, { id: 1, title: 1, pipeline_auto: 1 });
+      // Recovery is deliberately NOT confined to the selective-unpause scope.
+      // A rollback writes a status field and nothing else — no submission, no
+      // spend — while every phase that DOES spend stays scope-gated, so making
+      // a book eligible cannot leak paid work. Confining it here meant a book
+      // outside the 160-book allowlist could never self-heal: 8 books had to be
+      // repaired by hand (Thibault + 7 others, 10-23 days stuck) before this
+      // was noticed. An explicit --book override still narrows the run.
+      if (BOOK_OVERRIDE) staleBooks = await applyBookOverride(db, staleBooks, { id: 1, title: 1, pipeline_auto: 1 });
 
       console.log(`  Stale books: ${staleBooks.length}`);
 


### PR DESCRIPTION
## Phase 8.5's logic was never the problem

It already knows how to un-stick a book — it rolls `images_submitted` → `chapters_complete` after 48h. **Two gates stop it from ever seeing the books that need it:**

1. **Scope.** While globally paused with a selective-unpause scope, the phase ran its candidates through `applyBookOverride`, which filters to the allowlist — currently **160 books out of ~99.7K**. Anything outside could never self-heal.
2. **Pause.** A run limited to recovery exited at the global pause gate before reaching the phase at all.

Both are the same mistake in different clothes, and CLAUDE.md already names it:

> The pipeline pause is a SPEND control. Never gate bookkeeping on it.

A status rollback submits nothing and costs nothing. Every phase that *does* spend stays scope-gated, so making a book eligible cannot leak paid work.

## What the gap cost

Paid by hand: **8 books** (Thibault + 7 others, stuck 10–23 days) repaired manually this week. Six were sitting on preview-only OCR — 25 of 264 pages, 21 of 186 — and one was **already visible to readers** with its gallery plates missing.

## Verification

A/B against production on one non-scoped book temporarily marked stale, then restored byte-identical:

```
OLD:  Stale books: 0
NEW:  Stale books: 1
      Stale RETRY: De Voluptate (images_submitted -> chapters_complete)
```

Both runs `--dry-run`; nothing written. Confirmed in the same pass that a spending phase (`--phase 2`) is **still** confined to the 160 allowlisted books.

## Honest limitation

The stale population is **0 right now** — the pipeline is paused so nothing submits, and I drained the backlog by hand. This fixes a structural gap that repopulates when processing resumes; it is **not observable on live data today**, which is precisely why the A/B above exists rather than a "look, it's fixed in prod" claim.

## Follow-up, deliberately not in this PR

Only `--phase 9` is on cron, so even a correct Phase 8.5 runs rarely. A recovery-only cron entry (`--phase 8.5`, now safe under pause) would close the loop — but that's an ops change with its own review.

## Testing

`npx vitest run` — 1230 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)