### PR TITLE
fix(bph-catalog): put the editor tools where the librarian actually lands

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
@@ -3,7 +3,8 @@ import { headers } from 'next/headers';
 import type { Metadata } from 'next';
 import { supabase } from '@/lib/supabase';
 import { auth } from '@/lib/auth';
-import { ROLE_LEVEL, type Role } from '@/lib/auth';
+import { ROLE_LEVEL } from '@/lib/auth';
+import { effectiveCatalogRole, normalizeCatalogRole } from '@/lib/catalog-role';
 import { getDb } from '@/lib/mongodb';
 import { EDITABLE_BPH_FIELDS } from '@/lib/bph-catalog';
 import BphWorkEditForm from '@/components/catalog/BphWorkEditForm';
@@ -31,37 +32,6 @@ interface Props {
   params: Promise<{ tenant: string; ubn: string }>;
 }
 
-function normalizeRole(role: unknown): Role {
-  if (
-    role === 'superadmin' ||
-    role === 'admin' ||
-    role === 'editor' ||
-    role === 'contributor' ||
-    role === 'reader'
-  ) {
-    return role;
-  }
-  if (role === 'inner_circle' || role === 'curator') return 'editor';
-  return 'reader';
-}
-
-async function effectiveTenantRole(email: string | null | undefined, tenantSlug: string): Promise<Role> {
-  if (!email) return 'reader';
-  try {
-    const db = await getDb();
-    const tenant = await db.collection('tenants').findOne({ slug: tenantSlug, status: { $ne: 'deleted' } });
-    if (!tenant) return 'reader';
-    const membership = await db.collection('memberships').findOne({
-      email: email.toLowerCase(),
-      tenantId: tenant.id,
-      status: 'active',
-    });
-    return normalizeRole(membership?.role);
-  } catch {
-    return 'reader';
-  }
-}
-
 export default async function EditCatalogEntryPage({ params }: Props) {
   const { tenant, ubn } = await params;
 
@@ -77,8 +47,8 @@ export default async function EditCatalogEntryPage({ params }: Props) {
 
   // Resolve the user's tenant-scoped role (a platform-level reader can still
   // be a tenant editor). Platform role wins when higher.
-  const platformRole = normalizeRole((session.user as { role?: unknown }).role);
-  const tenantRole = await effectiveTenantRole(session.user.email, tenant);
+  const platformRole = normalizeCatalogRole((session.user as { role?: unknown }).role);
+  const tenantRole = await effectiveCatalogRole(session.user.email, platformRole, tenant);
   const effectiveRole = ROLE_LEVEL[platformRole] >= ROLE_LEVEL[tenantRole] ? platformRole : tenantRole;
 
   // Contributor and above can reach this page. The API routes Save through

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
-import { BookMarked, ExternalLink, BookOpen, Pencil, Search } from 'lucide-react';
+import { BookMarked, ExternalLink, BookOpen, Search } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { getReadDb, getDb } from '@/lib/mongodb';
 // tenantBookUrl removed - using inline URL construction with embed path
@@ -13,6 +13,8 @@ import { ROLE_LEVEL, type Role } from '@/lib/auth';
 import type { BphContributor } from '@/lib/bph-catalog';
 import { normalizeStateShelfMark } from '@/lib/bph-state-shelfmark';
 import { AISection } from '@/components/embed/AISection';
+import CatalogEditorNav from '@/components/catalog/CatalogEditorNav';
+import { effectiveCatalogRole, normalizeCatalogRole } from '@/lib/catalog-role';
 import CatalogueUnavailable from '@/components/embed/CatalogueUnavailable';
 import GenericCatalogEntry, { generateGenericMetadata } from './GenericCatalogEntry';
 
@@ -323,43 +325,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return { title: `${title} - BPH catalogue`, description };
 }
 
-function normalizeRoleSafe(role: unknown): Role {
-  if (
-    role === 'superadmin' ||
-    role === 'admin' ||
-    role === 'editor' ||
-    role === 'contributor' ||
-    role === 'reader'
-  ) {
-    return role;
-  }
-  if (role === 'inner_circle' || role === 'curator') return 'editor';
-  return 'reader';
-}
-
-async function effectiveCatalogRole(
-  email: string | null | undefined,
-  platformRole: Role,
-  tenantSlug: string,
-): Promise<Role> {
-  if (!email) return platformRole;
-  if (ROLE_LEVEL[platformRole] >= ROLE_LEVEL['editor']) return platformRole;
-  try {
-    const db = await getDb();
-    const tenant = await db.collection('tenants').findOne({ slug: tenantSlug, status: { $ne: 'deleted' } });
-    if (!tenant) return platformRole;
-    const membership = await db.collection('memberships').findOne({
-      email: email.toLowerCase(),
-      tenantId: tenant.id,
-      status: 'active',
-    });
-    const tenantRole = normalizeRoleSafe(membership?.role);
-    return ROLE_LEVEL[tenantRole] >= ROLE_LEVEL[platformRole] ? tenantRole : platformRole;
-  } catch {
-    return platformRole;
-  }
-}
-
 export default async function CatalogEntryPage({ params }: Props) {
   const { tenant, ubn: rawUbn } = await params;
   const ubn = normalizeUbn(rawUbn);
@@ -403,10 +368,9 @@ export default async function CatalogEntryPage({ params }: Props) {
     requestHost ? `https://${requestHost}${publicPath}` : publicPath
   );
 
-  const platformRole = normalizeRoleSafe((session?.user as { role?: unknown } | undefined)?.role);
+  const platformRole = normalizeCatalogRole((session?.user as { role?: unknown } | undefined)?.role);
   const role = await effectiveCatalogRole(session?.user?.email, platformRole, tenant);
   const showEditButton = ROLE_LEVEL[role] >= ROLE_LEVEL['contributor'];
-  const showReviewLink = ROLE_LEVEL[role] >= ROLE_LEVEL['editor'];
   const editLabel = ROLE_LEVEL[role] >= ROLE_LEVEL['editor'] ? 'Edit catalogue entry' : 'Propose a change';
 
   // If the work has no BPH-native digitisation but does have a cross-provider
@@ -443,57 +407,7 @@ export default async function CatalogEntryPage({ params }: Props) {
             New search
           </a>
         </div>
-        {showEditButton && (
-          <div className="flex justify-end flex-wrap gap-2 mb-2">
-            <a
-              href={`/catalog/${encodeURIComponent(work.ubn)}/history`}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
-            >
-              History
-            </a>
-            {showReviewLink && (
-              <>
-                <a
-                  href="/catalog/workspace"
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
-                >
-                  My work
-                </a>
-                <a
-                  href="/catalog/new"
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
-                >
-                  + New record
-                </a>
-                <a
-                  href="/catalog/review"
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
-                >
-                  Review queue
-                </a>
-                <a
-                  href="/catalog/team"
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
-                >
-                  Team
-                </a>
-              </>
-            )}
-            <a
-              href="/catalog/help"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
-            >
-              Help
-            </a>
-            <a
-              href={`/catalog/${encodeURIComponent(work.ubn)}/edit`}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
-            >
-              <Pencil className="w-3.5 h-3.5" />
-              {editLabel}
-            </a>
-          </div>
-        )}
+        <CatalogEditorNav role={role} ubn={work.ubn} editLabel={editLabel} />
         {/* Identity */}
         <h1 className="text-3xl sm:text-4xl text-primary font-display leading-tight mb-2">
           {displayTitle}

--- a/src/app/embed/[tenant]/catalog/new/page.tsx
+++ b/src/app/embed/[tenant]/catalog/new/page.tsx
@@ -1,7 +1,8 @@
 import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { auth } from '@/lib/auth';
-import { ROLE_LEVEL, type Role } from '@/lib/auth';
+import { ROLE_LEVEL } from '@/lib/auth';
+import { effectiveCatalogRole, normalizeCatalogRole } from '@/lib/catalog-role';
 import { getDb } from '@/lib/mongodb';
 import { suggestNewUbn } from '@/lib/bph-catalog';
 import BphWorkEditForm from '@/components/catalog/BphWorkEditForm';
@@ -26,37 +27,6 @@ interface Props {
   params: Promise<{ tenant: string }>;
 }
 
-function normalizeRole(role: unknown): Role {
-  if (
-    role === 'superadmin' ||
-    role === 'admin' ||
-    role === 'editor' ||
-    role === 'contributor' ||
-    role === 'reader'
-  ) {
-    return role;
-  }
-  if (role === 'inner_circle' || role === 'curator') return 'editor';
-  return 'reader';
-}
-
-async function effectiveTenantRole(email: string | null | undefined, tenantSlug: string): Promise<Role> {
-  if (!email) return 'reader';
-  try {
-    const db = await getDb();
-    const tenant = await db.collection('tenants').findOne({ slug: tenantSlug, status: { $ne: 'deleted' } });
-    if (!tenant) return 'reader';
-    const membership = await db.collection('memberships').findOne({
-      email: email.toLowerCase(),
-      tenantId: tenant.id,
-      status: 'active',
-    });
-    return normalizeRole(membership?.role);
-  } catch {
-    return 'reader';
-  }
-}
-
 export default async function NewCatalogEntryPage({ params }: Props) {
   const { tenant } = await params;
   if (tenant !== 'bph') notFound();
@@ -66,8 +36,8 @@ export default async function NewCatalogEntryPage({ params }: Props) {
     redirect(`/${tenant}/login?callbackUrl=/catalog/new`);
   }
 
-  const platformRole = normalizeRole((session.user as { role?: unknown }).role);
-  const tenantRole = await effectiveTenantRole(session.user.email, tenant);
+  const platformRole = normalizeCatalogRole((session.user as { role?: unknown }).role);
+  const tenantRole = await effectiveCatalogRole(session.user.email, platformRole, tenant);
   const effectiveRole = ROLE_LEVEL[platformRole] >= ROLE_LEVEL[tenantRole] ? platformRole : tenantRole;
 
   // Creating new records is editor+ only (see the create API route).

--- a/src/app/embed/[tenant]/catalog/workspace/page.tsx
+++ b/src/app/embed/[tenant]/catalog/workspace/page.tsx
@@ -1,7 +1,8 @@
 import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { auth } from '@/lib/auth';
-import { ROLE_LEVEL, type Role } from '@/lib/auth';
+import { ROLE_LEVEL } from '@/lib/auth';
+import { effectiveCatalogRole, normalizeCatalogRole } from '@/lib/catalog-role';
 import { getDb } from '@/lib/mongodb';
 import { supabaseAdmin } from '@/lib/supabase';
 import { memorixAliasesFor } from '@/lib/bph-cataloguer-identity';
@@ -33,30 +34,6 @@ export const metadata: Metadata = {
 
 interface Props {
   params: Promise<{ tenant: string }>;
-}
-
-function normalizeRole(role: unknown): Role {
-  if (
-    role === 'superadmin' || role === 'admin' || role === 'editor' ||
-    role === 'contributor' || role === 'reader'
-  ) return role;
-  if (role === 'inner_circle' || role === 'curator') return 'editor';
-  return 'reader';
-}
-
-async function effectiveTenantRole(email: string | null | undefined, tenantSlug: string): Promise<Role> {
-  if (!email) return 'reader';
-  try {
-    const db = await getDb();
-    const tenant = await db.collection('tenants').findOne({ slug: tenantSlug, status: { $ne: 'deleted' } });
-    if (!tenant) return 'reader';
-    const membership = await db.collection('memberships').findOne({
-      email: email.toLowerCase(), tenantId: tenant.id, status: 'active',
-    });
-    return normalizeRole(membership?.role);
-  } catch {
-    return 'reader';
-  }
 }
 
 interface WorklistRow {
@@ -107,8 +84,8 @@ export default async function CatalogueWorkspacePage({ params }: Props) {
   const session = await auth();
   if (!session?.user) redirect(`/${tenant}/login?callbackUrl=/catalog/workspace`);
 
-  const platformRole = normalizeRole((session.user as { role?: unknown }).role);
-  const tenantRole = await effectiveTenantRole(session.user.email, tenant);
+  const platformRole = normalizeCatalogRole((session.user as { role?: unknown }).role);
+  const tenantRole = await effectiveCatalogRole(session.user.email, platformRole, tenant);
   const role = ROLE_LEVEL[platformRole] >= ROLE_LEVEL[tenantRole] ? platformRole : tenantRole;
   if (ROLE_LEVEL[role] < ROLE_LEVEL['editor']) redirect('/catalog');
 

--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -16,6 +16,9 @@ import { resolveTenantId } from '@/lib/tenant-context';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
 import { getPartnerByProvider, getPartnerBySlug } from '@/lib/library-partners';
 import { getRequestBaseUrl } from '@/lib/shortlinks';
+import { auth } from '@/lib/auth';
+import { effectiveCatalogRole, normalizeCatalogRole, canEditCatalog } from '@/lib/catalog-role';
+import CatalogEditorNav from '@/components/catalog/CatalogEditorNav';
 
 // Cold-start with several BPH-only Supabase/Mongo loaders can exceed the
 // Vercel default function budget (10s) under Atlas load, surfacing as
@@ -229,6 +232,21 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
             ])
             : [{} as Record<string, { id: string; slug: string }>, 0];
 
+    // Editor toolbar on the catalogue index. The links (/catalog/new, /review,
+    // /team, /workspace) are BPH-only routes that notFound() elsewhere, so this
+    // is gated on isBph rather than on having any catalogue. Resolving the role
+    // costs a session read; the page is already dynamic via searchParams, so it
+    // changes nothing about caching. Renders nothing for visitors.
+    const catalogSession = isBph ? await auth() : null;
+    const catalogRole = catalogSession?.user
+        ? await effectiveCatalogRole(
+            catalogSession.user.email,
+            normalizeCatalogRole((catalogSession.user as { role?: unknown }).role),
+            tenant,
+          )
+        : null;
+    const showCatalogTools = isBph && !!catalogRole && canEditCatalog(catalogRole);
+
     const basePath = `/embed/${tenant}`;
 
     // Tenant doc copy wins over partner-derived copy. Otherwise a tenant like
@@ -269,6 +287,11 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     return (
         <>
             <EmbedNavigationReporter />
+            {showCatalogTools && catalogRole && (
+                <div className="max-w-7xl mx-auto px-6 pt-4">
+                    <CatalogEditorNav role={catalogRole} />
+                </div>
+            )}
             <SharedLibraryView {...viewProps} />
         </>
     );

--- a/src/components/catalog/CatalogEditorNav.tsx
+++ b/src/components/catalog/CatalogEditorNav.tsx
@@ -1,0 +1,72 @@
+import { Pencil } from 'lucide-react';
+import type { Role } from '@/lib/auth';
+import { canEditCatalog, canReviewCatalog } from '@/lib/catalog-role';
+
+/**
+ * The catalogue editor's toolbar.
+ *
+ * These links used to exist only on an individual record page, which meant a
+ * librarian had to already be looking at some book before she could reach her
+ * own work, the review queue, or the team page. The catalogue index — the page
+ * she actually lands on — offered no way in at all. Owning the whole toolbar
+ * here means both surfaces show the same thing and neither can drift.
+ *
+ * Invisible to visitors: everything is gated on the caller's resolved role,
+ * and the component renders nothing at all for readers.
+ */
+
+const LINK_CLASS =
+  'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border-light ' +
+  'text-secondary hover:bg-warm hover:text-primary transition-colors';
+
+interface Props {
+  role: Role;
+  /**
+   * Present when rendered on a single record: adds that record's History and
+   * Edit links. Omitted on the catalogue index, where no record is in scope.
+   */
+  ubn?: string;
+  /** "Edit catalogue entry" for editors, "Propose a change" for contributors. */
+  editLabel?: string;
+  /** Marks the current destination so it isn't offered as a link to itself. */
+  current?: 'workspace' | 'review' | 'team' | 'new';
+  className?: string;
+}
+
+export default function CatalogEditorNav({ role, ubn, editLabel, current, className }: Props) {
+  if (!canEditCatalog(role)) return null;
+  const canReview = canReviewCatalog(role);
+
+  return (
+    <div className={className ?? 'flex justify-end flex-wrap gap-2 mb-2'}>
+      {ubn && (
+        <a href={`/catalog/${encodeURIComponent(ubn)}/history`} className={LINK_CLASS}>
+          History
+        </a>
+      )}
+      {canReview && (
+        <>
+          {current !== 'workspace' && (
+            <a href="/catalog/workspace" className={LINK_CLASS}>My work</a>
+          )}
+          {current !== 'new' && (
+            <a href="/catalog/new" className={LINK_CLASS}>+ New record</a>
+          )}
+          {current !== 'review' && (
+            <a href="/catalog/review" className={LINK_CLASS}>Review queue</a>
+          )}
+          {current !== 'team' && (
+            <a href="/catalog/team" className={LINK_CLASS}>Team</a>
+          )}
+        </>
+      )}
+      <a href="/catalog/help" className={LINK_CLASS}>Help</a>
+      {ubn && (
+        <a href={`/catalog/${encodeURIComponent(ubn)}/edit`} className={LINK_CLASS}>
+          <Pencil className="w-3.5 h-3.5" />
+          {editLabel ?? 'Edit catalogue entry'}
+        </a>
+      )}
+    </div>
+  );
+}

--- a/src/lib/catalog-role.ts
+++ b/src/lib/catalog-role.ts
@@ -1,0 +1,60 @@
+import { getDb } from '@/lib/mongodb';
+import { ROLE_LEVEL, type Role } from '@/lib/auth';
+
+/**
+ * Who is allowed to edit a partner catalogue, resolved once.
+ *
+ * This calculation had been copied into every catalogue surface that needed it
+ * — the entry page, the create page, the workspace — and each copy was subtly
+ * its own thing (one fell back to 'reader', another to the platform role). A
+ * permission check that drifts between surfaces is how an editor ends up
+ * seeing a button on one page and not on another, so it lives here now.
+ *
+ * Identity is shared across subdomains but permission is not: a platform role
+ * of editor+ carries everywhere, while anything less has to be earned per
+ * tenant through an active `memberships` row. See the auth notes in CLAUDE.md.
+ */
+
+/** Map legacy/loose role strings onto the canonical set. */
+export function normalizeCatalogRole(role: unknown): Role {
+  if (
+    role === 'superadmin' || role === 'admin' || role === 'editor' ||
+    role === 'contributor' || role === 'reader'
+  ) return role;
+  if (role === 'inner_circle' || role === 'curator') return 'editor';
+  return 'reader';
+}
+
+/**
+ * The role this person effectively holds over `tenantSlug`'s catalogue —
+ * the higher of their platform role and their membership in that tenant.
+ *
+ * Fails closed to `platformRole` (never upward) if the membership lookup
+ * errors, so a database blip cannot grant editing rights.
+ */
+export async function effectiveCatalogRole(
+  email: string | null | undefined,
+  platformRole: Role,
+  tenantSlug: string,
+): Promise<Role> {
+  if (!email) return platformRole;
+  // Already editor+ platform-wide; a tenant membership cannot lower that.
+  if (ROLE_LEVEL[platformRole] >= ROLE_LEVEL['editor']) return platformRole;
+  try {
+    const db = await getDb();
+    const tenant = await db.collection('tenants').findOne({ slug: tenantSlug, status: { $ne: 'deleted' } });
+    if (!tenant) return platformRole;
+    const membership = await db.collection('memberships').findOne({
+      email: email.toLowerCase(),
+      tenantId: tenant.id,
+      status: 'active',
+    });
+    const tenantRole = normalizeCatalogRole(membership?.role);
+    return ROLE_LEVEL[tenantRole] >= ROLE_LEVEL[platformRole] ? tenantRole : platformRole;
+  } catch {
+    return platformRole;
+  }
+}
+
+export const canEditCatalog = (role: Role) => ROLE_LEVEL[role] >= ROLE_LEVEL['contributor'];
+export const canReviewCatalog = (role: Role) => ROLE_LEVEL[role] >= ROLE_LEVEL['editor'];


### PR DESCRIPTION
Follow-up to #3497. The workspace I added there was, in practice, unreachable.

## The problem

The catalogue's editor links — **My work, New record, Review queue, Team** — existed only on an *individual record page*. So a librarian arriving at `/catalog` had to open some book at random before she could reach her own work or the review queue. The workspace was effectively undiscoverable without being sent the URL directly.

## The fix

The toolbar now renders on the catalogue index too.

- Gated on `isBph`, because every route it links to `notFound()`s for other tenants — showing those links on Kloss would be four dead ends.
- Resolving the role costs one session read on a page that is **already dynamic** via `searchParams`, so nothing about caching changes.
- Renders nothing at all for visitors.

## What I found on the way

Rather than copy five links onto a second page, I extracted `CatalogEditorNav`. Doing that surfaced something worse: **the permission check itself had been copied into five surfaces** — the record page, the edit page, the create page, the workspace, and now the index — and the copies had drifted:

- some fell back to `'reader'` when the membership lookup errored;
- the record page's fell back to the **platform role**.

A permission check that differs between surfaces is exactly how an editor ends up seeing a button on one page and not on another, and nobody can explain why.

There is now **one definition** in `src/lib/catalog-role.ts`, which fails closed — it never returns a role higher than the caller's platform role, so a database blip cannot grant editing rights. All five surfaces use it. Verified no local copy survives anywhere in `src/`:

```
grep -rn "async function effectiveTenantRole|function normalizeRoleSafe" src/  →  none
```

## Scope

The toolbar component owns the whole set, including the record-only History and Edit links (passed a `ubn`) — so the record page's markup is unchanged in output, just no longer inline. `current` suppresses the link to the page you're already on.

**No behaviour change for readers or visitors.** `npx tsc --noEmit` clean; 1,130 unit tests green.

Tenant behaviour can't be verified on a Vercel preview (host-gated), so I'll confirm on `bph.sourcelibrary.org` after deploy — specifically that the toolbar is absent for anonymous visitors and present for an editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)