### PR TITLE
fix(librarian): a reader's questions were published under her real name

### DIFF
--- a/scripts/maintenance/unpublish-default-public-librarian-threads.mjs
+++ b/scripts/maintenance/unpublish-default-public-librarian-threads.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Retract Librarian threads that were published by DEFAULT, not by choice.
+ *
+ * POST /api/embassy/chat defaulted `visibility` to 'public', and the client's
+ * toggle started on 'public' too. A signed-in reader's conversation therefore
+ * appeared in the public "Recent" feed (GET /api/embassy/threads) carrying
+ * `creatorName` — their real account name. A reader wrote in on 2026-07-30 to
+ * ask why her questions showed her first and last name.
+ *
+ * The default is now 'private'. This retracts what the old default published.
+ *
+ * Because nobody could opt out of a default they never saw, every existing
+ * 'public' thread is treated as un-chosen and flipped to 'private'. Readers who
+ * actually want a thread public can re-publish it from the toggle.
+ *
+ * The affected _ids are written to a backup file BEFORE any write, so the flip
+ * is one command to reverse.
+ *
+ *   node scripts/maintenance/unpublish-default-public-librarian-threads.mjs            # dry run
+ *   node scripts/maintenance/unpublish-default-public-librarian-threads.mjs --apply
+ *   node scripts/maintenance/unpublish-default-public-librarian-threads.mjs --restore <backup.json>
+ */
+
+import { MongoClient, ObjectId } from 'mongodb';
+import fs from 'fs';
+import path from 'path';
+
+const APPLY = process.argv.includes('--apply');
+const restoreIdx = process.argv.indexOf('--restore');
+const RESTORE = restoreIdx !== -1 ? process.argv[restoreIdx + 1] : null;
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI is not set. Run with: set -a; source .env.production.local; set +a; node ...');
+  process.exit(1);
+}
+
+const client = new MongoClient(uri);
+
+async function main() {
+  await client.connect();
+  const threads = client.db('bookstore').collection('embassy_threads');
+
+  if (RESTORE) {
+    const backup = JSON.parse(fs.readFileSync(RESTORE, 'utf8'));
+    const ids = backup.ids.map(id => new ObjectId(id));
+    const res = await threads.updateMany(
+      { _id: { $in: ids } },
+      { $set: { visibility: 'public' }, $unset: { visibility_retracted_at: '' } },
+    );
+    console.log(`Restored ${res.modifiedCount} of ${ids.length} threads to public.`);
+    return;
+  }
+
+  // Only threads that are actually reachable in the public feed. The feed
+  // filters on messageCount >= 2, but retract every 'public' thread regardless
+  // — a one-message thread gains a second message the moment it is continued.
+  const filter = { visibility: 'public' };
+  const docs = await threads
+    .find(filter, { projection: { _id: 1, creatorName: 1, messageCount: 1, createdAt: 1 } })
+    .toArray();
+
+  const inFeed = docs.filter(d => (d.messageCount ?? 0) >= 2);
+  const named = new Set(docs.map(d => d.creatorName).filter(Boolean));
+
+  console.log(`public threads:            ${docs.length}`);
+  console.log(`  currently in Recent feed: ${inFeed.length}`);
+  console.log(`  distinct named creators:  ${named.size}`);
+  console.log(`  names exposed:            ${[...named].join(', ')}`);
+
+  if (!APPLY) {
+    console.log('\nDRY RUN — no writes. Re-run with --apply to retract.');
+    return;
+  }
+
+  const outDir = path.join(process.cwd(), 'scripts', 'output');
+  fs.mkdirSync(outDir, { recursive: true });
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backupPath = path.join(outDir, `librarian-public-threads-backup-${stamp}.json`);
+  fs.writeFileSync(
+    backupPath,
+    JSON.stringify({ retracted_at: new Date().toISOString(), ids: docs.map(d => d._id.toString()) }, null, 2),
+  );
+  console.log(`\nBackup written: ${backupPath}`);
+
+  const res = await threads.updateMany(
+    filter,
+    { $set: { visibility: 'private', visibility_retracted_at: new Date() } },
+  );
+  console.log(`matched ${res.matchedCount}, modified ${res.modifiedCount}`);
+
+  const remaining = await threads.countDocuments({ visibility: 'public' });
+  console.log(`public threads remaining:  ${remaining}`);
+  if (remaining !== 0) console.warn('WARNING: expected 0 public threads remaining.');
+}
+
+main()
+  .catch(err => { console.error(err); process.exitCode = 1; })
+  .finally(() => client.close());

--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -6,7 +6,7 @@ import { ObjectId } from 'mongodb';
 import { streamAgenticResponse, type LibrarianStep, type SourceCard } from '@/lib/embassy/librarian';
 import { applyCitationFixes, applyImageRemovals, type CitationFix } from '@/lib/embassy/citation-fixes';
 import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
-import { z } from 'zod';
+import { chatRequestSchema } from '@/lib/embassy/chat-request';
 import { toUserId } from '@/lib/user-id';
 
 export const dynamic = 'force-dynamic';
@@ -16,29 +16,6 @@ export const dynamic = 'force-dynamic';
 // "The Librarian seems to be away." 300 matches our other long-running routes.
 export const maxDuration = 300;
 
-const messageSchema = z.object({
-  role: z.enum(['user', 'assistant']),
-  // History is context, not content of record — clip rather than reject. The
-  // Librarian's own answers regularly exceed 10k chars, and the client sends
-  // them back verbatim as history; rejecting here made every follow-up in such
-  // a thread fail with a bare "Invalid request" (the thread looked dead to the
-  // reader). Allow empty for assistant messages (e.g., choices-only responses).
-  content: z.string().transform(s => s.slice(0, 10000)),
-});
-
-const chatRequestSchema = z.object({
-  threadId: z.string().nullable().optional(),
-  message: z.string()
-    .min(1, 'Message cannot be empty')
-    .max(5000, 'That message is too long for the Librarian — please keep it under 5,000 characters, or share the text a section at a time.'),
-  history: z.array(messageSchema).max(50).optional(),
-  visibility: z.enum(['public', 'private']).optional(),
-  stream: z.boolean().optional(),
-  // Optional collection slug/topic to weight the search toward. Set by the
-  // "Ask the Librarian" entry point on a collection page; the Librarian biases
-  // results toward this collection while still surfacing strong outside matches.
-  collection: z.string().max(120).nullable().optional(),
-});
 
 /**
  * POST /api/embassy/chat — Send a message to the Librarian.
@@ -110,7 +87,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { threadId, message, history = [], visibility = 'public', stream = false, collection = null } = parsed.data;
+  const { threadId, message, history = [], visibility, stream = false, collection = null } = parsed.data;
   const db = await getDb();
 
   // Get user display name (anonymous visitors skip the lookup)

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -389,7 +389,9 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
   useEffect(() => {
     if (status === 'authenticated') setSidebarTab('mine');
   }, [status]);
-  const [visibility, setVisibility] = useState<'public' | 'private'>('public');
+  // Private until the reader says otherwise — the toggle beneath the composer
+  // publishes the thread under their account name, so it must be opt-in.
+  const [visibility, setVisibility] = useState<'public' | 'private'>('private');
   // Research notebook accumulated live across the thread (from notebook_update).
   const [notebookFindings, setNotebookFindings] = useState<NotebookFinding[]>([]);
   const [notebookTopic, setNotebookTopic] = useState<string | undefined>();
@@ -1181,7 +1183,7 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                           className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans flex items-center gap-1"
                         >
                           <span>{visibility === 'public' ? 'Public' : 'Private'}</span>
-                          <span className="text-[9px]">{visibility === 'public' ? '(visible to others)' : '(only you)'}</span>
+                          <span className="text-[9px]">{visibility === 'public' ? '(shown in Recent, under your name)' : '(only you)'}</span>
                         </button>
                       )}
                       <span className="text-[9px] text-[#c0b8b0] font-mono">v5</span>

--- a/src/lib/embassy/chat-request.ts
+++ b/src/lib/embassy/chat-request.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+const messageSchema = z.object({
+  role: z.enum(['user', 'assistant']),
+  // History is context, not content of record — clip rather than reject. The
+  // Librarian's own answers regularly exceed 10k chars, and the client sends
+  // them back verbatim as history; rejecting here made every follow-up in such
+  // a thread fail with a bare "Invalid request" (the thread looked dead to the
+  // reader). Allow empty for assistant messages (e.g., choices-only responses).
+  content: z.string().transform(s => s.slice(0, 10000)),
+});
+
+/**
+ * Body schema for POST /api/embassy/chat.
+ *
+ * Lives here rather than in the route module so the defaults can be exercised
+ * by a unit test — importing the route drags in next-auth and the whole
+ * Librarian agent graph, which does not load under vitest.
+ */
+export const chatRequestSchema = z.object({
+  threadId: z.string().nullable().optional(),
+  message: z.string()
+    .min(1, 'Message cannot be empty')
+    .max(5000, 'That message is too long for the Librarian — please keep it under 5,000 characters, or share the text a section at a time.'),
+  history: z.array(messageSchema).max(50).optional(),
+  // Default PRIVATE. A Librarian thread is published in the public "Recent"
+  // feed under the reader's real account name, so publishing has to be
+  // something they chose, not something they failed to opt out of. The old
+  // default was 'public', which put 515 conversations and 10 readers' full
+  // names into that feed — a reader wrote in asking why her questions carried
+  // her first and last name.
+  visibility: z.enum(['public', 'private']).default('private'),
+  stream: z.boolean().optional(),
+  // Optional collection slug/topic to weight the search toward. Set by the
+  // "Ask the Librarian" entry point on a collection page; the Librarian biases
+  // results toward this collection while still surfacing strong outside matches.
+  collection: z.string().max(120).nullable().optional(),
+});
+
+export type ChatRequest = z.infer<typeof chatRequestSchema>;

--- a/tests/unit/librarian-thread-visibility-default.test.ts
+++ b/tests/unit/librarian-thread-visibility-default.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { chatRequestSchema } from '@/lib/embassy/chat-request';
+
+/**
+ * A Librarian thread is published in the public "Recent" feed under the
+ * reader's real account name (`creatorName`, surfaced by GET /api/embassy/threads).
+ * Publishing therefore has to be a choice the reader makes, never a default they
+ * failed to opt out of.
+ *
+ * The old default was 'public'. It put 515 conversations — 10 readers' full
+ * first-and-last names — into that feed, and a reader wrote in to ask why her
+ * questions carried her name.
+ *
+ * These exercise the schema rather than grepping the source: flipping the
+ * default back to 'public', or dropping `.default()` so the destructure falls
+ * through to undefined, fails here.
+ */
+describe('Librarian chat request — thread visibility', () => {
+  it('defaults to private when the client sends no visibility', () => {
+    const parsed = chatRequestSchema.parse({ message: 'what did Ficino say about the sun?' });
+    expect(parsed.visibility).toBe('private');
+  });
+
+  it('defaults to private when visibility is explicitly undefined', () => {
+    const parsed = chatRequestSchema.parse({ message: 'hello', visibility: undefined });
+    expect(parsed.visibility).toBe('private');
+  });
+
+  it('still honours an explicit opt-in to public', () => {
+    const parsed = chatRequestSchema.parse({ message: 'hello', visibility: 'public' });
+    expect(parsed.visibility).toBe('public');
+  });
+
+  it('rejects any visibility value outside the two-state toggle', () => {
+    expect(() => chatRequestSchema.parse({ message: 'hello', visibility: 'unlisted' })).toThrow();
+  });
+});


### PR DESCRIPTION
Rocio Bernardiner wrote in on 2026-07-30 asking why the questions she put to the Librarian appeared publicly with her first and last name. They did.

## What was wrong

`POST /api/embassy/chat` defaulted `visibility` to `'public'`, and the client toggle initialised to `'public'` as well. A signed-in reader's conversation therefore went straight into the public Recent feed (`GET /api/embassy/threads`), which returns `creatorName` — their real account name.

Nobody chose this. Measured before the fix: **539 public threads, 20 private.** The 515 reachable in the feed exposed **14 named people**, most with full first-and-last names.

The single-thread read gate in `/api/embassy/threads/[id]` was already correct (private threads 404 to everyone but their creator). The entire leak was the default.

## What changed

- `visibility` defaults to `'private'` on the server and in the client toggle.
- Request schema moved to `src/lib/embassy/chat-request.ts`. Importing the route drags in next-auth and the Librarian agent graph, neither of which loads under vitest — the schema needed its own module to be testable at all.
- The toggle now says what publishing costs: `(shown in Recent, under your name)` instead of `(visible to others)`.
- New `scripts/maintenance/unpublish-default-public-librarian-threads.mjs` — backs up the ids, then retracts what the old default published. `--restore <backup.json>` reverses it.

## Data remediation (already run)

Run against production before opening this PR, because the exposure was live:

```
matched 539, modified 539
public threads remaining:  0
```

`GET /api/embassy/threads` now returns `{"threads":[]}`. Ids saved to `scripts/output/librarian-public-threads-backup-2026-08-01.json` in the main checkout.

Every public thread was treated as un-chosen, since nobody could opt out of a default they never saw. Two of the 14 names are ours (`Derek Lomas`, `Source Library`) and may have been deliberate demos — `--restore` brings any subset back.

## The guard

`tests/unit/librarian-thread-visibility-default.test.ts` exercises the schema rather than grepping source. Negative-controlled per CLAUDE.md: flipping the default back to `'public'` turns 2 of the 4 tests red. Verified, not assumed.

## Out of scope

- Whether the Recent feed should carry a full real name **at all**, even for a deliberate opt-in. First-name-only or a display handle is probably the right end state; that is a product decision, not a leak fix.
- Anonymous threads stay `'unlisted'` — unchanged, and they carry no account name.

Found while verifying an external security review that arrived via the public MCP `submit_feedback` tool. Feedback-ID: 6a6ab4808b1d5089bd554672

🤖 Generated with [Claude Code](https://claude.com/claude-code)