### PR TITLE
semantic search: an RPC error is not an empty result

### DIFF
--- a/src/lib/semantic-search.ts
+++ b/src/lib/semantic-search.ts
@@ -2,6 +2,33 @@ import { supabase } from '@/lib/supabase';
 import { expandLanguages } from '@/lib/language-utils';
 
 /**
+ * Thrown when a semantic-search RPC fails. Do NOT swallow this into an empty
+ * result set.
+ *
+ * Why this class exists: every RPC here used to `console.error(...)` and
+ * `return []` on failure, which makes a database fault indistinguishable from
+ * "nothing matched". That is not hypothetical — it hid a completely undeployed
+ * `match_semantic` function for months (see the header of
+ * `scripts/migration/add-match-semantic-rpc.sql`: the lib "catches the error and
+ * returns []"), and in Aug 2026 it caused a language filter returning zero rows
+ * to be misdiagnosed as a filter bug when the filter was working correctly.
+ *
+ * An empty array is an *answer*. An error is not. Callers that genuinely want to
+ * degrade (multi-lane search, the librarian) already wrap these calls in
+ * try/catch and drop the lane; the API routes surface it as a 500. Both are
+ * correct — what was wrong was the callee deciding silently on their behalf.
+ *
+ * Note `getQueryEmbedding` returning null is NOT this case: Gemini being absent
+ * is a documented degrade to keyword-only search, and still returns [].
+ */
+export class SemanticSearchError extends Error {
+  constructor(public readonly rpc: string, message: string) {
+    super(`[semantic-search] ${rpc} failed: ${message}`);
+    this.name = 'SemanticSearchError';
+  }
+}
+
+/**
  * Generate query embedding via Gemini embedding-2-preview.
  * Must use the same model as the backfill (embed-gemini.mjs / backfill-book-embeddings.mjs).
  * Returns null if Gemini is unavailable (search degrades to keyword-only).
@@ -72,8 +99,7 @@ export async function semanticBookSearch(
   });
 
   if (error) {
-    console.error('[semantic-search] match_books_semantic error:', error.message);
-    return [];
+    throw new SemanticSearchError('match_books_semantic', error.message);
   }
 
   return (data || []).map((row: any) => ({
@@ -169,8 +195,7 @@ export async function semanticArtworkSearch(
   });
 
   if (error) {
-    console.error('[semantic-search] match_artworks_semantic error:', error.message);
-    return [];
+    throw new SemanticSearchError('match_artworks_semantic', error.message);
   }
 
   return (data || []).map((row: any) => ({
@@ -282,8 +307,7 @@ export async function semanticPageSearchGlobal(
   });
 
   if (error) {
-    console.error('[semantic-search] match_semantic error:', error.message);
-    return [];
+    throw new SemanticSearchError('match_semantic', error.message);
   }
 
   let rows = (data || []) as any[];
@@ -356,8 +380,7 @@ export async function semanticPageSearchScoped(
   });
 
   if (error) {
-    console.error('[semantic-search] match_pages_in_books error:', error.message);
-    return [];
+    throw new SemanticSearchError('match_pages_in_books', error.message);
   }
 
   return (data || []).map((row: any) => {

--- a/tests/unit/semantic-search-error.test.ts
+++ b/tests/unit/semantic-search-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The regression this guards: a failing RPC used to be reported as an empty
+// result set, making a database fault indistinguishable from "nothing matched".
+// That hid an undeployed match_semantic for months, and in Aug 2026 made a
+// working language filter look broken. See SemanticSearchError's docblock.
+
+const rpc = vi.fn();
+vi.mock('@/lib/supabase-admin', () => ({ supabase: { rpc: (...a: unknown[]) => rpc(...a) } }));
+vi.mock('@/lib/supabase', () => ({ supabase: { rpc: (...a: unknown[]) => rpc(...a) } }));
+
+describe('semantic search: an RPC error is not an empty result', () => {
+  beforeEach(() => {
+    rpc.mockReset();
+    vi.resetModules();
+    process.env.GEMINI_API_KEY = 'test-key';
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ embeddings: [{ values: Array(768).fill(0.01) }] }),
+    }) as unknown as typeof fetch;
+  });
+
+  it('throws SemanticSearchError when the RPC errors', async () => {
+    const { semanticPageSearchGlobal, SemanticSearchError } = await import('@/lib/semantic-search');
+    rpc.mockResolvedValue({ data: null, error: { message: 'function match_semantic does not exist' } });
+
+    await expect(semanticPageSearchGlobal('anything', 5)).rejects.toBeInstanceOf(SemanticSearchError);
+  });
+
+  it('names the failing RPC in the message, so the log identifies the fault', async () => {
+    const { semanticPageSearchGlobal } = await import('@/lib/semantic-search');
+    rpc.mockResolvedValue({ data: null, error: { message: 'statement timeout' } });
+
+    await expect(semanticPageSearchGlobal('anything', 5)).rejects.toThrow(/match_semantic failed: statement timeout/);
+  });
+
+  it('still returns [] for a genuinely empty result — an empty answer is an answer', async () => {
+    const { semanticPageSearchGlobal } = await import('@/lib/semantic-search');
+    rpc.mockResolvedValue({ data: [], error: null });
+
+    await expect(semanticPageSearchGlobal('anything', 5)).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Replaces `console.error(...); return []` with a thrown `SemanticSearchError` at all four RPC call sites in `src/lib/semantic-search.ts`.

## Why

A failing RPC and a genuinely empty result set were indistinguishable to every caller.

This has already cost real time twice:

1. **It hid an undeployed `match_semantic` for months.** The header of `scripts/migration/add-match-semantic-rpc.sql` records the diagnosis verbatim — *"It silently returned empty results for months because supabase.rpc() rejects with 'function not found' and the lib catches the error and returns []."*
2. **2026-08-01: it made a working language filter look broken.** A `languages` filter returning zero rows was reported as a filter bug (#3503, now closed). Direct probing of the deployed RPC showed the filter works correctly — the zero was a real result. The two are indistinguishable precisely because of this pattern.

An empty array is an *answer*. An error is not.

## Safety

Throwing is safe at every existing call site, all of which already handle it:

| Caller | Existing behaviour |
|---|---|
| `src/app/api/search/semantic/route.ts` | `try/catch` → 500 `{ error: 'Search failed' }` |
| `src/app/api/search/route.ts` (multi-lane) | per-lane `try/catch` → drops the lane |
| `src/lib/search/librarian-search.ts` | `try { … } catch { return [] }` |

So multi-lane search still degrades gracefully; the difference is that the fault is now visible instead of being reported as "no results".

`getQueryEmbedding` returning null still returns `[]` — Gemini being unavailable is a documented degrade to keyword-only search, not a fault.

## Tests

`tests/unit/semantic-search-error.test.ts` — 3 passing: throws on RPC error, names the failing RPC in the message, and still returns `[]` for a genuinely empty result.

`npx tsc --noEmit` clean on the touched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)