### PR TITLE
docs: invariants from the /welcome lockout and blank-form overwrite

### DIFF
--- a/.claude/handoffs/2026-08-01-welcome-gate-lockout-and-blank-form-overwrite.md
+++ b/.claude/handoffs/2026-08-01-welcome-gate-lockout-and-blank-form-overwrite.md
@@ -1,0 +1,113 @@
+# The welcome gate locked readers out, and the form erased what it never showed — 2026-07-30/08-01
+
+Reported as "`/welcome` → a 404 → an infinite loop… am I the only one?" It was three
+separate bugs stacked on one another, and no, he wasn't. PRs #3467, #3464, #3496.
+
+## What the reader experienced
+
+1. Any page → the welcome gate redirects to `/welcome?from=<path>`.
+2. Fill in the form, save. It saves correctly — `welcomedAt` is written.
+3. The reader is returned to their page, and the gate immediately sends them back
+   to `/welcome`. Forever, on every page. The site is unusable.
+4. Separately, the form re-presented itself **blank**, so the second save wrote
+   those blanks over the answers from the first.
+
+The 404 in the original report was a red herring: `/book/6810f4e60b70c1a5b48ba3f8`
+exists in neither `books` nor `deleted_books`. The `?from=` target was simply a dead
+URL, and the loop took over from the 404 page.
+
+## Root cause 1 — `update()` with no argument is a GET (#3467)
+
+`WelcomeForm` called `await update()` to refresh the session. In `next-auth/react`,
+`update(data)` only builds a request body **when called with data**, and
+`lib/client.js` only sets `method: 'POST'` when a body exists. So the call was a
+**GET**, a GET does not run the `jwt` callback with `trigger: 'update'`, and the
+callback's DB re-read is gated on `(user || trigger === 'update')`.
+
+`needsWelcome` was therefore frozen `true` in the JWT for its full 30-day life,
+whatever the database said. Confirmed directly: `welcomedAt = 2026-07-30T08:30:32Z`
+in Mongo while `/api/auth/session` still served `needsWelcome: true` hours and
+several saves later.
+
+**Fix:** `update({ welcomed: true })`. The `jwt` callback also honours that payload
+*outside* its try/catch, so a failed lookup cannot re-trap someone who just saved.
+
+**The structural half, which matters more.** `WelcomeGate`'s only guard was a
+mount-scoped `useRef` — and that is no guard at all, because every firing of the
+gate is a navigation and every navigation remounts the component. The gate now
+records one firing per tab in `sessionStorage`, so a stale flag costs one wasted
+navigation instead of the whole site. That is also what self-healed the readers
+whose tokens stayed stale for up to 30 days; nothing server-side can force-refresh
+a JWT.
+
+Scope: **42 readers** saved during the window (2026-07-29 → 07-30) and every one was
+then bounced. The gate had only started firing for real the day before, when #3448
+fixed the `users._id` string-vs-ObjectId lookup.
+
+## Root cause 2 — a blank form overwrites what it never showed (#3496)
+
+`/welcome` rendered every field empty on each visit and saved those blanks over
+`users.profile`. Alone this needed a deliberate revisit; combined with the loop —
+which *made* people submit twice — it erased their answers.
+
+**Blast radius, measured against every `volunteers` row rather than estimated: 2
+readers.** Both recovered, because the `volunteers` mirror is written on the first
+(non-empty) save and held the only surviving copy. Restored to `users.profile` with
+a `profile.restoredFrom` stamp.
+
+**Fixes:**
+
+- `/welcome` prefills from `users.profile`, resolved **server-side** — a
+  fetch-on-mount leaves a window where the form is mounted, empty and submittable.
+- The API distinguishes an **absent** key ("leave this alone") from a **present
+  empty string** ("the reader cleared this"). That distinction is the entire bug,
+  so it lives in `src/lib/welcome-profile-update.ts` with tests rather than inline.
+- A failed prefill read fails safe: the page passes `profileLoaded={false}` and the
+  form omits untouched fields. A database hiccup must not be able to erase anyone.
+- The `volunteers` mirror follows the same rule — it is the last-resort copy that
+  made recovery possible, so a field nobody sent must never overwrite it.
+
+**An existing test encoded the bug.** `tests/unit/welcome-name-capture.test.ts`
+asserted that a body *omitting* `preferred_language` should still write `''`, so
+that "asked and declined" stayed distinguishable from "never asked". That inference
+*is* the data-loss mechanism. The intent survives by moving the signal to the
+caller: the form sends all four fields whenever it could prefill them, so the
+declined case still records `''`. The case was rewritten, not deleted.
+
+## Root cause 3 — there was nowhere to fix it (#3464)
+
+`/account` had no editor for the four welcome answers at all; only *members* got a
+profile editor, and it edits a different thing. A reader who wanted to answer later
+had nowhere to go. `/account` now has a Reader profile card for every signed-in
+user, and `GET /api/me/welcome` exists so it can prefill.
+
+## Two measurement traps hit while sizing this
+
+- **A cohort keyed on an overwritten field drifts.** `users.welcomedAt` is rewritten
+  on every save, so a "who was affected in this window" query silently loses anyone
+  who came back and re-saved: the list went **42 → 40 within an hour**, dropping two
+  genuinely affected people. Freeze an incident recipient list to a file and never
+  re-derive it at send time. `volunteers.signals` is `$push`-ed per save and
+  preserves first-save time if you must reconstruct one.
+- **Wrong field names read as "no activity."** A first pass reported zero active
+  users because it queried `created_at`/`timestamp` on collections that use
+  `started_at`/`updated_at`, and looked for `user_id` on `analytics_pageviews`,
+  which stores none at all (#3405). The zero was an instrument artifact, not a fact.
+
+## Outcome
+
+42 readers were emailed a thank-you with the apology folded in — split by what they
+actually did (27 contributed, 15 pressed Skip or saved blank; thanking a skipper for
+contributing would be false) and by the reading language they themselves stated
+(12 Spanish). 42 sent, 0 failed, 0 bounced. Recipient list and send record are in the
+private ops repo, not here.
+
+## Files
+
+- `src/components/welcome/WelcomeForm.tsx`, `src/components/auth/WelcomeGate.tsx`
+- `src/lib/welcome-gate.ts`, `src/lib/welcome-profile-update.ts` (both new, both
+  extracted so the rule is reachable by a test)
+- `src/app/welcome/page.tsx`, `src/app/api/me/welcome/route.ts`
+- `src/app/account/AccountClient.tsx`
+- `tests/unit/welcome-gate.test.ts`, `tests/unit/welcome-profile-update.test.ts`,
+  `tests/unit/welcome-name-capture.test.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,40 @@ Lessons from the AS132203 scraper fleet, 2026-07-29 (#3438, #3446). Full postmor
 - **Scope an alias by an exact host match, never `host.includes('vercel.app')`.** Preview deployments (`*-git-*.vercel.app`, `*-<team>.vercel.app`) must keep serving the whole site or branch review stops working; the bare production alias must not. `DEPLOYMENT_ALIAS_HOSTS` in `src/lib/alias-host-scope.ts` is an exact-match set for that reason. And **check what points at an alias before scoping it** — `scripts/uptime-monitor.mjs` probes `sourcelibrary-v2.vercel.app`, and the Playwright suite defaulted `BASE_URL` to it, so a catch-all 308 would not merely have broken them: it would have silently repointed `e2e/crawl-all-pages.spec.ts` at production. Hence the allowlist's EXACT entries (`/api/books` yes, `/api/books/<id>/{text,quote}` no; the three `/embed/*` landing pages yes, the reading rooms beneath them no).
 - **Watch for it: `scripts/workers/traffic-anomaly-alert.mjs`** (hourly cron on Hetzner, pushes to `ntfy.sh/sourcelibrary-uptime` **on state change only** — a detector that repeats itself hourly trains you to ignore it). Three checks, one per failure above: volume concentration per /24, reader traffic on an unexpected hostname, and traffic still reaching the app from a network we believe is blocked. **Adding a new alias means adding it to `EXPECTED_HOSTS`** — the test pins that the allowlist stays small, because every host on it is a surface nobody is watching.
 
+## Session flags go stale, and blank forms erase — CRITICAL
+Lessons from the `/welcome` lockout, 2026-07-30 (#3467/#3496). Full postmortem:
+`.claude/handoffs/2026-08-01-welcome-gate-lockout-and-blank-form-overwrite.md`.
+Three bugs stacked: 42 readers could not leave the welcome page, and 2 had their
+answers erased.
+
+- **`useSession().update()` MUST be called with a payload.** With no argument it
+  issues a **GET** to `/api/auth/session` (next-auth's `update(data)` only builds a
+  body when given data; `lib/client.js` only sets `method:'POST'` when a body
+  exists), and a GET never runs the `jwt` callback with `trigger:'update'`. Since
+  the DB re-read in `src/lib/auth.ts` is gated on `(user || trigger === 'update')`,
+  every token field computed there stays frozen for the token's full 30-day life.
+  Mongo said `welcomedAt` was set; the session served `needsWelcome: true` for
+  hours. **Verify a session change by reading `/api/auth/session`, never by
+  trusting the write** — the disagreement between the two is the diagnosis.
+- **A mount-scoped `useRef` is not a redirect guard.** Every redirect is a
+  navigation and every navigation remounts, so the ref resets each time and a
+  stale flag becomes a lockout instead of a nuisance. Persist "already fired" in
+  `sessionStorage`. This is also the only thing that can heal a stale JWT, because
+  nothing server-side can force-refresh one.
+- **An ABSENT field means "leave this alone"; a PRESENT empty string means "the
+  reader cleared it".** Conflating them lets a form overwrite data it never showed
+  the reader — `/welcome` rendered blank on every visit, so the second save wiped
+  the first. Any surface that writes user-authored text must prefill (server-side,
+  so there is no mounted-and-empty window) or omit the key. Rule + tests:
+  `src/lib/welcome-profile-update.ts`. **Corollary:** a test asserting "record the
+  blank so declined ≠ never asked" encodes exactly this bug — keep the intent, move
+  the signal to the caller.
+- **A cohort keyed on an overwritten field drifts under you.** `users.welcomedAt`
+  is rewritten on every save, so a "who was affected in this window" query loses
+  anyone who came back and re-saved — a 42-person incident list became 40 within an
+  hour. Freeze an incident recipient list to a file (private ops repo — reader
+  addresses never go in this repo) and never re-derive it at send time.
+
 ## A metric is a claim about an instrument before it is a claim about readers
 A usage review on 2026-07-28 produced six findings; **three were instrument failures, not product facts** — and each failed *silently*, in the direction that invited a confident conclusion. Full postmortem: `.claude/handoffs/2026-07-28-instruments-lied-translation-streaming-crash.md`.
 


### PR DESCRIPTION
Follow-up to #3467 / #3496 / #3464. Doc-only.

Three bugs stacked on 2026-07-30: 42 readers could not leave `/welcome`, and 2 had their written answers erased. Each failure was non-obvious in a way that would bite the next person, so four rules go into CLAUDE.md:

- **`useSession().update()` must be called with a payload.** With no argument it sends a GET, which never runs the `jwt` callback with `trigger:'update'` — so any token field computed there stays frozen for the token's 30-day life. Verify a session change by reading `/api/auth/session`, never by trusting the write.
- **A mount-scoped `useRef` is not a redirect guard**, because every redirect is a navigation and every navigation remounts. Persisting "already fired" is also the only thing that can heal a stale JWT, since nothing server-side can force-refresh one.
- **Absent ≠ empty** when writing user-authored text. A form that renders blank overwrites what it never showed the reader. Includes the corollary that a test asserting "record the blank" encodes the bug.
- **A cohort keyed on an overwritten field drifts** — a 42-person incident list became 40 within an hour.

Plus the full postmortem in `.claude/handoffs/`, added by deliberate `git add -f`. It is a technical writeup with no PII; the recipient list and send record stay in the private ops repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)