### PR TITLE
fix(image-proxy): the host allowlist matched on a bare suffix

### DIFF
--- a/src/app/api/image/route.ts
+++ b/src/app/api/image/route.ts
@@ -4,6 +4,8 @@ import fs from 'fs';
 import path from 'path';
 import axios from 'axios';
 import crypto from 'crypto';
+import { refuseImageUrl } from '@/lib/image-proxy-hosts';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 
 // Cache resized images for 1 week
 const CACHE_DURATION = 60 * 60 * 24 * 7;
@@ -45,8 +47,81 @@ async function getProvenanceMark() {
   }
 }
 
+/** Thrown when a redirect hop points somewhere we refuse to follow. */
+class BlockedRedirectError extends Error {
+  constructor(public readonly reason: string) {
+    super(`Redirect refused: ${reason}`);
+    this.name = 'BlockedRedirectError';
+  }
+}
+
+/**
+ * Fetch an image, re-validating the host on EVERY redirect hop.
+ *
+ * axios follows redirects itself (up to 5) and performs no further checks, so
+ * a permitted origin — or, before the dot-boundary fix, an attacker-registered
+ * lookalike — could 302 us onto a private address. We follow the chain by hand
+ * with `maxRedirects: 0` and run each Location through the same policy as the
+ * caller-supplied URL.
+ */
+async function fetchAllowlistedImage(startUrl: string, maxHops = 5) {
+  let current = startUrl;
+
+  for (let hop = 0; hop <= maxHops; hop++) {
+    const response = await axios.get(current, {
+      responseType: 'arraybuffer',
+      timeout: FETCH_TIMEOUT_IN_MS,
+      // Axios timeout includes both connection and response timeouts.
+      // Cap the response body so an oversized source aborts the download
+      // instead of buffering hundreds of MB into the function (throws
+      // ERR_FR_MAX_CONTENT_LENGTH_EXCEEDED, handled by the caller as 413).
+      maxContentLength: MAX_INPUT_BYTES,
+      maxBodyLength: MAX_INPUT_BYTES,
+      maxRedirects: 0,
+      // 3xx must reach us as a value, not an axios throw, so we can inspect
+      // Location. Anything else keeps the usual error behaviour.
+      validateStatus: status => (status >= 200 && status < 300) || (status >= 300 && status < 400),
+    });
+
+    if (response.status < 300) return response;
+
+    const location = response.headers?.location;
+    if (!location) throw new BlockedRedirectError('redirect without a Location header');
+
+    // Relative Locations are legal and common; resolve against the current URL.
+    const next = new URL(location, current).toString();
+    const refusal = refuseImageUrl(next);
+    if (refusal) throw new BlockedRedirectError(refusal);
+    current = next;
+  }
+
+  throw new BlockedRedirectError(`more than ${maxHops} redirects`);
+}
+
+// Ceiling on how much fetch-and-resize work one caller can make us do. Even
+// with a tight allowlist the proxy is still a free image resizer over some very
+// large public buckets, so it needs a cap.
+//
+// Deliberately generous: a gallery grid is dozens of images, and the limiter is
+// per-lambda-instance and in-memory, so the effective ceiling across instances
+// is higher than the number below. Most requests are served from the CDN and
+// never reach this function at all — only cache misses count. Tune via
+// IMAGE_PROXY_PER_MIN if it ever bites a real reader.
+const IMAGE_PROXY_PER_MIN = Number(process.env.IMAGE_PROXY_PER_MIN || 600);
+
 export async function GET(request: NextRequest) {
   try {
+    const rl = checkRateLimit(
+      { name: 'image-proxy', limit: IMAGE_PROXY_PER_MIN, windowSeconds: 60 },
+      getClientIp(request),
+    );
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many image requests' },
+        { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } },
+      );
+    }
+
     const { searchParams } = new URL(request.url);
     const url = searchParams.get('url');
     const width = parseInt(searchParams.get('w') || '400', 10);
@@ -84,35 +159,15 @@ export async function GET(request: NextRequest) {
       }
       buffer = fs.readFileSync(localPath);
     } else {
-      // Only allow trusted image hosts for security
-      const allowedHosts = [
-        'amazonaws.com',
-        'archive.org',
-        'vercel-storage.com',
-        'blob.vercel-storage.com',
-        'r2.dev',                      // Cloudflare R2 (public bucket)
-        'images.sourcelibrary.org',    // Cloudflare R2 (custom domain)
-        // Museum / open-access sources
-        'upload.wikimedia.org',        // Wikimedia Commons (public domain images)
-        'images.metmuseum.org',        // The Metropolitan Museum of Art
-        'openaccess-cdn.clevelandart.org', // Cleveland Museum of Art
-        // IIIF sources
-        'gallica.bnf.fr',
-        'api.digitale-sammlungen.de',  // MDZ/BSB
-        'digi.vatlib.it',              // Vatican
-        'digital.bodleian.ox.ac.uk',   // Bodleian
-        'iiif.bodleian.ox.ac.uk',
-        'digital.archives.go.jp',       // National Archives of Japan
-        'contentdm.oclc.org',           // ContentDM (Laurenziana, etc.)
-        'uvaerfgoed.nl',               // UVA heritage collections
-        'rijksmuseum.nl',              // Rijksmuseum
-        'dl.ndl.go.jp',               // National Diet Library Japan
-        'e-rara.ch',                   // Swiss libraries
-      ];
-      const urlObj = new URL(url);
-      if (!allowedHosts.some(host => urlObj.hostname.endsWith(host))) {
+      // Only allow trusted image hosts. The allowlist and the matching rule
+      // live in src/lib/image-proxy-hosts.ts — matching is on a dot boundary,
+      // NOT a bare suffix. See that file for why (`evilarchive.org` used to
+      // pass), and tests/unit/image-proxy-hosts.test.ts for the cases.
+      const refusal = refuseImageUrl(url);
+      if (refusal) {
         return NextResponse.json({ error: 'URL not allowed' }, { status: 403 });
       }
+      const urlObj = new URL(url);
 
       // Fetch the original image with axios for better timeout control
       // Retry logic for transient network errors
@@ -121,21 +176,17 @@ export async function GET(request: NextRequest) {
 
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
-          const response = await axios.get(url, {
-            responseType: 'arraybuffer',
-            timeout: FETCH_TIMEOUT_IN_MS,
-            // Axios timeout includes both connection and response timeouts.
-            // Cap the response body so an oversized source aborts the download
-            // instead of buffering hundreds of MB into the function (throws
-            // ERR_FR_MAX_CONTENT_LENGTH_EXCEEDED, handled below as 413).
-            maxContentLength: MAX_INPUT_BYTES,
-            maxBodyLength: MAX_INPUT_BYTES,
-          });
+          const response = await fetchAllowlistedImage(url);
 
           buffer = Buffer.from(response.data);
           fetchSucceeded = true;
           break; // Success, exit retry loop
         } catch (fetchError: any) {
+          // A refused redirect is a policy decision, not a transient fault —
+          // return immediately rather than retrying it twice more.
+          if (fetchError instanceof BlockedRedirectError) {
+            return NextResponse.json({ error: 'URL not allowed' }, { status: 403 });
+          }
           // Only retry on network errors (ETIMEDOUT, ECONNREFUSED, etc), not on 4xx/5xx responses
           const isRetryable =
             fetchError.code === 'ETIMEDOUT' ||

--- a/src/lib/image-proxy-hosts.ts
+++ b/src/lib/image-proxy-hosts.ts
@@ -1,0 +1,127 @@
+/**
+ * Host policy for the server-side image proxy (`/api/image`).
+ *
+ * `/api/image?url=…` performs a server-side fetch of a caller-supplied URL, so
+ * the allowlist here is the only thing standing between a stranger and our
+ * outbound network. Two rules, both learned the hard way:
+ *
+ *  1. Match on a DOT BOUNDARY, never a bare suffix. The original check was
+ *     `hostname.endsWith(host)`, under which `evilarchive.org`, `xr2.dev` and
+ *     `notamazonaws.com` all passed — an attacker only had to register a
+ *     domain that ends in one of our allowlisted strings to make us fetch
+ *     anything they liked.
+ *  2. Re-validate on EVERY redirect hop. axios follows up to 5 redirects by
+ *     default with no further checks, so an allowlisted (or attacker-glued)
+ *     host could 302 us straight at a private address.
+ *
+ * Same shape as the OIDC redirect check in
+ * `src/app/api/auth/oidc/authorize/route.ts`, which already did this correctly.
+ */
+
+/**
+ * Domains we will fetch images from. An entry matches the host itself and any
+ * subdomain of it — `archive.org` matches `archive.org` and `ia1.us.archive.org`,
+ * but never `evilarchive.org`.
+ */
+export const ALLOWED_IMAGE_HOSTS = [
+  'amazonaws.com',
+  'archive.org',
+  'vercel-storage.com',
+  'r2.dev',                          // Cloudflare R2 (public bucket)
+  'images.sourcelibrary.org',        // Cloudflare R2 (custom domain)
+  // Museum / open-access sources
+  'upload.wikimedia.org',            // Wikimedia Commons (public domain images)
+  'images.metmuseum.org',            // The Metropolitan Museum of Art
+  'openaccess-cdn.clevelandart.org', // Cleveland Museum of Art
+  // IIIF sources
+  'gallica.bnf.fr',
+  'api.digitale-sammlungen.de',      // MDZ/BSB
+  'digi.vatlib.it',                  // Vatican
+  'digital.bodleian.ox.ac.uk',       // Bodleian
+  'iiif.bodleian.ox.ac.uk',
+  'digital.archives.go.jp',          // National Archives of Japan
+  'contentdm.oclc.org',              // ContentDM (Laurenziana, etc.)
+  'uvaerfgoed.nl',                   // UVA heritage collections
+  'rijksmuseum.nl',                  // Rijksmuseum
+  'dl.ndl.go.jp',                    // National Diet Library Japan
+  'e-rara.ch',                       // Swiss libraries
+] as const;
+
+/** IPv4 literal, or null if the string is not one. */
+function parseIPv4(host: string): number[] | null {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!m) return null;
+  const parts = m.slice(1).map(Number);
+  return parts.every(n => n >= 0 && n <= 255) ? parts : null;
+}
+
+/**
+ * True for addresses that must never be reachable through the proxy: loopback,
+ * RFC1918 private space, link-local (which is where cloud instance-metadata
+ * services live), carrier-grade NAT, and the IPv6 equivalents.
+ *
+ * Checked in addition to the allowlist, not instead of it — a hostname that
+ * resolves to a private address still fails the allowlist first. This is the
+ * belt to that suspenders, and it is what catches a redirect hop.
+ */
+export function isForbiddenAddress(host: string): boolean {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, '');
+
+  if (h === 'localhost' || h.endsWith('.localhost') || h.endsWith('.internal') || h.endsWith('.local')) {
+    return true;
+  }
+
+  // IPv6 loopback / link-local / unique-local
+  if (h === '::' || h === '::1' || h.startsWith('fe80:') || h.startsWith('fc') || h.startsWith('fd')) {
+    return true;
+  }
+  // IPv4-mapped IPv6, e.g. ::ffff:169.254.169.254
+  const mapped = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i.exec(h);
+  if (mapped) return isForbiddenAddress(mapped[1]);
+
+  const ip = parseIPv4(h);
+  if (!ip) return false;
+  const [a, b] = ip;
+  if (a === 0 || a === 127) return true;               // this-network, loopback
+  if (a === 10) return true;                            // RFC1918
+  if (a === 172 && b >= 16 && b <= 31) return true;     // RFC1918
+  if (a === 192 && b === 168) return true;              // RFC1918
+  if (a === 169 && b === 254) return true;              // link-local — cloud metadata
+  if (a === 100 && b >= 64 && b <= 127) return true;    // CGNAT
+  if (a >= 224) return true;                            // multicast / reserved
+  return false;
+}
+
+/**
+ * True if we are willing to fetch from this hostname.
+ *
+ * Exact match, or a subdomain separated by a real dot. `archive.org` matches
+ * `archive.org` and `ia1.us.archive.org`; it does NOT match `evilarchive.org`.
+ */
+export function isAllowedImageHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/\.$/, ''); // strip trailing root dot
+  if (!h || isForbiddenAddress(h)) return false;
+  return ALLOWED_IMAGE_HOSTS.some(allowed => h === allowed || h.endsWith('.' + allowed));
+}
+
+/**
+ * Validate a candidate URL for server-side fetching. Returns the reason for
+ * refusal, or null when the URL is acceptable.
+ *
+ * Used both for the caller-supplied `url` and for every redirect `Location`.
+ */
+export function refuseImageUrl(raw: string): string | null {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return 'malformed URL';
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') {
+    return `unsupported protocol ${u.protocol}`;
+  }
+  if (!isAllowedImageHost(u.hostname)) {
+    return 'host not allowed';
+  }
+  return null;
+}

--- a/tests/unit/image-proxy-hosts.test.ts
+++ b/tests/unit/image-proxy-hosts.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { isAllowedImageHost, isForbiddenAddress, refuseImageUrl } from '@/lib/image-proxy-hosts';
+
+/**
+ * `/api/image?url=…` fetches a caller-supplied URL server-side, so this policy
+ * is the only thing between a stranger and our outbound network.
+ *
+ * The bug these pin: the original check was `hostname.endsWith(host)` with no
+ * dot boundary, so anyone who registered a domain ending in an allowlisted
+ * string owned the proxy. Combined with axios's default redirect-following,
+ * that was a route to arbitrary internal addresses.
+ */
+describe('image proxy host policy', () => {
+  describe('legitimate sources still work', () => {
+    it.each([
+      'archive.org',
+      'ia801504.us.archive.org',
+      'gallica.bnf.fr',
+      'images.sourcelibrary.org',
+      'pub-abc123.r2.dev',
+      'my-bucket.s3.eu-central-1.amazonaws.com',
+      'upload.wikimedia.org',
+      'iiif.bodleian.ox.ac.uk',
+      'www.e-rara.ch',
+    ])('allows %s', host => {
+      expect(isAllowedImageHost(host)).toBe(true);
+    });
+  });
+
+  describe('suffix-glue lookalikes are refused', () => {
+    // Every one of these passed the old `endsWith` check.
+    it.each([
+      'evilarchive.org',
+      'xr2.dev',
+      'notamazonaws.com',
+      'my-archive.org',
+      'faker2.dev',
+      'attacker-e-rara.ch',
+      'notgallica.bnf.fr',
+    ])('refuses %s', host => {
+      expect(isAllowedImageHost(host)).toBe(false);
+    });
+
+    it('refuses a host that merely contains an allowed domain', () => {
+      expect(isAllowedImageHost('archive.org.attacker.com')).toBe(false);
+    });
+
+    it('is not fooled by a trailing root dot', () => {
+      expect(isAllowedImageHost('evilarchive.org.')).toBe(false);
+      expect(isAllowedImageHost('archive.org.')).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isAllowedImageHost('EvilArchive.ORG')).toBe(false);
+      expect(isAllowedImageHost('Archive.ORG')).toBe(true);
+    });
+  });
+
+  describe('private and metadata addresses are refused', () => {
+    it.each([
+      '169.254.169.254',   // cloud instance metadata
+      '127.0.0.1',
+      '10.0.0.5',
+      '172.16.4.4',
+      '172.31.255.255',
+      '192.168.1.1',
+      '100.64.0.1',        // CGNAT
+      '0.0.0.0',
+      'localhost',
+      'redis.internal',
+      '::1',
+      'fe80::1',
+      '::ffff:169.254.169.254',
+    ])('refuses %s', host => {
+      expect(isForbiddenAddress(host)).toBe(true);
+      expect(isAllowedImageHost(host)).toBe(false);
+    });
+
+    it('does not refuse public addresses that merely look adjacent', () => {
+      expect(isForbiddenAddress('172.32.0.1')).toBe(false);  // just outside RFC1918
+      expect(isForbiddenAddress('169.253.0.1')).toBe(false);
+      expect(isForbiddenAddress('11.0.0.1')).toBe(false);
+    });
+  });
+
+  describe('refuseImageUrl', () => {
+    it('accepts a real source URL', () => {
+      expect(refuseImageUrl('https://ia801504.us.archive.org/page/n1.jpg')).toBeNull();
+    });
+
+    it('refuses non-http protocols', () => {
+      expect(refuseImageUrl('file:///etc/passwd')).toBeTruthy();
+      expect(refuseImageUrl('gopher://archive.org/')).toBeTruthy();
+      expect(refuseImageUrl('data:image/png;base64,AAAA')).toBeTruthy();
+    });
+
+    it('refuses malformed input', () => {
+      expect(refuseImageUrl('not a url')).toBeTruthy();
+      expect(refuseImageUrl('')).toBeTruthy();
+    });
+
+    it('refuses credentials-in-host confusion', () => {
+      // Parses to host `evil.com`, not `archive.org`.
+      expect(refuseImageUrl('https://archive.org@evil.com/x.jpg')).toBeTruthy();
+    });
+
+    it('refuses the metadata endpoint outright', () => {
+      expect(refuseImageUrl('http://169.254.169.254/latest/meta-data/')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
`/api/image?url=…` performs a server-side fetch of a caller-supplied URL. It *did* check the host against an allowlist — the external review that prompted this assumed it didn't — but the check was `hostname.endsWith(host)` with no dot boundary.

Verified, not theorised:

| host | old rule | new rule |
|---|---|---|
| `evilarchive.org` | ✅ allowed | ❌ refused |
| `xr2.dev` | ✅ allowed | ❌ refused |
| `notamazonaws.com` | ✅ allowed | ❌ refused |
| `my-archive.org` | ✅ allowed | ❌ refused |

Registering a domain ending in one of our allowlisted strings was enough to own the proxy. And `axios` compounded it: it follows up to 5 redirects by default and re-checks nothing, so a permitted (or attacker-glued) origin could `302` us onto a private address.

## What changed

- **Dot-boundary matching.** `archive.org` matches `archive.org` and `ia1.us.archive.org`, never `evilarchive.org`. Same shape `src/app/api/auth/oidc/authorize/route.ts` already used correctly.
- **Private-address refusal.** Loopback, RFC1918, link-local (`169.254.0.0/16` — where cloud metadata lives), CGNAT, multicast, and IPv6 equivalents including `::ffff:`-mapped forms.
- **Protocol check.** `http`/`https` only, so `file://` and `data:` are refused explicitly rather than incidentally.
- **Per-hop redirect validation.** `maxRedirects: 0` and a hand-rolled follow loop that runs every `Location` through the same policy. A refused hop returns 403 and is not retried.
- **Rate limit** — 600 req/min per IP, `IMAGE_PROXY_PER_MIN` to tune. Even with a tight allowlist this is a free image resizer over some very large public buckets.

## Severity, honestly

Lower than it reads. Vercel runs on Lambda, which has **no EC2 instance-metadata service**, so the classic `169.254.169.254` IAM-credential theft doesn't apply to us — credentials arrive as env vars and aren't reachable over HTTP. The realistic abuse was an anonymous fetch-and-resize proxy on our compute and bandwidth. Worth fixing properly; not worth a panic.

## Regression check

The risk in tightening a host rule is breaking real images. Sampled 5,000 pages (~19K image references, 31 distinct hosts) from production and ran both rules:

**Nothing the old rule allowed is newly blocked.** Zero regressions.

## The guard

`tests/unit/image-proxy-hosts.test.ts` — 38 cases. Negative-controlled per CLAUDE.md: restoring the bare-suffix rule turns 9 of them red. Verified by running it, not by reading it.

## Out of scope (found while measuring, deliberately not fixed here)

The sample surfaced **1,735 references (~9%) pointing at hosts the proxy refuses** — `images.eap.bl.uk` (1,091), `mps.lib.harvard.edu` (290), `iiif.bdrc.io`, `content.staatsbibliothek-berlin.de`, `commons.wikimedia.org` and others. These were **already** blocked under the old rule; this PR does not change their status. Whether they should be on the allowlist is a separate question about which sources we serve through the proxy at all — filing separately rather than widening an allowlist inside a PR that exists to narrow one.

Found via an external security review filed through the public MCP `submit_feedback` tool. Feedback-ID: 6a6d49ba5797a2a6ecce4ba4

🤖 Generated with [Claude Code](https://claude.com/claude-code)