### PR TITLE
Measure AI-agent traffic server-side, split by operator

### DIFF
--- a/src/lib/agent-requests.ts
+++ b/src/lib/agent-requests.ts
@@ -1,0 +1,117 @@
+import type { NextRequest } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { classifyTraffic, type TrafficClass } from '@/lib/traffic-classification';
+
+/**
+ * Server-side counter for non-human requests, written from the proxy.
+ *
+ * Why this exists, and why it is not `analytics_traffic_class`:
+ *
+ * `analytics_traffic_class` is fed by `/api/track`, which is a **client-side
+ * beacon**. Bots do not execute JavaScript, so a server-rendered request from
+ * OAI-SearchBot never fires it. The classifier there is correct; it is simply
+ * positioned downstream of the traffic it is meant to classify. Measured
+ * 2026-08-01: that counter read `ai_agent: 2` over 30 days, while curl proved
+ * OAI-SearchBot and ChatGPT-User both receive full 330KB book pages (200), and
+ * `analytics_pageviews` recorded 5 Googlebot hits in the same window on a
+ * 36,000-book site. Those were not measurements of low bot traffic. They were
+ * not measurements of bot traffic. See #3519.
+ *
+ * The proxy sees every request including bots, so this is the only point where
+ * the evidence exists — the same "classify at WRITE time, at ingestion" rule
+ * CLAUDE.md draws from #3405, applied one layer up.
+ *
+ * **Separate collection, deliberately.** Humans are ~99% of traffic and are
+ * already counted by the beacon; incrementing the same counter here would
+ * double-count them and silently corrupt an existing long-term series. So this
+ * records non-human classes only, in its own collection, and the two are never
+ * summed.
+ *
+ * Two things it records that the beacon never could:
+ *   - **the operator**, not just the class — "how much does OpenAI use us" is
+ *     unanswerable from a single `ai_agent` bucket;
+ *   - **refusals**, because a blocked training crawler's attempt rate is
+ *     evidence of demand for the licence published at /licensing.
+ */
+
+/** Operator behind a user-agent. Coarse on purpose — one row per operator per day. */
+const OPERATORS: ReadonlyArray<readonly [string, RegExp]> = [
+  ['openai', /gptbot|oai-searchbot|chatgpt-user/i],
+  ['anthropic', /claudebot|claude-web|claude-user|anthropic-ai|claude-searchbot/i],
+  ['google', /googlebot|googleother|google-extended|google-cloudvertexbot|gemini-user/i],
+  ['perplexity', /perplexitybot|perplexity-user/i],
+  ['meta', /meta-externalagent|facebookbot/i],
+  ['bytedance', /bytespider/i],
+  ['amazon', /amazonbot/i],
+  ['apple', /applebot/i],
+  ['microsoft', /bingbot|bingpreview/i],
+  ['commoncrawl', /ccbot/i],
+  ['cohere', /cohere-ai/i],
+  ['duckduckgo', /duckduckbot|duckassistbot/i],
+];
+
+/** Which company's agent is this? `other` when no operator pattern matches. */
+export function operatorFor(userAgent: string | null | undefined): string {
+  const ua = userAgent || '';
+  for (const [name, re] of OPERATORS) if (re.test(ua)) return name;
+  return 'other';
+}
+
+export interface AgentRequestRecord {
+  cls: TrafficClass;
+  operator: string;
+  /** 'served' when we returned content, 'refused' when the request was blocked. */
+  outcome: 'served' | 'refused';
+}
+
+/**
+ * Classify a request and, if it is non-human, return what should be counted.
+ * Returns null for human traffic (already counted by the beacon — see above).
+ */
+export function classifyAgentRequest(
+  request: NextRequest,
+  outcome: 'served' | 'refused',
+): AgentRequestRecord | null {
+  const ua = request.headers.get('user-agent') || '';
+  const cls = classifyTraffic(ua, {
+    verifiedBot: request.headers.get('cf-verified-bot') === 'true',
+  });
+  if (cls === 'human') return null;
+  return { cls, operator: operatorFor(ua), outcome };
+}
+
+/**
+ * Increment the per-day/host/class/operator/outcome counter.
+ *
+ * Aggregate only: no per-request rows, no IP, no path, no TTL. One document per
+ * (day, host, class, operator, outcome) combination — a few dozen a day at most.
+ *
+ * Never awaited by the proxy: a counter must not be able to delay or fail a
+ * page. Errors are swallowed here and only here.
+ */
+export async function recordAgentRequest(
+  host: string,
+  rec: AgentRequestRecord,
+): Promise<void> {
+  try {
+    const day = new Date().toISOString().slice(0, 10);
+    const db = await getDb();
+    await db.collection('analytics_agent_requests').updateOne(
+      { _id: `${day}|${host}|${rec.cls}|${rec.operator}|${rec.outcome}` } as never,
+      {
+        $inc: { count: 1 },
+        $setOnInsert: {
+          day,
+          host,
+          class: rec.cls,
+          operator: rec.operator,
+          outcome: rec.outcome,
+        },
+      },
+      { upsert: true },
+    );
+  } catch {
+    // A measurement must never break a page. Silence is correct here and
+    // nowhere else in this module.
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,6 +6,7 @@ import { isGlobalOnlyTenantPath } from '@/lib/tenant-global-paths';
 import { retiredCollectionMessage } from '@/lib/retired-collections';
 import { shouldRedirectToCanonical, canonicalUrl, aliasPolicyForHost } from '@/lib/alias-host-scope';
 import { isBlockedNetwork, BLOCKED_NETWORK_RESPONSE } from '@/lib/blocked-networks';
+import { classifyAgentRequest, recordAgentRequest } from '@/lib/agent-requests';
 
 // Precomputed variant-slug → canonical-slug map for /author URL dedup (#2250).
 // Bundled because the proxy runs at the edge with no DB access; regenerate with
@@ -583,6 +584,30 @@ function pickOgVariantForToday(now: Date = new Date()): string {
   return OG_VARIANTS[dayOfYear % OG_VARIANTS.length];
 }
 
+/**
+ * Fire-and-forget non-human request counter. Deliberately not awaited: a
+ * measurement must never delay or fail a page. `recordAgentRequest` swallows
+ * its own errors; the extra `.catch` guards the classify step too.
+ */
+function countAgentRequest(request: NextRequest, outcome: 'served' | 'refused'): void {
+  try {
+    const rec = classifyAgentRequest(request, outcome);
+    if (!rec) return; // human — already counted by the /api/track beacon
+    void recordAgentRequest(resolveHostForAgentCount(request), rec).catch(() => {});
+  } catch {
+    // never surfaces
+  }
+}
+
+function resolveHostForAgentCount(request: NextRequest): string {
+  return (request.headers.get('x-forwarded-host') || request.headers.get('host') || 'sourcelibrary.org')
+    .split(',')[0]
+    .trim()
+    .toLowerCase()
+    .replace(/:\d+$/, '')
+    .replace(/^www\./, '');
+}
+
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -832,10 +857,17 @@ export async function proxy(request: NextRequest) {
   // --- Bot enforcement (before any other logic) ---
   const ua = request.headers.get('user-agent') || '';
 
+  // Count non-human traffic server-side. The `/api/track` beacon cannot see
+  // bots (they run no JavaScript), which is why `analytics_traffic_class` read
+  // `ai_agent: 2` over 30 days while OpenAI's agents were pulling whole books.
+  // Recorded here, at the only point where the evidence exists. #3519
+  countAgentRequest(request, 'served');
+
   // Hard block: bots explicitly forbidden in robots.txt — except on the
   // policy/licensing docs, which robots.txt grants to every reserved crawler.
   if (BLOCKED_BOT_RE.test(ua) && !isBotReadablePath(pathname)) {
     logBotAccess(request, 'blocked');
+    countAgentRequest(request, 'refused');
     return new NextResponse(BOT_RESPONSE, {
       status: 403,
       headers: { 'Content-Type': 'text/plain; charset=utf-8', 'X-Robots-Tag': 'noindex, nofollow' },

--- a/tests/unit/agent-requests.test.ts
+++ b/tests/unit/agent-requests.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { operatorFor, classifyAgentRequest } from '@/lib/agent-requests';
+
+// Guards #3519: `analytics_traffic_class` read `ai_agent: 2` over 30 days while
+// curl proved OAI-SearchBot and ChatGPT-User were both being served full 330KB
+// book pages. The beacon cannot see bots; this counter runs in the proxy, which
+// can. The two properties that make it useful are (a) per-operator attribution
+// and (b) counting refusals — neither is answerable from a single class bucket.
+
+const req = (ua: string) =>
+  ({ headers: new Headers({ 'user-agent': ua }) }) as unknown as Parameters<typeof classifyAgentRequest>[0];
+
+describe('operatorFor', () => {
+  it.each([
+    ['Mozilla/5.0 (compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot)', 'openai'],
+    ['Mozilla/5.0 (compatible; ChatGPT-User/1.0; +https://openai.com/bot)', 'openai'],
+    ['Mozilla/5.0 AppleWebKit/537.36; compatible; GPTBot/1.1; +https://openai.com/gptbot', 'openai'],
+    ['Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)', 'anthropic'],
+    ['Mozilla/5.0 (compatible; PerplexityBot/1.0)', 'perplexity'],
+    ['Mozilla/5.0 (compatible; Googlebot/2.1)', 'google'],
+    ['Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/120 Safari/537.36', 'other'],
+  ])('maps %s → %s', (ua, expected) => {
+    expect(operatorFor(ua)).toBe(expected);
+  });
+});
+
+describe('classifyAgentRequest', () => {
+  it('returns null for humans so the beacon series is never double-counted', () => {
+    expect(classifyAgentRequest(req('Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/120 Safari/537.36'), 'served')).toBeNull();
+  });
+
+  it('records OpenAI assistant fetches as ai_agent — the traffic the beacon misses', () => {
+    expect(classifyAgentRequest(req('Mozilla/5.0 (compatible; ChatGPT-User/1.0; +https://openai.com/bot)'), 'served'))
+      .toEqual({ cls: 'ai_agent', operator: 'openai', outcome: 'served' });
+  });
+
+  it('records OpenAI search crawling separately from its training crawler', () => {
+    expect(classifyAgentRequest(req('Mozilla/5.0 (compatible; OAI-SearchBot/1.0)'), 'served')?.cls).toBe('ai_agent');
+    expect(classifyAgentRequest(req('compatible; GPTBot/1.1; +https://openai.com/gptbot'), 'refused')?.cls).toBe('ai_trainer');
+  });
+
+  it('records a refusal, because attempts against the block are licence demand', () => {
+    expect(classifyAgentRequest(req('compatible; GPTBot/1.1'), 'refused'))
+      .toEqual({ cls: 'ai_trainer', operator: 'openai', outcome: 'refused' });
+  });
+});


### PR DESCRIPTION
Closes #3519.

## The number we could not produce

We are about to talk to frontier labs. The most persuasive opening available is *"your assistants fetched N pages from our library last month."* We could not produce N.

Verified 2026-08-01 by curl per UA against a book page — the test CLAUDE.md's crawler section prescribes:

| Agent | Status | Bytes |
|---|---|---|
| **OAI-SearchBot** | **200** | 330,696 |
| **ChatGPT-User** | **200** | 330,696 |
| GPTBot (training) | 403 | 25 |
| ClaudeBot (training) | 403 | 25 |

The policy works as designed. But in the same 30 days the instruments said:

| Instrument | Reading |
|---|---|
| `analytics_traffic_class` | human 338,751 · other_bot 2,255 · search_crawler 1,419 · **ai_agent 2** |
| `analytics_pageviews` UA regex | 0 OpenAI · **5 Googlebot** |

Five Googlebot pageviews in a month on a 36,000-book site is the tell. Those are not measurements of low bot traffic — they are not measurements of bot traffic.

## Why, and why the fix goes in the proxy

`analytics_traffic_class` is fed by `/api/track`, a **client-side beacon**. Bots do not run JavaScript, so a server-rendered request from OAI-SearchBot never fires it. `classifyTraffic` is correct; it is positioned downstream of the traffic it classifies.

The proxy sees every request including bots. That is the only point where the evidence exists — the same *"classify at WRITE time, at ingestion"* rule CLAUDE.md draws from #3405, applied one layer up.

## Design notes

**Separate collection, deliberately.** Humans are ~99% of traffic and already counted by the beacon. Incrementing `analytics_traffic_class` from the proxy would double-count them and silently corrupt an existing long-term series. `analytics_agent_requests` records non-human classes only; the two are never summed.

**Aggregate only** — one row per `day|host|class|operator|outcome`, a few dozen a day. No per-request rows, no IP, no path, no TTL.

**Per-operator attribution**, because "how much does OpenAI use us" is unanswerable from a single `ai_agent` bucket. That is the actual deliverable.

**Refusals counted**, because a blocked training crawler's attempt rate is evidence of demand for the $200k/yr licence published at /licensing.

**Fire-and-forget, errors swallowed.** A counter must never delay or fail a page. `recordAgentRequest` swallows its own errors and the proxy never awaits it — the one place in this codebase where swallowing is correct, and the opposite of the call I made in #3506 for search, where an empty result was masquerading as an answer.

**Reuses `classifyTraffic`** rather than forking the taxonomy.

## Tests

`tests/unit/agent-requests.test.ts` — 11 passing: operator mapping for OpenAI/Anthropic/Google/Perplexity, humans returning null so the beacon series stays clean, OAI-SearchBot classified `ai_agent` while GPTBot is `ai_trainer`, and refusals recorded.

Full unit suite: **102 files, 1,216 tests, all passing.** `npx tsc --noEmit` clean.

## After merge

No backfill is possible — those requests were never recorded. **Report the pre-fix period as `unmeasured`, never zero.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)