### PR TITLE
fix(archive): 403 is not auto-clearable — it is in-copyright material here

### DIFF
--- a/scripts/lib/archive-failure-class.mjs
+++ b/scripts/lib/archive-failure-class.mjs
@@ -21,10 +21,33 @@
  * it alone — an unclassified marker is not evidence of recoverability.
  */
 
+/**
+ * 403 is NOT retryable by default, despite looking like a transient block.
+ *
+ * It was classified transient on the reasoning that "403 means the provider
+ * refused us, not that the page is absent." That reasoning is right about the
+ * HTTP semantics and wrong about this corpus. 8,583 of 9,767 clearable markers
+ * (88%) are Internet Archive, and a sample resolved to `naghammadilibrar00jame`
+ * — Robinson's *Nag Hammadi Library in English* (1981), which IA reports as
+ * `access-restricted-item: true`, collections `inlibrary` / `printdisabled`.
+ *
+ * That 403 is IA correctly refusing to serve an IN-COPYRIGHT book. Clearing it
+ * re-queues a fetch that must never succeed — and if it ever did, we would be
+ * mirroring copyrighted pages into R2. The failure is doing its job.
+ *
+ * So bare 403 is now UNKNOWN: reported, never auto-cleared. Genuine rate-limit
+ * 403s do exist, so the ability to clear them is preserved behind an explicit
+ * opt-in (`--include-403`) for a caller who has checked the specific population
+ * — e.g. confirmed the books are public domain. The default must be the safe
+ * one, because the cost of being wrong here is a rights problem, not a retry.
+ */
+const RIGHTS_SENSITIVE = [
+  /HTTP 403/i,
+];
+
 /** Retryable: the source blocked, timed out, or the transfer broke mid-flight. */
 const TRANSIENT = [
-  /HTTP 403/i,          // provider block / rate limit — not "page absent"
-  /HTTP 429/i,
+  /HTTP 429/i,          // explicit rate limit — a real "slow down", not a refusal
   /HTTP 5\d\d/,         // any 5xx
   /timeout/i,
   /terminated/i,
@@ -45,14 +68,19 @@ const PERMANENT = [
 export const FAILURE_CLASS = {
   TRANSIENT: 'transient',
   PERMANENT: 'permanent',
+  /** Reported and left alone. Includes 403 unless explicitly opted in. */
   UNKNOWN: 'unknown',
 };
 
 /**
  * @param {string|null|undefined} archivedPhoto the raw field value
+ * @param {{ include403?: boolean }} [opts] `include403` opts a caller INTO
+ *   treating 403 as transient. Only pass it after checking that the affected
+ *   books are public domain — on this corpus 403 is dominated by IA
+ *   `access-restricted-item` (in-copyright) material.
  * @returns {{ isMarker: boolean, class: string, reason: string|null }}
  */
-export function classifyArchiveFailure(archivedPhoto) {
+export function classifyArchiveFailure(archivedPhoto, opts = {}) {
   if (typeof archivedPhoto !== 'string' || !archivedPhoto.startsWith('failed:')) {
     return { isMarker: false, class: null, reason: null };
   }
@@ -62,6 +90,15 @@ export function classifyArchiveFailure(archivedPhoto) {
   // we should not keep asking for.
   if (PERMANENT.some(re => re.test(reason))) {
     return { isMarker: true, class: FAILURE_CLASS.PERMANENT, reason };
+  }
+  // Rights-sensitive before transient: a 403 that also mentions a timeout is
+  // still a refusal, and must not be swept in on the timeout.
+  if (RIGHTS_SENSITIVE.some(re => re.test(reason))) {
+    return {
+      isMarker: true,
+      class: opts.include403 ? FAILURE_CLASS.TRANSIENT : FAILURE_CLASS.UNKNOWN,
+      reason,
+    };
   }
   if (TRANSIENT.some(re => re.test(reason))) {
     return { isMarker: true, class: FAILURE_CLASS.TRANSIENT, reason };

--- a/scripts/maintenance/clear-transient-archive-failures.mjs
+++ b/scripts/maintenance/clear-transient-archive-failures.mjs
@@ -42,6 +42,11 @@ const APPLY = args.includes('--apply');
 const BOOK_ID = getArg('book-id') || null;
 const MAX_PER_PROVIDER = parseInt(getArg('max-per-provider') || '0', 10) || Infinity;
 const LIMIT = parseInt(getArg('limit') || '0', 10) || Infinity;
+// Opt IN to clearing HTTP 403 markers. OFF by default: on this corpus 403 is
+// dominated by Internet Archive `access-restricted-item` books — IA correctly
+// refusing to serve in-copyright material. Only pass this after checking the
+// affected books are public domain.
+const INCLUDE_403 = args.includes('--include-403');
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('Missing MONGODB_URI'); process.exit(1); }
@@ -54,6 +59,11 @@ async function main() {
   const query = { archived_photo: { $regex: '^failed:' } };
   if (BOOK_ID) query.book_id = BOOK_ID;
 
+  if (INCLUDE_403) {
+    console.log('[clear-failures] WARNING: --include-403 is ON. 403 on this corpus is dominated by');
+    console.log('                 IA access-restricted (in-copyright) books. Confirm the affected');
+    console.log('                 books are public domain before applying.');
+  }
   console.log(`[clear-failures] ${APPLY ? 'APPLY' : 'DRY RUN'}${BOOK_ID ? ` book=${BOOK_ID}` : ''}` +
     `${MAX_PER_PROVIDER !== Infinity ? ` max-per-provider=${MAX_PER_PROVIDER}` : ''}`);
 
@@ -93,7 +103,7 @@ async function main() {
       const secs = ((Date.now() - t0) / 1000).toFixed(0);
       process.stdout.write(`  …scanned ${scanned} markers (${secs}s)\n`);
     }
-    const { class: cls } = classifyArchiveFailure(page.archived_photo);
+    const { class: cls } = classifyArchiveFailure(page.archived_photo, { include403: INCLUDE_403 });
     byClass[cls] = (byClass[cls] || 0) + 1;
     const key = failureReasonKey(page.archived_photo);
     if (key) byReason[key] = (byReason[key] || 0) + 1;

--- a/tests/unit/archive-failure-class.test.ts
+++ b/tests/unit/archive-failure-class.test.ts
@@ -27,11 +27,30 @@ describe('classifyArchiveFailure', () => {
     }
   });
 
-  it('treats a provider block as transient — 403 is not "page absent"', () => {
-    // 93.5% of the 14,123 production markers. Getting this wrong strands them all.
+  it('does NOT auto-clear 403 — on this corpus it is in-copyright material', () => {
+    // 8,583 of 9,767 clearable markers were Internet Archive, and a sample
+    // resolved to `naghammadilibrar00jame` (Robinson, Nag Hammadi Library in
+    // English, 1981) which IA reports as access-restricted-item: true. That 403
+    // is IA correctly refusing to serve a copyrighted book. Clearing it
+    // re-queues a fetch that must never succeed.
     const r = classifyArchiveFailure('failed:HTTP 403');
     expect(r.isMarker).toBe(true);
-    expect(r.class).toBe(FAILURE_CLASS.TRANSIENT);
+    expect(r.class).toBe(FAILURE_CLASS.UNKNOWN);
+    expect(r.class).not.toBe(FAILURE_CLASS.TRANSIENT);
+  });
+
+  it('allows 403 to be cleared only via explicit opt-in', () => {
+    // Genuine rate-limit 403s exist, so the capability is preserved — but the
+    // caller must assert they checked the population.
+    expect(classifyArchiveFailure('failed:HTTP 403', { include403: true }).class)
+      .toBe(FAILURE_CLASS.TRANSIENT);
+  });
+
+  it('keeps a 403 out of the sweep even when the reason also names a timeout', () => {
+    // Rights-sensitive must beat transient, or a compound message smuggles a
+    // refusal in through the timeout pattern.
+    expect(classifyArchiveFailure('failed:HTTP 403 after timeout').class)
+      .toBe(FAILURE_CLASS.UNKNOWN);
   });
 
   it('treats broken transfers as transient', () => {


### PR DESCRIPTION
## Correcting my own rule from #3500

#3500 classified `HTTP 403` as **transient**, on the reasoning that a 403 means the provider refused us rather than that the page is absent. That is right about HTTP semantics and **wrong about this corpus.**

8,583 of 9,767 clearable markers (88%) are Internet Archive. Sampling them resolved to `naghammadilibrar00jame` — Robinson's *Nag Hammadi Library in English* (1981):

```
access-restricted-item: true
collection: [internetarchivebooks, inlibrary, printdisabled]
```

That 403 is **IA correctly refusing to serve an in-copyright book.** Clearing the marker re-queues a fetch that must never succeed — and if one ever did, we'd be mirroring copyrighted pages into R2. The failure was doing its job; the sweep was trying to undo it.

## No harm done, verified

That book has **0** pages with a real `archived_photo` — nothing copyrighted was mirrored. It's `status: draft` with no `visible` flag, so not reader-facing either.

## The change

- Bare `403` → `UNKNOWN`: reported, **never auto-cleared**.
- Genuine rate-limit 403s exist, so the capability survives behind `--include-403`, which prints a warning and is documented as requiring the caller to confirm the affected books are public domain.
- **Rights-sensitive is checked before transient**, so a compound reason (`"HTTP 403 after timeout"`) can't smuggle a refusal in through the timeout pattern.
- `429` stays transient — an explicit "slow down" is a real rate limit, unlike a flat refusal.

## Consequence for the standing plan

**Do not clear the remaining 7,583 IA markers.** The ~1,000 already cleared are inert in practice (pipeline paused; a retry hits the lending gate and re-marks) but should be restored — I'm tracking that separately rather than bundling a data write into a code PR.

## Why default-safe

The asymmetry decides it: being wrong in the "leave it alone" direction costs a retry that never happens. Being wrong in the "clear it" direction is a rights problem. On a corpus where 88% of the population is in-copyright lending material, the default has to be the safe one.

## Testing

`npx vitest run` — 1318 pass. New cases pin: 403 is not transient by default; opt-in restores it; a compound 403+timeout reason stays out of the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)