### PR TITLE
Hero fade-in: final tuning (300ms fade + cover fade)

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1432,12 +1432,11 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                 </div>
               </div>
 
-              {/* Staff-only edit link (in-book search moved to the sub-nav + combo section) */}
-              <AuthCheck role="inner_circle">
-                <div className="mt-4 md:mt-5 text-[13.5px]">
-                  <Link href={`/book/${bookSlug}/edit`} className="transition-colors" style={{ color: '#d98a72' }}>✎ Edit</Link>
-                </div>
-              </AuthCheck>
+              {/* NOTE: the old staff-only "✎ Edit" link here pointed at
+                  /book/[id]/edit, which doesn't exist (dead 404), and popping in
+                  after the auth check re-centered the vertically-centred hero —
+                  the cover/title "jump". Removed. Editing is via the "Edit"
+                  button in the Bibliographic information panel (BookEditModal). */}
             </div>
           )}
         />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -832,16 +832,21 @@ html[data-sl-hide-ai="1"] [data-view-section="ai-summary-catalog"] {
    instantly from R2. A named animation (not a Tailwind transition) guarantees
    the ~1.9s timing regardless of how fast the load fires. */
 .hero-focus-in {
-  animation: hero-focus-in 1900ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: hero-focus-in 1000ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 @media (prefers-reduced-motion: reduce) {
   .hero-focus-in { animation: none; opacity: 1; filter: none; transform: none; }
 }
+/* dark → recognizable-but-soft page scans (you can make out lines of text and
+   the coloured blobs of illustrations) → sharp. A light 11px start blur keeps
+   the tiles readable-as-pages the whole way — a heavier blur washed to a flat
+   light tone first, which read as "dark → light → pages". */
 @keyframes hero-focus-in {
-  0%   { opacity: 0; filter: blur(30px); transform: scale(1.12); }
-  28%  { opacity: 1; filter: blur(22px); transform: scale(1.08); }
+  0%   { opacity: 0; filter: blur(11px); transform: scale(1.03); }
+  45%  { opacity: 1; filter: blur(7px);  }
   100% { opacity: 1; filter: blur(0);    transform: scale(1); }
 }
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 
 /* ── Section reveal-in (book page) ────────────────────────────────────────────
    Sections fade + rise as they scroll into view. Pure CSS via a scroll-driven

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -832,7 +832,7 @@ html[data-sl-hide-ai="1"] [data-view-section="ai-summary-catalog"] {
    instantly from R2. A named animation (not a Tailwind transition) guarantees
    the ~1.9s timing regardless of how fast the load fires. */
 .hero-focus-in {
-  animation: hero-focus-in 1000ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: hero-focus-in 500ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 @media (prefers-reduced-motion: reduce) {
   .hero-focus-in { animation: none; opacity: 1; filter: none; transform: none; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -831,20 +831,29 @@ html[data-sl-hide-ai="1"] [data-view-section="ai-summary-catalog"] {
    run) so the sharpening is clearly visible even though the image itself loads
    instantly from R2. A named animation (not a Tailwind transition) guarantees
    the ~1.9s timing regardless of how fast the load fires. */
+/* Mosaic background: a plain fade + subtle zoom (no blur), played once the
+   mosaic image has loaded (so on unseen books it waits for the composite). */
 .hero-focus-in {
-  animation: hero-focus-in 500ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: hero-focus-in 300ms ease-out both;
 }
-@media (prefers-reduced-motion: reduce) {
-  .hero-focus-in { animation: none; opacity: 1; filter: none; transform: none; }
-}
-/* dark → recognizable-but-soft page scans (you can make out lines of text and
-   the coloured blobs of illustrations) → sharp. A light 11px start blur keeps
-   the tiles readable-as-pages the whole way — a heavier blur washed to a flat
-   light tone first, which read as "dark → light → pages". */
 @keyframes hero-focus-in {
-  0%   { opacity: 0; filter: blur(11px); transform: scale(1.03); }
-  45%  { opacity: 1; filter: blur(7px);  }
-  100% { opacity: 1; filter: blur(0);    transform: scale(1); }
+  0%   { opacity: 0; transform: scale(1.05); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+/* Cover: the SAME fade, but NO zoom — and it plays on page load, independent of
+   the mosaic, so the cover fades in straight away even on an unseen book whose
+   mosaic hasn't generated yet. */
+.hero-cover-in {
+  animation: hero-cover-in 300ms ease-out both;
+}
+@keyframes hero-cover-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-focus-in, .hero-cover-in { animation: none; opacity: 1; transform: none; }
 }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -824,6 +824,25 @@ html[data-sl-hide-ai="1"] [data-view-section="ai-summary-catalog"] {
   fill: var(--accent-rust) !important;
 }
 
+/* ── Hero mosaic focus-in ─────────────────────────────────────────────────────
+   The background mosaic fades in fast, then the blur resolves slowly — a
+   deliberate "come into focus" rather than a hard pop. Opacity and blur are
+   decoupled on the keyframe timeline (opacity done by ~28%, blur over the full
+   run) so the sharpening is clearly visible even though the image itself loads
+   instantly from R2. A named animation (not a Tailwind transition) guarantees
+   the ~1.9s timing regardless of how fast the load fires. */
+.hero-focus-in {
+  animation: hero-focus-in 1900ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .hero-focus-in { animation: none; opacity: 1; filter: none; transform: none; }
+}
+@keyframes hero-focus-in {
+  0%   { opacity: 0; filter: blur(30px); transform: scale(1.12); }
+  28%  { opacity: 1; filter: blur(22px); transform: scale(1.08); }
+  100% { opacity: 1; filter: blur(0);    transform: scale(1); }
+}
+
 /* ── Section reveal-in (book page) ────────────────────────────────────────────
    Sections fade + rise as they scroll into view. Pure CSS via a scroll-driven
    view() timeline — no JS, no IntersectionObserver, no hydration flash.

--- a/src/components/book/BookAnalytics.tsx
+++ b/src/components/book/BookAnalytics.tsx
@@ -42,13 +42,15 @@ export default function BookAnalytics({ bookId, className, iconOnly = false }: B
 
   const colorClass = className || 'text-stone-400';
 
-  // Show placeholder while loading to prevent layout shift
+  // Reserve the exact final footprint while loading (a fixed-width, non-pulsing
+  // count slot) so the number appearing doesn't shift the row — the pulsing bar
+  // read as "jumpy". The value fades in when it arrives.
   if (!stats) {
     return (
       <div className={`flex items-center gap-4 text-sm ${colorClass}`}>
         <div className="flex items-center gap-1.5">
-          <Eye className="w-4 h-4 opacity-50" />
-          <span className="w-8 h-4 bg-current/20 rounded animate-pulse" />
+          <Eye className="w-4 h-4" />
+          {!iconOnly && <span className="inline-block min-w-[1.75rem] tabular-nums" aria-hidden>&nbsp;</span>}
         </div>
       </div>
     );
@@ -58,7 +60,7 @@ export default function BookAnalytics({ bookId, className, iconOnly = false }: B
     <div className={`flex items-center gap-4 text-sm ${colorClass}`}>
       <div className="flex items-center gap-1.5" title="Times viewed">
         <Eye className="w-4 h-4" />
-        {!iconOnly && <span>{stats.reads}</span>}
+        {!iconOnly && <span className="inline-block min-w-[1.75rem] tabular-nums animate-[fadeIn_260ms_ease-out]">{stats.reads}</span>}
       </div>
       {(stats.edits ?? 0) > 0 && (
         <div className="flex items-center gap-1.5" title="Edits made">

--- a/src/components/book/HeroVariants.tsx
+++ b/src/components/book/HeroVariants.tsx
@@ -80,8 +80,8 @@ export default function HeroVariants({
         onLoad={reveal}
         onError={onBgError}
         loading="eager"
-        className={`absolute inset-0 w-full h-full object-cover transition-[opacity,filter,transform] duration-[1600ms] delay-150 ease-out will-change-[opacity,filter,transform] ${
-          revealed ? 'opacity-100 blur-0 scale-100' : 'opacity-0 blur-[26px] scale-[1.10]'
+        className={`absolute inset-0 w-full h-full object-cover will-change-[opacity,filter,transform] ${
+          revealed ? 'hero-focus-in' : 'opacity-0'
         }`}
       />
     ) : null;

--- a/src/components/book/HeroVariants.tsx
+++ b/src/components/book/HeroVariants.tsx
@@ -127,7 +127,7 @@ export default function HeroVariants({
         <div className="flex flex-row-reverse items-start gap-4 md:contents">
           {/* Cover: 1/3 of the container on mobile (auto height); the large
               left-hand cover on desktop. */}
-          <div className="w-1/3 md:w-auto flex-shrink-0
+          <div className="hero-cover-in w-1/3 md:w-auto flex-shrink-0
             [&_img]:!w-full [&_img]:!h-auto [&_img]:!max-w-none [&_img]:!max-h-none
             md:[&_img]:!w-auto md:[&_img]:!h-[420px] md:[&_img]:!max-h-none md:[&_img]:!max-w-[min(44vw,520px)]">
             {cover}


### PR DESCRIPTION
## Hero fade-in: final tuning (ships the tail of #3397)

PR #3397 auto-merged at an early snapshot, before these were finalized — so prod
has the perf + section reveals but an older, subtle blur-in and still the dead
edit link. This carries the remaining, user-approved hero polish onto current main.

- **Mosaic blur-in → plain 300ms fade + subtle zoom (no blur)**, `ease-out`. (Dialed in via a live playground.)
- **Cover fades in too** — same 300ms, **no zoom** — and its fade is **independent of the mosaic** (CSS on load), so on an unseen book whose mosaic is still compositing, the cover still fades in immediately instead of waiting.
- **Load jumpiness fixed**: removed the dead `/book/[id]/edit` link (404; it re-centred the vertically-centred hero on auth), and the view-count stat now reserves width + fades in instead of a pulsing bar that popped.

Cherry-picked cleanly onto current main (only `page.tsx` had moved; no conflicts). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
