### PR TITLE
fix(press): redirect /press and /press/* instead of 404ing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -338,6 +338,19 @@ const nextConfig: NextConfig = {
         destination: '/collections',
         permanent: false,
       },
+      // The themed press pages were archived (src/app/_archived/press) when the
+      // press room moved to /press-releases, but nothing was left in their place
+      // — /press and all six /press/<theme> URLs 404 for inbound links.
+      {
+        source: '/press',
+        destination: '/press-releases',
+        permanent: true,
+      },
+      {
+        source: '/press/:path*',
+        destination: '/press-releases',
+        permanent: true,
+      },
       // Embassy → Reading Room → Librarian rename chain
       {
         source: '/embassy',

--- a/src/app/admin/system-map/page.tsx
+++ b/src/app/admin/system-map/page.tsx
@@ -188,7 +188,7 @@ const serviceData: Record<string, ServiceInfo> = {
       'Gallery: /gallery extracts illustrations from historical books with AI-generated metadata (subjects, symbols, technique, art period). Supports similarity search via vector embeddings.',
       'Encyclopedia: /encyclopedia/[name] has auto-generated entity pages for people, places, and concepts mentioned across the corpus.',
       'Blog: 29 posts at /blog/*, all hardcoded as JSX components (no CMS or MDX). Topics range from origin story to OCR methodology to progress updates.',
-      'Press: 6 themed press releases at /press/* — alchemy, hermetic tradition, kabbalah, origins of science, world sacred texts, BPH partnership.',
+      'Press: the press room lives at /press-releases (index + /press-releases/[slug] per release). The old themed /press/* pages are archived; /press and /press/* redirect to /press-releases.',
       'Ficino Society: /ficino-society has membership landing, discussion forum, and member directory. Gated by Stripe subscription ($100/year).',
       'Admin: /admin/* has ~15 dashboard pages for pipeline control, collection management, email campaigns, social media, KDP publishing, and duplicate detection.',
     ],

--- a/src/app/blog/progress-studies/page.tsx
+++ b/src/app/blog/progress-studies/page.tsx
@@ -602,12 +602,6 @@ export default function ProgressStudiesPage() {
                 internal: true,
               },
               {
-                href: '/press/origins-of-science',
-                title: 'The Mystic Who Discovered Planetary Motion',
-                detail: 'How Kepler\'s occult beliefs led to modern astronomy',
-                internal: true,
-              },
-              {
                 href: 'https://www.theatlantic.com/science/archive/2019/07/we-need-new-science-progress/594946/',
                 title: 'We Need a New Science of Progress',
                 detail: 'Patrick Collison and Tyler Cowen, The Atlantic (2019)',

--- a/src/app/platform/(protected)/admin/system-map/page.tsx
+++ b/src/app/platform/(protected)/admin/system-map/page.tsx
@@ -188,7 +188,7 @@ const serviceData: Record<string, ServiceInfo> = {
       'Gallery: /gallery extracts illustrations from historical books with AI-generated metadata (subjects, symbols, technique, art period). Supports similarity search via vector embeddings.',
       'Encyclopedia: /encyclopedia/[name] has auto-generated entity pages for people, places, and concepts mentioned across the corpus.',
       'Blog: 29 posts at /blog/*, all hardcoded as JSX components (no CMS or MDX). Topics range from origin story to OCR methodology to progress updates.',
-      'Press: 6 themed press releases at /press/* — alchemy, hermetic tradition, kabbalah, origins of science, world sacred texts, BPH partnership.',
+      'Press: the press room lives at /press-releases (index + /press-releases/[slug] per release). The old themed /press/* pages are archived; /press and /press/* redirect to /press-releases.',
       'Ficino Society: /ficino-society has membership landing, discussion forum, and member directory. Gated by Stripe subscription ($100/year).',
       'Admin: /admin/* has ~15 dashboard pages for pipeline control, collection management, email campaigns, social media, KDP publishing, and duplicate detection.',
     ],


### PR DESCRIPTION
`https://sourcelibrary.org/press` returns 404, as do all six themed `/press/<slug>` URLs.

Those pages were moved to `src/app/_archived/press` in `dbf2a6bc8` ("Archive stale pages, remove press from footer/sitemap") when the press room became `/press-releases`, but nothing was left at the old paths — so inbound links (and one of our own blog posts) have been landing on 404s.

## Changes

- `next.config.ts`: permanent 308 from `/press` and `/press/:path*` to `/press-releases`, following the existing `/shwep` and `/ficino-society` pattern.
- `blog/progress-studies`: removed the further-reading link to the archived `/press/origins-of-science`. The page no longer exists, and the redirect would send readers to the press room under an unrelated title, so the entry comes out rather than getting a wrong destination.
- `admin/system-map` (both copies): the architecture blurb still described "6 themed press releases at /press/*" as live. Updated to describe `/press-releases` and note the archive + redirect.

## Verification

Against `next dev` on this branch:

| path | before | after |
|---|---|---|
| `/press` | 404 | 308 → `/press-releases` |
| `/press/alchemy` | 404 | 308 → `/press-releases` |
| `/press/origins-of-science` | 404 | 308 → `/press-releases` |
| `/press-releases` | 200 | 200 |

`/blog/progress-studies` still renders 200, no console errors in the dev log.

Note: merging this does not fix production — `sourcelibrary.org` needs a manual `npm run deploy:prod` from `main` afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)