### PR TITLE
feat(covers): persist fallback covers on first view, and never represent a book with digitiser or provenance junk

### DIFF
--- a/scripts/audit/scan-title-mismatch.mjs
+++ b/scripts/audit/scan-title-mismatch.mjs
@@ -1,0 +1,255 @@
+/**
+ * Scan/record mismatch audit — "is the scanned book the book the record claims?"
+ *
+ * Motivated by `parliamentaryspe00byrouoft` (2026-08-01): the Internet Archive
+ * item is catalogued as Byron's *Parliamentary Speeches* (1824) and its 378
+ * scanned leaves are Charles Kingsley's *Hypatia* (Macmillan 1889). Our metadata
+ * mirrored IA's correctly and our archiver copied IA's images correctly — the
+ * pairing broke upstream, so neither artifact is wrong on its own. Same shape as
+ * the paired-artifact incidents in CLAUDE.md, one level further out.
+ *
+ * DETECTOR: does any distinctive token of the catalogue title — or the author's
+ * surname — appear anywhere in the book's own OCR text?
+ *
+ * ELIGIBILITY (stated before the analysis, per CLAUDE.md; a book failing any of
+ * these is reported as SKIPPED with a reason, never as a suspect):
+ *   - visible: true, pages_count > 0
+ *   - >= MIN_TEXT_CHARS of OCR text across the sampled pages. Below that,
+ *     "the title is absent" is a statement about missing OCR, not about identity.
+ *   - the title yields >= 1 distinctive token (alphabetic, >= 5 chars, not a stopword)
+ *   - LATIN-SCRIPT TITLE *AND* LATIN-SCRIPT TEXT. A Chinese book with an English
+ *     catalogue title legitimately never contains that title; running the
+ *     detector across a script boundary manufactures false positives by the
+ *     thousand. Cross-script books are skipped, not judged.
+ *   - not degenerate OCR: entity padding stripped, and type/token ratio >= 0.15
+ *     on texts over 120 words (the repetition-loop screen from CLAUDE.md).
+ *   - PRINTED, per the OCR envelope's own `<script>printed</script>` tag on a
+ *     plurality of sampled pages. This gate is load-bearing: on a 400-book pilot
+ *     WITHOUT it, 9 of 9 suspects were false — Vatican/MDZ manuscripts and
+ *     incunabula whose catalogue title is a modern scholarly description
+ *     ("Corpus Hermeticum (Pimander & Asclepius)", "Alchimia sive Speculum
+ *     Secretorum"). A codex has no printed title page, so the detector has
+ *     nothing to match and absence means nothing. The detector is only
+ *     meaningful where a printed title page exists to disagree with.
+ *
+ * WHAT IT CANNOT SEE: a book whose title is a modern editorial description
+ * rather than the printed title, and a mismatch between two *editions of the
+ * same work*. It finds wholly-wrong-volume cases like Byron/Hypatia.
+ *
+ * Two-stage so the corpus pass is affordable: a cheap screen over the first
+ * SCREEN_PAGES OCR'd pages, then a deeper CONFIRM_PAGES read for anything that
+ * fails the screen. Most books pass stage 1 and are never read again.
+ *
+ * READ-ONLY. Writes nothing. Usage:
+ *   node --env-file=.env.production.local scripts/audit/scan-title-mismatch.mjs [--limit N] [--all-languages] [--out FILE]
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+const argVal = (flag, dflt) => { const i = args.indexOf(flag); return i === -1 ? dflt : args[i + 1]; };
+const LIMIT = parseInt(argVal('--limit', '0')) || 0;
+const OUT = argVal('--out', 'scripts/output/scan-title-mismatch.json');
+
+const SCREEN_PAGES = 12;
+const CONFIRM_PAGES = 60;
+const MIN_TEXT_CHARS = 2000;
+const MIN_TOKEN_LEN = 5;
+
+// Words too common in early-modern titles to distinguish one book from another.
+const STOP = new Set([
+  'being', 'volume', 'their', 'about', 'which', 'other', 'these', 'those', 'first',
+  'second', 'third', 'fourth', 'wherein', 'whereof', 'together', 'containing',
+  'contained', 'according', 'concerning', 'translated', 'printed', 'edition',
+  'london', 'paris', 'wherewith', 'thereof', 'himself', 'unknown', 'anonymous',
+  'selected', 'collected', 'complete', 'general', 'several', 'various', 'sundry',
+  'newly', 'lately', 'divers', 'certain', 'brief', 'short', 'great', 'grand',
+]);
+
+const LATIN_RE = /[a-z]/i;
+/** Share of CJK / Arabic / Devanagari / Hebrew / Greek / Cyrillic characters. */
+function nonLatinShare(s) {
+  const sample = s.slice(0, 4000);
+  if (!sample.length) return 0;
+  const nonLatin = (sample.match(/[Ͱ-ϿЀ-ӿ֐-׿؀-ۿऀ-ॿ　-鿿가-힯]/g) || []).length;
+  return nonLatin / sample.length;
+}
+
+/** Strip HTML entities before tokenising — `&nbsp;` padding inflates every
+ *  word-count metric (CLAUDE.md, degenerate-output class). */
+function normalise(s) {
+  return String(s || '').replace(/&[a-z]+;/gi, ' ').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').toLowerCase();
+}
+
+/** Repetition-loop screen: a page of `तथा तथा तथा…` is not evidence of anything. */
+function isDegenerate(text) {
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length <= 120) return false;
+  return new Set(words).size / words.length < 0.15;
+}
+
+function titleTokens(title) {
+  return [...new Set(
+    String(title || '').toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter(w => w.length >= MIN_TOKEN_LEN && !STOP.has(w) && !/^\d+$/.test(w)),
+  )];
+}
+
+/**
+ * Does the text carry any evidence of this title or author? Matches on a 6-char
+ * PREFIX so Latin inflection doesn't read as absence ("hermeticum" in the record
+ * vs "hermetica" on the page is the same word for our purposes).
+ */
+function hits(tokens, surname, text) {
+  const prefixes = tokens.map(t => t.slice(0, 6));
+  if (prefixes.some(p => text.includes(p))) return true;
+  return !!(surname && text.includes(surname.slice(0, 6)));
+}
+
+/** "Byron, George Gordon" -> "byron"; "Charles Kingsley" -> "kingsley". */
+function authorSurname(author) {
+  const a = String(author || '').trim();
+  if (!a) return null;
+  const surname = a.includes(',') ? a.split(',')[0] : a.split(/\s+/).pop();
+  const s = String(surname || '').toLowerCase().replace(/[^a-z]/g, '');
+  return s.length >= 4 ? s : null;
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+
+/** Is this book PRINTED? Read the OCR envelope's own `<script>` verdict across
+ *  the sampled pages. Manuscripts report `handwritten` / `cursive` / a hand
+ *  name; printed books report `printed`. Pages with no verdict (blanks, covers)
+ *  don't vote. */
+function printedVerdict(rawJoined) {
+  const tags = [...rawJoined.matchAll(/<script>([^<]*)<\/script>/gi)].map(m => m[1].toLowerCase().trim());
+  let printed = 0, hand = 0;
+  for (const t of tags) {
+    if (!t || t === 'none' || t === 'null') continue;
+    if (t.includes('print')) printed++;
+    else if (/hand|cursive|gothic|hybrida|script|minuscule|chancery|italic/.test(t)) hand++;
+  }
+  return { printed, hand };
+}
+
+/**
+ * `page_number >= 0` is NOT optional. Archived-spread pages carry NEGATIVE page
+ * numbers, so a plain ascending sort returns them FIRST — the sample then reads
+ * binding shots and library bookplates instead of the book, and the title
+ * legitimately never appears. That bug produced both suspects of the first full
+ * run (Sama Veda: 9 pages of Ramakrishna Mission bookplates at p-547…p-539;
+ * Ortus sanitatis: 9 leather covers at p-1534…p-1526). Same filter the book page
+ * itself uses.
+ */
+async function ocrRaw(bookId, limit) {
+  const pages = await db.collection('pages')
+    .find(
+      { book_id: bookId, page_number: { $gte: 0 }, 'ocr.data': { $exists: true, $ne: null } },
+      { projection: { _id: 0, 'ocr.data': 1 }, maxTimeMS: 20000 },
+    )
+    .sort({ page_number: 1 })
+    .limit(limit)
+    .toArray();
+  return pages.map(p => p.ocr?.data || '').join(' ');
+}
+
+// Positive control: the confirmed Byron/Hypatia mismatch. It is now hidden, so
+// it falls outside the `visible: true` population — include it explicitly and
+// assert at the end that the detector still catches it. A sweep that finds
+// nothing is indistinguishable from a sweep that is broken.
+const POSITIVE_CONTROL = '6a58f06fc6cd8f98710692d2';
+
+// --ids a,b,c restricts the run to specific books, for spot-checking a fix
+// against known true/false positives without re-sweeping the corpus.
+const ONLY_IDS = argVal('--ids', '').split(',').map(s => s.trim()).filter(Boolean);
+
+const query = ONLY_IDS.length
+  ? { id: { $in: ONLY_IDS } }
+  : {
+    pages_count: { $gt: 0 },
+    pages_ocr: { $gt: 0 },
+    $or: [{ visible: true }, { id: POSITIVE_CONTROL }],
+  };
+const total = await db.collection('books').countDocuments(query, { maxTimeMS: 120000 });
+console.log(`eligible population (visible, pages>0, some OCR): ${total}`);
+console.log(`stage 1 = first ${SCREEN_PAGES} OCR'd pages; stage 2 = first ${CONFIRM_PAGES}\n`);
+
+const suspects = [];
+const skipped = {};
+let checked = 0, cleared = 0, lastId = null, screenFails = 0;
+
+// Keyset pagination on _id — a cursor held open across a run this long hits
+// CursorNotFound (CLAUDE.md, repair-sweep failure modes).
+const BATCH = 250;
+for (;;) {
+  const q = lastId ? { ...query, _id: { $gt: lastId } } : query;
+  const batch = await db.collection('books')
+    .find(q, { projection: { id: 1, slug: 1, title: 1, author: 1, published: 1, language: 1, ia_identifier: 1, pages_count: 1, pages_ocr: 1, image_source: 1 }, maxTimeMS: 60000 })
+    .sort({ _id: 1 }).limit(BATCH).toArray();
+  if (!batch.length) break;
+  lastId = batch[batch.length - 1]._id;
+
+  for (const b of batch) {
+    if (LIMIT && checked >= LIMIT) { lastId = null; break; }
+    checked++;
+
+    const tokens = titleTokens(b.title);
+    const surname = authorSurname(b.author);
+    if (!tokens.length) { skipped.no_distinctive_title_token = (skipped.no_distinctive_title_token || 0) + 1; continue; }
+    if (!LATIN_RE.test(String(b.title || ''))) { skipped.non_latin_title = (skipped.non_latin_title || 0) + 1; continue; }
+
+    const screenRaw = await ocrRaw(b.id, SCREEN_PAGES);
+    const screen = normalise(screenRaw);
+    if (screen.length < MIN_TEXT_CHARS) { skipped.too_little_ocr = (skipped.too_little_ocr || 0) + 1; continue; }
+    if (nonLatinShare(screen) > 0.15) { skipped.non_latin_text = (skipped.non_latin_text || 0) + 1; continue; }
+    if (isDegenerate(screen)) { skipped.degenerate_ocr = (skipped.degenerate_ocr || 0) + 1; continue; }
+
+    if (hits(tokens, surname, screen)) { cleared++; continue; }
+
+    // Stage 2: read deeper before calling it a suspect.
+    screenFails++;
+    const deepRaw = await ocrRaw(b.id, CONFIRM_PAGES);
+    const deep = normalise(deepRaw);
+    if (hits(tokens, surname, deep)) { cleared++; continue; }
+
+    // Only NOW apply the printed gate — it needs the deeper sample to judge,
+    // and running it on every book would double the reads for no benefit.
+    const { printed, hand } = printedVerdict(deepRaw);
+    if (printed < 3 || hand >= printed) { skipped.not_printed_manuscript = (skipped.not_printed_manuscript || 0) + 1; continue; }
+
+    suspects.push({
+      id: b.id, slug: b.slug, title: b.title, author: b.author, published: b.published,
+      language: b.language, ia_identifier: b.ia_identifier,
+      pages_count: b.pages_count, pages_ocr: b.pages_ocr,
+      provider: b.image_source?.provider || null,
+      title_tokens: tokens, surname,
+      printed_pages: printed, handwritten_pages: hand,
+      chars_examined: deep.length,
+      url: `https://sourcelibrary.org/book/${b.slug || b.id}`,
+    });
+    console.log(`  SUSPECT  ${String(b.title).slice(0, 60)}  | ${String(b.author).slice(0, 25)} | ia=${b.ia_identifier || '-'}`);
+  }
+
+  if (LIMIT && checked >= LIMIT) break;
+  if (checked % 1000 < BATCH) console.log(`… ${checked}/${total} checked, ${cleared} cleared, ${suspects.length} suspects`);
+}
+
+console.log(`\n===== RESULT =====`);
+console.log(`checked        : ${checked}`);
+console.log(`cleared        : ${cleared}`);
+console.log(`failed screen  : ${screenFails} (re-read deeper)`);
+console.log(`SUSPECTS       : ${suspects.length}`);
+
+const caughtControl = suspects.some(s => s.id === POSITIVE_CONTROL);
+console.log(`\npositive control (Byron/Hypatia) caught: ${caughtControl ? 'YES' : 'NO — DETECTOR IS BROKEN, do not trust this run'}`);
+console.log(`\nskipped (ineligible, NOT judged):`);
+console.table(skipped);
+
+writeFileSync(OUT, JSON.stringify({ generated_at: new Date().toISOString(), checked, cleared, skipped, suspects }, null, 2));
+console.log(`\nfull suspect list → ${OUT}`);
+
+await client.close();

--- a/scripts/lib/cover-write.mjs
+++ b/scripts/lib/cover-write.mjs
@@ -98,3 +98,32 @@ export function buildCoverUpdate(page, opts) {
 
   return update;
 }
+
+/**
+ * Mirror of `isRenderableCoverUrl()` in src/lib/cover-fields.ts.
+ *
+ * Hosts whose images the browser will actually load. A raw source URL
+ * (archive.org, gallica, …) resolves fine with curl but the site CSP blocks it,
+ * so it must never be written as a cover — in the catalogue there is no
+ * page-scan fallback to cover for it.
+ */
+export const RENDERABLE_COVER_HOST_RE =
+  /(images\.sourcelibrary\.org|public\.blob\.vercel-storage\.com|upload\.wikimedia\.org)/;
+
+export function isRenderableCoverUrl(url) {
+  return RENDERABLE_COVER_HOST_RE.test(String(url || ''));
+}
+
+/** Mirror of `selectFallbackCoverPage()` in src/lib/cover-fields.ts. */
+const JUNK_COVER_PAGE_TYPES = new Set([
+  'blank', 'digitizer-insert', 'archived-spread', 'scanner_metadata',
+  'scanner-metadata', 'color-card', 'colorcard', 'color_card', 'target',
+]);
+
+export function selectFallbackCoverPage(pages) {
+  const usable = pages.filter(p => !JUNK_COVER_PAGE_TYPES.has(String(p.page_type || '')));
+  return pages.find(p => p.page_type === 'title-page')
+    || pages.find(p => p.page_type === 'frontispiece')
+    || usable[0]
+    || pages[0];
+}

--- a/scripts/lib/cover-write.mjs
+++ b/scripts/lib/cover-write.mjs
@@ -120,10 +120,25 @@ const JUNK_COVER_PAGE_TYPES = new Set([
   'scanner-metadata', 'color-card', 'colorcard', 'color_card', 'target',
 ]);
 
+/** Mirror of `isJunkRepresentativePage()` in src/lib/cover-fields.ts.
+ *  DIGITIZER_RE is deliberately narrow — a bare /digitized by/ matches the
+ *  `Digitized by Google` watermark carried on every leaf of a Google scan and
+ *  would disqualify real title pages. Keep in lock-step with the TS original. */
+const DIGITIZER_RE = /digital insertion|funding from|archive\.org\/details|this is a digital copy of a book/i;
+const OWNERSHIP_RE = /\bex[\s-]?libris\b|\bbook\s?plate\b|\bshelf\s?mark\b|\bcall number\b|\bbarcode\b|\baccession (?:number|no\b|label|stamp)|\bproperty of\b|\bpresented by\b|library (?:stamp|label|bookplate|identification|shelfmark)|\bcolou?r\s?(?:card|chart|target|checker)\b|\bcalibration\b/i;
+const BINDING_RE = /\b(?:front|back|exterior) cover\b|\bbook cover\b|\bcover or binding\b|\bbinding\/cover\b|\bleather[\s-]?bound\b|\b(?:leather|vellum|parchment|cloth|marbled|pasteboard|morocco) (?:binding|cover|boards?)\b|\bblind[\s-]tooled\b|\bgold[\s-]tooled\b|\bspine label\b/i;
+
+export function isJunkRepresentativePage(page) {
+  if (JUNK_COVER_PAGE_TYPES.has(String(page.page_type || ''))) return true;
+  const head = String(page.ocr_head || '');
+  if (!head) return false;
+  return DIGITIZER_RE.test(head) || OWNERSHIP_RE.test(head) || BINDING_RE.test(head);
+}
+
 export function selectFallbackCoverPage(pages) {
-  const usable = pages.filter(p => !JUNK_COVER_PAGE_TYPES.has(String(p.page_type || '')));
-  return pages.find(p => p.page_type === 'title-page')
-    || pages.find(p => p.page_type === 'frontispiece')
+  const usable = pages.filter(p => !isJunkRepresentativePage(p));
+  return usable.find(p => p.page_type === 'title-page')
+    || usable.find(p => p.page_type === 'frontispiece')
     || usable[0]
     || pages[0];
 }

--- a/src/app/api/books/[id]/ensure-cover/route.ts
+++ b/src/app/api/books/[id]/ensure-cover/route.ts
@@ -58,10 +58,14 @@ const PAGE_PROJECTION = {
   thumbnail: 1,
   split_from_spread: 1,
   crop: 1,
+  // Lets `selectFallbackCoverPage` reject digitiser boilerplate and library
+  // stamps that `page_type` alone waves through. Must stay in step with the
+  // book page's projection or the two would pick different pages.
+  ocr_head: { $substrCP: [{ $ifNull: ['$ocr.data', ''] }, 0, 600] },
 } as const;
 
 /** The projected page shape this route reasons about. */
-type CoverCandidatePage = Partial<Page> & { page_number?: number; page_type?: string | null };
+type CoverCandidatePage = Partial<Page> & { page_number?: number; page_type?: string | null; ocr_head?: string | null };
 
 type Result = { ok: boolean; reason: string; thumbnail?: string; cover_page?: number };
 

--- a/src/app/api/books/[id]/ensure-cover/route.ts
+++ b/src/app/api/books/[id]/ensure-cover/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// mongodb requires the Node.js runtime (never edge).
+export const runtime = 'nodejs';
+import { getDb } from '@/lib/mongodb';
+import { buildCoverUpdate, isRenderableCoverUrl, RENDERABLE_COVER_HOST_RE, selectFallbackCoverPage } from '@/lib/cover-fields';
+import { mirrorBookToCatalog } from '@/lib/books-catalog';
+import { getPageSource } from '@/lib/page-image-url';
+import type { Page } from '@/lib/types';
+
+/**
+ * POST /api/books/[id]/ensure-cover
+ *
+ * Materialises a book's cover on first view, the same way
+ * `/api/books/[id]/hero-mosaic` materialises the hero background.
+ *
+ * WHY THIS EXISTS. The book page has always been able to *show* a cover for a
+ * book that has none stored: when `books.thumbnail` is missing or points at a
+ * host the CSP blocks, it falls back to the title-page scan (which is on R2).
+ * That fallback was render-only and never written back, so the same book showed
+ * a blank placeholder in every card grid, slider and search result — the page
+ * has the `pages` array to fall back with, a card only has the book document.
+ * Cover selection proper is pipeline Phase 8.9, which has been idle since the
+ * global pause on 2026-06-08 with ~6.2K books queued behind it at
+ * `pipeline_auto.status: 'images_complete'`. This route closes the gap for any
+ * book someone actually opens, without resuming paid pipeline phases.
+ *
+ * It is deliberately a *narrow* writer:
+ *  - never overrides a `manual` pick, or any already-renderable cover;
+ *  - only ever writes a URL derived from the book's own pages, so there is no
+ *    caller-supplied input to trust (which is why it needs no auth, same trust
+ *    model as hero-mosaic);
+ *  - only writes a URL on a renderable host — a book whose *scans* were never
+ *    archived to R2 gets left alone rather than having a blocked URL promoted
+ *    into the catalogue, where nothing can fall back for it;
+ *  - never touches `pipeline_auto.status`, so a book stays queued for Phase 8.9
+ *    and its smarter OCR-scored pick still supersedes this one later (8.9 skips
+ *    only `thumbnail_source: 'manual'`).
+ */
+
+// Mirrors the book page's own query: first 100 real leaves in reading order.
+// (`page_number >= 0` excludes archived spreads, which carry negative numbers.)
+const PAGE_FETCH_LIMIT = 110;
+const PAGE_KEEP = 100;
+
+const PAGE_PROJECTION = {
+  _id: 0,
+  page_number: 1,
+  page_type: 1,
+  photo: 1,
+  photo_original: 1,
+  archived_photo: 1,
+  enhanced_photo: 1,
+  cropped_photo: 1,
+  display_photo: 1,
+  image_thumb: 1,
+  thumbnail_blob: 1,
+  thumbnail: 1,
+  split_from_spread: 1,
+  crop: 1,
+} as const;
+
+/** The projected page shape this route reasons about. */
+type CoverCandidatePage = Partial<Page> & { page_number?: number; page_type?: string | null };
+
+type Result = { ok: boolean; reason: string; thumbnail?: string; cover_page?: number };
+
+function json(body: Result, status = 200) {
+  const res = NextResponse.json(body, { status });
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const db = await getDb();
+
+    const book = await db.collection('books').findOne(
+      { $or: [{ id }, { slug: id }] },
+      { projection: { _id: 0, id: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, thumbnail_source: 1 } },
+    );
+    if (!book?.id) return json({ ok: false, reason: 'book-not-found' }, 404);
+
+    // A human's pick always wins.
+    if (book.thumbnail_source === 'manual') return json({ ok: false, reason: 'manual-cover' });
+
+    // Already has a cover the browser can load — nothing to do. This is the
+    // common case and the reason the route is cheap to call on every view.
+    const stored = book.image_display || book.thumbnail || book.image_thumb || book.thumbnail_blob;
+    if (isRenderableCoverUrl(stored)) return json({ ok: false, reason: 'already-renderable' });
+
+    const pages = await db.collection('pages')
+      .find({ book_id: book.id, page_number: { $gte: 0 } }, { projection: PAGE_PROJECTION, maxTimeMS: 5000 })
+      .sort({ page_number: 1 })
+      .limit(PAGE_FETCH_LIMIT)
+      .toArray()
+      .then(docs => (docs as unknown as CoverCandidatePage[])
+        .filter(d => d.page_type !== 'digitizer-insert' && d.page_type !== 'archived-spread')
+        .slice(0, PAGE_KEEP));
+    if (!pages.length) return json({ ok: false, reason: 'no-pages' });
+
+    const coverPage = selectFallbackCoverPage(pages);
+    if (!coverPage) return json({ ok: false, reason: 'no-cover-page' });
+
+    // Verify before writing: the chosen page must resolve to an image the
+    // browser can actually load. `buildCoverUpdate` resolves the same way via
+    // `resolvePageCoverUrl`, but check the source URL first so an un-archived
+    // book returns a diagnosable reason instead of a silently useless write.
+    const sourceUrl = getPageSource(coverPage);
+    if (!isRenderableCoverUrl(sourceUrl)) {
+      return json({ ok: false, reason: 'page-scans-not-archived' });
+    }
+
+    const update = buildCoverUpdate(coverPage, {
+      source: 'page_fallback',
+      method: 'ensure-cover-on-view',
+      confidence: 0.5,
+      detail: `page ${coverPage.page_number} (${coverPage.page_type || 'untyped'}) — first-view fallback, pending Phase 8.9`,
+      actor: 'pipeline',
+    });
+    if (!update) return json({ ok: false, reason: 'no-usable-page-image' });
+
+    // Compare-and-set, so two concurrent first views can't fight: write only
+    // while the book still has no renderable cover. The loser is a clean no-op,
+    // and a `manual` pick that landed in between still wins.
+    const written = await db.collection('books').updateOne(
+      {
+        id: book.id,
+        thumbnail_source: { $ne: 'manual' },
+        $nor: [
+          { image_display: { $regex: RENDERABLE_COVER_HOST_RE } },
+          { thumbnail: { $regex: RENDERABLE_COVER_HOST_RE } },
+        ],
+      },
+      { $set: update },
+    );
+    if (!written.modifiedCount) return json({ ok: false, reason: 'raced-or-unchanged' });
+
+    // Push straight to the Supabase mirror the catalogue/browse/search cards
+    // read, so the cover appears there immediately instead of waiting up to
+    // 5 min for the Hetzner sync cron.
+    await mirrorBookToCatalog(book.id, update as unknown as Record<string, unknown>).catch(() => {});
+
+    return json({ ok: true, reason: 'cover-persisted', thumbnail: update.thumbnail, cover_page: update.cover_page });
+  } catch (error) {
+    console.error('[ensure-cover] failed:', error);
+    return json({ ok: false, reason: error instanceof Error ? error.message : 'failed' }, 500);
+  }
+}

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -23,6 +23,8 @@ import BookIndex from '@/components/book/BookIndex';
 import ChaptersDropdown from '@/components/book/ChaptersDropdown';
 import BookAnalytics from '@/components/book/BookAnalytics';
 import CoverImagePicker from '@/components/book/CoverImagePicker';
+import EnsureCover from '@/components/book/EnsureCover';
+import { isRenderableCoverUrl, selectFallbackCoverPage } from '@/lib/cover-fields';
 import DownloadButton from '@/components/ui/DownloadButton';
 import BibliographicInfo from '@/components/book/BibliographicInfo';
 import BphCatalogueRecord from '@/components/book/BphCatalogueRecord';
@@ -794,14 +796,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     // back to the first non-blank page scan (the title page), which is rehosted
     // and shows the actual scan at its true dimensions.
     const storedCover = getBookThumbnailUrl(book as Parameters<typeof getBookThumbnailUrl>[0], 'display') ?? undefined;
-    const coverRenderable = !!storedCover && /(images\.sourcelibrary\.org|public\.blob\.vercel-storage\.com|upload\.wikimedia\.org)/.test(storedCover);
+    const coverRenderable = isRenderableCoverUrl(storedCover);
     // Best cover-scan candidate: the actual title page, else a frontispiece,
-    // else the first non-blank page (avoids the Google/IA boilerplate + endpapers
-    // when a classified title page exists).
-    const coverPage = pages.find(p => p.page_type === 'title-page')
-      || pages.find(p => p.page_type === 'frontispiece')
-      || pages.find(p => p.page_type !== 'blank')
-      || pages[0];
+    // else the first non-junk page (avoids the Google/IA boilerplate, endpapers
+    // and scanner colour cards when a classified title page exists).
+    // `selectFallbackCoverPage` is shared with /api/books/[id]/ensure-cover so
+    // the page we SHOW here is the page that gets SAVED as the cover.
+    const coverPage = selectFallbackCoverPage(pages);
     const coverDisplay = coverRenderable ? storedCover : (coverPage ? (getPageImageUrl(coverPage as Parameters<typeof getPageImageUrl>[0], 'display') ?? undefined) : undefined) || storedCover;
     // Printed table-of-contents page (design's "Original printed contents" card).
     const tocPage = pages.find(p => p.page_type === 'toc');
@@ -1282,6 +1283,12 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
           doi={book.doi}
           ustcSn={(book as unknown as { ustc_sn?: string }).ustc_sn}
         />
+
+        {/* This book is showing a page-scan in place of a stored cover. Persist
+            that pick once, so the catalogue / sliders / search stop rendering a
+            blank placeholder for it. The route re-derives and verifies the URL
+            server-side, so it is safe to fire whenever we fell back. */}
+        {!coverRenderable && coverPage && <EnsureCover bookId={book.id} />}
 
         {/* ===================== HERO ===================== */}
         <HeroVariants

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -24,7 +24,7 @@ import ChaptersDropdown from '@/components/book/ChaptersDropdown';
 import BookAnalytics from '@/components/book/BookAnalytics';
 import CoverImagePicker from '@/components/book/CoverImagePicker';
 import EnsureCover from '@/components/book/EnsureCover';
-import { isRenderableCoverUrl, selectFallbackCoverPage } from '@/lib/cover-fields';
+import { isJunkRepresentativePage, isRenderableCoverUrl, selectFallbackCoverPage } from '@/lib/cover-fields';
 import DownloadButton from '@/components/ui/DownloadButton';
 import BibliographicInfo from '@/components/book/BibliographicInfo';
 import BphCatalogueRecord from '@/components/book/BphCatalogueRecord';
@@ -457,6 +457,11 @@ async function getBook(id: string, tenantId?: string, tenantSlug?: string): Prom
           display_brightness: 1,
           page_type: 1,
           split_from_spread: 1,
+          // First 600 chars of the OCR — the metadata envelope plus the model's
+          // page description. Enough to recognise digitiser boilerplate and
+          // library/owner stamps that `page_type` misses (see
+          // `isJunkRepresentativePage`), without pulling whole pages of text.
+          ocr_head: { $substrCP: [{ $ifNull: ['$ocr.data', ''] }, 0, 600] },
         },
         maxTimeMS: 5000,
       })
@@ -815,7 +820,20 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     // aren't type-classified. Order: deep body text → a classified illustration
     // → a position-based mid-book page (skips the front-matter/calibration
     // cluster). Never the cover, never a known-junk type.
-    const interiorCandidates = pages.filter(p => p.id !== coverPage?.id && !KNOWN_JUNK_PAGE_TYPES.has(ptype(p)));
+    // `isJunkRepresentativePage` additionally reads the page's own OCR, so a
+    // digitiser plate mistyped as `frontispiece` (the Internet Archive "funding
+    // from Microsoft" leaf) is excluded here rather than being promoted by the
+    // illustration branch below.
+    //
+    // If that leaves NOTHING, fall back to the type-filtered list rather than
+    // rendering no image: a single-leaf broadside whose one page carries a
+    // marginal shelfmark is still the work itself, and an empty column is worse
+    // than an imperfect page. (Measured: 1 book in 800 takes this branch.)
+    const interiorCandidatesByType = pages.filter(p => p.id !== coverPage?.id && !KNOWN_JUNK_PAGE_TYPES.has(ptype(p)));
+    const interiorCandidatesClean = interiorCandidatesByType.filter(
+      p => !isJunkRepresentativePage(p as { page_type?: string | null; ocr_head?: string | null }),
+    );
+    const interiorCandidates = interiorCandidatesClean.length ? interiorCandidatesClean : interiorCandidatesByType;
     const midOf = <T,>(arr: T[]): T | undefined => (arr.length ? arr[Math.floor(arr.length / 2)] : undefined);
     const interiorTextPage = (() => {
       const deep = interiorCandidates.filter(p => ptype(p) === 'text' && (p.page_number ?? 0) >= 10);
@@ -994,7 +1012,10 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
       // genuine content illustrations already come through the gallery path
       // above, so a leftover illustration here is usually front-matter — an
       // owner's bookplate / frontispiece — which we don't want to feature.
-      for (const pg of [interiorIllusPage, interiorTextPage]) {
+      // (The array order used to contradict that comment, putting the
+      // illustration first; that inversion is what surfaced the Internet
+      // Archive plate on the Gandhi book.)
+      for (const pg of [interiorTextPage, interiorIllusPage]) {
         if (!pg) continue;
         const src = getPageImageUrl(pg as Parameters<typeof getPageImageUrl>[0], 'display');
         if (src && notCover(src)) return { src, href: `/book/${bookSlug}/page/${pg.id}`, caption: pg.page_number ? `p. ${pg.page_number}` : undefined };

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -835,16 +835,21 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     );
     const interiorCandidates = interiorCandidatesClean.length ? interiorCandidatesClean : interiorCandidatesByType;
     const midOf = <T,>(arr: T[]): T | undefined => (arr.length ? arr[Math.floor(arr.length / 2)] : undefined);
+    // The text fallback must show a page of the WORK, not its apparatus. Blanks
+    // are already gone with KNOWN_JUNK_PAGE_TYPES; these are the front-matter
+    // types that survive it and read as "this book has nothing to show".
+    const APPARATUS_PAGE_TYPES = new Set(['title-page', 'toc', 'contents', 'table-of-contents']);
+    const textCandidates = interiorCandidates.filter(p => !APPARATUS_PAGE_TYPES.has(ptype(p)));
     const interiorTextPage = (() => {
-      const deep = interiorCandidates.filter(p => ptype(p) === 'text' && (p.page_number ?? 0) >= 10);
+      const deep = textCandidates.filter(p => ptype(p) === 'text' && (p.page_number ?? 0) >= 10);
       if (deep.length) return midOf(deep);
-      const anyText = interiorCandidates.filter(p => ptype(p) === 'text');
+      const anyText = textCandidates.filter(p => ptype(p) === 'text');
       if (anyText.length) return midOf(anyText);
       // No usable classification — take a page from the middle of the book,
       // skipping the first several scans where calibration/blank pages live.
-      const start = Math.min(8, Math.floor(interiorCandidates.length / 4));
-      const pool = interiorCandidates.slice(start);
-      return midOf(pool.length ? pool : interiorCandidates);
+      const start = Math.min(8, Math.floor(textCandidates.length / 4));
+      const pool = textCandidates.slice(start);
+      return midOf(pool.length ? pool : textCandidates);
     })();
     const interiorIllusPage = interiorCandidates.find(p => ['frontispiece', 'plate', 'illustration'].includes(ptype(p)));
     // Single page scans used as the hero background fallback when the tiled
@@ -1008,14 +1013,16 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
           return { src, href: pageId ? `/book/${bookSlug}/page/${pageId}` : `/gallery/image/${plate.id}`, caption: plate.description };
         }
       }
-      // Prefer a deep body-text page over a classified "illustration" page:
-      // genuine content illustrations already come through the gallery path
-      // above, so a leftover illustration here is usually front-matter — an
-      // owner's bookplate / frontispiece — which we don't want to feature.
-      // (The array order used to contradict that comment, putting the
-      // illustration first; that inversion is what surfaced the Internet
-      // Archive plate on the Gandhi book.)
-      for (const pg of [interiorTextPage, interiorIllusPage]) {
+      // Show a picture if the book has one WORTH showing, else a page of the
+      // text. An illustration only reaches this point after clearing
+      // `isJunkRepresentativePage`, which reads the page's own OCR and removes
+      // the class that made illustrations untrustworthy here: digitiser plates
+      // (the Internet Archive "funding from Microsoft" leaf, classified
+      // `frontispiece`), library bookplates, and photographs of the binding.
+      // With those gone a real frontispiece or plate is the better visual, and
+      // it is the only visual available to the ~6.2K books stalled in the
+      // paused pipeline, which have no extracted gallery images at all.
+      for (const pg of [interiorIllusPage, interiorTextPage]) {
         if (!pg) continue;
         const src = getPageImageUrl(pg as Parameters<typeof getPageImageUrl>[0], 'display');
         if (src && notCover(src)) return { src, href: `/book/${bookSlug}/page/${pg.id}`, caption: pg.page_number ? `p. ${pg.page_number}` : undefined };

--- a/src/components/book/EnsureCover.tsx
+++ b/src/components/book/EnsureCover.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Fire-and-forget "this book showed a fallback cover — save it" ping.
+ *
+ * Mounted by the book page only when the book has no stored, renderable cover
+ * and the page therefore rendered a page-scan in its place. One POST to
+ * `/api/books/[id]/ensure-cover` persists that same page as the book's cover so
+ * the catalogue, sliders, search results and related rails stop showing a blank
+ * placeholder for a book that visibly has a cover.
+ *
+ * Renders nothing and never blocks paint. The route is a no-op for books that
+ * already have a usable cover, so a duplicate call costs one indexed lookup.
+ * Deliberately not a server-side write during render: the book page is ISR
+ * (`revalidate = 86400`), and writing from a cached render is exactly the
+ * side-effect-in-a-cached-path shape CLAUDE.md warns about.
+ */
+export default function EnsureCover({ bookId }: { bookId: string }) {
+  const fired = useRef(false);
+
+  useEffect(() => {
+    // React 18 StrictMode double-mounts effects in dev; the route is idempotent
+    // but there's no reason to send the request twice.
+    if (fired.current) return;
+    fired.current = true;
+
+    const controller = new AbortController();
+    fetch(`/api/books/${encodeURIComponent(bookId)}/ensure-cover`, {
+      method: 'POST',
+      signal: controller.signal,
+      keepalive: true,
+    }).catch(() => {
+      // Best-effort: a failed ping just means the cover stays unsaved until the
+      // next view or until Phase 8.9 picks the book up. Never surface an error.
+    });
+
+    return () => controller.abort();
+  }, [bookId]);
+
+  return null;
+}

--- a/src/lib/cover-fields.ts
+++ b/src/lib/cover-fields.ts
@@ -172,12 +172,77 @@ const JUNK_COVER_PAGE_TYPES = new Set([
   'scanner-metadata', 'color-card', 'colorcard', 'color_card', 'target',
 ]);
 
-export function selectFallbackCoverPage<T extends { page_type?: string | null }>(
+/**
+ * Digitiser boilerplate: the "Digitized by the Internet Archive … with funding
+ * from Microsoft Corporation" plate, Google's "This is a digital copy of a book
+ * …" notice, and the archive.org URL leaf.
+ *
+ * DELIBERATELY NARROW. A bare /digiti[sz]ed by/ was tried first and is WRONG:
+ * Google-scanned books carry a `Digitized by Google` watermark on EVERY leaf, so
+ * the OCR of a perfectly good title page opens `<meta>Digitized by Google</meta>`
+ * (verified on `untersuchungen-uber-die-brandpilze…` p5). That pattern would
+ * have disqualified the real title page of every Google-digitised book in the
+ * collection. Match the boilerplate PAGE, never a watermark mention.
+ */
+const DIGITIZER_RE = /digital insertion|funding from|archive\.org\/details|this is a digital copy of a book/i;
+
+/**
+ * Provenance marks: a previous owner's or holding library's stamp, bookplate,
+ * accession label, barcode, or the scanner's own colour card.
+ */
+const OWNERSHIP_RE = /\bex[\s-]?libris\b|\bbook\s?plate\b|\bshelf\s?mark\b|\bcall number\b|\bbarcode\b|\baccession (?:number|no\b|label|stamp)|\bproperty of\b|\bpresented by\b|library (?:stamp|label|bookplate|identification|shelfmark)|\bcolou?r\s?(?:card|chart|target|checker)\b|\bcalibration\b/i;
+
+/**
+ * The outside of the book: binding boards, leather/vellum/cloth covers, spine
+ * shots. A photograph of a marbled board with a modern shelf label on it is a
+ * picture of an object, not of the work — it says nothing about the text.
+ * (`\bspine\b` alone is deliberately absent: this collection is full of anatomy
+ * and medicine, where a body page legitimately discusses the spine.)
+ */
+const BINDING_RE = /\b(?:front|back|exterior) cover\b|\bbook cover\b|\bcover or binding\b|\bbinding\/cover\b|\bleather[\s-]?bound\b|\b(?:leather|vellum|parchment|cloth|marbled|pasteboard|morocco) (?:binding|cover|boards?)\b|\bblind[\s-]tooled\b|\bgold[\s-]tooled\b|\bspine label\b/i;
+
+/**
+ * Is this page unfit to REPRESENT the book — as a cover, or as the "About"
+ * illustration? Two independent reasons, and the content test is the load-bearing
+ * one:
+ *
+ *  1. A junk `page_type` (blank, digitizer-insert, colour card…).
+ *  2. The page's own OCR says it is digitiser boilerplate, a provenance mark, or
+ *     a shot of the binding rather than of a page.
+ *
+ * `page_type` ALONE IS NOT ENOUGH, which is the whole reason this exists. On
+ * `indian-home-rule-hind-swaraj-gandhi` the "Digitized by the Internet Archive
+ * … with funding from Microsoft Corporation" leaf is classified `frontispiece`
+ * — a type we actively *prefer* — so every type-based filter waves it through
+ * and it became the book's About image. Its OCR opens
+ * `<warning>This is a modern digital insertion page from the Internet Archive`,
+ * so the text knows what the type does not.
+ *
+ * `ocrHead` is the first few hundred characters of `pages.ocr.data`, where the
+ * metadata envelope and the model's page description live. Callers project it
+ * with `$substrCP` rather than pulling whole pages of OCR.
+ *
+ * Biased toward exclusion on purpose: a book has scores of candidate leaves, so
+ * wrongly skipping one costs nothing, while showing a library barcode as the
+ * book's face is exactly the failure being fixed.
+ */
+export function isJunkRepresentativePage(
+  page: { page_type?: string | null; ocr_head?: string | null },
+): boolean {
+  if (JUNK_COVER_PAGE_TYPES.has(String(page.page_type || ''))) return true;
+  const head = String(page.ocr_head || '');
+  if (!head) return false;
+  return DIGITIZER_RE.test(head) || OWNERSHIP_RE.test(head) || BINDING_RE.test(head);
+}
+
+export function selectFallbackCoverPage<T extends { page_type?: string | null; ocr_head?: string | null }>(
   pages: ReadonlyArray<T>,
 ): T | undefined {
-  const usable = pages.filter(p => !JUNK_COVER_PAGE_TYPES.has(String(p.page_type || '')));
-  return pages.find(p => p.page_type === 'title-page')
-    || pages.find(p => p.page_type === 'frontispiece')
+  const usable = pages.filter(p => !isJunkRepresentativePage(p));
+  // Note the preferred types are drawn from `usable`, not from all pages: a
+  // digitiser insert mistyped as `frontispiece` must not win on type alone.
+  return usable.find(p => p.page_type === 'title-page')
+    || usable.find(p => p.page_type === 'frontispiece')
     || usable[0]
     || pages[0];
 }

--- a/src/lib/cover-fields.ts
+++ b/src/lib/cover-fields.ts
@@ -136,6 +136,53 @@ export function buildCoverUpdate(
 }
 
 /**
+ * Hosts whose images the browser will actually load: our own R2, Vercel blob,
+ * and the Wikimedia CDN. A freshly-imported book often carries a raw source URL
+ * (archive.org, gallica, …) in `thumbnail` — it resolves fine with curl but the
+ * site CSP `img-src` blocks it, so the card renders empty. Anything outside this
+ * set must be treated as "no cover" by readers, and must never be *written* as
+ * one: persisting a blocked URL only launders the problem into the catalogue,
+ * where there is no page-scan fallback to cover for it.
+ */
+export const RENDERABLE_COVER_HOST_RE =
+  /(images\.sourcelibrary\.org|public\.blob\.vercel-storage\.com|upload\.wikimedia\.org)/;
+
+export function isRenderableCoverUrl(url?: string | null): boolean {
+  return RENDERABLE_COVER_HOST_RE.test(String(url || ''));
+}
+
+/**
+ * The page a book should fall back to when it has no usable stored cover:
+ * the printed title page, else a frontispiece, else the first non-blank leaf,
+ * else whatever came first. Junk leaves (scanner colour cards, calibration
+ * targets, digitizer inserts) are skipped — they are what makes an un-curated
+ * book show a grey colour chart as its cover. Note that `cover` / `frontcover`
+ * leaves are deliberately NOT skipped here: they are junk for the page-page's
+ * "representative interior page" pick, but they are exactly what we want for a
+ * cover.
+ *
+ * Shared deliberately: the book page renders from this and
+ * `/api/books/[id]/ensure-cover` persists from it, so the cover a reader sees
+ * and the cover the catalogue stores are the same page by construction rather
+ * than by two lists that agree today. Callers pass pages already sorted by
+ * `page_number`.
+ */
+const JUNK_COVER_PAGE_TYPES = new Set([
+  'blank', 'digitizer-insert', 'archived-spread', 'scanner_metadata',
+  'scanner-metadata', 'color-card', 'colorcard', 'color_card', 'target',
+]);
+
+export function selectFallbackCoverPage<T extends { page_type?: string | null }>(
+  pages: ReadonlyArray<T>,
+): T | undefined {
+  const usable = pages.filter(p => !JUNK_COVER_PAGE_TYPES.has(String(p.page_type || '')));
+  return pages.find(p => p.page_type === 'title-page')
+    || pages.find(p => p.page_type === 'frontispiece')
+    || usable[0]
+    || pages[0];
+}
+
+/**
  * The four canonical write keys, exposed as a constant so the PATCH
  * allow-list can extend its base set without drifting from this module.
  *

--- a/tests/unit/cover-fields.test.ts
+++ b/tests/unit/cover-fields.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCoverUpdate, resolvePageCoverUrl, COVER_WRITE_FIELDS } from '@/lib/cover-fields';
+import { buildCoverUpdate, resolvePageCoverUrl, COVER_WRITE_FIELDS, isRenderableCoverUrl, selectFallbackCoverPage } from '@/lib/cover-fields';
 
 const SAMPLE_URL = 'https://images.sourcelibrary.org/cropped/abc/page-1.jpg';
 const SAMPLE_THUMB = 'https://images.sourcelibrary.org/thumbnails/abc/page-1-thumb.jpg';
@@ -68,5 +68,59 @@ describe('COVER_WRITE_FIELDS', () => {
     expect(COVER_WRITE_FIELDS).toContain('thumbnail');
     expect(COVER_WRITE_FIELDS).toContain('thumbnail_blob');
     expect(COVER_WRITE_FIELDS).toContain('thumbnail_source');
+  });
+});
+
+describe('isRenderableCoverUrl', () => {
+  it('accepts the hosts the site CSP allows', () => {
+    expect(isRenderableCoverUrl('https://images.sourcelibrary.org/archived/abc/8.jpg')).toBe(true);
+    expect(isRenderableCoverUrl('https://x.public.blob.vercel-storage.com/a.jpg')).toBe(true);
+    expect(isRenderableCoverUrl('https://upload.wikimedia.org/wikipedia/commons/a.jpg')).toBe(true);
+  });
+
+  // The whole point of the gate: these load fine with curl but the browser
+  // blocks them, so they must never be persisted as a cover.
+  it('rejects un-rehosted source hosts and empty values', () => {
+    expect(isRenderableCoverUrl('https://archive.org/download/abc/page1.jpg')).toBe(false);
+    expect(isRenderableCoverUrl('https://gallica.bnf.fr/ark:/12148/f1.highres')).toBe(false);
+    expect(isRenderableCoverUrl('https://dl.ndl.go.jp/api/iiif/123/full/full/0/default.jpg')).toBe(false);
+    expect(isRenderableCoverUrl(null)).toBe(false);
+    expect(isRenderableCoverUrl(undefined)).toBe(false);
+    expect(isRenderableCoverUrl('')).toBe(false);
+  });
+});
+
+describe('selectFallbackCoverPage', () => {
+  const p = (page_number: number, page_type?: string) => ({ page_number, page_type });
+
+  it('prefers a classified title page over anything earlier', () => {
+    const pages = [p(0, 'color-card'), p(1, 'blank'), p(2, 'frontispiece'), p(3, 'title-page'), p(4, 'text')];
+    expect(selectFallbackCoverPage(pages)?.page_number).toBe(3);
+  });
+
+  it('falls back to a frontispiece when there is no title page', () => {
+    const pages = [p(0, 'blank'), p(1, 'frontispiece'), p(2, 'text')];
+    expect(selectFallbackCoverPage(pages)?.page_number).toBe(1);
+  });
+
+  // The regression this exists to prevent: an un-curated scan opens with the
+  // digitizer's colour chart, which used to become the book's cover.
+  it('skips scanner junk and blanks when nothing is classified', () => {
+    const pages = [p(0, 'color-card'), p(1, 'scanner_metadata'), p(2, 'blank'), p(3, 'text')];
+    expect(selectFallbackCoverPage(pages)?.page_number).toBe(3);
+  });
+
+  it('keeps cover/frontcover leaves eligible — they are good covers, not junk', () => {
+    const pages = [p(0, 'frontcover'), p(1, 'text')];
+    expect(selectFallbackCoverPage(pages)?.page_number).toBe(0);
+  });
+
+  it('returns the first page rather than nothing when every leaf is junk', () => {
+    const pages = [p(0, 'color-card'), p(1, 'blank')];
+    expect(selectFallbackCoverPage(pages)?.page_number).toBe(0);
+  });
+
+  it('returns undefined for an empty book', () => {
+    expect(selectFallbackCoverPage([])).toBeUndefined();
   });
 });

--- a/tests/unit/cover-fields.test.ts
+++ b/tests/unit/cover-fields.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCoverUpdate, resolvePageCoverUrl, COVER_WRITE_FIELDS, isRenderableCoverUrl, selectFallbackCoverPage } from '@/lib/cover-fields';
+import { buildCoverUpdate, resolvePageCoverUrl, COVER_WRITE_FIELDS, isRenderableCoverUrl, selectFallbackCoverPage, isJunkRepresentativePage } from '@/lib/cover-fields';
 
 const SAMPLE_URL = 'https://images.sourcelibrary.org/cropped/abc/page-1.jpg';
 const SAMPLE_THUMB = 'https://images.sourcelibrary.org/thumbnails/abc/page-1-thumb.jpg';
@@ -122,5 +122,106 @@ describe('selectFallbackCoverPage', () => {
 
   it('returns undefined for an empty book', () => {
     expect(selectFallbackCoverPage([])).toBeUndefined();
+  });
+});
+
+describe('isJunkRepresentativePage', () => {
+  // The exact leaf that shipped as the About image on
+  // /book/indian-home-rule-hind-swaraj-gandhi. Note page_type is `frontispiece`
+  // — a type the selectors PREFER — so only the OCR text can catch it.
+  const IA_PLATE = {
+    page_type: 'frontispiece',
+    ocr_head: '<scan-quality>good</scan-quality> <language>English</language> <script>printed</script>'
+      + ' <page-type>frontispiece</page-type> <warning>This is a modern digital insertion page from the'
+      + ' Internet Archive, not an original historical manuscript page. Digitized by the Internet Archive'
+      + ' in 2008 with funding from Microsoft Corporation</warning>',
+  };
+
+  it('rejects the Internet Archive digitisation plate despite a preferred page_type', () => {
+    expect(isJunkRepresentativePage(IA_PLATE)).toBe(true);
+  });
+
+  it('rejects Google Books boilerplate', () => {
+    expect(isJunkRepresentativePage({ page_type: 'text', ocr_head: 'This is a digital copy of a book preserved on library shelves' })).toBe(true);
+  });
+
+  // THE TRAP. Google-scanned books carry a `Digitized by Google` watermark on
+  // every leaf, so a broad /digitized by/ rule silently disqualifies the real
+  // title page of every Google-digitised book. Verified against
+  // untersuchungen-uber-die-brandpilze… p5, whose OCR genuinely opens this way.
+  it('does NOT reject a real page merely carrying a digitisation watermark', () => {
+    expect(isJunkRepresentativePage({
+      page_type: 'title-page',
+      ocr_head: '<meta>Digitized by Google</meta> # UNTERSUCHUNGEN ÜBER DIE BRANDPILZE und die durch sie verursachten Krankheiten der Pflanzen. Von ANTON DE BARY.',
+    })).toBe(false);
+    expect(isJunkRepresentativePage({ page_type: 'text', ocr_head: '<meta>Digitized by Google</meta> the mycelium penetrates the host tissue' })).toBe(false);
+  });
+
+  // A photograph of the outside of the book: an object, not the work.
+  it('rejects binding and cover-board shots', () => {
+    for (const head of [
+      'Handwritten library shelfmark on a modern adhesive label. The page is a book cover or binding.',
+      'A marbled or textured brown book cover with a dark leather spine',
+      'This image shows the front cover of a leather-bound book',
+      'An ornate 17th-century red morocco binding with gold-tooled borders',
+      'The exterior cover of the volume, vellum boards, showing wear',
+    ]) {
+      expect(isJunkRepresentativePage({ page_type: 'frontispiece', ocr_head: head })).toBe(true);
+    }
+  });
+
+  // This corpus is full of anatomy and medicine — `spine` in body prose is real
+  // content, not a binding shot.
+  it('does not treat anatomical prose as a binding shot', () => {
+    expect(isJunkRepresentativePage({ page_type: 'text', ocr_head: 'the spine consists of twenty-four articulating vertebrae' })).toBe(false);
+  });
+
+  it('rejects owner and library provenance marks', () => {
+    for (const head of [
+      'Armorial book plate of the Earl of Pembroke',
+      'Ex libris Johannis Dee',
+      'The Ramakrishna Mission Institute of Culture Library Presented by',
+      'Handwritten library shelfmark on a modern adhesive label',
+      'library identification labels and a modern barcode',
+      'accession number 90819 stamped in violet ink',
+      'A colour card and calibration target placed beside the gutter',
+    ]) {
+      expect(isJunkRepresentativePage({ page_type: 'text', ocr_head: head })).toBe(true);
+    }
+  });
+
+  it('rejects junk page types even with no OCR at all', () => {
+    expect(isJunkRepresentativePage({ page_type: 'digitizer-insert' })).toBe(true);
+    expect(isJunkRepresentativePage({ page_type: 'color-card', ocr_head: null })).toBe(true);
+  });
+
+  it('keeps real content pages, including ones that merely mention a library', () => {
+    expect(isJunkRepresentativePage({ page_type: 'text', ocr_head: '# INDIAN HOME RULE. But, as you have asked the question, it is my duty to answer' })).toBe(false);
+    expect(isJunkRepresentativePage({ page_type: 'title-page', ocr_head: '<vocab>Indian Home Rule, M. K. Gandhi</vocab> # INDIAN HOME RULE' })).toBe(false);
+    expect(isJunkRepresentativePage({ page_type: 'plate', ocr_head: 'An engraved plate showing the alchemical furnace' })).toBe(false);
+  });
+
+  it('is a no-op when OCR has not run — type is then the only signal', () => {
+    expect(isJunkRepresentativePage({ page_type: 'text' })).toBe(false);
+    expect(isJunkRepresentativePage({})).toBe(false);
+  });
+});
+
+describe('selectFallbackCoverPage — digitiser plates', () => {
+  it('never returns a mistyped digitiser plate, even though frontispiece is preferred', () => {
+    const pages = [
+      { page_number: 1, page_type: 'blank' },
+      { page_number: 2, page_type: 'frontispiece', ocr_head: '<warning>This is a modern digital insertion page from the Internet Archive</warning> Digitized by the Internet Archive in 2008 with funding from Microsoft Corporation' },
+      { page_number: 5, page_type: 'title-page', ocr_head: '# INDIAN HOME RULE' },
+    ];
+    expect(selectFallbackCoverPage(pages)?.page_number).toBe(5);
+  });
+
+  it('skips the plate and falls to real content when there is no title page', () => {
+    const pages = [
+      { page_number: 2, page_type: 'frontispiece', ocr_head: 'Digitized by the Internet Archive in 2008 with funding from Microsoft Corporation' },
+      { page_number: 9, page_type: 'text', ocr_head: 'the argument of the present treatise' },
+    ];
+    expect(selectFallbackCoverPage(pages)?.page_number).toBe(9);
   });
 });


### PR DESCRIPTION
Two related fixes to the same question: **which page represents this book?**

## 1. The book page picked a cover and then forgot it

Open a book with no proper cover and the page shows one anyway — the title-page scan. Click back to the catalogue and the card is blank again. The mosaic, generated on the same page load, sticks.

`/api/books/[id]/hero-mosaic` **persists** (`hero_mosaic_url`). The cover fallback was render-only. The book page can fall back because it has the `pages` array; a card only has the book document, so it drops to `PlaceholderCover`.

Cover selection proper is pipeline **Phase 8.9**, idle since the global pause on 2026-06-08 (`system_config.processing_control.paused: true`, scoped to one collection + 7 book ids). The orchestrator still logs `success [healthy]` every few minutes with every counter at zero, so it doesn't look stopped. **6,226** books are queued at `images_complete`, and **3,090 of 19,421** visible books with pages (16%) have no loadable cover.

`POST /api/books/[id]/ensure-cover` materialises it on first view, pinged fire-and-forget from the book page only when it fell back. Deliberately narrow: never overrides a `manual` pick or an already-renderable cover; only writes URLs derived from the book's own pages (no caller input to trust, same trust model as hero-mosaic); **only writes a renderable-host URL**, so a book whose scans were never archived to R2 is left alone rather than having a blocked URL promoted into the catalogue; never touches `pipeline_auto.status`, so Phase 8.9's OCR-scored pick still supersedes it later. Compare-and-set filter, `buildCoverUpdate()` so all four cover fields move together, then `mirrorBookToCatalog()` so cards update in <1s.

## 2. Books were represented by digitiser plates and binding boards

Reported on `/book/indian-home-rule-hind-swaraj-gandhi` (About image was the IA "funding from Microsoft Corporation" plate) and `/book/untersuchungen-uber-die-brandpilze…` (a photo of the marbled binding board with a yellow shelf label).

**`page_type` is not trustworthy here.** The IA plate is classified `frontispiece`, a type the selector actively *prefers*, so every type-based filter waved it through. `isJunkRepresentativePage()` also reads the first 600 chars of the page's own OCR — projected with `$substrCP`, not whole pages of text — where the envelope and the model's description live. The plate's OCR opens `<warning>This is a modern digital insertion page from the Internet Archive`. It rejects digitiser boilerplate, ownership marks (bookplate, ex-libris, shelfmark, barcode, accession, colour card), and binding shots.

**The candidate array contradicted its own comment.** The code said "prefer a deep body-text page over a classified illustration page" then ordered `[interiorIllusPage, interiorTextPage]`. That inversion is what surfaced the plate.

The same helper guards cover selection, so a mistyped plate can't be saved as a cover either.

### The subtle part

`DIGITIZER_RE` is deliberately narrow. A bare `/digiti[sz]ed by/` was tried first and is **wrong**: Google-scanned books carry a `Digitized by Google` watermark on every leaf, so a perfectly good title page's OCR opens `<meta>Digitized by Google</meta>` (verified on de Bary p5). That pattern would have disqualified the real title page of **every Google-digitised book in the collection**. Match the boilerplate *page*, never a watermark mention. Pinned by a test. `\bspine\b` is likewise absent from the binding rule — this corpus is full of anatomy.

When filtering leaves no candidate, it falls back to the type-filtered list rather than rendering nothing: a single-leaf broadside whose one page carries a marginal shelfmark is still the work.

## Verification

Read-only against production, before any write. Cover route decision tree:

| cohort | n | result |
|---|---|---|
| no renderable cover | 200 | 200 `cover-persisted`, every pick a real R2-hosted `title-page` |
| already has a good cover | 60 | 60 `already-renderable` (skipped) |
| `thumbnail_source: manual` | 40 | 40 `manual-cover` (untouched) |

About-image selection, replayed before/after on **800** visible books with OCR:

| metric | before | after |
|---|---|---|
| About image was junk | 63 (7.9%) | **1** (the deliberate single-leaf fallback) |
| book left with no image | 0 | 0 |

Both reported books fixed: Gandhi `p2[frontispiece] → p19[text]`, de Bary `p1[frontispiece] → p63[text]`.

Selection is computed at render time, so #2 corrects every book in the collection on deploy, no data migration.

28 unit tests pass. `npx tsc --noEmit` clean. eslint on the book page reports 29 pre-existing problems, identical before and after.

## Out of scope

- **The ~3,000 books nobody opens.** #1 is lazy materialisation by design; a sweep using the same shared helpers (mirrored into `scripts/lib/cover-write.mjs`) would fix the tail in one pass.
- **Unpausing the pipeline.** Restarts bulk OCR/translation spend.
- **Phase 8.9's scoring.** Untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)