### PR TITLE
Hero: let editors change the cover from the hero

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1318,21 +1318,35 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             </div>
           )}
           cover={(
-            <div className="flex flex-col items-center md:items-start">
-              {coverDisplay ? (
-                /* eslint-disable-next-line @next/next/no-img-element */
-                <img
-                  src={coverDisplay}
-                  alt={book.display_title || book.title}
-                  className="block w-full h-auto max-h-[420px] md:w-auto md:h-[500px] md:max-h-none md:max-w-[min(46vw,560px)] object-contain object-left"
-                  style={{ filter: 'drop-shadow(0 34px 48px rgba(0,0,0,0.62))' }}
-                />
-              ) : (
-                <div className="w-full md:w-[300px] aspect-[3/4] flex items-center justify-center text-center text-sm px-4" style={{ background: '#f6f3ea', border: '1px solid #d3ccbc', color: '#7a7365' }}>
-                  {book.display_title || book.title}
+            /* Editors (inner_circle) get a "Change cover" affordance over the
+               hero cover — opens the page picker + writes via buildCoverUpdate.
+               Everyone else just sees the cover. */
+            <CoverImagePicker
+              bookId={book.id}
+              currentThumbnail={getBookThumbnailUrl(book as Parameters<typeof getBookThumbnailUrl>[0], 'display') ?? undefined}
+              currentThumbnailBlob={getBookThumbnailUrl(book as Parameters<typeof getBookThumbnailUrl>[0], 'thumb') ?? undefined}
+              bookTitle={book.display_title || book.title}
+              bookAuthor={book.author}
+              bookYear={book.published}
+              pages={pages}
+              trigger={
+                <div className="flex flex-col items-center md:items-start">
+                  {coverDisplay ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={coverDisplay}
+                      alt={book.display_title || book.title}
+                      className="block w-full h-auto max-h-[420px] md:w-auto md:h-[500px] md:max-h-none md:max-w-[min(46vw,560px)] object-contain object-left"
+                      style={{ filter: 'drop-shadow(0 34px 48px rgba(0,0,0,0.62))' }}
+                    />
+                  ) : (
+                    <div className="w-full md:w-[300px] aspect-[3/4] flex items-center justify-center text-center text-sm px-4" style={{ background: '#f6f3ea', border: '1px solid #d3ccbc', color: '#7a7365' }}>
+                      {book.display_title || book.title}
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
+              }
+            />
           )}
           meta={(
             <div className="min-w-0" style={{ color: '#f7f2ea' }}>

--- a/src/components/book/CoverImagePicker.tsx
+++ b/src/components/book/CoverImagePicker.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
-import { BookOpen, X, Check, Loader2 } from 'lucide-react';
+import { BookOpen, X, Check, Loader2, Pencil } from 'lucide-react';
 import { books } from '@/lib/api-client';
 import type { Page } from '@/lib/types';
 import { buildCoverUpdate } from '@/lib/cover-fields';
@@ -22,9 +22,13 @@ interface CoverImagePickerProps {
   bookAuthor?: string | null;
   bookYear?: string | number | null;
   pages: Page[];
+  /** Optional custom cover element to render in place of the built-in
+   *  thumbnail (e.g. the large hero cover). Editors get a "Change cover"
+   *  hover affordance over it; everyone else sees it plain. */
+  trigger?: ReactNode;
 }
 
-export default function CoverImagePicker({ bookId, currentThumbnail, currentThumbnailBlob, bookTitle, bookAuthor, bookYear, pages }: CoverImagePickerProps) {
+export default function CoverImagePicker({ bookId, currentThumbnail, currentThumbnailBlob, bookTitle, bookAuthor, bookYear, pages, trigger }: CoverImagePickerProps) {
   const router = useRouter();
   // Placeholder cover is an embedded-reading-room feature; the main site keeps
   // the plain icon fallback.
@@ -88,60 +92,60 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
 
   return (
     <>
-      {/* Cover Image - Clickable for admin and inner circle */}
-      <AuthCheck role="inner_circle"
+      {/* Cover — editors (inner_circle) can click to change it; everyone else
+          sees it plain. When `trigger` is provided (e.g. the hero cover), it
+          renders in place of the built-in thumbnail. */}
+      <AuthCheck
+        role="inner_circle"
         fallback={
-          // Non-authenticated users see the cover image but cannot click
-          <div className="w-32 sm:w-48 aspect-[3/4] relative rounded-lg overflow-hidden shadow-xl bg-stone-700">
+          trigger ?? (
+            // Non-authenticated users see the cover image but cannot click
+            <div className="w-32 sm:w-48 aspect-[3/4] relative rounded-lg overflow-hidden shadow-xl bg-stone-700">
+              {displayThumbnail && !thumbnailError ? (
+                <Image src={displayThumbnail} alt={bookTitle} fill className="object-cover" sizes="(max-width: 640px) 128px, 192px" priority onError={handleThumbnailError} />
+              ) : embed ? (
+                <PlaceholderCover title={bookTitle} author={bookAuthor} year={bookYear} />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center"><BookOpen className="w-12 sm:w-16 h-12 sm:h-16 text-stone-500" /></div>
+              )}
+            </div>
+          )
+        }
+      >
+        {trigger ? (
+          /* Custom trigger (hero cover): overlay a "Change cover" affordance */
+          <button
+            onClick={() => setIsOpen(true)}
+            className="group relative block w-full cursor-pointer text-left"
+            title="Change cover image"
+          >
+            {trigger}
+            <span
+              className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-center gap-1.5 py-2.5 text-[12.5px] font-semibold text-white opacity-0 group-hover:opacity-100 transition-opacity"
+              style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.78), transparent)' }}
+            >
+              <Pencil className="w-3.5 h-3.5" aria-hidden="true" /> Change cover
+            </span>
+          </button>
+        ) : (
+          /* Built-in clickable thumbnail for authenticated users */
+          <button
+            onClick={() => setIsOpen(true)}
+            className="w-32 sm:w-48 aspect-[3/4] relative rounded-lg overflow-hidden shadow-xl bg-stone-700 cursor-pointer group"
+            title="Click to change cover image"
+          >
             {displayThumbnail && !thumbnailError ? (
-              <Image
-                src={displayThumbnail}
-                alt={bookTitle}
-                fill
-                className="object-cover"
-                sizes="(max-width: 640px) 128px, 192px"
-                priority
-                onError={handleThumbnailError}
-              />
+              <Image src={displayThumbnail} alt={bookTitle} fill className="object-cover group-hover:opacity-80 transition-opacity" sizes="(max-width: 640px) 128px, 192px" priority onError={handleThumbnailError} />
             ) : embed ? (
               <PlaceholderCover title={bookTitle} author={bookAuthor} year={bookYear} />
             ) : (
-              <div className="w-full h-full flex items-center justify-center">
-                <BookOpen className="w-12 sm:w-16 h-12 sm:h-16 text-stone-500" />
-              </div>
+              <div className="w-full h-full flex items-center justify-center group-hover:bg-stone-600 transition-colors"><BookOpen className="w-12 sm:w-16 h-12 sm:h-16 text-stone-500" /></div>
             )}
-          </div>
-        }
-      >
-        {/* Clickable Cover Image for authenticated users */}
-        <button
-          onClick={() => setIsOpen(true)}
-          className="w-32 sm:w-48 aspect-[3/4] relative rounded-lg overflow-hidden shadow-xl bg-stone-700 cursor-pointer group"
-          title="Click to change cover image"
-        >
-          {displayThumbnail && !thumbnailError ? (
-            <Image
-              src={displayThumbnail}
-              alt={bookTitle}
-              fill
-              className="object-cover group-hover:opacity-80 transition-opacity"
-              sizes="(max-width: 640px) 128px, 192px"
-              priority
-              onError={handleThumbnailError}
-            />
-          ) : embed ? (
-            <PlaceholderCover title={bookTitle} author={bookAuthor} year={bookYear} />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center group-hover:bg-stone-600 transition-colors">
-              <BookOpen className="w-12 sm:w-16 h-12 sm:h-16 text-stone-500" />
+            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/30">
+              <span className="text-white text-sm font-medium px-2 py-1 bg-black/50 rounded">Change Cover</span>
             </div>
-          )}
-          <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/30">
-            <span className="text-white text-sm font-medium px-2 py-1 bg-black/50 rounded">
-              Change Cover
-            </span>
-          </div>
-        </button>
+          </button>
+        )}
       </AuthCheck>
 
       {/* Picker Modal - Only rendered for authenticated users */}


### PR DESCRIPTION
## Change the cover from the hero (editors)

The redesigned hero cover was a plain image — the cover-change UI (`CoverImagePicker`) only existed in the legacy layout, so there was no way to change a cover from the new book page.

- `CoverImagePicker` gains an optional **`trigger`** prop: when passed (the hero cover), it renders that in place of the built-in thumbnail and overlays a **"Change cover"** affordance on hover. Its existing page-picker modal and set-cover write path (`buildCoverUpdate` → `books.update`) are unchanged.
- Wired into the new hero cover in `book/[id]/page.tsx`.
- **Gated to `inner_circle` (editors)** — same permission as the existing Pages-grid "Set as cover" button. Non-editors (incl. logged-out) see the cover exactly as before; because the `AuthCheck` fallback renders the same trigger, there's **no layout shift**.

Backward-compatible: without `trigger`, `CoverImagePicker` behaves exactly as today (the legacy layout is untouched). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
