### PR TITLE
fix(urls): reader URLs carry the book's name, not its ObjectId

### DIFF
--- a/scripts/maintenance/repair-book-slugs.ts
+++ b/scripts/maintenance/repair-book-slugs.ts
@@ -1,0 +1,205 @@
+/**
+ * repair-book-slugs.ts — give every book a readable slug, without breaking
+ * any URL already in the wild.
+ *
+ * Two classes of broken book URL, one cause each:
+ *
+ *   1. NO SLUG at all (29 visible books). Reachable only as
+ *      /book/<objectid>. Older imports that predate slugs, or a batch that
+ *      skipped the step.
+ *   2. PLACEHOLDER SLUG (~85 visible books). An import wrote a bare counter,
+ *      so they sit at /book/-10, /book/-13. Every one of them has a perfectly
+ *      good English `display_title` going unused — "-10" should read
+ *      "setsubun-in-the-shimabara-district-issho". See also the
+ *      generateBookSlug fix in src/lib/slugify.ts, which stops a non-Latin
+ *      title from minting new ones.
+ *
+ * Renaming a slug changes a public URL, so the old one is pushed onto
+ * `slug_aliases` in the SAME update. findBookByIdOrSlug resolves aliases on
+ * its miss path and the caller 301s to the canonical slug, so existing links,
+ * citations and search-engine results keep working. Books in class 1 have no
+ * old slug to preserve — their /book/<objectid> URLs keep resolving by id,
+ * as they always have.
+ *
+ * Every prior slug is also written to a timestamped JSON backup before the
+ * first write, so the whole sweep is reversible from disk.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   npx tsx scripts/maintenance/repair-book-slugs.ts            # dry run (default)
+ *   npx tsx scripts/maintenance/repair-book-slugs.ts --apply
+ *   npx tsx scripts/maintenance/repair-book-slugs.ts --apply --include-hidden
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { MongoClient, type Db } from 'mongodb';
+import { generateBookSlug, appendSlugSuffix, isPlaceholderSlug } from '@/lib/slugify';
+
+const APPLY = process.argv.includes('--apply');
+const INCLUDE_HIDDEN = process.argv.includes('--include-hidden');
+const OUT_DIR = join(process.cwd(), 'scripts', 'output');
+
+interface BookRow {
+  _id: unknown;
+  id?: string;
+  slug?: string;
+  title?: string;
+  display_title?: string;
+  author?: string;
+  visible?: boolean;
+  slug_aliases?: string[];
+}
+
+/**
+ * Reserve a slug against both the database and the slugs minted earlier in
+ * this same run. generateUniqueBookSlug only checks the DB, which is correct
+ * for a single import but would hand the same slug to two books in a bulk
+ * sweep — the four Comte de Gabalis / Tyrocinium duplicates in this batch are
+ * exactly that case. `slug_aliases` is checked too: a freed-up old slug must
+ * not be reissued to a different book while it still redirects.
+ */
+async function reserveSlug(db: Db, base: string, taken: Set<string>): Promise<string> {
+  const exists = async (candidate: string) => {
+    if (taken.has(candidate)) return true;
+    const hit = await db.collection('books').findOne(
+      { $or: [{ slug: candidate }, { slug_aliases: candidate }] },
+      { projection: { _id: 1 } },
+    );
+    return !!hit;
+  };
+
+  let candidate = base;
+  let n = 1;
+  while (await exists(candidate)) {
+    n += 1;
+    candidate = appendSlugSuffix(base, n);
+  }
+  taken.add(candidate);
+  return candidate;
+}
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('MONGODB_URI not set. Run: set -a; source .env.production.local; set +a');
+    process.exit(1);
+  }
+
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db('bookstore');
+
+  const scope = INCLUDE_HIDDEN ? {} : { visible: true };
+  const candidates = (await db.collection('books')
+    .find(scope)
+    .project({ _id: 1, id: 1, slug: 1, title: 1, display_title: 1, author: 1, visible: 1, slug_aliases: 1 })
+    .toArray()) as unknown as BookRow[];
+
+  const broken = candidates.filter((b) => isPlaceholderSlug(b.slug));
+
+  console.log(`Scanned ${candidates.length} books${INCLUDE_HIDDEN ? '' : ' (visible only)'}`);
+  console.log(`Broken or missing slugs: ${broken.length}`);
+  if (broken.length === 0) {
+    await client.close();
+    return;
+  }
+
+  const taken = new Set<string>();
+  // `filter` is the exact document selector for the write. Books carry both a
+  // string `id` and a Mongo `_id`; prefer `id` (indexed, and what every other
+  // writer keys on) and fall back to the raw ObjectId, never a stringified one
+  // — a string never matches an ObjectId and the update would silently no-op.
+  const plan: Array<{
+    id: string; from: string; to: string; title: string; visible: boolean;
+    filter: Record<string, unknown>;
+  }> = [];
+
+  const skipped: string[] = [];
+
+  for (const book of broken) {
+    const title = book.display_title || book.title || '';
+    const base = generateBookSlug(book.title || '', book.author || '', book.display_title);
+
+    // generateBookSlug already falls back to the author, then to "untitled".
+    // If we land on a placeholder anyway (no Latin characters anywhere in
+    // title OR author), leave the book alone rather than moving it from one
+    // meaningless URL to another — it needs a display_title first, which is
+    // the enrichment pipeline's job, not this sweep's.
+    if (isPlaceholderSlug(base)) {
+      skipped.push(`${book.id} — nothing to build a slug from: "${title.slice(0, 40)}"`);
+      continue;
+    }
+
+    // A book that ALREADY has a URL only earns a rename if the new slug says
+    // something the old one didn't. Titles like "216" or "2-13" sanitize to
+    // themselves, so /book/216 would become /book/216-anonymous: a changed
+    // URL, no new information, and a redirect to maintain forever. Those are
+    // a metadata problem, not a slug problem. A book with NO slug is the
+    // opposite case — any readable segment beats /book/<objectid>.
+    const titleHasLetters = /[a-z]/i.test(
+      title.normalize('NFD').replace(/[\u0300-\u036f]/g, ''),
+    );
+    if (book.slug && !titleHasLetters) {
+      skipped.push(`${book.id} — slug "${book.slug}" already matches its title, no gain`);
+      continue;
+    }
+
+    const to = await reserveSlug(db, base, taken);
+    plan.push({
+      id: book.id || String(book._id),
+      from: book.slug || '',
+      to,
+      title: title.slice(0, 60),
+      visible: book.visible === true,
+      filter: book.id ? { id: book.id } : { _id: book._id },
+    });
+  }
+
+  console.log(`\nSkipped (left exactly as they are): ${skipped.length}`);
+  for (const line of skipped.slice(0, 10)) console.log(`  ${line}`);
+  if (skipped.length > 10) console.log(`  ... and ${skipped.length - 10} more`);
+
+  console.log(`\nPlanned renames: ${plan.length}${APPLY ? '' : ' (dry run — nothing written)'}\n`);
+  for (const p of plan) {
+    console.log(`  ${p.from || '(no slug)'} → ${p.to}`);
+    console.log(`      ${p.title}`);
+  }
+
+  if (!APPLY) {
+    console.log('\nRe-run with --apply to write. Old slugs will be preserved as aliases.');
+    await client.close();
+    return;
+  }
+
+  // Backup BEFORE the first write, so a bad sweep is reversible from disk.
+  mkdirSync(OUT_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = join(OUT_DIR, `book-slugs-backup-${stamp}.json`);
+  writeFileSync(backupPath, JSON.stringify(plan.map(({ filter: _f, ...rest }) => rest), null, 2));
+  console.log(`\nBackup written: ${backupPath}`);
+
+  let written = 0;
+  for (const p of plan) {
+    const update: Record<string, unknown> = { $set: { slug: p.to } };
+    // Only a real previous slug becomes an alias. A missing slug has no URL
+    // to preserve, and a placeholder like "-10" is worth keeping too: it may
+    // have been linked, and an alias costs one indexed field.
+    if (p.from) update.$addToSet = { slug_aliases: p.from };
+
+    const res = await db.collection('books').updateOne(p.filter, update);
+    if (res.matchedCount !== 1) {
+      console.error(`  MISS ${p.id} — selector matched ${res.matchedCount} docs, slug NOT written`);
+      continue;
+    }
+    written += 1;
+  }
+
+  console.log(`\nDone. ${written} slugs repaired, ${plan.filter((p) => p.from).length} old slugs kept as aliases.`);
+  console.log('Next: revalidate the affected book pages so the new URLs render.');
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
+import { readerPageUrl } from '@/lib/slugify';
 import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { CONTENT_LICENSE, type ContentLicense } from '@/lib/license-info';
@@ -126,9 +127,15 @@ function generateCitations(
   // Direct URL to page in Source Library (pinned to edition version).
   // baseUrl is the request host so citations rendered on tenant subdomains
   // (e.g. bph.sourcelibrary.org) link back to the same subdomain.
+  //
+  // Built from the book's slug, not the requested id: this URL gets printed
+  // into papers and footnotes, so it has to say which book it is. Calling the
+  // API by id would otherwise mint a permanent citation to /book/<objectid>.
+  // Still a relative path joined to the request host, so it stays on the
+  // tenant subdomain (lockdown invariant 4/5).
   const editionVersion = edition?.version;
   const vParam = editionVersion ? `?v=${editionVersion}` : '';
-  const url = `${baseUrl}/book/${bookId}/page/${pageId}${vParam}`;
+  const url = `${baseUrl}${readerPageUrl({ slug: book.slug, id: bookId }, pageId)}${vParam}`;
 
   // Short URL for sharing
   const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
+import { readerPageUrl } from '@/lib/slugify';
 import { markForExport } from '@/lib/provenance';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { CONTENT_LICENSE, type ContentLicense } from '@/lib/license-info';
@@ -126,9 +127,13 @@ function generateCitations(
   // Direct URL to page in Source Library (pinned to edition version).
   // baseUrl is derived from the request host so quotes returned from
   // tenant subdomains link back to the same subdomain.
+  //
+  // Built from the book's slug, not the requested id: this URL gets printed
+  // into papers and footnotes, so it has to say which book it is. Calling the
+  // API by id would otherwise mint a permanent citation to /book/<objectid>.
   const editionVersion = edition?.version;
   const vParam = editionVersion ? `?v=${editionVersion}` : '';
-  const url = `${baseUrl}/book/${bookId}/page/${pageId}${vParam}`;
+  const url = `${baseUrl}${readerPageUrl({ slug: book.slug, id: bookId }, pageId)}${vParam}`;
 
   // Short URL for sharing
   const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);

--- a/src/app/api/gallery/image/[id]/route.ts
+++ b/src/app/api/gallery/image/[id]/route.ts
@@ -184,7 +184,7 @@ export async function GET(
             year: pageData.book?.published,
           },
           pageNumber: pageData.page_number,
-          readUrl: tenantPath(`/book/${pageData.book_id}/page/${pageId}`),
+          readUrl: tenantPath(`/book/${pageData.book?.slug || pageData.book_id}/page/${pageId}`),
           galleryUrl: tenantPath(`/gallery?bookId=${pageData.book_id}`),
           citation: `${pageData.book?.author || ''}, "${pageData.book?.display_title || pageData.book?.title || 'Unknown'}", p. ${pageData.page_number}, Source Library, ${aiCitationNote(galleryDoc.model)}`,
           stale: true, // Signal that detection index is stale

--- a/src/app/api/redirect/book-slug/route.ts
+++ b/src/app/api/redirect/book-slug/route.ts
@@ -3,7 +3,8 @@ import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 
 /**
- * Resolves /book/{non-slug-id} to /book/{slug} via 301 redirect.
+ * Resolves /book/{non-slug-id} to /book/{slug} via 301 redirect, and
+ * /book/{non-slug-id}/page/{pageId} to /book/{slug}/page/{pageId}.
  * Called via proxy rewrite so the book page component never calls redirect(),
  * which would force it into fully-dynamic rendering (no ISR).
  */
@@ -12,6 +13,13 @@ export async function GET(request: NextRequest) {
   // Fall back to the query param for direct hits / older callers.
   const bookIdOrSlug =
     request.headers.get('x-redirect-book') || request.nextUrl.searchParams.get('id');
+
+  // Reader URLs carry a page tail and a query string that must survive the
+  // redirect — ?highlight= pins a search term, ?v= pins a cited edition
+  // version, and dropping either silently changes what the reader lands on.
+  const pageId = request.headers.get('x-redirect-page-id') || '';
+  const tail = pageId ? `/page/${encodeURIComponent(pageId)}` : '';
+  const search = request.headers.get('x-redirect-search') || '';
 
   if (!bookIdOrSlug) {
     return NextResponse.redirect(new URL('/', request.url), 302);
@@ -30,8 +38,11 @@ export async function GET(request: NextRequest) {
   // Instead, bounce back to /book/<input> with an `ns` marker. The proxy skips its
   // id→resolver rewrite when `ns` is present (so no loop), and /book/[id] renders
   // the book or calls notFound() for a real, styled 404.
-  const renderInPlace = () =>
-    NextResponse.redirect(new URL(`/book/${encodeURIComponent(bookIdOrSlug)}?ns=1`, request.url), 302);
+  const renderInPlace = () => {
+    const url = new URL(`/book/${encodeURIComponent(bookIdOrSlug)}${tail}${search}`, request.url);
+    url.searchParams.set('ns', '1');
+    return NextResponse.redirect(url, 302);
+  };
 
   if (!result) {
     return renderInPlace();
@@ -46,5 +57,5 @@ export async function GET(request: NextRequest) {
   }
 
   // Redirect non-slug URL to canonical slug URL
-  return NextResponse.redirect(new URL(`/book/${slug}`, request.url), 301);
+  return NextResponse.redirect(new URL(`/book/${slug}${tail}${search}`, request.url), 301);
 }

--- a/src/app/q/[code]/route.ts
+++ b/src/app/q/[code]/route.ts
@@ -20,24 +20,31 @@ export async function GET(request: NextRequest, context: RouteContext) {
     // Decode the shortlink
     const { bookId, pageNumber } = decodeShortlink(code);
 
-    // Look up the page to get its ID
+    // Look up the page to get its ID, and the book to get its slug. The
+    // shortlink encodes an ObjectId, so without the slug every shortlink we
+    // publish would land on /book/<objectid>/page/<pageid> and take a second
+    // redirect to reach its readable form. One projection, one hop.
     const db = await getReadDb();
-    const page = await db.collection('pages').findOne({
-      book_id: bookId,
-      page_number: pageNumber,
-    }) as unknown as Page | null;
+    const [page, book] = await Promise.all([
+      db.collection('pages').findOne({
+        book_id: bookId,
+        page_number: pageNumber,
+      }) as unknown as Promise<Page | null>,
+      db.collection('books').findOne({ id: bookId }, { projection: { _id: 0, id: 1, slug: 1 } }),
+    ]);
+    const bookPath = (book?.slug as string) || bookId;
 
     if (!page) {
       // Redirect to book page if specific page not found
       return NextResponse.redirect(
-        new URL(`/book/${bookId}`, request.url),
+        new URL(`/book/${bookPath}`, request.url),
         { status: 302 }
       );
     }
 
     // Redirect to the full page URL
     return NextResponse.redirect(
-      new URL(`/book/${bookId}/page/${page.id}`, request.url),
+      new URL(`/book/${bookPath}/page/${page.id}`, request.url),
       { status: 302 }
     );
   } catch (error) {

--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -64,6 +64,12 @@ export default function PageEditorClient({
   const isOnTenantSubdomain = typeof window !== 'undefined' && /^[a-z]+\.sourcelibrary\.org$/.test(window.location.hostname);
   const isOnEmbedRoute = pathname?.startsWith('/embed/');
   const tenantPrefix = isOnTenantSubdomain ? '' : (params?.tenant ? `${isOnEmbedRoute ? '/embed' : ''}/${params.tenant}` : '');
+  // Every reader URL this component writes uses the book's slug — the same
+  // human-readable segment the book page uses (/book/a-sacred-repository-…),
+  // never the raw ObjectId. The route resolves either (findBookByIdOrSlug) and
+  // the canonical <link> was already slug-based, but the address bar is what
+  // readers copy and share, so it has to be the readable one.
+  const bookPath = book.slug || book.id;
 
   // Version pinning: detect ?v= param for citation-pinned reading
   const [pinnedVersion, setPinnedVersion] = useState<string | null>(null);
@@ -253,6 +259,22 @@ export default function PageEditorClient({
     readingHistory.record(book.id, currentPageId, currentPage.page_number, referrer || undefined);
   }, [book.id, currentPageId, currentPage?.page_number]);
 
+  // Readers land on the ObjectId form of this URL from search results, quote
+  // links, shortlinks and old shares. The route serves it either way and the
+  // canonical <link> is already slug-based, but the address bar is what gets
+  // copied into a citation or a message — so swap the id segment for the slug
+  // once on mount. replaceState preserves the query string (?highlight=, ?v=)
+  // and adds no history entry, and it costs no server redirect on the site's
+  // highest-volume URL set (the per-page route is ISR — a redirect there would
+  // have to read searchParams and force it dynamic).
+  useEffect(() => {
+    if (!book.slug || !book.id || book.slug === book.id) return;
+    const idSegment = `/book/${book.id}/`;
+    if (!window.location.pathname.includes(idSegment)) return;
+    const slugged = window.location.pathname.replace(idSegment, `/book/${book.slug}/`);
+    window.history.replaceState(null, '', `${slugged}${window.location.search}${window.location.hash}`);
+  }, [book.id, book.slug]);
+
   // Client-side navigation - update URL and current page
   const handleNavigate = useCallback((newPageId: string, opts?: { toTop?: boolean }) => {
     // On mobile the panels stack vertically (image, then OCR, then translation).
@@ -272,7 +294,7 @@ export default function PageEditorClient({
     const newParams = new URLSearchParams();
     if (pinnedVersion) newParams.set('v', pinnedVersion);
     const suffix = newParams.toString() ? `?${newParams.toString()}` : '';
-    window.history.pushState(null, '', `${tenantPrefix}/book/${book.id}/page/${newPageId}${suffix}`);
+    window.history.pushState(null, '', `${tenantPrefix}/book/${bookPath}/page/${newPageId}${suffix}`);
 
     if (isMobile && activeSection) {
       // Land on the same section the reader was in (image / OCR / translation),
@@ -298,11 +320,11 @@ export default function PageEditorClient({
     // Notify embed.js host frame (no-op when not in an iframe)
     if (window.self !== window.top) {
       window.parent.postMessage(
-        { type: 'sl-navigate', book: book.slug || book.id, page: newPageId },
+        { type: 'sl-navigate', book: bookPath, page: newPageId },
         '*'
       );
     }
-  }, [book.id, book.slug, pinnedVersion, tenantPrefix]);
+  }, [bookPath, pinnedVersion, tenantPrefix]);
 
   const currentIndex = pageList.findIndex(p => p.id === currentPageId);
 
@@ -361,7 +383,7 @@ export default function PageEditorClient({
           isCurrentVersion={versionEdition.isCurrentVersion}
           doi={versionEdition.doi}
           doiUrl={versionEdition.doiUrl}
-          bookUrl={`${tenantPrefix}/book/${book.id}/page/${currentPageId}`}
+          bookUrl={`${tenantPrefix}/book/${bookPath}/page/${currentPageId}`}
         />
       )}
 

--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -267,13 +267,22 @@ export default function PageEditorClient({
   // and adds no history entry, and it costs no server redirect on the site's
   // highest-volume URL set (the per-page route is ISR — a redirect there would
   // have to read searchParams and force it dynamic).
+  // Rewrites whatever sits in the book position, not just an ObjectId, so a
+  // stale slug from a rename (resolved via slug_aliases in findBookByIdOrSlug)
+  // lands on the current one too.
   useEffect(() => {
-    if (!book.slug || !book.id || book.slug === book.id) return;
-    const idSegment = `/book/${book.id}/`;
-    if (!window.location.pathname.includes(idSegment)) return;
-    const slugged = window.location.pathname.replace(idSegment, `/book/${book.slug}/`);
-    window.history.replaceState(null, '', `${slugged}${window.location.search}${window.location.hash}`);
-  }, [book.id, book.slug]);
+    const slug = book.slug;
+    if (!slug) return;
+    const segments = window.location.pathname.split('/');
+    const bookAt = segments.lastIndexOf('book') + 1;
+    if (bookAt === 0 || !segments[bookAt] || segments[bookAt] === slug) return;
+    segments[bookAt] = slug;
+    window.history.replaceState(
+      null,
+      '',
+      `${segments.join('/')}${window.location.search}${window.location.hash}`
+    );
+  }, [book.slug]);
 
   // Client-side navigation - update URL and current page
   const handleNavigate = useCallback((newPageId: string, opts?: { toTop?: boolean }) => {

--- a/src/lib/metadata-enrichment.ts
+++ b/src/lib/metadata-enrichment.ts
@@ -14,7 +14,7 @@ import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/ge
 import { logGeminiCall, type GeminiTrigger } from './gemini-logger';
 import { logAuditEvent } from './audit-logger';
 import { logMetadataChange } from './book-changelog';
-import { generateUniqueBookSlug } from './slugify';
+import { generateUniqueBookSlug, isPlaceholderSlug } from './slugify';
 
 const MODEL = 'gemini-3-flash-preview';
 const MAX_OCR_PAGES = 25;
@@ -484,7 +484,10 @@ export async function enrichBookMetadata(
   // Regenerate slug if display_title was just set and current slug is bad
   if (updates.display_title) {
     const currentSlug = (book.slug as string) || '';
-    if (!currentSlug || currentSlug === 'undefined' || currentSlug.startsWith('untitled')) {
+    // isPlaceholderSlug also catches the leading-hyphen class (/book/-10),
+    // which this check used to miss — those books have a display_title now,
+    // which is exactly the input needed to build a real slug.
+    if (isPlaceholderSlug(currentSlug)) {
       const newSlug = await generateUniqueBookSlug(
         db, book.title as string, (updates.author || book.author) as string, updates.display_title as string
       );

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -25,7 +25,38 @@ export function generateBookSlug(
     return slugTitle || 'untitled';
   }
 
+  // slugifyText keeps only [a-z0-9], so a title written entirely in Greek,
+  // Hebrew, Japanese, Chinese, Tibetan or Sanskrit sanitizes to the empty
+  // string. Interpolating that produced a leading-hyphen slug — a Greek work
+  // edited by Markos Mousouros became "/book/-mousouros". Fall back to the
+  // author alone (generateUniqueBookSlug then suffixes collisions), so a
+  // non-Latin title degrades to a plain readable segment instead of a broken
+  // one. Prefer giving these books an English `display_title`: the generator
+  // reads it first, and it produces a genuinely descriptive slug.
+  if (!slugTitle) {
+    return slugAuthor;
+  }
+
   return `${slugTitle}-${slugAuthor}`;
+}
+
+/**
+ * Is this slug a placeholder or a malformed leftover rather than a real,
+ * readable URL segment?
+ *
+ * Catches: missing/empty, the literal string "undefined", the "untitled"
+ * family, and anything with no Latin letter at all — the class that produced
+ * ~85 visible books sitting at URLs like /book/-10 and /book/-13, written by
+ * an import that bypassed generateBookSlug entirely.
+ *
+ * Used by the repair sweep and by the enrichment path that regenerates a slug
+ * once a book finally has a display_title.
+ */
+export function isPlaceholderSlug(slug: string | null | undefined): boolean {
+  if (!slug) return true;
+  if (slug === 'undefined' || slug === 'null') return true;
+  if (/^untitled(-|$)/.test(slug)) return true;
+  return !/[a-z]/.test(slug);
 }
 
 /**
@@ -62,8 +93,16 @@ function slugifyText(text: string, maxLength: number): string {
  * Handles: "Michael Maier", "Maier, Michael", "Johann Daniel Mylius"
  */
 function extractLastName(author: string): string {
-  if (!author || author === 'Unknown' || author === 'Anonymous') {
-    return author?.toLowerCase() || 'unknown';
+  // "Unknown" in any of its forms is the absence of an author, not a surname.
+  // The old exact match let "Unknown artist" through, and the last-word rule
+  // then suffixed those books with "-artist" (/book/…-osu-kannon-artist).
+  // "Anonymous" is deliberately NOT folded in here — it is kept in the slug,
+  // pinned by tests/unit/slugify.test.ts.
+  if (!author || /^unknown\b/i.test(author.trim())) {
+    return 'unknown';
+  }
+  if (author === 'Anonymous') {
+    return 'anonymous';
   }
 
   // "Last, First" format
@@ -140,6 +179,25 @@ export function tenantBookUrl(
   _tenantSlug?: string | null
 ): string {
   return `/book/${book.slug || book.id}`;
+}
+
+/**
+ * Reader URL for one page of a book: /book/<slug>/page/<pageId>.
+ *
+ * Use this wherever a book document (or anything carrying its slug) is in
+ * scope, rather than interpolating a bare id. The proxy 301s the id form to
+ * this one, so an id-built link still lands correctly — it just publishes an
+ * unreadable URL into citations and chat until the redirect runs, and costs an
+ * extra hop. Call sites that only ever hold a page's `book_id` (the gallery
+ * image API, exhibition layouts) legitimately fall back to the redirect.
+ *
+ * The page segment stays a page *id*, not a printed page number: numbers go
+ * missing, repeat, turn roman and shift on split scans, so the id is the
+ * durable citation anchor. /book/<slug>/page/<number> is a supported input
+ * alias that 301s here.
+ */
+export function readerPageUrl(book: { slug?: string | null; id: string }, pageId: string): string {
+  return `/book/${book.slug || book.id}/page/${pageId}`;
 }
 
 export function collectionUrl(collection: { slug: string }): string {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -608,6 +608,18 @@ function resolveHostForAgentCount(request: NextRequest): string {
     .replace(/^www\./, '');
 }
 
+/**
+ * Does this /book/<segment> look like an id rather than a slug?
+ * Slugs contain hyphens and are >24 chars. ObjectIds are exactly 24 hex chars.
+ * Custom ids are shorter hex strings with at least one hex letter (a-f).
+ * Pure numeric strings (e.g. "13") are not valid ids and should 404 normally.
+ * Shared by the /book/<id> and /book/<id>/page/<pageId> canonical redirects.
+ */
+function looksLikeBookId(segment: string): boolean {
+  return /^[0-9a-f]{24}$/.test(segment)
+    || (!segment.includes('-') && /^[0-9a-f]+$/.test(segment) && /[a-f]/.test(segment));
+}
+
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -894,15 +906,11 @@ export async function proxy(request: NextRequest) {
       }
     }
 
-    // Non-slug IDs → redirect to canonical slug URL.
-    // Slugs contain hyphens and are >24 chars. ObjectIds are exactly 24 hex chars.
-    // Custom IDs are shorter hex strings with at least one hex letter (a-f).
-    // Pure numeric strings (e.g. "13") are not valid IDs and should 404 normally.
+    // Non-slug IDs → redirect to canonical slug URL (see looksLikeBookId).
     // `ns=1` means the book-slug resolver already ran and decided there's no
     // redirect target (no-slug book or 404) — skip re-rewriting so /book/[id]
     // renders in place. Without this guard, bouncing back here would loop.
-    const looksLikeId = /^[0-9a-f]{24}$/.test(segment) || (!segment.includes('-') && /^[0-9a-f]+$/.test(segment) && /[a-f]/.test(segment));
-    if (looksLikeId && !request.nextUrl.searchParams.has('ns')) {
+    if (looksLikeBookId(segment) && !request.nextUrl.searchParams.has('ns')) {
       const url = request.nextUrl.clone();
       url.pathname = '/api/redirect/book-slug';
       url.search = '';
@@ -935,6 +943,30 @@ export async function proxy(request: NextRequest) {
     headers.set('x-redirect-book', segment);
     headers.set('x-redirect-page', pageNum);
     return NextResponse.rewrite(url, { request: { headers } });
+  }
+
+  // Reader page URLs that address the book by *id* instead of its slug
+  // (/book/6a58f512…/page/6a58f512…). Exactly the canonicalisation the
+  // /book/<id> block above already does, one level down: the reader route
+  // resolves either form, so these are not broken — they just publish an
+  // unreadable URL into citations, chat messages and the address bar for the
+  // rest of the book. Resolved through the same book-slug resolver, which now
+  // carries the /page/<pageId> tail and the query string (?highlight=, ?v=)
+  // through the 301. Runs AFTER the page-number block so /book/<id>/page/5
+  // still resolves number → page id in one hop.
+  const readerIdMatch = pathname.match(/^\/book\/([^/]+)\/page\/([^/]+)$/);
+  if (readerIdMatch && !request.nextUrl.searchParams.has('ns')) {
+    const [, segment, pageId] = readerIdMatch;
+    if (looksLikeBookId(segment)) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/api/redirect/book-slug';
+      url.search = '';
+      const headers = new Headers(request.headers);
+      headers.set('x-redirect-book', segment);
+      headers.set('x-redirect-page-id', pageId);
+      headers.set('x-redirect-search', request.nextUrl.search);
+      return NextResponse.rewrite(url, { request: { headers } });
+    }
   }
 
   // --- Bot rate limiting (soft) ---

--- a/tests/unit/book-slug-quality.test.ts
+++ b/tests/unit/book-slug-quality.test.ts
@@ -1,0 +1,96 @@
+/**
+ * A book's slug IS its public URL, so a malformed one is a malformed page
+ * address, not a cosmetic issue.
+ *
+ * Measured on production 2026-08-01: 85 visible books sat at URLs like
+ * /book/-10 and /book/-13, and 29 more had no slug at all and could only be
+ * reached as /book/<objectid>. Two causes — an import that bypassed the
+ * generator, and generateBookSlug itself returning "-<author>" whenever the
+ * title sanitizes to nothing, which is every title written in a non-Latin
+ * script. This corpus is full of Greek, Hebrew, Chinese, Japanese, Tibetan
+ * and Sanskrit titles, so that path is load-bearing, not theoretical.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateBookSlug, isPlaceholderSlug, readerPageUrl } from '@/lib/slugify';
+
+describe('generateBookSlug', () => {
+  it('builds title-author for the ordinary case', () => {
+    expect(generateBookSlug('Atalanta Fugiens', 'Michael Maier')).toBe('atalanta-fugiens-maier');
+    expect(generateBookSlug('Tyrocinium chymicum', 'Beguin, Jean')).toBe('tyrocinium-chymicum-beguin');
+  });
+
+  it('prefers the English display_title when there is one', () => {
+    // The whole reason /book/-10 is repairable: these books already carry a
+    // usable English title, it was simply never read.
+    // "Miyagawa Isshō" has no comma, so extractLastName takes the final word.
+    expect(generateBookSlug('島原の節分図', 'Miyagawa Isshō', 'Setsubun in the Shimabara District'))
+      .toBe('setsubun-in-the-shimabara-district-issho');
+  });
+
+  it('never emits a leading hyphen when the title is non-Latin', () => {
+    // Was "-mousouros" → /book/-mousouros.
+    const greek = generateBookSlug('Ἐπιστολαὶ διαφόρων φιλοσόφων', 'Mousouros, Markos (ed.)');
+    expect(greek).toBe('mousouros');
+    expect(greek.startsWith('-')).toBe(false);
+
+    for (const title of ['青鬼', 'ཐར་པ་ཆེན་པོ', 'كتاب الأسرار', 'Ἑρμοῦ τοῦ Τρισμεγίστου']) {
+      const slug = generateBookSlug(title, 'Khunrath, Heinrich');
+      expect(slug.startsWith('-')).toBe(false);
+      expect(isPlaceholderSlug(slug)).toBe(false);
+    }
+  });
+
+  it('falls back to untitled only when there is nothing to work with', () => {
+    expect(generateBookSlug('青鬼', 'Unknown')).toBe('untitled');
+    expect(generateBookSlug('', '')).toBe('untitled');
+  });
+});
+
+describe('isPlaceholderSlug', () => {
+  it('flags the URLs that need repairing', () => {
+    expect(isPlaceholderSlug(undefined)).toBe(true);
+    expect(isPlaceholderSlug('')).toBe(true);
+    expect(isPlaceholderSlug('undefined')).toBe(true);
+    expect(isPlaceholderSlug('untitled')).toBe(true);
+    expect(isPlaceholderSlug('untitled-7')).toBe(true);
+    expect(isPlaceholderSlug('-10')).toBe(true);   // the production class
+    expect(isPlaceholderSlug('-13')).toBe(true);
+    expect(isPlaceholderSlug('123')).toBe(true);
+  });
+
+  it('leaves real slugs alone', () => {
+    expect(isPlaceholderSlug('atalanta-fugiens-maier')).toBe(false);
+    expect(isPlaceholderSlug('mousouros')).toBe(false);
+    // A legitimate slug that merely contains digits, or ends in a dedupe suffix.
+    expect(isPlaceholderSlug('de-re-metallica-1556-agricola')).toBe(false);
+    expect(isPlaceholderSlug('tyrocinium-chymicum-beguin-5')).toBe(false);
+  });
+});
+
+describe('readerPageUrl', () => {
+  it('uses the slug when there is one', () => {
+    expect(readerPageUrl({ slug: 'atalanta-fugiens-maier', id: '6a58f512c6cd8f9871069afb' }, 'p1'))
+      .toBe('/book/atalanta-fugiens-maier/page/p1');
+  });
+
+  it('falls back to the id so a slugless book still links', () => {
+    expect(readerPageUrl({ id: '6a58f512c6cd8f9871069afb' }, 'p1'))
+      .toBe('/book/6a58f512c6cd8f9871069afb/page/p1');
+  });
+});
+
+describe('unknown authors', () => {
+  it('does not suffix a slug with "artist" for "Unknown artist"', () => {
+    // /book/…-setsubun-oni-yari-ritual-at-osu-kannon-artist was a real
+    // planned slug before this: extractLastName took the last word.
+    expect(generateBookSlug('大須観音 節分会', 'Unknown artist', 'Setsubun Oni-yari Ritual at Ōsu Kannon'))
+      .toBe('setsubun-oni-yari-ritual-at-osu-kannon');
+    expect(generateBookSlug('A Title', 'unknown')).toBe('a-title');
+  });
+
+  it('still keeps "Anonymous", which is a real attribution in this corpus', () => {
+    // Deliberate, and pinned by tests/unit/slugify.test.ts — an anonymous
+    // early-modern imprint is not the same claim as "we do not know".
+    expect(generateBookSlug('Some Text', 'Anonymous')).toBe('some-text-anonymous');
+  });
+});

--- a/tests/unit/reader-canonical-url.test.ts
+++ b/tests/unit/reader-canonical-url.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Reader URLs must canonicalise to the book's slug.
+ *
+ * /book/<id> has 301'd to /book/<slug> for a long time, but the reader one
+ * level down did not: /book/6a58f512…/page/6a58f512… served a 200 and left an
+ * unreadable URL in the address bar, which is what readers copy into citations
+ * and chat messages. Worse, turning a page rewrote a slug URL back to the id
+ * form (PageEditorClient's pushState), so a reader who entered on a good URL
+ * left with a bad one.
+ *
+ * The redirect is wired in the proxy, not in the page, because the per-page
+ * reader route is ISR — calling redirect() there would have to read
+ * searchParams and force it dynamic. Same reason the /book/<id> and
+ * /book/<slug>/page/<number> redirects already live here.
+ *
+ * These call proxy() directly. Per CLAUDE.md, a Vercel preview cannot verify
+ * proxy behaviour (Host-header resolution serves the production deployment),
+ * and a test that greps proxy.ts for a string would only catch deletion.
+ */
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { proxy } from '@/proxy';
+
+const BOOK_ID = '6a58f512c6cd8f9871069afb';
+const PAGE_ID = '6a58f512c6cd8f9871069b13';
+const SLUG = 'a-sacred-repository-of-anthems-and-hymns-for-devotional-canterbury';
+
+const req = (path: string) =>
+  new NextRequest(`https://sourcelibrary.org${path}`, {
+    headers: {
+      host: 'sourcelibrary.org',
+      'user-agent': 'Mozilla/5.0 Chrome/124',
+      'accept-language': 'en',
+      'sec-fetch-mode': 'navigate',
+    },
+  });
+
+/** The internal rewrite target, or null when the proxy left the request alone. */
+const rewriteTarget = (res: Response | null | undefined) => {
+  const target = res?.headers.get('x-middleware-rewrite');
+  return target ? new URL(target).pathname : null;
+};
+
+/** A request header the proxy set on the rewritten request. */
+const forwarded = (res: Response | null | undefined, name: string) =>
+  res?.headers.get(`x-middleware-request-${name}`);
+
+describe('reader URL canonicalisation', () => {
+  it('sends an id-addressed reader URL to the slug resolver', async () => {
+    const res = await proxy(req(`/book/${BOOK_ID}/page/${PAGE_ID}`));
+
+    expect(rewriteTarget(res)).toBe('/api/redirect/book-slug');
+    expect(forwarded(res, 'x-redirect-book')).toBe(BOOK_ID);
+    expect(forwarded(res, 'x-redirect-page-id')).toBe(PAGE_ID);
+  });
+
+  it('carries the query string through, so ?highlight= and ?v= survive', async () => {
+    // ?v= pins a cited edition version and ?highlight= pins a search term.
+    // Dropping either changes what the reader lands on without saying so.
+    const res = await proxy(req(`/book/${BOOK_ID}/page/${PAGE_ID}?highlight=mercury&v=2`));
+
+    expect(rewriteTarget(res)).toBe('/api/redirect/book-slug');
+    expect(forwarded(res, 'x-redirect-search')).toBe('?highlight=mercury&v=2');
+  });
+
+  it('leaves a slug-addressed reader URL alone', async () => {
+    // The common case, and the one that must never pay for a Mongo lookup.
+    const res = await proxy(req(`/book/${SLUG}/page/${PAGE_ID}`));
+
+    expect(rewriteTarget(res)).not.toBe('/api/redirect/book-slug');
+  });
+
+  it('still resolves a page *number* in one hop, not two', async () => {
+    // /book/<id>/page/5 must go to the page-number resolver (number → page id
+    // AND id → slug in a single 301), not bounce through the slug resolver.
+    const res = await proxy(req(`/book/${BOOK_ID}/page/5`));
+
+    expect(rewriteTarget(res)).toBe('/api/redirect/book-page');
+    expect(forwarded(res, 'x-redirect-page')).toBe('5');
+  });
+
+  it('does not re-rewrite once the resolver has bounced back (ns=1)', async () => {
+    // Books with no slug bounce back with ns=1. Without this guard the proxy
+    // would rewrite it straight back to the resolver, forever.
+    const res = await proxy(req(`/book/${BOOK_ID}/page/${PAGE_ID}?ns=1`));
+
+    expect(rewriteTarget(res)).not.toBe('/api/redirect/book-slug');
+  });
+});


### PR DESCRIPTION
## What

The book page lives at `/book/a-sacred-repository-of-anthems-and-hymns-for-devotional-canterbury`, but the reader one level down published the raw ObjectId:

```
/book/6a58f512c6cd8f9871069afb/page/6a58f512c6cd8f9871069b13
```

You could land on a good URL, turn one page, and leave with an unreadable one — `handleNavigate`'s `pushState` built from `book.id`. That URL is what readers copy into citations, footnotes and messages.

Both forms always resolved (`findBookByIdOrSlug` takes either) and the canonical `<link>` was already slug-based, so this was never an SEO or a 404 problem. It was a "the URL doesn't say which book it is" problem.

## Changes

**Reader URLs**
- `PageEditorClient` builds every URL it writes from `bookPath` (slug, id fallback): the `pushState`, the VersionBanner link, the `sl-navigate` embed message.
- On mount, `replaceState` swaps whatever sits in the book position for the current slug — covers stale slugs after a rename, and UUID-form ids the redirect heuristic doesn't match.
- `/book/<id>/page/<pageId>` now 301s to `/book/<slug>/page/<pageId>`, so links already in the wild upgrade themselves.

Wired in the proxy, mirroring the `/book/<id>` and `/book/<slug>/page/<number>` redirects that already live there: the per-page reader route is ISR, so a `redirect()` inside it would have to read `searchParams` and force it dynamic. The book-slug resolver now carries the `/page/<pageId>` tail and the query string through the 301, because `?highlight=` pins a search term and `?v=` pins a cited edition version. Ordered after the page-number block so `/book/<id>/page/5` still resolves number → page id AND id → slug in one hop.

**Links born canonical**
- New `readerPageUrl()` in `slugify.ts`, next to `bookUrl()`/`tenantBookUrl()`. The rule lived nowhere, which is how the `pushState` drifted in the first place.
- Routed through it: both quote APIs (that URL gets printed into papers — calling the API by id minted a permanent citation to `/book/<objectid>`), the `/q/<code>` shortlink resolver (one extra projection turns a double redirect into one hop), and the stale-index branch of the gallery image API, the only one of its four siblings still using `book_id`.
- Call sites holding nothing but a page's `book_id` (orphaned gallery rows, exhibition layouts) keep relying on the 301 — they have no slug in scope.

**Slug quality**
- `generateBookSlug` no longer emits a leading hyphen. `slugifyText` keeps only `[a-z0-9]`, so a title in Greek, Hebrew, Japanese, Tibetan or Arabic sanitizes to `""` and `` `${title}-${author}` `` became `-mousouros`. Falls back to the author alone.
- `extractLastName` folds "Unknown artist" (it was suffixing those books `-artist`). "Anonymous" is deliberately left in the slug, per the existing test.
- `isPlaceholderSlug()`, used by the sweep below and by `metadata-enrichment`'s self-repair, which only caught empty/`undefined`/`untitled` before and so missed the whole `/book/-10` class.

**Repair sweep** — `scripts/maintenance/repair-book-slugs.ts` (not run by CI; dry-run by default)

Measured on production 2026-08-01: 29 visible books have no slug at all and are reachable only as `/book/<objectid>`; ~85 more sit at `/book/-10`, `/book/-13` from an import that wrote a bare counter, every one of them carrying an unused English `display_title`. Dry run: 208 flagged, 198 renamed, 10 skipped.

It backs every prior slug up to JSON before the first write and pushes the old slug onto `slug_aliases` in the same update, so existing links and citations 301 to the new URL. It skips books whose slug already matches their title (`216` → `216-anonymous` changes a URL to say nothing new) and books with no Latin text to work from — those need a `display_title` first, which is enrichment's job, not this sweep's.

## Out of scope

- **Page numbers as the canonical page segment.** They go missing, repeat, turn roman and shift on split scans, and this repo already ate ~1.2k indexed soft-404s from number-form URLs. The page id stays the durable citation anchor; `/book/<slug>/page/<number>` remains a supported input alias that 301s to it.
- **Rewriting the ~12 remaining id-form link builders.** Search panels, collection grids and the like only have a book id in scope; giving each one a lookup costs more than the redirect it saves.
- **Running the sweep.** It has not been applied — that is a separate, deliberate step.

## Verification

- `tests/unit/reader-canonical-url.test.ts` calls `proxy()` directly. A Vercel preview cannot verify proxy behaviour (Host-header resolution serves the production deployment), and a test that greps `proxy.ts` for a string would only catch deletion. Confirmed its two new-behaviour cases fail against the unfixed proxy.
- `tests/unit/book-slug-quality.test.ts` covers the non-Latin title class, the placeholder predicate and the unknown-author rule.
- 1372 unit tests pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)