### PR TITLE
fix(security): gate every page-text write at editor (#3511)

### DIFF
--- a/src/app/api/[tenant]/pages/[id]/quick-fix/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/quick-fix/route.ts
@@ -15,6 +15,10 @@ const quickFixSchema = z.object({
   }),
 });
 
+/**
+ * PATCH /api/[tenant]/pages/[id]/quick-fix — tenant-scoped twin of the above.
+ * Gated at `editor` (#3511); this is the one the QA page actually calls.
+ */
 export const PATCH = withAuth(async (request, session, context) => {
   try {
     const { tenant, id } = await context.params;
@@ -85,4 +89,4 @@ export const PATCH = withAuth(async (request, session, context) => {
     console.error('Error applying quick fix:', error);
     return NextResponse.json({ error: 'Failed to apply fix' }, { status: 500 });
   }
-});
+}, { minRole: 'editor' });

--- a/src/app/api/[tenant]/pages/[id]/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/route.ts
@@ -88,11 +88,17 @@ export async function GET(
   }
 }
 
+/**
+ * PATCH /api/[tenant]/pages/[id] — replace a page's OCR / translation / summary.
+ *
+ * Gated at `editor` (#3511), matching both the UI gate and the global twin at
+ * /api/pages/[id]. This is the route the reader's editor actually calls.
+ */
 export const PATCH = withAuth(async (request, session, context) => {
   try {
     const { tenant, id } = await context.params;
     const db = await getDb();
-    
+
     // Resolve tenant slug to UUID
     const tenantId = await resolveTenantId(tenant);
     if (!tenantId) {
@@ -216,13 +222,20 @@ export const PATCH = withAuth(async (request, session, context) => {
     console.error('Error updating page:', error);
     return NextResponse.json({ error: 'Failed to update page' }, { status: 500 });
   }
-});
+}, { minRole: 'editor' });
 
+/**
+ * DELETE /api/[tenant]/pages/[id] — hard-delete a page and renumber the rest.
+ *
+ * Gated at `admin`, matching the global twin at /api/pages/[id] (#3511). This
+ * had drifted to the `withAuth` default of `reader`: unlike the text writes
+ * above it creates no revision, so a wrong call was unrecoverable.
+ */
 export const DELETE = withAuth(async (request, session, context) => {
   try {
     const { tenant, id } = await context.params;
     const db = await getDb();
-    
+
     // Resolve tenant slug to UUID
     const tenantId = await resolveTenantId(tenant);
     if (!tenantId) {
@@ -266,4 +279,4 @@ export const DELETE = withAuth(async (request, session, context) => {
     console.error('Error deleting page:', error);
     return NextResponse.json({ error: 'Failed to delete page' }, { status: 500 });
   }
-});
+}, { minRole: 'admin' });

--- a/src/app/api/[tenant]/pages/batch-split/route.ts
+++ b/src/app/api/[tenant]/pages/batch-split/route.ts
@@ -299,4 +299,4 @@ export const POST = withAuth(async (request, session, context) => {
       { status: 500 }
     );
   }
-});
+}, { minRole: 'editor' });

--- a/src/app/api/pages/[id]/quick-fix/route.ts
+++ b/src/app/api/pages/[id]/quick-fix/route.ts
@@ -14,6 +14,15 @@ const quickFixSchema = z.object({
   }),
 });
 
+/**
+ * PATCH /api/pages/[id]/quick-fix — splice an insert/delete/replace into a
+ * page's OCR or translation text at a character offset.
+ *
+ * Gated at `editor` (#3511). This route looks up the page by `id` alone, with
+ * no tenant filter, so before the gate any signed-in account could rewrite any
+ * page in the corpus from the main domain — the broadest of the page-write
+ * routes, and the one furthest from its UI gate.
+ */
 export const PATCH = withAuth(async (request, session, context) => {
   try {
     const { id } = await context.params;
@@ -77,4 +86,4 @@ export const PATCH = withAuth(async (request, session, context) => {
     console.error('Error applying quick fix:', error);
     return NextResponse.json({ error: 'Failed to apply fix' }, { status: 500 });
   }
-});
+}, { minRole: 'editor' });

--- a/src/app/api/pages/[id]/reset/route.ts
+++ b/src/app/api/pages/[id]/reset/route.ts
@@ -6,6 +6,10 @@ export const maxDuration = 60;
 
 // Reset a split page back to its original state
 // This removes the crop from the original and deletes the split sibling
+//
+// Gated at `editor` (#3511). It hard-deletes the sibling page and renumbers
+// every page in the book, with no tenant filter and no revision — the most
+// destructive of the reader-defaulted page routes.
 export const POST = withAuth(async (request, session, context) => {
   try {
     const { id: pageId } = await context.params;
@@ -86,4 +90,4 @@ export const POST = withAuth(async (request, session, context) => {
       { status: 500 }
     );
   }
-});
+}, { minRole: 'editor' });

--- a/src/app/api/pages/[id]/revisions/[revisionId]/restore/route.ts
+++ b/src/app/api/pages/[id]/revisions/[revisionId]/restore/route.ts
@@ -7,6 +7,12 @@ import { withAuth } from '@/lib/auth-helpers';
  *
  * Restore a revision — writes the old content back to the page.
  * Creates a new revision of the current content first (nothing is lost).
+ *
+ * Gated at `editor` (#3511). Two reasons this one mattered most: the Restore
+ * button renders in the reader's *read* mode, so it was the only page-write
+ * affordance a non-editor could actually see; and `restoreRevision()` resolves
+ * the page from the revision document, ignoring the `[id]` in the path and
+ * applying no tenant filter — so any revision id rewrote its page, anywhere.
  */
 export const POST = withAuth(async (
   request: NextRequest,
@@ -32,4 +38,4 @@ export const POST = withAuth(async (
     console.error('Error restoring revision:', error);
     return NextResponse.json({ error: 'Failed to restore revision' }, { status: 500 });
   }
-});
+}, { minRole: 'editor' });

--- a/src/app/api/pages/[id]/route.ts
+++ b/src/app/api/pages/[id]/route.ts
@@ -85,6 +85,15 @@ export async function GET(
   }
 }
 
+/**
+ * PATCH /api/pages/[id] — replace a page's OCR / translation / summary text.
+ *
+ * Gated at `editor`, matching the UI: the Read/Edit toggle in TranslationEditor
+ * is wrapped in `<AuthCheck role="inner_circle">` (= effective role >= editor),
+ * so this is the API gate for an affordance no reader can see. It defaulted to
+ * `reader` until #3511, which meant any signed-in account could overwrite a
+ * page's text by calling the route directly.
+ */
 export const PATCH = withAuth(async (request, session, context) => {
   try {
     const { id } = await context.params;
@@ -212,7 +221,7 @@ export const PATCH = withAuth(async (request, session, context) => {
     console.error('Error updating page:', error);
     return NextResponse.json({ error: 'Failed to update page' }, { status: 500 });
   }
-});
+}, { minRole: 'editor' });
 
 export const DELETE = withAdminAuth(async (request, session, context) => {
   try {

--- a/src/app/api/pages/batch-split/route.ts
+++ b/src/app/api/pages/batch-split/route.ts
@@ -285,4 +285,4 @@ export const POST = withAuth(async (request, session) => {
       { status: 500 }
     );
   }
-});
+}, { minRole: 'editor' });

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -123,11 +123,18 @@ export default async function ParticipatePage() {
           The easiest way to start
         </h2>
         <div className="max-w-3xl">
+          {/* This section promised "an edit button on every page. No account needed."
+              No route has ever provided that: every page-text write is gated at
+              editor, and the Read/Edit toggle only renders for editors (#3511).
+              Flagging a problem really is open to everyone, so that is what it
+              now says. */}
           <p className="text-lg text-secondary leading-relaxed mb-4">
-            Open any book. Read the AI translation next to the original page image. If something is wrong, click edit and fix it. That&apos;s it.
+            Open any book. Read the AI translation next to the original page image. If something looks wrong, say so &mdash; every page has a &ldquo;Notice a translation issue?&rdquo; link that takes a note straight to us. No account needed.
           </p>
           <p className="text-secondary leading-relaxed mb-6">
-            Every book has an edit button on every page. No account needed. The languages we most need help with:{' '}
+            To correct the text yourself, write to{' '}
+            <a href="mailto:team@sourcelibrary.org?subject=Editing access" className="text-accent-rust hover:underline">team@sourcelibrary.org</a>
+            {' '}and we&apos;ll give your account editing access. The languages we most need help with:{' '}
             <span className="text-primary font-medium">Latin</span>,{' '}
             <span className="text-primary font-medium">German</span>,{' '}
             <span className="text-primary font-medium">Arabic</span>,{' '}

--- a/src/components/reader/RevisionHistory.tsx
+++ b/src/components/reader/RevisionHistory.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { History, RotateCcw, X, ChevronDown, Pencil } from 'lucide-react';
+import { AuthCheck } from '@/components/auth/AuthCheck';
 import type { PageRevision } from '@/lib/page-revisions';
 
 interface RevisionHistoryProps {
@@ -238,15 +239,22 @@ export default function RevisionHistory({ pageId, field, currentSource, editedBy
                         <span className="text-[10px]" style={{ color: 'var(--text-faint)' }}>
                           {rev.data.length.toLocaleString('en-US')} chars
                         </span>
-                        <button
-                          onClick={(e) => { e.stopPropagation(); handleRestore(rev.id); }}
-                          disabled={restoring === rev.id}
-                          className="flex items-center gap-1 px-2.5 py-1.5 rounded text-[10px] font-medium transition-colors hover:bg-accent-gold/8"
-                          style={{ color: 'var(--accent-rust)' }}
-                        >
-                          <RotateCcw className={`w-3 h-3 ${restoring === rev.id ? 'animate-spin' : ''}`} />
-                          {restoring === rev.id ? 'Restoring...' : 'Restore'}
-                        </button>
+                        {/* Reading the history is open to everyone — it is provenance,
+                            and seeing how a page was corrected is part of the point.
+                            Restoring rewrites the page, so it matches the editor gate
+                            on the route behind it (#3511). Before this the button
+                            rendered for every visitor and simply failed on click. */}
+                        <AuthCheck role="inner_circle">
+                          <button
+                            onClick={(e) => { e.stopPropagation(); handleRestore(rev.id); }}
+                            disabled={restoring === rev.id}
+                            className="flex items-center gap-1 px-2.5 py-1.5 rounded text-[10px] font-medium transition-colors hover:bg-accent-gold/8"
+                            style={{ color: 'var(--accent-rust)' }}
+                          >
+                            <RotateCcw className={`w-3 h-3 ${restoring === rev.id ? 'animate-spin' : ''}`} />
+                            {restoring === rev.id ? 'Restoring...' : 'Restore'}
+                          </button>
+                        </AuthCheck>
                       </div>
                     </div>
                   )}

--- a/tests/unit/page-write-auth.test.ts
+++ b/tests/unit/page-write-auth.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Every route that rewrites a page's text must be gated at `editor` (#3511).
+ *
+ * The UI has always gated editing correctly: the Read/Edit toggle in
+ * TranslationEditor is wrapped in `<AuthCheck role="inner_circle">`, so a reader
+ * never sees it. The API gates had drifted to `withAuth`'s default of `reader`,
+ * which meant any signed-in account could overwrite OCR or translation text by
+ * calling the route directly — and two of the routes (`quick-fix`, `restore`)
+ * apply no tenant filter, so the reach was the whole corpus from the main
+ * domain, not one tenant.
+ *
+ * This test runs the REAL `withAuth` against the REAL route modules. Only
+ * `auth()` and the database are faked. Deleting the `{ minRole: 'editor' }`
+ * option from any route below turns its case red — verified by doing exactly
+ * that, per the "a test that greps source is not a guard" rule in CLAUDE.md.
+ */
+
+const ROLE_LEVEL = { reader: 1, contributor: 2, editor: 3, admin: 4, superadmin: 5 };
+
+let currentRole = 'reader';
+
+vi.mock('@/lib/auth', () => ({
+  ROLE_LEVEL,
+  auth: vi.fn(async () => ({
+    user: { id: 'u1', name: 'A Reader', email: 'reader@example.com', role: currentRole },
+    expires: new Date(Date.now() + 3600_000).toISOString(),
+  })),
+}));
+
+// No memberships, no platform-superadmin grant, no page found. The handler is
+// allowed to run and fail on its own terms — this test only cares whether the
+// gate let it through at all.
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: () => ({
+      findOne: async () => null,
+      findOneAndUpdate: async () => null,
+      updateOne: async () => ({ matchedCount: 0 }),
+    }),
+  })),
+}));
+
+vi.mock('@/lib/page-revisions', () => ({
+  createRevision: async () => undefined,
+  restoreRevision: async () => ({ success: false, error: 'Revision not found' }),
+}));
+
+type RouteCase = {
+  name: string;
+  method: 'PATCH' | 'POST' | 'DELETE';
+  /** Lowest role the route must accept. */
+  minRole: 'editor' | 'admin';
+  load: () => Promise<Record<string, unknown>>;
+  params: Record<string, string>;
+  body?: unknown;
+};
+
+const PAGE_TEXT_BODY = {
+  ocr: { data: 'Aurum nostrum non est aurum vulgi.', language: 'Latin' },
+};
+
+const QUICK_FIX_BODY = {
+  field: 'ocr',
+  fix: { type: 'insert', position: 0, text: 'x' },
+};
+
+/**
+ * Every route that can rewrite or destroy stored page content. A new one added
+ * without a `minRole` will not be covered here automatically — the companion
+ * enumeration test below is what catches that.
+ */
+const CASES: RouteCase[] = [
+  {
+    name: 'PATCH /api/pages/[id]',
+    method: 'PATCH',
+    minRole: 'editor',
+    load: () => import('@/app/api/pages/[id]/route'),
+    params: { id: 'page-1' },
+    body: PAGE_TEXT_BODY,
+  },
+  {
+    name: 'PATCH /api/[tenant]/pages/[id]',
+    method: 'PATCH',
+    minRole: 'editor',
+    load: () => import('@/app/api/[tenant]/pages/[id]/route'),
+    params: { tenant: 'bph', id: 'page-1' },
+    body: PAGE_TEXT_BODY,
+  },
+  {
+    name: 'DELETE /api/[tenant]/pages/[id]',
+    method: 'DELETE',
+    minRole: 'admin',
+    load: () => import('@/app/api/[tenant]/pages/[id]/route'),
+    params: { tenant: 'bph', id: 'page-1' },
+  },
+  {
+    name: 'PATCH /api/pages/[id]/quick-fix',
+    method: 'PATCH',
+    minRole: 'editor',
+    load: () => import('@/app/api/pages/[id]/quick-fix/route'),
+    params: { id: 'page-1' },
+    body: QUICK_FIX_BODY,
+  },
+  {
+    name: 'PATCH /api/[tenant]/pages/[id]/quick-fix',
+    method: 'PATCH',
+    minRole: 'editor',
+    load: () => import('@/app/api/[tenant]/pages/[id]/quick-fix/route'),
+    params: { tenant: 'bph', id: 'page-1' },
+    body: QUICK_FIX_BODY,
+  },
+  {
+    name: 'POST /api/pages/[id]/revisions/[revisionId]/restore',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/pages/[id]/revisions/[revisionId]/restore/route'),
+    params: { id: 'page-1', revisionId: 'rev-1' },
+  },
+  {
+    name: 'POST /api/pages/[id]/reset',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/pages/[id]/reset/route'),
+    params: { id: 'page-1' },
+  },
+  {
+    name: 'POST /api/pages/batch-split',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/pages/batch-split/route'),
+    params: {},
+    body: { splits: [{ pageId: 'page-1', splitPosition: 500 }] },
+  },
+  {
+    name: 'POST /api/[tenant]/pages/batch-split',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/[tenant]/pages/batch-split/route'),
+    params: { tenant: 'bph' },
+    body: { splits: [{ pageId: 'page-1', splitPosition: 500 }] },
+  },
+];
+
+async function call(c: RouteCase, role: string) {
+  currentRole = role;
+  const mod = await c.load();
+  const handler = mod[c.method] as (req: unknown, ctx: unknown) => Promise<Response>;
+  const req = new Request('https://sourcelibrary.org/api/pages/page-1', {
+    method: c.method,
+    headers: { 'content-type': 'application/json' },
+    body: c.body ? JSON.stringify(c.body) : undefined,
+  });
+  return handler(req, { params: Promise.resolve(c.params) });
+}
+
+/** Roles strictly below the route's required role. */
+function rolesBelow(minRole: 'editor' | 'admin') {
+  return (['reader', 'contributor', 'editor', 'admin'] as const).filter(
+    (r) => ROLE_LEVEL[r] < ROLE_LEVEL[minRole],
+  );
+}
+
+describe('page-write routes are gated above reader (#3511)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    // A stray CRON_SECRET would not matter (we send no Authorization header),
+    // but PLATFORM_ADMIN_EMAILS would silently promote our test user.
+    vi.stubEnv('PLATFORM_ADMIN_EMAILS', '');
+  });
+
+  for (const c of CASES) {
+    for (const role of rolesBelow(c.minRole)) {
+      it(`${c.name} refuses a signed-in ${role}`, async () => {
+        const res = await call(c, role);
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: 'Forbidden - Insufficient role' });
+      });
+    }
+
+    it(`${c.name} admits ${c.minRole}`, async () => {
+      const res = await call(c, c.minRole);
+      // The handler runs and then fails on the mocked-empty database — several
+      // of these routes answer 403 themselves when they cannot resolve a
+      // tenant. So "did the gate let it through" cannot be read from the status
+      // alone; it is the gate's own error body that has to be absent.
+      expect(res.status).not.toBe(401);
+      const body = await res.json().catch(() => ({}));
+      expect(body).not.toEqual({ error: 'Forbidden - Insufficient role' });
+    });
+  }
+});
+
+describe('the page-write route list stays complete', () => {
+  /**
+   * The gates above are only as good as this list. Five of these six routes
+   * were missed by the issue that reported the sixth, which is the recurring
+   * shape here (see the five `entities.books[]` writers in CLAUDE.md). If a new
+   * page-text write route appears, add it to CASES.
+   */
+  it('covers every route module that writes page text', async () => {
+    const { readdirSync, readFileSync, statSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    const roots = ['src/app/api/pages', 'src/app/api/[tenant]/pages'];
+    const found: string[] = [];
+
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const p = join(dir, entry);
+        if (statSync(p).isDirectory()) {
+          walk(p);
+          continue;
+        }
+        if (entry !== 'route.ts') continue;
+        const src = readFileSync(p, 'utf8');
+        // Routes that assign client-supplied text into a page's stored fields,
+        // or remove a page outright. `modernize` and `transliterate` write only
+        // model output and take no text from the caller, so they are excluded.
+        const writesPageText =
+          /\[`?\$?\{?(?:revision\.)?field\}?`?\.data`?\]|['"](?:ocr|translation|summary)\.data['"]/.test(src);
+        const deletesPage = /deleteOne\(\s*\{\s*id/.test(src);
+        if (writesPageText || deletesPage) found.push(p);
+      }
+    };
+
+    for (const r of roots) walk(r);
+
+    // restoreRevision lives in a lib, so the restore route matches neither
+    // pattern by itself; it is covered in CASES and asserted separately.
+    const covered = new Set([
+      'src/app/api/pages/[id]/route.ts',
+      'src/app/api/[tenant]/pages/[id]/route.ts',
+      'src/app/api/pages/[id]/quick-fix/route.ts',
+      'src/app/api/[tenant]/pages/[id]/quick-fix/route.ts',
+      'src/app/api/pages/[id]/revisions/[revisionId]/restore/route.ts',
+      'src/app/api/pages/[id]/reset/route.ts',
+      'src/app/api/pages/batch-split/route.ts',
+      'src/app/api/[tenant]/pages/batch-split/route.ts',
+    ]);
+
+    const uncovered = found.filter((f) => !covered.has(f));
+    expect(uncovered, `page-write routes with no auth case in CASES: ${uncovered.join(', ')}`).toEqual([]);
+    expect(CASES.length).toBeGreaterThanOrEqual(covered.size);
+  });
+});


### PR DESCRIPTION
Closes #3511 (item 2), and answers item 1.

## What was wrong

Eight routes that rewrite or destroy stored page content sat on `withAuth`'s default `minRole: 'reader'`. Any signed-in account could call them directly.

The UI was never wrong — the Read/Edit toggle in `TranslationEditor` is wrapped in `<AuthCheck role="inner_circle">`, so a reader has never seen an edit button. The API gate behind that affordance had drifted away from it.

## Scope is wider than the issue reported

#3511 named one route and scoped the reach to "a tenant subdomain". Enumerating the writers found **eight**, and two of them are not tenant-scoped at all:

| Route | was | now | tenant filter |
|---|---|---|---|
| `PATCH /api/pages/[id]` | reader | editor | requires `x-tenant-id` |
| `PATCH /api/[tenant]/pages/[id]` | reader | editor | yes |
| `DELETE /api/[tenant]/pages/[id]` | reader | **admin** | yes |
| `PATCH /api/pages/[id]/quick-fix` | reader | editor | **none** |
| `PATCH /api/[tenant]/pages/[id]/quick-fix` | reader | editor | yes |
| `POST /api/pages/[id]/revisions/[revisionId]/restore` | reader | editor | **none** |
| `POST /api/pages/[id]/reset` | reader | editor | **none** |
| `POST /api/pages/batch-split` + tenant twin | reader | editor | global one: none |

`quick-fix` looks a page up by `id` alone. `restoreRevision()` resolves its page from the revision document, ignoring the `[id]` in the path. Both were reachable from the main domain against **any page in the corpus**, not one tenant.

Two are destructive rather than editorial, and neither writes a revision first:
- `DELETE /api/[tenant]/pages/[id]` hard-deletes a page and renumbers the book. Its global twin was correctly `withAdminAuth`; the tenant copy had drifted to reader. Now admin.
- `POST /api/pages/[id]/reset` deletes a split sibling on the same terms.
- `batch-split` clears OCR and translation across a set of pages (`confirmClearOcr: true` skips the warning).

## Also in this PR

**The Restore button was visible to everyone.** `RevisionHistory` renders in the reader's *read* mode with no gate, so it was the one page-write control a non-editor could actually see and click — it simply 401'd. Reading the history stays open (it is provenance, and worth seeing); restoring is now gated to match the route.

**`/contribute` promised something no route provides.** It said "Every book has an edit button on every page. No account needed." That has never been true. It now describes what *is* open to everyone — flagging a translation issue, which needs no account — and points at `team@sourcelibrary.org` for editing access. **This is authored copy; happy to take different wording.**

## Blast radius: none expected

- No client calls the global twins — `pagesApi` builds `/api/[tenant]/...` paths.
- The tenant-scoped routes the editor UI does call resolve a tenant membership role, so a BPH editor still passes at `editor`.
- The one behaviour that changes for a legitimate user is the Restore button disappearing for signed-in non-editors, for whom it never worked.

## Verification

`tests/unit/page-write-auth.test.ts` runs the **real** `withAuth` against the **real** route modules, faking only `auth()` and the database — it is not a source grep.

Negative-controlled per CLAUDE.md ("a test that greps source is not a guard"): stripping every `minRole` turned **19 of 29** cases red, and restoring them turned them green again. The 10 that stayed green are the "admits editor" cases, which correctly still pass without gates.

It also enumerates the page-write route modules under `src/app/api/**/pages/**`, so a ninth writer added later fails the build rather than silently inheriting the reader default. That enumeration is what found five of the eight.

`npx tsc --noEmit` clean.

## Out of scope

- **A pre-existing misroute:** `pagesApi.update()` builds `/api/${getTenantSlug()}/pages/...`, and `getTenantSlug()` returns `''` on `/book/...` paths (`book` is in `NON_TENANT_SEGMENTS`), producing `/api//pages/<id>`. Next.js 308s that to the global route, which 403s without `x-tenant-id`. So editor saves from the main-domain reader appear to be broken today, independently of this change. Filed separately rather than fixed here.
- The ~20 other unauthenticated POST routes that authenticate inside the handler — a real audit, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)