### PR TITLE
fix(security): rate limit the public submission inboxes (#3509)

### DIFF
--- a/src/app/api/collection-proposals/route.ts
+++ b/src/app/api/collection-proposals/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { withAdminAuth } from '@/lib/auth-helpers';
+import { guardPublicSubmission } from '@/lib/public-submission-guard';
 
 /**
  * "Propose a collection" — a lightweight submission inbox, modeled on
@@ -21,6 +22,9 @@ const MAX_RATIONALE = 5000;
 // POST /api/collection-proposals — submit a proposal (anonymous, like feedback)
 export async function POST(request: NextRequest) {
   try {
+    const limited = await guardPublicSubmission(request, 'collection-proposals');
+    if (limited) return limited;
+
     const body = await request.json();
     const { title, rationale, book_ids, suggested_slug, name, email } = body as {
       title?: unknown;

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,10 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { withAdminAuth } from '@/lib/auth-helpers';
+import { guardPublicSubmission } from '@/lib/public-submission-guard';
+import { getClientIp } from '@/lib/rate-limit';
 
 // POST /api/feedback — save feedback
 export async function POST(request: NextRequest) {
   try {
+    const limited = await guardPublicSubmission(request, 'feedback');
+    if (limited) return limited;
+
     const body = await request.json();
     const { message, page, name, email, wantsToHelp } = body;
 
@@ -17,7 +22,10 @@ export async function POST(request: NextRequest) {
     }
 
     const db = await getDb();
-    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || null;
+    // cf-connecting-ip first: behind the CDN, x-forwarded-for is a Cloudflare
+    // edge node, so reading it first filed every submission under ~15 shared
+    // addresses (#3491). Same helper the limiter above keys on.
+    const ip = getClientIp(request);
     const trimmedEmail = email?.trim()?.toLowerCase() || null;
     const wantsHelp = wantsToHelp === true;
 

--- a/src/app/api/share-findings/route.ts
+++ b/src/app/api/share-findings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { withAdminAuth } from '@/lib/auth-helpers';
+import { guardPublicSubmission } from '@/lib/public-submission-guard';
 
 /**
  * "Share back" — a lightweight submission inbox, modeled on /api/feedback.
@@ -25,6 +26,9 @@ const MAX_CITATIONS = 50;
 // POST /api/share-findings — submit a dossier (anonymous, like feedback)
 export async function POST(request: NextRequest) {
   try {
+    const limited = await guardPublicSubmission(request, 'share-findings');
+    if (limited) return limited;
+
     const body = await request.json();
     const { title, summary, citations, name, email } = body as {
       title?: unknown; summary?: unknown; citations?: unknown; name?: unknown; email?: unknown;

--- a/src/lib/public-submission-guard.ts
+++ b/src/lib/public-submission-guard.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { checkRateLimitShared, getClientIp } from '@/lib/rate-limit';
+
+/**
+ * Rate limit for the public, unauthenticated submission inboxes (#3509).
+ *
+ * Three routes accept writes from anyone — `/api/feedback`,
+ * `/api/share-findings`, `/api/collection-proposals`. All three already cap
+ * field sizes and land in an admin-reviewed queue that never renders publicly,
+ * so the exposure is not injection; it is that a stranger can fill a human
+ * being's worklist. `/api/mcp` sits behind `withApiAuth` (anon 60/hr) and so
+ * covers MCP-originated writes, but each route is reachable directly, and the
+ * on-page feedback widget posts to `/api/feedback` with no gate at all.
+ *
+ * This lives in one place rather than being inlined three times because the
+ * recurring defect in this codebase is a fourth writer added later that quietly
+ * skips the step (see the five `entities.books[]` writers, and the six search
+ * boxes of which one logged nothing for four months). A new public submission
+ * route calls this or it is unlimited.
+ *
+ * Uses the Mongo-backed limiter, not the in-memory one: these run on Vercel
+ * where each instance has its own memory, so a per-instance counter is a
+ * per-instance counter times however many instances are warm.
+ */
+
+/** Shared-Mongo limiter is keyed on this name — changing it resets the window. */
+export type PublicSubmissionRoute =
+  | 'feedback'
+  | 'share-findings'
+  | 'collection-proposals';
+
+const LIMITS: Record<PublicSubmissionRoute, number> = {
+  // A reader flagging translation issues page by page is doing exactly what we
+  // asked them to, so this is the loosest of the three.
+  feedback: 10,
+  // A dossier and a collection proposal are both considered submissions; more
+  // than a handful an hour from one address is not a person thinking.
+  'share-findings': 5,
+  'collection-proposals': 5,
+};
+
+const WINDOW_SECONDS = 3600;
+
+/**
+ * Returns a 429 response to send back, or `null` when the caller may proceed.
+ *
+ * If Mongo is slow or down, `checkRateLimitShared` degrades to the in-memory
+ * per-instance cap rather than refusing — a limiter outage must not swallow a
+ * reader's feedback.
+ *
+ * Note on the key: `getClientIp` reads `cf-connecting-ip` first, which is
+ * correct behind the CDN (#3491) but is caller-supplied on any hostname that
+ * bypasses Cloudflare. `alias-host-scope.ts` 308s those away from the API
+ * surface, so the spoofable path is closed elsewhere rather than here — worth
+ * re-checking if a new alias is ever allowed to serve `/api/*`.
+ */
+export async function guardPublicSubmission(
+  request: Request,
+  route: PublicSubmissionRoute,
+): Promise<NextResponse | null> {
+  const result = await checkRateLimitShared(
+    { name: route, limit: LIMITS[route], windowSeconds: WINDOW_SECONDS },
+    getClientIp(request),
+  );
+
+  if (result.allowed) return null;
+
+  return NextResponse.json(
+    { error: 'Too many submissions. Please try again later.' },
+    { status: 429, headers: { 'Retry-After': String(result.retryAfter) } },
+  );
+}

--- a/tests/unit/public-submission-rate-limit.test.ts
+++ b/tests/unit/public-submission-rate-limit.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The three public, unauthenticated submission inboxes must be rate limited
+ * (#3509). They are the only write surfaces on the site a stranger can reach
+ * with no credential of any kind, and each one lands in a queue a human reads.
+ *
+ * The routes are exercised for real; only the limiter and the database are
+ * faked. Removing the `guardPublicSubmission` call from any of them turns its
+ * case red — verified by deleting each one in turn.
+ */
+
+let denied = false;
+
+vi.mock('@/lib/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/rate-limit')>();
+  return {
+    ...actual,
+    checkRateLimitShared: vi.fn(async () =>
+      denied ? { allowed: false as const, retryAfter: 900 } : { allowed: true as const },
+    ),
+  };
+});
+
+// Each route also exports an admin-only GET. Only POST is under test here, and
+// importing the real wrapper drags in next-auth, which will not load under
+// vitest.
+vi.mock('@/lib/auth-helpers', () => ({
+  withAdminAuth: (h: unknown) => h,
+}));
+
+const inserted: Record<string, unknown[]> = {};
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: (name: string) => ({
+      insertOne: async (doc: unknown) => {
+        (inserted[name] ??= []).push(doc);
+        return { insertedId: 'inserted-1' };
+      },
+      updateOne: async () => ({ matchedCount: 1 }),
+      findOne: async () => null,
+      find: () => ({ toArray: async () => [] }),
+      countDocuments: async () => 0,
+    }),
+  })),
+}));
+
+const ROUTES = [
+  {
+    name: 'POST /api/feedback',
+    load: () => import('@/app/api/feedback/route'),
+    body: { message: 'The translation on this page drops a whole line.' },
+  },
+  {
+    name: 'POST /api/share-findings',
+    load: () => import('@/app/api/share-findings/route'),
+    body: {
+      title: 'Mercury in the Ripley scrolls',
+      summary: 'A thread across three books.',
+      citations: [{ book_id: 'book-1', page: 12, note: 'the sealed vessel' }],
+    },
+  },
+  {
+    name: 'POST /api/collection-proposals',
+    load: () => import('@/app/api/collection-proposals/route'),
+    body: {
+      title: 'Alchemical Emblems',
+      rationale: 'These plates belong together.',
+      book_ids: ['book-1', 'book-2'],
+    },
+  },
+];
+
+async function post(r: (typeof ROUTES)[number]) {
+  const { POST } = await r.load();
+  const req = new Request('https://sourcelibrary.org/api/x', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'cf-connecting-ip': '203.0.113.9' },
+    body: JSON.stringify(r.body),
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (POST as any)(req);
+}
+
+describe('public submission inboxes are rate limited (#3509)', () => {
+  beforeEach(() => {
+    denied = false;
+    for (const k of Object.keys(inserted)) delete inserted[k];
+  });
+
+  for (const r of ROUTES) {
+    it(`${r.name} returns 429 once the limit is hit`, async () => {
+      denied = true;
+      const res = await post(r);
+      expect(res.status).toBe(429);
+      expect(res.headers.get('Retry-After')).toBe('900');
+    });
+
+    it(`${r.name} writes nothing when refused`, async () => {
+      denied = true;
+      await post(r);
+      // The whole point is keeping spam out of a human's queue, so the refusal
+      // has to happen before the insert, not alongside it.
+      expect(Object.values(inserted).flat()).toEqual([]);
+    });
+
+    it(`${r.name} still accepts a submission under the limit`, async () => {
+      denied = false;
+      const res = await post(r);
+      expect(res.status).not.toBe(429);
+      expect(Object.values(inserted).flat().length).toBeGreaterThan(0);
+    });
+  }
+
+  it('keys the limiter on the CDN-aware client IP, not x-forwarded-for', async () => {
+    const { checkRateLimitShared } = await import('@/lib/rate-limit');
+    denied = false;
+    const { POST } = await ROUTES[0].load();
+    const req = new Request('https://sourcelibrary.org/api/feedback', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        // What a real request looks like behind Cloudflare: x-forwarded-for is
+        // a Cloudflare edge node, and using it would bucket unrelated readers
+        // together (#3491).
+        'cf-connecting-ip': '203.0.113.9',
+        'x-forwarded-for': '172.68.1.1',
+      },
+      body: JSON.stringify({ message: 'A note from a reader.' }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (POST as any)(req);
+    expect(checkRateLimitShared).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'feedback' }),
+      '203.0.113.9',
+    );
+  });
+});
+
+describe('the public submission route list stays complete', () => {
+  /**
+   * Scoped deliberately to the three inboxes #3509 is about — the ones that
+   * take a submission from an anonymous stranger and put it in front of a
+   * person. It is NOT a sweep of every unauthenticated POST in the app: a
+   * first draft of this test tried that and surfaced ~20 routes that
+   * authenticate inside the handler, verify a webhook signature, or write
+   * telemetry. Auditing those is real work and has its own issue; pretending
+   * this test covers them would be the more dangerous outcome.
+   */
+  it('each anonymous submission inbox calls the shared guard', async () => {
+    const { readFileSync } = await import('node:fs');
+
+    const inboxes = [
+      'src/app/api/feedback/route.ts',
+      'src/app/api/share-findings/route.ts',
+      'src/app/api/collection-proposals/route.ts',
+    ];
+
+    for (const f of inboxes) {
+      const src = readFileSync(f, 'utf8');
+      expect(src, `${f} no longer calls guardPublicSubmission`).toContain(
+        'guardPublicSubmission(request,',
+      );
+    }
+
+    // The behavioural cases above cover the same three routes. If that list and
+    // this one drift apart, one of them is no longer testing what it claims.
+    expect(ROUTES.length).toBe(inboxes.length);
+  });
+});


### PR DESCRIPTION
Closes #3509.

## What was wrong

`/api/feedback`, `/api/share-findings` and `/api/collection-proposals` accept writes from anyone with no credential of any kind, and none called `checkRateLimit`.

Everything else the review asked for was already true and I verified each: all three cap field sizes, and all three land in an admin-reviewed queue with no public render path — so there is no stored-XSS surface. `/api/mcp` sits behind `withApiAuth` (anon 60/hr), which covers MCP-originated writes; but the routes are also reachable directly, and the on-page feedback widget posts to `/api/feedback` with no gate at all.

Severity is low — spam into a queue, not injection — but it is an unauthenticated write to a human's worklist.

## Approach

Adds `guardPublicSubmission()` in `src/lib/public-submission-guard.ts` rather than inlining the check three times. The recurring defect in this codebase is the fourth writer added later that quietly skips the step — the five `entities.books[]` writers, the six search boxes of which one logged nothing for four months. One place to change the policy, and a new inbox calls it or is unlimited.

**Mongo-backed limiter, not the in-memory one.** These run on Vercel, where each instance keeps its own counter map, so a per-instance cap is a per-instance cap times however many instances are warm. `checkRateLimitShared` degrades to the in-memory cap if Mongo is slow or down — a limiter outage must not swallow a reader's feedback.

| route | limit |
|---|---|
| `feedback` | 10/hour |
| `share-findings` | 5/hour |
| `collection-proposals` | 5/hour |

Feedback is loosest because a reader flagging translation issues page by page is doing exactly what we asked them to.

## Also: `/api/feedback` was recording the CDN

It stored `x-forwarded-for` as the submitter's IP, which behind Cloudflare is an edge node — the #3491 mistake, filing every submission under ~15 shared addresses in Cloudflare's egress ranges. It now uses `getClientIp()`, the same CDN-aware helper the limiter keys on.

## Verification

`tests/unit/public-submission-rate-limit.test.ts` exercises the real routes with only the limiter and database faked. It asserts a 429 with `Retry-After`, that **nothing is inserted** when refused (the point is keeping spam out of the queue, so the refusal must precede the insert), that submissions under the limit still land, and that the limiter is keyed on `cf-connecting-ip` rather than `x-forwarded-for`.

Negative-controlled: removing the guard call from each route in turn turns that route's cases red (4, 3, 3 failures respectively), restoring turns them green.

`npx tsc --noEmit` clean.

## Deliberately narrow

The route-list check covers **these three only**. A first draft swept every unauthenticated POST in the app and surfaced ~20 routes — but they authenticate inside the handler, verify a webhook signature, or write telemetry. Auditing those is real work and deserves its own issue; a test that appeared to cover them while not actually checking anything meaningful would be worse than not having it.

## Note for review

`getClientIp` reads `cf-connecting-ip` first, which is correct behind the CDN but caller-supplied on any hostname that bypasses Cloudflare. `alias-host-scope.ts` (#3446) 308s those away from the API surface, so the spoofable path is closed elsewhere — worth re-checking if a new alias is ever allowed to serve `/api/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)