### PR TITLE
Analytics: Books tab (leaderboards + week-by-week)

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -20,9 +20,11 @@ const LogsTab = dynamic(() => import('@/components/analytics/tabs/LogsTab'), { s
 const SearchTab = dynamic(() => import('@/components/analytics/tabs/SearchTab'), { ssr: false, loading: LoadingBar });
 const TrafficTab = dynamic(() => import('@/components/analytics/tabs/TrafficTab'), { ssr: false, loading: LoadingBar });
 const PipelineTab = dynamic(() => import('@/components/analytics/tabs/PipelineTab'), { ssr: false, loading: LoadingBar });
-type Tab = 'usage' | 'performance' | 'logs' | 'search' | 'traffic' | 'pipeline';
+const BooksTab = dynamic(() => import('@/components/analytics/tabs/BooksTab'), { ssr: false, loading: LoadingBar });
+type Tab = 'books' | 'usage' | 'performance' | 'logs' | 'search' | 'traffic' | 'pipeline';
 
 const TABS: { key: Tab; label: string }[] = [
+  { key: 'books', label: 'Books' },
   { key: 'usage', label: 'Usage' },
   { key: 'performance', label: 'Performance' },
   { key: 'logs', label: 'Logs' },
@@ -32,7 +34,7 @@ const TABS: { key: Tab; label: string }[] = [
 ];
 
 export default function AnalyticsPage() {
-  const [activeTab, setActiveTab] = useState<Tab>('usage');
+  const [activeTab, setActiveTab] = useState<Tab>('books');
   const [days, setDays] = useState(30);
   const [hours, setHours] = useState(24);
   const [pipelineHours, setPipelineHours] = useState(24);
@@ -133,6 +135,7 @@ export default function AnalyticsPage() {
       </header>
 
       <main className="max-w-[1500px] mx-auto px-6 py-8">
+        {activeTab === 'books' && <BooksTab key={refreshKey} />}
         {activeTab === 'usage' && <UsageTab key={refreshKey} days={days} />}
         {activeTab === 'performance' && <PerformanceTab key={refreshKey} hours={hours} />}
         {activeTab === 'logs' && <LogsTab key={refreshKey} />}

--- a/src/app/api/admin/book-insights/route.ts
+++ b/src/app/api/admin/book-insights/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from 'next/server';
+import { withInnerCircleAuth } from '@/lib/auth-helpers';
+import { getReadDb } from '@/lib/mongodb';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/book-insights
+ *
+ * Book-centric analytics for the /analytics "Books" tab. All view/engagement
+ * signals are human-only (traffic_class:'human') and drawn from:
+ *   - books.read_count            → all-time views
+ *   - analytics_events book_read  → time-series views (weekly / trending)
+ *   - analytics_events download   → downloads by book
+ *   - analytics_events search_query → top searches
+ *   - likes (target_type:'book')  → most liked
+ */
+export const GET = withInnerCircleAuth(async () => {
+  const db = await getReadDb();
+  const AE = db.collection('analytics_events');
+  const B = db.collection('books');
+  const L = db.collection('likes');
+
+  const now = Date.now();
+  const d7 = new Date(now - 7 * 864e5);
+  const d14 = new Date(now - 14 * 864e5);
+  const d30 = new Date(now - 30 * 864e5);
+  const wk16 = new Date(now - 16 * 7 * 864e5);
+  const HUMAN = { traffic_class: 'human' };
+  const MT = { maxTimeMS: 20000 };
+
+  const [
+    topViewed, weeklyRaw, cur7, prev7, dlRaw, likeRaw, langRaw, searchRaw,
+    views7, views30, booksViewed, neverOpened, downloads30, bookLikes,
+  ] = await Promise.all([
+    // All-time most viewed (reliable cumulative counter)
+    B.find({ read_count: { $gt: 0 }, visible: true },
+      { projection: { _id: 0, id: 1, display_title: 1, title: 1, author: 1, slug: 1, read_count: 1, language: 1, pages_count: 1 } })
+      .sort({ read_count: -1 }).limit(25).toArray(),
+    // Weekly book-opens, last 16 weeks. NOT human-filtered: reliable human
+    // classification only began 2026-07-28 (#3405), so a human-only weekly
+    // trend would be a single bar. All-traffic gives the real 17-week shape;
+    // the UI labels it as book-opens (all traffic) to be honest about the mix.
+    AE.aggregate([
+      { $match: { event: 'book_read', created_at: { $gte: wk16 } } },
+      { $group: { _id: { $dateTrunc: { date: '$created_at', unit: 'week', startOfWeek: 'monday' } }, n: { $sum: 1 } } },
+      { $sort: { _id: 1 } },
+    ], MT).toArray(),
+    // Trending — per-book reads this 7d vs prior 7d
+    AE.aggregate([{ $match: { event: 'book_read', ...HUMAN, created_at: { $gte: d7 } } }, { $group: { _id: '$book_id', n: { $sum: 1 } } }], MT).toArray(),
+    AE.aggregate([{ $match: { event: 'book_read', ...HUMAN, created_at: { $gte: d14, $lt: d7 } } }, { $group: { _id: '$book_id', n: { $sum: 1 } } }], MT).toArray(),
+    // Downloads by book, last 30d
+    AE.aggregate([{ $match: { event: 'download', ...HUMAN, created_at: { $gte: d30 } } }, { $group: { _id: '$bookId', n: { $sum: 1 } } }, { $sort: { n: -1 } }, { $limit: 20 }], MT).toArray(),
+    // Most-liked books
+    L.aggregate([{ $match: { target_type: 'book' } }, { $group: { _id: '$target_id', n: { $sum: 1 } } }, { $sort: { n: -1 } }, { $limit: 20 }], MT).toArray(),
+    // Views by language (all-time read_count)
+    B.aggregate([{ $match: { visible: true, read_count: { $gt: 0 } } }, { $group: { _id: '$language', views: { $sum: '$read_count' }, books: { $sum: 1 } } }, { $sort: { views: -1 } }, { $limit: 12 }], MT).toArray(),
+    // Top searches, last 30d
+    AE.aggregate([{ $match: { event: 'search_query', ...HUMAN, created_at: { $gte: d30 } } }, { $group: { _id: '$query', n: { $sum: 1 } } }, { $match: { _id: { $nin: [null, ''] } } }, { $sort: { n: -1 } }, { $limit: 20 }], MT).toArray(),
+    // Summary counters
+    AE.countDocuments({ event: 'book_read', ...HUMAN, created_at: { $gte: d7 } }),
+    AE.countDocuments({ event: 'book_read', ...HUMAN, created_at: { $gte: d30 } }),
+    B.countDocuments({ read_count: { $gt: 0 } }),
+    B.countDocuments({ visible: true, pages_count: { $gt: 0 }, $or: [{ read_count: { $exists: false } }, { read_count: 0 }] }),
+    AE.countDocuments({ event: 'download', ...HUMAN, created_at: { $gte: d30 } }),
+    L.countDocuments({ target_type: 'book' }),
+  ]);
+
+  // ── Resolve titles for every book id referenced by the event aggregates ──
+  const prevMap = new Map<string, number>(prev7.map((r) => [r._id, r.n]));
+  const trendingIds = cur7.map((r) => r._id);
+  const ids = [...new Set([
+    ...trendingIds,
+    ...dlRaw.map((r) => r._id),
+    ...likeRaw.map((r) => r._id),
+  ].filter(Boolean))] as string[];
+  const bookDocs = ids.length
+    ? await B.find({ id: { $in: ids } }, { projection: { _id: 0, id: 1, display_title: 1, title: 1, author: 1, slug: 1 } }).toArray()
+    : [];
+  const meta = new Map(bookDocs.map((b) => [b.id, b]));
+  const label = (id: string) => {
+    const b = meta.get(id);
+    return { id, title: (b?.display_title || b?.title || 'Untitled') as string, author: (b?.author || '') as string, slug: (b?.slug || id) as string };
+  };
+
+  const trending = cur7
+    .map((r) => ({ ...label(r._id), now: r.n, prev: prevMap.get(r._id) || 0, delta: r.n - (prevMap.get(r._id) || 0) }))
+    .filter((r) => r.delta > 0)
+    .sort((a, b) => b.delta - a.delta)
+    .slice(0, 15);
+
+  const norm = (r: { _id: string; n: number }) => ({ ...label(r._id), count: r.n });
+  const asRows = (a: unknown[]) => a as Array<{ _id: string; n: number }>;
+
+  return NextResponse.json({
+    summary: {
+      views7, views30, booksViewed, neverOpened, downloads30, bookLikes,
+      weeklyAvg: weeklyRaw.length ? Math.round(weeklyRaw.reduce((s, w) => s + w.n, 0) / weeklyRaw.length) : 0,
+    },
+    weekly: weeklyRaw.map((w) => ({ week: w._id, views: w.n })),
+    topViewed: topViewed.map((b) => ({ id: b.id, title: b.display_title || b.title || 'Untitled', author: b.author || '', slug: b.slug || b.id, views: b.read_count, language: b.language, pages: b.pages_count })),
+    trending,
+    topDownloaded: asRows(dlRaw).map(norm),
+    topLiked: asRows(likeRaw).map(norm),
+    byLanguage: langRaw.map((l) => ({ language: l._id || 'Unknown', views: l.views, books: l.books })),
+    topSearches: searchRaw.map((s) => ({ term: s._id, count: s.n })),
+    generatedAt: new Date().toISOString(),
+  });
+});

--- a/src/app/api/admin/book-insights/route.ts
+++ b/src/app/api/admin/book-insights/route.ts
@@ -5,16 +5,14 @@ import { getReadDb } from '@/lib/mongodb';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
+type Agg = Array<{ _id: string; [k: string]: unknown }>;
+
 /**
- * GET /api/admin/book-insights
- *
- * Book-centric analytics for the /analytics "Books" tab. All view/engagement
- * signals are human-only (traffic_class:'human') and drawn from:
- *   - books.read_count            → all-time views
- *   - analytics_events book_read  → time-series views (weekly / trending)
- *   - analytics_events download   → downloads by book
- *   - analytics_events search_query → top searches
- *   - likes (target_type:'book')  → most liked
+ * GET /api/admin/book-insights — book-centric analytics for the /analytics
+ * "Books" tab. Human-only (traffic_class:'human') where the data supports it;
+ * the weekly opens trend is all-traffic on purpose (reliable human read
+ * tracking only began 2026-07-28, #3405). Sources: books.read_count,
+ * analytics_events (book_read / page_read / download / search_query), likes.
  */
 export const GET = withInnerCircleAuth(async () => {
   const db = await getReadDb();
@@ -26,85 +24,79 @@ export const GET = withInnerCircleAuth(async () => {
   const d7 = new Date(now - 7 * 864e5);
   const d14 = new Date(now - 14 * 864e5);
   const d30 = new Date(now - 30 * 864e5);
+  const d90 = new Date(now - 90 * 864e5);
   const wk16 = new Date(now - 16 * 7 * 864e5);
   const HUMAN = { traffic_class: 'human' };
-  const MT = { maxTimeMS: 20000 };
+  const MT = { maxTimeMS: 25000 };
 
   const [
-    topViewed, weeklyRaw, cur7, prev7, dlRaw, likeRaw, langRaw, searchRaw,
-    views7, views30, booksViewed, neverOpened, downloads30, bookLikes,
+    topViewed, weeklyRaw, cur7, prev7, dlRaw, likeTop, likeAll, langRaw, searchRaw,
+    geoRaw, gapsRaw, deepRaw, newArrivals,
+    views7, views30, pageReads30, booksViewed, neverOpened, downloads30, bookLikes,
   ] = await Promise.all([
-    // All-time most viewed (reliable cumulative counter)
-    B.find({ read_count: { $gt: 0 }, visible: true },
-      { projection: { _id: 0, id: 1, display_title: 1, title: 1, author: 1, slug: 1, read_count: 1, language: 1, pages_count: 1 } })
-      .sort({ read_count: -1 }).limit(25).toArray(),
-    // Weekly book-opens, last 16 weeks. NOT human-filtered: reliable human
-    // classification only began 2026-07-28 (#3405), so a human-only weekly
-    // trend would be a single bar. All-traffic gives the real 17-week shape;
-    // the UI labels it as book-opens (all traffic) to be honest about the mix.
-    AE.aggregate([
-      { $match: { event: 'book_read', created_at: { $gte: wk16 } } },
-      { $group: { _id: { $dateTrunc: { date: '$created_at', unit: 'week', startOfWeek: 'monday' } }, n: { $sum: 1 } } },
-      { $sort: { _id: 1 } },
-    ], MT).toArray(),
-    // Trending — per-book reads this 7d vs prior 7d
-    AE.aggregate([{ $match: { event: 'book_read', ...HUMAN, created_at: { $gte: d7 } } }, { $group: { _id: '$book_id', n: { $sum: 1 } } }], MT).toArray(),
-    AE.aggregate([{ $match: { event: 'book_read', ...HUMAN, created_at: { $gte: d14, $lt: d7 } } }, { $group: { _id: '$book_id', n: { $sum: 1 } } }], MT).toArray(),
-    // Downloads by book, last 30d
-    AE.aggregate([{ $match: { event: 'download', ...HUMAN, created_at: { $gte: d30 } } }, { $group: { _id: '$bookId', n: { $sum: 1 } } }, { $sort: { n: -1 } }, { $limit: 20 }], MT).toArray(),
-    // Most-liked books
+    B.find({ read_count: { $gt: 0 }, visible: true }, { projection: { _id: 0, id: 1, display_title: 1, title: 1, author: 1, slug: 1, read_count: 1, language: 1 } }).sort({ read_count: -1 }).limit(25).toArray(),
+    AE.aggregate([{ $match: { event: 'book_read', timestamp: { $gte: wk16 } } }, { $group: { _id: { $dateTrunc: { date: '$timestamp', unit: 'week', startOfWeek: 'monday' } }, n: { $sum: 1 } } }, { $sort: { _id: 1 } }], MT).toArray(),
+    AE.aggregate([{ $match: { event: 'book_read', ...HUMAN, timestamp: { $gte: d7 } } }, { $group: { _id: '$book_id', n: { $sum: 1 } } }], MT).toArray(),
+    AE.aggregate([{ $match: { event: 'book_read', ...HUMAN, timestamp: { $gte: d14, $lt: d7 } } }, { $group: { _id: '$book_id', n: { $sum: 1 } } }], MT).toArray(),
+    AE.aggregate([{ $match: { event: 'download', ...HUMAN, timestamp: { $gte: d30 } } }, { $group: { _id: '$bookId', n: { $sum: 1 } } }, { $sort: { n: -1 } }, { $limit: 20 }], MT).toArray(),
     L.aggregate([{ $match: { target_type: 'book' } }, { $group: { _id: '$target_id', n: { $sum: 1 } } }, { $sort: { n: -1 } }, { $limit: 20 }], MT).toArray(),
-    // Views by language (all-time read_count)
+    L.aggregate([{ $match: { target_type: 'book' } }, { $group: { _id: '$target_id', n: { $sum: 1 } } }, { $match: { n: { $gte: 2 } } }], MT).toArray(),
     B.aggregate([{ $match: { visible: true, read_count: { $gt: 0 } } }, { $group: { _id: '$language', views: { $sum: '$read_count' }, books: { $sum: 1 } } }, { $sort: { views: -1 } }, { $limit: 12 }], MT).toArray(),
-    // Top searches, last 30d
-    AE.aggregate([{ $match: { event: 'search_query', ...HUMAN, created_at: { $gte: d30 } } }, { $group: { _id: '$query', n: { $sum: 1 } } }, { $match: { _id: { $nin: [null, ''] } } }, { $sort: { n: -1 } }, { $limit: 20 }], MT).toArray(),
-    // Summary counters
-    AE.countDocuments({ event: 'book_read', ...HUMAN, created_at: { $gte: d7 } }),
-    AE.countDocuments({ event: 'book_read', ...HUMAN, created_at: { $gte: d30 } }),
+    AE.aggregate([{ $match: { event: 'search_query', ...HUMAN, timestamp: { $gte: d30 } } }, { $group: { _id: '$query', n: { $sum: 1 } } }, { $match: { _id: { $nin: [null, ''] } } }, { $sort: { n: -1 } }, { $limit: 20 }], MT).toArray(),
+    AE.aggregate([{ $match: { event: { $in: ['search_query', 'download'] }, ...HUMAN, country: { $nin: [null, ''] }, timestamp: { $gte: d30 } } }, { $group: { _id: '$country', n: { $sum: 1 } } }, { $sort: { n: -1 } }, { $limit: 12 }], MT).toArray(),
+    AE.aggregate([{ $match: { event: 'search_query', ...HUMAN, timestamp: { $gte: d30 }, results_count: { $lte: 2 } } }, { $group: { _id: '$query', n: { $sum: 1 }, res: { $max: '$results_count' } } }, { $match: { _id: { $nin: [null, ''] } } }, { $sort: { n: -1 } }, { $limit: 15 }], MT).toArray(),
+    AE.aggregate([{ $match: { event: 'page_read', ...HUMAN, timestamp: { $gte: d30 } } }, { $group: { _id: '$book_id', pages: { $sum: 1 } } }, { $sort: { pages: -1 } }, { $limit: 20 }], MT).toArray(),
+    B.find({ visible: true, read_count: { $gt: 0 }, created_at: { $gte: d90 } }, { projection: { _id: 0, id: 1, display_title: 1, title: 1, author: 1, slug: 1, read_count: 1, created_at: 1 } }).sort({ read_count: -1 }).limit(15).toArray(),
+    AE.countDocuments({ event: 'book_read', ...HUMAN, timestamp: { $gte: d7 } }),
+    AE.countDocuments({ event: 'book_read', ...HUMAN, timestamp: { $gte: d30 } }),
+    AE.countDocuments({ event: 'page_read', ...HUMAN, timestamp: { $gte: d30 } }),
     B.countDocuments({ read_count: { $gt: 0 } }),
     B.countDocuments({ visible: true, pages_count: { $gt: 0 }, $or: [{ read_count: { $exists: false } }, { read_count: 0 }] }),
-    AE.countDocuments({ event: 'download', ...HUMAN, created_at: { $gte: d30 } }),
+    AE.countDocuments({ event: 'download', ...HUMAN, timestamp: { $gte: d30 } }),
     L.countDocuments({ target_type: 'book' }),
   ]);
 
-  // ── Resolve titles for every book id referenced by the event aggregates ──
-  const prevMap = new Map<string, number>(prev7.map((r) => [r._id, r.n]));
-  const trendingIds = cur7.map((r) => r._id);
+  // ── Resolve titles + read_count for every referenced book id ──
+  const prevMap = new Map((prev7 as Agg).map((r) => [r._id, r.n as number]));
   const ids = [...new Set([
-    ...trendingIds,
-    ...dlRaw.map((r) => r._id),
-    ...likeRaw.map((r) => r._id),
+    ...(cur7 as Agg).map((r) => r._id),
+    ...(dlRaw as Agg).map((r) => r._id),
+    ...(likeTop as Agg).map((r) => r._id),
+    ...(likeAll as Agg).map((r) => r._id),
+    ...(deepRaw as Agg).map((r) => r._id),
   ].filter(Boolean))] as string[];
   const bookDocs = ids.length
-    ? await B.find({ id: { $in: ids } }, { projection: { _id: 0, id: 1, display_title: 1, title: 1, author: 1, slug: 1 } }).toArray()
+    ? await B.find({ id: { $in: ids } }, { projection: { _id: 0, id: 1, display_title: 1, title: 1, author: 1, slug: 1, read_count: 1 } }).toArray()
     : [];
   const meta = new Map(bookDocs.map((b) => [b.id, b]));
-  const label = (id: string) => {
-    const b = meta.get(id);
-    return { id, title: (b?.display_title || b?.title || 'Untitled') as string, author: (b?.author || '') as string, slug: (b?.slug || id) as string };
-  };
+  const label = (id: string) => { const b = meta.get(id); return { id, title: (b?.display_title || b?.title || 'Untitled') as string, author: (b?.author || '') as string, slug: (b?.slug || id) as string }; };
+  const rows = (a: unknown[], key = 'n') => (a as Agg).map((r) => ({ ...label(r._id), count: r[key] as number }));
 
-  const trending = cur7
-    .map((r) => ({ ...label(r._id), now: r.n, prev: prevMap.get(r._id) || 0, delta: r.n - (prevMap.get(r._id) || 0) }))
-    .filter((r) => r.delta > 0)
-    .sort((a, b) => b.delta - a.delta)
-    .slice(0, 15);
+  const trending = (cur7 as Agg)
+    .map((r) => ({ ...label(r._id), now: r.n as number, prev: prevMap.get(r._id) || 0, delta: (r.n as number) - (prevMap.get(r._id) || 0) }))
+    .filter((r) => r.delta > 0).sort((a, b) => b.delta - a.delta).slice(0, 15);
 
-  const norm = (r: { _id: string; n: number }) => ({ ...label(r._id), count: r.n });
-  const asRows = (a: unknown[]) => a as Array<{ _id: string; n: number }>;
+  // Punching above weight — likes per 100 views (needs enough views to matter)
+  const punching = (likeAll as Agg)
+    .map((r) => { const b = meta.get(r._id); const views = (b?.read_count as number) || 0; return { ...label(r._id), likes: r.n as number, views, per100: views ? ((r.n as number) / views) * 100 : 0 }; })
+    .filter((r) => r.views >= 25).sort((a, b) => b.per100 - a.per100).slice(0, 12);
+
+  const geoTotal = (geoRaw as Agg).reduce((s, g) => s + (g.n as number), 0);
 
   return NextResponse.json({
-    summary: {
-      views7, views30, booksViewed, neverOpened, downloads30, bookLikes,
-      weeklyAvg: weeklyRaw.length ? Math.round(weeklyRaw.reduce((s, w) => s + w.n, 0) / weeklyRaw.length) : 0,
-    },
-    weekly: weeklyRaw.map((w) => ({ week: w._id, views: w.n })),
-    topViewed: topViewed.map((b) => ({ id: b.id, title: b.display_title || b.title || 'Untitled', author: b.author || '', slug: b.slug || b.id, views: b.read_count, language: b.language, pages: b.pages_count })),
+    summary: { views7, views30, pageReads30, booksViewed, neverOpened, downloads30, bookLikes },
+    weekly: (weeklyRaw as Agg).map((w) => ({ week: w._id, views: w.n })),
+    topViewed: topViewed.map((b) => ({ id: b.id, title: b.display_title || b.title || 'Untitled', author: b.author || '', slug: b.slug || b.id, count: b.read_count, language: b.language })),
     trending,
-    topDownloaded: asRows(dlRaw).map(norm),
-    topLiked: asRows(likeRaw).map(norm),
-    byLanguage: langRaw.map((l) => ({ language: l._id || 'Unknown', views: l.views, books: l.books })),
-    topSearches: searchRaw.map((s) => ({ term: s._id, count: s.n })),
+    topDownloaded: rows(dlRaw),
+    topLiked: rows(likeTop),
+    deepestRead: rows(deepRaw, 'pages'),
+    punching,
+    newArrivals: newArrivals.map((b) => ({ id: b.id, title: b.display_title || b.title || 'Untitled', author: b.author || '', slug: b.slug || b.id, count: b.read_count, added: b.created_at })),
+    byLanguage: (langRaw as Agg).map((l) => ({ language: (l._id as string) || 'Unknown', views: l.views as number, books: l.books as number })),
+    topSearches: (searchRaw as Agg).map((s) => ({ term: s._id, count: s.n as number })),
+    searchGaps: (gapsRaw as Agg).map((s) => ({ term: s._id, count: s.n as number, results: s.res as number })),
+    geo: (geoRaw as Agg).map((g) => ({ country: g._id, count: g.n as number, pct: geoTotal ? Math.round(((g.n as number) / geoTotal) * 100) : 0 })),
     generatedAt: new Date().toISOString(),
   });
 });

--- a/src/components/analytics/tabs/BooksTab.tsx
+++ b/src/components/analytics/tabs/BooksTab.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { Eye, TrendingUp, Download, Heart, BookOpen, Search, Moon } from 'lucide-react';
+
+type BookRef = { id: string; title: string; author: string; slug: string };
+type Insights = {
+  summary: { views7: number; views30: number; booksViewed: number; neverOpened: number; downloads30: number; bookLikes: number; weeklyAvg: number };
+  weekly: { week: string; views: number }[];
+  topViewed: (BookRef & { views: number; language?: string; pages?: number })[];
+  trending: (BookRef & { now: number; prev: number; delta: number })[];
+  topDownloaded: (BookRef & { count: number })[];
+  topLiked: (BookRef & { count: number })[];
+  byLanguage: { language: string; views: number; books: number }[];
+  topSearches: { term: string; count: number }[];
+};
+
+const num = (n?: number) => (n ?? 0).toLocaleString();
+
+function StatCard({ icon, label, value, sub, tint }: { icon: React.ReactNode; label: string; value: string; sub?: string; tint: string }) {
+  return (
+    <div className="p-5 rounded-xl" style={{ background: `linear-gradient(135deg, var(--bg-white), ${tint})`, border: '1px solid var(--border-light)' }}>
+      <div className="flex items-center gap-2 mb-2" style={{ color: 'var(--text-muted)' }}>
+        {icon}<span className="text-xs font-medium uppercase tracking-wide">{label}</span>
+      </div>
+      <div className="text-3xl font-bold tabular-nums" style={{ color: 'var(--text-primary)' }}>{value}</div>
+      {sub && <div className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>{sub}</div>}
+    </div>
+  );
+}
+
+function BookLink({ b }: { b: BookRef }) {
+  return (
+    <Link href={`/book/${b.slug}`} target="_blank" className="hover:underline" style={{ color: 'var(--text-primary)' }}>
+      {b.title}{b.author ? <span style={{ color: 'var(--text-muted)' }}> · {b.author}</span> : null}
+    </Link>
+  );
+}
+
+function RankTable<T extends BookRef>({ title, icon, rows, value, empty }: { title: string; icon: React.ReactNode; rows: T[]; value: (r: T) => React.ReactNode; empty: string }) {
+  return (
+    <div className="rounded-xl overflow-hidden" style={{ border: '1px solid var(--border-light)' }}>
+      <div className="px-4 py-3 flex items-center gap-2" style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)' }}>
+        {icon}<h3 className="font-semibold text-sm">{title}</h3>
+      </div>
+      {rows.length === 0 ? (
+        <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text-muted)' }}>{empty}</div>
+      ) : (
+        <ol>
+          {rows.map((r, i) => (
+            <li key={r.id + i} className="flex items-center gap-3 px-4 py-2 text-sm" style={{ borderTop: i ? '1px solid var(--border-light)' : 'none' }}>
+              <span className="w-5 text-right tabular-nums" style={{ color: 'var(--text-muted)' }}>{i + 1}</span>
+              <span className="flex-1 min-w-0 truncate"><BookLink b={r} /></span>
+              <span className="tabular-nums font-semibold shrink-0" style={{ color: 'var(--text-primary)' }}>{value(r)}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+export default function BooksTab() {
+  const [d, setD] = useState<Insights | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/admin/book-insights')
+      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
+      .then(setD).catch((e) => setErr(e.message)).finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <div className="py-12 text-center text-sm" style={{ color: 'var(--text-muted)' }}>Crunching reads, likes & downloads…</div>;
+  if (err || !d) return <div className="py-12 text-center text-sm" style={{ color: 'var(--text-muted)' }}>Couldn&apos;t load insights{err ? ` (${err})` : ''}.</div>;
+
+  const maxWeek = Math.max(1, ...d.weekly.map((w) => w.views));
+  const maxLang = Math.max(1, ...d.byLanguage.map((l) => l.views));
+  const fmtWeek = (iso: string) => new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+
+  return (
+    <div className="space-y-8">
+      {/* Summary */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+        <StatCard icon={<Eye className="w-4 h-4" />} label="Reads · 7d" value={num(d.summary.views7)} sub={`${num(d.summary.weeklyAvg)}/wk avg`} tint="#eff6ff" />
+        <StatCard icon={<Eye className="w-4 h-4" />} label="Reads · 30d" value={num(d.summary.views30)} tint="#f0f9ff" />
+        <StatCard icon={<BookOpen className="w-4 h-4" />} label="Books opened" value={num(d.summary.booksViewed)} sub="all-time, ≥1 view" tint="#f0fdf4" />
+        <StatCard icon={<Moon className="w-4 h-4" />} label="Never opened" value={num(d.summary.neverOpened)} sub="visible, 0 views" tint="#faf5ff" />
+        <StatCard icon={<Download className="w-4 h-4" />} label="Downloads · 30d" value={num(d.summary.downloads30)} tint="#fff7ed" />
+        <StatCard icon={<Heart className="w-4 h-4" />} label="Book likes" value={num(d.summary.bookLikes)} sub="all-time" tint="#fef2f2" />
+      </div>
+
+      {/* Weekly trend */}
+      <div>
+        <h2 className="text-sm font-semibold uppercase tracking-wide mb-1" style={{ color: 'var(--text-muted)' }}>Book opens per week · last 16 weeks</h2>
+        <p className="text-xs mb-3" style={{ color: 'var(--text-muted)' }}>All traffic (bots included). Reliable <em>human</em> read tracking began Jul 28 (#3405), so the human counts in the cards above and the leaderboards below are recent-window; this trend gives the fuller shape.</p>
+        <div className="flex items-end gap-1.5 h-40 px-1 rounded-xl py-3" style={{ border: '1px solid var(--border-light)', background: 'var(--bg-white)' }}>
+          {d.weekly.map((w) => (
+            <div key={w.week} className="flex-1 flex flex-col items-center justify-end h-full group" title={`Week of ${fmtWeek(w.week)}: ${num(w.views)} opens`}>
+              <div className="w-full rounded-t transition-all group-hover:opacity-80" style={{ height: `${(w.views / maxWeek) * 100}%`, background: 'var(--accent-sage, #7c9885)', minHeight: 2 }} />
+              <span className="text-[9px] mt-1 whitespace-nowrap" style={{ color: 'var(--text-muted)' }}>{fmtWeek(w.week)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Trending + Most viewed */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <RankTable title="Trending this week" icon={<TrendingUp className="w-4 h-4" />} rows={d.trending}
+          value={(r) => <span title={`${r.now} this week vs ${r.prev} last`}>+{num(r.delta)}</span>} empty="No week-over-week risers yet." />
+        <RankTable title="Most read · all time" icon={<Eye className="w-4 h-4" />} rows={d.topViewed} value={(r) => num(r.views)} empty="No reads yet." />
+      </div>
+
+      {/* Liked + Downloaded */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <RankTable title="Most liked" icon={<Heart className="w-4 h-4" />} rows={d.topLiked} value={(r) => num(r.count)} empty="No book likes yet." />
+        <RankTable title="Most downloaded · 30d" icon={<Download className="w-4 h-4" />} rows={d.topDownloaded} value={(r) => num(r.count)} empty="No downloads in the last 30 days." />
+      </div>
+
+      {/* By language + Top searches */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="rounded-xl overflow-hidden" style={{ border: '1px solid var(--border-light)' }}>
+          <div className="px-4 py-3" style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)' }}><h3 className="font-semibold text-sm">Reads by language</h3></div>
+          <div className="p-4 space-y-2">
+            {d.byLanguage.map((l) => (
+              <div key={l.language} className="text-sm">
+                <div className="flex justify-between mb-0.5"><span style={{ color: 'var(--text-primary)' }}>{l.language}</span><span className="tabular-nums" style={{ color: 'var(--text-muted)' }}>{num(l.views)}</span></div>
+                <div className="h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--bg-warm)' }}><div className="h-full rounded-full" style={{ width: `${(l.views / maxLang) * 100}%`, background: 'var(--accent-sage, #7c9885)' }} /></div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="rounded-xl overflow-hidden" style={{ border: '1px solid var(--border-light)' }}>
+          <div className="px-4 py-3 flex items-center gap-2" style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)' }}><Search className="w-4 h-4" /><h3 className="font-semibold text-sm">Top searches · 30d</h3></div>
+          {d.topSearches.length === 0 ? <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text-muted)' }}>No searches yet.</div> : (
+            <ol>
+              {d.topSearches.map((s, i) => (
+                <li key={s.term + i} className="flex items-center gap-3 px-4 py-2 text-sm" style={{ borderTop: i ? '1px solid var(--border-light)' : 'none' }}>
+                  <span className="w-5 text-right tabular-nums" style={{ color: 'var(--text-muted)' }}>{i + 1}</span>
+                  <Link href={`/search?q=${encodeURIComponent(s.term)}`} target="_blank" className="flex-1 min-w-0 truncate hover:underline" style={{ color: 'var(--text-primary)' }}>{s.term}</Link>
+                  <span className="tabular-nums font-semibold shrink-0" style={{ color: 'var(--text-primary)' }}>{num(s.count)}</span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/tabs/BooksTab.tsx
+++ b/src/components/analytics/tabs/BooksTab.tsx
@@ -2,18 +2,23 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { Eye, TrendingUp, Download, Heart, BookOpen, Search, Moon } from 'lucide-react';
+import { Eye, TrendingUp, Download, Heart, BookOpen, Search, Moon, Globe, Layers, Sparkles, Star, HelpCircle } from 'lucide-react';
 
-type BookRef = { id: string; title: string; author: string; slug: string };
+type Ref = { id: string; title: string; author: string; slug: string };
 type Insights = {
-  summary: { views7: number; views30: number; booksViewed: number; neverOpened: number; downloads30: number; bookLikes: number; weeklyAvg: number };
+  summary: { views7: number; views30: number; pageReads30: number; booksViewed: number; neverOpened: number; downloads30: number; bookLikes: number };
   weekly: { week: string; views: number }[];
-  topViewed: (BookRef & { views: number; language?: string; pages?: number })[];
-  trending: (BookRef & { now: number; prev: number; delta: number })[];
-  topDownloaded: (BookRef & { count: number })[];
-  topLiked: (BookRef & { count: number })[];
+  topViewed: (Ref & { count: number; language?: string })[];
+  trending: (Ref & { now: number; prev: number; delta: number })[];
+  topDownloaded: (Ref & { count: number })[];
+  topLiked: (Ref & { count: number })[];
+  deepestRead: (Ref & { count: number })[];
+  punching: (Ref & { likes: number; views: number; per100: number })[];
+  newArrivals: (Ref & { count: number; added?: string })[];
   byLanguage: { language: string; views: number; books: number }[];
   topSearches: { term: string; count: number }[];
+  searchGaps: { term: string; count: number; results: number }[];
+  geo: { country: string; count: number; pct: number }[];
 };
 
 const num = (n?: number) => (n ?? 0).toLocaleString();
@@ -21,43 +26,41 @@ const num = (n?: number) => (n ?? 0).toLocaleString();
 function StatCard({ icon, label, value, sub, tint }: { icon: React.ReactNode; label: string; value: string; sub?: string; tint: string }) {
   return (
     <div className="p-5 rounded-xl" style={{ background: `linear-gradient(135deg, var(--bg-white), ${tint})`, border: '1px solid var(--border-light)' }}>
-      <div className="flex items-center gap-2 mb-2" style={{ color: 'var(--text-muted)' }}>
-        {icon}<span className="text-xs font-medium uppercase tracking-wide">{label}</span>
-      </div>
+      <div className="flex items-center gap-2 mb-2" style={{ color: 'var(--text-muted)' }}>{icon}<span className="text-xs font-medium uppercase tracking-wide">{label}</span></div>
       <div className="text-3xl font-bold tabular-nums" style={{ color: 'var(--text-primary)' }}>{value}</div>
       {sub && <div className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>{sub}</div>}
     </div>
   );
 }
 
-function BookLink({ b }: { b: BookRef }) {
-  return (
-    <Link href={`/book/${b.slug}`} target="_blank" className="hover:underline" style={{ color: 'var(--text-primary)' }}>
-      {b.title}{b.author ? <span style={{ color: 'var(--text-muted)' }}> · {b.author}</span> : null}
-    </Link>
-  );
+function BookLink({ b }: { b: Ref }) {
+  return <Link href={`/book/${b.slug}`} target="_blank" className="hover:underline" style={{ color: 'var(--text-primary)' }}>{b.title}{b.author ? <span style={{ color: 'var(--text-muted)' }}> · {b.author}</span> : null}</Link>;
 }
 
-function RankTable<T extends BookRef>({ title, icon, rows, value, empty }: { title: string; icon: React.ReactNode; rows: T[]; value: (r: T) => React.ReactNode; empty: string }) {
+function Panel({ title, icon, sub, children }: { title: string; icon: React.ReactNode; sub?: string; children: React.ReactNode }) {
   return (
     <div className="rounded-xl overflow-hidden" style={{ border: '1px solid var(--border-light)' }}>
       <div className="px-4 py-3 flex items-center gap-2" style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)' }}>
-        {icon}<h3 className="font-semibold text-sm">{title}</h3>
+        {icon}<h3 className="font-semibold text-sm">{title}</h3>{sub && <span className="text-xs font-normal ml-auto" style={{ color: 'var(--text-muted)' }}>{sub}</span>}
       </div>
-      {rows.length === 0 ? (
-        <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text-muted)' }}>{empty}</div>
-      ) : (
-        <ol>
-          {rows.map((r, i) => (
-            <li key={r.id + i} className="flex items-center gap-3 px-4 py-2 text-sm" style={{ borderTop: i ? '1px solid var(--border-light)' : 'none' }}>
-              <span className="w-5 text-right tabular-nums" style={{ color: 'var(--text-muted)' }}>{i + 1}</span>
-              <span className="flex-1 min-w-0 truncate"><BookLink b={r} /></span>
-              <span className="tabular-nums font-semibold shrink-0" style={{ color: 'var(--text-primary)' }}>{value(r)}</span>
-            </li>
-          ))}
-        </ol>
-      )}
+      {children}
     </div>
+  );
+}
+
+function RankTable<T extends Ref>({ title, icon, sub, rows, value, empty }: { title: string; icon: React.ReactNode; sub?: string; rows: T[]; value: (r: T) => React.ReactNode; empty: string }) {
+  return (
+    <Panel title={title} icon={icon} sub={sub}>
+      {rows.length === 0 ? <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text-muted)' }}>{empty}</div> : (
+        <ol>{rows.map((r, i) => (
+          <li key={r.id + i} className="flex items-center gap-3 px-4 py-2 text-sm" style={{ borderTop: i ? '1px solid var(--border-light)' : 'none' }}>
+            <span className="w-5 text-right tabular-nums" style={{ color: 'var(--text-muted)' }}>{i + 1}</span>
+            <span className="flex-1 min-w-0 truncate"><BookLink b={r} /></span>
+            <span className="tabular-nums font-semibold shrink-0" style={{ color: 'var(--text-primary)' }}>{value(r)}</span>
+          </li>
+        ))}</ol>
+      )}
+    </Panel>
   );
 }
 
@@ -67,12 +70,10 @@ export default function BooksTab() {
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch('/api/admin/book-insights')
-      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
-      .then(setD).catch((e) => setErr(e.message)).finally(() => setLoading(false));
+    fetch('/api/admin/book-insights').then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }).then(setD).catch((e) => setErr(e.message)).finally(() => setLoading(false));
   }, []);
 
-  if (loading) return <div className="py-12 text-center text-sm" style={{ color: 'var(--text-muted)' }}>Crunching reads, likes & downloads…</div>;
+  if (loading) return <div className="py-12 text-center text-sm" style={{ color: 'var(--text-muted)' }}>Crunching reads, likes, downloads &amp; searches…</div>;
   if (err || !d) return <div className="py-12 text-center text-sm" style={{ color: 'var(--text-muted)' }}>Couldn&apos;t load insights{err ? ` (${err})` : ''}.</div>;
 
   const maxWeek = Math.max(1, ...d.weekly.map((w) => w.views));
@@ -82,10 +83,11 @@ export default function BooksTab() {
   return (
     <div className="space-y-8">
       {/* Summary */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-        <StatCard icon={<Eye className="w-4 h-4" />} label="Reads · 7d" value={num(d.summary.views7)} sub={`${num(d.summary.weeklyAvg)}/wk avg`} tint="#eff6ff" />
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
+        <StatCard icon={<Eye className="w-4 h-4" />} label="Reads · 7d" value={num(d.summary.views7)} tint="#eff6ff" />
         <StatCard icon={<Eye className="w-4 h-4" />} label="Reads · 30d" value={num(d.summary.views30)} tint="#f0f9ff" />
-        <StatCard icon={<BookOpen className="w-4 h-4" />} label="Books opened" value={num(d.summary.booksViewed)} sub="all-time, ≥1 view" tint="#f0fdf4" />
+        <StatCard icon={<Layers className="w-4 h-4" />} label="Pages read · 30d" value={num(d.summary.pageReads30)} tint="#ecfeff" />
+        <StatCard icon={<BookOpen className="w-4 h-4" />} label="Books opened" value={num(d.summary.booksViewed)} sub="all-time" tint="#f0fdf4" />
         <StatCard icon={<Moon className="w-4 h-4" />} label="Never opened" value={num(d.summary.neverOpened)} sub="visible, 0 views" tint="#faf5ff" />
         <StatCard icon={<Download className="w-4 h-4" />} label="Downloads · 30d" value={num(d.summary.downloads30)} tint="#fff7ed" />
         <StatCard icon={<Heart className="w-4 h-4" />} label="Book likes" value={num(d.summary.bookLikes)} sub="all-time" tint="#fef2f2" />
@@ -94,7 +96,7 @@ export default function BooksTab() {
       {/* Weekly trend */}
       <div>
         <h2 className="text-sm font-semibold uppercase tracking-wide mb-1" style={{ color: 'var(--text-muted)' }}>Book opens per week · last 16 weeks</h2>
-        <p className="text-xs mb-3" style={{ color: 'var(--text-muted)' }}>All traffic (bots included). Reliable <em>human</em> read tracking began Jul 28 (#3405), so the human counts in the cards above and the leaderboards below are recent-window; this trend gives the fuller shape.</p>
+        <p className="text-xs mb-3" style={{ color: 'var(--text-muted)' }}>All traffic (bots included). Reliable <em>human</em> read tracking began Jul 28 (#3405), so the human counts in the cards and leaderboards are recent-window; this trend gives the fuller shape.</p>
         <div className="flex items-end gap-1.5 h-40 px-1 rounded-xl py-3" style={{ border: '1px solid var(--border-light)', background: 'var(--bg-white)' }}>
           {d.weekly.map((w) => (
             <div key={w.week} className="flex-1 flex flex-col items-center justify-end h-full group" title={`Week of ${fmtWeek(w.week)}: ${num(w.views)} opens`}>
@@ -105,23 +107,38 @@ export default function BooksTab() {
         </div>
       </div>
 
-      {/* Trending + Most viewed */}
+      {/* Trending + Most read */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <RankTable title="Trending this week" icon={<TrendingUp className="w-4 h-4" />} rows={d.trending}
-          value={(r) => <span title={`${r.now} this week vs ${r.prev} last`}>+{num(r.delta)}</span>} empty="No week-over-week risers yet." />
-        <RankTable title="Most read · all time" icon={<Eye className="w-4 h-4" />} rows={d.topViewed} value={(r) => num(r.views)} empty="No reads yet." />
+        <RankTable title="Trending this week" icon={<TrendingUp className="w-4 h-4" />} sub="reads, vs last week" rows={d.trending} value={(r) => <span title={`${r.now} this week vs ${r.prev} last`}>+{num(r.delta)}</span>} empty="Fills in as this week's reads accrue." />
+        <RankTable title="Most read · all time" icon={<Eye className="w-4 h-4" />} rows={d.topViewed} value={(r) => num(r.count)} empty="No reads yet." />
       </div>
 
-      {/* Liked + Downloaded */}
+      {/* Depth + quality */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <RankTable title="Most deeply read" icon={<Layers className="w-4 h-4" />} sub="pages turned · 30d" rows={d.deepestRead} value={(r) => num(r.count)} empty="No page reads yet." />
+        <RankTable title="Punching above their weight" icon={<Star className="w-4 h-4" />} sub="likes per 100 reads (≥25 reads)" rows={d.punching} value={(r) => <span title={`${r.likes} likes / ${num(r.views)} reads`}>{r.per100.toFixed(1)}</span>} empty="Not enough liked-and-read books yet." />
+      </div>
+
+      {/* Liked + Downloaded + New arrivals */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <RankTable title="Most liked" icon={<Heart className="w-4 h-4" />} rows={d.topLiked} value={(r) => num(r.count)} empty="No book likes yet." />
-        <RankTable title="Most downloaded · 30d" icon={<Download className="w-4 h-4" />} rows={d.topDownloaded} value={(r) => num(r.count)} empty="No downloads in the last 30 days." />
+        <RankTable title="Most downloaded" icon={<Download className="w-4 h-4" />} sub="30d" rows={d.topDownloaded} value={(r) => num(r.count)} empty="No downloads in 30 days." />
+        <RankTable title="New arrivals finding readers" icon={<Sparkles className="w-4 h-4" />} sub="added ≤90d" rows={d.newArrivals} value={(r) => num(r.count)} empty="No recent imports with reads." />
       </div>
 
-      {/* By language + Top searches */}
+      {/* Geography + Language */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="rounded-xl overflow-hidden" style={{ border: '1px solid var(--border-light)' }}>
-          <div className="px-4 py-3" style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)' }}><h3 className="font-semibold text-sm">Reads by language</h3></div>
+        <Panel title="Where readers are" icon={<Globe className="w-4 h-4" />} sub="searches & downloads · 30d">
+          <div className="p-4 space-y-2">
+            {d.geo.length === 0 ? <div className="text-center text-sm py-4" style={{ color: 'var(--text-muted)' }}>No geo data yet.</div> : d.geo.map((g) => (
+              <div key={g.country} className="text-sm">
+                <div className="flex justify-between mb-0.5"><span style={{ color: 'var(--text-primary)' }}>{g.country}</span><span className="tabular-nums" style={{ color: 'var(--text-muted)' }}>{g.pct}% · {num(g.count)}</span></div>
+                <div className="h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--bg-warm)' }}><div className="h-full rounded-full" style={{ width: `${g.pct}%`, background: 'var(--accent-sage, #7c9885)' }} /></div>
+              </div>
+            ))}
+          </div>
+        </Panel>
+        <Panel title="Reads by language" icon={<BookOpen className="w-4 h-4" />} sub="all-time">
           <div className="p-4 space-y-2">
             {d.byLanguage.map((l) => (
               <div key={l.language} className="text-sm">
@@ -130,21 +147,33 @@ export default function BooksTab() {
               </div>
             ))}
           </div>
-        </div>
-        <div className="rounded-xl overflow-hidden" style={{ border: '1px solid var(--border-light)' }}>
-          <div className="px-4 py-3 flex items-center gap-2" style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)' }}><Search className="w-4 h-4" /><h3 className="font-semibold text-sm">Top searches · 30d</h3></div>
+        </Panel>
+      </div>
+
+      {/* Searches + gaps */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Panel title="Top searches" icon={<Search className="w-4 h-4" />} sub="30d">
           {d.topSearches.length === 0 ? <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text-muted)' }}>No searches yet.</div> : (
-            <ol>
-              {d.topSearches.map((s, i) => (
-                <li key={s.term + i} className="flex items-center gap-3 px-4 py-2 text-sm" style={{ borderTop: i ? '1px solid var(--border-light)' : 'none' }}>
-                  <span className="w-5 text-right tabular-nums" style={{ color: 'var(--text-muted)' }}>{i + 1}</span>
-                  <Link href={`/search?q=${encodeURIComponent(s.term)}`} target="_blank" className="flex-1 min-w-0 truncate hover:underline" style={{ color: 'var(--text-primary)' }}>{s.term}</Link>
-                  <span className="tabular-nums font-semibold shrink-0" style={{ color: 'var(--text-primary)' }}>{num(s.count)}</span>
-                </li>
-              ))}
-            </ol>
+            <ol>{d.topSearches.map((s, i) => (
+              <li key={s.term + i} className="flex items-center gap-3 px-4 py-2 text-sm" style={{ borderTop: i ? '1px solid var(--border-light)' : 'none' }}>
+                <span className="w-5 text-right tabular-nums" style={{ color: 'var(--text-muted)' }}>{i + 1}</span>
+                <Link href={`/search?q=${encodeURIComponent(s.term)}`} target="_blank" className="flex-1 min-w-0 truncate hover:underline" style={{ color: 'var(--text-primary)' }}>{s.term}</Link>
+                <span className="tabular-nums font-semibold shrink-0" style={{ color: 'var(--text-primary)' }}>{num(s.count)}</span>
+              </li>
+            ))}</ol>
           )}
-        </div>
+        </Panel>
+        <Panel title="Searches that came up short" icon={<HelpCircle className="w-4 h-4" />} sub="≤2 results · 30d — acquisition signal">
+          {d.searchGaps.length === 0 ? <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text-muted)' }}>No low-result searches — nice.</div> : (
+            <ol>{d.searchGaps.map((s, i) => (
+              <li key={s.term + i} className="flex items-center gap-3 px-4 py-2 text-sm" style={{ borderTop: i ? '1px solid var(--border-light)' : 'none' }}>
+                <span className="w-5 text-right tabular-nums" style={{ color: 'var(--text-muted)' }}>{i + 1}</span>
+                <Link href={`/search?q=${encodeURIComponent(s.term)}`} target="_blank" className="flex-1 min-w-0 truncate hover:underline" style={{ color: 'var(--text-primary)' }}>{s.term}</Link>
+                <span className="text-xs shrink-0" style={{ color: 'var(--text-muted)' }}>{s.results} res · ×{s.count}</span>
+              </li>
+            ))}</ol>
+          )}
+        </Panel>
       </div>
     </div>
   );


### PR DESCRIPTION
Adds a **Books** tab to /analytics (inner_circle) with most-read/liked/downloaded books, a 16-week opens trend, trending-this-week, reads-by-language, and top searches — from read_count, analytics_events, and likes. Honest labeling around the 2026-07-28 human-tracking start (#3405). Held as draft for preview review.