### PR TITLE
feat(hero): a short mosaic repairs itself in the background

### DIFF
--- a/src/app/api/books/[id]/hero-mosaic/route.ts
+++ b/src/app/api/books/[id]/hero-mosaic/route.ts
@@ -152,7 +152,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         projection: {
           _id: 0, id: 1, hero_mosaic_url: 1, hero_mosaic_version: 1,
           hero_mosaic_tiles: 1, hero_mosaic_maxed: 1, hero_mosaic_upgrade_at: 1,
-          hero_mosaic_upgrade_attempts: 1,
+          hero_mosaic_upgrade_attempts: 1, hero_mosaic_source: 1,
         },
       },
     );
@@ -165,7 +165,12 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       // Refuse fast and cheaply — this endpoint is fired by every visitor to an
       // eligible book, so the no-op path must cost one indexed read.
       if (book.hero_mosaic_maxed) return upgradeSkipped('maxed');
-      if (priorTiles !== null && priorTiles >= MOSAIC_FULL_TILES) return upgradeSkipped('already-full');
+      const storedSource = book.hero_mosaic_source as string | undefined;
+      // A plate-tiled mosaic is never "already full": the book should be
+      // showing its pages, and those are usually fetchable by now.
+      if (storedSource !== 'plates' && priorTiles !== null && priorTiles >= MOSAIC_FULL_TILES) {
+        return upgradeSkipped('already-full');
+      }
       if (!mosaicUpgradeCooledDown(book.hero_mosaic_upgrade_at as Date | null, Date.now())) {
         return upgradeSkipped('cooldown');
       }
@@ -187,7 +192,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
             { id: book.id },
             { $set: { hero_mosaic_tiles: measured } },
           ).catch(() => {});
-          if (measured >= MOSAIC_FULL_TILES) return upgradeSkipped('measured-full', measured);
+          // Only a page-tiled mosaic can be settled by its size alone. A stored
+          // mosaic with no recorded source predates the field; measuring can't
+          // tell pages from plates, so a full grid is accepted as done and the
+          // plate case is caught on the next build, which does record it.
+          if (measured >= MOSAIC_FULL_TILES && storedSource !== 'plates') {
+            return upgradeSkipped('measured-full', measured);
+          }
         }
       }
       // Fall through: rebuild below, then judge the result.
@@ -337,7 +348,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     // Shape the grid to the hero's aspect (never repeated, always background-cover
     // filled). Short tiles get more rows / fewer columns so the block is never a
     // 1-row wide strip. Rows are laid out top-aligned at true dimensions.
-    void usingPlates;
+    // Which pool we tiled from is recorded below: a plates fallback is a
+    // symptom of page images being briefly unfetchable, and it must be
+    // revisitable once they land. It used to be discarded here.
     const medH = kept.map(t => t.height).sort((a, b) => a - b)[Math.floor(kept.length / 2)] || MAX_TILE_H;
     const { cols: rowCols, rows: numRows } = chooseGrid(kept.length, medH);
     const used = kept.slice(0, rowCols * numRows);
@@ -385,9 +398,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       hero_mosaic_tiles: builtTiles,
       hero_mosaic_cols: rowCols,
       hero_mosaic_rows: numRows,
+      hero_mosaic_source: usingPlates ? 'plates' : 'pages',
     };
     if (upgrade) {
-      const verdict = nextUpgradeVerdict(priorTiles, builtTiles, attempts);
+      const verdict = nextUpgradeVerdict(priorTiles, builtTiles, attempts, {
+        before: book.hero_mosaic_source as string | undefined,
+        after: usingPlates ? 'plates' : 'pages',
+      });
       fields.hero_mosaic_maxed = verdict.maxed;
       fields.hero_mosaic_upgrade_attempts = verdict.attempts;
     }

--- a/src/app/api/books/[id]/hero-mosaic/route.ts
+++ b/src/app/api/books/[id]/hero-mosaic/route.ts
@@ -6,9 +6,16 @@ import sharp from 'sharp';
 export const runtime = 'nodejs';
 import { getDb } from '@/lib/mongodb';
 import { storagePut } from '@/lib/storage';
+import { purgeCloudflareUrls } from '@/lib/cloudflare-cache';
+import { measureStoredGrid } from '@/lib/hero-mosaic-measure';
 import { images } from '@/lib/api-client/images';
 import { type PageImageFields } from '@/lib/page-image-url';
 import { HERO_MOSAIC_VERSION } from '@/lib/hero-mosaic-version';
+import {
+  MOSAIC_FULL_TILES,
+  mosaicUpgradeCooledDown,
+  nextUpgradeVerdict,
+} from '@/lib/hero-mosaic-upgrade';
 
 /**
  * GET /api/books/[id]/hero-mosaic
@@ -20,6 +27,16 @@ import { HERO_MOSAIC_VERSION } from '@/lib/hero-mosaic-version';
  * a good mosaic (too few *distinct* pages — e.g. every "thumb" fell back to the
  * same cover), we cache a negative result and 404 so the hero shows a plain
  * dark panel instead of a wall of identical tiles.
+ *
+ * ?upgrade=1 — background self-repair, fired by the hero once the stored image
+ * has painted (so nobody waits on it). The grid shape is fixed by how many
+ * tiles survived fetching AT GENERATION TIME, so a run where some page fetches
+ * flaked leaves a permanent 10x2 on a book with hundreds of usable pages, and
+ * the version short-circuit means nothing ever retries. This mode rebuilds such
+ * a book once and overwrites its mosaic, so the NEXT visitor gets the fuller
+ * grid. It refuses to run when the stored grid is already full, when the book
+ * can't do better, or within the cooldown — see lib/hero-mosaic-upgrade.ts.
+ * Never a version bump: that would rebuild the ~70% that are already correct.
  */
 
 const MOSAIC_VERSION = HERO_MOSAIC_VERSION; // shared with the book page (cache-buster)
@@ -127,14 +144,55 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const { id } = await params;
     const db = await getDb();
 
+    const upgrade = request.nextUrl.searchParams.get('upgrade') === '1';
+
     const book = await db.collection('books').findOne(
       { $or: [{ id }, { slug: id }] },
-      { projection: { _id: 0, id: 1, hero_mosaic_url: 1, hero_mosaic_version: 1 } },
+      {
+        projection: {
+          _id: 0, id: 1, hero_mosaic_url: 1, hero_mosaic_version: 1,
+          hero_mosaic_tiles: 1, hero_mosaic_maxed: 1, hero_mosaic_upgrade_at: 1,
+          hero_mosaic_upgrade_attempts: 1,
+        },
+      },
     );
     if (!book?.id) return NextResponse.json({ error: 'Book not found' }, { status: 404 });
 
-    // Up-to-date cache: redirect to the stored image, or 404 the negative result.
-    if (book.hero_mosaic_version === MOSAIC_VERSION) {
+    const priorTiles = typeof book.hero_mosaic_tiles === 'number' ? book.hero_mosaic_tiles : null;
+    const attempts = typeof book.hero_mosaic_upgrade_attempts === 'number' ? book.hero_mosaic_upgrade_attempts : 0;
+
+    if (upgrade) {
+      // Refuse fast and cheaply — this endpoint is fired by every visitor to an
+      // eligible book, so the no-op path must cost one indexed read.
+      if (book.hero_mosaic_maxed) return upgradeSkipped('maxed');
+      if (priorTiles !== null && priorTiles >= MOSAIC_FULL_TILES) return upgradeSkipped('already-full');
+      if (!mosaicUpgradeCooledDown(book.hero_mosaic_upgrade_at as Date | null, Date.now())) {
+        return upgradeSkipped('cooldown');
+      }
+      // Claim the slot BEFORE the expensive work, so concurrent visitors to the
+      // same book fall into the cooldown branch above instead of all rebuilding.
+      await db.collection('books').updateOne(
+        { id: book.id },
+        { $set: { hero_mosaic_upgrade_at: new Date() } },
+      ).catch(() => {});
+
+      // Unknown grid (every mosaic built before the generator recorded it):
+      // MEASURE the stored image rather than rebuilding it. One fetch + decode
+      // settles whether this book needs anything at all, and ~70% of them do
+      // not — that is what keeps this from becoming a full-corpus regen.
+      if (priorTiles === null && book.hero_mosaic_url) {
+        const measured = await measureStoredGrid(book.hero_mosaic_url as string);
+        if (measured !== null) {
+          await db.collection('books').updateOne(
+            { id: book.id },
+            { $set: { hero_mosaic_tiles: measured } },
+          ).catch(() => {});
+          if (measured >= MOSAIC_FULL_TILES) return upgradeSkipped('measured-full', measured);
+        }
+      }
+      // Fall through: rebuild below, then judge the result.
+    } else if (book.hero_mosaic_version === MOSAIC_VERSION) {
+      // Up-to-date cache: redirect to the stored image, or 404 the negative result.
       return book.hero_mosaic_url ? redirectToMosaic(book.hero_mosaic_url) : noMosaic();
     }
 
@@ -309,16 +367,58 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       .avif({ quality: AVIF_QUALITY, effort: 5 })
       .toBuffer();
 
-    const key = `hero-mosaic/${book.id}-v${MOSAIC_VERSION}.avif`;
+    // The tile count is part of the key. Overwriting one immutable-ish object
+    // would leave the CDN serving the OLD image after an upgrade — the whole
+    // point is that the next visitor sees the fuller grid. A rebuild that lands
+    // on the same shape reuses the same key, which is correct: nothing changed.
+    const builtTiles = rowCols * numRows;
+    const key = `hero-mosaic/${book.id}-v${MOSAIC_VERSION}-${builtTiles}.avif`;
     const uploaded = await storagePut(key, composed, { contentType: 'image/avif', allowOverwrite: true });
 
-    await db.collection('books').updateOne({ id: book.id }, { $set: { hero_mosaic_url: uploaded.url, hero_mosaic_version: MOSAIC_VERSION, hero_mosaic_at: new Date() } }).catch(() => {});
+    // Record the grid we actually built. Without this the shape is only
+    // recoverable by decoding the stored image, which is why 12,660 cached
+    // mosaics had to be measured one at a time to find the short ones.
+    const fields: Record<string, unknown> = {
+      hero_mosaic_url: uploaded.url,
+      hero_mosaic_version: MOSAIC_VERSION,
+      hero_mosaic_at: new Date(),
+      hero_mosaic_tiles: builtTiles,
+      hero_mosaic_cols: rowCols,
+      hero_mosaic_rows: numRows,
+    };
+    if (upgrade) {
+      const verdict = nextUpgradeVerdict(priorTiles, builtTiles, attempts);
+      fields.hero_mosaic_maxed = verdict.maxed;
+      fields.hero_mosaic_upgrade_attempts = verdict.attempts;
+    }
+    await db.collection('books').updateOne({ id: book.id }, { $set: fields }).catch(() => {});
 
+    if (upgrade) {
+      // Most books reach their mosaic through THIS route, whose 302 is edge
+      // cached for a week. Without dropping it, the next visitor follows the
+      // stale redirect to the old key and the rebuild is invisible.
+      if (builtTiles !== priorTiles) {
+        await purgeCloudflareUrls([`/api/books/${book.id}/hero-mosaic`]).catch(() => {});
+      }
+      return NextResponse.json(
+        { upgraded: true, before: priorTiles, after: builtTiles, cols: rowCols, rows: numRows },
+        { headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
     return redirectToMosaic(uploaded.url);
   } catch (error) {
     console.error('[hero-mosaic] generation error:', error);
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Failed' }, { status: 500 });
   }
+}
+
+function upgradeSkipped(reason: string, tiles?: number) {
+  const res = NextResponse.json({ upgraded: false, reason, tiles });
+  res.headers.set(
+    'Cache-Control',
+    reason === 'cooldown' ? 'no-store' : 'public, max-age=3600, s-maxage=604800',
+  );
+  return res;
 }
 
 function redirectToMosaic(url: string) {

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -54,6 +54,7 @@ import FirstTranslationEvidence from '@/components/book/FirstTranslationEvidence
 import GalleryMasonry, { type Plate } from '@/components/GalleryMasonry';
 import HeroVariants from '@/components/book/HeroVariants';
 import { HERO_MOSAIC_VERSION } from '@/lib/hero-mosaic-version';
+import { shouldOfferMosaicUpgrade } from '@/lib/hero-mosaic-upgrade';
 import AboutVariants from '@/components/book/AboutVariants';
 import BookBiblioPanel from '@/components/book/BookBiblioPanel';
 import PlusToggle from '@/components/book/PlusToggle';
@@ -1340,6 +1341,24 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
             (book as unknown as { hero_mosaic_version?: number }).hero_mosaic_version === HERO_MOSAIC_VERSION
               ? (book as unknown as { hero_mosaic_url?: string }).hero_mosaic_url
               : `/api/books/${book.id}/hero-mosaic`
+          }
+          /* A stored mosaic can be SHORT of the full 10x4 — its grid was fixed
+             by how many tiles survived fetching when it was generated, not by
+             how many pages the book has, and nothing retries it. Measured on
+             production: ~30% of cached mosaics are short, nearly all of them
+             with 40+ unused pages. Rather than bump the cache version (which
+             would rebuild the ~70% that are fine), offer a one-shot background
+             rebuild: this reader keeps the instant stored image, the next one
+             gets the fuller grid. The predicate reads only fields already on
+             the book doc, so it costs the ISR render nothing. */
+          upgradeUrl={
+            shouldOfferMosaicUpgrade({
+              tiles: (book as unknown as { hero_mosaic_tiles?: number }).hero_mosaic_tiles,
+              maxed: (book as unknown as { hero_mosaic_maxed?: boolean }).hero_mosaic_maxed,
+              pagesCount: (book as unknown as { pages_count?: number }).pages_count,
+            })
+              ? `/api/books/${book.id}/hero-mosaic?upgrade=1`
+              : undefined
           }
           actions={(
             /* Mobile-only: pinned to the foot of the hero (desktop keeps these

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1356,6 +1356,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
               tiles: (book as unknown as { hero_mosaic_tiles?: number }).hero_mosaic_tiles,
               maxed: (book as unknown as { hero_mosaic_maxed?: boolean }).hero_mosaic_maxed,
               pagesCount: (book as unknown as { pages_count?: number }).pages_count,
+              source: (book as unknown as { hero_mosaic_source?: string }).hero_mosaic_source,
             })
               ? `/api/books/${book.id}/hero-mosaic?upgrade=1`
               : undefined

--- a/src/components/book/HeroVariants.tsx
+++ b/src/components/book/HeroVariants.tsx
@@ -22,6 +22,7 @@ export default function HeroVariants({
   actions,
   pageThumbs = [],
   mosaicUrl,
+  upgradeUrl,
 }: {
   cover: ReactNode;
   meta: ReactNode;
@@ -31,6 +32,11 @@ export default function HeroVariants({
   pageThumbs?: string[];
   /** A single pre-composited tiled background image (preferred over pageThumbs). */
   mosaicUrl?: string;
+  /** Set when this book's STORED mosaic is short of a full 10x4 grid and the
+   *  book has the pages to do better. Pinged once after the current background
+   *  has painted, so this reader keeps the instant image and the NEXT visitor
+   *  gets the fuller one. Absent for books already at a full grid. */
+  upgradeUrl?: string;
 }) {
   const single = pageThumbs[0];
   const [bgSrc, setBgSrc] = useState<string | undefined>(mosaicUrl || single);
@@ -48,6 +54,28 @@ export default function HeroVariants({
   const reveal = () => {
     requestAnimationFrame(() => requestAnimationFrame(() => setRevealed(true)));
   };
+
+  // Background self-repair for a short mosaic. Deliberately fire-and-forget and
+  // deliberately AFTER the background has painted: this reader sees the stored
+  // image immediately and never waits on the rebuild — it exists to improve the
+  // NEXT visit. The server enforces the cooldown and the attempt cap, so a
+  // popular book can't rebuild in a loop; the ref just avoids firing twice from
+  // one mount. Errors are ignored on purpose (a failed upgrade is a no-op, and
+  // the hero is already showing the right thing).
+  const upgradeFired = useRef(false);
+  useEffect(() => {
+    if (!upgradeUrl || !revealed || upgradeFired.current) return;
+    upgradeFired.current = true;
+    const t = setTimeout(() => {
+      // Deliberately NOT `cache: 'no-store'`: when the server decides there is
+      // nothing to do it answers with a week-long Cache-Control, so the browser
+      // and the CDN absorb every repeat ping and the function is never reached.
+      // Forcing no-store here would turn a cached no-op into ~11k live
+      // invocations a day.
+      fetch(upgradeUrl, { method: 'GET', keepalive: true }).catch(() => {});
+    }, 2000); // let the page settle first — this is the lowest-priority work here
+    return () => clearTimeout(t);
+  }, [upgradeUrl, revealed]);
 
   // Subtle scroll parallax — the bg + tint drift slower than the page.
   const sectionRef = useRef<HTMLElement>(null);

--- a/src/lib/hero-mosaic-measure.ts
+++ b/src/lib/hero-mosaic-measure.ts
@@ -1,0 +1,90 @@
+/**
+ * Reads the grid shape back OUT of an already-composited hero mosaic.
+ *
+ * The generator only started recording cols/rows on 2026-08-02, so for the
+ * ~12,660 mosaics cached before that the shape exists nowhere but the pixels.
+ * Measuring is what keeps the self-repair cheap: one fetch + decode tells us
+ * whether a book needs anything, and ~70% of them don't, so they're recorded as
+ * full and never rebuilt.
+ *
+ * Imports `sharp`, so it must never be pulled into a page bundle — only the
+ * mosaic route and its tests use it. The page-side predicate lives in the
+ * sharp-free hero-mosaic-upgrade.ts.
+ */
+import sharp from 'sharp';
+
+/** Must match the compositor in the hero-mosaic route. */
+export const TILE_W = 168;
+export const GAP = 6;
+
+export interface MosaicGrid {
+  cols: number;
+  rows: number;
+  tiles: number;
+}
+
+/**
+ * Grid shape of a composited mosaic buffer.
+ *
+ * Columns come from the width formula the compositor used
+ * (`cols * TILE_W + (cols + 1) * GAP`). Rows are counted from the full-width
+ * background bands it leaves between them: one above the first row and one
+ * below the last, so `rows = bands - 1`.
+ *
+ * Verified against three production mosaics of independently known shape —
+ * Alciato's Emblemata (10×2), Corpus Inscriptionum Latinarum (10×3), and
+ * Illustrations of British Mycology (10×4) — and against constructed grids in
+ * tests/unit/hero-mosaic-measure.test.ts.
+ *
+ * Returns null when the buffer can't be decoded, so callers treat the shape as
+ * still-unknown rather than assuming the worst and rebuilding needlessly.
+ */
+export async function measureGrid(buf: Buffer): Promise<MosaicGrid | null> {
+  try {
+    const meta = await sharp(buf).metadata();
+    const { data, info } = await sharp(buf).raw().toBuffer({ resolveWithObject: true });
+    const { width, height, channels } = info;
+    if (!width || !height) return null;
+
+    // A gap band is uniform background, so sampling every 4th pixel is enough
+    // and keeps the scan linear in height rather than in area. The thresholds
+    // sit well above the BG colour (20,16,12) to absorb AVIF ringing.
+    const isBgRow = (y: number) => {
+      for (let x = 0; x < width; x += 4) {
+        const i = (y * width + x) * channels;
+        if (data[i] > 60 || data[i + 1] > 55 || data[i + 2] > 50) return false;
+      }
+      return true;
+    };
+
+    let bands = 0;
+    let run = 0;
+    for (let y = 0; y < height; y++) {
+      if (isBgRow(y)) { run++; continue; }
+      // Require 2px: a single dark scanline inside a very dark page scan should
+      // not read as a row boundary.
+      if (run >= 2) bands++;
+      run = 0;
+    }
+    if (run >= 2) bands++;
+
+    const rows = Math.max(1, bands - 1);
+    const cols = Math.round(((meta.width ?? width) - GAP) / (TILE_W + GAP));
+    if (cols < 1) return null;
+    return { cols, rows, tiles: cols * rows };
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch a stored mosaic and measure it. Null on any network or decode failure. */
+export async function measureStoredGrid(url: string): Promise<number | null> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return null;
+    const grid = await measureGrid(Buffer.from(await res.arrayBuffer()));
+    return grid ? grid.tiles : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/hero-mosaic-upgrade.ts
+++ b/src/lib/hero-mosaic-upgrade.ts
@@ -1,0 +1,102 @@
+/**
+ * Decides whether a book's CACHED hero mosaic is worth rebuilding.
+ *
+ * The mosaic is a cached artifact, and its grid shape is fixed by how many
+ * tiles survived fetching at the moment it was generated — not by how many
+ * pages the book has. `rows = floor(tiles / cols)`, so a run where a handful of
+ * page-image fetches flaked leaves a permanent 10×2 (20 tiles) on a book with
+ * 600 usable pages, and nothing ever retries it: the stored version still
+ * matches HERO_MOSAIC_VERSION, so the route short-circuits to the stored image
+ * forever.
+ *
+ * Measured on production 2026-08-02 (400 random books with a cached mosaic and
+ * ≥40 pages, each decoded and its grid counted): 30% were short of a full 10×4,
+ * and 115 of those 119 had ≥40 unused non-junk pages sitting there. About 1,500
+ * books are a full-width grid missing rows; ~840 more are short in both
+ * dimensions.
+ *
+ * The fix is deliberately NOT a version bump: that would rebuild all ~12,660
+ * cached mosaics, including the ~70% that are already correct. Instead a book
+ * whose stored grid is short serves its existing mosaic (instant, no flash) and
+ * the reader's browser kicks off ONE background rebuild, so the next visitor
+ * gets the fuller grid. Books that are already full, or that genuinely cannot
+ * do better, are never touched.
+ *
+ * This module stays free of `sharp` and `mongodb` so the book page — a server
+ * component — can import the predicate without pulling in the image toolchain
+ * (same reason hero-mosaic-version.ts is its own tiny module).
+ */
+
+/** A full grid: 10 columns × 4 rows. The most the hero can ever show. */
+export const MOSAIC_FULL_TILES = 40;
+
+/** Give up after this many rebuilds that failed to improve the grid, so a book
+ *  whose pages genuinely can't fill a 10×4 stops being retried on every view. */
+export const MOSAIC_MAX_UPGRADE_ATTEMPTS = 2;
+
+/** Ignore repeat triggers within this window. The book page is ISR-cached, so
+ *  every visitor in the cache window sees the same "upgradeable" flag and fires
+ *  the same request — this is what stops a popular book rebuilding in a loop. */
+export const MOSAIC_UPGRADE_COOLDOWN_MS = 10 * 60 * 1000;
+
+/** Fields the book page and the upgrade path both read. */
+export interface MosaicUpgradeState {
+  /** cols × rows of the STORED mosaic. Undefined for mosaics built before the
+   *  generator started recording it — treated as "unknown, worth measuring",
+   *  which costs one fetch + decode rather than a rebuild. */
+  tiles?: number | null;
+  /** Set once a rebuild has failed to improve the grid MAX_ATTEMPTS times. */
+  maxed?: boolean | null;
+  /** Last time an upgrade was attempted (cooldown anchor). */
+  upgradeAt?: Date | string | null;
+  /** Total pages on the book — a cheap upper bound on available tiles. */
+  pagesCount?: number | null;
+}
+
+/**
+ * Should the page offer a background upgrade for this book?
+ *
+ * Cheap and page-safe: it reads only fields already on the book document, so it
+ * adds no query to the ISR render. The expensive checks (does the book really
+ * have 40 usable page images? does a rebuild actually do better?) happen in the
+ * upgrade route, which records its verdict so this predicate stops firing.
+ */
+export function shouldOfferMosaicUpgrade(state: MosaicUpgradeState): boolean {
+  if (state.maxed) return false;
+  // A book with fewer pages than a full grid can never fill one — and page
+  // count is an UPPER bound, since blanks and scanner junk are filtered out.
+  if ((state.pagesCount ?? 0) < MOSAIC_FULL_TILES) return false;
+  if (typeof state.tiles === 'number' && state.tiles >= MOSAIC_FULL_TILES) return false;
+  return true;
+}
+
+/**
+ * Is an upgrade attempt allowed to run right now? Applied inside the upgrade
+ * route, where `upgradeAt` is authoritative (the page's copy can be up to a
+ * full ISR window stale).
+ */
+export function mosaicUpgradeCooledDown(upgradeAt: Date | string | null | undefined, now: number): boolean {
+  if (!upgradeAt) return true;
+  const last = upgradeAt instanceof Date ? upgradeAt.getTime() : Date.parse(upgradeAt);
+  if (Number.isNaN(last)) return true;
+  return now - last >= MOSAIC_UPGRADE_COOLDOWN_MS;
+}
+
+/**
+ * After a rebuild: did it earn its keep, and should we keep trying?
+ *
+ * A rebuild that reaches a full grid is done. One that improves but is still
+ * short stays eligible (the next visitor may catch a moment when more page
+ * fetches succeed). One that does no better burns an attempt, and after
+ * MAX_ATTEMPTS the book is marked maxed and left alone.
+ */
+export function nextUpgradeVerdict(
+  before: number | null | undefined,
+  after: number,
+  attempts: number,
+): { maxed: boolean; attempts: number } {
+  if (after >= MOSAIC_FULL_TILES) return { maxed: false, attempts: 0 };
+  const improved = typeof before === 'number' ? after > before : true;
+  const nextAttempts = improved ? attempts : attempts + 1;
+  return { maxed: nextAttempts >= MOSAIC_MAX_UPGRADE_ATTEMPTS, attempts: nextAttempts };
+}

--- a/src/lib/hero-mosaic-upgrade.ts
+++ b/src/lib/hero-mosaic-upgrade.ts
@@ -40,6 +40,12 @@ export const MOSAIC_MAX_UPGRADE_ATTEMPTS = 2;
 export const MOSAIC_UPGRADE_COOLDOWN_MS = 10 * 60 * 1000;
 
 /** Fields the book page and the upgrade path both read. */
+/** Which pool the stored mosaic was tiled from. `plates` means the generator
+ *  fell back to extracted illustrations because almost no PAGE images were
+ *  fetchable at the time — a state that outlives its cause, since the page
+ *  images usually land minutes or hours later. */
+export type MosaicSource = 'pages' | 'plates';
+
 export interface MosaicUpgradeState {
   /** cols × rows of the STORED mosaic. Undefined for mosaics built before the
    *  generator started recording it — treated as "unknown, worth measuring",
@@ -51,6 +57,8 @@ export interface MosaicUpgradeState {
   upgradeAt?: Date | string | null;
   /** Total pages on the book — a cheap upper bound on available tiles. */
   pagesCount?: number | null;
+  /** What the stored mosaic was tiled from. */
+  source?: MosaicSource | string | null;
 }
 
 /**
@@ -66,6 +74,13 @@ export function shouldOfferMosaicUpgrade(state: MosaicUpgradeState): boolean {
   // A book with fewer pages than a full grid can never fill one — and page
   // count is an UPPER bound, since blanks and scanner junk are filtered out.
   if ((state.pagesCount ?? 0) < MOSAIC_FULL_TILES) return false;
+  // A plate-tiled mosaic is worth retrying even at a FULL grid. The fallback
+  // fires only when almost no page image was fetchable in that one moment
+  // (Pal. lat. 1370: 322 pages, all fetchable today, tiled from 30 cropped
+  // diagrams on 26 July), and a book reads as its pages — plates are a last
+  // resort, not a better answer. Tile count alone would miss a plate mosaic
+  // that happens to fill 10x4.
+  if (state.source === 'plates') return true;
   if (typeof state.tiles === 'number' && state.tiles >= MOSAIC_FULL_TILES) return false;
   return true;
 }
@@ -94,9 +109,17 @@ export function nextUpgradeVerdict(
   before: number | null | undefined,
   after: number,
   attempts: number,
+  sources?: { before?: MosaicSource | string | null; after?: MosaicSource | string },
 ): { maxed: boolean; attempts: number } {
-  if (after >= MOSAIC_FULL_TILES) return { maxed: false, attempts: 0 };
-  const improved = typeof before === 'number' ? after > before : true;
+  // Swapping plates for real page scans is the win we were after, whatever it
+  // did to the tile count — a 10x3 of pages beats a 10x4 of cropped diagrams.
+  const switchedToPages = sources?.before === 'plates' && sources?.after === 'pages';
+  if (switchedToPages) return { maxed: false, attempts: 0 };
+  // Still on plates: the page images are evidently still unavailable, so this
+  // burns an attempt rather than retrying on every reader.
+  const stuckOnPlates = sources?.after === 'plates';
+  if (!stuckOnPlates && after >= MOSAIC_FULL_TILES) return { maxed: false, attempts: 0 };
+  const improved = !stuckOnPlates && (typeof before === 'number' ? after > before : true);
   const nextAttempts = improved ? attempts : attempts + 1;
   return { maxed: nextAttempts >= MOSAIC_MAX_UPGRADE_ATTEMPTS, attempts: nextAttempts };
 }

--- a/tests/unit/hero-mosaic-measure.test.ts
+++ b/tests/unit/hero-mosaic-measure.test.ts
@@ -1,0 +1,77 @@
+/**
+ * measureGrid reads a mosaic's shape back out of its pixels. It is what decides
+ * whether each of the ~12,660 mosaics cached before the generator recorded its
+ * grid needs rebuilding — so a wrong answer either leaves a short hero short
+ * forever, or rebuilds an image that was already fine.
+ *
+ * These build mosaics with the SAME geometry the route uses and check the shape
+ * comes back out, including through AVIF encoding (the stored format, and lossy
+ * enough that the gap bands are not exactly the background colour any more).
+ */
+import { describe, it, expect } from 'vitest';
+import sharp from 'sharp';
+import { measureGrid, TILE_W, GAP } from '@/lib/hero-mosaic-measure';
+
+const BG = { r: 20, g: 16, b: 12 };
+
+/** Compose a cols×rows grid exactly as the hero-mosaic route does: tiles at a
+ *  fixed column width, GAP everywhere including the outer edge. */
+async function buildGrid(cols: number, rows: number, tileH: number, tint = 235): Promise<Buffer> {
+  const width = cols * TILE_W + (cols + 1) * GAP;
+  const height = GAP + rows * (tileH + GAP);
+  const tile = await sharp({
+    create: { width: TILE_W, height: tileH, channels: 3, background: { r: tint, g: tint - 10, b: tint - 25 } },
+  }).png().toBuffer();
+
+  const placements = [];
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      placements.push({
+        input: tile,
+        left: GAP + c * (TILE_W + GAP),
+        top: GAP + r * (tileH + GAP),
+      });
+    }
+  }
+  return sharp({ create: { width, height, channels: 3, background: BG } })
+    .composite(placements)
+    .png()
+    .toBuffer();
+}
+
+describe('measureGrid', () => {
+  it('reads back every grid shape the compositor can produce', async () => {
+    for (const [cols, rows] of [[10, 4], [10, 3], [10, 2], [10, 1], [7, 4], [5, 2], [4, 1]] as const) {
+      const buf = await buildGrid(cols, rows, 276);
+      expect(await measureGrid(buf)).toEqual({ cols, rows, tiles: cols * rows });
+    }
+  });
+
+  it('survives AVIF encoding, which is how mosaics are actually stored', async () => {
+    // The gap bands are no longer exactly (20,16,12) after a lossy round trip —
+    // this is the case the production measurement actually runs on.
+    const png = await buildGrid(10, 2, 276);
+    const avif = await sharp(png).avif({ quality: 38, effort: 5 }).toBuffer();
+    expect(await measureGrid(avif)).toEqual({ cols: 10, rows: 2, tiles: 20 });
+  });
+
+  it('is not fooled by a very dark page scan', async () => {
+    // A dark manuscript tile is near the background colour. If the threshold
+    // read those rows as gaps, a full 10×4 would measure as many thin rows and
+    // the book would be judged "already full" at the wrong shape.
+    const buf = await buildGrid(10, 4, 276, 75);
+    const grid = await measureGrid(buf);
+    expect(grid).toEqual({ cols: 10, rows: 4, tiles: 40 });
+  });
+
+  it('distinguishes short from full at the threshold that drives repairs', async () => {
+    const short = await measureGrid(await buildGrid(10, 2, 276));
+    const full = await measureGrid(await buildGrid(10, 4, 276));
+    expect(short!.tiles).toBeLessThan(40);
+    expect(full!.tiles).toBe(40);
+  });
+
+  it('returns null rather than guessing when the buffer is not an image', async () => {
+    expect(await measureGrid(Buffer.from('not an image'))).toBeNull();
+  });
+});

--- a/tests/unit/hero-mosaic-upgrade.test.ts
+++ b/tests/unit/hero-mosaic-upgrade.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The hero mosaic repairs itself in the background, so the rules that decide
+ * WHEN it may do that are the ones worth pinning: they are all that stands
+ * between "a short grid quietly gets better" and "11,000 books rebuild an image
+ * on every page view".
+ *
+ * Context (measured on production 2026-08-02, 400 random books with a cached
+ * mosaic and ≥40 pages, each decoded and its grid counted): 30% were short of a
+ * full 10×4, and 115 of those 119 had 40+ unused non-junk pages. The grid is
+ * fixed by how many tiles survived fetching at generation time, and nothing
+ * retried it because the stored cache version still matched.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  MOSAIC_FULL_TILES,
+  MOSAIC_MAX_UPGRADE_ATTEMPTS,
+  MOSAIC_UPGRADE_COOLDOWN_MS,
+  shouldOfferMosaicUpgrade,
+  mosaicUpgradeCooledDown,
+  nextUpgradeVerdict,
+} from '@/lib/hero-mosaic-upgrade';
+
+describe('shouldOfferMosaicUpgrade', () => {
+  it('offers for the measured failure case: full width, missing rows', () => {
+    // Alciato's Emblemata: 182 pages, cached as 10×2 since 27 July.
+    expect(shouldOfferMosaicUpgrade({ tiles: 20, pagesCount: 182 })).toBe(true);
+    // Corpus Inscriptionum Latinarum: 880 pages, cached as 10×3.
+    expect(shouldOfferMosaicUpgrade({ tiles: 30, pagesCount: 880 })).toBe(true);
+  });
+
+  it('leaves a full grid alone — this must not become a corpus-wide regen', () => {
+    expect(shouldOfferMosaicUpgrade({ tiles: MOSAIC_FULL_TILES, pagesCount: 400 })).toBe(false);
+    expect(shouldOfferMosaicUpgrade({ tiles: 50, pagesCount: 400 })).toBe(false);
+  });
+
+  it('offers when the grid is unknown, so pre-existing mosaics get measured', () => {
+    // No stored mosaic carries a tile count yet; the route measures rather than
+    // rebuilds, which is what keeps the backlog cheap.
+    expect(shouldOfferMosaicUpgrade({ pagesCount: 200 })).toBe(true);
+    expect(shouldOfferMosaicUpgrade({ tiles: null, pagesCount: 200 })).toBe(true);
+  });
+
+  it('never offers for a book that cannot fill a grid', () => {
+    // pages_count is an UPPER bound — blanks and scanner junk are filtered out
+    // later — so anything under a full grid is hopeless before we even look.
+    expect(shouldOfferMosaicUpgrade({ tiles: 20, pagesCount: 39 })).toBe(false);
+    expect(shouldOfferMosaicUpgrade({ tiles: 20, pagesCount: 0 })).toBe(false);
+    expect(shouldOfferMosaicUpgrade({ tiles: 20 })).toBe(false);
+  });
+
+  it('stops once a book is marked maxed, whatever else is true', () => {
+    expect(shouldOfferMosaicUpgrade({ tiles: 20, pagesCount: 880, maxed: true })).toBe(false);
+  });
+});
+
+describe('mosaicUpgradeCooledDown', () => {
+  const now = Date.UTC(2026, 7, 2, 12, 0, 0);
+
+  it('allows a book that has never been tried', () => {
+    expect(mosaicUpgradeCooledDown(null, now)).toBe(true);
+    expect(mosaicUpgradeCooledDown(undefined, now)).toBe(true);
+  });
+
+  it('blocks a second attempt inside the window', () => {
+    // The book page is ISR-cached, so every visitor in the cache window sees the
+    // same "upgradeable" flag and fires the same request. This is the only thing
+    // stopping a popular book from rebuilding once per reader.
+    expect(mosaicUpgradeCooledDown(new Date(now - 60_000), now)).toBe(false);
+    expect(mosaicUpgradeCooledDown(new Date(now - MOSAIC_UPGRADE_COOLDOWN_MS + 1), now)).toBe(false);
+  });
+
+  it('allows again once the window has passed', () => {
+    expect(mosaicUpgradeCooledDown(new Date(now - MOSAIC_UPGRADE_COOLDOWN_MS), now)).toBe(true);
+  });
+
+  it('treats an unparseable timestamp as "never tried" rather than blocking forever', () => {
+    expect(mosaicUpgradeCooledDown('not a date', now)).toBe(true);
+  });
+
+  it('accepts the ISO string form Mongo round-trips through JSON', () => {
+    expect(mosaicUpgradeCooledDown(new Date(now - 60_000).toISOString(), now)).toBe(false);
+  });
+});
+
+describe('nextUpgradeVerdict', () => {
+  it('resets and stops when the rebuild reaches a full grid', () => {
+    expect(nextUpgradeVerdict(20, 40, 1)).toEqual({ maxed: false, attempts: 0 });
+  });
+
+  it('keeps trying while each rebuild does better', () => {
+    // Partial progress is real: a later visit may catch a moment when more of
+    // the page-image fetches succeed.
+    expect(nextUpgradeVerdict(20, 30, 0)).toEqual({ maxed: false, attempts: 0 });
+  });
+
+  it('gives up after repeated rebuilds that gain nothing', () => {
+    const first = nextUpgradeVerdict(30, 30, 0);
+    expect(first).toEqual({ maxed: false, attempts: 1 });
+    const second = nextUpgradeVerdict(30, 30, first.attempts);
+    expect(second).toEqual({ maxed: true, attempts: MOSAIC_MAX_UPGRADE_ATTEMPTS });
+  });
+
+  it('gives up when a rebuild makes things worse', () => {
+    const v = nextUpgradeVerdict(30, 20, MOSAIC_MAX_UPGRADE_ATTEMPTS - 1);
+    expect(v.maxed).toBe(true);
+  });
+
+  it('treats an unknown prior grid as progress, so the first measure is free', () => {
+    expect(nextUpgradeVerdict(null, 30, 0)).toEqual({ maxed: false, attempts: 0 });
+  });
+
+  it('converges: a book that never improves is left alone for good', () => {
+    let attempts = 0;
+    let maxed = false;
+    for (let i = 0; i < 10; i++) ({ maxed, attempts } = nextUpgradeVerdict(20, 20, attempts));
+    expect(maxed).toBe(true);
+    expect(attempts).toBeLessThanOrEqual(10 + MOSAIC_MAX_UPGRADE_ATTEMPTS);
+  });
+});

--- a/tests/unit/hero-mosaic-upgrade.test.ts
+++ b/tests/unit/hero-mosaic-upgrade.test.ts
@@ -117,3 +117,41 @@ describe('nextUpgradeVerdict', () => {
     expect(attempts).toBeLessThanOrEqual(10 + MOSAIC_MAX_UPGRADE_ATTEMPTS);
   });
 });
+
+describe('plate-tiled mosaics', () => {
+  // The generator falls back to extracted illustrations only when almost no
+  // PAGE image was fetchable in that moment. That state outlives its cause:
+  // Pal. lat. 1370 has 322 pages, every one fetchable today, yet its hero is 30
+  // cropped diagrams from 26 July. A book reads as its pages.
+  it('is offered even at a full grid, which tile count alone would miss', () => {
+    expect(shouldOfferMosaicUpgrade({ tiles: 40, pagesCount: 390, source: 'plates' })).toBe(true);
+  });
+
+  it('is offered when short, like Pal. lat. 1370 at 10x3', () => {
+    expect(shouldOfferMosaicUpgrade({ tiles: 30, pagesCount: 390, source: 'plates' })).toBe(true);
+  });
+
+  it('still respects maxed and the page-count floor', () => {
+    expect(shouldOfferMosaicUpgrade({ tiles: 30, pagesCount: 390, source: 'plates', maxed: true })).toBe(false);
+    expect(shouldOfferMosaicUpgrade({ tiles: 30, pagesCount: 12, source: 'plates' })).toBe(false);
+  });
+
+  it('leaves a full page-tiled mosaic alone', () => {
+    expect(shouldOfferMosaicUpgrade({ tiles: 40, pagesCount: 390, source: 'pages' })).toBe(false);
+  });
+
+  it('counts plates → pages as a win even if the grid got smaller', () => {
+    // A 10x3 of real page scans beats a 10x4 of cropped diagrams.
+    const v = nextUpgradeVerdict(40, 30, 1, { before: 'plates', after: 'pages' });
+    expect(v).toEqual({ maxed: false, attempts: 0 });
+  });
+
+  it('burns an attempt when the rebuild is still stuck on plates', () => {
+    // The page images are evidently still unfetchable; retrying on every reader
+    // would be a rebuild loop on the most expensive path there is.
+    const first = nextUpgradeVerdict(30, 30, 0, { before: 'plates', after: 'plates' });
+    expect(first).toEqual({ maxed: false, attempts: 1 });
+    const second = nextUpgradeVerdict(30, 40, first.attempts, { before: 'plates', after: 'plates' });
+    expect(second.maxed).toBe(true);
+  });
+});


### PR DESCRIPTION
## The problem

A book's hero mosaic is a cached image. Its grid shape is fixed by how many tiles survived **fetching** at generation time, not by how many pages the book has:

```
rows = floor(surviving_tiles / cols)   // capped at 4
```

So a run where a few page-image fetches flaked leaves a permanent 10×2 on a book with hundreds of usable pages — and nothing retries it, because the stored version still matches `HERO_MOSAIC_VERSION` and the route short-circuits to the stored image.

**Measured on production 2026-08-02** — 400 random books with a cached mosaic and ≥40 pages, each decoded and its grid counted:

| Shape | Sample | Est. corpus |
|---|---|---|
| 10 cols, 2–3 rows | 52 (13%) | ~1,500 |
| Narrow **and** short | 29 (7%) | ~840 |
| 7–8 cols, 4 rows (aspect branch, working as designed) | 34 (8.5%) | ~980 |
| Full 10×4 | 271 (68%) | ~7,800 |

119 of 400 are short; **115 of those have 40+ unused non-junk pages**. Alciato's *Emblemata*: 10×2 from 182 pages. *Corpus Inscriptionum Latinarum*: 10×3 from 880. Re-running the tile pipeline against Alciato today yields a full 40 with nothing discarded — the material was always there, the cached image is a fossil of a worse moment.

## The approach

**Not a version bump.** That rebuilds all ~12,660 cached mosaics including the ~70% already correct.

Instead: a book whose stored grid is short serves its existing mosaic (instant, no flash), and the reader's browser fires **one** background rebuild after the image has painted. This reader waits on nothing; the next visitor gets the fuller grid.

- `?upgrade=1` on the mosaic route — rebuild, judge the result, record it. Refuses on maxed / already-full / cooldown before doing any work.
- The generator now records `hero_mosaic_tiles/cols/rows`, so a grid's shape stops being recoverable only by decoding pixels.
- For the 12,660 mosaics predating that, the first ping **measures** the stored image rather than rebuilding it (one fetch + decode). ~70% get recorded as full and are never rebuilt — this is what stops it becoming a corpus-wide regen.
- The R2 key carries the tile count. Overwriting a single key would leave the CDN serving the old image, defeating the point.
- After a rebuild that changed the shape, the route's cached 302 is purged. Most books reach their mosaic through that route and the redirect is edge-cached for a week.

## Runaway protection

This fires from every reader's browser, so the limits matter:

- **A decided no-op is cached for a week.** The book page usually reads the Supabase catalog mirror, which has no `hero_mosaic_*` columns, so it can't rule an upgrade out itself and offers one whenever it can't. Caching the "nothing to do" answer per book turns those into browser/CDN hits that never reach a function.
- **A 10-minute cooldown, claimed before the expensive work**, so concurrent readers of one book don't all rebuild it.
- **Two rebuilds that fail to improve** mark the book maxed and it is left alone for good.

## Verification

- `tests/unit/hero-mosaic-upgrade.test.ts` — 16 cases over the decision rules, including that a book which never improves converges to maxed rather than retrying forever.
- `tests/unit/hero-mosaic-measure.test.ts` — the grid reader against constructed grids of every shape the compositor produces, through AVIF encoding (the stored format, lossy enough that gap bands aren't exactly the background colour), and a dark-scan case that could otherwise read as row gaps.
- The measurer also agrees with three production mosaics of independently known shape: 10×2, 10×3, 10×4.
- 1454 unit tests pass; `tsc --noEmit` clean. The two eslint errors in `HeroVariants.tsx` are pre-existing (verified against the unmodified file) and untouched here.

## Cost

No AI in this path. Per rebuild: ~64 thumbnail fetches, ~10s compute, one ~120KB R2 write. Spread over real traffic rather than run as a batch, and only for books measured as short — the other ~9,200 keep their cached image untouched.

## Out of scope

- The ~980 books at 7–8 columns with 4 rows. That's the aspect branch choosing fewer columns for short/landscape scans, which is the designed behaviour; whether it should still target 10 columns is a design question, not a bug.
- Backfilling `hero_mosaic_tiles` for books nobody visits. They're measured lazily on first view; a batch pass would work but isn't needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)