### PR TITLE
feat(reextract): --page-type-candidates reaches typed pages OCR never marked up

### DIFF
--- a/.github/workflows/mycology-image-extraction.yml
+++ b/.github/workflows/mycology-image-extraction.yml
@@ -1,0 +1,97 @@
+name: Mycology image extraction sweep
+
+# Maintenance sweep: image-extract every book in the `mycology` collection that
+# still has unprocessed illustration-candidate pages.
+#
+# Runs on Hetzner because that is the only machine holding real Gemini API keys
+# (local checkouts and the Vercel env both carry an empty GEMINI_API_KEY).
+#
+# Launched detached with nohup so a dropped SSH connection cannot kill a long
+# sweep; progress is observable from the `pages` collection
+# (`image_extraction_updated_at`) and from the log path echoed below.
+#
+# Safe to re-run: reextract-missed-pages.mjs stamps `miss_recheck_at` on every
+# page it tests, so a second pass skips already-examined pages and spends nothing
+# on them.
+
+on:
+  workflow_dispatch:
+    inputs:
+      extra_args:
+        description: 'Flags for reextract-missed-pages.mjs (e.g. --any-marker, --page-type-candidates)'
+        required: false
+        default: '--any-marker'
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Launch sweep on Hetzner
+        uses: appleboy/ssh-action@v1
+        env:
+          # Passed through as an env var rather than interpolated into the shell,
+          # so the input can never be spliced into the command itself.
+          EXTRA_ARGS: ${{ inputs.extra_args }}
+        with:
+          host: 46.224.122.120
+          username: root
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          envs: EXTRA_ARGS
+          script: |
+            set -e
+            cd /root/sourcelibrary
+            git fetch origin main
+            git reset --hard origin/main
+            mkdir -p /var/log/sourcelibrary
+
+            # Only the documented flags are allowed through.
+            case "${EXTRA_ARGS}" in
+              *[!a-z\ -]*) echo "refusing unexpected characters in EXTRA_ARGS"; exit 1 ;;
+            esac
+
+            cat > /tmp/mycology-sweep.sh <<SWEEP
+            #!/usr/bin/env bash
+            set -uo pipefail
+            cd /root/sourcelibrary
+            EXTRA="${EXTRA_ARGS}"
+            SWEEP
+            cat >> /tmp/mycology-sweep.sh <<'SWEEP'
+            BOOKS="
+            6a4170cde906de1d7b3b9959 6a601adc744548430e8ee345 6a6025da495fb0f61871b7d8
+            6a6025ed495fb0f61871b96d 6a601ac7744548430e8ee1c2 6a602600495fb0f61871ba4e
+            6a602615495fb0f61871ba8d 6a500f7be39653852101ac86 6a503c562f6539fb38937848
+            6a503ddd12003aed574feaac 6a601af0744548430e8ee49c
+            69d8ca14a09828f83ddc9902 69d8c9f8a09828f83ddc9083 69d8c9fea09828f83ddc9371
+            69d8ca91a09828f83ddcb710 69b1dddc537bff0aca8a9709 69d8cab9a09828f83ddcc1bb
+            69d8ca06a09828f83ddc973a 69d8ca55a09828f83ddcaa26 69d8cabda09828f83ddcc2c9
+            69d8ca5aa09828f83ddcaabf 69d8ca6ea09828f83ddcaeb5 69d8ca4ea09828f83ddca72d
+            69d8ca0ba09828f83ddc97eb 69d8ca77a09828f83ddcb132 69d8ca85a09828f83ddcb69a
+            69d8ca66a09828f83ddcac68 69d8ca22a09828f83ddc9c7a 69d8ca3fa09828f83ddca25f
+            69d8cab3a09828f83ddcbe96 69d8ca0fa09828f83ddc9898 69d8ca29a09828f83ddc9e05
+            69d8ca46a09828f83ddca6c0 69d8ca97a09828f83ddcb957 69d8ca9ea09828f83ddcbad0
+            69d8caa6a09828f83ddcbbd5 69d8ca1ca09828f83ddc9a51 69d8ca32a09828f83ddca008
+            69d8ca5fa09828f83ddcabf9 69d8ca80a09828f83ddcb41b 69d8ca8aa09828f83ddcb70e
+            "
+            i=0
+            total=$(echo $BOOKS | wc -w)
+            for id in $BOOKS; do
+              i=$((i+1))
+              echo "== [$i/$total] $id =="
+              node --env-file=.env.production.local \
+                scripts/maintenance/reextract-missed-pages.mjs \
+                --book="$id" $EXTRA --apply --limit=2000 --concurrency=8 \
+                || echo "  !! failed: $id"
+            done
+            echo "== sweep finished =="
+            SWEEP
+
+            chmod +x /tmp/mycology-sweep.sh
+            # flock so a re-dispatch can't run two sweeps over the same pages
+            nohup flock -n /tmp/mycology-sweep.lock \
+              /tmp/mycology-sweep.sh \
+              > /var/log/sourcelibrary/mycology-sweep.log 2>&1 &
+            sleep 5
+            echo "--- launched with EXTRA_ARGS=${EXTRA_ARGS}; first lines of log ---"
+            head -20 /var/log/sourcelibrary/mycology-sweep.log || true

--- a/scripts/maintenance/reextract-missed-pages.mjs
+++ b/scripts/maintenance/reextract-missed-pages.mjs
@@ -29,6 +29,14 @@
  *   --any-marker  widen the candidate test to ANY non-trivial <image-desc> tag,
  *                 including bare attribute-less tags from old OCR vintages
  *                 (issue #3165). Skips pages the vision model already examined.
+ *   --page-type-candidates
+ *                 ALSO accept pages whose `page_type` is already an illustration
+ *                 class (illustration/diagram/map/frontispiece/mixed/title-page)
+ *                 even when OCR left no <image-desc> marker at all — the
+ *                 production worker's own rule. Every marker-based gate above is
+ *                 blind to those pages, so they are never offered to the vision
+ *                 model and read as "extracted, empty" permanently. Also skips
+ *                 pages already examined.
  */
 
 import { MongoClient } from 'mongodb';
@@ -60,9 +68,14 @@ const RANDOM_BOOKS = parseInt(getArg('random-books', '0'));
 // <image-desc> whose type attribute is absent or non-trivial. Expect lower
 // yield than the default filter's measured ~63% (Qazwini pilot: 49%).
 const ANY_MARKER = args.includes('--any-marker');
+// Also accept pages the page-typer already called an illustration, whether or
+// not OCR left a marker behind — see pageIsWorkerCandidate() below.
+const PAGE_TYPE_CANDIDATES = args.includes('--page-type-candidates');
 
 const MODEL = 'gemini-3-flash-preview';
 const TRIVIAL = new Set(['symbol', 'stamp', 'ornament', 'blank', 'exlibris', 'bookplate', 'decorative', "printer's mark", 'photograph', 'photographic']);
+// Mirrors IMAGE_CANDIDATE_PAGE_TYPES in scripts/workers/image-extract-worker.mjs.
+const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed', 'title-page'];
 
 // ── Reuse the production prompt verbatim (extract from the worker source) ──
 const workerSrc = readFileSync(new URL('../workers/image-extract-worker.mjs', import.meta.url), 'utf8');
@@ -121,8 +134,25 @@ function pageHasNonTrivialHighSigMarker(ocr) {
   });
 }
 
+// Every marker test above keys off OCR markup, so a page the page-typer called
+// an `illustration` but whose OCR emitted no <image-desc> tag is invisible to
+// this script — the vision model is never asked, and the page reads as
+// "extracted, nothing there" forever. That is a coverage hole, not a judgment:
+// the production worker (image-extract-worker.mjs) keeps a page whose
+// `page_type` is in its candidate list regardless of markup, and only consults
+// markup to decide about UNtyped pages. `--page-type-candidates` opts into that
+// same rule so this script can reach them.
+//
+// Kept opt-in because the default gate is deliberately narrow: it targets the
+// measured ~63%-yield "vision missed it" pattern, and widening it lowers yield.
+function pageIsWorkerCandidate(page) {
+  if (IMAGE_CANDIDATE_PAGE_TYPES.includes(page.page_type)) return true;
+  // Untyped/other pages still have to clear the markup test.
+  return pageHasNonTrivialHighSigMarker(page.ocr?.data);
+}
+
 async function main() {
-  console.log(`[reextract-missed] start ${new Date().toISOString()} | apply=${APPLY} limit=${LIMIT} conc=${CONCURRENCY} anyMarker=${ANY_MARKER} keys=${API_KEYS.length}`);
+  console.log(`[reextract-missed] start ${new Date().toISOString()} | apply=${APPLY} limit=${LIMIT} conc=${CONCURRENCY} anyMarker=${ANY_MARKER} pageTypeCandidates=${PAGE_TYPE_CANDIDATES} keys=${API_KEYS.length}`);
   const client = new MongoClient(process.env.MONGODB_URI, { maxPoolSize: 5 });
   await client.connect();
   const db = client.db('bookstore');
@@ -151,14 +181,21 @@ async function main() {
       miss_recheck_at: { $exists: false },
       // Default mode re-tests examined-but-empty pages (the vision-missed
       // pattern its high-significance marker is strong evidence for). The
-      // relaxed marker isn't — restrict to never-examined pages.
-      ...(ANY_MARKER ? { image_extraction_updated_at: { $exists: false } } : {}),
+      // relaxed marker isn't — restrict to never-examined pages. Same reasoning
+      // for --page-type-candidates: page_type alone is weaker evidence than a
+      // high-significance marker, so don't spend a second vision call on a page
+      // some earlier pass already looked at and found empty.
+      ...(ANY_MARKER || PAGE_TYPE_CANDIDATES ? { image_extraction_updated_at: { $exists: false } } : {}),
     }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, display_photo: 1, crop: 1, split_from_spread: 1, 'ocr.data': 1 } }).toArray();
     for (const p of pages) {
       // Require the high-significance non-trivial OCR marker — the precise
       // "genuine miss" signal the pilot measured at ~63% recovery. (page_type
-      // alone is a weaker signal and dilutes yield.)
-      if (!pageHasNonTrivialHighSigMarker(p.ocr?.data)) continue;
+      // alone is a weaker signal and dilutes yield.) --page-type-candidates
+      // trades that yield for coverage of typed pages OCR never marked up.
+      const accept = PAGE_TYPE_CANDIDATES
+        ? pageIsWorkerCandidate(p)
+        : pageHasNonTrivialHighSigMarker(p.ocr?.data);
+      if (!accept) continue;
       // Keep only the fields getPageSource() needs — drop ocr.data so a 56K-page
       // full sweep doesn't hold the entire OCR corpus in memory.
       candidates.push({


### PR DESCRIPTION
## The hole

Every candidate gate in `reextract-missed-pages.mjs` keys off OCR markup — `pageHasNonTrivialHighSigMarker()` requires an `<image-desc>` or `<detected-images>` tag, and `--any-marker` only relaxes *which* tags count. So a page the page-typer already classified as `illustration` / `diagram` / `map` / `frontispiece` but whose OCR emitted no marker is invisible to this script. The vision model is never asked about it, and nothing records the omission, so it reads as "extracted, nothing there" permanently.

The production worker does **not** have this hole. `image-extract-worker.mjs` keeps a page whose `page_type` is in `IMAGE_CANDIDATE_PAGE_TYPES` regardless of markup, and only consults markup (`shouldSkipPageByMarkup`) to judge *untyped* pages. `--page-type-candidates` opts into that same rule.

Worth noting `--any-marker`'s own docstring claims it widens "to the production worker's gate" — it doesn't, quite, because it omits the page_type half. This adds the missing half rather than changing what `--any-marker` does.

## Design

- **Opt-in.** The default gate is deliberately narrow: it targets the measured ~63%-yield "vision missed it" pattern, and widening it lowers yield. Existing callers are unaffected.
- **Skips already-examined pages**, same as `--any-marker` (`image_extraction_updated_at` must be absent). `page_type` alone is weaker evidence than a high-significance marker, so it should never buy a second vision call on a page an earlier pass already looked at and found empty.
- `IMAGE_CANDIDATE_PAGE_TYPES` is duplicated from the worker with a comment pointing at the original, matching how this script already mirrors `TRIVIAL`.

## Verification

Simulated the exact new selection against production for the collection that surfaced this — same Mongo filter, same in-memory gate:

```
pages --page-type-candidates would select: 52  (across 15 books)  est cost $0.11
```

That 52 is reached independently two ways: by replicating the worker's gate, and by replicating this script's post-change gate. Both agree, and both agree the pages are ones no vision pass has ever examined.

The second commit moves the mycology sweep workflow onto `main` as `workflow_dispatch`-only (it lived on an ops branch with a push trigger) and makes the flags selectable, so the same workflow can run either pass. The dispatch input reaches the box as an env var and is character-checked before use rather than interpolated into the command, so it can't be spliced into the shell.

## Out of scope

Not changing `--any-marker`'s behaviour, and not touching the default gate — both would alter cost and yield for corpus-wide callers who haven't asked for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)