### PR TITLE
Books insights tab: admin-only

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useStableSession } from '@/hooks/useStableSession';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { ChevronLeft, RefreshCw } from 'lucide-react';
@@ -40,6 +41,16 @@ export default function AnalyticsPage() {
   const [pipelineHours, setPipelineHours] = useState(24);
   const [refreshKey, setRefreshKey] = useState(0);
 
+  // The "Books" tab is admin-only. Everyone reaching /analytics is editor+, so
+  // hide it (and switch off it) for non-admins; the API is also admin-gated.
+  const session = useStableSession();
+  const su = session.data?.user as { role?: string; tenantRole?: string } | undefined;
+  const isAdmin = ['admin', 'superadmin'].includes(su?.role || '') || ['admin', 'superadmin'].includes(su?.tenantRole || '');
+  useEffect(() => {
+    if (session.status === 'authenticated' && !isAdmin && activeTab === 'books') setActiveTab('usage');
+  }, [session.status, isAdmin, activeTab]);
+  const visibleTabs = TABS.filter(t => t.key !== 'books' || isAdmin);
+
   return (
     <div className="min-h-screen" style={{ background: 'var(--bg-cream)' }}>
       {/* Header */}
@@ -63,7 +74,7 @@ export default function AnalyticsPage() {
           <div className="flex items-center gap-4">
             {/* Tab toggle */}
             <div className="flex rounded-lg p-1" style={{ background: 'var(--bg-warm)' }}>
-              {TABS.map(tab => (
+              {visibleTabs.map(tab => (
                 <button
                   key={tab.key}
                   onClick={() => setActiveTab(tab.key)}
@@ -135,7 +146,7 @@ export default function AnalyticsPage() {
       </header>
 
       <main className="max-w-[1500px] mx-auto px-6 py-8">
-        {activeTab === 'books' && <BooksTab key={refreshKey} />}
+        {activeTab === 'books' && isAdmin && <BooksTab key={refreshKey} />}
         {activeTab === 'usage' && <UsageTab key={refreshKey} days={days} />}
         {activeTab === 'performance' && <PerformanceTab key={refreshKey} hours={hours} />}
         {activeTab === 'logs' && <LogsTab key={refreshKey} />}

--- a/src/app/api/admin/book-insights/route.ts
+++ b/src/app/api/admin/book-insights/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { withInnerCircleAuth } from '@/lib/auth-helpers';
+import { withAdminAuth } from '@/lib/auth-helpers';
 import { getReadDb } from '@/lib/mongodb';
 
 export const runtime = 'nodejs';
@@ -14,7 +14,7 @@ type Agg = Array<{ _id: string; [k: string]: unknown }>;
  * tracking only began 2026-07-28, #3405). Sources: books.read_count,
  * analytics_events (book_read / page_read / download / search_query), likes.
  */
-export const GET = withInnerCircleAuth(async () => {
+export const GET = withAdminAuth(async () => {
   const db = await getReadDb();
   const AE = db.collection('analytics_events');
   const B = db.collection('books');

--- a/src/components/analytics/tabs/BooksTab.tsx
+++ b/src/components/analytics/tabs/BooksTab.tsx
@@ -70,7 +70,7 @@ export default function BooksTab() {
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch('/api/admin/book-insights').then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }).then(setD).catch((e) => setErr(e.message)).finally(() => setLoading(false));
+    fetch('/api/admin/book-insights').then((r) => { if (r.status === 403 || r.status === 401) throw new Error('This tab is admin-only.'); if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }).then(setD).catch((e) => setErr(e.message)).finally(() => setLoading(false));
   }, []);
 
   if (loading) return <div className="py-12 text-center text-sm" style={{ color: 'var(--text-muted)' }}>Crunching reads, likes, downloads &amp; searches…</div>;


### PR DESCRIPTION
Locks the /analytics Books tab to admins — API to withAdminAuth (editors 403) + client hides/switches-off the tab for non-admins. tsc clean.