### PR TITLE
fix(fungi hero): use the book hero's tint

### DIFF
--- a/src/app/collections/mycology/page.tsx
+++ b/src/app/collections/mycology/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { Metadata } from 'next';
 import { BookOpen, ArrowRight } from 'lucide-react';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
+import HeroScrim from '@/components/HeroScrim';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { getReadDb } from '@/lib/mongodb';
 import { getPageImageUrl } from '@/lib/page-image-url';
@@ -265,14 +266,19 @@ export default async function MycologyCollectionPage() {
       {/* Dark navbar variant of the global header. Breadcrumbs live in the hero. */}
       <ConditionalSiteHeader variant="dark" />
       {/* ===== Hero ===== */}
-      <section className="relative bg-dark overflow-hidden min-h-[66vh] flex items-end">
+      <section className="relative overflow-hidden min-h-[66vh] flex items-end" style={{ background: '#14100c' }}>
         {/* One composited collage image (2:3 tiles) — single optimized load, subtle parallax. */}
         <ParallaxImage src={`/api/collections/${SLUG}/hero-collage`} loading="eager" strength={0.08} oversize={0.1} />
         {/* Mobile: vertical tint — strongest at the bottom (text), light at top. */}
         <div className="absolute inset-0 md:hidden bg-gradient-to-t from-dark/85 via-dark/45 to-dark/5" />
-        {/* Desktop: left-weighted tint + bottom fade (unchanged). */}
-        <div className="absolute inset-0 hidden md:block bg-gradient-to-r from-dark/90 via-dark/50 to-transparent" />
-        <div className="absolute inset-x-0 bottom-0 h-1/2 hidden md:block bg-gradient-to-t from-dark/85 via-dark/35 to-transparent" />
+        {/* Desktop: the book hero's tint, so the two read as one system —
+            see src/components/HeroScrim.tsx. The previous stack was a
+            left-weighted gradient plus a bottom fade with no flat base scrim,
+            which left the collage bright and cool where the book hero is evenly
+            darkened and warm. */}
+        <div className="absolute inset-0 hidden md:block">
+          <HeroScrim />
+        </div>
 
         <div className="relative z-10 w-full max-w-[1500px] mx-auto px-6 md:px-12 pt-12 pb-10">
           <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-white/60 mb-6">

--- a/src/components/HeroScrim.tsx
+++ b/src/components/HeroScrim.tsx
@@ -1,0 +1,32 @@
+/**
+ * The tint that sits between a hero's background imagery and its text.
+ *
+ * Three layers, in order:
+ *   1. a flat warm near-black at 72% — does most of the darkening, and is what
+ *      makes white text legible over arbitrary page scans;
+ *   2. a left-weighted gradient, so the side carrying the title is darker than
+ *      the side that is just imagery;
+ *   3. a faint rust glow up and to the right, which keeps the whole thing from
+ *      reading as neutral grey.
+ *
+ * Shared by the book hero (`HeroVariants`) and the collection hero so the two
+ * genuinely match rather than happening to hold the same numbers — changing the
+ * tint in one place changes it in both, which is the point.
+ *
+ * Expects a positioned ancestor; render it directly over the background layer.
+ */
+export default function HeroScrim() {
+  return (
+    <>
+      <div className="absolute inset-0" style={{ background: 'rgba(16,12,8,0.72)' }} />
+      <div
+        className="absolute inset-0"
+        style={{ background: 'linear-gradient(90deg, rgba(14,10,7,0.5) 0%, rgba(14,10,7,0.12) 60%, transparent 100%)' }}
+      />
+      <div
+        className="absolute inset-0"
+        style={{ background: 'radial-gradient(120% 90% at 82% 18%, rgba(165,80,61,0.2) 0%, transparent 55%)' }}
+      />
+    </>
+  );
+}

--- a/src/components/book/HeroVariants.tsx
+++ b/src/components/book/HeroVariants.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, type ReactNode } from 'react';
+import HeroScrim from '@/components/HeroScrim';
 
 /**
  * Book-page hero.
@@ -95,9 +96,7 @@ export default function HeroVariants({
         <div className="hidden md:block absolute inset-0 overflow-hidden">
           <div className="absolute inset-x-0 -top-[12%] h-[124%] will-change-transform" style={drift}>
             <Bg />
-            <div className="absolute inset-0" style={{ background: 'rgba(16,12,8,0.72)' }} />
-            <div className="absolute inset-0" style={{ background: 'linear-gradient(90deg, rgba(14,10,7,0.5) 0%, rgba(14,10,7,0.12) 60%, transparent 100%)' }} />
-            <div className="absolute inset-0" style={{ background: 'radial-gradient(120% 90% at 82% 18%, rgba(165,80,61,0.2) 0%, transparent 55%)' }} />
+            <HeroScrim />
           </div>
         </div>
         {/* Mobile: a clean band of the bg up top (drifting), then a fixed strong


### PR DESCRIPTION
The fungi collection hero and the book hero were tinting their background imagery differently, so the two read as separate surfaces. This points the fungi hero at the book hero's tint.

## Before

`src/app/collections/mycology/page.tsx` laid a left-weighted gradient plus a bottom fade over the collage:

```
bg-gradient-to-r from-dark/90 via-dark/50 to-transparent
+ bottom half: bg-gradient-to-t from-dark/85 via-dark/35 to-transparent
```

No flat base scrim and no warm cast, over `--bg-dark` (`#1a1612`). The book hero instead darkens evenly and warm: a flat `rgba(16,12,8,0.72)`, a left-weighted gradient, and a faint rust glow, on `#14100c`.

The practical effect was that the collage stayed bright and cool where the book hero is subdued, and the title competed with whatever illustration happened to sit under it.

## Measured

Mean colour of the hero band behind the title, sampled from headless screenshots at 1400×900:

| | luminance | warmth (R−B) |
|---|---|---|
| Book hero (target) | 63.2 | +15.8 |
| Fungi **before** | 82.9 | +19.8 |
| Fungi **after** | 57.6 | **+16.0** |

Warmth now matches the book hero almost exactly. Luminance lands slightly under it — the two backgrounds differ (bright cream plates vs. darker page scans), so an identical tint cannot produce an identical result; this is the same tint, not a tuned imitation.

## Shared, not copied

The stack is extracted into `<HeroScrim />` and used by both heroes, so they stay identical rather than merely holding matching numbers today. `HeroVariants` renders byte-identical output — the three divs moved, nothing changed.

## Scope

- **Desktop only.** The mobile tint is a bottom-weighted ramp for a different layout (text sits at the bottom of a taller crop) and is deliberately left alone.
- **Fungi only.** Mycology has its own route; the shared `collections/[id]` template is untouched, so no other collection page changes. I initially edited that shared template by mistake and reverted it — worth knowing the two exist, since the shared one has its own separate issue (its gradient reaches transparent exactly where its title sits).
- No new lint or type errors; the two `HeroVariants` lint errors and the unused-var warning are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)