### PR TITLE
fix(ft): the two guards a first-translation CANDIDATE default needs (#3524)

### DIFF
--- a/scripts/audit/ft-source-language-screen.mjs
+++ b/scripts/audit/ft-source-language-screen.mjs
@@ -1,0 +1,241 @@
+/**
+ * ft-source-language-screen.mjs — is the SOURCE already English? (#3524, #3459)
+ *
+ * WHY THIS EXISTS AS A STANDING SWEEP
+ * -----------------------------------
+ * A first-translation candidate is any non-English book with no prior found. The
+ * cheapest way for that default to be flatly wrong is for the book to be in
+ * English already — and `books.language` cannot tell you, because it records the
+ * language of the WORK, not of the pages we hold. Ganguli's *Mahābhārata* and
+ * Avalon's *Serpent Power* are catalogued Sanskrit and are English editions;
+ * Boehme's *Works* (1781) is catalogued Latin and is English. 55 such books were
+ * badged "first English translation" of a book already in English (#3524).
+ *
+ * `ft-translation-queue.mjs` already screens for this, but only over the head of
+ * the queue and it persists nothing — so every consumer re-derives it, or (more
+ * often) doesn't. This sweep runs the same detector across the whole candidate
+ * pool and WRITES THE VERDICT DOWN, so the screen is a fact about the book rather
+ * than a step someone has to remember.
+ *
+ * WHAT IT WRITES
+ *   books.source_language_screen = {
+ *     verdict: 'english_source' | 'foreign_source' | 'undetermined',
+ *     basis, english_share|mean, pages_judged, screened_at, code_version
+ *   }
+ *
+ * It writes NOTHING ELSE. It does not touch `is_first_translation`, `language`,
+ * or `visible` — a screen that also flips flags is how one writer ends up
+ * clobbering another (CLAUDE.md, the FT single-writer rule). Consumers read the
+ * field; the reconcile stays the only flag writer.
+ *
+ * COST: zero. Reads stored OCR text, no model calls.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/ft-source-language-screen.mjs                 # dry run, prints the report
+ *   node scripts/audit/ft-source-language-screen.mjs --apply         # persist verdicts
+ *   node scripts/audit/ft-source-language-screen.mjs --apply --all   # include hidden/unpaginated
+ *   node scripts/audit/ft-source-language-screen.mjs --rescreen      # ignore existing verdicts
+ */
+import fs from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
+import { execSync } from 'child_process';
+import { withMongo } from '../lib/mongo.mjs';
+import { classifySourceLanguage } from '../lib/english-source-detect.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const ALL = process.argv.includes('--all');
+const RESCREEN = process.argv.includes('--rescreen');
+const LIMIT = Number((process.argv.find((a) => a.startsWith('--limit=')) || '').split('=')[1] || 0);
+
+const ENGLISH_LANGS = ['English', 'english', 'en', 'eng'];
+const OUT_DIR = path.join(process.cwd(), 'scripts/output');
+
+/**
+ * Pin the code that produced a verdict. A screening threshold is a judgement, and
+ * a stored judgement whose code is unknown cannot be re-derived or disputed.
+ *
+ * `rev-parse HEAD` ALONE IS NOT ENOUGH, and getting this wrong cost a run: the
+ * first sweep was launched, then the detector was fixed while it was in flight.
+ * Node had already loaded the module, so 500 books were written by the old code —
+ * stamped with the same HEAD the fixed run would stamp, because the fix was
+ * uncommitted. Two different judgements, one version string, no way to tell them
+ * apart afterwards.
+ *
+ * So: refuse to write when the working tree is dirty. `--allow-dirty` marks the
+ * stamp `<sha>-dirty+<hash-of-detector>` instead, which at least distinguishes
+ * two dirty states from each other.
+ */
+const ALLOW_DIRTY = process.argv.includes('--allow-dirty');
+let CODE_VERSION = 'unknown';
+let DIRTY = false;
+try {
+  CODE_VERSION = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  DIRTY = execSync('git status --porcelain -- scripts/lib/english-source-detect.mjs scripts/audit/ft-source-language-screen.mjs',
+    { encoding: 'utf8' }).trim().length > 0;
+  if (DIRTY) {
+    const h = createHash('sha256')
+      .update(fs.readFileSync(new URL('../lib/english-source-detect.mjs', import.meta.url)))
+      .digest('hex').slice(0, 8);
+    CODE_VERSION = `${CODE_VERSION}-dirty+${h}`;
+  }
+} catch { /* not a repo */ }
+
+/**
+ * Scanner/library boilerplate. English by construction, on books in every
+ * language, and it is bound into the scan rather than printed in the book — so a
+ * page carrying it says nothing about the source language and must not vote.
+ *
+ * This is not hypothetical: the Zohrab Armenian New Testament was screened
+ * `english_source` on three consecutive pages of the Google Books notice.
+ */
+const BOILERPLATE_RE = /digital copy of a book that was preserved|make the world'?s books discoverable|public domain (?:book|work) is one that was never subject|google book search|digitized by (?:google|microsoft|the internet archive)/i;
+
+/**
+ * Sample pages SPREAD ACROSS the middle of the book.
+ *
+ * Three things had to be got right here, and the obvious implementation gets all
+ * three wrong. It was copied from `ft-translation-queue.mjs`, which still has
+ * them (see the PR): both flagged books it reported as already-English were
+ * false positives.
+ *
+ *  1. NEGATIVE PAGE NUMBERS ARE SOFT-HIDDEN PAGES. Sorting by `page_number`
+ *     ascending starts in them, so "skip 30%" can land entirely inside the hidden
+ *     range and never reach the book. The Armenian NT sampled pages -1378..-1376.
+ *
+ *  2. `skip` MUST BE AN OFFSET INTO THE OCR'd PAGES, NOT INTO `pages_count`.
+ *     Sparse OCR makes the two diverge without any error.
+ *
+ *  3. EIGHT CONSECUTIVE PAGES ARE ONE PLACE IN THE BOOK. Nicholson's *Kitab
+ *     al-Luma* is Arabic with an English glossary at the back; a consecutive
+ *     sample that lands in the glossary reports the whole book as English. A
+ *     spread sample lets the body outvote the apparatus.
+ *
+ * So: positive page numbers only, offsets computed over the OCR'd set, and the
+ * sample spread evenly across the middle 60% (20%–80%) to clear front matter at
+ * one end and index/glossary at the other.
+ */
+const SAMPLE_SIZE = 10;
+
+async function samplePages(pages, bookId) {
+  const nums = await pages.find(
+    { book_id: bookId, page_number: { $gt: 0 }, 'ocr.data': { $exists: true, $ne: null } },
+    { projection: { page_number: 1 }, sort: { page_number: 1 } },
+  ).toArray();
+  if (!nums.length) return { texts: [], available: 0 };
+
+  const lo = Math.floor(nums.length * 0.2);
+  const hi = Math.max(lo + 1, Math.floor(nums.length * 0.8));
+  const span = hi - lo;
+  const picks = [];
+  for (let i = 0; i < SAMPLE_SIZE; i++) {
+    const idx = lo + Math.floor((span * i) / SAMPLE_SIZE);
+    if (idx < nums.length && !picks.includes(nums[idx].page_number)) picks.push(nums[idx].page_number);
+  }
+
+  const rows = await pages.find(
+    { book_id: bookId, page_number: { $in: picks } },
+    { projection: { 'ocr.data': 1 } },
+  ).toArray();
+  const texts = rows.map((p) => p.ocr?.data).filter(Boolean).filter((t) => !BOILERPLATE_RE.test(t));
+  return { texts, available: nums.length };
+}
+
+await withMongo(async (db) => {
+  const books = db.collection('books');
+  const pages = db.collection('pages');
+
+  const q = { language: { $nin: ENGLISH_LANGS } };
+  if (!ALL) { q.visible = true; q.pages_count = { $gt: 0 }; }
+  if (!RESCREEN) q.source_language_screen = { $exists: false };
+
+  const total = await books.countDocuments(q);
+  console.log(`Source-language screen — ${total.toLocaleString()} book(s) to screen`);
+  console.log(`  scope: ${ALL ? 'ALL books' : 'visible + paginated'}${RESCREEN ? ', re-screening existing verdicts' : ''}`);
+  console.log(`  mode:  ${APPLY ? 'APPLY (writes books.source_language_screen)' : 'DRY RUN'}`);
+  console.log(`  code:  ${CODE_VERSION}\n`);
+
+  if (APPLY && DIRTY && !ALLOW_DIRTY) {
+    console.error('REFUSING TO WRITE — the detector or this script has uncommitted changes.');
+    console.error('A stored verdict must name the exact code that produced it. Commit first,');
+    console.error('or pass --allow-dirty to stamp a content hash instead.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const cursor = books.find(q, {
+    projection: { id: 1, title: 1, language: 1, pages_count: 1, is_first_translation: 1 },
+    // A long paced sweep outlives the default 10-minute cursor lifetime. This is
+    // the failure that killed the demote packet after 31 of 33 works, having
+    // written nothing.
+    noCursorTimeout: true,
+  });
+
+  const tally = { english_source: 0, foreign_source: 0, undetermined: 0, no_ocr: 0 };
+  const englishHits = [];
+  let seen = 0;
+  let writes = 0;
+  const ops = [];
+
+  for await (const b of cursor) {
+    if (LIMIT && seen >= LIMIT) break;
+    seen++;
+    const { texts, available } = await samplePages(pages, b.id);
+    // "We could not ask" is not "we asked and found nothing." A book with no OCR
+    // is unscreenable, not undetermined — collapsing the two turns an unasked
+    // question into a finding, which is the standing failure mode in this area.
+    const v = available === 0
+      ? { verdict: 'no_ocr', basis: 'no_ocr_pages', pages_judged: 0 }
+      : { ...classifySourceLanguage(texts), pages_available: available };
+    tally[v.verdict] = (tally[v.verdict] || 0) + 1;
+
+    if (v.verdict === 'english_source') {
+      englishHits.push({
+        id: b.id, title: b.title, language: b.language,
+        pages_count: b.pages_count, badged: !!b.is_first_translation,
+        basis: v.basis, english_share: v.english_share ?? null, mean: v.mean ?? null,
+        pages_judged: v.pages_judged,
+      });
+    }
+
+    if (APPLY) {
+      ops.push({
+        updateOne: {
+          filter: { id: b.id },
+          update: { $set: { source_language_screen: { ...v, screened_at: new Date(), code_version: CODE_VERSION } } },
+        },
+      });
+      if (ops.length >= 500) { const r = await books.bulkWrite(ops); writes += r.modifiedCount; ops.length = 0; }
+    }
+    if (seen % 500 === 0) console.log(`  …${seen.toLocaleString()}/${total.toLocaleString()}  english=${tally.english_source} foreign=${tally.foreign_source} undet=${tally.undetermined} no_ocr=${tally.no_ocr}`);
+  }
+  if (APPLY && ops.length) { const r = await books.bulkWrite(ops); writes += r.modifiedCount; }
+
+  console.log(`\n─── Screened ${seen.toLocaleString()} book(s) ───`);
+  console.log(`  english_source : ${tally.english_source.toLocaleString()}  ← catalogued foreign, pages are English`);
+  console.log(`  foreign_source : ${tally.foreign_source.toLocaleString()}`);
+  console.log(`  undetermined   : ${tally.undetermined.toLocaleString()}  ← OCR'd but not judgeable; NOT excluded`);
+  console.log(`  no_ocr         : ${tally.no_ocr.toLocaleString()}  ← unscreenable, not a finding; NOT excluded`);
+  if (APPLY) console.log(`  written        : ${writes.toLocaleString()} book(s) updated`);
+
+  const badgedEnglish = englishHits.filter((h) => h.badged);
+  console.log(`\n─── Already-English books currently BADGED as a first English translation: ${badgedEnglish.length} ───`);
+  for (const h of badgedEnglish.slice(0, 40)) {
+    console.log(`  ${String(h.language).padEnd(12)}${String(h.pages_count ?? 0).padStart(6)}pp  ${(h.title || '').slice(0, 56).padEnd(58)}${h.basis}`);
+  }
+  if (badgedEnglish.length > 40) console.log(`  …and ${badgedEnglish.length - 40} more`);
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const out = path.join(OUT_DIR, `ft-source-language-screen-${new Date().toISOString().slice(0, 10)}.json`);
+  fs.writeFileSync(out, JSON.stringify({
+    screened_at: new Date().toISOString(),
+    code_version: CODE_VERSION,
+    scope: ALL ? 'all' : 'visible+paginated',
+    applied: APPLY,
+    counts: { ...tally, screened: seen },
+    english_source: englishHits,
+  }, null, 2));
+  console.log(`\nReport: ${out}`);
+  if (!APPLY) console.log('Dry run — nothing written. Re-run with --apply to persist.');
+});

--- a/scripts/audit/ft-translator-as-author-screen.mjs
+++ b/scripts/audit/ft-translator-as-author-screen.mjs
@@ -1,0 +1,228 @@
+/**
+ * ft-translator-as-author-screen.mjs — is this book ITSELF a published English
+ * translation we re-hosted? (#3524, #3459)
+ *
+ * WHY THIS EXISTS ALONGSIDE THE SOURCE-LANGUAGE SCREEN
+ * ---------------------------------------------------
+ * `ft-source-language-screen.mjs` asks whether the pages we hold are English. It
+ * catches Ganguli's *Mahābhārata* and Avalon's *Serpent Power*. It CANNOT catch a
+ * BILINGUAL edition — Legge's *Chinese Classics*, the Loeb library, Sacred Books
+ * of the East — because the Chinese or Greek is right there on the page and the
+ * book screens, correctly, as a foreign source. Verified 2026-08-01: Legge's
+ * *Works of Mencius* screens `foreign_source` and is nonetheless Legge's own
+ * published English translation of 1893.
+ *
+ * That is the contamination mode unique to the PROMOTE direction, and it is why
+ * the June 2026 promote census held 5 books rather than badging them (Duyvendak's
+ * *Book of Lord Shang* is the canonical example). Left unscreened, a re-hosted
+ * published translation becomes a "first English translation" of itself.
+ *
+ * THE SIGNAL: `books.author` is a person who appears as a TRANSLATOR in the
+ * translation catalogue. Free, no model calls.
+ *
+ * WHY IT ONLY HOLDS, NEVER EXCLUDES
+ * ---------------------------------
+ * The signal is real and noisy, and the noise is structural rather than fixable:
+ *   - A translator is often also an author. Joscelyn Godwin translates AND writes;
+ *     Franz Hartmann wrote in German and translated.
+ *   - A name match is not a person match. "Swedenborg, Emanuel" matched on a
+ *     French edition of Swedenborg — he appears as a translator on some other row.
+ *   - A book being a translation does not defeat the claim unless it is a
+ *     translation INTO ENGLISH. A 1782 German rendering of Fludd does not.
+ * So this writes a HOLD with its evidence attached and a human decides. Measured
+ * on the live candidate pool the list is ~93 books, of which ~23 are badged —
+ * reviewable in an afternoon, which is the point. §17: never derive a destructive
+ * flag from an unverified match.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/ft-translator-as-author-screen.mjs             # dry run + review list
+ *   node scripts/audit/ft-translator-as-author-screen.mjs --apply     # persist holds
+ */
+import fs from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
+import { execSync } from 'child_process';
+import { withMongo } from '../lib/mongo.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const ALLOW_DIRTY = process.argv.includes('--allow-dirty');
+const ENGLISH_LANGS = ['English', 'english', 'en', 'eng'];
+const OUT_DIR = path.join(process.cwd(), 'scripts/output');
+
+/** Placeholder "translators" that are not people and must never seed the index. */
+const NON_PERSON_TRANSLATOR = /^(various|anonymous|unknown|n\.?a\.?|editor|the editors|multiple|s\.?n\.?)$/i;
+
+let CODE_VERSION = 'unknown';
+let DIRTY = false;
+try {
+  CODE_VERSION = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  DIRTY = execSync('git status --porcelain -- scripts/audit/ft-translator-as-author-screen.mjs',
+    { encoding: 'utf8' }).trim().length > 0;
+  if (DIRTY) {
+    const h = createHash('sha256').update(fs.readFileSync(new URL(import.meta.url))).digest('hex').slice(0, 8);
+    CODE_VERSION = `${CODE_VERSION}-dirty+${h}`;
+  }
+} catch { /* not a repo */ }
+
+/** Lowercase, drop life dates, parentheticals and punctuation. */
+export function normalizeName(s) {
+  return String(s || '').toLowerCase()
+    .replace(/\d{3,4}\s*-\s*\d{0,4}/g, ' ')
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/[.,;:'"]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Both orderings of a name, because catalogues store "Surname, First" and our
+ * `books.author` is frequently "First Surname".
+ *
+ * Requires two tokens: a bare surname is a collision waiting to happen, and this
+ * screen exists to reduce review load, not to generate it.
+ */
+export function nameVariants(s) {
+  const n = normalizeName(s);
+  if (!n || NON_PERSON_TRANSLATOR.test(n)) return [];
+  const out = new Set([n]);
+  const m = n.match(/^([^,]+),\s*(.+)$/);
+  if (m) out.add(`${m[2]} ${m[1]}`.replace(/\s+/g, ' ').trim());
+  return [...out].filter((x) => x.split(' ').length >= 2 && x.length > 5);
+}
+
+/**
+ * An explicit TRANSLATOR self-declaration in the author field — "(trans.)".
+ *
+ * ⚠️ `(ed.)` MUST NOT BE HERE, and including it was the first version of this
+ * screen. An editor of a critical edition edits the ORIGINAL: Dillmann's *Biblia
+ * Veteris Testamenti Aethiopica* is the Ge'ez text, Heiberg's *Euclidis Opera
+ * Omnia* is the Greek, Diels' *Fragmente der Vorsokratiker* is the Greek. Those
+ * are the most ordinary books in this corpus and every one of them is a
+ * legitimate first-translation candidate. Conflating the two roles produced 337
+ * spurious holds out of 430 — a screen that flags the normal case is worse than
+ * no screen, because someone has to clear it.
+ *
+ * Editor is a role in the ORIGINAL language; translator is a role in the TARGET
+ * language. Only the second can defeat a first-translation claim.
+ */
+const EXPLICIT_ROLE_RE = /\(\s*(?:trans(?:l(?:ated|ator))?|tr)\.?\s*\)|\btranslated by\b|\btransl\.\s*by\b/i;
+
+await withMongo(async (db) => {
+  const books = db.collection('books');
+
+  if (APPLY && DIRTY && !ALLOW_DIRTY) {
+    console.error('REFUSING TO WRITE — uncommitted changes to this script. Commit first, or --allow-dirty.');
+    process.exitCode = 1;
+    return;
+  }
+
+  // ── Build the translator index ────────────────────────────────────────────
+  const index = new Map(); // normalized variant -> sample catalogue row
+  for (const r of await db.collection('translation_catalogs')
+    .find({ translator: { $nin: [null, ''] } }, { projection: { translator: 1, english_title: 1, pub_year: 1, source: 1 } })
+    .toArray()) {
+    for (const v of nameVariants(r.translator)) if (!index.has(v)) index.set(v, r);
+  }
+
+  /**
+   * Names that are ALSO original authors in the same catalogue.
+   *
+   * Robert Fludd wrote *Medicina catholica*; Emanuel Swedenborg wrote his own
+   * works. Both also appear in some row's translator column, so a bare name match
+   * flagged eight Fludd titles and two Swedenborgs as "may be a translation" —
+   * pure collision. If the catalogue knows the name as an author of works in its
+   * own right, a name match carries no information and the `catalogue_match`
+   * basis is withheld. The explicit "(trans.)" declaration is unaffected: that is
+   * a statement about THIS book, not about the name.
+   */
+  const authorNames = new Set();
+  for (const r of await db.collection('translation_catalogs')
+    .find({ canonical_author: { $nin: [null, ''] } }, { projection: { canonical_author: 1 } })
+    .toArray()) {
+    for (const v of nameVariants(r.canonical_author)) authorNames.add(v);
+  }
+  console.log(`Translator index: ${index.size.toLocaleString()} name variants from translation_catalogs`);
+  console.log(`Author names withheld from name-matching: ${authorNames.size.toLocaleString()}\n`);
+
+  // ── Screen the candidate pool ─────────────────────────────────────────────
+  const pool = await books.find(
+    { visible: true, pages_count: { $gt: 0 }, language: { $nin: ENGLISH_LANGS } },
+    { projection: { id: 1, title: 1, author: 1, year: 1, language: 1, is_first_translation: 1 } },
+  ).toArray();
+
+  const holds = [];
+  for (const b of pool) {
+    if (!b.author) continue;
+    const explicit = EXPLICIT_ROLE_RE.test(b.author);
+    const vs = nameVariants(b.author);
+    // Withhold a bare name match when the catalogue also knows the name as an
+    // author in its own right — see `authorNames` above.
+    const match = vs.some((v) => authorNames.has(v)) ? null : vs.find((v) => index.has(v));
+    if (!match && !explicit) continue;
+    holds.push({
+      id: b.id,
+      title: b.title,
+      author: b.author,
+      language: b.language,
+      year: b.year ?? null,
+      badged: !!b.is_first_translation,
+      // Two independent reasons, reported separately: an explicit "(trans.)" in
+      // the author field is a self-declaration and far stronger than a name match.
+      basis: explicit && match ? 'explicit_role+catalogue_match' : explicit ? 'explicit_role' : 'catalogue_match',
+      matched_translator: match ?? null,
+      catalogue_example: match ? { title: index.get(match).english_title, year: index.get(match).pub_year, source: index.get(match).source } : null,
+    });
+  }
+
+  const badged = holds.filter((h) => h.badged);
+  console.log(`─── ${holds.length} book(s) HELD for review — may themselves be published translations ───`);
+  console.log(`  of those, currently badged as a first English translation: ${badged.length}\n`);
+  const byBasis = holds.reduce((a, h) => { a[h.basis] = (a[h.basis] || 0) + 1; return a; }, {});
+  console.log('  by basis:', JSON.stringify(byBasis), '\n');
+
+  for (const h of [...badged, ...holds.filter((x) => !x.badged)].slice(0, 45)) {
+    console.log(`  ${h.badged ? '[BADGED] ' : '         '}${String(h.language).slice(0, 14).padEnd(16)}${String(h.year || '').padEnd(6)}`
+      + `${(h.author || '').slice(0, 26).padEnd(28)}${(h.title || '').slice(0, 44).padEnd(46)}${h.basis}`);
+  }
+  if (holds.length > 45) console.log(`  …and ${holds.length - 45} more in the JSON`);
+
+  if (APPLY) {
+    const ops = holds.map((h) => ({
+      updateOne: {
+        filter: { id: h.id },
+        update: {
+          $set: {
+            translator_author_screen: {
+              verdict: 'hold',
+              basis: h.basis,
+              matched_translator: h.matched_translator,
+              catalogue_example: h.catalogue_example,
+              screened_at: new Date(),
+              code_version: CODE_VERSION,
+            },
+          },
+        },
+      },
+    }));
+    if (ops.length) {
+      const r = await books.bulkWrite(ops);
+      console.log(`\nWritten: ${r.modifiedCount} hold(s). NOTE: a hold is a review request, not an exclusion —`);
+      console.log('nothing downstream may treat it as a verdict, and no flag was touched.');
+    }
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const out = path.join(OUT_DIR, `ft-translator-as-author-${new Date().toISOString().slice(0, 10)}.json`);
+  fs.writeFileSync(out, JSON.stringify({
+    screened_at: new Date().toISOString(),
+    code_version: CODE_VERSION,
+    applied: APPLY,
+    pool_size: pool.length,
+    index_size: index.size,
+    counts: { held: holds.length, held_and_badged: badged.length, by_basis: byBasis },
+    holds,
+  }, null, 2));
+  console.log(`\nReview list: ${out}`);
+  if (!APPLY) console.log('Dry run — nothing written.');
+});

--- a/scripts/lib/english-source-detect.mjs
+++ b/scripts/lib/english-source-detect.mjs
@@ -71,8 +71,34 @@ const ENGLISH_FUNCTION_WORDS = new Set(
  * a Hebrew Zohar scored 0.32 on an annotated page and 0.00 on real Hebrew. The
  * detector was reading our own annotations and calling the source English.
  */
+/**
+ * A SECOND wrapper family, from the epigraphy/artifact OCR schema.
+ *
+ * `stripEditorialWrappers` knows the codex families (`<meta>`, `<summary>`,
+ * `<scan-quality>`, …). Tablet, papyrus and manuscript-fragment records use a
+ * different one — `<condition>`, `<period>`, `<surface>`, `<genre>`, `<notes>`,
+ * `<confidence>` — and `<condition>` in particular is a paragraph of English
+ * prose describing the artifact:
+ *
+ *   <language>Akkadian</language>
+ *   <condition>The image shows multiple fragments (K.2421, K.2511, K.16765)
+ *   from the British Museum collection, joined to form...</condition>
+ *
+ * Left in, that prose IS the page as far as a word-frequency measure is
+ * concerned, and a Neo-Assyrian tablet screens as English. Same bug the header
+ * above describes for the codex wrappers, in a family nobody had enumerated.
+ *
+ * ⚠️ These tags are almost certainly also reaching the quote/search/ngram
+ * surfaces, which strip only the families `stripEditorialWrappers` knows — that
+ * is the #2232 class and a wider blast radius than this file. Fixed locally here;
+ * the global fix belongs in `strip-editorial-wrappers.{ts,mjs}` with its own
+ * verification across every snippet surface.
+ */
+const ARTIFACT_WRAPPER_RE = /<(condition|period|surface|genre|notes|confidence|provenance|material|dimensions)>[\s\S]*?<\/\1>/gi;
+
 export function textWords(s) {
   return String(stripEditorialWrappers(String(s || '')))
+    .replace(ARTIFACT_WRAPPER_RE, ' ')
     .replace(/<[^>]*>/g, ' ')
     .toLowerCase()
     .match(/[a-z']+/g) ?? [];
@@ -98,6 +124,13 @@ export function englishFraction(text, minWords = 25) {
  * real first-translation candidate, which is the costlier error.
  */
 export const ENGLISH_SOURCE_THRESHOLD = 0.15;
+
+/**
+ * Minimum judgeable pages before FREQUENCY alone may return `english_source`.
+ * See the asymmetry note in `classifySourceLanguage`. Does not apply to the
+ * model's declared language, which is direct evidence rather than an estimate.
+ */
+export const MIN_PAGES_FOR_FREQUENCY_ENGLISH = 3;
 
 /**
  * The OCR model DECLARES the page's language in its metadata envelope —
@@ -146,8 +179,16 @@ export function declaresEnglish(ocrData) {
 export function classifySourceLanguage(pageTexts) {
   // Prefer the model's own declaration — a direct statement about the page beats
   // a frequency estimate derived from it.
+  //
+  // ONE declaration is enough. The old floor of 2 meant a single-page record —
+  // a tablet, a papyrus, a manuscript leaf — could never use its own declaration
+  // and fell through to frequency, which then read the English artifact
+  // description and called an Akkadian tablet English. If the model that read the
+  // page named the language, that is the best evidence available at any count;
+  // requiring a second copy of it discards the only signal on exactly the records
+  // that have nothing else.
   const declared = pageTexts.map((t) => declaresEnglish(t)).filter((d) => d !== null);
-  if (declared.length >= 2) {
+  if (declared.length >= 1) {
     const englishShare = declared.filter(Boolean).length / declared.length;
     return {
       verdict: englishShare >= 0.5 ? 'english_source' : 'foreign_source',
@@ -161,8 +202,18 @@ export function classifySourceLanguage(pageTexts) {
   const fracs = pageTexts.map((t) => englishFraction(t)).filter((f) => f !== null);
   if (!fracs.length) return { verdict: 'undetermined', basis: 'none', mean: null, pages_judged: 0 };
   const mean = fracs.reduce((a, b) => a + b, 0) / fracs.length;
+  const english = mean >= ENGLISH_SOURCE_THRESHOLD;
+
+  // Asymmetric floor, deliberately. The two errors do not cost the same: calling a
+  // foreign book English silently DROPS a genuine first-translation candidate and
+  // nothing downstream will ever revisit it, while calling an English book foreign
+  // merely leaves a candidate to be caught later. So a frequency-based
+  // `english_source` needs corroboration across pages; `foreign_source` does not.
+  if (english && fracs.length < MIN_PAGES_FOR_FREQUENCY_ENGLISH) {
+    return { verdict: 'undetermined', basis: 'insufficient_pages_for_frequency', mean, pages_judged: fracs.length };
+  }
   return {
-    verdict: mean >= ENGLISH_SOURCE_THRESHOLD ? 'english_source' : 'foreign_source',
+    verdict: english ? 'english_source' : 'foreign_source',
     basis: 'function_word_frequency',
     mean,
     pages_judged: fracs.length,

--- a/tests/unit/english-source-detect.test.ts
+++ b/tests/unit/english-source-detect.test.ts
@@ -1,0 +1,142 @@
+/**
+ * english-source-detect: four ways a foreign book reads as English. (#3524, #3459)
+ *
+ * A first-translation CANDIDATE is any non-English book with no prior found. The
+ * cheapest way for that default to be flatly wrong is for the pages to be English
+ * already — so this detector is a load-bearing guard, and its errors are
+ * asymmetric: a false `english_source` silently DROPS a genuine candidate and
+ * nothing downstream revisits it, while a false `foreign_source` merely leaves a
+ * candidate to be caught later.
+ *
+ * Every fixture below is a REAL false positive observed against production on
+ * 2026-08-01, reduced to the smallest text that reproduces it. These are
+ * behavioural tests: each one fails if the corresponding guard is removed from
+ * `english-source-detect.mjs` — verified by deleting each guard and watching the
+ * matching case go red. (CLAUDE.md: "a test that greps source is not a guard" —
+ * before writing one, ask what code change would make it fail.)
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import {
+  classifySourceLanguage,
+  englishFraction,
+  textWords,
+  ENGLISH_SOURCE_THRESHOLD,
+  MIN_PAGES_FOR_FREQUENCY_ENGLISH,
+} from '../../scripts/lib/english-source-detect.mjs';
+
+/** A page of real Latin body text — the control for "genuinely foreign". */
+const LATIN_PAGE = `<language>Latin</language>
+Quod si quis vero animo perpenderit quantum in rebus humanis valeat
+consuetudo, atque quam multa non ratione sed usu comprobata sint, is
+profecto intelliget quam difficile sit veterem opinionem evellere.`;
+
+/** A page of ordinary English body text. */
+const ENGLISH_PAGE = `<language>English</language>
+But if any one shall weigh in his mind how much custom avails in human
+affairs, and how many things are approved not by reason but by use, he
+will surely understand how hard it is to root out an old opinion.`;
+
+describe('the four false-positive modes', () => {
+  it('1. an English glossary at the back does not make an Arabic book English', () => {
+    // Nicholson's *Kitab al-Luma*: Arabic text, English-Arabic glossary at the
+    // back. The old sampler took 8 CONSECUTIVE pages and landed in the glossary.
+    // The detector's job here is only to let the body outvote the apparatus when
+    // it is given a spread sample — so the fixture is what a spread sample sees.
+    const glossaryPage = `<language>English</language>
+      English index 146 with to implore the help of God of mystical language
+      depth profundity absence used in a mystical sense`;
+    const spread = [LATIN_PAGE, LATIN_PAGE, LATIN_PAGE, LATIN_PAGE,
+      LATIN_PAGE, LATIN_PAGE, LATIN_PAGE, LATIN_PAGE, glossaryPage];
+    expect(classifySourceLanguage(spread).verdict).toBe('foreign_source');
+  });
+
+  it('2. scanner boilerplate is English on every book and must not vote', () => {
+    // The Zohrab Armenian NT screened english_source on three consecutive pages
+    // of the Google Books notice. The sweep filters these before classifying;
+    // this pins that the text itself is unmistakably English-scoring, i.e. that
+    // the filter is doing real work rather than being decorative.
+    const boilerplate = `This is a digital copy of a book that was preserved for
+      generations on library shelves before it was carefully scanned by Google as
+      part of a project to make the world's books discoverable online.`;
+    const frac = englishFraction(boilerplate);
+    expect(frac).not.toBeNull();
+    expect(frac!).toBeGreaterThan(ENGLISH_SOURCE_THRESHOLD);
+  });
+
+  it('3. an English ARTIFACT DESCRIPTION does not make an Akkadian tablet English', () => {
+    // The epigraphy schema — <condition>, <period>, <surface>, <genre> — is a
+    // second wrapper family that `stripEditorialWrappers` does not know. The
+    // <condition> block is a paragraph of English prose about the object.
+    const tabletPage = `<surface>full-view</surface>
+      <script>Neo-Assyrian</script>
+      <language>Akkadian</language>
+      <period>ca. 668-631 BC (Library of Ashurbanipal)</period>
+      <condition>The image shows multiple fragments (K.2421, K.2511, K.16765) from
+      the British Museum collection, joined to form a substantial portion of a
+      tablet. The surface is worn and chipped in places, but the script is a fine,
+      late Neo-Assyrian hand characteristic of the royal library at Nineveh.</condition>
+      <genre>literary</genre>
+      <transliteration>a-sar-ri ba-ni i-ne-mi sa-a-ti</transliteration>`;
+
+    // The wrapper prose must not survive tokenisation...
+    const words = textWords(tabletPage);
+    expect(words).not.toContain('british');
+    expect(words).not.toContain('museum');
+    expect(words).not.toContain('fragments');
+
+    // ...and the book must not be classified from it.
+    expect(classifySourceLanguage([tabletPage]).verdict).toBe('foreign_source');
+  });
+
+  it('4. a lone declaration is used, so a one-page record is judged on evidence', () => {
+    // The old floor of two declarations meant a single-page record — a tablet, a
+    // papyrus, a manuscript leaf — could never use its own declared language and
+    // fell through to frequency, which then read the English description.
+    const onePage = `<language>Akkadian</language>
+      <condition>A fragmentary tablet from the British Museum, worn at the edges
+      and chipped along the lower left, with a fine late hand throughout.</condition>`;
+    const v = classifySourceLanguage([onePage]);
+    expect(v.verdict).toBe('foreign_source');
+    expect(v.basis).toBe('declared_language');
+  });
+});
+
+describe('the asymmetry is enforced, not just intended', () => {
+  it('frequency alone cannot return english_source below the page floor', () => {
+    const thin = Array.from({ length: MIN_PAGES_FOR_FREQUENCY_ENGLISH - 1 },
+      () => ENGLISH_PAGE.replace('<language>English</language>', ''));
+    const v = classifySourceLanguage(thin);
+    expect(v.verdict).toBe('undetermined');
+    expect(v.basis).toBe('insufficient_pages_for_frequency');
+  });
+
+  it('but frequency alone CAN return foreign_source on a single page', () => {
+    // The cheap direction stays cheap: no corroboration required to keep a book
+    // in the candidate pool.
+    const v = classifySourceLanguage([LATIN_PAGE.replace('<language>Latin</language>', '')]);
+    expect(v.verdict).toBe('foreign_source');
+  });
+
+  it('above the floor, frequency still catches a genuinely English source', () => {
+    const enough = Array.from({ length: MIN_PAGES_FOR_FREQUENCY_ENGLISH },
+      () => ENGLISH_PAGE.replace('<language>English</language>', ''));
+    expect(classifySourceLanguage(enough).verdict).toBe('english_source');
+  });
+});
+
+describe('the controls still hold', () => {
+  it('a declared English source is still caught (Ganguli, Avalon)', () => {
+    expect(classifySourceLanguage([ENGLISH_PAGE, ENGLISH_PAGE]).verdict).toBe('english_source');
+  });
+
+  it('a declared foreign source is kept as a candidate', () => {
+    expect(classifySourceLanguage([LATIN_PAGE, LATIN_PAGE]).verdict).toBe('foreign_source');
+  });
+
+  it('no judgeable text is undetermined — never a verdict', () => {
+    expect(classifySourceLanguage([]).verdict).toBe('undetermined');
+    expect(classifySourceLanguage(['   ', '']).verdict).toBe('undetermined');
+  });
+});


### PR DESCRIPTION
Prerequisite for treating "non-English + no prior found" as a first-translation **candidate** by default. A candidate is only honest if the two ways it can be flatly wrong are screened: the book is already in English, or the book *is* a published English translation we re-hosted.

Both screens are free — stored OCR and existing catalogue rows, no model calls. Neither touches `is_first_translation`, `language` or `visible`; the reconcile stays the single flag writer.

## 1. Source-language screen — three bugs, all failing toward a false "already English"

Every book the existing screen flagged as already-English was a false positive, in three distinct ways. The error direction matters: a false `english_source` silently **drops a genuine candidate** and nothing downstream revisits it.

| # | bug | how it showed up |
|---|---|---|
| 1 | **Sampling.** Sorts by `page_number` asc and skips 30% of `pages_count`. Negative page numbers are soft-hidden pages, so the skip lands inside them; the offset is over `pages_count` not the OCR'd set; and 8 *consecutive* pages are one place in the book. | Zohrab Armenian NT sampled pages −1378…−1376, all Google Books boilerplate. Nicholson's Arabic *Kitab al-Luma* sampled its English glossary. |
| 2 | **A second wrapper family.** `<condition>`, `<period>`, `<surface>`, `<genre>` are not in `stripEditorialWrappers`, and `<condition>` is English prose describing the artifact. | A Neo-Assyrian tablet screened English off our own description of it. |
| 3 | **A lone declaration was discarded.** Required 2 declared pages, so a one-page record could never use its own `<language>Akkadian</language>`. | Fell through to frequency, which read the English description. |

Fixes: positive page numbers only, offsets over the OCR'd set, 10 pages spread across the middle 60%, boilerplate filtered; artifact wrappers stripped; one declaration is enough. Plus an **asymmetric floor** — frequency alone cannot return `english_source` below 3 judged pages, while `foreign_source` needs no corroboration.

⚠️ **`ft-translation-queue.mjs` has bug 1 today** and has been silently dropping candidates. Not fixed here (it needs its own verification pass); flagged in the code.

⚠️ **The artifact wrapper family is probably reaching the quote/search/ngram surfaces**, which strip only the families `stripEditorialWrappers` knows. That is the #2232 class and a much wider blast radius — stripped locally here, noted in the file, needs its own PR.

### Tests are behavioural, not source-shape

Every fixture is a real production false positive reduced to minimal text. **Each guard was deleted in turn to confirm the matching test goes red** — guard 1 → 1 failure, guard 2 → 2 failures, guard 3 → 1 failure. Per CLAUDE.md: if the only change that makes a test fail is deleting a line, it is documentation with a green checkmark.

## 2. Translator-as-author screen

The language screen cannot catch a **bilingual** edition — Legge's *Chinese Classics*, the Loebs, Sacred Books of the East — because the original is right there on the page. Verified: Legge's *Works of Mencius* screens `foreign_source` and is Legge's own published English translation. This is the contamination mode unique to the promote direction.

Two narrowings, each measured, took the list **430 → 166 → 117**:

- **`(ed.)` is not `(trans.)`** — an editor edits the *original*. Dillmann's Ge'ez Bible, Heiberg's Greek Euclid, Diels' *Vorsokratiker*. 337 spurious holds; a screen that flags the normal case is worse than none.
- **A name match is not a person match** — Fludd wrote his own Latin works and appears somewhere as a translator. Names the catalogue also knows as original authors are withheld from name-matching.

**117 held, 15 badged**, dominated by Ficino's Latin renderings of Plato, Plotinus and the Hermetica — the work-identity question a human should answer (#3261).

A hold is a **review request, never an exclusion**. The signal is irreducibly noisy, so §17 applies.

## Process note

The first sweep was launched, then the detector was fixed in flight. Node had already loaded the module, so 500 books were written by the old code — under the same git SHA the fixed run would stamp, because the fix was uncommitted. Those 500 were unset; the script now **refuses to write from a dirty tree**.

## Out of scope

- No `candidate` state in `derive.ts`, no badge copy, no flag changes. This is the prerequisite only.
- `ft-translation-queue.mjs` sampling bug: flagged, not fixed.
- Global `stripEditorialWrappers` fix for the artifact family: flagged, not fixed.
- The 117 holds are recorded, not adjudicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)