### PR TITLE
archive-iiif: park the daemon on metered links (hotspot / in-flight wifi)

### DIFF
--- a/scripts/workers/archive-iiif-daemon.sh
+++ b/scripts/workers/archive-iiif-daemon.sh
@@ -17,7 +17,21 @@ set -a; source .env.production.local; set +a
 
 W="node scripts/workers/archive-iiif-local.mjs --ignore-pause"
 
+# Optional per-machine guard: skip cycles while on a metered link (phone hotspot,
+# in-flight wifi), where this daemon would otherwise eat the whole uplink. It is
+# checked per CYCLE rather than at startup, so boarding a plane mid-run parks it.
+# FAILS OPEN by design — if the guard is absent (Hetzner, a fresh checkout, another
+# dev's machine) the daemon behaves exactly as it always has. Never make it required:
+# a missing guard must not stop archiving.
+GUARD="${BULK_NET_GUARD:-$HOME/bin/bulk-net-guard.sh}"
+
 while true; do
+  if [ -x "$GUARD" ] && ! "$GUARD" --why; then
+    echo "===== PARKED — metered link, re-checking in 10m $(date) ====="
+    sleep 600
+    continue
+  fi
+
   echo "===== CYCLE $(date) ====="
 
   # Fast lane: plain IIIF (the bulk). Clean, no throttling.


### PR DESCRIPTION
The `archive-iiif` KeepAlive daemon runs two archiving lanes flat out — the fast lane is concurrency 6 at 5 req/s. On a phone hotspot or in-flight wifi that is the entire uplink.

Found the hard way on a plane: this daemon plus a BPH page-repair job had pulled **1,156 MB over 171 open TCP connections** on a link with 740 ms RTT.

## Why the guard goes in the loop

The other three archive agents (`gallica`, `erara`, `harvard`) already carry an SSID check, but theirs live in the launchd plist because they are `StartInterval` one-shots. This one is `KeepAlive` and runs forever, so a startup check would only matter if the daemon happened to restart. Checking **per cycle** means boarding a plane mid-run parks it.

It sleeps 10m and `continue`s rather than exiting, so launchd never sees a process exit and never respawn-thrashes.

## Fails open, deliberately

`$BULK_NET_GUARD` (default `~/bin/bulk-net-guard.sh`) is a per-machine script. It is **absent** on Hetzner, on a fresh checkout, and on any other dev machine — in all of those the daemon behaves exactly as it does today. A missing guard must never stop archiving, so the check is `[ -x "$GUARD" ] && ! "$GUARD"`.

## Verification

Ran the actual script, not a reasoning exercise — three paths:

| Condition | Result |
|---|---|
| Real plane network (`DeltaWiFi.com`) | `PARKED`, no worker process started |
| Guard allows (`BULK_NET_GUARD_SSID=HomeNetwork`) | reaches `CYCLE`, invokes `archive-iiif-local.mjs` |
| Guard path absent | reaches `CYCLE` (fails open) |

The middle row is the negative control. Per CLAUDE.md ("a test that greps source is not a guard" / run the negative control rather than reasoning about it), the first row alone proves nothing — a guard that always parks would also pass it.

## Out of scope

The guard script itself is per-machine and intentionally **not** in this repo: it encodes one person's SSIDs and home path. The three sibling plists live in `~/Library/LaunchAgents` and were updated outside the repo. This PR is only the one guarded line in the repo-tracked daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)