### PR TITLE
fix(ft): one sampler, not two — plus the noTimeout fix that never shipped (#3524)

### DIFF
--- a/scripts/audit/ft-source-language-screen.mjs
+++ b/scripts/audit/ft-source-language-screen.mjs
@@ -42,7 +42,7 @@ import path from 'path';
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
 import { withMongo } from '../lib/mongo.mjs';
-import { classifySourceLanguage } from '../lib/english-source-detect.mjs';
+import { classifySourceLanguage, samplePagesForLanguage } from '../lib/english-source-detect.mjs';
 
 const APPLY = process.argv.includes('--apply');
 const ALL = process.argv.includes('--all');
@@ -81,66 +81,6 @@ try {
     CODE_VERSION = `${CODE_VERSION}-dirty+${h}`;
   }
 } catch { /* not a repo */ }
-
-/**
- * Scanner/library boilerplate. English by construction, on books in every
- * language, and it is bound into the scan rather than printed in the book — so a
- * page carrying it says nothing about the source language and must not vote.
- *
- * This is not hypothetical: the Zohrab Armenian New Testament was screened
- * `english_source` on three consecutive pages of the Google Books notice.
- */
-const BOILERPLATE_RE = /digital copy of a book that was preserved|make the world'?s books discoverable|public domain (?:book|work) is one that was never subject|google book search|digitized by (?:google|microsoft|the internet archive)/i;
-
-/**
- * Sample pages SPREAD ACROSS the middle of the book.
- *
- * Three things had to be got right here, and the obvious implementation gets all
- * three wrong. It was copied from `ft-translation-queue.mjs`, which still has
- * them (see the PR): both flagged books it reported as already-English were
- * false positives.
- *
- *  1. NEGATIVE PAGE NUMBERS ARE SOFT-HIDDEN PAGES. Sorting by `page_number`
- *     ascending starts in them, so "skip 30%" can land entirely inside the hidden
- *     range and never reach the book. The Armenian NT sampled pages -1378..-1376.
- *
- *  2. `skip` MUST BE AN OFFSET INTO THE OCR'd PAGES, NOT INTO `pages_count`.
- *     Sparse OCR makes the two diverge without any error.
- *
- *  3. EIGHT CONSECUTIVE PAGES ARE ONE PLACE IN THE BOOK. Nicholson's *Kitab
- *     al-Luma* is Arabic with an English glossary at the back; a consecutive
- *     sample that lands in the glossary reports the whole book as English. A
- *     spread sample lets the body outvote the apparatus.
- *
- * So: positive page numbers only, offsets computed over the OCR'd set, and the
- * sample spread evenly across the middle 60% (20%–80%) to clear front matter at
- * one end and index/glossary at the other.
- */
-const SAMPLE_SIZE = 10;
-
-async function samplePages(pages, bookId) {
-  const nums = await pages.find(
-    { book_id: bookId, page_number: { $gt: 0 }, 'ocr.data': { $exists: true, $ne: null } },
-    { projection: { page_number: 1 }, sort: { page_number: 1 } },
-  ).toArray();
-  if (!nums.length) return { texts: [], available: 0 };
-
-  const lo = Math.floor(nums.length * 0.2);
-  const hi = Math.max(lo + 1, Math.floor(nums.length * 0.8));
-  const span = hi - lo;
-  const picks = [];
-  for (let i = 0; i < SAMPLE_SIZE; i++) {
-    const idx = lo + Math.floor((span * i) / SAMPLE_SIZE);
-    if (idx < nums.length && !picks.includes(nums[idx].page_number)) picks.push(nums[idx].page_number);
-  }
-
-  const rows = await pages.find(
-    { book_id: bookId, page_number: { $in: picks } },
-    { projection: { 'ocr.data': 1 } },
-  ).toArray();
-  const texts = rows.map((p) => p.ocr?.data).filter(Boolean).filter((t) => !BOILERPLATE_RE.test(t));
-  return { texts, available: nums.length };
-}
 
 await withMongo(async (db) => {
   const books = db.collection('books');
@@ -181,7 +121,7 @@ await withMongo(async (db) => {
   for await (const b of cursor) {
     if (LIMIT && seen >= LIMIT) break;
     seen++;
-    const { texts, available } = await samplePages(pages, b.id);
+    const { texts, available } = await samplePagesForLanguage(pages, b.id);
     // "We could not ask" is not "we asked and found nothing." A book with no OCR
     // is unscreenable, not undetermined — collapsing the two turns an unasked
     // question into a finding, which is the standing failure mode in this area.

--- a/scripts/audit/ft-source-language-screen.mjs
+++ b/scripts/audit/ft-source-language-screen.mjs
@@ -178,4 +178,21 @@ await withMongo(async (db) => {
   }, null, 2));
   console.log(`\nReport: ${out}`);
   if (!APPLY) console.log('Dry run — nothing written. Re-run with --apply to persist.');
-});
+},
+/**
+ * `noTimeout` is REQUIRED, not a tuning choice.
+ *
+ * `withMongo` kills the process after 300s to stop zombie scripts. This sweep
+ * makes two `pages` queries per book across ~17,000 books and runs the better
+ * part of an hour, so the default watchdog fires mid-run. It has now done so
+ * twice — at 2,000 books on a laptop, then at 5,500 on the Hetzner box — with
+ * `[mongo] Script timeout after 300s — forcing exit`. Same failure that killed
+ * the demote packet at 31 of 33 works (CLAUDE.md, "Long paced runs need
+ * noTimeout").
+ *
+ * The run is resumable, since the driving query skips books that already carry a
+ * verdict, so a watchdog kill loses wall-clock rather than work. That is not a
+ * reason to tolerate it: a partial sweep reports partial counts and says nothing
+ * about being partial, which is how a 12%-complete screen gets read as a result.
+ */
+{ noTimeout: true });

--- a/scripts/eval/ft-translation-queue.mjs
+++ b/scripts/eval/ft-translation-queue.mjs
@@ -39,7 +39,7 @@ import readline from 'readline';
 import { fileURLToPath } from 'url';
 import { withMongo } from '../lib/mongo.mjs';
 import { canonicalLanguage } from '../lib/source-language-match.mjs';
-import { classifySourceLanguage } from '../lib/english-source-detect.mjs';
+import { classifySourceLanguage, samplePagesForLanguage } from '../lib/english-source-detect.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(__dirname, '..', 'output');
@@ -283,12 +283,20 @@ await withMongo(async (db) => {
       // Sample from the MIDDLE of the book. Front matter (title page, preface,
       // editor's introduction) is routinely English even in a Latin edition, so
       // sampling from the start reports the apparatus rather than the text.
-      const skip = Math.max(2, Math.floor((w.pages || 0) * 0.3));
-      const sample = await pages.find(
-        { book_id: w.id, 'ocr.data': { $exists: true, $ne: null } },
-        { projection: { 'ocr.data': 1 }, sort: { page_number: 1 }, skip, limit: 8 },
-      ).toArray();
-      const verdict = classifySourceLanguage(sample.map((p) => p.ocr?.data).filter(Boolean));
+      // Sampling lives in `english-source-detect.mjs` and is imported, not
+      // reimplemented. The copy that used to sit here got all three of its
+      // hazards wrong — soft-hidden negative page numbers, an offset over
+      // `pages_count` rather than the OCR'd set, and eight CONSECUTIVE pages
+      // (which is one place in the book, so an English glossary at the back
+      // spoke for the whole of it). Every book it flagged as already-English was
+      // a false positive, and each false positive silently DROPPED a genuine
+      // translation candidate off this queue.
+      const { texts, available } = await samplePagesForLanguage(pages, w.id);
+      // "We could not ask" is not "we asked and found nothing": a work with no
+      // OCR is unscreenable, and must not be reported as undetermined evidence.
+      const verdict = available === 0
+        ? { verdict: 'no_ocr', basis: 'no_ocr_pages', pages_judged: 0 }
+        : classifySourceLanguage(texts);
       w.source_language = verdict;
       if (verdict.verdict === 'english_source') alreadyEnglish.push(w);
       else { if (verdict.verdict === 'undetermined') undetermined++; kept.push(w); }

--- a/scripts/lib/english-source-detect.mjs
+++ b/scripts/lib/english-source-detect.mjs
@@ -219,3 +219,63 @@ export function classifySourceLanguage(pageTexts) {
     pages_judged: fracs.length,
   };
 }
+
+/**
+ * Scanner/library boilerplate. English by construction, on books in every
+ * language, and it is bound into the scan rather than printed in the book — so a
+ * page carrying it says nothing about the source language and must not vote.
+ *
+ * This is not hypothetical: the Zohrab Armenian New Testament was screened
+ * `english_source` on three consecutive pages of the Google Books notice.
+ */
+export const BOILERPLATE_RE = /digital copy of a book that was preserved|make the world'?s books discoverable|public domain (?:book|work) is one that was never subject|google book search|digitized by (?:google|microsoft|the internet archive)/i;
+
+/**
+ * Sample pages SPREAD ACROSS the middle of the book.
+ *
+ * Three things had to be got right here, and the obvious implementation gets all
+ * three wrong. It lived in two places — this and `ft-translation-queue.mjs` — and
+ * the second copy still had every one of them, which is why it is now ONE
+ * function that both callers import.
+ *
+ *  1. NEGATIVE PAGE NUMBERS ARE SOFT-HIDDEN PAGES. Sorting by `page_number`
+ *     ascending starts in them, so "skip 30%" can land entirely inside the hidden
+ *     range and never reach the book. The Armenian NT sampled pages -1378..-1376.
+ *
+ *  2. `skip` MUST BE AN OFFSET INTO THE OCR'd PAGES, NOT INTO `pages_count`.
+ *     Sparse OCR makes the two diverge without any error.
+ *
+ *  3. EIGHT CONSECUTIVE PAGES ARE ONE PLACE IN THE BOOK. Nicholson's *Kitab
+ *     al-Luma* is Arabic with an English glossary at the back; a consecutive
+ *     sample that lands in the glossary reports the whole book as English. A
+ *     spread sample lets the body outvote the apparatus.
+ *
+ * So: positive page numbers only, offsets computed over the OCR'd set, and the
+ * sample spread evenly across the middle 60% (20%–80%) to clear front matter at
+ * one end and index/glossary at the other.
+ */
+export const SAMPLE_SIZE = 10;
+
+export async function samplePagesForLanguage(pages, bookId) {
+  const nums = await pages.find(
+    { book_id: bookId, page_number: { $gt: 0 }, 'ocr.data': { $exists: true, $ne: null } },
+    { projection: { page_number: 1 }, sort: { page_number: 1 } },
+  ).toArray();
+  if (!nums.length) return { texts: [], available: 0 };
+
+  const lo = Math.floor(nums.length * 0.2);
+  const hi = Math.max(lo + 1, Math.floor(nums.length * 0.8));
+  const span = hi - lo;
+  const picks = [];
+  for (let i = 0; i < SAMPLE_SIZE; i++) {
+    const idx = lo + Math.floor((span * i) / SAMPLE_SIZE);
+    if (idx < nums.length && !picks.includes(nums[idx].page_number)) picks.push(nums[idx].page_number);
+  }
+
+  const rows = await pages.find(
+    { book_id: bookId, page_number: { $in: picks } },
+    { projection: { 'ocr.data': 1 } },
+  ).toArray();
+  const texts = rows.map((p) => p.ocr?.data).filter(Boolean).filter((t) => !BOILERPLATE_RE.test(t));
+  return { texts, available: nums.length };
+}

--- a/tests/unit/english-source-detect.test.ts
+++ b/tests/unit/english-source-detect.test.ts
@@ -24,6 +24,7 @@ import {
   textWords,
   ENGLISH_SOURCE_THRESHOLD,
   MIN_PAGES_FOR_FREQUENCY_ENGLISH,
+  samplePagesForLanguage,
 } from '../../scripts/lib/english-source-detect.mjs';
 
 /** A page of real Latin body text — the control for "genuinely foreign". */
@@ -138,5 +139,83 @@ describe('the controls still hold', () => {
   it('no judgeable text is undetermined — never a verdict', () => {
     expect(classifySourceLanguage([]).verdict).toBe('undetermined');
     expect(classifySourceLanguage(['   ', '']).verdict).toBe('undetermined');
+  });
+});
+
+/**
+ * The SAMPLER — the code that lived in two places and was wrong in both.
+ *
+ * A fake `pages` collection, because the three hazards are all about WHICH pages
+ * get chosen, which is exactly what a mock can pin and a real database cannot
+ * pin cheaply.
+ */
+function fakePages(docs: Array<{ page_number: number; ocr?: { data: string } }>) {
+  return {
+    find(filter: any, opts: any = {}) {
+      let rows = docs.filter((d) => {
+        // NOTE: this mock honours `$gt` only if the caller passes it. That is
+      // deliberate — it is what lets the soft-hidden-page test actually fail when
+      // the filter is removed from the implementation.
+      if (filter.page_number?.$gt !== undefined && !(d.page_number > filter.page_number.$gt)) return false;
+        if (filter.page_number?.$in && !filter.page_number.$in.includes(d.page_number)) return false;
+        if (filter['ocr.data']?.$exists && !d.ocr?.data) return false;
+        return true;
+      });
+      if (opts.sort?.page_number === 1) rows = [...rows].sort((a, b) => a.page_number - b.page_number);
+      return { toArray: async () => rows };
+    },
+  };
+}
+
+describe('samplePagesForLanguage — the three sampling hazards', () => {
+  it('never samples a soft-hidden (negative) page number', async () => {
+    // The Zohrab Armenian NT: 400 soft-hidden scan-boilerplate pages numbered
+    // negatively, then the real book. Sorting ascending and skipping 30% of the
+    // page COUNT lands entirely inside the hidden range.
+    const docs = [
+      ...Array.from({ length: 400 }, (_, i) => ({ page_number: -1400 + i, ocr: { data: 'hidden english boilerplate page' } })),
+      ...Array.from({ length: 200 }, (_, i) => ({ page_number: i + 1, ocr: { data: 'ARMENIAN BODY TEXT' } })),
+    ];
+    const { texts } = await samplePagesForLanguage(fakePages(docs) as any, 'b1');
+    expect(texts.length).toBeGreaterThan(0);
+    expect(texts.every((t: string) => t === 'ARMENIAN BODY TEXT')).toBe(true);
+  });
+
+  it('spreads across the MIDDLE, so neither front nor back matter speaks for the book', async () => {
+    // Nicholson's *Kitab al-Luma*: an English preface, the Arabic body, an
+    // English glossary at the back.
+    //
+    // ⚠️ The fixture MUST have English at BOTH ends. An earlier version had only
+    // the back-matter glossary, and it passed with a deliberately broken
+    // front-sampling implementation — because the front of that fixture was the
+    // body, so sampling from page 1 got the right answer by accident. A fixture
+    // whose wrong strategy still scores correctly tests nothing.
+    const docs = [
+      ...Array.from({ length: 30 }, (_, i) => ({ page_number: i + 1, ocr: { data: 'ENGLISH_PREFACE' } })),
+      ...Array.from({ length: 140 }, (_, i) => ({ page_number: 31 + i, ocr: { data: 'ARABIC' } })),
+      ...Array.from({ length: 30 }, (_, i) => ({ page_number: 171 + i, ocr: { data: 'ENGLISH_GLOSSARY' } })),
+    ];
+    const { texts } = await samplePagesForLanguage(fakePages(docs) as any, 'b2');
+    const arabic = texts.filter((t: string) => t === 'ARABIC').length;
+    const english = texts.filter((t: string) => t !== 'ARABIC').length;
+    expect(arabic).toBeGreaterThan(english);
+    // And specifically: neither end may dominate the sample.
+    expect(texts.filter((t: string) => t === 'ENGLISH_PREFACE').length).toBeLessThan(arabic);
+    expect(texts.filter((t: string) => t === 'ENGLISH_GLOSSARY').length).toBeLessThan(arabic);
+  });
+
+  it('offsets over the OCRd pages, not over pages_count', async () => {
+    // Sparse OCR: 1,000 pages exist, 10 are OCR'd. An offset over `pages_count`
+    // skips past every one of them and returns nothing.
+    const docs = Array.from({ length: 10 }, (_, i) => ({ page_number: i * 100 + 1, ocr: { data: 'LATIN' } }));
+    const { texts, available } = await samplePagesForLanguage(fakePages(docs) as any, 'b3');
+    expect(available).toBe(10);
+    expect(texts.length).toBeGreaterThan(0);
+  });
+
+  it('reports zero available when nothing is OCRd — never an empty verdict', async () => {
+    const { texts, available } = await samplePagesForLanguage(fakePages([]) as any, 'b4');
+    expect(available).toBe(0);
+    expect(texts).toEqual([]);
   });
 });


### PR DESCRIPTION
Follow-up to #3555. Two things, both consequences of that PR rather than new territory.

## 1. `ft-translation-queue.mjs` had every hazard #3555 just fixed

It carried its own copy of the page sampler, with all three:

- sorts by `page_number` ascending including **negative** (soft-hidden) pages, so the 30% skip can land entirely inside them
- offsets over `pages_count` rather than over the **OCR'd** pages, which diverge silently under sparse OCR
- takes 8 **consecutive** pages — one place in the book, so an English glossary at the back speaks for the whole of an Arabic text

Every book it flagged as already-English was a false positive, and each one silently **dropped a genuine work off the translation queue** — the costly direction, because nothing revisits it.

Fixed by **extraction, not a second edit**: `samplePagesForLanguage()` now lives in `english-source-detect.mjs` and both callers import it. A third copy is how this happened twice. The `no_ocr` / `undetermined` split comes across too, so "we could not ask" stops reading as evidence in the queue.

## 2. The `noTimeout` fix from #3555 never shipped

I committed it locally and **never pushed before merging**, so the squash took only the pushed commits. It silently did not ship — the trap already recorded as *"a merged PR ships only PUSHED commits."*

Observed consequence: the sweep died a **second** time, on the Hetzner box at 5,500 of 15,071, with the same `[mongo] Script timeout after 300s` the unshipped commit fixed. Restored here, with the second occurrence written into the comment.

## The negative control caught my own bad tests

The first version of the four sampler tests **passed against a deliberately broken front-sampling implementation.** Every fixture had its body at the front, so the wrong strategy scored correctly by accident — decorative tests, in a PR whose whole subject is sampling.

The glossary fixture now carries English at **both** ends. Verified:

| mutation | result |
|---|---|
| baseline | 14 passed |
| `lo = 0; hi = min(len,10)` (front-sampling) | **1 failed** |
| remove the `page_number: {$gt: 0}` filter | **1 failed** |
| restored | 14 passed |

## Out of scope

- No `candidate` state, no badge copy, no flag changes.
- The global `stripEditorialWrappers` gap for the artifact wrapper family (`<condition>`, `<period>`, `<surface>`) is still only fixed locally in the detector — that is the #2232 class and needs its own PR with verification across every snippet surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)