### PR TITLE
fix(review): repair the two 504'd volunteer queues, add notes everywhere, route people to the work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,14 @@ Each time, two artifacts produced by **different code at different times** were 
 
 Full postmortem: `.claude/handoffs/2026-07-27-bulk-jp2-leaf-offset.md`.
 
+## A request-path query must not scale with the corpus
+Two of the three volunteer review queues returned **504** for months (#3568): each picked one item by `$sample`-ing `pages` — **19.1M docs** — with a predicate no index can serve (a regex on `ocr.data`; `archived_photo: {$exists}`). That is a full collection scan per request, behind `maxDuration = 15`. It was never going to work at corpus scale and it degraded **quietly** as the corpus grew, because nothing alarms on "slower every month" and the client only ever showed "Network error".
+
+- **The tell is the query shape, not the timing:** an unindexed predicate on a collection whose size tracks the corpus. `pages` is 19.1M and growing; `gallery_images` is 207K. Confirm offline — the same aggregation also fails to return locally inside two minutes.
+- **Which one survived is the lesson.** `gallery-quality` worked only because `gallery_images` is a *materialized view* — and still cost 8.2s/item, its own kind of unusable. **Precompute a bounded pool** (`review_candidates`, built by `scripts/maintenance/build-review-candidates.mjs`, read via `src/lib/review-candidates.ts`) and the same work takes 23–61ms.
+- **A builder that feeds such a pool must cap items per book.** An unbounded draw lets one 900-page volume dominate and silently turns "quality of the corpus" into "quality of that book" — and write the `stratum` at build time, because a stratified draw cannot be reconstructed afterwards.
+- Same family as the `/explore` prerender timeout (#3373), where counts over `entities` sit close to `maxTimeMS`: a query that merely *fits* today is a deadline you have already scheduled.
+
 ## Data Protection — CRITICAL
 - **NEVER** delete books, pages, or source material without explicit confirmation
 - **NEVER** batch delete — list items first, wait for approval

--- a/scripts/lib/image-extraction-filter.mjs
+++ b/scripts/lib/image-extraction-filter.mjs
@@ -1,0 +1,65 @@
+/**
+ * Scripts-side twin of src/lib/image-extraction-filter.ts.
+ *
+ * Parity-pinned by tests/unit/image-extraction-filter-parity.test.ts —
+ * change both sides together.
+ *
+ * Exists so batch scripts can apply the SAME "would the extraction worker
+ * keep this page?" test the app applies, without a fourth hand-rolled copy.
+ * (scripts/workers/image-extract-worker.mjs and pipeline-orchestrator.mjs
+ * still carry their own inline copies; folding those in is a separate change.)
+ */
+
+export const SKIP_MARKUP_RULES = [
+  { type: 'symbol', significance: '*' },
+  { type: 'stamp', significance: '*' },
+  { type: 'ornament', significance: '*' },
+  { type: 'blank', significance: '*' },
+  { type: 'exlibris', significance: '*' },
+  { type: 'bookplate', significance: '*' },
+  { type: 'decorative', significance: 'low' },
+  { type: "printer's mark", significance: 'low' },
+  { type: 'photograph', significance: 'low' },
+  { type: 'photographic', significance: 'low' },
+];
+
+export const IMAGE_CANDIDATE_PAGE_TYPES = [
+  'illustration',
+  'diagram',
+  'map',
+  'frontispiece',
+  'mixed',
+  'title-page',
+];
+
+export function shouldSkipPageByMarkup(ocrData) {
+  if (!ocrData) return false;
+  if (ocrData.includes('<detected-images>')) return false;
+  const tags = [...ocrData.matchAll(/<image-desc([^>]*)>/g)];
+  if (tags.length === 0) return false;
+  for (const m of tags) {
+    const type = m[1].match(/type="([^"]+)"/)?.[1];
+    const sig = m[1].match(/significance="([^"]+)"/)?.[1];
+    const matched = SKIP_MARKUP_RULES.find(
+      r => r.type === type && (r.significance === '*' || r.significance === sig),
+    );
+    if (!matched) return false;
+  }
+  return true;
+}
+
+export function extractImageDescTags(ocrData) {
+  if (!ocrData) return [];
+  const tags = [];
+  const re = /<image-desc([^>]*)>([\s\S]*?)<\/image-desc>/g;
+  for (const m of ocrData.matchAll(re)) {
+    const attrs = m[1];
+    tags.push({
+      type: attrs.match(/type="([^"]+)"/)?.[1] ?? null,
+      significance: attrs.match(/significance="([^"]+)"/)?.[1] ?? null,
+      size: attrs.match(/size="([^"]+)"/)?.[1] ?? null,
+      description: m[2].trim(),
+    });
+  }
+  return tags;
+}

--- a/scripts/maintenance/build-review-candidates.mjs
+++ b/scripts/maintenance/build-review-candidates.mjs
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+/**
+ * Build the `review_candidates` pool that feeds the volunteer review queues.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The hallucination and scan-quality routes used to select an item by running
+ * `$sample` over `pages` — 19.1M documents — with a predicate no index can
+ * serve (`{'ocr.data': {$regex: '<image-desc'}}` and `{archived_photo: {$exists}}`).
+ * That is a full collection scan on every single item fetch, behind a 15s
+ * `maxDuration`. Both routes returned 504 in production (17-23s), so the two
+ * best queues were unusable while the third — which reads the much smaller
+ * `gallery_images` — kept working. Measured 2026-08-02.
+ *
+ * The fix is architectural, not a tuning knob: precompute a bounded pool the
+ * same way `gallery_images` is a materialized view of `pages.detected_images`,
+ * and let the request path read a small indexed collection.
+ *
+ * WHY PER-BOOK, NOT A GLOBAL SCAN
+ * -------------------------------
+ * We iterate books and query their pages via the {book_id, page_number} index,
+ * so no step ever scans the whole `pages` collection. It also bounds how many
+ * pages any single book contributes (`--per-book`), which matters for the
+ * statistics: an unbounded draw would let one 900-page book dominate the pool
+ * and quietly turn "quality of the corpus" into "quality of that book".
+ *
+ * STRATA
+ * ------
+ * Every candidate carries a `stratum` (language / century / provider). Nothing
+ * reads it yet — the live queues sample at random. It is written now because a
+ * stratified draw cannot be reconstructed after the fact, and the sampled assay
+ * (issue #3560) needs it.
+ *
+ * Usage:
+ *   node scripts/maintenance/build-review-candidates.mjs                 # both queues
+ *   node scripts/maintenance/build-review-candidates.mjs --queue=hallucination
+ *   node scripts/maintenance/build-review-candidates.mjs --target=4000 --per-book=2
+ *   node scripts/maintenance/build-review-candidates.mjs --dry-run
+ */
+
+import { MongoClient } from 'mongodb';
+import {
+  IMAGE_CANDIDATE_PAGE_TYPES,
+  extractImageDescTags,
+  shouldSkipPageByMarkup,
+} from '../lib/image-extraction-filter.mjs';
+
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const hit = args.find(a => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=').slice(1).join('=') : dflt;
+};
+const has = name => args.includes(`--${name}`);
+
+const DRY_RUN = has('dry-run');
+const TARGET = parseInt(flag('target', '4000'), 10);
+const PER_BOOK = parseInt(flag('per-book', '2'), 10);
+const ONLY_QUEUE = flag('queue', null);
+const QUEUES = ONLY_QUEUE ? [ONLY_QUEUE] : ['hallucination', 'scan-quality', 'gallery-quality'];
+
+const VALID_QUEUES = new Set(['hallucination', 'scan-quality', 'gallery-quality']);
+for (const q of QUEUES) {
+  if (!VALID_QUEUES.has(q)) {
+    console.error(`Unknown queue "${q}". Valid: ${[...VALID_QUEUES].join(', ')}`);
+    process.exit(1);
+  }
+}
+
+if (!process.env.MONGODB_URI) {
+  console.error('MONGODB_URI not set. Run with: set -a; source .env.production.local; set +a; node ...');
+  process.exit(1);
+}
+
+/** A build marker so we can retire the previous pool without a window-based
+ *  deleteMany on a shared collection (see CLAUDE.md — delete by marker, never
+ *  by time window). Not derived from Date.now() alone so concurrent builds of
+ *  different queues can't collide. */
+const BUILD_ID = `${new Date().toISOString().replace(/[:.]/g, '-')}-${process.pid}`;
+
+function centuryOf(year) {
+  if (typeof year !== 'number' || !Number.isFinite(year) || year < 800 || year > 2100) return 'unknown';
+  return `${Math.floor(year / 100) + 1}C`;
+}
+
+function providerOf(book) {
+  return (
+    book?.image_source?.provider ||
+    book?.held_by ||
+    (book?.ia_identifier ? 'internet-archive' : null) ||
+    'unknown'
+  );
+}
+
+function stratumOf(book) {
+  return {
+    language: book?.language || 'unknown',
+    century: centuryOf(book?.year),
+    provider: providerOf(book),
+  };
+}
+
+/** Shuffle in place (Fisher-Yates) so a truncated draw isn't just "first N by
+ *  insertion order", which correlates with page number and therefore with
+ *  front-matter. */
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function imageUrlFor(p, bookId) {
+  return (
+    p.archived_photo ||
+    p.photo_original ||
+    p.photo ||
+    `https://images.sourcelibrary.org/archived/${bookId}/${p.page_number}.jpg`
+  );
+}
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+  const pages = db.collection('pages');
+  const candidates = db.collection('review_candidates');
+
+  if (!DRY_RUN) {
+    await candidates.createIndex({ queue: 1, build_id: 1 });
+    await candidates.createIndex({ queue: 1, item_id: 1 }, { unique: true });
+    await candidates.createIndex({ queue: 1, 'stratum.language': 1, 'stratum.century': 1 });
+  }
+
+  // Visible books with OCR, shuffled so a partial run still spans the corpus
+  // rather than marching alphabetically through it.
+  const bookList = await books
+    .find(
+      { visible: true, pages_count: { $gt: 0 } },
+      {
+        projection: {
+          _id: 0, id: 1, title: 1, author: 1, year: 1, language: 1, slug: 1,
+          held_by: 1, ia_identifier: 1, 'image_source.provider': 1, pages_ocr: 1,
+        },
+      },
+    )
+    .toArray();
+  shuffle(bookList);
+  console.log(`[build] ${bookList.length} visible books with pages; target ${TARGET}/queue, max ${PER_BOOK}/book`);
+
+  for (const queue of QUEUES) {
+    const collected = [];
+    let booksScanned = 0;
+
+    // gallery-quality draws from `gallery_images` (207K docs, well indexed)
+    // rather than `pages`. It never 504'd, but `$sample` over that collection
+    // still cost ~8.2s per item, which is its own kind of unusable. Pooling it
+    // here puts all three queues on the same fast read path.
+    if (queue === 'gallery-quality') {
+      const bookById = new Map(bookList.map(b => [b.id, b]));
+      const perBookCount = new Map();
+      const rows = await db
+        .collection('gallery_images')
+        .find(
+          { extracted_url: { $ne: null }, book_visible: true, gallery_quality: { $gte: 0.4 } },
+          {
+            projection: {
+              _id: 0, id: 1, book_id: 1, page_number: 1, extracted_url: 1,
+              thumbnail_url: 1, image_url: 1, description: 1, type: 1,
+              gallery_quality: 1, book_title: 1, book_author: 1, book_year: 1, book_language: 1,
+            },
+          },
+        )
+        .toArray();
+      shuffle(rows);
+
+      for (const g of rows) {
+        if (collected.length >= TARGET) break;
+        const taken = perBookCount.get(g.book_id) ?? 0;
+        if (taken >= PER_BOOK) continue;
+        perBookCount.set(g.book_id, taken + 1);
+
+        const book = bookById.get(g.book_id);
+        collected.push({
+          queue,
+          build_id: BUILD_ID,
+          item_id: String(g.id),
+          book_id: g.book_id,
+          page_id: null,
+          page_number: g.page_number,
+          page_type: null,
+          image_url: g.extracted_url || g.thumbnail_url || g.image_url,
+          page_link: `https://sourcelibrary.org/book/${book?.slug || g.book_id}/page/${g.page_number}`,
+          book: {
+            id: g.book_id, title: g.book_title, author: g.book_author,
+            year: g.book_year, language: g.book_language, slug: book?.slug ?? null,
+          },
+          stratum: stratumOf(book ?? { language: g.book_language, year: g.book_year }),
+          payload: {
+            gallery_image_id: g.id,
+            full_page_url: g.image_url ?? null,
+            description: g.description ?? null,
+            type: g.type ?? null,
+            gallery_quality: g.gallery_quality ?? null,
+          },
+          is_gold: false,
+          gold_answer: null,
+          created_at: new Date(),
+        });
+      }
+      booksScanned = perBookCount.size;
+    }
+
+    for (const book of queue === 'gallery-quality' ? [] : bookList) {
+      if (collected.length >= TARGET) break;
+      booksScanned++;
+
+      let pageDocs;
+      if (queue === 'hallucination') {
+        if (!book.pages_ocr) continue;
+        // Indexed by book_id — never a collection scan. The regex is applied
+        // within one book's pages, which is a handful of documents.
+        pageDocs = await pages
+          .find(
+            { book_id: book.id, 'ocr.data': { $regex: '<image-desc' } },
+            {
+              projection: {
+                _id: 0, id: 1, book_id: 1, page_number: 1, page_type: 1,
+                archived_photo: 1, photo_original: 1, photo: 1, 'ocr.data': 1,
+              },
+              limit: 25,
+            },
+          )
+          .toArray();
+      } else {
+        pageDocs = await pages
+          .find(
+            { book_id: book.id, archived_photo: { $exists: true, $ne: null } },
+            {
+              projection: {
+                _id: 0, id: 1, book_id: 1, page_number: 1, page_type: 1,
+                archived_photo: 1, photo_original: 1, photo: 1, scan_quality: 1,
+              },
+              limit: 25,
+            },
+          )
+          .toArray();
+      }
+
+      if (!pageDocs.length) continue;
+      shuffle(pageDocs);
+
+      let takenFromBook = 0;
+      for (const p of pageDocs) {
+        if (takenFromBook >= PER_BOOK || collected.length >= TARGET) break;
+
+        const pageLink = `https://sourcelibrary.org/book/${book.slug || book.id}/page/${p.page_number}`;
+        const bookMeta = {
+          id: book.id, title: book.title, author: book.author,
+          year: book.year, language: book.language, slug: book.slug,
+        };
+
+        if (queue === 'hallucination') {
+          const ocrData = p.ocr?.data ?? '';
+          // Preserve the original route's semantics: only show pages the
+          // extraction worker would KEEP, so a volunteer's judgment maps onto
+          // a vision call we would otherwise have paid for.
+          const inCandidateType = IMAGE_CANDIDATE_PAGE_TYPES.includes(p.page_type);
+          if (!inCandidateType && shouldSkipPageByMarkup(ocrData)) continue;
+
+          const tags = extractImageDescTags(ocrData);
+          if (tags.length === 0) continue;
+
+          collected.push({
+            queue,
+            build_id: BUILD_ID,
+            item_id: `${p.book_id}:${p.page_number}`,
+            book_id: p.book_id,
+            page_id: p.id ?? null,
+            page_number: p.page_number,
+            page_type: p.page_type ?? null,
+            image_url: imageUrlFor(p, p.book_id),
+            page_link: pageLink,
+            book: bookMeta,
+            stratum: stratumOf(book),
+            payload: {
+              descriptions: tags.map(t => ({
+                type: t.type, significance: t.significance,
+                size: t.size, description: t.description,
+              })),
+            },
+            // Attention-check scaffolding. Items seeded with a known answer are
+            // marked here; nothing sets these yet (see #3560), but the queue
+            // route already refuses to leak the answer to the client.
+            is_gold: false,
+            gold_answer: null,
+            created_at: new Date(),
+          });
+        } else {
+          collected.push({
+            queue,
+            build_id: BUILD_ID,
+            item_id: String(p.id ?? `${p.book_id}:${p.page_number}`),
+            book_id: p.book_id,
+            page_id: p.id ?? null,
+            page_number: p.page_number,
+            page_type: p.page_type ?? null,
+            image_url: imageUrlFor(p, p.book_id),
+            page_link: pageLink,
+            book: bookMeta,
+            stratum: stratumOf(book),
+            payload: { existing_scan_quality: p.scan_quality ?? null },
+            is_gold: false,
+            gold_answer: null,
+            created_at: new Date(),
+          });
+        }
+        takenFromBook++;
+      }
+
+      if (booksScanned % 500 === 0) {
+        console.log(`[${queue}] ${booksScanned} books scanned, ${collected.length}/${TARGET} collected`);
+      }
+    }
+
+    console.log(`[${queue}] collected ${collected.length} candidates from ${booksScanned} books`);
+
+    const strata = {};
+    for (const c of collected) {
+      const k = `${c.stratum.language}/${c.stratum.century}`;
+      strata[k] = (strata[k] || 0) + 1;
+    }
+    const top = Object.entries(strata).sort((a, b) => b[1] - a[1]).slice(0, 8);
+    console.log(`[${queue}] top strata: ${top.map(([k, n]) => `${k}:${n}`).join('  ')}`);
+
+    if (DRY_RUN) {
+      console.log(`[${queue}] --dry-run, nothing written`);
+      continue;
+    }
+    if (collected.length === 0) {
+      console.log(`[${queue}] nothing collected — leaving the existing pool in place`);
+      continue;
+    }
+
+    // Insert the new pool, THEN retire the old one by marker. In this order a
+    // crash mid-run leaves both pools live (harmless duplicates) rather than
+    // an empty queue.
+    let inserted = 0;
+    for (let i = 0; i < collected.length; i += 500) {
+      const batch = collected.slice(i, i + 500);
+      try {
+        const res = await candidates.insertMany(batch, { ordered: false });
+        inserted += res.insertedCount;
+      } catch (err) {
+        // Duplicate item_id against a still-live previous pool is expected and fine.
+        inserted += err?.result?.nInserted ?? err?.insertedCount ?? 0;
+        const dupes = (err?.writeErrors ?? []).filter(e => e.code === 11000).length;
+        const other = (err?.writeErrors ?? []).filter(e => e.code !== 11000);
+        if (other.length) console.warn(`[${queue}] ${other.length} non-duplicate write errors, first:`, other[0]?.errmsg);
+        if (dupes) console.log(`[${queue}] ${dupes} already in pool, kept`);
+      }
+    }
+
+    const retired = await candidates.deleteMany({ queue, build_id: { $ne: BUILD_ID } });
+    const total = await candidates.countDocuments({ queue });
+    console.log(`[${queue}] inserted ${inserted}, retired ${retired.deletedCount} from prior builds, pool now ${total}`);
+  }
+
+  await client.close();
+  console.log('[build] done');
+}
+
+main().catch(err => {
+  console.error('[build] failed:', err);
+  process.exit(1);
+});

--- a/src/app/api/review/gallery-quality/next/route.ts
+++ b/src/app/api/review/gallery-quality/next/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getReadDb } from '@/lib/mongodb';
-import { supabaseAdmin } from '@/lib/supabase';
+import { nextCandidate } from '@/lib/review-candidates';
 
 export const maxDuration = 15;
 
@@ -8,12 +7,14 @@ export const maxDuration = 15;
  * GET /api/review/gallery-quality/next?volunteer_id=<uuid>
  *
  * Returns one unrated extracted image for the gallery-quality queue.
- * Biased toward the contested 0.5-0.85 quality band where the display
- * threshold matters most. The 0.7 display cutoff makes the band on either
- * side the highest-leverage place for human calibration.
+ * The pool is built from images at gallery_quality >= 0.4, capped per book so
+ * one heavily-illustrated volume can't dominate the sample. That selection now
+ * lives in the builder (scripts/maintenance/build-review-candidates.mjs)
+ * rather than in the request path.
  *
- * Item shape: { item_id, image_url, book, page_number, description, type,
- *   gallery_quality, ... }
+ * This route never 504'd, but `$sample` over `gallery_images` (207K docs) cost
+ * ~8.2s per item, which is its own kind of unusable. It now reads the pooled
+ * `review_candidates` collection like the other two queues.
  */
 export async function GET(request: NextRequest) {
   const volunteerId = request.nextUrl.searchParams.get('volunteer_id');
@@ -21,85 +22,27 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'volunteer_id required' }, { status: 400 });
   }
 
-  const ratedItemIds = new Set<string>();
-  if (supabaseAdmin) {
-    const { data } = await supabaseAdmin
-      .from('volunteer_ratings')
-      .select('item_id')
-      .eq('queue', 'gallery-quality')
-      .eq('volunteer_id', volunteerId)
-      .limit(5000);
-    if (data) for (const row of data) ratedItemIds.add(row.item_id as string);
+  const result = await nextCandidate('gallery-quality', volunteerId);
+  if (!result.item) {
+    return NextResponse.json({ item: null, message: result.message });
   }
 
-  const db = await getReadDb();
+  const c = result.item;
+  const p = c.payload ?? {};
 
-  // 70% of samples from the contested band (0.5-0.85), 30% from the full range
-  // so we still calibrate the high end occasionally.
-  const inContestedBand = Math.random() < 0.7;
-  const match: Record<string, unknown> = {
-    extracted_url: { $ne: null },
-    book_visible: true,
-  };
-  if (inContestedBand) {
-    match.gallery_quality = { $gte: 0.5, $lt: 0.85 };
-  } else {
-    match.gallery_quality = { $gte: 0.4 };
-  }
-
-  const candidates = await db.collection('gallery_images').aggregate([
-    { $match: match },
-    { $sample: { size: 30 } },
-    {
-      $project: {
-        _id: 0,
-        id: 1,
-        book_id: 1,
-        page_number: 1,
-        extracted_url: 1,
-        thumbnail_url: 1,
-        image_url: 1,
-        description: 1,
-        type: 1,
-        gallery_quality: 1,
-        book_title: 1,
-        book_author: 1,
-        book_year: 1,
-        book_language: 1,
-      },
+  return NextResponse.json({
+    item: {
+      item_id: c.item_id,
+      gallery_image_id: p.gallery_image_id ?? c.item_id,
+      book_id: c.book_id,
+      page_number: c.page_number,
+      image_url: c.image_url,
+      full_page_url: p.full_page_url ?? null,
+      page_link: c.page_link,
+      description: p.description ?? null,
+      type: p.type ?? null,
+      gallery_quality: p.gallery_quality ?? null,
+      book: c.book,
     },
-  ]).toArray();
-
-  for (const g of candidates) {
-    const itemId = String(g.id);
-    if (ratedItemIds.has(itemId)) continue;
-
-    // Pull the book slug for the page link
-    const book = await db
-      .collection('books')
-      .findOne({ id: g.book_id }, { projection: { _id: 0, slug: 1 } });
-
-    return NextResponse.json({
-      item: {
-        item_id: itemId,
-        gallery_image_id: g.id,
-        book_id: g.book_id,
-        page_number: g.page_number,
-        image_url: g.extracted_url || g.thumbnail_url || g.image_url,
-        full_page_url: g.image_url,
-        page_link: `https://sourcelibrary.org/book/${book?.slug || g.book_id}/page/${g.page_number}`,
-        description: g.description ?? null,
-        type: g.type ?? null,
-        gallery_quality: g.gallery_quality ?? null,
-        book: {
-          title: g.book_title,
-          author: g.book_author,
-          year: g.book_year,
-          language: g.book_language,
-        },
-      },
-    });
-  }
-
-  return NextResponse.json({ item: null, message: 'No unrated items in this sample — try again.' });
+  });
 }

--- a/src/app/api/review/hallucination/next/route.ts
+++ b/src/app/api/review/hallucination/next/route.ts
@@ -1,26 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getReadDb } from '@/lib/mongodb';
-import { supabaseAdmin } from '@/lib/supabase';
-import {
-  IMAGE_CANDIDATE_PAGE_TYPES,
-  extractImageDescTags,
-  shouldSkipPageByMarkup,
-} from '@/lib/image-extraction-filter';
+import { nextCandidate } from '@/lib/review-candidates';
 
 export const maxDuration = 15;
 
 /**
  * GET /api/review/hallucination/next?volunteer_id=<uuid>
  *
- * Returns the next unrated page from the hallucination-check queue.
- * The queue consists of pages that:
- *   - Have <image-desc> markup in OCR
- *   - Would NOT be skipped by the trivial-markup filter (so they're real
- *     candidates for vision extraction — we want humans to confirm the
- *     description matches reality before we spend the call).
- *   - Are from books the user hasn't seen in this queue.
+ * Returns the next unrated page from the hallucination-check queue: a page
+ * whose OCR claims an illustration, which the extraction worker would keep.
+ * The volunteer confirms the description matches the image before we spend a
+ * vision call on it.
  *
- * Response: { item } with image_url, page metadata, OCR descriptions, etc.
+ * Items are served from the pooled `review_candidates` collection. This route
+ * previously ran `$sample` over `pages` (19.1M docs) with a regex on
+ * `ocr.data` — an unindexable full collection scan that returned 504 in
+ * production. See src/lib/review-candidates.ts.
  */
 export async function GET(request: NextRequest) {
   const volunteerId = request.nextUrl.searchParams.get('volunteer_id');
@@ -28,92 +22,25 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'volunteer_id required' }, { status: 400 });
   }
 
-  // Pull list of item_ids this volunteer has already rated in this queue.
-  const ratedItemIds = new Set<string>();
-  if (supabaseAdmin) {
-    const { data } = await supabaseAdmin
-      .from('volunteer_ratings')
-      .select('item_id')
-      .eq('queue', 'hallucination')
-      .eq('volunteer_id', volunteerId)
-      .limit(2000);
-    if (data) for (const row of data) ratedItemIds.add(row.item_id as string);
+  const result = await nextCandidate('hallucination', volunteerId);
+  if (!result.item) {
+    return NextResponse.json({ item: null, message: result.message });
   }
 
-  const db = await getReadDb();
+  const c = result.item;
+  const descriptions =
+    (c.payload?.descriptions as Array<Record<string, unknown>> | undefined) ?? [];
 
-  // Random-sample candidate pages: visible books, pages with <image-desc>
-  // markup, page_type either a candidate type (would extract) or non-candidate
-  // type with markup. Use $sample for randomness across the corpus.
-  // Over-fetch since we'll discard ones that fail the skip filter or are
-  // already rated.
-  const pipeline: Record<string, unknown>[] = [
-    { $match: { 'ocr.data': { $regex: '<image-desc', $options: '' } } },
-    { $sample: { size: 60 } },
-    {
-      $project: {
-        _id: 0,
-        book_id: 1,
-        id: 1,
-        page_number: 1,
-        page_type: 1,
-        archived_photo: 1,
-        photo_original: 1,
-        photo: 1,
-        cropped_photo: 1,
-        'ocr.data': 1,
-      },
+  return NextResponse.json({
+    item: {
+      item_id: c.item_id,
+      book_id: c.book_id,
+      page_number: c.page_number,
+      page_type: c.page_type,
+      image_url: c.image_url,
+      page_link: c.page_link,
+      book: c.book,
+      descriptions,
     },
-  ];
-
-  const candidates = await db.collection('pages').aggregate(pipeline).toArray();
-
-  for (const p of candidates) {
-    const itemId = `${p.book_id}:${p.page_number}`;
-    if (ratedItemIds.has(itemId)) continue;
-
-    // Only show pages the worker would KEEP. Pages in IMAGE_CANDIDATE_PAGE_TYPES
-    // always extract regardless of markup; for others, apply the skip filter.
-    const ocrData = p.ocr?.data ?? '';
-    const inCandidateType = IMAGE_CANDIDATE_PAGE_TYPES.includes(p.page_type);
-    const wouldSkip = !inCandidateType && shouldSkipPageByMarkup(ocrData);
-    if (wouldSkip) continue;
-
-    const tags = extractImageDescTags(ocrData);
-    if (tags.length === 0) continue;
-
-    // Pull lightweight book metadata.
-    const book = await db
-      .collection('books')
-      .findOne(
-        { id: p.book_id },
-        { projection: { _id: 0, id: 1, title: 1, author: 1, year: 1, language: 1, slug: 1 } },
-      );
-
-    const imgUrl =
-      p.archived_photo ||
-      p.photo_original ||
-      p.photo ||
-      `https://images.sourcelibrary.org/archived/${p.book_id}/${p.page_number}.jpg`;
-
-    return NextResponse.json({
-      item: {
-        item_id: itemId,
-        book_id: p.book_id,
-        page_number: p.page_number,
-        page_type: p.page_type ?? null,
-        image_url: imgUrl,
-        page_link: `https://sourcelibrary.org/book/${book?.slug || p.book_id}/page/${p.page_number}`,
-        book: book ?? null,
-        descriptions: tags.map(t => ({
-          type: t.type,
-          significance: t.significance,
-          size: t.size,
-          description: t.description,
-        })),
-      },
-    });
-  }
-
-  return NextResponse.json({ item: null, message: 'No unrated items in this sample — try again.' });
+  });
 }

--- a/src/app/api/review/scan-quality/next/route.ts
+++ b/src/app/api/review/scan-quality/next/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getReadDb } from '@/lib/mongodb';
-import { supabaseAdmin } from '@/lib/supabase';
+import { nextCandidate } from '@/lib/review-candidates';
 
 export const maxDuration = 15;
 
@@ -9,11 +8,12 @@ export const maxDuration = 15;
  *
  * Returns one unrated full-page scan for the scan-quality queue.
  * Per CLAUDE.md, scan_quality is currently only computed on illustration-
- * candidate pages (~0.2% of pages). Human ratings here generate ground-
- * truth labels we can use to train a classifier on the rest.
+ * candidate pages (~0.2% of pages). Human ratings here generate ground-truth
+ * labels we can use to train a classifier on the rest.
  *
- * Sampling strategy: random pages from visible books, weighted toward pages
- * that don't already have a scan_quality classification.
+ * Items are served from the pooled `review_candidates` collection. This route
+ * previously ran `$sample` over `pages` (19.1M docs), a full collection scan
+ * that returned 504 in production. See src/lib/review-candidates.ts.
  */
 export async function GET(request: NextRequest) {
   const volunteerId = request.nextUrl.searchParams.get('volunteer_id');
@@ -21,64 +21,24 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'volunteer_id required' }, { status: 400 });
   }
 
-  const ratedItemIds = new Set<string>();
-  if (supabaseAdmin) {
-    const { data } = await supabaseAdmin
-      .from('volunteer_ratings')
-      .select('item_id')
-      .eq('queue', 'scan-quality')
-      .eq('volunteer_id', volunteerId)
-      .limit(5000);
-    if (data) for (const row of data) ratedItemIds.add(row.item_id as string);
+  const result = await nextCandidate('scan-quality', volunteerId);
+  if (!result.item) {
+    return NextResponse.json({ item: null, message: result.message });
   }
 
-  const db = await getReadDb();
+  const c = result.item;
 
-  const candidates = await db.collection('pages').aggregate([
-    { $match: { archived_photo: { $exists: true, $ne: null } } },
-    { $sample: { size: 30 } },
-    {
-      $project: {
-        _id: 0,
-        id: 1,
-        book_id: 1,
-        page_number: 1,
-        page_type: 1,
-        archived_photo: 1,
-        photo_original: 1,
-        photo: 1,
-        scan_quality: 1,
-      },
+  return NextResponse.json({
+    item: {
+      item_id: c.item_id,
+      page_id: c.page_id,
+      book_id: c.book_id,
+      page_number: c.page_number,
+      page_type: c.page_type,
+      image_url: c.image_url,
+      page_link: c.page_link,
+      existing_scan_quality: c.payload?.existing_scan_quality ?? null,
+      book: c.book,
     },
-  ]).toArray();
-
-  for (const p of candidates) {
-    const itemId = String(p.id);
-    if (ratedItemIds.has(itemId)) continue;
-
-    // Only include books that are visible (don't show users hidden material)
-    const book = await db
-      .collection('books')
-      .findOne(
-        { id: p.book_id, visible: true },
-        { projection: { _id: 0, id: 1, title: 1, author: 1, year: 1, language: 1, slug: 1 } },
-      );
-    if (!book) continue;
-
-    return NextResponse.json({
-      item: {
-        item_id: itemId,
-        page_id: p.id,
-        book_id: p.book_id,
-        page_number: p.page_number,
-        page_type: p.page_type ?? null,
-        image_url: p.archived_photo || p.photo_original || p.photo,
-        page_link: `https://sourcelibrary.org/book/${book.slug || p.book_id}/page/${p.page_number}`,
-        existing_scan_quality: p.scan_quality ?? null,
-        book,
-      },
-    });
-  }
-
-  return NextResponse.json({ item: null, message: 'No unrated items in this sample — try again.' });
+  });
 }

--- a/src/app/api/review/stats/route.ts
+++ b/src/app/api/review/stats/route.ts
@@ -8,6 +8,10 @@ export const maxDuration = 5;
  *
  * Returns lifetime totals and (if volunteer_id provided) per-volunteer
  * totals for the landing-page display.
+ *
+ * Counts filter `rating IS NOT NULL`: a volunteer may submit a note without a
+ * rating, and those rows are feedback, not judgments. Including them would
+ * inflate the rating count with things nobody rated.
  */
 export async function GET(request: NextRequest) {
   if (!supabaseAdmin) {
@@ -18,16 +22,23 @@ export async function GET(request: NextRequest) {
 
   const { count: total } = await supabaseAdmin
     .from('volunteer_ratings')
-    .select('id', { count: 'exact', head: true });
+    .select('id', { count: 'exact', head: true })
+    .not('rating', 'is', null);
+
+  const { count: notes } = await supabaseAdmin
+    .from('volunteer_ratings')
+    .select('id', { count: 'exact', head: true })
+    .not('note', 'is', null);
 
   let mine: number | null = null;
   if (volunteerId && /^[0-9a-f-]{36}$/i.test(volunteerId)) {
     const { count } = await supabaseAdmin
       .from('volunteer_ratings')
       .select('id', { count: 'exact', head: true })
-      .eq('volunteer_id', volunteerId);
+      .eq('volunteer_id', volunteerId)
+      .not('rating', 'is', null);
     mine = count ?? 0;
   }
 
-  return NextResponse.json({ total: total ?? 0, mine });
+  return NextResponse.json({ total: total ?? 0, notes: notes ?? 0, mine });
 }

--- a/src/app/api/review/submit/route.ts
+++ b/src/app/api/review/submit/route.ts
@@ -75,39 +75,11 @@ export async function POST(request: NextRequest) {
   };
 
   const { error } = await supabaseAdmin.from('volunteer_ratings').insert(row);
-  if (!error) return NextResponse.json({ ok: true });
 
-  /* COMPAT SHIM — remove once 20260802000000_volunteer_ratings_note.sql is
-     applied to production.
-     Merging a PR here does not deploy, and this DDL is applied by hand, so the
-     code and the schema can go live in either order. Without this branch, the
-     window between them fails EVERY submission — turning a feature addition
-     into an outage on the exact surface we are trying to revive.
-     The fallback keeps the note in `detail` (jsonb, already present) so no
-     volunteer's words are lost while the column is missing. A note-only
-     submission genuinely cannot be stored, because `rating` is still NOT NULL —
-     we say so rather than inventing a rating, which would corrupt the
-     distribution the ratings exist to measure. */
-  const missingColumn = error.code === 'PGRST204' || error.code === '42703';
-  if (missingColumn && note !== null) {
-    if (rating === null) {
-      console.error('[review/submit] note-only submission rejected — run the volunteer_ratings note migration');
-      return NextResponse.json(
-        { error: 'notes are not enabled yet — please include a rating' },
-        { status: 503 },
-      );
-    }
-    console.warn('[review/submit] `note` column missing — storing note in detail. Run the migration.');
-    const { error: retryError } = await supabaseAdmin.from('volunteer_ratings').insert({
-      ...row,
-      note: undefined,
-      detail: { ...(typeof detail === 'object' && detail !== null ? detail : {}), note },
-    });
-    if (!retryError) return NextResponse.json({ ok: true, noteStoredInDetail: true });
-    console.error('[review/submit] retry insert failed:', retryError);
+  if (error) {
+    console.error('[review/submit] insert failed:', error);
     return NextResponse.json({ error: 'insert failed' }, { status: 500 });
   }
 
-  console.error('[review/submit] insert failed:', error);
-  return NextResponse.json({ error: 'insert failed' }, { status: 500 });
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/review/submit/route.ts
+++ b/src/app/api/review/submit/route.ts
@@ -5,14 +5,21 @@ import { isValidRating, QUEUE_KEYS } from '@/lib/review-queue';
 export const maxDuration = 5;
 
 const ALLOWED_QUEUES = new Set<string>(QUEUE_KEYS);
+const MAX_NOTE_LENGTH = 4000;
 
 /**
  * POST /api/review/submit
  *
- * Body: { queue, item_id, rating, detail?, volunteer_id, volunteer_label? }
+ * Body: { queue, item_id, rating?, note?, detail?, volunteer_id, volunteer_label? }
  *
- * Records one volunteer rating. Anonymous (no auth). volunteer_id is the
+ * Records one volunteer judgment. Anonymous (no auth). volunteer_id is the
  * per-browser uuid the client generates.
+ *
+ * `rating` and `note` are independently optional, but a submission must carry
+ * at least one. A note WITHOUT a rating is deliberate and valid: a volunteer
+ * who can't honestly pick any button still needs somewhere to say why, and
+ * pushing them into a button to satisfy a NOT NULL would corrupt the very
+ * distribution the buttons exist to measure.
  */
 export async function POST(request: NextRequest) {
   let body: Record<string, unknown>;
@@ -24,10 +31,15 @@ export async function POST(request: NextRequest) {
 
   const queue = String(body.queue ?? '').trim();
   const itemId = String(body.item_id ?? '').trim();
-  const rating = String(body.rating ?? '').trim();
   const volunteerId = String(body.volunteer_id ?? '').trim();
   const volunteerLabel = body.volunteer_label ? String(body.volunteer_label).slice(0, 80) : null;
   const detail = body.detail ?? null;
+
+  const rawRating = body.rating == null ? '' : String(body.rating).trim();
+  const rating = rawRating === '' ? null : rawRating;
+
+  const rawNote = body.note == null ? '' : String(body.note);
+  const note = rawNote.trim() === '' ? null : rawNote.trim().slice(0, MAX_NOTE_LENGTH);
 
   if (!ALLOWED_QUEUES.has(queue)) {
     return NextResponse.json({ error: 'unknown queue' }, { status: 400 });
@@ -35,8 +47,11 @@ export async function POST(request: NextRequest) {
   if (!itemId || itemId.length > 200) {
     return NextResponse.json({ error: 'invalid item_id' }, { status: 400 });
   }
-  if (!isValidRating(queue, rating)) {
+  if (rating !== null && !isValidRating(queue, rating)) {
     return NextResponse.json({ error: 'invalid rating for this queue' }, { status: 400 });
+  }
+  if (rating === null && note === null) {
+    return NextResponse.json({ error: 'a rating or a note is required' }, { status: 400 });
   }
   if (!/^[0-9a-f-]{36}$/i.test(volunteerId)) {
     return NextResponse.json({ error: 'invalid volunteer_id' }, { status: 400 });
@@ -48,20 +63,51 @@ export async function POST(request: NextRequest) {
 
   const ua = request.headers.get('user-agent')?.slice(0, 240) ?? null;
 
-  const { error } = await supabaseAdmin.from('volunteer_ratings').insert({
+  const row = {
     queue,
     item_id: itemId,
     rating,
+    note,
     detail,
     volunteer_id: volunteerId,
     volunteer_label: volunteerLabel,
     user_agent: ua,
-  });
+  };
 
-  if (error) {
-    console.error('[review/submit] insert failed:', error);
+  const { error } = await supabaseAdmin.from('volunteer_ratings').insert(row);
+  if (!error) return NextResponse.json({ ok: true });
+
+  /* COMPAT SHIM — remove once 20260802000000_volunteer_ratings_note.sql is
+     applied to production.
+     Merging a PR here does not deploy, and this DDL is applied by hand, so the
+     code and the schema can go live in either order. Without this branch, the
+     window between them fails EVERY submission — turning a feature addition
+     into an outage on the exact surface we are trying to revive.
+     The fallback keeps the note in `detail` (jsonb, already present) so no
+     volunteer's words are lost while the column is missing. A note-only
+     submission genuinely cannot be stored, because `rating` is still NOT NULL —
+     we say so rather than inventing a rating, which would corrupt the
+     distribution the ratings exist to measure. */
+  const missingColumn = error.code === 'PGRST204' || error.code === '42703';
+  if (missingColumn && note !== null) {
+    if (rating === null) {
+      console.error('[review/submit] note-only submission rejected — run the volunteer_ratings note migration');
+      return NextResponse.json(
+        { error: 'notes are not enabled yet — please include a rating' },
+        { status: 503 },
+      );
+    }
+    console.warn('[review/submit] `note` column missing — storing note in detail. Run the migration.');
+    const { error: retryError } = await supabaseAdmin.from('volunteer_ratings').insert({
+      ...row,
+      note: undefined,
+      detail: { ...(typeof detail === 'object' && detail !== null ? detail : {}), note },
+    });
+    if (!retryError) return NextResponse.json({ ok: true, noteStoredInDetail: true });
+    console.error('[review/submit] retry insert failed:', retryError);
     return NextResponse.json({ error: 'insert failed' }, { status: 500 });
   }
 
-  return NextResponse.json({ ok: true });
+  console.error('[review/submit] insert failed:', error);
+  return NextResponse.json({ error: 'insert failed' }, { status: 500 });
 }

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -202,7 +202,11 @@ export default async function ParticipatePage() {
             </p>
           </Link>
 
-          <Link href="/gallery" className="group p-4 rounded-xl bg-white border border-border-light hover:border-accent-rust/40 hover:shadow-sm transition-all text-center">
+          {/* Points at the rating QUEUE, not the public gallery. This card
+              described /review/gallery-quality but linked to /gallery — which
+              has no rating control — so the one card on the site that pointed
+              at volunteer work sent people somewhere they could not do it. */}
+          <Link href="/review/gallery-quality" className="group p-4 rounded-xl bg-white border border-border-light hover:border-accent-rust/40 hover:shadow-sm transition-all text-center">
             <div className="w-9 h-9 mx-auto mb-2 rounded-lg bg-accent-rust/10 flex items-center justify-center">
               <svg className="w-5 h-5 text-accent-rust" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
@@ -210,7 +214,7 @@ export default async function ParticipatePage() {
             </div>
             <h3 className="text-sm font-semibold text-primary mb-0.5 group-hover:text-accent-rust transition-colors">Rate illustrations</h3>
             <p className="text-xs text-muted leading-snug">
-              Browse the gallery and rate image quality. Your ratings help curate the collection.
+              A few seconds each: does this plate belong in the gallery? Keyboard-driven, no signup.
             </p>
           </Link>
 

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -99,9 +99,10 @@ export default function ReviewLandingPage() {
           our filter rules and quality signals. Your ratings are stored only as a per-browser ID — no PII.
         </p>
         <p>
-          Built as an experiment in collaborative curation. Feedback?{' '}
-          <a href="mailto:derek@playpowerlabs.com" className="text-accent-rust hover:underline">
-            Email Derek
+          Every queue also has a free-text box: if you can see something the buttons can&apos;t
+          express, write it there. Those notes are read.{' '}
+          <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:underline">
+            Or email us
           </a>
           .
         </p>

--- a/src/components/contribute/VolunteerForm.tsx
+++ b/src/components/contribute/VolunteerForm.tsx
@@ -56,10 +56,26 @@ export default function VolunteerForm() {
 
   if (status === 'success') {
     return (
+      /* Do not make this a dead end again. Before 2026-08-02 this screen said
+         "we'll be in touch" and offered no next action, so 132 people signed up
+         and none of them ever reached the review queues — which were live and
+         working the whole time. Any rewrite of this screen must still hand the
+         volunteer something to do in the next thirty seconds. */
       <div className="bg-green-50 border border-green-200 rounded-xl p-8 text-center">
         <h3 className="text-xl font-semibold text-green-900 mb-2">Thank you!</h3>
-        <p className="text-green-700">
-          We&apos;ll be in touch soon. In the meantime, feel free to open any book and start reading. Every correction and annotation helps.
+        <p className="text-green-700 mb-6">
+          We read every one of these, and we&apos;ll write to you about the work that fits what you
+          told us. You don&apos;t have to wait for that to start.
+        </p>
+        <a
+          href="/review"
+          className="inline-block bg-green-800 text-white py-3 px-7 rounded-full hover:bg-green-900 transition-colors text-base font-medium"
+        >
+          Help check a few pages now &rarr;
+        </a>
+        <p className="text-sm text-green-700 mt-4">
+          A few seconds each, no signup. Or just{' '}
+          <a href="/" className="underline hover:text-green-900">open a book and read</a>.
         </p>
       </div>
     );

--- a/src/components/review/GalleryQualityReview.tsx
+++ b/src/components/review/GalleryQualityReview.tsx
@@ -78,6 +78,10 @@ export default function GalleryQualityReview() {
       onRetry={() => q.fetchNext(q.volunteerId)}
       body={body}
       submitting={q.submitting}
+      note={q.note}
+      onNoteChange={q.setNote}
+      onNoteSubmit={q.submitNote}
+      noteSaved={q.noteSaved}
     />
   );
 }

--- a/src/components/review/HallucinationReview.tsx
+++ b/src/components/review/HallucinationReview.tsx
@@ -94,6 +94,10 @@ export default function HallucinationReview() {
       onRetry={() => q.fetchNext(q.volunteerId)}
       body={body}
       submitting={q.submitting}
+      note={q.note}
+      onNoteChange={q.setNote}
+      onNoteSubmit={q.submitNote}
+      noteSaved={q.noteSaved}
     />
   );
 }

--- a/src/components/review/QueueShell.tsx
+++ b/src/components/review/QueueShell.tsx
@@ -6,8 +6,13 @@ import type { RatingOption } from '@/lib/review-queue';
 
 /**
  * Shared shell for all rating queues: sticky header (queue name, session
- * counter, keyboard cheatsheet), main body, rating panel. Each queue
- * supplies its own item-rendering content via `body` and rating handlers.
+ * counter, keyboard cheatsheet), main body, rating panel, and the note box.
+ * Each queue supplies its own item-rendering content via `body` and handlers.
+ *
+ * The note box lives HERE, not in the individual queues, so that every queue
+ * — including any added later — has a way to leave qualitative feedback by
+ * construction. A volunteer who can see something our four buttons can't
+ * express should never have to email us about it.
  */
 export function QueueShell(props: {
   queueTitle: string;
@@ -21,8 +26,16 @@ export function QueueShell(props: {
   onRetry: () => void;
   body: ReactNode | null;
   submitting: boolean;
+  note: string;
+  onNoteChange: (v: string) => void;
+  onNoteSubmit: () => void;
+  noteSaved: boolean;
 }) {
-  const { queueTitle, question, ratings, sessionCount, loading, error, onRate, onSkip, onRetry, body, submitting } = props;
+  const {
+    queueTitle, question, ratings, sessionCount, loading, error,
+    onRate, onSkip, onRetry, body, submitting,
+    note, onNoteChange, onNoteSubmit, noteSaved,
+  } = props;
   return (
     <main className="min-h-screen bg-stone-50">
       <header className="border-b border-stone-200 bg-white sticky top-0 z-10">
@@ -87,6 +100,34 @@ export function QueueShell(props: {
                 <kbd className="px-1.5 py-0.5 bg-stone-100 border border-stone-300 rounded text-xs mr-1">Space</kbd>
                 Skip (don't rate)
               </button>
+
+              <div className="border-t border-stone-200 pt-4">
+                <label htmlFor="review-note" className="block text-sm font-medium text-stone-700">
+                  Anything the buttons can't say?
+                </label>
+                <p className="text-xs text-stone-500 mt-0.5 mb-2">
+                  Optional. Sent with your rating — or on its own if none of the options is right.
+                </p>
+                <textarea
+                  id="review-note"
+                  value={note}
+                  onChange={e => onNoteChange(e.target.value)}
+                  rows={3}
+                  maxLength={4000}
+                  placeholder="e.g. not a hallucination — it's bleed-through from the facing leaf"
+                  className="w-full px-3 py-2 border border-stone-300 rounded-md text-sm text-stone-900 bg-white resize-y focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+                />
+                <div className="flex items-center gap-3 mt-2">
+                  <button
+                    onClick={onNoteSubmit}
+                    disabled={submitting || note.trim().length === 0}
+                    className="text-sm px-3 py-1.5 rounded-md border border-stone-300 text-stone-700 hover:border-stone-400 disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Send note only
+                  </button>
+                  {noteSaved && <span className="text-sm text-green-700">Note saved — thank you.</span>}
+                </div>
+              </div>
             </div>
           </div>
         )}

--- a/src/components/review/ScanQualityReview.tsx
+++ b/src/components/review/ScanQualityReview.tsx
@@ -71,6 +71,10 @@ export default function ScanQualityReview() {
       onRetry={() => q.fetchNext(q.volunteerId)}
       body={body}
       submitting={q.submitting}
+      note={q.note}
+      onNoteChange={q.setNote}
+      onNoteSubmit={q.submitNote}
+      noteSaved={q.noteSaved}
     />
   );
 }

--- a/src/components/review/useReviewQueue.ts
+++ b/src/components/review/useReviewQueue.ts
@@ -8,11 +8,16 @@ export type QueueItem = { item_id: string; page_link?: string };
 
 /**
  * Shared rating-state hook for review queues. Handles volunteer ID,
- * fetching the next item, submitting a rating, keyboard shortcuts,
- * session counter, and error state.
+ * fetching the next item, submitting a rating, qualitative notes, keyboard
+ * shortcuts, session counter, and error state.
  *
  * Each queue passes the queue slug + a function to derive the `detail`
  * jsonb payload from the current item.
+ *
+ * NOTES: every queue can carry free text. The note travels with the rating
+ * when there is one, and can be sent alone when the volunteer has something
+ * to say but no honest button to press. Rating buttons are the cheap signal;
+ * the note is where a specialist tells us the thing we didn't know to ask.
  */
 export function useReviewQueue<T extends QueueItem>(opts: {
   queue: string;
@@ -29,8 +34,14 @@ export function useReviewQueue<T extends QueueItem>(opts: {
   const [sessionCount, setSessionCount] = useState(0);
   const [streak, setStreak] = useState<{ rating: string; at: number } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [note, setNote] = useState('');
+  const [noteSaved, setNoteSaved] = useState(false);
   const itemRef = useRef<T | null>(null);
   itemRef.current = item;
+  // Read inside submit() without making every keystroke re-create the handler
+  // (which would tear down and rebuild the keydown listener on every letter).
+  const noteRef = useRef('');
+  noteRef.current = note;
 
   const fetchNext = useCallback(
     async (id: string) => {
@@ -60,28 +71,41 @@ export function useReviewQueue<T extends QueueItem>(opts: {
     fetchNext(id);
   }, [fetchNext]);
 
-  const submit = useCallback(
-    async (rating: string) => {
+  /** Post one judgment. `rating: null` means "note only" — the server accepts
+   *  it as long as the note is non-empty. Advances to the next item unless
+   *  `advance` is false (used when saving a note without moving on). */
+  const post = useCallback(
+    async (rating: string | null, noteText: string, advance: boolean) => {
       const current = itemRef.current;
-      if (!current || submitting || !volunteerId) return;
+      if (!current || submitting || !volunteerId) return false;
       setSubmitting(true);
       try {
-        await fetch('/api/review/submit', {
+        const res = await fetch('/api/review/submit', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             queue,
             item_id: current.item_id,
             rating,
+            note: noteText.trim() || null,
             volunteer_id: volunteerId,
             detail: itemToDetail?.(current) ?? null,
           }),
         });
-        setSessionCount(c => c + 1);
-        setStreak({ rating, at: Date.now() });
-        fetchNext(volunteerId);
+        if (!res.ok) {
+          setError('Submit failed — try again.');
+          return false;
+        }
+        if (rating) {
+          setSessionCount(c => c + 1);
+          setStreak({ rating, at: Date.now() });
+        }
+        setNote('');
+        if (advance) fetchNext(volunteerId);
+        return true;
       } catch {
         setError('Submit failed — try again.');
+        return false;
       } finally {
         setSubmitting(false);
       }
@@ -89,7 +113,23 @@ export function useReviewQueue<T extends QueueItem>(opts: {
     [submitting, volunteerId, fetchNext, queue, itemToDetail],
   );
 
+  const submit = useCallback(
+    (rating: string) => post(rating, noteRef.current, true),
+    [post],
+  );
+
+  /** Send free text without rating — for when none of the buttons is honest. */
+  const submitNote = useCallback(async () => {
+    if (!noteRef.current.trim()) return;
+    const ok = await post(null, noteRef.current, false);
+    if (ok) {
+      setNoteSaved(true);
+      window.setTimeout(() => setNoteSaved(false), 2500);
+    }
+  }, [post]);
+
   const skipItem = useCallback(() => {
+    setNote('');
     if (volunteerId) fetchNext(volunteerId);
   }, [volunteerId, fetchNext]);
 
@@ -117,5 +157,9 @@ export function useReviewQueue<T extends QueueItem>(opts: {
     return () => window.removeEventListener('keydown', onKey);
   }, [submit, skipItem, ratings]);
 
-  return { volunteerId, item, loading, submitting, sessionCount, streak, error, submit, skipItem, fetchNext, ratings };
+  return {
+    volunteerId, item, loading, submitting, sessionCount, streak, error,
+    submit, skipItem, fetchNext, ratings,
+    note, setNote, submitNote, noteSaved,
+  };
 }

--- a/src/lib/footer-nav.ts
+++ b/src/lib/footer-nav.ts
@@ -51,6 +51,7 @@ export const FOOTER_NAV_COLUMNS: ReadonlyArray<FooterNavColumn> = [
     links: [
       { key: 'libraries', href: '/libraries' },
       { key: 'contribute', href: '/contribute' },
+      { key: 'checkPages', href: '/review' },
       { key: 'support', href: '/support' },
       { key: 'sponsorship', href: '/sponsors' },
       { key: 'developers', href: '/developers' },

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -139,6 +139,7 @@ export interface FooterStrings {
   sponsorship: string;
   developers: string;
   giveFeedback: string;
+  checkPages: string;
   licenseLine: string;
 }
 
@@ -170,6 +171,7 @@ export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
     sponsorship: 'Corporate Sponsorship',
     developers: 'Developers',
     giveFeedback: 'Give Feedback',
+    checkPages: 'Check a few pages',
     licenseLine: 'Public domain originals · Translations CC BY-SA 4.0 · AI training requires a license',
   },
   es: {
@@ -199,6 +201,7 @@ export const FOOTER_STRINGS: Record<Locale, FooterStrings> = {
     sponsorship: 'Patrocinio corporativo',
     developers: 'Desarrolladores',
     giveFeedback: 'Enviar comentarios',
+    checkPages: 'Revisar algunas páginas',
     licenseLine: 'Originales de dominio público · Traducciones CC BY-SA 4.0 · El entrenamiento de IA requiere licencia',
   },
 };

--- a/src/lib/review-candidates.ts
+++ b/src/lib/review-candidates.ts
@@ -1,0 +1,101 @@
+import { getReadDb } from '@/lib/mongodb';
+import { supabaseAdmin } from '@/lib/supabase';
+
+/**
+ * Read path for the volunteer review queues.
+ *
+ * Every queue serves its next item out of `review_candidates`, a small pooled
+ * collection built offline by scripts/maintenance/build-review-candidates.mjs.
+ *
+ * The routes used to select an item by `$sample`-ing `pages` (19.1M docs) with
+ * predicates no index can serve. That is a full collection scan per item fetch,
+ * behind a 15s maxDuration — hallucination and scan-quality both returned 504
+ * in production (17-23s) and gallery-quality took 8.2s. Precomputing the pool
+ * moves that cost off the request path entirely. Never reintroduce a `$sample`
+ * over `pages` here.
+ */
+
+export type ReviewCandidate = {
+  item_id: string;
+  book_id: string;
+  page_id: string | null;
+  page_number: number;
+  page_type: string | null;
+  image_url: string;
+  page_link: string;
+  book: {
+    id?: string;
+    title?: string;
+    author?: string;
+    year?: number;
+    language?: string;
+    slug?: string | null;
+  } | null;
+  stratum?: { language?: string; century?: string; provider?: string };
+  payload?: Record<string, unknown>;
+  is_gold?: boolean;
+};
+
+/** Ratings this volunteer has already given in this queue, so we don't show
+ *  them the same item twice. Failing open (empty set) is correct: a repeat
+ *  item is a much smaller problem than a queue that won't serve anything. */
+async function alreadyRated(queue: string, volunteerId: string): Promise<Set<string>> {
+  const seen = new Set<string>();
+  if (!supabaseAdmin) return seen;
+  const { data, error } = await supabaseAdmin
+    .from('volunteer_ratings')
+    .select('item_id')
+    .eq('queue', queue)
+    .eq('volunteer_id', volunteerId)
+    .limit(5000);
+  if (error) {
+    console.error(`[review-candidates] rated-lookup failed for ${queue}:`, error.message);
+    return seen;
+  }
+  for (const row of data ?? []) seen.add(row.item_id as string);
+  return seen;
+}
+
+export type NextItemResult =
+  | { item: ReviewCandidate; poolEmpty?: false }
+  | { item: null; message: string; poolEmpty: boolean };
+
+/**
+ * Pick one unrated candidate for this volunteer.
+ *
+ * `$sample` is safe here because the pool is a few thousand documents, not
+ * 19 million. We over-fetch and filter in JS so a volunteer deep into a queue
+ * still gets an item without a second round trip.
+ */
+export async function nextCandidate(queue: string, volunteerId: string): Promise<NextItemResult> {
+  const [rated, db] = await Promise.all([alreadyRated(queue, volunteerId), getReadDb()]);
+
+  const docs = (await db
+    .collection('review_candidates')
+    .aggregate([{ $match: { queue } }, { $sample: { size: 40 } }, { $project: { _id: 0 } }])
+    .toArray()) as unknown as (ReviewCandidate & { gold_answer?: unknown })[];
+
+  if (docs.length === 0) {
+    return {
+      item: null,
+      poolEmpty: true,
+      message:
+        'This queue has no items pooled yet. Run scripts/maintenance/build-review-candidates.mjs.',
+    };
+  }
+
+  for (const doc of docs) {
+    if (rated.has(doc.item_id)) continue;
+    // `gold_answer` is the expected response for attention-check items. It must
+    // never reach the client, or the check measures nothing.
+    const { gold_answer: _gold, ...safe } = doc;
+    void _gold;
+    return { item: safe as ReviewCandidate };
+  }
+
+  return {
+    item: null,
+    poolEmpty: false,
+    message: "You've rated everything in this sample — refresh for more.",
+  };
+}

--- a/src/lib/tenant-global-paths.ts
+++ b/src/lib/tenant-global-paths.ts
@@ -48,6 +48,13 @@ export const GLOBAL_ONLY_TENANT_PAGE_PATHS = [
   '/contribute',
   '/support',
   '/sponsors',
+  // Volunteer review queues. Items are drawn from `review_candidates`, a pool
+  // built across every visible book in the corpus, so a partner reading room
+  // would hand its visitors other libraries' pages to judge — the same content
+  // leak as /encyclopedia, in a surface that also invites people to act on it.
+  // A tenant-scoped review queue is a different feature, not a filter.
+  '/review',
+  '/volunteers',
 ] as const;
 
 /**
@@ -83,6 +90,10 @@ export const GLOBAL_ONLY_TENANT_API_PATHS = [
   '/api/entities',
   '/api/explore',
   '/api/ngrams',
+  // The queue pages render client-side and fetch their items from the host
+  // they were served on, so blocking only the page would leave the unscoped
+  // corpus reachable from a tenant subdomain.
+  '/api/review',
 ] as const;
 
 const ALL_GLOBAL_ONLY_PATHS: readonly string[] = [

--- a/supabase/migrations/20260802000000_volunteer_ratings_note.sql
+++ b/supabase/migrations/20260802000000_volunteer_ratings_note.sql
@@ -1,0 +1,41 @@
+-- Qualitative feedback on every review queue.
+--
+-- A rating scale can only answer the question we thought to ask. Volunteers
+-- are domain experts — a Latinist looking at a page knows things our four
+-- buttons cannot express ("this isn't a hallucination, it's a bleed-through
+-- from the facing leaf", "the description is right but the plate is bound in
+-- upside down"). Without somewhere to put that, it is lost.
+--
+-- Two changes:
+--   1. `note` — optional free text attached to any judgment.
+--   2. `rating` becomes NULLABLE, so a volunteer can leave a note WITHOUT
+--      forcing a rating they don't believe. A note-only row is a real signal
+--      ("something is wrong with this item"), and coercing it into one of the
+--      buttons would corrupt the rating distribution to preserve a NOT NULL.
+--
+-- Counting consequence: any rate/agreement statistic must filter
+-- `rating IS NOT NULL`. `volunteer_ratings_rated_idx` exists to make that
+-- filter cheap and to make the constraint visible to whoever writes the query.
+
+ALTER TABLE volunteer_ratings ADD COLUMN IF NOT EXISTS note text;
+ALTER TABLE volunteer_ratings ALTER COLUMN rating DROP NOT NULL;
+
+-- A row with neither a rating nor a note carries no information at all.
+ALTER TABLE volunteer_ratings DROP CONSTRAINT IF EXISTS volunteer_ratings_has_signal;
+ALTER TABLE volunteer_ratings ADD CONSTRAINT volunteer_ratings_has_signal
+  CHECK (rating IS NOT NULL OR (note IS NOT NULL AND length(btrim(note)) > 0));
+
+CREATE INDEX IF NOT EXISTS volunteer_ratings_rated_idx
+  ON volunteer_ratings (queue, rating)
+  WHERE rating IS NOT NULL;
+
+-- Notes are read far more often than they are written; make the "show me what
+-- people actually said" query cheap.
+CREATE INDEX IF NOT EXISTS volunteer_ratings_note_idx
+  ON volunteer_ratings (created_at DESC)
+  WHERE note IS NOT NULL;
+
+COMMENT ON COLUMN volunteer_ratings.note IS
+  'Optional free-text from the volunteer. May be present with or without a rating.';
+COMMENT ON COLUMN volunteer_ratings.rating IS
+  'Queue-specific rating value. NULL means the volunteer left a note only — exclude these from every rate and agreement statistic.';

--- a/tests/unit/image-extraction-filter-parity.test.ts
+++ b/tests/unit/image-extraction-filter-parity.test.ts
@@ -1,0 +1,94 @@
+/**
+ * PARITY — scripts/lib/image-extraction-filter.mjs (used by the review-candidate
+ * builder, which decides which pages enter the volunteer hallucination queue)
+ * and src/lib/image-extraction-filter.ts (used by the app) must agree exactly.
+ *
+ * If they drift, the candidate pool stops matching the pages the extraction
+ * worker would actually keep, and volunteers spend their time judging pages
+ * that were never going to cost us a vision call.
+ *
+ * These assertions run BOTH implementations over the same inputs and compare
+ * outputs — deleting a rule from one side turns this red. They do not grep source.
+ */
+import { describe, it, expect } from 'vitest';
+
+import * as mjs from '../../scripts/lib/image-extraction-filter.mjs';
+import * as ts from '../../src/lib/image-extraction-filter';
+
+/** Pages drawn to exercise each branch: skip rules, significance gating,
+ *  the <detected-images> escape hatch, multi-tag pages, and malformed markup. */
+const FIXTURES: string[] = [
+  '',
+  'Plain page text with no markup at all.',
+  '<image-desc type="stamp" significance="high">A library stamp.</image-desc>',
+  '<image-desc type="decorative" significance="low">A drop cap.</image-desc>',
+  // decorative + HIGH is not in the skip list — must be kept
+  '<image-desc type="decorative" significance="high">An elaborate historiated initial.</image-desc>',
+  '<image-desc type="engraving" significance="high" size="large">A copperplate of a furnace.</image-desc>',
+  // every tag skippable → skip
+  '<image-desc type="ornament" significance="low">Rule</image-desc>' +
+    '<image-desc type="symbol" significance="high">Alchemical sigil</image-desc>',
+  // one non-skippable tag among skippable ones → keep
+  '<image-desc type="ornament" significance="low">Rule</image-desc>' +
+    '<image-desc type="diagram" significance="high">A volvelle with rotating discs.</image-desc>',
+  // the escape hatch wins even when every tag is skippable
+  '<detected-images><image-desc type="stamp" significance="high">Stamp</image-desc></detected-images>',
+  "<image-desc type=\"printer's mark\" significance=\"low\">Aldine anchor</image-desc>",
+  '<image-desc type="exlibris" significance="high">Bookplate of the NYBG.</image-desc>',
+  // missing attributes / malformed
+  '<image-desc>No attributes at all.</image-desc>',
+  '<image-desc type="stamp">No significance attribute.</image-desc>',
+  '<image-desc type="engraving" significance="high">Unclosed tag',
+  // multiline description with entities and nested angle brackets in prose
+  '<image-desc type="map" significance="high" size="large">A chart of the\n  Aegean, marked "PRO SCIENTIA".</image-desc>',
+];
+
+describe('image-extraction-filter twins', () => {
+  it('shouldSkipPageByMarkup agrees on every fixture', () => {
+    for (const ocr of FIXTURES) {
+      expect(mjs.shouldSkipPageByMarkup(ocr), `mismatch for: ${ocr.slice(0, 60)}`).toBe(
+        ts.shouldSkipPageByMarkup(ocr),
+      );
+    }
+  });
+
+  it('shouldSkipPageByMarkup agrees on null and undefined', () => {
+    expect(mjs.shouldSkipPageByMarkup(null)).toBe(ts.shouldSkipPageByMarkup(null));
+    expect(mjs.shouldSkipPageByMarkup(undefined)).toBe(ts.shouldSkipPageByMarkup(undefined));
+  });
+
+  it('extractImageDescTags agrees on every fixture', () => {
+    for (const ocr of FIXTURES) {
+      expect(mjs.extractImageDescTags(ocr), `mismatch for: ${ocr.slice(0, 60)}`).toEqual(
+        ts.extractImageDescTags(ocr),
+      );
+    }
+  });
+
+  it('rule tables and candidate page types are identical', () => {
+    expect(mjs.SKIP_MARKUP_RULES).toEqual(ts.SKIP_MARKUP_RULES);
+    expect(mjs.IMAGE_CANDIDATE_PAGE_TYPES).toEqual(ts.IMAGE_CANDIDATE_PAGE_TYPES);
+  });
+
+  /* Behavioral anchors — these pin the semantics the queue depends on,
+     independently of parity (both sides being wrong the same way is still wrong). */
+  it('keeps a page whose only tag is a real illustration', () => {
+    expect(
+      ts.shouldSkipPageByMarkup(
+        '<image-desc type="engraving" significance="high">A furnace.</image-desc>',
+      ),
+    ).toBe(false);
+  });
+
+  it('skips a page whose tags are all provenance marks', () => {
+    expect(
+      ts.shouldSkipPageByMarkup(
+        '<image-desc type="bookplate" significance="high">Bookplate.</image-desc>',
+      ),
+    ).toBe(true);
+  });
+
+  it('never skips a page with no markup', () => {
+    expect(ts.shouldSkipPageByMarkup('ordinary page text')).toBe(false);
+  });
+});

--- a/tests/unit/tenant-global-paths.test.ts
+++ b/tests/unit/tenant-global-paths.test.ts
@@ -16,7 +16,7 @@
  *     link to a path the proxy 404s
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { readFileSync, readdirSync, type Dirent } from 'fs';
 import path from 'path';
 import { NextRequest } from 'next/server';
 
@@ -211,20 +211,24 @@ describe('wiring', () => {
   });
 
   it('every blocked API path is a real route handler', () => {
+    // A typo here would silently block nothing. Each entry must be a directory
+    // that holds a route handler, either directly or in a child segment —
+    // several blocked prefixes (/api/explore, /api/review) are parent segments
+    // whose children carry the handlers.
+    const hasRouteHandler = (dir: string): boolean => {
+      let entries: Dirent[];
+      try {
+        entries = readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return false;
+      }
+      if (entries.some(e => e.isFile() && /^route\.tsx?$/.test(e.name))) return true;
+      return entries.some(e => e.isDirectory() && hasRouteHandler(path.join(dir, e.name)));
+    };
+
     for (const p of GLOBAL_ONLY_TENANT_API_PATHS) {
       const dir = path.join(repoRoot, 'src/app', p.replace(/^\//, ''));
-      let found = true;
-      try {
-        readFileSync(path.join(dir, 'route.ts'));
-      } catch {
-        // /api/explore is a parent segment whose children hold the handlers.
-        try {
-          readFileSync(path.join(dir, 'map', 'route.ts'));
-        } catch {
-          found = false;
-        }
-      }
-      expect(found, `${p} should resolve to a route handler`).toBe(true);
+      expect(hasRouteHandler(dir), `${p} should resolve to a route handler`).toBe(true);
     }
   });
 });


### PR DESCRIPTION
Closes part of #3560.

132 people signed up to volunteer. `volunteer_ratings` held **zero rows, ever**. Three independent causes were live simultaneously; this PR fixes all three.

## 1. Two of the three queues were returning 504

`/api/review/hallucination/next` and `/api/review/scan-quality/next` picked an item by `$sample`-ing `pages` — **19.1M documents** — with predicates no index can serve (`{'ocr.data': {$regex: '<image-desc'}}` and `{archived_photo: {$exists: true}}`). A full collection scan per item fetch, behind `maxDuration = 15`.

Measured against production 2026-08-02 with a browser UA:

| queue | before | after |
|---|---|---|
| hallucination | **504** after 17.8s, 23.2s on retry | 61 ms |
| scan-quality | **504** after 17.2s | 45 ms |
| gallery-quality | 200 in 8.2s | 23 ms |

Running the same aggregation locally does not return inside two minutes either — that is the confirmation, not a coincidence. `gallery-quality` survived only because it reads the much smaller `gallery_images` (207K), and 8.2s per item is its own kind of unusable, so it moves too.

**The fix is architectural, not a tuning knob.** `scripts/maintenance/build-review-candidates.mjs` precomputes a bounded `review_candidates` pool offline — the same relationship `gallery_images` has to `pages.detected_images` — and all three routes read it through `src/lib/review-candidates.ts`.

Two properties of the builder are load-bearing rather than incidental:

- **It never scans `pages`.** It iterates books and queries their pages via the `{book_id, page_number}` index.
- **It caps pages per book** (`--per-book`). An unbounded draw would let one 900-page volume dominate the pool and quietly turn "quality of the corpus" into "quality of that book".

Every candidate also carries a `stratum` (language / century / provider). Nothing reads it yet — the live queues still sample at random — but a stratified draw cannot be reconstructed after the fact, and the sampled assay in #3560 will need it.

Seeded on Hetzner: 3,000 items per queue, drawn from ~1,950 books each.

## 2. Nothing linked to the queues

`git grep` found no inbound link from the header, footer, homepage, or `/contribute`.

- The `/contribute` card titled **"Rate illustrations"** — whose copy describes `/review/gallery-quality` exactly — linked to `/gallery`, which has no rating control. It was the closest the site came to routing anyone into volunteer work, and it missed.
- The volunteer form's success screen said *"we'll be in touch soon"* and offered no next action. All 132 rows still read `contacted: false`. It now hands people something to do in the next thirty seconds, with a comment explaining why it must never become a dead end again.
- `/review` added to the footer's Participate column (en + es).

**`/review` and `/api/review` are added to `tenant-global-paths`.** Items are drawn across every visible book, so on a partner subdomain a reading room would hand its visitors *other libraries'* pages to judge — the #3364 content leak, in a surface that also invites people to act on it. The API prefix is listed separately because the queue pages render client-side and fetch from whatever host served them.

## 3. There was no way to say anything the buttons couldn't

A four-button scale only answers the question we thought to ask, and these volunteers are specialists — a Latinist looking at a page knows things our rating options cannot express ("not a hallucination, that's bleed-through from the facing leaf").

- The note box lives in `QueueShell`, so **every queue has one by construction**, including any added later.
- `rating` becomes **nullable**: a volunteer can leave a note *without* being forced into a button they don't believe. Coercing that into a rating to satisfy a `NOT NULL` would corrupt the very distribution the ratings exist to measure.
- Consequence, and it is a real one: **every rate and agreement statistic must filter `rating IS NOT NULL`.** `/api/review/stats` now does, and the migration adds a partial index plus a column comment so the next person writing that query sees the constraint.

## Migration: applied ✅

`supabase/migrations/20260802000000_volunteer_ratings_note.sql` was applied to production on 2026-08-03 (via `SUPABASE_DB_URL` from secret-lover — note that the password contains an `@`, so `psql` mis-parses the URL and the host resolution fails; split on the LAST `@`).

Verified in `information_schema`: `note text` present, `rating` now `is_nullable = YES`, `volunteer_ratings_has_signal` constraint in place.

**The compat shim has been removed** (commit `chore(review): drop the note-column compat shim`) — the submit route is back to a single insert.

## Testing

- Full unit suite: 1540 passed / 113 files.
- New `tests/unit/image-extraction-filter-parity.test.ts` runs both twins over the same fixtures. **Negative control performed**: deleting one rule from the `.mjs` twin turns it red (2 failures); restoring it turns it green. Per the repo rule that a guard which only catches deletion is documentation with a green checkmark.
- `tests/unit/tenant-global-paths.test.ts` caught that `/api/review` has no handler at its own path. Rather than special-case it, the wiring check now searches child segments recursively — which also removes the existing hardcoded exception for `/api/explore`. A typo still fails.
- `npx tsc --noEmit` clean.

## Out of scope

- **`/volunteers` is kept, deliberately.** It reads as a duplicate of `/review`, but it is a noindex invitation page written for outreach emails — precisely the landing page for writing to the 117 volunteers. It is on the tenant block list with `/review`.
- **The queues still sample at random, not stratified.** Fixing the 504 does not make this a publishable instrument: there is no second rater and no agreement figure, so it remains a defect-finder. The stratified double-judged assay is #3560.
- **Attention checks.** `review_candidates` carries `is_gold` / `gold_answer` scaffolding and `nextCandidate()` already strips `gold_answer` before it reaches the client, but nothing seeds gold items yet.
- The two workers still carry their own inline copies of the skip-filter logic; folding them onto the new shared twin is a separate change.
- Emailing the 117 volunteers — the actual point of all this — is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

