### PR TITLE
fix(security): gate every /api/upload route at editor

### DIFF
--- a/src/app/api/upload/from-s3/route.ts
+++ b/src/app/api/upload/from-s3/route.ts
@@ -13,6 +13,7 @@ import {
   validateBookAndGetPageNumber,
   getExtensionFromMimeType
 } from '@/lib/uploads/utils';
+import { withAuth } from '@/lib/auth-helpers';
 
 // Maximum file size: 300MB (same as formData upload)
 const MAX_FILE_SIZE_MEGABYTES = 300 * 1024 * 1024;
@@ -27,6 +28,9 @@ const MAX_FILE_SIZE_MEGABYTES = 300 * 1024 * 1024;
  * }
  *
  * Security:
+ * - Requires `editor` or above, or a `Bearer $CRON_SECRET` token for scripts.
+ *   It inserts pages into an attacker-controlled `bookId`, so it must never be
+ *   reachable unauthenticated.
  * - Only accepts HTTPS URLs from ALLOWED_S3_DOMAIN environment variable
  * - Validates URL format and domain before fetching
  * - Enforces 20MB size limit
@@ -39,6 +43,7 @@ const MAX_FILE_SIZE_MEGABYTES = 300 * 1024 * 1024;
  * ```bash
  * curl -X POST http://localhost:3000/api/upload/from-s3 \
  *   -H "Content-Type: application/json" \
+ *   -H "Authorization: Bearer $CRON_SECRET" \
  *   -d '{
  *     "bookId": "book-123",
  *     "imageUrls": [
@@ -48,7 +53,7 @@ const MAX_FILE_SIZE_MEGABYTES = 300 * 1024 * 1024;
  *   }'
  * ```
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest) => {
   // No-cache headers to prevent Edge Cache from caching this route
   const noCacheHeaders = {
     'Cache-Control': 'no-store, no-cache, must-revalidate, private',
@@ -175,4 +180,4 @@ export async function POST(request: NextRequest) {
       { status: 500, headers: noCacheHeaders }
     );
   }
-}
+}, { minRole: 'editor' })

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -15,6 +15,13 @@ import { withAuth } from '@/lib/auth-helpers';
 // Maximum file size: 20MB
 const MAX_FILE_SIZE_MEGABYTES = 20 * 1024 * 1024;
 
+/**
+ * Upload page images to a book.
+ *
+ * Auth: `editor` or above, or a `Bearer $CRON_SECRET` token. This was on
+ * `withAuth`'s permissive `reader` default, which meant any signed-in account
+ * could append pages to any book — the same shape as #3511.
+ */
 export const POST = withAuth(async (request: NextRequest) => {
   try {
     const formData = await request.formData();
@@ -103,4 +110,4 @@ export const POST = withAuth(async (request: NextRequest) => {
       { status: 500 }
     );
   }
-});
+}, { minRole: 'editor' });

--- a/src/app/api/upload/update-book/route.ts
+++ b/src/app/api/upload/update-book/route.ts
@@ -3,6 +3,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { updateBookAfterUpload } from '@/lib/uploads/utils';
+import { withAuth } from '@/lib/auth-helpers';
 
 /**
  * Update book metadata (thumbnail and page count)
@@ -17,14 +18,20 @@ import { updateBookAfterUpload } from '@/lib/uploads/utils';
  *
  * Can be called explicitly after batch uploads or by other scripts.
  *
+ * Auth: `editor` or above, or a `Bearer $CRON_SECRET` token for pipeline
+ * scripts. It writes `pages_count`, which feeds the canonical public filter
+ * (`visible: true && pages_count > 0`), so an unauthenticated caller could flip
+ * a book's visibility on every public surface.
+ *
  * Example:
  * ```bash
  * curl -X POST http://localhost:3000/api/upload/update-book \
  *   -H "Content-Type: application/json" \
+ *   -H "Authorization: Bearer $CRON_SECRET" \
  *   -d '{ "bookId": "book-123" }'
  * ```
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest) => {
   try {
     const body = await request.json();
     const { bookId } = body;
@@ -68,4 +75,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+}, { minRole: 'editor' });

--- a/src/app/book/[id]/capture/page.tsx
+++ b/src/app/book/[id]/capture/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from 'lucide-react';
 import { BookLoader } from '@/components/ui/BookLoader';
 import Link from 'next/link';
 import CameraCapture from '@/components/camera/CameraCapture';
+import { AuthCheck } from '@/components/auth/AuthCheck';
 import { books } from '@/lib/api-client';
 
 interface Book {
@@ -84,8 +85,22 @@ export default function CapturePage() {
         <div className="w-10" /> {/* Spacer for centering */}
       </header>
 
-      {/* Camera */}
-      <CameraCapture bookId={bookId} onComplete={handleComplete} />
+      {/*
+        Camera. `/api/upload` requires editor, so showing the capture UI to a
+        reader would only produce an opaque 403 at the end of a scanning
+        session. The gate that counts is the one on the route — this is purely
+        so the affordance matches it.
+      */}
+      <AuthCheck
+        role="inner_circle"
+        fallback={
+          <div className="flex-1 flex items-center justify-center p-8 text-center text-stone-400">
+            <p>Page capture is available to Source Library editors.</p>
+          </div>
+        }
+      >
+        <CameraCapture bookId={bookId} onComplete={handleComplete} />
+      </AuthCheck>
     </div>
   );
 }

--- a/tests/unit/upload-auth.test.ts
+++ b/tests/unit/upload-auth.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Every route under /api/upload must be gated at `editor`.
+ *
+ * `POST /api/upload/update-book` was reported as a fully unauthenticated write
+ * to the `books` collection, keyed on an attacker-supplied `bookId`. It
+ * recomputes its values from the database rather than accepting them, so the
+ * damage ceiling is a wrong `pages_count`/`thumbnail` — but `pages_count` feeds
+ * the canonical public filter (`visible: true && pages_count > 0`), so it can
+ * flip a book's visibility on every public surface.
+ *
+ * The reported instance was not the class. Its two siblings had the same
+ * defect and a higher ceiling, because they insert page images rather than
+ * recompute a count:
+ *   - `/api/upload/from-s3` was also fully unauthenticated.
+ *   - `/api/upload` sat on `withAuth`'s permissive `reader` default, so any
+ *     signed-in account could append pages to any book (the #3511 shape).
+ *
+ * This runs the REAL `withAuth` against the REAL route modules; only `auth()`,
+ * the database and the upload helpers are faked. Deleting `{ minRole: 'editor' }`
+ * from any route below turns its case red — verified by doing exactly that, per
+ * the "a test that greps source is not a guard" rule in CLAUDE.md.
+ */
+
+const ROLE_LEVEL = { reader: 1, contributor: 2, editor: 3, admin: 4, superadmin: 5 };
+
+let currentRole = 'reader';
+
+vi.mock('@/lib/auth', () => ({
+  ROLE_LEVEL,
+  auth: vi.fn(async () => ({
+    user: { id: 'u1', name: 'A Reader', email: 'reader@example.com', role: currentRole },
+    expires: new Date(Date.now() + 3600_000).toISOString(),
+  })),
+}));
+
+// No memberships, no platform-superadmin grant, no book found. The handler is
+// allowed to run and fail on its own terms — this test only cares whether the
+// gate let it through at all.
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: () => ({
+      findOne: async () => null,
+      insertMany: async () => ({ insertedCount: 0 }),
+      updateOne: async () => ({ matchedCount: 0 }),
+    }),
+  })),
+}));
+
+vi.mock('@/lib/uploads/utils', () => ({
+  validateBookAndGetPageNumber: async () => {
+    throw new Error('Book not found');
+  },
+  updateBookAfterUpload: async () => undefined,
+  getMimeTypeFromExtension: () => 'image/jpeg',
+  getExtensionFromMimeType: () => '.jpg',
+}));
+
+// Nothing below should be reached — a refused request must never fetch or
+// write an image. Calling either is a failure in its own right.
+const processImageUpload = vi.fn(async () => {
+  throw new Error('processImageUpload must not run in an auth test');
+});
+const fetchBufferWithMimeType = vi.fn(async () => {
+  throw new Error('S3 fetch must not run in an auth test');
+});
+
+vi.mock('@/lib/uploads/processing', () => ({ processImageUpload }));
+vi.mock('@/lib/api-client/images', () => ({
+  images: { fetchBufferWithMimeType },
+}));
+
+type RouteCase = {
+  name: string;
+  path: string;
+  load: () => Promise<Record<string, unknown>>;
+  /** Built fresh per call — a Request body can only be consumed once. */
+  makeBody: () => BodyInit | undefined;
+  headers?: Record<string, string>;
+};
+
+const CASES: RouteCase[] = [
+  {
+    name: 'POST /api/upload/update-book',
+    path: 'src/app/api/upload/update-book/route.ts',
+    load: () => import('@/app/api/upload/update-book/route'),
+    makeBody: () => JSON.stringify({ bookId: 'book-123' }),
+    headers: { 'content-type': 'application/json' },
+  },
+  {
+    name: 'POST /api/upload/from-s3',
+    path: 'src/app/api/upload/from-s3/route.ts',
+    load: () => import('@/app/api/upload/from-s3/route'),
+    makeBody: () =>
+      JSON.stringify({
+        bookId: 'book-123',
+        imageUrls: ['https://example-bucket.s3.amazonaws.com/image1.jpg'],
+      }),
+    headers: { 'content-type': 'application/json' },
+  },
+  {
+    name: 'POST /api/upload',
+    path: 'src/app/api/upload/route.ts',
+    load: () => import('@/app/api/upload/route'),
+    makeBody: () => {
+      const fd = new FormData();
+      fd.append('bookId', 'book-123');
+      fd.append('files', new File([new Uint8Array([1, 2, 3])], 'page.jpg', { type: 'image/jpeg' }));
+      return fd;
+    },
+  },
+];
+
+async function call(c: RouteCase, role: string) {
+  currentRole = role;
+  const mod = await c.load();
+  const handler = mod.POST as (req: unknown, ctx?: unknown) => Promise<Response>;
+  const req = new Request(`https://sourcelibrary.org/${c.path}`, {
+    method: 'POST',
+    headers: c.headers,
+    body: c.makeBody(),
+  });
+  return handler(req, { params: Promise.resolve({}) });
+}
+
+describe('upload routes are gated at editor', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    // A stray CRON_SECRET would not matter (we send no Authorization header),
+    // but PLATFORM_ADMIN_EMAILS would silently promote our test user.
+    vi.stubEnv('PLATFORM_ADMIN_EMAILS', '');
+    processImageUpload.mockClear();
+    fetchBufferWithMimeType.mockClear();
+  });
+
+  for (const c of CASES) {
+    for (const role of ['reader', 'contributor'] as const) {
+      it(`${c.name} refuses a signed-in ${role}`, async () => {
+        const res = await call(c, role);
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: 'Forbidden - Insufficient role' });
+        expect(processImageUpload).not.toHaveBeenCalled();
+        expect(fetchBufferWithMimeType).not.toHaveBeenCalled();
+      });
+    }
+
+    it(`${c.name} admits an editor`, async () => {
+      const res = await call(c, 'editor');
+      // The handler runs and then fails on the mocked-empty database, so "did
+      // the gate let it through" cannot be read from the status alone; it is
+      // the gate's own error body that has to be absent.
+      expect(res.status).not.toBe(401);
+      const body = await res.json().catch(() => ({}));
+      expect(body).not.toEqual({ error: 'Forbidden - Insufficient role' });
+    });
+  }
+});
+
+describe('the upload route list stays complete', () => {
+  /**
+   * The gates above are only as good as this list, and the issue that reported
+   * one of these three named only one. A new route under /api/upload must get
+   * an auth case here.
+   */
+  it('covers every route module under /api/upload', async () => {
+    const { readdirSync, statSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    const found: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const p = join(dir, entry);
+        if (statSync(p).isDirectory()) walk(p);
+        else if (entry === 'route.ts') found.push(p);
+      }
+    };
+    walk('src/app/api/upload');
+
+    const covered = new Set(CASES.map((c) => c.path));
+    const uncovered = found.filter((f) => !covered.has(f));
+    expect(uncovered, `upload routes with no auth case in CASES: ${uncovered.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes the unauthenticated-write report in Embassy-of-the-Free-Mind/sourcelibrary-ops#7 (cross-repo, so this does NOT auto-close it — close manually after merge).

## The reported route

`POST /api/upload/update-book` was a fully unauthenticated POST that mutates the `books` collection for any `bookId` in the body — the docblock even carried a ready-to-paste curl. It recomputes page count and thumbnail from the database rather than accepting attacker-supplied values, so the damage ceiling is a wrong `pages_count`/`thumbnail`. But `pages_count` feeds the canonical public filter (`visible: true && pages_count > 0`), so an anonymous caller could flip a book's visibility on public surfaces.

## The class

The reported instance was not the class. Both siblings in the same directory had the same defect, with a **higher** ceiling — they insert page images rather than recompute a count:

| Route | Before | After |
|---|---|---|
| `POST /api/upload/update-book` | no auth at all | `withAuth({ minRole: 'editor' })` |
| `POST /api/upload/from-s3` | no auth at all | `withAuth({ minRole: 'editor' })` |
| `POST /api/upload` | `withAuth(h)` — the permissive `reader` default | `withAuth(h, { minRole: 'editor' })` |

The third is the #3511 shape verbatim: `withAuth(handler)` reads as "this route is protected" and means "any signed-in account may call it." Per that lesson the `minRole` is written explicitly on all three, including where it would have matched a default.

`withAuth` already accepts `Bearer $CRON_SECRET`, which covers the "can be called by other scripts" use the docblocks describe, so script callers need only add the header. The curl examples are updated to show it.

## UI

`/book/[id]/capture` renders the camera that posts to `/api/upload` and had no gate of its own. It is now wrapped in `<AuthCheck role="inner_circle">`. This is **not** the access control — the route is the gate that counts — it is so a reader gets a message up front rather than an opaque 403 at the end of a scanning session.

## Test

`tests/unit/upload-auth.test.ts` runs the **real** `withAuth` against the **real** route modules; only `auth()`, Mongo and the upload helpers are faked. It also asserts that a refused request never reaches `processImageUpload` or the S3 fetch, so a future regression can't be "403 but the write already happened."

**Negative control run**, per the "a test that greps source is not a guard" rule: removing `{ minRole: 'editor' }` from all three routes turns exactly their six refusal cases red, and restoring it turns them green. A companion enumeration test fails if a new `route.ts` appears under `/api/upload` without an auth case — the completeness half, since the issue that reported one of these three named only one.

`npx tsc --noEmit` clean; `upload-auth` + `page-write-auth` = 39 tests passing.

## Out of scope

- Other unauthenticated write surfaces outside `/api/upload` (the ops issue mentions "the AI endpoints" as a separate, higher-consequence item) — those want their own PR and their own enumeration.
- No change to `withAuth`'s `reader` default itself. Flipping it would be the real fix for this class, but it silently re-gates every call site in the app and belongs in a PR that can be reviewed as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
