### PR TITLE
fix(security): editor-gate the three uncalled AI page routes (ops#6)

### DIFF
--- a/src/app/api/[tenant]/pages/[id]/ask/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/ask/route.ts
@@ -1,8 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getGeminiClient } from '@/lib/gemini-client';
 import { DEFAULT_MODEL } from '@/lib/types';
 import { MODEL_PRICING } from '@/lib/ai';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { withAuth } from '@/lib/auth-helpers';
+import { logGeminiCall } from '@/lib/gemini-logger';
+import { getTriggerSource } from '@/lib/cron-auth';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -155,19 +158,21 @@ Please answer their question helpfully:
 
 Answer:`;
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ tenant: string; id: string }> }
-) {
+// Gated at `editor` (ops#6) — see the note on the unscoped twin. `customPrompt`
+// is no longer read from the body.
+export const POST = withAuth(async (request, session, context) => {
+  const startTime = Date.now();
+
   try {
-    const { tenant, id: pageId } = await params;
-    
+    const { tenant, id: pageId } = await context.params;
+    const triggeredBy = getTriggerSource(request);
+
     // Resolve tenant slug to UUID (for validation)
     const tenantId = await resolveTenantId(tenant);
     if (!tenantId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
     }
-    
+
     const body = await request.json();
     const {
       question,
@@ -176,9 +181,6 @@ export async function POST(
       bookTitle,
       bookAuthor,
       pageNumber,
-      customPrompt,
-      authorSearchTerms,
-      personaName
     } = body;
 
     if (!question) {
@@ -216,11 +218,8 @@ export async function POST(
       authorSources = formatSourcesForPrompt(sources);
     }
 
-    // Use custom prompt if provided, otherwise use default
-    const promptTemplate = customPrompt || DEFAULT_PROMPT;
-
     // Replace variables in the prompt
-    const prompt = promptTemplate
+    const prompt = DEFAULT_PROMPT
       .replace('{page_number}', pageNumber || '?')
       .replace('{book_context}', bookContext)
       .replace('{page_text}', truncatedText)
@@ -236,6 +235,21 @@ export async function POST(
     const usageMetadata = response.usageMetadata;
     const inputTokens = usageMetadata?.promptTokenCount || 0;
     const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+
+    // Previously unlogged — see the unscoped twin.
+    logGeminiCall({
+      type: 'other',
+      mode: 'realtime',
+      model: DEFAULT_MODEL,
+      page_ids: [pageId],
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      status: 'success',
+      duration_ms: Date.now() - startTime,
+      prompt_version: 'page-ask-v1',
+      endpoint: '/api/[tenant]/pages/[id]/ask',
+      triggered_by: triggeredBy,
+    });
 
     return NextResponse.json({
       answer,
@@ -255,4 +269,4 @@ export async function POST(
       { status: 500 }
     );
   }
-}
+}, { minRole: 'editor' });

--- a/src/app/api/[tenant]/pages/[id]/detect-split/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/detect-split/route.ts
@@ -1,17 +1,22 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { GoogleGenerativeAI, SchemaType } from '@google/generative-ai';
 import { images } from '@/lib/api-client';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { withAuth } from '@/lib/auth-helpers';
+import { logGeminiCall } from '@/lib/gemini-logger';
+import { getTriggerSource } from '@/lib/cron-auth';
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+const DETECT_SPLIT_MODEL = 'gemini-3-flash-preview';
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ tenant: string; id: string }> }
-) {
+// Gated at `editor` (ops#6) — see the note on the unscoped twin.
+export const POST = withAuth(async (request, session, context) => {
+  const startTime = Date.now();
+
   try {
-    const { tenant, id } = await params;
+    const { tenant, id } = await context.params;
+    const triggeredBy = getTriggerSource(request);
     const db = await getDb();
     
     // Resolve tenant slug to UUID
@@ -38,7 +43,7 @@ export async function POST(
 
     // Run Gemini detection (using fastest model)
     const model = genAI.getGenerativeModel({
-      model: 'gemini-3-flash-preview',
+      model: DETECT_SPLIT_MODEL,
       generationConfig: {
         responseMimeType: 'application/json',
         responseSchema: {
@@ -100,6 +105,22 @@ Coordinates as 0-1000 scale.`,
       },
     ]);
 
+    // Bill per RESPONSE, not per saved page — see the unscoped twin.
+    logGeminiCall({
+      type: 'other',
+      mode: 'realtime',
+      model: DETECT_SPLIT_MODEL,
+      book_id: page.book_id,
+      page_ids: [id],
+      input_tokens: result.response.usageMetadata?.promptTokenCount || 0,
+      output_tokens: result.response.usageMetadata?.candidatesTokenCount || 0,
+      status: 'success',
+      duration_ms: Date.now() - startTime,
+      prompt_version: 'detect-split-v1',
+      endpoint: '/api/[tenant]/pages/[id]/detect-split',
+      triggered_by: triggeredBy,
+    });
+
     const detection = JSON.parse(result.response.text());
 
     // Save detection result to page
@@ -116,4 +137,4 @@ Coordinates as 0-1000 scale.`,
       { status: 500 }
     );
   }
-}
+}, { minRole: 'editor' });

--- a/src/app/api/[tenant]/pages/[id]/modernize/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/modernize/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { performModernization } from '@/lib/ai';
 import { DEFAULT_MODEL } from '@/lib/types';
 import { logGeminiCall } from '@/lib/gemini-logger';
 import { getTriggerSource } from '@/lib/cron-auth';
 import { resolveTenantId } from '@/lib/tenant-context';
+import { withAuth } from '@/lib/auth-helpers';
 
 // Simple hash function to detect translation changes
 function hashString(str: string): string {
@@ -17,14 +18,14 @@ function hashString(str: string): string {
   return hash.toString(16);
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ tenant: string; id: string }> }
-) {
+// Gated at `editor` (ops#6) — see the note on the unscoped twin. Note that
+// `resolveTenantId` below is a slug->UUID lookup, not an authorization check;
+// it was the only thing in front of this route.
+export const POST = withAuth(async (request, session, context) => {
   const startTime = Date.now();
 
   try {
-    const { tenant, id } = await params;
+    const { tenant, id } = await context.params;
     const triggeredBy = getTriggerSource(request);
     const db = await getDb();
     
@@ -36,7 +37,9 @@ export async function POST(
     
     const body = await request.json().catch(() => ({}));
 
-    const { regenerate = false, model = DEFAULT_MODEL } = body;
+    // `model` is no longer taken from the body — nothing sends it.
+    const { regenerate = false } = body;
+    const model = DEFAULT_MODEL;
 
     // Fetch the page
     const page = await db.collection('pages').findOne({ id, tenantId });
@@ -134,4 +137,4 @@ export async function POST(
       { status: 500 }
     );
   }
-}
+}, { minRole: 'editor' });

--- a/src/app/api/[tenant]/pages/[id]/transliterate/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/transliterate/route.ts
@@ -62,7 +62,9 @@ export async function POST(
 
     const body = await request.json().catch(() => ({}));
 
-    const { regenerate = false, model = TRANSLITERATION_MODEL } = body;
+    // `model` is not read from the body (ops#6) — see the unscoped twin.
+    const { regenerate = false } = body;
+    const model = TRANSLITERATION_MODEL;
 
     // Fetch the page
     const page = await db.collection('pages').findOne({ id, tenantId });

--- a/src/app/api/pages/[id]/ask/route.ts
+++ b/src/app/api/pages/[id]/ask/route.ts
@@ -1,7 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getGeminiClient } from '@/lib/gemini-client';
 import { DEFAULT_MODEL } from '@/lib/types';
 import { MODEL_PRICING } from '@/lib/ai';
+import { withAuth } from '@/lib/auth-helpers';
+import { logGeminiCall } from '@/lib/gemini-logger';
+import { getTriggerSource } from '@/lib/cron-auth';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -154,12 +157,19 @@ Please answer their question helpfully:
 
 Answer:`;
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+// Gated at `editor` (ops#6). Before this it was an unauthenticated proxy to
+// Gemini on our API key: uncached, and `customPrompt` let a caller supply the
+// prompt template verbatim. It also fans out to ~3 search + ~6 quote requests
+// against sourcelibrary.org per call, so it doubled as a request amplifier.
+//
+// `customPrompt` is no longer read from the body. Nothing sends it, and an
+// arbitrary-prompt path is not something to leave open behind any role.
+export const POST = withAuth(async (request, session, context) => {
+  const startTime = Date.now();
+
   try {
-    const { id: pageId } = await params;
+    const { id: pageId } = await context.params;
+    const triggeredBy = getTriggerSource(request);
     const body = await request.json();
     const {
       question,
@@ -168,9 +178,6 @@ export async function POST(
       bookTitle,
       bookAuthor,
       pageNumber,
-      customPrompt,
-      authorSearchTerms,
-      personaName
     } = body;
 
     if (!question) {
@@ -208,11 +215,8 @@ export async function POST(
       authorSources = formatSourcesForPrompt(sources);
     }
 
-    // Use custom prompt if provided, otherwise use default
-    const promptTemplate = customPrompt || DEFAULT_PROMPT;
-
     // Replace variables in the prompt
-    const prompt = promptTemplate
+    const prompt = DEFAULT_PROMPT
       .replace('{page_number}', pageNumber || '?')
       .replace('{book_context}', bookContext)
       .replace('{page_text}', truncatedText)
@@ -228,6 +232,22 @@ export async function POST(
     const usageMetadata = response.usageMetadata;
     const inputTokens = usageMetadata?.promptTokenCount || 0;
     const outputTokens = usageMetadata?.candidatesTokenCount || 0;
+
+    // This route computed its cost and returned it to the caller but never
+    // recorded it, so its spend did not exist in `gemini_usage`.
+    logGeminiCall({
+      type: 'other',
+      mode: 'realtime',
+      model: DEFAULT_MODEL,
+      page_ids: [pageId],
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      status: 'success',
+      duration_ms: Date.now() - startTime,
+      prompt_version: 'page-ask-v1',
+      endpoint: '/api/pages/[id]/ask',
+      triggered_by: triggeredBy,
+    });
 
     return NextResponse.json({
       answer,
@@ -247,4 +267,4 @@ export async function POST(
       { status: 500 }
     );
   }
-}
+}, { minRole: 'editor' });

--- a/src/app/api/pages/[id]/detect-split/route.ts
+++ b/src/app/api/pages/[id]/detect-split/route.ts
@@ -1,16 +1,23 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { GoogleGenerativeAI, SchemaType } from '@google/generative-ai';
 import { images } from '@/lib/api-client';
+import { withAuth } from '@/lib/auth-helpers';
+import { logGeminiCall } from '@/lib/gemini-logger';
+import { getTriggerSource } from '@/lib/cron-auth';
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+const DETECT_SPLIT_MODEL = 'gemini-3-flash-preview';
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+// Gated at `editor` (ops#6). The worst of the group before this: an
+// unauthenticated, entirely uncached, image-input vision call that also writes
+// `pages.split_detection`. There is no cache to hit, so every request spent.
+export const POST = withAuth(async (request, session, context) => {
+  const startTime = Date.now();
+
   try {
-    const { id } = await params;
+    const { id } = await context.params;
+    const triggeredBy = getTriggerSource(request);
     const db = await getDb();
 
     // Get the page
@@ -31,7 +38,7 @@ export async function POST(
 
     // Run Gemini detection (using fastest model)
     const model = genAI.getGenerativeModel({
-      model: 'gemini-3-flash-preview',
+      model: DETECT_SPLIT_MODEL,
       generationConfig: {
         responseMimeType: 'application/json',
         responseSchema: {
@@ -93,6 +100,25 @@ Coordinates as 0-1000 scale.`,
       },
     ]);
 
+    // Bill per RESPONSE, not per saved page: Gemini charges for this call even
+    // if the JSON below fails to parse, so log before touching the result.
+    // Until now this route called Gemini without logging at all, which is why
+    // its spend was invisible in `gemini_usage`.
+    logGeminiCall({
+      type: 'other',
+      mode: 'realtime',
+      model: DETECT_SPLIT_MODEL,
+      book_id: page.book_id,
+      page_ids: [id],
+      input_tokens: result.response.usageMetadata?.promptTokenCount || 0,
+      output_tokens: result.response.usageMetadata?.candidatesTokenCount || 0,
+      status: 'success',
+      duration_ms: Date.now() - startTime,
+      prompt_version: 'detect-split-v1',
+      endpoint: '/api/pages/[id]/detect-split',
+      triggered_by: triggeredBy,
+    });
+
     const detection = JSON.parse(result.response.text());
 
     // Save detection result to page
@@ -109,4 +135,4 @@ Coordinates as 0-1000 scale.`,
       { status: 500 }
     );
   }
-}
+}, { minRole: 'editor' });

--- a/src/app/api/pages/[id]/modernize/route.ts
+++ b/src/app/api/pages/[id]/modernize/route.ts
@@ -4,6 +4,7 @@ import { performModernization } from '@/lib/ai';
 import { DEFAULT_MODEL } from '@/lib/types';
 import { logGeminiCall } from '@/lib/gemini-logger';
 import { getTriggerSource } from '@/lib/cron-auth';
+import { withAuth } from '@/lib/auth-helpers';
 
 // Simple hash function to detect translation changes
 function hashString(str: string): string {
@@ -16,19 +17,25 @@ function hashString(str: string): string {
   return hash.toString(16);
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+// Gated at `editor` (ops#6). This writes `pages.modernized`, which renders to
+// readers, and every uncached call is a paid Gemini call — both were reachable
+// with no session, no API key and no anon gate. `{ regenerate: true }` skips
+// the cache, so an anonymous caller could spend without bound.
+//
+// `model` used to come from the request body. Nothing sends it (the api-client
+// posts no body at all), so it is fixed to DEFAULT_MODEL rather than left as a
+// caller-chosen route to an arbitrary model.
+export const POST = withAuth(async (request, session, context) => {
   const startTime = Date.now();
 
   try {
-    const { id } = await params;
+    const { id } = await context.params;
     const triggeredBy = getTriggerSource(request);
     const db = await getDb();
     const body = await request.json().catch(() => ({}));
 
-    const { regenerate = false, model = DEFAULT_MODEL } = body;
+    const { regenerate = false } = body;
+    const model = DEFAULT_MODEL;
 
     // Fetch the page
     const page = await db.collection('pages').findOne({ id });
@@ -125,9 +132,10 @@ export async function POST(
       { status: 500 }
     );
   }
-}
+}, { minRole: 'editor' });
 
-// GET to retrieve existing modernized text without regenerating
+// GET to retrieve existing modernized text without regenerating. Deliberately
+// left open: it is a cached read that spends nothing and writes nothing.
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }

--- a/src/app/api/pages/[id]/transliterate/route.ts
+++ b/src/app/api/pages/[id]/transliterate/route.ts
@@ -53,7 +53,11 @@ export async function POST(
     const db = await getDb();
     const body = await request.json().catch(() => ({}));
 
-    const { regenerate = false, model = TRANSLITERATION_MODEL } = body;
+    // `model` is not read from the body (ops#6): nothing sends it, and a
+    // caller-chosen model on a paid call is not worth keeping for no consumer.
+    // This route's anonymous-access gate is PR 2, not this change.
+    const { regenerate = false } = body;
+    const model = TRANSLITERATION_MODEL;
 
     // Fetch the page
     const page = await db.collection('pages').findOne({ id });

--- a/tests/unit/page-write-auth.test.ts
+++ b/tests/unit/page-write-auth.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * Every route that rewrites a page's text must be gated at `editor` (#3511).
+ * Every route that rewrites a page's stored state, or spends on Gemini, must be
+ * gated at `editor` (#3511, extended by ops#6).
  *
  * The UI has always gated editing correctly: the Read/Edit toggle in
  * TranslationEditor is wrapped in `<AuthCheck role="inner_circle">`, so a reader
@@ -10,6 +11,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * calling the route directly — and two of the routes (`quick-fix`, `restore`)
  * apply no tenant filter, so the reach was the whole corpus from the main
  * domain, not one tenant.
+ *
+ * ops#6 added the AI routes — `modernize`, `ask`, `detect-split` and their
+ * tenant twins — which had no wrapper at all rather than a drifted one. Two
+ * harms per route: an unauthenticated write to page state, and an
+ * unauthenticated paid Gemini call (`{ regenerate: true }` skips the cache).
+ * The db mock below returns no page, so none of them reaches Gemini here.
  *
  * This test runs the REAL `withAuth` against the REAL route modules. Only
  * `auth()` and the database are faked. Deleting the `{ minRole: 'editor' }`
@@ -141,6 +148,55 @@ const CASES: RouteCase[] = [
     params: { tenant: 'bph' },
     body: { splits: [{ pageId: 'page-1', splitPosition: 500 }] },
   },
+  // The AI routes (ops#6). Each of these writes page state and/or spends on
+  // Gemini, and each had no auth wrapper whatsoever before that issue.
+  {
+    name: 'POST /api/pages/[id]/modernize',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/pages/[id]/modernize/route'),
+    params: { id: 'page-1' },
+    body: { regenerate: true },
+  },
+  {
+    name: 'POST /api/[tenant]/pages/[id]/modernize',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/[tenant]/pages/[id]/modernize/route'),
+    params: { tenant: 'bph', id: 'page-1' },
+    body: { regenerate: true },
+  },
+  {
+    name: 'POST /api/pages/[id]/ask',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/pages/[id]/ask/route'),
+    params: { id: 'page-1' },
+    // Empty body: the handler answers 400 before reaching Gemini.
+    body: {},
+  },
+  {
+    name: 'POST /api/[tenant]/pages/[id]/ask',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/[tenant]/pages/[id]/ask/route'),
+    params: { tenant: 'bph', id: 'page-1' },
+    body: {},
+  },
+  {
+    name: 'POST /api/pages/[id]/detect-split',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/pages/[id]/detect-split/route'),
+    params: { id: 'page-1' },
+  },
+  {
+    name: 'POST /api/[tenant]/pages/[id]/detect-split',
+    method: 'POST',
+    minRole: 'editor',
+    load: () => import('@/app/api/[tenant]/pages/[id]/detect-split/route'),
+    params: { tenant: 'bph', id: 'page-1' },
+  },
 ];
 
 async function call(c: RouteCase, role: string) {
@@ -215,13 +271,18 @@ describe('the page-write route list stays complete', () => {
         }
         if (entry !== 'route.ts') continue;
         const src = readFileSync(p, 'utf8');
-        // Routes that assign client-supplied text into a page's stored fields,
-        // or remove a page outright. `modernize` and `transliterate` write only
-        // model output and take no text from the caller, so they are excluded.
+        // The criterion used to be "assigns client-supplied text into a page
+        // field", which excluded `modernize` and `transliterate` on the grounds
+        // that they write only model output. That reasoning holds for text
+        // integrity and misses cost entirely: an uncached call on either is a
+        // paid Gemini call an anonymous caller chose to make (ops#6). So the
+        // criterion is now "writes page state OR spends on Gemini".
         const writesPageText =
           /\[`?\$?\{?(?:revision\.)?field\}?`?\.data`?\]|['"](?:ocr|translation|summary)\.data['"]/.test(src);
+        const writesModelOutput =
+          /['"](?:modernized|transliteration)\.data['"]|\bsplit_detection:/.test(src);
         const deletesPage = /deleteOne\(\s*\{\s*id/.test(src);
-        if (writesPageText || deletesPage) found.push(p);
+        if (writesPageText || writesModelOutput || deletesPage) found.push(p);
       }
     };
 
@@ -238,6 +299,17 @@ describe('the page-write route list stays complete', () => {
       'src/app/api/pages/[id]/reset/route.ts',
       'src/app/api/pages/batch-split/route.ts',
       'src/app/api/[tenant]/pages/batch-split/route.ts',
+      'src/app/api/pages/[id]/modernize/route.ts',
+      'src/app/api/[tenant]/pages/[id]/modernize/route.ts',
+      'src/app/api/pages/[id]/detect-split/route.ts',
+      'src/app/api/[tenant]/pages/[id]/detect-split/route.ts',
+      // TODO(ops#6 PR 2): `transliterate` is the one route in this group with
+      // real anonymous reader traffic — TranslationEditor auto-fires it when
+      // the panel opens, outside every <AuthCheck>. Editor-gating it would
+      // break signed-out reading, so it gets `anonActionGate` on the
+      // cache-miss path instead and is covered by its own test, not by CASES.
+      'src/app/api/pages/[id]/transliterate/route.ts',
+      'src/app/api/[tenant]/pages/[id]/transliterate/route.ts',
     ]);
 
     const uncovered = found.filter((f) => !covered.has(f));


### PR DESCRIPTION
## The gap

`POST /api/pages/[id]/{modernize,ask,detect-split}` and their `[tenant]` twins had **no auth wrapper at all** — not a drifted `minRole` as in #3511, nothing. Each took a page id, called Gemini on our key, and two of the three wrote to `pages`. `{"regenerate": true}` skipped the cache on demand, so an anonymous caller chose how much we spent.

`resolveTenantId()` on the twins is a slug→UUID lookup, not an authorization check. It was the only thing in front of them.

| Route | Writes | Gemini | Cache |
|---|---|---|---|
| `modernize` | `pages.modernized.*` | yes | hash of translation, `regenerate` bypass |
| `ask` | none | yes — **`customPrompt` straight from the body** | none |
| `detect-split` | `pages.split_detection` | yes, **vision** | none — always regenerated |

## Blast radius: none

Nothing calls these three — not `src/`, not `scripts/`, not the MCP server. The `GET` cached read on `modernize` stays open. No user-facing behaviour changes.

`transliterate` is **deliberately not gated here.** It's the one route in the group with real anonymous reader traffic: `TranslationEditor.tsx:830` auto-fires it from a `useEffect` when the panel opens, and the toggle at `:1338` sits outside every `<AuthCheck>`. Editor-gating it would break signed-out reading of non-Latin-script books. It gets `anonActionGate` on the cache-miss path — a rate limit, not a wall — in a follow-up PR, along with the client-side 401 handling that has to ship with it.

## Also in scope

Since no internal caller sends a request body at all (`src/lib/api-client/pages.ts:134,142` post nothing):

- **`model` no longer read from the body** on `modernize` and `transliterate`. A caller-chosen model on a paid call with no consumer isn't worth keeping.
- **`customPrompt` no longer read** on `ask`, which made it an arbitrary-prompt proxy to Gemini on our API key.
- **`ask` and `detect-split` now call `logGeminiCall`.** They didn't, so their spend did not exist in `gemini_usage` — we could not see whether anyone was using them. Billed per **response**, not per saved page, since Gemini charges even when the JSON fails to parse.

## Guard

The six routes join `CASES` in `tests/unit/page-write-auth.test.ts`. The completeness walker's criterion changes from "assigns caller-supplied text into a page field" to "writes page state **or** spends on Gemini" — the old wording explicitly excluded `modernize`/`transliterate` on the grounds that they write only model output, which was correct about text integrity and silent about cost.

**Both negative controls were run**, per the "a test that greps source is not a guard" rule:

- Deleting `{ minRole: 'editor' }` from `detect-split` → 2 cases red, restored → green.
- Dropping `modernize` from the walker's covered set → walker fails naming that exact path. So the broadened regex genuinely finds these files; the allowlist didn't merely grow.

`npx tsc --noEmit` clean, eslint clean, 1475/1475 unit tests pass.

## Out of scope

- The issue's "75 of 108 write routes lack an auth wrapper" — that's a search result, not a finding. Many carry Stripe signature verification, `REVALIDATE_SECRET`, or in-handler session checks. Only the routes read and confirmed are touched here.
- `pages/batch` — cheap read, capped at 20 ids, real prefetch traffic, no spend. Unchanged.
- The sibling ops issue's routes.
- Any reader-facing "modernize" feature. Gating it today doesn't preclude one; it would arrive with its own anon-gate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)