### PR TITLE
fix(reader): meter anonymous transliteration instead of walling it (ops#6)

### DIFF
--- a/src/app/api/[tenant]/pages/[id]/transliterate/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/transliterate/route.ts
@@ -6,6 +6,10 @@ import { resolveTenantId } from '@/lib/tenant-context';
 const TRANSLITERATION_MODEL = 'gemini-3-flash-preview';
 import { logGeminiCall } from '@/lib/gemini-logger';
 import { getTriggerSource } from '@/lib/cron-auth';
+import { anonActionGate, SIGNIN_URL } from '@/lib/anon-gate';
+
+/** See the unscoped twin for why this is deliberately generous. */
+const ANON_TRANSLITERATION_LIMIT = 200;
 
 // Simple hash function to detect OCR changes
 function hashString(str: string): string {
@@ -96,6 +100,22 @@ export async function POST(
         script: page.transliteration.script,
         usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 }
       });
+    }
+
+    // Past this point the request costs money — see the unscoped twin (ops#6).
+    const gate = await anonActionGate(request, {
+      name: 'transliterate',
+      limit: ANON_TRANSLITERATION_LIMIT,
+    });
+    if (!gate.allowed) {
+      return NextResponse.json(
+        {
+          error: `You've used your ${ANON_TRANSLITERATION_LIMIT} free transliterations this hour. Sign in (free) to keep reading.`,
+          code: 'SIGNIN_REQUIRED',
+          sign_in: SIGNIN_URL,
+        },
+        { status: 401, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : {} },
+      );
     }
 
     // Perform transliteration

--- a/src/app/api/pages/[id]/transliterate/route.ts
+++ b/src/app/api/pages/[id]/transliterate/route.ts
@@ -4,6 +4,19 @@ import { performTransliteration } from '@/lib/ai';
 const TRANSLITERATION_MODEL = 'gemini-3-flash-preview';
 import { logGeminiCall } from '@/lib/gemini-logger';
 import { getTriggerSource } from '@/lib/cron-auth';
+import { anonActionGate, SIGNIN_URL } from '@/lib/anon-gate';
+
+/**
+ * Hourly per-IP cap on GENERATED transliterations for anonymous readers.
+ *
+ * Deliberately generous. TranslationEditor auto-fires this route when the
+ * transliteration panel opens, so one uncached page read == one call: a reader
+ * working through a Tibetan or Arabic book at 60 pages an hour is an ordinary
+ * session, not abuse. A university reading room behind NAT is also a single
+ * `cf-connecting-ip` sharing one bucket. Tighten this off `gate_hit` data in
+ * analytics_events, never up front.
+ */
+const ANON_TRANSLITERATION_LIMIT = 200;
 
 // Simple hash function to detect OCR changes
 function hashString(str: string): string {
@@ -89,6 +102,25 @@ export async function POST(
         script: page.transliteration.script,
         usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 }
       });
+    }
+
+    // Past this point the request costs money, so anonymous volume is metered
+    // (ops#6). Everything above — including the cache hit — stays free, which
+    // is the majority of real reader traffic. Signed-in users, verified
+    // crawlers and warm pings are exempt inside the gate.
+    const gate = await anonActionGate(request, {
+      name: 'transliterate',
+      limit: ANON_TRANSLITERATION_LIMIT,
+    });
+    if (!gate.allowed) {
+      return NextResponse.json(
+        {
+          error: `You've used your ${ANON_TRANSLITERATION_LIMIT} free transliterations this hour. Sign in (free) to keep reading.`,
+          code: 'SIGNIN_REQUIRED',
+          sign_in: SIGNIN_URL,
+        },
+        { status: 401, headers: gate.retryAfter ? { 'Retry-After': String(gate.retryAfter) } : {} },
+      );
     }
 
     // Perform transliteration

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useParams, usePathname } from 'next/navigation';
+import Link from 'next/link';
 import { useStableSession } from '@/hooks/useStableSession';
 import { useBrowserTranslation } from '@/hooks/useBrowserTranslation';
 import { toast } from 'sonner';
@@ -44,6 +45,7 @@ import ChapterDropdown from '@/components/reader/ChapterDropdown';
 import ShareButton from '@/components/ui/ShareButton';
 import CiteButton from '@/components/ui/CiteButton';
 import { prompts as promptsApi, analytics, pages as pagesApi, processing as processingApi } from '@/lib/api-client';
+import type { ApiClientError } from '@/lib/api-client';
 import LikeButton from '@/components/ui/LikeButton';
 import { getShortUrl } from '@/lib/shortlinks';
 import { getPageDisplayUrl, getPageThumbUrl, isUsableImageUrl } from '@/lib/utils';
@@ -65,6 +67,27 @@ const NON_LATIN_LANGUAGES = new Set([
 function hasNonLatinScript(language?: string): boolean {
   if (!language) return false;
   return NON_LATIN_LANGUAGES.has(language.toLowerCase());
+}
+
+type TransliterationGate = { message: string; signIn: string } | null;
+
+/**
+ * Both transliteration call sites — the panel's auto-fire effect and the
+ * explicit button — share this. Generating a transliteration is a paid Gemini
+ * call, so anonymous volume is capped per hour and the route answers 401 with
+ * `code: 'SIGNIN_REQUIRED'` at the cap (ops#6). That is a prompt, not a
+ * failure: it renders a sign-in CTA rather than an error toast, and nothing
+ * retries. Any other error keeps the existing toast.
+ */
+function handleTransliterationError(
+  err: ApiClientError,
+  setGate: (gate: TransliterationGate) => void,
+): void {
+  if (err?.code === 'SIGNIN_REQUIRED') {
+    setGate({ message: err.message, signIn: err.signIn || '/auth/signin' });
+    return;
+  }
+  toast.error(`Transliteration failed: ${err?.message || 'Unknown error'}`);
 }
 
 // Helper to format edit source info
@@ -588,6 +611,11 @@ export default function TranslationEditor({
   const [showGermanSourcePanel, setShowGermanSourcePanel] = useState(false);
   const [transliterationText, setTransliterationText] = useState('');
   const [transliterationLoading, setTransliterationLoading] = useState(false);
+  // Set when the anon-gate walls a signed-out reader (ops#6). Generating a
+  // transliteration is a paid call, so anonymous volume is capped per hour;
+  // hitting the cap is a sign-in prompt, not a failure, and must not retry.
+  const [transliterationGate, setTransliterationGate] =
+    useState<{ message: string; signIn: string } | null>(null);
   const [showPageMetadata, setShowPageMetadata] = useState(false); // Toggle for page metadata panel
   const [showFontControls, setShowFontControls] = useState(false);
   // Full book doc for the edition-info section of the metadata panel. The reader
@@ -827,12 +855,13 @@ export default function TranslationEditor({
     }
     let cancelled = false;
     setTransliterationLoading(true);
+    setTransliterationGate(null);
     pagesApi.transliterate(page.id)
       .then((res) => {
         if (!cancelled) setTransliterationText(res.transliteration || '');
       })
-      .catch((err) => {
-        if (!cancelled) toast.error(`Transliteration failed: ${err.message || 'Unknown error'}`);
+      .catch((err: ApiClientError) => {
+        if (!cancelled) handleTransliterationError(err, setTransliterationGate);
       })
       .finally(() => {
         if (!cancelled) setTransliterationLoading(false);
@@ -1879,6 +1908,22 @@ export default function TranslationEditor({
                         <Loader2 className="w-8 h-8 animate-spin mb-3" style={{ color: 'var(--accent-rust)' }} />
                         <p className="text-sm" style={{ color: 'var(--text-muted)' }}>Generating transliteration...</p>
                       </div>
+                    ) : transliterationGate ? (
+                      // Anon-gate wall (ops#6). Not an error state: the reader
+                      // has done nothing wrong and nothing is retried.
+                      <div className="h-full flex flex-col items-center justify-center text-center px-4">
+                        <Type className="w-8 h-8 mb-3" style={{ color: 'var(--text-faint)' }} />
+                        <p className="text-sm mb-4" style={{ color: 'var(--text-muted)' }}>
+                          {transliterationGate.message}
+                        </p>
+                        <Link
+                          href={`/auth/signin?callbackUrl=${encodeURIComponent(pathname)}&reason=limit`}
+                          className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-all hover:opacity-90"
+                          style={{ background: 'var(--accent-rust)' }}
+                        >
+                          Sign in — free
+                        </Link>
+                      </div>
                     ) : transliterationText ? (
                       <div className="prose-manuscript leading-relaxed" style={{ color: 'var(--text-secondary)' }} lang="und-Latn">
                         <NotesRenderer text={cleanTransliteration} showNotes={false} showMetadata={false} columns={effectiveColumns} />
@@ -1892,9 +1937,10 @@ export default function TranslationEditor({
                         <button
                           onClick={() => {
                             setTransliterationLoading(true);
+                            setTransliterationGate(null);
                             pagesApi.transliterate(page.id)
                               .then((res) => setTransliterationText(res.transliteration || ''))
-                              .catch((err) => toast.error(`Transliteration failed: ${err.message || 'Unknown error'}`))
+                              .catch((err: ApiClientError) => handleTransliterationError(err, setTransliterationGate))
                               .finally(() => setTransliterationLoading(false));
                           }}
                           className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-white transition-all hover:opacity-90"

--- a/src/lib/api-client/client.ts
+++ b/src/lib/api-client/client.ts
@@ -108,10 +108,28 @@ apiClient.interceptors.response.use(
     }
 
     // Extract error message from response
-    const message = (error.response?.data as any)?.error || error.message || 'Request failed';
-    throw new Error(message);
+    const data = error.response?.data as { error?: string; code?: string; sign_in?: string } | undefined;
+    const message = data?.error || error.message || 'Request failed';
+
+    // Carry the machine-readable fields through instead of collapsing the
+    // response to a prose string. Anon-gate walls answer 401 with
+    // `code: 'SIGNIN_REQUIRED'`, and a caller that can only see `err.message`
+    // has to regex the copy to recognise one — which `/search` currently does,
+    // and which breaks the moment the wording changes.
+    throw Object.assign(new Error(message), {
+      status: error.response?.status,
+      code: data?.code,
+      signIn: data?.sign_in,
+    });
   }
 );
+
+/** Shape of the error thrown by the response interceptor above. */
+export interface ApiClientError extends Error {
+  status?: number;
+  code?: string;
+  signIn?: string;
+}
 
 /**
  * Streaming request helper that applies interceptor logic

--- a/src/lib/api-client/index.ts
+++ b/src/lib/api-client/index.ts
@@ -22,6 +22,7 @@
 
 // Export the base client and streaming utility
 export { apiClient, streamRequest } from './client';
+export type { ApiClientError } from './client';
 
 // Export all types (single source of truth)
 export * from './types';

--- a/tests/unit/page-write-auth.test.ts
+++ b/tests/unit/page-write-auth.test.ts
@@ -303,11 +303,13 @@ describe('the page-write route list stays complete', () => {
       'src/app/api/[tenant]/pages/[id]/modernize/route.ts',
       'src/app/api/pages/[id]/detect-split/route.ts',
       'src/app/api/[tenant]/pages/[id]/detect-split/route.ts',
-      // TODO(ops#6 PR 2): `transliterate` is the one route in this group with
-      // real anonymous reader traffic — TranslationEditor auto-fires it when
-      // the panel opens, outside every <AuthCheck>. Editor-gating it would
-      // break signed-out reading, so it gets `anonActionGate` on the
-      // cache-miss path instead and is covered by its own test, not by CASES.
+      // `transliterate` is the one route in this group with real anonymous
+      // reader traffic — TranslationEditor auto-fires it when the panel opens,
+      // outside every <AuthCheck>. Editor-gating it would break signed-out
+      // reading, so it is metered by `anonActionGate` on the cache-miss path
+      // instead of walled. It belongs in this covered set but NOT in CASES,
+      // which asserts role behaviour. Its own guard is
+      // tests/unit/transliterate-anon-gate.test.ts.
       'src/app/api/pages/[id]/transliterate/route.ts',
       'src/app/api/[tenant]/pages/[id]/transliterate/route.ts',
     ]);

--- a/tests/unit/transliterate-anon-gate.test.ts
+++ b/tests/unit/transliterate-anon-gate.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `POST /api/pages/[id]/transliterate` generates a paid Gemini call, and
+ * TranslationEditor auto-fires it from a `useEffect` when the transliteration
+ * panel opens — outside every `<AuthCheck>`, so a signed-out reader triggers
+ * it. Editor-gating it (as ops#6 did for modernize/ask/detect-split) would
+ * break signed-out reading of every non-Latin-script book, so anonymous volume
+ * is METERED rather than walled.
+ *
+ * The invariant with teeth is the split: a CACHE HIT must stay free, because
+ * that is the majority of real reader traffic and it costs nothing. Only the
+ * generate path is gated. Getting that backwards — gating the whole route —
+ * would wall readers on pages we have already paid for.
+ *
+ * This exercises the real route module with `anonActionGate` mocked at the
+ * boundary, so it fails if the gate call is deleted, if it moves above the
+ * cache return, or if a non-allowed result stops short-circuiting. Verified by
+ * deleting the gate block and watching it go red, per the "a test that greps
+ * source is not a guard" rule in CLAUDE.md.
+ */
+
+const gate = vi.fn(async () => ({ allowed: true }) as { allowed: boolean; retryAfter?: number });
+const performTransliteration = vi.fn(async () => ({
+  text: 'Aurum nostrum non est aurum vulgi.',
+  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0 },
+}));
+
+vi.mock('@/lib/anon-gate', () => ({
+  anonActionGate: (...args: unknown[]) => gate(...(args as [])),
+  SIGNIN_URL: 'https://sourcelibrary.org/auth/signin',
+}));
+
+vi.mock('@/lib/ai', () => ({
+  performTransliteration: (...args: unknown[]) => performTransliteration(...(args as [])),
+}));
+
+vi.mock('@/lib/gemini-logger', () => ({ logGeminiCall: vi.fn() }));
+
+vi.mock('@/lib/tenant-context', () => ({
+  resolveTenantId: vi.fn(async () => 'tenant-uuid'),
+}));
+
+/** OCR text and the hash the route computes from it, kept in sync below. */
+const OCR = 'τὸ χρυσίον ἡμῶν οὐκ ἔστι τὸ χρυσίον τῶν πολλῶν';
+
+function hashString(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash) + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return hash.toString(16);
+}
+
+/** A page whose stored transliteration matches its OCR — i.e. a cache hit. */
+const CACHED_PAGE = {
+  id: 'page-1',
+  book_id: 'book-1',
+  ocr: { data: OCR },
+  transliteration: {
+    data: 'to chrysion hemon ouk esti to chrysion ton pollon',
+    source_ocr_hash: hashString(OCR),
+    script: 'Greek',
+  },
+};
+
+/** Same page with no stored transliteration — i.e. a cache miss. */
+const UNCACHED_PAGE = { id: 'page-1', book_id: 'book-1', ocr: { data: OCR } };
+
+let page: Record<string, unknown> = CACHED_PAGE;
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: vi.fn(async () => ({
+    collection: (name: string) => ({
+      findOne: async () => (name === 'pages' ? page : { id: 'book-1', language: 'greek' }),
+      updateOne: async () => ({ matchedCount: 1 }),
+    }),
+  })),
+}));
+
+/**
+ * Both twins, always. Every route in this area exists twice, and #3511 found
+ * two pairs that disagreed about who may call them — fixing one and shipping
+ * is how the identical bug shipped twice in one week before.
+ */
+const ROUTES = [
+  {
+    name: '/api/pages/[id]/transliterate',
+    load: () => import('@/app/api/pages/[id]/transliterate/route'),
+    params: { id: 'page-1' },
+  },
+  {
+    name: '/api/[tenant]/pages/[id]/transliterate',
+    load: () => import('@/app/api/[tenant]/pages/[id]/transliterate/route'),
+    params: { tenant: 'bph', id: 'page-1' },
+  },
+];
+
+describe.each(ROUTES)(
+  '$name meters anonymous generation without walling reads (ops#6)',
+  (route) => {
+    async function post(body: unknown = {}) {
+      const { POST } = await route.load();
+      const req = new Request('https://sourcelibrary.org/api/pages/page-1/transliterate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return (POST as (r: unknown, c: unknown) => Promise<Response>)(req, {
+        params: Promise.resolve(route.params),
+      });
+    }
+
+    beforeEach(() => {
+      gate.mockClear();
+      performTransliteration.mockClear();
+      gate.mockResolvedValue({ allowed: true });
+      page = CACHED_PAGE;
+    });
+
+    it('serves a cache hit without consulting the gate at all', async () => {
+      const res = await post();
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ cached: true });
+      // The point of the whole design: a free read never touches the limiter, so
+      // browsing already-transliterated pages cannot exhaust the hourly budget.
+      expect(gate).not.toHaveBeenCalled();
+      expect(performTransliteration).not.toHaveBeenCalled();
+    });
+
+    it('serves a cache hit even when the gate would refuse', async () => {
+      gate.mockResolvedValue({ allowed: false, retryAfter: 1800 });
+
+      const res = await post();
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ cached: true });
+    });
+
+    it('consults the gate on a cache miss', async () => {
+      page = UNCACHED_PAGE;
+
+      const res = await post();
+
+      expect(res.status).toBe(200);
+      expect(gate).toHaveBeenCalledTimes(1);
+      expect(gate.mock.calls[0][1]).toMatchObject({ name: 'transliterate' });
+      expect(performTransliteration).toHaveBeenCalledTimes(1);
+    });
+
+    it('consults the gate when regenerate skips a valid cache', async () => {
+      const res = await post({ regenerate: true });
+
+      expect(res.status).toBe(200);
+      expect(gate).toHaveBeenCalledTimes(1);
+    });
+
+    it('refuses a walled caller with 401, a machine-readable code and Retry-After', async () => {
+      page = UNCACHED_PAGE;
+      gate.mockResolvedValue({ allowed: false, retryAfter: 1800 });
+
+      const res = await post();
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get('Retry-After')).toBe('1800');
+      const body = await res.json();
+      // The client keys on `code`, never on the copy — see the api-client
+      // response interceptor, which carries code/sign_in through.
+      expect(body.code).toBe('SIGNIN_REQUIRED');
+      expect(body.sign_in).toBe('https://sourcelibrary.org/auth/signin');
+      // Refusing must be free: no Gemini call happens behind a closed gate.
+      expect(performTransliteration).not.toHaveBeenCalled();
+    });
+
+    it('omits Retry-After when the gate does not supply one', async () => {
+      page = UNCACHED_PAGE;
+      gate.mockResolvedValue({ allowed: false });
+
+      const res = await post();
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get('Retry-After')).toBeNull();
+    });
+  },
+);


### PR DESCRIPTION
> **Stacked on #3574** — base is `fix/gate-ai-page-routes`, not `main`, because both PRs touch the two `transliterate` routes and `page-write-auth.test.ts`. Merge #3574 first and this retargets cleanly. The diff shown here is this PR's changes only.

## Why this one is different

Second half of ops#6. `transliterate` is the only AI page route with **real anonymous reader traffic**: `TranslationEditor.tsx:830` auto-fires it from a `useEffect` when the transliteration panel opens, and the toolbar toggle at `:1338` sits outside every `<AuthCheck>`. Editor-gating it the way #3574 gated `modernize`/`ask`/`detect-split` would break signed-out reading of every non-Latin-script book.

So it gets a **rate limit, not a wall**.

## The split that matters

`anonActionGate` runs on the **cache-miss path only**, copying the precedent at `books/[id]/pages/[pageId]/alignment/route.ts:51-65`. A cache hit is free and ungated — it costs nothing and it's the majority of real traffic. Signed-in users, verified crawlers and warm pings are exempt inside the gate.

**Limit is 200/hour per IP, deliberately generous.** One uncached page equals one call, so a reader working through a Tibetan or Arabic book at 60 pages an hour is an ordinary session, not abuse — and a university reading room behind NAT is a single `cf-connecting-ip` sharing one bucket. The intent is to tighten off `{ event: 'gate_hit', feature: 'transliterate' }` rows in `analytics_events` after a week in production, never up front.

Checked before writing it: `getClientIp` reads `cf-connecting-ip` before `x-forwarded-for` ([rate-limit.ts:180](src/lib/rate-limit.ts#L180)), so this does **not** collapse every front-door reader into the ~15 shared Cloudflare edge addresses. That's the #3487 shape and it would have walled everyone within minutes of deploy.

## Client side — ships with it or the gate is just a bug

The panel auto-fires, so an unhandled 401 shows a reader a failure toast for something they did nothing wrong to hit.

- **`src/lib/api-client/client.ts`** — the response interceptor collapsed every error to `new Error(message)`, so a caller could only recognise an anon-gate wall by regex-matching the copy. `src/app/search/page.tsx:1192` does exactly that today, and it breaks the moment the wording changes. The thrown error now carries `status` / `code` / `signIn` (additive; `err.message` is unchanged).
- **`TranslationEditor.tsx`** — keys on `code === 'SIGNIN_REQUIRED'` and renders a sign-in CTA inside the panel (matching the existing `/search` wall pattern, `?reason=limit`) instead of a toast. Nothing retries. Both call sites — the auto-fire effect and the explicit button — go through one shared `handleTransliterationError`.

## Guard

`tests/unit/transliterate-anon-gate.test.ts`, parameterised over **both twins** (per CLAUDE.md's "check the twins" rule — #3511 found two pairs that disagreed). 12 tests. It exercises the real route module with `anonActionGate` mocked at the boundary.

**Three negative controls, each run and restored:**

| Mutation | Result |
|---|---|
| Delete the gate from the unscoped route | 4 red |
| Delete it from the tenant route | 4 red |
| Move it **above** the cache return | the 2 cache-hit tests go red |

The third is the one that matters. It's the plausible mistake, and it's the one that would wall readers on pages we've already paid for.

`npx tsc --noEmit` clean, eslint 0 errors (11 pre-existing warnings in `TranslationEditor`), 1487/1487 unit tests pass.

## Verification still to do on the preview

- Cached page, anonymous → 200, `cached: true`, no gate consulted.
- 201 × `{"regenerate":true}` from one IP → the 201st is 401 with `Retry-After`.
- Signed out in a browser: open a non-Latin-script book, toggle the panel — first open works; past the cap the panel shows a sign-in prompt, not an error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)