### PR TITLE
fix(quotes): the epigraphy wrapper family reached quotable text (#3524)

### DIFF
--- a/scripts/lib/strip-editorial-wrappers.mjs
+++ b/scripts/lib/strip-editorial-wrappers.mjs
@@ -12,7 +12,23 @@
 // incident history (PR #2232, #3108, issue #2764).
 
 const EDITORIAL_WRAPPERS =
-  'meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning|image-desc';
+  'meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning|image-desc'
+  // The EPIGRAPHY/ARTIFACT schema, used by tablet, papyrus and manuscript-fragment
+  // records. `<condition>` in particular is a paragraph of English prose about the
+  // OBJECT ("The image shows multiple fragments (K.2421, K.2511, K.16765) from the
+  // British Museum collection..."), which is editorial description, not the text on
+  // the page — quoting it fabricates a citation exactly as `<meta>` did (#2232).
+  //
+  // Deliberately NOT included: `<transliteration>`, which holds the real
+  // line-by-line reading of the artifact and IS the page's text; and `<notes>` /
+  // `<confidence>`, whose contents were not verified, so they are left alone rather
+  // than guessed at.
+  //
+  // SCOPE, measured 2026-08-03: 5 pages across 4 books (Ur III Administrative
+  // Tablet, Code of Hammurabi, Neo-Assyrian Medical Prescriptions, Manishtusu
+  // Obelisk) — zero hits in a random 30,240-page sample. Small, but a fabricated
+  // citation is a fabricated citation.
+  + '|condition|period|surface|genre';
 
 function flattenMarkdownTables(text) {
   return text

--- a/src/lib/strip-editorial-wrappers.ts
+++ b/src/lib/strip-editorial-wrappers.ts
@@ -39,7 +39,23 @@
 // quote/search/text/IIIF surfaces route through here, so stripping it here does
 // not touch the reader.
 const EDITORIAL_WRAPPERS =
-  'meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning|image-desc';
+  'meta|summary|keywords|vocab|language|scan-quality|script|page-type|columns|warning|image-desc'
+  // The EPIGRAPHY/ARTIFACT schema, used by tablet, papyrus and manuscript-fragment
+  // records. `<condition>` in particular is a paragraph of English prose about the
+  // OBJECT ("The image shows multiple fragments (K.2421, K.2511, K.16765) from the
+  // British Museum collection..."), which is editorial description, not the text on
+  // the page — quoting it fabricates a citation exactly as `<meta>` did (#2232).
+  //
+  // Deliberately NOT included: `<transliteration>`, which holds the real
+  // line-by-line reading of the artifact and IS the page's text; and `<notes>` /
+  // `<confidence>`, whose contents were not verified, so they are left alone rather
+  // than guessed at.
+  //
+  // SCOPE, measured 2026-08-03: 5 pages across 4 books (Ur III Administrative
+  // Tablet, Code of Hammurabi, Neo-Assyrian Medical Prescriptions, Manishtusu
+  // Obelisk) — zero hits in a random 30,240-page sample. Small, but a fabricated
+  // citation is a fabricated citation.
+  + '|condition|period|surface|genre';
 
 /**
  * Flatten GFM markdown tables to plain text.

--- a/tests/unit/ngram-normalize.test.ts
+++ b/tests/unit/ngram-normalize.test.ts
@@ -75,6 +75,48 @@ describe('wrapper-stripper parity (mjs twin vs src/lib original)', () => {
   });
 });
 
+/**
+ * The EPIGRAPHY/ARTIFACT wrapper family (#3524).
+ *
+ * Tablet and papyrus records use a schema the codex wrappers never covered, and
+ * `<condition>` holds a paragraph of English prose describing the OBJECT. Served
+ * as quotable text that is a fabricated citation — the #2232 class in a family
+ * nobody had enumerated.
+ *
+ * The distinction that matters: `<condition>` is ABOUT the artifact and goes;
+ * `<transliteration>` IS the artifact's text and stays. A stripper that took both
+ * would erase the only readable content these records have.
+ */
+describe('artifact wrappers: description goes, transliteration stays', () => {
+  const TABLET = [
+    '<surface>full-view</surface>',
+    '<language>Akkadian</language>',
+    '<period>ca. 668-631 BC (Library of Ashurbanipal)</period>',
+    '<condition>The image shows multiple fragments (K.2421, K.2511, K.16765) from',
+    'the British Museum collection, joined to form a substantial portion of a tablet.</condition>',
+    '<genre>literary</genre>',
+    '<transliteration>a-sar-ri ba-ni i-ne-mi sa-a-ti</transliteration>',
+  ].join('\n');
+
+  for (const [name, strip] of [['ts', stripTs], ['mjs', stripMjs]] as const) {
+    it(`${name}: drops the artifact DESCRIPTION`, () => {
+      const out = strip(TABLET);
+      expect(out).not.toMatch(/British Museum/);
+      expect(out).not.toMatch(/fragments/);
+      expect(out).not.toMatch(/Library of Ashurbanipal/);
+      expect(out).not.toMatch(/literary/);
+    });
+
+    it(`${name}: KEEPS the transliteration — it is the page's text`, () => {
+      expect(strip(TABLET)).toMatch(/a-sar-ri ba-ni/);
+    });
+  }
+
+  it('the two twins agree on the artifact fixture', () => {
+    expect(stripMjs(TABLET)).toEqual(stripTs(TABLET));
+  });
+});
+
 describe('normalizer behavior', () => {
   it('folds long s and ligatures', () => {
     expect(ts.tokenize('Chymiſtry æther ﬁre', 'en')).toEqual(['chymistry', 'aether', 'fire']);


### PR DESCRIPTION
`stripEditorialWrappers` knew the codex families (`<meta>`, `<summary>`, `<scan-quality>`, …). Tablet, papyrus and manuscript-fragment records use a schema it never covered — `<condition>`, `<period>`, `<surface>`, `<genre>` — and `<condition>` holds a paragraph of English prose describing the **object**:

> The image shows multiple fragments (K.2421, K.2511, K.16765) from the British Museum collection, joined to form a substantial portion of a tablet.

Served as quotable text, that is a fabricated citation — the #2232 class, in a family nobody had enumerated. Added to both twins (`src/lib/*.ts` and `scripts/lib/*.mjs`), parity pinned.

## The distinction that matters

`<condition>` is **about** the artifact and goes. `<transliteration>` **is** the artifact's text and stays — a stripper that took both would erase the only readable content these records have.

`<notes>` and `<confidence>` are deliberately **left alone**: their contents were not verified, and guessing is how the codex list grew wrong in the first place.

## Scope — and a correction to my own claim

[#3566](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/pull/3566)'s description said this family was *"probably reaching the quote/search/ngram surfaces"* with *"a much wider blast radius."* **That was asserted, not measured, and measuring it shrinks it a long way:**

| check | result |
|---|---|
| random 30,240-page sample | **0 hits** |
| targeted scan, all 3,193 books under 7 pages | **5 pages across 4 books** |

The four: Ur III Administrative Tablet (Drehem), Code of Hammurabi, Neo-Assyrian Medical Prescriptions (BAM 6, 555), Manishtusu Obelisk. One carries a first-translation badge.

So this is a small fix, not the wide one I implied. It is still worth making — a fabricated citation is a fabricated citation, and the cost is four tags in a regex.

## Negative control, both directions

| mutation | result |
|---|---|
| baseline | 24 passed |
| remove the four new tags | **2 failed** |
| add `<transliteration>` to the strip list | **2 failed** |
| restored | 24 passed |

(The first attempt at this control was itself wrong: I used `git checkout <file>` to restore between mutations, which restores from the **index** and silently reverted the unstaged change — so "restored" reported 2 failures. Redone with a file backup.)

## Out of scope

- No re-derivation of stored artifacts. `page_translations` snippets and embeddings written by the old stripper still contain this prose; that is the same frozen-artifact problem as #2232 and needs `backfill-clean-snippets.mjs`, not this PR.
- `<notes>` / `<confidence>`: unverified, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)