### PR TITLE
fix: replace stale derek@playpowerlabs.com contact on volunteer-facing pages

### DIFF
--- a/scripts/analysis/resolve-work-ids-wikidata.mjs
+++ b/scripts/analysis/resolve-work-ids-wikidata.mjs
@@ -17,7 +17,7 @@ import fs from 'fs';
 const APPLY = process.argv.includes('--apply');
 const LANG = (process.argv.find(a=>a.startsWith('--lang='))||'--lang=greek').split('=')[1].toLowerCase();
 const BOOKLANGS = { greek:['Greek','Ancient Greek'], latin:['Latin'], pali:['Pali','Pāli'] }[LANG] || [LANG[0].toUpperCase()+LANG.slice(1)];
-const UA = 'SourceLibrary-work-resolver/1.0 (https://sourcelibrary.org; derek@playpowerlabs.com)';
+const UA = 'SourceLibrary-work-resolver/1.0 (https://sourcelibrary.org; team@sourcelibrary.org)';
 const deacc = s => (s||'').normalize('NFKD').replace(/[̀-ͯ]/g,'').toLowerCase();
 // apparatus words only. NOT container words (fragments/works/opera) — those must
 // survive tokenization so the container-skip can see and reject them; they live

--- a/scripts/import-jung-library.mjs
+++ b/scripts/import-jung-library.mjs
@@ -126,7 +126,7 @@ async function harvestSet(setSpec) {
   while (url) {
     page++;
     const res = await fetch(url, {
-      headers: { 'User-Agent': 'SourceLibrary/1.0 (Jung Library crossref; derek@playpowerlabs.com)' },
+      headers: { 'User-Agent': 'SourceLibrary/1.0 (Jung Library crossref; team@sourcelibrary.org)' },
       signal: AbortSignal.timeout(60000),
     });
     if (!res.ok) {

--- a/src/app/brand/page.tsx
+++ b/src/app/brand/page.tsx
@@ -774,7 +774,7 @@ export default function BrandPage() {
               </div>
               <div className="border border-stone-200 rounded-lg p-4">
                 <p className="text-xs uppercase tracking-wide text-stone-400 mb-1">Email</p>
-                <p className="font-mono text-stone-700">derek@playpowerlabs.com</p>
+                <p className="font-mono text-stone-700">team@sourcelibrary.org</p>
                 <p className="text-xs text-stone-500 mt-1">Contact for press, partnerships, donor inquiries</p>
               </div>
             </div>

--- a/src/app/volunteers/page.tsx
+++ b/src/app/volunteers/page.tsx
@@ -95,15 +95,16 @@ export default function VolunteersWelcomePage() {
           only for spam detection.
         </p>
         <p>
-          <b>Feedback:</b>{' '}
-          <a href="mailto:derek@playpowerlabs.com" className="text-accent-rust hover:underline">
-            derek@playpowerlabs.com
+          <b>Feedback:</b> every queue has a note box — if you can see something the rating buttons
+          can't express, write it there and it comes straight to us. For anything longer,{' '}
+          <a href="mailto:team@sourcelibrary.org" className="text-accent-rust hover:underline">
+            team@sourcelibrary.org
           </a>
           . Bug reports, queue ideas, and "this rating UI made me crazy" notes all welcome.
         </p>
         <p>
-          <b>Want to be credited?</b> Reply to the invite email and we'll add you to the contributors page once
-          that lands.
+          <b>Want to be credited?</b> Say so in a note or an email and we'll add you to the
+          contributors page once that lands.
         </p>
       </div>
     </main>


### PR DESCRIPTION
Follow-on from #3568, found while reviewing the volunteer materials.

`/volunteers` is the noindex landing page written for outreach emails to invited volunteers — the page the 117 people who signed up would be sent to. It still offered **a personal address at a former employer** as its only feedback channel, and told readers to *"reply to the invite email"* to be credited, presuming an email that has never been sent.

`git grep` found six more instances of the same address. Fixed the ones that face a human or an external service:

| file | why |
|---|---|
| `src/app/volunteers/page.tsx` | the volunteer landing page — now points at the per-queue note box added in #3568, with `team@sourcelibrary.org` for anything longer |
| `src/app/brand/page.tsx` | listed as the contact for "press, partnerships, donor inquiries" |
| `scripts/analysis/resolve-work-ids-wikidata.mjs` | User-Agent contact — Wikidata uses it to reach us |
| `scripts/import-jung-library.mjs` | same, for Crossref |

A bouncing contact address in a User-Agent is worse than none: it is the channel a provider uses before rate-limiting or blocking you.

**Deliberately not changed:** the `ALERT_RECIPIENT` fallback in `src/app/api/admin/alert/route.ts`. Repointing where production alerts land is an ops decision rather than a copy fix, and changing it silently could drop alerts someone is still reading. Flagging it rather than touching it.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)