### PR TITLE
fix(review): drop unshowable pages from the review pool, and actually apply the contested-band bias

### DIFF
--- a/scripts/maintenance/build-review-candidates.mjs
+++ b/scripts/maintenance/build-review-candidates.mjs
@@ -110,6 +110,25 @@ function shuffle(arr) {
   return arr;
 }
 
+/**
+ * Pages a volunteer must never be shown.
+ *
+ * A NEGATIVE `page_number` is a soft-hide (see the page-image field notes): the
+ * page is deliberately not reachable in the reader, usually an un-split spread
+ * superseded by its two halves. Its `page_link` resolves to `/page/-111`, a
+ * dead URL — so the "click to open the actual page" affordance is broken, and
+ * any judgment collected is about a page no reader will ever see. Measured
+ * before this filter: 7.5% of the scan-quality pool, 3.7% of hallucination.
+ *
+ * `archived-spread` is the same story from the other side: the spread is kept
+ * for provenance but the halves are what readers get.
+ */
+function isUnshowable(p) {
+  if (typeof p.page_number !== 'number' || p.page_number < 0) return true;
+  if (p.page_type === 'archived-spread') return true;
+  return false;
+}
+
 function imageUrlFor(p, bookId) {
   return (
     p.archived_photo ||
@@ -175,8 +194,34 @@ async function main() {
         .toArray();
       shuffle(rows);
 
-      for (const g of rows) {
-        if (collected.length >= TARGET) break;
+      /* Bias toward the CONTESTED band, which is the whole point of asking a
+         human. The 0.7 display cutoff means images scored 0.5-0.85 are where a
+         human judgment can actually change what the gallery shows; an image at
+         0.95 is one everybody agrees on, and rating it teaches us nothing.
+         The old per-request route drew 70% from that band. When this builder
+         replaced it the bias was lost — the route comment claimed it "now
+         lives in the builder" while the builder just took everything >= 0.4,
+         and the resulting pool came out 34% at >= 0.85.
+
+         Fill the contested band to quota FIRST, then top up from the rest.
+         Ordering the array and iterating once is not enough: the per-book cap
+         skips a large share of the prefix, so the tail silently backfills with
+         uncontested images (measured 42.5% contested when we tried that). */
+      const CONTESTED_SHARE = 0.7;
+      const contestedTarget = Math.round(TARGET * CONTESTED_SHARE);
+      const inContested = g => g.gallery_quality >= 0.5 && g.gallery_quality < 0.85;
+      const passes = [
+        { rows: rows.filter(inContested), limit: contestedTarget },
+        { rows: rows.filter(g => !inContested(g)), limit: TARGET },
+        { rows: rows.filter(inContested), limit: TARGET }, // top up if the band ran dry
+      ];
+
+      for (const pass of passes) {
+      for (const g of pass.rows) {
+        if (collected.length >= Math.min(pass.limit, TARGET)) break;
+        // Soft-hidden pages (negative page_number) link to a dead /page/-111
+        // URL, same as in the pages lane — see isUnshowable().
+        if (typeof g.page_number !== 'number' || g.page_number < 0) continue;
         const taken = perBookCount.get(g.book_id) ?? 0;
         if (taken >= PER_BOOK) continue;
         perBookCount.set(g.book_id, taken + 1);
@@ -208,6 +253,7 @@ async function main() {
           gold_answer: null,
           created_at: new Date(),
         });
+      }
       }
       booksScanned = perBookCount.size;
     }
@@ -254,6 +300,7 @@ async function main() {
       let takenFromBook = 0;
       for (const p of pageDocs) {
         if (takenFromBook >= PER_BOOK || collected.length >= TARGET) break;
+        if (isUnshowable(p)) continue;
 
         const pageLink = `https://sourcelibrary.org/book/${book.slug || book.id}/page/${p.page_number}`;
         const bookMeta = {

--- a/src/app/api/review/gallery-quality/next/route.ts
+++ b/src/app/api/review/gallery-quality/next/route.ts
@@ -7,10 +7,11 @@ export const maxDuration = 15;
  * GET /api/review/gallery-quality/next?volunteer_id=<uuid>
  *
  * Returns one unrated extracted image for the gallery-quality queue.
- * The pool is built from images at gallery_quality >= 0.4, capped per book so
- * one heavily-illustrated volume can't dominate the sample. That selection now
- * lives in the builder (scripts/maintenance/build-review-candidates.mjs)
- * rather than in the request path.
+ * The pool is built biased toward the contested 0.5-0.85 quality band — where
+ * the 0.7 display cutoff means a human judgment can actually change what the
+ * gallery shows — and capped per book so one heavily-illustrated volume can't
+ * dominate the sample. Both live in the builder
+ * (scripts/maintenance/build-review-candidates.mjs), not in the request path.
  *
  * This route never 504'd, but `$sample` over `gallery_images` (207K docs) cost
  * ~8.2s per item, which is its own kind of unusable. It now reads the pooled

--- a/src/generated/blog-revisions.json
+++ b/src/generated/blog-revisions.json
@@ -278,8 +278,8 @@
   "progress-studies": {
     "path": "src/app/blog/progress-studies/page.tsx",
     "published": "2026-03-08T13:52:21+01:00",
-    "revised": "2026-07-16T01:06:36+02:00",
-    "revisions": 10
+    "revised": "2026-08-02T01:54:47+08:00",
+    "revisions": 11
   },
   "rashi-ocr": {
     "path": "src/app/blog/rashi-ocr/page.tsx",
@@ -295,9 +295,9 @@
   },
   "reciting-not-reading": {
     "path": "src/app/blog/reciting-not-reading/page.tsx",
-    "published": "2026-07-30T15:35:23+02:00",
+    "published": "2026-07-30T11:13:19+02:00",
     "revised": "2026-07-30T15:35:23+02:00",
-    "revisions": 1
+    "revisions": 2
   },
   "rithmomachia": {
     "path": "src/app/blog/rithmomachia/page.tsx",


### PR DESCRIPTION
Found by **working the queues as a volunteer would** before inviting 163 people to them. Neither defect is visible in the code; both are obvious within a dozen items.

## 1. Soft-hidden pages were in the pool

A negative `page_number` is a soft-hide — usually an un-split spread superseded by its two halves. Its `page_link` resolves to a dead URL:

```
https://sourcelibrary.org/book/navagraha-shanti-vidhanamu/page/-111
```

So the "click to open the actual page" affordance 404s, and any judgment collected is about a page no reader can reach. `archived-spread` is the same story from the other side.

| queue | soft-hidden before | after |
|---|---|---|
| scan-quality | 226 / 3000 (7.5%) | **0** |
| hallucination | 110 / 3000 (3.7%) | **0** |
| gallery-quality | 49 / 3000 (1.6%) | **0** |

## 2. The contested-band bias was lost, and a comment claimed otherwise

The old per-request route drew **70% from `gallery_quality` 0.5–0.85** — the band where the 0.7 display cutoff means a human judgment can actually change what the gallery shows. An image at 0.95 is one everybody agrees on; rating it teaches us nothing.

When the builder replaced that route the bias was dropped — it simply took everything `>= 0.4` — **while the route comment asserted the bias "now lives in the builder."** It did not. The pool came out 34% at `>= 0.85`.

Worth noting the failure mode: ordering the array contested-first and iterating once does **not** fix it. The per-book cap skips a large share of the prefix, so the tail silently backfills with uncontested images — measured **42.5%** contested when tried that way. It needs a real quota pass.

Pool after re-seed: **70.6% contested / 29.4% at >= 0.85**, against the intended 70/30.

## Verification

Re-seeded all three pools from Hetzner and re-measured against production Mongo — the numbers above are post-fix counts, not projections. `node --check` on the script, `npx tsc --noEmit` clean.

## Not fixed here, but found

- **`scan-quality` asks seven questions on three different axes** — `pristine/good/degraded` (quality), `bitonal/microfilm` (technique), `blank` (property of the page). A clean bitonal microfilm is honestly both "good" and "microfilm", so two careful reviewers disagree for reasons that have nothing to do with the corpus. That noise would land in any agreement statistic this queue feeds.
- **The pool contains objects that are not pages at all** — e.g. a colour photograph of a Tibetan cloth wrapper with a handwritten label pinned to it, `page_type=text`. None of the seven buttons honestly answers it.

Recommendation: **do not include `scan-quality` in the first volunteer invitation.** `hallucination` and `gallery-quality` are in good shape; scan-quality needs its scale re-cut first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)