### PR TITLE
feat(ft): the CANDIDATE state — default the claim, let evidence defeat it (#3524)

### DIFF
--- a/src/lib/first-translation/candidate.ts
+++ b/src/lib/first-translation/candidate.ts
@@ -1,0 +1,192 @@
+/**
+ * The CANDIDATE state — defaulting the claim, and letting evidence defeat it.
+ *
+ * WHY THE DEFAULT FLIPS
+ * ---------------------
+ * "First English translation" is an unprovable universal negative: a catalogue
+ * can only ever return *nothing found*. Our catalogue's recall is **27%** — three
+ * of every four known prior English translations are invisible to it — so a
+ * `none_found` can never be strong enough to assert the negative outright.
+ *
+ * The instrument is, however, precise in the OTHER direction. A prior that IS
+ * found is a positive, checkable fact (32/32 live identity confirmations; zero
+ * contradictions across 399 independently-classified `never_translated` books).
+ *
+ * So build on what the instrument is good at: **every non-English book is a
+ * candidate until a prior is linked.** Two properties follow, and both are the
+ * point:
+ *
+ *  - It is HONEST at any recall. "No prior translation found, here is the search"
+ *    is a claim about a bounded, dated act we actually performed. "This is the
+ *    first" is a claim about the world that no search can support.
+ *  - It is MONOTONE. Adding a source (ESTC, 84000, CBETA) can only ever move
+ *    books from candidate to defeated — never the reverse. The corpus corrects
+ *    itself as evidence grows, instead of wrong badges sitting wrong forever
+ *    until someone re-verifies each by hand.
+ *
+ * WHAT THIS FILE IS NOT
+ * ---------------------
+ * It does not write anything, it does not touch `is_first_translation`, and it
+ * renders nothing. It is a pure read over fields other passes already computed.
+ * The reconcile stays the single writer of the flag (#2564), and badge copy is a
+ * separate decision from badge state.
+ */
+
+import { isFirstTranslation, resolveFirstTranslation } from './derive';
+import type { FirstTranslationBook } from './types';
+
+/**
+ * What we can honestly say about this book's first-translation status.
+ *
+ * Ordered from strongest claim to no claim. `candidate` is the DEFAULT for the
+ * eligible pool, not an unusual state — measured 2026-08-03, 16,268 of 17,071
+ * eligible books sit here.
+ */
+export type FirstTranslationClaim =
+  /** A verified first. Earned by evidence, never defaulted into. */
+  | 'confirmed'
+  /** Non-English, no prior found, screens clear. The honest default. */
+  | 'candidate'
+  /** A prior English translation was found and linked. */
+  | 'defeated'
+  /** The question does not apply: the pages are already English, or this book IS a published translation. */
+  | 'not_applicable'
+  /** We could not ask. Distinct from "we asked and found nothing" — see below. */
+  | 'unknown';
+
+export interface FirstTranslationClaimResult {
+  claim: FirstTranslationClaim;
+  /** Machine-readable reason, for both UI copy and debugging a surprising claim. */
+  reason:
+    | 'verified_first'
+    | 'no_prior_found'
+    | 'prior_found'
+    | 'source_already_english'
+    | 'book_is_a_translation'
+    | 'catalogued_english'
+    | 'source_language_unscreened';
+  /**
+   * True when a screen could not run (no OCR, or too little legible text), so
+   * the claim rests on an UNRUN check rather than a passed one. A caller that
+   * renders a candidate must be able to say so.
+   *
+   * Deliberately not folded into `claim`: a book with no OCR is still a
+   * candidate, it is simply a less-checked one. Collapsing the two would either
+   * hide the gap or drop 449 books for a reason that is about us, not them.
+   */
+  screensIncomplete: boolean;
+  /** Set when a screen wants a human before this claim is published. */
+  needsReview: boolean;
+}
+
+/** Fields written by the two screening sweeps (#3524). */
+export interface ScreenedBook extends FirstTranslationBook {
+  source_language_screen?: {
+    verdict?: 'english_source' | 'foreign_source' | 'undetermined' | 'no_ocr';
+  } | null;
+  translator_author_screen?: { verdict?: 'hold' } | null;
+}
+
+const ENGLISH_LANGUAGES = new Set(['english', 'en', 'eng']);
+
+/**
+ * Is the CATALOGUED language English?
+ *
+ * ⚠️ Necessary but nowhere near sufficient, and never a substitute for the
+ * source-language screen. `books.language` is the language of the WORK, not of
+ * the pages we hold: Ganguli's *Mahābhārata* and Avalon's *Serpent Power* are
+ * catalogued Sanskrit and are English editions. That is why the screen exists,
+ * and why this check runs AFTER it.
+ */
+function isCataloguedEnglish(book: ScreenedBook): boolean {
+  const l = (book.language ?? '').trim().toLowerCase();
+  return ENGLISH_LANGUAGES.has(l);
+}
+
+/**
+ * Classify what we can honestly claim about this book.
+ *
+ * PRECEDENCE IS THE DESIGN. Evidence that DEFEATS the claim is checked before
+ * evidence that supports it, so a book can never be `confirmed` while carrying a
+ * found prior or an already-English source. That ordering is what makes the
+ * state monotone under new sources: adding evidence can only move a book down
+ * the list, never up.
+ */
+export function classifyFirstTranslationClaim(
+  book: ScreenedBook,
+): FirstTranslationClaimResult {
+  const sourceScreen = book.source_language_screen?.verdict;
+  const held = book.translator_author_screen?.verdict === 'hold';
+  const screensIncomplete =
+    sourceScreen === undefined || sourceScreen === 'no_ocr' || sourceScreen === 'undetermined';
+
+  // 1. A found prior defeats everything, including a confirmed verdict. This is
+  //    the only direction the instrument is reliable in, so it goes first.
+  const resolved = resolveFirstTranslation(book);
+  if (resolved?.verdict === 'not_first') {
+    return { claim: 'defeated', reason: 'prior_found', screensIncomplete, needsReview: false };
+  }
+
+  // 2. The pages are already English — measured, not inferred from `language`.
+  if (sourceScreen === 'english_source') {
+    return {
+      claim: 'not_applicable',
+      reason: 'source_already_english',
+      screensIncomplete: false,
+      needsReview: false,
+    };
+  }
+
+  // 3. Catalogued English AND not contradicted by the screen. Checked second
+  //    because the screen is the better instrument; this only catches books the
+  //    screen could not reach.
+  if (isCataloguedEnglish(book) && sourceScreen !== 'foreign_source') {
+    return {
+      claim: 'not_applicable',
+      reason: 'catalogued_english',
+      screensIncomplete,
+      needsReview: false,
+    };
+  }
+
+  // 4. The book may itself be a published translation we re-hosted (Legge's
+  //    *Chinese Classics*, the Loebs). A HOLD is a review request, never an
+  //    exclusion — the signal is irreducibly noisy (a translator is often also an
+  //    author; a rendering into German does not defeat a claim about English), so
+  //    §17 applies: never derive a destructive outcome from an unverified match.
+  //    The claim survives and is flagged.
+  if (held) {
+    return {
+      claim: 'candidate',
+      reason: 'book_is_a_translation',
+      screensIncomplete,
+      needsReview: true,
+    };
+  }
+
+  // 5. A verified first, earned through the existing gates (evidence quality,
+  //    readable coverage, the single-writer verdict).
+  if (isFirstTranslation(book)) {
+    return { claim: 'confirmed', reason: 'verified_first', screensIncomplete, needsReview: false };
+  }
+
+  // 6. The honest default.
+  return {
+    claim: 'candidate',
+    reason: screensIncomplete ? 'source_language_unscreened' : 'no_prior_found',
+    screensIncomplete,
+    needsReview: false,
+  };
+}
+
+/**
+ * Does this book carry a first-translation claim of ANY strength?
+ *
+ * Convenience for surfaces that list "works with no known prior translation"
+ * without distinguishing verified from candidate. Do NOT use it to render a
+ * badge: the whole point is that the two states must look different.
+ */
+export function hasFirstTranslationClaim(book: ScreenedBook): boolean {
+  const { claim } = classifyFirstTranslationClaim(book);
+  return claim === 'confirmed' || claim === 'candidate';
+}

--- a/src/lib/first-translation/index.ts
+++ b/src/lib/first-translation/index.ts
@@ -9,3 +9,4 @@ export * from './types';
 export * from './derive';
 export * from './attempt-log';
 export * from './resolve';
+export * from './candidate';

--- a/tests/unit/first-translation-candidate.test.ts
+++ b/tests/unit/first-translation-candidate.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The CANDIDATE state: what may be claimed, and what must defeat it. (#3524)
+ *
+ * These are behavioural, not source-shape. Every case below fails if the guard
+ * it covers is removed from `candidate.ts` — verified by deleting each branch in
+ * turn (see the PR). The fixtures are the real populations the screens found on
+ * 2026-08-03, not invented shapes.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  classifyFirstTranslationClaim,
+  hasFirstTranslationClaim,
+  type ScreenedBook,
+} from '../../src/lib/first-translation/candidate';
+
+/** A plain foreign-language book with a full translation and no prior found. */
+const FOREIGN: ScreenedBook = {
+  language: 'Latin',
+  pages_ocr: 100,
+  pages_blank: 0,
+  pages_translated: 100,
+  source_language_screen: { verdict: 'foreign_source' },
+};
+
+describe('the default is candidate, and it is the common case', () => {
+  it('a foreign book with no prior found is a candidate', () => {
+    const r = classifyFirstTranslationClaim(FOREIGN);
+    expect(r.claim).toBe('candidate');
+    expect(r.reason).toBe('no_prior_found');
+    expect(r.needsReview).toBe(false);
+    expect(r.screensIncomplete).toBe(false);
+  });
+
+  it('a candidate is NOT confirmed — the two must be distinguishable', () => {
+    expect(classifyFirstTranslationClaim(FOREIGN).claim).not.toBe('confirmed');
+  });
+});
+
+describe('evidence that defeats the claim', () => {
+  it('a found prior defeats it', () => {
+    const r = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      first_translation: { verdict: 'not_first' },
+    } as ScreenedBook);
+    expect(r.claim).toBe('defeated');
+    expect(r.reason).toBe('prior_found');
+  });
+
+  it('a found prior outranks a first-family verdict, not the other way round', () => {
+    // Precedence is the design: the direction the instrument is RELIABLE in wins.
+    const r = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      first_translation: { verdict: 'not_first', evidence_strength: 'strong' },
+    } as ScreenedBook);
+    expect(r.claim).toBe('defeated');
+  });
+
+  it('measured already-English pages make the question inapplicable', () => {
+    // Ganguli's *Mahābhārata*: catalogued Sanskrit, printed in English.
+    const r = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      language: 'Sanskrit',
+      source_language_screen: { verdict: 'english_source' },
+    });
+    expect(r.claim).toBe('not_applicable');
+    expect(r.reason).toBe('source_already_english');
+  });
+
+  it('a catalogued-English book the screen could not reach is inapplicable', () => {
+    // No screen verdict — this branch exists only to catch books the measured
+    // screen never reached. Where a screen HAS run it wins; see the next case.
+    const { source_language_screen: _drop, ...noScreen } = FOREIGN;
+    const r = classifyFirstTranslationClaim({ ...noScreen, language: 'English' });
+    expect(r.claim).toBe('not_applicable');
+    expect(r.reason).toBe('catalogued_english');
+  });
+
+  it('but the SCREEN outranks the catalogue when they disagree', () => {
+    // `books.language` is the language of the WORK, not of the pages. A book
+    // mislabelled English whose pages measure foreign stays a candidate.
+    const r = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      language: 'English',
+      source_language_screen: { verdict: 'foreign_source' },
+    });
+    expect(r.claim).toBe('candidate');
+  });
+});
+
+describe('a HOLD flags, it never excludes', () => {
+  it('keeps the claim and asks for a human', () => {
+    // Legge's *Chinese Classics*: bilingual, so the source screen correctly says
+    // foreign, and only the translator screen can see it.
+    const r = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      language: 'Chinese',
+      translator_author_screen: { verdict: 'hold' },
+    });
+    expect(r.claim).toBe('candidate');
+    expect(r.needsReview).toBe(true);
+    expect(r.reason).toBe('book_is_a_translation');
+  });
+
+  it('a hold does not silently become not_applicable', () => {
+    // §17: never derive a destructive outcome from an unverified match. The
+    // signal is noisy — a translator is often also an author.
+    const r = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      translator_author_screen: { verdict: 'hold' },
+    });
+    expect(r.claim).not.toBe('not_applicable');
+    expect(r.claim).not.toBe('defeated');
+  });
+});
+
+describe('"we could not ask" stays separate from "we asked and found nothing"', () => {
+  it('an unscreened book is still a candidate, but flagged as unscreened', () => {
+    const { source_language_screen: _drop, ...unscreened } = FOREIGN;
+    const r = classifyFirstTranslationClaim(unscreened);
+    expect(r.claim).toBe('candidate');
+    expect(r.screensIncomplete).toBe(true);
+    expect(r.reason).toBe('source_language_unscreened');
+  });
+
+  it('no OCR is unscreened, not a finding', () => {
+    const r = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      source_language_screen: { verdict: 'no_ocr' },
+    });
+    expect(r.claim).toBe('candidate');
+    expect(r.screensIncomplete).toBe(true);
+  });
+
+  it('undetermined is unscreened, not already-English', () => {
+    const r = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      source_language_screen: { verdict: 'undetermined' },
+    });
+    expect(r.claim).toBe('candidate');
+    expect(r.claim).not.toBe('not_applicable');
+    expect(r.screensIncomplete).toBe(true);
+  });
+
+  it('a screened book is NOT flagged incomplete', () => {
+    expect(classifyFirstTranslationClaim(FOREIGN).screensIncomplete).toBe(false);
+  });
+});
+
+describe('monotonicity: new evidence only ever weakens a claim', () => {
+  it('adding a found prior moves candidate -> defeated, never the reverse', () => {
+    const before = classifyFirstTranslationClaim(FOREIGN).claim;
+    const after = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      first_translation: { verdict: 'not_first' },
+    } as ScreenedBook).claim;
+    expect(before).toBe('candidate');
+    expect(after).toBe('defeated');
+  });
+
+  it('adding an english_source screen moves candidate -> not_applicable', () => {
+    expect(
+      classifyFirstTranslationClaim({
+        ...FOREIGN,
+        source_language_screen: { verdict: 'english_source' },
+      }).claim,
+    ).toBe('not_applicable');
+  });
+});
+
+describe('hasFirstTranslationClaim', () => {
+  it('covers confirmed and candidate, excludes the rest', () => {
+    expect(hasFirstTranslationClaim(FOREIGN)).toBe(true);
+    expect(
+      hasFirstTranslationClaim({
+        ...FOREIGN,
+        source_language_screen: { verdict: 'english_source' },
+      }),
+    ).toBe(false);
+    expect(
+      hasFirstTranslationClaim({
+        ...FOREIGN,
+        first_translation: { verdict: 'not_first' },
+      } as ScreenedBook),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
The state layer for candidate-by-default. **Pure read — writes nothing, touches no flag, renders nothing.** Badge *copy* is a separate decision from badge *state*, and this PR only does state.

## Why the default flips

"First English translation" is an unprovable universal negative and our catalogue's recall is **27%** — three of every four known priors are invisible to it. A `none_found` can never assert that.

But the instrument is precise in the **other** direction: a prior that *is* found is a positive, checkable fact (32/32 live identity confirmations; zero contradictions across 399 independently-classified `never_translated` books).

So build on the direction that works. Two properties follow, and both are the point:

- **Honest at any recall.** "No prior found, here is the search" is a claim about a bounded, dated act we performed. "This is the first" is a claim about the world no search can support.
- **Monotone.** Adding a source (ESTC, 84000, CBETA) can only move books candidate → defeated, never back. The corpus corrects itself as evidence grows, instead of wrong badges sitting wrong until someone re-checks each by hand.

## The API

`classifyFirstTranslationClaim(book)` → `confirmed | candidate | defeated | not_applicable | unknown`, plus `needsReview` and `screensIncomplete`.

**Precedence is the design.** Evidence that *defeats* is checked before evidence that *supports*, so a book can never be `confirmed` while carrying a found prior or an already-English source. That ordering is what makes the state monotone.

Three judgements worth arguing with:

| | |
|---|---|
| A **hold** flags, never excludes | The translator signal is irreducibly noisy — a translator is often also an author, and a rendering into German does not defeat a claim about English. §17. |
| The **screen outranks the catalogue** | `books.language` is the language of the WORK, not of the pages we hold (Ganguli's *Mahābhārata* is catalogued Sanskrit and is English). |
| `screensIncomplete` is **not** a claim | A book with no OCR is a *less-checked candidate*, not a different verdict. Folding them together would either hide the gap or drop 449 books for a reason that is about us, not them. |

## Validation

Negative control, per branch:

| mutation | result |
|---|---|
| baseline | 16 passed |
| remove defeat-by-prior | **4 failed** |
| remove the `english_source` gate | **3 failed** |
| remove the hold flag | **1 failed** |
| disable `screensIncomplete` | **3 failed** |
| restored | 16 passed |

Run against **4,000 live badged books**: 3,822 `confirmed`, 92 `candidate`, 48 `not_applicable`, 38 `defeated`.

⚠️ **A note on that number, because I nearly reported the opposite.** My first corpus run returned `confirmed: 0` and "all 5,947 badges unconfirmed" — which would have been an alarming and false finding. The cause was my own harness: it queried with a **projection** that dropped a field the gate reads. Re-run without the projection, 96% of badged books classify as `confirmed`. The full-corpus streaming run then timed out at 10 minutes, so the figures above are the 4,000-book sample, not the corpus.

## Out of scope

- **No rendering.** The two states must look different on the page, but that is badge copy and it is Derek's call.
- No writes, no reconcile change, no flag change.
- The 117 holds and the 158 classifier contradictions are surfaced by this classifier but not adjudicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)