### PR TITLE
fix(pages): an absent tenant is global scope, not a refusal (#3542)

### DIFF
--- a/src/app/api/[tenant]/pages/[id]/route.ts
+++ b/src/app/api/[tenant]/pages/[id]/route.ts
@@ -92,7 +92,19 @@ export async function GET(
  * PATCH /api/[tenant]/pages/[id] — replace a page's OCR / translation / summary.
  *
  * Gated at `editor` (#3511), matching both the UI gate and the global twin at
- * /api/pages/[id]. This is the route the reader's editor actually calls.
+ * /api/pages/[id].
+ *
+ * The 403 below is DELIBERATE and must not be relaxed to match the global twin,
+ * which now treats an absent tenant as global scope (#3542). Here `tenantId`
+ * comes from resolving the `[tenant]` path segment, so failing to resolve one
+ * means the caller named a tenant that does not exist — a misroute, not a global
+ * call. The two routes differ because their tenant inputs differ.
+ *
+ * Note this is NOT the only route the reader's editor reaches: `pagesApi` builds
+ * its URL from `window.location.pathname`, which is `/book/...` on the apex, so
+ * `getTenantSlug()` returns '' and the request interceptor collapses `/api//` to
+ * `/api/` — landing on the global twin. This route serves `/[tenant]/...` and
+ * `/embed/[tenant]/...` paths.
  */
 export const PATCH = withAuth(async (request, session, context) => {
   try {

--- a/src/app/api/pages/[id]/route.ts
+++ b/src/app/api/pages/[id]/route.ts
@@ -93,6 +93,27 @@ export async function GET(
  * so this is the API gate for an affordance no reader can see. It defaulted to
  * `reader` until #3511, which meant any signed-in account could overwrite a
  * page's text by calling the route directly.
+ *
+ * An absent tenant means GLOBAL SCOPE, not a refusal — the same semantics this
+ * route's GET has always had. This route used to answer 403 whenever no
+ * `x-tenant-id` was resolved, which made page saves fail on every book that
+ * carries no `tenantId` (30,132 of 34,039 visible books, measured 2026-08-04).
+ * The reader lives at `/book/<slug>/page/<id>` on the apex, so the only thing
+ * that ever supplied a tenant there was the proxy's referer fallback
+ * (`resolveTenantForBookSegment`), which resolves the tenant FROM THE BOOK and
+ * therefore returns null for a non-tenant one. Saves worked on the 11.5% of
+ * books owned by a tenant and 403'd on the rest (#3542).
+ *
+ * Access does not widen: with no `x-tenant-id`, `withAuth` cannot read a
+ * `memberships` row (`getTenantMembershipRole` returns null on a falsy tenant),
+ * so `effectiveRole` collapses to the JWT role — `superadmin` or `reader` and
+ * nothing else. Global page edits are therefore superadmin-only, which is the
+ * intended policy for now. Whether a non-superadmin should ever hold global
+ * edit rights is a separate open question — see the companion issue.
+ *
+ * The tenant twin `/api/[tenant]/pages/[id]` deliberately KEEPS its 403: there
+ * an unresolved tenant means the explicit `[tenant]` segment failed to resolve,
+ * which is a genuine misroute rather than a global call.
  */
 export const PATCH = withAuth(async (request, session, context) => {
   try {
@@ -100,9 +121,12 @@ export const PATCH = withAuth(async (request, session, context) => {
     const db = await getDb();
     const { id: tenantId } = getTenantContextFromRequest(request);
 
-    if (!tenantId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
-    }
+    // Scope the write to the tenant only when one was resolved. Note this must
+    // stay a conditional key: a literal `{ id, tenantId }` with a null tenant
+    // matches missing-and-null in Mongo, so it would appear to work on global
+    // books while silently never matching a tenant-owned page.
+    const scope: Record<string, unknown> = { id };
+    if (tenantId) scope.tenantId = tenantId;
 
     const rawBody = await request.json();
 
@@ -167,7 +191,7 @@ export const PATCH = withAuth(async (request, session, context) => {
 
     // Use findOneAndUpdate to get updated document in a single query
     const updatedPage = await db.collection('pages').findOneAndUpdate(
-      { id, tenantId },
+      scope,
       { $set: updateData, $inc: { edit_count: 1 } },
       { returnDocument: 'after' }
     );
@@ -181,13 +205,16 @@ export const PATCH = withAuth(async (request, session, context) => {
     if (body.ocr) {
       recordCorrectionEvent({
         revision: ocrRevision, after: body.ocr.data,
-        editorRole: 'editor', editedBy: editedBy, sessionEmail, tenantId,
+        editorRole: 'editor', editedBy: editedBy, sessionEmail,
+        // A global edit has no tenant to attribute; the field is optional.
+        tenantId: tenantId ?? undefined,
       }).catch(() => {});
     }
     if (body.translation) {
       recordCorrectionEvent({
         revision: translationRevision, after: body.translation.data,
-        editorRole: 'editor', editedBy: editedBy, sessionEmail, tenantId,
+        editorRole: 'editor', editedBy: editedBy, sessionEmail,
+        tenantId: tenantId ?? undefined,
       }).catch(() => {});
     }
 
@@ -229,22 +256,25 @@ export const DELETE = withAdminAuth(async (request, session, context) => {
     const db = await getDb();
     const { id: tenantId } = getTenantContextFromRequest(request);
 
-    if (!tenantId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
-    }
+    // Absent tenant = global scope, as on PATCH above. Still admin-gated, and
+    // with no `x-tenant-id` that resolves to superadmin only.
+    const scope: Record<string, unknown> = { id };
+    if (tenantId) scope.tenantId = tenantId;
+    const bookScope: Record<string, unknown> = {};
+    if (tenantId) bookScope.tenantId = tenantId;
 
     // Check if page exists
-    const page = await db.collection('pages').findOne({ id, tenantId });
+    const page = await db.collection('pages').findOne(scope);
     if (!page) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
     }
 
     // Delete the page
-    await db.collection('pages').deleteOne({ id, tenantId });
+    await db.collection('pages').deleteOne(scope);
 
     // Renumber remaining pages for this book - use bulkWrite for speed
     const remainingPages = await db.collection('pages')
-      .find({ book_id: page.book_id, tenantId })
+      .find({ book_id: page.book_id, ...bookScope })
       .sort({ page_number: 1 })
       .toArray();
 

--- a/tests/unit/page-write-auth.test.ts
+++ b/tests/unit/page-write-auth.test.ts
@@ -29,15 +29,34 @@ vi.mock('@/lib/auth', () => ({
   })),
 }));
 
+// Records every query filter the routes issue, so the tenant-scope suite below
+// can assert on the shape of the filter and not merely on the status code.
+const { dbCalls } = vi.hoisted(() => ({
+  dbCalls: [] as { collection: string; op: string; filter: unknown }[],
+}));
+
 // No memberships, no platform-superadmin grant, no page found. The handler is
 // allowed to run and fail on its own terms — this test only cares whether the
 // gate let it through at all.
 vi.mock('@/lib/mongodb', () => ({
   getDb: vi.fn(async () => ({
-    collection: () => ({
-      findOne: async () => null,
-      findOneAndUpdate: async () => null,
-      updateOne: async () => ({ matchedCount: 0 }),
+    collection: (name: string) => ({
+      findOne: async (filter: unknown) => {
+        dbCalls.push({ collection: name, op: 'findOne', filter });
+        return null;
+      },
+      findOneAndUpdate: async (filter: unknown) => {
+        dbCalls.push({ collection: name, op: 'findOneAndUpdate', filter });
+        return null;
+      },
+      updateOne: async (filter: unknown) => {
+        dbCalls.push({ collection: name, op: 'updateOne', filter });
+        return { matchedCount: 0 };
+      },
+      deleteOne: async (filter: unknown) => {
+        dbCalls.push({ collection: name, op: 'deleteOne', filter });
+        return { deletedCount: 1 };
+      },
     }),
   })),
 }));
@@ -94,6 +113,13 @@ const CASES: RouteCase[] = [
     minRole: 'admin',
     load: () => import('@/app/api/[tenant]/pages/[id]/route'),
     params: { tenant: 'bph', id: 'page-1' },
+  },
+  {
+    name: 'DELETE /api/pages/[id]',
+    method: 'DELETE',
+    minRole: 'admin',
+    load: () => import('@/app/api/pages/[id]/route'),
+    params: { id: 'page-1' },
   },
   {
     name: 'PATCH /api/pages/[id]/quick-fix',
@@ -190,6 +216,94 @@ describe('page-write routes are gated above reader (#3511)', () => {
       expect(body).not.toEqual({ error: 'Forbidden - Insufficient role' });
     });
   }
+});
+
+/**
+ * An absent tenant means GLOBAL SCOPE on the global route, not a refusal (#3542).
+ *
+ * The reader lives at `/book/<slug>/page/<id>`, so `getTenantSlug()` returns ''
+ * and the API client lands on `/api/pages/[id]` with no tenant. The only thing
+ * that ever supplied one there was the proxy's referer fallback, which resolves
+ * the tenant FROM THE BOOK — so it returns null for the 88.5% of visible books
+ * that carry no `tenantId`, and every save on them answered 403.
+ *
+ * These cases drive the real `withAuth` and the real route modules; only `auth()`
+ * and the DB are faked. Note the mocked session hands the route an `editor` role
+ * directly, which production cannot currently produce without a tenant header
+ * (the JWT role is only `superadmin` or `reader`) — that limit lives in the role
+ * model, not in this route, and is tracked separately.
+ */
+describe('global page writes are tenant-optional, tenant-scoped when present (#3542)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('PLATFORM_ADMIN_EMAILS', '');
+    dbCalls.length = 0;
+  });
+
+  async function patchGlobal(role: string, headers: Record<string, string> = {}) {
+    currentRole = role;
+    const mod = await import('@/app/api/pages/[id]/route');
+    const handler = mod.PATCH as (req: unknown, ctx: unknown) => Promise<Response>;
+    const req = new Request('https://sourcelibrary.org/api/pages/page-1', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify(PAGE_TEXT_BODY),
+    });
+    return handler(req, { params: Promise.resolve({ id: 'page-1' }) });
+  }
+
+  /** The filter the route used to locate the page it was about to rewrite. */
+  const pageWriteFilter = () =>
+    dbCalls.find((c) => c.collection === 'pages' && c.op === 'findOneAndUpdate')?.filter as
+      | Record<string, unknown>
+      | undefined;
+
+  it('does not refuse an editor for want of a tenant', async () => {
+    const res = await patchGlobal('editor');
+    // 404 from the mocked-empty DB is the pass condition: the handler ran.
+    expect(await res.json()).not.toEqual({ error: 'Unauthorized' });
+    expect(res.status).not.toBe(403);
+  });
+
+  it('omits tenantId from the write filter entirely when no tenant is resolved', async () => {
+    await patchGlobal('editor');
+    const filter = pageWriteFilter();
+    expect(filter).toBeDefined();
+    expect(filter).toEqual({ id: 'page-1' });
+    // Not `{ tenantId: null }` — that matches missing-and-null in Mongo, so it
+    // would read as working on global books while never matching a tenant page.
+    expect(Object.keys(filter!)).not.toContain('tenantId');
+  });
+
+  it('still scopes the write to the tenant when one is resolved', async () => {
+    const res = await patchGlobal('superadmin', { 'x-tenant-id': 'bce03f71-tenant' });
+    expect(res.status).not.toBe(403);
+    expect(pageWriteFilter()).toEqual({ id: 'page-1', tenantId: 'bce03f71-tenant' });
+  });
+
+  it('still refuses a reader that has no tenant', async () => {
+    const res = await patchGlobal('reader');
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Forbidden - Insufficient role' });
+  });
+
+  it('keeps the tenant twin refusing an unresolvable tenant', async () => {
+    // Deliberate divergence: there `tenantId` comes from the `[tenant]` path
+    // segment, so failing to resolve one is a misroute, not a global call.
+    currentRole = 'superadmin';
+    const mod = await import('@/app/api/[tenant]/pages/[id]/route');
+    const handler = mod.PATCH as (req: unknown, ctx: unknown) => Promise<Response>;
+    const req = new Request('https://sourcelibrary.org/api/no-such-tenant/pages/page-1', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(PAGE_TEXT_BODY),
+    });
+    const res = await handler(req, {
+      params: Promise.resolve({ tenant: 'no-such-tenant', id: 'page-1' }),
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+  });
 });
 
 describe('the page-write route list stays complete', () => {


### PR DESCRIPTION
Closes #3542.

## What was broken

`PATCH`/`DELETE /api/pages/[id]` answered `403 {"error":"Unauthorized"}` whenever no `x-tenant-id` was resolved. The reader lives at `/book/<slug>/page/<id>` on the apex, where `getTenantSlug()` returns `''` (`book` is in `NON_TENANT_SEGMENTS`), so the request lands on this global route with no tenant. The only thing that ever supplied one was the proxy's referer fallback — which resolves the tenant **from the book** (`resolveTenantForBookSegment`) and therefore returns null for a non-tenant book.

Net effect: page saves worked on the **3,907** visible books owned by a tenant and failed on the other **30,132** (measured 2026-08-04).

Verified end-to-end in production with a real editor session, which the issue explicitly asked for before any fix was written:

| Book | `tenantId` | Result |
|---|---|---|
| *50 Homilien oft verclaringhen* | `bce03f71…` | **200**, change visible in incognito |
| *Académie de l'espée* (Thibault) | absent | **403** `{"error":"Unauthorized"}` |

The `{"error":"Unauthorized"}` body is what identifies it as the route's own gate rather than `withAuth`'s `{"error":"Forbidden - Insufficient role"}` — i.e. a scoping bug, not a permissions one.

## The issue's stated mechanism was wrong on two counts

Both corrected in a comment on #3542, because as filed it sends the next reader somewhere unproductive:

1. **The `/api//pages/<id>` double slash doesn't happen.** The API client's request interceptor has collapsed `/api//` → `/api/` since #1880 (2026-05-19), two months before the issue was filed. The anonymous 308 observation was real but tested a URL the app never sends.
2. **The axis is not main-domain-vs-subdomain.** It is whether the referer book carries a `tenantId`.

## The fix

Both handlers now mirror the semantics this route's **GET** has always had ([route.ts:50-55](../blob/main/src/app/api/pages/%5Bid%5D/route.ts#L50-L55) — *"Calls from the global main domain arrive with no tenantId — those are allowed to read globally"*): scope the query by `tenantId` when one is resolved, treat absence as global scope.

The conditional key is load-bearing, not style. A literal `{ id, tenantId }` with a null tenant matches missing-**and**-null in Mongo, so it would read as working on global books while silently never matching a tenant-owned page — a worse bug than the one being fixed.

**Access does not widen.** With no `x-tenant-id`, `getTenantMembershipRole` returns null on the falsy tenant and membership can only *raise* `effectiveRole`, so the gate collapses to the JWT role — `superadmin` or `reader` and nothing else. Global page edits are superadmin-only, which is the intended policy for now.

**The tenant twin keeps its 403**, now with a comment saying the divergence is deliberate: there `tenantId` comes from resolving the `[tenant]` path segment, so failing to resolve one means the caller named a tenant that doesn't exist — a misroute, not a global call. The two routes differ because their tenant *inputs* differ. Its stale "this is the route the reader's editor actually calls" comment is corrected too; that claim is part of what made the original diagnosis confusing.

## Tests

Added to `tests/unit/page-write-auth.test.ts`, driving the real `withAuth` against the real route modules (only `auth()` and the DB are faked):

- a tenant-less editor PATCH is not refused
- the write filter omits `tenantId` **entirely** rather than sending null
- a resolved tenant still scopes the write
- a reader with no tenant is still refused
- the tenant twin still refuses an unresolvable tenant

**Negative control run**, per the "a test that greps source is not a guard" rule: reverting the fix turns the two behavioural cases red and leaves the rest green. Verified, not reasoned about.

Also adds the missing `DELETE /api/pages/[id]` case — the global admin-gated delete had no entry in `CASES`, so its gate was unpinned while the enumeration check reported the file as covered via its PATCH entry.

`npx tsc --noEmit` clean; 1,504 unit tests across 117 files pass.

## Out of scope

Filed separately rather than bundled, since each has a different "why":

- **No global editor role exists.** `token.role` is only `superadmin` or `reader` ([auth.ts:375-438](../blob/main/src/lib/auth.ts#L375-L438)); the open `TODO (Phase 1)` at auth.ts:430 is exactly this. It's what actually blocks the 4 tenant-scoped editors, and it's a design decision for Derek, not a bugfix.
- **A live `memberships` row with `tenantId: null, role: 'editor'` is inert** — `getTenantMembershipRole` skips null tenants and `isPlatformSuperadmin` only matches `superadmin`, so that account resolves as `reader` everywhere. Same root cause; retired for free if the above is built.
- **The six sibling global page writers** (`quick-fix`, `split`, `reset`, `revisions/[revisionId]/restore`, `batch-split`, `batch-reset`) apply no tenant filter at all. That's the inverse question — should they be scoped when a header *is* present? — and deserves its own PR.
- **The Edit toggle isn't book-aware.** `<AuthCheck role="inner_circle">` reads the session role, not the book on screen, so a BPH editor sees Edit on a global book and fails on save. Pre-existing; this PR only changes which error they get. Belongs with the role decision above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)