### PR TITLE
archive-iiif: --any-status, so the worker sees the backlog instead of an empty queue

### DIFF
--- a/scripts/workers/archive-iiif-local.mjs
+++ b/scripts/workers/archive-iiif-local.mjs
@@ -17,6 +17,30 @@
  * Safe to run repeatedly; idempotent (skips pages that already have
  * archived_photo). Mac-only by intent — do NOT cron on Hetzner.
  *
+ * ── Why --any-status ────────────────────────────────────────────────────────
+ * Selecting on pipeline_auto.status:'archiving' matches the pipeline QUEUE, not
+ * the archive BACKLOG, and the two had drifted apart completely: measured
+ * 2026-08-04, 21 books sat at 'archiving' (harvard + gallica only) while
+ * 5.07M pages across ~19,500 books were unarchived. So this worker reported
+ * "0 unarchived pages across 0 books" and idled, with ~4.1M archivable pages
+ * (iiif + bsb) sitting in states it never looked at — chapters_complete alone
+ * held 1.9M. Sampling confirmed ~100% of those remaining pages carry a photo
+ * URL on a recognised host, i.e. it is real work, not pages excused as
+ * non-archivable.
+ *
+ * --any-status widens selection to the same backlog predicate archive-harvard
+ * and archive-bulk already use. The reason it could not be a one-line query
+ * change is the status write below: this worker advances finished books to
+ * 'archive_complete', which for a book at 'chapters_complete' is a DOWNGRADE
+ * that would re-run paid OCR/translation/chapters over the whole book. Hence
+ * mayAdvanceToArchiveComplete() — archiving is recorded for every book, but
+ * status only ever moves forward.
+ *
+ * Archiving costs no Gemini spend, so this is safe to run under the global
+ * pause with --ignore-pause (that is what the flag is for). It does NOT enroll
+ * anything: books with no pipeline_auto stay un-enrolled, so widening this
+ * worker cannot start paid work by itself.
+ *
  * Usage:
  *   set -a; source .env.production.local; set +a; node scripts/workers/archive-iiif-local.mjs --dry-run
  *   ... node scripts/workers/archive-iiif-local.mjs --limit=3000 --concurrency=4 --rate=3
@@ -37,6 +61,39 @@ const PROVIDERS = (getArg('providers') || 'iiif,e-codices').split(',');
 const MAX_FAILS = parseInt(getArg('max-fails') || '25', 10);     // circuit-breaker threshold
 const TIMEOUT_MS = parseInt(getArg('timeout') || '60', 10) * 1000; // per-download timeout
 const DRY_RUN = hasFlag('dry-run');
+// Select books by ARCHIVE BACKLOG (pages_archived < pages_count) instead of by
+// pipeline_auto.status:'archiving'. See the "Why --any-status" note in the header.
+const ANY_STATUS = hasFlag('any-status');
+
+// Canonical pipeline order, mirroring PIPELINE_STATUS_ORDER in
+// scripts/workers/enrichment-snapshot.mjs. Used ONLY to decide whether advancing a
+// book to 'archive_complete' would move it BACKWARD.
+const PIPELINE_STATUS_ORDER = [
+  'queued', 'archiving', 'archive_complete', 'ocr_submitted', 'ocr_complete',
+  'metadata_enriched', 'translate_submitted', 'translate_complete',
+  'enriching', 'enriched', 'chapters', 'chapters_complete',
+  'images_submitted', 'images_complete', 'complete',
+];
+const ARCHIVE_COMPLETE_IDX = PIPELINE_STATUS_ORDER.indexOf('archive_complete');
+
+/**
+ * May this book be advanced to 'archive_complete'?
+ *
+ * Only when it is not already PAST that point. Downgrading a book that has
+ * finished OCR/translation/chapters would make the orchestrator re-run those
+ * paid Gemini phases over the whole book — the single most expensive mistake
+ * available here, and the reason --any-status could not simply widen the query.
+ *
+ * Terminal//holding states ('needs_attention', 'failed', 'parked', quarantine…)
+ * are deliberately NOT advanced either: they are not positions on the happy path,
+ * and something put them there on purpose.
+ */
+function mayAdvanceToArchiveComplete(currentStatus) {
+  if (!currentStatus) return true;              // never enrolled — safe to mark
+  const idx = PIPELINE_STATUS_ORDER.indexOf(currentStatus);
+  if (idx === -1) return false;                 // unknown/terminal — leave alone
+  return idx <= ARCHIVE_COMPLETE_IDX;
+}
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID;
@@ -115,12 +172,25 @@ async function main() {
     await client.close(); return;
   }
 
+  // Default: the pipeline queue (books parked at 'archiving').
+  // --any-status: the whole archive backlog for these providers, whatever pipeline
+  // state the book is in. Same predicate archive-harvard.mjs and archive-bulk.mjs
+  // already use. Safe because mayAdvanceToArchiveComplete() refuses to move an
+  // advanced book backward — see that function.
+  const bookFilter = ANY_STATUS
+    ? {
+        'image_source.provider': { $in: PROVIDERS },
+        pages_count: { $gt: 0 },
+        $expr: { $lt: [{ $ifNull: ['$pages_archived', 0] }, '$pages_count'] },
+      }
+    : {
+        'pipeline_auto.status': 'archiving',
+        'image_source.provider': { $in: PROVIDERS },
+        pages_count: { $gt: 0 },
+      };
+
   const books = await db.collection('books')
-    .find({
-      'pipeline_auto.status': 'archiving',
-      'image_source.provider': { $in: PROVIDERS },
-      pages_count: { $gt: 0 },
-    }, { projection: { id: 1, title: 1, pages_count: 1, pages_archived: 1 } })
+    .find(bookFilter, { projection: { id: 1, title: 1, pages_count: 1, pages_archived: 1, 'pipeline_auto.status': 1 } })
     .sort({ pages_archived: -1 })   // finish nearly-done books first → status advances sooner
     .limit(4000)
     .maxTimeMS(30_000)
@@ -209,9 +279,10 @@ async function main() {
   await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
 
   // Sync pages_archived and advance fully-archived books to archive_complete.
-  let synced = 0, advanced = 0;
+  let synced = 0, advanced = 0, advanceSkipped = 0;
   for (const bookId of touchedBookIds) {
-    const book = await db.collection('books').findOne({ id: bookId }, { projection: { pages_count: 1 } });
+    const book = await db.collection('books').findOne(
+      { id: bookId }, { projection: { pages_count: 1, 'pipeline_auto.status': 1 } });
     const archivedCount = await db.collection('pages').countDocuments(
       { book_id: bookId, archived_photo: { $exists: true, $nin: [null, ''] }, $expr: { $not: { $regexMatch: { input: { $ifNull: ['$archived_photo', ''] }, regex: '^failed:' } } } },
       { maxTimeMS: 10000 }
@@ -224,14 +295,23 @@ async function main() {
       $or: [{ archived_photo: { $exists: false } }, { archived_photo: null }, { archived_photo: '' }],
     }).catch(() => -1);
     if (remaining === 0 && book?.pages_count > 0) {
-      set['pipeline_auto.status'] = 'archive_complete';
-      set['pipeline_auto.last_updated'] = new Date();
-      advanced++;
+      // Forward-only. A book already past archiving keeps its status: writing
+      // 'archive_complete' over 'chapters_complete' would send it back through
+      // paid OCR/translation/chapters. Its pages_archived is still updated above —
+      // the archiving work is recorded either way, only the status is left alone.
+      if (mayAdvanceToArchiveComplete(book?.pipeline_auto?.status)) {
+        set['pipeline_auto.status'] = 'archive_complete';
+        set['pipeline_auto.last_updated'] = new Date();
+        advanced++;
+      } else {
+        advanceSkipped++;
+      }
     }
     await db.collection('books').updateOne({ id: bookId }, { $set: set });
     synced++;
   }
-  console.log(`[archive-iiif] synced ${synced} books, advanced ${advanced} to archive_complete`);
+  console.log(`[archive-iiif] synced ${synced} books, advanced ${advanced} to archive_complete` +
+    (advanceSkipped ? `, left ${advanceSkipped} already-past-archiving books at their current status` : ''));
 
   const duration = ((Date.now() - start) / 1000).toFixed(1);
   console.log(`[archive-iiif] Done in ${duration}s: ${archived} archived (${(totalBytes / 1048576).toFixed(0)} MB), ${failed} failed`);

--- a/tests/unit/archive-status-forward-only.test.ts
+++ b/tests/unit/archive-status-forward-only.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Guards the forward-only status rule in archive-iiif-local.mjs.
+ *
+ * The hazard: that worker advances a fully-archived book to 'archive_complete'.
+ * Once --any-status lets it select books at ANY pipeline stage, an unguarded
+ * write would knock a 'chapters_complete' book backwards, and the orchestrator
+ * would re-run OCR + translation + chapters over the whole book — paid Gemini
+ * work, at corpus scale.
+ *
+ * Per CLAUDE.md ("a test that greps source is not a guard") this EXERCISES the
+ * decision function rather than asserting that lines of source exist. The
+ * function is pure and self-contained, so it is extracted and evaluated here;
+ * deleting the guard in the worker makes the extraction fail, which fails the
+ * suite rather than silently passing.
+ */
+
+const WORKER = join(process.cwd(), 'scripts/workers/archive-iiif-local.mjs');
+
+function loadGuard(): (s?: string | null) => boolean {
+  const src = readFileSync(WORKER, 'utf8');
+
+  const orderMatch = src.match(/const PIPELINE_STATUS_ORDER = \[([\s\S]*?)\];/);
+  const fnMatch = src.match(/function mayAdvanceToArchiveComplete\(currentStatus\) \{[\s\S]*?\n\}/);
+  if (!orderMatch || !fnMatch) {
+    throw new Error('forward-only status guard missing from archive-iiif-local.mjs');
+  }
+
+  const factory = new Function(`
+    const PIPELINE_STATUS_ORDER = [${orderMatch[1]}];
+    const ARCHIVE_COMPLETE_IDX = PIPELINE_STATUS_ORDER.indexOf('archive_complete');
+    ${fnMatch[0]}
+    return mayAdvanceToArchiveComplete;
+  `);
+  return factory() as (s?: string | null) => boolean;
+}
+
+describe('archive-iiif-local forward-only status guard', () => {
+  const mayAdvance = loadGuard();
+
+  it('advances books at or before the archiving stage', () => {
+    expect(mayAdvance(undefined)).toBe(true);   // never enrolled
+    expect(mayAdvance(null)).toBe(true);
+    expect(mayAdvance('queued')).toBe(true);
+    expect(mayAdvance('archiving')).toBe(true);
+  });
+
+  it('is idempotent for a book already marked archive_complete', () => {
+    expect(mayAdvance('archive_complete')).toBe(true);
+  });
+
+  it('REFUSES to downgrade a book that has passed archiving', () => {
+    // Each of these would trigger re-running paid Gemini phases if overwritten.
+    for (const s of [
+      'ocr_submitted', 'ocr_complete', 'metadata_enriched',
+      'translate_submitted', 'translate_complete',
+      'enriching', 'enriched', 'chapters', 'chapters_complete',
+      'images_submitted', 'images_complete', 'complete',
+    ]) {
+      expect(mayAdvance(s), `${s} must not be downgraded`).toBe(false);
+    }
+  });
+
+  it('leaves terminal and holding states alone', () => {
+    for (const s of ['needs_attention', 'failed', 'parked', 'loop_quarantine_hold']) {
+      expect(mayAdvance(s), `${s} must not be advanced`).toBe(false);
+    }
+  });
+
+  it('covers every status the corpus actually holds', () => {
+    // Statuses observed in production on 2026-08-04 among books with unarchived
+    // pages. A new status appearing here must be classified deliberately, not
+    // silently fall through to "advance".
+    const observed = [
+      'chapters_complete', 'archive_complete', 'translate_complete',
+      'needs_attention', 'images_complete', 'archiving', 'queued',
+      'enrolled', 'complete', 'parked', 'ocr_queued',
+      'loop_quarantine_hold', 'failed',
+    ];
+    const advanced = observed.filter(s => mayAdvance(s));
+    expect(advanced.sort()).toEqual(['archive_complete', 'archiving', 'queued']);
+  });
+});


### PR DESCRIPTION
The IIIF archive daemon has been idling against a 5-million-page backlog.

## What was happening

`archive-iiif-local.mjs` selects books on `pipeline_auto.status: 'archiving'` — the pipeline **queue**. The archive **backlog** had drifted completely away from it. Measured 2026-08-04:

| | Books | Pages |
|---|---|---|
| At `archiving` (all this worker can see) | **21** | **28,978** |
| Unarchived corpus-wide | ~19,500 | **5,068,961** |

And the 21 are harvard + gallica only — **zero** in the iiif/e-codices lanes. So the daemon prints `0 unarchived pages across 0 books`, sleeps an hour, and repeats, while the work sits in states it never queries:

| Status | Books | Pages remaining |
|---|---|---|
| `(no pipeline_auto)` | 6,874 | 2,365,048 |
| `chapters_complete` | 9,754 | 1,902,155 |
| `archive_complete` | 629 | 291,310 |
| `translate_complete` | 821 | 243,786 |
| `needs_attention` | 530 | 175,815 |

That "0" reads as *done*. It means *empty queue*.

## Is it real work?

Yes. Sampled 25 books per bucket and counted how many remaining pages carry a `photo`/`photo_original` on a host in `ARCHIVABLE_SOURCES` — **~100%** in every bucket. These are not pages the orchestrator excused as non-archivable.

(First pass at that measurement returned 138% and 157%, which is impossible: spreading the `UNARCH` `$or` beside a second `$or` key silently dropped the unarchived filter. Fixed with `$and` before trusting any of it.)

## Why this is not a one-line query change

The worker advances a fully-archived book to `archive_complete`. Widen selection without touching that, and a book at `chapters_complete` gets written **backwards** — the orchestrator then re-runs OCR, translation and chapters over the whole book. That is paid Gemini work across 1.9M pages, under a standing spend pause.

`mayAdvanceToArchiveComplete()` makes the write forward-only. `pages_archived` is still recorded for every book; only the *status* is left alone when it is already past archiving. Terminal and holding states (`needs_attention`, `failed`, `parked`, `loop_quarantine_hold`) are never advanced either — something put them there deliberately.

## Safety

- **Opt-in.** No flag, no behaviour change.
- **No Gemini spend.** Archiving is free, so this is usable under the global pause via `--ignore-pause` — what the flag exists for.
- **Enrolls nothing.** Books with no `pipeline_auto` stay un-enrolled, so this cannot start paid work by itself. Deliberate: the pause reads `"Derek: pause Gemini spend until prioritized"`, and enrolling 6,874 books would defeat it.
- **`processing_control` untouched.** That document carries a history of being clobbered by automated sessions (`"RESTORED ... after I overwrote it"`, `"was clobbered to 3 books"`). Not written to here.

## Verification

Dry run against production, iiif+e-codices:

```
before   0 unarchived pages across 0 books
after  500 unarchived pages across 6 books   (limit-capped)
```

Other providers under `--any-status`: bsb, internet_archive, gallica all return work.

`tests/unit/archive-status-forward-only.test.ts` **exercises** the decision function rather than grepping for source lines, per CLAUDE.md. Negative control run: neutering the guard to `return true` turns 3 of its 5 cases red; restoring it turns them green.

## Out of scope

- The 6,874 never-enrolled books are stranded by `ENROLL_WINDOW_DAYS = 14` in the orchestrator (Phase 0 only enrolls `created_at >= now - 14d`). They can be archived by this worker, but they will never enter the pipeline without a deliberate backfill — which is a spend decision, not a bug fix.
- The 629 books marked `archive_complete` while still holding 291,310 unarchived pages look like a status writer closing out early. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)