### PR TITLE
docs(review): abstention design, and the four open questions decided

### DIFF
--- a/.claude/docs/community-quality-review-design.md
+++ b/.claude/docs/community-quality-review-design.md
@@ -1,9 +1,11 @@
 # Community quality review — design
 
 Status: **proposal, nothing built.** Written 2026-08-02 from a conversation with
-Derek about volunteer management. Read `.claude/docs/newsletter-queue.md` item 2
-alongside it — the volunteer letter is the recruiting instrument for this, and it
-should not go out until at least Phase 0 below exists.
+Derek about volunteer management; decisions on credit, payment, Spanish and
+abstention added 2026-08-04 (see "Decisions" at the end). Read
+`.claude/docs/newsletter-queue.md` item 2 alongside it — the volunteer letter is
+the recruiting instrument for this, and it should not go out until at least
+Phase 0 below exists.
 
 ## The problem, and the leverage
 
@@ -149,6 +151,13 @@ notes:   free text (optional)
 spans:   [{ quote, comment }]  (optional)
 ```
 
+A review row may instead carry **no verdict at all** — see the abstention
+section below. `passed_reason` and `verdict` are mutually exclusive, and any
+rate or agreement statistic must filter to rows that actually carry a verdict.
+(The `volunteer_ratings` table learned this the same way: `rating` is nullable
+so a note can arrive without one, and every statistic filters
+`rating IS NOT NULL`.)
+
 - **material_error** must be defined concretely or the scale drifts between
   reviewers: changes the sense, omits content that is present, or adds content
   that is not.
@@ -164,9 +173,11 @@ longer exists — the same paired-artifact failure as #3362 and #3368, in a new
 place.
 
 Proposed storage: a `page_reviews` collection — `page_id`, `book_id`,
-`reviewer_user_id`, `lane`, `assignment_id` (null for stream), `verdict`,
-`notes`, `spans`, `language`, `text_version`, `created_at`. Reviews never
-directly mutate public text; they are evidence, and a human applies fixes.
+`reviewer_user_id`, `lane`, `assignment_id` (null for stream), `verdict`
+(nullable), `passed_reason` (nullable), `notes`, `spans`, `language`,
+`text_version`, `created_at`. Exactly one of `verdict` / `passed_reason` is set.
+Reviews never directly mutate public text; they are evidence, and a human
+applies fixes.
 
 ## What we can and cannot say publicly
 
@@ -204,18 +215,102 @@ existing 32.
 
 **Phase 3.** A public statistics page, and per-reviewer readouts.
 
-## Open questions for Derek
+## Abstention — the reviewer must be able to say "not me"
 
-1. **Credit.** Named on a public methods/statistics page? Acknowledged in a
-   paper? For academics this is the actual compensation and it should be decided
-   before recruiting, not after.
-2. **Payment.** Is the panel paid? It is a defined piece of work and paying for
-   it is defensible. Needs an explicit yes before anything spends.
-3. **Who answers.** Every lane creates replies. The programme dies the first
-   month nobody responds, exactly as the standing offers have gone unanswered.
-4. **Spanish.** Five of the nine existing volunteers wrote in Spanish and one
-   said they do not read English. Does the review UI need Spanish, or only the
-   letter?
+Decided 2026-08-04. A reviewer handed a page in a language they do not read needs
+a way out, and **it must not be the `not_assessable` verdict.**
+
+Those are different objects:
+
+- `not_assessable` is a property of the **page** — blank, illegible, image
+  mismatch.
+- "I don't read Greek" is a property of the **reviewer–page pairing**.
+
+Conflating them corrupts the corpus statistic in the direction that flatters
+nobody: a Latinist reaching for `not_assessable` on a Greek page records that
+*the page* cannot be judged, which is false, and deflates the measured quality of
+a stratum for reasons that have nothing to do with the corpus. Same denominator
+error as the `reading_history` "62% came back" figure, in a new place.
+
+So: a **pass** action, stored as an assignment outcome rather than a verdict,
+which returns the page to the pool for someone else. Capture the reason —
+`not_my_language` / `not_my_period` / `cannot_read_scan` / `no_time`. The third
+is a page property wearing a reviewer's clothes and routes to repair; capture
+time is the only chance to tell them apart.
+
+### The incentive this creates, given credit-without-payment
+
+**Volume-based credit + no payment + an easy pass button = an incentive to
+guess.** If someone is named for reviewing N pages and a pass does not count
+toward N, the rational move for a person who wants the credit is to judge pages
+they cannot read — fabricating anchors into the one dataset whose entire value is
+that it is ground truth.
+
+Therefore: **credit attaches to completing a round, not to page count, and an
+abstention counts as participation.** This is not a nicety; it is what stops the
+compensation model from corrupting the measurement.
+
+### Abstention is data, and belongs in the paper
+
+- **Report coverage per stratum as a first-class number.** A stratum with 40%
+  abstention has a narrower effective reviewer population than its `n` suggests.
+- **Characterise the missingness, do not merely count it** (Rubin's
+  MCAR/MAR/MNAR). If reviewers abstain more on hard or degraded pages, the
+  retained sample is systematically easier and "% faithful" is optimistically
+  biased. This is cheaply testable: compare the machine cross-pass agreement
+  distribution of abstained vs completed pages. That agreement number already
+  exists for every page, so the instrument that detects the bias is free.
+- **The abstention pattern is the paper's own thesis replicated on the human
+  side.** If Latin draws twenty reviewers and Tibetan draws none, that is the
+  same ground-truth scarcity the memorization paper documents for machine
+  benchmarks. Report it as a finding, exactly as the scorecard reports the
+  zero-spaceless-anchor gap rather than laundering it.
+
+### Prior work to cite rather than re-derive
+
+- **Chow (1970)**, classification with a reject option — abstention buys accuracy
+  on retained decisions at the cost of coverage. Always report both.
+- **Rubin (1976)**, missing-data mechanisms — why the question is *which*
+  missingness, not *how much*.
+- **Dawid & Skene (1979)** — EM estimation of true labels *and* per-annotator
+  error rates from multiple noisy raters. The canonical answer to "we cannot
+  verify that someone reads Latin": infer competence from agreement instead of
+  trusting the declaration.
+- **MACE (Hovy et al. 2013)** — models annotators answering without looking.
+  This is what catches 40 pages in 90 seconds.
+- **Krippendorff's α, not Cohen's κ.** With abstention the coverage matrix is
+  ragged by construction, and α is the coefficient that tolerates missing data
+  and any number of raters. Not a stylistic preference.
+- **Artstein & Poesio (2008)** — standard IAA reference, including why raw
+  agreement flatters when one category dominates. Most pages will be fine, so
+  raw agreement will look excellent and mean little.
+
+In-repo precedent to copy rather than reinvent:
+`scripts/analysis/ft-rater-reliability.mjs` already separates **reliability**
+(chance-corrected agreement, by rater *family*, because the same model resampled
+shares its blind spot) from **validity** (accuracy against checkable gold), and
+warns that high agreement under shared bias is the trap. Same structure applies
+here.
+
+## Decisions (2026-08-04)
+
+1. **Credit — YES.** Contributors named on a public methods/statistics page and
+   acknowledged in the paper. Authorship is reserved for design and analysis
+   contributions; state that boundary in the recruiting letter rather than
+   negotiating it afterwards. Credit is per completed round, per the incentive
+   argument above.
+2. **Payment — NO.** The panel is unpaid. This makes the credit design
+   load-bearing rather than decorative, and it is why abstention must count as
+   participation.
+3. **Spanish — YES, and in the review UI, not only the letter.** 43 of 163
+   volunteers named Spanish and one said they do not read English. Honest caveat
+   to carry: reviewing a Spanish→English translation requires *both* languages,
+   so a Spanish UI serves Spanish-source review specifically — it does not make
+   Spanish speakers available for the whole corpus.
+4. **Who answers replies — STILL OPEN.** This is the one that kills programmes.
+   Every lane generates replies, and the standing offers already died of silence
+   once (132 signups, 0 ratings, all `contacted: false`). Assign a person before
+   the letter goes out.
 
 ## Risks
 

--- a/.claude/docs/community-quality-review-design.md
+++ b/.claude/docs/community-quality-review-design.md
@@ -96,6 +96,119 @@ pairs are image-shift artefacts, not legibility). A reviewer handed one of those
 reports "the text does not match the image," which is true, is worth knowing, and
 is *not* a translation-quality datum. It routes to archival repair instead.
 
+## Round 1 should be OCR adjudication, not translation review
+
+Added 2026-08-04. The panel's first round should adjudicate **double-OCR pairs**
+rather than judge translation faithfulness. It is better on every axis, and it
+serves the memorization paper's binding constraint directly.
+
+### Why this and not translation review
+
+`.claude/docs/ocr-memorization-paper.md` lists its own blocker: *"the corpus
+gives agreement and its factors, never accuracy. Only the anchor rows can supply
+truth."* The calibration scorecard's spaced fit rests on **n=32** non-canonical
+anchors (12 canonical, per-script: Greek 12, Armenian 8, German 5, Hebrew 2), and
+the **spaceless fit is n=0** — Chinese, Tibetan and Japanese have no anchor points
+at all.
+
+More importantly, the paper notes that *"two models reciting agree while both
+misreport the page."* So **agreement is structurally blind to the fabrication
+class**: two passes reproducing the same memorized text agree perfectly while
+neither reads the page. No quantity of corpus data can detect that. A human
+holding the image against both transcriptions is the only instrument that can —
+which makes volunteers not a cheaper source of anchors but the *only* way to
+measure the extreme form of the paper's central claim.
+
+The task shape is also far better suited to a mixed-skill pool. "Which of these
+two transcriptions matches the page?" is comparison rather than evaluation:
+faster, shallower, and a large share of disagreements are **mechanical** —
+truncation, repetition loops, `&nbsp;` padding, normalization conventions
+(`nūc`→`nunc`) — diagnosable by someone who does not read Latin. That directly
+relieves the abstention pressure described above.
+
+### Eligibility — three filters, in this order
+
+Measured on a random sample of 35 OCR revision pairs (2026-08-04; small, re-run
+at scale before relying on the percentages, though `revision-image-shift.mjs`
+already put the shift rate at 40.2% on n=3,339):
+
+1. **Drop byte-identical pairs — 11% of the sample.** Identical text and
+   identical length is a duplicate write, not a second pass. Including it
+   manufactures perfect agreement out of nothing.
+2. **Record and stratify on independence. 83% of pairs carry the SAME model AND
+   the SAME `prompt_version` on both sides.** Those are re-runs of one
+   configuration, not independent observers, and their agreement is inflated by
+   a shared blind spot. Classify each pair `cross_family` /
+   `same_family_diff_prompt` / `same_config` and never pool them. This is the
+   same doctrine `scripts/analysis/ft-rater-reliability.mjs` already applies:
+   independence is by *family*, because the same model resampled shares its
+   blind spot.
+3. **Split on the printed page number before sampling by agreement.** Where both
+   sides carry a `<page-num>`, they disagree **50%** of the time — and the
+   separation is nearly total:
+
+   | | median agreement |
+   |---|---|
+   | printed page numbers agree | **0.956** |
+   | printed page numbers differ | **0.204** |
+
+   **72% of pairs below 0.5 agreement are printed-number disagreements**, i.e.
+   the two texts describe different leaves. They are the #3357 repair artifact,
+   not legibility.
+
+### The trap this creates for the "spread across agreement deciles" sample
+
+The design above asks for anchors spread across the agreement range, because a
+random draw clusters at typical agreement and leaves the scorecard correctly
+refusing to extrapolate. But **the low end of the agreement range is
+overwhelmingly image-shift.** Draw the spread sample naively and roughly
+three-quarters of the low-agreement anchors are pages where the two texts are of
+different leaves — and the calibration curve's low end, which the paper already
+flags as *soft*, would be fitted on that.
+
+So: apply filter 3 **first**, then draw the spread sample from the surviving
+population. `different_leaf` remains a label a reviewer can apply (it is the one
+class humans catch instantly), and those rows route to archival repair and to
+measuring the printed-page-number detector's own recall — which CLAUDE.md notes
+is weak, since a *uniform* shift preserves the page-number sequence perfectly.
+
+### The adjudication
+
+Shown: the page image, transcription A and transcription B, no indication of
+which is current.
+
+```
+which:  a_matches | b_matches | both_match | neither_matches
+        | different_leaf | cannot_judge (+ passed_reason)
+cause:  [multi] truncation | repetition_loop | entity_padding
+        | normalization | misreading | commentary_as_transcription
+        | illegible_scan
+notes:  free text
+```
+
+- **`neither_matches` is the fabrication detector** and the reason this round
+  exists. It is unreachable from agreement.
+- **`cause` is confirmation, not authoring** — pre-fill the candidate class from
+  `disagreement-typology.mjs` and let the reviewer accept or correct it. Per the
+  gallery-volunteer doc: verification gets ~50× the throughput of blank-form
+  annotation.
+
+### What the labels produce, and what they are not
+
+The adjudication yields, per page, whether each side is correct — so aggregated
+within an agreement decile it gives **P(page correct | agreement)**. That is a
+calibration curve in probability space, and it is a *different quantity* from
+the scorecard's existing CER-based anchor fit. **Do not pool them.** The
+probability curve is arguably the more useful one for a public claim (it answers
+"what fraction of pages are right"), and it maps onto the panel's own
+`material_error` framing; the CER fit stays the instrument for the paper.
+
+Stratify by **canonicity** and one interaction becomes testable that nothing in
+the pipeline can currently produce: the memorization hypothesis predicts
+canonical pages show **high agreement *and* elevated `neither_matches`.** High
+agreement with low accuracy is the recitation signature, and it is only visible
+when a human holds the image against both sides.
+
 ## Lane 2 — the stream (improvement)
 
 Endless queue, self-selected, no quota, read whatever you like. This is the lane


### PR DESCRIPTION
Follows the volunteer-queue repair (#3568, #3586). Derek answered the design doc's open questions — **credit yes, Spanish yes, payment no** — and asked whether reviewers need a way to excuse themselves when they lack the language.

They do, and the obvious implementation is wrong.

## The escape hatch must not be `not_assessable`

Different objects:

| | is a property of |
|---|---|
| `not_assessable` | the **page** — blank, illegible, image mismatch |
| "I don't read Greek" | the **reviewer–page pairing** |

Conflating them corrupts the statistic: a Latinist reaching for `not_assessable` on a Greek page records that *the page* cannot be judged, which is false, and deflates that stratum's measured quality for reasons having nothing to do with the corpus. Same denominator error as the `reading_history` "62% came back" figure.

So `page_reviews` gains a nullable `passed_reason` (`not_my_language` / `not_my_period` / `cannot_read_scan` / `no_time`), mutually exclusive with `verdict`, page returned to the pool. `cannot_read_scan` is a page property wearing a reviewer's clothes and routes to repair — capture time is the only chance to separate them.

## The incentive that "credit, no payment" creates

**Volume-based credit + unpaid + an easy pass button = an incentive to guess.** If you are named for reviewing N pages and a pass does not count toward N, the rational move for someone who wants the credit is to judge pages they cannot read — fabricating anchors into the one dataset whose entire value is that it is ground truth.

So **credit attaches to completing a round, not to page count, and abstention counts as participation.** This is what stops the compensation model from corrupting the measurement.

## Abstention is data, and belongs in the paper

- **Coverage per stratum is a first-class number** — 40% abstention means a narrower effective reviewer population than `n` suggests.
- **Characterise the missingness, don't count it** (Rubin). If reviewers abstain more on hard pages, the retained sample is systematically easier and "% faithful" is optimistically biased. Cheaply testable: the machine cross-pass agreement score already exists for every page, so compare its distribution across abstained vs completed pages. The instrument that detects the bias is free.
- **The pattern is the memorization paper's thesis, replicated on humans.** If Latin draws twenty reviewers and Tibetan none, that is the same ground-truth scarcity the paper documents for machine benchmarks — reported as a finding, the way the scorecard reports the zero-spaceless-anchor gap rather than laundering it.

## Prior work, so it isn't re-derived

Chow (1970) reject option · Rubin (1976) missing-data mechanisms · Dawid & Skene (1979) and MACE (Hovy et al. 2013) for inferring annotator competence from agreement rather than trusting a declaration · **Krippendorff's α over Cohen's κ**, because abstention makes the coverage matrix ragged by construction · Artstein & Poesio (2008) on why raw agreement flatters when one category dominates, which it will.

In-repo precedent worth copying rather than reinventing: `scripts/analysis/ft-rater-reliability.mjs` already separates **reliability** (chance-corrected agreement by rater *family*, since the same model resampled shares its blind spot) from **validity** (accuracy against checkable gold), and warns that high agreement under shared bias is the trap.

## Decisions recorded

1. **Credit — yes.** Named on a public methods page, acknowledged in the paper; authorship reserved for design/analysis. Per completed round.
2. **Payment — no.** Which is what makes the credit design load-bearing.
3. **Spanish — yes, in the review UI, not only the letter.** 43 of 163 named it. Honest caveat carried in the doc: reviewing a Spanish→English translation needs *both* languages, so a Spanish UI serves Spanish-source review specifically.
4. **Who answers replies — still open.** Flagged loudly; it is the question that killed the standing offers once already (132 signups, 0 ratings, all `contacted: false`).

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)