### PR TITLE
pipeline: never mark a book archive_complete from an unknown page count

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2852,8 +2852,28 @@ async function run() {
         // A book is archive-complete when every page has either archived_photo or cropped_photo on R2.
         // Use pages_count as the target (avoids slow full-collection scans).
         const totalPages = book.pages_count || 0;
-        const coveredPages = archivedPages + croppedPages; // May double-count, but that's fine (>= is the check)
+        // A page carrying BOTH archived_photo and cropped_photo is counted twice here,
+        // so coveredPages can exceed the number of pages actually covered and drive
+        // `remaining` to 0 while real pages still lack an archive. Observed on the small
+        // idp_dunhuang books: pages_count 4, archived 2, cropped 4 -> covered 6 >= 4 ->
+        // marked complete with 2 pages unarchived. Subtract the overlap.
+        const bothPages = await db.collection('pages').countDocuments({
+          book_id: book.id,
+          archived_photo: { $exists: true, $regex: /^https?:\/\// },
+          cropped_photo: { $exists: true, $nin: [null, ''] },
+        });
+        const coveredPages = archivedPages + croppedPages - bothPages;
         const remaining = Math.max(0, totalPages - coveredPages);
+
+        // NEVER conclude "complete" from an unknown page count. With pages_count 0 or
+        // unset, totalPages is 0, so `remaining` is 0 and the check below marks the book
+        // archive_complete no matter how many unarchived pages it really has — and the
+        // status sticks once pages_count is later filled in by the sync worker. 622 books
+        // currently sit at archive_complete holding 291,310 unarchived pages, and the
+        // zero-page branch is the only path in this function that can produce a book with
+        // ZERO archived pages in that state (11 of 20 sampled). Not knowing the page count
+        // is a reason to skip the book, not to declare it done.
+        if (totalPages <= 0) continue;
 
         // Legacy fallback: for archivable sources, also check the old way
         // (pages from non-archivable sources that were never expected to be archived)


### PR DESCRIPTION
Follow-up to #3595. Phase 1's archive-completion check has two ways to declare a book archived that the page data does not support.

**622 books currently sit at `archive_complete` holding 291,310 unarchived pages.** Sampling 30 of them: 96.6% of those gap pages are on recognised archivable hosts, and **zero** are marked `failed:*`. Real work, not pages legitimately excused.

## 1. Zero/unset `pages_count`

```js
const totalPages = book.pages_count || 0;
const remaining  = Math.max(0, totalPages - coveredPages);
...
if (remaining === 0 || ...) -> archive_complete
```

With `pages_count` missing, `totalPages` is 0, so `remaining` is 0 and the book is marked complete **however many unarchived pages it has**. The status then sticks once the sync worker fills `pages_count` in.

This is the only branch in the function that can produce a book with **zero archived pages** at `archive_complete` — the state 11 of 20 sampled books are in. The clearest case: a 1,306-page e-rara dictionary, `pages_archived: 0`, marked complete 2026-03-29, whose page documents have not been touched since 2026-03-15 and carry **no `archived_photo` field at all**. Nothing cleared them; they were never archived.

Now skipped. Not knowing the page count is a reason to leave a book alone, not to declare it done.

## 2. Double counting

```js
const coveredPages = archivedPages + croppedPages; // May double-count, but that's fine (>= is the check)
```

It is not fine. A page carrying both fields is counted twice, so `covered` can exceed real coverage and force `remaining` to 0. Reproduced against production on the small `idp_dunhuang` books:

| pages_count | archived | cropped | both | covered | marked complete? |
|---|---|---|---|---|---|
| 4 | 2 | 4 | 2 | **6** | yes — with 2 pages unarchived |

204 such books, 358 pages. Now subtracts the overlap.

## Honest scope

**(1) is not proven to have fired historically.** The code path is provably wrong as written, and it is the only branch that explains the zero-archived cohort — but the 93 books at `archive_complete` with `pages_count` 0/unset *today* are empty shells with no page documents, so they are not evidence either way. I checked expecting confirmation and did not get it. The fix stands on the code being wrong on its face, not on that inference.

**(2) is directly reproduced** against production data.

## Recovering the existing 622

No status edit needed. `archive-iiif-local --any-status` (#3595, merged) selects on the backlog rather than on status, so these books are already reachable, and its forward-only guard leaves `archive_complete` in place. A run is in progress.

## Cost note

Adds one indexed `countDocuments` per book in the archiving phase, bounded by `ARCHIVE_LIMIT`. Phase 1 already runs two such counts per book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
