### PR TITLE
fix(contribute): volunteer page still promised editing without an account

### DIFF
--- a/src/app/contribute/volunteer/page.tsx
+++ b/src/app/contribute/volunteer/page.tsx
@@ -26,9 +26,16 @@ export default function VolunteerPage() {
 
         <VolunteerForm />
 
+        {/* This promised "an edit button on every page, no sign-up needed."
+            No route has ever provided that: every page-text write is gated at
+            editor and the Read/Edit toggle only renders for editors (#3511).
+            /contribute was corrected then; this page was missed. Flagging a
+            problem really is open to everyone, so that is what it now says —
+            same wording as /contribute, deliberately. */}
         <p className="text-muted text-sm mt-8 leading-relaxed">
-          You can also just start reading &mdash; every book has an edit button on every page, no sign-up needed.
-          This form helps us coordinate and reach out when we have something specific that matches your skills.
+          You can also just start reading &mdash; every page has a &ldquo;Notice a translation issue?&rdquo; link
+          that takes a note straight to us, no account needed. This form helps us coordinate and reach out
+          when we have something specific that matches your skills.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## What

`/contribute/volunteer` told readers:

> You can also just start reading — every book has an edit button on every page, no sign-up needed.

That has never been true, and is deliberately not true: every page-text write is gated at `editor`, and the Read/Edit toggle only renders for editors (#3511).

`/contribute` carried the identical sentence and was corrected when #3511 landed, with a comment recording why. This page was missed by that sweep. It now uses the same replacement wording, so the two pages agree:

> You can also just start reading — every page has a "Notice a translation issue?" link that takes a note straight to us, no account needed.

That is both accurate and the action we actually want from a reader who spots a bad translation.

`git grep` confirms no other live instance of the claim; the only remaining matches are the two comments recording that it used to exist.

## Provenance

Surfaced by an MCP `submit_feedback` security review, which flagged the mismatch between the README (PATCH `/api/pages/[id]` listed under authenticated/internal APIs) and the contribute copy, and asked which was true. The API was correct — the marketing copy was the wrong half. Worth noting the reviewer could only see the discrepancy, not which side of it was the bug.

## Scope

**In:** one sentence on one page.
**Out:** the separate question of how a volunteer actually *gets* editing access — `/contribute` points them at `team@sourcelibrary.org`, which this page does not mention. Left alone rather than inventing new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)