### PR TITLE
fix(seo): escape < in JSON-LD so page text cannot close its own script tag

### DIFF
--- a/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/(reader)/page.tsx
@@ -9,6 +9,7 @@ import HymnPlayer from '@/components/book/HymnPlayer';
 import { isHiddenBook } from '@/lib/book-access';
 import { stripEditorialWrappers } from '@/lib/strip-editorial-wrappers';
 import { getTranscriptionsForPage } from '@/lib/music-transcriptions';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 // Schema.org structured data for a translated page, so it surfaces as a
 // citable scholarly work in web search (#2822). Only emitted for indexable
@@ -125,7 +126,7 @@ export default async function PageEditorPage({ params, allowHidden = false }: Pa
       {jsonLd && (
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
         />
       )}
       <EmbedNavigationReporter book={book.slug || book.id} page={pageId} />

--- a/src/components/seo/AuthorSchema.tsx
+++ b/src/components/seo/AuthorSchema.tsx
@@ -1,4 +1,5 @@
 import { BASE_URL } from './schema-utils';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 interface AuthorSchemaProps {
   authorName: string;
@@ -120,7 +121,7 @@ export default function AuthorSchema({
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/components/seo/BlogPostSchema.tsx
+++ b/src/components/seo/BlogPostSchema.tsx
@@ -1,4 +1,5 @@
 import { BASE_URL } from './schema-utils';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 interface BlogPostSchemaProps {
   slug: string;
@@ -74,7 +75,7 @@ export default function BlogPostSchema({
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/components/seo/CategorySchema.tsx
+++ b/src/components/seo/CategorySchema.tsx
@@ -1,5 +1,6 @@
 import { BASE_URL } from './schema-utils';
 import { formatAuthor } from '@/lib/utils';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 interface CategorySchemaProps {
   id: string;
@@ -70,7 +71,7 @@ export default function CategorySchema({
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/components/seo/CollectionSchema.tsx
+++ b/src/components/seo/CollectionSchema.tsx
@@ -1,5 +1,6 @@
 import { BASE_URL } from './schema-utils';
 import { formatAuthor } from '@/lib/utils';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 interface CollectionSchemaProps {
   slug: string;
@@ -86,7 +87,7 @@ export default function CollectionSchema({
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/components/seo/EntitySchema.tsx
+++ b/src/components/seo/EntitySchema.tsx
@@ -1,5 +1,6 @@
 import { BASE_URL } from './schema-utils';
 import { buildSameAsArray } from '@/lib/jsonld';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 interface EntitySchemaProps {
   name: string;
@@ -126,7 +127,7 @@ export default function EntitySchema({
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/components/seo/GalleryImageSchema.tsx
+++ b/src/components/seo/GalleryImageSchema.tsx
@@ -1,5 +1,6 @@
 import { BASE_URL, PUBLIC_DOMAIN_MARK_URL, getLicenseUrl } from './schema-utils';
 import { formatAuthor } from '@/lib/utils';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 interface GalleryImageSchemaProps {
   imageId: string;
@@ -119,7 +120,7 @@ export default function GalleryImageSchema({
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/components/seo/GallerySchema.tsx
+++ b/src/components/seo/GallerySchema.tsx
@@ -1,4 +1,5 @@
 import { BASE_URL } from './schema-utils';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 /**
  * Schema.org JSON-LD for the gallery collection page.
@@ -37,7 +38,7 @@ export default function GallerySchema() {
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/components/seo/HomePageSchema.tsx
+++ b/src/components/seo/HomePageSchema.tsx
@@ -1,5 +1,6 @@
 import { Book } from '@/lib/types';
 import { formatAuthor } from '@/lib/utils';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 interface HomePageSchemaProps {
   books: Book[];
@@ -91,7 +92,7 @@ export default function HomePageSchema({ books, bookCount, translatedCount }: Ho
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/components/seo/LibrarySchema.tsx
+++ b/src/components/seo/LibrarySchema.tsx
@@ -1,4 +1,5 @@
 import { BASE_URL } from './schema-utils';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 interface LibrarySchemaProps {
   slug: string;
@@ -64,7 +65,7 @@ export default function LibrarySchema({
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/components/seo/SchemaOrgMetadata.tsx
+++ b/src/components/seo/SchemaOrgMetadata.tsx
@@ -2,6 +2,7 @@ import { Book, TranslationEdition } from '@/lib/types';
 import { CONTENT_LICENSE } from '@/lib/license-info';
 import { BASE_URL, PUBLIC_DOMAIN_MARK_URL, getLicenseUrl } from './schema-utils';
 import { formatAuthor } from '@/lib/utils';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 interface SchemaOrgMetadataProps {
   book: Book;
@@ -228,7 +229,7 @@ export default function SchemaOrgMetadata({
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd, null, 0) }}
+      dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
     />
   );
 }

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,0 +1,25 @@
+/**
+ * Safe serialization of JSON-LD into a `<script type="application/ld+json">`.
+ *
+ * `JSON.stringify` does not escape `<`, and the HTML parser ends a `<script>`
+ * element at the first `</script` it sees — inside a string literal or not. So
+ * any payload containing that sequence terminates the tag early, dumps the rest
+ * of the JSON into the document as text, and can execute whatever follows.
+ *
+ * This is not hypothetical for us. The reader page's JSON-LD carries a 500-char
+ * excerpt of page text, and our OCR metadata envelope literally contains a
+ * `<script>` tag — it records the writing system, e.g.
+ * `<script>printed</script>`. `stripEditorialWrappers()` removes that envelope,
+ * so the excerpt is normally clean; this function is the belt to that braces,
+ * and it also covers every other schema component, whose titles, descriptions
+ * and author names come from imported catalogue data we do not control.
+ *
+ * Escaping `<` is sufficient and is the standard fix: it defeats both
+ * `</script` and `<!--`. `<` is a valid JSON escape, so consumers
+ * (Google, schema validators) parse it back to `<` transparently.
+ *
+ * Pinned by tests/unit/json-ld-escape.test.ts.
+ */
+export function jsonLdHtml(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c');
+}

--- a/tests/unit/json-ld-escape.test.ts
+++ b/tests/unit/json-ld-escape.test.ts
@@ -1,0 +1,80 @@
+/**
+ * JSON-LD injected into a `<script type="application/ld+json">` must not be able
+ * to close its own tag.
+ *
+ * `JSON.stringify` leaves `<` alone, and the HTML parser ends a `<script>` at
+ * the first `</script` regardless of JS string context. Our reader page embeds a
+ * 500-char excerpt of PAGE TEXT in its JSON-LD, and the OCR metadata envelope
+ * contains a literal `<script>` tag recording the writing system
+ * (`<script>printed</script>`) — so this is reachable from real corpus data, not
+ * only from a crafted payload. Found 2026-08-04 when the same data broke an
+ * offline prototype the same way.
+ *
+ * These assertions run the escaper; they do not grep source. Deleting the
+ * `.replace()` in jsonLdHtml turns them red.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { jsonLdHtml } from '../../src/lib/json-ld';
+
+const repoRoot = path.resolve(__dirname, '../..');
+
+describe('jsonLdHtml', () => {
+  it('neutralises a closing script tag in the payload', () => {
+    const out = jsonLdHtml({ text: 'transcription </script><img src=x onerror=alert(1)>' });
+    expect(out).not.toContain('</script');
+    expect(out).not.toContain('<img');
+  });
+
+  it('neutralises the real OCR envelope tag that motivated this', () => {
+    const out = jsonLdHtml({ text: '<script>printed</script> Sæpe iam ad huius operis' });
+    expect(out).not.toContain('</script');
+    expect(out).not.toContain('<script');
+  });
+
+  it('neutralises an HTML comment opener', () => {
+    expect(jsonLdHtml({ a: '<!--' })).not.toContain('<!--');
+  });
+
+  it('still round-trips to the original data', () => {
+    const data = {
+      '@type': 'CreativeWork',
+      text: 'a </script> b <!-- c --> d',
+      name: 'Sæpe — Ἰλιάς — 甲骨文',
+      nested: { arr: [1, '<x>', null], flag: true },
+    };
+    expect(JSON.parse(jsonLdHtml(data))).toEqual(data);
+  });
+
+  it('escapes every angle bracket it emits', () => {
+    const out = jsonLdHtml({ a: '<<<>>>' });
+    expect(out.includes('<')).toBe(false);
+    expect(JSON.parse(out).a).toBe('<<<>>>');
+  });
+
+  /**
+   * ABSENCE invariant — deletion is the failure mode here, so a source check is
+   * the right instrument (see CLAUDE.md on when source-shape tests earn their
+   * keep). A new schema component that hand-rolls JSON.stringify into
+   * dangerouslySetInnerHTML reintroduces the bug, and nothing else would catch it.
+   */
+  it('no component serialises JSON-LD without the escaper', () => {
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const e of readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, e.name);
+        if (e.isDirectory()) { walk(p); continue; }
+        if (!/\.tsx?$/.test(e.name)) continue;
+        const src = readFileSync(p, 'utf8');
+        // strip comments so prose about the bug can't trip the check
+        const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+        if (/dangerouslySetInnerHTML=\{\{\s*__html:\s*JSON\.stringify/.test(code)) {
+          offenders.push(path.relative(repoRoot, p));
+        }
+      }
+    };
+    walk(path.join(repoRoot, 'src'));
+    expect(offenders, `use jsonLdHtml() instead of raw JSON.stringify in: ${offenders.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Found while debugging a broken prototype — the same corpus data broke it the same way.

## The bug

`JSON.stringify` does not escape `<`, and the HTML parser ends a `<script>` element at the first `</script` it sees, string literal or not. All **11** JSON-LD sites in `src/` hand-rolled `JSON.stringify` into `dangerouslySetInnerHTML`, unescaped.

## Why it's reachable from real data

The reader page embeds a **500-character excerpt of page text** in its JSON-LD (`buildPageJsonLd`, gated on `seo_indexable`). And our OCR metadata envelope contains a literal `<script>` tag — it records the writing system:

```
<scan-quality>good</scan-quality> <language>Latin</language> <script>printed</script> ...
```

That exact string terminated the script block of an offline prototype an hour ago, which is how this was noticed — `ReferenceError: printed is not defined`, because `printed` had escaped into the document as markup.

**Live pages are not currently broken:** `stripEditorialWrappers()` removes the envelope before the excerpt is taken. This is the belt to that braces — and the other ten components carry titles, descriptions and author names from imported catalogue data we don't control.

## The fix

All 11 sites now go through `jsonLdHtml()` (`src/lib/json-ld.ts`), which escapes `<` → `<`. Escaping `<` alone is sufficient (it defeats both `</script` and `<!--`), is the standard remedy, and is transparent to Google and schema validators because `<` is a valid JSON escape.

## Guard

`tests/unit/json-ld-escape.test.ts` — exercises the escaper against the real OCR envelope string, an injection payload, an HTML comment opener, and a full round-trip including non-ASCII (`Sæpe`, `Ἰλιάς`, `甲骨文`).

**Negative control performed:** deleting the `.replace()` in `jsonLdHtml` turns **4 of 6 red**; restoring it turns them green. Per the repo rule that a guard you haven't watched fail is a decoration.

The sixth test is a deliberate source-shape **absence** check — a new schema component hand-rolling `JSON.stringify` reintroduces the bug and nothing behavioural would catch it. It strips comments before matching, so prose about the bug can't satisfy it.

`npx tsc --noEmit` clean; full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)