### PR TITLE
feat(ref-set): one command to rebuild the reference set, and prove it landed (#3556)

### DIFF
--- a/scripts/enrichment/rebuild-reference-set.mjs
+++ b/scripts/enrichment/rebuild-reference-set.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * rebuild-reference-set.mjs — rebuild the reference set from zero, and PROVE it. (#3556)
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The reference set is the evidence under every first-translation claim, and its
+ * measured recall (27%) is the most-cited number in this subsystem. On 2026-08-04
+ * it emerged that the *inputs* to that number — the LoC extract and the Wikidata
+ * rows — existed **only inside one session's private git worktree**. Not in the
+ * repo (too large), not on the pipeline box, not anywhere shared. A single
+ * `git worktree remove` would have destroyed the artifacts behind the governing
+ * figure, and nothing would have reported it: the Mongo collection would have sat
+ * there looking complete while being unreproducible.
+ *
+ * So: one command that rebuilds both sources from their origins and then VERIFIES
+ * the result against the destination rather than against its own log.
+ *
+ * THE THREE FAILURES THIS GUARDS, ALL OBSERVED IN ONE AFTERNOON
+ * ------------------------------------------------------------
+ *  1. A DOCUMENTED COMMAND THAT WRITES NOTHING. The runbook said
+ *     `--parts 1-43 --keep-gz`. `--keep-gz` only retains downloads; **`--load` is
+ *     what writes Mongo.** Following the instructions extracted 126,558 rows to
+ *     disk and wrote zero, with a success-looking log.
+ *  2. A PARTIAL LOAD THAT LOOKS COMPLETE. `withMongo`'s 300s watchdog killed the
+ *     load at part 30 of 43, leaving 120,976 of 126,558 rows and exit code 0. A
+ *     short reference set does not error — it fails to find priors, which reads as
+ *     `none_found`, which reads as "first translation".
+ *  3. A BLOCKED SOURCE THAT RETURNS HTTP 200. loc.gov sits behind a Cloudflare bot
+ *     challenge; from a datacenter IP every part returns a 403 HTML page. The
+ *     ingest's gzip check catches it, but only because it fails closed.
+ *
+ * ⚠️ RESIDENTIAL IP REQUIRED. loc.gov challenges datacenter traffic — all 43 parts
+ * fail from the Hetzner box with `cf-mitigated: challenge`. **This must be run
+ * from a residential connection.** That is not a preference; it is why the extract
+ * cannot simply live on the pipeline box, and it is the reason these artifacts
+ * kept ending up on someone's laptop in the first place.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/enrichment/rebuild-reference-set.mjs            # verify only
+ *   node scripts/enrichment/rebuild-reference-set.mjs --rebuild  # re-derive, then verify
+ */
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
+
+/**
+ * Run the body only when EXECUTED, never when imported.
+ *
+ * Without this, importing `verifyReferenceSet` for a unit test runs the whole
+ * verification — and with `--rebuild` would re-download 3GB from loc.gov. The
+ * sibling script `ingest-loc-bulk.mjs` documents the identical trap (#3563); it
+ * was reintroduced here and caught by the tests failing to load at all.
+ */
+const IS_MAIN = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+const REBUILD = process.argv.includes('--rebuild');
+const OUT = path.join(process.cwd(), 'scripts', 'output');
+const LOC_DIR = path.join(OUT, 'loc-bulk');
+const WD_DIR = path.join(OUT, 'wikidata');
+
+const run = (args, label) => {
+  console.log(`\n─── ${label} ───`);
+  const r = spawnSync('node', args, { stdio: 'inherit', env: process.env });
+  if (r.status !== 0) {
+    console.error(`\n${label} FAILED (exit ${r.status}).`);
+    if (label.includes('LoC')) {
+      console.error('If every part failed a gzip integrity check, loc.gov served a');
+      console.error('Cloudflare challenge — you are on a datacenter IP. Re-run from a');
+      console.error('residential connection. See the header of this file.');
+    }
+    process.exit(1);
+  }
+};
+
+/**
+ * THE VERIFICATION. Pure, so it can be tested against the real incidents.
+ *
+ * Read the DESTINATION, never the log. Every failure documented in this file's
+ * header produced a log that looked like success; the only thing that
+ * distinguished them was querying what actually landed.
+ *
+ * @param {{locFiles:number, locRows:number, wdRows:number, inMongo:number}} state
+ * @returns {string[]} problems — empty means the set is usable
+ */
+export function verifyReferenceSet({ locFiles, locRows, wdRows, inMongo }) {
+  const problems = [];
+  if (locFiles !== 43) problems.push(`LoC extract has ${locFiles} of 43 parts — INCOMPLETE`);
+  if (locRows === 0) problems.push('LoC extract is empty — nothing was derived');
+  if (wdRows === 0) {
+    problems.push('Wikidata extract is empty — the search will run LoC-only, which is a '
+      + 'DIFFERENT baseline (25.8%, not 27.0%) and not comparable to the published figure');
+  }
+  // The load-truncation guard. Fires on the exact 2026-08-04 state: 120,976 in
+  // Mongo against a 126,558-row extract, after the watchdog killed the load at
+  // part 30 of 43 with exit code 0.
+  if (locRows && inMongo < locRows) {
+    problems.push(
+      `Mongo holds ${inMongo.toLocaleString()} but the extract has ${locRows.toLocaleString()} `
+      + `— ${(locRows - inMongo).toLocaleString()} rows never loaded. Re-run with --load; `
+      + 'a short reference set does not error, it silently reports `none_found`.',
+    );
+  }
+  return problems;
+}
+
+/** Count JSONL rows on disk. This is the SOURCE side of the verification. */
+async function countJsonl(dir) {
+  if (!fs.existsSync(dir)) return { files: 0, rows: 0 };
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.jsonl'));
+  let rows = 0;
+  for (const f of files) {
+    const rl = readline.createInterface({
+      input: fs.createReadStream(path.join(dir, f)), crlfDelay: Infinity,
+    });
+    for await (const line of rl) if (line.trim()) rows++;
+  }
+  return { files: files.length, rows };
+}
+
+if (IS_MAIN) {
+if (REBUILD) {
+  // `--load` is NOT optional. Without it this extracts to disk and writes nothing.
+  run(['scripts/enrichment/ingest-loc-bulk.mjs', '--parts', '1-43', '--load'], 'LoC MDSConnect bulk');
+  run(['scripts/enrichment/ingest-wikidata-translations.mjs', '--out', WD_DIR], 'Wikidata P629');
+}
+
+const loc = await countJsonl(LOC_DIR);
+const wd = await countJsonl(WD_DIR);
+
+await withMongo(async (db) => {
+  const rt = db.collection('reference_translations');
+  const inMongo = await rt.countDocuments({});
+  const bilingual = await rt.countDocuments({ bilingual: true });
+
+  console.log('\n─── Reference set ───────────────────────────────────────────');
+  console.log(`  LoC extract on disk   : ${loc.rows.toLocaleString()} rows in ${loc.files} file(s)`);
+  console.log(`  Wikidata on disk      : ${wd.rows.toLocaleString()} rows in ${wd.files} file(s)`);
+  console.log(`  reference_translations: ${inMongo.toLocaleString()} (Mongo)`);
+  console.log(`  ...bilingual          : ${bilingual.toLocaleString()}`);
+
+  const problems = verifyReferenceSet({
+    locFiles: loc.files, locRows: loc.rows, wdRows: wd.rows, inMongo,
+  });
+
+  if (problems.length) {
+    console.log('\n  ❌ NOT USABLE:');
+    for (const p of problems) console.log(`     - ${p}`);
+    console.log('\n  Do NOT quote recall or coverage from this state.');
+    process.exitCode = 1;
+    return;
+  }
+  console.log('\n  ✅ Extract and Mongo agree. Reference set is usable.');
+  console.log('     Next: ft-reference-set-search.mjs --cohort badged|inverse --apply');
+  console.log('           ft-reference-set-recall.mjs');
+},
+// A full verification walks the whole collection; the 300s watchdog would kill it
+// mid-count and report a mismatch that is an artifact of its own timeout.
+{ noTimeout: true });
+}

--- a/tests/unit/reference-set-verify.test.ts
+++ b/tests/unit/reference-set-verify.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The reference-set verification, tested against the incidents that motivated it. (#3556)
+ *
+ * Every fixture below is a REAL state observed on 2026-08-04 while re-deriving the
+ * set. Each one produced a log that looked like success. The whole point of this
+ * check is that it reads the destination instead.
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import { verifyReferenceSet } from '../../scripts/enrichment/rebuild-reference-set.mjs';
+
+/** The good state, measured 2026-08-04 after a clean rebuild. */
+const HEALTHY = { locFiles: 43, locRows: 126_558, wdRows: 15_015, inMongo: 126_558 };
+
+describe('the healthy state passes', () => {
+  it('no problems when extract and Mongo agree', () => {
+    expect(verifyReferenceSet(HEALTHY)).toEqual([]);
+  });
+});
+
+describe('the incidents it must catch', () => {
+  it('THE LOAD TRUNCATION: 120,976 in Mongo against a 126,558-row extract', () => {
+    // withMongo's 300s watchdog killed the load at part 30 of 43, exit code 0.
+    const problems = verifyReferenceSet({ ...HEALTHY, inMongo: 120_976 });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/5,582 rows never loaded/);
+    expect(problems[0]).toMatch(/--load/);
+  });
+
+  it('THE SILENT NO-OP: extraction ran, nothing was written to Mongo', () => {
+    // Following the documented `--keep-gz` runbook: 126,558 rows on disk, and the
+    // collection still holding its previous contents.
+    const problems = verifyReferenceSet({ ...HEALTHY, inMongo: 118_352 });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/8,206 rows never loaded/);
+  });
+
+  it('THE BLOCKED SOURCE: every part 403d, so nothing was derived', () => {
+    // loc.gov behind a Cloudflare challenge from a datacenter IP.
+    const problems = verifyReferenceSet({ locFiles: 0, locRows: 0, wdRows: 15_015, inMongo: 118_352 });
+    expect(problems.some((p: string) => /0 of 43 parts/.test(p))).toBe(true);
+    expect(problems.some((p: string) => /empty/.test(p))).toBe(true);
+  });
+
+  it('A PARTIAL EXTRACT: some parts failed, the rest look fine', () => {
+    const problems = verifyReferenceSet({ ...HEALTHY, locFiles: 41, locRows: 120_000, inMongo: 126_558 });
+    expect(problems.some((p: string) => /41 of 43 parts/.test(p))).toBe(true);
+  });
+
+  it('THE MISSING SECOND SOURCE: LoC-only is a different baseline, not a smaller one', () => {
+    // The Wikidata rows also lived only in the locked worktree. Running without
+    // them yields 25.8%, which is NOT comparable to the published 27.0% — the
+    // dangerous outcome is a number that looks like a regression and is a
+    // different measurement.
+    const problems = verifyReferenceSet({ ...HEALTHY, wdRows: 0 });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/25\.8%.*27\.0%/);
+  });
+});
+
+describe('it does not fire on states that are fine', () => {
+  it('Mongo ahead of the extract is not an error', () => {
+    // Extra rows from an older, larger snapshot are stale, not truncated. This
+    // check guards the truncation direction only, and says so.
+    expect(verifyReferenceSet({ ...HEALTHY, inMongo: 130_000 })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The problem this fixes

The reference set is the evidence under every first-translation claim, and its **27% recall** is the most-cited number in this subsystem.

On 2026-08-04 it emerged that the *inputs* to that number — the LoC extract and the Wikidata rows — existed **only inside one session's private git worktree.** Not in the repo (too large), not on the pipeline box, nowhere shared.

A single `git worktree remove` would have destroyed the artifacts behind the governing figure, and **nothing would have reported it**: the Mongo collection would have sat there looking complete while being unreproducible. Both had to be regenerated from scratch to run the re-derivation #3563 asked for.

## What it does

One command that rebuilds both sources and then **verifies the result against the destination rather than against its own log.** Every failure below produced a log that looked like success:

| failure | what it looked like | what was true |
|---|---|---|
| documented command writes nothing | clean 43-of-43 extraction, full stats block | `--keep-gz` was documented; **`--load`** writes Mongo. 126,558 rows to disk, **zero** written |
| partial load | exit code 0 | watchdog killed it at part 30 of 43 — **120,976 of 126,558** |
| blocked source | — | loc.gov 403s every part behind a Cloudflare challenge |

## ⚠️ The constraint nobody had written down

**loc.gov challenges datacenter traffic.** All 43 parts fail from the Hetzner box with `cf-mitigated: challenge`. The extract *cannot* be derived on the pipeline box — a residential connection is required.

That is why these artifacts kept ending up on someone's laptop, and it was discovered today and documented nowhere. It's now in the file header, so the next person doesn't rediscover it by watching 43 gzip integrity checks fail.

## Testing

`verifyReferenceSet()` is pure and unit-tested against the **real** states above, including the exact 120,976-of-126,558 truncation and the 118,352 silent no-op.

It deliberately does **not** fire when Mongo is *ahead* of the extract — stale extra rows are a different condition from a truncated load, and an alarm that fires on both trains people to ignore it.

| mutation | result |
|---|---|
| baseline | 7 passed |
| remove the load-truncation guard | **2 failed** |
| remove the parts-count guard | **2 failed** |
| remove the wikidata guard | **1 failed** |
| restored | 7 passed |

Verified end-to-end against the live state: 126,558 on disk in 43 files, 15,015 Wikidata rows, 126,558 in Mongo, 21,195 bilingual → ✅.

## One self-inflicted bug worth naming

The first version ran its **whole body on import**, so importing `verifyReferenceSet` for a test executed the verification — and with `--rebuild` would have re-downloaded 3GB. That is the identical trap `ingest-loc-bulk.mjs` documents in its own header (#3563). I reintroduced it, and it was caught only because the tests reported "no tests" rather than failing. Now carries an `IS_MAIN` guard.

## Out of scope

- Does not move the extracts to shared storage — that needs a decision about where (R2? the box can't derive them, but it could *hold* them).
- Does not touch the search or recall scripts; the `noTimeout` fixes for those are in #3613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)