### PR TITLE
audit: catch documented enums drifting from production

### DIFF
--- a/.claude/docs/data-provenance.md
+++ b/.claude/docs/data-provenance.md
@@ -58,7 +58,7 @@ page.ocr.prompt_version    // "v10"
 page.ocr.prompt_id         // ObjectId-string of the prompt document, or 'hardcoded' / 'custom'
 page.ocr.prompt_hash       // md5 of prompt content (cryptographic verifier)
 page.ocr.prompt_name       // "Standard OCR" | "Latin OCR (Neo-Latin)" | etc
-page.ocr.source            // 'ai' | 'batch_api' | 'manual' | 'contributor' | 'skip'
+page.ocr.source            // see the full enum below — 16 values, not 5
 page.translation.prompt_version
 page.translation.prompt_id
 page.translation.prompt_hash
@@ -127,7 +127,8 @@ For batch jobs the four fields are stamped on the `batch_jobs` row at submission
   data: "the full previous text content",
   source: "batch_api" | "ai" | "pipeline_preview" | "manual" | "skip" | "system" |
           "maintenance" | "mineru" | "realtime_api_sequential" | "unknown" | null |
-          "<sweep-label>",   // ad-hoc, e.g. "shift-repair-erara-2026-07"
+          "<sweep-label>",   // ad-hoc, e.g. "shift-repair-erara-2026-07",
+                             // "reocr-download-failure-fix-2026-07"
   model: "gemini-3-flash-preview",
   prompt_version: "v10",
   job_id: "job_abc123",
@@ -135,6 +136,45 @@ For batch jobs the four fields are stamped on the `batch_jobs` row at submission
   created_at: Date      // when it was SUPERSEDED (a snapshot clock — see below)
 }
 ```
+
+### The live `pages.{ocr,translation}.source` enum
+
+Exact counts, 2026-08-04, `node scripts/audit/doc-enum-drift.mjs`. **Guarded** —
+that script fails when production carries a value this doc does not mention, so
+the list below stays true or the audit says so.
+
+| `pages.ocr.source` | rows | | `pages.translation.source` | rows |
+|---|---|---|---|---|
+| `batch_api` | 4,159,051 | | `ai` | 5,153,668 |
+| `ai` | 2,070,501 | | `system` | 92,420 |
+| `pipeline_preview` | 210,527 | | `batch_api` | 82,826 |
+| `corpus` | 5,749 | | `corpus` | 5,759 |
+| `mineru` | 2,586 | | `skip` | 1,153 |
+| `system` | 775 | | `realtime_api_sequential` | 62 |
+| `spread-split` | 277 | | `manual` | 21 |
+| `ia-ocr-repair` | 191 | | `manual-backfill` | 12 |
+| `reocr-contamination-repair-3362` | 93 | | `broadsheet-ocr` | 2 |
+| `batch_api_recovery` | 74 | | `songshi-juan56` | 1 |
+| `manual` | 33 | | `AI generated` | 1 |
+| `wikisource` | 21 | | | |
+| `ai-repair-sync` | 11 | | | |
+| `broadsheet-ocr` | 2 | | | |
+| `songshi-juan56` | 1 | | | |
+| `AI generated` | 1 | | | |
+
+Three things in that table are load-bearing:
+
+- **`wikisource` (21 pages) is not model output at all.** Neither is `corpus`
+  (~5.7K on each field). Any metric that treats `pages.ocr` as "what the model
+  read" is wrong on those rows, and no field other than `source` says so.
+- **Repair sweeps write here too**, exactly as they do on `page_revisions`:
+  `ia-ocr-repair`, `reocr-contamination-repair-3362` (the #3362 shared-key
+  contamination), `spread-split`, `ai-repair-sync`. Text carrying one of these
+  was *relocated or rewritten*, not read from the page in front of it.
+- **`songshi-juan56` and `AI generated` (1 row each) are junk labels** — a book
+  slug and a free-text string that leaked into an enum. Left documented rather
+  than silently ignored, because the alternative is an audit that has to be
+  taught to lie.
 
 **`source` is the mechanism label, and it is the first thing to read when asking
 what a set of revisions actually records.** Measured 2026-08-01 (`node

--- a/.claude/handoffs/2026-08-04-revision-corpus-source-and-five-retractions.md
+++ b/.claude/handoffs/2026-08-04-revision-corpus-source-and-five-retractions.md
@@ -87,10 +87,16 @@ agreement elsewhere.** Using the word metric on Tibetan is what produced the voi
 
 ## Open, in priority order
 
-1. **PR #3617 is unverified.** The confirmation run — that `data-provenance.md` passes
-   its own check — died on a DNS drop mid-scan. The enum table came from a *completed*
-   exact scan so the values are right, but the round trip is not closed. Re-run
-   `node scripts/audit/doc-enum-drift.mjs --fail-on-findings` before merging.
+1. ~~**PR #3617 is unverified.**~~ **RESOLVED 2026-08-05 — verified and ready to merge.**
+   Exact full scans, no sampling: `page_revisions.source` 12 values, `pages.ocr.source`
+   16, `pages.translation.source` 11, all documented. Two bugs fixed on the way
+   (`4210b4db`): the error path **hung forever** — `process.exitCode` does not force an
+   exit and nothing closed the MongoClient, so one run sat alive 2h43m holding a
+   connection pool; and phantom detection was reporting field *paths* as values. The
+   hang was only visible from the process list, because the status check had been
+   reporting a *different* process for an hour. **Run this audit on Hetzner** — exact
+   mode scans `pages` twice at 19.1M docs and two of three local attempts died on a
+   network blip mid-scan.
 2. **#3614 — two `is_default: true` prompts** for `{summary, Standard Summary}`, one
    with no `version` field. Violates an invariant `data-provenance.md` itself states;
    `getSummaryPrompt()` resolves arbitrarily and one path records

--- a/.claude/handoffs/2026-08-04-revision-corpus-source-and-five-retractions.md
+++ b/.claude/handoffs/2026-08-04-revision-corpus-source-and-five-retractions.md
@@ -1,0 +1,131 @@
+# The revision corpus is a mixed record — and five things I got wrong finding that out
+
+2026-08-01 → 08-04, issue #3473. Merged: **PR #3475**. Open: **PR #3617**, issue **#3614**.
+
+Written to be read cold. The retractions are the point — every one was a confident,
+plausible aggregate over an instrument nobody had checked, and four of the five
+survived a first round of scrutiny before failing a second.
+
+---
+
+## What is true now
+
+**`page_revisions` is not a double-OCR corpus. It is a mixed record of model passes
+AND bulk maintenance, and `page_revisions.source` says which.**
+
+| source | ocr rows | leaf-shifted |
+|---|---|---|
+| `batch_api` | 109,982 | 3.8% |
+| `shift-repair-erara-2026-07` | 56,413 | **99.0%** |
+| `pipeline_preview` | 12,949 | 0.8% |
+| `ai` | 8,622 | 0% |
+
+The ±1 page-offset population that two sessions characterised by sampling,
+page-number arithmetic, per-book offset signatures and finally two scans opened by
+hand **is just the rows that say `shift-repair-erara-2026-07`**. The field was
+documented in `data-provenance.md` the whole time; the enum there was stale.
+
+Consequences that stand:
+
+- **Segment by `source` before quoting any number over `page_revisions`.** Now
+  enforced in `revision-agreement-corpus.mjs` and `repeat-instability-draw.mjs` via
+  `scripts/eval/lib/revision-source.mjs`, matched by *shape*
+  (`repair|fix|shift|migrat|backfill|cleanup|sweep|maintenance`) so next year's sweep
+  is excluded by default. Unlabelled rows are deliberately NOT treated as
+  maintenance — absence of a label is not evidence of a sweep.
+- **The published corpus barely moves:** 61,719 → 61,640 true repeats (0.13%
+  tightening). Requiring equal printed page numbers already dropped ~99% of sweep
+  rows. The change matters for correctness of *reasoning*, not of the headline.
+- **Repeat instability does not transfer to translation.** Median agreement 0.630 vs
+  0.996 for OCR; 89.8% of translation pairs fall below the 0.85 "unstable" threshold
+  against 9.3% for OCR. Structural, not a data problem: OCR has one correct output,
+  translation has many. A semantic metric (embedding cosine over `page_translations`)
+  is the path; the lexical one cannot work here.
+- **Translation was never measurable by page number:** 2.0% of translation rows carry
+  a printed `<page-num>` against 60.9% of OCR rows. The same-leaf filter cut 130,049
+  rows to **331**.
+- **Instability by language** (true repeats only — the metric finally pointed at the
+  question it was built for): English 2.3% unstable, German 4.4%, French 8.0%, Latin
+  15.5%, Italian 22.8%, Greek 23.3% (7.8% outright bad), **Arabic 59.7%**, **Persian
+  70.1%**. Caveat: stability ≠ accuracy, and Latin-vs-German may be *material* (older
+  holdings) rather than language.
+
+---
+
+## The five retractions
+
+| claimed | reality | how it failed |
+|---|---|---|
+| inverted timestamp proves a text move | 90% of *proven re-OCRs* invert too | signal never checked against a control cohort |
+| "no clock can order these rows" | `original_date` orders 99.3% correctly | one field's failure generalised to the category |
+| ~3.8% residual contamination in rescued pairs | the low tail is *hard pages*, not contamination | rate measured on one population, applied to another |
+| 86% of re-archived pages mispaired | 2.3× on spaced scripts, no signal on space-less | word metric on Tibetan + arms 76% vs 7% Tibetan |
+| Tibetan "instrument doesn't work" | that instability *is* the quality signal | conflated the pairing question with the quality question |
+
+Each was caught by opening the artifact, never by more reasoning. Two were caught only
+because Derek asked a question I had not asked myself ("is a timestamp recorded
+elsewhere?", "isn't this inconsistency what we can measure?").
+
+---
+
+## Instruments built
+
+| script | what it answers | cost |
+|---|---|---|
+| `scripts/audit/ocr-revision-provenance.mjs` | which mechanism wrote each revision | free, ~2 min |
+| `scripts/audit/doc-enum-drift.mjs` | does a documented enum still match production | free, minutes |
+| `scripts/eval/true-repeat-count.mjs` | before/after on the true-repeat filter | free, local |
+| `scripts/eval/reocr-pairing-check.mjs` | does stored text match the current image | ~$0.00079/page |
+| `scripts/eval/lib/revision-source.mjs` | reading vs maintenance classifier | pinned by 27 tests |
+
+`agreementPrimary` / `agreementChars` / `scriptClassOf` now live in
+`scripts/eval/lib/metrics.mjs` — **character agreement on space-less scripts, word
+agreement elsewhere.** Using the word metric on Tibetan is what produced the void
+86% result.
+
+---
+
+## Open, in priority order
+
+1. **PR #3617 is unverified.** The confirmation run — that `data-provenance.md` passes
+   its own check — died on a DNS drop mid-scan. The enum table came from a *completed*
+   exact scan so the values are right, but the round trip is not closed. Re-run
+   `node scripts/audit/doc-enum-drift.mjs --fail-on-findings` before merging.
+2. **#3614 — two `is_default: true` prompts** for `{summary, Standard Summary}`, one
+   with no `version` field. Violates an invariant `data-provenance.md` itself states;
+   `getSummaryPrompt()` resolves arbitrarily and one path records
+   `prompt_version: undefined`. Also: the doc's "Current defaults" table is 5 and 4
+   versions behind (OCR v10 vs **v15**, Translation v8 vs **v12**).
+3. **~40 stratified pairs** before adopting the leaf-agnostic corpus. It would grow the
+   usable set by +23,130 (ocr) / +50,446 (translation), and 4/4 spot-checked low-agreement
+   rescued pairs were genuinely the same page — but n=4 cannot move a published number.
+4. **`corpus` and `wikisource` rows are not model output** (~5.7K on each field). Every
+   quality number in this session assumed `pages.ocr` is what a model read. Too small to
+   move conclusions — but "too small to matter" is exactly the claim that was wrong four
+   times above, so measure it.
+5. **Semantic metric for translation quality.** Scoped in the measurement-loop doc so the
+   next attempt does not begin by re-running Levenshtein and rediscovering it fails.
+
+---
+
+## Does CLAUDE.md need a new invariant?
+
+**No — and that is a deliberate call, not an omission.**
+
+Every lesson here is already doctrine there, and adding a sixth restatement would
+violate CLAUDE.md's own rule that doctrine lives in one place:
+
+- "check whether the fact is stored before inferring it" → *"A metric is a claim about
+  an instrument before it is a claim about readers"* and *"Read the actual output before
+  interpreting an aggregate"*.
+- word-metric-on-space-less-scripts → already stated with the exact numbers (Chinese
+  36.7% word vs 72.7% character) in the quote-integrity section.
+- a check that reports a false clean → already stated for the tenant leak audit
+  (*"reports **NOT RUN** rather than passing"*).
+- `page_revisions` is a mixed record → **added** in #3475 as a Domain Context pointer,
+  which is the right weight: it routes to `data-provenance.md` rather than duplicating it.
+
+The gap this session exposed was never missing doctrine. It was that **prose rots
+silently and nothing notices** — `data-provenance.md` was stale in two independent
+places, and the second was found by accident. That is what `doc-enum-drift.mjs` is for,
+and it is a better answer than another paragraph.

--- a/scripts/audit/doc-enum-drift.mjs
+++ b/scripts/audit/doc-enum-drift.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Does a documented enum still match production?
+ *
+ * WHY THIS EXISTS. `.claude/docs/data-provenance.md` documented
+ * `page_revisions.source` as five values. Production had twelve. The eight
+ * undocumented ones covered 111,685 rows — including
+ * `shift-repair-erara-2026-07`, the label that says which 29.5% of the "double
+ * OCR" corpus is a maintenance sweep rather than a second reading.
+ *
+ * Because that value was undocumented, two sessions inferred the same fact the
+ * hard way — page-number arithmetic, per-book offset signatures, and finally two
+ * scans opened by hand — while `db.page_revisions.distinct('source')` answered
+ * it in one query (#3473).
+ *
+ * NOTHING CAUGHT IT. The doc was living, referenced, undated, and carried no
+ * date-plus-quantity pattern, so it passed every check in
+ * `doc-staleness.mjs`. Schema drift is a distinct failure mode: the prose stays
+ * true-looking while the world adds a value underneath it.
+ *
+ * THE CHECK. For each registered (collection, field, doc) triple: read the
+ * distinct values from production, and require that each one appears SOMEWHERE
+ * in the doc's text. That is deliberately crude — it does not parse structure,
+ * so it cannot be fooled by a table being reformatted, and it catches the exact
+ * failure above (a value exists in production and is absent from the doc).
+ *
+ * Values documented but ABSENT from production are reported separately and never
+ * fail the run: a legitimate enum value can simply have no rows yet, and a
+ * writer that has not fired is not a documentation defect.
+ *
+ * Needs MONGODB_URI. WITHOUT IT THIS REPORTS "NOT RUN" AND EXITS NON-ZERO under
+ * --fail-on-findings, rather than printing a clean pass — an unrun check that
+ * looks green is how the leak audit in CLAUDE.md nearly shipped twice.
+ *
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit/doc-enum-drift.mjs
+ *   node scripts/audit/doc-enum-drift.mjs --fail-on-findings
+ *   node scripts/audit/doc-enum-drift.mjs --json
+ *   node scripts/audit/doc-enum-drift.mjs --fast     # sample big collections;
+ *                                                    # can only find, never clear
+ */
+import { MongoClient } from 'mongodb';
+import { readFileSync, existsSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const failOnFindings = args.includes('--fail-on-findings');
+const fast = args.includes('--fast');   // opt IN to sampling; exact is the default
+/** Above this many documents, discover values by $sample rather than a full scan. */
+const EXACT_MAX = 2_000_000;
+const SAMPLE_SIZE = 50_000;
+
+/**
+ * Registered enums. Add a row when you document a value-list that production
+ * also writes — that is the whole maintenance burden, and skipping it is what
+ * this script exists to make visible.
+ *
+ * `filter` narrows the collection when a field's domain differs per subset.
+ * `ignore` is for values that are genuinely not worth documenting (test rows,
+ * one-off typos); keep it near-empty and justified inline.
+ */
+const REGISTRY = [
+  {
+    label: 'page_revisions.source',
+    collection: 'page_revisions',
+    field: 'source',
+    doc: '.claude/docs/data-provenance.md',
+    note: 'The mechanism label. A missing value here silently turns bulk maintenance into "a second OCR pass" for every consumer of the revision corpus.',
+  },
+  {
+    label: 'pages.ocr.source',
+    collection: 'pages',
+    field: 'ocr.source',
+    doc: '.claude/docs/data-provenance.md',
+    note: 'Per-page provenance for the live OCR text.',
+  },
+  {
+    label: 'pages.translation.source',
+    collection: 'pages',
+    field: 'translation.source',
+    doc: '.claude/docs/data-provenance.md',
+    note: 'Per-page provenance for the live translation text.',
+  },
+];
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    const msg = 'NOT RUN — MONGODB_URI is unset. This check cannot pass without a database; treat this as a finding, not a skip.';
+    console.log(asJson ? JSON.stringify({ status: 'not_run', reason: msg }, null, 2) : `\n${msg}\n`);
+    // process.exitCode, never process.exit(): exit() discards buffered stdout
+    // when stdout is a PIPE rather than a tty, so the report vanishes in CI and
+    // under any redirect -- the exact places this check is meant to speak up.
+    if (failOnFindings) process.exitCode = 1;
+    return;
+  }
+
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+
+  const findings = [];
+  for (const entry of REGISTRY) {
+    if (!existsSync(entry.doc)) {
+      findings.push({ ...entry, kind: 'missing_doc', undocumented: [], phantom: [] });
+      continue;
+    }
+    const text = readFileSync(entry.doc, 'utf8');
+    const coll = db.collection(entry.collection);
+
+    // ONE aggregation for values AND counts. The obvious spelling --
+    // distinct() then countDocuments() per value -- is N full scans and does not
+    // finish. Counts matter because "8 values undocumented" says nothing about
+    // blast radius; 111,685 rows does.
+    //
+    // SAMPLED ON BIG COLLECTIONS. `pages` holds 19.1M documents and a full
+    // $group over it takes many minutes -- and a check nobody runs is worth
+    // nothing, which is the failure mode this whole script exists to fix. Above
+    // EXACT_MAX we $sample instead and SAY SO, including the frequency below
+    // which a value would likely be missed. Sampling cannot prove absence; the
+    // report must never imply it does.
+    const total = await coll.estimatedDocumentCount();
+    const sampled = fast && total > EXACT_MAX;
+    const pipeline = [
+      ...(entry.filter ? [{ $match: entry.filter }] : []),
+      ...(sampled ? [{ $sample: { size: SAMPLE_SIZE } }] : []),
+      { $group: { _id: `$${entry.field}`, n: { $sum: 1 } } },
+      { $sort: { n: -1 } },
+    ];
+    const grouped = await coll.aggregate(pipeline, { allowDiskUse: true }).toArray();
+
+    const scale = sampled ? total / Math.min(SAMPLE_SIZE, total) : 1;
+    const counts = {};
+    for (const g of grouped) {
+      if (typeof g._id === 'string' && g._id !== '') counts[g._id] = Math.round(g.n * scale);
+    }
+    const values = Object.keys(counts);
+    // A value present on fewer than ~3x this many rows can be missed entirely by
+    // the sample. Reported so a clean result is read with the right confidence.
+    const floor = sampled ? Math.round(3 * total / SAMPLE_SIZE) : 0;
+
+    const ignore = new Set(entry.ignore || []);
+    const undocumented = values
+      .filter(v => !ignore.has(v) && !text.includes(v))
+      .sort((a, b) => (counts[b] || 0) - (counts[a] || 0));
+
+    // Phantom: quoted in the doc as a value of this field but absent from
+    // production. Informational only.
+    const quoted = [...text.matchAll(/["'`]([a-z][a-z0-9_.-]{2,40})["'`]/gi)].map(m => m[1]);
+    const present = new Set(values);
+    const phantom = [...new Set(quoted)].filter(q => !present.has(q) &&
+      new RegExp(`${entry.field.split('.').pop()}[^\\n]{0,80}["'\`]${q}["'\`]`).test(text));
+
+    findings.push({ ...entry, kind: undocumented.length ? 'undocumented_values' : 'ok',
+      values, counts, undocumented, phantom, sampled, total, floor });
+  }
+
+  await client.close();
+
+  if (asJson) {
+    console.log(JSON.stringify({ status: 'ran', findings }, null, 2));
+  } else {
+    console.log('');
+    for (const f of findings) {
+      const head = `${f.label}  ->  ${f.doc}`;
+      if (f.kind === 'missing_doc') { console.log(`✗ ${head}\n    doc file does not exist`); continue; }
+      const method = f.sampled
+        ? `sampled ${SAMPLE_SIZE.toLocaleString()} of ${f.total.toLocaleString()} docs — counts are ESTIMATES and a value on under ~${f.floor.toLocaleString()} rows may be missed entirely (drop --fast for a full scan)`
+        : `full scan of ${f.total.toLocaleString()} docs`;
+      if (!f.undocumented.length) {
+        // A SAMPLED run may never print a clean bill. Measured 2026-08-04:
+        // sampling 50k of 19.1M reported pages.translation.source "all
+        // documented" while an exact scan found four undocumented values, the
+        // largest on 5,759 rows -- five times the stated detection floor.
+        // MongoDB's $sample uses a pseudo-random cursor that is not uniform, so
+        // a rare value can be missed at any frequency. A check that can report a
+        // false clean is worse than no check.
+        console.log(f.sampled
+          ? `? ${head}\n    INCONCLUSIVE — no undocumented value found in the sample, which is NOT a clean bill\n    ${method}`
+          : `✓ ${head}\n    ${f.values.length} values, all documented\n    ${method}`);
+      } else {
+        console.log(`✗ ${head}`);
+        console.log(`    ${f.undocumented.length} of ${f.values.length} values NOT mentioned in the doc:`);
+        for (const v of f.undocumented) console.log(`      ${String(f.counts[v]).padStart(9)} rows  ${v}`);
+        console.log(`    ${f.note}`);
+        console.log(`    ${method}`);
+      }
+      if (f.phantom.length) console.log(`    (documented but absent from production: ${f.phantom.join(', ')} — informational)`);
+      console.log('');
+    }
+  }
+
+  // A sampled entry never counts as passing, even with nothing found.
+  const bad = findings.filter(f => f.kind !== 'ok' || f.sampled);
+  if (bad.length && failOnFindings) process.exitCode = 1;   // not process.exit() -- see above
+}
+
+main().catch(e => { console.error(e); process.exitCode = 1; });

--- a/scripts/audit/doc-enum-drift.mjs
+++ b/scripts/audit/doc-enum-drift.mjs
@@ -32,6 +32,11 @@
  * --fail-on-findings, rather than printing a clean pass — an unrun check that
  * looks green is how the leak audit in CLAUDE.md nearly shipped twice.
  *
+ * RUN IT ON HETZNER, not a laptop. The exact mode scans `pages` twice (19.1M
+ * docs each) and takes longer than a consumer connection reliably stays up --
+ * two of three attempts on 2026-08-04/05 died on a network blip mid-scan. The
+ * scans are the point, so the fix is where you run it, not a weaker check.
+ *
  *   set -a; source .env.production.local; set +a
  *   node scripts/audit/doc-enum-drift.mjs
  *   node scripts/audit/doc-enum-drift.mjs --fail-on-findings
@@ -99,7 +104,13 @@ async function main() {
   await client.connect();
   const db = client.db(process.env.MONGODB_DB || 'bookstore');
 
+  // try/finally, not a bare close at the end: without it an error mid-scan
+  // leaves the connection pool open and, because we set process.exitCode rather
+  // than calling process.exit(), node's event loop never drains and the process
+  // hangs FOREVER. Observed 2026-08-04 -- a DNS blip left a run alive 2h43m,
+  // printing its error and then simply never exiting.
   const findings = [];
+  try {
   for (const entry of REGISTRY) {
     if (!existsSync(entry.doc)) {
       findings.push({ ...entry, kind: 'missing_doc', undocumented: [], phantom: [] });
@@ -146,16 +157,22 @@ async function main() {
 
     // Phantom: quoted in the doc as a value of this field but absent from
     // production. Informational only.
-    const quoted = [...text.matchAll(/["'`]([a-z][a-z0-9_.-]{2,40})["'`]/gi)].map(m => m[1]);
+    // Values only: a token containing a dot is a FIELD PATH mentioned in prose
+    // (`pages.translation.source`), not a value of the enum. Reporting those as
+    // "documented but absent from production" was noise in a tool whose whole
+    // job is to be trusted.
+    const quoted = [...text.matchAll(/["'`]([a-z][a-z0-9_-]{2,40})["'`]/gi)].map(m => m[1]);
     const present = new Set(values);
-    const phantom = [...new Set(quoted)].filter(q => !present.has(q) &&
+    const phantom = [...new Set(quoted)].filter(q => !present.has(q) && !q.includes('.') &&
       new RegExp(`${entry.field.split('.').pop()}[^\\n]{0,80}["'\`]${q}["'\`]`).test(text));
 
     findings.push({ ...entry, kind: undocumented.length ? 'undocumented_values' : 'ok',
       values, counts, undocumented, phantom, sampled, total, floor });
   }
 
-  await client.close();
+  } finally {
+    await client.close().catch(() => {});
+  }
 
   if (asJson) {
     console.log(JSON.stringify({ status: 'ran', findings }, null, 2));


### PR DESCRIPTION
Follow-up to #3475. Adds `scripts/audit/doc-enum-drift.mjs` and corrects `data-provenance.md` with the real `pages.{ocr,translation}.source` enum.

## Why

`data-provenance.md` documented `page_revisions.source` as five values; production had twelve. The eight undocumented ones covered **111,685 rows**, including the label identifying which 29.5% of the "double OCR" corpus is a maintenance sweep rather than a second reading. Two sessions inferred that the hard way while `distinct('source')` answered it in one query.

Nothing caught it. The doc is living, referenced, undated, and carries no date-plus-quantity pattern, so it passes every check in `doc-staleness.mjs`. Schema drift is a distinct failure mode: the prose stays true-looking while the world adds a value underneath it.

## What the first run found — 14 undocumented values

`pages.ocr.source` (10) and `pages.translation.source` (4), in fields I had never touched by hand. Three matter beyond bookkeeping:

- **`corpus` (~5.7K rows on each field) and `wikisource` (21) are not model output.** Any metric treating `pages.ocr` as "what the model read" is wrong on those rows, and nothing but `source` says so.
- **Repair sweeps write to the live fields too**, not only `page_revisions`: `ia-ocr-repair`, `reocr-contamination-repair-3362`, `spread-split`, `ai-repair-sync`.
- **`songshi-juan56` and `AI generated`** (1 row each) are junk that leaked into an enum. Documented rather than ignored — the alternative is teaching the audit to lie.

## It also caught a flaw in itself

A sampled run reported `pages.translation.source` "all documented". The exact scan found four undocumented values there, the largest on 5,759 rows — five times the stated detection floor. MongoDB's `$sample` uses a pseudo-random cursor that is not uniform, so a value can be missed at any frequency.

A check that can report a false clean is worse than no check, so: **exact is the default**, `--fast` must be opted into, and a sampled run can only print `? INCONCLUSIVE` — never a pass, and it never satisfies `--fail-on-findings`.

## Known cost, stated rather than resolved

Exact means several minutes on `pages` (19.1M docs); `page_revisions` stays exact and fast (8s). I argued earlier that a slow check will not be run habitually, and that is still true — so if this ends up unrun, the fix is to schedule it, not to make it lie.

## NOT verified

The final confirmation run — that `data-provenance.md` now passes its own check — **died on a DNS drop mid-scan and has not been re-run.** The enum table was written from a completed exact scan, so the values are right, but the round-trip has not been closed. Worth re-running before merge:

```
set -a; source .env.production.local; set +a
node scripts/audit/doc-enum-drift.mjs --fail-on-findings
```

## Out of scope

- **#3614**, filed not fixed: two rows carry `is_default: true` for `{summary, Standard Summary}`, violating an invariant this same doc states, so `getSummaryPrompt()` resolves arbitrarily and one path records `prompt_version: undefined`. The doc's "Current defaults" table is also five and four versions behind (OCR v10 vs v15, Translation v8 vs v12).
- Extending the check to cover that defaults table — same shape, would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)