### PR TITLE
fix(ocr): the reader handled three page types the prompt never offered

### DIFF
--- a/src/components/reader/NotesRenderer.tsx
+++ b/src/components/reader/NotesRenderer.tsx
@@ -11,8 +11,20 @@ import { NOTE_TAG_STYLES } from '@/lib/style-constants';
 import { cleanOcrArtifacts } from '@/lib/strip-editorial-wrappers';
 import { normalizeAnnotationSpans } from '@/lib/normalize-annotation-spans';
 
-// Page types where the entire "translation" is AI-generated description (no original text)
-const DESCRIPTION_ONLY_PAGE_TYPES = new Set(['blank', 'frontispiece', 'illustration', 'cover', 'map', 'diagram', 'musical-score', 'table']);
+/**
+ * Page types where the entire "translation" is AI-generated description (no
+ * original text).
+ *
+ * EXPORTED so `tests/unit/page-type-vocabulary.test.ts` can check it against the
+ * OCR prompt. These two lists drifted apart silently: `cover`, `musical-score`
+ * and `table` were handled here while the prompt never offered them, so the OCR
+ * could not emit them and all three sat at ZERO pages corpus-wide (#3591
+ * follow-up). Kircher's *Musurgia Universalis* — 748 pages, much of it engraved
+ * music — had every score page typed `text`, so it was translated as prose and
+ * rendered without this branch. A reader branch for a value the writer cannot
+ * produce is dead by construction, and nothing reports it.
+ */
+export const DESCRIPTION_ONLY_PAGE_TYPES = new Set(['blank', 'frontispiece', 'illustration', 'cover', 'map', 'diagram', 'musical-score', 'table']);
 
 interface NotesRendererProps {
   text: string;

--- a/src/lib/types/prompts/defaults.ts
+++ b/src/lib/types/prompts/defaults.ts
@@ -160,9 +160,12 @@ export const DEFAULT_PROMPTS: ProcessingPrompts = {
 
 **Metadata tags (hidden from readers):**
 - <language>X</language> — the detected language of this page (REQUIRED — always identify the language, e.g. Latin, German, French, English)
-- <page-type>X</page-type> — classify this page (REQUIRED). One of: title-page, frontispiece, dedication, preface, toc, index, errata, colophon, appendix, blank, illustration, diagram, map, text, digitizer-insert, exlibris
+- <page-type>X</page-type> — classify this page (REQUIRED). One of: title-page, frontispiece, dedication, preface, toc, index, errata, colophon, appendix, blank, illustration, diagram, map, musical-score, table, cover, text, digitizer-insert, exlibris
   - Use "digitizer-insert" for pages added by the digitizer (NOT part of the original book): Internet Archive credit pages, Google Books inserts, "Digitized by Google" pages, library barcode/scan sheets, digital watermark pages
   - Use "exlibris" for an ownership bookplate pasted into the book (usually on a pastedown or endpaper): an armorial or emblematic plate naming or marking the owner, often with a motto. It is provenance, not the book's content — do NOT treat its motto as body text.
+  - Use "musical-score" when the page is engraved or printed music with no running prose — staves, notation, tablature. A header, signature or a few words of underlaid text do not make it a "text" page.
+  - Use "table" when the page is substantially one tabular ruling — a calendar, an ephemeris, a numeral or abjad table, an index laid out in columns — rather than prose that happens to contain a table.
+  - Use "cover" for the binding itself (front/back board, spine) as opposed to a blank leaf inside the book.
 - <columns>N</columns> — number of text columns on this page (omit for single-column pages, include for 2+ columns)
 - <page-num>N</page-num> — visible page/folio numbers (NOT in body text)
 - <header>X</header> — running headers/chapter titles at top of page (NEVER duplicate as heading in body)

--- a/tests/unit/page-type-vocabulary.test.ts
+++ b/tests/unit/page-type-vocabulary.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The reader's page-type branches must be reachable.
+ *
+ * `NotesRenderer` special-cases DESCRIPTION_ONLY_PAGE_TYPES — pages whose whole
+ * "translation" is an AI description, rendered as "toggle Notes to see the
+ * description" rather than as empty body text. That set and the page-type
+ * vocabulary offered to the OCR model drifted apart with nothing to notice:
+ *
+ *   cover, musical-score, table  →  in the reader, absent from the prompt
+ *
+ * The model can only emit a value the prompt lists, so all three sat at ZERO
+ * pages corpus-wide while the other five carried 210,023 / 72,124 / 12,292 /
+ * 11,760 / 4,927. Kircher's Musurgia Universalis (748 pages, much of it engraved
+ * music) had every score page typed `text` — translated as prose, and rendered
+ * without the branch written for it.
+ *
+ * A reader branch for a value the writer cannot produce is dead by
+ * construction, and nothing in CI reported it. This test is that report.
+ */
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_PROMPTS } from '@/lib/types/prompts/defaults';
+import { DESCRIPTION_ONLY_PAGE_TYPES } from '@/components/reader/NotesRenderer';
+
+const DEFAULT_OCR_PROMPT = DEFAULT_PROMPTS.ocr;
+
+/** Pull the enumerated values out of the prompt's own `One of: …` line. */
+function promptPageTypes(): string[] {
+  const line = DEFAULT_OCR_PROMPT.match(/<page-type>X<\/page-type>[^\n]*One of:([^\n]+)/);
+  if (!line) throw new Error('could not find the page-type "One of:" list in DEFAULT_OCR_PROMPT');
+  return line[1].split(',').map(s => s.trim()).filter(Boolean);
+}
+
+describe('page-type vocabulary', () => {
+  it('the prompt actually enumerates page types', () => {
+    const types = promptPageTypes();
+    expect(types.length).toBeGreaterThan(10);
+    expect(types).toContain('text');
+    expect(types).toContain('blank');
+  });
+
+  it('every page type the reader special-cases is offered to the OCR model', () => {
+    const offered = new Set(promptPageTypes());
+    const unreachable = [...DESCRIPTION_ONLY_PAGE_TYPES].filter(t => !offered.has(t));
+    expect(unreachable).toEqual([]);
+  });
+
+  it('names the three that were dead, so a revert is visible', () => {
+    const offered = new Set(promptPageTypes());
+    for (const t of ['cover', 'musical-score', 'table']) {
+      expect(offered.has(t), `"${t}" must stay in the OCR prompt vocabulary`).toBe(true);
+    }
+  });
+
+  it('gives the model guidance for each newly added type, not just the bare word', () => {
+    // A value in the enum with no instruction is nearly as dead as an absent
+    // one — the model has nothing to decide on.
+    for (const t of ['musical-score', 'table', 'cover']) {
+      expect(
+        DEFAULT_OCR_PROMPT.includes(`Use "${t}"`),
+        `prompt should explain when to use "${t}"`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## The finding

`NotesRenderer` special-cases `DESCRIPTION_ONLY_PAGE_TYPES` — pages whose entire "translation" is an AI description, rendered as *"toggle Notes to see the description"* rather than as near-empty body text. That set and the page-type vocabulary given to the OCR model had drifted apart, with nothing to notice:

| page_type | in reader | in OCR prompt | pages corpus-wide |
|---|---|---|---|
| blank | ✓ | ✓ | 210,023 |
| illustration | ✓ | ✓ | 72,124 |
| diagram | ✓ | ✓ | 12,292 |
| frontispiece | ✓ | ✓ | 11,760 |
| map | ✓ | ✓ | 4,927 |
| **cover** | ✓ | ✗ | **0** |
| **musical-score** | ✓ | ✗ | **0** |
| **table** | ✓ | ✗ | **0** |

The model can only emit a value the prompt enumerates. The zero is not a coincidence — those three reader branches were **dead by construction**, and nothing in CI or in any audit reported it.

## How it surfaced

`scripts/audit/note-tag-provenance.mjs` (merged in #3606) flagged 38 pages typed `text` carrying a `<note>` but no body text at all. Nearly all were one book: **Kircher's *Musurgia Universalis*** (1650, 748 pages), much of it engraved music.

Every score page in it is typed `text`. So each was sent for translation as prose — 10 of 10 sampled were translated, i.e. **paid for** — and then rendered without the branch written for exactly this case.

The OCR *knew*. Its own notes read: *"The page consists entirely of musical notation. There is no prose text to transcribe."* It had no vocabulary term to say so in the field that governs rendering.

## Changes

- **Add `musical-score`, `table`, `cover` to the prompt's page-type enum**, each with guidance. A bare word in an enum is nearly as dead as an absent one — the model has nothing to decide on. The `musical-score` note covers the Musurgia case directly: a header or a few words of underlaid text do not make a score page a "text" page.
- **Export `DESCRIPTION_ONLY_PAGE_TYPES`** so the two lists can be checked against each other.
- **`tests/unit/page-type-vocabulary.test.ts`** parses the prompt's own `One of:` line and asserts every reader-handled type appears in it. **Negative-controlled** — reverting the vocabulary fails 2/4.

## Scope

**Future OCR only.** Existing pages keep their stored `page_type`, and the pipeline is paused, so nothing re-runs on merge. Backfilling Musurgia's score pages is a separate, paid decision and deliberately not bundled here.

Full suite 1617 passing / 127 files. `npx tsc --noEmit` clean.

## Why this shape of bug is worth a guard

Same family as `reading_history.referrer` in CLAUDE.md — *a field nothing writes looks identical to a field nothing needs.* Here it is the inverse: a **value nothing can produce** looks identical to a value nothing has needed yet. Both are invisible from either side alone; only checking writer against reader reveals them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)