### PR TITLE
fix(ref-set): 041$h is not the only way MARC declares a translation

### DIFF
--- a/scripts/enrichment/ingest-estc.mjs
+++ b/scripts/enrichment/ingest-estc.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+/**
+ * ingest-estc.mjs — the English Short Title Catalogue as a reference-set source. (#3522)
+ *
+ * WHY THIS SOURCE, MEASURED RATHER THAN ASSUMED
+ * ---------------------------------------------
+ * The LoC extract is a general catalogue, and a general catalogue treats
+ * "is this a translation?" as optional metadata. Measured on one part (250,000
+ * records, 136,193 of them English-language):
+ *
+ *     declare a translation via 041$h            3,918
+ *     via 240$l English, no 041$h                  255
+ *     via a translator relator or 245$c, no 041$h   120 matchable
+ *     have a 240 but no language marker at all    1,349
+ *     ── declare NOTHING, by any of the four        ~131,000  (96%)
+ *
+ * So reading LoC perfectly tops out near 4% of its English records. The gap is
+ * missing data, not missed reading — three separate attempts to close it by
+ * reading harder (#3556, #3599, the screening backlog) each recovered single
+ * digits.
+ *
+ * ESTC records the same facts, because a short-title catalogue built for
+ * 1473-1800 exists to record them. Spot-checked against records where LoC is bare:
+ *
+ *   Agrippa 1569  LoC: no 041 at all
+ *                 ESTC S100458: uniform title "Della vanita delle scienze. English"
+ *   Maier  1654   LoC: absent
+ *                 ESTC R7027: language eng, relator "Hall, John, 1627-1656, translator."
+ *
+ * THE PAGINATION PROBLEM, AND WHY THE PARTITION IS BY ID
+ * -----------------------------------------------------
+ * `from` caps at 10,000 and fails SILENTLY — HTTP 200, no `rows` key, no error.
+ * A naive harvester would take the first 10,000 records, record nothing for the
+ * other 477,000, and every book downstream would read `none_found`. That is the
+ * exact shape of the LoC throttle that once returned 200 with an HTML page.
+ *
+ * There is no OAI-PMH (every plausible endpoint 404s) and `sort`/`search_after`/
+ * `scroll` are ignored. What works is `id:` with a prefix wildcard. Every record
+ * has exactly one id, so a prefix tree is a COMPLETE, NON-OVERLAPPING partition,
+ * and its completeness is checkable by arithmetic rather than by trust:
+ * subdividing `id:T*` (223,099) yields children summing to exactly 223,099.
+ *
+ * Hence the two invariants this script enforces, and aborts on:
+ *   1. every leaf must return exactly as many rows as it reported `hits`
+ *   2. the leaves must sum to the catalogue total
+ *
+ * COST — stated up front because it is worse than it looks
+ * -------------------------------------------------------
+ * A size=100 page is ~1,125 KB (the `holdings` arrays dominate) and NO field
+ * limiting is available: `_source`, `_source_includes`, `fields`, `fl`,
+ * `include`, `mode=brief`, `format=brief`, `brief=true` all return the identical
+ * payload. So a full harvest is ~4,875 requests and **~5.6 GB down**, larger
+ * than the 3 GB LoC dump. What we keep is ~154 MB. One-time, free, no auth.
+ *
+ * Usage:
+ *   node scripts/enrichment/ingest-estc.mjs --prefix C          # tiny smoke test
+ *   node scripts/enrichment/ingest-estc.mjs --prefix P          # 4,319 records
+ *   node scripts/enrichment/ingest-estc.mjs                     # everything
+ *   node scripts/enrichment/ingest-estc.mjs --out ./estc
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
+const OUT_DIR = argOf('--out') ?? path.join(process.cwd(), 'scripts', 'output', 'estc');
+const ONLY_PREFIX = argOf('--prefix');
+const DELAY_MS = parseInt(argOf('--delay') ?? '400', 10);
+
+const ENDPOINT = 'https://datb.cerl.org/estc/_search';
+const UA = 'SourceLibrary/1.0 (+https://sourcelibrary.org; reference-set ingest)';
+const PAGE = 100;      // server caps size at 100 regardless of what is asked
+const FROM_CAP = 10000; // `from` beyond this returns HTTP 200 with no rows
+const SNAPSHOT = new Date().toISOString().slice(0, 10);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * One search call. Returns {hits, rows} or throws.
+ *
+ * A response without a `rows` array is the silent-truncation signature, not an
+ * empty result — it must never be read as "this slice is empty".
+ */
+async function search(query, from = 0, size = 1) {
+  const url = `${ENDPOINT}?query=${encodeURIComponent(query)}&size=${size}&from=${from}`;
+  let lastErr;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': UA, Accept: 'application/json' },
+        signal: AbortSignal.timeout(60000),
+      });
+      const text = await res.text();
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      let json;
+      try { json = JSON.parse(text); } catch { throw new Error(`non-JSON response (${text.slice(0, 60)})`); }
+      if (typeof json.hits?.value !== 'number') throw new Error('response carries no hits count');
+      if (size > 1 && !Array.isArray(json.rows)) {
+        throw new Error(`no rows array at from=${from} — the ${FROM_CAP} paging cap, or a throttle`);
+      }
+      return { hits: json.hits.value, rows: json.rows ?? [] };
+    } catch (e) {
+      lastErr = e;
+      await sleep(1500 * (attempt + 1));
+    }
+  }
+  throw new Error(`${query} from=${from}: ${lastErr.message}`);
+}
+
+const countOf = async (prefix) => (await search(`id:${prefix}*`, 0, 1)).hits;
+
+/**
+ * Recursively split a prefix until every leaf fits under the paging cap.
+ * Returns [{prefix, hits}]. A leaf that still exceeds the cap after exhausting
+ * the alphabet is reported rather than silently truncated.
+ */
+const CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+async function partition(prefix, hits, depth = 0) {
+  if (hits === 0) return [];
+  if (hits <= FROM_CAP) return [{ prefix, hits }];
+  if (depth > 6) {
+    throw new Error(`prefix ${prefix} still has ${hits} rows at depth ${depth} — cannot partition under the cap`);
+  }
+  const leaves = [];
+  let childSum = 0;
+  for (const ch of CHARS) {
+    const n = await countOf(prefix + ch);
+    await sleep(DELAY_MS);
+    if (!n) continue;
+    childSum += n;
+    leaves.push(...await partition(prefix + ch, n, depth + 1));
+  }
+  // Arithmetic, not trust: an id belongs to exactly one child, so the children
+  // must account for the parent exactly. Anything else means the wildcard is not
+  // behaving as a prefix and the partition cannot be called complete.
+  if (childSum !== hits) {
+    throw new Error(`partition of ${prefix}* is lossy: children sum ${childSum} vs parent ${hits}`);
+  }
+  return leaves;
+}
+
+/** Page one leaf completely, asserting we received what it promised. */
+async function harvestLeaf(leaf, sink) {
+  let got = 0;
+  for (let from = 0; from < leaf.hits; from += PAGE) {
+    if (from >= FROM_CAP) throw new Error(`leaf ${leaf.prefix}* exceeds the ${FROM_CAP} cap — partition bug`);
+    const { rows } = await search(`id:${leaf.prefix}*`, from, PAGE);
+    if (!rows.length) throw new Error(`leaf ${leaf.prefix}* returned 0 rows at from=${from} of ${leaf.hits}`);
+    for (const row of rows) sink(row);
+    got += rows.length;
+    await sleep(DELAY_MS);
+  }
+  if (got !== leaf.hits) {
+    throw new Error(`leaf ${leaf.prefix}*: collected ${got} but it reported ${leaf.hits}`);
+  }
+  return got;
+}
+
+/**
+ * Reduce an ESTC row to the reference-set shape.
+ *
+ * `search_titles` carries the MARC 240 uniform title WITH its `$l` language
+ * ("De consolatione philosophiae. English"), which is the same join key
+ * scripts/lib/work-identity-match.mjs is built and gold-tested against. The
+ * language suffix is stripped into `translation_evidence` so the title matches
+ * our books, and the fact that it was declared is not lost.
+ */
+/**
+ * Pull the uniform title and its declared language out of an ESTC title string.
+ *
+ * A MARC 240 is a sequence of subfields flattened with ". " separators, and `$l`
+ * is NOT necessarily last — `$k` (Selections), `$s` (Version) and `$f` (Date)
+ * follow it routinely:
+ *
+ *   "De consolatione philosophiae. English"            $a … $l
+ *   "Bible. Psalms. English. Sternhold and Hopkins."   $a $p $l $s   ← language mid-field
+ *   "Bible. Old Testament. English. Authorised. Selections."         ← and again
+ *
+ * An end-anchored match drops every one of the second kind. Split into
+ * components instead and find the language wherever it sits; everything before
+ * it is the work's title, which is what the matcher joins on.
+ *
+ * The words must be a WHOLE component: "The English intelligencer" and "English
+ * exercises for school-boys" are 245 display titles that merely contain the word,
+ * and matching those would pour non-translations into the set.
+ */
+const LANG_COMPONENT = /^(English|English\s*(?:&|and)\s*[A-Za-z]+|[A-Za-z]+\s*(?:&|and)\s*English)$/i;
+
+export function splitUniformTitle(title) {
+  const parts = String(title || '').split('.').map((p) => p.trim()).filter(Boolean);
+  const at = parts.findIndex((p) => LANG_COMPONENT.test(p));
+  if (at <= 0) return null;                   // no language, or nothing before it
+  return { uniform: parts.slice(0, at).join('. '), declared: parts[at] };
+}
+
+export function toReferenceRow(row) {
+  const titles = row.search_titles ?? [];
+  let uniform = '';
+  let declared = '';
+  for (const t of titles) {
+    const m = splitUniformTitle(t);
+    if (m) { uniform = m.uniform; declared = m.declared; break; }
+  }
+  const names = row.search_names ?? [];
+  const translators = names.filter((n) => /translator/i.test(n));
+  const authors = names.filter((n) => !/translator|printer|bookseller|publisher|engraver/i.test(n));
+
+  return {
+    lccn: '',                                   // ESTC has none; the id is the identifier
+    estc_id: row.id,
+    author: authors[0] ?? '',
+    added_entries: [...authors.slice(1), ...translators],
+    uniform_title: uniform,
+    title: titles.find((t) => !splitUniformTitle(t)) ?? titles[0] ?? '',
+    subtitle: '',
+    year: (row.dates ?? [])[0] ?? '',
+    extent: '',
+    publisher: '',
+    // ESTC does not record the ORIGINAL language as a code. Leaving this empty is
+    // correct and load-bearing: the language screen treats an unresolvable value
+    // as UNKNOWN and keeps the candidate, rather than rejecting a real prior.
+    original_languages: [],
+    item_language: row.language ?? '',
+    subjects: (row.subjects ?? []).slice(0, 8),
+    translation_evidence: declared ? `uniform_title_lang:${declared}`
+      : translators.length ? 'translator_relator' : '',
+    source: 'estc',
+    snapshot: SNAPSHOT,
+  };
+}
+
+/** An ESTC row only enters the set if it declares itself an English translation. */
+const isEnglishTranslation = (r) => Boolean(r.translation_evidence) && /eng/i.test(r.item_language || '');
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const IS_MAIN = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (IS_MAIN) await main();
+
+async function main() {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const total = (await search('*', 0, 1)).hits;
+  console.log(`ESTC via CERL — ${total.toLocaleString()} records total\n`);
+
+  const roots = ONLY_PREFIX ? [ONLY_PREFIX] : 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+  console.log('Partitioning by id prefix (leaves must fit under the 10,000 paging cap)…');
+  const leaves = [];
+  for (const root of roots) {
+    const n = await countOf(root);
+    await sleep(DELAY_MS);
+    if (!n) continue;
+    const sub = await partition(root, n);
+    leaves.push(...sub);
+    console.log(`  id:${root}*  ${String(n).padStart(7)} → ${sub.length} leaf/leaves`);
+  }
+
+  const promised = leaves.reduce((s, l) => s + l.hits, 0);
+  console.log(`\n${leaves.length} leaves, ${promised.toLocaleString()} records promised`);
+  if (!ONLY_PREFIX && Math.abs(promised - total) > 1) {
+    throw new Error(`partition covers ${promised} of ${total} — refusing to harvest an incomplete set`);
+  }
+
+  const outPath = path.join(OUT_DIR, `estc-translations.${SNAPSHOT}.jsonl`);
+  const out = fs.createWriteStream(outPath);
+  let seen = 0, kept = 0;
+  const evidence = {};
+  for (const leaf of leaves) {
+    await harvestLeaf(leaf, (raw) => {
+      seen++;
+      const row = toReferenceRow(raw);
+      if (!isEnglishTranslation(row)) return;
+      kept++;
+      evidence[row.translation_evidence.split(':')[0]] = (evidence[row.translation_evidence.split(':')[0]] || 0) + 1;
+      out.write(JSON.stringify(row) + '\n');
+    });
+    process.stdout.write(`\r  harvested ${seen.toLocaleString()}/${promised.toLocaleString()}  kept ${kept.toLocaleString()}   `);
+  }
+  await new Promise((r) => out.end(r));
+
+  console.log(`\n\n─── ESTC reference set ───────────────────────────────────────`);
+  console.log(`  records examined        : ${seen.toLocaleString()}`);
+  console.log(`  English translations    : ${kept.toLocaleString()}`);
+  for (const [k, v] of Object.entries(evidence)) console.log(`    via ${k.padEnd(20)} ${v.toLocaleString()}`);
+  console.log(`\n  BOUNDARY: ESTC covers imprints 1473-1800 only. A translation`);
+  console.log(`  published after 1800 is absent by construction, not by evidence.`);
+  console.log(`\nWrote ${outPath}`);
+}

--- a/scripts/enrichment/ingest-loc-bulk.mjs
+++ b/scripts/enrichment/ingest-loc-bulk.mjs
@@ -188,14 +188,58 @@ export function itemLanguages(rec, f008 = controlField(rec, '008')) {
   return fallback ? [fallback] : [];
 }
 
-/** Extract the reference-set row, or null if this record is not an English translation. */
-export function extractEnglishTranslation(rec, reject = () => {}) {
-  if (!rec.includes('tag="041"')) { reject('no_041'); return null; }
-  const originalLangs = subfieldValues(rec, '041', 'h');
-  if (!originalLangs.length) { reject('no_041h'); return null; }
+/**
+ * Does the MARC 240 declare this item to be the ENGLISH version of the work?
+ *
+ * `240$l` is *Language of a work* — the cataloguer stating exactly what `041$h`
+ * states, in a different field. It is NOT necessarily the last subfield: `$s`
+ * (version), `$k` (selections) and `$f` (date) follow it routinely, so
+ * "Bible. Psalms. English. Sternhold and Hopkins." must match as readily as
+ * "De consolatione philosophiae. English".
+ */
+export function uniformTitleDeclaresEnglish(rec) {
+  const l = subfieldValues(rec, '240', 'l');
+  return l.some((v) => /\beng(lish)?\b/i.test(v));
+}
 
+/**
+ * Extract the reference-set row, or null if this record is not an English
+ * translation.
+ *
+ * THREE GRADES OF EVIDENCE, and requiring only the first was the dominant cause
+ * of 27% catalogue recall (#3599). Measured on one part: of 136,193
+ * English-language records, 3,918 carry `041$h` — and ~131,000 declare nothing
+ * at all by any means. Every confirmed-absent prior we chased was sitting in LoC
+ * with a perfectly good MARC 240 and no 041 whatsoever: Caplan's Loeb
+ * *Ad Herennium* (LCCN 55004252, `240 Rhetorica ad Herennium.`), Böhme
+ * (`36037588`).
+ *
+ *   041h               a cataloguer's explicit "translated from <lang>"
+ *   uniform_title_lang `240$l English` — the same assertion, different field
+ *   uniform_title_only a 240 exists on an English item, but no language marker.
+ *                      Noisier — roughly a third are genuine, the rest English
+ *                      works with collective uniform titles ("Works.", "Poems.").
+ *                      Kept because this is where Caplan lives, and because the
+ *                      matcher already screens the noise: containment against
+ *                      OUR title cannot fire on an unrelated English work, and
+ *                      generic 1-2 token uniform titles demand author
+ *                      corroboration.
+ *
+ * `original_languages` is empty for the latter two, which is correct and
+ * load-bearing — the language screen reads an unresolvable value as UNKNOWN and
+ * KEEPS the candidate rather than rejecting a real prior.
+ */
+export function extractEnglishTranslation(rec, reject = () => {}) {
   const f008 = controlField(rec, '008');
   const itemLangs = itemLanguages(rec, f008);
+  const originalLangs = rec.includes('tag="041"') ? subfieldValues(rec, '041', 'h') : [];
+  const uniform = subfieldValues(rec, '240', 'a')[0] || '';
+
+  const evidence = originalLangs.length ? '041h'
+    : uniformTitleDeclaresEnglish(rec) ? 'uniform_title_lang'
+      : uniform ? 'uniform_title_only'
+        : null;
+  if (!evidence) { reject(rec.includes('tag="041"') ? 'no_041h' : 'no_041'); return null; }
   // The item must contain English SOMEWHERE. A bilingual edition is still an
   // English translation — arguably the most citable kind, since the reader can
   // check it against the original on the facing page.
@@ -230,6 +274,10 @@ export function extractEnglishTranslation(rec, reject = () => {}) {
     item_language: itemLang,
     item_languages: itemLangs,
     bilingual: itemLangs.length > 1,
+    // HOW this row was established to be a translation. Screening needs it: an
+    // `041h` row is a cataloguer's assertion, `uniform_title_only` is our
+    // inference from the presence of a 240 on an English item.
+    translation_evidence: evidence,
     subjects: subfieldValues(rec, '650', 'a').concat(subfieldValues(rec, '600', 'a')).map(decode).slice(0, 8),
     source: 'loc_mdsconnect',
     snapshot: SNAPSHOT,

--- a/tests/unit/estc-uniform-title.test.ts
+++ b/tests/unit/estc-uniform-title.test.ts
@@ -1,0 +1,110 @@
+/**
+ * ESTC uniform-title extraction. (#3522)
+ *
+ * A MARC 240 is subfields flattened with ". ", and `$l` (language) is NOT
+ * necessarily last — `$s` (version), `$k` (selections) and `$f` (date) follow it
+ * routinely. The first implementation anchored the language to end-of-string and
+ * therefore dropped every "Bible. Psalms. English. Sternhold and Hopkins." shape.
+ * Caught by sampling: 9% of ESTC records carry the word "English" in a title but
+ * only 5.5% matched, and the gap was almost entirely this.
+ *
+ * The opposite error matters just as much: a 245 DISPLAY title that merely
+ * contains the word ("The English intelligencer", "English exercises for
+ * school-boys to translate into Latin") is not a translation, and admitting
+ * those would pour noise into a reference set whose whole job is deciding
+ * whether a prior exists.
+ *
+ * Every string below is real, taken from a live CERL sample.
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import { splitUniformTitle, toReferenceRow } from '../../scripts/enrichment/ingest-estc.mjs';
+
+describe('language as the LAST component', () => {
+  it.each([
+    ['De consolatione philosophiae. English', 'De consolatione philosophiae'],
+    ['Recueil des histoires de Troie. English', 'Recueil des histoires de Troie'],
+    ['Della vanita delle scienze. English', 'Della vanita delle scienze'],
+    ['Concio quam habuit reverendiss. in Christo pater Hugo Latimerus. English',
+      'Concio quam habuit reverendiss. in Christo pater Hugo Latimerus'],
+  ])('%s', (input, uniform) => {
+    expect(splitUniformTitle(input)?.uniform).toBe(uniform);
+  });
+});
+
+describe('language MID-field — the regression', () => {
+  it.each([
+    ['Bible. Psalms. English. Sternhold and Hopkins.', 'Bible. Psalms'],
+    ['Bible. Old Testament. English. Authorised. Selections.', 'Bible. Old Testament'],
+    ['Bible. English. Geneva.', 'Bible'],
+  ])('%s', (input, uniform) => {
+    const r = splitUniformTitle(input);
+    expect(r, 'an end-anchored match drops this entire shape').not.toBeNull();
+    expect(r.uniform).toBe(uniform);
+    expect(r.declared).toBe('English');
+  });
+
+  it('handles a bilingual language component', () => {
+    expect(splitUniformTitle('Catonis disticha. English and Latin.')?.declared).toBe('English and Latin');
+    expect(splitUniformTitle('Poems. English & Italian.')?.uniform).toBe('Poems');
+  });
+});
+
+describe('MUST NOT match — display titles that merely contain the word', () => {
+  it.each([
+    'The English intelligencer, shewing the true and most remarkeable passages',
+    'English exercises for school-boys to translate into Latin, ... By J. Garretson',
+    'The true English Protestants apology, against the blacke-mouth\'d obloquie',
+    'The penman\'s companion containing specimens in all hands, by the most eminent English',
+  ])('%s', (input) => {
+    expect(splitUniformTitle(input)).toBeNull();
+  });
+
+  it('refuses a title that is nothing but the language', () => {
+    // Nothing before the language means no work is named.
+    expect(splitUniformTitle('English')).toBeNull();
+    expect(splitUniformTitle('English.')).toBeNull();
+  });
+});
+
+describe('toReferenceRow', () => {
+  const row = {
+    id: 'S100458',
+    dates: ['1569'],
+    language: 'eng',
+    search_titles: [
+      'Della vanita delle scienze. English',
+      'Henrie Cornelius Agrippa, of the vanitie and vncertaintie of artes and sciences',
+    ],
+    search_names: ['Agrippa von Nettesheim, Heinrich Cornelius, 1486?-1535.', 'Sanford, James, translator.'],
+    subjects: [],
+  };
+
+  it('takes the uniform title as the join key and the other title for display', () => {
+    const r = toReferenceRow(row);
+    expect(r.uniform_title).toBe('Della vanita delle scienze');
+    expect(r.title).toMatch(/^Henrie Cornelius Agrippa/);
+    expect(r.estc_id).toBe('S100458');
+    expect(r.year).toBe('1569');
+  });
+
+  it('records HOW the translation was declared', () => {
+    expect(toReferenceRow(row).translation_evidence).toBe('uniform_title_lang:English');
+    expect(toReferenceRow({ ...row, search_titles: ['Some title'] }).translation_evidence)
+      .toBe('translator_relator');
+  });
+
+  it('leaves original_languages EMPTY rather than guessing', () => {
+    // ESTC records no original-language code. An empty array makes the language
+    // screen treat it as UNKNOWN and KEEP the candidate; inventing a value here
+    // would let it reject a real prior.
+    expect(toReferenceRow(row).original_languages).toEqual([]);
+  });
+
+  it('sorts a translator out of the author entries', () => {
+    const r = toReferenceRow(row);
+    expect(r.author).toMatch(/^Agrippa/);
+    expect(r.added_entries).toContain('Sanford, James, translator.');
+  });
+});

--- a/tests/unit/loc-bulk-item-language.test.ts
+++ b/tests/unit/loc-bulk-item-language.test.ts
@@ -146,3 +146,60 @@ describe('the reject tally — a filter that reports only survivors cannot be au
     expect(seen).toEqual([]);
   });
 });
+
+describe('three grades of translation evidence (#3599)', () => {
+  // Requiring 041$h was the dominant cause of 27% catalogue recall: of 136,193
+  // English-language records in one part, 3,918 carry it and ~131,000 declare
+  // nothing at all. Every confirmed-absent prior we chased was in LoC with a
+  // good MARC 240 and no 041 — Caplan's Loeb Ad Herennium (LCCN 55004252).
+  const withUniform = (uniform: string, lang?: string) => `<record>
+    <controlfield tag="008">000000s1954    xx            000 0 eng d</controlfield>
+    <datafield tag="240"><subfield code="a">${uniform}</subfield>${lang ? `<subfield code="l">${lang}</subfield>` : ''}</datafield>
+    <datafield tag="245"><subfield code="a">Ad C. Herennium de ratione dicendi</subfield></datafield>
+  </record>`;
+
+  it('accepts 041$h as before', () => {
+    const row = extractEnglishTranslation(marc({ langSubfields: ['eng'], original: 'lat' }));
+    expect(row.translation_evidence).toBe('041h');
+    expect(row.original_languages).toEqual(['lat']);
+  });
+
+  it('accepts 240$l English when there is no 041 at all — the Caplan shape', () => {
+    const row = extractEnglishTranslation(withUniform('Rhetorica ad Herennium.', 'English'));
+    expect(row, 'a 240 with $l English is the same assertion as 041$h').not.toBeNull();
+    expect(row.translation_evidence).toBe('uniform_title_lang');
+  });
+
+  it('accepts 240$l mid-field, where $s or $k follows the language', () => {
+    const rec = `<record>
+      <controlfield tag="008">000000s1600    xx            000 0 eng d</controlfield>
+      <datafield tag="240"><subfield code="a">Bible. Psalms</subfield><subfield code="l">English</subfield><subfield code="s">Sternhold and Hopkins</subfield></datafield>
+      <datafield tag="245"><subfield code="a">The whole booke of Psalmes</subfield></datafield>
+    </record>`;
+    expect(extractEnglishTranslation(rec).translation_evidence).toBe('uniform_title_lang');
+  });
+
+  it('accepts a bare 240 on an English item as the WEAKEST grade, labelled', () => {
+    const row = extractEnglishTranslation(withUniform('Rhetorica ad Herennium.'));
+    expect(row.translation_evidence).toBe('uniform_title_only');
+    // No 041$h means no source language. Empty is required: the language screen
+    // reads unresolvable as UNKNOWN and keeps the candidate.
+    expect(row.original_languages).toEqual([]);
+  });
+
+  it('still rejects an English item with no 240 and no 041$h', () => {
+    const rec = `<record>
+      <controlfield tag="008">000000s1900    xx            000 0 eng d</controlfield>
+      <datafield tag="245"><subfield code="a">An ordinary English book</subfield></datafield>
+    </record>`;
+    expect(extractEnglishTranslation(rec)).toBeNull();
+  });
+
+  it('still rejects a non-English item however it declares itself', () => {
+    const rec = `<record>
+      <controlfield tag="008">000000s1600    xx            000 0 fre d</controlfield>
+      <datafield tag="240"><subfield code="a">Rhetorica ad Herennium.</subfield><subfield code="l">French</subfield></datafield>
+    </record>`;
+    expect(extractEnglishTranslation(rec)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #3599.

Requiring `041$h` was the dominant cause of 27% catalogue recall. Of **136,193** English-language records in one part, **3,918** carry it — and **~131,000 declare nothing at all** by any means. Every confirmed-absent prior we chased was sitting in LoC with a perfectly good MARC 240 and no 041 whatsoever:

- Caplan's Loeb *Ad Herennium* — LCCN `55004252`, `240 Rhetorica ad Herennium.`, no 041
- Böhme's *Signature of All Things* — `36037588`, no 041

## Three grades of evidence, labelled on the row

| grade | meaning |
|---|---|
| `041h` | a cataloguer's explicit "translated from &lt;lang&gt;" |
| `uniform_title_lang` | `240$l English` — the same assertion, different field |
| `uniform_title_only` | a 240 on an English item with no language marker |

The third is noisier — about a third genuine, the rest English works with collective uniform titles (`Works.`, `Poems.`) — but **it is where Caplan lives**, and the matcher already screens it: containment against *our* title cannot fire on an unrelated English work, and generic 1–2 token uniform titles demand author corroboration.

`240$l` is read as a **subfield**, not by pattern-matching a flattened string: `$s`/`$k`/`$f` follow the language routinely, so `"Bible. Psalms. English. Sternhold and Hopkins."` must match as readily as `"De consolatione philosophiae. English"`. (The sibling ESTC ingest, which only sees flattened titles, needed a component split for the same reason.)

`original_languages` stays **empty** for the latter two grades — correct and load-bearing, since the language screen reads an unresolvable value as UNKNOWN and *keeps* the candidate. Inventing one would let it reject a real prior.

## Measured

Re-derive in progress: **part01 goes 3,918 → 5,522 English translations (+41%)** — exactly the ceiling predicted from the field census, on identical input.

20 behavioural tests over real MARC record shapes.