### PR TITLE
fix(ocr): drop invalid Gemini keys at startup (#3627)

### DIFF
--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -85,10 +85,43 @@ function getAllApiKeys() {
 }
 
 let currentKeyIndex = 0;
-const apiKeys = getAllApiKeys();
+let apiKeys = getAllApiKeys();
 const rateLimitedKeys = new Map(); // keyName -> unblock timestamp
 const RATE_LIMIT_COOLDOWN = 5 * 60 * 1000; // 5 min cooldown for rate-limited keys
-console.log(`API keys: ${apiKeys.map(k => k.name).join(', ')}`);
+
+/**
+ * Drop keys that are not merely throttled but INVALID (#3627).
+ *
+ * Rotation treats every configured key as usable, so a revoked one keeps taking
+ * its turn and failing. On 2026-08-04 two of four keys in `.env.production.local`
+ * returned 400 "API key not valid", and a 54-page run failed 27 of 54 — a clean
+ * 50%, which reads as throttling or bad images rather than what it was. The
+ * reason sat in `gemini_usage.error_message` and never reached the console.
+ *
+ * A 400 is permanent (a 429 is not), so the cheap fix is one probe per key at
+ * startup. Four requests to avoid silently halving every run.
+ */
+async function dropInvalidKeys(keys) {
+  const checked = await Promise.all(keys.map(async (k) => {
+    try {
+      const r = await fetch(`${GEMINI_API_BASE}/models?key=${k.key}`);
+      if (r.status === 400 || r.status === 403) {
+        const body = await r.text().catch(() => '');
+        return { ...k, dead: true, why: `HTTP ${r.status} ${(body.match(/"message":\s*"([^"]+)"/) || [])[1] || ''}`.trim() };
+      }
+      return { ...k, dead: false };
+    } catch {
+      // A network failure is not proof the key is bad — keep it and let the run
+      // surface the error per call, rather than silently shrinking the pool.
+      return { ...k, dead: false };
+    }
+  }));
+  const dead = checked.filter((k) => k.dead);
+  for (const k of dead) console.log(`  DROPPING ${k.name}: ${k.why}`);
+  const live = checked.filter((k) => !k.dead).map(({ key, name }) => ({ key, name }));
+  if (live.length === 0) throw new Error('Every configured Gemini key was rejected — fix the env before running.');
+  return live;
+}
 
 function getNextKey() {
   const now = Date.now();
@@ -453,6 +486,13 @@ async function main() {
   if (PIPELINE_STATUS) console.log(`  pipeline_status=${PIPELINE_STATUS}`);
   if (PROVIDER) console.log(`  provider=${PROVIDER}`);
   if (DRY_RUN) console.log(`  DRY RUN`);
+  console.log('');
+
+  // Validate the key pool before doing any work — a revoked key otherwise keeps
+  // its slot in the rotation and fails its share of every batch (#3627).
+  console.log(`API keys configured: ${apiKeys.map(k => k.name).join(', ')}`);
+  apiKeys = await dropInvalidKeys(apiKeys);
+  console.log(`API keys usable:     ${apiKeys.map(k => k.name).join(', ')}`);
   console.log('');
 
   try {


### PR DESCRIPTION
## What

`realtime-ocr.mjs` rotates across every `GEMINI_API_KEY*` it finds. Two of the four in `.env.production.local` are revoked and return `400 "API key not valid"`, so **half of every local OCR call failed**.

Observed while re-OCRing the false-split cohort (#3562): 27 of 54 failed. Retried at concurrency 3 in case it was rate limiting: 14 ok / 13 failed. Re-run with the dead keys unset: **13/13**.

`TIER3` is tried *first* because it is meant to have the highest limits — so the most-favoured slot in the rotation was one of the dead ones.

## Why it stayed invisible

A 50% failure rate on a batch job reads as throttling, flaky network, or bad images. All plausible. The actual message — `API key not valid` — was in `gemini_usage.error_message` throughout, while the console printed `Failed: 27` with no reason.

Same shape as the OCR sliver warnings in #3562: the system had recorded exactly what was wrong, in plain language, and nothing surfaced it.

## The fix

One probe per key at startup. A 400/403 is permanent (a 429 is not), so this is decidable for four requests:

```
API keys configured: TIER3, KEY_2, KEY_3, PRIMARY
  DROPPING TIER3: HTTP 400 API key not valid. Please pass a valid API key.
  DROPPING PRIMARY: HTTP 400 API key not valid. Please pass a valid API key.
API keys usable:     KEY_2, KEY_3
```

- A **network error during probing does not drop the key** — that is not proof of invalidity, and silently shrinking the pool is the bug being fixed.
- Refuses to start if every key is rejected, rather than failing page by page.

## Out of scope

**Replacing the dead key values.** Hetzner has three working keys (`…qatGsw`, `…omWjiQ`, `…RWx7wQ`) against local's two; only `KEY_3` is shared, matching the known Vercel/Hetzner divergence. I did not edit `.env.production.local` because it is Vercel-managed and would be overwritten by the next `vercel env pull` — the source of truth is the Vercel dashboard, which is Derek's to change.

**One thing worth a look, unconfirmed:** `vercel env pull --environment=production` returns `GEMINI_API_KEY` as an *empty* value, while `GEMINI_MODEL` pulls fine from the same file. 69 call sites in `src/` read `GEMINI_API_KEY`. I could **not** confirm any production breakage — every recent Gemini call in `gemini_usage` comes from the Hetzner workers, not from Vercel routes, so there is no positive evidence either way. Flagging it as worth checking in the dashboard, explicitly **not** as an outage claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)