### PR TITLE
feat(analytics): log outbound conversion clicks across all giving and partnership surfaces

### DIFF
--- a/src/app/api/analytics/event/route.ts
+++ b/src/app/api/analytics/event/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { classifyRequest } from '@/lib/analytics-ingest';
+import { ALLOWED_EVENTS, ALLOWED_PROPS } from '@/lib/analytics-event-allowlist';
 
 /**
  * General-purpose analytics event sink for value-moment interactions that the
@@ -14,48 +15,6 @@ import { classifyRequest } from '@/lib/analytics-ingest';
  * can't be used to write arbitrary documents.
  */
 
-const ALLOWED_EVENTS = new Set([
-  'cite', 'share', 'quote_copy', 'doi_view', 'download', 'signin_view',
-  // signup_start: fired when a visitor initiates sign-up from a surface, so we
-  // can attribute signups by `source` (hero / signin_page / …) and `method`.
-  'signup_start',
-  // confirm_view / confirm_click: the two halves of the magic-link interstitial
-  // at /auth/confirm. views-minus-clicks is the drop-off introduced by the
-  // prefetch-safe second click; without them an unconsumed verification token
-  // is indistinguishable from mail that was never opened at all.
-  'confirm_view', 'confirm_click',
-  // welcome_view / welcome_save / welcome_skip: the onboarding form at /welcome.
-  // It shipped with no instrumentation at all, which is how it went unnoticed
-  // that the interstitial never fired and the form had captured 4 profiles in
-  // its lifetime (#3448). Without the view event a low completion rate and an
-  // unreachable page look identical. `source` separates gate-redirected users
-  // from people who navigated to /welcome themselves.
-  'welcome_view', 'welcome_save', 'welcome_skip',
-]);
-
-// Only these prop keys are persisted; everything else is dropped.
-const ALLOWED_PROPS = new Set([
-  'bookId', 'format', 'channel', 'page', 'title', 'url', 'hasDoi', 'edition', 'source', 'reason', 'method',
-  // surface: which UI emitted a share (book page / gallery_image /
-  // collection_anchor_bar). Share controls exist on several surfaces and until
-  // #3399 two of them emitted nothing at all, so an undifferentiated `share`
-  // count could not tell "nobody shares" from "that surface isn't wired up".
-  'surface',
-  // safe: on confirm_view/confirm_click, whether the `next` callback parameter
-  // survived transit — separates "changed their mind" from "the link broke".
-  'safe',
-  // hasName / hasAbout / hasHelp / hasLanguage: on welcome_save, WHICH fields the
-  // reader actually filled — never their contents, which live in users.profile. A
-  // bare save count cannot tell "they answered everything" from "they typed a name
-  // and left the two essay boxes empty", and that distinction is the whole
-  // question about whether the form asks for the right things at the right time.
-  //
-  // ADDING A FIELD TO THE WELCOME FORM MEANS ADDING ITS FLAG HERE. A prop that is
-  // not on this list is dropped silently — 200 response, no error, and the key is
-  // simply absent when someone queries for it weeks later (CLAUDE.md: "A
-  // silently-dropped field is the default failure").
-  'hasName', 'hasAbout', 'hasHelp', 'hasLanguage',
-]);
 
 const DB_TIMEOUT_MS = 3000;
 

--- a/src/app/bhutan-library/page.tsx
+++ b/src/app/bhutan-library/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import OutboundLink from '@/components/analytics/OutboundLink';
 import { Metadata } from 'next';
 import SiteHeader from '@/components/layout/SiteHeader';
 import DonationIntentionForm from '@/components/donate/DonationIntentionForm';
@@ -328,10 +329,10 @@ export default async function BhutanLibraryPage() {
               </p>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <a
+                <OutboundLink
                   href={DONORPERFECT_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  surface="bhutan_library"
+                  channel="naf_donorperfect"
                   className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 hover:border-stone-400 transition-colors block"
                 >
                   <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">
@@ -339,11 +340,11 @@ export default async function BhutanLibraryPage() {
                   </span>
                   <span className="block text-sm font-semibold text-stone-900">Donate via NAF</span>
                   <span className="block text-xs text-stone-500 mt-1">501(c)(3) public charity</span>
-                </a>
-                <a
+                </OutboundLink>
+                <OutboundLink
                   href={EFM_STRIPE_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  surface="bhutan_library"
+                  channel="efm_stripe"
                   className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 hover:border-stone-400 transition-colors block"
                 >
                   <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">
@@ -351,17 +352,19 @@ export default async function BhutanLibraryPage() {
                   </span>
                   <span className="block text-sm font-semibold text-stone-900">Donate via EFM</span>
                   <span className="block text-xs text-stone-500 mt-1">ANBI-registered (NL)</span>
-                </a>
+                </OutboundLink>
                 <div className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 sm:col-span-2">
                   <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">
                     Sponsor the campaign — wire, stock, or donor-advised fund
                   </span>
-                  <a
+                  <OutboundLink
                     href={`mailto:${CONTACT_EMAIL}?subject=Bhutan%20Library%20Restoration%20%E2%80%94%20Donation%20Inquiry`}
+                    surface="bhutan_library"
+                    channel="email"
                     className="text-base font-semibold text-accent-rust hover:text-accent-gold-dark underline break-all select-all"
                   >
                     {CONTACT_EMAIL}
-                  </a>
+                  </OutboundLink>
                 </div>
               </div>
 

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import OutboundLink from '@/components/analytics/OutboundLink';
 import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { getReadDb } from '@/lib/mongodb';
@@ -260,12 +261,15 @@ export default async function DatasetPage() {
         </p>
 
         <div className="flex flex-wrap gap-4 mt-8">
-          <a
+          <OutboundLink
             href="mailto:team@sourcelibrary.org?subject=Dataset%20Access%20Request"
+            surface="dataset"
+            channel="email"
+            intent="inquiry"
             className="px-6 py-3 bg-[#1a1a18] text-white rounded-full text-sm font-medium hover:bg-[#333] transition-colors"
           >
             Request access
-          </a>
+          </OutboundLink>
           <a
             href="/api/dataset/v1/stats"
             className="px-6 py-3 border border-[#ccc] text-[#444] rounded-full text-sm font-medium hover:border-[#999] transition-colors"

--- a/src/app/ficino-society/page.tsx
+++ b/src/app/ficino-society/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Suspense, useState, useEffect } from 'react';
+import OutboundLink from '@/components/analytics/OutboundLink';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
@@ -310,14 +311,14 @@ function FicinoSocietyContent() {
               {isContributor ? 'Thank you' : contributing ? 'Redirecting...' : 'Contribute $100/year'}
             </button>
           ) : (
-            <a
+            <OutboundLink
               href={EFM_STRIPE_URL}
-              target="_blank"
-              rel="noopener noreferrer"
+              surface="ficino_society"
+              channel="efm_stripe"
               className="inline-block px-8 py-3 rounded text-sm font-sans tracking-wide border border-[#1a1612]/20 text-[#1a1612] hover:brightness-110 transition-all"
             >
               Contribute
-            </a>
+            </OutboundLink>
           )}
           <p className="mt-6 text-[12px] text-[#8a8480] font-body">
             Any amount welcome &mdash;{' '}

--- a/src/app/for-libraries/page.tsx
+++ b/src/app/for-libraries/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import OutboundLink from '@/components/analytics/OutboundLink';
 import type { Metadata } from 'next';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 
@@ -300,12 +301,15 @@ export default function ForLibrariesPage() {
             of whether Source Library is the right fit.
           </p>
           <div className="flex flex-wrap gap-3">
-            <a
+            <OutboundLink
               href={`mailto:${CONTACT_EMAIL}?subject=Source%20Library%20partnership%20inquiry`}
+              surface="for_libraries"
+              channel="email"
+              intent="inquiry"
               className="inline-flex items-center gap-2 px-5 py-2.5 bg-white text-stone-900 rounded-full hover:bg-stone-100 transition-colors text-sm font-medium"
             >
               Email {CONTACT_EMAIL}
-            </a>
+            </OutboundLink>
             <Link
               href="/about"
               className="inline-flex items-center gap-2 px-5 py-2.5 border border-stone-600 text-stone-100 rounded-full hover:bg-stone-700 transition-colors text-sm"

--- a/src/app/licensing/page.tsx
+++ b/src/app/licensing/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import OutboundLink from '@/components/analytics/OutboundLink';
 import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 
@@ -184,7 +185,7 @@ export default function LicensingPage() {
             (Latin, classical Chinese, Sanskrit, Tibetan, Syriac), none of it in
             Common Crawl. Corpus partners additionally receive priority input on what
             gets translated next through our{' '}
-            <a href="mailto:team@sourcelibrary.org?subject=AI%20Partnership" className="text-accent-rust hover:underline">sponsorship program</a>.
+            <OutboundLink href="mailto:team@sourcelibrary.org?subject=AI%20Partnership" surface="licensing_sponsorship" channel="email" intent="inquiry" className="text-accent-rust hover:underline">sponsorship program</OutboundLink>.
           </p>
           <p className="text-secondary leading-relaxed mb-4">
             Two properties of licensed data worth knowing. <strong>It&rsquo;s
@@ -210,7 +211,7 @@ export default function LicensingPage() {
           <h2 className="text-2xl text-primary mb-4">Licensing &amp; partnerships</h2>
           <p className="text-secondary leading-relaxed">
             For an AI-training or bulk-dataset license, or a research partnership,
-            contact <a href="mailto:team@sourcelibrary.org?subject=AI%20Licensing%20Inquiry" className="text-accent-rust hover:underline">team@sourcelibrary.org</a> with
+            contact <OutboundLink href="mailto:team@sourcelibrary.org?subject=AI%20Licensing%20Inquiry" surface="licensing_inquiry" channel="email" intent="inquiry" className="text-accent-rust hover:underline">team@sourcelibrary.org</OutboundLink> with
             the subject &ldquo;AI Licensing Inquiry.&rdquo; We respond within a day.
           </p>
         </section>

--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import OutboundLink from '@/components/analytics/OutboundLink';
 import { Metadata } from 'next';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { getReadDb } from '@/lib/mongodb';
@@ -110,12 +111,15 @@ export default async function SponsorsPage() {
             for anyone who wants to read them.
           </p>
           <div className="mt-10 flex flex-wrap gap-3">
-            <a
+            <OutboundLink
               href={mailto}
+              surface="sponsors_hero"
+              channel="email"
+              intent="inquiry"
               className="inline-flex items-center px-6 py-3 rounded-md bg-[#9e4a3a] text-white text-sm font-semibold hover:bg-[#7e3a2e] transition-colors"
             >
               Talk to us
-            </a>
+            </OutboundLink>
             <Link
               href="/collections"
               className="inline-flex items-center px-6 py-3 rounded-md border border-stone-300 text-stone-700 text-sm font-semibold hover:border-stone-500 transition-colors"
@@ -214,12 +218,15 @@ export default async function SponsorsPage() {
                   Scope set in conversation. Wire, stock, DAF, or annual invoice — whatever your
                   procurement team prefers.
                 </p>
-                <a
+                <OutboundLink
                   href={mailto}
+                  surface="sponsors_stewardship"
+                  channel="email"
+                  intent="inquiry"
                   className="inline-flex items-center px-5 py-3 rounded-md bg-[#9e4a3a] text-white text-sm font-semibold hover:bg-[#7e3a2e] transition-colors"
                 >
                   Open a conversation
-                </a>
+                </OutboundLink>
               </div>
             </div>
           </div>
@@ -253,12 +260,15 @@ export default async function SponsorsPage() {
                 </div>
                 <div className="font-display text-2xl text-[#c9a86c] mb-1">$1M / yr</div>
                 <div className="text-xs text-stone-400 mb-6">Multi-year, by arrangement</div>
-                <a
+                <OutboundLink
                   href={mailto}
+                  surface="sponsors_founding_steward"
+                  channel="email"
+                  intent="inquiry"
                   className="inline-flex items-center px-5 py-3 rounded-md bg-[#c9a86c] text-stone-900 text-sm font-semibold hover:bg-[#b8975b] transition-colors"
                 >
                   Be the first
-                </a>
+                </OutboundLink>
               </div>
             </div>
           </div>
@@ -369,12 +379,15 @@ export default async function SponsorsPage() {
             a collection you care about, an expedition, or something we haven&apos;t built yet.
             We&apos;ll come back inside a week with a concrete proposal.
           </p>
-          <a
+          <OutboundLink
             href={mailto}
+            surface="sponsors_footer_cta"
+            channel="email"
+            intent="inquiry"
             className="inline-flex items-center px-8 py-4 rounded-md bg-[#c9a86c] text-stone-900 text-sm font-semibold hover:bg-[#b8975b] transition-colors"
           >
             {PARTNERSHIP_EMAIL}
-          </a>
+          </OutboundLink>
           <p className="text-xs text-stone-500 mt-8">
             For individual donations and small gifts, see{' '}
             <Link href="/support" className="underline hover:text-stone-300">

--- a/src/app/support/business/page.tsx
+++ b/src/app/support/business/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Metadata } from 'next';
 import SiteHeader from '@/components/layout/SiteHeader';
+import OutboundLink from '@/components/analytics/OutboundLink';
 
 export const revalidate = 86400;
 
@@ -228,10 +229,10 @@ export default function BusinessGivingPage() {
           </h2>
 
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
-            <a
+            <OutboundLink
               href={EFM_STRIPE_URL}
-              target="_blank"
-              rel="noopener noreferrer"
+              surface="support_business"
+              channel="efm_stripe"
               className="bg-white rounded-xl border border-stone-200 p-5 hover:border-stone-400 transition-colors block"
             >
               <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">
@@ -241,11 +242,11 @@ export default function BusinessGivingPage() {
                 Give to Stichting Het Wereldhart
               </span>
               <span className="block text-xs text-stone-500 mt-1">Cultural ANBI</span>
-            </a>
-            <a
+            </OutboundLink>
+            <OutboundLink
               href={NAF_SOURCELIBRARY_URL}
-              target="_blank"
-              rel="noopener noreferrer"
+              surface="support_business"
+              channel="naf_donorperfect"
               className="bg-white rounded-xl border border-stone-200 p-5 hover:border-stone-400 transition-colors block"
             >
               <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">
@@ -255,9 +256,11 @@ export default function BusinessGivingPage() {
                 Give via the Netherland-America Foundation
               </span>
               <span className="block text-xs text-stone-500 mt-1">501(c)(3) public charity</span>
-            </a>
-            <a
+            </OutboundLink>
+            <OutboundLink
               href={MAILTO}
+              surface="support_business"
+              channel="email"
               className="bg-white rounded-xl border border-stone-200 p-5 hover:border-stone-400 transition-colors block"
             >
               <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">
@@ -269,7 +272,7 @@ export default function BusinessGivingPage() {
               <span className="block text-xs text-stone-500 mt-1">
                 Periodic gifts, sponsorship, in kind
               </span>
-            </a>
+            </OutboundLink>
           </div>
 
           <p className="text-sm text-stone-500 leading-relaxed max-w-3xl">
@@ -277,9 +280,9 @@ export default function BusinessGivingPage() {
             Rules described here are current for the 2026 tax year and the right answer depends on
             your company&apos;s profit, VAT position, and where you are resident. Confirm with your
             accountant before you give, and write to{' '}
-            <a href={MAILTO} className="text-[#9e4a3a] underline hover:text-[#7e3a2e]">
+            <OutboundLink href={MAILTO} surface="support_business" channel="email" className="text-[#9e4a3a] underline hover:text-[#7e3a2e]">
               {CONTACT_EMAIL}
-            </a>{' '}
+            </OutboundLink>{' '}
             if it would help to have us talk it through with them.
           </p>
         </div>

--- a/src/components/analytics/OutboundLink.tsx
+++ b/src/components/analytics/OutboundLink.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { trackEvent } from '@/lib/track-event';
+import { outboundClickPayload, type OutboundIntent } from '@/lib/outbound-click';
+
+/**
+ * A link that hands the visitor to a destination we don't own — the Embassy's
+ * Stripe page, NAF's DonorPerfect form, or their mail client — and logs the
+ * click on the way out.
+ *
+ * Why this exists: every giving and partnership route on the site ends off-site.
+ * Nothing on our side saw the handoff, and nothing on the other side reports back
+ * (no donation webhook, no attribution — see the ops-repo handoff
+ * `2026-06-29-metrics-feedback-skills-donation-flow.md`). So the question "does
+ * /support/business reach a single business owner?" was unanswerable from both
+ * ends simultaneously: we couldn't see the intent, and we couldn't see the gift.
+ * This closes the half we control.
+ *
+ * A CLICK IS NOT A GIFT. It is the last event we can observe, which makes it the
+ * only denominator we own — read it as intent-to-give, never as revenue, and
+ * never divide it into a donation total from another system to manufacture a
+ * conversion rate. The two numbers come from different populations (CLAUDE.md:
+ * "a metric's name is a claim about its denominator").
+ *
+ * Bot traffic is STORED and tagged here rather than dropped, matching the rest of
+ * /api/analytics/event — these clicks are low-volume so crawlers can't swamp
+ * them, and a crawler hitting a donate button is itself worth seeing. Read paths
+ * that want humans filter on `traffic_class`.
+ */
+export default function OutboundLink({
+  href,
+  surface,
+  channel,
+  locale,
+  intent = 'donate',
+  className,
+  newTab,
+  children,
+}: {
+  href: string;
+  /** Which page or component emitted the click — `support`, `support_business`, … */
+  surface: string;
+  /** Where it goes — `naf_donorperfect`, `efm_stripe`, `email`. */
+  channel: string;
+  locale?: string;
+  /** `donate` for money, `inquiry` for a partnership/licensing/dataset ask. */
+  intent?: OutboundIntent;
+  className?: string;
+  /** Defaults to true for http(s), false for mailto — a mailto in a new tab leaves a blank one behind. */
+  newTab?: boolean;
+  children: React.ReactNode;
+}) {
+  const openInNewTab = newTab ?? !href.startsWith('mailto:');
+
+  return (
+    <a
+      href={href}
+      className={className}
+      onClick={() => {
+        const { event, props } = outboundClickPayload({ surface, channel, locale, intent });
+        trackEvent(event, props);
+      }}
+      {...(openInNewTab ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/donate/SupportView.tsx
+++ b/src/components/donate/SupportView.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import SiteHeader from '@/components/layout/SiteHeader';
 import DonationIntentionForm from '@/components/donate/DonationIntentionForm';
 import QuickSubscribe from '@/components/donate/QuickSubscribe';
+import OutboundLink from '@/components/analytics/OutboundLink';
 import { getReadDb } from '@/lib/mongodb';
 import type { Locale } from '@/lib/i18n';
 
@@ -185,21 +186,21 @@ export default function SupportView({ stats, locale = 'en' }: { stats: SupportSt
               <p className="text-stone-600 leading-relaxed mb-6">{s.giveLead}</p>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <a href={DONORPERFECT_URL} target="_blank" rel="noopener noreferrer" className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 hover:border-stone-400 transition-colors block">
+                <OutboundLink href={DONORPERFECT_URL} surface="support" channel="naf_donorperfect" locale={locale} className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 hover:border-stone-400 transition-colors block">
                   <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">{s.usLabel}</span>
                   <span className="block text-sm font-semibold text-stone-900">{s.usTitle}</span>
                   <span className="block text-xs text-stone-500 mt-1">{s.usSub}</span>
-                </a>
-                <a href={EFM_STRIPE_URL} target="_blank" rel="noopener noreferrer" className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 hover:border-stone-400 transition-colors block">
+                </OutboundLink>
+                <OutboundLink href={EFM_STRIPE_URL} surface="support" channel="efm_stripe" locale={locale} className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 hover:border-stone-400 transition-colors block">
                   <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">{s.intlLabel}</span>
                   <span className="block text-sm font-semibold text-stone-900">{s.intlTitle}</span>
                   <span className="block text-xs text-stone-500 mt-1">{s.intlSub}</span>
-                </a>
+                </OutboundLink>
                 <div className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 sm:col-span-2">
                   <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">{s.largeLabel}</span>
-                  <a href={`mailto:${CONTACT_EMAIL}?subject=Source%20Library%20%E2%80%94%20Donation%20Inquiry`} className="text-base font-semibold text-accent-rust hover:text-accent-gold-dark underline break-all select-all">
+                  <OutboundLink href={`mailto:${CONTACT_EMAIL}?subject=Source%20Library%20%E2%80%94%20Donation%20Inquiry`} surface="support" channel="email" locale={locale} className="text-base font-semibold text-accent-rust hover:text-accent-gold-dark underline break-all select-all">
                     {CONTACT_EMAIL}
-                  </a>
+                  </OutboundLink>
                 </div>
               </div>
 

--- a/src/lib/analytics-event-allowlist.ts
+++ b/src/lib/analytics-event-allowlist.ts
@@ -1,0 +1,66 @@
+/**
+ * Allowlists for POST /api/analytics/event.
+ *
+ * These live in their own module (rather than inside the route) so a test can
+ * import the REAL sets and check a caller's payload against them. The failure
+ * mode they guard is silent: the route drops any prop key not listed here and
+ * still answers 200, so a field added to a caller without being added here is
+ * simply absent when someone queries for it weeks later — no error anywhere
+ * (CLAUDE.md: "A silently-dropped field is the default failure").
+ */
+
+export const ALLOWED_EVENTS = new Set([
+  'cite', 'share', 'quote_copy', 'doi_view', 'download', 'signin_view',
+  // signup_start: fired when a visitor initiates sign-up from a surface, so we
+  // can attribute signups by `source` (hero / signin_page / …) and `method`.
+  'signup_start',
+  // confirm_view / confirm_click: the two halves of the magic-link interstitial
+  // at /auth/confirm. views-minus-clicks is the drop-off introduced by the
+  // prefetch-safe second click; without them an unconsumed verification token
+  // is indistinguishable from mail that was never opened at all.
+  'confirm_view', 'confirm_click',
+  // welcome_view / welcome_save / welcome_skip: the onboarding form at /welcome.
+  // It shipped with no instrumentation at all, which is how it went unnoticed
+  // that the interstitial never fired and the form had captured 4 profiles in
+  // its lifetime (#3448). Without the view event a low completion rate and an
+  // unreachable page look identical. `source` separates gate-redirected users
+  // from people who navigated to /welcome themselves.
+  'welcome_view', 'welcome_save', 'welcome_skip',
+  // donate_click / inquiry_click: outbound handoffs to a payment page or an
+  // inquiry mailto, emitted by <OutboundLink>. Every giving route on the site
+  // ends at a destination we don't own and that sends nothing back, so before
+  // these existed "nobody gives through /support/business" and "nobody ever
+  // reaches it" were the same observation. Read them as intent, never revenue —
+  // the gift lands in EFM's Stripe or NAF's DonorPerfect, not here.
+  'donate_click', 'inquiry_click',
+]);
+
+// Only these prop keys are persisted; everything else is dropped.
+export const ALLOWED_PROPS = new Set([
+  'bookId', 'format', 'channel', 'page', 'title', 'url', 'hasDoi', 'edition', 'source', 'reason', 'method',
+  // surface: which UI emitted a share (book page / gallery_image /
+  // collection_anchor_bar). Share controls exist on several surfaces and until
+  // #3399 two of them emitted nothing at all, so an undifferentiated `share`
+  // count could not tell "nobody shares" from "that surface isn't wired up".
+  'surface',
+  // safe: on confirm_view/confirm_click, whether the `next` callback parameter
+  // survived transit — separates "changed their mind" from "the link broke".
+  'safe',
+  // hasName / hasAbout / hasHelp / hasLanguage: on welcome_save, WHICH fields the
+  // reader actually filled — never their contents, which live in users.profile. A
+  // bare save count cannot tell "they answered everything" from "they typed a name
+  // and left the two essay boxes empty", and that distinction is the whole
+  // question about whether the form asks for the right things at the right time.
+  //
+  // ADDING A FIELD TO THE WELCOME FORM MEANS ADDING ITS FLAG HERE. A prop that is
+  // not on this list is dropped silently — 200 response, no error, and the key is
+  // simply absent when someone queries for it weeks later (CLAUDE.md: "A
+  // silently-dropped field is the default failure").
+  'hasName', 'hasAbout', 'hasHelp', 'hasLanguage',
+  // locale: on donate_click/inquiry_click, which language the surface was serving.
+  // /support renders in EN and ES from the same component, so without this every
+  // Spanish giving click is filed under the English page and the two are
+  // indistinguishable forever. `surface` + `channel` (both above) carry the rest:
+  // which page emitted the click, and where it went.
+  'locale',
+]);

--- a/src/lib/outbound-click.ts
+++ b/src/lib/outbound-click.ts
@@ -1,0 +1,43 @@
+/**
+ * The analytics payload for an outbound conversion click, built as a pure
+ * function so it can be tested without a DOM.
+ *
+ * <OutboundLink> calls this and hands the result to trackEvent(). The test
+ * (tests/unit/outbound-click-allowlist.test.ts) calls the same function and
+ * checks every key it produces against the REAL route allowlist — which is the
+ * only way to catch this component's actual failure mode: a prop added here but
+ * not to ALLOWED_PROPS is dropped by the route with a 200 and no error, and the
+ * loss is invisible until someone queries for the field weeks later.
+ */
+
+export type OutboundIntent = 'donate' | 'inquiry';
+
+export interface OutboundClickInput {
+  surface: string;
+  channel: string;
+  locale?: string;
+  intent?: OutboundIntent;
+}
+
+export interface OutboundClickPayload {
+  event: 'donate_click' | 'inquiry_click';
+  props: Record<string, string>;
+}
+
+export function outboundClickPayload({
+  surface,
+  channel,
+  locale,
+  intent = 'donate',
+}: OutboundClickInput): OutboundClickPayload {
+  const props: Record<string, string> = { surface, channel };
+  // Omit rather than send undefined: trackEvent strips undefined anyway, but an
+  // absent key and an empty string mean different things downstream ("this
+  // surface has no locale" vs "the locale was blank").
+  if (locale) props.locale = locale;
+
+  return {
+    event: intent === 'donate' ? 'donate_click' : 'inquiry_click',
+    props,
+  };
+}

--- a/src/lib/track-event.ts
+++ b/src/lib/track-event.ts
@@ -27,7 +27,15 @@ export function trackEvent(
     // nobody could reach — which is exactly what it turned out to be (#3448).
     | 'welcome_view'
     | 'welcome_save'
-    | 'welcome_skip',
+    | 'welcome_skip'
+    // Outbound conversion clicks, fired by <OutboundLink>. `donate_click` is a
+    // handoff to a payment destination (NAF's DonorPerfect form, the Embassy's
+    // Stripe link); `inquiry_click` is a handoff to email for a partnership,
+    // licensing, dataset, or library ask. Both leave our origin, so the click is
+    // the last thing we can see — the gift itself lands in someone else's system
+    // with no webhook back to us. Never treat the count as revenue.
+    | 'donate_click'
+    | 'inquiry_click',
   props?: Record<string, string | number | boolean | undefined>,
 ): void {
   if (typeof window === 'undefined') return;

--- a/tests/unit/outbound-click-allowlist.test.ts
+++ b/tests/unit/outbound-click-allowlist.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { ALLOWED_EVENTS, ALLOWED_PROPS } from '@/lib/analytics-event-allowlist';
+import { outboundClickPayload } from '@/lib/outbound-click';
+
+/**
+ * Guards the silent half of outbound click logging.
+ *
+ * POST /api/analytics/event answers 200 and DROPS any prop key not in
+ * ALLOWED_PROPS, and rejects any event not in ALLOWED_EVENTS. So a payload that
+ * has drifted from the allowlist does not fail loudly — the field is simply
+ * absent when someone queries for it weeks later. These tests exercise the real
+ * payload builder against the real allowlists, so either side drifting is red.
+ *
+ * NOT a source-grep test (CLAUDE.md: "a test that greps source is not a guard").
+ * Negative controls verified by hand: removing 'donate_click' from
+ * ALLOWED_EVENTS, removing 'locale' from ALLOWED_PROPS, and adding an
+ * un-allowlisted key to outboundClickPayload each turn this file red.
+ */
+
+// Every (intent, locale) shape the component can emit. If OutboundLink gains a
+// prop, add its shape here — that is the point of the file.
+const SHAPES = [
+  { label: 'donate, no locale', input: { surface: 'support_business', channel: 'naf_donorperfect' } },
+  { label: 'donate, with locale', input: { surface: 'support', channel: 'efm_stripe', locale: 'es' } },
+  { label: 'donate to email', input: { surface: 'support', channel: 'email', locale: 'en' } },
+  {
+    label: 'inquiry',
+    input: { surface: 'sponsors_hero', channel: 'email', intent: 'inquiry' as const },
+  },
+];
+
+describe('outbound click payloads survive the analytics allowlist', () => {
+  it.each(SHAPES)('$label — event name is accepted by the route', ({ input }) => {
+    const { event } = outboundClickPayload(input);
+    expect(ALLOWED_EVENTS.has(event)).toBe(true);
+  });
+
+  it.each(SHAPES)('$label — every prop key is persisted, none silently dropped', ({ input }) => {
+    const { props } = outboundClickPayload(input);
+    const dropped = Object.keys(props).filter((k) => !ALLOWED_PROPS.has(k));
+    expect(dropped).toEqual([]);
+  });
+
+  it('emits at least one prop for every shape — an empty payload is unattributable', () => {
+    for (const { input } of SHAPES) {
+      const { props } = outboundClickPayload(input);
+      expect(Object.keys(props).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('distinguishes money from inquiry, so one cannot be read as the other', () => {
+    expect(outboundClickPayload({ surface: 's', channel: 'email' }).event).toBe('donate_click');
+    expect(
+      outboundClickPayload({ surface: 's', channel: 'email', intent: 'inquiry' }).event,
+    ).toBe('inquiry_click');
+  });
+
+  it('always carries surface AND channel — either alone cannot answer which page sent a gift where', () => {
+    for (const { input } of SHAPES) {
+      const { props } = outboundClickPayload(input);
+      expect(props.surface, 'surface missing').toBeTruthy();
+      expect(props.channel, 'channel missing').toBeTruthy();
+    }
+  });
+
+  it('omits locale rather than sending an empty string', () => {
+    const { props } = outboundClickPayload({ surface: 's', channel: 'email', locale: '' });
+    expect('locale' in props).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Every giving and partnership route on the site ends at a destination we don't own — the Embassy's Stripe page, NAF's DonorPerfect form, or the visitor's mail client — and none of them report back. There's no donation webhook and no attribution (ops-repo handoff `2026-06-29-metrics-feedback-skills-donation-flow.md`).

That meant **"nobody gives through `/support/business`" and "nobody ever reaches it" were the same observation**, from both ends simultaneously. We couldn't see intent and we couldn't see the gift. This closes the half we control, and it needs nobody else's cooperation.

## What

`<OutboundLink>` logs the handoff through the existing `/api/analytics/event` sink, which already classifies traffic at write time and stores `traffic_class` + `user_agent` — so these rows are diagnosable later instead of born contaminated. Bot clicks are stored and tagged rather than dropped, matching the rest of that route.

**15 links across 8 surfaces:**

| `surface` | Links |
|---|---|
| `support` (EN + ES) | NAF form, EFM Stripe, large-gift email |
| `support_business` | Wereldhart, NAF, email ×2 |
| `bhutan_library` | NAF form, EFM Stripe, donation email |
| `ficino_society` | EFM Stripe |
| `sponsors_*` | 4 CTAs tagged separately — hero / stewardship / founding_steward / footer_cta |
| `licensing_*` | AI partnership, AI licensing inquiry |
| `dataset` | access request |
| `for_libraries` | partnership inquiry |

The four `/sponsors` CTAs are the $250K–$1M asks and had **no instrumentation whatsoever**; they're tagged separately because "which of the four actually gets clicked" is the useful question.

Two events, so money and deals can't be read as each other: `donate_click`, `inquiry_click`. Props are `surface` + `channel`, plus `locale` (new to the allowlist — `/support` serves EN and ES from one component, so without it every Spanish giving click files under the English page, permanently).

**Deliberately not instrumented:** footer/blog contact mailtos, `/terms`, `/privacy`, press addresses. Not conversions; would only add noise.

## A click is not a gift

It's the last event we can observe — the gift lands in someone else's system. **Do not divide these into a Stripe or DonorPerfect total to compute a conversion rate.** Different populations, and that's precisely the denominator error CLAUDE.md warns about. Read as intent, never revenue.

## Guard, with the negative control actually run

The failure mode is silent: the route drops any prop not in `ALLOWED_PROPS` and still answers 200. So the allowlists moved to `src/lib/analytics-event-allowlist.ts` where a test can import the **real** sets, and the payload moved to a pure builder in `src/lib/outbound-click.ts` so it can be exercised without a DOM (no jsdom here). Not a source-grep test.

Controls run, not reasoned about:

| Break | Result |
|---|---|
| remove `locale` from `ALLOWED_PROPS` | 2 failures |
| remove `donate_click` from `ALLOWED_EVENTS` | 3 failures |
| add un-allowlisted key to the builder | 4 failures |

Baseline restored green afterwards.

## Checks

`tsc` clean · **1783 unit tests pass** · eslint clean — the 10 `no-html-link-for-pages` errors in `dataset/page.tsx` are pre-existing, verified identical against `HEAD`.

## Out of scope

- **No read path yet.** Nothing surfaces these counts; querying `analytics_events` for `donate_click` grouped by `surface`/`channel` is a one-liner but there's no dashboard tile or `/metrics` entry. Worth adding once there's a week of data.
- Still no webhook from Stripe or DonorPerfect, so the gift side stays invisible — that's the Sophie letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)