### PR TITLE
Smarter on-view cover selection + placeholder for CSP-blocked covers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 import { withBotId } from 'botid/next/config';
 import { withPostHogConfig } from '@posthog/nextjs-config';
 import collectionRedirects from './src/lib/collection-redirects.json';
+import { CSP_IMG_SRC } from './src/lib/csp-img-hosts';
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
@@ -119,8 +120,10 @@ const nextConfig: NextConfig = {
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://translate.google.com https://translate.googleapis.com https://www.googletagmanager.com https://analytics.ahrefs.com https://eu-assets.i.posthog.com",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://translate.googleapis.com",
               "font-src 'self' https://fonts.gstatic.com",
-              // Images: self + all configured remote image sources + data URIs for base64 thumbnails
-              "img-src 'self' data: blob: https://images.sourcelibrary.org https://*.r2.dev https://*.public.blob.vercel-storage.com https://*.amazonaws.com https://iiif.archive.org https://archive.org https://dl.ndl.go.jp https://gallica.bnf.fr https://api.digitale-sammlungen.de https://www.e-rara.ch https://digi.vatlib.it https://*.bodleian.ox.ac.uk https://cudl.lib.cam.ac.uk https://diglib.hab.de https://iiif.wellcomecollection.org https://upload.wikimedia.org https://*.loc.gov https://babel.hathitrust.org https://bl.digirati.io https://images.lib.cam.ac.uk https://www.e-codices.unifr.ch https://cdm21059.contentdm.oclc.org https://iiif.universiteitleiden.nl https://image.digitalcollections.manchester.ac.uk https://digi.ub.uni-heidelberg.de https://iiif.qdl.qa https://permalinkbnd.bnportugal.gov.pt https://cdli.earth https://images.uba.uva.nl https://imagenes.patrimonionacional.es https://images.eap.bl.uk https://*.basemaps.cartocdn.com",
+              // Images: self + all configured remote image sources + data URIs for base64 thumbnails.
+              // Host list lives in src/lib/csp-img-hosts.ts (shared with getBookThumbnailUrl's
+              // renderability screen — edit it there, never inline here).
+              CSP_IMG_SRC,
               "connect-src 'self' https://*.supabase.co https://generativelanguage.googleapis.com https://translate.googleapis.com wss://*.supabase.co https://api.elevenlabs.io wss://*.elevenlabs.io https://www.google-analytics.com https://region1.google-analytics.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://analytics.ahrefs.com",
               "media-src 'self' blob: https://api.elevenlabs.io https://images.sourcelibrary.org",
               "frame-src 'self' https://translate.google.com",

--- a/scripts/lib/cover-write.mjs
+++ b/scripts/lib/cover-write.mjs
@@ -17,6 +17,9 @@
  * field semantics there, mirror it here.
  */
 
+// Scanner's-hand screen — shared with the cover scorer (same file-pair rule).
+import { HAND_IN_FRAME_RE } from './cover-scoring.mjs';
+
 /** The four canonical write keys + provenance. */
 export const COVER_WRITE_FIELDS = [
   'image_display',
@@ -132,7 +135,8 @@ export function isJunkRepresentativePage(page) {
   if (JUNK_COVER_PAGE_TYPES.has(String(page.page_type || ''))) return true;
   const head = String(page.ocr_head || '');
   if (!head) return false;
-  return DIGITIZER_RE.test(head) || OWNERSHIP_RE.test(head) || BINDING_RE.test(head);
+  return DIGITIZER_RE.test(head) || OWNERSHIP_RE.test(head) || BINDING_RE.test(head)
+    || HAND_IN_FRAME_RE.test(head);
 }
 
 export function selectFallbackCoverPage(pages) {

--- a/src/app/api/books/[id]/ensure-cover/route.ts
+++ b/src/app/api/books/[id]/ensure-cover/route.ts
@@ -3,7 +3,14 @@ import { NextRequest, NextResponse } from 'next/server';
 // mongodb requires the Node.js runtime (never edge).
 export const runtime = 'nodejs';
 import { getDb } from '@/lib/mongodb';
-import { buildCoverUpdate, isRenderableCoverUrl, RENDERABLE_COVER_HOST_RE, selectFallbackCoverPage } from '@/lib/cover-fields';
+import {
+  buildCoverUpdate,
+  isRenderableCoverUrl,
+  RENDERABLE_COVER_HOST_RE,
+  selectScoredCoverPage,
+  type ThumbnailSource,
+} from '@/lib/cover-fields';
+import { selectBestCover } from '@/lib/cover-selection';
 import { mirrorBookToCatalog } from '@/lib/books-catalog';
 import { getPageSource } from '@/lib/page-image-url';
 import type { Page } from '@/lib/types';
@@ -25,6 +32,22 @@ import type { Page } from '@/lib/types';
  * `pipeline_auto.status: 'images_complete'`. This route closes the gap for any
  * book someone actually opens, without resuming paid pipeline phases.
  *
+ * HOW IT PICKS (2026-08 upgrade — the old type-priority-only rule chose
+ * blanks, library stamps, and scanner's-hand shots whenever `page_type` was
+ * missing, and passed over untagged title pages):
+ *  1. `selectScoredCoverPage` — the same OCR-content scorer as pipeline
+ *     Phase 8.9, shared with the book page's render fallback so the cover a
+ *     reader sees and the cover the catalogue stores stay the same page.
+ *  2. When the scorer can't decide (typically: OCR hasn't run yet, or nothing
+ *     in the front matter looks like a cover), ONE Gemini Vision pass over the
+ *     first pages (`selectBestCover`, ~$0.005–0.01). Guarded by an atomic
+ *     `cover_vision_attempted_at` marker so a book is only ever paid for once,
+ *     and by the `ENSURE_COVER_VISION=0` kill-switch. This only ever runs for
+ *     books someone actually opened that have no renderable cover — there is
+ *     no sweep behind it.
+ *  3. Otherwise the old type-priority pick (title page → frontispiece → first
+ *     non-junk leaf).
+ *
  * It is deliberately a *narrow* writer:
  *  - never overrides a `manual` pick, or any already-renderable cover;
  *  - only ever writes a URL derived from the book's own pages, so there is no
@@ -34,8 +57,8 @@ import type { Page } from '@/lib/types';
  *    archived to R2 gets left alone rather than having a blocked URL promoted
  *    into the catalogue, where nothing can fall back for it;
  *  - never touches `pipeline_auto.status`, so a book stays queued for Phase 8.9
- *    and its smarter OCR-scored pick still supersedes this one later (8.9 skips
- *    only `thumbnail_source: 'manual'`).
+ *    and its pick still supersedes this one later (8.9 skips only
+ *    `thumbnail_source: 'manual'`).
  */
 
 // Mirrors the book page's own query: first 100 real leaves in reading order.
@@ -58,14 +81,20 @@ const PAGE_PROJECTION = {
   thumbnail: 1,
   split_from_spread: 1,
   crop: 1,
-  // Lets `selectFallbackCoverPage` reject digitiser boilerplate and library
-  // stamps that `page_type` alone waves through. Must stay in step with the
-  // book page's projection or the two would pick different pages.
-  ocr_head: { $substrCP: [{ $ifNull: ['$ocr.data', ''] }, 0, 600] },
+  hidden: 1,
+  // Feeds both `isJunkRepresentativePage` and the cover scorer. 1200 chars is
+  // the scorer's window (`scorePageForCover`). Must stay in step with the book
+  // page's projection or the two would pick different pages.
+  ocr_head: { $substrCP: [{ $ifNull: ['$ocr.data', ''] }, 0, 1200] },
 } as const;
 
 /** The projected page shape this route reasons about. */
-type CoverCandidatePage = Partial<Page> & { page_number?: number; page_type?: string | null; ocr_head?: string | null };
+type CoverCandidatePage = Partial<Page> & {
+  page_number?: number;
+  page_type?: string | null;
+  ocr_head?: string | null;
+  hidden?: boolean;
+};
 
 type Result = { ok: boolean; reason: string; thumbnail?: string; cover_page?: number };
 
@@ -82,7 +111,7 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
 
     const book = await db.collection('books').findOne(
       { $or: [{ id }, { slug: id }] },
-      { projection: { _id: 0, id: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, thumbnail_source: 1 } },
+      { projection: { _id: 0, id: 1, title: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, thumbnail_source: 1 } },
     );
     if (!book?.id) return json({ ok: false, reason: 'book-not-found' }, 404);
 
@@ -104,8 +133,49 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
         .slice(0, PAGE_KEEP));
     if (!pages.length) return json({ ok: false, reason: 'no-pages' });
 
-    const coverPage = selectFallbackCoverPage(pages);
-    if (!coverPage) return json({ ok: false, reason: 'no-cover-page' });
+    const pick = selectScoredCoverPage(pages, book.title);
+    if (!pick) return json({ ok: false, reason: 'no-cover-page' });
+
+    let coverPage: CoverCandidatePage = pick.page;
+    let source: ThumbnailSource = pick.method === 'smart-ocr' ? 'smart_ocr' : 'page_fallback';
+    let method = pick.method === 'smart-ocr' ? 'ensure-cover-scored' : 'ensure-cover-on-view';
+    let confidence = pick.method === 'smart-ocr' ? 0.85 : 0.5;
+    let detail = pick.method === 'smart-ocr'
+      ? `page ${coverPage.page_number} — ${pick.reason} (score: ${pick.score})`
+      : `page ${coverPage.page_number} (${pick.reason}) — first-view fallback, pending Phase 8.9`;
+
+    // Text couldn't decide (no OCR yet, or nothing scored like a cover): one
+    // vision pass, at most once per book EVER. The atomic claim means two
+    // concurrent first views spend one call, and a failed call is never
+    // retried — the type-priority pick above stands until Phase 8.9.
+    if (pick.method === 'type-priority'
+        && process.env.ENSURE_COVER_VISION !== '0'
+        && process.env.GEMINI_API_KEY) {
+      const claim = await db.collection('books').updateOne(
+        { id: book.id, cover_vision_attempted_at: { $exists: false } },
+        { $set: { cover_vision_attempted_at: new Date() } },
+      );
+      if (claim.modifiedCount === 1) {
+        try {
+          const vision = await selectBestCover(db, book.id, 10, { triggered_by: 'auto_recovery' });
+          const visionPage = vision.confidence !== 'low'
+            ? pages.find(p => p.page_number === vision.pageNumber)
+            : undefined;
+          if (visionPage) {
+            coverPage = visionPage;
+            source = 'vision';
+            method = 'ensure-cover-vision';
+            confidence = vision.confidence === 'high' ? 0.9 : 0.7;
+            detail = `page ${visionPage.page_number} — ${vision.rationale}`;
+          }
+        } catch (err) {
+          // Non-fatal: the text pick stands. The claim marker stays set on
+          // purpose — a book whose images make Gemini fail once will fail the
+          // same way on every view, and each retry costs money.
+          console.warn('[ensure-cover] vision pass failed:', err instanceof Error ? err.message : err);
+        }
+      }
+    }
 
     // Verify before writing: the chosen page must resolve to an image the
     // browser can actually load. `buildCoverUpdate` resolves the same way via
@@ -117,10 +187,10 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
     }
 
     const update = buildCoverUpdate(coverPage, {
-      source: 'page_fallback',
-      method: 'ensure-cover-on-view',
-      confidence: 0.5,
-      detail: `page ${coverPage.page_number} (${coverPage.page_type || 'untyped'}) — first-view fallback, pending Phase 8.9`,
+      source,
+      method,
+      confidence,
+      detail,
       actor: 'pipeline',
     });
     if (!update) return json({ ok: false, reason: 'no-usable-page-image' });

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -25,7 +25,7 @@ import ChaptersDropdown from '@/components/book/ChaptersDropdown';
 import BookAnalytics from '@/components/book/BookAnalytics';
 import CoverImagePicker from '@/components/book/CoverImagePicker';
 import EnsureCover from '@/components/book/EnsureCover';
-import { isJunkRepresentativePage, isRenderableCoverUrl, selectFallbackCoverPage } from '@/lib/cover-fields';
+import { isJunkRepresentativePage, isRenderableCoverUrl, selectScoredCoverPage } from '@/lib/cover-fields';
 import DownloadButton from '@/components/ui/DownloadButton';
 import BibliographicInfo from '@/components/book/BibliographicInfo';
 import BphCatalogueRecord from '@/components/book/BphCatalogueRecord';
@@ -466,11 +466,13 @@ async function getBook(id: string, tenantId?: string, tenantSlug?: string): Prom
           display_brightness: 1,
           page_type: 1,
           split_from_spread: 1,
-          // First 600 chars of the OCR — the metadata envelope plus the model's
+          // First 1200 chars of the OCR — the metadata envelope plus the model's
           // page description. Enough to recognise digitiser boilerplate and
           // library/owner stamps that `page_type` misses (see
           // `isJunkRepresentativePage`), without pulling whole pages of text.
-          ocr_head: { $substrCP: [{ $ifNull: ['$ocr.data', ''] }, 0, 600] },
+          // 1200 is the cover scorer's window (`scorePageForCover`) — keep in
+          // step with ensure-cover's projection.
+          ocr_head: { $substrCP: [{ $ifNull: ['$ocr.data', ''] }, 0, 1200] },
         },
         maxTimeMS: 5000,
       })
@@ -811,12 +813,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
     // and shows the actual scan at its true dimensions.
     const storedCover = getBookThumbnailUrl(book as Parameters<typeof getBookThumbnailUrl>[0], 'display') ?? undefined;
     const coverRenderable = isRenderableCoverUrl(storedCover);
-    // Best cover-scan candidate: the actual title page, else a frontispiece,
-    // else the first non-junk page (avoids the Google/IA boilerplate, endpapers
-    // and scanner colour cards when a classified title page exists).
-    // `selectFallbackCoverPage` is shared with /api/books/[id]/ensure-cover so
-    // the page we SHOW here is the page that gets SAVED as the cover.
-    const coverPage = selectFallbackCoverPage(pages);
+    // Best cover-scan candidate: OCR-scored (same scorer as pipeline Phase
+    // 8.9 — decorated title pages and frontispieces win, blanks / stamps /
+    // scanner's-hand shots are rejected), falling back to the type-priority
+    // rule when nothing scores confidently. `selectScoredCoverPage` is shared
+    // with /api/books/[id]/ensure-cover so the page we SHOW here is the page
+    // that gets SAVED as the cover.
+    const coverPage = selectScoredCoverPage(pages, book.title)?.page;
     const coverDisplay = coverRenderable ? storedCover : (coverPage ? (getPageImageUrl(coverPage as Parameters<typeof getPageImageUrl>[0], 'display') ?? undefined) : undefined) || storedCover;
     // Printed table-of-contents page (design's "Original printed contents" card).
     const tocPage = pages.find(p => p.page_type === 'toc');

--- a/src/lib/cover-fields.ts
+++ b/src/lib/cover-fields.ts
@@ -25,6 +25,7 @@
 
 import type { Page } from './types';
 import { pageImageUrl } from './types/page';
+import { HAND_IN_FRAME_RE, scorePageForCover } from './cover-scoring';
 
 /**
  * Provenance label for the cover-selection method.
@@ -232,7 +233,8 @@ export function isJunkRepresentativePage(
   if (JUNK_COVER_PAGE_TYPES.has(String(page.page_type || ''))) return true;
   const head = String(page.ocr_head || '');
   if (!head) return false;
-  return DIGITIZER_RE.test(head) || OWNERSHIP_RE.test(head) || BINDING_RE.test(head);
+  return DIGITIZER_RE.test(head) || OWNERSHIP_RE.test(head) || BINDING_RE.test(head)
+    || HAND_IN_FRAME_RE.test(head);
 }
 
 export function selectFallbackCoverPage<T extends { page_type?: string | null; ocr_head?: string | null }>(
@@ -245,6 +247,45 @@ export function selectFallbackCoverPage<T extends { page_type?: string | null; o
     || usable.find(p => p.page_type === 'frontispiece')
     || usable[0]
     || pages[0];
+}
+
+/** A pick below this is "no confident pick" — callers fall back to the
+ *  type-priority rule or escalate to the vision selector. Matches the
+ *  pipeline's Phase 8.9 threshold in pipeline-orchestrator.mjs. */
+export const COVER_SCORE_CONFIDENT = 30;
+
+export interface ScoredCoverPick<T> {
+  page: T;
+  /** null when the pick came from the type-priority fallback, not the scorer. */
+  score: number | null;
+  reason: string;
+  method: 'smart-ocr' | 'type-priority';
+}
+
+/**
+ * The smarter shared pick: score every candidate with the same OCR-content
+ * scorer the pipeline uses (Phase 8.9), and only fall back to the
+ * type-priority rule when nothing scores confidently — which is the "no OCR
+ * yet / nothing looks like a cover" case. Both the book page's render
+ * fallback and `/api/books/[id]/ensure-cover` call this, so the cover a
+ * reader sees and the cover the catalogue stores stay the same page by
+ * construction. Callers pass pages already sorted by `page_number`, with
+ * `ocr_head` projected at 1200 chars (the scorer's window).
+ */
+export function selectScoredCoverPage<
+  T extends { page_number?: number; page_type?: string | null; ocr_head?: string | null; hidden?: boolean },
+>(pages: ReadonlyArray<T>, bookTitle?: string | null): ScoredCoverPick<T> | undefined {
+  let best: { page: T; score: number; reason: string } | null = null;
+  for (const page of pages) {
+    if (isJunkRepresentativePage(page)) continue;
+    const scored = scorePageForCover(page, { bookTitle });
+    if (!best || scored.score > best.score) best = { page, ...scored };
+  }
+  if (best && best.score >= COVER_SCORE_CONFIDENT) {
+    return { ...best, method: 'smart-ocr' };
+  }
+  const fallback = selectFallbackCoverPage(pages);
+  return fallback && { page: fallback, score: null, reason: fallback.page_type || 'untyped', method: 'type-priority' };
 }
 
 /**

--- a/src/lib/cover-scoring.ts
+++ b/src/lib/cover-scoring.ts
@@ -1,23 +1,40 @@
 /**
- * Shared cover page scoring logic.
+ * Cover page scoring — TS twin of `scripts/lib/cover-scoring.mjs`.
  *
- * Used by:
- *   - pipeline-orchestrator.mjs (Phase 3 + Phase 8.9)
- *   - smart-cover-selection.mjs (batch re-evaluation)
+ * Scores a page as a potential book cover from OCR content analysis. Used by
+ * `/api/books/[id]/ensure-cover` and the book page's render fallback so the
+ * on-view pick uses the same intelligence as pipeline Phase 8.9 instead of the
+ * crude type-priority rule (which picked blanks, library stamps, and pages
+ * with the scanner's hand in frame whenever `page_type` was missing).
  *
- * Scores a page as a potential book cover using OCR content analysis.
- * Parses <page-type> tags from OCR text when page.page_type is null.
- * Detects binding photos, digitizer inserts, bookplates (incl. BPH pelican),
- * and prefers decorated title pages with woodcuts/borders/printer's marks.
- *
- * TS twin: src/lib/cover-scoring.ts (used by ensure-cover + the book page).
- * Keep in lock-step — tests/unit/cover-scoring-parity.test.ts runs both over
- * the same fixtures and fails on divergence.
+ * Keep in lock-step with `scripts/lib/cover-scoring.mjs` — the parity test in
+ * `tests/unit/cover-scoring-parity.test.ts` runs both implementations over the
+ * same fixtures and fails on any divergence.
  */
 
-/** Scanner's hand caught in the frame. Mirror of HAND_IN_FRAME_RE in
- *  src/lib/cover-scoring.ts — deliberately narrow ("hand-colored",
- *  "handwriting", body text about hands must not match). */
+export interface CoverScoreInput {
+  page_number?: number;
+  page_type?: string | null;
+  hidden?: boolean;
+  ocr?: { data?: string | null } | null;
+  ocr_text?: string | null;
+  /** Projected head of `pages.ocr.data` (callers use `$substrCP` … 1200). */
+  ocr_head?: string | null;
+}
+
+export interface CoverScore {
+  score: number;
+  reason: string;
+}
+
+/**
+ * The scanner's own hand caught in the frame. Written the way the OCR model
+ * describes such pages ("a gloved hand is visible at the edge…"), and kept
+ * deliberately narrow: "hand-colored", "handwriting", and body text discussing
+ * hands must not match (same lesson as the DIGITIZER_RE watermark trap in
+ * cover-fields.ts). Mirrored in cover-fields.ts / cover-write.mjs /
+ * cover-scoring.mjs — change all four together.
+ */
 export const HAND_IN_FRAME_RE =
   /\b(?:human|person'?s|scanner'?s|gloved) hand\b|\bhands? (?:is |are )?(?:visible|hold(?:s|ing)|gripping|resting on|in (?:the )?frame|at the (?:edge|corner))|\bfingers? (?:is |are )?(?:visible|hold(?:s|ing)|gripping)|\bthumb (?:is |appears )?(?:visible|hold(?:s|ing)|in (?:the )?frame)/i;
 
@@ -25,24 +42,25 @@ export const HAND_IN_FRAME_RE =
  * Extract page type from <page-type> tags in OCR text.
  * Returns null if no tag found.
  */
-export function parsePageTypeFromOcr(ocrText) {
+export function parsePageTypeFromOcr(ocrText?: string | null): string | null {
   if (!ocrText) return null;
   const match = ocrText.match(/<page-type>([^<]+)<\/page-type>/);
   return match ? match[1].trim() : null;
 }
 
 /**
- * Score a page as a potential book cover.
- *
- * @param {Object} page - Page document with page_number, page_type, ocr.data, hidden
- * @param {Object} [options]
- * @param {string} [options.bookTitle] - Book title for title-match bonus
- * @returns {{ score: number, reason: string }}
+ * Score a page as a potential book cover. Higher is better; anything below 30
+ * is "no confident pick" (callers fall back or escalate to vision).
  */
-export function scorePageForCover(page, options = {}) {
+export function scorePageForCover(
+  page: CoverScoreInput,
+  options: { bookTitle?: string | null } = {},
+): CoverScore {
   const ocrRaw = page.ocr?.data || page.ocr_text || page.ocr_head || '';
   const ocr = ocrRaw.substring(0, 1200).toLowerCase();
-  const pageNum = page.page_number;
+  // NaN mirrors the mjs twin's `undefined` semantics: every position
+  // comparison is false for a page with no page_number.
+  const pageNum = page.page_number ?? NaN;
 
   // Resolve page type: explicit field → parsed from OCR tags → null
   const pageType = page.page_type || parsePageTypeFromOcr(ocrRaw);

--- a/src/lib/cover-selection.ts
+++ b/src/lib/cover-selection.ts
@@ -96,8 +96,10 @@ export async function selectBestCover(
     throw new Error(`Book not found for cover selection. Book ID: ${bookId}`);
   }
 
+  // `page_number >= 0` excludes archived spreads (negative numbers), which
+  // would otherwise sort first and crowd real leaves out of the sample.
   const pages = await db.collection('pages')
-    .find({ book_id: bookId })
+    .find({ book_id: bookId, page_number: { $gte: 0 } })
     .sort({ page_number: 1 })
     .limit(maxPages)
     .toArray();

--- a/src/lib/csp-img-hosts.ts
+++ b/src/lib/csp-img-hosts.ts
@@ -1,0 +1,98 @@
+/**
+ * Single source of truth for which image hosts the browser may load.
+ *
+ * The CSP `img-src` directive in `next.config.ts` is BUILT from this list, and
+ * `isBrowserRenderableImageUrl()` screens stored image URLs against the same
+ * list — so the two can never drift. Before this module existed they did:
+ * ~1,550 visible books carried cover URLs on hosts the CSP blocked (or that
+ * redirect off-allowlist), and every one of them rendered as a permanently
+ * blank card — the browser's load failure fires before React hydrates, so the
+ * typographic placeholder never swapped in. Readers that screen with
+ * `isBrowserRenderableImageUrl()` render the placeholder immediately instead.
+ *
+ * Entries use the CSP source syntax: `https://host` or `https://*.domain`.
+ * Adding a host here both allowlists it in the CSP and makes stored URLs on it
+ * render again — one edit, both layers (cf. the three-layer crawler gate
+ * lesson: changing one layer alone is silently defeated by the others).
+ */
+
+export const CSP_IMG_HOSTS = [
+  'https://images.sourcelibrary.org',
+  'https://*.r2.dev',
+  'https://*.public.blob.vercel-storage.com',
+  'https://*.amazonaws.com',
+  'https://iiif.archive.org',
+  'https://archive.org',
+  'https://dl.ndl.go.jp',
+  'https://gallica.bnf.fr',
+  'https://api.digitale-sammlungen.de',
+  'https://www.e-rara.ch',
+  'https://digi.vatlib.it',
+  'https://*.bodleian.ox.ac.uk',
+  'https://cudl.lib.cam.ac.uk',
+  'https://diglib.hab.de',
+  'https://iiif.hab.de',
+  'https://iiif.wellcomecollection.org',
+  'https://upload.wikimedia.org',
+  'https://*.loc.gov',
+  'https://babel.hathitrust.org',
+  'https://bl.digirati.io',
+  'https://images.lib.cam.ac.uk',
+  'https://www.e-codices.unifr.ch',
+  'https://cdm21059.contentdm.oclc.org',
+  'https://iiif.universiteitleiden.nl',
+  'https://image.digitalcollections.manchester.ac.uk',
+  'https://digi.ub.uni-heidelberg.de',
+  'https://iiif.qdl.qa',
+  'https://permalinkbnd.bnportugal.gov.pt',
+  'https://cdli.earth',
+  'https://images.uba.uva.nl',
+  'https://imagenes.patrimonionacional.es',
+  'https://images.eap.bl.uk',
+  'https://*.basemaps.cartocdn.com',
+  // Library IIIF hosts that hold live cover URLs for visible books but were
+  // missing from the CSP (measured 2026-08-04: ~570 blank cards between them).
+  'https://mps.lib.harvard.edu',
+  'https://digital.slub-dresden.de',
+  'https://iiif-images.library.upenn.edu',
+  'https://content.staatsbibliothek-berlin.de',
+  'https://images.sub.uni-goettingen.de',
+] as const;
+
+/** The full img-src directive value, consumed by next.config.ts. */
+export const CSP_IMG_SRC = `img-src 'self' data: blob: ${CSP_IMG_HOSTS.join(' ')}`;
+
+const EXACT_HOSTS = new Set<string>();
+const WILDCARD_SUFFIXES: string[] = [];
+for (const entry of CSP_IMG_HOSTS) {
+  const host = entry.replace(/^https:\/\//, '');
+  if (host.startsWith('*.')) WILDCARD_SUFFIXES.push(host.slice(1)); // keep leading '.'
+  else EXACT_HOSTS.add(host);
+}
+
+/**
+ * Can the BROWSER actually display this image URL?
+ *
+ * True only for https URLs whose host the CSP `img-src` allows. One deliberate
+ * exception: `archive.org/download/...` is on an allowlisted host but 302s to
+ * `ia*.us.archive.org`, which is not — the browser follows the redirect and
+ * blocks the final load, so those URLs must be treated as non-renderable even
+ * though a server-side fetch of them succeeds (a fetch success is a claim about
+ * the server's view, not the browser's).
+ *
+ * Note the dot-anchored wildcard match: `evil-r2.dev` must not pass `*.r2.dev`
+ * (cf. the #3508 suffix-match lesson).
+ */
+export function isBrowserRenderableImageUrl(url?: string | null): boolean {
+  const trimmed = String(url || '').trim();
+  if (!trimmed.startsWith('https://')) return false;
+  let host: string;
+  try {
+    host = new URL(trimmed).hostname;
+  } catch {
+    return false;
+  }
+  if (host === 'archive.org' && new URL(trimmed).pathname.startsWith('/download/')) return false;
+  if (EXACT_HOSTS.has(host)) return true;
+  return WILDCARD_SUFFIXES.some(suffix => host.endsWith(suffix));
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { getPageSource, getPageImageUrl as resolvePageImage } from '@/lib/page-image-url';
+import { isBrowserRenderableImageUrl } from '@/lib/csp-img-hosts';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -71,10 +72,19 @@ export function getBookThumbnailUrl(
   const artworkSource = (book.image_display?.includes('/artwork/') && book.image_display)
     || (book.thumbnail?.includes('/artwork/') && book.thumbnail)
     || null;
-  const raw = size === 'display'
+  let raw = size === 'display'
     ? (book.image_display || book.thumbnail || book.thumbnail_blob || null)
     : (artworkSource || book.image_thumb || book.thumbnail_blob || book.thumbnail || null);
   if (!raw) return null;
+  raw = raw.trim(); // a handful of stored covers carry trailing whitespace
+
+  // A stored cover the browser cannot load must read as "no cover", so cards
+  // render the typographic placeholder instead of an <Image> stuck in its
+  // shimmer state forever (the CSP block fires before React hydrates, so the
+  // onError → placeholder swap never happens). Screens against the same host
+  // list the CSP img-src is built from; notably rejects `archive.org/download/`
+  // URLs, which 302 to un-allowlisted `ia*.us.archive.org` hosts.
+  if (raw.startsWith('http') && !isBrowserRenderableImageUrl(raw)) return null;
 
   // Wikimedia Commons images: serve the upload.wikimedia.org CDN URL as-is.
   // We must NOT rewrite to commons.wikimedia.org/w/thumb.php — the site CSP

--- a/tests/unit/cover-fields.test.ts
+++ b/tests/unit/cover-fields.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCoverUpdate, resolvePageCoverUrl, COVER_WRITE_FIELDS, isRenderableCoverUrl, selectFallbackCoverPage, isJunkRepresentativePage } from '@/lib/cover-fields';
+import { buildCoverUpdate, resolvePageCoverUrl, COVER_WRITE_FIELDS, isRenderableCoverUrl, selectFallbackCoverPage, selectScoredCoverPage, isJunkRepresentativePage, COVER_SCORE_CONFIDENT } from '@/lib/cover-fields';
 
 const SAMPLE_URL = 'https://images.sourcelibrary.org/cropped/abc/page-1.jpg';
 const SAMPLE_THUMB = 'https://images.sourcelibrary.org/thumbnails/abc/page-1-thumb.jpg';
@@ -223,5 +223,62 @@ describe('selectFallbackCoverPage — digitiser plates', () => {
       { page_number: 9, page_type: 'text', ocr_head: 'the argument of the present treatise' },
     ];
     expect(selectFallbackCoverPage(pages)?.page_number).toBe(9);
+  });
+});
+
+describe('isJunkRepresentativePage — scanner hand in frame', () => {
+  it('rejects pages whose OCR describes a hand holding the book', () => {
+    for (const head of [
+      'A gloved hand is visible at the bottom edge of the page',
+      "The scanner's hand holding the volume open",
+      'fingers are visible along the left margin of the photograph',
+    ]) {
+      expect(isJunkRepresentativePage({ page_type: 'text', ocr_head: head })).toBe(true);
+    }
+  });
+
+  it('keeps hand-colored plates and handwriting notes', () => {
+    expect(isJunkRepresentativePage({ page_type: 'plate', ocr_head: 'A hand-colored woodcut of the celestial spheres' })).toBe(false);
+    expect(isJunkRepresentativePage({ page_type: 'text', ocr_head: 'Handwriting in the lower margin records a former owner' })).toBe(false);
+  });
+});
+
+describe('selectScoredCoverPage', () => {
+  it('uses the OCR scorer when it can decide: a real title page beats an earlier first leaf', () => {
+    const pages = [
+      { page_number: 1, ocr_head: 'Some faint unclassified text.' },
+      { page_number: 3, page_type: 'title-page', ocr_head: 'DE PROVIDENTIA ET FATO typis excudebat, ornamental border' },
+    ];
+    const pick = selectScoredCoverPage(pages, 'De providentia et fato');
+    expect(pick?.page.page_number).toBe(3);
+    expect(pick?.method).toBe('smart-ocr');
+    expect(pick?.score).toBeGreaterThanOrEqual(COVER_SCORE_CONFIDENT);
+  });
+
+  it('never scores a hand-in-frame or blank page as the cover', () => {
+    const pages = [
+      { page_number: 1, ocr_head: 'A gloved hand is visible at the edge, holding the book' },
+      { page_number: 2, ocr_head: 'This page is blank, aged paper.' },
+      { page_number: 4, page_type: 'frontispiece', ocr_head: 'An allegorical engraved portrait of the author' },
+    ];
+    const pick = selectScoredCoverPage(pages);
+    expect(pick?.page.page_number).toBe(4);
+    expect(pick?.method).toBe('smart-ocr');
+  });
+
+  it('falls back to the type-priority rule when nothing scores confidently (no OCR yet)', () => {
+    // A typed title page still clears the bar without OCR — the genuinely
+    // undecidable case is NO types and NO OCR.
+    const typed = selectScoredCoverPage([{ page_number: 1 }, { page_number: 2, page_type: 'title-page' }]);
+    expect(typed?.page.page_number).toBe(2);
+
+    const untyped = selectScoredCoverPage([{ page_number: 1 }, { page_number: 2 }]);
+    expect(untyped?.method).toBe('type-priority');
+    expect(untyped?.page.page_number).toBe(1);
+    expect(untyped?.score).toBeNull();
+  });
+
+  it('returns undefined on an empty page list', () => {
+    expect(selectScoredCoverPage([])).toBeUndefined();
   });
 });

--- a/tests/unit/cover-scoring-parity.test.ts
+++ b/tests/unit/cover-scoring-parity.test.ts
@@ -1,0 +1,130 @@
+/**
+ * PARITY — src/lib/cover-scoring.ts (ensure-cover + book page render fallback)
+ * vs scripts/lib/cover-scoring.mjs (pipeline Phase 3 / 8.9, batch scripts).
+ *
+ * Runs BOTH implementations over the same fixtures and fails on any
+ * divergence, so "keep in lock-step" is enforced rather than hoped. This is a
+ * behavioral guard, not a source-shape one: it executes both scorers.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  scorePageForCover as scoreTs,
+  parsePageTypeFromOcr as parseTs,
+  HAND_IN_FRAME_RE as handTs,
+} from '@/lib/cover-scoring';
+import {
+  scorePageForCover as scoreMjs,
+  parsePageTypeFromOcr as parseMjs,
+  HAND_IN_FRAME_RE as handMjs,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore — plain-JS module, no declarations
+} from '../../scripts/lib/cover-scoring.mjs';
+
+type Fixture = { name: string; page: Record<string, unknown>; title?: string };
+
+const FIXTURES: Fixture[] = [
+  {
+    name: 'decorated title page with imprint and title match',
+    title: 'Atalanta Fugiens Emblemata Nova',
+    page: {
+      page_number: 3,
+      page_type: 'title-page',
+      ocr: { data: '# ATALANTA FUGIENS\n## Emblemata Nova\nTypis Hieronymi Galleri, decorative woodcut border, atalanta fugiens emblemata' },
+    },
+  },
+  {
+    name: 'untyped page that looks like a title page (heading density)',
+    page: { page_number: 2, ocr: { data: '# TITLE\n# AUTHOR\n# CITY\nprinted by John Day' } },
+  },
+  {
+    name: 'blank page recognized from OCR content',
+    page: { page_number: 1, ocr: { data: 'This page is blank, aged paper with no printed content.' } },
+  },
+  {
+    name: 'scanner hand in frame',
+    page: { page_number: 1, ocr: { data: 'A gloved hand is visible at the bottom edge, holding the volume open.' } },
+  },
+  {
+    name: 'digitizer insert',
+    page: { page_number: 1, ocr: { data: 'Digitized by the Internet Archive in 2010 with funding from Microsoft Corporation' } },
+  },
+  {
+    name: 'ex-libris bookplate',
+    page: { page_number: 2, ocr: { data: 'Ex libris plate of the University Library, with an accession stamp.' } },
+  },
+  {
+    name: 'frontispiece with engraving',
+    page: { page_number: 1, page_type: 'frontispiece', ocr: { data: 'An allegorical engraved portrait of the author within an oval frame.' } },
+  },
+  {
+    name: 'binding photo mislabeled as frontispiece',
+    page: { page_number: 1, page_type: 'frontispiece', ocr: { data: 'Photograph of the leather cover and binding of the volume.' } },
+  },
+  { name: 'hidden page', page: { page_number: 1, page_type: 'title-page', hidden: true } },
+  { name: 'no OCR, no type, no page number', page: {} },
+  {
+    name: 'page type parsed from OCR tag',
+    page: { page_number: 4, ocr: { data: '<page-type>frontispiece</page-type>\nAn emblem engraving.' } },
+  },
+  {
+    name: 'ocr_head projection instead of full ocr.data',
+    page: { page_number: 3, page_type: 'title-page', ocr_head: 'DE PROVIDENTIA ET FATO, typis excudebat, ornamental border' },
+  },
+  { name: 'deep interior text page', page: { page_number: 40, page_type: 'text', ocr: { data: 'Caput primum. De rerum natura.' } } },
+];
+
+describe('cover scorer TS/mjs parity', () => {
+  for (const f of FIXTURES) {
+    it(`agrees on: ${f.name}`, () => {
+      const ts = scoreTs(f.page as never, { bookTitle: f.title });
+      const mjs = scoreMjs(f.page, { bookTitle: f.title });
+      expect(ts).toEqual(mjs);
+    });
+  }
+
+  it('agrees on parsePageTypeFromOcr', () => {
+    for (const text of ['<page-type>title-page</page-type>', 'no tag here', '', null]) {
+      expect(parseTs(text)).toEqual(parseMjs(text));
+    }
+  });
+
+  it('exports an identical hand-in-frame pattern', () => {
+    expect(handTs.source).toBe(handMjs.source);
+    expect(handTs.flags).toBe(handMjs.flags);
+  });
+});
+
+describe('scoring behavior (pins the failure classes ensure-cover shipped with)', () => {
+  it('rejects the scanner-hand page outright', () => {
+    expect(scoreTs({ page_number: 1, ocr_head: 'A gloved hand is visible at the edge' })).toEqual({ score: -75, reason: 'hand in frame' });
+  });
+
+  it('prefers a scored title page over an earlier plain page', () => {
+    const titlePage = scoreTs({ page_number: 3, page_type: 'title-page', ocr_head: 'TITLE typis apud decorative border' });
+    const firstLeaf = scoreTs({ page_number: 1, ocr_head: 'Some faint text.' });
+    expect(titlePage.score).toBeGreaterThan(30);
+    expect(titlePage.score).toBeGreaterThan(firstLeaf.score);
+  });
+
+  it('does not flag hand-colored / handwriting language as a hand in frame', () => {
+    for (const text of [
+      'A hand-colored woodcut of the zodiac',
+      'Handwriting in the lower margin',
+      'On the other hand, the author argues',
+      'the hand of God depicted in the engraving',
+    ]) {
+      expect(handTs.test(text)).toBe(false);
+    }
+  });
+
+  it('flags real hand-in-frame descriptions', () => {
+    for (const text of [
+      "The scanner's hand is visible at the corner",
+      'A gloved hand holding the page flat',
+      'fingers are visible at the bottom of the frame',
+      'a thumb is visible on the left edge',
+    ]) {
+      expect(handTs.test(text)).toBe(true);
+    }
+  });
+});

--- a/tests/unit/csp-image-hosts.test.ts
+++ b/tests/unit/csp-image-hosts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'fs';
 import path from 'path';
+import { CSP_IMG_HOSTS, CSP_IMG_SRC, isBrowserRenderableImageUrl } from '@/lib/csp-img-hosts';
 
 /**
  * Guards against a class of silent image breakage discovered in PR #2187:
@@ -29,14 +30,15 @@ function toMatcher(host: string): { wildcard: boolean; value: string } {
   return { wildcard: false, value: stripped };
 }
 
-/** Extract the host tokens from the CSP `img-src` directive. */
+/**
+ * The CSP img-src host tokens. Since PR (2026-08) the directive is BUILT from
+ * `src/lib/csp-img-hosts.ts` (shared with getBookThumbnailUrl's renderability
+ * screen), so the module IS the directive — but keep one assertion that
+ * next.config.ts actually consumes it, or this whole suite silently guards a
+ * list the config no longer reads.
+ */
 function parseImgSrcHosts(): string[] {
-  const m = NEXT_CONFIG.match(/"img-src ([^"]+)"/);
-  if (!m) throw new Error('Could not find CSP img-src directive in next.config.ts');
-  return m[1]
-    .split(/\s+/)
-    .filter((t) => t.startsWith('https://'))
-    .map((t) => t.replace(/^https:\/\//, ''));
+  return CSP_IMG_HOSTS.map((t) => t.replace(/^https:\/\//, ''));
 }
 
 /** Extract every hostname from `images.remotePatterns`. */
@@ -60,9 +62,14 @@ describe('CSP img-src / Next image allowlist consistency', () => {
   const imgSrc = parseImgSrcHosts().map(toMatcher);
   const remoteHosts = parseRemotePatternHosts();
 
-  it('finds both allowlists in next.config.ts', () => {
+  it('finds both allowlists', () => {
     expect(imgSrc.length).toBeGreaterThan(5);
     expect(remoteHosts.length).toBeGreaterThan(5);
+  });
+
+  it('next.config.ts builds its img-src from the shared module', () => {
+    expect(NEXT_CONFIG).toContain("from './src/lib/csp-img-hosts'");
+    expect(NEXT_CONFIG).toContain('CSP_IMG_SRC,');
   });
 
   it.each(remoteHosts)('remotePatterns host %s is allowed by CSP img-src', (host) => {
@@ -76,9 +83,8 @@ describe('CSP img-src / Next image allowlist consistency', () => {
 
 describe('Wikimedia image host regression (PR #2187)', () => {
   it('CSP img-src whitelists upload.wikimedia.org, not commons.wikimedia.org', () => {
-    const imgSrcLine = NEXT_CONFIG.match(/"img-src ([^"]+)"/)![1];
-    expect(imgSrcLine).toContain('upload.wikimedia.org');
-    expect(imgSrcLine).not.toContain('commons.wikimedia.org');
+    expect(CSP_IMG_SRC).toContain('upload.wikimedia.org');
+    expect(CSP_IMG_SRC).not.toContain('commons.wikimedia.org');
   });
 
   it('no source file builds a commons.wikimedia.org image URL', () => {
@@ -108,5 +114,51 @@ describe('Wikimedia image host regression (PR #2187)', () => {
         `Resolve Wikimedia images to upload.wikimedia.org instead (see src/lib/wikidata-enrichment.ts):\n` +
         offenders.join('\n'),
     ).toEqual([]);
+  });
+});
+
+describe('isBrowserRenderableImageUrl', () => {
+  it('accepts hosts on the CSP allowlist', () => {
+    expect(isBrowserRenderableImageUrl('https://images.sourcelibrary.org/pages/abc/0001.jpg')).toBe(true);
+    expect(isBrowserRenderableImageUrl('https://iiif.archive.org/iiif/x/full/full/0/default.jpg')).toBe(true);
+    expect(isBrowserRenderableImageUrl('https://upload.wikimedia.org/wikipedia/commons/a/ab/x.jpg')).toBe(true);
+    // Hosts added 2026-08-04 (they held live covers but were CSP-blocked)
+    expect(isBrowserRenderableImageUrl('https://mps.lib.harvard.edu/sds/view/1.jpg')).toBe(true);
+    expect(isBrowserRenderableImageUrl('https://digital.slub-dresden.de/data/x.jpg')).toBe(true);
+  });
+
+  it('matches wildcards on a dot boundary only (no suffix spoofing)', () => {
+    expect(isBrowserRenderableImageUrl('https://iiif.bodleian.ox.ac.uk/iiif/x.jpg')).toBe(true);
+    expect(isBrowserRenderableImageUrl('https://pub-123.r2.dev/x.jpg')).toBe(true);
+    expect(isBrowserRenderableImageUrl('https://evil-r2.dev/x.jpg')).toBe(false);
+    expect(isBrowserRenderableImageUrl('https://notamazonaws.com/x.jpg')).toBe(false);
+  });
+
+  it('rejects archive.org/download/ — allowlisted host, but it 302s to un-allowlisted ia*.us.archive.org', () => {
+    expect(isBrowserRenderableImageUrl('https://archive.org/download/some_item/page/n0/full/pct:15/0/default.jpg')).toBe(false);
+    // Other archive.org paths do not redirect off-host
+    expect(isBrowserRenderableImageUrl('https://archive.org/services/img/some_item')).toBe(true);
+  });
+
+  it('rejects non-https, unknown hosts, junk, and empties', () => {
+    expect(isBrowserRenderableImageUrl('http://images.sourcelibrary.org/x.jpg')).toBe(false);
+    expect(isBrowserRenderableImageUrl('https://example.com/x.jpg')).toBe(false);
+    expect(isBrowserRenderableImageUrl('not a url')).toBe(false);
+    expect(isBrowserRenderableImageUrl('')).toBe(false);
+    expect(isBrowserRenderableImageUrl(null)).toBe(false);
+    expect(isBrowserRenderableImageUrl(undefined)).toBe(false);
+  });
+
+  it('tolerates stray whitespace around stored URLs', () => {
+    expect(isBrowserRenderableImageUrl(' https://images.sourcelibrary.org/x.jpg\n')).toBe(true);
+  });
+});
+
+describe('CSP_IMG_SRC', () => {
+  it('is a complete img-src directive built from the host list', () => {
+    expect(CSP_IMG_SRC.startsWith("img-src 'self' data: blob: ")).toBe(true);
+    for (const host of CSP_IMG_HOSTS) {
+      expect(CSP_IMG_SRC).toContain(host);
+    }
   });
 });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -248,3 +248,28 @@ describe('getCoverImageCandidates', () => {
     expect(c[0]).toContain('-thumb.jpg');
   });
 });
+
+describe('getBookThumbnailUrl — browser-renderability screen', () => {
+  // A stored cover the browser cannot load must read as "no cover" (null), so
+  // cards render the typographic placeholder instead of an <Image> stuck in
+  // its shimmer state (the pre-hydration CSP block means onError never runs).
+  it('returns null for archive.org/download covers (302s off the CSP allowlist)', () => {
+    const book = { thumbnail: 'https://archive.org/download/some_item/page/n0/full/pct:15/0/default.jpg' };
+    expect(getBookThumbnailUrl(book, 'display')).toBeNull();
+    expect(getBookThumbnailUrl(book, 'thumb')).toBeNull();
+  });
+
+  it('returns null for hosts absent from the CSP img-src allowlist', () => {
+    expect(getBookThumbnailUrl({ thumbnail: 'https://example.com/cover.jpg' }, 'display')).toBeNull();
+  });
+
+  it('keeps covers on newly-allowlisted library hosts', () => {
+    const url = 'https://mps.lib.harvard.edu/sds/view/12345?width=400';
+    expect(getBookThumbnailUrl({ thumbnail: url }, 'display')).toBe(url);
+  });
+
+  it('trims stray whitespace from stored cover URLs', () => {
+    const book = { thumbnail: 'https://images.sourcelibrary.org/pages/abc/0001.jpg\n' };
+    expect(getBookThumbnailUrl(book, 'display')).toBe('https://images.sourcelibrary.org/pages/abc/0001.jpg');
+  });
+});


### PR DESCRIPTION
## What

Fixes two reader-visible cover problems reported 2026-08-04: card grids showing permanently blank beige covers, and `/api/books/[id]/ensure-cover` persisting bad picks (blanks, library stamps, scanner's-hand shots, missed title pages).

### 1. Blank cards → typographic placeholder (and ~570 real covers restored)

~1,550 visible books store cover URLs the browser can never load:
- 861 × `archive.org/download/…` — the host is CSP-allowlisted, but these URLs 302 to `ia*.us.archive.org`, which isn't; the browser blocks the redirected load *before hydration*, so the card's `onError → placeholder` swap never fires and the shimmer state is permanent.
- ~570 on library hosts absent from the CSP entirely (Harvard 301, SLUB Dresden 259, UPenn 7, Staatsbibliothek Berlin 3, Göttingen 2, iiif.hab.de 1).
- 3 with trailing whitespace in the URL; 112 with none at all.

Fix: the CSP `img-src` host list moves to `src/lib/csp-img-hosts.ts`; `next.config.ts` builds the directive from it, and `getBookThumbnailUrl()` screens stored URLs against the same list — non-renderable → `null` → `BookCoverPlaceholder` renders server-side. The missing library hosts are added to the allowlist, so those ~570 covers start actually rendering. Wildcards match on a dot boundary (no `evil-r2.dev` suffix spoofing).

### 2. ensure-cover picks with the real scorer

The route (and the book page's render fallback) used only the type-priority rule (`title-page → frontispiece → first non-junk leaf`), which collapses to "page 1, whatever it is" on books without `page_type`/OCR. Both now share `selectScoredCoverPage()` — the same OCR-content scorer as pipeline Phase 8.9, via a new TS twin `src/lib/cover-scoring.ts` parity-pinned to `scripts/lib/cover-scoring.mjs` (the parity test executes both implementations; verified red under a deliberate one-sided change). Both projections widen `ocr_head` 600 → 1200 chars (the scorer's window). A narrow hand-in-frame screen is added to the scorer and junk filter on both sides ("hand-colored", "handwriting", prose about hands don't match).

### 3. One vision pass when text can't decide

When the best text score is below threshold (typically: OCR hasn't run), ensure-cover runs the existing `selectBestCover()` Gemini Vision selector once — guarded by an atomic `cover_vision_attempted_at` claim (at most one paid call per book, ever, ~\$0.005–0.01, logged via `logGeminiCall`), an `ENSURE_COVER_VISION=0` kill-switch, and discard of low-confidence answers. **No sweep** — this only fires for books someone actually opens that have no renderable cover, so cost accrues per-book-opened, not per-corpus. Also fixed `selectBestCover` to exclude negative-numbered archived spreads from its sample.

## Out of scope (deliberately)

- No repair sweep over existing bad `pipeline-auto`/`page_fallback` picks (user chose free-now/on-view-only; provenance fields make a later sweep easy to target).
- Existing frozen covers on already-renderable hosts are untouched — ensure-cover still never overrides a renderable or manual cover.

## Verification

- 1,807 unit tests pass; `tsc --noEmit` clean; `next dev` boots with the config's new TS import.
- Parity guard negative-control: mutated the mjs scorer → test went red → restored → green.
- Data measured from prod Mongo (host distribution of visible books' effective cover URL) — both screenshot books (`al-itqan-…`, `de-providentia-fato-1655-hierocles`) have R2-archived scans and a tagged title page, so they self-heal on first open under the new route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)