### PR TITLE
fix(gallery): a filtered view must not render the previous filter's results (#3605)

### DIFF
--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -9,6 +9,7 @@ import {
   SlidersHorizontal, Loader2, ImagePlus, AlertCircle
 } from 'lucide-react';
 import LikeButton from '@/components/ui/LikeButton';
+import { canLoadMore } from '@/lib/gallery-pagination';
 import { useIdentity } from '@/hooks/useIdentity';
 import { BookLoader } from '@/components/ui/BookLoader';
 import FeaturedCollections from '@/components/gallery/FeaturedCollections';
@@ -122,6 +123,8 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   const [currentOffset, setCurrentOffset] = useState(initialData.items.length);
   const [showFilters, setShowFilters] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
+  // Monotonic id of the newest filter fetch — see the fetch effect below.
+  const fetchSeqRef = useRef(0);
 
   // Search state
   const [bookSearchQuery, setBookSearchQuery] = useState('');
@@ -185,6 +188,19 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
     }
     if (isInitialLoad) setIsInitialLoad(false);
 
+    // Drop the previous filter's results the moment the filter set changes.
+    // Keeping them meant a zero-result filter rendered "No images found"
+    // alongside leftover items and a live "Load more" from the old query
+    // (#3605) — two inconsistent pieces of state in one view.
+    setAllItems([]);
+    setCurrentOffset(0);
+
+    // Only the newest request may write state. Two fetches overlap routinely
+    // here (the identity id resolves after mount and re-runs this effect), and
+    // an older one resolving last used to restore the previous filter's items
+    // over the current filter's empty result.
+    const requestId = ++fetchSeqRef.current;
+
     const fetchGallery = async () => {
       setLoading(true);
       setError(null);
@@ -205,6 +221,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
           source: sourceFilter !== 'all' ? (sourceFilter as 'illustration' | 'artwork') : undefined,
           visitorId: identity.id || undefined,
         });
+        if (requestId !== fetchSeqRef.current) return;
         setData(json);
         setAllItems(json.items);
         // Paginate by page boundary, NOT cumulative item count. The merged
@@ -216,9 +233,10 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
         // appeared to do nothing.
         setCurrentOffset(limit);
       } catch (e) {
+        if (requestId !== fetchSeqRef.current) return;
         setError(e instanceof Error ? e.message : 'Failed to load gallery');
       } finally {
-        setLoading(false);
+        if (requestId === fetchSeqRef.current) setLoading(false);
       }
     };
 
@@ -228,7 +246,10 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
 
   // Load more handler — appends next batch to accumulated items
   const handleLoadMore = useCallback(async () => {
-    if (loadingMore || !data) return;
+    // Guard on the in-flight flag only. The old `|| !data` early-out returned
+    // silently and issued no request at all, which the reader experiences as a
+    // dead button (#3605); `data` is not an input to the request anyway.
+    if (loadingMore) return;
     setLoadingMore(true);
     try {
       const json = await gallery.list({
@@ -256,16 +277,18 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
         return [...prev, ...fresh];
       });
       setCurrentOffset(prev => prev + limit);
-      // Keep filters/total from the response
-      if (json.total) {
-        setData(prev => prev ? { ...prev, total: json.total } : json);
-      }
+      // Carry the response's own total AND hasMore forward. Trusting only the
+      // stale total left the button live after a page that returned nothing,
+      // so it kept fetching empty pages and appearing dead.
+      setData(prev => prev
+        ? { ...prev, total: json.total ?? prev.total, hasMore: json.hasMore }
+        : json);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load more images');
     } finally {
       setLoadingMore(false);
     }
-  }, [loadingMore, data, currentOffset, bookId, collectionFilter, libraryFilter, imageSearchQuery, typeFilter, subjectFilter, iconclassFilter, yearStart, yearEnd, qualityParam, identity.id, limit, sourceFilter]);
+  }, [loadingMore, currentOffset, bookId, collectionFilter, libraryFilter, imageSearchQuery, typeFilter, subjectFilter, iconclassFilter, yearStart, yearEnd, qualityParam, identity.id, limit, sourceFilter]);
 
   // Book search with debounce
   useEffect(() => {
@@ -305,8 +328,10 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  // Prefer the server's reliable hasMore flag; fall back to total-vs-offset.
-  const hasMore = data ? (data.hasMore ?? currentOffset < data.total) : false;
+  // Prefer the server's reliable hasMore flag; fall back to total-vs-offset,
+  // and never offer to extend an empty result set — a "Load more" button
+  // rendered next to "No images found" is never right (#3605).
+  const hasMore = canLoadMore(data, allItems.length, currentOffset);
 
   const handleBookSelect = (book: BookSearchResult) => {
     setBookSearchQuery('');
@@ -341,6 +366,17 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
 
   const hasFilters = bookId || collectionFilter || typeFilter || subjectFilter || libraryFilter || imageSearchQuery;
   const showCollections = !hasFilters;
+
+  // Every filter that narrows the query — including the ones `hasFilters`
+  // ignores, since any of them can be the reason a view came back empty
+  // (a hand-typed or shared `?type=` value that matches no facet, say).
+  const hasActiveFilters = Boolean(
+    hasFilters || iconclassFilter || yearStart || yearEnd || qualityParam || includeArchive || sourceFilter !== 'all'
+  );
+
+  const clearAllFilters = useCallback(() => {
+    router.push(`${tenantPrefix}/gallery`);
+  }, [router, tenantPrefix]);
 
   return (
     <>
@@ -668,8 +704,19 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
             <ImageIcon className="w-16 h-16 text-stone-300 mx-auto mb-4" />
             <p className="text-stone-500 mb-2">No images found</p>
             <p className="text-stone-400 text-sm">
-              Try a different search or browse all images
+              {hasActiveFilters
+                ? 'No images match these filters.'
+                : 'Try a different search or browse all images'}
             </p>
+            {hasActiveFilters && (
+              <button
+                onClick={clearAllFilters}
+                className="mt-5 inline-flex items-center gap-2 px-5 py-2.5 bg-white border border-stone-300 text-stone-700 rounded-full text-sm font-medium hover:bg-stone-50 hover:border-stone-400 transition-colors shadow-sm"
+              >
+                <X className="w-4 h-4" />
+                Clear filters
+              </button>
+            )}
           </div>
         )}
 

--- a/src/lib/gallery-pagination.ts
+++ b/src/lib/gallery-pagination.ts
@@ -1,0 +1,33 @@
+/**
+ * Gallery "Load more" visibility.
+ *
+ * Extracted from GalleryClient so the rule is testable without a DOM. #3605:
+ * `/gallery?type=artwork` (a filter value no facet matches, reachable from a
+ * shared or hand-typed link) rendered "No images found", leftover items from
+ * the previous unfiltered query, and a live "Load more" button all at once —
+ * the button read `hasMore` from a response the visible results no longer came
+ * from, and clicking it appended nothing.
+ *
+ * The item count is part of the decision, not a detail: with nothing on
+ * screen there is nothing to load *more* of, whatever the last response said.
+ */
+
+export interface GalleryPaginationState {
+  /** The server's own flag. Authoritative when present. */
+  hasMore?: boolean | null;
+  /** Total matches for the current filter set. */
+  total?: number | null;
+}
+
+export function canLoadMore(
+  state: GalleryPaginationState | null | undefined,
+  itemCount: number,
+  currentOffset: number,
+): boolean {
+  if (!state) return false;
+  // Never offer to extend an empty result set.
+  if (itemCount <= 0) return false;
+  // Prefer the server's reliable flag; fall back to total-vs-offset.
+  if (typeof state.hasMore === 'boolean') return state.hasMore;
+  return currentOffset < (state.total ?? 0);
+}

--- a/tests/unit/gallery-pagination.test.ts
+++ b/tests/unit/gallery-pagination.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { canLoadMore } from '@/lib/gallery-pagination';
+
+describe('canLoadMore', () => {
+  it('offers more when the server says there is more', () => {
+    expect(canLoadMore({ hasMore: true, total: 14681 }, 48, 48)).toBe(true);
+  });
+
+  it('stops when the server says there is no more', () => {
+    expect(canLoadMore({ hasMore: false, total: 36 }, 36, 48)).toBe(false);
+  });
+
+  // #3605: /gallery?type=artwork returns total=0, but the component could still
+  // be holding a hasMore:true response from the previous, unfiltered query.
+  // With zero items rendered, "Load more" must not appear next to the
+  // "No images found" message — clicking it can only ever be a no-op.
+  it('never offers more when nothing is rendered, even on a stale hasMore', () => {
+    expect(canLoadMore({ hasMore: true, total: 14681 }, 0, 48)).toBe(false);
+  });
+
+  it('never offers more for a genuinely empty filter result', () => {
+    expect(canLoadMore({ hasMore: false, total: 0 }, 0, 0)).toBe(false);
+  });
+
+  it('falls back to offset-vs-total when the server omits hasMore', () => {
+    expect(canLoadMore({ total: 100 }, 48, 48)).toBe(true);
+    expect(canLoadMore({ total: 48 }, 48, 48)).toBe(false);
+  });
+
+  it('treats a missing total as exhausted rather than infinite', () => {
+    expect(canLoadMore({}, 48, 48)).toBe(false);
+  });
+
+  it('offers nothing before the first response', () => {
+    expect(canLoadMore(null, 0, 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3605.

## The bug

`https://sourcelibrary.org/gallery?type=artwork` renders three contradictory things at once: "No images found", leftover items from the *unfiltered* query, and a live "Load more" button that issues no network request when clicked.

`artwork` is not a valid `type` facet — the API's own facet list is `alchemical, chart, decorative, diagram, emblem, engraving, frontispiece, illustration, map, musical score, musical_score, portrait, symbol, table, woodcut`, and `/api/gallery?type=artwork` correctly returns `total=0 hasMore=false`. The server is right; the client was holding two inconsistent pieces of state. `?type=artwork` is not producible by the UI's own controls (`type` and `source` are separate params), but it is reachable by URL and is a shared/bookmarked-link shape — and the state path is not specific to that one filter.

## Changes

- **Clear results on filter change.** `allItems`/`currentOffset` are reset synchronously when the filter set changes, so a zero-result filter cannot render leftovers.
- **Ignore stale responses.** A monotonic request id gates every state write. Two fetches overlap routinely here — `identity.id` resolves after mount and re-runs the effect — and an older one resolving last restored the previous filter's items over the current filter's empty result. This is the most likely path to the reported triple-render.
- **`handleLoadMore` no longer no-ops silently.** The `|| !data` early-out returned without issuing a request, which is exactly what the reader experiences as a dead button. `data` is not an input to the request.
- **"Load more" is never offered for an empty result set**, and the response's own `hasMore` is carried forward on append, so a page that returns nothing retires the button instead of leaving it live.
- **Empty state gets a "Clear filters" button** when any filter is active, so arriving on a filter that matches nothing is not a dead end.

## The test

The visibility rule moved to `canLoadMore()` in `src/lib/gallery-pagination.ts` so it can be exercised — the unit suite is node-env with no jsdom, so a rendering test wasn't available and a source-grep guard would not be a guard. Per the CLAUDE.md rule, it was **negative-controlled**: deleting the item-count check makes `tests/unit/gallery-pagination.test.ts` fail (1 failed / 6 passed), and restoring it makes it pass.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 134 files / 1814 tests pass
- `eslint` on changed files — 0 errors (one pre-existing unused-import warning)

## Out of scope

The server component only pre-filters on `bookId`, so SSR for any *other* filtered URL still paints unfiltered items before hydration corrects them. That's a first-paint flash and a crawler-content concern, not the reported state inconsistency — worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)