### PR TITLE
feat(give): a one-screen ask, in the header, that carries the amount

### DIFF
--- a/src/app/es/support/page.tsx
+++ b/src/app/es/support/page.tsx
@@ -1,7 +1,10 @@
 import { Metadata } from 'next';
+import { headers } from 'next/headers';
 import SupportView, { fetchSupportStats } from '@/components/donate/SupportView';
+import { defaultRouteForCountry } from '@/lib/give-routes';
 
-export const revalidate = 600;
+// Dynamic for the same reason as the English twin — see src/app/support/page.tsx.
+export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
 export const metadata: Metadata = {
@@ -13,6 +16,12 @@ export const metadata: Metadata = {
 // Spanish twin of /support — the acquisition front door for Spanish-speaking
 // donors and Instagram/webview visitors who have no browser translate (#2763).
 export default async function SupportPageEs() {
-  const stats = await fetchSupportStats();
-  return <SupportView stats={stats} locale="es" />;
+  const [stats, requestHeaders] = await Promise.all([fetchSupportStats(), headers()]);
+  return (
+    <SupportView
+      stats={stats}
+      locale="es"
+      defaultRoute={defaultRouteForCountry(requestHeaders.get('x-vercel-ip-country'))}
+    />
+  );
 }

--- a/src/app/give/page.tsx
+++ b/src/app/give/page.tsx
@@ -1,0 +1,83 @@
+import { Metadata } from 'next';
+import { headers } from 'next/headers';
+import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
+import GiveForm from '@/components/donate/GiveForm';
+import { defaultRouteForCountry } from '@/lib/give-routes';
+
+/**
+ * The short path to giving: one screen, no scrolling, no database.
+ *
+ * This is the header's "Support" destination and the target for any printed QR
+ * code, which is why the URL is one word. `/support` still exists and still
+ * makes the longer case — it mounts the same <GiveForm> so the two can't drift.
+ *
+ * NO DATA FETCHING, deliberately. Every other surface can degrade; the page that
+ * takes money cannot. `/support` reads corpus stats from Mongo and falls back to
+ * hardcoded numbers on failure — fine there, pointless here, and one more thing
+ * between a donor and a payment form. The only server work is reading the
+ * request country to pick a default route, which cannot fail: an unknown country
+ * is a valid answer (see defaultRouteForCountry).
+ *
+ * No `openGraph` block here on purpose. Defining one would REPLACE the root
+ * layout's entire openGraph object including its images, shipping a card with no
+ * image at all — the failure that hit three surfaces in one day (PRs #3149/
+ * #3151/#3152). Inheriting the root block is correct until this page earns a
+ * bespoke card, which would then also need its own `twitter.images`.
+ */
+
+export const metadata: Metadata = {
+  title: 'Give — Source Library',
+  description:
+    'Fund the digitization and translation of rare historical texts. Choose an amount and give in two taps — US tax-deductible or international.',
+  alternates: { canonical: '/give' },
+};
+
+export default async function GivePage() {
+  // Vercel resolves the visitor's country at the edge. Absent locally and on any
+  // non-Vercel host, which the default handles.
+  const country = (await headers()).get('x-vercel-ip-country');
+
+  return (
+    <div className="min-h-screen bg-[#f6f3ee] flex flex-col">
+      <SiteHeader variant="light" />
+
+      <main className="flex-1 px-6 py-10 md:py-16">
+        <div className="max-w-lg mx-auto">
+          <h1 className="text-3xl md:text-4xl font-display text-stone-900 mb-3 leading-tight">
+            Give to Source Library
+          </h1>
+          <p className="text-stone-600 leading-relaxed mb-8">
+            We digitize rare historical texts, translate them — many for the first
+            time in English — and publish them free for anyone to read and quote.
+            Your gift pays for scanning and translation.
+          </p>
+
+          <GiveForm defaultRoute={defaultRouteForCountry(country)} surface="give" />
+
+          <p className="mt-6 text-sm text-stone-500 leading-relaxed">
+            Want the longer version — where the money goes, giving through a
+            business, or becoming a sponsor?{' '}
+            <Link
+              href="/support"
+              className="text-accent-rust hover:text-accent-gold-dark underline underline-offset-2"
+            >
+              Read more about supporting the library
+            </Link>
+            .
+          </p>
+          <p className="mt-2 text-sm text-stone-500 leading-relaxed">
+            Not everyone gives money — some give time.{' '}
+            <Link
+              href="/contribute"
+              className="text-accent-rust hover:text-accent-gold-dark underline underline-offset-2"
+            >
+              Participate
+            </Link>{' '}
+            as a translator, reviewer, or volunteer.
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,7 +1,14 @@
 import { Metadata } from 'next';
+import { headers } from 'next/headers';
 import SupportView, { fetchSupportStats } from '@/components/donate/SupportView';
+import { defaultRouteForCountry } from '@/lib/give-routes';
 
-export const revalidate = 600;
+// Dynamic, not ISR, since #3639: the giving form defaults its tax route from the
+// visitor's country, and a cached page would serve one country's default to
+// everyone. The trade is trivial here — this page drew 60 pageviews in the 30
+// days to 2026-08-05 — and getting the route right matters more, because only
+// the NAF route carries the US 501(c)(3) deduction.
+export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
 export const metadata: Metadata = {
@@ -11,6 +18,12 @@ export const metadata: Metadata = {
 };
 
 export default async function SupportPage() {
-  const stats = await fetchSupportStats();
-  return <SupportView stats={stats} locale="en" />;
+  const [stats, requestHeaders] = await Promise.all([fetchSupportStats(), headers()]);
+  return (
+    <SupportView
+      stats={stats}
+      locale="en"
+      defaultRoute={defaultRouteForCountry(requestHeaders.get('x-vercel-ip-country'))}
+    />
+  );
 }

--- a/src/components/analytics/OutboundLink.tsx
+++ b/src/components/analytics/OutboundLink.tsx
@@ -33,6 +33,8 @@ export default function OutboundLink({
   channel,
   locale,
   intent = 'donate',
+  amount,
+  frequency,
   className,
   newTab,
   children,
@@ -45,6 +47,9 @@ export default function OutboundLink({
   locale?: string;
   /** `donate` for money, `inquiry` for a partnership/licensing/dataset ask. */
   intent?: OutboundIntent;
+  /** On surfaces that ask before handing off (/give): what the donor selected. */
+  amount?: number;
+  frequency?: 'once' | 'monthly';
   className?: string;
   /** Defaults to true for http(s), false for mailto — a mailto in a new tab leaves a blank one behind. */
   newTab?: boolean;
@@ -57,7 +62,7 @@ export default function OutboundLink({
       href={href}
       className={className}
       onClick={() => {
-        const { event, props } = outboundClickPayload({ surface, channel, locale, intent });
+        const { event, props } = outboundClickPayload({ surface, channel, locale, intent, amount, frequency });
         trackEvent(event, props);
       }}
       {...(openInNewTab ? { target: '_blank', rel: 'noopener noreferrer' } : {})}

--- a/src/components/donate/GiveForm.tsx
+++ b/src/components/donate/GiveForm.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import { useState } from 'react';
+import OutboundLink from '@/components/analytics/OutboundLink';
+import {
+  GIVE_PRESETS,
+  GIVE_DEFAULT_AMOUNT,
+  GIVE_MIN_AMOUNT,
+  GIVE_MAX_AMOUNT,
+  GIVE_CURRENCY,
+  giveDestination,
+  supportsFrequency,
+  formatGiveAmount,
+  type GiveFrequency,
+  type GiveRoute,
+} from '@/lib/give-routes';
+
+/**
+ * The whole ask, on one screen: how much, how often, and one button that leaves
+ * with the amount already attached.
+ *
+ * The shape is borrowed from the Internet Archive's donate page, which is the
+ * closest comparable audience solving the same problem — amount first, payment
+ * second, everything visible without scrolling. What we can't copy is card entry
+ * on our own domain: the receipt has to come from whichever entity receives the
+ * gift, and that is never us (see src/lib/give-routes.ts). So the last step is a
+ * handoff — but a handoff that carries the amount, which is the part that
+ * actually costs a donor something to redo.
+ *
+ * Mounted twice: standalone at /give (the header's destination) and inside
+ * /support, which keeps the longer case for giving around it. One component so
+ * the two can't drift.
+ */
+
+interface Copy {
+  frequencyLabel: string;
+  once: string;
+  monthly: string;
+  amountLabel: string;
+  custom: string;
+  give: string;
+  giveMonthly: string;
+  usRoute: string;
+  intlRoute: string;
+  switchToUs: string;
+  switchToIntl: string;
+  monthlyUnavailable: string;
+  taxUs: string;
+  taxIntl: string;
+  amountError: string;
+  largeGift: string;
+}
+
+const COPY: Record<'en' | 'es', Copy> = {
+  en: {
+    frequencyLabel: 'How often',
+    once: 'One time',
+    monthly: 'Monthly',
+    amountLabel: 'Amount',
+    custom: 'Other',
+    give: 'Give',
+    giveMonthly: 'a month',
+    usRoute: 'US tax-deductible — Netherland-America Foundation',
+    intlRoute: 'International — Embassy of the Free Mind',
+    switchToUs: 'Giving from the United States?',
+    switchToIntl: 'Giving from outside the United States?',
+    monthlyUnavailable: 'Monthly giving is currently available on the US route only.',
+    taxUs: 'NAF is a 501(c)(3) public charity and issues your receipt. Your gift is earmarked for Source Library.',
+    taxIntl: 'Goes to Stichting het Wereldhart (Cultural ANBI). Stripe issues your receipt automatically. Apple Pay, iDEAL and card accepted.',
+    amountError: 'Enter a whole number',
+    largeGift: 'Giving a larger amount, or by wire, stock, or donor-advised fund?',
+  },
+  es: {
+    frequencyLabel: 'Frecuencia',
+    once: 'Una vez',
+    monthly: 'Mensual',
+    amountLabel: 'Cantidad',
+    custom: 'Otra',
+    give: 'Donar',
+    giveMonthly: 'al mes',
+    usRoute: 'Deducible en EE. UU. — Netherland-America Foundation',
+    intlRoute: 'Internacional — Embassy of the Free Mind',
+    switchToUs: '¿Donas desde Estados Unidos?',
+    switchToIntl: '¿Donas desde fuera de Estados Unidos?',
+    monthlyUnavailable: 'La donación mensual está disponible por ahora solo en la vía de EE. UU.',
+    taxUs: 'La NAF es una entidad benéfica 501(c)(3) y emite tu recibo. Tu donación se destina a Source Library.',
+    taxIntl: 'Va a Stichting het Wereldhart (ANBI Cultural). Stripe emite el recibo automáticamente. Se acepta Apple Pay, iDEAL y tarjeta.',
+    amountError: 'Introduce un número entero',
+    largeGift: '¿Donas una cantidad mayor, o por transferencia, acciones o fondo asesorado?',
+  },
+};
+
+export default function GiveForm({
+  defaultRoute,
+  locale = 'en',
+  surface = 'give',
+  contactEmail = 'team@sourcelibrary.org',
+}: {
+  /** Resolved server-side from the request country so the common case needs no choice. */
+  defaultRoute: GiveRoute;
+  locale?: 'en' | 'es';
+  /** Distinguishes the /give mount from the /support mount in analytics. */
+  surface?: string;
+  contactEmail?: string;
+}) {
+  const t = COPY[locale];
+  const [route, setRoute] = useState<GiveRoute>(defaultRoute);
+  const [frequency, setFrequency] = useState<GiveFrequency>('once');
+  const [amount, setAmount] = useState<number>(GIVE_DEFAULT_AMOUNT.once);
+  // Empty string is a real state here, distinct from 0: it means "the donor is
+  // mid-typing", and showing a validation error at that moment is hostile.
+  const [customText, setCustomText] = useState('');
+
+  const presets = GIVE_PRESETS[frequency];
+  const symbol = GIVE_CURRENCY[route].symbol;
+  const usingCustom = customText !== '' || !presets.includes(amount);
+
+  // A custom entry is only an error once it is non-empty and still unusable.
+  const customInvalid =
+    customText !== '' &&
+    (!/^\d+$/.test(customText) ||
+      Number(customText) < GIVE_MIN_AMOUNT ||
+      Number(customText) > GIVE_MAX_AMOUNT);
+  const canGive = amount >= GIVE_MIN_AMOUNT && amount <= GIVE_MAX_AMOUNT && !customInvalid;
+
+  function pickFrequency(next: GiveFrequency) {
+    setFrequency(next);
+    // Move the amount onto the new ladder rather than carrying a rung that
+    // doesn't exist there — 250/month is not a sensible default for someone who
+    // just toggled monthly.
+    if (!customText) setAmount(GIVE_DEFAULT_AMOUNT[next]);
+    // Monthly can't be honoured internationally, so choosing it moves the donor
+    // to the route that can. Doing this silently would be worse than the switch:
+    // the note below the button says it happened.
+    if (next === 'monthly' && !supportsFrequency(route, 'monthly')) setRoute('us');
+  }
+
+  function pickPreset(value: number) {
+    setAmount(value);
+    setCustomText('');
+  }
+
+  function pickCustom(text: string) {
+    setCustomText(text);
+    if (/^\d+$/.test(text)) setAmount(Number(text));
+  }
+
+  const destination = canGive ? giveDestination(route, amount, frequency) : null;
+  const buttonLabel =
+    frequency === 'monthly'
+      ? `${t.give} ${formatGiveAmount(route, amount)} ${t.giveMonthly}`
+      : `${t.give} ${formatGiveAmount(route, amount)}`;
+
+  const routedAwayFromIntl = frequency === 'monthly' && defaultRoute === 'international';
+
+  return (
+    <div className="bg-white rounded-2xl border border-stone-200 p-5 sm:p-6 shadow-sm">
+      {/* Frequency */}
+      <fieldset>
+        <legend className="text-xs font-medium text-stone-400 uppercase tracking-wider mb-2">
+          {t.frequencyLabel}
+        </legend>
+        <div className="grid grid-cols-2 gap-2 mb-6">
+          {(['once', 'monthly'] as const).map((f) => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => pickFrequency(f)}
+              aria-pressed={frequency === f}
+              className={`py-2.5 rounded-lg text-sm font-semibold border transition-colors ${
+                frequency === f
+                  ? 'bg-accent-rust text-white border-accent-rust'
+                  : 'bg-white text-stone-700 border-stone-300 hover:border-stone-400'
+              }`}
+            >
+              {f === 'once' ? t.once : t.monthly}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Amount */}
+      <fieldset>
+        <legend className="text-xs font-medium text-stone-400 uppercase tracking-wider mb-2">
+          {t.amountLabel}
+        </legend>
+        <div className="grid grid-cols-3 gap-2">
+          {presets.map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => pickPreset(value)}
+              aria-pressed={!usingCustom && amount === value}
+              className={`py-3 rounded-lg text-base font-semibold border transition-colors ${
+                !usingCustom && amount === value
+                  ? 'bg-accent-rust text-white border-accent-rust'
+                  : 'bg-white text-stone-800 border-stone-300 hover:border-stone-400'
+              }`}
+            >
+              {symbol}
+              {value}
+            </button>
+          ))}
+          <div
+            className={`flex items-center rounded-lg border transition-colors ${
+              customInvalid
+                ? 'border-red-400'
+                : usingCustom
+                  ? 'border-accent-rust ring-1 ring-accent-rust'
+                  : 'border-stone-300'
+            }`}
+          >
+            <span className="pl-3 text-base font-semibold text-stone-500">{symbol}</span>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={customText}
+              onChange={(e) => pickCustom(e.target.value.replace(/[^\d]/g, ''))}
+              placeholder={t.custom}
+              aria-label={t.custom}
+              aria-invalid={customInvalid}
+              className="w-full bg-transparent px-1.5 py-3 text-base font-semibold text-stone-800 placeholder:font-normal placeholder:text-stone-400 outline-none min-w-0"
+            />
+          </div>
+        </div>
+        {customInvalid && (
+          <p className="mt-2 text-xs text-red-600">{t.amountError}</p>
+        )}
+      </fieldset>
+
+      {/* The one button. Rendered as a link so it survives a right-click, a
+          middle-click, and a broken analytics beacon. */}
+      <div className="mt-6">
+        {destination ? (
+          <OutboundLink
+            href={destination.url}
+            surface={surface}
+            channel={destination.channel}
+            locale={locale}
+            amount={amount}
+            frequency={frequency}
+            className="block w-full text-center bg-accent-rust hover:bg-accent-gold-dark text-white text-lg font-semibold py-4 rounded-xl transition-colors"
+          >
+            {buttonLabel}
+          </OutboundLink>
+        ) : (
+          <span className="block w-full text-center bg-stone-200 text-stone-500 text-lg font-semibold py-4 rounded-xl cursor-not-allowed">
+            {buttonLabel}
+          </span>
+        )}
+
+        <p className="mt-3 text-xs text-stone-500 leading-relaxed">
+          {route === 'us' ? t.taxUs : t.taxIntl}
+        </p>
+
+        {routedAwayFromIntl && (
+          <p className="mt-2 text-xs text-stone-500 leading-relaxed">{t.monthlyUnavailable}</p>
+        )}
+
+        {/* Switching route is a quiet secondary action, not a decision we make
+            the donor face first — the country default already got it right for
+            most people. Hidden when monthly has pinned the route to US, since
+            offering a switch we would immediately undo is just a dead control. */}
+        {!(frequency === 'monthly') && (
+          <button
+            type="button"
+            onClick={() => setRoute(route === 'us' ? 'international' : 'us')}
+            className="mt-3 text-xs text-accent-rust hover:text-accent-gold-dark underline underline-offset-2"
+          >
+            {route === 'us' ? t.switchToIntl : t.switchToUs}
+          </button>
+        )}
+      </div>
+
+      <p className="mt-5 pt-4 border-t border-stone-200 text-xs text-stone-500 leading-relaxed">
+        {t.largeGift}{' '}
+        <OutboundLink
+          href={`mailto:${contactEmail}?subject=Source%20Library%20%E2%80%94%20Donation%20Inquiry`}
+          surface={surface}
+          channel="email"
+          locale={locale}
+          className="text-accent-rust hover:text-accent-gold-dark underline break-all"
+        >
+          {contactEmail}
+        </OutboundLink>
+      </p>
+    </div>
+  );
+}

--- a/src/components/donate/SupportView.tsx
+++ b/src/components/donate/SupportView.tsx
@@ -2,17 +2,14 @@ import Link from 'next/link';
 import SiteHeader from '@/components/layout/SiteHeader';
 import DonationIntentionForm from '@/components/donate/DonationIntentionForm';
 import QuickSubscribe from '@/components/donate/QuickSubscribe';
-import OutboundLink from '@/components/analytics/OutboundLink';
+import GiveForm from '@/components/donate/GiveForm';
 import { getReadDb } from '@/lib/mongodb';
 import type { Locale } from '@/lib/i18n';
+import type { GiveRoute } from '@/lib/give-routes';
 
-const EFM_STRIPE_URL = 'https://donate.stripe.com/9B67sLbO1bOg2GxfxP9fW08';
-// The Netherland-America Foundation (NAF, EIN 13-2989216) runs TWO DonorPerfect forms for the
-// Embassy — see https://thenaf.org/friends-funds/embassy-of-the-free-mind/. `.../give/naf/
-// embassyofthefreemind` is GENERAL Embassy support (BPH preservation, exhibitions, the monument);
-// this one is the Source Library designation. A donor arriving from sourcelibrary.org means to
-// fund Source Library, so use this one. Don't "simplify" the two into the general form.
-const DONORPERFECT_URL = 'https://form-renderer-app.donorperfect.io/give/embassyofthefreemindsourcelibrary';
+// The two payment destinations, the NAF-form ambiguity, and the amount-carrying
+// URL params all live in src/lib/give-routes.ts now — this page and /give mount
+// the same <GiveForm>, so neither holds its own copy of a destination URL.
 const CONTACT_EMAIL = 'team@sourcelibrary.org';
 
 // Hand-coloured volvelle (perpetual calendar wheel) from the astrology collection.
@@ -135,7 +132,16 @@ const STRINGS: Record<Locale, SupportStrings> = {
   },
 };
 
-export default function SupportView({ stats, locale = 'en' }: { stats: SupportStats; locale?: Locale }) {
+export default function SupportView({
+  stats,
+  locale = 'en',
+  defaultRoute = 'international',
+}: {
+  stats: SupportStats;
+  locale?: Locale;
+  /** Resolved from the request country by the page; see defaultRouteForCountry. */
+  defaultRoute?: GiveRoute;
+}) {
   const s = STRINGS[locale];
   const homeHref = locale === 'es' ? '/es' : '/';
   return (
@@ -185,24 +191,13 @@ export default function SupportView({ stats, locale = 'en' }: { stats: SupportSt
               <h2 className="text-2xl md:text-3xl text-stone-900 mb-3 leading-tight font-display">{s.giveTitle}</h2>
               <p className="text-stone-600 leading-relaxed mb-6">{s.giveLead}</p>
 
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <OutboundLink href={DONORPERFECT_URL} surface="support" channel="naf_donorperfect" locale={locale} className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 hover:border-stone-400 transition-colors block">
-                  <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">{s.usLabel}</span>
-                  <span className="block text-sm font-semibold text-stone-900">{s.usTitle}</span>
-                  <span className="block text-xs text-stone-500 mt-1">{s.usSub}</span>
-                </OutboundLink>
-                <OutboundLink href={EFM_STRIPE_URL} surface="support" channel="efm_stripe" locale={locale} className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 hover:border-stone-400 transition-colors block">
-                  <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">{s.intlLabel}</span>
-                  <span className="block text-sm font-semibold text-stone-900">{s.intlTitle}</span>
-                  <span className="block text-xs text-stone-500 mt-1">{s.intlSub}</span>
-                </OutboundLink>
-                <div className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 sm:col-span-2">
-                  <span className="block text-xs font-medium text-stone-400 uppercase tracking-wider mb-1">{s.largeLabel}</span>
-                  <OutboundLink href={`mailto:${CONTACT_EMAIL}?subject=Source%20Library%20%E2%80%94%20Donation%20Inquiry`} surface="support" channel="email" locale={locale} className="text-base font-semibold text-accent-rust hover:text-accent-gold-dark underline break-all select-all">
-                    {CONTACT_EMAIL}
-                  </OutboundLink>
-                </div>
-              </div>
+              {/* The same picker /give serves, so the fast path and the long
+                  path can never disagree about amounts, routes, or which NAF
+                  form is the Source Library one. This replaced a pair of cards
+                  that linked out with no amount attached, leaving the donor to
+                  meet a $0.00 field on arrival — the anchor is the strongest
+                  lever on gift size and we were forfeiting it. */}
+              <GiveForm defaultRoute={defaultRoute} locale={locale} surface="support" contactEmail={CONTACT_EMAIL} />
 
               <p className="mt-5 text-xs text-stone-500 leading-relaxed">{s.taxNote}</p>
               <p className="mt-2 text-xs text-stone-500 leading-relaxed">

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -94,6 +94,20 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
   const NAV_LINKS = buildNavLinks(t).filter(
     link => !(isTenantHost && isGlobalOnlyNavHref(link.href))
   );
+  // The Support button is deliberately NOT in buildNavLinks: it is an action,
+  // not a destination among peers, and it renders as a pill after the nav rather
+  // than as another link in the row. It goes through the same tenant filter,
+  // which is what keeps it off partner subdomains (`/give` is on the global-only
+  // list — a BPH visitor asked for money on BPH's own domain would reasonably
+  // think the money went to BPH).
+  //
+  // Why it exists at all: measured over the 30 days to 2026-08-05, /support drew
+  // 60 of 330,698 pageviews (0.018%) while /book/* drew 217,490. The site had no
+  // giving link anywhere above the footer's third column, so two-thirds of all
+  // traffic never saw an ask. Every comparable library puts one in the header —
+  // Wikipedia's "Donate" is the first item in its article nav, ahead of "Create
+  // account"; the Internet Archive's sits in its sitewide bar.
+  const showSupport = !(isTenantHost && isGlobalOnlyNavHref('/give'));
   // The EN/ES toggle shows only where a real Spanish twin exists (home, sign-in,
   // support) — the thin-i18n bargain (#2763). On deep English-only pages the
   // toggle is hidden, so clicking ES never bounces the reader to the `/es`
@@ -215,6 +229,22 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
               );
             })}
           </nav>
+
+          {/* Support — a pill, at every breakpoint including mobile, where most
+              reading happens. Ordered before the language toggle and search so
+              it does not get pushed off a narrow viewport. */}
+          {showSupport && (
+            <Link
+              href="/give"
+              className={`whitespace-nowrap rounded-full border px-3 py-1.5 text-sm font-medium tracking-wide transition-colors ${
+                isWhiteText
+                  ? 'border-white/40 text-white hover:bg-white hover:text-dark'
+                  : 'border-accent-rust text-accent-rust hover:bg-accent-rust hover:text-white'
+              }`}
+            >
+              {t.support}
+            </Link>
+          )}
 
           {/* Language toggle — only on pages with a real Spanish twin (#2763) */}
           {showLangToggle && (

--- a/src/lib/analytics-event-allowlist.ts
+++ b/src/lib/analytics-event-allowlist.ts
@@ -63,4 +63,12 @@ export const ALLOWED_PROPS = new Set([
   // indistinguishable forever. `surface` + `channel` (both above) carry the rest:
   // which page emitted the click, and where it went.
   'locale',
+  // amount / frequency: on donate_click from /give, what the donor selected
+  // before we handed them off. This is INTENT, not revenue — the gift completes
+  // in NAF's or the Embassy's system and nothing reports back, so a click at
+  // amount=25 is a person who chose 25 and left our origin, never $25 received.
+  // Stored because it is the only signal we will ever have about which rungs of
+  // the ladder people actually reach for, and the ladder is the main lever we
+  // control (see GIVE_PRESETS in src/lib/give-routes.ts).
+  'amount', 'frequency',
 ]);

--- a/src/lib/give-routes.ts
+++ b/src/lib/give-routes.ts
@@ -1,0 +1,169 @@
+/**
+ * The giving handoff: amount + frequency chosen on our page, carried into the
+ * payment destination so the donor never types a number twice.
+ *
+ * Why a handoff at all, rather than an on-site card form: the two routes are two
+ * different legal entities with different receipting, and neither is us. US
+ * donors give through the Netherland-America Foundation (NAF), which issues the
+ * 501(c)(3) receipt; everyone else gives to Stichting het Wereldhart (Cultural
+ * ANBI) through the Embassy's Stripe, where Stripe issues the receipt. Source
+ * Library holds no Stripe account of its own — `STRIPE_SECRET_KEY` is absent
+ * from Vercel production, so every in-repo Checkout route (membership, adopt-a-
+ * book) answers 503 today. Processing gifts here would change who receives the
+ * money and who issues the receipt, which is a decision for the Embassy, not a
+ * frontend one.
+ *
+ * What we CAN do is make the handoff carry state, which is most of the win. Both
+ * destinations were tested by hand on 2026-08-05 and both accept a pre-filled
+ * amount, so "click Support → tap €25 → pay with Apple Pay" is two taps and no
+ * typing. See PARAM NOTES on each route below.
+ */
+
+export type GiveFrequency = 'once' | 'monthly';
+export type GiveRoute = 'us' | 'international';
+
+/**
+ * NAF's DonorPerfect form, Source Library designation.
+ *
+ * NAF runs TWO forms for the Embassy (see thenaf.org/friends-funds/
+ * embassy-of-the-free-mind/). `.../give/naf/embassyofthefreemind` is GENERAL
+ * Embassy support; this one is earmarked for Source Library. A donor arriving
+ * from sourcelibrary.org means to fund Source Library — don't "simplify" the two
+ * into the general form.
+ *
+ * PARAM NOTES (verified by hand, 2026-08-05):
+ *   ?amount=25          selects the $25 preset, or pre-fills the custom field
+ *                       when the value isn't one of the form's presets. WHOLE
+ *                       DOLLARS, not cents — `amount=2500` would ask for $2,500.
+ *   ?frequency=monthly  flips the form's One-time/Monthly toggle. Verified alone,
+ *                       without the `recurring=true` that was tried alongside it.
+ * The form carries two different preset ladders (one-time starts at $100,
+ * monthly at $25), which is why our own ladder below is the one that matters —
+ * an amount we send always wins over whichever ladder the form would show.
+ */
+const NAF_DONORPERFECT_URL =
+  'https://form-renderer-app.donorperfect.io/give/embassyofthefreemindsourcelibrary';
+
+/**
+ * The Embassy's Stripe payment link (Stichting het Wereldhart).
+ *
+ * PARAM NOTES (verified by hand, 2026-08-05):
+ *   ?__prefilled_amount=2500   pre-fills €25.00 and shows a "Change amount"
+ *                              control. CENTS, unlike DonorPerfect above — the
+ *                              two encodings are the reason this module exists
+ *                              rather than a template string at each call site.
+ *
+ * The double underscore marks this as Stripe-internal: it is not in the Payment
+ * Links docs, which list only `prefilled_email`, `prefilled_promo_code` and
+ * `client_reference_id`. It works today and degrades safely — if Stripe drops
+ * it, the donor lands on the €0.00 field and types an amount, which is exactly
+ * today's behaviour. Never build anything that assumes the amount ARRIVED.
+ *
+ * This link is ONE-TIME ONLY. `giveDestination` therefore refuses to pretend
+ * otherwise (see `supportsFrequency`); unlocking monthly here needs a recurring
+ * payment link created on the Embassy's Stripe account, not a code change.
+ */
+const EFM_STRIPE_URL = 'https://donate.stripe.com/9B67sLbO1bOg2GxfxP9fW08';
+
+/**
+ * Suggested amounts, in the route's own currency units (whole dollars/euros).
+ *
+ * Deliberately lower than the destinations' own ladders, which start at $100
+ * one-time. An anchor is the single strongest determinant of gift size, and a
+ * $100 floor on a general reading audience reads as "not for you" — the Internet
+ * Archive anchors at $10 against a comparable audience. The ladder still runs up
+ * to 250 so a donor who wants to give more doesn't have to reach for "custom".
+ *
+ * The default is the SECOND rung, not the first: the top of the list is the
+ * cheapest thing to click, and anchoring one step above it lifts the median
+ * without making the small gift feel unwelcome.
+ */
+export const GIVE_PRESETS: Record<GiveFrequency, number[]> = {
+  once: [10, 25, 50, 100, 250],
+  monthly: [5, 10, 25, 50, 100],
+};
+
+export const GIVE_DEFAULT_AMOUNT: Record<GiveFrequency, number> = {
+  once: 25,
+  monthly: 10,
+};
+
+/** Below this a card fee eats most of the gift; above it, route to a human. */
+export const GIVE_MIN_AMOUNT = 1;
+export const GIVE_MAX_AMOUNT = 50_000;
+
+export const GIVE_CURRENCY: Record<GiveRoute, { code: string; symbol: string }> = {
+  us: { code: 'USD', symbol: '$' },
+  international: { code: 'EUR', symbol: '€' },
+};
+
+/**
+ * Which frequencies a route can actually honour.
+ *
+ * Not cosmetic: sending a monthly donor to a one-time payment link takes their
+ * money once and silently drops the recurring intent, which is worse than not
+ * offering monthly at all.
+ */
+export function supportsFrequency(route: GiveRoute, frequency: GiveFrequency): boolean {
+  if (frequency === 'once') return true;
+  return route === 'us';
+}
+
+export interface GiveDestination {
+  /** Where to send the donor. */
+  url: string;
+  /** `channel` for the donate_click event — matches the existing /support values. */
+  channel: 'naf_donorperfect' | 'efm_stripe';
+}
+
+/**
+ * Build the payment URL for a chosen amount and frequency.
+ *
+ * Throws on an amount outside [GIVE_MIN_AMOUNT, GIVE_MAX_AMOUNT] or a
+ * non-integer, rather than silently clamping: a clamped amount would send the
+ * donor to a payment page showing a number they did not choose, and they would
+ * have no way to tell that we changed it. The caller validates the input field
+ * and never reaches this with a bad value.
+ */
+export function giveDestination(
+  route: GiveRoute,
+  amount: number,
+  frequency: GiveFrequency,
+): GiveDestination {
+  if (!Number.isInteger(amount) || amount < GIVE_MIN_AMOUNT || amount > GIVE_MAX_AMOUNT) {
+    throw new RangeError(
+      `give amount must be a whole number between ${GIVE_MIN_AMOUNT} and ${GIVE_MAX_AMOUNT}, got ${amount}`,
+    );
+  }
+
+  if (route === 'us') {
+    const params = new URLSearchParams({ amount: String(amount) });
+    // Only send the frequency param when it changes something. The form defaults
+    // to one-time, and an explicit `frequency=once` is an untested value.
+    if (frequency === 'monthly') params.set('frequency', 'monthly');
+    return { url: `${NAF_DONORPERFECT_URL}?${params}`, channel: 'naf_donorperfect' };
+  }
+
+  // Stripe wants the minor unit. No frequency param exists — a monthly choice
+  // cannot reach this link, which is what `supportsFrequency` exists to prevent
+  // the UI from offering.
+  const params = new URLSearchParams({ __prefilled_amount: String(amount * 100) });
+  return { url: `${EFM_STRIPE_URL}?${params}`, channel: 'efm_stripe' };
+}
+
+/**
+ * Default route from the visitor's country.
+ *
+ * US donors are the ones with something to lose by guessing wrong — the 501(c)(3)
+ * deduction only exists on the NAF route — so an unknown country defaults to
+ * international, where the gift is still receipted and nothing is forfeited. The
+ * donor can switch either way; this only decides which button is primary.
+ */
+export function defaultRouteForCountry(country: string | null | undefined): GiveRoute {
+  return country?.toUpperCase() === 'US' ? 'us' : 'international';
+}
+
+/** "$25" / "€25" — no decimals, thousands separator. */
+export function formatGiveAmount(route: GiveRoute, amount: number): string {
+  return `${GIVE_CURRENCY[route].symbol}${amount.toLocaleString('en-US')}`;
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -76,6 +76,7 @@ export interface NavStrings {
   podcast: string;
   search: string;
   menu: string;
+  support: string;
 }
 
 export const NAV_STRINGS: Record<Locale, NavStrings> = {
@@ -89,6 +90,7 @@ export const NAV_STRINGS: Record<Locale, NavStrings> = {
     podcast: 'Podcast',
     search: 'Search',
     menu: 'Navigation menu',
+    support: 'Support',
   },
   es: {
     collections: 'Colecciones',
@@ -100,6 +102,7 @@ export const NAV_STRINGS: Record<Locale, NavStrings> = {
     podcast: 'Podcast',
     search: 'Buscar',
     menu: 'Menú de navegación',
+    support: 'Donar',
   },
 };
 

--- a/src/lib/outbound-click.ts
+++ b/src/lib/outbound-click.ts
@@ -17,11 +17,18 @@ export interface OutboundClickInput {
   channel: string;
   locale?: string;
   intent?: OutboundIntent;
+  /**
+   * What the donor selected before the handoff, on surfaces that ask (currently
+   * /give). Whole currency units — the currency itself is implied by `channel`,
+   * since the NAF route is USD and the Embassy's Stripe is EUR.
+   */
+  amount?: number;
+  frequency?: 'once' | 'monthly';
 }
 
 export interface OutboundClickPayload {
   event: 'donate_click' | 'inquiry_click';
-  props: Record<string, string>;
+  props: Record<string, string | number>;
 }
 
 export function outboundClickPayload({
@@ -29,12 +36,19 @@ export function outboundClickPayload({
   channel,
   locale,
   intent = 'donate',
+  amount,
+  frequency,
 }: OutboundClickInput): OutboundClickPayload {
-  const props: Record<string, string> = { surface, channel };
+  const props: Record<string, string | number> = { surface, channel };
   // Omit rather than send undefined: trackEvent strips undefined anyway, but an
   // absent key and an empty string mean different things downstream ("this
   // surface has no locale" vs "the locale was blank").
   if (locale) props.locale = locale;
+  // Same rule, and it bites harder here: a surface that doesn't ask for an
+  // amount must not report 0, which would average into the ladder analysis as a
+  // real choice of nothing.
+  if (typeof amount === 'number' && Number.isFinite(amount)) props.amount = amount;
+  if (frequency) props.frequency = frequency;
 
   return {
     event: intent === 'donate' ? 'donate_click' : 'inquiry_click',

--- a/src/lib/tenant-global-paths.ts
+++ b/src/lib/tenant-global-paths.ts
@@ -47,6 +47,13 @@ export const GLOBAL_ONLY_TENANT_PAGE_PATHS = [
   '/blog',
   '/contribute',
   '/support',
+  // `/give` is /support's one-screen twin and the header's Support button. Both
+  // solicit for Source Library specifically (the NAF form is the Source Library
+  // designation, not the Embassy's general fund), so a partner reading room is
+  // the wrong place for it — a BPH visitor asked for money on BPH's own domain
+  // would reasonably think they were giving to BPH. The header filters on this
+  // list, so listing it here also removes the button on tenant hosts.
+  '/give',
   '/sponsors',
   // Volunteer review queues. Items are drawn from `review_candidates`, a pool
   // built across every visible book in the corpus, so a partner reading room

--- a/tests/unit/give-routes.test.ts
+++ b/tests/unit/give-routes.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import {
+  giveDestination,
+  supportsFrequency,
+  defaultRouteForCountry,
+  formatGiveAmount,
+  GIVE_PRESETS,
+  GIVE_DEFAULT_AMOUNT,
+  GIVE_MIN_AMOUNT,
+  GIVE_MAX_AMOUNT,
+} from '@/lib/give-routes';
+
+/**
+ * Guards the handoff that carries the donor's chosen amount into the payment
+ * page. Exercises the real builder — none of these pass if the encoding is
+ * wrong, which is the whole point (CLAUDE.md: "a test that greps source is not
+ * a guard").
+ *
+ * The failure this exists to catch is silent and expensive: the two destinations
+ * take the amount in DIFFERENT UNITS. DonorPerfect wants whole dollars,
+ * Stripe wants cents. Swap them and a donor who picks $25 is shown a bill for
+ * $2,500 — or, in the other direction, €0.25. Both render as a perfectly normal
+ * payment page, so nothing downstream can tell.
+ *
+ * The param names were verified by hand against the live destinations on
+ * 2026-08-05 (see PARAM NOTES in src/lib/give-routes.ts). This file pins the
+ * ENCODING, not their continued existence upstream — if Stripe drops
+ * `__prefilled_amount` the donor lands on an empty field and types, which is
+ * what happened before this feature.
+ */
+
+describe('giveDestination — unit encoding per destination', () => {
+  it('sends WHOLE DOLLARS to DonorPerfect', () => {
+    const { url } = giveDestination('us', 25, 'once');
+    const amount = new URL(url).searchParams.get('amount');
+    expect(amount).toBe('25');
+  });
+
+  it('sends CENTS to the Stripe payment link', () => {
+    const { url } = giveDestination('international', 25, 'once');
+    const amount = new URL(url).searchParams.get('__prefilled_amount');
+    expect(amount).toBe('2500');
+  });
+
+  // The regression that would cost the most: the two encodings crossed. Stated
+  // as its own case so a failure names the actual hazard.
+  it('never sends a cents value to DonorPerfect', () => {
+    const { url } = giveDestination('us', 100, 'once');
+    expect(new URL(url).searchParams.get('amount')).not.toBe('10000');
+  });
+
+  it.each([1, 5, 10, 25, 50, 100, 250, 1000])('round-trips %i without drift', (amount) => {
+    expect(new URL(giveDestination('us', amount, 'once').url).searchParams.get('amount'))
+      .toBe(String(amount));
+    expect(new URL(giveDestination('international', amount, 'once').url).searchParams.get('__prefilled_amount'))
+      .toBe(String(amount * 100));
+  });
+});
+
+describe('giveDestination — frequency', () => {
+  it('flips the DonorPerfect toggle for a monthly gift', () => {
+    const { url } = giveDestination('us', 10, 'monthly');
+    expect(new URL(url).searchParams.get('frequency')).toBe('monthly');
+  });
+
+  it('omits the frequency param for a one-time gift rather than sending an untested value', () => {
+    const { url } = giveDestination('us', 10, 'once');
+    expect(new URL(url).searchParams.has('frequency')).toBe(false);
+  });
+});
+
+describe('giveDestination — routing', () => {
+  it('points the US route at the Source Library designation, not the general Embassy fund', () => {
+    const { url, channel } = giveDestination('us', 25, 'once');
+    // NAF runs two forms for the Embassy; `.../give/naf/embassyofthefreemind` is
+    // the general one and would misdirect a gift made from sourcelibrary.org.
+    expect(url).toContain('/give/embassyofthefreemindsourcelibrary');
+    expect(url).not.toContain('/give/naf/embassyofthefreemind?');
+    expect(channel).toBe('naf_donorperfect');
+  });
+
+  it('points the international route at the Embassy Stripe link', () => {
+    const { url, channel } = giveDestination('international', 25, 'once');
+    expect(url.startsWith('https://donate.stripe.com/')).toBe(true);
+    expect(channel).toBe('efm_stripe');
+  });
+
+  it('emits channels that match the values /support already logs', () => {
+    // These strings are the join key for every donate_click query written before
+    // this feature existed; renaming one silently splits the series in two.
+    expect(giveDestination('us', 25, 'once').channel).toBe('naf_donorperfect');
+    expect(giveDestination('international', 25, 'once').channel).toBe('efm_stripe');
+  });
+});
+
+describe('giveDestination — refuses an amount it cannot honour', () => {
+  // Throwing rather than clamping is deliberate: a clamped amount sends the
+  // donor to a payment page showing a number they did not choose, with no way to
+  // tell that we changed it.
+  it.each([0, -5, 0.5, 25.5, NaN, Infinity, GIVE_MAX_AMOUNT + 1])('rejects %p', (amount) => {
+    expect(() => giveDestination('us', amount as number, 'once')).toThrow(RangeError);
+    expect(() => giveDestination('international', amount as number, 'once')).toThrow(RangeError);
+  });
+
+  it('accepts the exact boundaries', () => {
+    expect(() => giveDestination('us', GIVE_MIN_AMOUNT, 'once')).not.toThrow();
+    expect(() => giveDestination('us', GIVE_MAX_AMOUNT, 'once')).not.toThrow();
+  });
+});
+
+describe('supportsFrequency', () => {
+  it('allows one-time on both routes', () => {
+    expect(supportsFrequency('us', 'once')).toBe(true);
+    expect(supportsFrequency('international', 'once')).toBe(true);
+  });
+
+  // The Embassy's Stripe link is a one-time payment link. Offering monthly there
+  // would take the gift once and drop the recurring intent with no error — worse
+  // than not offering it. Unlocking this needs a recurring payment link created
+  // on the Embassy's Stripe account, at which point this expectation flips.
+  it('refuses monthly on the international route', () => {
+    expect(supportsFrequency('international', 'monthly')).toBe(false);
+  });
+
+  it('allows monthly on the US route, which DonorPerfect honours', () => {
+    expect(supportsFrequency('us', 'monthly')).toBe(true);
+  });
+});
+
+describe('defaultRouteForCountry', () => {
+  it('routes US visitors to the tax-deductible form', () => {
+    expect(defaultRouteForCountry('US')).toBe('us');
+    expect(defaultRouteForCountry('us')).toBe('us');
+  });
+
+  it.each(['NL', 'GB', 'DE', 'AR', 'JP'])('routes %s internationally', (country) => {
+    expect(defaultRouteForCountry(country)).toBe('international');
+  });
+
+  // Unknown country is the local/non-Vercel case and must not throw or guess US:
+  // only the NAF route carries a deduction, so a wrong US default hands someone
+  // a US tax form they cannot use, while a wrong international default forfeits
+  // nothing they were owed.
+  it.each([null, undefined, ''])('defaults %p to international', (country) => {
+    expect(defaultRouteForCountry(country)).toBe('international');
+  });
+});
+
+describe('preset ladders', () => {
+  it('anchors on the second rung, not the cheapest', () => {
+    for (const frequency of ['once', 'monthly'] as const) {
+      const presets = GIVE_PRESETS[frequency];
+      expect(presets).toContain(GIVE_DEFAULT_AMOUNT[frequency]);
+      expect(GIVE_DEFAULT_AMOUNT[frequency]).toBe(presets[1]);
+    }
+  });
+
+  it('keeps every rung inside the range the builder will accept', () => {
+    for (const presets of Object.values(GIVE_PRESETS)) {
+      for (const value of presets) {
+        expect(Number.isInteger(value)).toBe(true);
+        expect(value).toBeGreaterThanOrEqual(GIVE_MIN_AMOUNT);
+        expect(value).toBeLessThanOrEqual(GIVE_MAX_AMOUNT);
+        expect(() => giveDestination('us', value, 'once')).not.toThrow();
+      }
+    }
+  });
+
+  it('rises monotonically, so the ladder reads as a ladder', () => {
+    for (const presets of Object.values(GIVE_PRESETS)) {
+      expect([...presets].sort((a, b) => a - b)).toEqual(presets);
+    }
+  });
+
+  // The destinations' own ladders start at $100 one-time. Ours exists to anchor
+  // lower than that for a general reading audience; if the entry rung ever
+  // drifts back up, the reason for this module has quietly gone away.
+  it('opens below the destination forms own $100 entry rung', () => {
+    expect(GIVE_PRESETS.once[0]).toBeLessThan(100);
+    expect(GIVE_PRESETS.monthly[0]).toBeLessThan(100);
+  });
+});
+
+describe('formatGiveAmount', () => {
+  it('uses the currency the route actually charges in', () => {
+    expect(formatGiveAmount('us', 25)).toBe('$25');
+    expect(formatGiveAmount('international', 25)).toBe('€25');
+  });
+
+  it('groups thousands', () => {
+    expect(formatGiveAmount('us', 1000)).toBe('$1,000');
+  });
+});

--- a/tests/unit/outbound-click-allowlist.test.ts
+++ b/tests/unit/outbound-click-allowlist.test.ts
@@ -58,6 +58,31 @@ describe('outbound click payloads survive the analytics allowlist', () => {
     }
   });
 
+  // The allowlist check above is one-directional: it proves nothing we emit gets
+  // dropped, and says nothing about a field we STOP emitting. Both failures look
+  // identical in the data — the key is simply absent weeks later — so the
+  // reverse assertion has to be stated separately. Found by negative control:
+  // deleting the `amount` line from outboundClickPayload left every other test
+  // in this file green.
+  it.each(SHAPES.filter((s) => 'amount' in s.input || 'frequency' in s.input))(
+    '$label — an input that declares amount/frequency actually emits them',
+    ({ input }) => {
+      const { props } = outboundClickPayload(input);
+      const declared = input as { amount?: number; frequency?: string };
+      if (declared.amount !== undefined) expect(props.amount).toBe(declared.amount);
+      if (declared.frequency !== undefined) expect(props.frequency).toBe(declared.frequency);
+    },
+  );
+
+  // An amount of 0 is not a choice anyone made — it is a surface that doesn't
+  // ask, reporting one. Left in, it averages into the ladder analysis as a real
+  // decision to give nothing.
+  it('omits amount entirely on surfaces that never asked for one', () => {
+    const { props } = outboundClickPayload({ surface: 'sponsors_hero', channel: 'email' });
+    expect('amount' in props).toBe(false);
+    expect('frequency' in props).toBe(false);
+  });
+
   it('distinguishes money from inquiry, so one cannot be read as the other', () => {
     expect(outboundClickPayload({ surface: 's', channel: 'email' }).event).toBe('donate_click');
     expect(

--- a/tests/unit/outbound-click-allowlist.test.ts
+++ b/tests/unit/outbound-click-allowlist.test.ts
@@ -27,6 +27,16 @@ const SHAPES = [
     label: 'inquiry',
     input: { surface: 'sponsors_hero', channel: 'email', intent: 'inquiry' as const },
   },
+  // /give and the /support mount of <GiveForm> attach what the donor selected
+  // before the handoff. Read as intent, never revenue.
+  {
+    label: 'give, one-time with amount',
+    input: { surface: 'give', channel: 'efm_stripe', locale: 'en', amount: 25, frequency: 'once' as const },
+  },
+  {
+    label: 'give, monthly with amount',
+    input: { surface: 'support', channel: 'naf_donorperfect', locale: 'en', amount: 10, frequency: 'monthly' as const },
+  },
 ];
 
 describe('outbound click payloads survive the analytics allowlist', () => {


### PR DESCRIPTION
## Why

Measured over the 30 days to 2026-08-05: **330,698 pageviews, of which `/support` got 60** — 0.018%. `/book/*` got 217,490, two-thirds of all traffic.

The site had no giving link anywhere above the footer's third column, fourth item. So two-thirds of traffic never saw an ask, and the people who found `/support` were handed off to DonorPerfect or a Stripe link **with no amount attached** — landing on a `$0.00` field and choosing again. The anchor is the strongest single lever on gift size and we were forfeiting it.

Every comparable library puts the ask in the header: Wikipedia's "Donate" is the *first* item in its article nav, ahead of "Create account"; the Internet Archive's sits in its sitewide bar and its donate page is one screen with preset amounts and express pay.

## What's in scope

- **`Support` pill in `SiteHeader`**, at every breakpoint including mobile, filtered on tenant hosts via the existing `isGlobalOnlyNavHref` list.
- **`/give`** — one screen, **no database call**, amount + frequency + one button. Default tax route resolved from `x-vercel-ip-country`.
- **`src/lib/give-routes.ts`** — carries the chosen amount into both destinations.
- **`/support` mounts the same `<GiveForm>`**, so the fast path and the long path can't drift. Its two link-out cards are gone.
- `amount` / `frequency` added to the `donate_click` payload and the analytics allowlist.

## The handoff params (verified by hand, not assumed)

Both destinations accept a pre-filled amount. Tested live in a browser on 2026-08-05:

| Route | Param | Unit | Verified |
|---|---|---|---|
| NAF / DonorPerfect | `?amount=25` | whole dollars | selects the $25 preset |
| NAF / DonorPerfect | `?frequency=monthly` | — | flips the One-time/Monthly toggle (verified alone) |
| Embassy / Stripe | `?__prefilled_amount=2500` | **cents** | pre-fills €25.00 + "Change amount" |

So the flow is: click Support → tap €25 → Apple Pay. Two taps, no typing.

`__prefilled_amount` is Stripe-internal (not in the Payment Links docs). It degrades safely — if Stripe drops it the donor lands on the €0.00 field and types, which is exactly today's behaviour. Nothing assumes the amount *arrived*.

## Out of scope, deliberately

- **On-site card entry.** The two routes are two different legal entities with different receipting and **neither is us**. `STRIPE_SECRET_KEY` is absent from Vercel production entirely, so every in-repo Checkout route (membership, adopt-a-book) answers 503 today. Processing gifts here would change who receives the money and who issues the receipt — an Embassy decision, not a frontend one.
- **Monthly on the international route.** The Embassy's Stripe link is one-time only. `supportsFrequency()` refuses to pretend otherwise; choosing Monthly moves the donor to the route that can honour it and says so. Unlocking this needs a recurring payment link on the Embassy's Stripe account, not a code change.
- **Adopt-a-book.** Fully built and dark behind `NEXT_PUBLIC_ADOPT_ENABLED` (also unset in production), with a €250 floor. Contextual per-book giving is the strongest remaining idea and it needs a small-dollar rung; separate PR.
- **An in-reader ask.** Wikipedia's money comes from the banner in the reading context, not the donate page. Separate PR.

## Caching change

`/support` and `/es/support` move from `revalidate = 600` to `force-dynamic`, because the tax route now defaults from the visitor's country and a cached page would serve one country's default to everyone. At 60 pageviews/30d the cost is nil, and only the NAF route carries the US 501(c)(3) deduction, so getting it right matters.

## Verification

- `npx tsc --noEmit` clean; **1,875 unit tests pass** (58 new/changed).
- **All 10 negative controls go red** — cents/dollars crossed in either direction, `supportsFrequency` lying about monthly, clamping instead of refusing a bad amount, unknown country guessing US, pointing at NAF's *general* Embassy fund instead of the Source Library designation, a renamed channel, anchoring on the cheapest rung, and dropping `amount` from either the allowlist or the payload builder.
  - The tenth control **found a hole in the test**: deleting the `amount` line from `outboundClickPayload` left every assertion green, because the allowlist check is one-directional. Fixed in the second commit — both directions are now asserted.
- **Rendered and clicked through on a preview**, not just tested: desktop + 360px mobile, both routes, monthly toggle, and a custom amount (€37 → `__prefilled_amount=3700`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
