### PR TITLE
perf(deploy): stop invalidating three whole ISR subtrees on every deploy

### DIFF
--- a/src/app/api/deploy-warm/route.ts
+++ b/src/app/api/deploy-warm/route.ts
@@ -161,16 +161,33 @@ export async function POST(request: NextRequest) {
   ]);
   const allContentPaths = [...STATIC_PAGES, ...collectionPaths, ...bookPaths, ...browsePaths];
 
-  // 2. Revalidate all ISR-cached pages so Next.js drops stale HTML
-  //    Without this, warming re-caches old HTML that references deleted JS chunks,
-  //    causing raw RSC payload to render instead of the page.
+  // 2. Revalidate the static pages we are about to warm, so they pick up the
+  //    current deployment's chunks.
+  //
+  //    We deliberately do NOT revalidate the /book, /collections and /browse
+  //    route segments wholesale any more. That existed to stop cached HTML
+  //    referencing deleted JS chunks — but Vercel Skew Protection now keeps a
+  //    prior deployment's assets resolvable for 48h, which is longer than the
+  //    24h `CDN-Cache-Control: max-age=86400` we set on those routes in
+  //    next.config.ts. Stale HTML therefore resolves against assets that still
+  //    exist, and no invalidation is needed to prevent it.
+  //
+  //    The window sizing is load-bearing: skew max-age MUST stay > the CDN TTL.
+  //    It was 12h against a 24h TTL, and that 12h gap is what produced the
+  //    recurring "page renders fully unstyled after a deploy" reports.
+  //
+  //    Cost, for context: invalidating three whole subtrees on every deploy
+  //    (106 deploys/30d) meant the ISR cache was emptied faster than it could
+  //    be read — 54.6M ISR writes against 16.8M reads in Jul 2026, $282 of
+  //    writes buying $8 of reads, plus the full-render CPU and origin transfer
+  //    behind them. See #3645.
+  //
+  //    Content freshness is unaffected: edits revalidate through their own
+  //    paths (/api/books/[id], /api/admin/revalidate*, collections publish),
+  //    and anything else refreshes on its normal `revalidate` window.
+  //
   //    Skip in ?check mode — just report current warmth without invalidating.
   if (!checkOnly) {
-    // Revalidate entire route segments — covers ALL books/collections/browse,
-    // not just the ones we warm. Prevents stale RSC on the long tail.
-    revalidatePath('/book', 'layout');
-    revalidatePath('/collections', 'layout');
-    revalidatePath('/browse', 'layout');
     for (const path of STATIC_PAGES) {
       revalidatePath(path);
     }


### PR DESCRIPTION
Addresses the largest item in #3645.

## What changed

`deploy-warm` no longer calls `revalidatePath('/book' | '/collections' | '/browse', 'layout')`. It still revalidates and warms `STATIC_PAGES`, and still warms collections, top books and browse pages.

**Vercel Skew Protection `skewProtectionMaxAge` was raised 12h → 48h** (project setting, applied 2026-08-05, outside this repo).

## Why the invalidation was there, and why it isn't needed

Its stated reason was stopping cached HTML from referencing deleted JS chunks — the "page renders fully unstyled after a deploy" class of bug that `deploy-prod.sh` and CLAUDE.md both describe at length.

Skew Protection already solves that by keeping a prior deployment's assets resolvable. **The actual defect was that its window was too short: 12h, against the 24h `CDN-Cache-Control: max-age=86400` we set on those very routes in `next.config.ts:179`.** HTML cached 12–24h before a deploy fell into the gap. The blanket invalidation was a workaround for a mis-sized window, not for an unavoidable problem.

At 48h the gap is closed with margin.

**New invariant, recorded at the call site: skew max-age must stay greater than the CDN TTL.** Raising the TTL past 48h without raising skew reopens the bug. It is a Vercel project setting, so no test in this repo can pin it — flagged below.

## Measured cost of the behaviour being removed

Jul 2026 cycle: **54,613,998 ISR writes against 16,815,548 reads** — $282.46 of writes buying $8.47 of reads. Writes exceed reads in every month on record (2.4×–6.5×), which is the signature of a cache emptied faster than it can be served.

Three subtrees × ~32K visible books × 106 deploys/30d, while only the top 100 books were re-warmed. Everything else regenerated on first request, paying a full render: Fluid Active CPU $477.50 and Provisioned Memory $226.23 sit behind the same cause.

Full audit: #3645. Cost reference: `~/sourcelibrary-ops/costs/infrastructure-costs.md`.

## Out of scope, deliberately

**The Cloudflare `purge_everything` stays.** Skew Protection makes it droppable too, and doing so would cut most of the $533.46/mo `Fast Origin Transfer` line — but keeping it leaves a safety net while this half is verified, and it is a different risk profile (it governs how fast content edits propagate, not just chunk staleness). Follow-up once a full billing cycle confirms this change.

## Risk

- **Content freshness:** edits already revalidate through their own paths (`/api/books/[id]`, `/api/admin/revalidate*`, collections publish). The blanket call was belt-and-braces, not the mechanism. Anything not explicitly revalidated now refreshes on its own `revalidate` window rather than at the next deploy.
- **If skew is ever lowered below the CDN TTL, the unstyled-page bug returns.** That is the one way this regresses, and it cannot regress from a change in this repo alone.
- Rollback is reverting this commit; the Cloudflare purge is untouched and still runs.

## Verification

`npx tsc --noEmit` clean. The real verification is a billing cycle: **ISR Reads should come to exceed ISR Writes**, which is the signature that the cache is doing its job. Re-pull per `costs/infrastructure-costs.md`.

## Follow-up

- CLAUDE.md's deploy section implies the purge is always required; it needs a note about the skew window. Kept out of this PR (one concern per PR).
