### PR TITLE
fix(support): stop personalising a page the edge caches for 24h

### DIFF
--- a/src/app/es/support/page.tsx
+++ b/src/app/es/support/page.tsx
@@ -1,10 +1,10 @@
 import { Metadata } from 'next';
-import { headers } from 'next/headers';
 import SupportView, { fetchSupportStats } from '@/components/donate/SupportView';
-import { defaultRouteForCountry } from '@/lib/give-routes';
 
-// Dynamic for the same reason as the English twin — see src/app/support/page.tsx.
-export const dynamic = 'force-dynamic';
+// ISR and request-independent, for the reason spelled out in the English twin
+// (src/app/support/page.tsx): `/support` sits in the static-pages CDN rule, so a
+// `force-dynamic` page is still edge-cached for 24h and cannot personalise.
+export const revalidate = 600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {
@@ -16,12 +16,6 @@ export const metadata: Metadata = {
 // Spanish twin of /support — the acquisition front door for Spanish-speaking
 // donors and Instagram/webview visitors who have no browser translate (#2763).
 export default async function SupportPageEs() {
-  const [stats, requestHeaders] = await Promise.all([fetchSupportStats(), headers()]);
-  return (
-    <SupportView
-      stats={stats}
-      locale="es"
-      defaultRoute={defaultRouteForCountry(requestHeaders.get('x-vercel-ip-country'))}
-    />
-  );
+  const stats = await fetchSupportStats();
+  return <SupportView stats={stats} locale="es" />;
 }

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,14 +1,27 @@
 import { Metadata } from 'next';
-import { headers } from 'next/headers';
 import SupportView, { fetchSupportStats } from '@/components/donate/SupportView';
-import { defaultRouteForCountry } from '@/lib/give-routes';
 
-// Dynamic, not ISR, since #3639: the giving form defaults its tax route from the
-// visitor's country, and a cached page would serve one country's default to
-// everyone. The trade is trivial here — this page drew 60 pageviews in the 30
-// days to 2026-08-05 — and getting the route right matters more, because only
-// the NAF route carries the US 501(c)(3) deduction.
-export const dynamic = 'force-dynamic';
+// ISR, and the giving form here must NOT depend on the request.
+//
+// #3646 briefly made this page `force-dynamic` so <GiveForm> could default its
+// tax route from `x-vercel-ip-country`. That silently did nothing: `/support` is
+// listed in the static-pages CDN rule in next.config.ts (`CDN-Cache-Control:
+// public, max-age=86400`), which is a PATH rule and overrides the route's
+// dynamic setting at the edge. Measured on production 2026-08-05, the page
+// answered `cf-cache-status: HIT` with `age: 1202` — i.e. every visitor was
+// getting whichever country's copy the edge happened to cache first, held for
+// 24h, plus a per-request Mongo call that bought nothing.
+//
+// That TTL is load-bearing: a June 2026 scraper flood sent ~1.3M req/day at
+// exactly these pages and all of it reached Vercel, which is why the rule exists.
+// So the fix is to stop depending on request state here rather than to punch a
+// hole in the edge cache for a page drawing ~2 views/day.
+//
+// `/give` is the country-aware surface — it carries no CDN-Cache-Control, answers
+// BYPASS, and is where the header's Support button points. Here <GiveForm> falls
+// back to the international route and shows its "Giving from the United States?"
+// switch, which is one visible click. A cached page cannot honestly personalise.
+export const revalidate = 600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {
@@ -18,12 +31,6 @@ export const metadata: Metadata = {
 };
 
 export default async function SupportPage() {
-  const [stats, requestHeaders] = await Promise.all([fetchSupportStats(), headers()]);
-  return (
-    <SupportView
-      stats={stats}
-      locale="en"
-      defaultRoute={defaultRouteForCountry(requestHeaders.get('x-vercel-ip-country'))}
-    />
-  );
+  const stats = await fetchSupportStats();
+  return <SupportView stats={stats} locale="en" />;
 }

--- a/src/components/donate/SupportView.tsx
+++ b/src/components/donate/SupportView.tsx
@@ -5,7 +5,6 @@ import QuickSubscribe from '@/components/donate/QuickSubscribe';
 import GiveForm from '@/components/donate/GiveForm';
 import { getReadDb } from '@/lib/mongodb';
 import type { Locale } from '@/lib/i18n';
-import type { GiveRoute } from '@/lib/give-routes';
 
 // The two payment destinations, the NAF-form ambiguity, and the amount-carrying
 // URL params all live in src/lib/give-routes.ts now — this page and /give mount
@@ -135,12 +134,9 @@ const STRINGS: Record<Locale, SupportStrings> = {
 export default function SupportView({
   stats,
   locale = 'en',
-  defaultRoute = 'international',
 }: {
   stats: SupportStats;
   locale?: Locale;
-  /** Resolved from the request country by the page; see defaultRouteForCountry. */
-  defaultRoute?: GiveRoute;
 }) {
   const s = STRINGS[locale];
   const homeHref = locale === 'es' ? '/es' : '/';
@@ -197,7 +193,14 @@ export default function SupportView({
                   that linked out with no amount attached, leaving the donor to
                   meet a $0.00 field on arrival — the anchor is the strongest
                   lever on gift size and we were forfeiting it. */}
-              <GiveForm defaultRoute={defaultRoute} locale={locale} surface="support" contactEmail={CONTACT_EMAIL} />
+              {/* Hardcoded `international`, NOT resolved from the request
+                  country — this page is edge-cached for 24h by the static-pages
+                  rule in next.config.ts, so any per-visitor default would be
+                  frozen to whoever warmed the cache (measured: cf-cache-status
+                  HIT, age 1202, on a page marked force-dynamic). `/give` is the
+                  country-aware surface and is not edge-cached; here the donor
+                  gets a visible "Giving from the United States?" switch. */}
+              <GiveForm defaultRoute="international" locale={locale} surface="support" contactEmail={CONTACT_EMAIL} />
 
               <p className="mt-5 text-xs text-stone-500 leading-relaxed">{s.taxNote}</p>
               <p className="mt-2 text-xs text-stone-500 leading-relaxed">

--- a/tests/unit/dynamic-routes-not-edge-cached.test.ts
+++ b/tests/unit/dynamic-routes-not-edge-cached.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import nextConfig from '../../next.config';
+
+/**
+ * A route cannot be both `force-dynamic` and edge-cached. If it is, the dynamic
+ * setting silently does nothing.
+ *
+ * `CDN-Cache-Control` in next.config.ts is applied by PATH, independently of the
+ * route's own rendering mode. So a page marked `force-dynamic` that also matches
+ * a `public, max-age=…` rule is still cached at the edge — Cloudflare serves one
+ * visitor's render to everyone for the TTL, and the per-request work runs once
+ * and is thrown away.
+ *
+ * This shipped in #3646: `/support` was made `force-dynamic` so the giving form
+ * could default its tax route from `x-vercel-ip-country`, while `/support` sits
+ * in the static-pages rule at `max-age=86400`. Production answered
+ * `cf-cache-status: HIT` with `age: 1202` on a supposedly dynamic page — every
+ * visitor got whichever country warmed the cache, plus a wasted Mongo call per
+ * request. Nothing failed; the personalisation was simply inert.
+ *
+ * This is an ABSENCE invariant across two files that cannot be checked from
+ * either one alone, and no unit-testable function expresses it — the pairing
+ * only exists at the edge. That is the case where a source-shape assertion earns
+ * its keep (CLAUDE.md: "A test that greps source is not a guard" — and its stated
+ * exception for absence invariants, like the soft-404 loading guard).
+ *
+ * Negative control, verified by hand: restoring `export const dynamic =
+ * 'force-dynamic'` to src/app/support/page.tsx turns this test red and names the
+ * route and the rule it collides with.
+ */
+
+const APP_DIR = join(__dirname, '../../src/app');
+
+/**
+ * Convert a next.config `source` pattern into a matcher over app route paths.
+ *
+ * Handles the three shapes this config actually uses, including a `:param` in
+ * the MIDDLE of a path (`/book/:id/preview`) — an earlier version only matched
+ * params in trailing position, so the two editor `/preview` overrides silently
+ * never matched and the test reported them as unprotected. A matcher that
+ * quietly fails to match reads exactly like a rule that isn't there.
+ *
+ * App routes carry Next's dynamic segments literally (`/book/[id]/preview`), and
+ * `[^/]+` matches `[id]` fine — no need to normalise the other side.
+ */
+function sourceMatcher(source: string): (route: string) => boolean {
+  const pattern = source
+    // Escape regex metacharacters EXCEPT the ones we are about to interpret:
+    // `(`/`)`/`|` form alternation groups, `:`/`*` form params.
+    .replace(/[.+?^${}\\]/g, '\\$&')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+    // `:name*` — zero or more trailing segments.
+    .replace(/:[a-zA-Z]+\*/g, '(?:.*)')
+    // `:name` — exactly one segment.
+    .replace(/:[a-zA-Z]+/g, '[^/]+');
+
+  // `/book/:path*` must match the bare `/book` too, not just `/book/x`.
+  const re = new RegExp(`^${pattern.replace(/\/\(\?:\.\*\)$/, '(?:/.*)?')}$`);
+  return (route) => re.test(route);
+}
+
+/** Walk src/app and return { route, file } for every page.tsx. */
+function collectPages(dir: string, out: { route: string; file: string }[] = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '_archived' || entry === 'api') continue;
+      collectPages(full, out);
+    } else if (entry === 'page.tsx') {
+      // src/app/support/page.tsx -> /support ; strip route groups and drop
+      // dynamic segments, which no CDN rule in this config keys on literally.
+      const rel = relative(APP_DIR, dir).replace(/\\/g, '/');
+      const route =
+        '/' +
+        rel
+          .split('/')
+          .filter((s) => s && !s.startsWith('(') && !s.startsWith('@'))
+          .join('/');
+      out.push({ route: route === '/' ? '/' : route, file: full });
+    }
+  }
+  return out;
+}
+
+/**
+ * EVERY CDN-Cache-Control rule from the real config, in declaration order.
+ *
+ * Order is load-bearing and must not be collapsed. next.config.ts deliberately
+ * places narrow overrides AFTER the broad rule they correct — `/book/:id/preview`
+ * is `private, no-store` sitting after `/book/:path*` is `max-age=86400`, with a
+ * comment saying exactly that. A matcher that returns "any matching rule" reports
+ * those correctly-protected editor routes as cache collisions; only the LAST
+ * match is the effective header. (First version of this test did that and
+ * produced two false positives — the fixture was wrong, not the code.)
+ */
+async function cdnRules(): Promise<{ source: string; value: string }[]> {
+  const headers = await (nextConfig as { headers?: () => Promise<unknown[]> }).headers?.();
+  expect(Array.isArray(headers)).toBe(true);
+
+  const rules: { source: string; value: string }[] = [];
+  for (const entry of headers as {
+    source: string;
+    headers: { key: string; value: string }[];
+  }[]) {
+    for (const h of entry.headers ?? []) {
+      if (h.key.toLowerCase() !== 'cdn-cache-control') continue;
+      rules.push({ source: entry.source, value: h.value });
+    }
+  }
+  return rules;
+}
+
+function isPublicCached(value: string): boolean {
+  if (!/public/i.test(value)) return false;
+  const maxAge = value.match(/max-age=(\d+)/i);
+  return !!maxAge && Number(maxAge[1]) > 0;
+}
+
+/** The effective CDN-Cache-Control for a route: the last rule that matches it. */
+function effectiveRule(
+  route: string,
+  rules: { source: string; value: string }[],
+): { source: string; value: string } | undefined {
+  let winner: { source: string; value: string } | undefined;
+  for (const r of rules) if (sourceMatcher(r.source)(route)) winner = r;
+  return winner;
+}
+
+/** Routes whose effective CDN rule caches them publicly at the edge. */
+async function publicCdnRules(): Promise<{ source: string; value: string }[]> {
+  return (await cdnRules()).filter((r) => isPublicCached(r.value));
+}
+
+describe('no route is both force-dynamic and edge-cached', () => {
+  it('reads real CDN rules out of next.config.ts', async () => {
+    const rules = await publicCdnRules();
+    // If this ever hits zero the test has stopped testing anything — the config
+    // shape changed and every assertion below would pass vacuously.
+    expect(rules.length).toBeGreaterThan(5);
+    expect(rules.some((r) => r.source.includes('/book/'))).toBe(true);
+  });
+
+  it('finds the app routes it is supposed to be checking', () => {
+    const pages = collectPages(APP_DIR);
+    expect(pages.length).toBeGreaterThan(50);
+    expect(pages.some((p) => p.route === '/support')).toBe(true);
+    expect(pages.some((p) => p.route === '/give')).toBe(true);
+  });
+
+  /**
+   * Pre-existing collisions, inherited — NOT introduced by #3646/#3647.
+   *
+   * Each of these declares `force-dynamic` while its effective CDN rule caches it
+   * publicly for 24h, so the dynamic rendering is served from cache anyway. Not
+   * fixed here because each needs its own judgement: some may be dynamic to read
+   * `headers()` for tenant scoping (safe, since Cloudflare keys the cache per
+   * hostname), others may genuinely want the TTL gone. Filed for triage rather
+   * than changed blind — this PR's job is to stop ADDING to the list.
+   *
+   * Shrink this array when you fix one. Never grow it without saying why.
+   */
+  const KNOWN_COLLISIONS = new Set([
+    '/blog/man-his-own-maker',
+    '/blog/singularity-1486',
+    '/book/[id]/overview',
+    '/browse/artists/[letter]',
+    '/browse/authors/[letter]',
+    '/browse/titles/[letter]',
+    '/browse/years/[period]',
+    '/collections/[id]',
+    '/collections/mycology',
+    '/libraries/[slug]',
+  ]);
+
+  it('no NEW force-dynamic page sits under a public max-age CDN rule', async () => {
+    const rules = await cdnRules();
+
+    const collisions: string[] = [];
+    for (const { route, file } of collectPages(APP_DIR)) {
+      const src = readFileSync(file, 'utf8');
+      // Strip comments so prose ABOUT force-dynamic (this fix leaves plenty)
+      // cannot masquerade as the declaration itself.
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      if (!/export\s+const\s+dynamic\s*=\s*['"]force-dynamic['"]/.test(code)) continue;
+
+      const hit = effectiveRule(route, rules);
+      if (!hit || !isPublicCached(hit.value)) continue;
+      if (KNOWN_COLLISIONS.has(route)) continue;
+      collisions.push(`${route} (${relative(APP_DIR, file)}) vs rule "${hit.source}" → ${hit.value}`);
+    }
+
+    expect(collisions).toEqual([]);
+  });
+
+  it('the editor-only preview routes are protected by their narrower later rule', async () => {
+    // Guards the precedence the config comment depends on: `/book/:id/preview` is
+    // declared `private, no-store` AFTER the broad `/book/:path*` max-age rule.
+    // If someone reorders those, a cached editor 200 could be served to anon
+    // users — the leak the override exists to prevent.
+    const rules = await cdnRules();
+    for (const route of ['/book/[id]/preview', '/book/[id]/page/[pageId]/preview']) {
+      const hit = effectiveRule(route, rules);
+      expect(hit, `no CDN rule matched ${route}`).toBeDefined();
+      expect(isPublicCached(hit!.value), `${route} is publicly edge-cached`).toBe(false);
+    }
+  });
+
+  it('/give — the country-aware giving surface — is NOT edge-cached', async () => {
+    // The whole point of the fix: personalisation lives on the uncached route.
+    const rules = await publicCdnRules();
+    const matched = rules.filter((r) => sourceMatcher(r.source)('/give'));
+    expect(matched).toEqual([]);
+  });
+
+  it('/support IS edge-cached, so nothing there may depend on the request', async () => {
+    // Stated as a positive assertion so that removing /support from the static
+    // rule (which would reopen the scraper exposure the rule exists for) is a
+    // deliberate, visible change rather than a silent one.
+    const rules = await publicCdnRules();
+    const matched = rules.filter((r) => sourceMatcher(r.source)('/support'));
+    expect(matched.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Follow-up to #3646, fixing a defect that PR introduced.

## What was wrong

#3646 made `/support` (and `/es/support`) `force-dynamic` so `<GiveForm>` could default its tax route from `x-vercel-ip-country`. **That was inert.** `/support` is listed in the static-pages rule in `next.config.ts`:

```
source: '/(privacy|terms|dmca|support|sponsors|developers|contribute|beta)'
CDN-Cache-Control: public, max-age=86400, stale-while-revalidate=3600
```

`CDN-Cache-Control` is applied by **path**, independently of the route's rendering mode — so Cloudflare cached the "dynamic" page anyway. Measured on production after the merge:

```
cache-control:     private, no-cache, no-store, max-age=0, must-revalidate
cdn-cache-control: public, max-age=86400, stale-while-revalidate=3600
cf-cache-status:   HIT
age:               1202
```

Every visitor got whichever country happened to warm the cache, frozen for 24h, plus a per-request Mongo call that bought nothing. Nothing errored; the personalisation was simply dead.

For contrast, `/give` carries no `CDN-Cache-Control`, answers `cf-cache-status: BYPASS`, and its country routing works correctly. `/give` is where the header's Support button points, so the main path was always fine.

## The fix

Stop depending on the request on `/support`, rather than punching a hole in the edge cache.

That TTL is load-bearing — the rule's own comment records a June 2026 scraper flood of ~1.3M req/day aimed at exactly these pages, all of which reached Vercel. Removing `/support` from the group to rescue a country default on a page drawing **~2 views/day** is a bad trade.

- `/support` + `/es/support` back to `revalidate = 600`, no `headers()` read, no per-request Mongo call.
- `SupportView`'s `defaultRoute` prop **removed** rather than left defaulted. A prop nobody passes, documented as "resolved from the request country", is a trap for the next person; `<GiveForm>` is now mounted with a literal `"international"` and a comment saying why.
- Donors on `/support` get the visible "Giving from the United States?" switch — one click, already shipped.

## The guard

`tests/unit/dynamic-routes-not-edge-cached.test.ts` asserts the class: **no route may be both `force-dynamic` and publicly edge-cached.** It imports the real `next.config.ts`, resolves each route's *effective* rule, and walks `src/app`.

This is an absence invariant spanning two files that neither one can express alone, and no runtime function encodes it — the pairing only exists at the edge. That's the stated exception to "a test that greps source is not a guard", same shape as the soft-404 loading guard.

**It found 10 pre-existing collisions**, none introduced here — `/collections/[id]`, `/collections/mycology`, `/libraries/[slug]`, the four `/browse/*/[letter]` pages, `/book/[id]/overview`, and two blog posts. They're allowlisted with a comment rather than changed blind: each needs its own call (some are likely dynamic to read `headers()` for tenant scoping, which is safe since Cloudflare keys per hostname). **This PR's job is to stop adding to the list.** Worth separate triage.

## Two test bugs found and fixed before trusting it

- **Rule precedence.** The first version flagged `/book/[id]/preview` and `/book/[id]/page/[pageId]/preview` as unprotected. They aren't — `next.config.ts` declares `private, no-store` for them *after* the broad `/book/:path*` rule, which the config comment explicitly relies on. Only the **last** matching rule is effective. The fixture was wrong, not the code. There's now a test pinning that ordering, because reordering those rules could serve a cached editor 200 to anon users.
- **Mid-path params.** The matcher only handled `:param` in trailing position, so `/book/:id/preview` never matched anything and read exactly like a rule that doesn't exist.

## Verification

- `npx tsc --noEmit` clean; **1,881 unit tests pass** (137 files).
- Three negative controls, all red as required: re-adding `force-dynamic` to `/support`; deleting the narrow `/preview` override so the broad `/book` rule wins; and emptying the allowlist, which reports **exactly** the 10 known collisions — confirming it is neither stale nor over-broad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
