### PR TITLE
fix(analytics): refuse a stale snapshot instead of serving four-month-old totals

### DIFF
--- a/src/app/api/analytics/usage/route.ts
+++ b/src/app/api/analytics/usage/route.ts
@@ -9,6 +9,11 @@ export const maxDuration = 30;
 const cache = new Map<string, { data: any; timestamp: number }>();
 const CACHE_TTL_MS = 60 * 1000; // 1 minute (Supabase queries are fast)
 
+// Oldest a snapshot may be and still be served. `analytics_usage` is refreshed
+// hourly, so anything past a couple of days means its writer has stopped and
+// the honest answer is "not measurable", not a plausible stale total.
+const MAX_SNAPSHOT_AGE_MS = 2 * 24 * 60 * 60 * 1000;
+
 export const GET = withAuth(async (request: NextRequest, session) => {
   try {
     const { searchParams } = new URL(request.url);
@@ -137,12 +142,45 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     ]);
 
     // === Unpack snapshot (or fall back to dashboard_snapshot) ===
+    //
+    // The fallback exists for the cold case where `analytics_usage` has never
+    // been seeded. It is NOT a stand-in for a rollup that has stopped writing:
+    // `dashboard_snapshot` has no writer on any current path and was measured
+    // at 126 days old on 2026-08-06, so serving it silently would put
+    // four-month-old totals on the dashboard with nothing to say so.
+    //
+    // A number that looks authoritative and is wrong is worse than no number
+    // (`.claude/docs/invariants/measurement-instruments.md`). So: refuse
+    // anything past MAX_SNAPSHOT_AGE_MS, and always report the age and source
+    // of whatever we did serve, so the UI can label it.
     let snap = snapshot?.data;
+    let snapshotSource: 'analytics_usage' | 'dashboard_snapshot' | 'none' =
+      snap ? 'analytics_usage' : 'none';
+    let snapshotUpdatedAt: string | null = snapshot?.updated_at
+      ? new Date(snapshot.updated_at).toISOString()
+      : null;
+
     if (!snap) {
-      // Fall back to dashboard_snapshot if analytics_usage hasn't been seeded yet
       const fallback = await db.collection('system_config').findOne({ _id: 'dashboard_snapshot' } as any);
-      snap = fallback?.data;
+      const fallbackAt = fallback?.updated_at ? new Date(fallback.updated_at) : null;
+      const fallbackAge = fallbackAt ? Date.now() - fallbackAt.getTime() : Infinity;
+
+      if (fallback?.data && fallbackAge <= MAX_SNAPSHOT_AGE_MS) {
+        snap = fallback.data;
+        snapshotSource = 'dashboard_snapshot';
+        snapshotUpdatedAt = fallbackAt!.toISOString();
+      } else {
+        console.warn(
+          `[analytics/usage] analytics_usage missing and dashboard_snapshot is ` +
+          `${Number.isFinite(fallbackAge) ? Math.round(fallbackAge / 86_400_000) + 'd' : 'undated'} old ` +
+          `(max ${MAX_SNAPSHOT_AGE_MS / 86_400_000}d) — serving no snapshot rather than stale totals`
+        );
+      }
     }
+
+    const snapshotAgeMs = snapshotUpdatedAt
+      ? Date.now() - new Date(snapshotUpdatedAt).getTime()
+      : null;
 
     const canon = snap?.canon || {};
     const coverage = snap?.coverage || {};
@@ -238,6 +276,16 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     };
 
     const responseData = {
+      // Provenance for the corpus totals below. `summary` comes from a
+      // periodic rollup, not from a live count, so the UI must be able to say
+      // how old it is — and `source: 'none'` means we refused a stale snapshot
+      // and the totals are zeroes, which must NOT be rendered as real figures.
+      snapshot: {
+        source: snapshotSource,
+        updatedAt: snapshotUpdatedAt,
+        ageMs: snapshotAgeMs,
+        stale: snapshotAgeMs !== null && snapshotAgeMs > MAX_SNAPSHOT_AGE_MS,
+      },
       summary: {
         totalBooks, totalPages, pagesWithOcr, pagesWithTranslation,
         ocrPercentage: totalPages > 0 ? Math.round((pagesWithOcr / totalPages) * 100) : 0,

--- a/src/components/analytics/tabs/UsageTab.tsx
+++ b/src/components/analytics/tabs/UsageTab.tsx
@@ -44,10 +44,37 @@ export default function UsageTab({ days }: UsageTabProps) {
   );
   if (!data) return null;
 
+  // The corpus totals come from a periodic rollup. If it is missing or was
+  // refused as too stale, `summary` is zeroes — say so instead of rendering
+  // them, because a plausible wrong number is worse than no number.
+  const snap = data.snapshot;
+  const summaryUnavailable = snap ? snap.source === 'none' : false;
+  const snapAgeHours = snap?.ageMs != null ? snap.ageMs / 3_600_000 : null;
+
   return (
     <div className="space-y-8">
+      {summaryUnavailable && (
+        <div
+          className="flex items-start gap-3 p-4 rounded-xl"
+          style={{ background: 'var(--bg-warm)', border: '1px solid var(--border-light)' }}
+        >
+          <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" style={{ color: '#b45309' }} />
+          <div className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            <strong style={{ color: 'var(--text-primary)' }}>Corpus totals unavailable.</strong>{' '}
+            The rollup that feeds them has not been written recently enough to trust, so they are not
+            shown rather than shown wrong. Everything below is queried live and is unaffected.
+          </div>
+        </div>
+      )}
+      {snap && snap.source === 'dashboard_snapshot' && snapAgeHours != null && (
+        <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+          Corpus totals are from a fallback snapshot{' '}
+          {snapAgeHours < 48 ? `${Math.round(snapAgeHours)}h` : `${Math.round(snapAgeHours / 24)}d`} old.
+        </p>
+      )}
+
       {/* Summary Cards */}
-      {data.summary && (
+      {data.summary && !summaryUnavailable && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
           <div className="p-4 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
             <div className="flex items-center gap-2 mb-2">

--- a/src/lib/api-client/types/analytics.ts
+++ b/src/lib/api-client/types/analytics.ts
@@ -23,6 +23,18 @@ export interface TrackEventRequest {
 }
 
 export interface UsageStats {
+  /**
+   * Provenance of `summary`. Those totals come from a periodic rollup, not a
+   * live count. `source: 'none'` means the rollup was missing or too stale to
+   * serve, so `summary` is zeroes — render that as "unavailable", never as
+   * real figures.
+   */
+  snapshot?: {
+    source: 'analytics_usage' | 'dashboard_snapshot' | 'none';
+    updatedAt: string | null;
+    ageMs: number | null;
+    stale: boolean;
+  };
   summary: {
     totalBooks: number;
     totalPages: number;


### PR DESCRIPTION
Addresses the one finding in #3657 that survived verification and is safely fixable now.

## The problem

`src/app/api/analytics/usage/route.ts` falls back to `system_config.dashboard_snapshot` when `analytics_usage` is absent:

```ts
// Fall back to dashboard_snapshot if analytics_usage hasn't been seeded yet
const fallback = await db.collection('system_config').findOne({ _id: 'dashboard_snapshot' });
snap = fallback?.data;
```

**That fallback measured 126 days old on 2026-08-06** and has no writer on any current path. It is harmless *today* only because the primary happens to be fresh (1.3h). If the primary ever stopped, the Usage tab would have rendered four-month-old corpus totals — books, pages, OCR coverage, translation coverage — with nothing on screen indicating they were stale.

Exactly the failure `measurement-instruments.md` describes: *a number that looks authoritative and is wrong is worse than no number*, and *when an instrument is broken, say so instead of printing a number*. This applies it to the instrument itself.

## The change

- **Refuse a snapshot older than `MAX_SNAPSHOT_AGE_MS`** (2 days, against an hourly-refreshed primary), and `console.warn` the reason and the measured age.
- **Return a `snapshot` block** — `source` (`analytics_usage` | `dashboard_snapshot` | `none`), `updatedAt`, `ageMs`, `stale` — so the client can never be in the position of not knowing what it is showing.
- **`UsageTab` renders "Corpus totals unavailable"** instead of the zeroes when `source: 'none'`, and notes the age when a fallback is legitimately in use.
- Everything else on the tab is queried live and is untouched by this.

## Risk

Low. The only behaviour change is in a path that is currently never taken (the primary is fresh), and the failure direction is now *withholding* a number rather than showing a wrong one. `npx tsc --noEmit` clean.

The 2-day threshold is a judgement call: the primary refreshes hourly, so anything beyond a couple of days means its writer has stopped. Easy to tune.

## Scope

Not in this PR, deliberately:

- **`page_read` over-counts ~6× vs pageviews** (#3657). Real, but the mechanism needs browser instrumentation rather than a guess — see the issue.
- **Excluding editor surfaces from `page_read`** — I proposed this and then found it is a **no-op**: `TranslationEditor` is rendered only by `PageEditorClient`, which is mounted only by `src/app/book/[id]/page/[pageId]/(reader)/page.tsx`, the public reader route. There is no separate admin mount; the component name is legacy. Recording it here so nobody re-derives it.
- Dashboard unit labelling for pageviews vs `page_read` — UI work with a design decision in it.
