### PR TITLE
feat(analytics): attribute /give visits at the control, since referrers cannot

### DIFF
--- a/src/components/layout/GlobalFooter.tsx
+++ b/src/components/layout/GlobalFooter.tsx
@@ -8,6 +8,7 @@ import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 import FeedbackCallout from '@/components/feedback/FeedbackCallout';
 import ReaderPresence from '@/components/presence/ReaderPresence';
 import { clearConsent } from '@/lib/consent';
+import { trackEvent } from '@/lib/track-event';
 import { useIsEmbedded } from '@/hooks/useEmbedContext';
 import { visibleFooterNavColumns } from '@/lib/footer-nav';
 import { useLocale, FOOTER_STRINGS } from '@/lib/i18n';
@@ -104,6 +105,13 @@ export default function GlobalFooter() {
                     {link.key === 'support' ? (
                       <Link
                         href={link.href}
+                        // Instrumented alongside the header pill so the two paths
+                        // are comparable. Before the pill existed this footer link
+                        // was the ONLY route to giving, and it drew 60 of 330,698
+                        // pageviews in 30 days — the baseline the pill is meant to
+                        // beat. Attributing the split needs an event at each
+                        // control; the referrer cannot tell them apart.
+                        onClick={() => trackEvent('give_nav_click', { source: 'footer', url: link.href })}
                         className="text-sm text-white/50 hover:text-white transition-colors inline-flex items-center gap-1.5"
                       >
                         {t[link.key]}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -9,6 +9,7 @@ import { Search, ChevronDown } from 'lucide-react';
 import { useLocale, localeHref, hasLocalizedTwin, NAV_STRINGS, type NavStrings, type Locale } from '@/lib/i18n';
 import { isGlobalOnlyNavHref } from '@/lib/tenant-global-paths';
 import { useIsEmbedded } from '@/hooks/useEmbedContext';
+import { trackEvent } from '@/lib/track-event';
 
 interface NavLink {
   label: string;
@@ -236,6 +237,12 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
           {showSupport && (
             <Link
               href="/give"
+              // Fired here, at the control, because nothing downstream can
+              // reconstruct it: /api/track collapses self-referrals to 'direct'
+              // and client-side navigation preserves the original external
+              // referrer, so an arrival at /give cannot be attributed after the
+              // fact. trackEvent uses sendBeacon, which survives this navigation.
+              onClick={() => trackEvent('give_nav_click', { source: 'header', url: '/give' })}
               className={`whitespace-nowrap rounded-full border px-3 py-1.5 text-sm font-medium tracking-wide transition-colors ${
                 isWhiteText
                   ? 'border-white/40 text-white hover:bg-white hover:text-dark'

--- a/src/lib/analytics-event-allowlist.ts
+++ b/src/lib/analytics-event-allowlist.ts
@@ -33,6 +33,21 @@ export const ALLOWED_EVENTS = new Set([
   // reaches it" were the same observation. Read them as intent, never revenue —
   // the gift lands in EFM's Stripe or NAF's DonorPerfect, not here.
   'donate_click', 'inquiry_click',
+  // give_nav_click: someone pressed a control that navigates TO /give (the header
+  // Support pill, the footer link). Fired at the control, not on arrival, because
+  // referrers cannot recover this: /api/track deliberately collapses self-referrals
+  // to 'direct', and Next's client-side navigation leaves document.referrer as the
+  // ORIGINAL external referrer — so a reader who came from Google and then clicked
+  // the pill is logged identically to one who typed the URL. Measured 2026-08-07,
+  // /give had 7 visits (4 'direct', 3 Google) and the field could not attribute a
+  // single one. Pairs with the /give pageview count (total arrivals) and
+  // donate_click (actual gives) to make a three-step funnel.
+  //
+  // `source` names the CONTROL ('header' | 'footer'), `url` its DESTINATION —
+  // they differ: the header pill goes to /give, the footer link to /support.
+  // Recording only the control would silently merge two funnels with different
+  // pages and different conversion odds.
+  'give_nav_click',
 ]);
 
 // Only these prop keys are persisted; everything else is dropped.

--- a/src/lib/track-event.ts
+++ b/src/lib/track-event.ts
@@ -35,7 +35,12 @@ export function trackEvent(
     // the last thing we can see — the gift itself lands in someone else's system
     // with no webhook back to us. Never treat the count as revenue.
     | 'donate_click'
-    | 'inquiry_click',
+    | 'inquiry_click'
+    // give_nav_click: a press on a control that navigates to /give, carrying
+    // `source` ('header' | 'footer'). The referrer cannot answer this — see the
+    // note in analytics-event-allowlist.ts. Relies on this function's sendBeacon
+    // transport to survive the navigation it triggers.
+    | 'give_nav_click',
   props?: Record<string, string | number | boolean | undefined>,
 ): void {
   if (typeof window === 'undefined') return;

--- a/tests/unit/give-nav-attribution.test.ts
+++ b/tests/unit/give-nav-attribution.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ALLOWED_EVENTS, ALLOWED_PROPS } from '@/lib/analytics-event-allowlist';
+
+/**
+ * Guards the only measurement that can attribute a visit to /give.
+ *
+ * The referrer cannot do it, in two independent ways: `/api/track` collapses
+ * self-referrals to 'direct' (`if (hostname !== SITE_HOST)`), and Next's
+ * client-side navigation leaves `document.referrer` as the ORIGINAL external
+ * referrer. Measured 2026-08-07, /give had 7 visits — 4 'direct', 3 Google — and
+ * not one could be attributed to the header pill or to a stranger typing the URL.
+ *
+ * So the event has to be fired AT the control, and if a refactor drops the
+ * onClick the loss is silent: the page still works, the link still navigates, and
+ * the funnel just reads zero forever — indistinguishable from nobody clicking,
+ * which is exactly the question it exists to answer.
+ *
+ * The payload assertions run the REAL allowlists, so an event or prop that the
+ * route would silently drop fails here rather than weeks later.
+ */
+
+const SRC = join(__dirname, '../../src');
+const read = (p: string) => readFileSync(join(SRC, p), 'utf8');
+
+// Strip comments before matching: this file's own subject is heavily commented,
+// and prose ABOUT the call must not satisfy a check for the call.
+const code = (p: string) =>
+  read(p).replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('give_nav_click survives the analytics allowlist', () => {
+  it('the event name is accepted by the route', () => {
+    expect(ALLOWED_EVENTS.has('give_nav_click')).toBe(true);
+  });
+
+  it('both props it carries are persisted, not silently dropped', () => {
+    for (const key of ['source', 'url']) {
+      expect(ALLOWED_PROPS.has(key), `prop "${key}" is not allowlisted`).toBe(true);
+    }
+  });
+});
+
+describe('both giving controls are instrumented', () => {
+  // Asserted as a composite string so the call cannot be satisfied by the token
+  // appearing somewhere else in the file — the failure mode that let two earlier
+  // guards in this repo pass with the code they guarded deleted (#3484/#3488).
+  it('the header Support pill fires give_nav_click with source=header', () => {
+    const header = code('components/layout/SiteHeader.tsx');
+    expect(header).toMatch(
+      /trackEvent\(\s*['"]give_nav_click['"]\s*,\s*\{[^}]*source:\s*['"]header['"]/,
+    );
+  });
+
+  it('the footer Support link fires give_nav_click with source=footer', () => {
+    const footer = code('components/layout/GlobalFooter.tsx');
+    expect(footer).toMatch(
+      /trackEvent\(\s*['"]give_nav_click['"]\s*,\s*\{[^}]*source:\s*['"]footer['"]/,
+    );
+  });
+
+  it('each control records its DESTINATION, because the two differ', () => {
+    // header pill → /give, footer link → /support. Merging them would average two
+    // pages with different conversion odds into one meaningless rate.
+    expect(code('components/layout/SiteHeader.tsx')).toMatch(
+      /trackEvent\(\s*['"]give_nav_click['"][^)]*url:\s*['"]\/give['"]/,
+    );
+    expect(code('components/layout/GlobalFooter.tsx')).toMatch(
+      /trackEvent\(\s*['"]give_nav_click['"][^)]*url:\s*link\.href/,
+    );
+  });
+
+  it('the pill still points at /give — the event is worthless if the href moves', () => {
+    expect(code('components/layout/SiteHeader.tsx')).toMatch(/href="\/give"/);
+  });
+});
+
+describe('the transport can survive the navigation it triggers', () => {
+  it('trackEvent uses sendBeacon', () => {
+    // A plain fetch is cancelled when the click navigates away, so every one of
+    // these events would be lost in flight — the instrument would read zero for a
+    // reason that has nothing to do with readers.
+    expect(code('lib/track-event.ts')).toMatch(/navigator\.sendBeacon/);
+  });
+
+  it('give_nav_click is a declared event type on trackEvent', () => {
+    expect(code('lib/track-event.ts')).toMatch(/\|\s*['"]give_nav_click['"]/);
+  });
+});


### PR DESCRIPTION
Makes the giving funnel measurable. Follow-up to #3646/#3649.

## The problem

`/give` drew **7 visits in 36 hours** (against 22,474 pageviews, 17,683 of them human book-page views) and **not one could be attributed**. Four logged `direct`, three logged Google.

That is not a sampling problem — the referrer field structurally cannot answer the question, for two independent reasons:

1. **`/api/track` collapses self-referrals.** `if (hostname !== SITE_HOST) referrerDomain = hostname;` — otherwise it stays `'direct'`. So an internal click from a book page is byte-identical to a stranger typing the URL.
2. **Client-side navigation preserves the original referrer.** Next's `<Link>` does not reload the document, so `document.referrer` remains whatever external page started the session. A reader who arrived from Google and *then* clicked the header pill logs as `google.com`.

Between them, "did the header pill work?" was unanswerable in either direction — including the direction that flatters it. I previously read those referrers as "nobody clicked the header," which was an unsound inference from a field that cannot carry that signal.

## The fix

Fire the event **at the control**, where the information still exists:

- Header Support pill → `give_nav_click { source: 'header', url: '/give' }`
- Footer Support link → `give_nav_click { source: 'footer', url: '/support' }`

`source` names the control, `url` its **destination** — those differ, and merging them would average two pages with different conversion odds into one meaningless rate. The footer link was the *only* route to giving before the pill existed (60 of 330,698 pageviews in 30 days), so it is the baseline the pill has to beat.

Combined with the existing signals this gives a real three-step funnel where there was one unattributable number:

| step | signal |
|---|---|
| intent | `give_nav_click` by `source` |
| arrival | `/give` pageviews |
| gift | `donate_click` with `amount` + `frequency` |

## Verification

- `npx tsc --noEmit` clean; **1,940 unit tests pass** (143 files).
- **All 6 negative controls go red**: dropping the header `onClick`; dropping the footer `onClick`; removing `give_nav_click` from `ALLOWED_EVENTS` (the silent-drop path — route answers 200 and the field is simply absent later); dropping the destination so the two funnels merge; replacing `sendBeacon` (a plain fetch is cancelled by the navigation the click triggers, so every event would die in flight); and moving the pill's `href` off `/give`.
- The payload assertions run the **real** `ALLOWED_EVENTS` / `ALLOWED_PROPS` sets, so drift on either side is red here rather than discovered weeks later by an empty query.
- Source assertions are composite patterns (`trackEvent('give_nav_click', {… source: 'header'`) rather than bare tokens, and comments are stripped before matching — the failure that let two earlier guards in this repo pass with their subject deleted (#3484/#3488).

## Note on what this does not do

It measures the funnel; it does not improve it. `donate_click` is still **0 all-time**. If the pill turns out to be genuinely unclicked once this can distinguish that from an instrument gap, the answer is likely an in-reader ask rather than a louder header — Wikipedia's revenue comes from the banner in the reading context, not its nav link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
