### PR TITLE
fix(ft): adjudicate the English-badged books through the ledger, not a bulk flag (#3524)

### DIFF
--- a/.claude/docs/invariants/image-classifiers-and-splits.md
+++ b/.claude/docs/invariants/image-classifiers-and-splits.md
@@ -1,6 +1,6 @@
 # A classifier over images cannot validate itself
 
-**Read this when:** Writing a detector over page images, splitting spreads (`src/lib/spread-guard.ts`), or running a corpus-wide image repair sweep.
+**Read this when:** Writing a detector over page images or page OCR, sampling a book's pages to classify it, splitting spreads (`src/lib/spread-guard.ts`), or running a corpus-wide image repair sweep.
 
 *Split out of `CLAUDE.md` on 2026-08-04. The text is unchanged apart from cross-references repointed to their new files. See `.claude/docs/knowledge-layer.md` for why this tier exists.*
 
@@ -55,6 +55,31 @@ Corollary of the invented-fixture rule (`tests-that-are-not-guards.md`), met the
 11%-wide gutter puts the detector's flank-confirmation window entirely inside the
 gutter), not because the detector was wrong. Check the fixture against a real image
 before concluding the code is broken.
+
+**Sampling a book's pages is itself a classifier, and it has two standard failure modes**
+(2026-08-06, #3524, adjudicating 55 books badged "first English translation" while tagged
+English). Both shipped confident, internally consistent, wrong answers.
+
+- **`pages.ocr` is an OBJECT, not a string** — `{ data, model, prompt_hash, prompt_id,
+  prompt_name, prompt_version, source, updated_at }`. The text is `ocr.data`.
+  `String(p.ocr)` yields `"[object Object]"`, fifteen characters, so any
+  `length >= N` content filter matches *nothing*. The first run reported a clean "no
+  content pages sampled" for all 55 books and looked like a finding. (Documented in
+  `page-system.md` and `page-lifecycle.md` — the failure was not consulting them.)
+- **The FRONT of a book lies, not just page 1.** It is already known that page 1 is a
+  cover whose OCR `<language>` tag describes modern pencil cataloguing marks. The larger
+  trap is one level up: a scholarly edition of a Latin text opens with an English title
+  page, preface and introduction. Quignones' *Breviarium Romanum*, Feltoe's
+  *Sacramentarium Leonianum* and Little's *Opus Tertium* all read English for a dozen
+  content pages and are solidly Latin at pages 112, 113 and 63. Sampling the first N
+  content pages measures the **apparatus**, not the text — it put three legitimate
+  first-translation badges one step from demotion. Spread the sample across the interior
+  (`spreadSample()` in `scripts/audit/ft-english-badged-classify.mjs` trims ~15% front,
+  ~5% back).
+
+The general form: **when a probe returns "nothing found" for every input, that is a
+result about the probe.** Give it a positive control — a case you know should come back
+positive — before believing a negative. The same session's badge check hit this twice.
 
 **Splitting specifically:** `src/lib/spread-guard.ts` refuses to split an image that is
 not a spread, using content (a central ink-free channel with text on *both* sides) not

--- a/scripts/audit/ft-english-badged-classify.mjs
+++ b/scripts/audit/ft-english-badged-classify.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * ft-english-badged-classify.mjs — issue #3524.
+ *
+ * Books badged "first English translation" while `books.language` says English.
+ * That set looks like one bug and is three, needing OPPOSITE fixes — a bulk
+ * demote would strip genuine badges from Hebrew and Latin works whose language
+ * field is simply wrong. So this script only ever CLASSIFIES and reports; the
+ * writes live in `scripts/maintenance/ft-english-badged-adjudicate.mjs`.
+ *
+ * Why page 1 lies: the first page of a scan is nearly always a cover or flyleaf,
+ * and its OCR `<language>` tag describes the modern pencil cataloguing
+ * annotations, not the text. That is how a 12/12-Hebrew book ends up tagged
+ * English. So we sample CONTENT pages only (>= MIN_CONTENT_CHARS of OCR) and
+ * take the modal tag, plus a non-Latin script census of the body text.
+ *
+ * Why the FRONT of the book lies too — the same trap one level up, and the one
+ * that nearly demoted three legitimate badges on 2026-08-06. A scholarly edition
+ * of a Latin text carries an English title page, preface and introduction: the
+ * first dozen content pages of Quignones' *Breviarium Romanum*, Feltoe's
+ * *Sacramentarium Leonianum* and Little's *Opus Tertium* all read English while
+ * pages 112, 113 and 63 are solidly Latin. Sampling the first N content pages
+ * therefore measures the APPARATUS, not the text. We spread the sample evenly
+ * across the interior instead, skipping the front and back matter.
+ *
+ * Classes:
+ *   1  `books.language` is wrong; the badge is probably RIGHT.  Fix the language.
+ *   2  the text really is English; a "first English translation" of an English
+ *      work is not a claim that can be true.  Demote via `not_applicable`.
+ *   3  not enough OCR sampled to decide.  Send to the Tier-2 queue.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/audit/ft-english-badged-classify.mjs
+ *   node --env-file=.env.production.local scripts/audit/ft-english-badged-classify.mjs --json out.json
+ */
+import { MongoClient } from 'mongodb';
+import { writeFileSync } from 'node:fs';
+
+const MAX_PAGES = 12;
+const MIN_CONTENT_CHARS = 700;
+/** Skip this share of content pages at the front (title page, preface, introduction). */
+const SKIP_FRONT = 0.15;
+/** Skip this share at the back (indices, colophons, publisher's advertisements). */
+const SKIP_BACK = 0.05;
+/** Body-text non-Latin characters above this mean the text is genuinely not English. */
+const NONLATIN_REAL = 2000;
+/** Between this and NONLATIN_REAL: quotation-scale. Report, do not auto-classify. */
+const NONLATIN_QUOTE = 400;
+/** Share of sampled content pages that must read English to call the text English. */
+const ENGLISH_SHARE = 0.6;
+/**
+ * A demote must never rest on a thin sample. The Ānandakanda had exactly ONE
+ * readable content page reading English — an editor's preface in front of a
+ * Sanskrit text. Below this, the answer is "we don't know" (class 3), not
+ * "it's English".
+ */
+const MIN_SAMPLE_TO_DEMOTE = 4;
+/** Above this share, "the text is English" is unarguable and safe to auto-apply. */
+const CLEAR_SHARE = 0.85;
+
+const SCRIPTS = [
+  ['HEBREW', /[֐-׿]/g],
+  ['ARABIC', /[؀-ۿݐ-ݿ]/g],
+  ['GREEK', /[Ͱ-Ͽἀ-῿]/g],
+  ['CYRILLIC', /[Ѐ-ӿ]/g],
+  ['CJK', /[぀-ヿ一-鿿]/g],
+  ['DEVANAGARI', /[ऀ-ॿ]/g],
+  ['TIBETAN', /[ༀ-࿿]/g],
+  ['ARMENIAN', /[԰-֏]/g],
+  ['MALAYALAM', /[ഀ-ൿ]/g],
+  ['SYRIAC', /[܀-ݏ]/g],
+];
+
+const ENGLISH_TAGS = new Set(['en', 'eng', 'english', 'en-gb', 'en-us', 'modern english', 'early modern english']);
+/** Tags the OCR emits when it could not read a language off the page. Never a vote. */
+const NULL_TAGS = new Set(['none', 'n/a', 'na', 'null', 'unknown', 'undetermined', '-', '']);
+
+/**
+ * `pages.ocr` is an OBJECT — `{ data, model, prompt_hash, … }` — not a string.
+ * Coercing it with String() yields "[object Object]" (15 chars), which silently
+ * fails every length filter and reports a clean, wrong "no content pages" for
+ * the whole corpus. Always read `.data`.
+ */
+function ocrText(ocr) {
+  if (typeof ocr === 'string') return ocr;
+  if (ocr && typeof ocr.data === 'string') return ocr.data;
+  return '';
+}
+
+/** Strip the OCR markup so a `<language>English</language>` tag can't be counted as body text. */
+function bodyText(ocr) {
+  return ocrText(ocr).replace(/<[^>]*>/g, ' ');
+}
+
+function languageTag(ocr) {
+  const m = ocrText(ocr).match(/<language>\s*([^<]+?)\s*<\/language>/i);
+  if (!m) return null;
+  const tag = m[1].trim().toLowerCase();
+  return NULL_TAGS.has(tag) ? null : tag;
+}
+
+/**
+ * Take `n` content pages spread evenly across the book's interior. Front and back
+ * matter are trimmed first, because that is where an edition's English apparatus
+ * lives; the interior is where its actual text lives. For a short item there is
+ * no interior to speak of, so fall back to the whole set rather than return none.
+ */
+function spreadSample(content, n) {
+  if (content.length <= n) return content;
+  const from = Math.floor(content.length * SKIP_FRONT);
+  const to = Math.ceil(content.length * (1 - SKIP_BACK));
+  const interior = content.slice(from, to);
+  const pool = interior.length >= n ? interior : content;
+  const step = pool.length / n;
+  return Array.from({ length: n }, (_, i) => pool[Math.floor(i * step)]);
+}
+
+function scriptCensus(text) {
+  const out = {};
+  for (const [name, re] of SCRIPTS) {
+    const n = (text.match(re) || []).length;
+    if (n > 0) out[name] = n;
+  }
+  return out;
+}
+
+function classify({ sampled, modal, modalCount, englishCount, nonLatinTotal }) {
+  if (sampled === 0) return { cls: 3, why: 'no content pages sampled' };
+  if (nonLatinTotal >= NONLATIN_REAL) {
+    return { cls: 1, why: `body text carries ${nonLatinTotal} non-Latin chars` };
+  }
+  if (modal && !ENGLISH_TAGS.has(modal)) {
+    return { cls: 1, why: `modal OCR language is "${modal}" (${modalCount}/${sampled})` };
+  }
+  const share = englishCount / sampled;
+  if (share >= ENGLISH_SHARE) {
+    if (sampled < MIN_SAMPLE_TO_DEMOTE) {
+      return { cls: 3, why: `English ${englishCount}/${sampled} but only ${sampled} content page(s) — too thin to demote` };
+    }
+    if (nonLatinTotal >= NONLATIN_QUOTE) {
+      return { cls: 2, review: true, why: `English ${englishCount}/${sampled}; ${nonLatinTotal} non-Latin chars — check it is quotation, not the text` };
+    }
+    if (share < CLEAR_SHARE) {
+      return { cls: 2, review: true, why: `English ${englishCount}/${sampled} — majority but not decisive` };
+    }
+    return { cls: 2, why: `English ${englishCount}/${sampled} content pages` };
+  }
+  return { cls: 3, why: `no clear majority — English ${englishCount}/${sampled}, modal "${modal ?? 'none'}"` };
+}
+
+async function main() {
+  const jsonOut = process.argv.includes('--json')
+    ? process.argv[process.argv.indexOf('--json') + 1]
+    : null;
+
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+
+  const books = await db.collection('books').find(
+    {
+      is_first_translation: true,
+      visible: true,
+      pages_translated: { $gt: 0 },
+      language: /^en/i,
+    },
+    { projection: { id: 1, title: 1, author: 1, language: 1, year: 1, pages_count: 1, text_role: 1, first_translation_status: 1, first_translation: 1, _id: 0 } },
+  ).toArray();
+
+  console.log(`Badged + visible + translated + language=English: ${books.length} books\n`);
+
+  const rows = [];
+  for (const b of books) {
+    const pages = await db.collection('pages')
+      .find({ book_id: b.id }, { projection: { ocr: 1, page_number: 1, _id: 0 } })
+      .sort({ page_number: 1 })
+      .limit(400)
+      .toArray();
+
+    const allContent = pages.filter((p) => ocrText(p.ocr).length >= MIN_CONTENT_CHARS);
+    const content = spreadSample(allContent, MAX_PAGES);
+    const tags = content.map((p) => languageTag(p.ocr)).filter(Boolean);
+
+    const counts = {};
+    for (const t of tags) counts[t] = (counts[t] || 0) + 1;
+    let modal = null, modalCount = 0;
+    for (const [t, n] of Object.entries(counts)) if (n > modalCount) { modal = t; modalCount = n; }
+    const englishCount = tags.filter((t) => ENGLISH_TAGS.has(t)).length;
+
+    const census = scriptCensus(content.map((p) => bodyText(p.ocr)).join('\n'));
+    const nonLatinTotal = Object.values(census).reduce((a, n) => a + n, 0);
+
+    const verdict = classify({ sampled: content.length, modal, modalCount, englishCount, nonLatinTotal });
+    rows.push({
+      id: b.id,
+      title: (b.title || '').slice(0, 70),
+      author: (b.author || '').slice(0, 30),
+      year: b.year ?? null,
+      language: b.language,
+      ft_status: b.first_translation_status ?? null,
+      has_verdict: Boolean(b.first_translation),
+      resolver: b.first_translation?.resolver ?? null,
+      sampled: content.length,
+      modal,
+      modalCount,
+      englishCount,
+      census,
+      nonLatinTotal,
+      ...verdict,
+    });
+  }
+
+  rows.sort((a, b) => a.cls - b.cls || b.nonLatinTotal - a.nonLatinTotal);
+
+  for (const cls of [1, 2, 3]) {
+    const set = rows.filter((r) => r.cls === cls);
+    const label = { 1: 'CLASS 1 — books.language is WRONG; badge probably right; fix language', 2: 'CLASS 2 — text really is English; badge is definitionally impossible; demote via not_applicable', 3: 'CLASS 3 — insufficient OCR; send to Tier-2 queue' }[cls];
+    console.log(`\n${label}  (${set.length})`);
+    console.log('-'.repeat(110));
+    for (const r of set) {
+      const flag = r.review ? ' [REVIEW]' : '';
+      console.log(`${r.id}  ${String(r.sampled).padStart(2)}pp  ${(r.modal ?? '-').padEnd(10)} nonLatin=${String(r.nonLatinTotal).padEnd(7)} ${r.author} — ${r.title}`);
+      console.log(`    ${r.why}${flag}   [${r.ft_status ?? 'no status'}${r.has_verdict ? `, verdict resolver=${r.resolver}` : ', NO verdict (legacy bypass)'}]`);
+    }
+  }
+
+  console.log(`\nTOTALS  class1=${rows.filter(r => r.cls === 1).length}  class2=${rows.filter(r => r.cls === 2).length}  class3=${rows.filter(r => r.cls === 3).length}  (n=${rows.length})`);
+
+  if (jsonOut) {
+    writeFileSync(jsonOut, JSON.stringify({ generated_at: new Date().toISOString(), n: rows.length, rows }, null, 2));
+    console.log(`\nWrote ${jsonOut}`);
+  }
+
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/ft-english-badged-adjudicate.mjs
+++ b/scripts/maintenance/ft-english-badged-adjudicate.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * ft-english-badged-adjudicate.mjs — issue #3524, the write half.
+ *
+ * Takes the classification produced by `scripts/audit/ft-english-badged-classify.mjs`
+ * and records Class-2 books — the ones whose text really is English — as
+ * `not_applicable` attempts in the append-only ledger.
+ *
+ * WHY THIS SHAPE, AND NOT A FLAG WRITE. The obvious fix ("language is English →
+ * set is_first_translation false") would have stripped genuine badges from eight
+ * Hebrew kabbalistic works and nine Latin ones whose `books.language` is simply
+ * wrong — the June 2026 Arithmologia incident with a different predicate. So this
+ * script never touches `is_first_translation`. It appends evidence; the nightly
+ * derive turns evidence into a verdict; the sign-off-gated reconcile turns a
+ * verdict into a badge. Append-only means every step is inspectable and
+ * reversible, and a catalogue digitised next year can still overturn it.
+ *
+ * Why `method: 'human'`. A first English translation of a work already written in
+ * English is not a claim that can be true, so no external catalogue search is
+ * required or possible — this is a direct observation of our own page images.
+ * That makes it a human adjudication, which is also what clears the reconcile
+ * valve (`--resolver=tier2_agent,human`). Every attempt records the pages it read.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/ft-english-badged-adjudicate.mjs <classify.json>
+ *   node --env-file=.env.production.local scripts/maintenance/ft-english-badged-adjudicate.mjs <classify.json> --apply
+ *   ... --include-review     also write the entries the classifier flagged for review
+ */
+import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const ATTEMPTS = 'first_translation_attempts';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const INCLUDE_REVIEW = args.includes('--include-review');
+const INPUT = args.find((a) => a.endsWith('.json') && !a.startsWith('--'));
+
+if (!INPUT) {
+  console.error('Usage: ft-english-badged-adjudicate.mjs <classify-output.json> [--apply] [--include-review]');
+  process.exit(1);
+}
+
+async function main() {
+  const report = JSON.parse(readFileSync(INPUT, 'utf8'));
+  const stamp = report.generated_at || new Date().toISOString();
+
+  const all = report.rows.filter((r) => r.cls === 2);
+  const targets = INCLUDE_REVIEW ? all : all.filter((r) => !r.review);
+  const held = all.filter((r) => r.review && !INCLUDE_REVIEW);
+
+  console.log(`Class 2 in report: ${all.length}`);
+  console.log(`Writing attempts for: ${targets.length}${held.length ? `   (holding ${held.length} flagged for review — pass --include-review to write them)` : ''}`);
+  if (held.length) for (const h of held) console.log(`   HELD  ${h.id}  ${h.author} — ${h.title}\n         ${h.why}`);
+
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+
+  // Snapshot the pre-write badge state so the whole operation is reversible.
+  const ids = targets.map((r) => r.id);
+  const before = await db.collection('books').find(
+    { id: { $in: ids } },
+    { projection: { id: 1, title: 1, is_first_translation: 1, first_translation: 1, first_translation_status: 1, _id: 0 } },
+  ).toArray();
+
+  const backupPath = `scripts/output/ft-english-badged-backup-${stamp.slice(0, 10)}.json`;
+  writeFileSync(backupPath, JSON.stringify({ taken_at: stamp, books: before }, null, 2));
+  console.log(`\nPre-write state snapshotted to ${backupPath} (${before.length} books)\n`);
+
+  let written = 0, existing = 0;
+  for (const r of targets) {
+    const attempt = {
+      attempt_id: `${r.id}:human:${stamp}`,
+      book_id: r.id,
+      date: stamp,
+      method: 'human',
+      match_key: 'none',
+      result: 'not_applicable',
+      evidence_strength: 'strong',
+      sources_checked: ['sourcelibrary_pages_ocr'],
+      queries: [
+        `modal <language> tag over ${r.sampled} interior content pages (>=700 chars OCR, front/back matter excluded)`,
+        `non-Latin script census of body text: ${r.nonLatinTotal} chars`,
+      ],
+      independence_score: 1,
+      notes:
+        `not_applicable: our item is itself in English — ${r.why}. `
+        + `A first English translation of an English text is not a claim that can be true, so no external `
+        + `catalogue search applies; this is a direct reading of our own page images. `
+        + `Adjudicated ${stamp.slice(0, 10)} under issue #3524 by scripts/audit/ft-english-badged-classify.mjs.`,
+      verdict: 'not_applicable',
+    };
+
+    if (!APPLY) {
+      console.log(`  [dry] ${r.id}  ${r.author} — ${r.title}`);
+      console.log(`        ${r.why}`);
+      continue;
+    }
+
+    const res = await db.collection(ATTEMPTS).updateOne(
+      { attempt_id: attempt.attempt_id },
+      { $setOnInsert: attempt },
+      { upsert: true },
+    );
+    if (res.upsertedCount > 0) { written++; console.log(`  wrote ${r.id}  ${r.author} — ${r.title}`); }
+    else { existing++; console.log(`  exists ${r.id} (idempotent no-op)`); }
+  }
+
+  if (APPLY) {
+    console.log(`\nAttempts written: ${written}   already present: ${existing}`);
+    console.log('\nNothing public has changed yet. To materialise:');
+    console.log('  npx tsx scripts/maintenance/derive-ft-verdict-from-attempts.ts            # dry-run, review');
+    console.log('  npx tsx scripts/maintenance/derive-ft-verdict-from-attempts.ts --apply    # writes the verdict only');
+    console.log('  npx tsx scripts/maintenance/reconcile-first-translation-flag.ts --only-demotions --verdict=not_first,not_applicable --resolver=tier2_agent,human           # dry-run');
+    console.log('  ... add --apply to flip the badges.  (The 05:30 cron runs exactly this pair unattended.)');
+  } else {
+    console.log('\nDRY-RUN — no writes. Re-run with --apply to append the attempts.');
+  }
+
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/ft-english-badged-fix-language.mjs
+++ b/scripts/maintenance/ft-english-badged-fix-language.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * ft-english-badged-fix-language.mjs — issue #3524, Class 1.
+ *
+ * These books are tagged `books.language: English` while their pages are plainly
+ * Hebrew, Latin, German, French or Italian. The BADGE is probably right — we may
+ * well be the first English rendering — and the LANGUAGE FIELD is what is wrong.
+ * So this script repairs `books.language` and never touches
+ * `is_first_translation`. It is the mirror image of the Class-2 adjudication, and
+ * the reason a single bulk rule over this set would have been destructive.
+ *
+ * Conservative by construction:
+ *   - only a modal OCR language at or above MIN_SHARE of the sampled interior pages;
+ *   - only tags that map to exactly one language (so "latin, english, greek" is held);
+ *   - mixed-content containers (a manuscript box of loose material) are held;
+ *   - every prior value is snapshotted before the write.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/maintenance/ft-english-badged-fix-language.mjs <classify.json>
+ *   node --env-file=.env.production.local scripts/maintenance/ft-english-badged-fix-language.mjs <classify.json> --apply
+ */
+import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const MIN_SHARE = 0.75;
+
+/** Modal OCR tag → the canonical `books.language` value. One language only. */
+const CANON = {
+  la: 'Latin', latin: 'Latin',
+  he: 'Hebrew', hebrew: 'Hebrew',
+  de: 'German', german: 'German', deutsch: 'German',
+  fr: 'French', french: 'French',
+  it: 'Italian', italian: 'Italian',
+  nl: 'Dutch', dutch: 'Dutch',
+  es: 'Spanish', spanish: 'Spanish',
+  el: 'Greek', greek: 'Greek',
+  ar: 'Arabic', arabic: 'Arabic',
+  sa: 'Sanskrit', sanskrit: 'Sanskrit',
+  ml: 'Malayalam', malayalam: 'Malayalam',
+};
+
+/** Titles that describe a heterogeneous container, where one language is a lie. */
+const CONTAINER_RE = /\b(box|scrapbook|collection|miscellan|album|crest)\b/i;
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const INPUT = args.find((a) => a.endsWith('.json') && !a.startsWith('--'));
+if (!INPUT) { console.error('Usage: ft-english-badged-fix-language.mjs <classify.json> [--apply]'); process.exit(1); }
+
+async function main() {
+  const report = JSON.parse(readFileSync(INPUT, 'utf8'));
+  const stamp = report.generated_at || new Date().toISOString();
+  const rows = report.rows.filter((r) => r.cls === 1);
+
+  const plan = [], held = [];
+  for (const r of rows) {
+    const share = r.sampled ? r.modalCount / r.sampled : 0;
+    const canon = CANON[r.modal ?? ''];
+    if (!canon) { held.push({ ...r, hold: `modal "${r.modal}" does not map to one language` }); continue; }
+    if (share < MIN_SHARE) { held.push({ ...r, hold: `modal share ${r.modalCount}/${r.sampled} below ${MIN_SHARE}` }); continue; }
+    if (CONTAINER_RE.test(r.title)) { held.push({ ...r, hold: 'looks like a mixed-content container; one language would be a lie' }); continue; }
+    if (canon === r.language) { held.push({ ...r, hold: 'already correct' }); continue; }
+    plan.push({ ...r, to: canon, share });
+  }
+
+  console.log(`Class 1 in report: ${rows.length}`);
+  console.log(`Repairing language on: ${plan.length}    holding: ${held.length}\n`);
+  for (const p of plan) console.log(`  ${p.id}  ${p.language} -> ${p.to.padEnd(10)} (${p.modalCount}/${p.sampled})  ${p.author} — ${p.title}`);
+  if (held.length) {
+    console.log('\nHELD for review:');
+    for (const h of held) console.log(`  ${h.id}  modal=${h.modal ?? '-'} (${h.modalCount}/${h.sampled})  ${h.author} — ${h.title}\n        ${h.hold}`);
+  }
+
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+
+  const before = await db.collection('books').find(
+    { id: { $in: plan.map((p) => p.id) } },
+    { projection: { id: 1, title: 1, language: 1, original_language: 1, is_first_translation: 1, _id: 0 } },
+  ).toArray();
+  const backupPath = `scripts/output/ft-english-badged-language-backup-${stamp.slice(0, 10)}.json`;
+  writeFileSync(backupPath, JSON.stringify({ taken_at: stamp, books: before }, null, 2));
+  console.log(`\nPre-write state snapshotted to ${backupPath} (${before.length} books)`);
+
+  if (!APPLY) {
+    console.log('\nDRY-RUN — no writes. Re-run with --apply.');
+    await client.close();
+    return;
+  }
+
+  let n = 0;
+  for (const p of plan) {
+    const res = await db.collection('books').updateOne(
+      { id: p.id },
+      { $set: {
+          language: p.to,
+          updated_at: new Date(),
+          'field_provenance.language': {
+            source: 'ft-english-badged-fix-language',
+            was: p.language,
+            evidence: `modal OCR <language> "${p.modal}" on ${p.modalCount}/${p.sampled} interior content pages`,
+            issue: '#3524',
+            applied_at: new Date().toISOString(),
+          },
+        } },
+    );
+    n += res.modifiedCount;
+  }
+  console.log(`\nAPPLIED — language repaired on ${n} of ${plan.length} books. Badges untouched.`);
+  await client.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Closes the Class-1 and Class-2 halves of #3524. **Already applied to production** (2026-08-06) — this PR commits the instruments that did it, so the operation is reproducible and auditable.

## What was wrong

55 books carried a "first English translation" badge while `books.language` said English. #3524 established that this is three bugs needing opposite fixes, and that a bulk demote would destroy ~22 true claims. This does it per class.

| class | what it is | action | n |
|---|---|---|---|
| 2 | the text really **is** English | `not_applicable` attempt → derive → reconcile | **15 demoted** |
| 1 | `books.language` is wrong; badge is probably right | repair `language`, badge untouched | **19 repaired** |
| 3 + ambiguous | not enough evidence | held for Tier-2 | 21 |

English-badged: **55 → 21**.

## Why it goes through the ledger

No script here writes `is_first_translation` directly. Class 2 appends a `not_applicable` attempt with `method: 'human'` — a first English translation of an English text is not a claim that can be true, so this is a direct reading of our own page images, not a search. The nightly derive turns evidence into a verdict; the sign-off-gated reconcile turns a verdict into a badge. Every step is inspectable and reversible, and a catalogue digitised next year can still overturn it.

The valve narrowed correctly, which is the part worth reading:

```
DEMOTIONS (flag:true -> derived:false): 118
--verdict  filter -> writing 76 of 118
--resolver filter -> writing 15 of 76
--ids      filter -> 15 of 15 demotions, 0 of 178 promotions
APPLIED — demoted: 15, promoted: 0
```

## Two sampling bugs found while building this

Both produced confident, wrong, internally-consistent answers.

1. **`pages.ocr` is an object**, `{data, model, prompt_hash, …}`, not a string. `String()` yields `"[object Object]"` — 15 chars — so every content-length filter matched nothing and the first run reported a clean "no content pages sampled" for all 55 books. A check that cannot fail is not verification.

2. **Sampling the first N content pages measures the apparatus, not the text.** A scholarly edition of a Latin work opens with an English title page, preface and introduction. Quignones' *Breviarium Romanum*, Feltoe's *Sacramentarium Leonianum* and Little's *Opus Tertium* all read English for a dozen pages while pages 112, 113 and 63 are solidly Latin. Three legitimate badges were one step from demotion. The sampler now spreads evenly across the interior, skipping front and back matter. This is the "page 1 lies" trap from #3524 one level up.

## Verification

- 15/15 demoted, each with stored verdict `not_applicable` and resolver `human`
- English-badged 55 → 21, and the 21 are exactly the held sets (11 + 7 + 3)
- homepage `firstTranslationCount` 5,839 → 5,824, **−15 exactly**
- ledger 62,640 → 62,655 attempts, **+15 exactly**
- pre-write snapshots for both operations: `scripts/output/ft-english-badged-{backup,language-backup}-2026-08-07.json`

## Out of scope

Class 3 (7 books with too little OCR) and the ambiguous remainder — the three Class-2 books at 9/12 English, the mixed-content Manly Palmer Hall boxes, the *Masonic crest* tagged "latin, english, greek". These need Tier-2 adjudication, not a threshold. `--include-review` writes the Class-2 three if someone signs them off by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)