### PR TITLE
docs(invariants): CDN path rules beat force-dynamic; referrers can't attribute in-site clicks

### DIFF
--- a/.claude/docs/invariants/deploy-and-caching.md
+++ b/.claude/docs/invariants/deploy-and-caching.md
@@ -2,7 +2,8 @@
 
 *Read this when you touch: `src/app/api/deploy-warm/route.ts`, `scripts/deploy-prod.sh`,
 `.github/workflows/post-deploy-warm.yml`, any `CDN-Cache-Control` header in `next.config.ts`, any
-`revalidatePath` / `revalidateTag` call, or Vercel project settings.*
+`revalidatePath` / `revalidateTag` call, **any `export const dynamic` on a page**, or Vercel project
+settings.*
 
 ## There are two independent caches, and a deploy can empty both
 
@@ -87,3 +88,36 @@ The invoice line items measure the stack, not just the money:
 
 Line items are in the plaintext body of the Vercel receipt emails. Current figures and how to re-pull
 them live in the private ops repo (`costs/infrastructure-costs.md`) — not here.
+
+## `CDN-Cache-Control` is a PATH rule and overrides `force-dynamic`
+
+`export const dynamic = 'force-dynamic'` does **not** stop Cloudflare caching the page. The
+`CDN-Cache-Control` headers in `next.config.ts` are keyed on path, entirely independently of the
+route's rendering mode — so a route that is both `force-dynamic` and listed in a `public, max-age=…`
+rule renders per request, gets cached anyway, and serves one visitor's render to everyone for the TTL.
+
+Shipped this in #3646 and fixed it in #3649: `/support` was made `force-dynamic` so the giving form
+could default its tax route from `x-vercel-ip-country`, while `/support` sits in the static-pages rule
+(`/(privacy|terms|dmca|support|sponsors|developers|contribute|beta)`) at `max-age=86400`. Production
+answered `cf-cache-status: HIT` with `age: 1202` on the supposedly dynamic page. Nothing errored — the
+personalisation was simply dead, plus a per-request Mongo call that bought nothing.
+
+- **The tell is that both headers are present at once.** `cache-control: private, no-cache, no-store`
+  (what Next sends the browser, which looks correct and reassuring) sits **beside**
+  `cdn-cache-control: public, max-age=86400` and `cf-cache-status: HIT`. Reading only the first tells
+  you the opposite of the truth.
+- **Personalise on an UNCACHED route; never uncache a route in order to personalise.** These TTLs are
+  load-bearing — the rule's own comment records a June 2026 scraper flood of ~1.3M req/day at exactly
+  those pages, all of it reaching Vercel. `/give` carries no CDN rule, answers `BYPASS`, and is the
+  right home for anything request-dependent.
+- **Rule ORDER decides the effective header** — the last matching rule wins, and the config depends on
+  it: `/book/:id/preview` is `private, no-store` declared *after* `/book/:path*` is `max-age=86400`.
+  Reordering those could serve a cached editor 200 to anon users. Anything reasoning about these rules
+  must take the **last** match, not any match.
+- **Corollary: a prop nobody passes is a trap.** Leaving `SupportView`'s `defaultRoute` prop in place
+  with a default, documented as "resolved from the request country", would have told the next person
+  the page personalises when it cannot. Remove it and hardcode the literal with the reason.
+- Standing guard: `tests/unit/dynamic-routes-not-edge-cached.test.ts` fails on a new route that is both
+  `force-dynamic` and publicly edge-cached. It carries an allowlist of **10 pre-existing collisions**
+  (`/collections/[id]`, `/libraries/[slug]`, the four `/browse/*/[letter]` pages, `/book/[id]/overview`,
+  `/collections/mycology`, two blog posts) that were never triaged — shrink it, don't grow it.

--- a/.claude/docs/invariants/measurement-instruments.md
+++ b/.claude/docs/invariants/measurement-instruments.md
@@ -100,3 +100,35 @@ The general shape: a contamination finding is about a **population**; a spending
 about a **specific field**. Getting from one to the other requires showing the population
 actually reaches the field. See `lesson_denormalized_counter_definitional_gap` for the
 neighbouring error, where a counter gap that looked like staleness was definitional.
+
+## `referrer` cannot attribute an in-site click, in either direction
+
+**Never use `analytics_pageviews.referrer` to ask "did they get here from our own page X?"** It
+cannot answer, for two independent reasons that stack:
+
+1. **`/api/track` collapses self-referrals by design** — `if (hostname !== SITE_HOST) referrerDomain =
+   hostname;`, otherwise the row stores `'direct'`. An internal click is byte-identical to a stranger
+   typing the URL.
+2. **Next's `<Link>` does not reload the document**, so `document.referrer` stays whatever EXTERNAL
+   page started the session. A reader who arrived from Google and *then* clicked a nav control still
+   logs `google.com`.
+
+Hit this on 2026-08-07 (#3668) reading the new `/give` page: 7 visits, 4 `direct` and 3 Google. I
+first reported "none came from the header" — an unsound inference, since up to 4 of them may have been
+exactly that. The field was never capable of carrying the signal.
+
+- **Fire the event AT the control**, where the information still exists, rather than reconstructing it
+  downstream. `give_nav_click` on the header pill and footer link carries `source` (the control) and
+  `url` (its destination — they differ: header→`/give`, footer→`/support`, and merging them averages
+  two funnels with different odds). Guard: `tests/unit/give-nav-attribution.test.ts`.
+- **Use `sendBeacon` for any event fired on a control that navigates.** A plain `fetch` is cancelled by
+  the navigation the click triggers, so every event dies in flight and the metric reads zero for a
+  reason unrelated to users. `trackEvent` already does this — don't "simplify" it.
+- **Verify a new conversion event end-to-end in production before trusting its zero.** A unit test
+  cannot prove a beacon survives a navigation or that props clear the route's allowlist. Click it once
+  yourself, confirm the row, and **write down the timestamp** so the test row can be excluded.
+- Generalisation of the rule this file opens with: **a zero from a field that cannot express the thing
+  is not evidence of absence.** Before quoting a referrer breakdown, check whether the writer
+  normalises self-referrals and whether the navigation was client-side.
+- Neighbouring case, same family: `analytics_pageviews.path` strips query strings (0 of 926K rows
+  contain `?`), so any URL-param signal is invisible there too.


### PR DESCRIPTION
Two failure classes from the `/give` session (#3646 / #3649 / #3668). Both shipped silently, and both read as facts about users when they were facts about instruments.

## deploy-and-caching

`CDN-Cache-Control` in `next.config.ts` is keyed on **path** and overrides a route's `force-dynamic`. `/support` rendered per request and was edge-cached anyway — production answered `cf-cache-status: HIT` with `age: 1202` on a supposedly dynamic page, so every visitor got whichever country warmed the cache, held for 24h, plus a per-request Mongo call that bought nothing.

Adds:

- The tell — `cache-control: private, no-cache, no-store` and `cdn-cache-control: public, max-age=86400` are present in the **same response**. Reading only the first inverts the truth.
- Personalise on an uncached route; never uncache a route to personalise. Those TTLs are load-bearing (June 2026 scraper flood, ~1.3M req/day at exactly those paths).
- **Last match wins** — the ordering the `/book/:id/preview` `private, no-store` overrides depend on. Reordering them could serve a cached editor 200 to anon users.
- The standing guard (`tests/unit/dynamic-routes-not-edge-cached.test.ts`) and its **10 untriaged pre-existing collisions**.
- Trigger line updated so the doc fires on any `export const dynamic` on a page.

## measurement-instruments

`analytics_pageviews.referrer` cannot distinguish an in-site click from a direct arrival, for two independent reasons that stack: `/api/track` collapses self-referrals to `'direct'`, **and** Next's client-side navigation preserves the original external referrer.

I misread 7 `/give` visits as "none came from the header" when up to 4 of them may have been exactly that.

Adds:

- Fire the event **at the control**, not reconstructed downstream.
- Use `sendBeacon` for anything fired on a control that navigates — a plain `fetch` is cancelled by the navigation itself, so the metric reads zero for a reason unrelated to users.
- Verify a new conversion event end-to-end in production before trusting its zero, and **write down the test timestamp** so the row can be excluded.
- The generalisation: a zero from a field that cannot express the thing is not evidence of absence.

Docs only — no code, no behaviour change. `CLAUDE.md` stays at 202 lines; both lessons are subsystem-triggered, so they belong in `invariants/` rather than the always-loaded body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
