### PR TITLE
fix(metering): every worker now logs Gemini usage, plus a standing audit

### DIFF
--- a/scripts/audit/gemini-usage-logging.mjs
+++ b/scripts/audit/gemini-usage-logging.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Standing audit: which Gemini call sites do NOT log usage?
+ *
+ * WHY. Spend metering failed the same way the entity writers and the search
+ * boxes did — a new caller was added and nobody remembered to log it, and
+ * forgetting produces SILENCE, not an error. In Aug 2026 that meant ~4.9M
+ * embeddings were invisible to every cost surface, and total recorded spend
+ * read $7.5K against a corpus that plainly cost far more (#3576).
+ *
+ * This makes the omission visible instead of silent. It does NOT fail the
+ * build: many call sites are legitimately unmetered (one-off analysis scripts,
+ * validate-key probes). The point is that the list is SHORT and REVIEWED, not
+ * that it is empty.
+ *
+ *   node scripts/audit/gemini-usage-logging.mjs            # pipeline paths
+ *   node scripts/audit/gemini-usage-logging.mjs --all      # every caller
+ *   node scripts/audit/gemini-usage-logging.mjs --strict   # exit 1 if a WORKER is unlogged
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const ALL = process.argv.includes('--all');
+const STRICT = process.argv.includes('--strict');
+
+const CALL_RE = /generateContent|batchEmbedContents|generativelanguage\.googleapis/;
+const LOG_RE = /logUsage|logUsageAsync|logGeminiUsage|completeBatchUsage|buildUsagePayload|gemini_usage/;
+
+// Paths that run repeatedly at scale. An unlogged caller here is a real hole;
+// elsewhere it is usually a one-off and only worth listing.
+const PIPELINE = ['scripts/workers/', 'src/workers/', 'src/lib/', 'src/app/api/'];
+
+/**
+ * Known-and-accepted omissions. Each needs a REASON — an unexplained entry
+ * here is how a real hole gets grandfathered in.
+ */
+const ACCEPTED = {
+  'src/app/api/contribute/validate-key/route.ts': 'probes a user-supplied key; no corpus work, cost is the caller\'s',
+};
+
+const files = execSync(
+  "git grep -lE 'generateContent|batchEmbedContents|generativelanguage\\.googleapis' -- scripts src ':!*_archived*'",
+  { encoding: 'utf8' }
+).trim().split('\n').filter(Boolean);
+
+const rows = [];
+for (const f of files) {
+  let src = '';
+  try { src = readFileSync(f, 'utf8'); } catch { continue; }
+  if (!CALL_RE.test(src)) continue;
+  const logged = LOG_RE.test(src);
+  const isPipeline = PIPELINE.some(p => f.startsWith(p));
+  const isWorker = f.startsWith('scripts/workers/') || f.startsWith('src/workers/');
+  if (!ALL && !isPipeline) continue;
+  rows.push({ f, logged, isWorker, accepted: ACCEPTED[f] });
+}
+
+const unlogged = rows.filter(r => !r.logged && !r.accepted);
+const workers = unlogged.filter(r => r.isWorker);
+
+console.log(`Gemini call sites scanned: ${rows.length}${ALL ? ' (all)' : ' (pipeline paths)'}`);
+console.log(`  logged:   ${rows.filter(r => r.logged).length}`);
+console.log(`  accepted: ${rows.filter(r => r.accepted).length}`);
+console.log(`  UNLOGGED: ${unlogged.length}${workers.length ? `  (${workers.length} of them WORKERS)` : ''}`);
+
+if (workers.length) {
+  console.log('\n── WORKERS with no usage logging — these run at scale, fix them ──');
+  for (const r of workers) console.log(`  ${r.f}`);
+}
+const rest = unlogged.filter(r => !r.isWorker);
+if (rest.length) {
+  console.log('\n── other unlogged call sites (review; many are legitimately one-off) ──');
+  for (const r of rest) console.log(`  ${r.f}`);
+}
+if (rows.some(r => r.accepted)) {
+  console.log('\n── accepted omissions ──');
+  for (const r of rows.filter(x => x.accepted)) console.log(`  ${r.f}\n      ${r.accepted}`);
+}
+
+console.log('\nMetering notes:');
+console.log('  · Log via scripts/workers/lib/supabase-usage-logger.mjs (logUsage/logUsageAsync).');
+console.log('    It writes Supabase and falls back to Mongo — do NOT insert to gemini_usage directly.');
+console.log('  · Log BEFORE any early return on empty output: an empty candidate is still billed.');
+console.log('  · Batch spend belongs in batch_jobs, not gemini_usage — batch usage rows are');
+console.log('    placeholders written at submit time (#3452). See scripts/analysis/true-gemini-spend.mjs.');
+
+if (STRICT && workers.length) {
+  console.error(`\nFAIL: ${workers.length} worker(s) call Gemini without logging usage.`);
+  process.exit(1);
+}

--- a/scripts/workers/embed-gemini.mjs
+++ b/scripts/workers/embed-gemini.mjs
@@ -35,6 +35,7 @@
 import { MongoClient } from 'mongodb';
 import { createClient } from '@supabase/supabase-js';
 import fs from 'node:fs';
+import { logUsageAsync } from './lib/supabase-usage-logger.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -143,7 +144,40 @@ async function embedBatch(texts) {
   if (!data.embeddings || data.embeddings.length !== texts.length) {
     throw new Error(`Expected ${texts.length} embeddings, got ${data.embeddings?.length || 0}`);
   }
+
+  // Meter this call. Until 2026-08-07 this worker logged NOTHING, so ~4.9M
+  // embeddings across five tables were invisible to every cost surface — the
+  // single largest unmetered pipeline phase (#3576).
+  //
+  // `batchEmbedContents` returns no `usageMetadata`, so token count is READ if
+  // the API ever starts supplying it and ESTIMATED otherwise. The estimate is
+  // marked in `prompt_version` so a reader can tell measured from approximated
+  // — an unlabelled estimate in a meter is the failure this exercise was about.
+  const reportedTokens = num(data.usageMetadata?.totalTokenCount ?? data.usageMetadata?.promptTokenCount);
+  const estimated = reportedTokens === 0;
+  const inputTokens = estimated
+    ? Math.round(texts.reduce((s, t) => s + (t?.length || 0), 0) / 4) // ~4 chars/token
+    : reportedTokens;
+
+  logUsageAsync({
+    type: 'embedding',
+    mode: 'realtime',
+    model: MODEL,
+    page_count: texts.length,
+    input_tokens: inputTokens,
+    output_tokens: 0,               // embeddings produce vectors, not billed output tokens
+    status: 'success',
+    endpoint: 'worker/embed-gemini',
+    prompt_version: estimated ? 'tokens=estimated(chars/4)' : 'tokens=reported',
+  });
+
   return data.embeddings.map(e => e.values);
+}
+
+/** Coerce a possibly-absent numeric field to 0 rather than NaN. */
+function num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/scripts/workers/ocr-correct-grounded.mjs
+++ b/scripts/workers/ocr-correct-grounded.mjs
@@ -46,6 +46,7 @@ import { GoogleGenAI } from '@google/genai';
 import { getPageSource } from '../lib/page-image-url.mjs';
 import { saveRevisionsBeforeOverwrite } from '../lib/page-revisions.mjs';
 import { normalizeLongS, isCorrectionAcceptable, detectLongSArtefacts } from '../lib/early-modern-text.mjs';
+import { logUsageAsync } from './lib/supabase-usage-logger.mjs';
 
 const argv = process.argv.slice(2);
 const flag = k => argv.includes(k);
@@ -117,6 +118,21 @@ async function correctPage(page) {
     config: { temperature: 0.1, maxOutputTokens: 16384, thinkingConfig: { thinkingBudget: 0 } },
   });
 
+  // Meter the call. This worker logged nothing until 2026-08-07 (#3576), so its
+  // spend was invisible to every cost surface. Logged BEFORE the early return
+  // below: a call that produced empty output was still billed.
+  logUsageAsync({
+    type: 'ocr_correction',
+    mode: 'realtime',
+    model: MODEL,
+    book_id: page.book_id || null,
+    page_count: 1,
+    input_tokens: r.usageMetadata?.promptTokenCount || 0,
+    output_tokens: r.usageMetadata?.candidatesTokenCount || 0,
+    status: 'success',
+    endpoint: 'worker/ocr-correct-grounded',
+  });
+
   const finish = r.candidates?.[0]?.finishReason;
   let text = (r.text || '').trim();
   if (!text) return { skip: `empty output (${finish})`, finish };
@@ -131,7 +147,7 @@ for (const book of books) {
   const bid = book.id || String(book._id);
   const q = { book_id: bid, 'ocr.source': 'mineru', 'ocr.data': { $exists: true, $ne: '' } };
   let cur = db.collection('pages').find(q, { projection: {
-    id: 1, page_number: 1, 'ocr.data': 1, cropped_photo: 1, archived_photo: 1,
+    id: 1, book_id: 1, page_number: 1, 'ocr.data': 1, cropped_photo: 1, archived_photo: 1,
     photo_original: 1, photo: 1, enhanced_photo: 1, split_from_spread: 1, crop: 1,
   }}).sort({ page_number: 1 });
   if (PAGE_LIMIT) cur = cur.limit(PAGE_LIMIT);

--- a/scripts/workers/transliterate-greek.mjs
+++ b/scripts/workers/transliterate-greek.mjs
@@ -12,6 +12,7 @@
 
 import { MongoClient } from 'mongodb';
 import crypto from 'crypto';
+import { logUsageAsync } from './lib/supabase-usage-logger.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
@@ -79,6 +80,22 @@ async function transliteratePage(db, page) {
   }
 
   const data = await res.json();
+
+  // Meter the call. This worker logged nothing until 2026-08-07 (#3576).
+  // Logged BEFORE the empty-response throw below: an empty candidate is still
+  // a billed call (see the RECITATION/empty-candidate notes in batch-collector).
+  logUsageAsync({
+    type: 'transliterate',
+    mode: 'realtime',
+    model: MODEL,
+    book_id: page.book_id || null,
+    page_count: 1,
+    input_tokens: data.usageMetadata?.promptTokenCount || 0,
+    output_tokens: data.usageMetadata?.candidatesTokenCount || 0,
+    status: 'success',
+    endpoint: 'worker/transliterate-greek',
+  });
+
   const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
   if (!text) throw new Error('Empty response from Gemini');
 


### PR DESCRIPTION
Closes the worker half of the metering gap in #3576, and makes the rest visible instead of silent.

## The three workers

| worker | what was invisible |
|---|---|
| `embed-gemini.mjs` | **~4.9M embeddings** across five tables — the single largest unmetered phase |
| `ocr-correct-grounded.mjs` | grounded second-pass OCR correction |
| `transliterate-greek.mjs` | Greek transliteration |

All three now log via `supabase-usage-logger` (Supabase primary, Mongo fallback) rather than inserting to `gemini_usage` directly.

**Two deliberate details:**

**Logged BEFORE any early return on empty output.** An empty candidate is still a billed call — the same trap `batch-collector` documents for RECITATION blocks, where a job whose every page was blocked recorded $0.00.

**`batchEmbedContents` returns no `usageMetadata`.** So tokens are read if the API ever supplies them, and estimated (chars/4) otherwise — with the method recorded in `prompt_version` as `tokens=estimated(chars/4)`. An unlabelled estimate sitting in a meter is precisely the failure this work is about; a labelled one is honest. A reader can filter on it.

## The standing audit

`scripts/audit/gemini-usage-logging.mjs`. This class of hole is created by **forgetting**, and forgetting produces silence rather than an error — the same shape as the five `entities.books[]` writers and the six search boxes where one logged nothing for four months.

```
Gemini call sites scanned: 50 (pipeline paths)
  logged:   15
  accepted: 1
  UNLOGGED: 34      ← none are workers
```

It **does not fail the build by default** — many call sites are legitimately unmetered, and a detector that cries wolf gets bypassed. `--strict` fails only when a **worker** is unlogged, which is now zero. Accepted omissions require a written reason, so a real hole cannot be grandfathered in unexplained.

## Not in this PR: the other 34

All 34 are API routes and `src/lib` modules. Patching them one at a time would repeat the mistake the R2 key guard's own header warns about — *"40+ scripts with their own `uploadToR2`, and guarding them one at a time is how the same bug shipped twice."*

The leverage point is the boundary: **`src/lib/ai.ts` is the shared client for 26 modules** and exports `performOCR` / `performTranslation` / `generateSummary` / `performTransliteration` / `processPageComplete`. Instrumenting there plus `src/lib/gemini-batch.ts` (8 importers) covers most of the tail in two files.

Worth noting while in there: `src/lib/ai.ts` carries **its own duplicate `MODEL_PRICING` table**, which is exactly the drift `scripts/lib/model-pricing.mjs` was created to end.

## Verification

`node --check` on all three workers · audit runs clean in `--strict` · logging calls verified to have `page` in lexical scope (a syntax check would not catch that).
