### PR TITLE
fix(ft): state the search, not the negative — and stop confirming on evidence we call weak (#3459)

### DIFF
--- a/.claude/docs/invariants/first-translation-claims.md
+++ b/.claude/docs/invariants/first-translation-claims.md
@@ -21,6 +21,32 @@ predictive value at ~50%**: a coin flip. So:
 - **A null means different things in different traditions.** French has 23,035 English translations in the set, Syriac 119, and CJK is reachable only via MARC 880 (present on 2.3% of rows). Read reference-set *depth* beside every verdict; a flat badge cannot be honest across all of them.
 - **Keep "we could not ask" separate from "we asked and found nothing."** Conflating them turns an unasked question into a confident negative — the single most common way this system lies.
 
+**That distinction breaks at the PAYLOAD layer too, not just the evidence layer** (#3686,
+2026-08-07). Book surfaces are served from two sources for the same object: the Supabase
+`books_catalog` mirror (a projection, ~50ms) and the Atlas doc (complete, 1–5s). A pure
+classifier cannot tell which it received. `classifyFirstTranslationClaim` run inside
+`generateMetadata` — which resolves through `getCachedBookLookup`, i.e. the catalog row —
+returned `candidate` for **every** book, because the row carries `is_first_translation`
+but not `first_translation.evidence_strength`, and the classifier's "field absent" branch
+*was* its "evidence weak" branch. The assertive claim silently vanished from the meta
+description of the 627 books that had earned it. **Before classifying, assert the payload
+can answer** (`book.first_translation !== undefined`), fetch when it cannot, and fail
+toward the weaker claim. Check what `BOOK_SELECT` / `BOOK_DETAIL_SELECT` in
+`src/lib/books-catalog.ts` *omit*, not just what they carry.
+
+Two corollaries that cost real work here:
+
+- **A default is indistinguishable from a measurement**, so pick the direction that cannot lie. `firstTranslationBadge` and `firstTranslationDescription` default to `candidate`: every card surface renders from the catalog and none can evidence a first, so an assertive default would let all of them assert a universal negative by omission.
+- **A one-sided check on a two-sided change is a coin flip you will read as a pass.** The bug above and a successful fix produced identical output on the candidate direction. It surfaced only on the positive control — the book that should *still* assert. Test both registers.
+
+**And a state's name is a claim about its gate.** `classifyFirstTranslationClaim` gated
+`confirmed` on `isFirstTranslation()` — the *render* rule (first-family verdict, visible,
+some translated pages), which says nothing about evidence. That made 5,684 of 5,932 badged
+books (95.8%) `confirmed` while only 689 carried strong or moderate evidence, so the state
+resolved to "we badged it": the very claim it existed to qualify. Same family as a metric's
+name being a claim about its denominator. When a state promises "earned by evidence", the
+gate must read evidence.
+
 **Every bug in this area fails toward a confident clean negative.** Fourteen defects in one session, not one of which produced a false positive. A null is the cheap answer at every layer: an inverted year comparison, a capped fallback threshold, a throttled endpoint returning HTTP 200 with HTML, a schema mismatch between two extractors. The only thing that caught them was the **recorded reason on each rejected candidate** — a system that logs only what it found cannot be debugged.
 
 

--- a/scripts/audit/ft-claim-register.ts
+++ b/scripts/audit/ft-claim-register.ts
@@ -1,0 +1,73 @@
+/**
+ * Which REGISTER does each badged book's first-translation claim get?
+ *
+ * Runs `classifyFirstTranslationClaim` over every badged + visible book and
+ * reports the split, so a copy change is sized against real data and can be
+ * re-measured after any evidence sweep. Read-only.
+ *
+ *   npx tsx --env-file=.env.production.local scripts/audit/ft-claim-register.ts
+ *
+ * Baseline, 2026-08-07 (5,932 badged + visible):
+ *   candidate       5,217  87.9%   weak or unrecorded evidence
+ *   confirmed         627  10.6%   strong or moderate evidence
+ *   defeated           59   1.0%   badged while our own verdict names a prior
+ *   not_applicable     29   0.5%   English source, or catalogued English
+ *
+ * The `defeated` row is a screening queue, not a rendering state: those books
+ * carry `is_first_translation: true` while `first_translation.verdict` reads
+ * `not_first`. The evidence panel already shows them as "Existing translations",
+ * but the flag still drives the cards. See #3524 / #2933.
+ */
+import { getReadDb } from '@/lib/mongodb';
+import { classifyFirstTranslationClaim, type ScreenedBook } from '@/lib/first-translation/candidate';
+
+async function main() {
+const db = await getReadDb();
+const books = db.collection('books');
+
+const cur = books.find(
+  { is_first_translation: true, visible: true },
+  {
+    projection: {
+      id: 1, title: 1, language: 1, original_language: 1, is_first_translation: 1, visible: 1, author: 1,
+      first_translation: 1, translation_verification: 1,
+      source_language_screen: 1, translator_author_screen: 1,
+      pages_translated: 1, pages_ocr: 1, pages_blank: 1, pages_count: 1,
+    },
+  },
+);
+
+const tally: Record<string, number> = {};
+const reasons: Record<string, number> = {};
+const samples: Record<string, string[]> = {};
+let incomplete = 0;
+let review = 0;
+let n = 0;
+
+for await (const b of cur) {
+  n++;
+  const r = classifyFirstTranslationClaim(b as unknown as ScreenedBook);
+  tally[r.claim] = (tally[r.claim] ?? 0) + 1;
+  const key = `${r.claim} / ${r.reason}`;
+  reasons[key] = (reasons[key] ?? 0) + 1;
+  if (r.screensIncomplete) incomplete++;
+  if (r.needsReview) review++;
+  const s = (samples[key] ??= []);
+  if (s.length < 3) s.push(`${b.id} — ${String(b.title ?? '').slice(0, 55)}`);
+}
+
+console.log(`badged + visible scanned: ${n}\n`);
+console.log('claim:');
+for (const [k, v] of Object.entries(tally).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${k.padEnd(16)} ${String(v).padStart(6)}  ${((v / n) * 100).toFixed(1)}%`);
+}
+console.log('\nclaim / reason:');
+for (const [k, v] of Object.entries(reasons).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${k.padEnd(46)} ${String(v).padStart(6)}`);
+  for (const s of samples[k] ?? []) console.log(`      ${s}`);
+}
+console.log(`\nscreensIncomplete: ${incomplete}   needsReview: ${review}`);
+process.exit(0);
+}
+
+main();

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -287,13 +287,47 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       summaryText = s?.index?.bookSummary?.brief || s?.reading_summary?.overview || s?.summary?.data || null;
     } catch { /* keep null → factual template fallback */ }
   }
+  // The claim's register for the meta description (#3459).
+  //
+  // ⚠️ `getCachedBookLookup` serves the Supabase `books_catalog` row in the
+  // common case (it is ~50ms against Atlas's 1-5s), and that row carries
+  // `is_first_translation` and `ft_disposition` but NOT
+  // `first_translation.evidence_strength` or the screens. Classifying the thin
+  // payload directly returns `candidate` for EVERY book — including the 627 that
+  // earned the assertion — because "the field is absent" is indistinguishable
+  // from "the evidence is weak". That is the invariant this area keeps breaking:
+  // "we could not ask" must stay separate from "we asked and found nothing".
+  //
+  // So when the payload cannot answer, ASK — one projected lookup, and only for
+  // the ~17% of visible books that carry the flag at all. A failure falls back
+  // to `candidate`, which drops the "First" prefix rather than asserting it.
+  let ftClaimForSeo = classifyFirstTranslationClaim(book as unknown as ScreenedBook).claim;
+  const seoPayloadCanAnswer = (book as { first_translation?: unknown }).first_translation !== undefined;
+  if (!seoPayloadCanAnswer && book.is_first_translation && bookRec.id) {
+    try {
+      const sdb = await getReadDb();
+      const ev = await sdb.collection('books').findOne(
+        { id: bookRec.id },
+        {
+          projection: {
+            _id: 0, visible: 1, language: 1, pages_translated: 1,
+            first_translation: 1, translation_verification: 1,
+            source_language_screen: 1, translator_author_screen: 1,
+          },
+          maxTimeMS: 3000,
+        },
+      );
+      if (ev) ftClaimForSeo = classifyFirstTranslationClaim(ev as unknown as ScreenedBook).claim;
+    } catch { /* keep `candidate` — understate, never overstate */ }
+  }
+
   const description = buildSeoDescription({
     originalTitle: book.title,
     authorLabel: bylineLabel,
     year: displayYear,
     language: book.language,
     summary: summaryText,
-    firstTranslationClaim: classifyFirstTranslationClaim(book as unknown as ScreenedBook).claim,
+    firstTranslationClaim: ftClaimForSeo,
     pagesTranslated: book.pages_translated,
   });
   const bookUrl = `/book/${book.slug || book.id}`;

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -52,6 +52,11 @@ import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter'
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { authorUrl } from '@/lib/slugify';
 import FirstTranslationEvidence from '@/components/book/FirstTranslationEvidence';
+import {
+  classifyFirstTranslationClaim,
+  type ScreenedBook,
+} from '@/lib/first-translation/candidate';
+import { firstTranslationClause } from '@/lib/first-translation-labels';
 import GalleryMasonry, { type Plate } from '@/components/GalleryMasonry';
 import HeroVariants from '@/components/book/HeroVariants';
 import { HERO_MOSAIC_VERSION } from '@/lib/hero-mosaic-version';
@@ -288,7 +293,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     year: displayYear,
     language: book.language,
     summary: summaryText,
-    isFirstTranslation: book.is_first_translation,
+    firstTranslationClaim: classifyFirstTranslationClaim(book as unknown as ScreenedBook).claim,
     pagesTranslated: book.pages_translated,
   });
   const bookUrl = `/book/${book.slug || book.id}`;
@@ -655,6 +660,14 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
   }
 
   const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections, authorEntity } = data;
+
+  // What we can honestly SAY about this book's first-translation status (#3459).
+  // The flag decides whether a claim appears at all; this decides its register —
+  // `confirmed` asserts, anything weaker reports the search we ran instead.
+  // Computed once so the publication timeline, the stat line and the evidence
+  // panel cannot drift apart.
+  const ftClaim = classifyFirstTranslationClaim(book as unknown as ScreenedBook).claim;
+  const ftClause = firstTranslationClause(ftClaim);
 
   // Hidden books (visible:false) are not public — defense in depth alongside
   // the early gate in BookDetailPage. allowHidden is set only by the dynamic,
@@ -1141,7 +1154,9 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
         key: `edition-${i}`,
         dateText: my,
         label: i === 0
-          ? (book.is_first_translation ? 'First English translation published' : 'English edition published')
+          ? (ftClaim === 'confirmed'
+            ? 'First English translation published'
+            : 'English edition published')
           : 'New edition published',
         detail: (
           <>
@@ -1470,8 +1485,17 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy, isEmbedded = fa
                       {translatedPct >= 100 ? '✓' : `${translatedPct}%`} Translated
                     </span>
                   )}
-                  {!!book.is_first_translation && translatedCount > 0 && (
-                    <span title="First translation into English" style={{ color: '#e0b46a' }}>First translation</span>
+                  {!!book.is_first_translation && translatedCount > 0 && ftClause && (
+                    <span
+                      title={
+                        ftClaim === 'confirmed'
+                          ? 'First translation into English'
+                          : 'We searched the catalogues and found no earlier English translation — a record of the search, not proof none exists'
+                      }
+                      style={{ color: ftClaim === 'confirmed' ? '#e0b46a' : '#948d80' }}
+                    >
+                      {ftClaim === 'confirmed' ? 'First translation' : 'No prior translation found'}
+                    </span>
                   )}
                 </div>
               )}

--- a/src/components/book/FirstTranslationEvidence.tsx
+++ b/src/components/book/FirstTranslationEvidence.tsx
@@ -38,6 +38,10 @@ import {
   firstTranslationDescription,
   translationProgressNote,
 } from '@/lib/first-translation-labels';
+import {
+  classifyFirstTranslationClaim,
+  type ScreenedBook,
+} from '@/lib/first-translation/candidate';
 import type { PriorTranslationCredit } from '@/lib/types/book';
 import {
   hasPublishablePriorTranslation,
@@ -58,6 +62,13 @@ interface EvidenceBook {
   id: string;
   language?: string;
   is_first_translation?: boolean;
+  /** Required by the claim classifier's render gate — see classifyClaim below. */
+  visible?: boolean;
+  title?: string;
+  author?: string;
+  original_language?: string;
+  source_language_screen?: { verdict?: 'english_source' | 'foreign_source' | 'undetermined' | 'no_ocr' } | null;
+  translator_author_screen?: { verdict?: 'hold' } | null;
   pages_translated?: number | null;
   // Coverage inputs (#3435) — see translationCoverage() for the denominator.
   pages_ocr?: number | null;
@@ -307,6 +318,18 @@ export default async function FirstTranslationEvidence({
   const isFirst = !!verdict && FIRST_FAMILY.has(verdict) && published;
   const isExisting = verdict === 'not_first';
 
+  // Which REGISTER the claim is stated in (#3459). `confirmed` earns the
+  // assertive label; `candidate` reports the search instead of asserting the
+  // negative it cannot establish. This does not change WHETHER the panel
+  // renders — `isFirst` still governs that — only what it says.
+  //
+  // If the Atlas fetch failed and the page fell back to the Supabase catalog
+  // row, the verdict and screen fields are absent and this resolves to
+  // `candidate`. That is the safe direction: a thin payload understates the
+  // claim rather than overstating it.
+  const { claim } = classifyFirstTranslationClaim(book as unknown as ScreenedBook);
+  const isCandidateClaim = claim !== 'confirmed';
+
   // #3435: the claim can be true while the English edition is nowhere near
   // readable. Keep the badge, qualify it — and say how far along it actually is.
   const coverage = translationCoverage(book);
@@ -388,12 +411,18 @@ export default async function FirstTranslationEvidence({
   return (
     <div className="mt-3">
       <details className="group">
-        <summary className="inline-flex items-center gap-2 px-2.5 py-1 bg-accent-gold/20 text-accent-gold hover:bg-accent-gold/30 text-xs font-medium rounded-full border border-accent-gold/30 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden">
-          {firstTranslationBadge(dispForLabel, book.language, inProgress)}
+        <summary
+          className={
+            isCandidateClaim
+              ? 'inline-flex items-center gap-2 px-2.5 py-1 bg-stone-700/40 text-stone-300 hover:bg-stone-700/60 text-xs font-medium rounded-full border border-stone-600/50 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden'
+              : 'inline-flex items-center gap-2 px-2.5 py-1 bg-accent-gold/20 text-accent-gold hover:bg-accent-gold/30 text-xs font-medium rounded-full border border-accent-gold/30 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden'
+          }
+        >
+          {firstTranslationBadge(dispForLabel, book.language, inProgress, claim)}
         </summary>
         <div className="mt-2 p-3 bg-stone-800/50 rounded-lg border border-stone-700/50 text-xs space-y-2">
           <div className="flex items-start justify-between gap-2">
-            <p className="text-stone-300">{firstTranslationDescription(dispForLabel)}</p>
+            <p className="text-stone-300">{firstTranslationDescription(dispForLabel, claim)}</p>
             <StrengthChip strength={effectiveStrength} preliminary={isPreliminary} />
           </div>
           {inProgress && coverage !== null && (

--- a/src/lib/book-seo.ts
+++ b/src/lib/book-seo.ts
@@ -70,7 +70,18 @@ export interface DescriptionInput {
   year?: string | null;
   language?: string | null;
   summary?: string | null;
-  isFirstTranslation?: boolean;
+  /**
+   * The claim's register, not the badge flag (#3459). Only `confirmed` — a
+   * first-family verdict backed by strong or moderate evidence — earns the
+   * "First English translation" prefix here.
+   *
+   * A `candidate` gets the plain "English translation" prefix rather than a
+   * search statement. 155 characters is not room to state a search AND its
+   * limits, and a truncated caveat is worse than none: it would put the
+   * assertion in front of search engines and AI crawlers with the qualifier
+   * cut off. Saying less is the honest option at this length.
+   */
+  firstTranslationClaim?: string;
   pagesTranslated?: number | null;
 }
 
@@ -85,7 +96,7 @@ function clamp(s: string, max = DESC_MAX): string {
 /** Unique, accurate meta description from the real summary, with an honest
  *  translation claim (never on English-language originals). */
 export function buildSeoDescription(input: DescriptionInput): string {
-  const { originalTitle, authorLabel, year, language, summary, isFirstTranslation, pagesTranslated } = input;
+  const { originalTitle, authorLabel, year, language, summary, firstTranslationClaim, pagesTranslated } = input;
   const translated = (pagesTranslated ?? 0) > 0 && !isEnglish(language);
 
   const core = (summary && summary.trim())
@@ -95,7 +106,7 @@ export function buildSeoDescription(input: DescriptionInput): string {
   const alreadySaysTranslation = /translat/i.test(core.slice(0, 60));
   let prefix = '';
   if (translated && !alreadySaysTranslation) {
-    prefix = isFirstTranslation ? 'First English translation. ' : 'English translation. ';
+    prefix = firstTranslationClaim === 'confirmed' ? 'First English translation. ' : 'English translation. ';
   }
   return clamp(prefix + core);
 }

--- a/src/lib/first-translation-labels.ts
+++ b/src/lib/first-translation-labels.ts
@@ -1,8 +1,28 @@
 /**
- * Badge text for first-translation dispositions.
+ * Badge text for first-translation claims.
  *
  * Centralizes the mapping so all UI components stay in sync.
+ *
+ * THE COPY RULE (#3459). "First English translation" asserts an unprovable
+ * universal negative: no catalogue can establish one, it can only return
+ * *nothing found*. Our reference set's measured recall is 27% — three of every
+ * four known prior English translations are invisible to it — and a sampled
+ * check puts the positive predictive value of a `none_found` near 50%.
+ *
+ * So the copy states the SEARCH, which is a bounded, dated act we actually
+ * performed and can show, rather than the negative, which is a claim about the
+ * world that no search supports. "No prior English translation found" is true
+ * at any recall; "this is the first" is not.
+ *
+ * Two registers, and which one a book gets is decided by evidence strength in
+ * `classifyFirstTranslationClaim`, never by the badge flag alone:
+ *
+ *   confirmed → strong/moderate evidence. The assertive label stands.
+ *   candidate → weak or unrecorded evidence (88% of badged books, measured
+ *               2026-08-07). Reports the search and its limits.
  */
+
+import type { FirstTranslationClaim } from './first-translation/candidate';
 
 type Disposition = 'confirmed_first' | 'first_from_source' | 'first_complete_translation' | 'first_modern_translation' | 'translation_found' | 'needs_review';
 
@@ -16,12 +36,35 @@ type Disposition = 'confirmed_first' | 'first_from_source' | 'first_complete_tra
  * "First Complete Translation" collapses to "First Translation, in progress",
  * because calling a 6%-translated book *complete* is the specific claim the
  * coverage gate exists to prevent.
+ *
+ * `claim` decides the register. A `candidate` never gets an assertive label,
+ * however strong the disposition reads — the disposition records what a search
+ * concluded, not how well it was evidenced, and conflating the two is what put
+ * an unqualified "First Translation" on 5,243 weakly-evidenced books.
+ *
+ * ⚠️ IT DEFAULTS TO `candidate`, AND THAT DIRECTION IS THE POINT. A caller that
+ * cannot supply the claim has, by definition, not established the evidence —
+ * the collection, catalogue, author and exhibition cards all render from
+ * `books_catalog`, which carries `ft_disposition` but no evidence strength, so
+ * none of them can tell a cross-checked first from a legacy shim. Defaulting to
+ * the assertive label would let every one of those surfaces assert a universal
+ * negative by omission, which is precisely how this area fails (see
+ * `.claude/docs/invariants/first-translation-claims.md`: every defect here
+ * failed toward a confident clean negative). Opt IN to `confirmed`; never
+ * inherit it.
  */
 export function firstTranslationBadge(
   disposition?: string,
   language?: string,
   inProgress?: boolean,
+  claim: FirstTranslationClaim = 'candidate',
 ): string {
+  if (claim === 'candidate') {
+    // Deliberately one label, not a family. The disposition's shades
+    // (complete / modern / from-source) are distinctions the weak evidence
+    // cannot support, so drawing them here would dress up a coin flip.
+    return inProgress ? 'No prior translation found, in progress' : 'No prior translation found';
+  }
   if (inProgress) {
     return disposition === 'first_from_source' && language
       ? `First from ${language}, in progress`
@@ -41,9 +84,6 @@ export function firstTranslationBadge(
 }
 
 /**
- * Returns the expanded description shown in the book detail page.
- */
-/**
  * One sentence stating how much of the book is actually readable in English.
  * Shown beside the description whenever coverage is below the readable floor,
  * so the panel never lets a bibliographic claim stand in for a finished text.
@@ -53,7 +93,23 @@ export function translationProgressNote(coverage: number): string {
   return `Translation in progress — about ${pct}% of this book is available in English so far.`;
 }
 
-export function firstTranslationDescription(disposition?: string): string {
+/**
+ * The expanded description shown in the book detail panel.
+ *
+ * For a `candidate` this is the search statement — what we looked for, and the
+ * two things a reader needs in order to weigh it: that a catalogue can only
+ * report absence, and that ours is thin for exactly the period most of this
+ * corpus comes from. Stating the limit is not a hedge; it is the claim.
+ *
+ * Defaults to `candidate` for the same reason `firstTranslationBadge` does.
+ */
+export function firstTranslationDescription(
+  disposition?: string,
+  claim: FirstTranslationClaim = 'candidate',
+): string {
+  if (claim === 'candidate') {
+    return 'We searched the catalogues for an earlier English translation of this text and found none. That is a record of the search, not proof that none exists — catalogue coverage of early printed books is thin, and an absence there is weaker evidence than a find.';
+  }
   switch (disposition as Disposition) {
     case 'confirmed_first':
       return 'No prior complete English translation of this text has been found.';
@@ -64,6 +120,20 @@ export function firstTranslationDescription(disposition?: string): string {
     case 'first_modern_translation':
       return 'Only antiquated translations exist. This is the first modern English translation.';
     default:
-      return 'This text has not previously been translated into English.';
+      return 'No prior English translation of this text was found.';
   }
+}
+
+/**
+ * The claim as one clause, for surfaces with no room for a panel: the book
+ * page's publication line, `<meta name="description">`, structured data.
+ *
+ * Returns null when the book carries no first-translation claim worth stating,
+ * so callers fall back to their neutral wording rather than printing an empty
+ * qualifier.
+ */
+export function firstTranslationClause(claim: FirstTranslationClaim): string | null {
+  if (claim === 'confirmed') return 'First English translation';
+  if (claim === 'candidate') return 'No prior English translation found';
+  return null;
 }

--- a/src/lib/first-translation/candidate.ts
+++ b/src/lib/first-translation/candidate.ts
@@ -36,6 +36,20 @@ import { isFirstTranslation, resolveFirstTranslation } from './derive';
 import type { FirstTranslationBook } from './types';
 
 /**
+ * Evidence strengths that can carry an assertive claim.
+ *
+ * `strong` = cross-checked across independent catalogues/models.
+ * `moderate` = one documented search, queries retained.
+ *
+ * Everything else — `weak`, or a verdict object that never recorded a strength,
+ * or the legacy-disposition shim `resolveFirstTranslation` synthesizes for the
+ * 2,957 badged books with no verdict object at all — is NOT enough to assert a
+ * universal negative. Same two values `StrengthChip` already treats as earned,
+ * and the same cut `isPublicFirst` makes for the headline count.
+ */
+const ASSERTABLE_STRENGTHS: ReadonlySet<string> = new Set(['strong', 'moderate']);
+
+/**
  * What we can honestly say about this book's first-translation status.
  *
  * Ordered from strongest claim to no claim. `candidate` is the DEFAULT for the
@@ -43,7 +57,10 @@ import type { FirstTranslationBook } from './types';
  * eligible books sit here.
  */
 export type FirstTranslationClaim =
-  /** A verified first. Earned by evidence, never defaulted into. */
+  /**
+   * A verified first: first-family verdict AND strong or moderate evidence.
+   * Earned by evidence, never defaulted into — a badge alone does not qualify.
+   */
   | 'confirmed'
   /** Non-English, no prior found, screens clear. The honest default. */
   | 'candidate'
@@ -164,10 +181,32 @@ export function classifyFirstTranslationClaim(
     };
   }
 
-  // 5. A verified first, earned through the existing gates (evidence quality,
-  //    readable coverage, the single-writer verdict).
+  // 5. A verified first: the single-writer verdict AND evidence strong enough to
+  //    carry the assertion.
+  //
+  //    ⚠️ The strength check is load-bearing and was missing. `isFirstTranslation`
+  //    is the RENDER gate — verdict in the first family, visible, some translated
+  //    pages — and says nothing about evidence. Measured over the 5,932 badged +
+  //    visible books on 2026-08-07, gating on it alone made 5,684 (95.8%)
+  //    `confirmed`, while only 689 of those carry strong or moderate evidence:
+  //    2,286 are `weak` and 2,957 have no verdict object at all. That made this
+  //    state circular — "confirmed" meant "we badged it", which is the very
+  //    claim the state exists to qualify, and left this file's own promise
+  //    ("earned by evidence, never defaulted into") false.
   if (isFirstTranslation(book)) {
-    return { claim: 'confirmed', reason: 'verified_first', screensIncomplete, needsReview: false };
+    const strength = resolved?.evidence_strength;
+    if (strength && ASSERTABLE_STRENGTHS.has(strength)) {
+      return { claim: 'confirmed', reason: 'verified_first', screensIncomplete, needsReview: false };
+    }
+    // Badged, but on evidence too thin to assert a negative. This is a candidate
+    // — the honest default — not a demotion: the flag is untouched and the book
+    // still shows a first-translation claim, stated as the search we ran.
+    return {
+      claim: 'candidate',
+      reason: screensIncomplete ? 'source_language_unscreened' : 'no_prior_found',
+      screensIncomplete,
+      needsReview: false,
+    };
   }
 
   // 6. The honest default.

--- a/tests/unit/book-seo.test.ts
+++ b/tests/unit/book-seo.test.ts
@@ -37,19 +37,33 @@ describe('buildSeoDescription', () => {
   const summary = 'A cosmological treatise mapping the macrocosm and microcosm.';
 
   it('marks a genuine first translation', () => {
-    const d = buildSeoDescription({ originalTitle: 'Utriusque Cosmi Historia', language: 'Latin', summary, isFirstTranslation: true, pagesTranslated: 1036 });
+    const d = buildSeoDescription({ originalTitle: 'Utriusque Cosmi Historia', language: 'Latin', summary, firstTranslationClaim: 'confirmed', pagesTranslated: 1036 });
     expect(d.startsWith('First English translation.')).toBe(true);
     expect(d).toContain('macrocosm');
   });
 
   it('marks a later (non-first) translation plainly', () => {
-    const d = buildSeoDescription({ originalTitle: 'Sefer ha-Zohar', language: 'Hebrew', summary, isFirstTranslation: false, pagesTranslated: 611 });
+    const d = buildSeoDescription({ originalTitle: 'Sefer ha-Zohar', language: 'Hebrew', summary, firstTranslationClaim: 'defeated', pagesTranslated: 611 });
     expect(d.startsWith('English translation.')).toBe(true);
     expect(d.startsWith('First')).toBe(false);
   });
 
+  it('drops the "First" claim when the evidence only makes it a candidate', () => {
+    // 155 characters is not room to state a search AND its limits, and a
+    // truncated caveat would put the bare assertion in front of search engines
+    // and AI crawlers. Say less rather than assert more (#3459).
+    const d = buildSeoDescription({ originalTitle: 'Amphitheatrum sapientiae aeternae', language: 'Latin', summary, firstTranslationClaim: 'candidate', pagesTranslated: 400 });
+    expect(d.startsWith('English translation.')).toBe(true);
+    expect(d.startsWith('First')).toBe(false);
+  });
+
+  it('does not assert a first when the claim is missing entirely', () => {
+    const d = buildSeoDescription({ originalTitle: 'Amphitheatrum sapientiae aeternae', language: 'Latin', summary, pagesTranslated: 400 });
+    expect(d.startsWith('First')).toBe(false);
+  });
+
   it('never claims translation on an English-language original', () => {
-    const d = buildSeoDescription({ originalTitle: 'Illustrations of British Mycology', language: 'English', summary, isFirstTranslation: false, pagesTranslated: 0 });
+    const d = buildSeoDescription({ originalTitle: 'Illustrations of British Mycology', language: 'English', summary, firstTranslationClaim: 'not_applicable', pagesTranslated: 0 });
     expect(d.toLowerCase()).not.toContain('translation');
     expect(d).toContain('macrocosm');
   });

--- a/tests/unit/first-translation-candidate.test.ts
+++ b/tests/unit/first-translation-candidate.test.ts
@@ -168,6 +168,51 @@ describe('monotonicity: new evidence only ever weakens a claim', () => {
   });
 });
 
+describe('confirmed is earned by EVIDENCE, not by carrying the badge', () => {
+  /** A badged book — the render gate passes. Only evidence strength varies. */
+  const badged = (evidence_strength?: string): ScreenedBook => ({
+    ...FOREIGN,
+    visible: true,
+    is_first_translation: true,
+    first_translation: { verdict: 'first_no_prior', evidence_strength },
+  } as ScreenedBook);
+
+  it('strong and moderate evidence confirm', () => {
+    expect(classifyFirstTranslationClaim(badged('strong')).claim).toBe('confirmed');
+    expect(classifyFirstTranslationClaim(badged('moderate')).claim).toBe('confirmed');
+  });
+
+  it('weak evidence does NOT confirm — it is a candidate', () => {
+    // 2,286 of the 5,932 badged + visible books measured 2026-08-07.
+    const r = classifyFirstTranslationClaim(badged('weak'));
+    expect(r.claim).toBe('candidate');
+    expect(r.reason).toBe('no_prior_found');
+  });
+
+  it('an unrecorded strength does not confirm', () => {
+    expect(classifyFirstTranslationClaim(badged(undefined)).claim).toBe('candidate');
+  });
+
+  it('the legacy-disposition shim does not confirm', () => {
+    // 2,957 badged books carry no verdict object at all; resolveFirstTranslation
+    // synthesizes one and stamps it `weak` precisely because it was never
+    // produced by a real adjudicator. Without this, gating on the render rule
+    // alone made 95.8% of badged books "confirmed" — a state that meant only
+    // "we badged it", which is the claim it exists to qualify.
+    const r = classifyFirstTranslationClaim({
+      ...FOREIGN,
+      visible: true,
+      is_first_translation: true,
+      translation_verification: { disposition: 'confirmed_first' },
+    } as ScreenedBook);
+    expect(r.claim).toBe('candidate');
+  });
+
+  it('a badged book stays a claim — this qualifies it, it does not demote it', () => {
+    expect(hasFirstTranslationClaim(badged('weak'))).toBe(true);
+  });
+});
+
 describe('hasFirstTranslationClaim', () => {
   it('covers confirmed and candidate, excludes the rest', () => {
     expect(hasFirstTranslationClaim(FOREIGN)).toBe(true);

--- a/tests/unit/first-translation-coverage.test.ts
+++ b/tests/unit/first-translation-coverage.test.ts
@@ -21,7 +21,7 @@ import {
   isFirstTranslation,
   FIRST_TRANSLATION_READABLE_MIN,
 } from '@/lib/first-translation/derive';
-import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import { firstTranslationBadge, firstTranslationDescription } from '@/lib/first-translation-labels';
 import type { FirstTranslationBook } from '@/lib/first-translation/types';
 
 /** A badged book with strong evidence — the only thing varying is coverage. */
@@ -117,21 +117,52 @@ describe('isPublicFirst excludes barely-translated books from the headline', () 
 
 describe('firstTranslationBadge qualifies an in-progress translation', () => {
   it('reads plainly when the translation is done', () => {
-    expect(firstTranslationBadge('confirmed_first', 'Latin', false)).toBe('First Translation');
+    expect(firstTranslationBadge('confirmed_first', 'Latin', false, 'confirmed')).toBe('First Translation');
   });
 
   it('says so when it is not', () => {
-    expect(firstTranslationBadge('confirmed_first', 'Latin', true)).toBe('First Translation, in progress');
+    expect(firstTranslationBadge('confirmed_first', 'Latin', true, 'confirmed')).toBe('First Translation, in progress');
   });
 
   it('never calls a partly-translated book COMPLETE', () => {
     // The specific claim the gate exists to prevent: "First Complete
     // Translation" on a book that is 6% translated.
-    expect(firstTranslationBadge('first_complete_translation', 'Latin', true))
+    expect(firstTranslationBadge('first_complete_translation', 'Latin', true, 'confirmed'))
       .not.toContain('Complete');
   });
 
   it('keeps the source-language wording when qualifying', () => {
-    expect(firstTranslationBadge('first_from_source', 'Dutch', true)).toBe('First from Dutch, in progress');
+    expect(firstTranslationBadge('first_from_source', 'Dutch', true, 'confirmed')).toBe('First from Dutch, in progress');
+  });
+});
+
+describe('firstTranslationBadge states the search when the claim is a candidate', () => {
+  it('reports the search instead of asserting the negative', () => {
+    expect(firstTranslationBadge('confirmed_first', 'Latin', false, 'candidate'))
+      .toBe('No prior translation found');
+  });
+
+  it('keeps the in-progress qualifier', () => {
+    expect(firstTranslationBadge('confirmed_first', 'Latin', true, 'candidate'))
+      .toBe('No prior translation found, in progress');
+  });
+
+  it('does not draw distinctions the weak evidence cannot support', () => {
+    // complete / modern / from-source are gradations of a conclusion, not of the
+    // evidence behind it. Rendering them on a candidate dresses up a coin flip.
+    for (const d of ['first_complete_translation', 'first_modern_translation', 'first_from_source']) {
+      expect(firstTranslationBadge(d, 'Dutch', false, 'candidate')).toBe('No prior translation found');
+    }
+  });
+
+  it('DEFAULTS to the candidate register when the caller omits the claim', () => {
+    // The load-bearing default (#3459). Card surfaces render from
+    // `books_catalog`, which carries no evidence strength, so a caller that
+    // cannot supply the claim must not assert one by omission. If this ever
+    // flips to 'confirmed', every collection, catalogue and author card starts
+    // asserting a universal negative again.
+    expect(firstTranslationBadge('confirmed_first', 'Latin', false))
+      .toBe('No prior translation found');
+    expect(firstTranslationDescription('confirmed_first')).toContain('not proof');
   });
 });


### PR DESCRIPTION
Implements the first item in `.claude/docs/first-translation-reference-set.md` §8: *"Badge copy. ~5,839 live claims rest on evidence with ~50% PPV from a set that is 1% early-modern… Swapping to the search statement makes all of them true immediately and is gated on nothing."*

The state layer for this shipped in #3587 and rendered nowhere. This wires it — and fixes a defect in it that would have made the wiring a no-op.

## The defect: `confirmed` meant "we badged it"

`classifyFirstTranslationClaim` gated `confirmed` on `isFirstTranslation()`. That is the **render** rule — first-family verdict, visible, some translated pages — and it says nothing about evidence. Measured over the 5,932 badged + visible books on 2026-08-07:

| | |
|---|---|
| `confirmed` under the old gate | **5,684 (95.8%)** |
| badged books with `strong` evidence | 101 |
| with `moderate` | 588 |
| with `weak` | 2,286 |
| **with no verdict object at all** | **2,957** |

So the state was circular: "confirmed" resolved to the claim it exists to qualify, and this file's own promise — *"earned by evidence, never defaulted into"* — was false. Wiring it as-was would have changed nothing for 95.8% of books.

`confirmed` now also requires `strong` or `moderate` evidence: the same cut `isPublicFirst` makes for the headline count, and the same one `StrengthChip` already renders. After the fix:

```
candidate       5,217  87.9%
confirmed         627  10.6%
defeated           59   1.0%
not_applicable     29   0.5%
```

`scripts/audit/ft-claim-register.ts` produces that table and re-runs after any evidence sweep.

## Nothing is demoted

`is_first_translation` is untouched, the reconcile stays its single writer, and every badged book still carries a claim. 5,217 of them now state what we did instead of what no search can establish. A `candidate` is the honest default, not a penalty — and it is **monotone**: when ESTC lands and the evidence improves, books move up without anyone re-checking them by hand.

## The default is the safety property

`firstTranslationBadge` and `firstTranslationDescription` default to `candidate`, **not** `confirmed`. The collection, catalogue, author and exhibition cards render from `books_catalog`, which carries `ft_disposition` but no evidence strength — none of them can tell a cross-checked first from a legacy shim. An assertive default would let every one of those surfaces assert a universal negative by omission.

That is precisely how this area fails. Per `.claude/docs/invariants/first-translation-claims.md`: *"Every bug in this area fails toward a confident clean negative. Fourteen defects in one session, not one of which produced a false positive."* A test pins the direction, because a future refactor flipping that default would be silent and site-wide.

## In scope — where the claim is stated in prose

- **Evidence panel**: pill label, description, and colour. Gold asserts; stone reports. The candidate description states the search *and its limit* — "a record of the search, not proof that none exists" — because stating the limit is the claim, not a hedge.
- **Book page**: the publication-timeline label ("First English translation published" → "English edition published") and the stat-line chip.
- **`<meta description>`**: a candidate gets the plain `"English translation. "` prefix, not a search statement. 155 characters is not room for a search *and* its limits, and a truncated caveat is worse than none — it would put the bare assertion in front of search engines and AI crawlers with the qualifier cut off. Saying less is the honest option at this length.
- A candidate never gets the complete/modern/from-source gradations. Those are shades of a *conclusion*, not of the evidence behind it; drawing them dresses up a coin flip.

## Out of scope, deliberately

- **The card surfaces keep one label.** Giving them the real register needs an evidence-strength column on `books_catalog` plus a re-sync of ~100K rows — a separate PR. The safe default holds until then, so cards understate rather than overstate.
- **The 59 `defeated` books** — badged `is_first_translation: true` while `first_translation.verdict` reads `not_first`. The evidence panel already renders them correctly as "Existing translations", but the flag still drives the cards. That is a screening queue for #3524/#2933, not a rendering fix, and demoting a badge is sign-off-gated.
- **No new reference-set sources.** The ESTC harvest (#3522) is running separately; it moves books between registers without touching this code.

## Verification

- `npx tsc --noEmit` clean
- 148 test files / 1,910 tests pass
- New coverage: the evidence gate (strong/moderate confirm; weak, unrecorded, and the legacy-disposition shim do not), the candidate register's copy, and the `candidate` default on both label helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
