### PR TITLE
fix(estc): the leaf assertion was symmetric, and killed a correct harvest at 34%

### DIFF
--- a/scripts/enrichment/ingest-estc.mjs
+++ b/scripts/enrichment/ingest-estc.mjs
@@ -345,6 +345,18 @@ async function main() {
   const partsDir = path.join(OUT_DIR, 'leaves');
   fs.mkdirSync(partsDir, { recursive: true });
 
+  // ONE definition of a leaf's filename, used by the writer AND the reader.
+  //
+  // These were built independently and drifted: the writer appended `.exact` for
+  // an `exactOnly` leaf, the concatenator did not, and its `existsSync` turned
+  // the mismatch into a silent skip. All 37 exact leaves were dropped from the
+  // final file on the 2026-08-07 run — visible only because 2 of them happened
+  // to carry English translations (`N4`, `T17`), so the artifact came out at
+  // 22,536 rows against 22,538 collected. Same shape as the R2 key incident in
+  // CLAUDE.md: two sites deriving one path, and nothing comparing them.
+  const leafPathOf = (leaf) =>
+    path.join(partsDir, `${leaf.prefix}${leaf.exactOnly ? '.exact' : ''}.jsonl`);
+
   let seen = 0, kept = 0, skipped = 0;
   const evidence = {};
   const started = Date.now();
@@ -353,10 +365,22 @@ async function main() {
   const drift = { leaves: 0, records: 0, dupes: 0 };
 
   for (const [i, leaf] of leaves.entries()) {
-    const leafPath = path.join(partsDir, `${leaf.prefix}${leaf.exactOnly ? '.exact' : ''}.jsonl`);
+    const leafPath = leafPathOf(leaf);
     if (fs.existsSync(leafPath)) {
-      const done = fs.readFileSync(leafPath, 'utf8').split('\n').filter(Boolean).length;
-      kept += done; seen += leaf.hits; skipped++;
+      // Re-tally the evidence breakdown from the resumed rows. Counting only
+      // `kept` here made the printed breakdown cover fresh leaves ONLY: the
+      // 2026-08-07 run reported 22,538 translations but 15,518 + 166 = 15,684
+      // in the by-evidence lines, the 6,854 difference being exactly what the
+      // 146 resumed leaves held. A total whose own parts do not sum to it
+      // invites the reader to trust the wrong one.
+      const lines = fs.readFileSync(leafPath, 'utf8').split('\n').filter(Boolean);
+      for (const line of lines) {
+        try {
+          const k = String(JSON.parse(line).translation_evidence ?? '').split(':')[0];
+          if (k) evidence[k] = (evidence[k] || 0) + 1;
+        } catch { /* a malformed row would have failed its own leaf's rename */ }
+      }
+      kept += lines.length; seen += leaf.hits; skipped++;
       continue;
     }
     const tmp = `${leafPath}.partial`;
@@ -390,13 +414,34 @@ async function main() {
   }
 
   // Concatenate the verified leaves into the reference-set file.
+  //
+  // A missing leaf here is a BUG, not a condition to tolerate: every leaf in
+  // `leaves` was either harvested and renamed into place this run, or found on
+  // disk and skipped. `existsSync`-and-continue is what let the `.exact` path
+  // mismatch drop 37 leaves without a word.
   const outPath = path.join(OUT_DIR, `estc-translations.${SNAPSHOT}.jsonl`);
   const final = fs.createWriteStream(outPath);
+  let written = 0;
   for (const leaf of leaves) {
-    const p = path.join(partsDir, `${leaf.prefix}.jsonl`);
-    if (fs.existsSync(p)) final.write(fs.readFileSync(p));
+    const p = leafPathOf(leaf);
+    if (!fs.existsSync(p)) {
+      throw new Error(`leaf file missing at concatenation: ${p} — refusing to write a short reference set`);
+    }
+    const buf = fs.readFileSync(p);
+    written += buf.toString('utf8').split('\n').filter(Boolean).length;
+    final.write(buf);
   }
   await new Promise((r) => final.end(r));
+
+  // Reconcile the ARTIFACT against the count, which the script never did on its
+  // own output — the one place a silent shortfall would survive every upstream
+  // guard and still reach the reference set.
+  const onDisk = fs.readFileSync(outPath, 'utf8').split('\n').filter(Boolean).length;
+  if (onDisk !== kept || written !== kept) {
+    throw new Error(
+      `reference set does not reconcile: ${onDisk} rows on disk, ${written} concatenated, ${kept} counted`,
+    );
+  }
 
   console.log(`\n\n─── ESTC reference set ───────────────────────────────────────`);
   console.log(`  records examined        : ${seen.toLocaleString()}`);

--- a/scripts/enrichment/ingest-estc.mjs
+++ b/scripts/enrichment/ingest-estc.mjs
@@ -144,31 +144,79 @@ async function partition(prefix, hits, depth = 0) {
     leaves.push(...await partition(prefix + ch, n, depth + 1));
   }
   // Arithmetic, not trust: an id belongs to exactly one child, so the children
-  // must account for the parent exactly. Anything else means the wildcard is not
-  // behaving as a prefix and the partition cannot be called complete.
-  if (childSum !== hits) {
-    throw new Error(`partition of ${prefix}* is lossy: children sum ${childSum} vs parent ${hits}`);
+  // must account for the parent. Directional for the same reason as
+  // harvestLeaf — children SHORT of the parent means the wildcard is not
+  // behaving as a prefix and records are unreachable, which is fatal. Children
+  // OVER the parent means the live index grew between the two counts; the
+  // partition still covers everything, so it is reported, not thrown.
+  if (childSum < hits) {
+    throw new Error(
+      `partition of ${prefix}* is lossy: children sum ${childSum} vs parent ${hits} — `
+      + `${hits - childSum} records unreachable`,
+    );
+  }
+  if (childSum > hits) {
+    console.warn(`  ⚠ partition of ${prefix}*: children sum ${childSum} vs parent ${hits} — index grew between counts`);
   }
   return leaves;
 }
 
-/** Page one leaf completely, asserting we received what it promised. */
-async function harvestLeaf(leaf, sink) {
+/**
+ * Page one leaf completely, asserting we received what it promised.
+ *
+ * THE ASSERTION IS DIRECTIONAL, AND THAT IS THE POINT.
+ *
+ * The hazard this whole script exists to prevent is SILENT TRUNCATION — `from`
+ * past 10,000 returns HTTP 200 with no rows, so a naive harvester records
+ * nothing for most of the catalogue and every book downstream reads
+ * `none_found`. That failure is always `got < hits`. It stays fatal.
+ *
+ * `got > hits` cannot be that failure: we hold a superset of what was promised,
+ * so nothing is missing. CERL is a LIVE index and `hits` was read during
+ * partitioning, minutes before the paging — a record added or moved in between
+ * gives exactly this. Observed 2026-08-07 on the first full run: leaf `R5*`
+ * collected 2,284 against a promised 2,283 and killed a harvest that was 34%
+ * done and correct. Failing closed on the safe direction is not caution, it is
+ * a false alarm that costs the run.
+ *
+ * So: under-collection throws, over-collection is deduped by id (the ids are
+ * what the partition's own arithmetic rests on, so they are exact), counted, and
+ * reported. Drift is never swallowed — `main` prints the total at the end.
+ */
+export async function harvestLeaf(leaf, sink, drift = { leaves: 0, records: 0, dupes: 0 }, fetchPage = search) {
   // `exactOnly` leaves are the single record whose id IS the prefix; querying
   // them with a wildcard would re-collect the whole subtree.
   const query = leaf.exactOnly ? `id:${leaf.prefix}` : `id:${leaf.prefix}*`;
+  const ids = new Set();
   let got = 0;
+  let dupes = 0;
   for (let from = 0; from < leaf.hits; from += PAGE) {
     if (from >= FROM_CAP) throw new Error(`leaf ${leaf.prefix}* exceeds the ${FROM_CAP} cap — partition bug`);
-    const { rows } = await search(query, from, PAGE);
+    const { rows } = await fetchPage(query, from, PAGE);
     if (!rows.length) throw new Error(`leaf ${leaf.prefix}* returned 0 rows at from=${from} of ${leaf.hits}`);
-    for (const row of rows) sink(row);
-    got += rows.length;
+    for (const row of rows) {
+      // A record shifting position under a live index can surface twice across a
+      // page boundary. Deduping by id keeps `got` a count of DISTINCT records,
+      // so the comparison below measures coverage rather than paging noise.
+      if (row.id && ids.has(row.id)) { dupes++; continue; }
+      if (row.id) ids.add(row.id);
+      sink(row);
+      got++;
+    }
     await sleep(DELAY_MS);
   }
-  if (got !== leaf.hits) {
-    throw new Error(`leaf ${leaf.prefix}*: collected ${got} but it reported ${leaf.hits}`);
+  if (got < leaf.hits) {
+    throw new Error(
+      `leaf ${leaf.prefix}*: collected ${got} but it reported ${leaf.hits} — `
+      + `${leaf.hits - got} records missing, refusing to record a short leaf`,
+    );
   }
+  if (got > leaf.hits) {
+    drift.leaves++;
+    drift.records += got - leaf.hits;
+    console.warn(`  ⚠ leaf ${leaf.prefix}*: index grew under us — ${got} collected vs ${leaf.hits} promised (superset, kept)`);
+  }
+  if (dupes) drift.dupes += dupes;
   return got;
 }
 
@@ -272,8 +320,15 @@ async function main() {
 
   const promised = leaves.reduce((s, l) => s + l.hits, 0);
   console.log(`\n${leaves.length} leaves, ${promised.toLocaleString()} records promised`);
-  if (!ONLY_PREFIX && Math.abs(promised - total) > 1) {
+  // Directional here too. SHORT of the total is an incomplete partition and is
+  // fatal at any size. OVER the total is the live index having grown during the
+  // ~15-minute partitioning pass — harmless, but say by how much, because a
+  // silently-tolerated drift is how a real partition bug would hide.
+  if (!ONLY_PREFIX && promised < total) {
     throw new Error(`partition covers ${promised} of ${total} — refusing to harvest an incomplete set`);
+  }
+  if (!ONLY_PREFIX && promised > total) {
+    console.warn(`  ⚠ partition promises ${promised} vs a reported total of ${total} — index grew during partitioning (+${promised - total})`);
   }
 
   // ── RESUMABLE, per leaf ───────────────────────────────────────────────────
@@ -293,6 +348,9 @@ async function main() {
   let seen = 0, kept = 0, skipped = 0;
   const evidence = {};
   const started = Date.now();
+  // How far the live index moved under the harvest. Tolerated, never swallowed:
+  // reported at the end so a genuine partition bug cannot hide inside "drift".
+  const drift = { leaves: 0, records: 0, dupes: 0 };
 
   for (const [i, leaf] of leaves.entries()) {
     const leafPath = path.join(partsDir, `${leaf.prefix}${leaf.exactOnly ? '.exact' : ''}.jsonl`);
@@ -312,7 +370,7 @@ async function main() {
       const k = row.translation_evidence.split(':')[0];
       evidence[k] = (evidence[k] || 0) + 1;
       out.write(JSON.stringify(row) + '\n');
-    });
+    }, drift);
     await new Promise((r) => out.end(r));
     fs.renameSync(tmp, leafPath);   // atomic: only a verified leaf gets its name
 
@@ -323,6 +381,13 @@ async function main() {
       + `${String(leaf.hits).padStart(6)} rows, kept ${leafKept}  |  total kept ${kept.toLocaleString()}  ETA ~${eta}m`);
   }
   if (skipped) console.log(`\n  (${skipped} leaf/leaves already on disk — resumed)`);
+  if (drift.leaves || drift.dupes) {
+    console.log(
+      `\n  index drift: ${drift.leaves} leaf/leaves grew (+${drift.records} records), `
+      + `${drift.dupes} duplicate id(s) collapsed across page boundaries.`,
+    );
+    console.log('  (a superset is safe — a SHORT leaf would have thrown)');
+  }
 
   // Concatenate the verified leaves into the reference-set file.
   const outPath = path.join(OUT_DIR, `estc-translations.${SNAPSHOT}.jsonl`);

--- a/tests/unit/estc-uniform-title.test.ts
+++ b/tests/unit/estc-uniform-title.test.ts
@@ -19,7 +19,7 @@
 import { describe, it, expect } from 'vitest';
 
 // @ts-expect-error — .mjs script module without type declarations
-import { splitUniformTitle, toReferenceRow } from '../../scripts/enrichment/ingest-estc.mjs';
+import { splitUniformTitle, toReferenceRow, harvestLeaf } from '../../scripts/enrichment/ingest-estc.mjs';
 
 describe('language as the LAST component', () => {
   it.each([
@@ -106,5 +106,77 @@ describe('toReferenceRow', () => {
     const r = toReferenceRow(row);
     expect(r.author).toMatch(/^Agrippa/);
     expect(r.added_entries).toContain('Sanford, James, translator.');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The leaf assertion is DIRECTIONAL — under-collection is fatal, over is not.
+//
+// The whole script exists because CERL's `from` cap fails as HTTP 200 with no
+// rows, which always shows up as collecting FEWER records than promised. That
+// must stay fatal. Collecting MORE cannot be that failure — CERL is a live index
+// and `hits` is read minutes earlier during partitioning. On the first full run
+// (2026-08-07) leaf `R5*` returned 2,284 against a promised 2,283 and killed a
+// harvest that was 34% done and entirely correct.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('harvestLeaf: short is fatal, long is drift', () => {
+  /** A fake pager returning `total` synthetic rows, `PAGE`-sized, ids unique. */
+  const pagerOf = (total) => async (_q, from, size) => ({
+    hits: total,
+    rows: Array.from({ length: Math.max(0, Math.min(size, total - from)) },
+      (_, i) => ({ id: `R${from + i}`, language: 'eng', search_titles: [], search_names: [], subjects: [], dates: [] })),
+  });
+
+  it('accepts an exact leaf', async () => {
+    const drift = { leaves: 0, records: 0, dupes: 0 };
+    const got = await harvestLeaf({ prefix: 'R5', hits: 250 }, () => {}, drift, pagerOf(250));
+    expect(got).toBe(250);
+    expect(drift.leaves).toBe(0);
+  });
+
+  it('THROWS on the CERL truncation shape — a page that returns no rows', async () => {
+    // `from` past the cap answers HTTP 200 with no `rows` key. This is the exact
+    // failure the script exists to prevent, and it must never be tolerated.
+    await expect(
+      harvestLeaf({ prefix: 'R5', hits: 250 }, () => {}, undefined, pagerOf(200)),
+    ).rejects.toThrow(/returned 0 rows/);
+  });
+
+  it('THROWS on the OTHER short shape — pages that stay non-empty but under-deliver', async () => {
+    // Short-but-non-empty pages never trip the 0-rows guard, so the count
+    // comparison is the only thing standing between this and a silently
+    // shortened leaf. Pinned separately because the two shapes fail at
+    // different lines and a fixture that only produces one proves nothing
+    // about the other.
+    const shortPager = async (_q, from, size) => ({
+      hits: 250,
+      rows: Array.from({ length: Math.max(0, Math.min(size - 10, 250 - from)) },
+        (_, i) => ({ id: `S${from + i}` })),
+    });
+    await expect(
+      harvestLeaf({ prefix: 'R5', hits: 250 }, () => {}, undefined, shortPager),
+    ).rejects.toThrow(/records missing/);
+  });
+
+  it('KEEPS a superset and records the drift instead of dying', async () => {
+    // The exact shape that killed the 2026-08-07 run.
+    const drift = { leaves: 0, records: 0, dupes: 0 };
+    const got = await harvestLeaf({ prefix: 'R5', hits: 2283 }, () => {}, drift, pagerOf(2284));
+    expect(got).toBe(2284);
+    expect(drift.leaves).toBe(1);
+    expect(drift.records).toBe(1);
+  });
+
+  it('collapses a duplicate id across a page boundary rather than counting it', async () => {
+    // A record shifting under a live index can surface on two pages. Deduping
+    // keeps `got` a count of DISTINCT records, so the comparison measures
+    // coverage rather than paging noise.
+    const rows = [{ id: 'A' }, { id: 'B' }, { id: 'B' }, { id: 'C' }];
+    const pager = async (_q, from, size) => ({ hits: 3, rows: rows.slice(from, from + size) });
+    const drift = { leaves: 0, records: 0, dupes: 0 };
+    const got = await harvestLeaf({ prefix: 'X', hits: 3 }, () => {}, drift, pager);
+    expect(got).toBe(3);
+    expect(drift.dupes).toBe(1);
+    expect(drift.leaves).toBe(0);
   });
 });


### PR DESCRIPTION
The first full ESTC harvest (#3522 / #3619) died after 146 of 427 leaves, 34% in:

```
Error: leaf R5*: collected 2284 but it reported 2283
```

**Nothing was wrong with the harvest.** CERL is a live index, and `hits` is read during the partitioning pass — roughly fifteen minutes before that leaf is actually paged. A record added or moved in between produces exactly this. The guard compared with `!==`, so it treated a *superset* as a fatal error and threw away 34% of a correct run.

## Direction is the whole point of these checks

The hazard this script exists to prevent is the one documented in #3619: `from` past 10,000 answers **HTTP 200 with no rows**, so a naive harvester silently records nothing for 477,000 records and every book downstream reads `none_found`. That failure always presents as collecting **fewer** records than promised. It stays fatal, and now says how many are missing.

Collecting **more** cannot be that failure — we hold everything that was promised. It is reported and kept.

Same asymmetry fixed in the two sibling checks:

| check | short | over |
|---|---|---|
| `harvestLeaf` | throws — records missing | kept, counted as drift |
| `partition()` | throws — wildcard isn't behaving as a prefix, records unreachable | warns — index grew between counts |
| global coverage | throws — incomplete partition | warns with the delta |

## Drift is tolerated, never swallowed

- Duplicate ids across a page boundary are collapsed, so `got` counts **distinct** records and the comparison measures coverage rather than paging noise.
- The run prints how many leaves grew, by how many records, and how many duplicates were collapsed.

A silently-absorbed drift is precisely where a real partition bug would hide, which is the same reason `ingest-loc-bulk.mjs` now tallies its rejections by reason.

## Tests

`harvestLeaf` is exported with an injectable pager. Four cases pin the behaviour, and the two under-collection shapes are pinned **separately**:

- the CERL truncation shape — a page returning no rows
- short-but-non-empty pages, which never trip the 0-rows guard, so the count comparison is the only thing standing between them and a silently shortened leaf

They fail at different lines. My first draft of this test only produced the first shape and asserted the second one's error message — it failed, correctly, and that is why both are here now.

Plus: an exact leaf passes; the 2,283 → 2,284 shape that killed the run is kept and recorded as drift.

## State of the harvest

Resumable per leaf, so the **147 leaves already on disk stand** — about 6,850 English-translation rows collected. Restarting picks up at leaf 148 and re-runs only the partition pass. Keep rate is running ~4-5%, not the 18% floated in #3522, which that issue explicitly flagged as unreliable (it was sampled almost entirely from `from=0`, i.e. Caxton-heavy incunabula). I'll post the measured figure when the run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
