### PR TITLE
fix(mcp): a book with no embeddings looked identical to a book with no answer

### DIFF
--- a/src/app/api/books/[id]/search/route.ts
+++ b/src/app/api/books/[id]/search/route.ts
@@ -8,6 +8,7 @@ import { isBookReadable } from '@/lib/book-access';
 import { logSearchEvent } from '@/lib/search-event-log';
 import { frontMatterVerdict } from '@/lib/front-matter';
 import { scorePages } from '@/lib/passage-score';
+import { semanticCoverage, type SemanticCoverage } from '@/lib/semantic-coverage';
 
 /**
  * How many pages to pull before scoring. The cap must be applied AFTER ranking,
@@ -120,7 +121,7 @@ export async function GET(
     // doc is found we preserve prior behavior (just search pages) rather than 404.
     const gateBook = await db.collection('books').findOne(
       { $or: [{ id: bookId }, { slug: bookId }] },
-      { projection: { id: 1, visible: 1 } }
+      { projection: { id: 1, visible: 1, pages_translated: 1 } }
     );
     if (gateBook && !(await isBookReadable(gateBook, request))) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
@@ -380,6 +381,20 @@ export async function GET(
     results.length = 0;
     results.push(...capped);
 
+    // Was the semantic leg able to run at all? Only checked when it produced
+    // NOTHING — that is the one case where a caller could mistake a blind index
+    // for an absent passage, and checking unconditionally would put a Supabase
+    // round-trip on every search that is already working. See
+    // src/lib/semantic-coverage.ts for the measurement that motivated this.
+    let coverage: SemanticCoverage | undefined;
+    if (semanticResults.length === 0) {
+      coverage = await semanticCoverage(
+        (gateBook?.id as string) || bookId,
+        (gateBook?.pages_translated as number) || 0,
+      );
+      if (coverage.status === 'full' || coverage.status === 'unknown') coverage = undefined;
+    }
+
     let ocrPages = 0;
     let translationPages = 0;
     for (const result of results) {
@@ -403,6 +418,7 @@ export async function GET(
       ocrPages,
       translationPages,
       front_matter_results: results.filter((r) => r.is_front_matter).length,
+      ...(coverage ? { semantic_coverage: coverage } : {}),
       results
     });
   } catch (error) {

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -194,6 +194,10 @@ async function searchWithinBook(args: Record<string, unknown>) {
     const pageNum = Number(r.pageNumber);
     return {
       page: pageNum, snippet: stripProvenanceMarks(best?.snippet as string), source: best?.field, match_count: matches?.length || 0,
+      // Relevance and which leg found it. A page found by BOTH keyword and
+      // meaning is the strongest signal the tool can give.
+      ...(r.score !== undefined ? { score: r.score } : {}),
+      ...(r.found_by ? { found_by: r.found_by } : {}),
       // Not body text: introduction, preface, contents, index, blank leaves,
       // binding photography. Surfaced, not
       // just used for ordering, so a caller can SEE why something ranks low —
@@ -205,11 +209,16 @@ async function searchWithinBook(args: Record<string, unknown>) {
     };
   });
   const frontCount = Number(result.front_matter_results) || 0;
+  // Present only when the semantic leg could not see this book. Passed straight
+  // through so the caveat reaches the agent that has to decide whether a blank
+  // means "not here" — which, on an unembedded book, it does not.
+  const coverage = result.semantic_coverage as { status?: string; caveat?: string } | undefined;
   return {
-    book_id: args.book_id, query: result.query, total: result.total,
+    book_id: args.book_id, query: result.query, total: result.total, returned: result.returned,
     ...(frontCount ? { front_matter_results: frontCount } : {}),
+    ...(coverage ? { semantic_coverage: coverage } : {}),
     results,
-    tip: `Use get_book_text with from/to page numbers to read the full text around these matches. Always cite using short_url when presenting passages to users.${frontCount ? ` ${frontCount} of these are front matter (introduction, preface, contents) and are ordered last — they are the translator's or publisher's words, not the author's.` : ''}`,
+    tip: `Use get_book_text with from/to page numbers to read the full text around these matches. Always cite using short_url when presenting passages to users.${frontCount ? ` ${frontCount} of these are front matter (introduction, preface, contents) and are ordered last — they are the translator's or publisher's words, not the author's.` : ''}${coverage?.caveat ? ` SEMANTIC COVERAGE: ${coverage.caveat}` : ''}`,
   };
 }
 

--- a/src/lib/semantic-coverage.ts
+++ b/src/lib/semantic-coverage.ts
@@ -1,0 +1,84 @@
+import { supabase } from '@/lib/supabase';
+
+/**
+ * Can semantic search actually see this book?
+ *
+ * ## Why this exists
+ *
+ * Page vectors live in Supabase `page_translations` and are written by
+ * `scripts/workers/embed-gemini.mjs`. When a book has no rows there, the
+ * semantic leg returns an empty array — which is indistinguishable, from the
+ * caller's side, from "nothing in this book matches your meaning".
+ *
+ * That is not a hypothetical. Measured 2026-08-07 over 150 sampled visible books
+ * with >20 translated pages: **53% fully embedded, 22% under a quarter, 23% with
+ * zero rows.** Two of the volumes a reader spent a day searching were among the
+ * blind ones — Taylor's 1801 *Metaphysics* at 10 of 520 pages, the 1551 Aldine
+ * at 10 of 708. Their conclusion was that the corpus was thin on exactly the
+ * passages they wanted. The corpus was fine; the vectors were missing.
+ *
+ * The reader's own framing of the cost, from a separate report:
+ *
+ *   > "I can't tell a user a quote is absent from Aristotle, because I can't
+ *   > know what fraction of Aristotle exists here in a searchable language.
+ *   > Every negative had to be hedged."
+ *
+ * ## Why a caveat and not an error
+ *
+ * Throwing would be wrong. The keyword results on an unembedded book are
+ * perfectly good and are usually what the caller wanted; failing the whole
+ * request because one leg is blind would turn a partial answer into no answer.
+ * What the caller needs is to know that a semantic BLANK is not evidence of
+ * absence — so this is reported alongside the results, and only when it matters.
+ */
+
+export type CoverageStatus = 'full' | 'partial' | 'none' | 'unknown';
+
+export interface SemanticCoverage {
+  status: CoverageStatus;
+  embedded_pages: number;
+  translated_pages: number;
+  /** Present when the caller must not read an empty semantic result as absence. */
+  caveat?: string;
+}
+
+const CAVEAT_NONE =
+  'This book has no page embeddings yet, so conceptual/paraphrase matching could not run on it. '
+  + 'The keyword results are complete, but the ABSENCE of a semantic hit here is not evidence the '
+  + 'passage is missing — do not tell the user the text does not contain it. Try distinctive literal '
+  + 'terms from the period translation, or search_concept across the whole corpus.';
+
+const CAVEAT_PARTIAL =
+  'Only part of this book has page embeddings, so conceptual/paraphrase matching saw a fraction of '
+  + 'it. Treat a missing semantic hit as inconclusive rather than as absence.';
+
+/**
+ * Count this book's page vectors. Returns `unknown` rather than throwing — a
+ * coverage lookup must never be able to fail a search that already has results.
+ */
+export async function semanticCoverage(
+  bookId: string,
+  translatedPages: number,
+): Promise<SemanticCoverage> {
+  let embedded = 0;
+  try {
+    const { count, error } = await supabase
+      .from('page_translations')
+      .select('*', { count: 'exact', head: true })
+      .eq('book_id', bookId);
+    if (error) return { status: 'unknown', embedded_pages: 0, translated_pages: translatedPages };
+    embedded = count ?? 0;
+  } catch {
+    return { status: 'unknown', embedded_pages: 0, translated_pages: translatedPages };
+  }
+
+  if (embedded === 0) {
+    return { status: 'none', embedded_pages: 0, translated_pages: translatedPages, caveat: CAVEAT_NONE };
+  }
+  // A book can carry slightly more vectors than Mongo reports translated pages
+  // (untranslated originals get an OCR-derived vector), so compare generously.
+  if (translatedPages > 0 && embedded < translatedPages * 0.9) {
+    return { status: 'partial', embedded_pages: embedded, translated_pages: translatedPages, caveat: CAVEAT_PARTIAL };
+  }
+  return { status: 'full', embedded_pages: embedded, translated_pages: translatedPages };
+}

--- a/tests/unit/semantic-coverage.test.ts
+++ b/tests/unit/semantic-coverage.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * A semantic blank must be distinguishable from an absent passage.
+ *
+ * Measured 2026-08-07 across 150 sampled visible books with >20 translated
+ * pages: 53% fully embedded, 22% under a quarter, 23% with ZERO rows in
+ * `page_translations`. Two of the volumes a reader spent a day searching were
+ * among the blind ones — Taylor's 1801 Metaphysics at 10 of 520 pages, the 1551
+ * Aldine at 10 of 708 — and they concluded the corpus was thin on exactly the
+ * passages they wanted. It was not; the vectors were missing.
+ */
+
+const selectMock = vi.fn();
+vi.mock('@/lib/supabase', () => ({
+  supabase: { from: () => ({ select: selectMock }) },
+}));
+
+const { semanticCoverage } = await import('@/lib/semantic-coverage');
+
+/** Mirror the supabase-js chain: .select(...).eq(...) resolves to {count,error}. */
+const respond = (result: { count?: number | null; error?: unknown }) => {
+  selectMock.mockReturnValue({ eq: () => Promise.resolve(result) });
+};
+
+beforeEach(() => selectMock.mockReset());
+
+describe('semanticCoverage', () => {
+  it('reports none, with a caveat, when the book has no vectors', async () => {
+    respond({ count: 0 });
+    const c = await semanticCoverage('book1', 520);
+    expect(c.status).toBe('none');
+    expect(c.embedded_pages).toBe(0);
+    expect(c.caveat).toBeDefined();
+  });
+
+  it('tells the caller NOT to report the passage as missing', async () => {
+    // The whole point. An agent reading an empty semantic result on an
+    // unembedded book will otherwise tell the user the text does not contain it.
+    respond({ count: 0 });
+    const c = await semanticCoverage('book1', 520);
+    expect(c.caveat).toMatch(/not evidence/i);
+    expect(c.caveat).toMatch(/do not tell the user/i);
+  });
+
+  it('reports partial when most of the book is unembedded', async () => {
+    // Taylor's 1801 Metaphysics as measured: 10 of 520.
+    respond({ count: 10 });
+    const c = await semanticCoverage('book1', 520);
+    expect(c.status).toBe('partial');
+    expect(c.caveat).toMatch(/inconclusive/i);
+  });
+
+  it('reports full and NO caveat when the book is properly embedded', async () => {
+    respond({ count: 407 });
+    const c = await semanticCoverage('book1', 407);
+    expect(c.status).toBe('full');
+    expect(c.caveat).toBeUndefined();
+  });
+
+  it('treats a small surplus as full, not partial', async () => {
+    // Untranslated originals get an OCR-derived vector, so the vector count can
+    // legitimately exceed Mongo's translated-page count (Congreve: 570 vs 565).
+    respond({ count: 570 });
+    expect((await semanticCoverage('book1', 565)).status).toBe('full');
+  });
+
+  it('degrades to unknown rather than throwing when Supabase errors', async () => {
+    // A coverage lookup must never be able to fail a search that already has
+    // perfectly good keyword results.
+    respond({ error: { message: 'connection reset' } });
+    const c = await semanticCoverage('book1', 100);
+    expect(c.status).toBe('unknown');
+    expect(c.caveat).toBeUndefined();
+  });
+
+  it('degrades to unknown when the request rejects', async () => {
+    // The realistic outage shape: the query rejects rather than returning an
+    // error field. Must still not propagate — see above.
+    selectMock.mockReturnValue({ eq: () => Promise.reject(new Error('ECONNRESET')) });
+    expect((await semanticCoverage('book1', 100)).status).toBe('unknown');
+  });
+
+  it('does not divide by zero on a book with no translated pages', async () => {
+    respond({ count: 3 });
+    const c = await semanticCoverage('book1', 0);
+    expect(c.status).toBe('full');
+    expect(Number.isFinite(c.embedded_pages)).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #3680. Chasing why `search_within_book` returned semantic hits on
Sextus Empiricus but none on Taylor's *Metaphysics* turned up something larger
than any of the search bugs fixed there.

## Measured

150 sampled visible books with >20 translated pages, comparing Supabase
`page_translations` rows against Mongo's translated-page count:

| coverage | books | share |
|---|---|---|
| fully embedded (≥90%) | 79 | 53% |
| partial (25–90%) | 3 | 2% |
| **thin (<25%)** | 33 | **22%** |
| **none (zero rows)** | 35 | **23%** |

**Nearly half the sampled corpus is invisible to semantic search.** Two of the
volumes the reader spent a day searching were among the blind ones — Taylor's
1801 *Metaphysics* at 10 of 520 pages, the 1551 Aldine at 10 of 708. They
concluded the corpus was thin on exactly the passages they wanted. The corpus
was fine; the vectors were missing.

## Root cause

The page-embedding cron on the pipeline box is commented out behind a
`#PAUSED-GEMINI` marker. Its log is empty and dated **June 9** — it has not run
for two months. All three Gemini keys still embed fine against the live
`batchEmbedContents` endpoint, so nothing is broken; the worker is simply off.

**Unpausing it corpus-wide is a deliberate decision and is not taken in this
PR.** `scripts/workers/embed-gemini.mjs --books-file` is the mode built for this
shape (books with zero rows can't be reached by `--missing-only`, which only
scans books already present). Cost is $0 — free tier, ~13 texts/sec.

## The code change

An empty semantic result and an unembedded book produce the same response, and
the caller cannot tell them apart. The reader's own framing:

> I can't tell a user a quote is absent from Aristotle, because I can't know
> what fraction of Aristotle exists here in a searchable language. Every
> negative had to be hedged.

`search_within_book` now reports `semantic_coverage` when the semantic leg came
back empty, carrying a caveat that says in as many words: *the absence of a hit
here is not evidence the passage is missing; do not tell the user the text does
not contain it.*

Two deliberate choices:

- **Not an error.** The keyword results on an unembedded book are good and are
  usually what the caller wanted. Failing the whole request because one leg is
  blind turns a partial answer into no answer.
- **Lazy.** The coverage query runs *only* when the semantic leg returned
  nothing — the one case where it matters — so a search that is already working
  pays no extra round-trip.

Also passes `score` and `found_by` through the MCP layer; #3680 added them to
the REST response but did not surface them to tool callers.

## Backfilled

The two blind Aristotle volumes, free tier, 73 seconds, additive:

| book | before | after |
|---|---|---|
| Taylor 1801 *Metaphysics* | 10 / 520 (2%) | 470 / 520 (**90%**) |
| Aldine 1551 | 10 / 708 (1%) | 718 / 708 (**101%**) |

Semantic search can now see both.

## Still open

The other ~45% of the corpus. That needs a decision on the paused cron, not a
code change — see the root-cause section. Filed separately rather than bundled
here.

Signed-off-by: JDerekLomas <j.d.lomas@tudelft.nl>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
