### PR TITLE
feat(ref-set): ESTC in the reference set — loaded, reachable, and citable (#3522)

### DIFF
--- a/scripts/enrichment/ingest-estc.mjs
+++ b/scripts/enrichment/ingest-estc.mjs
@@ -60,12 +60,16 @@
  */
 import fs from 'fs';
 import path from 'path';
+import readline from 'readline';
 import { fileURLToPath } from 'url';
+import { withMongo } from '../lib/mongo.mjs';
 
 const argOf = (f) => { const i = process.argv.indexOf(f); return i === -1 ? null : process.argv[i + 1]; };
 const OUT_DIR = argOf('--out') ?? path.join(process.cwd(), 'scripts', 'output', 'estc');
 const ONLY_PREFIX = argOf('--prefix');
 const DELAY_MS = parseInt(argOf('--delay') ?? '400', 10);
+const LOAD = process.argv.includes('--load');
+const LOAD_ONLY = process.argv.includes('--load-only');
 
 const ENDPOINT = 'https://datb.cerl.org/estc/_search';
 const UA = 'SourceLibrary/1.0 (+https://sourcelibrary.org; reference-set ingest)';
@@ -270,7 +274,11 @@ export function toReferenceRow(row) {
   const authors = names.filter((n) => !/translator|printer|bookseller|publisher|engraver/i.test(n));
 
   return {
-    lccn: '',                                   // ESTC has none; the id is the identifier
+    // NO `lccn` KEY AT ALL — not `''`. `reference_translations` carries a
+    // UNIQUE SPARSE index on `lccn`, and sparse skips only missing/null: an
+    // empty string is a value, so 22,538 rows sharing `''` would collide on the
+    // second upsert. The identifier here is `estc_id` (the ESTC S/R/T/N-number),
+    // which is a citable access point in its own right.
     estc_id: row.id,
     author: authors[0] ?? '',
     added_entries: [...authors.slice(1), ...translators],
@@ -299,7 +307,18 @@ const isEnglishTranslation = (r) => Boolean(r.translation_evidence) && /eng/i.te
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 const IS_MAIN = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
-if (IS_MAIN) await main();
+if (IS_MAIN) {
+  if (LOAD_ONLY) {
+    // Load an artifact that already exists, without the ~15-minute partition
+    // pass. The harvest is idempotent, but re-walking 427 prefixes to reach a
+    // file sitting on disk is pure latency.
+    const existing = fs.readdirSync(OUT_DIR).filter((f) => /^estc-translations\..*\.jsonl$/.test(f)).sort();
+    if (!existing.length) throw new Error(`no estc-translations.*.jsonl in ${OUT_DIR} — run the harvest first`);
+    await loadIntoMongo(path.join(OUT_DIR, existing[existing.length - 1]));
+  } else {
+    await main();
+  }
+}
 
 async function main() {
   fs.mkdirSync(OUT_DIR, { recursive: true });
@@ -450,4 +469,68 @@ async function main() {
   console.log(`\n  BOUNDARY: ESTC covers imprints 1473-1800 only. A translation`);
   console.log(`  published after 1800 is absent by construction, not by evidence.`);
   console.log(`\nWrote ${outPath}`);
+
+  if (LOAD) await loadIntoMongo(outPath);
+}
+
+/**
+ * Upsert the harvested rows into Mongo `reference_translations`.
+ *
+ * KEYED ON `estc_id`, NOT `lccn`. The LoC loader's key is the LCCN and its
+ * fallback is `nolccn:${title}:${year}` — which for ESTC would collide any two
+ * records sharing a title and year, of which a short-title catalogue of the hand
+ * press era has many. `estc_id` is present on 100% of rows and unique by
+ * construction (the id-prefix partition's arithmetic depends on it).
+ *
+ * `noTimeout` is REQUIRED, not tuning: `withMongo` kills the process after 300s,
+ * and a watchdog firing mid-load exits 0 having written a PREFIX of the set. A
+ * short reference set does not error — it fails to find priors, which reads as
+ * `none_found`, which reads as "first translation". That exact failure left
+ * 120,976 of 126,558 LoC rows loaded on 2026-08-04 while the log looked clean.
+ */
+async function loadIntoMongo(outPath) {
+  if (!fs.existsSync(outPath)) {
+    throw new Error(`nothing to load: ${outPath} does not exist — run the harvest first`);
+  }
+  const expected = fs.readFileSync(outPath, 'utf8').split('\n').filter(Boolean).length;
+  console.log(`\nLoading ${expected.toLocaleString()} rows into Mongo \`reference_translations\`…`);
+
+  await withMongo(async (db) => {
+    const coll = db.collection('reference_translations');
+    await coll.createIndex({ estc_id: 1 }, { unique: true, sparse: true });
+
+    const before = await coll.countDocuments({ source: 'estc' });
+    let batch = [];
+    let loaded = 0;
+    const flush = async () => {
+      if (!batch.length) return;
+      await coll.bulkWrite(batch, { ordered: false });
+      loaded += batch.length;
+      batch = [];
+    };
+    const rl = readline.createInterface({ input: fs.createReadStream(outPath), crlfDelay: Infinity });
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      const row = JSON.parse(line);
+      if (!row.estc_id) throw new Error(`row without estc_id — refusing to load an unidentifiable record: ${line.slice(0, 120)}`);
+      // Belt and braces against the sparse-unique `lccn` index: an older
+      // artifact may still carry `lccn: ''`, which would collide across every
+      // ESTC row. Absent means absent.
+      if (!row.lccn) delete row.lccn;
+      batch.push({ updateOne: { filter: { estc_id: row.estc_id }, update: { $set: row }, upsert: true } });
+      if (batch.length >= 1000) await flush();
+    }
+    await flush();
+
+    // Reconcile against the DESTINATION, not the log — the same rule the
+    // concatenator now follows. A partial load is invisible from its own output.
+    const after = await coll.countDocuments({ source: 'estc' });
+    console.log(`  upserted ${loaded.toLocaleString()} · source:'estc' rows ${before.toLocaleString()} → ${after.toLocaleString()}`);
+    if (after !== expected) {
+      throw new Error(
+        `load does not reconcile: ${after} rows with source:'estc' in Mongo vs ${expected} in the artifact`,
+      );
+    }
+    console.log(`  ✓ reconciled: ${after.toLocaleString()} rows`);
+  }, { noTimeout: true });
 }

--- a/scripts/eval/ft-reference-set-recall.mjs
+++ b/scripts/eval/ft-reference-set-recall.mjs
@@ -81,7 +81,23 @@ function latestRun(cohort) {
   return path.join(OUT_DIR, files[files.length - 1]);
 }
 
-const CATALOGUE_SOURCES = new Set(['loc_mdsconnect', 'wikidata']);
+/**
+ * What counts as a CATALOGUE for the governing recall figure.
+ *
+ * The distinction is provenance, not usefulness: a catalogue is an external
+ * bibliographic authority we did not write. `translation_classification` is
+ * deliberately absent because it is our own model's output over our own books —
+ * including it makes the yardstick a subset of the thing it measures and returns
+ * exactly 100.0%, which is circular rather than good.
+ *
+ * ⚠️ ADDING A SOURCE TO THE SEARCH MEANS ADDING IT HERE. ESTC (#3522) is a
+ * national short-title catalogue and belongs in this set; leaving it out would
+ * have computed "catalogue-only recall" over a definition that excluded the
+ * catalogue just added, so 22,538 new rows would have moved the number by
+ * exactly zero and read as "ESTC contributed nothing". Same family as the
+ * yardstick-inside-the-set trap above, inverted.
+ */
+const CATALOGUE_SOURCES = new Set(['loc_mdsconnect', 'wikidata', 'estc']);
 
 const runs = ['inverse', 'badged'].map((c) => ({ cohort: c, file: latestRun(c) }));
 for (const r of runs) console.log(`  ${r.cohort.padEnd(8)} ${path.basename(r.file)}`);

--- a/scripts/eval/ft-reference-set-search.mjs
+++ b/scripts/eval/ft-reference-set-search.mjs
@@ -52,6 +52,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.join(__dirname, '..', 'output');
 const BULK_DIR = path.join(OUT_DIR, 'loc-bulk');
 const WIKIDATA_DIR = path.join(OUT_DIR, 'wikidata');
+const ESTC_DIR = path.join(OUT_DIR, 'estc');
 const DATE = new Date().toISOString().slice(0, 10);
 const WIKIDATA_SNAPSHOT = DATE;
 
@@ -285,6 +286,15 @@ const files = loadReferenceSet();
 const wikidataFiles = fs.existsSync(WIKIDATA_DIR)
   ? fs.readdirSync(WIKIDATA_DIR).filter((f) => f.endsWith('.jsonl')).map((f) => path.join(WIKIDATA_DIR, f))
   : [];
+// Third source (#3522). ESTC is not "more records" — it is the catalogue that
+// records what LoC omits for 1473-1800, which is where this corpus lives and
+// where LoC is structurally thin (~96% of its English records declare no
+// translation marker at all). Its `search_titles` carries the MARC 240 uniform
+// title with `$l English` as a matter of course, which is the exact key
+// work-identity-match.mjs is built and gold-tested against.
+const estcFiles = fs.existsSync(ESTC_DIR)
+  ? fs.readdirSync(ESTC_DIR).filter((f) => /^estc-translations\..*\.jsonl$/.test(f)).map((f) => path.join(ESTC_DIR, f))
+  : [];
 const bySurname = new Map();
 // Title-token index. An anonymous work has no author access point, but its TITLE
 // is one — and 771 of the 991 books previously reported "not searchable" had a
@@ -295,14 +305,17 @@ const byCjkGram = new Map();
 let rowCount = 0;
 
 let wikidataRows = 0;
-for (const file of [...files, ...wikidataFiles]) {
+let estcRows = 0;
+for (const file of [...files, ...wikidataFiles, ...estcFiles]) {
   const isWikidata = wikidataFiles.includes(file);
+  const isEstc = estcFiles.includes(file);
   const rl = readline.createInterface({ input: fs.createReadStream(file), crlfDelay: Infinity });
   for await (const line of rl) {
     if (!line.trim()) continue;
     const row = JSON.parse(line);
     rowCount++;
     if (isWikidata) wikidataRows++;
+    if (isEstc) estcRows++;
     for (const name of [row.author, ...(row.added_entries || [])].filter(Boolean)) {
       const sn = surname(name);
       if (!sn || sn.length < 3) continue;
@@ -349,8 +362,35 @@ function titlePool(bookToks) {
 }
 
 const REFERENCE_SET = {
-  version: `loc-2016.p${files.length}.v1`,
+  // The version names the GENERATION, and adding a source mints a new one — an
+  // effort recorded against `loc-2016.p43.v1` was answered by a set that could
+  // not see 1473-1800, and must not be read as though it could. `search_efforts`
+  // is immutable so a stale negative re-opens; `screening_decisions` is keyed on
+  // (work, prior) and is re-applied across generations, so human judgement
+  // survives the bump while machine negatives do not.
+  version: `loc-2016.p${files.length}.v1`,   // overwritten below — see the note there
   sources: [
+  ...(estcFiles.length ? [{
+    id: 'estc',
+    name: 'English Short Title Catalogue (via CERL)',
+    endpoint: 'https://datb.cerl.org/estc/_search',
+    snapshot_date: '2026-08-07',
+    record_count: 0, // set below, once counted
+    coverage: 'English translations among English imprints 1473-1800, declared by a '
+      + 'MARC 240 uniform title with `$l English` or by a translator relator term. '
+      + '22,538 of 487,427 records examined (4.6%)',
+    known_gaps: [
+      'BOUNDARY: covers imprints 1473-1800 ONLY. A translation published after 1800 '
+        + 'is absent BY CONSTRUCTION, not by evidence — and 80.8% of this corpus\'s '
+        + 'known Latin/Greek priors are post-1950 imprints. ESTC complements LoC at '
+        + 'the early-modern end; it does not replace it.',
+      'English imprints only — a prior English translation printed at Amsterdam, '
+        + 'Leiden or Paris (common for exile and Catholic presses) is out of scope',
+      'no LCCN and no Q-number; the citable identifier is the ESTC S/R/T/N-number',
+      'ESTC records the IMPRINT, so a translation reprinted without a new edition '
+        + 'statement may appear once rather than per issue',
+    ],
+  }] : []),
   ...(wikidataFiles.length ? [{
     id: 'wikidata',
     name: 'Wikidata — English editions of non-English works (P629)',
@@ -418,10 +458,20 @@ const REFERENCE_SET = {
 };
 const WD = REFERENCE_SET.sources.find((s) => s.id === 'wikidata');
 if (WD) WD.record_count = wikidataRows;
-REFERENCE_SET.version = `loc-2016.p${files.length}${wikidataFiles.length ? `+wd-${WIKIDATA_SNAPSHOT}` : ''}.v2`;
+const ES = REFERENCE_SET.sources.find((s) => s.id === 'estc');
+if (ES) ES.record_count = estcRows;
+// This assignment is the one that counts — it overwrites the literal above, so
+// a source added to `sources` without being named HERE is silently invisible in
+// the version string, and every effort it answers would be filed under a
+// generation that never saw it.
+REFERENCE_SET.version = `loc-2016.p${files.length}`
+  + `${wikidataFiles.length ? `+wd-${WIKIDATA_SNAPSHOT}` : ''}`
+  + `${estcFiles.length ? '+estc-2026-08-07' : ''}`
+  + `.v${estcFiles.length ? '3' : '2'}`;
 
 console.log(`Reference set ${REFERENCE_SET.version}: ${rowCount.toLocaleString()} English translations, `
-  + `${bySurname.size.toLocaleString()} distinct surnames (${files.length}/43 parts)\n`);
+  + `${bySurname.size.toLocaleString()} distinct surnames (${files.length}/43 parts`
+  + `${estcRows ? `, ${estcRows.toLocaleString()} ESTC` : ''})\n`);
 
 await withMongo(async (db) => {
   // Re-apply durable screening judgements. Without this, every new snapshot or
@@ -595,11 +645,17 @@ await withMongo(async (db) => {
       for (const run of cjkRuns(`${book.title} ${book.work_title || ''}`)) {
         for (let i = 0; i + 3 <= run.length; i++) grams.add(run.slice(i, i + 3));
       }
+      // Dedupe on a key that EVERY source has. This was `r.lccn`, which is
+      // absent on Wikidata and ESTC rows alike — so `seen.add(undefined)` on the
+      // first such row collapsed every subsequent one to a duplicate and dropped
+      // the whole non-LoC pool to a single record. Silent, and in the direction
+      // this subsystem always fails: fewer candidates found, read as no prior.
       const seen = new Set();
       for (const g of grams) {
         for (const r of byCjkGram.get(g) || []) {
-          if (seen.has(r.lccn)) continue;
-          seen.add(r.lccn); pool.push(r);
+          const key = r.lccn || r.estc_id || r.wikidata_edition || `${r.source}:${r.title}:${r.year}`;
+          if (seen.has(key)) continue;
+          seen.add(key); pool.push(r);
         }
       }
       queries.push({
@@ -656,9 +712,17 @@ await withMongo(async (db) => {
           // unrecoverable — the two catalogues were distinguishable only by an
           // empty LCCN, and recall cannot be measured per-source at all.
           source: row.source,
+          // Every source's own citable identifier. ESTC records carry no LCCN
+          // and no Q-number, so without this branch an ESTC candidate would
+          // arrive with `{wikidata_edition: undefined, wikidata_work: undefined}`
+          // — an unciteable prior, which defeats the entire reason for adding
+          // the source. An ESTC S/R/T/N-number resolves at
+          // estc.bl.uk / datb.cerl.org and is a standard bibliographic citation.
           identifiers: row.lccn
             ? { lccn: row.lccn }
-            : { wikidata_edition: row.wikidata_edition, wikidata_work: row.wikidata_work },
+            : row.estc_id
+              ? { estc_id: row.estc_id }
+              : { wikidata_edition: row.wikidata_edition, wikidata_work: row.wikidata_work },
           title: row.title,
           uniform_title: row.uniform_title || undefined,
           year: row.year,


### PR DESCRIPTION
The harvest landed 22,538 ESTC rows (#3688). This makes them **evidence**: loaded into `reference_translations`, read by the search, and carrying an identifier a reader can follow.

Three things had to be fixed before the rows could be used at all. Each would have failed in the direction this subsystem always fails — quietly, toward a clean negative.

### 1. `lccn: ''` collides with the index

`reference_translations` carries a **unique sparse** index on `lccn`, and sparse skips missing/null but **not the empty string**. 22,538 rows sharing `''` would have collided on the second upsert. ESTC rows now omit the key entirely; `estc_id` is the identifier, present on 100% and unique by construction.

### 2. The loader's key would have collapsed records

The LoC loader upserts on `lccn` with a `nolccn:${title}:${year}` fallback — which for a short-title catalogue of the hand-press era collides any two records sharing a title and year. The new `--load` keys on `estc_id`, creates its own unique sparse index, runs with `noTimeout` (the 300s watchdog left 120,976 of 126,558 LoC rows loaded on 2026-08-04 and exited 0), and **reconciles the destination against the artifact** before returning. `--load-only` skips the 15-minute partition pass.

Run against production:

```
Loading 22,538 rows into Mongo `reference_translations`…
  upserted 22,538 · source:'estc' rows 0 → 22,538
  ✓ reconciled: 22,538 rows
```

### 3. An ESTC candidate would have been uncitable

The search built `identifiers` as LCCN-or-Wikidata, so an ESTC row produced `{wikidata_edition: undefined, wikidata_work: undefined}`. That defeats the entire reason for the source — "naming a prior is not linking one", and this is the only layer that can link. It now carries `estc_id`, which resolves at estc.bl.uk / datb.cerl.org and is a standard citation.

### Plus a latent bug the new source would have triggered

The CJK candidate pool deduped on `r.lccn`. Wikidata rows have no LCCN either, so `seen.add(undefined)` on the first non-LoC row collapsed every later one to a duplicate and **dropped the whole non-LoC pool to a single record**. Silent, and in the usual direction: fewer candidates, read as no prior. Now keyed on whatever identifier the row actually has.

### The generation, and a trap in how it is set

Adding a source mints a new generation: `loc-2016.p43+wd-2026-08-07+estc-2026-08-07.v3`. An effort recorded against `loc-2016.p43.v1` was answered by a set that could not see 1473–1800 and must not be read as though it could.

⚠️ The version is **assigned below the object literal**, overwriting it — so a source added to `sources` without also being named at the assignment is invisible in the version string. My first attempt did exactly that. Commented at both sites now.

Screening decisions survive the bump (82 carried forward on the smoke run); machine negatives correctly do not.

### The source declares its own boundary

Imprints **1473–1800 only**. A translation published after 1800 is absent *by construction, not by evidence* — and 80.8% of this corpus's known Latin/Greek priors are post-1950 imprints. English imprints only, so an exile-press translation printed at Amsterdam or Leiden is out of scope. ESTC complements LoC at the early-modern end; it does not replace it. All declared as `known_gaps`.

## Verified: the rows are reachable, not just loaded

40 Latin books, dry run. ESTC supplied **10 of 38 candidates**:

| id | year | uniform title | screen |
|---|---|---|---|
| `S106508` | **1478** | De consolatione philosophiae | prior_translation |
| `R7385` | 1674 | De consolatione philosophiae, Books 1–4 | prior_translation |
| `R3694` | 1695 | De consolatione philosophiae | prior_translation |

Boethius is one of the books I flagged in #3687 as a prima-facie-correct demote. ESTC now supplies citable priors for it independently.

## Second commit: the recall definition excluded the catalogue we just added

`CATALOGUE_SOURCES` gates the governing 27% figure and listed only `loc_mdsconnect` and `wikidata`. Re-measuring after loading ESTC would have computed a catalogue-only number over a definition that **excluded ESTC** — moving it by exactly zero and reading as "the new source contributed nothing."

Same family as the documented circularity trap (`translation_classification` as both source and test set returns exactly 100.0%), inverted: one inflates by including our own answers, this one deflates by excluding a real source. `translation_classification` correctly stays out.

## Out of scope

- **Re-measuring recall.** Needs full `badged` and `inverse` cohort runs — hours over ~10K books. Queued next; the number to watch is catalogue-only, never the circular variant.
- **No `--apply`.** Nothing written to `search_efforts` yet.
- **Screening the `inconclusive` queue.** ESTC will move some of the ~2,415, but screening is its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
