### PR TITLE
fix(chapters): endPage was computed flatly, so every book-level span ran backwards

### DIFF
--- a/scripts/backfill-chapter-texts.mjs
+++ b/scripts/backfill-chapter-texts.mjs
@@ -8,6 +8,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { computeEndPages, chunkEndPage } from './lib/chapter-endpages.mjs';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) {
@@ -20,17 +21,6 @@ const limitArg = args.includes('--limit') ? parseInt(args[args.indexOf('--limit'
 const bookIdArg = args.includes('--book-id') ? args[args.indexOf('--book-id') + 1] : null;
 
 const client = new MongoClient(MONGODB_URI);
-
-function computeEndPages(chapters, totalPages) {
-  for (let i = 0; i < chapters.length; i++) {
-    if (i < chapters.length - 1) {
-      chapters[i].endPage = chapters[i + 1].pageNumber - 1;
-    } else {
-      chapters[i].endPage = totalPages;
-    }
-  }
-  return chapters;
-}
 
 async function materializeBook(db, book) {
   const chapters = computeEndPages(book.chapters, book.pages_count || 0);
@@ -58,7 +48,9 @@ async function materializeBook(db, book) {
   for (let i = 0; i < chapters.length; i++) {
     const ch = chapters[i];
     const startPage = ch.pageNumber;
-    const endPage = ch.endPage || book.pages_count || 0;
+    // NOT ch.endPage — a container's span covers its children, which must not
+    // be chunked twice. See chunkEndPage.
+    const endPage = chunkEndPage(chapters, i, book.pages_count || 0);
 
     // Collect per-page text first
     const pageTexts = [];

--- a/scripts/lib/chapter-endpages.mjs
+++ b/scripts/lib/chapter-endpages.mjs
@@ -1,0 +1,76 @@
+/**
+ * Where does a chapter END?
+ *
+ * `endPage` is a DERIVED field — nothing in the model output carries it. Each
+ * entry runs until the next entry AT OR ABOVE its own level begins.
+ *
+ * The level check is the whole point. Every copy of this used to look at
+ * `chapters[i + 1]` flatly, which is correct for a single-level list and wrong
+ * for every nested one: a "Book I" heading is immediately followed by its own
+ * "Chapter I", usually on the SAME page, so the book got
+ * `endPage = pageNumber - 1` and every level-1 span came back inverted.
+ *
+ * Measured 2026-08-07: 29,037 such entries across 6,901 books, 6,045 of them
+ * visible — essentially every multi-level book in the corpus. Reported from an
+ * MCP session that found Book I of Taylor's Nicomachean Ethics spanning
+ * pp. 12–11 (#3653 follow-up).
+ *
+ * A child is still bounded by the next sibling OR by the end of its parent,
+ * whichever comes first; that falls out of "next entry at or above my level"
+ * for free.
+ *
+ * TWIN: `src/lib/chapter-text.ts` exports the same function for the request
+ * path. Both must change together — the four independent copies that existed
+ * before are how one flat implementation stayed wrong in four places at once.
+ *
+ * Callers must pass chapters already sorted by pageNumber. Mutates in place
+ * and returns the array.
+ */
+/**
+ * How far does this entry's own MATERIALIZED TEXT run?
+ *
+ * This is deliberately NOT `endPage`. The two answer different questions:
+ *
+ *   endPage      — "where does Book I end?"   → p.57, children included.
+ *                  What a reader, the API, and a range query want.
+ *   chunkEndPage — "which pages are Book I's OWN text?" → p.12–11, i.e. the
+ *                  preamble before Chapter I starts. Usually empty.
+ *
+ * `chapter_texts` is a RETRIEVAL store, so its rows must PARTITION the book.
+ * If a container were chunked over its full span, "Book I" (pp. 12–57) would
+ * be stored on top of its ten chapters — every page twice, and a RAG caller
+ * handed the same passage under two labels.
+ *
+ * Keeping these separate is what lets `endPage` be fixed without touching a
+ * single materialized row: a container's chunk range here is exactly what the
+ * old flat rule produced, so `chapter_texts` output is unchanged.
+ *
+ * Entries are sorted by pageNumber, so a container is exactly an entry whose
+ * immediate successor sits at a deeper level.
+ *
+ * TWIN: `chunkEndPage` in `src/lib/chapter-text.ts`.
+ */
+export function chunkEndPage(chapters, i, totalPages) {
+  const next = chapters[i + 1];
+  if (next && (next.level ?? 1) > (chapters[i].level ?? 1)) {
+    return next.pageNumber - 1; // container: its own preamble only
+  }
+  return chapters[i].endPage ?? totalPages;
+}
+
+export function computeEndPages(chapters, totalPages) {
+  for (let i = 0; i < chapters.length; i++) {
+    const level = chapters[i].level ?? 1;
+    let end = totalPages;
+    for (let j = i + 1; j < chapters.length; j++) {
+      if ((chapters[j].level ?? 1) <= level) {
+        end = chapters[j].pageNumber - 1;
+        break;
+      }
+    }
+    // A heading whose successor starts on the same page would otherwise get an
+    // inverted span. It is at minimum one page long — the page it opens on.
+    chapters[i].endPage = Math.max(end, chapters[i].pageNumber);
+  }
+  return chapters;
+}

--- a/scripts/maintenance/repair-chapter-endpages.mjs
+++ b/scripts/maintenance/repair-chapter-endpages.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Recompute `books.chapters[].endPage` with the level-aware rule.
+ *
+ * WHY THIS IS SAFE TO RE-RUN: endPage is a DERIVED field. Nothing in the model
+ * output carries it — it is computed from `pageNumber` + `level` + the page
+ * count, all of which are already stored. So this sweep makes no AI calls,
+ * costs nothing, and is idempotent. It rewrites ONLY endPage; every other
+ * chapter field (title, titleEn, pageId, pageNumber, level, confidence) is
+ * passed through untouched.
+ *
+ * WHAT WAS WRONG: the old rule looked at `chapters[i + 1]` flatly. A "Book I"
+ * heading is immediately followed by its own "Chapter I", usually on the SAME
+ * page, so the book got `endPage = pageNumber - 1` — an inverted span. Measured
+ * 2026-08-07 before the fix: 29,037 entries across 6,901 books, 6,045 visible.
+ * Reported from an MCP session (#3653 follow-up) that asked for Book I of
+ * Taylor's Nicomachean Ethics and was told it spans pp. 12–11.
+ *
+ *   node scripts/maintenance/repair-chapter-endpages.mjs            # dry run
+ *   node scripts/maintenance/repair-chapter-endpages.mjs --apply
+ *   node scripts/maintenance/repair-chapter-endpages.mjs --book-id <id> --apply
+ *
+ * Writes are batched and paced. This touches `books`, not `entities`, so it
+ * does not collide with the /explore prerender interlock in CLAUDE.md — but it
+ * is still a bulk writer, so it yields between batches.
+ */
+import { MongoClient } from 'mongodb';
+import { computeEndPages } from '../lib/chapter-endpages.mjs';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI is not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const apply = args.includes('--apply');
+const bookId = args.includes('--book-id') ? args[args.indexOf('--book-id') + 1] : null;
+const BATCH = 500;
+
+const client = new MongoClient(MONGODB_URI);
+
+/** Deep-enough copy to compare before/after without aliasing the stored docs. */
+const spans = (chapters) => chapters.map((c) => c.endPage ?? null);
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+
+  const filter = bookId
+    ? { id: bookId }
+    : { chapters: { $exists: true, $ne: [] } };
+
+  const cursor = books.find(filter, {
+    projection: { id: 1, title: 1, visible: 1, chapters: 1, pages_count: 1 },
+  });
+
+  let scanned = 0;
+  let changedBooks = 0;
+  let changedEntries = 0;
+  let invertedBefore = 0;
+  let skippedNoPageCount = 0;
+  let ops = [];
+  const samples = [];
+
+  for await (const book of cursor) {
+    scanned++;
+    const chapters = book.chapters || [];
+    if (!chapters.length) continue;
+
+    // pages_count is the volume's last page. Without it the tail entry has no
+    // defensible end, and guessing one would write a WRONG value over a merely
+    // stale one — so leave those books alone and report the count.
+    const totalPages = book.pages_count || 0;
+    if (!totalPages) {
+      skippedNoPageCount++;
+      continue;
+    }
+
+    const before = spans(chapters);
+    invertedBefore += chapters.filter(
+      (c) => typeof c.endPage === 'number' && typeof c.pageNumber === 'number' && c.endPage < c.pageNumber,
+    ).length;
+
+    // computeEndPages assumes pageNumber order, and a stored array is not
+    // guaranteed to have stayed sorted. Sort a COPY — it holds the same object
+    // references, so computeEndPages mutates the very objects `chapters` still
+    // holds, and the original ORDER survives.
+    //
+    // That order is load-bearing: `chapter_texts.chapter_index` is this array's
+    // positional index. Writing the sorted array back would silently repoint
+    // every materialized chunk of any book whose chapters were not already in
+    // page order — turning a derived-field repair into a data corruption.
+    computeEndPages([...chapters].sort((a, b) => a.pageNumber - b.pageNumber), totalPages);
+    const after = spans(chapters);
+
+    const diff = after.filter((v, i) => v !== before[i]).length;
+    if (!diff) continue;
+
+    changedBooks++;
+    changedEntries += diff;
+    if (samples.length < 10) {
+      const at = after.findIndex((v, i) => v !== before[i]);
+      const first = chapters[at];
+      samples.push(
+        `${book.id} ${(book.title || '').slice(0, 48)} — ${diff}/${chapters.length} entries; e.g. "${first.title}" p.${first.pageNumber}: ${before[at]} → ${first.endPage}`,
+      );
+    }
+
+    if (apply) {
+      ops.push({
+        updateOne: { filter: { _id: book._id }, update: { $set: { chapters } } },
+      });
+      if (ops.length >= BATCH) {
+        const res = await books.bulkWrite(ops, { ordered: false });
+        console.log(`  wrote ${res.modifiedCount} books (scanned ${scanned})`);
+        ops = [];
+        await new Promise((r) => setTimeout(r, 250));
+      }
+    }
+  }
+
+  if (apply && ops.length) {
+    const res = await books.bulkWrite(ops, { ordered: false });
+    console.log(`  wrote ${res.modifiedCount} books (final batch)`);
+  }
+
+  console.log('\n' + (apply ? 'APPLIED' : 'DRY RUN — nothing written'));
+  console.log(`  books scanned:            ${scanned}`);
+  console.log(`  books needing change:     ${changedBooks}`);
+  console.log(`  chapter entries changed:  ${changedEntries}`);
+  console.log(`  inverted spans (before):  ${invertedBefore}`);
+  console.log(`  skipped (no pages_count): ${skippedNoPageCount}`);
+  if (samples.length) {
+    console.log('\n  samples:');
+    for (const s of samples) console.log('   ' + s);
+  }
+  if (!apply) console.log('\n  Re-run with --apply to write.');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => client.close());

--- a/scripts/reextract-broken-chapters.mjs
+++ b/scripts/reextract-broken-chapters.mjs
@@ -24,6 +24,7 @@ const client = new MongoClient(MONGODB_URI);
 
 // Inline the v2 extraction logic since we can't import TS from mjs
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import { computeEndPages, chunkEndPage } from './lib/chapter-endpages.mjs';
 const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
 
 function extractHeadingsV2(text, pageNumber) {
@@ -82,13 +83,6 @@ function buildPrompt(book, headings, tocPages, sectionHints, pageCount) {
 
 const MAX_CHUNK_CHARS = 400000;
 
-function computeEndPages(chapters, totalPages) {
-  for (let i = 0; i < chapters.length; i++) {
-    chapters[i].endPage = i < chapters.length - 1 ? chapters[i + 1].pageNumber - 1 : totalPages;
-  }
-  return chapters;
-}
-
 async function materializeBook(db, bookId, chapters, totalPages) {
   computeEndPages(chapters, totalPages);
   const pages = await db.collection('pages')
@@ -101,7 +95,9 @@ async function materializeBook(db, bookId, chapters, totalPages) {
   for (let i = 0; i < chapters.length; i++) {
     const ch = chapters[i];
     const startPage = ch.pageNumber;
-    const endPage = ch.endPage || totalPages;
+    // NOT ch.endPage — a container's span covers its children, which must not
+    // be chunked twice. See chunkEndPage.
+    const endPage = chunkEndPage(chapters, i, totalPages);
     const pageTexts = [];
     for (let pn = startPage; pn <= endPage; pn++) {
       const page = pageMap.get(pn);

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -44,6 +44,7 @@ import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selectiv
 import { buildPageTexts, attributeEntityPages, entityCounters } from '../lib/entity-page-match.mjs';
 import { composeBookEmbeddingText } from '../lib/book-embedding-text.mjs';
 import { embedBookPages } from '../lib/embed-book-pages.mjs';
+import { computeEndPages } from '../lib/chapter-endpages.mjs';
 import pg from 'pg';
 
 // Selective-unpause scope confinement, set in main() after the pause check.
@@ -1306,17 +1307,6 @@ Respond with ONLY a JSON array, no markdown fences, no explanation:
 Empty array [] if no discernible structure.`;
 
   return prompt;
-}
-
-function computeEndPages(chapters, totalPages) {
-  for (let i = 0; i < chapters.length; i++) {
-    if (i < chapters.length - 1) {
-      chapters[i].endPage = chapters[i + 1].pageNumber - 1;
-    } else {
-      chapters[i].endPage = totalPages;
-    }
-  }
-  return chapters;
 }
 
 async function extractChaptersForBook(db, bookId) {

--- a/src/lib/chapter-text.ts
+++ b/src/lib/chapter-text.ts
@@ -33,18 +33,72 @@ export interface ChapterText {
 }
 
 /**
- * Compute endPage for each chapter based on the next chapter's start page.
- * Mutates the chapters array in place and returns it.
+ * Compute endPage for each chapter: it runs until the next entry AT OR ABOVE
+ * its own level begins.
+ *
+ * The level check is the whole point. This used to look at `chapters[i + 1]`
+ * flatly, which is correct for a single-level list and wrong for every nested
+ * one — a "Book I" heading is immediately followed by its own "Chapter I",
+ * usually on the SAME page, so the book got `endPage = pageNumber - 1` and
+ * every level-1 span came back inverted. Measured 2026-08-07: 29,037 such
+ * entries across 6,901 books (6,045 of them visible), i.e. essentially every
+ * multi-level book in the corpus. Reported from an MCP session that found
+ * Book I of Taylor's Nicomachean Ethics spanning pp. 12–11 (#3653 follow-up).
+ *
+ * A child is still bounded by the next sibling OR by the end of its parent,
+ * whichever comes first, which falls out of "next entry at or above my level"
+ * for free.
+ *
+ * Mutates the chapters array in place and returns it. Callers must pass
+ * chapters already sorted by pageNumber.
  */
 export function computeEndPages(chapters: Chapter[], totalPages: number): Chapter[] {
   for (let i = 0; i < chapters.length; i++) {
-    if (i < chapters.length - 1) {
-      chapters[i].endPage = chapters[i + 1].pageNumber - 1;
-    } else {
-      chapters[i].endPage = totalPages;
+    const level = chapters[i].level ?? 1;
+    let end = totalPages;
+    for (let j = i + 1; j < chapters.length; j++) {
+      if ((chapters[j].level ?? 1) <= level) {
+        end = chapters[j].pageNumber - 1;
+        break;
+      }
     }
+    // A heading whose successor starts on the same page would otherwise get an
+    // inverted span. It is at minimum one page long — the page it opens on.
+    chapters[i].endPage = Math.max(end, chapters[i].pageNumber);
   }
   return chapters;
+}
+
+/**
+ * How far does this entry's own MATERIALIZED TEXT run?
+ *
+ * This is deliberately NOT `endPage`. The two answer different questions:
+ *
+ *   endPage      — "where does Book I end?"   → p.57, children included.
+ *                  What a reader, the API, and a range query want.
+ *   chunkEndPage — "which pages are Book I's OWN text?" → p.12–11, i.e. the
+ *                  preamble before Chapter I starts. Usually empty.
+ *
+ * `chapter_texts` is a RETRIEVAL store, so its rows must PARTITION the book.
+ * If a container were chunked over its full span, "Book I" (pp. 12–57) would
+ * be stored on top of its ten chapters — every page twice, and a RAG caller
+ * handed the same passage under two labels.
+ *
+ * Keeping these separate is what lets `endPage` be fixed without touching a
+ * single materialized row: a container's chunk range here is exactly what the
+ * old flat rule produced, so `chapter_texts` output is unchanged.
+ *
+ * Entries are sorted by pageNumber, so a container is exactly an entry whose
+ * immediate successor sits at a deeper level.
+ *
+ * TWIN: `chunkEndPage` in `scripts/lib/chapter-endpages.mjs`.
+ */
+export function chunkEndPage(chapters: Chapter[], i: number, totalPages: number): number {
+  const next = chapters[i + 1];
+  if (next && (next.level ?? 1) > (chapters[i].level ?? 1)) {
+    return next.pageNumber - 1; // container: its own preamble only
+  }
+  return chapters[i].endPage ?? totalPages;
 }
 
 /**
@@ -95,7 +149,9 @@ export async function materializeChapterTexts(
   for (let i = 0; i < chapters.length; i++) {
     const ch = chapters[i];
     const startPage = ch.pageNumber;
-    const endPage = ch.endPage || totalPages;
+    // NOT ch.endPage — a container's span covers its children, which must not
+    // be chunked twice. See chunkEndPage.
+    const endPage = chunkEndPage(chapters, i, totalPages);
 
     // Collect per-page text first, then chunk
     const pageTexts: Array<{ pn: number; trans: string; ocr: string }> = [];

--- a/tests/unit/chapter-endpages-levels.test.ts
+++ b/tests/unit/chapter-endpages-levels.test.ts
@@ -1,0 +1,181 @@
+/**
+ * `endPage` is derived, and it was derived flatly.
+ *
+ * The regression these pin is the one an MCP client hit on Taylor's Nicomachean
+ * Ethics: "Book I" at p.12 came back with endPage 11, because the very next
+ * entry in the flat list was its own "Chapter I" — also on p.12. Every level-1
+ * span in every nested book was inverted the same way (29,037 entries across
+ * 6,901 books, measured 2026-08-07).
+ *
+ * A flat implementation passes any single-level fixture, which is why this was
+ * invisible for so long. So the fixtures here are deliberately NESTED, and the
+ * first assertion is the same-page parent/child case that produced the bug.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeEndPages, chunkEndPage } from '@/lib/chapter-text';
+import type { Chapter } from '@/lib/types';
+
+/** The rule that shipped before the level fix, kept here as the oracle below. */
+function flatEndPages(chapters: Chapter[], totalPages: number): number[] {
+  return chapters.map((c, i) =>
+    i < chapters.length - 1 ? chapters[i + 1].pageNumber - 1 : totalPages,
+  );
+}
+
+const ch = (title: string, pageNumber: number, level: number): Chapter =>
+  ({ title, pageNumber, level }) as Chapter;
+
+describe('computeEndPages — levels', () => {
+  it('a book heading spans its chapters, not the page before itself', () => {
+    // The real shape from 6956953e8c9559f6c2db0b6d: Book I and its Chapter I
+    // both open on p.12, and Book II opens on p.58.
+    const chapters = [
+      ch('Book I', 12, 1),
+      ch('Chapter I', 12, 2),
+      ch('Chapter II', 13, 2),
+      ch('Book II', 58, 1),
+      ch('Chapter I', 58, 2),
+    ];
+    computeEndPages(chapters, 407);
+
+    expect(chapters[0].endPage).toBe(57); // Book I: 12–57, NOT 12–11
+    expect(chapters[1].endPage).toBe(12); // Chapter I bounded by its sibling
+    expect(chapters[2].endPage).toBe(57); // last child bounded by its parent's end
+    expect(chapters[3].endPage).toBe(407); // Book II runs to the end of the volume
+    expect(chapters[4].endPage).toBe(407);
+  });
+
+  it('never returns an inverted span', () => {
+    const chapters = [
+      ch('Part One', 5, 1),
+      ch('Section A', 5, 2),
+      ch('Subsection i', 5, 3),
+      ch('Part Two', 6, 1),
+    ];
+    computeEndPages(chapters, 10);
+    for (const c of chapters) {
+      expect(c.endPage).toBeGreaterThanOrEqual(c.pageNumber);
+    }
+    expect(chapters[3].endPage).toBe(10);
+  });
+
+  it('a deeper entry is bounded by its parent, not by the next entry of any level', () => {
+    // Chapter III's next SIBLING is in the following book, so a "next sibling
+    // only" rule would run it past the parent boundary. It must stop at 83.
+    const chapters = [
+      ch('Book II', 58, 1),
+      ch('Chapter III', 63, 2),
+      ch('Book III', 84, 1),
+      ch('Chapter I', 84, 2),
+    ];
+    computeEndPages(chapters, 200);
+    expect(chapters[1].endPage).toBe(83);
+  });
+
+  it('still behaves flatly for a single-level list', () => {
+    const chapters = [ch('I', 1, 1), ch('II', 10, 1), ch('III', 20, 1)];
+    computeEndPages(chapters, 30);
+    expect(chapters.map((c) => c.endPage)).toEqual([9, 19, 30]);
+  });
+
+  it('treats a missing level as level 1', () => {
+    const chapters = [
+      { title: 'A', pageNumber: 1 } as Chapter,
+      { title: 'B', pageNumber: 5 } as Chapter,
+    ];
+    computeEndPages(chapters, 9);
+    expect(chapters.map((c) => c.endPage)).toEqual([4, 9]);
+  });
+});
+
+/**
+ * The repair rewrites `books.chapters[].endPage`. It must NOT silently change
+ * what `chapter_texts` holds — 15,796 books' worth of materialized retrieval
+ * chunks that nothing in this change re-runs.
+ *
+ * `chunkEndPage` is what guarantees that: for every entry it must return
+ * exactly what the old flat rule returned, so the materializers see an
+ * identical page range before and after. If this test ever fails, the repair
+ * needs a re-materialization pass shipped alongside it.
+ */
+describe('chunkEndPage — chapter_texts ranges are unchanged by the fix', () => {
+  const cases: Array<[string, Chapter[], number]> = [
+    [
+      'nested, parent and first child share a page',
+      [
+        ch('Book I', 12, 1),
+        ch('Chapter I', 12, 2),
+        ch('Chapter II', 13, 2),
+        ch('Book II', 58, 1),
+        ch('Chapter I', 58, 2),
+      ],
+      407,
+    ],
+    [
+      'nested, parent has a preamble before its first child',
+      [ch('Book II', 58, 1), ch('Chapter I', 61, 2), ch('Book III', 84, 1)],
+      200,
+    ],
+    ['flat', [ch('I', 1, 1), ch('II', 10, 1), ch('III', 20, 1)], 30],
+    [
+      'three levels deep',
+      [ch('Part', 5, 1), ch('Section', 5, 2), ch('Sub', 7, 3), ch('Part Two', 9, 1)],
+      12,
+    ],
+  ];
+
+  for (const [name, chapters, totalPages] of cases) {
+    it(name, () => {
+      const expected = flatEndPages(chapters, totalPages);
+      computeEndPages(chapters, totalPages); // sets the NEW, level-aware endPage
+      const actual = chapters.map((_, i) => chunkEndPage(chapters, i, totalPages));
+      expect(actual).toEqual(expected);
+    });
+  }
+});
+
+/**
+ * The request path (`src/lib/chapter-text.ts`) and the worker path
+ * (`scripts/lib/chapter-endpages.mjs`) must agree. Four independent copies of
+ * this function is how one flat implementation stayed wrong in four places at
+ * once; two twins are the repo convention (cf. r2-key, ngram-normalize), and
+ * this is what keeps them honest.
+ */
+describe('computeEndPages — .ts/.mjs twin parity', () => {
+  it('both implementations return identical spans', async () => {
+    const { computeEndPages: mjs } = await import(
+      '../../scripts/lib/chapter-endpages.mjs'
+    );
+
+    const fixture = () => [
+      ch('Book I', 12, 1),
+      ch('Chapter I', 12, 2),
+      ch('Chapter II', 13, 2),
+      ch('Book II', 58, 1),
+      ch('Chapter I', 58, 2),
+      ch('Chapter II', 61, 2),
+    ];
+
+    const a = computeEndPages(fixture(), 407).map((c) => c.endPage);
+    const b = (mjs(fixture(), 407) as Chapter[]).map((c) => c.endPage);
+    expect(b).toEqual(a);
+  });
+
+  it('both implementations return identical chunk ranges', async () => {
+    const { computeEndPages: mjsEnd, chunkEndPage: mjsChunk } = await import(
+      '../../scripts/lib/chapter-endpages.mjs'
+    );
+    const fixture = () => [
+      ch('Book I', 12, 1),
+      ch('Chapter I', 12, 2),
+      ch('Book II', 58, 1),
+      ch('Chapter I', 61, 2),
+    ];
+
+    const ts = computeEndPages(fixture(), 407);
+    const mj = mjsEnd(fixture(), 407) as Chapter[];
+    expect(
+      mj.map((_, i) => mjsChunk(mj, i, 407)),
+    ).toEqual(ts.map((_, i) => chunkEndPage(ts, i, 407)));
+  });
+});


### PR DESCRIPTION
## What

`get_book` reports Book I of Taylor's Nicomachean Ethics as **pp. 12–11**, Book II as 58–57, and so on for every level-1 entry. Reported from an MCP quote-verification session (#3653 follow-up), which also verified the level-2 spans are correct — correctly isolating the defect to parent spans.

`endPage` is derived as `chapters[i + 1].pageNumber - 1`, with no regard for `level`. Right for a flat list, wrong for every nested one: a "Book I" heading is immediately followed by its own "Chapter I", usually on the same page, so the parent's end was computed from its own first child and landed one page *before* its own start.

**Measured before the fix: 29,037 inverted entries across 6,901 books, 6,045 of them visible.** Book-level ranges are unusable for any range query.

## The fix

An entry runs until the next entry **at or above its own level** — which also bounds a child by its parent's end for free — with a floor at its own `pageNumber` so no span can invert again.

Four independent copies of `computeEndPages` existed, which is how one flat implementation stayed wrong in four places at once. Collapsed to the repo's usual twin pair (`scripts/lib/chapter-endpages.mjs` + `src/lib/chapter-text.ts`), with a parity test.

## `chapter_texts` is deliberately unchanged

Its rows must **partition** the book. Chunking a container over its full span would store every child page twice and hand a RAG caller the same passage under two labels. A container is therefore chunked over its **own preamble only** — which is exactly what the old flat rule computed, so `chunkEndPage` reproduces it and **no materialized row changes**. A test pins that equivalence; if it ever fails, the repair owes a re-materialization pass.

This is why the fix is a pure `books.chapters` repair with no re-materialization cost.

## Repair sweep

`scripts/maintenance/repair-chapter-endpages.mjs`, dry-run by default. `endPage` is derived, so it makes **no AI calls** and is idempotent.

It writes the chapters array in its **original order**: `chapter_texts.chapter_index` is that array's positional index, so writing back a sorted copy would silently repoint every materialized chunk of any book not already in page order — turning a derived-field repair into data corruption.

```
books scanned:            15796
books needing change:     13537
chapter entries changed:  53010
inverted spans (before):  29012
skipped (no pages_count):     9
```

(53,010 > 29,012 because parents that were merely *truncated* at their first child also widen to their true end.)

## Out of scope

Same report, not addressed here — these are extraction-quality questions, not a derived-field bug:

- Book IX ch. IV is missing silently, with no gap indicator
- `confidence` is `"high"` on 96% of entries corpus-wide (303,009 high / 12,013 medium / 55 low), including the inverted spans — a field that barely varies implies a validation that never happened
- No end-matter category, so a final chapter absorbs the index (Book X ch. IX spans 16 pages where its siblings span 2–7)

## Test

`npx vitest run tests/unit/chapter-endpages-levels.test.ts` — 11 passing. Fixtures are deliberately nested; a flat implementation passes any single-level fixture, which is how this stayed invisible. `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)