### PR TITLE
test(mcp): golden-passage regressions — assert the right page ranks, not that something came back

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "deploy:prod": "./scripts/deploy-prod.sh",
     "lint": "eslint",
     "test": "vitest run && vitest run --config vitest.integration.config.ts",
+    "test:smoke": "vitest run --config vitest.smoke.config.ts",
     "test:unit": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest",

--- a/tests/fixtures/mcp-golden-passages.json
+++ b/tests/fixtures/mcp-golden-passages.json
@@ -1,0 +1,99 @@
+{
+  "$comment": "Golden-passage regression set for the MCP read/search surface. Every case here was reported by a real MCP client during Aristotle quote-verification sessions on 2026-08-05 and 2026-08-07, and every one is a case where the API answered with something PLAUSIBLE AND WRONG rather than with an error. See tests/smoke/mcp-golden-passages.test.ts for why these assert on rank and flag values rather than on non-emptiness.",
+
+  "ranking": {
+    "tool": "search_within_book",
+    "expectation": "The page that literally contains the searched sentence must appear in the top N results. Before #3680 every one of these ranked below 48 pages of front matter and apparatus, or did not appear at all.",
+    "$why": "The reporter's diagnosis: score was a raw count of distinct query terms present, unweighted. A natural-language query contributes ~10 function words that match every prose page, so every page ties and the tie breaks by page order — a contiguous run from page 1. The more precisely a caller described the passage they wanted, the worse the search performed.",
+    "cases": [
+      {
+        "book_id": "69d14a6c1c2a66dc094b41b2",
+        "book": "Taylor's Metaphysics, 1801",
+        "query": "the whole is not merely a heap but something besides its parts",
+        "expectPage": 264,
+        "withinTopN": 10,
+        "contains": "not merely a heap",
+        "$was": "Absent from the top 50 entirely; results were 48 front-matter pages at match_count 10-12."
+      },
+      {
+        "book_id": "6a0851bb49638a50931b901a",
+        "book": "Aldine Aristotle, 1551",
+        "query": "one should prefer plausible impossibilities to implausible possibilities",
+        "expectPage": 705,
+        "withinTopN": 10,
+        "$was": "Ranked last of 8 (match_count 2), beaten by p.642 — a Rhetoric passage that merely repeats 'plausible/implausible'. A verbatim phrase match lost to scattered repetition.",
+        "$note": "Poetics 1460a26. The front-matter detector does not fire on this volume at all: early modern books use signature marks, not roman pagination, and its front matter is in Greek and Latin."
+      },
+      {
+        "book_id": "6993882874305116d72cf9f3",
+        "book": "Diogenes Laertius, Pal.gr.182",
+        "query": "Aristotle asked what is hope, a waking dream; what is a friend, one soul in two bodies",
+        "expectPage": 159,
+        "withinTopN": 5,
+        "contains": "hope",
+        "$was": "Ranked ~50th of 59, behind 48 pages in strict ascending page order (title page, an attribution, a Vatican library seal). The page contains BOTH halves of the query verbatim."
+      }
+    ]
+  },
+
+  "rare_term_control": {
+    "tool": "search_within_book",
+    "expectation": "A single distinctive term still returns its few exact pages. This is the control that proves the ranking fix did not simply loosen matching.",
+    "cases": [
+      {
+        "book_id": "69d14a6c1c2a66dc094b41b2",
+        "query": "Speusippus",
+        "expectPagesInclude": [217, 347, 410],
+        "maxTotal": 25
+      }
+    ]
+  },
+
+  "nonsense_control": {
+    "tool": "search_within_book",
+    "expectation": "A query the book cannot answer must score BELOW one it answers verbatim, so a caller can tell 'not here' from 'found it'.",
+    "$openBug": "#3699 — currently both top out at score 1.0, because score is normalised within the result set. Marked it.fails in the test.",
+    "$historyNote": "The original reporter's control was 'nonsense returns total 0', which held before #3680 only because the semantic leg was not firing. It now fires, which is a fix, so returning neighbours for nonsense is correct behaviour — scoring them 1.0 is not. Do not restore the total===0 assertion.",
+    "cases": [
+      {
+        "book_id": "69d14a6c1c2a66dc094b41b2",
+        "query": "zebra pancake velocipede submarine trombone"
+      }
+    ]
+  },
+
+  "continuity": {
+    "tool": "get_quote",
+    "expectation": "Page-edge flags must be correct in BOTH directions and must read the hyphen from the original, not the translation.",
+    "$why": "A page opening mid-sentence reads as complete prose and carries a perfectly valid citation, so a wrong flag here produces a confident misquote. Both cases below returned false before #3680.",
+    "cases": [
+      {
+        "book_id": "6956953e8c9559f6c2db0b6d",
+        "page": 269,
+        "expect": { "continues_from_previous": true },
+        "$why": "Opens 'dom from pain' — the tail of 'the prudent man pursues a free-' on p.268. The detector caught forward splits but missed backward ones. Root cause: stripInlineNoise ran before the furniture strip and ate the '>' of every tag, so a tagged running head was never removed and the head was never reached."
+      },
+      {
+        "book_id": "6993882874305116d72cf9f3",
+        "page": 33,
+        "expect": { "hyphen_split_at_end": true },
+        "$why": "The Greek original ends 'ἐγέ-' (ἐγέ-/-νετο). The flag was tested against the TRANSLATION, where a translator has already resolved the hyphen — so it could never fire. Different book and different language from the case above, deliberately: this is the cross-script confirmation."
+      }
+    ]
+  },
+
+  "structure": {
+    "tool": "get_book",
+    "expectation": "Chapter spans must never invert, and a container must span its children.",
+    "$why": "endPage was derived as chapters[i+1].pageNumber - 1 with no regard for level. A 'Book I' heading is immediately followed by its own 'Chapter I', usually on the same page, so every level-1 span ran backwards (29,037 entries across 6,901 books before #3696).",
+    "cases": [
+      {
+        "book_id": "6956953e8c9559f6c2db0b6d",
+        "book": "Taylor's Nicomachean Ethics, 1818",
+        "expectNoInvertedSpans": true,
+        "expectChapter": { "title": "Book I", "pageNumber": 12, "endPage": 57 },
+        "$was": "Book I: pageNumber 12, endPage 11. Book II: 58/57. Book III: 84/83. Every level-1 entry."
+      }
+    ]
+  }
+}

--- a/tests/smoke/mcp-golden-passages.test.ts
+++ b/tests/smoke/mcp-golden-passages.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Golden-passage regression for the MCP read/search surface.
+ *
+ * ## Why this file exists, when tests/smoke/mcp-search.test.ts already does
+ *
+ * That file asks "did anything come back?". Every assertion in it is a
+ * non-emptiness check, and **every one of them passed throughout** the period a
+ * real MCP client was reporting that `search_within_book` was unusable: for a
+ * natural-language query it returned 48 pages of front matter, in strict page
+ * order, with the page containing the searched sentence verbatim ranked ~50th
+ * or absent. The results were never empty. They were plausible and wrong.
+ *
+ * That is the failure mode this corpus is most exposed to, and it is invisible
+ * to a non-emptiness assertion. A search tool that returns page 1 through 48 of
+ * every book would pass the existing suite completely.
+ *
+ * So the assertions here are of a different kind:
+ *
+ *   1. GOLDEN PASSAGE — for this query on this book, THIS page must be in the
+ *      top N. Sourced from a reader who verified the page contains the sentence.
+ *   2. CONTROLS — a rare term must still return its few exact pages, and
+ *      nonsense must return zero. Without these a "fix" that loosens matching
+ *      until everything ranks everywhere would pass (1).
+ *   3. FLAG CORRECTNESS — continuity flags asserted true where a human
+ *      confirmed the page opens or breaks mid-word.
+ *   4. STRUCTURAL INVARIANT — no chapter span may invert.
+ *
+ * Every case is a real reported defect, not a hypothetical. `$was` in the
+ * fixture records what the API actually returned before the fix, so a future
+ * reader can tell a regression from a never-worked.
+ *
+ * ## These hit production
+ *
+ * Smoke tests run against https://sourcelibrary.org by default and are not in
+ * CI (there is no smoke job in .github/workflows). Run them by hand after any
+ * change to search ranking, the continuity predicates, or chapter derivation:
+ *
+ *   npx vitest run --config vitest.smoke.config.ts tests/smoke/mcp-golden-passages.test.ts
+ *
+ * Set TEST_BASE_URL to point at a preview deploy.
+ *
+ * ## On maintaining these
+ *
+ * A failure here is far more likely to be a real regression than a stale
+ * fixture — page numbers are physical scan positions and do not drift. But if a
+ * book is re-archived or re-split, its page numbers CAN move (see
+ * .claude/docs/invariants/paired-artifacts.md). Before editing an expectation,
+ * confirm against the live page which of the two happened.
+ */
+import { describe, it, expect } from 'vitest';
+import fixture from '../fixtures/mcp-golden-passages.json' with { type: 'json' };
+
+const BASE = process.env.TEST_BASE_URL || 'https://sourcelibrary.org';
+
+interface SearchResult {
+  page: number;
+  snippet?: string;
+  score?: number;
+  found_by?: string;
+  is_front_matter?: boolean;
+}
+
+/**
+ * Hit the MCP route itself rather than the underlying REST endpoints.
+ *
+ * The existing smoke file deliberately calls /api/search directly, which is
+ * fine for the bugs it covers. It is the wrong choice here: the ranking
+ * interleave, the front-matter ordering and the continuity flags are all
+ * applied IN the MCP wrapper (src/app/api/mcp/route.ts), so testing the REST
+ * layer would exercise none of the code these cases are about.
+ */
+async function mcpCall(name: string, args: Record<string, unknown>) {
+  const res = await fetch(`${BASE}/api/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    }),
+  });
+  expect(res.status, `MCP call ${name} returned HTTP ${res.status}`).toBe(200);
+  const body = await res.json();
+  const text = body?.result?.content?.[0]?.text;
+  return text ? JSON.parse(text) : body?.result;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Golden passages — the page a reader verified must rank near the top
+// ---------------------------------------------------------------------------
+
+describe('search_within_book — the right page must rank, not merely appear', () => {
+  for (const c of fixture.ranking.cases) {
+    it(`${c.book}: "${c.query.slice(0, 48)}…" → p.${c.expectPage} in top ${c.withinTopN}`, async () => {
+      const data = await mcpCall('search_within_book', {
+        book_id: c.book_id,
+        query: c.query,
+      });
+      const results: SearchResult[] = data?.results || [];
+      expect(results.length, 'no results at all').toBeGreaterThan(0);
+
+      const rank = results.findIndex((r) => r.page === c.expectPage);
+      expect(
+        rank,
+        `p.${c.expectPage} not in results at all (returned ${results.length} of ${data?.total}). ` +
+          `Top 5 pages: ${results.slice(0, 5).map((r) => r.page).join(', ')}. Previously: ${c.$was}`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        rank + 1,
+        `p.${c.expectPage} ranked ${rank + 1} of ${results.length}, wanted top ${c.withinTopN}. ` +
+          `Pages above it: ${results.slice(0, rank).map((r) => r.page).join(', ')}`,
+      ).toBeLessThanOrEqual(c.withinTopN);
+
+      if ('contains' in c && c.contains) {
+        expect(
+          (results[rank].snippet || '').toLowerCase(),
+          'the ranked page is the right number but its snippet does not carry the searched text',
+        ).toContain(String(c.contains).toLowerCase());
+      }
+    });
+  }
+
+  it('front matter is ordered last, not merely labelled', async () => {
+    // The flag shipped one release before the sort that uses it, so for a while
+    // the response said front matter was "ordered last" while 48 flagged pages
+    // occupied slots 1-48. Labelling without ordering is the regression.
+    const c = fixture.ranking.cases[0];
+    const data = await mcpCall('search_within_book', { book_id: c.book_id, query: c.query });
+    const results: SearchResult[] = data?.results || [];
+    const firstFront = results.findIndex((r) => r.is_front_matter);
+    const lastBody = results.map((r) => !r.is_front_matter).lastIndexOf(true);
+    if (firstFront >= 0 && lastBody >= 0) {
+      expect(
+        firstFront,
+        `a front-matter result appears at rank ${firstFront + 1}, above body text ending at rank ${lastBody + 1}`,
+      ).toBeGreaterThan(lastBody);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Controls — without these, "rank everything everywhere" would pass above
+// ---------------------------------------------------------------------------
+
+describe('search_within_book — precision controls', () => {
+  for (const c of fixture.rare_term_control.cases) {
+    it(`a rare term ("${c.query}") still returns its exact pages`, async () => {
+      const data = await mcpCall('search_within_book', { book_id: c.book_id, query: c.query });
+      const pages = (data?.results || []).map((r: SearchResult) => r.page);
+      for (const p of c.expectPagesInclude) {
+        expect(pages, `p.${p} missing for rare term "${c.query}"`).toContain(p);
+      }
+      expect(
+        data?.total,
+        `"${c.query}" matched ${data?.total} pages — matching has been loosened past usefulness`,
+      ).toBeLessThanOrEqual(c.maxTotal);
+    });
+  }
+
+  /**
+   * KNOWN FAILURE — #3699. `it.fails` asserts this DOES fail, so when the bug
+   * is fixed the test goes red and whoever fixed it removes the marker. A
+   * `skip` would rot silently instead.
+   *
+   * The invariant is the one that matters to a caller deciding whether a
+   * passage is present or absent: a query the book cannot possibly answer must
+   * score BELOW one it answers verbatim. Today both top out at 1.0, because
+   * `score` is normalised within the result set — so the best of a bad lot is
+   * always a perfect match and the tool can never say "nothing here".
+   *
+   * Note this is NOT the control the original reporter wrote. Theirs was
+   * "nonsense returns total 0", which passed before #3680 because the semantic
+   * leg was not firing at all. It now fires — a genuine fix — so returning
+   * neighbours for nonsense is correct. Scoring them 1.0 is not.
+   */
+  for (const c of fixture.nonsense_control.cases) {
+    it.fails(`[#3699] nonsense ("${c.query}") must score below a verbatim hit`, async () => {
+      const golden = fixture.ranking.cases.find((r) => r.book_id === c.book_id)!;
+      const [nonsense, real] = await Promise.all([
+        mcpCall('search_within_book', { book_id: c.book_id, query: c.query }),
+        mcpCall('search_within_book', { book_id: c.book_id, query: golden.query }),
+      ]);
+      const topScore = (d: { results?: SearchResult[] }) =>
+        Math.max(0, ...(d?.results || []).map((r) => r.score ?? 0));
+
+      expect(
+        topScore(nonsense),
+        `nonsense top score ${topScore(nonsense)} vs verbatim-hit top score ${topScore(real)} — ` +
+          'a caller cannot distinguish "found it" from "not in this book"',
+      ).toBeLessThan(topScore(real));
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. Continuity flags — wrong here means a confident misquote
+// ---------------------------------------------------------------------------
+
+describe('get_quote — page-edge flags', () => {
+  for (const c of fixture.continuity.cases) {
+    const [flag] = Object.keys(c.expect);
+    it(`${c.book_id} p.${c.page}: ${flag} is ${Object.values(c.expect)[0]}`, async () => {
+      const data = await mcpCall('get_quote', { book_id: c.book_id, page: c.page });
+      const continuity = data?.continuity || {};
+      for (const [key, want] of Object.entries(c.expect)) {
+        expect(
+          continuity[key],
+          `${key} was ${continuity[key]}, wanted ${want}. ${c.$why}`,
+        ).toBe(want);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. Structural invariant — a span may never run backwards
+// ---------------------------------------------------------------------------
+
+describe('get_book — chapter spans', () => {
+  for (const c of fixture.structure.cases) {
+    it(`${c.book}: no chapter span inverts`, async () => {
+      const data = await mcpCall('get_book', { book_id: c.book_id });
+      const chapters = data?.chapters || [];
+      expect(chapters.length, 'no chapters returned').toBeGreaterThan(0);
+
+      const inverted = chapters.filter(
+        (ch: { pageNumber: number; endPage: number }) =>
+          typeof ch.endPage === 'number' && ch.endPage < ch.pageNumber,
+      );
+      expect(
+        inverted.map((ch: { title: string; pageNumber: number; endPage: number }) =>
+          `"${ch.title}" ${ch.pageNumber}–${ch.endPage}`),
+        'chapter spans running backwards',
+      ).toEqual([]);
+    });
+
+    it(`${c.book}: a container spans its children`, async () => {
+      const data = await mcpCall('get_book', { book_id: c.book_id });
+      const chapters = data?.chapters || [];
+      const want = c.expectChapter;
+      const found = chapters.find(
+        (ch: { title: string; pageNumber: number }) =>
+          ch.title === want.title && ch.pageNumber === want.pageNumber,
+      );
+      expect(found, `no chapter "${want.title}" starting at p.${want.pageNumber}`).toBeTruthy();
+      expect(
+        found.endPage,
+        `"${want.title}" ends at ${found.endPage}; it should run to ${want.endPage}, where the next entry at its own level begins`,
+      ).toBe(want.endPage);
+    });
+  }
+});

--- a/tests/smoke/mcp-search.test.ts
+++ b/tests/smoke/mcp-search.test.ts
@@ -17,6 +17,21 @@
  * Query matrix: tests/fixtures/mcp-search-regression-queries.json
  * PR: https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/pull/2162
  *
+ * ## Scope, and what this file CANNOT catch
+ *
+ * Every assertion here is a non-emptiness or stability check — "did anything
+ * come back?", "is the total deterministic?". That is the right shape for the
+ * two bugs above, both of which were silent-zero failures.
+ *
+ * It is the wrong shape for a ranking bug, and all of these passed throughout
+ * the period an MCP client was reporting that `search_within_book` returned 48
+ * pages of front matter in page order with the target passage ranked ~50th.
+ * The results were never empty; they were plausible and wrong.
+ *
+ * Golden-passage assertions — "for THIS query on THIS book, THIS page must be
+ * in the top N" — live in tests/smoke/mcp-golden-passages.test.ts. Add ranking
+ * and flag-correctness cases there, not here.
+ *
  * Run with: npx vitest run --config vitest.smoke.config.ts tests/smoke/mcp-search.test.ts
  *
  * To exercise the actual MCP JSON-RPC endpoint (requires API key):


### PR DESCRIPTION
## Why

The existing MCP smoke suite asks *"did anything come back?"*. Every assertion in it is a non-emptiness or stability check — and **every one passed throughout** the period a real MCP client was reporting that `search_within_book` was unusable: a natural-language query returned 48 pages of front matter in strict page order, with the page containing the searched sentence ranked ~50th or absent.

The results were never empty. They were **plausible and wrong** — the failure mode this corpus is most exposed to, and the one a non-emptiness assertion cannot see. A search tool that returned pages 1–48 of every book would pass the old suite completely.

## What this file asserts instead

1. **Golden passage** — for this query on this book, *this* page must rank in the top N. All three cases come from a reader who verified the page carries the sentence verbatim; all three failed before #3680.
2. **Controls** — a rare term must still return its exact pages, and a query the book cannot answer must score below one it answers verbatim. Without these, a "fix" that loosens matching until everything ranks everywhere would satisfy (1).
3. **Flag correctness** — continuity asserted true on two pages a human confirmed open or break mid-word, in two books and two scripts.
4. **Structural invariant** — no chapter span may run backwards (#3696).

Verified against production: **9 pass, 1 expected-fail.**

## The expected failure is a new bug this exercise found

#3699, **not previously reported** — it was introduced by the ranking fix in #3680, which shipped *after* the reporting session's last test.

```
search_within_book("zebra pancake velocipede submarine trombone")
→ total 9, all found_by "semantic", scores 1.0, 0.999, 0.995 …
```

A verbatim hit on the same book also tops out at **1.0**. `score` is normalised within the result set, so the best of a bad lot is always a perfect match and the tool **cannot express "nothing here"**.

That matters because a defensible negative is exactly what the reporter valued most in the API:

> The similarity calibration in the response tip (0.70+ / 0.55–0.70 / below 0.55) is the best-designed thing in the whole API. **It let me report negatives with confidence rather than hedging.**

Marked `it.fails` rather than `skip`, so fixing #3699 turns the test red and prompts removal of the marker. A skipped test rots silently.

## Fixture notes

`$was` records what the API actually returned before each fix, so a future reader can tell a regression from a never-worked. It also explicitly warns against restoring the original reporter's `total === 0` nonsense control — that held only because the semantic leg was not firing, which has since been genuinely fixed.

## Also

- `npm run test:smoke`
- A scope note on `tests/smoke/mcp-search.test.ts` explaining what it cannot catch and pointing here.

Smoke tests hit production and are not in CI (there is no smoke job). Run after any change to search ranking, the continuity predicates, or chapter derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
