### PR TITLE
feat(locus): resolve Bekker and Stephanus references to the leaves that carry them (#3661)

### DIFF
--- a/.claude/docs/invariants/canonical-loci.md
+++ b/.claude/docs/invariants/canonical-loci.md
@@ -1,0 +1,103 @@
+# A canonical locus is read off the leaf, never derived from a page count
+
+**Read this when:** touching `locus_anchors` / `locus_books`, registering an edition in `src/lib/locus-editions.ts`, changing `src/lib/locus.ts` or `/api/locus`, or about to state where a Bekker or Stephanus reference lands.
+
+*Added 2026-08-07 with the first implementation (#3661). The measurement that scoped it is on that issue; this file is the part you must not break.*
+
+---
+
+## What the system is for
+
+Scholarship addresses Aristotle by Bekker number (`1094a8`) and Plato by Stephanus
+number (`Rep. 328b`). Those systems were agreed centuries ago so a citation would
+survive re-typesetting. Source Library addressed everything by scan page, which is
+a property of one copy and shareable with nobody — so an agent fact-checking
+attributed Aristotle quotes through MCP had to rebuild the mapping by hand and
+then **guess**: *"deriving page ≈ 310 + (Bekker − 1094), and guessing"* (#3653
+item 2). It happened to be right. That is the situation this replaces.
+
+## The rule that must not be relaxed
+
+**A published locus is a number that was printed on that leaf.** Not fitted, not
+interpolated, not inferred from a range table. There is exactly one exception and
+it is fenced: in a root edition whose scan→printed offset is constant and
+verified, a leaf whose own number was misread may take the frame value **iff both
+neighbouring leaves are printed anchors agreeing with the offset**. Those carry
+`basis: "frame"` and are counted separately everywhere.
+
+Why the fence is tight: a fabricated citation is worse than no citation
+(`entity-page-attribution.md`). An interpolated locus looks exactly like a read
+one, and the reader who follows it lands on prose that is not what they cited.
+
+**Segment before quoting any coverage number.** Two different mechanisms put a
+canonical number on a page and they are not comparable:
+
+| | mechanism | editions |
+|---|---|---|
+| A | the book's own pagination IS the citation standard | Bekker 1831, Stephanus 1578 |
+| B | the reference is printed in the margin beside the text | Burnet's OCT, the Oxford translation |
+
+#3661's first pass asked one question of both — "does scan→printed fit a line?" —
+and scored the more valuable mechanism **worst**, because Bekker numbers in a
+margin do not advance at the rate of pages. Historia Animalium scored `fit=0.009`
+and is one of the best books in the corpus for this. Never sum A and B into one
+"% covered".
+
+## Where the reference frame comes from — and where it does not
+
+The per-work reference ranges are **derived** from the editions' own running
+heads joined to the numbers read inside them, not asserted from memory. They then
+agree with the values a classicist would recognise (Physics 184–267, Metaphysics
+980–1093, NE 1094–1181, Politics 1252–1342, Poetics 1447–1462, Republic 327–621,
+Laws 624–969). That agreement is a **check on the derivation, never its source**.
+
+`src/lib/locus-works.ts` does assert one thing: that `ΠΟΛΙΤΕΙΑ` and `DE REPVBL`
+name the same dialogue, and that its English name is "Republic". It carries **no
+page ranges by design**, so a wrong row can mislabel a leaf but cannot move a
+citation to a different one. A test asserts that no range field ever appears
+there. Keep it that way.
+
+`expect` blocks in `src/lib/locus-editions.ts` are regression pins recording what
+a reviewed run produced. They are verified against the data and a mismatch
+**refuses the edition** rather than warning; they are never read to decide where a
+locus is (`tests-that-are-not-guards.md`).
+
+## Traps that already bit
+
+- **A printed number is not necessarily a canonical number.** Stephanus vols. 1
+  and 3 append Estienne's and Serranus's annotations, separately paginated from 1.
+  Those numbers are printed, real, and not Stephanus references — 54 anchors in
+  vol. 1 and 130 in vol. 3. They are dropped as off-frame. Vol. 3's frame holds on
+  only 75.9% of its printed numbers, the weakest in the set; re-check it first if
+  anything drifts.
+- **Match by page, never by section.** A leaf carries a run of Stephanus sections
+  and the margin records only one. Filtering on the requested section reported
+  `Republic 328b` as absent while we held the leaf, whose margin read `328 c`.
+- **A work's opening leaves can sit under its predecessor's running head.** The
+  recto names the work, the verso names only the author, so the first leaf or two
+  of a work inherits the previous one. Stephanus vol. 2 leaf 340 is printed 328 and
+  is Republic text under the head `PLATONIS`; before both candidates were recorded
+  (`work_header_alt`), `Republic 328b` missed the very edition the numbering is
+  named after. Verified against the scans: leaf 339 is the Republic's title page.
+- **Two works genuinely share a page** where one ends and the next begins — Bekker
+  184 (Sophistical Refutations / Physics) and 1447 (Rhetorica ad Alexandrum /
+  Poetics) are both such joins. The API reports these as
+  `other_works_at_this_reference` rather than hiding them; a caller that ignores
+  that field will conclude a passage is absent when it is one row down.
+- **The same number exists in both systems.** Bekker and Stephanus ranges overlap
+  almost entirely, so a bare number returns Aristotle and Plato leaves together.
+  Never infer the system from the number's magnitude — that misattributes a
+  quotation to a different author.
+- **`locus_anchors` is a derived store with one writer outside the pipeline** —
+  the exact shape that went dark for 60 days in the page-embedding outage
+  (`derived-stores-and-schedules.md`). `locus_books.ocr_updated_max` holds the
+  SOURCE's OCR timestamp so a re-OCR is detectable, and
+  `scripts/audit/locus-anchor-staleness.mjs` is the detector: it checks coverage
+  against the registry and exits 1. A stale anchor points at text that has moved.
+
+## What this does NOT solve
+
+Of 276 live Aristotle and Plato books, 10 are registered here. The rest hold no
+usable numeric structure and **cannot be reached this way at all** — bridging them
+needs text alignment to a root edition, not number alignment. Do not let a
+coverage number over these 10 editions be read as coverage of the corpus.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ they open with a "Read this when" line so you can bail in two seconds.
 - `visible` / `hidden` / `hidden_reason`, homepage stats, FT badge gating → `visibility-and-stats.md`
 - `books.author`, `author_id`, the `authors` thesaurus, `/author/[slug]` → `author-identity.md`
 - `books.work_id`, translation gaps, "do we hold the original?", acquisition at scale → `work-identity.md`
+- Bekker/Stephanus references, `locus_anchors`, `/api/locus`, "which page is 1094a?" → `canonical-loci.md`
 - `entities.books[]`, book-index generation, page citations from the index → `entity-page-attribution.md`
 - Measuring OCR agreement / calibration / page difficulty → `page-revisions-corpus.md`
 - Asserting, badging, or counting "first translation" → `first-translation-claims.md`

--- a/scripts/audit/locus-anchor-staleness.mjs
+++ b/scripts/audit/locus-anchor-staleness.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Are the canonical locus anchors still true of the pages they were read from?
+ *
+ *   node scripts/audit/locus-anchor-staleness.mjs
+ *
+ * ## Why this exists before anyone asked for it
+ *
+ * `locus_anchors` is a store derived from `pages.ocr`, written by a script that
+ * nothing schedules. That is precisely the shape that went dark for 60 days in
+ * the page-embedding outage: a derived artifact with one writer outside the
+ * pipeline, whose absence is indistinguishable from an empty answer
+ * (`.claude/docs/invariants/derived-stores-and-schedules.md`, #3692).
+ *
+ * A stale locus anchor is worse than a missing one. Re-OCR can move the text on a
+ * leaf, and an anchor still pointing there would produce a confident citation to
+ * the wrong lines — the failure `entity-page-attribution.md` exists to prevent.
+ *
+ * ## What it checks, and why not `updated_at`
+ *
+ * Coverage against the Mongo denominator, plus a diff of the SOURCE's own OCR
+ * timestamp against the one recorded at extraction. The lesson from that outage
+ * was that a derived store's own `updated_at` lies in both directions; the signal
+ * that would have fired on day one is coverage against the source.
+ *
+ * Exit 1 if any registered edition is unpublished or stale, so this can gate.
+ */
+import { MongoClient } from 'mongodb';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const { LOCUS_EDITIONS } = await import(join(ROOT, 'src', 'lib', 'locus-editions.ts'));
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+
+let problems = 0;
+console.log(`\n${LOCUS_EDITIONS.length} registered editions\n${'-'.repeat(72)}`);
+
+for (const ed of LOCUS_EDITIONS) {
+  const state = await db.collection('locus_books').findOne({ book_id: ed.book_id });
+  const anchors = await db.collection('locus_anchors').countDocuments({ book_id: ed.book_id });
+
+  if (!state || !anchors) {
+    problems++;
+    console.log(`✗ NOT PUBLISHED  ${ed.book_id}  ${ed.label}`);
+    console.log(`    run: npx tsx scripts/locus/extract-locus-anchors.mjs --book=${ed.book_id} --apply`);
+    continue;
+  }
+
+  // The newest OCR timestamp on the book NOW, against the one seen at extraction.
+  const newest = await db.collection('pages')
+    .find({ book_id: ed.book_id, 'ocr.updated_at': { $exists: true } }, { projection: { 'ocr.updated_at': 1 } })
+    .sort({ 'ocr.updated_at': -1 }).limit(1).toArray();
+  const nowMax = newest[0]?.ocr?.updated_at ?? null;
+  const thenMax = state.ocr_updated_max ?? null;
+  const stale = nowMax && thenMax && nowMax > thenMax;
+
+  const min = ed.expect?.min_anchors;
+  const thin = min && anchors < min;
+
+  if (stale || thin) problems++;
+  console.log(
+    `${stale || thin ? '✗' : '✓'} ${String(anchors).padStart(5)} anchors  ` +
+    `ref ${state.ref_min}–${state.ref_max}  ${ed.label}`,
+  );
+  if (stale) {
+    console.log(`    STALE: pages re-OCR'd ${nowMax.toISOString?.() ?? nowMax} after extraction at ${thenMax.toISOString?.() ?? thenMax}`);
+    console.log(`    Anchors may point at text that has moved. Re-extract before trusting them.`);
+  }
+  if (thin) console.log(`    THIN: below the reviewed floor of ${min}`);
+}
+
+// Anchors whose edition is no longer registered — a row nothing would refresh.
+const registered = new Set(LOCUS_EDITIONS.map((e) => e.book_id));
+const orphanIds = (await db.collection('locus_anchors').distinct('book_id')).filter((id) => !registered.has(id));
+if (orphanIds.length) {
+  problems++;
+  console.log(`\n✗ ${orphanIds.length} book(s) hold anchors but are no longer registered:`);
+  for (const id of orphanIds) console.log(`    ${id}  — delete the rows or re-register the edition`);
+}
+
+console.log(`\n${problems ? `${problems} problem(s)` : 'all registered editions published and current'}`);
+await client.close();
+process.exit(problems ? 1 : 0);

--- a/scripts/locus/extract-locus-anchors.mjs
+++ b/scripts/locus/extract-locus-anchors.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * Extract canonical loci (Bekker / Stephanus) from the editions that print them.
+ *
+ *   npx tsx scripts/locus/extract-locus-anchors.mjs                 # dry run, full report
+ *   npx tsx scripts/locus/extract-locus-anchors.mjs --apply
+ *   npx tsx scripts/locus/extract-locus-anchors.mjs --book=<id>      # one edition
+ *   npx tsx scripts/locus/extract-locus-anchors.mjs --residuals      # print what was dropped
+ *
+ * ## What this is for (#3661)
+ *
+ * Scholarship addresses Aristotle by Bekker number and Plato by Stephanus number.
+ * We addressed everything by scan page, which is a property of one copy and
+ * shareable with nobody. An agent verifying attributed Aristotle quotes through
+ * MCP had to rebuild the Bekker mapping by hand and then guess (#3653 item 2).
+ *
+ * ## The rule
+ *
+ * A locus is published only where a number was **printed on the leaf** and
+ * continues its work's monotone run, or — in a root edition whose scan→printed
+ * offset is constant and verified — where both neighbouring leaves bracket it
+ * exactly. Everything else is reported as a residual and stored nowhere. See
+ * `src/lib/locus.ts` for the acceptance rule and why it is deliberately local.
+ *
+ * ## Two mechanisms, never one number
+ *
+ * `printed` anchors from a root edition's own pagination and `printed` anchors
+ * from a marginal reference are different evidence, and #3661 records that
+ * summing them into one "% covered" scored the more valuable mechanism worst.
+ * The report segments by edition and by basis and never totals across them.
+ *
+ * ## Staleness
+ *
+ * `locus_books.ocr_updated_max` records the source OCR's own timestamp, so a
+ * re-OCR that moves the text under a stored anchor is detectable — the failure
+ * mode `.claude/docs/invariants/derived-stores-and-schedules.md` was written
+ * about. `scripts/audit/locus-anchor-staleness.mjs` is the detector.
+ */
+import { MongoClient } from 'mongodb';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const { extractAnchors, refSortKey, formatRef } = await import(join(ROOT, 'src', 'lib', 'locus.ts'));
+const { LOCUS_EDITIONS } = await import(join(ROOT, 'src', 'lib', 'locus-editions.ts'));
+
+const EXTRACTOR_VERSION = 'locus-anchors/1';
+
+const APPLY = process.argv.includes('--apply');
+const SHOW_RESIDUALS = process.argv.includes('--residuals');
+const ONLY = (process.argv.find((a) => a.startsWith('--book=')) || '').split('=')[1] || null;
+
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const NOW = new Date();
+
+const tagOf = (text, tag) => {
+  const m = text.match(new RegExp(`<${tag}>\\s*([\\s\\S]{0,120}?)\\s*</${tag}>`, 'i'));
+  return m ? m[1].trim() : null;
+};
+
+const editions = LOCUS_EDITIONS.filter((e) => !ONLY || e.book_id === ONLY);
+if (!editions.length) { console.error(`no registered edition matches ${ONLY}`); process.exit(1); }
+
+const perBook = [];
+const refused = [];
+
+for (const ed of editions) {
+  const book = await db.collection('books').findOne({ id: ed.book_id }, { projection: { id: 1, title: 1, author: 1, year: 1, language: 1, slug: 1, visible: 1, pages_count: 1 } });
+  if (!book) { refused.push([ed.book_id, 'book not found']); continue; }
+
+  const pages = await db.collection('pages')
+    .find({ book_id: ed.book_id }, { projection: { page_number: 1, 'ocr.data': 1, 'ocr.updated_at': 1 } })
+    .sort({ page_number: 1 }).toArray();
+
+  let ocrUpdatedMax = null;
+  const inputs = [];
+  for (const p of pages) {
+    const text = p.ocr?.data || '';
+    if (p.ocr?.updated_at && (!ocrUpdatedMax || p.ocr.updated_at > ocrUpdatedMax)) ocrUpdatedMax = p.ocr.updated_at;
+    if (!text) continue;
+    inputs.push({
+      page_number: p.page_number,
+      header: tagOf(text, 'header'),
+      page_num: tagOf(text, 'page-num'),
+    });
+  }
+
+  const { anchors, rejected, report } = extractAnchors(inputs, {
+    author: book.author || '',
+    frame: ed.frame,
+  });
+
+  // Verify the reviewed pins. A book that fails one is REFUSED, not published
+  // with a warning: a wrong frame re-addresses every citation it touches, and a
+  // warning nobody reads is how that ships.
+  const problems = [];
+  const exp = ed.expect || {};
+  if (exp.offset !== undefined && report.frame_offset !== exp.offset) {
+    problems.push(`frame offset ${report.frame_offset} != reviewed ${exp.offset} (share ${report.frame_offset_share})`);
+  }
+  if (exp.min_anchors !== undefined && anchors.length < exp.min_anchors) {
+    problems.push(`${anchors.length} anchors < reviewed floor ${exp.min_anchors}`);
+  }
+  if (exp.ref_range && anchors.length) {
+    const lo = report.ref_min;
+    const hi = report.ref_max;
+    const [elo, ehi] = exp.ref_range;
+    // A tighter range is drift too — it means anchors were lost.
+    if (lo < elo || hi > ehi || lo > elo + 12 || hi < ehi - 12) {
+      problems.push(`ref range ${lo}–${hi} outside reviewed ${elo}–${ehi}`);
+    }
+  }
+
+  perBook.push({ ed, book, anchors, rejected, report, problems, ocrUpdatedMax });
+}
+
+// ── report ─────────────────────────────────────────────────────────
+
+console.log(`\n${'='.repeat(78)}\nCANONICAL LOCUS EXTRACTION — ${EXTRACTOR_VERSION}\n${'='.repeat(78)}`);
+
+for (const r of perBook) {
+  const { ed, book, report, anchors, problems } = r;
+  console.log(`\n■ ${ed.label}`);
+  console.log(`  ${ed.book_id}  ${book.pages_count} pages · ${report.candidate_pages} with a <page-num> that parsed`);
+  console.log(`  system=${ed.system}  mechanism=${ed.frame ? 'A: own pagination is the standard' : 'B: reference printed in the margin'}`);
+  console.log(`  anchors: ${report.printed} printed` + (ed.frame ? ` + ${report.frame} frame-filled` : '') + `   residual: ${report.rejected} dropped` + (report.off_frame ? ` (${report.off_frame} of them off-frame)` : ''));
+  if (ed.frame) console.log(`  frame offset: ${report.frame_offset === null ? 'NO CONSTANT OFFSET — edition refused' : `${report.frame_offset} on ${(report.frame_offset_share * 100).toFixed(1)}% of printed anchors`}`);
+  if (anchors.length) console.log(`  reference range: ${report.ref_min} … ${report.ref_max}`);
+  console.log(`  works (derived from running heads, ranges derived from the anchors inside them):`);
+  for (const s of report.segments) {
+    console.log(`     ${String(s.anchors).padStart(4)} anchors  ref ${String(s.ref_min).padStart(4)}–${String(s.ref_max).padEnd(4)}  scan ${String(s.first_page).padStart(4)}–${String(s.last_page).padEnd(4)}  ${s.work_header ?? '(no running head)'}`);
+  }
+  if (problems.length) {
+    console.log(`  ✗ REFUSED — reviewed expectations not met:`);
+    for (const p of problems) console.log(`     ${p}`);
+  }
+  if (SHOW_RESIDUALS && r.rejected.length) {
+    console.log(`  residuals (first 20):`);
+    for (const x of r.rejected.slice(0, 20)) console.log(`     scan ${String(x.page_number).padStart(4)}  raw=${JSON.stringify((x.raw || '').slice(0, 40))}  ${x.reason}`);
+  }
+}
+
+const publishable = perBook.filter((r) => !r.problems.length && r.anchors.length);
+console.log(`\n${'-'.repeat(78)}`);
+console.log(`${publishable.length}/${perBook.length} editions publishable`);
+for (const [id, why] of refused) console.log(`  skipped ${id}: ${why}`);
+// Deliberately no grand total of anchors across mechanisms — see the header.
+console.log(`  mechanism A (own pagination): ${publishable.filter((r) => r.ed.frame).reduce((n, r) => n + r.anchors.length, 0)} anchors in ${publishable.filter((r) => r.ed.frame).length} editions`);
+console.log(`  mechanism B (marginal refs) : ${publishable.filter((r) => !r.ed.frame).reduce((n, r) => n + r.anchors.length, 0)} anchors in ${publishable.filter((r) => !r.ed.frame).length} editions`);
+
+if (!APPLY) {
+  console.log(`\nDRY RUN — nothing written. Pass --apply.`);
+  await client.close();
+  process.exit(0);
+}
+
+// ── write ──────────────────────────────────────────────────────────
+
+const anchorsCol = db.collection('locus_anchors');
+const booksCol = db.collection('locus_books');
+
+await anchorsCol.createIndex({ system: 1, ref_page: 1, ref_section: 1 });
+await anchorsCol.createIndex({ book_id: 1, page_number: 1 });
+await anchorsCol.createIndex({ system: 1, work_header: 1, ref_sort: 1 });
+
+let wrote = 0;
+for (const r of publishable) {
+  const { ed, book, anchors, report, ocrUpdatedMax } = r;
+  // Replace this edition's rows wholesale. The extraction is a pure function of
+  // the book's OCR, so a partial update would leave anchors from an older parse
+  // interleaved with the new ones and nothing would say which was which.
+  await anchorsCol.deleteMany({ book_id: ed.book_id });
+  const docs = anchors.map((a) => ({
+    book_id: ed.book_id,
+    book_slug: book.slug || null,
+    system: ed.system,
+    ref_page: a.ref.page,
+    ref_section: a.ref.section,
+    ref_line: a.ref.line,
+    ref_sort: refSortKey(a.ref),
+    ref_label: formatRef(a.ref),
+    page_number: a.page_number,
+    basis: a.basis,
+    work_header: a.work_header,
+    work_header_alt: a.work_header_alt ?? null,
+    raw: a.raw,
+    extractor_version: EXTRACTOR_VERSION,
+    extracted_at: NOW,
+  }));
+  for (let i = 0; i < docs.length; i += 500) await anchorsCol.insertMany(docs.slice(i, i + 500));
+  wrote += docs.length;
+
+  await booksCol.replaceOne({ book_id: ed.book_id }, {
+    book_id: ed.book_id,
+    book_slug: book.slug || null,
+    title: book.title,
+    author: book.author,
+    year: book.year ?? null,
+    language: book.language ?? null,
+    system: ed.system,
+    label: ed.label,
+    mechanism: ed.frame ? 'pagination' : 'marginal',
+    anchors_printed: report.printed,
+    anchors_frame: report.frame,
+    residual: report.rejected,
+    frame_offset: report.frame_offset,
+    frame_offset_share: report.frame_offset_share,
+    ref_min: Math.min(...anchors.map((a) => a.ref.page)),
+    ref_max: Math.max(...anchors.map((a) => a.ref.page)),
+    segments: report.segments,
+    // The SOURCE's timestamp, not ours — a re-OCR moves this and the staleness
+    // detector diffs it. Storing our own write time instead would make the store
+    // look fresh forever (derived-stores-and-schedules.md).
+    ocr_updated_max: ocrUpdatedMax,
+    extractor_version: EXTRACTOR_VERSION,
+    extracted_at: NOW,
+  }, { upsert: true });
+}
+
+console.log(`\nwrote ${wrote} anchors across ${publishable.length} editions`);
+await client.close();

--- a/src/app/api/locus/route.ts
+++ b/src/app/api/locus/route.ts
@@ -1,0 +1,266 @@
+/**
+ * GET /api/locus?ref=1094a8
+ * GET /api/locus?work=Republic&ref=328b
+ * GET /api/locus?system=bekker&ref=1447
+ *
+ * Resolve a canonical reference — a Bekker number for Aristotle, a Stephanus
+ * number for Plato — to every leaf in the library that carries it (#3661).
+ *
+ * ## Why this route exists
+ *
+ * A scan page is a property of one copy and shareable with nobody. Bekker and
+ * Stephanus numbers were agreed centuries ago so that a citation survives
+ * re-typesetting, and they are how the field actually addresses these texts. An
+ * agent verifying attributed Aristotle quotes through MCP had to rebuild the
+ * mapping by hand and then guess which leaf held 1094 (#3653 item 2).
+ *
+ * ## What it will and will not answer
+ *
+ * Every witness returned is a leaf on which the reference was **printed** (or, in
+ * a root edition with a verified constant offset, a leaf bracketed exactly by two
+ * printed neighbours — reported as `basis: "frame"`). There is no interpolation:
+ * a reference we hold no anchor for returns no witness, and the response says
+ * which editions were searched so "not found" can be told from "not covered".
+ *
+ * A Stephanus number without a work is genuinely ambiguous — it restarts in each
+ * of the three 1578 volumes — so the response lists the candidate works rather
+ * than picking one.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+import { withApiAuth } from '@/lib/api-auth';
+import { parseLocusQuery, type LocusSystem } from '@/lib/locus';
+import { findWorkByName, findWorkByHead } from '@/lib/locus-works';
+
+interface AnchorDoc {
+  book_id: string;
+  book_slug: string | null;
+  system: LocusSystem;
+  ref_page: number;
+  ref_section: string | null;
+  ref_label: string;
+  page_number: number;
+  basis: 'printed' | 'frame';
+  work_header: string | null;
+  work_header_alt: string | null;
+}
+
+export const GET = withApiAuth(async (request: NextRequest) => {
+  const { searchParams } = new URL(request.url);
+  const refParam = (searchParams.get('ref') || searchParams.get('locus') || '').trim();
+  const workParam = (searchParams.get('work') || '').trim();
+  const systemParam = (searchParams.get('system') || '').trim().toLowerCase();
+
+  if (!refParam) {
+    return NextResponse.json(
+      { error: 'ref is required, e.g. ?ref=1094a8 or ?work=Republic&ref=328b' },
+      { status: 400 },
+    );
+  }
+
+  const parsed = parseLocusQuery(workParam ? `${workParam} ${refParam}` : refParam);
+  if (!parsed) {
+    return NextResponse.json(
+      { error: `could not read "${refParam}" as a canonical reference. Expected forms: 1094a8, 1094a, Rep. 328b, Bekker 1447a.` },
+      { status: 400 },
+    );
+  }
+
+  let system: LocusSystem | null =
+    systemParam === 'bekker' || systemParam === 'stephanus' ? systemParam : parsed.system;
+
+  const workName = workParam || parsed.work;
+  const work = workName ? findWorkByName(workName, system) : null;
+  if (workName && !work) {
+    return NextResponse.json(
+      {
+        error: `unknown work "${workName}"`,
+        hint: 'Omit work to search by reference alone, or use a name as printed in the edition. Bekker numbers are unique across Aristotle and need no work.',
+      },
+      { status: 404 },
+    );
+  }
+  if (work) system = work.system;
+
+  const db = await getReadDb();
+
+  // Which editions could answer at all. Reported on every response so an empty
+  // result can be read correctly: "we hold no anchor there" is a different fact
+  // from "the reference does not exist", and only this list distinguishes them.
+  const editions = await db
+    .collection('locus_books')
+    .find(system ? { system } : {}, {
+      projection: {
+        _id: 0, book_id: 1, book_slug: 1, title: 1, author: 1, year: 1, language: 1,
+        system: 1, label: 1, mechanism: 1, ref_min: 1, ref_max: 1,
+        anchors_printed: 1, anchors_frame: 1,
+      },
+    })
+    .toArray();
+
+  // Matched on the PAGE only, never on the section.
+  //
+  // A leaf carries a whole Bekker page or a run of Stephanus sections, and the
+  // anchor records whichever one the printer happened to put in the margin. The
+  // Burnet leaf covering 328a–328c is anchored `328 c`; filtering on the
+  // requested section `b` returned nothing for `Republic 328b` — a leaf we hold,
+  // reported as absent. Each witness carries its own printed `reference` so the
+  // caller can see what was actually on the leaf.
+  const query: Record<string, unknown> = { ref_page: parsed.ref.page };
+  if (system) query.system = system;
+
+  const anchors = (await db
+    .collection('locus_anchors')
+    .find(query, { projection: { _id: 0 } })
+    .sort({ system: 1, ref_sort: 1 })
+    .limit(200)
+    .toArray()) as unknown as AnchorDoc[];
+
+  const bookById = new Map(editions.map((e) => [e.book_id as string, e]));
+
+  const allAtRef = anchors
+    .map((a) => {
+      const ed = bookById.get(a.book_id);
+      const w = findWorkByHead(a.work_header, a.system);
+      const alt = findWorkByHead(a.work_header_alt, a.system);
+      return {
+        work_alt: alt ? { slug: alt.slug, label: alt.label } : null,
+        book_id: a.book_id,
+        title: (ed?.title as string) ?? null,
+        author: (ed?.author as string) ?? null,
+        year: (ed?.year as number) ?? null,
+        language: (ed?.language as string) ?? null,
+        edition: (ed?.label as string) ?? null,
+        system: a.system,
+        reference: a.ref_label,
+        /** The scan page — what `/page-number/N` and get_quote both key on. */
+        page: a.page_number,
+        basis: a.basis,
+        work: w ? { slug: w.slug, label: w.label } : null,
+        /** The running head printed on that leaf. The evidence for `work`. */
+        running_head: a.work_header,
+        url: `https://sourcelibrary.org/book/${a.book_slug || a.book_id}/page-number/${a.page_number}`,
+        quote_api: `https://sourcelibrary.org/api/books/${a.book_id}/quote?page=${a.page_number}`,
+      };
+    });
+
+  // The work filter, applied after each leaf's head is resolved: this is where a
+  // Stephanus number is disambiguated between the three 1578 volumes.
+  const witnesses = (work ? allAtRef.filter((w) => w.work?.slug === work.slug || w.work_alt?.slug === work.slug) : allAtRef)
+    .map(({ work_alt, ...w }) => ({
+      ...w,
+      // Say so when the match came from the boundary candidate rather than the
+      // head printed on the leaf. The caller can then check the leaf itself.
+      attribution: work && w.work?.slug !== work.slug
+        ? `boundary: this leaf carries no running head of its own and sits under ${w.work?.label ?? 'the previous work'}; ${work_alt?.label ?? 'the requested work'} begins within two leaves`
+        : 'running head',
+    }));
+
+  // A leaf whose head names a DIFFERENT work is worth reporting rather than
+  // discarding, because at a work boundary the attribution is the weak link: a
+  // work's opening leaves often carry the previous work's running head (the recto
+  // names the work, the verso names only the author), so the first leaf or two of
+  // a dialogue can sit under its predecessor. Saying "we hold this number, filed
+  // under X" lets the caller judge; a bare empty result hides a leaf we have.
+  const filteredOut = work
+    ? allAtRef
+        .filter((w) => w.work?.slug !== work.slug && w.work_alt?.slug !== work.slug)
+        .map((w) => ({
+          book_id: w.book_id,
+          edition: w.edition,
+          page: w.page,
+          reference: w.reference,
+          filed_under: w.work?.label ?? null,
+          running_head: w.running_head,
+          url: w.url,
+        }))
+    : [];
+
+  const distinctWorks = [...new Map(witnesses.map((w) => [w.work?.slug ?? w.running_head, w])).keys()];
+  const ambiguous = !work && system === 'stephanus' && distinctWorks.length > 1;
+  const systemsHit = [...new Set(witnesses.map((w) => w.system))];
+
+  return NextResponse.json({
+    query: {
+      reference: parsed.ref,
+      reference_label: `${parsed.ref.page}${parsed.ref.section ?? ''}${parsed.ref.line ? `.${parsed.ref.line}` : ''}`,
+      system: system ?? 'either',
+      work: work ? { slug: work.slug, label: work.label } : null,
+    },
+    witnesses,
+    witness_count: witnesses.length,
+    ambiguous_work: ambiguous || undefined,
+    other_works_at_this_reference: filteredOut.length ? filteredOut : undefined,
+    note: buildNote({
+      system, work: !!work, count: witnesses.length, ambiguous,
+      line: parsed.ref.line, sectionAsked: parsed.ref.section,
+      sectionsFound: [...new Set(witnesses.map((w) => w.reference))],
+      otherWorks: filteredOut.length,
+      systemsHit,
+    }),
+    // Only the editions that could answer at this reference, so an empty result
+    // is readable: if this list is empty the number is outside everything we
+    // hold, and if it is not, we hold the range and not the leaf.
+    editions_searched: editions
+      .filter((e) => (e.ref_min as number) <= parsed.ref.page && parsed.ref.page <= (e.ref_max as number))
+      .map((e) => ({
+        book_id: e.book_id, edition: e.label, system: e.system, language: e.language,
+        mechanism: e.mechanism, covers: [e.ref_min, e.ref_max],
+        anchors: (e.anchors_printed as number) + (e.anchors_frame as number),
+      })),
+    editions_registered: editions.length,
+  });
+}, { route: 'locus' });
+
+function buildNote(o: {
+  system: LocusSystem | null;
+  work: boolean;
+  count: number;
+  ambiguous: boolean;
+  line: number | null;
+  sectionAsked: string | null;
+  sectionsFound: string[];
+  otherWorks: number;
+  systemsHit: LocusSystem[];
+}): string {
+  const parts: string[] = [];
+  if (o.systemsHit.length > 1) {
+    // The same number is a Bekker page of Aristotle AND a Stephanus page of
+    // Plato. Both sets of leaves are real; taking one for the other would
+    // misattribute a quotation to a different author entirely.
+    parts.push(
+      'This number exists in BOTH systems, so the witnesses below span Aristotle (bekker) and Plato (stephanus). Read the system field on each, and pass system= or work= to narrow.',
+    );
+  }
+  if (!o.count) {
+    parts.push(
+      'No witness holds an anchor at this reference. That means this library has no leaf on which the number is printed — not that the reference is invalid. editions_searched lists what was consulted and the reference range each covers.',
+    );
+  }
+  if (o.otherWorks) {
+    parts.push(
+      `${o.otherWorks} leaf/leaves carry this number under a different work — see other_works_at_this_reference. At a work boundary the running head can lag by a leaf, so if the reference is near the start of the work you asked for, one of those is probably it.`,
+    );
+  }
+  if (o.sectionAsked && o.sectionsFound.some((r) => !r.endsWith(o.sectionAsked as string))) {
+    parts.push(
+      `Matching is by page, not section: you asked for ${o.sectionAsked} and the anchors printed on these leaves read ${o.sectionsFound.join(', ')}. A leaf carries a run of sections and the margin records only one of them, so this is the right leaf — read the section off it.`,
+    );
+  }
+  if (o.ambiguous) {
+    parts.push(
+      'Stephanus numbers restart in each of the three 1578 volumes, so this number occurs in more than one dialogue. Pass work= to disambiguate; the running_head on each witness is the evidence for the work shown.',
+    );
+  }
+  if (o.line) {
+    parts.push(
+      'Line numbers are not resolved: anchors are page- and column-level, so the witness is the right leaf and the line must be found by reading it. Use get_quote on the page.',
+    );
+  }
+  if (o.count) {
+    parts.push(
+      'Every witness is a leaf on which this reference was printed, except where basis is "frame" — those sit between two printed neighbours under a verified constant offset. Nothing is interpolated.',
+    );
+  }
+  return parts.join(' ');
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -564,6 +564,24 @@ async function proposeCollection(args: Record<string, unknown>) {
   return { ok: true, id: result.id, message: result.message || 'Collection proposal sent to the Source Library team for review. Thank you!' };
 }
 
+/**
+ * Resolve a canonical locus — a Bekker or Stephanus reference — to the leaves
+ * that carry it (#3661).
+ *
+ * This exists because a reader fact-checking attributed Aristotle quotes had to
+ * reconstruct the Bekker mapping by hand and then guess which scan page held
+ * 1094 (#3653 item 2). A scan page is a property of one copy; a Bekker number is
+ * how the field cites, and it is stable across every edition.
+ */
+async function getLocus(args: Record<string, unknown>) {
+  const ref = String(args.reference ?? args.ref ?? '').trim();
+  if (!ref) return { error: 'Provide reference, e.g. "1094a8" (Bekker) or "328b" with work: "Republic" (Stephanus).' };
+  const params = new URLSearchParams({ ref });
+  if (args.work) params.set('work', String(args.work));
+  if (args.system) params.set('system', String(args.system));
+  return apiGet('/locus', params);
+}
+
 // ── Tool definitions ───────────────────────────────────────────────
 
 // Shared annotation for all read-only tools
@@ -812,6 +830,21 @@ const TOOLS: Tool[] = [
       required: ['title', 'rationale', 'book_ids'],
     },
   },
+  {
+    name: 'get_locus',
+    title: 'Find a Canonical Reference (Bekker / Stephanus)',
+    description: 'Turn a CANONICAL CITATION into the actual leaves that carry it. Aristotle is cited by Bekker number (1094a8, 1447a) and Plato by Stephanus number (Rep. 328b) — the references scholarship has used for centuries, which survive re-typesetting and are shareable in a way a scan page never is. USE THIS FIRST whenever a passage arrives as a canonical reference rather than a page: do not try to derive the page yourself from a book\'s pagination, which is what produced a wrong guess before this tool existed. Bekker numbers are unique across the whole Aristotelian corpus, so the number alone is enough and it also tells you WHICH WORK you are citing. Stephanus numbers restart in each of the three 1578 volumes, so pass work ("Republic", "Timaeus") — without it the response lists the candidate dialogues instead of choosing one. Returns every witness the library holds: the Greek reference edition and, where we have one, an English translation of the same lines, each with its scan page, a reader URL and a quote_api link — so you can compare the original against a translation at one reference. Then call get_quote with the returned book_id + page for the verbatim text and a citable shortlink. LIMITS, stated plainly: a witness is only returned where the reference is PRINTED on that leaf (or, in the two root editions, where a verified constant offset brackets it) — nothing is interpolated, so an empty result means this library holds no anchored leaf there, NOT that the citation is wrong; editions_searched shows what was consulted and the range each covers. Line numbers (the "8" of 1094a8) are not resolved — you get the right leaf and read the line off it. Two works can share a page where one ends and the next begins (Bekker 184 and 1447 are both such joins), and each leaf is filed by the running head printed on it, so a reference at the very start of a work may come back under its predecessor — always read other_works_at_this_reference before concluding a passage is absent. A bare number that exists in both systems returns Aristotle and Plato leaves together; check the system field on each.',
+    annotations: { title: 'Find a Canonical Reference', ...READ_ONLY },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        reference: { type: 'string', description: 'The canonical reference: "1094a8", "1094a", "1447", "328b". A leading system name is accepted ("Bekker 1094a"), as is a work name ("Rep. 328b").' },
+        work: { type: 'string', description: 'The work or dialogue, when the reference needs it (Plato always does): "Republic", "Timaeus", "Laws", "Nicomachean Ethics", "Poetics". Greek or Latin titles as printed in the editions also resolve.' },
+        system: { type: 'string', description: 'Optional: "bekker" or "stephanus". Inferred from the work when omitted; do not guess it from the number, since the two ranges overlap.' },
+      },
+      required: ['reference'],
+    },
+  },
 ];
 
 // ── Tool dispatch ──────────────────────────────────────────────────
@@ -828,6 +861,7 @@ async function handleToolCall(name: string, args: ToolArgs) {
     case 'list_books': return listBooks(args);
     case 'get_book': return getBook(args);
     case 'list_editions': return listEditions(args);
+    case 'get_locus': return getLocus(args);
     case 'get_book_text': return getBookText(args);
     case 'get_quote': return getQuote(args);
     case 'get_quotes': return getQuotes(args);
@@ -926,7 +960,7 @@ function buildNoResultsHint(tool: string, result: unknown, args: ToolArgs) {
 
 function createServer(reqContext: { ip: string; userAgent: string | null; identity: ApiIdentity }) {
   const server = new Server(
-    { name: 'source-library', version: '4.6.0' },
+    { name: 'source-library', version: '4.7.0' },
     { capabilities: { tools: {}, resources: {} } },
   );
 
@@ -979,6 +1013,7 @@ function createServer(reqContext: { ip: string; userAgent: string | null; identi
         '4. CITE from here, frame from elsewhere. Use Source Library passages as evidence. Use your own knowledge and web search for context, scholarly consensus, author biography, modern interpretation, comparison to texts not in this corpus.',
         '5. EMPTY RESULTS mean "try a different angle" (broaden terms, try the original language, brainstorm adjacent authors) — not "doesn\'t exist."',
         '6. CITE WITH URLS. Every passage you present to a user should include its short_url (e.g. sourcelibrary.org/q/abc123). These are stable, shareable citations — the standard way to refer to a Source Library passage.',
+        '7. A CANONICAL REFERENCE IS NOT A PAGE. If a passage arrives as "1094a8" (Bekker, Aristotle) or "Rep. 328b" (Stephanus, Plato), call get_locus — do not derive the page from a volume\'s pagination. Deriving it is how a previous session guessed wrong.',
       ].join('\n'),
     },
   }));

--- a/src/lib/locus-editions.ts
+++ b/src/lib/locus-editions.ts
@@ -1,0 +1,145 @@
+/**
+ * The editions whose canonical references we publish — a reviewed list, not a
+ * detector.
+ *
+ * #3661's guard is "publish a locus only where corroborated", and the honest way
+ * to hold that line is for a human to have looked at each edition once. Adding a
+ * book here is the review; the extractor then verifies what this file claims and
+ * refuses the book if the data disagrees.
+ *
+ * `expect` fields are **regression pins, not inputs**: they record what a
+ * reviewed extraction produced, so that a re-OCR or a parser change that shifts
+ * the frame fails loudly instead of quietly re-addressing the corpus. They are
+ * never consulted to decide where a locus is — see the note on
+ * `.claude/docs/invariants/tests-that-are-not-guards.md`.
+ */
+
+import type { LocusSystem } from './locus';
+
+export interface LocusEdition {
+  book_id: string;
+  system: LocusSystem;
+  /** Short label for the witness, for the API response. */
+  label: string;
+  /**
+   * True when this edition's OWN pagination is the citation standard (mechanism A
+   * in #3661) — Bekker 1831, Stephanus 1578. Enables frame filling.
+   * False when the reference is printed in the margin beside the text
+   * (mechanism B) — Burnet's OCT, the Oxford translation.
+   */
+  frame: boolean;
+  /** What a reviewed run produced. Drift here is a failure, not a new baseline. */
+  expect?: {
+    /** printed − scan, for a frame edition. */
+    offset?: number;
+    /** Inclusive canonical range the accepted anchors span. */
+    ref_range?: [number, number];
+    /** Floor on accepted anchors, so a silent collapse to a handful is caught. */
+    min_anchors?: number;
+  };
+}
+
+/**
+ * ## The two root editions
+ *
+ * These are the editions the systems are named after, and we hold both complete.
+ * That is what makes #3661 tractable at all: they are the reference frame, and
+ * every other witness is bridged against them by number, not by guesswork.
+ *
+ * ## Why the Oxford translations matter more than their count suggests
+ *
+ * They carry Bekker numbers in the margin AND they are in English, so a reader
+ * who cites `1094a` can be shown the Greek and a translation of the same lines.
+ * That bridge is the deliverable; the Greek frame alone only relocates the
+ * problem.
+ */
+export const LOCUS_EDITIONS: LocusEdition[] = [
+  // ── Aristotle: Bekker ───────────────────────────────────────────
+  {
+    book_id: '69afe65fda5fa12b664a75a2',
+    system: 'bekker',
+    label: 'Bekker, Aristotelis Opera vol. I (Reimer, 1831) — Greek',
+    frame: true,
+    expect: { offset: -16, ref_range: [1, 789], min_anchors: 700 },
+  },
+  {
+    book_id: '69937973b0a84a5763964d43',
+    system: 'bekker',
+    label: 'Bekker, Aristotelis Opera vol. II (Reimer, 1831) — Greek',
+    frame: true,
+    expect: { offset: 784, ref_range: [792, 1462], min_anchors: 600 },
+  },
+  {
+    book_id: '69ae6681b3b0e7bf712d6201',
+    system: 'bekker',
+    label: 'Works of Aristotle vol. 2 (Oxford trans., Ross & Smith) — English',
+    frame: false,
+    expect: { ref_range: [184, 338], min_anchors: 300 },
+  },
+  {
+    book_id: '69ae668db3b0e7bf712d66a9',
+    system: 'bekker',
+    label: 'Meteorologica, De Anima, Parva Naturalia (Oxford trans.) — English',
+    frame: false,
+    expect: { ref_range: [338, 486], min_anchors: 400 },
+  },
+  {
+    book_id: '69ae6694b3b0e7bf712d6885',
+    system: 'bekker',
+    label: 'Historia Animalium (Oxford trans., D’Arcy Thompson) — English',
+    frame: false,
+    expect: { ref_range: [486, 633], min_anchors: 400 },
+  },
+
+  // ── Plato: Stephanus ────────────────────────────────────────────
+  //
+  // Stephanus numbers restart in each of the three 1578 volumes, and citation
+  // practice keys on the dialogue rather than the volume. Work attribution from
+  // the running head is therefore load-bearing here in a way it is not for
+  // Bekker, whose numbers are unique corpus-wide.
+  {
+    book_id: '69b21d36ddb4fa7c305b4440',
+    system: 'stephanus',
+    label: 'Stephanus, Platonis Opera vol. 1 (1578) — Greek/Latin',
+    frame: true,
+    // 54 printed numbers are dropped as off-frame: the volume appends Estienne's
+    // annotations, paginated separately from 1. Those numbers are real and are
+    // not Stephanus references.
+    expect: { offset: -42, ref_range: [1, 483], min_anchors: 400 },
+  },
+  {
+    book_id: '69b21d42ddb4fa7c305b4693',
+    system: 'stephanus',
+    label: 'Stephanus, Platonis Opera vol. 2 (1578) — Greek/Latin',
+    frame: true,
+    expect: { offset: -12, ref_range: [3, 992], min_anchors: 900 },
+  },
+  {
+    book_id: '69b21d4addb4fa7c305b4a88',
+    system: 'stephanus',
+    label: 'Stephanus, Platonis Opera vol. 3 (1578) — Greek/Latin',
+    frame: true,
+    // The weakest frame in the set: 75.9% of printed numbers sit on it, the rest
+    // belong to Serranus's separately-paginated annotations. Above the floor, but
+    // this is the edition to re-check first if anything drifts.
+    expect: { offset: -14, ref_range: [3, 416], min_anchors: 350 },
+  },
+  {
+    book_id: '699376d2b0a84a5763961a97',
+    system: 'stephanus',
+    label: 'Burnet, Platonis Opera (Republic, Timaeus, Critias), OCT 1902 — Greek',
+    frame: false,
+    expect: { ref_range: [18, 621], min_anchors: 550 },
+  },
+  {
+    book_id: '69937734b0a84a57639630fa',
+    system: 'stephanus',
+    label: 'Burnet, Platonis Opera (Laws, Epinomis, Letters, Definitions), OCT 1907 — Greek',
+    frame: false,
+    expect: { ref_range: [309, 992], min_anchors: 650 },
+  },
+];
+
+export function locusEdition(bookId: string): LocusEdition | undefined {
+  return LOCUS_EDITIONS.find((e) => e.book_id === bookId);
+}

--- a/src/lib/locus-works.ts
+++ b/src/lib/locus-works.ts
@@ -1,0 +1,200 @@
+/**
+ * Names for the works our locus anchors sit inside — a translation table, and
+ * nothing more.
+ *
+ * ## Why a table exists at all, and why it cannot misaddress
+ *
+ * A Bekker number is unique across the whole Aristotelian corpus, so resolving
+ * `1094a8` needs no names: the number finds the leaf. A Stephanus number is not
+ * unique — it restarts in each of the three 1578 volumes, so `328b` is a page of
+ * the *Republic*, of the *Cratylus* and of the *Eryxias*, and citation practice
+ * disambiguates by naming the dialogue. That name has to be resolvable.
+ *
+ * The rows below therefore map **head strings printed on the leaves** to a slug
+ * and an English label. They assert only that `ΠΟΛΙΤΕΙΑ` and `DE REPVBL` are the
+ * same dialogue — a claim a reader can check against the running head itself.
+ * They never carry a page range, so a wrong row cannot move a citation to a
+ * different leaf; it can only mislabel one. Ranges stay derived
+ * (`locus_books.segments`), and `scripts/locus/verify-locus-works.mjs` checks
+ * every row against them: if two editions we equate here cover ranges that do not
+ * agree, that is reported.
+ *
+ * ## Where the head strings came from
+ *
+ * Observed, not invented: every `heads` entry below appears in the extractor's own
+ * output for one of the registered editions. The English `label` is the only new
+ * information in this file.
+ *
+ * Heads are matched after `locusWorkKey` normalisation (upper case, accents kept,
+ * letter-spacing collapsed, trailing book numerals stripped) and by prefix, so
+ * `ΠΟΛΙΤΕΙΑΣ` matches the entry `ΠΟΛΙΤΕΙΑ`.
+ */
+
+import type { LocusSystem } from './locus';
+
+export interface LocusWork {
+  slug: string;
+  label: string;
+  system: LocusSystem;
+  /** Running heads observed for this work, normalised. Matched by prefix. */
+  heads: string[];
+  /** What a caller might type. Matched case- and accent-insensitively. */
+  aliases: string[];
+}
+
+/**
+ * Aristotle — the Bekker frame. Names here are a convenience for callers who
+ * would rather write "Nicomachean Ethics 1103b" than "1103b"; the number alone
+ * always works.
+ */
+const ARISTOTLE: LocusWork[] = [
+  { slug: 'categories', label: 'Categories', system: 'bekker', heads: ['ΚΑΤΗΓΟΡΙΑΙ'], aliases: ['categories', 'categoriae', 'cat'] },
+  { slug: 'de-interpretatione', label: 'De Interpretatione', system: 'bekker', heads: ['ΠΕΡΙ ΕΡΜΗΝΕΙΑΣ'], aliases: ['de interpretatione', 'on interpretation', 'int'] },
+  { slug: 'prior-analytics', label: 'Prior Analytics', system: 'bekker', heads: ['ΑΝΑΛΥΤΙΚΩΝ ΠΡΟΤΕΡΩΝ'], aliases: ['prior analytics', 'analytica priora', 'apr'] },
+  { slug: 'posterior-analytics', label: 'Posterior Analytics', system: 'bekker', heads: ['ΑΝΑΛΥΤΙΚΩΝ ΥΣΤΕΡΩΝ'], aliases: ['posterior analytics', 'analytica posteriora', 'apo'] },
+  { slug: 'topics', label: 'Topics', system: 'bekker', heads: ['ΤΟΠΙΚΩΝ'], aliases: ['topics', 'topica', 'top'] },
+  { slug: 'sophistical-refutations', label: 'Sophistical Refutations', system: 'bekker', heads: ['ΠΕΡΙ ΣΟΦΙΣΤΙΚΩΝ ΕΛΕΓΧΩΝ'], aliases: ['sophistical refutations', 'de sophisticis elenchis', 'soph el'] },
+  { slug: 'physics', label: 'Physics', system: 'bekker', heads: ['ΦΥΣΙΚΗΣ ΑΚΡΟΑΣΕΩΣ', 'PHYSICA'], aliases: ['physics', 'physica', 'phys'] },
+  { slug: 'de-caelo', label: 'De Caelo (On the Heavens)', system: 'bekker', heads: ['ΠΕΡΙ ΟΥΡΑΝΟΥ', 'DE CAELO'], aliases: ['de caelo', 'on the heavens', 'cael'] },
+  { slug: 'de-generatione-et-corruptione', label: 'De Generatione et Corruptione', system: 'bekker', heads: ['ΠΕΡΙ ΓΕΝΕΣΕΩΣ ΚΑΙ ΦΘΟΡΑΣ', 'DE GENERATIONE ET CORRUPTIONE'], aliases: ['de generatione et corruptione', 'on generation and corruption', 'gc'] },
+  { slug: 'meteorology', label: 'Meteorologica', system: 'bekker', heads: ['ΜΕΤΕΩΡΟΛΟΓΙΚΩΝ', 'METEOROLOGICA'], aliases: ['meteorology', 'meteorologica', 'mete'] },
+  { slug: 'de-mundo', label: 'De Mundo', system: 'bekker', heads: ['ΠΕΡΙ ΚΟΣΜΟΥ', 'DE MUNDO'], aliases: ['de mundo', 'on the cosmos'] },
+  { slug: 'de-anima', label: 'De Anima (On the Soul)', system: 'bekker', heads: ['ΠΕΡΙ ΨΥΧΗΣ', 'DE ANIMA'], aliases: ['de anima', 'on the soul', 'an'] },
+  { slug: 'de-sensu', label: 'De Sensu et Sensibilibus', system: 'bekker', heads: ['ΠΕΡΙ ΑΙΣΘΗΣΕΩΣ ΚΑΙ ΑΙΣΘΗΤΩΝ', 'DE SENSU'], aliases: ['de sensu', 'on sense and sensible objects'] },
+  { slug: 'de-memoria', label: 'De Memoria et Reminiscentia', system: 'bekker', heads: ['ΠΕΡΙ ΜΝΗΜΗΣ ΚΑΙ ΑΝΑΜΝΗΣΕΩΣ', 'DE MEMORIA ET REMINISCENTIA'], aliases: ['de memoria', 'on memory'] },
+  { slug: 'de-somno', label: 'De Somno et Vigilia', system: 'bekker', heads: ['ΠΕΡΙ ΥΠΝΟΥ ΚΑΙ ΕΓΡΗΓΟΡΣΕΩΣ', 'DE SOMNO ET VIGILIA'], aliases: ['de somno', 'on sleep'] },
+  { slug: 'de-insomniis', label: 'De Insomniis', system: 'bekker', heads: ['ΠΕΡΙ ΕΝΥΠΝΙΩΝ', 'DE SOMNIIS'], aliases: ['de insomniis', 'de somniis', 'on dreams'] },
+  { slug: 'de-divinatione-per-somnum', label: 'De Divinatione per Somnum', system: 'bekker', heads: ['DE DIVINATIONE PER SOMNUM'], aliases: ['de divinatione per somnum', 'on divination in sleep'] },
+  { slug: 'de-longitudine-vitae', label: 'De Longitudine et Brevitate Vitae', system: 'bekker', heads: ['ΠΕΡΙ ΜΑΚΡΟΒΙΟΤΗΤΟΣ ΚΑΙ ΒΡΑΧΥΒΙΟΤΗΤΟΣ', 'DE LONGITUDINE ET BREVITATE VITAE'], aliases: ['de longitudine', 'on length and shortness of life'] },
+  { slug: 'de-iuventute', label: 'De Iuventute et Senectute', system: 'bekker', heads: ['DE IUVENTUTE ET SENECTUTE'], aliases: ['de iuventute', 'on youth and old age'] },
+  { slug: 'de-respiratione', label: 'De Respiratione', system: 'bekker', heads: ['ΠΕΡΙ ΑΝΑΠΝΟΗΣ', 'DE RESPIRATIONE'], aliases: ['de respiratione', 'on respiration'] },
+  { slug: 'de-spiritu', label: 'De Spiritu', system: 'bekker', heads: ['ΠΕΡΙ ΠΝΕΥΜΑΤΟΣ', 'DE SPIRITU'], aliases: ['de spiritu', 'on breath'] },
+  { slug: 'historia-animalium', label: 'Historia Animalium', system: 'bekker', heads: ['ΠΕΡΙ ΤΑ ΖΩΑ ΙΣΤΟΡΙΩΝ', 'HISTORIA ANIMALIUM'], aliases: ['historia animalium', 'history of animals', 'ha'] },
+  { slug: 'de-partibus-animalium', label: 'De Partibus Animalium', system: 'bekker', heads: ['ΠΕΡΙ ΖΩΩΝ ΜΟΡΙΩΝ'], aliases: ['de partibus animalium', 'parts of animals', 'pa'] },
+  { slug: 'de-motu-animalium', label: 'De Motu Animalium', system: 'bekker', heads: ['ΠΕΡΙ ΖΩΩΝ ΚΙΝΗΣΕΩΣ'], aliases: ['de motu animalium', 'movement of animals'] },
+  { slug: 'de-incessu-animalium', label: 'De Incessu Animalium', system: 'bekker', heads: ['ΠΕΡΙ ΠΟΡΕΙΑΣ ΖΩΩΝ'], aliases: ['de incessu animalium', 'progression of animals'] },
+  { slug: 'de-generatione-animalium', label: 'De Generatione Animalium', system: 'bekker', heads: ['ΠΕΡΙ ΖΩΩΝ ΓΕΝΕΣΕΩΣ'], aliases: ['de generatione animalium', 'generation of animals', 'ga'] },
+  { slug: 'de-coloribus', label: 'De Coloribus', system: 'bekker', heads: ['ΠΕΡΙ ΧΡΩΜΑΤΩΝ'], aliases: ['de coloribus', 'on colours'] },
+  { slug: 'de-audibilibus', label: 'De Audibilibus', system: 'bekker', heads: ['ΕΚ ΤΟΥ ΠΕΡΙ ΑΚΟΥΣΤΩΝ'], aliases: ['de audibilibus', 'on things heard'] },
+  { slug: 'physiognomonica', label: 'Physiognomonica', system: 'bekker', heads: ['ΦΥΣΙΟΓΝΩΜΟΝΙΚΑ'], aliases: ['physiognomonica', 'physiognomics'] },
+  { slug: 'de-plantis', label: 'De Plantis', system: 'bekker', heads: ['ΠΕΡΙ ΦΥΤΩΝ'], aliases: ['de plantis', 'on plants'] },
+  { slug: 'mirabilia', label: 'De Mirabilibus Auscultationibus', system: 'bekker', heads: ['ΠΕΡΙ ΘΑΥΜΑΣΙΩΝ ΑΚΟΥΣΜΑΤΩΝ'], aliases: ['mirabilia', 'de mirabilibus auscultationibus', 'marvellous things heard'] },
+  { slug: 'mechanica', label: 'Mechanica', system: 'bekker', heads: ['ΜΗΧΑΝΙΚΑ'], aliases: ['mechanica', 'mechanics'] },
+  { slug: 'problemata', label: 'Problemata', system: 'bekker', heads: ['ΠΡΟΒΛΗΜΑΤΩΝ'], aliases: ['problemata', 'problems'] },
+  { slug: 'de-lineis-insecabilibus', label: 'De Lineis Insecabilibus', system: 'bekker', heads: ['ΠΕΡΙ ΑΤΟΜΩΝ ΓΡΑΜΜΩΝ'], aliases: ['de lineis insecabilibus', 'on indivisible lines'] },
+  { slug: 'de-xenophane', label: 'De Melisso, Xenophane, Gorgia', system: 'bekker', heads: ['ΠΕΡΙ ΞΕΝΟΦΑΝΟΥΣ'], aliases: ['de xenophane', 'de melisso xenophane gorgia'] },
+  { slug: 'metaphysics', label: 'Metaphysics', system: 'bekker', heads: ['ΤΩΝ ΜΕΤΑ ΤΑ ΦΥΣΙΚΑ'], aliases: ['metaphysics', 'metaphysica', 'metaph'] },
+  { slug: 'nicomachean-ethics', label: 'Nicomachean Ethics', system: 'bekker', heads: ['ΗΘΙΚΩΝ ΝΙΚΟΜΑΧΕΙΩΝ'], aliases: ['nicomachean ethics', 'ethica nicomachea', 'ne', 'en'] },
+  { slug: 'magna-moralia', label: 'Magna Moralia', system: 'bekker', heads: ['ΗΘΙΚΩΝ ΜΕΓΑΛΩΝ'], aliases: ['magna moralia', 'mm'] },
+  { slug: 'eudemian-ethics', label: 'Eudemian Ethics', system: 'bekker', heads: ['ΗΘΙΚΩΝ ΕΥΔΗΜΙΩΝ'], aliases: ['eudemian ethics', 'ethica eudemia', 'ee'] },
+  { slug: 'de-virtutibus', label: 'De Virtutibus et Vitiis', system: 'bekker', heads: ['ΠΕΡΙ ΑΡΕΤΩΝ ΚΑΙ ΚΑΚΙΩΝ'], aliases: ['de virtutibus et vitiis', 'on virtues and vices'] },
+  { slug: 'politics', label: 'Politics', system: 'bekker', heads: ['ΠΟΛΙΤΙΚΩΝ'], aliases: ['politics', 'politica', 'pol'] },
+  { slug: 'oeconomica', label: 'Oeconomica', system: 'bekker', heads: ['ΟΙΚΟΝΟΜΙΚΩΝ'], aliases: ['oeconomica', 'economics'] },
+  { slug: 'rhetoric', label: 'Rhetoric', system: 'bekker', heads: ['ΡΗΤΟΡΙΚΗ'], aliases: ['rhetoric', 'rhetorica', 'rhet'] },
+  { slug: 'rhetorica-ad-alexandrum', label: 'Rhetorica ad Alexandrum', system: 'bekker', heads: ['ΠΡΟΣ ΑΛΕΞΑΝΔΡΟΝ'], aliases: ['rhetorica ad alexandrum', 'rhet alex'] },
+  { slug: 'poetics', label: 'Poetics', system: 'bekker', heads: ['ΠΕΡΙ ΠΟΙΗΤΙΚΗΣ'], aliases: ['poetics', 'poetica', 'poet'] },
+];
+
+/**
+ * Plato — the Stephanus frame. Here the names are load-bearing, because the
+ * number alone is ambiguous between the three 1578 volumes.
+ *
+ * Latin heads come from Stephanus itself, Greek heads from Burnet's OCT. A row
+ * carrying both is the bridge that lets `Republic 328b` find the 1578 leaf and
+ * the 1902 leaf in one call.
+ */
+const PLATO: LocusWork[] = [
+  { slug: 'euthyphro', label: 'Euthyphro', system: 'stephanus', heads: ['EVTHYPHRO'], aliases: ['euthyphro', 'euthphr'] },
+  { slug: 'apology', label: 'Apology', system: 'stephanus', heads: ['APOLOGIA'], aliases: ['apology', 'apologia', 'apol'] },
+  { slug: 'crito', label: 'Crito', system: 'stephanus', heads: ['CRITO'], aliases: ['crito', 'crit'] },
+  { slug: 'phaedo', label: 'Phaedo', system: 'stephanus', heads: ['PHAEDO', 'PHÆDO', 'ΦΑΙΔΩΝ'], aliases: ['phaedo', 'phd'] },
+  { slug: 'theages', label: 'Theages', system: 'stephanus', heads: ['THEAGES'], aliases: ['theages'] },
+  { slug: 'lovers', label: 'Amatores (Lovers)', system: 'stephanus', heads: ['AMATORES'], aliases: ['amatores', 'lovers', 'rival lovers'] },
+  { slug: 'theaetetus', label: 'Theaetetus', system: 'stephanus', heads: ['THEAETETVS', 'ΘΕΑΙΤΗΤΟΣ'], aliases: ['theaetetus', 'tht'] },
+  { slug: 'sophist', label: 'Sophist', system: 'stephanus', heads: ['SOPHISTA', 'ΣΟΦΙΣΤΗΣ'], aliases: ['sophist', 'sophista', 'soph'] },
+  { slug: 'euthydemus', label: 'Euthydemus', system: 'stephanus', heads: ['EVTHYDEMVS'], aliases: ['euthydemus', 'euthd'] },
+  { slug: 'protagoras', label: 'Protagoras', system: 'stephanus', heads: ['PROTAGORAS', 'ΠΡΩΤΑΓΟΡΑΣ'], aliases: ['protagoras', 'prt'] },
+  { slug: 'hippias', label: 'Hippias Minor', system: 'stephanus', heads: ['HIPPIAS'], aliases: ['hippias minor', 'hippias'] },
+  { slug: 'cratylus', label: 'Cratylus', system: 'stephanus', heads: ['CRATYLVS', 'ΚΡΑΤΥΛΟΣ'], aliases: ['cratylus', 'crat'] },
+  { slug: 'gorgias', label: 'Gorgias', system: 'stephanus', heads: ['GORGIAS', 'ΓΟΡΓΙΑΣ'], aliases: ['gorgias', 'grg'] },
+  { slug: 'philebus', label: 'Philebus', system: 'stephanus', heads: ['PHILEBVS', 'ΦΙΛΗΒΟΣ'], aliases: ['philebus', 'phlb'] },
+  { slug: 'meno', label: 'Meno', system: 'stephanus', heads: ['MENO', 'ΜΕΝΩΝ'], aliases: ['meno', 'men'] },
+  { slug: 'alcibiades', label: 'Alcibiades', system: 'stephanus', heads: ['ALCIBIADES', 'ΑΛΚΙΒΙΑΔΗΣ'], aliases: ['alcibiades', 'alc'] },
+  { slug: 'charmides', label: 'Charmides', system: 'stephanus', heads: ['CHARMIDES', 'ΧΑΡΜΙΔΗΣ'], aliases: ['charmides', 'chrm'] },
+  { slug: 'laches', label: 'Laches', system: 'stephanus', heads: ['LACHES', 'ΛΑΧΗΣ'], aliases: ['laches', 'lach'] },
+  { slug: 'lysis', label: 'Lysis', system: 'stephanus', heads: ['LYSIS', 'ΛΥΣΙΣ'], aliases: ['lysis', 'lys'] },
+  { slug: 'hipparchus', label: 'Hipparchus', system: 'stephanus', heads: ['HIPPARCHVS'], aliases: ['hipparchus', 'hipparch'] },
+  { slug: 'menexenus', label: 'Menexenus', system: 'stephanus', heads: ['MENEXENVS', 'ΜΕΝΕΞΕΝΟΣ'], aliases: ['menexenus', 'menex'] },
+  { slug: 'statesman', label: 'Statesman (Politicus)', system: 'stephanus', heads: ['POLITICVS', 'ΠΟΛΙΤΙΚΟΣ'], aliases: ['statesman', 'politicus', 'plt'] },
+  { slug: 'minos', label: 'Minos', system: 'stephanus', heads: ['MINOS', 'ΜΙΝΩΣ'], aliases: ['minos'] },
+  { slug: 'republic', label: 'Republic', system: 'stephanus', heads: ['DE REPVB', 'DE REPVBL', 'ΠΟΛΙΤΕΙΑ'], aliases: ['republic', 'respublica', 'de republica', 'politeia', 'rep'] },
+  { slug: 'laws', label: 'Laws', system: 'stephanus', heads: ['DE LEGIBVS', 'ΝΟΜΩΝ', 'ΝΟΜΟΙ'], aliases: ['laws', 'de legibus', 'leg', 'nomoi'] },
+  { slug: 'epinomis', label: 'Epinomis', system: 'stephanus', heads: ['EPINOMIS', 'ΕΠΙΝΟΜΙΣ'], aliases: ['epinomis', 'epin'] },
+  { slug: 'timaeus', label: 'Timaeus', system: 'stephanus', heads: ['TIMAEVS', 'ΤΙΜΑΙΟΣ'], aliases: ['timaeus', 'ti', 'tim'] },
+  { slug: 'critias', label: 'Critias', system: 'stephanus', heads: ['CRITIAS', 'ΚΡΙΤΙΑΣ'], aliases: ['critias', 'criti'] },
+  { slug: 'parmenides', label: 'Parmenides', system: 'stephanus', heads: ['PARMENIDES', 'ΠΑΡΜΕΝΙΔΗΣ'], aliases: ['parmenides', 'prm'] },
+  { slug: 'symposium', label: 'Symposium', system: 'stephanus', heads: ['CONVIVIVM', 'ΣΥΜΠΟΣΙΟΝ'], aliases: ['symposium', 'convivium', 'smp'] },
+  { slug: 'phaedrus', label: 'Phaedrus', system: 'stephanus', heads: ['PHAEDRVS', 'PHAEDRUS', 'ΦΑΙΔΡΟΣ'], aliases: ['phaedrus', 'phdr'] },
+  { slug: 'hippias-major', label: 'Hippias Major', system: 'stephanus', heads: ['HIPPIAS MAIOR', 'HIPPIASMAIOR'], aliases: ['hippias major', 'hippias maior'] },
+  { slug: 'letters', label: 'Letters (Epistulae)', system: 'stephanus', heads: ['EPISTOLA', 'EPISTOLAE', 'ΕΠΙΣΤΟΛΗ', 'ΕΠΙΣΤΟΛΑΙ'], aliases: ['letters', 'epistles', 'epistulae', 'epistolae', 'ep'] },
+  { slug: 'axiochus', label: 'Axiochus', system: 'stephanus', heads: ['AXIOCHVS', 'ΑΞΙΟΧΟΣ'], aliases: ['axiochus'] },
+  { slug: 'de-iusto', label: 'De Iusto (On Justice)', system: 'stephanus', heads: ['DE IVSTO', 'ΠΕΡΙ ΔΙΚΑΙΟΥ'], aliases: ['de iusto', 'on justice'] },
+  { slug: 'de-virtute', label: 'De Virtute (On Virtue)', system: 'stephanus', heads: ['DE VIRTVTE', 'ΠΕΡΙ ΑΡΕΤΗΣ'], aliases: ['de virtute', 'on virtue'] },
+  { slug: 'demodocus', label: 'Demodocus', system: 'stephanus', heads: ['DEMODOCVS', 'ΔΗΜΟΔΟΚΟΣ'], aliases: ['demodocus'] },
+  { slug: 'sisyphus', label: 'Sisyphus', system: 'stephanus', heads: ['SISYPHVS', 'ΣΙΣΥΦΟΣ'], aliases: ['sisyphus'] },
+  { slug: 'eryxias', label: 'Eryxias', system: 'stephanus', heads: ['ERYXIAS', 'ΕΡΥΞΙΑΣ'], aliases: ['eryxias'] },
+  { slug: 'clitopho', label: 'Clitopho', system: 'stephanus', heads: ['CLITOPHO', 'ΚΛΕΙΤΟΦΩΝ'], aliases: ['clitopho', 'cleitophon', 'clitophon'] },
+  { slug: 'definitions', label: 'Definitions (Horoi)', system: 'stephanus', heads: ['DEFINITIONES', 'ΟΡΟΙ'], aliases: ['definitions', 'definitiones', 'horoi'] },
+  { slug: 'timaeus-locrus', label: 'Timaeus Locrus, De Anima Mundi', system: 'stephanus', heads: ['TIMAEI LOCRI', 'DE ANIMA MVNDI'], aliases: ['timaeus locrus', 'de anima mundi'] },
+];
+
+export const LOCUS_WORKS: LocusWork[] = [...ARISTOTLE, ...PLATO];
+
+function fold(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/\p{M}+/gu, '')
+    .toUpperCase()
+    .replace(/[^\p{L}\p{N} ]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** The work a caller's name refers to, or null. Accent- and case-insensitive. */
+export function findWorkByName(name: string, system?: LocusSystem | null): LocusWork | null {
+  const q = fold(name);
+  if (!q) return null;
+  const pool = system ? LOCUS_WORKS.filter((w) => w.system === system) : LOCUS_WORKS;
+  return (
+    pool.find((w) => w.aliases.some((a) => fold(a) === q) || fold(w.label) === q || w.slug === q.toLowerCase().replace(/ /g, '-')) ||
+    pool.find((w) => w.heads.some((h) => fold(h) === q)) ||
+    // Last resort: a caller typing part of a name. Longest match wins so
+    // "hippias major" cannot be answered by the "hippias" row.
+    pool
+      .filter((w) => [...w.aliases, w.label].some((a) => fold(a).startsWith(q)))
+      .sort((a, b) => b.label.length - a.label.length)[0] ||
+    null
+  );
+}
+
+/**
+ * The work whose observed running head this anchor sits under.
+ *
+ * Prefix matching, longest first: the head `ΠΟΛΙΤΕΙΑΣ` should resolve to
+ * `ΠΟΛΙΤΕΙΑ` (Republic) and the head `ΠΟΛΙΤΙΚΟΣ` must NOT — which is why the
+ * longest matching head wins rather than the first.
+ */
+export function findWorkByHead(head: string | null | undefined, system: LocusSystem): LocusWork | null {
+  if (!head) return null;
+  const h = fold(head);
+  let best: LocusWork | null = null;
+  let bestLen = 0;
+  for (const w of LOCUS_WORKS) {
+    if (w.system !== system) continue;
+    for (const cand of w.heads) {
+      const c = fold(cand);
+      if ((h === c || h.startsWith(c) || c.startsWith(h)) && c.length > bestLen) { best = w; bestLen = c.length; }
+    }
+  }
+  return best;
+}

--- a/src/lib/locus.ts
+++ b/src/lib/locus.ts
@@ -1,0 +1,622 @@
+/**
+ * Canonical loci — addressing a passage the way scholarship does, not the way
+ * one scan happens to be paginated.
+ *
+ * ## The problem (#3661, surfaced through MCP in #3653 item 2)
+ *
+ * Source Library addresses everything by scan page, which is a property of one
+ * copy and shareable with nobody. Scholarship addresses Aristotle by Bekker
+ * number and Plato by Stephanus number — agreed centuries ago precisely so a
+ * citation survives re-typesetting. An agent verifying attributed Aristotle
+ * quotes had to reconstruct the Bekker mapping by hand and then guess:
+ * *"deriving page ≈ 310 + (Bekker − 1094), and guessing."*
+ *
+ * ## What this module does, and what it refuses to do
+ *
+ * It reads references that are **printed on the page** out of the OCR's
+ * `<page-num>` tag, and pairs them with the scan page they were printed on.
+ * There is no fitting, no interpolation and no external reference table in the
+ * addressing path: a locus is published only where a number was read off the
+ * leaf, or (in a root edition whose scan→printed offset is constant and
+ * verified) where the two neighbouring leaves bracket it exactly.
+ *
+ * Two mechanisms put a canonical number on a page and they are NOT comparable —
+ * `#3661` records that conflating them scored the more valuable one worst:
+ *
+ *   A. the book's own pagination IS the citation standard (Bekker 1831,
+ *      Stephanus 1578 — the editions the systems are named after)
+ *   B. the canonical reference is printed in the margin beside the text
+ *      (the Oxford/OCT convention: Burnet, the Oxford translation)
+ *
+ * Both are handled by the same acceptance rule below, and every anchor records
+ * which mechanism produced it, so no coverage number ever sums the two.
+ *
+ * ## Why work identity comes from the running head
+ *
+ * A Bekker number is unique across the whole Aristotelian corpus, so it needs no
+ * work. A Stephanus number does not: it repeats between volumes, and citation
+ * practice keys on the dialogue ("Rep. 328b"). Rather than assert a
+ * dialogue→page table from memory — the exact failure #3661 corrects in its own
+ * opening — the work comes from the running head the printer put on every leaf,
+ * the same evidence `src/lib/contains-works.ts` uses for "what does this volume
+ * contain" (#3652), whose doc comment names this issue as its next step. Head
+ * normalisation is shared with that module; the work/division decision is not
+ * (see `locusWorkKey`). The canonical range of each work is then DERIVED by
+ * joining head runs to the references read inside them, and two editions agreeing
+ * on a range is corroboration from two witnesses.
+ *
+ * The derived ranges were checked against the values a classicist would recognise
+ * — Physics 184–267, Metaphysics 980–1093, NE 1094–1181, Politics 1252–1342,
+ * Poetics 1447–1462, Republic 327–621, Laws 624–969 — and they agree. That
+ * agreement is a CHECK on the derivation, never its source: nothing in the
+ * addressing path consults a range table.
+ */
+
+import { normalizeHeader } from './contains-works';
+import { nameFormsFor } from './classical-name-forms';
+
+export type LocusSystem = 'bekker' | 'stephanus';
+
+/** One canonical reference. `section` is a Bekker column (a|b) or a Stephanus section (a–e). */
+export interface LocusRef {
+  page: number;
+  section: string | null;
+  line: number | null;
+}
+
+/**
+ * How an anchor's reference came to be.
+ *
+ * `printed` — read off that leaf. `frame` — the leaf's own number was unreadable
+ * or misread, and the leaf sits between two `printed` neighbours whose values
+ * bracket it exactly under a constant, verified offset. Nothing else is emitted.
+ * These are counted separately everywhere; see the guard in #3661.
+ */
+export type AnchorBasis = 'printed' | 'frame';
+
+export interface LocusAnchor {
+  page_number: number;
+  ref: LocusRef;
+  basis: AnchorBasis;
+  /** The running head this page sits under, normalised. Null when no head governs it. */
+  work_header: string | null;
+  /**
+   * The work beginning within two leaves, when this leaf carries no head of its
+   * own. A work's opening leaves can sit under the previous work's head, so both
+   * candidates are recorded rather than one being guessed.
+   */
+  work_header_alt: string | null;
+  /** The `<page-num>` payload exactly as OCR'd, so a reviewer can check the parse. */
+  raw: string | null;
+}
+
+// ── Reference parsing ──────────────────────────────────────────────
+
+const SUPERSCRIPT_LETTERS: Record<string, string> = {
+  'ᵃ': 'a', 'ᵇ': 'b', 'ᶜ': 'c', 'ᵈ': 'd', 'ᵉ': 'e',
+  // U+00AA, the feminine ordinal — what OCR returns for a superscript a on
+  // `339ª` in the Meteorologica volume.
+  'ª': 'a',
+};
+
+/**
+ * Flatten the many ways OCR renders a column letter onto a plain letter.
+ *
+ * Observed in the pilot set on a single book (`69ae6681…`, the Oxford Physics):
+ * `184^a`, `185ᵃ`, `186<sup>a</sup>`, `339ª`. A parser that handles only one of
+ * them silently drops two thirds of that book's anchors.
+ */
+export function normaliseRefText(raw: string): string {
+  let s = String(raw);
+  s = s.replace(/<sup>\s*([a-eA-E])\s*<\/sup>/g, '$1');
+  s = s.replace(/[ᵃ-ᵉªᵇ]/g, (ch) => SUPERSCRIPT_LETTERS[ch] ?? ch);
+  s = s.replace(/\^\s*([a-eA-E])/g, '$1');
+  // Any other markup (<unclear>, <insert>…) becomes a separator rather than
+  // being deleted, so `<unclear>553 a, b</unclear>` cannot fuse into one token.
+  s = s.replace(/<[^>]*>/g, ' ');
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Every reference candidate in a `<page-num>` payload, in printed order.
+ *
+ * A payload is not always one reference. Real examples from the OCT volumes:
+ * `407 e - 408 c` (the span the leaf covers), `409 e, 410` (a section end and a
+ * page start), `184b, 185a`. Both endpoints are anchors — the leaf genuinely
+ * carries both — so both are returned and the caller decides.
+ *
+ * Returns [] when nothing numeric is present: roman front matter (`vii`), a
+ * library shelfmark, an empty tag.
+ */
+export function parseRefCandidates(raw: string | null | undefined): LocusRef[] {
+  if (!raw) return [];
+  const s = normaliseRefText(raw);
+  const out: LocusRef[] = [];
+  // A number, optionally followed by a section letter. The letter must not be
+  // glued to a longer word (`1900 v. 4` must not read as section "v").
+  const re = /(\d{1,4})\s*([a-e])?(?![\p{L}\d])/giu;
+  for (const m of s.matchAll(re)) {
+    out.push({ page: Number(m[1]), section: m[2] ? m[2].toLowerCase() : null, line: null });
+  }
+  return out;
+}
+
+/** Sortable key: page, then section, then line. */
+export function refSortKey(ref: LocusRef): number {
+  const sec = ref.section ? ref.section.charCodeAt(0) - 96 : 0;
+  return ref.page * 10000 + sec * 100 + Math.min(ref.line ?? 0, 99);
+}
+
+export function formatRef(ref: LocusRef): string {
+  return `${ref.page}${ref.section ?? ''}${ref.line ? `.${ref.line}` : ''}`;
+}
+
+// ── Query parsing ──────────────────────────────────────────────────
+
+export interface LocusQuery {
+  system: LocusSystem | null;
+  /** Free text before the number — a work name or an abbreviation, unresolved. */
+  work: string | null;
+  ref: LocusRef;
+}
+
+/**
+ * Parse what a caller actually types: `1094a8`, `1094 a 8`, `Bekker 1094a`,
+ * `Rep. 328b`, `Republic 328 b`, `Nicomachean Ethics 1103b`.
+ *
+ * The system is named only when the caller says so or when the shape gives it
+ * away; otherwise it stays null and resolution decides from the anchors. Do not
+ * infer a system from the number's magnitude — Stephanus and Bekker ranges
+ * overlap almost completely.
+ */
+export function parseLocusQuery(input: string): LocusQuery | null {
+  const s = normaliseRefText(String(input || '')).trim();
+  if (!s) return null;
+
+  let system: LocusSystem | null = null;
+  let rest = s;
+  const sysMatch = rest.match(/^(bekker|stephanus|steph)\b[\s.:]*/i);
+  if (sysMatch) {
+    system = /^steph/i.test(sysMatch[1]) ? 'stephanus' : 'bekker';
+    rest = rest.slice(sysMatch[0].length);
+  }
+
+  // page + optional section + optional line, at the END of the string
+  const m = rest.match(/(\d{1,4})\s*([a-eA-E])?\s*[.,]?\s*(\d{1,3})?\s*$/);
+  if (!m) return null;
+  const work = rest.slice(0, m.index).replace(/[\s.,:]+$/, '').trim() || null;
+  return {
+    system,
+    work,
+    ref: {
+      page: Number(m[1]),
+      section: m[2] ? m[2].toLowerCase() : null,
+      line: m[3] ? Number(m[3]) : null,
+    },
+  };
+}
+
+// ── Which running head names a work ────────────────────────────────
+
+/**
+ * Fold accents so a Greek head can be compared with a Greek name form.
+ *
+ * `normalizeHeader` strips Latin punctuation and uppercases, which turns
+ * `Πλάτωνος` into `ΠΛΆΤΩΝΟΣ` — not equal to the `ΠΛΑΤΩΝΟΣ` printed on the leaf.
+ * Without folding, the author's own name is accepted as a work and the Burnet
+ * Republic reports 363 anchors under the head "ΠΛΑΤΩΝΟΣ", which is not a work.
+ */
+function foldDiacritics(s: string): string {
+  return s.normalize('NFD').replace(/\p{M}+/gu, '').normalize('NFC');
+}
+
+/**
+ * A head that names a division of a work rather than a work.
+ *
+ * These matter more here than in `contains-works.ts`, because a division head
+ * does not merely add a spurious row — it *cuts the work's reference run in two*,
+ * and each fragment is then chained separately. Burnet's Republic heads its rectos
+ * `ΠΟΛΙΤΕΙΑΣ Α I` … `ΠΟΛΙΤΕΙΑΣ Ι Χ`, and the Oxford translation heads
+ * `BOOK IV 8`; left alone, one dialogue became eleven segments.
+ */
+const DIVISION_HEAD =
+  /^(BOOK|CHAPTER|CHAP|PART|SECTION|LIBER|LIB|CAPUT|CAP|ΒΙΒΛΙΟΝ|ΤΜΗΜΑ)\b/i;
+
+const NOT_A_WORK_HEAD =
+  /^(INTRODUCTION|INTROD|PREFACE|PRAEFATIO|CONTENTS|INDEX|ERRATA|CORRIGENDA|ADVERTISEMENT|APPENDIX|NOTES?|ADNOTATIONES|ANNOT\b|DEDICATION|PROLEGOMENA|ΠΙΝΑΞ|ΠΡΟΛΟΓΟΣ|BIBLIOGRAPH)/i;
+
+/**
+ * The work a running head names, or null if it names none.
+ *
+ * Built on `normalizeHeader` (#3652 — letter-spacing collapse and trailing book
+ * numerals) with three additions this use needs:
+ *
+ *   - a trailing numeral PAIR: a Greek book letter followed by its roman
+ *     equivalent, `ΝΟΜΩΝ Θ IX` → `ΝΟΜΩΝ`. `normalizeHeader` cannot strip these
+ *     because its guard refuses to strip a numeral preceded by a single letter —
+ *     the guard that stops letter-spaced capitals from eating themselves.
+ *   - division heads and front matter rejected outright (see DIVISION_HEAD).
+ *   - the author's own name rejected, with accents folded first.
+ */
+export function locusWorkKey(raw: string | null | undefined, author?: string): string | null {
+  if (!raw) return null;
+  let s = normalizeHeader(String(raw).replace(/[[\]()]/g, ' '));
+  // Greek book letter + roman numeral, e.g. "ΠΟΛΙΤΕΙΑΣ Α I" / "ΝΟΜΩΝ ΙΒ XII".
+  s = s.replace(/\s+[ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩϚ]{1,3}\s+[IVXLCΧ]{1,6}$/u, '').trim();
+  s = normalizeHeader(s);
+  if (!s || s.length < 3) return null;
+  if (!/\p{L}/u.test(s)) return null;
+  if (DIVISION_HEAD.test(s) || NOT_A_WORK_HEAD.test(s)) return null;
+
+  const folded = foldDiacritics(s);
+  const authorForms = [
+    ...String(author || '').split(/[;,|(]/),
+    ...nameFormsFor(author),
+  ]
+    .map((a) => foldDiacritics(normalizeHeader(a.trim())))
+    .filter((a) => a.length >= 4);
+
+  // An inflected form of the author's name, not just an exact match. The verso
+  // head of the 1578 Stephanus is `PLATONIS` — the Latin genitive — against an
+  // `author` field of "Plato", and the Greek volumes head `ΠΛΑΤΩΝΟΣ` against
+  // `Πλάτων`. Exact comparison accepted both as works, and `PLATONIS` then
+  // "contained" 464 anchors spanning the entire volume.
+  if (!/\s/.test(folded)) {
+    for (const f of authorForms) {
+      if (folded === f) return null;
+      if (folded.startsWith(f) && folded.length - f.length <= 4) return null;
+      if (f.startsWith(folded) && f.length - folded.length <= 4) return null;
+    }
+  }
+
+  return s;
+}
+
+// ── Anchor extraction ──────────────────────────────────────────────
+
+export interface LocusPageInput {
+  page_number: number;
+  /** The `<header>` payload, raw. */
+  header: string | null;
+  /** The `<page-num>` payload, raw. */
+  page_num: string | null;
+}
+
+export interface WorkSegment {
+  work_header: string | null;
+  first_page: number;
+  last_page: number;
+  ref_min: number;
+  ref_max: number;
+  anchors: number;
+}
+
+export interface ExtractOptions {
+  /** The book's author, so a head that is only the author's name names no work. */
+  author?: string;
+  /**
+   * Set for a root edition whose own pagination IS the citation standard. The
+   * offset (printed − scan) is then measured, required to be constant across
+   * `frameMinShare` of accepted anchors, and used to fill leaves whose own
+   * number was misread but whose neighbours bracket them.
+   */
+  frame?: boolean;
+  frameMinShare?: number;
+}
+
+export interface ExtractReport {
+  pages: number;
+  /** Pages carrying a `<page-num>` that parsed to at least one candidate. */
+  candidate_pages: number;
+  printed: number;
+  frame: number;
+  /** Printed numbers dropped because they sat off a frame edition's verified offset. */
+  off_frame: number;
+  /** Every dropped candidate, whatever the reason. */
+  rejected: number;
+  ref_min: number | null;
+  ref_max: number | null;
+  /** printed − scan, when constant enough to be a frame. Null otherwise. */
+  frame_offset: number | null;
+  frame_offset_share: number | null;
+  segments: WorkSegment[];
+}
+
+export interface ExtractResult {
+  anchors: LocusAnchor[];
+  report: ExtractReport;
+  /** Every dropped candidate, with the reason — the residual, reported not smoothed. */
+  rejected: Array<{ page_number: number; raw: string | null; reason: string }>;
+}
+
+/**
+ * How far a reference may advance between two anchored leaves.
+ *
+ * Bounded by the scan-page gap, because intervening unanchored leaves legitimately
+ * carry the reference forward. Generous on purpose: the rule exists to reject a
+ * value from a different numbering system that landed in `<page-num>` (a chapter
+ * number, a shelfmark, the book's own folio), not to police typesetting.
+ */
+function maxStep(gap: number): number {
+  return 3 * Math.max(1, gap) + 3;
+}
+
+/**
+ * The longest monotone chain through per-page candidates.
+ *
+ * This is the whole acceptance rule, and it is deliberately local: a candidate is
+ * kept iff it continues a non-decreasing run within its work at a bounded rate.
+ * That is what separates a canonical marginal from the OCR having caught the
+ * chapter number instead — in the Oxford Physics, `<page-num>` holds `186a` on
+ * one leaf and `5` (a chapter) on another, and no range table is needed to tell
+ * them apart because 5 does not continue the run.
+ *
+ * Dynamic programming rather than a greedy walk, because the run has to be able
+ * to start at the right value: seeding from the first candidate would let one
+ * piece of front-matter noise reject the entire book.
+ */
+function longestMonotoneChain(
+  items: Array<{ pageIndex: number; page_number: number; candIndex: number; ref: LocusRef }>,
+): Set<string> {
+  const n = items.length;
+  if (!n) return new Set();
+  const best = new Array<number>(n).fill(1);
+  const prev = new Array<number>(n).fill(-1);
+  let bestEnd = 0;
+
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < i; j++) {
+      if (items[j].page_number > items[i].page_number) continue; // same leaf, later candidate
+      const refGap = items[i].ref.page - items[j].ref.page;
+      if (refGap < 0) continue;
+      const scanGap = items[i].page_number - items[j].page_number;
+      if (refGap > maxStep(scanGap)) continue;
+      if (best[j] + 1 > best[i]) { best[i] = best[j] + 1; prev[i] = j; }
+    }
+    if (best[i] > best[bestEnd]) bestEnd = i;
+  }
+
+  const keep = new Set<string>();
+  for (let i = bestEnd; i !== -1; i = prev[i]) keep.add(`${items[i].pageIndex}:${items[i].candIndex}`);
+  return keep;
+}
+
+/**
+ * Extract canonical anchors from one book's pages.
+ *
+ * Pure: takes `[page, header, page-num]` triples and returns anchors plus the
+ * residual. Nothing here touches the database, so the acceptance rule is testable
+ * against fixtures — and it is, in `tests/unit/locus-anchors.test.ts`.
+ */
+export function extractAnchors(pages: LocusPageInput[], opts: ExtractOptions = {}): ExtractResult {
+  const sorted = [...pages].sort((a, b) => a.page_number - b.page_number);
+
+  // 1. Which running heads name a work at all. Reuses the reviewed derivation
+  //    from #3652 rather than re-deciding it here: same author-name rejection,
+  //    same letter-spacing collapse, same density floor.
+  const rawKeyAt = sorted.map((p) => locusWorkKey(p.header, opts.author));
+
+  // Fuse a book numeral back onto its work. Once letter-spacing is collapsed, a
+  // numeral glued to the end of a display-capital head cannot be told from the
+  // word's own last letter: Bekker vol. II heads `Π Ο Λ Ι Τ Ι Κ Ω Ν  Β`, which
+  // collapses to `ΠΟΛΙΤΙΚΩΝΒ`. `contains-works.ts` resolves this by merging a
+  // key that is a prefix of another; the rule here is tighter — the extra
+  // characters must themselves BE numerals — because a wrong merge here does not
+  // add a row, it moves anchors under the wrong work.
+  const NUMERAL_TAIL = /^[ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩϚIVX]{1,2}$/u;
+  const rawCounts = new Map<string, number>();
+  for (const k of rawKeyAt) if (k) rawCounts.set(k, (rawCounts.get(k) ?? 0) + 1);
+  const canonical = new Map<string, string>();
+  const byLength = [...rawCounts.keys()].sort((a, b) => a.length - b.length);
+  for (const long of byLength) {
+    for (const short of byLength) {
+      if (short.length >= long.length || short.length < 5) continue;
+      if (!long.startsWith(short)) continue;
+      if (!NUMERAL_TAIL.test(long.slice(short.length))) continue;
+      canonical.set(long, canonical.get(short) ?? short);
+      break;
+    }
+  }
+
+  const keyAt = rawKeyAt.map((k) => (k ? canonical.get(k) ?? k : null));
+  const headCounts = new Map<string, number>();
+  for (const k of keyAt) if (k) headCounts.set(k, (headCounts.get(k) ?? 0) + 1);
+
+  // 2. Segment the leaves by work: each leaf inherits the last work-naming head
+  //    seen at or before it. A verso head that is only the author's name
+  //    ("ΠΛΑΤΩΝΟΣ" on 254 leaves of the Burnet Republic) names no work and
+  //    correctly carries the previous one forward.
+  const isWorkHead = (i: number) => {
+    const k = keyAt[i];
+    return !!k && (headCounts.get(k) ?? 0) >= 2;
+  };
+
+  const segmentOf: Array<string | null> = [];
+  const segmentIdOf: number[] = [];
+  let current: string | null = null;
+  let segmentId = 0;
+  for (let i = 0; i < sorted.length; i++) {
+    if (isWorkHead(i) && keyAt[i] !== current) { current = keyAt[i]; segmentId++; }
+    segmentOf.push(current);
+    segmentIdOf.push(segmentId);
+  }
+
+  // A work's opening leaves can sit under its predecessor's head.
+  //
+  // In these editions the recto names the work and the verso names only the
+  // author, so a leaf carrying no head of its own inherits the previous work —
+  // correct in the middle of a work, wrong for the first leaf or two of the next
+  // one. Stephanus vol. 2 prints the Republic from page 327, and leaf 340
+  // (printed 328) came back filed under MINOS, so `Republic 328b` reported the
+  // 1902 OCT and NOT the 1578 edition the number is named after.
+  //
+  // Rather than guess which side such a leaf belongs to, record BOTH: the
+  // inherited work and the one starting within two leaves. Resolution accepts
+  // either and says which leaves were matched that way.
+  const altOf: Array<string | null> = new Array(sorted.length).fill(null);
+  for (let i = 0; i < sorted.length; i++) {
+    if (isWorkHead(i)) continue;
+    for (let j = i + 1; j <= i + 2 && j < sorted.length; j++) {
+      if (!isWorkHead(j)) continue;
+      if (keyAt[j] !== segmentOf[i]) altOf[i] = keyAt[j];
+      break;
+    }
+  }
+
+  // 3. Accept candidates by monotone run WITHIN each work. Across works the
+  //    reference legitimately resets — Burnet's vol. 4 runs Clitopho 406–410,
+  //    then Republic 327–621, then Timaeus 17–92 — so a single global run would
+  //    throw away two thirds of the book.
+  const bySegment = new Map<number, Array<{ pageIndex: number; page_number: number; candIndex: number; ref: LocusRef; raw: string }>>();
+  let candidatePages = 0;
+  sorted.forEach((p, pageIndex) => {
+    const cands = parseRefCandidates(p.page_num);
+    if (!cands.length) return;
+    candidatePages++;
+    const seg = segmentIdOf[pageIndex];
+    const arr = bySegment.get(seg) ?? [];
+    cands.forEach((ref, candIndex) => arr.push({ pageIndex, page_number: p.page_number, candIndex, ref, raw: p.page_num as string }));
+    bySegment.set(seg, arr);
+  });
+
+  const kept = new Set<string>();
+  for (const [, items] of bySegment) {
+    for (const k of longestMonotoneChain(items)) kept.add(k);
+  }
+
+  const anchors: LocusAnchor[] = [];
+  const rejected: ExtractResult['rejected'] = [];
+  for (const [, items] of bySegment) {
+    for (const it of items) {
+      const key = `${it.pageIndex}:${it.candIndex}`;
+      if (kept.has(key)) {
+        anchors.push({
+          page_number: it.page_number,
+          ref: it.ref,
+          basis: 'printed',
+          work_header: segmentOf[it.pageIndex],
+          work_header_alt: altOf[it.pageIndex],
+          raw: it.raw,
+        });
+      } else {
+        rejected.push({ page_number: it.page_number, raw: it.raw, reason: 'breaks the monotone run within its work' });
+      }
+    }
+  }
+  anchors.sort((a, b) => a.page_number - b.page_number || refSortKey(a.ref) - refSortKey(b.ref));
+
+  // 4. Root editions only: measure the scan→printed offset and, if it is
+  //    genuinely constant, fill the leaves whose own number was misread.
+  //
+  //    This is the one place a reference is not read off its own leaf, and it is
+  //    fenced accordingly: the offset must hold on `frameMinShare` of accepted
+  //    anchors, and a leaf is filled only when BOTH neighbours are printed
+  //    anchors agreeing with the offset — i.e. they bracket the missing value
+  //    exactly. That is corroboration by adjacency, not interpolation across a
+  //    gap, and #3661's guard ("never interpolate a locus that isn't
+  //    corroborated") is the reason for the distinction.
+  let frameOffset: number | null = null;
+  let frameShare: number | null = null;
+  let frameCount = 0;
+  let offFrame = 0;
+  let published = anchors;
+
+  if (opts.frame && anchors.length) {
+    const counts = new Map<number, number>();
+    for (const a of anchors) {
+      const off = a.ref.page - a.page_number;
+      counts.set(off, (counts.get(off) ?? 0) + 1);
+    }
+    const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+    frameShare = ranked[0][1] / anchors.length;
+
+    if (frameShare >= (opts.frameMinShare ?? 0.75)) {
+      frameOffset = ranked[0][0];
+
+      // Anchors OFF the frame are not published, even though their number was
+      // printed. In a mechanism-A edition the published claim is "this leaf's
+      // printed number IS the canonical reference", and that claim holds only
+      // where the frame holds. Stephanus vols. 1 and 3 each append Estienne's or
+      // Serranus's annotations, separately paginated from 1 — publishing those
+      // would answer "Stephanus 100" with a page of a 16th-century commentary.
+      const onFrame: LocusAnchor[] = [];
+      for (const a of anchors) {
+        if (a.ref.page - a.page_number === frameOffset) onFrame.push(a);
+        else {
+          offFrame++;
+          rejected.push({
+            page_number: a.page_number,
+            raw: a.raw,
+            reason: `printed number ${a.ref.page} is off the verified frame (offset ${frameOffset}) — a second pagination sequence, not a canonical reference`,
+          });
+        }
+      }
+
+      const printedAt = new Set(onFrame.map((a) => a.page_number));
+      for (let i = 0; i < sorted.length; i++) {
+        const pn = sorted[i].page_number;
+        if (printedAt.has(pn)) continue;
+        if (!printedAt.has(pn - 1) || !printedAt.has(pn + 1)) continue;
+        onFrame.push({
+          page_number: pn,
+          ref: { page: pn + frameOffset, section: null, line: null },
+          basis: 'frame',
+          work_header: segmentOf[i],
+          work_header_alt: altOf[i],
+          raw: sorted[i].page_num ?? null,
+        });
+        frameCount++;
+      }
+      onFrame.sort((a, b) => a.page_number - b.page_number || refSortKey(a.ref) - refSortKey(b.ref));
+      published = onFrame;
+    } else {
+      // The edition was declared a reference frame and is not one. Publish
+      // nothing rather than publish a number whose meaning is unestablished.
+      for (const a of anchors) {
+        rejected.push({
+          page_number: a.page_number,
+          raw: a.raw,
+          reason: `edition declared a reference frame but no constant offset holds (best ${ranked[0][0]} on ${(frameShare * 100).toFixed(1)}%)`,
+        });
+      }
+      published = [];
+    }
+  }
+  const anchorsOut = published;
+
+  // 5. Per-work reference ranges — derived, not declared. This is the table that
+  //    lets a bare Bekker number name its work, and lets two editions corroborate
+  //    each other by agreeing on a range.
+  const segMap = new Map<string | null, WorkSegment>();
+  for (const a of anchorsOut) {
+    const key = a.work_header;
+    const e = segMap.get(key) ?? {
+      work_header: key, first_page: a.page_number, last_page: a.page_number,
+      ref_min: a.ref.page, ref_max: a.ref.page, anchors: 0,
+    };
+    e.first_page = Math.min(e.first_page, a.page_number);
+    e.last_page = Math.max(e.last_page, a.page_number);
+    e.ref_min = Math.min(e.ref_min, a.ref.page);
+    e.ref_max = Math.max(e.ref_max, a.ref.page);
+    e.anchors++;
+    segMap.set(key, e);
+  }
+
+  return {
+    anchors: anchorsOut,
+    rejected,
+    report: {
+      pages: sorted.length,
+      candidate_pages: candidatePages,
+      printed: anchorsOut.filter((a) => a.basis === 'printed').length,
+      frame: frameCount,
+      off_frame: offFrame,
+      rejected: rejected.length,
+      frame_offset: frameOffset,
+      frame_offset_share: frameShare === null ? null : Number(frameShare.toFixed(4)),
+      ref_min: anchorsOut.length ? Math.min(...anchorsOut.map((a) => a.ref.page)) : null,
+      ref_max: anchorsOut.length ? Math.max(...anchorsOut.map((a) => a.ref.page)) : null,
+      segments: [...segMap.values()].sort((a, b) => a.ref_min - b.ref_min),
+    },
+  };
+}

--- a/tests/unit/locus.test.ts
+++ b/tests/unit/locus.test.ts
@@ -1,0 +1,302 @@
+/**
+ * The acceptance rule for canonical loci (#3661).
+ *
+ * These fixtures are real strings from the registered editions, not invented
+ * shapes — the parser's failure mode is silently dropping a spelling of a column
+ * letter it has not seen, and only real payloads catch that. Each `it` names the
+ * book it came from.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseRefCandidates,
+  parseLocusQuery,
+  refSortKey,
+  formatRef,
+  locusWorkKey,
+  extractAnchors,
+  type LocusPageInput,
+} from '@/lib/locus';
+import { findWorkByName, findWorkByHead, LOCUS_WORKS } from '@/lib/locus-works';
+
+describe('parseRefCandidates', () => {
+  it('reads every rendering of a Bekker column letter', () => {
+    // All four occur in the Oxford translation volumes; a parser handling one
+    // spelling loses most of the book's anchors.
+    expect(parseRefCandidates('184^a')).toEqual([{ page: 184, section: 'a', line: null }]);
+    expect(parseRefCandidates('185ᵃ')).toEqual([{ page: 185, section: 'a', line: null }]);
+    expect(parseRefCandidates('186<sup>a</sup>')).toEqual([{ page: 186, section: 'a', line: null }]);
+    expect(parseRefCandidates('339ª')).toEqual([{ page: 339, section: 'a', line: null }]);
+  });
+
+  it('returns both endpoints of a span the leaf covers', () => {
+    // Burnet's OCT prints the range the page covers.
+    expect(parseRefCandidates('407 e - 408 c')).toEqual([
+      { page: 407, section: 'e', line: null },
+      { page: 408, section: 'c', line: null },
+    ]);
+    expect(parseRefCandidates('409 e, 410')).toEqual([
+      { page: 409, section: 'e', line: null },
+      { page: 410, section: null, line: null },
+    ]);
+  });
+
+  it('finds nothing numeric in roman front matter or a shelfmark', () => {
+    expect(parseRefCandidates('vii')).toEqual([]);
+    expect(parseRefCandidates(null)).toEqual([]);
+  });
+
+  it('does not read a word initial as a section letter', () => {
+    // "1900 v. 4" is a shelfmark line; reading "v" as a section would invent a
+    // section that no system has.
+    expect(parseRefCandidates('1900 v. 4').map((r) => r.section)).toEqual([null, null]);
+  });
+
+  it('keeps a markup boundary as a separator', () => {
+    expect(parseRefCandidates('<unclear>553 a, b</unclear>')[0]).toEqual({ page: 553, section: 'a', line: null });
+  });
+});
+
+describe('parseLocusQuery', () => {
+  it('reads a bare Bekker reference with line', () => {
+    expect(parseLocusQuery('1094a8')).toMatchObject({ system: null, work: null, ref: { page: 1094, section: 'a', line: 8 } });
+  });
+
+  it('reads a named system', () => {
+    expect(parseLocusQuery('Bekker 1447a')).toMatchObject({ system: 'bekker', ref: { page: 1447, section: 'a' } });
+    expect(parseLocusQuery('Stephanus 328b')).toMatchObject({ system: 'stephanus', ref: { page: 328, section: 'b' } });
+  });
+
+  it('separates a work name from the reference', () => {
+    expect(parseLocusQuery('Rep. 328b')).toMatchObject({ work: 'Rep', ref: { page: 328, section: 'b' } });
+    expect(parseLocusQuery('Nicomachean Ethics 1103b')).toMatchObject({ work: 'Nicomachean Ethics', ref: { page: 1103, section: 'b' } });
+  });
+
+  it('never guesses the system from the number', () => {
+    // Bekker and Stephanus ranges overlap almost entirely; inferring from
+    // magnitude would answer a Plato citation with an Aristotle leaf.
+    expect(parseLocusQuery('328b')?.system).toBeNull();
+    expect(parseLocusQuery('1094a')?.system).toBeNull();
+  });
+});
+
+describe('refSortKey / formatRef', () => {
+  it('orders page, then section, then line', () => {
+    const k = (p: number, s: string | null, l: number | null) => refSortKey({ page: p, section: s, line: l });
+    expect(k(1094, null, null)).toBeLessThan(k(1094, 'a', null));
+    expect(k(1094, 'a', 8)).toBeLessThan(k(1094, 'b', 1));
+    expect(k(1094, 'b', null)).toBeLessThan(k(1095, null, null));
+  });
+
+  it('formats the way a citation is written', () => {
+    expect(formatRef({ page: 1094, section: 'a', line: 8 })).toBe('1094a.8');
+    expect(formatRef({ page: 1447, section: null, line: null })).toBe('1447');
+  });
+});
+
+describe('locusWorkKey', () => {
+  it('strips a book numeral pair that normalizeHeader cannot', () => {
+    // Burnet heads the Republic's rectos with a Greek book letter AND its roman
+    // equivalent. Left alone, one dialogue became eleven segments.
+    expect(locusWorkKey('ΠΟΛΙΤΕΙΑΣ Α I.')).toBe('ΠΟΛΙΤΕΙΑΣ');
+    expect(locusWorkKey('ΝΟΜΩΝ ΙΒ XII.')).toBe('ΝΟΜΩΝ');
+  });
+
+  it('rejects a division head', () => {
+    expect(locusWorkKey('BOOK IV. 8')).toBeNull();
+    expect(locusWorkKey('CHAPTER II')).toBeNull();
+    expect(locusWorkKey('PRAEFATIO')).toBeNull();
+  });
+
+  it('rejects the author name, including an inflected form', () => {
+    // The 1578 Stephanus heads its versos PLATONIS against an author field of
+    // "Plato"; the Greek volumes head them ΠΛΑΤΩΝΟΣ. Exact comparison accepted
+    // both, and PLATONIS then "contained" the entire volume.
+    expect(locusWorkKey('PLATONIS', 'Plato')).toBeNull();
+    expect(locusWorkKey('ΠΛΑΤΩΝΟΣ', 'Plato')).toBeNull();
+    expect(locusWorkKey('ΑΡΙΣΤΟΤΕΛΟΥΣ', 'Aristotle')).toBeNull();
+  });
+
+  it('keeps a real work head', () => {
+    expect(locusWorkKey('ΠΕΡΙ ΠΟΙΗΤΙΚΗΣ', 'Aristotle')).toBe('ΠΕΡΙ ΠΟΙΗΤΙΚΗΣ');
+    expect(locusWorkKey('HISTORIA ANIMALIUM', 'Aristotle')).toBe('HISTORIA ANIMALIUM');
+  });
+});
+
+/** Build page inputs for a synthetic edition. */
+function pages(rows: Array<[number, string | null, string | null]>): LocusPageInput[] {
+  return rows.map(([page_number, header, page_num]) => ({ page_number, header, page_num }));
+}
+
+describe('extractAnchors — marginal editions', () => {
+  it('keeps the canonical run and drops a chapter number that landed in page-num', () => {
+    // The Oxford Physics really does this: the running head is "BOOK I. 5" and
+    // the OCR captured the chapter number 5 as the page number. 5 cannot
+    // continue a run at 186, and that alone is enough to reject it — no range
+    // table needed.
+    const { anchors, rejected } = extractAnchors(
+      pages([
+        [18, 'PHYSICA', '184a'],
+        [19, 'PHYSICA', '184b'],
+        [20, 'PHYSICA', '185a'],
+        [21, 'BOOK I. 5', '5'],
+        [22, 'PHYSICA', '186a'],
+      ]),
+      { author: 'Aristotle' },
+    );
+    expect(anchors.map((a) => a.ref.page)).toEqual([184, 184, 185, 186]);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].page_number).toBe(21);
+  });
+
+  it('lets the reference reset between works in one volume', () => {
+    // Burnet vol. 4 runs Clitopho 406-410, then the Republic from 327. A single
+    // global monotone run would throw the Republic away.
+    const { anchors } = extractAnchors(
+      pages([
+        [19, 'ΚΛΕΙΤΟΦΩΝ', '406'],
+        [20, 'ΚΛΕΙΤΟΦΩΝ', '407 e - 408 c'],
+        [21, 'ΚΛΕΙΤΟΦΩΝ', '409'],
+        [28, 'ΠΟΛΙΤΕΙΑΣ Α I.', '327 c'],
+        [29, 'ΠΟΛΙΤΕΙΑΣ Α I.', '328 c'],
+        [30, 'ΠΛΑΤΩΝΟΣ', '329 b'],
+      ]),
+      { author: 'Plato' },
+    );
+    expect(anchors.filter((a) => a.work_header === 'ΚΛΕΙΤΟΦΩΝ')).toHaveLength(4);
+    const republic = anchors.filter((a) => a.work_header === 'ΠΟΛΙΤΕΙΑΣ');
+    expect(republic.map((a) => a.ref.page)).toEqual([327, 328, 329]);
+    // The author-name verso carries the work forward rather than starting one.
+    expect(anchors.every((a) => a.work_header !== 'ΠΛΑΤΩΝΟΣ')).toBe(true);
+  });
+
+  it('records both candidates for a leaf at a work boundary', () => {
+    // Verified against the scans: Stephanus vol. 2 leaf 339 is printed 327, the
+    // Republic's title page; leaf 340 is printed 328 and is Republic text under
+    // the generic verso head PLATONIS; leaf 341 is the first recto to say
+    // DE REPVB. So leaf 340 inherits MINOS and is the Republic — and until both
+    // candidates were recorded, `Republic 328b` missed the very edition the
+    // Stephanus numbers are named after.
+    const { anchors } = extractAnchors(
+      pages([
+        [336, 'MINOS', '324'],
+        [337, 'MINOS', '325'],
+        [338, null, '326'],
+        [339, null, '327'],
+        [340, 'PLATONIS', '328'],
+        [341, 'DE REPVB. LIB. I.', '329'],
+        [342, 'PLATONIS', '330'],
+        [343, 'DE REPVB. LIB. I.', '331'],
+      ]),
+      { author: 'Plato' },
+    );
+    const at328 = anchors.find((a) => a.ref.page === 328);
+    expect(at328?.work_header).toBe('MINOS');
+    expect(at328?.work_header_alt).toBe('DE REPVB');
+
+    // ...and a leaf in the MIDDLE of a work gets no alternative, so the boundary
+    // rule cannot quietly widen every work by two leaves.
+    const at330 = anchors.find((a) => a.ref.page === 330);
+    expect(at330?.work_header).toBe('DE REPVB');
+    expect(at330?.work_header_alt).toBeNull();
+  });
+});
+
+describe('extractAnchors — frame editions', () => {
+  const frameRows = (): Array<[number, string | null, string | null]> => {
+    const rows: Array<[number, string | null, string | null]> = [];
+    for (let scan = 10; scan <= 40; scan++) rows.push([scan, 'ΗΘΙΚΩΝ ΝΙΚΟΜΑΧΕΙΩΝ', String(scan + 784)]);
+    return rows;
+  };
+
+  it('measures the offset and fills a leaf its neighbours bracket', () => {
+    const rows = frameRows();
+    rows[5][2] = null; // one leaf's number unreadable
+    const { anchors, report } = extractAnchors(pages(rows), { author: 'Aristotle', frame: true });
+    expect(report.frame_offset).toBe(784);
+    expect(report.frame).toBe(1);
+    const filled = anchors.find((a) => a.basis === 'frame');
+    expect(filled?.page_number).toBe(15);
+    expect(filled?.ref.page).toBe(799);
+  });
+
+  it('does not fill across a gap wider than one leaf', () => {
+    const rows = frameRows();
+    rows[5][2] = null;
+    rows[6][2] = null;
+    const { report } = extractAnchors(pages(rows), { author: 'Aristotle', frame: true });
+    // Neither leaf has printed neighbours on both sides, so neither is filled.
+    // Interpolating across the pair is exactly what #3661's guard forbids.
+    expect(report.frame).toBe(0);
+  });
+
+  it('drops a printed number that sits off the verified frame', () => {
+    // Stephanus vols. 1 and 3 append separately-paginated annotations under
+    // their own running head, so those numbers form a valid run of their own and
+    // survive the monotone rule. They are printed numbers and they are NOT
+    // Stephanus references: publishing them would answer "Stephanus 100" with a
+    // page of a 16th-century commentary. 54 anchors are dropped this way in
+    // vol. 1 and 130 in vol. 3.
+    const rows = frameRows();
+    for (let scan = 41; scan <= 50; scan++) rows.push([scan, 'HENRICI STEPHANI', String(scan - 40)]);
+    const { anchors, report } = extractAnchors(pages(rows), { author: 'Plato', frame: true });
+    expect(report.off_frame).toBeGreaterThan(0);
+    expect(anchors.every((a) => a.ref.page - a.page_number === 784)).toBe(true);
+    expect(anchors.every((a) => a.work_header !== 'HENRICI STEPHANI')).toBe(true);
+  });
+
+  it('rejects a second numbering inside the same work by the run rule alone', () => {
+    // When the stray numbers sit under a head that names no work (front matter,
+    // an annotation label), they stay inside the enclosing work's segment and the
+    // monotone rule rejects them before the frame check ever sees them. Two
+    // independent guards, and this one fires first.
+    const rows = frameRows();
+    rows.push([41, 'ANNOT IN PLAT', '7']);
+    rows.push([42, 'ANNOT IN PLAT', '8']);
+    const { anchors, rejected } = extractAnchors(pages(rows), { author: 'Aristotle', frame: true });
+    expect(rejected.some((r) => r.page_number === 41)).toBe(true);
+    expect(anchors.every((a) => a.ref.page - a.page_number === 784)).toBe(true);
+  });
+
+  it('publishes nothing when a declared frame has no constant offset', () => {
+    const rows: Array<[number, string | null, string | null]> = [];
+    for (let scan = 10; scan <= 30; scan++) rows.push([scan, 'ΝΟΜΩΝ', String(scan * 3)]);
+    const { anchors, report } = extractAnchors(pages(rows), { author: 'Plato', frame: true });
+    expect(report.frame_offset).toBeNull();
+    expect(anchors).toHaveLength(0);
+    expect(report.rejected).toBeGreaterThan(0);
+  });
+});
+
+describe('locus work names', () => {
+  it('resolves an English name, an abbreviation and a printed head', () => {
+    expect(findWorkByName('Republic')?.slug).toBe('republic');
+    expect(findWorkByName('rep')?.slug).toBe('republic');
+    expect(findWorkByName('Nicomachean Ethics')?.slug).toBe('nicomachean-ethics');
+    expect(findWorkByHead('ΠΟΛΙΤΕΙΑΣ', 'stephanus')?.slug).toBe('republic');
+    expect(findWorkByHead('DE REPVBL', 'stephanus')?.slug).toBe('republic');
+  });
+
+  it('does not confuse the Republic with the Statesman', () => {
+    // ΠΟΛΙΤΕΙΑ and ΠΟΛΙΤΙΚΟΣ share a stem; a first-match rule gets this wrong.
+    expect(findWorkByHead('ΠΟΛΙΤΙΚΟΣ', 'stephanus')?.slug).toBe('statesman');
+    expect(findWorkByHead('ΠΟΛΙΤΙΚΩΝ', 'bekker')?.slug).toBe('politics');
+  });
+
+  it('prefers the longer name when one is a prefix of another', () => {
+    expect(findWorkByName('hippias major')?.slug).toBe('hippias-major');
+  });
+
+  it('carries no page ranges, so a wrong row cannot move a citation', () => {
+    // The addressing key is the printed number; this table only supplies names.
+    // If a range ever appears here, resolution can start disagreeing with the
+    // leaves — see the header of src/lib/locus-works.ts.
+    for (const w of LOCUS_WORKS) {
+      expect(Object.keys(w).sort()).toEqual(['aliases', 'heads', 'label', 'slug', 'system']);
+    }
+  });
+
+  it('has no duplicate slugs', () => {
+    const slugs = LOCUS_WORKS.map((w) => w.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});


### PR DESCRIPTION
Implements #3661 phases 1–3.

## Why

Scholarship addresses Aristotle by Bekker number (`1094a8`) and Plato by Stephanus number (`Rep. 328b`) — systems agreed centuries ago so a citation survives re-typesetting. We addressed everything by scan page, which is a property of one copy and shareable with nobody. An agent fact-checking attributed Aristotle quotes through MCP had to rebuild the mapping by hand and then guess (#3653 item 2):

> *"I found the Poetics passage by noticing Bekker vol. 2's scan pages map 1:1 onto Bekker numbers, deriving page ≈ 310 + (Bekker − 1094), and guessing."*

`get_locus("1094a8")` now returns Bekker vol. II p.310, Nicomachean Ethics. Verified against the leaf: printed 1094, head ΗΘΙΚΩΝ ΝΙΚΟΜΑΧΕΙΩΝ Α, text opening Πᾶσα τέχνη καὶ πᾶσα μέθοδος.

## What ships

10 registered editions, 6,324 anchors — **both root editions complete**, which is what makes this tractable:

| | mechanism | anchors |
|---|---|---|
| Bekker, Aristotelis Opera vols I–II (1831) | own pagination is the standard | 779 + 669 |
| Stephanus, Platonis Opera vols 1–3 (1578) | own pagination is the standard | 476 + 981 + 412 |
| Burnet OCT 1902, 1907 | marginal reference | 667 + 778 |
| Oxford translations ×3 (English) | marginal reference | 558 + 495 + 509 |

The three Oxford volumes are the point of the English ones: `get_locus("486a")` returns the Greek Bekker leaf **and** an English translation of the same lines.

- `src/lib/locus.ts` — parsing + the acceptance rule (pure, unit-tested)
- `src/lib/locus-editions.ts` — the reviewed registry with regression pins
- `src/lib/locus-works.ts` — names only, no ranges
- `scripts/locus/extract-locus-anchors.mjs` — dry-run by default, `--apply` writes
- `scripts/audit/locus-anchor-staleness.mjs` — exits 1 on drift
- `GET /api/locus` + `get_locus` MCP tool (server 4.6.0 → 4.7.0; additive, no directory re-review)

## The rule

**A published locus is a number printed on that leaf.** No fitting, no interpolation, no range table anywhere in the addressing path. One fenced exception: in a root edition whose scan→printed offset is constant and verified, a leaf whose own number was misread takes the frame value only when *both* neighbours bracket it exactly — `basis: "frame"`, counted separately (37 anchors of 6,324).

Per-work ranges are **derived** from the editions' own running heads joined to the numbers read inside them, and they then agree with the values a classicist would recognise (Physics 184–267, Metaphysics 980–1093, NE 1094–1181, Politics 1252–1342, Poetics 1447–1462, Republic 327–621, Laws 624–969). That agreement is a check on the derivation, never its source.

## Defects found against real data, not fixtures

- Filtering on the requested **section** reported `Republic 328b` absent while we hold the leaf — its margin reads `328 c`. Match by page; report what was printed.
- A work's **opening leaves inherit the predecessor's running head** (recto names the work, verso names only the author). Stephanus vol. 2 leaf 340 is printed 328 and is Republic text headed `PLATONIS` — verified against the scans, leaf 339 being the Republic's title page. Both candidates are now recorded; before that, `Republic 328b` missed the very edition the numbering is named after.
- Stephanus vols 1 and 3 append **separately-paginated annotations**; 184 printed numbers that are not Stephanus references are dropped as off-frame, rather than answering "Stephanus 100" with a page of a 16th-century commentary.
- The **author's name inflected** read as a work: `PLATONIS` "contained" 464 anchors spanning a whole volume.

## Guards (from the issue)

- Mechanism A and B are never summed into one coverage number — the first pass in #3661 conflated them and scored the more valuable one worst.
- `locus-works.ts` carries names and no page ranges, so a wrong row can mislabel a leaf but cannot move a citation. A test asserts no range field ever appears there.
- `expect` blocks **refuse** an edition on drift instead of warning.
- `locus_anchors` is a derived store with one writer outside the pipeline — the shape that went dark for 60 days in the embedding outage (#3692). `locus_books.ocr_updated_max` holds the *source's* OCR timestamp and the audit exits 1.
- The response distinguishes "no anchor here" from "not covered", reports `other_works_at_this_reference` at shared-page joins (Bekker 184 and 1447 are both such joins), and warns when a bare number exists in both systems.

## Out of scope

The ~151 Aristotle/Plato books with no usable numeric structure **cannot be reached this way at all** — that needs text alignment to a root edition, not number alignment. No figure here should be read as corpus coverage. CTS URN emission (the issue's later comments) is deliberately not attempted; nothing here blocks it, and `locus_books.segments` is the per-work evidence it would need.

Line numbers are not resolved: you get the right leaf and read the line off it.

## Verification

- `npx tsc --noEmit` clean; full unit suite 2,077 passing (28 new).
- Every query below run against production data through a local dev server: `1094a8`, `184a10`, `1447a`, `486a`, `Republic 328b`, `Timaeus 28a`, `Poetics 1450b`, and a miss (`99999`).
- Anchors already written to production Mongo (`locus_anchors`, `locus_books`) — read-only additive collections, nothing existing is touched, and the API returns empty until deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNGn75hQdSrAEFQQAUkc9T
