### PR TITLE
feat(ft): screen the demote queue before spending agent time on it (#3687)

### DIFF
--- a/scripts/audit/ft-demote-queue-screen.mjs
+++ b/scripts/audit/ft-demote-queue-screen.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Screen the first-translation DEMOTE queue before spending agent time on it.
+ *
+ * The queue is the books badged `is_first_translation: true` whose own verdict
+ * reads `not_first` — 59 of them as of 2026-08-07 (#3687). Sixteen were verified
+ * one at a time by independent Claude subagents, each chosen *because* it looked
+ * like an obvious demote, and **13 of the 16 badges turned out to be correct**.
+ *
+ * So the expensive step should not run first. This ranks the queue by how likely
+ * the DEMOTE is to be wrong, using signals already present in the data, and the
+ * detectors are pinned against those 16 verified outcomes
+ * (`tests/unit/ft-demote-screen.test.ts`).
+ *
+ * READ-ONLY. Writes nothing, flips nothing. A signal is a reason to look.
+ *
+ * Usage:
+ *   node --env-file=.env.production.local scripts/audit/ft-demote-queue-screen.mjs
+ *   node --env-file=.env.production.local scripts/audit/ft-demote-queue-screen.mjs --json out.json
+ */
+import fs from 'fs';
+import { MongoClient } from 'mongodb';
+import { screenDemoteCandidate, KNOWN_LIMITS } from '../lib/ft-demote-screen.mjs';
+
+const jsonOut = (() => {
+  const i = process.argv.indexOf('--json');
+  return i === -1 ? null : process.argv[i + 1];
+})();
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db(process.env.MONGODB_DB || 'bookstore');
+const books = db.collection('books');
+const attempts = db.collection('first_translation_attempts');
+
+const rows = await books.find(
+  { is_first_translation: true, visible: true, 'first_translation.verdict': 'not_first' },
+  {
+    projection: {
+      _id: 0, id: 1, title: 1, author: 1, language: 1, year: 1, text_role: 1,
+      'first_translation.resolver': 1, 'first_translation.evidence_strength': 1,
+      'translation_verification.translations_found': 1,
+    },
+  },
+).toArray();
+
+const screened = [];
+for (const b of rows) {
+  const att = await attempts.find({ book_id: b.id }).sort({ date: -1 }).limit(6).toArray();
+  const priors = [];
+  for (const a of att) for (const p of (a.priors ?? [])) if (p.english_title) priors.push(p);
+  for (const p of (b.translation_verification?.translations_found ?? [])) {
+    if (p.english_title) priors.push(p);
+  }
+  const seen = new Set();
+  const uniq = priors.filter((p) => {
+    const k = `${p.english_title}|${p.translator ?? ''}|${p.pub_year ?? ''}`;
+    if (seen.has(k)) return false; seen.add(k); return true;
+  });
+  const result = screenDemoteCandidate(b, uniq);
+  screened.push({ ...b, priorCount: uniq.length, ...result });
+}
+
+screened.sort((a, b) => b.riskScore - a.riskScore);
+
+const byCode = {};
+for (const s of screened) for (const sig of new Set(s.signals.map((x) => x.code))) byCode[sig] = (byCode[sig] ?? 0) + 1;
+
+const flagged = screened.filter((s) => s.riskScore > 0);
+const clean = screened.filter((s) => s.riskScore === 0);
+
+console.log(`\nFIRST-TRANSLATION DEMOTE QUEUE — screened ${screened.length} candidates\n`);
+console.log(`  flagged (demote likely unsafe) : ${flagged.length}`);
+console.log(`  no signal                      : ${clean.length}`);
+console.log(`\n  signal frequency:`);
+for (const [k, v] of Object.entries(byCode).sort((a, b) => b[1] - a[1])) {
+  console.log(`    ${k.padEnd(26)} ${String(v).padStart(3)}`);
+}
+
+console.log(`\n─── FLAGGED — verify before demoting ${'─'.repeat(28)}`);
+for (const s of flagged) {
+  console.log(`\n  [${s.riskScore}] ${s.id}  [${s.language}] ${String(s.author ?? '?').slice(0, 26)}`);
+  console.log(`      ${String(s.title).slice(0, 78)}`);
+  for (const sig of s.signals) console.log(`      · ${sig.code}`);
+}
+
+console.log(`\n─── NO SIGNAL — demote is plausible, still needs verification ${'─'.repeat(8)}`);
+for (const s of clean) {
+  console.log(`  ${s.id}  [${s.language}] ${String(s.author ?? '?').slice(0, 24)} — ${String(s.title).slice(0, 52)}`);
+}
+
+console.log(`\n⚠ A zero score is NOT a clearance — ${KNOWN_LIMITS.blind_spot}.`);
+console.log(`  Recall on the gold set: ${KNOWN_LIMITS.gold_set_recall}. Upstream fix: ${KNOWN_LIMITS.upstream_fix}.\n`);
+
+if (jsonOut) {
+  fs.writeFileSync(jsonOut, JSON.stringify(screened, null, 1));
+  console.log(`Wrote ${jsonOut}\n`);
+}
+
+await client.close();

--- a/scripts/lib/ft-demote-screen.mjs
+++ b/scripts/lib/ft-demote-screen.mjs
@@ -1,0 +1,242 @@
+/**
+ * Detectors for the five ways a first-translation DEMOTE candidate goes wrong.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * 16 books were verified one at a time by independent Claude subagents on
+ * 2026-08-07 (#3687, rounds 1-2). Every one had been selected *because* it
+ * looked like an obvious demote — a canonical work with well-known English
+ * translations. **13 of the 16 badges turned out to be correct.**
+ *
+ * The failures were not scattered. They fell into five shapes, and four of the
+ * five are visible in data we already hold, without a single web search. This
+ * module is those four (plus one that needs the item's own language), so the
+ * expensive agent verification can be reserved for candidates that survive.
+ *
+ * A DETECTOR IS A REASON TO LOOK, NEVER A VERDICT. Nothing here demotes,
+ * promotes or writes. §17 applies with full force: a mechanical signal about a
+ * bibliographic claim is a screening queue, not an adjudication. The output
+ * ranks candidates by how likely the DEMOTE is to be wrong, so a human or an
+ * agent spends its attention where the evidence is thinnest.
+ */
+
+/** A translator field that names no person — the fabricated-citation signature. */
+const NON_PERSONAL_TRANSLATOR =
+  /^\s*(unknown|anonymous|anon\.?|various|multiple|several|n\/?a|none|unattributed|unspecified|not\s+(known|stated|recorded)|attributed\s+to|traditional)\b/i;
+
+/**
+ * Titles that name a multi-work CONTAINER rather than a single text.
+ *
+ * `Opera`/`Works` are the obvious ones; `Lucubrationes` is here because two of
+ * the 16 (Chrysostom 1527, Hilary 1523) were Erasmus-edited Froben anthologies
+ * and both badges survived. Anchored to word boundaries so "Operation" and
+ * "Networks" do not match.
+ */
+const CONTAINER_TITLE =
+  /\b(opera|omnia|posthuma|lucubrationes|varia|opuscula|collectanea|miscellanea|gesammelte|s[äa]mtliche|oeuvres|works|collected\s+works|complete\s+works|corpus\s+reformatorum|thesaurus)\b/i;
+
+/**
+ * The item is ITSELF a translation — so a prior that rendered the original is a
+ * different-source-language prior and does not defeat the claim (POLICY 2).
+ *
+ * Matches the ways a title states its own translator or target language:
+ * "Tr: Ambrosius Traversarius", "in Latinum versa", "verdeutscht", "translated
+ * by", "Arabic Translation", "vertaald".
+ */
+const ITEM_IS_A_TRANSLATION =
+  /(\btr(ans)?\.?\s*:|\btranslated\s+(by|into|from)\b|\btraduit\b|\bvertaald\b|\b[üu]bersetz|\bverdeutscht\b|\bin\s+latinum\s+versa\b|\bversa\b\s*(&|,|$)|\b(arabic|latin|greek|hebrew|syriac|armenian|dutch|german|french|italian|spanish|chinese)\s+translation\b)/i;
+
+/** A prior whose title is expository — a study ABOUT a text, not a rendering of it. */
+const EXPOSITORY_PRIOR_TITLE =
+  /(:\s*(its|the)\s+\w+|\bits\s+(scientific|theological|historical|literary)\b|\b(the\s+)?(influence|significance|reception|scholarly\s+career|life\s+and\s+works|evolution)\s+of\b|\bin\s+praise\s+of\b|\b(a|an)\s+(study|survey|introduction|essay|account)\s+of\b|\bcommentary\s+on\s+the\s+\w+\s+of\b.*\bsignificance\b)/i;
+
+/** A translator field holding a disjunction — two people fused into one citation. */
+const AMALGAMATED_TRANSLATOR = /\(\s*or\s+[^)]+\)|\bor\b\s+[A-Z][a-z]+\s+[A-Z][a-z]+\s*$/;
+
+/**
+ * The item IS a commentary, or bundles a base text with APPARATUS.
+ *
+ * Both shapes break the same way: a prior that renders the BASE text does not
+ * cover this item.
+ *  - bundled — Boethius' *De Consolatione Philosophiae* "comm. Thomas Waleys":
+ *    Walsh 1999 and Green 1962 translate Boethius and not a word of Waleys.
+ *  - standalone — Cardano's *In Cl. Ptolemaei de Astrorum Iudiciis Commentaria*:
+ *    a translation of Ptolemy's Tetrabiblos is not a translation of Cardano.
+ *
+ * The marker sits in the AUTHOR field as often as the title, so both are checked.
+ *
+ * ⚠️ The Latin declines: commentaria / commentarii / commentarius / commentariis
+ * / commentario / commentarium. An earlier version of this pattern listed only
+ * some of those endings and let Cardano through on the live queue — the gold set
+ * did not contain a `-aria` form, so only running it on real data caught it.
+ */
+const WORK_PLUS_APPARATUS =
+  /(\bcomm\.|\bcommentar(y|ies|ia|ii|io|ium|iis|ius)\b|\bscholia\b|\bcum\s+(commentariis|notis|scholiis)\b|\bwith\s+(the\s+)?(commentary|notes|annotations)\b|\bannotat(ed|ionibus)\b|\bglossa\b|\bin\s+\w+\s+(libros|librum)\b)/i;
+
+const norm = (s) => String(s ?? '').trim();
+
+/**
+ * Screen one demote candidate.
+ *
+ * @param {object} book  { title, author, language, original_language }
+ * @param {Array}  priors [{ translator, pub_year, english_title, completeness }]
+ * @returns {{signals: Array, riskScore: number, strongestReason: string|null}}
+ *   `riskScore` is the count of DISTINCT signals that the demote is unsafe.
+ *   It is an ordering key for human attention, not a probability.
+ */
+export function screenDemoteCandidate(book, priors = []) {
+  const signals = [];
+  const title = norm(book.title);
+  const author = norm(book.author);
+
+  // `text_role` is the field that SHOULD make witness-detection trivial. Where
+  // it is set correctly this is exact; see the blind spot noted in KNOWN_LIMITS.
+  if (/translation/i.test(norm(book.text_role))) {
+    signals.push({
+      code: 'item_is_a_witness',
+      severity: 'high',
+      detail: 'text_role marks this item as a translation, so a prior rendering the original is a '
+        + 'different-source-language prior and does not defeat the claim (POLICY 2).',
+    });
+  }
+
+  if (WORK_PLUS_APPARATUS.test(title) || WORK_PLUS_APPARATUS.test(author)) {
+    signals.push({
+      code: 'work_plus_apparatus',
+      severity: 'high',
+      detail: 'The item bundles a base text with a commentary, scholia or notes. A prior covering the '
+        + 'base text does not cover the apparatus — scope the claim before grading it.',
+    });
+  }
+
+  if (ITEM_IS_A_TRANSLATION.test(title)) {
+    signals.push({
+      code: 'item_is_a_witness',
+      severity: 'high',
+      detail: 'The item declares itself a translation, so a prior that rendered the original is a '
+        + 'different-source-language prior and does not defeat the claim (POLICY 2).',
+    });
+  }
+
+  if (CONTAINER_TITLE.test(title)) {
+    signals.push({
+      code: 'container_title',
+      severity: 'high',
+      detail: 'Title names a multi-work container. Completeness must be judged against the CONTAINER, '
+        + 'and a prior covering one constituent work does not defeat it.',
+    });
+  }
+
+  // Priors with no year cannot be graded: the first_modern rule turns on it.
+  let yearlessPriors = 0;
+
+  for (const p of priors) {
+    const t = norm(p.translator);
+    const et = norm(p.english_title);
+
+    if (!t || NON_PERSONAL_TRANSLATOR.test(t)) {
+      signals.push({
+        code: 'no_named_translator',
+        severity: 'high',
+        detail: `Prior "${et.slice(0, 60)}" names no translator (${t || 'empty'}) — the fabricated-citation `
+          + 'signature. Verify it exists in ESTC/Wing/WorldCat before trusting it.',
+      });
+    }
+
+    if (AMALGAMATED_TRANSLATOR.test(t)) {
+      signals.push({
+        code: 'amalgamated_translator',
+        severity: 'high',
+        detail: `Prior translator "${t}" is a disjunction, not an attribution — two people are likely `
+          + 'fused into one citation, of two different works.',
+      });
+    }
+
+    if (et && EXPOSITORY_PRIOR_TITLE.test(et)) {
+      signals.push({
+        code: 'prior_is_a_study',
+        severity: 'medium',
+        detail: `Prior "${et.slice(0, 70)}" reads as a study ABOUT the text rather than a rendering of it. `
+          + 'A work that quotes and analyses is not a translation.',
+      });
+    }
+
+    if (!norm(p.pub_year)) yearlessPriors++;
+  }
+
+  if (yearlessPriors) {
+    signals.push({
+      code: 'prior_without_year',
+      severity: 'medium',
+      detail: `${yearlessPriors} prior(s) carry no pub_year. The first_modern rule turns on the year — `
+        + 'a pre-1900-only prior is a badgeable first, not a defeat — so an ungraded year can collapse '
+        + 'a genuine first_modern to not_first.',
+    });
+  }
+
+  // Every prior partial/excerpt: by the survivor rules the badge already stands.
+  const graded = priors.filter((p) => norm(p.completeness));
+  if (graded.length && graded.every((p) => /partial|excerpt/i.test(norm(p.completeness)))) {
+    signals.push({
+      code: 'no_complete_prior_claimed',
+      severity: 'high',
+      detail: 'Every cited prior is partial or excerpt. Under the survivor rules a demote requires a '
+        + 'COMPLETE prior, so this one is unsupported on its own evidence.',
+    });
+  }
+
+  // Only pre-1900 complete priors → first_modern, a first-family badge.
+  const completeYears = priors
+    .filter((p) => /complete/i.test(norm(p.completeness)))
+    .map((p) => parseInt(norm(p.pub_year), 10))
+    .filter((y) => Number.isFinite(y));
+  if (completeYears.length && completeYears.every((y) => y < 1900)) {
+    signals.push({
+      code: 'first_modern_candidate',
+      severity: 'high',
+      detail: `All complete priors are pre-1900 (${completeYears.join(', ')}). That grades the text `
+        + 'first_modern — a first-family BADGE — not not_first.',
+    });
+  }
+
+  const order = { high: 2, medium: 1 };
+  const strongest = signals.slice().sort((a, b) => order[b.severity] - order[a.severity])[0];
+  return {
+    signals,
+    riskScore: new Set(signals.map((s) => s.code)).size,
+    strongestReason: strongest?.code ?? null,
+  };
+}
+
+export const DETECTORS = [
+  'item_is_a_witness', 'work_plus_apparatus', 'container_title', 'no_named_translator',
+  'amalgamated_translator', 'prior_is_a_study', 'prior_without_year',
+  'no_complete_prior_claimed', 'first_modern_candidate',
+];
+
+/**
+ * MEASURED BLIND SPOT — read this before trusting a clean screen.
+ *
+ * Coornhert's *De dolinghe van Ulysse* is a Dutch translation of Homer whose
+ * badge survived verification, and the screen does NOT flag it. Its record says
+ * `language: "Dutch"`, `author: "Homer"`, **`text_role: "original"`** — and that
+ * last value is simply wrong: the item is a translation. With `text_role` right,
+ * the witness detector above catches it exactly.
+ *
+ * So the gap is a DATA defect, not a missing rule, and the fix belongs upstream
+ * in work identity (#2318 / #3258), not in another regex here. Catching it by
+ * pattern would mean asserting "Homer wrote in Greek" from a hand-written
+ * author-language table — the exact unverifiable-assertion list that
+ * `source-language-match.mjs` deliberately refuses to keep, and that reproduces
+ * its bug on the first wrong entry.
+ *
+ * Consequence for the caller: **a zero risk score is not a clearance.** It means
+ * no known-unsafe pattern matched, and the known patterns do not cover a
+ * mislabelled witness. Treat the screen as ordering attention, never as a filter
+ * that removes candidates from review.
+ */
+export const KNOWN_LIMITS = {
+  gold_set_recall: '13 of 14 surviving badges flagged (2026-08-07, n=16)',
+  blind_spot: 'a translation whose text_role is mislabelled `original` — e.g. Coornhert/Homer',
+  upstream_fix: 'work identity + correct text_role (#2318, #3258)',
+};

--- a/tests/unit/ft-demote-screen.test.ts
+++ b/tests/unit/ft-demote-screen.test.ts
@@ -1,0 +1,310 @@
+/**
+ * The demote screen, pinned against VERIFIED ground truth.
+ *
+ * These 16 books were each verified by an independent Claude subagent doing real
+ * web research on 2026-08-07 (#3687, rounds 1-2). Every one was chosen *because*
+ * it looked like an obvious demote; 13 of the 16 badges turned out to be
+ * correct. That makes them a gold set rather than a fixture: the expected values
+ * below are what the world says, not what the code currently does.
+ *
+ * The screen's job is to raise a signal on the badges that SHOULD survive, so
+ * agent time goes to the candidates where a demote is actually plausible. It is
+ * a triage instrument and nothing else — it never adjudicates.
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import { screenDemoteCandidate } from '../../scripts/lib/ft-demote-screen.mjs';
+
+/** book, priors, and the VERIFIED outcome. `keep` = the badge was correct. */
+const GOLD: Array<{
+  name: string;
+  book: { title: string; author?: string; text_role?: string };
+  priors: Array<{ translator?: string; pub_year?: string; english_title?: string; completeness?: string }>;
+  keep: boolean;
+}> = [
+  // ── Round 1 ──────────────────────────────────────────────────────────────
+  {
+    name: 'Thucydides, Histories (MS, 11th c.) — DEMOTE HELD',
+    book: { title: 'Thucydides, Histories (MS, 11th c.)' },
+    priors: [
+      { translator: 'Thomas Nicolls', pub_year: '1550', english_title: 'The Hystory writtone by Thucidides', completeness: 'complete' },
+      { translator: 'Thomas Hobbes', pub_year: '1629', english_title: 'Eight Bookes of the Peloponnesian Warre', completeness: 'complete' },
+      { translator: 'Richard Crawley', pub_year: '1874', english_title: 'The History of the Peloponnesian War', completeness: 'complete' },
+      { translator: 'Rex Warner', pub_year: '1954', english_title: 'History of the Peloponnesian War', completeness: 'complete' },
+    ],
+    keep: false,
+  },
+  {
+    name: 'Newton, Emerald Tablet commentary — DEMOTE HELD',
+    book: { title: 'Commentary on the Emerald Tablet of Hermes (Keynes MS 13)' },
+    priors: [
+      { translator: 'Betty Jo Teeter Dobbs', pub_year: '1991', english_title: 'The Commentary on the Emerald Tablet', completeness: 'complete' },
+    ],
+    keep: false,
+  },
+  {
+    // The MEASURED BLIND SPOT. Its record says text_role:"original", which is
+    // wrong — the item is Coornhert's Dutch translation of Homer. With that
+    // field correct the witness detector catches it exactly; the gap is a data
+    // defect, not a missing rule. See KNOWN_LIMITS.
+    name: 'Homer / Coornhert Dutch Odyssey — BADGE STANDS',
+    book: { title: 'De Odyssea / De dolinghe van Ulysse' },
+    priors: [
+      { translator: 'George Chapman', pub_year: '1615', english_title: 'The Odysseys of Homer', completeness: 'complete' },
+      { translator: 'Richmond Lattimore', pub_year: '1967', english_title: 'The Odyssey of Homer', completeness: 'complete' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Diogenes Laertius / Traversari Latin — BADGE STANDS',
+    book: { title: 'Vitae et sententiae philosophorum. Tr: Ambrosius Traversarius' },
+    priors: [
+      { translator: 'Charles Duke Yonge', pub_year: '1853', english_title: 'The Lives and Opinions of Eminent Philosophers', completeness: 'complete' },
+      { translator: 'Robert Drew Hicks', pub_year: '1925', english_title: 'Lives of Eminent Philosophers', completeness: 'complete' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Calvin, Opera Quae Supersunt Omnia — BADGE STANDS',
+    book: { title: 'Opera Quae Supersunt Omnia (Corpus Reformatorum)' },
+    priors: [
+      { translator: 'Ford Lewis Battles', pub_year: '1960', english_title: 'Institutes of the Christian Religion', completeness: 'complete' },
+      { translator: 'John King, William Pringle', pub_year: '1844', english_title: "Calvin's Commentaries", completeness: 'partial' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Chrysostom, Lucubrationes (1527) — BADGE STANDS',
+    book: { title: 'Lucubrationes (1527)' },
+    priors: [
+      { translator: 'Paul W. Harkins', pub_year: '1979', english_title: 'Discourses against Judaizing Christians', completeness: 'partial' },
+      { translator: 'J. F. Brady and J. C. Olin', pub_year: '1992', english_title: "Erasmus' Life of John Chrysostom (Preface)", completeness: 'excerpt' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'al-Jahiz, Kitab al-Hayawan — BADGE STANDS',
+    book: { title: 'Kitab al-Hayawan' },
+    priors: [
+      { translator: 'Charles Pellat', pub_year: '1969', english_title: 'The Life and Works of Jahiz', completeness: 'excerpt' },
+      { translator: 'James E. Montgomery', pub_year: '2013', english_title: 'Al-Jahiz: In Praise of Books', completeness: 'partial' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Secretum secretorum — BADGE STANDS (first_modern)',
+    book: { title: 'Secretum secretorum ad Alexandrum Magnum' },
+    priors: [
+      { translator: 'Robert Copland', pub_year: '1528', english_title: 'The Secrete of Secretes of Arystotle', completeness: 'complete' },
+    ],
+    keep: true,
+  },
+  // ── Round 2 ──────────────────────────────────────────────────────────────
+  {
+    name: 'ibn Sallum, Arabic Paracelsus — BADGE STANDS',
+    book: { title: 'Paracelsus — Arabic Translation (PH254)' },
+    priors: [
+      { translator: 'Emilie Savage-Smith', pub_year: '1987', english_title: "Drug therapy of eye diseases in seventeenth-century Islamic medicine: The influence of the 'new chemistry' of the Paracelsians", completeness: 'excerpt' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Bellarmine / Petraeus Armenian-Latin — BADGE STANDS',
+    book: { title: 'Doctrina christiana Armenice, in Latinum versa, & publicata à muḳdasī M. Theodoro Petraeo' },
+    priors: [
+      { translator: 'Richard Hadock (or Richard Gibbons)', pub_year: '1614', english_title: 'A short Christian doctrine', completeness: 'complete' },
+      { translator: 'Ryan Grant', pub_year: '2016', english_title: 'Doctrina Christiana: The Timeless Catechism of St. Robert Bellarmine', completeness: 'complete' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Hollandus, De lapide philosophico — BADGE STANDS (fabricated prior)',
+    book: { title: 'Isaaci Hollandi tractatus de lapide philosophico oder vom Stein der Weisen' },
+    priors: [
+      { translator: 'Unknown (attributed to the 17th-century alchemical tradition)', pub_year: '1659', english_title: "A Work of John Isaac Hollandus concerning the Philosopher's Stone", completeness: 'complete' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Huygens, Opera Varia Vol. 1 — BADGE STANDS',
+    book: { title: 'Opera Varia, Vol. 1' },
+    priors: [
+      { translator: 'Richard J. Blackwell', pub_year: '1986', english_title: 'The Pendulum Clock', completeness: 'complete' },
+      { translator: 'Henry Oldenburg', pub_year: '1669', english_title: 'Instructions concerning the use of pendulum-watches', completeness: 'complete' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Malpighi, Opera Posthuma — BADGE STANDS',
+    book: { title: 'Opera Posthuma' },
+    priors: [
+      { translator: 'John M. Forrester', pub_year: '1995', english_title: "Malpighi's De polypo cordis: an annotated translation", completeness: 'excerpt' },
+      { translator: 'Howard B. Adelmann', pub_year: '1966', english_title: 'Marcello Malpighi and the Evolution of Embryology', completeness: 'partial' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Hilary of Poitiers, Lucubrationes (1523) — BADGE STANDS',
+    book: { title: 'Lucubrationes (1523)' },
+    priors: [
+      { translator: 'E.W. Watson and L. Pullan', pub_year: '1899', english_title: 'On the Trinity; On the Councils; Homilies on Psalms', completeness: 'partial' },
+      { translator: 'D.H. Williams', pub_year: '2012', english_title: 'Commentary on Matthew', completeness: 'partial' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Staupitz, Von der liebe Gottes — BADGE STANDS (first_modern)',
+    book: { title: 'Von der liebe Gottes ein wunder hübsch underrichtung' },
+    priors: [
+      { translator: 'unknown', pub_year: '1548', english_title: 'A righte goodly rule howe a christen man ought to occupie hym selfe', completeness: 'complete' },
+      { translator: 'Anonymous', pub_year: '1692', english_title: 'Of the Love of God', completeness: 'complete' },
+    ],
+    keep: true,
+  },
+  {
+    name: 'Boethius + Waleys commentary — SCOPE-DEPENDENT (treated as keep-signal)',
+    book: { title: 'De Consolatione Philosophiae', author: 'Boethius; comm. Thomas Waleys' },
+    priors: [
+      { translator: 'P.G. Walsh', pub_year: '1999', english_title: 'The Consolation of Philosophy', completeness: 'complete' },
+      { translator: 'Richard H. Green', pub_year: '1962', english_title: 'The Consolation of Philosophy', completeness: 'complete' },
+    ],
+    keep: true,
+  },
+];
+
+/** The one gold-set entry the screen cannot see — a data defect, not a rule gap. */
+const KNOWN_BLIND_SPOT = 'Homer / Coornhert Dutch Odyssey — BADGE STANDS';
+
+describe('the screen raises a signal on badges that survived verification', () => {
+  for (const g of GOLD.filter((x) => x.keep && x.name !== KNOWN_BLIND_SPOT)) {
+    it(`flags: ${g.name}`, () => {
+      const r = screenDemoteCandidate(g.book, g.priors);
+      expect(r.riskScore, `no signal raised; strongest=${r.strongestReason}`).toBeGreaterThan(0);
+    });
+  }
+
+  it('the blind spot is UNFLAGGED, and becomes flagged once text_role is correct', () => {
+    const g = GOLD.find((x) => x.name === KNOWN_BLIND_SPOT)!;
+    // As stored today: text_role is wrongly "original", so nothing fires.
+    expect(screenDemoteCandidate(g.book, g.priors).riskScore).toBe(0);
+    // With the field corrected, the witness detector catches it exactly. This is
+    // the proof that the gap is upstream data (#2318/#3258), not a missing rule.
+    const fixed = screenDemoteCandidate({ ...g.book, text_role: 'translation' }, g.priors);
+    expect(fixed.signals.map((s: { code: string }) => s.code)).toContain('item_is_a_witness');
+  });
+});
+
+describe('measured performance over the whole gold set', () => {
+  it('reports precision and recall rather than asserting them', () => {
+    const rows = GOLD.map((g) => ({ ...g, r: screenDemoteCandidate(g.book, g.priors) }));
+    const flagged = rows.filter((x) => x.r.riskScore > 0);
+    const keeps = rows.filter((x) => x.keep);
+
+    const truePos = flagged.filter((x) => x.keep).length;      // flagged AND badge was right
+    const falsePos = flagged.filter((x) => !x.keep).length;    // flagged BUT demote was right
+    const missed = keeps.filter((x) => x.r.riskScore === 0);   // badge right, no signal
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n  gold set n=${rows.length} · badges that survived=${keeps.length}\n`
+      + `  flagged=${flagged.length}  caught=${truePos}/${keeps.length}  `
+      + `also-flagged-a-real-demote=${falsePos}\n`
+      + (missed.length ? `  MISSED: ${missed.map((m) => m.name).join('; ')}\n` : '  MISSED: none\n'),
+    );
+
+    // Recall is what matters: a surviving badge that raises NO signal would be
+    // swept by anyone trusting the screen. That is the failure mode to prevent.
+    // Exactly ONE known miss, named. If this number rises, a new blind spot
+    // appeared and the screen is quietly under-flagging — the failure mode that
+    // would let someone sweep a correct badge.
+    expect(missed.map((m) => m.name)).toEqual([KNOWN_BLIND_SPOT]);
+  });
+
+  it('does NOT claim to separate real demotes — it only triages', () => {
+    // Thucydides and Newton were genuine demotes and both carry container/witness
+    // -adjacent noise, so the screen flags them too. That is expected and is why
+    // a signal is a reason to look, never a verdict. Pinned so nobody later
+    // "improves" the screen into an adjudicator.
+    const thucydides = GOLD.find((g) => g.name.startsWith('Thucydides'))!;
+    const r = screenDemoteCandidate(thucydides.book, thucydides.priors);
+    expect(r.riskScore).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('individual detectors fire on the case that motivated them', () => {
+  it('no_named_translator catches the fabricated Hollandus prior', () => {
+    const r = screenDemoteCandidate(
+      { title: 'Isaaci Hollandi tractatus de lapide philosophico' },
+      [{ translator: 'Unknown (attributed to the 17th-century alchemical tradition)', pub_year: '1659', english_title: 'A Work of John Isaac Hollandus', completeness: 'complete' }],
+    );
+    expect(r.signals.map((s: { code: string }) => s.code)).toContain('no_named_translator');
+  });
+
+  it('amalgamated_translator catches "Hadock (or Gibbons)"', () => {
+    const r = screenDemoteCandidate(
+      { title: 'Doctrina christiana' },
+      [{ translator: 'Richard Hadock (or Richard Gibbons)', pub_year: '1614', english_title: 'A short Christian doctrine', completeness: 'complete' }],
+    );
+    expect(r.signals.map((s: { code: string }) => s.code)).toContain('amalgamated_translator');
+  });
+
+  it('item_is_a_witness catches a title that names its own translator', () => {
+    const r = screenDemoteCandidate(
+      { title: 'Vitae et sententiae philosophorum. Tr: Ambrosius Traversarius' },
+      [{ translator: 'R.D. Hicks', pub_year: '1925', english_title: 'Lives', completeness: 'complete' }],
+    );
+    expect(r.signals.map((s: { code: string }) => s.code)).toContain('item_is_a_witness');
+  });
+
+  it('container_title catches Opera / Lucubrationes / Posthuma', () => {
+    for (const t of ['Opera Quae Supersunt Omnia', 'Lucubrationes (1523)', 'Opera Posthuma', 'Opera Varia, Vol. 1']) {
+      const r = screenDemoteCandidate({ title: t }, [{ translator: 'X Y', pub_year: '1990', english_title: 'Z', completeness: 'complete' }]);
+      expect(r.signals.map((s: { code: string }) => s.code), t).toContain('container_title');
+    }
+  });
+
+  it('first_modern_candidate fires when every complete prior is pre-1900', () => {
+    const r = screenDemoteCandidate(
+      { title: 'Secretum secretorum ad Alexandrum Magnum' },
+      [{ translator: 'Robert Copland', pub_year: '1528', english_title: 'The Secrete of Secretes', completeness: 'complete' }],
+    );
+    expect(r.signals.map((s: { code: string }) => s.code)).toContain('first_modern_candidate');
+  });
+
+  it('does not fire on an ordinary, well-formed demote', () => {
+    const r = screenDemoteCandidate(
+      { title: 'Die Verwandlung' },
+      [{ translator: 'Willa Muir', pub_year: '1933', english_title: 'The Metamorphosis', completeness: 'complete' }],
+    );
+    expect(r.riskScore).toBe(0);
+  });
+});
+
+describe('regressions found by running on the live queue, not the gold set', () => {
+  it('catches the Latin declensions of "commentarius" — Cardano slipped through on -aria', () => {
+    // The gold set contained no `-aria` form, so this gap was invisible to it
+    // and only surfaced against the real 59-book queue. Every ending is pinned
+    // because the next miss will be whichever one is absent here.
+    for (const t of [
+      'In Cl. Ptolemaei de Astrorum Iudiciis Commentaria',
+      'Commentarii in Genesim',
+      'Commentarius in Epistolam',
+      'Cum commentariis Thomae',
+      'Commentarium in Somnium Scipionis',
+    ]) {
+      const r = screenDemoteCandidate({ title: t }, [
+        { translator: 'A B', pub_year: '1990', english_title: 'X', completeness: 'complete' },
+      ]);
+      expect(r.signals.map((s: { code: string }) => s.code), t).toContain('work_plus_apparatus');
+    }
+  });
+
+  it('still fires on the bundled form, where the marker is in the AUTHOR field', () => {
+    const r = screenDemoteCandidate(
+      { title: 'De Consolatione Philosophiae', author: 'Boethius; comm. Thomas Waleys' },
+      [{ translator: 'P.G. Walsh', pub_year: '1999', english_title: 'The Consolation of Philosophy', completeness: 'complete' }],
+    );
+    expect(r.signals.map((s: { code: string }) => s.code)).toContain('work_plus_apparatus');
+  });
+});


### PR DESCRIPTION
Sixteen demote candidates from #3687 were verified one at a time by independent Claude subagents doing real web research. Every one had been picked *because* it looked like an obvious demote — a canonical work with famous English translations. **Thirteen of the sixteen badges turned out to be correct.**

The failures weren't scattered. They fell into shapes, and most of those shapes are visible in data we already hold. This is those detectors plus the instrument to run them.

## The nine signals

Each traces to a case that motivated it:

| signal | what it catches |
|---|---|
| `item_is_a_witness` | the item is itself a translation — a prior on the original is different-source-language (POLICY 2) |
| `work_plus_apparatus` | the item is, or bundles, a commentary — a prior on the base text doesn't cover it |
| `container_title` | `Opera` / `Omnia` / `Lucubrationes` / `Posthuma` / `Varia` — judge completeness against the container |
| `no_named_translator` | the fabricated-citation signature |
| `amalgamated_translator` | "Hadock **(or** Gibbons)" — a disjunction is not an attribution |
| `prior_is_a_study` | an expository title: a work *about* a text, not a rendering of it |
| `prior_without_year` | no `pub_year`, so `first_modern` cannot be graded |
| `no_complete_prior_claimed` | every prior partial/excerpt — unsupported on its own evidence |
| `first_modern_candidate` | all complete priors pre-1900, which is a **badge**, not a defeat |

## Measured, not asserted

`tests/unit/ft-demote-screen.test.ts` is a **gold set**, not a fixture: the sixteen verified books with their real outcomes, so the expected values are what the world said rather than what the code happens to do.

**Recall: 13 of 14 surviving badges flagged.**

The one miss is named and pinned rather than papered over. Coornhert's Dutch *Odyssey* isn't flagged because its record says `text_role: "original"` — which is wrong; the item is a translation. Two assertions cover it: that it stays unflagged today, and that **correcting the field makes the witness detector catch it exactly**. That's the proof the gap is upstream data (#2318/#3258), not a missing rule.

Closing it by pattern would mean hand-writing "Homer wrote in Greek" into an author-language table — precisely the unverifiable-assertion list `source-language-match.mjs` deliberately refuses to keep, and which reproduces its bug on the first wrong entry.

## The gold set could not catch everything, and the live queue proved it

Running against the real 59 immediately exposed a gap invisible to the tests: **`commentarius` declines.** The pattern listed `-y/-ies/-io/-iis/-ius` and Cardano's *In Cl. Ptolemaei de Astrorum Iudiciis **Commentaria*** slipped through on `-aria`. Fixed, with every ending pinned in a regression test, because the next miss will be whichever ending is absent.

Worth stating plainly: a gold set drawn from verified cases can only contain the forms those cases happened to use. It measures recall on the population it came from and is silent about everything else.

## Result on the live queue

```
screened 59 candidates
  flagged (demote likely unsafe) : 57
  no signal                      :  2

  no_complete_prior_claimed   36     container_title          5
  no_named_translator         33     work_plus_apparatus      4
  prior_without_year          28     item_is_a_witness        3
  prior_is_a_study            13     first_modern_candidate   2
                                     amalgamated_translator   1
```

The two clean candidates are Thucydides — **a verified genuine demote** — and Tremearne's bilingual *Hausa Folk-Tales*, whose claimed prior translator is the author himself and which may be `not_applicable` rather than either.

So the screen turns a 59-book agent-verification queue into a 2-book one, and the one already-verified demote in the queue lands correctly in the clean set.

## What it does not do

**READ-ONLY.** Writes nothing, flips nothing, calls no model. §17 applies in full: a mechanical signal about a bibliographic claim is a screening queue, never an adjudication.

**A zero score is explicitly NOT a clearance** — both the module and the script's own output say so at the point of use, because the known blind spot is exactly a candidate that scores zero. The screen orders attention; it must never be used as a filter that removes candidates from review.

## Bearing on #2933

The resolver valve blocking every one of these was **protecting correct badges**. Its asymmetry — verified provenance required to *withdraw* a claim while the claim itself rests on the legacy shim — reads less like an inconsistency now and more like the right default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
