### PR TITLE
fix(ft): recall is 32.1% after ESTC — and the header that would have hidden it

### DIFF
--- a/.claude/docs/first-translation-reference-set.md
+++ b/.claude/docs/first-translation-reference-set.md
@@ -46,21 +46,33 @@ cannot be debugged.
 
 ---
 
-## 2. THE GOVERNING NUMBER: catalogue recall is 27%
+## 2. THE GOVERNING NUMBER: catalogue recall is 32.1%
 
 `scripts/eval/ft-reference-set-recall.mjs`. Measured over the 607 books an
 independent classifier marks `previously_translated` that the search also examined:
 
 | variant | surfaced | none_found | recall |
 |---|---|---|---|
-| catalogue-only, all bases | 162 | 439 | **27.0%** |
+| catalogue-only, **LoC + Wikidata + ESTC** | 193 | 408 | **32.1%** *(2026-08-07)* |
+| catalogue-only, LoC + Wikidata | 162 | 439 | 27.0% *(2026-08-01, after MARC 240)* |
 | catalogue-only, no 245 confirmation | 133 | 468 | 22.1% *(the pre-2026-08-01 ceiling)* |
 | LoC alone | 155 | 446 | 25.8% |
 | Wikidata alone | 46 | 555 | 7.7% |
 | combined, incl. `translation_classification` | 607 | 0 | 100.0% **CIRCULAR — not recall** |
 
-**Three of every four known prior English translations are invisible to the
-catalogues.** Therefore:
+**ESTC bought +5.1 points** (#3522): 22,538 rows, a 16% increase in set size,
+contributing **8,325 candidates across 986 efforts** — about a third of all
+candidates surfaced. The gain was attributed by counting candidates carrying
+`source: 'estc'`, not inferred from the delta.
+
+That is a real improvement and it does not change the conclusion. **Two of every
+three known prior English translations remain invisible to the catalogues**, and
+the reason is structural rather than fixable by another source of the same kind:
+ESTC covers imprints **1473–1800**, while 80.8% of this corpus's known
+Latin/Greek priors are post-1950 imprints. The remaining loss sits in modern
+scholarly publishing that no early-modern catalogue can reach.
+
+Therefore, unchanged:
 
 - **`none_found` is WEAK evidence. Never quote a count built on it, in any cohort.**
 - **Positive findings are unaffected.** Poor recall cannot manufacture a false
@@ -380,7 +392,7 @@ Never pool them. Every effort records its cohort.
 | `inverse` | visible, translated, unbadged | a claim we may have and never made |
 | `untranslated` | everything we HOLD, non-English, no English translation (~57,600) | **a work queue** — nobody in this set has done it |
 
-### Why 27% recall is acceptable for `untranslated` and not for badging
+### Why sub-50% recall is acceptable for `untranslated` and not for badging
 
 Prioritisation **publishes nothing**, and the error directions cost differently:
 

--- a/.claude/docs/first-translation-system.md
+++ b/.claude/docs/first-translation-system.md
@@ -9,13 +9,17 @@
 > recorded, dated, reproducible **search** (`search_efforts`), and — crucially —
 > it *measures* what that search is worth. The headline:
 >
-> - **Catalogue recall is 27%.** Three of every four known prior English
->   translations are invisible to the reference set. **`none_found` is weak
->   evidence and no count built on it should be quoted.** Positive findings are
->   unaffected.
+> - **Catalogue recall is 32.1%** (2026-08-07, after adding ESTC; 22% → 27% → 32.1%).
+>   **Two of every three** known prior English translations are still invisible to
+>   the reference set. **`none_found` is weak evidence and no count built on it
+>   should be quoted.** Positive findings are unaffected.
 > - A sample of the queue puts `none_found`'s **positive predictive value at ~50%**.
-> - The cause is corpus, not matching: the extract is **1.04% pre-1800** against an
->   early-modern corpus. **Matcher/threshold work is finished** — see #3522 (ESTC).
+> - The cause is corpus, not matching, and ESTC (#3522, merged) bought +5.1 points —
+>   but it covers imprints **1473–1800** while 80.8% of this corpus's known
+>   Latin/Greek priors are post-1950 imprints, so the remaining loss sits in modern
+>   scholarly publishing that no early-modern catalogue can reach. **Do not read the
+>   gain as the problem receding.** (The old "the extract is 1.04% pre-1800" line was
+>   retracted as a false diagnosis — see the reference-set doc §2b/§2c.)
 >
 > Any statement in this doc of the form "N books are first translations" or "N have
 > no prior" was written without that measurement and should be re-derived. The

--- a/.claude/docs/invariants/first-translation-claims.md
+++ b/.claude/docs/invariants/first-translation-claims.md
@@ -11,11 +11,18 @@
 **Full doc: `.claude/docs/first-translation-reference-set.md`** — the evidence
 layer, its measured reliability, and the invariants below in detail.
 
-That machinery is only honest if you know the set's **recall**, and ours is **27%**
-(was 22%; `scripts/eval/ft-reference-set-recall.mjs`, measured against the attributed
-priors in `translation_classification`) — three of four known prior translations are
-invisible to it. A sampled check of the queue puts `none_found`'s **positive
-predictive value at ~50%**: a coin flip. So:
+That machinery is only honest if you know the set's **recall**, and ours is **32.1%**
+(22% → 27% with MARC 240 containment → 32.1% on 2026-08-07 with ESTC added;
+`scripts/eval/ft-reference-set-recall.mjs`, measured against the attributed priors in
+`translation_classification`) — **two of every three** known prior translations are
+still invisible to it. A sampled check of the queue puts `none_found`'s **positive
+predictive value at ~50%**: a coin flip.
+
+**Do not read the improvement as the problem receding.** ESTC covers imprints
+1473–1800 while 80.8% of this corpus's known Latin/Greek priors are post-1950
+imprints, so the remaining loss sits in modern scholarly publishing that no
+early-modern catalogue can reach. Adding sources of the same kind will not close
+it. So:
 
 - **`none_found` is WEAK evidence.** Never quote a count built on it. Positive findings (a prior *found* and verified) are unaffected — poor recall cannot manufacture a false positive.
 - **A null means different things in different traditions.** French has 23,035 English translations in the set, Syriac 119, and CJK is reachable only via MARC 880 (present on 2.3% of rows). Read reference-set *depth* beside every verdict; a flat badge cannot be honest across all of them.

--- a/.claude/docs/translation-works-architecture.md
+++ b/.claude/docs/translation-works-architecture.md
@@ -29,7 +29,8 @@ Hence the governing policy everywhere below:
 > a "no" from those sources actually worth?** It records the search itself
 > (`search_efforts`) and measures it.
 >
-> **Catalogue recall is 27%**, and a sampled positive predictive value of ~50% —
+> **Catalogue recall is 32.1%** (2026-08-07, after ESTC; was 27%), and a sampled
+> positive predictive value of ~50% —
 > so **`none_found` is weak evidence and no count built on it should be quoted**,
 > anywhere in this stack. Positive findings are unaffected. Read that doc before
 > quoting any gap, census, or registry figure that rests on an absence.

--- a/scripts/eval/ft-reference-set-recall.mjs
+++ b/scripts/eval/ft-reference-set-recall.mjs
@@ -22,10 +22,21 @@
  * answer to. That number is worthless and must never be quoted.
  *
  * So the honest measure is CATALOGUE-ONLY recall: re-derive each verdict from the
- * candidates that came from LoC and Wikidata alone, and ask how often those
- * catalogues independently surface a prior we know exists. That is directly
- * comparable to the 22.0% baseline of 2026-07-31 and is the number that moves
- * when the matcher genuinely improves.
+ * candidates that came from the external bibliographic catalogues alone —
+ * whatever `CATALOGUE_SOURCES` currently lists — and ask how often those
+ * catalogues independently surface a prior we know exists. It is the number that
+ * moves when the matcher genuinely improves, or when a source is added.
+ *
+ * Measured baselines, so a run can be read against its own history:
+ *   22.0%  2026-07-31  LoC + Wikidata, before MARC 240 containment
+ *   27.0%  2026-08-01  after 240 uniform-title containment (#3459)
+ *   32.1%  2026-08-07  after adding ESTC (#3522) — 22,538 rows, +16% set size,
+ *                      contributing 8,325 candidates across 986 efforts
+ *
+ * ⚠️ ADDING A SOURCE MEANS ADDING IT TO `CATALOGUE_SOURCES`. Leaving it out
+ * computes "catalogue-only" over a definition that excludes the catalogue you
+ * just added, so the number cannot move and reads as "that source contributed
+ * nothing." The printed header is derived from the set for the same reason.
  *
  * The combined figure is still worth printing, because it is what an effort
  * actually says about a book today — but it measures COVERAGE (do we hold any
@@ -144,10 +155,21 @@ await withMongo(async (db) => {
     return pct;
   };
 
+  // The label is DERIVED from the set, never hand-written. A hard-coded
+  // "(LoC + Wikidata)" survived the addition of ESTC and printed a header that
+  // named two sources while the number behind it counted three — the exact trap
+  // this subsystem keeps hitting: a metric's name is a claim about its
+  // denominator, and a stale name is a false claim. Anyone reading that output
+  // would have concluded ESTC contributed nothing.
+  const catalogueNames = [...CATALOGUE_SOURCES]
+    .map((s) => ({ loc_mdsconnect: 'LoC', wikidata: 'Wikidata', estc: 'ESTC' }[s] ?? s))
+    .join(' + ');
+
   const catalogue = report(
-    'CATALOGUE-ONLY (LoC + Wikidata) — the honest number',
+    `CATALOGUE-ONLY (${catalogueNames}) — the honest number`,
     (c) => CATALOGUE_SOURCES.has(c.source),
-    'Comparable to the 22.0% baseline of 2026-07-31. This is the one to quote.',
+    'Baselines: 22.0% (2026-07-31, LoC+Wikidata pre-240) → 27.0% (2026-08-01, after MARC 240\n'
+    + '  uniform-title containment) → this run. This is the one to quote.',
   );
 
   report(


### PR DESCRIPTION
Re-measured with ESTC in the set (#3522, #3695).

## The number

**Catalogue-only recall: 27.0% → 32.1%** over the same 607 books.

| variant | surfaced | none_found | recall |
|---|---|---|---|
| LoC + Wikidata + **ESTC** | 193 | 408 | **32.1%** (2026-08-07) |
| LoC + Wikidata | 162 | 439 | 27.0% (2026-08-01, after MARC 240) |
| no 245 confirmation | 133 | 468 | 22.1% (pre-2026-08-01 ceiling) |

**Attributed, not inferred.** ESTC contributed **8,325 candidates across 986 efforts** — about a third of all candidates surfaced — counted by `source: 'estc'` on the candidate rows rather than read off the delta.

## The header was a lie, and that is the interesting part

The report printed `CATALOGUE-ONLY (LoC + Wikidata)` from a hard-coded string while the number behind it counted three sources. **Anyone reading that output would have concluded ESTC contributed nothing.**

Same shape as the `CATALOGUE_SOURCES` omission fixed in #3695, one layer out: there the *set* excluded the new source, here the *label* did. A metric's name is a claim about its denominator, and a stale name is a false claim. The label is now derived from `CATALOGUE_SOURCES`, so it cannot drift again.

The baseline note was stale too — it compared against 22.0% (2026-07-31) with no mention of the 27.0% the MARC 240 work had already produced. It now prints the whole series so a run reads against its own history.

## The conclusion does not change, and the docs now say so

**Two of every three known priors remain invisible**, and the residue is structural rather than fixable by another source of the same kind: ESTC covers imprints **1473–1800**, while 80.8% of this corpus's known Latin/Greek priors are **post-1950 imprints**. The remaining loss sits in modern scholarly publishing that no early-modern catalogue can reach.

A `none_found` is still weak evidence and no count built on it should be quoted. Every doc that carried the old figure as current is updated — the reference-set doc, the invariant, `translation-works-architecture`, `first-translation-system` — with an explicit warning not to read the gain as the problem receding.

## One retraction carried through

`first-translation-system.md` still asserted *"the cause is corpus, not matching: the extract is 1.04% pre-1800"*. The reference-set doc had already retracted that as a true statistic and a false diagnosis (§2b/§2c — the real cause was an ingest filter requiring `041$h`), but it survived in the summary most readers hit first. Now corrected there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)