### PR TITLE
feat(locus): address the corpus by Bekker and Stephanus number, not scan page

### DIFF
--- a/scripts/audit/mcp-directory-contract.tools.json
+++ b/scripts/audit/mcp-directory-contract.tools.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Tool names the Anthropic directory listing was reviewed against, captured from the live tools/list response on 2026-08-05 (server 4.4.0), the day after the connector was published at claude.ai/directory/connectors/source-library. ADDING a tool is safe and needs no re-review — both listings store a pointer to /api/mcp, not a snapshot, and clients call tools/list on connect. RENAMING or REMOVING one silently breaks saved Claude Projects and any client holding the old name, so scripts/audit/mcp-directory-contract.mjs fails when a name here goes missing. Update this file deliberately, as part of a decision to break a name — never to make CI green. list_editions added 2026-08-07 alongside the tool itself — adding a tool is additive and needs no re-review; this file exists to catch REMOVALS.",
+  "_comment": "Tool names the Anthropic directory listing was reviewed against, captured from the live tools/list response on 2026-08-05 (server 4.4.0), the day after the connector was published at claude.ai/directory/connectors/source-library. ADDING a tool is safe and needs no re-review — both listings store a pointer to /api/mcp, not a snapshot, and clients call tools/list on connect. RENAMING or REMOVING one silently breaks saved Claude Projects and any client holding the old name, so scripts/audit/mcp-directory-contract.mjs fails when a name here goes missing. Update this file deliberately, as part of a decision to break a name — never to make CI green. list_editions added 2026-08-07 alongside the tool itself — adding a tool is additive and needs no re-review; this file exists to catch REMOVALS. get_locus added 2026-08-07 (server 4.7.0), same reasoning.",
   "captured_from": "https://sourcelibrary.org/api/mcp",
   "captured_at": "2026-08-05",
   "server_version_at_capture": "4.5.0",
@@ -58,6 +58,10 @@
     },
     {
       "name": "list_editions",
+      "readOnly": true
+    },
+    {
+      "name": "get_locus",
       "readOnly": true
     }
   ]

--- a/scripts/lib/locus-editions.mjs
+++ b/scripts/lib/locus-editions.mjs
@@ -1,0 +1,93 @@
+/**
+ * Which editions carry canonical loci, and on what evidence.
+ *
+ * This registry is deliberately a CURATED LIST rather than a detector.
+ *
+ * #3661 measured the alternative: across all 276 live Aristotle and Plato books,
+ * a linear scan-page→printed-number fit classified only ~22% as usable, and it
+ * scored the most valuable books WORST — a book printing Bekker numbers in the
+ * margin fits at 0.009 precisely because canonical numbers do not advance at the
+ * rate of pages. Any detector built on that signal would reject the best sources
+ * and accept a book's own pagination as though it were a citation standard.
+ *
+ * Getting that wrong does not produce a missing feature. It produces a confident
+ * wrong citation, which is the failure family
+ * `.claude/docs/invariants/entity-page-attribution.md` exists to prevent. So a
+ * book appears here only when someone has looked at its pages and can say which
+ * of the two mechanisms is printing the number.
+ *
+ * ## Growing this list
+ *
+ * `scripts/maintenance/extract-locus-anchors.mjs --survey` reports candidates:
+ * books whose `<page-num>` values parse as loci at a high rate. That output is a
+ * SHORTLIST FOR A HUMAN, not an auto-promotion path. Read a few pages, confirm
+ * the number is what you think it is, then add a row with its evidence.
+ *
+ * ## Fields
+ *
+ *   system    'bekker' | 'stephanus'
+ *   kind      'pagination' — the edition's own paging IS the standard (root
+ *                            editions only)
+ *             'marginal'   — canonical refs printed beside the text
+ *   evidence  why we believe it, in a sentence. Not decoration: this is what a
+ *             later reader checks the row against.
+ */
+
+export const LOCUS_EDITIONS = [
+  {
+    book_id: '69937973b0a84a5763964d43',
+    title: 'Aristotelis Opera, Vol. 2 (Bekker, Reimer 1831)',
+    system: 'bekker',
+    kind: 'pagination',
+    evidence:
+      'The root edition — Bekker numbers ARE this book\'s page numbers. Scan p.320 carries <page-num>1104</page-num>, p.321 1105, advancing 1:1. This is the reference frame every Aristotle citation resolves against.',
+  },
+  {
+    book_id: '69b21d42ddb4fa7c305b4693',
+    title: 'Platonis Opera Quae Extant, Vol. 2 (Stephanus 1578)',
+    system: 'stephanus',
+    kind: 'pagination',
+    evidence:
+      'The root edition — Stephanus numbers are named after this printing and are its page numbers. Scan pp.15,16,17 carry 3,4,5.',
+  },
+  {
+    book_id: '699376d2b0a84a5763961a97',
+    title: 'Platonis Opera (Burnet OCT 1902) — Republic, Timaeus, Critias',
+    system: 'stephanus',
+    kind: 'marginal',
+    evidence:
+      'Burnet prints Stephanus refs in the margin and the OCR captures them as ranges: p.122 reads "393 e - 394 d", p.123 "394 d - 395 b". Section letters run a-e, which only Stephanus does.',
+  },
+  {
+    book_id: '69937734b0a84a57639630fa',
+    title: 'Platonis Opera (Burnet OCT 1907) — Laws, Definitions',
+    system: 'stephanus',
+    kind: 'marginal',
+    evidence: 'Same Burnet OCT convention as the 1902 volume above.',
+  },
+  {
+    book_id: '69ae6681b3b0e7bf712d6201',
+    title: 'Works of Aristotle, Vol. 2 (Oxford 1908) — Physics, De Caelo',
+    system: 'bekker',
+    kind: 'marginal',
+    evidence:
+      'The Oxford translation prints Bekker page+column in the margin: p.60 "198a", p.62 "198b, 199a". Columns are a/b only, as Bekker requires.',
+  },
+  {
+    book_id: '69ae668db3b0e7bf712d66a9',
+    title: 'Meteorologica (Oxford 1923)',
+    system: 'bekker',
+    kind: 'marginal',
+    evidence: 'Same Oxford marginal-Bekker convention.',
+  },
+  {
+    book_id: '69ae6694b3b0e7bf712d6885',
+    title: 'Historia Animalium (Oxford 1910)',
+    system: 'bekker',
+    kind: 'marginal',
+    evidence:
+      'Same Oxford convention. Cited in #3661 as the case that proves the point: it scores fit=0.009 on a linear test and is one of the best sources in the corpus.',
+  },
+];
+
+export const LOCUS_EDITION_BY_ID = new Map(LOCUS_EDITIONS.map((e) => [e.book_id, e]));

--- a/scripts/lib/locus-parse.mjs
+++ b/scripts/lib/locus-parse.mjs
@@ -1,0 +1,190 @@
+/**
+ * Parsing canonical loci out of the numbers printed on a scanned page.
+ *
+ * ## What a locus is, and why scan pages are not one
+ *
+ * Bekker numbers (Aristotle) and Stephanus numbers (Plato) were fixed in 1831
+ * and 1578 so that a citation would survive re-typesetting. `1103b24` means the
+ * same words in every edition ever printed. A scan page number means those
+ * words in ONE copy, and is shareable with nobody — which is why an MCP client
+ * verifying Aristotle quotations had to reconstruct the mapping by hand and
+ * then guess at it (#3653 item 2, #3661).
+ *
+ * ## Two mechanisms that look identical in the data
+ *
+ * `<page-num>` holds a printed number. That number is one of two very different
+ * things, and telling them apart is the whole problem:
+ *
+ *   A. THE EDITION'S OWN PAGINATION. A locus only when that edition's paging
+ *      *is* the citation standard — true for the Bekker 1831 and Stephanus 1578
+ *      root editions, false for everything else.
+ *   B. MARGINAL CANONICAL REFERENCES printed beside the text, the Oxford/OCT
+ *      convention. These ARE loci already and need no fitting.
+ *
+ * A linear scan-page→printed-number fit separates them, and **scores B worst**,
+ * because canonical numbers do not advance at the rate of pages. Historia
+ * Animalium fits at 0.009 and is one of the best books in the corpus for this.
+ * So this module never infers the mechanism from the numbers. The book declares
+ * it (see `scripts/lib/locus-editions.mjs`), because a wrong guess here
+ * publishes a fabricated citation, which is worse than publishing none
+ * (`.claude/docs/invariants/entity-page-attribution.md`).
+ *
+ * ## Why the SYSTEM is also declared, never sniffed
+ *
+ * It is tempting to read the section letter: Bekker uses only columns a/b,
+ * Stephanus runs a–e, so an `e` implies Stephanus. That inference is wrong
+ * often enough to matter — OCR turns `c` into `e`, and a Bekker page with a
+ * misread column would silently become a Plato citation. The system is a
+ * property of the edition, which we know from its author, so it is passed in.
+ *
+ * ## The shapes actually observed
+ *
+ * Sampled from the pilot editions (2026-08-07). Every one of these is a real
+ * string from production `<page-num>`:
+ *
+ *   "1104"            Bekker root, bare page
+ *   "198a"            Oxford Aristotle, page + column
+ *   "184^a"           same, caret-marked superscript
+ *   "184ª"            same, unicode ordinal
+ *   "198b, 199a"      two references on one leaf
+ *   "393 b"           Burnet OCT, Stephanus page + section
+ *   "393 e - 394 d"   a range spanning the leaf
+ *   "iii" / "xi"      front-matter roman numerals — NOT loci
+ */
+
+/** Bekker pages run 184a1–1462b18. Stephanus runs 1a–1379e. */
+const RANGE = {
+  bekker: [184, 1462],
+  stephanus: [1, 1400],
+};
+
+/** Bekker has two columns; Stephanus has five sections. */
+const SECTIONS = {
+  bekker: 'ab',
+  stephanus: 'abcde',
+};
+
+/**
+ * Superscript and ordinal markers that printers used for the column letter, and
+ * that OCR preserves in several forms. `184^a`, `184ª`, `184a` are one thing.
+ */
+function normalizeRef(raw) {
+  return String(raw)
+    .replace(/[ªº]/g, 'a') // ª º — ordinal indicators, always column a
+    .replace(/\^/g, '')
+    .replace(/–|—/g, '-') // en/em dash → hyphen, so ranges parse
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * One printed reference → {page, section} or null.
+ *
+ * Rejects anything that is not a plain arabic number optionally followed by a
+ * single section letter. Roman numerals, library shelf marks ("PA 4279 A2"),
+ * accession stamps and reader annotations all fail here, which is the point —
+ * front matter is dense with them.
+ */
+function parseOne(token, system) {
+  const m = /^(\d{1,4})\s*([a-e])?$/i.exec(token.trim());
+  if (!m) return null;
+
+  const page = Number(m[1]);
+  const [lo, hi] = RANGE[system];
+  if (page < lo || page > hi) return null;
+
+  const section = m[2] ? m[2].toLowerCase() : null;
+  if (section && !SECTIONS[system].includes(section)) return null;
+
+  return { page, section };
+}
+
+/**
+ * Parse a `<page-num>` payload into every canonical reference it names.
+ *
+ * Returns `[]` rather than throwing on anything unrecognised: this runs over
+ * every page of a scanned book, most of which carry something that is not a
+ * locus, and a parser that treats noise as failure would be useless here.
+ *
+ * A range ("393 e - 394 d") yields its two ENDPOINTS, not the pages between.
+ * Interpolating the interior would invent anchors that are not printed
+ * anywhere, which is exactly the fabrication this module exists to avoid — the
+ * span is recorded on the anchor instead, so a caller can see the page covers
+ * a range without us claiming to know where inside it anything falls.
+ */
+export function parseLocusRefs(pageNumText, system) {
+  if (!pageNumText || !RANGE[system]) return [];
+  const text = normalizeRef(pageNumText);
+
+  // Split on commas and semicolons first — "198b, 199a" is two references.
+  // Then on hyphens, which mark a range across the leaf.
+  const out = [];
+  for (const chunk of text.split(/[,;]/)) {
+    // Empty parts come from a leading or trailing dash — "- 394 d" is a
+    // continuation marker for a range that began on the previous leaf, and the
+    // number after it is still a perfectly good anchor.
+    const parts = chunk.split('-').map((s) => s.trim()).filter(Boolean);
+
+    if (parts.length === 2) {
+      const from = parseOne(parts[0], system);
+      const to = parseOne(parts[1], system);
+      // A range is only trustworthy if BOTH ends parse. One good end and one
+      // scanning artefact is not half a range; it is an unread line.
+      if (from && to) out.push({ ...from, range_end: to });
+      continue;
+    }
+
+    // Anything with three or more dash-separated parts is not a reference we
+    // recognise — a date, a shelf mark, a hyphenated word bleeding in from the
+    // text. Guessing which fragment is the citation is how noise gets published.
+    if (parts.length !== 1) continue;
+
+    const one = parseOne(parts[0], system);
+    if (one) out.push(one);
+  }
+  return out;
+}
+
+/** "1103b" / "1103" — the canonical string form, for display and lookup. */
+export function formatLocus(page, section) {
+  return section ? `${page}${section}` : String(page);
+}
+
+/**
+ * Parse a user-supplied citation into a lookup key.
+ *
+ * Accepts what a classicist actually types: "1103b24", "Bekker 1103b",
+ * "Pol. 1287a28", "509d", "Republic 509 d". The work name and the line number
+ * are DISCARDED — deliberately.
+ *
+ * Line numbers are dropped because we anchor at page-and-column granularity;
+ * pretending to resolve `b24` when the anchor is `b` would be a precision claim
+ * we cannot support. The caller gets the column and reads it.
+ *
+ * The work name is dropped because canonical numbers are globally unique within
+ * their system: Bekker 1103 is in the Nicomachean Ethics no matter which volume
+ * you hold it in. That is what makes locus lookup independent of the work-identity
+ * problem in #3653 — the number resolves without knowing which work it names.
+ */
+export function parseLocusQuery(input, system) {
+  if (!input) return null;
+  const text = normalizeRef(input)
+    // Strip a leading system name or work abbreviation: "Bekker 1103b",
+    // "Pol. 1287a28", "Republic 509d".
+    .replace(/^[^\d]*/, '')
+    .trim();
+
+  const m = /^(\d{1,4})\s*([a-e])?\s*\d*$/i.exec(text);
+  if (!m) return null;
+
+  const page = Number(m[1]);
+  const [lo, hi] = RANGE[system];
+  if (page < lo || page > hi) return null;
+
+  const section = m[2] ? m[2].toLowerCase() : null;
+  if (section && !SECTIONS[system].includes(section)) return null;
+
+  return { page, section };
+}
+
+export const LOCUS_SYSTEMS = Object.keys(RANGE);

--- a/scripts/maintenance/extract-locus-anchors.mjs
+++ b/scripts/maintenance/extract-locus-anchors.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+/**
+ * Build `locus_anchors`: canonical reference → (book, scan page).
+ *
+ * Phase 1 of #3661. Reads the number the printer put on the page and records
+ * where it sits. No fitting, no interpolation — every row here is a number
+ * somebody printed, on a page we can show you.
+ *
+ *   node scripts/maintenance/extract-locus-anchors.mjs            # dry run
+ *   node scripts/maintenance/extract-locus-anchors.mjs --apply
+ *   node scripts/maintenance/extract-locus-anchors.mjs --survey   # find candidates
+ *
+ * ## The monotonicity check is the guard, not decoration
+ *
+ * OCR misreads numbers. A stray "1004" in a run of 1104s would, unchecked,
+ * publish a citation pointing 100 Bekker pages away — and it would look
+ * completely ordinary in the data, because a wrong number is the same shape as
+ * a right one. So anchors must not decrease as scan pages advance. Violations
+ * are DROPPED and COUNTED, never smoothed: the residual is reported so a reader
+ * can judge the source, which is what #3661's guards ask for.
+ *
+ * A book is refused entirely if too many of its anchors violate, because at
+ * that point the sequence is not a misread digit here and there — it is
+ * evidence the book is not what the registry claims.
+ *
+ * ## --survey
+ *
+ * Reports books NOT in the registry whose <page-num> values parse as loci at a
+ * high rate. This is a shortlist for a human to read, never an auto-promotion:
+ * a book's own pagination parses just as happily as a marginal canonical ref,
+ * and telling them apart is the one thing the numbers cannot do for you.
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+import { parseLocusRefs, formatLocus } from '../lib/locus-parse.mjs';
+import { LOCUS_EDITIONS } from '../lib/locus-editions.mjs';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI is not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const apply = args.includes('--apply');
+const survey = args.includes('--survey');
+
+/** Above this share of out-of-order anchors, disbelieve the book, not the digits. */
+const MAX_VIOLATION_RATE = 0.15;
+
+const client = new MongoClient(MONGODB_URI);
+
+function pageNumPayloads(text) {
+  return [...String(text || '').matchAll(/<page-num>([^<]*)<\/page-num>/g)].map((m) => m[1]);
+}
+
+/**
+ * A locus is only PARTIALLY ordered, and treating it as totally ordered is
+ * wrong in a way that looks exactly like bad OCR.
+ *
+ * `488` and `488a` are not two positions. The first is the second with the
+ * column unread — the printer set one number, and the scan caught the column on
+ * one leaf and not the next. A naive key of `page * 10 + section` ranks bare
+ * `488` BELOW `488a`, so an ordinary run reads as a backward step. That single
+ * mistake produced 101 false violations in Historia Animalium and refused a
+ * book #3661 names as one of the best sources in the corpus.
+ *
+ * So: compare pages first, and compare sections only when BOTH anchors have
+ * one. An underspecified anchor is never evidence of disorder.
+ */
+function isBackward(prev, next) {
+  if (next.page !== prev.page) return next.page < prev.page;
+  if (!prev.section || !next.section) return false; // one side underspecified
+  return next.section < prev.section;
+}
+
+/**
+ * A large backward jump is EITHER a new work starting OR a misread digit, and
+ * size alone cannot tell them apart.
+ *
+ * A collected-works volume restarts canonical numbering at each work: Burnet's
+ * 1902 OCT runs the Republic to Stephanus 621 and then begins the Timaeus at
+ * 17. But a single OCR error — 1104 read as 302 — jumps backward just as far.
+ *
+ * Accepting every large jump as a restart looked fine and was wrong: the Bekker
+ * root came out as three segments (792–804, 302–858, 603–1462) when the volume
+ * is one continuous run of 792–1462, and Burnet 1902 came out as eleven when
+ * the Republic, Timaeus and Critias make three. Each spurious "restart" admits
+ * the bad anchor as the start of a legitimate run — the wrong number ends up in
+ * the published data wearing a clean shirt.
+ *
+ * The distinguishing signal is what comes AFTER. A real restart is followed by
+ * a sustained ascending run at the new level; a misread is a single blip and
+ * the sequence resumes where it left off. So a reset must be CONFIRMED by
+ * look-ahead, and an unconfirmed jump is dropped as noise.
+ */
+const SEGMENT_RESET_PAGES = 20;
+const RESET_CONFIRM_ANCHORS = 3;
+
+/**
+ * Does a backward jump at `i` look like a genuine work restart?
+ *
+ * True only when the next few anchors continue ASCENDING from the new, lower
+ * level and stay below where the previous run had reached. A blip fails both
+ * halves: the sequence jumps straight back up past the old ceiling.
+ */
+function isConfirmedReset(raw, i, prev) {
+  const here = raw[i].ref;
+  let seen = 0;
+  let last = here;
+  for (let j = i + 1; j < raw.length && seen < RESET_CONFIRM_ANCHORS; j++) {
+    const next = raw[j].ref;
+    if (next.page >= prev.page) return false; // snapped back to the old run
+    if (next.page < last.page) return false; // not ascending from the new level
+    last = next;
+    seen++;
+  }
+  return seen === RESET_CONFIRM_ANCHORS;
+}
+
+/**
+ * Anchors for one book, in scan order, with out-of-order rows removed.
+ *
+ * Returns the kept anchors AND the dropped ones — the caller reports both. A
+ * function that returned only the good rows would make the source look cleaner
+ * than it is.
+ *
+ * `segment` counts work-restarts within the volume, so a caller can see that
+ * two anchors with the same number belong to different works.
+ */
+function anchorsForBook(pages, system) {
+  const raw = [];
+  for (const p of pages) {
+    const text = p.ocr?.data || '';
+    for (const payload of pageNumPayloads(text)) {
+      for (const ref of parseLocusRefs(payload, system)) {
+        raw.push({ page: p.page_number, ref });
+      }
+    }
+  }
+
+  const kept = [];
+  const dropped = [];
+  let prev = null;
+  let segment = 0;
+  let resets = 0;
+
+  for (let i = 0; i < raw.length; i++) {
+    const a = raw[i];
+    if (prev && isBackward(prev, a.ref)) {
+      const bigEnough = prev.page - a.ref.page >= SEGMENT_RESET_PAGES;
+      if (bigEnough && isConfirmedReset(raw, i, prev)) {
+        segment++;
+        resets++;
+      } else {
+        dropped.push(a);
+        continue;
+      }
+    }
+    prev = a.ref;
+    kept.push({ ...a, segment });
+  }
+  return { kept, dropped, resets, total: raw.length };
+}
+
+async function loadPages(db, bookId) {
+  return db
+    .collection('pages')
+    .find(
+      { book_id: bookId, 'ocr.data': { $exists: true, $ne: '' } },
+      { projection: { page_number: 1, 'ocr.data': 1 } },
+    )
+    .sort({ page_number: 1 })
+    .toArray();
+}
+
+async function runSurvey(db) {
+  console.log('Surveying Aristotle and Plato books not already in the registry.\n');
+  const known = new Set(LOCUS_EDITIONS.map((e) => e.book_id));
+  const books = await db
+    .collection('books')
+    .find(
+      { visible: true, pages_count: { $gt: 50 }, author: { $regex: /aristotle|plato/i } },
+      { projection: { id: 1, title: 1, author: 1, language: 1, published: 1, pages_count: 1 } },
+    )
+    .toArray();
+
+  const rows = [];
+  for (const b of books) {
+    if (known.has(b.id)) continue;
+    const system = /plato/i.test(b.author || '') ? 'stephanus' : 'bekker';
+    const pages = await loadPages(db, b.id);
+    if (pages.length < 50) continue;
+
+    let withPayload = 0;
+    let parsed = 0;
+    for (const p of pages) {
+      const payloads = pageNumPayloads(p.ocr?.data);
+      if (!payloads.length) continue;
+      withPayload++;
+      if (payloads.some((x) => parseLocusRefs(x, system).length)) parsed++;
+    }
+    if (withPayload < 30) continue;
+    const rate = parsed / withPayload;
+    if (rate < 0.6) continue;
+
+    const { kept, dropped, total } = anchorsForBook(pages, system);
+    rows.push({
+      id: b.id,
+      title: (b.title || '').slice(0, 52),
+      lang: b.language,
+      year: b.published,
+      system,
+      parseRate: rate,
+      anchors: kept.length,
+      violationRate: total ? dropped.length / total : 0,
+    });
+  }
+
+  rows.sort((a, b) => b.anchors - a.anchors);
+  console.log(`${rows.length} candidates (parse rate >= 0.60, >= 30 pages with a page-num):\n`);
+  for (const r of rows.slice(0, 40)) {
+    console.log(
+      `  ${r.id}  ${r.system.padEnd(9)} ${String(r.year).padEnd(6)} ${r.lang.padEnd(8)} ` +
+        `parse ${(r.parseRate * 100).toFixed(0).padStart(3)}%  anchors ${String(r.anchors).padStart(4)}  ` +
+        `out-of-order ${(r.violationRate * 100).toFixed(0).padStart(3)}%  ${r.title}`,
+    );
+  }
+  console.log(
+    '\nThese are NOT confirmed. A book\'s own pagination parses exactly as well as a\n' +
+      'marginal canonical reference. Read a few pages before adding a row to\n' +
+      'scripts/lib/locus-editions.mjs, and record which mechanism you saw.',
+  );
+}
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+
+  if (survey) {
+    await runSurvey(db);
+    return;
+  }
+
+  const docs = [];
+  const report = [];
+
+  for (const ed of LOCUS_EDITIONS) {
+    const book = await db
+      .collection('books')
+      .findOne({ _id: new ObjectId(ed.book_id) }, { projection: { id: 1, title: 1, author: 1, published: 1, language: 1, visible: 1 } });
+    if (!book) {
+      report.push({ ...ed, status: 'BOOK NOT FOUND', anchors: 0 });
+      continue;
+    }
+
+    const pages = await loadPages(db, book.id);
+    const { kept, dropped, resets, total } = anchorsForBook(pages, ed.system);
+    const violationRate = total ? dropped.length / total : 0;
+
+    if (violationRate > MAX_VIOLATION_RATE) {
+      report.push({
+        ...ed,
+        status: `REFUSED — ${(violationRate * 100).toFixed(0)}% out of order`,
+        anchors: 0,
+        dropped: dropped.length,
+        total,
+      });
+      continue;
+    }
+
+    for (const a of kept) {
+      docs.push({
+        system: ed.system,
+        page: a.ref.page,
+        section: a.ref.section,
+        locus: formatLocus(a.ref.page, a.ref.section),
+        ...(a.ref.range_end
+          ? { range_end_locus: formatLocus(a.ref.range_end.page, a.ref.range_end.section) }
+          : {}),
+        book_id: book.id,
+        scan_page: a.page,
+        book_title: book.title,
+        author: book.author,
+        published: book.published,
+        language: book.language,
+        edition_kind: ed.kind,
+        extracted_at: new Date(),
+      });
+    }
+
+    // Report a range PER SEGMENT. A single first-to-last span is nonsense on a
+    // collected-works volume: Burnet 1902 runs the Republic to 621 and then
+    // restarts at Timaeus 17, so its "span" printed as 406–220.
+    const segments = [];
+    for (const a of kept) {
+      const s = (segments[a.segment] ||= { from: a.ref, to: a.ref, n: 0 });
+      s.to = a.ref;
+      s.n++;
+    }
+
+    report.push({
+      ...ed,
+      status: 'ok',
+      anchors: kept.length,
+      dropped: dropped.length,
+      resets,
+      total,
+      segments: segments
+        .filter(Boolean)
+        .map((s) => `${formatLocus(s.from.page, s.from.section)}–${formatLocus(s.to.page, s.to.section)}`),
+    });
+  }
+
+  console.log(apply ? 'APPLYING\n' : 'DRY RUN — nothing written\n');
+  for (const r of report) {
+    console.log(`  ${r.system.padEnd(9)} ${r.kind.padEnd(10)} ${r.title.slice(0, 48)}`);
+    console.log(
+      `      ${r.status}  anchors ${r.anchors}` +
+        (r.total ? `  dropped ${r.dropped}/${r.total} (${((r.dropped / r.total) * 100).toFixed(1)}%)` : '') +
+        (r.resets ? `  work-restarts ${r.resets}` : ''),
+    );
+    if (r.segments?.length) console.log(`      ranges: ${r.segments.join('  |  ')}`);
+  }
+
+  const bySystem = docs.reduce((acc, d) => ((acc[d.system] = (acc[d.system] || 0) + 1), acc), {});
+  console.log(`\n  total anchors: ${docs.length} ${JSON.stringify(bySystem)}`);
+
+  if (apply) {
+    const col = db.collection('locus_anchors');
+    // Rebuild wholesale: anchors are derived, so a partial update would leave
+    // rows from a previous parser version alongside the current ones with no
+    // way to tell which is which.
+    await col.deleteMany({});
+    if (docs.length) await col.insertMany(docs);
+    await col.createIndex({ system: 1, page: 1, section: 1 });
+    await col.createIndex({ book_id: 1, scan_page: 1 });
+    console.log(`  wrote ${docs.length} anchors to locus_anchors`);
+  } else {
+    console.log('\n  Re-run with --apply to write.');
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => client.close());

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Embassy-of-the-Free-Mind/sourcelibrary",
   "title": "Source Library",
   "description": "Search 15K rare pre-modern texts translated to English: philosophy, religion, science, literature.",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "repository": {
     "url": "https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2",
     "source": "github"

--- a/src/app/api/locus/route.ts
+++ b/src/app/api/locus/route.ts
@@ -1,0 +1,151 @@
+/**
+ * GET /api/locus?system=bekker&ref=1103b
+ *
+ * Resolve a canonical citation to every witness the library holds.
+ *
+ * Bekker and Stephanus numbers were fixed in 1831 and 1578 so a citation would
+ * survive re-typesetting: `1103b` names the same words in every edition ever
+ * printed. Until now this library could only be addressed by scan page, which
+ * is a property of one copy and shareable with nobody — an MCP client verifying
+ * Aristotle quotations had to reconstruct the mapping by hand and then guess
+ * (#3653, #3661).
+ *
+ * Every row served here is a number a printer put on a page. Nothing is
+ * interpolated: if no anchor was printed for the requested locus, the nearest
+ * ones BELOW and ABOVE are returned and labelled as such, because "it is
+ * between these two leaves" is true and "it is on this leaf" would not be.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { parseLocusQuery, formatLocus, isLocusSystem, LOCUS_SYSTEMS } from '@/lib/locus';
+
+export const dynamic = 'force-dynamic';
+
+interface AnchorDoc {
+  system: string;
+  page: number;
+  section: string | null;
+  locus: string;
+  range_end_locus?: string;
+  book_id: string;
+  scan_page: number;
+  book_title: string;
+  author: string;
+  published: string;
+  language: string;
+  edition_kind: string;
+}
+
+/** Sort key that treats a bare page as compatible with any section of it. */
+const key = (page: number, section: string | null) =>
+  page * 10 + (section ? section.charCodeAt(0) - 96 : 0);
+
+function witness(a: AnchorDoc, exact: boolean) {
+  return {
+    book_id: a.book_id,
+    title: a.book_title,
+    author: a.author,
+    language: a.language,
+    published: a.published,
+    page: a.scan_page,
+    locus_on_page: a.locus,
+    ...(a.range_end_locus ? { page_runs_to: a.range_end_locus } : {}),
+    edition_kind: a.edition_kind,
+    match: exact ? 'exact' : 'nearest',
+    url: `https://sourcelibrary.org/book/${a.book_id}?page=${a.scan_page}`,
+    quote_url: `https://sourcelibrary.org/api/books/${a.book_id}/quote?page=${a.scan_page}`,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const system = searchParams.get('system');
+  const ref = searchParams.get('ref');
+
+  if (!isLocusSystem(system)) {
+    return NextResponse.json(
+      { error: `Unknown system. Available: ${LOCUS_SYSTEMS.join(', ')}.` },
+      { status: 400 },
+    );
+  }
+
+  const parsed = parseLocusQuery(ref, system);
+  if (!parsed) {
+    return NextResponse.json(
+      {
+        error: `Could not read "${ref}" as a ${system} reference.`,
+        recovery: 'Use a page number with an optional section letter, e.g. "1103b" or "509d". A line number may follow and is ignored.',
+      },
+      { status: 400 },
+    );
+  }
+
+  const db = await getDb();
+  const col = db.collection<AnchorDoc>('locus_anchors');
+  const target = key(parsed.page, parsed.section);
+
+  // Exact: same page, and same section when the caller named one. A caller
+  // asking for "1103" wants any column of 1103; one asking for "1103b" wants b.
+  const exactFilter: Record<string, unknown> = { system, page: parsed.page };
+  if (parsed.section) {
+    // Accept the bare-page anchor too — the printer set one number and the scan
+    // may not have caught the column. Excluding it would report "not held" for
+    // a leaf we can actually show.
+    exactFilter.section = { $in: [parsed.section, null] };
+  }
+
+  const exact = await col.find(exactFilter).limit(50).toArray();
+
+  // Books that could have answered but did not — so a caller can tell "we do
+  // not hold this passage" from "we hold it and the anchor was not printed".
+  const holders = await col.distinct('book_id', { system });
+  const hit = new Set(exact.map((a) => a.book_id));
+
+  // Bracket the requested locus per book: the last anchor at or below it and
+  // the first at or above. A book only brackets the passage if it has BOTH —
+  // one-sided means the locus falls outside the range that book covers, and
+  // returning its final page as "nearest" would point a reader at the wrong
+  // work entirely.
+  const nearest: AnchorDoc[] = [];
+  if (!exact.length) {
+    for (const bookId of holders) {
+      const [below] = await col
+        .find({ system, book_id: bookId, page: { $lte: parsed.page } })
+        .sort({ page: -1, section: -1 })
+        .limit(1)
+        .toArray();
+      const [above] = await col
+        .find({ system, book_id: bookId, page: { $gte: parsed.page } })
+        .sort({ page: 1, section: 1 })
+        .limit(1)
+        .toArray();
+      if (below && above) nearest.push(below, above);
+    }
+  }
+
+  const witnesses = exact.length
+    ? exact
+        .sort((a, b) => Math.abs(key(a.page, a.section) - target) - Math.abs(key(b.page, b.section) - target))
+        .map((a) => witness(a, true))
+    : nearest.map((a) => witness(a, false));
+
+  return NextResponse.json({
+    system,
+    reference: formatLocus(parsed.page, parsed.section),
+    requested: ref,
+    total: witnesses.length,
+    exact: exact.length > 0,
+    witnesses,
+    coverage: {
+      books_with_anchors: holders.length,
+      books_answering: hit.size,
+      note:
+        'Anchors are read from the numbers printed on the page — no interpolation. Only editions that print canonical references carry them, so a locus absent here is not evidence the corpus lacks the passage; it means no anchor was printed on a leaf we hold.',
+    },
+    ...(exact.length
+      ? {}
+      : {
+          caveat: `No anchor is printed for ${formatLocus(parsed.page, parsed.section)}. The witnesses above are the nearest anchors BELOW and ABOVE it, so the passage falls between them — read from there rather than citing these pages as the locus.`,
+        }),
+  });
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -321,6 +321,25 @@ async function listEditions(args: Record<string, unknown>) {
   };
 }
 
+/**
+ * Resolve a canonical citation — Bekker for Aristotle, Stephanus for Plato — to
+ * the pages that carry it.
+ *
+ * This is the "biggest missing feature" from the MCP quote-verification reports
+ * (#3653 item 2): scan pages are a property of one copy, while a Bekker number
+ * is the coordinate scholarship actually uses. Note it needs no work identity,
+ * which is what unblocked it — canonical numbers are globally unique within
+ * their system, so 1103b resolves without knowing which work it names.
+ */
+async function getLocus(args: Record<string, unknown>) {
+  const system = String(args.system || '').toLowerCase();
+  const reference = String(args.reference || '');
+  if (!system || !reference) {
+    return { error: 'invalid_request', message: 'Both system and reference are required, e.g. system "bekker", reference "1103b24".' };
+  }
+  return apiGet('/locus', new URLSearchParams({ system, ref: reference }));
+}
+
 async function getBookText(args: Record<string, unknown>) {
   const params = new URLSearchParams();
   if (args.chapter !== undefined) params.set('chapter', String(args.chapter));
@@ -718,6 +737,20 @@ const TOOLS: Tool[] = [
     },
   },
   {
+    name: 'get_locus',
+    title: 'Find a Canonical Reference (Bekker / Stephanus)',
+    description: 'RESOLVES A CANONICAL CITATION to the pages that carry it — Bekker numbers for Aristotle ("1103b24"), Stephanus for Plato ("509d"). PICK THIS when you have a reference rather than a phrase: verifying an attributed quotation, following a footnote, or comparing one passage across witnesses. Accepts what a classicist writes — "1103b24", "Bekker 1103b", "Pol. 1287a28", "Republic 509 d"; a work name and a trailing line number are ignored, since anchors are page-and-column. Returns each witness with its scan page, a reading URL and a quote URL. COVERAGE IS NARROW AND YOU MUST READ IT: only editions that PRINT canonical references carry anchors — currently the Bekker 1831 and Stephanus 1578 root editions plus five Oxford/Burnet volumes, together spanning Bekker 184a–1462 and Stephanus 3–992. A reference outside those ranges returns nothing, and that is NOT evidence the corpus lacks the passage — it means no anchor was printed on a leaf we hold. When no exact anchor exists the response returns the nearest anchors BELOW and ABOVE with exact:false and a caveat; the passage falls between them, so read from there rather than citing those pages as the locus. → To search by wording instead, use search_within_book; by meaning, search_concept.',
+    annotations: { title: 'Find a Canonical Reference (Bekker / Stephanus)', ...READ_ONLY },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        system: { type: 'string', enum: ['bekker', 'stephanus'], description: 'bekker for Aristotle, stephanus for Plato.' },
+        reference: { type: 'string', description: 'The citation, e.g. "1103b24", "Bekker 1103b", "Pol. 1287a28", "509d".' },
+      },
+      required: ['system', 'reference'],
+    },
+  },
+  {
     name: 'get_quotes',
     title: 'Get Quotes (batch)',
     description: 'READ PIPELINE step 3 — CITE, in batch. Get verbatim text + citation_link for SEVERAL pages of a single book in one round-trip, to assemble a multi-passage dossier. Specify either pages (an explicit array, e.g. [12, 40, 41]) or an inclusive from/to range. Max 25 pages per call. Each entry carries its own citation_link to present alongside the quote.',
@@ -828,6 +861,7 @@ async function handleToolCall(name: string, args: ToolArgs) {
     case 'list_books': return listBooks(args);
     case 'get_book': return getBook(args);
     case 'list_editions': return listEditions(args);
+    case 'get_locus': return getLocus(args);
     case 'get_book_text': return getBookText(args);
     case 'get_quote': return getQuote(args);
     case 'get_quotes': return getQuotes(args);
@@ -926,7 +960,7 @@ function buildNoResultsHint(tool: string, result: unknown, args: ToolArgs) {
 
 function createServer(reqContext: { ip: string; userAgent: string | null; identity: ApiIdentity }) {
   const server = new Server(
-    { name: 'source-library', version: '4.6.0' },
+    { name: 'source-library', version: '4.7.0' },
     { capabilities: { tools: {}, resources: {} } },
   );
 
@@ -1053,7 +1087,10 @@ function createServer(reqContext: { ip: string; userAgent: string | null; identi
 export async function GET() {
   return new Response(JSON.stringify({
     name: 'source-library',
-    version: '4.5.0',
+    // Kept in step with the initialize handshake above and with server.json.
+    // These had drifted to 4.6.0 / 4.5.0 / 4.6.0 — the same class of silent
+    // divergence that the directory contract audit exists to catch.
+    version: '4.7.0',
     description: 'Source Library MCP Server — search, read, and cite 15,000+ rare pre-modern texts translated to English. Connect via POST to this endpoint.',
     docs: 'https://sourcelibrary.org/developers',
     tools: TOOLS.map(t => t.name),

--- a/src/lib/locus.ts
+++ b/src/lib/locus.ts
@@ -1,0 +1,92 @@
+/**
+ * Canonical loci on the request path.
+ *
+ * TWIN: `scripts/lib/locus-parse.mjs` holds the full parser, including the
+ * extraction side (`parseLocusRefs`) that reads printed page numbers during the
+ * corpus sweep. Only the QUERY side is needed here — turning what a user typed
+ * into a lookup key — so only that is duplicated, and
+ * `tests/unit/locus-parse.test.ts` pins the two against each other.
+ *
+ * See the .mjs for why the system is declared rather than sniffed from the
+ * number, and why line numbers are dropped rather than resolved.
+ */
+
+export type LocusSystem = 'bekker' | 'stephanus';
+
+/** Bekker pages run 184a1–1462b18. Stephanus runs 1a–1379e. */
+const RANGE: Record<LocusSystem, [number, number]> = {
+  bekker: [184, 1462],
+  stephanus: [1, 1400],
+};
+
+/** Bekker has two columns; Stephanus has five sections. */
+const SECTIONS: Record<LocusSystem, string> = {
+  bekker: 'ab',
+  stephanus: 'abcde',
+};
+
+export const LOCUS_SYSTEMS = Object.keys(RANGE) as LocusSystem[];
+
+export function isLocusSystem(v: unknown): v is LocusSystem {
+  return typeof v === 'string' && v in RANGE;
+}
+
+export interface ParsedLocus {
+  page: number;
+  section: string | null;
+}
+
+/**
+ * Parse a citation as a classicist would type it: "1103b24", "Bekker 1103b",
+ * "Pol. 1287a28", "Republic 509 d".
+ *
+ * The work name and the line number are DISCARDED. Line numbers because anchors
+ * are page-and-column, and answering `1103b24` differently from `1103b` would
+ * claim a precision the data does not carry. Work names because canonical
+ * numbers are globally unique within their system — Bekker 1103 is in the
+ * Nicomachean Ethics whichever volume holds it — which is exactly what makes
+ * locus lookup independent of the unresolved work-identity problem in #3653.
+ */
+export function parseLocusQuery(input: string | null | undefined, system: LocusSystem): ParsedLocus | null {
+  if (!input || !RANGE[system]) return null;
+
+  const text = String(input)
+    .replace(/[ªº]/g, 'a')
+    .replace(/\^/g, '')
+    .replace(/–|—/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[^\d]*/, '') // strip a leading system name or work abbreviation
+    .trim();
+
+  const m = /^(\d{1,4})\s*([a-e])?\s*\d*$/i.exec(text);
+  if (!m) return null;
+
+  const page = Number(m[1]);
+  const [lo, hi] = RANGE[system];
+  if (page < lo || page > hi) return null;
+
+  const section = m[2] ? m[2].toLowerCase() : null;
+  if (section && !SECTIONS[system].includes(section)) return null;
+
+  return { page, section };
+}
+
+/** "1103b" / "1103" — the canonical string form. */
+export function formatLocus(page: number, section: string | null): string {
+  return section ? `${page}${section}` : String(page);
+}
+
+/**
+ * Which system does an author cite in?
+ *
+ * Deliberately narrow. Bekker and Stephanus are the two systems we hold anchors
+ * for; Diels-Kranz, Migne and the rest are real and not yet extracted, so this
+ * returns null rather than guessing at a frame we cannot resolve.
+ */
+export function systemForAuthor(author: string | null | undefined): LocusSystem | null {
+  if (!author) return null;
+  if (/aristotle|aristotel/i.test(author)) return 'bekker';
+  if (/plato(?!n?ist)|platon(?!ist)/i.test(author)) return 'stephanus';
+  return null;
+}

--- a/tests/unit/locus-parse.test.ts
+++ b/tests/unit/locus-parse.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Parsing canonical loci out of what the printer actually put on the page.
+ *
+ * Every input string in the "real shapes" block below was taken from production
+ * `<page-num>` values in the pilot editions on 2026-08-07. That matters: the
+ * failure mode for this parser is not "throws on garbage" — it is accepting a
+ * shelf mark, an accession stamp, or a front-matter roman numeral as a
+ * citation, which publishes a locus nobody printed.
+ *
+ * The negative cases are therefore the important half of this file.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — .mjs sibling, no type declarations
+import { parseLocusRefs, parseLocusQuery, formatLocus } from '../../scripts/lib/locus-parse.mjs';
+
+describe('parseLocusRefs — shapes observed in production', () => {
+  it('a bare Bekker page', () => {
+    expect(parseLocusRefs('1104', 'bekker')).toEqual([{ page: 1104, section: null }]);
+  });
+
+  it('Bekker page with column', () => {
+    expect(parseLocusRefs('198a', 'bekker')).toEqual([{ page: 198, section: 'a' }]);
+  });
+
+  it('caret and ordinal superscripts are the same column', () => {
+    // The Oxford scans yield all three forms for one printed marker.
+    expect(parseLocusRefs('184^a', 'bekker')).toEqual([{ page: 184, section: 'a' }]);
+    expect(parseLocusRefs('184ª', 'bekker')).toEqual([{ page: 184, section: 'a' }]);
+    expect(parseLocusRefs('184a', 'bekker')).toEqual([{ page: 184, section: 'a' }]);
+  });
+
+  it('two references on one leaf', () => {
+    expect(parseLocusRefs('198b, 199a', 'bekker')).toEqual([
+      { page: 198, section: 'b' },
+      { page: 199, section: 'a' },
+    ]);
+  });
+
+  it('a Stephanus page with section', () => {
+    expect(parseLocusRefs('393 b', 'stephanus')).toEqual([{ page: 393, section: 'b' }]);
+  });
+
+  it('a range keeps both endpoints and interpolates nothing', () => {
+    // Burnet prints "393 e - 394 d" for one leaf. We record where the leaf
+    // starts and where it ends; claiming to know where 394a falls inside it
+    // would be inventing an anchor nobody printed.
+    expect(parseLocusRefs('393 e - 394 d', 'stephanus')).toEqual([
+      { page: 393, section: 'e', range_end: { page: 394, section: 'd' } },
+    ]);
+  });
+
+  it('en-dash ranges parse like hyphens', () => {
+    expect(parseLocusRefs('407 e – 408 c', 'stephanus')).toEqual([
+      { page: 407, section: 'e', range_end: { page: 408, section: 'c' } },
+    ]);
+  });
+});
+
+describe('parseLocusRefs — what must NOT become a citation', () => {
+  it('front-matter roman numerals', () => {
+    for (const r of ['iii', 'iv', 'vii', 'xi', 'ix']) {
+      expect(parseLocusRefs(r, 'bekker'), r).toEqual([]);
+    }
+  });
+
+  it('library shelf marks and accession stamps', () => {
+    // Real strings from the Historia Animalium and Burnet front matter.
+    expect(parseLocusRefs('PA 4279 A2 1900 v. 4', 'stephanus')).toEqual([]);
+    expect(parseLocusRefs('590 Ar4 1910', 'bekker')).toEqual([]);
+    expect(parseLocusRefs('25 Ap 38', 'bekker')).toEqual([]);
+  });
+
+  it('numbers outside the system range', () => {
+    // Bekker starts at 184; a page-number of 12 is the book's own pagination.
+    expect(parseLocusRefs('12', 'bekker')).toEqual([]);
+    expect(parseLocusRefs('9999', 'bekker')).toEqual([]);
+  });
+
+  it('a section letter the system does not have', () => {
+    // Bekker has columns a and b only. An "e" here means the OCR misread, or
+    // the book is not what we think — either way it is not a Bekker locus.
+    expect(parseLocusRefs('1103e', 'bekker')).toEqual([]);
+    expect(parseLocusRefs('393e', 'stephanus')).toEqual([{ page: 393, section: 'e' }]);
+  });
+
+  it('a half-readable range is not half a range', () => {
+    // One good end plus one scanning artefact is an unread line, not evidence.
+    expect(parseLocusRefs('393 e - ???', 'stephanus')).toEqual([]);
+    expect(parseLocusRefs('- 394 d', 'stephanus')).toEqual([{ page: 394, section: 'd' }]);
+  });
+
+  it('empty and unknown systems', () => {
+    expect(parseLocusRefs('', 'bekker')).toEqual([]);
+    expect(parseLocusRefs('1104', 'diels-kranz')).toEqual([]);
+  });
+});
+
+describe('parseLocusQuery — what a classicist actually types', () => {
+  it('accepts a bare reference', () => {
+    expect(parseLocusQuery('1103b', 'bekker')).toEqual({ page: 1103, section: 'b' });
+  });
+
+  it('drops the line number rather than pretending to resolve it', () => {
+    // Anchors are page-and-column. Returning something different for 1103b24
+    // than for 1103b would claim a precision we do not have.
+    expect(parseLocusQuery('1103b24', 'bekker')).toEqual({ page: 1103, section: 'b' });
+  });
+
+  it('strips a system name or work abbreviation', () => {
+    expect(parseLocusQuery('Bekker 1103b', 'bekker')).toEqual({ page: 1103, section: 'b' });
+    expect(parseLocusQuery('Pol. 1287a28', 'bekker')).toEqual({ page: 1287, section: 'a' });
+    expect(parseLocusQuery('Republic 509 d', 'stephanus')).toEqual({ page: 509, section: 'd' });
+  });
+
+  it('rejects what it cannot read', () => {
+    expect(parseLocusQuery('somewhere in the Ethics', 'bekker')).toBeNull();
+    expect(parseLocusQuery('', 'bekker')).toBeNull();
+    expect(parseLocusQuery('12', 'bekker')).toBeNull();
+  });
+});
+
+/**
+ * The request path (`src/lib/locus.ts`) duplicates only the QUERY side of the
+ * parser, because that is all an API route needs. Duplication is how the four
+ * copies of computeEndPages stayed wrong in four places at once (#3696), so the
+ * twins are pinned here.
+ */
+describe('.ts/.mjs twin parity — parseLocusQuery', () => {
+  it('both implementations agree on every query form', async () => {
+    const ts = await import('@/lib/locus');
+    const cases: Array<[string, 'bekker' | 'stephanus']> = [
+      ['1103b24', 'bekker'],
+      ['Bekker 1103b', 'bekker'],
+      ['Pol. 1287a28', 'bekker'],
+      ['184a', 'bekker'],
+      ['1462', 'bekker'],
+      ['12', 'bekker'],
+      ['1103e', 'bekker'],
+      ['509d', 'stephanus'],
+      ['Republic 621 d', 'stephanus'],
+      ['somewhere in the Ethics', 'bekker'],
+      ['', 'bekker'],
+    ];
+    for (const [input, system] of cases) {
+      expect(ts.parseLocusQuery(input, system), `"${input}" (${system})`).toEqual(
+        parseLocusQuery(input, system),
+      );
+    }
+  });
+
+  it('formatLocus agrees', async () => {
+    const ts = await import('@/lib/locus');
+    for (const [p, s] of [[1103, 'b'], [1104, null], [509, 'd']] as Array<[number, string | null]>) {
+      expect(ts.formatLocus(p, s)).toBe(formatLocus(p, s));
+    }
+  });
+});
+
+describe('formatLocus', () => {
+  it('round-trips through parseLocusQuery', () => {
+    for (const s of ['1103b', '1104', '509d', '184a']) {
+      const system = Number(s.replace(/\D/g, '')) >= 184 ? 'bekker' : 'stephanus';
+      const parsed = parseLocusQuery(s, system);
+      if (parsed) expect(formatLocus(parsed.page, parsed.section)).toBe(s);
+    }
+  });
+});


### PR DESCRIPTION
Phases 1 and 3 of #3661 — the top ask across four separate MCP reports (#3653 item 2).

## What it does

```
get_locus("bekker", "1103b24")  →  p.319 of the Bekker 1831 Opera
```

That page carries, immediately after its `<column-break/>`, **μὲν δίκαια πράττοντες δίκαιοι γινόμεθα** — NE 1103b1, "by doing just acts we become just". Verified by reading the page, not by trusting the fit.

Every target named in the reports resolves: `Pol. 1287a28`, Poetics `1460a26` (the passage that cost the reporter six calls to find by hand), Metaphysics `1045a8`, Physics `184a`, Republic `509d`.

## Why this wasn't blocked on work identity

#3653 framed locus lookup as downstream of decomposing multi-work volumes. **It isn't.** Canonical numbers are globally unique within their system — 1103b is in the Nicomachean Ethics whichever volume holds it — so the reference resolves without knowing which work it names. That is what made this shippable now rather than after `contains_works`.

## The system and mechanism are declared, never sniffed

`<page-num>` holds *either* the edition's own pagination *or* a marginal canonical reference. A linear fit separates them and scores the more valuable one **worst** — Historia Animalium fits at 0.009 and is one of the best sources in the corpus. Guessing wrong doesn't produce a missing feature; it produces a confident wrong citation.

So `scripts/lib/locus-editions.mjs` is a curated list carrying per-row evidence, and `--survey` yields a shortlist for a human rather than an auto-promotion path.

## Two ordering bugs the data found, both of which had refused good books

**A bare `488` is not a position before `488a`** — it's the same page with the column unread. Ranking it lower made 101 ordinary steps look backward and refused Historia Animalium outright (22% "out of order").

**A collected-works volume restarts numbering per work.** Burnet 1902 runs the Republic to Stephanus 621, then begins the Timaeus at 17. But a misread digit jumps backward just as far, so size alone can't distinguish them — and accepting every large jump admitted the bad anchor as the head of a legitimate run. A reset now requires look-ahead confirmation: a real restart is followed by a sustained ascending run, a blip isn't.

That took the Bekker root from three bogus segments (`792–804 | 302–858 | 603–1462`) to the single continuous `792–1462` the volume actually is, and Burnet 1902 from eleven segments to three.

## Result

**4,279 anchors over 7 editions, 0–2.4% dropped.**

| edition | anchors | dropped | ranges |
|---|---|---|---|
| Bekker 1831 (root) | 651 | 0.3% | 792–1462 |
| Stephanus 1578 (root) | 981 | 0.2% | 3–992 |
| Burnet OCT 1902 | 534 | 1.7% | Republic / Timaeus / Critias |
| Burnet OCT 1907 | 568 | 1.0% | Minos, Laws, Epinomis, Definitions |
| Oxford 1908 | 551 | **0.0%** | 184a–338b |
| Meteorologica 1923 | 490 | **0.0%** | 338a–486b |
| Historia Animalium 1910 | 504 | **0.0%** | 486a–633 |

The three Oxford volumes tile contiguously and match the published Bekker ranges exactly (Physics opens at 184a1, HA at 486a5).

## Nothing is interpolated

Where no anchor was printed, the response returns the nearest anchors **below and above** with `exact: false` and states the passage falls between them. A book is offered as a bracket only when it has *both* sides — a one-sided "nearest" points at the wrong work entirely.

The tool description states the coverage ranges outright and says that a miss is **not** evidence the corpus lacks the passage, only that no anchor was printed on a leaf we hold. Per #3661's guards: publish only where corroborated, report residuals rather than smoothing them.

## Also

Fixes a pre-existing version drift that the directory contract audit exists to catch: the `initialize` handshake said 4.6.0, the `GET` said 4.5.0, `server.json` said 4.6.0. All three now read **4.7.0**. `get_locus` is added to the pinned tool manifest — additive, so no directory re-review needed.

## Out of scope

Phase 2's cross-edition fit, and the ~151 Aristotle/Plato books with no usable numeric structure — reaching those needs *text* alignment to a root edition, not number alignment. #3661 is explicit that Phases 1–3 should not be sold as solving it.

Not built, but now visible: the Bekker root's OCR preserves `<column-break/>`, so resolving `1103a` vs `1103b` to the correct half of the page is derivable. Worth a follow-up.

## Test

`npx vitest run tests/unit/locus-parse.test.ts` — 20 passing, including `.ts`/`.mjs` twin parity. Full unit suite green (2,096). `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
