### PR TITLE
fix(mcp): the server version was three literals, and they drifted to three values

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Embassy-of-the-Free-Mind/sourcelibrary",
   "title": "Source Library",
   "description": "Search 15K rare pre-modern texts translated to English: philosophy, religion, science, literature.",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "repository": {
     "url": "https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2",
     "source": "github"

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -17,6 +17,26 @@ import {
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
+/**
+ * The MCP server version, in ONE place.
+ *
+ * It used to be three string literals — the `initialize` handshake, the
+ * `GET /api/mcp` banner, and `server.json` — and they drifted apart every time
+ * someone bumped one of them: on 2026-08-07 they read 4.7.0, 4.5.0 and 4.6.0
+ * simultaneously. Two of those bumps were made by people specifically tidying
+ * the version, which is the tell that the problem is the duplication, not the
+ * carelessness.
+ *
+ * `scripts/audit/mcp-directory-contract.mjs` compares the live handshake
+ * against `server.json`, so a drift here is a real tripwire and not cosmetic —
+ * but it can only compare two values, and there were three.
+ *
+ * `server.json` is consumed by the MCP registry publisher and cannot import
+ * TypeScript, so it stays a literal. That is now the ONLY other copy, and the
+ * audit's job is exactly to hold it against this one. Bump both together.
+ */
+const SERVER_VERSION = '4.7.0';
+
 // ── API helpers (same as mcp-server/src/api.ts, self-calling) ──────
 
 const API_BASE = 'https://sourcelibrary.org/api';
@@ -960,7 +980,7 @@ function buildNoResultsHint(tool: string, result: unknown, args: ToolArgs) {
 
 function createServer(reqContext: { ip: string; userAgent: string | null; identity: ApiIdentity }) {
   const server = new Server(
-    { name: 'source-library', version: '4.7.0' },
+    { name: 'source-library', version: SERVER_VERSION },
     { capabilities: { tools: {}, resources: {} } },
   );
 
@@ -1088,7 +1108,7 @@ function createServer(reqContext: { ip: string; userAgent: string | null; identi
 export async function GET() {
   return new Response(JSON.stringify({
     name: 'source-library',
-    version: '4.5.0',
+    version: SERVER_VERSION,
     description: 'Source Library MCP Server — search, read, and cite 15,000+ rare pre-modern texts translated to English. Connect via POST to this endpoint.',
     docs: 'https://sourcelibrary.org/developers',
     tools: TOOLS.map(t => t.name),


### PR DESCRIPTION
The MCP server currently reports **three different versions at once**:

| site | version |
|---|---|
| `initialize` handshake | 4.7.0 |
| `GET /api/mcp` banner | 4.5.0 |
| `server.json` | 4.6.0 |

## Why this is a duplication bug, not a carelessness bug

Two of those three had been bumped by people *specifically tidying the version*. Each bump found one copy, updated it, and left the others behind. A third round of hand-correcting the numbers would have the same half-life.

`scripts/audit/mcp-directory-contract.mjs` compares the live handshake against `server.json`, so this is a real tripwire rather than cosmetic — that audit exists because the connector was silently de-listed once already. But it can only hold **two** values against each other, and there were three, so the `GET` banner could drift indefinitely with nothing noticing.

## The fix

One `SERVER_VERSION` constant in `route.ts` feeds both runtime sites. `server.json` stays a literal — the MCP registry publisher consumes it and it can't import TypeScript — but it is now the *only* other copy, which is exactly the pair the audit was written to compare.

No behaviour change: 4.7.0 is what the handshake already reported and what the directory has been talking to.

## Provenance

Split out of #3713, which I closed as superseded by #3703. This was the only piece of it worth keeping — #3703 bumped the handshake to 4.7.0 but the other two sites were left behind, so the drift is still live on `main`.

## Verified

- `node scripts/audit/mcp-directory-contract.mjs --self-test` — 14/14
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
