### PR TITLE
fix(batch): collect Gemini results on a schedule, not by hand

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -31,6 +31,15 @@ const limitIdx = args.indexOf('--limit');
 const LIMIT = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : Infinity;
 const concIdx = args.indexOf('--concurrency');
 const CONCURRENCY = concIdx >= 0 ? parseInt(args[concIdx + 1], 10) : 10;
+// Gemini discards batch output a couple of days after a job finishes. A job still
+// uncollected weeks later is not "pending", it is unrecoverable — but it matched the
+// selection query on every run, so each pass burned a lookup on it and reported it as
+// an error. With the collector on a cron that meant a permanently red log, which is
+// worse than useless: it hides a real failure among 22 that will never clear.
+// --abandon-stale=N marks anything older than N days as given up on, with provenance.
+const abandonArg = args.find(a => a.startsWith('--abandon-stale='));
+const ABANDON_STALE_DAYS = abandonArg ? parseInt(abandonArg.split('=')[1], 10) : null;
+const DRY_RUN = args.includes('--dry-run');
 
 // --- OCR metadata extraction (mirrors defaults.ts) ---
 function extractPageType(text) {
@@ -320,6 +329,40 @@ async function processOneJob(db, job) {
 }
 
 // --- Main ---
+/**
+ * Mark jobs older than `days` as abandoned so the collector stops retrying them.
+ *
+ * Never deletes: sets a flag plus the reason and the status it had, so the decision is
+ * auditable and reversible with a single $unset. Only touches jobs the collector would
+ * otherwise select — a job already collected is left alone.
+ */
+async function abandonStaleJobs(db, days) {
+  const cutoff = new Date(Date.now() - days * 86400000);
+  const filter = {
+    child_job_ids: { $exists: false },
+    collection_abandoned: { $ne: true },
+    created_at: { $lt: cutoff },
+    $or: [
+      { status: { $in: ['pending', 'processing', 'completed', 'completed_with_errors', 'JOB_STATE_PENDING', 'JOB_STATE_RUNNING'] }, results_collected: { $ne: true } },
+      { status: 'saved', completed_pages: 0 },
+    ],
+  };
+  const stale = await db.collection('batch_jobs').countDocuments(filter);
+  if (stale === 0) { console.log(`No jobs older than ${days}d to abandon.`); return; }
+  if (DRY_RUN) { console.log(`[dry-run] would abandon ${stale} job(s) older than ${days}d`); return; }
+  const res = await db.collection('batch_jobs').updateMany(filter, [
+    {
+      $set: {
+        collection_abandoned: true,
+        collection_abandoned_at: new Date(),
+        collection_abandoned_reason: `uncollected after ${days}d — Gemini batch output has expired`,
+        status_before_abandon: '$status',
+      },
+    },
+  ]);
+  console.log(`Abandoned ${res.modifiedCount} stale job(s) older than ${days}d (reversible: $unset collection_abandoned).`);
+}
+
 async function run() {
   const client = new MongoClient(MONGODB_URI, { maxPoolSize: 1, serverSelectionTimeoutMS: 10000 });
   await client.connect();
@@ -330,9 +373,14 @@ async function run() {
   // 2. completed/completed_with_errors — parent set status but results not collected
   // 3. saved with 0 pages — broken by metadata.key bug
   // Exclude parent jobs (child_job_ids exists) — they don't have Gemini results
+  // Exclude jobs explicitly given up on (see --abandon-stale) — their output has
+  // expired at Gemini and retrying them only manufactures errors.
+  if (ABANDON_STALE_DAYS != null) await abandonStaleJobs(db, ABANDON_STALE_DAYS);
+
   const pendingJobs = await db.collection('batch_jobs')
     .find({
       child_job_ids: { $exists: false },
+      collection_abandoned: { $ne: true },
       $or: [
         {
           status: { $in: ['pending', 'processing', 'completed', 'completed_with_errors', 'JOB_STATE_PENDING', 'JOB_STATE_RUNNING'] },

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -122,6 +122,13 @@
 30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-acquire.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/acquire-gap-batch.mjs --batch 400 --concurrency 10" >> /var/log/sourcelibrary/acquire.log 2>&1
 # Archive newly-acquired gap books to R2 (companion to acquisition)
 45 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-arch-acq.lock bash -c "set -a; source .env.production.local; set +a; npx tsx scripts/catalog-coverage/archive-acquired.ts --batch 240 --concurrency 10" >> /var/log/sourcelibrary/archive-acquired.log 2>&1
+
+# Collect Gemini Batch API results (#3713). Submitting a batch and getting text are
+# different events: the Vercel process-batches cron was archived as "replaced by Hetzner
+# workers", but this replacement was never added, so results sat on Gemini's side until
+# somebody ran the script by hand. --abandon-stale=7 stops the collector retrying jobs
+# whose output Gemini has already discarded, which otherwise keeps this log permanently red.
+*/30 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-collect-batch.lock bash -c "set -a; source .env.production.local; set +a; node scripts/batch/collect-batch-results.mjs --limit 200 --abandon-stale=7" >> /var/log/sourcelibrary/collect-batch.log 2>&1
 */20 * * * * tmux has-session -t catchup 2>/dev/null || ( cd /root/sourcelibrary && P=$(bash -c "set -a; source .env.production.local; set +a; node -e \"const {MongoClient}=require(process.cwd()+\x27/node_modules/mongodb\x27);(async()=>{const c=new MongoClient(process.env.MONGODB_URI);await c.connect();console.log(await c.db(\x27bookstore\x27).collection(\x27acquisition_queue\x27).countDocuments({status:\x27pending\x27}));await c.close();})()\"" 2>/dev/null); [ "$P" -gt 500 ] 2>/dev/null && tmux new-session -d -s catchup "/tmp/acquire_catchup.sh" )
 30 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-supabase-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/supabase-sync.mjs" >> /var/log/sourcelibrary/supabase-sync.log 2>&1
 # catchup-watchdog: restart the acquisition catch-up if it died (loop self-exits when queue drains)


### PR DESCRIPTION
## Why

**Submitting a batch and getting text are different events**, and nothing was closing the gap.

`src/app/api/cron/_archived/process-batches` was retired in `45fb98fb` as *"replaced by Hetzner workers"*. For this one the replacement was never built — there is no collector entry in the Hetzner crontab and none in `scripts/workers/crontab.production` (verified: zero matches in both). So every batch submitted since then sat *finished* on Google's side until a human remembered to run `collect-batch-results.mjs` by hand.

The failure is silent in the worst way: a book that had been paid for and OCR'd looks identical to one that was never submitted. Nothing errors. `pages_ocr` just quietly stops advancing.

## What this does

**1. Schedules it.** Every 30 minutes, `flock`-guarded, following the house pattern — added to `crontab.production` and installed on the box. It runs on Hetzner because that is where the key set lives: Gemini batch jobs are visible only to their creating key, and the collector tries every key it holds.

**2. Stops it retrying the dead.** Scheduling exposed a second problem — 22 jobs at status `saved` with `completed_pages: 0` (the metadata.key bug), aged 11 to 136 days. Gemini discards batch output a couple of days after a job finishes, so those are unrecoverable, but they matched the selection query on every pass and reported as errors.

Run by hand that was noise. Run every 30 minutes it is a **permanently red log**, which is worse than useless: it hides the one real failure among 22 that will never clear. `--abandon-stale=N` marks anything older than N days as given up on, and the selection query skips flagged jobs. The cron passes 7, comfortably past Gemini's retention window.

It **flags, never deletes** — `collection_abandoned`, the reason, and the status the job had, so the decision is auditable and reversible with a single `$unset`.

## Verification

Against production, dry-run: `would abandon 22 job(s) older than 7d`, out of 23 selected — exactly the 22 that error, leaving the one genuinely pending job untouched. The exact cron command was then run on Hetzner: exit 0, collected results, wrote its log.

## Known limit, not fixed here

Hetzner does **not** hold Vercel's Gemini key (Vercel's only key is on neither the box nor any laptop). So batches submitted *from a Vercel route* remain uncollectable by this cron. `pipeline-health-alert.mjs` already alarms on that daily as `gemini_key_drift`; the fix is mirroring the key, which needs dashboard access. Nothing in this PR makes that worse — it is the same gap the drift alarm was built for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)