### PR TITLE
fix(locus): server.json version, section-letter guard, and a schema check for a clobbered store

### DIFF
--- a/.claude/docs/invariants/canonical-loci.md
+++ b/.claude/docs/invariants/canonical-loci.md
@@ -95,6 +95,63 @@ locus is (`tests-that-are-not-guards.md`).
   `scripts/audit/locus-anchor-staleness.mjs` is the detector: it checks coverage
   against the registry and exits 1. A stale anchor points at text that has moved.
 
+## The collection name is shared state between sessions
+
+**This already broke production, on the day it shipped.** Two sessions implemented
+#3661 in parallel — #3703 merged, #3713 opened four minutes later — and both wrote
+a Mongo collection called `locus_anchors` with incompatible schemas
+(`ref_page`/`page_number`/`ref_label` against `page`/`scan_page`/`locus`). The
+second extractor ran after the first and replaced 6,324 rows with 4,279. The
+merged API queried `ref_page`, matched nothing, and every reference on production
+returned `witness_count: 0` with the honest message *"no witness holds an anchor
+at this reference"* — **indistinguishable from a genuine gap in the corpus.**
+
+Three things worth keeping from that:
+
+- **A row count is not an integrity check.** The foreign rows carried `book_id`,
+  so per-edition counts passed while the feature was dead. The audit now asserts
+  the SHAPE (`ref_page` present on every row) and fails loudly. That is the
+  read-side lesson of `derived-stores-and-schedules.md` one layer down: an empty
+  answer and an unreadable store look identical from outside.
+- **A write-time guard would not have helped.** The clobbering writer was the
+  other session's script, which does not run this repo's guards. Only a check that
+  both sides run — or a check on the read side — can catch it.
+- **The root cause was coordination, not code.** Neither session claimed the issue
+  before starting, though `CLAUDE.md` prescribes exactly that. No guard in an
+  extractor fixes duplicated work.
+
+## Taken from the parallel implementation (#3713)
+
+Recorded because the reasoning is worth keeping, and because two of these were
+defects in the merged version:
+
+- **`server.json` must be bumped with the MCP server version.** #3703 moved the
+  route to 4.7.0 and left the manifest at 4.6.0;
+  `scripts/audit/mcp-directory-contract.mjs` asserts they match, and it would have
+  failed against production. Adding a tool needs no directory re-review — the
+  fixture exists to catch REMOVALS — but the version has to track.
+- **The section letter is checkable.** Bekker prints two columns (a, b); Stephanus
+  divides a page into five sections (a–e). A Bekker anchor reading `1094e` is an
+  OCR misread of `b`. `plausibleSection()` drops the letter and **keeps the page**,
+  because the digits are separate evidence from the letter — #3713 rejects the
+  whole anchor. Measured 2026-08-07: this corrects **zero** rows across the ten
+  registered editions, so it is preventive, not a fix.
+
+And two things in that implementation to avoid, both measured against our data:
+
+- **Do not gate Bekker at a lower bound of 184.** #3713's parser rejects any
+  Bekker page outside `[184, 1462]`, but Bekker numbering starts at 1 — we hold
+  **175 anchors below 184**, the whole Organon (Categories 2–15, De
+  Interpretatione 16–24, Prior Analytics 25–71, Posterior Analytics 72–100, Topics
+  101–164, Sophistical Refutations 165–183). The gate is latent there only because
+  that registry omits Bekker vol. I; add it and the Organon vanishes with no error.
+- **Do not discard the work name for Stephanus.** #3713 drops it, reasoning that a
+  canonical number is globally unique within its system. True for Bekker, **false
+  for Stephanus**, which restarts in each 1578 volume: Stephanus 328 appears under
+  **five** distinct running heads in our editions (Letters, Minos, Protagoras,
+  Epistola, Republic) and under three within #3713's own seven. Without the work
+  name, `Republic 328b` and `Letters 328b` are the same query.
+
 ## What this does NOT solve
 
 Of 276 live Aristotle and Plato books, 10 are registered here. The rest hold no

--- a/scripts/audit/locus-anchor-staleness.mjs
+++ b/scripts/audit/locus-anchor-staleness.mjs
@@ -39,6 +39,32 @@ await client.connect();
 const db = client.db('bookstore');
 
 let problems = 0;
+
+// Is this collection even OURS?
+//
+// On 2026-08-07 a second session implemented #3661 in parallel and wrote the
+// same collection name with a different schema (`page`/`scan_page`/`locus`
+// instead of `ref_page`/`page_number`/`ref_label`), replacing 6,324 rows with
+// 4,279. The API queries `ref_page`, matched nothing, and every reference on
+// production returned `witness_count: 0` with an honest "no witness holds an
+// anchor at this reference" — indistinguishable from a genuine gap in the
+// corpus. A row count alone would have passed: the foreign rows carry
+// `book_id` too.
+//
+// So check the SHAPE, not just the count. This is the read-side lesson from the
+// embedding outage applied one layer down (derived-stores-and-schedules.md): an
+// empty answer and an unreadable store look identical from outside.
+const total = await db.collection('locus_anchors').countDocuments({});
+const mine = await db.collection('locus_anchors').countDocuments({ ref_page: { $exists: true } });
+if (total && mine !== total) {
+  problems++;
+  console.log(`\n✗ FOREIGN SCHEMA in locus_anchors: ${total - mine} of ${total} rows carry no ref_page.`);
+  console.log(`    Something else is writing this collection. /api/locus queries ref_page and will`);
+  console.log(`    return "no witness" for every reference — silently, as a data gap.`);
+  const stray = await db.collection('locus_anchors').findOne({ ref_page: { $exists: false } }, { projection: { _id: 0 } });
+  console.log(`    example row: ${JSON.stringify(stray).slice(0, 200)}`);
+}
+
 console.log(`\n${LOCUS_EDITIONS.length} registered editions\n${'-'.repeat(72)}`);
 
 for (const ed of LOCUS_EDITIONS) {

--- a/scripts/audit/mcp-directory-contract.tools.json
+++ b/scripts/audit/mcp-directory-contract.tools.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Tool names the Anthropic directory listing was reviewed against, captured from the live tools/list response on 2026-08-05 (server 4.4.0), the day after the connector was published at claude.ai/directory/connectors/source-library. ADDING a tool is safe and needs no re-review — both listings store a pointer to /api/mcp, not a snapshot, and clients call tools/list on connect. RENAMING or REMOVING one silently breaks saved Claude Projects and any client holding the old name, so scripts/audit/mcp-directory-contract.mjs fails when a name here goes missing. Update this file deliberately, as part of a decision to break a name — never to make CI green. list_editions added 2026-08-07 alongside the tool itself — adding a tool is additive and needs no re-review; this file exists to catch REMOVALS.",
+  "_comment": "Tool names the Anthropic directory listing was reviewed against, captured from the live tools/list response on 2026-08-05 (server 4.4.0), the day after the connector was published at claude.ai/directory/connectors/source-library. ADDING a tool is safe and needs no re-review — both listings store a pointer to /api/mcp, not a snapshot, and clients call tools/list on connect. RENAMING or REMOVING one silently breaks saved Claude Projects and any client holding the old name, so scripts/audit/mcp-directory-contract.mjs fails when a name here goes missing. Update this file deliberately, as part of a decision to break a name — never to make CI green. list_editions added 2026-08-07 alongside the tool itself — adding a tool is additive and needs no re-review; this file exists to catch REMOVALS. get_locus added 2026-08-07 (server 4.7.0), same reasoning.",
   "captured_from": "https://sourcelibrary.org/api/mcp",
   "captured_at": "2026-08-05",
   "server_version_at_capture": "4.5.0",
@@ -58,6 +58,10 @@
     },
     {
       "name": "list_editions",
+      "readOnly": true
+    },
+    {
+      "name": "get_locus",
       "readOnly": true
     }
   ]

--- a/scripts/locus/extract-locus-anchors.mjs
+++ b/scripts/locus/extract-locus-anchors.mjs
@@ -92,6 +92,7 @@ for (const ed of editions) {
   const { anchors, rejected, report } = extractAnchors(inputs, {
     author: book.author || '',
     frame: ed.frame,
+    system: ed.system,
   });
 
   // Verify the reviewed pins. A book that fails one is REFUSED, not published

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Embassy-of-the-Free-Mind/sourcelibrary",
   "title": "Source Library",
   "description": "Search 15K rare pre-modern texts translated to English: philosophy, religion, science, literature.",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "repository": {
     "url": "https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2",
     "source": "github"

--- a/src/lib/locus.ts
+++ b/src/lib/locus.ts
@@ -128,7 +128,7 @@ export function normaliseRefText(raw: string): string {
  * Returns [] when nothing numeric is present: roman front matter (`vii`), a
  * library shelfmark, an empty tag.
  */
-export function parseRefCandidates(raw: string | null | undefined): LocusRef[] {
+export function parseRefCandidates(raw: string | null | undefined, system?: LocusSystem | null): LocusRef[] {
   if (!raw) return [];
   const s = normaliseRefText(raw);
   const out: LocusRef[] = [];
@@ -136,9 +136,40 @@ export function parseRefCandidates(raw: string | null | undefined): LocusRef[] {
   // glued to a longer word (`1900 v. 4` must not read as section "v").
   const re = /(\d{1,4})\s*([a-e])?(?![\p{L}\d])/giu;
   for (const m of s.matchAll(re)) {
-    out.push({ page: Number(m[1]), section: m[2] ? m[2].toLowerCase() : null, line: null });
+    out.push({
+      page: Number(m[1]),
+      section: plausibleSection(m[2] ? m[2].toLowerCase() : null, system),
+      line: null,
+    });
   }
   return out;
+}
+
+/**
+ * How many divisions a page has in each system: Bekker prints two columns, a
+ * and b; Stephanus divides a page into five sections, a–e.
+ *
+ * Adopted from the parallel implementation in #3713, which spotted that the
+ * section letter is checkable. It matters because OCR confuses `c` and `e` and
+ * `b` and `d`: a Bekker anchor reading `1094e` is a misread, since no such
+ * column exists.
+ *
+ * The response to an implausible letter is to keep the PAGE and drop the
+ * SECTION, not to reject the anchor. The digits and the letter are separate
+ * pieces of evidence — an unreadable column letter says nothing about the page
+ * number printed beside it, and rejecting the whole anchor would lose a leaf we
+ * can address correctly. #3713 rejects; this is the conservative half of the
+ * same insight.
+ */
+const SECTIONS_PER_SYSTEM: Record<LocusSystem, string> = {
+  bekker: 'ab',
+  stephanus: 'abcde',
+};
+
+/** Null out a section letter the system cannot have. Keeps the page. */
+export function plausibleSection(section: string | null, system?: LocusSystem | null): string | null {
+  if (!section || !system) return section;
+  return SECTIONS_PER_SYSTEM[system].includes(section) ? section : null;
 }
 
 /** Sortable key: page, then section, then line. */
@@ -294,6 +325,8 @@ export interface WorkSegment {
 export interface ExtractOptions {
   /** The book's author, so a head that is only the author's name names no work. */
   author?: string;
+  /** Which system this edition is in, so an impossible section letter is dropped. */
+  system?: LocusSystem;
   /**
    * Set for a root edition whose own pagination IS the citation standard. The
    * offset (printed − scan) is then measured, required to be constant across
@@ -470,7 +503,7 @@ export function extractAnchors(pages: LocusPageInput[], opts: ExtractOptions = {
   const bySegment = new Map<number, Array<{ pageIndex: number; page_number: number; candIndex: number; ref: LocusRef; raw: string }>>();
   let candidatePages = 0;
   sorted.forEach((p, pageIndex) => {
-    const cands = parseRefCandidates(p.page_num);
+    const cands = parseRefCandidates(p.page_num, opts.system);
     if (!cands.length) return;
     candidatePages++;
     const seg = segmentIdOf[pageIndex];

--- a/tests/unit/locus.test.ts
+++ b/tests/unit/locus.test.ts
@@ -54,6 +54,24 @@ describe('parseRefCandidates', () => {
   it('keeps a markup boundary as a separator', () => {
     expect(parseRefCandidates('<unclear>553 a, b</unclear>')[0]).toEqual({ page: 553, section: 'a', line: null });
   });
+
+  it('drops a column letter the system cannot have, and keeps the page', () => {
+    // Bekker prints two columns, a and b; Stephanus divides a page into five
+    // sections, a-e. OCR confuses c/e and b/d, so `1094e` is a misread.
+    //
+    // Adopted from the parallel implementation in #3713. It corrects ZERO rows
+    // in the ten registered editions as of 2026-08-07 — measured, not assumed —
+    // so this is preventive: it stops an unreadable letter being published as a
+    // precision claim. The page is kept because the digits are separate evidence
+    // from the letter; #3713 rejects the whole anchor instead.
+    expect(parseRefCandidates('1094e', 'bekker')).toEqual([{ page: 1094, section: null, line: null }]);
+    expect(parseRefCandidates('1094b', 'bekker')).toEqual([{ page: 1094, section: 'b', line: null }]);
+    expect(parseRefCandidates('328e', 'stephanus')).toEqual([{ page: 328, section: 'e', line: null }]);
+    // Without a declared system nothing is dropped — the caller has not said
+    // which system it is, and guessing from the letter is the inference #3713's
+    // own comment warns against.
+    expect(parseRefCandidates('1094e')[0].section).toBe('e');
+  });
 });
 
 describe('parseLocusQuery', () => {


### PR DESCRIPTION
Follow-up to #3703, resolving the parallel implementation in #3713. Two sessions built #3661 simultaneously. The merged implementation keeps its addressing; this takes what the other one got right, and records what it got wrong.

## Taken from #3713

**`server.json` 4.6.0 → 4.7.0 — a real defect in #3703.** That PR bumped the MCP route and left the manifest behind, and `scripts/audit/mcp-directory-contract.mjs` asserts the two match, so it would have failed against production. The "Live contract audit" check was *skipping* on #3703, which is why I didn't see it. `get_locus` added to the tools fixture as well, though by that file's own comment adding a tool needs no directory re-review — it exists to catch removals.

**The section letter is checkable.** Bekker prints two columns (a, b); Stephanus divides a page into five sections (a–e). So a Bekker anchor reading `1094e` is an OCR misread of `b`. `plausibleSection()` drops the letter and **keeps the page**, because the digits are separate evidence from the letter — #3713 rejects the whole anchor, which would lose a leaf we can address correctly.

Measured: this corrects **zero** rows across the ten registered editions. It is preventive, not a repair, and the test says so rather than letting it read as a fix.

## The schema check, and why it is on the read side

Both implementations write a collection named `locus_anchors`, with incompatible schemas (`ref_page`/`page_number`/`ref_label` vs `page`/`scan_page`/`locus`). The other extractor ran at 23:07, after #3703 merged at 23:09… — its rows replaced 6,324 with 4,279. The merged API queries `ref_page`, matched nothing, and **every reference on production returned `witness_count: 0`** with the honest message *"no witness holds an anchor at this reference."* Indistinguishable from a genuine gap in the corpus. Restored by re-running the extractor; production now answers `?ref=1094a8` correctly.

A row count would not have caught it — the foreign rows carry `book_id`, so per-edition counts passed while the feature was dead. `scripts/audit/locus-anchor-staleness.mjs` now asserts the **shape** and fails loudly.

**Proved with a positive control:** inserted one foreign-shaped row, watched the check fire and name it, removed the row, confirmed 6,324 rows and 0 foreign remaining. A guard that has never returned "found" is not known to work.

**A write-time guard was considered and rejected.** The clobbering writer is another session's script and does not run this repo's guards, so a refusal in our extractor would not have prevented anything. Only a check both sides run — or one on the read side — can catch it. And a check that occasionally refuses a legitimate write trains people to `--force`, which is the lesson already recorded about the worktree reaper.

The root cause was coordination, not code: neither session claimed #3661 before starting, though `CLAUDE.md` prescribes exactly that. No extractor guard fixes duplicated work.

## Recorded against #3713, measured against our own data

Both in `.claude/docs/invariants/canonical-loci.md` so the next person does not reintroduce them:

- **Its parser gates Bekker at `[184, 1462]`.** Bekker numbering starts at 1 — we hold **175 anchors below 184**: Categories 2–15, De Interpretatione 16–24, Prior Analytics 25–71, Posterior Analytics 72–100, Topics 101–164, Sophistical Refutations 165–183. The whole Organon. Latent in that PR only because its registry omits Bekker vol. I; add it and the Organon vanishes silently.
- **It discards the work name**, reasoning that a canonical number is globally unique within its system. True for Bekker, **false for Stephanus**, which restarts in each 1578 volume: Stephanus 328 appears under **five** distinct running heads in our editions (Letters, Minos, Protagoras, Epistola, Republic), and **three within #3713's own seven**. Without the work name, `Republic 328b` and `Letters 328b` are the same query.

## Verification

- `npx tsc --noEmit` clean; locus suite 29 passing (1 new).
- Audit exits 0 on clean data, and was seen to fail on a planted foreign row.
- Production re-probed: `?ref=1094a8` → Bekker vol. II p.310, *Nicomachean Ethics*.

Closing #3713 with a comment pointing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNGn75hQdSrAEFQQAUkc9T
