### PR TITLE
feat(feedback): raise the message cap to 20,000 and make it one constant

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -4,8 +4,15 @@ import { withAdminAuth } from '@/lib/auth-helpers';
 import { guardPublicSubmission } from '@/lib/public-submission-guard';
 import { getClientIp } from '@/lib/rate-limit';
 
-/** Kept in step with the `message` field's documented range in the MCP tool schema. */
-const MAX_MESSAGE = 5000;
+import { MAX_FEEDBACK_MESSAGE, MIN_FEEDBACK_MESSAGE } from '@/lib/feedback-limits';
+
+/**
+ * One constant, shared with the `submit_feedback` tool schema that advertises it.
+ * Previously two literals kept in step by a comment — the same shape as the MCP
+ * server version, which was written three times and drifted to three values on
+ * the same day (#3715).
+ */
+const MAX_MESSAGE = MAX_FEEDBACK_MESSAGE;
 
 // POST /api/feedback — save feedback
 export async function POST(request: NextRequest) {
@@ -16,7 +23,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { message, page, name, email, wantsToHelp } = body;
 
-    if (!message || typeof message !== 'string' || message.trim().length < 2) {
+    if (!message || typeof message !== 'string' || message.trim().length < MIN_FEEDBACK_MESSAGE) {
       return NextResponse.json({ error: 'Message is required' }, { status: 400 });
     }
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -6,6 +6,7 @@ import { getClientIp, peekRateLimit } from '@/lib/rate-limit';
 import { getShortUrl } from '@/lib/shortlinks';
 import { pageContinuity, continuityHint } from '@/lib/page-continuity';
 import { classifyApiError } from '@/lib/mcp-errors';
+import { MAX_FEEDBACK_MESSAGE, MIN_FEEDBACK_MESSAGE } from '@/lib/feedback-limits';
 import { stripProvenanceMarks } from '@/lib/provenance';
 import {
   CallToolRequestSchema,
@@ -795,7 +796,7 @@ const TOOLS: Tool[] = [
     inputSchema: {
       type: 'object' as const,
       properties: {
-        message: { type: 'string', description: 'Your feedback (2-5000 chars)' },
+        message: { type: 'string', description: `Your feedback (${MIN_FEEDBACK_MESSAGE}-${MAX_FEEDBACK_MESSAGE} chars). Long structured reports are welcome — the limit was raised from 5,000 because agent reports were pressing against it and being split across submissions.` },
         name: { type: 'string' }, email: { type: 'string' },
       },
       required: ['message'],

--- a/src/lib/feedback-limits.ts
+++ b/src/lib/feedback-limits.ts
@@ -1,0 +1,33 @@
+/**
+ * How long a feedback message may be — ONE constant, used by both the validator
+ * and the tool schema that advertises it.
+ *
+ * ## Why it is a constant and not two literals
+ *
+ * On 2026-08-07 the MCP server version was written three times and drifted to
+ * three different values simultaneously (#3715). This limit had the same shape:
+ * `MAX_MESSAGE` in `/api/feedback` and the string "2-5000 chars" in the
+ * `submit_feedback` tool description, kept in step by a comment asking whoever
+ * changed one to remember the other. Both are now derived from here, so they
+ * cannot disagree.
+ *
+ * ## Why 20,000 rather than 5,000
+ *
+ * The cap exists because `/api/feedback` is a public, unauthenticated write
+ * surface. What actually stops abuse there is the rate limiter
+ * (`guardPublicSubmission`); the length cap only bounds a single request.
+ *
+ * 5,000 was sized for a sentence typed by a reader, and it was right for that:
+ * measured across 367 stored messages, the average is **383 characters** and only
+ * 23 exceed 2,500. But the heaviest users of this endpoint are now MCP clients
+ * filing structured multi-section reports, and **all 10 messages over 4,000
+ * characters arrived on one day**, clustered at 4,845–4,956 — i.e. pressed right
+ * against the ceiling. One of those reports was itself a complaint about hitting
+ * the limit, and the reader split the day's findings across five submissions.
+ *
+ * A cap that shapes the content it is meant to collect is too tight. 20,000
+ * leaves ~4x headroom over the largest real report while still bounding the
+ * request. The floor stays at 2 — a one-character message is a mis-click.
+ */
+export const MAX_FEEDBACK_MESSAGE = 20000;
+export const MIN_FEEDBACK_MESSAGE = 2;


### PR DESCRIPTION
The cap was shaping the reports it exists to collect.

Measured across 367 stored messages: average **383** characters, 23 over 2,500, and **10 over 4,000 — all 10 on a single day**, clustered at 4,845–4,956, pressed against the 5,000 ceiling. One of those reports was itself a complaint about hitting the limit, and that reader split the day's findings across five submissions. Human feedback never comes close; the heaviest users of this endpoint are now MCP clients filing structured multi-section reports.

5,000 was right for a sentence typed by a reader. 20,000 leaves ~4x headroom over the largest real report and still bounds a single request. What protects a public unauthenticated write surface is the rate limiter in `guardPublicSubmission`, not the length cap.

**Also de-duplicated the limit.** It was two literals — `MAX_MESSAGE` in the route and the string `"2-5000 chars"` in the `submit_feedback` schema — kept in step by a comment asking whoever changed one to remember the other. That is the exact shape of the MCP server version, which was written three times and drifted to three values on the same day (#3715). Both now derive from `MAX_FEEDBACK_MESSAGE`.

**What this is NOT.** A reporter claimed the real ceiling was lower than documented — messages under 5,000 being rejected. That claim is wrong: the longest stored message is **4,956** characters, so the cap was exactly where it said it was. They estimated their own length and guessed low, and the error at the time gave no numbers, which is why they couldn't tell. That half was fair and was already fixed.

Verified: `tsc` clean, 2,048 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNGn75hQdSrAEFQQAUkc9T