### PR TITLE
feat(pipeline): translate-core — one door for writing a translation (#3725, Phases 0–2)

### DIFF
--- a/.claude/docs/translating-a-book.md
+++ b/.claude/docs/translating-a-book.md
@@ -59,6 +59,13 @@ unpause the production pipeline."** Or invoke the skill directly: `/batch-transl
 Both take `Authorization: Bearer $CRON_SECRET`. Both return a Gemini Batch job
 that completes in ~24h — they do not block.
 
+**Quality tradeoff to know:** this batch route translates each page
+*independently* — no previous-page continuity, unlike the (currently dormant)
+sequential worker, which feeds each finished page into the next page's prompt.
+For a single requested book that tradeoff is deliberate and fine; for bulk
+reprocessing, or a text where cross-page flow matters a lot, use the
+sequential path instead (see `memory/pipeline-ops.md`, Critical Rules).
+
 ### Model
 Don't hardcode a model. The pipeline uses `getModelForBook(book)`
 (`src/lib/types/ai-models.ts`), which routes BPH and non-Latin-script books to the

--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -2,7 +2,19 @@
 
 Operational reference for pipeline monitoring, debugging, and processing. For full architecture details, see `.claude/docs/pipeline-architecture.md`.
 
-## Where Everything Runs (snapshot 2026-05 — verify if older than ~30 days)
+## Where Everything Runs
+
+> **Reality check (2026-08-08):** the table below describes the ORCHESTRATED
+> era and much of it is dormant. Verified against the live Hetzner crontab:
+> the main `pipeline-orchestrator.mjs` loop is **not scheduled at all** (only
+> `--phase 9` finalize runs, every 15 min), `translate-worker.mjs` is **not
+> running**, and enrich-worker is idle with the pipeline paused. What IS live:
+> the finalize tail, `collect-batch-results.mjs` (every 30 min, #3717 — batch
+> result collection), archiving/acquisition crons, and the daily health alert.
+> Processing happens per-book via the batch routes (see `translating-a-book.md`).
+> Shared translation logic now lives in `scripts/lib/translate-core.mjs` (the
+> "one door": model routing, DB prompts, revision-before-overwrite, counter
+> sync — issue #3725); any new translation writer must import it.
 
 | Component | Where | How |
 |-----------|-------|-----|
@@ -52,7 +64,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 
 ## Critical Rules
 
-- NEVER use Gemini Batch API for translation — lacks cross-page context. Use `translate-worker.mjs` (Hetzner) or Lambda FIFO (fallback).
+- **Batch-API translation: banned for bulk, sanctioned for one-off books — know why.** Sequential translation (translate-worker, Lambda FIFO) feeds each page's finished translation into the next page's prompt; that chain is what keeps cross-page sentences and terminology coherent, and the Batch API cannot provide it. The per-book route `batch-translate-async` (the `translating-a-book.md` path) IS Batch-API translation: each page is translated independently, with no previous-page context — a deliberate cost/coherence tradeoff acceptable for a single requested book, wrong for bulk reprocessing. (The Feb 18 incident — 17K wrong translations — was a separate bug: batch results matched by array index instead of `metadata.key`; that part is fixed.) So: bulk → sequential worker; one-off → batch route; never claim the two produce equivalent quality.
 - **Translation prompt source of truth is the DB `prompts` collection** (type: 'translation', is_default: true). Both workers read it once per run and cache. Never hardcode prompts in worker files. To update the prompt, update the DB — no code deploy needed.
 - **Any Hetzner worker that writes to `pages` must also update the parent book's cached counters** (`pages_ocr`, `pages_translated`, `pages_archived`). Vercel API routes do this via shared helpers, but standalone Hetzner scripts bypass them. See #497.
 - Any script overwriting `ocr.data` or `translation.data` MUST call `createRevision(pageId, field, jobId?)` first

--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -169,7 +169,20 @@ async function extractResults(geminiData, apiKey) {
 }
 
 // --- Process one job ---
+// Type allowlist (#3725): the save path treats anything that isn't
+// 'ocr'/'image_extraction' as a translation, so a typo'd type on a new
+// submitter would silently write model output into translation.data.
+const KNOWN_JOB_TYPES = new Set(['ocr', 'translation', 'translate', 'image_extraction']);
+
 async function processOneJob(db, job) {
+  if (!KNOWN_JOB_TYPES.has(job.type)) {
+    console.error(`  UNKNOWN job type '${job.type}' on ${job.id || job._id} — refusing to collect; marking failed for human triage.`);
+    await db.collection('batch_jobs').updateOne(
+      { _id: job._id },
+      { $set: { status: 'failed', error: `unknown job type '${job.type}' — collector allowlist refused (#3725)`, updated_at: new Date() } }
+    );
+    return { status: 'unknown_type' };
+  }
   const jobName = job.job_name || job.gemini_job_name;
   if (!jobName) return { status: 'skipped' };
 

--- a/scripts/batch/realtime-translate.mjs
+++ b/scripts/batch/realtime-translate.mjs
@@ -25,12 +25,19 @@
  */
 
 import { MongoClient } from 'mongodb';
-import { saveRevisionBeforeOverwrite } from '../lib/page-revisions.mjs';
 import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
+import {
+  getTranslateModelForBook,
+  loadTranslationPrompts,
+  buildTranslationPrompt,
+  writePageTranslation,
+} from '../lib/translate-core.mjs';
 
 // --- Config ---
-const TARGET_MODEL = 'gemini-3-flash-preview';
-const TARGET_PROMPT = 'v5.2026-02';
+// Model + prompt come from translate-core (issue #3725). This script used to
+// hardcode gemini-3-flash-preview for EVERY book — the same shape as the #482
+// bug that once tripled translation costs — and carried its own hardcoded
+// English modernization prompt with no provenance stamping.
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 const SKIP_PAGE_TYPES = ['blank'];
 
@@ -77,8 +84,8 @@ function getNextKey() {
 }
 
 // --- Gemini API call ---
-async function callGemini(promptText, apiKey) {
-  const url = `${GEMINI_API_BASE}/models/${TARGET_MODEL}:generateContent?key=${apiKey}`;
+async function callGemini(promptText, apiKey, model) {
+  const url = `${GEMINI_API_BASE}/models/${model}:generateContent?key=${apiKey}`;
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -109,50 +116,12 @@ async function callGemini(promptText, apiKey) {
   };
 }
 
-// --- Translation prompt ---
-async function getTranslationPrompt(db) {
-  const prompt = await db.collection('prompts').findOne(
-    { type: 'translation', is_default: true },
-    { sort: { version: -1 } }
-  );
-  if (!prompt?.content) throw new Error('No default translation prompt found in DB');
-  console.log(`Translation prompt: ${prompt.name} v${prompt.version}`);
-  return prompt.content;
-}
-
-// English modernization prompt (hardcoded, same as in code)
-const ENGLISH_MODERNIZATION_PROMPT = `You are a specialist in Early Modern English (pre-1700). Your task is to modernize the following text into clear, contemporary English while preserving the author's meaning, tone, and intent.
-
-**Rules:**
-- Update archaic spelling, grammar, and vocabulary to modern equivalents
-- Preserve proper nouns, titles, and technical terms
-- Keep the paragraph structure intact
-- Do NOT summarize or abridge — modernize every sentence
-- If a passage is ambiguous, choose the most likely modern reading
-- Output ONLY the modernized text, no commentary`;
-
-function buildTranslationPrompt(basePrompt, ocrText, language, previousTranslation) {
-  const isEnglish = language.toLowerCase() === 'english';
-
-  let prompt;
-  if (isEnglish) {
-    prompt = ENGLISH_MODERNIZATION_PROMPT;
-    prompt += `\n\n**Text to modernize:**\n${ocrText}`;
-    if (previousTranslation) {
-      prompt += `\n\n**Previous page (modernized) for continuity:**\n${previousTranslation.slice(0, 2000)}...`;
-    }
-  } else {
-    prompt = basePrompt
-      .replace('{language}', language)
-      .replace('{sourceLanguage}', language)
-      .replace('{targetLanguage}', 'English');
-    prompt += `\n\n**Text to translate:**\n${ocrText}`;
-    if (previousTranslation) {
-      prompt += `\n\n**Previous page translation for continuity:**\n${previousTranslation.slice(0, 2000)}...`;
-    }
-  }
-
-  return prompt;
+// --- Translation prompts — DB-owned, loaded once via translate-core ---
+async function getPrompts(db) {
+  const prompts = await loadTranslationPrompts(db);
+  console.log(`Translation prompt: ${prompts.translation.ref.name} v${prompts.translation.ref.version}`);
+  console.log(`Modernization prompt: ${prompts.english.ref.name} v${prompts.english.ref.version}`);
+  return prompts;
 }
 
 // --- Extract translation metadata (simplified) ---
@@ -167,8 +136,8 @@ function extractTranslationMetadata(text) {
 }
 
 // --- Process one book sequentially ---
-async function processBook(book, pages, basePrompt, db, globalStats) {
-  const language = book.language || book.original_language || 'Latin';
+async function processBook(book, pages, prompts, db, globalStats) {
+  const model = getTranslateModelForBook(book);
   let previousTranslation = null;
   let bookCompleted = 0, bookFailed = 0, bookSkipped = 0;
 
@@ -207,8 +176,10 @@ async function processBook(book, pages, basePrompt, db, globalStats) {
     const startTime = Date.now();
 
     try {
-      const prompt = buildTranslationPrompt(basePrompt, page.ocr.data, language, previousTranslation);
-      const result = await callGemini(prompt, keyInfo.key);
+      const { prompt, promptRef } = buildTranslationPrompt({
+        prompts, book, ocrText: page.ocr.data, previousTranslation,
+      });
+      const result = await callGemini(prompt, keyInfo.key, model);
       const durationMs = Date.now() - startTime;
 
       if (!result.text || result.text.length < 5) {
@@ -228,36 +199,21 @@ async function processBook(book, pages, basePrompt, db, globalStats) {
 
       const translationMeta = extractTranslationMetadata(result.text);
 
-      // Retain existing translation as a revision before overwriting (#3240) —
-      // no-op on first translation, fires in --stale mode re-translations.
-      await saveRevisionBeforeOverwrite(db, page.id, 'translation', { reason: 'retranslate_stale' });
-
-      await db.collection('pages').updateOne(
-        { id: page.id },
-        {
-          $set: {
-            translation: {
-              data: result.text,
-              language: 'English',
-              model: TARGET_MODEL,
-              updated_at: new Date(),
-              source: 'ai',
-              prompt_version: TARGET_PROMPT,
-            },
-            ...translationMeta,
-            updated_at: new Date(),
-          },
-        }
-      );
+      // The one door (translate-core): revision snapshot (#3240) + provenance-
+      // stamped write + counter-safe extras, in one call.
+      await writePageTranslation(db, {
+        page, book, text: result.text, promptRef, model,
+        note: 'retranslate_stale', extraSet: translationMeta,
+      });
 
       // Non-blocking usage log
       db.collection('gemini_usage').insertOne({
-        type: 'translate', mode: 'realtime', model: TARGET_MODEL,
+        type: 'translate', mode: 'realtime', model,
         book_id: book.id, page_ids: [page.id],
         input_tokens: result.usage.inputTokens,
         output_tokens: result.usage.outputTokens,
         status: 'success', duration_ms: durationMs,
-        prompt_version: TARGET_PROMPT,
+        prompt_version: String(promptRef?.version ?? ''),
         endpoint: 'scripts/realtime-translate.mjs',
         timestamp: new Date(),
       }).catch(() => {});
@@ -271,10 +227,10 @@ async function processBook(book, pages, basePrompt, db, globalStats) {
       const durationMs = Date.now() - startTime;
 
       db.collection('gemini_usage').insertOne({
-        type: 'translate', mode: 'realtime', model: TARGET_MODEL,
+        type: 'translate', mode: 'realtime', model,
         book_id: book.id, page_ids: [page.id],
         status: 'error', error_message: error.message?.substring(0, 200),
-        duration_ms: durationMs, prompt_version: TARGET_PROMPT,
+        duration_ms: durationMs,
         endpoint: 'scripts/realtime-translate.mjs', timestamp: new Date(),
       }).catch(() => {});
 
@@ -441,8 +397,8 @@ async function main() {
       return;
     }
 
-    // Get translation prompt
-    const basePrompt = await getTranslationPrompt(db);
+    // Get translation prompts (DB-owned)
+    const prompts = await getPrompts(db);
 
     // Process books in parallel batches
     const globalStats = {
@@ -459,7 +415,7 @@ async function main() {
       console.log(`\nBatch ${Math.floor(i / BOOK_CONCURRENCY) + 1}: ${bookNames.join(', ')}`);
 
       await Promise.allSettled(
-        batch.map(({ book, pages }) => processBook(book, pages, basePrompt, db, globalStats))
+        batch.map(({ book, pages }) => processBook(book, pages, prompts, db, globalStats))
       );
     }
 

--- a/scripts/lib/translate-core.mjs
+++ b/scripts/lib/translate-core.mjs
@@ -1,0 +1,261 @@
+/**
+ * translate-core — the one door for writing a page translation (issue #3725).
+ *
+ * Every code path that produces a translation (worker, batch collector, repair
+ * script, one-off) must go through this module rather than carrying its own
+ * copy of the logic. The door enforces the four promises of the pipeline:
+ *
+ *   1. The MODEL is chosen by routing (getTranslateModelForBook), never
+ *      hardcoded — BPH and non-Latin-script books get full flash, the rest lite.
+ *   2. The PROMPT comes from the `prompts` DB collection (loadTranslationPrompts),
+ *      and every written page records which prompt produced it.
+ *   3. Nothing is overwritten without a `page_revisions` snapshot first
+ *      (writePageTranslation does this internally — callers cannot forget it).
+ *   4. The book's cached counters are recomputed with the canonical
+ *      visible-pages convention (syncBookTranslationCounters → page-counts.mjs).
+ *
+ * TS twin for API routes: src/lib/types/ai-models.ts (routing) +
+ * src/lib/prompts.ts (prompt fetch) + src/lib/page-counts.ts (counters).
+ * Parity is pinned by tests/unit/translate-core-parity.test.ts — if you change
+ * routing here or in ai-models.ts, change both or the suite fails.
+ */
+
+import { createHash } from 'crypto';
+import { buildVisiblePageCountPipeline } from './page-counts.mjs';
+import { saveRevisionBeforeOverwrite } from './page-revisions.mjs';
+
+export const MODEL_FLASH = 'gemini-3-flash-preview';
+export const MODEL_LITE = 'gemini-3.1-flash-lite';
+
+/**
+ * Mirror of LATIN_SCRIPT_LANGUAGES in src/lib/types/ai-models.ts — the
+ * allowlist of languages safe for the cheaper lite model. Allowlist (not
+ * denylist) so unknown/null routes to the safer full model.
+ *
+ * NOTE: Malay is deliberately absent. Our Malay holdings are mostly Jawi
+ * (Arabic-script) manuscripts — flash-lite garbles them into confident
+ * nonsense (2026-07-18 Hikayat Tanah Hitu pilot). Malay must route to full
+ * flash. A drifted copy of this list in translate-worker.mjs used to include
+ * it, which is exactly why the copies were consolidated here.
+ */
+export const LATIN_SCRIPT_LANGUAGES = new Set([
+  'english', 'en', 'eng',
+  'latin', 'la', 'lat',
+  'french', 'fr', 'fra',
+  'italian', 'it', 'ita',
+  'spanish', 'es', 'spa',
+  'portuguese', 'pt', 'por',
+  'romanian', 'ro', 'ron', 'rum',
+  'catalan', 'ca', 'cat',
+  'german', 'de', 'deu', 'ger',
+  'dutch', 'nl', 'nld', 'dut',
+  'swedish', 'sv', 'swe',
+  'norwegian', 'no', 'nor',
+  'danish', 'da', 'dan',
+  'finnish', 'fi', 'fin',
+  'icelandic', 'is', 'isl', 'ice',
+  'welsh', 'cy', 'cym', 'wel',
+  'irish', 'ga', 'gle',
+  'polish', 'pl', 'pol',
+  'czech', 'cs', 'ces', 'cze',
+  'slovak', 'sk', 'slk', 'slo',
+  'slovenian', 'sl', 'slv',
+  'croatian', 'hr', 'hrv',
+  'hungarian', 'hu', 'hun',
+  'estonian', 'et', 'est',
+  'latvian', 'lv', 'lav',
+  'lithuanian', 'lt', 'lit',
+  'albanian', 'sq', 'sqi', 'alb',
+  'turkish', 'tr', 'tur',
+  'indonesian', 'id', 'ind',
+  'vietnamese', 'vi', 'vie',
+  'tagalog', 'tl', 'tgl', 'filipino',
+  'swahili', 'sw', 'swa',
+]);
+
+export function isLatinScriptLanguage(language) {
+  if (!language) return false;
+  return LATIN_SCRIPT_LANGUAGES.has(String(language).toLowerCase().trim());
+}
+
+/**
+ * THE model routing for OCR/translation. Mirrors getModelForBook in
+ * src/lib/types/ai-models.ts.
+ */
+export function getTranslateModelForBook(book) {
+  if (book?.image_source?.provider === 'bph') return MODEL_FLASH;
+  if (!isLatinScriptLanguage(book?.language)) return MODEL_FLASH;
+  return MODEL_LITE;
+}
+
+/**
+ * Safety settings required on EVERY translation call: without BLOCK_NONE,
+ * pre-1930 public-domain works trip RECITATION/safety refusals page after page
+ * (2026-03-28 lesson). The pre-1930 note added by buildTranslationPrompt is
+ * the other half of that fix.
+ */
+export const SAFETY_SETTINGS = [
+  { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
+  { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
+  { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
+  { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
+  { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' },
+];
+
+/**
+ * Load the default translation + english_modernization prompts from the DB.
+ * Throws if either is missing — a silent hardcoded fallback is how prompt
+ * provenance was lost before; scripts should fail loudly instead.
+ *
+ * Returns { translation, english }, each { text, ref } where ref carries
+ * { id, name, version, content_hash } for page provenance stamping.
+ */
+export async function loadTranslationPrompts(db) {
+  const load = async (type) => {
+    const doc = await db.collection('prompts').findOne(
+      { type, is_default: true },
+      { sort: { version: -1 } }
+    );
+    if (!doc?.content) {
+      throw new Error(
+        `[translate-core] No default '${type}' prompt in the prompts collection — seed it before running (prompts are DB-owned, never hardcoded).`
+      );
+    }
+    return {
+      text: doc.content,
+      ref: {
+        id: doc._id?.toString(),
+        name: doc.name,
+        version: doc.version,
+        content_hash: doc.content_hash
+          || createHash('md5').update(doc.content).digest('hex'),
+      },
+    };
+  };
+  return {
+    translation: await load('translation'),
+    english: await load('english_modernization'),
+  };
+}
+
+/** English books are modernized, not translated. */
+export function isEnglishBook(book) {
+  return (book?.language || '').toLowerCase().trim() === 'english';
+}
+
+/**
+ * Build the full user prompt for one page, mirroring the production worker:
+ * language substitution, source-work metadata, the pre-1930 public-domain
+ * note, the page text, and previous-page continuity (the chain that makes
+ * translation sequential — see the pipeline explainer).
+ */
+export function buildTranslationPrompt({ prompts, book, ocrText, previousTranslation }) {
+  const english = isEnglishBook(book);
+  const base = english ? prompts.english : prompts.translation;
+  let prompt = base.text
+    .replace('{source_language}', book?.language || 'Latin')
+    .replace('{target_language}', 'English')
+    .replace('{language}', book?.language || 'Latin');
+
+  const parts = [];
+  if (book?.display_title || book?.title) parts.push(`Title: ${book.display_title || book.title}`);
+  if (book?.author) parts.push(`Author: ${book.author}`);
+  if (book?.year || book?.published) parts.push(`Date: ${book.year || book.published}`);
+  if (parts.length) prompt += `\n\n**Source work:** ${parts.join(' | ')}`;
+
+  const year = parseInt(book?.year || book?.published, 10);
+  if (year && year < 1930) {
+    prompt += `\n\n**Note:** This is a public domain work published in ${year}. It is not under copyright.`;
+  }
+
+  prompt += english
+    ? `\n\n**Text to modernize:**\n${ocrText}`
+    : `\n\n**Text to translate:**\n${ocrText}`;
+
+  if (previousTranslation) {
+    prompt += english
+      ? `\n\n**Previous page (modernized) for continuity:**\n${previousTranslation.slice(0, 2000)}...`
+      : `\n\n**Previous page translation for continuity:**\n${previousTranslation.slice(0, 2000)}...`;
+  }
+
+  return { prompt, promptRef: base.ref, isEnglish: english };
+}
+
+/** Close unterminated inline tags the model sometimes emits mid-stream. */
+export function sanitizeTranslationTags(text) {
+  if (!text) return text;
+  return text
+    .replace(/<(margin|gloss|insert|unclear|term|heading|footnote|caption)>([^<]*?)$/gm,
+      (_, tag, content) => `<${tag}>${content}</${tag}>`)
+    .replace(/<\/(margin|gloss|insert|unclear|term|heading|footnote|caption)>\s*<\/\1>/g,
+      (_, tag) => `</${tag}>`);
+}
+
+export const contentHash = (t) =>
+  createHash('sha256').update(t || '').digest('hex').slice(0, 16);
+
+/**
+ * Snapshot the page's current translation into page_revisions, then write the
+ * new one with full provenance. Promise 3 lives here so no caller can forget
+ * it. Non-fatal revision failure is logged, never blocks the write (matching
+ * the production worker's long-standing behavior).
+ *
+ * @param {object} args
+ * @param {object} args.page       page doc with at least { id, book_id }
+ * @param {object} args.book      book doc (for model routing when model omitted)
+ * @param {string} args.text      the new translation text (already sanitized or not — we sanitize again, idempotent)
+ * @param {object} args.promptRef  { id, name, version, content_hash } from loadTranslationPrompts
+ * @param {string} [args.model]   override; defaults to getTranslateModelForBook(book)
+ * @param {string} [args.jobId]   job identifier for the revision row
+ * @param {string} [args.note]    revision reason (e.g. 'anomaly-fix', 'retranslate_stale')
+ * @param {object} [args.extraSet] extra top-level page fields to $set in the same write
+ *                                (e.g. detected_terms) — never translation.* keys
+ */
+export async function writePageTranslation(db, { page, book, text, promptRef, model, jobId, note, extraSet }) {
+  const clean = sanitizeTranslationTags(text);
+  // Promise 3 delegates to the blessed revision helper (scripts/lib/
+  // page-revisions.mjs): marker-text skip, reason field, never throws.
+  await saveRevisionBeforeOverwrite(db, page.id, 'translation', { jobId, reason: note });
+
+  await db.collection('pages').updateOne(
+    { id: page.id },
+    {
+      $set: {
+        translation: {
+          data: clean,
+          content_hash: contentHash(clean),
+          language: 'English',
+          model: model || getTranslateModelForBook(book),
+          updated_at: new Date(),
+          source: 'ai',
+          prompt_version: String(promptRef?.version ?? ''),
+          prompt_id: promptRef?.id,
+          prompt_hash: promptRef?.content_hash,
+          prompt_name: promptRef?.name,
+        },
+        ...(extraSet || {}),
+        updated_at: new Date(),
+      },
+    }
+  );
+  return clean;
+}
+
+/**
+ * Recompute the book's cached page counters with the canonical visible-pages
+ * convention (#3293) and bump updated_at (which the Supabase catalog sync
+ * keys on — a counter write without updated_at is invisible downstream).
+ * Extra fields (e.g. a status transition) ride along in the same update.
+ */
+export async function syncBookTranslationCounters(db, bookId, extraSet = {}) {
+  const [counts] = await db.collection('pages')
+    .aggregate(buildVisiblePageCountPipeline(bookId)).toArray();
+  const $set = { updated_at: new Date(), ...extraSet };
+  if (counts) {
+    $set.pages_count = counts.total;
+    $set.pages_ocr = counts.with_ocr;
+    $set.pages_translated = counts.with_translation;
+  }
+  await db.collection('books').updateOne({ id: bookId }, { $set });
+  return counts || null;
+}

--- a/scripts/maintenance/retranslate-pages.mjs
+++ b/scripts/maintenance/retranslate-pages.mjs
@@ -28,7 +28,6 @@
 import { withMongo } from '../lib/mongo.mjs';
 import { ObjectId } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { createHash, randomBytes } from 'crypto';
 import * as fs from 'fs';
 
 const arg = (name, def) => {
@@ -44,35 +43,27 @@ const MAX_RETRIES = parseInt(arg('retries', '2'), 10);
 const CONCURRENCY = parseInt(arg('concurrency', '8'), 10);
 const MODEL_OVERRIDE = arg('model', null); // 'flash' | 'lite' | null(=auto routing)
 
-// ── model routing (verbatim from translate-worker.mjs) ──
-const MODEL_FLASH = 'gemini-3-flash-preview';
-const MODEL_LITE = 'gemini-3.1-flash-lite';
-const LATIN_SCRIPT_LANGS_FOR_LITE = new Set([
-  'english','en','eng','latin','la','lat','french','fr','fra','italian','it','ita',
-  'spanish','es','spa','portuguese','pt','por','romanian','ro','ron','rum','catalan','ca','cat',
-  'german','de','deu','ger','dutch','nl','nld','dut','swedish','sv','swe','norwegian','no','nor',
-  'danish','da','dan','finnish','fi','fin','icelandic','is','isl','ice','welsh','cy','cym','wel',
-  'irish','ga','gle','polish','pl','pol','czech','cs','ces','cze','slovak','sk','slk','slo',
-  'slovenian','sl','slv','croatian','hr','hrv','hungarian','hu','hun',
-]);
+// ── model routing from translate-core (the one door, issue #3725) ──
+// The verbatim copy this replaces had drifted: it was missing nine languages
+// (Estonian through Swahili), silently sending them to flash at 2× cost.
+import {
+  getTranslateModelForBook,
+  MODEL_FLASH,
+  MODEL_LITE,
+  SAFETY_SETTINGS,
+  loadTranslationPrompts,
+  buildTranslationPrompt,
+  writePageTranslation,
+  syncBookTranslationCounters,
+} from '../lib/translate-core.mjs';
+
 function getModelForBook(book) {
   // Re-translation override: collapses happened on lite, so a fix run forces the
   // stronger model. --model=flash is the default recommendation for fixes.
   if (MODEL_OVERRIDE === 'flash') return MODEL_FLASH;
   if (MODEL_OVERRIDE === 'lite') return MODEL_LITE;
-  if (book?.image_source?.provider === 'bph') return MODEL_FLASH;
-  const lang = (book?.language || '').toLowerCase().trim();
-  if (!lang || !LATIN_SCRIPT_LANGS_FOR_LITE.has(lang)) return MODEL_FLASH;
-  return MODEL_LITE;
+  return getTranslateModelForBook(book);
 }
-
-const SAFETY_SETTINGS = [
-  { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
-  { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
-  { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
-  { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
-  { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' },
-];
 
 const API_KEYS = [
   process.env.GEMINI_API_KEY,
@@ -83,15 +74,7 @@ const API_KEYS = [
 let keyIdx = 0;
 const aiClient = () => new GoogleGenerativeAI(API_KEYS[keyIdx++ % API_KEYS.length]);
 
-function sanitizeTranslationTags(text) {
-  if (!text) return text;
-  return text
-    .replace(/<(margin|gloss|insert|unclear|term|heading|footnote|caption)>([^<]*?)$/gm,
-      (_, tag, content) => `<${tag}>${content}</${tag}>`)
-    .replace(/<\/(margin|gloss|insert|unclear|term|heading|footnote|caption)>\s*<\/\1>/g,
-      (_, tag) => `</${tag}>`);
-}
-const contentHash = t => createHash('sha256').update(t || '').digest('hex').slice(0, 16);
+import { sanitizeTranslationTags } from '../lib/translate-core.mjs';
 
 // ── collapse-guard body measurement (mirror of detect-translation-collapse.mjs) ──
 const BLOCK_TAGS = ['meta','image-desc','vocab','summary','keywords','warning','note',
@@ -129,39 +112,22 @@ const badnessScore = (ocr, tr) => {
   return Math.abs(Math.log(tb / ob));
 };
 
-let _prompt = null, _engPrompt = null;
+// Prompts come from the DB via translate-core (promise 2: never hardcoded).
+let _prompts = null;
 async function loadPrompts(db) {
-  if (!_prompt) _prompt = await db.collection('prompts').findOne({ type: 'translation', is_default: true }, { sort: { version: -1 } });
-  if (!_engPrompt) _engPrompt = await db.collection('prompts').findOne({ type: 'english_modernization', is_default: true }, { sort: { version: -1 } });
-  if (!_prompt?.content) throw new Error('No default translation prompt in DB');
-}
-function buildHeader(book) {
-  const isEnglish = (book.language || '').toLowerCase() === 'english';
-  const baseRef = isEnglish ? _engPrompt : _prompt;
-  let prompt = baseRef.content.replace('{source_language}', book.language || 'Latin');
-  const parts = [];
-  if (book.display_title || book.title) parts.push(`Title: ${book.display_title || book.title}`);
-  if (book.author) parts.push(`Author: ${book.author}`);
-  if (book.year || book.published) parts.push(`Date: ${book.year || book.published}`);
-  if (parts.length) prompt += `\n\n**Source work:** ${parts.join(' | ')}`;
-  const year = parseInt(book.year || book.published, 10);
-  if (year && year < 1930) prompt += `\n\n**Note:** This is a public domain work published in ${year}. It is not under copyright.`;
-  return { prompt, isEnglish, baseRef };
+  if (!_prompts) _prompts = await loadTranslationPrompts(db);
 }
 
 async function translateOnce(page, book, prevTranslation) {
-  const { prompt: header, isEnglish, baseRef } = buildHeader(book);
-  let prompt = header + (isEnglish
-    ? `\n\n**Text to modernize:**\n${page.ocr.data}`
-    : `\n\n**Text to translate:**\n${page.ocr.data}`);
-  if (prevTranslation) {
-    prompt += isEnglish
-      ? `\n\n**Previous page (modernized) for continuity:**\n${prevTranslation.slice(0, 2000)}...`
-      : `\n\n**Previous page translation for continuity:**\n${prevTranslation.slice(0, 2000)}...`;
-  }
+  const { prompt, promptRef } = buildTranslationPrompt({
+    prompts: _prompts,
+    book,
+    ocrText: page.ocr.data,
+    previousTranslation: prevTranslation,
+  });
   const model = aiClient().getGenerativeModel({ model: getModelForBook(book), safetySettings: SAFETY_SETTINGS });
   const result = await model.generateContent(prompt);
-  return { text: sanitizeTranslationTags(result.response.text()), baseRef };
+  return { text: sanitizeTranslationTags(result.response.text()), promptRef };
 }
 
 await withMongo(async (db) => {
@@ -193,6 +159,7 @@ await withMongo(async (db) => {
   };
 
   let fixed = 0, stillBad = 0, skipped = 0, alreadyGood = 0, done = 0;
+  const touchedBooks = new Set();
 
   async function processTarget(t) {
     const book = await getBook(t.book_id);
@@ -215,9 +182,9 @@ await withMongo(async (db) => {
     let best = null;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        const { text, baseRef } = await translateOnce(page, book, prevTr);
-        if (!best || badnessScore(page.ocr.data, text) < badnessScore(page.ocr.data, best.text)) best = { text, baseRef };
-        if (!isBad(page.ocr.data, text)) { best = { text, baseRef }; break; }
+        const { text, promptRef } = await translateOnce(page, book, prevTr);
+        if (!best || badnessScore(page.ocr.data, text) < badnessScore(page.ocr.data, best.text)) best = { text, promptRef };
+        if (!isBad(page.ocr.data, text)) { best = { text, promptRef }; break; }
       } catch (e) {
         console.log(`    ${book.id} p${t.page_number} attempt ${attempt} error: ${e.message?.slice(0, 70)}`);
         await new Promise(r => setTimeout(r, 2000));
@@ -231,24 +198,11 @@ await withMongo(async (db) => {
     // nothing. These pages need a benchmark, not a blind re-run.
     if (isBad(page.ocr.data, best.text)) { stillBad++; return; }
 
-    if (page.translation?.data) {
-      await db.collection('page_revisions').insertOne({
-        id: randomBytes(6).toString('hex'), page_id: page.id, book_id: page.book_id,
-        field: 'translation', data: page.translation.data, source: page.translation.source || 'ai',
-        model: page.translation.model, language: page.translation.language,
-        prompt_version: page.translation.prompt_version, original_date: page.translation.updated_at,
-        note: 'anomaly-fix', created_at: new Date(),
-      }).catch(() => {});
-    }
-    await db.collection('pages').updateOne({ id: page.id }, { $set: {
-      translation: {
-        data: best.text, content_hash: contentHash(best.text), language: 'English',
-        model, updated_at: new Date(), source: 'ai',
-        prompt_version: String(best.baseRef?.version ?? 1), prompt_id: best.baseRef?._id?.toString(),
-        prompt_hash: best.baseRef?.content_hash, prompt_name: best.baseRef?.name,
-      },
-      updated_at: new Date(),
-    } });
+    // The one door: revision snapshot + provenance-stamped write (translate-core).
+    await writePageTranslation(db, {
+      page, book, text: best.text, promptRef: best.promptRef, model, note: 'anomaly-fix',
+    });
+    touchedBooks.add(t.book_id);
     fixed++;
   }
 
@@ -263,6 +217,13 @@ await withMongo(async (db) => {
   }
   await Promise.all(Array.from({ length: Math.min(CONCURRENCY, targets.length) }, worker));
   process.stderr.write('\n');
+
+  // Promise 4: recount the touched books' cached counters (this script used to
+  // skip this, leaving pages_translated stale until sync-worker converged it).
+  for (const bookId of touchedBooks) {
+    await syncBookTranslationCounters(db, bookId);
+  }
+  if (touchedBooks.size) console.log(`  counters synced for ${touchedBooks.size} book(s)`);
 
   console.log(`\nDone. fixed=${fixed} stillBad=${stillBad} alreadyGood=${alreadyGood} skipped=${skipped}`);
 }, { maxPoolSize: 12, noTimeout: true });

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -292,9 +292,25 @@ async function closeUsagePlaceholder(db, job, reason, status = 'failed') {
 
 // ── Process one job ──
 
+// Types this collector knows how to save. Everything else is refused (#3725).
+const KNOWN_JOB_TYPES = new Set(['ocr', 'translation', 'translate', 'image_extraction']);
+
 async function processOneJob(db, job) {
   const jobName = job.job_name || job.gemini_job_name;
   if (!jobName) return { status: 'skipped' };
+
+  // Type allowlist (#3725): the save path below treats anything that isn't
+  // 'ocr'/'image_extraction' as a translation, so a typo'd type on a new
+  // submitter would silently write model output into translation.data.
+  // Refuse to collect unknown types and mark the job so it stops re-matching.
+  if (!KNOWN_JOB_TYPES.has(job.type)) {
+    console.error(`  UNKNOWN job type '${job.type}' on ${job.id || job._id} — refusing to collect; marking failed for human triage.`);
+    await db.collection('batch_jobs').updateOne(
+      { _id: job._id },
+      { $set: { status: 'failed', error: `unknown job type '${job.type}' — collector allowlist refused (#3725)`, updated_at: new Date() } }
+    );
+    return { status: 'unknown_type' };
+  }
 
   const result = await getJobData(jobName);
   if (!result) return { status: 'not_found', jobName };

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -26,6 +26,7 @@ import { nanoid } from 'nanoid';
 import { getPageSource as getPageImageUrl } from '../lib/page-image-url.mjs';
 import { buildPageGrounding } from '../lib/page-grounding.mjs';
 import { VISIBLE_PAGE_MATCH } from '../lib/page-counts.mjs';
+import { getTranslateModelForBook } from '../lib/translate-core.mjs';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { GoogleGenAI } from '@google/genai';
@@ -559,12 +560,9 @@ function hashString(str) {
 
 const TRANSLATE_MODEL_FLASH = 'gemini-3-flash-preview';
 const TRANSLATE_MODEL_LITE = 'gemini-3.1-flash-lite';
-function getTranslateModelForBook(book) {
-  if (book?.image_source?.provider === 'bph') return TRANSLATE_MODEL_FLASH;
-  return TRANSLATE_MODEL_LITE;
-}
-const TRANSLATE_MODEL = TRANSLATE_MODEL_FLASH; // Legacy fallback
-const TRANSLATE_PROMPT_VERSION = 'v10';
+// Model routing imported from translate-core (issue #3725). The local copy
+// this replaces routed ONLY on provider — it would have stamped non-Latin-
+// script (e.g. Tibetan) jobs with the lite model that hallucinates on them.
 const TRANSLITERATION_MODEL = 'gemini-3.1-flash-lite';
 const TRANSLITERATION_PROMPT = `You are a scholarly transliterator. Convert the following text to Latin characters using standard academic Romanization conventions.
 
@@ -648,156 +646,9 @@ async function transliteratePage(db, page, sourceScript) {
   return { inputTokens, outputTokens, costUsd };
 }
 
-// ── Direct translation (Gemini realtime, FIFO per book) ──
-
-// Translation prompt loaded from DB prompts collection (single source of truth).
-// Returns { text, id, name, version, content_hash } so callers can stamp
-// prompt_id / prompt_hash / prompt_name on each page write.
-let _cachedTranslationPrompt = null;
-async function getTranslationPromptFromDb(db) {
-  if (_cachedTranslationPrompt) return _cachedTranslationPrompt;
-  const prompt = await db.collection('prompts').findOne(
-    { type: 'translation', is_default: true },
-    { sort: { version: -1 } }
-  );
-  if (!prompt?.content) throw new Error('No default translation prompt found in DB');
-  console.log(`[pipeline] Loaded translation prompt v${prompt.version} from DB`);
-  _cachedTranslationPrompt = {
-    text: prompt.content,
-    id: prompt._id?.toString(),
-    name: prompt.name,
-    version: String(prompt.version ?? 1),
-    content_hash: prompt.content_hash,
-  };
-  return _cachedTranslationPrompt;
-}
-
-// English modernization prompt loaded from DB (single source of truth)
-let _cachedEnglishPrompt = null;
-async function getEnglishModernizationPromptFromDb(db) {
-  if (_cachedEnglishPrompt) return _cachedEnglishPrompt;
-  const prompt = await db.collection('prompts').findOne(
-    { type: 'english_modernization', is_default: true },
-    { sort: { version: -1 } }
-  );
-  if (!prompt?.content) throw new Error('No default english_modernization prompt found in DB');
-  console.log(`[pipeline] Loaded english modernization prompt v${prompt.version} from DB`);
-  _cachedEnglishPrompt = {
-    text: prompt.content,
-    id: prompt._id?.toString(),
-    name: prompt.name,
-    version: String(prompt.version ?? 1),
-    content_hash: prompt.content_hash,
-  };
-  return _cachedEnglishPrompt;
-}
-
-function extractTranslationMetadata(text) {
-  const result = {};
-  const summaryMatch = text.match(/<summary>([\s\S]*?)<\/summary>/i);
-  if (summaryMatch) {
-    const s = summaryMatch[1].trim();
-    if (s.length > 0) result.translation_summary = s;
-  }
-  const keywordsMatch = text.match(/<keywords>([\s\S]*?)<\/keywords>/i);
-  if (keywordsMatch) {
-    const raw = keywordsMatch[1].trim();
-    if (raw.length > 0) {
-      const kw = raw.split(/[,;]\s*|\s+-\s+/).map(k => k.trim()).filter(k => k.length > 0);
-      if (kw.length > 0) result.translation_keywords = [...new Set(kw)];
-    }
-  }
-  return result;
-}
-
-/**
- * Translate a single page via direct Gemini realtime call.
- * Returns the translation text (for use as context for the next page).
- */
-async function translatePage(db, page, sourceLanguage, previousTranslation) {
-  const apiKey = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
-  const url = `${GEMINI_API_BASE}/models/${TRANSLATE_MODEL}:generateContent?key=${apiKey}`;
-
-  const isEnglish = sourceLanguage.toLowerCase() === 'english';
-  const translationPrompt = await getTranslationPromptFromDb(db);
-  const englishPrompt = await getEnglishModernizationPromptFromDb(db);
-  const basePromptRef = isEnglish ? englishPrompt : translationPrompt;
-  let prompt = basePromptRef.text
-    .replace('{source_language}', sourceLanguage)
-    .replace('{target_language}', 'English');
-
-  prompt += isEnglish
-    ? `\n\n**Text to modernize:**\n${page.ocr.data}`
-    : `\n\n**Text to translate:**\n${page.ocr.data}`;
-
-  if (previousTranslation) {
-    prompt += isEnglish
-      ? `\n\n**Previous page (modernized) for continuity:**\n${previousTranslation.slice(0, 2000)}...`
-      : `\n\n**Previous page translation for continuity:**\n${previousTranslation.slice(0, 2000)}...`;
-  }
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      contents: [{ role: 'user', parts: [{ text: prompt }] }],
-      safetySettings: [
-        { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
-        { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
-        { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
-        { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
-      ],
-    }),
-  });
-
-  if (!response.ok) {
-    const errText = await response.text();
-    throw new Error(`Gemini ${response.status}: ${errText.substring(0, 300)}`);
-  }
-
-  const data = await response.json();
-  const text = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
-  const usage = data.usageMetadata || {};
-  const inputTokens = usage.promptTokenCount || 0;
-  const outputTokens = usage.candidatesTokenCount || 0;
-
-  if (!text) throw new Error('Empty response from Gemini');
-
-  // Extract metadata from translation output
-  const meta = extractTranslationMetadata(text);
-
-  // Save revision before overwriting, then write translation
-  await saveRevisionBeforeOverwrite(db, page.id, 'translation');
-  await db.collection('pages').updateOne(
-    { id: page.id },
-    {
-      $set: {
-        'translation.data': text,
-        'translation.language': 'English',
-        'translation.model': TRANSLATE_MODEL,
-        'translation.updated_at': new Date(),
-        'translation.source': 'ai',
-        'translation.prompt_version': basePromptRef.version || TRANSLATE_PROMPT_VERSION,
-        'translation.prompt_id': basePromptRef.id,
-        'translation.prompt_hash': basePromptRef.content_hash,
-        'translation.prompt_name': basePromptRef.name,
-        ...meta,
-        updated_at: new Date(),
-      },
-    }
-  );
-
-  // Log usage (fire-and-forget)
-  const costUsd = (inputTokens / 1_000_000) * 0.50 + (outputTokens / 1_000_000) * 3.00;
-  logUsageAsync({
-    type: 'translation', mode: 'realtime', model: TRANSLATE_MODEL,
-    book_id: page.book_id, page_ids: [page.id],
-    input_tokens: inputTokens, output_tokens: outputTokens,
-    cost_usd: costUsd, status: 'success', endpoint: 'hetzner/pipeline-orchestrator',
-  }, db);
-
-  return { text, inputTokens, outputTokens, costUsd };
-}
+// The realtime translatePage lane that lived here was dead code — a fully
+// armed second writer never called from any phase. Translation is dispatched
+// to translate-worker.mjs (Phase 4) and written through translate-core (#3725).
 
 // Sources whose pages need archiving
 const ARCHIVABLE_SOURCES = /archive\.org|gallica\.bnf\.fr|digitale-sammlungen\.de|digi\.vatlib\.it|diglib\.hab\.de|e-rara|wellcomecollection|cudl\.lib\.cam|digital\.bodleian|cdli\.earth|contentdm\.oclc\.org|digitalcollections\.manchester|viewer\.cbl\.ie|universiteitleiden|digi\.ub\.uni-heidelberg|iiif\.qdl\.qa|permalinkbnd\.bnportugal|dl\.ndl\.go\.jp/;

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -26,6 +26,12 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 import { createHash, randomBytes } from 'crypto';
 import { nanoid } from 'nanoid';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
+import {
+  getTranslateModelForBook as getModelForBook,
+  sanitizeTranslationTags,
+  contentHash,
+} from '../lib/translate-core.mjs';
+import { saveRevisionBeforeOverwrite as saveRevisionShared } from '../lib/page-revisions.mjs';
 import { syncPageUpdate, syncPageBatch } from './lib/supabase-page-writer.mjs';
 import { shouldBypassPause, hasScope, resolveScopeBookIds } from './lib/selective-unpause.mjs';
 
@@ -44,56 +50,10 @@ const RATE_LIMIT_BACKOFF_MS = 15000;
 const BATCH_SIZE = parseInt(process.argv.find(a => a.startsWith('--batch-size='))?.split('=')[1] || '8', 10);
 const SINGLE_PAGE = process.argv.includes('--single-page');
 const MAX_BATCH_OCR_CHARS = 20000; // If total OCR text exceeds this, reduce batch size
-const MODEL_FLASH = 'gemini-3-flash-preview';
-const MODEL_LITE = 'gemini-3.1-flash-lite';
-
-// Latin-script languages safe for flash-lite translation. Non-Latin scripts
-// (Tibetan, Arabic, Hebrew, CJK, Cyrillic, Greek, Syriac, etc.) route to flash.
-// flash-lite hallucinates on low-resource scripts during OCR — translation
-// from those OCR outputs is doubly exposed. Keep in sync with the matching
-// list in src/lib/types/ai-models.ts and pipeline-orchestrator.mjs.
-const LATIN_SCRIPT_LANGS_FOR_LITE = new Set([
-  'english', 'en', 'eng',
-  'latin', 'la', 'lat',
-  'french', 'fr', 'fra',
-  'italian', 'it', 'ita',
-  'spanish', 'es', 'spa',
-  'portuguese', 'pt', 'por',
-  'romanian', 'ro', 'ron', 'rum',
-  'catalan', 'ca', 'cat',
-  'german', 'de', 'deu', 'ger',
-  'dutch', 'nl', 'nld', 'dut',
-  'swedish', 'sv', 'swe',
-  'norwegian', 'no', 'nor',
-  'danish', 'da', 'dan',
-  'finnish', 'fi', 'fin',
-  'icelandic', 'is', 'isl', 'ice',
-  'welsh', 'cy', 'cym', 'wel',
-  'irish', 'ga', 'gle',
-  'polish', 'pl', 'pol',
-  'czech', 'cs', 'ces', 'cze',
-  'slovak', 'sk', 'slk', 'slo',
-  'slovenian', 'sl', 'slv',
-  'croatian', 'hr', 'hrv',
-  'hungarian', 'hu', 'hun',
-  'estonian', 'et', 'est',
-  'latvian', 'lv', 'lav',
-  'lithuanian', 'lt', 'lit',
-  'albanian', 'sq', 'sqi', 'alb',
-  'turkish', 'tr', 'tur',
-  'indonesian', 'id', 'ind',
-  'vietnamese', 'vi', 'vie',
-  'malay', 'ms', 'msa',
-  'tagalog', 'tl', 'tgl', 'filipino',
-  'swahili', 'sw', 'swa',
-]);
-
-function getModelForBook(book) {
-  if (book?.image_source?.provider === 'bph') return MODEL_FLASH;
-  const lang = (book?.language || '').toLowerCase().trim();
-  if (!lang || !LATIN_SCRIPT_LANGS_FOR_LITE.has(lang)) return MODEL_FLASH;
-  return MODEL_LITE;
-}
+// Model routing lives in translate-core (the one door, issue #3725) — this
+// worker's local copy had drifted to include Malay, routing Jawi manuscripts
+// to the lite model that garbles them. Parity with src/lib/types/ai-models.ts
+// is pinned by tests/unit/translate-core-parity.test.ts.
 const PROMPT_VERSION = 'v10';
 
 // ── Gemini API keys ──
@@ -226,21 +186,7 @@ const client = new MongoClient(process.env.MONGODB_URI, {
   maxPoolSize: 20,
 });
 
-// ── Sanitize translation tags (matches src/lib/sanitize-translation-tags.ts) ──
-function sanitizeTranslationTags(text) {
-  if (!text) return text;
-  // Fix common unclosed/malformed XML tags from Gemini
-  return text
-    .replace(/<(margin|gloss|insert|unclear|term|heading|footnote|caption)>([^<]*?)$/gm,
-      (_, tag, content) => `<${tag}>${content}</${tag}>`)
-    .replace(/<\/(margin|gloss|insert|unclear|term|heading|footnote|caption)>\s*<\/\1>/g,
-      (_, tag) => `</${tag}>`);
-}
-
-// ── Content hash for provenance ──
-function contentHash(text) {
-  return createHash('sha256').update(text || '').digest('hex').slice(0, 16);
-}
+// sanitizeTranslationTags + contentHash come from translate-core (one door).
 
 // ── Cost calculation ──
 const MODEL_PRICING = {
@@ -451,38 +397,11 @@ function effectiveBatchSize(pages, maxBatchSize) {
   return Math.max(1, size);
 }
 
-/**
- * Save current page content as a revision before overwriting.
- * Lightweight inline version of src/lib/page-revisions.ts createRevision().
- */
+// Revision snapshots use the shared helper (scripts/lib/page-revisions.mjs) —
+// this worker's lightweight inline copy predated it and stamped every revision
+// with job_id: undefined (3-arg calls against a 4-arg signature, issue #3725).
 async function saveRevisionBeforeOverwrite(db, pageId, field, jobId) {
-  try {
-    const page = await db.collection('pages').findOne(
-      { id: pageId },
-      { projection: { book_id: 1, ocr: 1, translation: 1 } }
-    );
-    if (!page) return;
-    const fieldData = page[field];
-    if (!fieldData?.data) return; // No existing content — first write
-    await db.collection('page_revisions').insertOne({
-      id: randomBytes(6).toString('hex'),
-      page_id: pageId,
-      book_id: page.book_id,
-      field,
-      data: fieldData.data,
-      source: fieldData.source || 'ai',
-      model: fieldData.model,
-      language: fieldData.language,
-      prompt_version: fieldData.prompt_version,
-      edited_by: fieldData.edited_by,
-      job_id: jobId,
-      original_date: fieldData.updated_at,
-      created_at: new Date(),
-    });
-  } catch (e) {
-    // Non-fatal — don't block translation on revision failure
-    console.error(`  [revision] Failed for ${pageId}/${field}: ${e.message?.slice(0, 50)}`);
-  }
+  return saveRevisionShared(db, pageId, field, { jobId });
 }
 
 // ── Write a single page translation to DB ──
@@ -490,7 +409,7 @@ async function saveRevisionBeforeOverwrite(db, pageId, field, jobId) {
 // Falls back to PROMPT_VERSION constant for callers that pre-date the
 // prompt-reference threading (none in this file after the audit, but safe).
 async function writePageTranslation(db, page, text, book, promptRef) {
-  await saveRevisionBeforeOverwrite(db, page.id, 'translation');
+  await saveRevisionBeforeOverwrite(db, page.id, 'translation', book?.job?.job_id);
   const setPayload = {
     translation: {
       data: text,
@@ -520,7 +439,7 @@ async function bulkWritePageTranslations(db, entries, book, promptRef) {
   }
   // Save revisions before overwriting (parallel, non-blocking)
   await Promise.all(entries.map(({ page }) =>
-    saveRevisionBeforeOverwrite(db, page.id, 'translation')
+    saveRevisionBeforeOverwrite(db, page.id, 'translation', book?.job?.job_id)
   ));
   const now = new Date();
   const model = getModelForBook(book);
@@ -608,7 +527,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
   if (blankFromOcr.length > 0) {
     const blankIds = blankFromOcr.map(p => p.id);
     // Snapshot prior translation content before overwriting with the blank marker.
-    await Promise.all(blankIds.map(id => saveRevisionBeforeOverwrite(db, id, 'translation')));
+    await Promise.all(blankIds.map(id => saveRevisionBeforeOverwrite(db, id, 'translation', job?.id)));
     await db.collection('pages').updateMany(
       { id: { $in: blankIds } },
       { $set: { page_type: 'blank', updated_at: new Date(), 'translation.data': '[Blank page]', 'translation.language': 'English', 'translation.source': 'skip', 'translation.updated_at': new Date() } },
@@ -751,7 +670,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
           if (msg.includes('PROHIBITED') || msg.includes('SAFETY') || msg.includes('safety') || msg.includes('RECITATION')) {
             try {
               // Snapshot prior translation before overwriting with the block marker.
-              await saveRevisionBeforeOverwrite(db, page.id, 'translation');
+              await saveRevisionBeforeOverwrite(db, page.id, 'translation', job?.id);
               // Replace null translation with {} so sub-fields can be set
               await db.collection('pages').updateOne(
                 { _id: page._id },
@@ -828,7 +747,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
               console.error(`  [${label}] Fallback page ${page.page_number} failed: ${errMsg.substring(0, 80)}`);
               try {
                 // Snapshot prior translation before overwriting with the block marker.
-                await saveRevisionBeforeOverwrite(db, page.id, 'translation');
+                await saveRevisionBeforeOverwrite(db, page.id, 'translation', job?.id);
                 // Replace null translation with {} so sub-fields can be set
                 await db.collection('pages').updateOne(
                   { _id: page._id },
@@ -903,7 +822,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
               console.error(`  [${label}] Fallback page ${page.page_number} failed: ${errMsg.substring(0, 80)}`);
               try {
                 // Snapshot prior translation before overwriting with the block marker.
-                await saveRevisionBeforeOverwrite(db, page.id, 'translation');
+                await saveRevisionBeforeOverwrite(db, page.id, 'translation', job?.id);
                 // Replace null translation with {} so sub-fields can be set
                 await db.collection('pages').updateOne(
                   { _id: page._id },

--- a/src/app/api/[tenant]/books/[id]/batch-translate-async/route.ts
+++ b/src/app/api/[tenant]/books/[id]/batch-translate-async/route.ts
@@ -7,6 +7,7 @@ import { getTranslationPrompt } from '@/lib/prompts';
 import { PROMPT_VERSION, SKIP_TRANSLATION_PAGE_TYPES } from '@/lib/types/prompts/defaults';
 import { createRevision } from '@/lib/page-revisions';
 import { withAuth } from '@/lib/auth-helpers';
+import { VISIBLE_PAGE_MATCH } from '@/lib/page-counts';
 import { resolveTenantId } from '@/lib/tenant-context';
 
 /**
@@ -376,10 +377,12 @@ export const GET = withAuth(async (request, session, context) => {
           }
         );
 
-        // Update book's translation count
+        // Update book's translation count — visible pages only (#3293); the
+        // old count included soft-hidden pages (page_number <= 0).
         const translatedCount = await db.collection('pages').countDocuments({
           book_id: bookId,
           tenantId,
+          ...VISIBLE_PAGE_MATCH,
           'translation.data': { $exists: true, $nin: [null, ''] }
         });
 

--- a/src/app/api/books/[id]/batch-translate-async/route.ts
+++ b/src/app/api/books/[id]/batch-translate-async/route.ts
@@ -7,6 +7,7 @@ import { getTranslationPrompt } from '@/lib/prompts';
 import { PROMPT_VERSION, SKIP_TRANSLATION_PAGE_TYPES } from '@/lib/types/prompts/defaults';
 import { createRevision } from '@/lib/page-revisions';
 import { withAuth } from '@/lib/auth-helpers';
+import { buildVisiblePageCountPipeline } from '@/lib/page-counts';
 
 /**
  * Async Batch Translation using Gemini Batch API
@@ -361,17 +362,20 @@ export const GET = withAuth(async (request, session, context) => {
           }
         );
 
-        // Update book's translation count
-        const translatedCount = await db.collection('pages').countDocuments({
-          book_id: bookId,
-          'translation.data': { $exists: true, $nin: [null, ''] }
-        });
-
+        // Update book counters with the canonical visible-pages convention
+        // (#3293) — the old count here included soft-hidden pages
+        // (page_number <= 0), drifting from every other writer.
+        const [counts] = await db.collection('pages')
+          .aggregate(buildVisiblePageCountPipeline(bookId)).toArray();
         await db.collection('books').updateOne(
           { id: bookId },
           {
             $set: {
-              pages_translated: translatedCount,
+              ...(counts ? {
+                pages_count: counts.total,
+                pages_ocr: counts.with_ocr,
+                pages_translated: counts.with_translation,
+              } : {}),
               last_translation_at: new Date(),
               updated_at: new Date()
             }

--- a/src/lib/page-counts.ts
+++ b/src/lib/page-counts.ts
@@ -1,0 +1,56 @@
+/**
+ * Canonical page-count convention (issue #3293) — TS twin of
+ * scripts/lib/page-counts.mjs. Keep the two in lock-step.
+ *
+ * `books.pages_count` / `pages_ocr` / `pages_translated` are VISIBLE-only:
+ * they count pages with `page_number > 0`. Pages with `page_number <= 0` are
+ * a deliberate soft-hide — they never render in the reader — so counting them
+ * corrupts the read path (which divides by `pages_count` for readability
+ * gates). Every writer that recomputes these counters must count visible
+ * pages only.
+ */
+
+import type { Document } from 'mongodb';
+
+/** Match fragment selecting only visible (renderable) pages. */
+export const VISIBLE_PAGE_MATCH = { page_number: { $gt: 0 } } as const;
+
+/**
+ * Aggregation pipeline returning { total, with_ocr, with_translation } for
+ * the VISIBLE pages of one book. Mirror of the .mjs implementation.
+ */
+export function buildVisiblePageCountPipeline(bookId: string): Document[] {
+  return [
+    { $match: { book_id: bookId, ...VISIBLE_PAGE_MATCH } },
+    {
+      $group: {
+        _id: null,
+        total: { $sum: 1 },
+        with_ocr: {
+          $sum: {
+            $cond: [
+              { $and: [
+                { $ne: ['$ocr.data', null] },
+                { $ne: ['$ocr.data', ''] },
+                { $ifNull: ['$ocr.data', false] },
+              ] },
+              1, 0,
+            ],
+          },
+        },
+        with_translation: {
+          $sum: {
+            $cond: [
+              { $and: [
+                { $ne: ['$translation.data', null] },
+                { $ne: ['$translation.data', ''] },
+                { $ifNull: ['$translation.data', false] },
+              ] },
+              1, 0,
+            ],
+          },
+        },
+      },
+    },
+  ];
+}

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -182,6 +182,34 @@ export async function getTranslationPrompt(
   const isEnglish = sourceLanguage.toLowerCase() === 'english';
 
   if (isEnglish && !options?.customText && !options?.name && !options?.id) {
+    // DB-first (#3725): the english_modernization prompt lives in the prompts
+    // collection — the same row translate-worker.mjs reads — so improving it
+    // never requires a deploy. This used to short-circuit to the hardcoded
+    // constant, silently forking the prompt for every English book processed
+    // through the API/Lambda paths. The constant remains only as a fallback
+    // so English books never fail closed on a DB hiccup.
+    try {
+      const db = await getDb();
+      const doc = await db.collection('prompts').findOne(
+        { type: 'english_modernization', is_default: true },
+        { sort: { version: -1 } }
+      );
+      if (doc?.content) {
+        const content = doc.content as string;
+        return {
+          text: content,
+          reference: {
+            id: doc._id?.toString() || 'unknown',
+            name: (doc.name as string) || 'English Modernization',
+            version: (doc.version as number) || 1,
+            content_hash: (doc.content_hash as string) || promptContentHash(content),
+          },
+        };
+      }
+    } catch (error) {
+      console.error('[prompts] Error fetching english_modernization prompt:', error);
+    }
+    console.warn('[prompts] No english_modernization prompt in DB, using hardcoded fallback');
     return {
       text: ENGLISH_MODERNIZATION_PROMPT,
       reference: {

--- a/tests/unit/translate-core-parity.test.ts
+++ b/tests/unit/translate-core-parity.test.ts
@@ -1,0 +1,64 @@
+/**
+ * PARITY — src/lib/types/ai-models.ts getModelForBook (API routes, Lambda)
+ * vs scripts/lib/translate-core.mjs getTranslateModelForBook (workers, scripts).
+ *
+ * Runs BOTH routings over the same probes and fails on any divergence, so
+ * "keep in lock-step" is enforced rather than hoped. The probe set includes
+ * every language in the .mjs allowlist plus the historical divergence cases:
+ * a drifted copy in translate-worker.mjs once routed Malay (Jawi manuscripts)
+ * to the lite model, the exact hallucination case the allowlist exists to
+ * prevent (issue #3725).
+ */
+import { describe, it, expect } from 'vitest';
+import { getModelForBook as routeTs } from '@/lib/types/ai-models';
+import {
+  getTranslateModelForBook as routeMjs,
+  LATIN_SCRIPT_LANGUAGES,
+  MODEL_FLASH,
+  MODEL_LITE,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore — plain-JS module, no declarations
+} from '../../scripts/lib/translate-core.mjs';
+
+type Probe = { name: string; book: Parameters<typeof routeTs>[0] };
+
+const DIVERGENCE_SUSPECTS = [
+  // Deliberately absent from the allowlist — must go to full flash.
+  'malay', 'ms', 'msa',
+  // Missing from the drifted retranslate-pages copy — must stay on lite.
+  'estonian', 'et', 'est',
+  // Non-Latin scripts — full flash always.
+  'greek', 'tibetan', 'hebrew', 'arabic', 'chinese', 'russian', 'sanskrit',
+  // Junk and edge cases.
+  'klingon', '', '  latin  ', 'LATIN', 'English',
+];
+
+const probes: Probe[] = [
+  { name: 'bph provider wins over language', book: { image_source: { provider: 'bph' }, language: 'latin' } },
+  { name: 'null book', book: null },
+  { name: 'no language', book: {} },
+  { name: 'null language', book: { language: null } },
+  ...[...LATIN_SCRIPT_LANGUAGES as Set<string>].map((lang) => ({
+    name: `allowlist: ${lang}`,
+    book: { language: lang },
+  })),
+  ...DIVERGENCE_SUSPECTS.map((lang) => ({
+    name: `suspect: ${JSON.stringify(lang)}`,
+    book: { language: lang },
+  })),
+];
+
+describe('translate-core routing parity', () => {
+  it.each(probes)('$name', ({ book }) => {
+    expect(routeMjs(book)).toBe(routeTs(book));
+  });
+
+  it('routes Malay (Jawi) to full flash — the case the drifted copy broke', () => {
+    expect(routeMjs({ language: 'malay' })).toBe(MODEL_FLASH);
+    expect(routeTs({ language: 'malay' })).toBe(MODEL_FLASH);
+  });
+
+  it('routes plain Latin-script books to lite', () => {
+    expect(routeMjs({ language: 'latin' })).toBe(MODEL_LITE);
+  });
+});


### PR DESCRIPTION
Implements Phases 0–2 of #3725 (the pipeline rationalization plan).

## What this is

A new shared module, `scripts/lib/translate-core.mjs`, now owns the four promises every translation writer must keep — routed model, DB-owned prompt, revision-before-overwrite, canonical counter sync — and the writers that had drifted are wired through it.

## In scope

- **translate-core module** + `src/lib/page-counts.ts` (TS twin of the counter convention) + a 129-probe parity test that runs BOTH routing implementations over the same inputs.
- **Real bugs found by consolidating, not just tidiness:**
  - translate-worker's drifted language list routed **Malay (Jawi manuscripts) to the lite model** that garbles them — the exact hallucination case the allowlist exists to prevent.
  - Every revision from the production worker carried `job_id: undefined` (3-arg calls against a 4-arg signature).
  - The orchestrator's Phase 4 dispatch stamped jobs with a local BPH-or-lite routing that **ignored language entirely**.
  - `realtime-translate.mjs` hardcoded flash for every book (the #482 cost-bug shape) and carried a fork of the English modernization prompt with no provenance.
  - `retranslate-pages.mjs` was the only writer that never recounted `pages_translated`.
  - Both collectors would save an unknown job type **into `translation.data`** by default; they now refuse and mark it failed.
  - `getTranslationPrompt()` short-circuited English books to a hardcoded prompt before touching the DB; now DB-first with the constant as fail-open fallback (the DB row exists — verified).
  - Dead code: the orchestrator's 150-line `translatePage` lane (zero call sites) is gone.
- **Docs (Phase 0):** `memory/pipeline-ops.md` now states which workers actually run (orchestrator loop + translate-worker are dormant; `collect-batch-results` is live every 30 min per #3717) and resolves the batch-translation doctrine contradiction: banned for bulk (sequential context chain), sanctioned per-book with the tradeoff stated in `translating-a-book.md`.

## Out of scope (deliberately)

- Lambda `translation-processor-logic.ts` adoption of core (next PR — it already reads DB prompts via the fixed `getTranslationPrompt`).
- `stitch-translations` hardcoded prompt; the one-off `oraec` importer.
- Phase 3 (Gemini key regeneration — Derek-only) and Phase 4 (pipeline posture decision).

## Risk notes

- `translate-worker.mjs` and `pipeline-orchestrator.mjs` translation phases are **dormant in production** (pause since 2026-06-08; neither is on the Hetzner crontab), so their changes cannot affect prod until the line restarts.
- `collect-batch-results.mjs` **is live** (Hetzner cron every 30 min); its only change is the type allowlist, which is a no-op for all three types that exist in prod.
- English-prompt DB-first changes which prompt text English books get on the API/Lambda paths — from the hardcoded fork to the DB row the worker already uses. That is the intended unification.

## Verification

- `npx tsc --noEmit` clean; full unit suite 158 files / 2,177 tests green (includes the new parity test).
- `node --check` on every touched .mjs.
- DB checked: `prompts` holds `english_modernization` v1 `is_default: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EuBTCAanbHTNmLPqKc7nx