### PR TITLE
fix(mcp): feedback ceiling ate 42% of submissions; docs described a server three versions gone

### DIFF
--- a/memory/mcp-server.md
+++ b/memory/mcp-server.md
@@ -9,14 +9,20 @@ them as one.
 | Code | `src/app/api/mcp/route.ts` | `mcp-server/` (separate package at the repo root) |
 | Reached at | `https://sourcelibrary.org/api/mcp` (Streamable HTTP, stateless) | installed locally, stdio |
 | Used by | Claude.ai, Cowork, Claude Code, anything in the directory | local/dev clients |
-| Version | `4.4.0` (in the route's `serverInfo`) | `4.5.0` (`mcp-server/package.json`) |
-| Tools | 13 | 12 |
+| Version | `SERVER_VERSION` in the route (single literal since #3715; `server.json` is the only other copy — bump both together) | `4.5.0` (`mcp-server/package.json`) |
+| Tools | 15 | 12 |
+
+The remote version used to be three drifting literals (4.7.0 / 4.5.0 / 4.6.0
+simultaneously on 2026-08-07); #3715 collapsed it to one constant, held against
+`server.json` by the audit below.
 
 The two tool lists have **diverged** and that is not (currently) a bug to fix
-blindly: the remote server carries `get_quotes` (batch) and `propose_collection`
-which the package lacks, and the package carries `check_duplicate` — a
-pre-import helper that has no business on a public unauthenticated surface — which
-the remote server rightly lacks. Check the file you are actually changing.
+blindly: the remote server carries `get_quotes` (batch), `propose_collection`,
+`list_editions` (#3676) and `get_locus` (#3703) which the package lacks, and the
+package carries `check_duplicate` — a pre-import helper that has no business on
+a public unauthenticated surface — which the remote server rightly lacks. Check
+the file you are actually changing. The gap is now four tools wide; whether to
+sync or deprecate the npm package is an open decision.
 
 ## The listing, and the thing that must not happen again
 
@@ -75,4 +81,12 @@ deprecate instead; the manifest in
   `mcp_clients` (initialize handshakes, #3644) and `mcp_tool_calls` record who
   connects — **segment by `client_name` before quoting usage**, because a large
   share of handshakes are directory crawlers (`glimind-probe`, `mcpbeat`, `glama`,
-  `MCPScoringEngine`, `census-probe`, …) rather than readers.
+  `MCPScoringEngine`, `census-probe`, …) rather than readers. Snapshot 2026-08-08
+  (14 days): ~1,950 handshakes but the top real clients are `Anthropic/ClaudeAI`
+  (394) and `claude-code` (302); ~940 genuine tool calls, led by `get_book_text`,
+  `search_library`, `search_within_book`, `get_quote`, `list_books`. Read errors
+  before adding features: the same window showed `submit_feedback` failing 14/33
+  calls on a 5,000-char limit (raised to 20,000 as one shared constant,
+  `src/lib/feedback-limits.ts`, #3722) — the failure table in `mcp_tool_calls`
+  is the cheapest ergonomics backlog we have. Two sessions independently found
+  and fixed this within hours of each other; check open PRs before acting on it.

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Embassy-of-the-Free-Mind/sourcelibrary",
   "title": "Source Library",
   "description": "Search 15K rare pre-modern texts translated to English: philosophy, religion, science, literature.",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "repository": {
     "url": "https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2",
     "source": "github"

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -36,7 +36,7 @@ import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
  * TypeScript, so it stays a literal. That is now the ONLY other copy, and the
  * audit's job is exactly to hold it against this one. Bump both together.
  */
-const SERVER_VERSION = '4.7.0';
+const SERVER_VERSION = '4.7.1';
 
 // ── API helpers (same as mcp-server/src/api.ts, self-calling) ──────
 
@@ -890,7 +890,9 @@ async function handleToolCall(name: string, args: ToolArgs) {
     case 'submit_feedback': return submitFeedback(args);
     case 'share_findings': return shareFindings(args);
     case 'propose_collection': return proposeCollection(args);
-    default: throw new Error(`Unknown tool: ${name}`);
+    // Name every tool in the error: a caller that guessed a name ("search") can
+    // self-correct on the next call instead of concluding the server is broken.
+    default: throw new Error(`Unknown tool: ${name}. Available tools: ${TOOLS.map((t) => t.name).join(', ')}`);
   }
 }
 

--- a/src/app/blog/mcp-server/page.tsx
+++ b/src/app/blog/mcp-server/page.tsx
@@ -87,7 +87,7 @@ export default function McpServerPage() {
 
         <div className="bg-white rounded-xl border border-border-light p-6 mb-4">
           <p className="text-stone-700 italic mb-2">&ldquo;Find everything about Hermes Trismegistus in the collection. What books mention him, and how does his treatment change across traditions?&rdquo;</p>
-          <p className="text-xs text-muted">Tools used: <code className="text-accent-rust">search_entities</code> &rarr; <code className="text-accent-rust">get_entity</code> &rarr; <code className="text-accent-rust">get_book_text</code></p>
+          <p className="text-xs text-muted">Tools used: <code className="text-accent-rust">search_library</code> &rarr; <code className="text-accent-rust">search_within_book</code> &rarr; <code className="text-accent-rust">get_quotes</code></p>
         </div>
 
         <p className="text-secondary leading-relaxed mb-6">
@@ -146,7 +146,7 @@ export default function McpServerPage() {
 
         <div className="bg-white rounded-xl border border-border-light p-6 mb-4">
           <p className="text-stone-700 italic mb-2">&ldquo;Find alchemical emblems depicting the ouroboros. What texts are they from, and what do they symbolize?&rdquo;</p>
-          <p className="text-xs text-muted">Tools used: <code className="text-accent-rust">search_images</code> &rarr; <code className="text-accent-rust">get_image</code> &rarr; <code className="text-accent-rust">get_book_text</code></p>
+          <p className="text-xs text-muted">Tools used: <code className="text-accent-rust">search_images</code> &rarr; <code className="text-accent-rust">get_quote</code></p>
         </div>
 
         <p className="text-secondary leading-relaxed mb-8">

--- a/src/app/blog/mcp-server/page.tsx
+++ b/src/app/blog/mcp-server/page.tsx
@@ -50,7 +50,7 @@ export default function McpServerPage() {
         <p className="text-xl text-secondary leading-relaxed mb-8">
           Today we&apos;re releasing an{' '}
           <a href="https://www.npmjs.com/package/@source-library/mcp-server" className="text-accent-rust hover:text-accent-rust underline" target="_blank" rel="noopener noreferrer">MCP server</a>
-          {' '}that gives Claude direct access to Source Library. One command, no API key, and Claude can search, read, and cite thousands of historical texts &mdash; with full English translations, a cross-book entity knowledge graph, and 90,000+ extracted illustrations.
+          {' '}that gives Claude direct access to Source Library. One command, no API key, and Claude can search, read, and cite thousands of historical texts &mdash; with full English translations and 110,000+ extracted illustrations.
         </p>
 
         <div className="bg-stone-900 rounded-xl p-4 mb-8 overflow-x-auto">
@@ -59,7 +59,7 @@ export default function McpServerPage() {
 
         <p className="text-secondary leading-relaxed mb-8">
           <a href="https://modelcontextprotocol.io/" className="text-accent-rust hover:text-accent-rust underline" target="_blank" rel="noopener noreferrer">MCP</a>
-          {' '}(Model Context Protocol) is an open standard that lets AI assistants connect to external data sources. Instead of pasting text into a chat window, you give Claude a set of tools &mdash; and it decides when and how to use them. Our server provides 11 tools covering search, full-text reading, entity lookup, academic citation, and image retrieval.
+          {' '}(Model Context Protocol) is an open standard that lets AI assistants connect to external data sources. Instead of pasting text into a chat window, you give Claude a set of tools &mdash; and it decides when and how to use them. The server now provides 15 tools covering search, full-text reading, verbatim citation, canonical-reference lookup, and image retrieval &mdash; plus ways to contribute findings back. <em>(This post has been updated as the toolset has grown since launch; the list below is current.)</em>
         </p>
 
         <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
@@ -201,37 +201,47 @@ export default function McpServerPage() {
         </p>
 
         <p className="text-secondary leading-relaxed mb-6">
-          The 11 tools are organized into four groups:
+          The 15 tools are organized into five groups:
         </p>
 
         <div className="grid md:grid-cols-2 gap-4 mb-8">
           <div className="bg-white rounded-lg border border-border-light p-5">
-            <h4 className="font-semibold text-primary mb-2">Discovery</h4>
+            <h4 className="font-semibold text-primary mb-2">Search</h4>
             <p className="text-secondary text-sm">
-              <code className="text-accent-rust">search_library</code> for full-text search across all books and pages.{' '}
-              <code className="text-accent-rust">list_books</code> for browsing with filters (language, category, sort).
+              <code className="text-accent-rust">search_library</code> to find books on a topic.{' '}
+              <code className="text-accent-rust">search_translations</code> for quotable passages by keyword,{' '}
+              <code className="text-accent-rust">search_concept</code> for passages by meaning (semantic search), and{' '}
+              <code className="text-accent-rust">search_within_book</code> to dig inside one book.
             </p>
           </div>
           <div className="bg-white rounded-lg border border-border-light p-5">
             <h4 className="font-semibold text-primary mb-2">Reading</h4>
             <p className="text-secondary text-sm">
-              <code className="text-accent-rust">get_book_text</code> for bulk reading (whole books or page ranges).{' '}
-              <code className="text-accent-rust">get_book</code> for metadata.{' '}
-              <code className="text-accent-rust">get_quote</code> for cited passages.
+              <code className="text-accent-rust">get_book</code> for a book&apos;s summary, chapters, and metadata.{' '}
+              <code className="text-accent-rust">get_book_text</code> for bulk reading (chapters or page ranges).{' '}
+              <code className="text-accent-rust">list_books</code> to browse the catalog and{' '}
+              <code className="text-accent-rust">list_editions</code> to find every edition of a work we hold.
             </p>
           </div>
           <div className="bg-white rounded-lg border border-border-light p-5">
-            <h4 className="font-semibold text-primary mb-2">Knowledge Graph</h4>
+            <h4 className="font-semibold text-primary mb-2">Citing</h4>
             <p className="text-secondary text-sm">
-              <code className="text-accent-rust">search_index</code> for concepts, people, and places in book indexes.{' '}
-              <code className="text-accent-rust">search_entities</code> and <code className="text-accent-rust">get_entity</code> for the cross-book entity network.
+              <code className="text-accent-rust">get_quote</code> and <code className="text-accent-rust">get_quotes</code> for verbatim page text with stable citation links.{' '}
+              <code className="text-accent-rust">get_locus</code> resolves canonical references &mdash; Bekker numbers for Aristotle, Stephanus pages for Plato &mdash; to the actual leaves that carry them.
             </p>
           </div>
           <div className="bg-white rounded-lg border border-border-light p-5">
             <h4 className="font-semibold text-primary mb-2">Gallery</h4>
             <p className="text-secondary text-sm">
-              <code className="text-accent-rust">search_images</code> across 90,000+ illustrations by subject, symbol, figure, or type.{' '}
-              <code className="text-accent-rust">get_image</code> and <code className="text-accent-rust">get_book_images</code> for details.
+              <code className="text-accent-rust">search_images</code> across 110,000+ illustrations and 23,000+ artworks by subject, symbol, figure, or type.
+            </p>
+          </div>
+          <div className="bg-white rounded-lg border border-border-light p-5">
+            <h4 className="font-semibold text-primary mb-2">Contributing</h4>
+            <p className="text-secondary text-sm">
+              <code className="text-accent-rust">submit_feedback</code> for bug reports and requests,{' '}
+              <code className="text-accent-rust">share_findings</code> to send back a cited research dossier, and{' '}
+              <code className="text-accent-rust">propose_collection</code> to suggest a themed grouping of books. All three go to a human review queue.
             </p>
           </div>
         </div>
@@ -241,7 +251,14 @@ export default function McpServerPage() {
         </h2>
 
         <p className="text-secondary leading-relaxed mb-4">
-          For Claude Code:
+          The easiest path today needs no install at all: Source Library is in the{' '}
+          <a href="https://claude.ai/directory/connectors/source-library" className="text-accent-rust hover:text-accent-rust underline" target="_blank" rel="noopener noreferrer">Claude connector directory</a>
+          {' '}&mdash; switch it on from the connectors menu, or add{' '}
+          <code className="text-accent-rust text-sm">https://sourcelibrary.org/api/mcp</code> as a custom connector in any MCP client.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-4">
+          To run it locally instead &mdash; for Claude Code:
         </p>
 
         <div className="bg-stone-900 rounded-xl p-4 mb-6 overflow-x-auto">

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -2,10 +2,47 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import ApiKeyRequestForm from '@/components/developers/ApiKeyRequestForm';
+import toolManifest from '../../../scripts/audit/mcp-directory-contract.tools.json';
+
+// One row per MCP tool, in the order the table shows them. The blurbs are
+// human one-liners — the agent-facing descriptions live in
+// src/app/api/mcp/route.ts and are much longer.
+const MCP_TOOLS: Array<{ name: string; blurb: string }> = [
+  { name: 'search_library', blurb: 'Find books on a topic — full-text search across the catalog' },
+  { name: 'search_translations', blurb: 'Find quotable passages by keyword across the whole library' },
+  { name: 'search_concept', blurb: 'Semantic passage search — matches paraphrases and adjacent ideas, not just keywords' },
+  { name: 'search_within_book', blurb: 'Search inside a specific book’s pages' },
+  { name: 'list_books', blurb: 'Browse with filters — language, year, category, translation status' },
+  { name: 'list_editions', blurb: 'Every edition of a work the library holds, across languages and centuries' },
+  { name: 'get_book', blurb: 'Book metadata: summary, chapters, edition info, DOI' },
+  { name: 'get_book_text', blurb: 'Read 50+ pages in one call — OCR, translation, or both' },
+  { name: 'get_quote', blurb: 'Exact text of a single page with a stable citation URL' },
+  { name: 'get_quotes', blurb: 'Verbatim text + citation links for up to 25 pages in one call' },
+  { name: 'get_locus', blurb: 'Resolve canonical references — Bekker (Aristotle) and Stephanus (Plato) — to the leaves that carry them' },
+  { name: 'search_images', blurb: 'Search historical illustrations and artworks by subject, symbol, figure, type' },
+  { name: 'submit_feedback', blurb: 'Send bug reports and requests to the team' },
+  { name: 'share_findings', blurb: 'Contribute a cited research dossier back to the library (human-reviewed)' },
+  { name: 'propose_collection', blurb: 'Propose a themed grouping of books (human-reviewed)' },
+];
+
+// Build-time tripwire: the manifest is CI-audited against the live server
+// (scripts/audit/mcp-directory-contract.mjs), so if this table and the manifest
+// disagree, the page is documenting tools that don't exist — fail the build
+// instead of publishing the drift. This page said "9 research tools" for months
+// while the server had 15.
+{
+  const manifestNames = new Set(toolManifest.tools.map((t) => t.name));
+  const tableNames = new Set(MCP_TOOLS.map((t) => t.name));
+  const missing = [...manifestNames].filter((n) => !tableNames.has(n));
+  const extra = [...tableNames].filter((n) => !manifestNames.has(n));
+  if (missing.length || extra.length) {
+    throw new Error(`developers page tool table out of sync with MCP manifest — missing: [${missing}], extra: [${extra}]`);
+  }
+}
 
 export const metadata: Metadata = {
   title: 'Developers - Source Library',
-  description: 'Open API over 15,000+ rare pre-modern texts translated to English — theology, philosophy, history, science, mysticism, literature. No auth required — call /api/mcp from curl, the browser, or any MCP client. 9 research tools, REST endpoints, CLI.',
+  description: `Open API over 15,000+ rare pre-modern texts translated to English — theology, philosophy, history, science, mysticism, literature. No auth required — call /api/mcp from curl, the browser, or any MCP client. ${MCP_TOOLS.length} research tools, REST endpoints, CLI.`,
   alternates: {
     canonical: '/developers',
   },
@@ -247,42 +284,12 @@ export default function DevelopersPage() {
         <div className="overflow-x-auto mb-10">
           <table className="w-full text-sm">
             <tbody className="divide-y divide-stone-100">
-              <tr>
-                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">search_library</td>
-                <td className="py-2.5 text-secondary">Full-text search across books and page content</td>
-              </tr>
-              <tr>
-                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">search_translations</td>
-                <td className="py-2.5 text-secondary">Search inside translated text across the whole library</td>
-              </tr>
-              <tr>
-                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">search_concept</td>
-                <td className="py-2.5 text-secondary">Semantic / conceptual passage search &mdash; matches paraphrases and adjacent ideas, not just keywords</td>
-              </tr>
-              <tr>
-                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">search_within_book</td>
-                <td className="py-2.5 text-secondary">Search inside a specific book&apos;s pages</td>
-              </tr>
-              <tr>
-                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">list_books</td>
-                <td className="py-2.5 text-secondary">Browse with filters &mdash; language, year, category, translation status</td>
-              </tr>
-              <tr>
-                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">get_book</td>
-                <td className="py-2.5 text-secondary">Book metadata: summary, chapters, edition info, DOI</td>
-              </tr>
-              <tr>
-                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">get_book_text</td>
-                <td className="py-2.5 text-secondary">Read 50+ pages in one call &mdash; OCR, translation, or both</td>
-              </tr>
-              <tr>
-                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">get_quote</td>
-                <td className="py-2.5 text-secondary">Exact text of a single page with citation URL</td>
-              </tr>
-              <tr>
-                <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">search_images</td>
-                <td className="py-2.5 text-secondary">Search 150,000+ historical illustrations by subject, symbol, type</td>
-              </tr>
+              {MCP_TOOLS.map((tool) => (
+                <tr key={tool.name}>
+                  <td className="py-2.5 pr-4 font-mono text-accent-rust whitespace-nowrap">{tool.name}</td>
+                  <td className="py-2.5 text-secondary">{tool.blurb}</td>
+                </tr>
+              ))}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## What

Ergonomics + documentation fixes for the MCP server, driven by the `mcp_tool_calls` failure table (last 14 days: ~940 real tool calls).

**Behavior:**
- Unknown-tool errors now enumerate the available tools (a caller guessed `search` and got nothing to aim at).
- ~~submit_feedback length limit~~ — **superseded during this PR's life by #3722**, which raised the cap to 20,000 as one shared constant (`src/lib/feedback-limits.ts`). This branch is rebased on top and keeps that version; the failure data that motivated it (14 of 33 calls rejected, all 5,037–6,227 chars) independently confirms #3722's reading.

**Documentation drift, fixed:**
- `/developers` claimed **"9 research tools"**; the server has 15. The tool table is now rendered from a data array that **build-fails if it disagrees with the CI-audited manifest** (`scripts/audit/mcp-directory-contract.tools.json`) — the count in the meta description is derived, not typed.
- `/blog/mcp-server` documented **five tools removed in the 4.0.0 consolidation** (`search_index`, `search_entities`, `get_entity`, `get_image`, `get_book_images`) and never mentioned the hosted connector. Tool groups rewritten to the current 15; connector-directory + remote-URL install path added.
- `memory/mcp-server.md` refreshed (15 tools, single version literal per #3715, usage/failure snapshot, #3722 credit).

`SERVER_VERSION` + `server.json` bumped together to **4.7.1**. After merge the registry copy needs `mcp-publisher publish`.

## Out of scope (filed as #3733)
- npm package divergence (12 tools at 4.5.0 vs remote 15) — sync-or-deprecate decision
- `search_images` latency (12s avg) and `list_editions` latency (6.7s avg)

## Verification
- `npx tsc --noEmit` clean after rebase
- `npm run audit:mcp:self-test` 14/14
- Live `npm run audit:mcp` against the pre-rebase preview: 14/14 (incl. 4.7.1 parity); re-run against the rebased preview before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)