### PR TITLE
docs: rewrite ARCHITECTURE.md for a human reading cold, and generate its numbers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,131 +1,209 @@
-# Source Library Architecture
+# How Source Library works
 
-## Overview
+A guide for a person reading cold. Start here, read once, and you should be able
+to place any file, collection or worker you meet afterwards.
 
-Source Library is a Next.js application for digitizing, processing, and translating early printed books (primarily pre-1650 works). It uses MongoDB for storage, Gemini AI for OCR and translation, and integrates with USTC (Universal Short Title Catalogue) for bibliographic metadata.
+> **This is the human tier.** The machine tier is `CLAUDE.md` and
+> `.claude/docs/invariants/`, indexed by *"read this before you touch X"*. That
+> tier is deliberately not a narrative and this one is deliberately not
+> exhaustive. When you need the detail, the last section says where to look.
 
-## Key Workflows
+---
 
-### 1. Book Import
-- Upload PDFs or import from archive.org/IIIF sources
-- Images stored as page records in MongoDB
-- USTC metadata can be linked for bibliographic accuracy
+## 1. What this is
 
-### 2. Page Splitting (`/book/[id]/split`)
-- Many source scans are two-page spreads
-- Split page detects gutter position (auto, dark, bright, center, Gemini AI)
-- Creates two virtual pages with crop coordinates (non-destructive)
-- Original images preserved
+Source Library is a digital library of historical primary sources — alchemy,
+Hermetica, Kabbalah, Rosicrucianism, early modern science, and a good deal
+beyond them — that makes scanned books **readable and citable**: page images,
+AI-aided OCR, translation into English, and curation that surfaces them.
 
-### 3. OCR & Translation (`/book/[id]` actions)
-- Gemini-powered OCR extracts text from page images
-- Translation to English with scholarly annotations
-- Page summaries for indexing
+The core experience is *reading and quoting an original*. Everything else exists
+to serve that: collections and galleries are how a reader finds a text,
+shortlinks and DOIs are how they cite it, and partner subdomains are how an
+institution presents its own holdings as a reading room.
 
-### 4. Reading & Export
-- `/book/[id]/read` - Parallel text reader (Loeb-style)
-- EPUB export in multiple formats
-- Citation generation with USTC links
+Two things follow from this that shape the whole system:
 
-## Architectural Decisions
+- **A citation must be trustworthy.** Serving a passage that is not quite what
+  the author wrote is the worst thing this system can do — worse than serving
+  nothing. Much of the code that looks defensive exists for that reason.
+- **The corpus is unevenly processed, on purpose.** A book can be acquired,
+  scanned, read, translated and curated at different times, or never. "How many
+  books do we have" therefore has several correct answers.
 
-### ADR-001: Split Page vs Prepare Page (2024-12)
+## 2. The corpus, measured
 
-**Status:** Decided
+<!-- STATS:BEGIN -->
+*Measured 2026-08-08 against production. Regenerate with `node scripts/audit/architecture-stats.mjs --apply` — do not hand-edit, and do not quote these elsewhere without re-measuring.*
 
-**Context:** Two overlapping pages existed for book preparation:
-- `/book/[id]/prepare` (1543 lines) - Monolithic page handling split, OCR, translation, summary
-- `/book/[id]/split` (906 lines) - Focused on split detection workflow
+| | count | what it means |
+|---|---|---|
+| Books, all records | 104,625 | includes acquisition candidates and unprocessed imports |
+| — with page images | 79,639 | the scan actually arrived |
+| — with OCR | 55,362 | at least one page has been read |
+| — with translation | 20,462 | at least one page has been translated |
+| — publicly listed | 34,084 | `visible: true` |
+| **— live** | **19,465** | **`visible: true` AND `pages_count > 0` — the canonical "readable" filter** |
+| Pages | 19,132,895 | one document per leaf |
+| Entities | 1,018,025 | people, places and things extracted from the text |
+| Collections | 375 | curated groupings |
 
-**Decision:** Keep `/split`, deprecate `/prepare`
+Most-held languages among live books: Latin 6,543 · English 2,336 · German 2,309 · Tibetan 1,473 · Greek 1,105 · French 763.
 
-**Rationale:**
-1. **Single responsibility** - Split page does one thing well
-2. **Maintainability** - Smaller, focused codebase is easier to maintain
-3. **User flow** - Split is a distinct step before OCR/translation
-4. **Existing patterns** - OCR and translation actions already accessible from book detail page
+**The gap between 104,625 and 19,465 is the system**, not a defect: a book is acquired long before it is readable, and each stage below moves some of that difference.
+<!-- STATS:END -->
 
-**Consequences:**
-- Remove `/book/[id]/prepare` directory
-- Update any links pointing to prepare page
-- Split functionality remains at `/book/[id]/split`
-- OCR/translation initiated from book detail page buttons
+## 3. The life of a book
 
-## Directory Structure
+This is the spine. Everything else in the repository hangs off some stage of it.
 
 ```
-src/
-  app/
-    book/[id]/
-      page.tsx         - Book detail (main hub for actions)
-      split/page.tsx   - Dedicated split detection workflow
-      read/page.tsx    - Parallel text reader
-      summary/page.tsx - Book summary and index
-    api/
-      books/           - Book CRUD
-      pages/           - Page processing
-      image/           - Image proxy with cropping
-      download/        - EPUB/PDF export
-  components/
-    BookPagesSection   - Grid view of pages
-    SplitModeOverlay   - Split line adjustment UI
-    TranslationEditor  - Side-by-side OCR/translation view
-    BibliographicInfo  - USTC metadata display
-  lib/
-    types.ts           - Shared TypeScript types
-    mongodb.ts         - Database connection
+  ACQUIRE ──> IMPORT ──> ARCHIVE ──> READ ──> TRANSLATE ──> ENRICH ──> SERVE
+  catalogues   record     images      OCR      English      meaning    reader,
+  & archives   created    to R2       text     text         & search   API, MCP
 ```
 
-## Data Model
+**1. Acquire.** Candidate books are found in public archives — Internet Archive,
+Gallica, HathiTrust, e-rara, museum IIIF endpoints — and screened for subject fit
+and duplication. Deduplication happens *before* import (`src/lib/dedup.ts`),
+because a duplicate that gets in is far more expensive than one kept out.
 
-### Book
-```typescript
-{
-  id: string;           // Custom ID (slug)
-  title: string;        // Original language title (USTC-aligned)
-  display_title: string; // English translation for non-English works
-  author: string;
-  language: string;
-  published: string;    // Publication year
-  ustc_id: string;      // USTC catalog reference
-  place_published: string;
-  publisher: string;
-  format: string;       // folio, quarto, octavo, etc.
-  thumbnail: string;
-  editions: TranslationEdition[];
+**2. Import.** A `books` record is created, usually **hidden**, with metadata
+from the source catalogue. Metadata from archives is frequently wrong — languages
+mistagged, editors recorded as authors — so several later stages exist to correct
+rather than trust it.
 
-  // Image source and licensing
-  image_source?: {
-    provider: 'internet_archive' | 'google_books' | 'user_upload' | ...;
-    provider_name: string;  // "Internet Archive"
-    source_url: string;     // Link to original
-    license: string;        // SPDX: "publicdomain", "CC-BY-4.0"
-    attribution?: string;   // Required credit text
-  };
-}
+**3. Archive the images.** Page images are fetched and written to **Cloudflare
+R2**, served from `images.sourcelibrary.org`. This is the stage most often
+mistaken for "OCR is stuck", because a book waiting on images looks identical to
+one waiting to be read. Spreads are split into single leaves here, and crops are
+non-destructive: the original stays.
+
+**4. Read (OCR).** Each page image goes to Gemini and comes back as text with
+light structure — running heads, printed page numbers, marginalia, notes marked
+up in place. That markup matters later: it is how the reader knows which words
+are the author's and which are the printer's furniture, and it is where canonical
+citation numbers turn out to have been hiding all along (§7).
+
+**5. Translate.** Pages are translated into English, with the original preserved
+alongside. Both are served; neither replaces the other.
+
+**6. Enrich.** Summaries, chapter structure, extracted entities, quality scores,
+collection assignment, and **page embeddings** for semantic search. Embeddings
+are written here, in the pipeline, rather than by a separate job — a cron that
+stops is silent, and one that had stopped left semantic search blind on nearly
+half the corpus for two months before anyone noticed.
+
+**7. Serve.** The reader, the API, the MCP server, exports, DOIs. Covered in §5.
+
+A book can stall at any stage, and many deliberately do — processing is currently
+**paused** by choice, not by breakage.
+
+## 4. The four stores, and why there are four
+
+The most confusing thing for a newcomer. Each exists for a reason that the others
+cannot serve.
+
+| Store | Holds | Why not one of the others |
+|---|---|---|
+| **MongoDB Atlas** (`bookstore`) | The truth: books, pages, OCR, translations, entities, users. 141 collections. | Documents of wildly varying shape, and the pipeline writes constantly. |
+| **Supabase Postgres** | Derived read models: browse/catalog listings, analytics, and every **vector** index for semantic search. | Postgres does relational filtering and `pgvector` similarity that Mongo would do badly. |
+| **Cloudflare R2** | Page images and derivatives. | Object storage is the right shape and the cheap egress matters at 19M pages. |
+| **Cloudflare CDN** | Cached HTML and images at the edge. | Pages are cached for 24h, which is why deploys need a purge (§6). |
+
+**The rule worth internalising:** Mongo is authoritative; Supabase is derived. A
+derived store can be rebuilt and will silently fall behind, so when something is
+missing from search but present in the reader, suspect the sync, not the data.
+The inverse — a book readable but not listed — is usually the same thing from the
+other side.
+
+## 5. What consumes it
+
+- **The website** (`sourcelibrary.org`) — reading, browsing, collections,
+  galleries, the librarian chat.
+- **Partner subdomains** — an institution's own holdings as a standalone reading
+  room, on their own domain, with their own branding.
+- **The MCP server** (`/api/mcp`) — the library as a tool for AI agents: search,
+  quote with citation, canonical-reference lookup. Listed in the Claude
+  connector directory, and a meaningful share of serious use now arrives here.
+- **The REST API** (`/api/…`) — the same capabilities for ordinary clients.
+- **Exports** — PDFs, plain text, corpus snapshots, and DOI-minted scholarly
+  editions via Zenodo.
+
+The MCP surface deserves particular attention when changing anything about how
+text is served: an agent will follow an instruction in a tool description
+literally, at scale, and cannot see the page to notice something is off.
+
+## 6. Where it runs
+
+| Where | Runs what |
+|---|---|
+| **Vercel** | The Next.js app and its scheduled jobs. Merging to `main` deploys production, and the cache purge afterwards is automatic. |
+| **Hetzner** (a rented box) | Pipeline orchestration, translation and embedding workers. It pulls `main` every few minutes, so script changes go live without a deploy. |
+| **AWS Lambda + SQS** | Per-page AI work — OCR, translation, image processing — queued and run in parallel. |
+| **Gemini** | The model behind OCR, translation and enrichment. |
+
+Two consequences that catch people out: a change under `scripts/` needs no
+deploy, and a bare `vercel --prod` without a cache purge can leave pages
+rendering unstyled for up to a day.
+
+## 7. Two ideas worth understanding early
+
+Most of the subtlety in this codebase comes from two problems that sound simple.
+
+**Which words are the author's?** A scanned page carries the author's text, the
+printer's running heads, a translator's notes, an editor's commentary, and
+sometimes a long extract from a completely different author. If the system cannot
+tell these apart, it will hand someone a beautifully formatted citation
+attributing one writer's words to another. Page markup, front-matter detection,
+continuity flags across page breaks, and interpolation detection all exist for
+this single problem, and it is not solved.
+
+**How do you address a passage?** A scan page number is a property of one copy
+and shareable with nobody. Scholarship addresses Aristotle by Bekker number and
+Plato by Stephanus number, agreed centuries ago precisely so a citation survives
+re-typesetting. Those numbers were already printed on our pages and captured in
+OCR; `get_locus` now resolves them to leaves. The same question — *what is the
+stable identity of this thing* — recurs for works, editions and authors, and is
+the hardest unfinished business in the data model.
+
+## 8. How to see it working
+
+Reading about a system is worse than watching it. All read-only:
+
+```bash
+# The corpus, live
+node scripts/audit/architecture-stats.mjs
+
+# Is the MCP surface healthy? 14 checks against production
+node --env-file=.env.production.local scripts/audit/mcp-directory-contract.mjs
+
+# Ask the library a question the way an AI client does
+curl -s "https://sourcelibrary.org/api/locus?ref=1094a8"
 ```
 
-### Page
-```typescript
-{
-  id: string;
-  book_id: string;
-  page_number: number;
-  photo: string;        // Image URL (possibly cropped view)
-  photo_original: string; // Original uncropped image
-  crop?: {              // Virtual crop coordinates
-    xStart: number;
-    xEnd: number;
-  };
-  split_from?: string;  // If created from split, parent page ID
-  ocr?: { data: string; model: string; timestamp: Date };
-  translation?: { data: string; model: string; timestamp: Date };
-  summary?: { data: string; model: string; timestamp: Date };
-}
-```
+`/health`, `/progress` and `/status` (repository slash-commands) give a fuller
+picture of the pipeline.
 
-## Future Considerations
+## 9. Where the deep knowledge lives, and why it is shaped that way
 
-- **IIIF Integration** - Manifest generation for interoperability
-- **TEI Export** - Scholarly XML format
-- **Collaborative editing** - Multiple users per book
+This document is a map. The territory is documented elsewhere, in a form that
+looks strange until you see the reason for it:
+
+- **`CLAUDE.md`** — the rules that apply no matter what you are doing. Capped in
+  length on purpose.
+- **`.claude/docs/invariants/`** — one file per subsystem, each opening with
+  *"Read this when…"*. Every one is scar tissue from a real incident, and they
+  are written to be found at the moment of danger rather than read through.
+- **`.claude/docs/`** — reference material, read on demand.
+- **`.claude/handoffs/`** — what happened in a particular session.
+
+**Why the split matters.** Those documents are organised for *retrieval by
+trigger*; this one is organised as a *narrative*. Both are legitimate and they
+cannot be merged: a narrative is full of counts, which rot, while an invariant is
+anchored to an incident, which does not. That difference is exactly why this file
+went eight months describing a system that no longer existed while the tier next
+door stayed accurate — and why its numbers are now generated (§2) rather than
+typed.
+
+If you change how the system works, this file is part of the change.

--- a/scripts/audit/architecture-stats.mjs
+++ b/scripts/audit/architecture-stats.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Regenerate the measured block in ARCHITECTURE.md.
+ *
+ *   node scripts/audit/architecture-stats.mjs           # print, change nothing
+ *   node scripts/audit/architecture-stats.mjs --apply   # rewrite the block in place
+ *
+ * ## Why this exists
+ *
+ * `ARCHITECTURE.md` is the document a human opens first, and on 2026-08-08 it
+ * had gone **eight months** without a commit while saying the corpus was
+ * "primarily pre-1650 works" and that page images live in MongoDB. Neither had
+ * been true for a long time.
+ *
+ * The agent-facing tier next door did not rot, and the reason is structural: an
+ * invariant is anchored to an incident, and incidents do not change. An overview
+ * is full of counts, and counts change weekly. `doc-staleness.mjs` checks the
+ * auto-loaded agent files for exactly this and does not look at the repo root —
+ * so the human entry point rotted invisibly, by design.
+ *
+ * The durable fix is not vigilance. It is to stop typing the numbers: everything
+ * between the STATS markers is generated from the live database, so re-running
+ * this is the whole maintenance burden.
+ *
+ * Prose outside the markers is written by hand and this script never touches it.
+ */
+import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DOC = join(ROOT, 'ARCHITECTURE.md');
+const BEGIN = '<!-- STATS:BEGIN -->';
+const END = '<!-- STATS:END -->';
+
+const APPLY = process.argv.includes('--apply');
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+const client = new MongoClient(uri);
+await client.connect();
+const db = client.db('bookstore');
+const B = db.collection('books');
+
+const [total, visible, withPages, ocrd, translated, live, pages, entities, collections] = await Promise.all([
+  B.countDocuments({}),
+  B.countDocuments({ visible: true }),
+  B.countDocuments({ pages_count: { $gt: 0 } }),
+  B.countDocuments({ pages_ocr: { $gt: 0 } }),
+  B.countDocuments({ pages_translated: { $gt: 0 } }),
+  B.countDocuments({ visible: true, pages_count: { $gt: 0 } }),
+  db.collection('pages').estimatedDocumentCount(),
+  db.collection('entities').estimatedDocumentCount(),
+  db.collection('collections').countDocuments({}),
+]);
+
+const langs = await B.aggregate([
+  { $match: { visible: true, pages_count: { $gt: 0 } } },
+  { $group: { _id: '$language', n: { $sum: 1 } } },
+  { $sort: { n: -1 } }, { $limit: 6 },
+]).toArray();
+
+const n = (x) => x.toLocaleString('en-US');
+const today = new Date().toISOString().slice(0, 10);
+
+const block = `${BEGIN}
+*Measured ${today} against production. Regenerate with \`node scripts/audit/architecture-stats.mjs --apply\` — do not hand-edit, and do not quote these elsewhere without re-measuring.*
+
+| | count | what it means |
+|---|---|---|
+| Books, all records | ${n(total)} | includes acquisition candidates and unprocessed imports |
+| — with page images | ${n(withPages)} | the scan actually arrived |
+| — with OCR | ${n(ocrd)} | at least one page has been read |
+| — with translation | ${n(translated)} | at least one page has been translated |
+| — publicly listed | ${n(visible)} | \`visible: true\` |
+| **— live** | **${n(live)}** | **\`visible: true\` AND \`pages_count > 0\` — the canonical "readable" filter** |
+| Pages | ${n(pages)} | one document per leaf |
+| Entities | ${n(entities)} | people, places and things extracted from the text |
+| Collections | ${n(collections)} | curated groupings |
+
+Most-held languages among live books: ${langs.map((l) => `${l._id} ${n(l.n)}`).join(' · ')}.
+
+**The gap between ${n(total)} and ${n(live)} is the system**, not a defect: a book is acquired long before it is readable, and each stage below moves some of that difference.
+${END}`;
+
+if (!APPLY) {
+  console.log(block);
+  console.log('\n(dry run — pass --apply to write into ARCHITECTURE.md)');
+  await client.close();
+  process.exit(0);
+}
+
+const doc = readFileSync(DOC, 'utf8');
+const start = doc.indexOf(BEGIN);
+const stop = doc.indexOf(END);
+if (start === -1 || stop === -1) {
+  console.error(`markers not found in ${DOC} — add ${BEGIN} / ${END} first`);
+  process.exit(1);
+}
+writeFileSync(DOC, doc.slice(0, start) + block + doc.slice(stop + END.length));
+console.log(`rewrote the measured block in ARCHITECTURE.md (${today})`);
+await client.close();


### PR DESCRIPTION
Stage 1 of documenting the system for human understanding.

## The finding

The document a person opens first had gone **eight months** without a commit, while saying the corpus is "primarily pre-1650 works" (it runs from Sumerian tablets to the 19th century) and that page images are "stored as page records in MongoDB" (they are in R2).

Meanwhile the tier next door — 124 docs, 26 invariants, 32 handoffs — is accurate and well kept.

## Why that asymmetry is structural, not sloppiness

> An **invariant** is anchored to an incident, and incidents do not change.
> An **overview** is full of counts, and counts change weekly.

So the agent-facing tier stays true by its nature and the human-facing tier rots by its nature. `doc-staleness.mjs` checks the auto-loaded agent files for stale stats and **does not look at the repo root** — so this file rotted invisibly, by design.

## What changed

Rewritten as a **narrative**, which is precisely what the invariant tier cannot be: what this is · the corpus measured · **the life of a book** (acquire → import → archive → read → translate → enrich → serve) · the four stores and why there are four · what consumes it · where it runs · the two hard ideas (*whose words are these?* and *how do you address a passage?*) · how to watch it work · where the deep knowledge lives and why it is shaped that way.

**The durable half: the numbers are no longer typed.** Everything between the `STATS` markers is generated from production by `scripts/audit/architecture-stats.mjs --apply`; prose outside them is never touched. Re-running it is the entire maintenance burden. Verified idempotent.

Measured 2026-08-08: 104,625 book records · 79,639 with images · 55,362 with OCR · 20,462 with translation · **19,465 live** · 19.1M pages · 1.02M entities · 375 collections.

## Deliberately not in this PR

- Extending `doc-staleness.mjs` to notice root-level docs — the guard that would have caught this. Worth doing, separate concern.
- The diagram and the public-facing version (stages 2 and 3). Both should derive from this file rather than duplicate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNGn75hQdSrAEFQQAUkc9T