### PR TITLE
fix(catalog): Catalan was missing from the source-language vocabulary

### DIFF
--- a/scripts/lib/translation-catalog-record.mjs
+++ b/scripts/lib/translation-catalog-record.mjs
@@ -85,6 +85,13 @@ export const KNOWN_SOURCE_LANGUAGES = new Set([
   'egy', // Egyptian
   'ta',  // Tamil
   'de', 'nl', 'fr', 'it', 'es', // modern European (parity with existing rows)
+  // Catalan. Added 2026-08-08 after a verified prior was quarantined for it:
+  // McKenny 2024 translates Ramon Llull's *Llibre de contemplació* from the
+  // Catalan, and Llull is a major author in this corpus — the omission sat
+  // beside Spanish, French and Italian and looked like an oversight rather than
+  // a judgement. The quarantine worked exactly as designed (kept the row and the
+  // reason instead of dropping it), which is how the gap surfaced at all.
+  'ca',  // Catalan
   // Long-tail sources that appear in hand-verified rows. Added with #3460 so a
   // real verified prior is never lost to an over-narrow whitelist — every one of
   // these was observed in `source: 'claude_subagent_verify'` production rows.
@@ -135,6 +142,7 @@ const SOURCE_LANGUAGE_ALIASES = {
   french: 'fr', fr: 'fr',
   italian: 'it', it: 'it',
   spanish: 'es', es: 'es',
+  catalan: 'ca', ca: 'ca', valencian: 'ca',
   'middle english': 'enm', enm: 'enm',
   nahuatl: 'nah', nah: 'nah',
   mandaic: 'myz', myz: 'myz',

--- a/tests/unit/translation-catalog-catalan.test.ts
+++ b/tests/unit/translation-catalog-catalan.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Catalan in the catalog-record source-language vocabulary (#3460 follow-up).
+ *
+ * Found the honest way: a REAL verified prior was quarantined for it. McKenny
+ * 2024 translates Ramon Llull's *Llibre de contemplació en Déu* from the
+ * Catalan, and the ingest refused the row because `ca` was absent from a list
+ * that already held `es`, `fr`, `it`, `nl` and `de`. Llull is a major author in
+ * this corpus, so that was an oversight rather than a judgement.
+ *
+ * Worth recording HOW it surfaced: the guard quarantines an unmappable
+ * source_language — keeping the row and the reason — instead of dropping it or
+ * silently coercing it. A guard that failed closed by discarding would have lost
+ * a verified prior and left no trace to notice. The reason string is what made
+ * the gap visible.
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-expect-error — .mjs script module without type declarations
+import { buildCatalogDoc } from '../../scripts/lib/translation-catalog-record.mjs';
+
+describe('Catalan is an accepted source language', () => {
+  it('accepts the case that was quarantined', () => {
+    const doc = buildCatalogDoc({
+      english_title: "Ramon Llull's Book of Contemplation in God (Book I, Prologue-Chapter 29)",
+      translator: 'Mihow P. McKenny',
+      pub_year: '2024',
+      source_language: 'Catalan',
+      completeness: 'partial',
+      source: 'claude_subagent_verify',
+    });
+    expect(doc.source_language).toBe('ca');
+  });
+
+  it('accepts the ISO code and the Valencian variant name', () => {
+    for (const v of ['ca', 'catalan', 'Valencian']) {
+      const doc = buildCatalogDoc({
+        english_title: 'X',
+        translator: 'A B',
+        pub_year: '2000',
+        source_language: v,
+        completeness: 'complete',
+        source: 'claude_subagent_verify',
+      });
+      expect(doc.source_language, v).toBe('ca');
+    }
+  });
+
+  it('still THROWS on a genuinely unmappable language, so the quarantine keeps working', () => {
+    // The point of the change is one missing entry, not a looser guard. An
+    // unrecognised value must still fail loudly enough to be quarantined with a
+    // reason — that behaviour is what surfaced Catalan in the first place.
+    expect(() => buildCatalogDoc({
+      english_title: 'X',
+      translator: 'A B',
+      pub_year: '2000',
+      source_language: 'Klingon',
+      completeness: 'complete',
+      source: 'claude_subagent_verify',
+    })).toThrow(/invalid source_language/i);
+  });
+});


### PR DESCRIPTION
A real verified prior was quarantined for it.

McKenny 2024 translates Ramon Llull's *Llibre de contemplació en Déu* from the **Catalan**, and `buildCatalogDoc` refused the row because `ca` was absent from a list that already carried `es`, `fr`, `it`, `nl` and `de`. Llull is a major author in this corpus; the omission sat beside its obvious neighbours and reads as an oversight rather than a judgement.

## The design deserves the credit for this

The guard **quarantines** an unmappable `source_language` — keeping the row *and the reason* — rather than dropping it or coercing it to something plausible. A guard that failed closed by discarding would have lost a verified prior and left nothing to notice.

The reason string is the entire reason this gap is fixed instead of silently eating rows:

```
buildCatalogDoc: invalid source_language "Catalan" for
"Ramon Llull's Book of Contemplation in God (Book I, Prologue-Chapter 29)"
(must resolve to one of la,grc,he,arc,ar,sa,pli,bo,zh,lzh,syc,hy,akk,sux,ja,ko,
 fa,ave,egy,ta,de,nl,fr,it,es,enm,nah,myz,cy,hai,en)
```

That is the same principle as the rest of this subsystem: **a filter's discards are the only place its blind spot is visible, so make it report them.**

## The change

Adds `ca` plus `catalan` / `Valencian` aliases. Three tests: the case that was quarantined, the code and variant names, and — deliberately — that an **unrecognised** language still throws. The change is one missing entry, not a looser guard.

## Follow-up

The quarantined Llull row is preserved in `translation_catalogs_quarantine` and should be re-ingested once this merges. Found during #3687 round 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)