### PR TITLE
feat(work): canon work registry — one address per ancient work (/work/iliad)

### DIFF
--- a/src/app/work/[id]/compare/page.tsx
+++ b/src/app/work/[id]/compare/page.tsx
@@ -4,8 +4,11 @@ import { notFound } from 'next/navigation';
 import type { Book } from '@/lib/types';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import CompareClient from './CompareClient';
+import { canonWork, workEditionsFilter } from '@/lib/canon-works';
 
-export const revalidate = false;
+// Must be a finite number — `false` would cache a bad render forever (same
+// rule as the parent work page; see CLAUDE.md on ISR + fallible fetches).
+export const revalidate = 21600;
 export const dynamicParams = true;
 export async function generateStaticParams() {
   return [];
@@ -53,7 +56,7 @@ async function getEditionsForCompare(workId: string): Promise<EditionForCompare[
   const editions = await db
     .collection('books')
     .find(
-      { $or: [{ work_slug: workId }, { work_id: workId }], visible: true },
+      workEditionsFilter(workId),
       {
         projection: {
           id: 1,
@@ -100,7 +103,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { id: rawId } = await params;
   // Decode non-ASCII work_id (CJK / accented) before use — see /work/[id]/page.tsx.
   const id = decodeURIComponent(rawId);
-  const title = workTitle(id);
+  const title = canonWork(id)?.title || workTitle(id);
   return {
     title: `Compare Translations — ${title} | Source Library`,
     description: `Compare translations across editions of ${title}. View original language texts alongside AI and human translations side by side.`,
@@ -115,7 +118,7 @@ export default async function CompareWorkPage({ params }: PageProps) {
   const editions = await getEditionsForCompare(id);
   if (editions.length < 2) notFound();
 
-  const title = workTitleFromEditions(editions, id);
+  const title = canonWork(id)?.title || workTitleFromEditions(editions, id);
   const translatedEditions = editions.filter((e) => e.pages_translated > 0);
 
   return (

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getBookThumbnailUrl } from '@/lib/utils';
 import { canonWork, canonWorkForWorkId, workEditionsFilter, type CanonWork } from '@/lib/canon-works';
 import { authorUrl, bookUrl } from '@/lib/slugify';
 import { locusEdition } from '@/lib/locus-editions';
+import { jsonLdHtml } from '@/lib/json-ld';
 
 // Must be a finite number — `false` would cache a bad-render fallback forever
 // (e.g. the noindex metadata below) until the next deploy.
@@ -267,7 +268,7 @@ export default async function WorkPage({ params }: PageProps) {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
+            __html: jsonLdHtml({
               '@context': 'https://schema.org',
               '@type': 'CreativeWork',
               name: canon.title,

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -1,10 +1,13 @@
 import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
 import type { Book } from '@/lib/types';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import { canonWork, canonWorkForWorkId, workEditionsFilter, type CanonWork } from '@/lib/canon-works';
+import { authorUrl, bookUrl } from '@/lib/slugify';
+import { locusEdition } from '@/lib/locus-editions';
 
 // Must be a finite number — `false` would cache a bad-render fallback forever
 // (e.g. the noindex metadata below) until the next deploy.
@@ -18,22 +21,38 @@ interface PageProps {
   params: Promise<{ id: string }>;
 }
 
+type WorkEdition = Book & {
+  image_source?: { provider_name?: string };
+  work_slug?: string;
+};
+
+const EDITION_PROJECTION = {
+  id: 1, slug: 1, title: 1, display_title: 1, author: 1, published: 1,
+  language: 1, original_language: 1, 'image_source.provider_name': 1,
+  thumbnail_blob: 1, thumbnail: 1, image_display: 1, image_thumb: 1, pages_count: 1, pages_ocr: 1,
+  pages_translated: 1, resource_type: 1, work_title: 1, work_slug: 1,
+};
+
 async function getWorkEditions(idOrSlug: string) {
   const db = await getReadDb();
-  // resolve by the clean work_slug first, fall back to the raw work_id (back-compat)
+  // canon slugs expand to their verified work_id set; anything else resolves by
+  // work_slug first, then raw work_id (back-compat)
   const editions = await db.collection('books').find(
-    { $or: [{ work_slug: idOrSlug }, { work_id: idOrSlug }], visible: true },
-    {
-      projection: {
-        id: 1, slug: 1, title: 1, display_title: 1, author: 1, published: 1,
-        language: 1, original_language: 1, 'image_source.provider_name': 1,
-        thumbnail_blob: 1, thumbnail: 1, image_display: 1, image_thumb: 1, pages_count: 1, pages_ocr: 1,
-        pages_translated: 1, resource_type: 1, work_title: 1, work_slug: 1,
-      },
-      sort: { published: 1 },
-    }
+    workEditionsFilter(idOrSlug),
+    { projection: EDITION_PROJECTION, sort: { published: 1 } }
   ).toArray();
-  return editions as unknown as (Book & { image_source?: { provider_name?: string } })[];
+  return editions as unknown as WorkEdition[];
+}
+
+async function getCollectedEditions(canon: CanonWork) {
+  const ids = canon.collectedWorkIds || [];
+  if (ids.length === 0) return [];
+  const db = await getReadDb();
+  const editions = await db.collection('books').find(
+    { $or: [{ work_id: { $in: ids } }, { work_slug: { $in: ids } }], visible: true },
+    { projection: EDITION_PROJECTION, sort: { published: 1 } }
+  ).toArray();
+  return editions as unknown as WorkEdition[];
 }
 
 // Derive a human-readable work title. Prefer the curated `work_title` carried on
@@ -53,6 +72,67 @@ function workTitleFromEditions(editions: { work_title?: string | null }[], workI
   return tail.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
 }
 
+/* ── Read-now selection (canon pages) ──
+ * Two lanes: the original language, and English. The English lane prefers a
+ * printed English edition with OCR; when none exists, the best-translated
+ * original serves both lanes — the reader shows our page-level English
+ * translation beside the facsimile, so a fully-translated Greek edition IS
+ * readable in English. Deterministic; no hand-picking. */
+function translatedRatio(b: WorkEdition): number {
+  return b.pages_count ? (b.pages_translated || 0) / b.pages_count : 0;
+}
+function ocrRatio(b: WorkEdition): number {
+  return b.pages_count ? (b.pages_ocr || 0) / b.pages_count : 0;
+}
+function pickReadNow(canon: CanonWork, editions: WorkEdition[]) {
+  const readable = editions.filter(b => (b.pages_count || 0) > 0);
+  const score = (b: WorkEdition) =>
+    translatedRatio(b) * 2 + ocrRatio(b) + (locusEdition(b.id) ? 0.5 : 0) +
+    Math.min((b.pages_count || 0) / 1000, 0.3); // nudge complete copies over 1-page fragments
+  const inLang = (b: WorkEdition, lang: string) => (b.language || '').includes(lang);
+
+  const original = readable
+    .filter(b => inLang(b, canon.originalLanguage))
+    .sort((a, b) => score(b) - score(a))[0];
+  const printedEnglish = readable
+    .filter(b => inLang(b, 'English') && ocrRatio(b) > 0)
+    .sort((a, b) => ocrRatio(b) - ocrRatio(a) + (score(b) - score(a)) * 0.001)[0];
+  // fall back to the best-translated original (≥50% translated reads fine)
+  const english = printedEnglish
+    || (original && translatedRatio(original) >= 0.5 ? original : undefined);
+  return { original, english };
+}
+
+function ReadNowCard({ book, lane, sameBook }: { book: WorkEdition; lane: string; sameBook?: boolean }) {
+  const thumb = getBookThumbnailUrl(book);
+  return (
+    <Link
+      href={bookUrl(book)}
+      className="flex items-center gap-4 p-5 border border-stone-300 hover:border-stone-400 bg-white hover:bg-stone-50/50 rounded-xl transition-all group"
+    >
+      {thumb ? (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img src={thumb} alt="" className="w-14 h-20 object-cover rounded shadow-sm flex-shrink-0" loading="lazy" />
+      ) : (
+        <div className="w-14 h-20 bg-stone-100 rounded flex-shrink-0" />
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="text-xs uppercase tracking-wide text-stone-500 mb-1">
+          {lane}{sameBook ? ' · with English translation' : ''}
+        </p>
+        <h3 className="text-base font-medium text-stone-800 group-hover:text-stone-900 leading-snug line-clamp-2">
+          {book.display_title || book.title}
+        </h3>
+        <p className="text-sm text-stone-500 mt-1">
+          {book.published && book.published !== 'Unknown' ? `${book.published} · ` : ''}
+          {(book.pages_count || 0).toLocaleString('en-US')} pages
+        </p>
+      </div>
+      <span className="text-stone-400 group-hover:text-stone-600 transition-colors" aria-hidden>→</span>
+    </Link>
+  );
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id: rawId } = await params;
   // work_id values include non-ASCII (CJK, accented Latin); the route param
@@ -64,27 +144,102 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const editions = await getWorkEditions(id);
   if (editions.length === 0) return { title: 'Work Not Found', robots: { index: false, follow: true } };
 
+  const canon = canonWork(id);
+  if (canon) {
+    return {
+      title: `${canon.title} — ${canon.author} | Source Library`,
+      description: `Read the ${canon.title} (${canon.originalTitle}) of ${canon.author} in ${canon.originalLanguage} and English: ${editions.length} editions and manuscripts with page-level translations of the original scans.`,
+      alternates: { canonical: `/work/${canon.slug}` },
+    };
+  }
+
   const title = workTitleFromEditions(editions as { work_title?: string | null }[], id);
-  const libraries = new Set(editions.map(e => (e as unknown as { image_source?: { provider_name?: string } }).image_source?.provider_name).filter(Boolean));
+  const libraries = new Set(editions.map(e => e.image_source?.provider_name).filter(Boolean));
 
   return {
     title: `${title} — ${editions.length} Editions | Source Library`,
     description: `${editions.length} editions and manuscripts of ${title} across ${libraries.size} libraries. Browse, compare, and read translations.`,
-    alternates: { canonical: `/work/${(editions.find(e => (e as { work_slug?: string }).work_slug) as { work_slug?: string } | undefined)?.work_slug || id}` },
+    alternates: { canonical: `/work/${editions.find(e => e.work_slug)?.work_slug || id}` },
   };
+}
+
+function EditionRow({ book }: { book: WorkEdition }) {
+  const provider = book.image_source?.provider_name;
+  const thumb = getBookThumbnailUrl(book);
+  const displayTitle = book.display_title || book.title;
+  const pagesOcr = book.pages_ocr || 0;
+  const pagesTranslated = book.pages_translated || 0;
+  const pagesCount = book.pages_count || 0;
+  const locus = locusEdition(book.id);
+
+  return (
+    <Link
+      href={bookUrl(book)}
+      className="flex items-start gap-4 p-4 rounded-xl border border-stone-200 hover:border-stone-300 hover:bg-stone-50/50 transition-all group"
+    >
+      {thumb ? (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={thumb}
+          alt=""
+          className="w-16 h-22 object-cover rounded shadow-sm flex-shrink-0"
+          loading="lazy"
+        />
+      ) : (
+        <div className="w-16 h-22 bg-stone-100 rounded flex-shrink-0" />
+      )}
+      <div className="min-w-0 flex-1">
+        <h3 className="text-base font-medium text-stone-800 group-hover:text-stone-900 leading-snug">
+          {displayTitle}
+        </h3>
+        <p className="text-sm text-stone-500 mt-1">
+          {book.author}
+          {book.published && book.published !== 'Unknown' ? ` · ${book.published}` : ''}
+        </p>
+        <div className="flex flex-wrap gap-3 mt-2 text-xs text-stone-400">
+          {book.language && book.language !== 'Unknown' && (
+            <span>{book.language}</span>
+          )}
+          {pagesCount > 0 && <span>{pagesCount} pp</span>}
+          {pagesOcr > 0 && (
+            <span className="text-emerald-600">
+              {pagesTranslated > 0
+                ? `${Math.round((pagesTranslated / pagesOcr) * 100)}% translated`
+                : 'OCR done'}
+            </span>
+          )}
+          {locus && (
+            <span className="text-amber-700">
+              {locus.system === 'bekker' ? 'Bekker' : 'Stephanus'} reference edition
+            </span>
+          )}
+          {provider && <span>{provider}</span>}
+        </div>
+      </div>
+    </Link>
+  );
 }
 
 export default async function WorkPage({ params }: PageProps) {
   const { id: rawId } = await params;
   const id = decodeURIComponent(rawId);
+
+  const canon = canonWork(id);
+  if (!canon) {
+    // a raw work_id that belongs to a canon entry gets one stable address
+    const owner = canonWorkForWorkId(id);
+    if (owner) redirect(`/work/${owner.slug}`);
+  }
+
   const editions = await getWorkEditions(id);
   if (editions.length === 0) notFound();
+  const collected = canon ? await getCollectedEditions(canon) : [];
 
-  const title = workTitleFromEditions(editions as { work_title?: string | null }[], id);
-  const workSlug = (editions.find(e => (e as { work_slug?: string }).work_slug) as { work_slug?: string })?.work_slug || id;
+  const title = canon ? canon.title : workTitleFromEditions(editions as { work_title?: string | null }[], id);
+  const workSlug = canon ? canon.slug : (editions.find(e => e.work_slug)?.work_slug || id);
   const libraries = [...new Set(
-    editions.map(e => (e as unknown as { image_source?: { provider_name?: string } }).image_source?.provider_name).filter(Boolean)
-  )];
+    [...editions, ...collected].map(e => e.image_source?.provider_name).filter(Boolean)
+  )] as string[];
   const languages = [...new Set(editions.map(e => e.language || (e as unknown as { original_language?: string }).original_language).filter(Boolean).filter(l => l !== 'Unknown'))];
   const dateRange = editions
     .map(e => parseInt(e.published || '0'))
@@ -92,17 +247,43 @@ export default async function WorkPage({ params }: PageProps) {
   const earliest = dateRange.length ? Math.min(...dateRange) : null;
   const latest = dateRange.length ? Math.max(...dateRange) : null;
   const totalPages = editions.reduce((s, e) => s + (e.pages_count || 0), 0);
+  const canonAuthorUrl = canon ? authorUrl(canon.author) : null;
+  const readNow = canon ? pickReadNow(canon, editions) : null;
+  const sameBook = !!(readNow?.original && readNow.original === readNow.english);
 
   return (
     <ContentPageLayout
       header={
         <ContentHeader
           title={title}
-          subtitle={`${editions.length} editions across ${libraries.length} ${libraries.length === 1 ? 'library' : 'libraries'}`}
+          subtitle={canon
+            ? `${canon.originalTitle} · ${canon.author} · ${canon.era}`
+            : `${editions.length} editions across ${libraries.length} ${libraries.length === 1 ? 'library' : 'libraries'}`}
         />
       }
       bg="bg-cream"
     >
+      {canon && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'CreativeWork',
+              name: canon.title,
+              alternateName: canon.originalTitle,
+              author: { '@type': 'Person', name: canon.author },
+              inLanguage: canon.originalLanguage,
+              workExample: editions.slice(0, 10).map(b => ({
+                '@type': 'Book',
+                name: b.display_title || b.title,
+                datePublished: b.published !== 'Unknown' ? b.published : undefined,
+                url: `https://sourcelibrary.org${bookUrl(b)}`,
+              })),
+            }),
+          }}
+        />
+      )}
       <div className="prose-content max-w-none">
         {/* Stats bar */}
         <div className="flex flex-wrap items-center gap-6 text-sm text-stone-500 mb-10">
@@ -113,6 +294,11 @@ export default async function WorkPage({ params }: PageProps) {
           {languages.length > 0 && <span>{languages.join(', ')}</span>}
           <span>{totalPages.toLocaleString('en-US')} pages</span>
           <span>{editions.length} editions</span>
+          {canonAuthorUrl && (
+            <Link href={canonAuthorUrl} className="text-stone-600 hover:text-stone-800 underline underline-offset-2">
+              More by {canon!.author}
+            </Link>
+          )}
           {editions.filter(e => (e.pages_translated || 0) > 0).length >= 2 && (
             <Link
               href={`/work/${workSlug}/compare`}
@@ -123,59 +309,43 @@ export default async function WorkPage({ params }: PageProps) {
           )}
         </div>
 
-        {/* Editions grid */}
-        <div className="grid gap-4">
-          {editions.map((book) => {
-            const provider = (book as unknown as { image_source?: { provider_name?: string } }).image_source?.provider_name;
-            const thumb = getBookThumbnailUrl(book);
-            const displayTitle = book.display_title || book.title;
-            const pagesOcr = book.pages_ocr || 0;
-            const pagesTranslated = book.pages_translated || 0;
-            const pagesCount = book.pages_count || 0;
+        {/* Read now (canon works) */}
+        {readNow && (readNow.original || readNow.english) && (
+          <div className="mb-12">
+            <h2 className="text-lg font-medium text-stone-700 mb-4">Start reading</h2>
+            <div className={`grid gap-4 ${!sameBook && readNow.original && readNow.english ? 'sm:grid-cols-2' : ''}`}>
+              {readNow.original && (
+                <ReadNowCard
+                  book={readNow.original}
+                  lane={`Read in ${canon!.originalLanguage}`}
+                  sameBook={sameBook}
+                />
+              )}
+              {readNow.english && !sameBook && (
+                <ReadNowCard book={readNow.english} lane="Read in English" />
+              )}
+            </div>
+          </div>
+        )}
 
-            return (
-              <Link
-                key={book.id}
-                href={`/book/${book.slug || book.id}`}
-                className="flex items-start gap-4 p-4 rounded-xl border border-stone-200 hover:border-stone-300 hover:bg-stone-50/50 transition-all group"
-              >
-                {thumb ? (
-                  <img
-                    src={thumb}
-                    alt=""
-                    className="w-16 h-22 object-cover rounded shadow-sm flex-shrink-0"
-                    loading="lazy"
-                  />
-                ) : (
-                  <div className="w-16 h-22 bg-stone-100 rounded flex-shrink-0" />
-                )}
-                <div className="min-w-0 flex-1">
-                  <h3 className="text-base font-medium text-stone-800 group-hover:text-stone-900 leading-snug">
-                    {displayTitle}
-                  </h3>
-                  <p className="text-sm text-stone-500 mt-1">
-                    {book.author}
-                    {book.published && book.published !== 'Unknown' ? ` · ${book.published}` : ''}
-                  </p>
-                  <div className="flex flex-wrap gap-3 mt-2 text-xs text-stone-400">
-                    {book.language && book.language !== 'Unknown' && (
-                      <span>{book.language}</span>
-                    )}
-                    {pagesCount > 0 && <span>{pagesCount} pp</span>}
-                    {pagesOcr > 0 && (
-                      <span className="text-emerald-600">
-                        {pagesTranslated > 0
-                          ? `${Math.round((pagesTranslated / pagesOcr) * 100)}% translated`
-                          : 'OCR done'}
-                      </span>
-                    )}
-                    {provider && <span>{provider}</span>}
-                  </div>
-                </div>
-              </Link>
-            );
-          })}
+        {/* Editions grid */}
+        {canon && <h2 className="text-lg font-medium text-stone-700 mb-4">Editions &amp; manuscripts</h2>}
+        <div className="grid gap-4">
+          {editions.map((book) => <EditionRow key={book.id} book={book} />)}
         </div>
+
+        {/* Collected editions containing this work */}
+        {collected.length > 0 && (
+          <div className="mt-12 pt-8 border-t border-border-light">
+            <h2 className="text-lg font-medium text-stone-700 mb-1">Collected editions containing this work</h2>
+            <p className="text-sm text-stone-500 mb-4">
+              Opera and complete-works editions that include the {canon!.title} alongside other works.
+            </p>
+            <div className="grid gap-4">
+              {collected.map((book) => <EditionRow key={book.id} book={book} />)}
+            </div>
+          </div>
+        )}
 
         {/* Libraries section */}
         {libraries.length > 1 && (

--- a/src/lib/canon-works.ts
+++ b/src/lib/canon-works.ts
@@ -1,0 +1,268 @@
+/**
+ * Canon works registry — hand-curated landing slugs for major ancient works.
+ *
+ * Why this exists: the same work is fragmented across several `books.work_id`
+ * values (Wikidata QIDs, minted `local:…` ids, legacy clean slugs — the Iliad
+ * alone spans four). A canon slug aggregates those verified clusters into one
+ * stable reading address: /work/iliad. See issue #3736.
+ *
+ * Rules for adding an entry:
+ * - Every id in `workIds`/`collectedWorkIds` must be VERIFIED against
+ *   production (cluster the author's live books by work_id and read the
+ *   titles) — never guessed from memory. A wrong id silently pulls another
+ *   work's editions onto the page.
+ * - Slugs are permanent once published (they become citation URLs). Prefer the
+ *   common English short title; qualify only to break a real ambiguity
+ *   (`laws-plato`, `herodotus-histories`).
+ * - `collectedWorkIds` are Opera/collected editions that CONTAIN the work.
+ *   They render in a separate section, never mixed into the editions list —
+ *   a reader looking for the Republic should see the Stephanus Opera, but not
+ *   counted as "an edition of the Republic".
+ */
+
+export interface CanonWork {
+  slug: string;
+  /** English display title, e.g. "Republic" */
+  title: string;
+  /** Title in the original language/script, e.g. "Πολιτεία" */
+  originalTitle: string;
+  author: string;
+  /** Approximate composition date, reader-facing, e.g. "c. 375 BCE" */
+  era: string;
+  /** Language the work was composed in ("Greek" | "Latin") */
+  originalLanguage: string;
+  /** Verified work_id / work_slug values whose books ARE editions of this work */
+  workIds: string[];
+  /** Verified work_id values of collected editions containing this work */
+  collectedWorkIds?: string[];
+}
+
+const PLATO_COLLECTED = ['Q139619812', 'plato-opera-ficino']; // Stephanus 1578; Ficino's Latin Opera
+const HOMER_COLLECTED = ['Q106691509']; // Homeri Opera (multi-volume)
+
+export const CANON_WORKS: CanonWork[] = [
+  {
+    slug: 'iliad',
+    title: 'Iliad',
+    originalTitle: 'Ἰλιάς',
+    author: 'Homer',
+    era: 'c. 8th century BCE',
+    originalLanguage: 'Greek',
+    workIds: ['Q125518202', 'Q16547641', 'homer-homer-iliad-odyssey', 'Q19090449'],
+    collectedWorkIds: HOMER_COLLECTED,
+  },
+  {
+    slug: 'odyssey',
+    title: 'Odyssey',
+    originalTitle: 'Ὀδύσσεια',
+    author: 'Homer',
+    era: 'c. 8th century BCE',
+    originalLanguage: 'Greek',
+    workIds: ['local:a:homer:dolinghe-odyssea-ulysse-van', 'Q19090449', 'homer-homer-iliad-odyssey'],
+    collectedWorkIds: HOMER_COLLECTED,
+  },
+  {
+    slug: 'homeric-hymns',
+    title: 'Homeric Hymns',
+    originalTitle: 'Ὕμνοι Ὁμηρικοί',
+    author: 'Homer',
+    era: '7th–6th century BCE',
+    originalLanguage: 'Greek',
+    workIds: ['Q329342'],
+    collectedWorkIds: HOMER_COLLECTED,
+  },
+  {
+    slug: 'republic',
+    title: 'Republic',
+    originalTitle: 'Πολιτεία',
+    author: 'Plato',
+    era: 'c. 375 BCE',
+    originalLanguage: 'Greek',
+    workIds: ['plato-republic'],
+    collectedWorkIds: PLATO_COLLECTED,
+  },
+  {
+    slug: 'timaeus',
+    title: 'Timaeus',
+    originalTitle: 'Τίμαιος',
+    author: 'Plato',
+    era: 'c. 360 BCE',
+    originalLanguage: 'Greek',
+    workIds: ['Q371884', 'plato-timaeus'],
+    collectedWorkIds: PLATO_COLLECTED,
+  },
+  {
+    slug: 'phaedo',
+    title: 'Phaedo',
+    originalTitle: 'Φαίδων',
+    author: 'Plato',
+    era: 'c. 380 BCE',
+    originalLanguage: 'Greek',
+    workIds: ['Q244161'],
+    collectedWorkIds: PLATO_COLLECTED,
+  },
+  {
+    slug: 'laws-plato',
+    title: 'Laws',
+    originalTitle: 'Νόμοι',
+    author: 'Plato',
+    era: 'c. 350 BCE',
+    originalLanguage: 'Greek',
+    workIds: ['Q752285'],
+    collectedWorkIds: PLATO_COLLECTED,
+  },
+  {
+    slug: 'nicomachean-ethics',
+    title: 'Nicomachean Ethics',
+    originalTitle: 'Ἠθικὰ Νικομάχεια',
+    author: 'Aristotle',
+    era: '4th century BCE',
+    originalLanguage: 'Greek',
+    workIds: ['aristotle-nicomachean-ethics'],
+  },
+  {
+    slug: 'metaphysics',
+    title: 'Metaphysics',
+    originalTitle: 'Τὰ μετὰ τὰ φυσικά',
+    author: 'Aristotle',
+    era: '4th century BCE',
+    originalLanguage: 'Greek',
+    workIds: ['aristotle-metaphysics'],
+  },
+  {
+    slug: 'organon',
+    title: 'Organon',
+    originalTitle: 'Ὄργανον',
+    author: 'Aristotle',
+    era: '4th century BCE',
+    originalLanguage: 'Greek',
+    workIds: ['Q500930'],
+  },
+  {
+    slug: 'on-the-soul',
+    title: 'On the Soul',
+    originalTitle: 'Περὶ ψυχῆς',
+    author: 'Aristotle',
+    era: '4th century BCE',
+    originalLanguage: 'Greek',
+    workIds: ['local:a:aristotle:soul'],
+  },
+  {
+    slug: 'herodotus-histories',
+    title: 'Histories',
+    originalTitle: 'Ἱστορίαι',
+    author: 'Herodotus',
+    era: 'c. 430 BCE',
+    originalLanguage: 'Greek',
+    workIds: [
+      'Q746583',
+      'local:n:herodotus:histories',
+      'local:a:herodotus:1-2-persian-wars',
+      'local:a:herodotus:historiae',
+      'local:a:herodotus:histories-works',
+    ],
+  },
+  {
+    slug: 'meditations',
+    title: 'Meditations',
+    originalTitle: 'Τὰ εἰς ἑαυτόν',
+    author: 'Marcus Aurelius',
+    era: '170–180 CE',
+    originalLanguage: 'Greek',
+    workIds: ['Q136035389'],
+  },
+  {
+    slug: 'elements',
+    title: 'Elements',
+    originalTitle: 'Στοιχεῖα',
+    author: 'Euclid',
+    era: 'c. 300 BCE',
+    originalLanguage: 'Greek',
+    workIds: ['Q172891', 'local:a:euclid:elements'],
+  },
+  {
+    slug: 'aeneid',
+    title: 'Aeneid',
+    originalTitle: 'Aeneis',
+    author: 'Virgil',
+    era: '29–19 BCE',
+    originalLanguage: 'Latin',
+    workIds: ['Q60220'],
+    collectedWorkIds: ['Q21205467'], // Opera (Bucolica, Georgica, Aeneis)
+  },
+  {
+    slug: 'metamorphoses',
+    title: 'Metamorphoses',
+    originalTitle: 'Metamorphoseon libri XV',
+    author: 'Ovid',
+    era: '8 CE',
+    originalLanguage: 'Latin',
+    workIds: ['Q106595694'],
+  },
+  {
+    slug: 'de-rerum-natura',
+    title: 'On the Nature of Things',
+    originalTitle: 'De rerum natura',
+    author: 'Lucretius',
+    era: 'c. 55 BCE',
+    originalLanguage: 'Latin',
+    workIds: ['Q137592632', 'local:a:titus-lucretius:natura-rerum'],
+  },
+  {
+    slug: 'consolation-of-philosophy',
+    title: 'The Consolation of Philosophy',
+    originalTitle: 'De consolatione philosophiae',
+    author: 'Boethius',
+    era: '524 CE',
+    originalLanguage: 'Latin',
+    workIds: ['Q138752489', 'local:n:boethius:consolation-philosophy'],
+  },
+  {
+    slug: 'epistulae-morales',
+    title: 'Moral Letters to Lucilius',
+    originalTitle: 'Epistulae morales ad Lucilium',
+    author: 'Seneca',
+    era: 'c. 65 CE',
+    originalLanguage: 'Latin',
+    workIds: [
+      'seneca-epistulae-morales',
+      'local:a:seneca:ad-add-buschius-epistolae-hermannus-lucilium-senecae-vita',
+    ],
+  },
+];
+
+const bySlug = new Map(CANON_WORKS.map((w) => [w.slug, w]));
+const byWorkId = new Map<string, CanonWork>();
+for (const w of CANON_WORKS) {
+  for (const id of w.workIds) {
+    // First entry wins for shared ids (combined Iliad+Odyssey volumes appear in
+    // both entries; redirects should land somewhere stable, not flip-flop).
+    if (!byWorkId.has(id)) byWorkId.set(id, w);
+  }
+}
+
+export function canonWork(slug: string): CanonWork | undefined {
+  return bySlug.get(slug);
+}
+
+/** The canon entry whose editions list includes this work_id, if any. */
+export function canonWorkForWorkId(workId: string): CanonWork | undefined {
+  return byWorkId.get(workId);
+}
+
+/**
+ * Mongo filter matching the editions of a /work/[id] route param: canon slugs
+ * expand to their verified work_id set; anything else matches work_slug or
+ * work_id directly (back-compat). Shared by the work page and its compare page
+ * so a canon slug resolves identically on both.
+ */
+export function workEditionsFilter(idOrSlug: string): Record<string, unknown> {
+  const canon = bySlug.get(idOrSlug);
+  if (canon) {
+    return {
+      $or: [{ work_id: { $in: canon.workIds } }, { work_slug: { $in: canon.workIds } }],
+      visible: true,
+    };
+  }
+  return { $or: [{ work_slug: idOrSlug }, { work_id: idOrSlug }], visible: true };
+}


### PR DESCRIPTION
## What

Phase 1 of #3736 (work landing pages). Adds `src/lib/canon-works.ts` — a hand-verified registry of 19 major Greek/Latin works — and extends the existing `/work/[id]` page with a canon layer.

**In scope:**
- **Canon slugs**: `/work/iliad`, `/work/republic`, `/work/meditations`… aggregate editions across ALL of a work's fragmented `work_id` values (the Iliad spans four: two QIDs, a legacy slug, a combined-volume id). Raw fragment ids 307-redirect to the canon address.
- **Canon header**: original-language title, author (linked), composition era — `Πολιτεία · Plato · c. 375 BCE`.
- **Start reading**: deterministic best copy per lane. Printed English edition with OCR when we hold one; otherwise the best-translated original serves both lanes (the reader shows facing English translation). No hand-picking.
- **Collected editions**: Opera/complete-works (Stephanus 1578, Ficino's Latin Plato, Virgil's Opera) render in their own section — visible to the reader, never counted as "an edition of the work".
- **Locus badges**: rows for registered Bekker/Stephanus editions get a "reference edition" chip — first frontend consumer of `src/lib/locus-editions.ts`.
- **JSON-LD** `CreativeWork` with `workExample` on canon pages.
- Compare page shares the resolver (canon slugs work there) and its `revalidate = false` — forbidden with a fallible fetch per CLAUDE.md — becomes `21600`.

**Out of scope (deliberately):** the citation jump box (Phase 2 of #3736), a `/works` index page (Phase 4), curated intros, registry entries beyond the 19 whose work_ids I verified against production clusters this session. Non-canon `/work` pages are byte-identical in behavior.

## Verification
- Every `workIds`/`collectedWorkIds` entry verified against production Mongo (clustered each author's live books by work_id, read the titles) — per the `work-identity.md` invariant, none guessed.
- `npx tsc --noEmit` clean; `scripts/audit/headerless-pages.mjs` clean.
- Dev-server render tests: canon page (header/read-now/collected/badges), two-lane read-now (`/work/nicomachean-ethics`), redirects (`plato-republic`→`/work/republic`, `Q371884`→`/work/timaeus`), legacy non-canon page (`turba-philosophorum` 200), canon compare (200).

Closes nothing; Phase 1 of #3736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)