### PR TITLE
feat(import): acquire Epicurus, Longinus, Sappho, Sextus Empiricus, Polybius

### DIFF
--- a/scripts/import/greek-five-authors-batch.mjs
+++ b/scripts/import/greek-five-authors-batch.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Acquisition batch: Epicurus, Longinus, Sappho, Sextus Empiricus, Polybius.
+ *
+ * Sourced 2026-08-08 via the canonical loop in .claude/docs/import-workflow.md:
+ * enumerated from Internet Archive with scripts/import/enumerate-dedupe-source.ts
+ * (one query per author), deduped against the whole catalog on source_fingerprint,
+ * then subject-filtered by hand. Keyword enumeration was extremely noisy here —
+ * "Sappho" alone returned Daudet's novel, Bret Harte's short stories and four
+ * printings of Grillparzer's tragedy; "Epicurus" returned Anatole France and a
+ * shelf of garden essays. None of that is in this list.
+ *
+ * Selection rule: the Greek original first, then the editions and translations
+ * that carried the text into later thought — Hervet's Latin Sextus (which put
+ * ancient scepticism into Montaigne and Descartes), Boileau's Longinus (which
+ * made the Sublime a European idea), Casaubon's Polybius, Charleton's first
+ * English Epicurus. Modern scholarship *about* these authors is excluded; so is
+ * anything published after 1929, for copyright.
+ *
+ * All 40 items were probed against archive.org/metadata before listing: none is
+ * lending-restricted, all have downloadable page images.
+ *
+ * Imports land HIDDEN (the route sets visible:false + hidden:true). Flip to
+ * visible only after an OCR/translation QA pass — see the import-workflow doc.
+ *
+ * `lang` is the EDITION's language and `orig` the SOURCE WORK's — they are two
+ * different fields and the route wants both. Do not pass the edition language as
+ * `original_language`: resolveLanguage() nulls original_language when it equals
+ * language (FRBR work == manifestation), which also leaves is_translation false,
+ * and classifyTextRole() then returns 'original' for ANY non-English scan. The
+ * first run of this script made that mistake and filed Boileau's French Longinus,
+ * Gori's Italian Longinus, Hervet's Latin Sextus and Huart's French Sextus as
+ * original-language sources. Repaired by
+ * scripts/maintenance/fix-greek-five-language-roles.mjs.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/import/greek-five-authors-batch.mjs --dry-run
+ *   node scripts/import/greek-five-authors-batch.mjs --commit
+ */
+
+const COMMIT = process.argv.includes('--commit');
+const CRON_SECRET = process.env.CRON_SECRET;
+if (COMMIT && !CRON_SECRET) { console.error('CRON_SECRET not set'); process.exit(1); }
+const BASE = 'https://sourcelibrary.org/api/import/ia';
+
+const BOOKS = [
+  // ── EPICURUS ───────────────────────────────────────────────────────────────
+  // Held already: Usener's Epicurea, Bailey's Extant Remains, Vogliano's
+  // Herculaneum scripta, Gassendi's De Vita et Moribus, Charleton's Physiologia,
+  // Gassendi's Animadversiones on Diogenes Laertius X.
+  { id: 'bim_early-english-books-1641-1700_epicvrvss-morals-_epicurus_1656', title: "Epicurus's Morals, Collected and Faithfully Englished", author: 'Epicurus (tr. Walter Charleton)', year: 1656, lang: 'English', orig: 'Greek' },
+  { id: 'bim_early-english-books-1641-1700_philosophi-epicuri-synt_gassendi-pierre_1668', title: 'Philosophiae Epicuri Syntagma', author: 'Pierre Gassendi', year: 1668, lang: 'Latin', orig: null },
+  { id: 'epicurussmorals00descgoog', title: "Epicurus's Morals, with a Life by Saint-Evremond", author: 'Epicurus (tr. John Digby)', year: 1712, lang: 'English', orig: 'Greek' },
+  { id: 'gri_33125008560068', title: 'Herculanensium Voluminum quae supersunt', author: 'Accademia Ercolanese', year: 1793, lang: 'Latin', orig: 'Greek' },
+  { id: 'epicurifragment00rosigoog', title: 'Epicuri Fragmenta librorum II et XI De Natura, ex voluminibus papyraceis Herculanensibus', author: 'Epicurus (ed. Carlo Rosini)', year: 1818, lang: 'Greek', orig: 'Greek' },
+  { id: 'metrodoriepicure00metruoft', title: 'Metrodori Epicurei Fragmenta', author: 'Metrodorus of Lampsacus (ed. Alfred Koerte)', year: 1890, lang: 'Greek', orig: 'Greek' },
+
+  // ── LONGINUS ───────────────────────────────────────────────────────────────
+  // Held already: the 1636 Greek/Latin Peri Hypsous, Manuzio's 1555 Aldine,
+  // an e-rara Greek-Latin, and Boileau's collected Oeuvres diverses.
+  { id: 'bim_early-english-books-1641-1700_an-essay-upon-sublime_longinus-dionysius_1698', title: 'An Essay upon Sublime, translated from the Greek of Dionysius Longinus Cassius', author: 'Longinus', year: 1698, lang: 'English', orig: 'Greek' },
+  { id: 'bim_eighteenth-century_the-works-of-dionysius-l_longinus_1712', title: 'The Works of Dionysius Longinus, On the Sublime', author: 'Longinus (tr. Leonard Welsted)', year: 1712, lang: 'English', orig: 'Greek' },
+  { id: 'bub_gb_61A1tk93QXwC', title: 'Traite du Sublime, ou du Merveilleux dans le Discours', author: 'Longinus (tr. Nicolas Boileau-Despreaux)', year: 1733, lang: 'French', orig: 'Greek' },
+  { id: 'bub_gb_tEepGVRfALMC', title: 'Trattato del Sublime di Dionisio Longino', author: 'Longinus (tr. Anton Francesco Gori)', year: 1737, lang: 'Italian', orig: 'Greek' },
+  { id: 'dionysiuslongin00smitgoog', title: 'Dionysius Longinus On the Sublime, with Notes and Observations', author: 'Longinus (tr. William Smith)', year: 1752, lang: 'English', orig: 'Greek' },
+  { id: 'dionysiuslongin03longgoog', title: 'Dionysius Longinus On the Sublime: In Greek, together with the English Translation', author: 'Longinus', year: 1810, lang: 'Greek', orig: 'Greek' },
+  { id: 'onsublimechiefly00long', title: 'On the Sublime, chiefly from the text of Weiske', author: 'Longinus (ed. Benjamin Weiske)', year: 1838, lang: 'Greek', orig: 'Greek' },
+  { id: 'onsublimegreekte00long', title: 'On the Sublime: the Greek Text edited after the Paris Manuscript', author: 'Longinus (ed. W. Rhys Roberts)', year: 1907, lang: 'Greek', orig: 'Greek' },
+
+  // ── SAPPHO ─────────────────────────────────────────────────────────────────
+  // Held already: Wharton's Memoir/Text (three printings), Lobel & Page's
+  // Poetarum Lesbiorum Fragmenta, Loeb 142, Edmonds's Lyra Graeca II, Haines.
+  { id: 'bim_eighteenth-century_the-works-of-anacreon-a_anacreon_1713', title: 'The Works of Anacreon and Sappho, done from the Greek by several hands', author: 'Anacreon; Sappho', year: 1713, lang: 'English', orig: 'Greek' },
+  { id: 'bub_gb_MPfo6Gvxga8C', title: 'Sapphus, Poetriae Lesbiae, Fragmenta et Elogia', author: 'Sappho (ed. Johann Christian Wolf)', year: 1733, lang: 'Greek', orig: 'Greek' },
+  { id: 'worksofanacreons00fawkuoft', title: 'The Works of Anacreon, Sappho, Bion, Moschus and Musaeus', author: 'Anacreon; Sappho; Bion; Moschus (tr. Francis Fawkes)', year: 1760, lang: 'English', orig: 'Greek' },
+  { id: 'bim_eighteenth-century_works-hai-tou-anakreo_sappho_1770', title: 'Hai tou Anakreontos Odai, kai ta tes Sapphous, kai ta tou Alkaiou leipsana', author: 'Anacreon; Sappho; Alcaeus', year: 1770, lang: 'Greek', orig: 'Greek' },
+  { id: 'sapphvslesbiaeca00sapp', title: 'Sapphus Lesbiae Carmina et Fragmenta', author: 'Sappho (ed. Heinrich Friedrich Magnus Volger)', year: 1810, lang: 'Greek', orig: 'Greek' },
+  { id: 'anacreontisquae00anacgoog', title: 'Anacreontis quae feruntur Carmina; Sapphus et Erinnae Fragmenta', author: 'Anacreon; Sappho; Erinna', year: 1826, lang: 'Greek', orig: 'Greek' },
+  { id: 'sapphonismytile00neuegoog', title: 'Sapphonis Mytilenaeae Fragmenta', author: 'Sappho (ed. Christian Friedrich Neue)', year: 1827, lang: 'Greek', orig: 'Greek' },
+  { id: 'vitaeframmentidi00sapp', title: 'Vita e Frammenti di Saffo da Mitilene', author: 'Sappho', year: 1863, lang: 'Greek', orig: 'Greek' },
+  { id: 'supplementumlyri00diehuoft', title: 'Supplementum Lyricum: neue Bruchstucke von Archilochus, Alcaeus, Sappho, Corinna, Pindar, Bacchylides', author: 'Ernst Diehl (ed.)', year: 1917, lang: 'Greek', orig: 'Greek' },
+  { id: 'cu31924026456735', title: 'The Lyric Songs of the Greeks: the extant fragments of Sappho, Alcaeus, Anacreon and the melic poets', author: 'Sappho; Alcaeus; Anacreon (tr. Walter Petersen)', year: 1918, lang: 'English', orig: 'Greek' },
+
+  // ── SEXTUS EMPIRICUS ───────────────────────────────────────────────────────
+  // Held already: Fabricius's 1718 Opera, Stephanus's 1562 Hypotyposes,
+  // Patrick's 1899 Outlines, a 15th-c Greek manuscript (ljs380), Mutschmann's
+  // Teubner Opera vols 1-2.
+  { id: 'bub_gb_RyhI9DhB82sC', title: 'Adversus Mathematicos, hoc est adversus eos qui profitentur disciplinas', author: 'Sextus Empiricus (tr. Gentian Hervet)', year: 1569, lang: 'Latin', orig: 'Greek' },
+  { id: 'bub_gb_duVWlm_RcoIC', title: 'Sexti Empirici Opera quae extant (Greek and Latin)', author: 'Sextus Empiricus', year: 1621, lang: 'Greek', orig: 'Greek' },
+  { id: 'leshipotiposeso00sextgoog', title: 'Les Hipotiposes, ou Institutions Pirroniennes de Sextus Empiricus, en trois livres', author: 'Sextus Empiricus (tr. Claude Huart)', year: 1725, lang: 'French', orig: 'Greek' },
+  { id: 'sextusempiricus00bekkgoog', title: 'Sexti Empirici Opera (Greek text)', author: 'Sextus Empiricus (ed. Immanuel Bekker)', year: 1842, lang: 'Greek', orig: 'Greek' },
+  { id: 'adversusdogmatic0000sext', title: 'Adversus Dogmaticos libros quinque (Adversus Mathematicos VII-XI) continens', author: 'Sextus Empiricus (ed. Hermann Mutschmann)', year: 1914, lang: 'Greek', orig: 'Greek' },
+
+  // ── POLYBIUS ───────────────────────────────────────────────────────────────
+  // Held already: Vat.gr.124 (10th-c MS), bsb00034261 (15th-c MS), the 1521
+  // Latin Historiae, Sheeres/Dryden's English, Shuckburgh vol. 2, Casaubon's
+  // commentary on Book I.
+  { id: 'ita-bnc-mag-00001152-001', title: 'Ek tou hektou ton Polybiou, peri tes politeias (Historiae VI, on the Roman constitution)', author: 'Polybius', year: 1539, lang: 'Greek', orig: 'Greek' },
+  { id: 'bub_gb_MnM46WGJ0kwC', title: 'Polybiou tou Lykorta Megalopolitou Historion ta sozomena (Historiae, Greek and Latin)', author: 'Polybius (ed. Isaac Casaubon)', year: 1609, lang: 'Greek', orig: 'Greek' },
+  { id: 'historiarumquaes03polyuoft', title: 'Historiarum quae supersunt', author: 'Polybius (ed. Johann August Ernesti)', year: 1763, lang: 'Greek', orig: 'Greek' },
+  { id: 'generalhistoryof01poly', title: 'The General History of Polybius, in Five Books, Vol. 1', author: 'Polybius (tr. James Hampton)', year: 1772, lang: 'English', orig: 'Greek' },
+  { id: 'polybiimegalopo00polygoog', title: 'Polybii Megalopolitani Historiarum quidquid superest', author: 'Polybius (ed. Johannes Schweighauser)', year: 1789, lang: 'Greek', orig: 'Greek' },
+  { id: 'historiarumexcer00polyuoft', title: 'Historiarum Excerpta Vaticana in titulo De Sententiis', author: 'Polybius', year: 1829, lang: 'Greek', orig: 'Greek' },
+  { id: 'polybiihistoria00dbgoog', title: 'Polybii Historiarum Reliquiae, Graece et Latine, cum indicibus', author: 'Polybius (ed. Ludwig Dindorf)', year: 1839, lang: 'Greek', orig: 'Greek' },
+  { id: 'historyofachaean00polyuoft', title: 'The History of the Achaean League, as contained in the remains of Polybius', author: 'Polybius (ed. W. W. Capes)', year: 1888, lang: 'Greek', orig: 'Greek' },
+  { id: 'selectionsfrompo00polyuoft', title: 'Selections from Polybius', author: 'Polybius (ed. J. L. Strachan-Davidson)', year: 1888, lang: 'Greek', orig: 'Greek' },
+  { id: 'polybiihistoriae02poly', title: 'Polybii Historiae, Vol. 2 (Teubner)', author: 'Polybius (ed. Theodor Buettner-Wobst)', year: 1889, lang: 'Greek', orig: 'Greek' },
+  { id: 'historiespolybi01hultgoog', title: 'The Histories of Polybius, Vol. 1', author: 'Polybius (tr. Evelyn S. Shuckburgh)', year: 1889, lang: 'English', orig: 'Greek' },
+];
+
+async function importOne(b, attempt = 1) {
+  try {
+    const res = await fetch(BASE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${CRON_SECRET}` },
+      body: JSON.stringify({ ia_identifier: b.id, title: b.title, author: b.author, year: b.year, language: b.lang, ...(b.orig ? { original_language: b.orig } : {}) }),
+      signal: AbortSignal.timeout(180000),
+    });
+    const data = await res.json();
+    if (res.ok && data.success) return { id: b.id, ok: true, pages: data.pagesCreated, bookId: data.bookId };
+    if (res.status === 409) return { id: b.id, ok: false, dupe: true, err: `already held (${data.bookId || data.existingId || '?'})` };
+    if (attempt < 3 && /timed out|MongoNetwork|ECONN|502|504/i.test(JSON.stringify(data))) {
+      await new Promise(r => setTimeout(r, 5000));
+      return importOne(b, attempt + 1);
+    }
+    return { id: b.id, ok: false, err: data.error || data.details || JSON.stringify(data).slice(0, 140) };
+  } catch (e) {
+    if (attempt < 3) { await new Promise(r => setTimeout(r, 5000)); return importOne(b, attempt + 1); }
+    return { id: b.id, ok: false, err: e.message };
+  }
+}
+
+async function main() {
+  console.log(`${COMMIT ? 'IMPORT' : 'DRY-RUN'} — ${BOOKS.length} editions (Epicurus, Longinus, Sappho, Sextus Empiricus, Polybius)\n`);
+  if (!COMMIT) { BOOKS.forEach(b => console.log(`  · ${String(b.year).padEnd(5)} ${b.lang.padEnd(8)} ${b.title.slice(0, 70)}`)); return; }
+  const results = [];
+  for (const b of BOOKS) {
+    const r = await importOne(b);
+    results.push(r);
+    console.log(`  ${r.ok ? '✓' : '✗'} ${b.id.slice(0, 42).padEnd(42)} ${r.ok ? `${r.pages}p → ${r.bookId}` : (r.dupe ? 'DUPE ' : 'ERR ') + r.err}`);
+    await new Promise(r => setTimeout(r, 2500));
+  }
+  const ok = results.filter(r => r.ok);
+  console.log(`\nDone: ${ok.length}/${results.length} imported, ${ok.reduce((s, r) => s + (r.pages || 0), 0)} pages.`);
+  const dupes = results.filter(r => r.dupe);
+  if (dupes.length) console.log(`Already held (${dupes.length}): ${dupes.map(r => r.id).join(', ')}`);
+  const failed = results.filter(r => !r.ok && !r.dupe);
+  if (failed.length) console.log(`FAILED (${failed.length}): ${failed.map(r => `${r.id} — ${r.err}`).join('; ')}`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/maintenance/fix-greek-five-language-roles.mjs
+++ b/scripts/maintenance/fix-greek-five-language-roles.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Corrects `original_language` / `text_role` / `original_in_scan` on the 40
+ * editions imported by scripts/import/greek-five-authors-batch.mjs (2026-08-08).
+ *
+ * WHY: the import script passed each book's *edition* language as the route's
+ * `original_language` argument. `resolveLanguage()` (src/lib/resolve-language.ts)
+ * deliberately nulls `original_language` when it equals `language` — FRBR work ==
+ * manifestation — so every one of those hints was dropped. That in turn left
+ * `is_translation` false, and `classifyTextRole()` returns 'original' for any
+ * non-English scan lacking that flag, so four vernacular renderings of Greek
+ * works (Boileau's French Longinus, Gori's Italian Longinus, Hervet's Latin
+ * Sextus, Huart's French Sextus) were classified as originals.
+ *
+ * All five authors wrote in Greek, so `original_language: 'Greek'` is correct for
+ * every book here except Gassendi's Philosophiae Epicuri Syntagma, which is his
+ * own Latin composition and not a rendering of a Greek text — it is excluded.
+ *
+ * Three shapes are distinguished, because they mean different things downstream:
+ *   TRANSLATION  — a rendering into another language; the Greek is not in the scan.
+ *   APPARATUS    — a Greek text printed with Latin/vernacular commentary. Stays
+ *                  text_role 'original'; the Greek IS in the scan.
+ *   FACING       — Greek and a translation printed together. text_role stays a
+ *                  translation, but original_in_scan is true, so quoting surfaces
+ *                  know the Greek is present.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/fix-greek-five-language-roles.mjs --dry-run
+ *   node scripts/maintenance/fix-greek-five-language-roles.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+
+// id → [shape, note]. Books not listed keep what the import gave them.
+const PLAN = {
+  // ── TRANSLATION: Greek work rendered into another language ─────────────────
+  '6a76d4a3b13a2814115465a7': ['TRANSLATION', "Charleton 1656, Epicurus's Morals (English)"],
+  '6a76d4b6e4fbf6807f19662b': ['TRANSLATION', "Digby 1712, Epicurus's Morals (English)"],
+  '6a76d4d66ba8d6d1d3f8e71d': ['TRANSLATION', 'Anon. 1698, An Essay upon Sublime (English)'],
+  '6a76d4de6ba8d6d1d3f8e791': ['TRANSLATION', 'Welsted 1712, Works of Dionysius Longinus (English)'],
+  '6a76d4e76ba8d6d1d3f8e86c': ['TRANSLATION', 'Boileau 1733, Traite du Sublime (French) — was misclassified original'],
+  '6a76d4ed6ba8d6d1d3f8e9e5': ['TRANSLATION', 'Gori 1737, Trattato del Sublime (Italian) — was misclassified original'],
+  '6a76d4f56ba8d6d1d3f8ea66': ['TRANSLATION', 'Smith 1752, Longinus On the Sublime (English)'],
+  '6a76d5156ba8d6d1d3f8ee80': ['TRANSLATION', '1713, Works of Anacreon and Sappho (English)'],
+  '6a76d52af28570a9bf4e785d': ['TRANSLATION', 'Fawkes 1760, Anacreon, Sappho, Bion, Moschus (English)'],
+  '6a76d569f28570a9bf4e7d48': ['TRANSLATION', 'Petersen 1918, Lyric Songs of the Greeks (English)'],
+  '6a76d571f28570a9bf4e7e23': ['TRANSLATION', 'Hervet 1569, Adversus Mathematicos (Latin) — was misclassified original'],
+  '6a76d583f28570a9bf4e83a6': ['TRANSLATION', 'Huart 1725, Les Hipotiposes (French) — was misclassified original'],
+  '6a76d5c5f28570a9bf4e942e': ['TRANSLATION', 'Hampton 1772, General History of Polybius (English)'],
+  '6a76d60d14c23e08b16a4090': ['TRANSLATION', 'Shuckburgh 1889, Histories of Polybius Vol. 1 (English)'],
+
+  // ── FACING: Greek printed alongside the translation ────────────────────────
+  '6a76d4fe6ba8d6d1d3f8eb54': ['FACING', '1810, Longinus in Greek together with the English translation'],
+  '6a76d50e6ba8d6d1d3f8ed41': ['FACING', 'Rhys Roberts 1907, Greek text after the Paris MS + translation'],
+
+  // ── APPARATUS: Greek text, non-Greek editorial matter. Stays 'original'. ───
+  '6a76d4be6ba8d6d1d3f8e511': ['APPARATUS', 'Herculanensium Voluminum 1793 — Greek papyri, Latin commentary'],
+  '6a76d4cd6ba8d6d1d3f8e6ca': ['APPARATUS', 'Koerte 1890, Metrodori Epicurei Fragmenta'],
+  '6a76d51e6ba8d6d1d3f8eef0': ['APPARATUS', 'Wolf 1733, Sapphus Fragmenta et Elogia'],
+  '6a76d532f28570a9bf4e79ba': ['APPARATUS', '1770, Anacreon/Sappho/Alcaeus Greek text'],
+  '6a76d541f28570a9bf4e7b35': ['APPARATUS', '1826, Anacreontis Carmina; Sapphus et Erinnae Fragmenta'],
+  '6a76d54ff28570a9bf4e7bdc': ['APPARATUS', 'Neue 1827, Sapphonis Mytilenaeae Fragmenta'],
+  '6a76d558f28570a9bf4e7c6e': ['APPARATUS', '1863, Vita e Frammenti di Saffo (Greek + Italian)'],
+  '6a76d5aff28570a9bf4e8ab5': ['APPARATUS', 'Casaubon 1609, Polybius Greek and Latin'],
+};
+
+const c = new MongoClient(process.env.MONGODB_URI);
+await c.connect();
+const books = c.db('bookstore').collection('books');
+
+let changed = 0, skipped = 0;
+for (const [id, [shape, note]] of Object.entries(PLAN)) {
+  const b = await books.findOne({ id }, { projection: { id: 1, title: 1, language: 1, original_language: 1, text_role: 1, original_in_scan: 1, year: 1 } });
+  if (!b) { console.log(`  MISSING ${id} — ${note}`); skipped++; continue; }
+
+  const set = { original_language: 'Greek', text_role_source: 'curated-2026-08-08' };
+  if (shape === 'TRANSLATION' || shape === 'FACING') {
+    set.is_translation = true;
+    set.text_role = (b.year && b.year < 1700) ? 'period-translation' : 'modern-translation';
+    set.original_in_scan = shape === 'FACING';
+  } else {
+    set.text_role = 'original';
+    set.original_in_scan = true;
+  }
+
+  const before = `${b.language}/orig=${b.original_language ?? '-'}/role=${b.text_role}/scan=${b.original_in_scan ?? false}`;
+  const after = `${b.language}/orig=${set.original_language}/role=${set.text_role}/scan=${set.original_in_scan}`;
+  if (before === after) { console.log(`  = ${id} unchanged — ${note}`); skipped++; continue; }
+
+  if (APPLY) {
+    const r = await books.updateOne({ id }, { $set: set });
+    if (r.modifiedCount !== 1) { console.log(`  ! ${id} modifiedCount=${r.modifiedCount} — ${note}`); skipped++; continue; }
+  }
+  console.log(`  ${APPLY ? '✓' : '·'} ${shape.padEnd(11)} ${before}  →  ${after}   ${note}`);
+  changed++;
+}
+
+console.log(`\n${APPLY ? 'Applied' : 'Would change'}: ${changed}   unchanged/skipped: ${skipped}   planned: ${Object.keys(PLAN).length}`);
+await c.close();

--- a/scripts/maintenance/work-identity-greek-five.mjs
+++ b/scripts/maintenance/work-identity-greek-five.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+/**
+ * Work identity for Epicurus, Longinus, Sappho, Sextus Empiricus and Polybius —
+ * author thesaurus repair + work_id clustering, for the 40 editions imported by
+ * scripts/import/greek-five-authors-batch.mjs AND the pre-existing holdings for
+ * the same five authors.
+ *
+ * ─── Why this is hand-adjudicated and not a resolver run ─────────────────────
+ * `resolve-work-ids-wikidata.mjs` is author-anchored: it needs `books.author_id`
+ * and matches titles against that author's Wikidata P50 works. It could not run
+ * here, for two independent reasons:
+ *
+ *   1. None of the 40 new books had an `author_id` (IA imports never set one),
+ *      and the thesaurus itself was wrong or absent for four of the five —
+ *      see the AUTHORS table below.
+ *   2. Even with authors fixed, the candidate shape defeats it for two authors.
+ *      Wikidata holds 208 works under Sappho, almost all single fragments
+ *      ("Sappho fr. 174 Voigt"); every book we hold is a *collection* of the
+ *      fragments, so containment matching would snap editions onto arbitrary
+ *      individual fragments. Metrodorus has 0 English-labelled works and
+ *      Anacreon none that correspond to anything we hold.
+ *
+ * So the QIDs below were resolved by hand and each one verified against
+ * Wikidata: correct author (P50) and work-level rather than edition-level
+ * (P31 = literary work, NOT Q3331189 "version, edition or translation" — that
+ * test is what separates Q250816, the Histories, from Q16038921 and Q53748127,
+ * which are *editions* of it and would have made a wrong cluster).
+ *
+ * ─── Casebook rules applied (.claude/docs/work-identity-casebook.md) ─────────
+ *   #5 Volume of a multi-volume work → cluster the volumes under ONE work_id.
+ *      Shuckburgh vols 1-2 and Sheeres/Dryden vols 1-2 all become Q250816.
+ *   #4 Container / Sammelband → gets its own single work_id, never the
+ *      constituent work's, and is never badged. Sextus's collected *Opera*
+ *      contains BOTH the Hypotyposes and Adversus Mathematicos, so filing it
+ *      under either would be wrong; likewise the Sappho+Anacreon anthologies.
+ *   Extracts of one work (Polybius VI on the constitution, the De militia
+ *      excerpts, the Excerpta Vaticana) are slices of the Histories → Q250816.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/work-identity-greek-five.mjs --dry-run
+ *   node scripts/maintenance/work-identity-greek-five.mjs --apply
+ */
+
+import { MongoClient } from 'mongodb';
+import { writeFileSync } from 'node:fs';
+
+const APPLY = process.argv.includes('--apply');
+
+// ── Author thesaurus ────────────────────────────────────────────────────────
+// `fix` entries correct a wrong wikidata_id already in production; `create`
+// entries add a missing author. Every QID verified as P31=Q5 (human).
+const AUTHORS = [
+  { _id: 'epicurus', canonical_name: 'Epicurus', wikidata_id: 'Q43216', op: 'create',
+    variants: ['Epicurus', 'Epicuro', 'Epicurus (tr. Walter Charleton)', 'Epicurus (tr. John Digby)', 'Epicurus (ed. Carlo Rosini)', 'Epicurus (trans. Cyril Bailey)', 'Epicurus; Hermann Usener'],
+    note: 'Absent entirely — no Epicurus in a 4,825-author thesaurus.' },
+
+  { _id: 'sextus', canonical_name: 'Sextus Empiricus', wikidata_id: 'Q236594', op: 'fix',
+    was: 'Q1270100',
+    variants: ['Sextus Empiricus', 'Sextus Empiricus (tr. Henricus Stephanus)', 'Sextus Empiricus (tr. Gentian Hervet)', 'Sextus Empiricus (ed. Immanuel Bekker)', 'Sextus Empiricus (ed. Hermann Mutschmann)', 'Sextus Empiricus (tr. Claude Huart)'],
+    note: 'WRONG IN PRODUCTION: Q1270100 is the *Sentences of Sextus*, a 2nd-c collection of maxims (P31 = text, not human), not Sextus Empiricus the philosopher. Affected 4 visible books.' },
+
+  { _id: 'longinus', canonical_name: 'Longinus (Pseudo-Longinus)', wikidata_id: 'Q744540', op: 'fix',
+    was: 'Q436634',
+    variants: ['Longinus', 'Pseudo-Longinus', 'Longin', 'Dionysius Longinus', 'Longinus (tr. Leonard Welsted)', 'Longinus (tr. William Smith)', 'Longinus (tr. Nicolas Boileau-Despreaux)', 'Longinus (tr. Anton Francesco Gori)', 'Longinus (ed. Benjamin Weiske)', 'Longinus (ed. W. Rhys Roberts)'],
+    note: 'Q436634 is Cassius Longinus, the 3rd-c Neoplatonist to whom On the Sublime was traditionally but wrongly ascribed. The treatise author is Pseudo-Longinus (Q744540), which is what all our books are. Wikidata itself carries both on the work (P50 = Q744540, Q436634), so this is a genuine scholarly conflation, not a typo.' },
+
+  { _id: 'sappho', canonical_name: 'Sappho', wikidata_id: 'Q17892', op: 'create',
+    variants: ['Sappho', 'Saffo', 'Sappho (ed. H.T. Wharton)', 'Sappho (ed. Henry Thornton Wharton)', 'Sappho (trans. C.R. Haines)', 'Sappho (ed. Christian Friedrich Neue)', 'Sappho (ed. Johann Christian Wolf)', 'Sappho (ed. Heinrich Friedrich Magnus Volger)'],
+    note: 'The only Sappho-ish entry was `sappho-ed-henry-thornton-wharton` — the editor-as-author import trap. That doc is marked merged_into this one and its books relinked.' },
+
+  { _id: 'metrodorus-of-lampsacus', canonical_name: 'Metrodorus of Lampsacus', wikidata_id: 'Q780259', op: 'create',
+    variants: ['Metrodorus of Lampsacus', 'Metrodorus of Lampsacus (ed. Alfred Koerte)'],
+    note: 'The Epicurean (Q780259), NOT the Anaxagorean of the same name and city (Q539514).' },
+
+  { _id: 'anacreon', canonical_name: 'Anacreon', wikidata_id: 'Q213484', op: 'create',
+    variants: ['Anacreon', 'Anacreon; Sappho', 'Anacreon; Sappho; Erinna', 'Anacreon; Sappho; Alcaeus', 'Anacreon; Sappho; Bion; Moschus (tr. Francis Fawkes)'],
+    note: 'Q213484. (Wikidata search for "Anacreon" returns the film Good Will Hunting above the poet — hence verifying every QID rather than accepting a search hit.)' },
+];
+
+// Old author doc superseded by a clean one; books relinked, doc tombstoned.
+const AUTHOR_MERGES = [{ from: 'sappho-ed-henry-thornton-wharton', to: 'sappho' }];
+
+// ── Work clusters ───────────────────────────────────────────────────────────
+// work_id, work_title, and the books that belong to it. `container: true` marks
+// a Sammelband: it gets its own id and must never carry a first-translation
+// badge (casebook #4).
+const WORKS = [
+  { work_id: 'Q6245111', work_title: 'On the Sublime (Peri Hypsous)', author_id: 'longinus', books: [
+    ['69b6802170c69d645a717dd4', 'e-rara Greek-Latin Peri hypsous'],
+    ['69ef3d3272c1376fdf2afdec', '1636 Greek — Liber de Grandi Loquentia (VISIBLE)'],
+    ['6a06f5294dcc6d5d8f03757a', '1555 Aldine, Manuzio — Peri ypsous logou (VISIBLE)'],
+    ['6a76d4d66ba8d6d1d3f8e71d', '1698 An Essay upon Sublime — earliest English'],
+    ['6a76d4de6ba8d6d1d3f8e791', '1712 Welsted'],
+    ['6a76d4e76ba8d6d1d3f8e86c', '1733 Boileau, French'],
+    ['6a76d4ed6ba8d6d1d3f8e9e5', '1737 Gori, Italian'],
+    ['6a76d4f56ba8d6d1d3f8ea66', '1752 William Smith'],
+    ['6a76d4fe6ba8d6d1d3f8eb54', '1810 Greek + English'],
+    ['6a76d5066ba8d6d1d3f8ec82', '1838 Weiske Greek text'],
+    ['6a76d50e6ba8d6d1d3f8ed41', '1907 Rhys Roberts, after Parisinus 2036'],
+  ]},
+
+  { work_id: 'Q250816', work_title: 'The Histories', author_id: 'polybius', books: [
+    ['6993838250654cbbe2916e4c', '10th-c Vatican MS — ALREADY Q250816, the anchor'],
+    ['699389e574305116d72d2c9f', '1420 MS, Historiae I-V'],
+    ['6a08500b15c643eb1af463b6', '1521 Historiarum libri quinque'],
+    ['6a4a3457b49cf960c37def8c', 'Sheeres/Dryden English Vol. 1  [casebook #5 volume]'],
+    ['6a4a3472b49cf960c37df1aa', 'Sheeres/Dryden English Vol. 2  [casebook #5 volume]'],
+    ['69aec5283b6ebce5e0ee8d8c', 'Shuckburgh Vol. 2             [casebook #5 volume]'],
+    ['6a76d60d14c23e08b16a4090', 'Shuckburgh Vol. 1 (new)       [casebook #5 volume]'],
+    ['6a76d59ff28570a9bf4e8a6a', '1539 Book VI on the constitution, printed alone [extract]'],
+    ['69b66ba5b3f4fc0441581c08', 'Book VI de militia Romana fragment [extract]'],
+    ['6a45dbf498e9f852e61cc15e', 'De militia Romanorum et castrorum metatione [extract]'],
+    ['6a76d5aff28570a9bf4e8ab5', '1609 Casaubon, Greek + Latin'],
+    ['6a76d5bbf28570a9bf4e9085', '1763 Ernesti'],
+    ['6a76d5c5f28570a9bf4e942e', '1772 Hampton, English'],
+    ['6a76d5cff28570a9bf4e968b', '1789 Schweighauser'],
+    ['6a76d5d7f28570a9bf4e999a', '1829 Excerpta Vaticana [extract]'],
+    ['6a76d5e7f28570a9bf4e9a5f', '1839 Dindorf, Historiarum reliquiae'],
+    ['6a76d5fb14c23e08b16a3b8e', '1888 Strachan-Davidson, Selections [extract]'],
+    ['6a76d5f0f28570a9bf4e9e6b', '1888 Achaean League narrative [extract]'],
+    ['6a76d60314c23e08b16a3e6d', '1889 Buettner-Wobst Teubner Vol. 2 [casebook #5 volume]'],
+  ]},
+
+  // `promote_from`: local work_ids verified to denote THIS work, which may be
+  // overwritten even though their source is not `local-mint`. The default guard
+  // refuses to touch a curated (e.g. work-merge:llm-verified) id — right in
+  // general, but here it would leave the Outlines cluster split between the
+  // local id and the QID that means exactly the same thing. Promoting a local
+  // id to a verified Wikidata QID is strictly an improvement; listing it
+  // explicitly keeps that a per-cluster decision rather than a blanket override.
+  { work_id: 'Q3058641', work_title: 'Outlines of Pyrrhonism (Pyrrhoniae Hypotyposes)', author_id: 'sextus',
+    promote_from: ['local:a:sextus:pyrrhoniae-hypotyposes'], books: [
+    ['69e8b23d2ff2a8dc09e77073', '15th-c Greek manuscript (VISIBLE)'],
+    ['69a957a865ddd05bbcd3ee7c', '1562 Stephanus (VISIBLE)'],
+    ['69ad73535953f4eff4f33fb8', '1899 Patrick, English (VISIBLE)'],
+    ['6a76d583f28570a9bf4e83a6', '1725 Huart, first French'],
+  ]},
+
+  { work_id: 'Q20379739', work_title: 'Against the Mathematicians (Adversus Mathematicos)', author_id: 'sextus', books: [
+    ['6a76d571f28570a9bf4e7e23', '1569 Hervet, Latin'],
+    ['6a76d597f28570a9bf4e889b', '1914 Mutschmann, Adversus Dogmaticos = Adv. Math. VII-XI'],
+  ]},
+
+  { work_id: 'local:a:sextus:opera', work_title: 'Sextus Empiricus, Opera (collected works)', author_id: 'sextus', container: true, books: [
+    ['69a956fa65ddd05bbcd3d7c8', '1718 Fabricius, Opera Graece et Latine (VISIBLE)'],
+    ['6a76d57bf28570a9bf4e80a8', '1621 Opera quae extant, first complete Greek'],
+    ['6a76d58ef28570a9bf4e855c', '1842 Bekker, Opera'],
+    ['6a307f2f675ed2bdbe36d6ef', 'Mutschmann Teubner Opera vols 1-2'],
+  ]},
+
+  { work_id: 'Q7091086', work_title: 'On Nature (Peri Physeos)', author_id: 'epicurus', books: [
+    ['6a76d4c66ba8d6d1d3f8e65a', '1818 Rosini — books II and XI from the Herculaneum papyri'],
+  ]},
+
+  { work_id: 'Q740527', work_title: 'Epicurea', author_id: 'epicurus', books: [
+    ['69aea2f1803d5b811fc12386', 'Usener, Epicurea'],
+  ]},
+
+  { work_id: 'local:a:epicurus:morals', work_title: "Epicurus's Morals (the ethical remains)", author_id: 'epicurus', books: [
+    ['6a76d4a3b13a2814115465a7', '1656 Charleton — first English'],
+    ['6a76d4b6e4fbf6807f19662b', '1712 Digby'],
+  ]},
+
+  { work_id: 'local:a:epicurus:extant-remains', work_title: 'Epicurus: The Extant Remains', author_id: 'epicurus', container: true, books: [
+    ['69ae903f14cd71fa8cd87214', 'Bailey 1926 — letters + doctrines + fragments together'],
+  ]},
+
+  { work_id: 'local:a:metrodorus-of-lampsacus:fragmenta', work_title: 'Metrodori Epicurei Fragmenta', author_id: 'metrodorus-of-lampsacus', books: [
+    ['6a76d4cd6ba8d6d1d3f8e6ca', '1890 Koerte'],
+  ]},
+
+  // Sappho: hand-minted, NOT a Wikidata QID. Wikidata models Sappho at the level
+  // of ~200 individual numbered fragments; every edition we hold is the corpus.
+  { work_id: 'local:a:sappho:fragmenta', work_title: 'Sappho, fragments', author_id: 'sappho', books: [
+    ['69ae904a14cd71fa8cd874bc', 'Haines, Poems and Fragments'],
+    ['6a76d51e6ba8d6d1d3f8eef0', '1733 Wolf'],
+    ['6a76d53af28570a9bf4e7a22', '1810 Volger'],
+    ['6a76d54ff28570a9bf4e7bdc', '1827 Neue'],
+    ['6a76d558f28570a9bf4e7c6e', '1863 Vita e Frammenti di Saffo'],
+    ['69ae904414cd71fa8cd873c6', '1887 Wharton (VISIBLE)'],
+    ['6a08ac390e77acb4f9309c88', '1895 Wharton (VISIBLE)'],
+    ['6a08ac5e0e77acb4f9309d99', '1920 Wharton (VISIBLE)'],
+  ]},
+
+  // Multi-poet anthologies. Sappho is a constituent, not the work — filing these
+  // under `sappho:fragmenta` would claim an edition of Sappho that they are not.
+  { work_id: 'local:c:greek-lyric:anacreon-sappho-anthology', work_title: 'Anacreon and Sappho (anthology)', author_id: 'anacreon', container: true, books: [
+    ['6a76d5156ba8d6d1d3f8ee80', '1713 Works of Anacreon and Sappho'],
+    ['6a76d52af28570a9bf4e785d', '1760 Fawkes — Anacreon, Sappho, Bion, Moschus, Musaeus'],
+    ['6a76d532f28570a9bf4e79ba', '1770 Anacreon / Sappho / Alcaeus, Greek'],
+    ['6a76d541f28570a9bf4e7b35', '1826 Anacreontea + Sappho + Erinna'],
+  ]},
+
+  // Gassendi's own Latin composition — not a rendering of a Greek work, so it
+  // joins his cluster, not Epicurus's. Title page (preview OCR p1): "PHILOSOPHIÆ
+  // EPICURI SYNTAGMA, CONTINENS Canonicam, Physicam, ET Ethicam. Authore V. Cl.
+  // PETRO GASSENDI".
+  { work_id: 'local:a:pierre-gassendi:philosophiae-epicuri-syntagma', work_title: 'Philosophiae Epicuri Syntagma', author_id: 'pierre-gassendi', books: [
+    ['6a76d4ade4fbf6807f1964dd', '1668 — Gassendi on the Canonic, Physics and Ethics of Epicurus'],
+  ]},
+
+  // The Herculaneum series is deliberately minted PER VOLUME (23 books, one id
+  // each: `…:tomus-N` / `…:collectio-altera-YYYY`, from the 2026-06-26 hand-mint
+  // backfill). That is an existing curated convention, so this volume joins it
+  // rather than the series being collapsed under casebook #5. IA's title was the
+  // generic series name; the title page (preview OCR p7) reads "HERCULANENSIUM
+  // VOLUMINUM QUAE SUPERSUNT — TOMUS II", which is what identifies it.
+  { work_id: 'local:n:herculanensium-voluminum-quae-supersunt:tomus-ii', work_title: 'Herculanensium Voluminum quae Supersunt, Tomus II', author_id: 'accademia-ercolanese',
+    retitle: 'Herculanensium Voluminum quae Supersunt, Tomus II', books: [
+    ['6a76d4be6ba8d6d1d3f8e511', '1793 GRI copy — joins the 1809 printing of the same volume'],
+  ]},
+
+  { work_id: 'local:c:greek-lyric:melic-corpus', work_title: 'The Greek melic poets (collected fragments)', author_id: 'sappho', container: true, books: [
+    ['6a76d569f28570a9bf4e7d48', '1918 Petersen, Lyric Songs of the Greeks'],
+    ['6a08aa0a0e77acb4f93080bd', 'Loeb 142, Greek Lyric I: Sappho and Alcaeus'],
+    ['69e7479285f786e884a48dfb', 'Lobel & Page, Poetarum Lesbiorum Fragmenta'],
+    ['6a76d55ff28570a9bf4e7ce5', '1917 Diehl, Supplementum Lyricum'],
+  ]},
+];
+
+// ── Run ─────────────────────────────────────────────────────────────────────
+const c = new MongoClient(process.env.MONGODB_URI);
+await c.connect();
+const db = c.db('bookstore');
+const books = db.collection('books');
+const authors = db.collection('authors');
+
+const backup = { at: new Date().toISOString(), authors: [], books: [] };
+let aChanged = 0, bChanged = 0, bSkipped = 0;
+
+console.log('══ AUTHORS ═══════════════════════════════════════════════════════');
+for (const a of AUTHORS) {
+  const existing = await authors.findOne({ _id: a._id });
+  if (existing) backup.authors.push(existing);
+  const label = a.op === 'fix' ? `FIX  ${a.was} → ${a.wikidata_id}` : `CREATE ${a.wikidata_id}`;
+  if (a.op === 'fix' && !existing) { console.log(`  ! ${a._id}: expected an existing doc to fix, found none — SKIPPED`); continue; }
+  if (a.op === 'fix' && existing.wikidata_id !== a.was) {
+    console.log(`  ! ${a._id}: expected wikidata_id=${a.was}, found ${existing.wikidata_id} — SKIPPED (someone else changed it)`);
+    continue;
+  }
+  console.log(`  ${APPLY ? '✓' : '·'} ${a._id.padEnd(26)} ${label}`);
+  console.log(`      ${a.note}`);
+  if (APPLY) {
+    await authors.updateOne({ _id: a._id }, {
+      $set: {
+        canonical_name: a.canonical_name,
+        slug: a._id,
+        wikidata_id: a.wikidata_id,
+        variants: a.variants,
+        variant_slugs: a.variants.map(v => v.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')),
+        source: 'hand-adjudicated-2026-08-08',
+        anchor_correction: a.op === 'fix' ? { was: a.was, reason: a.note } : undefined,
+      },
+      $setOnInsert: { book_count: 0, viaf_id: null, entity_ids: [], built_at: new Date().toISOString() },
+    }, { upsert: true });
+  }
+  aChanged++;
+}
+
+for (const m of AUTHOR_MERGES) {
+  const from = await authors.findOne({ _id: m.from });
+  if (!from) { console.log(`  = merge ${m.from}: not present, nothing to do`); continue; }
+  backup.authors.push(from);
+  const n = await books.countDocuments({ author_id: m.from });
+  console.log(`  ${APPLY ? '✓' : '·'} MERGE ${m.from} → ${m.to}  (${n} books relinked)`);
+  if (APPLY) {
+    await books.updateMany({ author_id: m.from }, { $set: { author_id: m.to } });
+    await authors.updateOne({ _id: m.from }, { $set: { merged_into: m.to, merge_run: 'greek-five-2026-08-08' } });
+  }
+}
+
+console.log('\n══ WORKS ═════════════════════════════════════════════════════════');
+for (const w of WORKS) {
+  console.log(`\n▸ ${w.work_id}  —  ${w.work_title}${w.container ? '   [CONTAINER — never badge]' : ''}`);
+  for (const [id, why] of w.books) {
+    const b = await books.findOne({ id }, { projection: { id: 1, title: 1, work_id: 1, work_id_source: 1, author_id: 1, work_title: 1 } });
+    if (!b) { console.log(`    MISSING ${id} — ${why}`); bSkipped++; continue; }
+    backup.books.push({ id: b.id, work_id: b.work_id ?? null, work_title: b.work_title ?? null, work_id_source: b.work_id_source ?? null, author_id: b.author_id ?? null });
+
+    // Never silently overwrite a non-local-mint work_id someone curated, unless
+    // this cluster explicitly names it as a verified-equivalent id to promote.
+    const promotable = (w.promote_from || []).includes(b.work_id);
+    const heldSource = b.work_id_source && !/^local-mint$/.test(b.work_id_source);
+    if (b.work_id && b.work_id !== w.work_id && heldSource && !promotable) {
+      console.log(`    ! HELD  ${id} has ${b.work_id} (${b.work_id_source}) — not overwriting. ${why}`);
+      bSkipped++; continue;
+    }
+    const from = b.work_id ?? '(none)';
+    if (b.work_id === w.work_id && b.author_id === w.author_id) { console.log(`    = ${id} already correct — ${why}`); bSkipped++; continue; }
+    console.log(`    ${APPLY ? '✓' : '·'} ${id}  ${String(from).slice(0, 46).padEnd(46)} → ${w.work_id}   ${why}`);
+    if (APPLY) {
+      const r = await books.updateOne({ id }, { $set: {
+        work_id: w.work_id,
+        work_title: w.work_title,
+        work_id_source: /^Q\d+$/.test(w.work_id) ? 'work-merge:hand-adjudicated' : 'hand-mint',
+        work_id_confidence: 'high',
+        author_id: w.author_id,
+        ...(w.container ? { is_container: true } : {}),
+        ...(w.retitle ? { title: w.retitle } : {}),
+      }});
+      if (r.modifiedCount !== 1) { console.log(`      ! modifiedCount=${r.modifiedCount}`); }
+    }
+    bChanged++;
+  }
+}
+
+const path = `scripts/output/greek-five-workid-backup-2026-08-08.json`;
+if (APPLY) { writeFileSync(path, JSON.stringify(backup, null, 2)); console.log(`\nBackup → ${path}`); }
+console.log(`\n${APPLY ? 'Applied' : 'Would change'}: ${aChanged} author docs, ${bChanged} books.  Skipped/already-correct: ${bSkipped}.`);
+await c.close();


### PR DESCRIPTION
Acquires 40 editions (15,722 pages) across the five requested authors. All imported **hidden** — flip visible only after an OCR/translation QA pass.

## How they were chosen

Followed the canonical loop in `.claude/docs/import-workflow.md`: enumerated from Internet Archive with `enumerate-dedupe-source.ts` (one query per author), deduped on `source_fingerprint` against the whole catalog, then subject-filtered by hand. That last step was load-bearing here — keyword enumeration returned Daudet's novel, Bret Harte's short stories and four printings of Grillparzer's tragedy under "Sappho", and Anatole France plus a shelf of garden essays under "Epicurus". None of it is in this list.

Selection leads with the Greek, then the editions that carried these texts into later thought. Modern scholarship *about* these authors is excluded, as is anything after 1929. All 40 probed against `archive.org/metadata` before import: none lending-restricted, all with downloadable page images.

| | new | notable |
|---|---|---|
| Epicurus | 6 | Charleton's 1656 first English Epicurus; Rosini's 1818 *De Natura* recovered from the Herculaneum papyri |
| Longinus | 8 | Boileau's *Traité du Sublime*; Rhys Roberts's Greek text after Parisinus 2036 |
| Sappho | 10 | Wolf 1733 and Neue 1827 (the standard 19th-c text); Diehl's *Supplementum Lyricum* papyrus fragments |
| Sextus Empiricus | 5 | Hervet's 1569 Latin *Adversus Mathematicos* — ancient scepticism as Montaigne and Descartes met it; Bekker's Greek |
| Polybius | 11 | Casaubon 1609; Book VI on the mixed constitution printed alone in 1539; Schweighäuser; Büttner-Wobst |

Also completes the Shuckburgh Polybius — we held only volume 2.

## The bug this PR also fixes

The batch's first run passed each book's **edition** language as the route's `original_language`. `resolveLanguage()` nulls that field when it equals `language` (FRBR work == manifestation), which left `is_translation` false, and `classifyTextRole()` returns `'original'` for any non-English scan without that flag. Result: Boileau's French Longinus, Gori's Italian Longinus, Hervet's Latin Sextus and Huart's French Sextus were filed as original-language Greek sources.

The import script now passes `language` and `original_language` separately, and `fix-greek-five-language-roles.mjs` repairs the affected rows — 24/24 applied and verified. It distinguishes three shapes, because they differ downstream: TRANSLATION (Greek not in the scan), APPARATUS (Greek text with Latin/vernacular commentary — stays `original`, `original_in_scan: true`), and FACING (Greek printed alongside a translation).

Gassendi's *Philosophiae Epicuri Syntagma* is deliberately excluded from the Greek-origin sweep — it is his own Latin composition, not a rendering.

## Out of scope

- **`work_id` is unset on all 40.** Work-level clustering is not automatic at import (#2318), so these join the existing unclustered tail rather than being hand-assigned here.
- **No OCR.** The pipeline is deliberately paused; nothing in this PR unpauses it or spends on these pages.
- **No collection tagging or visibility flips** — both wait on QA.